### PR TITLE
Update docs to make it clear that url processing is for user input only

### DIFF
--- a/src/cache/projectContextCache.ts
+++ b/src/cache/projectContextCache.ts
@@ -692,15 +692,15 @@ export class ProjectContextCache {
     for (const filePath in cache.fileContexts) {
       const file = this.vault.getAbstractFileByPath(filePath);
 
-        // If file no longer exists or doesn't match patterns, remove its reference
-        if (!(file instanceof TFile) || !shouldIndexFile(file, inclusions, exclusions, true)) {
-          // Note: We don't remove from fileCache to preserve content for future use
-          removedCount++;
-        } else {
-          // Keep the file reference if it still matches
-          updatedFileContexts[filePath] = cache.fileContexts[filePath];
-        }
+      // If file no longer exists or doesn't match patterns, remove its reference
+      if (!(file instanceof TFile) || !shouldIndexFile(file, inclusions, exclusions, true)) {
+        // Note: We don't remove from fileCache to preserve content for future use
+        removedCount++;
+      } else {
+        // Keep the file reference if it still matches
+        updatedFileContexts[filePath] = cache.fileContexts[filePath];
       }
+    }
 
     // Only update if we actually removed something
     if (removedCount > 0) {

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -50,6 +50,10 @@ export class ContextProcessor {
   /**
    * Processes context notes, excluding any already handled by custom prompts.
    *
+   * NOTE: This method reads and includes note content as-is. URLs within note content
+   * are NOT extracted or processed with url4llm. Only URLs directly typed in the user's
+   * chat input are processed, not URLs that happen to be in the content of context notes.
+   *
    * @param excludedNotePaths A set of file paths that should be skipped.
    * @param fileParserManager
    * @param vault

--- a/src/core/ContextManager.ts
+++ b/src/core/ContextManager.ts
@@ -62,6 +62,10 @@ export class ContextManager {
       );
 
       // 2. Extract URLs and process them (for Copilot Plus chain)
+      // IMPORTANT: Only process URLs from the user's direct chat input message,
+      // NOT from the content of context notes. This ensures url4llm is only called
+      // for URLs explicitly typed by the user in the chat, similar to how YouTube
+      // transcription only processes YouTube URLs from user input.
       const urlContextAddition =
         chainType === ChainType.COPILOT_PLUS_CHAIN
           ? await this.mention.processUrls(processedMessage)

--- a/src/mentions/Mention.ts
+++ b/src/mentions/Mention.ts
@@ -53,7 +53,16 @@ export class Mention {
     }
   }
 
-  // For non-youtube URLs
+  /**
+   * Process URLs from user input text for url4llm endpoint.
+   *
+   * IMPORTANT: This method should ONLY be called with the user's direct chat input,
+   * NOT with content from context notes. This ensures url4llm is only called for
+   * URLs explicitly typed by the user, similar to YouTube transcript processing.
+   *
+   * @param text The user's chat input text
+   * @returns Processed URL context and any errors
+   */
   async processUrls(text: string): Promise<{
     urlContext: string;
     imageUrls: string[];


### PR DESCRIPTION
- Updated ContextProcessor to clarify that note content is included as-is without URL extraction.
- Modified ContextManager and Mention classes to ensure only URLs from user input are processed, improving clarity on URL handling.
- Added documentation to emphasize the importance of processing URLs exclusively from user chat input, aligning with existing functionality.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Clarify in the documentation and code comments that URL processing using `url4llm` is intended exclusively for URLs received from user input in chats, and not from URLs embedded in context notes.

### Why are these changes being made?

The changes are made to ensure clear differentiation between user-input URLs and URLs that are part of context notes. This prevents undesired processing of URLs in notes, aligning the behavior of URL processing with YouTube link transcription, which only processes links explicitly entered by users, enhancing clarity and preventing unintentional URL processing.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->