### PR TITLE
fix: caught (in promise) Error: (Azure) OpenAI API key not found

### DIFF
--- a/src/aiState.ts
+++ b/src/aiState.ts
@@ -240,7 +240,7 @@ class AIState {
 
   getEmbeddingsAPI(): Embeddings {
     const OpenAIEmbeddingsAPI = new OpenAIEmbeddings({
-      openAIApiKey: this.langChainParams.openAIApiKey,
+      openAIApiKey: this.langChainParams.openAIApiKey || this.langChainParams.azureOpenAIApiKey,
       maxRetries: 3,
       maxConcurrency: 3,
       timeout: 10000,


### PR DESCRIPTION
when using azure open ai, switch to "QA: Active Note" or rebuild index for  Active Note the console will report this error
![image](https://github.com/logancyang/obsidian-copilot/assets/21985353/7f3bbfad-3d50-457b-bff4-5f44ef2133a0)
