### PR TITLE
fix: add 'None' option to system prompt dropdown in chat settings

### DIFF
--- a/src/components/chat-components/ChatSettingsPopover.tsx
+++ b/src/components/chat-components/ChatSettingsPopover.tsx
@@ -247,18 +247,22 @@ export function ChatSettingsPopover() {
                       value={displayValue}
                       onChange={(e) => {
                         const value = e.target.value;
-                        // Only update if a valid prompt is selected
-                        if (value && promptExists(value)) {
+                        if (value === "") {
+                          setSessionPrompt("");
+                        } else if (promptExists(value)) {
                           setSessionPrompt(value);
                         }
                       }}
-                      options={prompts.map((prompt) => ({
-                        label:
-                          prompt.title === globalDefault
-                            ? `${prompt.title} (Default)`
-                            : prompt.title,
-                        value: prompt.title,
-                      }))}
+                      options={[
+                        { label: "None (use built-in prompt)", value: "" },
+                        ...prompts.map((prompt) => ({
+                          label:
+                            prompt.title === globalDefault
+                              ? `${prompt.title} (Default)`
+                              : prompt.title,
+                          value: prompt.title,
+                        })),
+                      ]}
                       placeholder="Select system prompt"
                       containerClassName="tw-flex-1"
                     />


### PR DESCRIPTION
## Summary
- Adds "None (use built-in prompt)" as the first option in the chat settings system prompt dropdown, matching the Advanced settings tab
- Allows selecting empty value to clear the session system prompt

Closes #2292

## Test plan
- [ ] Open chat settings (gear menu), verify "None (use built-in prompt)" appears as first option
- [ ] Select a custom prompt, then switch to "None", verify it clears the system prompt
- [ ] Verify Advanced settings tab still works the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)