### PR TITLE
Add toggles for sample built-in commands

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -2,138 +2,93 @@ import { LanguageModal } from "@/components/LanguageModal";
 import { ToneModal } from "@/components/ToneModal";
 import CopilotPlugin from "@/main";
 import { Editor, Notice } from "obsidian";
+import { COMMAND_IDS } from "./constants";
 
 export function registerBuiltInCommands(plugin: CopilotPlugin) {
-  plugin.addCommand({
-    id: "fix-grammar-prompt",
-    name: "Fix grammar and spelling of selection",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "fixGrammarSpellingSelection");
-    },
+  const addCommandIfEnabled = (
+    id: string,
+    callback: (editor: Editor) => void,
+  ) => {
+    const commandSettings = plugin.settings.enabledCommands[id];
+    if (commandSettings && commandSettings.enabled) {
+      plugin.addCommand({
+        id,
+        name: commandSettings.name,
+        editorCallback: callback,
+      });
+    }
+  };
+
+  addCommandIfEnabled(COMMAND_IDS.FIX_GRAMMAR, (editor) => {
+    plugin.processSelection(editor, "fixGrammarSpellingSelection");
   });
 
-  plugin.addCommand({
-    id: "summarize-prompt",
-    name: "Summarize selection",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "summarizeSelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.SUMMARIZE, (editor) => {
+    plugin.processSelection(editor, "summarizeSelection");
   });
 
-  plugin.addCommand({
-    id: "generate-toc-prompt",
-    name: "Generate table of contents for selection",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "tocSelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.GENERATE_TOC, (editor) => {
+    plugin.processSelection(editor, "tocSelection");
   });
 
-  plugin.addCommand({
-    id: "generate-glossary-prompt",
-    name: "Generate glossary for selection",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "glossarySelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.GENERATE_GLOSSARY, (editor) => {
+    plugin.processSelection(editor, "glossarySelection");
   });
 
-  plugin.addCommand({
-    id: "simplify-prompt",
-    name: "Simplify selection",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "simplifySelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.SIMPLIFY, (editor) => {
+    plugin.processSelection(editor, "simplifySelection");
   });
 
-  plugin.addCommand({
-    id: "emojify-prompt",
-    name: "Emojify selection",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "emojifySelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.EMOJIFY, (editor) => {
+    plugin.processSelection(editor, "emojifySelection");
   });
 
-  plugin.addCommand({
-    id: "remove-urls-prompt",
-    name: "Remove URLs from selection",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "removeUrlsFromSelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.REMOVE_URLS, (editor) => {
+    plugin.processSelection(editor, "removeUrlsFromSelection");
   });
 
-  plugin.addCommand({
-    id: "rewrite-tweet-prompt",
-    name: "Rewrite selection to a tweet",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "rewriteTweetSelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.REWRITE_TWEET, (editor) => {
+    plugin.processSelection(editor, "rewriteTweetSelection");
   });
 
-  plugin.addCommand({
-    id: "rewrite-tweet-thread-prompt",
-    name: "Rewrite selection to a tweet thread",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "rewriteTweetThreadSelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.REWRITE_TWEET_THREAD, (editor) => {
+    plugin.processSelection(editor, "rewriteTweetThreadSelection");
   });
 
-  plugin.addCommand({
-    id: "make-shorter-prompt",
-    name: "Make selection shorter",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "rewriteShorterSelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.MAKE_SHORTER, (editor) => {
+    plugin.processSelection(editor, "rewriteShorterSelection");
   });
 
-  plugin.addCommand({
-    id: "make-longer-prompt",
-    name: "Make selection longer",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "rewriteLongerSelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.MAKE_LONGER, (editor) => {
+    plugin.processSelection(editor, "rewriteLongerSelection");
   });
 
-  plugin.addCommand({
-    id: "eli5-prompt",
-    name: "Explain selection like I'm 5",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "eli5Selection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.ELI5, (editor) => {
+    plugin.processSelection(editor, "eli5Selection");
   });
 
-  plugin.addCommand({
-    id: "press-release-prompt",
-    name: "Rewrite selection to a press release",
-    editorCallback: (editor: Editor) => {
-      plugin.processSelection(editor, "rewritePressReleaseSelection");
-    },
+  addCommandIfEnabled(COMMAND_IDS.PRESS_RELEASE, (editor) => {
+    plugin.processSelection(editor, "rewritePressReleaseSelection");
   });
 
-  plugin.addCommand({
-    id: "translate-selection-prompt",
-    name: "Translate selection",
-    editorCallback: (editor: Editor) => {
-      new LanguageModal(plugin.app, (language) => {
-        if (!language) {
-          new Notice("Please select a language.");
-          return;
-        }
-        plugin.processSelection(editor, "translateSelection", language);
-      }).open();
-    },
+  addCommandIfEnabled(COMMAND_IDS.TRANSLATE, (editor) => {
+    new LanguageModal(plugin.app, (language) => {
+      if (!language) {
+        new Notice("Please select a language.");
+        return;
+      }
+      plugin.processSelection(editor, "translateSelection", language);
+    }).open();
   });
 
-  plugin.addCommand({
-    id: "change-tone-prompt",
-    name: "Change tone of selection",
-    editorCallback: (editor: Editor) => {
-      new ToneModal(plugin.app, (tone) => {
-        if (!tone) {
-          new Notice("Please select a tone.");
-          return;
-        }
-        plugin.processSelection(editor, "changeToneSelection", tone);
-      }).open();
-    },
+  addCommandIfEnabled(COMMAND_IDS.CHANGE_TONE, (editor) => {
+    new ToneModal(plugin.app, (tone) => {
+      if (!tone) {
+        new Notice("Please select a tone.");
+        return;
+      }
+      plugin.processSelection(editor, "changeToneSelection", tone);
+    }).open();
   });
 
   plugin.addCommand({

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -144,6 +144,26 @@ export const VAULT_VECTOR_STORE_STRATEGIES = [
 
 export const PROXY_SERVER_PORT = 53001;
 
+export const COMMAND_IDS = {
+  FIX_GRAMMAR: "fix-grammar-prompt",
+  SUMMARIZE: "summarize-prompt",
+  GENERATE_TOC: "generate-toc-prompt",
+  GENERATE_GLOSSARY: "generate-glossary-prompt",
+  SIMPLIFY: "simplify-prompt",
+  EMOJIFY: "emojify-prompt",
+  REMOVE_URLS: "remove-urls-prompt",
+  REWRITE_TWEET: "rewrite-tweet-prompt",
+  REWRITE_TWEET_THREAD: "rewrite-tweet-thread-prompt",
+  MAKE_SHORTER: "make-shorter-prompt",
+  MAKE_LONGER: "make-longer-prompt",
+  ELI5: "eli5-prompt",
+  PRESS_RELEASE: "press-release-prompt",
+  TRANSLATE: "translate-selection-prompt",
+  CHANGE_TONE: "change-tone-prompt",
+  COUNT_TOKENS: "count-tokens",
+  COUNT_TOTAL_VAULT_TOKENS: "count-total-vault-tokens",
+};
+
 export const DEFAULT_SETTINGS: CopilotSettings = {
   openAIApiKey: "",
   openAIOrgId: "",
@@ -161,8 +181,8 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   googleCustomModel: "",
   openRouterAiApiKey: "",
   openRouterModel: "cognitivecomputations/dolphin-mixtral-8x7b",
-  defaultModel: ChatModels.GPT_4_TURBO,
-  defaultModelDisplayName: ChatModelDisplayNames.GPT_4_TURBO,
+  defaultModel: ChatModels.GPT_4o,
+  defaultModelDisplayName: ChatModelDisplayNames.GPT_4o,
   embeddingModel: EmbeddingModels.OPENAI_EMBEDDING_SMALL,
   temperature: 0.1,
   maxTokens: 1000,
@@ -187,4 +207,66 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   maxSourceChunks: 3,
   groqModel: "llama3-70b-8192",
   groqApiKey: "",
+  enabledCommands: {
+    [COMMAND_IDS.FIX_GRAMMAR]: {
+      enabled: true,
+      name: "Fix grammar and spelling of selection",
+    },
+    [COMMAND_IDS.SUMMARIZE]: {
+      enabled: true,
+      name: "Summarize selection",
+    },
+    [COMMAND_IDS.GENERATE_TOC]: {
+      enabled: true,
+      name: "Generate table of contents for selection",
+    },
+    [COMMAND_IDS.GENERATE_GLOSSARY]: {
+      enabled: true,
+      name: "Generate glossary for selection",
+    },
+    [COMMAND_IDS.SIMPLIFY]: {
+      enabled: true,
+      name: "Simplify selection",
+    },
+    [COMMAND_IDS.EMOJIFY]: {
+      enabled: true,
+      name: "Emojify selection",
+    },
+    [COMMAND_IDS.REMOVE_URLS]: {
+      enabled: true,
+      name: "Remove URLs from selection",
+    },
+    [COMMAND_IDS.REWRITE_TWEET]: {
+      enabled: true,
+      name: "Rewrite selection to a tweet",
+    },
+    [COMMAND_IDS.REWRITE_TWEET_THREAD]: {
+      enabled: true,
+      name: "Rewrite selection to a tweet thread",
+    },
+    [COMMAND_IDS.MAKE_SHORTER]: {
+      enabled: true,
+      name: "Make selection shorter",
+    },
+    [COMMAND_IDS.MAKE_LONGER]: {
+      enabled: true,
+      name: "Make selection longer",
+    },
+    [COMMAND_IDS.ELI5]: {
+      enabled: true,
+      name: "Explain selection like I'm 5",
+    },
+    [COMMAND_IDS.PRESS_RELEASE]: {
+      enabled: true,
+      name: "Rewrite selection to a press release",
+    },
+    [COMMAND_IDS.TRANSLATE]: {
+      enabled: true,
+      name: "Translate selection",
+    },
+    [COMMAND_IDS.CHANGE_TONE]: {
+      enabled: true,
+      name: "Change tone of selection",
+    },
+  },
 };

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -47,6 +47,7 @@ export interface CopilotSettings {
   qaExclusionPaths: string;
   groqModel: string;
   groqApiKey: string;
+  enabledCommands: Record<string, { enabled: boolean; name: string; }>;
 }
 
 export class CopilotSettingTab extends PluginSettingTab {

--- a/src/settings/components/CommandToggleSettings.tsx
+++ b/src/settings/components/CommandToggleSettings.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { ToggleComponent } from './SettingBlocks';
+
+interface CommandToggleSettingsProps {
+  enabledCommands: Record<string, { enabled: boolean; name: string }>;
+  setEnabledCommands: (enabledCommands: Record<string, { enabled: boolean; name: string }>) => void;
+}
+
+const CommandToggleSettings: React.FC<CommandToggleSettingsProps> = ({
+  enabledCommands,
+  setEnabledCommands,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const toggleCommand = (commandId: string, enabled: boolean) => {
+    setEnabledCommands({
+      ...enabledCommands,
+      [commandId]: { ...enabledCommands[commandId], enabled }
+    });
+  };
+
+  return (
+    <div>
+      <h2 onClick={() => setIsExpanded(!isExpanded)} style={{ cursor: 'pointer' }}>
+        Command Settings {isExpanded ? '▼' : '▶'}
+      </h2>
+      {isExpanded && (
+        <div>
+          {Object.entries(enabledCommands).map(([commandId, { enabled, name }]) => (
+            <ToggleComponent
+              key={commandId}
+              name={`${name}`}
+              value={enabled}
+              onChange={(value) => toggleCommand(commandId, value)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CommandToggleSettings;

--- a/src/settings/components/SettingsMain.tsx
+++ b/src/settings/components/SettingsMain.tsx
@@ -4,6 +4,7 @@ import React, { Fragment, useState } from 'react';
 import { ChatModelDisplayNames, DEFAULT_SETTINGS, DISPLAY_NAME_TO_MODEL } from '../../constants';
 import AdvancedSettings from './AdvancedSettings';
 import ApiSettings from './ApiSettings';
+import CommandToggleSettings from './CommandToggleSettings';
 import LocalCopilotSettings from './LocalCopilotSettings';
 import QASettings from './QASettings';
 import { DropdownComponent, SliderComponent, TextComponent } from './SettingBlocks';
@@ -63,6 +64,9 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
   const [ollamaModel, setOllamaModel] = useState(plugin.settings.ollamaModel);
   const [ollamaBaseUrl, setOllamaBaseUrl] = useState(plugin.settings.ollamaBaseUrl);
 
+  // Built-in Command Toggles
+  const [enabledCommands, setEnabledCommands] = useState(plugin.settings.enabledCommands);
+
   // NOTE: When new settings are added, make sure to add them to saveAllSettings
   const saveAllSettings = async () => {
     plugin.settings.defaultModelDisplayName = defaultModelDisplayName;
@@ -111,6 +115,8 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
     plugin.settings.lmStudioBaseUrl = lmStudioBaseUrl;
     plugin.settings.ollamaModel = ollamaModel;
     plugin.settings.ollamaBaseUrl = ollamaBaseUrl;
+
+    plugin.settings.enabledCommands = enabledCommands;
 
     await plugin.saveSettings();
     await reloadPlugin();
@@ -193,6 +199,10 @@ export default function SettingsMain({ plugin, reloadPlugin }: SettingsMainProps
           onChange={async (value) => {
             setContextTurns(value);
           }}
+        />
+        <CommandToggleSettings
+          enabledCommands={enabledCommands}
+          setEnabledCommands={setEnabledCommands}
         />
       </div>
 


### PR DESCRIPTION
Now many non-essential built-in Copilot commands can be toggled off to reduce clutter

<img width="599" alt="SCR-20240810-bbxx" src="https://github.com/user-attachments/assets/654bcc0d-d40e-47e6-975e-c51a39e5eb8b">
