### PR TITLE
refactor(tools): remove daily note append/prepend CLI commands

### DIFF
--- a/src/LLMProviders/chainRunner/utils/AgentReasoningState.test.ts
+++ b/src/LLMProviders/chainRunner/utils/AgentReasoningState.test.ts
@@ -8,12 +8,6 @@ describe("AgentReasoningState tool summaries", () => {
     expect(summarizeToolCall("obsidianDailyNote", { command: "daily:read", vault: "Work" })).toBe(
       `Reading today's daily note from "Work"`
     );
-    expect(summarizeToolCall("obsidianDailyNote", { command: "daily:append" })).toBe(
-      "Appending to daily note"
-    );
-    expect(
-      summarizeToolCall("obsidianDailyNote", { command: "daily:prepend", vault: "Work" })
-    ).toBe(`Prepending to daily note from "Work"`);
     expect(summarizeToolCall("obsidianDailyNote", { command: "daily:path" })).toBe(
       "Getting daily note path"
     );
@@ -36,11 +30,6 @@ describe("AgentReasoningState tool summaries", () => {
         command: "daily:read",
       })
     ).toBe("Loaded today's daily note");
-    expect(
-      summarizeToolResult("obsidianDailyNote", { success: true }, undefined, {
-        command: "daily:append",
-      })
-    ).toBe("Appended to daily note");
     expect(
       summarizeToolResult("obsidianDailyNote", { success: true }, undefined, {
         command: "daily:path",
@@ -66,9 +55,9 @@ describe("AgentReasoningState tool summaries", () => {
     expect(summarizeToolCall("obsidianProperties", { command: "properties" })).toBe(
       "Listing vault properties"
     );
-    expect(summarizeToolCall("obsidianProperties", { command: "property:read", name: "tags" })).toBe(
-      `Reading property "tags"`
-    );
+    expect(
+      summarizeToolCall("obsidianProperties", { command: "property:read", name: "tags" })
+    ).toBe(`Reading property "tags"`);
     expect(summarizeToolCall("obsidianTasks", { command: "tasks" })).toBe("Listing vault tasks");
     expect(summarizeToolCall("obsidianLinks", { command: "backlinks" })).toBe("Listing backlinks");
     expect(summarizeToolCall("obsidianLinks", { command: "orphans" })).toBe(

--- a/src/LLMProviders/chainRunner/utils/AgentReasoningState.ts
+++ b/src/LLMProviders/chainRunner/utils/AgentReasoningState.ts
@@ -206,8 +206,6 @@ export function summarizeToolResult(
       const command = args?.command as string | undefined;
       const vault = args?.vault as string | undefined;
       const vaultSuffix = vault && vault.trim().length > 0 ? ` from "${vault}"` : "";
-      if (command === "daily:append") return `Appended to daily note${vaultSuffix}`;
-      if (command === "daily:prepend") return `Prepended to daily note${vaultSuffix}`;
       if (command === "daily:path") return `Got daily note path${vaultSuffix}`;
       return `Loaded today's daily note${vaultSuffix}`;
     }
@@ -378,8 +376,6 @@ export function summarizeToolCall(
       const command = args?.command as string | undefined;
       const vault = args?.vault as string | undefined;
       const vaultSuffix = vault && vault.trim().length > 0 ? ` from "${vault}"` : "";
-      if (command === "daily:append") return `Appending to daily note${vaultSuffix}`;
-      if (command === "daily:prepend") return `Prepending to daily note${vaultSuffix}`;
       if (command === "daily:path") return `Getting daily note path${vaultSuffix}`;
       return `Reading today's daily note${vaultSuffix}`;
     }

--- a/src/tools/ObsidianCliTools.test.ts
+++ b/src/tools/ObsidianCliTools.test.ts
@@ -127,49 +127,6 @@ describe("obsidianDailyNoteTool", () => {
     expect(parsed.content).toBe("Daily/2026-03-03.md");
   });
 
-  test("daily:append passes content and inline params", async () => {
-    mockedRunCommand.mockResolvedValue(buildSuccessResult("daily:append", ""));
-
-    await (obsidianDailyNoteTool as any).invoke({
-      command: "daily:append",
-      content: "- New task",
-      inline: false,
-    });
-
-    expect(mockedRunCommand).toHaveBeenCalledWith({
-      command: "daily:append",
-      vault: undefined,
-      params: { content: "- New task", inline: false },
-    });
-  });
-
-  test("daily:prepend passes content param", async () => {
-    mockedRunCommand.mockResolvedValue(buildSuccessResult("daily:prepend", ""));
-
-    await (obsidianDailyNoteTool as any).invoke({
-      command: "daily:prepend",
-      content: "## Morning",
-    });
-
-    expect(mockedRunCommand).toHaveBeenCalledWith({
-      command: "daily:prepend",
-      vault: undefined,
-      params: { content: "## Morning" },
-    });
-  });
-
-  test("daily:append throws when content is missing", async () => {
-    await expect(
-      (obsidianDailyNoteTool as any).invoke({ command: "daily:append" })
-    ).rejects.toThrow("content is required for daily:append");
-  });
-
-  test("daily:prepend throws when content is missing", async () => {
-    await expect(
-      (obsidianDailyNoteTool as any).invoke({ command: "daily:prepend" })
-    ).rejects.toThrow("content is required for daily:prepend");
-  });
-
   test("throws on CLI failure with stderr message", async () => {
     mockedRunCommand.mockResolvedValue(
       buildFailedResult("daily:read", "EFAIL", "Daily note plugin not enabled", 1)

--- a/src/tools/ObsidianCliTools.ts
+++ b/src/tools/ObsidianCliTools.ts
@@ -19,19 +19,9 @@ function buildCliParams(args: Record<string, unknown>): Record<string, string | 
 
 const dailyNoteSchema = z.object({
   command: z
-    .enum(["daily", "daily:read", "daily:append", "daily:prepend", "daily:path"])
+    .enum(["daily", "daily:read", "daily:path"])
     .describe(
-      "daily — create today's daily note (applies configured template). daily:read — read today's daily note content. daily:append — append text to the end. daily:prepend — prepend text to the beginning. daily:path — get the vault-relative file path."
-    ),
-  content: z
-    .string()
-    .optional()
-    .describe("Text to append or prepend. Required for daily:append and daily:prepend."),
-  inline: z
-    .boolean()
-    .optional()
-    .describe(
-      "For daily:append: append without a leading newline. For daily:prepend: prepend without a trailing newline."
+      "daily — create today's daily note (applies configured template). daily:read — read today's daily note content. daily:path — get the vault-relative file path."
     ),
   vault: z
     .string()
@@ -46,13 +36,10 @@ const dailyNoteSchema = z.object({
 export const obsidianDailyNoteTool = createLangChainTool({
   name: "obsidianDailyNote",
   description:
-    "Create, read, append, or prepend content to today's daily note, or get its vault path, via the official Obsidian CLI. Use readNote for reading specific notes by path. Use obsidianRandomRead for picking a random note.",
+    "Create or read today's daily note, or get its vault path, via the official Obsidian CLI. Use readNote for reading specific notes by path. Use obsidianRandomRead for picking a random note.",
   schema: dailyNoteSchema,
   func: async (args) => {
     const { command, vault } = args;
-    if ((command === "daily:append" || command === "daily:prepend") && !args.content) {
-      throw new Error(`content is required for ${command}`);
-    }
 
     const params = buildCliParams(args as Record<string, unknown>);
     const result = await runObsidianCliCommand({ command, vault, params });
@@ -60,7 +47,6 @@ export const obsidianDailyNoteTool = createLangChainTool({
     if (!result.ok) throwCliFailure(result);
 
     // Preserve raw stdout for read commands — trimming may alter meaningful Markdown whitespace.
-    // Non-read commands (append, prepend, path) return short status strings where trimming is safe.
     const content = command === "daily:read" ? result.stdout : result.stdout.trim();
 
     return {

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -335,21 +335,17 @@ export function registerCliTools(): void {
     metadata: {
       id: "obsidianDailyNote",
       displayName: "Daily Note",
-      description: "Create, read, append, or prepend to today's daily note, or get its path",
+      description: "Create or read today's daily note, or get its path",
       category: "cli",
       requiresVault: true,
       customPromptInstructions: `For obsidianDailyNote:
-- Use for all daily note operations: creating, reading content, appending text, prepending text, or getting the file path.
+- Use for daily note operations: creating, reading content, or getting the file path.
 - Use readNote for reading specific notes by path. Use obsidianDailyNote only for today's daily note.
 - daily — create today's daily note. Applies the user's configured daily note template automatically. Use this when the user asks to create or set up today's daily note.
 - daily:read — read today's daily note content.
-- daily:append — append text to the end. Requires content parameter (must be non-empty). Use inline=true to append without a newline.
-- daily:prepend — prepend text to the beginning. Requires content parameter (must be non-empty). Use inline=true to prepend without a newline.
 - daily:path — get the vault-relative file path (useful for follow-up readNote calls).
-- daily:append and daily:prepend also auto-create the daily note if it doesn't exist, but do NOT apply the template.
-- Use \\n for newlines and \\t for tabs in content strings.
 - For past or future daily notes (e.g. "yesterday's daily note"): NEVER ask the user for the date — use the time tools. Workflow: (1) call getCurrentTime to resolve the date, (2) call daily:path to discover the date format and folder, (3) call obsidianTemplates with command=templates to list available template names, then call template:read with the name that matches (e.g. "Daily Note Template"), (4) use writeToFile to create the note at the resolved path with the template content, replacing variables like {{date}} with the target date. If templates returns an error or no daily template is found, ask the user for their template path and use readNote to read it.
-- For arbitrary file writes beyond daily notes, use writeToFile or replaceInFile instead.
+- To add content to a daily note, use writeToFile or replaceInFile.
 - If the user names a specific vault, pass it using the vault parameter.`,
     },
   });
@@ -438,7 +434,7 @@ export function registerCliTools(): void {
       customPromptInstructions: `For obsidianTemplates:
 - Use 'templates' to list all available templates when you need to find the right template for a task.
 - Use 'template:read' with a template name to get its content with variables resolved. Requires name parameter.
-- This is useful for creating daily notes from templates — read the template first, then use obsidianDailyNote's daily:prepend to populate the note.`,
+- This is useful for creating daily notes from templates — read the template first, then use writeToFile to populate the note.`,
     },
   });
 


### PR DESCRIPTION
## Summary
- Remove `daily:append` and `daily:prepend` commands from the `obsidianDailyNote` tool
- These overlapped with `writeToFile`/`replaceInFile`, causing agent confusion when users ask to add content to daily notes
- Update prompt instructions to direct the agent to use `writeToFile`/`replaceInFile` for daily note content modifications

## Test plan
- [x] All 1896 tests pass (4 append/prepend tests removed)
- [x] Lint and format clean
- [ ] Verify agent uses `writeToFile`/`replaceInFile` when asked to add content to daily note

🤖 Generated with [Claude Code](https://claude.com/claude-code)