### PR TITLE
feat: push tagged chat nodes along the context, reconfigure .editorconfig to match current style better

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,5 +6,5 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 indent_style = tab
-indent_size = 4
-tab_width = 4
+indent_size = 2
+tab_width = 2

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -150,5 +150,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   embeddingProvider: ModelProviders.OPENAI,
   defaultSaveFolder: 'copilot-conversations',
   chatNoteContextPath: '',
+	chatNoteContextTags: '',
   debug: false,
 };

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -4,7 +4,9 @@ import React from 'react';
 import { createRoot } from "react-dom/client";
 import SettingsMain from "./components/SettingsMain";
 
-export interface CopilotSettings {
+export type CopilotSettings = MainSettings & ChatNoteContextSettings;
+
+interface MainSettings {
   openAIApiKey: string;
   huggingfaceApiKey: string;
   cohereApiKey: string;
@@ -32,8 +34,12 @@ export interface CopilotSettings {
   stream: boolean;
   embeddingProvider: string;
   defaultSaveFolder: string;
-  chatNoteContextPath: string;
   debug: boolean;
+}
+
+interface ChatNoteContextSettings {
+	chatNoteContextPath: string;
+	chatNoteContextTags: string;
 }
 
 export class CopilotSettingTab extends PluginSettingTab {

--- a/src/settings/components/SettingsMain.tsx
+++ b/src/settings/components/SettingsMain.tsx
@@ -49,6 +49,9 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
   const [ollamaModel, setOllamaModel] = useState(plugin.settings.ollamaModel);
   const [ollamaBaseUrl, setOllamaBaseUrl] = useState(plugin.settings.ollamaBaseUrl);
 
+	// Context note chat settings
+	const [chatNoteContextTags, setChatNoteContextTags] = useState(plugin.settings.chatNoteContextTags);
+
   // NOTE: When new settings are added, make sure to add them to saveAllSettings
   const saveAllSettings = async () => {
     plugin.settings.defaultModelDisplayName = defaultModelDisplayName;
@@ -84,6 +87,9 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
     plugin.settings.lmStudioBaseUrl = lmStudioBaseUrl;
     plugin.settings.ollamaModel = ollamaModel;
     plugin.settings.ollamaBaseUrl = ollamaBaseUrl;
+
+		// Context note chat settings
+		plugin.settings.chatNoteContextTags = chatNoteContextTags;
 
     await plugin.saveSettings();
     await reloadPlugin();
@@ -215,6 +221,13 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
         ollamaBaseUrl={ollamaBaseUrl}
         setOllamaBaseUrl={setOllamaBaseUrl}
       />
+			<TextComponent
+				name="Chat note context tags"
+				description="Comma-separated list of tags that will be fetched alongside active notes for context."
+				placeholder="#copilot_notes,#copilot_other_notes"
+				value={chatNoteContextTags}
+				onChange={setChatNoteContextTags}
+			/>
     </>
   );
 }


### PR DESCRIPTION
The gist is to allow the note context to be configurable, in the current state chat context is still pretty much useless.
Defaults to old behavior, allows comma-separated list of tags (no additional safety checks done for that field)

Reads full file content and looks up the file content

Also minor adjustments to code style because it doesn't seem to even remotely match the actual one in code repo

P.S. I was baffled when I read the `"Please reply with the following word for word"`, that will make the costs skyrocket for literally no reason, but don't think there's a reason to blow up the scope of this PR