### PR TITLE
Add tool execution tests and implement Plus subscription checks

### DIFF
--- a/src/LLMProviders/chainRunner/utils/toolExecution.test.ts
+++ b/src/LLMProviders/chainRunner/utils/toolExecution.test.ts
@@ -1,0 +1,121 @@
+import { executeSequentialToolCall } from "./toolExecution";
+import { createTool } from "@/tools/SimpleTool";
+import { z } from "zod";
+
+// Mock dependencies
+jest.mock("@/plusUtils", () => ({
+  checkIsPlusUser: jest.fn(),
+}));
+
+jest.mock("@/logger", () => ({
+  logError: jest.fn(),
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+}));
+
+jest.mock("@/tools/toolManager", () => ({
+  ToolManager: {
+    callTool: jest.fn(),
+  },
+}));
+
+import { checkIsPlusUser } from "@/plusUtils";
+import { ToolManager } from "@/tools/toolManager";
+
+describe("toolExecution", () => {
+  const mockCheckIsPlusUser = checkIsPlusUser as jest.MockedFunction<typeof checkIsPlusUser>;
+  const mockCallTool = ToolManager.callTool as jest.MockedFunction<typeof ToolManager.callTool>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("executeSequentialToolCall", () => {
+    it("should execute tools without isPlusOnly flag", async () => {
+      const testTool = createTool({
+        name: "testTool",
+        description: "Test tool",
+        schema: z.object({ input: z.string() }),
+        handler: async ({ input }) => `Result: ${input}`,
+      });
+
+      mockCallTool.mockResolvedValueOnce("Tool executed successfully");
+
+      const result = await executeSequentialToolCall(
+        { name: "testTool", args: { input: "test" } },
+        [testTool]
+      );
+
+      expect(result).toEqual({
+        toolName: "testTool",
+        result: "Tool executed successfully",
+        success: true,
+      });
+      expect(mockCheckIsPlusUser).not.toHaveBeenCalled();
+    });
+
+    it("should block plus-only tools for non-plus users", async () => {
+      const plusTool = createTool({
+        name: "plusTool",
+        description: "Plus-only tool",
+        schema: z.void(),
+        handler: async () => "Should not execute",
+        isPlusOnly: true,
+      });
+
+      mockCheckIsPlusUser.mockResolvedValueOnce(false);
+
+      const result = await executeSequentialToolCall({ name: "plusTool", args: {} }, [plusTool]);
+
+      expect(result).toEqual({
+        toolName: "plusTool",
+        result: "Error: plusTool requires a Copilot Plus subscription",
+        success: false,
+      });
+      expect(mockCallTool).not.toHaveBeenCalled();
+    });
+
+    it("should allow plus-only tools for plus users", async () => {
+      const plusTool = createTool({
+        name: "plusTool",
+        description: "Plus-only tool",
+        schema: z.void(),
+        handler: async () => "Plus tool executed",
+        isPlusOnly: true,
+      });
+
+      mockCheckIsPlusUser.mockResolvedValueOnce(true);
+      mockCallTool.mockResolvedValueOnce("Plus tool executed");
+
+      const result = await executeSequentialToolCall({ name: "plusTool", args: {} }, [plusTool]);
+
+      expect(result).toEqual({
+        toolName: "plusTool",
+        result: "Plus tool executed",
+        success: true,
+      });
+      expect(mockCheckIsPlusUser).toHaveBeenCalled();
+      expect(mockCallTool).toHaveBeenCalled();
+    });
+
+    it("should handle tool not found", async () => {
+      const result = await executeSequentialToolCall({ name: "unknownTool", args: {} }, []);
+
+      expect(result).toEqual({
+        toolName: "unknownTool",
+        result: "Error: Tool 'unknownTool' not found. Available tools: ",
+        success: false,
+      });
+    });
+
+    it("should handle invalid tool call", async () => {
+      const result = await executeSequentialToolCall(null as any, []);
+
+      expect(result).toEqual({
+        toolName: "unknown",
+        result: "Error: Invalid tool call - missing tool name",
+        success: false,
+      });
+    });
+  });
+});

--- a/src/LLMProviders/chainRunner/utils/toolExecution.ts
+++ b/src/LLMProviders/chainRunner/utils/toolExecution.ts
@@ -1,4 +1,5 @@
 import { logError, logInfo, logWarn } from "@/logger";
+import { checkIsPlusUser } from "@/plusUtils";
 import { ToolManager } from "@/tools/toolManager";
 import { err2String } from "@/utils";
 import { ToolCall } from "./xmlParsing";
@@ -38,6 +39,18 @@ export async function executeSequentialToolCall(
         result: `Error: Tool '${toolCall.name}' not found. Available tools: ${availableToolNames}`,
         success: false,
       };
+    }
+
+    // Check if tool requires Plus subscription
+    if (tool.isPlusOnly) {
+      const isPlusUser = await checkIsPlusUser();
+      if (!isPlusUser) {
+        return {
+          toolName: toolCall.name,
+          result: `Error: ${getToolDisplayName(toolCall.name)} requires a Copilot Plus subscription`,
+          success: false,
+        };
+      }
     }
 
     // Determine timeout for this tool

--- a/src/tools/SearchTools.ts
+++ b/src/tools/SearchTools.ts
@@ -126,6 +126,7 @@ const webSearchTool = createTool({
   name: "webSearch",
   description: "Search the web for information",
   schema: webSearchSchema,
+  isPlusOnly: true,
   handler: async ({ query, chatHistory }) => {
     try {
       // Get standalone question considering chat history

--- a/src/tools/SimpleTool.ts
+++ b/src/tools/SimpleTool.ts
@@ -24,6 +24,7 @@ export interface SimpleTool<TSchema extends z.ZodType = z.ZodVoid, TOutput = any
   call: (args: z.infer<TSchema>) => Promise<TOutput>;
   timeoutMs?: number;
   isBackground?: boolean; // If true, tool execution is not shown to user
+  isPlusOnly?: boolean; // If true, tool requires Plus subscription
   // Future extensibility fields
   version?: string; // Tool version for compatibility
   deprecated?: boolean; // Mark tools for future removal
@@ -37,6 +38,7 @@ export interface CreateToolOptions<TSchema extends z.ZodType, TOutput = any> {
   handler: (args: z.infer<TSchema>) => Promise<TOutput>;
   timeoutMs?: number;
   isBackground?: boolean;
+  isPlusOnly?: boolean;
   version?: string;
   deprecated?: boolean;
   metadata?: Record<string, unknown>;
@@ -81,6 +83,7 @@ export function createTool<TSchema extends z.ZodType, TOutput = any>(
     },
     timeoutMs: options.timeoutMs,
     isBackground: options.isBackground,
+    isPlusOnly: options.isPlusOnly,
     version: options.version,
     deprecated: options.deprecated,
     metadata: options.metadata,

--- a/src/tools/YoutubeTools.ts
+++ b/src/tools/YoutubeTools.ts
@@ -8,6 +8,7 @@ const simpleYoutubeTranscriptionTool = createTool({
   schema: z.object({
     url: z.string().url().describe("The YouTube video URL"),
   }),
+  isPlusOnly: true,
   handler: async ({ url }) => {
     try {
       const response = await BrevilabsClient.getInstance().youtube4llm(url);


### PR DESCRIPTION
- Introduced unit tests for the `executeSequentialToolCall` function to validate tool execution behavior, including handling of Plus-only tools.
- Enhanced `executeSequentialToolCall` to check for Plus subscription requirements before executing tools.
- Updated `createTool` and `SimpleTool` interfaces to include an `isPlusOnly` flag, indicating tools that require a Copilot Plus subscription.
- Marked existing tools (e.g., webSearch and YouTube transcription) as Plus-only where applicable.