### PR TITLE
Fix plugin loading when there is no openai key

### DIFF
--- a/src/aiState.ts
+++ b/src/aiState.ts
@@ -124,6 +124,13 @@ class AIState {
       key, model, temperature, maxTokens,
     } = this.langChainParams;
 
+    if (!key) {
+      new Notice(
+        'No OpenAI API key provided. Please set it in Copilot settings, and restart the plugin.'
+      );
+      return;
+    }
+
     AIState.chatOpenAI = new ChatOpenAI({
       openAIApiKey: key,
       modelName: model,

--- a/src/langchainStream.ts
+++ b/src/langchainStream.ts
@@ -1,5 +1,6 @@
 import AIState from '@/aiState';
 import { ChatMessage } from '@/sharedState';
+import { Notice } from 'obsidian';
 
 export type Role = 'assistant' | 'user' | 'system';
 
@@ -12,17 +13,25 @@ export const getAIResponse = async (
   updateShouldAbort: (abortController: AbortController | null) => void,
   debug = false,
 ) => {
+  const {
+    key,
+    model,
+    temperature,
+    maxTokens,
+    systemMessage,
+    chatContextTurns,
+  } = aiState.langChainParams;
+  if (!key) {
+    new Notice(
+      'No OpenAI API key provided. Please set it in Copilot settings, and restart the plugin.'
+    );
+    return;
+  }
+
   const abortController = new AbortController();
 
   updateShouldAbort(abortController);
   if (debug) {
-    const {
-      model,
-      temperature,
-      maxTokens,
-      systemMessage,
-      chatContextTurns,
-    } = aiState.langChainParams;
     console.log(`*** DEBUG INFO ***\n`
       + `user message: ${userMessage.message}\n`
       + `model: ${model}\n`

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -54,7 +54,7 @@ export class CopilotSettingTab extends PluginSettingTab {
       )
       .addText((text) => {
         text.inputEl.type = "password";
-        text.inputEl.style.width = "80%";
+        text.inputEl.style.width = "100%";
         text
           .setPlaceholder("OpenAI API key")
           .setValue(this.plugin.settings.openAiApiKey)


### PR DESCRIPTION
Right after installation, resetting to default settings, or whenever there is no OpenAI API key, the plugin fails to load, and the ribbon on the left does not show up without any notice.

Now, a notice will show up to inform the user
<img width="327" alt="image" src="https://github.com/logancyang/obsidian-copilot/assets/4860545/aa68f522-64e7-4a97-bc06-18c1962428ff">
