### PR TITLE
Refactor note reference and fix dupe title issue

### DIFF
--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -1,14 +1,23 @@
 import { useChainType, useModelKey } from "@/aiParams";
 import { ChainType } from "@/chainFactory";
+import { AddContextNoteModal } from "@/components/modals/AddContextNoteModal";
 import { AddImageModal } from "@/components/modals/AddImageModal";
 import { ListPromptModal } from "@/components/modals/ListPromptModal";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { ModelDisplay } from "@/components/ui/model-display";
 import { ContextProcessor } from "@/contextProcessor";
 import { CustomPromptProcessor } from "@/customPromptProcessor";
 import { COPILOT_TOOL_NAMES } from "@/LLMProviders/intentAnalyzer";
 import { Mention } from "@/mentions/Mention";
 import { getModelKeyFromModel, useSettingsValue } from "@/settings/model";
 import { getToolDescription } from "@/tools/toolManager";
-import { err2String, extractNoteTitles, checkModelApiKey } from "@/utils";
+import { checkModelApiKey, err2String, extractNoteFiles, isNoteTitleUnique } from "@/utils";
 import {
   ArrowBigUp,
   ChevronDown,
@@ -18,28 +27,18 @@ import {
   StopCircle,
   X,
 } from "lucide-react";
-import { App, Platform, TFile } from "obsidian";
+import { App, Notice, Platform, TFile } from "obsidian";
 import React, {
   forwardRef,
+  useCallback,
   useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
   useState,
-  useCallback,
 } from "react";
-import ContextControl from "./ContextControl";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Button } from "@/components/ui/button";
 import { useDropzone } from "react-dropzone";
-import { AddContextNoteModal } from "@/components/modals/AddContextNoteModal";
-import { ModelDisplay } from "@/components/ui/model-display";
-import { Notice } from "obsidian";
+import ContextControl from "./ContextControl";
 
 interface ChatInputProps {
   inputMessage: string;
@@ -165,7 +164,12 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
           onNoteSelect: async (note: TFile) => {
             const before = inputMessage.slice(0, cursorPos - 2);
             const after = inputMessage.slice(cursorPos - 1);
-            const newInputMessage = `${before}[[${note.basename}]]${after}`;
+
+            // Check if this note title has duplicates
+            const isUnique = isNoteTitleUnique(note.basename, app.vault);
+            // If the title is unique, just show the title, otherwise show the full path
+            const noteRef = isUnique ? note.basename : note.path;
+            const newInputMessage = `${before}[[${noteRef}]]${after}`;
             setInputMessage(newInputMessage);
 
             const activeNote = app.workspace.getActiveFile();
@@ -183,7 +187,7 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
             // Add a delay to ensure the cursor is set after inputMessage is updated
             setTimeout(() => {
               if (textAreaRef.current) {
-                const newCursorPos = cursorPos + note.basename.length + 2;
+                const newCursorPos = cursorPos + noteRef.length + 2;
                 textAreaRef.current.setSelectionRange(newCursorPos, newCursorPos);
               }
             }, 0);
@@ -325,10 +329,10 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
 
     useEffect(() => {
       // Get all note titles that are referenced using [[note]] syntax in the input
-      const currentTitles = new Set(extractNoteTitles(inputMessage));
+      const currentFiles = new Set(extractNoteFiles(inputMessage, app.vault));
       // Get all URLs mentioned in the input
       const currentUrls = mention.extractAllUrls(inputMessage);
-
+      console.log("note files", currentFiles);
       setContextNotes((prev) =>
         prev.filter((note) => {
           // Check if this note was added manually via the "+" button
@@ -344,22 +348,19 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
           if (note.path === currentActiveNote?.path) {
             if (wasAddedViaReference) {
               // Case 1: Active note was added by typing [[note]]
-              // Keep it only if its title is still in the input
-              // This ensures it's removed when you delete the [[note]] reference
-              return currentTitles.has(note.basename);
+              // Keep it only if its file is still in the input
+              return currentFiles.has(note);
             } else {
               // Case 2: Active note was NOT added by [[note]], but by the includeActiveNote toggle
               // Keep it only if includeActiveNote is true
-              // This handles the "Include active note" toggle in the UI
               return includeActiveNote;
             }
           } else {
             // Handling for all other notes (not the active note)
             if (wasAddedViaReference) {
               // Case 3: Other note was added by typing [[note]]
-              // Keep it only if its title is still in the input
-              // This ensures it's removed when you delete the [[note]] reference
-              return currentTitles.has(note.basename);
+              // Keep it only if its file is still in the input
+              return currentFiles.has(note);
             } else {
               // Case 4: Other note was added via "Add Note to Context" button
               // Always keep these notes as they were manually added
@@ -371,7 +372,7 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
 
       // Remove any URLs that are no longer present in the input
       setContextUrls((prev) => prev.filter((url) => currentUrls.includes(url)));
-    }, [inputMessage, includeActiveNote, currentActiveNote, mention, setContextNotes]);
+    }, [inputMessage, includeActiveNote, currentActiveNote, mention, setContextNotes, app.vault]);
 
     // Update the current active note whenever it changes
     useEffect(() => {

--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -332,7 +332,7 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
       const currentFiles = new Set(extractNoteFiles(inputMessage, app.vault));
       // Get all URLs mentioned in the input
       const currentUrls = mention.extractAllUrls(inputMessage);
-      console.log("note files", currentFiles);
+
       setContextNotes((prev) =>
         prev.filter((note) => {
           // Check if this note was added manually via the "+" button

--- a/src/components/modals/OramaSearchModal.tsx
+++ b/src/components/modals/OramaSearchModal.tsx
@@ -1,5 +1,5 @@
 import CopilotPlugin from "@/main";
-import { extractNoteTitles } from "@/utils";
+import { extractNoteFiles } from "@/utils";
 import { App, Modal, Notice, TFile } from "obsidian";
 
 export class OramaSearchModal extends Modal {
@@ -36,7 +36,7 @@ export class OramaSearchModal extends Modal {
 
     searchButton.addEventListener("click", async () => {
       const input = this.searchInput.value;
-      const notePaths = extractNoteTitles(input);
+      const notePaths = extractNoteFiles(input, this.app.vault).map((file) => file.path);
 
       if (notePaths.length === 0) {
         new Notice("No valid note paths found. Use format: - [[Note Name]]");

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -57,6 +57,12 @@ export class ContextProcessor {
 
     const processNote = async (note: TFile) => {
       try {
+        // Skip if this note was already processed by processCustomPrompt
+        const noteRef = `[[${note.basename}]]`;
+        if (processedVars.has(noteRef)) {
+          return;
+        }
+
         if (currentChain !== ChainType.COPILOT_PLUS_CHAIN && note.extension !== "md") {
           if (!fileParserManager.supportsExtension(note.extension)) {
             console.warn(`Unsupported file type: ${note.extension}`);
@@ -77,10 +83,10 @@ export class ContextProcessor {
           content = await this.processEmbeddedPDFs(content, vault, fileParserManager);
         }
 
-        additionalContext += `\n\n[[${note.basename}.${note.extension}]]:\n\n${content}`;
+        additionalContext += `\n\nTitle: [[${note.basename}]]\nPath: ${note.path}\n\n${content}`;
       } catch (error) {
         console.error(`Error processing file ${note.path}:`, error);
-        additionalContext += `\n\n[[${note.basename}]]: [Error: Could not process file]`;
+        additionalContext += `\n\nTitle: [[${note.basename}]]\nPath: ${note.path}\n\n[Error: Could not process file]`;
       }
     };
 

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -120,11 +120,8 @@ export class ContextProcessor {
     setContextNotes: (notes: TFile[] | ((prev: TFile[]) => TFile[])) => void,
     setIncludeActiveNote: (include: boolean) => void
   ): Promise<void> {
-    // First check if this note can be added
-    if (
-      contextNotes.some((existing) => existing.path === note.path) ||
-      (activeNote && note.path === activeNote.path)
-    ) {
+    // Only check if the note exists in contextNotes
+    if (contextNotes.some((existing) => existing.path === note.path)) {
       return; // Note already exists in context
     }
 
@@ -132,18 +129,18 @@ export class ContextProcessor {
     const content = await vault.read(note);
     const hasEmbeddedPDFs = await this.hasEmbeddedPDFs(content);
 
-    // If it's the active note, set includeActiveNote to true
+    // Set includeActiveNote if it's the active note
     if (activeNote && note.path === activeNote.path) {
       setIncludeActiveNote(true);
-    } else {
-      // Otherwise add it to contextNotes
-      setContextNotes((prev: TFile[]) => [
-        ...prev,
-        Object.assign(note, {
-          wasAddedViaReference: true,
-          hasEmbeddedPDFs,
-        }),
-      ]);
     }
+
+    // Add to contextNotes with wasAddedViaReference flag
+    setContextNotes((prev: TFile[]) => [
+      ...prev,
+      Object.assign(note, {
+        wasAddedViaReference: true,
+        hasEmbeddedPDFs,
+      }),
+    ]);
   }
 }

--- a/src/search/hybridRetriever.ts
+++ b/src/search/hybridRetriever.ts
@@ -267,11 +267,10 @@ export class HybridRetriever extends BaseRetriever {
         },
       }));
 
-      logInfo("==== Modified and created time range: ====", startTime, endTime);
+      logInfo("==== Modified time range: ====", startTime, endTime);
 
       // Perform a second search with time range filters
       searchParams.where = {
-        ctime: { between: [startTime, endTime] },
         mtime: { between: [startTime, endTime] },
       };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,29 +80,6 @@ export const isFolderMatch = (fileFullpath: string, inputPath: string): boolean 
   return fileSegments.includes(inputPath.toLowerCase());
 };
 
-/**
- * @deprecated File display title can be duplicated, so we should use file path
- * instead of title to find the note file.
- */
-export async function getNoteFileFromTitle(vault: Vault, noteTitle: string): Promise<TFile | null> {
-  // Get all markdown files in the vault
-  const files = vault.getMarkdownFiles();
-
-  // Iterate through all files to find a match by title
-  for (const file of files) {
-    // Extract the title from the filename by removing the extension
-    const title = file.basename;
-
-    if (title === noteTitle) {
-      // If a match is found, return the file path
-      return file;
-    }
-  }
-
-  // If no match is found, return null
-  return null;
-}
-
 /** TODO: Rewrite with app.vault.getAbstractFileByPath() */
 export const getNotesFromPath = (vault: Vault, path: string): TFile[] => {
   const files = vault.getMarkdownFiles();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -389,17 +389,55 @@ export function extractChatHistory(memoryVariables: MemoryVariables): [string, s
   return chatHistory;
 }
 
-// TODO: Deprecate this. Note mentions should be an object with title and path (optional).
-// When user input `[[` the popup should show title and path for selection.
-// The selected item has path to avoid duplicate titles. If user manually types
-// the full title, path can still be missing. In that case title is used to retrieve
-// the note.
-export function extractNoteTitles(query: string): string[] {
-  // Use a regular expression to extract note titles wrapped in [[]]
+export function extractNoteFiles(query: string, vault: Vault): TFile[] {
+  // Use a regular expression to extract note titles and paths wrapped in [[]]
   const regex = /\[\[(.*?)\]\]/g;
   const matches = query.match(regex);
-  const uniqueTitles = new Set(matches ? matches.map((match) => match.slice(2, -2)) : []);
-  return Array.from(uniqueTitles);
+  const uniqueFiles = new Map<string, TFile>();
+
+  if (matches) {
+    matches.forEach((match) => {
+      const inner = match.slice(2, -2);
+
+      // First try to get file by full path
+      const file = vault.getAbstractFileByPath(inner);
+
+      if (file instanceof TFile) {
+        // Found by path, use it directly
+        uniqueFiles.set(file.path, file);
+      } else {
+        // Try to find by title
+        const files = vault.getMarkdownFiles();
+        const matchingFiles = files.filter((f) => f.basename === inner);
+
+        if (matchingFiles.length > 0) {
+          if (isNoteTitleUnique(inner, vault)) {
+            // Only one file with this title, use it
+            uniqueFiles.set(matchingFiles[0].path, matchingFiles[0]);
+          } else {
+            // Multiple files with same title - this shouldn't happen
+            // as we should be using full paths for duplicate titles
+            console.warn(
+              `Found multiple files with title "${inner}". Expected a full path for duplicate titles.`
+            );
+          }
+        }
+      }
+    });
+  }
+
+  return Array.from(uniqueFiles.values());
+}
+
+// Helper function to check if a note title is unique in the vault
+export function isNoteTitleUnique(title: string, vault: Vault): boolean {
+  const files = vault.getMarkdownFiles();
+  return files.filter((f) => f.basename === title).length === 1;
+}
+
+// Helper function to determine if we should show the full path for a file
+export function shouldShowPath(file: TFile): boolean {
+  return (file as any).needsPathDisplay === true;
 }
 
 /**


### PR DESCRIPTION
Related #1253 

- When the note title is unique, add the title `[[title]]` to chat input
- When the note title has dupes, add the full path `[[path]]` to chat input
- Update note reference to use full path everywhere, remove any note reference by title in the codebase
- Remove ctime filter for time-based queries and rely on mtime only