### PR TITLE
feat: add configurable output folder for converted document markdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,17 @@ For detailed architecture diagrams and documentation, see [`MESSAGE_ARCHITECTURE
 - Test files adjacent to implementation (`.test.ts`)
 - Use `@testing-library/react` for component testing
 
+### Avoiding Deep Dependency Chains in Tests
+
+This codebase has deep transitive import chains (e.g. a utility → cache → searchUtils → embeddingManager → brevilabsClient → plusUtils → Modal). Importing any module in this chain from a test requires mocking the entire tree, which is brittle and verbose.
+
+**Rules for new code:**
+
+1. **Pass data, not services** — If a function only needs a string (like `outputFolder`), accept it as a parameter. Don't give it access to the entire settings singleton.
+2. **Singletons at the edges only** — `getSettings()`, `PDFCache.getInstance()`, `BrevilabsClient.getInstance()` should only be called in top-level orchestration (constructors, main entry points). Inner functions receive what they need as parameters.
+3. **Pure logic in leaf modules** — Extract testable logic into small files with minimal imports. The orchestration file (which has heavy imports) calls the leaf function and passes in the dependencies. See `src/tools/convertedDocOutput.ts` as an example.
+4. **Litmus test before writing a function** — "Can I test this by calling it directly with plain arguments?" If the answer is no because of an import, that dependency should be a parameter instead.
+
 ## Development Session Planning
 
 ### Using TODO.md for Session Management

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_CHAT_HISTORY_FOLDER = `${COPILOT_FOLDER_ROOT}/copilot-conve
 export const DEFAULT_CUSTOM_PROMPTS_FOLDER = `${COPILOT_FOLDER_ROOT}/copilot-custom-prompts`;
 export const DEFAULT_MEMORY_FOLDER = `${COPILOT_FOLDER_ROOT}/memory`;
 export const DEFAULT_SYSTEM_PROMPTS_FOLDER = `${COPILOT_FOLDER_ROOT}/system-prompts`;
+export const DEFAULT_CONVERTED_DOC_OUTPUT_FOLDER = "";
 export const DEFAULT_QA_EXCLUSIONS_SETTING = COPILOT_FOLDER_ROOT;
 export const DEFAULT_SYSTEM_PROMPT = `You are Obsidian Copilot, a helpful assistant that integrates AI to Obsidian note-taking.
   1. Never mention that you do not have access to something. Always rely on the user provided context.
@@ -941,6 +942,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   userSystemPromptsFolder: DEFAULT_SYSTEM_PROMPTS_FOLDER,
   defaultSystemPromptTitle: "",
   autoCompactThreshold: 128000,
+  convertedDocOutputFolder: DEFAULT_CONVERTED_DOC_OUTPUT_FOLDER,
 };
 
 export const EVENT_NAMES = {

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -407,6 +407,9 @@ export class MiyoClient {
       ...(getSettings().debug && options.method === "POST" ? { postBody: options.body } : {}),
     });
 
+    // TODO: Add a configurable timeout for large file parsing (e.g. big PDFs).
+    // Obsidian's requestUrl does not expose a timeout option, so consider using
+    // AbortController or a wrapper with Promise.race to prevent indefinite hangs.
     const response = await requestUrl({
       url: url.toString(),
       method: options.method,

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -193,6 +193,8 @@ export interface CopilotSettings {
   defaultSystemPromptTitle: string;
   /** Token threshold for auto-compacting large context (range: 64k-1M tokens, default: 128000) */
   autoCompactThreshold: number;
+  /** Folder where converted document markdown files are saved */
+  convertedDocOutputFolder: string;
 }
 
 export const settingsStore = createStore();

--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -122,6 +122,19 @@ export const CopilotPlusSettings: React.FC = () => {
             </>
           )}
 
+          <div className="tw-pt-4 tw-text-xl tw-font-semibold">Document Processor</div>
+
+          <SettingItem
+            type="text"
+            title="Store converted markdown at"
+            description="When PDFs and other documents are processed, the converted markdown is saved to this folder. Leave empty to skip saving."
+            value={settings.convertedDocOutputFolder}
+            onChange={(value) => {
+              updateSetting("convertedDocOutputFolder", value);
+            }}
+            placeholder="e.g. copilot/converteddocs"
+          />
+
           <div className="tw-pt-4 tw-text-xl tw-font-semibold">Memory (experimental)</div>
 
           <SettingItem

--- a/src/utils/convertedDocOutput.test.ts
+++ b/src/utils/convertedDocOutput.test.ts
@@ -1,0 +1,153 @@
+import { TFile, Vault } from "obsidian";
+import { saveConvertedDocOutput } from "./convertedDocOutput";
+
+jest.mock("@/utils", () => ({
+  ensureFolderExists: jest.fn(),
+}));
+
+jest.mock("@/logger", () => ({
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+  logError: jest.fn(),
+}));
+
+jest.mock("obsidian", () => ({
+  TFile: class {},
+  Vault: class {},
+}));
+
+function makeTFile(path: string): TFile {
+  const parts = path.split("/");
+  const filename = parts[parts.length - 1];
+  const basename = filename.replace(/\.[^.]+$/, "");
+  const extension = filename.split(".").pop() ?? "";
+  return { path, basename, extension } as unknown as TFile;
+}
+
+function makeVaultAdapter() {
+  const files: Record<string, string> = {};
+  return {
+    files,
+    exists: jest.fn(async (p: string) => p in files),
+    read: jest.fn(async (p: string) => files[p] ?? ""),
+    write: jest.fn(async (p: string, content: string) => {
+      files[p] = content;
+    }),
+  };
+}
+
+function makeVault(adapter: ReturnType<typeof makeVaultAdapter>): Vault {
+  return { adapter } as unknown as Vault;
+}
+
+describe("saveConvertedDocOutput", () => {
+  it("no-ops when outputFolder is empty", async () => {
+    const adapter = makeVaultAdapter();
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(makeTFile("docs/report.pdf"), "content", vault, "");
+    expect(adapter.write).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when outputFolder is whitespace", async () => {
+    const adapter = makeVaultAdapter();
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(makeTFile("docs/report.pdf"), "content", vault, "   ");
+    expect(adapter.write).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when file is markdown", async () => {
+    const adapter = makeVaultAdapter();
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(makeTFile("notes/note.md"), "content", vault, "output");
+    expect(adapter.write).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when content is empty", async () => {
+    const adapter = makeVaultAdapter();
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(makeTFile("docs/report.pdf"), "", vault, "output");
+    expect(adapter.write).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when content is an error string", async () => {
+    const adapter = makeVaultAdapter();
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(
+      makeTFile("docs/report.pdf"),
+      "[Error: something failed]",
+      vault,
+      "output"
+    );
+    expect(adapter.write).not.toHaveBeenCalled();
+  });
+
+  it("writes {basename}.md with source header", async () => {
+    const adapter = makeVaultAdapter();
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(makeTFile("docs/report.pdf"), "parsed markdown", vault, "output");
+    expect(adapter.write).toHaveBeenCalledWith(
+      "output/report.md",
+      "<!-- source: docs/report.pdf -->\nparsed markdown"
+    );
+  });
+
+  it("skips write when existing file has identical content", async () => {
+    const adapter = makeVaultAdapter();
+    adapter.files["output/report.md"] = "<!-- source: docs/report.pdf -->\nparsed markdown";
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(makeTFile("docs/report.pdf"), "parsed markdown", vault, "output");
+    expect(adapter.write).not.toHaveBeenCalled();
+  });
+
+  it("overwrites when same source but content changed", async () => {
+    const adapter = makeVaultAdapter();
+    adapter.files["output/report.md"] = "<!-- source: docs/report.pdf -->\nold content";
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(makeTFile("docs/report.pdf"), "new content", vault, "output");
+    expect(adapter.write).toHaveBeenCalledWith(
+      "output/report.md",
+      "<!-- source: docs/report.pdf -->\nnew content"
+    );
+  });
+
+  it("disambiguates with __ separator when basename collides with different source", async () => {
+    const adapter = makeVaultAdapter();
+    adapter.files["output/report.md"] = "<!-- source: other/report.pdf -->\nother content";
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(makeTFile("docs/report.pdf"), "my content", vault, "output");
+    expect(adapter.write).toHaveBeenCalledWith(
+      "output/docs__report.md",
+      "<!-- source: docs/report.pdf -->\nmy content"
+    );
+  });
+
+  it("skips when disambiguated path also collides with different source", async () => {
+    const adapter = makeVaultAdapter();
+    adapter.files["output/report.md"] = "<!-- source: other/report.pdf -->\nother";
+    adapter.files["output/docs__report.md"] =
+      "<!-- source: yet-another/docs__report.pdf -->\nyet another";
+    const vault = makeVault(adapter);
+    await saveConvertedDocOutput(makeTFile("docs/report.pdf"), "my content", vault, "output");
+    expect(adapter.write).not.toHaveBeenCalled();
+  });
+
+  it("__ separator distinguishes a/b/x.pdf from a_b/x.pdf", async () => {
+    // a/b/x.pdf
+    const adapter1 = makeVaultAdapter();
+    adapter1.files["output/x.md"] = "<!-- source: other/x.pdf -->\nother";
+    const vault1 = makeVault(adapter1);
+    await saveConvertedDocOutput(makeTFile("a/b/x.pdf"), "content1", vault1, "output");
+
+    // a_b/x.pdf
+    const adapter2 = makeVaultAdapter();
+    adapter2.files["output/x.md"] = "<!-- source: other/x.pdf -->\nother";
+    const vault2 = makeVault(adapter2);
+    await saveConvertedDocOutput(makeTFile("a_b/x.pdf"), "content2", vault2, "output");
+
+    const path1 = adapter1.write.mock.calls[0][0];
+    const path2 = adapter2.write.mock.calls[0][0];
+    expect(path1).toBe("output/a__b__x.md");
+    expect(path2).toBe("output/a_b__x.md");
+    expect(path1).not.toBe(path2);
+  });
+});

--- a/src/utils/convertedDocOutput.ts
+++ b/src/utils/convertedDocOutput.ts
@@ -1,0 +1,70 @@
+import { logError, logInfo, logWarn } from "@/logger";
+import { ensureFolderExists } from "@/utils";
+import { TFile, Vault } from "obsidian";
+
+/**
+ * Save converted document content to the specified output folder.
+ * Uses flat naming: {basename}.md, disambiguating with double-underscore
+ * path flattening on collision. No-op when outputFolder is empty, content
+ * is empty/error, or source is already markdown.
+ *
+ * @param file - Source file that was converted.
+ * @param content - Converted markdown content.
+ * @param vault - Obsidian vault instance.
+ * @param outputFolder - Target folder path (empty string = disabled).
+ */
+export async function saveConvertedDocOutput(
+  file: TFile,
+  content: string,
+  vault: Vault,
+  outputFolder: string
+): Promise<void> {
+  const trimmed = outputFolder?.trim();
+  if (!trimmed) return;
+
+  // Skip markdown files — they don't need conversion output
+  if (file.extension === "md") return;
+
+  // Skip empty or error content
+  if (!content || content.startsWith("[Error:")) return;
+
+  try {
+    await ensureFolderExists(trimmed);
+
+    let outputPath = `${trimmed}/${file.basename}.md`;
+
+    // Disambiguate if a file with the same name already exists from a different source
+    if (await vault.adapter.exists(outputPath)) {
+      const existing = await vault.adapter.read(outputPath);
+      if (existing && !existing.startsWith(`<!-- source: ${file.path} -->`)) {
+        // Use full path to guarantee uniqueness even when path separators
+        // were part of the original folder name (e.g. a/b/x.pdf vs a_b/x.pdf)
+        const safePath = file.path.replace(/\.[^.]+$/, "").replace(/[/\\]/g, "__");
+        outputPath = `${trimmed}/${safePath}.md`;
+
+        // Final guard: if the disambiguated path also exists from a different source, skip
+        if (await vault.adapter.exists(outputPath)) {
+          const existingDisambig = await vault.adapter.read(outputPath);
+          if (existingDisambig && !existingDisambig.startsWith(`<!-- source: ${file.path} -->`)) {
+            logWarn(`Skipping converted doc output for ${file.path}: collision at ${outputPath}`);
+            return;
+          }
+        }
+      }
+    }
+
+    // Prepend source path as a comment for traceability and collision detection
+    const outputContent = `<!-- source: ${file.path} -->\n${content}`;
+
+    // Skip write when content is unchanged to avoid mtime churn and re-indexing
+    if (await vault.adapter.exists(outputPath)) {
+      const existing = await vault.adapter.read(outputPath);
+      if (existing === outputContent) return;
+    }
+
+    await vault.adapter.write(outputPath, outputContent);
+    logInfo(`Saved converted doc output: ${outputPath}`);
+  } catch (error) {
+    logError(`Failed to save converted doc output for ${file.path}:`, error);
+  }
+}


### PR DESCRIPTION
## Summary

- **Configurable output folder for converted docs**: New "Store converted markdown at" setting under Document Processor (Copilot Plus). When set, converted markdown from pdf4llm/docs4llm is saved to the specified vault folder with readable flat naming (`{basename}.md`). Empty = disabled. Suggested path: `copilot/converteddocs` (already excluded from indexing by default via `qaExclusions`).
- **Miyo PDF routing in project mode**: PDFs are now routed through Miyo's `parse-doc` endpoint in project mode when self-host is enabled, not just in non-project mode.
- **Self-host privacy preservation**: When Miyo fails to parse a PDF in self-host mode, we never fall back to the cloud API. In project mode (`Docs4LLMParser`) this throws so `executeWithProcessTracking` correctly marks the file as failed/retriable. In non-project mode (`PDFParser`) it returns an error string to the chat.
- **MiyoParseResult type**: Replaces the previous `string | null` return with a discriminated union (`null | {content} | {error}`) so Miyo error details (empty text, network failure, path issues) propagate to the user instead of generic messages.
- **Content-dedup on write**: `saveConvertedDocOutput` compares existing file content before writing, preventing mtime churn that triggers re-indexing/sync on every project refresh.
- **Cache-hit export**: All cache-hit paths (PDFParser, Docs4LLMParser, ProjectManager) now trigger `saveConvertedDocOutput`, so enabling the setting retroactively works without clearing caches.
- **Collision handling**: Double-underscore (`__`) path separator for disambiguation, with source-header verification and a final guard against overwrites.
- **TODO comments**: Request timeout in MiyoClient, batch progress feedback in ProjectManager.

## Test plan

- [x] All 1678 unit tests pass
- [x] Enable "Store converted markdown at" with `copilot/converteddocs`, process a PDF — verify `.md` file appears with `<!-- source: ... -->` header
- [x] Change the setting path, reprocess — verify output appears in new location
- [x] Leave setting empty — verify no output files created
- [x] Enable self-host + Miyo, process a normal PDF — verify Miyo is used
- [ ] Enable self-host + Miyo, process a failing PDF — verify error thrown (no cloud fallback), file marked as failed in project load tracker
- [x] Disable self-host, process a PDF — verify pdf4llm cloud API is used as before
- [ ] Process two PDFs with same basename from different folders — verify disambiguation naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)