### PR TITLE
Fix new note not discoverable in copilot chat

### DIFF
--- a/src/state/vaultDataAtoms.ts
+++ b/src/state/vaultDataAtoms.ts
@@ -126,8 +126,10 @@ export class VaultDataManager {
 
   /**
    * Handles file rename events
+   * Note: oldPath parameter is required by Obsidian's event signature but not used
+   * since we simply refresh all affected data structures
    */
-  private handleFileRename = (file: TAbstractFile, oldPath: string): void => {
+  private handleFileRename = (file: TAbstractFile, _oldPath: string): void => {
     if (file instanceof TFile) {
       if (file.extension === "md" || file.extension === "pdf") {
         this.debouncedRefreshNotes();


### PR DESCRIPTION
# Vault Data Sync Fix: Renamed Files Not Appearing in Typeahead

## Issue Summary

**Problem**: When users created a new note and renamed it, the renamed file would not appear in the Copilot chat input typeahead (`@` mentions and `[[` wikilinks) until a full plugin reload.

**Impact**: Critical UX issue affecting the core file selection workflow.

## Root Cause

### The Bug

The `VaultDataManager` class in `src/state/vaultDataAtoms.ts` used a "stable reference optimization" to prevent unnecessary React re-renders. It compared the old and new file arrays, and only updated the Jotai atom if the arrays were different:

```typescript
// Old code (BUGGY)
private refreshNotes = (): void => {
  const newFiles = [...markdownFiles, ...pdfFiles];
  const currentFiles = settingsStore.get(notesAtom);

  if (!this.arraysEqual(currentFiles, newFiles)) {
    settingsStore.set(notesAtom, newFiles);  // Only update if different
  }
};
```

### Why It Failed on Rename

**Obsidian mutates TFile objects in-place when files are renamed**. This means:

1. User creates "Untitled 1.md" → `TFile` object created with `path = "Untitled 1.md"`
2. User renames to "MyNote.md" → **Same `TFile` object**, but `path` is mutated to `"MyNote.md"`
3. `VaultDataManager` receives the `rename` event and calls `refreshNotes()`
4. Gets fresh file list from vault → Contains the same `TFile` object (now with path = "MyNote.md")
5. Compares old array (which also has the mutated object with new path) vs new array
6. Arrays appear identical by path comparison → **Skips updating the atom**
7. React components don't re-render → Typeahead shows stale data

### Timeline of Events

```
t=0ms:   File created: "Untitled 1.md"
         → TFile object: { path: "Untitled 1.md", ... }
         → Atom updated, typeahead shows "Untitled 1"

t=100ms: User renames to "MyNote.md"
         → Obsidian mutates: TFile { path: "MyNote.md", ... }
         → rename event fires
         → refreshNotes() called
         → Old array: [TFile { path: "MyNote.md" }] (mutated!)
         → New array: [TFile { path: "MyNote.md" }]
         → arraysEqual() returns TRUE
         → ❌ Atom NOT updated
         → ❌ React doesn't re-render
         → ❌ Typeahead still shows "Untitled 1"
```

## The Fix

**Removed the optimization and always update atoms with new array references:**

```typescript
// New code (FIXED)
private refreshNotes = (): void => {
  const newFiles = [...markdownFiles, ...pdfFiles];

  // Always update atom with new array reference
  // Obsidian mutates TFile objects in-place, so we need new
  // array references to trigger re-renders
  settingsStore.set(notesAtom, newFiles);
};
```

### Why This Works

- **New array reference on every refresh** → Jotai detects the change
- **React components re-render** → Typeahead sees updated data
- **Works for all events**: create, rename, delete
- **Minimal performance impact**: Debouncing (250ms) still batches rapid changes

## Performance Considerations

### Debouncing Strategy

The fix maintains performance through debouncing with `leading: true, trailing: true`:

```typescript
private debouncedRefreshNotes = debounce(() => this.refreshNotes(), 250, {
  leading: true,   // First event triggers immediately
  trailing: true   // Subsequent events within 250ms are batched
});
```

This gives us:
- **Instant feedback**: Single file operations feel immediate (< 1ms)
- **Batched updates**: Bulk operations (e.g., git pull) trigger one update after 250ms
- **Best of both worlds**: Responsive UX + efficient bulk handling

### Why Atom Updates Are Cheap

1. **Shallow comparison**: Jotai/React only checks array reference, not contents
2. **Selective re-renders**: Only subscribed components re-render
3. **Memoization**: Downstream hooks use `useMemo` to prevent cascading renders
4. **Real-world impact**: Negligible performance difference vs the buggy "optimization"

## Files Changed

- `src/state/vaultDataAtoms.ts`:
  - Removed `arraysEqual()` method
  - Updated `refreshNotes()` to always update atom
  - Updated `refreshFolders()` to always update atom
  - Updated `refreshTagsFrontmatter()` to always update atom
  - Updated `refreshTagsAll()` to always update atom

## Testing

### Before Fix
1. Create new note → "Untitled 1.md"
2. Rename to "MyNote.md"
3. Type `@` or `[[` in chat input
4. ❌ File not in typeahead
5. Reload plugin
6. ✅ File now appears

### After Fix
1. Create new note → "Untitled 1.md"
2. Rename to "MyNote.md"
3. Type `@` or `[[` in chat input
4. ✅ File appears immediately

## Lessons Learned

### Premature Optimization

The "stable reference optimization" was added to prevent unnecessary re-renders, but:
- **Broke core functionality** due to Obsidian's mutation behavior
- **Saved negligible CPU** (array reference changes are cheap)
- **Added complexity** with the `arraysEqual` helper

### Obsidian API Behavior

Key insight: **Obsidian mutates file/folder objects in-place** rather than creating new objects. This affects:
- Rename events
- Move events (changes `path` property)
- Any code relying on object identity or reference equality

### When to Optimize

React/Jotai are already highly optimized. Additional optimizations should:
1. **Solve a measured problem** (profile first)
2. **Not break core functionality**
3. **Have significant impact** (10%+ improvement)

In this case, the "optimization" failed all three criteria.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Always refresh vault atoms with new array refs and enable leading debounced updates; adjust rename handler signature to include old path.
> 
> - **State management (vault atoms)**:
>   - Always set `notesAtom`, `foldersAtom`, `tagsFrontmatterAtom`, `tagsAllAtom` with new array references in `refresh*` methods (remove equality checks and `arraysEqual` helper).
> - **Debounce behavior**:
>   - Set `leading: true, trailing: true` for `debouncedRefreshNotes`, `debouncedRefreshFolders`, `debouncedRefreshTagsFrontmatter`, `debouncedRefreshTagsAll`.
> - **Event handling**:
>   - Update `handleFileRename(file, _oldPath)` signature to include unused `oldPath` per Obsidian API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbcb0e9101ae8ca9f1ca9a46d47929cf48cd9e10. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->