### PR TITLE
fix(tools): replace cachedRead with vault.read in agent/tool paths

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -539,7 +539,7 @@ export default class CopilotPlugin extends Plugin {
         if (selection) return selection;
         // Default to the entire active file if no selection
         const activeFile = this.app.workspace.getActiveFile();
-        return activeFile ? this.app.vault.cachedRead(activeFile) : "";
+        return activeFile ? this.app.vault.read(activeFile) : "";
       },
       replaceSelection: activeView?.editor?.replaceSelection.bind(activeView.editor) || (() => {}),
     } as Partial<Editor> as Editor;

--- a/src/tools/CanvasLoader.ts
+++ b/src/tools/CanvasLoader.ts
@@ -54,7 +54,7 @@ export class CanvasLoader {
       nodes.map(async (n) => {
         if (n.type === "file" && n.file) {
           const file = this.vault.getAbstractFileByPath(n.file);
-          const md = file instanceof TFile ? await this.vault.cachedRead(file) : "";
+          const md = file instanceof TFile ? await this.vault.read(file) : "";
           return { ...n, content: md };
         }
         if (n.type === "text") return { ...n, content: n.text ?? "" };

--- a/src/tools/NoteTools.ts
+++ b/src/tools/NoteTools.ts
@@ -217,7 +217,7 @@ async function resolveNoteFile(notePath: string): Promise<ResolveNoteOutcome> {
 
 async function readNoteText(file: TFile): Promise<string> {
   try {
-    return await app.vault.cachedRead(file);
+    return await app.vault.read(file);
   } catch (error) {
     logWarn(`readNote: failed to read ${file.path}`, error);
     return "";

--- a/src/tools/ReadNoteTool.test.ts
+++ b/src/tools/ReadNoteTool.test.ts
@@ -1,6 +1,6 @@
 import { StructuredTool } from "@langchain/core/tools";
 
-const mockCachedRead = jest.fn();
+const mockRead = jest.fn();
 
 // Helper to invoke tool and parse JSON result
 const invokeReadNoteTool = async (tool: StructuredTool, args: any) => {
@@ -39,14 +39,14 @@ describe("readNoteTool", () => {
     getAbstractFileByPathMock = jest.fn();
     getMarkdownFilesMock = jest.fn().mockReturnValue([]);
     getFirstLinkpathDestMock = jest.fn().mockReturnValue(null);
-    mockCachedRead.mockReset();
-    mockCachedRead.mockResolvedValue("");
+    mockRead.mockReset();
+    mockRead.mockResolvedValue("");
 
     global.app = {
       vault: {
         getAbstractFileByPath: getAbstractFileByPathMock,
         getMarkdownFiles: getMarkdownFilesMock,
-        cachedRead: mockCachedRead,
+        read: mockRead,
       },
       metadataCache: {
         getFileCache: jest.fn(),
@@ -69,7 +69,7 @@ describe("readNoteTool", () => {
     const notePath = "Notes/test.md";
     const file = new MockTFile(notePath);
     getAbstractFileByPathMock.mockReturnValue(file);
-    mockCachedRead.mockResolvedValue(["## Heading", "Line 1", "Line 2"].join("\n"));
+    mockRead.mockResolvedValue(["## Heading", "Line 1", "Line 2"].join("\n"));
 
     const result = await invokeReadNoteTool(readNoteTool, { notePath });
 
@@ -85,7 +85,7 @@ describe("readNoteTool", () => {
     getAbstractFileByPathMock.mockReturnValue(file);
 
     const lines = Array.from({ length: 210 }, (_, i) => `Line ${i + 1}`);
-    mockCachedRead.mockResolvedValue(lines.join("\n"));
+    mockRead.mockResolvedValue(lines.join("\n"));
 
     const result = await invokeReadNoteTool(readNoteTool, { notePath, chunkIndex: 1 });
 
@@ -99,7 +99,7 @@ describe("readNoteTool", () => {
     getAbstractFileByPathMock.mockReturnValue(file);
 
     const lines = Array.from({ length: 205 }, (_, i) => `Line ${i + 1}`);
-    mockCachedRead.mockResolvedValue(lines.join("\n"));
+    mockRead.mockResolvedValue(lines.join("\n"));
 
     const result = await invokeReadNoteTool(readNoteTool, { notePath, chunkIndex: "1" as any });
 
@@ -118,7 +118,7 @@ describe("readNoteTool", () => {
       status: "not_found",
       message: 'Note "Notes/missing.md" was not found or is not a readable file.',
     });
-    expect(mockCachedRead).not.toHaveBeenCalled();
+    expect(mockRead).not.toHaveBeenCalled();
   });
 
   it("returns not_found for section-only wiki link targets", async () => {
@@ -134,7 +134,7 @@ describe("readNoteTool", () => {
       status: "not_found",
       message: 'Note "[[#Setup]]" was not found or is not a readable file.',
     });
-    expect(mockCachedRead).not.toHaveBeenCalled();
+    expect(mockRead).not.toHaveBeenCalled();
   });
 
   it("returns not_found for empty wiki link targets", async () => {
@@ -150,7 +150,7 @@ describe("readNoteTool", () => {
       status: "not_found",
       message: 'Note "[[]]" was not found or is not a readable file.',
     });
-    expect(mockCachedRead).not.toHaveBeenCalled();
+    expect(mockRead).not.toHaveBeenCalled();
   });
 
   it("returns invalid_path when notePath starts with a leading slash", async () => {
@@ -162,7 +162,7 @@ describe("readNoteTool", () => {
       message: "Provide the note path relative to the vault root without a leading slash.",
     });
     expect(getAbstractFileByPathMock).not.toHaveBeenCalled();
-    expect(mockCachedRead).not.toHaveBeenCalled();
+    expect(mockRead).not.toHaveBeenCalled();
   });
 
   it("surfaces linked note candidates including duplicate basenames", async () => {
@@ -176,7 +176,7 @@ describe("readNoteTool", () => {
       link === "Project Plan" ? candidatePrimary : null
     );
     getMarkdownFilesMock.mockReturnValue([candidatePrimary, candidateDuplicate, file]);
-    mockCachedRead.mockResolvedValue("Intro [[Project Plan]] details");
+    mockRead.mockResolvedValue("Intro [[Project Plan]] details");
 
     const result = await invokeReadNoteTool(readNoteTool, { notePath });
 
@@ -203,7 +203,7 @@ describe("readNoteTool", () => {
       link === "Docs/Guide" ? guideFile : null
     );
     getMarkdownFilesMock.mockReturnValue([guideFile, file]);
-    mockCachedRead.mockResolvedValue("See [[Docs/Guide#Setup|Quick Start]] for steps.");
+    mockRead.mockResolvedValue("See [[Docs/Guide#Setup|Quick Start]] for steps.");
 
     const result = await invokeReadNoteTool(readNoteTool, { notePath });
 
@@ -231,13 +231,13 @@ describe("readNoteTool", () => {
       return null;
     });
 
-    mockCachedRead.mockResolvedValue("Content");
+    mockRead.mockResolvedValue("Content");
 
     const result = await invokeReadNoteTool(readNoteTool, { notePath: rawPath });
 
     expect(result.notePath).toBe(file.path);
     expect(result.chunkIndex).toBe(0);
-    expect(mockCachedRead).toHaveBeenCalledWith(file);
+    expect(mockRead).toHaveBeenCalledWith(file);
   });
 
   it("resolves wiki-linked notes via metadata without active note context", async () => {
@@ -251,12 +251,12 @@ describe("readNoteTool", () => {
       }
       return null;
     });
-    mockCachedRead.mockResolvedValue("Content");
+    mockRead.mockResolvedValue("Content");
 
     const result = await invokeReadNoteTool(readNoteTool, { notePath: requestedPath });
 
     expect(result.notePath).toBe(targetFile.path);
-    expect(mockCachedRead).toHaveBeenCalledWith(targetFile);
+    expect(mockRead).toHaveBeenCalledWith(targetFile);
     expect(getFirstLinkpathDestMock).toHaveBeenCalledWith(requestedPath, "");
   });
 
@@ -267,12 +267,12 @@ describe("readNoteTool", () => {
     getAbstractFileByPathMock.mockReturnValue(null);
     getFirstLinkpathDestMock.mockReturnValue(null);
     getMarkdownFilesMock.mockReturnValue([targetFile]);
-    mockCachedRead.mockResolvedValue("Content");
+    mockRead.mockResolvedValue("Content");
 
     const result = await invokeReadNoteTool(readNoteTool, { notePath: requestedPath });
 
     expect(result.notePath).toBe(targetFile.path);
-    expect(mockCachedRead).toHaveBeenCalledWith(targetFile);
+    expect(mockRead).toHaveBeenCalledWith(targetFile);
   });
 
   it("returns not_unique when multiple notes share the same title", async () => {
@@ -295,7 +295,7 @@ describe("readNoteTool", () => {
         { path: archiveFile.path, title: archiveFile.basename },
       ],
     });
-    expect(mockCachedRead).not.toHaveBeenCalled();
+    expect(mockRead).not.toHaveBeenCalled();
   });
 
   it("matches a unique partial path when multiple basenames exist", async () => {
@@ -306,11 +306,11 @@ describe("readNoteTool", () => {
     getAbstractFileByPathMock.mockReturnValue(null);
     getFirstLinkpathDestMock.mockReturnValue(null);
     getMarkdownFilesMock.mockReturnValue([targetFile, duplicateFile]);
-    mockCachedRead.mockResolvedValue("Content");
+    mockRead.mockResolvedValue("Content");
 
     const result = await invokeReadNoteTool(readNoteTool, { notePath: requestedPath });
 
     expect(result.notePath).toBe(targetFile.path);
-    expect(mockCachedRead).toHaveBeenCalledWith(targetFile);
+    expect(mockRead).toHaveBeenCalledWith(targetFile);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -372,7 +372,7 @@ export function stringToFormattedDateTime(timestamp: string): FormattedDateTime 
 
 export async function getFileContent(file: TFile, vault: Vault): Promise<string | null> {
   if (file.extension != "md" && file.extension != "canvas") return null;
-  return await vault.cachedRead(file);
+  return await vault.read(file);
 }
 
 export function getFileName(file: TFile): string {


### PR DESCRIPTION
## Problem

\`vault.cachedRead()\` can return stale content after programmatic writes. For example, when an AI agent writes via \`vault.modify()\` and then reads back via \`cachedRead()\`, it sees pre-write content, leading to a "write-hallucination" bug where the agent thinks the write failed.

## Fix

Replace \`cachedRead\` with \`vault.read()\` in 4 tool/agent code paths where data freshness matters:
- \`src/tools/NoteTools.ts:220\` — \`readNoteText()\`
- \`src/utils.ts:375\` — \`getFileContent()\`
- \`src/tools/CanvasLoader.ts:57\` — canvas node content loading
- \`src/main.ts:542\` — \`getCurrentEditorOrDummy()\` fallback

## Changed Files

- \`src/tools/NoteTools.ts\`
- \`src/utils.ts\`
- \`src/tools/CanvasLoader.ts\`
- \`src/main.ts\`
- \`src/tools/ReadNoteTool.test.ts\` (updated test mocks)

## NOT Changed

Search/indexing paths (GrepScanner, FilterRetriever, chunks.ts, etc.) intentionally keep \`cachedRead\` because performance is critical for bulk operations and stale reads are acceptable in those contexts.

## Supersedes

PR #2227 (closed) — that PR used a more complex "editor-first" approach. This PR is a simpler, surgical fix focused solely on fixing stale disk reads after programmatic writes.

## Verification

- ✅ All 1765 tests pass
- ✅ Build succeeds
- ✅ Lint passes (0 warnings)
- ✅ Grep verification: exactly 4 \`cachedRead\` calls removed from tool/agent paths