### PR TITLE
Turn autosaveChat ON by default

### DIFF
--- a/src/LLMProviders/chainRunner/utils/modelAdapter.ts
+++ b/src/LLMProviders/chainRunner/utils/modelAdapter.ts
@@ -256,11 +256,14 @@ Example for "meetings about project X last week":
 
 
 ## File-related Queries
-When creating a new file, you must use the getFileTree tool to confirm folder first unless user explicitly ask to create new folders
+When creating a new file in given folder, you must use the getFileTree tool to confirm folder first unless user explicitly ask to create new folders
 
 Example for "create a new note in the projects folder":
 1. Call getFileTree to get the exact folder path
 2. Use writeToFile with the folder path
+
+Example for "create a new note about topic X":
+1. Use writeToFile with the path "topicX.md" for creating the note in the root folder
 `,
     });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -737,7 +737,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   stream: true,
   defaultSaveFolder: DEFAULT_CHAT_HISTORY_FOLDER,
   defaultConversationTag: "copilot-conversation",
-  autosaveChat: false,
+  autosaveChat: true,
   generateAIChatTitleOnSave: true,
   includeActiveNoteAsContext: true,
   defaultOpenArea: DEFAULT_OPEN_AREA.VIEW,

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -380,18 +380,12 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   }
 
   // Ensure enableRecentConversations has a default value
-  if (
-    !sanitizedSettings.enableRecentConversations ||
-    typeof sanitizedSettings.enableRecentConversations !== "boolean"
-  ) {
+  if (typeof sanitizedSettings.enableRecentConversations !== "boolean") {
     sanitizedSettings.enableRecentConversations = DEFAULT_SETTINGS.enableRecentConversations;
   }
 
   // Ensure enableSavedMemory has a default value
-  if (
-    !sanitizedSettings.enableSavedMemory ||
-    typeof sanitizedSettings.enableSavedMemory !== "boolean"
-  ) {
+  if (typeof sanitizedSettings.enableSavedMemory !== "boolean") {
     sanitizedSettings.enableSavedMemory = DEFAULT_SETTINGS.enableSavedMemory;
   }
 
@@ -401,6 +395,11 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
     sanitizedSettings.maxRecentConversations = DEFAULT_SETTINGS.maxRecentConversations;
   } else {
     sanitizedSettings.maxRecentConversations = maxRecentConversations;
+  }
+
+  // Ensure autosaveChat has a default value
+  if (typeof sanitizedSettings.autosaveChat !== "boolean") {
+    sanitizedSettings.autosaveChat = DEFAULT_SETTINGS.autosaveChat;
   }
 
   // Ensure folder settings fall back to defaults when empty/whitespace


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable autosaveChat by default, add autosaveChat sanitization and simplify boolean sanitizers, and refine file-creation tool instructions.
> 
> - **Settings**:
>   - **Default behavior**: Set `DEFAULT_SETTINGS.autosaveChat` to `true`.
>   - **Sanitization**: Add fallback for `autosaveChat` when not a boolean; simplify checks for `enableRecentConversations` and `enableSavedMemory`.
> - **Agent Prompt/Tooling**:
>   - Refine file-related guidance: require `getFileTree` only when creating in a given folder; add example for creating a root-level note using `writeToFile` with path like `"topicX.md"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d61d24d2a17c0a5f0f6f95b1ad432a87aea42ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->