### PR TITLE
fix(ui): improve system prompt template syntax hints

### DIFF
--- a/src/components/SystemPromptSyntaxInstruction.tsx
+++ b/src/components/SystemPromptSyntaxInstruction.tsx
@@ -8,12 +8,13 @@ export function SystemPromptSyntaxInstruction() {
   return (
     <ul className="tw-m-0 tw-px-4 tw-text-sm">
       <li>
-        <span className="tw-font-medium tw-text-accent">{`{activeNote}`}</span> represents the
-        active note.
+        <span className="tw-font-medium tw-text-accent">{`{[[Note Title]]}`}</span> includes a
+        note&apos;s content. Note: bare <span className="tw-font-medium">{`[[Note Title]]`}</span>{" "}
+        without curly braces will NOT include the note content.
       </li>
       <li>
-        <span className="tw-font-medium tw-text-accent">{`{[[Note Title]]}`}</span> represents a
-        note.
+        <span className="tw-font-medium tw-text-accent">{`{activeNote}`}</span> represents the
+        active note.
       </li>
       <li>
         <span className="tw-font-medium tw-text-accent">{`{#tag1, #tag2}`}</span> represents ALL

--- a/src/components/modals/project/AddProjectModal.tsx
+++ b/src/components/modals/project/AddProjectModal.tsx
@@ -9,6 +9,7 @@ import { ObsidianNativeSelect } from "@/components/ui/obsidian-native-select";
 import { SettingSlider } from "@/components/ui/setting-slider";
 import { Textarea } from "@/components/ui/textarea";
 import { DEFAULT_MODEL_SETTING } from "@/constants";
+import { SystemPromptSyntaxInstruction } from "@/components/SystemPromptSyntaxInstruction";
 import { getDecodedPatterns } from "@/search/searchUtils";
 import { getModelKeyFromModel, useSettingsValue } from "@/settings/model";
 import { checkModelApiKey, err2String, randomUUID } from "@/utils";
@@ -196,10 +197,12 @@ function AddProjectModalContent({ initialProject, onSave, onCancel }: AddProject
           label="Project System Prompt"
           description="Custom instructions for how the AI should behave in this project context"
         >
+          <SystemPromptSyntaxInstruction />
           <Textarea
             value={formData.systemPrompt}
             onChange={(e) => handleInputChange("systemPrompt", e.target.value)}
             onBlur={() => setTouched((prev) => ({ ...prev, systemPrompt: true }))}
+            placeholder="Enter your project system prompt here... Use {[[Note Name]]} to include note contents."
             className="tw-min-h-32"
           />
         </FormField>

--- a/src/system-prompts/SystemPromptAddModal.tsx
+++ b/src/system-prompts/SystemPromptAddModal.tsx
@@ -147,7 +147,7 @@ function SystemPromptAddModalContent({
         <div className="tw-relative">
           <Textarea
             id="content"
-            placeholder="Enter your system prompt here..."
+            placeholder="Enter your system prompt here... Use {[[Note Name]]} to include note contents."
             value={prompt.content}
             onChange={(e) => handleUpdate("content", e.target.value)}
             rows={10}


### PR DESCRIPTION
## Summary
- Clarifies that note references in system prompts require `{[[Note Name]]}` syntax (with curly braces) — bare `[[Note Name]]` wikilinks are **not** resolved and their contents won't be included
- Adds placeholder text to both the system prompt and project system prompt textareas hinting at the correct syntax
- Adds `SystemPromptSyntaxInstruction` component to the project system prompt editor (previously only shown in the system prompt add modal)
- Reorders syntax instruction list to lead with the most common `{[[Note Title]]}` pattern

Closes #2235

## Test plan
- [x] Open Settings > System Prompts > Add — verify placeholder text shows `{[[Note Name]]}` hint and syntax instruction highlights the curly-brace requirement
- [x] Open Project modal (new or edit) — verify the system prompt field now shows syntax instructions and placeholder text
- [x] Confirm `{[[Note Name]]}` in a system prompt still resolves note contents correctly
- [x] Confirm bare `[[Note Name]]` still passes through as literal text (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)