### PR TITLE
Enhance ChatPersistenceManager to escape modelKey in frontmatter

### DIFF
--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -17,6 +17,14 @@ import { MessageRepository } from "./MessageRepository";
 const SAFE_FILENAME_BYTE_LIMIT = 100;
 
 /**
+ * Escape a string for safe YAML double-quoted string value
+ * Escapes backslashes and double quotes to prevent YAML parsing errors
+ */
+function escapeYamlString(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
  * ChatPersistenceManager - Handles saving and loading chat messages
  *
  * This class is responsible for:
@@ -582,7 +590,7 @@ ${conversationSummary}`;
 
     return `---
 epoch: ${firstMessageEpoch}
-modelKey: ${modelKey}
+modelKey: "${escapeYamlString(modelKey)}"
 ${topic ? `topic: "${topic}"` : ""}
 ${currentProject ? `projectId: ${currentProject.id}` : ""}
 ${currentProject ? `projectName: ${currentProject.name}` : ""}


### PR DESCRIPTION
Fixes #1990 

- Introduced a new utility function `escapeYamlString` to handle escaping of special characters in modelKey values, ensuring valid YAML formatting.
- Updated the `modelKey` assignment in the generated note content to use the new escaping function.
- Added comprehensive tests to verify correct escaping for various special characters, including quotes, backslashes, and pipes, ensuring data integrity during save-load operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Quotes and escapes `modelKey` in frontmatter and adds tests to validate handling of special characters and round-trip preservation.
> 
> - **Core**:
>   - Escape and quote `modelKey` in frontmatter using `escapeYamlString` within `generateNoteContent`.
>   - New helper `escapeYamlString` to escape backslashes and double quotes.
> - **Tests**:
>   - Add comprehensive cases for `modelKey` with Unicode, slashes, pipes, quotes, and backslashes.
>   - Verify correct YAML output and round-trip preservation through save-load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66ec78461add4d1172a6a9bcf43dcf8cc25c121e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->