### PR TITLE
Label and mask licence key when debug logging is enabled

### DIFF
--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -144,7 +144,7 @@ export class BrevilabsClient {
    * unknown error.
    */
   async validateLicenseKey(): Promise<boolean | undefined> {
-    logInfo("settings value", getSettings().plusLicenseKey);
+    logInfo("License key", getSettings().plusLicenseKey.replace(/(?<=^.{2}).*(?=.{2}$)/g, m => '*'.repeat(m.length)));
     const { error } = await this.makeRequest(
       "/license",
       {


### PR DESCRIPTION
The plus licence key is printed verbatim when logging is enabled. In the interest of privacy and security, I would suggest masking it slightly, to avoid that people accidentally disclosing it e.g. when posting console logs.