### PR TITLE
fix: save chat with correct project ID during project switch

### DIFF
--- a/src/LLMProviders/projectManager.ts
+++ b/src/LLMProviders/projectManager.ts
@@ -1,8 +1,12 @@
 import {
   FailedItem,
   getChainType,
+  getCurrentProject,
+  getProjectContextLoadState,
   isProjectMode,
   ProjectConfig,
+  setCurrentProject,
+  setProjectContextLoadState,
   setProjectLoading,
   subscribeToChainTypeChange,
   subscribeToModelKeyChange,
@@ -36,6 +40,12 @@ export default class ProjectManager {
   private fileParserManager: FileParserManager;
   private loadTracker: ProjectLoadTracker;
   private readonly projectUsageTimestampsManager = new RecentUsageManager<string>();
+  /** Serialization lock: only one switchProject executes at a time. */
+  private switchLock: Promise<void> = Promise.resolve();
+  /** Reason: true while switchProject is writing the atom via setCurrentProject().
+   *  The subscription callback checks this flag and skips re-entry, while real
+   *  user requests (where this flag is false) pass through to the lock queue. */
+  private updatingAtom = false;
 
   private constructor(app: App, plugin: CopilotPlugin) {
     this.app = app;
@@ -72,8 +82,12 @@ export default class ProjectManager {
       });
     });
 
-    // Subscribe to Project changes
+    // Subscribe to Project changes.
+    // Reason: skip re-entry caused by switchProject's own setCurrentProject() call.
+    // Real user requests (e.g. from UI) go through switchProject() directly,
+    // not through this subscription.
     subscribeToProjectChange(async (project) => {
+      if (this.updatingAtom) return;
       await this.switchProject(project);
     });
 
@@ -183,45 +197,111 @@ export default class ProjectManager {
   }
 
   public async switchProject(project: ProjectConfig | null): Promise<void> {
+    const nextProjectId = project?.id ?? null;
+
+    // Reason: serialize concurrent switches so that save always observes the correct
+    // project atom. Without this, rapid A→B→C clicks can interleave, causing
+    // saveCurrentProjectMessage to persist repo A's messages under project B's prefix.
+    const prev = this.switchLock;
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    let resolve: () => void = () => {};
+    this.switchLock = new Promise<void>((r) => (resolve = r));
+    await prev;
+
+    // Reason: snapshot load-tracking state before clearing so any rollback path
+    // (including save failure in the outer catch) can restore it.
+    const prevLoadState = { ...getProjectContextLoadState() };
+
     try {
+      // Reason: re-check after acquiring the lock. A queued duplicate (e.g. rapid
+      // double-click A→B) may find that the previous call already completed the switch,
+      // making this invocation a no-op. Must be inside try so finally still runs resolve().
+      if (this.currentProjectId === nextProjectId) return;
+
       // Clear all project context loading states
       this.loadTracker.clearAllLoadStates();
       setProjectLoading(true);
       logInfo("Project loading started...");
 
-      // 1. save current project message. 2. load next project message
+      // Reason: capture the current project BEFORE any state changes so that
+      // saveCurrentProjectMessage persists under the correct project identity,
+      // regardless of atom update ordering.
+      const prevProject = getCurrentProject();
+      const prevProjectId = this.currentProjectId;
 
       // switch default project
       if (!project) {
-        await this.saveCurrentProjectMessage();
-        this.currentProjectId = null; // ensure set currentProjectId
+        await this.saveCurrentProjectMessage(prevProject);
+        this.currentProjectId = null;
+        this.updatingAtom = true;
+        setCurrentProject(null);
+        this.updatingAtom = false;
 
-        await this.loadNextProjectMessage();
+        try {
+          await this.loadNextProjectMessage();
+        } catch (loadError) {
+          // Reason: restore previous project identity, then resync runtime
+          // state (repo + chain) so the UI is consistent with rolled-back selection.
+          this.currentProjectId = prevProjectId;
+          this.updatingAtom = true;
+          setCurrentProject(prevProject ?? null);
+          this.updatingAtom = false;
+          setProjectContextLoadState(prevLoadState);
+          try {
+            await this.loadNextProjectMessage();
+            await this.getCurrentChainManager().createChainWithNewModel();
+            this.refreshChatView();
+          } catch (restoreError) {
+            logError(`Failed to restore previous project runtime after rollback: ${restoreError}`);
+          }
+          throw loadError;
+        }
         this.refreshChatView();
         return;
       }
 
-      // else
-      const projectId = project.id;
-      if (this.currentProjectId === projectId) {
-        return;
+      await this.saveCurrentProjectMessage(prevProject);
+      this.currentProjectId = nextProjectId;
+      this.updatingAtom = true;
+      setCurrentProject(project);
+      this.updatingAtom = false;
+
+      // Reason: capture previous fileParserManager so we can restore it
+      // if any step below fails and we need to roll back.
+      const prevFileParserManager = this.fileParserManager;
+
+      try {
+        // Use sequential operations to ensure loading state is maintained
+        // through the entire process
+        await this.loadNextProjectMessage();
+        await this.getCurrentChainManager().createChainWithNewModel();
+        // Update FileParserManager with the current project
+        this.fileParserManager = new FileParserManager(
+          BrevilabsClient.getInstance(),
+          this.app.vault,
+          true,
+          project
+        );
+        await this.loadProjectContext(project);
+      } catch (switchError) {
+        // Reason: restore previous project identity, then resync runtime
+        // state (repo + chain) so the UI is consistent with rolled-back selection.
+        logWarn(`Rolling back project switch due to error: ${switchError}`);
+        this.currentProjectId = prevProjectId;
+        this.fileParserManager = prevFileParserManager;
+        this.updatingAtom = true;
+        setCurrentProject(prevProject ?? null);
+        this.updatingAtom = false;
+        setProjectContextLoadState(prevLoadState);
+        try {
+          await this.loadNextProjectMessage();
+          await this.getCurrentChainManager().createChainWithNewModel();
+          this.refreshChatView();
+        } catch (restoreError) {
+          logError(`Failed to restore previous project runtime after rollback: ${restoreError}`);
+        }
+        throw switchError;
       }
-
-      await this.saveCurrentProjectMessage();
-      this.currentProjectId = projectId; // ensure set currentProjectId
-
-      // Use sequential operations to ensure loading state is maintained
-      // through the entire process
-      await this.loadNextProjectMessage();
-      await this.getCurrentChainManager().createChainWithNewModel();
-      // Update FileParserManager with the current project
-      this.fileParserManager = new FileParserManager(
-        BrevilabsClient.getInstance(),
-        this.app.vault,
-        true,
-        project
-      );
-      await this.loadProjectContext(project);
 
       // fresh chat view
       this.refreshChatView();
@@ -232,16 +312,20 @@ export default class ProjectManager {
       logInfo(`Switched to project: ${project.name}`);
     } catch (error) {
       logError(`Failed to switch project: ${error}`);
+      // Reason: restore load-tracking state for any failure path that didn't
+      // already restore it (e.g. save failure before inner try/catch).
+      setProjectContextLoadState(prevLoadState);
       throw error;
     } finally {
       setProjectLoading(false);
+      resolve();
     }
   }
 
-  private async saveCurrentProjectMessage() {
+  private async saveCurrentProjectMessage(projectOverride?: ProjectConfig | null) {
     // The new ChatManager handles message persistence internally
     // during project switches, so we just need to trigger autosave
-    await this.plugin.autosaveCurrentChat();
+    await this.plugin.autosaveCurrentChat(projectOverride);
   }
 
   private async loadNextProjectMessage() {

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -59,7 +59,7 @@ type ChatMode = "default" | "project";
 
 interface ChatProps {
   chainManager: ChainManager;
-  onSaveChat: (saveAsNote: () => Promise<void>) => void;
+  onSaveChat: (saveAsNote: (projectOverride?: ProjectConfig | null) => Promise<void>) => void;
   updateUserMessageHistory: (newMessage: string) => void;
   fileParserManager: FileParserManager;
   plugin: CopilotPlugin;
@@ -345,9 +345,9 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
         updateUserMessageHistory(inputMessage);
       }
 
-      // Autosave if enabled
+      // Autosave if enabled (fire-and-forget; error already noticed inside handleSaveAsNote)
       if (settings.autosaveChat) {
-        handleSaveAsNote();
+        handleSaveAsNote().catch(() => {});
       }
 
       // Get the LLM message for AI processing
@@ -363,9 +363,9 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
         );
       }
 
-      // Autosave again after AI response
+      // Autosave again after AI response (fire-and-forget)
       if (settings.autosaveChat) {
-        handleSaveAsNote();
+        handleSaveAsNote().catch(() => {});
       }
     } catch (error) {
       logError("Error sending message:", error);
@@ -377,20 +377,26 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
     }
   };
 
-  const handleSaveAsNote = useCallback(async () => {
-    if (!app) {
-      logError("App instance is not available.");
-      return;
-    }
+  const handleSaveAsNote = useCallback(
+    async (projectOverride?: ProjectConfig | null) => {
+      if (!app) {
+        logError("App instance is not available.");
+        return;
+      }
 
-    try {
-      // Use the new ChatManager persistence functionality
-      await chatUIState.saveChat(currentModelKey);
-    } catch (error) {
-      logError("Error saving chat as note:", err2String(error));
-      new Notice("Failed to save chat as note. Check console for details.");
-    }
-  }, [app, chatUIState, currentModelKey]);
+      try {
+        await chatUIState.saveChat(currentModelKey, projectOverride);
+      } catch (error) {
+        logError("Error saving chat as note:", err2String(error));
+        new Notice("Failed to save chat as note. Check console for details.");
+        // Reason: rethrow so callers (e.g. switchProject → autosaveCurrentChat)
+        // can detect save failure and abort the project switch.
+        // Manual callers (fire-and-forget) will simply ignore the unhandled rejection.
+        throw error;
+      }
+    },
+    [app, chatUIState, currentModelKey]
+  );
 
   const handleStopGenerating = useCallback(
     (reason?: ABORT_REASON) => {
@@ -448,9 +454,9 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
           console.log("Message regenerated successfully");
         }
 
-        // Autosave the chat if the setting is enabled
+        // Autosave the chat if the setting is enabled (fire-and-forget)
         if (settings.autosaveChat) {
-          handleSaveAsNote();
+          handleSaveAsNote().catch(() => {});
         }
       } catch (error) {
         logError("Error regenerating message:", error);
@@ -525,9 +531,9 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
           }
         }
 
-        // Autosave the chat if the setting is enabled
+        // Autosave the chat if the setting is enabled (fire-and-forget)
         if (settings.autosaveChat) {
-          handleSaveAsNote();
+          handleSaveAsNote().catch(() => {});
         }
       } catch (error) {
         logError("Error editing message:", error);
@@ -898,6 +904,11 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
                 if (newMode === ChainType.PROJECT_CHAIN) {
                   setShowChatUI(false);
                 }
+              }}
+              onCloseProject={async () => {
+                // Reason: switchProject saves old chat with correct project ID
+                // before clearing the atom, preventing wrong-project saves.
+                await plugin.projectManager.switchProject(null);
               }}
               chatHistory={chatHistoryItems}
               onUpdateChatTitle={handleUpdateChatTitle}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -704,9 +704,11 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
       }
     }
 
-    // First autosave the current chat if the setting is enabled
+    // First autosave the current chat if the setting is enabled.
+    // Reason: catch here because handleNewChat is called from an onClick handler
+    // where a rejected promise would become an unhandled rejection.
     if (settings.autosaveChat) {
-      await handleSaveAsNote();
+      await handleSaveAsNote().catch(() => {});
     }
 
     // Clear messages through the new architecture
@@ -896,7 +898,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
           <>
             <ChatControls
               onNewChat={handleNewChat}
-              onSaveAsNote={() => handleSaveAsNote()}
+              onSaveAsNote={() => handleSaveAsNote().catch(() => {})}
               onLoadHistory={handleLoadChatHistory}
               onModeChange={(newMode) => {
                 setPreviousMode(selectedChain);

--- a/src/components/CopilotView.tsx
+++ b/src/components/CopilotView.tsx
@@ -1,3 +1,4 @@
+import { ProjectConfig } from "@/aiParams";
 import ChainManager from "@/LLMProviders/chainManager";
 import Chat from "@/components/Chat";
 import { ChatViewLayout } from "@/components/chat-components/ChatViewLayout";
@@ -17,7 +18,8 @@ export default class CopilotView extends ItemView {
 
   private fileParserManager: FileParserManager;
   private root: Root | null = null;
-  private handleSaveAsNote: (() => Promise<void>) | null = null;
+  private handleSaveAsNote: ((projectOverride?: ProjectConfig | null) => Promise<void>) | null =
+    null;
   private keyboardObserver: MutationObserver | null = null;
   private drawerHideObserver: MutationObserver | null = null;
   private layout: ChatViewLayout | null = null;
@@ -55,7 +57,9 @@ export default class CopilotView extends ItemView {
 
   async onOpen(): Promise<void> {
     this.root = createRoot(this.containerEl.children[1]);
-    const handleSaveAsNote = (saveFunction: () => Promise<void>) => {
+    const handleSaveAsNote = (
+      saveFunction: (projectOverride?: ProjectConfig | null) => Promise<void>
+    ) => {
       this.handleSaveAsNote = saveFunction;
     };
     const updateUserMessageHistory = (newMessage: string) => {
@@ -162,7 +166,9 @@ export default class CopilotView extends ItemView {
   }
 
   private renderView(
-    handleSaveAsNote: (saveFunction: () => Promise<void>) => void,
+    handleSaveAsNote: (
+      saveFunction: (projectOverride?: ProjectConfig | null) => Promise<void>
+    ) => void,
     updateUserMessageHistory: (newMessage: string) => void
   ): void {
     if (!this.root) return;
@@ -185,16 +191,18 @@ export default class CopilotView extends ItemView {
     );
   }
 
-  async saveChat(): Promise<void> {
+  async saveChat(projectOverride?: ProjectConfig | null): Promise<void> {
     if (this.handleSaveAsNote) {
-      await this.handleSaveAsNote();
+      await this.handleSaveAsNote(projectOverride);
     }
   }
 
   updateView(): void {
     // Note: The new architecture handles message loading through ChatManager
     // The messages will be loaded when the Chat component initializes
-    const handleSaveAsNote = (saveFunction: () => Promise<void>) => {
+    const handleSaveAsNote = (
+      saveFunction: (projectOverride?: ProjectConfig | null) => Promise<void>
+    ) => {
       this.handleSaveAsNote = saveFunction;
     };
     const updateUserMessageHistory = (newMessage: string) => {

--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -1,4 +1,4 @@
-import { getCurrentProject, setCurrentProject, setProjectLoading, useChainType } from "@/aiParams";
+import { getCurrentProject, setProjectLoading, useChainType } from "@/aiParams";
 import { ProjectContextCache } from "@/cache/projectContextCache";
 import { ChainType } from "@/chainFactory";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
@@ -175,7 +175,7 @@ interface ChatControlsProps {
   onSaveAsNote: () => Promise<void>;
   onLoadHistory: () => void;
   onModeChange: (mode: ChainType) => void;
-  onCloseProject?: () => void;
+  onCloseProject?: () => Promise<void>;
   chatHistory: ChatHistoryItem[];
   onUpdateChatTitle: (id: string, newTitle: string) => Promise<void>;
   onDeleteChat: (id: string) => Promise<void>;
@@ -202,20 +202,19 @@ export function ChatControls({
   const isPlusUser = useIsPlusUser();
 
   const handleModeChange = async (chainType: ChainType) => {
-    // If leaving project mode with autosave enabled, save chat BEFORE clearing project context
-    // This ensures the chat is saved with the correct project prefix
-    const isLeavingProjectMode =
-      selectedChain === ChainType.PROJECT_CHAIN && chainType !== ChainType.PROJECT_CHAIN;
-    if (isLeavingProjectMode && settings.autosaveChat) {
-      await onSaveAsNote();
+    // Reason: close project BEFORE changing mode so that switchProject can
+    // save with the correct project context. If close fails, mode stays unchanged.
+    if (chainType !== ChainType.PROJECT_CHAIN) {
+      try {
+        await onCloseProject?.();
+      } catch (error) {
+        logError("[ChatControls] Failed to close project:", error);
+        new Notice("Failed to close project. Please try again.");
+        return;
+      }
     }
-
     setSelectedChain(chainType);
     onModeChange(chainType);
-    if (chainType !== ChainType.PROJECT_CHAIN) {
-      setCurrentProject(null);
-      onCloseProject?.();
-    }
   };
 
   return (
@@ -266,7 +265,7 @@ export function ChatControls({
               <DropdownMenuItem
                 onSelect={() => {
                   navigateToPlusPage(PLUS_UTM_MEDIUMS.CHAT_MODE_SELECT);
-                  onCloseProject?.();
+                  onCloseProject?.()?.catch(() => {});
                 }}
               >
                 copilot plus
@@ -288,7 +287,7 @@ export function ChatControls({
               <DropdownMenuItem
                 onSelect={() => {
                   navigateToPlusPage(PLUS_UTM_MEDIUMS.CHAT_MODE_SELECT);
-                  onCloseProject?.();
+                  onCloseProject?.()?.catch(() => {});
                 }}
               >
                 copilot plus

--- a/src/components/chat-components/ProjectList.tsx
+++ b/src/components/chat-components/ProjectList.tsx
@@ -1,4 +1,4 @@
-import { ProjectConfig, setCurrentProject } from "@/aiParams";
+import { ProjectConfig } from "@/aiParams";
 import { AddProjectModal } from "@/components/modals/project/AddProjectModal";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { Button } from "@/components/ui/button";
@@ -248,45 +248,69 @@ export const ProjectList = memo(
       modal.open();
     };
 
-    const handleDeleteProject = (project: ProjectConfig) => {
-      const currentProjects = projects || [];
-      const newProjectList = currentProjects.filter((p) => p.name !== project.name);
-
-      // If the deleted project is currently selected, close it
-      if (selectedProject?.name === project.name) {
-        enableOrDisableProject(false);
+    const handleDeleteProject = async (project: ProjectConfig) => {
+      // Reason: close the project first so switchProject(null) saves the chat
+      // before the project is removed from settings. If close fails, abort
+      // the delete to avoid removing a project whose chat was not saved.
+      if (selectedProject?.id === project.id) {
+        const closed = await enableOrDisableProject(false);
+        if (!closed) return;
       }
+
+      const currentProjects = projects || [];
+      const newProjectList = currentProjects.filter((p) => p.id !== project.id);
 
       // Update the project list in settings
       updateSetting("projectList", newProjectList);
       new Notice(`Project "${project.name}" deleted successfully`);
     };
 
-    const enableOrDisableProject = (enable: boolean, project?: ProjectConfig) => {
+    /** @returns true if the operation succeeded, false on failure */
+    const enableOrDisableProject = async (
+      enable: boolean,
+      project?: ProjectConfig
+    ): Promise<boolean> => {
       if (!enable) {
+        try {
+          // Reason: await switchProject first so UI only updates on success.
+          await plugin?.projectManager?.switchProject(null);
+        } catch (error) {
+          logError("[ProjectList] Failed to close project:", error);
+          new Notice("Failed to close project. Please try again.");
+          return false;
+        }
         setSelectedProject(null);
         setShowChatInput(false);
         setIsOpen(true);
         showChatUI(false);
-        setCurrentProject(null);
-        return;
+        return true;
       } else {
         if (!project) {
           logError("Must be exist one project.");
-          return;
+          return false;
         }
         setSelectedProject(project);
         setShowChatInput(true);
         setIsOpen(false);
+        return true;
       }
     };
 
-    const handleLoadContext = (p: ProjectConfig) => {
+    const handleLoadContext = async (p: ProjectConfig) => {
+      try {
+        // Reason: await switchProject first so UI only updates on success.
+        // switchProject saves old chat before updating atom.
+        await plugin?.projectManager?.switchProject(p);
+      } catch (error) {
+        logError("[ProjectList] Failed to switch project:", error);
+        new Notice("Failed to switch project. Please try again.");
+        return;
+      }
+
       setSelectedProject(p);
       setShowChatInput(true);
       setIsOpen(false);
       showChatUI(true);
-      setCurrentProject(p);
 
       setTimeout(() => {
         chatInput.focusInput();
@@ -348,9 +372,9 @@ export const ProjectList = memo(
                       <Button
                         variant="ghost2"
                         size="icon"
-                        onClick={() => {
-                          enableOrDisableProject(false);
-                          onProjectClose();
+                        onClick={async () => {
+                          const closed = await enableOrDisableProject(false);
+                          if (closed) onProjectClose();
                         }}
                         aria-label="Close Current Project"
                       >

--- a/src/core/ChatManager.ts
+++ b/src/core/ChatManager.ts
@@ -5,7 +5,7 @@ import {
   getSystemPromptWithMemory,
 } from "@/system-prompts/systemPromptBuilder";
 import { ChainType } from "@/chainFactory";
-import { getChainType, getCurrentProject } from "@/aiParams";
+import { getChainType, getCurrentProject, ProjectConfig } from "@/aiParams";
 import { logInfo, logWarn } from "@/logger";
 import { ChatMessage, MessageContext, WebTabContext } from "@/types/message";
 import { processPrompt, type ProcessedPromptResult } from "@/commands/customCommandUtils";
@@ -770,8 +770,8 @@ export class ChatManager {
   /**
    * Save current chat history
    */
-  async saveChat(modelKey: string): Promise<void> {
-    await this.persistenceManager.saveChat(modelKey);
+  async saveChat(modelKey: string, projectOverride?: ProjectConfig | null): Promise<void> {
+    await this.persistenceManager.saveChat(modelKey, projectOverride);
   }
 
   /**

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -233,6 +233,35 @@ export class ChatPersistenceManager {
         content = await this.app.vault.adapter.read(file.path);
       }
       const messages = this.parseChatContent(content);
+
+      // Reason: parseChatContent reconstructs epoch from body timestamps which only
+      // have second precision (YYYY/MM/DD HH:mm:ss), losing the original milliseconds.
+      // The frontmatter epoch is the authoritative conversation identity used by
+      // findFileByEpoch/saveChat. Restore it here so a load→save cycle correctly
+      // matches the original file instead of creating a duplicate.
+      if (messages.length > 0) {
+        const frontmatter = this.app.metadataCache.getFileCache(file)?.frontmatter;
+        // Reason: also try adapter-based read for hidden directory files
+        const fmEpoch = frontmatter?.epoch
+          ?? (await readFrontmatterViaAdapter(this.app, file.path).catch(() => null))?.epoch;
+        if (fmEpoch != null) {
+          const epoch = Number(fmEpoch);
+          if (!Number.isNaN(epoch)) {
+            // Reason: ensure timestamp object exists even when parseChatContent
+            // returned null (e.g. "Unknown time" format in older notes).
+            if (messages[0].timestamp) {
+              messages[0].timestamp.epoch = epoch;
+            } else {
+              messages[0].timestamp = {
+                epoch,
+                display: "Unknown time",
+                fileName: "",
+              };
+            }
+          }
+        }
+      }
+
       logInfo(`[ChatPersistenceManager] Loaded ${messages.length} messages from ${file.path}`);
       return messages;
     } catch (error) {

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -50,7 +50,7 @@ export class ChatPersistenceManager {
   /**
    * Save current chat history to a markdown file
    */
-  async saveChat(modelKey: string): Promise<void> {
+  async saveChat(modelKey: string, projectOverride?: ProjectConfig | null): Promise<void> {
     try {
       const messages = this.messageRepo.getDisplayMessages();
       if (messages.length === 0) {
@@ -87,18 +87,22 @@ export class ChatPersistenceManager {
         }
       }
 
-      const currentProject = getCurrentProject();
+      // Reason: resolve the target project once and use this local variable everywhere.
+      // During project switches the caller passes the OLD project explicitly so that
+      // save correctness does not depend on global atom update ordering.
+      const project = projectOverride ?? getCurrentProject();
 
       const preferredFileName = existingFile
         ? existingFile.path
-        : this.generateFileName(currentProject, messages, firstMessageEpoch, existingTopic);
+        : this.generateFileName(project, messages, firstMessageEpoch, existingTopic);
 
       const noteContent = this.generateNoteContent(
         chatContent,
         firstMessageEpoch,
         modelKey,
         existingTopic,
-        existingLastAccessedAt
+        existingLastAccessedAt,
+        project
       );
       let targetFile: TFile | null = existingFile;
 
@@ -144,7 +148,8 @@ export class ChatPersistenceManager {
                 firstMessageEpoch,
                 modelKey,
                 existingTopic,
-                conflictLastAccessedAt
+                conflictLastAccessedAt,
+                project
               );
               await this.app.vault.modify(conflictFile, updatedContent);
               targetFile = conflictFile;
@@ -162,7 +167,7 @@ export class ChatPersistenceManager {
             }
           } else if (this.isNameTooLongError(error)) {
             // Single fallback: minimal guaranteed-to-work filename with project prefix
-            const filePrefix = currentProject ? `${currentProject.id}__` : "";
+            const filePrefix = project ? `${project.id}__` : "";
             const fallbackName = `${settings.defaultSaveFolder}/${filePrefix}chat-${firstMessageEpoch}.md`;
 
             try {
@@ -187,7 +192,8 @@ export class ChatPersistenceManager {
                     firstMessageEpoch,
                     modelKey,
                     conflictTopic,
-                    conflictLastAccessedAt
+                    conflictLastAccessedAt,
+                    project
                   );
                   await this.app.vault.modify(conflictFile, updatedContent);
                   targetFile = conflictFile;
@@ -213,10 +219,12 @@ export class ChatPersistenceManager {
         }
       }
 
-      this.generateTopicAsyncIfNeeded(currentProject, targetFile, messages, existingTopic);
+      this.generateTopicAsyncIfNeeded(project, targetFile, messages, existingTopic);
     } catch (error) {
       logError("[ChatPersistenceManager] Error saving chat:", error);
-      new Notice("Failed to save chat as note. Check console for details.");
+      // Reason: rethrow so callers (e.g. switchProject) can abort on save failure
+      // instead of silently proceeding with stale data. Callers handle user-facing notices.
+      throw error instanceof Error ? error : new Error(String(error));
     }
   }
 
@@ -748,18 +756,19 @@ ${conversationSummary}`;
     firstMessageEpoch: number,
     modelKey: string,
     topic?: string,
-    lastAccessedAt?: number
+    lastAccessedAt?: number,
+    projectOverride?: ProjectConfig | null
   ): string {
     const settings = getSettings();
-    const currentProject = getCurrentProject();
+    const project = projectOverride ?? getCurrentProject();
 
     return `---
 epoch: ${firstMessageEpoch}
 modelKey: "${escapeYamlString(modelKey)}"
 ${topic ? `topic: "${topic}"` : ""}
 ${lastAccessedAt ? `lastAccessedAt: ${lastAccessedAt}` : ""}
-${currentProject ? `projectId: ${currentProject.id}` : ""}
-${currentProject ? `projectName: ${currentProject.name}` : ""}
+${project ? `projectId: ${project.id}` : ""}
+${project ? `projectName: ${project.name}` : ""}
 tags:
   - ${settings.defaultConversationTag}
 ---

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import ProjectManager from "@/LLMProviders/projectManager";
 import {
   CustomModel,
   getCurrentProject,
+  ProjectConfig,
   setSelectedTextContexts,
   getSelectedTextContexts,
 } from "@/aiParams";
@@ -284,11 +285,11 @@ export default class CopilotPlugin extends Plugin {
     this.userMessageHistory = [...this.userMessageHistory, newMessage];
   }
 
-  async autosaveCurrentChat() {
+  async autosaveCurrentChat(projectOverride?: ProjectConfig | null) {
     if (getSettings().autosaveChat) {
       const chatView = this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE)[0]?.view as CopilotView;
       if (chatView) {
-        await chatView.saveChat();
+        await chatView.saveChat(projectOverride);
       }
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -289,7 +289,14 @@ export default class CopilotPlugin extends Plugin {
     if (getSettings().autosaveChat) {
       const chatView = this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE)[0]?.view as CopilotView;
       if (chatView) {
-        await chatView.saveChat(projectOverride);
+        if (projectOverride !== undefined) {
+          // Reason: project-switch path needs to detect save failure to abort the switch.
+          await chatView.saveChat(projectOverride);
+        } else {
+          // Reason: non-switch callers (loadChatHistory, newChat, settings reload) should
+          // not be blocked by a transient save error. Error is already logged+noticed inside.
+          await chatView.saveChat().catch(() => {});
+        }
       }
     }
   }

--- a/src/state/ChatUIState.ts
+++ b/src/state/ChatUIState.ts
@@ -1,3 +1,4 @@
+import { ProjectConfig } from "@/aiParams";
 import { ChainType } from "@/chainFactory";
 import { logInfo } from "@/logger";
 import { ChatManager } from "@/core/ChatManager";
@@ -249,8 +250,8 @@ export class ChatUIState {
   /**
    * Save current chat history
    */
-  async saveChat(modelKey: string): Promise<void> {
-    await this.chatManager.saveChat(modelKey);
+  async saveChat(modelKey: string, projectOverride?: ProjectConfig | null): Promise<void> {
+    await this.chatManager.saveChat(modelKey, projectOverride);
   }
 
   /**


### PR DESCRIPTION
## Issues

- #2315

## Summary

- Fix chat history being saved with wrong project ID when switching projects in the chat UI dropdown
- Route all project switching through `ProjectManager.switchProject()` instead of direct `setCurrentProject()` atom mutation, ensuring autosave completes before the atom updates
- Add serialization lock (`switchLock`) to prevent rapid A→B→C clicks from interleaving save/load operations
- Add pre-lock and post-lock ID-equality guards for subscription re-entry and duplicate request safety
- Fix duplicate chat files on load→save cycle by restoring frontmatter epoch (millisecond precision) to loaded messages, preventing `findFileByEpoch` mismatch caused by second-precision body timestamps

## Test plan

- [ ] In project chat, send a message in test1 → switch to test2 via dropdown → verify `conversations/` has no file with test2 ID containing test1 messages
- [ ] Click history icon in test2 → should not show test1 chats
- [ ] Close project → should not create unprefixed duplicate file
- [ ] Leave project mode via mode switcher → should not create duplicate
- [ ] Send message → new chat → load history → close project → verify no duplicate file created
- [ ] Rapid project switching (A→B→C quickly) → verify no interleaved/duplicate saves
- [ ] TypeScript compiles, lint passes, all tests pass