### PR TITLE
fix: Optimized the height of the modal box and the display of the close button on mobile devices.

### DIFF
--- a/src/settings/v2/components/ModelEditDialog.tsx
+++ b/src/settings/v2/components/ModelEditDialog.tsx
@@ -18,7 +18,7 @@ import {
 import { getSettings } from "@/settings/model";
 import { debounce, getProviderInfo, getProviderLabel } from "@/utils";
 import { HelpCircle } from "lucide-react";
-import { App, Modal } from "obsidian";
+import { App, Modal, Platform } from "obsidian";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { createRoot, Root } from "react-dom/client";
 import { ParameterControl } from "@/components/ui/parameter-controls";
@@ -430,7 +430,11 @@ export class ModelEditModal extends Modal {
   }
 
   onOpen() {
-    const { contentEl } = this;
+    const { contentEl, modalEl } = this;
+    // It occupies only 80% of the height, leaving a clickable blank area to prevent the close icon from malfunctioning.
+    if (Platform.isMobile) {
+      modalEl.style.height = "80%";
+    }
     this.root = createRoot(contentEl);
 
     const handleUpdate = (

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -871,3 +871,8 @@ If your plugin does not need CSS, delete this file.
   color: var(--text-error);
   opacity: 1;
 }
+
+/* Maybe ob's error removed the hierarchy, so add hierarchy to the modal box on mobile for now */
+.is-phone .modal .modal-close-button {
+  z-index: var(--layer-modal);
+}


### PR DESCRIPTION
## Fix: Mobile modal height and close button z-index issues

**Changes:**
- Limit modal height to 80% on mobile to prevent close button malfunction
- Add z-index for mobile modal close button visibility

**Files:**
- ModelEditDialog.tsx - Modal height constraint
- tailwind.css - Close button z-index fix

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Optimize the height of the modal box to occupy 80% and adjust the z-index of the close button for mobile devices to prevent display issues.

### Why are these changes being made?

These changes address a display inconsistency on mobile devices where the modal's close button was malfunctioning due to excessive height, and the lack of sufficient z-index hierarchy caused it to be obscured. Establishing clear styles ensures better user experience and functionality.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->