### PR TITLE
ci: add automated release workflow on PR merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,14 +110,17 @@ jobs:
           fi
 
       # ── Step 9: Create GitHub Release ────────────────────────────────────────
-      # gh release create automatically creates the git tag on the merge commit.
+      # --target pins the tag to the exact merge commit SHA so concurrent
+      # merges cannot cause the release tag to point at a different commit.
       # Artifacts: main.js, manifest.json, styles.css
       - name: Create GitHub Release
         if: steps.semver.outputs.is_release == 'true' && steps.check_existing.outputs.exists != 'true'
         env:
           VERSION: ${{ steps.semver.outputs.version }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
           gh release create "$VERSION" \
+            --target "$MERGE_SHA" \
             --title "$VERSION" \
             --notes-file /tmp/release-notes.md \
             main.js \


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` that triggers on PR merge to master
- Only creates a release when the PR title is strict semver (e.g., "3.2.3")
- Non-semver PR titles are silently skipped (no noisy failures)
- Builds the plugin and attaches `main.js`, `manifest.json`, `styles.css` to the GitHub Release
- PR body becomes the release notes (via `--notes-file` for shell safety)
- Validates that PR title version matches `manifest.json` version

## How to use
1. Bump version in `package.json`, `manifest.json`, `versions.json`
2. Write release notes in the PR description
3. Set PR title to the version number (e.g., "3.2.4")
4. Merge → release is created automatically

## Test plan
- [ ] Merge a PR with title "3.2.4" → verify release is created with correct artifacts
- [ ] Merge a PR with title "fix: something" → verify workflow skips silently
- [ ] Merge a PR with mismatched title/manifest version → verify workflow fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)