### PR TITLE
feat(miyo): add toggle to search all indexed content

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -963,6 +963,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   enableSemanticSearchV3: false,
   enableSelfHostMode: false,
   enableMiyo: false,
+  miyoSearchAll: true,
   selfHostModeValidatedAt: null,
   selfHostValidationCount: 0,
   selfHostUrl: "",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -963,7 +963,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   enableSemanticSearchV3: false,
   enableSelfHostMode: false,
   enableMiyo: false,
-  miyoSearchAll: true,
+  miyoSearchAll: false,
   selfHostModeValidatedAt: null,
   selfHostValidationCount: 0,
   selfHostUrl: "",

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -285,14 +285,14 @@ export class MiyoClient {
    */
   public async search(
     baseUrl: string,
-    folderName: string,
+    folderName: string | undefined,
     query: string,
     limit: number,
     filters?: MiyoSearchFilter[]
   ): Promise<MiyoSearchResponse> {
     const payload = {
       query,
-      folder_name: folderName,
+      ...(folderName ? { folder_name: folderName } : {}),
       limit,
       ...(filters && filters.length > 0 ? { filters } : {}),
     };

--- a/src/search/miyo/MiyoSemanticRetriever.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.ts
@@ -89,13 +89,8 @@ export class MiyoSemanticRetriever extends BaseRetriever {
           filters,
         });
       }
-      const response = await this.client.search(
-        baseUrl,
-        getMiyoFolderName(this.app),
-        query,
-        limit,
-        filters
-      );
+      const folderName = getSettings().miyoSearchAll ? undefined : getMiyoFolderName(this.app);
+      const response = await this.client.search(baseUrl, folderName, query, limit, filters);
 
       const rawResults = response.results || [];
       const filteredResults = rawResults.filter((result) => this.isScoreAboveThreshold(result));

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -131,6 +131,8 @@ export interface CopilotSettings {
   enableSelfHostMode: boolean;
   /** Enable Miyo-backed indexing and semantic search when self-host mode is active */
   enableMiyo: boolean;
+  /** When true, omit folder_name from Miyo search requests so all indexed content is searched */
+  miyoSearchAll: boolean;
   /** Timestamp of last successful Believer validation for self-host mode (null if never validated) */
   selfHostModeValidatedAt: number | null;
   /** Count of successful periodic validations (3 = permanently valid) */
@@ -429,6 +431,11 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   // Ensure enableMiyo has a default value
   if (typeof sanitizedSettings.enableMiyo !== "boolean") {
     sanitizedSettings.enableMiyo = DEFAULT_SETTINGS.enableMiyo;
+  }
+
+  // Ensure miyoSearchAll has a default value
+  if (typeof sanitizedSettings.miyoSearchAll !== "boolean") {
+    sanitizedSettings.miyoSearchAll = DEFAULT_SETTINGS.miyoSearchAll;
   }
 
   // Ensure miyoServerUrl has a default value

--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -237,12 +237,24 @@ export const CopilotPlusSettings: React.FC = () => {
                   />
 
                   {settings.enableMiyo && (
-                    <div className="tw-text-xs tw-text-muted">
-                      Folder identifier sent to Miyo:{" "}
-                      <span className="tw-font-medium tw-text-normal">
-                        {getMiyoFolderName(app)}
-                      </span>
-                    </div>
+                    <>
+                      <SettingItem
+                        type="switch"
+                        title="Search everything in Miyo"
+                        description="When enabled, Miyo searches all indexed content across all folders. When disabled, searches are limited to the current vault folder only."
+                        checked={settings.miyoSearchAll}
+                        onCheckedChange={(checked) => updateSetting("miyoSearchAll", checked)}
+                      />
+
+                      {!settings.miyoSearchAll && (
+                        <div className="tw-text-xs tw-text-muted">
+                          Folder identifier sent to Miyo:{" "}
+                          <span className="tw-font-medium tw-text-normal">
+                            {getMiyoFolderName(app)}
+                          </span>
+                        </div>
+                      )}
+                    </>
                   )}
 
                   <SettingItem


### PR DESCRIPTION
## Summary
- Add `miyoSearchAll` setting (default: `true`) that omits `folder_name` from Miyo search requests, enabling cross-folder search across all indexed content
- Add "Search everything in Miyo" toggle in settings UI, visible when Miyo is enabled
- When disabled, searches are scoped to the current vault folder and the folder identifier is displayed

## Test plan
- [ ] Enable Miyo, verify "Search everything in Miyo" toggle appears and is on by default
- [ ] With toggle on, run a search and confirm `folder_name` is not in the request payload (check debug logs)
- [ ] Toggle off, verify the folder identifier text appears and search requests include `folder_name`
- [ ] Verify other Miyo endpoints (parseDoc, listFolderFiles) still send `folder_name` regardless of toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)