### PR TITLE
Custom command settings improvement

### DIFF
--- a/src/commands/constants.ts
+++ b/src/commands/constants.ts
@@ -5,8 +5,8 @@ export const COMMAND_NAME_MAX_LENGTH = 50;
 export const EMPTY_COMMAND: CustomCommand = {
   title: "",
   content: "",
-  showInContextMenu: false,
-  showInSlashMenu: false,
+  showInContextMenu: true,
+  showInSlashMenu: true,
   order: Number.MAX_SAFE_INTEGER,
   modelKey: "",
   lastUsedMs: 0,

--- a/src/commands/constants.ts
+++ b/src/commands/constants.ts
@@ -7,7 +7,7 @@ export const EMPTY_COMMAND: CustomCommand = {
   content: "",
   showInContextMenu: true,
   showInSlashMenu: true,
-  order: Number.MAX_SAFE_INTEGER,
+  order: 0,
   modelKey: "",
   lastUsedMs: 0,
 };

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -21,7 +21,12 @@ export class CustomCommandManager {
     return CustomCommandManager.instance;
   }
 
-  async createCommand(command: CustomCommand, skipStoreUpdate = false): Promise<void> {
+  // This method is private. To create a command, use updateCommand instead as
+  // it skips command creation if the command already exists.
+  private async createCommand(command: CustomCommand, skipStoreUpdate = false): Promise<void> {
+    if (!skipStoreUpdate) {
+      updateCachedCommand(command, command.title);
+    }
     const folderPath = getCustomCommandsFolder();
     const filePath = getCommandFilePath(command.title);
 
@@ -39,9 +44,6 @@ export class CustomCommandManager {
       frontmatter[COPILOT_COMMAND_MODEL_KEY] = command.modelKey;
       frontmatter[COPILOT_COMMAND_LAST_USED] = command.lastUsedMs;
     });
-    if (!skipStoreUpdate) {
-      updateCachedCommand(command, command.title);
-    }
   }
 
   async recordUsage(command: CustomCommand) {
@@ -50,7 +52,7 @@ export class CustomCommandManager {
 
   async updateCommand(command: CustomCommand, prevCommandTitle: string, skipStoreUpdate = false) {
     if (!skipStoreUpdate) {
-      updateCachedCommand(command, command.title);
+      updateCachedCommand(command, prevCommandTitle);
     }
     let commandFile = app.vault.getAbstractFileByPath(getCommandFilePath(command.title));
     // Verify whether the title has changed to decide whether to rename the file

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -1,5 +1,9 @@
 import { TFile } from "obsidian";
-import { getCommandFilePath, getCustomCommandsFolder } from "@/commands/customCommandUtils";
+import {
+  getCommandFilePath,
+  getCustomCommandsFolder,
+  getNextCustomCommandOrder,
+} from "@/commands/customCommandUtils";
 import { CustomCommand } from "@/commands/type";
 import { CustomError } from "@/error";
 import {
@@ -12,7 +16,6 @@ import {
 import {
   addPendingFileWrite,
   deleteCachedCommand,
-  getCachedCustomCommands,
   removePendingFileWrite,
   updateCachedCommand,
   updateCachedCommands,
@@ -44,13 +47,7 @@ export class CustomCommandManager {
       addPendingFileWrite(filePath);
       let newOrder = command.order;
       if (mergedOptions.autoOrder) {
-        const commands = getCachedCustomCommands();
-        const lastOrder = commands.reduce(
-          (prev, curr) => (prev > curr.order ? prev : curr.order),
-          0
-        );
-        // If the last ordered command uses the max order, reuse the max order
-        newOrder = lastOrder === Number.MAX_SAFE_INTEGER ? Number.MAX_SAFE_INTEGER : lastOrder + 10;
+        newOrder = getNextCustomCommandOrder();
       }
       command = { ...command, order: newOrder };
 

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -9,12 +9,7 @@ import {
   COPILOT_COMMAND_MODEL_KEY,
   COPILOT_COMMAND_SLASH_ENABLED,
 } from "@/commands/constants";
-import {
-  createCachedCommand,
-  deleteCachedCommand,
-  updateCachedCommand,
-  updateCachedCommands,
-} from "./state";
+import { deleteCachedCommand, updateCachedCommand, updateCachedCommands } from "./state";
 
 export class CustomCommandManager {
   private static instance: CustomCommandManager;
@@ -27,9 +22,6 @@ export class CustomCommandManager {
   }
 
   async createCommand(command: CustomCommand, skipStoreUpdate = false): Promise<void> {
-    if (!skipStoreUpdate) {
-      command = createCachedCommand(command);
-    }
     const folderPath = getCustomCommandsFolder();
     const filePath = getCommandFilePath(command.title);
 

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -114,7 +114,9 @@ export class CustomCommandManager {
 
       if (!commandFile) {
         // Pass skipStoreUpdate to createCommand to avoid redundant cache update
-        await this.createCommand(command, { skipStoreUpdate });
+        // When creating a new command, we want to auto-order it so it appears
+        // at the bottom of the menu.
+        await this.createCommand(command, { skipStoreUpdate, autoOrder: true });
         commandFile = app.vault.getAbstractFileByPath(getCommandFilePath(command.title));
       }
 

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -8,6 +8,7 @@ import {
   COPILOT_COMMAND_LAST_USED,
   COPILOT_COMMAND_MODEL_KEY,
   COPILOT_COMMAND_SLASH_ENABLED,
+  EMPTY_COMMAND,
 } from "@/commands/constants";
 import {
   createCachedCommand,
@@ -27,8 +28,9 @@ export class CustomCommandManager {
   }
 
   async createCommand(title: string, content: string, skipStoreUpdate = false): Promise<void> {
+    let command = { ...EMPTY_COMMAND, title, content };
     if (!skipStoreUpdate) {
-      createCachedCommand(title);
+      command = createCachedCommand(title, content);
     }
     const folderPath = getCustomCommandsFolder();
     const filePath = getCommandFilePath(title);
@@ -41,11 +43,11 @@ export class CustomCommandManager {
 
     const file = await app.vault.create(filePath, content);
     await app.fileManager.processFrontMatter(file, (frontmatter) => {
-      frontmatter[COPILOT_COMMAND_CONTEXT_MENU_ENABLED] = false;
-      frontmatter[COPILOT_COMMAND_SLASH_ENABLED] = false;
-      frontmatter[COPILOT_COMMAND_CONTEXT_MENU_ORDER] = Number.MAX_SAFE_INTEGER;
-      frontmatter[COPILOT_COMMAND_MODEL_KEY] = "";
-      frontmatter[COPILOT_COMMAND_LAST_USED] = 0;
+      frontmatter[COPILOT_COMMAND_CONTEXT_MENU_ENABLED] = command.showInContextMenu;
+      frontmatter[COPILOT_COMMAND_SLASH_ENABLED] = command.showInSlashMenu;
+      frontmatter[COPILOT_COMMAND_CONTEXT_MENU_ORDER] = command.order;
+      frontmatter[COPILOT_COMMAND_MODEL_KEY] = command.modelKey;
+      frontmatter[COPILOT_COMMAND_LAST_USED] = command.lastUsedMs;
     });
   }
 

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -32,6 +32,7 @@ export class CustomCommandManager {
   /**
    * Creates a new command file and caches the command in memory.
    * If autoOrder is true, the order of the command is set to the next available order.
+   * If autoOrder is false (default), preserves the order from the command object/frontmatter.
    */
   async createCommand(
     command: CustomCommand,

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -35,30 +35,26 @@ export class CustomCommandManager {
    */
   async createCommand(
     command: CustomCommand,
-    options: { skipStoreUpdate?: boolean; autoOrder?: boolean } = {
-      skipStoreUpdate: false,
-      autoOrder: true,
-    }
+    options: { skipStoreUpdate?: boolean; autoOrder?: boolean } = {}
   ): Promise<void> {
+    // Merge default options with provided options
+    const mergedOptions = { skipStoreUpdate: false, autoOrder: true, ...options };
     const filePath = getCommandFilePath(command.title);
     try {
       addPendingFileWrite(filePath);
       let newOrder = command.order;
-      if (options.autoOrder) {
+      if (mergedOptions.autoOrder) {
         const commands = getCachedCustomCommands();
-        const lastOrderedCommand = commands.reduce((prev, curr) =>
-          prev.order > curr.order ? prev : curr
+        const lastOrder = commands.reduce(
+          (prev, curr) => (prev > curr.order ? prev : curr.order),
+          0
         );
-        const lastOrderedOrder = lastOrderedCommand ? lastOrderedCommand.order : 0;
         // If the last ordered command uses the max order, reuse the max order
-        newOrder =
-          lastOrderedOrder === Number.MAX_SAFE_INTEGER
-            ? Number.MAX_SAFE_INTEGER
-            : lastOrderedOrder + 10;
+        newOrder = lastOrder === Number.MAX_SAFE_INTEGER ? Number.MAX_SAFE_INTEGER : lastOrder + 10;
       }
       command = { ...command, order: newOrder };
 
-      if (!options.skipStoreUpdate) {
+      if (!mergedOptions.skipStoreUpdate) {
         updateCachedCommand(command, command.title);
       }
 

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -96,6 +96,18 @@ export class CustomCommandManager {
     await Promise.all(commands.map((command) => this.updateCommand(command, command.title, true)));
   }
 
+  /**
+   * Reorders the given commands by setting their order property in increments of 10,
+   * then updates all commands in the manager.
+   */
+  async reorderCommands(commands: CustomCommand[]) {
+    const newCommands = [...commands];
+    for (let i = 0; i < newCommands.length; i++) {
+      newCommands[i] = { ...newCommands[i], order: i * 10 };
+    }
+    await this.updateCommands(newCommands);
+  }
+
   async deleteCommand(command: CustomCommand) {
     deleteCachedCommand(command.title);
     const file = app.vault.getAbstractFileByPath(getCommandFilePath(command.title));

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -117,8 +117,8 @@ export class CustomCommandRegister {
     if (isCustomCommandFile(file)) {
       logInfo("command file renamed", file.path);
       const parsedCommand = await parseCustomCommandFile(file);
-      await CustomCommandManager.getInstance().createCommand(parsedCommand);
       this.registerCommand(parsedCommand);
+      updateCachedCommand(parsedCommand, parsedCommand.title);
     }
   };
 

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -5,6 +5,7 @@ import {
   parseCustomCommandFile,
   getNextCustomCommandOrder,
   ensureCommandFrontmatter,
+  hasOrderFrontmatter,
 } from "@/commands/customCommandUtils";
 import { Editor, Plugin, TFile, Vault } from "obsidian";
 import { CustomCommandChatModal } from "@/commands/CustomCommandChatModal";
@@ -88,13 +89,15 @@ export class CustomCommandRegister {
     }
     try {
       logInfo("new command file created", file.path);
-      const customCommand = await parseCustomCommandFile(file);
-      // Compute the correct order for the new command
-      const newOrder = getNextCustomCommandOrder();
-      const commandWithOrder = { ...customCommand, order: newOrder };
-      await ensureCommandFrontmatter(file, commandWithOrder);
-      updateCachedCommand(commandWithOrder, commandWithOrder.title);
-      this.registerCommand(commandWithOrder);
+      let customCommand = await parseCustomCommandFile(file);
+      if (!hasOrderFrontmatter(file)) {
+        // Compute the correct order for the new command
+        const newOrder = getNextCustomCommandOrder();
+        customCommand = { ...customCommand, order: newOrder };
+      }
+      await ensureCommandFrontmatter(file, customCommand);
+      updateCachedCommand(customCommand, customCommand.title);
+      this.registerCommand(customCommand);
     } catch (error) {
       logError(`Error processing custom command creation: ${file.path}`, error);
     }

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -9,7 +9,6 @@ import { CustomCommandChatModal } from "@/commands/CustomCommandChatModal";
 import debounce from "lodash.debounce";
 import { CustomCommand } from "@/commands/type";
 import {
-  createCachedCommand,
   deleteCachedCommand,
   getCachedCustomCommands,
   updateCachedCommand,
@@ -79,8 +78,11 @@ export class CustomCommandRegister {
   private handleFileCreation = async (file: TFile) => {
     if (isCustomCommandFile(file)) {
       const customCommand = await parseCustomCommandFile(file);
+
+      // Use updateCommand to ensure proper frontmatter is added
+      await CustomCommandManager.getInstance().updateCommand(customCommand, customCommand.title);
+
       this.registerCommand(customCommand);
-      createCachedCommand(customCommand.title);
     }
   };
 
@@ -103,8 +105,9 @@ export class CustomCommandRegister {
     // Register the new command if it's still a custom command file
     if (isCustomCommandFile(file)) {
       const customCommand = await parseCustomCommandFile(file);
+      // Use updateCommand to ensure proper frontmatter is added
+      await CustomCommandManager.getInstance().updateCommand(customCommand, customCommand.title);
       this.registerCommand(customCommand);
-      updateCachedCommand(customCommand, customCommand.title);
     }
   };
 

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -66,7 +66,7 @@ export class CustomCommandRegister {
         updateCachedCommand(customCommand, customCommand.title);
       }
     },
-    3000,
+    1000,
     {
       // We cannot use leading: true because frontmatter is not updated
       // immediately when modify event is triggered.
@@ -77,12 +77,15 @@ export class CustomCommandRegister {
 
   private handleFileCreation = async (file: TFile) => {
     if (isCustomCommandFile(file)) {
-      const customCommand = await parseCustomCommandFile(file);
+      setTimeout(async () => {
+        const customCommand = await parseCustomCommandFile(file);
 
-      // Use updateCommand to ensure proper frontmatter is added
-      await CustomCommandManager.getInstance().updateCommand(customCommand, customCommand.title);
+        // Use updateCommand to ensure proper frontmatter is added
+        await CustomCommandManager.getInstance().updateCommand(customCommand, customCommand.title);
 
-      this.registerCommand(customCommand);
+        this.registerCommand(customCommand);
+        // We need to wait for the frontmatter to be updated
+      }, 1000);
     }
   };
 

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -93,6 +93,7 @@ export class CustomCommandRegister {
       const newOrder = getNextCustomCommandOrder();
       const commandWithOrder = { ...customCommand, order: newOrder };
       await ensureCommandFrontmatter(file, commandWithOrder);
+      updateCachedCommand(commandWithOrder, commandWithOrder.title);
       this.registerCommand(commandWithOrder);
     } catch (error) {
       logError(`Error processing custom command creation: ${file.path}`, error);
@@ -123,11 +124,9 @@ export class CustomCommandRegister {
     if (isCustomCommandFile(file)) {
       logInfo("command file renamed", file.path);
       const parsedCommand = await parseCustomCommandFile(file);
-      const newOrder = getNextCustomCommandOrder();
-      const commandWithOrder = { ...parsedCommand, order: newOrder };
       this.registerCommand(parsedCommand);
       updateCachedCommand(parsedCommand, parsedCommand.title);
-      await ensureCommandFrontmatter(file, commandWithOrder);
+      await ensureCommandFrontmatter(file, parsedCommand);
     }
   };
 

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -123,8 +123,18 @@ export class CustomCommandRegister {
           );
           return;
         }
-        // Use updateCommand to ensure proper frontmatter is added
-        await CustomCommandManager.getInstance().updateCommand(customCommand, customCommand.title);
+        const cachedCommands = getCachedCustomCommands();
+        const latestCommand = cachedCommands.find((cmd) => cmd.title === customCommand.title);
+        // The cache may have been updated since the file was created, so we need to
+        // check if the command exists in the cache. Only update the command if it doesn't
+        // exist in the cache.
+        if (!latestCommand) {
+          // Call updateCommand to ensure the command frontmatter is set correctly
+          await CustomCommandManager.getInstance().updateCommand(
+            customCommand,
+            customCommand.title
+          );
+        }
         this.registerCommand(customCommand);
       } catch (error) {
         console.error(
@@ -157,13 +167,11 @@ export class CustomCommandRegister {
       const parsedCommand = await parseCustomCommandFile(file);
       const cachedCommands = getCachedCustomCommands();
       const latestCommand = cachedCommands.find((cmd) => cmd.title === parsedCommand.title);
-      logInfo("latestCommand", latestCommand);
       if (latestCommand) {
         // Use the latest command object to ensure latest edits are persisted
         await CustomCommandManager.getInstance().updateCommand(latestCommand, latestCommand.title);
       } else {
         // Fallback: use the parsed file if no cached command exists
-        logInfo("no cached command found, using parsed command", parsedCommand);
         await CustomCommandManager.getInstance().updateCommand(parsedCommand, parsedCommand.title);
       }
       this.registerCommand(parsedCommand);

--- a/src/commands/customCommandUtils.test.ts
+++ b/src/commands/customCommandUtils.test.ts
@@ -686,8 +686,8 @@ describe("parseCustomCommandFile", () => {
       title: "Test Command",
       modelKey: "",
       content: "Prompt content only, no frontmatter.",
-      showInContextMenu: false,
-      showInSlashMenu: false,
+      showInContextMenu: true,
+      showInSlashMenu: true,
       order: Number.MAX_SAFE_INTEGER,
       lastUsedMs: 0,
     });

--- a/src/commands/customCommandUtils.test.ts
+++ b/src/commands/customCommandUtils.test.ts
@@ -688,7 +688,7 @@ describe("parseCustomCommandFile", () => {
       content: "Prompt content only, no frontmatter.",
       showInContextMenu: true,
       showInSlashMenu: true,
-      order: Number.MAX_SAFE_INTEGER,
+      order: 0,
       lastUsedMs: 0,
     });
   });

--- a/src/commands/customCommandUtils.ts
+++ b/src/commands/customCommandUtils.ts
@@ -395,3 +395,23 @@ export async function processPrompt(
     includedFiles: Array.from(includedFiles),
   };
 }
+
+/**
+ * Generates a unique name for a copied command by adding "(copy)" or "(copy N)" suffix.
+ */
+export function generateCopyCommandName(
+  originalName: string,
+  existingCommands: CustomCommand[]
+): string {
+  const baseName = `${originalName} (copy)`;
+  let copyName = baseName;
+  let counter = 1;
+
+  // Check if the base copy name already exists
+  while (existingCommands.some((cmd) => cmd.title.toLowerCase() === copyName.toLowerCase())) {
+    counter++;
+    copyName = `${originalName} (copy ${counter})`;
+  }
+
+  return copyName;
+}

--- a/src/commands/customCommandUtils.ts
+++ b/src/commands/customCommandUtils.ts
@@ -33,6 +33,10 @@ export function validateCommandName(
     return null; // No change is allowed
   }
 
+  if (!trimmedName) {
+    return "Command name cannot be empty";
+  }
+
   // eslint-disable-next-line no-control-regex
   const invalidChars = /[#<>:"/\\|?*[\]^\x00-\x1F]/g;
   if (invalidChars.test(trimmedName)) {

--- a/src/commands/customCommandUtils.ts
+++ b/src/commands/customCommandUtils.ts
@@ -98,6 +98,11 @@ function stripFrontmatter(content: string): string {
   return content;
 }
 
+export function hasOrderFrontmatter(file: TFile): boolean {
+  const metadata = app.metadataCache.getFileCache(file);
+  return metadata?.frontmatter?.[COPILOT_COMMAND_CONTEXT_MENU_ORDER] != null;
+}
+
 /**
  * Parse a TFile as a CustomCommand by reading its content and extracting frontmatter.
  */

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -346,7 +346,7 @@ export function registerCommands(
   });
 
   // Add command to create a new custom command
-  addCommand(plugin, COMMAND_IDS.CREATE_CUSTOM_COMMAND, async () => {
+  addCommand(plugin, COMMAND_IDS.ADD_CUSTOM_COMMAND, async () => {
     const commands = getCachedCustomCommands();
     const newCommand = { ...EMPTY_COMMAND };
     const modal = new CustomCommandSettingsModal(
@@ -354,11 +354,7 @@ export function registerCommands(
       commands,
       newCommand,
       async (updatedCommand) => {
-        await CustomCommandManager.getInstance().reorderCommands(commands);
-        await CustomCommandManager.getInstance().updateCommand(
-          updatedCommand,
-          updatedCommand.title
-        );
+        await CustomCommandManager.getInstance().createCommand(updatedCommand);
       }
     );
     modal.open();

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -13,6 +13,10 @@ import { SelectedTextContext } from "@/sharedState";
 import { Editor, Notice, TFile } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import { COMMAND_IDS, COMMAND_NAMES, CommandId } from "../constants";
+import { CustomCommandSettingsModal } from "@/commands/CustomCommandSettingsModal";
+import { EMPTY_COMMAND } from "@/commands/constants";
+import { getCachedCustomCommands } from "@/commands/state";
+import { CustomCommandManager } from "@/commands/customCommandManager";
 
 /**
  * Add a command to the plugin.
@@ -339,5 +343,24 @@ export function registerCommands(
 
     // Open chat window to show the context was added
     plugin.activateView();
+  });
+
+  // Add command to create a new custom command
+  addCommand(plugin, COMMAND_IDS.CREATE_CUSTOM_COMMAND, async () => {
+    const commands = getCachedCustomCommands();
+    const newCommand = { ...EMPTY_COMMAND };
+    const modal = new CustomCommandSettingsModal(
+      plugin.app,
+      commands,
+      newCommand,
+      async (updatedCommand) => {
+        await CustomCommandManager.getInstance().reorderCommands(commands);
+        await CustomCommandManager.getInstance().updateCommand(
+          updatedCommand,
+          updatedCommand.title
+        );
+      }
+    );
+    modal.open();
   });
 }

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -4,23 +4,18 @@ import { CustomCommand } from "./type";
 
 const customCommandsStore = createStore();
 const customCommandsAtom = atom<CustomCommand[]>([]);
-const pendingFileWritesAtom = atom<Set<string>>(new Set<string>());
+const pendingFileWritesAtom = new Set<string>();
 
 export function addPendingFileWrite(filePath: string) {
-  const pendingFileWrites = customCommandsStore.get(pendingFileWritesAtom);
-  pendingFileWrites.add(filePath);
-  customCommandsStore.set(pendingFileWritesAtom, pendingFileWrites);
+  pendingFileWritesAtom.add(filePath);
 }
 
 export function removePendingFileWrite(filePath: string) {
-  const pendingFileWrites = customCommandsStore.get(pendingFileWritesAtom);
-  pendingFileWrites.delete(filePath);
-  customCommandsStore.set(pendingFileWritesAtom, pendingFileWrites);
+  pendingFileWritesAtom.delete(filePath);
 }
 
 export function isFileWritePending(filePath: string) {
-  const pendingFileWrites = customCommandsStore.get(pendingFileWritesAtom);
-  return pendingFileWrites.has(filePath);
+  return pendingFileWritesAtom.has(filePath);
 }
 
 export function createCachedCommand(command: CustomCommand): CustomCommand {

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -1,20 +1,18 @@
 import { atom, createStore } from "jotai";
 import { useAtomValue } from "jotai";
 import { CustomCommand } from "./type";
-import { EMPTY_COMMAND } from "@/commands/constants";
 
 const customCommandsStore = createStore();
 const customCommandsAtom = atom<CustomCommand[]>([]);
 
-export function createCachedCommand(title: string, content = ""): CustomCommand {
+export function createCachedCommand(command: CustomCommand): CustomCommand {
   const commands = customCommandsStore.get(customCommandsAtom);
-  const command = commands.find((command) => command.title === title);
-  if (command) {
-    return command;
+  const existingCommand = commands.find((c) => c.title === command.title);
+  if (existingCommand) {
+    return existingCommand;
   }
-  const newCommand = { ...EMPTY_COMMAND, title, content };
-  customCommandsStore.set(customCommandsAtom, [...commands, newCommand]);
-  return newCommand;
+  customCommandsStore.set(customCommandsAtom, [...commands, command]);
+  return command;
 }
 
 export function deleteCachedCommand(title: string) {

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -4,6 +4,24 @@ import { CustomCommand } from "./type";
 
 const customCommandsStore = createStore();
 const customCommandsAtom = atom<CustomCommand[]>([]);
+const pendingFileWritesAtom = atom<Set<string>>(new Set<string>());
+
+export function addPendingFileWrite(filePath: string) {
+  const pendingFileWrites = customCommandsStore.get(pendingFileWritesAtom);
+  pendingFileWrites.add(filePath);
+  customCommandsStore.set(pendingFileWritesAtom, pendingFileWrites);
+}
+
+export function removePendingFileWrite(filePath: string) {
+  const pendingFileWrites = customCommandsStore.get(pendingFileWritesAtom);
+  pendingFileWrites.delete(filePath);
+  customCommandsStore.set(pendingFileWritesAtom, pendingFileWrites);
+}
+
+export function isFileWritePending(filePath: string) {
+  const pendingFileWrites = customCommandsStore.get(pendingFileWritesAtom);
+  return pendingFileWrites.has(filePath);
+}
 
 export function createCachedCommand(command: CustomCommand): CustomCommand {
   const commands = customCommandsStore.get(customCommandsAtom);

--- a/src/commands/state.ts
+++ b/src/commands/state.ts
@@ -6,12 +6,15 @@ import { EMPTY_COMMAND } from "@/commands/constants";
 const customCommandsStore = createStore();
 const customCommandsAtom = atom<CustomCommand[]>([]);
 
-export function createCachedCommand(title: string) {
+export function createCachedCommand(title: string, content = ""): CustomCommand {
   const commands = customCommandsStore.get(customCommandsAtom);
-  if (commands.some((command) => command.title === title)) {
-    return;
+  const command = commands.find((command) => command.title === title);
+  if (command) {
+    return command;
   }
-  customCommandsStore.set(customCommandsAtom, [...commands, { ...EMPTY_COMMAND, title }]);
+  const newCommand = { ...EMPTY_COMMAND, title, content };
+  customCommandsStore.set(customCommandsAtom, [...commands, newCommand]);
+  return newCommand;
 }
 
 export function deleteCachedCommand(title: string) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -602,6 +602,7 @@ export const COMMAND_IDS = {
   TOGGLE_COPILOT_CHAT_WINDOW: "chat-toggle-window",
   TOGGLE_AUTOCOMPLETE: "toggle-autocomplete",
   ADD_SELECTION_TO_CHAT_CONTEXT: "add-selection-to-chat-context",
+  CREATE_CUSTOM_COMMAND: "create-custom-command",
 } as const;
 
 export const COMMAND_NAMES: Record<CommandId, string> = {
@@ -625,6 +626,7 @@ export const COMMAND_NAMES: Record<CommandId, string> = {
   [COMMAND_IDS.TOGGLE_COPILOT_CHAT_WINDOW]: "Toggle Copilot Chat Window",
   [COMMAND_IDS.TOGGLE_AUTOCOMPLETE]: "Toggle autocomplete",
   [COMMAND_IDS.ADD_SELECTION_TO_CHAT_CONTEXT]: "Add selection to chat context",
+  [COMMAND_IDS.CREATE_CUSTOM_COMMAND]: "Create new custom command",
 };
 
 export type CommandId = (typeof COMMAND_IDS)[keyof typeof COMMAND_IDS];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -602,7 +602,7 @@ export const COMMAND_IDS = {
   TOGGLE_COPILOT_CHAT_WINDOW: "chat-toggle-window",
   TOGGLE_AUTOCOMPLETE: "toggle-autocomplete",
   ADD_SELECTION_TO_CHAT_CONTEXT: "add-selection-to-chat-context",
-  CREATE_CUSTOM_COMMAND: "create-custom-command",
+  ADD_CUSTOM_COMMAND: "add-custom-command",
 } as const;
 
 export const COMMAND_NAMES: Record<CommandId, string> = {
@@ -626,7 +626,7 @@ export const COMMAND_NAMES: Record<CommandId, string> = {
   [COMMAND_IDS.TOGGLE_COPILOT_CHAT_WINDOW]: "Toggle Copilot Chat Window",
   [COMMAND_IDS.TOGGLE_AUTOCOMPLETE]: "Toggle autocomplete",
   [COMMAND_IDS.ADD_SELECTION_TO_CHAT_CONTEXT]: "Add selection to chat context",
-  [COMMAND_IDS.CREATE_CUSTOM_COMMAND]: "Create new custom command",
+  [COMMAND_IDS.ADD_CUSTOM_COMMAND]: "Add new custom command",
 };
 
 export type CommandId = (typeof COMMAND_IDS)[keyof typeof COMMAND_IDS];

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -185,11 +185,7 @@ export const CommandSettings: React.FC = () => {
   };
 
   const handleCreate = async (newCommand: CustomCommand) => {
-    // Reorder the existing commands so the order frontmatter is set to the
-    // correct value. This allows the new command to always show up at the bottom
-    // of the list.
-    await CustomCommandManager.getInstance().reorderCommands(commands);
-    await CustomCommandManager.getInstance().updateCommand(newCommand, newCommand.title);
+    await CustomCommandManager.getInstance().createCommand(newCommand);
   };
 
   const handleRemove = async (command: CustomCommand) => {
@@ -210,8 +206,11 @@ export const CommandSettings: React.FC = () => {
       const copiedCommand: CustomCommand = {
         ...command,
         title: copyName,
+        order: command.order + 1,
       };
-      await CustomCommandManager.getInstance().updateCommand(copiedCommand, copiedCommand.title);
+      await CustomCommandManager.getInstance().createCommand(copiedCommand, {
+        autoOrder: false,
+      });
     } catch (error) {
       console.error("Failed to copy command:", error);
       new Notice("Failed to copy command. Please try again.");

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -188,7 +188,7 @@ export const CommandSettings: React.FC = () => {
     // Reorder the existing commands so the order frontmatter is set to the
     // correct value. This allows the new command to always show up at the bottom
     // of the list.
-    reorderCommands(commands);
+    await reorderCommands(commands);
     await handleUpdate(newCommand, newCommand.title);
   };
 

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -188,7 +188,7 @@ export const CommandSettings: React.FC = () => {
     // Reorder the existing commands so the order frontmatter is set to the
     // correct value. This allows the new command to always show up at the bottom
     // of the list.
-    await reorderCommands(commands);
+    await CustomCommandManager.getInstance().reorderCommands(commands);
     await handleUpdate(newCommand, newCommand.title);
   };
 
@@ -218,14 +218,6 @@ export const CommandSettings: React.FC = () => {
     }
   };
 
-  const reorderCommands = async (newOrderedCommands: CustomCommand[]) => {
-    const newCommands = [...newOrderedCommands];
-    for (let i = 0; i < newCommands.length; i++) {
-      newCommands[i] = { ...newCommands[i], order: i * 10 };
-    }
-    await CustomCommandManager.getInstance().updateCommands(newCommands);
-  };
-
   const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event;
 
@@ -245,7 +237,7 @@ export const CommandSettings: React.FC = () => {
     const [movedCommand] = newCommands.splice(activeIndex, 1);
     newCommands.splice(overIndex, 0, movedCommand);
 
-    await reorderCommands(newCommands);
+    await CustomCommandManager.getInstance().reorderCommands(newCommands);
   };
 
   return (

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -189,7 +189,7 @@ export const CommandSettings: React.FC = () => {
     // correct value. This allows the new command to always show up at the bottom
     // of the list.
     await CustomCommandManager.getInstance().reorderCommands(commands);
-    await handleUpdate(newCommand, newCommand.title);
+    await CustomCommandManager.getInstance().updateCommand(newCommand, newCommand.title);
   };
 
   const handleRemove = async (command: CustomCommand) => {

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -206,7 +206,6 @@ export const CommandSettings: React.FC = () => {
       const copiedCommand: CustomCommand = {
         ...command,
         title: copyName,
-        order: command.order + 1,
       };
       await CustomCommandManager.getInstance().createCommand(copiedCommand, {
         autoOrder: false,

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -208,6 +208,9 @@ export const CommandSettings: React.FC = () => {
         title: copyName,
       };
       await CustomCommandManager.getInstance().createCommand(copiedCommand, {
+        // Explicitly make the new command the same order as the original command
+        // so it appears next to the original command in the menu. The extra
+        // suffix will ensure it is below the original command in the menu.
         autoOrder: false,
       });
     } catch (error) {


### PR DESCRIPTION
- Auto add frontmatter when adding or renaming custom prompt files
- Updated the default value for slash and custom command to true.
- Added the copy command button back in the command settings.
- Reused edit command dialog when creating a new command.
- Moved add command button to the top of the command table.
- Ensured the new command always show up at the bottom of the command table.
- Added the "Add new custom command" command back

![2025-07-06 23 20 51](https://github.com/user-attachments/assets/55861ea0-a2c9-4fc3-81b7-20e567f3e913)

![2025-07-07 00 39 20](https://github.com/user-attachments/assets/1dad02a6-5af7-4e9c-a1bd-d7b751f93f6e)



