### PR TITLE
Remove emoji from FAQ link url in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is the future we believe in. If you share this vision, please support this 
   - [Free User](#free-user)
   - [Copilot Plus/Believer](#copilot-plusbeliever)
 - [Need Help?](#need-help)
-- [FAQ](#️faq)
+- [FAQ](#faq)
 
 ## Copilot V3 is a New Era 🔥
 


### PR DESCRIPTION
This PR corrects a broken link in the README Table of Contents.

The FAQ link contained an unintended Unicode character in the anchor (`#️faq`), which prevented the link from resolving to the FAQ section. The selector has been removed so the link now correctly targets `#faq`.

Only this link has been updated.
