### PR TITLE
fix: focus on click copilot chat icon in left ribbon

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -297,7 +297,10 @@ export default class CopilotPlugin extends Plugin {
     } else {
       this.app.workspace.revealLeaf(leaves[0]);
     }
-    this.emitChatIsVisible();
+    // Small delay to ensure React component is ready to receive the focus event
+    setTimeout(() => {
+      this.emitChatIsVisible();
+    }, 50);
   }
 
   async deactivateView() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Emits `CHAT_IS_VISIBLE` after a 50ms timeout when activating/revealing the Copilot Chat view to ensure the component is ready to receive focus.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26d0990a6765cffb5488d465c371b708dfc00d90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->