### PR TITLE
Pass multiple notes to prompt by setting folder as context using Copilot command

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test

--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -1,0 +1,16 @@
+// __mocks__/obsidian.js
+module.exports = {
+  Vault: jest.fn().mockImplementation(() => {
+      return {
+        getMarkdownFiles: jest.fn().mockImplementation(() => {
+          // Return an array of mock markdown file objects
+          return Promise.resolve([
+            { path: 'test/test2/note1.md' },
+            { path: 'test/note2.md' },
+            { path: 'test2/note3.md' },
+            { path: 'note4.md' },
+          ]);
+        }),
+      };
+    }),
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,8 +8,10 @@ module.exports = {
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '^@/(.*)$': '<rootDir>/src/$1',
+    '^obsidian$': '<rootDir>/__mocks__/obsidian.js'
   },
   testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testPathIgnorePatterns: ['/node_modules/'],
+  setupFiles: ['<rootDir>/jest.setup.js'],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import 'web-streams-polyfill/dist/polyfill.min.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@testing-library/react": "^14.0.0",
         "@types/crypto-js": "^4.1.1",
         "@types/events": "^3.0.0",
-        "@types/jest": "^29.5.0",
+        "@types/jest": "^29.5.11",
         "@types/koa": "^2.13.7",
         "@types/koa__cors": "^4.0.0",
         "@types/node": "^16.11.6",
@@ -49,12 +49,13 @@
         "@typescript-eslint/parser": "5.29.0",
         "builtin-modules": "3.3.0",
         "esbuild": "0.17.3",
-        "jest": "^29.5.0",
+        "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.5.0",
         "obsidian": "latest",
         "ts-jest": "^29.1.0",
         "tslib": "2.4.0",
-        "typescript": "4.7.4"
+        "typescript": "4.7.4",
+        "web-streams-polyfill": "^3.3.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -347,9 +348,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.20.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
-      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -578,12 +579,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.21.4.tgz",
-      "integrity": "sha512-5hewiLct5OKyh6PLKEYaFclcqtIgCb6bmELouxjF6up5q3Sov7rOayW4RwhbaBL0dit8rA80GNfY+UuDp2mBbQ==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
+      "integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2"
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -680,12 +681,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.21.4.tgz",
-      "integrity": "sha512-xz0D39NvhQn4t4RNsHmDnnsaQizIlUkdtYvLs8La1BlfjQ6JEwxkJGeqJMW2tAXx+q6H+WFuUTXNdYVpEya0YA==",
+      "version": "7.23.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
+      "integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.20.2"
+        "@babel/helper-plugin-utils": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1361,16 +1362,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.5.0.tgz",
-      "integrity": "sha512-NEpkObxPwyw/XxZVLPmAGKE89IQRp4puc6IQRPru6JKd1M3fW9v1xM1AnzIJE65hbCkzQAdnL8P47e9hzhiYLQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.5.0",
-        "jest-util": "^29.5.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1394,37 +1395,37 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.5.0.tgz",
-      "integrity": "sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.5.0",
-        "@jest/reporters": "^29.5.0",
-        "@jest/test-result": "^29.5.0",
-        "@jest/transform": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
-        "jest-changed-files": "^29.5.0",
-        "jest-config": "^29.5.0",
-        "jest-haste-map": "^29.5.0",
-        "jest-message-util": "^29.5.0",
-        "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.5.0",
-        "jest-resolve-dependencies": "^29.5.0",
-        "jest-runner": "^29.5.0",
-        "jest-runtime": "^29.5.0",
-        "jest-snapshot": "^29.5.0",
-        "jest-util": "^29.5.0",
-        "jest-validate": "^29.5.0",
-        "jest-watcher": "^29.5.0",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.5.0",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -1457,12 +1458,12 @@
       }
     },
     "node_modules/@jest/core/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -1489,89 +1490,89 @@
       "dev": true
     },
     "node_modules/@jest/environment": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.5.0.tgz",
-      "integrity": "sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-mock": "^29.5.0"
+        "jest-mock": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.5.0.tgz",
-      "integrity": "sha512-PueDR2HGihN3ciUNGr4uelropW7rqUfTiOn+8u0leg/42UhblPxHkfoh0Ruu3I9Y1962P3u2DY4+h7GVTSVU6g==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.5.0",
-        "jest-snapshot": "^29.5.0"
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
-      "integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^29.4.3"
+        "jest-get-type": "^29.6.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.5.0.tgz",
-      "integrity": "sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.5.0",
-        "jest-mock": "^29.5.0",
-        "jest-util": "^29.5.0"
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.5.0.tgz",
-      "integrity": "sha512-S02y0qMWGihdzNbUiqSAiKSpSozSuHX5UYc7QbnHP+D9Lyw8DgGGCinrN9uSuHPeKgSSzvPom2q1nAtBvUsvPQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.5.0",
-        "@jest/expect": "^29.5.0",
-        "@jest/types": "^29.5.0",
-        "jest-mock": "^29.5.0"
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.5.0.tgz",
-      "integrity": "sha512-D05STXqj/M8bP9hQNSICtPqz97u7ffGzZu+9XLucXhkOFBqKcXe04JLZOgIekOxdb73MAoBUFnqvf7MCpKk5OA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.5.0",
-        "@jest/test-result": "^29.5.0",
-        "@jest/transform": "^29.5.0",
-        "@jest/types": "^29.5.0",
-        "@jridgewell/trace-mapping": "^0.3.15",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
@@ -1579,13 +1580,13 @@
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
         "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-instrument": "^6.0.0",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.5.0",
-        "jest-util": "^29.5.0",
-        "jest-worker": "^29.5.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -1619,25 +1620,41 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@jest/schemas": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
-      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.1.tgz",
+      "integrity": "sha512-EAMEJBsYuyyztxMxW3g7ugGPkrZsV57v0Hmv3mm1uQsmB+QnZuepg731CRaIgeUVSdmsTngOkSnauNF8p7FIhA==",
       "dev": true,
       "dependencies": {
-        "@sinclair/typebox": "^0.25.16"
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/source-map": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.4.3.tgz",
-      "integrity": "sha512-qyt/mb6rLyd9j1jUts4EQncvS6Yy3PM9HghnNv86QBlV+zdL2inCdK1tuVlL+J+lpiw2BI67qXOrX3UurBqQ1w==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.15",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "callsites": "^3.0.0",
         "graceful-fs": "^4.2.9"
       },
@@ -1646,13 +1663,13 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.5.0.tgz",
-      "integrity": "sha512-fGl4rfitnbfLsrfx1uUpDEESS7zM8JdgZgOCQuxQvL1Sn/I6ijeAVQWGfXI9zb1i9Mzo495cIpVZhA0yr60PkQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       },
@@ -1661,14 +1678,14 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.5.0.tgz",
-      "integrity": "sha512-yPafQEcKjkSfDXyvtgiV4pevSeyuA6MQr6ZIdVkWJly9vkqjnFfcfhRQqpD5whjoU8EORki752xQmjaqoFjzMQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.5.0",
+        "@jest/test-result": "^29.7.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.5.0",
+        "jest-haste-map": "^29.7.0",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1676,22 +1693,22 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.5.0.tgz",
-      "integrity": "sha512-8vbeZWqLJOvHaDfeMuoHITGKSz5qWc9u04lnWrQE3VyuSw604PzQM824ZeX9XSjUCeDiE3GuxZe5UKa8J61NQw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/types": "^29.5.0",
-        "@jridgewell/trace-mapping": "^0.3.15",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
         "babel-plugin-istanbul": "^6.1.1",
         "chalk": "^4.0.0",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.5.0",
-        "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.5.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -1718,12 +1735,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
-      "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^3.0.0",
         "@types/node": "*",
@@ -2418,9 +2435,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.25.24",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
-      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==",
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -2583,9 +2600,9 @@
       "dev": true
     },
     "node_modules/@types/babel__core": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.0.tgz",
-      "integrity": "sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -2596,18 +2613,18 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
-      "integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
     },
     "node_modules/@types/babel__template": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.1.tgz",
-      "integrity": "sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -2615,12 +2632,12 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
-      "integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+      "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.3.0"
+        "@babel/types": "^7.20.7"
       }
     },
     "node_modules/@types/body-parser": {
@@ -2720,9 +2737,9 @@
       }
     },
     "node_modules/@types/graceful-fs": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
-      "integrity": "sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -2782,9 +2799,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
-      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
+      "version": "29.5.11",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
+      "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -3075,12 +3092,6 @@
         "@types/pouchdb-core": "*",
         "@types/pouchdb-find": "*"
       }
-    },
-    "node_modules/@types/prettier": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
-      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
-      "dev": true
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -3637,15 +3648,15 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.5.0.tgz",
-      "integrity": "sha512-mA4eCDh5mSo2EcA9xQjVTpmbbNk32Zb3Q3QFQsNhaK56Q+yoXowzFodLux30HRgyOho5rsQ6B0P9QpMkvvnJ0Q==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^29.5.0",
+        "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.5.0",
+        "babel-preset-jest": "^29.6.3",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
@@ -3690,9 +3701,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.5.0.tgz",
-      "integrity": "sha512-zSuuuAlTMT4mzLj2nPnUm6fsE6270vdOfnpbJ+RmruU75UhLFvL0N2NgI7xpeS7NaB6hGqmd5pVpGTDYvi4Q3w==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -3728,12 +3739,12 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.5.0.tgz",
-      "integrity": "sha512-JOMloxOqdiBSxMAzjRaH023/vvcaSaec49zvg+2LmNsktC7ei39LTJGw02J+9uUtTZUq6xbLyJ4dxe9sSmIuAg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
       "dev": true,
       "dependencies": {
-        "babel-plugin-jest-hoist": "^29.5.0",
+        "babel-plugin-jest-hoist": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
@@ -4057,9 +4068,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
-      "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
     "node_modules/client-only": {
@@ -4112,9 +4123,9 @@
       }
     },
     "node_modules/collect-v8-coverage": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
-      "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==",
       "dev": true
     },
     "node_modules/color-convert": {
@@ -4220,6 +4231,43 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "dev": true,
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/create-jest/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -4398,10 +4446,18 @@
       }
     },
     "node_modules/dedent": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
-      "dev": true
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
     },
     "node_modules/deep-equal": {
       "version": "2.2.0",
@@ -4530,9 +4586,9 @@
       }
     },
     "node_modules/diff-sequences": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz",
-      "integrity": "sha512-ofrBgwpPhCD85kMKtE9RYFFq6OC1A89oW2vvgWZNCwxrUpRUILopY7lsYyMDSjc8g6U6aiO0Qubg6r4Wgt5ZnA==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5220,16 +5276,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
-      "integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.5.0",
-        "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.5.0",
-        "jest-message-util": "^29.5.0",
-        "jest-util": "^29.5.0"
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5493,9 +5549,9 @@
       "dev": true
     },
     "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -5507,9 +5563,12 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -5741,6 +5800,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-parse-selector": {
@@ -6234,12 +6305,12 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6558,17 +6629,17 @@
       }
     },
     "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
@@ -6586,9 +6657,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -6599,15 +6670,15 @@
       }
     },
     "node_modules/jest": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.5.0.tgz",
-      "integrity": "sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.5.0"
+        "jest-cli": "^29.7.0"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -6625,12 +6696,13 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.5.0.tgz",
-      "integrity": "sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
       "dev": true,
       "dependencies": {
         "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -6638,28 +6710,28 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.5.0.tgz",
-      "integrity": "sha512-gq/ongqeQKAplVxqJmbeUOJJKkW3dDNPY8PjhJ5G0lBRvu0e3EWGxGy5cI4LAGA7gV2UHCtWBI4EMXK8c9nQKA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.5.0",
-        "@jest/expect": "^29.5.0",
-        "@jest/test-result": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "dedent": "^0.7.0",
+        "dedent": "^1.0.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.5.0",
-        "jest-matcher-utils": "^29.5.0",
-        "jest-message-util": "^29.5.0",
-        "jest-runtime": "^29.5.0",
-        "jest-snapshot": "^29.5.0",
-        "jest-util": "^29.5.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.5.0",
+        "pretty-format": "^29.7.0",
         "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
@@ -6685,12 +6757,12 @@
       }
     },
     "node_modules/jest-circus/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -6717,22 +6789,21 @@
       "dev": true
     },
     "node_modules/jest-cli": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.5.0.tgz",
-      "integrity": "sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.5.0",
-        "@jest/test-result": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
         "exit": "^0.1.2",
-        "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.5.0",
-        "jest-util": "^29.5.0",
-        "jest-validate": "^29.5.0",
-        "prompts": "^2.0.1",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
         "yargs": "^17.3.1"
       },
       "bin": {
@@ -6767,31 +6838,31 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.5.0.tgz",
-      "integrity": "sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.5.0",
-        "@jest/types": "^29.5.0",
-        "babel-jest": "^29.5.0",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.5.0",
-        "jest-environment-node": "^29.5.0",
-        "jest-get-type": "^29.4.3",
-        "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.5.0",
-        "jest-runner": "^29.5.0",
-        "jest-util": "^29.5.0",
-        "jest-validate": "^29.5.0",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.5.0",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -6828,12 +6899,12 @@
       }
     },
     "node_modules/jest-config/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -6860,15 +6931,15 @@
       "dev": true
     },
     "node_modules/jest-diff": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.5.0.tgz",
-      "integrity": "sha512-LtxijLLZBduXnHSniy0WMdaHjmQnt3g5sa16W4p0HqukYTTsyTW3GD1q41TyGl5YFXj/5B2U6dlh5FM1LIMgxw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "diff-sequences": "^29.4.3",
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.5.0"
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6891,12 +6962,12 @@
       }
     },
     "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -6923,9 +6994,9 @@
       "dev": true
     },
     "node_modules/jest-docblock": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.4.3.tgz",
-      "integrity": "sha512-fzdTftThczeSD9nZ3fzA/4KkHtnmllawWrXO69vtI+L9WjEIuXWs4AmyME7lN5hU7dB0sHhuPfcKofRsUb/2Fg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
       "dev": true,
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -6935,16 +7006,16 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.5.0.tgz",
-      "integrity": "sha512-HM5kIJ1BTnVt+DQZ2ALp3rzXEl+g726csObrW/jpEGl+CDSSQpOJJX2KE/vEg8cxcMXdyEPu6U4QX5eruQv5hA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.4.3",
-        "jest-util": "^29.5.0",
-        "pretty-format": "^29.5.0"
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6967,12 +7038,12 @@
       }
     },
     "node_modules/jest-each/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -7026,46 +7097,46 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.5.0.tgz",
-      "integrity": "sha512-ExxuIK/+yQ+6PRGaHkKewYtg6hto2uGCgvKdb2nfJfKXgZ17DfXjvbZ+jA1Qt9A8EQSfPnt5FKIfnOO3u1h9qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.5.0",
-        "@jest/fake-timers": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-mock": "^29.5.0",
-        "jest-util": "^29.5.0"
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-get-type": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.4.3.tgz",
-      "integrity": "sha512-J5Xez4nRRMjk8emnTpWrlkyb9pfRQQanDrvWHhsR1+VUfbwxi30eVcZFlcdGInRibU4G5LwHXpI7IRHU0CY+gg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.5.0.tgz",
-      "integrity": "sha512-IspOPnnBro8YfVYSw6yDRKh/TiCdRngjxeacCps1cQ9cgVN6+10JUcuJ1EabrgYLOATsIAigxA0rLR9x/YlrSA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.5.0",
-        "jest-worker": "^29.5.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -7077,13 +7148,13 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.5.0.tgz",
-      "integrity": "sha512-u9YdeeVnghBUtpN5mVxjID7KbkKE1QU4f6uUwuxiY0vYRi9BUCLKlPEZfDGR67ofdFmDz9oPAy2G92Ujrntmow==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
       "dev": true,
       "dependencies": {
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.5.0"
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7102,12 +7173,12 @@
       }
     },
     "node_modules/jest-leak-detector/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -7122,15 +7193,15 @@
       "dev": true
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
-      "integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.5.0",
-        "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.5.0"
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7153,12 +7224,12 @@
       }
     },
     "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -7185,18 +7256,18 @@
       "dev": true
     },
     "node_modules/jest-message-util": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
-      "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.5.0",
+        "pretty-format": "^29.7.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -7221,12 +7292,12 @@
       }
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -7253,14 +7324,14 @@
       "dev": true
     },
     "node_modules/jest-mock": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.5.0.tgz",
-      "integrity": "sha512-GqOzvdWDE4fAV2bWQLQCkujxYWL7RxjCnj71b5VhDAGOevB3qj3Ovg26A5NI84ZpODxyzaozXLOh2NCgkbvyaw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "jest-util": "^29.5.0"
+        "jest-util": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7284,26 +7355,26 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "29.4.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.4.3.tgz",
-      "integrity": "sha512-O4FglZaMmWXbGHSQInfXewIsd1LMn9p3ZXB/6r4FOkyhX2/iP/soMG98jGvk/A3HAN78+5VWcBGO0BJAPRh4kg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-resolve": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.5.0.tgz",
-      "integrity": "sha512-1TzxJ37FQq7J10jPtQjcc+MkCkE3GBpBecsSUWJ0qZNJpmg6m0D9/7II03yJulm3H/fvVjgqLh/k2eYg+ui52w==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.5.0",
+        "jest-haste-map": "^29.7.0",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.5.0",
-        "jest-validate": "^29.5.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -7313,13 +7384,13 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.5.0.tgz",
-      "integrity": "sha512-sjV3GFr0hDJMBpYeUuGduP+YeCRbd7S/ck6IvL3kQ9cpySYKqcqhdLLC2rFwrcL7tz5vYibomBrsFYWkIGGjOg==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
       "dev": true,
       "dependencies": {
-        "jest-regex-util": "^29.4.3",
-        "jest-snapshot": "^29.5.0"
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7342,30 +7413,30 @@
       }
     },
     "node_modules/jest-runner": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.5.0.tgz",
-      "integrity": "sha512-m7b6ypERhFghJsslMLhydaXBiLf7+jXy8FwGRHO3BGV1mcQpPbwiqiKUR2zU2NJuNeMenJmlFZCsIqzJCTeGLQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.5.0",
-        "@jest/environment": "^29.5.0",
-        "@jest/test-result": "^29.5.0",
-        "@jest/transform": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
-        "jest-docblock": "^29.4.3",
-        "jest-environment-node": "^29.5.0",
-        "jest-haste-map": "^29.5.0",
-        "jest-leak-detector": "^29.5.0",
-        "jest-message-util": "^29.5.0",
-        "jest-resolve": "^29.5.0",
-        "jest-runtime": "^29.5.0",
-        "jest-util": "^29.5.0",
-        "jest-watcher": "^29.5.0",
-        "jest-worker": "^29.5.0",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -7390,31 +7461,31 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.5.0.tgz",
-      "integrity": "sha512-1Hr6Hh7bAgXQP+pln3homOiEZtCDZFqwmle7Ew2j8OlbkIu6uE3Y/etJQG8MLQs3Zy90xrp2C0BRrtPHG4zryw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.5.0",
-        "@jest/fake-timers": "^29.5.0",
-        "@jest/globals": "^29.5.0",
-        "@jest/source-map": "^29.4.3",
-        "@jest/test-result": "^29.5.0",
-        "@jest/transform": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "cjs-module-lexer": "^1.0.0",
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.5.0",
-        "jest-message-util": "^29.5.0",
-        "jest-mock": "^29.5.0",
-        "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.5.0",
-        "jest-snapshot": "^29.5.0",
-        "jest-util": "^29.5.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -7439,34 +7510,31 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.5.0.tgz",
-      "integrity": "sha512-x7Wolra5V0tt3wRs3/ts3S6ciSQVypgGQlJpz2rsdQYoUKxMxPNaoHMGJN6qAuPJqS+2iQ1ZUn5kl7HCyls84g==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@babel/generator": "^7.7.2",
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
-        "@babel/traverse": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.5.0",
-        "@jest/transform": "^29.5.0",
-        "@jest/types": "^29.5.0",
-        "@types/babel__traverse": "^7.0.6",
-        "@types/prettier": "^2.1.5",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.5.0",
+        "expect": "^29.7.0",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.5.0",
-        "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.5.0",
-        "jest-message-util": "^29.5.0",
-        "jest-util": "^29.5.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.5.0",
-        "semver": "^7.3.5"
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7489,12 +7557,12 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -7521,12 +7589,12 @@
       "dev": true
     },
     "node_modules/jest-util": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
-      "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
+      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
@@ -7554,17 +7622,17 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.5.0.tgz",
-      "integrity": "sha512-pC26etNIi+y3HV8A+tUGr/lph9B18GnzSRAkPaaZJIE1eFdiYm6/CewuiJQ8/RlfHd1u/8Ioi8/sJ+CmbA+zAQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^29.5.0",
+        "@jest/types": "^29.6.3",
         "camelcase": "^6.2.0",
         "chalk": "^4.0.0",
-        "jest-get-type": "^29.4.3",
+        "jest-get-type": "^29.6.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.5.0"
+        "pretty-format": "^29.7.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7599,12 +7667,12 @@
       }
     },
     "node_modules/jest-validate/node_modules/pretty-format": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
-      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
       "dev": true,
       "dependencies": {
-        "@jest/schemas": "^29.4.3",
+        "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
         "react-is": "^18.0.0"
       },
@@ -7631,18 +7699,18 @@
       "dev": true
     },
     "node_modules/jest-watcher": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.5.0.tgz",
-      "integrity": "sha512-KmTojKcapuqYrKDpRwfqcQ3zjMlwu27SYext9pt4GlF5FUgB+7XE1mcCnSm6a4uUpFyQIkb6ZhzZvHl+jiBCiA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.5.0",
-        "@jest/types": "^29.5.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
-        "jest-util": "^29.5.0",
+        "jest-util": "^29.7.0",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -7666,13 +7734,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.5.0.tgz",
-      "integrity": "sha512-NcrQnevGoSp4b5kg+akIpthoAFHxPBcb5P6mYPY0fUNT+sSvmtu6jlkEle3anczUKIKEbMxFimk9oTP/tpIPgA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.5.0",
+        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -8450,27 +8518,18 @@
       }
     },
     "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -10084,9 +10143,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.1.tgz",
-      "integrity": "sha512-t+x1zEHDjBwkDGY5v5ApnZ/utcd4XYDiJsaQQoptTXgUXX95sDg1elCdJghzicm7n2mbCBJ3uYWr6M22SO19rg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
+      "integrity": "sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==",
       "dev": true,
       "funding": [
         {
@@ -10367,12 +10426,12 @@
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -11379,24 +11438,18 @@
       }
     },
     "node_modules/v8-to-istanbul": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
-      "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
         "@types/istanbul-lib-coverage": "^2.0.1",
-        "convert-source-map": "^1.6.0"
+        "convert-source-map": "^2.0.0"
       },
       "engines": {
         "node": ">=10.12.0"
       }
-    },
-    "node_modules/v8-to-istanbul/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-      "dev": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -11490,9 +11543,9 @@
       }
     },
     "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.2.tgz",
+      "integrity": "sha512-3pRGuxRF5gpuZc0W+EpwQRmCD7gRqcDOMt688KmdlDAgAyaB1XlN0zq2njfDNm44XVdIouE7pZ6GzbdyH47uIQ==",
       "engines": {
         "node": ">= 8"
       }
@@ -11732,9 +11785,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@testing-library/react": "^14.0.0",
     "@types/crypto-js": "^4.1.1",
     "@types/events": "^3.0.0",
-    "@types/jest": "^29.5.0",
+    "@types/jest": "^29.5.11",
     "@types/koa": "^2.13.7",
     "@types/koa__cors": "^4.0.0",
     "@types/node": "^16.11.6",
@@ -28,12 +28,13 @@
     "@typescript-eslint/parser": "5.29.0",
     "builtin-modules": "3.3.0",
     "esbuild": "0.17.3",
-    "jest": "^29.5.0",
+    "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.5.0",
     "obsidian": "latest",
     "ts-jest": "^29.1.0",
     "tslib": "2.4.0",
-    "typescript": "4.7.4"
+    "typescript": "4.7.4",
+    "web-streams-polyfill": "^3.3.2"
   },
   "dependencies": {
     "@huggingface/inference": "^2.6.4",

--- a/src/components/AddPromptModal.tsx
+++ b/src/components/AddPromptModal.tsx
@@ -13,21 +13,21 @@ export class AddPromptModal extends Modal {
 
     this.contentEl.createEl('h2', { text: 'User Custom Prompt' });
 
-    const formContainer = this.contentEl.createEl('div', { cls: 'custom-prompt-modal' });
+    const formContainer = this.contentEl.createEl('div', { cls: 'copilot-command-modal' });
 
     const titleContainer = formContainer.createEl(
       'div',
-      { cls: 'custom-prompt-input-container' }
+      { cls: 'copilot-command-input-container' }
     );
 
     titleContainer.createEl(
-      'h3', { text: 'Title', cls: 'custom-prompt-header' }
+      'h3', { text: 'Title', cls: 'copilot-command-header' }
     );
     titleContainer.createEl(
       'p',
       {
         text: 'The title of the prompt, must be unique.',
-        cls: 'custom-prompt-description',
+        cls: 'copilot-command-input-description',
       }
     );
 
@@ -41,17 +41,17 @@ export class AddPromptModal extends Modal {
 
     const promptContainer = formContainer.createEl(
       'div',
-      { cls: 'custom-prompt-input-container' }
+      { cls: 'copilot-command-input-container' }
     );
 
     promptContainer.createEl(
-      'h3', { text: 'Prompt', cls: 'custom-prompt-header' }
+      'h3', { text: 'Prompt', cls: 'copilot-command-header' }
     );
     promptContainer.createEl(
       'p',
       {
         text: 'The content of the prompt. Use "{}" to represent the selected text. For example, "Improve the readability of the following text: {}"',
-        cls: 'custom-prompt-description',
+        cls: 'copilot-command-input-description',
       }
     );
     const promptField = promptContainer.createEl('textarea');
@@ -75,18 +75,18 @@ export class AddPromptModal extends Modal {
     });
 
     const descContainer = promptContainer.createEl('p', {
-      cls: 'custom-prompt-description',
+      cls: 'copilot-command-input-description',
     });
 
     descContainer.appendChild(descFragment);
 
     const saveButtonContainer = formContainer.createEl(
       'div',
-      { cls: 'custom-prompt-save-btn-container' }
+      { cls: 'copilot-command-save-btn-container' }
     );
     const saveButton = saveButtonContainer.createEl(
       'button',
-      { text: 'Save', cls: 'custom-prompt-save-btn' }
+      { text: 'Save', cls: 'copilot-command-save-btn' }
     );
     saveButton.addEventListener('click', () => {
       if (titleField.value && promptField.value) {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -7,6 +7,7 @@ import ChatMessages from '@/components/ChatComponents/ChatMessages';
 import { AI_SENDER, USER_SENDER } from '@/constants';
 import { AppContext } from '@/context';
 import { getAIResponse } from '@/langchainStream';
+import { CopilotSettings } from '@/settings/SettingsPage';
 import SharedState, {
   ChatMessage, useSharedState,
 } from '@/sharedState';
@@ -20,6 +21,8 @@ import {
   formatDateTime,
   getFileContent,
   getFileName,
+  getNotesFromPath,
+  getSendChatContextNotesPrompt,
   glossaryPrompt,
   removeUrlsFromSelectionPrompt,
   rewriteLongerSelectionPrompt,
@@ -27,14 +30,14 @@ import {
   rewriteShorterSelectionPrompt,
   rewriteTweetSelectionPrompt,
   rewriteTweetThreadSelectionPrompt,
-  sendNoteContentPrompt,
+  sendNotesContentPrompt,
   simplifyPrompt,
   summarizePrompt,
-  tocPrompt
+  tocPrompt,
 } from '@/utils';
 import VectorDBManager from '@/vectorDBManager';
 import { EventEmitter } from 'events';
-import { Notice, TFile } from 'obsidian';
+import { Notice, TFile, Vault } from 'obsidian';
 import React, {
   useContext,
   useEffect,
@@ -49,15 +52,24 @@ interface CreateEffectOptions {
 
 interface ChatProps {
   sharedState: SharedState;
+  settings: CopilotSettings;
   chainManager: ChainManager;
   emitter: EventEmitter;
   getChatVisibility: () => Promise<boolean>;
   defaultSaveFolder: string;
+  vault: Vault;
   debug: boolean;
 }
 
 const Chat: React.FC<ChatProps> = ({
-  sharedState, chainManager, emitter, getChatVisibility, defaultSaveFolder, debug
+  sharedState,
+  settings,
+  chainManager,
+  emitter,
+  getChatVisibility,
+  defaultSaveFolder,
+  vault,
+  debug
 }) => {
   const [
     chatHistory, addMessage, clearMessages,
@@ -138,30 +150,45 @@ const Chat: React.FC<ChatProps> = ({
       return;
     }
 
-    const file = app.workspace.getActiveFile();
-    if (!file) {
-      new Notice('No active note found.');
-      console.error('No active note found.');
-      return;
+    let noteFiles: TFile[] = [];
+    if (debug) {
+      console.log('Chat note context path:', settings.chatNoteContextPath);
+    }
+    if (settings.chatNoteContextPath) {
+      // Recursively get all note TFiles in the path
+      noteFiles = await getNotesFromPath(vault, settings.chatNoteContextPath);
     }
 
-    const noteContent = await getFileContent(file);
-    const noteName = getFileName(file);
-    if (!noteContent) {
-      new Notice('No note content found.');
-      console.error('No note content found.');
-      return;
+    const file = app.workspace.getActiveFile();
+    // If no note context provided, default to the active note
+    if (noteFiles.length === 0) {
+      if (!file) {
+        new Notice('No active note found.');
+        console.error('No active note found.');
+        return;
+      }
+      new Notice('No valid Chat context provided. Defaulting to the active note.');
+      noteFiles = [file];
+    }
+
+    const notes = [];
+    for (const file of noteFiles) {
+      const content = await getFileContent(file);
+      if (content) {
+        notes.push({ name: getFileName(file), content });
+      }
     }
 
     // Send the content of the note to AI
     const promptMessageHidden: ChatMessage = {
-      message: sendNoteContentPrompt(noteName, noteContent),
+      message: sendNotesContentPrompt(notes),
       sender: USER_SENDER,
       isVisible: false,
     };
 
     // Visible user message that is not sent to AI
-    const sendNoteContentUserMessage = `Please read this note [[${noteName}]] and be ready to answer questions about it.`;
+    // const sendNoteContentUserMessage = `Please read the following notes [[${activeNoteContent}]] and be ready to answer questions about it.`;
+    const sendNoteContentUserMessage = getSendChatContextNotesPrompt(notes);
     const promptMessageVisible: ChatMessage = {
       message: sendNoteContentUserMessage,
       sender: USER_SENDER,

--- a/src/components/ChatComponents/ChatIcons.tsx
+++ b/src/components/ChatComponents/ChatIcons.tsx
@@ -156,7 +156,7 @@ const ChatIcons: React.FC<ChatIconsProps> = ({
       {selectedChain === 'llm_chain' && (
         <button className='chat-icon-button' onClick={onSendActiveNoteToPrompt}>
           <SendActiveNoteToPromptIcon className='icon-scaler' />
-          <span className="tooltip-text">Send Active Note to Prompt<br/>(use with long context models)</span>
+          <span className="tooltip-text">Send Note(s) to Prompt<br/>(Set with Copilot command.<br/>Default is active note)</span>
         </button>
       )}
       {selectedChain === 'retrieval_qa' && (

--- a/src/components/ChatNoteContextModal.tsx
+++ b/src/components/ChatNoteContextModal.tsx
@@ -1,0 +1,57 @@
+import { CopilotSettings } from "@/settings/SettingsPage";
+import { App, Modal } from "obsidian";
+
+export class ChatNoteContextModal extends Modal {
+  private settings: CopilotSettings;
+  private onSubmit: (path: string) => void;
+
+  constructor(app: App, settings: CopilotSettings, onSubmit: (path: string) => void) {
+    super(app);
+    this.settings = settings;
+    this.onSubmit = onSubmit;
+  }
+
+  onOpen() {
+    const formContainer = this.contentEl.createEl('div', { cls: 'copilot-command-modal' });
+    const pathContainer = formContainer.createEl('div', { cls: 'copilot-command-input-container' });
+
+    pathContainer.createEl('h3', { text: 'Folder Path', cls: 'copilot-command-header' });
+    const descFragment = createFragment((frag) => {
+      frag.appendText('All notes under the path will be sent to the prompt when the ');
+      frag.createEl(
+        'strong',
+        { text: 'Send Note(s) to Prompt' }
+      );
+      frag.appendText(' button is clicked in Chat mode. ');
+      frag.appendText('If none provided, ');
+      frag.createEl(
+        'strong',
+        { text: 'default context is the active note' }
+      );
+    });
+    pathContainer.appendChild(descFragment);
+
+    const pathField = pathContainer.createEl(
+      'input',
+      {
+        type: 'text',
+        cls: 'copilot-command-input',
+        value: this.settings.chatNoteContextPath,
+      }
+    );
+    pathField.setAttribute('name', 'folderPath');
+
+    const submitButtonContainer = formContainer.createEl('div', { cls: 'copilot-command-save-btn-container' });
+    const submitButton = submitButtonContainer.createEl('button', { text: 'Submit', cls: 'copilot-command-save-btn' });
+
+    submitButton.addEventListener('click', () => {
+      // Remove the leading slash if it exists
+      let pathValue = pathField.value;
+      if (pathValue.startsWith('/') && pathValue.length > 1) {
+        pathValue = pathValue.slice(1);
+      }
+      this.onSubmit(pathValue);
+      this.close();
+    });
+  }
+}

--- a/src/components/CopilotView.tsx
+++ b/src/components/CopilotView.tsx
@@ -3,9 +3,10 @@ import Chat from '@/components/Chat';
 import { CHAT_VIEWTYPE } from '@/constants';
 import { AppContext } from '@/context';
 import CopilotPlugin from '@/main';
+import { CopilotSettings } from '@/settings/SettingsPage';
 import SharedState from '@/sharedState';
 import { EventEmitter } from 'events';
-import { ItemView, WorkspaceLeaf } from 'obsidian';
+import { ItemView, Vault, WorkspaceLeaf } from 'obsidian';
 import * as React from 'react';
 import { Root, createRoot } from 'react-dom/client';
 
@@ -14,6 +15,8 @@ export default class CopilotView extends ItemView {
   private sharedState: SharedState;
   private chainManager: ChainManager;
   private root: Root | null = null;
+  private vault: Vault;
+  private settings: CopilotSettings;
   private defaultSaveFolder: string;
   private debug = false;
   emitter: EventEmitter;
@@ -22,12 +25,14 @@ export default class CopilotView extends ItemView {
   constructor(leaf: WorkspaceLeaf, private plugin: CopilotPlugin) {
     super(leaf);
     this.sharedState = plugin.sharedState;
+    this.settings = plugin.settings;
     this.app = plugin.app;
     this.chainManager = plugin.chainManager;
     this.debug = plugin.settings.debug;
     this.emitter = new EventEmitter();
     this.getChatVisibility = this.getChatVisibility.bind(this);
     this.userSystemPrompt = plugin.settings.userSystemPrompt;
+    this.vault = plugin.app.vault;
     this.defaultSaveFolder = plugin.settings.defaultSaveFolder;
   }
 
@@ -63,10 +68,12 @@ export default class CopilotView extends ItemView {
         <React.StrictMode>
           <Chat
             sharedState={this.sharedState}
+            settings={this.settings}
             chainManager={this.chainManager}
             emitter={this.emitter}
             getChatVisibility={this.getChatVisibility}
             defaultSaveFolder={this.defaultSaveFolder}
+            vault={this.vault}
             debug={this.debug}
           />
         </React.StrictMode>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -149,5 +149,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   stream: true,
   embeddingProvider: ModelProviders.OPENAI,
   defaultSaveFolder: 'copilot-conversations',
+  chatNoteContextPath: '',
   debug: false,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import ChainManager from '@/LLMProviders/chainManager';
 import { LangChainParams, SetChainOptions } from '@/aiParams';
 import { ChainType } from '@/chainFactory';
 import { AddPromptModal } from "@/components/AddPromptModal";
+import { ChatNoteContextModal } from "@/components/ChatNoteContextModal";
 import CopilotView from '@/components/CopilotView';
 import { LanguageModal } from "@/components/LanguageModal";
 import { ListPromptModal } from "@/components/ListPromptModal";
@@ -367,6 +368,18 @@ export default class CopilotPlugin extends Plugin {
           new Notice('An error occurred while clearing the local vector store.');
         }
       }
+    });
+
+    this.addCommand({
+      id: 'set-chat-note-context',
+      name: 'Set note context for Chat mode',
+      callback: async () => {
+        new ChatNoteContextModal(this.app, this.settings, async (path: string) => {
+          // Store the path in the plugin's settings, default to empty string
+          this.settings.chatNoteContextPath = path;
+          await this.saveSettings();
+        }).open();
+      },
     });
   }
 

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -32,6 +32,7 @@ export interface CopilotSettings {
   stream: boolean;
   embeddingProvider: string;
   defaultSaveFolder: string;
+  chatNoteContextPath: string;
   debug: boolean;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,31 @@ import {
   RetrievalQAChain
 } from "langchain/chains";
 import moment from 'moment';
-import { TFile } from 'obsidian';
+import { TFile, Vault } from 'obsidian';
+
+const isFolderMatch = (fileFullpath: string, inputPath: string): boolean => {
+  const fileSegments = fileFullpath.split('/');
+  const fileLastDir = fileSegments[fileSegments.length - 2]?.toLowerCase();
+  return fileLastDir === inputPath;
+}
+
+export const getNotesFromPath = async (vault: Vault, path: string): Promise<TFile[]> => {
+  const files = await vault.getMarkdownFiles();
+
+  // Special handling for the root path '/'
+  if (path === '/') {
+    return files;
+  }
+
+  // Split the path to get the last folder name
+  const pathSegments = path.split('/');
+  const lastSegment = pathSegments[pathSegments.length - 1].toLowerCase();
+
+  return files.filter(file => {
+    // Split the file path and get the last directory name
+    return isFolderMatch(file.path, lastSegment) || file.basename === lastSegment;
+  });
+}
 
 export const stringToChainType = (chain: string): ChainType => {
   switch(chain) {
@@ -73,7 +97,7 @@ export const formatDateTime = (now: Date, timezone: 'local' | 'utc' = 'local') =
 
 export async function getFileContent(file: TFile): Promise<string | null> {
   if (file.extension != "md") return null;
-  return await this.app.vault.read(file);
+  return await this.app.vault.cachedRead(file);
 }
 
 export function getFileName(file: TFile): string {
@@ -117,17 +141,19 @@ export function sendNoteContentPrompt(
     + `Feel free to ask related questions, such as 'give me a summary of this note in bullet points', 'what key questions does it answer', etc. "\n`
 }
 
-export function useNoteAsContextPrompt(
-  noteName: string,
-  noteContent: string | null,
-): string {
-  return `Please read the note below and be ready to answer questions about it. `
+export function sendNotesContentPrompt(notes: { name: string; content: string }[]): string {
+  return `Please read the notes below and be ready to answer questions about them. `
     + `If there's no information about a certain topic, just say the note `
     + `does not mention it. `
-    + `The content of the note is between "/***/":\n\n/***/\n\n${noteContent}\n\n/***/\n\n`
+    + `The content of the note is between "/***/":\n\n/***/\n\n${JSON.stringify(notes)}\n\n/***/\n\n`
     + `Please reply with the following word for word:`
-    + `"OK I've read this note titled [[ ${noteName} ]]. `
-    + `Feel free to ask **specific** questions about it. For generic questions like 'give me a summary', 'brainstorm based on the content', Chat mode with *context sent in the prompt* is a better choice."\n`
+    + `"OK I've read these notes. `
+    + `Feel free to ask related questions, such as 'give me a summary of these notes in bullet points', 'what key questions does these notes answer', etc. "\n`
+}
+
+export function getSendChatContextNotesPrompt(notes: { name: string; content: string }[]): string {
+  const noteTitles = notes.map(note => `[[${note.name}]]`).join('\n\n');
+  return `Please read the notes below and be ready to answer questions about them. \n\n${noteTitles}`;
 }
 
 export function fixGrammarSpellingSelectionPrompt(selectedText: string): string {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,10 +15,9 @@ import {
 import moment from 'moment';
 import { TFile, Vault } from 'obsidian';
 
-const isFolderMatch = (fileFullpath: string, inputPath: string): boolean => {
-  const fileSegments = fileFullpath.split('/');
-  const fileLastDir = fileSegments[fileSegments.length - 2]?.toLowerCase();
-  return fileLastDir === inputPath;
+export const isFolderMatch = (fileFullpath: string, inputPath: string): boolean => {
+  const fileSegments = fileFullpath.split('/').map(segment => segment.toLowerCase());
+  return fileSegments.includes(inputPath.toLowerCase());
 }
 
 export const getNotesFromPath = async (vault: Vault, path: string): Promise<TFile[]> => {

--- a/styles.css
+++ b/styles.css
@@ -269,38 +269,37 @@ If your plugin does not need CSS, delete this file.
   width: 95%;
 }
 
-/* Apply some style to AddPromptModal */
-.custom-prompt-modal {
+.copilot-command-modal {
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 10px;
 }
 
-.custom-prompt-input-container {
+.copilot-command-input-container {
   width: 90%;
   margin: auto;
 }
 
-.custom-prompt-input-container input,
-.custom-prompt-input-container textarea {
+.copilot-command-input-container input,
+.copilot-command-input-container textarea {
   display: block;
   width: 100%;
   margin-top: 5px;
 }
 
-.custom-prompt-input-container textarea {
+.copilot-command-input-container textarea {
   height: 150px;
   resize: vertical;
 }
 
-.custom-prompt-save-btn-container {
+.copilot-command-save-btn-container {
   display: flex;
   justify-content: center;
   align-items: center;
   text-align: center;
 }
 
-.custom-prompt-save-btn {
+.copilot-command-save-btn {
   margin-top: 15px;
 }

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,97 @@
+import * as Obsidian from 'obsidian';
+import { getNotesFromPath, isFolderMatch } from '../src/utils';
+
+
+describe('isFolderMatch', () => {
+  it('should return file from the folder name 1', async () => {
+    const match = isFolderMatch('test2/note3.md', 'test2');
+    expect(match).toEqual(true);
+  });
+
+  it('should return file from the folder name 2', async () => {
+    const match = isFolderMatch('test/test2/note1.md', 'test2');
+    expect(match).toEqual(true);
+  });
+
+  it('should return file from the folder name 3', async () => {
+    const match = isFolderMatch('test/test2/note1.md', 'test');
+    expect(match).toEqual(true);
+  });
+
+  it('should not return file from the folder name 1', async () => {
+    const match = isFolderMatch('test/test2/note1.md', 'tes');
+    expect(match).toEqual(false);
+  });
+
+  it('should return file from file name 1', async () => {
+    const match = isFolderMatch('test/test2/note1.md', 'note1.md');
+    expect(match).toEqual(true);
+  });
+});
+
+describe('Vault', () => {
+  it('should return all markdown files', async () => {
+    const vault = new Obsidian.Vault();
+    const files = await vault.getMarkdownFiles();
+    expect(files).toEqual([
+      { path: 'test/test2/note1.md' },
+      { path: 'test/note2.md' },
+      { path: 'test2/note3.md' },
+      { path: 'note4.md' },
+    ]);
+  });
+});
+
+describe('getNotesFromPath', () => {
+  it('should return all markdown files', async () => {
+    const vault = new Obsidian.Vault();
+    const files = await getNotesFromPath(vault, '/');
+    expect(files).toEqual([
+      { path: 'test/test2/note1.md' },
+      { path: 'test/note2.md' },
+      { path: 'test2/note3.md' },
+      { path: 'note4.md' },
+    ]);
+  });
+
+  it('should return filtered markdown files 1', async () => {
+    const vault = new Obsidian.Vault();
+    const files = await getNotesFromPath(vault, 'test2');
+    expect(files).toEqual([
+      { path: 'test/test2/note1.md' },
+      { path: 'test2/note3.md' },
+    ]);
+  });
+
+  it('should return filtered markdown files 2', async () => {
+    const vault = new Obsidian.Vault();
+    const files = await getNotesFromPath(vault, 'test');
+    expect(files).toEqual([
+      { path: 'test/test2/note1.md' },
+      { path: 'test/note2.md' },
+    ]);
+  });
+
+  it('should return filtered markdown files 3', async () => {
+    const vault = new Obsidian.Vault();
+    const files = await getNotesFromPath(vault, 'note4.md');
+    expect(files).toEqual([
+      { path: 'note4.md' },
+    ]);
+  });
+
+  it('should return filtered markdown files 4', async () => {
+    const vault = new Obsidian.Vault();
+    const files = await getNotesFromPath(vault, '/test');
+    expect(files).toEqual([
+      { path: 'test/test2/note1.md' },
+      { path: 'test/note2.md' },
+    ]);
+  });
+
+  it('should not return markdown files', async () => {
+    const vault = new Obsidian.Vault();
+    const files = await getNotesFromPath(vault, '');
+    expect(files).toEqual([]);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "jsx": "react",
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-	"strictNullChecks": true,
+    "strictNullChecks": true,
+    "types": ["jest"],
     "lib": [
       "DOM",
       "ES5",


### PR DESCRIPTION
Now you can use the new Copilot command `Set note context for Chat mode` to specify a folder of notes. Then click the `Send Note(s) to Prompt` button to send these notes directly to the LLM to start a conversation about them.

<img width="503" alt="SCR-20240127-tjvd" src="https://github.com/logancyang/obsidian-copilot/assets/4860545/d041b674-788b-4800-8bd7-67943df4ed14">

<img width="247" alt="SCR-20240127-tjjl" src="https://github.com/logancyang/obsidian-copilot/assets/4860545/889e830b-1ffd-4f91-a17f-f6b80db739fc">

<img width="285" alt="SCR-20240127-tjta" src="https://github.com/logancyang/obsidian-copilot/assets/4860545/06c5ba8b-2620-4b30-abbc-aa51e18ad1c9">

<img width="580" alt="SCR-20240127-tjxi" src="https://github.com/logancyang/obsidian-copilot/assets/4860545/4de6ab97-99d3-4cf3-8f38-df5e50af4444">

You could also specify your entire vault with `/` if
1. Your vault is super small
2. Your LLM context window is super large
😆