### PR TITLE
Make AI chat title optional

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -703,6 +703,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   defaultSaveFolder: DEFAULT_CHAT_HISTORY_FOLDER,
   defaultConversationTag: "copilot-conversation",
   autosaveChat: false,
+  generateAIChatTitleOnSave: true,
   includeActiveNoteAsContext: true,
   defaultOpenArea: DEFAULT_OPEN_AREA.VIEW,
   customPromptsFolder: DEFAULT_CUSTOM_PROMPTS_FOLDER,

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -54,8 +54,12 @@ export class ChatPersistenceManager {
         const frontmatter = this.app.metadataCache.getFileCache(existingFile)?.frontmatter;
         topic = frontmatter?.topic;
       } else {
-        // If new file, generate AI topic
-        topic = await this.generateAITopic(messages);
+        // If new file, generate AI topic only if enabled in settings
+        if (settings.generateAIChatTitleOnSave) {
+          topic = await this.generateAITopic(messages);
+        } else {
+          topic = undefined; // fallback to first 10 words will be used in filename
+        }
       }
 
       const fileName = this.generateFileName(messages, firstMessageEpoch, topic);

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -75,6 +75,11 @@ export interface CopilotSettings {
   defaultSaveFolder: string;
   defaultConversationTag: string;
   autosaveChat: boolean;
+  /**
+   * When enabled, generate a short AI title for chat notes on save.
+   * When disabled (default), use the first 10 words of the first user message.
+   */
+  generateAIChatTitleOnSave: boolean;
   includeActiveNoteAsContext: boolean;
   customPromptsFolder: string;
   indexVaultToVectorStore: string;
@@ -258,6 +263,11 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   // Ensure includeActiveNoteAsContext has a default value
   if (typeof sanitizedSettings.includeActiveNoteAsContext !== "boolean") {
     sanitizedSettings.includeActiveNoteAsContext = DEFAULT_SETTINGS.includeActiveNoteAsContext;
+  }
+
+  // Ensure generateAIChatTitleOnSave has a default value
+  if (typeof sanitizedSettings.generateAIChatTitleOnSave !== "boolean") {
+    sanitizedSettings.generateAIChatTitleOnSave = DEFAULT_SETTINGS.generateAIChatTitleOnSave;
   }
 
   // Ensure passMarkdownImages has a default value

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -345,6 +345,14 @@ export const BasicSettings: React.FC = () => {
 
           <SettingItem
             type="switch"
+            title="Generate AI Chat Title on Save"
+            description="When enabled, uses an AI model to generate a concise title for saved chat notes. When disabled, uses the first 10 words of the first user message."
+            checked={settings.generateAIChatTitleOnSave}
+            onCheckedChange={(checked) => updateSetting("generateAIChatTitleOnSave", checked)}
+          />
+
+          <SettingItem
+            type="switch"
             title="Include Current Note in Context Menu"
             description="Automatically include the current note in the chat context menu by default when sending messages to the AI."
             checked={settings.includeActiveNoteAsContext}


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce an optional setting for generating AI chat titles upon save, with the default behavior using the first ten words of the first user message if the setting is disabled.

### Why are these changes being made?

This change provides users with greater flexibility and control over how their chat notes are titled upon saving. The default behavior leverages the first ten words for simplicity, while the optional AI-generated titles offer a more descriptive and dynamic alternative, accommodating different user preferences.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->