### PR TITLE
Improve settings and chat focus

### DIFF
--- a/src/components/ChatComponents/ChatControls.tsx
+++ b/src/components/ChatComponents/ChatControls.tsx
@@ -1,7 +1,6 @@
 import { SetChainOptions } from "@/aiParams";
 import { VAULT_VECTOR_STORE_STRATEGY } from "@/constants";
 import { CustomError } from "@/error";
-import { CopilotSettings } from "@/settings/SettingsPage";
 import { App, Notice } from "obsidian";
 import React, { useEffect, useState } from "react";
 
@@ -11,6 +10,7 @@ import { TooltipActionButton } from "@/components/ChatComponents/TooltipActionBu
 import { stringToChainType } from "@/utils";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { ChevronDown, Download, Puzzle, RefreshCw } from "lucide-react";
+import { useSettingsValueContext } from "@/settings/contexts/SettingsValueContext";
 
 import { TFile } from "obsidian";
 import { ChatContextMenu } from "./ChatContextMenu";
@@ -21,8 +21,6 @@ interface ChatControlsProps {
   onNewChat: (openNote: boolean) => void;
   onSaveAsNote: () => void;
   onRefreshVaultContext: () => void;
-  settings: CopilotSettings;
-  vault_qa_strategy: string;
   isIndexLoadedPromise: Promise<boolean>;
   app: App;
   contextNotes: TFile[];
@@ -40,8 +38,6 @@ const ChatControls: React.FC<ChatControlsProps> = ({
   onNewChat,
   onSaveAsNote,
   onRefreshVaultContext,
-  settings,
-  vault_qa_strategy,
   isIndexLoadedPromise,
   app,
   contextNotes,
@@ -61,6 +57,8 @@ const ChatControls: React.FC<ChatControlsProps> = ({
       setIsIndexLoaded(loaded);
     });
   }, [isIndexLoadedPromise]);
+  const settings = useSettingsValueContext();
+  const indexVaultToVectorStore = settings.indexVaultToVectorStore;
 
   const handleChainChange = async ({ value }: { value: string }) => {
     const newChain = stringToChainType(value);
@@ -86,7 +84,7 @@ const ChatControls: React.FC<ChatControlsProps> = ({
       if (
         (selectedChain === ChainType.VAULT_QA_CHAIN ||
           selectedChain === ChainType.COPILOT_PLUS_CHAIN) &&
-        vault_qa_strategy === VAULT_VECTOR_STORE_STRATEGY.ON_MODE_SWITCH
+        indexVaultToVectorStore === VAULT_VECTOR_STORE_STRATEGY.ON_MODE_SWITCH
       ) {
         await onRefreshVaultContext();
       }
@@ -108,10 +106,6 @@ const ChatControls: React.FC<ChatControlsProps> = ({
 
     handleChainSelection();
   }, [selectedChain]);
-
-  useEffect(() => {
-    setSelectedChain(settings.defaultChainType);
-  }, [settings.defaultChainType]);
 
   // const handleFindSimilarNotes = async () => {
   //   const activeFile = app.workspace.getActiveFile();

--- a/src/components/ChatComponents/ChatInput.tsx
+++ b/src/components/ChatComponents/ChatInput.tsx
@@ -6,27 +6,24 @@ import { ContextProcessor } from "@/contextProcessor";
 import { CustomPromptProcessor } from "@/customPromptProcessor";
 import { COPILOT_TOOL_NAMES } from "@/LLMProviders/intentAnalyzer";
 import { Mention } from "@/mentions/Mention";
-import { CopilotSettings } from "@/settings/SettingsPage";
-import { ChatMessage } from "@/sharedState";
 import { getToolDescription } from "@/tools/toolManager";
 import { extractNoteTitles } from "@/utils";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { ArrowBigUp, ChevronUp, Command, CornerDownLeft, Image, StopCircle } from "lucide-react";
-import { App, Platform, TFile, Vault } from "obsidian";
-import React, { useEffect, useRef, useState } from "react";
+import { App, Platform, TFile } from "obsidian";
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { AddImageModal } from "../AddImageModal";
 import ChatControls from "./ChatControls";
 import { TooltipActionButton } from "./TooltipActionButton";
+import { useSettingsValueContext } from "@/settings/contexts/SettingsValueContext";
 
 interface ChatInputProps {
   inputMessage: string;
   setInputMessage: (message: string) => void;
   handleSendMessage: (toolCalls?: string[]) => void;
   isGenerating: boolean;
-  chatIsVisible: boolean;
   onStopGenerating: () => void;
   app: App;
-  settings: CopilotSettings;
   navigateHistory: (direction: "up" | "down") => string;
   currentModelKey: string;
   setCurrentModelKey: (modelKey: string) => void;
@@ -35,9 +32,6 @@ interface ChatInputProps {
   onNewChat: (openNote: boolean) => void;
   onSaveAsNote: () => void;
   onRefreshVaultContext: () => void;
-  addMessage: (message: ChatMessage) => void;
-  vault: Vault;
-  vault_qa_strategy: string;
   isIndexLoadedPromise: Promise<boolean>;
   contextNotes: TFile[];
   setContextNotes: React.Dispatch<React.SetStateAction<TFile[]>>;
@@ -52,463 +46,460 @@ interface ChatInputProps {
 
 const getModelKey = (model: CustomModel) => `${model.name}|${model.provider}`;
 
-const ChatInput: React.FC<ChatInputProps> = ({
-  inputMessage,
-  setInputMessage,
-  handleSendMessage,
-  isGenerating,
-  onStopGenerating,
-  app,
-  settings,
-  navigateHistory,
-  chatIsVisible,
-  currentModelKey,
-  setCurrentModelKey,
-  currentChain,
-  setCurrentChain,
-  onNewChat,
-  onSaveAsNote,
-  onRefreshVaultContext,
-  addMessage,
-  vault,
-  vault_qa_strategy,
-  isIndexLoadedPromise,
-  contextNotes,
-  setContextNotes,
-  includeActiveNote,
-  setIncludeActiveNote,
-  mention,
-  selectedImages,
-  onAddImage,
-  setSelectedImages,
-  debug,
-}) => {
-  const [shouldFocus, setShouldFocus] = useState(false);
-  const [historyIndex, setHistoryIndex] = useState(-1);
-  const [tempInput, setTempInput] = useState("");
-  const [isModelDropdownOpen, setIsModelDropdownOpen] = useState(false);
-  const [contextUrls, setContextUrls] = useState<string[]>([]);
-  const textAreaRef = useRef<HTMLTextAreaElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
+  (
+    {
+      inputMessage,
+      setInputMessage,
+      handleSendMessage,
+      isGenerating,
+      onStopGenerating,
+      app,
+      navigateHistory,
+      currentModelKey,
+      setCurrentModelKey,
+      currentChain,
+      setCurrentChain,
+      onNewChat,
+      onSaveAsNote,
+      onRefreshVaultContext,
+      isIndexLoadedPromise,
+      contextNotes,
+      setContextNotes,
+      includeActiveNote,
+      setIncludeActiveNote,
+      mention,
+      selectedImages,
+      onAddImage,
+      setSelectedImages,
+      debug,
+    },
+    ref
+  ) => {
+    const [historyIndex, setHistoryIndex] = useState(-1);
+    const [tempInput, setTempInput] = useState("");
+    const [isModelDropdownOpen, setIsModelDropdownOpen] = useState(false);
+    const [contextUrls, setContextUrls] = useState<string[]>([]);
+    const textAreaRef = useRef<HTMLTextAreaElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const settings = useSettingsValueContext();
 
-  const debounce = <T extends (...args: any[]) => any>(
-    fn: T,
-    delay: number
-  ): ((...args: Parameters<T>) => void) => {
-    let timeoutId: NodeJS.Timeout;
-    return (...args: Parameters<T>) => {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => fn(...args), delay);
+    useImperativeHandle(ref, () => ({
+      focus: () => {
+        textAreaRef.current?.focus();
+      },
+    }));
+
+    const debounce = <T extends (...args: any[]) => any>(
+      fn: T,
+      delay: number
+    ): ((...args: Parameters<T>) => void) => {
+      let timeoutId: NodeJS.Timeout;
+      return (...args: Parameters<T>) => {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => fn(...args), delay);
+      };
     };
-  };
 
-  // Debounce the context update to prevent excessive re-renders
-  const debouncedUpdateContext = debounce(
-    async (
-      inputValue: string,
-      setContextNotes: React.Dispatch<React.SetStateAction<TFile[]>>,
-      currentContextNotes: TFile[],
-      app: App
-    ) => {
-      const noteTitles = extractNoteTitles(inputValue);
+    // Debounce the context update to prevent excessive re-renders
+    const debouncedUpdateContext = debounce(
+      async (
+        inputValue: string,
+        setContextNotes: React.Dispatch<React.SetStateAction<TFile[]>>,
+        currentContextNotes: TFile[],
+        app: App
+      ) => {
+        const noteTitles = extractNoteTitles(inputValue);
 
-      const notesToAdd = await Promise.all(
-        noteTitles.map(async (title) => {
-          const files = app.vault.getMarkdownFiles();
-          const file = files.find((file) => file.basename === title);
-          if (file) {
-            return Object.assign(file, { wasAddedViaReference: true }) as TFile & {
-              wasAddedViaReference: boolean;
-            };
+        const notesToAdd = await Promise.all(
+          noteTitles.map(async (title) => {
+            const files = app.vault.getMarkdownFiles();
+            const file = files.find((file) => file.basename === title);
+            if (file) {
+              return Object.assign(file, { wasAddedViaReference: true }) as TFile & {
+                wasAddedViaReference: boolean;
+              };
+            }
+            return undefined;
+          })
+        );
+
+        const validNotes = notesToAdd.filter(
+          (note): note is TFile & { wasAddedViaReference: boolean } =>
+            note !== undefined &&
+            !currentContextNotes.some((existing) => existing.path === note.path)
+        );
+
+        if (validNotes.length > 0) {
+          setContextNotes((prev) => [...prev, ...validNotes]);
+        }
+      },
+      50
+    );
+
+    const handleInputChange = async (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const inputValue = event.target.value;
+      const cursorPos = event.target.selectionStart;
+
+      setInputMessage(inputValue);
+      adjustTextareaHeight();
+
+      // Extract URLs and update mentions
+      const urls = mention.extractAllUrls(inputValue);
+
+      // Update URLs in context, ensuring uniqueness
+      const newUrls = urls.filter((url) => !contextUrls.includes(url));
+      if (newUrls.length > 0) {
+        // Use Set to ensure uniqueness
+        setContextUrls((prev) => Array.from(new Set([...prev, ...newUrls])));
+      }
+
+      // Update context with debouncing
+      debouncedUpdateContext(inputValue, setContextNotes, contextNotes, app);
+
+      // Handle other input triggers
+      if (cursorPos >= 2 && inputValue.slice(cursorPos - 2, cursorPos) === "[[") {
+        showNoteTitleModal(cursorPos);
+      } else if (inputValue === "/") {
+        showCustomPromptModal();
+      } else if (inputValue.slice(-1) === "@" && currentChain === ChainType.COPILOT_PLUS_CHAIN) {
+        showCopilotPlusOptionsModal();
+      }
+    };
+
+    const adjustTextareaHeight = () => {
+      if (textAreaRef.current) {
+        textAreaRef.current.style.height = "auto"; // Reset height
+        textAreaRef.current.style.height = `${textAreaRef.current.scrollHeight}px`; // Adjust height
+      }
+    };
+
+    useEffect(() => {
+      adjustTextareaHeight();
+    }, [inputMessage]);
+
+    const showNoteTitleModal = (cursorPos: number) => {
+      const fetchNoteTitles = async () => {
+        const noteTitles = app.vault.getMarkdownFiles().map((file: TFile) => file.basename);
+        const contextProcessor = ContextProcessor.getInstance();
+
+        new NoteTitleModal(app, noteTitles, async (noteTitle: string) => {
+          const before = inputMessage.slice(0, cursorPos - 2);
+          const after = inputMessage.slice(cursorPos - 1);
+          const newInputMessage = `${before}[[${noteTitle}]]${after}`;
+          setInputMessage(newInputMessage);
+
+          // Manually invoke debouncedUpdateContext
+          debouncedUpdateContext(newInputMessage, setContextNotes, contextNotes, app);
+
+          const activeNote = app.workspace.getActiveFile();
+          const noteFile = app.vault.getMarkdownFiles().find((file) => file.basename === noteTitle);
+
+          if (noteFile) {
+            await contextProcessor.addNoteToContext(
+              noteFile,
+              app.vault,
+              contextNotes,
+              activeNote,
+              setContextNotes,
+              setIncludeActiveNote
+            );
           }
-          return undefined;
+
+          // Add a delay to ensure the cursor is set after inputMessage is updated
+          setTimeout(() => {
+            if (textAreaRef.current) {
+              const newCursorPos = cursorPos + noteTitle.length + 2;
+              textAreaRef.current.setSelectionRange(newCursorPos, newCursorPos);
+            }
+          }, 0);
+        }).open();
+      };
+      fetchNoteTitles();
+    };
+
+    const showCustomPromptModal = async () => {
+      const customPromptProcessor = CustomPromptProcessor.getInstance(app.vault, settings);
+      const prompts = await customPromptProcessor.getAllPrompts();
+      const promptTitles = prompts.map((prompt) => prompt.title);
+
+      new ListPromptModal(app, promptTitles, async (promptTitle: string) => {
+        const selectedPrompt = prompts.find((prompt) => prompt.title === promptTitle);
+        if (selectedPrompt) {
+          await customPromptProcessor.recordPromptUsage(selectedPrompt.title);
+          setInputMessage(selectedPrompt.content);
+        }
+      }).open();
+    };
+
+    const showCopilotPlusOptionsModal = () => {
+      // Create a map of options with their descriptions
+      const optionsWithDescriptions = COPILOT_TOOL_NAMES.map((option) => ({
+        title: option,
+        description: getToolDescription(option),
+      }));
+
+      new ListPromptModal(
+        app,
+        optionsWithDescriptions.map((o) => o.title),
+        (selectedOption: string) => {
+          setInputMessage(inputMessage + selectedOption + " ");
+        },
+        // Add descriptions as a separate array
+        optionsWithDescriptions.map((o) => o.description)
+      ).open();
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.nativeEvent.isComposing) return;
+
+      const textarea = textAreaRef.current;
+      if (!textarea) return;
+
+      const { selectionStart, value } = textarea;
+      const lines = value.split("\n");
+      const currentLineIndex = value.substring(0, selectionStart).split("\n").length - 1;
+
+      // Check for Cmd+Shift+Enter (Mac) or Ctrl+Shift+Enter (Windows)
+      if (e.key === "Enter" && e.shiftKey && (Platform.isMacOS ? e.metaKey : e.ctrlKey)) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (currentChain === ChainType.COPILOT_PLUS_CHAIN) {
+          handleSendMessage(["@vault"]);
+        } else {
+          handleSendMessage();
+        }
+        setHistoryIndex(-1);
+        setTempInput("");
+        return;
+      }
+
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSendMessage();
+        setHistoryIndex(-1);
+        setTempInput("");
+      } else if (e.key === "ArrowUp") {
+        if (currentLineIndex > 0 || selectionStart > 0) {
+          // Allow normal cursor movement within multi-line input
+          return;
+        }
+        e.preventDefault();
+        if (historyIndex === -1 && value.trim() !== "") {
+          setTempInput(value);
+        }
+        const newMessage = navigateHistory("up");
+        if (newMessage !== inputMessage) {
+          setHistoryIndex(historyIndex + 1);
+          setInputMessage(newMessage);
+          // Set cursor to beginning of input after update
+          setTimeout(() => {
+            if (textarea) {
+              textarea.selectionStart = textarea.selectionEnd = 0;
+            }
+          }, 0);
+        }
+      } else if (e.key === "ArrowDown") {
+        if (currentLineIndex < lines.length - 1 || selectionStart < value.length) {
+          // Allow normal cursor movement within multi-line input
+          return;
+        }
+        e.preventDefault();
+        if (historyIndex > -1) {
+          const newMessage = navigateHistory("down");
+          setHistoryIndex(historyIndex - 1);
+          if (historyIndex === 0) {
+            setInputMessage(tempInput);
+          } else {
+            setInputMessage(newMessage);
+          }
+          // Set cursor to beginning of input after update
+          setTimeout(() => {
+            if (textarea) {
+              textarea.selectionStart = textarea.selectionEnd = 0;
+            }
+          }, 0);
+        }
+      }
+    };
+
+    useEffect(() => {
+      // Get all note titles that are referenced using [[note]] syntax in the input
+      const currentTitles = new Set(extractNoteTitles(inputMessage));
+      // Get all URLs mentioned in the input
+      const currentUrls = mention.extractAllUrls(inputMessage);
+      // Get the currently open note in the editor
+      const activeNote = app.workspace.getActiveFile();
+
+      setContextNotes((prev) =>
+        prev.filter((note) => {
+          // Check if this note was added by typing [[note]] in the input
+          // as opposed to being added via the "Add Note to Context" button
+          const wasAddedViaReference = (note as any).wasAddedViaReference === true;
+
+          // Special handling for the active note (currently open in editor)
+          if (note.path === activeNote?.path) {
+            if (wasAddedViaReference) {
+              // Case 1: Active note was added by typing [[note]]
+              // Keep it only if its title is still in the input
+              // This ensures it's removed when you delete the [[note]] reference
+              return currentTitles.has(note.basename);
+            } else {
+              // Case 2: Active note was NOT added by [[note]], but by the includeActiveNote toggle
+              // Keep it only if includeActiveNote is true
+              // This handles the "Include active note" toggle in the UI
+              return includeActiveNote;
+            }
+          } else {
+            // Handling for all other notes (not the active note)
+            if (wasAddedViaReference) {
+              // Case 3: Other note was added by typing [[note]]
+              // Keep it only if its title is still in the input
+              // This ensures it's removed when you delete the [[note]] reference
+              return currentTitles.has(note.basename);
+            } else {
+              // Case 4: Other note was added via "Add Note to Context" button
+              // Always keep these notes as they were manually added
+              return true;
+            }
+          }
         })
       );
 
-      const validNotes = notesToAdd.filter(
-        (note): note is TFile & { wasAddedViaReference: boolean } =>
-          note !== undefined && !currentContextNotes.some((existing) => existing.path === note.path)
-      );
+      // Remove any URLs that are no longer present in the input
+      setContextUrls((prev) => prev.filter((url) => currentUrls.includes(url)));
+    }, [inputMessage, includeActiveNote]);
 
-      if (validNotes.length > 0) {
-        setContextNotes((prev) => [...prev, ...validNotes]);
-      }
-    },
-    50
-  );
+    return (
+      <div className="chat-input-container" ref={containerRef}>
+        <ChatControls
+          currentChain={currentChain}
+          setCurrentChain={setCurrentChain}
+          onNewChat={onNewChat}
+          onSaveAsNote={onSaveAsNote}
+          onRefreshVaultContext={onRefreshVaultContext}
+          isIndexLoadedPromise={isIndexLoadedPromise}
+          app={app}
+          contextNotes={contextNotes}
+          setContextNotes={setContextNotes}
+          includeActiveNote={includeActiveNote}
+          setIncludeActiveNote={setIncludeActiveNote}
+          contextUrls={contextUrls}
+          onRemoveUrl={(url: string) => setContextUrls((prev) => prev.filter((u) => u !== url))}
+          debug={debug}
+        />
 
-  const handleInputChange = async (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const inputValue = event.target.value;
-    const cursorPos = event.target.selectionStart;
-
-    setInputMessage(inputValue);
-    adjustTextareaHeight();
-
-    // Extract URLs and update mentions
-    const urls = mention.extractAllUrls(inputValue);
-
-    // Update URLs in context, ensuring uniqueness
-    const newUrls = urls.filter((url) => !contextUrls.includes(url));
-    if (newUrls.length > 0) {
-      // Use Set to ensure uniqueness
-      setContextUrls((prev) => Array.from(new Set([...prev, ...newUrls])));
-    }
-
-    // Update context with debouncing
-    debouncedUpdateContext(inputValue, setContextNotes, contextNotes, app);
-
-    // Handle other input triggers
-    if (cursorPos >= 2 && inputValue.slice(cursorPos - 2, cursorPos) === "[[") {
-      showNoteTitleModal(cursorPos);
-    } else if (inputValue === "/") {
-      showCustomPromptModal();
-    } else if (inputValue.slice(-1) === "@" && currentChain === ChainType.COPILOT_PLUS_CHAIN) {
-      showCopilotPlusOptionsModal();
-    }
-  };
-
-  const adjustTextareaHeight = () => {
-    if (textAreaRef.current) {
-      textAreaRef.current.style.height = "auto"; // Reset height
-      textAreaRef.current.style.height = `${textAreaRef.current.scrollHeight}px`; // Adjust height
-    }
-  };
-
-  useEffect(() => {
-    adjustTextareaHeight();
-  }, [inputMessage]);
-
-  const showNoteTitleModal = (cursorPos: number) => {
-    const fetchNoteTitles = async () => {
-      const noteTitles = app.vault.getMarkdownFiles().map((file: TFile) => file.basename);
-      const contextProcessor = ContextProcessor.getInstance();
-
-      new NoteTitleModal(app, noteTitles, async (noteTitle: string) => {
-        const before = inputMessage.slice(0, cursorPos - 2);
-        const after = inputMessage.slice(cursorPos - 1);
-        const newInputMessage = `${before}[[${noteTitle}]]${after}`;
-        setInputMessage(newInputMessage);
-
-        // Manually invoke debouncedUpdateContext
-        debouncedUpdateContext(newInputMessage, setContextNotes, contextNotes, app);
-
-        const activeNote = app.workspace.getActiveFile();
-        const noteFile = app.vault.getMarkdownFiles().find((file) => file.basename === noteTitle);
-
-        if (noteFile) {
-          await contextProcessor.addNoteToContext(
-            noteFile,
-            vault,
-            contextNotes,
-            activeNote,
-            setContextNotes,
-            setIncludeActiveNote
-          );
-        }
-
-        // Add a delay to ensure the cursor is set after inputMessage is updated
-        setTimeout(() => {
-          if (textAreaRef.current) {
-            const newCursorPos = cursorPos + noteTitle.length + 2;
-            textAreaRef.current.setSelectionRange(newCursorPos, newCursorPos);
-          }
-        }, 0);
-      }).open();
-    };
-    fetchNoteTitles();
-  };
-
-  const showCustomPromptModal = async () => {
-    const customPromptProcessor = CustomPromptProcessor.getInstance(app.vault, settings);
-    const prompts = await customPromptProcessor.getAllPrompts();
-    const promptTitles = prompts.map((prompt) => prompt.title);
-
-    new ListPromptModal(app, promptTitles, async (promptTitle: string) => {
-      const selectedPrompt = prompts.find((prompt) => prompt.title === promptTitle);
-      if (selectedPrompt) {
-        await customPromptProcessor.recordPromptUsage(selectedPrompt.title);
-        setInputMessage(selectedPrompt.content);
-      }
-    }).open();
-  };
-
-  const showCopilotPlusOptionsModal = () => {
-    // Create a map of options with their descriptions
-    const optionsWithDescriptions = COPILOT_TOOL_NAMES.map((option) => ({
-      title: option,
-      description: getToolDescription(option),
-    }));
-
-    new ListPromptModal(
-      app,
-      optionsWithDescriptions.map((o) => o.title),
-      (selectedOption: string) => {
-        setInputMessage(inputMessage + selectedOption + " ");
-      },
-      // Add descriptions as a separate array
-      optionsWithDescriptions.map((o) => o.description)
-    ).open();
-  };
-
-  useEffect(() => {
-    setShouldFocus(chatIsVisible);
-  }, [chatIsVisible]);
-
-  useEffect(() => {
-    if (textAreaRef.current && shouldFocus) {
-      textAreaRef.current.focus();
-    }
-  }, [shouldFocus]);
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.nativeEvent.isComposing) return;
-
-    const textarea = textAreaRef.current;
-    if (!textarea) return;
-
-    const { selectionStart, value } = textarea;
-    const lines = value.split("\n");
-    const currentLineIndex = value.substring(0, selectionStart).split("\n").length - 1;
-
-    // Check for Cmd+Shift+Enter (Mac) or Ctrl+Shift+Enter (Windows)
-    if (e.key === "Enter" && e.shiftKey && (Platform.isMacOS ? e.metaKey : e.ctrlKey)) {
-      e.preventDefault();
-      e.stopPropagation();
-
-      if (currentChain === ChainType.COPILOT_PLUS_CHAIN) {
-        handleSendMessage(["@vault"]);
-      } else {
-        handleSendMessage();
-      }
-      setHistoryIndex(-1);
-      setTempInput("");
-      return;
-    }
-
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSendMessage();
-      setHistoryIndex(-1);
-      setTempInput("");
-    } else if (e.key === "ArrowUp") {
-      if (currentLineIndex > 0 || selectionStart > 0) {
-        // Allow normal cursor movement within multi-line input
-        return;
-      }
-      e.preventDefault();
-      if (historyIndex === -1 && value.trim() !== "") {
-        setTempInput(value);
-      }
-      const newMessage = navigateHistory("up");
-      if (newMessage !== inputMessage) {
-        setHistoryIndex(historyIndex + 1);
-        setInputMessage(newMessage);
-        // Set cursor to beginning of input after update
-        setTimeout(() => {
-          if (textarea) {
-            textarea.selectionStart = textarea.selectionEnd = 0;
-          }
-        }, 0);
-      }
-    } else if (e.key === "ArrowDown") {
-      if (currentLineIndex < lines.length - 1 || selectionStart < value.length) {
-        // Allow normal cursor movement within multi-line input
-        return;
-      }
-      e.preventDefault();
-      if (historyIndex > -1) {
-        const newMessage = navigateHistory("down");
-        setHistoryIndex(historyIndex - 1);
-        if (historyIndex === 0) {
-          setInputMessage(tempInput);
-        } else {
-          setInputMessage(newMessage);
-        }
-        // Set cursor to beginning of input after update
-        setTimeout(() => {
-          if (textarea) {
-            textarea.selectionStart = textarea.selectionEnd = 0;
-          }
-        }, 0);
-      }
-    }
-  };
-
-  useEffect(() => {
-    // Get all note titles that are referenced using [[note]] syntax in the input
-    const currentTitles = new Set(extractNoteTitles(inputMessage));
-    // Get all URLs mentioned in the input
-    const currentUrls = mention.extractAllUrls(inputMessage);
-    // Get the currently open note in the editor
-    const activeNote = app.workspace.getActiveFile();
-
-    setContextNotes((prev) =>
-      prev.filter((note) => {
-        // Check if this note was added by typing [[note]] in the input
-        // as opposed to being added via the "Add Note to Context" button
-        const wasAddedViaReference = (note as any).wasAddedViaReference === true;
-
-        // Special handling for the active note (currently open in editor)
-        if (note.path === activeNote?.path) {
-          if (wasAddedViaReference) {
-            // Case 1: Active note was added by typing [[note]]
-            // Keep it only if its title is still in the input
-            // This ensures it's removed when you delete the [[note]] reference
-            return currentTitles.has(note.basename);
-          } else {
-            // Case 2: Active note was NOT added by [[note]], but by the includeActiveNote toggle
-            // Keep it only if includeActiveNote is true
-            // This handles the "Include active note" toggle in the UI
-            return includeActiveNote;
-          }
-        } else {
-          // Handling for all other notes (not the active note)
-          if (wasAddedViaReference) {
-            // Case 3: Other note was added by typing [[note]]
-            // Keep it only if its title is still in the input
-            // This ensures it's removed when you delete the [[note]] reference
-            return currentTitles.has(note.basename);
-          } else {
-            // Case 4: Other note was added via "Add Note to Context" button
-            // Always keep these notes as they were manually added
-            return true;
-          }
-        }
-      })
-    );
-
-    // Remove any URLs that are no longer present in the input
-    setContextUrls((prev) => prev.filter((url) => currentUrls.includes(url)));
-  }, [inputMessage, includeActiveNote]);
-
-  return (
-    <div className="chat-input-container" ref={containerRef}>
-      <ChatControls
-        currentChain={currentChain}
-        setCurrentChain={setCurrentChain}
-        onNewChat={onNewChat}
-        onSaveAsNote={onSaveAsNote}
-        onRefreshVaultContext={onRefreshVaultContext}
-        settings={settings}
-        vault_qa_strategy={vault_qa_strategy}
-        isIndexLoadedPromise={isIndexLoadedPromise}
-        app={app}
-        contextNotes={contextNotes}
-        setContextNotes={setContextNotes}
-        includeActiveNote={includeActiveNote}
-        setIncludeActiveNote={setIncludeActiveNote}
-        contextUrls={contextUrls}
-        onRemoveUrl={(url: string) => setContextUrls((prev) => prev.filter((u) => u !== url))}
-        debug={debug}
-      />
-
-      {selectedImages.length > 0 && (
-        <div className="selected-images">
-          {selectedImages.map((file, index) => (
-            <div key={index} className="image-preview-container">
-              <img
-                src={URL.createObjectURL(file)}
-                alt={file.name}
-                className="selected-image-preview"
-              />
-              <button
-                className="remove-image-button"
-                onClick={() => setSelectedImages((prev) => prev.filter((_, i) => i !== index))}
-                title="Remove image"
-              >
-                ×
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-
-      <textarea
-        ref={textAreaRef}
-        className="chat-input-textarea"
-        placeholder="Ask anything. [[ for notes. / for custom prompts."
-        value={inputMessage}
-        onChange={handleInputChange}
-        onKeyDown={handleKeyDown}
-      />
-
-      <div className="chat-input-controls">
-        <div className="chat-input-left">
-          <DropdownMenu.Root open={isModelDropdownOpen} onOpenChange={setIsModelDropdownOpen}>
-            <DropdownMenu.Trigger className="model-select-button">
-              {settings.activeModels.find((model) => getModelKey(model) === currentModelKey)
-                ?.name || "Select Model"}
-              <ChevronUp size={10} />
-            </DropdownMenu.Trigger>
-
-            <DropdownMenu.Portal>
-              <DropdownMenu.Content className="model-select-content" align="start">
-                {settings.activeModels
-                  .filter((model) => model.enabled)
-                  .map((model) => (
-                    <DropdownMenu.Item
-                      key={getModelKey(model)}
-                      onSelect={() => setCurrentModelKey(getModelKey(model))}
-                    >
-                      {model.name}
-                    </DropdownMenu.Item>
-                  ))}
-              </DropdownMenu.Content>
-            </DropdownMenu.Portal>
-          </DropdownMenu.Root>
-
-          {currentChain === ChainType.COPILOT_PLUS_CHAIN && (
-            <TooltipActionButton
-              onClick={() => {
-                new AddImageModal(app, onAddImage).open();
-              }}
-              Icon={
-                <div className="button-content">
-                  <span>image</span>
-                  <Image className="icon-scaler" />
-                </div>
-              }
-            >
-              Add Image
-            </TooltipActionButton>
-          )}
-        </div>
-
-        <div className="chat-input-buttons">
-          {isGenerating && (
-            <button onClick={() => onStopGenerating()} className="submit-button cancel">
-              <StopCircle />
-            </button>
-          )}
-          <button onClick={() => handleSendMessage()} className="submit-button">
-            <CornerDownLeft size={16} />
-            <span>chat</span>
-          </button>
-
-          {currentChain === "copilot_plus" && (
-            <button onClick={() => handleSendMessage(["@vault"])} className="submit-button vault">
-              <div className="button-content">
-                {Platform.isMacOS ? (
-                  <>
-                    <Command size={12} />
-                    <ArrowBigUp size={16} />
-                    <CornerDownLeft size={16} />
-                  </>
-                ) : (
-                  <>
-                    <span>Ctrl</span>
-                    <ArrowBigUp size={16} />
-                    <CornerDownLeft size={16} />
-                  </>
-                )}
-                <span>vault</span>
+        {selectedImages.length > 0 && (
+          <div className="selected-images">
+            {selectedImages.map((file, index) => (
+              <div key={index} className="image-preview-container">
+                <img
+                  src={URL.createObjectURL(file)}
+                  alt={file.name}
+                  className="selected-image-preview"
+                />
+                <button
+                  className="remove-image-button"
+                  onClick={() => setSelectedImages((prev) => prev.filter((_, i) => i !== index))}
+                  title="Remove image"
+                >
+                  ×
+                </button>
               </div>
+            ))}
+          </div>
+        )}
+
+        <textarea
+          ref={textAreaRef}
+          className="chat-input-textarea"
+          placeholder="Ask anything. [[ for notes. / for custom prompts."
+          value={inputMessage}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+        />
+
+        <div className="chat-input-controls">
+          <div className="chat-input-left">
+            <DropdownMenu.Root open={isModelDropdownOpen} onOpenChange={setIsModelDropdownOpen}>
+              <DropdownMenu.Trigger className="model-select-button">
+                {settings.activeModels.find((model) => getModelKey(model) === currentModelKey)
+                  ?.name || "Select Model"}
+                <ChevronUp size={10} />
+              </DropdownMenu.Trigger>
+
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content className="model-select-content" align="start">
+                  {settings.activeModels
+                    .filter((model) => model.enabled)
+                    .map((model) => (
+                      <DropdownMenu.Item
+                        key={getModelKey(model)}
+                        onSelect={() => setCurrentModelKey(getModelKey(model))}
+                      >
+                        {model.name}
+                      </DropdownMenu.Item>
+                    ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+
+            {currentChain === ChainType.COPILOT_PLUS_CHAIN && (
+              <TooltipActionButton
+                onClick={() => {
+                  new AddImageModal(app, onAddImage).open();
+                }}
+                Icon={
+                  <div className="button-content">
+                    <span>image</span>
+                    <Image className="icon-scaler" />
+                  </div>
+                }
+              >
+                Add Image
+              </TooltipActionButton>
+            )}
+          </div>
+
+          <div className="chat-input-buttons">
+            {isGenerating && (
+              <button onClick={() => onStopGenerating()} className="submit-button cancel">
+                <StopCircle />
+              </button>
+            )}
+            <button onClick={() => handleSendMessage()} className="submit-button">
+              <CornerDownLeft size={16} />
+              <span>chat</span>
             </button>
-          )}
+
+            {currentChain === "copilot_plus" && (
+              <button onClick={() => handleSendMessage(["@vault"])} className="submit-button vault">
+                <div className="button-content">
+                  {Platform.isMacOS ? (
+                    <>
+                      <Command size={12} />
+                      <ArrowBigUp size={16} />
+                      <CornerDownLeft size={16} />
+                    </>
+                  ) : (
+                    <>
+                      <span>Ctrl</span>
+                      <ArrowBigUp size={16} />
+                      <CornerDownLeft size={16} />
+                    </>
+                  )}
+                  <span>vault</span>
+                </div>
+              </button>
+            )}
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+);
+
+ChatInput.displayName = "ChatInput";
 
 export default ChatInput;

--- a/src/components/ChatComponents/ChatMessages.tsx
+++ b/src/components/ChatComponents/ChatMessages.tsx
@@ -1,7 +1,6 @@
 import { ChainType } from "@/chainFactory";
 import ChatSingleMessage from "@/components/ChatComponents/ChatSingleMessage";
 import { SuggestedPrompts } from "@/components/ChatComponents/SuggestedPrompts";
-import { VAULT_VECTOR_STORE_STRATEGY } from "@/constants";
 import { ChatMessage } from "@/sharedState";
 import { App } from "obsidian";
 import React, { useEffect, useState } from "react";
@@ -12,7 +11,6 @@ interface ChatMessagesProps {
   loading?: boolean;
   loadingMessage?: string;
   app: App;
-  indexVaultToVectorStore: VAULT_VECTOR_STORE_STRATEGY;
   currentChain: ChainType;
   onInsertAtCursor: (message: string) => void;
   onRegenerate: (messageIndex: number) => void;
@@ -26,7 +24,6 @@ const ChatMessages: React.FC<ChatMessagesProps> = ({
   currentAiMessage,
   loading,
   currentChain,
-  indexVaultToVectorStore,
   loadingMessage,
   app,
   onInsertAtCursor,
@@ -65,11 +62,7 @@ const ChatMessages: React.FC<ChatMessagesProps> = ({
   if (!chatHistory.filter((message) => message.isVisible).length && !currentAiMessage) {
     return (
       <div className="chat-messages">
-        <SuggestedPrompts
-          chainType={currentChain}
-          indexVaultToVectorStore={indexVaultToVectorStore}
-          onClick={onSelectSuggestedPrompt}
-        />
+        <SuggestedPrompts chainType={currentChain} onClick={onSelectSuggestedPrompt} />
       </div>
     );
   }

--- a/src/components/ChatComponents/SuggestedPrompts.tsx
+++ b/src/components/ChatComponents/SuggestedPrompts.tsx
@@ -1,5 +1,6 @@
 import { ChainType } from "@/chainFactory";
 import { VAULT_VECTOR_STORE_STRATEGY } from "@/constants";
+import { useSettingsValueContext } from "@/settings/contexts/SettingsValueContext";
 import React, { useMemo } from "react";
 
 interface NotePrompt {
@@ -80,16 +81,19 @@ function getRandomPrompt(chainType: ChainType = ChainType.LLM_CHAIN) {
 
 interface SuggestedPromptsProps {
   chainType: ChainType;
-  indexVaultToVectorStore: VAULT_VECTOR_STORE_STRATEGY;
   onClick: (text: string) => void;
 }
 
-export const SuggestedPrompts: React.FC<SuggestedPromptsProps> = ({
-  chainType,
-  indexVaultToVectorStore,
-  onClick,
-}) => {
+export const SuggestedPrompts: React.FC<SuggestedPromptsProps> = ({ chainType, onClick }) => {
   const prompts = useMemo(() => getRandomPrompt(chainType), [chainType]);
+  const settings = useSettingsValueContext();
+  const indexVaultToVectorStore = settings.indexVaultToVectorStore as VAULT_VECTOR_STORE_STRATEGY;
+  const showSuggestedPrompts = settings.showSuggestedPrompts;
+
+  if (!showSuggestedPrompts) {
+    return null;
+  }
+
   return (
     <div
       style={{

--- a/src/components/CopilotView.tsx
+++ b/src/components/CopilotView.tsx
@@ -10,6 +10,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import { ItemView, WorkspaceLeaf } from "obsidian";
 import * as React from "react";
 import { Root, createRoot } from "react-dom/client";
+import { SettingsValueProvider } from "@/settings/contexts/SettingsValueContext";
 
 export default class CopilotView extends ItemView {
   private chainManager: ChainManager;
@@ -64,22 +65,23 @@ export default class CopilotView extends ItemView {
       <AppContext.Provider value={this.app}>
         <React.StrictMode>
           <Tooltip.Provider delayDuration={0}>
-            <Chat
-              sharedState={this.sharedState}
-              settings={this.settings}
-              chainManager={this.chainManager}
-              emitter={this.emitter}
-              defaultSaveFolder={this.defaultSaveFolder}
-              updateUserMessageHistory={(newMessage) => {
-                this.plugin.updateUserMessageHistory(newMessage);
-              }}
-              fileParserManager={this.fileParserManager}
-              plugin={this.plugin}
-              debug={this.debug}
-              onSaveChat={(saveFunction) => {
-                this.handleSaveAsNote = saveFunction;
-              }}
-            />
+            <SettingsValueProvider value={this.settings}>
+              <Chat
+                sharedState={this.sharedState}
+                chainManager={this.chainManager}
+                emitter={this.emitter}
+                defaultSaveFolder={this.defaultSaveFolder}
+                updateUserMessageHistory={(newMessage) => {
+                  this.plugin.updateUserMessageHistory(newMessage);
+                }}
+                fileParserManager={this.fileParserManager}
+                plugin={this.plugin}
+                debug={this.debug}
+                onSaveChat={(saveFunction) => {
+                  this.handleSaveAsNote = saveFunction;
+                }}
+              />
+            </SettingsValueProvider>
           </Tooltip.Provider>
         </React.StrictMode>
       </AppContext.Provider>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -257,6 +257,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   activeEmbeddingModels: BUILTIN_EMBEDDING_MODELS,
   embeddingRequestsPerSecond: 10,
   disableIndexOnMobile: true,
+  showSuggestedPrompts: true,
   enabledCommands: {
     [COMMAND_IDS.FIX_GRAMMAR]: {
       enabled: true,

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -53,6 +53,7 @@ export interface CopilotSettings {
   embeddingRequestsPerSecond: number;
   defaultOpenArea: DEFAULT_OPEN_AREA;
   disableIndexOnMobile: boolean;
+  showSuggestedPrompts: boolean;
 }
 
 export class CopilotSettingTab extends PluginSettingTab {
@@ -97,7 +98,7 @@ export class CopilotSettingTab extends PluginSettingTab {
 
     sections.render(
       <SettingsProvider plugin={this.plugin} reloadPlugin={this.reloadPlugin.bind(this)}>
-        <SettingsMain plugin={this.plugin} reloadPlugin={this.reloadPlugin.bind(this)} />
+        <SettingsMain plugin={this.plugin} />
       </SettingsProvider>
     );
 

--- a/src/settings/components/GeneralSettings.tsx
+++ b/src/settings/components/GeneralSettings.tsx
@@ -108,6 +108,12 @@ const GeneralSettings: React.FC<GeneralSettingsProps> = ({
         value={settings.autosaveChat}
         onChange={(value) => updateSettings({ autosaveChat: value })}
       />
+      <ToggleComponent
+        name="Suggested Prompts"
+        description="Show suggested prompts in the chat view"
+        value={settings.showSuggestedPrompts}
+        onChange={(value) => updateSettings({ showSuggestedPrompts: value })}
+      />
       <div className="chat-icon-selection-tooltip">
         <h2>Open Plugin In</h2>
         <div className="select-wrapper">

--- a/src/settings/components/SettingsMain.tsx
+++ b/src/settings/components/SettingsMain.tsx
@@ -7,10 +7,7 @@ import CopilotPlusSettings from "./CopilotPlusSettings";
 import GeneralSettings from "./GeneralSettings";
 import QASettings from "./QASettings";
 
-const SettingsMain: React.FC<{ plugin: CopilotPlugin; reloadPlugin: () => Promise<void> }> = ({
-  plugin,
-  reloadPlugin,
-}) => {
+const SettingsMain: React.FC<{ plugin: CopilotPlugin }> = ({ plugin }) => {
   const { settings, updateSettings, saveSettings, resetSettings } = useSettingsContext();
 
   return (

--- a/src/settings/contexts/SettingsContext.tsx
+++ b/src/settings/contexts/SettingsContext.tsx
@@ -8,7 +8,6 @@ interface SettingsContextType {
   updateSettings: (newSettings: Partial<CopilotSettings>) => void;
   saveSettings: () => Promise<void>;
   resetSettings: () => Promise<void>;
-  reloadPlugin: () => Promise<void>;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
@@ -51,9 +50,7 @@ export const SettingsProvider: React.FC<{
   }, [plugin, reloadPlugin]);
 
   return (
-    <SettingsContext.Provider
-      value={{ settings, updateSettings, saveSettings, resetSettings, reloadPlugin }}
-    >
+    <SettingsContext.Provider value={{ settings, updateSettings, saveSettings, resetSettings }}>
       {children}
     </SettingsContext.Provider>
   );

--- a/src/settings/contexts/SettingsValueContext.tsx
+++ b/src/settings/contexts/SettingsValueContext.tsx
@@ -1,0 +1,19 @@
+import { CopilotSettings } from "@/settings/SettingsPage";
+import React, { createContext, useContext } from "react";
+
+const SettingsValueContext = createContext<CopilotSettings | undefined>(undefined);
+
+export const SettingsValueProvider: React.FC<{
+  value: CopilotSettings;
+  children: React.ReactNode;
+}> = ({ value, children }) => {
+  return <SettingsValueContext.Provider value={value}>{children}</SettingsValueContext.Provider>;
+};
+
+export const useSettingsValueContext = () => {
+  const context = useContext(SettingsValueContext);
+  if (context === undefined) {
+    throw new Error("useSettingsValueContext must be used within a SettingsValueProvider");
+  }
+  return context;
+};


### PR DESCRIPTION
This PR includes the following features and bug fixes:

- Features
  - Added a settings to hide suggested prompts
<img width="948" alt="Screenshot 2024-11-16 at 12 56 53 PM" src="https://github.com/user-attachments/assets/f63a01ad-7aeb-48b5-a6a8-b71f88b86554">

- Bug Fixes
  - Open chat command will now properly focus the chat.
![2024-11-16 12 58 04](https://github.com/user-attachments/assets/1280de6a-1c9d-4cb9-9bfc-788bb51d793f)

  - Reopen chat window will inherit the previous chat control settings.
![2024-11-16 12 58 43](https://github.com/user-attachments/assets/e5130df7-d52e-4762-a5b8-f39f1884f5df)

- Dev Ex Improvements
  - Added a settings value context. Chat components can use it directly to avoid props drilling.
  - Removed unused variables and imports.
  - Changed how chat focus is working. Made it more reliable and easier to work with.

