### PR TITLE
Rebuild "Active Note" and more chat input improvement

### DIFF
--- a/src/components/chat-components/AtMentionTypeahead.tsx
+++ b/src/components/chat-components/AtMentionTypeahead.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
+import { TFile } from "obsidian";
 import { TypeaheadMenuPopover } from "./TypeaheadMenuPopover";
 import {
   useAtMentionCategories,
@@ -13,6 +14,7 @@ interface AtMentionTypeaheadProps {
   onClose: () => void;
   onSelect: (category: AtMentionCategory, data: any) => void;
   isCopilotPlus?: boolean;
+  currentActiveFile?: TFile | null;
 }
 
 // Type guard functions
@@ -29,6 +31,7 @@ export function AtMentionTypeahead({
   onClose,
   onSelect,
   isCopilotPlus = false,
+  currentActiveFile = null,
 }: AtMentionTypeaheadProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -47,7 +50,8 @@ export function AtMentionTypeahead({
     extendedState.mode,
     extendedState.selectedCategory,
     isCopilotPlus,
-    availableCategoryOptions
+    availableCategoryOptions,
+    currentActiveFile
   );
 
   // Handle selection

--- a/src/components/chat-components/ChatContextMenu.tsx
+++ b/src/components/chat-components/ChatContextMenu.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
   ContextNoteBadge,
+  ContextActiveNoteBadge,
   ContextUrlBadge,
   ContextTagBadge,
   ContextFolderBadge,
@@ -19,7 +20,8 @@ import { AtMentionTypeahead } from "./AtMentionTypeahead";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 
 interface ChatContextMenuProps {
-  activeNote: TFile | null;
+  includeActiveNote: boolean;
+  currentActiveFile: TFile | null;
   contextNotes: TFile[];
   contextUrls: string[];
   contextTags: string[];
@@ -63,7 +65,8 @@ function ContextSelection({
 }
 
 export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
-  activeNote,
+  includeActiveNote,
+  currentActiveFile,
   contextNotes,
   contextUrls,
   contextTags,
@@ -99,12 +102,8 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
 
   const uniqueNotes = React.useMemo(() => {
     const notesMap = new Map(contextNotes.map((note) => [note.path, note]));
-
-    return Array.from(notesMap.values()).filter((note) => {
-      // Show all notes except the active note (when it's already displayed separately)
-      return !(activeNote && note.path === activeNote.path);
-    });
-  }, [contextNotes, activeNote]);
+    return Array.from(notesMap.values());
+  }, [contextNotes]);
 
   const uniqueUrls = React.useMemo(() => Array.from(new Set(contextUrls)), [contextUrls]);
 
@@ -114,7 +113,7 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
     selectedTextContexts.length > 0 ||
     contextTags.length > 0 ||
     contextFolders.length > 0 ||
-    !!activeNote;
+    includeActiveNote;
 
   // Get contextStatus from the shared hook
   const getContextStatusIcon = () => {
@@ -151,17 +150,16 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
               onClose={handleTypeaheadClose}
               onSelect={handleTypeaheadSelect}
               isCopilotPlus={isCopilotPlus}
+              currentActiveFile={currentActiveFile}
             />
           </PopoverContent>
         </Popover>
       </div>
       <div className="tw-flex tw-flex-1 tw-flex-wrap tw-gap-1">
-        {activeNote && (
-          <ContextNoteBadge
-            key={activeNote.path}
-            note={activeNote}
-            isActive={true}
-            onRemove={() => onRemoveContext("notes", activeNote.path)}
+        {includeActiveNote && (
+          <ContextActiveNoteBadge
+            currentActiveFile={currentActiveFile}
+            onRemove={() => onRemoveContext("activeNote", "")}
           />
         )}
         {uniqueNotes.map((note) => (

--- a/src/components/chat-components/ContextBadges.tsx
+++ b/src/components/chat-components/ContextBadges.tsx
@@ -26,6 +26,46 @@ interface ContextFolderBadgeProps extends BaseContextBadgeProps {
   folder: string;
 }
 
+interface ContextActiveNoteBadgeProps extends BaseContextBadgeProps {
+  currentActiveFile: TFile | null;
+}
+
+export function ContextActiveNoteBadge({
+  currentActiveFile,
+  onRemove,
+}: ContextActiveNoteBadgeProps) {
+  if (!currentActiveFile) {
+    return null;
+  }
+
+  const tooltipContent = <div className="tw-text-left">{currentActiveFile.path}</div>;
+  const isPdf = currentActiveFile.extension === "pdf";
+
+  return (
+    <ContextBadgeWrapper hasRemoveButton={!!onRemove}>
+      <div className="tw-flex tw-items-center tw-gap-1">
+        <FileText className="tw-size-3" />
+        <TruncatedText className="tw-max-w-40" tooltipContent={tooltipContent} alwaysShowTooltip>
+          {currentActiveFile.basename}
+        </TruncatedText>
+        <span className="tw-text-xs tw-text-faint">Current</span>
+        {isPdf && <span className="tw-text-xs tw-text-faint">pdf</span>}
+      </div>
+      {onRemove && (
+        <Button
+          variant="ghost2"
+          size="fit"
+          onClick={onRemove}
+          aria-label="Remove from context"
+          className="tw-text-muted"
+        >
+          <X className="tw-size-4" />
+        </Button>
+      )}
+    </ContextBadgeWrapper>
+  );
+}
+
 export function ContextNoteBadge({ note, isActive = false, onRemove }: ContextNoteBadgeProps) {
   const tooltipContent = <div className="tw-text-left">{note.path}</div>;
 

--- a/src/components/chat-components/ContextControl.tsx
+++ b/src/components/chat-components/ContextControl.tsx
@@ -47,7 +47,8 @@ export const ContextControl: React.FC<ChatControlsProps> = ({
 
   return (
     <ChatContextMenu
-      activeNote={includeActiveNote ? activeNote : null}
+      includeActiveNote={includeActiveNote}
+      currentActiveFile={activeNote}
       contextNotes={contextNotes}
       onRemoveContext={handleRemoveContext}
       contextUrls={contextUrls}

--- a/src/components/chat-components/TypeaheadMenuContent.tsx
+++ b/src/components/chat-components/TypeaheadMenuContent.tsx
@@ -122,7 +122,8 @@ export function TypeaheadMenuContent({
           <div className="tw-p-2 tw-text-normal">
             {options.map((option, index) => {
               const isSelected = index === selectedIndex;
-              const isCategory = mode === "category" && !query && option.icon;
+              const isCategory =
+                mode === "category" && !query && option.icon && !("data" in option);
 
               return (
                 <div

--- a/src/components/chat-components/context/ActiveFileContext.tsx
+++ b/src/components/chat-components/context/ActiveFileContext.tsx
@@ -1,0 +1,44 @@
+import React, { createContext, useContext } from "react";
+import { TFile } from "obsidian";
+
+/**
+ * Context that provides the current active file to Lexical nodes
+ * This allows pills and other components to reactively display information
+ * about the currently active file in Obsidian
+ */
+interface ActiveFileContextType {
+  currentActiveFile: TFile | null;
+}
+
+const ActiveFileContext = createContext<ActiveFileContextType | undefined>(undefined);
+
+/**
+ * Hook to access the current active file from any component
+ * within the Lexical editor tree
+ */
+export function useActiveFile(): TFile | null {
+  const context = useContext(ActiveFileContext);
+  if (context === undefined) {
+    // Return null if used outside provider instead of throwing
+    // This allows pills to work even if context isn't set up
+    return null;
+  }
+  return context.currentActiveFile;
+}
+
+interface ActiveFileProviderProps {
+  currentActiveFile: TFile | null;
+  children: React.ReactNode;
+}
+
+/**
+ * Provider component that makes the current active file available
+ * to all descendant components
+ */
+export function ActiveFileProvider({ currentActiveFile, children }: ActiveFileProviderProps) {
+  return (
+    <ActiveFileContext.Provider value={{ currentActiveFile }}>
+      {children}
+    </ActiveFileContext.Provider>
+  );
+}

--- a/src/components/chat-components/hooks/useAtMentionCategories.tsx
+++ b/src/components/chat-components/hooks/useAtMentionCategories.tsx
@@ -3,7 +3,7 @@ import { TFile, TFolder } from "obsidian";
 import { FileText, Wrench, Folder, Hash } from "lucide-react";
 import { TypeaheadOption } from "../TypeaheadMenuContent";
 
-export type AtMentionCategory = "notes" | "tools" | "folders" | "tags";
+export type AtMentionCategory = "notes" | "tools" | "folders" | "tags" | "activeNote";
 
 export interface AtMentionOption extends TypeaheadOption {
   category: AtMentionCategory;

--- a/src/components/chat-components/hooks/useAtMentionSearch.ts
+++ b/src/components/chat-components/hooks/useAtMentionSearch.ts
@@ -8,6 +8,7 @@ import { useAllNotes } from "./useAllNotes";
 import { useAllFolders } from "./useAllFolders";
 import { useAllTags } from "./useAllTags";
 import { AtMentionCategory, AtMentionOption, CategoryOption } from "./useAtMentionCategories";
+import { getSettings } from "@/settings/model";
 
 /**
  * Custom hook for @ mention search results with unified fuzzy search
@@ -136,6 +137,27 @@ export function useAtMentionSearch(
 
       // Apply fuzzy search for all categories if there's a query
       if (!query) {
+        // For notes category with no query, rank custom command notes lower
+        if (selectedCategory === "notes") {
+          const customPromptsFolder = getSettings().customPromptsFolder;
+          const regularNotes = items.filter(
+            (item) =>
+              !(
+                typeof item.data === "object" &&
+                "path" in item.data &&
+                typeof item.data.path === "string" &&
+                item.data.path.startsWith(customPromptsFolder + "/")
+              )
+          );
+          const customCommandNotes = items.filter(
+            (item) =>
+              typeof item.data === "object" &&
+              "path" in item.data &&
+              typeof item.data.path === "string" &&
+              item.data.path.startsWith(customPromptsFolder + "/")
+          );
+          return [...regularNotes, ...customCommandNotes].slice(0, 30);
+        }
         return items.slice(0, 30);
       }
 

--- a/src/components/chat-components/hooks/useNoteSearch.ts
+++ b/src/components/chat-components/hooks/useNoteSearch.ts
@@ -3,6 +3,7 @@ import { TFile } from "obsidian";
 import fuzzysort from "fuzzysort";
 import { useAllNotes } from "./useAllNotes";
 import { TypeaheadOption } from "../TypeaheadMenuContent";
+import { getSettings } from "@/settings/model";
 
 export interface NoteSearchOption extends TypeaheadOption {
   file: TFile;
@@ -55,10 +56,17 @@ export function useNoteSearch(
   // Filter and search notes based on query (name only)
   const searchResults = useMemo(() => {
     const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+    const customPromptsFolder = getSettings().customPromptsFolder;
 
-    // If no query, return first N notes
+    // If no query, return first N notes with custom command notes ranked lower
     if (!query.trim()) {
-      return allNoteOptions.slice(0, mergedConfig.limit);
+      const regularNotes = allNoteOptions.filter(
+        (opt) => !opt.file.path.startsWith(customPromptsFolder + "/")
+      );
+      const customCommandNotes = allNoteOptions.filter((opt) =>
+        opt.file.path.startsWith(customPromptsFolder + "/")
+      );
+      return [...regularNotes, ...customCommandNotes].slice(0, mergedConfig.limit);
     }
 
     const searchQuery = query.trim();

--- a/src/components/chat-components/hooks/useNoteSearch.ts
+++ b/src/components/chat-components/hooks/useNoteSearch.ts
@@ -1,5 +1,6 @@
-import { useMemo } from "react";
+import React, { useMemo } from "react";
 import { TFile } from "obsidian";
+import { FileText } from "lucide-react";
 import fuzzysort from "fuzzysort";
 import { useAllNotes } from "./useAllNotes";
 import { TypeaheadOption } from "../TypeaheadMenuContent";
@@ -49,6 +50,7 @@ export function useNoteSearch(
       title: file.basename,
       subtitle: file.path,
       content: "", // Will be loaded async when needed
+      icon: React.createElement(FileText, { className: "tw-size-4" }),
       file,
     }));
   }, [allNotes]);

--- a/src/components/chat-components/pills/ActiveNotePillNode.tsx
+++ b/src/components/chat-components/pills/ActiveNotePillNode.tsx
@@ -1,0 +1,180 @@
+import React from "react";
+import {
+  DOMConversionMap,
+  DOMConversionOutput,
+  DOMExportOutput,
+  EditorConfig,
+  LexicalNode,
+  NodeKey,
+  $getRoot,
+} from "lexical";
+import { BasePillNode, SerializedBasePillNode } from "./BasePillNode";
+import { TruncatedPillText } from "./TruncatedPillText";
+import { PillBadge } from "./PillBadge";
+import { useActiveFile } from "../context/ActiveFileContext";
+
+// Active note pill doesn't store any file-specific data
+// It always represents the current active file
+export type SerializedActiveNotePillNode = SerializedBasePillNode;
+
+/**
+ * ActiveNotePillNode represents the "Current Note" in context
+ * It automatically displays whatever file is currently active in Obsidian
+ * This is a separate context type from regular notes
+ */
+export class ActiveNotePillNode extends BasePillNode {
+  static getType(): string {
+    return "active-note-pill";
+  }
+
+  static clone(node: ActiveNotePillNode): ActiveNotePillNode {
+    return new ActiveNotePillNode(node.__key);
+  }
+
+  constructor(key?: NodeKey) {
+    super("Current Note", key);
+  }
+
+  getClassName(): string {
+    return "active-note-pill-wrapper";
+  }
+
+  getDataAttribute(): string {
+    return "data-lexical-active-note-pill";
+  }
+
+  createDOM(_config: EditorConfig): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "active-note-pill-wrapper";
+    return span;
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      span: (node: HTMLElement) => {
+        if (node.hasAttribute("data-lexical-active-note-pill")) {
+          return {
+            conversion: convertActiveNotePillElement,
+            priority: 2,
+          };
+        }
+        return null;
+      },
+    };
+  }
+
+  static importJSON(_serializedNode: SerializedActiveNotePillNode): ActiveNotePillNode {
+    return $createActiveNotePillNode();
+  }
+
+  exportJSON(): SerializedActiveNotePillNode {
+    return {
+      ...super.exportJSON(),
+      type: "active-note-pill",
+      version: 1,
+    };
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement("span");
+    element.setAttribute("data-lexical-active-note-pill", "true");
+    element.textContent = "{activeNote}";
+    return { element };
+  }
+
+  getTextContent(): string {
+    return "{activeNote}";
+  }
+
+  decorate(): JSX.Element {
+    return <ActiveNotePillComponent />;
+  }
+}
+
+function convertActiveNotePillElement(_domNode: HTMLElement): DOMConversionOutput | null {
+  const node = $createActiveNotePillNode();
+  return { node };
+}
+
+/**
+ * Component that renders the active note pill
+ * Uses ActiveFileContext to get the current active file and display its name
+ */
+function ActiveNotePillComponent(): JSX.Element {
+  const currentActiveFile = useActiveFile();
+
+  // If no active file, show {activeNote} to match what gets sent to LLM
+  if (!currentActiveFile) {
+    return (
+      <PillBadge>
+        <div className="tw-flex tw-items-center tw-gap-1">
+          <TruncatedPillText
+            content="activeNote"
+            openBracket="{"
+            closeBracket="}"
+            tooltipContent={
+              <div className="tw-text-left">
+                Will use the active note at the time the message is sent
+              </div>
+            }
+          />
+        </div>
+      </PillBadge>
+    );
+  }
+
+  // Active file exists - show its name with "Current" label
+  const noteTitle = currentActiveFile.basename;
+  const notePath = currentActiveFile.path;
+  const isPdf = notePath.toLowerCase().endsWith(".pdf");
+
+  return (
+    <PillBadge>
+      <div className="tw-flex tw-items-center tw-gap-1">
+        <TruncatedPillText
+          content={noteTitle}
+          openBracket="[["
+          closeBracket="]]"
+          tooltipContent={<div className="tw-text-left">{notePath}</div>}
+        />
+        <span className="tw-text-xs tw-text-faint">Current</span>
+        {isPdf && <span className="tw-text-xs tw-text-faint">pdf</span>}
+      </div>
+    </PillBadge>
+  );
+}
+
+// Utility functions
+export function $createActiveNotePillNode(): ActiveNotePillNode {
+  return new ActiveNotePillNode();
+}
+
+export function $isActiveNotePillNode(
+  node: LexicalNode | null | undefined
+): node is ActiveNotePillNode {
+  return node instanceof ActiveNotePillNode;
+}
+
+/**
+ * Removes all active note pills from the editor
+ * @returns The number of pills removed
+ */
+export function $removeActiveNotePills(): number {
+  const root = $getRoot();
+  let removedCount = 0;
+
+  function traverse(node: any): void {
+    if ($isActiveNotePillNode(node)) {
+      node.remove();
+      removedCount++;
+    } else if (typeof node.getChildren === "function") {
+      const children = node.getChildren();
+      for (const child of children) {
+        traverse(child);
+      }
+    }
+  }
+
+  traverse(root);
+  return removedCount;
+}

--- a/src/components/chat-components/pills/NotePillNode.tsx
+++ b/src/components/chat-components/pills/NotePillNode.tsx
@@ -15,27 +15,24 @@ import { PillBadge } from "./PillBadge";
 export interface SerializedNotePillNode extends SerializedBasePillNode {
   noteTitle: string;
   notePath: string;
-  isActive?: boolean;
 }
 
 export class NotePillNode extends BasePillNode {
   __noteTitle: string;
   __notePath: string;
-  __isActive: boolean;
 
   static getType(): string {
     return "note-pill";
   }
 
   static clone(node: NotePillNode): NotePillNode {
-    return new NotePillNode(node.__noteTitle, node.__notePath, node.__isActive, node.__key);
+    return new NotePillNode(node.__noteTitle, node.__notePath, node.__key);
   }
 
-  constructor(noteTitle: string, notePath: string, isActive = false, key?: NodeKey) {
+  constructor(noteTitle: string, notePath: string, key?: NodeKey) {
     super(noteTitle, key);
     this.__noteTitle = noteTitle;
     this.__notePath = notePath;
-    this.__isActive = isActive;
   }
 
   getClassName(): string {
@@ -67,8 +64,8 @@ export class NotePillNode extends BasePillNode {
   }
 
   static importJSON(serializedNode: SerializedNotePillNode): NotePillNode {
-    const { noteTitle, notePath, isActive } = serializedNode;
-    return $createNotePillNode(noteTitle, notePath, isActive);
+    const { noteTitle, notePath } = serializedNode;
+    return $createNotePillNode(noteTitle, notePath);
   }
 
   exportJSON(): SerializedNotePillNode {
@@ -76,7 +73,6 @@ export class NotePillNode extends BasePillNode {
       ...super.exportJSON(),
       noteTitle: this.__noteTitle,
       notePath: this.__notePath,
-      isActive: this.__isActive,
       type: "note-pill",
       version: 1,
     };
@@ -99,15 +95,6 @@ export class NotePillNode extends BasePillNode {
       ? `${this.__noteTitle}.pdf`
       : this.__noteTitle;
     return `[[${displayName}]]`;
-  }
-
-  setActive(isActive: boolean): void {
-    const writable = this.getWritable();
-    writable.__isActive = isActive;
-  }
-
-  getActive(): boolean {
-    return this.__isActive;
   }
 
   getNoteTitle(): string {
@@ -140,7 +127,6 @@ interface NotePillComponentProps {
 function NotePillComponent({ node }: NotePillComponentProps): JSX.Element {
   const noteTitle = node.getNoteTitle();
   const notePath = node.getNotePath();
-  const isActive = node.getActive();
   const isPdf = notePath.toLowerCase().endsWith(".pdf");
 
   const tooltipContent = <div className="tw-text-left">{notePath}</div>;
@@ -154,7 +140,6 @@ function NotePillComponent({ node }: NotePillComponentProps): JSX.Element {
           closeBracket="]]"
           tooltipContent={tooltipContent}
         />
-        {isActive && <span className="tw-text-xs tw-text-faint">Current</span>}
         {isPdf && <span className="tw-text-xs tw-text-faint">pdf</span>}
       </div>
     </PillBadge>
@@ -162,12 +147,8 @@ function NotePillComponent({ node }: NotePillComponentProps): JSX.Element {
 }
 
 // Utility functions
-export function $createNotePillNode(
-  noteTitle: string,
-  notePath: string,
-  isActive = false
-): NotePillNode {
-  return new NotePillNode(noteTitle, notePath, isActive);
+export function $createNotePillNode(noteTitle: string, notePath: string): NotePillNode {
+  return new NotePillNode(noteTitle, notePath);
 }
 
 export function $isNotePillNode(node: LexicalNode | null | undefined): node is NotePillNode {

--- a/src/components/chat-components/plugins/ActiveNotePillSyncPlugin.tsx
+++ b/src/components/chat-components/plugins/ActiveNotePillSyncPlugin.tsx
@@ -1,0 +1,75 @@
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { useEffect } from "react";
+import { $getRoot } from "lexical";
+import { $isActiveNotePillNode } from "../pills/ActiveNotePillNode";
+
+/**
+ * Props for the ActiveNotePillSyncPlugin component
+ */
+interface ActiveNotePillSyncPluginProps {
+  /** Callback triggered when active note pill is added */
+  onActiveNoteAdded?: () => void;
+  /** Callback triggered when active note pill is removed */
+  onActiveNoteRemoved?: () => void;
+}
+
+/**
+ * Lexical plugin that monitors active note pill nodes in the editor
+ * Notifies parent when the active note pill is added or removed
+ * Multiple active note pills can exist in the editor, but the context menu
+ * shows a single badge tracking whether any active note pills exist
+ */
+export function ActiveNotePillSyncPlugin({
+  onActiveNoteAdded,
+  onActiveNoteRemoved,
+}: ActiveNotePillSyncPluginProps) {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    let hasActiveNotePill = false;
+
+    // Register update listener
+    const removeUpdateListener = editor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        const root = $getRoot();
+
+        // Recursively traverse the editor tree to find active note pill
+        let foundActiveNotePill = false;
+        function traverse(node: any): void {
+          if ($isActiveNotePillNode(node)) {
+            foundActiveNotePill = true;
+            return;
+          }
+
+          // Only traverse children if the node has the getChildren method
+          if (typeof node.getChildren === "function") {
+            const children = node.getChildren();
+            for (const child of children) {
+              if (foundActiveNotePill) return; // Early exit if found
+              traverse(child);
+            }
+          }
+        }
+
+        traverse(root);
+
+        // Detect state changes
+        if (foundActiveNotePill && !hasActiveNotePill) {
+          // Active note pill was added
+          hasActiveNotePill = true;
+          onActiveNoteAdded?.();
+        } else if (!foundActiveNotePill && hasActiveNotePill) {
+          // Active note pill was removed
+          hasActiveNotePill = false;
+          onActiveNoteRemoved?.();
+        }
+      });
+    });
+
+    return () => {
+      removeUpdateListener();
+    };
+  }, [editor, onActiveNoteAdded, onActiveNoteRemoved]);
+
+  return null;
+}

--- a/src/components/chat-components/plugins/AtMentionCommandPlugin.tsx
+++ b/src/components/chat-components/plugins/AtMentionCommandPlugin.tsx
@@ -17,10 +17,12 @@ declare const app: App;
 
 interface AtMentionCommandPluginProps {
   isCopilotPlus?: boolean;
+  currentActiveFile?: TFile | null;
 }
 
 export function AtMentionCommandPlugin({
   isCopilotPlus = false,
+  currentActiveFile = null,
 }: AtMentionCommandPluginProps): JSX.Element {
   const [editor] = useLexicalComposerContext();
   const [extendedState, setExtendedState] = useState<{
@@ -67,7 +69,8 @@ export function AtMentionCommandPlugin({
     extendedState.mode,
     extendedState.selectedCategory,
     isCopilotPlus,
-    availableCategoryOptions
+    availableCategoryOptions,
+    currentActiveFile
   );
 
   // Type guard functions
@@ -100,15 +103,24 @@ export function AtMentionCommandPlugin({
 
       // Item was selected - create appropriate pill using shared utility
       if (isAtMentionOption(option)) {
-        const pillData: PillData = {
-          type: option.category,
-          title: option.title,
-          data: option.data,
-        };
+        // Check if this is the "Active Note" option by its category
+        if (option.category === "activeNote") {
+          // Create ActiveNotePillNode instead of regular NotePillNode
+          editor.update(() => {
+            $replaceTriggeredTextWithPill("@", { type: "active-note" });
+          });
+        } else {
+          // Regular pill
+          const pillData: PillData = {
+            type: option.category,
+            title: option.title,
+            data: option.data,
+          };
 
-        editor.update(() => {
-          $replaceTriggeredTextWithPill("@", pillData);
-        });
+          editor.update(() => {
+            $replaceTriggeredTextWithPill("@", pillData);
+          });
+        }
       }
     },
     [extendedState.mode, currentQuery, isCategoryOption, isAtMentionOption, editor]

--- a/src/components/chat-components/plugins/PastePlugin.tsx
+++ b/src/components/chat-components/plugins/PastePlugin.tsx
@@ -79,6 +79,7 @@ export function PastePlugin({ enableURLPills = false, onImagePaste }: PastePlugi
         const hasValidPills = segments.some(
           (segment) =>
             segment.type === "note-pill" ||
+            segment.type === "active-note-pill" ||
             (enableURLPills && segment.type === "url-pill") ||
             segment.type === "tool-pill" ||
             segment.type === "tag-pill" ||

--- a/src/components/chat-components/utils/lexicalTextUtils.ts
+++ b/src/components/chat-components/utils/lexicalTextUtils.ts
@@ -11,6 +11,7 @@ import {
 } from "lexical";
 import { TFile, TFolder, App } from "obsidian";
 import { $createNotePillNode } from "../pills/NotePillNode";
+import { $createActiveNotePillNode } from "../pills/ActiveNotePillNode";
 import { $createURLPillNode } from "../pills/URLPillNode";
 import { $createToolPillNode } from "../pills/ToolPillNode";
 import { $createTagPillNode } from "../pills/TagPillNode";
@@ -20,12 +21,12 @@ import { AVAILABLE_TOOLS } from "../constants/tools";
 
 declare const app: App;
 
-export type PillType = "notes" | "tools" | "folders" | "tags";
+export type PillType = "notes" | "tools" | "folders" | "tags" | "active-note";
 
 export interface PillData {
   type: PillType;
-  title: string;
-  data: TFile | TFolder | string;
+  title?: string;
+  data?: TFile | TFolder | string;
 }
 
 /**
@@ -35,11 +36,12 @@ export function $createPillNode(pillData: PillData) {
   const { type, title, data } = pillData;
 
   switch (type) {
+    case "active-note":
+      // Active note pill doesn't need title or data - it automatically shows current active file
+      return $createActiveNotePillNode();
     case "notes":
-      if (data instanceof TFile) {
-        const activeNote = app?.workspace.getActiveFile();
-        const isActive = activeNote?.path === data.path;
-        return $createNotePillNode(title, data.path, isActive);
+      if (data instanceof TFile && title) {
+        return $createNotePillNode(title, data.path);
       }
       break;
     case "tools":
@@ -63,7 +65,14 @@ export function $createPillNode(pillData: PillData) {
 }
 
 export interface ParsedContent {
-  type: "text" | "note-pill" | "url-pill" | "tool-pill" | "tag-pill" | "folder-pill";
+  type:
+    | "text"
+    | "note-pill"
+    | "active-note-pill"
+    | "url-pill"
+    | "tool-pill"
+    | "tag-pill"
+    | "folder-pill";
   content: string;
   file?: TFile;
   url?: string;
@@ -386,7 +395,7 @@ function resolveNoteReference(noteName: string): TFile | null {
 }
 
 interface PatternInfo {
-  type: "notes" | "urls" | "tools" | "tags" | "folders";
+  type: "notes" | "urls" | "tools" | "tags" | "customTemplates";
   groupCount: number;
   startIndex: number;
 }
@@ -442,8 +451,8 @@ export function parseTextForPills(
     currentGroupIndex += 1;
   }
   if (includeFolders) {
-    patterns.push("(\\{([^}]+)\\})"); // 2 groups: full match and folder name
-    patternInfo.push({ type: "folders", groupCount: 2, startIndex: currentGroupIndex });
+    patterns.push("(\\{([^}]+)\\})"); // 2 groups: full match and custom template content
+    patternInfo.push({ type: "customTemplates", groupCount: 2, startIndex: currentGroupIndex });
     currentGroupIndex += 2;
   }
 
@@ -558,23 +567,32 @@ export function parseTextForPills(
           content: match[0],
         });
       }
-    } else if (matchedPattern.type === "folders") {
-      // This is a folder reference {folderName}
-      const folderName = match[matchedPattern.startIndex + 1].trim();
-      const resolvedFolder = resolveFolderReference(folderName);
+    } else if (matchedPattern.type === "customTemplates") {
+      // This is a custom template: folder reference {folderName} or special {activeNote} syntax
+      const templateContent = match[matchedPattern.startIndex + 1].trim();
 
-      if (resolvedFolder) {
+      // Special case: {activeNote} should create an active-note-pill
+      if (templateContent === "activeNote") {
         segments.push({
-          type: "folder-pill",
-          content: resolvedFolder.path,
-          folder: resolvedFolder,
+          type: "active-note-pill",
+          content: "activeNote",
         });
       } else {
-        // Invalid folder reference - keep as plain text
-        segments.push({
-          type: "text",
-          content: match[0],
-        });
+        const resolvedFolder = resolveFolderReference(templateContent);
+
+        if (resolvedFolder) {
+          segments.push({
+            type: "folder-pill",
+            content: resolvedFolder.path,
+            folder: resolvedFolder,
+          });
+        } else {
+          // Invalid folder reference - keep as plain text
+          segments.push({
+            type: "text",
+            content: match[0],
+          });
+        }
       }
     }
 
@@ -606,10 +624,10 @@ export function createNodesFromSegments(segments: ParsedContent[]): LexicalNode[
   for (const segment of segments) {
     if (segment.type === "text" && segment.content) {
       nodes.push($createTextNode(segment.content));
+    } else if (segment.type === "active-note-pill") {
+      nodes.push($createActiveNotePillNode());
     } else if (segment.type === "note-pill" && segment.file) {
-      nodes.push(
-        $createNotePillNode(segment.content, segment.file.path, segment.isActive || false)
-      );
+      nodes.push($createNotePillNode(segment.content, segment.file.path));
     } else if (segment.type === "url-pill" && segment.url) {
       nodes.push($createURLPillNode(segment.url));
     } else if (segment.type === "tool-pill" && segment.toolName) {


### PR DESCRIPTION
- Active note logic is rebuilt. It becomes its own context type. It's now added to the new @ mention typeahead menu.
- Custom command notes are ranked lower when there is no search query.

<img width="683" height="405" alt="Screenshot 2025-09-30 at 11 19 02 PM" src="https://github.com/user-attachments/assets/67190139-0b0c-43ff-adb2-269f39abc8d1" />
