### PR TITLE
Fix auto scrolling

### DIFF
--- a/src/hooks/useChatScrolling.ts
+++ b/src/hooks/useChatScrolling.ts
@@ -140,6 +140,11 @@ export const useChatScrolling = ({
 
   // Scroll to bottom only when user messages are added
   useEffect(() => {
+    // Reset ref if chat history shrinks (new chat, deleted messages)
+    if (chatHistory.length < prevChatLengthRef.current) {
+      prevChatLengthRef.current = chatHistory.length;
+    }
+
     if (chatHistory.length > 0) {
       // Check if a new message was added
       const hasNewMessage = chatHistory.length > prevChatLengthRef.current;


### PR DESCRIPTION
Before this change: auto scrolls to the bottom when AI is streaming, and when it finishes it goes back to the user message.

After: user message moves to the top and there's no further auto scrolling as the AI is streaming.

This prevents crazy oscillations with long AI streaming responses, especially when images are in the stream.