### PR TITLE
Fix ENAMETOOLONG error in Composer writeToFile tool

### DIFF
--- a/src/tools/ComposerTools.test.ts
+++ b/src/tools/ComposerTools.test.ts
@@ -3,6 +3,7 @@ import {
   normalizeLineEndings,
   replaceWithLineEndingAwareness,
 } from "./ComposerTools";
+import { sanitizeFilePath } from "@/utils";
 
 describe("parseSearchReplaceBlocks", () => {
   describe("Standard format", () => {
@@ -471,5 +472,80 @@ describe("replaceWithLineEndingAwareness", () => {
       const result = replaceWithLineEndingAwareness(content, searchText, replaceText);
       expect(result).toBe("new\r\ntest new\r\nmore new\r\n");
     });
+  });
+});
+
+describe("sanitizeFilePath", () => {
+  test("should return path unchanged when basename is within limits", () => {
+    expect(sanitizeFilePath("folder/short-name.md")).toBe("folder/short-name.md");
+  });
+
+  test("should return path unchanged for root-level files", () => {
+    expect(sanitizeFilePath("readme.md")).toBe("readme.md");
+  });
+
+  test("should truncate a basename that exceeds 255 bytes", () => {
+    // Create a filename with 300 ASCII characters + .md extension
+    const longName = "a".repeat(300) + ".md";
+    const result = sanitizeFilePath(`folder/${longName}`);
+    const basename = result.split("/").pop()!;
+
+    expect(new TextEncoder().encode(basename).length).toBeLessThanOrEqual(255);
+    expect(basename.endsWith(".md")).toBe(true);
+    expect(result.startsWith("folder/")).toBe(true);
+  });
+
+  test("should handle multi-byte Cyrillic characters correctly", () => {
+    // Cyrillic characters are 2 bytes each in UTF-8
+    // 128 Cyrillic chars = 256 bytes, which exceeds the 255-byte limit
+    const longCyrillicName = "А".repeat(128) + ".md";
+    const result = sanitizeFilePath(longCyrillicName);
+    const byteLength = new TextEncoder().encode(result).length;
+
+    expect(byteLength).toBeLessThanOrEqual(255);
+    expect(result.endsWith(".md")).toBe(true);
+  });
+
+  test("should handle the exact bug report scenario: long Cyrillic filename", () => {
+    const longName =
+      "Интервью_О._Югина_глобальные_кризисы_экономика_США_Китая_России_AI_и_инвестиции.md";
+    const result = sanitizeFilePath(`Документы/Library/${longName}`);
+    const basename = result.split("/").pop()!;
+    const byteLength = new TextEncoder().encode(basename).length;
+
+    // This particular filename is ~146 bytes, well within limits
+    // But verify the function handles it correctly either way
+    expect(byteLength).toBeLessThanOrEqual(255);
+    expect(result.startsWith("Документы/Library/")).toBe(true);
+  });
+
+  test("should preserve deep folder paths and only truncate basename", () => {
+    const longName = "x".repeat(300) + ".canvas";
+    const result = sanitizeFilePath(`a/b/c/d/${longName}`);
+    const parts = result.split("/");
+
+    expect(parts.slice(0, -1).join("/")).toBe("a/b/c/d");
+    expect(new TextEncoder().encode(parts[parts.length - 1]).length).toBeLessThanOrEqual(255);
+    expect(result.endsWith(".canvas")).toBe(true);
+  });
+
+  test("should handle file without extension", () => {
+    const longName = "a".repeat(300);
+    const result = sanitizeFilePath(longName);
+
+    expect(new TextEncoder().encode(result).length).toBeLessThanOrEqual(255);
+  });
+
+  test("should not break multi-byte characters when truncating", () => {
+    // 4-byte emoji characters: ensure we don't split in the middle
+    const longName = "\u{1F600}".repeat(80) + ".md"; // 80 emoji × 4 bytes = 320 bytes + .md
+    const result = sanitizeFilePath(longName);
+    const basename = result.split("/").pop()!;
+    const byteLength = new TextEncoder().encode(basename).length;
+
+    expect(byteLength).toBeLessThanOrEqual(255);
+    expect(result.endsWith(".md")).toBe(true);
+    // Ensure no broken characters (would result in replacement characters)
+    expect(result).not.toContain("\uFFFD");
   });
 });


### PR DESCRIPTION
## Summary
- Add `sanitizeFilePath()` utility to `src/utils.ts` that truncates overlong basenames to the 255-byte filesystem limit while preserving file extensions and multi-byte character boundaries (Cyrillic, emoji, etc.)
- Apply sanitization at the `writeToFileTool` entry point so both the bypass (auto-accept) and preview (ApplyView) flows receive the safe path
- Reuses existing `getUtf8ByteLength` / `truncateToByteLimit` utilities already used by `ChatPersistenceManager` for the same class of bug

Fixes the reported issue where the Composer tool crashes with `ENAMETOOLONG` on Linux (ext4) when the LLM generates a long filename, but Copilot reports successful completion.

## Test plan
- [x] 8 new unit tests for `sanitizeFilePath` covering ASCII overflow, Cyrillic, emoji, deep paths, extensionless files, and the exact bug report scenario
- [x] All 46 ComposerTools tests pass
- [x] Lint clean
- [x] Build succeeds
- [x] Codex review passed (P1 fix verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)