### PR TITLE
fix: use thinking.type=adaptive for claude-opus-4-7+

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -193,7 +193,7 @@ export default class ChatModelManager {
 
     const modelName = customModel.name;
     const modelInfo = getModelInfo(modelName);
-    const { isThinkingEnabled } = modelInfo;
+    const { isThinkingEnabled, usesAdaptiveThinking } = modelInfo;
     const resolvedTemperature = this.getTemperatureForModel(modelInfo, customModel, settings);
     const maxTokens = customModel.maxTokens ?? settings.maxTokens;
 
@@ -240,10 +240,13 @@ export default class ChatModelManager {
           fetch: customModel.enableCors ? safeFetch : undefined,
         },
         ...(isThinkingEnabled && {
-          thinking: {
-            type: "enabled",
-            budget_tokens: ChatModelManager.ANTHROPIC_THINKING_BUDGET_TOKENS,
-          },
+          // claude-opus-4-7+ uses thinking.type="adaptive"; older models use "enabled"+budget_tokens
+          thinking: usesAdaptiveThinking
+            ? { type: "adaptive" as const }
+            : {
+                type: "enabled" as const,
+                budget_tokens: ChatModelManager.ANTHROPIC_THINKING_BUDGET_TOKENS,
+              },
         }),
       },
       [ChatModelProviders.AZURE_OPENAI]: await (async () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1188,6 +1188,8 @@ export interface ModelInfo {
   isOSeries: boolean;
   isGPT5: boolean;
   isThinkingEnabled: boolean;
+  /** True for claude-opus-4-7+ which use thinking.type="adaptive" instead of type="enabled"+budget_tokens */
+  usesAdaptiveThinking: boolean;
 }
 
 export function getModelInfo(model: BaseChatModel | string): ModelInfo {
@@ -1201,10 +1203,17 @@ export function getModelInfo(model: BaseChatModel | string): ModelInfo {
     modelName.startsWith("claude-sonnet-4") ||
     modelName.startsWith("claude-opus-4");
 
+  // claude-opus-4-7 and later versions dropped support for thinking.type="enabled"+budget_tokens
+  // in favour of thinking.type="adaptive" (the model decides when to use extended thinking).
+  // Extract the minor version from the model name and treat >= 7 as using the new adaptive API.
+  const opusMinorMatch = modelName.match(/^claude-opus-4-(\d+)/);
+  const usesAdaptiveThinking = opusMinorMatch ? parseInt(opusMinorMatch[1], 10) >= 7 : false;
+
   return {
     isOSeries,
     isGPT5,
     isThinkingEnabled,
+    usesAdaptiveThinking,
   };
 }
 


### PR DESCRIPTION
Fixes #2361

## Problem

`claude-opus-4-7` returns a 400 error when added as a custom model because the plugin sends the legacy extended-thinking parameter (`thinking.type=enabled` + `budget_tokens`) which is no longer supported by this model. The Anthropic API error message is:

```
`thinking.type.enabled` is not supported for this model. Use `thinking.type.adaptive` and `output_config.effort` to control thinking behavior.
```

The root cause is in `getModelInfo` (`src/utils.ts`): any model whose name starts with `claude-opus-4` is flagged as `isThinkingEnabled`, which causes `chatModelManager.ts` to unconditionally inject `{ type: "enabled", budget_tokens: 2048 }` into the Anthropic API request — regardless of which generation of the model the user has configured.

## Solution

Add a `usesAdaptiveThinking` field to `ModelInfo` that detects claude-opus-4 models with minor version ≥ 7 (the generational boundary where the API format changed):

```typescript
const opusMinorMatch = modelName.match(/^claude-opus-4-(\d+)/);
const usesAdaptiveThinking = opusMinorMatch ? parseInt(opusMinorMatch[1], 10) >= 7 : false;
```

In the Anthropic provider config, use the appropriate format based on this flag:

- **claude-3-7-sonnet-\*, claude-sonnet-4-\*, claude-opus-4-6 and earlier** → unchanged: `{ type: "enabled", budget_tokens: 2048 }`
- **claude-opus-4-7 and newer** → new format: `{ type: "adaptive" }`

## Testing

- `getModelInfo("claude-opus-4-6")` → `usesAdaptiveThinking: false` (old format, no regression)
- `getModelInfo("claude-opus-4-7")` → `usesAdaptiveThinking: true` (new format, fixes the 400)
- `getModelInfo("claude-sonnet-4-6")` → `usesAdaptiveThinking: false` (unaffected)
- `getModelInfo("claude-3-7-sonnet-20250219")` → `usesAdaptiveThinking: false` (unaffected)