### PR TITLE
Implement compaction with adjustable threshold and loading messages

### DIFF
--- a/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
+++ b/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
@@ -15,6 +15,7 @@ import {
   withSuppressedTokenWarnings,
 } from "@/utils";
 import { BaseChainRunner } from "./BaseChainRunner";
+import { loadAndAddChatHistory } from "./utils/chatHistoryUtils";
 import {
   formatSourceCatalog,
   getQACitationInstructions,
@@ -175,9 +176,7 @@ export class VaultQAChainRunner extends BaseChainRunner {
       }
 
       // Insert L4 (chat history) between system and user
-      for (const entry of chatHistory) {
-        messages.push({ role: entry.role, content: entry.content });
-      }
+      await loadAndAddChatHistory(memory, messages);
 
       // Add user message with RAG prepended
       // User message now contains: RAG results + citations + L3 smart references + L5

--- a/src/LLMProviders/chainRunner/utils/chatHistoryUtils.test.ts
+++ b/src/LLMProviders/chainRunner/utils/chatHistoryUtils.test.ts
@@ -2,6 +2,8 @@ import {
   processRawChatHistory,
   addChatHistoryToMessages,
   processedMessagesToTextOnly,
+  extractConversationTurns,
+  estimateToolOutputSize,
 } from "./chatHistoryUtils";
 
 describe("chatHistoryUtils", () => {
@@ -240,6 +242,216 @@ describe("chatHistoryUtils", () => {
       const result = processedMessagesToTextOnly(processedMessages);
 
       expect(result).toEqual([{ role: "user", content: "[Image content]" }]);
+    });
+  });
+
+  describe("extractConversationTurns", () => {
+    it("should extract complete turn pairs from even-length history", () => {
+      const history = [
+        { role: "user" as const, content: "Hello" },
+        { role: "assistant" as const, content: "Hi there!" },
+        { role: "user" as const, content: "How are you?" },
+        { role: "assistant" as const, content: "I am doing well!" },
+      ];
+
+      const result = extractConversationTurns(history);
+
+      expect(result.turns).toEqual([
+        { user: "Hello", assistant: "Hi there!" },
+        { user: "How are you?", assistant: "I am doing well!" },
+      ]);
+      expect(result.trailingUserMessage).toBeNull();
+    });
+
+    it("should detect trailing unpaired user message", () => {
+      const history = [
+        { role: "user" as const, content: "Hello" },
+        { role: "assistant" as const, content: "Hi there!" },
+        { role: "user" as const, content: "What about this?" },
+      ];
+
+      const result = extractConversationTurns(history);
+
+      expect(result.turns).toEqual([{ user: "Hello", assistant: "Hi there!" }]);
+      expect(result.trailingUserMessage).toBe("What about this?");
+    });
+
+    it("should handle single user message (no complete turns)", () => {
+      const history = [{ role: "user" as const, content: "Hello" }];
+
+      const result = extractConversationTurns(history);
+
+      expect(result.turns).toEqual([]);
+      expect(result.trailingUserMessage).toBe("Hello");
+    });
+
+    it("should handle empty history", () => {
+      const result = extractConversationTurns([]);
+
+      expect(result.turns).toEqual([]);
+      expect(result.trailingUserMessage).toBeNull();
+    });
+
+    it("should handle multimodal content by extracting text", () => {
+      const multimodalContent = [
+        { type: "text", text: "What is this?" },
+        { type: "image_url", image_url: { url: "data:image/jpeg;base64,..." } },
+      ];
+
+      const history = [
+        { role: "user" as const, content: multimodalContent },
+        { role: "assistant" as const, content: "This is a cat." },
+        { role: "user" as const, content: "Tell me more" },
+      ];
+
+      const result = extractConversationTurns(history);
+
+      // Should extract text content, not stringify (which would include huge base64 data)
+      expect(result.turns).toEqual([{ user: "What is this?", assistant: "This is a cat." }]);
+      expect(result.trailingUserMessage).toBe("Tell me more");
+    });
+
+    it("should handle trailing user message with multimodal content", () => {
+      const multimodalContent = [{ type: "text", text: "Look at this" }];
+
+      const history = [
+        { role: "user" as const, content: "Hello" },
+        { role: "assistant" as const, content: "Hi!" },
+        { role: "user" as const, content: multimodalContent },
+      ];
+
+      const result = extractConversationTurns(history);
+
+      expect(result.turns).toEqual([{ user: "Hello", assistant: "Hi!" }]);
+      // Should extract text content, not stringify
+      expect(result.trailingUserMessage).toBe("Look at this");
+    });
+
+    it("should handle assistant-first history (e.g., BufferWindowMemory slice)", () => {
+      // When BufferWindowMemory slices mid-conversation, history may start with assistant
+      const history = [
+        { role: "assistant" as const, content: "Starting message" }, // assistant first (sliced)
+        { role: "user" as const, content: "Hello" },
+        { role: "assistant" as const, content: "Hi!" },
+      ];
+
+      const result = extractConversationTurns(history);
+
+      // Should skip the orphaned assistant message and extract the user-assistant pair
+      expect(result.turns).toEqual([{ user: "Hello", assistant: "Hi!" }]);
+      expect(result.trailingUserMessage).toBeNull();
+    });
+
+    it("should handle multiple orphaned assistant messages at start", () => {
+      const history = [
+        { role: "assistant" as const, content: "Orphan 1" },
+        { role: "assistant" as const, content: "Orphan 2" },
+        { role: "user" as const, content: "Hello" },
+        { role: "assistant" as const, content: "Hi!" },
+        { role: "user" as const, content: "Follow up" },
+      ];
+
+      const result = extractConversationTurns(history);
+
+      // Should skip orphaned assistant messages, extract one turn, detect trailing user
+      expect(result.turns).toEqual([{ user: "Hello", assistant: "Hi!" }]);
+      expect(result.trailingUserMessage).toBe("Follow up");
+    });
+
+    it("should handle consecutive user messages (only last before assistant forms pair)", () => {
+      const history = [
+        { role: "user" as const, content: "First attempt" },
+        { role: "user" as const, content: "Let me rephrase" },
+        { role: "assistant" as const, content: "I understand now" },
+      ];
+
+      const result = extractConversationTurns(history);
+
+      // First user message has no following assistant, second does
+      expect(result.turns).toEqual([{ user: "Let me rephrase", assistant: "I understand now" }]);
+      expect(result.trailingUserMessage).toBeNull();
+    });
+  });
+
+  describe("estimateToolOutputSize", () => {
+    it("should return 0 for empty tool outputs", () => {
+      const result = estimateToolOutputSize([]);
+      expect(result).toBe(0);
+    });
+
+    it("should calculate size for single tool output", () => {
+      const toolOutputs = [{ tool: "search", output: "result data" }];
+
+      const result = estimateToolOutputSize(toolOutputs);
+
+      // "# Additional context:\n\n" = 23 chars (21 + 2 newlines)
+      // "<search>\n" = 9 chars
+      // "result data" = 11 chars
+      // "\n</search>" = 10 chars
+      // Total: 23 + 9 + 11 + 10 = 53
+      expect(result).toBe(53);
+    });
+
+    it("should calculate size for multiple tool outputs with separators", () => {
+      const toolOutputs = [
+        { tool: "search", output: "abc" },
+        { tool: "web", output: "xyz" },
+      ];
+
+      const result = estimateToolOutputSize(toolOutputs);
+
+      // "# Additional context:\n\n" = 23 chars
+      // "<search>\nabc\n</search>" = 9 + 3 + 10 = 22 chars
+      // "\n\n" separator = 2 chars
+      // "<web>\nxyz\n</web>" = 6 + 3 + 7 = 16 chars
+      // Total: 23 + 22 + 2 + 16 = 63
+      expect(result).toBe(63);
+    });
+
+    it("should stringify object outputs", () => {
+      const toolOutputs = [{ tool: "api", output: { key: "value" } }];
+
+      const result = estimateToolOutputSize(toolOutputs);
+
+      // JSON.stringify({ key: "value" }) = '{"key":"value"}' = 15 chars
+      // "# Additional context:\n\n" = 23 chars
+      // "<api>\n" = 6 chars
+      // jsonContent = 15 chars
+      // "\n</api>" = 7 chars
+      // Total: 23 + 6 + 15 + 7 = 51
+      expect(result).toBe(51);
+    });
+
+    it("should handle tool outputs with long content", () => {
+      const longContent = "x".repeat(10000);
+      const toolOutputs = [{ tool: "data", output: longContent }];
+
+      const result = estimateToolOutputSize(toolOutputs);
+
+      // "# Additional context:\n\n" = 23 chars
+      // "<data>\n" = 7 chars
+      // longContent = 10000 chars
+      // "\n</data>" = 8 chars
+      // Total: 23 + 7 + 10000 + 8 = 10038
+      expect(result).toBe(10038);
+    });
+
+    it("should match actual formatted output size", () => {
+      // This test verifies the estimate matches the actual format used
+      const toolOutputs = [
+        { tool: "localSearch", output: "Found 5 results" },
+        { tool: "webSearch", output: "Web results here" },
+      ];
+
+      const estimated = estimateToolOutputSize(toolOutputs);
+
+      // Manually build what formatAllToolOutputs would produce
+      const formatted =
+        "# Additional context:\n\n" +
+        "<localSearch>\nFound 5 results\n</localSearch>\n\n" +
+        "<webSearch>\nWeb results here\n</webSearch>";
+
+      expect(estimated).toBe(formatted.length);
     });
   });
 });

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -97,7 +97,10 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
       const messageToAdd = shouldAttachId ? { ...message, id: streamingId } : message;
 
       rawAddMessage(messageToAdd);
-      if (messageToAdd.sender === AI_SENDER && messageToAdd.responseMetadata?.tokenUsage?.totalTokens) {
+      if (
+        messageToAdd.sender === AI_SENDER &&
+        messageToAdd.responseMetadata?.tokenUsage?.totalTokens
+      ) {
         setLatestTokenCount(messageToAdd.responseMetadata.tokenUsage.totalTokens);
       }
     },
@@ -279,7 +282,8 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
         currentChain,
         effectiveIncludeActiveNote,
         effectiveIncludeActiveWebTab,
-        content.length > 0 ? content : undefined
+        content.length > 0 ? content : undefined,
+        safeSet.setLoadingMessage
       );
 
       // Add to user message history

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -126,6 +126,7 @@ export const LOADING_MESSAGES = {
   READING_FILES: "Reading files",
   SEARCHING_WEB: "Searching the web",
   READING_FILE_TREE: "Reading file tree",
+  COMPACTING: "Compacting",
 };
 export const PLUS_UTM_MEDIUMS = {
   SETTINGS: "settings",
@@ -877,6 +878,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   autoAcceptEdits: false,
   userSystemPromptsFolder: DEFAULT_SYSTEM_PROMPTS_FOLDER,
   defaultSystemPromptTitle: "",
+  autoCompactThreshold: 128000,
 };
 
 export const EVENT_NAMES = {

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -547,10 +547,6 @@ export class ContextProcessor {
           return;
         }
 
-        logInfo(
-          `Processing note: ${note.path}, extension: ${note.extension}, chain: ${currentChain}`
-        );
-
         // 1. Check if the file extension is supported by any parser
         if (!fileParserManager.supportsExtension(note.extension)) {
           logWarn(`Unsupported file type: ${note.extension}`);
@@ -846,7 +842,9 @@ export class ContextProcessor {
     if (!availability.supported || !availability.available) {
       const reason =
         availability.reason ??
-        (availability.supported ? "Web Viewer is not available." : "Web Viewer is not supported on this platform.");
+        (availability.supported
+          ? "Web Viewer is not available."
+          : "Web Viewer is not supported on this platform.");
 
       const blocks: string[] = [];
       if (activeTab) {

--- a/src/core/ChatManager.test.ts
+++ b/src/core/ChatManager.test.ts
@@ -1,5 +1,7 @@
 // Mock dependencies first to avoid circular dependencies
 jest.mock("./MessageRepository");
+jest.mock("@/LLMProviders/chatModelManager");
+jest.mock("./ContextCompactor");
 jest.mock("./ContextManager");
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
@@ -189,7 +191,8 @@ describe("ChatManager", () => {
         mockActiveFile,
         expect.anything(), // messageRepo
         expect.any(String), // systemPrompt
-        expect.any(Array) // systemPromptIncludedFiles
+        expect.any(Array), // systemPromptIncludedFiles
+        undefined // updateLoadingMessage
       );
       expect(mockMessageRepo.updateProcessedText).toHaveBeenCalledWith(
         "msg-1",
@@ -1080,9 +1083,7 @@ describe("ChatManager", () => {
             content: "Some selected text from web",
           },
         ],
-        webTabs: [
-          { url: "https://existing.example.com", title: "Existing Tab" },
-        ],
+        webTabs: [{ url: "https://existing.example.com", title: "Existing Tab" }],
       };
 
       mockGetWebViewerService.mockReturnValue({
@@ -1449,7 +1450,8 @@ describe("ChatManager", () => {
           mockActiveFile,
           expect.anything(),
           expect.any(String),
-          expect.arrayContaining([mockIncludedFile]) // Should contain the included file
+          expect.arrayContaining([mockIncludedFile]), // Should contain the included file
+          undefined // updateLoadingMessage
         );
       });
     });
@@ -1529,10 +1531,12 @@ describe("ChatManager", () => {
 
         // CRITICAL: Structural assertion to catch $& expansion bug
         // If $& were interpreted, it would inject the entire matched block, causing nested tags
-        const openTagCount = ((systemPromptArg as string).match(/<user_custom_instructions>/g) || [])
-          .length;
-        const closeTagCount = ((systemPromptArg as string).match(/<\/user_custom_instructions>/g) ||
-          []).length;
+        const openTagCount = (
+          (systemPromptArg as string).match(/<user_custom_instructions>/g) || []
+        ).length;
+        const closeTagCount = (
+          (systemPromptArg as string).match(/<\/user_custom_instructions>/g) || []
+        ).length;
         expect(openTagCount).toBe(1);
         expect(closeTagCount).toBe(1);
       });
@@ -1578,10 +1582,12 @@ describe("ChatManager", () => {
 
         // CRITICAL: Structural assertion to catch $& expansion bug
         // If $& were interpreted, it would inject the entire matched block, causing nested tags
-        const openTagCount = ((systemPromptArg as string).match(/<user_custom_instructions>/g) || [])
-          .length;
-        const closeTagCount = ((systemPromptArg as string).match(/<\/user_custom_instructions>/g) ||
-          []).length;
+        const openTagCount = (
+          (systemPromptArg as string).match(/<user_custom_instructions>/g) || []
+        ).length;
+        const closeTagCount = (
+          (systemPromptArg as string).match(/<\/user_custom_instructions>/g) || []
+        ).length;
         expect(openTagCount).toBe(1);
         expect(closeTagCount).toBe(1);
       });

--- a/src/core/ChatManager.ts
+++ b/src/core/ChatManager.ts
@@ -402,7 +402,8 @@ export class ChatManager {
     chainType: ChainType,
     includeActiveNote: boolean = false,
     includeActiveWebTab: boolean = false,
-    content?: any[]
+    content?: any[],
+    updateLoadingMessage?: (message: string) => void
   ): Promise<string> {
     try {
       logInfo(`[ChatManager] Sending message: "${displayText}"`);
@@ -425,8 +426,7 @@ export class ChatManager {
       // BUT: any selection takes priority and suppresses active tab to avoid redundant context
       const hasAnySelection = (updatedContext.selectedTextContexts || []).length > 0;
       const shouldIncludeActiveWebTab =
-        !hasAnySelection &&
-        (includeActiveWebTab || displayText.includes(ACTIVE_WEB_TAB_MARKER));
+        !hasAnySelection && (includeActiveWebTab || displayText.includes(ACTIVE_WEB_TAB_MARKER));
       updatedContext.webTabs = this.buildWebTabsWithActiveSnapshot(
         updatedContext.webTabs || [],
         shouldIncludeActiveWebTab
@@ -467,7 +467,8 @@ export class ChatManager {
         activeNote,
         currentRepo, // Pass MessageRepository for L2 building
         systemPrompt,
-        systemPromptIncludedFiles
+        systemPromptIncludedFiles,
+        updateLoadingMessage
       );
 
       // Update the processed content

--- a/src/core/ContextCompactor.ts
+++ b/src/core/ContextCompactor.ts
@@ -1,0 +1,341 @@
+import { logInfo } from "@/logger";
+import ChatModelManager from "@/LLMProviders/chatModelManager";
+import { CompactionResult, ParsedContextItem } from "@/types/compaction";
+import { HumanMessage } from "@langchain/core/messages";
+
+/**
+ * ContextCompactor - Compresses large context using map-reduce summarization.
+ *
+ * ## How It Works
+ *
+ * When context attached to a user message exceeds a configurable threshold (in tokens),
+ * this class automatically compresses it using a map-reduce pattern:
+ *
+ * ### 1. PARSE Phase
+ * The XML-structured context is parsed into discrete items. Each context block
+ * (note_context, active_note, url_content, etc.) becomes a separate item with:
+ * - type: The XML tag name
+ * - path: File path or URL
+ * - title: Note/page title
+ * - content: The actual text content
+ * - metadata: Additional info (ctime, mtime)
+ *
+ * ### 2. MAP Phase (Parallel Summarization)
+ * Large items (>50k chars) are sent to the LLM for summarization in parallel.
+ * - Uses low temperature (0.1) for deterministic output
+ * - Max 3 concurrent requests to avoid API overload
+ * - Failed summarizations keep original content
+ * - If >50% fail, compaction aborts entirely (fail-safe)
+ *
+ * ### 3. REDUCE Phase (Rebuild)
+ * Summarized items are recombined into the original XML structure.
+ * - Preserves all metadata (title, path, timestamps)
+ * - Marks summarized content with [SUMMARIZED] prefix
+ * - Maintains item order for consistent citations
+ *
+ * ## Configuration
+ *
+ * The threshold is set in Settings > QA > Auto-Compact Threshold (in tokens).
+ * Internally converted to chars using 4 chars/token estimate.
+ * Set to 0 to disable auto-compaction.
+ *
+ * ## Example
+ *
+ * Before (500k chars):
+ * ```xml
+ * <note_context>
+ *   <title>Research Notes</title>
+ *   <path>notes/research.md</path>
+ *   <content>[... 50,000 chars of content ...]</content>
+ * </note_context>
+ * ```
+ *
+ * After (~5k chars):
+ * ```xml
+ * <note_context>
+ *   <title>Research Notes</title>
+ *   <path>notes/research.md</path>
+ *   <content>[SUMMARIZED]
+ *   Key findings: ... (concise summary preserving main ideas)
+ *   </content>
+ * </note_context>
+ * ```
+ */
+export class ContextCompactor {
+  private static instance: ContextCompactor;
+  private chatModelManager: ChatModelManager;
+
+  /** Minimum chars to consider an item for summarization */
+  private readonly MIN_ITEM_SIZE = 50000;
+  /** Max parallel LLM calls */
+  private readonly MAX_CONCURRENCY = 3;
+  /** Low temperature for deterministic summaries */
+  private readonly TEMPERATURE = 0.1;
+  /** Max chars per item before truncation */
+  private readonly MAX_ITEM_SIZE = 500000;
+
+  /** XML block types to parse */
+  private readonly BLOCK_TYPES = [
+    "note_context",
+    "active_note",
+    "url_content",
+    "selected_text",
+    "embedded_note",
+    "embedded_pdf",
+    "web_tab_context",
+    "active_web_tab",
+    "youtube_video_context",
+  ];
+
+  private readonly PROMPT = `Summarize the following content, preserving:
+- Key concepts and main ideas
+- Important facts, names, and dates
+- Technical details relevant for Q&A
+
+Keep the summary concise but information-dense. Output only the summary.
+
+Title: {title}
+Path: {path}
+
+Content:
+{content}
+
+Summary:`;
+
+  private constructor() {
+    this.chatModelManager = ChatModelManager.getInstance();
+  }
+
+  static getInstance(): ContextCompactor {
+    if (!ContextCompactor.instance) {
+      ContextCompactor.instance = new ContextCompactor();
+    }
+    return ContextCompactor.instance;
+  }
+
+  /**
+   * Compact context using map-reduce summarization.
+   */
+  async compact(content: string): Promise<CompactionResult> {
+    const originalCharCount = content.length;
+    logInfo(`[ContextCompactor] Starting compaction of ${originalCharCount} chars`);
+
+    // Parse XML into items
+    const items = this.parseItems(content);
+    if (items.length === 0) {
+      return this.noOpResult(content);
+    }
+
+    // Map: summarize large items
+    const summaries = await this.summarizeItems(items);
+    if (summaries.size === 0) {
+      return this.noOpResult(content);
+    }
+
+    // Reduce: rebuild with summaries
+    const compacted = this.rebuild(content, items, summaries);
+
+    logInfo(
+      `[ContextCompactor] Done: ${originalCharCount} -> ${compacted.length} chars ` +
+        `(${((1 - compacted.length / originalCharCount) * 100).toFixed(0)}% reduction)`
+    );
+
+    return {
+      content: compacted,
+      wasCompacted: true,
+      originalCharCount,
+      compactedCharCount: compacted.length,
+      itemsProcessed: items.length,
+      itemsSummarized: summaries.size,
+    };
+  }
+
+  /**
+   * Creates a no-op compaction result when no compaction was performed.
+   * @param content - The original content that was not compacted
+   * @returns A CompactionResult indicating no changes were made
+   */
+  private noOpResult(content: string): CompactionResult {
+    return {
+      content,
+      wasCompacted: false,
+      originalCharCount: content.length,
+      compactedCharCount: content.length,
+      itemsProcessed: 0,
+      itemsSummarized: 0,
+    };
+  }
+
+  /**
+   * Parse XML content into discrete items.
+   * Filters out nested blocks to avoid overlapping replacements.
+   */
+  private parseItems(content: string): ParsedContextItem[] {
+    const items: ParsedContextItem[] = [];
+
+    for (const type of this.BLOCK_TYPES) {
+      const regex = new RegExp(`<${type}>[\\s\\S]*?<\\/${type}>`, "g");
+      let match;
+      while ((match = regex.exec(content)) !== null) {
+        const item = this.parseBlock(match[0], type, match.index);
+        if (item) items.push(item);
+      }
+    }
+
+    // Sort by start index
+    items.sort((a, b) => a.startIndex - b.startIndex);
+
+    // Filter out nested items (fully contained within another item)
+    // This prevents overlapping replacements that corrupt indices
+    return items.filter(
+      (item, i) =>
+        !items.some(
+          (other, j) =>
+            i !== j && other.startIndex <= item.startIndex && other.endIndex >= item.endIndex
+        )
+    );
+  }
+
+  /**
+   * Parses a single XML block into a ParsedContextItem.
+   * @param block - The raw XML block string
+   * @param type - The type of context block (e.g., 'note_context', 'active_note')
+   * @param startIndex - The character index where this block starts in the original content
+   * @returns A ParsedContextItem or null if parsing fails
+   */
+  private parseBlock(block: string, type: string, startIndex: number): ParsedContextItem | null {
+    const extract = (tag: string) => new RegExp(`<${tag}>([^<]*)</${tag}>`).exec(block)?.[1] || "";
+    const extractContent = () => /<content>([\s\S]*?)<\/content>/.exec(block)?.[1] || "";
+
+    const path = extract("path") || extract("url");
+    const title = extract("title") || path.split("/").pop() || "Untitled";
+    const innerContent = extractContent();
+
+    return {
+      type,
+      path,
+      title,
+      content: innerContent,
+      metadata: { ctime: extract("ctime"), mtime: extract("mtime") },
+      originalXml: block,
+      startIndex,
+      endIndex: startIndex + block.length,
+    };
+  }
+
+  /**
+   * Map phase: summarize large items in parallel batches.
+   */
+  private async summarizeItems(items: ParsedContextItem[]): Promise<Map<number, string>> {
+    const summaries = new Map<number, string>();
+
+    // Filter items needing summarization
+    const toProcess = items
+      .map((item, index) => ({ index, item }))
+      .filter(({ item }) => item.content.length >= this.MIN_ITEM_SIZE);
+
+    if (toProcess.length === 0) return summaries;
+
+    logInfo(`[ContextCompactor] Summarizing ${toProcess.length} items`);
+
+    // Process in batches
+    for (let i = 0; i < toProcess.length; i += this.MAX_CONCURRENCY) {
+      const batch = toProcess.slice(i, i + this.MAX_CONCURRENCY);
+      const results = await Promise.all(
+        batch.map(async ({ index, item }) => {
+          try {
+            return { index, summary: await this.summarize(item) };
+          } catch (e) {
+            logInfo(`[ContextCompactor] Failed to summarize item ${index}:`, e);
+            return { index, summary: null };
+          }
+        })
+      );
+      results.forEach(({ index, summary }) => {
+        if (summary) summaries.set(index, summary);
+      });
+    }
+
+    // Abort if too many failures
+    if (summaries.size < toProcess.length * 0.5) {
+      logInfo(`[ContextCompactor] High failure rate, aborting compaction`);
+      return new Map();
+    }
+
+    return summaries;
+  }
+
+  /**
+   * Summarizes a single context item using the LLM.
+   * @param item - The parsed context item to summarize
+   * @returns The summarized content string
+   */
+  private async summarize(item: ParsedContextItem): Promise<string> {
+    let content = item.content;
+    if (content.length > this.MAX_ITEM_SIZE) {
+      content = content.slice(0, this.MAX_ITEM_SIZE) + "\n[TRUNCATED]";
+    }
+
+    const prompt = this.PROMPT.replace("{title}", item.title)
+      .replace("{path}", item.path)
+      .replace("{content}", content);
+
+    const model = await this.chatModelManager.getChatModelWithTemperature(this.TEMPERATURE);
+    const response = await model.invoke([new HumanMessage(prompt)]);
+
+    return typeof response.content === "string" ? response.content.trim() : "";
+  }
+
+  /**
+   * Reduce phase: rebuild content with summaries.
+   */
+  private rebuild(
+    original: string,
+    items: ParsedContextItem[],
+    summaries: Map<number, string>
+  ): string {
+    let result = original;
+
+    // Process from end to preserve indices
+    Array.from(summaries.keys())
+      .sort((a, b) => b - a)
+      .forEach((index) => {
+        const item = items[index];
+        const summary = summaries.get(index)!;
+        const newBlock = this.buildBlock(item, summary);
+        result = result.slice(0, item.startIndex) + newBlock + result.slice(item.endIndex);
+      });
+
+    return result;
+  }
+
+  /** Block types that use <url> instead of <path> */
+  private readonly URL_BASED_TYPES = [
+    "url_content",
+    "web_tab_context",
+    "active_web_tab",
+    "youtube_video_context",
+  ];
+
+  /**
+   * Builds an XML block from a parsed item with its summary content.
+   * @param item - The original parsed context item
+   * @param summary - The summarized content to include
+   * @returns The rebuilt XML block string with summary
+   */
+  private buildBlock(item: ParsedContextItem, summary: string): string {
+    const parts = [`<${item.type}>`];
+
+    if (item.title) parts.push(`<title>${item.title}</title>`);
+    if (item.path) {
+      const tag = this.URL_BASED_TYPES.includes(item.type) ? "url" : "path";
+      parts.push(`<${tag}>${item.path}</${tag}>`);
+    }
+    if (item.metadata.ctime) parts.push(`<ctime>${item.metadata.ctime}</ctime>`);
+    if (item.metadata.mtime) parts.push(`<mtime>${item.metadata.mtime}</mtime>`);
+    parts.push(`<content>[SUMMARIZED]\n${summary}</content>`);
+    parts.push(`</${item.type}>`);
+
+    return parts.join("\n");
+  }
+}

--- a/src/settings/v2/components/ModelSettings.tsx
+++ b/src/settings/v2/components/ModelSettings.tsx
@@ -179,6 +179,16 @@ export const ModelSettings: React.FC = () => {
             max={50}
             step={1}
           />
+          <SettingItem
+            type="slider"
+            title="Auto-compact threshold"
+            description="Automatically summarize context using map-reduce when it exceeds this token count. Default is 128k."
+            min={64000}
+            max={1000000}
+            step={64000}
+            value={settings.autoCompactThreshold}
+            onChange={(value) => updateSetting("autoCompactThreshold", value)}
+          />
         </div>
       </section>
 

--- a/src/state/ChatUIState.ts
+++ b/src/state/ChatUIState.ts
@@ -63,7 +63,8 @@ export class ChatUIState {
     chainType: ChainType,
     includeActiveNote: boolean = false,
     includeActiveWebTab: boolean = false,
-    content?: any[]
+    content?: any[],
+    updateLoadingMessage?: (message: string) => void
   ): Promise<string> {
     const messageId = await this.chatManager.sendMessage(
       displayText,
@@ -71,7 +72,8 @@ export class ChatUIState {
       chainType,
       includeActiveNote,
       includeActiveWebTab,
-      content
+      content,
+      updateLoadingMessage
     );
     this.notifyListeners();
     return messageId;

--- a/src/types/compaction.ts
+++ b/src/types/compaction.ts
@@ -1,0 +1,39 @@
+/**
+ * Result of context compaction operation
+ */
+export interface CompactionResult {
+  /** Compacted content string (XML-formatted) */
+  content: string;
+  /** Whether compaction was performed */
+  wasCompacted: boolean;
+  /** Original character count */
+  originalCharCount: number;
+  /** Final character count after compaction */
+  compactedCharCount: number;
+  /** Number of context items processed */
+  itemsProcessed: number;
+  /** Number of items that were summarized */
+  itemsSummarized: number;
+}
+
+/**
+ * Parsed context item from XML content
+ */
+export interface ParsedContextItem {
+  /** XML tag name (note_context, active_note, url_content, etc.) */
+  type: string;
+  /** Full path or identifier */
+  path: string;
+  /** Title/name for display */
+  title: string;
+  /** Raw content string */
+  content: string;
+  /** Additional metadata (mtime, ctime, etc.) */
+  metadata: Record<string, string>;
+  /** Original full XML block */
+  originalXml: string;
+  /** Start index in the original content */
+  startIndex: number;
+  /** End index in the original content */
+  endIndex: number;
+}


### PR DESCRIPTION
# Auto-Compact Context Feature

## Summary

Implements automatic context compaction using map-reduce summarization when context exceeds a configurable token threshold. This prevents context overflow errors and reduces token usage for large context windows.

## Changes

### New Files
- **`src/core/ContextCompactor.ts`** - Singleton class that compresses large context using map-reduce pattern
- **`src/types/compaction.ts`** - Type definitions for `CompactionResult` and `ParsedContextItem`

### Modified Files
- **`src/core/ContextManager.ts`** - Integrated compaction, preserves compacted content across turns
- **`src/settings/model.ts`** - Added `autoCompactThreshold` setting
- **`src/constants.ts`** - Added default threshold (128k tokens) and "Compacting" loading message
- **`src/settings/v2/components/ModelSettings.tsx`** - Added threshold slider in Models tab
- **`src/state/ChatUIState.ts`** - Thread loading message callback
- **`src/core/ChatManager.ts`** - Thread loading message callback
- **`src/components/Chat.tsx`** - Pass loading message callback to sendMessage
- **`src/core/ChatManager.test.ts`** - Added mocks and updated test assertions
- **`src/LLMProviders/chainRunner/utils/chatHistoryUtils.ts`** - Added `addChatHistoryWithCompaction` for conversation history compaction
- **`src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts`** - Uses compaction-aware chat history
- **`src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts`** - Uses compaction-aware chat history
- **`src/contextProcessor.ts`** - Removed verbose "Processing note" logs

## How It Works

When context attached to a user message exceeds the threshold (in tokens), the compactor:

1. **PARSE**: Extracts XML-structured context blocks (`note_context`, `active_note`, `url_content`, etc.) into discrete items
2. **MAP**: Summarizes large items (>50k chars) in parallel using the current chat model with low temperature (0.1)
3. **REDUCE**: Rebuilds XML structure with summarized content, preserving metadata (title, path, timestamps)

### Multi-Turn Compaction Preservation

**Key improvement**: Once context is compacted, it stays compacted across turns.

- **Turn 1**: User attaches folders A, B, C → compacted → stored in envelope L3 with `compactedPaths` metadata
- **Turn 2**: Same folders attached again
  - L2 uses Turn 1's **compacted** content (not re-read from disk)
  - L3 only includes **new** files not already in L2 (deduped via `compactedPaths`)
  - No re-compaction of already-summarized content

This is achieved by:
1. `buildL2ContextFromPreviousTurns` reads stored L3 content from previous envelopes
2. Extracts paths from `segment.metadata.compactedPaths` for deduplication
3. Returns `l2Paths` set to filter out files already in L2
4. After compaction, `buildCompactedEnvelope` stores original paths in metadata for future turns

### Conversation History Compaction

When total context (system + chat history + current message) exceeds the threshold, older conversation turns are automatically summarized:

- Keeps the 2 most recent turns intact
- Summarizes older turns into a concise summary preserving key decisions and context
- Shows "Compacting..." during summarization
- Prevents context overflow errors from long conversations

### Fail-safes
- Max 3 concurrent LLM calls to avoid API overload
- Aborts if >50% of summarizations fail
- Truncates items >500k chars before summarization
- Projects mode uses fixed 1M token threshold
- Lazy-loads ContextCompactor to avoid test dependency issues
- Chat history compaction keeps 2 most recent turns intact, summarizes older ones

## Configuration

**Settings > Models > Auto-compact threshold**
- Range: 64k - 1M tokens
- Default: 128k tokens
- Step: 64k tokens

Higher values effectively disable compaction since context won't reach the threshold.

## User Experience

- Shows "Compacting..." with animated dots during compaction
- Summarized content is marked with `[SUMMARIZED]` prefix
- Original metadata preserved for accurate citations
