### PR TITLE
Fix Add Custom Chat Model action button crowding

### DIFF
--- a/src/settings/v2/components/ModelAddDialog.tsx
+++ b/src/settings/v2/components/ModelAddDialog.tsx
@@ -670,7 +670,7 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
 
         <div className="tw-flex tw-flex-col tw-gap-3 sm:tw-flex-row sm:tw-items-center sm:tw-justify-between">
           {/* CORS 和 CURL */}
-          <div className="tw-flex tw-items-center tw-gap-3">
+          <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-3 sm:tw-flex-1">
             <div className="tw-flex tw-items-center tw-gap-2">
               <Checkbox
                 id="enable-cors"
@@ -738,7 +738,7 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
           </div>
 
           {/* 主要操作区：Test 和 Add Model */}
-          <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
+          <div className="tw-flex tw-shrink-0 tw-items-center tw-justify-end tw-gap-2">
             {verifyStatus === "success" && <CheckCircle2 className="tw-size-5 tw-text-success" />}
             {verifyStatus === "failed" && <XCircle className="tw-size-5 tw-text-error" />}
             <TooltipProvider>


### PR DESCRIPTION
## Summary
- fixes issue #2231 by adjusting Add Custom Chat Model dialog footer layout
- allows the left-side options row (CORS / Stream Usage / CURL) to wrap when needed
- prevents the right-side action area (Test / Add Model) from shrinking
- UI-only change with no logic or behavior changes

## Test plan
- 
> obsidian-copilot@3.2.3 lint
> eslint . --ext .js,.jsx,.ts,.tsx src/settings/v2/components/ModelAddDialog.tsx
- 
> obsidian-copilot@3.2.3 test
> jest --testPathIgnorePatterns=src/integration_tests/ --findRelatedTests src/settings/v2/components/ModelAddDialog.tsx --passWithNoTests
- pre-commit hook also ran full 
> obsidian-copilot@3.2.3 lint
> eslint . --ext .js,.jsx,.ts,.tsx successfully during commit

## Next steps
- verify visually in Obsidian settings that Stream Usage no longer crowds Test/Add buttons on narrower widths

Closes #2231