### PR TITLE
feat: Preserve existing content during streaming response errors and enhance error message display

### DIFF
--- a/src/chainFactory.ts
+++ b/src/chainFactory.ts
@@ -8,7 +8,7 @@ import { BaseRetriever } from "@langchain/core/retrievers";
 import { RunnablePassthrough, RunnableSequence } from "@langchain/core/runnables";
 import { BaseChatMemory } from "langchain/memory";
 import { formatDocumentsAsString } from "langchain/util/document";
-import { removeThinkTags } from "./utils";
+import { removeThinkTags, removeErrorTags } from "./utils";
 
 export interface LLMChainInput {
   llm: BaseLanguageModel;
@@ -182,7 +182,8 @@ Question: {question}
       llm,
       new StringOutputParser(),
       (output) => {
-        const cleanedOutput = removeThinkTags(output);
+        const thinkTagsCleaned = removeThinkTags(output);
+        const cleanedOutput = removeErrorTags(thinkTagsCleaned);
         if (debug) console.log("Standalone Question: ", cleanedOutput);
         return cleanedOutput;
       },

--- a/src/chainUtils.ts
+++ b/src/chainUtils.ts
@@ -1,5 +1,10 @@
 import ProjectManager from "@/LLMProviders/projectManager";
-import { ChatHistoryEntry, removeThinkTags, withSuppressedTokenWarnings } from "@/utils";
+import {
+  ChatHistoryEntry,
+  removeThinkTags,
+  removeErrorTags,
+  withSuppressedTokenWarnings,
+} from "@/utils";
 import { BaseChatModelCallOptions } from "@langchain/core/language_models/chat_models";
 
 export async function getStandaloneQuestion(
@@ -37,6 +42,7 @@ export async function getStandaloneQuestion(
       },
     ]);
 
-    return removeThinkTags(response.content as string);
+    const cleanedResponse = removeThinkTags(response.content as string);
+    return removeErrorTags(cleanedResponse);
   });
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -7,9 +7,7 @@ export function logInfo(...args: any[]) {
 }
 
 export function logError(...args: any[]) {
-  if (getSettings().debug) {
-    console.error(...args);
-  }
+  console.error(...args);
 }
 
 export function logWarn(...args: any[]) {

--- a/src/search/hybridRetriever.ts
+++ b/src/search/hybridRetriever.ts
@@ -4,7 +4,12 @@ import ProjectManager from "@/LLMProviders/projectManager";
 import { logInfo } from "@/logger";
 import VectorStoreManager from "@/search/vectorStoreManager";
 import { getSettings } from "@/settings/model";
-import { extractNoteFiles, removeThinkTags, withSuppressedTokenWarnings } from "@/utils";
+import {
+  extractNoteFiles,
+  removeThinkTags,
+  removeErrorTags,
+  withSuppressedTokenWarnings,
+} from "@/utils";
 import { BaseCallbackConfig } from "@langchain/core/callbacks/manager";
 import { Document } from "@langchain/core/documents";
 import { BaseChatModelCallOptions } from "@langchain/core/language_models/chat_models";
@@ -146,7 +151,8 @@ export class HybridRetriever extends BaseRetriever {
 
       // Process the result
       if (rewrittenQueryObject && "content" in rewrittenQueryObject) {
-        return removeThinkTags(rewrittenQueryObject.content as string);
+        const cleanedContent = removeThinkTags(rewrittenQueryObject.content as string);
+        return removeErrorTags(cleanedContent);
       }
 
       console.warn("Unexpected rewrittenQuery format. Falling back to original query.");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -813,6 +813,20 @@ export function removeThinkTags(text: any): string {
   return cleanedText.trim();
 }
 
+/**
+ * Removes any <errorChunk> tags and their content from the text.
+ * This is used to clean model outputs before using them for RAG.
+ * Handles both string content and array-based content (Claude 3.7 format)
+ * @param text - The text or content array to remove error tags from
+ * @returns The text with error tags removed
+ */
+export function removeErrorTags(text: any): string {
+  // First convert any content format to plain text
+  const plainText = extractTextFromChunk(text);
+  // Then remove error tags
+  return plainText.replace(/<errorChunk>[\s\S]*?<\/errorChunk>/g, "").trim();
+}
+
 export function randomUUID() {
   return crypto.randomUUID();
 }


### PR DESCRIPTION
## Overview

now, when an error occurs during streaming response, it's not clear partial success response.

actual effect:

![CleanShot 2025-06-29 at 00 38 32](https://github.com/user-attachments/assets/8a7d662a-30a2-41ab-b4f6-879ab631264e)



## issues

#1527


## Key changes
- Add `<errorChunk>xxx</errorChunk>` tags to mark error messages
- Add `errorPostProcessor` to handle error message
- keep a similar logic to `think tag`

