### PR TITLE
feat: Add AWS Bedrock cross-region inference profile guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,25 @@ The TODO.md should be:
 - For technical debt and known issues, see [`TECHDEBT.md`](./docs/TECHDEBT.md)
 - For current development session planning, see [`TODO.md`](./TODO.md)
 
+### AWS Bedrock Usage
+
+**IMPORTANT**: When using AWS Bedrock, always use **cross-region inference profile IDs** for better reliability and availability:
+
+- **Global** (recommended): `global.anthropic.claude-sonnet-4-5-20250929-v1:0`
+  - Routes to any commercial AWS region automatically
+  - Best for reliability and performance
+- **US**: `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
+- **EU**: `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`
+- **APAC**: `apac.anthropic.claude-sonnet-4-5-20250929-v1:0`
+
+❌ **Avoid regional model IDs** (without prefix): `anthropic.claude-sonnet-4-5-20250929-v1:0`
+- These only work in specific regions and often fail
+- Not recommended for production use
+
+**References:**
+- [AWS Bedrock Cross-Region Inference](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html)
+- [Supported Inference Profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html)
+
 ### Obsidian Plugin Environment
 
 - **Global `app` variable**: In Obsidian plugins, `app` is a globally available variable that provides access to the Obsidian API. It's automatically available in all files without needing to import or declare it.

--- a/src/settings/v2/components/ModelAddDialog.tsx
+++ b/src/settings/v2/components/ModelAddDialog.tsx
@@ -366,7 +366,7 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
           return (
             <FormField
               label="Region (optional)"
-              description="Defaults to us-east-1 when left blank unless a custom base URL is provided."
+              description="Defaults to us-east-1 when left blank. With inference profiles (global., us., eu., apac.), region is auto-managed."
             >
               <Input
                 type="text"
@@ -448,11 +448,20 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
             required
             error={errors.name}
             errorMessage="Model name is required"
+            description={
+              model.provider === ChatModelProviders.AMAZON_BEDROCK && !isEmbeddingModel
+                ? "For Bedrock, use cross-region inference profile IDs (global., us., eu., or apac. prefix) for better reliability. Regional IDs without prefixes may fail."
+                : undefined
+            }
           >
             <Input
               type="text"
               placeholder={`Enter model name (e.g. ${
-                isEmbeddingModel ? "text-embedding-3-small" : "gpt-4"
+                model.provider === ChatModelProviders.AMAZON_BEDROCK && !isEmbeddingModel
+                  ? "global.anthropic.claude-sonnet-4-5-20250929-v1:0"
+                  : isEmbeddingModel
+                    ? "text-embedding-3-small"
+                    : "gpt-4"
               })`}
               value={model.name}
               onChange={(e) => {

--- a/src/settings/v2/components/ModelEditDialog.tsx
+++ b/src/settings/v2/components/ModelEditDialog.tsx
@@ -182,7 +182,7 @@ export const ModelEditModalContent: React.FC<ModelEditModalContentProps> = ({
         {isBedrockProvider && (
           <FormField
             label="Region (optional)"
-            description="Defaults to us-east-1 when left blank unless this model defines a custom base URL."
+            description="Defaults to us-east-1 when left blank. With inference profiles (global., us., eu., apac.), region is auto-managed."
           >
             <Input
               type="text"


### PR DESCRIPTION
## Summary

This PR improves AWS Bedrock support by adding user guidance for cross-region inference profiles, addressing issue #2006.

Currently, users entering AWS Bedrock models often use regional model IDs (e.g., `anthropic.claude-sonnet-4-5-20250929-v1:0`) which only work in specific regions and frequently fail. According to [AWS documentation](https://aws.amazon.com/blogs/aws/introducing-claude-sonnet-4-5-in-amazon-bedrock-anthropics-most-intelligent-model-best-for-coding-and-complex-agents/), Claude Sonnet 4.5 can only be accessed through inference profiles, not direct regional model IDs.

## Changes

### UI Improvements
- **ModelAddDialog**: 
  - Added helper text explaining cross-region inference profiles for Bedrock models
  - Updated placeholder to show example with `global.` prefix: `global.anthropic.claude-sonnet-4-5-20250929-v1:0`
  - Shows guidance only when Amazon Bedrock provider is selected

- **ModelEditDialog**:
  - Updated region field description to explain inference profile behavior

### Documentation
- **CLAUDE.md**: Added comprehensive AWS Bedrock usage section with:
  - Examples of all inference profile formats (global, us, eu, apac)
  - Warning about regional model IDs
  - Links to AWS documentation

### Other
- Updated `.gitignore` for development environment files

## Visual Changes

When adding a Bedrock model, users now see:
- Clear placeholder: `global.anthropic.claude-sonnet-4-5-20250929-v1:0`
- Helper text: "For Bedrock, use cross-region inference profile IDs (global., us., eu., or apac. prefix) for better reliability. Regional IDs without prefixes may fail."

## Testing

- Code changes are UI-only (no logic changes)
- TypeScript syntax validated
- Changes follow existing pattern from other providers (Azure OpenAI)

## References

- Fixes #2006
- [AWS Bedrock Cross-Region Inference Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html)
- [Supported Inference Profiles](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html)
- Similar issue in Claude Code: [anthropics/claude-code#1434](https://github.com/anthropics/claude-code/issues/1434)

## Checklist

- [x] Changes follow the existing code style
- [x] Documentation updated (CLAUDE.md)
- [x] No breaking changes
- [x] UI improvements are intuitive and helpful
- [x] Issue referenced (#2006)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)