### PR TITLE
Attach plugin version to request headers

### DIFF
--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -71,6 +71,7 @@ export interface Youtube4llmResponse {
 
 export class BrevilabsClient {
   private static instance: BrevilabsClient;
+  private pluginVersion: string = "Unknown";
 
   static getInstance(): BrevilabsClient {
     if (!BrevilabsClient.instance) {
@@ -88,6 +89,10 @@ export class BrevilabsClient {
     }
   }
 
+  setPluginVersion(pluginVersion: string) {
+    this.pluginVersion = pluginVersion;
+  }
+
   private async makeRequest<T>(endpoint: string, body: any, method = "POST"): Promise<T> {
     this.checkLicenseKey();
 
@@ -99,12 +104,15 @@ export class BrevilabsClient {
       });
     }
 
+    const headers = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${await getDecryptedKey(getSettings().plusLicenseKey)}`,
+      "X-Client-Version": this.pluginVersion,
+    };
+
     const response = await safeFetch(url.toString(), {
       method,
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${await getDecryptedKey(getSettings().plusLicenseKey)}`,
-      },
+      headers,
       ...(method === "POST" && { body: JSON.stringify(body) }),
     });
 

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -104,18 +104,15 @@ export class BrevilabsClient {
       });
     }
 
-    const headers = {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${await getDecryptedKey(getSettings().plusLicenseKey)}`,
-      "X-Client-Version": this.pluginVersion,
-    };
-
     const response = await safeFetch(url.toString(), {
       method,
-      headers,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${await getDecryptedKey(getSettings().plusLicenseKey)}`,
+        "X-Client-Version": this.pluginVersion,
+      },
       ...(method === "POST" && { body: JSON.stringify(body) }),
     });
-
     const data = await response.json();
     if (getSettings().debug) {
       console.log(`==== ${endpoint} request ====:`, data);

--- a/src/main.ts
+++ b/src/main.ts
@@ -62,6 +62,7 @@ export default class CopilotPlugin extends Plugin {
 
     // Initialize BrevilabsClient
     this.brevilabsClient = BrevilabsClient.getInstance();
+    this.brevilabsClient.setPluginVersion(this.manifest.version);
 
     this.chainManager = new ChainManager(this.app, this.vectorStoreManager);
 


### PR DESCRIPTION
So that the backend is aware the client version.

TEST: Used `console.log` to print the version number in `makeRequest` and verified the number was correct.