### PR TITLE
Update YouTube Script command and modal title to indicate Plus feature

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -432,7 +432,7 @@ export function registerCommands(
   addCommand(plugin, COMMAND_IDS.DOWNLOAD_YOUTUBE_SCRIPT, async () => {
     const isPlusUser = await checkIsPlusUser();
     if (!isPlusUser) {
-      new Notice("Download YouTube Script is a Copilot Plus feature");
+      new Notice("Download YouTube Script (plus) is a Copilot Plus feature");
       return;
     }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -685,7 +685,7 @@ export const COMMAND_NAMES: Record<CommandId, string> = {
   [COMMAND_IDS.APPLY_CUSTOM_COMMAND]: "Apply custom command",
   [COMMAND_IDS.OPEN_LOG_FILE]: "Create log file",
   [COMMAND_IDS.CLEAR_LOG_FILE]: "Clear log file",
-  [COMMAND_IDS.DOWNLOAD_YOUTUBE_SCRIPT]: "Download YouTube Script",
+  [COMMAND_IDS.DOWNLOAD_YOUTUBE_SCRIPT]: "Download YouTube Script (plus)",
 };
 
 export type CommandId = (typeof COMMAND_IDS)[keyof typeof COMMAND_IDS];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an Insert at Cursor action to the YouTube transcript modal and updates command/modal text to indicate the feature is Copilot Plus-only.
> 
> - **UI/Commands**:
>   - Update `COMMAND_NAMES[DOWNLOAD_YOUTUBE_SCRIPT]` to `"Download YouTube Script (plus)"` in `src/constants.ts`.
>   - Change non-Plus notice text in `src/commands/index.ts` to mention "(plus)".
>   - Set modal title to `"Download YouTube Script (plus)"` in `YoutubeTranscriptModal`.
> - **Modal Enhancements (`src/components/modals/YoutubeTranscriptModal.tsx`)**:
>   - Add "Insert at Cursor" button that inserts the formatted transcript into the active editor via `insertIntoEditor(...)`.
>   - Replace `console.error` with `logError` for failures (download, clipboard).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fb381856d6e1a13967203aee63e427d637c474a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->