### PR TITLE
fix: replace Node.js Buffer with cross-platform TextEncoder for mobile indexing

### DIFF
--- a/src/search/v3/chunks.ts
+++ b/src/search/v3/chunks.ts
@@ -2,6 +2,7 @@ import { logInfo, logWarn } from "@/logger";
 import { CHUNK_SIZE } from "@/constants";
 import { App, TFile } from "obsidian";
 import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+import { MemoryManager } from "./utils/MemoryManager";
 
 /**
  * Chunk interface for unified search system
@@ -558,7 +559,7 @@ export class ChunkManager {
    */
   private calculateChunkBytes(chunks: Chunk[]): number {
     return chunks.reduce((total, chunk) => {
-      return total + Buffer.byteLength(chunk.content, "utf8");
+      return total + MemoryManager.getByteSize(chunk.content);
     }, 0);
   }
 

--- a/src/search/v3/engines/FullTextEngine.ts
+++ b/src/search/v3/engines/FullTextEngine.ts
@@ -179,7 +179,7 @@ export class FullTextEngine {
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
 
-      const contentSize = Buffer.byteLength(chunk.content, "utf8");
+      const contentSize = MemoryManager.getByteSize(chunk.content);
       if (!this.memoryManager.canAddContent(contentSize)) {
         logInfo(`FullTextEngine: Memory limit reached at ${indexed} chunks`);
         break;


### PR DESCRIPTION
## Summary
- Indexing fails on Obsidian mobile (Android/iOS) with `ReferenceError: Buffer is not defined` because `Buffer.byteLength()` is a Node.js API unavailable in mobile WebView environments
- Replaced `Buffer.byteLength(str, "utf8")` with the existing `MemoryManager.getByteSize(str)` helper (uses cross-platform `TextEncoder`) in `chunks.ts` and `FullTextEngine.ts`

## Test plan
- [x] All 1689 unit tests pass
- [x] Production build succeeds
- [ ] Verify indexing works on Android/iOS Obsidian mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)