### PR TITLE
Update default embedding requests per minute setting to 60

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -705,7 +705,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   groqApiKey: "",
   activeModels: BUILTIN_CHAT_MODELS,
   activeEmbeddingModels: BUILTIN_EMBEDDING_MODELS,
-  embeddingRequestsPerMin: 90,
+  embeddingRequestsPerMin: 60,
   embeddingBatchSize: 16,
   disableIndexOnMobile: true,
   showSuggestedPrompts: true,

--- a/src/settings/v2/components/QASettings.tsx
+++ b/src/settings/v2/components/QASettings.tsx
@@ -176,7 +176,7 @@ export const QASettings: React.FC = () => {
               <SettingItem
                 type="slider"
                 title="Requests per Minute"
-                description="Default is 30. Decrease if you are rate limited by your embedding provider."
+                description="Default is 60. Decrease if you are rate limited by your embedding provider."
                 min={10}
                 max={60}
                 step={10}


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the default setting for embedding requests per minute from 90 to 60 and modify the description in the QASettings component to reflect this change.

### Why are these changes being made?

The changes are being made to adjust the default request rate to better align with typical rate limits imposed by embedding providers, which improves usability for users by minimizing the chance of rate limiting. The new value provides a balance between performance and compliance with external service constraints.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->