### PR TITLE
some project-based feature bug fix 

### DIFF
--- a/src/LLMProviders/chainRunner.ts
+++ b/src/LLMProviders/chainRunner.ts
@@ -776,8 +776,8 @@ class ProjectChainRunner extends CopilotPlusChainRunner {
       return super.getSystemPrompt();
     }
 
-    // Get cached context synchronously
-    const context = ProjectManager.instance.getProjectContext(projectConfig.id);
+    // Get context asynchronously
+    const context = await ProjectManager.instance.getProjectContext(projectConfig.id);
     let finalPrompt = projectConfig.systemPrompt;
 
     if (context) {

--- a/src/LLMProviders/projectManager.ts
+++ b/src/LLMProviders/projectManager.ts
@@ -39,7 +39,7 @@ export default class ProjectManager {
     this.plugin = plugin;
     this.currentProjectId = null;
     this.chainMangerInstance = new ChainManager(app, vectorStoreManager);
-    this.projectContextCache = ProjectContextCache.getInstance();
+    this.projectContextCache = ProjectContextCache.getInstance(app);
     this.chatMessageCache = new Map();
 
     // Set up subscriptions
@@ -251,14 +251,6 @@ ${contextParts.join("\n\n")}
     return this.projectContextCache.getSync(project);
   }
 
-  public async clearContextCache(projectId: string): Promise<void> {
-    const project = getSettings().projectList.find((p) => p.id === projectId);
-    if (project) {
-      await this.projectContextCache.clearForProject(project);
-      logInfo(`Context cache cleared for project: ${projectId}`);
-    }
-  }
-
   private async processMarkdownContext(inclusions?: string, exclusions?: string): Promise<string> {
     if (!inclusions && !exclusions) {
       return "";
@@ -335,5 +327,9 @@ ${content}`;
 
     const results = await Promise.all(processPromises);
     return results.join("");
+  }
+
+  public onunload(): void {
+    this.projectContextCache.cleanup();
   }
 }

--- a/src/LLMProviders/projectManager.ts
+++ b/src/LLMProviders/projectManager.ts
@@ -83,7 +83,7 @@ export default class ProjectManager {
           // Check if project configuration has changed
           if (JSON.stringify(prevProject) !== JSON.stringify(nextProject)) {
             // Clear context cache for this project
-            await this.projectContextCache.clearForProject(nextProject);
+            await this.projectContextCache.clearForProject(prevProject);
 
             // If this is the current project, reload its context and recreate chain
             if (this.currentProjectId === nextProject.id) {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -28,8 +28,6 @@ import { Buffer } from "buffer";
 import { Notice, TFile } from "obsidian";
 import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 
-type ChatMode = "default" | "project";
-
 interface ChatProps {
   sharedState: SharedState;
   chainManager: ChainManager;
@@ -37,7 +35,6 @@ interface ChatProps {
   updateUserMessageHistory: (newMessage: string) => void;
   fileParserManager: FileParserManager;
   plugin: CopilotPlugin;
-  mode?: ChatMode;
 }
 
 const Chat: React.FC<ChatProps> = ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,6 +126,10 @@ export default class CopilotPlugin extends Plugin {
       this.vectorStoreManager.onunload();
     }
 
+    if (this.projectManager) {
+      this.projectManager.onunload();
+    }
+
     this.settingsUnsubscriber?.();
     this.autocompleteService?.destroy();
 


### PR DESCRIPTION
## Bug
1. the old project context cache file isn't deleted when cache updated.
2. the context cache doesn't be updated when the source file updated.
3. Since All those API(url、pdf api) calls are slow and expensive, so need to refactor project caching functionality.

## Fixed

1. Fixed issues with item 1 and item 2.
2. Refactor project caching functionality.
  - 1.new cache structure.
 
     ```ts
       export interface ContextCache {
          markdownContext: string;
          webContexts: Record<string, string>; // URL -> context
          youtubeContexts: Record<string, string>; // URL -> context
          timestamp: number;
          markdownNeedsReload: boolean;
       }
    ```

 - 2.When the project configuration changed, markdownContext、webContexts/youtubeContexts will be processed differently
   - markdownContext: all markdownContext cache will be deleted.
   - webContexts/youtubeContexts: Remove context for URLs that no longer exist.
 - 3.Load project context steps
   - markdownContext: Only process if `markdownNeedsReload` flag is true or there is no existing content
   - webContexts/youtubeContexts: For each url, fetch from cache if available; otherwise, make API call load context.