### PR TITLE
Custom prompt support in chat

### DIFF
--- a/src/components/AddPromptModal.tsx
+++ b/src/components/AddPromptModal.tsx
@@ -43,6 +43,8 @@ export class AddPromptModal extends Modal {
       frag.createEl("br");
       frag.createEl("strong", { text: "- {[[Note Title]]} represents a note. " });
       frag.createEl("br");
+      frag.createEl("strong", { text: "- {activeNote} represents the active note. " });
+      frag.createEl("br");
       frag.createEl("strong", { text: "- {FolderPath} represents a folder of notes. " });
       frag.createEl("br");
       frag.createEl("strong", {

--- a/src/components/AdhocPromptModal.tsx
+++ b/src/components/AdhocPromptModal.tsx
@@ -19,6 +19,8 @@ export class AdhocPromptModal extends Modal {
       frag.createEl("br");
       frag.createEl("strong", { text: "- {[[Note Title]]} represents a note. " });
       frag.createEl("br");
+      frag.createEl("strong", { text: "- {activeNote} represents the active note. " });
+      frag.createEl("br");
       frag.createEl("strong", { text: "- {FolderPath} represents a folder of notes. " });
       frag.createEl("br");
       frag.createEl("strong", {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -16,12 +16,10 @@ import {
   createTranslateSelectionPrompt,
   eli5SelectionPrompt,
   emojifyPrompt,
-  extractNoteTitles,
   fixGrammarSpellingSelectionPrompt,
   formatDateTime,
   getFileContent,
   getFileName,
-  getNoteFileFromTitle,
   getNotesFromPath,
   getNotesFromTags,
   getSendChatContextNotesPrompt,
@@ -83,19 +81,8 @@ const Chat: React.FC<ChatProps> = ({
   const handleSendMessage = async () => {
     if (!inputMessage) return;
 
-    let processedUserMessage = inputMessage;
-    // If in Chat mode and user input has [[note title]]'s, append the note content
-    // below the original user message
-    if (currentChain === ChainType.LLM_CHAIN) {
-      const noteTitles = extractNoteTitles(inputMessage);
-      for (const noteTitle of noteTitles) {
-        const noteFile = await getNoteFileFromTitle(app.vault, noteTitle);
-        if (noteFile) {
-          const noteContent = await getFileContent(noteFile, app.vault);
-          processedUserMessage = `${processedUserMessage}\n\n[[${noteTitle}]]: \n${noteContent}`;
-        }
-      }
-    }
+    const customPromptProcessor = CustomPromptProcessor.getInstance(app.vault, settings);
+    const processedUserMessage = await customPromptProcessor.processCustomPrompt(inputMessage, "");
 
     const userMessage: ChatMessage = {
       message: inputMessage,

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -635,6 +635,8 @@ ${chatContent}`;
           getChatVisibility={getChatVisibility}
           isGenerating={loading}
           onStopGenerating={handleStopGenerating}
+          app={app}
+          settings={settings}
         />
       </div>
     </div>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -82,7 +82,11 @@ const Chat: React.FC<ChatProps> = ({
     if (!inputMessage) return;
 
     const customPromptProcessor = CustomPromptProcessor.getInstance(app.vault, settings);
-    const processedUserMessage = await customPromptProcessor.processCustomPrompt(inputMessage, "");
+    const processedUserMessage = await customPromptProcessor.processCustomPrompt(
+      inputMessage,
+      "",
+      app.workspace.getActiveFile() as TFile | undefined
+    );
 
     const userMessage: ChatMessage = {
       message: inputMessage,
@@ -528,7 +532,11 @@ ${chatContent}`;
         if (!customPrompt) {
           return selectedText;
         }
-        return await customPromptProcessor.processCustomPrompt(customPrompt, selectedText);
+        return await customPromptProcessor.processCustomPrompt(
+          customPrompt,
+          selectedText,
+          app.workspace.getActiveFile() as TFile | undefined
+        );
       },
       { isVisible: debug, ignoreSystemMessage: true, custom_temperature: 0.1 }
     ),
@@ -542,7 +550,11 @@ ${chatContent}`;
         if (!customPrompt) {
           return selectedText;
         }
-        return await customPromptProcessor.processCustomPrompt(customPrompt, selectedText);
+        return await customPromptProcessor.processCustomPrompt(
+          customPrompt,
+          selectedText,
+          app.workspace.getActiveFile() as TFile | undefined
+        );
       },
       { isVisible: debug, ignoreSystemMessage: true, custom_temperature: 0.1 }
     ),

--- a/src/components/ChatComponents/ChatInput.tsx
+++ b/src/components/ChatComponents/ChatInput.tsx
@@ -75,9 +75,12 @@ const ChatInput: React.FC<ChatInputProps> = ({
     const lineHeight = 20;
     const maxHeight = 200;
     const minRows = 1;
+    const charactersPerRow = 40;
 
+    const newlineRows = text.split("\n").length;
+    const characterRows = Math.ceil(text.length / charactersPerRow);
     const rowsNeeded = Math.min(
-      Math.max(text.split("\n").length, minRows),
+      Math.max(newlineRows, characterRows, minRows),
       Math.floor(maxHeight / lineHeight)
     );
     setRows(rowsNeeded);

--- a/src/components/ChatComponents/ChatInput.tsx
+++ b/src/components/ChatComponents/ChatInput.tsx
@@ -1,5 +1,9 @@
+import { ListPromptModal } from "@/components/ListPromptModal";
 import { NoteTitleModal } from "@/components/NoteTitleModal";
+import { CustomPromptProcessor } from "@/customPromptProcessor";
+import { CopilotSettings } from "@/settings/SettingsPage";
 import { IconPlayerStopFilled, IconSend } from "@tabler/icons-react";
+import { App, TFile } from "obsidian";
 import React, { useEffect, useRef, useState } from "react";
 
 interface ChatInputProps {
@@ -10,6 +14,8 @@ interface ChatInputProps {
   getChatVisibility: () => Promise<boolean>;
   isGenerating: boolean;
   onStopGenerating: () => void;
+  app: App;
+  settings: CopilotSettings;
 }
 
 const ChatInput: React.FC<ChatInputProps> = ({
@@ -20,25 +26,28 @@ const ChatInput: React.FC<ChatInputProps> = ({
   getChatVisibility,
   isGenerating,
   onStopGenerating,
+  app,
+  settings,
 }) => {
   const [rows, setRows] = useState(1);
   const [shouldFocus, setShouldFocus] = useState(false);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleInputChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleInputChange = async (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const inputValue = event.target.value;
     setInputMessage(inputValue);
     updateRows(inputValue);
 
-    // Check if the user typed `[[`
     if (inputValue.slice(-2) === "[[") {
       showNoteTitleModal();
+    } else if (inputValue === "/") {
+      showCustomPromptModal();
     }
   };
 
   const showNoteTitleModal = () => {
     const fetchNoteTitles = async () => {
-      const noteTitles = app.vault.getMarkdownFiles().map((file) => file.basename);
+      const noteTitles = app.vault.getMarkdownFiles().map((file: TFile) => file.basename);
 
       new NoteTitleModal(app, noteTitles, (noteTitle: string) => {
         setInputMessage(inputMessage.slice(0, -2) + ` [[${noteTitle}]]`);
@@ -48,9 +57,23 @@ const ChatInput: React.FC<ChatInputProps> = ({
     fetchNoteTitles();
   };
 
+  const showCustomPromptModal = async () => {
+    const customPromptProcessor = CustomPromptProcessor.getInstance(app.vault, settings);
+    const prompts = await customPromptProcessor.getAllPrompts();
+    const promptTitles = prompts.map((prompt) => prompt.title);
+
+    new ListPromptModal(app, promptTitles, async (promptTitle: string) => {
+      const selectedPrompt = prompts.find((prompt) => prompt.title === promptTitle);
+      if (selectedPrompt) {
+        setInputMessage(selectedPrompt.content);
+        updateRows(selectedPrompt.content);
+      }
+    }).open();
+  };
+
   const updateRows = (text: string) => {
-    const lineHeight = 20; // Adjust this value based on CSS line-height
-    const maxHeight = 200; // Match this to the max-height value in CSS
+    const lineHeight = 20;
+    const maxHeight = 200;
     const minRows = 1;
 
     const rowsNeeded = Math.min(
@@ -81,7 +104,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
       <textarea
         ref={textAreaRef}
         className="chat-input-textarea"
-        placeholder="Enter your message here..."
+        placeholder="Ask anything. [[ for notes. / for custom prompts."
         value={inputMessage}
         onChange={handleInputChange}
         onKeyDown={handleKeyDown}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,7 +60,7 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     isBuiltIn: true,
   },
   {
-    name: ChatModels.CLAUDE_3_5_SONNET,
+    name: ChatModels.CLAUDE_3_HAIKU,
     provider: ChatModelProviders.ANTHROPIC,
     enabled: true,
     isBuiltIn: true,

--- a/src/customPromptProcessor.ts
+++ b/src/customPromptProcessor.ts
@@ -165,14 +165,27 @@ export class CustomPromptProcessor {
     const matches = [...processedPrompt.matchAll(/\{([^}]+)\}/g)];
 
     let additionalInfo = "";
+    let activeNoteContent: string | null = null;
+
     if (processedPrompt.includes("{}")) {
       processedPrompt = processedPrompt.replace(/\{\}/g, "{selectedText}");
-      additionalInfo += `selectedText:\n\n ${selectedText}`;
+      if (selectedText) {
+        additionalInfo += `selectedText:\n\n ${selectedText}`;
+      } else if (activeNote) {
+        activeNoteContent = await getFileContent(activeNote, this.vault);
+        additionalInfo += `selectedText (entire active note):\n\n ${activeNoteContent}`;
+      } else {
+        additionalInfo += `selectedText:\n\n (No selected text or active note available)`;
+      }
     }
 
     for (let i = 0; i < variablesWithContent.length; i++) {
       if (matches[i]) {
         const varname = matches[i][1];
+        if (varname.toLowerCase() === "activenote" && activeNoteContent) {
+          // Skip adding activeNote content if it's already added as selectedText
+          continue;
+        }
         additionalInfo += `\n\n${varname}:\n\n${variablesWithContent[i]}`;
       }
     }

--- a/tests/customPromptProcessor.test.ts
+++ b/tests/customPromptProcessor.test.ts
@@ -1,12 +1,14 @@
 import { CustomPrompt, CustomPromptProcessor } from "@/customPromptProcessor";
 import { CopilotSettings } from "@/settings/SettingsPage";
+import { extractNoteTitles, getFileContent, getNoteFileFromTitle } from "@/utils";
+import { TFile } from "obsidian";
 
-// Mocking Obsidian Vault
-const mockVault = {
-  read: jest.fn(),
-  write: jest.fn(),
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-} as any;
+// Mock the utility functions
+jest.mock("@/utils", () => ({
+  extractNoteTitles: jest.fn().mockReturnValue([]),
+  getNoteFileFromTitle: jest.fn(),
+  getFileContent: jest.fn(),
+}));
 
 describe("CustomPromptProcessor", () => {
   let processor: CustomPromptProcessor;
@@ -16,7 +18,7 @@ describe("CustomPromptProcessor", () => {
     jest.clearAllMocks();
 
     // Create an instance of CustomPromptProcessor with mocked dependencies
-    processor = CustomPromptProcessor.getInstance(mockVault, {} as CopilotSettings);
+    processor = CustomPromptProcessor.getInstance({} as any, {} as CopilotSettings);
   });
 
   it("should add 1 context and selectedText", async () => {
@@ -145,5 +147,109 @@ describe("CustomPromptProcessor", () => {
     expect(result).toContain(
       '[{"name":"note1","content":"Note content for #tag1"},{"name":"note2","content":"Note content for #tag2"}]'
     );
+  });
+
+  it("should process [[note title]] syntax correctly", async () => {
+    const customPrompt = "Content of [[Test Note]] is important.";
+    const selectedText = "";
+
+    // Mock the necessary functions
+    jest.spyOn(processor, "extractVariablesFromPrompt").mockResolvedValue([]);
+    (extractNoteTitles as jest.Mock).mockReturnValue(["Test Note"]);
+    (getNoteFileFromTitle as jest.Mock).mockResolvedValue({} as TFile);
+    (getFileContent as jest.Mock).mockResolvedValue("Test note content");
+
+    const result = await processor.processCustomPrompt(customPrompt, selectedText);
+
+    expect(result).toContain("Content of [[Test Note]] is important.");
+    expect(result).toContain("[[Test Note]]:\n\nTest note content");
+  });
+
+  it("should process {[[note title]]} syntax correctly without duplication", async () => {
+    const customPrompt = "Content of {[[Test Note]]} is important.";
+    const selectedText = "";
+
+    // Mock the necessary functions
+    jest
+      .spyOn(processor, "extractVariablesFromPrompt")
+      .mockResolvedValue([JSON.stringify([{ name: "Test Note", content: "Test note content" }])]);
+    (extractNoteTitles as jest.Mock).mockReturnValue(["Test Note"]);
+
+    const result = await processor.processCustomPrompt(customPrompt, selectedText);
+
+    expect(result).toContain("Content of {[[Test Note]]} is important.");
+    expect(result).toContain(
+      '[[Test Note]]:\n\n[{"name":"Test Note","content":"Test note content"}]'
+    );
+
+    // Ensure the content is not duplicated
+    const occurrences = (result.match(/Test note content/g) || []).length;
+    expect(occurrences).toBe(1);
+
+    // Verify that getNoteFileFromTitle was not called
+    expect(getNoteFileFromTitle).not.toHaveBeenCalled();
+  });
+
+  it("should process both {[[note title]]} and [[note title]] syntax correctly", async () => {
+    const customPrompt = "{[[Note1]]} content and [[Note2]] are both important.";
+    const selectedText = "";
+
+    // Mock the necessary functions
+    jest
+      .spyOn(processor, "extractVariablesFromPrompt")
+      .mockResolvedValue([JSON.stringify([{ name: "Note1", content: "Note1 content" }])]);
+    (extractNoteTitles as jest.Mock).mockReturnValue(["Note1", "Note2"]);
+    (getNoteFileFromTitle as jest.Mock).mockResolvedValue({} as TFile);
+    (getFileContent as jest.Mock).mockResolvedValue("Note2 content");
+
+    const result = await processor.processCustomPrompt(customPrompt, selectedText);
+
+    expect(result).toContain("{[[Note1]]} content and [[Note2]] are both important.");
+    expect(result).toContain('[[Note1]]:\n\n[{"name":"Note1","content":"Note1 content"}]');
+    expect(result).toContain("[[Note2]]:\n\nNote2 content");
+
+    // Ensure Note1 content is not duplicated
+    const note1Occurrences = (result.match(/Note1 content/g) || []).length;
+    expect(note1Occurrences).toBe(1);
+
+    // Verify that getNoteFileFromTitle was called only for Note2
+    expect(getNoteFileFromTitle).toHaveBeenCalledTimes(1);
+    expect(getNoteFileFromTitle).toHaveBeenCalledWith(expect.anything(), "Note2");
+  });
+
+  it("should handle multiple occurrences of [[note title]] syntax", async () => {
+    const customPrompt = "[[Note1]] is related to [[Note2]] and [[Note3]].";
+    const selectedText = "";
+
+    // Mock the necessary functions
+    jest.spyOn(processor, "extractVariablesFromPrompt").mockResolvedValue([]);
+    (extractNoteTitles as jest.Mock).mockReturnValue(["Note1", "Note2", "Note3"]);
+    (getNoteFileFromTitle as jest.Mock).mockResolvedValue({} as TFile);
+    (getFileContent as jest.Mock)
+      .mockResolvedValueOnce("Note1 content")
+      .mockResolvedValueOnce("Note2 content")
+      .mockResolvedValueOnce("Note3 content");
+
+    const result = await processor.processCustomPrompt(customPrompt, selectedText);
+
+    expect(result).toContain("[[Note1]] is related to [[Note2]] and [[Note3]].");
+    expect(result).toContain("[[Note1]]:\n\nNote1 content");
+    expect(result).toContain("[[Note2]]:\n\nNote2 content");
+    expect(result).toContain("[[Note3]]:\n\nNote3 content");
+  });
+
+  it("should handle non-existent note titles gracefully", async () => {
+    const customPrompt = "[[Non-existent Note]] should not cause errors.";
+    const selectedText = "";
+
+    // Mock the necessary functions
+    jest.spyOn(processor, "extractVariablesFromPrompt").mockResolvedValue([]);
+    (extractNoteTitles as jest.Mock).mockReturnValue(["Non-existent Note"]);
+    (getNoteFileFromTitle as jest.Mock).mockResolvedValue(null);
+
+    const result = await processor.processCustomPrompt(customPrompt, selectedText);
+
+    expect(result).toContain("[[Non-existent Note]] should not cause errors.");
+    expect(result).not.toContain("[[Non-existent Note]]:");
   });
 });


### PR DESCRIPTION
Fixes #590
Fixes #624 
Fixes #623

- Type `/` and it brings up the custom prompts list, selecting one fills it into the chat input.
- `{activeNote}` is supported now
- When `{}` is present but no text is selected, fallback to the entire active note.