### PR TITLE
Throttle number of links returned

### DIFF
--- a/src/noteUtils.ts
+++ b/src/noteUtils.ts
@@ -4,9 +4,10 @@ import { TFile } from "obsidian";
 /**
  * Get all outgoing links from a note
  * @param file The note file to analyze
+ * @param limit The maximum number of linked notes to return
  * @returns Array of linked note
  */
-export function getLinkedNotes(file: TFile): TFile[] {
+export function getLinkedNotes(file: TFile, limit = 20): TFile[] {
   // Get the cache for the current file
   const fileCache = app.metadataCache.getFileCache(file);
   const linkedNotes: TFile[] = [];
@@ -17,16 +18,22 @@ export function getLinkedNotes(file: TFile): TFile[] {
       const resolvedFile = app.metadataCache.getFirstLinkpathDest(link.link, file.path);
       if (resolvedFile) {
         linkedNotes.push(resolvedFile);
+        if (linkedNotes.length >= limit) {
+          break;
+        }
       }
     }
   }
 
-  if (fileCache?.embeds) {
+  if (fileCache?.embeds && linkedNotes.length < limit) {
     // Get all embedded links ![[link]]
     for (const embed of fileCache.embeds) {
       const resolvedFile = app.metadataCache.getFirstLinkpathDest(embed.link, file.path);
       if (resolvedFile) {
         linkedNotes.push(resolvedFile);
+        if (linkedNotes.length >= limit) {
+          break;
+        }
       }
     }
   }
@@ -37,9 +44,10 @@ export function getLinkedNotes(file: TFile): TFile[] {
 /**
  * Get all notes that link to the given note
  * @param file The note file to analyze
+ * @param limit The maximum number of backlinked notes to return
  * @returns Array of backlinked note
  */
-export function getBacklinkedNotes(file: TFile): TFile[] {
+export function getBacklinkedNotes(file: TFile, limit = 20): TFile[] {
   const backlinkedNotes: TFile[] = [];
 
   // Get the backlinks from metadata cache
@@ -51,6 +59,9 @@ export function getBacklinkedNotes(file: TFile): TFile[] {
       const file = app.vault.getAbstractFileByPath(path);
       if (file instanceof TFile) {
         backlinkedNotes.push(file);
+        if (backlinkedNotes.length >= limit) {
+          break;
+        }
       }
     }
   }


### PR DESCRIPTION
These two functions will load all the linked notes in memory, which can crash for notes with many links.