### PR TITLE
Enhance writeToFile tool with confirmation option

### DIFF
--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -255,7 +255,16 @@ Example usage:
 <name>writeToFile</name>
 <path>path/to/note.md</path>
 <content>FULL CONTENT OF THE NOTE</content>
-</use_tool>`,
+</use_tool>
+
+Example usage with user explicitly asks to skip preview or confirmation:
+<use_tool>
+<name>writeToFile</name>
+<path>path/to/note.md</path>
+<content>FULL CONTENT OF THE NOTE</content>
+<confirmation>false</confirmation>
+</use_tool>
+`,
     },
   },
   {


### PR DESCRIPTION
- Added an optional `confirmation` parameter to the `writeToFile` tool, allowing users to skip the preview UI and apply changes directly to the file.
- Updated the tool's schema to include the new parameter, with a default value of true for confirmation.
- Enhanced the handler logic to manage file writing based on the user's confirmation choice, improving flexibility in file operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional `confirmation` flag to `writeToFile` enabling no-preview writes and updates tool instructions with a new example.
> 
> - **Tools**:
>   - **`writeToFile` (`src/tools/ComposerTools.ts`)**:
>     - Schema: add optional `confirmation` (boolean/string-coercible, default `true`) to control preview.
>     - Handler: support immediate write when `confirmation === false`; otherwise show preview; return JSON-wrapped result.
>   - Minor: add JSDoc for `show_preview`.
> - **Docs/Instructions**:
>   - Update `src/tools/builtinTools.ts` `writeToFile` instructions with an example showing `<confirmation>false</confirmation>` usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 201c1d6c37bf0cd7334c1c656ab01bfacdb34713. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->