### PR TITLE
Sort notes in typeahead menu by creation time

### DIFF
--- a/src/components/chat-components/hooks/useAllNotes.ts
+++ b/src/components/chat-components/hooks/useAllNotes.ts
@@ -25,8 +25,8 @@ export function useAllNotes(isCopilotPlus: boolean = false): TFile[] {
     let files: TFile[];
 
     if (isCopilotPlus) {
-      // Return all files (md + PDFs)
-      files = allNotes;
+      // Return all files (md + PDFs) - create a copy to avoid mutating the atom
+      files = [...allNotes];
     } else {
       // Filter out PDFs for non-Plus users
       files = allNotes.filter((file) => file.extension === "md");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sorts notes returned by useAllNotes by creation time (newest first), with non-Plus still filtering PDFs and avoiding atom mutation.
> 
> - **Hooks**:
>   - `useAllNotes`:
>     - Sorts returned files by `stat.ctime` descending (newest first).
>     - Copies `allNotes` in Copilot Plus mode to avoid mutating atom state.
>     - Keeps PDF filtering for non-Plus users.
>     - Updates JSDoc to document sorting behavior and return type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31cd7ba9b0aa6f8f53eae7f821fff096575be14b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->