### PR TITLE
Switch to the new file when creating files with composer tools.

### DIFF
--- a/src/tools/ComposerTools.ts
+++ b/src/tools/ComposerTools.ts
@@ -6,10 +6,16 @@ import { z } from "zod";
 import { createTool } from "./SimpleTool";
 
 async function show_preview(file_path: string, content: string): Promise<ApplyViewResult> {
-  const file = app.vault.getAbstractFileByPath(file_path);
+  let file = app.vault.getAbstractFileByPath(file_path);
 
   // Check if the current active note is the same as the target note
   const activeFile = app.workspace.getActiveFile();
+  // Create the file with empty content if it doesn't exist
+  if (!file) {
+    await app.vault.create(file_path, "");
+    file = app.vault.getAbstractFileByPath(file_path);
+  }
+
   if (file && (!activeFile || activeFile.path !== file_path)) {
     // If not, open the target file in the current leaf
     await app.workspace.getLeaf().openFile(file as TFile);


### PR DESCRIPTION
This is address this feedback: https://discord.com/channels/1182847556032659546/1411282005714534451/1411282005714534451

Right now composer will only switch to existing file when displaying the preview. We should do the same for new file.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify `ComposerTools.ts` to automatically switch to a newly created file when using composer tools by creating the file with empty content if it does not exist.

### Why are these changes being made?

This change addresses the issue where a new file was not being switched to upon creation, improving the workflow in the composer tools by ensuring that the newly created file is opened and displayed for the user, enhancing their productivity and experience.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->