### PR TITLE
Remove selection requirement for custom commands

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -64,9 +64,14 @@ export function addCheckCommand(
  * Process an inline edit command and display a modal with the processed prompt.
  */
 async function processInlineEditCommand(editor: Editor, commandId: string) {
-  const selectedText = editor.getSelection().trim();
-  if (!selectedText) {
-    return;
+  let selectedText = editor.getSelection();
+  if (!selectedText.trim()) {
+    const activeFile = app.workspace.getActiveFile();
+    if (!activeFile) {
+      new Notice("No active note found.");
+      return;
+    }
+    selectedText = await app.vault.cachedRead(activeFile);
   }
 
   const command = getCommandById(commandId);

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -219,8 +219,9 @@ export const CommandSettings: React.FC = () => {
         <div className="flex flex-col mb-4 gap-2">
           <div className="text-xl font-bold">Custom Commands</div>
           <div className="text-sm text-muted">
-            To trigger a custom command, highlight text in the editor and select it from the command
-            palette, or right-click and choose it from the context menu if configured.
+            To trigger a custom command, select it from the command palette or right-click and
+            choose it from the context menu if configured. When no text is highlighted, the entire
+            note will be used.
           </div>
         </div>
         {!hasModifiedCommand() && (


### PR DESCRIPTION
## Summary
- allow custom commands to use the entire note when no text is selected
- update custom command instructions

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
