### PR TITLE
FIX: Improve the regex for composer codeblock

### DIFF
--- a/.cursor/rules/coding-rule.mdc
+++ b/.cursor/rules/coding-rule.mdc
@@ -1,0 +1,6 @@
+---
+description:
+globs:
+alwaysApply: true
+---
+Always use functions from logger.ts for logging

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -175,7 +175,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
         const unwrapXmlCodeblocks = (text: string): string => {
           // Pattern to match XML codeblocks that contain writeToFile tags
           const xmlCodeblockRegex =
-            /```xml\s*([\s\S]*?<writeToFile>[\s\S]*?<\/writeToFile>[\s\S]*?)\s*```/g;
+            /```(?:xml)?\s*([\s\S]*?<writeToFile>[\s\S]*?<\/writeToFile>[\s\S]*?)\s*```/g;
 
           return text.replace(xmlCodeblockRegex, (match, xmlContent) => {
             // Extract just the content inside the codeblock and return it without the codeblock wrapper

--- a/src/tools/ComposerTools.ts
+++ b/src/tools/ComposerTools.ts
@@ -4,6 +4,7 @@ import { diffTrimmedLines } from "diff";
 import { ApplyViewResult } from "@/types";
 import { z } from "zod";
 import { createTool } from "./SimpleTool";
+import { logError } from "@/logger";
 
 async function show_preview(file_path: string, content: string): Promise<ApplyViewResult> {
   let file = app.vault.getAbstractFileByPath(file_path);
@@ -20,7 +21,7 @@ async function show_preview(file_path: string, content: string): Promise<ApplyVi
       if (maybeNowExists && maybeNowExists instanceof TFile) {
         file = maybeNowExists;
       } else {
-        console.error(`Failed to create file at ${file_path}`, error);
+        logError(`Failed to create file: ${file_path}`, error);
         new Notice(`Failed to create file: ${file_path}`);
         return "failed";
       }


### PR DESCRIPTION
In in non-agent mode, the composer code block can be either 


\`\`\`xml
CODE BLOCK
\`\`\`


or
\`\`\`
CODE BLOCK
\`\`\`

We need to support both

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Improve the regex for matching composer codeblocks, enforce consistent logging via `logger.ts`, and update versioning to reflect accurate package information.

### Why are these changes being made?

The regex update allows for more flexible XML codeblock matching in `ChatSingleMessage.tsx`, the use of `logger.ts` standardizes error logging in `ComposerTools.ts` improving maintainability, and the versioning adjustments correct a previous oversight in `manifest.json`, `package.json`, and `versions.json` to ensure consistency and accuracy in version tracking.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->