### PR TITLE
Make open window command focus active view

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,7 @@ export default class CopilotPlugin extends Plugin {
     });
 
     this.addRibbonIcon("message-square", "Copilot Chat", (evt: MouseEvent) => {
-      this.toggleView();
+      this.activateView();
     });
 
     registerBuiltInCommands(this);
@@ -494,19 +494,21 @@ export default class CopilotPlugin extends Plugin {
   }
 
   async activateView(): Promise<void> {
-    this.app.workspace.detachLeavesOfType(CHAT_VIEWTYPE);
-    if (this.settings.defaultOpenArea === DEFAULT_OPEN_AREA.VIEW) {
-      await this.app.workspace.getRightLeaf(false).setViewState({
-        type: CHAT_VIEWTYPE,
-        active: true,
-      });
-    } else {
-      await this.app.workspace.getLeaf(true).setViewState({
-        type: CHAT_VIEWTYPE,
-        active: true,
-      });
+    const leaves = this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE);
+    if (leaves.length === 0) {
+      if (this.settings.defaultOpenArea === DEFAULT_OPEN_AREA.VIEW) {
+        await this.app.workspace.getRightLeaf(false).setViewState({
+          type: CHAT_VIEWTYPE,
+          active: true,
+        });
+      } else {
+        await this.app.workspace.getLeaf(true).setViewState({
+          type: CHAT_VIEWTYPE,
+          active: true,
+        });
+      }
     }
-    this.app.workspace.revealLeaf(this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE)[0]);
+    this.app.workspace.revealLeaf(leaves[0]);
     this.emitChatIsVisible();
   }
 


### PR DESCRIPTION

![2024-11-25 13 14 59](https://github.com/user-attachments/assets/a3656d94-060f-4515-994c-c9e3fe2eded3)

A quick fix to make "Open Copilot Chat Window" command focus on existing active view instead of disabling and instantiating a new view. The previous behavior will disrupt the layout and move the window back to its default location.

This PR also made the ribbon icon use "open window" command instead of "toggle window" command.

https://github.com/logancyang/obsidian-copilot/issues/749