### PR TITLE
Add ModelCapability enum and capability detection

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -373,4 +373,9 @@ export default class ChatModelManager {
       }
     }
   }
+
+  findModelByName(modelName: string): CustomModel | undefined {
+    const settings = getSettings();
+    return settings.activeModels.find((model) => model.name === modelName);
+  }
 }

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -64,6 +64,12 @@ export interface SetChainOptions {
   refreshIndex?: boolean;
 }
 
+export enum ModelCapability {
+  REASONING = "reasoning",
+  VISION = "vision",
+  WEB_SEARCH = "websearch",
+}
+
 export interface CustomModel {
   name: string;
   provider: string;
@@ -79,6 +85,7 @@ export interface CustomModel {
   maxTokens?: number;
   context?: number;
   believerExclusive?: boolean;
+  capabilities?: ModelCapability[];
   // Embedding models only (Jina at the moment)
   dimensions?: number;
   // OpenAI specific fields

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { CustomModel } from "@/aiParams";
+import { CustomModel, ModelCapability } from "@/aiParams";
 import { type CopilotSettings } from "@/settings/model";
 import { ChainType } from "./chainFactory";
 
@@ -78,6 +78,7 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     enabled: true,
     isBuiltIn: true,
     core: true,
+    capabilities: [ModelCapability.VISION],
   },
   {
     name: ChatModels.GPT_4o,
@@ -85,6 +86,7 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     enabled: true,
     isBuiltIn: true,
     core: true,
+    capabilities: [ModelCapability.VISION],
   },
   {
     name: ChatModels.GPT_4o_mini,
@@ -98,12 +100,14 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     provider: ChatModelProviders.OPENAI,
     enabled: true,
     isBuiltIn: true,
+    capabilities: [ModelCapability.REASONING],
   },
   {
     name: ChatModels.O3_mini,
     provider: ChatModelProviders.OPENAI,
     enabled: true,
     isBuiltIn: true,
+    capabilities: [ModelCapability.REASONING],
   },
   {
     name: ChatModels.CLAUDE_3_5_SONNET,
@@ -111,6 +115,7 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     enabled: true,
     isBuiltIn: true,
     core: true,
+    capabilities: [ModelCapability.VISION],
   },
   {
     name: ChatModels.CLAUDE_3_5_HAIKU,
@@ -135,12 +140,14 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     provider: ChatModelProviders.GOOGLE,
     enabled: true,
     isBuiltIn: true,
+    capabilities: [ModelCapability.VISION],
   },
   {
     name: ChatModels.GEMINI_FLASH,
     provider: ChatModelProviders.GOOGLE,
     enabled: true,
     isBuiltIn: true,
+    capabilities: [ModelCapability.VISION],
   },
   {
     name: ChatModels.AZURE_OPENAI,


### PR DESCRIPTION
Fix text-only models in plus mode, such as those from Groq. 

Related: #1141 

cc @Emt-lin : borrowing part of your setup in #1225, you can rebase on this one. The ability to let user check abilities in the Custom Model form is crucial for this change.