### PR TITLE
fix(ollama): route through safeFetch when enableCors is set

### DIFF
--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -344,6 +344,9 @@ export default class ChatModelManager {
         headers: {
           Authorization: `Bearer ${await getDecryptedKey(customModel.apiKey || "default-key")}`,
         },
+        // Route through Obsidian's requestUrl (safeFetch) to bypass CORS / mixed-content
+        // restrictions — required on mobile (WKWebView) when calling http:// Ollama hosts.
+        fetch: customModel.enableCors ? safeFetch : undefined,
         // Enable thinking for models with REASONING capability (e.g., qwen3, deepseek-r1)
         // Thinking content goes to additional_kwargs.reasoning_content
         think: customModel.capabilities?.includes(ModelCapability.REASONING) ?? false,


### PR DESCRIPTION
Other OpenAI-compatible providers (LM Studio, OpenAI-format, SiliconFlow, etc.) already pass a fetch override so requests can go through Obsidian's requestUrl API. The Ollama branch was missing this wiring, so toggling "Enable CORS" on an Ollama model had no effect and mobile (WKWebView) requests to http:// Ollama hosts failed with "Load failed" due to CORS / mixed-content blocking.