### PR TITLE
fix: use safeFetch for Copilot Plus to bypass browser TLS errors

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -347,7 +347,7 @@ export default class ChatModelManager {
         apiKey: await getDecryptedKey(settings.plusLicenseKey),
         configuration: {
           baseURL: BREVILABS_MODELS_BASE_URL,
-          fetch: customModel.enableCors ? safeFetch : undefined,
+          fetch: safeFetch,
         },
       },
       [ChatModelProviders.MISTRAL]: {


### PR DESCRIPTION
## Problem

Fixes #2250

Users see **"Connection error. Failed to fetch"** when using Copilot Plus models. The underlying browser error is:

```
net::ERR_CERT_AUTHORITY_INVALID
Failed to load resource: net::ERR_CERT_AUTHORITY_INVALID
https://models.brevilabs.com/chat/completions
```

## Root Cause

The `COPILOT_PLUS` provider was conditionally using `safeFetch` only when `customModel.enableCors` was `true`. The built-in `copilot-plus-flash` model does not set this flag, so Obsidian's Chromium/WebKit renderer used native browser `fetch()` to call `models.brevilabs.com`.

The renderer's native `fetch()` enforces its own TLS certificate validation. This fails with `ERR_CERT_AUTHORITY_INVALID` when:
- The server's SSL certificate isn't trusted by the Chromium trust store (e.g. Railway SSL cert issues)
- A corporate proxy or network intercepts TLS traffic
- The system trust store differs from what Chromium expects

## Fix

Always use `safeFetch` for the `COPILOT_PLUS` provider:

```typescript
// Before
fetch: customModel.enableCors ? safeFetch : undefined,

// After
fetch: safeFetch,
```

`safeFetch` routes requests through Obsidian's `requestUrl` API (the Node/Electron layer), which handles TLS validation differently than the Chromium renderer and does not hit this certificate error.

## No Streaming Impact

The Brevilabs backend already buffers responses internally before streaming them to the client. Switching from native `fetch()` to `safeFetch` has no effect on streaming UX — responses still stream to the user as expected.

## Testing

- All 1718 unit tests pass
- ESLint clean