### PR TITLE
Disable index loading on mobile

### DIFF
--- a/src/LLMProviders/chainManager.ts
+++ b/src/LLMProviders/chainManager.ts
@@ -195,8 +195,14 @@ export default class ChainManager {
           return;
         }
 
+        const db = this.vectorStoreManager.getDb();
+        if (!db) {
+          console.error("Copilot index is not loaded. Please check your settings.");
+          return;
+        }
+
         const retriever = new HybridRetriever(
-          this.vectorStoreManager.getDb(),
+          db,
           this.app.vault,
           chatModel,
           embeddingsAPI,
@@ -428,6 +434,8 @@ export default class ChainManager {
 
   async indexFile(noteFile: any): Promise<any | undefined> {
     const embeddingsAPI = this.embeddingsManager.getEmbeddingsAPI();
+    const db = this.vectorStoreManager.getDb();
+
     if (!embeddingsAPI) {
       const errorMsg =
         "Failed to load file, embedding API is not set correctly, please check your settings.";
@@ -435,11 +443,15 @@ export default class ChainManager {
       console.error(errorMsg);
       return;
     }
-    return await VectorDBManager.indexFile(
-      this.vectorStoreManager.getDb(),
-      embeddingsAPI,
-      noteFile
-    );
+
+    if (!db) {
+      const errorMsg = "Vector database is not initialized or disabled on mobile.";
+      new Notice(errorMsg);
+      console.error(errorMsg);
+      return;
+    }
+
+    return await VectorDBManager.indexFile(db, embeddingsAPI, noteFile);
   }
 
   async updateMemoryWithLoadedMessages(messages: ChatMessage[]) {

--- a/src/VectorStoreManager.ts
+++ b/src/VectorStoreManager.ts
@@ -323,10 +323,11 @@ class VectorStoreManager {
 
         if (!areEmbeddingModelsSame(prevEmbeddingModel, currEmbeddingModel)) {
           // Model has changed, reinitialize DB
-          await this.initializeDB();
+          this.oramaDb = await this.createNewDb();
           overwrite = true;
           new Notice("Detected change in embedding model. Rebuilding vector store from scratch.");
           console.log("Detected change in embedding model. Rebuilding vector store from scratch.");
+          await this.saveDB();
         }
       } else {
         console.log("No previous embedding model found in the database.");

--- a/src/VectorStoreManager.ts
+++ b/src/VectorStoreManager.ts
@@ -51,7 +51,11 @@ class VectorStoreManager {
     this.initializationPromise = this.initializeDB()
       .then((db) => {
         this.oramaDb = db;
-        console.log("Copilot database initialized successfully.");
+        if (db) {
+          console.log("Copilot database initialized successfully.");
+        } else {
+          console.log("Copilot index is disabled on mobile devices.");
+        }
 
         // Perform any operations that depend on the initialized database here
         this.performPostInitializationTasks();
@@ -171,6 +175,7 @@ class VectorStoreManager {
       `Created new Orama database for ${this.dbPath}. ` +
         `Embedding model: ${EmbeddingsManager.getModelName(embeddingInstance)} with vector length ${vectorLength}.`
     );
+    this.isIndexLoaded = true;
     return db;
   }
 
@@ -467,6 +472,9 @@ class VectorStoreManager {
           }
         }
       }
+
+      // Set isIndexLoaded to true after successful indexing
+      this.isIndexLoaded = true;
 
       // Hide the notice after completion
       setTimeout(() => {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -574,6 +574,7 @@ ${chatContent}`;
           debug={debug}
           addMessage={addMessage}
           vault={app.vault}
+          isIndexLoaded={plugin.vectorStoreManager.getIsIndexLoaded()}
         />
       </div>
     </div>

--- a/src/components/ChatComponents/ChatControls.tsx
+++ b/src/components/ChatComponents/ChatControls.tsx
@@ -21,6 +21,7 @@ interface ChatControlsProps {
   settings: CopilotSettings;
   vault_qa_strategy: string;
   debug?: boolean;
+  isIndexLoaded: boolean;
 }
 
 const ChatControls: React.FC<ChatControlsProps> = ({
@@ -32,6 +33,7 @@ const ChatControls: React.FC<ChatControlsProps> = ({
   settings,
   vault_qa_strategy,
   debug,
+  isIndexLoaded,
 }) => {
   const [selectedChain, setSelectedChain] = useState<ChainType>(currentChain);
 
@@ -131,11 +133,19 @@ const ChatControls: React.FC<ChatControlsProps> = ({
               <DropdownMenu.Item onSelect={() => handleChainChange({ value: "llm_chain" })}>
                 chat
               </DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={() => handleChainChange({ value: "vault_qa" })}>
-                vault QA (basic)
+              <DropdownMenu.Item
+                onSelect={() => handleChainChange({ value: "vault_qa" })}
+                disabled={!isIndexLoaded}
+                className={!isIndexLoaded ? "disabled-menu-item" : ""}
+              >
+                vault QA (basic) {!isIndexLoaded && "(index not loaded)"}
               </DropdownMenu.Item>
-              <DropdownMenu.Item onSelect={() => handleChainChange({ value: "copilot_plus" })}>
-                copilot plus (alpha)
+              <DropdownMenu.Item
+                onSelect={() => handleChainChange({ value: "copilot_plus" })}
+                disabled={!isIndexLoaded}
+                className={!isIndexLoaded ? "disabled-menu-item" : ""}
+              >
+                copilot plus (alpha) {!isIndexLoaded && "(index not loaded)"}
               </DropdownMenu.Item>
             </DropdownMenu.Content>
           </DropdownMenu.Portal>

--- a/src/components/ChatComponents/ChatInput.tsx
+++ b/src/components/ChatComponents/ChatInput.tsx
@@ -31,6 +31,7 @@ interface ChatInputProps {
   addMessage: (message: ChatMessage) => void;
   vault: Vault;
   vault_qa_strategy: string;
+  isIndexLoaded: boolean;
   debug?: boolean;
 }
 
@@ -56,6 +57,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
   addMessage,
   vault,
   vault_qa_strategy,
+  isIndexLoaded,
   debug,
 }) => {
   const [shouldFocus, setShouldFocus] = useState(false);
@@ -204,6 +206,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
         onRefreshVaultContext={onRefreshVaultContext}
         settings={settings}
         vault_qa_strategy={vault_qa_strategy}
+        isIndexLoaded={isIndexLoaded}
         debug={debug}
       />
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -243,6 +243,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   activeModels: BUILTIN_CHAT_MODELS,
   activeEmbeddingModels: BUILTIN_EMBEDDING_MODELS,
   embeddingRequestsPerSecond: 10,
+  disableIndexOnMobile: false,
   enabledCommands: {
     [COMMAND_IDS.FIX_GRAMMAR]: {
       enabled: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -662,6 +662,9 @@ export default class CopilotPlugin extends Plugin {
     await this.vectorStoreManager.waitForInitialization();
 
     const db = this.vectorStoreManager.getDb();
+    if (!db) {
+      throw new CustomError("Orama database not found.");
+    }
 
     // Check if the index is empty
     const singleDoc = await search(db, {

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -51,6 +51,7 @@ export interface CopilotSettings {
   promptUsageTimestamps: Record<string, number>;
   embeddingRequestsPerSecond: number;
   defaultOpenArea: DEFAULT_OPEN_AREA;
+  disableIndexOnMobile: boolean;
 }
 
 export class CopilotSettingTab extends PluginSettingTab {

--- a/src/settings/components/QASettings.tsx
+++ b/src/settings/components/QASettings.tsx
@@ -7,6 +7,7 @@ import {
   ModelSettingsComponent,
   SliderComponent,
   TextAreaComponent,
+  ToggleComponent,
 } from "./SettingBlocks";
 
 interface QASettingsProps {
@@ -16,6 +17,8 @@ interface QASettingsProps {
   setIndexVaultToVectorStore: (value: string) => void;
   maxSourceChunks: number;
   setMaxSourceChunks: (value: number) => void;
+  disableIndexOnMobile: boolean;
+  setDisableIndexOnMobile: (value: boolean) => void;
 }
 
 const QASettings: React.FC<QASettingsProps> = ({
@@ -23,6 +26,8 @@ const QASettings: React.FC<QASettingsProps> = ({
   setIndexVaultToVectorStore,
   maxSourceChunks,
   setMaxSourceChunks,
+  disableIndexOnMobile,
+  setDisableIndexOnMobile,
 }) => {
   const { settings, updateSettings } = useSettingsContext();
 
@@ -143,6 +148,12 @@ const QASettings: React.FC<QASettingsProps> = ({
         placeholder="folder1, #tag1, [[note1]]"
         value={settings.qaInclusions}
         onChange={(value) => updateSettings({ qaInclusions: value })}
+      />
+      <ToggleComponent
+        name="Disable index loading on mobile"
+        description="When enabled, vector store index won't be loaded on mobile devices to save resources. Only chat mode will be available. Any existing index from desktop sync will be preserved."
+        value={disableIndexOnMobile}
+        onChange={setDisableIndexOnMobile}
       />
     </div>
   );

--- a/src/settings/components/SettingsMain.tsx
+++ b/src/settings/components/SettingsMain.tsx
@@ -57,6 +57,8 @@ const SettingsMain: React.FC<{ plugin: CopilotPlugin; reloadPlugin: () => Promis
         setHuggingfaceApiKey={(value) => updateSettings({ huggingfaceApiKey: value })}
         setIndexVaultToVectorStore={(value) => updateSettings({ indexVaultToVectorStore: value })}
         setMaxSourceChunks={(value) => updateSettings({ maxSourceChunks: value })}
+        disableIndexOnMobile={settings.disableIndexOnMobile}
+        setDisableIndexOnMobile={(value) => updateSettings({ disableIndexOnMobile: value })}
       />
       <AdvancedSettings
         {...settings}

--- a/src/vectorDBManager.ts
+++ b/src/vectorDBManager.ts
@@ -196,7 +196,7 @@ class VectorDBManager {
     return result.hits;
   }
 
-  public static async getLatestFileMtime(db: Orama<any>): Promise<number> {
+  public static async getLatestFileMtime(db: Orama<any> | undefined): Promise<number> {
     if (!db) throw new Error("DB not initialized");
 
     try {

--- a/styles.css
+++ b/styles.css
@@ -224,6 +224,7 @@ If your plugin does not need CSS, delete this file.
   padding: 4px;
   font-size: 10px;
   transform: translateX(30px);
+  z-index: 1000;
 }
 
 .model-select-content [role="menuitem"] {
@@ -259,6 +260,7 @@ If your plugin does not need CSS, delete this file.
   padding: 4px;
   font-size: 10px;
   transform: translateX(-5px);
+  z-index: 1000;
 }
 
 .chain-select-content [role="menuitem"] {
@@ -774,6 +776,25 @@ If your plugin does not need CSS, delete this file.
 
   .model-card-item .switch {
     margin: 0;
+  }
+
+  .model-select-content,
+  .chain-select-content {
+    background: var(--background-primary);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  }
+
+  .model-select-content [role="menuitem"],
+  .chain-select-content [role="menuitem"] {
+    background: var(--background-primary);
+    color: var(--text-normal);
+    padding: 8px 12px;
+    font-size: 14px;
+  }
+
+  .model-select-content [role="menuitem"]:hover,
+  .chain-select-content [role="menuitem"]:hover {
+    background: var(--background-modifier-hover);
   }
 }
 


### PR DESCRIPTION
Related #739, #806 

- Disable index loading on mobile to avoid large copilot index crashing the Obsidian app. Only Chat mode is available when this setting is set.
- Fix mobile UI for model and mode selection
- Fix index recreation at embedding model switch