### PR TITLE
Remove think and action blocks from copy and insert

### DIFF
--- a/src/LLMProviders/chainRunner/utils/ThinkBlockStreamer.ts
+++ b/src/LLMProviders/chainRunner/utils/ThinkBlockStreamer.ts
@@ -26,7 +26,10 @@ export class ThinkBlockStreamer {
             this.fullResponse += "\n<think>";
             this.hasOpenThinkBlock = true;
           }
-          this.fullResponse += item.thinking;
+          // Guard against undefined thinking content
+          if (item.thinking !== undefined) {
+            this.fullResponse += item.thinking;
+          }
           this.updateCurrentAiMessage(this.fullResponse);
           return true; // Indicate we handled a thinking chunk
       }
@@ -49,7 +52,10 @@ export class ThinkBlockStreamer {
         this.fullResponse += "\n<think>";
         this.hasOpenThinkBlock = true;
       }
-      this.fullResponse += chunk.additional_kwargs.reasoning_content;
+      // Guard against undefined reasoning content
+      if (chunk.additional_kwargs.reasoning_content !== undefined) {
+        this.fullResponse += chunk.additional_kwargs.reasoning_content;
+      }
       return true; // Indicate we handled a thinking chunk
     }
     return false; // No thinking chunk handled

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -167,7 +167,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
       };
 
       const processThinkSection = (content: string): string => {
-        return processCollapsibleSection(content, "think", "Thought for a second", "Thinking...");
+        return processCollapsibleSection(content, "think", "Thought for a while", "Thinking...");
       };
 
       const processWriteToFileSection = (content: string): string => {

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -7,7 +7,7 @@ import { USER_SENDER } from "@/constants";
 import { cn } from "@/lib/utils";
 import { parseToolCallMarkers } from "@/LLMProviders/chainRunner/utils/toolCallParser";
 import { ChatMessage } from "@/types/message";
-import { insertIntoEditor } from "@/utils";
+import { cleanMessageForCopy, insertIntoEditor } from "@/utils";
 import { Bot, User } from "lucide-react";
 import { App, Component, MarkdownRenderer, MarkdownView, TFile } from "obsidian";
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -105,7 +105,8 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
       return;
     }
 
-    navigator.clipboard.writeText(message.message).then(() => {
+    const cleanedContent = cleanMessageForCopy(message.message);
+    navigator.clipboard.writeText(cleanedContent).then(() => {
       setIsCopied(true);
 
       setTimeout(() => {
@@ -543,7 +544,8 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
 
     const editor = leaf.view.editor;
     const hasSelection = editor.getSelection().length > 0;
-    insertIntoEditor(message.message, hasSelection);
+    const cleanedContent = cleanMessageForCopy(message.message);
+    insertIntoEditor(cleanedContent, hasSelection);
   };
 
   const renderMessageContent = () => {

--- a/src/utils.cleanMessageForCopy.test.ts
+++ b/src/utils.cleanMessageForCopy.test.ts
@@ -1,0 +1,110 @@
+import { cleanMessageForCopy } from "./utils";
+
+describe("cleanMessageForCopy", () => {
+  it("should remove Think blocks", () => {
+    const input = "Before text\n<think>This is my thought process</think>\nAfter text";
+    const expected = "Before text\n\nAfter text";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+
+  it("should remove writeToFile blocks wrapped in XML codeblocks", () => {
+    const input = `Some text before
+\`\`\`xml
+<writeToFile>
+<path>test.md</path>
+<content>File content here</content>
+</writeToFile>
+\`\`\`
+Some text after`;
+    const expected = "Some text before\n\nSome text after";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+
+  it("should remove standalone writeToFile blocks", () => {
+    const input = `Text before
+<writeToFile>
+<path>test.md</path>
+<content>File content</content>
+</writeToFile>
+Text after`;
+    const expected = "Text before\n\nText after";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+
+  it("should remove tool call markers", () => {
+    const input =
+      "Before\n<!--TOOL_CALL_START:123:localSearch:Local Search:🔍::true-->Searching...<!--TOOL_CALL_END:123:Found 5 results-->\nAfter";
+    const expected = "Before\n\nAfter";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+
+  it("should handle multiple blocks in one message", () => {
+    const input = `Start of message
+<think>First thought</think>
+Middle part
+<writeToFile><path>file.md</path><content>content</content></writeToFile>
+<!--TOOL_CALL_START:456:webSearch:Web Search:🌐::false-->Searching web<!--TOOL_CALL_END:456:Results-->
+End of message`;
+    const expected = "Start of message\n\nMiddle part\n\nEnd of message";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+
+  it("should clean up multiple consecutive newlines", () => {
+    const input = `Text\n\n\n\n\nMore text`;
+    const expected = "Text\n\nMore text";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+
+  it("should preserve normal content", () => {
+    const input = `# Heading
+This is a normal message with:
+- Bullet points
+- Code blocks: \`const x = 1;\`
+- **Bold** and *italic* text
+
+\`\`\`javascript
+function test() {
+  return true;
+}
+\`\`\`
+
+More content here.`;
+    expect(cleanMessageForCopy(input)).toBe(input);
+  });
+
+  it("should handle nested think blocks", () => {
+    const input =
+      "Before\n<think>Outer thought <think>Inner thought</think> back to outer</think>\nAfter";
+    // Since we're not handling nested blocks, the outer block will be removed but inner content remains
+    const expected = "Before\n back to outer</think>\nAfter";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+
+  it("should handle multiline content in blocks", () => {
+    const input = `Start
+<think>
+Line 1 of thought
+Line 2 of thought
+Line 3 of thought
+</think>
+End`;
+    const expected = "Start\n\nEnd";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+
+  it("should trim leading and trailing whitespace", () => {
+    const input = "\n\n  Content with spaces  \n\n";
+    const expected = "Content with spaces";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+
+  it("should handle empty message", () => {
+    expect(cleanMessageForCopy("")).toBe("");
+  });
+
+  it("should handle message with only blocks to remove", () => {
+    const input = "<think>Only a thought</think>";
+    const expected = "";
+    expect(cleanMessageForCopy(input)).toBe(expected);
+  });
+});


### PR DESCRIPTION
Fix composer for thinking models

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Remove Think and Action (writeToFile) blocks along with tool call markers from the copy and insert functionalities by implementing a new utility function `cleanMessageForCopy`.

### Why are these changes being made?
These changes are needed to prevent unnecessary metadata and tool-specific blocks from being included when messages are copied to the clipboard or inserted into the editor. This improves message clarity and user experience. The new utility function was created to handle various formats and ensures consistent behavior when processing chat messages.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->