### PR TITLE
Remove proxy server for LocalAI

### DIFF
--- a/localai_setup.md
+++ b/localai_setup.md
@@ -5,6 +5,7 @@ Local Copilot is powered by [LocalAI](https://github.com/go-skynet/LocalAI), a c
 First, you need to be able to run LocalAI server locally on your device. Make sure you have some decent hardware! Refer to [this guide](https://www.reddit.com/r/LocalLLaMA/comments/11o6o3f/how_to_install_llama_8bit_and_4bit/) to check system requirements. I recommend testing with smaller models first. But keep in mind, smaller models could hallucinate more and may not give you satisfactory results for some use cases. If you have the hardware, try larger models variants!
 
 ## How to setup LocalAI on Apple Silicon
+
 First, make sure in your terminal, `arch` shows `arm64` and not `i386`. The latter is Rosetta. If you are running Rosetta, find your terminal app and right click, find Get Info window and **uncheck "Open using Rosetta"**.
 
 ```bash
@@ -21,7 +22,7 @@ git clone https://github.com/go-skynet/LocalAI.git
 cd LocalAI
 
 # build the binary
-make build
+make BUILD_TYPE=metal build
 
 # Start localai with model gallery
 GALLERIES='[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index.yaml"}, {"url": "github:go-skynet/model-gallery/huggingface.yaml","name":"huggingface"}]' ./local-ai --models-path ./models/ --debug
@@ -30,6 +31,7 @@ GALLERIES='[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index
 (Here's the original [localAI guide](https://localai.io/basics/build/#build-on-mac) I referred to. I added some more details for the errors I saw when I set it up on my M1 Macbook Air. Hope this helps!)
 
 ## How to setup LocalAI on Windows WSL (Linux)
+
 First make sure you have WSL installed and running. Follow [this guide](https://learn.microsoft.com/en-us/windows/wsl/install) if you don't have WSL. Then in your WSL terminal:
 
 ```bash
@@ -68,6 +70,7 @@ docker compose up -d
 If you have issues, feel free to ask in the discussion section to see if people have any tips or solutions. It's also helpful to check [LocalAI's Github page](https://github.com/go-skynet/LocalAI) and [documentation](https://localai.io/). Join their Discord community for more real-time help. I got help there when I was setting it up myself.
 
 ## How to install models and test the API
+
 Now that you have LocalAI running successfully on your machine, it's time to get some models! They have a [model gallery](https://github.com/go-skynet/model-gallery) where you can see a lot of the model variants that you can install via the LocalAI `/models/apply` API.
 
 ```bash
@@ -96,6 +99,7 @@ curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/jso
 If you get a response for the curl above you are almost there!
 
 ## ⚠️ Modify the prompt template for the model ⚠️
+
 **This is a crucial step**! If this is not correct, the bot will not be able to understand the context properly.
 
 First, check your `LocalAI/models/` directory and find these files:
@@ -115,28 +119,29 @@ Add `roles` to `llama-2-uncensored-q4ks.yaml`, and point the chat template to `l
 context_size: 1024
 name: llama-2-uncensored-q4ks
 parameters:
-  model: luna-ai-llama2-uncensored.ggmlv3.q4_K_S.bin
-  temperature: 0.2
-  top_k: 80
-  top_p: 0.7
+    model: luna-ai-llama2-uncensored.ggmlv3.q4_K_S.bin
+    temperature: 0.2
+    top_k: 80
+    top_p: 0.7
 roles:
-  assistant: 'ASSISTANT'
-  user: 'USER'
+    assistant: "ASSISTANT"
+    user: "USER"
 template:
-  chat: luna-ai-chat
-  completion: completion
+    chat: luna-ai-chat
+    completion: completion
 ```
 
 Then add the following to the `luna-ai-chat.tmpl` file (it is shown in the model card on Huggingface):
 
 ```yml
-USER: {{.Input}}
+USER: { { .Input } }
 ASSISTANT:
 ```
 
 **Always remember to use the prompt template from the model card!** The default `chat.tmpl` does not always work with various models.
 
 ## How to start chatting with Local Copilot
+
 Assuming you have done everything above correctly, head to Copilot settings, toggle "Use Local Copilot" on, then type in your model name below (in this case, llama-2-uncensored-q4ks).
 
 <img src="./images/local-copilot-setting.png" width="500" alt="UI" />
@@ -146,6 +151,7 @@ Restart your plugin, select **LocalAI** in your chat window, and start chatting!
 <img src="./images/local-copilot.png" width="500" alt="UI" />
 
 ## How to run QA mode offline
+
 If you would like to have QA mode completely offline as well, you can install the BERT embedding model to substitute the OpenAI `text-embedding-ada-002` like this:
 
 ```bash
@@ -164,6 +170,7 @@ Don't forget to **choose LocalAI as the embedding provider in Copilot settings**
 Now hopefully you should be able to turn off your internet and still have full Copilot functionality! Let me know if you have any other questions!
 
 ## Caveats
+
 This is still in early experimental phase. Local LLMs require some experience to set up and interact with. Please be careful with any large models and ensure you have enough storage and memory for them.
 
 If you experience issues, feel free to reach out in the discussion section. If you believe the bug is with Copilot, please submit an issue. If you think the issue is with LocalAI itself, please open an issue there instead. Again, they have a great Discord community to help troubleshoot as well, consider joining there!

--- a/localai_setup.md
+++ b/localai_setup.md
@@ -24,8 +24,8 @@ cd LocalAI
 # build the binary
 make BUILD_TYPE=metal build
 
-# Start localai with model gallery
-GALLERIES='[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index.yaml"}, {"url": "github:go-skynet/model-gallery/huggingface.yaml","name":"huggingface"}]' ./local-ai --models-path ./models/ --debug
+# Start localai with model gallery with CORS enabled
+GALLERIES='[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index.yaml"}, {"url": "github:go-skynet/model-gallery/huggingface.yaml","name":"huggingface"}]' ./local-ai --models-path ./models/ --debug --cors
 ```
 
 (Here's the original [localAI guide](https://localai.io/basics/build/#build-on-mac) I referred to. I added some more details for the errors I saw when I set it up on my M1 Macbook Air. Hope this helps!)
@@ -58,6 +58,12 @@ Set the `GALLERIES` env variable to load models from model-gallery. Edit `.env` 
 
 ```
 GALLERIES=[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index.yaml"}, {"url": "github:go-skynet/model-gallery/huggingface.yaml","name":"huggingface"}]
+```
+
+Also uncomment the `CORS` settings in `.env`
+
+```
+CORS=true
 ```
 
 Then start the Docker container,

--- a/localai_setup.md
+++ b/localai_setup.md
@@ -5,7 +5,6 @@ Local Copilot is powered by [LocalAI](https://github.com/go-skynet/LocalAI), a c
 First, you need to be able to run LocalAI server locally on your device. Make sure you have some decent hardware! Refer to [this guide](https://www.reddit.com/r/LocalLLaMA/comments/11o6o3f/how_to_install_llama_8bit_and_4bit/) to check system requirements. I recommend testing with smaller models first. But keep in mind, smaller models could hallucinate more and may not give you satisfactory results for some use cases. If you have the hardware, try larger models variants!
 
 ## How to setup LocalAI on Apple Silicon
-
 First, make sure in your terminal, `arch` shows `arm64` and not `i386`. The latter is Rosetta. If you are running Rosetta, find your terminal app and right click, find Get Info window and **uncheck "Open using Rosetta"**.
 
 ```bash
@@ -31,7 +30,6 @@ GALLERIES='[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index
 (Here's the original [localAI guide](https://localai.io/basics/build/#build-on-mac) I referred to. I added some more details for the errors I saw when I set it up on my M1 Macbook Air. Hope this helps!)
 
 ## How to setup LocalAI on Windows WSL (Linux)
-
 First make sure you have WSL installed and running. Follow [this guide](https://learn.microsoft.com/en-us/windows/wsl/install) if you don't have WSL. Then in your WSL terminal:
 
 ```bash
@@ -76,7 +74,6 @@ docker compose up -d
 If you have issues, feel free to ask in the discussion section to see if people have any tips or solutions. It's also helpful to check [LocalAI's Github page](https://github.com/go-skynet/LocalAI) and [documentation](https://localai.io/). Join their Discord community for more real-time help. I got help there when I was setting it up myself.
 
 ## How to install models and test the API
-
 Now that you have LocalAI running successfully on your machine, it's time to get some models! They have a [model gallery](https://github.com/go-skynet/model-gallery) where you can see a lot of the model variants that you can install via the LocalAI `/models/apply` API.
 
 ```bash
@@ -105,7 +102,6 @@ curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/jso
 If you get a response for the curl above you are almost there!
 
 ## ⚠️ Modify the prompt template for the model ⚠️
-
 **This is a crucial step**! If this is not correct, the bot will not be able to understand the context properly.
 
 First, check your `LocalAI/models/` directory and find these files:
@@ -125,29 +121,28 @@ Add `roles` to `llama-2-uncensored-q4ks.yaml`, and point the chat template to `l
 context_size: 1024
 name: llama-2-uncensored-q4ks
 parameters:
-    model: luna-ai-llama2-uncensored.ggmlv3.q4_K_S.bin
-    temperature: 0.2
-    top_k: 80
-    top_p: 0.7
+  model: luna-ai-llama2-uncensored.ggmlv3.q4_K_S.bin
+  temperature: 0.2
+  top_k: 80
+  top_p: 0.7
 roles:
-    assistant: "ASSISTANT"
-    user: "USER"
+  assistant: 'ASSISTANT'
+  user: 'USER'
 template:
-    chat: luna-ai-chat
-    completion: completion
+  chat: luna-ai-chat
+  completion: completion
 ```
 
 Then add the following to the `luna-ai-chat.tmpl` file (it is shown in the model card on Huggingface):
 
 ```yml
-USER: { { .Input } }
+USER: {{.Input}}
 ASSISTANT:
 ```
 
 **Always remember to use the prompt template from the model card!** The default `chat.tmpl` does not always work with various models.
 
 ## How to start chatting with Local Copilot
-
 Assuming you have done everything above correctly, head to Copilot settings, toggle "Use Local Copilot" on, then type in your model name below (in this case, llama-2-uncensored-q4ks).
 
 <img src="./images/local-copilot-setting.png" width="500" alt="UI" />
@@ -157,7 +152,6 @@ Restart your plugin, select **LocalAI** in your chat window, and start chatting!
 <img src="./images/local-copilot.png" width="500" alt="UI" />
 
 ## How to run QA mode offline
-
 If you would like to have QA mode completely offline as well, you can install the BERT embedding model to substitute the OpenAI `text-embedding-ada-002` like this:
 
 ```bash
@@ -176,7 +170,6 @@ Don't forget to **choose LocalAI as the embedding provider in Copilot settings**
 Now hopefully you should be able to turn off your internet and still have full Copilot functionality! Let me know if you have any other questions!
 
 ## Caveats
-
 This is still in early experimental phase. Local LLMs require some experience to set up and interact with. Please be careful with any large models and ensure you have enough storage and memory for them.
 
 If you experience issues, feel free to reach out in the discussion section. If you believe the bug is with Copilot, please submit an issue. If you think the issue is with LocalAI itself, please open an issue there instead. Again, they have a great Discord community to help troubleshoot as well, consider joining there!

--- a/src/aiState.ts
+++ b/src/aiState.ts
@@ -63,7 +63,6 @@ interface ModelConfig {
   azureOpenAIApiDeploymentName?: string,
   azureOpenAIApiVersion?: string,
   openAIProxyBaseUrl?: string,
-  useLocalProxy?: boolean,
   localAIModel?: string,
 }
 
@@ -87,7 +86,6 @@ export interface LangChainParams {
   chainType: ChainType,  // Default ChainType is set in main.ts getAIStateParams
   options: SetChainOptions,
   openAIProxyBaseUrl?: string,
-  useLocalProxy?: boolean,
   localAIModel?: string,
 }
 
@@ -171,7 +169,6 @@ class AIState {
       temperature,
       maxTokens,
       openAIProxyBaseUrl,
-      useLocalProxy,
       localAIModel,
     } = this.langChainParams;
 
@@ -191,7 +188,6 @@ class AIState {
           openAIApiKey,
           maxTokens,
           openAIProxyBaseUrl,
-          useLocalProxy,
           localAIModel,
         };
         break;
@@ -265,7 +261,6 @@ class AIState {
       azureOpenAIApiVersion,
       azureOpenAIApiEmbeddingDeploymentName,
       openAIProxyBaseUrl,
-      useLocalProxy,
     } = this.langChainParams;
 
     const OpenAIEmbeddingsAPI = new OpenAIEmbeddings({
@@ -307,7 +302,6 @@ class AIState {
         return new ProxyOpenAIEmbeddings({
           openAIApiKey,
           openAIProxyBaseUrl,
-          useLocalProxy,
           maxRetries: 3,
           maxConcurrency: 3,
           timeout: 10000,
@@ -364,12 +358,17 @@ class AIState {
   setModel(newModelDisplayName: string): void {
     // model and model display name must be update at the same time!
     let newModel = getModelName(newModelDisplayName);
-    const {useLocalProxy, localAIModel} = this.langChainParams;
+    const {localAIModel} = this.langChainParams;
 
-    if (newModelDisplayName === ChatModelDisplayNames.LOCAL_AI && useLocalProxy) {
+    if (newModelDisplayName === ChatModelDisplayNames.LOCAL_AI) {
       if (!localAIModel) {
         new Notice('No local AI model provided! Please set it in settings first.');
         console.error('No local AI model provided! Please set it in settings first.');
+        return;
+      }
+      if (!this.langChainParams.openAIProxyBaseUrl) {
+        new Notice('Please set the OpenAI Proxy Base URL in settings.');
+        console.error('Please set the OpenAI Proxy Base URL in settings.');
         return;
       }
       newModel = localAIModel;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,9 +90,6 @@ export const DISTILBERT_NLI = 'sentence-transformers/distilbert-base-nli-mean-to
 export const INSTRUCTOR_XL = 'hkunlp/instructor-xl'; // Inference API is off for this
 export const MPNET_V2 = 'sentence-transformers/all-mpnet-base-v2'; // Inference API returns 400
 
-// Proxy parameters
-export const PROXY_SERVER_PORT = 3001;
-export const LOCALAI_URL = 'http://localhost:8080/v1';  // LocalAI server
 // export const LOCALAI_DEFAULT_MODEL = 'ggml-gpt4all-j';
 
 export const DEFAULT_SETTINGS: CopilotSettings = {
@@ -113,7 +110,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   useNotesAsContext: false,
   userSystemPrompt: '',
   openAIProxyBaseUrl: '',
-  useLocalProxy: false,
   localAIModel: '',
   stream: true,
   embeddingProvider: OPENAI,

--- a/src/langchainWrappers.ts
+++ b/src/langchainWrappers.ts
@@ -8,10 +8,8 @@ export class ProxyChatOpenAI extends ChatOpenAI {
   ) {
     super(fields ?? {});
 
-    const modelName = fields.useLocalProxy ? fields.localAIModel : fields.modelName;
-    if (fields.useLocalProxy) {
-      console.log('Using local proxy, LocalAI model: ', modelName);
-    }
+    // Use LocalAIModel if it is set
+    const modelName = fields.localAIModel ? fields.localAIModel : fields.modelName;
 
     const clientConfig = new Configuration({
       ...this["clientConfig"],
@@ -29,10 +27,6 @@ export class ProxyOpenAIEmbeddings extends OpenAIEmbeddings {
     fields?: any,
   ) {
     super(fields ?? {});
-
-    if (fields.useLocalProxy) {
-      console.log('Using local proxy, LocalAI embedding. ');
-    }
 
     const clientConfig = new Configuration({
       ...this["clientConfig"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,6 @@ import { ListPromptModal } from "@/components/ListPromptModal";
 import { ToneModal } from "@/components/ToneModal";
 import {
   CHAT_VIEWTYPE, DEFAULT_SETTINGS, DEFAULT_SYSTEM_PROMPT,
-  LOCALAI_URL,
-  PROXY_SERVER_PORT
 } from '@/constants';
 import { CopilotSettingTab } from '@/settings';
 import SharedState from '@/sharedState';
@@ -40,7 +38,6 @@ export interface CopilotSettings {
   useNotesAsContext: boolean;
   userSystemPrompt: string;
   openAIProxyBaseUrl: string;
-  useLocalProxy: boolean;
   localAIModel: string;
   stream: boolean;
   embeddingProvider: string;
@@ -72,12 +69,6 @@ export default class CopilotPlugin extends Plugin {
     // Always have one instance of sharedState and aiState in the plugin
     this.sharedState = new SharedState();
     const langChainParams = this.getAIStateParams();
-    if (this.settings.useLocalProxy) {
-      // If using local proxy, 3rd party proxy is overridden
-      langChainParams.openAIProxyBaseUrl = `http://localhost:${PROXY_SERVER_PORT}`;
-      langChainParams.useLocalProxy = true;
-      await this.startProxyServer(LOCALAI_URL);
-    }
     this.aiState = new AIState(langChainParams);
 
     this.dbPrompts = new PouchDB<CustomPrompt>('copilot_custom_prompts');
@@ -377,10 +368,6 @@ export default class CopilotPlugin extends Plugin {
     });
   }
 
-  async onunload() {
-    await this.stopProxyServer();
-  }
-
   processSelection(editor: Editor, eventType: string, eventSubtype?: string) {
     if (editor.somethingSelected() === false) {
       new Notice('Please select some text to rewrite.');
@@ -497,58 +484,5 @@ export default class CopilotPlugin extends Plugin {
       options: { forceNewCreation: true } as SetChainOptions,
       openAIProxyBaseUrl: this.settings.openAIProxyBaseUrl,
     };
-  }
-
-  async startProxyServer(proxyBaseUrl: string) {
-    console.log('loading plugin');
-    // check if the port is already in use
-    const inUse = await this.checkPortInUse(PROXY_SERVER_PORT);
-
-    if (!inUse) {
-      // Create a new Koa application
-      const app = new Koa();
-
-      app.use(cors());
-
-      // Create and apply the proxy middleware
-      app.use(proxy('/', {
-        // your target API, e.g. http://localhost:8080 for LocalAI
-        target: proxyBaseUrl,
-        changeOrigin: true,
-      }));
-
-      // Start the server on the specified port
-      this.server = app.listen(PROXY_SERVER_PORT);
-      console.log(`Proxy server running on http://localhost:${PROXY_SERVER_PORT}`);
-    } else {
-      console.error(`Port ${PROXY_SERVER_PORT} is in use`);
-    }
-  }
-
-  async stopProxyServer() {
-    console.log('stopping proxy server...');
-    if (this.server) {
-      this.server.close();
-    }
-  }
-
-  checkPortInUse(port: number) {
-    return new Promise((resolve, reject) => {
-      const server = net.createServer()
-        .once('error', (err: NodeJS.ErrnoException) => {  // Typecast here
-          if (err.code === 'EADDRINUSE') {
-            resolve(true);  // Port is in use
-          } else {
-            reject(err);
-          }
-        })
-        .once('listening', () => {
-          server.once('close', () => {
-            resolve(false);  // Port is not in use
-          })
-          .close();
-        })
-        .listen(port);
-    });
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -401,31 +401,12 @@ export class CopilotSettingTab extends PluginSettingTab {
     containerEl.createEl('h6', { text: 'Local models can be limited in capabilities and may not work for some use cases at this time. Keep in mind that it is still in early experimental phase. But it is definitely fun to try out!' });
 
     new Setting(containerEl)
-      .setName("Use Local Copilot")
-      .setDesc(
-        createFragment((frag) => {
-          frag.appendText("Toggle this switch to launch a local proxy server. If this is on, 3rd-party proxy in Advanced Setting is overridden.");
-          frag.createEl('br');
-          frag.createEl(
-            'strong',
-            { text: "Plugin restart required." }
-          );
-        })
-      )
-      .addToggle((toggle) => {
-        toggle
-          .setValue(this.plugin.settings.useLocalProxy)
-          .onChange(async (value) => {
-            this.plugin.settings.useLocalProxy = value;
-            await this.plugin.saveSettings();
-          });
-      });
-
-    new Setting(containerEl)
       .setName("LocalAI Model")
       .setDesc(
         createFragment((frag) => {
           frag.appendText("The local model you'd like to use. Make sure you download that model in your LocalAI models directory.");
+          frag.createEl('br');
+          frag.appendText("NOTE: Please set OpenAI Proxy Base URL to http://localhost:8080/v1 under Advanced Settings")
         })
       )
       .addText((text) => {


### PR DESCRIPTION
This PR hopes to resolve the need for a proxy server when using LocalAI as mentioned in #122.

These changes have been tested with LocalAI running with Docker and from source with my M2 Max Macbook.

# Changes
- Remove Use LocalCopilot setting
- Remove code that creates Proxy Server for LocalAI
- LocalAI Url now relies on the OpenAI Proxy Base URL setting with the value of `http://localhost:8080/v1`
- Updated documentation for how to run LocalAI with CORS enabled for local build and Docker

# Screenshot of updated Settings
<img width="789" alt="image" src="https://github.com/logancyang/obsidian-copilot/assets/68660379/94b8da74-474d-47ba-9a3f-09d69ab6ae22">
