### PR TITLE
Add better agent prompt logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "version": "node version-bump.mjs && git add manifest.json versions.json",
     "test": "jest --testPathIgnorePatterns=src/integration_tests/",
     "test:integration": "jest src/integration_tests/",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prompt:debug": "node scripts/printPromptDebug.js"
   },
   "keywords": [],
   "author": "Logan Yang",

--- a/scripts/printPromptDebug.js
+++ b/scripts/printPromptDebug.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+/**
+ * Bundle the TypeScript entry file into a temporary ESM module and execute it.
+ */
+async function main() {
+  const [{ build }, fs, os, path, url] = await Promise.all([
+    import("esbuild"),
+    import("node:fs/promises"),
+    import("node:os"),
+    import("node:path"),
+    import("node:url"),
+  ]);
+
+  const entryFile = path.resolve(__dirname, "printPromptDebugEntry.ts");
+  const outfile = path.join(os.tmpdir(), `prompt-debug-${Date.now()}.mjs`);
+
+  if (!Array.prototype.contains) {
+    Object.defineProperty(Array.prototype, "contains", {
+      value(value) {
+        return this.includes(value);
+      },
+      enumerable: false,
+    });
+  }
+
+  const obsidianStubPlugin = {
+    name: "obsidian-stub",
+    setup(build) {
+      build.onResolve({ filter: /^obsidian$/ }, () => ({
+        path: path.resolve(__dirname, "stubs/obsidian.ts"),
+      }));
+    },
+  };
+
+  await build({
+    entryPoints: [entryFile],
+    outfile,
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    sourcemap: false,
+    target: "node18",
+    tsconfig: path.resolve(__dirname, "../tsconfig.json"),
+    plugins: [obsidianStubPlugin],
+  });
+
+  try {
+    const module = await import(url.pathToFileURL(outfile).href);
+    await module.run(process.argv.slice(2));
+  } finally {
+    await fs.unlink(outfile).catch(() => {
+      /* ignore cleanup errors */
+    });
+  }
+}
+
+main().catch((error) => {
+  console.error("Failed to generate prompt debug report:", error);
+  process.exitCode = 1;
+});

--- a/scripts/printPromptDebugEntry.ts
+++ b/scripts/printPromptDebugEntry.ts
@@ -1,0 +1,127 @@
+import MemoryManager from "@/LLMProviders/memoryManager";
+import { ModelAdapterFactory } from "@/LLMProviders/chainRunner/utils/modelAdapter";
+import { buildAgentPromptDebugReport } from "@/LLMProviders/chainRunner/utils/promptDebugService";
+import { ToolRegistry } from "@/tools/ToolRegistry";
+import { ChatMessage } from "@/types/message";
+import { initializeBuiltinTools } from "@/tools/builtinTools";
+import { getSettings } from "@/settings/model";
+import { UserMemoryManager } from "@/memory/UserMemoryManager";
+
+interface HeadlessApp {
+  vault: {
+    getRoot: () => { name: string };
+    getAbstractFileByPath: (path: string) => null;
+    read: (file: unknown) => Promise<string>;
+    getMarkdownFiles: () => unknown[];
+    getAllLoadedFiles: () => unknown[];
+    adapter: {
+      mkdir: (path: string) => Promise<void>;
+    };
+  };
+  metadataCache: {
+    getFirstLinkpathDest: () => null;
+    getFileCache: () => null;
+  };
+  workspace: {
+    getActiveFile: () => null;
+    getLeaf: () => { openFile: () => Promise<void> };
+  };
+}
+
+/**
+ * Create a minimal Obsidian app stub suitable for CLI usage.
+ *
+ * The autonomous agent only needs vault lookups and metadata cache reads, so this
+ * provides no-op implementations that satisfy those expectations.
+ */
+function createHeadlessApp(): HeadlessApp {
+  return {
+    vault: {
+      getRoot: () => ({ name: "root" }),
+      getAbstractFileByPath: () => null,
+      read: async () => "",
+      getMarkdownFiles: () => [],
+      getAllLoadedFiles: () => [],
+      adapter: {
+        mkdir: async () => {
+          /* no-op */
+        },
+      },
+    },
+    metadataCache: {
+      getFirstLinkpathDest: () => null,
+      getFileCache: () => null,
+    },
+    workspace: {
+      getActiveFile: () => null,
+      getLeaf: () => ({
+        openFile: async () => {
+          /* no-op */
+        },
+      }),
+    },
+  };
+}
+
+/**
+ * Format a plain user message into the ChatMessage shape used by the agent.
+ *
+ * @param message - Raw user text to analyse.
+ * @returns Minimal chat message.
+ */
+function buildChatMessage(message: string): ChatMessage {
+  return {
+    message,
+    originalMessage: message,
+    sender: "user",
+    timestamp: null,
+    isVisible: true,
+  };
+}
+
+/**
+ * Generate the annotated prompt debug report for a given user input.
+ *
+ * @param args - CLI arguments (expects the user prompt as the concatenated string).
+ */
+export async function run(args: string[]): Promise<void> {
+  const userInput = args.join(" ").trim();
+
+  if (!userInput) {
+    console.error('Usage: npm run prompt:debug -- "your message here"');
+    process.exitCode = 1;
+    return;
+  }
+
+  const app = createHeadlessApp();
+  (globalThis as any).app = app;
+
+  initializeBuiltinTools();
+
+  const registry = ToolRegistry.getInstance();
+  const settings = getSettings();
+  const enabledToolIds = new Set(settings.autonomousAgentEnabledToolIds || []);
+  const availableTools = registry.getEnabledTools(enabledToolIds, false);
+
+  const toolDescriptions = (
+    await import("@/LLMProviders/chainRunner/AutonomousAgentChainRunner")
+  ).AutonomousAgentChainRunner.generateToolDescriptions(availableTools);
+
+  const memoryManager = MemoryManager.getInstance();
+  const userMemoryManager = new UserMemoryManager(app as any);
+  const chainContext = {
+    memoryManager,
+    userMemoryManager,
+  } as any;
+
+  const adapter = ModelAdapterFactory.createAdapter({ modelName: "gpt-4" } as any);
+  const report = await buildAgentPromptDebugReport({
+    chainManager: chainContext,
+    adapter,
+    availableTools,
+    toolDescriptions,
+    userMessage: buildChatMessage(userInput),
+  });
+
+  console.log(report.annotatedPrompt);
+}

--- a/scripts/stubs/obsidian.ts
+++ b/scripts/stubs/obsidian.ts
@@ -1,0 +1,93 @@
+export class App {}
+
+export class Notice {
+  constructor(public message?: string) {
+    if (message) {
+      console.warn(`[Notice] ${message}`);
+    }
+  }
+}
+
+export class TFile {
+  path: string;
+  basename: string;
+  extension: string;
+
+  constructor(path: string) {
+    this.path = path;
+    this.basename = path.split("/").pop() || path;
+    const parts = this.basename.split(".");
+    this.extension = parts.length > 1 ? parts.pop() || "" : "";
+  }
+}
+
+export class Vault {
+  getRoot() {
+    return { name: "root" };
+  }
+
+  getAbstractFileByPath() {
+    return null;
+  }
+
+  async read() {
+    return "";
+  }
+
+  getMarkdownFiles() {
+    return [];
+  }
+
+  getAllLoadedFiles() {
+    return [];
+  }
+
+  adapter = {
+    mkdir: async () => {
+      /* no-op */
+    },
+  };
+}
+
+export const Platform = {
+  isDesktop: true,
+  isMobile: false,
+};
+
+export function normalizePath(path: string): string {
+  return path;
+}
+
+export async function requestUrl(): Promise<never> {
+  throw new Error("requestUrl is not available in the CLI environment.");
+}
+
+export function getAllTags(): string[] {
+  return [];
+}
+
+export class MarkdownView {}
+
+export class TAbstractFile {}
+
+export class WorkspaceLeaf {
+  async openFile(): Promise<void> {
+    /* no-op */
+  }
+}
+
+export class ItemView {}
+
+export class Modal {
+  open(): void {
+    /* no-op */
+  }
+
+  close(): void {
+    /* no-op */
+  }
+}
+
+export function parseYaml(_: string): any {
+  return {};
+}

--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -18,7 +18,11 @@ import {
   STREAMING_TRUNCATE_THRESHOLD,
 } from "./utils/modelAdapter";
 import { ThinkBlockStreamer } from "./utils/ThinkBlockStreamer";
-import { createToolCallMarker, updateToolCallMarker } from "./utils/toolCallParser";
+import {
+  createToolCallMarker,
+  updateToolCallMarker,
+  ensureEncodedToolCallMarkerResults,
+} from "./utils/toolCallParser";
 import {
   deduplicateSources,
   executeSequentialToolCall,
@@ -352,9 +356,10 @@ ${params}
           }
           fullAIResponse = allParts.join("\n\n");
 
+          const safeAssistantMessage = ensureEncodedToolCallMarkerResults(response);
           conversationMessages.push({
             role: "assistant",
-            content: response,
+            content: safeAssistantMessage,
           });
 
           // Add final response to LLM messages
@@ -515,7 +520,6 @@ ${params}
 
         // Add AI response to conversation for next iteration
         // Ensure any tool markers have encoded results before storing in conversation
-        const { ensureEncodedToolCallMarkerResults } = await import("./utils/toolCallParser");
         const safeAssistantContent = ensureEncodedToolCallMarkerResults(response);
         conversationMessages.push({
           role: "assistant",

--- a/src/LLMProviders/chainRunner/utils/cicPromptUtils.test.ts
+++ b/src/LLMProviders/chainRunner/utils/cicPromptUtils.test.ts
@@ -1,5 +1,6 @@
 import {
   buildLocalSearchInnerContent,
+  ensureCiCOrderingWithQuestion,
   renderCiCMessage,
   wrapLocalSearchPayload,
 } from "./cicPromptUtils";
@@ -45,6 +46,30 @@ describe("cicPromptUtils", () => {
 
     it("returns the original question when context is blank", () => {
       expect(renderCiCMessage("  \n  ", "What?", false)).toBe("What?");
+    });
+  });
+
+  describe("ensureCiCOrderingWithQuestion", () => {
+    it("appends the trimmed question after the payload when missing", () => {
+      const payload = "<localSearch>\n<context/>\n</localSearch>";
+      const question = "  What did I do last week?  ";
+
+      const result = ensureCiCOrderingWithQuestion(payload, question);
+
+      expect(result).toBe(renderCiCMessage(payload, "What did I do last week?", true));
+    });
+
+    it("returns payload unchanged when question already included", () => {
+      const question = "What did I do last week?";
+      const payload = renderCiCMessage("<localSearch />", question, true);
+
+      expect(ensureCiCOrderingWithQuestion(payload, question)).toBe(payload);
+    });
+
+    it("returns payload unchanged when question is blank", () => {
+      const payload = "<localSearch>\n<context/>\n</localSearch>";
+
+      expect(ensureCiCOrderingWithQuestion(payload, "   ")).toBe(payload);
     });
   });
 });

--- a/src/LLMProviders/chainRunner/utils/cicPromptUtils.ts
+++ b/src/LLMProviders/chainRunner/utils/cicPromptUtils.ts
@@ -48,3 +48,26 @@ export function renderCiCMessage(
   const questionBlock = labelQuestion ? `Question: ${userQuestion}` : userQuestion;
   return `${contextBlock}\n\n${questionBlock}`;
 }
+
+/**
+ * Ensure a CiC payload appends the user's question, avoiding duplicates when the question already exists.
+ * @param localSearchPayload XML-wrapped local search payload.
+ * @param originalUserQuestion The original user question to append.
+ * @returns CiC ordered payload with the question appended when missing.
+ */
+export function ensureCiCOrderingWithQuestion(
+  localSearchPayload: string,
+  originalUserQuestion: string
+): string {
+  const trimmedQuestion = originalUserQuestion.trim();
+
+  if (!trimmedQuestion) {
+    return localSearchPayload;
+  }
+
+  if (localSearchPayload.includes(trimmedQuestion)) {
+    return localSearchPayload;
+  }
+
+  return renderCiCMessage(localSearchPayload, trimmedQuestion, true);
+}

--- a/src/LLMProviders/chainRunner/utils/modelAdapter.test.ts
+++ b/src/LLMProviders/chainRunner/utils/modelAdapter.test.ts
@@ -1,4 +1,4 @@
-import { ModelAdapterFactory } from "./modelAdapter";
+import { ModelAdapterFactory, joinPromptSections } from "./modelAdapter";
 import { ToolMetadata } from "@/tools/ToolRegistry";
 
 describe("ModelAdapter", () => {
@@ -138,6 +138,22 @@ describe("ModelAdapter", () => {
       expect(enhancedPrompt).toContain("fix the typo");
       expect(enhancedPrompt).toContain("add item 4 to the list");
       expect(enhancedPrompt).toContain("diff parameter MUST contain");
+    });
+
+    it("should rebuild enhanceSystemPrompt output from section metadata", () => {
+      const mockModel = { modelName: "gpt-4" } as any;
+      const adapter = ModelAdapterFactory.createAdapter(mockModel);
+
+      const sections = adapter.buildSystemPromptSections(basePrompt, toolDescriptions, [], []);
+      expect(sections.length).toBeGreaterThan(0);
+      expect(sections[0].id).toBe("base-system-prompt");
+
+      const reconstructed = joinPromptSections(sections);
+      const enhancedPrompt = adapter.enhanceSystemPrompt(basePrompt, toolDescriptions, [], []);
+
+      expect(reconstructed).toEqual(enhancedPrompt);
+      expect(enhancedPrompt).toContain("Available tools:\nTool descriptions here");
+      expect(enhancedPrompt).not.toContain("Available tools:\n\nTool descriptions here");
     });
 
     it("should enhance file editing messages for GPT", () => {

--- a/src/LLMProviders/chainRunner/utils/modelAdapter.ts
+++ b/src/LLMProviders/chainRunner/utils/modelAdapter.ts
@@ -5,6 +5,29 @@ import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 export const STREAMING_TRUNCATE_THRESHOLD = 50;
 
 /**
+ * Represents a labeled segment of the system prompt used for tool prompting.
+ */
+export interface PromptSection {
+  id: string;
+  label: string;
+  source: string;
+  content: string;
+}
+
+/**
+ * Join prompt sections into a single prompt while preserving blank line separation.
+ *
+ * @param sections - Prompt sections to concatenate in order.
+ * @returns The combined prompt content suitable for LLM input.
+ */
+export function joinPromptSections(sections: PromptSection[]): string {
+  return sections
+    .map((section) => section.content)
+    .filter((content) => content && content.trim().length > 0)
+    .join("\n\n");
+}
+
+/**
  * Model-specific adaptations for autonomous agent
  * Handles quirks and requirements of different LLM providers
  */
@@ -24,6 +47,22 @@ export interface ModelAdapter {
     availableToolNames?: string[],
     toolMetadata?: ToolMetadata[]
   ): string;
+
+  /**
+   * Build ordered system prompt sections tagged with their source information.
+   *
+   * @param basePrompt - The base system prompt to enhance.
+   * @param toolDescriptions - The tool descriptions included in the prompt.
+   * @param availableToolNames - Names of tools enabled for the run.
+   * @param toolMetadata - Metadata with custom instructions for each tool.
+   * @returns Array of prompt sections in the order they should appear.
+   */
+  buildSystemPromptSections(
+    basePrompt: string,
+    toolDescriptions: string,
+    availableToolNames?: string[],
+    toolMetadata?: ToolMetadata[]
+  ): PromptSection[];
 
   /**
    * Enhance user message if needed for specific models
@@ -133,14 +172,37 @@ class BaseModelAdapter implements ModelAdapter {
     availableToolNames?: string[],
     toolMetadata?: ToolMetadata[]
   ): string {
+    const sections = this.buildSystemPromptSections(
+      basePrompt,
+      toolDescriptions,
+      availableToolNames,
+      toolMetadata
+    );
+    return joinPromptSections(sections);
+  }
+
+  buildSystemPromptSections(
+    basePrompt: string,
+    toolDescriptions: string,
+    _availableToolNames?: string[],
+    toolMetadata?: ToolMetadata[]
+  ): PromptSection[] {
     const metadata = toolMetadata || [];
-
-    // Build tool-specific instructions from metadata
-    const toolSpecificInstructions = this.buildToolSpecificInstructions(metadata);
-
-    return `${basePrompt}
-
-# Autonomous Agent Mode
+    const toolSpecificInstructions = this.buildToolSpecificInstructions(metadata).trim();
+    const normalizedBasePrompt = basePrompt.trimEnd();
+    const sections: PromptSection[] = [
+      {
+        id: "base-system-prompt",
+        label: "System prompt with memory",
+        source: "src/settings/model.ts#getSystemPromptWithMemory",
+        content: normalizedBasePrompt,
+      },
+      {
+        id: "autonomous-agent-intro",
+        label: "Autonomous agent introduction",
+        source:
+          "src/LLMProviders/chainRunner/utils/modelAdapter.ts#BaseModelAdapter.buildSystemPromptSections",
+        content: `# Autonomous Agent Mode
 
 You are now in autonomous agent mode. You can use tools to gather information and complete tasks step by step.
 
@@ -152,11 +214,29 @@ When you need to use a tool, format it EXACTLY like this:
 </use_tool>
 
 IMPORTANT: Use the EXACT parameter names as shown in the tool descriptions below. Do NOT use generic names like "param1" or "param".
+`,
+      },
+    ];
 
-Available tools:
-${toolDescriptions}
+    const trimmedToolDescriptions = toolDescriptions.trim();
 
-# Tool Usage Guidelines
+    if (trimmedToolDescriptions.length > 0) {
+      sections.push({
+        id: "tool-descriptions",
+        label: "Tool XML parameter descriptions",
+        source:
+          "src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts#generateToolDescriptions",
+        content: `Available tools:
+${trimmedToolDescriptions}`,
+      });
+    }
+
+    sections.push({
+      id: "tool-usage-guidelines",
+      label: "Tool usage guidelines",
+      source:
+        "src/LLMProviders/chainRunner/utils/modelAdapter.ts#BaseModelAdapter.buildSystemPromptSections",
+      content: `# Tool Usage Guidelines
 
 ## Time-based Queries
 When users ask about temporal periods (e.g., "what did I do last month", "show me notes from last week"), you MUST:
@@ -172,9 +252,25 @@ Example for "what did I do last month":
 Example for "meetings about project X last week":
 1. Call getTimeRangeMs with timeExpression: "last week"
 2. Use localSearch with query "meetings about project X"
-3. salientTerms: ["meetings", "project", "X"] - these words exist in the original query
+3. salientTerms: ["meetings", "project", "X"] - these words exist in the original query`,
+    });
 
-${toolSpecificInstructions ? toolSpecificInstructions + "\n\n" : ""}## General Guidelines
+    if (toolSpecificInstructions.length > 0) {
+      sections.push({
+        id: "tool-specific-instructions",
+        label: "Tool-specific instructions",
+        source:
+          "src/LLMProviders/chainRunner/utils/modelAdapter.ts#BaseModelAdapter.buildToolSpecificInstructions",
+        content: toolSpecificInstructions,
+      });
+    }
+
+    sections.push({
+      id: "general-guidelines",
+      label: "General guidelines",
+      source:
+        "src/LLMProviders/chainRunner/utils/modelAdapter.ts#BaseModelAdapter.buildSystemPromptSections",
+      content: `## General Guidelines
 - Think hard about whether a query could potentially be answered from personal knowledge or notes, if yes, call a vault search (localSearch) first
 - Only use web search if: the query explicitly asks for web search, OR the query explicitly requires current/web information
 - NEVER mention tool names like "localSearch", "webSearch", etc. in your responses. Use natural language like "searching your vault", "searching the web", etc.
@@ -186,7 +282,10 @@ When you've gathered enough information, provide your final response without any
 
 IMPORTANT: Do not include any code blocks (\`\`\`) or tool_code blocks in your responses. Only use the <use_tool> format for tool calls.
 
-NOTE: Use individual XML parameter tags. For arrays, use JSON format like ["item1", "item2"].`;
+NOTE: Use individual XML parameter tags. For arrays, use JSON format like ["item1", "item2"].`,
+    });
+
+    return sections;
   }
 
   enhanceUserMessage(message: string, requiresTools: boolean): string {
@@ -209,13 +308,13 @@ class GPTModelAdapter extends BaseModelAdapter {
   protected isGPT5Model(): boolean {
     return this.modelName.includes("gpt-5") || this.modelName.includes("gpt5");
   }
-  enhanceSystemPrompt(
+  buildSystemPromptSections(
     basePrompt: string,
     toolDescriptions: string,
     availableToolNames?: string[],
     toolMetadata?: ToolMetadata[]
-  ): string {
-    const baseSystemPrompt = super.enhanceSystemPrompt(
+  ): PromptSection[] {
+    const sections = super.buildSystemPromptSections(
       basePrompt,
       toolDescriptions,
       availableToolNames,
@@ -225,14 +324,10 @@ class GPTModelAdapter extends BaseModelAdapter {
     const tools = availableToolNames || [];
     const hasComposerTools = tools.includes("writeToFile") || tools.includes("replaceInFile");
 
-    // Insert GPT-specific instructions after the base prompt
-    let gptSpecificSection = "";
+    const gptSectionParts: string[] = [];
 
-    // Add GPT-5 specific instructions
     if (this.isGPT5Model()) {
-      gptSpecificSection = `
-
-GPT-5 SPECIFIC RULES:
+      gptSectionParts.push(`GPT-5 SPECIFIC RULES:
 - Use maximum 2 tool calls initially, then provide an answer
 - Call each tool ONCE per unique query
 - For optional parameters: OMIT them entirely if not needed (don't pass empty strings/null)
@@ -243,17 +338,15 @@ Example localSearch without time:
 <name>localSearch</name>
 <query>piano notes</query>
 <salientTerms>["piano", "notes"]</salientTerms>
-</use_tool>`;
+</use_tool>`);
     } else {
-      gptSpecificSection = `
-
-CRITICAL FOR GPT MODELS: You MUST ALWAYS include XML tool calls in your response. Do not just describe what you plan to do - you MUST include the actual XML tool call blocks.`;
+      gptSectionParts.push(
+        "CRITICAL FOR GPT MODELS: You MUST ALWAYS include XML tool calls in your response. Do not just describe what you plan to do - you MUST include the actual XML tool call blocks."
+      );
     }
 
     if (hasComposerTools) {
-      gptSpecificSection += `
-
-🚨 FILE EDITING WITH COMPOSER TOOLS - GPT SPECIFIC EXAMPLES 🚨
+      gptSectionParts.push(`🚨 FILE EDITING WITH COMPOSER TOOLS - GPT SPECIFIC EXAMPLES 🚨
 
 When user asks you to edit or modify a file, you MUST:
 1. Determine if it's a small edit (use replaceInFile) or major rewrite (use writeToFile)
@@ -300,14 +393,24 @@ EXAMPLE 2 - User says "add item 4 to the list":
 "I'll help you add item 4 to the list. Let me update that for you."
 [No tool call = FAILURE]
 
-CRITICAL: The diff parameter MUST contain the SEARCH/REPLACE blocks wrapped in triple backticks EXACTLY as shown above.`;
+CRITICAL: The diff parameter MUST contain the SEARCH/REPLACE blocks wrapped in triple backticks EXACTLY as shown above.`);
     }
 
-    gptSpecificSection += `
+    gptSectionParts.push(
+      "FINAL REMINDER FOR GPT MODELS: If the user asks you to search, find, edit, or modify anything, you MUST include the appropriate <use_tool> XML block in your very next response. Do not wait for another turn."
+    );
 
-FINAL REMINDER FOR GPT MODELS: If the user asks you to search, find, edit, or modify anything, you MUST include the appropriate <use_tool> XML block in your very next response. Do not wait for another turn.`;
+    const gptSpecificContent = gptSectionParts.join("\n\n");
 
-    return baseSystemPrompt + gptSpecificSection;
+    sections.push({
+      id: "gpt-specific-guidelines",
+      label: "GPT-specific guidance",
+      source:
+        "src/LLMProviders/chainRunner/utils/modelAdapter.ts#GPTModelAdapter.buildSystemPromptSections",
+      content: gptSpecificContent,
+    });
+
+    return sections;
   }
 
   enhanceUserMessage(message: string, requiresTools: boolean): string {
@@ -380,24 +483,25 @@ class ClaudeModelAdapter extends BaseModelAdapter {
     );
   }
 
-  enhanceSystemPrompt(
+  buildSystemPromptSections(
     basePrompt: string,
     toolDescriptions: string,
     availableToolNames?: string[],
     toolMetadata?: ToolMetadata[]
-  ): string {
-    const baseSystemPrompt = super.enhanceSystemPrompt(
+  ): PromptSection[] {
+    const sections = super.buildSystemPromptSections(
       basePrompt,
       toolDescriptions,
       availableToolNames,
       toolMetadata
     );
 
-    // Add specific instructions for thinking models
-    if (this.isThinkingModel()) {
-      let thinkingModelSection = `
+    if (!this.isThinkingModel()) {
+      return sections;
+    }
 
-IMPORTANT FOR CLAUDE THINKING MODELS:
+    const thinkingSectionParts: string[] = [
+      `IMPORTANT FOR CLAUDE THINKING MODELS:
 - You are a thinking model with internal reasoning capability
 - Your thinking process will be automatically wrapped in <think> tags - do not manually add thinking tags
 - Place ALL tool calls AFTER your thinking is complete, in the main response body
@@ -413,13 +517,11 @@ CORRECT FLOW FOR THINKING MODELS:
 4. Provide final response based on gathered information
 
 INCORRECT: Providing a final answer before using tools
-CORRECT: Using tools first, then providing answer based on results`;
+CORRECT: Using tools first, then providing answer based on results`,
+    ];
 
-      // Add even stronger instructions specifically for Claude Sonnet 4
-      if (this.isClaudeSonnet4()) {
-        thinkingModelSection += `
-
-🚨 CRITICAL INSTRUCTIONS FOR CLAUDE SONNET 4 - AUTONOMOUS AGENT MODE 🚨
+    if (this.isClaudeSonnet4()) {
+      thinkingSectionParts.push(`🚨 CRITICAL INSTRUCTIONS FOR CLAUDE SONNET 4 - AUTONOMOUS AGENT MODE 🚨
 
 ⚠️  WARNING: You have a specific tendency to write complete responses immediately after tool calls. This BREAKS the autonomous agent pattern!
 
@@ -491,13 +593,18 @@ Based on the search results, here's a complete practice plan...
 3. If you need more tools: Brief sentence + more tool calls, then STOP
 4. If you have enough info: THEN provide your final response
 
-REMEMBER: One brief sentence before tools is perfect. Nothing after tool calls.`;
-      }
-
-      return baseSystemPrompt + thinkingModelSection;
+REMEMBER: One brief sentence before tools is perfect. Nothing after tool calls.`);
     }
 
-    return baseSystemPrompt;
+    sections.push({
+      id: "claude-thinking-guidelines",
+      label: "Claude thinking model guidance",
+      source:
+        "src/LLMProviders/chainRunner/utils/modelAdapter.ts#ClaudeModelAdapter.buildSystemPromptSections",
+      content: thinkingSectionParts.join("\n\n"),
+    });
+
+    return sections;
   }
 
   needsSpecialHandling(): boolean {
@@ -630,13 +737,13 @@ REMEMBER: One brief sentence before tools is perfect. Nothing after tool calls.`
  * Gemini adapter with aggressive tool calling prompts
  */
 class GeminiModelAdapter extends BaseModelAdapter {
-  enhanceSystemPrompt(
+  buildSystemPromptSections(
     basePrompt: string,
     toolDescriptions: string,
     availableToolNames?: string[],
     toolMetadata?: ToolMetadata[]
-  ): string {
-    const baseSystemPrompt = super.enhanceSystemPrompt(
+  ): PromptSection[] {
+    const sections = super.buildSystemPromptSections(
       basePrompt,
       toolDescriptions,
       availableToolNames,
@@ -647,9 +754,8 @@ class GeminiModelAdapter extends BaseModelAdapter {
     const tools = availableToolNames || [];
     const hasLocalSearch = tools.includes("localSearch");
 
-    const geminiSpecificSection = `
-
-🚨 CRITICAL INSTRUCTIONS FOR GEMINI - AUTONOMOUS AGENT MODE 🚨
+    const geminiSectionParts: string[] = [
+      `🚨 CRITICAL INSTRUCTIONS FOR GEMINI - AUTONOMOUS AGENT MODE 🚨
 
 You MUST use tools to complete tasks. DO NOT ask the user questions about how to proceed.
 ${
@@ -665,11 +771,12 @@ When the user mentions "my notes" or "my vault", use the localSearch tool.
 <name>localSearch</name>
 <query>piano</query>
 <salientTerms>["piano"]</salientTerms>
-</use_tool>
-`
+</use_tool>`
     : ""
-}
-GEMINI SPECIFIC RULES:
+}`.trim(),
+    ];
+
+    geminiSectionParts.push(`GEMINI SPECIFIC RULES:
 1. When user mentions "my notes" about X → use localSearch with query "X"
 2. DO NOT ask clarifying questions about search terms
 3. DO NOT wait for permission to use tools
@@ -684,9 +791,17 @@ Your response:
 <salientTerms>["project", "roadmap"]</salientTerms>
 </use_tool>
 
-Remember: The user has already told you what to do. Execute it NOW with the available tools.`;
+Remember: The user has already told you what to do. Execute it NOW with the available tools.`);
 
-    return baseSystemPrompt + geminiSpecificSection;
+    sections.push({
+      id: "gemini-specific-guidelines",
+      label: "Gemini-specific guidance",
+      source:
+        "src/LLMProviders/chainRunner/utils/modelAdapter.ts#GeminiModelAdapter.buildSystemPromptSections",
+      content: geminiSectionParts.join("\n\n"),
+    });
+
+    return sections;
   }
 
   enhanceUserMessage(message: string, requiresTools: boolean): string {

--- a/src/LLMProviders/chainRunner/utils/promptDebugService.test.ts
+++ b/src/LLMProviders/chainRunner/utils/promptDebugService.test.ts
@@ -1,0 +1,98 @@
+import { generatePromptDebugReportForAgent, resolveBasePrompt } from "./promptDebugService";
+import { PromptSection } from "./modelAdapter";
+import { PromptDebugReport } from "./toolPromptDebugger";
+
+const createAdapter = () => ({
+  buildSystemPromptSections: jest.fn(
+    (
+      basePrompt: string,
+      toolDescriptions: string,
+      toolNames?: string[],
+      toolMetadata?: any[]
+    ): PromptSection[] => [
+      {
+        id: "system",
+        label: "System",
+        source: "test",
+        content: `${basePrompt}::${toolDescriptions}::${toolNames?.join(",") || ""}::${
+          toolMetadata?.length ?? 0
+        }`,
+      },
+    ]
+  ),
+  enhanceUserMessage: jest.fn((message: string) => `${message} (enhanced)`),
+  constructor: { name: "TestAdapter" },
+});
+
+const createChainContext = (history: any[] = []) => {
+  const memory = {
+    loadMemoryVariables: jest.fn().mockResolvedValue({ history }),
+  };
+
+  return {
+    memoryManager: {
+      getMemory: () => memory,
+    },
+    userMemoryManager: {
+      getUserMemoryPrompt: jest.fn().mockResolvedValue(null),
+    },
+  } as any;
+};
+
+describe("promptDebugService", () => {
+  it("builds prompt debug report with annotated sections", async () => {
+    const adapter = createAdapter();
+    const chainManager = createChainContext([{ _getType: () => "human", content: "hello" }]);
+
+    const report: PromptDebugReport = await generatePromptDebugReportForAgent({
+      chainManager,
+      adapter: adapter as any,
+      basePrompt: "BasePrompt",
+      toolDescriptions: "<tool></tool>",
+      toolNames: ["localSearch"],
+      toolMetadata: [
+        {
+          id: "localSearch",
+          displayName: "Vault Search",
+          description: "Search",
+          category: "search",
+        },
+      ],
+      userMessage: {
+        message: "search my notes",
+        originalMessage: "search my notes",
+        sender: "user",
+        timestamp: null,
+        isVisible: true,
+      },
+    });
+
+    expect(adapter.buildSystemPromptSections).toHaveBeenCalledWith(
+      "BasePrompt",
+      "<tool></tool>",
+      ["localSearch"],
+      expect.any(Array)
+    );
+    expect(adapter.enhanceUserMessage).toHaveBeenCalledWith("search my notes", true);
+    expect(report.sections.map((section) => section.id)).toEqual([
+      "system",
+      "chat-history",
+      "user-original-message",
+      "user-enhanced-message",
+    ]);
+    expect(report.annotatedPrompt).toContain("[Section: System | Source: test]");
+    expect(report.systemPrompt).toBeDefined();
+  });
+
+  it("resolves base prompt using provided user memory manager", async () => {
+    const memoryPrompt = "<memory>data</memory>";
+    const chainManager = {
+      userMemoryManager: {
+        getUserMemoryPrompt: jest.fn().mockResolvedValue(memoryPrompt),
+      },
+    } as any;
+
+    const prompt = await resolveBasePrompt(chainManager);
+    expect(prompt).toContain(memoryPrompt);
+  });
+});

--- a/src/LLMProviders/chainRunner/utils/promptDebugService.ts
+++ b/src/LLMProviders/chainRunner/utils/promptDebugService.ts
@@ -1,0 +1,108 @@
+import ChainManager from "@/LLMProviders/chainManager";
+import { getSystemPromptWithMemory } from "@/settings/model";
+import { ToolMetadata, ToolRegistry } from "@/tools/ToolRegistry";
+import { ChatMessage } from "@/types/message";
+import { messageRequiresTools, ModelAdapter } from "./modelAdapter";
+import { buildPromptDebugReport, PromptDebugReport } from "./toolPromptDebugger";
+import { SimpleTool } from "@/tools/SimpleTool";
+
+interface GeneratePromptDebugReportParams {
+  chainManager: ChainManager;
+  adapter: ModelAdapter;
+  basePrompt: string;
+  toolDescriptions: string;
+  toolNames: string[];
+  toolMetadata: ToolMetadata[];
+  userMessage: ChatMessage;
+}
+
+/**
+ * Build an annotated prompt debug report for the autonomous agent.
+ *
+ * @param params - Context required to assemble the prompt sections.
+ * @returns Structured prompt report with provenance metadata.
+ */
+export async function generatePromptDebugReportForAgent(
+  params: GeneratePromptDebugReportParams
+): Promise<PromptDebugReport> {
+  const {
+    chainManager,
+    adapter,
+    basePrompt,
+    toolDescriptions,
+    toolNames,
+    toolMetadata,
+    userMessage,
+  } = params;
+
+  const systemSections = adapter.buildSystemPromptSections(
+    basePrompt,
+    toolDescriptions,
+    toolNames,
+    toolMetadata
+  );
+
+  const memory = chainManager.memoryManager.getMemory();
+  const memoryVariables = await memory.loadMemoryVariables({});
+  const rawHistory = Array.isArray(memoryVariables.history) ? memoryVariables.history : [];
+
+  const originalUserMessage = userMessage.originalMessage || userMessage.message;
+  const requiresTools = messageRequiresTools(userMessage.message);
+  const enhancedUserMessage = adapter.enhanceUserMessage(userMessage.message, requiresTools);
+
+  return buildPromptDebugReport({
+    systemSections,
+    rawHistory,
+    adapterName: adapter.constructor?.name || "ModelAdapter",
+    originalUserMessage,
+    enhancedUserMessage,
+  });
+}
+
+/**
+ * Convenience helper to compute the base prompt with memory using the provided chain manager.
+ *
+ * @param chainManager - Chain manager hosting the user memory manager.
+ * @returns The base system prompt inclusive of memory content.
+ */
+export async function resolveBasePrompt(chainManager: ChainManager): Promise<string> {
+  return getSystemPromptWithMemory(chainManager.userMemoryManager);
+}
+
+interface AgentPromptDebugOptions {
+  chainManager: ChainManager;
+  adapter: ModelAdapter;
+  availableTools: SimpleTool<any, any>[];
+  toolDescriptions: string;
+  userMessage: ChatMessage;
+}
+
+/**
+ * Produce a prompt debug report directly from an agent runner context.
+ *
+ * @param options - Agent context, available tools, and user message.
+ * @returns Annotated prompt debug report.
+ */
+export async function buildAgentPromptDebugReport(
+  options: AgentPromptDebugOptions
+): Promise<PromptDebugReport> {
+  const { chainManager, adapter, availableTools, toolDescriptions, userMessage } = options;
+
+  const registry = ToolRegistry.getInstance();
+  const toolNames = availableTools.map((tool) => tool.name);
+  const toolMetadata = availableTools
+    .map((tool) => registry.getToolMetadata(tool.name))
+    .filter((meta): meta is NonNullable<typeof meta> => meta !== undefined);
+
+  const basePrompt = await resolveBasePrompt(chainManager);
+
+  return generatePromptDebugReportForAgent({
+    chainManager,
+    adapter,
+    basePrompt,
+    toolDescriptions,
+    toolNames,
+    toolMetadata,
+    userMessage,
+  });
+}

--- a/src/LLMProviders/chainRunner/utils/promptPayloadRecorder.test.ts
+++ b/src/LLMProviders/chainRunner/utils/promptPayloadRecorder.test.ts
@@ -1,0 +1,70 @@
+import { logMarkdownBlock } from "@/logger";
+import {
+  __getLatestPromptPayloadSnapshotForTests,
+  clearRecordedPromptPayload,
+  flushRecordedPromptPayloadToLog,
+  recordPromptPayload,
+} from "./promptPayloadRecorder";
+
+jest.mock("@/logger", () => ({
+  logMarkdownBlock: jest.fn(),
+}));
+
+describe("promptPayloadRecorder", () => {
+  beforeEach(() => {
+    (logMarkdownBlock as jest.Mock).mockClear();
+    clearRecordedPromptPayload();
+  });
+
+  it("records messages and flushes them as markdown", async () => {
+    const messages = [
+      { role: "system", content: "hello" },
+      { role: "user", content: "world" },
+    ];
+
+    recordPromptPayload({ messages, modelName: "gpt-test" });
+    expect(__getLatestPromptPayloadSnapshotForTests()).not.toBeNull();
+
+    await flushRecordedPromptPayloadToLog();
+
+    expect(logMarkdownBlock).toHaveBeenCalledTimes(1);
+    const lines = (logMarkdownBlock as jest.Mock).mock.calls[0][0] as string[];
+    expect(lines[0]).toContain("Agent Prompt Payload");
+    expect(lines[0]).toContain("gpt-test");
+    expect(lines[1]).toBe("```json");
+    expect(lines[2]).toContain('"role": "system"');
+    expect(lines[3]).toBe("```");
+    expect(__getLatestPromptPayloadSnapshotForTests()).toBeNull();
+  });
+
+  it("does not flush twice without a new recording", async () => {
+    recordPromptPayload({ messages: [{ role: "system", content: "hello" }] });
+
+    await flushRecordedPromptPayloadToLog();
+    await flushRecordedPromptPayloadToLog();
+
+    expect(logMarkdownBlock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears recorded payloads when requested", async () => {
+    recordPromptPayload({ messages: [{ role: "system", content: "hello" }] });
+    clearRecordedPromptPayload();
+
+    await flushRecordedPromptPayloadToLog();
+
+    expect(logMarkdownBlock).not.toHaveBeenCalled();
+  });
+
+  it("serializes circular message graphs without throwing", async () => {
+    const circular: any = { role: "system" };
+    circular.self = circular;
+
+    expect(() => recordPromptPayload({ messages: [circular] })).not.toThrow();
+
+    await flushRecordedPromptPayloadToLog();
+
+    expect(logMarkdownBlock).toHaveBeenCalledTimes(1);
+    const lines = (logMarkdownBlock as jest.Mock).mock.calls[0][0] as string[];
+    expect(lines[2]).toContain("[Circular]");
+  });
+});

--- a/src/LLMProviders/chainRunner/utils/promptPayloadRecorder.ts
+++ b/src/LLMProviders/chainRunner/utils/promptPayloadRecorder.ts
@@ -1,0 +1,96 @@
+import { logMarkdownBlock } from "@/logger";
+
+interface PromptPayloadSnapshot {
+  timestamp: string;
+  modelName?: string;
+  serializedMessages: string;
+}
+
+let latestSnapshot: PromptPayloadSnapshot | null = null;
+
+/**
+ * Safely serialize the model conversation payload for logging while preserving readability.
+ *
+ * @param value - Messages array destined for the LLM.
+ * @returns Pretty-printed JSON representation with circular references handled.
+ */
+function safeSerialize(value: unknown): string {
+  const seen = new WeakSet();
+
+  return JSON.stringify(
+    value,
+    (key, val) => {
+      if (typeof val === "object" && val !== null) {
+        if (seen.has(val)) {
+          return "[Circular]";
+        }
+        seen.add(val);
+      }
+
+      if (typeof val === "bigint") {
+        return val.toString();
+      }
+
+      return val;
+    },
+    2
+  );
+}
+
+/**
+ * Record the latest prompt payload destined for the LLM so it can be shared on demand.
+ *
+ * @param params - Metadata describing the payload and the message array.
+ */
+export function recordPromptPayload(params: { messages: unknown[]; modelName?: string }): void {
+  const { messages, modelName } = params;
+
+  try {
+    latestSnapshot = {
+      timestamp: new Date().toISOString(),
+      modelName,
+      serializedMessages: safeSerialize(messages),
+    };
+  } catch {
+    // Fall back to best-effort stringification to avoid blocking logging entirely.
+    latestSnapshot = {
+      timestamp: new Date().toISOString(),
+      modelName,
+      serializedMessages: String(messages),
+    };
+  }
+}
+
+/**
+ * Clear the stored prompt payload so stale data is not shared after a reset/new chat.
+ */
+export function clearRecordedPromptPayload(): void {
+  latestSnapshot = null;
+}
+
+/**
+ * Flush the recorded payload into the Copilot log file using a markdown block.
+ */
+export async function flushRecordedPromptPayloadToLog(): Promise<void> {
+  if (!latestSnapshot) {
+    return;
+  }
+
+  const { timestamp, modelName, serializedMessages } = latestSnapshot;
+  const headerLines = [
+    `### Agent Prompt Payload — ${timestamp}${modelName ? ` (model: ${modelName})` : ""}`,
+  ];
+
+  logMarkdownBlock([...headerLines, "```json", serializedMessages, "```", ""]);
+
+  latestSnapshot = null;
+}
+
+/**
+ * Internal helper exposed for tests to inspect the stored snapshot state.
+ *
+ * @returns The current snapshot or null if none is stored.
+ */
+export function __getLatestPromptPayloadSnapshotForTests(): PromptPayloadSnapshot | null {
+  return latestSnapshot;
+}

--- a/src/LLMProviders/chainRunner/utils/toolPromptDebugger.test.ts
+++ b/src/LLMProviders/chainRunner/utils/toolPromptDebugger.test.ts
@@ -1,0 +1,58 @@
+import { buildPromptDebugReport } from "./toolPromptDebugger";
+import { PromptSection } from "./modelAdapter";
+
+describe("toolPromptDebugger", () => {
+  it("builds annotated prompt output with provenance markers", () => {
+    const systemSections: PromptSection[] = [
+      {
+        id: "base",
+        label: "Base System Prompt",
+        source: "base-source",
+        content: "base content",
+      },
+      {
+        id: "intro",
+        label: "Intro",
+        source: "intro-source",
+        content: "intro content",
+      },
+    ];
+
+    const rawHistory = [
+      {
+        _getType: () => "human",
+        content: "Previous user question",
+      },
+      {
+        _getType: () => "ai",
+        content: "Assistant reply",
+      },
+    ];
+
+    const report = buildPromptDebugReport({
+      systemSections,
+      rawHistory,
+      adapterName: "BaseModelAdapter",
+      originalUserMessage: "What is the plan?",
+      enhancedUserMessage: "What is the plan?",
+    });
+
+    const sectionIds = report.sections.map((section) => section.id);
+    expect(sectionIds).toEqual([
+      "base",
+      "intro",
+      "chat-history",
+      "user-original-message",
+      "user-enhanced-message",
+    ]);
+
+    const enhancedSection = report.sections[report.sections.length - 1];
+    expect(enhancedSection.label).toContain("unchanged");
+
+    expect(report.annotatedPrompt).toContain("[Section: Base System Prompt | Source: base-source]");
+    expect(report.annotatedPrompt).toContain("1. USER");
+    expect(report.annotatedPrompt).toContain("2. ASSISTANT");
+
+    expect(report.systemPrompt).toBe("base content\n\nintro content");
+  });
+});

--- a/src/LLMProviders/chainRunner/utils/toolPromptDebugger.ts
+++ b/src/LLMProviders/chainRunner/utils/toolPromptDebugger.ts
@@ -1,0 +1,106 @@
+import { PromptSection, joinPromptSections } from "./modelAdapter";
+import { processRawChatHistory, processedMessagesToTextOnly } from "./chatHistoryUtils";
+
+/**
+ * Options for building prompt debug sections with annotated provenance.
+ */
+export interface BuildPromptDebugSectionsOptions {
+  systemSections: PromptSection[];
+  rawHistory?: any[];
+  adapterName: string;
+  originalUserMessage: string;
+  enhancedUserMessage: string;
+}
+
+/**
+ * Resulting debug report containing structured sections and the annotated string representation.
+ */
+export interface PromptDebugReport {
+  sections: PromptSection[];
+  annotatedPrompt: string;
+  systemPrompt: string;
+}
+
+/**
+ * Build ordered prompt sections that include system prompt components, optional chat history, and user messages.
+ *
+ * @param options - Data required to assemble annotated prompt sections.
+ * @returns Prompt sections with provenance metadata.
+ */
+export function buildPromptDebugSections(
+  options: BuildPromptDebugSectionsOptions
+): PromptSection[] {
+  const { systemSections, rawHistory, adapterName, originalUserMessage, enhancedUserMessage } =
+    options;
+  const sections: PromptSection[] = [...systemSections];
+
+  if (rawHistory && rawHistory.length > 0) {
+    const processedHistory = processRawChatHistory(rawHistory);
+    if (processedHistory.length > 0) {
+      const textHistory = processedMessagesToTextOnly(processedHistory);
+      const historyLines = textHistory.map((entry, index) => {
+        return `${index + 1}. ${entry.role.toUpperCase()}\n${entry.content}`;
+      });
+
+      sections.push({
+        id: "chat-history",
+        label: "Restored chat history from memory",
+        source: "src/LLMProviders/chainRunner/utils/chatHistoryUtils.ts#processRawChatHistory",
+        content: historyLines.join("\n\n"),
+      });
+    }
+  }
+
+  sections.push({
+    id: "user-original-message",
+    label: "Original user message",
+    source: "Chat input",
+    content: originalUserMessage,
+  });
+
+  const adapterLabelSuffix = enhancedUserMessage === originalUserMessage ? " (unchanged)" : "";
+
+  sections.push({
+    id: "user-enhanced-message",
+    label: `User message after ${adapterName}.enhanceUserMessage${adapterLabelSuffix}`,
+    source: `src/LLMProviders/chainRunner/utils/modelAdapter.ts#${adapterName}.enhanceUserMessage`,
+    content: enhancedUserMessage,
+  });
+
+  return sections;
+}
+
+/**
+ * Format prompt sections into an annotated string that highlights each section's origin.
+ *
+ * @param sections - Prompt sections with provenance metadata.
+ * @returns Multiline string with section headers that identify code sources.
+ */
+export function formatPromptSectionsWithAnnotations(sections: PromptSection[]): string {
+  return sections
+    .map((section) => {
+      const header = `[Section: ${section.label} | Source: ${section.source}]`;
+      return `${header}\n${section.content}`;
+    })
+    .join("\n\n");
+}
+
+/**
+ * Build a complete prompt debug report containing structured sections and the annotated string output.
+ *
+ * @param options - Data required to assemble annotated prompt sections.
+ * @returns Report including sections, annotated prompt, and the raw system prompt string.
+ */
+export function buildPromptDebugReport(
+  options: BuildPromptDebugSectionsOptions
+): PromptDebugReport {
+  const sections = buildPromptDebugSections(options);
+  const annotatedPrompt = formatPromptSectionsWithAnnotations(sections);
+  const systemPrompt = joinPromptSections(options.systemSections);
+
+  return {
+    sections,
+    annotatedPrompt,
+    systemPrompt,
+  };
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,10 @@ import { logFileManager } from "@/logFileManager";
 import { FileCache } from "@/cache/fileCache";
 import { ProjectContextCache } from "@/cache/projectContextCache";
 import { logError } from "@/logger";
+import {
+  clearRecordedPromptPayload,
+  flushRecordedPromptPayloadToLog,
+} from "@/LLMProviders/chainRunner/utils/promptPayloadRecorder";
 
 import { CustomCommandSettingsModal } from "@/commands/CustomCommandSettingsModal";
 import { EMPTY_COMMAND, QUICK_COMMAND_CODE_BLOCK } from "@/commands/constants";
@@ -99,6 +103,7 @@ export function registerCommands(
   });
 
   addCommand(plugin, COMMAND_IDS.NEW_CHAT, () => {
+    clearRecordedPromptPayload();
     plugin.newChat();
   });
 
@@ -334,6 +339,7 @@ export function registerCommands(
   // Create Copilot log file
   addCommand(plugin, COMMAND_IDS.OPEN_LOG_FILE, async () => {
     try {
+      await flushRecordedPromptPayloadToLog();
       await logFileManager.openLogFile();
     } catch (error) {
       logError("Error creating Copilot log file:", error);

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -11,7 +11,6 @@ import {
 import { ChainType } from "@/chainFactory";
 import { useProjectContextStatus } from "@/hooks/useProjectContextStatus";
 import { logInfo, logError } from "@/logger";
-import { logFileManager } from "@/logFileManager";
 
 import { ChatControls, reloadCurrentProject } from "@/components/chat-components/ChatControls";
 import ChatInput from "@/components/chat-components/ChatInput";
@@ -539,7 +538,6 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
 
   const handleNewChat = useCallback(async () => {
     clearRecordedPromptPayload();
-    await logFileManager.clear();
     handleStopGenerating(ABORT_REASON.NEW_CHAT);
 
     // Analyze chat messages for memory if enabled

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -11,6 +11,7 @@ import {
 import { ChainType } from "@/chainFactory";
 import { useProjectContextStatus } from "@/hooks/useProjectContextStatus";
 import { logInfo, logError } from "@/logger";
+import { logFileManager } from "@/logFileManager";
 
 import { ChatControls, reloadCurrentProject } from "@/components/chat-components/ChatControls";
 import ChatInput from "@/components/chat-components/ChatInput";
@@ -30,6 +31,7 @@ import { ChatInputProvider, useChatInput } from "@/context/ChatInputContext";
 import { useChatManager } from "@/hooks/useChatManager";
 import { getAIResponse } from "@/langchainStream";
 import ChainManager from "@/LLMProviders/chainManager";
+import { clearRecordedPromptPayload } from "@/LLMProviders/chainRunner/utils/promptPayloadRecorder";
 import CopilotPlugin from "@/main";
 import { useIsPlusUser } from "@/plusUtils";
 import { updateSetting, useSettingsValue } from "@/settings/model";
@@ -536,6 +538,8 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
   );
 
   const handleNewChat = useCallback(async () => {
+    clearRecordedPromptPayload();
+    await logFileManager.clear();
     handleStopGenerating(ABORT_REASON.NEW_CHAT);
 
     // Analyze chat messages for memory if enabled

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -156,7 +156,7 @@ export enum ChatModels {
   OPENROUTER_GEMINI_2_5_FLASH_LITE = "google/gemini-2.5-flash-lite",
   OPENROUTER_GPT_41 = "openai/gpt-4.1",
   OPENROUTER_GPT_41_MINI = "openai/gpt-4.1-mini",
-  OPENROUTER_GROK_4_FAST_FREE = "x-ai/grok-4-fast:free",
+  OPENROUTER_GROK_4_FAST = "x-ai/grok-4-fast",
 }
 
 // Model Providers
@@ -246,7 +246,7 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     capabilities: [ModelCapability.VISION],
   },
   {
-    name: ChatModels.OPENROUTER_GROK_4_FAST_FREE,
+    name: ChatModels.OPENROUTER_GROK_4_FAST,
     provider: ChatModelProviders.OPENROUTERAI,
     enabled: true,
     isBuiltIn: true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import { encryptAllKeys } from "@/encryptionService";
 import { logInfo } from "@/logger";
 import { logFileManager } from "@/logFileManager";
 import { UserMemoryManager } from "@/memory/UserMemoryManager";
+import { clearRecordedPromptPayload } from "@/LLMProviders/chainRunner/utils/promptPayloadRecorder";
 import { checkIsPlusUser } from "@/plusUtils";
 import VectorStoreManager from "@/search/vectorStoreManager";
 import { CopilotSettingTab } from "@/settings/SettingsPage";
@@ -466,6 +467,9 @@ export default class CopilotPlugin extends Plugin {
   }
 
   async handleNewChat() {
+    clearRecordedPromptPayload();
+    await logFileManager.clear();
+
     // Analyze chat messages for memory if enabled
     if (getSettings().enableRecentConversations) {
       try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -468,7 +468,6 @@ export default class CopilotPlugin extends Plugin {
 
   async handleNewChat() {
     clearRecordedPromptPayload();
-    await logFileManager.clear();
 
     // Analyze chat messages for memory if enabled
     if (getSettings().enableRecentConversations) {

--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { SettingItem } from "@/components/ui/setting-item";
 import { logFileManager } from "@/logFileManager";
+import { flushRecordedPromptPayloadToLog } from "@/LLMProviders/chainRunner/utils/promptPayloadRecorder";
 import { updateSetting, useSettingsValue } from "@/settings/model";
 import React from "react";
 
@@ -50,6 +51,7 @@ export const AdvancedSettings: React.FC = () => {
               variant="secondary"
               size="sm"
               onClick={async () => {
+                await flushRecordedPromptPayloadToLog();
                 await logFileManager.flush();
                 await logFileManager.openLogFile();
               }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a CLI and services for agent prompt debugging, refactors model adapters to structured prompt sections, improves tool-call/CiC handling, and records/flushed prompt payloads to logs.
> 
> - **Agent Prompt Debugging**:
>   - Add CLI `npm run prompt:debug` with `scripts/printPromptDebug.*` and Obsidian stubs to generate annotated prompt reports.
>   - New services: `promptDebugService` and `toolPromptDebugger` to build sectioned, provenance-annotated prompts.
> - **Model Adapter Refactor**:
>   - Introduce `PromptSection` and `joinPromptSections`; adapters now build ordered sections (`buildSystemPromptSections`) for GPT/Claude/Gemini and then join.
>   - Tests updated/added to validate reconstruction and annotations.
> - **Autonomous Agent Enhancements**:
>   - Expose `generateToolDescriptions`; add `buildToolPromptDebugReport`.
>   - Ensure encoded tool-call marker results are stored; append assistant/final messages consistently.
>   - Apply CiC ordering to `localSearch` via `ensureCiCOrderingWithQuestion`.
>   - Record conversation payloads with `recordPromptPayload` (including model name).
> - **Prompt Payload Recording**:
>   - New `promptPayloadRecorder` to record/flush/clear payloads; wired into commands, Chat, main, and settings (flush on open log; clear on new chat).
> - **Utilities/Tests**:
>   - Add `ensureCiCOrderingWithQuestion` to `cicPromptUtils` with tests.
>   - Add comprehensive tests for prompt debug and payload recorder.
> - **Models**:
>   - Rename `ChatModels.OPENROUTER_GROK_4_FAST_FREE` to `OPENROUTER_GROK_4_FAST` in `constants`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5facf0f13e70f7725c8fac94c177250bb561e42a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->