### PR TITLE
Remove transcript

### DIFF
--- a/src/commands/constants.ts
+++ b/src/commands/constants.ts
@@ -262,17 +262,9 @@ tags:
 
 <Brief 2-3 paragraph summary of the page content>
 
-## 摘要
-
-<用中文写的 2-3 段摘要>
-
 ## Key Takeaways
 
 <List 5-8 key takeaways as bullet points>
-
-## 要点
-
-<用中文列出 5-8 个要点>
 
 ## Mindmap
 


### PR DESCRIPTION
- Clip Youtube command now needs the model to output the entire video transcript. This is wrong. Remove for now until a programmatic solution for the transcript is in place.
- For base commands, builtin prompts should be in English. There should be a solution to add a final output language for all commands.