### PR TITLE
feat: migrate project storage from data.json to vault files

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -3,6 +3,8 @@
 import yaml from "js-yaml";
 
 module.exports = {
+  // Reason: normalizePath is used by projectPaths.ts; identity function is sufficient for tests
+  normalizePath: jest.fn().mockImplementation((p) => p),
   Vault: jest.fn().mockImplementation(() => {
     return {
       getMarkdownFiles: jest.fn().mockImplementation(() => {

--- a/src/LLMProviders/projectManager.ts
+++ b/src/LLMProviders/projectManager.ts
@@ -1,8 +1,10 @@
 import {
   FailedItem,
   getChainType,
+  getCurrentProject,
   isProjectMode,
   ProjectConfig,
+  setCurrentProject,
   setProjectLoading,
   subscribeToChainTypeChange,
   subscribeToModelKeyChange,
@@ -16,7 +18,10 @@ import { logError, logInfo, logWarn } from "@/logger";
 import CopilotPlugin from "@/main";
 import { Mention } from "@/mentions/Mention";
 import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
-import { getSettings, subscribeToSettingsChange, updateSetting } from "@/settings/model";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { getCachedProjects, subscribeToProjectRecords } from "@/projects/state";
+import { ProjectFileRecord } from "@/projects/type";
+import { getSettings } from "@/settings/model";
 import { FileParserManager, saveConvertedDocOutput } from "@/tools/FileParserManager";
 import { err2String } from "@/utils";
 import { isRateLimitError } from "@/utils/rateLimitUtils";
@@ -35,7 +40,7 @@ export default class ProjectManager {
   private readonly projectContextCache: ProjectContextCache;
   private fileParserManager: FileParserManager;
   private loadTracker: ProjectLoadTracker;
-  private readonly projectUsageTimestampsManager = new RecentUsageManager<string>();
+  private projectRecordsUnsubscriber?: () => void;
 
   private constructor(app: App, plugin: CopilotPlugin) {
     this.app = app;
@@ -77,16 +82,36 @@ export default class ProjectManager {
       await this.switchProject(project);
     });
 
-    // Subscribe to settings changes to monitor projectList changes
+    // Subscribe to project cache changes to monitor project modifications
     this.setupProjectListChangeMonitor();
   }
 
-  private setupProjectListChangeMonitor() {
-    subscribeToSettingsChange(async (prev, next) => {
-      if (!prev || !next) return;
+  private previousProjectRecords: ProjectFileRecord[] = [];
 
-      const prevProjects = prev.projectList || [];
-      const nextProjects = next.projectList || [];
+  private setupProjectListChangeMonitor() {
+    this.previousProjectRecords = [];
+    this.projectRecordsUnsubscriber?.();
+    this.projectRecordsUnsubscriber = subscribeToProjectRecords((nextRecords) => {
+      const prevProjects = this.previousProjectRecords.map((r) => r.project);
+      const nextProjects = nextRecords.map((r) => r.project);
+      this.previousProjectRecords = nextRecords;
+
+      // Reason: if the active project's id disappeared (e.g. manual frontmatter id edit),
+      // clear selection so state doesn't point at a phantom project.
+      // Reason: if the active project disappeared externally (file deleted/moved/invalidated),
+      // use switchProject(null) which saves the current chat first, then clears the atom.
+      // Calling setCurrentProject(null) directly would cause saveChat() to misclassify
+      // the project chat as non-project because it reads the atom at save time.
+      if (
+        this.currentProjectId &&
+        !nextProjects.some((p) => p.id === this.currentProjectId) &&
+        getCurrentProject()?.id === this.currentProjectId
+      ) {
+        logWarn(`[ProjectManager] Active project id="${this.currentProjectId}" no longer exists, clearing selection`);
+        void this.switchProject(null).catch((err) =>
+          logError("[ProjectManager] Failed to switch away from removed project", err)
+        );
+      }
 
       // Find modified projects
       for (const nextProject of nextProjects) {
@@ -95,15 +120,31 @@ export default class ProjectManager {
           // Check if project configuration has changed (ignoring UsageTimestamps)
           if (this.hasMeaningfulProjectConfigChange(prevProject, nextProject)) {
             // Compare project configuration changes and selectively update cache
-            await this.compareAndUpdateCache(prevProject, nextProject);
+            void this.compareAndUpdateCache(prevProject, nextProject).catch((err) =>
+              logError("[ProjectManager] compareAndUpdateCache failed", err)
+            );
 
             // If this is the current project, reload its context and recreate chain
-            if (this.currentProjectId === nextProject.id) {
-              await Promise.all([
+            // Reason: also check getCurrentProject()?.id to avoid overwriting the atom
+            // during a switchProject() transition (where currentProjectId is still the old id
+            // but the atom has already been updated to the new project).
+            if (
+              this.currentProjectId === nextProject.id &&
+              getCurrentProject()?.id === nextProject.id
+            ) {
+              // Reason: keep aiParams.getCurrentProject() fresh so PromptManager/ChainManager
+              // observe updated systemPrompt and modelConfigs when vault files change.
+              setCurrentProject(nextProject);
+              void Promise.all([
                 this.loadProjectContext(nextProject, true),
                 // Recreate chain to pick up new system prompt
                 this.getCurrentChainManager().createChainWithNewModel(),
-              ]);
+              ]).catch((error) => {
+                logError(
+                  `[Projects] Failed to refresh current project after config change id=${nextProject.id}`,
+                  error
+                );
+              });
             }
           }
         }
@@ -140,38 +181,12 @@ export default class ProjectManager {
   }
 
   /**
-   * Touch the project's usage timestamp in settings with throttled persistence.
-   * Memory is always updated immediately (for UI sorting), but settings writes are throttled.
+   * Touch the project's usage timestamp with throttled persistence.
+   * Delegates to ProjectFileManager for vault file writes.
    */
   private touchProjectUsageTimestamps(project: ProjectConfig): void {
-    // Always update memory for immediate UI feedback
-    this.projectUsageTimestampsManager.touch(project.id);
-
-    // Check if we should persist to settings (throttled)
-    const currentProjects = getSettings().projectList || [];
-    const persistedProject = currentProjects.find((p) => p.id === project.id);
-    if (!persistedProject) {
-      return;
-    }
-
-    const timestampToPersist = this.projectUsageTimestampsManager.shouldPersist(
-      project.id,
-      persistedProject.UsageTimestamps
-    );
-
-    if (timestampToPersist === null) {
-      return;
-    }
-
-    updateSetting(
-      "projectList",
-      currentProjects.map((p) =>
-        p.id === project.id ? { ...p, UsageTimestamps: timestampToPersist } : p
-      )
-    );
-
-    // Mark persistence successful for throttling purposes
-    this.projectUsageTimestampsManager.markPersisted(project.id, timestampToPersist);
+    const manager = ProjectFileManager.getInstance(this.app.vault);
+    void manager.touchProjectLastUsed(project.id);
   }
 
   /**
@@ -179,10 +194,19 @@ export default class ProjectManager {
    * This allows UI components to use in-memory values for immediate feedback.
    */
   public getProjectUsageTimestampsManager(): RecentUsageManager<string> {
-    return this.projectUsageTimestampsManager;
+    return ProjectFileManager.getInstance(this.app.vault).getProjectUsageTimestampsManager();
   }
 
   public async switchProject(project: ProjectConfig | null): Promise<void> {
+    // Reason: setCurrentProject(updatedConfig) fires this callback even for same-id updates
+    // (e.g. when vault file content changes). Skip early to avoid loading-state churn.
+    if (project && this.currentProjectId === project.id) {
+      return;
+    }
+    if (!project && this.currentProjectId === null) {
+      return;
+    }
+
     try {
       // Clear all project context loading states
       this.loadTracker.clearAllLoadStates();
@@ -196,6 +220,12 @@ export default class ProjectManager {
         await this.saveCurrentProjectMessage();
         this.currentProjectId = null; // ensure set currentProjectId
 
+        // Reason: update the atom AFTER saving so saveChat() uses the correct project context.
+        // The guard at the top of switchProject prevents re-entry when this fires the subscriber.
+        if (getCurrentProject() !== null) {
+          setCurrentProject(null);
+        }
+
         await this.loadNextProjectMessage();
         this.refreshChatView();
         return;
@@ -203,9 +233,6 @@ export default class ProjectManager {
 
       // else
       const projectId = project.id;
-      if (this.currentProjectId === projectId) {
-        return;
-      }
 
       await this.saveCurrentProjectMessage();
       this.currentProjectId = projectId; // ensure set currentProjectId
@@ -287,7 +314,7 @@ export default class ProjectManager {
       await this.projectContextCache.setCacheSafely(project, updatedContextCacheAfterSources);
 
       // After other contexts are processed, ensure all referenced non-markdown files are parsed and cached
-      await this.processNonMarkdownFiles(project, projectAllFiles);
+      await this.processNonMarkdownFiles(project, projectAllFiles, updatedContextCacheAfterSources);
 
       logInfo(`[loadProjectContext] Completed for project: ${project.name}.`);
       return updatedContextCacheAfterSources;
@@ -369,7 +396,7 @@ export default class ProjectManager {
   }
 
   public async getProjectContext(projectId: string): Promise<string | null> {
-    const project = getSettings().projectList.find((p) => p.id === projectId);
+    const project = getCachedProjects().find((p) => p.id === projectId);
     if (!project) {
       logWarn(`[getProjectContext] Project not found for ID: ${projectId}`);
       return null;
@@ -789,7 +816,8 @@ modified: ${stat ? new Date(stat.mtime).toISOString() : "unknown"}`;
 
   private async processNonMarkdownFiles(
     project: ProjectConfig,
-    projectAllFiles: TFile[]
+    projectAllFiles: TFile[],
+    contextCache: ContextCache
   ): Promise<void> {
     const nonMarkdownFiles = projectAllFiles.filter((file) => file.extension !== "md");
 
@@ -808,12 +836,28 @@ modified: ${stat ? new Date(stat.mtime).toISOString() : "unknown"}`;
       project
     );
 
+    // Reason: reorder so files with existing cache references are processed first.
+    // This is a heuristic — fileContexts[path] is a cacheKey reference, not a guarantee
+    // that content exists — but in practice, referenced files almost always have valid
+    // cached content, so they complete near-instantly via getOrReuseFileContext().
+    // This prevents slow/failing uncached items from blocking already-cached ones.
+    const likelyCachedFiles: TFile[] = [];
+    const remainingFiles: TFile[] = [];
+    for (const file of nonMarkdownFiles) {
+      if (contextCache.fileContexts[file.path]?.cacheKey) {
+        likelyCachedFiles.push(file);
+      } else {
+        remainingFiles.push(file);
+      }
+    }
+    const orderedFiles = [...likelyCachedFiles, ...remainingFiles];
+
     let processedNonMdCount = 0;
 
     // TODO: Add batch progress feedback (e.g. Notice or status bar update) so users
     // know how many files remain. Consider bounded concurrency (e.g. p-limit) instead
     // of sequential processing for faster throughput on large vaults.
-    for (const file of nonMarkdownFiles) {
+    for (const file of orderedFiles) {
       const filePath = file.path;
       if (this.fileParserManager.supportsExtension(file.extension)) {
         try {
@@ -867,7 +911,7 @@ modified: ${stat ? new Date(stat.mtime).toISOString() : "unknown"}`;
         return;
       }
 
-      const project = getSettings().projectList.find((p) => p.id === this.currentProjectId);
+      const project = getCachedProjects().find((p) => p.id === this.currentProjectId);
       if (!project) {
         logError(`[retryFailedItem] Current project not found: ${this.currentProjectId}`);
         return;
@@ -991,6 +1035,8 @@ modified: ${stat ? new Date(stat.mtime).toISOString() : "unknown"}`;
   }
 
   public onunload(): void {
+    this.projectRecordsUnsubscriber?.();
+    this.projectRecordsUnsubscriber = undefined;
     this.projectContextCache.cleanup();
   }
 }

--- a/src/cache/projectContextCache.ts
+++ b/src/cache/projectContextCache.ts
@@ -2,7 +2,7 @@ import { ProjectConfig } from "@/aiParams";
 import { FileCache } from "@/cache/fileCache";
 import { logError, logInfo, logWarn } from "@/logger";
 import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
-import { getSettings } from "@/settings/model";
+import { getCachedProjects } from "@/projects/state";
 import { MD5 } from "crypto-js";
 import { TAbstractFile, TFile, Vault } from "obsidian";
 import debounce from "lodash.debounce";
@@ -22,6 +22,38 @@ export interface ContextCache {
 
   // Cache metadata
   timestamp: number;
+}
+
+/** Reference to a cached file on disk, resolved from ContextCache. */
+export interface CacheFileRef {
+  cacheKey: string;
+  cachePath: string;
+}
+
+/** Default cache directory used by FileCache. */
+const FILE_CONTENT_CACHE_DIR = ".copilot/file-content-cache";
+
+/**
+ * Synchronously resolve the on-disk cache file reference for a parsed file.
+ * Accepts an already-loaded ContextCache so the caller controls the data source
+ * (avoids depending on memoryCache state which may not be populated yet).
+ *
+ * @param cache - Already-loaded ContextCache (from parent component state)
+ * @param filePath - Original source file path in the vault
+ * @returns Cache file reference, or null if not cached / invalid key
+ */
+export function getFileCacheRef(
+  cache: ContextCache | null | undefined,
+  filePath: string
+): CacheFileRef | null {
+  const entry = cache?.fileContexts?.[filePath];
+  if (!entry?.cacheKey || typeof entry.cacheKey !== "string" || !entry.cacheKey.trim()) {
+    return null;
+  }
+  return {
+    cacheKey: entry.cacheKey,
+    cachePath: `${FILE_CONTENT_CACHE_DIR}/${entry.cacheKey}.md`,
+  };
 }
 
 /**
@@ -94,8 +126,7 @@ export class ProjectContextCache {
         return;
       }
 
-      const settings = getSettings();
-      const projects = settings.projectList || [];
+      const projects = getCachedProjects();
 
       // Check each project to see if the file matches its patterns
       for (const project of projects) {
@@ -609,8 +640,7 @@ export class ProjectContextCache {
     filePath: string
   ): Promise<{ cacheKey: string; content: string } | null> {
     try {
-      const settings = getSettings();
-      const projects = settings.projectList || [];
+      const projects = getCachedProjects();
 
       if (projects.length === 0) {
         return null;

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -4,7 +4,6 @@ import {
   getSelectedTextContexts,
   ProjectConfig,
   removeSelectedTextContext,
-  setCurrentProject,
   useChainType,
   updateIndexingProgressState,
   useIndexingProgress,
@@ -42,7 +41,9 @@ import { clearRecordedPromptPayload } from "@/LLMProviders/chainRunner/utils/pro
 import { logFileManager } from "@/logFileManager";
 import CopilotPlugin from "@/main";
 import { useIsPlusUser } from "@/plusUtils";
-import { updateSetting, useSettingsValue } from "@/settings/model";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { useProjects } from "@/projects/state";
+import { useSettingsValue } from "@/settings/model";
 import { ChatUIState } from "@/state/ChatUIState";
 import { FileParserManager } from "@/tools/FileParserManager";
 import { ChatMessage } from "@/types/message";
@@ -78,6 +79,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
   chatInput,
 }) => {
   const settings = useSettingsValue();
+  const projects = useProjects();
   const eventTarget = useContext(EventTargetContext);
 
   const { messages: chatHistory, addMessage: rawAddMessage } = useChatManager(chatUIState);
@@ -445,7 +447,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
         if (!success) {
           new Notice("Failed to regenerate message. Please try again.");
         } else if (settings.debug) {
-          console.log("Message regenerated successfully");
+          logInfo("Message regenerated successfully");
         }
 
         // Autosave the chat if the setting is enabled
@@ -557,71 +559,33 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
   }, [onSaveChat, handleSaveAsNote]);
 
   const handleAddProject = useCallback(
-    (project: ProjectConfig) => {
-      const currentProjects = settings.projectList || [];
-      const existingIndex = currentProjects.findIndex((p) => p.name === project.name);
+    async (project: ProjectConfig) => {
+      const manager = ProjectFileManager.getInstance(plugin.app.vault);
+      await manager.createProject(project);
+      new Notice(`${project.name} added successfully`);
 
-      if (existingIndex >= 0) {
-        throw new Error(`Project "${project.name}" already exists, please use a different name`);
-      }
-
-      const newProjectList = [...currentProjects, project];
-      updateSetting("projectList", newProjectList);
-
-      // Check if this project is now the current project
+      // Reason: reload is best-effort — the project is already saved, so a reload failure
+      // must not surface as a "save failed" error to the modal (which would cause retries
+      // and duplicate-id errors). reloadCurrentProject() handles its own error notices.
       const currentProject = getCurrentProject();
       if (currentProject?.id === project.id) {
-        // Reload the project context for the newly added project
-        reloadCurrentProject()
-          .then(() => {
-            new Notice(`${project.name} added and context loaded`);
-          })
-          .catch((error: Error) => {
-            logError("Error loading project context:", error);
-            new Notice(`${project.name} added but context loading failed`);
-          });
-      } else {
-        new Notice(`${project.name} added successfully`);
+        void reloadCurrentProject();
       }
-
-      return true;
     },
-    [settings.projectList]
+    [plugin.app.vault]
   );
 
   const handleEditProject = useCallback(
-    (originP: ProjectConfig, updateP: ProjectConfig) => {
-      const currentProjects = settings.projectList || [];
-      const existingProject = currentProjects.find((p) => p.name === originP.name);
-
-      if (!existingProject) {
-        throw new Error(`Project "${originP.name}" does not exist`);
-      }
-
-      const newProjectList = currentProjects.map((p) => (p.name === originP.name ? updateP : p));
-      updateSetting("projectList", newProjectList);
-
-      // If this is the current project, update the current project atom
-      const currentProject = getCurrentProject();
-      if (currentProject?.id === originP.id) {
-        setCurrentProject(updateP);
-
-        // Reload the project context
-        reloadCurrentProject()
-          .then(() => {
-            new Notice(`${originP.name} updated and context reloaded`);
-          })
-          .catch((error: Error) => {
-            logError("Error reloading project context:", error);
-            new Notice(`${originP.name} updated but context reload failed`);
-          });
-      } else {
-        new Notice(`${originP.name} updated successfully`);
-      }
-
-      return true;
+    async (originP: ProjectConfig, updateP: ProjectConfig) => {
+      const manager = ProjectFileManager.getInstance(plugin.app.vault);
+      await manager.updateProject(originP.id, updateP);
+      new Notice(`${originP.name} updated successfully`);
+      // Reason: no explicit reload needed here — ProjectManager's project-record subscriber
+      // already reacts to the cache update from updateProject() and triggers
+      // setCurrentProject + loadProjectContext + createChainWithNewModel.
+      // Doing it here too would duplicate expensive work (URL fetches, chain recreation).
     },
-    [settings.projectList]
+    [plugin.app.vault]
   );
 
   const handleRemoveSelectedText = useCallback(
@@ -955,7 +919,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
           {selectedChain === ChainType.PROJECT_CHAIN && (
             <div className={`${selectedChain === ChainType.PROJECT_CHAIN ? "tw-z-modal" : ""}`}>
               <ProjectList
-                projects={settings.projectList || []}
+                projects={projects}
                 defaultOpen={true}
                 app={app}
                 plugin={plugin}

--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -52,7 +52,7 @@ export async function refreshVaultIndex() {
       new Notice("Lexical search builds indexes on demand. No manual indexing required.");
     }
   } catch (error) {
-    console.error("Error refreshing vault index:", error);
+    logError("Error refreshing vault index:", error);
     new Notice("Failed to refresh vault index. Check console for details.");
   }
 }
@@ -71,7 +71,7 @@ export async function forceReindexVault() {
       new Notice("Lexical search builds indexes on demand. No manual indexing required.");
     }
   } catch (error) {
-    console.error("Error force reindexing vault:", error);
+    logError("Error force reindexing vault:", error);
     new Notice("Failed to force reindex vault. Check console for details.");
   }
 }
@@ -98,6 +98,9 @@ export async function reloadCurrentProject() {
     const plugin = (app as any).plugins.getPlugin("copilot");
     if (plugin && plugin.projectManager) {
       await plugin.projectManager.getProjectContext(currentProject.id);
+      // Reason: chain/model config must be refreshed after context reload so the next
+      // user message uses the updated system prompt and model settings.
+      await plugin.projectManager.getCurrentChainManager().createChainWithNewModel();
       new Notice(`Project context for "${currentProject.name}" reloaded successfully.`);
     } else {
       throw new Error("Copilot plugin or ProjectManager not available.");

--- a/src/components/chat-components/ProjectList.tsx
+++ b/src/components/chat-components/ProjectList.tsx
@@ -14,10 +14,12 @@ import {
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { SearchBar } from "@/components/ui/SearchBar";
 import { cn } from "@/lib/utils";
-import { logError } from "@/logger";
-import { updateSetting, useSettingsValue } from "@/settings/model";
+import { logError, logWarn } from "@/logger";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { useSettingsValue } from "@/settings/model";
 import { RecentUsageManager, sortByStrategy } from "@/utils/recentUsageManager";
 import {
+  ArrowUpRight,
   ChevronDown,
   ChevronUp,
   Edit2,
@@ -28,6 +30,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
+import { getCachedProjectRecordById } from "@/projects/state";
 import { App, Notice } from "obsidian";
 import React, { memo, useEffect, useMemo, useState } from "react";
 import { filterProjects } from "@/utils/projectUtils";
@@ -96,6 +99,7 @@ function ProjectItem({
             <Button
               variant="ghost2"
               size="icon"
+              aria-label="Edit Project"
               onClick={(e) => {
                 e.stopPropagation();
                 onEdit(project);
@@ -111,6 +115,7 @@ function ProjectItem({
             <Button
               variant="ghost2"
               size="icon"
+              aria-label="Start Chat"
               onClick={(e) => {
                 e.stopPropagation();
                 loadContext(project);
@@ -126,6 +131,32 @@ function ProjectItem({
             <Button
               variant="ghost2"
               size="icon"
+              aria-label="Open Project File"
+              onClick={(e) => {
+                e.stopPropagation();
+                const record = getCachedProjectRecordById(project.id);
+                if (record?.filePath) {
+                  // Reason: hidden-folder files are not in vault cache, so openLinkText silently fails.
+                  const fileInCache = app.vault.getAbstractFileByPath(record.filePath);
+                  if (fileInCache) {
+                    app.workspace.openLinkText(record.filePath, "", true);
+                  } else {
+                    new Notice("Project file is in a hidden folder and cannot be opened from the file explorer.");
+                  }
+                }
+              }}
+            >
+              <ArrowUpRight className="tw-size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Open Project File</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost2"
+              size="icon"
+              aria-label="Delete Project"
               onClick={(e) => {
                 e.stopPropagation();
                 const modal = new ConfirmModal(
@@ -166,8 +197,8 @@ export const ProjectList = memo(
     defaultOpen?: boolean;
     app: App;
     plugin?: any; // CopilotPlugin, optional for backwards compatibility
-    onProjectAdded: (project: ProjectConfig) => void;
-    onEditProject: (originP: ProjectConfig, updateP: ProjectConfig) => void;
+    onProjectAdded: (project: ProjectConfig) => Promise<void>;
+    onEditProject: (originP: ProjectConfig, updateP: ProjectConfig) => Promise<void>;
     hasMessages?: boolean;
     showChatUI: (v: boolean) => void;
     onClose: () => void;
@@ -179,6 +210,20 @@ export const ProjectList = memo(
     const [searchQuery, setSearchQuery] = useState("");
     const chatInput = useChatInput();
     const settings = useSettingsValue();
+
+    // Safety net: if the selected project disappears from the list (delete/move/duplicate-id),
+    // clear local UI selection. Don't call setCurrentProject(null) here — ProjectManager's
+    // records subscriber handles the atom update with save-first ordering via switchProject(null).
+    useEffect(() => {
+      if (!selectedProject) return;
+      const stillExists = projects.some((p) => p.id === selectedProject.id);
+      if (!stillExists) {
+        setSelectedProject(null);
+        setShowChatInput(false);
+        setIsOpen(true);
+        showChatUI(false);
+      }
+    }, [projects, selectedProject, showChatUI]);
 
     // Get the project usage manager for subscription
     const projectUsageTimestampsManager =
@@ -228,9 +273,14 @@ export const ProjectList = memo(
     }, [sortedProjects, searchQuery]);
 
     const handleAddProject = () => {
-      const modal = new AddProjectModal(app, async (project: ProjectConfig) => {
-        onProjectAdded(project);
-      });
+      const modal = new AddProjectModal(
+        app,
+        async (project: ProjectConfig) => {
+          await onProjectAdded(project);
+        },
+        undefined,
+        plugin
+      );
       modal.open();
     };
 
@@ -238,28 +288,35 @@ export const ProjectList = memo(
       const modal = new AddProjectModal(
         app,
         async (updatedProject: ProjectConfig) => {
-          onEditProject(originP, updatedProject);
-          if (selectedProject && selectedProject.name === originP.name) {
+          await onEditProject(originP, updatedProject);
+          if (selectedProject && selectedProject.id === originP.id) {
             setSelectedProject(updatedProject);
           }
         },
-        originP
+        originP,
+        plugin
       );
       modal.open();
     };
 
-    const handleDeleteProject = (project: ProjectConfig) => {
-      const currentProjects = projects || [];
-      const newProjectList = currentProjects.filter((p) => p.name !== project.name);
-
-      // If the deleted project is currently selected, close it
-      if (selectedProject?.name === project.name) {
-        enableOrDisableProject(false);
+    const handleDeleteProject = async (project: ProjectConfig) => {
+      const manager = ProjectFileManager.getInstance(app.vault);
+      try {
+        await manager.deleteProject(project.id);
+        // Reason: only clear UI selection — don't call setCurrentProject(null) here
+        // because deleteProject already triggers the register's save-first flow.
+        if (selectedProject?.id === project.id) {
+          setSelectedProject(null);
+          setShowChatInput(false);
+          setIsOpen(true);
+          showChatUI(false);
+        }
+        new Notice(`Project "${project.name}" deleted successfully`);
+      } catch (error) {
+        logError("[Projects] Failed to delete project", error);
+        const message = error instanceof Error ? error.message : String(error);
+        new Notice(`Failed to delete project: ${message}`);
       }
-
-      // Update the project list in settings
-      updateSetting("projectList", newProjectList);
-      new Notice(`Project "${project.name}" deleted successfully`);
     };
 
     const enableOrDisableProject = (enable: boolean, project?: ProjectConfig) => {
@@ -272,7 +329,7 @@ export const ProjectList = memo(
         return;
       } else {
         if (!project) {
-          logError("Must be exist one project.");
+          logWarn("[Projects] No project provided for context loading");
           return;
         }
         setSelectedProject(project);
@@ -302,9 +359,9 @@ export const ProjectList = memo(
                 <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
                   <span className="tw-font-semibold tw-text-normal">Projects</span>
                   <Select
-                    value={selectedProject.name}
+                    value={selectedProject.id}
                     onValueChange={(value) => {
-                      const project = sortedProjects.find((p) => p.name === value);
+                      const project = sortedProjects.find((p) => p.id === value);
                       if (project) {
                         handleLoadContext(project);
                       }
@@ -321,8 +378,8 @@ export const ProjectList = memo(
                     <SelectContent className="tw-truncate">
                       {sortedProjects.map((project) => (
                         <SelectItem
-                          key={project.name}
-                          value={project.name}
+                          key={project.id}
+                          value={project.id}
                           className="tw-flex tw-items-center tw-gap-2"
                         >
                           <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
@@ -428,7 +485,7 @@ export const ProjectList = memo(
                       <div className="tw-flex tw-flex-col tw-gap-2 @2xl:tw-grid @2xl:tw-grid-cols-2 @4xl:tw-grid-cols-3">
                         {filteredProjects.map((project) => (
                           <ProjectItem
-                            key={project.name}
+                            key={project.id}
                             project={project}
                             loadContext={handleLoadContext}
                             onEdit={handleEditProject}

--- a/src/components/modals/CachePreviewModal.ts
+++ b/src/components/modals/CachePreviewModal.ts
@@ -1,0 +1,92 @@
+import { App, Component, MarkdownRenderer, Modal, Notice, setIcon } from "obsidian";
+
+/**
+ * Read-only modal for previewing cached parsed file content.
+ *
+ * Features:
+ * - Wider layout (90vw / max 800px) for comfortable reading
+ * - Markdown rendering via Obsidian's MarkdownRenderer
+ * - Copy icon button with visual feedback (copy → check → copy)
+ * - Scrollable content area with theme-aware styling
+ */
+export class CachePreviewModal extends Modal {
+  private component: Component;
+
+  constructor(
+    app: App,
+    private title: string,
+    private content: string
+  ) {
+    super(app);
+    this.component = new Component();
+  }
+
+  onOpen(): void {
+    const { contentEl, modalEl } = this;
+
+    // Reason: override default modal width for wider content preview
+    modalEl.style.width = "90vw";
+    modalEl.style.maxWidth = "800px";
+
+    contentEl.empty();
+    contentEl.addClass("tw-flex", "tw-flex-col", "tw-p-0");
+    this.component.load();
+
+    // Header: file icon + title + copy button
+    const header = contentEl.createDiv({
+      cls: "tw-flex tw-items-center tw-justify-between tw-px-5 tw-py-3 tw-border-b tw-border-border",
+    });
+
+    const titleWrapper = header.createDiv({
+      cls: "tw-flex tw-items-center tw-gap-2 tw-min-w-0",
+    });
+    const fileIconEl = titleWrapper.createDiv({ cls: "tw-text-muted tw-shrink-0" });
+    setIcon(fileIconEl, "file-text");
+    titleWrapper.createEl("span", {
+      text: this.title,
+      cls: "tw-font-semibold tw-text-normal tw-truncate",
+    });
+
+    // Copy button with icon feedback
+    const copyBtn = header.createEl("button", {
+      cls: "tw-flex tw-items-center tw-gap-1 tw-px-2 tw-py-1 tw-rounded-md tw-bg-secondary tw-border-none tw-cursor-pointer tw-text-muted hover:tw-text-normal tw-shrink-0",
+      attr: { "aria-label": "Copy content", title: "Copy content" },
+    });
+    const copyIconEl = copyBtn.createSpan({ cls: "tw-flex tw-items-center" });
+    setIcon(copyIconEl, "copy");
+
+    copyBtn.addEventListener("click", () => {
+      navigator.clipboard.writeText(this.content).then(
+        () => {
+          // Reason: visual feedback — icon changes to check mark for 2 seconds
+          setIcon(copyIconEl, "check");
+          copyBtn.addClass("tw-text-accent");
+          new Notice("Copied to clipboard");
+          setTimeout(() => {
+            setIcon(copyIconEl, "copy");
+            copyBtn.removeClass("tw-text-accent");
+          }, 2000);
+        },
+        () => new Notice("Failed to copy")
+      );
+    });
+
+    // Content area: scrollable rendered markdown
+    const scrollArea = contentEl.createDiv({
+      cls: "tw-overflow-auto tw-p-5",
+      attr: { style: "max-height: 50vh" },
+    });
+
+    const mdContainer = scrollArea.createDiv({
+      cls: "markdown-rendered tw-p-4 tw-bg-primary-alt tw-rounded-lg tw-border tw-border-border",
+    });
+
+    // Reason: pass empty sourcePath to prevent vault link resolution
+    MarkdownRenderer.renderMarkdown(this.content, mdContainer, "", this.component);
+  }
+
+  onClose(): void {
+    this.component.unload();
+    this.contentEl.empty();
+  }
+}

--- a/src/components/modals/project/AddProjectModal.tsx
+++ b/src/components/modals/project/AddProjectModal.tsx
@@ -1,30 +1,48 @@
-import { ProjectConfig, getCurrentProject } from "@/aiParams";
+import { ProjectConfig } from "@/aiParams";
 import { ContextManageModal } from "@/components/modals/project/context-manage-modal";
-import { TruncatedText } from "@/components/TruncatedText";
+import { openCachedItemPreview } from "@/utils/cacheFileOpener";
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import { ProcessingStatus } from "@/components/project/processing-status";
+import { useProjectProcessingData } from "@/components/project/useProjectProcessingData";
 import { Button } from "@/components/ui/button";
 import { FormField } from "@/components/ui/form-field";
+import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { Input } from "@/components/ui/input";
 import { getModelDisplayWithIcons } from "@/components/ui/model-display";
 import { ObsidianNativeSelect } from "@/components/ui/obsidian-native-select";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { SettingSlider } from "@/components/ui/setting-slider";
 import { Textarea } from "@/components/ui/textarea";
-import { DEFAULT_MODEL_SETTING } from "@/constants";
+import { UrlTagInput } from "@/components/ui/url-tag-input";
 import { SystemPromptSyntaxInstruction } from "@/components/SystemPromptSyntaxInstruction";
-import { getDecodedPatterns } from "@/search/searchUtils";
+import { DEFAULT_MODEL_SETTING } from "@/constants";
+import { ProjectContextBadgeList } from "@/components/project/ProjectContextBadgeList";
 import { getModelKeyFromModel, useSettingsValue } from "@/settings/model";
 import { checkModelApiKey, err2String, randomUUID } from "@/utils";
+import { Settings } from "lucide-react";
+import {
+  type UrlItem,
+  parseProjectUrls,
+  serializeProjectUrls,
+} from "@/utils/urlTagUtils";
+import type CopilotPlugin from "@/main";
 import { App, Modal, Notice } from "obsidian";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { createRoot, Root } from "react-dom/client";
-import { HelpTooltip } from "@/components/ui/help-tooltip";
 
 interface AddProjectModalContentProps {
   initialProject?: ProjectConfig;
   onSave: (project: ProjectConfig) => Promise<void>;
   onCancel: () => void;
+  plugin?: CopilotPlugin;
 }
 
-function AddProjectModalContent({ initialProject, onSave, onCancel }: AddProjectModalContentProps) {
+function AddProjectModalContent({
+  initialProject,
+  onSave,
+  onCancel,
+  plugin,
+}: AddProjectModalContentProps) {
   const settings = useSettingsValue();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [touched, setTouched] = useState({
@@ -56,30 +74,43 @@ function AddProjectModalContent({ initialProject, onSave, onCancel }: AddProject
     }
   );
 
-  const showContext = getDecodedPatterns(
-    formData.contextSource.inclusions || formData.contextSource.exclusions || "nothing"
-  )
-    .reverse()
-    .join(",");
+  // URL items derived from formData for UrlTagInput
+  const urlItems = useMemo(
+    () =>
+      parseProjectUrls(
+        formData.contextSource?.webUrls || "",
+        formData.contextSource?.youtubeUrls || ""
+      ),
+    [formData.contextSource?.webUrls, formData.contextSource?.youtubeUrls]
+  );
 
-  const handleEditProjectContext = (originP: ProjectConfig) => {
-    // attempt to retrieve the latest project configuration.
-    let projectToEdit = originP;
+  // Reason: Shared hook handles cache loading, file enumeration, and processingData construction.
+  // contextSource draft is passed so newly added (unsaved) URLs appear as "Pending".
+  const { processingData, projectCache, isCurrentProject } = useProjectProcessingData({
+    cacheProject: initialProject ?? null,
+    contextSource: formData.contextSource,
+  });
 
-    if (initialProject?.id) {
-      const currentProject = getCurrentProject();
-      if (currentProject?.id === originP.id) {
-        // Use the latest global project configuration
-        projectToEdit = currentProject;
-      }
-    }
 
+
+  const handleEditProjectContext = (projectDraft: ProjectConfig) => {
     const modal = new ContextManageModal(
       app,
-      async (updatedProject: ProjectConfig) => {
-        setFormData(updatedProject);
+      (updatedProject: ProjectConfig) => {
+        // Reason: Only merge inclusions/exclusions (what ContextManageModal edits).
+        // Don't replace the entire contextSource — that would overwrite any
+        // webUrls/youtubeUrls changes the user made in AddProjectModal while
+        // the child modal was open.
+        setFormData((prev) => ({
+          ...prev,
+          contextSource: {
+            ...prev.contextSource,
+            inclusions: updatedProject.contextSource?.inclusions,
+            exclusions: updatedProject.contextSource?.exclusions,
+          },
+        }));
       },
-      projectToEdit
+      projectDraft
     );
     modal.open();
   };
@@ -93,14 +124,11 @@ function AddProjectModalContent({ initialProject, onSave, onCancel }: AddProject
     value: string | number | string[] | Record<string, any>
   ) => {
     setFormData((prev) => {
-      // Handle text input
       if (typeof value === "string") {
-        // Only trim for model key which shouldn't have whitespace
         if (field === "projectModelKey") {
           value = value.trim();
         }
       }
-      // Handle string arrays
       if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
         value = value.map((item) => item.trim()).filter(Boolean);
       }
@@ -127,14 +155,65 @@ function AddProjectModalContent({ initialProject, onSave, onCancel }: AddProject
     });
   };
 
-  const handleSave = async () => {
-    // Trim the project name before validation and saving
-    if (formData.name) {
-      formData.name = formData.name.trim();
+  /** Handle URL adds from UrlTagInput, serialize back to formData strings */
+  const handleUrlAdd = (newUrls: UrlItem[]) => {
+    const allUrls = [...urlItems, ...newUrls];
+    const { webUrls, youtubeUrls } = serializeProjectUrls(allUrls);
+    handleInputChange("contextSource.webUrls", webUrls);
+    handleInputChange("contextSource.youtubeUrls", youtubeUrls);
+  };
+
+  /** Handle URL removal from UrlTagInput */
+  const handleUrlRemove = (id: string) => {
+    const remaining = urlItems.filter((u) => u.id !== id);
+    const { webUrls, youtubeUrls } = serializeProjectUrls(remaining);
+    handleInputChange("contextSource.webUrls", webUrls);
+    handleInputChange("contextSource.youtubeUrls", youtubeUrls);
+  };
+
+  /** Handle inclusions pattern changes from badge list deletion */
+  const handleInclusionsChange = (value: string) => {
+    handleInputChange("contextSource.inclusions", value);
+  };
+
+  /** Handle exclusions pattern changes from badge list deletion */
+  const handleExclusionsChange = (value: string) => {
+    handleInputChange("contextSource.exclusions", value);
+  };
+
+  /** Handle opening cached parsed content for any item (file or URL) */
+  const handleOpenCachedItem = (item: ProcessingItem) => {
+    openCachedItemPreview(app, projectCache, item);
+  };
+
+  /** Handle removing a failed URL from the project config via ProcessingStatus × button */
+  const handleRemoveUrl = (item: ProcessingItem) => {
+    // Reason: ProcessingItem.id is the raw URL, while UrlItem.id is "type:url".
+    // Match by url field and cacheKind to avoid ID format mismatch.
+    const targetType = item.cacheKind === "youtube" ? "youtube" : "web";
+    const remaining = urlItems.filter((u) => !(u.type === targetType && u.url === item.id));
+    const { webUrls, youtubeUrls } = serializeProjectUrls(remaining);
+    handleInputChange("contextSource.webUrls", webUrls);
+    handleInputChange("contextSource.youtubeUrls", youtubeUrls);
+  };
+
+  /** Handle retry for failed processing items */
+  const handleRetry = (itemId: string) => {
+    if (!plugin?.projectManager || !processingData) return;
+    const failedItem = processingData.failedItemMap.get(itemId);
+    if (failedItem) {
+      plugin.projectManager.retryFailedItem(failedItem);
     }
+  };
+
+  const handleSave = async () => {
+    const trimmedName = formData.name?.trim() ?? "";
+    const saveData = { ...formData, name: trimmedName };
 
     const requiredFields = ["name", "projectModelKey"];
-    const missingFields = requiredFields.filter((field) => !formData[field as keyof ProjectConfig]);
+    const missingFields = requiredFields.filter(
+      (field) => !saveData[field as keyof ProjectConfig]
+    );
 
     if (missingFields.length > 0) {
       setTouched((prev) => ({
@@ -147,7 +226,7 @@ function AddProjectModalContent({ initialProject, onSave, onCancel }: AddProject
 
     try {
       setIsSubmitting(true);
-      await onSave(formData as ProjectConfig);
+      await onSave(saveData as ProjectConfig);
     } catch (e) {
       new Notice(err2String(e));
       setTouched((prev) => ({
@@ -160,222 +239,220 @@ function AddProjectModalContent({ initialProject, onSave, onCancel }: AddProject
   };
 
   return (
-    <div className="tw-flex tw-flex-col tw-gap-2 tw-p-4">
-      <div className="tw-mb-2 tw-text-xl tw-font-bold tw-text-normal">
-        {initialProject ? "Edit Project" : "New Project"}
+    <div className="tw-flex tw-h-full tw-flex-col">
+      {/* Header */}
+      <div className="tw-shrink-0 tw-px-4 tw-pb-2 tw-pt-4">
+        <div className="tw-text-xl tw-font-bold tw-text-normal">
+          {initialProject ? "Edit Project" : "New Project"}
+        </div>
+        <p className="tw-mt-1 tw-text-sm tw-text-muted">
+          Configure your project settings and context sources
+        </p>
       </div>
 
-      <div className="tw-flex tw-flex-col tw-gap-2">
-        <FormField
-          label="Project Name"
-          required
-          error={touched.name && !formData.name}
-          errorMessage="Project name is required"
-        >
-          <Input
-            type="text"
-            value={formData.name}
-            onChange={(e) => handleInputChange("name", e.target.value)}
-            onBlur={() => setTouched((prev) => ({ ...prev, name: true }))}
-            className="tw-w-full"
-          />
-        </FormField>
+      {/* Scrollable Content */}
+      <ScrollArea className="tw-min-h-0 tw-flex-1">
+        <div className="tw-flex tw-flex-col tw-gap-6 tw-p-4">
+          {/* Basic Info Card */}
+          <div className="tw-rounded-lg tw-border tw-border-border tw-p-4 tw-bg-secondary/50">
+            <h3 className="tw-mb-3 tw-text-sm tw-font-medium tw-text-normal">Basic Info</h3>
+            <div className="tw-flex tw-flex-col tw-gap-3">
+              <FormField
+                label="Project Name"
+                required
+                error={touched.name && !formData.name}
+                errorMessage="Project name is required"
+              >
+                <Input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => handleInputChange("name", e.target.value)}
+                  onBlur={() => setTouched((prev) => ({ ...prev, name: true }))}
+                  className="tw-w-full"
+                />
+              </FormField>
 
-        <FormField
-          label="Description"
-          description="Briefly describe the purpose and goals of the project"
-        >
-          <Input
-            type="text"
-            value={formData.description}
-            onChange={(e) => handleInputChange("description", e.target.value)}
-            className="tw-w-full"
-          />
-        </FormField>
+              <FormField
+                label="Description"
+                description="Briefly describe the purpose and goals of the project"
+              >
+                <Input
+                  type="text"
+                  value={formData.description}
+                  onChange={(e) => handleInputChange("description", e.target.value)}
+                  className="tw-w-full"
+                />
+              </FormField>
 
-        <FormField
-          label="Project System Prompt"
-          description="Custom instructions for how the AI should behave in this project context"
-        >
-          <SystemPromptSyntaxInstruction />
-          <Textarea
-            value={formData.systemPrompt}
-            onChange={(e) => handleInputChange("systemPrompt", e.target.value)}
-            onBlur={() => setTouched((prev) => ({ ...prev, systemPrompt: true }))}
-            placeholder="Enter your project system prompt here... Use {[[Note Name]]} to include note contents."
-            className="tw-min-h-32"
-          />
-        </FormField>
-
-        <FormField
-          label="Default Model"
-          required
-          error={touched.projectModelKey && !formData.projectModelKey}
-          errorMessage="Default model is required"
-        >
-          <ObsidianNativeSelect
-            value={formData.projectModelKey}
-            onChange={(e) => {
-              const value = e.target.value;
-              const selectedModel = settings.activeModels.find(
-                (m) => m.enabled && getModelKeyFromModel(m) === value
-              );
-              if (!selectedModel) return;
-
-              const { hasApiKey, errorNotice } = checkModelApiKey(selectedModel, settings);
-              if (!hasApiKey && errorNotice) {
-                // Keep selection allowed; error will surface in chat on send
-              }
-              handleInputChange("projectModelKey", value);
-            }}
-            onBlur={() => setTouched((prev) => ({ ...prev, projectModelKey: true }))}
-            placeholder="Select a model"
-            options={settings.activeModels
-              .filter((m) => m.enabled && m.projectEnabled)
-              .map((model) => ({
-                label: getModelDisplayWithIcons(model),
-                value: getModelKeyFromModel(model),
-              }))}
-          />
-        </FormField>
-
-        <div className="tw-space-y-4">
-          <div className="tw-text-base tw-font-medium">Model Configuration</div>
-          <div className="tw-grid tw-grid-cols-1 tw-gap-4">
-            <FormField label="Temperature">
-              <SettingSlider
-                value={formData.modelConfigs?.temperature ?? DEFAULT_MODEL_SETTING.TEMPERATURE}
-                onChange={(value) => handleInputChange("modelConfigs.temperature", value)}
-                min={0}
-                max={2}
-                step={0.01}
-                className="tw-w-full"
-              />
-            </FormField>
-            <FormField label="Token Limit">
-              <SettingSlider
-                value={formData.modelConfigs?.maxTokens ?? DEFAULT_MODEL_SETTING.MAX_TOKENS}
-                onChange={(value) => handleInputChange("modelConfigs.maxTokens", value)}
-                min={1}
-                max={65000}
-                step={1}
-                className="tw-w-full"
-              />
-            </FormField>
+              <FormField
+                label="Project System Prompt"
+                description="Custom instructions for how the AI should behave in this project context"
+              >
+                <SystemPromptSyntaxInstruction />
+                <Textarea
+                  value={formData.systemPrompt}
+                  onChange={(e) => handleInputChange("systemPrompt", e.target.value)}
+                  onBlur={() => setTouched((prev) => ({ ...prev, systemPrompt: true }))}
+                  placeholder="Enter your project system prompt here... Use {[[Note Name]]} to include note contents."
+                  className="tw-min-h-32"
+                />
+              </FormField>
+            </div>
           </div>
-        </div>
 
-        <div className="tw-space-y-4">
-          <div className="tw-text-base tw-font-medium">Context Sources</div>
-          <FormField
-            label={
-              <div className="tw-flex tw-items-center tw-gap-2">
-                <span>File Context</span>
-                <HelpTooltip
-                  buttonClassName="tw-size-4 tw-text-muted"
-                  content={
-                    <div className="tw-max-w-80">
-                      <strong>Supported File Types:</strong>
-                      <br />
-                      <strong>• Documents:</strong> pdf, doc, docx, ppt, pptx, epub, txt, rtf and
-                      many more
-                      <br />
-                      <strong>• Images:</strong> jpg, png, svg, gif, bmp, webp, tiff
-                      <br />
-                      <strong>• Spreadsheets:</strong> xlsx, xls, csv, numbers
-                      <br />
-                      <br />
-                      Non-markdown files are converted to markdown in the background.
-                      <br />
-                      <strong>Rate limit:</strong> 50 files or 100MB per 3 hours, whichever is
-                      reached first.
+          {/* Model Configuration Card */}
+          <div className="tw-rounded-lg tw-border tw-border-border tw-p-4 tw-bg-secondary/50">
+            <h3 className="tw-mb-3 tw-text-sm tw-font-medium tw-text-normal">
+              Model Configuration
+            </h3>
+            <div className="tw-flex tw-flex-col tw-gap-3">
+              <FormField
+                label="Default Model"
+                required
+                error={touched.projectModelKey && !formData.projectModelKey}
+                errorMessage="Default model is required"
+              >
+                <ObsidianNativeSelect
+                  value={formData.projectModelKey}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    const selectedModel = settings.activeModels.find(
+                      (m) => m.enabled && getModelKeyFromModel(m) === value
+                    );
+                    if (!selectedModel) return;
+
+                    const { hasApiKey, errorNotice } = checkModelApiKey(selectedModel, settings);
+                    if (!hasApiKey && errorNotice) {
+                      // Keep selection allowed; error will surface in chat on send
+                    }
+                    handleInputChange("projectModelKey", value);
+                  }}
+                  onBlur={() => setTouched((prev) => ({ ...prev, projectModelKey: true }))}
+                  placeholder="Select a model"
+                  options={settings.activeModels
+                    .filter((m) => m.enabled && m.projectEnabled)
+                    .map((model) => ({
+                      label: getModelDisplayWithIcons(model),
+                      value: getModelKeyFromModel(model),
+                    }))}
+                />
+              </FormField>
+
+              <FormField label="Temperature">
+                <SettingSlider
+                  value={formData.modelConfigs?.temperature ?? DEFAULT_MODEL_SETTING.TEMPERATURE}
+                  onChange={(value) => handleInputChange("modelConfigs.temperature", value)}
+                  min={0}
+                  max={2}
+                  step={0.01}
+                  className="tw-w-full"
+                />
+              </FormField>
+
+              <FormField label="Token Limit">
+                <SettingSlider
+                  value={formData.modelConfigs?.maxTokens ?? DEFAULT_MODEL_SETTING.MAX_TOKENS}
+                  onChange={(value) => handleInputChange("modelConfigs.maxTokens", value)}
+                  min={1}
+                  max={65000}
+                  step={1}
+                  className="tw-w-full"
+                />
+              </FormField>
+            </div>
+          </div>
+
+          {/* Context Sources Card */}
+          <div className="tw-rounded-lg tw-border tw-border-border tw-p-4 tw-bg-secondary/50">
+            <h3 className="tw-mb-3 tw-text-sm tw-font-medium tw-text-normal">Context Sources</h3>
+            <div className="tw-flex tw-flex-col tw-gap-4">
+              {/* File Context Sub-card */}
+              <div className="tw-rounded-lg tw-border tw-border-border tw-p-4">
+                <FormField
+                  label={
+                    <div className="tw-flex tw-items-center tw-gap-2">
+                      <span>File Context</span>
+                      <HelpTooltip
+                        buttonClassName="tw-size-4 tw-text-muted"
+                        content={
+                          <div className="tw-max-w-80">
+                            <strong>Supported File Types:</strong>
+                            <br />
+                            <strong>• Documents:</strong> pdf, doc, docx, ppt, pptx, epub, txt, rtf
+                            and many more
+                            <br />
+                            <strong>• Images:</strong> jpg, png, svg, gif, bmp, webp, tiff
+                            <br />
+                            <strong>• Spreadsheets:</strong> xlsx, xls, csv, numbers
+                            <br />
+                            <br />
+                            Non-markdown files are converted to markdown in the background.
+                            <br />
+                            <strong>Rate limit:</strong> 50 files or 100MB per 3 hours, whichever is
+                            reached first.
+                          </div>
+                        }
+                      />
                     </div>
                   }
-                />
-              </div>
-            }
-            description="Define patterns to include specific files, folders or tags (specified in the note property) in the project context."
-          >
-            <div className="tw-flex tw-items-center tw-gap-2">
-              <div className="tw-flex tw-flex-1 tw-flex-row">
-                <TruncatedText className="tw-max-w-[100px] tw-text-sm tw-text-accent">
-                  {showContext}
-                </TruncatedText>
-              </div>
-              <Button
-                variant="secondary"
-                onClick={() => {
-                  handleEditProjectContext(formData);
-                }}
-              >
-                Manage Context
-              </Button>
-            </div>
-          </FormField>
-
-          <FormField label="Web URLs">
-            <Textarea
-              value={formData.contextSource?.webUrls}
-              onChange={(e) => {
-                const urls = e.target.value.split("\n");
-
-                // Process each URL while preserving spaces and empty lines
-                const processedUrls = urls.map((url) => {
-                  if (!url.trim()) return url; // Preserve empty lines and whitespace-only lines
-                  try {
-                    new URL(url.trim());
-                    return url; // Keep original formatting including spaces
-                  } catch {
-                    return url; // Keep invalid URLs for user to fix
-                  }
-                });
-
-                handleInputChange("contextSource.webUrls", processedUrls.join("\n"));
-              }}
-              placeholder="Enter web URLs, one per line"
-              className="tw-min-h-20 tw-w-full"
-            />
-          </FormField>
-
-          <FormField label="YouTube URLs">
-            <Textarea
-              value={formData.contextSource?.youtubeUrls}
-              onChange={(e) => {
-                const urls = e.target.value.split("\n");
-
-                // Process each URL while preserving spaces and empty lines
-                const processedUrls = urls.map((url) => {
-                  if (!url.trim()) return url; // Preserve empty lines and whitespace-only lines
-                  try {
-                    const urlObj = new URL(url.trim());
-                    if (
-                      urlObj.hostname.includes("youtube.com") ||
-                      urlObj.hostname.includes("youtu.be")
-                    ) {
-                      return url; // Keep original formatting including spaces
+                  description="Define patterns to include specific files, folders or tags (specified in the note property) in the project context."
+                >
+                  <ProjectContextBadgeList
+                    inclusions={formData.contextSource?.inclusions}
+                    exclusions={formData.contextSource?.exclusions}
+                    onInclusionsChange={handleInclusionsChange}
+                    onExclusionsChange={handleExclusionsChange}
+                    actionSlot={
+                      <Button
+                        size="lg"
+                        className="tw-h-9 tw-gap-1 tw-px-3 sm:tw-h-auto sm:tw-px-2"
+                        onClick={() => handleEditProjectContext(formData)}
+                      >
+                        <Settings className="tw-size-4 sm:tw-size-3.5" />
+                        Manage Context
+                      </Button>
                     }
-                    return url; // Keep non-YouTube URLs for user to fix
-                  } catch {
-                    return url; // Keep invalid URLs for user to fix
-                  }
-                });
+                  />
+                </FormField>
+              </div>
 
-                handleInputChange("contextSource.youtubeUrls", processedUrls.join("\n"));
-              }}
-              placeholder="Enter YouTube URLs, one per line"
-              className="tw-min-h-20 tw-w-full"
+              {/* URLs Sub-card */}
+              <div className="tw-rounded-lg tw-border tw-border-border tw-p-4">
+                <div className="tw-mb-3">
+                  <span className="tw-text-sm tw-font-medium tw-text-normal">URLs</span>
+                  <p className="tw-mt-1 tw-text-ui-smaller tw-text-muted">
+                    Add web pages or YouTube videos as context sources
+                  </p>
+                </div>
+                <UrlTagInput urls={urlItems} onAdd={handleUrlAdd} onRemove={handleUrlRemove} />
+              </div>
+            </div>
+          </div>
+
+          {/* Processing Status - show for any project in edit mode (active: live state; others: cache state) */}
+          {initialProject && processingData && (
+            <ProcessingStatus
+              items={processingData.items}
+              onRetry={isCurrentProject ? handleRetry : undefined}
+              onOpenCachedItem={projectCache != null ? handleOpenCachedItem : undefined}
+              onRemoveUrl={handleRemoveUrl}
+              defaultExpanded={false}
+              maxHeight="200px"
             />
-          </FormField>
+          )}
         </div>
-      </div>
+      </ScrollArea>
 
-      <div className="tw-mt-4 tw-flex tw-items-center tw-justify-end tw-gap-2">
-        <Button variant="ghost" onClick={onCancel} disabled={isSubmitting}>
-          Cancel
-        </Button>
-        <Button onClick={handleSave} disabled={isSubmitting || !isFormValid()}>
-          {isSubmitting ? "Saving..." : "Save"}
-        </Button>
+      {/* Sticky Footer */}
+      <div className="tw-shrink-0 tw-border-t tw-border-border tw-px-4 tw-py-3">
+        <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
+          <Button variant="ghost" onClick={onCancel} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={isSubmitting || !isFormValid()}>
+            {isSubmitting ? "Saving..." : "Save"}
+          </Button>
+        </div>
       </div>
     </div>
   );
@@ -387,13 +464,19 @@ export class AddProjectModal extends Modal {
   constructor(
     app: App,
     private onSave: (project: ProjectConfig) => Promise<void>,
-    private initialProject?: ProjectConfig
+    private initialProject?: ProjectConfig,
+    private plugin?: CopilotPlugin
   ) {
     super(app);
   }
 
   onOpen() {
-    const { contentEl } = this;
+    const { contentEl, modalEl } = this;
+
+    // Reason: Ensure the modal is wide enough for card layout and tall enough for ScrollArea
+    // modalEl.style.minWidth = "min(640px, 90vw)";
+    modalEl.style.maxHeight = "85vh";
+
     this.root = createRoot(contentEl);
 
     const handleSave = async (project: ProjectConfig) => {
@@ -410,6 +493,7 @@ export class AddProjectModal extends Modal {
         initialProject={this.initialProject}
         onSave={handleSave}
         onCancel={handleCancel}
+        plugin={this.plugin}
       />
     );
   }

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -1,6 +1,7 @@
 import { FailedItem, ProjectConfig, useProjectContextLoad, getCurrentProject } from "@/aiParams";
 import { ContextCache, ProjectContextCache } from "@/cache/projectContextCache";
 import { FolderSearchModal } from "@/components/modals/FolderSearchModal";
+import { openCachedProjectFile } from "@/utils/cacheFileOpener";
 import { ProjectFileSelectModal } from "@/components/modals/ProjectFileSelectModal";
 import { TagSearchModal } from "@/components/modals/TagSearchModal";
 import { TruncatedText } from "@/components/TruncatedText";
@@ -22,6 +23,7 @@ import {
 import { getTagsFromNote } from "@/utils";
 import {
   AlertCircle,
+  ArrowUpRight,
   CheckCircle,
   FileAudio,
   FileImage,
@@ -255,9 +257,11 @@ interface ItemCardProps {
   viewMode: "list";
   loadStatus?: ProjectContextItemStatusInfo;
   onDelete: (e: React.MouseEvent, item: GroupItem) => void;
+  /** Optional: callback to open the cached parsed content for this file. */
+  onOpenCached?: () => void;
 }
 
-function ItemCard({ item, viewMode, loadStatus, onDelete }: ItemCardProps) {
+function ItemCard({ item, viewMode, loadStatus, onDelete, onOpenCached }: ItemCardProps) {
   const extension = item.id.split(".").pop() || "";
 
   // add or remove
@@ -306,6 +310,20 @@ function ItemCard({ item, viewMode, loadStatus, onDelete }: ItemCardProps) {
             )}
             <span className="tw-hidden md:tw-inline">{STATUS_LABELS[loadStatus.status]}</span>
           </Badge>
+        )}
+        {onOpenCached && loadStatus?.status === "success" && (
+          <Button
+            variant="ghost2"
+            size="icon"
+            className="tw-hidden tw-size-5 group-hover:tw-block"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpenCached();
+            }}
+            title="View Parsed Content"
+          >
+            <ArrowUpRight className="tw-size-4" />
+          </Button>
         )}
         <IconComponent
           className="tw-hidden tw-size-4 tw-shrink-0 tw-text-muted hover:tw-text-warning group-hover:tw-block group-hover:tw-flex-none"
@@ -1307,6 +1325,16 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
                                 activeSection === "ignoreFiles" || item.isIgnored
                                   ? handleDeleteIgnoreItem
                                   : handleDeleteItem
+                              }
+                              onOpenCached={
+                                // Reason: only offer open for non-markdown files that have been processed
+                                !item.isIgnored &&
+                                item.id.split(".").pop()?.toLowerCase() !== "md"
+                                  ? () => {
+                                      const name = item.name || item.id.split("/").pop() || item.id;
+                                      openCachedProjectFile(app, projectCache, item.id, name);
+                                    }
+                                  : undefined
                               }
                             />
                           ) : null

--- a/src/components/project/ProjectContextBadgeList.test.ts
+++ b/src/components/project/ProjectContextBadgeList.test.ts
@@ -1,0 +1,91 @@
+import { buildBadgeItems, removePattern } from "./ProjectContextBadgeList";
+
+describe("buildBadgeItems", () => {
+  it("returns empty array for empty/undefined input", () => {
+    expect(buildBadgeItems("")).toEqual([]);
+    expect(buildBadgeItems(undefined)).toEqual([]);
+  });
+
+  it("categorizes patterns by type", () => {
+    // Encoded: folder, #tag, [[note]], *.pdf
+    const value = "my-folder,%23tag,%5B%5Bnote%5D%5D,*.pdf";
+    const items = buildBadgeItems(value);
+
+    expect(items).toEqual([
+      { pattern: "my-folder", type: "folder" },
+      { pattern: "#tag", type: "tag" },
+      { pattern: "[[note]]", type: "note" },
+      { pattern: "*.pdf", type: "extension" },
+    ]);
+  });
+
+  it("deduplicates patterns", () => {
+    const value = "my-folder,my-folder";
+    const items = buildBadgeItems(value);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({ pattern: "my-folder", type: "folder" });
+  });
+
+  it("handles multiple patterns of the same type", () => {
+    const value = "folder-a,folder-b,%23tag1,%23tag2";
+    const items = buildBadgeItems(value);
+
+    expect(items).toEqual([
+      { pattern: "folder-a", type: "folder" },
+      { pattern: "folder-b", type: "folder" },
+      { pattern: "#tag1", type: "tag" },
+      { pattern: "#tag2", type: "tag" },
+    ]);
+  });
+});
+
+describe("removePattern", () => {
+  it("removes a folder pattern", () => {
+    const value = "folder-a,folder-b,%23tag1";
+    const result = removePattern(value, "folder-a", "folder");
+
+    expect(result).toContain("folder-b");
+    expect(result).toContain("%23tag1");
+    expect(result).not.toContain(encodeURIComponent("folder-a"));
+  });
+
+  it("removes a tag pattern", () => {
+    const value = "%23tag1,%23tag2,my-folder";
+    const result = removePattern(value, "#tag1", "tag");
+
+    expect(result).toContain("%23tag2");
+    expect(result).toContain("my-folder");
+    // Verify #tag1 is gone — check decoded result doesn't include it
+    const remaining = decodeURIComponent(result);
+    expect(remaining).not.toContain("#tag1");
+  });
+
+  it("removes a note pattern", () => {
+    const value = "%5B%5Bnote%5D%5D,my-folder";
+    const result = removePattern(value, "[[note]]", "note");
+
+    expect(result).toContain("my-folder");
+    expect(result).not.toContain("%5B%5Bnote%5D%5D");
+  });
+
+  it("removes an extension pattern", () => {
+    const value = "*.pdf,my-folder";
+    const result = removePattern(value, "*.pdf", "extension");
+
+    expect(result).toContain("my-folder");
+    expect(result).not.toContain("*.pdf");
+  });
+
+  it("returns empty string when removing the last pattern", () => {
+    const value = "my-folder";
+    const result = removePattern(value, "my-folder", "folder");
+
+    expect(result).toBe("");
+  });
+
+  it("handles undefined input", () => {
+    const result = removePattern(undefined, "my-folder", "folder");
+    expect(result).toBe("");
+  });
+});

--- a/src/components/project/ProjectContextBadgeList.tsx
+++ b/src/components/project/ProjectContextBadgeList.tsx
@@ -1,0 +1,255 @@
+import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
+
+import { ChevronDown, ChevronUp, FileText, Folder, Hash, Tag, X } from "lucide-react";
+
+import { TruncatedText } from "@/components/TruncatedText";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import {
+  categorizePatterns,
+  createPatternSettingsValue,
+  getDecodedPatterns,
+} from "@/search/searchUtils";
+
+const PATTERN_TYPE_CONFIG = {
+  folder: { icon: Folder, colorClass: "tw-text-context-manager-yellow" },
+  tag: { icon: Tag, colorClass: "tw-text-context-manager-orange" },
+  note: { icon: FileText, colorClass: "tw-text-context-manager-blue" },
+  extension: { icon: Hash, colorClass: "tw-text-context-manager-green" },
+} as const;
+
+type PatternType = keyof typeof PATTERN_TYPE_CONFIG;
+
+/** Ordered list of pattern types for consistent badge rendering */
+const PATTERN_TYPES: PatternType[] = ["folder", "tag", "note", "extension"];
+
+const CATEGORY_MAP = {
+  folder: "folderPatterns",
+  tag: "tagPatterns",
+  note: "notePatterns",
+  extension: "extensionPatterns",
+} as const;
+
+interface BadgeItem {
+  pattern: string;
+  type: PatternType;
+}
+
+interface ProjectContextBadgeListProps {
+  inclusions?: string;
+  exclusions?: string;
+  /** When provided, badges show X button for deletion. When absent, badges are read-only. */
+  onInclusionsChange?: (value: string) => void;
+  /** When provided, exclusion badges show X button. When absent, exclusion badges are read-only. */
+  onExclusionsChange?: (value: string) => void;
+  maxCollapsedHeight?: number;
+  /** Max height when expanded — content scrolls beyond this. */
+  maxExpandedHeight?: number;
+  /** Optional action element rendered on the right of the control bar (e.g. "Manage Context" button). */
+  actionSlot?: React.ReactNode;
+}
+
+/** Decode, deduplicate, and categorize a pattern string into badge items */
+export function buildBadgeItems(value: string | undefined): BadgeItem[] {
+  const patterns = [...new Set(getDecodedPatterns(value || ""))];
+  const categorized = categorizePatterns(patterns);
+  const items: BadgeItem[] = [];
+  PATTERN_TYPES.forEach((type) => {
+    categorized[CATEGORY_MAP[type]].forEach((p) => items.push({ pattern: p, type }));
+  });
+  return items;
+}
+
+/**
+ * Remove a pattern from a serialized pattern string.
+ * Returns the new serialized string with the pattern removed.
+ */
+export function removePattern(value: string | undefined, pattern: string, type: PatternType): string {
+  const patterns = [...new Set(getDecodedPatterns(value || ""))];
+  const categorized = categorizePatterns(patterns);
+  const categoryKey = CATEGORY_MAP[type];
+  return createPatternSettingsValue({
+    ...categorized,
+    [categoryKey]: categorized[categoryKey].filter((p) => p !== pattern),
+  });
+}
+
+export const ProjectContextBadgeList: React.FC<ProjectContextBadgeListProps> = ({
+  inclusions,
+  exclusions,
+  onInclusionsChange,
+  onExclusionsChange,
+  maxCollapsedHeight = 84,
+  maxExpandedHeight = 200,
+  actionSlot,
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const [contentHeight, setContentHeight] = useState<number>(0);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const inclusionBadges = useMemo(() => buildBadgeItems(inclusions), [inclusions]);
+  const exclusionBadges = useMemo(() => buildBadgeItems(exclusions), [exclusions]);
+  const hasPatterns = inclusionBadges.length > 0 || exclusionBadges.length > 0;
+
+  // Detect overflow with ResizeObserver (same pattern as PatternListEditor)
+  useLayoutEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+
+    const checkOverflow = () => {
+      const scrollH = el.scrollHeight;
+      setContentHeight(scrollH);
+      const overflows = scrollH > maxCollapsedHeight;
+      setIsOverflowing(overflows);
+      // Reason: Reset expanded state when content shrinks below threshold after deletion
+      if (!overflows) setIsExpanded(false);
+    };
+
+    checkOverflow();
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(checkOverflow);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [maxCollapsedHeight, inclusionBadges, exclusionBadges]);
+
+  const isTruncated = isOverflowing && !isExpanded;
+  // Reason: Cap expanded height so the badge list scrolls instead of pushing the modal off-screen.
+  const animatedMaxHeight = isExpanded
+    ? Math.min(contentHeight, maxExpandedHeight)
+    : maxCollapsedHeight;
+
+  const handleRemoveInclusion = (pattern: string, type: PatternType) => {
+    onInclusionsChange?.(removePattern(inclusions, pattern, type));
+  };
+
+  const handleRemoveExclusion = (pattern: string, type: PatternType) => {
+    onExclusionsChange?.(removePattern(exclusions, pattern, type));
+  };
+
+  const renderBadge = (
+    item: BadgeItem,
+    isExclusion: boolean,
+    onRemove?: (pattern: string, type: PatternType) => void
+  ) => {
+    const config = PATTERN_TYPE_CONFIG[item.type];
+    const Icon = config.icon;
+    return (
+      <Badge
+        key={`${isExclusion ? "ex" : "in"}:${item.type}:${item.pattern}`}
+        variant="secondary"
+        className={cn(
+          "tw-group tw-flex tw-h-7 tw-items-center tw-gap-1.5 tw-py-1 tw-pl-2 tw-pr-1.5 sm:tw-h-6 sm:tw-py-0.5 sm:tw-pl-1.5",
+          isExclusion && "tw-opacity-60"
+        )}
+      >
+        <Icon className={cn("tw-size-4 tw-shrink-0 sm:tw-size-3", config.colorClass)} />
+        <TruncatedText className="tw-max-w-[100px] sm:tw-max-w-[120px]">
+          {item.pattern}
+        </TruncatedText>
+        {onRemove && (
+          <Button
+            variant="ghost2"
+            size="fit"
+            aria-label={`Remove ${item.pattern}`}
+            className="tw-h-auto tw-p-0"
+            onClick={() => onRemove(item.pattern, item.type)}
+          >
+            <X className="tw-size-4 tw-shrink-0 tw-text-muted hover:tw-text-warning sm:tw-size-3" />
+          </Button>
+        )}
+      </Badge>
+    );
+  };
+
+  // Empty state
+  if (!hasPatterns) {
+    return (
+      <div className="tw-flex tw-flex-col tw-gap-2">
+        <div className="tw-rounded-md tw-border tw-border-dashed tw-border-border tw-py-4 tw-text-center">
+          <span className="tw-text-sm tw-italic tw-text-muted">No file patterns configured</span>
+        </div>
+        {actionSlot && (
+          <div className="tw-flex tw-justify-end">{actionSlot}</div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-2">
+      {/* Content container */}
+      <div className="tw-relative tw-rounded-md tw-border tw-border-solid tw-border-border tw-p-2">
+        <div
+          ref={contentRef}
+          className={cn(
+            "tw-transition-[max-height] tw-duration-300 tw-ease-in-out",
+            isExpanded && contentHeight > maxExpandedHeight
+              ? "tw-overflow-y-auto"
+              : "tw-overflow-hidden"
+          )}
+          style={{ maxHeight: isOverflowing ? animatedMaxHeight : undefined }}
+        >
+          {/* Inclusion badges */}
+          {inclusionBadges.length > 0 && (
+            <div className="tw-flex tw-flex-wrap tw-gap-1.5">
+              {inclusionBadges.map((b) =>
+                renderBadge(b, false, onInclusionsChange ? handleRemoveInclusion : undefined)
+              )}
+            </div>
+          )}
+
+          {/* Exclusion area: dashed separator + "Excluded:" label + badges */}
+          {exclusionBadges.length > 0 && (
+            <>
+              {inclusionBadges.length > 0 && (
+                <div className="tw-my-2 tw-border-t tw-border-dashed tw-border-border" />
+              )}
+              <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-1.5">
+                <span className="tw-mr-1 tw-text-xs tw-font-medium tw-text-muted">Excluded:</span>
+                {exclusionBadges.map((b) =>
+                  renderBadge(b, true, onExclusionsChange ? handleRemoveExclusion : undefined)
+                )}
+              </div>
+            </>
+          )}
+        </div>
+
+        {/* Gradient fade mask when truncated */}
+        {isTruncated && (
+          <div className="copilot-fade-mask-bottom tw-pointer-events-none tw-absolute tw-inset-x-0 tw-bottom-0 tw-h-10 tw-rounded-b-md" />
+        )}
+      </div>
+
+      {/* Control bar: Show on left, action slot on right */}
+      {(isOverflowing || actionSlot) && (
+        <div className="tw-flex tw-flex-row tw-items-center tw-justify-between">
+          {isOverflowing ? (
+            <Button
+              variant="ghost2"
+              size="sm"
+              onClick={() => setIsExpanded((prev) => !prev)}
+              className="tw-h-9 tw-gap-1 tw-px-3 tw-text-accent sm:tw-h-auto sm:tw-px-2"
+            >
+              {isExpanded ? (
+                <>
+                  Show less <ChevronUp className="tw-size-4 sm:tw-size-3" />
+                </>
+              ) : (
+                <>
+                  Show all ({inclusionBadges.length + exclusionBadges.length}){" "}
+                  <ChevronDown className="tw-size-4 sm:tw-size-3" />
+                </>
+              )}
+            </Button>
+          ) : (
+            <div />
+          )}
+          {actionSlot}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/project/processing-status.tsx
+++ b/src/components/project/processing-status.tsx
@@ -1,0 +1,476 @@
+/**
+ * Content conversion status panel for project context.
+ *
+ * Shows non-markdown files and URLs that need conversion,
+ * grouped by source (Files vs URLs). Supports retry for failed items.
+ * Adapted from the prototype's ProcessingStatus component.
+ */
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { Progress } from "@/components/ui/progress";
+import { TruncatedText } from "@/components/TruncatedText";
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import {
+  AlertCircle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  ArrowUpRight,
+  FileImage,
+  FileText,
+  FileVideo,
+  FolderOpen,
+  Globe,
+  HelpCircle,
+  Loader2,
+  RefreshCw,
+  X,
+  Youtube,
+} from "lucide-react";
+import React, { useCallback, useRef, useState } from "react";
+
+interface ProcessingStatusProps {
+  items: ProcessingItem[];
+  /** Optional: only provided for the currently active project. */
+  onRetry?: (id: string) => void;
+  /** Optional: callback to open a cached item's parsed content (file or URL). */
+  onOpenCachedItem?: (item: ProcessingItem) => void;
+  /** Optional: callback to remove a failed URL from the project config. */
+  onRemoveUrl?: (item: ProcessingItem) => void;
+  defaultExpanded?: boolean;
+  maxHeight?: string;
+  /** When false, hides the title and description. Use for embedding inside another panel. */
+  showHeader?: boolean;
+}
+
+/**
+ * Renders the status icon for a ProcessingItem.
+ * For ready+contentEmpty items, shows a warning HelpCircle instead of a green checkmark.
+ */
+function StatusIcon({
+  status,
+  contentEmpty,
+}: {
+  status: ProcessingItem["status"];
+  contentEmpty?: boolean;
+}) {
+  // Reason: contentEmpty is a sub-state of "ready" — item was fetched but had no extractable content.
+  if (status === "ready" && contentEmpty) {
+    return <HelpCircle className="tw-size-3.5 tw-text-warning" />;
+  }
+
+  switch (status) {
+    case "ready":
+      return <CheckCircle2 className="tw-size-3.5 tw-text-success" />;
+    case "processing":
+      return <Loader2 className="tw-size-3.5 tw-animate-spin tw-text-loading" />;
+    case "failed":
+      return <AlertCircle className="tw-size-3.5 tw-text-error" />;
+    case "pending":
+      return <Clock className="tw-size-3.5 tw-text-muted" />;
+    case "unsupported":
+      return <HelpCircle className="tw-size-3.5 tw-text-muted" />;
+  }
+}
+
+function FileTypeIcon({ fileType }: { fileType: ProcessingItem["fileType"] }) {
+  switch (fileType) {
+    case "pdf":
+      return <FileText className="tw-size-3.5 tw-text-error" />;
+    case "image":
+      return <FileImage className="tw-size-3.5 tw-text-accent" />;
+    case "web":
+      return <Globe className="tw-size-3.5 tw-text-accent" />;
+    case "youtube":
+      return <Youtube className="tw-size-3.5 tw-text-error" />;
+    case "audio":
+      return <FileVideo className="tw-size-3.5 tw-text-warning" />;
+    default:
+      return <FileText className="tw-size-3.5 tw-text-muted" />;
+  }
+}
+
+/** Returns counts for each status category, including unsupported. */
+function getStatusCounts(items: ProcessingItem[]) {
+  return {
+    ready: items.filter((i) => i.status === "ready").length,
+    processing: items.filter((i) => i.status === "processing").length,
+    failed: items.filter((i) => i.status === "failed").length,
+    pending: items.filter((i) => i.status === "pending").length,
+    unsupported: items.filter((i) => i.status === "unsupported").length,
+    total: items.length,
+  };
+}
+
+/**
+ * Returns the human-readable label for a given status.
+ * For ready+contentEmpty items the caller should override to "No content".
+ */
+function getStatusLabel(status: ProcessingItem["status"], contentEmpty?: boolean): string {
+  // Reason: "No content" is a UI-only distinction within the "ready" status.
+  if (status === "ready" && contentEmpty) return "No content";
+
+  switch (status) {
+    case "ready":
+      return "Converted";
+    case "processing":
+      return "Converting...";
+    case "failed":
+      return "Failed";
+    case "pending":
+      return "Queued";
+    case "unsupported":
+      return "Unsupported";
+  }
+}
+
+/** Status priority for sorting: active/problematic items first, completed last. */
+const STATUS_SORT_PRIORITY: Record<ProcessingItem["status"], number> = {
+  processing: 0,
+  failed: 1,
+  pending: 2,
+  unsupported: 3,
+  ready: 4,
+};
+
+/** Sort items by status priority. Same-status items retain their original relative order. */
+function sortByStatusPriority(items: ProcessingItem[]): ProcessingItem[] {
+  return [...items].sort(
+    (a, b) => (STATUS_SORT_PRIORITY[a.status] ?? 99) - (STATUS_SORT_PRIORITY[b.status] ?? 99)
+  );
+}
+
+export function ProcessingStatus({
+  items,
+  onRetry,
+  onOpenCachedItem,
+  onRemoveUrl,
+  defaultExpanded = false,
+  maxHeight,
+  showHeader = true,
+}: ProcessingStatusProps) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const counts = getStatusCounts(items);
+
+  const sortedFileItems = sortByStatusPriority(items.filter((i) => i.source === "file"));
+  const sortedUrlItems = sortByStatusPriority(items.filter((i) => i.source === "url"));
+
+  return (
+    <div className="tw-space-y-2">
+      {/* Title Row — hidden when embedded inside another panel */}
+      {showHeader && (
+        <div className="tw-space-y-1">
+          <div className="tw-flex tw-items-center tw-gap-2">
+            <h4 className="tw-text-sm tw-font-medium tw-text-normal">Content Conversion</h4>
+          </div>
+          <p className="tw-text-ui-smaller tw-text-muted">
+            Non-markdown files (PDF, images, web pages, ...) are converted to text for AI.
+          </p>
+        </div>
+      )}
+
+      {/* Empty state when no non-markdown files or URLs exist */}
+      {items.length === 0 && (
+        <div className="tw-rounded-lg tw-border tw-border-border tw-p-3 tw-bg-muted/10">
+          <div className="tw-text-ui-smaller tw-text-muted">
+            No non-markdown files or URLs need conversion for this project.
+          </div>
+        </div>
+      )}
+
+      {/* Status Panel — only when there are items to show */}
+      {items.length > 0 && (
+        <div className="tw-rounded-lg tw-border tw-border-border">
+          <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+            {/* Summary Bar */}
+            <CollapsibleTrigger asChild>
+              <Button
+                variant="secondary"
+                className=" tw-flex tw-h-auto tw-w-full tw-items-center tw-justify-between tw-rounded-lg tw-p-3 tw-text-left tw-transition-colors hover:tw-bg-modifier-hover"
+              >
+                <div className="tw-flex tw-items-center tw-gap-2">
+                  <div className="tw-flex tw-items-center tw-gap-1.5">
+                    {counts.ready > 0 && (
+                      <Badge
+                        variant="secondary"
+                        className="tw-h-5 tw-gap-1 tw-bg-success tw-px-1.5 tw-text-ui-smaller tw-text-success"
+                      >
+                        <CheckCircle2 className="tw-size-3" />
+                        {counts.ready}
+                      </Badge>
+                    )}
+                    {counts.processing > 0 && (
+                      <Badge
+                        variant="secondary"
+                        className="tw-h-5 tw-gap-1 tw-px-1.5 tw-text-ui-smaller"
+                      >
+                        <Loader2 className="tw-size-3 tw-animate-spin" />
+                        {counts.processing}
+                      </Badge>
+                    )}
+                    {counts.pending > 0 && (
+                      <Badge
+                        variant="secondary"
+                        className="tw-h-5 tw-gap-1 tw-px-1.5 tw-text-ui-smaller"
+                      >
+                        <Clock className="tw-size-3" />
+                        {counts.pending}
+                      </Badge>
+                    )}
+                    {counts.failed > 0 && (
+                      <Badge
+                        variant="secondary"
+                        className="tw-h-5 tw-gap-1 tw-bg-error tw-px-1.5 tw-text-ui-smaller tw-text-error"
+                      >
+                        <AlertCircle className="tw-size-3" />
+                        {counts.failed}
+                      </Badge>
+                    )}
+                    {/* Reason: unsupported items get a neutral gray badge to distinguish
+                        them from errors — they're not failures, just unprocessable file types. */}
+                    {counts.unsupported > 0 && (
+                      <Badge
+                        variant="secondary"
+                        className="tw-h-5 tw-gap-1 tw-px-1.5 tw-text-ui-smaller tw-text-muted"
+                      >
+                        <HelpCircle className="tw-size-3" />
+                        {counts.unsupported}
+                      </Badge>
+                    )}
+                  </div>
+                  <span className="tw-text-ui-smaller tw-text-muted">{counts.total} items</span>
+                </div>
+                {isExpanded ? (
+                  <ChevronDown className="tw-size-4 tw-text-muted" />
+                ) : (
+                  <ChevronRight className="tw-size-4 tw-text-muted" />
+                )}
+              </Button>
+            </CollapsibleTrigger>
+
+            <CollapsibleContent>
+              {/* Reason: each section scrolls independently so files don't push URLs out of view */}
+              <div className="tw-space-y-3 tw-border-t tw-border-border tw-p-3">
+                {/* From Files Section */}
+                {sortedFileItems.length > 0 && (
+                  <div className="tw-space-y-2">
+                    <div className="tw-flex tw-items-center tw-gap-1.5 tw-px-1">
+                      <FolderOpen className="tw-size-3.5 tw-text-accent" />
+                      <span className="tw-text-ui-smaller tw-font-medium tw-text-muted">
+                        From Files ({sortedFileItems.length})
+                      </span>
+                    </div>
+                    <ScrollableList maxHeight={maxHeight || "200px"}>
+                      {sortedFileItems.map((item) => (
+                        <ProcessingItemRow
+                          key={item.id}
+                          item={item}
+                          onRetry={onRetry}
+                          onOpenCached={
+                            onOpenCachedItem ? () => onOpenCachedItem(item) : undefined
+                          }
+                        />
+                      ))}
+                    </ScrollableList>
+                  </div>
+                )}
+
+                {/* From URLs Section */}
+                {sortedUrlItems.length > 0 && (
+                  <div className="tw-space-y-2">
+                    <div className="tw-flex tw-items-center tw-gap-1.5 tw-px-1">
+                      <Globe className="tw-size-3.5 tw-text-accent" />
+                      <span className="tw-text-ui-smaller tw-font-medium tw-text-muted">
+                        From URLs ({sortedUrlItems.length})
+                      </span>
+                    </div>
+                    <ScrollableList maxHeight={maxHeight || "200px"}>
+                      {sortedUrlItems.map((item) => (
+                        <ProcessingItemRow
+                          key={item.id}
+                          item={item}
+                          onRetry={onRetry}
+                          onOpenCached={
+                            onOpenCachedItem ? () => onOpenCachedItem(item) : undefined
+                          }
+                          onRemove={
+                            onRemoveUrl ? () => onRemoveUrl(item) : undefined
+                          }
+                        />
+                      ))}
+                    </ScrollableList>
+                  </div>
+                )}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Scroll container with a bottom fade mask when content overflows.
+ * Reuses the existing `.copilot-fade-mask-bottom` CSS class from PatternListEditor.
+ */
+function ScrollableList({
+  maxHeight,
+  children,
+}: {
+  maxHeight: string;
+  children: React.ReactNode;
+}) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  const checkOverflow = useCallback((el: HTMLDivElement | null) => {
+    scrollRef.current = el;
+    if (el) {
+      setIsOverflowing(el.scrollHeight > el.clientHeight);
+    }
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // Reason: hide fade mask when scrolled to bottom
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 4;
+    setIsOverflowing(!atBottom);
+  }, []);
+
+  return (
+    <div className="tw-relative">
+      <div
+        ref={checkOverflow}
+        className="tw-space-y-1 tw-overflow-y-auto"
+        style={{ maxHeight }}
+        onScroll={handleScroll}
+      >
+        {children}
+      </div>
+      {isOverflowing && (
+        <div className="copilot-fade-mask-bottom tw-pointer-events-none tw-absolute tw-inset-x-0 tw-bottom-0 tw-h-8 tw-rounded-b-md" />
+      )}
+    </div>
+  );
+}
+
+function ProcessingItemRow({
+  item,
+  onRetry,
+  onOpenCached,
+  onRemove,
+}: {
+  item: ProcessingItem;
+  onRetry?: (id: string) => void;
+  /** Callback to open the cached parsed content for this file item. */
+  onOpenCached?: () => void;
+  /** Callback to remove this URL from the project config. Only for URL items. */
+  onRemove?: () => void;
+}) {
+  const isProcessing = item.status === "processing";
+  const isFailed = item.status === "failed";
+  // Reason: show open button for any item that is ready with actual content (file or URL)
+  const canOpenCached =
+    onOpenCached &&
+    item.status === "ready" &&
+    !item.contentEmpty;
+
+  return (
+    <div className="tw-group tw-rounded-md tw-border tw-border-border tw-bg-primary tw-p-2.5">
+      <div className="tw-flex tw-items-center tw-gap-2">
+        <FileTypeIcon fileType={item.fileType} />
+        <div className="tw-min-w-0 tw-flex-1">
+          <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
+            <TruncatedText className="tw-text-sm tw-text-normal">
+              {item.source === "url" ? item.id : item.name}
+            </TruncatedText>
+            <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-1.5">
+              {canOpenCached && (
+                <Button
+                  variant="ghost2"
+                  size="icon"
+                  aria-label="View Parsed Content"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onOpenCached();
+                  }}
+                  title="View Parsed Content"
+                  className="tw-size-5"
+                >
+                  <ArrowUpRight className="tw-size-4" />
+                </Button>
+              )}
+              {/* Reason: ready items only show the checkmark icon, no text label —
+                  the icon is sufficient and saves horizontal space for the name.
+                  Exception: contentEmpty items need a visible "No content" label. */}
+              {(item.status !== "ready" || item.contentEmpty) && (
+                <span className="tw-text-ui-smaller tw-text-muted">
+                  {getStatusLabel(item.status, item.contentEmpty)}
+                </span>
+              )}
+              <StatusIcon status={item.status} contentEmpty={item.contentEmpty} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Progress bar for processing items */}
+      {isProcessing && item.progress !== undefined && (
+        <div className="tw-mt-2 tw-flex tw-items-center tw-gap-2">
+          <Progress value={item.progress} className="tw-h-1.5 tw-flex-1" />
+          <span className="tw-w-8 tw-text-ui-smaller tw-text-muted">{item.progress}%</span>
+        </div>
+      )}
+
+      {/* Error row for failed items:
+          - Retry icon only when onRetry is provided (i.e. active project).
+          - Remove icon only when onRemove is provided (URL items only).
+          - Non-active projects display the error text without actions. */}
+      {isFailed && (
+        <div className="tw-mt-2 tw-flex tw-items-center tw-justify-between">
+          <TruncatedText className="tw-flex-1 tw-text-ui-smaller tw-text-error">
+            {item.error || "Conversion failed"}
+          </TruncatedText>
+          <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-1">
+            {onRetry && (
+              <Button
+                variant="ghost2"
+                size="icon"
+                aria-label="Retry"
+                onClick={() => onRetry(item.id)}
+                title="Retry"
+                className="tw-size-5 tw-text-muted hover:tw-text-accent"
+              >
+                <RefreshCw className="tw-size-3.5" />
+              </Button>
+            )}
+            {onRemove && (
+              <Button
+                variant="ghost2"
+                size="icon"
+                aria-label="Remove URL from project"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRemove();
+                }}
+                title="Remove URL from project"
+                className="tw-size-5 tw-text-muted hover:tw-text-error"
+              >
+                <X className="tw-size-3.5" />
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/project/processingAdapter.ts
+++ b/src/components/project/processingAdapter.ts
@@ -1,0 +1,395 @@
+/**
+ * Adapter that bridges project context load state and project cache into the
+ * ProcessingItem[] model used by the ProcessingStatus component.
+ *
+ * Reason: The ProcessingStatus UI expects a flat array of ProcessingItem objects.
+ * Our system stores context load state as four separate arrays (total, success,
+ * failed, processingFiles) and a persistent ContextCache for non-active projects.
+ * This adapter translates both into a unified view while:
+ *  - Filtering markdown files (they don't need conversion)
+ *  - Supporting cache-fallback status for non-current projects
+ *  - Detecting empty URL/YouTube content (contentEmpty flag)
+ *  - Marking unsupported file extensions explicitly
+ */
+
+import type { FailedItem, ProjectConfig } from "@/aiParams";
+import type { ContextCache } from "@/cache/projectContextCache";
+import { detectUrlType } from "@/utils/urlTagUtils";
+import type { TFile } from "obsidian";
+
+export interface ProcessingItem {
+  id: string;
+  name: string;
+  source: "file" | "url";
+  fileType: "pdf" | "image" | "web" | "youtube" | "audio" | "other";
+  /**
+   * "unsupported" means the file extension is not handled by the project-mode parser
+   * and will never be processed. "pending" means it will be processed eventually.
+   */
+  status: "pending" | "processing" | "ready" | "failed" | "unsupported";
+  progress?: number;
+  error?: string;
+  /**
+   * True when a URL was successfully fetched but returned no extractable content.
+   * Only set for the current active project (non-current projects cannot distinguish
+   * "never fetched" from "fetched but empty" since empty results aren't cached).
+   */
+  contentEmpty?: boolean;
+  /**
+   * Which cache bucket holds this item's parsed content.
+   * Determined by config source field, not by inferred fileType.
+   * - "file" → fileContexts (content on disk via cacheKey)
+   * - "web" → webContexts (string in memory)
+   * - "youtube" → youtubeContexts (string in memory)
+   */
+  cacheKind: "file" | "web" | "youtube";
+}
+
+export interface ProcessingAdapterResult {
+  items: ProcessingItem[];
+  /** Maps ProcessingItem.id → original FailedItem for retry calls */
+  failedItemMap: Map<string, FailedItem>;
+}
+
+/**
+ * Live state snapshot from useProjectContextLoad().
+ * Represents the current processing session for the active project.
+ */
+interface ContextLoadState {
+  total: string[];
+  success: string[];
+  failed: FailedItem[];
+  processingFiles: string[];
+}
+
+/**
+ * Options for building the processing items list.
+ * Callers supply all needed context so this function remains pure and testable.
+ */
+export interface BuildProcessingItemsOptions {
+  /** The project whose items are being displayed. */
+  project: ProjectConfig;
+  /** True if this project is the currently active/loaded project. */
+  isCurrentProject: boolean;
+  /** Live processing state (from useProjectContextLoad). */
+  liveState: ContextLoadState;
+  /** Persistent context cache for this project (null = no cache, undefined = still loading). */
+  projectCache: ContextCache | null | undefined;
+  /** All vault files that match this project's inclusion patterns. */
+  projectFiles: TFile[];
+  /** Extensions supported in project mode (from FileParserManager.getProjectSupportedExtensions). */
+  supportedExtensions: Set<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const IMAGE_EXTENSIONS = new Set(["jpg", "jpeg", "png", "gif", "bmp", "webp", "svg", "tiff"]);
+const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "m4a", "ogg", "flac", "aac", "mp4", "mpeg", "mpga", "webm"]);
+
+/** Infer file type from a file path's extension. */
+function inferFileType(path: string): ProcessingItem["fileType"] {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  if (ext === "pdf") return "pdf";
+  if (IMAGE_EXTENSIONS.has(ext)) return "image";
+  if (AUDIO_EXTENSIONS.has(ext)) return "audio";
+  return "other";
+}
+
+/** Infer file type for a URL by reusing the shared YouTube detection in urlTagUtils. */
+function inferUrlFileType(url: string): ProcessingItem["fileType"] {
+  return detectUrlType(url);
+}
+
+/** Extract a human-readable name from a file path or URL. */
+function extractName(key: string): string {
+  // Reason: URLs should show domain + path + query; file paths should show just the filename.
+  if (key.startsWith("http://") || key.startsWith("https://")) {
+    try {
+      const urlObj = new URL(key);
+      const hostname = urlObj.hostname.replace("www.", "");
+      const pathAndQuery = urlObj.pathname + urlObj.search;
+      if (pathAndQuery && pathAndQuery !== "/") {
+        const maxLen = 30;
+        const shortPath = pathAndQuery.length > maxLen ? pathAndQuery.slice(0, maxLen) + "..." : pathAndQuery;
+        return hostname + shortPath;
+      }
+      return hostname;
+    } catch {
+      return key.slice(0, 50);
+    }
+  }
+  const parts = key.split("/");
+  return parts[parts.length - 1] || key;
+}
+
+/**
+ * Parse raw newline-separated URL config strings into a deduplicated array.
+ * Returns only non-empty trimmed lines.
+ */
+function parseUrlConfig(raw?: string): string[] {
+  if (!raw) return [];
+  // Reason: Deduplicate to prevent duplicate React keys and duplicate status rows
+  return [...new Set(
+    raw
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+  )];
+}
+
+/**
+ * Determine the status of a single key (file path or URL) for the CURRENT active project.
+ * Priority order: processing > failed > ready > pending.
+ */
+function resolveCurrentProjectStatus(
+  key: string,
+  processingSet: Set<string>,
+  failedByPath: Map<string, FailedItem>,
+  successSet: Set<string>
+): { status: ProcessingItem["status"]; error?: string; failedItem?: FailedItem } {
+  if (processingSet.has(key)) {
+    return { status: "processing" };
+  }
+  if (failedByPath.has(key)) {
+    const failedItem = failedByPath.get(key)!;
+    return { status: "failed", error: failedItem.error, failedItem };
+  }
+  if (successSet.has(key)) {
+    return { status: "ready" };
+  }
+  return { status: "pending" };
+}
+
+/**
+ * Determine if a "ready" URL item has no extractable content.
+ *
+ * Reason: Empty fetch results are NOT stored in the cache (projectManager.ts only
+ * writes to webContexts/youtubeContexts when content is truthy). So if a URL is
+ * in the success set but absent from the cache, it was fetched but yielded nothing.
+ * This check is only valid for the current active project where we have liveState.
+ *
+ * Reason: We use cacheField (which cache dict to check) instead of fileType, because
+ * a YouTube URL in webUrls is stored in webContexts by projectManager, not youtubeContexts.
+ */
+function detectContentEmpty(
+  url: string,
+  cacheField: "web" | "youtube",
+  projectCache: ContextCache | null | undefined
+): boolean {
+  if (!projectCache) return false;
+  if (cacheField === "youtube") {
+    const content = projectCache.youtubeContexts?.[url];
+    return !content || content.trim().length === 0;
+  }
+  // "web" type
+  const content = projectCache.webContexts?.[url];
+  return !content || content.trim().length === 0;
+}
+
+/**
+ * Determine the status of a single key for a NON-CURRENT project using cache data only.
+ *
+ * Logic (mirrors ContextManageModal.getProjectContextItemStatus):
+ *  - File path: present in fileContexts with a cacheKey → "ready", else "pending"
+ *  - Web URL: present in webContexts with non-empty content → "ready", else "pending"
+ *  - YouTube URL: present in youtubeContexts with non-empty content → "ready", else "pending"
+ *
+ * Reason: cacheField determines which cache dict to check. This is based on which
+ * config field the URL came from, NOT the inferred fileType, because projectManager
+ * stores results by config field (webUrls → webContexts, youtubeUrls → youtubeContexts).
+ */
+function resolveNonCurrentProjectStatus(
+  key: string,
+  isUrl: boolean,
+  cacheField: "web" | "youtube" | null,
+  cache: ContextCache | null | undefined
+): ProcessingItem["status"] {
+  if (!cache) return "pending";
+
+  if (isUrl && cacheField) {
+    if (cacheField === "youtube") {
+      const content = cache.youtubeContexts?.[key];
+      return content && content.trim().length > 0 ? "ready" : "pending";
+    }
+    // web URL
+    const content = cache.webContexts?.[key];
+    return content && content.trim().length > 0 ? "ready" : "pending";
+  }
+
+  // File path: check fileContexts for a valid cacheKey
+  const entry = cache.fileContexts?.[key];
+  return entry?.cacheKey ? "ready" : "pending";
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the flat ProcessingItem list for the ProcessingStatus component.
+ *
+ * Candidate enumeration:
+ *  - Non-markdown files from projectFiles (vault files matching project patterns)
+ *  - URLs from project.contextSource.webUrls and .youtubeUrls
+ *
+ * This avoids depending on liveState.total which may be stale or empty for
+ * non-current projects.
+ */
+export function buildProcessingItems(options: BuildProcessingItemsOptions): ProcessingAdapterResult {
+  const {
+    project,
+    isCurrentProject,
+    liveState,
+    projectCache,
+    projectFiles,
+    supportedExtensions,
+  } = options;
+
+  // Pre-process live state sets for O(1) lookups
+  const successSet = new Set(liveState.success);
+  const processingSet = new Set(liveState.processingFiles);
+  const failedByPath = new Map<string, FailedItem>();
+  for (const item of liveState.failed) {
+    failedByPath.set(item.path, item);
+  }
+
+  const items: ProcessingItem[] = [];
+  const failedItemMap = new Map<string, FailedItem>();
+  // Reason: Track seen IDs to prevent duplicate rows when the same URL appears
+  // in both webUrls and youtubeUrls config fields.
+  const seenIds = new Set<string>();
+
+  // -------------------------------------------------------------------------
+  // 1. Non-markdown vault files
+  // -------------------------------------------------------------------------
+  for (const file of projectFiles) {
+    // Reason: Only .md files are handled by the markdown context pipeline.
+    // .markdown files go through processNonMarkdownFiles and should appear in the panel.
+    if (file.extension === "md") continue;
+
+    const key = file.path;
+    if (seenIds.has(key)) continue;
+    seenIds.add(key);
+    const ext = file.extension.toLowerCase();
+
+    // Files with unsupported extensions will never be processed in project mode.
+    // Reason: Show "unsupported" rather than leaving them forever as "pending",
+    // which looks like a stalled queue to the user.
+    if (!supportedExtensions.has(ext)) {
+      items.push({
+        id: key,
+        name: extractName(key),
+        source: "file",
+        fileType: inferFileType(key),
+        status: "unsupported",
+        cacheKind: "file",
+      });
+      continue;
+    }
+
+    let status: ProcessingItem["status"];
+    let error: string | undefined;
+
+    if (isCurrentProject) {
+      const resolved = resolveCurrentProjectStatus(key, processingSet, failedByPath, successSet);
+      status = resolved.status;
+      error = resolved.error;
+      if (resolved.failedItem) {
+        failedItemMap.set(key, resolved.failedItem);
+      }
+    } else {
+      status = resolveNonCurrentProjectStatus(key, false, null, projectCache);
+    }
+
+    items.push({
+      id: key,
+      name: extractName(key),
+      source: "file",
+      fileType: inferFileType(key),
+      status,
+      error,
+      cacheKind: "file",
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // 2. Web URLs
+  // -------------------------------------------------------------------------
+  for (const url of parseUrlConfig(project.contextSource?.webUrls)) {
+    if (seenIds.has(url)) continue;
+    seenIds.add(url);
+    const fileType = inferUrlFileType(url);
+    let status: ProcessingItem["status"];
+    let error: string | undefined;
+    let contentEmpty: boolean | undefined;
+
+    if (isCurrentProject) {
+      const resolved = resolveCurrentProjectStatus(url, processingSet, failedByPath, successSet);
+      status = resolved.status;
+      error = resolved.error;
+      if (resolved.failedItem) {
+        failedItemMap.set(url, resolved.failedItem);
+      }
+      // Detect empty-content fetch only when status is ready (URL was processed)
+      if (status === "ready") {
+        contentEmpty = detectContentEmpty(url, "web", projectCache) || undefined;
+      }
+    } else {
+      status = resolveNonCurrentProjectStatus(url, true, "web", projectCache);
+    }
+
+    items.push({
+      id: url,
+      name: extractName(url),
+      source: "url",
+      fileType,
+      status,
+      error,
+      contentEmpty,
+      cacheKind: "web",
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // 3. YouTube URLs
+  // -------------------------------------------------------------------------
+  for (const url of parseUrlConfig(project.contextSource?.youtubeUrls)) {
+    if (seenIds.has(url)) continue;
+    seenIds.add(url);
+    const fileType: ProcessingItem["fileType"] = "youtube";
+    let status: ProcessingItem["status"];
+    let error: string | undefined;
+    let contentEmpty: boolean | undefined;
+
+    if (isCurrentProject) {
+      const resolved = resolveCurrentProjectStatus(url, processingSet, failedByPath, successSet);
+      status = resolved.status;
+      error = resolved.error;
+      if (resolved.failedItem) {
+        failedItemMap.set(url, resolved.failedItem);
+      }
+      if (status === "ready") {
+        contentEmpty = detectContentEmpty(url, "youtube", projectCache) || undefined;
+      }
+    } else {
+      status = resolveNonCurrentProjectStatus(url, true, "youtube", projectCache);
+    }
+
+    items.push({
+      id: url,
+      name: extractName(url),
+      source: "url",
+      fileType,
+      status,
+      error,
+      contentEmpty,
+      cacheKind: "youtube",
+    });
+  }
+
+  // Non-current projects have no live failed state to surface for retry.
+  // Reason: We only have cache data for non-current projects, not error details.
+  return { items, failedItemMap: isCurrentProject ? failedItemMap : new Map() };
+}

--- a/src/components/project/progress-card.tsx
+++ b/src/components/project/progress-card.tsx
@@ -1,20 +1,31 @@
 import * as React from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { FailedItem, getCurrentProject, useProjectContextLoad } from "@/aiParams";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import {
   AlertCircle,
   ChevronDown,
   ChevronRight,
   FileText,
   Loader2,
-  RotateCcw,
+  RefreshCw,
   X,
 } from "lucide-react";
-import { FailedItem, useProjectContextLoad } from "@/aiParams";
 import { Button } from "@/components/ui/button";
 import { TruncatedText } from "@/components/TruncatedText";
+import { ProcessingStatus } from "@/components/project/processing-status";
+import { useProjectProcessingData } from "@/components/project/useProjectProcessingData";
+import { openCachedItemPreview } from "@/utils/cacheFileOpener";
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { splitUrlsStringToArray } from "@/projects/projectUtils";
 import CopilotPlugin from "@/main";
 import { logError } from "@/logger";
 
@@ -25,40 +36,81 @@ interface ProgressCardProps {
 }
 
 export default function ProgressCard({ plugin, setHiddenCard, onEditContext }: ProgressCardProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
   const [contextLoadState] = useProjectContextLoad();
   const totalFiles = contextLoadState.total;
   const successFiles = contextLoadState.success;
   const failedFiles = contextLoadState.failed;
   const processingFiles = contextLoadState.processingFiles;
 
-  // Control file list expand/collapse state
-  const [isProcessingExpanded, setIsProcessingExpanded] = useState(false);
-  const [isFailedExpanded, setIsFailedExpanded] = useState(false);
-
   const processedFilesLen = successFiles.length + failedFiles.length;
   const progressPercentage =
     totalFiles.length > 0 ? Math.round((processedFilesLen / totalFiles.length) * 100) : 0;
 
-  const getFailedItemDisplayName = (item: FailedItem): string => {
-    return item.path;
+  // Reason: get current project for the shared hook — ProgressCard always shows the active project.
+  const currentProject = getCurrentProject() ?? null;
+  const { processingData, projectCache } = useProjectProcessingData({
+    cacheProject: currentProject,
+  });
+
+  // Reason: markdown files are not in processingData (adapter skips .md files) but they
+  // can still fail or be processing. Extract them so they remain visible and retryable.
+  const mdProcessingFiles = useMemo(
+    () => processingFiles.filter((p) => p.endsWith(".md")),
+    [processingFiles]
+  );
+  const mdFailedFiles = useMemo(
+    () => failedFiles.filter((item) => item.type === "md"),
+    [failedFiles]
+  );
+  const hasMdItems = mdProcessingFiles.length > 0 || mdFailedFiles.length > 0;
+
+  // Reason: determine whether the detail section has any content to show.
+  // Without this, the "View Details" trigger would expand to empty space.
+  const hasDetailContent =
+    (processingData && processingData.items.length > 0) || hasMdItems;
+
+  /** Retry a failed conversion item via processingData.failedItemMap. */
+  const handleRetry = (itemId: string) => {
+    if (!plugin?.projectManager || !processingData) return;
+    const failedItem = processingData.failedItemMap.get(itemId);
+    if (!failedItem) return;
+    plugin.projectManager.retryFailedItem(failedItem).catch((error) => {
+      logError(`Error retrying failed item: ${error}`);
+    });
   };
 
-  // TODO(emt-lin): maybe use it in the future
-  /*const handleRetryAllFailed = () => {
-    console.log("Retrying all failed items");
-  };*/
-
-  const handleRetryFailedItem = async (item: FailedItem) => {
-    if (!plugin?.projectManager) {
-      logError("ProjectManager not available");
-      return;
-    }
-
-    try {
-      await plugin.projectManager.retryFailedItem(item);
-    } catch (error) {
+  /** Retry a failed markdown item directly. */
+  const handleRetryMdItem = (item: FailedItem) => {
+    if (!plugin?.projectManager) return;
+    plugin.projectManager.retryFailedItem(item).catch((error) => {
       logError(`Error retrying failed item: ${error}`);
+    });
+  };
+
+  /** Remove a failed URL from the saved project config. */
+  const handleRemoveUrl = async (item: ProcessingItem) => {
+    if (!currentProject) return;
+    const field = item.cacheKind === "youtube" ? "youtubeUrls" : "webUrls";
+    const currentUrls = splitUrlsStringToArray(currentProject.contextSource?.[field] || "");
+    const remaining = currentUrls.filter((url) => url !== item.id);
+    const updatedProject = {
+      ...currentProject,
+      contextSource: {
+        ...currentProject.contextSource,
+        [field]: remaining.join("\n"),
+      },
+    };
+    try {
+      await ProjectFileManager.getInstance().updateProject(currentProject.id, updatedProject);
+    } catch (error) {
+      logError(`Error removing URL from project: ${error}`);
     }
+  };
+
+  /** Open parsed content preview for a cached item. */
+  const handleOpenCachedItem = (item: ProcessingItem) => {
+    openCachedItemPreview(app, projectCache, item);
   };
 
   return (
@@ -92,8 +144,8 @@ export default function ProgressCard({ plugin, setHiddenCard, onEditContext }: P
           </div>
         </CardTitle>
       </CardHeader>
-      <CardContent className="tw-space-y-6">
-        {/* Total progress display */}
+      <CardContent className="tw-space-y-4">
+        {/* Progress bar — always visible, covers all files (md + non-md) */}
         <div className="tw-space-y-2">
           <div className="tw-flex tw-items-center tw-justify-between tw-text-sm">
             <div className="tw-flex tw-items-center tw-gap-2">
@@ -101,7 +153,8 @@ export default function ProgressCard({ plugin, setHiddenCard, onEditContext }: P
               <span className="tw-text-xs tw-text-muted">
                 (Success:{" "}
                 <span className="tw-font-medium tw-text-success">{successFiles.length}</span>,
-                Failed: <span className="tw-font-medium tw-text-error">{failedFiles.length}</span>)
+                Failed:{" "}
+                <span className="tw-font-medium tw-text-error">{failedFiles.length}</span>)
               </span>
             </div>
             <span className="tw-font-medium">
@@ -111,119 +164,114 @@ export default function ProgressCard({ plugin, setHiddenCard, onEditContext }: P
           <Progress value={progressPercentage} className="tw-h-2" />
         </div>
 
-        {/* Currently processing file */}
-        {processingFiles.length > 0 && (
-          <div className="tw-space-y-3">
-            <div
-              className="tw--m-1 tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded-md tw-p-1 tw-transition-colors hover:tw-bg-muted/10"
-              onClick={() => setIsProcessingExpanded(!isProcessingExpanded)}
-            >
-              <Loader2 className="tw-size-4 tw-animate-spin tw-text-accent" />
-              <span className="tw-text-sm tw-font-medium">Processing</span>
-              {isProcessingExpanded ? (
-                <ChevronDown className="tw-ml-auto tw-size-4" />
-              ) : (
-                <ChevronRight className="tw-ml-auto tw-size-4" />
-              )}
-            </div>
-
-            {isProcessingExpanded && (
-              <div className="tw-max-h-32 tw-space-y-2 tw-overflow-y-auto">
-                {processingFiles.map((fileName, index) => (
-                  <div
-                    key={index}
-                    className="tw-flex tw-items-center tw-gap-2 tw-rounded-md tw-p-2 tw-text-sm tw-bg-faint/10"
-                  >
-                    <div className="tw-size-2 tw-animate-pulse tw-rounded-full tw-bg-interactive-accent" />
-                    <TruncatedText className="tw-flex-1" title={fileName}>
-                      {fileName}
-                    </TruncatedText>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Failed to process the file */}
-        {failedFiles.length > 0 && (
-          <div className="tw-space-y-3">
-            <div className="tw-flex tw-items-center tw-gap-2">
-              <div
-                className="-tw-m-1 tw-flex tw-flex-1 tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded-md tw-p-1 tw-transition-colors hover:tw-bg-muted/10"
-                onClick={() => setIsFailedExpanded(!isFailedExpanded)}
+        {/* Collapsible detail section — each sub-section manages its own population */}
+        {hasDetailContent && (
+          <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+            <CollapsibleTrigger asChild>
+              <Button
+                variant="secondary"
+                className="tw-flex tw-h-auto tw-w-full tw-items-center tw-justify-between tw-rounded-md tw-p-2 tw-text-left tw-transition-colors hover:tw-bg-modifier-hover"
               >
-                <AlertCircle className="tw-size-4 tw-text-error" />
-                <span className="tw-text-sm tw-font-medium">Failed</span>
-                <Badge variant="destructive" className="tw-text-xs">
-                  {failedFiles.length} files
-                </Badge>
-                {isFailedExpanded ? (
-                  <ChevronDown className="tw-ml-auto tw-size-4" />
+                <span className="tw-text-ui-smaller tw-text-muted">View Details</span>
+                {isExpanded ? (
+                  <ChevronDown className="tw-size-4 tw-text-muted" />
                 ) : (
-                  <ChevronRight className="tw-ml-auto tw-size-4" />
+                  <ChevronRight className="tw-size-4 tw-text-muted" />
                 )}
-              </div>
-              {/*todo(emt-lin): in the future, we can add all failed files to retry*/}
-              {/*<Button
-                size="sm"
-                variant="ghost"
-                className="tw-size-6 tw-bg-transparent tw-p-0"
-                title="Retry failed files"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  // Handle retry logic
-                  handleRetryAllFailed()
-                }}
-              >
-                <RotateCcw className="tw-size-3" />
-              </Button>*/}
-            </div>
+              </Button>
+            </CollapsibleTrigger>
 
-            {isFailedExpanded && (
-              <div className="tw-max-h-32 tw-space-y-2 tw-overflow-y-auto">
-                {failedFiles.map((failedItem: FailedItem, index: number) => (
-                  <div
-                    key={index}
-                    className="tw-flex tw-items-center tw-gap-2 tw-rounded-md tw-p-2 tw-text-sm tw-bg-faint/10"
-                  >
-                    <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-1">
-                      <div className="tw-flex tw-items-center tw-gap-2">
-                        <div className="tw-size-2 tw-rounded-full tw-bg-error/80" />
-                        <TruncatedText className="tw-flex-1 tw-font-bold" title={failedItem.path}>
-                          {getFailedItemDisplayName(failedItem)}
+            <CollapsibleContent>
+              <div className="tw-mt-2 tw-space-y-3">
+                {/* Section 1: Content Conversion (non-markdown items — PDF, images, URLs) */}
+                {processingData && processingData.items.length > 0 && (
+                  <ProcessingStatus
+                    items={processingData.items}
+                    onRetry={handleRetry}
+                    onOpenCachedItem={projectCache != null ? handleOpenCachedItem : undefined}
+                    onRemoveUrl={handleRemoveUrl}
+                    defaultExpanded
+                    maxHeight="200px"
+                  />
+                )}
+
+                {/* Section 2: Markdown Files (processing + failed only) */}
+                {hasMdItems && (
+                  <div className="tw-space-y-1.5">
+                    <div className="tw-flex tw-items-center tw-gap-1.5 tw-px-1">
+                      <FileText className="tw-size-3.5 tw-text-muted" />
+                      <span className="tw-text-ui-smaller tw-font-medium tw-text-muted">
+                        Markdown Files
+                      </span>
+                      {mdProcessingFiles.length > 0 && (
+                        <Badge
+                          variant="secondary"
+                          className="tw-h-4 tw-gap-0.5 tw-px-1 tw-text-[10px]"
+                        >
+                          <Loader2 className="tw-size-2.5 tw-animate-spin" />
+                          {mdProcessingFiles.length}
+                        </Badge>
+                      )}
+                      {mdFailedFiles.length > 0 && (
+                        <Badge
+                          variant="secondary"
+                          className="tw-h-4 tw-gap-0.5 tw-bg-error tw-px-1 tw-text-[10px] tw-text-error"
+                        >
+                          <AlertCircle className="tw-size-2.5" />
+                          {mdFailedFiles.length}
+                        </Badge>
+                      )}
+                    </div>
+                    {mdProcessingFiles.map((path, i) => (
+                      <div
+                        key={`md-proc-${i}`}
+                        className="tw-flex tw-items-center tw-gap-2 tw-rounded-md tw-border tw-border-border tw-bg-primary tw-p-2"
+                      >
+                        <Loader2 className="tw-size-3.5 tw-animate-spin tw-text-loading" />
+                        <TruncatedText
+                          className="tw-flex-1 tw-text-ui-smaller tw-text-normal"
+                          title={path}
+                        >
+                          {path}
                         </TruncatedText>
                       </div>
-                      <div className="tw-flex tw-items-center tw-gap-2">
-                        <div className="tw-size-2 tw-rounded-full" />
-                        {failedItem.error && (
+                    ))}
+                    {mdFailedFiles.map((item, i) => (
+                      <div
+                        key={`md-fail-${i}`}
+                        className="tw-rounded-md tw-border tw-border-border tw-bg-primary tw-p-2"
+                      >
+                        <div className="tw-flex tw-items-center tw-gap-2">
+                          <AlertCircle className="tw-size-3.5 tw-shrink-0 tw-text-error" />
                           <TruncatedText
-                            className="tw-flex-1 tw-text-xs tw-text-error/80"
-                            title={failedItem.error}
+                            className="tw-flex-1 tw-text-ui-smaller tw-text-normal"
+                            title={item.path}
                           >
-                            <span className="tw-text-sm tw-text-error">Loading Error: </span>
-                            {failedItem.error}
+                            {item.path}
+                          </TruncatedText>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            className="tw-h-5 tw-shrink-0 tw-px-1.5 tw-text-ui-smaller"
+                            title="Retry"
+                            onClick={() => handleRetryMdItem(item)}
+                          >
+                            <RefreshCw className="tw-mr-1 tw-size-3" />
+                            Retry
+                          </Button>
+                        </div>
+                        {item.error && (
+                          <TruncatedText className="tw-mt-1 tw-pl-5.5 tw-text-ui-smaller tw-text-error">
+                            {item.error}
                           </TruncatedText>
                         )}
                       </div>
-                    </div>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="tw-size-5 tw-p-0"
-                      title={`Retry ${failedItem.type} item`}
-                      onClick={async (e) => {
-                        e.stopPropagation();
-                        await handleRetryFailedItem(failedItem);
-                      }}
-                    >
-                      <RotateCcw className="tw-size-3" />
-                    </Button>
+                    ))}
                   </div>
-                ))}
+                )}
               </div>
-            )}
-          </div>
+            </CollapsibleContent>
+          </Collapsible>
         )}
       </CardContent>
     </Card>

--- a/src/components/project/useProjectProcessingData.ts
+++ b/src/components/project/useProjectProcessingData.ts
@@ -1,0 +1,143 @@
+/**
+ * Shared hook for building project processing status data.
+ *
+ * Extracted from AddProjectModal to be reusable by both
+ * AddProjectModal (with draft contextSource preview) and
+ * ProgressCard (with saved project only).
+ */
+
+import { getCurrentProject, ProjectConfig, useProjectContextLoad } from "@/aiParams";
+import { ContextCache, ProjectContextCache } from "@/cache/projectContextCache";
+import {
+  buildProcessingItems,
+  type ProcessingAdapterResult,
+} from "@/components/project/processingAdapter";
+import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
+import { FileParserManager } from "@/tools/FileParserManager";
+import { TFile } from "obsidian";
+import { useEffect, useMemo, useState } from "react";
+
+export interface UseProjectProcessingDataParams {
+  /** Saved project config — used for cache lookup, isCurrentProject check, and file enumeration. */
+  cacheProject: ProjectConfig | null;
+  /**
+   * Optional draft contextSource override for generating the items list.
+   * When provided, newly added (but unsaved) URLs appear as "Pending".
+   * When omitted, falls back to cacheProject.contextSource.
+   */
+  contextSource?: ProjectConfig["contextSource"];
+}
+
+export interface UseProjectProcessingDataResult {
+  /** Full adapter result including items and failedItemMap (null while loading or no project). */
+  processingData: ProcessingAdapterResult | null;
+  /** Cache three-state: undefined = loading, null = no cache, ContextCache = loaded. */
+  projectCache: ContextCache | null | undefined;
+  /** Whether cacheProject is the currently active/loaded project. */
+  isCurrentProject: boolean;
+}
+
+/**
+ * Build project processing status data for ProcessingStatus rendering.
+ *
+ * Handles:
+ * - Async cache loading (re-fetches when contextLoadState changes)
+ * - Vault file enumeration from cacheProject's inclusion/exclusion patterns
+ * - Static supportedExtensions lookup
+ * - previewProject construction from cacheProject + contextSource draft
+ * - Deferred rendering for non-current projects until cache is ready
+ */
+export function useProjectProcessingData(
+  params: UseProjectProcessingDataParams
+): UseProjectProcessingDataResult {
+  const { cacheProject, contextSource } = params;
+
+  // Reason: Load the project's persistent context cache.
+  // undefined = still loading, null = loaded but no cache exists, ContextCache = loaded with data.
+  // Reason: Re-fetch cache when contextLoadState changes so contentEmpty detection stays current.
+  const [projectCache, setProjectCache] = useState<ContextCache | null | undefined>(undefined);
+  const [contextLoadState] = useProjectContextLoad();
+
+  // Reason: reset cache to "loading" when project identity changes to avoid
+  // briefly showing stale cache from the previous project during a switch.
+  const cacheProjectId = cacheProject?.id;
+  useEffect(() => {
+    setProjectCache(undefined);
+  }, [cacheProjectId]);
+
+  useEffect(() => {
+    if (!cacheProject) {
+      setProjectCache(undefined);
+      return;
+    }
+    let mounted = true;
+    ProjectContextCache.getInstance()
+      .get(cacheProject)
+      .then((cache) => {
+        if (mounted) setProjectCache(cache);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [cacheProject, contextLoadState]);
+
+  // Reason: isCurrentProject drives whether we show live state or cache-fallback state.
+  // We use cacheProject (the saved config) because the load state corresponds to
+  // the already-saved configuration, not unsaved edits.
+  const isCurrentProject = !!cacheProject && cacheProject.id === getCurrentProject()?.id;
+
+  // Reason: Enumerate vault files matching inclusion/exclusion patterns.
+  // Uses draft contextSource when available so unsaved edits are reflected in the file preview;
+  // falls back to cacheProject.contextSource for saved-only views (e.g. ProgressCard).
+  const effectiveInclusions = contextSource?.inclusions ?? cacheProject?.contextSource?.inclusions;
+  const effectiveExclusions = contextSource?.exclusions ?? cacheProject?.contextSource?.exclusions;
+  const [projectFiles, setProjectFiles] = useState<TFile[]>([]);
+  useEffect(() => {
+    if (!cacheProject) {
+      setProjectFiles([]);
+      return;
+    }
+    const { inclusions, exclusions } = getMatchingPatterns({
+      inclusions: effectiveInclusions,
+      exclusions: effectiveExclusions,
+      isProject: true,
+    });
+    setProjectFiles(
+      app.vault.getFiles().filter((file) => shouldIndexFile(file, inclusions, exclusions, true))
+    );
+  }, [cacheProject, effectiveInclusions, effectiveExclusions]);
+
+  // Reason: Static method — the set of supported extensions never changes at runtime.
+  const supportedExtensions = useMemo(() => FileParserManager.getProjectSupportedExtensions(), []);
+
+  // Reason: Merge draft contextSource into cacheProject so the Content Conversion panel
+  // reflects the current form state (newly added URLs show as "Pending").
+  // Status data (ready/failed/processing) still comes from live state and cache.
+  const displayProject = useMemo<ProjectConfig | null>(() => {
+    if (!cacheProject) return null;
+    // Reason: only override contextSource when a draft is explicitly provided.
+    // This avoids unnecessary object creation when no draft is present.
+    if (!contextSource) return cacheProject;
+    return {
+      ...cacheProject,
+      contextSource,
+    };
+  }, [cacheProject, contextSource]);
+
+  const processingData = useMemo(() => {
+    if (!displayProject) return null;
+    // Reason: Don't render until cache is loaded for non-current projects to avoid empty state flash.
+    // Current project has live state so it can render immediately without cache.
+    if (projectCache === undefined && !isCurrentProject) return null;
+    return buildProcessingItems({
+      project: displayProject,
+      isCurrentProject,
+      liveState: contextLoadState,
+      projectCache,
+      projectFiles,
+      supportedExtensions,
+    });
+  }, [displayProject, isCurrentProject, contextLoadState, projectCache, projectFiles, supportedExtensions]);
+
+  return { processingData, projectCache, isCurrentProject };
+}

--- a/src/components/ui/url-tag-input.tsx
+++ b/src/components/ui/url-tag-input.tsx
@@ -1,0 +1,247 @@
+/**
+ * Tag-style URL input component for project context URLs.
+ *
+ * Supports:
+ * - Single URL entry via Enter key
+ * - Batch paste (newline/space separated)
+ * - Automatic web/youtube classification
+ * - Grouped display (Web section + YouTube section)
+ * - Duplicate detection on add
+ */
+
+import { Button } from "@/components/ui/button";
+import {
+  type UrlItem,
+  detectUrlType,
+  isValidUrl,
+} from "@/utils/urlTagUtils";
+import { TruncatedText } from "@/components/TruncatedText";
+import { ClipboardPaste, Globe, Link, X, Youtube } from "lucide-react";
+import React, { useCallback, useRef, useState, type ClipboardEvent, type KeyboardEvent } from "react";
+
+interface UrlTagInputProps {
+  urls: UrlItem[];
+  onAdd: (urls: UrlItem[]) => void;
+  onRemove: (id: string) => void;
+}
+
+/** Generate a short random ID */
+function generateId(): string {
+  return Math.random().toString(36).substring(2, 9);
+}
+
+export function UrlTagInput({ urls, onAdd, onRemove }: UrlTagInputProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reason: Existing URL set for dedup — prevents duplicate entries on add
+  const existingUrls = new Set(urls.map((u) => u.url.trim()));
+
+  const parseAndAddUrls = (text: string) => {
+    const urlStrings = text
+      .split(/[\n\s]+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0 && isValidUrl(s));
+
+    if (urlStrings.length === 0) return;
+
+    const newUrls: UrlItem[] = [];
+    for (const raw of urlStrings) {
+      const url = raw.startsWith("http") ? raw : `https://${raw}`;
+      if (existingUrls.has(url)) continue;
+      existingUrls.add(url);
+      newUrls.push({ id: generateId(), url, type: detectUrlType(raw) });
+    }
+
+    if (newUrls.length > 0) {
+      onAdd(newUrls);
+    }
+    setInputValue("");
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && inputValue.trim()) {
+      e.preventDefault();
+      parseAndAddUrls(inputValue);
+    }
+    if (e.key === "Backspace" && !inputValue && urls.length > 0) {
+      onRemove(urls[urls.length - 1].id);
+    }
+  };
+
+  const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
+    const pastedText = e.clipboardData.getData("text");
+    // Reason: If paste contains multiple URLs, intercept and batch-process
+    if (pastedText.includes("\n") || pastedText.split(/\s+/).filter(isValidUrl).length > 1) {
+      e.preventDefault();
+      parseAndAddUrls(pastedText);
+    }
+  };
+
+  const handlePasteFromClipboard = async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        parseAndAddUrls(text);
+      }
+    } catch {
+      // Clipboard API not available or permission denied in Obsidian
+    }
+  };
+
+  const webUrls = urls.filter((u) => u.type === "web");
+  const youtubeUrls = urls.filter((u) => u.type === "youtube");
+
+  return (
+    <div className="tw-space-y-3">
+      {/* Input Row */}
+      <div className="tw-flex tw-gap-2">
+        <div
+          className={`tw-flex tw-min-h-[40px] tw-flex-1 tw-items-center tw-rounded-md tw-border tw-border-border tw-px-3 tw-transition-colors ${
+            isFocused ? "tw-border-interactive-accent tw-ring-1 tw-ring-ring" : ""
+          }`}
+          onClick={() => inputRef.current?.focus()}
+        >
+          <Link className="tw-mr-2 tw-size-4 tw-text-muted" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            className="tw-flex-1 tw-bg-transparent tw-text-sm tw-text-normal tw-outline-none placeholder:tw-text-muted"
+            placeholder="Enter URL and press Enter..."
+          />
+        </div>
+        <Button
+          variant="secondary"
+          onClick={handlePasteFromClipboard}
+          title="Paste from clipboard"
+          className="tw-px-2"
+        >
+          <ClipboardPaste className="tw-size-4" />
+        </Button>
+      </div>
+
+      {/* URL List - Grouped */}
+      {urls.length > 0 && (
+        <div className="tw-divide-y tw-divide-border tw-rounded-md tw-border tw-border-border">
+          {/* Web URLs Section */}
+          {webUrls.length > 0 && (
+            <div className="tw-p-2">
+              <div className="tw-mb-2 tw-flex tw-items-center tw-gap-1.5 tw-px-1">
+                <Globe className="tw-size-3.5 tw-text-accent" />
+                <span className="tw-text-ui-smaller tw-font-medium tw-text-muted">
+                  Web ({webUrls.length})
+                </span>
+              </div>
+              {/* Reason: Each section scrolls independently so YouTube is always visible */}
+              {/* Reason: reverse so newly added URLs appear at top */}
+              <FadingScrollArea maxHeight="120px">
+                {[...webUrls].reverse().map((url) => (
+                  <UrlItemRow key={url.id} url={url} onRemove={onRemove} />
+                ))}
+              </FadingScrollArea>
+            </div>
+          )}
+
+          {/* YouTube Section */}
+          {youtubeUrls.length > 0 && (
+            <div className="tw-p-2">
+              <div className="tw-mb-2 tw-flex tw-items-center tw-gap-1.5 tw-px-1">
+                <Youtube className="tw-size-3.5 tw-text-error" />
+                <span className="tw-text-ui-smaller tw-font-medium tw-text-muted">
+                  YouTube ({youtubeUrls.length})
+                </span>
+              </div>
+              {/* Reason: reverse so newly added URLs appear at top */}
+              <FadingScrollArea maxHeight="120px">
+                {[...youtubeUrls].reverse().map((url) => (
+                  <UrlItemRow key={url.id} url={url} onRemove={onRemove} />
+                ))}
+              </FadingScrollArea>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Empty State */}
+      {urls.length === 0 && (
+        <p className="tw-text-ui-smaller tw-text-muted">
+          Add web pages or YouTube videos. Supports batch paste (one URL per line).
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** Scroll area with a bottom fade mask when content overflows. */
+function FadingScrollArea({
+  maxHeight,
+  children,
+}: {
+  maxHeight: string;
+  children: React.ReactNode;
+}) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [showFade, setShowFade] = useState(false);
+
+  const refCallback = useCallback((el: HTMLDivElement | null) => {
+    scrollRef.current = el;
+    if (el) setShowFade(el.scrollHeight > el.clientHeight);
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 4;
+    setShowFade(!atBottom);
+  }, []);
+
+  return (
+    <div className="tw-relative">
+      <div
+        ref={refCallback}
+        className="tw-space-y-1 tw-overflow-y-auto"
+        style={{ maxHeight }}
+        onScroll={handleScroll}
+      >
+        {children}
+      </div>
+      {showFade && (
+        <div className="copilot-fade-mask-bottom tw-pointer-events-none tw-absolute tw-inset-x-0 tw-bottom-0 tw-h-8 tw-rounded-b-md" />
+      )}
+    </div>
+  );
+}
+
+function UrlItemRow({ url, onRemove }: { url: UrlItem; onRemove: (id: string) => void }) {
+  return (
+    <div className="tw-group tw-flex tw-items-center tw-justify-between tw-rounded tw-px-2 tw-py-1.5 hover:tw-bg-modifier-hover">
+      <div className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-2">
+        {url.type === "youtube" ? (
+          <Youtube className="tw-size-3.5 tw-shrink-0 tw-text-error" />
+        ) : (
+          <Globe className="tw-size-3.5 tw-shrink-0 tw-text-accent" />
+        )}
+        <TruncatedText className="tw-text-sm tw-text-normal" tooltipContent={url.url}>
+          {url.url.replace(/^https?:\/\//, "")}
+        </TruncatedText>
+      </div>
+      <Button
+        type="button"
+        variant="ghost2"
+        size="fit"
+        onClick={() => onRemove(url.id)}
+        className="tw-rounded tw-p-1 tw-opacity-0 tw-transition-opacity hover:tw-bg-modifier-hover group-hover:tw-opacity-100"
+        title="Remove"
+      >
+        <X className="tw-size-3.5 tw-text-muted" />
+      </Button>
+    </div>
+  );
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -16,6 +16,7 @@ export const DEFAULT_CHAT_HISTORY_FOLDER = `${COPILOT_FOLDER_ROOT}/copilot-conve
 export const DEFAULT_CUSTOM_PROMPTS_FOLDER = `${COPILOT_FOLDER_ROOT}/copilot-custom-prompts`;
 export const DEFAULT_MEMORY_FOLDER = `${COPILOT_FOLDER_ROOT}/memory`;
 export const DEFAULT_SYSTEM_PROMPTS_FOLDER = `${COPILOT_FOLDER_ROOT}/system-prompts`;
+export const DEFAULT_PROJECTS_FOLDER = `${COPILOT_FOLDER_ROOT}/projects`;
 export const DEFAULT_CONVERTED_DOC_OUTPUT_FOLDER = "";
 export const DEFAULT_QA_EXCLUSIONS_SETTING = COPILOT_FOLDER_ROOT;
 export const DEFAULT_SYSTEM_PROMPT = `You are Obsidian Copilot, a helpful assistant that integrates AI to Obsidian note-taking.
@@ -952,6 +953,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   promptSortStrategy: PromptSortStrategy.TIMESTAMP,
   chatHistorySortStrategy: "recent",
   projectListSortStrategy: "recent",
+  projectsFolder: DEFAULT_PROJECTS_FOLDER,
   defaultConversationNoteName: "{$topic}@{$date}_{$time}",
   /** @deprecated */
   inlineEditCommands: [],

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -3,6 +3,8 @@ import { AI_SENDER, USER_SENDER } from "@/constants";
 import ChainManager from "@/LLMProviders/chainManager";
 import { parseReasoningBlock } from "@/LLMProviders/chainRunner/utils/AgentReasoningState";
 import { logError, logInfo, logWarn } from "@/logger";
+import { sanitizeVaultPathSegment } from "@/projects/projectUtils";
+import { filterChatHistoryFiles, readChatPathProjectId } from "@/utils/chatHistoryUtils";
 import { getSettings } from "@/settings/model";
 import { ChatMessage } from "@/types/message";
 import {
@@ -114,14 +116,21 @@ export class ChatPersistenceManager {
         !isInVaultCache(this.app, preferredFileName) &&
         (await this.app.vault.adapter.exists(preferredFileName))
       ) {
-        // File exists on disk but not in the vault cache.
-        // This happens when the save folder is a hidden directory (path starting with '.')
-        // because Obsidian's metadata cache does not index hidden paths.
-        await this.app.vault.adapter.write(preferredFileName, noteContent);
-        new Notice("Existing chat note found - updating it now.");
-        logInfo(
-          `[ChatPersistenceManager] Updated existing chat file via adapter: ${preferredFileName}`
-        );
+        // File exists on disk but not in the vault cache (hidden directory).
+        // Reason: check ownership before overwriting to prevent cross-project collision.
+        const safePath = await this.resolveChatSavePath(preferredFileName, currentProject);
+        await this.app.vault.adapter.write(safePath, noteContent);
+        if (safePath !== preferredFileName) {
+          new Notice(`Chat saved as note: ${safePath}`);
+          logWarn(
+            `[ChatPersistenceManager] Avoided cross-project overwrite in hidden folder. Created: ${safePath}`
+          );
+        } else {
+          new Notice("Existing chat note found - updating it now.");
+          logInfo(
+            `[ChatPersistenceManager] Updated existing chat file via adapter: ${preferredFileName}`
+          );
+        }
       } else {
         // File doesn't exist, create a new one
         try {
@@ -135,35 +144,65 @@ export class ChatPersistenceManager {
               // Read existing frontmatter to preserve lastAccessedAt and topic
               const conflictFrontmatter =
                 this.app.metadataCache.getFileCache(conflictFile)?.frontmatter;
-              existingTopic = conflictFrontmatter?.topic ?? existingTopic;
-              const conflictLastAccessedAt = conflictFrontmatter?.lastAccessedAt;
 
-              // Regenerate content with preserved frontmatter values
-              const updatedContent = this.generateNoteContent(
-                chatContent,
-                firstMessageEpoch,
-                modelKey,
-                existingTopic,
-                conflictLastAccessedAt
-              );
-              await this.app.vault.modify(conflictFile, updatedContent);
-              targetFile = conflictFile;
-              new Notice("Existing chat note found - updating it now.");
-              logInfo(
-                `[ChatPersistenceManager] Resolved save conflict by updating existing chat file: ${conflictFile.path}`
-              );
+              // Reason: only overwrite when ownership is confirmed to match.
+              // Treating undefined (missing frontmatter) as safe would corrupt legacy/manual files.
+              const conflictProjectId = conflictFrontmatter?.projectId;
+              const currentProjectId = currentProject?.id;
+              if (currentProjectId && conflictProjectId !== currentProjectId) {
+                // Different project owns this file — generate a unique name instead
+                const rawUniqueName = `${settings.defaultSaveFolder}/${sanitizeVaultPathSegment(currentProjectId)}__chat-${firstMessageEpoch}.md`;
+                const uniqueName = await this.resolveChatSavePath(rawUniqueName, currentProject);
+                targetFile = await this.app.vault.create(uniqueName, noteContent);
+                new Notice(`Chat saved as note: ${uniqueName}`);
+                logWarn(
+                  `[ChatPersistenceManager] Avoided cross-project overwrite. Created: ${uniqueName}`
+                );
+              } else {
+                existingTopic = conflictFrontmatter?.topic ?? existingTopic;
+                const conflictLastAccessedAt = conflictFrontmatter?.lastAccessedAt;
+
+                // Regenerate content with preserved frontmatter values
+                const updatedContent = this.generateNoteContent(
+                  chatContent,
+                  firstMessageEpoch,
+                  modelKey,
+                  existingTopic,
+                  conflictLastAccessedAt
+                );
+                await this.app.vault.modify(conflictFile, updatedContent);
+                targetFile = conflictFile;
+                new Notice("Existing chat note found - updating it now.");
+                logInfo(
+                  `[ChatPersistenceManager] Resolved save conflict by updating existing chat file: ${conflictFile.path}`
+                );
+              }
             } else {
               // File exists on disk but not in vault cache (hidden directory)
-              await this.app.vault.adapter.write(preferredFileName, noteContent);
-              new Notice("Existing chat note found - updating it now.");
-              logInfo(
-                `[ChatPersistenceManager] Resolved save conflict via adapter: ${preferredFileName}`
-              );
+              // Reason: check ownership before overwriting to prevent cross-project collision.
+              const safePath = await this.resolveChatSavePath(preferredFileName, currentProject);
+              await this.app.vault.adapter.write(safePath, noteContent);
+              if (safePath !== preferredFileName) {
+                new Notice(`Chat saved as note: ${safePath}`);
+                logWarn(
+                  `[ChatPersistenceManager] Avoided cross-project overwrite via adapter. Created: ${safePath}`
+                );
+              } else {
+                new Notice("Existing chat note found - updating it now.");
+                logInfo(
+                  `[ChatPersistenceManager] Resolved save conflict via adapter: ${preferredFileName}`
+                );
+              }
             }
           } else if (this.isNameTooLongError(error)) {
             // Single fallback: minimal guaranteed-to-work filename with project prefix
-            const filePrefix = currentProject ? `${currentProject.id}__` : "";
-            const fallbackName = `${settings.defaultSaveFolder}/${filePrefix}chat-${firstMessageEpoch}.md`;
+            const fallbackProject = getCurrentProject();
+            const filePrefix = fallbackProject
+              ? `${sanitizeVaultPathSegment(fallbackProject.id)}__`
+              : "";
+            const rawFallbackName = `${settings.defaultSaveFolder}/${filePrefix}chat-${firstMessageEpoch}.md`;
+            // Reason: check ownership to prevent cross-project collision on fallback path
+            const fallbackName = await this.resolveChatSavePath(rawFallbackName, currentProject);
 
             try {
               targetFile = await this.app.vault.create(fallbackName, noteContent);
@@ -197,6 +236,7 @@ export class ChatPersistenceManager {
                   );
                 } else {
                   // File exists on disk but not in vault cache (hidden directory)
+                  // Reason: resolveChatSavePath already checked ownership above
                   await this.app.vault.adapter.write(fallbackName, noteContent);
                   new Notice("Existing chat note found - updating it now.");
                   logInfo(
@@ -243,6 +283,39 @@ export class ChatPersistenceManager {
   }
 
   /**
+   * Resolve a safe chat save path for the current project.
+   * If the file at `preferredPath` already exists and belongs to a different project,
+   * returns a suffixed path to avoid cross-project overwrites.
+   */
+  private async resolveChatSavePath(
+    preferredPath: string,
+    currentProject: ProjectConfig | null
+  ): Promise<string> {
+    if (!(await this.app.vault.adapter.exists(preferredPath))) return preferredPath;
+
+    const currentProjectId = currentProject?.id;
+    if (!currentProjectId) return preferredPath;
+
+    const existingProjectId = await readChatPathProjectId(this.app, preferredPath);
+
+    // Reason: only reuse the path when ownership is confirmed to match.
+    // Treating undefined (missing frontmatter) as safe would corrupt legacy/manual chat files.
+    if (existingProjectId === currentProjectId) {
+      return preferredPath;
+    }
+
+    // Different project owns this path — generate a unique suffix
+    const basePath = preferredPath.replace(/\.md$/i, "");
+    let suffix = 2;
+    let candidate = `${basePath}-${suffix}.md`;
+    while (await this.app.vault.adapter.exists(candidate)) {
+      suffix++;
+      candidate = `${basePath}-${suffix}.md`;
+    }
+    return candidate;
+  }
+
+  /**
    * Get all chat history files from the vault
    */
   async getChatHistoryFiles(): Promise<TFile[]> {
@@ -250,19 +323,11 @@ export class ChatPersistenceManager {
     const folderFiles = await listMarkdownFiles(this.app, settings.defaultSaveFolder);
     if (folderFiles.length === 0) return [];
 
-    // Get current project ID if in a project
     const currentProject = getCurrentProject();
 
-    // Filter files based on project context
-    return folderFiles.filter((file) => {
-      if (currentProject) {
-        // In project mode, only show files for this project
-        return file.basename.startsWith(`${currentProject.id}__`);
-      } else {
-        // In non-project mode, only show files without project prefix
-        return !file.basename.includes("__") || !file.basename.split("__")[0];
-      }
-    });
+    // Reason: pass all files to filterChatHistoryFiles which checks frontmatter projectId.
+    // A prefix prefilter would miss renamed or legacy files that still have correct frontmatter.
+    return filterChatHistoryFiles(this.app, folderFiles, currentProject?.id);
   }
 
   /**
@@ -523,7 +588,7 @@ export class ChatPersistenceManager {
   }
 
   /**
-   * Find a file by its epoch in the frontmatter
+   * Find a file by its epoch in the frontmatter.
    */
   private async findFileByEpoch(epoch: number): Promise<TFile | null> {
     const files = await this.getChatHistoryFiles();
@@ -661,7 +726,9 @@ ${conversationSummary}`;
 
     // Prefix from an input project, global project, or empty if none
     const currentProject = project === undefined ? getCurrentProject() : project;
-    const filePrefix = currentProject ? `${currentProject.id}__` : "";
+    const filePrefix = currentProject
+      ? `${sanitizeVaultPathSegment(currentProject.id)}__`
+      : "";
 
     // Calculate fixed components in bytes
     const extensionBytes = getUtf8ByteLength(".md");
@@ -727,10 +794,10 @@ ${conversationSummary}`;
     return `---
 epoch: ${firstMessageEpoch}
 modelKey: "${escapeYamlString(modelKey)}"
-${topic ? `topic: "${topic}"` : ""}
+${topic ? `topic: "${escapeYamlString(topic)}"` : ""}
 ${lastAccessedAt ? `lastAccessedAt: ${lastAccessedAt}` : ""}
-${currentProject ? `projectId: ${currentProject.id}` : ""}
-${currentProject ? `projectName: ${currentProject.name}` : ""}
+${currentProject ? `projectId: "${escapeYamlString(currentProject.id)}"` : ""}
+${currentProject ? `projectName: "${escapeYamlString(currentProject.name)}"` : ""}
 tags:
   - ${settings.defaultConversationTag}
 ---

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,11 +17,12 @@ import { CustomCommandRegister } from "@/commands/customCommandRegister";
 import { migrateCommands, suggestDefaultCommands } from "@/commands/migrator";
 import { migrateSystemPromptsFromSettings } from "@/system-prompts/migration";
 import { SystemPromptRegister } from "@/system-prompts/systemPromptRegister";
+import { ProjectRegister } from "@/projects/projectRegister";
 import { ABORT_REASON, CHAT_VIEWTYPE, DEFAULT_OPEN_AREA, EVENT_NAMES } from "@/constants";
 import { ChatManager } from "@/core/ChatManager";
 import { MessageRepository } from "@/core/MessageRepository";
 import { encryptAllKeys } from "@/encryptionService";
-import { logInfo, logWarn } from "@/logger";
+import { logError, logInfo, logWarn } from "@/logger";
 import { logFileManager } from "@/logFileManager";
 import { UserMemoryManager } from "@/memory/UserMemoryManager";
 import { clearRecordedPromptPayload } from "@/LLMProviders/chainRunner/utils/promptPayloadRecorder";
@@ -65,9 +66,14 @@ import {
   extractChatDate,
   extractChatLastAccessedAtMs,
   extractChatTitle,
+  filterChatHistoryFiles,
 } from "@/utils/chatHistoryUtils";
 import { RecentUsageManager } from "@/utils/recentUsageManager";
-import { listMarkdownFiles, patchFrontmatter, resolveFileByPath } from "@/utils/vaultAdapterUtils";
+import {
+  listMarkdownFiles,
+  patchFrontmatter,
+  resolveFileByPath,
+} from "@/utils/vaultAdapterUtils";
 import { v4 as uuidv4 } from "uuid";
 
 // Removed unused FileTrackingState interface
@@ -81,6 +87,7 @@ export default class CopilotPlugin extends Plugin {
   fileParserManager: FileParserManager;
   customCommandRegister: CustomCommandRegister;
   systemPromptRegister: SystemPromptRegister;
+  projectRegister: ProjectRegister;
   settingsUnsubscriber?: () => void;
   chatUIState: ChatUIState;
   userMemoryManager: UserMemoryManager;
@@ -203,8 +210,18 @@ export default class CopilotPlugin extends Plugin {
 
     this.customCommandRegister = new CustomCommandRegister(this, this.app.vault);
     this.systemPromptRegister = new SystemPromptRegister(this, this.app.vault);
+    this.projectRegister = new ProjectRegister(this.app.vault);
 
     this.app.workspace.onLayoutReady(() => {
+      // Reason: projects must initialize after vault file tree is indexed (onLayoutReady),
+      // not in onload(). Otherwise getAbstractFileByPath() returns null for non-hidden
+      // folders and the adapter fallback creates synthetic TFiles that crash vault.read().
+      // This matches the system-prompts initialization pattern.
+      this.projectRegister.initialize().catch((error) => {
+        logError("[Projects] ProjectRegister initialization failed", error);
+        new Notice("Failed to load projects. Check console for details.");
+      });
+
       // Initialize custom commands
       this.customCommandRegister.initialize().then(migrateCommands).then(suggestDefaultCommands);
 
@@ -239,6 +256,7 @@ export default class CopilotPlugin extends Plugin {
 
     this.customCommandRegister.cleanup();
     this.systemPromptRegister.cleanup();
+    this.projectRegister.cleanup();
     this.settingsUnsubscriber?.();
 
     // Cleanup selection handler
@@ -636,22 +654,11 @@ export default class CopilotPlugin extends Plugin {
     const folderFiles = await listMarkdownFiles(this.app, getSettings().defaultSaveFolder);
     if (folderFiles.length === 0) return [];
 
-    // Get current project ID if in a project
     const currentProject = getCurrentProject();
-    const currentProjectId = currentProject?.id;
 
-    if (currentProjectId) {
-      // In project mode: return only files with this project's ID prefix
-      const projectPrefix = `${currentProjectId}__`;
-      return folderFiles.filter((file) => file.basename.startsWith(projectPrefix));
-    } else {
-      // In non-project mode: return only files without any project ID prefix
-      // This assumes project IDs always use the format projectId__ as prefix
-      return folderFiles.filter((file) => {
-        // Check if the filename has any projectId__ prefix pattern
-        return !file.basename.match(/^[a-zA-Z0-9-]+__/);
-      });
-    }
+    // Reason: pass all files to filterChatHistoryFiles which checks frontmatter projectId.
+    // A prefix prefilter would miss renamed or legacy files that still have correct frontmatter.
+    return filterChatHistoryFiles(this.app, folderFiles, currentProject?.id);
   }
 
   async getChatHistoryItems(): Promise<ChatHistoryItem[]> {

--- a/src/projects/ProjectFileManager.test.ts
+++ b/src/projects/ProjectFileManager.test.ts
@@ -1,0 +1,150 @@
+import { TFile, Vault } from "obsidian";
+import { ProjectConfig } from "@/aiParams";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({ projectsFolder: "copilot-projects", projectList: [] })),
+  updateSetting: jest.fn(),
+}));
+
+jest.mock("@/projects/state", () => ({
+  addPendingFileWrite: jest.fn(),
+  removePendingFileWrite: jest.fn(),
+  isPendingFileWrite: jest.fn(() => false),
+  upsertCachedProjectRecord: jest.fn(),
+  deleteCachedProjectRecordById: jest.fn(),
+  updateCachedProjectRecords: jest.fn(),
+  // Reason: overridden per-test to simulate cache state
+  getCachedProjectRecords: jest.fn(() => []),
+  getCachedProjectRecordById: jest.fn(() => undefined),
+}));
+
+jest.mock("@/logger", () => ({
+  logWarn: jest.fn(),
+  logError: jest.fn(),
+  logInfo: jest.fn(),
+}));
+
+jest.mock("@/projects/projectUtils", () => ({
+  sanitizeVaultPathSegment: jest.fn((s: string) => s.replace(/[/\\]/g, "_")),
+  fetchAllProjects: jest.fn(async () => []),
+  loadAllProjects: jest.fn(async () => []),
+  writeProjectFrontmatter: jest.fn(async () => {}),
+  getProjectsFolder: jest.fn(() => "copilot-projects"),
+  getProjectFolderPath: jest.fn((name: string) => `copilot-projects/${name}`),
+  getProjectConfigFilePath: jest.fn((name: string) => `copilot-projects/${name}/project.md`),
+}));
+
+jest.mock("@/utils", () => ({
+  ensureFolderExists: jest.fn(async () => {}),
+}));
+
+jest.mock("@/cache/projectContextCache", () => ({
+  ProjectContextCache: {
+    getInstance: jest.fn(() => ({ clearForProject: jest.fn(async () => {}) })),
+  },
+}));
+
+jest.mock("@/utils/recentUsageManager", () => ({
+  RecentUsageManager: jest.fn().mockImplementation(() => ({
+    touch: jest.fn(),
+    shouldPersist: jest.fn(() => null),
+    markPersisted: jest.fn(),
+    getLastTouchedAt: jest.fn(() => null),
+    getRecentItems: jest.fn(() => []),
+  })),
+}));
+
+jest.mock("@/projects/projectMigration", () => ({
+  ensureProjectsMigratedIfNeeded: jest.fn(async () => {}),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+import {
+  getCachedProjectRecords,
+  getCachedProjectRecordById,
+} from "@/projects/state";
+
+/** Minimal valid ProjectConfig for test use. */
+function makeConfig(overrides: { id: string; name: string } & Partial<ProjectConfig>): ProjectConfig {
+  return {
+    systemPrompt: "",
+    projectModelKey: "",
+    modelConfigs: {},
+    contextSource: {},
+    created: 0,
+    UsageTimestamps: 0,
+    ...overrides,
+  };
+}
+
+/** Build a minimal Vault mock. */
+function makeMockVault(): jest.Mocked<Vault> {
+  return {
+    create: jest.fn(async (path: string) => ({ path } as TFile)),
+    // Reason: null = file does not exist yet, avoids collision error in createProject
+    getAbstractFileByPath: jest.fn(() => null),
+    adapter: { exists: jest.fn(async () => false) },
+  } as unknown as jest.Mocked<Vault>;
+}
+
+/** Reset the singleton so each test gets a fresh instance. */
+function resetSingleton() {
+  (ProjectFileManager as unknown as Record<string, unknown>)["instance"] = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ProjectFileManager.createProject", () => {
+  let vault: jest.Mocked<Vault>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetSingleton();
+    vault = makeMockVault();
+    (getCachedProjectRecords as jest.Mock).mockReturnValue([]);
+    (getCachedProjectRecordById as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it("rejects duplicate project names (case-insensitive)", async () => {
+    (getCachedProjectRecords as jest.Mock).mockReturnValue([
+      {
+        project: makeConfig({ id: "existing", name: "My Project" }),
+        filePath: "copilot-projects/existing/project.md",
+        folderName: "existing",
+      },
+    ]);
+
+    const manager = ProjectFileManager.getInstance(vault);
+
+    // "my project" (lowercase) collides with "My Project"
+    await expect(
+      manager.createProject(makeConfig({ id: "new-project", name: "my project" }))
+    ).rejects.toThrow(/already exists/i);
+  });
+
+  it("rejects empty project id", async () => {
+    const manager = ProjectFileManager.getInstance(vault);
+
+    await expect(
+      manager.createProject(makeConfig({ id: "", name: "Valid Name" }))
+    ).rejects.toThrow(/cannot be empty/i);
+  });
+
+  it("rejects whitespace-only project id", async () => {
+    const manager = ProjectFileManager.getInstance(vault);
+
+    await expect(
+      manager.createProject(makeConfig({ id: "   ", name: "Valid Name" }))
+    ).rejects.toThrow(/cannot be empty/i);
+  });
+});

--- a/src/projects/ProjectFileManager.ts
+++ b/src/projects/ProjectFileManager.ts
@@ -1,0 +1,658 @@
+import { ProjectConfig } from "@/aiParams";
+import { ProjectContextCache } from "@/cache/projectContextCache";
+import { logError, logInfo, logWarn } from "@/logger";
+import {
+  COPILOT_PROJECT_CREATED,
+  COPILOT_PROJECT_DESCRIPTION,
+  COPILOT_PROJECT_EXCLUSIONS,
+  COPILOT_PROJECT_ID,
+  COPILOT_PROJECT_INCLUSIONS,
+  COPILOT_PROJECT_LAST_USED,
+  COPILOT_PROJECT_MAX_TOKENS,
+  COPILOT_PROJECT_MODEL_KEY,
+  COPILOT_PROJECT_NAME,
+  COPILOT_PROJECT_TEMPERATURE,
+  COPILOT_PROJECT_WEB_URLS,
+  COPILOT_PROJECT_YOUTUBE_URLS,
+  PROJECTS_UNSUPPORTED_FOLDER_NAME,
+} from "@/projects/constants";
+import { ProjectFileRecord } from "@/projects/type";
+import {
+  fetchAllProjects,
+  getProjectConfigFilePath,
+  getProjectFolderPath,
+  getProjectsFolder,
+  loadAllProjects,
+  sanitizeVaultPathSegment,
+  splitUrlsStringToArray,
+  writeProjectFrontmatter,
+} from "@/projects/projectUtils";
+import {
+  addPendingFileWrite,
+  deleteCachedProjectRecordById,
+  getCachedProjectRecordById,
+  getCachedProjectRecords,
+  isPendingFileWrite,
+  removePendingFileWrite,
+  upsertCachedProjectRecord,
+} from "@/projects/state";
+import { ensureFolderExists } from "@/utils";
+import { RecentUsageManager } from "@/utils/recentUsageManager";
+import {
+  isInVaultCache,
+  patchFrontmatter,
+  readFrontmatterViaAdapter,
+  resolveFileByPath,
+} from "@/utils/vaultAdapterUtils";
+import { normalizePath, stringifyYaml, TFile, TFolder, Vault } from "obsidian";
+import { ensureProjectsMigratedIfNeeded } from "@/projects/projectMigration";
+
+/**
+ * Project file manager (aligned with system-prompts Manager pattern).
+ *
+ * Responsibilities:
+ * - CRUD: create/update/delete project.md files
+ * - Cache: maintain in-memory list via state.ts
+ * - last-used: throttled frontmatter writes via RecentUsageManager
+ */
+export class ProjectFileManager {
+  private static instance: ProjectFileManager;
+  private vault: Vault;
+  private readonly projectLastUsedManager = new RecentUsageManager<string>();
+
+  private constructor(vault: Vault) {
+    this.vault = vault;
+  }
+
+  /**
+   * Get singleton instance.
+   * @param vault - Obsidian Vault (required on first call)
+   * @returns ProjectFileManager singleton
+   */
+  public static getInstance(vault?: Vault): ProjectFileManager {
+    if (!ProjectFileManager.instance) {
+      if (!vault) throw new Error("Vault is required for first initialization");
+      ProjectFileManager.instance = new ProjectFileManager(vault);
+    }
+    return ProjectFileManager.instance;
+  }
+
+  /**
+   * Initialize: run one-time migration from data.json if needed, then load all
+   * projects from vault files. Migration unconditionally clears settings.projectList
+   * after backing up failures to unsupported/ (no retry/merge — single source of truth).
+   */
+  public async initialize(): Promise<void> {
+    logInfo("[Projects] Initializing ProjectFileManager");
+    await ensureProjectsMigratedIfNeeded(this.vault);
+    await loadAllProjects();
+  }
+
+  /**
+   * Get cached ProjectConfig list.
+   * @returns Array of ProjectConfig
+   */
+  public getProjects(): ProjectConfig[] {
+    return getCachedProjectRecords().map((r) => r.project);
+  }
+
+  /**
+   * Get cached ProjectFileRecord list.
+   * @returns Array of ProjectFileRecord
+   */
+  public getProjectRecords(): ProjectFileRecord[] {
+    return getCachedProjectRecords();
+  }
+
+  /**
+   * Reload all projects from vault (full scan + cache replace).
+   */
+  public async reloadProjects(): Promise<ProjectFileRecord[]> {
+    return await loadAllProjects();
+  }
+
+  /**
+   * Fetch all projects from vault without updating cache.
+   */
+  public async fetchProjects(): Promise<ProjectFileRecord[]> {
+    return await fetchAllProjects();
+  }
+
+  /**
+   * Get the RecentUsageManager for project last-used timestamps (for UI sorting).
+   */
+  public getProjectUsageTimestampsManager(): RecentUsageManager<string> {
+    return this.projectLastUsedManager;
+  }
+
+  /**
+   * Sanitize a string for use as a project folder name.
+   * Typically receives the project name (or id as fallback when name is empty).
+   * Replaces path separators and control characters.
+   * Rejects reserved names that conflict with internal directories.
+   */
+  private sanitizeFolderName(input: string): string {
+    const sanitized = sanitizeVaultPathSegment(input);
+    // Reason: "unsupported" is reserved for migration failure backups
+    if (sanitized.toLowerCase() === PROJECTS_UNSUPPORTED_FOLDER_NAME) {
+      return `_${sanitized}`;
+    }
+    return sanitized;
+  }
+
+  /**
+   * Best-effort rollback: delete a file created during a failed operation.
+   * Also removes the parent folder if empty. Logs errors but never throws.
+   */
+  private async rollbackCreatedFile(filePath: string, folderPath: string): Promise<void> {
+    try {
+      const file = this.vault.getAbstractFileByPath(filePath);
+      if (file instanceof TFile) {
+        await this.vault.delete(file, true);
+      } else if (await this.vault.adapter.exists(filePath)) {
+        // Reason: hidden-folder files are not indexed by vault cache.
+        // Fall back to adapter-based deletion for consistent hidden-folder support.
+        await this.vault.adapter.remove(filePath);
+      }
+      const folder = this.vault.getAbstractFileByPath(folderPath);
+      if (folder instanceof TFolder && folder.children.length === 0) {
+        await this.vault.delete(folder, true);
+      } else if (await this.vault.adapter.exists(folderPath)) {
+        const listing = await this.vault.adapter.list(folderPath);
+        if (listing.files.length === 0 && listing.folders.length === 0) {
+          await this.vault.adapter.rmdir(folderPath, false);
+        }
+      }
+    } catch (rollbackError) {
+      logError(`[Projects] Rollback failed for ${filePath}`, rollbackError);
+    }
+  }
+
+  /**
+   * Extract the leading YAML frontmatter block (including closing marker and trailing newline).
+   * @returns The frontmatter block string, or null if none found
+   */
+  private getLeadingFrontmatterBlock(raw: string): string | null {
+    // Reason: strip optional BOM before matching, consistent with readFrontmatterFieldFromFile
+    const content = raw.replace(/^\uFEFF/, "");
+    const match = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/);
+    return match ? match[0] : null;
+  }
+
+  /**
+   * Build complete file content (frontmatter + body) for a project.
+   * Used for hidden-folder files where processFrontMatter is unavailable.
+   *
+   * @param project - ProjectConfig to serialize
+   * @param folderName - Folder name (fallback for id/name)
+   * @param timestamps - Created and last-used timestamps
+   * @returns Complete file content string
+   */
+  private buildProjectFileContent(
+    project: ProjectConfig,
+    folderName: string,
+    timestamps: { createdMs: number; lastUsedMs: number }
+  ): string {
+    const webUrls = splitUrlsStringToArray(project.contextSource?.webUrls || "");
+    const youtubeUrls = splitUrlsStringToArray(project.contextSource?.youtubeUrls || "");
+
+    const fm: Record<string, unknown> = {
+      // Reason: do NOT fallback to folderName for id — with name-based folders,
+      // folderName is derived from project name, not id.
+      [COPILOT_PROJECT_ID]: project.id.trim(),
+      [COPILOT_PROJECT_NAME]: (project.name || folderName).trim(),
+      [COPILOT_PROJECT_DESCRIPTION]: (project.description || "").trim(),
+      [COPILOT_PROJECT_MODEL_KEY]: (project.projectModelKey || "").trim(),
+      [COPILOT_PROJECT_INCLUSIONS]: project.contextSource?.inclusions || "",
+      [COPILOT_PROJECT_EXCLUSIONS]: project.contextSource?.exclusions || "",
+      [COPILOT_PROJECT_WEB_URLS]: webUrls,
+      [COPILOT_PROJECT_YOUTUBE_URLS]: youtubeUrls,
+      [COPILOT_PROJECT_CREATED]: timestamps.createdMs,
+      [COPILOT_PROJECT_LAST_USED]: timestamps.lastUsedMs,
+    };
+
+    if (project.modelConfigs?.temperature != null) {
+      fm[COPILOT_PROJECT_TEMPERATURE] = project.modelConfigs.temperature;
+    }
+    if (project.modelConfigs?.maxTokens != null) {
+      fm[COPILOT_PROJECT_MAX_TOKENS] = project.modelConfigs.maxTokens;
+    }
+
+    return `---\n${stringifyYaml(fm)}---\n${project.systemPrompt || ""}`;
+  }
+
+  /**
+   * Create a new project file (\<projectsFolder\>/\<id\>/project.md).
+   * @param project - ProjectConfig to create
+   * @returns Newly created ProjectFileRecord
+   */
+  public async createProject(project: ProjectConfig): Promise<ProjectFileRecord> {
+    // Reason: validate raw id first, then sanitize only for folder name derivation.
+    // The project.id stays as-is for stable logical identity.
+    const projectId = (project.id || "").trim();
+    if (!projectId) throw new Error("Project id cannot be empty");
+
+    if (getCachedProjectRecordById(projectId)) {
+      throw new Error(`Project id already exists: ${projectId}`);
+    }
+
+    const trimmedName = (project.name || "").trim();
+    if (trimmedName) {
+      const nameExists = getCachedProjectRecords().some(
+        (r) => r.project.name.trim().toLowerCase() === trimmedName.toLowerCase()
+      );
+      if (nameExists) {
+        throw new Error(`A project with the name "${trimmedName}" already exists`);
+      }
+    }
+
+    // Reason: derive folder name from project name for user-friendly vault browsing.
+    // Fall back to id when name is empty/whitespace.
+    const folderName = this.sanitizeFolderName(trimmedName || projectId);
+    const folderPath = getProjectFolderPath(folderName);
+    const filePath = getProjectConfigFilePath(folderName);
+
+    // Reason: detect case-insensitive folder collisions (macOS/Windows vaults are
+    // case-insensitive). Without this, "Foo" and "foo" map to the same disk folder.
+    const folderKey = folderName.toLowerCase();
+    const cachedRecords = getCachedProjectRecords();
+    const existingFolderConflict = cachedRecords.find(
+      (r) => r.folderName.toLowerCase() === folderKey && r.project.id !== projectId
+    );
+    if (existingFolderConflict) {
+      throw new Error(
+        `Folder name collision: project id "${projectId}" sanitizes to folder "${folderName}" ` +
+          `which conflicts with existing project "${existingFolderConflict.project.id}"`
+      );
+    }
+
+    try {
+      addPendingFileWrite(filePath);
+
+      await ensureFolderExists(getProjectsFolder());
+      await ensureFolderExists(folderPath);
+
+      // Reason: detect folder name collisions where a different project id sanitizes to the
+      // same folder (e.g. "a/b" and "a\\b" both produce "a_b"). Check both cache and filesystem.
+      // Uses adapter.exists() instead of getAbstractFileByPath() for hidden-folder compatibility.
+      if (await this.vault.adapter.exists(filePath)) {
+        throw new Error(
+          `Project file already exists at "${filePath}". ` +
+            `This may be a folder name collision — project id "${projectId}" sanitizes to folder "${folderName}"`
+        );
+      }
+
+      const now = Date.now();
+      const createdMs = Number.isFinite(project.created) && project.created > 0 ? project.created : now;
+      const lastUsedMs =
+        Number.isFinite(project.UsageTimestamps) && project.UsageTimestamps > 0
+          ? project.UsageTimestamps
+          : 0;
+
+      // Reason: use vault.create() return value directly instead of re-fetching via
+      // getAbstractFileByPath(), which fails for hidden folders not indexed by vault cache.
+      const file = await this.vault.create(filePath, project.systemPrompt || "");
+
+      try {
+        await writeProjectFrontmatter(file, project, folderName, { createdMs, lastUsedMs });
+      } catch (fmError) {
+        // Reason: rollback the created file to avoid leaving a "poisoned" file without frontmatter
+        await this.rollbackCreatedFile(filePath, folderPath);
+        throw fmError;
+      }
+
+      const record: ProjectFileRecord = {
+        project: { ...project, id: projectId, created: createdMs, UsageTimestamps: lastUsedMs },
+        filePath,
+        folderName,
+      };
+
+      upsertCachedProjectRecord(record);
+      logInfo(`[Projects] Created project: ${projectId} -> ${filePath}`);
+      return record;
+    } finally {
+      removePendingFileWrite(filePath);
+    }
+  }
+
+  /**
+   * Update an existing project (located by id).
+   * @param projectId - Project id to update
+   * @param nextProject - New ProjectConfig (id must match)
+   * @returns Updated ProjectFileRecord
+   */
+  public async updateProject(projectId: string, nextProject: ProjectConfig): Promise<ProjectFileRecord> {
+    const normalizedId = (projectId || "").trim();
+    if (!normalizedId) throw new Error("Project id cannot be empty");
+    if ((nextProject.id || "").trim() !== normalizedId) {
+      throw new Error("Project id mismatch: cannot change id via update");
+    }
+
+    const existing = getCachedProjectRecordById(normalizedId);
+    if (!existing) throw new Error(`Project not found: ${normalizedId}`);
+
+    const trimmedName = (nextProject.name || "").trim();
+    if (trimmedName) {
+      const nameConflict = getCachedProjectRecords().some(
+        (r) => r.project.id !== normalizedId && r.project.name.trim().toLowerCase() === trimmedName.toLowerCase()
+      );
+      if (nameConflict) {
+        throw new Error(`A project with the name "${trimmedName}" already exists`);
+      }
+    }
+
+    let filePath = existing.filePath;
+    let folderName = existing.folderName;
+
+    // Reason: when the project name changes, the folder should be renamed to match.
+    // This keeps vault browsing intuitive (folder = project name).
+    const nextFolderName = this.sanitizeFolderName(trimmedName || normalizedId);
+    let oldFilePathForPending: string | null = null;
+
+    if (nextFolderName !== existing.folderName) {
+      const newFolderPath = getProjectFolderPath(nextFolderName);
+      const newFilePath = getProjectConfigFilePath(nextFolderName);
+
+      // Check collision: cache (case-insensitive) + filesystem
+      const folderKey = nextFolderName.toLowerCase();
+      const folderConflict = getCachedProjectRecords().find(
+        (r) => r.project.id !== normalizedId && r.folderName.toLowerCase() === folderKey
+      );
+      if (folderConflict) {
+        throw new Error(
+          `Cannot rename project folder: "${nextFolderName}" conflicts with project "${folderConflict.project.name}"`
+        );
+      }
+      // Reason: on case-insensitive filesystems (macOS/Windows), a case-only rename
+      // (e.g. "foo" → "Foo") reports the old folder as "already existing". Skip the
+      // disk-conflict check when the paths differ only in case.
+      const isCaseOnlyRename =
+        newFolderPath.toLowerCase() === getProjectFolderPath(existing.folderName).toLowerCase();
+      if (!isCaseOnlyRename && (await this.vault.adapter.exists(newFolderPath))) {
+        throw new Error(
+          `Cannot rename project folder: "${newFolderPath}" already exists on disk`
+        );
+      }
+
+      // Suppress vault events for both old and new project.md paths
+      oldFilePathForPending = filePath;
+      addPendingFileWrite(oldFilePathForPending);
+      addPendingFileWrite(newFilePath);
+
+      try {
+        const oldFolderPath = getProjectFolderPath(existing.folderName);
+        // Reason: use vault-cache-aware rename when possible, adapter fallback for hidden folders
+        const folderObj = this.vault.getAbstractFileByPath(oldFolderPath);
+        if (folderObj instanceof TFolder) {
+          await this.vault.rename(folderObj, newFolderPath);
+        } else {
+          await this.vault.adapter.rename(oldFolderPath, newFolderPath);
+        }
+      } catch (renameError) {
+        // Rename failed — folder not moved, clean up pending and rethrow
+        removePendingFileWrite(oldFilePathForPending);
+        removePendingFileWrite(newFilePath);
+        throw renameError;
+      }
+
+      // Update local variables to use new paths for subsequent writes
+      filePath = newFilePath;
+      folderName = nextFolderName;
+      logInfo(
+        `[Projects] Renamed project folder: "${existing.folderName}" → "${nextFolderName}" for project ${normalizedId}`
+      );
+    }
+
+    try {
+      // Reason: only add pending-write guard when no folder rename occurred.
+      // When a rename happened, the new path was already guarded at L380 and will be
+      // cleaned up in the finally block. Adding again would leak the ref-count.
+      if (!oldFilePathForPending) {
+        addPendingFileWrite(filePath);
+      }
+
+      // Reason: use resolveFileByPath to handle both vault-cached and hidden-folder files.
+      // getAbstractFileByPath returns null for hidden folders even when the file exists on disk.
+      let file = await resolveFileByPath(app, filePath);
+      let materialized = false;
+
+      // Reason: if the file doesn't exist anywhere (e.g. legacy project merged into cache before
+      // migration completed), materialize it now so the update can proceed.
+      if (!file) {
+        logInfo(`[Projects] Materializing missing vault file for project: ${normalizedId}`);
+        const folderPath = getProjectFolderPath(folderName);
+        await ensureFolderExists(getProjectsFolder());
+        await ensureFolderExists(folderPath);
+        file = await this.vault.create(filePath, nextProject.systemPrompt || "");
+        materialized = true;
+      }
+
+      const createdMs =
+        Number.isFinite(existing.project.created) && existing.project.created > 0
+          ? existing.project.created
+          : Date.now();
+      // Reason: take the maximum of cached value and in-memory manager value to avoid
+      // clobbering a recent touchProjectLastUsed() write with a stale cached value.
+      const cachedLastUsed =
+        Number.isFinite(existing.project.UsageTimestamps) && existing.project.UsageTimestamps > 0
+          ? existing.project.UsageTimestamps
+          : 0;
+      const memoryLastUsed = this.projectLastUsedManager.getLastTouchedAt(normalizedId) ?? 0;
+      const lastUsedMs = Math.max(cachedLastUsed, memoryLastUsed);
+
+      const projectForWrite = { ...nextProject, created: createdMs, UsageTimestamps: lastUsedMs };
+
+      // Reason: processFrontMatter (used by writeProjectFrontmatter) does not work reliably
+      // on synthetic TFiles for hidden folders. Split into cached-file and adapter-based paths.
+      if (isInVaultCache(app, filePath)) {
+        // Vault-cached file: use processFrontMatter for safe field-level updates
+        try {
+          await writeProjectFrontmatter(file, projectForWrite, folderName, { createdMs, lastUsedMs });
+        } catch (fmError) {
+          if (materialized) await this.rollbackCreatedFile(filePath, getProjectFolderPath(folderName));
+          throw fmError;
+        }
+
+        // Read back the updated frontmatter block, then combine with new body in a single write
+        const rawWithFrontmatter = await this.vault.read(file);
+        const frontmatterBlock = this.getLeadingFrontmatterBlock(rawWithFrontmatter);
+        if (!frontmatterBlock) {
+          throw new Error(`Expected frontmatter block after update: ${file.path}`);
+        }
+        const separator = frontmatterBlock.endsWith("\n") ? "" : "\n";
+        await this.vault.modify(
+          file,
+          frontmatterBlock + separator + (nextProject.systemPrompt || "")
+        );
+      } else {
+        // Hidden-folder file: build complete content and write via adapter
+        const content = this.buildProjectFileContent(projectForWrite, folderName, {
+          createdMs,
+          lastUsedMs,
+        });
+        await this.vault.adapter.write(filePath, content);
+      }
+
+      const updated: ProjectFileRecord = {
+        project: { ...nextProject, created: createdMs, UsageTimestamps: lastUsedMs },
+        filePath,
+        folderName,
+      };
+
+      upsertCachedProjectRecord(updated);
+
+      logInfo(`[Projects] Updated project: ${normalizedId} -> ${filePath}`);
+      return updated;
+    } catch (writeError) {
+      // Reason: if the folder was already renamed but writing failed, roll the folder back
+      // to prevent leaving the project in an inconsistent location.
+      if (oldFilePathForPending && folderName !== existing.folderName) {
+        try {
+          const oldFolderPath = getProjectFolderPath(existing.folderName);
+          const newFolderPath = getProjectFolderPath(folderName);
+          // Reason: use vault.rename() for cached folders (same as forward rename) so
+          // the vault cache stays consistent. Fall back to adapter for hidden folders.
+          const renamedFolder = this.vault.getAbstractFileByPath(newFolderPath);
+          if (renamedFolder instanceof TFolder) {
+            await this.vault.rename(renamedFolder, oldFolderPath);
+          } else {
+            await this.vault.adapter.rename(newFolderPath, oldFolderPath);
+          }
+          logWarn(
+            `[Projects] Rolled back folder rename "${folderName}" → "${existing.folderName}" after write failure`
+          );
+        } catch (rollbackError) {
+          logError(`[Projects] Failed to rollback folder rename for ${normalizedId}`, rollbackError);
+        }
+      }
+      throw writeError;
+    } finally {
+      // Reason: mirror the add logic — only remove the non-rename guard when no rename occurred.
+      // When a rename happened, filePath points to newFilePath which was guarded at L380.
+      // Remove that single guard plus the old-path guard. No double-remove.
+      removePendingFileWrite(filePath);
+      if (oldFilePathForPending) removePendingFileWrite(oldFilePathForPending);
+    }
+  }
+
+  /**
+   * Delete a project by id. Deletes only the managed project.md file, then removes
+   * the folder if it is empty (to avoid deleting user-created files).
+   * @param projectId - Project id to delete
+   */
+  public async deleteProject(projectId: string): Promise<void> {
+    const normalizedId = (projectId || "").trim();
+    const existing = getCachedProjectRecordById(normalizedId);
+    if (!existing) {
+      logWarn(`[Projects] deleteProject: not found: ${normalizedId}`);
+      return;
+    }
+
+    const folderPath = getProjectFolderPath(existing.folderName);
+
+    try {
+      addPendingFileWrite(existing.filePath);
+
+      // Reason: delete only the managed config file to avoid destroying user files
+      // that may have been placed in the project folder. Use non-force delete so
+      // Obsidian respects the user's trash behavior (system trash / .trash folder).
+      const configFile = this.vault.getAbstractFileByPath(existing.filePath);
+      if (configFile instanceof TFile) {
+        await this.vault.delete(configFile);
+      } else if (await this.vault.adapter.exists(existing.filePath)) {
+        // Reason: hidden-folder files are not indexed by vault cache.
+        // Fall back to adapter-based deletion for consistent hidden-folder support.
+        await this.vault.adapter.remove(existing.filePath);
+      }
+
+      // Reason: clear cache immediately after file deletion to prevent phantom project
+      // state if the subsequent folder cleanup fails.
+      deleteCachedProjectRecordById(normalizedId);
+
+      // Cleanup: remove the folder only if it is empty after deleting project.md.
+      // Best-effort: the project file is already gone, so cleanup failure
+      // must not leave a phantom project in memory.
+      try {
+        const folder = this.vault.getAbstractFileByPath(folderPath);
+        if (folder instanceof TFolder && folder.children.length === 0) {
+          await this.vault.delete(folder);
+        } else if (await this.vault.adapter.exists(folderPath)) {
+          const listing = await this.vault.adapter.list(folderPath);
+          if (listing.files.length === 0 && listing.folders.length === 0) {
+            await this.vault.adapter.rmdir(folderPath, false);
+          }
+        }
+      } catch (cleanupError) {
+        logWarn(`[Projects] Failed to clean up empty project folder: ${folderPath}`, cleanupError);
+      }
+
+      // Reason: await cache clear to prevent same-ID recreation from having its
+      // fresh cache wiped by a stale async cleanup. Consistent with folder-switch path.
+      await ProjectContextCache.getInstance()
+        .clearForProject(existing.project)
+        .catch((err) => logError("[Projects] Failed to clear context cache on delete", err));
+
+      logInfo(`[Projects] Deleted project: ${normalizedId} -> ${folderPath}`);
+
+      // Reason: rescan to re-admit any previously-ignored duplicate-id files.
+      // The register won't fire (pending guard), so we trigger rescan here.
+      void loadAllProjects().catch((err) =>
+        logError("[Projects] Rescan after delete failed", err)
+      );
+    } finally {
+      removePendingFileWrite(existing.filePath);
+    }
+  }
+
+  /**
+   * Touch project last-used: memory updated immediately; frontmatter write throttled.
+   * @param projectId - Project id to touch
+   */
+  public async touchProjectLastUsed(projectId: string): Promise<void> {
+    const normalizedId = (projectId || "").trim();
+    const record = getCachedProjectRecordById(normalizedId);
+    if (!record) return;
+
+    try {
+      // 1. Update memory immediately (for UI sorting feedback)
+      this.projectLastUsedManager.touch(normalizedId);
+
+      // 2. Check if persistence is needed (throttled)
+      const timestampToPersist = this.projectLastUsedManager.shouldPersist(
+        normalizedId,
+        record.project.UsageTimestamps
+      );
+      if (timestampToPersist === null) return;
+
+      const filePath = normalizePath(record.filePath);
+      const file = await resolveFileByPath(app, filePath);
+      if (!file) return;
+
+      // Reason: use alreadyPending pattern to avoid clearing another in-flight pending write
+      const alreadyPending = isPendingFileWrite(filePath);
+      let actualPersistedValue = timestampToPersist;
+      try {
+        if (!alreadyPending) addPendingFileWrite(filePath);
+
+        if (isInVaultCache(app, filePath)) {
+          // Vault-cached file: use processFrontMatter for safe field-level update
+          await app.fileManager.processFrontMatter(file, (frontmatter) => {
+            const existing = Number(frontmatter[COPILOT_PROJECT_LAST_USED]);
+            const existingMs = Number.isFinite(existing) && existing > 0 ? existing : 0;
+            actualPersistedValue = Math.max(existingMs, timestampToPersist);
+            if (existingMs === actualPersistedValue) return;
+            frontmatter[COPILOT_PROJECT_LAST_USED] = actualPersistedValue;
+          });
+        } else {
+          // Hidden-folder file: use adapter-based frontmatter patch
+          const adapterFm = await readFrontmatterViaAdapter(app, filePath);
+          const existing = Number(adapterFm?.[COPILOT_PROJECT_LAST_USED]);
+          const existingMs = Number.isFinite(existing) && existing > 0 ? existing : 0;
+          actualPersistedValue = Math.max(existingMs, timestampToPersist);
+          if (existingMs !== actualPersistedValue) {
+            await patchFrontmatter(app, filePath, {
+              [COPILOT_PROJECT_LAST_USED]: actualPersistedValue,
+            });
+          }
+        }
+      } finally {
+        if (!alreadyPending) removePendingFileWrite(filePath);
+      }
+
+      // 3. Mark persistence successful with actual written value (for accurate throttling)
+      this.projectLastUsedManager.markPersisted(normalizedId, actualPersistedValue);
+
+      // 4. Sync cached record so updateProject() sees the latest value.
+      // Reason: re-read fresh record to avoid overwriting concurrent edits to other fields.
+      const freshRecord = getCachedProjectRecordById(normalizedId);
+      if (freshRecord) {
+        upsertCachedProjectRecord({
+          ...freshRecord,
+          project: { ...freshRecord.project, UsageTimestamps: actualPersistedValue },
+        });
+      }
+    } catch (error) {
+      logError(`[Projects] Failed to touch last-used for projectId=${projectId}`, error);
+    }
+  }
+}

--- a/src/projects/constants.ts
+++ b/src/projects/constants.ts
@@ -1,0 +1,34 @@
+import { ProjectConfig } from "@/aiParams";
+
+/**
+ * Empty project config used as default/fallback for missing fields.
+ */
+export const EMPTY_PROJECT_CONFIG: ProjectConfig = {
+  id: "",
+  name: "",
+  description: "",
+  systemPrompt: "",
+  projectModelKey: "",
+  modelConfigs: {},
+  contextSource: {},
+  created: 0,
+  UsageTimestamps: 0,
+};
+
+// Frontmatter property keys (copilot-project-* prefix to avoid user property conflicts)
+export const COPILOT_PROJECT_ID = "copilot-project-id";
+export const COPILOT_PROJECT_NAME = "copilot-project-name";
+export const COPILOT_PROJECT_DESCRIPTION = "copilot-project-description";
+export const COPILOT_PROJECT_MODEL_KEY = "copilot-project-model-key";
+export const COPILOT_PROJECT_TEMPERATURE = "copilot-project-temperature";
+export const COPILOT_PROJECT_MAX_TOKENS = "copilot-project-max-tokens";
+export const COPILOT_PROJECT_CREATED = "copilot-project-created";
+export const COPILOT_PROJECT_LAST_USED = "copilot-project-last-used";
+export const COPILOT_PROJECT_INCLUSIONS = "copilot-project-inclusions";
+export const COPILOT_PROJECT_EXCLUSIONS = "copilot-project-exclusions";
+export const COPILOT_PROJECT_WEB_URLS = "copilot-project-web-urls";
+export const COPILOT_PROJECT_YOUTUBE_URLS = "copilot-project-youtube-urls";
+
+// File structure conventions
+export const PROJECT_CONFIG_FILE_NAME = "project.md";
+export const PROJECTS_UNSUPPORTED_FOLDER_NAME = "unsupported";

--- a/src/projects/index.ts
+++ b/src/projects/index.ts
@@ -1,0 +1,7 @@
+export * from "./type";
+export * from "./constants";
+export * from "./projectUtils";
+export * from "./state";
+export { ProjectFileManager } from "./ProjectFileManager";
+export { ProjectRegister } from "./projectRegister";
+export { ensureProjectsMigratedIfNeeded, migrateProjectsFromSettingsToVault } from "./projectMigration";

--- a/src/projects/projectMigration.test.ts
+++ b/src/projects/projectMigration.test.ts
@@ -1,0 +1,66 @@
+import { deriveProjectFolderName, sanitizeVaultPathSegment } from "@/projects/projectPaths";
+
+// Mock dependencies required by projectPaths imports
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({ projectsFolder: "copilot-projects" })),
+}));
+
+describe("deriveProjectFolderName", () => {
+  it("uses project name when available", () => {
+    expect(deriveProjectFolderName("id-123", "My Project")).toBe("My Project");
+  });
+
+  it("falls back to project id when name is empty", () => {
+    expect(deriveProjectFolderName("id-123", "")).toBe("id-123");
+    expect(deriveProjectFolderName("id-123")).toBe("id-123");
+  });
+
+  it("falls back to project id when name is whitespace-only", () => {
+    expect(deriveProjectFolderName("id-123", "   ")).toBe("id-123");
+  });
+
+  it("sanitizes special characters in project name", () => {
+    const result = deriveProjectFolderName("id-1", "My/Project: v1");
+    expect(result).not.toContain("/");
+    expect(result).not.toContain(":");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('prefixes "unsupported" with underscore (reserved folder name)', () => {
+    expect(deriveProjectFolderName("id-1", "unsupported")).toBe("_unsupported");
+    expect(deriveProjectFolderName("id-1", "Unsupported")).toBe("_Unsupported");
+    expect(deriveProjectFolderName("id-1", "UNSUPPORTED")).toBe("_UNSUPPORTED");
+  });
+
+  it("preserves CJK and emoji in project names", () => {
+    expect(deriveProjectFolderName("id-1", "我的项目")).toBe("我的项目");
+    expect(deriveProjectFolderName("id-1", "🎵 Music")).toContain("🎵");
+  });
+});
+
+describe("folder name collision scenarios", () => {
+  it('different names sanitize to the same folder: "a/b" and "a|b"', () => {
+    // Both "/" and "|" are replaced with "_", so both produce "a_b"
+    const name1 = sanitizeVaultPathSegment("a/b");
+    const name2 = sanitizeVaultPathSegment("a|b");
+    // Reason: demonstrates that collision detection in migration is necessary
+    expect(name1).toBe(name2);
+  });
+
+  it("case-insensitive collision: MyProject vs myproject", () => {
+    const name1 = sanitizeVaultPathSegment("MyProject");
+    const name2 = sanitizeVaultPathSegment("myproject");
+    // Reason: on macOS/Windows, these map to the same disk folder
+    expect(name1.toLowerCase()).toBe(name2.toLowerCase());
+    // But the raw sanitized values differ in case
+    expect(name1).not.toBe(name2);
+  });
+
+  it("all-special-chars names collide at fallback underscore", () => {
+    // "***" → "___", "???" → "___" — same result
+    const name1 = sanitizeVaultPathSegment("***");
+    const name2 = sanitizeVaultPathSegment("???");
+    expect(name1).toBe(name2);
+    expect(name1).toBe("___");
+  });
+});

--- a/src/projects/projectMigration.ts
+++ b/src/projects/projectMigration.ts
@@ -60,18 +60,17 @@ async function saveFailedProjectToUnsupported(
     // Reason: use adapter.exists() instead of vault.getAbstractFileByPath() because
     // hidden folders are not indexed in the vault cache.
     while (await vault.adapter.exists(filePath)) {
-      // Reason: if the existing file is for the same project (same raw id), skip — no new backup needed.
-      // Only add a suffix when the collision is from a different project id.
+      // Reason: skip only when the existing backup is structurally identical (same id AND content).
+      // Duplicate-id entries with different content (e.g. different systemPrompt/name) must each
+      // get their own backup, otherwise the second one is unrecoverable after projectList is cleared.
       if (suffix === 2) {
-        // First collision: check if existing backup is for the same project
         try {
           const existingContent = await vault.adapter.read(filePath);
-          // Reason: parse the fenced JSON block to structurally compare project id,
-          // avoiding false positives from substring matches in name/description/systemPrompt.
           const jsonMatch = existingContent.match(/```json\s*\n([\s\S]*?)\n```/);
           if (jsonMatch) {
             const backedUpProject = JSON.parse(jsonMatch[1]);
-            if (backedUpProject?.id === project.id) return false;
+            // Reason: compare full JSON to detect same-id but different-content duplicates.
+            if (JSON.stringify(backedUpProject) === JSON.stringify(project)) return false;
           }
         } catch {
           // Can't verify — treat as collision and create suffixed backup

--- a/src/projects/projectMigration.ts
+++ b/src/projects/projectMigration.ts
@@ -1,0 +1,613 @@
+import { ProjectConfig } from "@/aiParams";
+import { ConfirmModal } from "@/components/modals/ConfirmModal";
+import { logError, logInfo, logWarn } from "@/logger";
+import {
+  COPILOT_PROJECT_ID,
+  PROJECTS_UNSUPPORTED_FOLDER_NAME,
+} from "@/projects/constants";
+import {
+  deriveProjectFolderName,
+  sanitizeVaultPathSegment,
+} from "@/projects/projectPaths";
+import {
+  ensureProjectFrontmatter,
+  getProjectConfigFilePath,
+  getProjectFolderPath,
+  getProjectsFolder,
+  getProjectsUnsupportedFolder,
+  readFrontmatterFieldFromFile,
+  scanAllProjectConfigFiles,
+  writeProjectFrontmatter,
+} from "@/projects/projectUtils";
+import { addPendingFileWrite, removePendingFileWrite } from "@/projects/state";
+import { getSettings, updateSetting } from "@/settings/model";
+import { ensureFolderExists, stripFrontmatter } from "@/utils";
+import { Notice, parseYaml, TFile, TFolder, Vault } from "obsidian";
+
+/**
+ * Normalize line endings for content comparison (avoid CRLF/LF mismatches).
+ */
+function normalizeLineEndings(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/**
+ * Save a failed migration project to unsupported/ directory as recovery backup.
+ * Best-effort: if backup itself fails, log error but don't throw
+ * (to avoid crashing the migration loop and losing the legacy data).
+ *
+ * @param vault - Vault instance
+ * @param project - Original project config
+ * @param reason - Failure reason
+ * @returns true if a new backup was created, false if it already existed or backup failed
+ */
+async function saveFailedProjectToUnsupported(
+  vault: Vault,
+  project: ProjectConfig,
+  reason: string
+): Promise<boolean> {
+  try {
+    const unsupportedFolder = getProjectsUnsupportedFolder();
+    await ensureFolderExists(unsupportedFolder);
+
+    const safeId = sanitizeVaultPathSegment(project.id || "unknown") || "unknown";
+    // Reason: use deterministic base name so repeated migration runs don't create duplicate
+    // backups for the same project. Add a collision suffix when different projects sanitize
+    // to the same id (e.g. "a/b" and "a\\b" both become "a_b").
+    const baseName = `Project Migration Failed - ${safeId}`;
+    let filePath = `${unsupportedFolder}/${baseName}.md`;
+    let suffix = 2;
+    // Reason: use adapter.exists() instead of vault.getAbstractFileByPath() because
+    // hidden folders are not indexed in the vault cache.
+    while (await vault.adapter.exists(filePath)) {
+      // Reason: if the existing file is for the same project (same raw id), skip — no new backup needed.
+      // Only add a suffix when the collision is from a different project id.
+      if (suffix === 2) {
+        // First collision: check if existing backup is for the same project
+        try {
+          const existingContent = await vault.adapter.read(filePath);
+          // Reason: parse the fenced JSON block to structurally compare project id,
+          // avoiding false positives from substring matches in name/description/systemPrompt.
+          const jsonMatch = existingContent.match(/```json\s*\n([\s\S]*?)\n```/);
+          if (jsonMatch) {
+            const backedUpProject = JSON.parse(jsonMatch[1]);
+            if (backedUpProject?.id === project.id) return false;
+          }
+        } catch {
+          // Can't verify — treat as collision and create suffixed backup
+        }
+      }
+      filePath = `${unsupportedFolder}/${baseName} - ${suffix}.md`;
+      suffix++;
+      if (suffix > 20) {
+        logWarn(`[Projects] Too many backup collisions for safeId="${safeId}", giving up`);
+        return false;
+      }
+    }
+
+    const content = [
+      `> Projects migration failed: ${reason}`,
+      ">",
+      "> This file is an automatic backup (unsupported/), for manual recovery.",
+      "> You can recreate the project from the JSON below, or fix and re-migrate.",
+      "",
+      "```json",
+      JSON.stringify(project, null, 2),
+      "```",
+      "",
+    ].join("\n");
+
+    await vault.create(filePath, content);
+    return true;
+  } catch (backupError) {
+    // Reason: backup failure must not crash migration loop or cause legacy data loss
+    logError(
+      `[Projects] Failed to save unsupported backup for project id=${project.id || "unknown"}`,
+      backupError
+    );
+    return false;
+  }
+}
+
+/**
+ * Best-effort rollback: delete a file and its parent folder if empty.
+ * Logs errors but never throws.
+ */
+async function rollbackCreatedFile(vault: Vault, filePath: string, folderPath: string): Promise<void> {
+  try {
+    const file = vault.getAbstractFileByPath(filePath);
+    if (file instanceof TFile) {
+      await vault.delete(file, true);
+    } else if (await vault.adapter.exists(filePath)) {
+      // Reason: hidden-folder files are not indexed by vault cache.
+      // Fall back to adapter-based deletion for consistent hidden-folder support.
+      await vault.adapter.remove(filePath);
+    }
+    const folder = vault.getAbstractFileByPath(folderPath);
+    if (folder instanceof TFolder && folder.children.length === 0) {
+      await vault.delete(folder, true);
+    } else if (await vault.adapter.exists(folderPath)) {
+      const listing = await vault.adapter.list(folderPath);
+      if (listing.files.length === 0 && listing.folders.length === 0) {
+        await vault.adapter.rmdir(folderPath, false);
+      }
+    }
+  } catch (rollbackError) {
+    logError(`[Projects] Migration rollback failed for ${filePath}`, rollbackError);
+  }
+}
+
+/**
+ * Write a single project to a vault file with full frontmatter.
+ *
+ * @param vault - Vault instance
+ * @param project - ProjectConfig to write
+ * @param folderName - Target folder name (typically the project id)
+ * @returns The created TFile (for hidden-folder compatibility, avoids re-fetching via vault cache)
+ */
+async function writeProjectToVaultFile(
+  vault: Vault,
+  project: ProjectConfig,
+  folderName: string
+): Promise<TFile> {
+  const projectsFolder = getProjectsFolder();
+  await ensureFolderExists(projectsFolder);
+  await ensureFolderExists(`${projectsFolder}/${folderName}`);
+
+  const filePath = getProjectConfigFilePath(folderName);
+
+  const folderPath = `${projectsFolder}/${folderName}`;
+
+  addPendingFileWrite(filePath);
+  try {
+    // Reason: use vault.create() return value directly for hidden folder compatibility.
+    const file = await vault.create(filePath, project.systemPrompt || "");
+
+    const now = Date.now();
+    const createdMs =
+      Number.isFinite(project.created) && project.created > 0 ? project.created : now;
+    const lastUsedMs =
+      Number.isFinite(project.UsageTimestamps) && project.UsageTimestamps > 0
+        ? project.UsageTimestamps
+        : 0;
+
+    try {
+      await writeProjectFrontmatter(file, project, folderName, { createdMs, lastUsedMs });
+    } catch (fmError) {
+      // Reason: rollback the created file to avoid leaving a "poisoned" file without frontmatter
+      await rollbackCreatedFile(vault, filePath, folderPath);
+      throw fmError;
+    }
+
+    return file;
+  } finally {
+    removePendingFileWrite(filePath);
+  }
+}
+
+/**
+ * Write-then-verify: check that migrated file content matches original systemPrompt.
+ * Aligned with system-prompts migration verification strategy.
+ *
+ * @param vault - Vault instance
+ * @param fileOrPath - TFile or string path (for hidden-folder compatibility)
+ * @param originalSystemPrompt - Expected body content
+ */
+async function verifyMigratedContent(
+  vault: Vault,
+  fileOrPath: TFile | string,
+  originalSystemPrompt: string
+): Promise<boolean> {
+  try {
+    // Reason: support both TFile (normal folders) and string path (hidden folders)
+    const rawContent =
+      fileOrPath instanceof TFile
+        ? await vault.read(fileOrPath)
+        : await vault.adapter.read(fileOrPath);
+    const savedContent = stripFrontmatter(rawContent, { trimStart: false });
+
+    const savedNorm = normalizeLineEndings(savedContent).replace(/^\n+/, "");
+    const originalNorm = normalizeLineEndings(originalSystemPrompt || "").replace(/^\n+/, "");
+
+    if (savedNorm !== originalNorm) {
+      logWarn(
+        `[Projects] Migration verify failed: content mismatch. ` +
+          `Expected ${originalNorm.length} chars, got ${savedNorm.length} chars`
+      );
+      return false;
+    }
+    return true;
+  } catch (error) {
+    logError("[Projects] Migration verify failed: unable to read back file", error);
+    return false;
+  }
+}
+
+/**
+ * Derive the migration folder name from project name (preferred) or id (fallback).
+ * Delegates to the shared deriveProjectFolderName utility in projectPaths.ts.
+ */
+function getMigrationFolderName(projectId: string, projectName?: string): string {
+  return deriveProjectFolderName(projectId, projectName);
+}
+
+/**
+ * Execute project migration from data.json (settings.projectList) to vault files.
+ *
+ * Safety guarantees:
+ * - write-then-verify: each file is read back and verified
+ * - unsupported/ backup: failed items are backed up for manual recovery
+ * - dirty data defense: skip duplicate ids, empty ids
+ * - retry-safe: already-migrated projects (target file exists with matching id) are skipped
+ * - clear-on-success: projectList entries are removed only for successfully migrated projects
+ *
+ * @param vault - Vault instance
+ */
+export async function migrateProjectsFromSettingsToVault(vault: Vault): Promise<void> {
+  const settings = getSettings();
+  const legacyProjects = settings.projectList || [];
+
+  if (legacyProjects.length === 0) {
+    logInfo("[Projects] No legacy projects to migrate");
+    return;
+  }
+
+  logInfo(`[Projects] Migrating ${legacyProjects.length} legacy projects to vault files...`);
+
+  const migratedEntries: ProjectConfig[] = [];
+  const seenIds = new Set<string>();
+  // Reason: track sanitized folder names (case-insensitive) to detect collisions where
+  // different ids map to the same folder. Case-insensitive because macOS/Windows vaults
+  // have case-insensitive filesystems (e.g. "MyProject" and "myproject" collide on disk).
+  const seenFolderNames = new Map<string, string>(); // lowercase folderName -> first project id
+
+  for (const project of legacyProjects) {
+    const id = (project.id || "").trim();
+
+    // Dirty data defense: skip empty ids
+    if (!id) {
+      logWarn("[Projects] Skip migrating project with empty id");
+      await saveFailedProjectToUnsupported(vault, project, "empty project id");
+      continue;
+    }
+
+    // Dirty data defense: skip duplicate ids
+    if (seenIds.has(id)) {
+      logWarn(`[Projects] Skip migrating duplicate project id: ${id}`);
+      await saveFailedProjectToUnsupported(vault, project, `duplicate project id: ${id}`);
+      continue;
+    }
+    seenIds.add(id);
+
+    const folderName = getMigrationFolderName(id, project.name);
+
+    // Dirty data defense: skip folder name collisions (case-insensitive for cross-platform safety)
+    const folderKey = folderName.toLowerCase();
+    const firstIdForFolder = seenFolderNames.get(folderKey);
+    if (firstIdForFolder) {
+      logWarn(
+        `[Projects] Skip migrating project id="${id}": folder name "${folderName}" ` +
+          `collides with id="${firstIdForFolder}"`
+      );
+      await saveFailedProjectToUnsupported(
+        vault,
+        project,
+        `folder name collision: "${folderName}" already used by id="${firstIdForFolder}"`
+      );
+      continue;
+    }
+    seenFolderNames.set(folderKey, id);
+    const filePath = getProjectConfigFilePath(folderName);
+
+    // Retry-safety: if target file already exists from a prior partial migration, skip it
+    // but only if the frontmatter id matches (to avoid treating conflict files as successful)
+    // Reason: use adapter.exists() as primary check for hidden-folder compatibility.
+    // getAbstractFileByPath() returns null for hidden folders not indexed by vault cache.
+    const existingFile = vault.getAbstractFileByPath(filePath);
+    const fileExistsOnDisk =
+      existingFile instanceof TFile || (await vault.adapter.exists(filePath));
+    if (fileExistsOnDisk) {
+      // Try metadataCache first (fast path), fall back to reading file content directly
+      // Reason: metadataCache may not be ready on startup, returning null frontmatter
+      // which would cause false conflict detection and unnecessary unsupported backups
+      let existingId = "";
+      if (existingFile instanceof TFile) {
+        const existingMeta = app.metadataCache.getFileCache(existingFile);
+        existingId = String(existingMeta?.frontmatter?.[COPILOT_PROJECT_ID] ?? "").trim();
+        if (!existingId) {
+          existingId = await readFrontmatterFieldFromFile(vault, existingFile, COPILOT_PROJECT_ID);
+        }
+      } else {
+        // Reason: hidden-folder file — read frontmatter id via adapter since TFile is unavailable.
+        // Use parseYaml (same as normal path in projectUtils) to handle quoted values, comments,
+        // and other YAML formatting that simple regex would miss on reruns.
+        try {
+          const raw = await vault.adapter.read(filePath);
+          const fmMatch = raw.replace(/^\uFEFF/, "").match(/^---\r?\n([\s\S]*?)\r?\n---/);
+          if (fmMatch) {
+            const parsed = parseYaml(fmMatch[1]);
+            if (parsed && typeof parsed === "object") {
+              existingId = String(
+                (parsed as Record<string, unknown>)[COPILOT_PROJECT_ID] ?? ""
+              ).trim();
+            }
+          }
+        } catch {
+          existingId = "";
+        }
+      }
+
+      // Reason: compare against raw id since writeProjectFrontmatter now preserves
+      // the original id. Both the legacy id and the persisted id should match directly.
+      if (existingId === id) {
+        // Reason: verify content on retry to avoid cementing a previously truncated/corrupted file.
+        // Without this, a partial first-run write would be skipped on rerun and counted as success.
+        const verified = await verifyMigratedContent(
+          vault,
+          existingFile instanceof TFile ? existingFile : filePath,
+          project.systemPrompt || ""
+        );
+        if (verified) {
+          // Reason: a partial prior migration may have written body content but incomplete
+          // frontmatter. Repair any missing fields using the authoritative legacy data.
+          // ensureProjectFrontmatter is idempotent — only fills null fields, never overwrites.
+          // Skip for hidden-folder files where TFile is unavailable (frontmatter was already
+          // written by the initial migration — can't process frontmatter without a TFile).
+          if (existingFile instanceof TFile) {
+            try {
+              const folderNameForRepair = getMigrationFolderName(id, project.name);
+              await ensureProjectFrontmatter(existingFile, {
+                project,
+                filePath,
+                folderName: folderNameForRepair,
+              });
+            } catch (repairError) {
+              logWarn(
+                `[Projects] Failed to repair frontmatter for id=${id}, continuing`,
+                repairError
+              );
+            }
+          }
+          logInfo(
+            `[Projects] Migration skip: target file already exists for id=${id} at ${filePath}`
+          );
+          // Reason: existing verified file counts as successfully migrated — clear from settings
+          migratedEntries.push(project);
+          continue;
+        }
+
+        logWarn(
+          `[Projects] Migration verify failed on existing file for id=${id} at ${filePath}`
+        );
+        await saveFailedProjectToUnsupported(
+          vault,
+          project,
+          `existing file content mismatch at ${filePath} (delete/rename the file and re-run migration)`
+        );
+        continue;
+      }
+
+      // File exists but id doesn't match — treat as conflict
+      logWarn(
+        `[Projects] Migration conflict: ${filePath} exists with id="${existingId}" but expected "${id}"`
+      );
+      await saveFailedProjectToUnsupported(
+        vault,
+        project,
+        `target file exists at ${filePath} with mismatched id="${existingId}"`
+      );
+      continue;
+    }
+
+    try {
+      const file = await writeProjectToVaultFile(vault, project, folderName);
+
+      const verified = await verifyMigratedContent(vault, file, project.systemPrompt || "");
+      if (!verified) {
+        // Reason: rollback the just-created file to prevent a permanent retry-failure loop.
+        // Without this, the existing-file branch on next restart re-detects, re-verifies,
+        // and fails again indefinitely.
+        const folderPath = `${getProjectsFolder()}/${folderName}`;
+        await rollbackCreatedFile(vault, file.path, folderPath);
+        await saveFailedProjectToUnsupported(vault, project, "content verification mismatch");
+      } else {
+        migratedEntries.push(project);
+      }
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      logError(`[Projects] Failed to migrate project id=${id}`, error);
+      await saveFailedProjectToUnsupported(vault, project, msg);
+    }
+  }
+
+  // Reason: unconditionally clear ALL legacy entries from projectList.
+  // This follows the same pattern as custom command migration (commands/migrator.ts):
+  //   - Failed projects are already backed up to unsupported/ for manual recovery
+  //   - Keeping failed entries would create a dual source of truth (settings + vault files)
+  //     which causes: startup dialog spam on every launch, stale-state bugs when users
+  //     edit/delete merged projects, and sync conflicts across devices
+  //   - The unsupported/ folder is the single recovery path for failed migrations
+  //   - If backup itself fails (extremely rare — requires filesystem write failure),
+  //     data loss is accepted as an edge case not worth the complexity of tracking
+  //     per-entry backup outcomes and retaining partial projectList state
+  updateSetting("projectList", []);
+
+  const successCount = migratedEntries.length;
+  const failedCount = legacyProjects.length - successCount;
+  const projectsFolder = getProjectsFolder();
+  const unsupportedFolder = getProjectsUnsupportedFolder();
+
+  // Reason: reveal the target folder in Obsidian's file explorer so users can
+  // quickly navigate to their migrated project files or unsupported backups.
+  const revealFolderInExplorer = (folderPath: string) => {
+    const folder = vault.getAbstractFileByPath(folderPath);
+    if (folder instanceof TFolder) {
+      // Reason: use the internal file-explorer plugin API to reveal and highlight the folder.
+      const fileExplorer = (app as any).internalPlugins?.getPluginById?.("file-explorer");
+      if (fileExplorer?.enabled && fileExplorer.instance?.revealInFolder) {
+        fileExplorer.instance.revealInFolder(folder);
+      }
+    } else {
+      // Reason: hidden-folder files are not in vault cache, so revealInFolder silently fails.
+      new Notice(`Folder "${folderPath}" is hidden and cannot be revealed in Obsidian's explorer.`);
+    }
+  };
+
+  if (failedCount === 0) {
+    logInfo(`[Projects] Migration succeeded: all ${successCount} project(s) migrated to vault files`);
+    new ConfirmModal(
+      app,
+      () => revealFolderInExplorer(projectsFolder),
+      `Your projects have been upgraded to the new file-based format. They are now stored in: ${projectsFolder}\n\nYou can now:\n• Edit project settings directly in the file\n• View and manage project files in the vault\n• All ${successCount} project(s) were migrated successfully.`,
+      "🚀 Projects Upgraded",
+      "Show in Folder",
+      "OK"
+    ).open();
+  } else if (successCount > 0) {
+    logWarn(
+      `[Projects] Migration partially succeeded: ${successCount} migrated, ${failedCount} failed`
+    );
+    new ConfirmModal(
+      app,
+      () => revealFolderInExplorer(projectsFolder),
+      `⚠️ Projects migration partially completed.\n\n✅ ${successCount} project(s) migrated successfully.\n❌ ${failedCount} project(s) failed — their data has been backed up to:\n${unsupportedFolder}\n\nYou can manually recover failed projects from the unsupported folder.`,
+      "⚠️ Projects Migration: Partial Success",
+      "Show in Folder",
+      "OK"
+    ).open();
+  } else {
+    logWarn("[Projects] Migration failed: no projects were migrated");
+    new ConfirmModal(
+      app,
+      () => revealFolderInExplorer(unsupportedFolder),
+      `⚠️ Projects migration could not be completed.\n\nYour project data has been backed up to:\n${unsupportedFolder}\n\nTo recover:\n1. Open the files in the unsupported folder\n2. Review the content\n3. Recreate the projects manually`,
+      "⚠️ Projects Migration Failed",
+      "Show in Folder",
+      "OK"
+    ).open();
+  }
+}
+
+/**
+ * Read-side fallback: auto-trigger migration when data.json has unmigrated projects.
+ *
+ * Retry-safe: even if vault already has some project files (from a prior partial migration),
+ * we still attempt migration — the migration loop will skip already-existing target files.
+ *
+ * @param vault - Vault instance
+ */
+/**
+ * Migrate existing project folders from id-based to name-based naming.
+ * Scans all project config files and renames folders where the current folder name
+ * doesn't match the sanitized project name.
+ *
+ * This is idempotent: projects already using name-based folders are skipped.
+ * Collisions are handled gracefully (skip with warning).
+ */
+async function migrateProjectFolderNames(vault: Vault): Promise<void> {
+  const { records } = await scanAllProjectConfigFiles();
+  if (records.length === 0) return;
+
+  let renamed = 0;
+  const projectsFolder = getProjectsFolder();
+  // Reason: track reserved lowercase folder names to prevent case-insensitive collisions
+  // (e.g. "Foo" and "foo" both targeting the same path on macOS/Windows).
+  // Matches the same guard used in createProject() and updateProject().
+  const reservedLowerNames = new Map<string, string>(); // lowercase folderName -> project id
+  for (const r of records) {
+    reservedLowerNames.set(r.folderName.toLowerCase(), r.project.id);
+  }
+
+  for (const record of records) {
+    const name = (record.project.name || "").trim();
+    if (!name) continue; // No name to derive folder from
+
+    const expectedFolder = sanitizeVaultPathSegment(name);
+    // Reason: handle reserved "unsupported" folder name
+    const safeFolderName =
+      expectedFolder.toLowerCase() === PROJECTS_UNSUPPORTED_FOLDER_NAME
+        ? `_${expectedFolder}`
+        : expectedFolder;
+
+    if (safeFolderName === record.folderName) continue; // Already correct
+
+    const newFolderPath = `${projectsFolder}/${safeFolderName}`;
+    const oldFolderPath = getProjectFolderPath(record.folderName);
+    const oldFilePath = record.filePath;
+    const newFilePath = getProjectConfigFilePath(safeFolderName);
+
+    // Reason: case-insensitive collision guard — skip if another project already
+    // occupies or is targeting this lowercase folder name (cross-platform safety).
+    const lowerTarget = safeFolderName.toLowerCase();
+    const existingOwner = reservedLowerNames.get(lowerTarget);
+    if (existingOwner && existingOwner !== record.project.id) {
+      logWarn(
+        `[Projects] Naming migration skip: folder "${safeFolderName}" collides (case-insensitive) ` +
+          `with project id="${existingOwner}" for project id="${record.project.id}"`
+      );
+      continue;
+    }
+
+    // Reason: on case-insensitive filesystems (macOS/Windows), a case-only rename
+    // (e.g. "foo" → "Foo") reports the old folder as "already existing". Skip the
+    // disk-conflict check when the paths differ only in case. This matches the
+    // guard in ProjectFileManager.updateProject().
+    const isCaseOnlyRename = newFolderPath.toLowerCase() === oldFolderPath.toLowerCase();
+    if (!isCaseOnlyRename && (await vault.adapter.exists(newFolderPath))) {
+      logWarn(
+        `[Projects] Naming migration skip: target folder "${newFolderPath}" already exists ` +
+          `for project id="${record.project.id}"`
+      );
+      continue;
+    }
+
+    try {
+      // Suppress vault events during rename
+      addPendingFileWrite(oldFilePath);
+      addPendingFileWrite(newFilePath);
+
+      // Reason: use vault.rename() for cache-visible folders so the vault cache updates
+      // synchronously. adapter.rename() would leave stale TFolder.children until Obsidian
+      // refreshes its cache, causing the subsequent scanAllProjectConfigFiles() to miss
+      // renamed projects. Fall back to adapter.rename() for hidden folders.
+      const folderObj = vault.getAbstractFileByPath(oldFolderPath);
+      if (folderObj instanceof TFolder) {
+        await vault.rename(folderObj, newFolderPath);
+      } else {
+        await vault.adapter.rename(oldFolderPath, newFolderPath);
+      }
+      renamed++;
+      // Update reserved names: release old folder name, claim the new one
+      reservedLowerNames.delete(record.folderName.toLowerCase());
+      reservedLowerNames.set(lowerTarget, record.project.id);
+      logInfo(
+        `[Projects] Naming migration: renamed folder "${record.folderName}" → "${safeFolderName}" ` +
+          `for project "${name}" (id=${record.project.id})`
+      );
+    } catch (error) {
+      logError(
+        `[Projects] Naming migration failed for project id="${record.project.id}"`,
+        error
+      );
+    } finally {
+      removePendingFileWrite(oldFilePath);
+      removePendingFileWrite(newFilePath);
+    }
+  }
+
+  if (renamed > 0) {
+    logInfo(`[Projects] Naming migration complete: ${renamed} folder(s) renamed`);
+  }
+}
+
+export async function ensureProjectsMigratedIfNeeded(vault: Vault): Promise<void> {
+  const legacyProjects = getSettings().projectList || [];
+  if (legacyProjects.length > 0) {
+    await migrateProjectsFromSettingsToVault(vault);
+  }
+
+  // Reason: run naming migration after data.json migration to rename id-based folders
+  // to name-based folders. This also handles pre-existing projects from before the
+  // naming convention change. Runs before loadAllProjects() in initialization flow.
+  await migrateProjectFolderNames(vault);
+}

--- a/src/projects/projectPaths.ts
+++ b/src/projects/projectPaths.ts
@@ -1,0 +1,231 @@
+import { PROJECT_CONFIG_FILE_NAME, PROJECTS_UNSUPPORTED_FOLDER_NAME } from "@/projects/constants";
+import { getSettings } from "@/settings/model";
+import { normalizePath, TAbstractFile, TFile, Vault } from "obsidian";
+
+/**
+ * Get the projects root folder path from settings.
+ * @returns Normalized vault path
+ */
+export function getProjectsFolder(): string {
+  return normalizePath(getSettings().projectsFolder);
+}
+
+/**
+ * Get the unsupported backup folder path for failed migrations.
+ * @returns Normalized vault path
+ */
+export function getProjectsUnsupportedFolder(): string {
+  return normalizePath(`${getProjectsFolder()}/${PROJECTS_UNSUPPORTED_FOLDER_NAME}`);
+}
+
+/**
+ * Get a project's folder path by folder name.
+ * @param folderName - Project folder name (typically the project id)
+ * @returns Normalized vault path
+ */
+export function getProjectFolderPath(folderName: string): string {
+  return normalizePath(`${getProjectsFolder()}/${folderName}`);
+}
+
+/**
+ * Get a project's config file (project.md) path.
+ * @param folderName - Project folder name
+ * @param folderOverride - Optional root folder override
+ * @returns Normalized vault path
+ */
+export function getProjectConfigFilePath(folderName: string, folderOverride?: string): string {
+  const root = folderOverride ? normalizePath(folderOverride) : getProjectsFolder();
+  return normalizePath(`${root}/${folderName}/${PROJECT_CONFIG_FILE_NAME}`);
+}
+
+/**
+ * Check if a file is a project config file (project.md).
+ *
+ * Rules:
+ * - Must be under projectsFolder
+ * - Path must be: \<projectsFolder\>/\<folderName\>/project.md (exactly 2 levels deep)
+ * - Excludes unsupported/ directory
+ *
+ * @param file - Vault abstract file
+ * @returns Type guard: true if file is a valid project config TFile
+ */
+export function isProjectConfigFile(file: TAbstractFile): file is TFile {
+  if (!(file instanceof TFile)) return false;
+  if (file.extension !== "md") return false;
+
+  const folder = getProjectsFolder();
+  if (!file.path.startsWith(folder + "/")) return false;
+
+  const relativePath = file.path.slice(folder.length + 1);
+  if (relativePath.startsWith(`${PROJECTS_UNSUPPORTED_FOLDER_NAME}/`)) return false;
+
+  const parts = relativePath.split("/");
+  if (parts.length !== 2) return false;
+  if (parts[1] !== PROJECT_CONFIG_FILE_NAME) return false;
+
+  return true;
+}
+
+/**
+ * Extract the project folder name from a project.md path.
+ * @param filePath - Vault path of project.md
+ * @returns Folder name, or null if path is invalid
+ */
+export function getProjectFolderNameFromConfigPath(filePath: string): string | null {
+  const folder = getProjectsFolder();
+  if (!filePath.startsWith(folder + "/")) return null;
+
+  const relativePath = filePath.slice(folder.length + 1);
+  const parts = relativePath.split("/");
+  if (parts.length !== 2 || parts[1] !== PROJECT_CONFIG_FILE_NAME) return null;
+
+  return parts[0] || null;
+}
+
+/**
+ * Sanitize a string for use as a single vault path segment.
+ * Strips path separators, Windows-reserved characters, and ASCII control characters.
+ * @param input - Raw string (e.g. project id)
+ * @returns Sanitized string safe for use as a folder/file name
+ */
+export function sanitizeVaultPathSegment(input: string): string {
+  const trimmed = (input || "").trim();
+  // eslint-disable-next-line no-control-regex
+  let sanitized = trimmed.replace(/[<>:"/\\|?*]/g, "_").replace(/[\x00-\x1F]/g, "_");
+
+  // Reason: Windows does not allow trailing dots or spaces in folder/file names
+  sanitized = sanitized.replace(/[. ]+$/g, "");
+
+  // Reason: "." and ".." are path traversal segments, not valid folder names
+  if (sanitized === "." || sanitized === "..") {
+    sanitized = sanitized.replace(/\./g, "_");
+  }
+
+  // Reason: Windows reserved device names are invalid as folder/file names (case-insensitive)
+  if (/^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i.test(sanitized)) {
+    sanitized = `_${sanitized}`;
+  }
+
+  // Reason: callers rely on non-empty return for folder/file creation
+  if (!sanitized) sanitized = "_";
+  return sanitized;
+}
+
+/**
+ * Derive the folder name for a project from its name (preferred) or id (fallback).
+ * Applies sanitization and reserves the "unsupported" folder name for migration backups.
+ *
+ * @param projectId - Project id (used as fallback when name is empty)
+ * @param projectName - Project display name (preferred source for folder name)
+ * @returns Sanitized folder name safe for use as a vault path segment
+ */
+export function deriveProjectFolderName(projectId: string, projectName?: string): string {
+  const source = (projectName || "").trim() || projectId;
+  let folderName = sanitizeVaultPathSegment(source);
+  // Reason: "unsupported" is reserved for migration failure backups
+  if (folderName.toLowerCase() === PROJECTS_UNSUPPORTED_FOLDER_NAME) {
+    folderName = `_${folderName}`;
+  }
+  return folderName;
+}
+
+/** Convert newline-separated URL string to array (for YAML frontmatter). */
+export function splitUrlsStringToArray(urlsString: string): string[] {
+  return (urlsString || "")
+    .split("\n")
+    .map((u) => u.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Read a simple `key: value` frontmatter field directly from file content.
+ * Used as fallback when metadataCache is not yet populated (e.g. on startup).
+ *
+ * @param vault - Vault instance
+ * @param file - Target file
+ * @param key - Frontmatter key to extract
+ * @returns Trimmed value string, or empty string if not found
+ */
+export async function readFrontmatterFieldFromFile(
+  vault: Vault,
+  file: TFile,
+  key: string
+): Promise<string> {
+  try {
+    const raw = await vault.cachedRead(file);
+    // Reason: handle both LF and CRLF line endings, and optional BOM for cross-platform compat
+    const fmMatch = raw.replace(/^\uFEFF/, "").match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!fmMatch) return "";
+
+    // Reason: simple line-by-line match is sufficient for single-line frontmatter values
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const lineMatch = fmMatch[1].match(new RegExp(`^${escaped}:\\s*(.+)$`, "m"));
+    if (!lineMatch) return "";
+
+    let value = lineMatch[1].trim();
+    // Reason: strip inline YAML comments (unquoted values only)
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    } else {
+      const commentIndex = value.indexOf(" #");
+      if (commentIndex > 0) {
+        value = value.slice(0, commentIndex).trim();
+      }
+    }
+    return value;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Read a YAML list field from frontmatter directly from file content.
+ * Used as fallback when metadataCache is not yet populated.
+ * Handles the `key:\n- item1\n- item2` YAML list format.
+ *
+ * @param vault - Vault instance
+ * @param file - Target file
+ * @param key - Frontmatter key to extract
+ * @returns Array of string values
+ */
+export async function readFrontmatterListFromFile(
+  vault: Vault,
+  file: TFile,
+  key: string
+): Promise<string[]> {
+  try {
+    const raw = await vault.cachedRead(file);
+    const fmMatch = raw.replace(/^\uFEFF/, "").match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!fmMatch) return [];
+
+    const lines = fmMatch[1].split(/\r?\n/);
+    const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const keyRegex = new RegExp(`^${escaped}:\\s*$`);
+
+    let collecting = false;
+    const items: string[] = [];
+
+    for (const line of lines) {
+      if (keyRegex.test(line)) {
+        collecting = true;
+        continue;
+      }
+      if (collecting) {
+        // Reason: YAML list items start with "- ", stop collecting on any non-list line
+        const listMatch = line.match(/^\s*-\s+(.+)$/);
+        if (listMatch) {
+          const val = listMatch[1].trim();
+          if (val) items.push(val);
+        } else {
+          break;
+        }
+      }
+    }
+    return items;
+  } catch {
+    return [];
+  }
+}

--- a/src/projects/projectRegister.ts
+++ b/src/projects/projectRegister.ts
@@ -45,13 +45,20 @@ export class ProjectRegister {
   constructor(vault: Vault) {
     this.vault = vault;
     this.manager = ProjectFileManager.getInstance(vault);
-    this.initializeEventListeners();
   }
 
   /**
-   * Initialize: load all projects (internally runs read-side fallback migration).
+   * Initialize: register vault listeners and load all projects.
+   *
+   * Reason: listeners must be registered here (not in the constructor) because
+   * the constructor runs during plugin onload(), before onLayoutReady(). Obsidian's
+   * Vault.on("create") fires for every existing file during the initial vault load,
+   * which would trigger premature cache mutations and ensureProjectFrontmatter writes
+   * before migration has completed. Deferring to initialize() (called from
+   * onLayoutReady) avoids this race.
    */
   async initialize(): Promise<void> {
+    this.initializeEventListeners();
     await this.manager.initialize();
   }
 

--- a/src/projects/projectRegister.ts
+++ b/src/projects/projectRegister.ts
@@ -1,0 +1,449 @@
+import { getCurrentProject } from "@/aiParams";
+import { ProjectContextCache } from "@/cache/projectContextCache";
+import { logError, logInfo, logWarn } from "@/logger";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import {
+  ensureProjectFrontmatter,
+  getProjectsFolder,
+  isProjectConfigFile,
+  parseProjectConfigFile,
+} from "@/projects/projectUtils";
+import {
+  deleteCachedProjectRecordByFilePath,
+  getCachedProjectRecordByFilePath,
+  getCachedProjectRecordById,
+  getCachedProjectRecords,
+  isPendingFileWrite,
+  replaceCachedProjectRecordByFilePath,
+  updateCachedProjectRecords,
+  upsertCachedProjectRecord,
+} from "@/projects/state";
+import { loadAllProjects } from "@/projects/projectUtils";
+import { PROJECT_CONFIG_FILE_NAME, PROJECTS_UNSUPPORTED_FOLDER_NAME } from "@/projects/constants";
+import { getSettings, subscribeToSettingsChange } from "@/settings/model";
+import debounce from "lodash.debounce";
+import { Notice, TAbstractFile, Vault } from "obsidian";
+
+/**
+ * Project Register: manages vault event listeners and cache synchronization.
+ * Aligned with system-prompts Register pattern.
+ *
+ * Responsibilities:
+ * - Auto-sync project.md create/modify/delete/rename to in-memory cache
+ * - Listen for projectsFolder setting changes with latest-wins reload
+ * - Avoid event loops from pending file writes
+ */
+export class ProjectRegister {
+  private vault: Vault;
+  private manager: ProjectFileManager;
+  private settingsUnsubscriber?: () => void;
+  /** Monotonic request id for latest-wins semantics on folder change. */
+  private folderChangeRequestId = 0;
+  /** Per-file debounced modify handlers to avoid cross-file debounce collisions. */
+  private fileModifyDebouncers = new Map<string, ReturnType<typeof debounce>>();
+
+  constructor(vault: Vault) {
+    this.vault = vault;
+    this.manager = ProjectFileManager.getInstance(vault);
+    this.initializeEventListeners();
+  }
+
+  /**
+   * Initialize: load all projects (internally runs read-side fallback migration).
+   */
+  async initialize(): Promise<void> {
+    await this.manager.initialize();
+  }
+
+  /**
+   * Cleanup event listeners (called on plugin unload).
+   */
+  cleanup(): void {
+    for (const d of this.fileModifyDebouncers.values()) d.cancel();
+    this.fileModifyDebouncers.clear();
+    this.debouncedFolderChange.cancel();
+    this.settingsUnsubscriber?.();
+
+    this.vault.off("create", this.handleFileCreation);
+    this.vault.off("delete", this.handleFileDeletion);
+    this.vault.off("rename", this.handleFileRename);
+    this.vault.off("modify", this.handleFileModify);
+  }
+
+  /**
+   * Wire up vault event listeners and settings subscription.
+   */
+  private initializeEventListeners(): void {
+    this.vault.on("create", this.handleFileCreation);
+    this.vault.on("delete", this.handleFileDeletion);
+    this.vault.on("rename", this.handleFileRename);
+    this.vault.on("modify", this.handleFileModify);
+    this.settingsUnsubscriber = subscribeToSettingsChange(this.handleSettingsChange);
+  }
+
+  /**
+   * Settings change handler: react to projectsFolder changes.
+   */
+  private handleSettingsChange = (
+    prev: ReturnType<typeof getSettings>,
+    next: ReturnType<typeof getSettings>
+  ): void => {
+    if (prev.projectsFolder !== next.projectsFolder) {
+      this.debouncedFolderChange(next.projectsFolder);
+    }
+  };
+
+  /**
+   * Debounced folder change handler (avoid rapid-fire during user typing).
+   */
+  private debouncedFolderChange = debounce(
+    (nextFolder: string) => {
+      void this.handleProjectsFolderChange(nextFolder);
+    },
+    1000,
+    { leading: false, trailing: true }
+  );
+
+  /**
+   * Handle projectsFolder change: success-then-replace reload with latest-wins.
+   */
+  private async handleProjectsFolderChange(nextFolder: string): Promise<void> {
+    const currentRequestId = ++this.folderChangeRequestId;
+
+    try {
+      const nextRecords = await this.manager.fetchProjects();
+
+      // Latest-wins: discard stale results
+      if (currentRequestId !== this.folderChangeRequestId) return;
+
+      // Reason: old folder's debouncers are stale after folder change
+      for (const d of this.fileModifyDebouncers.values()) d.cancel();
+      this.fileModifyDebouncers.clear();
+
+      // Reason: await old cache clears before installing new records to prevent
+      // same-id race: fire-and-forget clears could delete freshly rebuilt cache.
+      const oldRecords = getCachedProjectRecords();
+      const cache = ProjectContextCache.getInstance();
+      await Promise.all(
+        oldRecords.map((old) =>
+          cache.clearForProject(old.project).catch((err) =>
+            logError("[Projects] Failed to clear context cache on folder switch", err)
+          )
+        )
+      );
+
+      updateCachedProjectRecords(nextRecords);
+
+      // Reason: don't call setCurrentProject(null) here — ProjectManager's
+      // records subscriber will detect the disappearance after updateCachedProjectRecords
+      // and handle save-first ordering via switchProject(null).
+      const current = getCurrentProject();
+      if (current) {
+        const stillExists = getCachedProjectRecordById(current.id);
+        if (!stillExists) {
+          new Notice(`Project "${current.name}" not found in new folder. Cleared selection.`);
+        }
+      }
+
+      logInfo(`[Projects] Folder changed -> reloaded: ${nextFolder}`);
+      new Notice(`Projects folder updated: ${nextFolder}`);
+    } catch (error) {
+      // Reason: latest-wins guard — discard stale failure from an earlier request
+      // that resolved after a newer successful reload.
+      if (currentRequestId !== this.folderChangeRequestId) return;
+
+      // Reason: clear stale cache on failure to avoid split-brain storage where
+      // creates go to the new folder while edits/deletes target old cached paths.
+      for (const d of this.fileModifyDebouncers.values()) d.cancel();
+      this.fileModifyDebouncers.clear();
+
+      // Reason: clear context caches before wiping records to prevent same-id
+      // projects from reusing stale context on a later retry.
+      const oldRecords = getCachedProjectRecords();
+      const cache = ProjectContextCache.getInstance();
+      await Promise.all(
+        oldRecords.map((old) =>
+          cache.clearForProject(old.project).catch((err) =>
+            logError("[Projects] Failed to clear context cache on folder switch failure", err)
+          )
+        )
+      );
+
+      updateCachedProjectRecords([]);
+
+      logError(`[Projects] Failed to reload after folder change: ${nextFolder}`, error);
+      new Notice(`Failed to reload projects from "${nextFolder}". Projects cleared — reopen settings to retry.`);
+    }
+  }
+
+  /**
+   * String-level check if oldPath could be a project config path (for rename events).
+   */
+  private isProjectConfigPathString(oldPath: string): boolean {
+    const folder = getProjectsFolder();
+    if (!oldPath.startsWith(folder + "/")) return false;
+
+    const relativePath = oldPath.slice(folder.length + 1);
+    if (relativePath.startsWith(`${PROJECTS_UNSUPPORTED_FOLDER_NAME}/`)) return false;
+
+    const parts = relativePath.split("/");
+    return parts.length === 2 && parts[1] === PROJECT_CONFIG_FILE_NAME;
+  }
+
+  /**
+   * File creation event: parse and upsert to cache; ensure frontmatter if needed.
+   */
+  private handleFileCreation = async (file: TAbstractFile) => {
+    if (!isProjectConfigFile(file) || isPendingFileWrite(file.path)) return;
+
+    try {
+      const record = await parseProjectConfigFile(file);
+      if (!record) return;
+
+      // Duplicate id: keep first in cache, ignore incoming
+      const existing = getCachedProjectRecordById(record.project.id);
+      if (existing && existing.filePath !== record.filePath) {
+        logWarn(
+          `[Projects] Duplicate id="${record.project.id}": ` +
+            `existing=${existing.filePath}, incoming=${record.filePath}; ignored`
+        );
+        return;
+      }
+
+      await ensureProjectFrontmatter(file, record);
+      const updated = await parseProjectConfigFile(file);
+      if (updated) upsertCachedProjectRecord(updated);
+    } catch (error) {
+      logError(`[Projects] Error on file creation: ${file.path}`, error);
+    }
+  };
+
+  /**
+   * File deletion event: remove from cache by filePath.
+   * If deleted project is currently selected, clear the selection.
+   */
+  private handleFileDeletion = async (file: TAbstractFile) => {
+    if (!isProjectConfigFile(file) || isPendingFileWrite(file.path)) return;
+
+    this.evictFileModifyDebouncer(file.path);
+
+    try {
+      const record = getCachedProjectRecordByFilePath(file.path);
+      deleteCachedProjectRecordByFilePath(file.path);
+
+      // Reason: if the deleted file was the current project, clear selection to avoid UI pointing
+      // to a non-existent project (aligned with system-prompts delete handler).
+      if (record) {
+        // Reason: don't call setCurrentProject(null) here — ProjectManager's
+        // records subscriber will detect the disappearance and handle save-first
+        // ordering via switchProject(null) to avoid misclassifying the chat.
+        const current = getCurrentProject();
+        if (current?.id === record.project.id) {
+          new Notice(`Project "${record.project.name}" was deleted.`);
+        }
+
+        // Reason: await cache clear to prevent same-ID recreation from having its
+        // fresh cache wiped by a stale async cleanup. Consistent with folder-switch path.
+        await ProjectContextCache.getInstance()
+          .clearForProject(record.project)
+          .catch((err) => logError("[Projects] Failed to clear context cache on external delete", err));
+
+        // Reason: rescan to re-admit any previously-ignored duplicate-id files
+        // that were hidden while the deleted file was the "kept" entry.
+        // Re-merge legacy projects after rescan so unmigrated fallback entries stay visible.
+        void loadAllProjects().catch((err) =>
+          logError("[Projects] Rescan after delete failed", err)
+        );
+      }
+    } catch (error) {
+      logError(`[Projects] Error on file deletion: ${file.path}`, error);
+    }
+  };
+
+  /**
+   * File rename event: sync cache for old/new paths.
+   * If renamed out of projects folder and was current project, clear selection.
+   */
+  private handleFileRename = async (file: TAbstractFile, oldPath: string) => {
+    if (isPendingFileWrite(file.path) || isPendingFileWrite(oldPath)) return;
+
+    const wasValid = this.isProjectConfigPathString(oldPath);
+    const isValidNow = isProjectConfigFile(file);
+
+    if (!wasValid && !isValidNow) return;
+
+    if (wasValid) this.evictFileModifyDebouncer(oldPath);
+
+    try {
+      const oldRecord = wasValid ? getCachedProjectRecordByFilePath(oldPath) : undefined;
+
+      // Reason: validate the new file before deleting the old cache entry,
+      // so a duplicate-ID rename doesn't leave a cache gap.
+      if (isValidNow) {
+        const record = await parseProjectConfigFile(file);
+        if (!record) {
+          if (wasValid) deleteCachedProjectRecordByFilePath(oldPath);
+          return;
+        }
+
+        // Reason: check for duplicate ID, but exclude the old record being renamed
+        // (self-rename: existing.filePath === oldPath means it's the same project).
+        const existing = getCachedProjectRecordById(record.project.id);
+        const isTrueDuplicate =
+          existing && existing.filePath !== record.filePath && existing.filePath !== oldPath;
+
+        if (isTrueDuplicate) {
+          if (wasValid) deleteCachedProjectRecordByFilePath(oldPath);
+          logWarn(
+            `[Projects] Duplicate id="${record.project.id}" after rename: ` +
+              `existing=${existing.filePath}, incoming=${record.filePath}; ignored`
+          );
+          return;
+        }
+
+        await ensureProjectFrontmatter(file, record);
+        const updated = await parseProjectConfigFile(file);
+        if (updated) {
+          // Reason: use atomic replace to avoid transient disappearance gap.
+          // delete+upsert causes the subscriber to see the active project as missing
+          // and trigger switchProject(null) during valid renames.
+          if (wasValid) {
+            replaceCachedProjectRecordByFilePath(oldPath, updated);
+          } else {
+            upsertCachedProjectRecord(updated);
+          }
+        } else if (wasValid) {
+          deleteCachedProjectRecordByFilePath(oldPath);
+        }
+      } else if (wasValid) {
+        deleteCachedProjectRecordByFilePath(oldPath);
+      }
+
+      // Reason: project moved out of projects folder → clear current selection and context cache
+      if (wasValid && !isValidNow && oldRecord) {
+        // Reason: don't call setCurrentProject(null) here — ProjectManager's
+        // records subscriber handles save-first ordering via switchProject(null).
+        const current = getCurrentProject();
+        if (current?.id === oldRecord.project.id) {
+          new Notice(`Project "${oldRecord.project.name}" was moved.`);
+        }
+
+        // Reason: await cache clear to prevent same-ID recreation from having its
+        // fresh cache wiped by a stale async cleanup. Consistent with folder-switch path.
+        await ProjectContextCache.getInstance()
+          .clearForProject(oldRecord.project)
+          .catch((err) => logError("[Projects] Failed to clear context cache on rename-out", err));
+
+        // Reason: rescan to re-admit any previously-ignored duplicate-id files
+        // that were hidden while the moved file was the "kept" entry.
+        void loadAllProjects().catch((err) =>
+          logError("[Projects] Rescan after rename-out failed", err)
+        );
+      }
+    } catch (error) {
+      logError(`[Projects] Error on file rename: ${oldPath} -> ${file.path}`, error);
+    }
+  };
+
+  /** Cancel and remove a per-file debouncer (on delete/rename/folder change). */
+  private evictFileModifyDebouncer(filePath: string): void {
+    const d = this.fileModifyDebouncers.get(filePath);
+    if (d) {
+      d.cancel();
+      this.fileModifyDebouncers.delete(filePath);
+    }
+  }
+
+  /**
+   * Process a single file modify: parse and update cache.
+   */
+  private async processFileModify(file: TAbstractFile): Promise<void> {
+    // Reason: second guard — a new pending write may have started during the debounce window
+    if (!isProjectConfigFile(file) || isPendingFileWrite(file.path)) return;
+
+    try {
+      const record = await parseProjectConfigFile(file);
+      if (!record) {
+        // Reason: file became invalid YAML — remove stale cache entry and clear selection
+        // if this was the active project, so UI and chain don't use stale config.
+        const staleRecord = getCachedProjectRecordByFilePath(file.path);
+        deleteCachedProjectRecordByFilePath(file.path);
+        if (staleRecord) {
+          void ProjectContextCache.getInstance()
+            .clearForProject(staleRecord.project)
+            .catch((err) => logError("[Projects] Failed to clear context cache on invalid edit", err));
+          // Reason: rescan to re-admit previously-ignored duplicate-id files
+          void loadAllProjects().catch((err) =>
+            logError("[Projects] Rescan after invalid edit failed", err)
+          );
+        }
+        return;
+      }
+
+      const existing = getCachedProjectRecordById(record.project.id);
+      if (existing && existing.filePath !== record.filePath) {
+        // Reason: another file already owns this id. Remove stale entry.
+        const staleRecord = getCachedProjectRecordByFilePath(file.path);
+        deleteCachedProjectRecordByFilePath(file.path);
+        if (staleRecord) {
+          void ProjectContextCache.getInstance()
+            .clearForProject(staleRecord.project)
+            .catch((err) => logError("[Projects] Failed to clear context cache on duplicate edit", err));
+          // Reason: rescan to re-admit previously-ignored duplicate-id files
+          void loadAllProjects().catch((err) =>
+            logError("[Projects] Rescan after duplicate edit failed", err)
+          );
+        }
+        logWarn(
+          `[Projects] Duplicate id="${record.project.id}" on modify: ` +
+            `existing=${existing.filePath}, incoming=${record.filePath}; ignored`
+        );
+        return;
+      }
+
+      // Reason: if the user edited copilot-project-id directly, clear the old id's
+      // context cache to prevent stale context resurrection when the old id is reused.
+      const oldRecord = getCachedProjectRecordByFilePath(file.path);
+      if (oldRecord && oldRecord.project.id !== record.project.id) {
+        await ProjectContextCache.getInstance()
+          .clearForProject(oldRecord.project)
+          .catch((err) => logError("[Projects] Failed to clear context cache on id change", err));
+      }
+
+      // Reason: single atomic write avoids transient gap where subscribers see the project disappear
+      replaceCachedProjectRecordByFilePath(file.path, record);
+    } catch (error) {
+      logError(`[Projects] Error on file modify: ${file.path}`, error);
+    }
+  }
+
+  /**
+   * Get or create a per-file debounced modify handler.
+   * Reason: per-file debounce avoids cross-file collisions where modifying projectA
+   * within the debounce window of projectB would drop projectB's cache update.
+   */
+  private getFileModifyDebouncer(filePath: string): ReturnType<typeof debounce> {
+    let d = this.fileModifyDebouncers.get(filePath);
+    if (!d) {
+      d = debounce(
+        (file: TAbstractFile) => {
+          void this.processFileModify(file);
+        },
+        1000,
+        { leading: false, trailing: true }
+      );
+      this.fileModifyDebouncers.set(filePath, d);
+    }
+    return d;
+  }
+
+  /**
+   * File modify event: filter pending writes at event time (before debounce),
+   * so the guard is checked when the event fires, not 1s later when the pending flag
+   * may already be cleared. Uses per-file debounce to avoid cross-file collisions.
+   */
+  private handleFileModify = (file: TAbstractFile): void => {
+    if (!isProjectConfigFile(file) || isPendingFileWrite(file.path)) return;
+    this.getFileModifyDebouncer(file.path)(file);
+  };
+}

--- a/src/projects/projectUtils.test.ts
+++ b/src/projects/projectUtils.test.ts
@@ -1,0 +1,237 @@
+import { TFile } from "obsidian";
+import { parseProjectConfigFile, sanitizeVaultPathSegment } from "@/projects/projectUtils";
+
+// Mock deep dependencies to avoid transitive import chains
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({ projectsFolder: "copilot-projects" })),
+}));
+
+jest.mock("@/projects/state", () => ({
+  addPendingFileWrite: jest.fn(),
+  removePendingFileWrite: jest.fn(),
+  isPendingFileWrite: jest.fn(() => false),
+  updateCachedProjectRecords: jest.fn(),
+}));
+
+jest.mock("@/logger", () => ({
+  logWarn: jest.fn(),
+  logError: jest.fn(),
+  logInfo: jest.fn(),
+}));
+
+// Helper: create a minimal TFile mock for a project config path
+function makeMockFile(path: string): TFile {
+  return {
+    path,
+    name: "project.md",
+    basename: "project",
+    extension: "md",
+    stat: { ctime: 1000, mtime: 1000, size: 0 },
+    vault: {} as never,
+    parent: null,
+  } as unknown as TFile;
+}
+
+// Helper: set up the global `app` mock used by parseProjectConfigFile
+function setupAppMock(rawContent: string, frontmatter: Record<string, unknown> | null) {
+  (global as Record<string, unknown>).app = {
+    vault: {
+      read: jest.fn().mockResolvedValue(rawContent),
+      // Reason: parseProjectConfigFile uses `cachedFile instanceof TFile` to detect synthetic TFiles.
+      // Return an object with TFile prototype so tests exercise the vault.read() path by default.
+      getAbstractFileByPath: jest.fn((path: string) =>
+        Object.assign(Object.create(TFile.prototype), { path })
+      ),
+      adapter: { read: jest.fn().mockResolvedValue(rawContent) },
+    },
+    metadataCache: {
+      // Reason: returning null forces the fallback YAML parse path in parseProjectConfigFile
+      getFileCache: jest.fn().mockReturnValue(frontmatter ? { frontmatter } : null),
+    },
+  };
+}
+
+describe("parseProjectConfigFile", () => {
+  const VALID_PATH = "copilot-projects/my-project/project.md";
+
+  it("returns null when YAML frontmatter is malformed", async () => {
+    // Malformed YAML: unbalanced braces cause a parse error
+    const malformedContent = "---\nname: {bad: yaml: here\n---\nBody text";
+    // Force the metadata-cache miss so the fallback YAML parser runs
+    setupAppMock(malformedContent, null);
+
+    const file = makeMockFile(VALID_PATH);
+    const result = await parseProjectConfigFile(file);
+
+    expect(result).toBeNull();
+  });
+
+  it("correctly parses valid frontmatter with all fields", async () => {
+    const rawContent = [
+      "---",
+      "copilot-project-id: my-project",
+      "copilot-project-name: My Project",
+      "copilot-project-description: A test project",
+      "copilot-project-model-key: gpt-4",
+      "copilot-project-temperature: 0.7",
+      "copilot-project-max-tokens: 2048",
+      "copilot-project-inclusions: notes/",
+      "copilot-project-exclusions: archive/",
+      "copilot-project-web-urls:",
+      "  - https://example.com",
+      "copilot-project-youtube-urls: []",
+      "copilot-project-created: 1700000000000",
+      "copilot-project-last-used: 1700000001000",
+      "---",
+      "System prompt body",
+    ].join("\n");
+
+    // Use metadata-cache path (non-null frontmatter) for the happy path
+    setupAppMock(rawContent, {
+      "copilot-project-id": "my-project",
+      "copilot-project-name": "My Project",
+      "copilot-project-description": "A test project",
+      "copilot-project-model-key": "gpt-4",
+      "copilot-project-temperature": 0.7,
+      "copilot-project-max-tokens": 2048,
+      "copilot-project-inclusions": "notes/",
+      "copilot-project-exclusions": "archive/",
+      "copilot-project-web-urls": ["https://example.com"],
+      "copilot-project-youtube-urls": [],
+      "copilot-project-created": 1700000000000,
+      "copilot-project-last-used": 1700000001000,
+    });
+
+    const file = makeMockFile(VALID_PATH);
+    const result = await parseProjectConfigFile(file);
+
+    expect(result).not.toBeNull();
+    expect(result!.project.id).toBe("my-project");
+    expect(result!.project.name).toBe("My Project");
+    expect(result!.project.description).toBe("A test project");
+    expect(result!.project.projectModelKey).toBe("gpt-4");
+    expect(result!.project.modelConfigs?.temperature).toBe(0.7);
+    expect(result!.project.modelConfigs?.maxTokens).toBe(2048);
+    expect(result!.project.contextSource?.inclusions).toBe("notes/");
+    expect(result!.project.contextSource?.exclusions).toBe("archive/");
+    expect(result!.project.contextSource?.webUrls).toBe("https://example.com");
+    expect(result!.project.created).toBe(1700000000000);
+    expect(result!.project.UsageTimestamps).toBe(1700000001000);
+    expect(result!.filePath).toBe(VALID_PATH);
+    expect(result!.folderName).toBe("my-project");
+  });
+
+  it("returns null when copilot-project-id is missing from frontmatter", async () => {
+    const rawContent = [
+      "---",
+      "copilot-project-name: My Project",
+      "---",
+      "Body text",
+    ].join("\n");
+
+    setupAppMock(rawContent, {
+      "copilot-project-name": "My Project",
+    });
+
+    const file = makeMockFile(VALID_PATH);
+    const result = await parseProjectConfigFile(file);
+
+    // Reason: files without copilot-project-id are treated as corrupted and skipped.
+    // With name-based folders, folderName can no longer serve as id fallback.
+    expect(result).toBeNull();
+  });
+});
+
+describe("sanitizeVaultPathSegment", () => {
+  it("blocks path traversal with ../", () => {
+    // Reason: the slash is the dangerous part — removing it prevents escaping the project folder.
+    // The dots themselves are harmless once the separator is gone.
+    const result = sanitizeVaultPathSegment("../foo");
+    expect(result).not.toContain("/");
+    expect(result).not.toContain("\\");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("replaces forward slashes in nested paths", () => {
+    // "foo/bar" would escape the project folder — slash must be replaced
+    const result = sanitizeVaultPathSegment("foo/bar");
+    expect(result).not.toContain("/");
+  });
+
+  it("handles double-dot without slash (foo..bar)", () => {
+    // "foo..bar" is not a traversal segment but should pass through safely
+    const result = sanitizeVaultPathSegment("foo..bar");
+    // Must not be empty and must not equal the traversal sentinels
+    expect(result).not.toBe(".");
+    expect(result).not.toBe("..");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("replaces all invalid filename characters with underscores", () => {
+    const result = sanitizeVaultPathSegment('<>:"/\\|?*');
+    expect(result).toBe("_________");
+    expect(result).not.toMatch(/[<>:"/\\|?*]/);
+  });
+
+  it("handles mixed valid and invalid characters", () => {
+    const result = sanitizeVaultPathSegment("My Project: v1.0 <beta>");
+    expect(result).not.toContain(":");
+    expect(result).not.toContain("<");
+    expect(result).not.toContain(">");
+    expect(result).toContain("My Project");
+  });
+
+  it("preserves CJK characters unchanged", () => {
+    expect(sanitizeVaultPathSegment("我的项目")).toBe("我的项目");
+    expect(sanitizeVaultPathSegment("プロジェクト")).toBe("プロジェクト");
+    expect(sanitizeVaultPathSegment("프로젝트")).toBe("프로젝트");
+  });
+
+  it("preserves emoji characters", () => {
+    const result = sanitizeVaultPathSegment("🎵 Piano Notes");
+    expect(result).toContain("🎵");
+    expect(result).toContain("Piano Notes");
+  });
+
+  it("does not truncate long names", () => {
+    const longName = "a".repeat(300);
+    expect(sanitizeVaultPathSegment(longName)).toBe(longName);
+  });
+
+  it("converts all-special-characters to underscores", () => {
+    expect(sanitizeVaultPathSegment("***")).toBe("___");
+  });
+
+  it("returns fallback for whitespace-only input", () => {
+    expect(sanitizeVaultPathSegment("   ")).toBe("_");
+  });
+
+  it("strips trailing dots and spaces (Windows compat)", () => {
+    expect(sanitizeVaultPathSegment("project...")).toBe("project");
+    expect(sanitizeVaultPathSegment("project   ")).toBe("project");
+    expect(sanitizeVaultPathSegment("project. . .")).toBe("project");
+  });
+
+  it("prefixes Windows reserved device names", () => {
+    expect(sanitizeVaultPathSegment("CON")).toBe("_CON");
+    expect(sanitizeVaultPathSegment("prn")).toBe("_prn");
+    expect(sanitizeVaultPathSegment("NUL")).toBe("_NUL");
+    expect(sanitizeVaultPathSegment("COM1")).toBe("_COM1");
+    expect(sanitizeVaultPathSegment("LPT9")).toBe("_LPT9");
+  });
+
+  it("replaces control characters with underscores", () => {
+    expect(sanitizeVaultPathSegment("abc\x00def")).toBe("abc_def");
+    expect(sanitizeVaultPathSegment("test\x1Fname")).toBe("test_name");
+  });
+
+  it("returns fallback for empty string", () => {
+    expect(sanitizeVaultPathSegment("")).toBe("_");
+  });
+
+  it("converts lone dot and double-dot to fallback", () => {
+    // Reason: "." and ".." have trailing dots stripped first, then become empty → fallback "_"
+    expect(sanitizeVaultPathSegment(".")).toBe("_");
+    expect(sanitizeVaultPathSegment("..")).toBe("_");
+  });
+});

--- a/src/projects/projectUtils.ts
+++ b/src/projects/projectUtils.ts
@@ -204,12 +204,18 @@ export async function parseProjectConfigFile(file: TFile): Promise<ProjectFileRe
   // Reason: frontmatter id is the sole authoritative identity. Do NOT fallback to folderName
   // because with name-based folders, folderName is derived from project name, not id.
   // Files missing copilot-project-id are treated as corrupted and skipped.
-  const idFromFrontmatter = coerceFrontmatterString(frontmatter?.[COPILOT_PROJECT_ID], "").trim();
-  if (!idFromFrontmatter) {
+  // Reason: YAML scalar typing can parse bare numeric ids (e.g. `copilot-project-id: 123`)
+  // as numbers. Coerce to string so valid numeric ids are not silently dropped.
+  const rawId = frontmatter?.[COPILOT_PROJECT_ID];
+  const idFromFrontmatter =
+    typeof rawId === "number" && Number.isFinite(rawId)
+      ? String(rawId)
+      : coerceFrontmatterString(rawId, "");
+  if (!idFromFrontmatter.trim()) {
     logWarn(`[Projects] Missing ${COPILOT_PROJECT_ID} in frontmatter, skipping file: ${file.path}`);
     return null;
   }
-  const projectId = idFromFrontmatter;
+  const projectId = idFromFrontmatter.trim();
 
   const nameFromFrontmatter = coerceFrontmatterString(
     frontmatter?.[COPILOT_PROJECT_NAME],

--- a/src/projects/projectUtils.ts
+++ b/src/projects/projectUtils.ts
@@ -1,0 +1,477 @@
+import { ProjectConfig } from "@/aiParams";
+import {
+  COPILOT_PROJECT_CREATED,
+  COPILOT_PROJECT_DESCRIPTION,
+  COPILOT_PROJECT_EXCLUSIONS,
+  COPILOT_PROJECT_ID,
+  COPILOT_PROJECT_INCLUSIONS,
+  COPILOT_PROJECT_LAST_USED,
+  COPILOT_PROJECT_MAX_TOKENS,
+  COPILOT_PROJECT_MODEL_KEY,
+  COPILOT_PROJECT_NAME,
+  COPILOT_PROJECT_TEMPERATURE,
+  COPILOT_PROJECT_WEB_URLS,
+  COPILOT_PROJECT_YOUTUBE_URLS,
+  EMPTY_PROJECT_CONFIG,
+  PROJECT_CONFIG_FILE_NAME,
+  PROJECTS_UNSUPPORTED_FOLDER_NAME,
+} from "@/projects/constants";
+import {
+  getProjectFolderNameFromConfigPath,
+  getProjectsFolder,
+  splitUrlsStringToArray,
+} from "@/projects/projectPaths";
+import { ProjectFileRecord, ProjectScanDiagnostics } from "@/projects/type";
+import { stripFrontmatter } from "@/utils";
+import { logError, logWarn } from "@/logger";
+import { parseYaml, TFile, TFolder } from "obsidian";
+import {
+  addPendingFileWrite,
+  isPendingFileWrite,
+  removePendingFileWrite,
+  updateCachedProjectRecords,
+} from "@/projects/state";
+
+// Re-export path utilities so existing consumers don't need to change imports
+export {
+  getProjectsFolder,
+  getProjectsUnsupportedFolder,
+  getProjectFolderPath,
+  getProjectConfigFilePath,
+  isProjectConfigFile,
+  getProjectFolderNameFromConfigPath,
+  sanitizeVaultPathSegment,
+  splitUrlsStringToArray,
+  readFrontmatterFieldFromFile,
+  readFrontmatterListFromFile,
+} from "@/projects/projectPaths";
+
+/**
+ * Write all project frontmatter fields to a file (overwrite mode).
+ * Shared by both ProjectFileManager and migration to avoid duplication.
+ *
+ * @param file - Target TFile
+ * @param project - ProjectConfig to serialize
+ * @param folderName - Folder name (used as fallback for id/name)
+ * @param timestamps - Created and last-used timestamps
+ */
+export async function writeProjectFrontmatter(
+  file: TFile,
+  project: ProjectConfig,
+  folderName: string,
+  timestamps: { createdMs: number; lastUsedMs: number }
+): Promise<void> {
+  const webUrls = splitUrlsStringToArray(project.contextSource?.webUrls || "");
+  const youtubeUrls = splitUrlsStringToArray(project.contextSource?.youtubeUrls || "");
+
+  await app.fileManager.processFrontMatter(file, (frontmatter) => {
+    // Reason: project.id is the stable logical identity, always set by createProject/migration.
+    // Do NOT fallback to folderName — with name-based folders, folderName is derived from
+    // project name, not id, so it cannot serve as an id substitute.
+    frontmatter[COPILOT_PROJECT_ID] = project.id.trim();
+    frontmatter[COPILOT_PROJECT_NAME] = (project.name || folderName).trim();
+    frontmatter[COPILOT_PROJECT_DESCRIPTION] = (project.description || "").trim();
+    frontmatter[COPILOT_PROJECT_MODEL_KEY] = (project.projectModelKey || "").trim();
+
+    if (project.modelConfigs?.temperature != null) {
+      frontmatter[COPILOT_PROJECT_TEMPERATURE] = project.modelConfigs.temperature;
+    } else {
+      delete frontmatter[COPILOT_PROJECT_TEMPERATURE];
+    }
+
+    if (project.modelConfigs?.maxTokens != null) {
+      frontmatter[COPILOT_PROJECT_MAX_TOKENS] = project.modelConfigs.maxTokens;
+    } else {
+      delete frontmatter[COPILOT_PROJECT_MAX_TOKENS];
+    }
+
+    frontmatter[COPILOT_PROJECT_INCLUSIONS] = project.contextSource?.inclusions || "";
+    frontmatter[COPILOT_PROJECT_EXCLUSIONS] = project.contextSource?.exclusions || "";
+    frontmatter[COPILOT_PROJECT_WEB_URLS] = webUrls;
+    frontmatter[COPILOT_PROJECT_YOUTUBE_URLS] = youtubeUrls;
+    frontmatter[COPILOT_PROJECT_CREATED] = timestamps.createdMs;
+    frontmatter[COPILOT_PROJECT_LAST_USED] = timestamps.lastUsedMs;
+  });
+}
+
+/**
+ * Coerce a frontmatter value to a finite number.
+ * Handles YAML parsing string values gracefully.
+ */
+function coerceFrontmatterNumber(value: unknown, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+/** Coerce a frontmatter value to string with fallback. */
+function coerceFrontmatterString(value: unknown, fallback: string): string {
+  if (typeof value === "string") return value;
+  return fallback;
+}
+
+/**
+ * Coerce a frontmatter value to a string array.
+ * Handles both YAML arrays and single strings (split by newline).
+ */
+function coerceFrontmatterStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split("\n")
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+/**
+ * Strip YAML folding artifacts from encoded strings.
+ * Long encoded strings may be folded by YAML serializers, inserting newlines/spaces.
+ */
+function stripYamlFoldingArtifacts(value: string): string {
+  // Reason: YAML serializers may fold long strings, inserting \n followed by spaces.
+  // Encoded strings (URL-encoded inclusions/exclusions) must not contain these artifacts.
+  return value.replace(/\n\s*/g, "").replace(/\r/g, "");
+}
+
+/** Convert URL array to newline-separated string (for ProjectConfig runtime format). */
+function joinUrlsArrayToString(urls: string[]): string {
+  return (urls || [])
+    .map((u) => u.trim())
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Parse a project.md file into a ProjectFileRecord.
+ *
+ * Key constraints:
+ * - id: frontmatter is authoritative, folder name is fallback
+ * - Frontmatter parse failure: return null and logWarn (no auto-fix)
+ * - inclusions/exclusions: kept as encoded strings with YAML folding stripped
+ * - webUrls/youtubeUrls: stored as YAML arrays, converted to newline strings for runtime
+ *
+ * @param file - project.md TFile
+ * @returns ProjectFileRecord, or null if parse fails
+ */
+export async function parseProjectConfigFile(file: TFile): Promise<ProjectFileRecord | null> {
+  // Reason: vault.read() calls internal TFile.cache which doesn't exist on synthetic TFiles
+  // created by resolveFileByPath() for hidden-folder or not-yet-indexed files.
+  // Use the cached real TFile for vault API calls; fall back to adapter for synthetic files.
+  const cachedFile = app.vault.getAbstractFileByPath(file.path);
+  const isRealVaultFile = cachedFile instanceof TFile;
+  const rawContent = isRealVaultFile
+    ? await app.vault.read(cachedFile)
+    : await app.vault.adapter.read(file.path);
+  const content = stripFrontmatter(rawContent, { trimStart: false });
+
+  // Reason: rawContent is authoritative — metadataCache can lag behind writes from
+  // ensureProjectFrontmatter(), external edits, or sync. Parse frontmatter from the
+  // just-read file first; only fall back to metadataCache when no frontmatter block exists.
+  let frontmatter: Record<string, unknown> | undefined;
+  const fmMatch = rawContent.replace(/^\uFEFF/, "").match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (fmMatch) {
+    try {
+      const parsed = parseYaml(fmMatch[1]);
+      if (parsed && typeof parsed === "object") {
+        frontmatter = parsed as Record<string, unknown>;
+      }
+    } catch {
+      logWarn(`[Projects] Failed to parse YAML frontmatter from file: ${file.path}`);
+      return null;
+    }
+  }
+  if (!frontmatter && isRealVaultFile) {
+    const metadata = app.metadataCache.getFileCache(cachedFile);
+    frontmatter = metadata?.frontmatter;
+  }
+
+  const folderName = getProjectFolderNameFromConfigPath(file.path);
+  if (!folderName) {
+    logWarn(`[Projects] Cannot extract folder name from path, ignoring file: ${file.path}`);
+    return null;
+  }
+
+  // Reason: frontmatter id is the sole authoritative identity. Do NOT fallback to folderName
+  // because with name-based folders, folderName is derived from project name, not id.
+  // Files missing copilot-project-id are treated as corrupted and skipped.
+  const idFromFrontmatter = coerceFrontmatterString(frontmatter?.[COPILOT_PROJECT_ID], "").trim();
+  if (!idFromFrontmatter) {
+    logWarn(`[Projects] Missing ${COPILOT_PROJECT_ID} in frontmatter, skipping file: ${file.path}`);
+    return null;
+  }
+  const projectId = idFromFrontmatter;
+
+  const nameFromFrontmatter = coerceFrontmatterString(
+    frontmatter?.[COPILOT_PROJECT_NAME],
+    ""
+  ).trim();
+  const projectName = nameFromFrontmatter || folderName;
+
+  const description = coerceFrontmatterString(
+    frontmatter?.[COPILOT_PROJECT_DESCRIPTION],
+    ""
+  ).trim();
+  const projectModelKey = coerceFrontmatterString(
+    frontmatter?.[COPILOT_PROJECT_MODEL_KEY],
+    ""
+  ).trim();
+
+  const temperature = coerceFrontmatterNumber(frontmatter?.[COPILOT_PROJECT_TEMPERATURE], NaN);
+  const maxTokens = coerceFrontmatterNumber(frontmatter?.[COPILOT_PROJECT_MAX_TOKENS], NaN);
+
+  // Encoded strings: strip YAML folding artifacts, keep encoded format
+  const rawInclusions = coerceFrontmatterString(frontmatter?.[COPILOT_PROJECT_INCLUSIONS], "");
+  const rawExclusions = coerceFrontmatterString(frontmatter?.[COPILOT_PROJECT_EXCLUSIONS], "");
+  const inclusions = stripYamlFoldingArtifacts(rawInclusions);
+  const exclusions = stripYamlFoldingArtifacts(rawExclusions);
+
+  const webUrlsArray = coerceFrontmatterStringArray(frontmatter?.[COPILOT_PROJECT_WEB_URLS]);
+  const youtubeUrlsArray = coerceFrontmatterStringArray(
+    frontmatter?.[COPILOT_PROJECT_YOUTUBE_URLS]
+  );
+
+  const createdMs = coerceFrontmatterNumber(
+    frontmatter?.[COPILOT_PROJECT_CREATED],
+    file.stat?.ctime ?? 0
+  );
+  const lastUsedMs = coerceFrontmatterNumber(frontmatter?.[COPILOT_PROJECT_LAST_USED], 0);
+
+  const modelConfigs: ProjectFileRecord["project"]["modelConfigs"] = {};
+  if (Number.isFinite(temperature)) {
+    modelConfigs.temperature = temperature;
+  }
+  if (Number.isFinite(maxTokens) && maxTokens > 0) {
+    modelConfigs.maxTokens = maxTokens;
+  }
+
+  return {
+    project: {
+      ...EMPTY_PROJECT_CONFIG,
+      id: projectId,
+      name: projectName,
+      description: description || "",
+      systemPrompt: content,
+      projectModelKey,
+      modelConfigs,
+      contextSource: {
+        inclusions: inclusions || "",
+        exclusions: exclusions || "",
+        webUrls: joinUrlsArrayToString(webUrlsArray),
+        youtubeUrls: joinUrlsArrayToString(youtubeUrlsArray),
+      },
+      created: Number.isFinite(createdMs) && createdMs > 0 ? createdMs : 0,
+      UsageTimestamps: Number.isFinite(lastUsedMs) && lastUsedMs > 0 ? lastUsedMs : 0,
+    },
+    filePath: file.path,
+    folderName,
+  };
+}
+
+/**
+ * Scan all project config files with duplicate id detection.
+ *
+ * Performance: only traverses the projectsFolder subtree, not the entire vault.
+ * Looks for \<projectsFolder\>/\<folderName\>/project.md (one level deep).
+ *
+ * Duplicate rules:
+ * - Build id -> path[] index during scan
+ * - On duplicate: logWarn, keep first by path alphabetical order (stable)
+ *
+ * @returns Records and diagnostics
+ */
+export async function scanAllProjectConfigFiles(): Promise<{
+  records: ProjectFileRecord[];
+  diagnostics: ProjectScanDiagnostics;
+}> {
+  // Reason: §1.8 requires targeted folder traversal, not vault-wide scan.
+  // Falls back to adapter-based listing for hidden folders not indexed by vault cache.
+  const projectsFolder = getProjectsFolder();
+  const rootFolder = app.vault.getAbstractFileByPath(projectsFolder);
+
+  const files: TFile[] = [];
+  if (rootFolder instanceof TFolder) {
+    for (const child of rootFolder.children) {
+      if (!(child instanceof TFolder)) continue;
+      if (child.name === PROJECTS_UNSUPPORTED_FOLDER_NAME) continue;
+      const configFile = child.children.find(
+        (f) => f instanceof TFile && f.name === PROJECT_CONFIG_FILE_NAME
+      );
+      if (configFile instanceof TFile) {
+        files.push(configFile);
+      }
+    }
+  } else if (await app.vault.adapter.exists(projectsFolder)) {
+    // Reason: hidden folders (e.g. ".copilot/projects") are not indexed by vault cache.
+    // Use adapter.list() to discover project sub-folders and resolve config files.
+    const { resolveFileByPath } = await import("@/utils/vaultAdapterUtils");
+    const listing = await app.vault.adapter.list(projectsFolder);
+    for (const subFolderPath of listing.folders) {
+      const folderName = subFolderPath.split("/").pop() ?? "";
+      if (folderName === PROJECTS_UNSUPPORTED_FOLDER_NAME) continue;
+      const configPath = `${subFolderPath}/${PROJECT_CONFIG_FILE_NAME}`;
+      if (await app.vault.adapter.exists(configPath)) {
+        const resolved = await resolveFileByPath(app, configPath);
+        if (resolved) files.push(resolved);
+      }
+    }
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+
+  const duplicateIdIndex: Record<string, string[]> = {};
+  const ignoredFiles: string[] = [];
+  const records: ProjectFileRecord[] = [];
+
+  for (const file of files) {
+    let record: ProjectFileRecord | null;
+    try {
+      record = await parseProjectConfigFile(file);
+    } catch (error) {
+      logError(`[Projects] Failed to parse project file, skipping: ${file.path}`, error);
+      ignoredFiles.push(file.path);
+      continue;
+    }
+    if (!record) {
+      ignoredFiles.push(file.path);
+      continue;
+    }
+
+    const id = record.project.id;
+    if (!duplicateIdIndex[id]) {
+      duplicateIdIndex[id] = [];
+    }
+    duplicateIdIndex[id].push(file.path);
+
+    if (duplicateIdIndex[id].length > 1) {
+      logWarn(
+        `[Projects] Duplicate project id="${id}": ` +
+          `${duplicateIdIndex[id].join(", ")}; keeping first: ${duplicateIdIndex[id][0]}`
+      );
+      continue;
+    }
+
+    records.push(record);
+  }
+
+  return { records, diagnostics: { duplicateIdIndex, ignoredFiles } };
+}
+
+/**
+ * Load all projects from vault and update the cache.
+ *
+ * NOTE: This does NOT merge legacy settings.projectList entries.
+ * Migration unconditionally clears projectList after backup (matching the
+ * custom command and system prompt migration patterns). Failed projects
+ * are recovered from the unsupported/ folder, not from settings.
+ *
+ * @returns Array of ProjectFileRecord
+ */
+export async function loadAllProjects(): Promise<ProjectFileRecord[]> {
+  const { records } = await scanAllProjectConfigFiles();
+  updateCachedProjectRecords(records);
+  return records;
+}
+
+/**
+ * Fetch all projects from vault without updating the cache.
+ * @returns Array of ProjectFileRecord
+ */
+export async function fetchAllProjects(): Promise<ProjectFileRecord[]> {
+  const { records } = await scanAllProjectConfigFiles();
+  return records;
+}
+
+/**
+ * Ensure a project.md has required frontmatter fields (idempotent, only fills missing).
+ *
+ * @param file - project.md TFile
+ * @param record - Parsed record providing default values
+ */
+export async function ensureProjectFrontmatter(
+  file: TFile,
+  record: ProjectFileRecord
+): Promise<void> {
+  const alreadyPending = isPendingFileWrite(file.path);
+
+  const now = Date.now();
+  const createdMs =
+    Number.isFinite(record.project.created) && record.project.created > 0
+      ? record.project.created
+      : now;
+  const lastUsedMs =
+    Number.isFinite(record.project.UsageTimestamps) && record.project.UsageTimestamps > 0
+      ? record.project.UsageTimestamps
+      : 0;
+
+  const webUrls = splitUrlsStringToArray(record.project.contextSource?.webUrls || "");
+  const youtubeUrls = splitUrlsStringToArray(record.project.contextSource?.youtubeUrls || "");
+
+  try {
+    if (!alreadyPending) addPendingFileWrite(file.path);
+
+    await app.fileManager.processFrontMatter(file, (frontmatter) => {
+      // Reason: do NOT fallback to record.folderName for id — with name-based folders,
+      // folderName is derived from project name, not id.
+      if (frontmatter[COPILOT_PROJECT_ID] == null && record.project.id) {
+        frontmatter[COPILOT_PROJECT_ID] = record.project.id;
+      }
+      if (frontmatter[COPILOT_PROJECT_NAME] == null) {
+        frontmatter[COPILOT_PROJECT_NAME] = record.project.name || record.folderName;
+      }
+      if (frontmatter[COPILOT_PROJECT_DESCRIPTION] == null && record.project.description) {
+        frontmatter[COPILOT_PROJECT_DESCRIPTION] = record.project.description;
+      }
+      if (frontmatter[COPILOT_PROJECT_MODEL_KEY] == null && record.project.projectModelKey) {
+        frontmatter[COPILOT_PROJECT_MODEL_KEY] = record.project.projectModelKey;
+      }
+      if (
+        frontmatter[COPILOT_PROJECT_TEMPERATURE] == null &&
+        record.project.modelConfigs?.temperature != null
+      ) {
+        frontmatter[COPILOT_PROJECT_TEMPERATURE] = record.project.modelConfigs.temperature;
+      }
+      if (
+        frontmatter[COPILOT_PROJECT_MAX_TOKENS] == null &&
+        record.project.modelConfigs?.maxTokens != null
+      ) {
+        frontmatter[COPILOT_PROJECT_MAX_TOKENS] = record.project.modelConfigs.maxTokens;
+      }
+      if (
+        frontmatter[COPILOT_PROJECT_INCLUSIONS] == null &&
+        record.project.contextSource?.inclusions
+      ) {
+        frontmatter[COPILOT_PROJECT_INCLUSIONS] = record.project.contextSource.inclusions;
+      }
+      if (
+        frontmatter[COPILOT_PROJECT_EXCLUSIONS] == null &&
+        record.project.contextSource?.exclusions
+      ) {
+        frontmatter[COPILOT_PROJECT_EXCLUSIONS] = record.project.contextSource.exclusions;
+      }
+      if (frontmatter[COPILOT_PROJECT_WEB_URLS] == null && webUrls.length > 0) {
+        frontmatter[COPILOT_PROJECT_WEB_URLS] = webUrls;
+      }
+      if (frontmatter[COPILOT_PROJECT_YOUTUBE_URLS] == null && youtubeUrls.length > 0) {
+        frontmatter[COPILOT_PROJECT_YOUTUBE_URLS] = youtubeUrls;
+      }
+      if (frontmatter[COPILOT_PROJECT_CREATED] == null) {
+        frontmatter[COPILOT_PROJECT_CREATED] = createdMs;
+      }
+      if (frontmatter[COPILOT_PROJECT_LAST_USED] == null) {
+        frontmatter[COPILOT_PROJECT_LAST_USED] = lastUsedMs;
+      }
+    });
+  } finally {
+    if (!alreadyPending) removePendingFileWrite(file.path);
+  }
+}

--- a/src/projects/state.ts
+++ b/src/projects/state.ts
@@ -1,0 +1,191 @@
+import { atom, createStore } from "jotai";
+import { useAtomValue } from "jotai";
+import { ProjectConfig } from "@/aiParams";
+import { ProjectFileRecord } from "@/projects/type";
+import { normalizePath } from "obsidian";
+
+// Independent store for projects (aligned with system-prompts pattern)
+const projectsStore = createStore();
+
+const projectRecordsAtom = atom<ProjectFileRecord[]>([]);
+
+// Reason: derived atom so that useProjects() returns a stable array reference
+// (only recomputed when projectRecordsAtom changes, not on every parent render).
+const projectConfigsAtom = atom<ProjectConfig[]>((get) =>
+  get(projectRecordsAtom).map((r) => r.project)
+);
+
+/**
+ * React hook: get all project file records.
+ * This is the single entry point for UI components to read projects.
+ * @returns Array of ProjectFileRecord
+ */
+export function useProjectRecords(): ProjectFileRecord[] {
+  return useAtomValue(projectRecordsAtom, { store: projectsStore });
+}
+
+/**
+ * React hook: get all ProjectConfig objects (convenience wrapper).
+ * Uses a derived atom so the array reference is stable across re-renders.
+ * @returns Array of ProjectConfig
+ */
+export function useProjects(): ProjectConfig[] {
+  return useAtomValue(projectConfigsAtom, { store: projectsStore });
+}
+
+/**
+ * Non-reactive: get cached project records.
+ * @returns Array of ProjectFileRecord
+ */
+export function getCachedProjectRecords(): ProjectFileRecord[] {
+  return projectsStore.get(projectRecordsAtom);
+}
+
+/**
+ * Non-reactive: get cached ProjectConfig objects.
+ * @returns Array of ProjectConfig
+ */
+export function getCachedProjects(): ProjectConfig[] {
+  return projectsStore.get(projectRecordsAtom).map((r) => r.project);
+}
+
+/**
+ * Non-reactive: find a cached record by project id.
+ * @param projectId - Project id to look up
+ * @returns Matching record or undefined
+ */
+export function getCachedProjectRecordById(projectId: string): ProjectFileRecord | undefined {
+  return projectsStore.get(projectRecordsAtom).find((r) => r.project.id === projectId);
+}
+
+/**
+ * Non-reactive: find a cached record by file path.
+ * @param filePath - Vault path of project.md
+ * @returns Matching record or undefined
+ */
+export function getCachedProjectRecordByFilePath(filePath: string): ProjectFileRecord | undefined {
+  return projectsStore.get(projectRecordsAtom).find((r) => r.filePath === filePath);
+}
+
+/**
+ * Replace all cached project records.
+ * @param records - New array of ProjectFileRecord
+ */
+export function updateCachedProjectRecords(records: ProjectFileRecord[]): void {
+  projectsStore.set(projectRecordsAtom, records);
+}
+
+/**
+ * Replace the cached record for a given file path in a single store write.
+ * Avoids transient "disappear/reappear" gaps for subscribers during modify events,
+ * while still cleaning up stale entries when the frontmatter id changes.
+ *
+ * @param filePath - Vault path of project.md being modified
+ * @param record - Parsed record to store for that file
+ */
+export function replaceCachedProjectRecordByFilePath(
+  filePath: string,
+  record: ProjectFileRecord
+): void {
+  const prev = projectsStore.get(projectRecordsAtom);
+
+  // Reason: find the original index by filePath to preserve array order (avoid moving to end on
+  // every modify). If the record exists, replace in-place; otherwise append.
+  const existingIndex = prev.findIndex((r) => r.filePath === filePath);
+
+  if (existingIndex !== -1) {
+    // Reason: also remove any other entry with the same id but different filePath (stale duplicate),
+    // then replace in-place at the original position.
+    const updated = prev.filter(
+      (r, i) => i === existingIndex || r.project.id !== record.project.id
+    );
+    const newIndex = updated.findIndex((r) => r.filePath === filePath);
+    updated[newIndex] = record;
+    projectsStore.set(projectRecordsAtom, updated);
+  } else {
+    // New filePath: remove any stale id match, then append
+    const withoutId = prev.filter((r) => r.project.id !== record.project.id);
+    projectsStore.set(projectRecordsAtom, [...withoutId, record]);
+  }
+}
+
+/**
+ * Add or update a project record by project.id.
+ * @param record - ProjectFileRecord to upsert
+ */
+export function upsertCachedProjectRecord(record: ProjectFileRecord): void {
+  const records = projectsStore.get(projectRecordsAtom);
+  const existingIndex = records.findIndex((r) => r.project.id === record.project.id);
+
+  if (existingIndex !== -1) {
+    const updated = [...records];
+    updated[existingIndex] = record;
+    projectsStore.set(projectRecordsAtom, updated);
+  } else {
+    projectsStore.set(projectRecordsAtom, [...records, record]);
+  }
+}
+
+/**
+ * Remove a project record by project id.
+ * @param projectId - Project id to remove
+ */
+export function deleteCachedProjectRecordById(projectId: string): void {
+  const records = projectsStore.get(projectRecordsAtom);
+  projectsStore.set(
+    projectRecordsAtom,
+    records.filter((r) => r.project.id !== projectId)
+  );
+}
+
+/**
+ * Remove a project record by file path (used for delete/rename events).
+ * @param filePath - Vault path of project.md
+ */
+export function deleteCachedProjectRecordByFilePath(filePath: string): void {
+  const records = projectsStore.get(projectRecordsAtom);
+  projectsStore.set(
+    projectRecordsAtom,
+    records.filter((r) => r.filePath !== filePath)
+  );
+}
+
+/**
+ * Subscribe to project records changes (for non-React code like projectManager).
+ * Returns an unsubscribe function.
+ * @param callback - Called with the new records array whenever it changes
+ * @returns Unsubscribe function
+ */
+export function subscribeToProjectRecords(
+  callback: (records: ProjectFileRecord[]) => void
+): () => void {
+  return projectsStore.sub(projectRecordsAtom, () => {
+    callback(projectsStore.get(projectRecordsAtom));
+  });
+}
+
+// Reason: use a ref-counted Map instead of a plain Set so overlapping async writes to the
+// same path don't prematurely clear the guard when the first writer finishes.
+const pendingFileWrites = new Map<string, number>();
+
+/** Mark a file path as pending write (normalizes path to avoid mismatches). */
+export function addPendingFileWrite(path: string): void {
+  const key = normalizePath(path);
+  pendingFileWrites.set(key, (pendingFileWrites.get(key) ?? 0) + 1);
+}
+
+/** Remove a file path from pending writes (normalizes path to avoid mismatches). */
+export function removePendingFileWrite(path: string): void {
+  const key = normalizePath(path);
+  const count = (pendingFileWrites.get(key) ?? 0) - 1;
+  if (count <= 0) {
+    pendingFileWrites.delete(key);
+  } else {
+    pendingFileWrites.set(key, count);
+  }
+}
+
+/** Check if a file path is pending write (normalizes path to avoid mismatches). */
+export function isPendingFileWrite(path: string): boolean {
+  return (pendingFileWrites.get(normalizePath(path)) ?? 0) > 0;
+}

--- a/src/projects/type.ts
+++ b/src/projects/type.ts
@@ -1,0 +1,26 @@
+import { ProjectConfig } from "@/aiParams";
+
+/**
+ * A parsed project file record (project.md).
+ *
+ * - `project.id`: authoritative value from frontmatter; folder name as fallback
+ * - `filePath`: vault path for write-back operations (e.g. last-used throttled persist)
+ */
+export interface ProjectFileRecord {
+  /** Runtime-compatible ProjectConfig. */
+  project: ProjectConfig;
+
+  /** Vault path of the project.md file. */
+  filePath: string;
+
+  /** Parent folder name (used as id fallback). */
+  folderName: string;
+}
+
+/**
+ * Diagnostics from a full project scan (duplicate id detection, ignored files).
+ */
+export interface ProjectScanDiagnostics {
+  duplicateIdIndex: Record<string, string[]>;
+  ignoredFiles: string[];
+}

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -1,5 +1,6 @@
 import { CustomError } from "@/error";
 import EmbeddingsManager from "@/LLMProviders/embeddingManager";
+import { logError, logInfo, logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
 import { logFileManager } from "@/logFileManager";
 import { getTagsFromNote, stripHash } from "@/utils";
@@ -25,12 +26,12 @@ export async function getVectorLength(embeddingInstance: Embeddings | undefined)
       throw new CustomError("Failed to get valid embedding vector length");
     }
 
-    console.log(
+    logInfo(
       `Detected vector length: ${sampleEmbedding.length} for model: ${EmbeddingsManager.getModelName(embeddingInstance)}`
     );
     return sampleEmbedding.length;
   } catch (error) {
-    console.error("Error getting vector length:", error);
+    logError("Error getting vector length:", error);
     throw new CustomError(
       "Failed to determine embedding vector length. Please check your Copilot settings to make sure you have a working embedding model."
     );
@@ -356,7 +357,7 @@ export function extractAppIgnoreSettings(app: App): string[] {
   } catch (e) {
     // Only log in non-test environments
     if (process.env.NODE_ENV !== "test") {
-      console.warn("Error getting userIgnoreFilters from Obsidian config", e);
+      logWarn("Error getting userIgnoreFilters from Obsidian config", e);
     }
   }
 
@@ -382,19 +383,52 @@ export function getExtensionPattern(extension: string): string {
 
 /**
  * Get a list of internal Copilot file paths that must be excluded from searches.
- * Currently includes the rolling log file path (e.g., "copilot/copilot-log.md").
+ * Includes the rolling log file path (e.g., "copilot/copilot-log.md").
  */
 export function getInternalExcludePaths(): string[] {
   return [logFileManager.getLogPath()];
 }
 
 /**
+ * Get a list of internal Copilot folder prefixes that must be excluded from searches.
+ * Any file whose path starts with one of these prefixes is considered internal.
+ */
+export function getInternalExcludeFolderPrefixes(): string[] {
+  const settings = getSettings();
+  const projectsFolder = (settings.projectsFolder || "").trim();
+  if (projectsFolder) {
+    // Reason: normalize to forward slashes, collapse duplicates, strip trailing slash,
+    // then append exactly one "/" for prefix matching. Mirrors normalizePath behavior
+    // without depending on Obsidian runtime (needed for testability).
+    const normalized = projectsFolder.replace(/\\/g, "/").replace(/\/+/g, "/").replace(/\/+$/, "");
+    return [`${normalized}/`];
+  }
+  return [];
+}
+
+/**
  * Check whether a file path is an internal Copilot file that should be excluded from searches.
+ * Checks both exact path matches (log file) and folder prefix matches (projects folder).
  * @param filePath - Full path to the file in the vault
  */
 export function isInternalExcludedPath(filePath: string): boolean {
   const excludes = new Set(getInternalExcludePaths());
-  return excludes.has(filePath);
+  if (excludes.has(filePath)) return true;
+
+  // Reason: only exclude internal project files (project.md configs and unsupported/ backups),
+  // not user-created files that may live alongside project configs in the projects folder.
+  // Check exact depth: only <projectsFolder>/<folderName>/project.md (one level deep).
+  const prefixes = getInternalExcludeFolderPrefixes();
+  if (prefixes.length === 0) return false;
+  for (const prefix of prefixes) {
+    if (!filePath.startsWith(prefix)) continue;
+    const relativePath = filePath.slice(prefix.length);
+    const parts = relativePath.split("/");
+    // Exact match: <folderName>/project.md (2 segments, second is "project.md")
+    if (parts.length === 2 && parts[1] === "project.md") return true;
+    if (relativePath.startsWith("unsupported/") || relativePath === "unsupported") return true;
+  }
+  return false;
 }
 
 /**

--- a/src/services/webViewerService/webViewerServiceActions.ts
+++ b/src/services/webViewerService/webViewerServiceActions.ts
@@ -6,6 +6,7 @@
  */
 
 import { logError, logInfo, logWarn } from "@/logger";
+import { getYouTubeVideoId } from "@/utils/youtubeUrl";
 import {
   requireWebview,
   type SaveToVaultResult,
@@ -215,46 +216,10 @@ export async function getHtml(leaf: WebViewerLeaf, includeDocumentElement = true
 // YouTube Transcript Extraction
 // ============================================================================
 
-/**
- * Extract YouTube video ID from various URL formats.
- * Supports: youtube.com/watch, youtu.be, youtube.com/shorts, m.youtube.com, embed
- * @returns video ID or null if not a valid YouTube video URL
- */
-export function getYouTubeVideoId(url: string): string | null {
-  try {
-    const u = new URL(url);
-    const hostname = u.hostname.replace(/^www\./, "").replace(/^m\./, "");
-
-    // youtube.com/watch?v=xxx or youtube.com/watch?v=xxx&t=120
-    if (hostname === "youtube.com" && u.pathname === "/watch") {
-      return u.searchParams.get("v");
-    }
-
-    // youtu.be/xxx or youtu.be/xxx?t=120
-    if (hostname === "youtu.be" && u.pathname.length > 1) {
-      return u.pathname.slice(1).split("/")[0];
-    }
-
-    // youtube.com/shorts/xxx
-    if (hostname === "youtube.com" && u.pathname.startsWith("/shorts/")) {
-      return u.pathname.split("/")[2] || null;
-    }
-
-    // youtube.com/embed/xxx
-    if (hostname === "youtube.com" && u.pathname.startsWith("/embed/")) {
-      return u.pathname.split("/")[2] || null;
-    }
-
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-/** Check if URL is a YouTube video page */
-export function isYouTubeVideoUrl(url: string): boolean {
-  return getYouTubeVideoId(url) !== null;
-}
+// Re-exported from neutral utils to avoid circular dependencies.
+// Reason: Both utils (urlTagUtils) and services need these functions.
+// The implementation lives in src/utils/youtubeUrl.ts.
+export { getYouTubeVideoId, isYouTubeVideoUrl } from "@/utils/youtubeUrl";
 
 /** YouTube transcript segment */
 export interface YouTubeTranscriptSegment {

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -109,6 +109,8 @@ export interface CopilotSettings {
   promptSortStrategy: string;
   chatHistorySortStrategy: SortStrategy;
   projectListSortStrategy: SortStrategy;
+  /** Projects config root folder in vault (default: "copilot/projects"). */
+  projectsFolder: string;
   embeddingRequestsPerMin: number;
   embeddingBatchSize: number;
   defaultOpenArea: DEFAULT_OPEN_AREA;
@@ -561,6 +563,18 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   const promptsFolder = (settingsToSanitize.customPromptsFolder || "").trim();
   sanitizedSettings.customPromptsFolder =
     promptsFolder.length > 0 ? promptsFolder : DEFAULT_SETTINGS.customPromptsFolder;
+
+  // Ensure projectsFolder falls back to default when empty/whitespace.
+  // Reason: reject path traversal segments ("..") and absolute paths to prevent
+  // writes outside the vault root.
+  const projectsFolder = (settingsToSanitize.projectsFolder || "").trim();
+  // Reason: also reject Unix absolute paths (/foo) and UNC paths (\\server\share)
+  const hasTraversal =
+    /(^|[/\\])\.\.[/\\]?/.test(projectsFolder) ||
+    /^[a-zA-Z]:/.test(projectsFolder) ||
+    /^[/\\]/.test(projectsFolder);
+  sanitizedSettings.projectsFolder =
+    projectsFolder.length > 0 && !hasTraversal ? projectsFolder : DEFAULT_SETTINGS.projectsFolder;
 
   // Ensure chatHistorySortStrategy has a valid value (exclude "manual" which is only for custom commands)
   if (

--- a/src/settings/v2/components/PatternListEditor.tsx
+++ b/src/settings/v2/components/PatternListEditor.tsx
@@ -40,12 +40,15 @@ interface PatternListEditorProps {
   value: string;
   onChange: (value: string) => void;
   maxCollapsedHeight?: number;
+  /** Max height when expanded — content scrolls beyond this. */
+  maxExpandedHeight?: number;
 }
 
 export const PatternListEditor: React.FC<PatternListEditorProps> = ({
   value,
   onChange,
   maxCollapsedHeight = 84,
+  maxExpandedHeight = 200,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -92,7 +95,10 @@ export const PatternListEditor: React.FC<PatternListEditorProps> = ({
   }, [maxCollapsedHeight, patterns]);
 
   const isTruncated = isOverflowing && !isExpanded;
-  const animatedMaxHeight = isExpanded ? contentHeight : maxCollapsedHeight;
+  // Reason: Cap expanded height so the badge list scrolls instead of pushing the modal off-screen.
+  const animatedMaxHeight = isExpanded
+    ? Math.min(contentHeight, maxExpandedHeight)
+    : maxCollapsedHeight;
 
   // Update patterns
   const updatePatterns = (newCategories: {
@@ -253,7 +259,12 @@ export const PatternListEditor: React.FC<PatternListEditorProps> = ({
       <div className="tw-relative tw-rounded-md tw-border tw-border-solid tw-border-border tw-p-2">
         <div
           ref={contentRef}
-          className="tw-overflow-hidden tw-transition-[max-height] tw-duration-300 tw-ease-in-out"
+          className={cn(
+            "tw-transition-[max-height] tw-duration-300 tw-ease-in-out",
+            isExpanded && contentHeight > maxExpandedHeight
+              ? "tw-overflow-y-auto"
+              : "tw-overflow-hidden"
+          )}
           style={{ maxHeight: isOverflowing ? animatedMaxHeight : undefined }}
         >
           {/* Empty state */}

--- a/src/tools/FileParserManager.ts
+++ b/src/tools/FileParserManager.ts
@@ -190,113 +190,124 @@ export class CanvasParser implements FileParser {
   }
 }
 
+/**
+ * All file extensions supported by Docs4LLMParser.
+ * Extracted as a module-level constant so FileParserManager.getProjectSupportedExtensions()
+ * can read the list statically without constructing a full Docs4LLMParser instance.
+ *
+ * Reason: The static method needs these extensions at UI layer (before any real API client exists),
+ * so we can't safely construct Docs4LLMParser just to read a property.
+ */
+export const DOCS4LLM_SUPPORTED_EXTENSIONS: readonly string[] = [
+  // Base types
+  "pdf",
+
+  // Documents and presentations
+  "602",
+  "abw",
+  "cgm",
+  "cwk",
+  "doc",
+  "docx",
+  "docm",
+  "dot",
+  "dotm",
+  "hwp",
+  "key",
+  "lwp",
+  "mw",
+  "mcw",
+  "pages",
+  "pbd",
+  "ppt",
+  "pptm",
+  "pptx",
+  "pot",
+  "potm",
+  "potx",
+  "rtf",
+  "sda",
+  "sdd",
+  "sdp",
+  "sdw",
+  "sgl",
+  "sti",
+  "sxi",
+  "sxw",
+  "stw",
+  "sxg",
+  "txt",
+  "uof",
+  "uop",
+  "uot",
+  "vor",
+  "wpd",
+  "wps",
+  "xml",
+  "zabw",
+  "epub",
+
+  // Images
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "bmp",
+  "svg",
+  "tiff",
+  "webp",
+  "web",
+  "htm",
+  "html",
+
+  // Spreadsheets
+  "xlsx",
+  "xls",
+  "xlsm",
+  "xlsb",
+  "xlw",
+  "csv",
+  "dif",
+  "sylk",
+  "slk",
+  "prn",
+  "numbers",
+  "et",
+  "ods",
+  "fods",
+  "uos1",
+  "uos2",
+  "dbf",
+  "wk1",
+  "wk2",
+  "wk3",
+  "wk4",
+  "wks",
+  "123",
+  "wq1",
+  "wq2",
+  "wb1",
+  "wb2",
+  "wb3",
+  "qpw",
+  "xlr",
+  "eth",
+  "tsv",
+
+  // Audio (limited to 20MB)
+  "mp3",
+  "mp4",
+  "mpeg",
+  "mpga",
+  "m4a",
+  "wav",
+  "webm",
+];
+
 export class Docs4LLMParser implements FileParser {
-  // Support various document and media file types
-  supportedExtensions = [
-    // Base types
-    "pdf",
-
-    // Documents and presentations
-    "602",
-    "abw",
-    "cgm",
-    "cwk",
-    "doc",
-    "docx",
-    "docm",
-    "dot",
-    "dotm",
-    "hwp",
-    "key",
-    "lwp",
-    "mw",
-    "mcw",
-    "pages",
-    "pbd",
-    "ppt",
-    "pptm",
-    "pptx",
-    "pot",
-    "potm",
-    "potx",
-    "rtf",
-    "sda",
-    "sdd",
-    "sdp",
-    "sdw",
-    "sgl",
-    "sti",
-    "sxi",
-    "sxw",
-    "stw",
-    "sxg",
-    "txt",
-    "uof",
-    "uop",
-    "uot",
-    "vor",
-    "wpd",
-    "wps",
-    "xml",
-    "zabw",
-    "epub",
-
-    // Images
-    "jpg",
-    "jpeg",
-    "png",
-    "gif",
-    "bmp",
-    "svg",
-    "tiff",
-    "webp",
-    "web",
-    "htm",
-    "html",
-
-    // Spreadsheets
-    "xlsx",
-    "xls",
-    "xlsm",
-    "xlsb",
-    "xlw",
-    "csv",
-    "dif",
-    "sylk",
-    "slk",
-    "prn",
-    "numbers",
-    "et",
-    "ods",
-    "fods",
-    "uos1",
-    "uos2",
-    "dbf",
-    "wk1",
-    "wk2",
-    "wk3",
-    "wk4",
-    "wks",
-    "123",
-    "wq1",
-    "wq2",
-    "wb1",
-    "wb2",
-    "wb3",
-    "qpw",
-    "xlr",
-    "eth",
-    "tsv",
-
-    // Audio (limited to 20MB)
-    "mp3",
-    "mp4",
-    "mpeg",
-    "mpga",
-    "m4a",
-    "wav",
-    "webm",
-  ];
+  // Reason: Reference the shared constant so getProjectSupportedExtensions() stays in sync
+  // with the actual parser registrations without duplicating the list.
+  supportedExtensions = [...DOCS4LLM_SUPPORTED_EXTENSIONS];
   private brevilabsClient: BrevilabsClient;
   private projectContextCache: ProjectContextCache;
   private selfHostPdfParser: SelfHostPdfParser;
@@ -472,6 +483,34 @@ class DocxParser implements FileParser {
 
 export class FileParserManager {
   private parsers: Map<string, FileParser> = new Map();
+
+  /**
+   * Returns the set of file extensions supported in project mode (isProjectMode=true).
+   *
+   * Reason: The UI status panel needs to distinguish between "pending" (will be processed)
+   * and "unsupported" (will never be processed) for non-markdown files. This method
+   * exposes the exact extension set used when constructing a project-mode FileParserManager,
+   * without requiring a full instantiation with real BrevilabsClient/Vault dependencies.
+   *
+   * Project mode registers: MarkdownParser + Docs4LLMParser + CanvasParser
+   * (PDFParser is skipped because Docs4LLMParser already handles PDFs in project mode)
+   */
+  public static getProjectSupportedExtensions(): Set<string> {
+    const extensions = new Set<string>();
+
+    // MarkdownParser: ["md"]
+    extensions.add("md");
+
+    // Docs4LLMParser: all document/image/spreadsheet/audio types (read from shared constant)
+    for (const ext of DOCS4LLM_SUPPORTED_EXTENSIONS) {
+      extensions.add(ext);
+    }
+
+    // CanvasParser: ["canvas"]
+    extensions.add("canvas");
+
+    return extensions;
+  }
 
   constructor(
     brevilabsClient: BrevilabsClient,

--- a/src/utils/cacheFileOpener.ts
+++ b/src/utils/cacheFileOpener.ts
@@ -1,0 +1,98 @@
+import { type ContextCache, getFileCacheRef } from "@/cache/projectContextCache";
+import { CachePreviewModal } from "@/components/modals/CachePreviewModal";
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import { logError } from "@/logger";
+import { App, Notice } from "obsidian";
+
+/**
+ * Open a preview modal for a cached project file (file-only).
+ * Kept for backwards compatibility with context-manage-modal.
+ *
+ * @param app - Obsidian App instance
+ * @param cache - Already-loaded ContextCache for the project
+ * @param filePath - Original source file path
+ * @param displayName - Human-readable name for modal title
+ */
+export async function openCachedProjectFile(
+  app: App,
+  cache: ContextCache | null | undefined,
+  filePath: string,
+  displayName: string
+): Promise<void> {
+  const ref = getFileCacheRef(cache, filePath);
+  if (!ref) {
+    new Notice("No cached content available for this file.");
+    return;
+  }
+
+  const exists = await app.vault.adapter.exists(ref.cachePath);
+  if (!exists) {
+    new Notice("Cache expired. Please re-process the file.");
+    return;
+  }
+
+  try {
+    const content = await app.vault.adapter.read(ref.cachePath);
+    new CachePreviewModal(app, displayName, content).open();
+  } catch (error) {
+    logError(`Failed to read cached content for ${filePath}:`, error);
+    new Notice("Failed to read cached content.");
+  }
+}
+
+/**
+ * Open a preview modal for any cached project item (file, web URL, or YouTube URL).
+ * Reads content from the appropriate cache bucket based on item.cacheKind.
+ *
+ * @param app - Obsidian App instance
+ * @param cache - Already-loaded ContextCache for the project
+ * @param item - ProcessingItem with id, name, and cacheKind
+ */
+export async function openCachedItemPreview(
+  app: App,
+  cache: ContextCache | null | undefined,
+  item: Pick<ProcessingItem, "id" | "name" | "cacheKind">
+): Promise<void> {
+  if (!cache) {
+    new Notice("No cached content available.");
+    return;
+  }
+
+  let content: string | null = null;
+
+  switch (item.cacheKind) {
+    case "web":
+      content = cache.webContexts?.[item.id] ?? null;
+      break;
+    case "youtube":
+      content = cache.youtubeContexts?.[item.id] ?? null;
+      break;
+    case "file": {
+      const ref = getFileCacheRef(cache, item.id);
+      if (!ref) {
+        new Notice("No cached content available for this file.");
+        return;
+      }
+      const exists = await app.vault.adapter.exists(ref.cachePath);
+      if (!exists) {
+        new Notice("Cache expired. Please re-process the file.");
+        return;
+      }
+      try {
+        content = await app.vault.adapter.read(ref.cachePath);
+      } catch (error) {
+        logError(`Failed to read cached file: ${ref.cachePath}`, error);
+        new Notice("Failed to read cached content.");
+        return;
+      }
+      break;
+    }
+  }
+
+  if (!content || !content.trim()) {
+    new Notice("No content available for this item.");
+    return;
+  }
+
+  new CachePreviewModal(app, item.name, content).open();
+}

--- a/src/utils/chatHistoryUtils.ts
+++ b/src/utils/chatHistoryUtils.ts
@@ -1,5 +1,123 @@
+import { sanitizeVaultPathSegment } from "@/projects/projectPaths";
+import { getCachedProjectRecords } from "@/projects/state";
 import { formatDateTime } from "@/utils";
-import { TFile } from "obsidian";
+import { readFrontmatterViaAdapter } from "@/utils/vaultAdapterUtils";
+import { App, TFile } from "obsidian";
+
+/**
+ * Check if a chat file's basename matches a known project ID prefix.
+ * Used to exclude legacy project chat files (which lack projectId frontmatter)
+ * from the non-project chat history view.
+ *
+ * @param basename - File basename to check
+ * @returns true if the basename starts with a known project prefix
+ */
+export function hasKnownProjectPrefix(basename: string): boolean {
+  const records = getCachedProjectRecords();
+
+  // Reason: check precise prefix matching against known cached project IDs first.
+  const matchesCachedProject = records.some((r) => {
+    const sanitizedPrefix = `${sanitizeVaultPathSegment(r.project.id)}__`;
+    const rawPrefix = `${r.project.id}__`;
+    return basename.startsWith(sanitizedPrefix) || basename.startsWith(rawPrefix);
+  });
+  // Reason: only match precise known project IDs — a broad regex like ^[a-zA-Z0-9_-]+__
+  // would hide legitimate non-project notes (e.g. "foo__bar.md") in the chat folder.
+  return matchesCachedProject;
+}
+
+/**
+ * Coerce a raw frontmatter projectId value to a normalized string or undefined.
+ */
+function coerceProjectId(projectId: unknown): string | undefined {
+  if (typeof projectId === "string") return projectId.trim() || undefined;
+  if (typeof projectId === "number") return String(projectId);
+  return undefined;
+}
+
+/**
+ * Read the projectId from a chat file's frontmatter.
+ * Tries metadataCache first, falls back to adapter read for hidden-directory files.
+ */
+export async function readChatFileProjectId(
+  app: App,
+  file: TFile
+): Promise<string | undefined> {
+  const fm = app.metadataCache.getFileCache(file)?.frontmatter;
+  let projectId: unknown = fm?.projectId;
+
+  // Reason: hidden-directory files are not indexed by metadataCache
+  if (projectId === undefined && !fm) {
+    try {
+      const adapterFm = await readFrontmatterViaAdapter(app, file.path);
+      projectId = adapterFm?.projectId;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return coerceProjectId(projectId);
+}
+
+/**
+ * Read the projectId from a chat file path (supports both vault-cached and hidden-directory files).
+ */
+export async function readChatPathProjectId(
+  app: App,
+  filePath: string
+): Promise<string | undefined> {
+  const existingFile = app.vault.getAbstractFileByPath(filePath);
+  if (existingFile instanceof TFile) {
+    return readChatFileProjectId(app, existingFile);
+  }
+
+  try {
+    const adapterFm = await readFrontmatterViaAdapter(app, filePath);
+    return coerceProjectId(adapterFm?.projectId);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Filter chat history files by project ownership.
+ * In project mode: returns files belonging to the given project (by frontmatter or legacy prefix).
+ * In non-project mode: returns files without a projectId, excluding legacy project chats.
+ *
+ * @param app - Obsidian app instance
+ * @param files - Pre-filtered candidate files
+ * @param currentProjectId - Current project ID, or undefined for non-project mode
+ */
+export async function filterChatHistoryFiles(
+  app: App,
+  files: TFile[],
+  currentProjectId?: string
+): Promise<TFile[]> {
+  const results = await Promise.all(
+    files.map(async (file) => ({
+      file,
+      projectId: await readChatFileProjectId(app, file),
+    }))
+  );
+
+  return results
+    .filter(({ file, projectId }) => {
+      if (currentProjectId) {
+        if (projectId === currentProjectId) return true;
+        // Reason: legacy files may lack projectId frontmatter; only include them
+        // if the basename matches this project's prefix to avoid leaking unrelated chats.
+        if (projectId === undefined) {
+          const sanitizedPrefix = `${sanitizeVaultPathSegment(currentProjectId)}__`;
+          const rawPrefix = `${currentProjectId}__`;
+          return file.basename.startsWith(sanitizedPrefix) || file.basename.startsWith(rawPrefix);
+        }
+        return false;
+      }
+      // Reason: exclude files with projectId OR known project prefix in filename
+      return !projectId && !hasKnownProjectPrefix(file.basename);
+    })
+    .map(({ file }) => file);
+}
 
 /**
  * Extract chat title from a file.
@@ -16,8 +134,31 @@ export function extractChatTitle(file: TFile): string {
   }
 
   // Fallback to extracting from filename
-  // First, remove project ID prefix if it exists (format: projectId__)
-  const basename = file.basename.replace(/^[a-zA-Z0-9-]+__/, "");
+  // Reason: use the exact frontmatter projectId to strip the prefix precisely,
+  // rather than guessing which characters the sanitized prefix may contain.
+  // Coerce numeric IDs (YAML parses unquoted digits as numbers).
+  let basename = file.basename;
+  const rawProjectId = frontmatter?.projectId;
+  const projectId =
+    typeof rawProjectId === "string"
+      ? rawProjectId.trim()
+      : typeof rawProjectId === "number"
+        ? String(rawProjectId)
+        : "";
+
+  if (projectId) {
+    const sanitizedPrefix = `${sanitizeVaultPathSegment(projectId)}__`;
+    const rawPrefix = `${projectId}__`;
+    if (basename.startsWith(sanitizedPrefix)) {
+      basename = basename.slice(sanitizedPrefix.length);
+    } else if (basename.startsWith(rawPrefix)) {
+      basename = basename.slice(rawPrefix.length);
+    }
+  } else {
+    // Reason: hidden-directory files have no metadataCache entry, so projectId
+    // is unavailable. Fall back to heuristic regex to strip common prefixes.
+    basename = basename.replace(/^[a-zA-Z0-9_-]+__/, "");
+  }
 
   // Remove {$date} and {$time} parts from the filename
   return basename

--- a/src/utils/urlTagUtils.ts
+++ b/src/utils/urlTagUtils.ts
@@ -1,0 +1,156 @@
+/**
+ * Pure utility functions for converting between ProjectConfig's newline-separated
+ * URL strings and the UrlItem[] model used by UrlTagInput.
+ *
+ * Reason: The UrlTagInput component works with structured UrlItem objects,
+ * but ProjectConfig stores URLs as newline-separated strings in two separate
+ * fields (webUrls / youtubeUrls). This module bridges those two representations
+ * with stable round-trip guarantees so saving unchanged URLs won't trigger
+ * unnecessary cache invalidation in projectManager.
+ */
+
+import { getYouTubeVideoId } from "@/utils/youtubeUrl";
+
+export interface UrlItem {
+  id: string;
+  url: string;
+  type: "web" | "youtube";
+}
+
+/**
+ * Create a stable ID from type and URL.
+ * Reason: Using random IDs causes React key instability when the list is
+ * re-parsed from strings on every render. A deterministic ID based on
+ * the URL content ensures stable keys and prevents unnecessary re-mounts.
+ */
+function stableId(type: "web" | "youtube", url: string): string {
+  return `${type}:${url}`;
+}
+
+/**
+ * Detect whether a URL is a YouTube video (watch/shorts/embed/youtu.be).
+ *
+ * Reason: Reuses the structured URL parser `getYouTubeVideoId` from `@/utils/youtubeUrl`
+ * instead of a loose hostname check, so only actual video URLs are classified as
+ * "youtube". Non-video YouTube pages (channels, playlists, homepage) correctly
+ * fall through to "web", matching the downstream transcript pipeline expectation.
+ */
+export function detectUrlType(url: string): "web" | "youtube" {
+  // Reason: User input may omit the protocol (e.g. "youtube.com/watch?v=...").
+  // getYouTubeVideoId requires a full URL for `new URL()` parsing.
+  const normalized = url.startsWith("http") ? url : `https://${url}`;
+  return getYouTubeVideoId(normalized) !== null ? "youtube" : "web";
+}
+
+/**
+ * Parse ProjectConfig's webUrls + youtubeUrls newline strings into UrlItem[].
+ *
+ * Web items come first (preserving order), then YouTube items (preserving order).
+ * Duplicates within the same field are removed (first occurrence wins).
+ */
+export function parseProjectUrls(webUrls: string, youtubeUrls: string): UrlItem[] {
+  // Reason: Dedup by (type, url) pair so the same URL in both webUrls and youtubeUrls
+  // is preserved for each field independently — prevents silent data loss on round-trip.
+  const seen = new Set<string>();
+  const items: UrlItem[] = [];
+
+  const parseField = (raw: string, type: "web" | "youtube") => {
+    if (!raw) return;
+    const lines = raw.split("\n");
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const key = stableId(type, trimmed);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      items.push({ id: key, url: trimmed, type });
+    }
+  };
+
+  // Reason: Web first, then YouTube — matches the visual grouping order in UrlTagInput
+  parseField(webUrls, "web");
+  parseField(youtubeUrls, "youtube");
+
+  return items;
+}
+
+/**
+ * Serialize UrlItem[] back to the two newline-separated strings that
+ * ProjectConfig expects.
+ *
+ * Preserves item order within each type. Trims and deduplicates.
+ * Produces stable output so unchanged URLs produce identical strings.
+ */
+export function serializeProjectUrls(items: UrlItem[]): {
+  webUrls: string;
+  youtubeUrls: string;
+} {
+  const webSeen = new Set<string>();
+  const youtubeSeen = new Set<string>();
+  const webLines: string[] = [];
+  const youtubeLines: string[] = [];
+
+  for (const item of items) {
+    const trimmed = item.url.trim();
+    if (!trimmed) continue;
+
+    if (item.type === "youtube") {
+      if (youtubeSeen.has(trimmed)) continue;
+      youtubeSeen.add(trimmed);
+      youtubeLines.push(trimmed);
+    } else {
+      if (webSeen.has(trimmed)) continue;
+      webSeen.add(trimmed);
+      webLines.push(trimmed);
+    }
+  }
+
+  return {
+    webUrls: webLines.join("\n"),
+    youtubeUrls: youtubeLines.join("\n"),
+  };
+}
+
+/**
+ * Check whether a string looks like a real URL.
+ * Reason: The old Textarea didn't validate — users typed raw text.
+ * The new UrlTagInput actively parses, splits, and normalizes input,
+ * so this function is the behavioral gate. A loose check like `includes(".")`
+ * would silently convert "e.g.", "v1.2.3", or filenames into URLs.
+ */
+export function isValidUrl(text: string): boolean {
+  const normalized = text.trim();
+  if (!normalized) return false;
+
+  try {
+    const url = new URL(
+      normalized.startsWith("http://") || normalized.startsWith("https://")
+        ? normalized
+        : `https://${normalized}`
+    );
+
+    // Reason: only http/https are valid project context URLs
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+
+    // Reason: reject email-like inputs (user@host) and mailto: URIs that the
+    // URL constructor parses as authority-form URLs with a username component.
+    if (url.username) return false;
+
+    const hostname = url.hostname.toLowerCase();
+    if (!hostname) return false;
+
+    // Reason: localhost, IPv4, and IPv6 are valid hosts that the old textarea accepted
+    if (hostname === "localhost") return true;
+    if (/^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname)) return true;
+    if (hostname.startsWith("[") && hostname.endsWith("]")) return true;
+
+    // Reason: any dotted hostname is accepted (e.g. youtu.be, example.com).
+    // Bare single-label words like "foo" are still rejected so Enter/paste
+    // doesn't silently convert arbitrary text into URLs.
+    if (hostname.includes(".")) return true;
+
+    return false;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/vaultAdapterUtils.ts
+++ b/src/utils/vaultAdapterUtils.ts
@@ -67,8 +67,10 @@ export async function patchFrontmatter(
   if (!(await app.vault.adapter.exists(filePath))) return;
 
   const raw = await app.vault.adapter.read(filePath);
+  // Reason: detect line ending style to preserve consistency when appending new fields
+  const lineEnding = raw.includes("\r\n") ? "\r\n" : "\n";
   const updated = raw.replace(
-    /^(---\n[\s\S]*?)(---)/,
+    /^(\uFEFF?---\r?\n[\s\S]*?\r?\n)(---)/,
     (_match, yamlBlock: string, closing: string) => {
       let patched = yamlBlock;
       for (const [key, value] of Object.entries(updates)) {
@@ -80,7 +82,7 @@ export async function patchFrontmatter(
         if (fieldRegex.test(patched)) {
           patched = patched.replace(fieldRegex, `${key}: ${formattedValue}`);
         } else {
-          patched += `${key}: ${formattedValue}\n`;
+          patched += `${key}: ${formattedValue}${lineEnding}`;
         }
       }
       return patched + closing;
@@ -102,12 +104,15 @@ export async function readFrontmatterViaAdapter(
   filePath: string
 ): Promise<Record<string, string> | null> {
   const raw = await app.vault.adapter.read(filePath);
-  const yaml = raw.match(/^---\n([\s\S]*?)\n---/)?.[1];
+  // Reason: strip BOM and accept CRLF line endings for Windows/external-editor compatibility
+  const normalized = raw.replace(/^\uFEFF/, "");
+  const yaml = normalized.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1];
   if (!yaml) return null;
 
   const result: Record<string, string> = {};
-  for (const line of yaml.split("\n")) {
-    const match = line.match(/^(\w+):\s*(.+)/);
+  for (const line of yaml.split(/\r?\n/)) {
+    // Reason: use [\w-] instead of \w to support hyphenated YAML keys (e.g. copilot-project-last-used)
+    const match = line.match(/^([\w-]+):\s*(.+)/);
     if (match) {
       result[match[1]] = match[2].trim().replace(/^["']|["']$/g, "");
     }

--- a/src/utils/youtubeUrl.ts
+++ b/src/utils/youtubeUrl.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure YouTube URL parsing utilities.
+ *
+ * Reason: These functions are needed by both utils (urlTagUtils) and services
+ * (webViewerService). Placing them in a neutral utils module avoids a utils → service
+ * dependency and keeps the dependency graph clean.
+ */
+
+/**
+ * Extract YouTube video ID from various URL formats.
+ * Supports: youtube.com/watch, youtu.be, youtube.com/shorts, m.youtube.com, embed
+ * @returns video ID or null if not a valid YouTube video URL
+ */
+export function getYouTubeVideoId(url: string): string | null {
+  try {
+    const u = new URL(url);
+    const hostname = u.hostname.replace(/^www\./, "").replace(/^m\./, "");
+
+    // youtube.com/watch?v=xxx or youtube.com/watch?v=xxx&t=120
+    if (hostname === "youtube.com" && u.pathname === "/watch") {
+      return u.searchParams.get("v");
+    }
+
+    // youtu.be/xxx or youtu.be/xxx?t=120
+    if (hostname === "youtu.be" && u.pathname.length > 1) {
+      return u.pathname.slice(1).split("/")[0];
+    }
+
+    // youtube.com/shorts/xxx
+    if (hostname === "youtube.com" && u.pathname.startsWith("/shorts/")) {
+      return u.pathname.split("/")[2] || null;
+    }
+
+    // youtube.com/embed/xxx
+    if (hostname === "youtube.com" && u.pathname.startsWith("/embed/")) {
+      return u.pathname.split("/")[2] || null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Check if URL is a YouTube video page */
+export function isYouTubeVideoUrl(url: string): boolean {
+  return getYouTubeVideoId(url) !== null;
+}


### PR DESCRIPTION
## Summary

- Migrate project definitions and metadata from `data.json` (`settings.projectList`) to individual markdown files in the vault's projects directory
- Add `ProjectFileManager` for CRUD operations with YAML frontmatter parsing/persistence
- Add `ProjectRegister` for vault-event reconciliation (create/rename/delete/modify)
- Add migration logic from legacy format with `unsupported/` backup for failed entries
- Add project UI components: `AddProjectModal`, `ProjectList`, `ProgressCard`, `ProcessingStatus`
- Integrate chat history with new file-based project storage model
- Add status sorting, cache-first ordering, and URL removal in processing pipeline
- Use atomic cache operations (`replaceCachedProjectRecordByFilePath`) to prevent transient disappearance on rename
- Await context cache cleanup on all delete/rename/folder-switch paths to prevent same-ID race
- Parse frontmatter from raw file content first, fall back to metadataCache only when no frontmatter block exists
- Add BOM/CRLF support in `readFrontmatterViaAdapter` and `patchFrontmatter`
- Add `aria-label` to all icon-only buttons for accessibility

## Test plan

- [x] Unit tests pass (106 suites, 1938 tests)
- [x] ESLint passes with 0 errors
- [ ] Verify fresh install: no legacy projects → no migration dialog
- [ ] Verify migration: existing `data.json` projects migrate to vault files correctly
- [ ] Verify failed migration: unsupported projects backed up to `unsupported/` folder
- [ ] Verify project CRUD: create, edit, rename, delete projects via UI
- [ ] Verify external file operations: rename/delete project files outside Obsidian
- [ ] Verify folder switch: change projects folder in settings, confirm reload
- [ ] Verify chat isolation: project chats remain separate from non-project chats
- [ ] Verify hidden folder support: projects in dot-prefixed folders work correctly

## Actual Effect

https://github.com/user-attachments/assets/adea067e-7037-43b7-a7f4-195ba8b74243