### PR TITLE
Improve live mode check for quick command

### DIFF
--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -3,7 +3,6 @@ import { getCachedCustomCommands } from "@/commands/state";
 import { COMMAND_IDS } from "@/constants";
 import { Menu } from "obsidian";
 import { CustomCommand } from "./type";
-import { isLivePreviewModeOn } from "@/utils";
 
 export function registerContextMenu(menu: Menu) {
   // Create the main "Copilot" submenu
@@ -23,13 +22,11 @@ export function registerContextMenu(menu: Menu) {
       });
     });
 
-    if (isLivePreviewModeOn()) {
-      submenu.addItem((subItem: any) => {
-        subItem.setTitle("Trigger quick command").onClick(() => {
-          (app as any).commands.executeCommandById(`copilot:${COMMAND_IDS.TRIGGER_QUICK_COMMAND}`);
-        });
+    submenu.addItem((subItem: any) => {
+      subItem.setTitle("Trigger quick command").onClick(() => {
+        (app as any).commands.executeCommandById(`copilot:${COMMAND_IDS.TRIGGER_QUICK_COMMAND}`);
       });
-    }
+    });
 
     // Get custom commands
     const commands = getCachedCustomCommands();

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,7 +15,7 @@ import CopilotPlugin from "@/main";
 import { getAllQAMarkdownContent } from "@/search/searchUtils";
 import { CopilotSettings, getSettings, updateSetting } from "@/settings/model";
 import { SelectedTextContext } from "@/types/message";
-import { isLivePreviewModeOn } from "@/utils";
+import { isSourceModeOn } from "@/utils";
 import { Editor, MarkdownView, Notice, TFile } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import { COMMAND_IDS, COMMAND_NAMES, CommandId } from "../constants";
@@ -104,13 +104,13 @@ export function registerCommands(
     const activeView = plugin.app.workspace.getActiveViewOfType(MarkdownView);
 
     if (checking) {
-      // Return true only if we're in live preview mode
-      return !!(isLivePreviewModeOn() && activeView && activeView.editor);
+      // Return true only if we're not in source mode
+      return !!(!isSourceModeOn() && activeView && activeView.editor);
     }
 
     // Need to check this again because it can still be triggered via shortcut.
-    if (!isLivePreviewModeOn()) {
-      new Notice("Quick commands are only available in live preview mode.");
+    if (isSourceModeOn()) {
+      new Notice("Quick command is not available in source mode.");
       return false;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -954,8 +954,12 @@ export async function withSuppressedTokenWarnings<T>(fn: () => Promise<T>): Prom
 }
 
 /**
- * Check if the current Obsidian editor setting is in live preview mode
+ * Check if the current Obsidian editor setting is in source mode
  */
-export function isLivePreviewModeOn(): boolean {
-  return !!(app.vault as any).config?.livePreview;
+export function isSourceModeOn(): boolean {
+  const view = app.workspace.getActiveViewOfType(MarkdownView);
+  if (!view) return true;
+
+  const state = view.getState() as { source?: boolean };
+  return state.source === true;
 }


### PR DESCRIPTION
Use the active view state to detect whether the user is in source mode or live preview mode. Previously, users could update the view settings, and the vault level check was not enough.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor live preview mode checks to source mode checks across the codebase for the quick command feature.

### Why are these changes being made?

This change aligns the command availability with the editor's source mode rather than live preview mode to enhance user experience and consistency. This approach ensures that the quick command cannot be triggered when in source mode, which was a necessary adjustment per user feedback and functionality needs.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->