### PR TITLE
Remove HyDE query rewriting from semantic search

### DIFF
--- a/src/search/v3/MergedSemanticRetriever.ts
+++ b/src/search/v3/MergedSemanticRetriever.ts
@@ -1,7 +1,6 @@
 import { HybridRetriever } from "@/search/hybridRetriever";
 import { RETURN_ALL_LIMIT } from "@/search/v3/SearchCore";
 import { TieredLexicalRetriever } from "@/search/v3/TieredLexicalRetriever";
-import { BaseCallbackConfig } from "@langchain/core/callbacks/manager";
 import { Document } from "@langchain/core/documents";
 import { BaseRetriever } from "@langchain/core/retrievers";
 import { App } from "obsidian";
@@ -84,16 +83,12 @@ export class MergedSemanticRetriever extends BaseRetriever {
    * Retrieves relevant documents by combining semantic and lexical matches.
    *
    * @param query - User query string
-   * @param config - Optional LangChain callback configuration
    * @returns Array of merged and ranked Documents
    */
-  public async getRelevantDocuments(
-    query: string,
-    config?: BaseCallbackConfig
-  ): Promise<Document[]> {
+  public async getRelevantDocuments(query: string): Promise<Document[]> {
     const [lexicalDocs, semanticDocs] = await Promise.all([
-      this.lexicalRetriever.getRelevantDocuments(query, config),
-      this.semanticRetriever.getRelevantDocuments(query, config),
+      this.lexicalRetriever.getRelevantDocuments(query),
+      this.semanticRetriever.getRelevantDocuments(query),
     ]);
 
     const merged = new Map<string, Document>();


### PR DESCRIPTION
## Summary
- Remove HyDE (Hypothetical Document Embeddings) query rewriting from `HybridRetriever`, which was generating garbage passages for non-question queries (e.g., "find all my ai digests" → instructional essay) and polluting vector search results
- This fixes Plus mode failing "find all" queries while Agent mode succeeded — Plus mode does a single search and the HyDE-corrupted semantic results pushed relevant notes out of the top results
- Raw query is now used directly for vector embedding search, which modern embeddings handle well
- Eliminates an extra LLM call per search for faster responses

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 84 test suites / 1620 tests pass
- [x] Manually test Plus mode with "find all my ai digests" query (semantic search enabled)
- [x] Verify semantic search still works for standard questions (e.g., "how does X work?")
- [x] Verify Vault QA mode still returns relevant results

🤖 Generated with [Claude Code](https://claude.com/claude-code)