### PR TITLE
FIX: Use simplified File Tree when it's larger than 0.5MB

### DIFF
--- a/src/tools/FileTreeTools.ts
+++ b/src/tools/FileTreeTools.ts
@@ -109,7 +109,7 @@ const createGetFileTreeTool = (root: TFolder) =>
 `;
       const jsonResult = JSON.stringify(tree);
 
-      // Check if result is too large (0.5MB)
+      // If the file tree is larger than 0.5MB, use the simplified version instead.
       if (jsonResult.length > 500000) {
         // Rebuild tree without file lists
         const simplifiedTree = buildFileTree(root, false);

--- a/src/tools/FileTreeTools.ts
+++ b/src/tools/FileTreeTools.ts
@@ -109,8 +109,8 @@ const createGetFileTreeTool = (root: TFolder) =>
 `;
       const jsonResult = JSON.stringify(tree);
 
-      // Check if result is too large (1.5MB is roughly 1.5 million characters)
-      if (jsonResult.length > 1500000) {
+      // Check if result is too large (0.5MB)
+      if (jsonResult.length > 500000) {
         // Rebuild tree without file lists
         const simplifiedTree = buildFileTree(root, false);
         return prompt + JSON.stringify(simplifiedTree);


### PR DESCRIPTION
Based on user's feedback, a file tree with 1.3MB size still cannot be processed by the flash model. Let's update the threshold to 0.5MB instead.