### PR TITLE
fix: Enhance error handling

### DIFF
--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -599,15 +599,19 @@ ${params}
         }
 
         if (toolCall.name === "localSearch") {
-          const processed = loopDeps.processLocalSearchResult(result);
-          collectedSources.push(...processed.sources);
-          result.result = loopDeps.applyCiCOrderingToLocalSearchResult(
-            processed.formattedForLLM,
-            originalUserPrompt || ""
-          );
-          result.displayResult = processed.formattedForDisplay;
+          if (result.success) {
+            const processed = loopDeps.processLocalSearchResult(result);
+            collectedSources.push(...processed.sources);
+            result.result = loopDeps.applyCiCOrderingToLocalSearchResult(
+              processed.formattedForLLM,
+              originalUserPrompt || ""
+            );
+            result.displayResult = processed.formattedForDisplay;
+          }
         } else if (toolCall.name === "readNote") {
-          result.displayResult = ToolResultFormatter.format("readNote", result.result);
+          if (result.success) {
+            result.displayResult = ToolResultFormatter.format("readNote", result.result);
+          }
         }
 
         toolResults.push(result);


### PR DESCRIPTION
Enhance error handling in AutonomousAgentChainRunner for local search and readNote tool calls

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only process and display `localSearch` and `readNote` results when successful; otherwise preserve LLM result and show formatted error output.
> 
> - **Agent loop (`src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts`)**:
>   - **Error handling**: On failed tool calls, set `displayResult` to a formatted error chunk for UI.
>   - **Guarded processing**:
>     - `localSearch`: Process sources/LLM/display outputs only when `result.success` is true.
>     - `readNote`: Apply `ToolResultFormatter` only on success.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91720e4fd531311013f5ef4a40c777172b06e38e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->