### PR TITLE
Handle NaN scores

### DIFF
--- a/src/components/modals/DebugSearchModal.tsx
+++ b/src/components/modals/DebugSearchModal.tsx
@@ -1,0 +1,106 @@
+import CopilotPlugin from "@/main";
+import { search } from "@orama/orama";
+import { App, Modal, Notice, TFile } from "obsidian";
+
+export class DebugSearchModal extends Modal {
+  private plugin: CopilotPlugin;
+  private searchInput: HTMLTextAreaElement;
+
+  constructor(app: App, plugin: CopilotPlugin) {
+    super(app);
+    this.plugin = plugin;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    contentEl.empty();
+
+    contentEl.createEl("h2", { text: "Debug: Search OramaDB" });
+
+    // Add description
+    const descEl = contentEl.createEl("p");
+    descEl.innerHTML =
+      'Enter a JSON search params object. Example:<br><pre>{<br>  "term": "#tag",<br>  "mode": "hybrid",<br>  "limit": 10,<br>  "includeVectors": true<br>}</pre>';
+
+    // Create textarea
+    this.searchInput = contentEl.createEl("textarea", {
+      attr: {
+        placeholder: "Enter search params JSON...",
+        rows: "10",
+        style:
+          "width: 100%; min-height: 200px; margin: 10px 0; padding: 10px; font-family: monospace;",
+      },
+    });
+
+    // Create button container
+    const buttonContainer = contentEl.createEl("div", {
+      cls: "search-button-container",
+    });
+
+    // Add search button
+    const searchButton = buttonContainer.createEl("button", {
+      text: "Search",
+      cls: "mod-cta",
+    });
+
+    searchButton.addEventListener("click", async () => {
+      try {
+        const searchParams = JSON.parse(this.searchInput.value);
+
+        // Convert vector object to array if needed
+        if (searchParams.vector?.value && !Array.isArray(searchParams.vector.value)) {
+          searchParams.vector.value = Object.values(searchParams.vector.value);
+        }
+
+        const db = await this.plugin.vectorStoreManager.getDb();
+        if (!db) {
+          new Notice("Database not found");
+          return;
+        }
+
+        const searchResults = await search(db, searchParams);
+
+        // Create content for the results file
+        const content = [
+          "## Search Parameters",
+          "```json",
+          JSON.stringify(searchParams, null, 2),
+          "```",
+          "",
+          "## Results",
+          `Total hits: ${searchResults.hits.length}`,
+          "",
+          "### Hits",
+          "```json",
+          JSON.stringify(searchResults.hits, null, 2),
+          "```",
+        ].join("\n");
+
+        // Create or update the file
+        const fileName = `OramaDB-Debug-Search.md`;
+
+        const existingFile = this.app.vault.getAbstractFileByPath(fileName);
+        if (existingFile instanceof TFile) {
+          await this.app.vault.modify(existingFile, content);
+        } else {
+          await this.app.vault.create(fileName, content);
+        }
+
+        // Open the file
+        const file = this.app.vault.getAbstractFileByPath(fileName);
+        if (file instanceof TFile) {
+          await this.app.workspace.getLeaf().openFile(file);
+          this.close();
+        }
+      } catch (error) {
+        console.error("Error in debug search:", error);
+        new Notice("Error executing search. Check console for details.");
+      }
+    });
+  }
+
+  onClose() {
+    const { contentEl } = this;
+    contentEl.empty();
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const EMPTY_INDEX_ERROR_MESSAGE =
 export const CHUNK_SIZE = 4000;
 export const CONTEXT_SCORE_THRESHOLD = 0.4;
 export const TEXT_WEIGHT = 0.4;
+export const PLUS_MODE_DEFAULT_SOURCE_CHUNKS = 15;
 export const LOADING_MESSAGES = {
   DEFAULT: "",
   READING_FILES: "Reading files",

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { registerBuiltInCommands } from "@/commands";
 import CopilotView from "@/components/CopilotView";
 import { AddPromptModal } from "@/components/modals/AddPromptModal";
 import { AdhocPromptModal } from "@/components/modals/AdhocPromptModal";
+import { DebugSearchModal } from "@/components/modals/DebugSearchModal";
 import { ListPromptModal } from "@/components/modals/ListPromptModal";
 import { LoadChatHistoryModal } from "@/components/modals/LoadChatHistoryModal";
 import { OramaSearchModal } from "@/components/modals/OramaSearchModal";
@@ -328,15 +329,23 @@ export default class CopilotPlugin extends Plugin {
 
     this.addCommand({
       id: "copilot-inspect-index-by-note-paths",
-      name: "Inspect Copilot Index by Note Paths",
+      name: "Inspect Copilot Index by Note Paths (debug)",
       callback: () => {
         new OramaSearchModal(this.app, this).open();
       },
     });
 
     this.addCommand({
-      id: "list-indexed-files",
-      name: "List all indexed files",
+      id: "copilot-debug-search-oramadb",
+      name: "Search OramaDB (debug)",
+      callback: () => {
+        new DebugSearchModal(this.app, this).open();
+      },
+    });
+
+    this.addCommand({
+      id: "copilot-list-indexed-files",
+      name: "List all indexed files (debug)",
       callback: async () => {
         try {
           const indexedFiles = await this.vectorStoreManager.getIndexedFiles();

--- a/src/tools/SearchTools.ts
+++ b/src/tools/SearchTools.ts
@@ -1,8 +1,13 @@
-import { EMPTY_INDEX_ERROR_MESSAGE, TEXT_WEIGHT } from "@/constants";
+import {
+  EMPTY_INDEX_ERROR_MESSAGE,
+  PLUS_MODE_DEFAULT_SOURCE_CHUNKS,
+  TEXT_WEIGHT,
+} from "@/constants";
 import { CustomError } from "@/error";
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import { HybridRetriever } from "@/search/hybridRetriever";
 import VectorStoreManager from "@/search/vectorStoreManager";
+import { getSettings } from "@/settings/model";
 import { TimeInfo } from "@/tools/TimeTools";
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
@@ -23,10 +28,14 @@ const localSearchTool = tool(
     }
 
     const returnAll = timeRange !== undefined;
+    const maxSourceChunks =
+      getSettings().maxSourceChunks < PLUS_MODE_DEFAULT_SOURCE_CHUNKS
+        ? PLUS_MODE_DEFAULT_SOURCE_CHUNKS
+        : getSettings().maxSourceChunks;
 
     const hybridRetriever = new HybridRetriever({
       minSimilarityScore: returnAll ? 0.0 : 0.1,
-      maxK: returnAll ? 100 : 15,
+      maxK: returnAll ? 100 : maxSourceChunks,
       salientTerms,
       timeRange: timeRange
         ? {


### PR DESCRIPTION
Sometimes Orama returns `hit.score: NaN`. 

- Add a command and trace messages to enable better debugging.
- Do not filter out NaN chunks in the final result.