### PR TITLE
feat(i18n): add internationalization support with Chinese translation

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -51,6 +51,7 @@ import { arrayBufferToBase64 } from "@/utils/base64";
 import { Notice, TFile } from "obsidian";
 import { ContextManageModal } from "@/components/modals/project/context-manage-modal";
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { t } from "@/lang";
 import { v4 as uuidv4 } from "uuid";
 import { ChatHistoryItem } from "@/components/chat-components/ChatHistoryPopover";
 import { useActiveWebTabState } from "@/components/chat-components/hooks/useActiveWebTabState";
@@ -369,7 +370,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
       }
     } catch (error) {
       logError("Error sending message:", error);
-      new Notice("Failed to send message. Please try again.");
+      new Notice(t("messages.failedToSend"));
     } finally {
       safeSet.setLoading(false);
       safeSet.setLoadingMessage(LOADING_MESSAGES.DEFAULT);
@@ -388,7 +389,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
       await chatUIState.saveChat(currentModelKey);
     } catch (error) {
       logError("Error saving chat as note:", err2String(error));
-      new Notice("Failed to save chat as note. Check console for details.");
+      new Notice(t("messages.failedToSave"));
     }
   }, [app, chatUIState, currentModelKey]);
 
@@ -421,13 +422,13 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
   const handleRegenerate = useCallback(
     async (messageIndex: number) => {
       if (messageIndex <= 0) {
-        new Notice("Cannot regenerate the first message.");
+        new Notice(t("messages.cannotRegenerateFirst"));
         return;
       }
 
       const messageToRegenerate = chatHistory[messageIndex];
       if (!messageToRegenerate) {
-        new Notice("Message not found.");
+        new Notice(t("messages.messageNotFound"));
         return;
       }
 
@@ -443,7 +444,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
         );
 
         if (!success) {
-          new Notice("Failed to regenerate message. Please try again.");
+          new Notice(t("messages.failedToRegenerate"));
         } else if (settings.debug) {
           console.log("Message regenerated successfully");
         }
@@ -562,7 +563,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
       const existingIndex = currentProjects.findIndex((p) => p.name === project.name);
 
       if (existingIndex >= 0) {
-        throw new Error(`Project "${project.name}" already exists, please use a different name`);
+        throw new Error(t("project.projectAlreadyExists", { name: project.name }));
       }
 
       const newProjectList = [...currentProjects, project];
@@ -574,14 +575,14 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
         // Reload the project context for the newly added project
         reloadCurrentProject()
           .then(() => {
-            new Notice(`${project.name} added and context loaded`);
+            new Notice(`${project.name} ${t("project.projectAddedContextLoaded")}`);
           })
           .catch((error: Error) => {
             logError("Error loading project context:", error);
-            new Notice(`${project.name} added but context loading failed`);
+            new Notice(`${project.name} ${t("project.projectAddedContextFailed")}`);
           });
       } else {
-        new Notice(`${project.name} added successfully`);
+        new Notice(`${project.name} ${t("project.projectAdded")}`);
       }
 
       return true;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -125,6 +125,7 @@ export const LLM_TIMEOUT_MS = 30000; // 30 seconds timeout for LLM operations
 export const DEFAULT_MAX_SOURCE_CHUNKS = 30; // Default max chunks for search results (with diverse top-K)
 export const AGENT_LOOP_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes timeout for agent loop
 export const AGENT_MAX_ITERATIONS_LIMIT = 16; // Maximum allowed value for agent iterations setting
+// Loading messages - use getLoadingMessage() from langUtils.ts for localized versions
 export const LOADING_MESSAGES = {
   DEFAULT: "",
   READING_FILES: "Reading files",

--- a/src/lang/en.ts
+++ b/src/lang/en.ts
@@ -1,0 +1,116 @@
+/**
+ * English translations for Obsidian Copilot
+ */
+export default {
+  // Chat UI
+  chat: {
+    newChat: "New Chat",
+    send: "Send",
+    sendMessage: "Send message",
+    stopGenerating: "Stop generating",
+    dropFilesHere: "Drop files here...",
+    saveAsNote: "Save Chat as Note",
+    copy: "Copy",
+    delete: "Delete",
+    cancel: "Cancel",
+    confirm: "Confirm",
+    regenerate: "Regenerate",
+    edit: "Edit",
+    untitledConversation: "Untitled Conversation",
+    noResults: "No results",
+    loadingModels: "Loading models...",
+  },
+
+  // Messages
+  messages: {
+    messageNotFound: "Message not found.",
+    cannotRegenerateFirst: "Cannot regenerate the first message.",
+    failedToSend: "Failed to send message. Please try again.",
+    failedToRegenerate: "Failed to regenerate message. Please try again.",
+    failedToEdit: "Failed to edit message. Please try again.",
+    failedToDelete: "Failed to delete message. Please try again.",
+    failedToRegenerateAI: "Failed to regenerate AI response. Please try again.",
+    failedToSave: "Failed to save chat as note. Check console for details.",
+    failedToLoadHistory: "Failed to load chat history.",
+    failedToUpdateTitle: "Failed to update chat title.",
+    failedToDeleteChat: "Failed to delete chat.",
+    failedToLoadChat: "Failed to load chat.",
+    failedToOpenSource: "Failed to open source file.",
+  },
+
+  // Loading states
+  loading: {
+    default: "",
+    readingFiles: "Reading files",
+    searchingWeb: "Searching the web",
+    readingFileTree: "Reading file tree",
+    compacting: "Compacting",
+  },
+
+  // Project
+  project: {
+    add: "Add Project",
+    edit: "Edit Project",
+    delete: "Delete Project",
+    projectAdded: "added successfully",
+    projectUpdated: "updated successfully",
+    projectAddedContextLoaded: "added and context loaded",
+    projectUpdatedContextReloaded: "updated and context reloaded",
+    projectAddedContextFailed: "added but context loading failed",
+    projectUpdatedContextFailed: "updated but context reload failed",
+    projectAlreadyExists: "Project \"{{name}}\" already exists, please use a different name",
+    projectDoesNotExist: "does not exist",
+  },
+
+  // Model
+  model: {
+    selectModel: "Select Model",
+    addModel: "Add Model",
+    unknownModel: "Unknown Model",
+    noActiveModel: "No active model is configured. Please configure a model in Copilot settings.",
+    noModelKey: "No model key found. Please select a model in settings.",
+  },
+
+  // Settings
+  settings: {
+    title: "Copilot Settings",
+    reload: "Reload Plugin",
+    reloadSuccess: "Plugin reloaded successfully.",
+    reloadFailed: "Failed to reload the plugin. Please reload manually.",
+    testFailed: "Test operation failed",
+    invalidLicense: "Invalid license key",
+  },
+
+  // Errors
+  errors: {
+    inputValidationFailed: "Input validation failed",
+    invalidInput: "Invalid input",
+    invalidOperation: "Invalid operation",
+    networkFailed: "Network request failed",
+    failedFetch: "Failed to fetch",
+    failedLoadContent: "Failed to load content",
+    failedCopyClipboard: "Failed to copy to clipboard",
+    pleaseFillRequired: "Please fill in all required fields",
+  },
+
+  // Tools
+  tools: {
+    webSearch: "Web Search",
+    vaultSearch: "Vault Search",
+    activeNote: "Active Note",
+    ignoreFiles: "Ignore Files",
+    forceReindex: "Force Reindex Vault",
+  },
+
+  // Copilot Plus
+  plus: {
+    copilotPlus: "Copilot Plus",
+  },
+
+  // Misc
+  misc: {
+    none: "None (use built-in prompt)",
+    noCustomPrompts: "No custom prompt files found.",
+    noRelevantDocs: "No relevant documents found.",
+  },
+};

--- a/src/lang/i18n.ts
+++ b/src/lang/i18n.ts
@@ -1,0 +1,125 @@
+/**
+ * Internationalization (i18n) module for Obsidian Copilot
+ *
+ * This module provides translation support for multiple languages.
+ * It automatically detects Obsidian's locale and loads the appropriate translations.
+ */
+
+import en from "./en";
+import zhCN from "./zh-CN";
+
+// Supported languages
+export type SupportedLanguage = "en" | "zh-CN";
+
+// Translation type (inferred from English translations)
+export type Translation = typeof en;
+
+// All available translations
+const translations: Record<SupportedLanguage, Translation> = {
+  en,
+  "zh-CN": zhCN,
+};
+
+// Language code mapping (Obsidian locale -> our language code)
+const languageMap: Record<string, SupportedLanguage> = {
+  en: "en",
+  "en-US": "en",
+  "en-GB": "en",
+  zh: "zh-CN",
+  "zh-CN": "zh-CN",
+  "zh-TW": "zh-CN", // Fallback to Simplified Chinese
+  "zh-HK": "zh-CN", // Fallback to Simplified Chinese
+};
+
+// Default language
+const DEFAULT_LANGUAGE: SupportedLanguage = "en";
+
+// Current language (cached)
+let currentLanguage: SupportedLanguage | null = null;
+
+/**
+ * Get the current language code based on Obsidian's locale
+ */
+export function getCurrentLanguage(): SupportedLanguage {
+  if (currentLanguage) {
+    return currentLanguage;
+  }
+
+  // Get Obsidian's locale
+  // @ts-ignore - Obsidian's internal API
+  const obsidianLocale = window.localStorage.getItem("language") || "en";
+
+  // Map to our supported language
+  currentLanguage = languageMap[obsidianLocale] || DEFAULT_LANGUAGE;
+
+  return currentLanguage;
+}
+
+/**
+ * Set the current language manually
+ * This can be used to override Obsidian's locale
+ */
+export function setLanguage(language: SupportedLanguage): void {
+  currentLanguage = language;
+}
+
+/**
+ * Get translations for the current language
+ */
+export function getTranslations(): Translation {
+  const language = getCurrentLanguage();
+  return translations[language] || translations[DEFAULT_LANGUAGE];
+}
+
+/**
+ * Get a nested translation value by key path
+ * @param key - Dot-separated key path (e.g., "chat.newChat")
+ * @param params - Optional parameters for string interpolation
+ */
+export function t(key: string, params?: Record<string, string | number>): string {
+  const translations = getTranslations();
+  const keys = key.split(".");
+
+  // Navigate to the nested value
+  let value: unknown = translations;
+  for (const k of keys) {
+    if (typeof value === "object" && value !== null && k in value) {
+      value = (value as Record<string, unknown>)[k];
+    } else {
+      // Key not found, return the key itself
+      console.warn(`Translation key not found: ${key}`);
+      return key;
+    }
+  }
+
+  if (typeof value !== "string") {
+    console.warn(`Translation value is not a string: ${key}`);
+    return key;
+  }
+
+  // Interpolate parameters if provided
+  if (params) {
+    return value.replace(/\{\{(\w+)\}\}/g, (_, paramKey) => {
+      return String(params[paramKey] ?? `{{${paramKey}}}`);
+    });
+  }
+
+  return value;
+}
+
+/**
+ * Check if a language is supported
+ */
+export function isLanguageSupported(language: string): language is SupportedLanguage {
+  return language in translations;
+}
+
+/**
+ * Get all supported languages
+ */
+export function getSupportedLanguages(): SupportedLanguage[] {
+  return Object.keys(translations) as SupportedLanguage[];
+}
+
+// Export translations for direct access if needed
+export { translations };

--- a/src/lang/index.ts
+++ b/src/lang/index.ts
@@ -1,0 +1,6 @@
+/**
+ * i18n module entry point
+ * Re-export everything from i18n.ts for convenient imports
+ */
+export { t, getTranslations, getCurrentLanguage, setLanguage, isLanguageSupported, getSupportedLanguages, translations } from "./i18n";
+export type { Translation, SupportedLanguage } from "./i18n";

--- a/src/lang/langUtils.ts
+++ b/src/lang/langUtils.ts
@@ -1,0 +1,31 @@
+/**
+ * Utility functions for localized messages
+ */
+import { t } from "@/lang";
+
+/**
+ * Loading message keys
+ */
+export type LoadingMessageKey = "DEFAULT" | "READING_FILES" | "SEARCHING_WEB" | "READING_FILE_TREE" | "COMPACTING";
+
+/**
+ * Get localized loading message
+ */
+export function getLoadingMessage(key: LoadingMessageKey): string {
+  const keyMap: Record<LoadingMessageKey, string> = {
+    DEFAULT: "loading.default",
+    READING_FILES: "loading.readingFiles",
+    SEARCHING_WEB: "loading.searchingWeb",
+    READING_FILE_TREE: "loading.readingFileTree",
+    COMPACTING: "loading.compacting",
+  };
+
+  return t(keyMap[key]);
+}
+
+/**
+ * Get localized notice message with optional parameter interpolation
+ */
+export function getNoticeMessage(key: string, params?: Record<string, string | number>): string {
+  return t(key, params);
+}

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -1,0 +1,116 @@
+/**
+ * 简体中文翻译 - Simplified Chinese translations for Obsidian Copilot
+ */
+export default {
+  // 聊天界面
+  chat: {
+    newChat: "新对话",
+    send: "发送",
+    sendMessage: "发送消息",
+    stopGenerating: "停止生成",
+    dropFilesHere: "将文件拖放到这里...",
+    saveAsNote: "保存为笔记",
+    copy: "复制",
+    delete: "删除",
+    cancel: "取消",
+    confirm: "确认",
+    regenerate: "重新生成",
+    edit: "编辑",
+    untitledConversation: "未命名对话",
+    noResults: "无结果",
+    loadingModels: "正在加载模型...",
+  },
+
+  // 消息
+  messages: {
+    messageNotFound: "未找到消息。",
+    cannotRegenerateFirst: "无法重新生成第一条消息。",
+    failedToSend: "发送消息失败，请重试。",
+    failedToRegenerate: "重新生成消息失败，请重试。",
+    failedToEdit: "编辑消息失败，请重试。",
+    failedToDelete: "删除消息失败，请重试。",
+    failedToRegenerateAI: "重新生成 AI 回复失败，请重试。",
+    failedToSave: "保存对话为笔记失败，请查看控制台了解详情。",
+    failedToLoadHistory: "加载对话历史失败。",
+    failedToUpdateTitle: "更新对话标题失败。",
+    failedToDeleteChat: "删除对话失败。",
+    failedToLoadChat: "加载对话失败。",
+    failedToOpenSource: "打开源文件失败。",
+  },
+
+  // 加载状态
+  loading: {
+    default: "",
+    readingFiles: "正在读取文件",
+    searchingWeb: "正在搜索网络",
+    readingFileTree: "正在读取文件树",
+    compacting: "正在压缩",
+  },
+
+  // 项目
+  project: {
+    add: "添加项目",
+    edit: "编辑项目",
+    delete: "删除项目",
+    projectAdded: "添加成功",
+    projectUpdated: "更新成功",
+    projectAddedContextLoaded: "已添加并加载上下文",
+    projectUpdatedContextReloaded: "已更新并重新加载上下文",
+    projectAddedContextFailed: "已添加但上下文加载失败",
+    projectUpdatedContextFailed: "已更新但上下文重新加载失败",
+    projectAlreadyExists: "项目 \"{{name}}\" 已存在，请使用不同的名称",
+    projectDoesNotExist: "不存在",
+  },
+
+  // 模型
+  model: {
+    selectModel: "选择模型",
+    addModel: "添加模型",
+    unknownModel: "未知模型",
+    noActiveModel: "未配置活动模型。请在 Copilot 设置中配置模型。",
+    noModelKey: "未找到模型密钥。请在设置中选择模型。",
+  },
+
+  // 设置
+  settings: {
+    title: "Copilot 设置",
+    reload: "重新加载插件",
+    reloadSuccess: "插件重新加载成功。",
+    reloadFailed: "插件重新加载失败，请手动重新加载。",
+    testFailed: "测试操作失败",
+    invalidLicense: "无效的许可证密钥",
+  },
+
+  // 错误
+  errors: {
+    inputValidationFailed: "输入验证失败",
+    invalidInput: "无效输入",
+    invalidOperation: "无效操作",
+    networkFailed: "网络请求失败",
+    failedFetch: "获取失败",
+    failedLoadContent: "加载内容失败",
+    failedCopyClipboard: "复制到剪贴板失败",
+    pleaseFillRequired: "请填写所有必填字段",
+  },
+
+  // 工具
+  tools: {
+    webSearch: "网络搜索",
+    vaultSearch: "库搜索",
+    activeNote: "当前笔记",
+    ignoreFiles: "忽略文件",
+    forceReindex: "强制重新索引库",
+  },
+
+  // Copilot Plus
+  plus: {
+    copilotPlus: "Copilot Plus",
+  },
+
+  // 其他
+  misc: {
+    none: "无（使用内置提示）",
+    noCustomPrompts: "未找到自定义提示文件。",
+    noRelevantDocs: "未找到相关文档。",
+  },
+};


### PR DESCRIPTION
## Summary
- Add i18n framework with automatic language detection based on Obsidian locale
- Create translation files for English (en) and Simplified Chinese (zh-CN)
- Add utility functions for localized messages
- Update Chat.tsx to use translations for notice messages

## Details
This PR implements the foundational i18n (internationalization) infrastructure for the Obsidian Copilot plugin, addressing issue #2037.

### New Files
- `src/lang/en.ts` - English translations (default)
- `src/lang/zh-CN.ts` - Simplified Chinese translations
- `src/lang/i18n.ts` - i18n core module with language detection and translation functions
- `src/lang/index.ts` - Module exports
- `src/lang/langUtils.ts` - Utility functions for localized messages

### Modified Files
- `src/components/Chat.tsx` - Updated to use `t()` function for user-facing messages
- `src/constants.ts` - Added comment about localized loading messages

### Translation Keys
The following categories of strings are now translatable:
- `chat` - Chat UI strings (new chat, send, save, etc.)
- `messages` - Notice messages (errors, confirmations)
- `loading` - Loading state messages
- `project` - Project-related messages
- `model` - Model selection messages
- `settings` - Settings messages
- `errors` - Error messages
- `tools` - Tool names
- `plus` - Copilot Plus related
- `misc` - Miscellaneous strings

### How It Works
1. The i18n module automatically detects Obsidian's locale setting
2. Falls back to English for unsupported languages
3. Provides a simple `t("key.path")` function for translations
4. Supports parameter interpolation: `t("key", { name: "value" })`

### Future Work
- Extend translations to more components
- Add more languages (community contributions welcome!)
- Add a settings option to manually override language

Closes #2037
