### PR TITLE
fix: Quick Ask/Command panel positioning overhaul

### DIFF
--- a/src/commands/CustomCommandChatModal.tsx
+++ b/src/commands/CustomCommandChatModal.tsx
@@ -1,10 +1,13 @@
 import { CustomModel, useModelKey } from "@/aiParams";
 import { processCommandPrompt } from "@/commands/customCommandUtils";
 import { MenuCommandModal, type ContentState } from "@/components/command-ui";
+import { MODAL_MIN_HEIGHT_COMPACT, MODAL_MIN_HEIGHT_EXPANDED } from "@/components/command-ui/constants";
 import { SelectionHighlight } from "@/editor/selectionHighlight";
 import { createHighlightReplaceGuard, type ReplaceGuard } from "@/editor/replaceGuard";
 import { logError, logWarn } from "@/logger";
 import { cleanMessageForCopy, findCustomModel, insertIntoEditor } from "@/utils";
+import { computeVerticalPlacement } from "@/utils/panelPlacement";
+import { computeSelectionAnchors } from "@/utils/selectionAnchors";
 import type { EditorView } from "@codemirror/view";
 import { PenLine } from "lucide-react";
 import { App, Component, MarkdownRenderer, Notice, MarkdownView } from "obsidian";
@@ -84,6 +87,8 @@ interface CustomCommandChatModalContentProps {
   onClose: () => void;
   systemPrompt?: string;
   initialPosition?: { x: number; y: number };
+  /** Bottom-anchor Y for "above" placement (panel grows upward) */
+  anchorBottom?: number;
   behaviorConfig?: Partial<ModalBehaviorConfig>;
 }
 
@@ -98,6 +103,7 @@ function CustomCommandChatModalContent({
   onClose,
   systemPrompt,
   initialPosition,
+  anchorBottom,
   behaviorConfig,
 }: CustomCommandChatModalContentProps) {
   // Resolve behavior configuration
@@ -451,6 +457,7 @@ function CustomCommandChatModalContent({
       onInsert={handleInsert}
       onReplace={handleReplace}
       initialPosition={initialPosition}
+      anchorBottom={anchorBottom}
       resizable
       hideContentAreaOnIdle={behavior.hideContentAreaOnIdle}
       includeNoteContext={behavior.showIncludeNoteContext ? includeNoteContext : undefined}
@@ -508,12 +515,20 @@ export class CustomCommandChatModal {
 
   /**
    * Calculate initial position based on cursor/selection in the editor.
-   * Handles: single-line, multi-line, line-start trap, flip when near bottom edge.
+   * Strategy: vertical-first (determines placement), then horizontal (depends on placement).
+   * - Multi-line selections always center horizontally on the editor.
+   * - Space checks use scrollRect (editor visible area), not window.
+   * - Horizontal clamp to scrollRect first, then viewport as safety net.
    */
-  private getInitialPosition(activeView: MarkdownView | null): { x: number; y: number } {
+  private getInitialPosition(activeView: MarkdownView | null): { x: number; y: number; anchorBottom?: number } {
     const win = this.resolveWindow(activeView);
     const panelWidth = Math.min(500, win.innerWidth * 0.9);
-    const panelHeight = 440;
+    // Reason: The actual initial panel height depends on whether ContentArea is shown.
+    // Quick Command starts idle with no ContentArea (compact).
+    // Custom Commands always show ContentArea (expanded).
+    // Using the correct height prevents gaps (above) or overlaps (below).
+    const hideContentAreaOnIdle = this.configs.behaviorConfig?.hideContentAreaOnIdle ?? false;
+    const panelHeight = hideContentAreaOnIdle ? MODAL_MIN_HEIGHT_COMPACT : MODAL_MIN_HEIGHT_EXPANDED;
     const margin = 12;
     const gap = 6;
 
@@ -531,100 +546,91 @@ export class CustomCommandChatModal {
     const selection = view.state.selection.main;
     const isCursor = selection.empty;
 
-    // Reason: Use `head` (where user's cursor is) instead of `to`, so that
-    // reverse selections still position the popup near the user's focus point.
-    let anchorPos = selection.head;
+    // Reason: Dual-anchor model — compute separate top/bottom anchor positions.
+    // bottomPos is used for "place below selection", topPos for "place above selection".
+    // The shared utility handles the line-start trap correction.
+    const anchors = computeSelectionAnchors(selection, view.state.doc);
 
-    // Fix "line-start trap": when head lands on next line's start after selecting newline
-    // Reason: Only apply when head is at the END of selection (head === to), not when
-    // user reverse-selects TO a line start (head === from). This avoids jumping to
-    // previous line when user intentionally selects to line beginning.
-    if (!isCursor && anchorPos > 0 && anchorPos === selection.to) {
-      const lineAtHead = view.state.doc.lineAt(anchorPos);
-      if (anchorPos === lineAtHead.from) {
-        // Head is at line start and is the selection end, move back to previous line's end
-        anchorPos = anchorPos - 1;
-      }
-    }
+    // Get coordinates for all anchor positions
+    const focusCoords = view.coordsAtPos(anchors.focusPos);
+    const bottomCoords = view.coordsAtPos(anchors.bottomPos);
+    const topCoords = view.coordsAtPos(anchors.topPos);
 
-    // Get coordinates for anchor position
-    const anchorCoords = view.coordsAtPos(anchorPos);
-    if (!anchorCoords) {
+    if (!focusCoords && !bottomCoords && !topCoords) {
       return fallback;
     }
 
-    // Check visibility (both vertical and horizontal)
+    // Check visibility of each anchor against the editor's visible scroll area
     const scrollRect = view.scrollDOM.getBoundingClientRect();
-    const isVerticallyVisible =
-      anchorCoords.bottom >= scrollRect.top && anchorCoords.top <= scrollRect.bottom;
-    const isHorizontallyVisible =
-      anchorCoords.right >= scrollRect.left && anchorCoords.left <= scrollRect.right;
+    const isVisible = (coords: { top: number; bottom: number; left: number; right: number }) =>
+      coords.bottom >= scrollRect.top &&
+      coords.top <= scrollRect.bottom &&
+      coords.right >= scrollRect.left &&
+      coords.left <= scrollRect.right;
 
-    if (!isVerticallyVisible || !isHorizontallyVisible) {
+    const visibleFocus = focusCoords && isVisible(focusCoords) ? focusCoords : null;
+    const visibleBottom = bottomCoords && isVisible(bottomCoords) ? bottomCoords : null;
+    const visibleTop = topCoords && isVisible(topCoords) ? topCoords : null;
+
+    if (!visibleFocus && !visibleBottom && !visibleTop) {
       return fallback;
     }
 
-    // Calculate horizontal position
-    let centerX: number;
-    if (isCursor) {
-      // Cursor only: position near cursor (not centered, to avoid obscuring)
-      centerX = anchorCoords.left;
-    } else {
-      // Selection: check if single-line or multi-line
-      const lineAtFrom = view.state.doc.lineAt(selection.from);
-      const lineAtTo = view.state.doc.lineAt(selection.to);
+    // --- Visual multi-line detection ---
+    // Reason: Using visual line height comparison instead of logical line numbers
+    // correctly handles soft-wrapped lines that span multiple visual rows.
+    const caretHeight = Math.min(
+      (topCoords?.bottom ?? 0) - (topCoords?.top ?? 0),
+      (bottomCoords?.bottom ?? 0) - (bottomCoords?.top ?? 0)
+    );
+    const isVisualMultiLine = !isCursor && topCoords && bottomCoords
+      && Math.abs(topCoords.top - bottomCoords.top) > Math.max(caretHeight / 2, 2);
 
-      if (lineAtFrom.number === lineAtTo.number) {
-        // Single-line: center between from and to
-        const fromCoords = view.coordsAtPos(selection.from);
-        const toCoords = view.coordsAtPos(selection.to);
-        if (fromCoords && toCoords) {
-          centerX = (fromCoords.left + toCoords.right) / 2;
-        } else {
-          centerX = anchorCoords.left;
-        }
-      } else {
-        // Multi-line: follow the anchor (head) position
-        centerX = anchorCoords.left;
-      }
-    }
+    // --- Vertical positioning (decides placement first) ---
+    // Reason: Extracted to a pure helper (computeVerticalPlacement) so the
+    // branching logic is testable without DOM/CodeMirror dependencies.
+    const { top: rawTop, anchorBottomY } = computeVerticalPlacement({
+      scrollRect,
+      visibleBottom,
+      visibleTop,
+      panelHeight,
+      margin,
+      gap,
+      viewportHeight: win.innerHeight,
+    });
+    const top = rawTop;
 
-    // Calculate left position
-    // For cursor: align left edge near cursor; for selection: center the panel
+    // --- Horizontal positioning (depends on vertical placement) ---
     let left: number;
+
     if (isCursor) {
-      left = centerX;
+      // Cursor: anchor at cursor position
+      const anchor = visibleFocus ?? visibleBottom ?? visibleTop!;
+      left = anchor.left;
+    } else if (!isVisualMultiLine) {
+      // Visual single-line: center panel on the selection span
+      // Reason: Use normalized anchor positions instead of raw selection.from/to
+      // to handle newline-at-end selections (line-start trap).
+      const fromCoords = view.coordsAtPos(anchors.topPos);
+      const toCoords = view.coordsAtPos(anchors.bottomPos);
+      if (fromCoords && toCoords) {
+        const centerX = (fromCoords.left + toCoords.right) / 2;
+        left = centerX - panelWidth / 2;
+      } else {
+        // Coords unavailable — fall back to editor center
+        left = (scrollRect.left + scrollRect.right) / 2 - panelWidth / 2;
+      }
     } else {
-      left = centerX - panelWidth / 2;
+      // Reason: Visual multi-line selections center on the editor regardless of
+      // below/above/center placement, preventing left-edge snapping on reverse selections.
+      left = (scrollRect.left + scrollRect.right) / 2 - panelWidth / 2;
     }
+
+    // Clamp to editor visible area first, then viewport as safety net
+    left = Math.max(scrollRect.left, Math.min(left, scrollRect.right - panelWidth));
     left = Math.max(margin, Math.min(left, win.innerWidth - margin - panelWidth));
 
-    // Calculate vertical position with flip logic
-    const anchorBottom = anchorCoords.bottom;
-    const anchorTop = anchorCoords.top;
-    const spaceBelow = win.innerHeight - anchorBottom - gap;
-    const spaceAbove = anchorTop - gap;
-
-    let top: number;
-    if (spaceBelow >= panelHeight + margin) {
-      // Enough space below: place below anchor
-      top = anchorBottom + gap;
-    } else if (spaceAbove >= panelHeight + margin) {
-      // Not enough below but enough above: flip to above
-      top = anchorTop - gap - panelHeight;
-    } else {
-      // Neither side has enough space: prefer the side with more space
-      if (spaceBelow >= spaceAbove) {
-        top = anchorBottom + gap;
-      } else {
-        top = anchorTop - gap - panelHeight;
-      }
-    }
-
-    // Final clamp to ensure panel stays within viewport
-    top = Math.max(margin, Math.min(top, win.innerHeight - margin - panelHeight));
-
-    return { x: left, y: top };
+    return { x: left, y: top, anchorBottom: anchorBottomY };
   }
 
   open() {
@@ -669,7 +675,7 @@ export class CustomCommandChatModal {
       });
     }
 
-    const initialPosition = this.getInitialPosition(activeView);
+    const { anchorBottom, ...initialPosition } = this.getInitialPosition(activeView);
 
     const handleInsert = (message: string) => {
       insertIntoEditor(message);
@@ -707,6 +713,7 @@ export class CustomCommandChatModal {
         onClose={handleClose}
         systemPrompt={systemPrompt}
         initialPosition={initialPosition}
+        anchorBottom={anchorBottom}
         behaviorConfig={behaviorConfig}
       />
     );

--- a/src/components/command-ui/constants.ts
+++ b/src/components/command-ui/constants.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared layout constants for command-ui modals.
+ *
+ * These values are used by both the initial positioning logic
+ * (CustomCommandChatModal.getInitialPosition) and the runtime modal
+ * (MenuCommandModal / DraggableModal). Keeping them in one place
+ * prevents silent drift when headers, footers, or content areas change.
+ */
+
+/** Minimum modal height when ContentArea is hidden (compact / idle Quick Command). */
+export const MODAL_MIN_HEIGHT_COMPACT = 180;
+
+/** Minimum modal height when ContentArea is visible (expanded / custom commands). */
+export const MODAL_MIN_HEIGHT_EXPANDED = 400;

--- a/src/components/command-ui/draggable-modal.tsx
+++ b/src/components/command-ui/draggable-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useDraggable } from "@/hooks/use-draggable";
 import { useRafResizable } from "@/hooks/use-resizable";
@@ -31,6 +31,13 @@ interface DraggableModalProps {
    * while avoiding the "one Escape closes all open modals" issue when multiple DraggableModals are open.
    */
   closeOnEscapeFromOutside?: boolean;
+  /**
+   * Bottom-anchor Y coordinate for "above" placement.
+   * When set (and user hasn't manually repositioned), position.y is kept at
+   * anchorBottom - height so the panel grows upward as content loads.
+   * Cleared automatically on user drag or resize.
+   */
+  anchorBottom?: number;
 }
 
 /**
@@ -47,8 +54,9 @@ export function DraggableModal({
   resizable = false,
   minHeight = 260,
   closeOnEscapeFromOutside = false,
+  anchorBottom,
 }: DraggableModalProps) {
-  const { position, setPosition, dragRef, handleMouseDown, isDragging } = useDraggable({
+  const { position, setPosition, dragRef, handleMouseDown: rawHandleMouseDown, isDragging } = useDraggable({
     initialPosition: initialPosition || {
       x: typeof window !== "undefined" ? (window.innerWidth - 500) / 2 : 100,
       y: typeof window !== "undefined" ? (window.innerHeight - 400) / 2 : 100,
@@ -56,6 +64,68 @@ export function DraggableModal({
     // Allow dragging outside window bounds (like Quick Ask)
     bounds: null,
   });
+
+  // Reason: Track whether the user has manually repositioned (drag or resize).
+  // Once manual, anchorBottom is ignored and the panel uses free positioning.
+  const isManualPositionRef = useRef(false);
+  const pendingDragCleanupRef = useRef<(() => void) | null>(null);
+
+  // Reason: Only flip isManualPositionRef after actual pointer movement (>2px),
+  // so a click on the drag handle (without dragging) preserves anchorBottom behavior.
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      const ownerDoc = e.currentTarget.ownerDocument;
+      const startX = e.clientX;
+      const startY = e.clientY;
+
+      pendingDragCleanupRef.current?.();
+
+      const cleanup = () => {
+        ownerDoc.removeEventListener("mousemove", onMove, true);
+        ownerDoc.removeEventListener("mouseup", onUp, true);
+        if (pendingDragCleanupRef.current === cleanup) {
+          pendingDragCleanupRef.current = null;
+        }
+      };
+
+      const onMove = (ev: MouseEvent) => {
+        if (Math.abs(ev.clientX - startX) < 2 && Math.abs(ev.clientY - startY) < 2) return;
+        isManualPositionRef.current = true;
+        cleanup();
+      };
+
+      const onUp = () => cleanup();
+
+      ownerDoc.addEventListener("mousemove", onMove, true);
+      ownerDoc.addEventListener("mouseup", onUp, true);
+      pendingDragCleanupRef.current = cleanup;
+
+      rawHandleMouseDown(e);
+    },
+    [rawHandleMouseDown]
+  );
+
+  // Reason: Reset transient state when the modal reopens so that stale
+  // drag/resize/anchor state from a previous session does not leak.
+  useEffect(() => {
+    if (!open) return;
+    pendingDragCleanupRef.current?.();
+    pendingDragCleanupRef.current = null;
+    isManualPositionRef.current = false;
+    setHeightPx(null);
+    setWidthPx(null);
+    if (initialPosition) {
+      setPosition(initialPosition);
+    }
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps -- intentionally only on open transitions
+
+  // Clean up pending drag listeners on unmount
+  useEffect(() => {
+    return () => {
+      pendingDragCleanupRef.current?.();
+      pendingDragCleanupRef.current = null;
+    };
+  }, []);
 
   // Resize state (height and width)
   const [heightPx, setHeightPx] = useState<number | null>(null);
@@ -88,6 +158,39 @@ export function DraggableModal({
     }
   }, [resizable, minHeight, heightPx]);
 
+  // Reason: For "above" placement, keep the panel's bottom edge anchored.
+  // When height increases (e.g., ContentArea appears), shift position.y up so the
+  // panel grows upward instead of downward into the selection.
+  // Uses useLayoutEffect to apply before paint, preventing visual flash.
+  useLayoutEffect(() => {
+    if (anchorBottom === undefined || isManualPositionRef.current) return;
+    if (heightPx === null) return;
+
+    const newY = Math.max(12, anchorBottom - heightPx);
+    // Guard: only update if position actually changed (avoid infinite re-render)
+    if (Math.abs(position.y - newY) < 1) return;
+
+    setPosition({ x: position.x, y: newY });
+  }, [anchorBottom, heightPx, position.x, position.y, setPosition]);
+
+  // Reason: Generic overflow correction for non-anchored panels.
+  // If content/minHeight growth pushes the modal below the viewport edge,
+  // shift it upward to keep the full panel visible. This handles cases like
+  // Quick Command starting compact (180px) then expanding (400px) near the
+  // bottom of the editor, without requiring the caller to anticipate future
+  // height changes.
+  useLayoutEffect(() => {
+    if (anchorBottom !== undefined || isManualPositionRef.current) return;
+    if (heightPx === null) return;
+
+    const ownerWindow = dragRef.current?.ownerDocument?.defaultView ?? window;
+    const maxY = ownerWindow.innerHeight - 12 - heightPx;
+    const newY = Math.max(12, Math.min(position.y, maxY));
+    if (Math.abs(position.y - newY) < 1) return;
+
+    setPosition({ x: position.x, y: newY });
+  }, [anchorBottom, heightPx, position.x, position.y, setPosition, dragRef]);
+
   const getResizeRect = useCallback(() => {
     return dragRef.current?.getBoundingClientRect() ?? null;
   }, [dragRef]);
@@ -102,6 +205,8 @@ export function DraggableModal({
 
   const applyResize = useCallback(
     (next: { width: number; height: number; x?: number }) => {
+      // Reason: User-initiated resize overrides bottom-anchor behavior
+      isManualPositionRef.current = true;
       setHeightPx((prev) => (prev === next.height ? prev : next.height));
       setWidthPx((prev) => (prev === next.width ? prev : next.width));
       if (typeof next.x === "number") {

--- a/src/components/command-ui/menu-command-modal.tsx
+++ b/src/components/command-ui/menu-command-modal.tsx
@@ -10,6 +10,7 @@ import { ModelSelector } from "@/components/ui/ModelSelector";
 import { Checkbox } from "@/components/ui/checkbox";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { ActionButtons } from "./action-buttons";
+import { MODAL_MIN_HEIGHT_COMPACT, MODAL_MIN_HEIGHT_EXPANDED } from "./constants";
 import { Button } from "@/components/ui/button";
 
 interface MenuCommandModalProps {
@@ -36,6 +37,11 @@ interface MenuCommandModalProps {
   onReplace?: () => void;
   /** Initial position for the modal (defaults to center of screen) */
   initialPosition?: { x: number; y: number };
+  /**
+   * Bottom-anchor Y for "above" placement. Passed through to DraggableModal.
+   * When set, the panel grows upward as content loads.
+   */
+  anchorBottom?: number;
   /** Enable QuickAsk-style resize (height only). */
   resizable?: boolean;
   /** Hide ContentArea when state is idle (for Quick Command mode) */
@@ -74,6 +80,7 @@ export function MenuCommandModal({
   onInsert,
   onReplace,
   initialPosition,
+  anchorBottom,
   resizable = false,
   hideContentAreaOnIdle = false,
   includeNoteContext,
@@ -145,13 +152,14 @@ export function MenuCommandModal({
   const showContentArea = hideContentAreaOnIdle ? contentState.type !== "idle" : true;
 
   // Dynamic minHeight: compact when ContentArea is hidden, normal when shown
-  const dynamicMinHeight = showContentArea ? 400 : 180;
+  const dynamicMinHeight = showContentArea ? MODAL_MIN_HEIGHT_EXPANDED : MODAL_MIN_HEIGHT_COMPACT;
 
   return (
     <DraggableModal
       open={open}
       onClose={onClose}
       initialPosition={initialPosition}
+      anchorBottom={anchorBottom}
       resizable={resizable}
       minHeight={resizable ? dynamicMinHeight : undefined}
       closeOnEscapeFromOutside

--- a/src/components/quick-ask/QuickAskOverlay.tsx
+++ b/src/components/quick-ask/QuickAskOverlay.tsx
@@ -71,9 +71,14 @@ export class QuickAskOverlay {
   // Reason: Track whether the user has intentionally resized the height
   // (vs width-only resize which shouldn't remove the chat area max-height).
   private hasUserResizedHeight = false;
-  // Anchor position
-  private pos: number | null = null;
-  private fallbackPos: number | null = null;
+  // Anchor positions (dual-anchor model for flip logic)
+  private bottomAnchorPos: number | null = null;
+  private topAnchorPos: number | null = null;
+  /** Focus anchor — selection.head for horizontal placement in reverse selections */
+  private focusAnchorPos: number | null = null;
+  // Reason: Side lock prevents flipping between above/below during streaming output.
+  // Only reset on scroll, resize, or anchor visibility changes — not on content height changes.
+  private placementSide: "below" | "above" | null = null;
 
   // Resize interaction state
   private isResizing = false;
@@ -89,12 +94,14 @@ export class QuickAskOverlay {
 
   /**
    * Mounts the overlay at the specified anchor positions.
-   * @param pos - Primary anchor position (typically selection head)
-   * @param fallbackPos - Fallback anchor position (typically selection anchor)
+   * @param bottomAnchorPos - Bottom anchor (normalized selection.to) for "place below"
+   * @param topAnchorPos - Top anchor (selection.from) for "place above" flip target
    */
-  mount(pos: number, fallbackPos?: number | null): void {
-    this.pos = pos;
-    this.fallbackPos = typeof fallbackPos === "number" ? fallbackPos : null;
+  mount(bottomAnchorPos: number, topAnchorPos?: number | null, focusAnchorPos?: number | null): void {
+    this.bottomAnchorPos = bottomAnchorPos;
+    this.topAnchorPos = typeof topAnchorPos === "number" ? topAnchorPos : null;
+    this.focusAnchorPos = typeof focusAnchorPos === "number" ? focusAnchorPos : null;
+    this.placementSide = null;
     QuickAskOverlay.currentInstance = this;
     this.mountOverlay();
     this.setupGlobalListeners();
@@ -161,24 +168,39 @@ export class QuickAskOverlay {
       QuickAskOverlay.overlayRoot = null;
       host?.classList.remove("copilot-quick-ask-overlay-host");
     }
-    this.pos = null;
-    this.fallbackPos = null;
+    this.bottomAnchorPos = null;
+    this.topAnchorPos = null;
+    this.focusAnchorPos = null;
+    this.placementSide = null;
     this.ownerDocument = null;
     this.ownerWindow = null;
   }
 
   /**
-   * Updates the anchor position.
+   * Updates the anchor positions and recalculates panel placement.
+   * Called by quickAskExtension on document changes (positions remapped via mapPos).
    */
-  updatePosition(pos?: number, fallbackPos?: number | null): void {
-    if (typeof pos === "number") {
-      this.pos = pos;
+  updatePosition(
+    bottomAnchorPos?: number,
+    topAnchorPos?: number | null,
+    focusAnchorPos?: number | null
+  ): void {
+    if (typeof bottomAnchorPos === "number") {
+      this.bottomAnchorPos = bottomAnchorPos;
     }
-    if (typeof fallbackPos === "number") {
-      this.fallbackPos = fallbackPos;
-    } else if (fallbackPos === null) {
-      this.fallbackPos = null;
+    if (typeof topAnchorPos === "number") {
+      this.topAnchorPos = topAnchorPos;
+    } else if (topAnchorPos === null) {
+      this.topAnchorPos = null;
     }
+    if (typeof focusAnchorPos === "number") {
+      this.focusAnchorPos = focusAnchorPos;
+    } else if (focusAnchorPos === null) {
+      this.focusAnchorPos = null;
+    }
+    // Reason: Doc changes may shift anchor visibility, so reset side lock
+    // to allow re-evaluation of above/below placement.
+    this.placementSide = null;
     this.schedulePositionUpdate();
   }
 
@@ -317,12 +339,20 @@ export class QuickAskOverlay {
     this.root = createRoot(overlayContainer);
     this.renderPanel();
 
-    // Setup scroll listeners
-    const handleScroll = () => this.schedulePositionUpdate();
+    // Reason: Reset side lock on scroll/resize so placement is re-evaluated
+    // when anchor visibility may have changed. Without this, the panel could
+    // stay locked to "above" even after scrolling makes "below" viable.
+    const handleScroll = () => {
+      this.placementSide = null;
+      this.schedulePositionUpdate();
+    };
     win.addEventListener("scroll", handleScroll, true);
     this.cleanupCallbacks.push(() => win.removeEventListener("scroll", handleScroll, true));
 
-    const handleResize = () => this.schedulePositionUpdate();
+    const handleResize = () => {
+      this.placementSide = null;
+      this.schedulePositionUpdate();
+    };
     win.addEventListener("resize", handleResize);
     this.cleanupCallbacks.push(() => win.removeEventListener("resize", handleResize));
 
@@ -337,7 +367,10 @@ export class QuickAskOverlay {
     // overlayContainer — its height changes during AI streaming would trigger
     // position recalculation and cause the panel to jump up/down.
     if (typeof ResizeObserver !== "undefined") {
-      this.resizeObserver = new ResizeObserver(() => this.schedulePositionUpdate());
+      this.resizeObserver = new ResizeObserver(() => {
+        this.placementSide = null;
+        this.schedulePositionUpdate();
+      });
       if (scrollDom) this.resizeObserver.observe(scrollDom);
     }
   }
@@ -388,28 +421,106 @@ export class QuickAskOverlay {
   }
 
   /**
-   * Try selection head first, then anchor - use whichever is visible.
-   * If neither is visible, return null so the caller can fall back to centering.
+   * Resolves visibility of both anchor positions independently.
+   * Returns separate rects for bottom and top anchors so the caller can
+   * decide placement based on available space at each end of the selection.
    */
-  private resolveVisibleAnchorRect(
+  private resolveVisibleAnchors(
     hostRect: DOMRect,
     scrollRect: DOMRect | undefined
-  ): AnchorRect | null {
+  ): { bottomRect: AnchorRect | null; topRect: AnchorRect | null; focusRect: AnchorRect | null } {
     const visibleRect = scrollRect ?? hostRect;
-    const positionsToTry: Array<number | null> = [this.pos, this.fallbackPos];
 
-    for (const pos of positionsToTry) {
-      if (typeof pos !== "number") continue;
+    const getVisibleRect = (pos: number | null): AnchorRect | null => {
+      if (typeof pos !== "number") return null;
       const coords = this.options.view.coordsAtPos(pos) as AnchorRect | null;
-      if (!coords) continue;
-      if (this.isAnchorRectVisible(coords, visibleRect)) return coords;
+      if (!coords) return null;
+      return this.isAnchorRectVisible(coords, visibleRect) ? coords : null;
+    };
+
+    return {
+      bottomRect: getVisibleRect(this.bottomAnchorPos),
+      topRect: getVisibleRect(this.topAnchorPos),
+      focusRect: getVisibleRect(this.focusAnchorPos),
+    };
+  }
+
+  /**
+   * Determines vertical placement (below or above) using dual-anchor flip logic.
+   * Implements side lock to prevent flipping during streaming output.
+   */
+  private computeVerticalPlacement(
+    bottomRect: AnchorRect | null,
+    topRect: AnchorRect | null,
+    hostRect: DOMRect,
+    visibleTop: number,
+    visibleBottom: number,
+    visibleHeight: number,
+    heightForClamp: number,
+    minTop: number
+  ): number {
+    let top: number;
+
+    // Reason: Side lock — if a previous placement was chosen and the relevant anchor
+    // is still visible, reuse that side. This prevents flipping during streaming output
+    // when the panel grows taller. The lock is reset on scroll, resize, or doc changes.
+    if (this.placementSide === "below" && bottomRect) {
+      top = bottomRect.bottom - hostRect.top + PANEL_OFFSET_Y;
+    } else if (this.placementSide === "above" && topRect) {
+      top = topRect.top - hostRect.top - PANEL_OFFSET_Y - heightForClamp;
+    } else if (bottomRect) {
+      const belowY = bottomRect.bottom - hostRect.top + PANEL_OFFSET_Y;
+      const spaceBelow = visibleBottom - (bottomRect.bottom - hostRect.top) - PANEL_OFFSET_Y;
+
+      if (spaceBelow >= heightForClamp + PANEL_MARGIN) {
+        top = belowY;
+        this.placementSide = "below";
+      } else if (topRect) {
+        const aboveY = topRect.top - hostRect.top - PANEL_OFFSET_Y - heightForClamp;
+        const spaceAbove = (topRect.top - hostRect.top) - PANEL_OFFSET_Y - visibleTop;
+
+        if (spaceAbove >= heightForClamp + PANEL_MARGIN) {
+          top = aboveY;
+          this.placementSide = "above";
+        } else {
+          // Neither side has enough space: center in visible area
+          // Reason: Consistent with other fallback branches and Quick Command behavior.
+          top = visibleTop + (visibleHeight - heightForClamp) / 2;
+          this.placementSide = null;
+        }
+      } else {
+        // Only bottom visible, not enough space below: center in visible area
+        // Reason: Flipping above would place panel inside the invisible selection.
+        top = visibleTop + (visibleHeight - heightForClamp) / 2;
+        this.placementSide = null;
+      }
+    } else if (topRect) {
+      // Bottom anchor not visible (selection extends below viewport): place above topRect
+      const aboveY = topRect.top - hostRect.top - PANEL_OFFSET_Y - heightForClamp;
+      const spaceAbove = (topRect.top - hostRect.top) - PANEL_OFFSET_Y - visibleTop;
+
+      if (spaceAbove >= heightForClamp + PANEL_MARGIN) {
+        top = aboveY;
+        this.placementSide = "above";
+      } else {
+        // Not enough space above either: center in visible area
+        top = visibleTop + (visibleHeight - heightForClamp) / 2;
+        this.placementSide = null;
+      }
+    } else {
+      // Neither anchor visible: center in viewport
+      top = visibleTop + (visibleHeight - heightForClamp) / 2;
+      this.placementSide = null;
     }
 
-    return null;
+    // Clamp top to keep panel within visible viewport
+    const maxTop = visibleBottom - PANEL_MARGIN - heightForClamp;
+    const effectiveMaxTop = Math.max(minTop, maxTop);
+    return Math.max(minTop, Math.min(top, effectiveMaxTop));
   }
 
   private updateOverlayPosition(): void {
-    if (!this.overlayContainer || this.pos === null) return;
+    if (!this.overlayContainer || this.bottomAnchorPos === null) return;
 
     // If panel has been dragged, use drag position
     if (this.dragPosition) {
@@ -427,8 +538,8 @@ export class QuickAskOverlay {
     const sizer = scrollDom?.querySelector(".cm-sizer");
     const sizerRect = sizer?.getBoundingClientRect();
 
-    // Try to find a visible anchor position (head first, then anchor)
-    const anchorRect = this.resolveVisibleAnchorRect(hostRect, scrollRect);
+    // Resolve both anchor rects independently
+    const { bottomRect, topRect, focusRect } = this.resolveVisibleAnchors(hostRect, scrollRect);
 
     // Calculate panel dimensions using constants
     const defaultWidth = Math.min(
@@ -449,10 +560,38 @@ export class QuickAskOverlay {
       sizerRect?.width ?? scrollRect?.width ?? viewportWidth - PANEL_MARGIN * 2;
     const contentRight = contentLeft + editorContentWidth;
 
-    // Calculate left position: anchor to selection if visible, otherwise center
-    let left = anchorRect
-      ? anchorRect.left - hostRect.left
-      : contentLeft + (editorContentWidth - panelWidth) / 2;
+    // --- Visual multi-line detection ---
+    // Reason: Multiline selections center on the editor to avoid edge-snapping on
+    // reverse selections and soft-wrapped content, matching CustomCommandChatModal behavior.
+    const isCursor =
+      this.topAnchorPos !== null &&
+      this.bottomAnchorPos !== null &&
+      this.topAnchorPos === this.bottomAnchorPos;
+    const topCoords =
+      typeof this.topAnchorPos === "number"
+        ? this.options.view.coordsAtPos(this.topAnchorPos)
+        : null;
+    const bottomCoords =
+      typeof this.bottomAnchorPos === "number"
+        ? this.options.view.coordsAtPos(this.bottomAnchorPos)
+        : null;
+    const caretHeight = Math.min(
+      (topCoords?.bottom ?? 0) - (topCoords?.top ?? 0),
+      (bottomCoords?.bottom ?? 0) - (bottomCoords?.top ?? 0)
+    );
+    const isVisualMultiLine =
+      !isCursor &&
+      !!topCoords &&
+      !!bottomCoords &&
+      Math.abs(topCoords.top - bottomCoords.top) > Math.max(caretHeight / 2, 2);
+
+    // Horizontal placement: center multiline on editor, otherwise anchor at focus end
+    const horizontalAnchor = focusRect ?? bottomRect ?? topRect;
+    let left = isVisualMultiLine
+      ? contentLeft + (editorContentWidth - panelWidth) / 2
+      : horizontalAnchor
+        ? horizontalAnchor.left - hostRect.left
+        : contentLeft + (editorContentWidth - panelWidth) / 2;
     left = Math.min(left, contentRight - panelWidth);
     left = Math.max(left, contentLeft);
     left = Math.min(left, viewportWidth - PANEL_MARGIN - panelWidth);
@@ -464,7 +603,7 @@ export class QuickAskOverlay {
     const visibleHeight = visibleBottom - visibleTop;
     const minTop = visibleTop + PANEL_MARGIN;
 
-    // First pass: apply width/left so we can measure actual height for centering
+    // First pass: apply width/left so we can measure actual height
     updateDynamicStyleClass(this.overlayContainer, "copilot-quick-ask-overlay-pos", {
       width: panelWidth,
       ...(typeof panelHeight === "number" ? { height: panelHeight } : {}),
@@ -472,22 +611,23 @@ export class QuickAskOverlay {
       top: Math.round(minTop), // Temporary top for measurement
     });
 
-    // Measure height for centering and clamping
+    // Measure height for placement decision and clamping
     const heightForClamp =
       typeof panelHeight === "number"
         ? panelHeight
         : this.overlayContainer.getBoundingClientRect().height || PANEL_MIN_HEIGHT;
 
-    // Calculate top position: anchor below selection if visible, otherwise center in viewport
-    let top = anchorRect
-      ? anchorRect.bottom - hostRect.top + PANEL_OFFSET_Y
-      : visibleTop + (visibleHeight - heightForClamp) / 2; // True center
-    top = Math.max(top, minTop);
-
-    // Clamp top to keep panel within viewport
-    const maxTop = visibleBottom - PANEL_MARGIN - heightForClamp;
-    const effectiveMaxTop = Math.max(minTop, maxTop);
-    const clampedTop = Math.max(minTop, Math.min(top, effectiveMaxTop));
+    // Calculate vertical position with dual-anchor flip logic
+    const clampedTop = this.computeVerticalPlacement(
+      bottomRect,
+      topRect,
+      hostRect,
+      visibleTop,
+      visibleBottom,
+      visibleHeight,
+      heightForClamp,
+      minTop
+    );
 
     // Final pass: apply the correct top position
     updateDynamicStyleClass(this.overlayContainer, "copilot-quick-ask-overlay-pos", {

--- a/src/components/quick-ask/types.ts
+++ b/src/components/quick-ask/types.ts
@@ -51,9 +51,12 @@ export interface QuickAskPanelProps {
  * Payload for the Quick Ask widget StateEffect.
  */
 export interface QuickAskWidgetPayload {
-  pos: number;
-  /** Optional fallback anchor position (typically selection anchor) */
-  fallbackPos?: number | null;
+  /** Bottom anchor position — normalized selection.to for "place below" */
+  bottomAnchorPos: number;
+  /** Top anchor position — selection.from for "place above" (flip target) */
+  topAnchorPos?: number | null;
+  /** Focus anchor position — selection.head for horizontal placement in reverse selections */
+  focusAnchorPos?: number | null;
   options: {
     plugin: CopilotPlugin;
     editor: Editor;

--- a/src/editor/quickAskController.ts
+++ b/src/editor/quickAskController.ts
@@ -12,10 +12,10 @@ import { createMapPosReplaceGuard } from "./replaceGuard";
 import { SelectionHighlight } from "./selectionHighlight";
 import type CopilotPlugin from "@/main";
 import { logWarn } from "@/logger";
+import { computeSelectionAnchors } from "@/utils/selectionAnchors";
 
 interface QuickAskWidgetState {
   view: EditorView;
-  pos: number;
   close: (restoreFocus?: boolean) => void;
 }
 
@@ -143,6 +143,8 @@ export class QuickAskController {
     };
 
     try {
+      const anchors = computeSelectionAnchors(selection, view.state.doc);
+
       view.dispatch({
         effects: [
           // First clear any existing widget and highlight
@@ -150,8 +152,9 @@ export class QuickAskController {
           ...SelectionHighlight.buildEffects(view, null),
           // Then create the new widget with highlight
           quickAskWidgetEffect.of({
-            pos: selection.head,
-            fallbackPos: selection.anchor,
+            bottomAnchorPos: anchors.bottomPos,
+            topAnchorPos: anchors.topPos,
+            focusAnchorPos: anchors.focusPos,
             options: {
               plugin: this.plugin,
               editor,
@@ -167,7 +170,7 @@ export class QuickAskController {
         ],
       });
 
-      this.quickAskWidgetState = { view, pos: selection.head, close };
+      this.quickAskWidgetState = { view, close };
     } catch (error) {
       // View may have been destroyed
       logWarn("Failed to show Quick Ask panel:", error);

--- a/src/editor/quickAskExtension.ts
+++ b/src/editor/quickAskExtension.ts
@@ -11,6 +11,7 @@ import { StateEffect } from "@codemirror/state";
 import { EditorView, ViewPlugin, ViewUpdate } from "@codemirror/view";
 import { QuickAskOverlay } from "@/components/quick-ask/QuickAskOverlay";
 import type { QuickAskWidgetPayload } from "@/components/quick-ask/types";
+import { mapQuickAskAnchorPositions } from "@/utils/quickAskAnchorMapping";
 
 /**
  * StateEffect for showing/hiding the Quick Ask widget.
@@ -25,8 +26,9 @@ export const quickAskWidgetEffect = StateEffect.define<QuickAskWidgetPayload | n
 export const quickAskOverlayPlugin = ViewPlugin.fromClass(
   class {
     private overlay: QuickAskOverlay | null = null;
-    private pos: number | null = null;
-    private fallbackPos: number | null = null;
+    private bottomAnchorPos: number | null = null;
+    private topAnchorPos: number | null = null;
+    private focusAnchorPos: number | null = null;
 
     constructor(private readonly view: EditorView) {}
 
@@ -41,21 +43,25 @@ export const quickAskOverlayPlugin = ViewPlugin.fromClass(
             // Close the overlay (highlight is handled by controller)
             this.overlay?.destroy();
             this.overlay = null;
-            this.pos = null;
-            this.fallbackPos = null;
+            this.bottomAnchorPos = null;
+            this.topAnchorPos = null;
+            this.focusAnchorPos = null;
             continue;
           }
 
           // Close existing overlay before opening new one
           this.overlay?.destroy();
-          this.pos = payload.pos;
-          this.fallbackPos = typeof payload.fallbackPos === "number" ? payload.fallbackPos : null;
+          this.bottomAnchorPos = payload.bottomAnchorPos;
+          this.topAnchorPos =
+            typeof payload.topAnchorPos === "number" ? payload.topAnchorPos : null;
+          this.focusAnchorPos =
+            typeof payload.focusAnchorPos === "number" ? payload.focusAnchorPos : null;
 
           // NOTE: SelectionHighlight is now managed by quickAskController.ts
           // to avoid dispatch-during-update errors
 
           this.overlay = new QuickAskOverlay(payload.options);
-          this.overlay.mount(payload.pos, this.fallbackPos);
+          this.overlay.mount(payload.bottomAnchorPos, this.topAnchorPos, this.focusAnchorPos);
         }
       }
 
@@ -67,15 +73,19 @@ export const quickAskOverlayPlugin = ViewPlugin.fromClass(
           guard.onDocChanged(update.changes);
         }
 
-        // Update anchor position for panel positioning
-        if (this.pos !== null) {
-          this.pos = update.changes.mapPos(this.pos);
-        }
-        if (this.fallbackPos !== null) {
-          this.fallbackPos = update.changes.mapPos(this.fallbackPos);
-        }
-        if (this.pos !== null) {
-          this.overlay.updatePosition(this.pos, this.fallbackPos);
+        const mapped = mapQuickAskAnchorPositions(
+          {
+            bottomAnchorPos: this.bottomAnchorPos,
+            topAnchorPos: this.topAnchorPos,
+            focusAnchorPos: this.focusAnchorPos,
+          },
+          update.changes
+        );
+        this.bottomAnchorPos = mapped.bottomAnchorPos;
+        this.topAnchorPos = mapped.topAnchorPos;
+        this.focusAnchorPos = mapped.focusAnchorPos;
+        if (this.bottomAnchorPos !== null) {
+          this.overlay.updatePosition(this.bottomAnchorPos, this.topAnchorPos, this.focusAnchorPos);
         }
 
         // Trigger panel re-render to update Replace button disabled state
@@ -87,8 +97,9 @@ export const quickAskOverlayPlugin = ViewPlugin.fromClass(
       // NOTE: SelectionHighlight cleanup is handled by quickAskController.ts
       this.overlay?.destroy();
       this.overlay = null;
-      this.pos = null;
-      this.fallbackPos = null;
+      this.bottomAnchorPos = null;
+      this.topAnchorPos = null;
+      this.focusAnchorPos = null;
     }
   }
 );

--- a/src/utils/panelPlacement.test.ts
+++ b/src/utils/panelPlacement.test.ts
@@ -1,0 +1,128 @@
+import { computeVerticalPlacement, type VerticalPlacementInput } from "./panelPlacement";
+
+/** Helper: build input with sensible defaults. */
+function makeInput(overrides: Partial<VerticalPlacementInput> = {}): VerticalPlacementInput {
+  return {
+    scrollRect: { top: 50, bottom: 850 },
+    visibleBottom: null,
+    visibleTop: null,
+    panelHeight: 400,
+    margin: 12,
+    gap: 6,
+    viewportHeight: 900,
+    ...overrides,
+  };
+}
+
+describe("computeVerticalPlacement", () => {
+  // --- Both anchors visible ---
+
+  it("places below when enough space below", () => {
+    const input = makeInput({
+      visibleBottom: { top: 100, bottom: 120 },
+      visibleTop: { top: 80, bottom: 100 },
+    });
+    const result = computeVerticalPlacement(input);
+    expect(result.top).toBe(120 + 6); // visibleBottom.bottom + gap
+    expect(result.anchorBottomY).toBeUndefined();
+  });
+
+  it("places above when not enough space below but enough above", () => {
+    const input = makeInput({
+      visibleBottom: { top: 700, bottom: 720 },
+      visibleTop: { top: 500, bottom: 520 },
+    });
+    const result = computeVerticalPlacement(input);
+    expect(result.anchorBottomY).toBe(500 - 6); // visibleTop.top - gap
+    expect(result.top).toBe(500 - 6 - 400); // anchorBottomY - panelHeight
+  });
+
+  it("centers when neither above nor below fits", () => {
+    const input = makeInput({
+      scrollRect: { top: 50, bottom: 500 },
+      visibleBottom: { top: 200, bottom: 220 },
+      visibleTop: { top: 100, bottom: 120 },
+      panelHeight: 400,
+    });
+    const result = computeVerticalPlacement(input);
+    // editorCenter = (50 + 500) / 2 - 400 / 2 = 275 - 200 = 75
+    // Clamped: max(12, min(75, 900 - 12 - 400)) = max(12, min(75, 488)) = 75
+    expect(result.top).toBe(75);
+    expect(result.anchorBottomY).toBeUndefined();
+  });
+
+  // --- Only bottom anchor visible ---
+
+  it("places below when only bottom visible and space fits", () => {
+    const input = makeInput({
+      visibleBottom: { top: 100, bottom: 120 },
+      visibleTop: null,
+    });
+    const result = computeVerticalPlacement(input);
+    expect(result.top).toBe(120 + 6); // visibleBottom.bottom + gap
+    expect(result.anchorBottomY).toBeUndefined();
+  });
+
+  it("centers when only bottom visible and below doesn't fit", () => {
+    const input = makeInput({
+      visibleBottom: { top: 780, bottom: 800 },
+      visibleTop: null,
+    });
+    const result = computeVerticalPlacement(input);
+    // spaceBelow = 850 - 800 - 6 = 44, requiredSpace = 412 → center
+    // editorCenter = (50 + 850) / 2 - 200 = 250
+    expect(result.top).toBe(250);
+    expect(result.anchorBottomY).toBeUndefined();
+  });
+
+  it("does not flip above visibleBottom (regression: panel inside selection)", () => {
+    const input = makeInput({
+      visibleBottom: { top: 400, bottom: 420 },
+      visibleTop: null,
+      panelHeight: 400,
+    });
+    const result = computeVerticalPlacement(input);
+    // spaceBelow = 850 - 420 - 6 = 424, requiredSpace = 412 → fits below
+    expect(result.top).toBe(420 + 6);
+    expect(result.anchorBottomY).toBeUndefined();
+  });
+
+  // --- Only top anchor visible ---
+
+  it("places above when only top visible and enough space", () => {
+    const input = makeInput({
+      visibleTop: { top: 500, bottom: 520 },
+      visibleBottom: null,
+    });
+    const result = computeVerticalPlacement(input);
+    expect(result.anchorBottomY).toBe(500 - 6);
+    expect(result.top).toBe(500 - 6 - 400);
+  });
+
+  it("centers when only top visible and not enough space above", () => {
+    const input = makeInput({
+      scrollRect: { top: 50, bottom: 850 },
+      visibleTop: { top: 100, bottom: 120 },
+      visibleBottom: null,
+      panelHeight: 400,
+    });
+    const result = computeVerticalPlacement(input);
+    // spaceAbove = 100 - 50 - 6 = 44, requiredSpace = 412, so center
+    // editorCenter = (50 + 850) / 2 - 200 = 250
+    expect(result.top).toBe(250);
+    expect(result.anchorBottomY).toBeUndefined();
+  });
+
+  // --- Neither anchor visible ---
+
+  it("centers when neither anchor is visible", () => {
+    const input = makeInput({
+      visibleBottom: null,
+      visibleTop: null,
+    });
+    const result = computeVerticalPlacement(input);
+    // editorCenter = (50 + 850) / 2 - 200 = 250
+    expect(result.top).toBe(250);
+    expect(result.anchorBottomY).toBeUndefined();
+  });
+});

--- a/src/utils/panelPlacement.ts
+++ b/src/utils/panelPlacement.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure vertical placement logic for selection-anchored panels
+ * (Quick Command, Custom Command, etc.).
+ *
+ * Extracted so the branching can be tested without DOM / CodeMirror dependencies.
+ */
+
+export interface Rect {
+  top: number;
+  bottom: number;
+}
+
+export interface VerticalPlacementInput {
+  /** Editor visible scroll area. */
+  scrollRect: Rect;
+  /** Coords of the bottom selection anchor (null if not visible). */
+  visibleBottom: Rect | null;
+  /** Coords of the top selection anchor (null if not visible). */
+  visibleTop: Rect | null;
+  /** Estimated panel height. */
+  panelHeight: number;
+  /** Minimum margin from viewport edge. */
+  margin: number;
+  /** Gap between anchor and panel. */
+  gap: number;
+  /** Viewport height (window.innerHeight). */
+  viewportHeight: number;
+}
+
+export interface VerticalPlacementResult {
+  top: number;
+  /** Set only when panel is placed above, for upward-growth anchoring. */
+  anchorBottomY?: number;
+}
+
+/**
+ * Decides the vertical position for a selection-anchored panel.
+ *
+ * Priority:
+ * 1. Both anchors visible → below > above > center
+ * 2. Only bottom visible → below if fits, otherwise center
+ * 3. Only top visible → above > center
+ * 4. Neither → center
+ */
+export function computeVerticalPlacement(input: VerticalPlacementInput): VerticalPlacementResult {
+  const { scrollRect, visibleBottom, visibleTop, panelHeight, margin, gap, viewportHeight } = input;
+
+  const editorCenter = (scrollRect.top + scrollRect.bottom) / 2 - panelHeight / 2;
+  const requiredSpace = panelHeight + margin;
+
+  let top: number;
+  let anchorBottomY: number | undefined;
+
+  if (visibleBottom && visibleTop) {
+    const spaceBelow = scrollRect.bottom - visibleBottom.bottom - gap;
+    const spaceAbove = visibleTop.top - scrollRect.top - gap;
+
+    if (spaceBelow >= requiredSpace) {
+      top = visibleBottom.bottom + gap;
+    } else if (spaceAbove >= requiredSpace) {
+      anchorBottomY = visibleTop.top - gap;
+      top = anchorBottomY - panelHeight;
+    } else {
+      top = editorCenter;
+    }
+  } else if (visibleBottom) {
+    // Reason: Never flip above — that would place panel inside the invisible selection.
+    // If below doesn't fit either, center in editor (consistent with other fallbacks).
+    const spaceBelow = scrollRect.bottom - visibleBottom.bottom - gap;
+
+    if (spaceBelow >= requiredSpace) {
+      top = visibleBottom.bottom + gap;
+    } else {
+      top = editorCenter;
+    }
+  } else if (visibleTop) {
+    const spaceAbove = visibleTop.top - scrollRect.top - gap;
+
+    if (spaceAbove >= requiredSpace) {
+      anchorBottomY = visibleTop.top - gap;
+      top = anchorBottomY - panelHeight;
+    } else {
+      top = editorCenter;
+    }
+  } else {
+    top = editorCenter;
+  }
+
+  // Clamp within viewport
+  top = Math.max(margin, Math.min(top, viewportHeight - margin - panelHeight));
+
+  return anchorBottomY !== undefined ? { top, anchorBottomY } : { top };
+}

--- a/src/utils/quickAskAnchorMapping.test.ts
+++ b/src/utils/quickAskAnchorMapping.test.ts
@@ -1,0 +1,96 @@
+import {
+  mapQuickAskAnchorPositions,
+  type QuickAskAnchorPositions,
+} from "./quickAskAnchorMapping";
+
+/** Creates a mock ChangeMapper that records calls and returns deterministic results. */
+function makeChanges() {
+  const calls: Array<{ pos: number; assoc?: number }> = [];
+  return {
+    calls,
+    changes: {
+      mapPos(pos: number, assoc?: number) {
+        calls.push({ pos, assoc });
+        // Deterministic: multiply by 10 and add assoc so we can verify which assoc was used
+        return pos * 10 + (assoc ?? 0);
+      },
+    },
+  };
+}
+
+describe("mapQuickAskAnchorPositions", () => {
+  it("maps cursor selections once so all anchors stay identical", () => {
+    const { calls, changes } = makeChanges();
+    const anchors: QuickAskAnchorPositions = {
+      bottomAnchorPos: 12,
+      topAnchorPos: 12,
+      focusAnchorPos: 12,
+    };
+
+    const result = mapQuickAskAnchorPositions(anchors, changes);
+
+    expect(calls).toEqual([{ pos: 12, assoc: 1 }]);
+    expect(result).toEqual({
+      bottomAnchorPos: 121,
+      topAnchorPos: 121,
+      focusAnchorPos: 121,
+    });
+  });
+
+  it("maps forward selection (focus at bottom) with correct assoc values", () => {
+    const { calls, changes } = makeChanges();
+    const anchors: QuickAskAnchorPositions = {
+      bottomAnchorPos: 20,
+      topAnchorPos: 10,
+      focusAnchorPos: 20, // forward: head is at the bottom edge
+    };
+
+    mapQuickAskAnchorPositions(anchors, changes);
+
+    expect(calls).toEqual([
+      { pos: 20, assoc: -1 }, // bottom sticks left
+      { pos: 10, assoc: 1 }, // top sticks right
+      { pos: 20, assoc: -1 }, // focus follows bottom edge
+    ]);
+  });
+
+  it("maps reverse selection (focus at top) with correct assoc values", () => {
+    const { calls, changes } = makeChanges();
+    const anchors: QuickAskAnchorPositions = {
+      bottomAnchorPos: 20,
+      topAnchorPos: 10,
+      focusAnchorPos: 10, // reverse: head is at the top edge
+    };
+
+    mapQuickAskAnchorPositions(anchors, changes);
+
+    expect(calls).toEqual([
+      { pos: 20, assoc: -1 }, // bottom sticks left
+      { pos: 10, assoc: 1 }, // top sticks right
+      { pos: 10, assoc: 1 }, // focus follows top edge
+    ]);
+  });
+
+  it("handles null anchors gracefully", () => {
+    const { changes } = makeChanges();
+    const result = mapQuickAskAnchorPositions(
+      { bottomAnchorPos: null, topAnchorPos: null, focusAnchorPos: null },
+      changes
+    );
+    expect(result).toEqual({
+      bottomAnchorPos: null,
+      topAnchorPos: null,
+      focusAnchorPos: null,
+    });
+  });
+
+  it("handles newline-end selections the same as any other bottom anchor", () => {
+    const { changes } = makeChanges();
+    const result = mapQuickAskAnchorPositions(
+      { bottomAnchorPos: 11, topAnchorPos: 2, focusAnchorPos: 11 },
+      changes
+    );
+    // bottom: 11*10 + (-1) = 109
+    expect(result.bottomAnchorPos).toBe(109);
+  });
+});

--- a/src/utils/quickAskAnchorMapping.ts
+++ b/src/utils/quickAskAnchorMapping.ts
@@ -1,0 +1,41 @@
+export interface QuickAskAnchorPositions {
+  bottomAnchorPos: number | null;
+  topAnchorPos: number | null;
+  focusAnchorPos: number | null;
+}
+
+interface ChangeMapper {
+  mapPos(pos: number, assoc?: number): number;
+}
+
+/**
+ * Maps Quick Ask anchor positions across document changes.
+ *
+ * Uses explicit assoc to match ReplaceGuard semantics (replaceGuard.ts:159-160):
+ * - `topAnchorPos` (selection.from) uses `assoc=1` so insertions before it push it right.
+ * - `bottomAnchorPos` (selection.to) uses `assoc=-1` so insertions after it don't move it.
+ * - `focusAnchorPos` follows whichever edge currently holds the user's head/focus:
+ *   if focus == topPos (reverse selection), assoc=1; if focus == bottomPos (forward), assoc=-1.
+ * - Cursor selections (all positions equal) map once to keep anchors identical.
+ */
+export function mapQuickAskAnchorPositions(
+  anchors: QuickAskAnchorPositions,
+  changes: ChangeMapper
+): QuickAskAnchorPositions {
+  const { bottomAnchorPos, topAnchorPos, focusAnchorPos } = anchors;
+
+  // Cursor selection: map once to avoid divergence
+  if (bottomAnchorPos !== null && bottomAnchorPos === topAnchorPos) {
+    const mapped = changes.mapPos(bottomAnchorPos, 1);
+    return { bottomAnchorPos: mapped, topAnchorPos: mapped, focusAnchorPos: mapped };
+  }
+
+  // Range selection: each anchor maps with its own assoc
+  const focusAssoc = focusAnchorPos === topAnchorPos ? 1 : -1;
+
+  return {
+    bottomAnchorPos: bottomAnchorPos !== null ? changes.mapPos(bottomAnchorPos, -1) : null,
+    topAnchorPos: topAnchorPos !== null ? changes.mapPos(topAnchorPos, 1) : null,
+    focusAnchorPos: focusAnchorPos !== null ? changes.mapPos(focusAnchorPos, focusAssoc) : null,
+  };
+}

--- a/src/utils/selectionAnchors.test.ts
+++ b/src/utils/selectionAnchors.test.ts
@@ -1,0 +1,62 @@
+import { computeSelectionAnchors } from "./selectionAnchors";
+
+/** Creates a mock document with lineAt() based on known line start positions. */
+function makeDoc(lineStarts: number[]) {
+  return {
+    lineAt(pos: number) {
+      const from = [...lineStarts].reverse().find((start) => start <= pos) ?? 0;
+      return { from };
+    },
+  };
+}
+
+describe("computeSelectionAnchors", () => {
+  it("returns unchanged positions for a regular forward selection", () => {
+    const doc = makeDoc([0, 6]);
+    const result = computeSelectionAnchors({ from: 1, to: 4, head: 4, empty: false }, doc);
+
+    expect(result).toEqual({ topPos: 1, bottomPos: 4, focusPos: 4 });
+  });
+
+  it("backs bottomPos up one character when selection.to lands at a line start", () => {
+    const doc = makeDoc([0, 6, 12]);
+    const result = computeSelectionAnchors({ from: 2, to: 6, head: 6, empty: false }, doc);
+
+    expect(result).toEqual({ topPos: 2, bottomPos: 5, focusPos: 5 });
+  });
+
+  it("does not apply the line-start trap to an empty selection", () => {
+    const doc = makeDoc([0, 6]);
+    const result = computeSelectionAnchors({ from: 6, to: 6, head: 6, empty: true }, doc);
+
+    expect(result).toEqual({ topPos: 6, bottomPos: 6, focusPos: 6 });
+  });
+
+  it("preserves focusPos at selection.from for reverse (backward) selections", () => {
+    // Reverse selection: head is at from (top), anchor is at to (bottom)
+    const doc = makeDoc([0, 10]);
+    const result = computeSelectionAnchors({ from: 2, to: 8, head: 2, empty: false }, doc);
+
+    expect(result.focusPos).toBe(2);
+    expect(result.topPos).toBe(2);
+    expect(result.bottomPos).toBe(8);
+  });
+
+  it("applies line-start trap to focusPos when it equals selection.to at a line start", () => {
+    // Forward selection where head==to lands on a line start
+    const doc = makeDoc([0, 6, 12]);
+    const result = computeSelectionAnchors({ from: 2, to: 12, head: 12, empty: false }, doc);
+
+    expect(result.bottomPos).toBe(11);
+    expect(result.focusPos).toBe(11);
+  });
+
+  it("does not apply line-start trap to focusPos when head != selection.to", () => {
+    // Reverse selection: head is at from, not at to — no trap needed
+    const doc = makeDoc([0, 6, 12]);
+    const result = computeSelectionAnchors({ from: 6, to: 12, head: 6, empty: false }, doc);
+
+    expect(result.bottomPos).toBe(11); // line-start trap applied
+    expect(result.focusPos).toBe(6); // head is at from, no trap
+  });
+});

--- a/src/utils/selectionAnchors.ts
+++ b/src/utils/selectionAnchors.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared utility for computing dual-anchor positions from a CodeMirror selection.
+ * Used by Quick Ask and Quick Command to determine panel placement relative to selection.
+ */
+
+export interface SelectionAnchors {
+  /** Normalized selection.to — visual bottom of the selection (line-start trap applied) */
+  bottomPos: number;
+  /** selection.from — visual top of the selection */
+  topPos: number;
+  /** selection.head — the user's focus end (for horizontal anchor in reverse selections) */
+  focusPos: number;
+}
+
+/**
+ * Computes dual-anchor positions from a CodeMirror selection.
+ *
+ * The "line-start trap" fix handles the case where selecting text that includes
+ * a newline causes `selection.to` to land on the next line's start. In this case,
+ * `coordsAtPos(to)` would return coordinates for the next line, causing the panel
+ * to anchor one line too low. We fix this by backing up to `to - 1`.
+ *
+ * @param selection - CodeMirror selection with from, to, and empty fields
+ * @param doc - Document object with lineAt() for line-start detection
+ * @returns Dual anchors: bottomPos for "place below", topPos for "place above"
+ */
+export function computeSelectionAnchors(
+  selection: { from: number; to: number; head: number; empty: boolean },
+  doc: { lineAt(pos: number): { from: number } }
+): SelectionAnchors {
+  const topPos = selection.from;
+  let bottomPos = selection.to;
+  let focusPos = selection.head;
+
+  // Reason: Line-start trap — only applies to non-empty selections with to > 0.
+  // When selection.to lands exactly at a line's start (after selecting a newline),
+  // back up one character so coordsAtPos returns the previous line's bottom.
+  if (!selection.empty && bottomPos > 0) {
+    if (doc.lineAt(bottomPos).from === bottomPos) {
+      bottomPos = bottomPos - 1;
+    }
+  }
+
+  // Reason: Apply the same line-start trap to focusPos when it equals selection.to,
+  // so reverse selections still anchor near the user's focus end.
+  if (!selection.empty && focusPos > 0 && focusPos === selection.to) {
+    if (doc.lineAt(focusPos).from === focusPos) {
+      focusPos = focusPos - 1;
+    }
+  }
+
+  return { bottomPos, topPos, focusPos };
+}


### PR DESCRIPTION
## issues 
- #2261

## Summary
- Overhaul vertical placement for Quick Ask and Command panels: panels now appear above the selection when there is insufficient space below, with upward-growing anchor behavior
- Extract pure helpers (`panelPlacement.ts`, `selectionAnchors.ts`, `quickAskAnchorMapping.ts`) for testable positioning and anchor mapping logic
- Add visual multiline detection to both QuickAskOverlay and CustomCommandChatModal — multiline selections center the panel on the editor instead of edge-snapping
- Fix drag detection in DraggableModal: only mark as manually positioned after actual pointer movement (>2px), so a click on the drag handle preserves anchor behavior
- Normalize newline-at-end selections to avoid the "line-start trap" where the panel jumps to column 0

## Test plan
- [x] 20 unit tests added across `panelPlacement.test.ts`, `selectionAnchors.test.ts`, `quickAskAnchorMapping.test.ts`
- [x] All 1785 existing tests pass
- [x] TypeScript compiles clean, ESLint clean
- [ ] Manual: select text near bottom of editor → panel appears above selection
- [ ] Manual: multiline selection → panel centers horizontally on editor
- [ ] Manual: click drag handle without dragging → panel stays anchored (no jump)
- [ ] Manual: drag the panel → panel switches to free positioning correctly

## Actual Effect

<img width="2182" height="4898" alt="Obsidian 2026-03-11 21 12 24" src="https://github.com/user-attachments/assets/fb6c2800-0c99-45f6-a7f6-b380bfde4c28" />