### PR TITLE
Fix Azure OpenAI chat model baseURL construction logic.

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -120,7 +120,9 @@ export default class ChatModelManager {
           customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName,
         openAIApiKey: await getDecryptedKey(customModel.apiKey || settings.azureOpenAIApiKey),
         configuration: {
-          baseURL: customModel.baseUrl,
+          baseURL:
+            customModel.baseUrl ||
+            `https://${customModel.azureOpenAIApiInstanceName || settings.azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName}`,
           defaultQuery: {
             "api-version": customModel.azureOpenAIApiVersion || settings.azureOpenAIApiVersion,
           },

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -120,7 +120,7 @@ export default class ChatModelManager {
           customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName,
         openAIApiKey: await getDecryptedKey(customModel.apiKey || settings.azureOpenAIApiKey),
         configuration: {
-          baseURL: `https://${customModel.azureOpenAIApiInstanceName || settings.azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName}`,
+          baseURL: customModel.baseUrl,
           defaultQuery: {
             "api-version": customModel.azureOpenAIApiVersion || settings.azureOpenAIApiVersion,
           },

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -121,7 +121,8 @@ export default class ChatModelManager {
         openAIApiKey: await getDecryptedKey(customModel.apiKey || settings.azureOpenAIApiKey),
         configuration: {
           baseURL:
-            customModel.baseUrl || `https://${customModel.azureOpenAIApiInstanceName || settings.azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName}/chat/completions`,
+            customModel.baseUrl ||
+            `https://${customModel.azureOpenAIApiInstanceName || settings.azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName}`,
           defaultQuery: {
             "api-version": customModel.azureOpenAIApiVersion || settings.azureOpenAIApiVersion,
           },

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -121,8 +121,7 @@ export default class ChatModelManager {
         openAIApiKey: await getDecryptedKey(customModel.apiKey || settings.azureOpenAIApiKey),
         configuration: {
           baseURL:
-            customModel.baseUrl ||
-            `https://${customModel.azureOpenAIApiInstanceName || settings.azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName}`,
+            customModel.baseUrl || `https://${customModel.azureOpenAIApiInstanceName || settings.azureOpenAIApiInstanceName}.openai.azure.com/openai/deployments/${customModel.azureOpenAIApiDeploymentName || settings.azureOpenAIApiDeploymentName}/chat/completions`,
           defaultQuery: {
             "api-version": customModel.azureOpenAIApiVersion || settings.azureOpenAIApiVersion,
           },


### PR DESCRIPTION
Hi, I noticed that when using Azure OpenAI as the chat model provider, the generated URL is incorrect. I modified the code to use the user-provided endpoint URL, and it worked correctly for me.

However, there is still an issue when using Azure OpenAI as the embedding model provider. Unfortunately, I am not familiar enough with this part of the script to rewrite the URL logic. I can, however, provide some error details: the script generates a default URL in the format `https://{model_name}xx.openai.xx`, which is not the correct format for the Azure OpenAI API. I strongly recommend using the user-provided endpoint URL instead of constructing the URL programmatically based on rules.