### PR TITLE
feat: conditionally initialize VectorStoreManager

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -83,7 +83,7 @@ export default class CopilotPlugin extends Plugin {
     // Initialize ProjectManager
     this.projectManager = ProjectManager.getInstance(this.app, this);
 
-    // Initialize VectorStoreManager
+    // Always construct VectorStoreManager; it internally no-ops when semantic search is disabled
     this.vectorStoreManager = VectorStoreManager.getInstance();
 
     // Initialize FileParserManager early with other core services

--- a/src/search/vectorStoreManager.ts
+++ b/src/search/vectorStoreManager.ts
@@ -61,6 +61,11 @@ export default class VectorStoreManager {
   }
 
   private async initialize(): Promise<void> {
+    // Do not initialize or show notices if semantic search is disabled
+    const settings = getSettings();
+    if (!settings.enableSemanticSearchV3) {
+      return;
+    }
     try {
       let retries = 3;
       while (retries > 0) {


### PR DESCRIPTION
- Initialize VectorStoreManager only when semantic search is enabled.
- Disable relevant notes caching when semantic search is turned off.
- Update UI message to inform users that semantic search must be enabled to use relevant notes feature.
- Prevent initialization of VectorStoreManager if semantic search is disabled.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Conditionally initialize and gate all semantic-search-related features behind the enableSemanticSearchV3 flag, including VectorStoreManager, relevant notes retrieval, and related UI messaging.

### Why are these changes being made?
Respect the semantic search setting and avoid loading related services when disabled. This reduces startup overhead and prevents confusing UI when the feature is off.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->