### PR TITLE
Fix context not being sent to LLM for `[[note]]` references

### DIFF
--- a/src/LLMProviders/chainRunner/LLMChainRunner.ts
+++ b/src/LLMProviders/chainRunner/LLMChainRunner.ts
@@ -47,9 +47,17 @@ export class LLMChainRunner extends BaseChainRunner {
 
       // Add current user message - support multimodal content if available
       if (userMessage.content && Array.isArray(userMessage.content)) {
+        // For multimodal messages with images, replace the text content with processed text
+        const updatedContent = userMessage.content.map((item: any) => {
+          if (item.type === "text") {
+            // Use processed message text that includes context
+            return { ...item, text: userMessage.message };
+          }
+          return item;
+        });
         messages.push({
           role: "user",
-          content: userMessage.content,
+          content: updatedContent,
         });
       } else {
         messages.push({

--- a/src/commands/customCommandUtils.ts
+++ b/src/commands/customCommandUtils.ts
@@ -412,7 +412,15 @@ export async function processPrompt(
         const ctime = stats ? new Date(stats.ctime).toISOString() : "Unknown";
         const mtime = stats ? new Date(stats.mtime).toISOString() : "Unknown";
 
-        const noteContext = `<${NOTE_CONTEXT_PROMPT_TAG}>\n<title>${noteFile.basename}</title>\n<path>${noteFile.path}</path>\n<ctime>${ctime}</ctime>\n<mtime>${mtime}</mtime>\n<content>\n${noteContent}\n</content>\n</${NOTE_CONTEXT_PROMPT_TAG}>`;
+        const noteContext = `<${NOTE_CONTEXT_PROMPT_TAG}>
+<title>${noteFile.basename}</title>
+<path>${noteFile.path}</path>
+<ctime>${ctime}</ctime>
+<mtime>${mtime}</mtime>
+<content>
+${noteContent}
+</content>
+</${NOTE_CONTEXT_PROMPT_TAG}>`;
         if (additionalInfo) {
           additionalInfo += `\n\n`;
         }


### PR DESCRIPTION
- Update `LLMChainRunner` to use processed message text (with context) for multimodal content
- This ensures that when using `[[note title]]` syntax, the note content is properly included in LLM requests

Closes #1763.