### PR TITLE
feat(provider): add MiniMax-M2.7 (Global + CN)

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -75,6 +75,8 @@ const CHAT_PROVIDER_CONSTRUCTORS = {
   [ChatModelProviders.GROQ]: ChatGroq,
   [ChatModelProviders.OPENAI_FORMAT]: ChatOpenAI,
   [ChatModelProviders.SILICONFLOW]: ChatOpenAI,
+  [ChatModelProviders.MINIMAX]: ChatOpenAI,
+  [ChatModelProviders.MINIMAX_CN]: ChatOpenAI,
   [ChatModelProviders.COPILOT_PLUS]: ChatOpenRouter,
   [ChatModelProviders.MISTRAL]: ChatMistralAI,
   [ChatModelProviders.DEEPSEEK]: ChatDeepSeek,
@@ -144,6 +146,8 @@ export default class ChatModelManager {
     [ChatModelProviders.DEEPSEEK]: () => getSettings().deepseekApiKey,
     [ChatModelProviders.AMAZON_BEDROCK]: () => getSettings().amazonBedrockApiKey,
     [ChatModelProviders.SILICONFLOW]: () => getSettings().siliconflowApiKey,
+    [ChatModelProviders.MINIMAX]: () => getSettings().minimaxApiKey,
+    [ChatModelProviders.MINIMAX_CN]: () => getSettings().minimaxCnApiKey,
     [ChatModelProviders.GITHUB_COPILOT]: () =>
       getSettings().githubCopilotToken || getSettings().githubCopilotAccessToken,
   } as const;
@@ -398,6 +402,34 @@ export default class ChatModelManager {
           customModel
         ),
       },
+      [ChatModelProviders.MINIMAX]: {
+        modelName: modelName,
+        apiKey: await getDecryptedKey(customModel.apiKey || settings.minimaxApiKey),
+        configuration: {
+          baseURL: customModel.baseUrl || ProviderInfo[ChatModelProviders.MINIMAX].host,
+          fetch: customModel.enableCors ? safeFetch : undefined,
+        },
+        ...this.getOpenAISpecialConfig(
+          modelName,
+          customModel.maxTokens ?? settings.maxTokens,
+          customModel.temperature ?? settings.temperature,
+          customModel
+        ),
+      },
+      [ChatModelProviders.MINIMAX_CN]: {
+        modelName: modelName,
+        apiKey: await getDecryptedKey(customModel.apiKey || settings.minimaxCnApiKey),
+        configuration: {
+          baseURL: customModel.baseUrl || ProviderInfo[ChatModelProviders.MINIMAX_CN].host,
+          fetch: customModel.enableCors ? safeFetch : undefined,
+        },
+        ...this.getOpenAISpecialConfig(
+          modelName,
+          customModel.maxTokens ?? settings.maxTokens,
+          customModel.temperature ?? settings.temperature,
+          customModel
+        ),
+      },
       [ChatModelProviders.COPILOT_PLUS]: {
         modelName: modelName,
         apiKey: await getDecryptedKey(settings.plusLicenseKey),
@@ -598,6 +630,8 @@ export default class ChatModelManager {
           ChatModelProviders.MISTRAL,
           ChatModelProviders.DEEPSEEK,
           ChatModelProviders.SILICONFLOW,
+          ChatModelProviders.MINIMAX,
+          ChatModelProviders.MINIMAX_CN,
         ].includes(provider)
       ) {
         params.topP = customModel.topP;
@@ -618,6 +652,8 @@ export default class ChatModelManager {
           ChatModelProviders.MISTRAL,
           ChatModelProviders.DEEPSEEK,
           ChatModelProviders.SILICONFLOW,
+          ChatModelProviders.MINIMAX,
+          ChatModelProviders.MINIMAX_CN,
         ].includes(provider)
       ) {
         params.frequencyPenalty = customModel.frequencyPenalty;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -202,6 +202,7 @@ export enum ChatModels {
   OPENROUTER_GROK_4_1_FAST = "x-ai/grok-4.1-fast",
   SILICONFLOW_DEEPSEEK_V3 = "deepseek-ai/DeepSeek-V3",
   SILICONFLOW_DEEPSEEK_R1 = "deepseek-ai/DeepSeek-R1",
+  MINIMAX_M27 = "MiniMax-M2.7",
 }
 
 // Model Providers
@@ -223,6 +224,8 @@ export enum ChatModelProviders {
   COHEREAI = "cohereai",
   SILICONFLOW = "siliconflow",
   GITHUB_COPILOT = "github-copilot",
+  MINIMAX = "minimax",
+  MINIMAX_CN = "minimax-cn",
 }
 
 export enum ModelCapability {
@@ -430,6 +433,22 @@ export const BUILTIN_CHAT_MODELS: CustomModel[] = [
     enabled: false,
     isBuiltIn: false,
     baseUrl: "https://api.siliconflow.com/v1",
+    capabilities: [ModelCapability.REASONING],
+  },
+  {
+    name: ChatModels.MINIMAX_M27,
+    provider: ChatModelProviders.MINIMAX,
+    enabled: false,
+    isBuiltIn: true,
+    baseUrl: "https://api.minimax.io/v1",
+    capabilities: [ModelCapability.REASONING],
+  },
+  {
+    name: ChatModels.MINIMAX_M27,
+    provider: ChatModelProviders.MINIMAX_CN,
+    enabled: false,
+    isBuiltIn: true,
+    baseUrl: "https://api.minimaxi.com/v1",
     capabilities: [ModelCapability.REASONING],
   },
 ];
@@ -667,6 +686,22 @@ export const ProviderInfo: Record<Provider, ProviderMetadata> = {
     listModelURL: "https://api.siliconflow.com/v1/models",
     testModel: ChatModels.SILICONFLOW_DEEPSEEK_V3,
   },
+  [ChatModelProviders.MINIMAX]: {
+    label: "MiniMax",
+    host: "https://api.minimax.io/v1",
+    curlBaseURL: "https://api.minimax.io/v1",
+    keyManagementURL: "https://platform.minimax.io/user-center/basic-information/interface-key",
+    listModelURL: "https://api.minimax.io/v1/models",
+    testModel: ChatModels.MINIMAX_M27,
+  },
+  [ChatModelProviders.MINIMAX_CN]: {
+    label: "MiniMax (CN)",
+    host: "https://api.minimaxi.com/v1",
+    curlBaseURL: "https://api.minimaxi.com/v1",
+    keyManagementURL: "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+    listModelURL: "https://api.minimaxi.com/v1/models",
+    testModel: ChatModels.MINIMAX_M27,
+  },
   [ChatModelProviders.OLLAMA]: {
     label: "Ollama",
     host: "http://localhost:11434/v1/",
@@ -750,6 +785,8 @@ export const ProviderSettingsKeyMap: Record<SettingKeyProviders, keyof CopilotSe
   "amazon-bedrock": "amazonBedrockApiKey",
   siliconflow: "siliconflowApiKey",
   "github-copilot": "githubCopilotToken",
+  minimax: "minimaxApiKey",
+  "minimax-cn": "minimaxCnApiKey",
 };
 
 export enum VAULT_VECTOR_STORE_STRATEGY {
@@ -905,6 +942,8 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   amazonBedrockApiKey: "",
   amazonBedrockRegion: "",
   siliconflowApiKey: "",
+  minimaxApiKey: "",
+  minimaxCnApiKey: "",
   // GitHub Copilot OAuth tokens
   githubCopilotAccessToken: "",
   githubCopilotToken: "",

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -66,6 +66,8 @@ export interface CopilotSettings {
   amazonBedrockApiKey: string;
   amazonBedrockRegion: string;
   siliconflowApiKey: string;
+  minimaxApiKey: string;
+  minimaxCnApiKey: string;
   // GitHub Copilot OAuth tokens
   githubCopilotAccessToken: string;
   githubCopilotToken: string;

--- a/src/settings/providerModels.ts
+++ b/src/settings/providerModels.ts
@@ -344,6 +344,19 @@ export interface SiliconFlowModel {
   owned_by: string;
 }
 
+// MiniMax response model definition
+export interface MiniMaxModelResponse {
+  object: string;
+  data: MiniMaxModel[];
+}
+
+export interface MiniMaxModel {
+  id: string;
+  object: string;
+  created: number;
+  owned_by: string;
+}
+
 // GitHub Copilot response model definition
 export interface GitHubCopilotModelResponse {
   object: string;
@@ -407,6 +420,8 @@ export interface ProviderResponseMap {
   [ChatModelProviders.XAI]: XAIModelResponse;
   [ChatModelProviders.OPENROUTERAI]: OpenRouterAIModelResponse;
   [ChatModelProviders.SILICONFLOW]: SiliconFlowModelResponse;
+  [ChatModelProviders.MINIMAX]: MiniMaxModelResponse;
+  [ChatModelProviders.MINIMAX_CN]: MiniMaxModelResponse;
   [ChatModelProviders.COPILOT_PLUS]: null;
   [ChatModelProviders.AZURE_OPENAI]: null;
   [ChatModelProviders.AMAZON_BEDROCK]: unknown;
@@ -501,6 +516,20 @@ export const providerAdapters: ProviderModelAdapters = {
       id: model.id,
       name: model.id,
       provider: ChatModelProviders.SILICONFLOW,
+    })) || [],
+
+  [ChatModelProviders.MINIMAX]: (data): StandardModel[] =>
+    data.data?.map((model) => ({
+      id: model.id,
+      name: model.id,
+      provider: ChatModelProviders.MINIMAX,
+    })) || [],
+
+  [ChatModelProviders.MINIMAX_CN]: (data): StandardModel[] =>
+    data.data?.map((model) => ({
+      id: model.id,
+      name: model.id,
+      provider: ChatModelProviders.MINIMAX_CN,
     })) || [],
 
   [ChatModelProviders.GITHUB_COPILOT]: (data): StandardModel[] =>

--- a/src/utils/curlCommand.ts
+++ b/src/utils/curlCommand.ts
@@ -40,6 +40,8 @@ const OPENAI_COMPATIBLE_PROVIDERS = new Set<string>([
   ChatModelProviders.XAI,
   ChatModelProviders.SILICONFLOW,
   EmbeddingModelProviders.SILICONFLOW,
+  ChatModelProviders.MINIMAX,
+  ChatModelProviders.MINIMAX_CN,
   ChatModelProviders.OPENAI_FORMAT,
   EmbeddingModelProviders.OPENAI_FORMAT,
   ChatModelProviders.LM_STUDIO,


### PR DESCRIPTION
Adds MiniMax as a built-in OpenAI-compatible provider with `MiniMax-M2.7` selectable from the model picker. Mirrors the SiliconFlow pattern.

Two regional providers since URLs and API keys differ:
- **MiniMax** — `api.minimax.io`, key from [platform.minimax.io](https://platform.minimax.io)
- **MiniMax (CN)** — `api.minimaxi.com`, key from [platform.minimaxi.com](https://platform.minimaxi.com)

`format`, `lint`, `test` (1904/1904) all pass.