### PR TITLE
feat: add support for Github Copilot as a provider

### DIFF
--- a/src/LLMProviders/githubCopilotChatModel.ts
+++ b/src/LLMProviders/githubCopilotChatModel.ts
@@ -81,28 +81,3 @@ export class CopilotChatModel extends BaseChatModel {
     return Math.ceil(text.length / 4);
   }
 }
-
-export class ChatGitHubCopilot {
-  private provider: GitHubCopilotProvider;
-  constructor(config: any) {
-    this.provider = new GitHubCopilotProvider();
-  }
-  async send(messages: { role: string; content: string }[], model = "gpt-4") {
-    return this.provider.sendChatMessage(messages, model);
-  }
-  getAuthState() {
-    return this.provider.getAuthState();
-  }
-  async startAuth() {
-    return this.provider.startDeviceCodeFlow();
-  }
-  async pollForAccessToken() {
-    return this.provider.pollForAccessToken();
-  }
-  async fetchCopilotToken() {
-    return this.provider.fetchCopilotToken();
-  }
-  resetAuth() {
-    this.provider.resetAuth();
-  }
-}

--- a/src/LLMProviders/githubCopilotChatModel.ts
+++ b/src/LLMProviders/githubCopilotChatModel.ts
@@ -6,6 +6,7 @@ import { AIMessage, type BaseMessage, type MessageContent } from "@langchain/cor
 import { type ChatResult, ChatGeneration } from "@langchain/core/outputs";
 import { type CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import { GitHubCopilotProvider } from "./githubCopilotProvider";
+import { extractTextFromChunk } from "@/utils";
 
 export interface CopilotChatModelParams extends BaseChatModelParams {
   provider: GitHubCopilotProvider;
@@ -53,7 +54,7 @@ export class CopilotChatModel extends BaseChatModel {
   ): Promise<ChatResult> {
     const chatMessages = messages.map((m) => ({
       role: this._convertMessageType(m._getType()),
-      content: m.content as string,
+      content: extractTextFromChunk(m.content),
     }));
 
     const response = await this.provider.sendChatMessage(chatMessages, this.modelName);

--- a/src/LLMProviders/githubCopilotChatModel.ts
+++ b/src/LLMProviders/githubCopilotChatModel.ts
@@ -1,0 +1,107 @@
+import {
+  BaseChatModel,
+  type BaseChatModelParams,
+} from "@langchain/core/language_models/chat_models";
+import { AIMessage, type BaseMessage, type MessageContent } from "@langchain/core/messages";
+import { type ChatResult, ChatGeneration } from "@langchain/core/outputs";
+import { type CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
+import { GitHubCopilotProvider } from "./githubCopilotProvider";
+
+export interface CopilotChatModelParams extends BaseChatModelParams {
+  provider: GitHubCopilotProvider;
+  modelName: string;
+}
+
+export class CopilotChatModel extends BaseChatModel {
+  lc_serializable = false;
+  lc_namespace = ["langchain", "chat_models", "copilot"];
+  private provider: GitHubCopilotProvider;
+  modelName: string;
+
+  constructor(fields: CopilotChatModelParams) {
+    super(fields);
+    this.provider = fields.provider;
+    this.modelName = fields.modelName;
+  }
+
+  _llmType(): string {
+    return "copilot-chat-model";
+  }
+
+  private _convertMessageType(messageType: string): string {
+    switch (messageType) {
+      case "human":
+        return "user";
+      case "ai":
+        return "assistant";
+      case "system":
+        return "system";
+      case "tool":
+        return "tool";
+      case "function":
+        return "function";
+      case "generic":
+      default:
+        return "user";
+    }
+  }
+
+  async _generate(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun
+  ): Promise<ChatResult> {
+    const chatMessages = messages.map((m) => ({
+      role: this._convertMessageType(m._getType()),
+      content: m.content as string,
+    }));
+
+    const response = await this.provider.sendChatMessage(chatMessages, this.modelName);
+    const content = response.choices?.[0]?.message?.content || "";
+
+    const generation: ChatGeneration = {
+      text: content,
+      message: new AIMessage(content),
+    };
+
+    return {
+      generations: [generation],
+      llmOutput: {}, // add more details here if needed
+    };
+  }
+
+  /**
+   * A simple approximation: ~4 chars per token for English text
+   * This matches the fallback behavior in ChatModelManager.countTokens
+   */
+  async getNumTokens(content: MessageContent): Promise<number> {
+    const text = typeof content === "string" ? content : JSON.stringify(content);
+    if (!text) return 0;
+    return Math.ceil(text.length / 4);
+  }
+}
+
+export class ChatGitHubCopilot {
+  private provider: GitHubCopilotProvider;
+  constructor(config: any) {
+    this.provider = new GitHubCopilotProvider();
+  }
+  async send(messages: { role: string; content: string }[], model = "gpt-4") {
+    return this.provider.sendChatMessage(messages, model);
+  }
+  getAuthState() {
+    return this.provider.getAuthState();
+  }
+  async startAuth() {
+    return this.provider.startDeviceCodeFlow();
+  }
+  async pollForAccessToken() {
+    return this.provider.pollForAccessToken();
+  }
+  async fetchCopilotToken() {
+    return this.provider.fetchCopilotToken();
+  }
+  resetAuth() {
+    this.provider.resetAuth();
+  }
+}

--- a/src/LLMProviders/githubCopilotProvider.ts
+++ b/src/LLMProviders/githubCopilotProvider.ts
@@ -120,8 +120,9 @@ export class GitHubCopilotProvider {
     if (res.status !== 200) throw new Error("Failed to get Copilot token");
     const data = res.json;
     this.authState.copilotToken = data.token;
-    this.authState.copilotTokenExpiresAt =
-      Date.now() + (data.expires_at ? data.expires_at * 1000 : 3600 * 1000);
+    this.authState.copilotTokenExpiresAt = data.expires_at
+      ? data.expires_at * 1000
+      : Date.now() + 3600 * 1000;
     this.authState.status = "authenticated";
     // Persist Copilot token and expiration
     updateSetting("copilotToken", data.token);

--- a/src/LLMProviders/githubCopilotProvider.ts
+++ b/src/LLMProviders/githubCopilotProvider.ts
@@ -1,0 +1,164 @@
+// Based on the flow used in Pierrad/obsidian-github-copilot
+// Handles device code flow, token exchange, and chat requests
+
+import { getSettings, updateSetting } from "@/settings/model";
+import { requestUrl, Notice } from "obsidian";
+
+const CLIENT_ID = "Iv1.b507a08c87ecfe98"; // Copilot VSCode client ID
+const DEVICE_CODE_URL = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const COPILOT_TOKEN_URL = "https://api.github.com/copilot_internal/v2/token";
+const CHAT_COMPLETIONS_URL = "https://api.githubcopilot.com/chat/completions";
+
+export interface CopilotAuthState {
+  deviceCode?: string;
+  userCode?: string;
+  verificationUri?: string;
+  expiresIn?: number;
+  interval?: number;
+  accessToken?: string;
+  copilotToken?: string;
+  copilotTokenExpiresAt?: number;
+  status: "idle" | "pending" | "authenticated" | "error";
+  error?: string;
+}
+
+export class GitHubCopilotProvider {
+  private authState: CopilotAuthState = { status: "idle" };
+
+  constructor() {
+    // Load persisted tokens from settings
+    const settings = getSettings();
+    if (settings.copilotAccessToken && settings.copilotToken) {
+      this.authState.accessToken = settings.copilotAccessToken;
+      this.authState.copilotToken = settings.copilotToken;
+      this.authState.copilotTokenExpiresAt = settings.copilotTokenExpiresAt;
+      if (settings.copilotTokenExpiresAt && settings.copilotTokenExpiresAt > Date.now()) {
+        this.authState.status = "authenticated";
+      }
+    }
+  }
+
+  getAuthState() {
+    return this.authState;
+  }
+
+  // Step 1: Start device code flow
+  async startDeviceCodeFlow() {
+    this.authState.status = "pending";
+    try {
+      const res = await requestUrl({
+        url: DEVICE_CODE_URL,
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ client_id: CLIENT_ID, scope: "read:user" }),
+      });
+      if (res.status !== 200) throw new Error("Failed to get device code");
+      const data = res.json;
+      this.authState.deviceCode = data.device_code;
+      this.authState.userCode = data.user_code;
+      this.authState.verificationUri = data.verification_uri || data.verification_uri_complete;
+      this.authState.expiresIn = data.expires_in;
+      this.authState.interval = data.interval;
+      this.authState.status = "pending";
+      return {
+        userCode: data.user_code,
+        verificationUri: data.verification_uri || data.verification_uri_complete,
+      };
+    } catch (e: any) {
+      this.authState.status = "error";
+      this.authState.error = e.message;
+      throw e;
+    }
+  }
+
+  // Step 2: Poll for access token
+  async pollForAccessToken() {
+    if (!this.authState.deviceCode) throw new Error("No device code");
+
+    new Notice("Waiting for you to authorize in the browser...", 15000);
+
+    const poll = async () => {
+      const res = await requestUrl({
+        url: ACCESS_TOKEN_URL,
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({
+          client_id: CLIENT_ID,
+          device_code: this.authState.deviceCode,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      });
+      const data = res.json;
+      if (data.error === "authorization_pending") return null;
+      if (data.error) throw new Error(data.error_description || data.error);
+      return data.access_token;
+    };
+    const interval = this.authState.interval || 5;
+    const expiresAt = Date.now() + (this.authState.expiresIn || 900) * 1000;
+    while (Date.now() < expiresAt) {
+      const token = await poll();
+      if (token) {
+        this.authState.accessToken = token;
+        // Persist access token
+        updateSetting("copilotAccessToken", token);
+        return token;
+      }
+      await new Promise((resolve) => setTimeout(resolve, interval * 1000));
+    }
+    throw new Error("Device code expired");
+  }
+
+  // Step 3: Exchange for Copilot token
+  async fetchCopilotToken() {
+    if (!this.authState.accessToken) throw new Error("No access token");
+    const res = await requestUrl({
+      url: COPILOT_TOKEN_URL,
+      method: "GET",
+      headers: { Authorization: `Bearer ${this.authState.accessToken}` },
+    });
+    if (res.status !== 200) throw new Error("Failed to get Copilot token");
+    const data = res.json;
+    this.authState.copilotToken = data.token;
+    this.authState.copilotTokenExpiresAt =
+      Date.now() + (data.expires_at ? data.expires_at * 1000 : 3600 * 1000);
+    this.authState.status = "authenticated";
+    // Persist Copilot token and expiration
+    updateSetting("copilotToken", data.token);
+    updateSetting("copilotTokenExpiresAt", this.authState.copilotTokenExpiresAt);
+    return data.token;
+  }
+
+  // Step 4: Send chat message
+  async sendChatMessage(messages: { role: string; content: string }[], model = "gpt-4") {
+    if (!this.authState.copilotToken) throw new Error("Not authenticated with Copilot");
+    const res = await requestUrl({
+      url: CHAT_COMPLETIONS_URL,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.authState.copilotToken}`,
+        "User-Agent": "vscode/1.80.1",
+        "Editor-Version": "vscode/1.80.1",
+        "OpenAI-Intent": "conversation-panel",
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        stream: false,
+      }),
+    });
+    if (res.status !== 200) throw new Error("Copilot chat request failed");
+    const data = res.json;
+    return data;
+  }
+
+  // Utility: Reset authentication state
+  resetAuth() {
+    this.authState = { status: "idle" };
+    // Clear persisted tokens
+    updateSetting("copilotAccessToken", "");
+    updateSetting("copilotToken", "");
+    updateSetting("copilotTokenExpiresAt", 0);
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -148,6 +148,7 @@ export enum ChatModelProviders {
   COPILOT_PLUS = "copilot-plus",
   MISTRAL = "mistralai",
   DEEPSEEK = "deepseek",
+  GITHUB_COPILOT = "github-copilot",
 }
 
 export enum ModelCapability {
@@ -507,6 +508,12 @@ export const ProviderInfo: Record<Provider, ProviderMetadata> = {
     keyManagementURL: "",
     listModelURL: "",
   },
+  [ChatModelProviders.GITHUB_COPILOT]: {
+    label: "GitHub Copilot",
+    host: "https://api.githubcopilot.com",
+    keyManagementURL: "",
+    listModelURL: "",
+  },
   [EmbeddingModelProviders.COPILOT_PLUS_JINA]: {
     label: "Copilot Plus",
     host: "https://api.brevilabs.com/v1",
@@ -528,6 +535,7 @@ export const ProviderSettingsKeyMap: Record<SettingKeyProviders, keyof CopilotSe
   "copilot-plus": "plusLicenseKey",
   mistralai: "mistralApiKey",
   deepseek: "deepseekApiKey",
+  "github-copilot": "copilotToken",
 };
 
 export enum VAULT_VECTOR_STORE_STRATEGY {
@@ -666,6 +674,10 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   passMarkdownImages: true,
   enableCustomPromptTemplating: true,
   suggestedDefaultCommands: false,
+  // GitHub Copilot provider tokens (optional, for persistence)
+  copilotAccessToken: "",
+  copilotToken: "",
+  copilotTokenExpiresAt: 0,
 };
 
 export const EVENT_NAMES = {

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -112,6 +112,9 @@ export interface CopilotSettings {
   enableCustomPromptTemplating: boolean;
   /** Whether we have suggested built-in default commands to the user once. */
   suggestedDefaultCommands: boolean;
+  copilotAccessToken?: string;
+  copilotToken?: string;
+  copilotTokenExpiresAt?: number;
 }
 
 export const settingsStore = createStore();

--- a/src/settings/providerModels.ts
+++ b/src/settings/providerModels.ts
@@ -338,13 +338,13 @@ export interface ProviderResponseMap {
 }
 
 // Adapter type definition - converts provider-specific models to standard format
-export type ModelAdapter<T extends SettingKeyProviders> = (
+export type ModelAdapter<T extends keyof ProviderResponseMap> = (
   data: ProviderResponseMap[T]
 ) => StandardModel[];
 
 // Create adapter function type
 export type ProviderModelAdapters = {
-  [K in SettingKeyProviders]?: ModelAdapter<K>;
+  [K in Extract<SettingKeyProviders, keyof ProviderResponseMap>]?: ModelAdapter<K>;
 };
 
 /**
@@ -455,7 +455,8 @@ export const getDefaultModelAdapter = (provider: SettingKeyProviders) => {
  * Uses provider-specific adapter if available, otherwise falls back to default adapter
  */
 export const getModelAdapter = (provider: SettingKeyProviders) => {
-  return providerAdapters[provider] || getDefaultModelAdapter(provider);
+  // Type assertion to allow unknown providers to fallback to default adapter
+  return (providerAdapters as any)[provider] || getDefaultModelAdapter(provider);
 };
 
 /**

--- a/src/settings/v2/components/ModelAddDialog.tsx
+++ b/src/settings/v2/components/ModelAddDialog.tsx
@@ -37,6 +37,7 @@ import { PasswordInput } from "@/components/ui/password-input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { FormField } from "@/components/ui/form-field";
+import { SettingSwitch } from "@/components/ui/setting-switch";
 
 interface FormErrors {
   name: boolean;
@@ -547,6 +548,30 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
           </FormField>
 
           {renderProviderSpecificFields()}
+
+          <div className="tw-flex tw-items-center tw-justify-between tw-py-2">
+            <div className="tw-flex tw-items-center tw-gap-2">
+              <span className="tw-text-sm tw-font-medium">Stream output</span>
+              <TooltipProvider delayDuration={0}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <HelpCircle className="tw-size-4 tw-text-muted" />
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    Enable streaming responses from the model.
+                    {model.provider === "github-copilot" && (
+                      <p className="tw-text-error">Not supported by GitHub Copilot.</p>
+                    )}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
+            <SettingSwitch
+              checked={model.provider === "github-copilot" ? false : (model.stream ?? true)}
+              disabled={model.provider === "github-copilot"}
+              onCheckedChange={(checked) => setModel({ ...model, stream: checked })}
+            />
+          </div>
         </div>
 
         <div className="tw-flex tw-items-center tw-justify-end tw-gap-4">


### PR DESCRIPTION
You can now authenticate with Github to use Github Copilot as a model provider.


- Authenticate with one button in the bottom of the Api keys setting
- Add model with Github Copilot selected as the provider
- and use

#506 

does not support streaming as it already bypasses CORS
does not support auto-getting available models

<img width="517" alt="image" src="https://github.com/user-attachments/assets/e5d38d0b-55de-4edd-b04f-7c540b817021" />
<img width="405" alt="image" src="https://github.com/user-attachments/assets/6923f347-f959-450a-b604-923aaff10d38" />
<img width="373" alt="image" src="https://github.com/user-attachments/assets/4ac40500-1b0e-4fc1-9bca-509b11628208" />
<img width="377" alt="image" src="https://github.com/user-attachments/assets/e00abba4-da08-422a-a804-b8682274e891" />
(why does typing a with 4.1 give me sometimes this language or chinese)
