### PR TITLE
feat: add streamUsage config for 3rd party OpenAI-format providers

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -298,6 +298,7 @@ export default class ChatModelManager {
       [ChatModelProviders.LM_STUDIO]: {
         modelName: modelName,
         apiKey: customModel.apiKey || "default-key",
+        streamUsage: customModel.streamUsage ?? false,
         configuration: {
           baseURL: customModel.baseUrl || "http://localhost:1234/v1",
           fetch: customModel.enableCors ? safeFetch : undefined,
@@ -306,6 +307,7 @@ export default class ChatModelManager {
       [ChatModelProviders.OPENAI_FORMAT]: {
         modelName: modelName,
         apiKey: await getDecryptedKey(customModel.apiKey || settings.openAIApiKey),
+        streamUsage: customModel.streamUsage ?? false,
         configuration: {
           baseURL: customModel.baseUrl,
           fetch: customModel.enableCors ? safeFetch : undefined,

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -124,6 +124,7 @@ export interface CustomModel {
   enableCors?: boolean;
   core?: boolean;
   stream?: boolean;
+  streamUsage?: boolean;
   temperature?: number;
   maxTokens?: number;
   topP?: number;

--- a/src/settings/v2/components/ModelAddDialog.tsx
+++ b/src/settings/v2/components/ModelAddDialog.tsx
@@ -691,6 +691,32 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
                 </div>
               </Label>
             </div>
+            {(model.provider === ChatModelProviders.OPENAI_FORMAT ||
+              model.provider === ChatModelProviders.LM_STUDIO) && (
+              <div className="tw-flex tw-items-center tw-gap-2">
+                <Checkbox
+                  id="stream-usage"
+                  checked={model.streamUsage || false}
+                  onCheckedChange={(checked: boolean) =>
+                    setModel({ ...model, streamUsage: checked })
+                  }
+                />
+                <Label htmlFor="stream-usage" className="tw-cursor-pointer">
+                  <div className="tw-flex tw-items-center tw-gap-1">
+                    <span className="tw-text-sm">Stream Usage</span>
+                    <HelpTooltip
+                      content={
+                        <div className="tw-text-sm tw-text-muted">
+                          Enable if your provider supports stream_options for token usage tracking.
+                          Disable for providers that do not support it (e.g., Databricks, MLFlow).
+                        </div>
+                      }
+                      contentClassName="tw-max-w-96"
+                    />
+                  </div>
+                </Label>
+              </div>
+            )}
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/src/settings/v2/components/ModelEditDialog.tsx
+++ b/src/settings/v2/components/ModelEditDialog.tsx
@@ -248,6 +248,32 @@ export const ModelEditModalContent: React.FC<ModelEditModalContentProps> = ({
               </div>
             </FormField>
 
+            {/* Stream Usage Toggle for OpenAI-format providers */}
+            {(localModel.provider === ChatModelProviders.OPENAI_FORMAT ||
+              localModel.provider === ChatModelProviders.LM_STUDIO) && (
+              <FormField label="Stream Options">
+                <div className="tw-flex tw-items-center tw-gap-2">
+                  <Checkbox
+                    id="stream-usage"
+                    checked={localModel.streamUsage || false}
+                    onCheckedChange={(checked) => handleLocalUpdate("streamUsage", checked)}
+                  />
+                  <HelpTooltip
+                    content={
+                      <div className="tw-text-sm tw-text-muted">
+                        Enable if your provider supports stream_options for token usage tracking.
+                        Disable for providers that do not support it (e.g., Databricks, MLFlow).
+                      </div>
+                    }
+                  >
+                    <Label htmlFor="stream-usage" className="tw-cursor-pointer tw-text-sm">
+                      Stream Usage
+                    </Label>
+                  </HelpTooltip>
+                </div>
+              </FormField>
+            )}
+
             {/* Model Parameters Editor */}
             <ModelParametersEditor
               model={localModel}


### PR DESCRIPTION
Add optional streamUsage setting to CustomModel interface that allows users to control whether stream_options is sent to the API. This fixes compatibility with 3rd party providers (e.g., Databricks, MLFlow) that do not support the stream_options parameter.

- Add streamUsage?: boolean to CustomModel interface in aiParams.ts
- Pass streamUsage to ChatOpenAI config for OPENAI_FORMAT and LM_STUDIO providers
- Add UI toggle in ModelAddDialog and ModelEditDialog with helpful tooltip
- Default to false to maintain compatibility with providers that error on stream_options

Closes #2046