### PR TITLE
Add Miyo document parsing toggle and PDF parse-doc integration

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -905,7 +905,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   enableSemanticSearchV3: false,
   enableSelfHostMode: false,
   enableMiyoSearch: false,
-  enableMiyoDocumentParsing: false,
   selfHostModeValidatedAt: null,
   selfHostValidationCount: 0,
   selfHostUrl: "",

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -131,8 +131,6 @@ export interface CopilotSettings {
   enableSelfHostMode: boolean;
   /** Enable Miyo-backed indexing and semantic search when self-host mode is active */
   enableMiyoSearch: boolean;
-  /** Enable Miyo parse-doc for PDF parsing in non-project mode */
-  enableMiyoDocumentParsing: boolean;
   /** Timestamp of last successful Believer validation for self-host mode (null if never validated) */
   selfHostModeValidatedAt: number | null;
   /** Count of successful periodic validations (3 = permanently valid) */
@@ -412,11 +410,6 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   // Ensure enableMiyoSearch has a default value
   if (typeof sanitizedSettings.enableMiyoSearch !== "boolean") {
     sanitizedSettings.enableMiyoSearch = DEFAULT_SETTINGS.enableMiyoSearch;
-  }
-
-  // Ensure enableMiyoDocumentParsing has a default value
-  if (typeof sanitizedSettings.enableMiyoDocumentParsing !== "boolean") {
-    sanitizedSettings.enableMiyoDocumentParsing = DEFAULT_SETTINGS.enableMiyoDocumentParsing;
   }
 
   // Ensure selfHostSearchProvider is a valid value

--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -32,7 +32,6 @@ export const CopilotPlusSettings: React.FC = () => {
     } else {
       updateSetting("enableSelfHostMode", false);
       updateSetting("enableMiyoSearch", false);
-      updateSetting("enableMiyoDocumentParsing", false);
     }
   };
 
@@ -210,21 +209,10 @@ export const CopilotPlusSettings: React.FC = () => {
                 <>
                   <SettingItem
                     type="switch"
-                    title="Enable Miyo Search"
-                    description="Use Miyo as your local search engine and context hub — supports larger vaults than built-in Copilot search. Enabling this will prompt a one-time index refresh."
+                    title="Enable Miyo"
+                    description="Use Miyo as your local search, PDF parsing, and context hub. Enabling this will prompt a one-time index refresh."
                     checked={settings.enableMiyoSearch}
                     onCheckedChange={handleMiyoSearchToggle}
-                    disabled={isValidatingSelfHost}
-                  />
-
-                  <SettingItem
-                    type="switch"
-                    title="Enable Miyo Document Parsing"
-                    description="Use Miyo for document parsing in Copilot Plus. Currently PDF-only support; additional document formats are coming soon."
-                    checked={settings.enableMiyoDocumentParsing}
-                    onCheckedChange={(checked) =>
-                      updateSetting("enableMiyoDocumentParsing", checked)
-                    }
                     disabled={isValidatingSelfHost}
                   />
 

--- a/src/tools/FileParserManager.ts
+++ b/src/tools/FileParserManager.ts
@@ -58,7 +58,7 @@ class SelfHostPdfParser {
    */
   public async parsePdf(file: TFile, vault: Vault): Promise<string | null> {
     const settings = getSettings();
-    if (!settings.enableMiyoDocumentParsing || file.extension.toLowerCase() !== "pdf") {
+    if (!settings.enableMiyoSearch || file.extension.toLowerCase() !== "pdf") {
       return null;
     }
 
@@ -124,7 +124,7 @@ export class PDFParser implements FileParser {
       const settings = getSettings();
       if (
         isSelfHostModeValid() &&
-        settings.enableMiyoDocumentParsing &&
+        settings.enableMiyoSearch &&
         file.extension.toLowerCase() === "pdf"
       ) {
         const selfHostPdfContent = await this.selfHostPdfParser.parsePdf(file, vault);
@@ -136,12 +136,8 @@ export class PDFParser implements FileParser {
           return selfHostPdfContent;
         }
 
-        logError(`[PDFParser] Miyo document parsing enabled but parse-doc failed for ${file.path}`);
+        logError(`[PDFParser] Miyo enabled but parse-doc failed for ${file.path}`);
         return `[Error: Could not extract content from PDF ${file.basename}]`;
-      } else {
-        logInfo(`isSelfHostModeValid: ${isSelfHostModeValid()}`);
-        logInfo(`settings.enableMiyoDocumentParsing: ${settings.enableMiyoDocumentParsing}`);
-        logInfo(`file.extension: ${file.extension}`);
       }
 
       // If not in cache, read the file and call the API


### PR DESCRIPTION
## Summary
- add a new self-host setting: **Enable Miyo Document Parsing** (This is independent from **Miyo Search** )
- Route non-project PDF parsing through Miyo `/v0/parse-doc` when document parsing is enabled
- keep project-mode `Docs4LLMParser` behavior on `docs4llm`
- add `MiyoClient.parseDoc()` and unit tests

## Details
- Added `enableMiyoDocumentParsing` to settings model/defaults/sanitization.
- Added UI toggle under Self-Host Mode with note that only PDF is currently supported.
- In `PDFParser`, when self-host mode is valid and `enableMiyoDocumentParsing` is enabled, use Miyo parse-doc and return an error if parse-doc fails (no `pdf4llm` fallback in this mode).
- When the toggle is disabled, `PDFParser` uses existing `pdf4llm` flow.

## Validation
- `npm run lint -- src/constants.ts src/miyo/MiyoClient.ts src/settings/model.ts src/settings/v2/components/CopilotPlusSettings.tsx src/tools/FileParserManager.ts src/miyo/MiyoClient.test.ts`
- `npx jest src/miyo/MiyoClient.test.ts src/settings/model.test.ts --runInBand`
<img width="559" height="266" alt="Screenshot 2026-02-21 at 19 23 21" src="https://github.com/user-attachments/assets/9d84ff01-e10d-460f-8992-1039eb2fc1db" />


<img width="1026" height="495" alt="Screenshot 2026-02-21 at 19 22 04" src="https://github.com/user-attachments/assets/57fa33ee-8a30-482f-ad7d-a185d92a585a" />

