### PR TITLE
fix: pass openAIProxyBaseUrl to embeddings when set openai proxy

### DIFF
--- a/src/aiState.ts
+++ b/src/aiState.ts
@@ -32,6 +32,7 @@ import { Embeddings } from "langchain/embeddings/base";
 import { CohereEmbeddings } from "langchain/embeddings/cohere";
 import { HuggingFaceInferenceEmbeddings } from "langchain/embeddings/hf";
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";
+import { ConfigurationParameters } from "openai";
 import { BufferWindowMemory } from "langchain/memory";
 import {
   ChatPromptTemplate,
@@ -263,12 +264,15 @@ class AIState {
       openAIProxyBaseUrl,
     } = this.langChainParams;
 
+	const OpenAIEmbeddingsConfs: ConfigurationParameters = {};
+	openAIProxyBaseUrl ? OpenAIEmbeddingsConfs["basePath"] = openAIProxyBaseUrl : null;
+
     const OpenAIEmbeddingsAPI = new OpenAIEmbeddings({
       openAIApiKey,
       maxRetries: 3,
       maxConcurrency: 3,
       timeout: 10000,
-    });
+    }, OpenAIEmbeddingsConfs);
 
     switch(this.langChainParams.embeddingProvider) {
       case OPENAI:


### PR DESCRIPTION
Hi, when I use the thirdparty proxy of openai, I found the base-url of the embeddings api is not replaced by the openAIProxyBaseUrl, so, I add this code to the repo

### Changes
- import the interface ConfigurationParameters of OpenAI
- add the logic to set the embeddings config - basePath
- add the second param when new OpenAIEmbeddings class

:)
