### PR TITLE
Fix index rebuild on semantic search toggle

### DIFF
--- a/src/search/dbOperations.ts
+++ b/src/search/dbOperations.ts
@@ -444,12 +444,14 @@ export class DBOperations {
 
   async checkAndHandleEmbeddingModelChange(embeddingInstance: Embeddings): Promise<boolean> {
     if (!this.oramaDb) {
-      logInfo(
-        "Embedding model change detected. Semantic index database not found. Initializing new database..."
-      );
+      logInfo("Semantic index database not loaded in memory. Checking for existing index...");
       try {
         await this.initializeDB(embeddingInstance);
-        return true;
+        // After initialization, oramaDb might still be undefined if no index exists
+        if (!this.oramaDb) {
+          logInfo("No existing index found. Will create new index.");
+          return false; // No model change, just no index yet
+        }
       } catch (error) {
         logError("Failed to initialize database:", error);
         throw new CustomError(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Only triggers a full index rebuild when the embedding model actually changes; initializes/creates the DB if missing and proceeds with normal indexing instead of forcing rebuild.
> 
> - **Semantic Index (Orama) → `src/search/dbOperations.ts`**:
>   - **Embedding model change flow**:
>     - Loads existing DB from disk if not in memory; if none exists, proceeds with first-time build (returns `false`).
>     - Returns `true` only when a model change is detected against an existing index to trigger full rebuild.
>     - Updated logs and added detailed JSDoc clarifying rebuild vs. first-time build behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a50a550a2e589be2370f3c5d44c463d796b7709. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->