### PR TITLE
Update Gemini Flash-Lite

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -126,6 +126,7 @@ export enum ChatModels {
   AZURE_OPENAI = "azure-openai",
   GEMINI_PRO = "gemini-2.5-pro",
   GEMINI_FLASH = "gemini-2.5-flash",
+  GEMINI_FLASH_LITE = "gemini-2.5-flash-lite",
   CLAUDE_3_5_SONNET = "claude-3-5-sonnet-latest",
   CLAUDE_3_7_SONNET = "claude-3-7-sonnet-latest",
   CLAUDE_4_SONNET = "claude-sonnet-4-20250514",
@@ -141,7 +142,7 @@ export enum ChatModels {
   DEEPSEEK_CHAT = "deepseek-chat",
   OPENROUTER_GEMINI_2_5_FLASH = "google/gemini-2.5-flash",
   OPENROUTER_GEMINI_2_5_PRO = "google/gemini-2.5-pro",
-  OPENROUTER_GEMINI_2_5_FLASH_LITE = "google/gemini-2.5-flash-lite-preview-06-17",
+  OPENROUTER_GEMINI_2_5_FLASH_LITE = "google/gemini-2.5-flash-lite",
 }
 
 // Model Providers
@@ -288,6 +289,14 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
   },
   {
     name: ChatModels.GEMINI_FLASH,
+    provider: ChatModelProviders.GOOGLE,
+    enabled: true,
+    isBuiltIn: true,
+    projectEnabled: true,
+    capabilities: [ModelCapability.VISION],
+  },
+  {
+    name: ChatModels.GEMINI_FLASH_LITE,
     provider: ChatModelProviders.GOOGLE,
     enabled: true,
     isBuiltIn: true,


### PR DESCRIPTION
Gemini Flash-Lite has been officially released (see https://alternativeto.net/news/2025/7/google-gemini-2-5-flash-lite-launches-with-lower-pricing-and-1m-context-window/). It is recommended to remove the old alias (`gemini-2.5-flash-lite-preview-06-17`) before August 25. This PR adds `gemini-2.5-flash-lite` from the Google provider, not Openrouter.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add `GEMINI_FLASH_LITE` to the chat models enumeration and the built-in chat models configuration.

### Why are these changes being made?

This change introduces the `GEMINI_FLASH_LITE` model to the system, aligning it with other models by providing its configuration and enabling it by default. This ensures consistency across available models and allows for immediate use in projects requiring vision capabilities.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->