### PR TITLE
Fix source link when vault name has spaces

### DIFF
--- a/src/LLMProviders/chainManager.ts
+++ b/src/LLMProviders/chainManager.ts
@@ -545,7 +545,7 @@ export default class ChainManager {
       const markdownLinks = docTitles
         .map(
           (title) =>
-            `[${title}](obsidian://open?vault=${this.app.vault.getName()}&file=${encodeURIComponent(
+            `[${title}](obsidian://open?vault=${encodeURIComponent(this.app.vault.getName())}&file=${encodeURIComponent(
               title,
             )})`,
         )


### PR DESCRIPTION
Address https://github.com/logancyang/obsidian-copilot/issues/371