### PR TITLE
Transition to unlimited context qa

### DIFF
--- a/src/aiState.ts
+++ b/src/aiState.ts
@@ -157,10 +157,11 @@ class AIState {
         }
 
         const docHash = ChainFactory.getDocumentHash(options.noteContent);
-        if (ChainFactory.vectorStoreMap.has(docHash)) {
+        const vectorStore = ChainFactory.vectorStoreMap.get(docHash);
+        if (vectorStore) {
           AIState.retrievalChain = RetrievalQAChain.fromLLM(
             AIState.chatOpenAI,
-            this.vectorStore.asRetriever(),
+            vectorStore.asRetriever(),
           );
           console.log('Existing vector store for document hash: ', docHash);
         } else {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -136,15 +136,24 @@ const Chat: React.FC<ChatProps> = ({
       return;
     }
 
+    let activeNoteOnMessage: ChatMessage;
     const docHash = ChainFactory.getDocumentHash(noteContent);
-    await aiState.buildIndex(noteContent, docHash);
-    console.log('Vector store added for docHash:', docHash)
+    const vectorStore = ChainFactory.vectorStoreMap.get(docHash);
+    if (vectorStore) {
+      activeNoteOnMessage = {
+        sender: AI_SENDER,
+        message: `I have Read [[${noteName}]].\n\n Please switch to "QA: Active Note" to ask questions about it.`,
+        isVisible: true,
+      };
+    } else {
+      await aiState.buildIndex(noteContent, docHash);
+      activeNoteOnMessage = {
+        sender: AI_SENDER,
+        message: `Reading [[${noteName}]]...\n\n Please switch to "QA: Active Note" to ask questions about it.`,
+        isVisible: true,
+      };
+    }
 
-    const activeNoteOnMessage: ChatMessage = {
-      sender: AI_SENDER,
-      message: `Reading [[${noteName}]]...\n\n Switch to "QA: Active Note" to ask questions about it.`,
-      isVisible: true,
-    };
     addMessage(activeNoteOnMessage);
   };
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,4 +1,5 @@
 import AIState, { useAIState } from '@/aiState';
+import ChainFactory from '@/chainFactory';
 import ChatIcons from '@/components/ChatComponents/ChatIcons';
 import ChatInput from '@/components/ChatComponents/ChatInput';
 import ChatMessages from '@/components/ChatComponents/ChatMessages';
@@ -27,8 +28,7 @@ import {
   rewriteTweetThreadSelectionPrompt,
   simplifyPrompt,
   summarizePrompt,
-  tocPrompt,
-  useNoteAsContextPrompt,
+  tocPrompt
 } from '@/utils';
 import { EventEmitter } from 'events';
 import { Notice, TFile } from 'obsidian';
@@ -130,28 +130,22 @@ const Chat: React.FC<ChatProps> = ({
     }
     const noteContent = await getFileContent(file);
     const noteName = getFileName(file);
+    if (!noteContent) {
+      new Notice('No note content found.');
+      console.error('No note content found.');
+      return;
+    }
 
-    // Set the context based on the noteContent
-    const prompt = useNoteAsContextPrompt(noteName, noteContent);
+    const docHash = ChainFactory.getDocumentHash(noteContent);
+    await aiState.buildIndex(noteContent, docHash);
+    console.log('Vector store added for docHash:', docHash)
 
-    // Send the prompt as a user message
-    const promptMessage: ChatMessage = {
-      sender: USER_SENDER,
-      message: prompt,
-      isVisible: false,
+    const activeNoteOnMessage: ChatMessage = {
+      sender: AI_SENDER,
+      message: `Reading [[${noteName}]]...\n\n Switch to "QA: Active Note" to ask questions about it.`,
+      isVisible: true,
     };
-    addMessage(promptMessage);
-
-    // Hide the prompt from the user
-    await getAIResponse(
-      promptMessage,
-      chatContext,
-      aiState,
-      addMessage,
-      setCurrentAiMessage,
-      setAbortController,
-      debug,
-    );
+    addMessage(activeNoteOnMessage);
   };
 
   const clearCurrentAiMessage = () => {

--- a/src/components/ChatComponents/ChatIcons.tsx
+++ b/src/components/ChatComponents/ChatIcons.tsx
@@ -78,7 +78,7 @@ const ChatIcons: React.FC<ChatIconsProps> = ({
 
       const activeNoteOnMessage: ChatMessage = {
         sender: AI_SENDER,
-        message: `OK I've read this long note [[${noteName}]]. Feel free to ask me questions about it.`,
+        message: `OK Feel free to ask me questions about [[${noteName}]].`,
         isVisible: true,
       };
       addMessage(activeNoteOnMessage);
@@ -119,7 +119,7 @@ const ChatIcons: React.FC<ChatIconsProps> = ({
       </button>
       <button className='chat-icon-button' onClick={onUseActiveNoteAsContext}>
         <UseActiveNoteAsContextIcon className='icon-scaler' />
-        <span className="tooltip-text">QA: Active Short Note</span>
+        <span className="tooltip-text">Use Active Note as Context</span>
       </button>
       <div className="chat-icon-selection-tooltip">
         <div className="select-wrapper">
@@ -130,7 +130,7 @@ const ChatIcons: React.FC<ChatIconsProps> = ({
             onChange={handleChainChange}
           >
             <option value='llm_chain'>Conversation</option>
-            <option value='retrieval_qa'>QA: Long Note</option>
+            <option value='retrieval_qa'>QA: Active Note</option>
           </select>
           <span className="tooltip-text">Chain Selection<br/>(clears history!)</span>
         </div>


### PR DESCRIPTION
New behavior: 

Clicking on "Use Active Note as Context" builds the index for the active note in-memory. Then, switch to "QA: Active Note" in Chain Selection dropdown to chat with the note.