### PR TITLE
Enhance ChatPersistenceManager to handle file save conflicts

### DIFF
--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -73,7 +73,7 @@ export class ChatPersistenceManager {
         } catch (error) {
           if (this.isFileAlreadyExistsError(error)) {
             const conflictFile = this.app.vault.getAbstractFileByPath(fileName);
-            if (conflictFile instanceof TFile) {
+            if (conflictFile && conflictFile instanceof TFile) {
               // Update existingTopic to prevent unnecessary regeneration
               existingTopic =
                 this.app.metadataCache.getFileCache(conflictFile)?.frontmatter?.topic ??


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds conflict-aware saving that updates existing notes on create collisions and makes epoch-based lookup handle string values, with accompanying tests.
> 
> - **Core (`src/core/ChatPersistenceManager.ts`)**:
>   - **Save conflict handling**: Wrap `vault.create` in try/catch; on "already exists" update existing `TFile`, show notice, and preserve/update `existingTopic` before `generateTopicAsyncIfNeeded`.
>   - **Epoch lookup**: `findFileByEpoch` now matches `frontmatter.epoch` when stored as number or string (with NaN guard).
>   - **Helper**: Add `isFileAlreadyExistsError` for Obsidian file-exists detection.
> - **Tests (`src/core/ChatPersistenceManager.test.ts`)**:
>   - Cover updating when epoch is a string in frontmatter.
>   - Verify locating existing file by path when epoch is missing and resolving create conflicts by modifying the existing file and showing a notice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df7d4ac054650d02e4172f7331e4b57bbe6f10ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->