### PR TITLE
Prevent submission during IME composition in ChatInput

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -98,6 +98,7 @@ const Chat: React.FC<ChatProps> = ({
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (event.nativeEvent.isComposing) return;
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault(); // Prevents adding a newline to the textarea
       handleSendMessage();


### PR DESCRIPTION
### Overview
This pull request addresses an issue where the input form gets submitted when the "Enter" key is pressed during IME (Input Method Editor) composition, which is a common scenario for Japanese and other East Asian languages. By preventing form submission during IME composition, we can enhance the user experience and prevent unintended submissions.

### Changes
- Modified the `handleKeyDown` function to include a condition that checks the `isComposing` property of the native event. If `isComposing` is true, the function returns early to prevent form submission.

### Testing
- Ensure that the input form does not submit when the "Enter" key is pressed during IME composition.
- Verify that the form can be submitted as expected when not in IME composition mode.
