### PR TITLE
Adding support for Mistral as an LLM provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@langchain/core": "^0.3.27",
         "@langchain/google-genai": "^0.1.6",
         "@langchain/groq": "^0.1.2",
+        "@langchain/mistralai": "^0.2.0",
         "@langchain/openai": "^0.4.2",
         "@orama/orama": "^3.0.0-rc-2",
         "@radix-ui/react-checkbox": "^1.1.3",
@@ -4394,6 +4395,35 @@
         "@langchain/core": ">=0.3.29 <0.4.0"
       }
     },
+    "node_modules/@langchain/mistralai": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@langchain/mistralai/-/mistralai-0.2.0.tgz",
+      "integrity": "sha512-VdfbKZopAuSXf/vlXbriGWLK3c7j5s47DoB3S31xpprY2BMSKZZiX9vE9TsgxMfAPuIDPIYcfgU7p1upvTYt8g==",
+      "dependencies": {
+        "@mistralai/mistralai": "^1.3.1",
+        "uuid": "^10.0.0",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.22.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.7 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/mistralai/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@langchain/ollama": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@langchain/ollama/-/ollama-0.1.1.tgz",
@@ -4453,6 +4483,17 @@
       },
       "peerDependencies": {
         "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.5.0.tgz",
+      "integrity": "sha512-AIn8pwAwA/fDvEUvmkt+40zH1ZmfaG3Q7oUWl17GUEC1tU7ZPwYz8Cv9P59lyS1SisHdDSu81oknO7f1ywkz8Q==",
+      "dependencies": {
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "peerDependencies": {
+        "zod": ">= 3"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@langchain/core": "^0.3.27",
     "@langchain/google-genai": "^0.1.6",
     "@langchain/groq": "^0.1.2",
+    "@langchain/mistralai": "^0.2.0",
     "@langchain/openai": "^0.4.2",
     "@orama/orama": "^3.0.0-rc-2",
     "@radix-ui/react-checkbox": "^1.1.3",

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -11,6 +11,7 @@ import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 import { ChatGroq } from "@langchain/groq";
 import { ChatOllama } from "@langchain/ollama";
 import { ChatOpenAI } from "@langchain/openai";
+import { ChatMistralAI } from "@langchain/mistralai";
 import { Notice } from "obsidian";
 
 type ChatConstructorType = new (config: any) => BaseChatModel;
@@ -27,6 +28,7 @@ const CHAT_PROVIDER_CONSTRUCTORS = {
   [ChatModelProviders.GROQ]: ChatGroq,
   [ChatModelProviders.OPENAI_FORMAT]: ChatOpenAI,
   [ChatModelProviders.COPILOT_PLUS]: ChatOpenAI,
+  [ChatModelProviders.MISTRAL]: ChatMistralAI,
 } as const;
 
 type ChatProviderConstructMap = typeof CHAT_PROVIDER_CONSTRUCTORS;
@@ -55,6 +57,7 @@ export default class ChatModelManager {
     [ChatModelProviders.LM_STUDIO]: () => "default-key",
     [ChatModelProviders.OPENAI_FORMAT]: () => "default-key",
     [ChatModelProviders.COPILOT_PLUS]: () => getSettings().plusLicenseKey,
+    [ChatModelProviders.MISTRAL]: () => getSettings().mistralApiKey,
   } as const;
 
   private constructor() {
@@ -195,6 +198,11 @@ export default class ChatModelManager {
           baseURL: BREVILABS_API_BASE_URL,
           fetch: customModel.enableCors ? safeFetch : undefined,
         },
+      },
+      [ChatModelProviders.MISTRAL]: {
+        model: modelName,
+        apiKey: await getDecryptedKey(customModel.apiKey || settings.mistralApiKey),
+        serverURL: customModel.baseUrl,
       },
     };
 

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -53,6 +53,7 @@ export interface ModelConfig {
   apiKey?: string;
   openAIProxyBaseUrl?: string;
   groqApiKey?: string;
+  mistralApiKey?: string;
   enableCors?: boolean;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,6 +53,7 @@ export enum ChatModels {
   COMMAND_R_PLUS = "command-r-plus",
   OPENROUTER_GPT_4o = "openai/chatgpt-4o-latest",
   GROQ_LLAMA_8b = "llama3-8b-8192",
+  MISTRAL_TINY = "mistral-tiny-latest",
 }
 
 // Model Providers
@@ -68,6 +69,7 @@ export enum ChatModelProviders {
   LM_STUDIO = "lm-studio",
   OPENAI_FORMAT = "3rd party (openai-format)",
   COPILOT_PLUS = "copilot-plus",
+  MISTRAL = "mistralai",
 }
 
 export const BUILTIN_CHAT_MODELS: CustomModel[] = [
@@ -326,6 +328,12 @@ export const ProviderInfo: Record<Provider, ProviderMetadata> = {
     host: "https://api.example.com/v1",
     keyManagementURL: "",
   },
+  [ChatModelProviders.MISTRAL]: {
+    label: "Mistral",
+    host: "https://api.mistral.ai/v1",
+    keyManagementURL: "https://console.mistral.ai/api-keys",
+    testModel: ChatModels.MISTRAL_TINY,
+  },
   [EmbeddingModelProviders.COPILOT_PLUS]: {
     label: "Copilot Plus",
     host: "https://api.brevilabs.com/v1",
@@ -348,6 +356,7 @@ export const ProviderSettingsKeyMap: Record<DisplayKeyProviders, keyof CopilotSe
   openrouterai: "openRouterAiApiKey",
   cohereai: "cohereApiKey",
   "copilot-plus": "plusLicenseKey",
+  mistralai: "mistralApiKey",
 };
 
 export enum VAULT_VECTOR_STORE_STRATEGY {
@@ -535,6 +544,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   enableEncryption: false,
   maxSourceChunks: 3,
   groqApiKey: "",
+  mistralApiKey: "",
   activeModels: BUILTIN_CHAT_MODELS,
   activeEmbeddingModels: BUILTIN_EMBEDDING_MODELS,
   embeddingRequestsPerMin: 90,

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -25,6 +25,7 @@ export interface CopilotSettings {
   azureOpenAIApiEmbeddingDeploymentName: string;
   googleApiKey: string;
   openRouterAiApiKey: string;
+  mistralApiKey: string;
   defaultChainType: ChainType;
   defaultModelKey: string;
   embeddingModelKey: string;


### PR DESCRIPTION
Adding support for Mistral as an LLM provider. Tested in the chat mode. This is to complete the abandoned #841 PR for the reworked codebase.