### PR TITLE
Add default open area settings

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -178,6 +178,11 @@ export const VAULT_VECTOR_STORE_STRATEGIES = [
   VAULT_VECTOR_STORE_STRATEGY.ON_MODE_SWITCH,
 ];
 
+export enum DEFAULT_OPEN_AREA {
+  EDITOR = "editor",
+  VIEW = "view",
+}
+
 export const COMMAND_IDS = {
   FIX_GRAMMAR: "fix-grammar-prompt",
   SUMMARIZE: "summarize-prompt",
@@ -223,7 +228,8 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   stream: true,
   defaultSaveFolder: "copilot-conversations",
   defaultConversationTag: "copilot-conversation",
-  autosaveChat: true,
+  autosaveChat: false,
+  defaultOpenArea: DEFAULT_OPEN_AREA.VIEW,
   customPromptsFolder: "copilot-custom-prompts",
   indexVaultToVectorStore: VAULT_VECTOR_STORE_STRATEGY.ON_MODE_SWITCH,
   qaExclusions: "",

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { CustomModel } from "@/aiParams";
 import { ChainType } from "@/chainFactory";
 import CopilotView from "@/components/CopilotView";
-import { CHAT_VIEWTYPE } from "@/constants";
+import { CHAT_VIEWTYPE, DEFAULT_OPEN_AREA } from "@/constants";
 import CopilotPlugin from "@/main";
 import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import React from "react";
@@ -50,6 +50,7 @@ export interface CopilotSettings {
   activeEmbeddingModels: Array<CustomModel>;
   promptUsageTimestamps: Record<string, number>;
   embeddingRequestsPerSecond: number;
+  defaultOpenArea: DEFAULT_OPEN_AREA;
 }
 
 export class CopilotSettingTab extends PluginSettingTab {

--- a/src/settings/components/GeneralSettings.tsx
+++ b/src/settings/components/GeneralSettings.tsx
@@ -1,6 +1,6 @@
 import { CustomModel, LangChainParams } from "@/aiParams";
 import { ChainType } from "@/chainFactory";
-import { ChatModelProviders } from "@/constants";
+import { ChatModelProviders, DEFAULT_OPEN_AREA } from "@/constants";
 import EncryptionService from "@/encryptionService";
 import React from "react";
 import { useSettingsContext } from "../contexts/SettingsContext";
@@ -107,6 +107,21 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
         value={settings.autosaveChat}
         onChange={(value) => updateSettings({ autosaveChat: value })}
       />
+      <div className="chat-icon-selection-tooltip">
+        <h2>Open Plugin In</h2>
+        <div className="select-wrapper">
+          <select
+            id="openPluginInSelect"
+            value={settings.defaultOpenArea}
+            onChange={(e) =>
+              updateSettings({ defaultOpenArea: e.target.value as DEFAULT_OPEN_AREA })
+            }
+          >
+            <option value={DEFAULT_OPEN_AREA.VIEW}>Sidebar View</option>
+            <option value={DEFAULT_OPEN_AREA.EDITOR}>Editor</option>
+          </select>
+        </div>
+      </div>
       <TextComponent
         name="Custom Prompts Folder Name"
         description="The default folder name where custom prompts will be saved. Default is 'copilot-custom-prompts'"


### PR DESCRIPTION
https://github.com/logancyang/obsidian-copilot/issues/749

- Refactored open window commands. 
  - Deleted "toggle window in note area" 
  - Added "open copilot chat window". Open command will reopen the chat view if one already exists. Toggle command will toggle the view.
 
<img width="730" alt="Screenshot 2024-11-09 at 1 34 07 PM" src="https://github.com/user-attachments/assets/1d263411-c557-4c2c-b1af-12e113bb7af3">

- Added a setting to define the default open view: "editor" or "sidebar view".

<img width="1089" alt="Screenshot 2024-11-09 at 1 32 48 PM" src="https://github.com/user-attachments/assets/d3e298d5-7074-4e71-aa6e-8a0bf044fbf6">

![2024-11-09 13 33 14](https://github.com/user-attachments/assets/aac73d7e-f7f5-4ad4-af62-731833eb0a90)
![2024-11-09 13 33 39](https://github.com/user-attachments/assets/2c6bf783-b68e-4f90-b82c-37ac8920ef84)
