### PR TITLE
Fix template note processing

### DIFF
--- a/src/commands/customCommandUtils.ts
+++ b/src/commands/customCommandUtils.ts
@@ -19,7 +19,7 @@ import {
 } from "./state";
 import { PromptSortStrategy } from "@/types";
 import {
-  extractNoteFiles,
+  extractTemplateNoteFiles,
   getFileContent,
   getFileName,
   getNotesFromPath,
@@ -240,8 +240,10 @@ export async function processCommandPrompt(
  * {copilot-selection} is the legacy custom command special placeholder. It must
  * be skipped when processing custom prompts because it's handled differently
  * by the custom command prompt processor.
+ *
+ * Also excludes {[[...]]} patterns which are handled separately by extractTemplateNoteFiles.
  */
-const VARIABLE_REGEX = /\{(?!copilot-selection\})([^}]+)\}/g;
+const VARIABLE_REGEX = /\{(?!copilot-selection\}|\[\[)([^}]+)\}/g;
 
 /**
  * Represents the result of processing a custom prompt variable.
@@ -399,8 +401,8 @@ export async function processPrompt(
     }
   }
 
-  // Process [[note title]] syntax
-  const noteLinkFiles = extractNoteFiles(processedPrompt, vault);
+  // Process {[[note title]]} syntax - only wikilinks wrapped in curly braces
+  const noteLinkFiles = extractTemplateNoteFiles(processedPrompt, vault);
   for (const noteFile of noteLinkFiles) {
     // Check if this note wasn't already included via a variable
     // We use the Set's reference equality which works for TFile objects

--- a/src/commands/customCommandUtils.xmlescape.test.ts
+++ b/src/commands/customCommandUtils.xmlescape.test.ts
@@ -4,7 +4,7 @@ import { getFileContent, getFileName, getNotesFromPath } from "@/utils";
 
 // Mock the dependencies
 jest.mock("@/utils", () => ({
-  extractNoteFiles: jest.fn().mockReturnValue([]),
+  extractTemplateNoteFiles: jest.fn().mockReturnValue([]),
   getFileContent: jest.fn(),
   getFileName: jest.fn(),
   getNotesFromPath: jest.fn(),
@@ -108,7 +108,7 @@ describe("XML Escaping in processPrompt", () => {
     } as TFile;
 
     (getNotesFromPath as jest.Mock).mockResolvedValue([]);
-    jest.requireMock("@/utils").extractNoteFiles.mockReturnValue([mockNote]);
+    jest.requireMock("@/utils").extractTemplateNoteFiles.mockReturnValue([mockNote]);
     (getFileContent as jest.Mock).mockResolvedValue("Content with & and < and >");
 
     const result = await processPrompt(customPrompt, "", mockVault, mockActiveNote);


### PR DESCRIPTION
Only process the `[[note name]]` in the chat input if it's wrapped with `{}` when the note is not included in the context.

Context: https://discord.com/channels/1182847556032659546/1325363836596912189/1434718139886866554

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts note inclusion to {[[wikilink]]} syntax, adds dedicated extractor, updates variable parsing, and refactors utils with shared resolver and tests.
> 
> - **Custom Command Processing (`src/commands/customCommandUtils.ts`)**
>   - Use `extractTemplateNoteFiles` instead of `extractNoteFiles` to include notes only for `{[[...]]}` patterns.
>   - Update `VARIABLE_REGEX` to ignore `{copilot-selection}` and `{[[...]]}` variables.
>   - Maintain de-duplication with variable-included files when adding `<note_context>`.
> - **Utils (`src/utils.ts`)**
>   - Add `resolveNoteFilesFromTitles` shared resolver for wikilinks.
>   - Refactor `extractNoteFiles` to use resolver; add new `extractTemplateNoteFiles` for `{[[...]]}`.
> - **Tests**
>   - Update command and XML escape tests to mock/use `extractTemplateNoteFiles` and verify only `{[[...]]}` are processed.
>   - Add comprehensive tests for `extractTemplateNoteFiles`; ensure bare `[[...]]` are ignored.
>   - Adjust expectations to new `<note_context>` behavior and non-escaping of metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 176350b120f762cb521b09945b4289e84c8811c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->