### PR TITLE
Add an alert when user hits the maxToken limit

### DIFF
--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -646,11 +646,9 @@ ${params}
 
     while (retryCount <= maxRetries) {
       try {
-        // Enable usage metadata for OpenAI models (stream_options may not be typed in all LangChain versions)
         const chatStream = await withSuppressedTokenWarnings(() =>
           this.chainManager.chatModelManager.getChatModel().stream(messages, {
             signal: abortController.signal,
-            stream_options: { include_usage: true },
           } as any)
         );
 
@@ -662,14 +660,6 @@ ${params}
         }
 
         const result = streamer.close();
-
-        // Log token usage and show warning if truncated
-        if (result.tokenUsage) {
-          logInfo("AutonomousAgent token usage:", result.tokenUsage);
-        }
-        if (result.wasTruncated) {
-          logWarn("AutonomousAgent response was truncated due to token limit", result.tokenUsage);
-        }
 
         return {
           content: result.content,

--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -649,7 +649,7 @@ ${params}
         const chatStream = await withSuppressedTokenWarnings(() =>
           this.chainManager.chatModelManager.getChatModel().stream(messages, {
             signal: abortController.signal,
-          } as any)
+          })
         );
 
         for await (const chunk of chatStream) {

--- a/src/LLMProviders/chainRunner/BaseChainRunner.ts
+++ b/src/LLMProviders/chainRunner/BaseChainRunner.ts
@@ -1,6 +1,6 @@
 import { ABORT_REASON, AI_SENDER } from "@/constants";
 import { logError, logInfo } from "@/logger";
-import { ChatMessage } from "@/types/message";
+import { ChatMessage, ResponseMetadata } from "@/types/message";
 import { err2String, formatDateTime } from "@/utils";
 import { Notice } from "obsidian";
 import ChainManager from "../chainManager";
@@ -45,7 +45,8 @@ export abstract class BaseChainRunner implements ChainRunner {
     addMessage: (message: ChatMessage) => void,
     updateCurrentAiMessage: (message: string) => void,
     sources?: { title: string; path: string; score: number }[],
-    llmFormattedOutput?: string
+    llmFormattedOutput?: string,
+    responseMetadata?: ResponseMetadata
   ) {
     // Save to memory and add message if we have a response
     // Skip only if it's a NEW_CHAT abort (clearing everything)
@@ -68,6 +69,7 @@ export abstract class BaseChainRunner implements ChainRunner {
         isVisible: true,
         timestamp: formatDateTime(new Date()),
         sources: sources,
+        responseMetadata: responseMetadata,
       });
 
       // Clear the streaming message since it's now in chat history

--- a/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
+++ b/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
@@ -341,7 +341,7 @@ export class CopilotPlusChainRunner extends BaseChainRunner {
     const chatStream = await withSuppressedTokenWarnings(() =>
       this.chainManager.chatModelManager.getChatModel().stream(messages, {
         signal: abortController.signal,
-      } as any)
+      })
     );
 
     for await (const chunk of chatStream) {

--- a/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
+++ b/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
@@ -338,11 +338,9 @@ export class CopilotPlusChainRunner extends BaseChainRunner {
     const thinkStreamer = new ThinkBlockStreamer(updateCurrentAiMessage);
 
     // Wrap the stream call with warning suppression
-    // Enable usage metadata for OpenAI models (stream_options may not be typed in all LangChain versions)
     const chatStream = await withSuppressedTokenWarnings(() =>
       this.chainManager.chatModelManager.getChatModel().stream(messages, {
         signal: abortController.signal,
-        // stream_options: { include_usage: true },
       } as any)
     );
 

--- a/src/LLMProviders/chainRunner/LLMChainRunner.ts
+++ b/src/LLMProviders/chainRunner/LLMChainRunner.ts
@@ -69,11 +69,9 @@ export class LLMChainRunner extends BaseChainRunner {
       logInfo("Final Request to AI:\n", messages);
 
       // Stream with abort signal
-      // Enable usage metadata for OpenAI models (stream_options may not be typed in all LangChain versions)
       const chatStream = await withSuppressedTokenWarnings(() =>
         this.chainManager.chatModelManager.getChatModel().stream(messages, {
           signal: abortController.signal,
-          stream_options: { include_usage: true },
         } as any)
       );
 

--- a/src/LLMProviders/chainRunner/LLMChainRunner.ts
+++ b/src/LLMProviders/chainRunner/LLMChainRunner.ts
@@ -97,7 +97,7 @@ export class LLMChainRunner extends BaseChainRunner {
 
     const responseMetadata = {
       wasTruncated: result.wasTruncated,
-      tokenUsage: result.tokenUsage || undefined,
+      tokenUsage: result.tokenUsage ?? undefined,
     };
 
     // Only skip saving if it's a new chat (clearing everything)

--- a/src/LLMProviders/chainRunner/LLMChainRunner.ts
+++ b/src/LLMProviders/chainRunner/LLMChainRunner.ts
@@ -72,7 +72,7 @@ export class LLMChainRunner extends BaseChainRunner {
       const chatStream = await withSuppressedTokenWarnings(() =>
         this.chainManager.chatModelManager.getChatModel().stream(messages, {
           signal: abortController.signal,
-        } as any)
+        })
       );
 
       for await (const chunk of chatStream) {

--- a/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
+++ b/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
@@ -145,11 +145,9 @@ export class VaultQAChainRunner extends BaseChainRunner {
       logInfo("Final Request to AI:\n", messages);
 
       // Stream with abort signal
-      // Enable usage metadata for OpenAI models (stream_options may not be typed in all LangChain versions)
       const chatStream = await withSuppressedTokenWarnings(() =>
         this.chainManager.chatModelManager.getChatModel().stream(messages, {
           signal: abortController.signal,
-          stream_options: { include_usage: true },
         } as any)
       );
 

--- a/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
+++ b/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
@@ -173,7 +173,7 @@ export class VaultQAChainRunner extends BaseChainRunner {
 
     const responseMetadata = {
       wasTruncated: result.wasTruncated,
-      tokenUsage: result.tokenUsage || undefined,
+      tokenUsage: result.tokenUsage ?? undefined,
     };
 
     // Only skip saving if it's a new chat (clearing everything)

--- a/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
+++ b/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
@@ -148,7 +148,7 @@ export class VaultQAChainRunner extends BaseChainRunner {
       const chatStream = await withSuppressedTokenWarnings(() =>
         this.chainManager.chatModelManager.getChatModel().stream(messages, {
           signal: abortController.signal,
-        } as any)
+        })
       );
 
       for await (const chunk of chatStream) {

--- a/src/LLMProviders/chainRunner/utils/ThinkBlockStreamer.ts
+++ b/src/LLMProviders/chainRunner/utils/ThinkBlockStreamer.ts
@@ -1,13 +1,31 @@
 import { ModelAdapter } from "./modelAdapter";
+import { detectTruncation, extractTokenUsage } from "./finishReasonDetector";
+
+export interface StreamingResult {
+  content: string;
+  wasTruncated: boolean;
+  tokenUsage: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  } | null;
+}
 
 /**
  * ThinkBlockStreamer handles streaming content from various LLM providers
  * that support thinking/reasoning modes (like Claude and Deepseek).
+ * Also detects truncation due to token limits across all providers.
  */
 export class ThinkBlockStreamer {
   private hasOpenThinkBlock = false;
   private fullResponse = "";
   private shouldTruncate = false;
+  private wasTruncated = false;
+  private tokenUsage: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  } | null = null;
 
   constructor(
     private updateCurrentAiMessage: (message: string) => void,
@@ -67,6 +85,18 @@ export class ThinkBlockStreamer {
       return;
     }
 
+    // Detect truncation using multi-provider detector
+    const truncationResult = detectTruncation(chunk);
+    if (truncationResult.wasTruncated) {
+      this.wasTruncated = true;
+    }
+
+    // Extract token usage if available
+    const usage = extractTokenUsage(chunk);
+    if (usage) {
+      this.tokenUsage = usage;
+    }
+
     let handledThinking = false;
 
     // Handle Claude 3.7 array-based content
@@ -113,12 +143,17 @@ export class ThinkBlockStreamer {
     return truncated;
   }
 
-  close() {
+  close(): StreamingResult {
     // Make sure to close any open think block at the end
     if (this.hasOpenThinkBlock) {
       this.fullResponse += "</think>";
       this.updateCurrentAiMessage(this.fullResponse);
     }
-    return this.fullResponse;
+
+    return {
+      content: this.fullResponse,
+      wasTruncated: this.wasTruncated,
+      tokenUsage: this.tokenUsage,
+    };
   }
 }

--- a/src/LLMProviders/chainRunner/utils/ThinkBlockStreamer.ts
+++ b/src/LLMProviders/chainRunner/utils/ThinkBlockStreamer.ts
@@ -1,15 +1,6 @@
+import { StreamingResult, TokenUsage } from "@/types/message";
 import { ModelAdapter } from "./modelAdapter";
 import { detectTruncation, extractTokenUsage } from "./finishReasonDetector";
-
-export interface StreamingResult {
-  content: string;
-  wasTruncated: boolean;
-  tokenUsage: {
-    inputTokens?: number;
-    outputTokens?: number;
-    totalTokens?: number;
-  } | null;
-}
 
 /**
  * ThinkBlockStreamer handles streaming content from various LLM providers
@@ -21,11 +12,7 @@ export class ThinkBlockStreamer {
   private fullResponse = "";
   private shouldTruncate = false;
   private wasTruncated = false;
-  private tokenUsage: {
-    inputTokens?: number;
-    outputTokens?: number;
-    totalTokens?: number;
-  } | null = null;
+  private tokenUsage: TokenUsage | null = null;
 
   constructor(
     private updateCurrentAiMessage: (message: string) => void,

--- a/src/LLMProviders/chainRunner/utils/finishReasonDetector.ts
+++ b/src/LLMProviders/chainRunner/utils/finishReasonDetector.ts
@@ -1,0 +1,107 @@
+/**
+ * Finish Reason Detection Utility
+ *
+ * This module provides utilities to detect when LLM responses are truncated
+ * due to token limits across different providers (OpenAI, Anthropic, Google, etc.)
+ */
+
+export interface FinishReasonResult {
+  /** Whether the response was truncated due to token limits */
+  wasTruncated: boolean;
+  /** User-friendly message explaining the truncation */
+  message: string | null;
+}
+
+/**
+ * Detects whether a response was truncated due to token limits
+ * by examining the response metadata from various LLM providers.
+ *
+ * Supports:
+ * - OpenAI (finish_reason: "length")
+ * - Anthropic (stop_reason: "max_tokens")
+ * - Google Gemini (finishReason: "MAX_TOKENS")
+ * - DeepSeek (finish_reason: "length")
+ * - Mistral (finish_reason: "length")
+ * - Cohere (finish_reason: "MAX_TOKENS")
+ * - Groq (finish_reason: "length")
+ *
+ * @param chunk The streaming chunk from the LLM (AIMessageChunk)
+ * @returns FinishReasonResult with truncation status and details
+ */
+export function detectTruncation(chunk: any): FinishReasonResult {
+  const metadata = chunk.response_metadata || {};
+
+  // OpenAI, DeepSeek, Mistral, Groq use "length"
+  if (metadata.finish_reason === "length") {
+    return {
+      wasTruncated: true,
+      message: "Response truncated due to token limit",
+    };
+  }
+
+  // Anthropic uses "max_tokens"
+  if (metadata.stop_reason === "max_tokens") {
+    return {
+      wasTruncated: true,
+      message: "Response truncated due to max_tokens limit",
+    };
+  }
+
+  // Google Gemini and Cohere use "MAX_TOKENS"
+  if (metadata.finishReason === "MAX_TOKENS" || metadata.finish_reason === "MAX_TOKENS") {
+    return {
+      wasTruncated: true,
+      message: "Response truncated due to MAX_TOKENS limit",
+    };
+  }
+
+  // No truncation detected
+  return {
+    wasTruncated: false,
+    message: null,
+  };
+}
+
+/**
+ * Extracts token usage information from response metadata.
+ * Different providers use different field names and structures.
+ *
+ * @param chunk The streaming chunk from the LLM
+ * @returns Token usage object or null if not available
+ */
+export function extractTokenUsage(chunk: any): {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+} | null {
+  const metadata = chunk.response_metadata || {};
+
+  // OpenAI format: tokenUsage with camelCase
+  if (metadata.tokenUsage) {
+    return {
+      inputTokens: metadata.tokenUsage.promptTokens,
+      outputTokens: metadata.tokenUsage.completionTokens,
+      totalTokens: metadata.tokenUsage.totalTokens,
+    };
+  }
+
+  // Anthropic/others format: usage with snake_case
+  if (metadata.usage) {
+    return {
+      inputTokens: metadata.usage.input_tokens || metadata.usage.prompt_tokens,
+      outputTokens: metadata.usage.output_tokens || metadata.usage.completion_tokens,
+      totalTokens: metadata.usage.total_tokens,
+    };
+  }
+
+  // LangChain's usage_metadata format
+  if (chunk.usage_metadata) {
+    return {
+      inputTokens: chunk.usage_metadata.input_tokens,
+      outputTokens: chunk.usage_metadata.output_tokens,
+      totalTokens: chunk.usage_metadata.total_tokens,
+    };
+  }
+
+  return null;
+}

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -8,6 +8,7 @@ import {
   ContextFolderBadge,
 } from "@/components/chat-components/ContextBadges";
 import { InlineMessageEditor } from "@/components/chat-components/InlineMessageEditor";
+import { TokenLimitWarning } from "@/components/chat-components/TokenLimitWarning";
 import {
   cleanupMessageToolCallRoots,
   cleanupStaleToolCallRoots,
@@ -576,6 +577,10 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
         <div className="tw-flex tw-max-w-full tw-flex-col tw-gap-2 tw-overflow-hidden">
           {!isEditing && <MessageContext context={message.context} />}
           <div className="message-content">{renderMessageContent()}</div>
+
+          {message.responseMetadata?.wasTruncated && message.sender !== USER_SENDER && (
+            <TokenLimitWarning message={message} app={app} inline={true} />
+          )}
 
           {!isStreaming && (
             <div className="tw-flex tw-items-center tw-justify-between">

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -579,7 +579,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
           <div className="message-content">{renderMessageContent()}</div>
 
           {message.responseMetadata?.wasTruncated && message.sender !== USER_SENDER && (
-            <TokenLimitWarning message={message} app={app} inline={true} />
+            <TokenLimitWarning message={message} app={app} />
           )}
 
           {!isStreaming && (

--- a/src/components/chat-components/TokenLimitWarning.tsx
+++ b/src/components/chat-components/TokenLimitWarning.tsx
@@ -10,18 +10,13 @@ import React from "react";
 interface TokenLimitWarningProps {
   message: ChatMessage;
   app: App;
-  inline?: boolean;
 }
 
 /**
  * Warning message component displayed when AI response is truncated due to token limits.
  * Shows a clear message and provides a button to open model settings.
  */
-export const TokenLimitWarning: React.FC<TokenLimitWarningProps> = ({
-  message,
-  app,
-  inline = false,
-}) => {
+export const TokenLimitWarning: React.FC<TokenLimitWarningProps> = ({ message, app }) => {
   const handleOpenSettings = () => {
     const settings = getSettings();
     const currentModelKey = getModelKey();
@@ -46,11 +41,7 @@ export const TokenLimitWarning: React.FC<TokenLimitWarningProps> = ({
   };
 
   return (
-    <div
-      className={`tw-rounded-md tw-border tw-border-border tw-bg-callout-warning/20 tw-p-4 ${
-        inline ? "tw-mt-3" : "tw-my-4"
-      }`}
-    >
+    <div className="tw-mt-3 tw-rounded-md tw-border tw-border-border tw-bg-callout-warning/20 tw-p-4">
       <div className="tw-flex tw-items-start tw-gap-3">
         <AlertTriangle className="tw-size-5 tw-shrink-0 tw-text-warning" />
         <div className="tw-flex-1">

--- a/src/components/chat-components/TokenLimitWarning.tsx
+++ b/src/components/chat-components/TokenLimitWarning.tsx
@@ -1,0 +1,79 @@
+import { getModelKey } from "@/aiParams";
+import { Button } from "@/components/ui/button";
+import { getModelKeyFromModel, getSettings, updateSetting } from "@/settings/model";
+import { ModelEditModal } from "@/settings/v2/components/ModelEditDialog";
+import { ChatMessage } from "@/types/message";
+import { AlertTriangle } from "lucide-react";
+import { App, Notice } from "obsidian";
+import React from "react";
+
+interface TokenLimitWarningProps {
+  message: ChatMessage;
+  app: App;
+  inline?: boolean;
+}
+
+/**
+ * Warning message component displayed when AI response is truncated due to token limits.
+ * Shows a clear message and provides a button to open model settings.
+ */
+export const TokenLimitWarning: React.FC<TokenLimitWarningProps> = ({
+  message,
+  app,
+  inline = false,
+}) => {
+  const handleOpenSettings = () => {
+    const settings = getSettings();
+    const currentModelKey = getModelKey();
+
+    // Find the current model
+    const model = settings.activeModels.find((m) => getModelKeyFromModel(m) === currentModelKey);
+
+    if (!model) {
+      new Notice("Could not find the current model settings");
+      return;
+    }
+
+    // Create update handler
+    const handleModelUpdate = (isEmbedding: boolean, original: any, updated: any) => {
+      const updatedModels = settings.activeModels.map((m) => (m === original ? updated : m));
+      updateSetting("activeModels", updatedModels);
+    };
+
+    // Open the model edit modal
+    const modal = new ModelEditModal(app, model, false, handleModelUpdate);
+    modal.open();
+  };
+
+  return (
+    <div
+      className={`tw-rounded-md tw-border tw-border-border tw-bg-callout-warning/20 tw-p-4 ${
+        inline ? "tw-mt-3" : "tw-my-4"
+      }`}
+    >
+      <div className="tw-flex tw-items-start tw-gap-3">
+        <AlertTriangle className="tw-size-5 tw-shrink-0 tw-text-warning" />
+        <div className="tw-flex-1">
+          <div className="tw-mb-2 tw-font-semibold tw-text-warning">Response Truncated</div>
+          <div className="tw-mb-3 tw-text-normal">
+            The AI response was cut off because it reached the token limit. You can increase the
+            &apos;Token Limit&apos; in model settings for longer responses.
+          </div>
+          {message.responseMetadata?.tokenUsage && (
+            <div className="tw-mb-3 tw-text-sm tw-text-muted">
+              Output tokens used: {message.responseMetadata.tokenUsage.outputTokens || "N/A"}
+            </div>
+          )}
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleOpenSettings}
+            className="tw-text-warning hover:tw-bg-callout-warning/10"
+          >
+            Open Model Settings
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/core/ChatManager.test.ts
+++ b/src/core/ChatManager.test.ts
@@ -56,8 +56,6 @@ describe("ChatManager", () => {
       updateProcessedText: jest.fn(),
       truncateAfterMessageId: jest.fn(),
       deleteMessage: jest.fn(),
-      addDisplayOnlyMessage: jest.fn(),
-      addFullMessage: jest.fn(),
       clear: jest.fn(),
       getDisplayMessages: jest.fn(),
       getLLMMessages: jest.fn(),
@@ -405,32 +403,8 @@ describe("ChatManager", () => {
     });
   });
 
-  describe("addDisplayMessage", () => {
-    it("should add a display message", () => {
-      mockMessageRepo.addDisplayOnlyMessage.mockReturnValue("msg-1");
-
-      const result = chatManager.addDisplayMessage("Hello", "AI");
-
-      expect(result).toBe("msg-1");
-      expect(mockMessageRepo.addDisplayOnlyMessage).toHaveBeenCalledWith("Hello", "AI", undefined);
-    });
-
-    it("should add a display message with custom ID", () => {
-      mockMessageRepo.addDisplayOnlyMessage.mockReturnValue("custom-id");
-
-      const result = chatManager.addDisplayMessage("Hello", "AI", "custom-id");
-
-      expect(result).toBe("custom-id");
-      expect(mockMessageRepo.addDisplayOnlyMessage).toHaveBeenCalledWith(
-        "Hello",
-        "AI",
-        "custom-id"
-      );
-    });
-  });
-
-  describe("addFullMessage", () => {
-    it("should add a full message", () => {
+  describe("addMessage", () => {
+    it("should add a message from ChatMessage object", () => {
       const mockMessage: ChatMessage = {
         id: "msg-1",
         message: "Hello",
@@ -439,12 +413,12 @@ describe("ChatManager", () => {
         isVisible: true,
       };
 
-      mockMessageRepo.addFullMessage.mockReturnValue("msg-1");
+      mockMessageRepo.addMessage.mockReturnValue("msg-1");
 
-      const result = chatManager.addFullMessage(mockMessage);
+      const result = chatManager.addMessage(mockMessage);
 
       expect(result).toBe("msg-1");
-      expect(mockMessageRepo.addFullMessage).toHaveBeenCalledWith(mockMessage);
+      expect(mockMessageRepo.addMessage).toHaveBeenCalledWith(mockMessage);
     });
   });
 
@@ -458,7 +432,7 @@ describe("ChatManager", () => {
       chatManager.loadMessages(messages);
 
       expect(mockMessageRepo.clear).toHaveBeenCalled();
-      expect(mockMessageRepo.addFullMessage).toHaveBeenCalledTimes(2);
+      expect(mockMessageRepo.addMessage).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/src/core/ChatManager.ts
+++ b/src/core/ChatManager.ts
@@ -292,20 +292,11 @@ export class ChatManager {
   }
 
   /**
-   * Add a display-only message (for AI responses)
+   * Add a message
    */
-  addDisplayMessage(text: string, sender: string, id?: string): string {
+  addMessage(message: ChatMessage): string {
     const currentRepo = this.getCurrentMessageRepo();
-    const messageId = currentRepo.addDisplayOnlyMessage(text, sender, id);
-    return messageId;
-  }
-
-  /**
-   * Add a full message object
-   */
-  addFullMessage(message: ChatMessage): string {
-    const currentRepo = this.getCurrentMessageRepo();
-    const messageId = currentRepo.addFullMessage(message);
+    const messageId = currentRepo.addMessage(message);
     return messageId;
   }
 
@@ -386,7 +377,7 @@ export class ChatManager {
     const currentRepo = this.getCurrentMessageRepo();
     currentRepo.clear();
     messages.forEach((msg) => {
-      currentRepo.addFullMessage(msg);
+      currentRepo.addMessage(msg);
     });
 
     // Update chain memory with loaded messages
@@ -447,7 +438,7 @@ export class ChatManager {
     // Add messages to the current repository
     const currentRepo = this.getCurrentMessageRepo();
     for (const message of messages) {
-      currentRepo.addFullMessage(message);
+      currentRepo.addMessage(message);
     }
 
     // Update chain memory with loaded messages

--- a/src/core/MessageRepository.test.ts
+++ b/src/core/MessageRepository.test.ts
@@ -202,29 +202,7 @@ describe("MessageRepository", () => {
     });
   });
 
-  describe("addDisplayOnlyMessage", () => {
-    it("should add message with same display and processed text", () => {
-      const messageId = messageRepo.addDisplayOnlyMessage("AI Response", "AI");
-
-      const displayMessage = messageRepo.getMessage(messageId);
-      const llmMessage = messageRepo.getLLMMessage(messageId);
-
-      expect(displayMessage?.message).toBe("AI Response");
-      expect(llmMessage?.message).toBe("AI Response");
-    });
-
-    it("should use provided ID if given", () => {
-      const customId = "custom-message-id";
-      const messageId = messageRepo.addDisplayOnlyMessage("AI Response", "AI", customId);
-
-      expect(messageId).toBe(customId);
-
-      const message = messageRepo.getMessage(customId);
-      expect(message?.id).toBe(customId);
-    });
-  });
-
-  describe("addFullMessage", () => {
+  describe("addMessage with ChatMessage object", () => {
     it("should add message from ChatMessage object", () => {
       const chatMessage: ChatMessage = {
         id: "test-id",
@@ -239,7 +217,7 @@ describe("MessageRepository", () => {
         },
       };
 
-      const messageId = messageRepo.addFullMessage(chatMessage);
+      const messageId = messageRepo.addMessage(chatMessage);
 
       expect(messageId).toBe("test-id");
 
@@ -256,7 +234,7 @@ describe("MessageRepository", () => {
         isVisible: true,
       };
 
-      const messageId = messageRepo.addFullMessage(chatMessage);
+      const messageId = messageRepo.addMessage(chatMessage);
 
       expect(messageId).toBeDefined();
       expect(messageId).toMatch(/^msg-\d+-\w+$/);

--- a/src/core/MessageRepository.ts
+++ b/src/core/MessageRepository.ts
@@ -95,6 +95,7 @@ export class MessageRepository {
       isErrorMessage: message.isErrorMessage,
       sources: message.sources,
       content: message.content,
+      responseMetadata: message.responseMetadata,
     };
 
     this.messages.push(storedMessage);
@@ -208,6 +209,7 @@ export class MessageRepository {
         isErrorMessage: msg.isErrorMessage,
         sources: msg.sources,
         content: msg.content,
+        responseMetadata: msg.responseMetadata,
       }));
   }
 
@@ -230,6 +232,7 @@ export class MessageRepository {
       isErrorMessage: msg.isErrorMessage,
       sources: msg.sources,
       content: msg.content,
+      responseMetadata: msg.responseMetadata,
     };
   }
 

--- a/src/core/MessageRepository.ts
+++ b/src/core/MessageRepository.ts
@@ -67,7 +67,11 @@ export class MessageRepository {
       return id;
     }
 
-    // Otherwise, use parameters
+    // Otherwise, use string parameters
+    if (processedText === undefined || sender === undefined) {
+      throw new Error("processedText and sender are required when using string-based addMessage");
+    }
+
     const displayText = messageOrDisplayText;
     const id = this.generateId();
     const timestamp = formatDateTime(new Date());
@@ -75,8 +79,8 @@ export class MessageRepository {
     const message: StoredMessage = {
       id,
       displayText,
-      processedText: processedText!,
-      sender: sender!,
+      processedText,
+      sender,
       timestamp,
       context,
       isVisible: true,

--- a/src/hooks/useChatManager.ts
+++ b/src/hooks/useChatManager.ts
@@ -74,20 +74,6 @@ export function useChatManager(chatUIState: ChatUIState) {
     [chatUIState]
   );
 
-  const addDisplayMessage = useCallback(
-    (text: string, sender: string, id?: string): string => {
-      return chatUIState.addDisplayMessage(text, sender, id);
-    },
-    [chatUIState]
-  );
-
-  const addFullMessage = useCallback(
-    (message: ChatMessage): string => {
-      return chatUIState.addFullMessage(message);
-    },
-    [chatUIState]
-  );
-
   const clearMessages = useCallback((): void => {
     chatUIState.clearMessages();
   }, [chatUIState]);
@@ -150,13 +136,9 @@ export function useChatManager(chatUIState: ChatUIState) {
     editMessage,
     regenerateMessage,
     deleteMessage,
-    addDisplayMessage,
-    addFullMessage,
+    addMessage,
     clearMessages,
     truncateAfterMessageId,
-
-    // Compatibility methods
-    addMessage,
 
     // Advanced operations
     loadMessages,

--- a/src/settings/v2/components/ModelEditDialog.tsx
+++ b/src/settings/v2/components/ModelEditDialog.tsx
@@ -30,13 +30,11 @@ interface ModelEditModalContentProps {
     originalModel: CustomModel,
     updatedModel: CustomModel
   ) => void;
-  onCancel: () => void;
 }
 
 export const ModelEditModalContent: React.FC<ModelEditModalContentProps> = ({
   model,
   onUpdate,
-  onCancel,
   isEmbeddingModel,
 }) => {
   const [localModel, setLocalModel] = useState<CustomModel>(model);
@@ -122,11 +120,6 @@ export const ModelEditModalContent: React.FC<ModelEditModalContentProps> = ({
 
   return (
     <div className="tw-space-y-3 tw-p-4">
-      <div className="tw-mb-4">
-        <h2 className="tw-text-xl tw-font-bold">Model Settings - {localModel.name}</h2>
-        <p className="tw-text-sm tw-text-muted">Customize model parameters</p>
-      </div>
-
       <div className="tw-space-y-3">
         <FormField label="Model Name" required>
           <Input
@@ -412,6 +405,8 @@ export class ModelEditModal extends Modal {
     ) => void
   ) {
     super(app);
+    // @ts-ignore
+    this.setTitle(`Model Settings - ${this.model.name}`);
   }
 
   onOpen() {
@@ -430,16 +425,11 @@ export class ModelEditModal extends Modal {
       this.onUpdate(isEmbeddingModel, originalModel, updatedModel);
     };
 
-    const handleCancel = () => {
-      this.close();
-    };
-
     this.root.render(
       <ModelEditModalContent
         model={this.model}
         isEmbeddingModel={this.isEmbeddingModel}
         onUpdate={handleUpdate}
-        onCancel={handleCancel}
       />
     );
   }

--- a/src/settings/v2/components/ModelEditDialog.tsx
+++ b/src/settings/v2/components/ModelEditDialog.tsx
@@ -1,4 +1,5 @@
 import { CustomModel } from "@/aiParams";
+import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
@@ -30,12 +31,14 @@ interface ModelEditModalContentProps {
     originalModel: CustomModel,
     updatedModel: CustomModel
   ) => void;
+  onCancel: () => void;
 }
 
 export const ModelEditModalContent: React.FC<ModelEditModalContentProps> = ({
   model,
   onUpdate,
   isEmbeddingModel,
+  onCancel,
 }) => {
   const [localModel, setLocalModel] = useState<CustomModel>(model);
   const [originalModel, setOriginalModel] = useState<CustomModel>(model);
@@ -238,7 +241,7 @@ export const ModelEditModalContent: React.FC<ModelEditModalContentProps> = ({
                 value={localModel.maxTokens ?? settings.maxTokens}
                 onChange={(value) => handleLocalUpdate("maxTokens", value)}
                 max={65000}
-                min={0}
+                min={100}
                 step={100}
                 defaultValue={DEFAULT_MODEL_SETTING.MAX_TOKENS}
                 helpText={
@@ -387,6 +390,12 @@ export const ModelEditModalContent: React.FC<ModelEditModalContentProps> = ({
           </>
         )}
       </div>
+
+      <div className="tw-mt-6 tw-flex tw-justify-end tw-gap-2 tw-border-t tw-border-border tw-pt-4">
+        <Button variant="secondary" onClick={onCancel}>
+          Close
+        </Button>
+      </div>
     </div>
   );
 };
@@ -425,11 +434,16 @@ export class ModelEditModal extends Modal {
       this.onUpdate(isEmbeddingModel, originalModel, updatedModel);
     };
 
+    const handleCancel = () => {
+      this.close();
+    };
+
     this.root.render(
       <ModelEditModalContent
         model={this.model}
         isEmbeddingModel={this.isEmbeddingModel}
         onUpdate={handleUpdate}
+        onCancel={handleCancel}
       />
     );
   }

--- a/src/state/ChatUIState.ts
+++ b/src/state/ChatUIState.ts
@@ -215,8 +215,8 @@ export class ChatUIState {
    */
   addMessage(message: ChatMessage): void {
     if (message.isVisible) {
-      // If the message has sources or other metadata, use addFullMessage to preserve them
-      if (message.sources || message.content) {
+      // If the message has sources, content, or responseMetadata, use addFullMessage to preserve them
+      if (message.sources || message.content || message.responseMetadata) {
         this.addFullMessage(message);
       } else {
         this.addDisplayMessage(message.message, message.sender, message.id);

--- a/src/state/ChatUIState.ts
+++ b/src/state/ChatUIState.ts
@@ -134,24 +134,6 @@ export class ChatUIState {
   }
 
   /**
-   * Add a display-only message (for AI responses)
-   */
-  addDisplayMessage(text: string, sender: string, id?: string): string {
-    const messageId = this.chatManager.addDisplayMessage(text, sender, id);
-    this.notifyListeners();
-    return messageId;
-  }
-
-  /**
-   * Add a full message object
-   */
-  addFullMessage(message: ChatMessage): string {
-    const messageId = this.chatManager.addFullMessage(message);
-    this.notifyListeners();
-    return messageId;
-  }
-
-  /**
    * Clear all messages
    */
   clearMessages(): void {
@@ -211,19 +193,11 @@ export class ChatUIState {
   }
 
   /**
-   * Legacy compatibility - add message with visibility logic
+   * Add a message
    */
   addMessage(message: ChatMessage): void {
-    if (message.isVisible) {
-      // If the message has sources, content, or responseMetadata, use addFullMessage to preserve them
-      if (message.sources || message.content || message.responseMetadata) {
-        this.addFullMessage(message);
-      } else {
-        this.addDisplayMessage(message.message, message.sender, message.id);
-      }
-    } else {
-      this.addFullMessage(message);
-    }
+    this.chatManager.addMessage(message);
+    this.notifyListeners();
   }
 
   /**

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -33,6 +33,15 @@ export interface MessageContext {
 }
 
 /**
+ * Token usage statistics from LLM providers
+ */
+export interface TokenUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}
+
+/**
  * Response metadata from LLM providers
  */
 export interface ResponseMetadata {
@@ -40,11 +49,22 @@ export interface ResponseMetadata {
   wasTruncated?: boolean;
 
   /** Token usage statistics */
-  tokenUsage?: {
-    inputTokens?: number;
-    outputTokens?: number;
-    totalTokens?: number;
-  };
+  tokenUsage?: TokenUsage;
+}
+
+/**
+ * Streaming response result from chain runners
+ * Similar to ResponseMetadata but with required fields and content
+ */
+export interface StreamingResult {
+  /** The streamed content */
+  content: string;
+
+  /** Whether the response was truncated (required for streaming) */
+  wasTruncated: boolean;
+
+  /** Token usage statistics (may be null if not yet available) */
+  tokenUsage: TokenUsage | null;
 }
 
 /**

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -33,6 +33,21 @@ export interface MessageContext {
 }
 
 /**
+ * Response metadata from LLM providers
+ */
+export interface ResponseMetadata {
+  /** Whether the response was truncated due to token limits */
+  wasTruncated?: boolean;
+
+  /** Token usage statistics */
+  tokenUsage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+/**
  * Core chat message interface
  * This represents both display and LLM messages with different content
  */
@@ -69,6 +84,9 @@ export interface ChatMessage {
 
   /** Whether context needs to be reprocessed (after editing) */
   needsContextReprocessing?: boolean;
+
+  /** Response metadata from LLM (for AI messages) */
+  responseMetadata?: ResponseMetadata;
 }
 
 /**
@@ -91,4 +109,5 @@ export interface StoredMessage {
   isErrorMessage?: boolean;
   sources?: { title: string; path: string; score: number; explanation?: any }[];
   content?: any[];
+  responseMetadata?: ResponseMetadata;
 }


### PR DESCRIPTION
<img width="708" height="972" alt="Screenshot 2025-10-04 at 11 10 22 PM" src="https://github.com/user-attachments/assets/f84483a7-d730-4487-965d-1940f90b27d9" />

Add a warning when the output is truncated due to hitting the max token limit. The alert also has a shortcut to configure the max token for the selected model

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects token-limit truncation and token usage during streaming, surfaces a UI warning with quick access to model settings, and refactors message storage/APIs to carry response metadata.
> 
> - **Streaming/LLM**:
>   - Add multi-provider truncation and token-usage detection (`utils/finishReasonDetector.ts`).
>   - Extend `ThinkBlockStreamer` to return `StreamingResult` with `content`, `wasTruncated`, `tokenUsage`.
>   - Update chain runners (`LLMChainRunner`, `VaultQAChainRunner`, `CopilotPlusChainRunner`, `AutonomousAgentChainRunner`) to use `StreamingResult`, propagate `ResponseMetadata`, and pass it via `handleResponse`.
>   - `BaseChainRunner.handleResponse` now accepts `responseMetadata` and attaches it to saved AI messages.
> - **UI**:
>   - Show truncation alert in `ChatSingleMessage` via new `TokenLimitWarning` (opens `ModelEditDialog`; displays output token usage when available).
> - **Types/Storage**:
>   - Add `TokenUsage`, `ResponseMetadata`, `StreamingResult` to `types/message` and persist `responseMetadata` in `MessageRepository` and getters.
> - **Chat API Refactor**:
>   - Replace `addDisplayOnlyMessage`/`addFullMessage` with unified `addMessage` across `MessageRepository`, `ChatManager`, `ChatUIState`, and `useChatManager`.
> - **Settings**:
>   - Improve `ModelEditDialog`: add Close button, set modal title, raise token slider min to `100`.
> - **Tests**:
>   - Update unit tests to reflect unified `addMessage` API and new repository behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f19c7602d2afcc278d2ea0be05e49641b17b933. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->