### PR TITLE
Use markdown for custom prompt, move off PouchDB

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -531,7 +531,7 @@ ${chatContent}`;
     []
   );
 
-  const customPromptProcessor = CustomPromptProcessor.getInstance(app.vault);
+  const customPromptProcessor = CustomPromptProcessor.getInstance(app.vault, settings);
   useEffect(
     createEffect(
       "applyCustomPrompt",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -209,6 +209,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   stream: true,
   defaultSaveFolder: "copilot-conversations",
   autosaveChat: true,
+  customPromptsFolder: "copilot-custom-prompts",
   indexVaultToVectorStore: VAULT_VECTOR_STORE_STRATEGY.ON_MODE_SWITCH,
   qaExclusionPaths: "",
   chatNoteContextPath: "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ import {
   USER_SENDER,
   VAULT_VECTOR_STORE_STRATEGY,
 } from "@/constants";
-import { CustomPrompt } from "@/customPromptProcessor";
+import { CustomPrompt, CustomPromptDB, CustomPromptProcessor } from "@/customPromptProcessor";
 import EncryptionService from "@/encryptionService";
 import { CopilotSettingTab, CopilotSettings } from "@/settings/SettingsPage";
 import SharedState, { ChatMessage } from "@/sharedState";
@@ -114,14 +114,15 @@ export default class CopilotPlugin extends Plugin {
 
     registerBuiltInCommands(this);
 
+    const promptProcessor = CustomPromptProcessor.getInstance(this.app.vault, this.settings);
+
     this.addCommand({
       id: "add-custom-prompt",
       name: "Add custom prompt",
       callback: () => {
         new AddPromptModal(this.app, async (title: string, prompt: string) => {
           try {
-            // Save the prompt to the database
-            await this.dbPrompts.put({ _id: title, prompt: prompt });
+            await promptProcessor.savePrompt(title, prompt);
             new Notice("Custom prompt saved successfully.");
           } catch (e) {
             new Notice("Error saving custom prompt. Please check if the title already exists.");
@@ -134,30 +135,26 @@ export default class CopilotPlugin extends Plugin {
     this.addCommand({
       id: "apply-custom-prompt",
       name: "Apply custom prompt",
-      callback: () => {
-        this.fetchPromptTitles().then((promptTitles: string[]) => {
-          new ListPromptModal(this.app, promptTitles, async (promptTitle: string) => {
-            if (!promptTitle) {
-              new Notice("Please select a prompt title.");
+      callback: async () => {
+        const prompts = await promptProcessor.getAllPrompts();
+        const promptTitles = prompts.map((p) => p.title);
+        new ListPromptModal(this.app, promptTitles, async (promptTitle: string) => {
+          if (!promptTitle) {
+            new Notice("Please select a prompt title.");
+            return;
+          }
+          try {
+            const prompt = await promptProcessor.getPrompt(promptTitle);
+            if (!prompt) {
+              new Notice(`No prompt found with the title "${promptTitle}".`);
               return;
             }
-            try {
-              const doc = (await this.dbPrompts.get(promptTitle)) as CustomPrompt;
-              if (!doc.prompt) {
-                new Notice(`No prompt found with the title "${promptTitle}".`);
-                return;
-              }
-              this.processCustomPrompt("applyCustomPrompt", doc.prompt);
-            } catch (err) {
-              if (err.name === "not_found") {
-                new Notice(`No prompt found with the title "${promptTitle}".`);
-              } else {
-                console.error(err);
-                new Notice("An error occurred.");
-              }
-            }
-          }).open();
-        });
+            this.processCustomPrompt("applyCustomPrompt", prompt.content);
+          } catch (err) {
+            console.error(err);
+            new Notice("An error occurred.");
+          }
+        }).open();
       },
     });
 
@@ -186,7 +183,8 @@ export default class CopilotPlugin extends Plugin {
           return true;
         }
 
-        this.fetchPromptTitles().then((promptTitles: string[]) => {
+        promptProcessor.getAllPrompts().then((prompts) => {
+          const promptTitles = prompts.map((p) => p.title);
           new ListPromptModal(this.app, promptTitles, async (promptTitle: string) => {
             if (!promptTitle) {
               new Notice("Please select a prompt title.");
@@ -194,20 +192,11 @@ export default class CopilotPlugin extends Plugin {
             }
 
             try {
-              const doc = await this.dbPrompts.get(promptTitle);
-              if (doc._rev) {
-                await this.dbPrompts.remove(doc as PouchDB.Core.RemoveDocument);
-                new Notice(`Prompt "${promptTitle}" has been deleted.`);
-              } else {
-                new Notice(`Failed to delete prompt "${promptTitle}": No revision found.`);
-              }
+              await promptProcessor.deletePrompt(promptTitle);
+              new Notice(`Prompt "${promptTitle}" has been deleted.`);
             } catch (err) {
-              if (err.name === "not_found") {
-                new Notice(`No prompt found with the title "${promptTitle}".`);
-              } else {
-                console.error(err);
-                new Notice("An error occurred while deleting the prompt.");
-              }
+              console.error(err);
+              new Notice("An error occurred while deleting the prompt.");
             }
           }).open();
         });
@@ -224,7 +213,8 @@ export default class CopilotPlugin extends Plugin {
           return true;
         }
 
-        this.fetchPromptTitles().then((promptTitles: string[]) => {
+        promptProcessor.getAllPrompts().then((prompts) => {
+          const promptTitles = prompts.map((p) => p.title);
           new ListPromptModal(this.app, promptTitles, async (promptTitle: string) => {
             if (!promptTitle) {
               new Notice("Please select a prompt title.");
@@ -232,31 +222,24 @@ export default class CopilotPlugin extends Plugin {
             }
 
             try {
-              const doc = (await this.dbPrompts.get(promptTitle)) as CustomPrompt;
-              if (doc.prompt) {
+              const prompt = await promptProcessor.getPrompt(promptTitle);
+              if (prompt) {
                 new AddPromptModal(
                   this.app,
-                  (title: string, newPrompt: string) => {
-                    this.dbPrompts.put({
-                      ...doc,
-                      prompt: newPrompt,
-                    });
+                  async (title: string, newPrompt: string) => {
+                    await promptProcessor.updatePrompt(title, newPrompt);
                     new Notice(`Prompt "${title}" has been updated.`);
                   },
-                  doc._id,
-                  doc.prompt,
+                  prompt.title,
+                  prompt.content,
                   true
                 ).open();
               } else {
                 new Notice(`No prompt found with the title "${promptTitle}".`);
               }
             } catch (err) {
-              if (err.name === "not_found") {
-                new Notice(`No prompt found with the title "${promptTitle}".`);
-              } else {
-                console.error(err);
-                new Notice("An error occurred.");
-              }
+              console.error(err);
+              new Notice("An error occurred.");
             }
           }).open();
         });
@@ -421,7 +404,7 @@ export default class CopilotPlugin extends Plugin {
   }
 
   async dumpCustomPrompts(): Promise<void> {
-    const folder = this.settings.customPromptsFolder || "custom_prompts";
+    const folder = this.settings.customPromptsFolder || DEFAULT_SETTINGS.customPromptsFolder;
 
     try {
       // Ensure the folder exists
@@ -433,7 +416,7 @@ export default class CopilotPlugin extends Plugin {
       const response = await this.dbPrompts.allDocs({ include_docs: true });
 
       for (const row of response.rows) {
-        const doc = row.doc as CustomPrompt;
+        const doc = row.doc as CustomPromptDB;
         if (doc && doc._id && doc.prompt) {
           const fileName = `${folder}/${doc._id}.md`;
           await this.app.vault.create(fileName, doc.prompt);
@@ -719,11 +702,6 @@ export default class CopilotPlugin extends Plugin {
     this.mergeAllActiveModelsWithExisting();
 
     await this.saveData(this.settings);
-  }
-
-  async fetchPromptTitles(): Promise<string[]> {
-    const response = await this.dbPrompts.allDocs({ include_docs: true });
-    return response.rows.map((row) => (row.doc as CustomPrompt)?._id).filter(Boolean) as string[];
   }
 
   async countTotalTokens(): Promise<number> {

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -32,6 +32,7 @@ export interface CopilotSettings {
   stream: boolean;
   defaultSaveFolder: string;
   autosaveChat: boolean;
+  customPromptsFolder: string;
   indexVaultToVectorStore: string;
   chatNoteContextPath: string;
   chatNoteContextTags: string[];

--- a/src/settings/components/GeneralSettings.tsx
+++ b/src/settings/components/GeneralSettings.tsx
@@ -69,6 +69,13 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
         value={settings.autosaveChat}
         onChange={(value) => updateSettings({ autosaveChat: value })}
       />
+      <TextComponent
+        name="Custom Prompts Folder Name"
+        description="The default folder name where custom prompts will be saved. Default is 'copilot-custom-prompts'"
+        placeholder="copilot-custom-prompts"
+        value={settings.customPromptsFolder}
+        onChange={(value) => updateSettings({ customPromptsFolder: value })}
+      />
       <h6>
         Please be mindful of the number of tokens and context conversation turns you set here, as
         they will affect the cost of your API requests.

--- a/tests/customPromptProcessor.test.ts
+++ b/tests/customPromptProcessor.test.ts
@@ -1,4 +1,5 @@
 import { CustomPrompt, CustomPromptProcessor } from "@/customPromptProcessor";
+import { CopilotSettings } from "@/settings/SettingsPage";
 
 // Mocking Obsidian Vault
 const mockVault = {
@@ -15,13 +16,13 @@ describe("CustomPromptProcessor", () => {
     jest.clearAllMocks();
 
     // Create an instance of CustomPromptProcessor with mocked dependencies
-    processor = CustomPromptProcessor.getInstance(mockVault);
+    processor = CustomPromptProcessor.getInstance(mockVault, {} as CopilotSettings);
   });
 
   it("should add 1 context and selectedText", async () => {
     const doc: CustomPrompt = {
-      _id: "test-prompt",
-      prompt: "This is a {variable} and {}.",
+      title: "test-prompt",
+      content: "This is a {variable} and {}.",
     };
     const selectedText = "here is some selected text 12345";
 
@@ -30,7 +31,7 @@ describe("CustomPromptProcessor", () => {
       .spyOn(processor, "extractVariablesFromPrompt")
       .mockResolvedValue(["here is the note content for note0"]);
 
-    const result = await processor.processCustomPrompt(doc.prompt, selectedText);
+    const result = await processor.processCustomPrompt(doc.content, selectedText);
 
     expect(result).toContain("This is a {variable} and {selectedText}.");
     expect(result).toContain("here is some selected text 12345");
@@ -39,8 +40,8 @@ describe("CustomPromptProcessor", () => {
 
   it("should add 2 context and no selectedText", async () => {
     const doc: CustomPrompt = {
-      _id: "test-prompt",
-      prompt: "This is a {variable} and {var2}.",
+      title: "test-prompt",
+      content: "This is a {variable} and {var2}.",
     };
     const selectedText = "here is some selected text 12345";
 
@@ -49,7 +50,7 @@ describe("CustomPromptProcessor", () => {
       .spyOn(processor, "extractVariablesFromPrompt")
       .mockResolvedValue(["here is the note content for note0", "note content for note1"]);
 
-    const result = await processor.processCustomPrompt(doc.prompt, selectedText);
+    const result = await processor.processCustomPrompt(doc.content, selectedText);
 
     expect(result).toContain("This is a {variable} and {var2}.");
     expect(result).toContain("here is the note content for note0");
@@ -58,8 +59,8 @@ describe("CustomPromptProcessor", () => {
 
   it("should add 1 selectedText and no context", async () => {
     const doc: CustomPrompt = {
-      _id: "test-prompt",
-      prompt: "Rewrite the following text {}",
+      title: "test-prompt",
+      content: "Rewrite the following text {}",
     };
     const selectedText = "here is some selected text 12345";
 
@@ -68,7 +69,7 @@ describe("CustomPromptProcessor", () => {
       .spyOn(processor, "extractVariablesFromPrompt")
       .mockResolvedValue(["here is the note content for note0", "note content for note1"]);
 
-    const result = await processor.processCustomPrompt(doc.prompt, selectedText);
+    const result = await processor.processCustomPrompt(doc.content, selectedText);
 
     expect(result).toContain("Rewrite the following text {selectedText}");
     expect(result).toContain("here is some selected text 12345");
@@ -79,8 +80,8 @@ describe("CustomPromptProcessor", () => {
   // This is not an expected use case but it's possible
   it("should add 2 selectedText and no context", async () => {
     const doc: CustomPrompt = {
-      _id: "test-prompt",
-      prompt: "Rewrite the following text {} and {}",
+      title: "test-prompt",
+      content: "Rewrite the following text {} and {}",
     };
     const selectedText = "here is some selected text 12345";
 
@@ -89,7 +90,7 @@ describe("CustomPromptProcessor", () => {
       .spyOn(processor, "extractVariablesFromPrompt")
       .mockResolvedValue(["here is the note content for note0", "note content for note1"]);
 
-    const result = await processor.processCustomPrompt(doc.prompt, selectedText);
+    const result = await processor.processCustomPrompt(doc.content, selectedText);
 
     expect(result).toContain("Rewrite the following text {selectedText} and {selectedText}");
     expect(result).toContain("here is some selected text 12345");
@@ -99,15 +100,15 @@ describe("CustomPromptProcessor", () => {
 
   it("should handle prompts without variables", async () => {
     const doc: CustomPrompt = {
-      _id: "test-prompt",
-      prompt: "This is a test prompt with no variables.",
+      title: "test-prompt",
+      content: "This is a test prompt with no variables.",
     };
     const selectedText = "selected text";
 
     // Mock the extractVariablesFromPrompt method to return an empty array
     jest.spyOn(processor, "extractVariablesFromPrompt").mockResolvedValue([]);
 
-    const result = await processor.processCustomPrompt(doc.prompt, selectedText);
+    const result = await processor.processCustomPrompt(doc.content, selectedText);
 
     expect(result).toBe("This is a test prompt with no variables.\n\n");
   });


### PR DESCRIPTION
Fixes #591 

- [x] Setting for the custom prompts destination folder
- [x] Dumping custom prompt command from pouchdb to markdown
- [x]  Add/Edit/Apply/Delete custom prompts using markdown files instead of PouchDB
- [x] Stop loading from pouchdb, this way current users can't find their custom prompt so they are aware of this migration

<img width="758" alt="SCR-20240905-sihk" src="https://github.com/user-attachments/assets/04b6362e-b792-477b-893c-1c1d410e282c">
