### PR TITLE
Update 'replaceInFile' tool description to indicate experimental status and remove it from default tool list

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -745,7 +745,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
     "pomodoro",
     "youtubeTranscription",
     "writeToFile",
-    "replaceInFile",
   ],
   reasoningEffort: DEFAULT_MODEL_SETTING.REASONING_EFFORT,
   verbosity: DEFAULT_MODEL_SETTING.VERBOSITY,

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -216,7 +216,7 @@ Example usage:
       id: "replaceInFile",
       displayName: "Replace in File (Experimental)",
       description:
-        "Make targeted changes to existing files using SEARCH/REPLACE blocks. (This tool is experimental and may only work well with very advanced models like Gemini Flash 2.5 or GPT-5)",
+        "Make targeted changes to existing files using SEARCH/REPLACE blocks. (This tool is experimental and may not work reliably)",
       category: "file",
       requiresVault: true,
       customPromptInstructions: `For replaceInFile:

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -214,8 +214,9 @@ Example usage:
     tool: replaceInFileTool,
     metadata: {
       id: "replaceInFile",
-      displayName: "Replace in File",
-      description: "Make targeted changes to existing files using SEARCH/REPLACE blocks",
+      displayName: "Replace in File (Experimental)",
+      description:
+        "Make targeted changes to existing files using SEARCH/REPLACE blocks. (This tool is experimental and may only work well with very advanced models like Gemini Flash 2.5 or GPT-5)",
       category: "file",
       requiresVault: true,
       customPromptInstructions: `For replaceInFile:


### PR DESCRIPTION
'replaceInFile' has been reported being unreliable on copilot-flash. Disable it by default and mark it as experimental until we figure out a better approach.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the 'replaceInFile' tool description to indicate its experimental status and remove it from the default tool list.

### Why are these changes being made?

The 'replaceInFile' tool is currently experimental and may only function properly with very advanced models, thus it's being removed from the default settings to prevent potential issues. Updating the description to reflect its experimental nature provides clarity to users and sets proper expectations regarding its current capabilities.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->