### PR TITLE
Add anthropic version required field for bedrock

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -455,7 +455,9 @@ export default class ChatModelManager {
     const endpoint = `${endpointBase}/model/${encodedModel}/invoke`;
     const streamEndpoint = `${endpointBase}/model/${encodedModel}/invoke-with-response-stream`;
     const fetchImplementation = customModel.enableCors ? safeFetch : undefined;
-    const anthropicVersion = modelName.startsWith("anthropic.") ? "bedrock-2023-05-31" : undefined;
+    // Inference profiles prefix Anthropic identifiers (e.g. global.anthropic.*), so look for the segment anywhere.
+    const requiresAnthropicVersion = /(^|\.)anthropic\./.test(modelName);
+    const anthropicVersion = requiresAnthropicVersion ? "bedrock-2023-05-31" : undefined;
 
     return {
       modelName,

--- a/src/settings/v2/components/ModelAddDialog.tsx
+++ b/src/settings/v2/components/ModelAddDialog.tsx
@@ -147,7 +147,7 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
       enabled: true,
       isBuiltIn: false,
       baseUrl: "",
-      apiKey: provider === ChatModelProviders.AMAZON_BEDROCK ? "" : getDefaultApiKey(provider),
+      apiKey: getDefaultApiKey(provider),
       isEmbeddingModel,
       capabilities: [],
     };
@@ -222,7 +222,7 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
     setModel({
       ...model,
       provider,
-      apiKey: provider === ChatModelProviders.AMAZON_BEDROCK ? "" : getDefaultApiKey(provider),
+      apiKey: getDefaultApiKey(provider),
       ...(provider === ChatModelProviders.OPENAI ? { openAIOrgId: settings.openAIOrgId } : {}),
       ...(provider === ChatModelProviders.AZURE_OPENAI
         ? {


### PR DESCRIPTION
Related #2006 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detect Anthropic models on Bedrock even with prefixed IDs (e.g., global.anthropic.*) and prefill the Bedrock API key from settings in the add-model dialog.
> 
> - **Bedrock runtime config (`src/LLMProviders/chatModelManager.ts`)**:
>   - Detect Anthropic models using a regex to handle prefixed IDs (e.g., `global.anthropic.*`), setting `anthropicVersion` accordingly.
> - **Settings UI (`src/settings/v2/components/ModelAddDialog.tsx`)**:
>   - Always initialize/reset `apiKey` with provider default, including for `AMAZON_BEDROCK` (was previously blank).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdfc3ad5924dfb5fdd354617505b03fcef6564f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->