### PR TITLE
fix: Add a new line when press the Enter key on mobile.

### DIFF
--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -253,10 +253,14 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
       }
 
       if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        onSendMessage(false);
-        setHistoryIndex(-1);
-        setTempInput("");
+        // Only prevent default and send message on non-mobile platforms
+        if (!Platform.isMobile) {
+          e.preventDefault();
+          onSendMessage(false);
+          setHistoryIndex(-1);
+          setTempInput("");
+        }
+        // On mobile, do nothing here, allowing the default newline behavior
       } else if (e.key === "ArrowUp") {
         if (currentLineIndex > 0 || selectionStart > 0) {
           // Allow normal cursor movement within multi-line input


### PR DESCRIPTION
## Bug

When typing in the chat interface on mobile, the return key seems to randomly alternates between:
- Adding a new line to the message
- Submitting the message to chat

This is frustrating as you can't predict which will happen, leading to accidentally sent incomplete messages.

## fixed

Provide consistent behavior: Add a new line when press the Enter key on mobile.