### PR TITLE
Add update notification

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -19,6 +19,7 @@ import { err2String, formatDateTime } from "@/utils";
 import { Notice, TFile } from "obsidian";
 import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { Buffer } from "buffer";
+import { NewVersionBanner } from "@/components/chat-components/NewVersionBanner";
 
 interface ChatProps {
   sharedState: SharedState;
@@ -557,7 +558,8 @@ ${chatContent}`;
   ]);
 
   return (
-    <div className="chat-container">
+    <div className="flex flex-col size-full overflow-hidden">
+      <NewVersionBanner currentVersion={plugin.manifest.version} />
       <ChatMessages
         chatHistory={chatHistory}
         currentAiMessage={currentAiMessage}

--- a/src/components/chat-components/NewVersionBanner.tsx
+++ b/src/components/chat-components/NewVersionBanner.tsx
@@ -1,0 +1,78 @@
+import { Button } from "@/components/ui/button";
+import { useLatestVersion } from "@/hooks/useLatestVersion";
+import { cn } from "@/lib/utils";
+import { updateSetting, useSettingsValue } from "@/settings/model";
+import { isNewerVersion } from "@/utils";
+import { XIcon } from "lucide-react";
+import React, { useState } from "react";
+
+interface NewVersionBannerProps {
+  currentVersion: string;
+}
+
+export function NewVersionBanner({ currentVersion }: NewVersionBannerProps) {
+  const { latestVersion, hasUpdate } = useLatestVersion(currentVersion);
+  const lastDismissedVersion = useSettingsValue().lastDismissedVersion;
+  const [isVisible, setIsVisible] = useState(true);
+
+  const showBanner =
+    hasUpdate &&
+    latestVersion &&
+    isNewerVersion(latestVersion, currentVersion) &&
+    lastDismissedVersion !== latestVersion;
+
+  const handleDismiss = () => {
+    if (latestVersion) {
+      setIsVisible(false);
+      // Wait for animation to complete before updating setting
+      setTimeout(() => {
+        updateSetting("lastDismissedVersion", latestVersion);
+      }, 300);
+    }
+  };
+
+  if (!showBanner) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        "min-h-14 overflow-hidden",
+        isVisible
+          ? "animate-in slide-in-from-top duration-300"
+          : "animate-out slide-out-to-top duration-300"
+      )}
+    >
+      <div className="flex items-center justify-between gap-2 p-2 pl-3 mb-1 text-xs border border-border border-solid rounded-md">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">Update available:</span>(
+          <a
+            href={`https://github.com/logancyang/obsidian-copilot/releases/latest`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-normal"
+          >
+            v{latestVersion}
+          </a>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            size="fit"
+            variant="ghost2"
+            className="text-accent hover:text-accent-hover"
+            onClick={() => {
+              window.open(`obsidian://show-plugin?id=copilot`, "_blank");
+              handleDismiss();
+            }}
+          >
+            Update
+          </Button>
+          <Button variant="ghost2" size="icon" onClick={handleDismiss}>
+            <XIcon className="size-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -521,6 +521,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   promptUsageTimestamps: {},
   defaultConversationNoteName: "{$topic}@{$date}_{$time}",
   inlineEditCommands: DEFAULT_INLINE_EDIT_COMMANDS,
+  lastDismissedVersion: null,
 };
 
 export const EVENT_NAMES = {

--- a/src/hooks/useLatestVersion.ts
+++ b/src/hooks/useLatestVersion.ts
@@ -1,0 +1,28 @@
+import { checkLatestVersion, isNewerVersion } from "@/utils";
+import { useEffect, useState } from "react";
+
+interface UseLatestVersionResult {
+  latestVersion: string | null;
+  hasUpdate: boolean;
+}
+
+export function useLatestVersion(currentVersion: string): UseLatestVersionResult {
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    const checkVersion = async () => {
+      const result = await checkLatestVersion();
+      if (result.version) {
+        setLatestVersion(result.version);
+      }
+    };
+    checkVersion();
+  }, []);
+
+  const hasUpdate = latestVersion !== null && isNewerVersion(latestVersion, currentVersion);
+
+  return {
+    latestVersion,
+    hasUpdate,
+  };
+}

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -57,6 +57,7 @@ export interface CopilotSettings {
   temperature: number;
   maxTokens: number;
   contextTurns: number;
+  lastDismissedVersion: string | null;
   // Do not use this directly, use getSystemPrompt() instead
   userSystemPrompt: string;
   openAIProxyBaseUrl: string;

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -82,14 +82,6 @@ If your plugin does not need CSS, delete this file.
   width: 70%;
 }
 
-.chat-container {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-}
-
 .bottom-container {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
A banner was added to the chat container to notify users about the latest update. To make it less intrusive, it will no longer show until the next version if the user dismisses it.

![2025-03-30 23 24 48](https://github.com/user-attachments/assets/13152151-53c0-462d-b7d9-3dcb29cdcaf8)

Also updated the settings version
<img width="668" alt="Screenshot 2025-03-30 at 11 40 44 PM" src="https://github.com/user-attachments/assets/21dccb7b-9ba8-45c4-95d7-0bf10815e001" />
