### PR TITLE
Enhance file creation instructions in modelAdapter and update tool usage guidelines in builtinTools

### DIFF
--- a/src/LLMProviders/chainRunner/utils/modelAdapter.ts
+++ b/src/LLMProviders/chainRunner/utils/modelAdapter.ts
@@ -252,7 +252,16 @@ Example for "what did I do last month":
 Example for "meetings about project X last week":
 1. Call getTimeRangeMs with timeExpression: "last week"
 2. Use localSearch with query "meetings about project X"
-3. salientTerms: ["meetings", "project", "X"] - these words exist in the original query`,
+3. salientTerms: ["meetings", "project", "X"] - these words exist in the original query
+
+
+## File-related Queries
+When creating a new file, you must use the getFileTree tool to confirm folder first unless user explicitly ask to create new folders
+
+Example for "create a new note in the projects folder":
+1. Call getFileTree to get the exact folder path
+2. Use writeToFile with the folder path
+`,
     });
 
     if (toolSpecificInstructions.length > 0) {

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -316,7 +316,8 @@ export function registerFileTreeTool(vault: Vault): void {
       requiresVault: true,
       customPromptInstructions: `For getFileTree:
 - Use to browse the vault's file structure
-- Use this tool only if the user asks for the vault structure, or a specific file or folder but you are unsure about the exact path.
+- Use this tool when the user asks for the vault structure, or a specific file or folder but you are unsure about the exact path.
+- Use this tool too look up folders when user asks to create new notes under a folder.
 - DO NOT use this tool to look up note contents or metadata - use localSearch or readNote instead.
 - No parameters needed
 


### PR DESCRIPTION
- Added instructions for confirming folder existence before creating new files in modelAdapter.
- Updated custom prompt instructions in builtinTools to clarify the use of getFileTree for folder lookups when creating new notes.

TESTED: Manually tested on copilot-flash with query "create a new note under folder X" and observed getFileTree was called.