### PR TITLE
fix: chat panel table rendering and third-party plugin compatibility

### DIFF
--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -41,7 +41,10 @@ jest.mock("obsidian", () => {
     MarkdownRenderer: {
       renderMarkdown,
     },
-    Component: class {},
+    Component: class {
+      load() {}
+      unload() {}
+    },
     MarkdownView: class {},
     TFile: class {},
     App: class {},

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -538,6 +538,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
       // Create a new Component instance if it doesn't exist
       if (!componentRef.current) {
         componentRef.current = new Component();
+        componentRef.current.load();
       }
 
       // Capture open states of collapsible sections before re-rendering

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -379,8 +379,20 @@ If your plugin does not need CSS, delete this file.
 }
 
 .message-content table {
+  border-collapse: collapse;
   margin-top: 15px;
   margin-bottom: 15px;
+}
+
+.message-content th,
+.message-content td {
+  padding: var(--size-2-2) var(--size-4-2);
+  border: var(--table-border-width) solid var(--table-border-color);
+}
+
+.message-content th {
+  font-weight: var(--table-header-weight);
+  background-color: var(--table-header-background);
 }
 
 /* Style for inline code */


### PR DESCRIPTION
### issues
- #2205

### Summary                                                                                                      
                                       
- Call `Component.load()` after creating the `Component` instance used for `MarkdownRenderer.renderMarkdown()` in
 `ChatSingleMessage`, so that Obsidian post-processor children (e.g. `advanced-table-xt`'s `SheetElement`) can
properly execute their `onload()` lifecycle. Without this, the post-processor empties the original table via
`tableEl.empty()` but the rebuild never runs, causing table content to disappear entirely.
- Add table border, padding, and header styles to `.message-content` to match Obsidian's native table appearance.
 Previously, tables in the chat panel had no visible borders or cell separation because the rendering container
does not use the `markdown-rendered` class (intentionally, to keep compact chat layout).

### Test plan

- [ ] Enable `advanced-table-xt` (or similar table post-processor plugin), send a message that produces a
markdown table in the chat panel — table content should render correctly
- [ ] Disable `advanced-table-xt`, verify tables in chat panel now have proper borders and header styling
- [ ] Verify Quick Chat panel tables are unaffected
- [ ] Verify other markdown elements (code blocks, lists, links) render correctly in chat panel