### PR TITLE
Remove beta labels from Copilot Plus

### DIFF
--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -183,7 +183,7 @@ export function ChatControls({
               {selectedChain === ChainType.COPILOT_PLUS_CHAIN && (
                 <div className="tw-flex tw-items-center tw-gap-1">
                   <Sparkles className="tw-size-4" />
-                  copilot plus (beta)
+                  copilot plus
                 </div>
               )}
               {selectedChain === ChainType.PROJECT_CHAIN && "projects (alpha)"}
@@ -213,7 +213,7 @@ export function ChatControls({
               >
                 <div className="tw-flex tw-items-center tw-gap-1">
                   <Sparkles className="tw-size-4" />
-                  copilot plus (beta)
+                  copilot plus
                 </div>
               </DropdownMenuItem>
             ) : (
@@ -223,7 +223,7 @@ export function ChatControls({
                   onCloseProject?.();
                 }}
               >
-                copilot plus (beta)
+                copilot plus
                 <SquareArrowOutUpRight className="tw-size-3" />
               </DropdownMenuItem>
             )}
@@ -245,7 +245,7 @@ export function ChatControls({
                   onCloseProject?.();
                 }}
               >
-                copilot plus (beta)
+                copilot plus
                 <SquareArrowOutUpRight className="tw-size-3" />
               </DropdownMenuItem>
             )}

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils";
 const ChainType2Label: Record<ChainType, string> = {
   [ChainType.LLM_CHAIN]: "Chat",
   [ChainType.VAULT_QA_CHAIN]: "Vault QA (Basic)",
-  [ChainType.COPILOT_PLUS_CHAIN]: "Copilot Plus (beta)",
+  [ChainType.COPILOT_PLUS_CHAIN]: "Copilot Plus",
   [ChainType.PROJECT_CHAIN]: "Projects (alpha)",
 };
 

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -21,7 +21,7 @@ export function PlusSettings() {
   return (
     <section className="tw-flex tw-flex-col tw-gap-4 tw-rounded-lg tw-bg-secondary tw-p-4">
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-text-xl tw-font-bold">
-        <span>Copilot Plus (beta)</span>
+        <span>Copilot Plus</span>
         {isPlusUser && (
           <Badge variant="outline" className="tw-text-success">
             Active
@@ -35,8 +35,8 @@ export function PlusSettings() {
           image support, web search integration, exclusive chat and embedding models, and much more.
         </div>
         <div>
-          Currently in beta, Copilot Plus is evolving fast, with new features and improvements
-          rolling out regularly. Join now to secure the lowest price and get early access!
+          Copilot Plus is evolving fast, with new features and improvements rolling out regularly.
+          Join now to secure the lowest price and get early access!
         </div>
       </div>
       <div className="tw-flex tw-items-center tw-gap-2">


### PR DESCRIPTION
- Remove "(beta)" from Copilot Plus in all UI components
- Update PlusSettings.tsx heading and description
- Update BasicSettings.tsx ChainType label
- Update ChatControls.tsx dropdown menu items

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Remove all beta labels from Copilot Plus across the codebase.

### Why are these changes being made?
Copilot Plus has moved out of the beta phase to a stable release, and the removal of the beta labels reflects this update, ensuring consistency and accuracy in our user interface.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->