### PR TITLE
Added ability to tag saved conversations

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -199,6 +199,8 @@ const Chat: React.FC<ChatProps> = ({
       const noteContentWithTimestamp = `---
 epoch: ${epoch}
 modelKey: ${currentModelKey}
+tags:
+  - ${settings.defaultTag}
 ---
 
 ${chatContent}`;

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -200,7 +200,7 @@ const Chat: React.FC<ChatProps> = ({
 epoch: ${epoch}
 modelKey: ${currentModelKey}
 tags:
-  - ${settings.defaultTag}
+  - ${settings.defaultConversationTag}
 ---
 
 ${chatContent}`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -207,6 +207,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   openAIEmbeddingProxyBaseUrl: "",
   stream: true,
   defaultSaveFolder: "copilot-conversations",
+  defaultConversationTag: "ai-conversations",
   autosaveChat: true,
   customPromptsFolder: "copilot-custom-prompts",
   indexVaultToVectorStore: VAULT_VECTOR_STORE_STRATEGY.ON_MODE_SWITCH,

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -22,6 +22,7 @@ export interface CopilotSettings {
   googleApiKey: string;
   openRouterAiApiKey: string;
   defaultModelKey: string;
+  defaultTag: string;
   embeddingModelKey: string;
   temperature: number;
   maxTokens: number;

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -22,7 +22,6 @@ export interface CopilotSettings {
   googleApiKey: string;
   openRouterAiApiKey: string;
   defaultModelKey: string;
-  defaultTag: string;
   embeddingModelKey: string;
   temperature: number;
   maxTokens: number;
@@ -32,6 +31,7 @@ export interface CopilotSettings {
   openAIEmbeddingProxyBaseUrl: string;
   stream: boolean;
   defaultSaveFolder: string;
+  defaultConversationTag: string;
   autosaveChat: boolean;
   customPromptsFolder: string;
   indexVaultToVectorStore: string;

--- a/src/settings/components/GeneralSettings.tsx
+++ b/src/settings/components/GeneralSettings.tsx
@@ -83,8 +83,8 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
         name="Default Conversation Tag"
         description="The default tag to be used when saving a conversation. Default is 'ai-conversations'"
         placeholder="ai-conversation"
-        value={settings.defaultTag}
-        onChange={(value) => updateSettings({ defaultTag: value })}
+        value={settings.defaultConversationTag}
+        onChange={(value) => updateSettings({ defaultConversationTag: value })}
       />
       <ToggleComponent
         name="Autosave Chat"

--- a/src/settings/components/GeneralSettings.tsx
+++ b/src/settings/components/GeneralSettings.tsx
@@ -79,6 +79,13 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
         value={settings.defaultSaveFolder}
         onChange={(value) => updateSettings({ defaultSaveFolder: value })}
       />
+      <TextComponent
+        name="Default Conversation Tag"
+        description="The default tag to be used when saving a conversation. Default is 'ai-conversations'"
+        placeholder="ai-conversation"
+        value={settings.defaultTag}
+        onChange={(value) => updateSettings({ defaultTag: value })}
+      />
       <ToggleComponent
         name="Autosave Chat"
         description="Automatically save the chat when starting a new one or when the plugin reloads"


### PR DESCRIPTION
**Purpose**
This pull request adds the ability to tag conversations within Obsidian Copilot, allowing for easier referencing and analysis using Dataview.

**Motivation:** 
Currently, Obsidian Copilot doesn't offer a way to tag conversations, making it difficult to organize and retrieve specific conversations for analysis using Dataview. 

This feature would enable users to:
- Categorize conversations: Tag conversations based on topics, projects, or other relevant criteria.
- Filter conversations: Use Dataview queries to retrieve conversations based on specific tags.
- Analyze conversations: Gain insights from tagged conversations by using Dataview's powerful analysis capabilities.

**Changes:**
- Added a new settings called **Default Conversation Tag** which defaults to ai-conversation. 
- Updated SettingsPage.tsc CopilotSettings interface to reference the new defaultTag string
- Updated Chat.tsx to reference the new setting
- Updated GeneralSettings.tsx to include new TextComponent