### PR TITLE
fix: update 'upcoming desktop app' to 'our desktop app Miyo'

### DIFF
--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -181,8 +181,8 @@ export const CopilotPlusSettings: React.FC = () => {
                 description={
                   <div className="tw-flex tw-items-center tw-gap-1.5">
                     <span className="tw-leading-none">
-                      Use your own infrastructure for LLMs, embeddings (and local document
-                      understanding soon with our upcoming desktop app).
+                      Use your own infrastructure for LLMs, embeddings and local document
+                      understanding with our desktop app Miyo.
                     </span>
                     <HelpTooltip
                       content={


### PR DESCRIPTION
## Summary
- Updated self-host mode description in Copilot Plus settings to reflect that Miyo is no longer upcoming but released
- Changed "upcoming desktop app" to "our desktop app Miyo"

## Test plan
- [x] All 90 test suites pass (1671 tests)
- [x] Verify the updated text displays correctly in Copilot Plus settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)