### PR TITLE
fix: restore Ctrl+Enter text-replacement shortcut in command modal

### DIFF
--- a/src/components/command-ui/action-buttons.tsx
+++ b/src/components/command-ui/action-buttons.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Platform } from "obsidian";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
@@ -43,10 +44,19 @@ export function ActionButtons({
       {/* Insert/Replace buttons on result */}
       {state === "result" && showInsertReplace && (
         <>
-          <Button size="sm" variant="secondary" onClick={onInsert}>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={onInsert}
+            title={`Insert below selection (${Platform.isMacOS ? "⌘" : "Ctrl"}+Shift+Enter)`}
+          >
             Insert
           </Button>
-          <Button size="sm" onClick={onReplace}>
+          <Button
+            size="sm"
+            onClick={onReplace}
+            title={`Replace selection (${Platform.isMacOS ? "⌘" : "Ctrl"}+Enter)`}
+          >
             Replace
           </Button>
         </>


### PR DESCRIPTION
## Summary
- Restores `Ctrl+Enter` (Replace) and `Ctrl+Shift+Enter` (Insert) keyboard shortcuts that were lost during the Quick Ask floating panel refactor
- Adds tooltip hints on Insert/Replace buttons showing the keyboard shortcuts
- Properly scopes the listener to the modal's `ownerDocument` for popout window support and to the focused modal to prevent cross-modal firing

Fixes #2219

## Test plan
- [ ] Select text in editor, run a custom command (e.g. Summarize), wait for result
- [ ] Press `Ctrl+Enter` (Win/Linux) or `Cmd+Enter` (Mac) — should replace selected text
- [ ] Press `Ctrl+Shift+Enter` (Win/Linux) or `Cmd+Shift+Enter` (Mac) — should insert below
- [ ] Hover over Insert/Replace buttons — should show shortcut hints in tooltip
- [ ] Verify shortcuts don't fire while AI is still streaming
- [ ] If using Obsidian popout windows, verify shortcuts work there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)