### PR TITLE
Add twitter4llm support for Twitter/X URLs

### DIFF
--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -62,6 +62,11 @@ export interface Youtube4llmResponse {
   elapsed_time_ms: number;
 }
 
+export interface Twitter4llmResponse {
+  response: any;
+  elapsed_time_ms: number;
+}
+
 export interface LicenseResponse {
   is_valid: boolean;
   plan: string;
@@ -368,6 +373,18 @@ export class BrevilabsClient {
     }
     if (!data) {
       throw new Error("No data returned from youtube4llm");
+    }
+
+    return data;
+  }
+
+  async twitter4llm(url: string): Promise<Twitter4llmResponse> {
+    const { data, error } = await this.makeRequest<Twitter4llmResponse>("/twitter4llm", { url });
+    if (error) {
+      throw error;
+    }
+    if (!data) {
+      throw new Error("No data returned from twitter4llm");
     }
 
     return data;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -747,6 +747,25 @@ export function isYoutubeUrl(url: string): boolean {
 }
 
 /**
+ * Check if a URL is a Twitter/X URL (e.g. tweet or post link)
+ */
+export function isTwitterUrl(url: string): boolean {
+  if (!url || typeof url !== "string") return false;
+  try {
+    const urlObj = new URL(url.trim());
+    return (
+      (urlObj.hostname === "x.com" ||
+        urlObj.hostname === "www.x.com" ||
+        urlObj.hostname === "twitter.com" ||
+        urlObj.hostname === "www.twitter.com") &&
+      urlObj.pathname.includes("/status/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Extract first YouTube URL from text (legacy function for backward compatibility)
  */
 export function extractYoutubeUrl(text: string): string | null {


### PR DESCRIPTION
## Summary
- Route Twitter/X URLs (`x.com`, `twitter.com` with `/status/`) to the new brevilabs `twitter4llm` endpoint instead of the generic `url4llm` endpoint
- Add `isTwitterUrl()` utility for URL detection and `twitter4llm()` client method
- Wrap Twitter content in `<twitter_content>` XML tags in the processed output

## Test plan
- [x] Paste a `https://x.com/.../status/...` URL in chat and verify it calls `twitter4llm`
- [x] Paste a `https://twitter.com/.../status/...` URL and verify same behavior
- [x] Verify regular URLs still go through `url4llm`
- [x] Verify YouTube URLs still go through `youtube4llm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)