### PR TITLE
Add support for multiple Azure OpenAI deployments

### DIFF
--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -48,6 +48,7 @@ export interface ModelConfig {
   azureOpenAIApiInstanceName?: string;
   azureOpenAIApiDeploymentName?: string;
   azureOpenAIApiVersion?: string;
+  azureOpenAIApiEmbeddingDeploymentName?: string;
   // Google and TogetherAI API key share this property
   apiKey?: string;
   openAIProxyBaseUrl?: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,7 @@ export enum ChatModels {
   CLAUDE_3_5_HAIKU = "claude-3-5-haiku-latest",
   COMMAND_R = "command-r",
   COMMAND_R_PLUS = "command-r-plus",
+  O1_PREVIEW = "o1-preview",
 }
 
 // Model Providers
@@ -114,6 +115,12 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
   {
     name: ChatModels.AZURE_OPENAI,
     provider: ChatModelProviders.AZURE_OPENAI,
+    enabled: true,
+    isBuiltIn: true,
+  },
+  {
+    name: ChatModels.O1_PREVIEW,
+    provider: ChatModelProviders.OPENAI,
     enabled: true,
     isBuiltIn: true,
   },

--- a/src/settings/components/ApiSettings.tsx
+++ b/src/settings/components/ApiSettings.tsx
@@ -1,10 +1,39 @@
 import { updateSetting, useSettingsValue } from "@/settings/model";
-import React from "react";
+import React, { useState } from "react";
 import ApiSetting from "./ApiSetting";
 import Collapsible from "./Collapsible";
 
 const ApiSettings: React.FC = () => {
   const settings = useSettingsValue();
+  const [azureDeployments, setAzureDeployments] = useState(settings.azureDeployments || []);
+
+  const handleAddDeployment = () => {
+    setAzureDeployments([
+      ...azureDeployments,
+      {
+        apiKey: "",
+        instanceName: "",
+        deploymentName: "",
+        version: "",
+        embeddingDeploymentName: "",
+      },
+    ]);
+  };
+
+  const handleUpdateDeployment = (index, key, value) => {
+    const updatedDeployments = azureDeployments.map((deployment, i) =>
+      i === index ? { ...deployment, [key]: value } : deployment
+    );
+    setAzureDeployments(updatedDeployments);
+    updateSetting("azureDeployments", updatedDeployments);
+  };
+
+  const handleDeleteDeployment = (index) => {
+    const updatedDeployments = azureDeployments.filter((_, i) => i !== index);
+    setAzureDeployments(updatedDeployments);
+    updateSetting("azureDeployments", updatedDeployments);
+  };
+
   return (
     <div>
       <h1>API Settings</h1>
@@ -126,44 +155,48 @@ const ApiSettings: React.FC = () => {
       </Collapsible>
 
       <Collapsible title="Azure OpenAI API Settings">
-        <div>
-          <ApiSetting
-            title="Azure OpenAI API Key"
-            value={settings.azureOpenAIApiKey}
-            setValue={(value) => updateSetting("azureOpenAIApiKey", value)}
-            placeholder="Enter Azure OpenAI API Key"
-          />
-          <ApiSetting
-            title="Azure OpenAI API Instance Name"
-            value={settings.azureOpenAIApiInstanceName}
-            setValue={(value) => updateSetting("azureOpenAIApiInstanceName", value)}
-            placeholder="Enter Azure OpenAI API Instance Name"
-            type="text"
-          />
-          <ApiSetting
-            title="Azure OpenAI API Deployment Name"
-            description="This is your actual model, no need to pass a model name separately."
-            value={settings.azureOpenAIApiDeploymentName}
-            setValue={(value) => updateSetting("azureOpenAIApiDeploymentName", value)}
-            placeholder="Enter Azure OpenAI API Deployment Name"
-            type="text"
-          />
-          <ApiSetting
-            title="Azure OpenAI API Version"
-            value={settings.azureOpenAIApiVersion}
-            setValue={(value) => updateSetting("azureOpenAIApiVersion", value)}
-            placeholder="Enter Azure OpenAI API Version"
-            type="text"
-          />
-          <ApiSetting
-            title="Azure OpenAI API Embedding Deployment Name"
-            description="(Optional) For embedding provider Azure OpenAI"
-            value={settings.azureOpenAIApiEmbeddingDeploymentName}
-            setValue={(value) => updateSetting("azureOpenAIApiEmbeddingDeploymentName", value)}
-            placeholder="Enter Azure OpenAI API Embedding Deployment Name"
-            type="text"
-          />
-        </div>
+        {azureDeployments.map((deployment, index) => (
+          <div key={index}>
+            <ApiSetting
+              title={`Azure OpenAI API Key ${index + 1}`}
+              value={deployment.apiKey}
+              setValue={(value) => handleUpdateDeployment(index, "apiKey", value)}
+              placeholder="Enter Azure OpenAI API Key"
+            />
+            <ApiSetting
+              title={`Azure OpenAI API Instance Name ${index + 1}`}
+              value={deployment.instanceName}
+              setValue={(value) => handleUpdateDeployment(index, "instanceName", value)}
+              placeholder="Enter Azure OpenAI API Instance Name"
+              type="text"
+            />
+            <ApiSetting
+              title={`Azure OpenAI API Deployment Name ${index + 1}`}
+              description="This is your actual model, no need to pass a model name separately."
+              value={deployment.deploymentName}
+              setValue={(value) => handleUpdateDeployment(index, "deploymentName", value)}
+              placeholder="Enter Azure OpenAI API Deployment Name"
+              type="text"
+            />
+            <ApiSetting
+              title={`Azure OpenAI API Version ${index + 1}`}
+              value={deployment.version}
+              setValue={(value) => handleUpdateDeployment(index, "version", value)}
+              placeholder="Enter Azure OpenAI API Version"
+              type="text"
+            />
+            <ApiSetting
+              title={`Azure OpenAI API Embedding Deployment Name ${index + 1}`}
+              description="(Optional) For embedding provider Azure OpenAI"
+              value={deployment.embeddingDeploymentName}
+              setValue={(value) => handleUpdateDeployment(index, "embeddingDeploymentName", value)}
+              placeholder="Enter Azure OpenAI API Embedding Deployment Name"
+              type="text"
+            />
+            <button onClick={() => handleDeleteDeployment(index)}>Delete Deployment</button>
+          </div>
+        ))}
+        <button onClick={handleAddDeployment}>Add Deployment</button>
       </Collapsible>
 
       <Collapsible title="Groq API Settings">


### PR DESCRIPTION
Add support for multiple Azure OpenAI deployment configurations and o1-preview model deployments.

* **UI Changes**:
  - Add state management for multiple Azure OpenAI deployments in `src/settings/components/ApiSettings.tsx`.
  - Add functions to handle adding, updating, and deleting deployments.
  - Update UI to display multiple deployment configurations and allow user interaction.

* **Constants**:
  - Add `O1_PREVIEW` to `ChatModels` in `src/constants.ts`.
  - Add a new model configuration for `O1_PREVIEW`.

* **Data Structure**:
  - Update `ModelConfig` interface in `src/aiParams.ts` to include `azureOpenAIApiEmbeddingDeploymentName`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/logancyang/obsidian-copilot/pull/966?shareId=166e863c-9871-4365-9626-f284a400bba8).