### PR TITLE
Restrict replaceInFile for large files

### DIFF
--- a/src/LLMProviders/chainRunner/utils/modelAdapter.ts
+++ b/src/LLMProviders/chainRunner/utils/modelAdapter.ts
@@ -230,13 +230,13 @@ EXAMPLE 1 - User says "fix the typo 'teh' to 'the' in my note":
 <use_tool>
 <name>replaceInFile</name>
 <path>path/to/note.md</path>
-<diff>\`\`\`
+<diff>
 ------- SEARCH
 teh
 =======
 the
 +++++++ REPLACE
-\`\`\`</diff>
+</diff>
 </use_tool>"
 
 EXAMPLE 2 - User says "add item 4 to the list":
@@ -246,7 +246,7 @@ EXAMPLE 2 - User says "add item 4 to the list":
 <use_tool>
 <name>replaceInFile</name>
 <path>path/to/file.md</path>
-<diff>\`\`\`
+<diff>
 ------- SEARCH
 - Item 1
 - Item 2
@@ -257,7 +257,7 @@ EXAMPLE 2 - User says "add item 4 to the list":
 - Item 3
 - Item 4
 +++++++ REPLACE
-\`\`\`</diff>
+</diff>
 </use_tool>"
 
 ❌ WRONG (DO NOT DO THIS):

--- a/src/integration_tests/AgentPrompt.test.ts
+++ b/src/integration_tests/AgentPrompt.test.ts
@@ -135,7 +135,7 @@ async function generateSystemPrompt(availableTools: any[]): Promise<string> {
   // Create a mock Gemini model to get the adapter
   const { ChatGoogleGenerativeAI } = await import("@langchain/google-genai");
   const mockModel = new ChatGoogleGenerativeAI({
-    model: "gemini-2.5-flash",
+    model: "gemini-2.5-flash-lite",
     apiKey: process.env.GEMINI_API_KEY || "",
   });
 
@@ -299,10 +299,14 @@ describe("Agent Prompt Integration Test - Direct Model Testing", () => {
       expectedCalls: [
         {
           toolName: "replaceInFile",
+          // Check if args.diff contains the correct search text
           argumentValidator: (args) => {
             expect(args).toEqual(
               expect.objectContaining({
                 path: "test.md",
+                diff: expect.stringContaining(
+                  `------- SEARCH\nLondon, UK - A city of kings and punks, rain and rebellion. London blends royal heritage with cutting-edge creativity, from the Tower of London to Shoreditch street art.\n=======`
+                ),
               })
             );
           },

--- a/src/tools/ComposerTools.ts
+++ b/src/tools/ComposerTools.ts
@@ -191,7 +191,7 @@ const replaceInFileTool = createTool({
       let modifiedContent = originalContent;
 
       // Reject this tool if the original content is small
-      const MIN_FILE_SIZE_FOR_REPLACE = 3000; // Files smaller than 3KB should use writeToFile for simplicity
+      const MIN_FILE_SIZE_FOR_REPLACE = 3000;
       if (originalContent.length < MIN_FILE_SIZE_FOR_REPLACE) {
         return `File is too small to use this tool. Please use writeToFile instead.`;
       }

--- a/src/tools/ComposerTools.ts
+++ b/src/tools/ComposerTools.ts
@@ -113,13 +113,11 @@ const replaceInFileSchema = z.object({
   diff: z.string()
     .describe(`(Required) One or more SEARCH/REPLACE blocks. Each block MUST follow this exact format with these exact markers:
 
-\`\`\`
 ------- SEARCH
 [exact content to find, including all whitespace and indentation]
 =======
 [new content to replace with]
 +++++++ REPLACE
-\`\`\`
 
 WHEN TO USE THIS TOOL vs writeToFile:
 - Use replaceInFile for: small edits, fixing typos, updating specific sections, targeted changes
@@ -127,14 +125,12 @@ WHEN TO USE THIS TOOL vs writeToFile:
 
 CRITICAL RULES:
 1. SEARCH content must match EXACTLY - every character, space, and line break
-2. Always wrap blocks in triple backticks (\`\`\`)
-3. Use the exact markers: "------- SEARCH", "=======", "+++++++ REPLACE"
-4. For multiple changes, include multiple SEARCH/REPLACE blocks in order
-5. Keep blocks concise - include only the lines being changed plus minimal context
+2. Use the exact markers: "------- SEARCH", "=======", "+++++++ REPLACE"
+3. For multiple changes, include multiple SEARCH/REPLACE blocks in order
+4. Keep blocks concise - include only the lines being changed plus minimal context
 
 COMMON MISTAKES TO AVOID:
 - Wrong: Using different markers like "---- SEARCH" or "SEARCH -------"
-- Wrong: Forgetting the triple backticks
 - Wrong: Including too many unchanged lines
 - Wrong: Not matching whitespace/indentation exactly`),
 });
@@ -182,7 +178,7 @@ function replaceWithLineEndingAwareness(
 
 const replaceInFileTool = createTool({
   name: "replaceInFile",
-  description: `Request to replace sections of content in an existing file using SEARCH/REPLACE blocks that define exact changes to specific parts of the file. This tool should be used when you need to make targeted changes to specific parts of a file.`,
+  description: `Request to replace sections of content in an existing file using SEARCH/REPLACE blocks that define exact changes to specific parts of the file. This tool should be used when you need to make targeted changes to specific parts of a LARGE file.`,
   schema: replaceInFileSchema,
   handler: async ({ path, diff }: { path: string; diff: string }) => {
     const file = app.vault.getAbstractFileByPath(path);
@@ -195,6 +191,11 @@ const replaceInFileTool = createTool({
       const originalContent = await app.vault.read(file);
       let modifiedContent = originalContent;
 
+      // Reject this tool if the original content is small
+      if (originalContent.length < 3000) {
+        return `File is too small to use this tool. Please use writeToFile instead.`;
+      }
+
       // Parse SEARCH/REPLACE blocks from diff
       const searchReplaceBlocks = parseSearchReplaceBlocks(diff);
 
@@ -206,17 +207,23 @@ const replaceInFileTool = createTool({
 
       // Apply each SEARCH/REPLACE block in order
       for (const block of searchReplaceBlocks) {
-        const { searchText, replaceText } = block;
+        let { searchText, replaceText } = block;
 
         // Check if the search text exists in the current content (with line ending normalization)
         const normalizedContent = normalizeLineEndings(modifiedContent);
         const normalizedSearchText = normalizeLineEndings(searchText);
 
         if (!normalizedContent.includes(normalizedSearchText)) {
-          logWarn(
-            `Search text not found in file ${path}. Block ${changesApplied + 1}: "${searchText}".`
-          );
-          continue;
+          // Handle corner case where the search text is at the end of the file
+          if (normalizedContent.includes(normalizedSearchText.trimEnd())) {
+            searchText = searchText.trimEnd();
+            replaceText = replaceText.trimEnd();
+          } else {
+            logWarn(
+              `Search text not found in file ${path}. Block ${changesApplied + 1}: "${searchText}".`
+            );
+            continue;
+          }
         }
 
         // Replace all occurrences using line ending aware replacement

--- a/src/tools/ComposerTools.ts
+++ b/src/tools/ComposerTools.ts
@@ -1,4 +1,3 @@
-import { logWarn } from "@/logger";
 import { Notice, TFile } from "obsidian";
 import { APPLY_VIEW_TYPE } from "@/components/composer/ApplyView";
 import { diffTrimmedLines } from "diff";
@@ -192,7 +191,8 @@ const replaceInFileTool = createTool({
       let modifiedContent = originalContent;
 
       // Reject this tool if the original content is small
-      if (originalContent.length < 3000) {
+      const MIN_FILE_SIZE_FOR_REPLACE = 3000; // Files smaller than 3KB should use writeToFile for simplicity
+      if (originalContent.length < MIN_FILE_SIZE_FOR_REPLACE) {
         return `File is too small to use this tool. Please use writeToFile instead.`;
       }
 
@@ -219,10 +219,7 @@ const replaceInFileTool = createTool({
             searchText = searchText.trimEnd();
             replaceText = replaceText.trimEnd();
           } else {
-            logWarn(
-              `Search text not found in file ${path}. Block ${changesApplied + 1}: "${searchText}".`
-            );
-            continue;
+            return `Search text not found in file ${path} : "${searchText}".`;
           }
         }
 

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -226,7 +226,7 @@ Example usage:
 <use_tool>
 <name>replaceInFile</name>
 <path>notes/meeting.md</path>
-<diff>\`\`\`
+<diff>
 ------- SEARCH
 ## Attendees
 - John Smith
@@ -237,7 +237,7 @@ Example usage:
 - Jane Doe
 - Bob Johnson
 +++++++ REPLACE
-\`\`\`</diff>
+</diff>
 </use_tool>`,
     },
   },


### PR DESCRIPTION
`replaceInFile` is a complex tool and currently has some reliability issues. For now, let’s enable it only for large files while we work on improvements.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove triple backticks from `replaceInFile` tool's diff schema and restrict the tool's usage to files larger than 3000 characters.

### Why are these changes being made?

These changes simplify the diff schema formatting and ensure that the `replaceInFile` tool is only used for large files, promoting more efficient usage of the tool by steering small file modifications to use `writeToFile` instead. This helps prevent inappropriate tool use and optimizes performance in handling large files.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->