### PR TITLE
Support "list files" intent in project mode

### DIFF
--- a/src/LLMProviders/intentAnalyzer.ts
+++ b/src/LLMProviders/intentAnalyzer.ts
@@ -69,6 +69,11 @@ export class IntentAnalyzer {
           if (tool.name === "getTimeRangeMs") {
             timeRange = await ToolManager.callTool(tool, args);
           }
+          if (tool.name == "getFileTree" && isProjectMode()) {
+            // Skip file tree tool call in project mode so when user asks "what files do I have?",
+            // we return files in the project context instead of the vault.
+            continue;
+          }
 
           processedToolCalls.push({ tool, args });
         }


### PR DESCRIPTION
#1519

The context source info is already in the project context, so we just need to disabling file tree to support the "list files" intent.

<img width="443" alt="Screenshot 2025-06-05 at 18 09 56" src="https://github.com/user-attachments/assets/39cd6c6f-420b-4820-8bc6-d33562b462fe" />
