### PR TITLE
Stop condensing history in plus nonagent route

### DIFF
--- a/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
+++ b/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
@@ -1,4 +1,3 @@
-import { getStandaloneQuestion } from "@/chainUtils";
 import { AVAILABLE_TOOLS } from "@/components/chat-components/constants/tools";
 import {
   ABORT_REASON,
@@ -25,11 +24,7 @@ import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { IntentAnalyzer } from "../intentAnalyzer";
 import { BaseChainRunner } from "./BaseChainRunner";
 import { ActionBlockStreamer } from "./utils/ActionBlockStreamer";
-import {
-  addChatHistoryToMessages,
-  processedMessagesToTextOnly,
-  processRawChatHistory,
-} from "./utils/chatHistoryUtils";
+import { addChatHistoryToMessages } from "./utils/chatHistoryUtils";
 import {
   addFallbackSources,
   formatSourceCatalog,
@@ -431,21 +426,7 @@ export class CopilotPlusChainRunner extends BaseChainRunner {
       const hasLocalSearchWithResults = localSearchResult && sources.length > 0;
 
       // Format chat history from memory
-      const memory = this.chainManager.memoryManager.getMemory();
-      const memoryVariables = await memory.loadMemoryVariables({});
-      const rawHistory = memoryVariables.history || [];
-
-      // Process history consistently - same data used for both LLM and question condensing
-      const processedHistory = processRawChatHistory(rawHistory);
-      const chatHistory = processedMessagesToTextOnly(processedHistory);
-
-      // Get standalone question if we have chat history
-      let questionForEnhancement = cleanedUserMessage;
-      if (chatHistory.length > 0) {
-        logInfo("Condensing question");
-        questionForEnhancement = await getStandaloneQuestion(cleanedUserMessage, chatHistory);
-        logInfo("Condensed standalone question: ", questionForEnhancement);
-      }
+      const questionForEnhancement = cleanedUserMessage;
 
       // Enhance with ALL tool outputs including localSearch
       let enhancedUserMessage = this.prepareEnhancedUserMessage(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stops condensing user questions from chat history in CopilotPlus, using the cleaned user message directly while keeping tool-based enhancements intact.
> 
> - **CopilotPlusChainRunner**:
>   - Remove history processing and standalone question condensation (`getStandaloneQuestion`, `processRawChatHistory`, `processedMessagesToTextOnly`).
>   - Use `cleanedUserMessage` directly as `questionForEnhancement` before applying tool output context.
>   - Simplify imports to only `addChatHistoryToMessages` from `chatHistoryUtils`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4d41fa741ff1bdd29b73e696e8cfc335653034e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->