### PR TITLE
implement model switching for custom prompts

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -390,4 +390,10 @@ export default class ChatModelManager {
     const settings = getSettings();
     return settings.activeModels.find((model) => model.name === modelName);
   }
+
+  getCurrentModel(): CustomModel | null {
+    const currentModelKey = getModelKey();
+    if (!currentModelKey) return null;
+    return this.findModelByName(currentModelKey.split("|")[0]) || null;
+  }
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -122,7 +122,7 @@ export function registerBuiltInCommands(plugin: CopilotPlugin) {
     (plugin as any).removeCommand(id);
   });
 
-  const promptProcessor = CustomPromptProcessor.getInstance(plugin.app.vault);
+  const promptProcessor = CustomPromptProcessor.getInstance(plugin.app);
 
   addEditorCommand(plugin, COMMAND_IDS.FIX_GRAMMAR, (editor) => {
     processInlineEditCommand(plugin, editor, COMMAND_IDS.FIX_GRAMMAR);
@@ -249,7 +249,12 @@ export function registerBuiltInCommands(plugin: CopilotPlugin) {
           new Notice(`No prompt found with the title "${promptTitle}".`);
           return;
         }
-        plugin.processCustomPrompt(COMMAND_IDS.APPLY_CUSTOM_PROMPT, prompt.content);
+        plugin.processCustomPrompt(
+          COMMAND_IDS.APPLY_CUSTOM_PROMPT,
+          prompt.content,
+          prompt.model,
+          prompt.isTemporaryModel
+        );
       } catch (err) {
         console.error(err);
         new Notice("An error occurred.");
@@ -260,6 +265,7 @@ export function registerBuiltInCommands(plugin: CopilotPlugin) {
   addCommand(plugin, COMMAND_IDS.APPLY_ADHOC_PROMPT, async () => {
     const modal = new AdhocPromptModal(plugin.app, async (adhocPrompt: string) => {
       try {
+        // For ad-hoc prompts, we don't support model switching
         plugin.processCustomPrompt(COMMAND_IDS.APPLY_ADHOC_PROMPT, adhocPrompt);
       } catch (err) {
         console.error(err);

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -154,7 +154,7 @@ const Chat: React.FC<ChatProps> = ({
     setLoadingMessage(LOADING_MESSAGES.DEFAULT);
 
     // First, process the original user message for custom prompts
-    const customPromptProcessor = CustomPromptProcessor.getInstance(app.vault);
+    const customPromptProcessor = CustomPromptProcessor.getInstance(app);
     let processedUserMessage = await customPromptProcessor.processCustomPrompt(
       inputMessage || "",
       "",
@@ -482,7 +482,7 @@ ${chatContent}`;
     };
   };
 
-  const customPromptProcessor = CustomPromptProcessor.getInstance(app.vault);
+  const customPromptProcessor = CustomPromptProcessor.getInstance(app);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(
     createEffect(COMMAND_IDS.APPLY_CUSTOM_PROMPT, async (selectedText, customPrompt) => {


### PR DESCRIPTION
Add support for both permanent and temporary model switching in custom prompts using frontmatter configuration. Users can now specify models using either 'model:' for permanent switches or 'temp-model:' for temporary switches.

This change improves the flexibility of custom prompts by allowing users to switch models contextually while maintaining their current model setting.

- closes #1146