### PR TITLE
Add read tool

### DIFF
--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -34,7 +34,10 @@ import {
   ToolExecutionResult,
 } from "./utils/toolExecution";
 
-import { ensureCiCOrderingWithQuestion } from "./utils/cicPromptUtils";
+import {
+  appendInlineCitationReminder,
+  ensureCiCOrderingWithQuestion,
+} from "./utils/cicPromptUtils";
 import { buildAgentPromptDebugReport } from "./utils/promptDebugService";
 import { recordPromptPayload } from "./utils/promptPayloadRecorder";
 import { PromptDebugReport } from "./utils/toolPromptDebugger";
@@ -153,7 +156,12 @@ ${params}
     localSearchPayload: string,
     originalPrompt: string
   ): string {
-    return ensureCiCOrderingWithQuestion(localSearchPayload, originalPrompt);
+    const settings = getSettings();
+    const promptWithReminder = appendInlineCitationReminder(
+      originalPrompt,
+      Boolean(settings?.enableInlineCitations)
+    );
+    return ensureCiCOrderingWithQuestion(localSearchPayload, promptWithReminder);
   }
 
   private getTemporaryToolCallId(toolName: string, index: number): string {

--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -406,7 +406,14 @@ ${params}
           if (!isBackgroundTool) {
             // Create tool calling message with structured marker
             const toolEmoji = getToolEmoji(toolCall.name);
-            const toolDisplayName = getToolDisplayName(toolCall.name);
+            let toolDisplayName = getToolDisplayName(toolCall.name);
+            if (toolCall.name === "readNote") {
+              const notePath =
+                typeof toolCall.args?.notePath === "string" ? toolCall.args.notePath : null;
+              if (notePath && notePath.trim().length > 0) {
+                toolDisplayName = notePath.trim();
+              }
+            }
             const confirmationMessage = getToolConfirmtionMessage(toolCall.name);
 
             // Generate unique ID for this tool call

--- a/src/LLMProviders/chainRunner/utils/cicPromptUtils.test.ts
+++ b/src/LLMProviders/chainRunner/utils/cicPromptUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  appendInlineCitationReminder,
   buildLocalSearchInnerContent,
   ensureCiCOrderingWithQuestion,
   renderCiCMessage,
@@ -46,6 +47,35 @@ describe("cicPromptUtils", () => {
 
     it("returns the original question when context is blank", () => {
       expect(renderCiCMessage("  \n  ", "What?", false)).toBe("What?");
+    });
+  });
+
+  describe("appendInlineCitationReminder", () => {
+    it("appends reminder when enabled and question has content", () => {
+      const result = appendInlineCitationReminder("Summarize my notes.", true);
+
+      expect(result).toBe(
+        "Summarize my notes.\n\nHave inline citations according to the guidance."
+      );
+    });
+
+    it("returns original question when reminder disabled", () => {
+      const result = appendInlineCitationReminder("Summarize my notes.", false);
+
+      expect(result).toBe("Summarize my notes.");
+    });
+
+    it("avoids duplicating reminder when already present", () => {
+      const question = "Summarize. Have inline citations according to the guidance.";
+      const result = appendInlineCitationReminder(question, true);
+
+      expect(result).toBe("Summarize. Have inline citations according to the guidance.");
+    });
+
+    it("returns reminder alone when question is blank", () => {
+      const result = appendInlineCitationReminder("   ", true);
+
+      expect(result).toBe("Have inline citations according to the guidance.");
     });
   });
 

--- a/src/LLMProviders/chainRunner/utils/cicPromptUtils.ts
+++ b/src/LLMProviders/chainRunner/utils/cicPromptUtils.ts
@@ -29,6 +29,32 @@ export function wrapLocalSearchPayload(innerContent: string, timeExpression: str
 }
 
 /**
+ * Append an inline citation reminder to the user's question when enabled.
+ *
+ * @param question - The original user question.
+ * @param shouldRemind - Whether inline citations are enabled and the reminder should be added.
+ * @returns The question with the reminder appended when required.
+ */
+export function appendInlineCitationReminder(question: string, shouldRemind: boolean): string {
+  if (!shouldRemind) {
+    return question;
+  }
+
+  const reminder = "Have inline citations according to the guidance.";
+  const trimmedQuestion = question.trimEnd();
+
+  if (!trimmedQuestion) {
+    return reminder;
+  }
+
+  if (trimmedQuestion.toLowerCase().includes(reminder.toLowerCase())) {
+    return trimmedQuestion;
+  }
+
+  return `${trimmedQuestion}\n\n${reminder}`;
+}
+
+/**
  * Produces a CiC-aligned prompt by placing context first and the user question last.
  * @param contextSection Prepared instruction/context block.
  * @param userQuestion Original user message.

--- a/src/LLMProviders/chainRunner/utils/toolExecution.ts
+++ b/src/LLMProviders/chainRunner/utils/toolExecution.ts
@@ -172,6 +172,7 @@ export function getToolEmoji(toolName: string): string {
     indexTool: "📚",
     writeToFile: "✏️",
     replaceInFile: "🔄",
+    readNote: "🔍",
   };
 
   return emojiMap[toolName] || "🔧";

--- a/src/components/chat-components/ToolCallBanner.tsx
+++ b/src/components/chat-components/ToolCallBanner.tsx
@@ -114,8 +114,10 @@ export const ToolCallBanner: React.FC<ToolCallBannerProps> = ({
           <div className="tw-flex tw-items-center tw-gap-2">
             <span className="tw-text-base">{emoji}</span>
             <span className="tw-font-medium">
-              {isExecuting ? "Calling" : "Called"} {displayName}
-              {isExecuting && "..."}
+              {toolName === "readNote"
+                ? `${isExecuting ? "Reading" : "Read"} ${displayName}`
+                : `${isExecuting ? "Calling" : "Called"} ${displayName}`}
+              {isExecuting && toolName !== "readNote" && "..."}
             </span>
             {isExecuting && confirmationMessage && (
               <span className="tw-text-xs tw-text-muted">• {confirmationMessage}...</span>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -781,6 +781,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   autonomousAgentMaxIterations: 4,
   autonomousAgentEnabledToolIds: [
     "localSearch",
+    "readNote",
     "webSearch",
     "pomodoro",
     "youtubeTranscription",

--- a/src/tools/NoteTools.ts
+++ b/src/tools/NoteTools.ts
@@ -1,0 +1,127 @@
+import { TFile } from "obsidian";
+import { z } from "zod";
+import { logInfo, logWarn } from "@/logger";
+import { Chunk, ChunkManager } from "@/search/v3/chunks";
+import { createTool } from "./SimpleTool";
+
+let chunkManagerInstance: ChunkManager | null = null;
+
+/**
+ * Lazily retrieve the shared ChunkManager instance.
+ */
+function getChunkManager(): ChunkManager {
+  if (!chunkManagerInstance) {
+    chunkManagerInstance = new ChunkManager(app);
+  }
+  return chunkManagerInstance;
+}
+
+/**
+ * Resolve the note path to a TFile if possible.
+ */
+async function resolveNoteFile(notePath: string): Promise<TFile | null> {
+  const file = app.vault.getAbstractFileByPath(notePath);
+
+  if (!file || !(file instanceof TFile)) {
+    return null;
+  }
+
+  return file;
+}
+
+/**
+ * Load chunks for the specified note and return them ordered by their index.
+ */
+async function loadOrderedChunks(notePath: string): Promise<Chunk[]> {
+  const chunkManager = getChunkManager();
+  const chunks = await chunkManager.getChunks([notePath]);
+
+  return chunks
+    .filter((chunk) => chunk.notePath === notePath)
+    .sort((a, b) => a.chunkIndex - b.chunkIndex);
+}
+
+const readNoteSchema = z.object({
+  notePath: z
+    .string()
+    .min(1)
+    .describe(
+      "Full path to the note (relative to the vault root) that needs to be read, such as 'Projects/plan.md'."
+    ),
+  chunkIndex: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("0-based chunk index to read. Omit to read the first chunk."),
+});
+
+const readNoteTool = createTool({
+  name: "readNote",
+  description:
+    "Read a single note in search v3 sized chunks. Use only when you already know the exact note path and need its contents.",
+  schema: readNoteSchema,
+  handler: async ({ notePath, chunkIndex = 0 }) => {
+    const sanitizedPath = notePath.trim();
+
+    if (sanitizedPath.startsWith("/")) {
+      return {
+        notePath: sanitizedPath,
+        status: "invalid_path",
+        message: "Provide the note path relative to the vault root without a leading slash.",
+      };
+    }
+
+    const file = await resolveNoteFile(sanitizedPath);
+    if (!file) {
+      logWarn(`readNote: note not found or not a file (${sanitizedPath})`);
+      return {
+        notePath: sanitizedPath,
+        status: "not_found",
+        message: `Note "${sanitizedPath}" was not found or is not a readable file.`,
+      };
+    }
+
+    const chunks = await loadOrderedChunks(sanitizedPath);
+
+    if (chunks.length === 0) {
+      logWarn(`readNote: no chunks generated for ${sanitizedPath}`);
+      return {
+        notePath: sanitizedPath,
+        status: "empty",
+        message: `No readable content was found in "${sanitizedPath}".`,
+      };
+    }
+
+    if (chunkIndex >= chunks.length) {
+      return {
+        notePath: sanitizedPath,
+        status: "out_of_range",
+        message: `Chunk index ${chunkIndex} exceeds available chunks (last index ${chunks.length - 1}).`,
+        totalChunks: chunks.length,
+      };
+    }
+
+    const chunk = chunks[chunkIndex];
+    logInfo(
+      `readNote: returning chunk ${chunk.chunkIndex} of ${chunks.length} for ${sanitizedPath}`
+    );
+
+    const hasMore = chunk.chunkIndex < chunks.length - 1;
+
+    return {
+      notePath: sanitizedPath,
+      noteTitle: chunk.title,
+      heading: chunk.heading,
+      chunkId: chunk.id,
+      chunkIndex: chunk.chunkIndex,
+      totalChunks: chunks.length,
+      hasMore,
+      nextChunkIndex: hasMore ? chunk.chunkIndex + 1 : null,
+      content: chunk.content,
+      mtime: chunk.mtime,
+    };
+  },
+});
+
+export { readNoteSchema, readNoteTool };

--- a/src/tools/ReadNoteTool.test.ts
+++ b/src/tools/ReadNoteTool.test.ts
@@ -1,0 +1,202 @@
+import { SimpleTool } from "./SimpleTool";
+
+const mockGetChunks = jest.fn();
+
+jest.mock("@/search/v3/chunks", () => ({
+  ChunkManager: jest.fn().mockImplementation(() => ({
+    getChunks: mockGetChunks,
+  })),
+}));
+
+class MockTFile {
+  path: string;
+  basename: string;
+  stat: { mtime: number };
+
+  constructor(path: string) {
+    this.path = path;
+    this.basename = path.split("/").pop() || path;
+    this.stat = { mtime: Date.now() };
+  }
+}
+
+jest.mock("obsidian", () => ({
+  TFile: MockTFile,
+}));
+
+describe("readNoteTool", () => {
+  let readNoteTool: SimpleTool<any, any>;
+  let originalApp: any;
+  let getAbstractFileByPathMock: jest.Mock;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    mockGetChunks.mockReset();
+
+    originalApp = global.app;
+    getAbstractFileByPathMock = jest.fn();
+    global.app = {
+      vault: {
+        getAbstractFileByPath: getAbstractFileByPathMock,
+      },
+      metadataCache: {
+        getFileCache: jest.fn(),
+      },
+      workspace: {
+        getLeavesOfType: jest.fn().mockReturnValue([]),
+        getActiveFile: jest.fn().mockReturnValue(null),
+      },
+    } as any;
+
+    ({ readNoteTool } = await import("./NoteTools"));
+  });
+
+  afterEach(() => {
+    global.app = originalApp;
+  });
+
+  it("returns the first chunk with follow-up metadata", async () => {
+    const notePath = "Notes/test.md";
+    const file = new MockTFile(notePath);
+    getAbstractFileByPathMock.mockReturnValue(file);
+
+    mockGetChunks.mockResolvedValue([
+      {
+        id: `${notePath}#1`,
+        notePath,
+        chunkIndex: 1,
+        content: "Second chunk",
+        contentHash: "hash-1",
+        title: file.basename,
+        heading: "Details",
+        mtime: 200,
+      },
+      {
+        id: `${notePath}#0`,
+        notePath,
+        chunkIndex: 0,
+        content: "First chunk",
+        contentHash: "hash-0",
+        title: file.basename,
+        heading: "Intro",
+        mtime: 100,
+      },
+    ]);
+
+    const result = await readNoteTool.call({ notePath });
+
+    expect(mockGetChunks).toHaveBeenCalledWith([notePath]);
+    expect(result).toEqual({
+      notePath,
+      noteTitle: file.basename,
+      heading: "Intro",
+      chunkId: `${notePath}#0`,
+      chunkIndex: 0,
+      totalChunks: 2,
+      hasMore: true,
+      nextChunkIndex: 1,
+      content: "First chunk",
+      mtime: 100,
+    });
+  });
+
+  it("respects the requested chunk index", async () => {
+    const notePath = "Notes/test.md";
+    const file = new MockTFile(notePath);
+    getAbstractFileByPathMock.mockReturnValue(file);
+
+    mockGetChunks.mockResolvedValue([
+      {
+        id: `${notePath}#0`,
+        notePath,
+        chunkIndex: 0,
+        content: "First chunk",
+        contentHash: "hash-0",
+        title: file.basename,
+        heading: "Intro",
+        mtime: 100,
+      },
+      {
+        id: `${notePath}#1`,
+        notePath,
+        chunkIndex: 1,
+        content: "Second chunk",
+        contentHash: "hash-1",
+        title: file.basename,
+        heading: "Details",
+        mtime: 200,
+      },
+    ]);
+
+    const result = await readNoteTool.call({ notePath, chunkIndex: 1 });
+
+    expect(result).toEqual({
+      notePath,
+      noteTitle: file.basename,
+      heading: "Details",
+      chunkId: `${notePath}#1`,
+      chunkIndex: 1,
+      totalChunks: 2,
+      hasMore: false,
+      nextChunkIndex: null,
+      content: "Second chunk",
+      mtime: 200,
+    });
+  });
+
+  it("returns out_of_range when the chunk index exceeds available chunks", async () => {
+    const notePath = "Notes/test.md";
+    const file = new MockTFile(notePath);
+    getAbstractFileByPathMock.mockReturnValue(file);
+
+    mockGetChunks.mockResolvedValue([
+      {
+        id: `${notePath}#0`,
+        notePath,
+        chunkIndex: 0,
+        content: "First chunk",
+        contentHash: "hash-0",
+        title: file.basename,
+        heading: "Intro",
+        mtime: 100,
+      },
+    ]);
+
+    const result = await readNoteTool.call({ notePath, chunkIndex: 5 });
+
+    expect(result).toEqual({
+      notePath,
+      status: "out_of_range",
+      message: "Chunk index 5 exceeds available chunks (last index 0).",
+      totalChunks: 1,
+    });
+  });
+
+  it("returns not_found when the note cannot be resolved", async () => {
+    const notePath = "Notes/missing.md";
+    getAbstractFileByPathMock.mockReturnValue(null);
+
+    mockGetChunks.mockResolvedValue([]);
+
+    const result = await readNoteTool.call({ notePath });
+
+    expect(result).toEqual({
+      notePath,
+      status: "not_found",
+      message: 'Note "Notes/missing.md" was not found or is not a readable file.',
+    });
+    expect(mockGetChunks).not.toHaveBeenCalled();
+  });
+
+  it("returns invalid_path when notePath starts with a leading slash", async () => {
+    const result = await readNoteTool.call({ notePath: "/Projects/note.md" });
+
+    expect(result).toEqual({
+      notePath: "/Projects/note.md",
+      status: "invalid_path",
+      message: "Provide the note path relative to the vault root without a leading slash.",
+    });
+    expect(getAbstractFileByPathMock).not.toHaveBeenCalled();
+    expect(mockGetChunks).not.toHaveBeenCalled();
+  });
+});

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -191,8 +191,8 @@ Example - "what time is 6pm PT in Tokyo" (PT is UTC-8 or UTC-7, Tokyo is UTC+9):
       requiresVault: true,
       isAlwaysEnabled: true,
       customPromptInstructions: `For readNote:
-- Decide based on the user's request: only call this tool when the question requires reading note content. If the question is unrelated to note contents, you can skip the tool.
-- When the user references the active note or a note shown in <note_context>, read its <path> value from that block and use it as <notePath>.
+- Decide based on the user's request: only call this tool when the question requires reading note content.
+- If the user is asking about a note that is already mentioned or linked in <active_note> or <note_context> blocks, call readNote directly—do not use localSearch to look it up. Skip the tool when a note is irrelevant.
 - If the user asks about notes linked from that note, read the original note first, then follow the "linkedNotes" paths returned in the tool result to inspect those linked notes.
 - Always start with chunk 0 (omit <chunkIndex> or set it to 0). Only request the next chunk if the previous chunk did not answer the question.
 - Pass vault-relative paths without a leading slash. If a call fails, adjust the path (for example, add ".md" or use an alternative candidate) and retry only if necessary.

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -191,8 +191,9 @@ Example - "what time is 6pm PT in Tokyo" (PT is UTC-8 or UTC-7, Tokyo is UTC+9):
       requiresVault: true,
       isAlwaysEnabled: true,
       customPromptInstructions: `For readNote:
-- Use this tool whenever the user asks about the contents of the active note, context notes or any specific note whose path you know. The target note path is provided in the context—read it before answering.
-- The linked notes called out in the document body are only discoverable by reading the note. Call readNote on the active note first to surface the "linkedNotes" list before answering about them.
+- Decide based on the user's request: only call this tool when the question requires reading note content. If the question is unrelated to note contents, you can skip the tool.
+- When the user references the active note or a note shown in <note_context>, read its <path> value from that block and use it as <notePath>.
+- If the user asks about notes linked from that note, read the original note first, then follow the "linkedNotes" paths returned in the tool result to inspect those linked notes.
 - Always start with chunk 0 (omit <chunkIndex> or set it to 0). Only request the next chunk if the previous chunk did not answer the question.
 - Pass vault-relative paths without a leading slash. If a call fails, adjust the path (for example, add ".md" or use an alternative candidate) and retry only if necessary.
 - Every tool result may include a "linkedNotes" array. If the user needs information from those linked notes, call readNote again with one of the provided candidate paths, starting again at chunk 0. Do not expand links you don't need.

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -8,6 +8,7 @@ import {
 } from "./TimeTools";
 import { youtubeTranscriptionTool } from "./YoutubeTools";
 import { writeToFileTool, replaceInFileTool } from "./ComposerTools";
+import { readNoteTool } from "./NoteTools";
 import { createGetFileTreeTool } from "./FileTreeTools";
 import { memoryTool } from "./memoryTools";
 import { getSettings } from "@/settings/model";
@@ -180,6 +181,34 @@ Example - "what time is 6pm PT in Tokyo" (PT is UTC-8 or UTC-7, Tokyo is UTC+9):
   },
 
   // File tools
+  {
+    tool: readNoteTool,
+    metadata: {
+      id: "readNote",
+      displayName: "Read Note",
+      description: "Read a specific note in sequential chunks using the vault chunking pipeline.",
+      category: "file",
+      requiresVault: true,
+      customPromptInstructions: `For readNote (targeted note reading):
+- Only call this tool when you already know the exact note path (for example, after localSearch). Do NOT use it to discover notes.
+- Provide a vault-relative <notePath> without a leading slash. Start with the first chunk by omitting <chunkIndex> or setting it to 0.
+- Review the returned chunk before deciding to read more. Only request the next chunk when the previous chunk does not answer the question.
+- Stop as soon as you have enough information. Never stream the entire note by default.
+
+Example (first chunk):
+<use_tool>
+<name>readNote</name>
+<notePath>Projects/launch-plan.md</notePath>
+</use_tool>
+
+Example (follow-up chunk):
+<use_tool>
+<name>readNote</name>
+<notePath>Projects/launch-plan.md</notePath>
+<chunkIndex>1</chunkIndex>
+</use_tool>`,
+    },
+  },
   {
     tool: writeToFileTool,
     metadata: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a chunked note-reading tool (`readNote`) with linked-note metadata, integrates an inline-citation reminder into CiC prompts, and updates UI/formatters and defaults to support it.
> 
> - **Tools**:
>   - **`readNote` (new)**: Reads notes in sequential chunks (by lines), returns headings, follow-up metadata (`hasMore`, `nextChunkIndex`), and `linkedNotes` candidates from wiki links; resolves extensionless paths. Registered in `BUILTIN_TOOLS` with usage guidance; added to autonomous agent enabled tools.
>   - **Formatting**: `ToolResultFormatter` now formats `readNote` results (title, path, chunk info, preview, truncation).
> - **Agent/Prompting**:
>   - **Inline citations**: New `appendInlineCitationReminder` utility; `AutonomousAgentChainRunner` applies it (when enabled) before `ensureCiCOrderingWithQuestion` for local search payloads.
>   - **Tool call UX**: When calling `readNote`, display name uses `notePath` if provided; added emoji mapping.
> - **UI**:
>   - `ToolCallBanner`: Customizes banner text for `readNote` (“Reading/Read …”) and ellipsis behavior.
> - **Tests**:
>   - Added comprehensive tests for `readNote` (chunking, path resolution, linked-note metadata, error cases) and for the inline citation reminder utility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7157c46d2e2e0d1d98b1716806b02eaca26d559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->