### PR TITLE
Fix default model reset

### DIFF
--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -113,27 +113,7 @@ export function turnOnPlus(): void {
 
 export function turnOffPlus(): void {
   const previousIsPlusUser = getSettings().isPlusUser;
-  const previousEmbeddingModelKey = getSettings().embeddingModelKey;
-
-  logInfo("turnOffPlus: Resetting embedding model", {
-    from: previousEmbeddingModelKey,
-    to: DEFAULT_FREE_EMBEDDING_MODEL_KEY,
-    changed: previousEmbeddingModelKey !== DEFAULT_FREE_EMBEDDING_MODEL_KEY,
-  });
-
-  // Reset models to default free user models
-  setModelKey(DEFAULT_FREE_CHAT_MODEL_KEY);
-  setChainType(DEFAULT_SETTINGS.defaultChainType);
-  setSettings({
-    isPlusUser: false,
-    defaultModelKey: DEFAULT_FREE_CHAT_MODEL_KEY,
-    embeddingModelKey: DEFAULT_FREE_EMBEDDING_MODEL_KEY,
-    defaultChainType: DEFAULT_SETTINGS.defaultChainType,
-  });
-
-  // Note: Reindexing will be handled automatically by the model change detection system
-  // when the embedding model change is detected elsewhere in the application
-
+  updateSetting("isPlusUser", false);
   if (previousIsPlusUser) {
     new CopilotPlusExpiredModal(app).open();
   }

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -111,6 +111,12 @@ export function turnOnPlus(): void {
   updateSetting("isPlusUser", true);
 }
 
+/**
+ * Turn off Plus user status.
+ * IMPORTANT: This is called on every plugin start for users without a Plus license key (see checkIsPlusUser).
+ * DO NOT reset model settings here - it will cause free users to lose their model selections on every app restart.
+ * Only update the isPlusUser flag.
+ */
 export function turnOffPlus(): void {
   const previousIsPlusUser = getSettings().isPlusUser;
   updateSetting("isPlusUser", false);


### PR DESCRIPTION
Related #1596 

`turnOffPlus` is called at plugin start for all free users. There shouldn't be model reset logic here.