### PR TITLE
fix: Focus to chat input on opening chat window command

### DIFF
--- a/src/components/chat-components/LexicalEditor.tsx
+++ b/src/components/chat-components/LexicalEditor.tsx
@@ -87,6 +87,11 @@ const LexicalEditor: React.FC<LexicalEditorProps> = ({
   const chatInputContext = useChatInput();
   const settings = useSettingsValue();
 
+  // Wrapper to properly set function state (avoids React's updater function interpretation)
+  const handleFocusRegistration = React.useCallback((fn: () => void) => {
+    setFocusFn(() => fn);
+  }, []);
+
   // Register editor and focus handler with context
   useEffect(() => {
     if (editorInstance) {
@@ -163,7 +168,7 @@ const LexicalEditor: React.FC<LexicalEditorProps> = ({
           <HistoryPlugin />
           <KeyboardPlugin onSubmit={onSubmit} sendShortcut={settings.defaultSendShortcut} />
           <ValueSyncPlugin value={value} />
-          <FocusPlugin onFocus={setFocusFn} onEditorReady={handleEditorReady} />
+          <FocusPlugin onFocus={handleFocusRegistration} onEditorReady={handleEditorReady} />
           <NotePillSyncPlugin onNotesChange={onNotesChange} onNotesRemoved={onNotesRemoved} />
           {onURLsChange && (
             <URLPillSyncPlugin onURLsChange={onURLsChange} onURLsRemoved={onURLsRemoved} />


### PR DESCRIPTION
- Introduced a wrapper function `handleFocusRegistration` to properly set the focus function state, avoiding issues with React's updater function interpretation.
- Updated the `FocusPlugin` to utilize the new focus registration method for better clarity and functionality.

# Why This Fix Is Needed

In React, when you pass a function directly to a state setter like setState(myFunction), React interprets it as an updater function (similar to `setState(prev => prev + 1))` rather than as the value to store. The original code had `<FocusPlugin onFocus={setFocusFn} />`, which meant when FocusPlugin called `onFocus(focusEditor)`, it was effectively calling `setFocusFn(focusEditor)`. React then tried to invoke focusEditor as an updater function instead of storing it as the state value, causing the focus handler to never be registered. The fix wraps the function in an arrow function `(setFocusFn(() => fn))`, which tells React "store this function as a value, don't execute it as an updater." This is a well-known React pattern for storing function values in state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safely registers the chat input focus handler via a new wrapper and wires it into `FocusPlugin`.
> 
> - **LexicalEditor (`src/components/chat-components/LexicalEditor.tsx`)**:
>   - Add `handleFocusRegistration` callback to safely store focus handler (`setFocusFn(() => fn)`).
>   - Update `FocusPlugin` to use `onFocus={handleFocusRegistration}` and keep `onEditorReady` wiring.
>   - Maintains context registration flows for editor and focus handler via `useEffect`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96347bb97a0548fc942af0d6cfddb983db1ecb56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->