### PR TITLE
feat(custom prompts): Adhoc-Custom Prompt

### DIFF
--- a/src/components/AdhocPromptModal.tsx
+++ b/src/components/AdhocPromptModal.tsx
@@ -1,0 +1,40 @@
+import { App, Modal } from 'obsidian';
+
+export class AdhocPromptModal extends Modal {
+    result: string;
+    onSubmit: (result: string) => void;
+
+    private placeholderText = 'Please enter your custom ad-hoc prompt to process the selection.';
+
+    constructor(app: App, onSubmit: (result: string) => void) {
+        super(app);
+        this.onSubmit = onSubmit;
+    }
+
+    onOpen() {
+        const { contentEl } = this;
+
+        const textareaEl = contentEl.createEl('textarea', { attr: { placeholder: this.placeholderText } });
+        textareaEl.style.width = '100%';
+        textareaEl.style.height = '100px'; // Set the desired height
+        textareaEl.style.padding = '10px';
+        textareaEl.style.resize = 'vertical'; // Allow vertical resizing
+
+        textareaEl.addEventListener('input', (evt) => {
+            this.result = (evt.target as HTMLTextAreaElement).value;
+        });
+
+        textareaEl.addEventListener('keydown', (evt) => {
+            if (evt.key === 'Enter' && !evt.shiftKey) {
+                evt.preventDefault(); // Prevent line break unless Shift key is pressed
+                this.close();
+                this.onSubmit(this.result);
+            }
+        });
+    }
+
+    onClose() {
+        const { contentEl } = this;
+        contentEl.empty();
+    }
+}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -12,6 +12,7 @@ import SharedState, {
   ChatMessage, useSharedState,
 } from '@/sharedState';
 import {
+  createAdhocSelectionPrompt,
   createChangeToneSelectionPrompt,
   createTranslateSelectionPrompt,
   eli5SelectionPrompt,
@@ -373,6 +374,14 @@ const Chat: React.FC<ChatProps> = ({
       // Not showing the custom prompt in the chat UI for now, Leaving it here as an option.
       // To check the prompt, use Debug mode in the setting.
       // { isVisible: true },
+    ),
+    []
+  );
+  useEffect(
+    createEffect(
+      'applyAdhocPromptSelection',
+      (selectedText, prompt) =>
+        createAdhocSelectionPrompt(prompt)(selectedText),
     ),
     []
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import ChainManager from '@/LLMProviders/chainManager';
 import { LangChainParams, SetChainOptions } from '@/aiParams';
 import { ChainType } from '@/chainFactory';
 import { AddPromptModal } from "@/components/AddPromptModal";
+import { AdhocPromptModal } from "@/components/AdhocPromptModal";
 import { ChatNoteContextModal } from "@/components/ChatNoteContextModal";
 import CopilotView from '@/components/CopilotView';
 import { LanguageModal } from "@/components/LanguageModal";
@@ -268,6 +269,23 @@ export default class CopilotPlugin extends Plugin {
         });
       },
     });
+
+    this.addCommand({
+      id: 'apply-adhoc-prompt',
+      name: 'Apply ad-hoc custom prompt to selection',
+      editorCallback: async (editor: Editor) => {
+          const modal = new AdhocPromptModal(this.app, async (adhocPrompt: string) => {
+              try {
+                  this.processSelection(editor, 'applyAdhocPromptSelection', adhocPrompt);
+              } catch (err) {
+                  console.error(err);
+                  new Notice('An error occurred.');
+              }
+          });
+
+          modal.open();
+      },
+  });
 
     this.addCommand({
       id: 'delete-custom-prompt',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -238,6 +238,15 @@ export function createChangeToneSelectionPrompt(tone?: string) {
   };
 }
 
+export function createAdhocSelectionPrompt(adhocPrompt?: string) {
+  return (selectedText: string): string => {
+    if (!adhocPrompt) {
+      return selectedText;
+    }
+    return `${adhocPrompt}.\n\n` + `${selectedText}`;
+  };
+}
+
 export function fillInSelectionForCustomPrompt(prompt?: string) {
   return (selectedText: string): string => {
     if (!prompt) {


### PR DESCRIPTION
Adds an adhoc custom prompt command to the plugin. The user can trigger it and enter any prompt as he wishes

This serves my workflow pretty good.... 
i think of something for a selection and want to ask chatgpt something for it...
he responds and i can integrate it into the text...

i would love to see it in the upstream