### PR TITLE
Add Mistral AI support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@langchain/core": "^0.3.3",
         "@langchain/google-genai": "^0.1.2",
         "@langchain/groq": "^0.1.2",
+        "@langchain/mistralai": "^0.1.1",
         "@orama/orama": "^3.0.0-rc-2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-tooltip": "^1.1.3",
@@ -3788,6 +3789,37 @@
         "@langchain/core": ">=0.2.21 <0.4.0"
       }
     },
+    "node_modules/@langchain/mistralai": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@langchain/mistralai/-/mistralai-0.1.1.tgz",
+      "integrity": "sha512-gnHdQRfn+iBReKD0u1nydGqHgVOjnKHpd0Q2qEN61ZuxiqFOOauWYkrbyml7tzcOdMv2vUAr5+pjpXip+ez59w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mistralai/mistralai": "^0.4.0",
+        "uuid": "^10.0.0",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.22.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/mistralai/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@langchain/ollama": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@langchain/ollama/-/ollama-0.1.1.tgz",
@@ -3846,6 +3878,15 @@
       },
       "peerDependencies": {
         "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-0.4.0.tgz",
+      "integrity": "sha512-KmFzNro1RKxIFh19J3osmUQhucefBBauMXN5fa9doG6dT9OHR/moBvvn+riVlR7c0AVfuxO8Dfa03AyLYYzbyg==",
+      "license": "ISC",
+      "dependencies": {
+        "node-fetch": "^2.6.7"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@langchain/core": "^0.3.3",
     "@langchain/google-genai": "^0.1.2",
     "@langchain/groq": "^0.1.2",
+    "@langchain/mistralai": "^0.1.1",
     "@orama/orama": "^3.0.0-rc-2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-tooltip": "^1.1.3",

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -9,6 +9,7 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { ChatGroq } from "@langchain/groq";
 import { ChatOllama } from "@langchain/ollama";
 import { ChatOpenAI } from "@langchain/openai";
+import { ChatMistralAI } from "@langchain/mistralai";
 import { Notice } from "obsidian";
 
 export default class ChatModelManager {
@@ -16,6 +17,7 @@ export default class ChatModelManager {
   private static instance: ChatModelManager;
   private static chatModel: BaseChatModel;
   private static chatOpenAI: ChatOpenAI;
+  // private static chatMistralAI: ChatMistralAI;
   private static modelMap: Record<
     string,
     {
@@ -67,6 +69,12 @@ export default class ChatModelManager {
         modelName: customModel.name,
         openAIApiKey: decrypt(customModel.apiKey || params.openAIApiKey),
         openAIOrgId: decrypt(params.openAIOrgId),
+        maxTokens: params.maxTokens,
+      },
+      [ChatModelProviders.MISTRAL]: {
+        modelName: customModel.name,
+        // why it has to be apikey exactly?
+        apiKey: decrypt(customModel.apiKey || params.mistralApiKey),
         maxTokens: params.maxTokens,
       },
       [ChatModelProviders.ANTHROPIC]: {
@@ -193,6 +201,10 @@ export default class ChatModelManager {
           case ChatModelProviders.OPENAI_FORMAT:
             constructor = ProxyChatOpenAI;
             apiKey = model.apiKey || "default-key";
+            break;
+          case ChatModelProviders.MISTRAL:
+            constructor = ChatMistralAI;
+            apiKey = model.apiKey || this.getLangChainParams().mistralApiKey;
             break;
           default:
             console.warn(`Unknown provider: ${model.provider} for model: ${model.name}`);

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -11,6 +11,7 @@ export interface ModelConfig {
   maxTokens?: number;
   openAIApiKey?: string;
   openAIOrgId?: string;
+  mistralApiKey?: string;
   anthropicApiKey?: string;
   cohereApiKey?: string;
   azureOpenAIApiKey?: string;
@@ -28,6 +29,7 @@ export interface LangChainParams {
   modelKey: string; // name | provider, e.g. "gpt-4o|openai"
   openAIApiKey: string;
   openAIOrgId: string;
+  mistralApiKey: string;
   huggingfaceApiKey: string;
   cohereApiKey: string;
   anthropicApiKey: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,7 @@ export enum ChatModels {
   CLAUDE_3_HAIKU = "claude-3-haiku-20240307",
   COMMAND_R = "command-r",
   COMMAND_R_PLUS = "command-r-plus",
+  MISTRAL_LARGE = "mistral-large-latest",
 }
 
 // Model Providers
@@ -46,6 +47,7 @@ export enum ChatModelProviders {
   OLLAMA = "ollama",
   LM_STUDIO = "lm-studio",
   OPENAI_FORMAT = "3rd party (openai-format)",
+  MISTRAL = "mistral",
 }
 
 export const BUILTIN_CHAT_MODELS: CustomModel[] = [
@@ -108,6 +110,12 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
   {
     name: ChatModels.AZURE_OPENAI,
     provider: ChatModelProviders.AZURE_OPENAI,
+    enabled: true,
+    isBuiltIn: true,
+  },
+  {
+    name: ChatModels.MISTRAL_LARGE,
+    provider: ChatModelProviders.MISTRAL,
     enabled: true,
     isBuiltIn: true,
   },
@@ -219,6 +227,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   plusLicenseKey: "",
   openAIApiKey: "",
   openAIOrgId: "",
+  mistralApiKey: "",
   huggingfaceApiKey: "",
   cohereApiKey: "",
   anthropicApiKey: "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -591,6 +591,7 @@ export default class CopilotPlugin extends Plugin {
     const {
       openAIApiKey,
       openAIOrgId,
+      mistralApiKey,
       huggingfaceApiKey,
       cohereApiKey,
       anthropicApiKey,
@@ -610,6 +611,7 @@ export default class CopilotPlugin extends Plugin {
     return {
       openAIApiKey,
       openAIOrgId,
+      mistralApiKey,
       huggingfaceApiKey,
       cohereApiKey,
       anthropicApiKey,

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -13,6 +13,7 @@ export interface CopilotSettings {
   plusLicenseKey: string;
   openAIApiKey: string;
   openAIOrgId: string;
+  mistralApiKey: string;
   huggingfaceApiKey: string;
   cohereApiKey: string;
   anthropicApiKey: string;

--- a/src/settings/components/ApiSettings.tsx
+++ b/src/settings/components/ApiSettings.tsx
@@ -7,6 +7,8 @@ interface ApiSettingsProps {
   setOpenAIApiKey: (value: string) => void;
   openAIOrgId: string;
   setOpenAIOrgId: (value: string) => void;
+  mistralApiKey: string;
+  setMistralApiKey: (value: string) => void;
   googleApiKey: string;
   setGoogleApiKey: (value: string) => void;
   anthropicApiKey: string;
@@ -34,6 +36,8 @@ const ApiSettings: React.FC<ApiSettingsProps> = ({
   setOpenAIApiKey,
   openAIOrgId,
   setOpenAIOrgId,
+  mistralApiKey,
+  setMistralApiKey,
   googleApiKey,
   setGoogleApiKey,
   anthropicApiKey,
@@ -251,6 +255,24 @@ const ApiSettings: React.FC<ApiSettingsProps> = ({
           <a href="https://dashboard.cohere.ai/api-keys" target="_blank" rel="noreferrer">
             here
           </a>
+        </p>
+      </Collapsible>
+
+      <Collapsible title="Mistral AI API Settings">
+        <ApiSetting
+          title="Mistral API Key"
+          value={mistralApiKey}
+          setValue={setMistralApiKey}
+          placeholder="Enter Mistral API Key"
+        />
+        <p>
+          You can find your API key at{" "}
+          <a href="https://console.mistral.ai/api-keys/" target="_blank" rel="noreferrer">
+            here
+          </a>
+          .
+          <br />
+          Your API key is stored locally and is only used to make requests to Mistra AI services.
         </p>
       </Collapsible>
     </div>

--- a/src/settings/components/SettingsMain.tsx
+++ b/src/settings/components/SettingsMain.tsx
@@ -37,6 +37,7 @@ const SettingsMain: React.FC<{ plugin: CopilotPlugin; reloadPlugin: () => Promis
         {...settings}
         setOpenAIApiKey={(value) => updateSettings({ openAIApiKey: value })}
         setOpenAIOrgId={(value) => updateSettings({ openAIOrgId: value })}
+        setMistralApiKey={(value) => updateSettings({ mistralApiKey: value })}
         setGoogleApiKey={(value) => updateSettings({ googleApiKey: value })}
         setAnthropicApiKey={(value) => updateSettings({ anthropicApiKey: value })}
         setOpenRouterAiApiKey={(value) => updateSettings({ openRouterAiApiKey: value })}


### PR DESCRIPTION
I felt creative this weekend, and decided to implement Mistral AI support to Obsidian Copilot, following #238 

For support I've used `@langchain/mistralai` dedicated package. Now I know Mistral in theory supports OpenAI API format, but I was kind of lazy.

Maybe your OpenAI proxy class could be somehow modified, didn't test it yet.

Currently `mistral-large-latest` is hardcoded as model.

Also I figure just enough of your code to add support of it. There are some nuisances which I didn't get. If you wish feel free to either make changes or guide me a bit.

![obraz](https://github.com/user-attachments/assets/5b7e8056-de07-4ccf-9c3f-85d3cf3c64e9)
