### PR TITLE
Fix Azure OpenAI Instance Name not used for URL

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -119,7 +119,7 @@ export default class ChatModelManager {
           customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName,
         openAIApiKey: await getDecryptedKey(customModel.apiKey || settings.azureOpenAIApiKey),
         configuration: {
-          baseURL: `https://copilot-experimental.openai.azure.com/openai/deployments/${customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName}`,
+          baseURL: `https://${customModel.azureOpenAIApiInstanceName || settings.azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName}`,
           defaultQuery: {
             "api-version": customModel.azureOpenAIApiVersion || settings.azureOpenAIApiVersion,
           },


### PR DESCRIPTION
Fix for [https://github.com/logancyang/obsidian-copilot/issues/1302](https://github.com/logancyang/obsidian-copilot/issues/1302)