### PR TITLE
feat: Add function to escape tasks code blocks in AI response

### DIFF
--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -201,6 +201,17 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
         return text;
       };
 
+      /**
+       * Escapes tasks code blocks to prevent execution in AI responses.
+       * Converts ```tasks to ```text so they display as static code examples
+       * instead of executing task queries.
+       */
+      const escapeTasksCodeBlocks = (text: string): string => {
+        // Replace ```tasks (with optional whitespace before newline/end)
+        text = text.replace(/```tasks(\s*(?:\n|$))/g, "```text$1");
+        return text;
+      };
+
       const processCollapsibleSection = (
         content: string,
         tagName: string,
@@ -313,8 +324,11 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
       // Escape dataview code blocks first to prevent execution
       const dataviewEscaped = escapeDataviewCodeBlocks(content);
 
+      // Escape tasks code blocks to prevent execution
+      const tasksEscaped = escapeTasksCodeBlocks(dataviewEscaped);
+
       // Process LaTeX
-      const latexProcessed = dataviewEscaped
+      const latexProcessed = tasksEscaped
         .replace(/\\\[\s*/g, "$$")
         .replace(/\s*\\\]/g, "$$")
         .replace(/\\\(\s*/g, "$")


### PR DESCRIPTION
Fixes #1902 

- Introduced `escapeTasksCodeBlocks` to convert ```tasks to ```text, preventing execution in AI responses and ensuring static display of task queries.
- Updated processing logic to utilize the new function, enhancing content safety and display consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `escapeTasksCodeBlocks` and integrates it into message preprocessing to convert ```tasks to ```text, preventing task query execution.
> 
> - **Chat message preprocessing (`src/components/chat-components/ChatSingleMessage.tsx`)**:
>   - Add `escapeTasksCodeBlocks` to convert ```tasks to ```text.
>   - Integrate new escape step before LaTeX processing (now processes `tasksEscaped` instead of `dataviewEscaped`).
>   - Keeps existing Dataview escapes; ensures Tasks code blocks render as static examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c7c0881d010f981f65da04e16a5b1f25a21f9cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->