### PR TITLE
feat: add Gemini Embedding 2 preview support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -454,6 +454,7 @@ export enum EmbeddingModels {
   COHEREAI_EMBED_MULTILINGUAL_LIGHT_V3_0 = "embed-multilingual-light-v3.0",
   GOOGLE_ENG = "text-embedding-004",
   GOOGLE_GEMINI_EMBEDDING = "gemini-embedding-001",
+  GOOGLE_GEMINI_EMBEDDING_2_PREVIEW = "gemini-embedding-2-preview",
   COPILOT_PLUS_SMALL = "copilot-plus-small",
   COPILOT_PLUS_LARGE = "copilot-plus-large",
   COPILOT_PLUS_MULTILINGUAL = "copilot-plus-multilingual",
@@ -531,6 +532,14 @@ export const BUILTIN_EMBEDDING_MODELS: CustomModel[] = [
   },
   {
     name: EmbeddingModels.GOOGLE_GEMINI_EMBEDDING,
+    provider: EmbeddingModelProviders.GOOGLE,
+    enabled: true,
+    isBuiltIn: true,
+    isEmbeddingModel: true,
+    core: true,
+  },
+  {
+    name: EmbeddingModels.GOOGLE_GEMINI_EMBEDDING_2_PREVIEW,
     provider: EmbeddingModelProviders.GOOGLE,
     enabled: true,
     isBuiltIn: true,


### PR DESCRIPTION
## Summary

- Adds `gemini-embedding-2-preview` to `EmbeddingModels` enum and `BUILTIN_EMBEDDING_MODELS` in `src/constants.ts`
- Enabled by default (`core: true`) so users can select it immediately after providing their Google API key
- No changes to `EmbeddingManager` — the existing `GoogleGenerativeAIEmbeddings` LangChain class handles this model automatically

## Why

`gemini-embedding-2-preview` is Google's latest embedding model (as of March 2026) with significant improvements over the existing `gemini-embedding-001`:
- **Multimodal**: unified embedding space for text, images, video, audio, and PDF
- **Larger context**: 8,192 token input limit (vs 2,048)
- **Higher dimensions**: up to 3,072 output dimensions
- **Better quality**: state-of-the-art MTEB leaderboard performance

Closes #2298

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] `npm run test` passes (1852 tests)
- [ ] New model appears in embedding model dropdown in Obsidian settings
- [ ] Selecting the model and indexing vault works with a valid Google API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)