### PR TITLE
Save and load conversation with autosave option

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -54,6 +54,7 @@ interface ChatProps {
   emitter: EventTarget;
   getChatVisibility: () => Promise<boolean>;
   defaultSaveFolder: string;
+  onSaveChat: (saveAsNote: () => Promise<void>) => void;
   plugin: CopilotPlugin;
   debug: boolean;
 }
@@ -65,6 +66,7 @@ const Chat: React.FC<ChatProps> = ({
   emitter,
   getChatVisibility,
   defaultSaveFolder,
+  onSaveChat,
   plugin,
   debug,
 }) => {
@@ -580,6 +582,13 @@ ${chatContent}`;
     new Notice("Message inserted into the active note.");
   };
 
+  // Expose handleSaveAsNote to parent
+  useEffect(() => {
+    if (onSaveChat) {
+      onSaveChat(handleSaveAsNote);
+    }
+  }, [onSaveChat]);
+
   return (
     <div className="chat-container">
       <ChatMessages
@@ -597,7 +606,10 @@ ${chatContent}`;
           setCurrentModelKey={setModelKey}
           currentChain={currentChain}
           setCurrentChain={setChain}
-          onNewChat={() => {
+          onNewChat={async () => {
+            if (settings.autosaveChat && chatHistory.length > 0) {
+              await handleSaveAsNote();
+            }
             clearMessages();
             clearChatMemory();
             clearCurrentAiMessage();

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -192,6 +192,7 @@ ${chatContent}`;
       const newNote: TFile = await app.vault.create(noteFileName, noteContentWithTimestamp);
       const leaf = app.workspace.getLeaf();
       leaf.openFile(newNote);
+      new Notice(`Chat saved as note in folder: ${defaultSaveFolder}.`);
     } catch (error) {
       console.error("Error saving chat as note:", error);
     }

--- a/src/components/CopilotView.tsx
+++ b/src/components/CopilotView.tsx
@@ -10,14 +10,15 @@ import * as React from "react";
 import { Root, createRoot } from "react-dom/client";
 
 export default class CopilotView extends ItemView {
-  private sharedState: SharedState;
   private chainManager: ChainManager;
   private root: Root | null = null;
   private settings: CopilotSettings;
   private defaultSaveFolder: string;
+  private handleSaveAsNote: (() => Promise<void>) | null = null;
   private debug = false;
+  sharedState: SharedState;
   emitter: EventTarget;
-  userSystemPrompt = '';
+  userSystemPrompt = "";
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -75,10 +76,19 @@ export default class CopilotView extends ItemView {
             defaultSaveFolder={this.defaultSaveFolder}
             plugin={this.plugin}
             debug={this.debug}
+            onSaveChat={(saveFunction) => {
+              this.handleSaveAsNote = saveFunction;
+            }}
           />
         </React.StrictMode>
       </AppContext.Provider>
     );
+  }
+
+  async saveChat(): Promise<void> {
+    if (this.handleSaveAsNote) {
+      await this.handleSaveAsNote();
+    }
   }
 
   async onClose(): Promise<void> {

--- a/src/components/LoadChatHistoryModal.tsx
+++ b/src/components/LoadChatHistoryModal.tsx
@@ -1,0 +1,34 @@
+import { App, FuzzySuggestModal, TFile } from "obsidian";
+
+export class LoadChatHistoryModal extends FuzzySuggestModal<TFile> {
+  private onChooseFile: (file: TFile) => void;
+
+  constructor(
+    app: App,
+    private chatFiles: TFile[],
+    onChooseFile: (file: TFile) => void
+  ) {
+    super(app);
+    this.onChooseFile = onChooseFile;
+  }
+
+  getItems(): TFile[] {
+    return this.chatFiles;
+  }
+
+  getItemText(file: TFile): string {
+    const [title, timestamp] = file.basename.split("@");
+    if (timestamp) {
+      const formattedTimestamp = timestamp
+        .replace(/_/g, "/")
+        .replace(/(\d{4}\/\d{2}\/\d{2})\//, "$1 ")
+        .replace(/(\d{2})\/(\d{2})\/(\d{2})$/, "$1:$2:$3");
+      return `${title.replace(/_/g, " ").trim()} - ${formattedTimestamp}`;
+    }
+    return file.basename;
+  }
+
+  onChooseItem(file: TFile, evt: MouseEvent | KeyboardEvent) {
+    this.onChooseFile(file);
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -208,6 +208,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   openAIEmbeddingProxyBaseUrl: "",
   stream: true,
   defaultSaveFolder: "copilot-conversations",
+  autosaveChat: true,
   indexVaultToVectorStore: VAULT_VECTOR_STORE_STRATEGY.ON_MODE_SWITCH,
   qaExclusionPaths: "",
   chatNoteContextPath: "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -402,6 +402,15 @@ export default class CopilotPlugin extends Plugin {
     this.registerEvent(this.app.workspace.on("editor-menu", this.handleContextMenu));
   }
 
+  async autosaveCurrentChat() {
+    if (this.settings.autosaveChat) {
+      const chatView = this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE)[0]?.view as CopilotView;
+      if (chatView && chatView.sharedState.chatHistory.length > 0) {
+        await chatView.saveChat();
+      }
+    }
+  }
+
   private getVaultIdentifier(): string {
     const vaultName = this.app.vault.getName();
     return MD5(vaultName).toString();

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,19 +8,22 @@ import { AdhocPromptModal } from "@/components/AdhocPromptModal";
 import { ChatNoteContextModal } from "@/components/ChatNoteContextModal";
 import CopilotView from "@/components/CopilotView";
 import { ListPromptModal } from "@/components/ListPromptModal";
+import { LoadChatHistoryModal } from "@/components/LoadChatHistoryModal";
 import { QAExclusionModal } from "@/components/QAExclusionModal";
 import {
+  AI_SENDER,
   BUILTIN_CHAT_MODELS,
   BUILTIN_EMBEDDING_MODELS,
   CHAT_VIEWTYPE,
   DEFAULT_SETTINGS,
   DEFAULT_SYSTEM_PROMPT,
+  USER_SENDER,
   VAULT_VECTOR_STORE_STRATEGY,
 } from "@/constants";
 import { CustomPrompt } from "@/customPromptProcessor";
 import EncryptionService from "@/encryptionService";
 import { CopilotSettingTab, CopilotSettings } from "@/settings/SettingsPage";
-import SharedState from "@/sharedState";
+import SharedState, { ChatMessage } from "@/sharedState";
 import {
   areEmbeddingModelsSame,
   getAllNotesContent,
@@ -29,7 +32,16 @@ import {
 } from "@/utils";
 import VectorDBManager, { VectorStoreDocument } from "@/vectorDBManager";
 import { MD5 } from "crypto-js";
-import { Editor, MarkdownView, Menu, Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
+import {
+  Editor,
+  MarkdownView,
+  Menu,
+  Notice,
+  Plugin,
+  TFile,
+  TFolder,
+  WorkspaceLeaf,
+} from "obsidian";
 import PouchDB from "pouchdb-browser";
 
 export default class CopilotPlugin extends Plugin {
@@ -361,6 +373,14 @@ export default class CopilotPlugin extends Plugin {
       },
     });
 
+    this.addCommand({
+      id: "load-copilot-chat-conversation",
+      name: "Load Copilot Chat conversation",
+      callback: () => {
+        this.loadCopilotChatHistory();
+      },
+    });
+
     this.registerEvent(
       this.app.vault.on("delete", (file) => {
         const docHash = VectorDBManager.getDocumentHash(file.path);
@@ -562,7 +582,7 @@ export default class CopilotPlugin extends Plugin {
     leaves.length > 0 ? this.deactivateView() : this.activateView();
   }
 
-  async activateView() {
+  async activateView(): Promise<void> {
     this.app.workspace.detachLeavesOfType(CHAT_VIEWTYPE);
     this.activateViewPromise = this.app.workspace.getRightLeaf(false).setViewState({
       type: CHAT_VIEWTYPE,
@@ -740,5 +760,64 @@ export default class CopilotPlugin extends Plugin {
 
   getEncryptionService(): EncryptionService {
     return this.encryptionService;
+  }
+
+  async loadCopilotChatHistory() {
+    const chatFiles = await this.getChatHistoryFiles();
+    if (chatFiles.length === 0) {
+      new Notice("No chat history found.");
+      return;
+    }
+    new LoadChatHistoryModal(this.app, chatFiles, this.loadChatHistory.bind(this)).open();
+  }
+
+  async getChatHistoryFiles(): Promise<TFile[]> {
+    const folder = this.app.vault.getAbstractFileByPath(this.settings.defaultSaveFolder);
+    if (!(folder instanceof TFolder)) {
+      return [];
+    }
+    const files = await this.app.vault.getMarkdownFiles();
+    return files.filter((file) => file.path.startsWith(folder.path));
+  }
+
+  async loadChatHistory(file: TFile) {
+    const content = await this.app.vault.read(file);
+    const messages = this.parseChatContent(content);
+    this.sharedState.clearChatHistory();
+    messages.forEach((message) => this.sharedState.addMessage(message));
+    this.activateView();
+  }
+
+  parseChatContent(content: string): ChatMessage[] {
+    const lines = content.split("\n");
+    const messages: ChatMessage[] = [];
+    let currentSender = "";
+    let currentMessage = "";
+
+    for (const line of lines) {
+      if (line.startsWith("**user**:") || line.startsWith("**ai**:")) {
+        if (currentSender && currentMessage) {
+          messages.push({
+            sender: currentSender === USER_SENDER ? USER_SENDER : AI_SENDER,
+            message: currentMessage.trim(),
+            isVisible: true,
+          });
+        }
+        currentSender = line.startsWith("**user**:") ? USER_SENDER : AI_SENDER;
+        currentMessage = line.substring(line.indexOf(":") + 1).trim();
+      } else {
+        currentMessage += "\n" + line;
+      }
+    }
+
+    if (currentSender && currentMessage) {
+      messages.push({
+        sender: currentSender === USER_SENDER ? USER_SENDER : AI_SENDER,
+        message: currentMessage.trim(),
+        isVisible: true,
+      });
+    }
+
+    return messages;
   }
 }

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -1,4 +1,6 @@
 import { CustomModel } from "@/aiParams";
+import CopilotView from "@/components/CopilotView";
+import { CHAT_VIEWTYPE } from "@/constants";
 import CopilotPlugin from "@/main";
 import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import React from "react";
@@ -29,6 +31,7 @@ export interface CopilotSettings {
   openAIEmbeddingProxyBaseUrl: string;
   stream: boolean;
   defaultSaveFolder: string;
+  autosaveChat: boolean;
   indexVaultToVectorStore: string;
   chatNoteContextPath: string;
   chatNoteContextTags: string[];
@@ -54,6 +57,12 @@ export class CopilotSettingTab extends PluginSettingTab {
     try {
       // Save the settings before reloading
       await this.plugin.saveSettings();
+
+      // Autosave the current chat before reloading
+      const chatView = this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE)[0]?.view as CopilotView;
+      if (chatView && this.plugin.settings.autosaveChat) {
+        await this.plugin.autosaveCurrentChat();
+      }
 
       // Reload the plugin
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/settings/components/GeneralSettings.tsx
+++ b/src/settings/components/GeneralSettings.tsx
@@ -4,7 +4,12 @@ import EncryptionService from "@/encryptionService";
 import React from "react";
 import { useSettingsContext } from "../contexts/SettingsContext";
 import CommandToggleSettings from "./CommandToggleSettings";
-import { ModelSettingsComponent, SliderComponent, TextComponent } from "./SettingBlocks";
+import {
+  ModelSettingsComponent,
+  SliderComponent,
+  TextComponent,
+  ToggleComponent,
+} from "./SettingBlocks";
 
 interface GeneralSettingsProps {
   getLangChainParams: () => LangChainParams;
@@ -57,6 +62,12 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
         placeholder="copilot-conversations"
         value={settings.defaultSaveFolder}
         onChange={(value) => updateSettings({ defaultSaveFolder: value })}
+      />
+      <ToggleComponent
+        name="Autosave Chat"
+        description="Automatically save the chat when starting a new one or when the plugin reloads"
+        value={settings.autosaveChat}
+        onChange={(value) => updateSettings({ autosaveChat: value })}
       />
       <h6>
         Please be mindful of the number of tokens and context conversation turns you set here, as

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -207,7 +207,11 @@ export const formatDateTime = (now: Date, timezone: "local" | "utc" = "local") =
     formattedDateTime.utc();
   }
 
-  return formattedDateTime.format("YYYY_MM_DD-HH_mm_ss");
+  return {
+    fileName: formattedDateTime.format("YYYY_MM_DD_HH_mm_ss"),
+    display: formattedDateTime.format("YYYY/MM/DD HH:mm:ss"),
+    epoch: formattedDateTime.valueOf(),
+  };
 };
 
 export async function getFileContent(file: TFile, vault: Vault): Promise<string | null> {


### PR DESCRIPTION
Closes #268 

- [x] Have command to load conversations
  - *Load Copilot Chat conversation*, select one, loads from md file
- [x] Setting for automatically save conversation to markdown
  - Whenever new chat is clicked, save the conversation
  - When plugin reloads, save the current conversation

<img width="723" alt="SCR-20240905-oqih" src="https://github.com/user-attachments/assets/b3591c09-2ef4-4880-b782-10a274e03a6e">
<img width="678" alt="SCR-20240905-oqlr" src="https://github.com/user-attachments/assets/0bd7e5a3-461e-4a41-8b15-bec2a9b7126c">
