### PR TITLE
Use variable names directly in advanced custom prompt

### DIFF
--- a/src/customPromptProcessor.ts
+++ b/src/customPromptProcessor.ts
@@ -90,12 +90,7 @@ export class CustomPromptProcessor {
       customPrompt
     );
     let processedPrompt = customPrompt;
-    let index = 0; // Start with 0 for context0, context1, etc.
-
-    // Replace placeholders with contextX
-    processedPrompt = processedPrompt.replace(/\{([^}]+)\}/g, () => {
-      return `{context${index++}}`;
-    });
+    const matches = [...processedPrompt.matchAll(/\{([^}]+)\}/g)];
 
     let additionalInfo = "";
     if (processedPrompt.includes("{}")) {
@@ -104,11 +99,13 @@ export class CustomPromptProcessor {
       additionalInfo += `selectedText:\n\n ${selectedText}`;
     }
 
-    for (let i = 0; i < index; i++) {
-      additionalInfo += `\n\ncontext${i}:\n\n${variablesWithContent[i]}`;
+    for (let i = 0; i < variablesWithContent.length; i++) {
+      if (matches[i]) {
+        const varname = matches[i][1];
+        additionalInfo += `\n\n${varname}:\n\n${variablesWithContent[i]}`;
+      }
     }
 
-    const endLine = "\nAvoid mentioning the variable names 'selectedText' or 'contextX' in the reply. ";
-    return processedPrompt + "\n\n" + additionalInfo + (index > 0 ? endLine : "");
+    return processedPrompt + "\n\n" + additionalInfo;
   }
 }

--- a/tests/customPromptProcessor.test.ts
+++ b/tests/customPromptProcessor.test.ts
@@ -18,7 +18,7 @@ describe('CustomPromptProcessor', () => {
     processor = CustomPromptProcessor.getInstance(mockVault);
   });
 
-  it('should replace placeholders with 1 context and selectedText', async () => {
+  it('should add 1 context and selectedText', async () => {
     const doc: CustomPrompt = {
       _id: 'test-prompt',
       prompt: 'This is a {variable} and {}.'
@@ -30,12 +30,12 @@ describe('CustomPromptProcessor', () => {
 
     const result = await processor.processCustomPrompt(doc.prompt, selectedText);
 
-    expect(result).toContain('This is a {context0} and {selectedText}.');
+    expect(result).toContain('This is a {variable} and {selectedText}.');
     expect(result).toContain('here is some selected text 12345');
     expect(result).toContain('here is the note content for note0');
   });
 
-  it('should replace placeholders with 2 context and no selectedText', async () => {
+  it('should add 2 context and no selectedText', async () => {
     const doc: CustomPrompt = {
       _id: 'test-prompt',
       prompt: 'This is a {variable} and {var2}.'
@@ -50,12 +50,12 @@ describe('CustomPromptProcessor', () => {
 
     const result = await processor.processCustomPrompt(doc.prompt, selectedText);
 
-    expect(result).toContain('This is a {context0} and {context1}.');
+    expect(result).toContain('This is a {variable} and {var2}.');
     expect(result).toContain('here is the note content for note0');
     expect(result).toContain('note content for note1');
   });
 
-  it('should replace placeholders with 1 selectedText and no context', async () => {
+  it('should add 1 selectedText and no context', async () => {
     const doc: CustomPrompt = {
       _id: 'test-prompt',
       prompt: 'Rewrite the following text {}'
@@ -77,7 +77,7 @@ describe('CustomPromptProcessor', () => {
   });
 
   // This is not an expected use case but it's possible
-  it('should replace placeholders with 2 selectedText and no context', async () => {
+  it('should add 2 selectedText and no context', async () => {
     const doc: CustomPrompt = {
       _id: 'test-prompt',
       prompt: 'Rewrite the following text {} and {}'
@@ -129,14 +129,14 @@ describe('CustomPromptProcessor', () => {
       selectedText
     );
 
-    expect(result).toContain("Notes related to {context0} are:");
+    expect(result).toContain("Notes related to {#tag} are:");
     expect(result).toContain(
       '[{"name":"note","content":"Note content for #tag"}]'
     );
   });
 
   it("should process multiple tag variables correctly", async () => {
-    const customPrompt = "Notes related to {#tag1,#tag2,   #tag3} are:";
+    const customPrompt = "Notes related to {#tag1,#tag2,#tag3} are:";
     const selectedText = "";
 
     // Mock the extractVariablesFromPrompt method to simulate processing of multiple tags
@@ -151,7 +151,7 @@ describe('CustomPromptProcessor', () => {
       selectedText
     );
 
-    expect(result).toContain("Notes related to {context0} are:");
+    expect(result).toContain("Notes related to {#tag1,#tag2,#tag3} are:");
     expect(result).toContain(
       '[{"name":"note1","content":"Note content for #tag1"},{"name":"note2","content":"Note content for #tag2"}]'
     );


### PR DESCRIPTION
No need to replace them. It looks more clear and requires less prompt engineering.