### PR TITLE
Add LM studio embedding support

### DIFF
--- a/src/LLMProviders/embeddingManager.ts
+++ b/src/LLMProviders/embeddingManager.ts
@@ -2,6 +2,9 @@
 import { LangChainParams } from "@/aiParams";
 import {
   EMBEDDING_MODEL_TO_PROVIDERS,
+  EmbeddingModels,
+  LM_STUDIO_BGE_LARGE_EN_V1_5,
+  LM_STUDIO_NOMIC_EMBED_TEXT_V1_5,
   ModelProviders,
   NOMIC_EMBED_TEXT,
 } from "@/constants";
@@ -130,6 +133,19 @@ export default class EmbeddingManager {
             : {}),
           // TODO: Add custom ollama embedding model setting once they have other models
           model: NOMIC_EMBED_TEXT,
+        });
+      case ModelProviders.LM_STUDIO:
+        return new ProxyOpenAIEmbeddings({
+          openAIApiKey: "lm-studio",
+          ...(this.langChainParams.lmStudioBaseUrl
+            ? { baseUrl: this.langChainParams.lmStudioBaseUrl }
+            : {}),
+          // TODO: Add custom LM Studio embedding model setting once they have other models
+          model:
+            this.langChainParams.embeddingModel ==
+            EmbeddingModels.LM_STUDIO_NOMIC_EMBED_TEXT_V1_5
+              ? LM_STUDIO_NOMIC_EMBED_TEXT_V1_5
+              : LM_STUDIO_BGE_LARGE_EN_V1_5,
         });
       default:
         console.error(

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -112,7 +112,10 @@ export enum EmbeddingModels {
   OPENAI_EMBEDDING_LARGE = "text-embedding-3-large",
   AZURE_OPENAI = "azure-openai",
   COHEREAI = "cohereai",
-  OLLAMA_NOMIC = "ollama-nomic-embed-text",
+  OLLAMA_NOMIC = "ollama/nomic-embed-text (local API)",
+  // LM STUDIO Embedding Models do not support configurable context length yet
+  LM_STUDIO_NOMIC_EMBED_TEXT_V1_5 = "lmstudio/nomic-embed-text-v1.5-GGUF (local API)",
+  LM_STUDIO_BGE_LARGE_EN_V1_5 = "lmstudio/bge-large-en-v1.5-gguf (local API)", // only 512 context length
 }
 
 export const EMBEDDING_MODEL_TO_PROVIDERS: Record<string, string> = {
@@ -122,10 +125,16 @@ export const EMBEDDING_MODEL_TO_PROVIDERS: Record<string, string> = {
   [EmbeddingModels.AZURE_OPENAI]: ModelProviders.AZURE_OPENAI,
   [EmbeddingModels.COHEREAI]: ModelProviders.COHEREAI,
   [EmbeddingModels.OLLAMA_NOMIC]: ModelProviders.OLLAMA,
+  [EmbeddingModels.LM_STUDIO_NOMIC_EMBED_TEXT_V1_5]: ModelProviders.LM_STUDIO,
+  [EmbeddingModels.LM_STUDIO_BGE_LARGE_EN_V1_5]: ModelProviders.LM_STUDIO,
 };
 
 // Embedding Models
 export const NOMIC_EMBED_TEXT = "nomic-embed-text";
+export const LM_STUDIO_NOMIC_EMBED_TEXT_V1_5 =
+  "nomic-ai/nomic-embed-text-v1.5-GGUF";
+export const LM_STUDIO_BGE_LARGE_EN_V1_5 =
+  "CompendiumLabs/bge-large-en-v1.5-gguf";
 // export const DISTILBERT_NLI = 'sentence-transformers/distilbert-base-nli-mean-tokens';
 // export const INSTRUCTOR_XL = 'hkunlp/instructor-xl'; // Inference API is off for this
 // export const MPNET_V2 = 'sentence-transformers/all-mpnet-base-v2'; // Inference API returns 400

--- a/src/langchainWrappers.ts
+++ b/src/langchainWrappers.ts
@@ -23,7 +23,7 @@ export class ProxyOpenAIEmbeddings extends OpenAIEmbeddings {
     // Reinitialize the client with the updated clientConfig
     this["client"] = new OpenAI({
       ...this["clientConfig"],
-      baseURL: fields.openAIEmbeddingProxyBaseUrl,
+      baseURL: fields.baseUrl || fields.openAIEmbeddingProxyBaseUrl,
     });
   }
 }


### PR DESCRIPTION
Fixes #408.

<img width="848" alt="SCR-20240814-stke" src="https://github.com/user-attachments/assets/ffba68d3-871a-411a-8686-91e6296fadb0">

However, the answer quality is quite problematic. It seems LM Studio only support these 2 embedding models and the context length is fixed to 512, which won't work for the current setting.

Found a bug along the way: debug info not showing the correct chat model when setting to lm studio then switch to other models.