### PR TITLE
Rename enableMiyoSearch to enableMiyo and scope Miyo to Plus/agent chains

### DIFF
--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -38,7 +38,7 @@ const SELF_HOST_GRACE_PERIOD_MS = 15 * 24 * 60 * 60 * 1000;
  * @returns True when Miyo mode and self-host validation are active.
  */
 function shouldUseMiyoIndex(settings: CopilotSettings): boolean {
-  if (!settings.enableMiyoSearch || !settings.enableSemanticSearchV3) {
+  if (!settings.enableMiyo || !settings.enableSemanticSearchV3) {
     return false;
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -904,7 +904,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   enableCustomPromptTemplating: true,
   enableSemanticSearchV3: false,
   enableSelfHostMode: false,
-  enableMiyoSearch: false,
+  enableMiyo: false,
   selfHostModeValidatedAt: null,
   selfHostValidationCount: 0,
   selfHostUrl: "",

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -282,7 +282,7 @@ export async function validateSelfHostMode(): Promise<boolean> {
  */
 export async function refreshSelfHostModeValidation(): Promise<void> {
   const settings = getSettings();
-  if (!settings.enableSelfHostMode && !settings.enableMiyoSearch) {
+  if (!settings.enableSelfHostMode && !settings.enableMiyo) {
     return;
   }
 
@@ -318,7 +318,7 @@ export async function refreshSelfHostModeValidation(): Promise<void> {
     } else {
       // User is no longer on an eligible plan, disable self-host mode
       updateSetting("enableSelfHostMode", false);
-      updateSetting("enableMiyoSearch", false);
+      updateSetting("enableMiyo", false);
       updateSetting("selfHostModeValidatedAt", null);
       updateSetting("selfHostValidationCount", 0);
       logInfo("Self-host mode disabled - user is no longer on an eligible plan");

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -87,7 +87,7 @@ describe("findRelevantNotes", () => {
     mockedGetSettings.mockReturnValue({
       debug: false,
       selfHostUrl: "",
-      enableMiyoSearch: false,
+      enableMiyo: false,
       enableSemanticSearchV3: false,
       selfHostModeValidatedAt: null,
       selfHostValidationCount: 0,
@@ -173,7 +173,7 @@ describe("findRelevantNotes", () => {
     mockedGetSettings.mockReturnValue({
       debug: false,
       selfHostUrl: "http://127.0.0.1:8742",
-      enableMiyoSearch: true,
+      enableMiyo: true,
       enableSemanticSearchV3: true,
       selfHostModeValidatedAt: Date.now(),
       selfHostValidationCount: 0,
@@ -221,7 +221,7 @@ describe("findRelevantNotes", () => {
     mockedGetSettings.mockReturnValue({
       debug: false,
       selfHostUrl: "http://127.0.0.1:8742",
-      enableMiyoSearch: true,
+      enableMiyo: true,
       enableSemanticSearchV3: true,
       selfHostModeValidatedAt: Date.now(),
       selfHostValidationCount: 0,

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -21,7 +21,7 @@ const SELF_HOST_GRACE_PERIOD_MS = 15 * 24 * 60 * 60 * 1000;
  */
 function shouldUseMiyoForRelevantNotes(): boolean {
   const settings = getSettings();
-  if (!settings.enableMiyoSearch || !settings.enableSemanticSearchV3) {
+  if (!settings.enableMiyo || !settings.enableSemanticSearchV3) {
     return false;
   }
 

--- a/src/search/miyo/MiyoSemanticRetriever.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.ts
@@ -147,11 +147,13 @@ export class MiyoSemanticRetriever extends BaseRetriever {
       metadata.chunkId ||
       (result.chunk_index !== undefined ? `${result.path}#${result.chunk_index}` : undefined);
 
+    const score = typeof result.score === "number" ? result.score.toFixed(2) : "?";
     return new Document({
       pageContent: result.chunk_text ?? "",
       metadata: {
         ...metadata,
         score: result.score,
+        explanation: `miyo ${score}`,
         path: result.path,
         mtime: result.mtime,
         ctime: result.ctime,

--- a/src/search/vectorStoreManager.ts
+++ b/src/search/vectorStoreManager.ts
@@ -207,7 +207,7 @@ export default class VectorStoreManager {
    * @returns True when Miyo should be the active backend.
    */
   private shouldUseMiyo(settings: CopilotSettings): boolean {
-    return settings.enableMiyoSearch && settings.enableSemanticSearchV3 && isSelfHostAccessValid();
+    return settings.enableMiyo && settings.enableSemanticSearchV3 && isSelfHostAccessValid();
   }
 
   /**
@@ -255,7 +255,7 @@ export default class VectorStoreManager {
     if (
       prevSettings &&
       settings.enableSemanticSearchV3 &&
-      settings.enableMiyoSearch !== prevSettings.enableMiyoSearch
+      settings.enableMiyo !== prevSettings.enableMiyo
     ) {
       logInfo("VectorStoreManager: Miyo backend toggled; reindex recommended.");
     }

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -130,7 +130,7 @@ export interface CopilotSettings {
   /** Enable self-host mode (e.g., Miyo) - uses self-hosted services for search, LLMs, OCR, etc. */
   enableSelfHostMode: boolean;
   /** Enable Miyo-backed indexing and semantic search when self-host mode is active */
-  enableMiyoSearch: boolean;
+  enableMiyo: boolean;
   /** Timestamp of last successful Believer validation for self-host mode (null if never validated) */
   selfHostModeValidatedAt: number | null;
   /** Count of successful periodic validations (3 = permanently valid) */
@@ -407,9 +407,9 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
     sanitizedSettings.generateAIChatTitleOnSave = DEFAULT_SETTINGS.generateAIChatTitleOnSave;
   }
 
-  // Ensure enableMiyoSearch has a default value
-  if (typeof sanitizedSettings.enableMiyoSearch !== "boolean") {
-    sanitizedSettings.enableMiyoSearch = DEFAULT_SETTINGS.enableMiyoSearch;
+  // Ensure enableMiyo has a default value
+  if (typeof sanitizedSettings.enableMiyo !== "boolean") {
+    sanitizedSettings.enableMiyo = DEFAULT_SETTINGS.enableMiyo;
   }
 
   // Ensure selfHostSearchProvider is a valid value

--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -32,7 +32,7 @@ export const CopilotPlusSettings: React.FC = () => {
       updateSetting("enableSelfHostMode", true);
     } else {
       updateSetting("enableSelfHostMode", false);
-      updateSetting("enableMiyoSearch", false);
+      updateSetting("enableMiyo", false);
     }
   };
 
@@ -42,12 +42,12 @@ export const CopilotPlusSettings: React.FC = () => {
    * @param enabled - Whether Miyo search should be enabled.
    */
   const handleMiyoSearchToggle = async (enabled: boolean) => {
-    if (enabled === settings.enableMiyoSearch) {
+    if (enabled === settings.enableMiyo) {
       return;
     }
 
     if (!enabled) {
-      updateSetting("enableMiyoSearch", false);
+      updateSetting("enableMiyo", false);
       return;
     }
 
@@ -75,7 +75,7 @@ export const CopilotPlusSettings: React.FC = () => {
         updateSetting("embeddingBatchSize", DEFAULT_SETTINGS.embeddingBatchSize);
       }
 
-      updateSetting("enableMiyoSearch", enabled);
+      updateSetting("enableMiyo", enabled);
 
       if (enabled && !settings.enableSemanticSearchV3) {
         updateSetting("enableSemanticSearchV3", true);
@@ -216,7 +216,7 @@ export const CopilotPlusSettings: React.FC = () => {
                     type="switch"
                     title="Enable Miyo"
                     description="Use Miyo as your local search, PDF parsing, and context hub. Enabling this will prompt a one-time index refresh."
-                    checked={settings.enableMiyoSearch}
+                    checked={settings.enableMiyo}
                     onCheckedChange={handleMiyoSearchToggle}
                     disabled={isValidatingSelfHost}
                   />

--- a/src/settings/v2/components/QASettings.tsx
+++ b/src/settings/v2/components/QASettings.tsx
@@ -13,7 +13,7 @@ import { PatternListEditor } from "@/settings/v2/components/PatternListEditor";
 
 export const QASettings: React.FC = () => {
   const settings = useSettingsValue();
-  const isMiyoSearchActive = settings.enableMiyoSearch;
+  const isMiyoSearchActive = settings.enableMiyo;
   const visibleEmbeddingModels = settings.activeEmbeddingModels;
 
   const handleSetDefaultEmbeddingModel = async (modelKey: string) => {
@@ -56,8 +56,8 @@ export const QASettings: React.FC = () => {
                 app,
                 async () => {
                   updateSetting("enableSemanticSearchV3", checked);
-                  if (!checked && settings.enableMiyoSearch) {
-                    updateSetting("enableMiyoSearch", false);
+                  if (!checked && settings.enableMiyo) {
+                    updateSetting("enableMiyo", false);
                   }
                   if (checked) {
                     const VectorStoreManager = (await import("@/search/vectorStoreManager"))

--- a/src/tools/FileParserManager.ts
+++ b/src/tools/FileParserManager.ts
@@ -58,7 +58,7 @@ class SelfHostPdfParser {
    */
   public async parsePdf(file: TFile, vault: Vault): Promise<string | null> {
     const settings = getSettings();
-    if (!settings.enableMiyoSearch || file.extension.toLowerCase() !== "pdf") {
+    if (!settings.enableMiyo || file.extension.toLowerCase() !== "pdf") {
       return null;
     }
 
@@ -122,11 +122,7 @@ export class PDFParser implements FileParser {
       }
 
       const settings = getSettings();
-      if (
-        isSelfHostModeValid() &&
-        settings.enableMiyoSearch &&
-        file.extension.toLowerCase() === "pdf"
-      ) {
+      if (isSelfHostModeValid() && settings.enableMiyo && file.extension.toLowerCase() === "pdf") {
         const selfHostPdfContent = await this.selfHostPdfParser.parsePdf(file, vault);
         if (selfHostPdfContent !== null) {
           await this.pdfCache.set(file, {


### PR DESCRIPTION
## Summary
- Rename `enableMiyoSearch` setting flag to `enableMiyo` across all 13 files (settings, UI, search, utils)
- Skip fulltext search path in `performLexicalSearch` (Plus/agent chains) when Miyo is active — `filterRetriever` still runs for tag/title matching
- VaultQA chain now explicitly bypasses Miyo via `{ enableMiyo: false }` settings override to `RetrieverFactory.createRetriever`
- Expose `RetrieverFactory.isMiyoActive()` public static method for clean Miyo-state checks

## Test plan
- [x] All 1666 unit tests pass (including findRelevantNotes Miyo tests)
- [x] Verify Miyo-enabled Plus chat skips local fulltext search, filterRetriever still returns tag/title matches
- [x] Verify VaultQA chain never routes through Miyo backend regardless of enableMiyo setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)