### PR TITLE
fix(search): allow Miyo backend to re-index on mobile with disableIndexOnMobile enabled

### DIFF
--- a/src/search/indexBackend/MiyoIndexBackend.ts
+++ b/src/search/indexBackend/MiyoIndexBackend.ts
@@ -275,6 +275,15 @@ export class MiyoIndexBackend implements SemanticIndexBackend {
   }
 
   /**
+   * Miyo is a remote HTTP backend with no local index.
+   *
+   * @returns True because Miyo sends data to a remote service.
+   */
+  public isRemoteBackend(): boolean {
+    return true;
+  }
+
+  /**
    * Resolve the Miyo base URL using settings and discovery.
    *
    * @returns Base URL string.

--- a/src/search/indexBackend/OramaIndexBackend.ts
+++ b/src/search/indexBackend/OramaIndexBackend.ts
@@ -186,6 +186,15 @@ export class OramaIndexBackend implements SemanticIndexBackend {
   }
 
   /**
+   * Orama uses a local index, so it is not a remote backend.
+   *
+   * @returns False because Orama stores data locally.
+   */
+  public isRemoteBackend(): boolean {
+    return false;
+  }
+
+  /**
    * Return the underlying Orama database instance when available.
    */
   public getDb(): Orama<any> | undefined {

--- a/src/search/indexBackend/SemanticIndexBackend.ts
+++ b/src/search/indexBackend/SemanticIndexBackend.ts
@@ -122,4 +122,11 @@ export interface SemanticIndexBackend {
    * Flush or persist any pending backend work before unload.
    */
   onunload(): void;
+
+  /**
+   * Return true when this backend is remote (e.g. Miyo) and does not use a local index.
+   * Used to bypass the `disableIndexOnMobile` guard for remote backends that have no
+   * local storage concerns.
+   */
+  isRemoteBackend(): boolean;
 }

--- a/src/search/indexEventHandler.ts
+++ b/src/search/indexEventHandler.ts
@@ -72,7 +72,11 @@ export class IndexEventHandler {
     if (!this.shouldHandleEvents()) {
       return;
     }
-    if (Platform.isMobile && getSettings().disableIndexOnMobile) {
+    if (
+      Platform.isMobile &&
+      getSettings().disableIndexOnMobile &&
+      !this.indexBackend.isRemoteBackend()
+    ) {
       return;
     }
 

--- a/src/search/vectorStoreManager.ts
+++ b/src/search/vectorStoreManager.ts
@@ -130,7 +130,11 @@ export default class VectorStoreManager {
       return 0;
     }
 
-    if (Platform.isMobile && getSettings().disableIndexOnMobile) {
+    if (
+      Platform.isMobile &&
+      getSettings().disableIndexOnMobile &&
+      !this.indexBackend.isRemoteBackend()
+    ) {
       new Notice("Indexing is disabled on mobile devices");
       return 0;
     }


### PR DESCRIPTION
## Summary

- Added `isRemoteBackend(): boolean` to the `SemanticIndexBackend` interface
- `OramaIndexBackend` returns `false` (local DB); `MiyoIndexBackend` returns `true` (remote HTTP)
- Updated mobile guards in `IndexEventHandler` and `VectorStoreManager` to skip the block for remote backends

## Problem

The `disableIndexOnMobile` toggle was designed to prevent loading the heavy local Orama vector index on mobile. As a side effect it was also blocking incremental re-indexing for the Miyo backend — a remote HTTP service with no local index, RAM, or CPU overhead concerns.

## Verification

- Orama on mobile with toggle enabled: re-indexing still blocked (no behavior change)
- Miyo on mobile with toggle enabled: re-indexing now proceeds via HTTP POST as expected
- All 1876 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)