### PR TITLE
fix: skip redundant eligibility check when enabling Miyo

### DIFF
--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -59,11 +59,6 @@ export const CopilotPlusSettings: React.FC = () => {
         new Notice("Miyo app is not available. Please start the Miyo app and try again.");
         return;
       }
-
-      const isValid = await validateSelfHostMode();
-      if (!isValid) {
-        return;
-      }
     } finally {
       setIsValidatingSelfHost(false);
     }


### PR DESCRIPTION
## Summary

- When a user enables Self-Host Mode, `validateSelfHostMode()` is called and eligibility is confirmed before `enableSelfHostMode` is set to `true`
- The Miyo toggle is only rendered when `settings.enableSelfHostMode` is `true`, so by the time a user can toggle Miyo on, they've already passed the eligibility check
- Removed the redundant `validateSelfHostMode()` call from `handleMiyoSearchToggle` — the only check still needed is `isBackendAvailable` to confirm the Miyo app process is running

## Test plan

- [ ] Enable Self-Host Mode → eligibility check runs once (expected)
- [ ] Enable Miyo → no second eligibility check, only checks if Miyo app is running
- [ ] Disabling and re-enabling Miyo does not trigger another API validation call
- [ ] Disabling Self-Host Mode still disables Miyo as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)