### PR TITLE
Don’t escape special XML characters in context data

### DIFF
--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -23,7 +23,7 @@ import {
   logToolResult,
   ToolExecutionResult,
 } from "./utils/toolExecution";
-import { escapeXml, parseXMLToolCalls, stripToolCallXML } from "./utils/xmlParsing";
+import { parseXMLToolCalls, stripToolCallXML } from "./utils/xmlParsing";
 
 export class AutonomousAgentChainRunner extends CopilotPlusChainRunner {
   private llmFormattedMessages: string[] = []; // Track LLM-formatted messages for memory
@@ -54,19 +54,16 @@ export class AutonomousAgentChainRunner extends CopilotPlusChainRunner {
         const parameters = extractParametersFromZod(tool.schema);
         if (Object.keys(parameters).length > 0) {
           params = Object.entries(parameters)
-            .map(
-              ([key, description]) =>
-                `<${escapeXml(key)}>${escapeXml(description)}</${escapeXml(key)}>`
-            )
+            .map(([key, description]) => `<${key}>${description}</${key}>`)
             .join("\n");
         }
 
-        return `<${escapeXml(tool.name)}>
-<description>${escapeXml(tool.description)}</description>
+        return `<${tool.name}>
+<description>${tool.description}</description>
 <parameters>
 ${params}
 </parameters>
-</${escapeXml(tool.name)}>`;
+</${tool.name}>`;
       })
       .join("\n\n");
   }

--- a/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
+++ b/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
@@ -1,5 +1,4 @@
 import { ABORT_REASON, EMPTY_INDEX_ERROR_MESSAGE, RETRIEVED_DOCUMENT_TAG } from "@/constants";
-import { escapeXml } from "./utils/xmlParsing";
 import { logInfo } from "@/logger";
 import { HybridRetriever } from "@/search/hybridRetriever";
 import { getSettings, getSystemPrompt } from "@/settings/model";
@@ -71,7 +70,7 @@ export class VaultQAChainRunner extends BaseChainRunner {
       const context = retrievedDocs
         .map(
           (doc: any) =>
-            `<${RETRIEVED_DOCUMENT_TAG}>\n${escapeXml(doc.pageContent)}\n</${RETRIEVED_DOCUMENT_TAG}>`
+            `<${RETRIEVED_DOCUMENT_TAG}>\n${doc.pageContent}\n</${RETRIEVED_DOCUMENT_TAG}>`
         )
         .join("\n\n");
 

--- a/src/commands/customCommandUtils.ts
+++ b/src/commands/customCommandUtils.ts
@@ -32,7 +32,6 @@ import {
   VARIABLE_TAG,
   VARIABLE_NOTE_TAG,
 } from "@/constants";
-import { escapeXml, escapeXmlAttribute } from "@/LLMProviders/chainRunner/utils/xmlParsing";
 
 export function validateCommandName(
   name: string,
@@ -273,7 +272,7 @@ async function extractVariablesFromPrompt(
       if (activeNote) {
         const content = await getFileContent(activeNote, vault);
         if (content) {
-          variableResult.content = `<${VARIABLE_NOTE_TAG}>\n## ${escapeXml(getFileName(activeNote))}\n\n${escapeXml(content)}\n</${VARIABLE_NOTE_TAG}>`;
+          variableResult.content = `<${VARIABLE_NOTE_TAG}>\n## ${getFileName(activeNote)}\n\n${content}\n</${VARIABLE_NOTE_TAG}>`;
           variableResult.files.push(activeNote);
         }
       } else {
@@ -291,7 +290,7 @@ async function extractVariablesFromPrompt(
         const content = await getFileContent(file, vault);
         if (content) {
           notesContent.push(
-            `<${VARIABLE_NOTE_TAG}>\n## ${escapeXml(getFileName(file))}\n\n${escapeXml(content)}\n</${VARIABLE_NOTE_TAG}>`
+            `<${VARIABLE_NOTE_TAG}>\n## ${getFileName(file)}\n\n${content}\n</${VARIABLE_NOTE_TAG}>`
           );
           variableResult.files.push(file);
         }
@@ -305,7 +304,7 @@ async function extractVariablesFromPrompt(
         const content = await getFileContent(file, vault);
         if (content) {
           notesContent.push(
-            `<${VARIABLE_NOTE_TAG}>\n## ${escapeXml(getFileName(file))}\n\n${escapeXml(content)}\n</${VARIABLE_NOTE_TAG}>`
+            `<${VARIABLE_NOTE_TAG}>\n## ${getFileName(file)}\n\n${content}\n</${VARIABLE_NOTE_TAG}>`
           );
           variableResult.files.push(file);
         }
@@ -375,11 +374,11 @@ export async function processPrompt(
   if (processedPrompt.includes("{}")) {
     processedPrompt = processedPrompt.replace(/\{\}/g, `{${SELECTED_TEXT_TAG}}`);
     if (selectedText) {
-      additionalInfo += `<${SELECTED_TEXT_TAG}>\n${escapeXml(selectedText)}\n</${SELECTED_TEXT_TAG}>`;
+      additionalInfo += `<${SELECTED_TEXT_TAG}>\n${selectedText}\n</${SELECTED_TEXT_TAG}>`;
       // Note: selectedText doesn't directly correspond to a file inclusion here
     } else if (activeNote) {
       activeNoteContent = await getFileContent(activeNote, vault);
-      additionalInfo += `<${SELECTED_TEXT_TAG} type="active_note">\n${escapeXml(activeNoteContent || "")}\n</${SELECTED_TEXT_TAG}>`;
+      additionalInfo += `<${SELECTED_TEXT_TAG} type="active_note">\n${activeNoteContent || ""}\n</${SELECTED_TEXT_TAG}>`;
       includedFiles.add(activeNote); // Ensure active note is tracked if used for {}
     } else {
       additionalInfo += `<${SELECTED_TEXT_TAG}>\n(No selected text or active note available)\n</${SELECTED_TEXT_TAG}>`;
@@ -394,9 +393,9 @@ export async function processPrompt(
       continue;
     }
     if (additionalInfo) {
-      additionalInfo += `\n\n<${VARIABLE_TAG} name="${escapeXmlAttribute(varName)}">\n${content}\n</${VARIABLE_TAG}>`;
+      additionalInfo += `\n\n<${VARIABLE_TAG} name="${varName}">\n${content}\n</${VARIABLE_TAG}>`;
     } else {
-      additionalInfo += `<${VARIABLE_TAG} name="${escapeXmlAttribute(varName)}">\n${content}\n</${VARIABLE_TAG}>`;
+      additionalInfo += `<${VARIABLE_TAG} name="${varName}">\n${content}\n</${VARIABLE_TAG}>`;
     }
   }
 
@@ -413,7 +412,7 @@ export async function processPrompt(
         const ctime = stats ? new Date(stats.ctime).toISOString() : "Unknown";
         const mtime = stats ? new Date(stats.mtime).toISOString() : "Unknown";
 
-        const noteContext = `<${NOTE_CONTEXT_PROMPT_TAG}>\n<title>${escapeXml(noteFile.basename)}</title>\n<path>${escapeXml(noteFile.path)}</path>\n<ctime>${escapeXml(ctime)}</ctime>\n<mtime>${escapeXml(mtime)}</mtime>\n<content>\n${escapeXml(noteContent)}\n</content>\n</${NOTE_CONTEXT_PROMPT_TAG}>`;
+        const noteContext = `<${NOTE_CONTEXT_PROMPT_TAG}>\n<title>${noteFile.basename}</title>\n<path>${noteFile.path}</path>\n<ctime>${ctime}</ctime>\n<mtime>${mtime}</mtime>\n<content>\n${noteContent}\n</content>\n</${NOTE_CONTEXT_PROMPT_TAG}>`;
         if (additionalInfo) {
           additionalInfo += `\n\n`;
         }

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -3,7 +3,6 @@ import { ChainType } from "@/chainFactory";
 import { FileParserManager } from "@/tools/FileParserManager";
 import { TFile, Vault } from "obsidian";
 import { NOTE_CONTEXT_PROMPT_TAG, EMBEDDED_PDF_TAG, SELECTED_TEXT_TAG } from "./constants";
-import { escapeXml } from "./LLMProviders/chainRunner/utils/xmlParsing";
 
 export class ContextProcessor {
   private static instance: ContextProcessor;
@@ -34,13 +33,13 @@ export class ContextProcessor {
           const pdfContent = await fileParserManager.parseFile(pdfFile, vault);
           content = content.replace(
             match[0],
-            `\n\n<${EMBEDDED_PDF_TAG}>\n<name>${escapeXml(pdfName)}</name>\n<content>\n${escapeXml(pdfContent)}\n</content>\n</${EMBEDDED_PDF_TAG}>\n\n`
+            `\n\n<${EMBEDDED_PDF_TAG}>\n<name>${pdfName}</name>\n<content>\n${pdfContent}\n</content>\n</${EMBEDDED_PDF_TAG}>\n\n`
           );
         } catch (error) {
           console.error(`Error processing embedded PDF ${pdfName}:`, error);
           content = content.replace(
             match[0],
-            `\n\n<${EMBEDDED_PDF_TAG}>\n<name>${escapeXml(pdfName)}</name>\n<error>Could not process PDF</error>\n</${EMBEDDED_PDF_TAG}>\n\n`
+            `\n\n<${EMBEDDED_PDF_TAG}>\n<name>${pdfName}</name>\n<error>Could not process PDF</error>\n</${EMBEDDED_PDF_TAG}>\n\n`
           );
         }
       }
@@ -115,10 +114,10 @@ export class ContextProcessor {
         const ctime = stats ? new Date(stats.ctime).toISOString() : "Unknown";
         const mtime = stats ? new Date(stats.mtime).toISOString() : "Unknown";
 
-        additionalContext += `\n\n<${prompt_tag}>\n<title>${escapeXml(note.basename)}</title>\n<path>${escapeXml(note.path)}</path>\n<ctime>${escapeXml(ctime)}</ctime>\n<mtime>${escapeXml(mtime)}</mtime>\n<content>\n${escapeXml(content)}\n</content>\n</${prompt_tag}>`;
+        additionalContext += `\n\n<${prompt_tag}>\n<title>${note.basename}</title>\n<path>${note.path}</path>\n<ctime>${ctime}</ctime>\n<mtime>${mtime}</mtime>\n<content>\n${content}\n</content>\n</${prompt_tag}>`;
       } catch (error) {
         console.error(`Error processing file ${note.path}:`, error);
-        additionalContext += `\n\n<${prompt_tag}_error>\n<title>${escapeXml(note.basename)}</title>\n<path>${escapeXml(note.path)}</path>\n<error>[Error: Could not process file]</error>\n</${prompt_tag}_error>`;
+        additionalContext += `\n\n<${prompt_tag}_error>\n<title>${note.basename}</title>\n<path>${note.path}</path>\n<error>[Error: Could not process file]</error>\n</${prompt_tag}_error>`;
       }
     };
 
@@ -189,7 +188,7 @@ export class ContextProcessor {
     let additionalContext = "";
 
     for (const selectedText of selectedTextContexts) {
-      additionalContext += `\n\n<${SELECTED_TEXT_TAG}>\n<title>${escapeXml(selectedText.noteTitle)}</title>\n<path>${escapeXml(selectedText.notePath)}</path>\n<start_line>${escapeXml(selectedText.startLine.toString())}</start_line>\n<end_line>${escapeXml(selectedText.endLine.toString())}</end_line>\n<content>\n${escapeXml(selectedText.content)}\n</content>\n</${SELECTED_TEXT_TAG}>`;
+      additionalContext += `\n\n<${SELECTED_TEXT_TAG}>\n<title>${selectedText.noteTitle}</title>\n<path>${selectedText.notePath}</path>\n<start_line>${selectedText.startLine.toString()}</start_line>\n<end_line>${selectedText.endLine.toString()}</end_line>\n<content>\n${selectedText.content}\n</content>\n</${SELECTED_TEXT_TAG}>`;
     }
 
     return additionalContext;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -299,9 +299,8 @@ export async function getAllNotesContent(vault: Vault): Promise<string> {
     const fileContent = await vault.cachedRead(file);
     // Import is not available at the top level due to circular dependency
     const { VAULT_NOTE_TAG } = await import("@/constants");
-    const { escapeXml } = await import("@/LLMProviders/chainRunner/utils/xmlParsing");
     vaultNotes.push(
-      `<${VAULT_NOTE_TAG}>\n<path>${escapeXml(file.path)}</path>\n<content>\n${escapeXml(fileContent)}\n</content>\n</${VAULT_NOTE_TAG}>`
+      `<${VAULT_NOTE_TAG}>\n<path>${file.path}</path>\n<content>\n${fileContent}\n</content>\n</${VAULT_NOTE_TAG}>`
     );
   }
 


### PR DESCRIPTION
Escaping special characters in context data (like context notes and tool info) alters the original content and can let composer overwrite original content with escaped content. 

Since we don’t parse context data as XML, escaping is unnecessary and may break expected behavior.

TESTED: tested notes with special XML characers with both @compose and agent mode.


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.
