### PR TITLE
Reduce binary size

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -41,7 +41,9 @@ const context = await esbuild.context({
   plugins: [svgPlugin(), wasmPlugin],
   define: {
     global: "window",
+    "process.env.NODE_ENV": prod ? '"production"' : '"development"',
   },
+  minify: prod,
 });
 
 if (prod) {


### PR DESCRIPTION
We are seeing copilot slows down large vault. I suspect it is related to the large binary size. After some investigation, I found that we were not using production build or minifying the JS code. With the correct esbuild config, we can reduce the binary size by 4M. 

Before: 6.6M
<img width="972" alt="Screenshot 2025-02-11 at 11 17 20 PM" src="https://github.com/user-attachments/assets/28837c4d-492c-4548-b9f9-4687896a6d02" />

After: 2.5M
<img width="981" alt="Screenshot 2025-02-11 at 11 16 49 PM" src="https://github.com/user-attachments/assets/f415b2a2-fdf3-4909-82e4-6a0e93968109" />

This change doesn't seem to improve the vault load time in my local testing...But I think it's nice to use the production build anyway.