### PR TITLE
Improve new user onboarding by removing notice on missing api key

### DIFF
--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -1,10 +1,10 @@
 import { BREVILABS_API_BASE_URL } from "@/constants";
 import { getDecryptedKey } from "@/encryptionService";
+import { MissingPlusLicenseError } from "@/error";
 import { logInfo } from "@/logger";
 import { turnOffPlus, turnOnPlus } from "@/plusUtils";
 import { getSettings } from "@/settings/model";
 import { arrayBufferToBase64 } from "@/utils/base64";
-import { Notice } from "obsidian";
 
 export interface BrocaResponse {
   response: {
@@ -108,10 +108,9 @@ export class BrevilabsClient {
 
   private checkLicenseKey() {
     if (!getSettings().plusLicenseKey) {
-      new Notice(
+      throw new MissingPlusLicenseError(
         "Copilot Plus license key not found. Please enter your license key in the settings."
       );
-      throw new Error("License key not initialized");
     }
   }
 

--- a/src/components/modals/project/AddProjectModal.tsx
+++ b/src/components/modals/project/AddProjectModal.tsx
@@ -221,8 +221,7 @@ function AddProjectModalContent({ initialProject, onSave, onCancel }: AddProject
 
               const { hasApiKey, errorNotice } = checkModelApiKey(selectedModel, settings);
               if (!hasApiKey && errorNotice) {
-                new Notice(errorNotice);
-                return;
+                // Keep selection allowed; error will surface in chat on send
               }
               handleInputChange("projectModelKey", value);
             }}

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Notice } from "obsidian";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -70,9 +69,7 @@ export function ModelSelector({
                 key={getModelKeyFromModel(model)}
                 onSelect={async (event) => {
                   if (!hasApiKey && errorNotice) {
-                    event.preventDefault();
-                    new Notice(errorNotice);
-                    return;
+                    setModelError(errorNotice);
                   }
 
                   try {
@@ -81,7 +78,6 @@ export function ModelSelector({
                   } catch (error) {
                     const msg = `Model switch failed: ` + err2String(error);
                     setModelError(msg);
-                    new Notice(msg);
                     // Restore to the last valid model
                     const lastValidModel = settings.activeModels.find(
                       (m) => m.enabled && getModelKeyFromModel(m) === value
@@ -91,7 +87,7 @@ export function ModelSelector({
                     }
                   }
                 }}
-                className={!hasApiKey ? "tw-cursor-not-allowed tw-opacity-50" : ""}
+                className={!hasApiKey ? "tw-opacity-70" : ""}
               >
                 <ModelDisplay model={model} iconSize={12} />
               </DropdownMenuItem>

--- a/src/error.ts
+++ b/src/error.ts
@@ -20,3 +20,32 @@ export class TimeoutError extends Error {
     Object.setPrototypeOf(this, TimeoutError.prototype);
   }
 }
+
+/**
+ * LLM onboarding and configuration errors.
+ * These typed errors are used to surface missing credentials or model
+ * configuration issues as in-chat messages instead of popup notices.
+ */
+export class MissingApiKeyError extends Error {
+  constructor(message: string = "API key is not configured.") {
+    super(message);
+    this.name = "MissingApiKeyError";
+    Object.setPrototypeOf(this, MissingApiKeyError.prototype);
+  }
+}
+
+export class MissingPlusLicenseError extends Error {
+  constructor(message: string = "Copilot Plus license key is not configured.") {
+    super(message);
+    this.name = "MissingPlusLicenseError";
+    Object.setPrototypeOf(this, MissingPlusLicenseError.prototype);
+  }
+}
+
+export class MissingModelKeyError extends Error {
+  constructor(message: string = "No model key found. Please select a model in settings.") {
+    super(message);
+    this.name = "MissingModelKeyError";
+    Object.setPrototypeOf(this, MissingModelKeyError.prototype);
+  }
+}

--- a/src/langchainStream.test.ts
+++ b/src/langchainStream.test.ts
@@ -1,0 +1,46 @@
+jest.mock("@/settings/model", () => ({
+  getSettings: () => ({ debug: false }),
+}));
+
+import { AI_SENDER } from "@/constants";
+import { MissingApiKeyError } from "@/error";
+import { getAIResponse } from "@/langchainStream";
+import { ChatMessage } from "@/types/message";
+
+describe("getAIResponse onboarding errors", () => {
+  it("surfaces missing API key as an AI error message without throwing", async () => {
+    const addMessage = jest.fn();
+    const updateCurrentAiMessage = jest.fn();
+    const updateShouldAbort = jest.fn();
+
+    const chainManager = {
+      runChain: jest.fn(async () => {
+        throw new MissingApiKeyError("API key is not configured for the selected model.");
+      }),
+    } as unknown as any;
+
+    const userMessage: ChatMessage = {
+      id: "user-1",
+      message: "hello",
+      sender: "user",
+      timestamp: null,
+      isVisible: true,
+    };
+
+    await getAIResponse(
+      userMessage,
+      chainManager,
+      addMessage,
+      updateCurrentAiMessage,
+      updateShouldAbort
+    );
+
+    expect(chainManager.runChain).toHaveBeenCalledTimes(1);
+    expect(addMessage).toHaveBeenCalledTimes(1);
+
+    const errorMessage = addMessage.mock.calls[0][0] as ChatMessage;
+    expect(errorMessage.sender).toBe(AI_SENDER);
+    expect(errorMessage.isErrorMessage).toBe(true);
+    expect(errorMessage.message).toContain("API key");
+  });
+});

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -162,8 +162,7 @@ export const BasicSettings: React.FC = () => {
 
               const { hasApiKey, errorNotice } = checkModelApiKey(selectedModel, settings);
               if (!hasApiKey && errorNotice) {
-                new Notice(errorNotice);
-                return;
+                // Keep selection allowed; error will surface in chat on send
               }
               updateSetting("defaultModelKey", value);
             }}


### PR DESCRIPTION
# Onboarding Error Handling (Missing API Keys)

## Why this change
- 3.1.3 introduced slow keydown because `useChatManager` started pulling `chatUIState.getMessages()` on every render, forcing the whole transcript to re-render on each keystroke. That change has been reverted for performance. Reverted #2038 
- We still need to remove popup notices for new users with no API key or Copilot Plus license and surface those issues as in-chat AI responses instead of Obsidian `Notice` popups.

## Design goals
- Keep the performant `useChatManager` pattern (local state + subscription); do not reintroduce per-render `getMessages()` calls.
- Provide calm onboarding: missing credentials should produce a single AI error message in chat, not a popup.
- Avoid blocking model selection; allow users to pick a model even without a key, while guiding them in-chat on first send.
- Centralize missing-credential handling with typed errors; keep logging via `logInfo`/`logError`.

## Implementation steps
1) **Define typed errors**
   - Add domain errors (e.g., `MissingApiKeyError`, `MissingPlusLicenseError`, `MissingModelKeyError`) in the LLM layer with user-friendly messages.

2) **Throw typed errors instead of Notices**
   - `ChatModelManager.validateApiKey`/`setChatModel`: throw `MissingApiKeyError` (and Plus-specific variant) instead of `Notice`.
   - `BrevilabsClient.checkLicenseKey`: throw `MissingPlusLicenseError`; no `Notice`.
   - `ChainManager.createChainWithNewModel`: throw `MissingModelKeyError` when no key; keep logging, no `Notice`.

3) **Delay surfacing until send time**
   - `ChainManager` may cache the last init error, but do not surface it during renders. Only validate when a send/regenerate is attempted.

4) **Translate errors to chat messages**
   - In `ChatManager.sendMessage`/`regenerateMessage`, catch the typed errors and append a single AI error chat message (`isErrorMessage: true`) with guidance (“API key is not configured. Open Copilot settings to add a key.”). Then abort the send.
   - Ensure no Obsidian `Notice` is fired in these flows.

5) **Keep model selection non-blocking**
   - `ModelSelector`, project pickers, and settings should allow selection without an API key. Remove `event.preventDefault()`/blocking logic; optional: subtle disabled styling or tooltip, but no popup.

6) **Tests**
   - Unit tests: missing-key path yields an error chat message and no `Notice`; plus-license missing throws the typed error; model selection remains allowed.

## Guardrails
- Do not touch `useChatManager`’s current state/subscription structure.
- No render-time validation that reaches into chat state; validate only on send/regenerate.
- Keep logging via `logInfo`/`logError`; avoid `console.log`.
