### PR TITLE
fix: remove 100ms IME timeout that delayed Enter key for Korean/CJK input

### DIFF
--- a/src/components/chat-components/plugins/KeyboardPlugin.tsx
+++ b/src/components/chat-components/plugins/KeyboardPlugin.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from "react";
+import { useEffect } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { COMMAND_PRIORITY_LOW, KEY_ENTER_COMMAND } from "lexical";
 import { SEND_SHORTCUT } from "@/constants";
@@ -19,75 +19,6 @@ interface KeyboardPluginProps {
  */
 export function KeyboardPlugin({ onSubmit, sendShortcut }: KeyboardPluginProps) {
   const [editor] = useLexicalComposerContext();
-  // Track IME composition state with a ref to avoid stale closure issues
-  const isComposingRef = useRef(false);
-  // Track the timeout to clear it on new composition
-  const compositionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Handle composition events to track IME state
-  // Use registerRootListener to handle cases where rootElement is initially null
-  useEffect(() => {
-    let currentRootElement: HTMLElement | null = null;
-
-    const handleCompositionStart = () => {
-      // Clear any pending timeout from previous composition
-      if (compositionTimeoutRef.current) {
-        clearTimeout(compositionTimeoutRef.current);
-        compositionTimeoutRef.current = null;
-      }
-      isComposingRef.current = true;
-    };
-
-    const handleCompositionEnd = () => {
-      // Clear any pending timeout
-      if (compositionTimeoutRef.current) {
-        clearTimeout(compositionTimeoutRef.current);
-      }
-      // Delay resetting the flag to ensure the Enter key from IME confirmation is ignored
-      compositionTimeoutRef.current = setTimeout(() => {
-        isComposingRef.current = false;
-        compositionTimeoutRef.current = null;
-      }, 100);
-    };
-
-    const attachListeners = (el: HTMLElement) => {
-      el.addEventListener("compositionstart", handleCompositionStart);
-      el.addEventListener("compositionend", handleCompositionEnd);
-    };
-
-    const detachListeners = (el: HTMLElement) => {
-      el.removeEventListener("compositionstart", handleCompositionStart);
-      el.removeEventListener("compositionend", handleCompositionEnd);
-    };
-
-    // Use registerRootListener to handle root element changes
-    const unregisterRootListener = editor.registerRootListener(
-      (rootElement: HTMLElement | null, prevRootElement: HTMLElement | null) => {
-        if (prevRootElement) {
-          detachListeners(prevRootElement);
-        }
-        if (rootElement) {
-          attachListeners(rootElement);
-        }
-        currentRootElement = rootElement;
-      }
-    );
-
-    return () => {
-      unregisterRootListener();
-
-      if (currentRootElement) {
-        detachListeners(currentRootElement);
-        currentRootElement = null;
-      }
-
-      // Clean up timeout on unmount
-      if (compositionTimeoutRef.current) {
-        clearTimeout(compositionTimeoutRef.current);
-        compositionTimeoutRef.current = null;
-      }
-    };
-  }, [editor]);
 
   useEffect(() => {
     return editor.registerCommand(
@@ -98,10 +29,10 @@ export function KeyboardPlugin({ onSubmit, sendShortcut }: KeyboardPluginProps) 
           return false;
         }
 
-        // Ignore Enter key during IME composition (e.g., Chinese, Japanese, Korean input)
-        // Check our ref, event.isComposing, and keyCode 229 for comprehensive IME detection
-        // IMPORTANT: Return true and preventDefault to "swallow" the event, preventing default newline insertion
-        if (isComposingRef.current || event.isComposing || event.keyCode === 229) {
+        // Ignore Enter key during IME composition (e.g., Chinese, Japanese, Korean input).
+        // event.isComposing is set by the browser while a composition session is active.
+        // keyCode 229 is the legacy indicator used by some environments during IME input.
+        if (event.isComposing || event.keyCode === 229) {
           event.preventDefault();
           return true;
         }


### PR DESCRIPTION
Fixes #2354

## Problem

When typing in Korean (Hangul) IME, pressing Enter to send a message required a noticeably longer press than expected. The root cause was a 100ms timeout introduced in the `KeyboardPlugin` component's `compositionend` handler:

```ts
// Old code — 100ms delay before isComposingRef resets
compositionTimeoutRef.current = setTimeout(() => {
  isComposingRef.current = false;
}, 100);
```

Because `isComposingRef.current` stayed `true` for 100ms after composition ended, any Enter key pressed within that window was silently blocked. Users had to either hold Enter (waiting for key-repeat to fire after the timeout) or press Enter twice with a deliberate pause — both feel like "the key requires a longer press".

## Solution

Remove the ref-based composition tracking entirely and rely directly on `event.isComposing || event.keyCode === 229`.

In Chromium/Electron (Obsidian's runtime), the `keydown` event for the Enter that confirms the final IME character fires **with `isComposing: true`** — the same composition flag the browser exposes. This means the explicit `compositionstart`/`compositionend` ref is redundant: the flag on the event itself is already reliable.

This approach is consistent with `follow-up-input.tsx` in the same codebase, which has always used the simpler `nativeEvent.isComposing || nativeEvent.keyCode === 229` check without any timeout.

## Testing

- All 16 existing `KeyboardPlugin` unit tests pass (`npm test -- --testPathPattern="KeyboardPlugin"`).
- Manual verification: after this change, a single normal-speed Enter press sends the message immediately after Korean IME composition ends, with no perceptible delay.