### PR TITLE
Add embedding local proxy for cors issue WIP

### DIFF
--- a/src/LLMProviders/chainManager.ts
+++ b/src/LLMProviders/chainManager.ts
@@ -152,7 +152,8 @@ export default class ChainManager {
     if (chainType === ChainType.LONG_NOTE_QA_CHAIN || chainType === ChainType.VAULT_QA_CHAIN) {
       this.embeddingsManager = EmbeddingsManager.getInstance(
         this.langChainParams,
-        this.encryptionService
+        this.encryptionService,
+        this.settings
       );
     }
 

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -60,6 +60,7 @@ export interface LangChainParams {
   lmStudioBaseUrl: string;
   openAIProxyBaseUrl?: string;
   useOpenAILocalProxy?: boolean;
+  useOpenAIEmbeddingLocalProxy?: boolean;
   openAIProxyModelName?: string;
   openAIEmbeddingProxyBaseUrl?: string;
   openAIEmbeddingProxyModelName?: string;

--- a/src/components/ChatComponents/ChatIcons.tsx
+++ b/src/components/ChatComponents/ChatIcons.tsx
@@ -57,21 +57,13 @@ const ChatIcons: React.FC<ChatIconsProps> = ({
     // Start proxy server based on the selected model & settings
     const proxyServerURL = proxyServer.getProxyURL(selectedModel);
     if (proxyServerURL) {
-      await proxyServer.startProxyServer(
-        proxyServerURL,
-        selectedModel !== ChatModelDisplayNames.CLAUDE
-      );
-    } else {
-      await proxyServer.stopProxyServer();
+      await proxyServer.startChatProxyServer(proxyServerURL);
     }
   };
 
   useEffect(() => {
     const startProxyServerForClaude = async (proxyServerURL: string) => {
-      await proxyServer.startProxyServer(
-        proxyServerURL,
-        currentModel !== ChatModelDisplayNames.CLAUDE
-      );
+      await proxyServer.startChatProxyServer(proxyServerURL);
     };
 
     // Call the function on component mount
@@ -82,7 +74,7 @@ const ChatIcons: React.FC<ChatIconsProps> = ({
 
     // Cleanup function to stop the proxy server when the component unmounts
     return () => {
-      proxyServer.stopProxyServer().catch(console.error);
+      proxyServer.stopChatProxyServer().catch(console.error);
     };
   }, []);
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -141,6 +141,7 @@ export const VAULT_VECTOR_STORE_STRATEGIES = [
 ];
 
 export const PROXY_SERVER_PORT = 53001;
+export const EMBEDDING_PROXY_SERVER_PORT = 53002;
 
 export const COMMAND_IDS = {
   FIX_GRAMMAR: "fix-grammar-prompt",
@@ -190,6 +191,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   useOpenAILocalProxy: false,
   openAIProxyModelName: "",
   openAIEmbeddingProxyBaseUrl: "",
+  useOpenAIEmbeddingLocalProxy: false,
   openAIEmbeddingProxyModelName: "",
   ollamaModel: "llama2",
   ollamaBaseUrl: "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import {
   CHAT_VIEWTYPE,
   DEFAULT_SETTINGS,
   DEFAULT_SYSTEM_PROMPT,
+  EMBEDDING_PROXY_SERVER_PORT,
   PROXY_SERVER_PORT,
   VAULT_VECTOR_STORE_STRATEGY,
 } from "@/constants";
@@ -50,7 +51,11 @@ export default class CopilotPlugin extends Plugin {
 
   async onload(): Promise<void> {
     await this.loadSettings();
-    this.proxyServer = new ProxyServer(this.settings, PROXY_SERVER_PORT);
+    this.proxyServer = ProxyServer.getInstance(
+      this.settings,
+      PROXY_SERVER_PORT,
+      EMBEDDING_PROXY_SERVER_PORT
+    );
     this.addSettingTab(new CopilotSettingTab(this.app, this));
     // Always have one instance of sharedState and chainManager in the plugin
     this.sharedState = new SharedState();
@@ -71,7 +76,11 @@ export default class CopilotPlugin extends Plugin {
       await this.saveSettings();
     }
 
-    this.embeddingsManager = EmbeddingsManager.getInstance(langChainParams, this.encryptionService);
+    this.embeddingsManager = EmbeddingsManager.getInstance(
+      langChainParams,
+      this.encryptionService,
+      this.settings
+    );
     this.dbPrompts = new PouchDB<CustomPrompt>("copilot_custom_prompts");
 
     this.registerView(CHAT_VIEWTYPE, (leaf: WorkspaceLeaf) => new CopilotView(leaf, this));

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -31,6 +31,7 @@ export interface CopilotSettings {
   userSystemPrompt: string;
   openAIProxyBaseUrl: string;
   useOpenAILocalProxy: boolean;
+  useOpenAIEmbeddingLocalProxy: boolean;
   openAIProxyModelName: string;
   openAIEmbeddingProxyBaseUrl: string;
   openAIEmbeddingProxyModelName: string;

--- a/src/settings/components/AdvancedSettings.tsx
+++ b/src/settings/components/AdvancedSettings.tsx
@@ -10,6 +10,8 @@ interface AdvancedSettingsProps {
   setOpenAIProxyModelName: (value: string) => void;
   openAIEmbeddingProxyBaseUrl: string;
   setOpenAIEmbeddingProxyBaseUrl: (value: string) => void;
+  useOpenAIEmbeddingLocalProxy: boolean;
+  setUseOpenAIEmbeddingLocalProxy: (value: boolean) => void;
   openAIEmbeddingProxyModelName: string;
   setOpenAIEmbeddingProxyModelName: (value: string) => void;
   userSystemPrompt: string;
@@ -25,6 +27,8 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
   setOpenAIProxyModelName,
   openAIEmbeddingProxyBaseUrl,
   setOpenAIEmbeddingProxyBaseUrl,
+  useOpenAIEmbeddingLocalProxy,
+  setUseOpenAIEmbeddingLocalProxy,
   openAIEmbeddingProxyModelName,
   setOpenAIEmbeddingProxyModelName,
   userSystemPrompt,
@@ -69,6 +73,12 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({
         value={openAIEmbeddingProxyBaseUrl}
         onChange={setOpenAIEmbeddingProxyBaseUrl}
         placeholder="https://openai.example.com/v1"
+      />
+      <ToggleComponent
+        name="Use local proxy server for OpenAI Embedding"
+        description="Enable if your embedding proxy base URL results in CORS errors."
+        value={useOpenAIEmbeddingLocalProxy}
+        onChange={setUseOpenAIEmbeddingLocalProxy}
       />
       <TextComponent
         name="OpenAI Embedding Proxy Model Name"

--- a/src/settings/components/SettingsMain.tsx
+++ b/src/settings/components/SettingsMain.tsx
@@ -70,6 +70,9 @@ const SettingsMain: React.FC<{ plugin: CopilotPlugin; reloadPlugin: () => Promis
         setOpenAIEmbeddingProxyBaseUrl={(value) =>
           updateSettings({ openAIEmbeddingProxyBaseUrl: value })
         }
+        setUseOpenAIEmbeddingLocalProxy={(value) =>
+          updateSettings({ useOpenAIEmbeddingLocalProxy: value })
+        }
         setOpenAIEmbeddingProxyModelName={(value) =>
           updateSettings({ openAIEmbeddingProxyModelName: value })
         }


### PR DESCRIPTION
Fixes #528 

Embedding proxy needs its own toggle. 

TODO: Now these 3rd party overrides don't have a place to add their own API keys, they are all using the OpenAI API key field at the moment. This needs to change when Cursor style setting is introduced #524.