### PR TITLE
Disallow file types in context

### DIFF
--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -25,7 +25,13 @@ import { Mention } from "@/mentions/Mention";
 import { getModelKeyFromModel, useSettingsValue } from "@/settings/model";
 import { SelectedTextContext } from "@/sharedState";
 import { getToolDescription } from "@/tools/toolManager";
-import { checkModelApiKey, err2String, extractNoteFiles, isNoteTitleUnique } from "@/utils";
+import {
+  checkModelApiKey,
+  err2String,
+  extractNoteFiles,
+  isAllowedFileForContext,
+  isNoteTitleUnique,
+} from "@/utils";
 import {
   ArrowBigUp,
   ChevronDown,
@@ -106,9 +112,10 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
     const [modelError, setModelError] = useState<string | null>(null);
     const [currentChain] = useChainType();
     const [isProjectLoading] = useProjectLoading();
-    const [currentActiveNote, setCurrentActiveNote] = useState<TFile | null>(
-      app.workspace.getActiveFile()
-    );
+    const [currentActiveNote, setCurrentActiveNote] = useState<TFile | null>(() => {
+      const activeFile = app.workspace.getActiveFile();
+      return isAllowedFileForContext(activeFile) ? activeFile : null;
+    });
     const [selectedProject, setSelectedProject] = useState<ProjectConfig | null>(null);
     const settings = useSettingsValue();
     const isCopilotPlus =
@@ -441,7 +448,7 @@ const ChatInput = forwardRef<{ focus: () => void }, ChatInputProps>(
         // Set new timeout
         timeoutId = setTimeout(() => {
           const activeNote = app.workspace.getActiveFile();
-          setCurrentActiveNote(activeNote);
+          setCurrentActiveNote(isAllowedFileForContext(activeNote) ? activeNote : null);
         }, 100); // Wait 100ms after the last event because it fires multiple times
       };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -280,6 +280,16 @@ export function getFileName(file: TFile): string {
   return file.basename;
 }
 
+/**
+ * Check if a file is allowed for context (markdown, PDF, or canvas files)
+ * @param file The file to check
+ * @returns true if the file is allowed, false otherwise
+ */
+export function isAllowedFileForContext(file: TFile | null): boolean {
+  if (!file) return false;
+  return file.extension === "md" || file.extension === "pdf" || file.extension === "canvas";
+}
+
 export async function getAllNotesContent(vault: Vault): Promise<string> {
   let allContent = "";
 


### PR DESCRIPTION
- Added `isAllowedFileForContext` utility function to check if a file is of allowed types (markdown, PDF, or canvas).
- Updated `ChatInput` to use this function for setting the current active note.
- Refactored `BaseNoteModal` to utilize the new utility for filtering files and managing the active note state.