### PR TITLE
feat: Add support for selected text context in chat component

### DIFF
--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -4,6 +4,7 @@ import { ChatPromptTemplate } from "@langchain/core/prompts";
 
 import { ModelCapability } from "@/constants";
 import { settingsAtom, settingsStore } from "@/settings/model";
+import { SelectedTextContext } from "@/sharedState";
 import { atom, useAtom } from "jotai";
 
 const userModelKeyAtom = atom<string | null>(null);
@@ -36,6 +37,8 @@ const chainTypeAtom = atom(
 
 const currentProjectAtom = atom<ProjectConfig | null>(null);
 const projectLoadingAtom = atom<boolean>(false);
+
+const selectedTextContextsAtom = atom<SelectedTextContext[]>([]);
 
 export interface ProjectConfig {
   id: string;
@@ -202,4 +205,32 @@ export function useProjectLoading() {
 
 export function isProjectMode() {
   return getChainType() === ChainType.PROJECT_CHAIN;
+}
+
+export function setSelectedTextContexts(contexts: SelectedTextContext[]) {
+  settingsStore.set(selectedTextContextsAtom, contexts);
+}
+
+export function getSelectedTextContexts(): SelectedTextContext[] {
+  return settingsStore.get(selectedTextContextsAtom);
+}
+
+export function addSelectedTextContext(context: SelectedTextContext) {
+  const current = getSelectedTextContexts();
+  setSelectedTextContexts([...current, context]);
+}
+
+export function removeSelectedTextContext(id: string) {
+  const current = getSelectedTextContexts();
+  setSelectedTextContexts(current.filter((context) => context.id !== id));
+}
+
+export function clearSelectedTextContexts() {
+  setSelectedTextContexts([]);
+}
+
+export function useSelectedTextContexts() {
+  return useAtom(selectedTextContextsAtom, {
+    store: settingsStore,
+  });
 }

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -1,10 +1,26 @@
 import { getCommandId, sortCommandsByOrder } from "@/commands/customCommandUtils";
+import { getCachedCustomCommands } from "@/commands/state";
+import { COMMAND_IDS } from "@/constants";
 import { Menu } from "obsidian";
 import { CustomCommand } from "./type";
-import { getCachedCustomCommands } from "@/commands/state";
 
 export function registerContextMenu(menu: Menu) {
+  menu.addItem((item) => {
+    item.setTitle("Copilot: Add selection to chat context").onClick(() => {
+      (app as any).commands.executeCommandById(
+        `copilot:${COMMAND_IDS.ADD_SELECTION_TO_CHAT_CONTEXT}`
+      );
+    });
+  });
+
+  // Add separator if there are custom commands too
   const commands = getCachedCustomCommands();
+  const visibleCustomCommands = commands.filter(
+    (command: CustomCommand) => command.showInContextMenu
+  );
+  if (visibleCustomCommands.length > 0) {
+    menu.addSeparator();
+  }
 
   sortCommandsByOrder(
     commands.filter((command: CustomCommand) => command.showInContextMenu)

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,4 @@
-import { getChainType } from "@/aiParams";
+import { addSelectedTextContext, getChainType } from "@/aiParams";
 import { FileCache } from "@/cache/fileCache";
 import { ProjectContextCache } from "@/cache/projectContextCache";
 import { ChainType } from "@/chainFactory";
@@ -334,19 +334,10 @@ export function registerCommands(
       endLine: Math.max(startLine, endLine),
     };
 
-    // Add to plugin's selected text contexts
-    plugin.addSelectedTextContext(selectedTextContext);
+    // Add to selected text contexts atom
+    addSelectedTextContext(selectedTextContext);
 
     // Open chat window to show the context was added
     plugin.activateView();
-
-    const lineRange =
-      selectedTextContext.startLine === selectedTextContext.endLine
-        ? `L${selectedTextContext.startLine}`
-        : `L${selectedTextContext.startLine}-${selectedTextContext.endLine}`;
-
-    new Notice(
-      `Added selection from ${selectedTextContext.noteTitle} (${lineRange}) to chat context`
-    );
   });
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,7 @@
+import { getChainType } from "@/aiParams";
 import { FileCache } from "@/cache/fileCache";
 import { ProjectContextCache } from "@/cache/projectContextCache";
+import { ChainType } from "@/chainFactory";
 import { AdhocPromptModal } from "@/components/modals/AdhocPromptModal";
 import { DebugSearchModal } from "@/components/modals/DebugSearchModal";
 import { OramaSearchModal } from "@/components/modals/OramaSearchModal";
@@ -9,8 +11,8 @@ import { getAllQAMarkdownContent } from "@/search/searchUtils";
 import { CopilotSettings, getSettings, updateSetting } from "@/settings/model";
 import { SelectedTextContext } from "@/sharedState";
 import { Editor, Notice, TFile } from "obsidian";
-import { COMMAND_IDS, COMMAND_NAMES, CommandId } from "../constants";
 import { v4 as uuidv4 } from "uuid";
+import { COMMAND_IDS, COMMAND_NAMES, CommandId } from "../constants";
 
 /**
  * Add a command to the plugin.
@@ -290,6 +292,16 @@ export function registerCommands(
 
   // Add selection to chat context command
   addEditorCommand(plugin, COMMAND_IDS.ADD_SELECTION_TO_CHAT_CONTEXT, async (editor: Editor) => {
+    // Check if we're in Copilot Plus mode
+    const currentChainType = getChainType();
+    if (
+      currentChainType !== ChainType.COPILOT_PLUS_CHAIN &&
+      currentChainType !== ChainType.PROJECT_CHAIN
+    ) {
+      new Notice("Selected text context is only available in Copilot Plus and Project modes");
+      return;
+    }
+
     const selectedText = editor.getSelection();
     if (!selectedText) {
       new Notice("No text selected");

--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -23,6 +23,7 @@ import { CustomCommandManager } from "@/commands/customCommandManager";
 import { COPILOT_TOOL_NAMES } from "@/LLMProviders/intentAnalyzer";
 import { Mention } from "@/mentions/Mention";
 import { getModelKeyFromModel, useSettingsValue } from "@/settings/model";
+import { SelectedTextContext } from "@/sharedState";
 import { getToolDescription } from "@/tools/toolManager";
 import { checkModelApiKey, err2String, extractNoteFiles, isNoteTitleUnique } from "@/utils";
 import {
@@ -57,6 +58,7 @@ interface ChatInputProps {
     toolCalls?: string[];
     urls?: string[];
     contextNotes?: TFile[];
+    selectedTextContexts?: SelectedTextContext[];
   }) => void;
   isGenerating: boolean;
   onStopGenerating: () => void;
@@ -70,6 +72,8 @@ interface ChatInputProps {
   onAddImage: (files: File[]) => void;
   setSelectedImages: React.Dispatch<React.SetStateAction<File[]>>;
   disableModelSwitch?: boolean;
+  selectedTextContexts?: SelectedTextContext[];
+  onRemoveSelectedText?: (id: string) => void;
 }
 
 const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
@@ -90,6 +94,8 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
       onAddImage,
       setSelectedImages,
       disableModelSwitch,
+      selectedTextContexts,
+      onRemoveSelectedText,
     },
     ref
   ) => {
@@ -168,6 +174,7 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
         toolCalls: includeVault ? ["@vault"] : [],
         contextNotes,
         urls: contextUrls,
+        selectedTextContexts,
       });
     };
 
@@ -478,6 +485,8 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
           activeNote={currentActiveNote}
           contextUrls={contextUrls}
           onRemoveUrl={(url: string) => setContextUrls((prev) => prev.filter((u) => u !== url))}
+          selectedTextContexts={selectedTextContexts}
+          onRemoveSelectedText={onRemoveSelectedText}
         />
 
         {selectedImages.length > 0 && (

--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -58,7 +58,6 @@ interface ChatInputProps {
     toolCalls?: string[];
     urls?: string[];
     contextNotes?: TFile[];
-    selectedTextContexts?: SelectedTextContext[];
   }) => void;
   isGenerating: boolean;
   onStopGenerating: () => void;
@@ -174,7 +173,6 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
         toolCalls: includeVault ? ["@vault"] : [],
         contextNotes,
         urls: contextUrls,
-        selectedTextContexts,
       });
     };
 

--- a/src/components/chat-components/ContextControl.tsx
+++ b/src/components/chat-components/ContextControl.tsx
@@ -6,6 +6,7 @@ import { ChainType } from "@/chainFactory";
 import { AddContextNoteModal } from "@/components/modals/AddContextNoteModal";
 import { TFile } from "obsidian";
 import { ChatContextMenu } from "./ChatContextMenu";
+import { SelectedTextContext } from "@/sharedState";
 
 interface ChatControlsProps {
   app: App;
@@ -17,6 +18,8 @@ interface ChatControlsProps {
   activeNote: TFile | null;
   contextUrls: string[];
   onRemoveUrl: (url: string) => void;
+  selectedTextContexts?: SelectedTextContext[];
+  onRemoveSelectedText?: (id: string) => void;
 }
 
 const ContextControl: React.FC<ChatControlsProps> = ({
@@ -29,6 +32,8 @@ const ContextControl: React.FC<ChatControlsProps> = ({
   activeNote,
   contextUrls,
   onRemoveUrl,
+  selectedTextContexts,
+  onRemoveSelectedText,
 }) => {
   const [selectedChain] = useChainType();
 
@@ -68,7 +73,23 @@ const ContextControl: React.FC<ChatControlsProps> = ({
   };
 
   if (selectedChain !== ChainType.COPILOT_PLUS_CHAIN) {
-    return null;
+    // In non-Plus modes, only show selected text contexts if any exist
+    if (!selectedTextContexts || selectedTextContexts.length === 0) {
+      return null;
+    }
+
+    return (
+      <ChatContextMenu
+        activeNote={null}
+        contextNotes={[]}
+        onAddContext={() => {}} // No-op for non-Plus modes
+        onRemoveContext={() => {}} // No-op for non-Plus modes
+        contextUrls={[]}
+        onRemoveUrl={() => {}} // No-op for non-Plus modes
+        selectedTextContexts={selectedTextContexts}
+        onRemoveSelectedText={onRemoveSelectedText}
+      />
+    );
   }
 
   return (
@@ -79,6 +100,8 @@ const ContextControl: React.FC<ChatControlsProps> = ({
       onRemoveContext={handleRemoveContext}
       contextUrls={contextUrls}
       onRemoveUrl={onRemoveUrl}
+      selectedTextContexts={selectedTextContexts}
+      onRemoveSelectedText={onRemoveSelectedText}
     />
   );
 };

--- a/src/components/chat-components/ContextControl.tsx
+++ b/src/components/chat-components/ContextControl.tsx
@@ -4,9 +4,9 @@ import React from "react";
 
 import { ChainType } from "@/chainFactory";
 import { AddContextNoteModal } from "@/components/modals/AddContextNoteModal";
+import { SelectedTextContext } from "@/sharedState";
 import { TFile } from "obsidian";
 import { ChatContextMenu } from "./ChatContextMenu";
-import { SelectedTextContext } from "@/sharedState";
 
 interface ChatControlsProps {
   app: App;
@@ -72,24 +72,8 @@ const ContextControl: React.FC<ChatControlsProps> = ({
     }
   };
 
-  if (selectedChain !== ChainType.COPILOT_PLUS_CHAIN) {
-    // In non-Plus modes, only show selected text contexts if any exist
-    if (!selectedTextContexts || selectedTextContexts.length === 0) {
-      return null;
-    }
-
-    return (
-      <ChatContextMenu
-        activeNote={null}
-        contextNotes={[]}
-        onAddContext={() => {}} // No-op for non-Plus modes
-        onRemoveContext={() => {}} // No-op for non-Plus modes
-        contextUrls={[]}
-        onRemoveUrl={() => {}} // No-op for non-Plus modes
-        selectedTextContexts={selectedTextContexts}
-        onRemoveSelectedText={onRemoveSelectedText}
-      />
-    );
+  if (selectedChain !== ChainType.COPILOT_PLUS_CHAIN && selectedChain !== ChainType.PROJECT_CHAIN) {
+    return null;
   }
 
   return (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -596,6 +596,7 @@ export const COMMAND_IDS = {
   SEARCH_ORAMA_DB: "copilot-search-orama-db",
   TOGGLE_COPILOT_CHAT_WINDOW: "chat-toggle-window",
   TOGGLE_AUTOCOMPLETE: "toggle-autocomplete",
+  ADD_SELECTION_TO_CHAT_CONTEXT: "add-selection-to-chat-context",
 } as const;
 
 export const COMMAND_NAMES: Record<CommandId, string> = {
@@ -618,6 +619,7 @@ export const COMMAND_NAMES: Record<CommandId, string> = {
   [COMMAND_IDS.SEARCH_ORAMA_DB]: "Search OramaDB (debug)",
   [COMMAND_IDS.TOGGLE_COPILOT_CHAT_WINDOW]: "Toggle Copilot Chat Window",
   [COMMAND_IDS.TOGGLE_AUTOCOMPLETE]: "Toggle autocomplete",
+  [COMMAND_IDS.ADD_SELECTION_TO_CHAT_CONTEXT]: "Add selection to chat context",
 };
 
 export type CommandId = (typeof COMMAND_IDS)[keyof typeof COMMAND_IDS];

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -2,6 +2,7 @@ import { ChainType } from "@/chainFactory";
 import { FileParserManager } from "@/tools/FileParserManager";
 import { TFile, Vault } from "obsidian";
 import { NOTE_CONTEXT_PROMPT_TAG } from "./constants";
+import { SelectedTextContext } from "./sharedState";
 
 export class ContextProcessor {
   private static instance: ContextProcessor;
@@ -167,5 +168,24 @@ export class ContextProcessor {
         hasEmbeddedPDFs,
       }),
     ]);
+  }
+
+  processSelectedTextContexts(selectedTextContexts: SelectedTextContext[]): string {
+    if (!selectedTextContexts || selectedTextContexts.length === 0) {
+      return "";
+    }
+
+    let additionalContext = "";
+
+    for (const selectedText of selectedTextContexts) {
+      const lineRange =
+        selectedText.startLine === selectedText.endLine
+          ? `L${selectedText.startLine}`
+          : `L${selectedText.startLine}-${selectedText.endLine}`;
+
+      additionalContext += `\n\n <selected_text> \n Title: [[${selectedText.noteTitle}]]\nPath: ${selectedText.notePath}\nLines: ${lineRange}\n\n${selectedText.content}\n</selected_text>`;
+    }
+
+    return additionalContext;
   }
 }

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -1,8 +1,8 @@
+import { getSelectedTextContexts } from "@/aiParams";
 import { ChainType } from "@/chainFactory";
 import { FileParserManager } from "@/tools/FileParserManager";
 import { TFile, Vault } from "obsidian";
 import { NOTE_CONTEXT_PROMPT_TAG } from "./constants";
-import { SelectedTextContext } from "./sharedState";
 
 export class ContextProcessor {
   private static instance: ContextProcessor;
@@ -170,7 +170,9 @@ export class ContextProcessor {
     ]);
   }
 
-  processSelectedTextContexts(selectedTextContexts: SelectedTextContext[]): string {
+  processSelectedTextContexts(): string {
+    const selectedTextContexts = getSelectedTextContexts();
+
     if (!selectedTextContexts || selectedTextContexts.length === 0) {
       return "";
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -23,7 +23,7 @@ import {
   setSettings,
   subscribeToSettingsChange,
 } from "@/settings/model";
-import SharedState, { SelectedTextContext } from "@/sharedState";
+import SharedState from "@/sharedState";
 import { FileParserManager } from "@/tools/FileParserManager";
 import {
   Editor,
@@ -51,8 +51,6 @@ export default class CopilotPlugin extends Plugin {
   customCommandRegister: CustomCommandRegister;
   settingsUnsubscriber?: () => void;
   private autocompleteService: AutocompleteService;
-  selectedTextContexts: SelectedTextContext[] = [];
-  private selectedTextContextsCallbacks: Set<() => void> = new Set();
 
   async onload(): Promise<void> {
     await this.loadSettings();
@@ -406,31 +404,5 @@ export default class CopilotPlugin extends Plugin {
       content: doc.pageContent,
       metadata: doc.metadata,
     }));
-  }
-
-  addSelectedTextContext(context: SelectedTextContext): void {
-    this.selectedTextContexts.push(context);
-    this.notifySelectedTextContextsChange();
-  }
-
-  removeSelectedTextContext(id: string): void {
-    this.selectedTextContexts = this.selectedTextContexts.filter((context) => context.id !== id);
-    this.notifySelectedTextContextsChange();
-  }
-
-  clearSelectedTextContexts(): void {
-    this.selectedTextContexts = [];
-    this.notifySelectedTextContextsChange();
-  }
-
-  subscribeToSelectedTextContextsChange(callback: () => void): () => void {
-    this.selectedTextContextsCallbacks.add(callback);
-    return () => {
-      this.selectedTextContextsCallbacks.delete(callback);
-    };
-  }
-
-  private notifySelectedTextContextsChange(): void {
-    this.selectedTextContextsCallbacks.forEach((callback) => callback());
   }
 }

--- a/src/sharedState.ts
+++ b/src/sharedState.ts
@@ -3,6 +3,15 @@ import { FormattedDateTime } from "./utils";
 import { TFile } from "obsidian";
 import CopilotPlugin from "@/main";
 
+export interface SelectedTextContext {
+  content: string;
+  noteTitle: string;
+  notePath: string;
+  startLine: number;
+  endLine: number;
+  id: string;
+}
+
 export interface ChatMessage {
   message: string;
   originalMessage?: string;
@@ -14,6 +23,7 @@ export interface ChatMessage {
   context?: {
     notes: TFile[];
     urls: string[];
+    selectedTextContexts?: SelectedTextContext[];
   };
   isErrorMessage?: boolean;
 }


### PR DESCRIPTION
- Introduced a new command to add selected text to the chat context.
- Implemented functionality to manage selected text contexts within the plugin.
- Enhanced Chat and ChatContextMenu components to display and remove selected text contexts.
- Updated shared state to include selected text context structure.
- Improved user experience with notifications for added selections.