### PR TITLE
fix: prevent arrow keys from getting stuck in typeahead with no matches

### DIFF
--- a/src/components/chat-components/hooks/useTypeaheadPlugin.ts
+++ b/src/components/chat-components/hooks/useTypeaheadPlugin.ts
@@ -94,6 +94,7 @@ export function useTypeaheadPlugin<T extends TypeaheadOption>({
 
       switch (event.key) {
         case "ArrowDown": {
+          if (options.length === 0) return false;
           event.preventDefault();
           let nextIndex = state.selectedIndex + 1;
           // Skip disabled options
@@ -109,6 +110,7 @@ export function useTypeaheadPlugin<T extends TypeaheadOption>({
         }
 
         case "ArrowUp": {
+          if (options.length === 0) return false;
           event.preventDefault();
           let prevIndex = state.selectedIndex - 1;
           // Skip disabled options


### PR DESCRIPTION
## Summary
- Fix arrow keys getting trapped when typeahead menu has no matching options
- Add early return in ArrowDown/ArrowUp handlers when `options.length === 0`

## Why
When the typeahead menu is triggered (via `@` or `[[`) but the query matches nothing, the menu visually disappears (`TypeaheadMenuPortal` returns `null`) but `state.isOpen` remains `true`. The arrow key handlers were checking only `isOpen`, intercepting events even with no options to navigate — this trapped the cursor, preventing normal text navigation.

The fix is consistent with how `Enter`/`Tab` already handle empty options (close menu and return `false`). Rather than closing and reopening the menu on every keystroke, we simply stop intercepting arrow keys when there's nothing to navigate.