### PR TITLE
fix: log Miyo health check status and remove debug guard on availability failure

### DIFF
--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -166,11 +166,13 @@ export class MiyoClient {
       const health = await this.requestJson<{ status?: string }>(baseUrl, "/v0/health", {
         method: "GET",
       });
-      return health?.status === "ok";
-    } catch (error) {
-      if (getSettings().debug) {
-        logWarn(`Miyo backend availability check failed: ${err2String(error)}`);
+      if (health?.status !== "ok") {
+        logWarn(`Miyo health check failed: status="${health?.status ?? "unknown"}"`);
+        return false;
       }
+      return true;
+    } catch (error) {
+      logWarn(`Miyo backend availability check failed: ${err2String(error)}`);
       return false;
     }
   }


### PR DESCRIPTION
## Summary

- When Miyo returns a non-`"ok"` status (e.g. `"degraded"`), `isBackendAvailable` was silently returning `false` with no log output
- This caused users to see the \"Miyo app is not available\" notification even when the health endpoint was reachable and returning a valid response
- The pre-request log (`Miyo request: GET /v0/health`) made users think the health check passed, while the actual status check failed silently

## Changes

- Log the actual health status unconditionally when it is not `"ok"`, e.g. `Miyo health check failed: status="degraded"`
- Remove the `debug`-only guard from the catch block so network/connection errors are always surfaced in logs

## Test plan

- [ ] Enable Miyo toggle when Miyo is running with `status: "ok"` → should succeed as before
- [ ] Enable Miyo toggle when Miyo returns `status: "degraded"` → should show notification AND log `Miyo health check failed: status="degraded"`
- [ ] Enable Miyo toggle when Miyo is not running → should show notification AND log the connection error

🤖 Generated with [Claude Code](https://claude.com/claude-code)