### PR TITLE
Fix model switch bug

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -6,9 +6,10 @@ import {
   ModelProviders,
   OLLAMA_MODELS,
   OPENAI_MODELS,
-  OPENROUTERAI_MODELS
+  OPENROUTERAI_MODELS,
 } from '@/constants';
 import { ProxyChatOpenAI } from '@/langchainWrappers';
+import { getModelName } from '@/utils';
 import { ChatOllama } from "@langchain/community/chat_models/ollama";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { BaseChatModel } from 'langchain/chat_models/base';
@@ -156,6 +157,8 @@ export default class ChatModelManager {
     if (!ChatModelManager.modelMap.hasOwnProperty(modelDisplayName)) {
       throw new Error(`No model found for: ${modelDisplayName}`);
     }
+    // MUST update it since chatModelManager is a singleton.
+    this.langChainParams.model = getModelName(modelDisplayName);
 
     // Create and return the appropriate model
     const selectedModel = ChatModelManager.modelMap[modelDisplayName];


### PR DESCRIPTION
There's a bug when you trigger a copilot command, switch the model, and the following chat session fails.

It's caused by a missing update of the param. This is a quick small fix, a better way is to use dependency injection for langChainParams to ChatModelManager and ChainManager.