### PR TITLE
Avoid full vault scan on incremental indexing

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,5 @@
 import "web-streams-polyfill/dist/polyfill.min.js";
+import { TextEncoder, TextDecoder } from "util";
+
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;

--- a/src/search/searchUtils.test.ts
+++ b/src/search/searchUtils.test.ts
@@ -1,0 +1,130 @@
+import { TFile } from "obsidian";
+import { shouldIndexFile } from "./searchUtils";
+import * as utils from "@/utils";
+
+// Mock Obsidian's TFile class
+jest.mock("obsidian", () => ({
+  TFile: class TFile {
+    path: string;
+  },
+}));
+
+// Create test files using the mocked TFile
+const createTestFile = (path: string) => {
+  const file = new TFile();
+  file.path = path;
+  return file;
+};
+
+// Mock the global app object
+const mockGetAbstractFileByPath = jest.fn();
+const mockApp = {
+  vault: {
+    getAbstractFileByPath: mockGetAbstractFileByPath,
+  },
+} as any;
+
+// Mock getTagsFromNote utility function
+jest.mock("@/utils", () => ({
+  ...jest.requireActual("@/utils"),
+  getTagsFromNote: jest.fn(),
+  isPathInList: jest.requireActual("@/utils").isPathInList,
+  stripHash: jest.requireActual("@/utils").stripHash,
+}));
+
+describe("shouldIndexFile", () => {
+  beforeAll(() => {
+    // @ts-ignore
+    global.app = mockApp;
+  });
+
+  afterAll(() => {
+    // @ts-ignore
+    delete global.app;
+  });
+
+  beforeEach(() => {
+    mockGetAbstractFileByPath.mockReset();
+    (utils.getTagsFromNote as jest.Mock).mockReset();
+  });
+
+  it("should return true when no inclusions or exclusions are specified", () => {
+    const file = createTestFile("test.md");
+    expect(shouldIndexFile(file, [], [])).toBe(true);
+  });
+
+  it("should return false when file matches exclusion pattern", () => {
+    const file = createTestFile("private/secret.md");
+    const exclusions = ["private"];
+    expect(shouldIndexFile(file, [], exclusions)).toBe(false);
+  });
+
+  it("should return true when file matches inclusion pattern", () => {
+    const file = createTestFile("notes/important.md");
+    const inclusions = ["notes"];
+    expect(shouldIndexFile(file, inclusions, [])).toBe(true);
+  });
+
+  it("should return false when file doesn't match inclusion pattern", () => {
+    const file = createTestFile("random/file.md");
+    const inclusions = ["notes"];
+    expect(shouldIndexFile(file, inclusions, [])).toBe(false);
+  });
+
+  it("should prioritize exclusions over inclusions", () => {
+    const file = createTestFile("notes/private/secret.md");
+    const inclusions = ["notes"];
+    const exclusions = ["private"];
+    expect(shouldIndexFile(file, inclusions, exclusions)).toBe(false);
+  });
+
+  it("should handle multiple inclusion patterns", () => {
+    const file = createTestFile("blog/post.md");
+    const inclusions = ["notes", "blog", "docs"];
+    expect(shouldIndexFile(file, inclusions, [])).toBe(true);
+  });
+
+  it("should handle multiple exclusion patterns", () => {
+    const file = createTestFile("temp/draft.md");
+    const exclusions = ["private", "temp", "archive"];
+    expect(shouldIndexFile(file, [], exclusions)).toBe(false);
+  });
+
+  it("should handle tag-based inclusion patterns", () => {
+    const file = createTestFile("notes/tagged.md");
+    mockGetAbstractFileByPath.mockReturnValue(file);
+    (utils.getTagsFromNote as jest.Mock).mockReturnValue(["important", "review"]);
+
+    const inclusions = ["#important"];
+    expect(shouldIndexFile(file, inclusions, [])).toBe(true);
+  });
+
+  it("should handle tag-based exclusion patterns", () => {
+    const file = createTestFile("notes/tagged.md");
+    mockGetAbstractFileByPath.mockReturnValue(file);
+    (utils.getTagsFromNote as jest.Mock).mockReturnValue(["private", "draft"]);
+
+    const exclusions = ["#private"];
+    expect(shouldIndexFile(file, [], exclusions)).toBe(false);
+  });
+
+  it("should handle file extension patterns in inclusions", () => {
+    const file = createTestFile("notes/document.pdf");
+    const inclusions = ["*.pdf"];
+    expect(shouldIndexFile(file, inclusions, [])).toBe(true);
+  });
+
+  it("should handle file extension patterns in exclusions", () => {
+    const file = createTestFile("notes/document.pdf");
+    const exclusions = ["*.pdf"];
+    expect(shouldIndexFile(file, [], exclusions)).toBe(false);
+  });
+
+  it("should return false when tag check fails due to file not found", () => {
+    const file = createTestFile("notes/tagged.md");
+    mockGetAbstractFileByPath.mockReturnValue(null);
+
+    const inclusions = ["#important"];
+    expect(shouldIndexFile(file, inclusions, [])).toBe(false);
+  });
+});

--- a/src/search/vectorStoreManager.ts
+++ b/src/search/vectorStoreManager.ts
@@ -51,14 +51,6 @@ export default class VectorStoreManager {
           await this.dbOps.initializeDB(await this.embeddingsManager.getEmbeddingsAPI());
         }
       }
-
-      // Handle inclusion/exclusion changes
-      if (
-        settings.qaExclusions !== prevSettings?.qaExclusions ||
-        settings.qaInclusions !== prevSettings?.qaInclusions
-      ) {
-        await this.eventHandler.updateExcludedFiles();
-      }
     };
 
     subscribeToSettingsChange(() => {
@@ -92,7 +84,6 @@ export default class VectorStoreManager {
           break;
         }
       }
-      this.eventHandler.initializeEventListeners();
     } catch (error) {
       console.error("Failed to initialize vector store:", error);
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ import { MemoryVariables } from "@langchain/core/memory";
 import { RunnableSequence } from "@langchain/core/runnables";
 import { BaseChain, RetrievalQAChain } from "langchain/chains";
 import moment from "moment";
-import { MarkdownView, Notice, TFile, Vault, parseYaml, requestUrl } from "obsidian";
+import { MarkdownView, Notice, TFile, Vault, requestUrl } from "obsidian";
 import { CustomModel } from "./aiParams";
 
 export const getModelNameFromKey = (modelKey: string): string => {
@@ -47,7 +47,7 @@ export async function getNoteFileFromTitle(vault: Vault, noteTitle: string): Pro
 }
 
 /** TODO: Rewrite with app.vault.getAbstractFileByPath() */
-export const getNotesFromPath = async (vault: Vault, path: string): Promise<TFile[]> => {
+export const getNotesFromPath = (vault: Vault, path: string): TFile[] => {
   const files = vault.getMarkdownFiles();
 
   // Special handling for the root path '/'
@@ -82,49 +82,60 @@ export const getNotesFromPath = async (vault: Vault, path: string): Promise<TFil
   });
 };
 
-export async function getTagsFromNote(file: TFile, vault: Vault): Promise<string[]> {
-  const fileContent = await vault.cachedRead(file);
-  // Check if the file starts with frontmatter delimiter
-  if (fileContent.startsWith("---")) {
-    const frontMatterBlock = fileContent.split("---", 3);
-    // Ensure there's a closing delimiter for frontmatter
-    if (frontMatterBlock.length >= 3) {
-      const frontMatterContent = frontMatterBlock[1];
-      try {
-        const frontMatter = parseYaml(frontMatterContent) || {};
-        const tags = frontMatter.tags || [];
-        // Handle both array and string formats of tags
-        const normalizedTags = Array.isArray(tags) ? tags : [tags];
-        // Strip any '#' from the frontmatter tags and convert to lowercase
-        return normalizedTags
-          .map((tag: string) => tag.toString().replace(/^#/, ""))
-          .map((tag: string) => tag.toLowerCase());
-      } catch (error) {
-        console.error("Error parsing YAML frontmatter:", error);
-        return [];
-      }
-    }
-  }
-  return [];
+/**
+ * @param tag - The tag to strip the hash symbol from.
+ * @returns The tag without the hash symbol in lowercase.
+ */
+export function stripHash(tag: string): string {
+  return tag.replace(/^#/, "").trim().toLowerCase();
 }
 
-export async function getNotesFromTags(
-  vault: Vault,
-  tags: string[],
-  noteFiles?: TFile[]
-): Promise<TFile[]> {
+/**
+ * @param file - The note file to get tags from.
+ * @param vault - The vault to get tags from.
+ * @returns An array of lowercase tags without the hash symbol.
+ */
+export function getTagsFromNote(file: TFile): string[] {
+  const metadata = app.metadataCache.getFileCache(file);
+  const inlineTags = metadata?.tags?.map((tag) => tag.tag);
+  const frontmatterTags = metadata?.frontmatter?.tags;
+  const allTags = new Set<string>();
+
+  if (inlineTags) {
+    inlineTags.forEach((tag) => allTags.add(stripHash(tag)));
+  }
+
+  // Add frontmatter tags
+  if (frontmatterTags) {
+    if (Array.isArray(frontmatterTags)) {
+      frontmatterTags.forEach((tag) => allTags.add(stripHash(tag)));
+    } else if (typeof frontmatterTags === "string") {
+      allTags.add(stripHash(frontmatterTags));
+    }
+  }
+
+  return Array.from(allTags);
+}
+
+/**
+ * Get notes from tags.
+ * @param vault - The vault to get notes from.
+ * @param tags - The tags to get notes from. Tags should be with the hash symbol.
+ * @param noteFiles - The notes to get notes from.
+ * @returns An array of note files.
+ */
+export function getNotesFromTags(vault: Vault, tags: string[], noteFiles?: TFile[]): TFile[] {
   if (tags.length === 0) {
     return [];
   }
 
-  // Strip any '#' from the tags and convert to lowercase for consistent comparison
-  tags = tags.map((tag) => tag.replace(/^#/, "").toLowerCase());
+  tags = tags.map((tag) => stripHash(tag));
 
-  const files = noteFiles && noteFiles.length > 0 ? noteFiles : await getNotesFromPath(vault, "/");
+  const files = noteFiles && noteFiles.length > 0 ? noteFiles : getNotesFromPath(vault, "/");
   const filesWithTag = [];
 
   for (const file of files) {
-    const noteTags = await getTagsFromNote(file, vault);
+    const noteTags = getTagsFromNote(file);
     if (tags.some((tag) => noteTags.includes(tag))) {
       filesWithTag.push(file);
     }
@@ -388,38 +399,6 @@ export function extractUniqueTitlesFromDocs(docs: Document[]): string[] {
   });
 
   return Array.from(titlesSet);
-}
-
-export async function getFilePathsFromPatterns(
-  patterns: string[],
-  vault: Vault
-): Promise<string[]> {
-  const filePaths = new Set<string>();
-
-  for (const pattern of patterns) {
-    if (pattern.startsWith("#")) {
-      // Tag-based pattern
-      const taggedFiles = await getNotesFromTags(vault, [pattern]);
-      taggedFiles.forEach((file) => filePaths.add(file.path));
-    } else if (pattern.startsWith("*")) {
-      // File-extension-based pattern
-      const extensionName = pattern.slice(1);
-      vault.getFiles().forEach((file) => {
-        if (file.name.toLowerCase().endsWith(extensionName.toLowerCase())) {
-          filePaths.add(file.path);
-        }
-      });
-    } else {
-      // Path-based pattern
-      vault.getFiles().forEach((file) => {
-        if (isPathInList(file.path, pattern)) {
-          filePaths.add(file.path);
-        }
-      });
-    }
-  }
-
-  return Array.from(filePaths);
 }
 
 export function extractJsonFromCodeBlock(content: string): any {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,17 +92,19 @@ export function stripHash(tag: string): string {
 
 /**
  * @param file - The note file to get tags from.
- * @param vault - The vault to get tags from.
+ * @param frontmatterOnly - Whether to only get tags from frontmatter.
  * @returns An array of lowercase tags without the hash symbol.
  */
-export function getTagsFromNote(file: TFile): string[] {
+export function getTagsFromNote(file: TFile, frontmatterOnly = true): string[] {
   const metadata = app.metadataCache.getFileCache(file);
-  const inlineTags = metadata?.tags?.map((tag) => tag.tag);
   const frontmatterTags = metadata?.frontmatter?.tags;
   const allTags = new Set<string>();
 
-  if (inlineTags) {
-    inlineTags.forEach((tag) => allTags.add(stripHash(tag)));
+  if (!frontmatterOnly) {
+    const inlineTags = metadata?.tags?.map((tag) => tag.tag);
+    if (inlineTags) {
+      inlineTags.forEach((tag) => allTags.add(stripHash(tag)));
+    }
   }
 
   // Add frontmatter tags

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -44,17 +44,20 @@ const mockMetadataCache = {
 // Mock file metadata for different test cases
 const mockFileMetadata = {
   "test/test2/note1.md": {
-    tags: [{ tag: "#tag1" }, { tag: "#tag2" }],
-    frontmatter: { tags: ["tag4"] },
+    tags: [{ tag: "#inlineTag1" }, { tag: "#inlineTag2" }],
+    frontmatter: { tags: ["tag1", "tag2", "tag4"] },
   },
   "test/note2.md": {
-    tags: [{ tag: "#tag2" }, { tag: "#tag3" }],
+    tags: [{ tag: "#inlineTag3" }, { tag: "#inlineTag4" }],
+    frontmatter: { tags: ["tag2", "tag3"] },
   },
   "test2/note3.md": {
-    frontmatter: { tags: "tag5" },
+    tags: [{ tag: "#inlineTag5" }],
+    frontmatter: { tags: ["tag5"] },
   },
   "note4.md": {
-    tags: [{ tag: "#tag1" }, { tag: "#tag4" }],
+    tags: [{ tag: "#inlineTag1" }, { tag: "#inlineTag6" }],
+    frontmatter: { tags: ["tag1", "tag4"] },
   },
 };
 
@@ -235,20 +238,8 @@ describe("getNotesFromTags", () => {
 
   it("should return files with specified tags 1", async () => {
     const mockVault = new Obsidian.Vault();
-    const tags = ["tag1"];
+    const tags = ["#tag1"];
     const expectedPaths = ["test/test2/note1.md", "note4.md"];
-
-    const result = await getNotesFromTags(mockVault, tags);
-    const resultPaths = result.map((fileWithTags) => fileWithTags.path);
-
-    expect(resultPaths).toEqual(expect.arrayContaining(expectedPaths));
-    expect(resultPaths.length).toEqual(expectedPaths.length);
-  });
-
-  it("should return files with specified tags 2", async () => {
-    const mockVault = new Obsidian.Vault();
-    const tags = ["#tag3"];
-    const expectedPaths = ["test/note2.md"];
 
     const result = await getNotesFromTags(mockVault, tags);
     const resultPaths = result.map((fileWithTags) => fileWithTags.path);
@@ -259,7 +250,7 @@ describe("getNotesFromTags", () => {
 
   it("should return an empty array if no files match the specified nonexistent tags", async () => {
     const mockVault = new Obsidian.Vault();
-    const tags = ["nonexistentTag"];
+    const tags = ["#nonexistentTag"];
     const expected: string[] = [];
 
     const result = await getNotesFromTags(mockVault, tags);
@@ -269,7 +260,7 @@ describe("getNotesFromTags", () => {
 
   it("should handle multiple tags, returning files that match any of them", async () => {
     const mockVault = new Obsidian.Vault();
-    const tags = ["tag2", "tag4"]; // Files that include 'tag2' or 'tag4'
+    const tags = ["#tag2", "#tag4"];
     const expectedPaths = ["test/test2/note1.md", "test/note2.md", "note4.md"];
 
     const result = await getNotesFromTags(mockVault, tags);
@@ -281,7 +272,7 @@ describe("getNotesFromTags", () => {
 
   it("should handle both path and tags, returning files under the specified path with the specified tags", async () => {
     const mockVault = new Obsidian.Vault();
-    const tags = ["tag1"];
+    const tags = ["#tag1"];
     const noteFiles = [{ path: "test/test2/note1.md" }, { path: "test/note2.md" }] as TFile[];
     const expectedPaths = ["test/test2/note1.md"];
 
@@ -290,6 +281,15 @@ describe("getNotesFromTags", () => {
 
     expect(resultPaths).toEqual(expect.arrayContaining(expectedPaths));
     expect(resultPaths.length).toEqual(expectedPaths.length);
+  });
+
+  it("should ignore inline tags and only consider frontmatter tags", async () => {
+    const mockVault = new Obsidian.Vault();
+
+    const tags = ["#inlineTag1"];
+    const result = await getNotesFromTags(mockVault, tags);
+
+    expect(result).toEqual([]); // Should return empty since inline tags are ignored
   });
 });
 


### PR DESCRIPTION
Previously, we added an incremental indexing feature for copilot plus users. On any note update, It generates the excluded file list and checks whether the current file should be updated. This process can take 5 seconds for large vaults and causes the plugin to be unusable in those extreme scenarios. This PR fixes the issue by stopping the generation of included/excluded file lists and matching the current file path against the matching patterns. 

- Added a new `shouldIndexFile` method that checks whether a TFile should be indexed. It consolidates all the custom validation logic that checks `inclusions` and `exclusions`.
- Updated the pattern-matching logic to use native obsidian API when possible.
