### PR TITLE
Render composer markdown blocks

### DIFF
--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -203,6 +203,70 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
         "", // Empty string for sourcePath as we don't have a specific source file
         componentRef.current
       );
+
+      // Function to add apply buttons to code blocks
+      const addApplyButtonsToCodeBlocks = () => {
+        if (!contentRef.current) return;
+
+        // Find all pre elements (code blocks) in the rendered content
+        const codeBlocks = contentRef.current.querySelectorAll("pre");
+
+        codeBlocks.forEach((pre) => {
+          // Create apply button
+          const applyButton = document.createElement("button");
+          applyButton.className = "apply-code-button";
+          applyButton.textContent = "Apply";
+          applyButton.title = "Apply this code";
+
+          // Get the code element
+          const codeElement = pre.querySelector("code");
+          if (!codeElement) return;
+
+          // Process the code block to extract metadata and clean the display
+          const originalCode = codeElement.textContent || "";
+          const lines = originalCode.split("\n");
+          const firstLine = lines[0].trim();
+
+          // Extract metadata from the first line
+          const metadata: Record<string, string> = {};
+          let shouldRemoveFirstLine = false;
+
+          // Check if the first line contains path= or other metadata
+          const firstLinePathMatch = firstLine.match(/path=([^\s]+)/);
+          if (firstLinePathMatch && firstLinePathMatch[1]) {
+            metadata.path = firstLinePathMatch[1];
+            shouldRemoveFirstLine = true;
+
+            // Update the button title to include the filename
+            const filename = metadata.path.split("/").pop();
+            applyButton.title = `Apply to ${filename}`;
+            applyButton.textContent = `Apply to ${filename}`;
+          }
+
+          // If we found metadata in the first line, remove it from the displayed code
+          if (shouldRemoveFirstLine) {
+            const cleanedCode = lines.slice(1).join("\n");
+            codeElement.textContent = cleanedCode;
+
+            // Store the original code and metadata as data attributes
+            pre.dataset.originalCode = originalCode;
+            pre.dataset.path = metadata.path;
+          }
+
+          // Add click event listener to the apply button
+          applyButton.addEventListener("click", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            console.log("Apply " + pre.dataset.path);
+          });
+
+          // Add the apply button to the pre element
+          pre.appendChild(applyButton);
+        });
+      };
+
+      // Add apply buttons to code blocks after rendering
+      addApplyButtonsToCodeBlocks();
     }
 
     // Cleanup function

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -432,24 +432,48 @@ If your plugin does not need CSS, delete this file.
 .message-content pre .copy-code-button {
   position: absolute;
   top: 0;
-  right: 0;
+  right: 60px; /* Move to the left to make room for apply button */
   padding: 4px 8px;
   color: var(--text-muted);
   background-color: var(--background-primary);
   border: 1px solid var(--background-modifier-border);
-  border-radius: 0 4px 0 4px;
+  border-radius: 4px 0 0 4px; /* Change border radius for left position */
   font-size: 0.8em;
   transition: all 0.1s ease;
   opacity: 0;
+}
+
+/* Style for the apply button in code blocks */
+.message-content pre .apply-code-button {
+  position: absolute;
+  top: 0;
+  right: 0; /* Position to the right of the copy button */
+  padding: 4px 8px;
+  color: white;
+  background-color: var(--text-accent);
+  border: 1px solid var(--text-accent);
+  border-radius: 0 4px 0 4px; /* Change border radius for right position */
+  font-size: 0.8em;
+  transition: all 0.1s ease;
+  opacity: 1; /* Always visible */
+  font-weight: 500;
 }
 
 .message-content pre:hover .copy-code-button {
   opacity: 1;
 }
 
-.message-content pre .copy-code-button:hover {
+.message-content pre .copy-code-button:hover,
+.message-content pre .apply-code-button:hover {
   background-color: var(--background-modifier-hover);
   color: var(--text-normal);
+}
+
+/* Apply button specific hover effect */
+.message-content pre .apply-code-button:hover {
+  background-color: var(--interactive-accent-hover);
+  color: white;
+  border-color: var(--interactive-accent-hover);
 }
 
 .message-content ul,


### PR DESCRIPTION
The markdown code blocks returned from composer output all have file paths in the beginning <!-- path=folder/note.md -->. In this PR, the plugin renders these code blocks with a path title on the top and an "Apply" button on the top right.

See 
<img width="498" alt="Screenshot 2025-02-26 at 16 43 28" src="https://github.com/user-attachments/assets/9f3bd1a4-118a-49bd-b0f7-ed96ea543fbe" />

The current copy button will still show up on mousehover. See

<img width="499" alt="Screenshot 2025-02-26 at 16 44 05" src="https://github.com/user-attachments/assets/4ec0ffc2-a4ff-4b6f-91b7-e1467d4d0550" />
<img width="485" alt="Screenshot 2025-02-26 at 17 17 36" src="https://github.com/user-attachments/assets/e7a5e5c8-be5c-4941-8fd7-350b771ae8d0" />

