### PR TITLE
Enhancement: Add file counts to file tree and remove file list from large file trees.

### DIFF
--- a/src/tools/FileTreeTools.test.ts
+++ b/src/tools/FileTreeTools.test.ts
@@ -1,5 +1,5 @@
 import { TFolder } from "obsidian";
-import { createGetFileTreeTool } from "./FileTreeTools";
+import { createGetFileTreeTool, buildFileTree } from "./FileTreeTools";
 import * as searchUtils from "@/search/searchUtils";
 
 // Mock the searchUtils functions
@@ -70,14 +70,16 @@ describe("FileTreeTools", () => {
     projects.children = [
       new MockTFile("docs/projects/project1.md", projects),
       new MockTFile("docs/projects/project2.md", projects),
+      new MockTFile("docs/projects/data.json", projects),
     ];
 
     notes.children = [
       new MockTFile("docs/notes/note1.md", notes),
       new MockTFile("docs/notes/note2.md", notes),
+      new MockTFile("docs/notes/image.png", notes),
     ];
 
-    root.children = [docs, new MockTFile("readme.md", root)];
+    root.children = [docs, new MockTFile("readme.md", root), new MockTFile("config.json", root)];
 
     // Reset mocks before each test
     jest.clearAllMocks();
@@ -90,32 +92,72 @@ describe("FileTreeTools", () => {
     (searchUtils.shouldIndexFile as jest.Mock).mockReturnValue(true);
   });
 
-  it("should generate correct JSON file tree when no exclusions", async () => {
-    const tool = createGetFileTreeTool(root);
-    const result = await tool.invoke({});
-    // Extract JSON part after the prompt
-    const jsonPart = result.substring(result.indexOf("{"));
-    const parsedResult = JSON.parse(jsonPart);
+  it("should generate correct file tree structure with files and extension counts", async () => {
+    // Test buildFileTree function directly
+    const tree = buildFileTree(root);
 
-    expect(searchUtils.getMatchingPatterns).toHaveBeenCalled();
-    expect(searchUtils.shouldIndexFile).toHaveBeenCalled();
-
-    const expected = {
-      vault: [
-        ["readme.md"],
-        {
-          docs: [
-            ["readme.md"],
-            {
-              projects: ["project1.md", "project2.md"],
-              notes: ["note1.md", "note2.md"],
+    // Define expected tree structure
+    const expectedTree = {
+      vault: {
+        files: ["readme.md", "config.json"],
+        subFolders: {
+          docs: {
+            files: ["readme.md"],
+            subFolders: {
+              projects: {
+                files: ["project1.md", "project2.md", "data.json"],
+                extensionCounts: { md: 2, json: 1 },
+              },
+              notes: {
+                files: ["note1.md", "note2.md", "image.png"],
+                extensionCounts: { md: 2, png: 1 },
+              },
             },
-          ],
+            extensionCounts: { md: 5, json: 1, png: 1 },
+          },
         },
-      ],
+        extensionCounts: { md: 6, json: 2, png: 1 },
+      },
     };
 
-    expect(parsedResult).toEqual(expected);
+    expect(tree).toEqual(expectedTree);
+
+    // Also test the tool to ensure it uses buildFileTree correctly
+    const tool = createGetFileTreeTool(root);
+    const result = await tool.invoke({});
+
+    // Extract JSON part after the prompt
+    const jsonPart = result.substring(result.indexOf("{"));
+    const treeFromTool = JSON.parse(jsonPart);
+
+    expect(treeFromTool).toEqual(expectedTree);
+  });
+
+  it("should handle size limit by rebuilding without files", async () => {
+    // Test buildFileTree with size limit handling
+    const tree = buildFileTree(root, false);
+
+    // Define expected simplified tree structure
+    const expectedTree = {
+      vault: {
+        subFolders: {
+          docs: {
+            subFolders: {
+              projects: {
+                extensionCounts: { md: 2, json: 1 },
+              },
+              notes: {
+                extensionCounts: { md: 2, png: 1 },
+              },
+            },
+            extensionCounts: { md: 5, json: 1, png: 1 },
+          },
+        },
+        extensionCounts: { md: 6, json: 2, png: 1 },
+      },
+    };
+
+    expect(tree).toEqual(expectedTree);
   });
 
   it("should exclude files based on patterns", async () => {
@@ -124,59 +166,41 @@ describe("FileTreeTools", () => {
       return !file.path.includes("projects");
     });
 
-    const tool = createGetFileTreeTool(root);
-    const result = await tool.invoke({});
-    const jsonPart = result.substring(result.indexOf("{"));
-    const parsedResult = JSON.parse(jsonPart);
+    // Test buildFileTree with exclusion patterns
+    const tree = buildFileTree(root);
 
-    const expected = {
-      vault: [
-        ["readme.md"],
-        {
-          docs: [
-            ["readme.md"],
-            {
-              notes: ["note1.md", "note2.md"],
-            },
-          ],
-        },
-      ],
-    };
-
-    expect(parsedResult).toEqual(expected);
-  });
-
-  it("should handle empty folder after exclusions", async () => {
-    // Mock shouldIndexFile to exclude all files
-    (searchUtils.shouldIndexFile as jest.Mock).mockReturnValue(false);
-
-    const tool = createGetFileTreeTool(root);
-    const result = await tool.invoke({});
-    const jsonPart = result.substring(result.indexOf("{"));
-    const parsedResult = JSON.parse(jsonPart);
-
-    expect(parsedResult).toEqual({});
-  });
-
-  it("should handle partial folder exclusions", async () => {
-    // Mock shouldIndexFile to only include files with "note" in the path
-    (searchUtils.shouldIndexFile as jest.Mock).mockImplementation((file) => {
-      return file.path.includes("note");
-    });
-
-    const tool = createGetFileTreeTool(root);
-    const result = await tool.invoke({});
-    const jsonPart = result.substring(result.indexOf("{"));
-    const parsedResult = JSON.parse(jsonPart);
-
-    const expected = {
+    // Define expected tree with projects excluded
+    const expectedTree = {
       vault: {
-        docs: {
-          notes: ["note1.md", "note2.md"],
+        files: ["readme.md", "config.json"],
+        subFolders: {
+          docs: {
+            files: ["readme.md"],
+            subFolders: {
+              notes: {
+                files: ["note1.md", "note2.md", "image.png"],
+                extensionCounts: { md: 2, png: 1 },
+              },
+            },
+            extensionCounts: { md: 3, png: 1 },
+          },
         },
+        extensionCounts: { md: 4, png: 1, json: 1 },
       },
     };
 
-    expect(parsedResult).toEqual(expected);
+    expect(tree).toEqual(expectedTree);
+  });
+
+  it("should handle empty folders after filtering", async () => {
+    // Mock shouldIndexFile to exclude all files
+    (searchUtils.shouldIndexFile as jest.Mock).mockReturnValue(false);
+
+    // Test buildFileTree with all files excluded
+    const tree = buildFileTree(root);
+
+    const expectedTree = {};
+
+    expect(tree).toEqual(expectedTree);
   });
 });

--- a/src/tools/FileTreeTools.test.ts
+++ b/src/tools/FileTreeTools.test.ts
@@ -79,7 +79,12 @@ describe("FileTreeTools", () => {
       new MockTFile("docs/notes/image.png", notes),
     ];
 
-    root.children = [docs, new MockTFile("readme.md", root), new MockTFile("config.json", root)];
+    root.children = [
+      docs,
+      new MockTFile("readme.md", root),
+      new MockTFile("config.json", root),
+      new MockTFile("text", root),
+    ];
 
     // Reset mocks before each test
     jest.clearAllMocks();
@@ -99,7 +104,7 @@ describe("FileTreeTools", () => {
     // Define expected tree structure
     const expectedTree = {
       vault: {
-        files: ["readme.md", "config.json"],
+        files: ["readme.md", "config.json", "text"],
         subFolders: {
           docs: {
             files: ["readme.md"],
@@ -116,7 +121,7 @@ describe("FileTreeTools", () => {
             extensionCounts: { md: 5, json: 1, png: 1 },
           },
         },
-        extensionCounts: { md: 6, json: 2, png: 1 },
+        extensionCounts: { md: 6, json: 2, png: 1, unknown: 1 },
       },
     };
 
@@ -153,7 +158,7 @@ describe("FileTreeTools", () => {
             extensionCounts: { md: 5, json: 1, png: 1 },
           },
         },
-        extensionCounts: { md: 6, json: 2, png: 1 },
+        extensionCounts: { md: 6, json: 2, png: 1, unknown: 1 },
       },
     };
 
@@ -172,7 +177,7 @@ describe("FileTreeTools", () => {
     // Define expected tree with projects excluded
     const expectedTree = {
       vault: {
-        files: ["readme.md", "config.json"],
+        files: ["readme.md", "config.json", "text"],
         subFolders: {
           docs: {
             files: ["readme.md"],
@@ -185,7 +190,7 @@ describe("FileTreeTools", () => {
             extensionCounts: { md: 3, png: 1 },
           },
         },
-        extensionCounts: { md: 4, png: 1, json: 1 },
+        extensionCounts: { md: 4, png: 1, json: 1, unknown: 1 },
       },
     };
 

--- a/src/tools/FileTreeTools.ts
+++ b/src/tools/FileTreeTools.ts
@@ -44,7 +44,7 @@ function buildFileTree(
         }
 
         // Always count file extensions
-        const ext = getFileExtension(child.name);
+        const ext = getFileExtension(child.name) || "unknown";
         if (ext) {
           extensionCounts[ext] = (extensionCounts[ext] || 0) + 1;
         }


### PR DESCRIPTION
New file tree now looks like this:

Full file tree if size < 1.5MB
```
vault: {
        files: ["readme.md", "config.json", "text"],
        subFolders: {
          docs: {
            files: ["readme.md"],
            subFolders: {
              projects: {
                files: ["project1.md", "project2.md", "data.json"],
                extensionCounts: { md: 2, json: 1 },
              },
              notes: {
                files: ["note1.md", "note2.md", "image.png"],
                extensionCounts: { md: 2, png: 1 },
              },
            },
            extensionCounts: { md: 5, json: 1, png: 1 },
          },
        },
        extensionCounts: { md: 6, json: 2, png: 1, unknown: 1 },
      }
```
Simple file tree without file list if size >= 1.5MB
```
vault: {
        subFolders: {
          docs: {
            subFolders: {
              projects: {
                extensionCounts: { md: 2, json: 1 },
              },
              notes: {
                extensionCounts: { md: 2, png: 1 },
              },
            },
            extensionCounts: { md: 5, json: 1, png: 1 },
          },
        },
        extensionCounts: { md: 6, json: 2, png: 1, unknown: 1 },
      }
```

* Added a new property in the file tree node for the number of files of different types. (serves as the summary of the folder)
* Removed file list if the file tree is larger than 1.5MB.
* Added descriptive key back to the tree to improve clarity.

Tested both cases in my test vault.

For reference, below is the an example when the file tree does not have the file list.

<img width="365" alt="Screenshot 2025-02-25 at 12 21 30" src="https://github.com/user-attachments/assets/a67a2eec-4f67-4d88-872c-bd5af0717095" />
