### PR TITLE
fix(utils): Fix handling of headers in the safeFetch util

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -512,7 +512,8 @@ export function extractAllYoutubeUrls(text: string): string[] {
  * https://forum.obsidian.md/t/support-streaming-the-request-and-requesturl-response-body/87381 */
 export async function safeFetch(url: string, options: RequestInit = {}): Promise<Response> {
   // Initialize headers if not provided
-  const headers = options.headers ? { ...options.headers } : {};
+  const normalizedHeaders = new Headers(options.headers);
+  const headers = Object.fromEntries(normalizedHeaders.entries());
 
   // Remove content-length if it exists
   delete (headers as Record<string, string>)["content-length"];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "esModuleInterop": true,
     "strictNullChecks": true,
     "types": ["jest"],
-    "lib": ["DOM", "ES5", "ES6", "ES7", "ES2022"]
+    "lib": ["DOM", "DOM.Iterable", "ES5", "ES6", "ES7", "ES2022"]
   },
   "include": ["**/*.ts", "src", "typings/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Fixes the issue, where all requests to custom models using CORS failed with 403.

The underlying problem was that headers were always treated as plain objects, which is only one of the possible options to define headers in the `RequestInit` interface. If case headers were an instance of the `Headers` class, their conversion to a plain object for Obsidian's `requestUrl` silently failed, effectively making them always empty.

P.S. I added the `DOM.Iterable` lib to the typescript configuration because [`Headers.entries()`](https://developer.mozilla.org/en-US/docs/Web/API/Headers/entries) is defined there.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix the handling of request headers in the `safeFetch` utility function by normalizing the headers, and update the `tsconfig.json` to include `DOM.Iterable` in the `lib` list.

### Why are these changes being made?

The current implementation did not properly handle request headers, which could cause issues with certain requests where headers need to be standardized. By normalizing the headers using the `Headers` constructor, we ensure consistent handling. The update to the `tsconfig.json` makes the TypeScript configuration more comprehensive by supporting iterable operations on DOM collections, which might be required by new code logic.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->