### PR TITLE
chore: fix pre-commit hook to enforce formatting and linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,1 @@
-# .husky/pre-commit
-prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
-git update-index --again
-
-# Add linting
-npm run lint
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -22,15 +22,12 @@
   },
   "keywords": [],
   "author": "Logan Yang",
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,css,md}": [
-      "prettier --write",
-      "git add"
+      "prettier --write"
+    ],
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix --no-warn-ignored"
     ]
   },
   "license": "AGPL-3.0",


### PR DESCRIPTION
## Summary
- Make `.husky/pre-commit` executable (was `644`, now `755`)
- Use `npx lint-staged` instead of raw prettier/eslint commands
- Remove deprecated husky v4 `hooks` config from package.json
- Remove unnecessary `git add` from lint-staged (auto-staged in v15)
- Add `eslint --fix` to lint-staged for JS/TS files

Closes #2296

## Test plan
- [x] Hook runs on commit (verified: lint-staged output shown)
- [x] Build passes
- [x] All 1852 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)