### PR TITLE
Fix note cannot be removed bug

### DIFF
--- a/src/components/chat-components/ChatContextMenu.tsx
+++ b/src/components/chat-components/ChatContextMenu.tsx
@@ -23,9 +23,15 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
   const uniqueNotes = React.useMemo(() => {
     const notesMap = new Map(contextNotes.map((note) => [note.path, note]));
 
-    return Array.from(notesMap.values()).filter(
-      (note) => !(activeNote && note.path === activeNote.path)
-    );
+    return Array.from(notesMap.values()).filter((note) => {
+      // If the note was added manually, always show it in the list
+      if ((note as any).wasAddedManually) {
+        return true;
+      }
+
+      // For non-manually added notes, show them if they're not the active note
+      return !(activeNote && note.path === activeNote.path);
+    });
   }, [contextNotes, activeNote]);
 
   const uniqueUrls = React.useMemo(() => Array.from(new Set(contextUrls)), [contextUrls]);

--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -10,10 +10,10 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { ChevronDown, Download, MessageCirclePlus, Puzzle } from "lucide-react";
 
 import { NewChatConfirmModal } from "@/components/modals/NewChatConfirmModal";
+import { useSettingsValue } from "@/settings/model";
 import { ChatMessage } from "@/sharedState";
 import { TFile } from "obsidian";
 import { ChatContextMenu } from "./ChatContextMenu";
-import { useSettingsValue } from "@/settings/model";
 
 interface ChatControlsProps {
   onNewChat: (openNote: boolean) => void;
@@ -108,10 +108,20 @@ const ChatControls: React.FC<ChatControlsProps> = ({
   };
 
   const handleRemoveContext = (path: string) => {
-    if (activeNote && path === activeNote.path) {
-      setIncludeActiveNote(false);
-    } else {
+    // First check if this note was added manually
+    const noteToRemove = contextNotes.find((note) => note.path === path);
+    const wasAddedManually = noteToRemove && (noteToRemove as any).wasAddedManually;
+
+    if (wasAddedManually) {
+      // If it was added manually, just remove it from contextNotes
       setContextNotes((prev) => prev.filter((note) => note.path !== path));
+    } else {
+      // If it wasn't added manually, it could be either:
+      // 1. The active note (controlled by includeActiveNote)
+      // 2. A note added via [[reference]]
+      // In either case, we should:
+      setIncludeActiveNote(false); // Turn off includeActiveNote if this was the active note
+      setContextNotes((prev) => prev.filter((note) => note.path !== path)); // Remove from contextNotes if it was there
     }
   };
 


### PR DESCRIPTION
Getting active note after a note switch isn't reliable from Obsidian API. Need to make sure any manually added note can be removed from context menu.

Related #878 