### PR TITLE
Fix Radix portal

### DIFF
--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -142,7 +142,7 @@ const ChatControls: React.FC<ChatControlsProps> = ({
                 <ChevronDown size={10} />
               </DropdownMenu.Trigger>
 
-              <DropdownMenu.Portal>
+              <DropdownMenu.Portal container={activeDocument.body}>
                 <DropdownMenu.Content className="chain-select-content" align="end" sideOffset={5}>
                   <DropdownMenu.Item
                     onSelect={() => handleChainChange({ value: ChainType.LLM_CHAIN })}

--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -452,7 +452,7 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
                 <ChevronUp size={10} />
               </DropdownMenu.Trigger>
 
-              <DropdownMenu.Portal>
+              <DropdownMenu.Portal container={activeDocument.body}>
                 <DropdownMenu.Content className="model-select-content" align="start">
                   {settings.activeModels
                     .filter((model) => model.enabled)

--- a/src/components/chat-components/TooltipActionButton.tsx
+++ b/src/components/chat-components/TooltipActionButton.tsx
@@ -15,7 +15,7 @@ export function TooltipActionButton({ onClick, Icon, children }: PropsWithChildr
           {Icon}
         </button>
       </Tooltip.Trigger>
-      <Tooltip.Portal>
+      <Tooltip.Portal container={activeDocument.body}>
         <Tooltip.Content sideOffset={5} className="tooltip-text">
           {children}
         </Tooltip.Content>


### PR DESCRIPTION
Radix UI isn't compatible with Electron window management by default. The portal container is pinned to the window that created the plugin. We need to ensure it always uses the document of the active window.

We can look into how to enforce this by creating a new Dropdown component in the future. Maybe after https://github.com/logancyang/obsidian-copilot/pull/888 is done

https://github.com/logancyang/obsidian-copilot/issues/960 

<img width="1395" alt="Screenshot 2024-12-22 at 9 08 40 PM" src="https://github.com/user-attachments/assets/db34ac8c-a003-44e4-ba76-d1db2ebf408a" />
