### PR TITLE
Add small delay to avoid race condition

### DIFF
--- a/src/search/indexOperations.ts
+++ b/src/search/indexOperations.ts
@@ -475,9 +475,13 @@ export class IndexOperations {
     }
   }
 
-  public cancelIndexing(): void {
+  public async cancelIndexing(): Promise<void> {
     console.log("Indexing cancelled by user");
     this.state.isIndexingCancelled = true;
+
+    // Add a small delay to ensure all state updates are processed
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     if (this.state.currentIndexingNotice) {
       this.state.currentIndexingNotice.hide();
     }


### PR DESCRIPTION
Async bug: in Plus mode, during indexing, clicking on Stop and immediately switch to Chat mode, it will automatically switch back to Plus mode.

Fix: add a small delay to deprioritize the state change in favor of the user-initiated mode switch.