### PR TITLE
fix(miyo): send portable folder-prefixed path to related-notes endpoint

### DIFF
--- a/src/miyo/miyoUtils.test.ts
+++ b/src/miyo/miyoUtils.test.ts
@@ -2,7 +2,7 @@ jest.mock("@/plusUtils", () => ({
   isSelfHostAccessValid: jest.fn(),
 }));
 
-import { getMiyoFolderName, getVaultRelativeMiyoPath } from "@/miyo/miyoUtils";
+import { getMiyoFilePath, getMiyoFolderName, getVaultRelativeMiyoPath } from "@/miyo/miyoUtils";
 
 describe("getMiyoFolderName", () => {
   it("uses the vault folder name even when an adapter exposes an absolute path", () => {
@@ -57,5 +57,36 @@ describe("getVaultRelativeMiyoPath", () => {
 
   it("returns the normalized path when the vault folder name is empty", () => {
     expect(getVaultRelativeMiyoPath(buildApp(""), "notes\\foo.md")).toBe("notes/foo.md");
+  });
+});
+
+describe("getMiyoFilePath", () => {
+  const buildApp = (vaultName: string) =>
+    ({
+      vault: {
+        getName: () => vaultName,
+      },
+    }) as any;
+
+  it("prefixes the vault folder name to a vault-relative path", () => {
+    expect(getMiyoFilePath(buildApp("MyVault"), "notes/foo.md")).toBe("MyVault/notes/foo.md");
+  });
+
+  it("normalizes backslash separators before prefixing", () => {
+    expect(getMiyoFilePath(buildApp("MyVault"), "notes\\foo.md")).toBe("MyVault/notes/foo.md");
+  });
+
+  it("strips a leading slash from the input so the result has no duplicate separator", () => {
+    expect(getMiyoFilePath(buildApp("MyVault"), "/notes/foo.md")).toBe("MyVault/notes/foo.md");
+  });
+
+  it("round-trips with getVaultRelativeMiyoPath", () => {
+    const app = buildApp("MyVault");
+    const original = "notes/foo.md";
+    expect(getVaultRelativeMiyoPath(app, getMiyoFilePath(app, original))).toBe(original);
+  });
+
+  it("returns the normalized path when the vault folder name is empty", () => {
+    expect(getMiyoFilePath(buildApp(""), "notes/foo.md")).toBe("notes/foo.md");
   });
 });

--- a/src/miyo/miyoUtils.ts
+++ b/src/miyo/miyoUtils.ts
@@ -1,6 +1,6 @@
 import { isSelfHostAccessValid } from "@/plusUtils";
 import { CopilotSettings } from "@/settings/model";
-import { App, FileSystemAdapter, Platform } from "obsidian";
+import { App, Platform } from "obsidian";
 
 /**
  * Convert backslashes to forward slashes and trim trailing slashes.
@@ -56,24 +56,26 @@ export function getMiyoFolderName(app: App): string {
 }
 
 /**
- * Resolve an absolute filesystem path for a vault file so it can be sent to Miyo.
+ * Build the portable file identifier sent to Miyo.
+ *
+ * Why: Miyo may be running on a different device than the vault on disk (e.g. a
+ * laptop reading a server-hosted Miyo). The server-side absolute path on Miyo's
+ * machine is unknown — and likely different — from the local Obsidian adapter's
+ * absolute path. The folder name (== vault name) is the only device-independent
+ * identifier, and Miyo's `resolveFileInput` remaps `<FolderName>/relative/path`
+ * to the matching registered folder's canonical absolute path on the server.
  *
  * @param app - Obsidian application instance.
- * @param vaultRelativePath - Vault-relative note path.
- * @returns Absolute file path when available, otherwise the original path.
+ * @param vaultRelativePath - Vault-relative note path (e.g. "Notes/foo.md").
+ * @returns `<FolderName>/<vaultRelativePath>` with forward slashes.
  */
-export function getMiyoAbsolutePath(app: App, vaultRelativePath: string): string {
-  const adapter = app.vault.adapter;
-  if (adapter instanceof FileSystemAdapter) {
-    return adapter.getFullPath(vaultRelativePath);
+export function getMiyoFilePath(app: App, vaultRelativePath: string): string {
+  const normalized = normalizeFilesystemPath(vaultRelativePath).replace(/^\/+/, "");
+  const folderName = getMiyoFolderName(app);
+  if (!folderName) {
+    return normalized;
   }
-
-  const adapterAny = adapter as unknown as { getFullPath?: (normalizedPath: string) => string };
-  if (typeof adapterAny.getFullPath === "function") {
-    return adapterAny.getFullPath(vaultRelativePath);
-  }
-
-  return vaultRelativePath;
+  return `${folderName}/${normalized}`;
 }
 
 /**

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -3,7 +3,7 @@ import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
 import { findRelevantNotes } from "@/search/findRelevantNotes";
 import { MiyoClient } from "@/miyo/MiyoClient";
 import {
-  getMiyoAbsolutePath,
+  getMiyoFilePath,
   getMiyoFolderName,
   getVaultRelativeMiyoPath,
   shouldUseMiyo,
@@ -53,8 +53,8 @@ jest.mock("@/miyo/MiyoClient", () => ({
 
 jest.mock("@/miyo/miyoUtils", () => ({
   getMiyoFolderName: jest.fn(),
-  getMiyoAbsolutePath: jest.fn((_: unknown, path: string) => `/vault/${path}`),
-  getVaultRelativeMiyoPath: jest.fn((_: unknown, path: string) => path.replace("/vault/", "")),
+  getMiyoFilePath: jest.fn((_: unknown, path: string) => `vault/${path}`),
+  getVaultRelativeMiyoPath: jest.fn((_: unknown, path: string) => path.replace(/^vault\//, "")),
   getMiyoCustomUrl: jest.fn().mockReturnValue(""),
   shouldUseMiyo: jest.fn(),
 }));
@@ -86,9 +86,7 @@ describe("findRelevantNotes", () => {
   const mockedGetMiyoFolderName = getMiyoFolderName as jest.MockedFunction<
     typeof getMiyoFolderName
   >;
-  const mockedGetMiyoAbsolutePath = getMiyoAbsolutePath as jest.MockedFunction<
-    typeof getMiyoAbsolutePath
-  >;
+  const mockedGetMiyoFilePath = getMiyoFilePath as jest.MockedFunction<typeof getMiyoFilePath>;
   const mockedGetVaultRelativeMiyoPath = getVaultRelativeMiyoPath as jest.MockedFunction<
     typeof getVaultRelativeMiyoPath
   >;
@@ -113,10 +111,10 @@ describe("findRelevantNotes", () => {
     } as any);
     mockedGetLinkedNotes.mockReturnValue([]);
     mockedGetBacklinkedNotes.mockReturnValue([]);
-    mockedGetMiyoFolderName.mockReturnValue("/vault");
-    mockedGetMiyoAbsolutePath.mockImplementation((_: unknown, path: string) => `/vault/${path}`);
+    mockedGetMiyoFolderName.mockReturnValue("vault");
+    mockedGetMiyoFilePath.mockImplementation((_: unknown, path: string) => `vault/${path}`);
     mockedGetVaultRelativeMiyoPath.mockImplementation((_: unknown, path: string) =>
-      path.replace("/vault/", "")
+      path.replace(/^vault\//, "")
     );
 
     const source = createMarkdownFile("source.md");
@@ -217,10 +215,10 @@ describe("findRelevantNotes", () => {
     mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
     mockSearchRelated.mockResolvedValue({
       results: [
-        { id: "self", path: "/vault/source.md", score: 0.99, chunk_text: "self" },
-        { id: "a-1", path: "/vault/alpha.md", score: 0.45, chunk_text: "alpha1" },
-        { id: "b-1", path: "/vault/beta.md", score: 0.88, chunk_text: "beta" },
-        { id: "a-2", path: "/vault/alpha.md", score: 0.6, chunk_text: "alpha2" },
+        { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
+        { id: "a-1", path: "vault/alpha.md", score: 0.45, chunk_text: "alpha1" },
+        { id: "b-1", path: "vault/beta.md", score: 0.88, chunk_text: "beta" },
+        { id: "a-2", path: "vault/alpha.md", score: 0.6, chunk_text: "alpha2" },
       ],
     });
 
@@ -233,8 +231,8 @@ describe("findRelevantNotes", () => {
     expect(mockGetDb).not.toHaveBeenCalled();
     expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
     expect(mockSearchRelated).toHaveBeenCalledTimes(1);
-    expect(mockSearchRelated).toHaveBeenCalledWith("http://127.0.0.1:8742", "/vault/source.md", {
-      folderName: "/vault",
+    expect(mockSearchRelated).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault/source.md", {
+      folderName: "vault",
       limit: 20,
     });
   });
@@ -254,8 +252,8 @@ describe("findRelevantNotes", () => {
     mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
     mockSearchRelated.mockResolvedValue({
       results: [
-        { id: "a-1", path: "/vault/alpha.md", score: 0.75, chunk_text: "alpha chunk" },
-        { id: "self", path: "/vault/source.md", score: 0.99, chunk_text: "self" },
+        { id: "a-1", path: "vault/alpha.md", score: 0.75, chunk_text: "alpha chunk" },
+        { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
       ],
     });
 

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -1,8 +1,8 @@
-import { logInfo, logWarn } from "@/logger";
+import { logError, logInfo, logWarn } from "@/logger";
 import { MiyoClient } from "@/miyo/MiyoClient";
 import {
-  getMiyoAbsolutePath,
   getMiyoCustomUrl,
+  getMiyoFilePath,
   getMiyoFolderName,
   getVaultRelativeMiyoPath,
   shouldUseMiyo,
@@ -125,12 +125,13 @@ async function calculateSimilarityScoreFromOrama({
  * @returns Map of note paths to max similarity score.
  */
 async function calculateSimilarityScoreFromMiyo(filePath: string): Promise<Map<string, number>> {
+  const settings = getSettings();
+  const miyoClient = new MiyoClient();
+  const folderName = getMiyoFolderName(app);
+  const miyoFilePath = getMiyoFilePath(app, filePath);
   try {
-    const settings = getSettings();
-    const miyoClient = new MiyoClient();
     const baseUrl = await miyoClient.resolveBaseUrl(getMiyoCustomUrl(settings));
-    const folderName = getMiyoFolderName(app);
-    const response = await miyoClient.searchRelated(baseUrl, getMiyoAbsolutePath(app, filePath), {
+    const response = await miyoClient.searchRelated(baseUrl, miyoFilePath, {
       folderName,
       limit: MAX_K,
     });
@@ -151,15 +152,25 @@ async function calculateSimilarityScoreFromMiyo(filePath: string): Promise<Map<s
       }
     }
 
-    if (getSettings().debug) {
+    if (settings.debug) {
+      const sampleResponsePath = results[0]?.path;
+      const sampleStripped = sampleResponsePath
+        ? getVaultRelativeMiyoPath(app, sampleResponsePath)
+        : undefined;
       logInfo(
-        `RelevantNotes(Miyo): received ${results.length} chunks, collected ${similarityScoreMap.size} note scores`
+        `RelevantNotes(Miyo): file_path=${miyoFilePath} folder_name=${folderName} ` +
+          `received ${results.length} chunks, collected ${similarityScoreMap.size} note scores ` +
+          `(sample response.path=${sampleResponsePath ?? "n/a"} → stripped=${sampleStripped ?? "n/a"})`
       );
     }
 
     return capToTopK(similarityScoreMap);
   } catch (error) {
-    logWarn("RelevantNotes(Miyo): failed to compute similarity scores", error);
+    logError(
+      `RelevantNotes(Miyo): searchRelated failed for file_path=${miyoFilePath} folder_name=${folderName}: ${
+        (error as Error).message
+      }`
+    );
     return new Map();
   }
 }

--- a/src/search/indexBackend/MiyoIndexBackend.ts
+++ b/src/search/indexBackend/MiyoIndexBackend.ts
@@ -3,8 +3,8 @@ import { App, Notice } from "obsidian";
 import { logInfo, logWarn } from "@/logger";
 import { MiyoClient, MiyoIndexedFileEntry } from "@/miyo/MiyoClient";
 import {
-  getMiyoAbsolutePath,
   getMiyoCustomUrl,
+  getMiyoFilePath,
   getMiyoFolderName,
   getVaultRelativeMiyoPath,
 } from "@/miyo/miyoUtils";
@@ -141,11 +141,11 @@ export class MiyoIndexBackend implements SemanticIndexBackend {
    */
   public async getDocumentsByPath(path: string): Promise<SemanticIndexDocument[]> {
     const baseUrl = await this.getBaseUrl();
-    const absolutePath = getMiyoAbsolutePath(this.app, path);
+    const miyoFilePath = getMiyoFilePath(this.app, path);
     const response = await this.client.getDocumentsByPath(
       baseUrl,
       this.getFolderName(),
-      absolutePath
+      miyoFilePath
     );
     const docs = response.documents ?? [];
     return docs.map((doc) => this.fromMiyoDocument(path, doc));


### PR DESCRIPTION
## Summary

- `findRelevantNotes` and `MiyoIndexBackend.getDocumentsByPath` were sending the *local* absolute filesystem path as Miyo's `file_path`. On remote-vault setups (same vault name on two devices, different absolute paths), the server's indexed path never matches, so the scroll filter at `/v0/search/related` returns 0 points → 404, and related notes always show empty.
- Replaced `getMiyoAbsolutePath` with `getMiyoFilePath`, which returns `<FolderName>/<vaultRelativePath>` — the inverse of `getVaultRelativeMiyoPath`. Miyo's `resolveFileInput` already remaps this format to the registered folder's canonical absolute path on the server, so it works identically for local and remote Miyo.
- Same fix applied to `MiyoIndexBackend.getDocumentsByPath` (also feeds `GET /v0/folder/documents` with a `file_path`).

No server-side change required — Miyo already accepts the portable form.

## Test plan

- [x] `npm test` — 1915 tests pass
- [x] New `getMiyoFilePath` unit tests in `miyoUtils.test.ts` including a round-trip with `getVaultRelativeMiyoPath`
- [x] Updated `findRelevantNotes.test.ts` mock + assertion
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Manual: open a note on a device whose Miyo runs remotely, confirm related notes populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)