### PR TITLE
Add usingDocker setting for Local Copilot

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -114,6 +114,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   userSystemPrompt: '',
   openAIProxyBaseUrl: '',
   useLocalProxy: false,
+  usingDocker: true,
   localAIModel: '',
   stream: true,
   embeddingProvider: OPENAI,

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ export default class CopilotPlugin extends Plugin {
       // If using local proxy, 3rd party proxy is overridden
       langChainParams.openAIProxyBaseUrl = this.settings.usingDocker
       ? `http://localhost:${PROXY_SERVER_PORT}`
-      : LOCALAI_URL.replace(/\/v1$/, '');
+      : LOCALAI_URL.substring(0, LOCALAI_URL.lastIndexOf('/'));
 
       langChainParams.useLocalProxy = true;
       await this.startProxyServer(LOCALAI_URL);

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,6 +41,7 @@ export interface CopilotSettings {
   userSystemPrompt: string;
   openAIProxyBaseUrl: string;
   useLocalProxy: boolean;
+  usingDocker: boolean;
   localAIModel: string;
   stream: boolean;
   embeddingProvider: string;
@@ -74,7 +75,10 @@ export default class CopilotPlugin extends Plugin {
     const langChainParams = this.getAIStateParams();
     if (this.settings.useLocalProxy) {
       // If using local proxy, 3rd party proxy is overridden
-      langChainParams.openAIProxyBaseUrl = `http://localhost:${PROXY_SERVER_PORT}`;
+      langChainParams.openAIProxyBaseUrl = this.settings.usingDocker
+      ? `http://localhost:${PROXY_SERVER_PORT}`
+      : LOCALAI_URL.replace(/\/v1$/, '');
+
       langChainParams.useLocalProxy = true;
       await this.startProxyServer(LOCALAI_URL);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -422,6 +422,27 @@ export class CopilotSettingTab extends PluginSettingTab {
       });
 
     new Setting(containerEl)
+      .setName("Running LocalAI with Docker")
+      .setDesc(
+        createFragment((frag) => {
+          frag.appendText("Enable this option if you are running LocalAI with Docker; otherwise, disable it.");
+          frag.createEl('br');
+          frag.createEl(
+            'strong',
+            { text: "Plugin restart required." }
+          );
+        })
+      )
+      .addToggle((toggle) => {
+        toggle
+          .setValue(this.plugin.settings.usingDocker)
+          .onChange(async (value) => {
+            this.plugin.settings.usingDocker = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
+    new Setting(containerEl)
       .setName("LocalAI Model")
       .setDesc(
         createFragment((frag) => {


### PR DESCRIPTION
Hi, thanks for creating this great plugin. I have been trying the new Local Copilot feature.

With the "Use Local Copilot" setting I get the error: _LangChain error: AxiosError: Request failed with status code 503 and body Service Unavailable_ because of the PROXY_SERVER_PORT being 3001.

I am running LocalAI on my Macbook **without Docker** as recommended in [LocalAI Getting Started](https://localai.io/basics/getting_started/#:~:text=How%20about%20you%3F%22%7D%7D%5D%7D-,Note,-If%20running%20on). I have personally noticed Docker being around 2-3 times slower on my M2 Max than from source with Metal acceleration. I am running LocalAI with this command: `./local-ai --models-path ./models/ --debug --cors` (--cors must be included).

This PR changes the openAIProxyBaseUrl to `http://localhost:8080` if the user is not using Docker which resolves the error.

Please let me know if any changes are needed.