### PR TITLE
Tag search v3

### DIFF
--- a/src/search/v3/QueryExpander.test.ts
+++ b/src/search/v3/QueryExpander.test.ts
@@ -96,6 +96,16 @@ describe("QueryExpander", () => {
       );
     });
 
+    it("should retain standalone term even when similar tag bodies appear multiple times", async () => {
+      mockChatModel.invoke.mockRejectedValue(new Error("LLM error"));
+
+      const result = await expander.expand("#project updates about project deadlines");
+
+      expect(result.salientTerms).toEqual(
+        expect.arrayContaining(["#project", "updates", "about", "project", "deadlines"])
+      );
+    });
+
     it("should limit variants to maxVariants", async () => {
       mockChatModel.invoke.mockResolvedValue({
         content: `<queries>

--- a/src/search/v3/QueryExpander.test.ts
+++ b/src/search/v3/QueryExpander.test.ts
@@ -86,6 +86,16 @@ describe("QueryExpander", () => {
       expect(result.salientTerms).not.toContain("2024/plan");
     });
 
+    it("should keep standalone term when both tagged and untagged variants exist", async () => {
+      mockChatModel.invoke.mockRejectedValue(new Error("LLM error"));
+
+      const result = await expander.expand("#project project kickoff brief");
+
+      expect(result.salientTerms).toEqual(
+        expect.arrayContaining(["#project", "project", "kickoff", "brief"])
+      );
+    });
+
     it("should limit variants to maxVariants", async () => {
       mockChatModel.invoke.mockResolvedValue({
         content: `<queries>

--- a/src/search/v3/QueryExpander.ts
+++ b/src/search/v3/QueryExpander.ts
@@ -502,15 +502,7 @@ Format your response using XML tags:
       return Array.from(combined);
     }
 
-    const normalizedQuery = originalQuery.toLowerCase();
-    let queryWithoutTags = normalizedQuery;
-
-    for (const tag of tagTerms) {
-      const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-      queryWithoutTags = queryWithoutTags.replace(new RegExp(escapedTag, "g"), " ");
-    }
-
-    const standaloneTerms = new Set(this.extractTermsFromQueries([queryWithoutTags]));
+    const standaloneTerms = this.collectStandaloneTerms(originalQuery);
 
     for (const tag of tagTerms) {
       const withoutHash = tag.slice(1);
@@ -520,6 +512,96 @@ Format your response using XML tags:
     }
 
     return Array.from(combined);
+  }
+
+  /**
+   * Collects lowercase standalone terms from the original query that do not belong to tag tokens.
+   * These terms originate from user text outside of hash-prefixed tags.
+   *
+   * @param originalQuery - Raw user query containing potential tag and non-tag text
+   * @returns Set of standalone terms detected outside tag spans
+   */
+  private collectStandaloneTerms(originalQuery: string): Set<string> {
+    const standaloneTerms = new Set<string>();
+
+    if (!originalQuery) {
+      return standaloneTerms;
+    }
+
+    const normalizedQuery = originalQuery.toLowerCase();
+    const tagRanges = this.findTagRanges(normalizedQuery);
+
+    const wordPatterns = [/[\p{L}\p{N}_-]+/gu, /[a-z0-9_-]+/g];
+
+    for (const pattern of wordPatterns) {
+      try {
+        for (const match of normalizedQuery.matchAll(pattern)) {
+          if (match.index === undefined) {
+            continue;
+          }
+
+          const start = match.index;
+          const end = start + match[0].length;
+          const insideTag = tagRanges.some(
+            ({ start: tagStart, end: tagEnd }) => start >= tagStart && end <= tagEnd
+          );
+
+          if (insideTag) {
+            continue;
+          }
+
+          const candidate = match[0];
+          if (this.isValidTerm(candidate) && !candidate.startsWith("#")) {
+            standaloneTerms.add(candidate);
+
+            if (candidate.includes("-")) {
+              candidate.split("-").forEach((part) => {
+                if (this.isValidTerm(part) && !part.startsWith("#")) {
+                  standaloneTerms.add(part);
+                }
+              });
+            }
+          }
+        }
+        break;
+      } catch {
+        continue;
+      }
+    }
+
+    return standaloneTerms;
+  }
+
+  /**
+   * Finds the start and end indices for every tag token inside the query string.
+   * Ranges include the '#' prefix so downstream checks can exclude tag spans precisely.
+   *
+   * @param normalizedQuery - Lowercase query used for regex scanning
+   * @returns Array of inclusive-exclusive index ranges for each tag occurrence
+   */
+  private findTagRanges(normalizedQuery: string): Array<{ start: number; end: number }> {
+    const ranges: Array<{ start: number; end: number }> = [];
+    const tagPatterns = [/#[\p{L}\p{N}_/-]+/gu, /#[a-z0-9_/-]+/g];
+
+    for (const pattern of tagPatterns) {
+      try {
+        for (const match of normalizedQuery.matchAll(pattern)) {
+          if (match.index === undefined) {
+            continue;
+          }
+
+          ranges.push({
+            start: match.index,
+            end: match.index + match[0].length,
+          });
+        }
+        break;
+      } catch {
+        continue;
+      }
+    }
+
+    return ranges;
   }
 
   /**

--- a/src/search/v3/SearchCore.test.ts
+++ b/src/search/v3/SearchCore.test.ts
@@ -1,0 +1,155 @@
+import { NoteIdRank } from "./interfaces";
+
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({ debug: false, enableLexicalBoosts: true })),
+}));
+
+const buildFromCandidatesMock = jest.fn();
+const searchMock = jest.fn();
+const clearMock = jest.fn();
+const getStatsMock = jest.fn(() => ({
+  documentsIndexed: 0,
+  memoryUsed: 0,
+  memoryPercent: 0,
+}));
+const expandMock = jest.fn();
+const batchCachedReadGrepMock = jest.fn();
+const applyFolderBoostMock = jest.fn((results: NoteIdRank[]) => results);
+const applyGraphBoostMock = jest.fn((results: NoteIdRank[]) => results);
+const normalizeMock = jest.fn((results: NoteIdRank[]) => results);
+
+jest.mock("./engines/FullTextEngine", () => ({
+  FullTextEngine: jest.fn().mockImplementation(() => ({
+    buildFromCandidates: buildFromCandidatesMock,
+    search: searchMock,
+    clear: clearMock,
+    getStats: getStatsMock,
+  })),
+}));
+
+jest.mock("./QueryExpander", () => ({
+  QueryExpander: jest.fn().mockImplementation(() => ({
+    expand: expandMock,
+    clearCache: jest.fn(),
+  })),
+}));
+
+jest.mock("./scanners/GrepScanner", () => ({
+  GrepScanner: jest.fn().mockImplementation(() => ({
+    batchCachedReadGrep: batchCachedReadGrepMock,
+    grep: jest.fn(),
+  })),
+}));
+
+jest.mock("./scoring/FolderBoostCalculator", () => ({
+  FolderBoostCalculator: jest.fn().mockImplementation(() => ({
+    applyBoosts: applyFolderBoostMock,
+  })),
+}));
+
+jest.mock("./scoring/GraphBoostCalculator", () => ({
+  GraphBoostCalculator: jest.fn().mockImplementation(() => ({
+    applyBoost: applyGraphBoostMock,
+  })),
+}));
+
+jest.mock("./utils/ScoreNormalizer", () => ({
+  ScoreNormalizer: jest.fn().mockImplementation(() => ({
+    normalize: normalizeMock,
+  })),
+}));
+
+jest.mock("./chunks", () => ({
+  ChunkManager: jest.fn().mockImplementation(() => ({
+    getChunks: jest.fn().mockResolvedValue([]),
+  })),
+}));
+
+import { SearchCore } from "./SearchCore";
+
+describe("SearchCore tag recall", () => {
+  let mockApp: any;
+
+  beforeEach(() => {
+    buildFromCandidatesMock.mockReset();
+    searchMock.mockReset();
+    clearMock.mockReset();
+    getStatsMock.mockReset();
+    expandMock.mockReset();
+    batchCachedReadGrepMock.mockReset();
+    applyFolderBoostMock.mockReset();
+    applyGraphBoostMock.mockReset();
+    normalizeMock.mockReset();
+
+    buildFromCandidatesMock.mockResolvedValue(1);
+    searchMock.mockReturnValue([{ id: "note.md#0", score: 0.9, engine: "fulltext" }]);
+    getStatsMock.mockReturnValue({ documentsIndexed: 1, memoryUsed: 0, memoryPercent: 0 });
+    applyFolderBoostMock.mockImplementation((results: NoteIdRank[]) => results);
+    applyGraphBoostMock.mockImplementation((results: NoteIdRank[]) => results);
+    normalizeMock.mockImplementation((results: NoteIdRank[]) => results);
+
+    expandMock.mockResolvedValue({
+      queries: ["#ProjectAlpha/Phase1 update"],
+      salientTerms: ["#projectalpha/phase1", "update"],
+      originalQuery: "#ProjectAlpha/Phase1 update",
+      expandedQueries: [],
+      expandedTerms: [],
+    });
+    batchCachedReadGrepMock.mockResolvedValue(["note.md"]);
+
+    mockApp = {
+      vault: {
+        getMarkdownFiles: jest.fn(() => []),
+        getAbstractFileByPath: jest.fn(() => null),
+      },
+      metadataCache: {
+        getFileCache: jest.fn(() => undefined),
+        resolvedLinks: {},
+        getBacklinksForFile: jest.fn(() => ({ data: {} })),
+      },
+    };
+  });
+
+  it("should surface hierarchy-aware recall terms for hash tags", async () => {
+    const searchCore = new SearchCore(mockApp as any);
+
+    const results = await searchCore.retrieve("#ProjectAlpha/Phase1 update");
+
+    expect(results).toHaveLength(1);
+    const recallQueries = searchMock.mock.calls[0][0];
+
+    expect(recallQueries).toEqual(
+      expect.arrayContaining([
+        "#projectalpha/phase1",
+        "projectalpha/phase1",
+        "projectalpha",
+        "phase1",
+      ])
+    );
+
+    const grepQueries = batchCachedReadGrepMock.mock.calls[0][0];
+    expect(grepQueries).toEqual(
+      expect.arrayContaining(["projectalpha/phase1", "projectalpha", "phase1"])
+    );
+  });
+
+  it("should bypass ceilings when returnAll is enabled", async () => {
+    const searchCore = new SearchCore(mockApp as any);
+
+    buildFromCandidatesMock.mockResolvedValueOnce(5);
+    batchCachedReadGrepMock.mockResolvedValueOnce(["note1.md", "note2.md"]);
+    searchMock.mockReturnValueOnce([
+      { id: "note1.md#0", score: 0.9, engine: "fulltext" },
+      { id: "note2.md#0", score: 0.8, engine: "fulltext" },
+    ]);
+
+    const results = await searchCore.retrieve("#project", {
+      salientTerms: ["#project"],
+      returnAll: true,
+    });
+
+    expect(batchCachedReadGrepMock).toHaveBeenCalledWith(expect.any(Array), 200);
+    expect(searchMock.mock.calls[0][1]).toBe(400);
+    expect(results.length).toBe(2);
+  });
+});

--- a/src/search/v3/SearchCore.ts
+++ b/src/search/v3/SearchCore.ts
@@ -13,6 +13,7 @@ import { ScoreNormalizer } from "./utils/ScoreNormalizer";
 
 // Search constants
 const FULLTEXT_RESULT_MULTIPLIER = 2;
+export const RETURN_ALL_LIMIT = 200;
 
 /**
  * Core search engine that orchestrates the multi-stage retrieval pipeline
@@ -80,8 +81,13 @@ export class SearchCore {
     }
 
     // Validate and sanitize options with bounds checking
-    const maxResults = Math.min(Math.max(1, options.maxResults || 30), 100);
-    const candidateLimit = Math.min(Math.max(10, options.candidateLimit || 500), 1000);
+    const returnAll = Boolean(options.returnAll);
+    const maxResults = returnAll
+      ? RETURN_ALL_LIMIT
+      : Math.min(Math.max(1, options.maxResults || 30), 100);
+    const candidateLimit = returnAll
+      ? RETURN_ALL_LIMIT
+      : Math.min(Math.max(10, options.candidateLimit || 500), 1000);
     const enableLexicalBoosts = Boolean(options.enableLexicalBoosts ?? true); // Default to enabled
 
     try {
@@ -96,6 +102,28 @@ export class SearchCore {
         ? [...new Set([...expanded.salientTerms, ...options.salientTerms])]
         : expanded.salientTerms;
 
+      // Build recall queries, ensuring tag variants are included for maximum recall
+      const tagRecallTerms = this.buildTagRecallQueries(salientTerms);
+      const recallQueries: string[] = [];
+      const recallLookup = new Set<string>();
+
+      const addRecallTerm = (term: string | undefined) => {
+        if (!term) {
+          return;
+        }
+        const normalized = term.toLowerCase();
+        if (normalized.length === 0 || recallLookup.has(normalized)) {
+          return;
+        }
+        recallLookup.add(normalized);
+        recallQueries.push(term);
+      };
+
+      queries.forEach(addRecallTerm);
+      expanded.expandedTerms.forEach(addRecallTerm);
+      salientTerms.forEach(addRecallTerm);
+      tagRecallTerms.forEach(addRecallTerm);
+
       // Only log details if expansion produced significant variants
       if (queries.length > 1 || salientTerms.length > 3 || expanded.expandedTerms.length > 0) {
         logInfo(
@@ -104,8 +132,8 @@ export class SearchCore {
       }
 
       // 2. GREP for initial candidates (use all terms for maximum recall)
-      const recallQueries = [...queries, ...expanded.expandedTerms, ...salientTerms];
-      const grepHits = await this.grepScanner.batchCachedReadGrep(recallQueries, 200);
+      const grepLimit = returnAll ? RETURN_ALL_LIMIT : 200;
+      const grepHits = await this.grepScanner.batchCachedReadGrep(recallQueries, grepLimit);
 
       // 3. Limit candidates (no graph expansion - we use graph for boost only)
       const candidates = grepHits.slice(0, candidateLimit);
@@ -119,7 +147,8 @@ export class SearchCore {
         recallQueries,
         salientTerms,
         maxResults,
-        expanded.originalQuery
+        expanded.originalQuery,
+        returnAll
       );
 
       // 6. Apply boosts to lexical results (if enabled)
@@ -136,7 +165,9 @@ export class SearchCore {
       this.fullTextEngine.clear();
 
       // 9. Return top K results
-      finalResults = finalResults.slice(0, maxResults);
+      if (finalResults.length > maxResults) {
+        finalResults = finalResults.slice(0, maxResults);
+      }
 
       // Log final result summary
       if (finalResults.length > 0) {
@@ -211,6 +242,47 @@ export class SearchCore {
   }
 
   /**
+   * Builds additional recall terms for tag queries so that tagged notes are always considered during recall.
+   * Generates lowercase variants without the hash prefix and splits hierarchical tags into their components.
+   *
+   * @param salientTerms - Salient terms extracted from the original query (may include hash-prefixed tags)
+   * @returns Unique recall terms derived from tag tokens (e.g., ['project/alpha', 'project', 'alpha'])
+   */
+  private buildTagRecallQueries(salientTerms: string[]): string[] {
+    const tagQueries = new Set<string>();
+
+    for (const term of salientTerms) {
+      if (!term || !term.startsWith("#")) {
+        continue;
+      }
+
+      const normalized = term.toLowerCase();
+      if (normalized.length <= 1) {
+        continue;
+      }
+
+      const withoutHash = normalized.slice(1);
+      if (withoutHash.length === 0) {
+        continue;
+      }
+
+      tagQueries.add(withoutHash);
+
+      const segments = withoutHash.split("/").filter((segment) => segment.length > 0);
+      if (segments.length > 0) {
+        let prefix = "";
+        for (const segment of segments) {
+          prefix = prefix ? `${prefix}/${segment}` : segment;
+          tagQueries.add(prefix);
+          tagQueries.add(segment);
+        }
+      }
+    }
+
+    return Array.from(tagQueries);
+  }
+
+  /**
    * Execute lexical search with full-text index
    * @param candidates - Candidate documents to index
    * @param recallQueries - All queries for recall (original + expanded + salient terms)
@@ -224,7 +296,8 @@ export class SearchCore {
     recallQueries: string[],
     salientTerms: string[],
     maxResults: number,
-    originalQuery?: string
+    originalQuery?: string,
+    returnAll: boolean = false
   ): Promise<NoteIdRank[]> {
     try {
       // Build ephemeral full-text index
@@ -234,9 +307,17 @@ export class SearchCore {
 
       // Search the index
       const searchStartTime = Date.now();
+      const effectiveMaxResults = returnAll
+        ? RETURN_ALL_LIMIT
+        : Number.isFinite(maxResults)
+          ? Math.min(maxResults, 1000)
+          : candidates.length || 30;
+      const searchLimit = returnAll
+        ? RETURN_ALL_LIMIT * FULLTEXT_RESULT_MULTIPLIER
+        : Math.max(effectiveMaxResults * FULLTEXT_RESULT_MULTIPLIER, FULLTEXT_RESULT_MULTIPLIER);
       const results = this.fullTextEngine.search(
         recallQueries,
-        maxResults * FULLTEXT_RESULT_MULTIPLIER,
+        searchLimit,
         salientTerms,
         originalQuery
       );

--- a/src/search/v3/SearchCore.ts
+++ b/src/search/v3/SearchCore.ts
@@ -125,9 +125,11 @@ export class SearchCore {
       tagRecallTerms.forEach(addRecallTerm);
 
       // Only log details if expansion produced significant variants
-      if (queries.length > 1 || salientTerms.length > 3 || expanded.expandedTerms.length > 0) {
+      if (queries.length > 1 || salientTerms.length > 0 || expanded.expandedTerms.length > 0) {
         logInfo(
-          `Query expansion: ${queries.length} variants, ${salientTerms.length} scoring terms (from original), ${expanded.expandedTerms.length} recall terms (LLM-generated)`
+          `Query expansion: variants=${JSON.stringify(queries)}, salient=${JSON.stringify(
+            salientTerms
+          )}, recall=${JSON.stringify(expanded.expandedTerms)}`
         );
       }
 

--- a/src/search/v3/TieredLexicalRetriever.test.ts
+++ b/src/search/v3/TieredLexicalRetriever.test.ts
@@ -197,13 +197,15 @@ describe("TieredLexicalRetriever", () => {
         { id: "tagNote.md#1", score: 0.8, engine: "fulltext" },
       ]);
 
-      const tagRetriever = new TieredLexicalRetriever(mockApp, {
+      const tagRetrieverOptions: ConstructorParameters<typeof TieredLexicalRetriever>[1] = {
         minSimilarityScore: 0.1,
         maxK: Number.MAX_SAFE_INTEGER,
         salientTerms: ["#project"],
         returnAllTags: true,
         tagTerms: ["#project"],
-      });
+      };
+
+      const tagRetriever = new TieredLexicalRetriever(mockApp, tagRetrieverOptions);
 
       mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) => {
         if (path === "tagNote.md") {

--- a/src/search/v3/TieredLexicalRetriever.test.ts
+++ b/src/search/v3/TieredLexicalRetriever.test.ts
@@ -1,45 +1,27 @@
 import { Document } from "@langchain/core/documents";
 import { TFile } from "obsidian";
-import * as SearchCoreModule from "./SearchCore";
 import { TieredLexicalRetriever } from "./TieredLexicalRetriever";
+
+const retrieveMock = jest.fn();
+const mockChunkManager: { getChunkTextSync: jest.Mock } = {
+  getChunkTextSync: jest.fn(),
+};
 
 // Mock modules
 jest.mock("obsidian");
 jest.mock("@/logger");
-jest.mock("./SearchCore", () => {
-  const mockChunkManager = {
-    getChunkTextSync: jest.fn((id: string) => {
-      if (id === "note1.md#0") return "First chunk content from note1";
-      if (id === "note1.md#1") return "Second chunk content from note1";
-      if (id === "note2.md#0") return "Content from note2 chunk";
-      return "";
-    }),
-  };
-
-  return {
-    SearchCore: jest.fn().mockImplementation(() => ({
-      retrieve: jest.fn().mockResolvedValue([
-        { id: "note1.md#0", score: 0.8, engine: "fulltext" },
-        { id: "note1.md#1", score: 0.7, engine: "fulltext" },
-        { id: "note2.md#0", score: 0.6, engine: "grep" },
-      ]),
-      getChunkManager: jest.fn(() => mockChunkManager),
-    })),
-  };
-});
+jest.mock("./SearchCore", () => ({
+  SearchCore: jest.fn().mockImplementation(() => ({
+    retrieve: retrieveMock,
+    getChunkManager: jest.fn(() => mockChunkManager),
+  })),
+}));
 jest.mock("@/LLMProviders/chatModelManager");
 jest.mock("@/utils", () => ({
   extractNoteFiles: jest.fn().mockReturnValue([]),
 }));
 jest.mock("./chunks", () => ({
-  ChunkManager: jest.fn().mockImplementation(() => ({
-    getChunkTextSync: jest.fn((id: string) => {
-      if (id === "note1.md#0") return "First chunk content from note1";
-      if (id === "note1.md#1") return "Second chunk content from note1";
-      if (id === "note2.md#0") return "Content from note2 chunk";
-      return "";
-    }),
-  })),
+  ChunkManager: jest.fn().mockImplementation(() => mockChunkManager),
 }));
 
 describe("TieredLexicalRetriever", () => {
@@ -48,6 +30,21 @@ describe("TieredLexicalRetriever", () => {
   // legacy var no longer used after refactor
 
   beforeEach(() => {
+    retrieveMock.mockReset();
+    retrieveMock.mockResolvedValue([
+      { id: "note1.md#0", score: 0.8, engine: "fulltext" },
+      { id: "note1.md#1", score: 0.7, engine: "fulltext" },
+      { id: "note2.md#0", score: 0.6, engine: "grep" },
+    ]);
+
+    mockChunkManager.getChunkTextSync.mockReset();
+    mockChunkManager.getChunkTextSync.mockImplementation((id: string) => {
+      if (id === "note1.md#0") return "First chunk content from note1";
+      if (id === "note1.md#1") return "Second chunk content from note1";
+      if (id === "note2.md#0") return "Content from note2 chunk";
+      return "";
+    });
+
     // Mock app
     mockApp = {
       vault: {
@@ -58,15 +55,6 @@ describe("TieredLexicalRetriever", () => {
         getFileCache: jest.fn(),
       },
     };
-
-    // Ensure SearchCore is mocked before constructing retriever
-    jest.spyOn(SearchCoreModule, "SearchCore").mockImplementation((() => ({
-      retrieve: jest.fn().mockResolvedValue([
-        { id: "note1.md#0", score: 0.8, engine: "fulltext" },
-        { id: "note1.md#1", score: 0.7, engine: "fulltext" },
-        { id: "note2.md#0", score: 0.6, engine: "grep" },
-      ]),
-    })) as any);
 
     // Create retriever instance
     retriever = new TieredLexicalRetriever(mockApp, {
@@ -164,23 +152,19 @@ describe("TieredLexicalRetriever", () => {
     });
 
     it("should integrate all components correctly and return chunk Documents", async () => {
-      // Ensure SearchCore mock returns chunk results
-      jest.spyOn(SearchCoreModule, "SearchCore").mockImplementation((() => ({
-        retrieve: jest.fn().mockResolvedValue([
-          { id: "note1.md#0", score: 0.8, engine: "fulltext" },
-          { id: "note2.md#0", score: 0.6, engine: "grep" },
-        ]),
-      })) as any);
+      retrieveMock.mockResolvedValueOnce([
+        { id: "note1.md#0", score: 0.8, engine: "fulltext" },
+        { id: "note2.md#0", score: 0.6, engine: "grep" },
+      ]);
 
-      // Recreate retriever with the mocked SearchCore
-      retriever = new TieredLexicalRetriever(mockApp, {
+      const chunkRetriever = new TieredLexicalRetriever(mockApp, {
         minSimilarityScore: 0.1,
         maxK: 30,
         salientTerms: [],
       });
 
       const query = "test query";
-      const results = await retriever.getRelevantDocuments(query);
+      const results = await chunkRetriever.getRelevantDocuments(query);
 
       // Should return chunk Documents (all chunks from SearchCore, no title matches)
       expect(results.length).toBe(2);
@@ -197,17 +181,56 @@ describe("TieredLexicalRetriever", () => {
     });
 
     it("should handle empty search results", async () => {
-      jest
-        .spyOn(SearchCoreModule, "SearchCore")
-        .mockImplementation((() => ({ retrieve: jest.fn().mockResolvedValue([]) })) as any);
-      // Recreate retriever to use the new mock implementation
-      retriever = new TieredLexicalRetriever(mockApp, {
+      retrieveMock.mockResolvedValue([]);
+      const emptyRetriever = new TieredLexicalRetriever(mockApp, {
         minSimilarityScore: 0.1,
         maxK: 30,
         salientTerms: [],
       });
-      const results = await retriever.getRelevantDocuments("no matches");
+      const results = await emptyRetriever.getRelevantDocuments("no matches");
       expect(results).toEqual([]);
+    });
+
+    it("should retrieve all tag matches when returnAllTags is enabled", async () => {
+      retrieveMock.mockResolvedValue([
+        { id: "tagNote.md#0", score: 0.9, engine: "fulltext" },
+        { id: "tagNote.md#1", score: 0.8, engine: "fulltext" },
+      ]);
+
+      const tagRetriever = new TieredLexicalRetriever(mockApp, {
+        minSimilarityScore: 0.1,
+        maxK: Number.MAX_SAFE_INTEGER,
+        salientTerms: ["#project"],
+        returnAllTags: true,
+        tagTerms: ["#project"],
+      });
+
+      mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) => {
+        if (path === "tagNote.md") {
+          const file = new (TFile as any)(path);
+          Object.setPrototypeOf(file, (TFile as any).prototype);
+          (file as any).stat = { mtime: 1000, ctime: 1000 };
+          return file;
+        }
+        return null;
+      });
+
+      mockChunkManager.getChunkTextSync.mockImplementation((id: string) => {
+        if (id === "tagNote.md#0") return "Tag chunk 0";
+        if (id === "tagNote.md#1") return "Tag chunk 1";
+        return "";
+      });
+
+      const results = await tagRetriever.getRelevantDocuments("#project work log");
+
+      expect(retrieveMock).toHaveBeenCalledWith(
+        expect.stringContaining("#project"),
+        expect.objectContaining({
+          returnAll: true,
+          salientTerms: ["#project"],
+        })
+      );
+      expect(results.length).toBe(2);
     });
 
     it("should extract mentioned notes from query", async () => {
@@ -243,21 +266,16 @@ describe("TieredLexicalRetriever", () => {
       (mockMentionedFile as any).stat = { mtime: 1000, ctime: 1000 };
       extractNoteFiles.mockReturnValueOnce([mockMentionedFile]);
 
-      jest.spyOn(SearchCoreModule, "SearchCore").mockImplementation((() => ({
-        retrieve: jest
-          .fn()
-          .mockResolvedValue([{ id: "other.md#0", score: 0.4, engine: "fulltext" }]),
-      })) as any);
+      retrieveMock.mockResolvedValueOnce([{ id: "other.md#0", score: 0.4, engine: "fulltext" }]);
 
-      // Recreate retriever to use the new mock implementation
-      retriever = new TieredLexicalRetriever(mockApp, {
+      const mentionRetriever = new TieredLexicalRetriever(mockApp, {
         minSimilarityScore: 0.1,
         maxK: 30,
         salientTerms: [],
       });
 
       const query = "search [[mentioned]] for something";
-      const results = await retriever.getRelevantDocuments(query);
+      const results = await mentionRetriever.getRelevantDocuments(query);
 
       // Should include the mentioned note
       const mentioned = results.find((d) => d.metadata.path === "mentioned.md");
@@ -268,22 +286,17 @@ describe("TieredLexicalRetriever", () => {
   describe("chunk Document handling", () => {
     it("should return chunk Documents with chunk content", async () => {
       // Update ChunkManager mock for these specific chunk IDs
-      const { ChunkManager } = jest.requireMock("./chunks");
-      ChunkManager.mockImplementation(() => ({
-        getChunkTextSync: jest.fn((id: string) => {
-          if (id === "test.md#0") return "First chunk from test note";
-          if (id === "test.md#1") return "Second chunk from test note";
-          return "";
-        }),
-      }));
+      mockChunkManager.getChunkTextSync.mockImplementation((id: string) => {
+        if (id === "test.md#0") return "First chunk from test note";
+        if (id === "test.md#1") return "Second chunk from test note";
+        return "";
+      });
 
       // Mock SearchCore before creating retriever
-      jest.spyOn(SearchCoreModule, "SearchCore").mockImplementation((() => ({
-        retrieve: jest.fn().mockResolvedValue([
-          { id: "test.md#0", score: 0.9, engine: "fulltext" },
-          { id: "test.md#1", score: 0.8, engine: "fulltext" },
-        ]),
-      })) as any);
+      retrieveMock.mockResolvedValueOnce([
+        { id: "test.md#0", score: 0.9, engine: "fulltext" },
+        { id: "test.md#1", score: 0.8, engine: "fulltext" },
+      ]);
 
       mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) => {
         if (path === "test.md") {
@@ -295,14 +308,13 @@ describe("TieredLexicalRetriever", () => {
         return null;
       });
 
-      // Recreate retriever with the mocked SearchCore
-      retriever = new TieredLexicalRetriever(mockApp, {
+      const chunkRetriever = new TieredLexicalRetriever(mockApp, {
         minSimilarityScore: 0.1,
         maxK: 30,
         salientTerms: [],
       });
 
-      const results = await retriever.getRelevantDocuments("test query");
+      const results = await chunkRetriever.getRelevantDocuments("test query");
 
       // Should return all chunk Documents
       expect(results.length).toBe(2);
@@ -313,25 +325,17 @@ describe("TieredLexicalRetriever", () => {
 
     it("should handle missing chunk content gracefully", async () => {
       // Mock ChunkManager to return empty content
-      const { ChunkManager: mockChunkManager } = jest.requireMock("./chunks");
-      mockChunkManager.mockImplementation(() => ({
-        getChunkTextSync: jest.fn(() => ""), // Empty chunk content
-      }));
+      mockChunkManager.getChunkTextSync.mockImplementation(() => "");
 
-      jest.spyOn(SearchCoreModule, "SearchCore").mockImplementation((() => ({
-        retrieve: jest
-          .fn()
-          .mockResolvedValue([{ id: "test.md#0", score: 0.9, engine: "fulltext" }]),
-      })) as any);
+      retrieveMock.mockResolvedValueOnce([{ id: "test.md#0", score: 0.9, engine: "fulltext" }]);
 
-      // Recreate retriever to use new mock
-      retriever = new TieredLexicalRetriever(mockApp, {
+      const emptyChunkRetriever = new TieredLexicalRetriever(mockApp, {
         minSimilarityScore: 0.1,
         maxK: 30,
         salientTerms: [],
       });
 
-      const results = await retriever.getRelevantDocuments("test query");
+      const results = await emptyChunkRetriever.getRelevantDocuments("test query");
 
       // Should skip chunks with empty content
       expect(results.length).toBe(0);
@@ -340,14 +344,6 @@ describe("TieredLexicalRetriever", () => {
 
   describe("multiple chunks", () => {
     it("should handle multiple chunks from same note correctly", async () => {
-      jest.spyOn(SearchCoreModule, "SearchCore").mockImplementation((() => ({
-        retrieve: jest.fn().mockResolvedValue([
-          { id: "large.md#0", score: 0.9, engine: "fulltext" },
-          { id: "large.md#1", score: 0.8, engine: "fulltext" },
-          { id: "other.md#0", score: 0.6, engine: "fulltext" },
-        ]),
-      })) as any);
-
       // Mock file system
       mockApp.vault.getAbstractFileByPath.mockImplementation((path: string) => {
         if (path === "large.md" || path === "other.md") {
@@ -359,25 +355,26 @@ describe("TieredLexicalRetriever", () => {
         return null;
       });
 
-      // Update ChunkManager mock
-      const { ChunkManager: mockChunkManager } = jest.requireMock("./chunks");
-      mockChunkManager.mockImplementation(() => ({
-        getChunkTextSync: jest.fn((id: string) => {
-          if (id === "large.md#0") return "First chunk from large note";
-          if (id === "large.md#1") return "Second chunk from large note";
-          if (id === "other.md#0") return "Content from other note";
-          return "";
-        }),
-      }));
+      retrieveMock.mockResolvedValueOnce([
+        { id: "large.md#0", score: 0.9, engine: "fulltext" },
+        { id: "large.md#1", score: 0.8, engine: "fulltext" },
+        { id: "other.md#0", score: 0.6, engine: "fulltext" },
+      ]);
 
-      // Recreate retriever
-      retriever = new TieredLexicalRetriever(mockApp, {
+      mockChunkManager.getChunkTextSync.mockImplementation((id: string) => {
+        if (id === "large.md#0") return "First chunk from large note";
+        if (id === "large.md#1") return "Second chunk from large note";
+        if (id === "other.md#0") return "Content from other note";
+        return "";
+      });
+
+      const multiChunkRetriever = new TieredLexicalRetriever(mockApp, {
         minSimilarityScore: 0.1,
         maxK: 30,
         salientTerms: [],
       });
 
-      const results = await retriever.getRelevantDocuments("test query");
+      const results = await multiChunkRetriever.getRelevantDocuments("test query");
 
       // Should return all chunks
       expect(results.length).toBe(3);

--- a/src/search/v3/engines/FullTextEngine.test.ts
+++ b/src/search/v3/engines/FullTextEngine.test.ts
@@ -158,6 +158,24 @@ jest.mock("../chunks", () => ({
           heading: "",
           mtime: Date.now(),
         },
+        {
+          id: "common.md#0",
+          notePath: "common.md",
+          chunkIndex: 0,
+          content: "Meeting note summary with meeting agenda note note.",
+          title: "Common Note",
+          heading: "",
+          mtime: Date.now(),
+        },
+        {
+          id: "unique.md#0",
+          notePath: "unique.md",
+          chunkIndex: 0,
+          content: "Meeting note covering architecture rareterm decisions for alpha.",
+          title: "Unique Note",
+          heading: "",
+          mtime: Date.now(),
+        },
       ];
 
       // Filter chunks based on candidates
@@ -252,6 +270,14 @@ describe("FullTextEngine", () => {
         headings: [],
         frontmatter: {}, // Will be set up separately for circular test
       },
+      "common.md": {
+        headings: [],
+        frontmatter: {},
+      },
+      "unique.md": {
+        headings: [],
+        frontmatter: {},
+      },
     };
 
     // Mock app
@@ -275,6 +301,8 @@ describe("FullTextEngine", () => {
             "array-test.md": "Testing arrays in frontmatter",
             "edge-cases.md": "Testing edge cases",
             "circular.md": "body",
+            "common.md": "Meeting note summary with meeting agenda note note.",
+            "unique.md": "Meeting note covering architecture rareterm decisions for alpha.",
           };
           return Promise.resolve(contents[file.path] || "");
         }),
@@ -332,6 +360,31 @@ describe("FullTextEngine", () => {
 
       expect(tokens).toContain("中");
       expect(tokens).toContain("文");
+    });
+
+    it("should tokenize hash tags and their hierarchy variants", () => {
+      const tokens = (engine as any).tokenizeMixed("Working on #Project/Alpha and #deepWork");
+
+      expect(tokens).toEqual(
+        expect.arrayContaining([
+          "#project/alpha",
+          "#project",
+          "project/alpha",
+          "project",
+          "alpha",
+          "#deepwork",
+          "deepwork",
+        ])
+      );
+    });
+
+    it("should not split hyphenated tags into partial word tokens", () => {
+      const tokens = (engine as any).tokenizeMixed("#copilot-conversation updates");
+
+      expect(tokens).toContain("#copilot-conversation");
+      expect(tokens).toContain("copilot-conversation");
+      expect(tokens).not.toContain("copilot");
+      expect(tokens).not.toContain("conversation");
     });
 
     it("should return empty array for empty input", () => {
@@ -574,6 +627,42 @@ describe("FullTextEngine", () => {
         expect(results[0].score).toBeGreaterThan(0);
       }
     });
+
+    it("should prioritize chunks that match tag queries", () => {
+      const results = engine.search(["#piano", "piano"], 10, ["#piano"], "#piano");
+
+      expect(results.length).toBeGreaterThan(0);
+      const tagMatchIndex = results.findIndex((r) => r.id === "projects/music.md#0");
+      expect(tagMatchIndex).toBeGreaterThanOrEqual(0);
+
+      const lessonIndex = results.findIndex((r) => r.id.includes("Lesson 1"));
+      if (lessonIndex >= 0) {
+        expect(tagMatchIndex).toBeLessThan(lessonIndex);
+      }
+
+      const tagMatchScore = results[tagMatchIndex]?.score ?? 0;
+      const otherScore = lessonIndex >= 0 ? (results[lessonIndex]?.score ?? 0) : 0;
+      expect(tagMatchScore).toBeGreaterThan(otherScore);
+    });
+
+    it("should downweight ubiquitous terms during ranking", async () => {
+      await engine.buildFromCandidates(["common.md"]);
+      const results = engine.search(["meeting"], 10, ["meeting"], "meeting");
+
+      expect(results[0].explanation?.baseScore).toBeCloseTo(0.4, 2);
+    });
+
+    it("should keep rare terms dominant when combined with common terms", async () => {
+      await engine.buildFromCandidates(["common.md", "unique.md"]);
+      const results = engine.search(
+        ["meeting", "rareterm"],
+        10,
+        ["meeting", "rareterm"],
+        "meeting rareterm"
+      );
+
+      expect(results[0].id).toBe("unique.md#0");
+    });
   });
 
   describe("chunk-based indexing", () => {
@@ -624,10 +713,10 @@ describe("FullTextEngine", () => {
       const getFieldWeight = (engine as any).getFieldWeight.bind(engine);
 
       expect(getFieldWeight("title")).toBe(3);
-      expect(getFieldWeight("heading")).toBe(1); // Default weight since not in field weights map
+      expect(getFieldWeight("heading")).toBe(2.5);
       expect(getFieldWeight("path")).toBe(1.5); // Actual weight from implementation
       expect(getFieldWeight("headings")).toBe(1.5);
-      expect(getFieldWeight("tags")).toBe(1.5);
+      expect(getFieldWeight("tags")).toBe(4);
       expect(getFieldWeight("props")).toBe(1.5);
       expect(getFieldWeight("links")).toBe(1.5);
       expect(getFieldWeight("body")).toBe(1);

--- a/src/search/v3/engines/FullTextEngine.test.ts
+++ b/src/search/v3/engines/FullTextEngine.test.ts
@@ -663,6 +663,16 @@ describe("FullTextEngine", () => {
 
       expect(results[0].id).toBe("unique.md#0");
     });
+
+    it("should display hashless explanation for non-tag matches", async () => {
+      await engine.buildFromCandidates(["unique.md"]);
+      const results = engine.search(["#rareterm"], 10, ["#rareterm"], "#rareterm");
+      const explanation = results[0].explanation?.lexicalMatches?.find(
+        (match) => match.field === "body"
+      );
+
+      expect(explanation?.query).toBe("rareterm");
+    });
   });
 
   describe("chunk-based indexing", () => {

--- a/src/search/v3/engines/FullTextEngine.ts
+++ b/src/search/v3/engines/FullTextEngine.ts
@@ -610,11 +610,14 @@ export class FullTextEngine {
           const queriesMatched = new Set(existing.queriesMatched);
           queriesMatched.add(query);
 
+          const explanationQuery =
+            fieldName === "tags" || !query.startsWith("#") ? query : query.replace(/^#/, "");
+
           const lexicalMatches = [
             ...existing.lexicalMatches,
             {
               field: fieldName,
-              query,
+              query: explanationQuery,
               weight: fieldWeight,
             },
           ];

--- a/src/search/v3/engines/FullTextEngine.ts
+++ b/src/search/v3/engines/FullTextEngine.ts
@@ -128,7 +128,8 @@ export class FullTextEngine {
             tokens.add(segment);
           }
         }
-        asciiSource = asciiSource.replace(tag, " ");
+        const escapedTag = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        asciiSource = asciiSource.replace(new RegExp(escapedTag, "gu"), " ");
       }
     }
 
@@ -658,7 +659,7 @@ export class FullTextEngine {
   /**
    * Build final results with bonuses applied
    */
-  private buildFinalResults(scoreMap: Map<string, any>, limit: number): NoteIdRank[] {
+  private buildFinalResults(scoreMap: Map<string, ScoreAccumulator>, limit: number): NoteIdRank[] {
     const finalResults: NoteIdRank[] = [];
 
     for (const [id, data] of scoreMap.entries()) {

--- a/src/search/v3/interfaces.ts
+++ b/src/search/v3/interfaces.ts
@@ -53,4 +53,6 @@ export interface SearchOptions {
   salientTerms?: string[]; // Additional terms to enhance the search
   /** Enable lexical boosts (folder and graph) - default: true */
   enableLexicalBoosts?: boolean;
+  /** When true, bypasses max result ceilings and returns every matching chunk */
+  returnAll?: boolean;
 }

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -31,6 +31,8 @@ export const BUILTIN_TOOLS: ToolDefinition[] = [
 - You MUST always provide both "query" (string) and "salientTerms" (array of strings)
 - salientTerms MUST be extracted from the user's original query - never invent new terms
 - They are keywords used for BM25 full-text search to find notes containing those exact words
+- Treat every token that begins with "#" as a high-priority salient term. Keep the leading "#" and the full tag hierarchy (e.g., "#project/phase1").
+- Include tagged terms alongside other meaningful words; never strip hashes or rewrite tags into plain words.
 - Extract meaningful content words from the query (nouns, verbs, names, etc.)
 - Exclude common words like "what", "I", "do", "the", "a", etc.
 - Exclude time expressions like "last month", "yesterday", "last week"
@@ -41,6 +43,13 @@ Example usage:
 <name>localSearch</name>
 <query>piano learning practice</query>
 <salientTerms>["piano", "learning", "practice"]</salientTerms>
+</use_tool>
+
+For localSearch with tags in the query (e.g., "#projectx status update"):
+<use_tool>
+<name>localSearch</name>
+<query>#projectx status update</query>
+<salientTerms>["#projectx", "status", "update"]</salientTerms>
 </use_tool>
 
 For localSearch with time range (e.g., "what did I do last week"):


### PR DESCRIPTION
# Improve Tag Search v3
- Both note property and inline tags are supported. Note property tags are attached to every chunk of the note.
- Tags trigger "returnAll", similar to time-range queries
- During ranking, tag results are weighted highly

# Implications
We have been supporting `{#tag}` in templating and recently added tags to the new chat input and context menu. With that, we find all notes with those tags (in note property only) and pass to the LLM along with the user query. It is not a search path. So, for a user query such as

> Find notes with #tag 

in the chat input where the `#tag` is added as a context pill, it would trigger the search tool in agent mode. This is undesirable.

@zeroliu we probably need to do these next when tag search v3 is stable

- Disable the old tag templating logic that automatically attaches all tagged notes (property only) to the user query
- Support the list of all tags instead of just property tags when a user types `#` in the chat input. But don't add them as pills nor to the context menu, just as plain text to be handled by the search tool.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce tag-preserving expansion, hierarchical tag recall, stronger tag indexing/weights, and a return-all mode for tag/time queries across Search v3.
> 
> - **Search pipeline (v3)**:
>   - Add `returnAll` flow with `RETURN_ALL_LIMIT=200`; applied to tag and time-range queries in `SearchCore`, `TieredLexicalRetriever`, and tools.
>   - Build hierarchical tag recall terms from `#tags` (e.g., `#project/alpha` → `project/alpha`, `project`, `alpha`).
> - **QueryExpander**:
>   - Preserve hash-prefixed tags as salient terms; avoid fuzzing tags.
>   - New helpers: `extractTags`, `combineBaseAndTagTerms`, `collectStandaloneTerms`, `findTagRanges`; `isValidTerm` supports tags.
> - **FullTextEngine**:
>   - Tokenizer/indexing now tag-aware: keeps `#tags`, adds hierarchy variants, avoids splitting hyphenated tags.
>   - Index fields/weights updated: `heading=2.5`, `tags=4` (added to index config).
>   - Tag normalization from inline/frontmatter; include tag/prop metadata per chunk.
>   - Ranking tweaks: downweight ubiquitous terms; tag-specific boosts (metadata priority, diversity, base bonuses); clearer explanations.
> - **TieredLexicalRetriever**:
>   - Support `returnAllTags` and tag term derivation from query/options; route to exhaustive tag retrieval when present.
>   - Cap/time-range limits aligned to `RETURN_ALL_LIMIT`; shares ChunkManager with SearchCore.
> - **Tools & Docs**:
>   - `localSearch`/`lexicalSearch` force lexical for tag/time queries; propagate tag terms and `returnAll`.
>   - Built-in tool prompt updated to keep `#tags` intact; README refreshed with tag-aware flow, field weights, and examples.
> - **Tests**:
>   - Extensive new/updated tests for tag handling, recall building, tokenizer behavior, ranking/weights, return-all ceilings, and retriever/tool integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dd16e75d23d1ac4d375aba1f06c88481e187c20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->