### PR TITLE
Add release agent definition

### DIFF
--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -53,10 +53,12 @@ Find the last release tag:
 git describe --tags --abbrev=0
 ```
 
-List all merged PRs since that tag:
+List all merged PRs since that tag (paginate to avoid missing entries if there are many):
 ```bash
-gh pr list --state merged --base master --search "merged:>YYYY-MM-DD" --json number,title,author,labels --limit 100
+gh pr list --state merged --base master --search "merged:>YYYY-MM-DD" --json number,title,author,labels --limit 500
 ```
+
+If the output is exactly 500 entries, there may be more — repeat with an earlier `--search` cutoff or use `--limit 1000` and re-run.
 
 Use the tag date as the cutoff. You can get it with:
 ```bash
@@ -103,7 +105,7 @@ Prepend the new release entry at the top of `RELEASES.md`, right after the `# Re
 
 Stage all changed files:
 ```bash
-git add package.json manifest.json versions.json RELEASES.md
+git add package.json package-lock.json manifest.json versions.json RELEASES.md
 ```
 
 Commit with message: `release: vX.Y.Z`


### PR DESCRIPTION
## Summary
- Adds a `.claude/agents/release.md` agent definition that automates creating release PRs
- The agent asks patch/minor/major, bumps version, generates release notes from merged PRs, updates RELEASES.md, and creates a PR with the semver title to trigger the auto-release workflow

## Test plan
- [x] Verify the agent is available via Claude Code in this project
- [x] Test a dry-run release flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)