### PR TITLE
Add support for organization-id for OpenAI

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -68,6 +68,7 @@ export default class ChatModelManager {
       [ModelProviders.OPENAI]: {
         modelName: params.openAIProxyModelName || params.model,
         openAIApiKey: decrypt(params.openAIApiKey),
+        openAIOrgId: decrypt(params.openAIOrgId),
         maxTokens: params.maxTokens,
         openAIProxyBaseUrl: params.openAIProxyBaseUrl,
       },
@@ -115,6 +116,7 @@ export default class ChatModelManager {
       {
         models: OPENAI_MODELS,
         apiKey: this.langChainParams.openAIApiKey,
+        organization: this.langChainParams.openAIOrgId,
         constructor: OpenAIChatModel,
         vendor: ModelProviders.OPENAI,
       },

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -10,6 +10,7 @@ export interface ModelConfig {
   maxConcurrency: number;
   maxTokens?: number;
   openAIApiKey?: string;
+  openAIOrgId?: string;
   anthropicApiKey?: string;
   anthropicModel?: string;
   azureOpenAIApiKey?: string;
@@ -28,6 +29,7 @@ export interface ModelConfig {
 
 export interface LangChainParams {
   openAIApiKey: string;
+  openAIOrgId: string;
   huggingfaceApiKey: string;
   cohereApiKey: string;
   anthropicApiKey: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -134,6 +134,7 @@ export const PROXY_SERVER_PORT = 53001;
 
 export const DEFAULT_SETTINGS: CopilotSettings = {
   openAIApiKey: "",
+  openAIOrgId: "",
   huggingfaceApiKey: "",
   cohereApiKey: "",
   anthropicApiKey: "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -702,6 +702,7 @@ export default class CopilotPlugin extends Plugin {
   getChainManagerParams(): LangChainParams {
     const {
       openAIApiKey,
+      openAIOrgId,
       huggingfaceApiKey,
       cohereApiKey,
       anthropicApiKey,
@@ -724,6 +725,7 @@ export default class CopilotPlugin extends Plugin {
     } = sanitizeSettings(this.settings);
     return {
       openAIApiKey,
+      openAIOrgId,
       huggingfaceApiKey,
       cohereApiKey,
       anthropicApiKey,

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -6,6 +6,7 @@ import SettingsMain from "./components/SettingsMain";
 
 export interface CopilotSettings {
   openAIApiKey: string;
+  openAIOrgId: string;
   huggingfaceApiKey: string;
   cohereApiKey: string;
   anthropicApiKey: string;

--- a/src/settings/components/ApiSettings.tsx
+++ b/src/settings/components/ApiSettings.tsx
@@ -6,6 +6,8 @@ import Collapsible from './Collapsible';
 interface ApiSettingsProps {
   openAIApiKey: string;
   setOpenAIApiKey: (value: string) => void;
+  openAIOrgId: string;
+  setOpenAIOrgId: (value: string) => void;
   googleApiKey: string;
   setGoogleApiKey: (value: string) => void;
   anthropicApiKey: string;
@@ -31,6 +33,8 @@ interface ApiSettingsProps {
 const ApiSettings: React.FC<ApiSettingsProps> = ({
   openAIApiKey,
   setOpenAIApiKey,
+  openAIOrgId,
+  setOpenAIOrgId,
   googleApiKey,
   setGoogleApiKey,
   anthropicApiKey,
@@ -79,6 +83,12 @@ const ApiSettings: React.FC<ApiSettingsProps> = ({
               https://platform.openai.com/api-keys
             </a>
           </p>
+          <ApiSetting
+            title="OpenAI Organization ID"
+            value={openAIOrgId}
+            setValue={setOpenAIOrgId}
+            placeholder="Enter OpenAI Organization ID if applicable"
+          />
         </div>
         <div className="warning-message">
           <span>If you are a new user, try </span>

--- a/src/settings/components/SettingsMain.tsx
+++ b/src/settings/components/SettingsMain.tsx
@@ -22,6 +22,7 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
 
   // API settings
   const [openAIApiKey, setOpenAIApiKey] = useState(plugin.settings.openAIApiKey);
+  const [openAIOrgId, setOpenAIOrgId] = useState(plugin.settings.openAIOrgId);
   const [googleApiKey, setGoogleApiKey] = useState(plugin.settings.googleApiKey);
 
   const [anthropicApiKey, setAnthropicApiKey] = useState(plugin.settings.anthropicApiKey);
@@ -66,6 +67,7 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
 
     // API settings
     plugin.settings.openAIApiKey = openAIApiKey;
+    plugin.settings.openAIOrgId = openAIOrgId;
     plugin.settings.googleApiKey = googleApiKey;
     plugin.settings.anthropicApiKey = anthropicApiKey;
     plugin.settings.anthropicModel = anthropicModel;
@@ -183,6 +185,8 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
       <ApiSettings
         openAIApiKey={openAIApiKey}
         setOpenAIApiKey={setOpenAIApiKey}
+        openAIOrgId={openAIOrgId}
+        setOpenAIOrgId={setOpenAIOrgId}
         googleApiKey={googleApiKey}
         setGoogleApiKey={setGoogleApiKey}
         anthropicApiKey={anthropicApiKey}


### PR DESCRIPTION
resolves #435  

This PR adds a new field 'Open AI Organization ID' in the settings page right after Open AI Key as shown in the screensho.
<img width="781" alt="Screenshot 2024-04-29 at 10 43 06 PM" src="https://github.com/logancyang/obsidian-copilot/assets/146442/28cb896c-9d6c-4fff-88a4-9964eb6b323c">

This field is optional, and if provided it will be passed down to langchain's API calls or to the proxy http-agent.