### PR TITLE
Fix note read

### DIFF
--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -6,6 +6,7 @@ import { getSettings, getSystemPromptWithMemory } from "@/settings/model";
 import { initializeBuiltinTools } from "@/tools/builtinTools";
 import { extractParametersFromZod, SimpleTool } from "@/tools/SimpleTool";
 import { ToolRegistry } from "@/tools/ToolRegistry";
+import { deriveReadNoteDisplayName } from "@/tools/ToolResultFormatter";
 import { ChatMessage, ResponseMetadata, StreamingResult } from "@/types/message";
 import { getMessageRole, withSuppressedTokenWarnings } from "@/utils";
 import { processToolResults } from "@/utils/toolResultUtils";
@@ -496,7 +497,7 @@ ${params}
             const notePath =
               typeof toolCall.args?.notePath === "string" ? toolCall.args.notePath : null;
             if (notePath && notePath.trim().length > 0) {
-              toolDisplayName = notePath.trim();
+              toolDisplayName = deriveReadNoteDisplayName(notePath);
             }
           }
           const confirmationMessage = getToolConfirmtionMessage(toolCall.name);

--- a/src/tools/NoteTools.ts
+++ b/src/tools/NoteTools.ts
@@ -26,6 +26,22 @@ interface NoteChunk {
   heading: string;
 }
 
+type ResolveNoteSuccess = {
+  type: "resolved";
+  file: TFile;
+};
+
+type ResolveNoteAmbiguous = {
+  type: "not_unique";
+  matches: TFile[];
+};
+
+type ResolveNoteFailure = {
+  type: "not_found";
+};
+
+type ResolveNoteOutcome = ResolveNoteSuccess | ResolveNoteAmbiguous | ResolveNoteFailure;
+
 /**
  * Normalizes a path fragment to support case-insensitive comparisons with forward slashes.
  *
@@ -46,7 +62,7 @@ function pathHasExtension(value: string): boolean {
   return /\.[^/]+$/.test(value);
 }
 
-async function resolveNoteFile(notePath: string): Promise<TFile | null> {
+async function resolveNoteFile(notePath: string): Promise<ResolveNoteOutcome> {
   const tryResolve = (path: string) => {
     const maybeFile = app.vault.getAbstractFileByPath(path);
     return maybeFile instanceof TFile ? maybeFile : null;
@@ -68,14 +84,14 @@ async function resolveNoteFile(notePath: string): Promise<TFile | null> {
   for (const candidate of attemptedPaths) {
     const direct = tryResolve(candidate);
     if (direct) {
-      return direct;
+      return { type: "resolved", file: direct };
     }
 
     if (!pathHasExtension(candidate)) {
       for (const ext of [".md", ".canvas"]) {
         const resolved = tryResolve(`${candidate}${ext}`);
         if (resolved) {
-          return resolved;
+          return { type: "resolved", file: resolved };
         }
       }
     }
@@ -96,18 +112,18 @@ async function resolveNoteFile(notePath: string): Promise<TFile | null> {
     for (const target of linkTargets) {
       const resolved = metadataCache.getFirstLinkpathDest?.(target, "");
       if (resolved instanceof TFile) {
-        return resolved;
+        return { type: "resolved", file: resolved };
       }
     }
   }
 
   if (!resolutionTarget) {
-    return null;
+    return { type: "not_found" };
   }
 
   const markdownFiles = app.vault.getMarkdownFiles?.() ?? [];
   if (markdownFiles.length === 0) {
-    return null;
+    return { type: "not_found" };
   }
 
   const normalizedTarget = normalizePathFragment(resolutionTarget);
@@ -122,7 +138,7 @@ async function resolveNoteFile(notePath: string): Promise<TFile | null> {
   for (const file of markdownFiles) {
     const normalizedFilePath = normalizePathFragment(file.path);
     if (candidatePathForms.has(normalizedFilePath)) {
-      return file;
+      return { type: "resolved", file };
     }
   }
 
@@ -134,7 +150,11 @@ async function resolveNoteFile(notePath: string): Promise<TFile | null> {
     );
 
     if (basenameMatches.length === 1) {
-      return basenameMatches[0];
+      return { type: "resolved", file: basenameMatches[0] };
+    }
+
+    if (basenameMatches.length > 1) {
+      return { type: "not_unique", matches: basenameMatches };
     }
   }
 
@@ -143,10 +163,14 @@ async function resolveNoteFile(notePath: string): Promise<TFile | null> {
   );
 
   if (partialMatches.length === 1) {
-    return partialMatches[0];
+    return { type: "resolved", file: partialMatches[0] };
   }
 
-  return null;
+  if (partialMatches.length > 1) {
+    return { type: "not_unique", matches: partialMatches };
+  }
+
+  return { type: "not_found" };
 }
 
 async function readNoteText(file: TFile): Promise<string> {
@@ -330,8 +354,8 @@ const readNoteTool = createTool({
       };
     }
 
-    const file = await resolveNoteFile(sanitizedPath);
-    if (!file) {
+    const resolution = await resolveNoteFile(sanitizedPath);
+    if (resolution.type === "not_found") {
       logWarn(`readNote: note not found or not a file (${sanitizedPath})`);
       return {
         notePath: sanitizedPath,
@@ -340,6 +364,23 @@ const readNoteTool = createTool({
       };
     }
 
+    if (resolution.type === "not_unique") {
+      logWarn(
+        `readNote: ambiguous note path "${sanitizedPath}" matched multiple files`,
+        resolution.matches.map((file) => file.path)
+      );
+      return {
+        notePath: sanitizedPath,
+        status: "not_unique",
+        message: `Multiple notes match "${sanitizedPath}". Provide a more specific path.`,
+        candidates: resolution.matches.map((file) => ({
+          path: file.path,
+          title: file.basename,
+        })),
+      };
+    }
+
+    const file = resolution.file;
     const canonicalPath = file.path;
     const text = await readNoteText(file);
     const chunks = chunkContentByLines(file, text);

--- a/src/tools/ReadNoteTool.test.ts
+++ b/src/tools/ReadNoteTool.test.ts
@@ -237,6 +237,29 @@ describe("readNoteTool", () => {
     expect(mockCachedRead).toHaveBeenCalledWith(targetFile);
   });
 
+  it("returns not_unique when multiple notes share the same title", async () => {
+    const requestedPath = "Project Plan";
+    const projectFile = new MockTFile("Projects/Project Plan.md");
+    const archiveFile = new MockTFile("Archive/Project Plan.md");
+
+    getAbstractFileByPathMock.mockReturnValue(null);
+    getFirstLinkpathDestMock.mockReturnValue(null);
+    getMarkdownFilesMock.mockReturnValue([projectFile, archiveFile]);
+
+    const result = await readNoteTool.call({ notePath: requestedPath });
+
+    expect(result).toEqual({
+      notePath: requestedPath,
+      status: "not_unique",
+      message: 'Multiple notes match "Project Plan". Provide a more specific path.',
+      candidates: [
+        { path: projectFile.path, title: projectFile.basename },
+        { path: archiveFile.path, title: archiveFile.basename },
+      ],
+    });
+    expect(mockCachedRead).not.toHaveBeenCalled();
+  });
+
   it("matches a unique partial path when multiple basenames exist", async () => {
     const requestedPath = "Projects/Project Plan";
     const targetFile = new MockTFile("Projects/Project Plan.md");

--- a/src/tools/ReadNoteTool.test.ts
+++ b/src/tools/ReadNoteTool.test.ts
@@ -115,6 +115,38 @@ describe("readNoteTool", () => {
     expect(mockCachedRead).not.toHaveBeenCalled();
   });
 
+  it("returns not_found for section-only wiki link targets", async () => {
+    const notePath = "[[#Setup]]";
+    getAbstractFileByPathMock.mockReturnValue(null);
+    getFirstLinkpathDestMock.mockReturnValue(null);
+    getMarkdownFilesMock.mockReturnValue([new MockTFile("Docs/Guide.md")]);
+
+    const result = await readNoteTool.call({ notePath });
+
+    expect(result).toEqual({
+      notePath,
+      status: "not_found",
+      message: 'Note "[[#Setup]]" was not found or is not a readable file.',
+    });
+    expect(mockCachedRead).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found for empty wiki link targets", async () => {
+    const notePath = "[[]]";
+    getAbstractFileByPathMock.mockReturnValue(null);
+    getFirstLinkpathDestMock.mockReturnValue(null);
+    getMarkdownFilesMock.mockReturnValue([new MockTFile("Docs/Guide.md")]);
+
+    const result = await readNoteTool.call({ notePath });
+
+    expect(result).toEqual({
+      notePath,
+      status: "not_found",
+      message: 'Note "[[]]" was not found or is not a readable file.',
+    });
+    expect(mockCachedRead).not.toHaveBeenCalled();
+  });
+
   it("returns invalid_path when notePath starts with a leading slash", async () => {
     const result = await readNoteTool.call({ notePath: "/Projects/note.md" });
 

--- a/src/tools/ToolResultFormatter.test.ts
+++ b/src/tools/ToolResultFormatter.test.ts
@@ -1,4 +1,4 @@
-import { ToolResultFormatter } from "./ToolResultFormatter";
+import { deriveReadNoteDisplayName, ToolResultFormatter } from "./ToolResultFormatter";
 
 describe("ToolResultFormatter", () => {
   describe("formatLocalSearch", () => {
@@ -184,6 +184,25 @@ Just content, no path or modified date
       // which doesn't match the XML pattern, so it falls back to parseSearchResults
       // which returns empty array for "null" string, resulting in "no results" message
       expect(formatted).toBe("📚 Found 0 relevant notes\n\nNo matching notes found.");
+    });
+  });
+
+  describe("deriveReadNoteDisplayName", () => {
+    it("returns a generic label when the input is blank", () => {
+      expect(deriveReadNoteDisplayName("")).toBe("note");
+      expect(deriveReadNoteDisplayName("   ")).toBe("note");
+    });
+
+    it("strips wiki-link syntax, aliases, sections, and extensions", () => {
+      expect(deriveReadNoteDisplayName("[[Projects/Plan.md]]")).toBe("Plan");
+      expect(deriveReadNoteDisplayName("[[Projects/Plan.md|Project Plan]]")).toBe("Project Plan");
+      expect(deriveReadNoteDisplayName("[[Docs/Guide#Setup|Quick Start]]")).toBe("Quick Start");
+      expect(deriveReadNoteDisplayName("[[Area/Tasks.canvas]]")).toBe("Tasks");
+    });
+
+    it("returns the last path segment when no wiki syntax is present", () => {
+      expect(deriveReadNoteDisplayName("Area/Deep/Notes/Plan.md")).toBe("Plan");
+      expect(deriveReadNoteDisplayName("Area/Deep/Notes")).toBe("Notes");
     });
   });
 });

--- a/src/tools/ToolResultFormatter.ts
+++ b/src/tools/ToolResultFormatter.ts
@@ -478,6 +478,38 @@ export class ToolResultFormatter {
       return typeof result === "string" ? result : JSON.stringify(result, null, 2);
     }
 
+    const status = typeof data.status === "string" ? data.status : null;
+    const message = typeof data.message === "string" ? data.message : null;
+    const candidates = Array.isArray(data.candidates) ? data.candidates : null;
+
+    if (status === "not_found") {
+      const baseLines = ["⚠️ Note not found"];
+      if (message) {
+        baseLines.push("");
+        baseLines.push(message);
+      }
+      return baseLines.join("\n");
+    }
+
+    if (status === "not_unique") {
+      const baseLines = ["⚠️ Multiple notes match that title"];
+      if (message) {
+        baseLines.push("");
+        baseLines.push(message);
+      }
+      if (candidates && candidates.length > 0) {
+        baseLines.push("");
+        baseLines.push("Candidates:");
+        for (const candidate of candidates) {
+          const path = typeof candidate?.path === "string" ? candidate.path : "";
+          const title =
+            typeof candidate?.title === "string" ? candidate.title : path || "(unknown)";
+          baseLines.push(`- ${title}${path && path !== title ? ` (${path})` : ""}`);
+        }
+      }
+      return baseLines.join("\n");
+    }
+
     const notePath = data.notePath ?? "";
     const title = data.noteTitle ?? notePath ?? "Note excerpt";
     const chunkIndex = typeof data.chunkIndex === "number" ? data.chunkIndex : 0;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves readNote path resolution (wiki links, extensions, partials), returns structured not_found/not_unique results with candidates, updates UI formatting/title derivation, and displays better tool call labels.
> 
> - **Notes/Tools**:
>   - **readNote resolution**: Add robust resolver supporting wiki links, alias/section stripping, extension inference, metadata/basename/partial-path matching; returns `resolved`/`not_unique`/`not_found` outcomes.
>   - **Ambiguity handling**: `not_unique` response includes candidate `{path,title}` list; handler surfaces `invalid_path`, `empty`, `out_of_range` as before.
> - **UI Formatting**:
>   - Add `deriveReadNoteDisplayName` to compute clean titles from paths/wiki links.
>   - `ToolResultFormatter.format("readNote")`: handles `not_found`/`not_unique` messages and candidate lists; uses derived display name.
> - **Agent Runner**:
>   - When calling `readNote`, show derived display name instead of raw path for tool call markers.
> - **Tests**:
>   - Add/expand cases for wiki-link parsing, section-only/empty targets, metadata resolution, basename duplicates (`not_unique`), partial path matches, and title derivation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf4604b2a135098f8094b4835c6ea5197b1bc6cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->