### PR TITLE
Replace warning triangle with Build Index button in Relevant Notes

### DIFF
--- a/src/search/indexSignal.ts
+++ b/src/search/indexSignal.ts
@@ -1,0 +1,21 @@
+/**
+ * Lightweight pub-sub for index state changes (clear, build, reindex).
+ * UI hooks subscribe via {@link onIndexChanged} and re-check index state
+ * when any command fires {@link notifyIndexChanged}.
+ */
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+/** Subscribe to index change events. Returns an unsubscribe function. */
+export function onIndexChanged(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** Notify all subscribers that the index state has changed. */
+export function notifyIndexChanged(): void {
+  listeners.forEach((l) => l());
+}

--- a/src/search/vectorStoreManager.ts
+++ b/src/search/vectorStoreManager.ts
@@ -12,6 +12,7 @@ import type {
   SemanticIndexDocument,
 } from "./indexBackend/SemanticIndexBackend";
 import { IndexEventHandler } from "./indexEventHandler";
+import { notifyIndexChanged } from "./indexSignal";
 import { IndexOperations } from "./indexOperations";
 
 export default class VectorStoreManager {
@@ -110,12 +111,15 @@ export default class VectorStoreManager {
       new Notice("Indexing is disabled on mobile devices");
       return 0;
     }
-    return this.indexOps.indexVaultToVectorStore(overwrite);
+    const count = await this.indexOps.indexVaultToVectorStore(overwrite);
+    notifyIndexChanged();
+    return count;
   }
 
   public async clearIndex(): Promise<void> {
     await this.waitForInitialization();
     await this.indexBackend.clearIndex(await this.embeddingsManager.getEmbeddingsAPI());
+    notifyIndexChanged();
   }
 
   public async garbageCollectVectorStore(): Promise<number> {
@@ -171,5 +175,6 @@ export default class VectorStoreManager {
   public async reindexFile(file: TFile): Promise<void> {
     await this.waitForInitialization();
     await this.indexOps.reindexFile(file);
+    notifyIndexChanged();
   }
 }


### PR DESCRIPTION
## Summary
- Replace the yellow warning triangle and "No index available" text with a **Build Index** button when the semantic index is missing
- If semantic search is off, clicking Build Index shows the enable confirmation modal (same as settings page), then builds the vault index
- Add lightweight `indexSignal` pub-sub so the UI reacts instantly to external index changes (clear, rebuild commands) — signal fires from `VectorStoreManager` (single source of truth)
- Move the Build Index button to the header area so it's always accessible, even when link-based relevant notes are showing
- Update help tooltip to mention semantic search requirement

## Test plan
- [x] Open Copilot with semantic search **off** — verify "Build Index" button appears (no warning triangle)
- [x] Click "Build Index" — verify enable semantic search modal appears, and index builds on confirm
- [x] With semantic search **on** and index built — verify refresh icon shows and relevant notes load
- [x] Run "Clear Copilot Index" command — verify UI immediately switches to "Build Index" button
- [x] Run "Refresh Vault Index" command — verify UI updates to show refresh icon again

🤖 Generated with [Claude Code](https://claude.com/claude-code)