### PR TITLE
Support more chain types, implement vector search powered by huggingface inference api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 🔍 Copilot for Obsidian
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/logancyang/obsidian-copilot?style=for-the-badge&sort=semver) ![Obsidian plugin](https://img.shields.io/endpoint?url=https%3A%2F%2Fscambier.xyz%2Fobsidian-endpoints%2Fcopilot.json&style=for-the-badge)
+![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/logancyang/obsidian-copilot?style=for-the-badge&sort=semver) ![Obsidian Downloads](https://img.shields.io/badge/dynamic/json?logo=obsidian&color=%23483699&label=downloads&query=%24%5B%22copilot%22%5D.downloads&url=https%3A%2F%2Fraw.githubusercontent.com%2Fobsidianmd%2Fobsidian-releases%2Fmaster%2Fcommunity-plugin-stats.json&style=for-the-badge)
 
 
 Copilot for Obsidian is a ChatGPT interface right inside Obsidian. It has a minimalistic design and is straightforward to use.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@huggingface/inference": "^1.8.0",
         "@tabler/icons-react": "^2.14.0",
         "axios": "^1.3.4",
         "esbuild-plugin-svg": "^0.1.0",
@@ -1105,6 +1106,14 @@
       "integrity": "sha512-621GAuLMvKtyZQ3IA6nlDWhV1V/7PGOTNIGLUifxt0KzM+dZIweJ6F3XvQF3QnqeNfS1N7WQ0Kil1Di/lhChEw==",
       "engines": {
         "node": ">=16.15"
+      }
+    },
+    "node_modules/@huggingface/inference": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/inference/-/inference-1.8.0.tgz",
+      "integrity": "sha512-Dkh7PiyMf6TINRocQsdceiR5LcqJiUHgWjaBMRpCUOCbs+GZA122VH9q+wodoSptj6rIQf7wIwtDsof+/gd0WA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "typescript": "4.7.4"
   },
   "dependencies": {
+    "@huggingface/inference": "^1.8.0",
     "@tabler/icons-react": "^2.14.0",
     "axios": "^1.3.4",
     "esbuild-plugin-svg": "^0.1.0",

--- a/src/chainFactory.ts
+++ b/src/chainFactory.ts
@@ -7,8 +7,8 @@ import {
 } from "langchain/chains";
 
 // Add new chain types here
-const CONVERSATION_CHAIN = 'ConversationChain';
-const CONVERSATIONAL_RETRIEVAL_QA_CHAIN = 'ConversationalRetrievalQAChain';
+export const CONVERSATION_CHAIN = 'ConversationChain';
+export const CONVERSATIONAL_RETRIEVAL_QA_CHAIN = 'ConversationalRetrievalQAChain';
 const SUPPORTED_CHAIN_TYPES = new Set([
   CONVERSATION_CHAIN,
   CONVERSATIONAL_RETRIEVAL_QA_CHAIN,

--- a/src/chainFactory.ts
+++ b/src/chainFactory.ts
@@ -1,0 +1,47 @@
+import {
+  BaseChain,
+  ConversationChain,
+  ConversationalRetrievalQAChain,
+  ConversationalRetrievalQAChainInput,
+  LLMChainInput,
+} from "langchain/chains";
+
+// Add new chain types here
+const CONVERSATION_CHAIN = 'ConversationChain';
+const CONVERSATIONAL_RETRIEVAL_QA_CHAIN = 'ConversationalRetrievalQAChain';
+const SUPPORTED_CHAIN_TYPES = new Set([
+  CONVERSATION_CHAIN,
+  CONVERSATIONAL_RETRIEVAL_QA_CHAIN,
+]);
+
+class ChainFactory {
+  private static instances: Map<string, BaseChain> = new Map();
+
+  public static getChain(
+    chainType: string,
+    args: LLMChainInput | ConversationalRetrievalQAChainInput
+  ): BaseChain {
+    let instance = ChainFactory.instances.get(chainType);
+    if (!instance) {
+      if (!SUPPORTED_CHAIN_TYPES.has(chainType)) {
+        throw new Error(`Unsupported chain type: ${chainType}`);
+      }
+
+      if (chainType === CONVERSATION_CHAIN) {
+        instance = new ConversationChain(args as LLMChainInput);
+      } else if (chainType === CONVERSATIONAL_RETRIEVAL_QA_CHAIN) {
+        instance = new ConversationalRetrievalQAChain(
+          args as ConversationalRetrievalQAChainInput
+        );
+      } else {
+        throw new Error(`Invalid arguments for chain type: ${chainType}`);
+      }
+
+      ChainFactory.instances.set(chainType, instance);
+    }
+
+    return instance;
+  }
+}
+
+export default ChainFactory;

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -28,10 +28,10 @@ import {
   simplifyPrompt,
   summarizePrompt,
   tocPrompt,
-  useNoteAsContextPrompt
+  useNoteAsContextPrompt,
 } from '@/utils';
 import { EventEmitter } from 'events';
-import { TFile } from 'obsidian';
+import { Notice, TFile } from 'obsidian';
 import React, {
   useContext,
   useEffect,
@@ -124,11 +124,30 @@ const Chat: React.FC<ChatProps> = ({
 
     const file = app.workspace.getActiveFile();
     if (!file) {
+      new Notice('No active note found.');
       console.error('No active note found.');
       return;
     }
     const noteContent = await getFileContent(file);
     const noteName = getFileName(file);
+
+    /* TODO: Make a switch for unlimited context search, on and off. When turned on, this
+       message is shown in both notice and console: Unlimited Context Enabled!
+    */
+    // const activeNoteOnMessage: ChatMessage = {
+    //   sender: AI_SENDER,
+    //   message: `OK please ask me questions about [[${noteName}]]`,
+    //   isVisible: true,
+    // };
+    // addMessage(activeNoteOnMessage);
+
+    // if (noteContent) {
+    //   aiState.setChain(CONVERSATIONAL_RETRIEVAL_QA_CHAIN, { noteContent });
+    // } else {
+    //   new Notice('No note content found.');
+    //   console.error('No note content found.');
+    //   return;
+    // }
 
     // Set the context based on the noteContent
     const prompt = useNoteAsContextPrompt(noteName, noteContent);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const AI_SENDER = 'ai';
 export const DEFAULT_SYSTEM_PROMPT = 'You are Obsidian Copilot, a helpful assistant that integrates AI to Obsidian note-taking.';
 export const DEFAULT_SETTINGS: CopilotSettings = {
   openAiApiKey: '',
+  huggingfaceApiKey: '',
   defaultModel: 'gpt-3.5-turbo',
   temperature: '0.7',
   maxTokens: '1000',

--- a/src/langchainStream.ts
+++ b/src/langchainStream.ts
@@ -31,8 +31,17 @@ export const getAIResponse = async (
       );
     }
 
-    await aiState.runChatOpenAI(
-      userMessage,
+    // await aiState.runChatOpenAI(
+    //   userMessage,
+    //   chatContext,
+    //   abortController,
+    //   updateCurrentAiMessage,
+    //   addMessage,
+    //   debug,
+    // );
+
+    await aiState.runChain(
+      userMessage.message,
       chatContext,
       abortController,
       updateCurrentAiMessage,

--- a/src/langchainStream.ts
+++ b/src/langchainStream.ts
@@ -31,23 +31,23 @@ export const getAIResponse = async (
       );
     }
 
-    // await aiState.runChatOpenAI(
-    //   userMessage,
-    //   chatContext,
-    //   abortController,
-    //   updateCurrentAiMessage,
-    //   addMessage,
-    //   debug,
-    // );
-
-    await aiState.runChain(
-      userMessage.message,
+    await aiState.runChatOpenAI(
+      userMessage,
       chatContext,
       abortController,
       updateCurrentAiMessage,
       addMessage,
       debug,
     );
+
+    // await aiState.runChain(
+    //   userMessage.message,
+    //   chatContext,
+    //   abortController,
+    //   updateCurrentAiMessage,
+    //   addMessage,
+    //   debug,
+    // );
   } catch (error) {
     const errorData = error?.response?.data?.error || error;
     const errorCode = errorData?.code || error;

--- a/src/langchainStream.ts
+++ b/src/langchainStream.ts
@@ -37,6 +37,7 @@ export const getAIResponse = async (
       abortController,
       updateCurrentAiMessage,
       addMessage,
+      debug,
     );
   } catch (error) {
     const errorData = error?.response?.data?.error || error;

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import { Editor, Notice, Plugin, WorkspaceLeaf } from 'obsidian';
 
 export interface CopilotSettings {
   openAiApiKey: string;
+  huggingfaceApiKey: string;
   defaultModel: string;
   temperature: string;
   maxTokens: string;
@@ -257,12 +258,14 @@ export default class CopilotPlugin extends Plugin {
   getAIStateParams(): LangChainParams {
     const {
       openAiApiKey,
+      huggingfaceApiKey,
       temperature,
       maxTokens,
       contextTurns,
     } = sanitizeSettings(this.settings);
     return {
       key: openAiApiKey,
+      huggingfaceApiKey: huggingfaceApiKey,
       model: this.settings.defaultModel,
       temperature: Number(temperature),
       maxTokens: Number(maxTokens),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -173,33 +173,33 @@ export class CopilotSettingTab extends PluginSettingTab {
     //     })
     //   );
 
-    containerEl.createEl('h4', {text: 'Other API Settings'});
+    // containerEl.createEl('h4', {text: 'Other API Settings'});
 
-    new Setting(containerEl)
-      .setName("Your Huggingface Inference API key")
-      .setDesc(
-        createFragment((frag) => {
-          frag.appendText("You can find your API key at ");
-          frag.createEl('a', {
-            text: "https://hf.co/settings/tokens",
-            href: "https://hf.co/settings/tokens"
-          });
-          frag.createEl('br');
-          frag.appendText("It is used to make requests to Huggingface Inference API for vector search.");
-        })
-      )
-      .addText((text) =>{
-        text.inputEl.type = "password";
-        text.inputEl.style.width = "80%";
-        text
-          .setPlaceholder("Huggingface Inference API key")
-          .setValue(this.plugin.settings.huggingfaceApiKey)
-          .onChange(async (value) => {
-            this.plugin.settings.huggingfaceApiKey = value;
-            await this.plugin.saveSettings();
-          })
-        }
-      );
+    // new Setting(containerEl)
+    //   .setName("Your Huggingface Inference API key")
+    //   .setDesc(
+    //     createFragment((frag) => {
+    //       frag.appendText("You can find your API key at ");
+    //       frag.createEl('a', {
+    //         text: "https://hf.co/settings/tokens",
+    //         href: "https://hf.co/settings/tokens"
+    //       });
+    //       frag.createEl('br');
+    //       frag.appendText("It is used to make requests to Huggingface Inference API for vector search (BETA).");
+    //     })
+    //   )
+    //   .addText((text) =>{
+    //     text.inputEl.type = "password";
+    //     text.inputEl.style.width = "80%";
+    //     text
+    //       .setPlaceholder("Huggingface Inference API key")
+    //       .setValue(this.plugin.settings.huggingfaceApiKey)
+    //       .onChange(async (value) => {
+    //         this.plugin.settings.huggingfaceApiKey = value;
+    //         await this.plugin.saveSettings();
+    //       })
+    //     }
+    //   );
 
     containerEl.createEl('h4', {text: 'Advanced Settings'});
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -173,6 +173,34 @@ export class CopilotSettingTab extends PluginSettingTab {
     //     })
     //   );
 
+    containerEl.createEl('h4', {text: 'Other API Settings'});
+
+    new Setting(containerEl)
+      .setName("Your Huggingface Inference API key")
+      .setDesc(
+        createFragment((frag) => {
+          frag.appendText("You can find your API key at ");
+          frag.createEl('a', {
+            text: "https://hf.co/settings/tokens",
+            href: "https://hf.co/settings/tokens"
+          });
+          frag.createEl('br');
+          frag.appendText("It is used to make requests to Huggingface Inference API for vector search.");
+        })
+      )
+      .addText((text) =>{
+        text.inputEl.type = "password";
+        text.inputEl.style.width = "80%";
+        text
+          .setPlaceholder("Huggingface Inference API key")
+          .setValue(this.plugin.settings.huggingfaceApiKey)
+          .onChange(async (value) => {
+            this.plugin.settings.huggingfaceApiKey = value;
+            await this.plugin.saveSettings();
+          })
+        }
+      );
+
     containerEl.createEl('h4', {text: 'Advanced Settings'});
 
     new Setting(containerEl)


### PR DESCRIPTION
- Added ChainFactory for more singleton chain instances of different types
- Added logic for vector search powered by Huggingface Inference API, will ship this in the next minor release.

Problems encountered:
- Streaming causes ConversationalRetrievalQAChain to always start answers with a rephrased question https://github.com/hwchase17/langchainjs/issues/754
  - Need to wait and test more and wait for this fix to launch "Use Active Note as Context" for long notes.
- `Refused to set unsafe header "User-Agent"` error, happens only when there's non-streaming `ChatOpenAI`. This is unfortunate because LangchainJS is using `openai-node` which causes this error. The recommended way is to have a server that uses LangchainJS and `openai-node`, but this is a pure client app. Avoid non-streaming for now.