### PR TITLE
feat: add MiniMax as first-class LLM provider

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -75,6 +75,7 @@ const CHAT_PROVIDER_CONSTRUCTORS = {
   [ChatModelProviders.GROQ]: ChatGroq,
   [ChatModelProviders.OPENAI_FORMAT]: ChatOpenAI,
   [ChatModelProviders.SILICONFLOW]: ChatOpenAI,
+  [ChatModelProviders.MINIMAX]: ChatOpenAI,
   [ChatModelProviders.COPILOT_PLUS]: ChatOpenRouter,
   [ChatModelProviders.MISTRAL]: ChatMistralAI,
   [ChatModelProviders.DEEPSEEK]: ChatDeepSeek,
@@ -144,6 +145,7 @@ export default class ChatModelManager {
     [ChatModelProviders.DEEPSEEK]: () => getSettings().deepseekApiKey,
     [ChatModelProviders.AMAZON_BEDROCK]: () => getSettings().amazonBedrockApiKey,
     [ChatModelProviders.SILICONFLOW]: () => getSettings().siliconflowApiKey,
+    [ChatModelProviders.MINIMAX]: () => getSettings().minimaxApiKey,
     [ChatModelProviders.GITHUB_COPILOT]: () =>
       getSettings().githubCopilotToken || getSettings().githubCopilotAccessToken,
   } as const;
@@ -398,6 +400,14 @@ export default class ChatModelManager {
           customModel
         ),
       },
+      [ChatModelProviders.MINIMAX]: {
+        modelName: modelName,
+        apiKey: await getDecryptedKey(customModel.apiKey || settings.minimaxApiKey),
+        configuration: {
+          baseURL: customModel.baseUrl || ProviderInfo[ChatModelProviders.MINIMAX].host,
+          fetch: customModel.enableCors ? safeFetch : undefined,
+        },
+      },
       [ChatModelProviders.COPILOT_PLUS]: {
         modelName: modelName,
         apiKey: await getDecryptedKey(settings.plusLicenseKey),
@@ -598,6 +608,7 @@ export default class ChatModelManager {
           ChatModelProviders.MISTRAL,
           ChatModelProviders.DEEPSEEK,
           ChatModelProviders.SILICONFLOW,
+          ChatModelProviders.MINIMAX,
         ].includes(provider)
       ) {
         params.topP = customModel.topP;
@@ -618,6 +629,7 @@ export default class ChatModelManager {
           ChatModelProviders.MISTRAL,
           ChatModelProviders.DEEPSEEK,
           ChatModelProviders.SILICONFLOW,
+          ChatModelProviders.MINIMAX,
         ].includes(provider)
       ) {
         params.frequencyPenalty = customModel.frequencyPenalty;

--- a/src/LLMProviders/minimax.test.ts
+++ b/src/LLMProviders/minimax.test.ts
@@ -1,0 +1,142 @@
+import {
+  BUILTIN_CHAT_MODELS,
+  ChatModelProviders,
+  ChatModels,
+  DEFAULT_SETTINGS,
+  ProviderInfo,
+  ProviderSettingsKeyMap,
+} from "@/constants";
+import { providerAdapters, MiniMaxModelResponse } from "@/settings/providerModels";
+
+describe("MiniMax provider registration", () => {
+  it("should have MINIMAX in ChatModelProviders enum", () => {
+    expect(ChatModelProviders.MINIMAX).toBe("minimax");
+  });
+
+  it("should have MiniMax-M2.7 in ChatModels enum", () => {
+    expect(ChatModels.MINIMAX_M2_7).toBe("MiniMax-M2.7");
+  });
+
+  it("should have MiniMax-M2.5 in ChatModels enum", () => {
+    expect(ChatModels.MINIMAX_M2_5).toBe("MiniMax-M2.5");
+  });
+});
+
+describe("MiniMax built-in models", () => {
+  const minimaxModels = BUILTIN_CHAT_MODELS.filter(
+    (m) => m.provider === ChatModelProviders.MINIMAX
+  );
+
+  it("should include MiniMax models in BUILTIN_CHAT_MODELS", () => {
+    expect(minimaxModels.length).toBe(2);
+  });
+
+  it("should have MiniMax-M2.7 model", () => {
+    const m27 = minimaxModels.find((m) => m.name === ChatModels.MINIMAX_M2_7);
+    expect(m27).toBeDefined();
+    expect(m27!.provider).toBe(ChatModelProviders.MINIMAX);
+    expect(m27!.isBuiltIn).toBe(true);
+  });
+
+  it("should have MiniMax-M2.5 model", () => {
+    const m25 = minimaxModels.find((m) => m.name === ChatModels.MINIMAX_M2_5);
+    expect(m25).toBeDefined();
+    expect(m25!.provider).toBe(ChatModelProviders.MINIMAX);
+    expect(m25!.isBuiltIn).toBe(true);
+  });
+
+  it("should have MiniMax models disabled by default", () => {
+    minimaxModels.forEach((m) => {
+      expect(m.enabled).toBe(false);
+    });
+  });
+});
+
+describe("MiniMax ProviderInfo", () => {
+  const info = ProviderInfo[ChatModelProviders.MINIMAX];
+
+  it("should have MiniMax provider info", () => {
+    expect(info).toBeDefined();
+  });
+
+  it("should have correct label", () => {
+    expect(info.label).toBe("MiniMax");
+  });
+
+  it("should have correct API host", () => {
+    expect(info.host).toBe("https://api.minimax.io/v1");
+  });
+
+  it("should have correct curlBaseURL", () => {
+    expect(info.curlBaseURL).toBe("https://api.minimax.io/v1");
+  });
+
+  it("should have key management URL", () => {
+    expect(info.keyManagementURL).toBeTruthy();
+    expect(info.keyManagementURL).toContain("minimaxi.com");
+  });
+
+  it("should have list model URL", () => {
+    expect(info.listModelURL).toBe("https://api.minimax.io/v1/models");
+  });
+
+  it("should have test model set to MiniMax-M2.7", () => {
+    expect(info.testModel).toBe(ChatModels.MINIMAX_M2_7);
+  });
+});
+
+describe("MiniMax settings key mapping", () => {
+  it("should map minimax provider to minimaxApiKey setting", () => {
+    expect(ProviderSettingsKeyMap["minimax" as keyof typeof ProviderSettingsKeyMap]).toBe(
+      "minimaxApiKey"
+    );
+  });
+});
+
+describe("MiniMax default settings", () => {
+  it("should have minimaxApiKey in DEFAULT_SETTINGS", () => {
+    expect(DEFAULT_SETTINGS).toHaveProperty("minimaxApiKey");
+    expect(DEFAULT_SETTINGS.minimaxApiKey).toBe("");
+  });
+});
+
+describe("MiniMax provider model adapter", () => {
+  const adapter = providerAdapters[ChatModelProviders.MINIMAX];
+
+  it("should have a model adapter for MiniMax", () => {
+    expect(adapter).toBeDefined();
+  });
+
+  it("should parse MiniMax model list response", () => {
+    const mockResponse: MiniMaxModelResponse = {
+      object: "list",
+      data: [
+        { id: "MiniMax-M2.7", object: "model", created: 1710000000, owned_by: "minimax" },
+        { id: "MiniMax-M2.5", object: "model", created: 1700000000, owned_by: "minimax" },
+      ],
+    };
+
+    const models = adapter!(mockResponse);
+    expect(models).toHaveLength(2);
+    expect(models[0].id).toBe("MiniMax-M2.7");
+    expect(models[0].name).toBe("MiniMax-M2.7");
+    expect(models[0].provider).toBe(ChatModelProviders.MINIMAX);
+    expect(models[1].id).toBe("MiniMax-M2.5");
+  });
+
+  it("should handle empty model list", () => {
+    const mockResponse: MiniMaxModelResponse = {
+      object: "list",
+      data: [],
+    };
+
+    const models = adapter!(mockResponse);
+    expect(models).toHaveLength(0);
+  });
+
+  it("should handle missing data field gracefully", () => {
+    const mockResponse = { object: "list" } as any;
+    const models = adapter!(mockResponse);
+    expect(models).toEqual([]);
+  });
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -202,6 +202,8 @@ export enum ChatModels {
   OPENROUTER_GROK_4_1_FAST = "x-ai/grok-4.1-fast",
   SILICONFLOW_DEEPSEEK_V3 = "deepseek-ai/DeepSeek-V3",
   SILICONFLOW_DEEPSEEK_R1 = "deepseek-ai/DeepSeek-R1",
+  MINIMAX_M2_7 = "MiniMax-M2.7",
+  MINIMAX_M2_5 = "MiniMax-M2.5",
 }
 
 // Model Providers
@@ -222,6 +224,7 @@ export enum ChatModelProviders {
   DEEPSEEK = "deepseek",
   COHEREAI = "cohereai",
   SILICONFLOW = "siliconflow",
+  MINIMAX = "minimax",
   GITHUB_COPILOT = "github-copilot",
 }
 
@@ -431,6 +434,18 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     isBuiltIn: false,
     baseUrl: "https://api.siliconflow.com/v1",
     capabilities: [ModelCapability.REASONING],
+  },
+  {
+    name: ChatModels.MINIMAX_M2_7,
+    provider: ChatModelProviders.MINIMAX,
+    enabled: false,
+    isBuiltIn: true,
+  },
+  {
+    name: ChatModels.MINIMAX_M2_5,
+    provider: ChatModelProviders.MINIMAX,
+    enabled: false,
+    isBuiltIn: true,
   },
 ];
 
@@ -725,6 +740,14 @@ export const ProviderInfo: Record<Provider, ProviderMetadata> = {
     keyManagementURL: "",
     listModelURL: "",
   },
+  [ChatModelProviders.MINIMAX]: {
+    label: "MiniMax",
+    host: "https://api.minimax.io/v1",
+    curlBaseURL: "https://api.minimax.io/v1",
+    keyManagementURL: "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+    listModelURL: "https://api.minimax.io/v1/models",
+    testModel: ChatModels.MINIMAX_M2_7,
+  },
   [ChatModelProviders.GITHUB_COPILOT]: {
     label: "GitHub Copilot",
     host: "https://api.githubcopilot.com",
@@ -749,6 +772,7 @@ export const ProviderSettingsKeyMap: Record<SettingKeyProviders, keyof CopilotSe
   deepseek: "deepseekApiKey",
   "amazon-bedrock": "amazonBedrockApiKey",
   siliconflow: "siliconflowApiKey",
+  minimax: "minimaxApiKey",
   "github-copilot": "githubCopilotToken",
 };
 
@@ -905,6 +929,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   amazonBedrockApiKey: "",
   amazonBedrockRegion: "",
   siliconflowApiKey: "",
+  minimaxApiKey: "",
   // GitHub Copilot OAuth tokens
   githubCopilotAccessToken: "",
   githubCopilotToken: "",

--- a/src/integration_tests/minimax.test.ts
+++ b/src/integration_tests/minimax.test.ts
@@ -1,0 +1,90 @@
+/**
+ * MiniMax provider integration tests.
+ *
+ * These tests verify that MiniMax API calls work end-to-end.
+ * They require a MINIMAX_API_KEY environment variable to be set.
+ *
+ * Run with: npm run test:integration -- -t "MiniMax"
+ */
+import * as dotenv from "dotenv";
+
+// Add global fetch polyfill for Node.js environments
+import fetch, { Headers, Request, Response } from "node-fetch";
+if (!globalThis.fetch) {
+  globalThis.fetch = fetch as any;
+  globalThis.Headers = Headers as any;
+  globalThis.Request = Request as any;
+  globalThis.Response = Response as any;
+}
+
+// Add TextDecoderStream polyfill for Node.js environments
+import "web-streams-polyfill/dist/polyfill.js";
+
+// Load environment variables from .env.test
+dotenv.config({ path: ".env.test" });
+
+import { ChatOpenAI } from "@langchain/openai";
+import { HumanMessage } from "@langchain/core/messages";
+
+const MINIMAX_API_KEY = process.env.MINIMAX_API_KEY;
+const describeIntegration = MINIMAX_API_KEY ? describe : describe.skip;
+
+describeIntegration("MiniMax integration", () => {
+  it("should complete a chat request with MiniMax-M2.7", async () => {
+    const chat = new ChatOpenAI({
+      modelName: "MiniMax-M2.7",
+      apiKey: MINIMAX_API_KEY!,
+      configuration: {
+        baseURL: "https://api.minimax.io/v1",
+      },
+      maxTokens: 50,
+      temperature: 0.7,
+    });
+
+    const response = await chat.invoke([new HumanMessage("Say hello in one sentence.")]);
+    expect(response.content).toBeTruthy();
+    expect(typeof response.content).toBe("string");
+  }, 30000);
+
+  it("should complete a chat request with MiniMax-M2.5", async () => {
+    const chat = new ChatOpenAI({
+      modelName: "MiniMax-M2.5",
+      apiKey: MINIMAX_API_KEY!,
+      configuration: {
+        baseURL: "https://api.minimax.io/v1",
+      },
+      maxTokens: 50,
+      temperature: 0.7,
+    });
+
+    const response = await chat.invoke([new HumanMessage("Say hello in one sentence.")]);
+    expect(response.content).toBeTruthy();
+    expect(typeof response.content).toBe("string");
+  }, 30000);
+
+  it("should support streaming with MiniMax", async () => {
+    const chat = new ChatOpenAI({
+      modelName: "MiniMax-M2.7",
+      apiKey: MINIMAX_API_KEY!,
+      configuration: {
+        baseURL: "https://api.minimax.io/v1",
+      },
+      maxTokens: 50,
+      temperature: 0.7,
+      streaming: true,
+    });
+
+    const chunks: string[] = [];
+    const stream = await chat.stream([new HumanMessage("Count from 1 to 3.")]);
+
+    for await (const chunk of stream) {
+      if (typeof chunk.content === "string" && chunk.content) {
+        chunks.push(chunk.content);
+      }
+    }
+
+    expect(chunks.length).toBeGreaterThan(0);
+    const fullResponse = chunks.join("");
+    expect(fullResponse).toBeTruthy();
+  }, 30000);
+});

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -66,6 +66,7 @@ export interface CopilotSettings {
   amazonBedrockApiKey: string;
   amazonBedrockRegion: string;
   siliconflowApiKey: string;
+  minimaxApiKey: string;
   // GitHub Copilot OAuth tokens
   githubCopilotAccessToken: string;
   githubCopilotToken: string;

--- a/src/settings/providerModels.ts
+++ b/src/settings/providerModels.ts
@@ -344,6 +344,27 @@ export interface SiliconFlowModel {
   owned_by: string;
 }
 
+// MiniMax response model definition (OpenAI-compatible format)
+export interface MiniMaxModelResponse {
+  object: string;
+  data: MiniMaxModel[];
+}
+
+/**
+ {
+ "id": "MiniMax-M2.7",
+ "object": "model",
+ "created": 1710000000,
+ "owned_by": "minimax"
+ }
+ */
+export interface MiniMaxModel {
+  id: string;
+  object: string;
+  created: number;
+  owned_by: string;
+}
+
 // GitHub Copilot response model definition
 export interface GitHubCopilotModelResponse {
   object: string;
@@ -407,6 +428,7 @@ export interface ProviderResponseMap {
   [ChatModelProviders.XAI]: XAIModelResponse;
   [ChatModelProviders.OPENROUTERAI]: OpenRouterAIModelResponse;
   [ChatModelProviders.SILICONFLOW]: SiliconFlowModelResponse;
+  [ChatModelProviders.MINIMAX]: MiniMaxModelResponse;
   [ChatModelProviders.COPILOT_PLUS]: null;
   [ChatModelProviders.AZURE_OPENAI]: null;
   [ChatModelProviders.AMAZON_BEDROCK]: unknown;
@@ -501,6 +523,13 @@ export const providerAdapters: ProviderModelAdapters = {
       id: model.id,
       name: model.id,
       provider: ChatModelProviders.SILICONFLOW,
+    })) || [],
+
+  [ChatModelProviders.MINIMAX]: (data): StandardModel[] =>
+    data.data?.map((model) => ({
+      id: model.id,
+      name: model.id,
+      provider: ChatModelProviders.MINIMAX,
     })) || [],
 
   [ChatModelProviders.GITHUB_COPILOT]: (data): StandardModel[] =>


### PR DESCRIPTION
## Summary

Add [MiniMax AI](https://www.minimaxi.com) as a built-in LLM provider alongside existing providers like OpenAI, DeepSeek, SiliconFlow, etc.

MiniMax provides OpenAI-compatible API endpoints, making integration straightforward using `ChatOpenAI` from LangChain — following the same pattern as DeepSeek and SiliconFlow.

### Models added:
- **MiniMax-M2.7** — latest flagship model with up to 1M context window
- **MiniMax-M2.5** — cost-effective model with 204K context

### Changes:
- **`src/constants.ts`** — Add `MINIMAX` to `ChatModelProviders` enum, `ChatModels` enum, `BUILTIN_CHAT_MODELS`, `ProviderInfo` metadata, `ProviderSettingsKeyMap`, and `DEFAULT_SETTINGS`
- **`src/settings/model.ts`** — Add `minimaxApiKey` to `CopilotSettings` interface
- **`src/LLMProviders/chatModelManager.ts`** — Add MiniMax constructor mapping (`ChatOpenAI`), API key getter, provider config with `baseURL` routing, and `topP`/`frequencyPenalty` support
- **`src/settings/providerModels.ts`** — Add `MiniMaxModelResponse` type, `MiniMaxModel` interface, `ProviderResponseMap` entry, and model list adapter
- **`src/LLMProviders/minimax.test.ts`** — 20 unit tests covering provider registration, built-in models, provider info, settings mapping, and model adapter
- **`src/integration_tests/minimax.test.ts`** — 3 integration tests covering chat completion, model variants, and streaming

## Test plan
- [x] `npm run build` passes (TypeScript check + esbuild)
- [x] `npm run test -- --testPathPattern=minimax` — 20/20 unit tests pass
- [x] Prettier formatting verified
- [ ] Integration tests require `MINIMAX_API_KEY` in `.env.test`

## How users enable MiniMax
1. Get an API key from [MiniMax Platform](https://platform.minimaxi.com/user-center/basic-information/interface-key)
2. Enter the key in Copilot Settings → API Keys → MiniMax
3. Enable MiniMax-M2.7 or MiniMax-M2.5 from the model list
4. Users can also import models dynamically via the model list endpoint