### PR TITLE
Ollama ApiKey support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
-        "@langchain/ollama": "^0.1.1",
+        "@langchain/ollama": "^0.2.0",
         "@tailwindcss/container-queries": "^0.1.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
@@ -4572,13 +4572,16 @@
       }
     },
     "node_modules/@langchain/ollama": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@langchain/ollama/-/ollama-0.1.1.tgz",
-      "integrity": "sha512-IQEdzGkfKzdoyys3GW5hCXc64d/u1xkrYXved73BLO+bnyQfzrM224jdsiYGUpjW3cUaO1ebD6PUiMYcANPPFQ==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@langchain/ollama/-/ollama-0.2.0.tgz",
+      "integrity": "sha512-jLlYFqt+nbhaJKLakk7lRTWHZJ7wHeJLM6yuv4jToQ8zPzpL//372+MjggDoW0mnw8ofysg1T2C6mEJspKJtiA==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "ollama": "^0.5.9",
-        "uuid": "^10.0.0"
+        "ollama": "^0.5.12",
+        "uuid": "^10.0.0",
+        "zod": "^3.24.1",
+        "zod-to-json-schema": "^3.24.1"
       },
       "engines": {
         "node": ">=18"
@@ -17248,10 +17251,11 @@
       }
     },
     "node_modules/ollama": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.9.tgz",
-      "integrity": "sha512-F/KZuDRC+ZsVCuMvcOYuQ6zj42/idzCkkuknGyyGVmNStMZ/sU3jQpvhnl4SyC0+zBzLiKNZJnJeuPFuieWZvQ==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.14.tgz",
+      "integrity": "sha512-pvOuEYa2WkkAumxzJP0RdEYHkbZ64AYyyUszXVX7ruLvk5L+EiO2G71da2GqEQ4IAk4j6eLoUbGk5arzFT1wJA==",
       "devOptional": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-fetch": "^3.6.20"
       }
@@ -20623,7 +20627,8 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
-      "devOptional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@langchain/ollama": "^0.1.1",
+    "@langchain/ollama": "^0.2.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -182,10 +182,11 @@ export default class ChatModelManager {
       [ChatModelProviders.OLLAMA]: {
         // ChatOllama has `model` instead of `modelName`!!
         model: modelName,
-        // @ts-ignore
-        apiKey: customModel.apiKey || "default-key",
         // MUST NOT use /v1 in the baseUrl for ollama
         baseUrl: customModel.baseUrl || "http://localhost:11434",
+        headers: new Headers({
+          Authorization: `Bearer ${await getDecryptedKey(customModel.apiKey || "default-key")}`,
+        }),
       },
       [ChatModelProviders.LM_STUDIO]: {
         modelName: modelName,

--- a/src/LLMProviders/embeddingManager.ts
+++ b/src/LLMProviders/embeddingManager.ts
@@ -256,6 +256,9 @@ export default class EmbeddingManager {
         baseUrl: customModel.baseUrl || "http://localhost:11434",
         model: modelName,
         truncate: true,
+        headers: {
+          Authorization: `Bearer ${await getDecryptedKey(customModel.apiKey || "default-key")}`,
+        },
       },
       [EmbeddingModelProviders.LM_STUDIO]: {
         modelName,


### PR DESCRIPTION
I have implemented this as noted in https://github.com/logancyang/obsidian-copilot/discussions/1167#discussioncomment-12655101

This pull request includes updates to dependencies and improvements to the handling of API keys in the `ChatModelManager` and `EmbeddingManager` classes. The most important changes include updating the `@langchain/ollama` dependency and enhancing security by using encrypted API keys.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L36-R36): Updated the `@langchain/ollama` dependency from version `^0.1.1` to `^0.2.0`. Not strictly necessary for this PR
* [`package-lock.json`](diffhunk://#diff-053150b640a7ce75eff69d1a22cae7f0f94ad64ce9a855db544dda0929316519L17251-R17256): Updated the downstream `ollama` dependency from version `0.5.9` to `0.5.14`. At least an upgrade to `0.5.10` is necessary, as it [introduced the possibility to pass headers](https://github.com/ollama/ollama-js/releases/tag/v0.5.10). An upgrade to `0.5.14` is probably neccessary because of [fixes to header parsing](https://github.com/ollama/ollama-js/releases/tag/v0.5.14)

Improvements:

* [`src/LLMProviders/chatModelManager.ts`](diffhunk://#diff-17d5d3367a41452e8954a4a04b620abb8940d891a19a59e67cedf324098f2f96L185-R189): Modified the `ChatModelManager` class to pass API keys through the `Authorization` header.
* [`src/LLMProviders/embeddingManager.ts`](diffhunk://#diff-fc66504e28467f607f542c94300106d6b69ec2104b633ccd9c4a974f7205e461R259-R261): Modified the `EmbeddingManager` class to pass API keys through the `Authorization` header.