### PR TITLE
add support for an OpenAI proxy server

### DIFF
--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -57,6 +57,7 @@ export interface LangChainParams {
   openRouterModel: string;
   lmStudioBaseUrl: string;
   openAIProxyBaseUrl?: string;
+  useOpenAILocalProxy?: boolean;
   openAIProxyModelName?: string;
   openAIEmbeddingProxyBaseUrl?: string;
   openAIEmbeddingProxyModelName?: string;

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -480,6 +480,7 @@ const Chat: React.FC<ChatProps> = ({
           vault={app.vault}
           vault_qa_strategy={plugin.settings.indexVaultToVectorStore}
           proxyServer={plugin.proxyServer}
+          settings={settings}
           debug={debug}
         />
         <ChatInput

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -480,7 +480,6 @@ const Chat: React.FC<ChatProps> = ({
           vault={app.vault}
           vault_qa_strategy={plugin.settings.indexVaultToVectorStore}
           proxyServer={plugin.proxyServer}
-          settings={settings}
           debug={debug}
         />
         <ChatInput

--- a/src/components/ChatComponents/ChatIcons.tsx
+++ b/src/components/ChatComponents/ChatIcons.tsx
@@ -19,7 +19,6 @@ import {
   UseActiveNoteAsContextIcon,
 } from "@/components/Icons";
 import { stringToChainType } from "@/utils";
-import { CopilotSettings } from "@/settings/SettingsPage";
 
 interface ChatIconsProps {
   currentModel: string;
@@ -36,7 +35,6 @@ interface ChatIconsProps {
   vault: Vault;
   vault_qa_strategy: string;
   proxyServer: ProxyServer;
-  settings: CopilotSettings;
   debug?: boolean;
 }
 
@@ -55,7 +53,6 @@ const ChatIcons: React.FC<ChatIconsProps> = ({
   vault,
   vault_qa_strategy,
   proxyServer,
-  settings,
   debug,
 }) => {
   const [selectedChain, setSelectedChain] = useState<ChainType>(currentChain);
@@ -74,7 +71,6 @@ const ChatIcons: React.FC<ChatIconsProps> = ({
   };
 
   useEffect(() => {
-    // Start proxy server based on the selected model & settings
     const startProxyServerForClaude = async (proxyServerURL: string) => {
       await proxyServer.startProxyServer(proxyServerURL, currentModel !== ChatModelDisplayNames.CLAUDE);
     };
@@ -89,7 +85,7 @@ const ChatIcons: React.FC<ChatIconsProps> = ({
     return () => {
       proxyServer.stopProxyServer().catch(console.error);
     };
-  }, [currentModel, proxyServer]);
+  }, []);
 
   const handleChainChange = async (
     event: React.ChangeEvent<HTMLSelectElement>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -169,6 +169,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   contextTurns: 15,
   userSystemPrompt: "",
   openAIProxyBaseUrl: "",
+  useOpenAILocalProxy: false,
   openAIProxyModelName: "",
   openAIEmbeddingProxyBaseUrl: "",
   openAIEmbeddingProxyModelName: "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,7 +50,7 @@ export default class CopilotPlugin extends Plugin {
 
   async onload(): Promise<void> {
     await this.loadSettings();
-    this.proxyServer = new ProxyServer(PROXY_SERVER_PORT);
+    this.proxyServer = new ProxyServer(this.settings, PROXY_SERVER_PORT);
     this.addSettingTab(new CopilotSettingTab(this.app, this));
     // Always have one instance of sharedState and chainManager in the plugin
     this.sharedState = new SharedState();
@@ -775,6 +775,7 @@ export default class CopilotPlugin extends Plugin {
       chainType: ChainType.LLM_CHAIN, // Set LLM_CHAIN as default ChainType
       options: { forceNewCreation: true } as SetChainOptions,
       openAIProxyBaseUrl: this.settings.openAIProxyBaseUrl,
+      useOpenAILocalProxy: this.settings.useOpenAILocalProxy,
       openAIProxyModelName: this.settings.openAIProxyModelName,
       openAIEmbeddingProxyBaseUrl: this.settings.openAIEmbeddingProxyBaseUrl,
       openAIEmbeddingProxyModelName:

--- a/src/proxyServer.ts
+++ b/src/proxyServer.ts
@@ -1,15 +1,17 @@
 import cors from "@koa/cors";
 import Koa from "koa";
 import proxy from "koa-proxies";
-import net from "net";
 import { CopilotSettings } from "@/settings/SettingsPage";
 import { ChatModelDisplayNames } from "@/constants";
+
+// There should only be 1 running proxy server at a time so keep it in upper scope
+let server: any;
 
 export class ProxyServer {
   private settings: CopilotSettings;
   private debug: boolean;
   private port: number;
-  private server?: net.Server;
+  private runningUrl: string;
 
   constructor(settings: CopilotSettings, port: number) {
     this.settings = settings;
@@ -19,19 +21,24 @@ export class ProxyServer {
 
   getProxyURL(currentModel: string): string {
     if (currentModel === ChatModelDisplayNames.CLAUDE) {
-      return "https://api.anthropic.com/"
-    } else if (this.settings.useOpenAILocalProxy && this.settings.openAIProxyBaseUrl) {
-      return `http://localhost:${this.port}`;
+      return "https://api.anthropic.com/";
+    } else if (
+      this.settings.useOpenAILocalProxy &&
+      this.settings.openAIProxyBaseUrl
+    ) {
+      return this.settings.openAIProxyBaseUrl;
     }
-    
-    return '';
+
+    return "";
   }
 
   // Starts a proxy server on localhost that forwards requests to the provided base URL
   // If rewritePaths is true, the proxy will rewrite all paths of the requests to match the base URL
   async startProxyServer(proxyBaseUrl: string, rewritePaths = true) {
+    await this.stopProxyServer();
+
     if (this.debug) {
-      console.log("Attempting to start proxy server...");
+      console.log(`Attempting to start proxy server to ${proxyBaseUrl}...`);
     }
 
     const app = new Koa();
@@ -41,15 +48,18 @@ export class ProxyServer {
     app.use(
       proxy("/", {
         target: proxyBaseUrl,
-        changeOrigin: true, 
-        logs: this.debug,
-        rewrite: rewritePaths ? (path) => path : undefined, 
+        changeOrigin: true,
+        logs: false,
+        rewrite: rewritePaths ? (path) => path : undefined,
       }),
     );
 
     // Create the server and attach error handling for "EADDRINUSE"
-    this.server = app.listen(this.port);
-    this.server.on("error", (err: NodeJS.ErrnoException) => {
+    if (server?.listening) {
+      return
+    }
+    server = app.listen(this.port);
+    server.on("error", (err: NodeJS.ErrnoException) => {
       if (err.code === "EADDRINUSE") {
         console.error(`Proxy server port ${this.port} is already in use.`);
       } else {
@@ -57,24 +67,35 @@ export class ProxyServer {
       }
     });
 
-    this.server.on("listening", () => {
+    server.on("listening", () => {
+      this.runningUrl = proxyBaseUrl;
       if (this.debug) {
-        console.log(`Proxy server running on http://localhost:${this.port}`);
+        console.log(
+          `Proxy server running on http://localhost:${this.port}. Proxy to ${proxyBaseUrl}`,
+        );
       }
     });
   }
 
   async stopProxyServer() {
-    if (this.debug) {
-      console.log("Attempting to stop proxy server...");
+    let waitForClose: Promise<boolean> | boolean = false;
+    if (server) {
+      if (this.debug) {
+        console.log(
+          `Attempting to stop proxy server proxying to ${this.runningUrl}...`,
+        );
+      }
+      waitForClose = new Promise((resolve) => {
+        server.on("close", () => {
+          this.runningUrl = "";
+          if (this.debug) {
+            console.log("Proxy server stopped.");
+          }
+          resolve(true);
+        });
+        server.close();
+      });
     }
-    if (this.server) {
-      this.server.on("close", () => {
-        if (this.debug) {
-          console.log("Proxy server stopped.");
-        }
-      })
-      this.server.close();
-    }
+    return waitForClose;
   }
 }

--- a/src/proxyServer.ts
+++ b/src/proxyServer.ts
@@ -2,21 +2,50 @@ import cors from "@koa/cors";
 import Koa from "koa";
 import proxy from "koa-proxies";
 import net from "net";
+import { CopilotSettings } from "@/settings/SettingsPage";
+import { ChatModelDisplayNames } from "@/constants";
 
 export class ProxyServer {
+  private settings: CopilotSettings;
+  private debug: boolean;
   private port: number;
   private server?: net.Server;
 
-  constructor(port: number) {
+  constructor(settings: CopilotSettings, port: number) {
+    this.settings = settings;
     this.port = port;
+    this.debug = settings.debug;
   }
 
-  async startProxyServer(proxyBaseUrl: string) {
-    console.log("Attempting to start proxy server...");
+  getProxyURL(currentModel: string): string {
+    if (currentModel === ChatModelDisplayNames.CLAUDE) {
+      return "https://api.anthropic.com/"
+    } else if (this.settings.useOpenAILocalProxy && this.settings.openAIProxyBaseUrl) {
+      return `http://localhost:${this.port}`;
+    }
+    
+    return '';
+  }
+
+  // Starts a proxy server on localhost that forwards requests to the provided base URL
+  // If rewritePaths is true, the proxy will rewrite all paths of the requests to match the base URL
+  async startProxyServer(proxyBaseUrl: string, rewritePaths = true) {
+    if (this.debug) {
+      console.log("Attempting to start proxy server...");
+    }
 
     const app = new Koa();
     app.use(cors());
-    app.use(proxy("/", { target: proxyBaseUrl, changeOrigin: true }));
+
+    // Proxy all requests to the new base URL
+    app.use(
+      proxy("/", {
+        target: proxyBaseUrl,
+        changeOrigin: true, 
+        logs: this.debug,
+        rewrite: rewritePaths ? (path) => path : undefined, 
+      }),
+    );
 
     // Create the server and attach error handling for "EADDRINUSE"
     this.server = app.listen(this.port);
@@ -29,12 +58,22 @@ export class ProxyServer {
     });
 
     this.server.on("listening", () => {
-      console.log(`Proxy server running on http://localhost:${this.port}`);
+      if (this.debug) {
+        console.log(`Proxy server running on http://localhost:${this.port}`);
+      }
     });
   }
 
   async stopProxyServer() {
+    if (this.debug) {
+      console.log("Attempting to stop proxy server...");
+    }
     if (this.server) {
+      this.server.on("close", () => {
+        if (this.debug) {
+          console.log("Proxy server stopped.");
+        }
+      })
       this.server.close();
     }
   }

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -27,6 +27,7 @@ export interface CopilotSettings {
   contextTurns: number;
   userSystemPrompt: string;
   openAIProxyBaseUrl: string;
+  useOpenAILocalProxy: boolean
   openAIProxyModelName: string;
   openAIEmbeddingProxyBaseUrl: string;
   openAIEmbeddingProxyModelName: string;

--- a/src/settings/components/AdvancedSettings.tsx
+++ b/src/settings/components/AdvancedSettings.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import { TextAreaComponent, TextComponent } from './SettingBlocks';
+import {
+  TextAreaComponent,
+  TextComponent,
+  ToggleComponent,
+} from './SettingBlocks';
 
 interface AdvancedSettingsProps {
   openAIProxyBaseUrl: string;
   setOpenAIProxyBaseUrl: (value: string) => void;
+  useOpenAILocalProxy: boolean;
+  setUseOpenAILocalProxy: (value: boolean) => void;
   openAIProxyModelName: string;
   setOpenAIProxyModelName: (value: string) => void;
   openAIEmbeddingProxyBaseUrl: string;
@@ -17,6 +23,8 @@ interface AdvancedSettingsProps {
 const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
   openAIProxyBaseUrl,
   setOpenAIProxyBaseUrl,
+  useOpenAILocalProxy,
+  setUseOpenAILocalProxy,
   openAIProxyModelName,
   setOpenAIProxyModelName,
   openAIEmbeddingProxyBaseUrl,
@@ -40,6 +48,12 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
         value={openAIProxyBaseUrl}
         onChange={setOpenAIProxyBaseUrl}
         placeholder="https://openai.example.com/v1"
+      />
+      <ToggleComponent
+        name="Use local proxy server for OpenAI"
+        description="Enable if your proxy base URL results in CORS errors."
+        value={useOpenAILocalProxy}
+        onChange={setUseOpenAILocalProxy}
       />
       <TextComponent
         name="OpenAI Proxy Model Name"

--- a/src/settings/components/SettingsMain.tsx
+++ b/src/settings/components/SettingsMain.tsx
@@ -50,6 +50,7 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
   // Advanced settings
   const [userSystemPrompt, setUserSystemPrompt] = useState(plugin.settings.userSystemPrompt);
   const [openAIProxyBaseUrl, setOpenAIProxyBaseUrl] = useState(plugin.settings.openAIProxyBaseUrl);
+  const [useOpenAILocalProxy, setUseOpenAILocalProxy] = useState(plugin.settings.useOpenAILocalProxy);
   const [openAIProxyModelName, setOpenAIProxyModelName] = useState(plugin.settings.openAIProxyModelName);
   const [openAIEmbeddingProxyBaseUrl, setOpenAIEmbeddingProxyBaseUrl] = useState(plugin.settings.openAIEmbeddingProxyBaseUrl);
   const [openAIEmbeddingProxyModelName, setOpenAIEmbeddingProxyModelName] = useState(plugin.settings.openAIEmbeddingProxyModelName);
@@ -94,6 +95,7 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
     // Advanced settings
     plugin.settings.userSystemPrompt = userSystemPrompt;
     plugin.settings.openAIProxyBaseUrl = openAIProxyBaseUrl;
+    plugin.settings.useOpenAILocalProxy = useOpenAILocalProxy;
     plugin.settings.openAIProxyModelName = openAIProxyModelName;
     plugin.settings.openAIEmbeddingProxyBaseUrl = openAIEmbeddingProxyBaseUrl;
     plugin.settings.openAIEmbeddingProxyModelName = openAIEmbeddingProxyModelName;
@@ -232,6 +234,8 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
       <AdvancedSettings
         openAIProxyBaseUrl={openAIProxyBaseUrl}
         setOpenAIProxyBaseUrl={setOpenAIProxyBaseUrl}
+        useOpenAILocalProxy={useOpenAILocalProxy}
+        setUseOpenAILocalProxy={setUseOpenAILocalProxy}
         openAIProxyModelName={openAIProxyModelName}
         setOpenAIProxyModelName={setOpenAIProxyModelName}
         openAIEmbeddingProxyBaseUrl={openAIEmbeddingProxyBaseUrl}


### PR DESCRIPTION
Closes https://github.com/logancyang/obsidian-copilot/issues/360

![image](https://github.com/user-attachments/assets/c94753ef-f7a7-41c0-8c62-3b12252adc93)

Adds a new options to "Use local proxy server for OpenAI"

Was able to test with a custom "OpenAI Proxy Base URL" and get things working. Previously, I was blocked by CORS requests.

This specific change will eventually allow users to use a GitHub token to authenticate their OpenAI model once https://github.blog/news-insights/product-news/introducing-github-models/ becomes publicly available. 

I don't have anything setup with Anthropic so I tried to leave the existing functionality, but I haven't been able to test it. 