### PR TITLE
Improve relevant note performance

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -33,7 +33,7 @@ import {
   tocPrompt,
 } from "@/utils";
 import { MarkdownView, Notice, TFile } from "obsidian";
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 interface CreateEffectOptions {
   custom_temperature?: number;
@@ -568,7 +568,7 @@ ${chatContent}`;
     []
   );
 
-  const handleInsertAtCursor = async (message: string) => {
+  const handleInsertAtCursor = useCallback(async (message: string) => {
     let leaf = app.workspace.getMostRecentLeaf();
     if (!leaf) {
       new Notice("No active leaf found.");
@@ -589,7 +589,7 @@ ${chatContent}`;
     const cursor = editor.getCursor();
     editor.replaceRange(message, cursor);
     new Notice("Message inserted into the active note.");
-  };
+  }, []);
 
   // Expose handleSaveAsNote to parent
   useEffect(() => {
@@ -608,6 +608,10 @@ ${chatContent}`;
     await updateChatMemory(newChatHistory, chainManager.memoryManager);
   };
 
+  const handleInsertToChat = useCallback((prompt: string) => {
+    setInputMessage((prev) => `${prev} ${prompt} `);
+  }, []);
+
   return (
     <div className="chat-container">
       <ChatMessages
@@ -620,9 +624,7 @@ ${chatContent}`;
         onRegenerate={handleRegenerate}
         onEdit={handleEdit}
         onDelete={handleDelete}
-        onInsertToChat={(prompt) => {
-          setInputMessage((prev) => `${prev} ${prompt} `);
-        }}
+        onInsertToChat={handleInsertToChat}
         onReplaceChat={setInputMessage}
       />
       <div className="bottom-container">

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -16,7 +16,7 @@ import {
   RefreshCcw,
   TriangleAlert,
 } from "lucide-react";
-import React, { forwardRef, useEffect, useState } from "react";
+import React, { forwardRef, memo, useEffect, useState } from "react";
 import { Notice, TFile } from "obsidian";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
@@ -184,127 +184,129 @@ function RelevantNotePopover({
   );
 }
 
-export function RelevantNotes({
-  className,
-  onInsertToChat,
-  defaultOpen = false,
-}: {
-  className?: string;
-  onInsertToChat: (prompt: string) => void;
-  defaultOpen?: boolean;
-}) {
-  const [refresher, setRefresher] = useState(0);
-  const [isOpen, setIsOpen] = useState(defaultOpen);
-  const relevantNotes = useRelevantNotes(refresher);
-  const activeFile = app.workspace.getActiveFile();
-  const hasIndex = useHasIndex(activeFile?.path ?? "", refresher);
-  const navigateToNote = (notePath: string) => {
-    const file = app.vault.getAbstractFileByPath(notePath);
-    if (file instanceof TFile) {
-      app.workspace.getLeaf(false).openFile(file);
-    }
-  };
-  const addToChat = (prompt: string) => {
-    onInsertToChat(`[[${prompt}]]`);
-  };
-  const refreshIndex = async () => {
-    if (activeFile) {
-      await VectorStoreManager.getInstance().reindexFile(activeFile);
-      new Notice(`Reindexed ${activeFile.name}`);
-      setRefresher(refresher + 1);
-    }
-  };
-  return (
-    <div
-      className={cn(
-        "@container w-full border border-transparent border-b-border border-solid pb-2",
-        className
-      )}
-    >
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <div className="flex justify-between items-center px-2 pb-2">
-          <div className="flex gap-2 items-center flex-1">
-            <span className="font-semibold text-normal">Relevant Notes</span>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Info className="size-4 text-muted" />
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="w-64">
-                Relevance is a combination of semantic similarity and links.
-              </TooltipContent>
-            </Tooltip>
-
-            {!hasIndex && (
+export const RelevantNotes = memo(
+  ({
+    className,
+    onInsertToChat,
+    defaultOpen = false,
+  }: {
+    className?: string;
+    onInsertToChat: (prompt: string) => void;
+    defaultOpen?: boolean;
+  }) => {
+    const [refresher, setRefresher] = useState(0);
+    const [isOpen, setIsOpen] = useState(defaultOpen);
+    const relevantNotes = useRelevantNotes(refresher);
+    const activeFile = app.workspace.getActiveFile();
+    const hasIndex = useHasIndex(activeFile?.path ?? "", refresher);
+    const navigateToNote = (notePath: string) => {
+      const file = app.vault.getAbstractFileByPath(notePath);
+      if (file instanceof TFile) {
+        app.workspace.getLeaf(false).openFile(file);
+      }
+    };
+    const addToChat = (prompt: string) => {
+      onInsertToChat(`[[${prompt}]]`);
+    };
+    const refreshIndex = async () => {
+      if (activeFile) {
+        await VectorStoreManager.getInstance().reindexFile(activeFile);
+        new Notice(`Reindexed ${activeFile.name}`);
+        setRefresher(refresher + 1);
+      }
+    };
+    return (
+      <div
+        className={cn(
+          "@container w-full border border-transparent border-b-border border-solid pb-2",
+          className
+        )}
+      >
+        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+          <div className="flex justify-between items-center px-2 pb-2">
+            <div className="flex gap-2 items-center flex-1">
+              <span className="font-semibold text-normal">Relevant Notes</span>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <TriangleAlert className="size-4 text-warning" />
+                  <Info className="size-4 text-muted" />
                 </TooltipTrigger>
-                <TooltipContent side="bottom">Note has not been indexed</TooltipContent>
+                <TooltipContent side="bottom" className="w-64">
+                  Relevance is a combination of semantic similarity and links.
+                </TooltipContent>
               </Tooltip>
-            )}
+
+              {!hasIndex && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <TriangleAlert className="size-4 text-warning" />
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Note has not been indexed</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+            <div className="flex gap-2 items-center">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    className="size-6 p-0 !bg-transparent border-none !shadow-none hover:!bg-interactive-hover"
+                    onClick={refreshIndex}
+                  >
+                    <RefreshCcw className="size-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">Reindex Current Note</TooltipContent>
+              </Tooltip>
+              {relevantNotes.length > 0 && (
+                <CollapsibleTrigger asChild>
+                  <button className="size-6 p-0 !bg-transparent border-none !shadow-none hover:!bg-interactive-hover">
+                    {isOpen ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
+                  </button>
+                </CollapsibleTrigger>
+              )}
+            </div>
           </div>
-          <div className="flex gap-2 items-center">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  className="size-6 p-0 !bg-transparent border-none !shadow-none hover:!bg-interactive-hover"
-                  onClick={refreshIndex}
-                >
-                  <RefreshCcw className="size-4" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">Reindex Current Note</TooltipContent>
-            </Tooltip>
-            {relevantNotes.length > 0 && (
-              <CollapsibleTrigger asChild>
-                <button className="size-6 p-0 !bg-transparent border-none !shadow-none hover:!bg-interactive-hover">
-                  {isOpen ? <ChevronUp className="size-4" /> : <ChevronDown className="size-4" />}
-                </button>
-              </CollapsibleTrigger>
-            )}
-          </div>
-        </div>
-        {relevantNotes.length === 0 && (
-          <div className="flex flex-wrap gap-x-2 gap-y-1 max-h-12 overflow-y-hidden px-2">
-            <span className="text-xs text-muted">No relevant notes found</span>
-          </div>
-        )}
-        {!isOpen && relevantNotes.length > 0 && (
-          <div className="flex flex-wrap gap-x-2 gap-y-1 max-h-6 overflow-y-hidden px-2">
-            {relevantNotes.map((note) => (
-              <RelevantNotePopover
-                key={note.document.path}
-                note={note}
-                onAddToChat={() => addToChat(note.document.title)}
-                onNavigateToNote={() => navigateToNote(note.document.path)}
-              >
-                <Badge
-                  variant="outline"
+          {relevantNotes.length === 0 && (
+            <div className="flex flex-wrap gap-x-2 gap-y-1 max-h-12 overflow-y-hidden px-2">
+              <span className="text-xs text-muted">No relevant notes found</span>
+            </div>
+          )}
+          {!isOpen && relevantNotes.length > 0 && (
+            <div className="flex flex-wrap gap-x-2 gap-y-1 max-h-6 overflow-y-hidden px-2">
+              {relevantNotes.map((note) => (
+                <RelevantNotePopover
                   key={note.document.path}
-                  className="text-xs max-w-40 text-muted hover:cursor-pointer hover:bg-interactive-hover"
+                  note={note}
+                  onAddToChat={() => addToChat(note.document.title)}
+                  onNavigateToNote={() => navigateToNote(note.document.path)}
                 >
-                  <span className="text-ellipsis overflow-hidden whitespace-nowrap">
-                    {note.document.title}
-                  </span>
-                </Badge>
-              </RelevantNotePopover>
-            ))}
-          </div>
-        )}
-        <CollapsibleContent>
-          <div className="p-2 max-h-96 overflow-y-auto flex flex-col gap-2 @2xl:grid @2xl:grid-cols-2 @4xl:grid-cols-3">
-            {relevantNotes.map((note) => (
-              <RelevantNote
-                showPath={!inSameFolder(activeFile?.path ?? "", note.document.path)}
-                note={note}
-                key={note.document.path}
-                onAddToChat={() => addToChat(note.document.title)}
-                onNavigateToNote={() => navigateToNote(note.document.path)}
-              />
-            ))}
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
-  );
-}
+                  <Badge
+                    variant="outline"
+                    key={note.document.path}
+                    className="text-xs max-w-40 text-muted hover:cursor-pointer hover:bg-interactive-hover"
+                  >
+                    <span className="text-ellipsis overflow-hidden whitespace-nowrap">
+                      {note.document.title}
+                    </span>
+                  </Badge>
+                </RelevantNotePopover>
+              ))}
+            </div>
+          )}
+          <CollapsibleContent>
+            <div className="p-2 max-h-96 overflow-y-auto flex flex-col gap-2 @2xl:grid @2xl:grid-cols-2 @4xl:grid-cols-3">
+              {relevantNotes.map((note) => (
+                <RelevantNote
+                  showPath={!inSameFolder(activeFile?.path ?? "", note.document.path)}
+                  note={note}
+                  key={note.document.path}
+                  onAddToChat={() => addToChat(note.document.title)}
+                  onNavigateToNote={() => navigateToNote(note.document.path)}
+                />
+              ))}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    );
+  }
+);


### PR DESCRIPTION
The chat input will cause the entire chat component to re-render on every key stroke today. As a quick fix, we will memorize the Relevant note component since its props do not depend on any variables affected by chat input.

In the future, we will find ways to not re-render the entire chat component on chat input change.