### PR TITLE
chore: enforce prettier formatting in CI and fix all drift

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm ci
+      - run: npm run format:check
       - run: npm run lint
       - run: npm run build --if-present
       - run: npm test

--- a/src/LLMProviders/githubCopilot/GitHubCopilotChatModel.ts
+++ b/src/LLMProviders/githubCopilot/GitHubCopilotChatModel.ts
@@ -38,7 +38,9 @@ function normalizeDeltaContent(content: unknown): string {
 }
 
 /** Extract the constructor fields type from ChatOpenAICompletions. */
-type ChatOpenAICompletionsFields = NonNullable<ConstructorParameters<typeof ChatOpenAICompletions>[0]>;
+type ChatOpenAICompletionsFields = NonNullable<
+  ConstructorParameters<typeof ChatOpenAICompletions>[0]
+>;
 
 /**
  * Constructor params for GitHubCopilotChatModel.

--- a/src/commands/CustomCommandChatModal.tsx
+++ b/src/commands/CustomCommandChatModal.tsx
@@ -1,7 +1,10 @@
 import { CustomModel, useModelKey } from "@/aiParams";
 import { processCommandPrompt } from "@/commands/customCommandUtils";
 import { MenuCommandModal, type ContentState } from "@/components/command-ui";
-import { MODAL_MIN_HEIGHT_COMPACT, MODAL_MIN_HEIGHT_EXPANDED } from "@/components/command-ui/constants";
+import {
+  MODAL_MIN_HEIGHT_COMPACT,
+  MODAL_MIN_HEIGHT_EXPANDED,
+} from "@/components/command-ui/constants";
 import { SelectionHighlight } from "@/editor/selectionHighlight";
 import { createHighlightReplaceGuard, type ReplaceGuard } from "@/editor/replaceGuard";
 import { logError, logWarn } from "@/logger";
@@ -520,7 +523,11 @@ export class CustomCommandChatModal {
    * - Space checks use scrollRect (editor visible area), not window.
    * - Horizontal clamp to scrollRect first, then viewport as safety net.
    */
-  private getInitialPosition(activeView: MarkdownView | null): { x: number; y: number; anchorBottom?: number } {
+  private getInitialPosition(activeView: MarkdownView | null): {
+    x: number;
+    y: number;
+    anchorBottom?: number;
+  } {
     const win = this.resolveWindow(activeView);
     const panelWidth = Math.min(500, win.innerWidth * 0.9);
     // Reason: The actual initial panel height depends on whether ContentArea is shown.
@@ -528,7 +535,9 @@ export class CustomCommandChatModal {
     // Custom Commands always show ContentArea (expanded).
     // Using the correct height prevents gaps (above) or overlaps (below).
     const hideContentAreaOnIdle = this.configs.behaviorConfig?.hideContentAreaOnIdle ?? false;
-    const panelHeight = hideContentAreaOnIdle ? MODAL_MIN_HEIGHT_COMPACT : MODAL_MIN_HEIGHT_EXPANDED;
+    const panelHeight = hideContentAreaOnIdle
+      ? MODAL_MIN_HEIGHT_COMPACT
+      : MODAL_MIN_HEIGHT_EXPANDED;
     const margin = 12;
     const gap = 6;
 
@@ -583,8 +592,11 @@ export class CustomCommandChatModal {
       (topCoords?.bottom ?? 0) - (topCoords?.top ?? 0),
       (bottomCoords?.bottom ?? 0) - (bottomCoords?.top ?? 0)
     );
-    const isVisualMultiLine = !isCursor && topCoords && bottomCoords
-      && Math.abs(topCoords.top - bottomCoords.top) > Math.max(caretHeight / 2, 2);
+    const isVisualMultiLine =
+      !isCursor &&
+      topCoords &&
+      bottomCoords &&
+      Math.abs(topCoords.top - bottomCoords.top) > Math.max(caretHeight / 2, 2);
 
     // --- Vertical positioning (decides placement first) ---
     // Reason: Extracted to a pure helper (computeVerticalPlacement) so the

--- a/src/components/command-ui/action-buttons.tsx
+++ b/src/components/command-ui/action-buttons.tsx
@@ -47,12 +47,7 @@ export function ActionButtons({
       {state === "result" && showInsertReplace && (
         <>
           {onCopy && (
-            <Button
-              size="sm"
-              variant="secondary"
-              onClick={onCopy}
-              title="Copy to clipboard"
-            >
+            <Button size="sm" variant="secondary" onClick={onCopy} title="Copy to clipboard">
               Copy
             </Button>
           )}

--- a/src/components/command-ui/content-area.tsx
+++ b/src/components/command-ui/content-area.tsx
@@ -55,10 +55,8 @@ export function ContentArea({
   const [isEditMode, setIsEditMode] = React.useState(false);
 
   // Determine if we should show the markdown preview
-  const isCompletedResult =
-    state.type === "result" && !state.isStreaming;
-  const showPreview =
-    !!renderMarkdown && isCompletedResult && !isEditMode;
+  const isCompletedResult = state.type === "result" && !state.isStreaming;
+  const showPreview = !!renderMarkdown && isCompletedResult && !isEditMode;
 
   // Reason: Reset to preview mode whenever a new generation starts.
   // This covers both type transitions (idle→loading) and same-type transitions
@@ -94,7 +92,8 @@ export function ContentArea({
 
   // Markdown preview mode
   if (showPreview && renderMarkdown) {
-    const previewContent = (editable && value !== undefined) ? value : (state as { text: string }).text;
+    const previewContent =
+      editable && value !== undefined ? value : (state as { text: string }).text;
     return (
       <div className={cn("tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-px-4 tw-py-2", className)}>
         <div className="tw-relative tw-min-h-0 tw-flex-1 tw-overflow-auto tw-rounded-md tw-border tw-border-solid tw-px-3 tw-py-2">

--- a/src/components/command-ui/draggable-modal.tsx
+++ b/src/components/command-ui/draggable-modal.tsx
@@ -56,7 +56,13 @@ export function DraggableModal({
   closeOnEscapeFromOutside = false,
   anchorBottom,
 }: DraggableModalProps) {
-  const { position, setPosition, dragRef, handleMouseDown: rawHandleMouseDown, isDragging } = useDraggable({
+  const {
+    position,
+    setPosition,
+    dragRef,
+    handleMouseDown: rawHandleMouseDown,
+    isDragging,
+  } = useDraggable({
     initialPosition: initialPosition || {
       x: typeof window !== "undefined" ? (window.innerWidth - 500) / 2 : 100,
       y: typeof window !== "undefined" ? (window.innerHeight - 400) / 2 : 100,

--- a/src/components/quick-ask/QuickAskMessage.tsx
+++ b/src/components/quick-ask/QuickAskMessage.tsx
@@ -95,7 +95,9 @@ export const QuickAskMessageComponent = React.memo(function QuickAskMessageCompo
   if (message.role === "user") {
     return (
       <div className="tw-max-w-[85%] tw-self-end tw-rounded-lg tw-rounded-br-sm tw-bg-interactive-accent tw-px-3 tw-py-2 tw-text-on-accent">
-        <div data-quick-ask-selectable className="tw-whitespace-pre-wrap tw-break-words tw-text-sm">{message.content}</div>
+        <div data-quick-ask-selectable className="tw-whitespace-pre-wrap tw-break-words tw-text-sm">
+          {message.content}
+        </div>
       </div>
     );
   }
@@ -104,7 +106,10 @@ export const QuickAskMessageComponent = React.memo(function QuickAskMessageCompo
   if (isStreaming) {
     return (
       <div className="tw-max-w-[95%] tw-self-start tw-rounded-lg tw-rounded-bl-sm tw-bg-secondary tw-px-3 tw-py-2">
-        <div data-quick-ask-selectable className="tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-text-normal">
+        <div
+          data-quick-ask-selectable
+          className="tw-whitespace-pre-wrap tw-break-words tw-text-sm tw-text-normal"
+        >
           {message.content}
           <span className="tw-animate-pulse tw-text-accent">▊</span>
         </div>

--- a/src/components/quick-ask/QuickAskOverlay.tsx
+++ b/src/components/quick-ask/QuickAskOverlay.tsx
@@ -97,7 +97,11 @@ export class QuickAskOverlay {
    * @param bottomAnchorPos - Bottom anchor (normalized selection.to) for "place below"
    * @param topAnchorPos - Top anchor (selection.from) for "place above" flip target
    */
-  mount(bottomAnchorPos: number, topAnchorPos?: number | null, focusAnchorPos?: number | null): void {
+  mount(
+    bottomAnchorPos: number,
+    topAnchorPos?: number | null,
+    focusAnchorPos?: number | null
+  ): void {
     this.bottomAnchorPos = bottomAnchorPos;
     this.topAnchorPos = typeof topAnchorPos === "number" ? topAnchorPos : null;
     this.focusAnchorPos = typeof focusAnchorPos === "number" ? focusAnchorPos : null;
@@ -477,7 +481,7 @@ export class QuickAskOverlay {
         this.placementSide = "below";
       } else if (topRect) {
         const aboveY = topRect.top - hostRect.top - PANEL_OFFSET_Y - heightForClamp;
-        const spaceAbove = (topRect.top - hostRect.top) - PANEL_OFFSET_Y - visibleTop;
+        const spaceAbove = topRect.top - hostRect.top - PANEL_OFFSET_Y - visibleTop;
 
         if (spaceAbove >= heightForClamp + PANEL_MARGIN) {
           top = aboveY;
@@ -497,7 +501,7 @@ export class QuickAskOverlay {
     } else if (topRect) {
       // Bottom anchor not visible (selection extends below viewport): place above topRect
       const aboveY = topRect.top - hostRect.top - PANEL_OFFSET_Y - heightForClamp;
-      const spaceAbove = (topRect.top - hostRect.top) - PANEL_OFFSET_Y - visibleTop;
+      const spaceAbove = topRect.top - hostRect.top - PANEL_OFFSET_Y - visibleTop;
 
       if (spaceAbove >= heightForClamp + PANEL_MARGIN) {
         top = aboveY;

--- a/src/components/ui/ModelParametersEditor.tsx
+++ b/src/components/ui/ModelParametersEditor.tsx
@@ -78,7 +78,8 @@ export function ModelParametersEditor({
     model.provider === "lm_studio" ||
     model.provider === ChatModelProviders.LM_STUDIO ||
     hasReasoningCapability;
-  const showVerbosity = model.name.startsWith("gpt-5") && model.provider === ChatModelProviders.OPENAI;
+  const showVerbosity =
+    model.name.startsWith("gpt-5") && model.provider === ChatModelProviders.OPENAI;
 
   return (
     <div className="tw-space-y-4">
@@ -131,8 +132,8 @@ export function ModelParametersEditor({
                   model can use as context. Default is {DEFAULT_OLLAMA_NUM_CTX}.
                 </p>
                 <em>
-                  Lower this value to reduce VRAM usage on GPUs with limited memory. Ollama will
-                  cap this at the model&apos;s actual maximum.
+                  Lower this value to reduce VRAM usage on GPUs with limited memory. Ollama will cap
+                  this at the model&apos;s actual maximum.
                 </em>
               </>
             }

--- a/src/core/ContextManager.l2Promotion.test.ts
+++ b/src/core/ContextManager.l2Promotion.test.ts
@@ -84,7 +84,9 @@ function buildEnvelopeWithL3Segments(segments: PromptLayerSegment[]): PromptCont
 /**
  * Create a mock MessageRepository that returns the given display messages.
  */
-function createMockMessageRepo(messages: Array<{ id: string; sender: string; contextEnvelope?: PromptContextEnvelope }>) {
+function createMockMessageRepo(
+  messages: Array<{ id: string; sender: string; contextEnvelope?: PromptContextEnvelope }>
+) {
   return {
     getDisplayMessages: () =>
       messages.map((msg) => ({

--- a/src/services/obsidianCli/cliErrors.ts
+++ b/src/services/obsidianCli/cliErrors.ts
@@ -45,6 +45,11 @@ export function formatCliFailureMessage(
  */
 export function throwCliFailure(result: ObsidianCliProcessResult): never {
   throw new Error(
-    formatCliFailureMessage(result.stderr, result.exitCode, result.errorCode, result.attemptedBinaries)
+    formatCliFailureMessage(
+      result.stderr,
+      result.exitCode,
+      result.errorCode,
+      result.attemptedBinaries
+    )
   );
 }

--- a/src/settings/v2/components/ModelImporter.tsx
+++ b/src/settings/v2/components/ModelImporter.tsx
@@ -45,14 +45,24 @@ function renderVerificationMessage(message: string): React.ReactNode {
       const match = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
       if (match) {
         return (
-          <a key={j} href={match[2]} target="_blank" rel="noopener noreferrer" className="tw-underline">
+          <a
+            key={j}
+            href={match[2]}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="tw-underline"
+          >
             {match[1]}
           </a>
         );
       }
       return part;
     });
-    return <p key={i} className={i > 0 ? "tw-mt-1" : ""}>{nodes}</p>;
+    return (
+      <p key={i} className={i > 0 ? "tw-mt-1" : ""}>
+        {nodes}
+      </p>
+    );
   });
 }
 

--- a/src/utils/quickAskAnchorMapping.test.ts
+++ b/src/utils/quickAskAnchorMapping.test.ts
@@ -1,7 +1,4 @@
-import {
-  mapQuickAskAnchorPositions,
-  type QuickAskAnchorPositions,
-} from "./quickAskAnchorMapping";
+import { mapQuickAskAnchorPositions, type QuickAskAnchorPositions } from "./quickAskAnchorMapping";
 
 /** Creates a mock ChangeMapper that records calls and returns deterministic results. */
 function makeChanges() {


### PR DESCRIPTION
## Summary

- Adds `npm run format:check` to CI so PRs fail if any file is unformatted
- Runs a one-time full-codebase format to clear 13 files worth of accumulated drift

## Why

The pre-commit hook (lint-staged) only formats **staged files**, so unformatted code from contributors accumulates silently. Every PR that ran `npm run format` would pick up unrelated changes. The CI check enforces formatting on all files going forward.

## Test plan

- [ ] CI passes with `format:check` step green
- [ ] No formatting changes appear in future PRs on unrelated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)