### PR TITLE
Only include composer prompt for @composer

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -168,7 +168,7 @@ const Chat: React.FC<ChatProps> = ({
     // First, add composer instruction if necessary
     let processedInputMessage = inputMessage;
     const composerPrompt = await getComposerOutputPrompt();
-    if (inputMessage.includes("@composer") && composerPrompt != "") {
+    if (inputMessage.includes("@composer") && composerPrompt !== "") {
       processedInputMessage =
         inputMessage + "\n\n<output_format>\n" + composerPrompt + "\n</output_format>";
     }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const DEFAULT_SYSTEM_PROMPT = `You are Obsidian Copilot, a helpful assist
   12. Do NOT mention the additional context provided such as getCurrentTime and getTimeRangeMs if it's irrelevant to the user message.
   13. If the user mentions "tags", it most likely means tags in Obsidian note properties.`;
 
-export const COMPOSER_INSTRUCTIONS = `If the user explicitly requests to update or create markdown notes or canvases OR mentions "@composer", always return the new note content in a special JSON format.
+export const COMPOSER_OUTPUT_INSTRUCTIONS = `Return the new note content or canvas JSON in a special JSON format.
 
   # JSON Format
   Provide the content in JSON format and wrap it in a code block with the following structure:

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -104,10 +104,10 @@ export class ContextProcessor {
           content = await this.processEmbeddedPDFs(content, vault, fileParserManager);
         }
 
-        additionalContext += `\n\nTitle: [[${note.basename}]]\nPath: ${note.path}\n\n${content}`;
+        additionalContext += `\n\n <note_in_context> \n Title: [[${note.basename}]]\nPath: ${note.path}\n\n${content}\n</note_in_context>`;
       } catch (error) {
         console.error(`Error processing file ${note.path}:`, error);
-        additionalContext += `\n\nTitle: [[${note.basename}]]\nPath: ${note.path}\n\n[Error: Could not process file]`;
+        additionalContext += `\n\n <note_in_context_error> \n Title: [[${note.basename}]]\nPath: ${note.path}\n\n[Error: Could not process file]\n</note_in_context_error>`;
       }
     };
 
@@ -116,9 +116,14 @@ export class ContextProcessor {
       await processNote(activeNote);
     }
 
+    const includedFilePaths = new Set<string>();
     // Process context notes
     for (const note of contextNotes) {
+      if (includedFilePaths.has(note.path)) {
+        continue;
+      }
       await processNote(note);
+      includedFilePaths.add(note.path);
     }
 
     return additionalContext;

--- a/src/customPromptProcessor.ts
+++ b/src/customPromptProcessor.ts
@@ -21,7 +21,7 @@ export interface CustomPrompt {
  * be skipped when processing custom prompts because it's handled differently
  * by the custom command prompt processor.
  */
-const VARIABLE_REGEX = /\{(?!copilot-selection\})([^}]+)\}/g;
+const VARIABLE_REGEX = /\{(?!copilot-selection\})([^\n}]+)\}/g;
 
 /**
  * Represents the result of processing a custom prompt variable.

--- a/src/customPromptProcessor.ts
+++ b/src/customPromptProcessor.ts
@@ -21,7 +21,7 @@ export interface CustomPrompt {
  * be skipped when processing custom prompts because it's handled differently
  * by the custom command prompt processor.
  */
-const VARIABLE_REGEX = /\{(?!copilot-selection\})([^\n}]+)\}/g;
+const VARIABLE_REGEX = /\{(?!copilot-selection\})([^}]+)\}/g;
 
 /**
  * Represents the result of processing a custom prompt variable.
@@ -91,7 +91,11 @@ async function extractVariablesFromPrompt(
       variablesMap.set(variableName, variableResult.content);
       variableResult.files.forEach((file) => includedFiles.add(file));
     } else if (variableName.toLowerCase() !== "activenote") {
-      console.warn(`No notes found for variable: ${variableName}`);
+      if (variableName.startsWith('"')) {
+        // DO NOTHING as the user probably wants to write a JSON object
+      } else {
+        console.warn(`No notes found for variable: ${variableName}`);
+      }
     }
   }
 

--- a/src/integration_tests/composerPrompt.test.ts
+++ b/src/integration_tests/composerPrompt.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_SYSTEM_PROMPT, COMPOSER_INSTRUCTIONS } from "../constants";
+import { DEFAULT_SYSTEM_PROMPT, COMPOSER_OUTPUT_INSTRUCTIONS } from "../constants";
 import * as dotenv from "dotenv";
 import { jest } from "@jest/globals";
 import {
@@ -55,7 +55,7 @@ describe("Composer Instructions - Integration Tests", () => {
         temperature: 0.1,
         maxOutputTokens: 1000,
       },
-      systemInstruction: `${DEFAULT_SYSTEM_PROMPT}\n\n${COMPOSER_INSTRUCTIONS}`,
+      systemInstruction: DEFAULT_SYSTEM_PROMPT,
       safetySettings: [
         {
           category: HarmCategory.HARM_CATEGORY_HARASSMENT,
@@ -87,7 +87,9 @@ describe("Composer Instructions - Integration Tests", () => {
       try {
         // Create chat session and send message
         const chat = model.startChat();
-        const result = await chat.sendMessage(userPrompt);
+        const result = await chat.sendMessage(
+          userPrompt + "\n\n<output_format>\n" + COMPOSER_OUTPUT_INSTRUCTIONS + "\n</output_format>"
+        );
         const content = result.response.text();
         if (expectedBlocks == 0) {
           expect(content).not.toContain('"type": "composer"');
@@ -137,7 +139,10 @@ describe("Composer Instructions - Integration Tests", () => {
   };
 
   // Run tests with different prompts
-  testComposerResponse("Composer: create a new note", "Create a new note about climate change?");
+  testComposerResponse(
+    "Composer: create a new note",
+    "@composer Create a new note about climate change?"
+  );
 
   testComposerResponse(
     "Composer: add content to a note",
@@ -150,7 +155,7 @@ describe("Composer Instructions - Integration Tests", () => {
 
   testComposerResponse(
     "Composer: rewrite a note",
-    `Rewrite the note [[atom]] to be more concise.
+    `@composer Rewrite the note [[atom]] to be more concise.
 
      Title: [[atom]] 
      Path: atom.md
@@ -159,7 +164,7 @@ describe("Composer Instructions - Integration Tests", () => {
 
   testComposerResponse(
     "Composer: remove content from a note",
-    `Remove the second paragraph.
+    `@composer Remove the second paragraph.
 
      Title: [[atom]] 
      Path: atom.md
@@ -168,15 +173,19 @@ describe("Composer Instructions - Integration Tests", () => {
 
   testComposerResponse(
     "Composer: update multiple notes",
-    "Create two notes on the topic of Earth and Mars separately",
+    "@composer Create two notes on the topic of Earth and Mars separately",
     2
   );
 
-  testComposerResponse("Composer: create a canvas", "Create a canvas about water cycle", 1);
+  testComposerResponse(
+    "Composer: create a canvas",
+    "@composer Create a canvas about water cycle",
+    1
+  );
 
   testComposerResponse(
     "Composer: not triggered on summarization",
-    "Summarize the note [[atom]]",
+    "@composer Summarize the note [[atom]]",
     0
   );
 });

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -7,7 +7,7 @@ import { type ChainType } from "@/chainFactory";
 import {
   BUILTIN_CHAT_MODELS,
   BUILTIN_EMBEDDING_MODELS,
-  COMPOSER_INSTRUCTIONS,
+  COMPOSER_OUTPUT_INSTRUCTIONS,
   DEFAULT_OPEN_AREA,
   DEFAULT_SETTINGS,
   DEFAULT_SYSTEM_PROMPT,
@@ -250,22 +250,15 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   return sanitizedSettings;
 }
 
-export function getComposerPrompt(): string {
+export function getComposerOutputPrompt(): string {
   const isPlusUser = getSettings().isPlusUser;
 
-  if (isPlusUser) {
-    return COMPOSER_INSTRUCTIONS;
-  }
-
-  return "";
+  return isPlusUser ? COMPOSER_OUTPUT_INSTRUCTIONS : "";
 }
 
 export function getSystemPrompt(): string {
   const userPrompt = getSettings().userSystemPrompt;
-  let basePrompt = DEFAULT_SYSTEM_PROMPT;
-
-  // Add composer instructions for plus users
-  basePrompt = `${basePrompt}\n\n${getComposerPrompt()}`;
+  const basePrompt = DEFAULT_SYSTEM_PROMPT;
 
   if (userPrompt) {
     return `${basePrompt}


### PR DESCRIPTION
* Move composer prompt from system prompt to user prompt and only include it with explicit `@composer`
* Composer prompt is added before any context note.


Testing:
* Unit tests
* Some basic integration tests

<img width="762" alt="Screenshot 2025-06-03 at 23 10 44" src="https://github.com/user-attachments/assets/60bd87a0-d774-4d26-b1e1-e5eaa0600de2" />

<img width="571" alt="Screenshot 2025-06-03 at 23 12 10" src="https://github.com/user-attachments/assets/6fc111af-ed54-405d-b843-11bac549fe87" />

<img width="529" alt="Screenshot 2025-06-03 at 23 14 34" src="https://github.com/user-attachments/assets/3cc4f097-c019-460f-912a-96c7f5c371e5" />
