### PR TITLE
refactor(miyo): rename folder_path to folder_name

### DIFF
--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -84,7 +84,7 @@ describe("MiyoClient", () => {
           Authorization: "Bearer plus-test-license",
         },
         contentType: "application/json",
-        body: JSON.stringify({ folder_path: "TestVault", path: "docs/sample.pdf" }),
+        body: JSON.stringify({ folder_name: "TestVault", path: "docs/sample.pdf" }),
       })
     );
     expect(mockedLogInfo).toHaveBeenCalledWith(
@@ -97,7 +97,7 @@ describe("MiyoClient", () => {
     );
   });
 
-  it("sends folder_path in /v0/search requests", async () => {
+  it("sends folder_name in /v0/search requests", async () => {
     mockedRequestUrl.mockResolvedValue({
       status: 200,
       json: { results: [] },
@@ -115,7 +115,7 @@ describe("MiyoClient", () => {
         method: "POST",
         body: JSON.stringify({
           query: "project notes",
-          folder_path: "/vault",
+          folder_name: "/vault",
           limit: 10,
           filters: [{ field: "mtime", gte: 1, lte: 2 }],
         }),
@@ -143,7 +143,7 @@ describe("MiyoClient", () => {
     );
   });
 
-  it("lists indexed files from /v0/folder/files with folder_path query params", async () => {
+  it("lists indexed files from /v0/folder/files with folder_name query params", async () => {
     mockedRequestUrl.mockResolvedValue({
       status: 200,
       json: { files: [], total: 0 },
@@ -160,7 +160,7 @@ describe("MiyoClient", () => {
 
     expect(mockedRequestUrl).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "http://127.0.0.1:8742/v0/folder/files?folder_path=%2Fvault&offset=10&limit=25&order_by=mtime",
+        url: "http://127.0.0.1:8742/v0/folder/files?folder_name=%2Fvault&offset=10&limit=25&order_by=mtime",
         method: "GET",
       })
     );

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -13,7 +13,6 @@ export interface MiyoIndexedFileEntry {
   title?: string | null;
   mtime: number;
   updated_at?: string;
-  folder_path?: string | null;
   total_chunks?: number;
 }
 
@@ -62,7 +61,6 @@ export interface MiyoDocumentsResponse {
     extension?: string;
     created_at?: string | number | null;
     nchars?: number;
-    folder_path?: string | null;
   }>;
 }
 
@@ -84,7 +82,6 @@ export interface MiyoSearchResult {
   extension?: string;
   created_at?: string | number | null;
   nchars?: number;
-  folder_path?: string | null;
 }
 
 /**
@@ -242,7 +239,7 @@ export class MiyoClient {
     return this.requestJson<MiyoIndexedFilesResponse>(baseUrl, "/v0/folder/files", {
       method: "GET",
       query: {
-        folder_path: options.folderName,
+        folder_name: options.folderName,
         title: options.title,
         file_path: options.filePath,
         mtime_after: options.mtimeAfter,
@@ -271,7 +268,7 @@ export class MiyoClient {
       method: "GET",
       query: {
         path,
-        folder_path: folderName,
+        folder_name: folderName,
       },
     });
   }
@@ -295,7 +292,7 @@ export class MiyoClient {
   ): Promise<MiyoSearchResponse> {
     const payload = {
       query,
-      folder_path: folderName,
+      folder_name: folderName,
       limit,
       ...(filters && filters.length > 0 ? { filters } : {}),
     };
@@ -327,7 +324,7 @@ export class MiyoClient {
   ): Promise<MiyoRelatedSearchResponse> {
     const payload = {
       file_path: filePath,
-      ...(options?.folderName ? { folder_path: options.folderName } : {}),
+      ...(options?.folderName ? { folder_name: options.folderName } : {}),
       ...(typeof options?.limit === "number" ? { limit: options.limit } : {}),
       ...(options?.filters && options.filters.length > 0 ? { filters: options.filters } : {}),
     };
@@ -352,7 +349,7 @@ export class MiyoClient {
   ): Promise<MiyoParseDocResponse> {
     return this.requestJson<MiyoParseDocResponse>(baseUrl, "/v0/parse-doc", {
       method: "POST",
-      body: { folder_path: folderName, path },
+      body: { folder_name: folderName, path },
     });
   }
 

--- a/src/miyo/miyoUtils.ts
+++ b/src/miyo/miyoUtils.ts
@@ -36,7 +36,7 @@ export function shouldUseMiyo(settings: CopilotSettings): boolean {
 }
 
 /**
- * Resolve the folder identifier sent to Miyo as `folder_path`.
+ * Resolve the folder identifier sent to Miyo as `folder_name`.
  *
  * @param app - Obsidian application instance.
  * @returns Vault folder name.


### PR DESCRIPTION
## Summary
- Rename all `folder_path` request parameters to `folder_name` across Miyo client methods (`listFolderFiles`, `getDocumentsByPath`, `search`, `searchRelated`, `parseDoc`) to match the updated Miyo server API
- Remove `folder_path` from response interfaces (`MiyoIndexedFileEntry`, `MiyoDocumentsResponse`, `MiyoSearchResult`) as the server no longer returns it
- Update tests and JSDoc to reflect the rename

## Test plan
- [x] All MiyoClient unit tests pass with updated expectations
- [ ] Verify Miyo search, indexing, and parse-doc work end-to-end against the updated server

🤖 Generated with [Claude Code](https://claude.com/claude-code)