### PR TITLE
fix: AI response streaming UI broken with react error 409

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -741,4 +741,5 @@ export const EVENT_NAMES = {
 export enum ABORT_REASON {
   USER_STOPPED = "user-stopped",
   NEW_CHAT = "new-chat",
+  UNMOUNT = "component-unmount",
 }


### PR DESCRIPTION
CC: 

The error 409 happens when React tries to update a component that has been unmounted. Looking at the code, I see that
  updateCurrentAiMessage is being called from the streaming process (in ThinkBlockStreamer and other places), and this callback is directly
  connected to setCurrentAiMessage in the Chat component.

  The problem occurs when:
  1. The Chat component unmounts (e.g., user navigates away, closes the chat, or switches views)
  2. The streaming is still in progress and tries to call updateCurrentAiMessage
  3. This triggers setCurrentAiMessage on an unmounted component, causing React error 409
  
