### PR TITLE
fix(settings): allow resetting default system prompt to built-in

### DIFF
--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -22,7 +22,6 @@ export const AdvancedSettings: React.FC = () => {
   const displayValue = defaultPromptExists ? settings.defaultSystemPromptTitle : "";
 
   const handleSelectChange = (value: string) => {
-    if (!value) return; // Prevent setting empty value
     updateSetting("defaultSystemPromptTitle", value);
   };
 
@@ -54,14 +53,16 @@ export const AdvancedSettings: React.FC = () => {
             <ObsidianNativeSelect
               value={displayValue}
               onChange={(e) => handleSelectChange(e.target.value)}
-              options={prompts.map((prompt) => ({
-                label:
-                  prompt.title === settings.defaultSystemPromptTitle
-                    ? `${prompt.title} (Default)`
-                    : prompt.title,
-                value: prompt.title,
-              }))}
-              placeholder="Select system prompt"
+              options={[
+                { label: "None (use built-in prompt)", value: "" },
+                ...prompts.map((prompt) => ({
+                  label:
+                    prompt.title === settings.defaultSystemPromptTitle
+                      ? `${prompt.title} (Default)`
+                      : prompt.title,
+                  value: prompt.title,
+                })),
+              ]}
               containerClassName="tw-flex-1"
             />
             <Button


### PR DESCRIPTION
## Summary
- Adds a "None (use built-in prompt)" option at the top of the default system prompt dropdown in Advanced Settings
- Removes the guard that prevented setting an empty value, allowing users to deselect their custom system prompt
- Removes the disabled placeholder option since the "None" option now serves as the default selectable state

Previously, once a custom system prompt was selected, there was no way to go back to the built-in default.

## Test plan
- [x] Open Settings > Advanced > Default System Prompt dropdown
- [x] Verify "None (use built-in prompt)" appears as the first option
- [x] Select a custom system prompt, then switch back to "None" — confirm it resets to the built-in prompt
- [x] Verify the "Open source file" button is correctly disabled when "None" is selected
- [x] Start a new chat after resetting — confirm the built-in system prompt is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)