### PR TITLE
docs: update local copilot instructions for macOS

### DIFF
--- a/local_copilot.md
+++ b/local_copilot.md
@@ -43,11 +43,29 @@ Look for this parameter `llama_new_context_with_model: n_ctx` in your server log
 
 #### Start Ollama server for Obsidian
 
+<details>
+<summary>CLI</summary>
+
 Now, **start the local server with `OLLAMA_ORIGINS=app://obsidian.md* ollama serve`, this will allow the Obsidian app to access the local server without CORS issues**.
 
 > **NOTE**: If using `fish`, quote the env value: `OLLAMA_ORIGINS="app://obsidian.md*" ollama serve`
 
 Again, `OLLAMA_ORIGINS=app://obsidian.md*` is required!
+
+</details>
+
+<details>
+<summary>macOS</summary>
+
+The macOS Ollama application is managed by `launchctl`. Update the env for `OLLAMA_ORIGINS` with the following command:
+
+```sh
+launchctl setenv OLLAMA_ORIGINS "app://obsidian.md*"
+```
+
+Then, restart the Ollama application.
+
+</details>
 
 <img src="./images/ollama-serve.png" alt="Ollama">
 

--- a/local_copilot.md
+++ b/local_copilot.md
@@ -43,6 +43,8 @@ Look for this parameter `llama_new_context_with_model: n_ctx` in your server log
 
 #### Start Ollama server for Obsidian
 
+In order for Obsidian to communicate with Ollama, the `OLLAMA_ORIGINS` variable needs to be updated. Choose your method for running Ollama to get detailed instructions for how to update Ollama correctly.
+
 <details>
 <summary>CLI</summary>
 
@@ -55,15 +57,15 @@ Again, `OLLAMA_ORIGINS=app://obsidian.md*` is required!
 </details>
 
 <details>
-<summary>macOS</summary>
+<summary>macOS App</summary>
 
-The macOS Ollama application is managed by `launchctl`. Update the env for `OLLAMA_ORIGINS` with the following command:
+If Ollama is run as a macOS application, [environment variables should be set using launchctl](https://github.com/Ollama/Ollama/blob/main/docs/faq.md#setting-environment-variables-on-mac). To support Obsidian, set "app://obsidian.md*" on the `OLLAMA_ORIGINS` variable by running this command:
 
 ```sh
 launchctl setenv OLLAMA_ORIGINS "app://obsidian.md*"
 ```
 
-Then, restart the Ollama application.
+Then, quit Ollama from the menu bar and reopen it.
 
 </details>
 


### PR DESCRIPTION
Hey @logancyang, thanks for a great plugin!

I updated the docs to include how to setup macOS without having to manually run the CLI command but rather update the launchctl env variable. I've tested and confirmed this works.