### PR TITLE
fix: Fix view-content padding for different display modes.

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -875,9 +875,16 @@ If your plugin does not need CSS, delete this file.
 }
 
 /* use 'important' to prevent ob default css style from being third-party theme overridden */
+
 .workspace-leaf-content[data-type="copilot-chat-view"] .view-content {
   padding-bottom: max(var(--safe-area-inset-bottom), var(--size-4-8)) !important;
 }
+
+/* open plugin in Editor mode for mobile */
+body.is-mobile .workspace-tab-container .workspace-leaf-content[data-type="copilot-chat-view"] .view-content {
+  padding-bottom: var(--size-4-1) !important;
+}
+
 
 /* Collapsible sources styling */
 .copilot-sources {


### PR DESCRIPTION
### issues
- #1738

### Summary

- For Obsidian internal css styles, Separate padding rules for Sidebar View mode (`.workspace-drawer-tab-container`) and Editor mode (`.workspace-tab-container`)
- Ensure proper bottom spacing in both display contexts

### Changes

- Split the single `.view-content` padding rule into two mode-specific selectors
- Sidebar View: Uses `safe-area-inset-bottom` for mobile device compatibility
- Editor View: Uses fixed padding value

### Actual Effect

`Open plugin in Editor mode on mobile`

![Screenshot_20260108_185210_Obsidian](https://github.com/user-attachments/assets/c352ed6d-e242-44aa-b91d-6feedd4d9bfa)
