### PR TITLE
Fix "index not loaded"

### DIFF
--- a/src/VectorStoreManager.ts
+++ b/src/VectorStoreManager.ts
@@ -149,7 +149,8 @@ class VectorStoreManager {
     }
   }
 
-  public getIsIndexLoaded(): boolean {
+  public async getIsIndexLoaded(): Promise<boolean> {
+    await this.waitForInitialization();
     return this.isIndexLoaded;
   }
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -574,7 +574,7 @@ ${chatContent}`;
           debug={debug}
           addMessage={addMessage}
           vault={app.vault}
-          isIndexLoaded={plugin.vectorStoreManager.getIsIndexLoaded()}
+          isIndexLoadedPromise={plugin.vectorStoreManager.getIsIndexLoaded()}
         />
       </div>
     </div>

--- a/src/components/ChatComponents/ChatControls.tsx
+++ b/src/components/ChatComponents/ChatControls.tsx
@@ -20,8 +20,8 @@ interface ChatControlsProps {
   onRefreshVaultContext: () => void;
   settings: CopilotSettings;
   vault_qa_strategy: string;
+  isIndexLoadedPromise: Promise<boolean>;
   debug?: boolean;
-  isIndexLoaded: boolean;
 }
 
 const ChatControls: React.FC<ChatControlsProps> = ({
@@ -33,9 +33,16 @@ const ChatControls: React.FC<ChatControlsProps> = ({
   settings,
   vault_qa_strategy,
   debug,
-  isIndexLoaded,
+  isIndexLoadedPromise,
 }) => {
   const [selectedChain, setSelectedChain] = useState<ChainType>(currentChain);
+  const [isIndexLoaded, setIsIndexLoaded] = useState(false);
+
+  useEffect(() => {
+    isIndexLoadedPromise.then((loaded) => {
+      setIsIndexLoaded(loaded);
+    });
+  }, [isIndexLoadedPromise]);
 
   const handleChainChange = async ({ value }: { value: string }) => {
     const newChain = stringToChainType(value);

--- a/src/components/ChatComponents/ChatInput.tsx
+++ b/src/components/ChatComponents/ChatInput.tsx
@@ -31,7 +31,7 @@ interface ChatInputProps {
   addMessage: (message: ChatMessage) => void;
   vault: Vault;
   vault_qa_strategy: string;
-  isIndexLoaded: boolean;
+  isIndexLoadedPromise: Promise<boolean>;
   debug?: boolean;
 }
 
@@ -57,7 +57,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
   addMessage,
   vault,
   vault_qa_strategy,
-  isIndexLoaded,
+  isIndexLoadedPromise,
   debug,
 }) => {
   const [shouldFocus, setShouldFocus] = useState(false);
@@ -206,7 +206,7 @@ const ChatInput: React.FC<ChatInputProps> = ({
         onRefreshVaultContext={onRefreshVaultContext}
         settings={settings}
         vault_qa_strategy={vault_qa_strategy}
-        isIndexLoaded={isIndexLoaded}
+        isIndexLoadedPromise={isIndexLoadedPromise}
         debug={debug}
       />
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -243,7 +243,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   activeModels: BUILTIN_CHAT_MODELS,
   activeEmbeddingModels: BUILTIN_EMBEDDING_MODELS,
   embeddingRequestsPerSecond: 10,
-  disableIndexOnMobile: false,
+  disableIndexOnMobile: true,
   enabledCommands: {
     [COMMAND_IDS.FIX_GRAMMAR]: {
       enabled: true,

--- a/src/settings/components/QASettings.tsx
+++ b/src/settings/components/QASettings.tsx
@@ -151,7 +151,7 @@ const QASettings: React.FC<QASettingsProps> = ({
       />
       <ToggleComponent
         name="Disable index loading on mobile"
-        description="When enabled, vector store index won't be loaded on mobile devices to save resources. Only chat mode will be available. Any existing index from desktop sync will be preserved."
+        description="When enabled, vector store index won't be loaded on mobile devices to save resources. Only chat mode will be available. Any existing index from desktop sync will be preserved. Uncheck to enable QA modes on mobile."
         value={disableIndexOnMobile}
         onChange={setDisableIndexOnMobile}
       />


### PR DESCRIPTION
Related: #815 

When `disable indexing on mobile` is false, or it's on desktop, the index should always be loaded and all chat modes should be available.

Also set this setting to true by default for not crashing mobile app.