### PR TITLE
Add cross-platform Miyo service discovery with Windows Roaming fallback

### DIFF
--- a/src/miyo/MiyoServiceDiscovery.ts
+++ b/src/miyo/MiyoServiceDiscovery.ts
@@ -62,7 +62,7 @@ export class MiyoServiceDiscovery {
     const serviceConfig = await this.readServiceConfig();
     if (serviceConfig === "missing") {
       const fallbackBaseUrl = this.getDefaultBaseUrl();
-      this.cachedBaseUrl = fallbackBaseUrl;
+      this.cachedBaseUrl = null;
       if (getSettings().debug) {
         logInfo(`Miyo service discovery file missing; using fallback ${fallbackBaseUrl}`);
       }


### PR DESCRIPTION
Summary: add platform-aware Miyo service discovery for macOS, Windows, and Linux; try Windows Local then Roaming; fallback to http://127.0.0.1:8742 only when discovery files are missing (ENOENT); add tests for all paths and fallback order. Validation: npm run format, npm run lint, npx jest src/miyo/MiyoServiceDiscovery.test.ts --runInBand.


## Test

* Tested on Windows and observed Obsidian connected to Miyo for indexing and searching.
* Tested on Mac and observed Obsidian connected to Miyo for indexing and searching.