### PR TITLE
Make it work with with OpenRouter.ai

### DIFF
--- a/src/openAiStream.ts
+++ b/src/openAiStream.ts
@@ -146,6 +146,9 @@ export const OpenAIRequest = async (
     url: OPEN_AI_API_URL,
     headers: {
       'Content-Type': 'application/json',
+      'HTTP-Referer': `https://github.com/logancyang/obsidian-copilot`, // To identify your app. Can be set to e.g. http://localhost:3000 for testing
+      'X-Title': `Obsidian CoPilot`, // Optional. Shows on openrouter.ai
+
       Authorization: `Bearer ${key ? key : process.env.OPENAI_API_KEY}`,
       ...(process.env.OPENAI_ORGANIZATION && {
         'OpenAI-Organization': process.env.OPENAI_ORGANIZATION,


### PR DESCRIPTION
This fix should (as far as I understood TypeScript) make it working with OpenRouter.ai
Regular version results in "Please set an "HTTP-Referer" header with the URL of your app"

According to OpenRouter's docs at https://openrouter.ai/docs#format - HTTP-referer could be https://localhost/ but it must be set. Title also should be set if possible.