### PR TITLE
Move copilot-plus-flash and copilot plus embedding models to models.brevilabs

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -1,6 +1,6 @@
 import { CustomModel, getModelKey, ModelConfig } from "@/aiParams";
 import {
-  BREVILABS_API_BASE_URL,
+  BREVILABS_MODELS_BASE_URL,
   BUILTIN_CHAT_MODELS,
   ChatModelProviders,
   ProviderInfo,
@@ -284,7 +284,7 @@ export default class ChatModelManager {
         modelName: modelName,
         apiKey: await getDecryptedKey(settings.plusLicenseKey),
         configuration: {
-          baseURL: BREVILABS_API_BASE_URL,
+          baseURL: BREVILABS_MODELS_BASE_URL,
           fetch: customModel.enableCors ? safeFetch : undefined,
         },
       },

--- a/src/LLMProviders/embeddingManager.ts
+++ b/src/LLMProviders/embeddingManager.ts
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { CustomModel } from "@/aiParams";
-import { BREVILABS_API_BASE_URL, EmbeddingModelProviders } from "@/constants";
+import { BREVILABS_MODELS_BASE_URL, EmbeddingModelProviders } from "@/constants";
 import { getDecryptedKey } from "@/encryptionService";
 import { CustomError } from "@/error";
 import { getModelKeyFromModel, getSettings, subscribeToSettingsChange } from "@/settings/model";
-import { BrevilabsClient } from "./brevilabsClient";
 import { err2String, safeFetch } from "@/utils";
 import { CohereEmbeddings } from "@langchain/cohere";
 import { Embeddings } from "@langchain/core/embeddings";
@@ -12,6 +11,7 @@ import { GoogleGenerativeAIEmbeddings } from "@langchain/google-genai";
 import { OllamaEmbeddings } from "@langchain/ollama";
 import { AzureOpenAIEmbeddings, OpenAIEmbeddings } from "@langchain/openai";
 import { Notice } from "obsidian";
+import { BrevilabsClient } from "./brevilabsClient";
 import { CustomJinaEmbeddings } from "./CustomJinaEmbeddings";
 import { CustomOpenAIEmbeddings } from "./CustomOpenAIEmbeddings";
 
@@ -210,7 +210,7 @@ export default class EmbeddingManager {
         timeout: 10000,
         batchSize: getSettings().embeddingBatchSize,
         configuration: {
-          baseURL: BREVILABS_API_BASE_URL,
+          baseURL: BREVILABS_MODELS_BASE_URL,
           fetch: customModel.enableCors ? safeFetch : undefined,
         },
       },
@@ -220,7 +220,7 @@ export default class EmbeddingManager {
         timeout: 10000,
         batchSize: getSettings().embeddingBatchSize,
         dimensions: customModel.dimensions,
-        baseUrl: BREVILABS_API_BASE_URL + "/embeddings",
+        baseUrl: BREVILABS_MODELS_BASE_URL + "/embeddings",
         configuration: {
           fetch: customModel.enableCors ? safeFetch : undefined,
         },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ import { ChainType } from "./chainFactory";
 import { PromptSortStrategy } from "./types";
 
 export const BREVILABS_API_BASE_URL = "https://api.brevilabs.com/v1";
+export const BREVILABS_MODELS_BASE_URL = "https://models.brevilabs.com/v1";
 export const CHAT_VIEWTYPE = "copilot-chat-view";
 export const USER_SENDER = "user";
 export const AI_SENDER = "ai";
@@ -588,13 +589,13 @@ export const ProviderInfo: Record<Provider, ProviderMetadata> = {
   },
   [EmbeddingModelProviders.COPILOT_PLUS]: {
     label: "Copilot Plus",
-    host: "https://api.brevilabs.com/v1",
+    host: BREVILABS_MODELS_BASE_URL,
     keyManagementURL: "",
     listModelURL: "",
   },
   [EmbeddingModelProviders.COPILOT_PLUS_JINA]: {
     label: "Copilot Plus",
-    host: "https://api.brevilabs.com/v1",
+    host: BREVILABS_MODELS_BASE_URL,
     keyManagementURL: "",
     listModelURL: "",
   },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch Copilot Plus chat and embedding endpoints from api.brevilabs.com to models.brevilabs.com, updating configs and provider metadata.
> 
> - **LLM Providers**:
>   - **Chat**: Update `COPILOT_PLUS` config in `src/LLMProviders/chatModelManager.ts` to use `BREVILABS_MODELS_BASE_URL` for `configuration.baseURL`.
>   - **Embeddings**: Update `COPILOT_PLUS` and `COPILOT_PLUS_JINA` configs in `src/LLMProviders/embeddingManager.ts` to use `BREVILABS_MODELS_BASE_URL` (`baseURL` and `baseUrl + "/embeddings"`).
> - **Constants**:
>   - Add `BREVILABS_MODELS_BASE_URL = "https://models.brevilabs.com/v1"` in `src/constants.ts`.
>   - Point `ProviderInfo` hosts for `EmbeddingModelProviders.COPILOT_PLUS` and `COPILOT_PLUS_JINA` to `BREVILABS_MODELS_BASE_URL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cab819a12dbfea24afb7c7fff4b62356d33da8f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->