### PR TITLE
Implement note title mention in Chat and Vault QA mode

### DIFF
--- a/src/components/ NoteTitleModal.tsx
+++ b/src/components/ NoteTitleModal.tsx
@@ -1,0 +1,28 @@
+import { App, FuzzySuggestModal } from "obsidian";
+
+export class NoteTitleModal extends FuzzySuggestModal<string> {
+  private onChooseNoteTitle: (noteTitle: string) => void;
+  private noteTitles: string[];
+
+  constructor(
+    app: App,
+    noteTitles: string[],
+    onChooseNoteTitle: (noteTitle: string) => void
+  ) {
+    super(app);
+    this.noteTitles = noteTitles;
+    this.onChooseNoteTitle = onChooseNoteTitle;
+  }
+
+  getItems(): string[] {
+    return this.noteTitles;
+  }
+
+  getItemText(noteTitle: string): string {
+    return noteTitle;
+  }
+
+  onChooseItem(noteTitle: string, evt: MouseEvent | KeyboardEvent) {
+    this.onChooseNoteTitle(noteTitle);
+  }
+}

--- a/src/components/ChatComponents/ChatInput.tsx
+++ b/src/components/ChatComponents/ChatInput.tsx
@@ -1,5 +1,5 @@
+import { NoteTitleModal } from '@/components/ NoteTitleModal';
 import React, { useEffect, useRef, useState } from 'react';
-
 
 interface ChatInputProps {
   inputMessage: string;
@@ -17,8 +17,30 @@ const ChatInput: React.FC<ChatInputProps> = ({
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setInputMessage(event.target.value);
-    updateRows(event.target.value);
+    const inputValue = event.target.value;
+    setInputMessage(inputValue);
+    updateRows(inputValue);
+
+    // Check if the user typed `[[`
+    if (inputValue.slice(-2) === '[[') {
+      showNoteTitleModal();
+    }
+  };
+
+  const showNoteTitleModal = () => {
+    const fetchNoteTitles = async () => {
+      const noteTitles = app.vault.getMarkdownFiles().map(file => file.basename);
+
+      new NoteTitleModal(
+        app,
+        noteTitles,
+        (noteTitle: string) => {
+          setInputMessage(inputMessage.slice(0, -2) + ` [[${noteTitle}]]`);
+        }
+      ).open();
+    };
+
+    fetchNoteTitles();
   };
 
   const updateRows = (text: string) => {

--- a/src/search/hybridRetriever.ts
+++ b/src/search/hybridRetriever.ts
@@ -1,4 +1,4 @@
-import { getNotePathFromTitle } from "@/utils";
+import { extractNoteTitles, getNotePathFromTitle } from "@/utils";
 import VectorDBManager from "@/vectorDBManager";
 import { BaseRetriever } from "@langchain/core/retrievers";
 import { VectorStore } from "@langchain/core/vectorstores";
@@ -23,7 +23,7 @@ export class HybridRetriever<V extends VectorStore> extends BaseRetriever {
 
   async getRelevantDocuments(query: string): Promise<Document[]> {
     // Extract note titles wrapped in [[]] from the query
-    const noteTitles = this.extractNoteTitles(query);
+    const noteTitles = extractNoteTitles(query);
     // Retrieve chunks for explicitly mentioned note titles
     const explicitChunks = await this.getExplicitChunks(noteTitles);
     if (this.debug) {
@@ -57,13 +57,6 @@ export class HybridRetriever<V extends VectorStore> extends BaseRetriever {
 
     // Make sure the combined chunks are at most maxK
     return combinedChunks.slice(0, this.options.maxK);
-  }
-
-  private extractNoteTitles(query: string): string[] {
-    // Use a regular expression to extract note titles wrapped in [[]]
-    const regex = /\[\[(.*?)\]\]/g;
-    const matches = query.match(regex);
-    return matches ? matches.map((match) => match.slice(2, -2)) : [];
   }
 
   private async getExplicitChunks(noteTitles: string[]): Promise<Document[]> {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -493,6 +493,22 @@ export function extractChatHistory(
   return chatHistory;
 }
 
+export function extractNoteTitles(query: string): string[] {
+  // Use a regular expression to extract note titles wrapped in [[]]
+  const regex = /\[\[(.*?)\]\]/g;
+  const matches = query.match(regex);
+  const uniqueTitles = new Set(
+    matches ? matches.map((match) => match.slice(2, -2)) : [],
+  );
+  return Array.from(uniqueTitles);
+}
+
+/**
+ * Process the variable name to generate a note path if it's enclosed in double brackets, otherwise return the variable name as is.
+ *
+ * @param {string} variableName - The name of the variable to process
+ * @return {string} The processed note path or the variable name itself
+ */
 export function processVariableNameForNotePath(variableName: string): string {
   variableName = variableName.trim();
   // Check if the variable name is enclosed in double brackets indicating it's a note

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,6 +1,7 @@
 import * as Obsidian from "obsidian";
 import { TFile } from "obsidian";
 import {
+  extractNoteTitles,
   getNotesFromPath,
   getNotesFromTags,
   isFolderMatch,
@@ -268,5 +269,50 @@ describe("isPathInList", () => {
       " another/folder , test/folder ",
     );
     expect(result).toBe(true);
+  });
+});
+
+describe("extractNoteTitles", () => {
+  it("should extract single note title", () => {
+    const query = "Please refer to [[Note1]] for more information.";
+    const expected = ["Note1"];
+    const result = extractNoteTitles(query);
+    expect(result).toEqual(expected);
+  });
+
+  it("should extract multiple note titles", () => {
+    const query =
+      "Please refer to [[Note1]] and [[Note2]] for more information.";
+    const expected = ["Note1", "Note2"];
+    const result = extractNoteTitles(query);
+    expect(result).toEqual(expected);
+  });
+
+  it("should handle note titles with spaces", () => {
+    const query = "Check out [[Note 1]] and [[Another Note]] for details.";
+    const expected = ["Note 1", "Another Note"];
+    const result = extractNoteTitles(query);
+    expect(result).toEqual(expected);
+  });
+
+  it("should ignore duplicates and return unique titles", () => {
+    const query = "Refer to [[Note1]], [[Note2]], and [[Note1]] again.";
+    const expected = ["Note1", "Note2"];
+    const result = extractNoteTitles(query);
+    expect(result).toEqual(expected);
+  });
+
+  it("should return an empty array if no note titles are found", () => {
+    const query = "There are no note titles in this string.";
+    const expected: string[] = [];
+    const result = extractNoteTitles(query);
+    expect(result).toEqual(expected);
+  });
+
+  it("should extract note titles with special characters", () => {
+    const query = "Important notes: [[Note-1]], [[Note_2]], and [[Note#3]].";
+    const expected = ["Note-1", "Note_2", "Note#3"];
+    const result = extractNoteTitles(query);
+    expect(result).toEqual(expected);
   });
 });


### PR DESCRIPTION
- Now, if you type `[[` in the chat input it will trigger a fuzzy list modal for your note titles.
- In Chat mode, mentioning a note title `[[note title]]` will append the full note directly to the prompt in the background
- In Vault QA mode, a mention of a note title ensures that it will be at top of the retrieved list