### PR TITLE
Avoid using jotai default store

### DIFF
--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -2,8 +2,8 @@ import { ChainType } from "@/chainFactory";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 
-import { atom, getDefaultStore, useAtom } from "jotai";
-import { settingsAtom } from "@/settings/model";
+import { atom, useAtom } from "jotai";
+import { settingsAtom, settingsStore } from "@/settings/model";
 
 const userModelKeyAtom = atom<string | null>(null);
 const modelKeyAtom = atom(
@@ -76,33 +76,37 @@ export interface CustomModel {
 }
 
 export function setModelKey(modelKey: string) {
-  getDefaultStore().set(modelKeyAtom, modelKey);
+  settingsStore.set(modelKeyAtom, modelKey);
 }
 
 export function getModelKey(): string {
-  return getDefaultStore().get(modelKeyAtom);
+  return settingsStore.get(modelKeyAtom);
 }
 
 export function subscribeToModelKeyChange(callback: () => void): () => void {
-  return getDefaultStore().sub(modelKeyAtom, callback);
+  return settingsStore.sub(modelKeyAtom, callback);
 }
 
 export function useModelKey() {
-  return useAtom(modelKeyAtom);
+  return useAtom(modelKeyAtom, {
+    store: settingsStore,
+  });
 }
 
 export function getChainType(): ChainType {
-  return getDefaultStore().get(chainTypeAtom);
+  return settingsStore.get(chainTypeAtom);
 }
 
 export function setChainType(chainType: ChainType) {
-  getDefaultStore().set(chainTypeAtom, chainType);
+  settingsStore.set(chainTypeAtom, chainType);
 }
 
 export function subscribeToChainTypeChange(callback: () => void): () => void {
-  return getDefaultStore().sub(chainTypeAtom, callback);
+  return settingsStore.sub(chainTypeAtom, callback);
 }
 
 export function useChainType() {
-  return useAtom(chainTypeAtom);
+  return useAtom(chainTypeAtom, {
+    store: settingsStore,
+  });
 }

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -1,5 +1,5 @@
 import { CustomModel } from "@/aiParams";
-import { atom, getDefaultStore, useAtomValue } from "jotai";
+import { atom, createStore, useAtomValue } from "jotai";
 
 import { type ChainType } from "@/chainFactory";
 import {
@@ -59,6 +59,7 @@ export interface CopilotSettings {
   showSuggestedPrompts: boolean;
 }
 
+export const settingsStore = createStore();
 export const settingsAtom = atom<CopilotSettings>(DEFAULT_SETTINGS);
 
 /**
@@ -66,7 +67,7 @@ export const settingsAtom = atom<CopilotSettings>(DEFAULT_SETTINGS);
  */
 export function setSettings(settings: Partial<CopilotSettings>) {
   const newSettings = mergeAllActiveModelsWithCoreModels({ ...getSettings(), ...settings });
-  getDefaultStore().set(settingsAtom, newSettings);
+  settingsStore.set(settingsAtom, newSettings);
 }
 
 /**
@@ -82,7 +83,7 @@ export function updateSetting<K extends keyof CopilotSettings>(key: K, value: Co
  * changes.
  */
 export function getSettings(): Readonly<CopilotSettings> {
-  return getDefaultStore().get(settingsAtom);
+  return settingsStore.get(settingsAtom);
 }
 
 /**
@@ -101,14 +102,16 @@ export function resetSettings(): void {
  * Subscribes to changes in the settings atom.
  */
 export function subscribeToSettingsChange(callback: () => void): () => void {
-  return getDefaultStore().sub(settingsAtom, callback);
+  return settingsStore.sub(settingsAtom, callback);
 }
 
 /**
  * Hook to get the settings value from the atom.
  */
 export function useSettingsValue(): Readonly<CopilotSettings> {
-  return useAtomValue(settingsAtom);
+  return useAtomValue(settingsAtom, {
+    store: settingsStore,
+  });
 }
 
 /**


### PR DESCRIPTION
"Detected multiple Jotai instances" warning is thrown when the plugin is reloaded. This PR makes setting model create a dedicated module-level store to replace the jotai global default store to avoid the warning.