### PR TITLE
Improve onboarding by removing the popups

### DIFF
--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -4,7 +4,6 @@ import { logInfo } from "@/logger";
 import { turnOffPlus, turnOnPlus } from "@/plusUtils";
 import { getSettings } from "@/settings/model";
 import { arrayBufferToBase64 } from "@/utils/base64";
-import { Notice } from "obsidian";
 
 export interface BrocaResponse {
   response: {
@@ -108,10 +107,10 @@ export class BrevilabsClient {
 
   private checkLicenseKey() {
     if (!getSettings().plusLicenseKey) {
-      new Notice(
-        "Copilot Plus license key not found. Please enter your license key in the settings."
+      // Don't show popup notice - let error propagate to be handled by the caller
+      throw new Error(
+        "Copilot Plus license key not found. Please enter your license key in the Copilot Plus section at the top of Basic Settings."
       );
-      throw new Error("License key not initialized");
     }
   }
 

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -690,7 +690,8 @@ export default class ChatModelManager {
       }
     } catch (error) {
       logError(error);
-      new Notice(`Error creating model: ${modelKey}`);
+      // Don't show popup notice - let error propagate to be handled by chat interface
+      throw new Error(`Error creating model: ${modelKey} - ${err2String(error)}`);
     }
   }
 
@@ -702,8 +703,14 @@ export default class ChatModelManager {
       throw new Error(`No model found for: ${modelKey}`);
     }
     if (!selectedModel.hasApiKey) {
+      // Provide specific error message for Plus models
+      if (model.provider === ChatModelProviders.COPILOT_PLUS) {
+        throw new Error(
+          `Copilot Plus license key is not configured. Please enter your license key in the Copilot Plus section at the top of Basic Settings to use ${model.name}.`
+        );
+      }
       const errorMessage = `API key is not provided for the model: ${modelKey}.`;
-      new Notice(errorMessage);
+      // Don't show popup notice - let error propagate to be handled by chat interface
       throw new Error(errorMessage);
     }
 

--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -281,7 +281,7 @@ export function ChatControls({
                   onCloseProject?.();
                 }}
               >
-                copilot plus
+                projects
                 <SquareArrowOutUpRight className="tw-size-3" />
               </DropdownMenuItem>
             )}

--- a/src/components/modals/project/AddProjectModal.tsx
+++ b/src/components/modals/project/AddProjectModal.tsx
@@ -222,7 +222,7 @@ function AddProjectModalContent({ initialProject, onSave, onCancel }: AddProject
               const { hasApiKey, errorNotice } = checkModelApiKey(selectedModel, settings);
               if (!hasApiKey && errorNotice) {
                 new Notice(errorNotice);
-                return;
+                // Allow the selection to proceed despite missing API key
               }
               handleInputChange("projectModelKey", value);
             }}

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -70,9 +70,8 @@ export function ModelSelector({
                 key={getModelKeyFromModel(model)}
                 onSelect={async (event) => {
                   if (!hasApiKey && errorNotice) {
-                    event.preventDefault();
                     new Notice(errorNotice);
-                    return;
+                    // Allow the selection to proceed despite missing API key
                   }
 
                   try {
@@ -91,7 +90,6 @@ export function ModelSelector({
                     }
                   }
                 }}
-                className={!hasApiKey ? "tw-cursor-not-allowed tw-opacity-50" : ""}
               >
                 <ModelDisplay model={model} iconSize={12} />
               </DropdownMenuItem>

--- a/src/hooks/useChatManager.ts
+++ b/src/hooks/useChatManager.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 import { ChainType } from "@/chainFactory";
 import { ChatMessage, MessageContext } from "@/types/message";
 import { ChatUIState } from "@/state/ChatUIState";
@@ -7,26 +7,29 @@ import { ChatUIState } from "@/state/ChatUIState";
  * React hook for using ChatManager through ChatUIState
  *
  * This provides a clean React integration that:
- * - Manages local state synchronization
+ * - Manages local state synchronization with forced re-renders
  * - Provides memoized callback functions
  * - Handles subscriptions and cleanup
  * - Maintains compatibility with existing Chat component API
  */
 export function useChatManager(chatUIState: ChatUIState) {
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  // Use reducer to force re-renders on external state changes
+  const [, forceUpdate] = useReducer((x: number) => x + 1, 0);
 
-  // Subscribe to state changes
+  // Subscribe to state changes and force re-render
   useEffect(() => {
-    // Initial sync
-    setMessages([...chatUIState.getMessages()]);
-
     // Subscribe to updates
     const unsubscribe = chatUIState.subscribe(() => {
-      setMessages([...chatUIState.getMessages()]);
+      // Force a re-render which will call getMessages() below
+      forceUpdate();
     });
 
     return unsubscribe;
   }, [chatUIState]);
+
+  // Always get fresh messages on each render
+  // This ensures we always have the latest data
+  const messages = chatUIState.getMessages();
 
   // ================================
   // MESSAGE OPERATIONS

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -163,7 +163,7 @@ export const BasicSettings: React.FC = () => {
               const { hasApiKey, errorNotice } = checkModelApiKey(selectedModel, settings);
               if (!hasApiKey && errorNotice) {
                 new Notice(errorNotice);
-                return;
+                // Allow the selection to proceed despite missing API key
               }
               updateSetting("defaultModelKey", value);
             }}


### PR DESCRIPTION
#2013 

# Issues
- first-time user enabling the plugin throws intrusive Notice popups (“API key missing”, “Error creating model”) instead of using the chat’s inline error blocks.
- model errors were added to the repo but React never re-rendered until the next user message because async updates fired while a render was still in-flight. State mirroring, useSyncExternalStore, flushSync, etc. were all tried and failed thanks to Obsidian’s bundled React. 
<img width="629" height="404" alt="SCR-20251108-ujcp" src="https://github.com/user-attachments/assets/bc014a65-58b7-4c80-a883-f55ede9feb47" />

# Solution
- ChainManager now queues model-init failures in pendingModelError and clears it only after a successful setChatModel. validateChatModel rethrows the stored error during the user’s next runChain, so onboarding/model-switch issues surface as chat error blocks while settings/project switches remain non-blocking.
- ChatUIState uses microtask scheduling (queueMicrotask with a Promise fallback) to fire listener notifications after the current render completes, removing the React race that delayed async error replies.
- useChatManager forces a tiny re-render on subscription callbacks and grabs fresh messages each render, ensuring the UI picks up those scheduled updates immediately without extra popups.

# Screenshot
Allow selecting models with no API key, have error in the response instead of a notice.
<img width="622" height="194" alt="SCR-20251108-ucuf" src="https://github.com/user-attachments/assets/603e7d42-a699-4686-8375-c187b7a7e34e" />
