### PR TITLE
Strip partial tool call tag

### DIFF
--- a/src/LLMProviders/chainRunner/utils/xmlParsing.test.ts
+++ b/src/LLMProviders/chainRunner/utils/xmlParsing.test.ts
@@ -1,4 +1,4 @@
-import { parseXMLToolCalls, escapeXml, escapeXmlAttribute } from "./xmlParsing";
+import { parseXMLToolCalls, escapeXml, escapeXmlAttribute, stripToolCallXML } from "./xmlParsing";
 
 describe("parseXMLToolCalls", () => {
   it("should parse hybrid XML tool calls with JSON arrays", () => {
@@ -284,6 +284,253 @@ describe("XML Escaping Utilities", () => {
       expect(escapeXmlAttribute('my"variable')).toBe("my&quot;variable");
       expect(escapeXmlAttribute("my'variable")).toBe("my&apos;variable");
       expect(escapeXmlAttribute("my<variable>")).toBe("my&lt;variable&gt;");
+    });
+  });
+});
+
+describe("stripToolCallXML", () => {
+  describe("complete tool calls", () => {
+    it("should remove complete tool call blocks", () => {
+      const text = `Before tool call.
+
+<use_tool>
+<name>localSearch</name>
+<query>test query</query>
+</use_tool>
+
+After tool call.`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Before tool call.\n\nAfter tool call.");
+    });
+
+    it("should remove multiple complete tool call blocks", () => {
+      const text = `First text.
+
+<use_tool>
+<name>localSearch</name>
+<query>first search</query>
+</use_tool>
+
+Middle text.
+
+<use_tool>
+<name>webSearch</name>
+<query>second search</query>
+</use_tool>
+
+Final text.`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("First text.\n\nMiddle text.\n\nFinal text.");
+    });
+
+    it("should preserve tool indicators when option is enabled", () => {
+      const text = `Before tool call.
+
+<use_tool>
+<name>localSearch</name>
+<query>test query</query>
+</use_tool>
+
+After tool call.`;
+
+      const result = stripToolCallXML(text, { preserveToolIndicators: true });
+      expect(result).toBe("Before tool call.\n\n[🔧 Tool call: vault search]\n\nAfter tool call.");
+    });
+  });
+
+  describe("partial tool calls", () => {
+    it("should remove partial tool call at end of text", () => {
+      const text = `Some text before.
+
+<use_tool>
+<name>localSearch</name>
+<query>incomplete`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Some text before.");
+    });
+
+    it("should remove partial tool call with only opening tag", () => {
+      const text = `Some text before.
+
+<use_tool>`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Some text before.");
+    });
+
+    it("should remove partial tool call with incomplete parameters", () => {
+      const text = `Some text before.
+
+<use_tool>
+<name>webSearch</name>
+<query>incomplete query
+<someParam>value`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Some text before.");
+    });
+
+    it("should handle mixed complete and partial tool calls", () => {
+      const text = `Start text.
+
+<use_tool>
+<name>localSearch</name>
+<query>complete search</query>
+</use_tool>
+
+Middle text.
+
+<use_tool>
+<name>webSearch</name>
+<query>incomplete`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Start text.\n\nMiddle text.");
+    });
+
+    it("should handle partial tool calls with preserveToolIndicators", () => {
+      const text = `Complete tool call:
+
+<use_tool>
+<name>localSearch</name>
+<query>complete search</query>
+</use_tool>
+
+Then partial:
+
+<use_tool>
+<name>webSearch</name>
+<query>incomplete`;
+
+      const result = stripToolCallXML(text, { preserveToolIndicators: true });
+      expect(result).toBe("Complete tool call:\n\n[🔧 Tool call: vault search]\n\nThen partial:");
+    });
+
+    it("should remove partial tool call in middle when followed by text", () => {
+      const text = `Before text.
+
+<use_tool>
+<name>localSearch</name>
+<query>incomplete query without closing
+
+This text should remain.`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Before text.");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle text with no tool calls", () => {
+      const text = "Just regular text with no tool calls.";
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Just regular text with no tool calls.");
+    });
+
+    it("should handle empty string", () => {
+      const result = stripToolCallXML("");
+      expect(result).toBe("");
+    });
+
+    it("should handle text with just whitespace", () => {
+      const result = stripToolCallXML("   \n  \n   ");
+      expect(result).toBe("");
+    });
+
+    it("should handle multiple partial tool calls", () => {
+      const text = `Text before.
+
+<use_tool>
+<name>tool1</name>
+
+More text.
+
+<use_tool>
+<name>tool2</name>
+<param>value`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Text before.");
+    });
+
+    it("should preserve non-tool XML tags", () => {
+      const text = `Some text with <strong>bold</strong> and <em>italic</em> tags.
+
+<use_tool>
+<name>localSearch</name>
+<query>search</query>
+</use_tool>
+
+More <div>HTML-like</div> content.`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe(
+        "Some text with <strong>bold</strong> and <em>italic</em> tags.\n\nMore <div>HTML-like</div> content."
+      );
+    });
+
+    it("should handle tool calls with complex nested content", () => {
+      const text = `Before tool.
+
+<use_tool>
+<name>complexTool</name>
+<nested>
+  <item>value1</item>
+  <item>value2</item>
+</nested>
+<jsonParam>["item1", "item2"]</jsonParam>
+</use_tool>
+
+After tool.`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Before tool.\n\nAfter tool.");
+    });
+  });
+
+  describe("code block removal", () => {
+    it("should remove empty code blocks", () => {
+      const text = `Some text.
+
+\`\`\`
+\`\`\`
+
+More text.
+
+\`\`\`javascript
+\`\`\``;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Some text.\n\nMore text.");
+    });
+
+    it("should remove tool_code blocks", () => {
+      const text = `Some text.
+
+\`\`\`tool_code
+some tool code here
+\`\`\`
+
+More text.`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Some text.\n\nMore text.");
+    });
+
+    it("should clean up excessive whitespace", () => {
+      const text = `Text with
+
+
+multiple
+
+
+newlines.`;
+
+      const result = stripToolCallXML(text);
+      expect(result).toBe("Text with\n\nmultiple\n\nnewlines.");
     });
   });
 });

--- a/src/LLMProviders/chainRunner/utils/xmlParsing.test.ts
+++ b/src/LLMProviders/chainRunner/utils/xmlParsing.test.ts
@@ -324,20 +324,6 @@ Final text.`;
       const result = stripToolCallXML(text);
       expect(result).toBe("First text.\n\nMiddle text.\n\nFinal text.");
     });
-
-    it("should preserve tool indicators when option is enabled", () => {
-      const text = `Before tool call.
-
-<use_tool>
-<name>localSearch</name>
-<query>test query</query>
-</use_tool>
-
-After tool call.`;
-
-      const result = stripToolCallXML(text, { preserveToolIndicators: true });
-      expect(result).toBe("Before tool call.\n\n[🔧 Tool call: vault search]\n\nAfter tool call.");
-    });
   });
 
   describe("partial tool calls", () => {
@@ -391,26 +377,6 @@ Middle text.
       expect(result).toBe("Start text.\n\nMiddle text.\n\nCalling web search...");
     });
 
-    it("should handle partial tool calls with preserveToolIndicators", () => {
-      const text = `Complete tool call:
-
-<use_tool>
-<name>localSearch</name>
-<query>complete search</query>
-</use_tool>
-
-Then partial:
-
-<use_tool>
-<name>webSearch</name>
-<query>incomplete`;
-
-      const result = stripToolCallXML(text, { preserveToolIndicators: true });
-      expect(result).toBe(
-        "Complete tool call:\n\n[🔧 Tool call: vault search]\n\nThen partial:\n\n[🔧 Calling web search...]"
-      );
-    });
-
     it("should show calling message for partial tool call in middle when followed by text", () => {
       const text = `Before text.
 
@@ -432,16 +398,6 @@ This text should remain.`;
 
       const result = stripToolCallXML(text);
       expect(result).toBe("Some text before.\n\nCalling tool...");
-    });
-
-    it("should show calling message with preserveToolIndicators when name not available", () => {
-      const text = `Some text before.
-
-<use_tool>
-<query>search without name`;
-
-      const result = stripToolCallXML(text, { preserveToolIndicators: true });
-      expect(result).toBe("Some text before.\n\n[🔧 Calling tool...]");
     });
   });
 

--- a/src/LLMProviders/chainRunner/utils/xmlParsing.ts
+++ b/src/LLMProviders/chainRunner/utils/xmlParsing.ts
@@ -210,6 +210,7 @@ export function stripToolCallXML(
     const toolNames = extractToolNamesFromXML(text);
     let toolIndex = 0;
 
+    // Remove complete tool calls and replace with indicators
     cleaned = cleaned.replace(/<use_tool>[\s\S]*?<\/use_tool>/g, () => {
       if (toolIndex < toolNames.length) {
         const toolName = toolNames[toolIndex];
@@ -219,9 +220,15 @@ export function stripToolCallXML(
       }
       return "";
     });
+
+    // Remove any remaining partial tool calls (everything after <use_tool> opening tag)
+    cleaned = cleaned.replace(/<use_tool>[\s\S]*$/g, "");
   } else {
-    // Remove all <use_tool>...</use_tool> blocks completely
+    // Remove all complete <use_tool>...</use_tool> blocks
     cleaned = cleaned.replace(/<use_tool>[\s\S]*?<\/use_tool>/g, "");
+
+    // Remove any partial tool calls (everything after <use_tool> opening tag)
+    cleaned = cleaned.replace(/<use_tool>[\s\S]*$/g, "");
   }
 
   // Keep thinking blocks in autonomous agent mode as they provide valuable context

--- a/src/LLMProviders/chainRunner/utils/xmlParsing.ts
+++ b/src/LLMProviders/chainRunner/utils/xmlParsing.ts
@@ -1,4 +1,5 @@
 import { logError, logWarn } from "@/logger";
+import { getToolDisplayName } from "./toolExecution";
 
 /**
  * Escapes special XML characters in a string to prevent XML injection
@@ -155,28 +156,6 @@ function parseParameterContent(content: string, parameterName?: string): any {
 }
 
 /**
- * Extracts tool names from tool call blocks for display purposes
- */
-function extractToolNamesFromXML(text: string): string[] {
-  const toolNames: string[] = [];
-  const regex = /<use_tool>([\s\S]*?)<\/use_tool>/g;
-
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    const content = match[1];
-    const nameMatch = content.match(/<name>([\s\S]*?)<\/name>/);
-    if (nameMatch) {
-      const name = nameMatch[1].trim();
-      if (name) {
-        toolNames.push(name);
-      }
-    }
-  }
-
-  return toolNames;
-}
-
-/**
  * Extracts tool name from a partial tool call block
  */
 function extractToolNameFromPartialBlock(partialContent: string): string | null {
@@ -189,53 +168,15 @@ function extractToolNameFromPartialBlock(partialContent: string): string | null 
 }
 
 /**
- * Maps tool names to display names for better user experience
- */
-function getToolDisplayName(toolName: string): string {
-  const displayNames: Record<string, string> = {
-    localSearch: "vault search",
-    webSearch: "web search",
-    getFileTree: "file explorer",
-    getCurrentTime: "time check",
-    pomodoroTimer: "pomodoro timer",
-    simpleYoutubeTranscription: "YouTube transcript",
-    indexVault: "vault indexing",
-  };
-  return displayNames[toolName] || toolName;
-}
-
-/**
  * Strips XML tool call blocks, thinking blocks, and various code blocks from text.
  * @param text - The text to clean
- * @param options - Options for stripping behavior
  * @returns The cleaned text
  */
-export function stripToolCallXML(
-  text: string,
-  options: { preserveToolIndicators?: boolean } = {}
-): string {
+export function stripToolCallXML(text: string): string {
   let cleaned = text;
 
-  // Handle tool calls based on options
-  if (options.preserveToolIndicators) {
-    // Replace tool calls with visible indicators
-    const toolNames = extractToolNamesFromXML(text);
-    let toolIndex = 0;
-
-    // Remove complete tool calls and replace with indicators
-    cleaned = cleaned.replace(/<use_tool>[\s\S]*?<\/use_tool>/g, () => {
-      if (toolIndex < toolNames.length) {
-        const toolName = toolNames[toolIndex];
-        const displayName = getToolDisplayName(toolName);
-        toolIndex++;
-        return `\n[🔧 Tool call: ${displayName}]\n`;
-      }
-      return "";
-    });
-  } else {
-    // Remove all complete <use_tool>...</use_tool> blocks
-    cleaned = cleaned.replace(/<use_tool>[\s\S]*?<\/use_tool>/g, "");
-  }
+  // Remove all complete <use_tool>...</use_tool> blocks
+  cleaned = cleaned.replace(/<use_tool>[\s\S]*?<\/use_tool>/g, "");
 
   // Replace partial tool calls with calling message
   cleaned = cleaned.replace(/<use_tool>([\s\S]*)$/g, (match, partialContent) => {


### PR DESCRIPTION
This prevents tool call message becoming user-visible before the close tag is returned.




https://github.com/user-attachments/assets/ebad28dd-7958-4ae8-8fd6-48f7633ef769


<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a `stripToolCallXML` utility function for removing complete and partial tool call XML blocks from strings, along with associated tests to validate its functionality.

### Why are these changes being made?

This change is needed to enhance preprocessing of text data by eliminating tool call XML blocks, both complete and partial, which can clutter or confuse downstream processing workflows. The added tests ensure that this function behaves correctly in a variety of scenarios, including handling edge cases and options like preserving tool indicators. This approach provides a robust utility for maintaining clean and readable text outputs.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->