### PR TITLE
chore(styles): replace element.style with Tailwind + CSS vars (W5/9)

### DIFF
--- a/src/components/chat-components/ChatViewLayout.ts
+++ b/src/components/chat-components/ChatViewLayout.ts
@@ -54,7 +54,9 @@ export class ChatViewLayout {
       if (!statusBar || !viewContent) return;
 
       // Zero out clearance and force reflow to measure natural overlap.
-      viewContent.style.setProperty("--copilot-status-bar-clearance", "0px");
+      // Remove any inline override left from a prior run so the CSS default
+      // (0px) applies and the resulting rect reflects the natural overlap.
+      viewContent.style.removeProperty("--copilot-status-bar-clearance");
       const overlap =
         viewContent.getBoundingClientRect().bottom - statusBar.getBoundingClientRect().top;
 

--- a/src/components/chat-components/ChatViewLayout.ts
+++ b/src/components/chat-components/ChatViewLayout.ts
@@ -56,7 +56,7 @@ export class ChatViewLayout {
       // Zero out clearance and force reflow to measure natural overlap.
       // Remove any inline override left from a prior run so the CSS default
       // (0px) applies and the resulting rect reflects the natural overlap.
-      viewContent.style.removeProperty("--copilot-status-bar-clearance");
+      viewContent.setCssProps({ "--copilot-status-bar-clearance": "" });
       const overlap =
         viewContent.getBoundingClientRect().bottom - statusBar.getBoundingClientRect().top;
 
@@ -69,10 +69,9 @@ export class ChatViewLayout {
       const s = getComputedStyle(statusBar);
       const hidden =
         s.display === "none" || s.visibility === "hidden" || parseFloat(s.opacity) === 0;
-      viewContent.style.setProperty(
-        "--copilot-status-bar-clearance",
-        `${hidden ? 0 : Math.ceil(overlap)}px`
-      );
+      viewContent.setCssProps({
+        "--copilot-status-bar-clearance": `${hidden ? 0 : Math.ceil(overlap)}px`,
+      });
     };
 
     syncClearance();

--- a/src/components/command-ui/draggable-modal.tsx
+++ b/src/components/command-ui/draggable-modal.tsx
@@ -286,6 +286,9 @@ export function DraggableModal({
       className={cn(
         // Positioning and z-index
         "tw-fixed tw-z-popover",
+        // Position driven by useDraggable's CSS variables (--copilot-drag-x/y).
+        // Fallback covers first paint before the hook's useLayoutEffect runs.
+        "tw-left-[var(--copilot-drag-x,0px)] tw-top-[var(--copilot-drag-y,0px)]",
         // Flexbox layout for stable structure
         "tw-flex tw-flex-col",
         // Visual styling
@@ -301,8 +304,6 @@ export function DraggableModal({
         className
       )}
       style={{
-        left: position.x,
-        top: position.y,
         width: resizable && widthPx !== null ? widthPx : width,
         ...(resizable && heightPx !== null ? { height: heightPx } : {}),
       }}

--- a/src/components/modals/CachePreviewModal.ts
+++ b/src/components/modals/CachePreviewModal.ts
@@ -25,8 +25,7 @@ export class CachePreviewModal extends Modal {
     const { contentEl, modalEl } = this;
 
     // Reason: override default modal width for wider content preview
-    modalEl.style.width = "90vw";
-    modalEl.style.maxWidth = "800px";
+    modalEl.addClass("!tw-w-[90vw]", "!tw-max-w-[800px]");
 
     contentEl.empty();
     contentEl.addClass("tw-flex", "tw-flex-col", "tw-p-0");

--- a/src/components/modals/SourcesModal.tsx
+++ b/src/components/modals/SourcesModal.tsx
@@ -27,23 +27,19 @@ export class SourcesModal extends Modal {
     sources: { title: string; path: string; score: number; explanation?: any }[]
   ) {
     const list = container.createEl("ul");
-    list.style.listStyleType = "none";
-    list.style.padding = "0";
+    list.addClass("tw-list-none", "tw-p-0");
 
     sources.forEach((source) => {
       const item = list.createEl("li");
-      item.style.marginBottom = "1em";
+      item.addClass("tw-mb-4");
 
       // Create collapsible container
       const itemContainer = item.createDiv();
-      itemContainer.style.cursor = "pointer";
+      itemContainer.addClass("tw-cursor-pointer");
 
       // Add expand/collapse indicator
       const expandIndicator = itemContainer.createSpan();
-      expandIndicator.style.marginRight = "0.5em";
-      expandIndicator.style.display = "inline-block";
-      expandIndicator.style.width = "1em";
-      expandIndicator.style.transition = "transform 0.2s";
+      expandIndicator.addClass("tw-mr-2", "tw-inline-block", "tw-w-4", "tw-transition-transform");
       expandIndicator.textContent = source.explanation ? "▶" : "";
 
       // Display title, but show path in parentheses if there are duplicates
@@ -87,16 +83,16 @@ export class SourcesModal extends Modal {
       let explanationDiv: HTMLElement | null = null;
       if (source.explanation) {
         explanationDiv = this.addExplanation(item, source.explanation);
-        explanationDiv.style.display = "none"; // Initially collapsed
+        explanationDiv.addClass("tw-hidden"); // Initially collapsed
 
         // Toggle expansion on click
         itemContainer.addEventListener("click", (e) => {
           if (e.target === link) return; // Don't toggle when clicking the link
 
           if (explanationDiv) {
-            const isExpanded = explanationDiv.style.display !== "none";
-            explanationDiv.style.display = isExpanded ? "none" : "block";
-            expandIndicator.style.transform = isExpanded ? "" : "rotate(90deg)";
+            const isExpanded = !explanationDiv.hasClass("tw-hidden");
+            explanationDiv.toggleClass("tw-hidden", isExpanded);
+            expandIndicator.toggleClass("tw-rotate-90", !isExpanded);
           }
         });
       }
@@ -105,12 +101,15 @@ export class SourcesModal extends Modal {
 
   private addExplanation(container: HTMLElement, explanation: any): HTMLElement {
     const explanationDiv = container.createDiv({ cls: "search-explanation" });
-    explanationDiv.style.marginTop = "0.5em";
-    explanationDiv.style.marginLeft = "2.5em";
-    explanationDiv.style.fontSize = "0.9em";
-    explanationDiv.style.color = "var(--text-muted)";
-    explanationDiv.style.borderLeft = "2px solid var(--background-modifier-border)";
-    explanationDiv.style.paddingLeft = "0.5em";
+    explanationDiv.addClass(
+      "tw-ml-[2.5em]",
+      "tw-mt-2",
+      "tw-pl-2",
+      "tw-text-[0.9em]",
+      "tw-text-muted",
+      "tw-border-l",
+      "tw-border-l-border"
+    );
 
     const details: string[] = [];
 
@@ -168,7 +167,7 @@ export class SourcesModal extends Modal {
     if (details.length > 0) {
       details.forEach((detail) => {
         const detailDiv = explanationDiv.createEl("div");
-        detailDiv.style.marginBottom = "0.25em";
+        detailDiv.addClass("tw-mb-1");
         detailDiv.textContent = `• ${detail}`;
       });
     }

--- a/src/components/modals/project/AddProjectModal.tsx
+++ b/src/components/modals/project/AddProjectModal.tsx
@@ -466,8 +466,7 @@ export class AddProjectModal extends Modal {
     const { contentEl, modalEl } = this;
 
     // Reason: Ensure the modal is wide enough for card layout and tall enough for ScrollArea
-    // modalEl.style.minWidth = "min(640px, 90vw)";
-    modalEl.style.maxHeight = "85vh";
+    modalEl.addClass("!tw-max-h-[85vh]");
 
     this.root = createRoot(contentEl);
 

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -1382,7 +1382,7 @@ export class ContextManageModal extends Modal {
     const { contentEl, modalEl } = this;
     this.root = createRoot(contentEl);
 
-    modalEl.style.minWidth = "50vw";
+    modalEl.addClass("tw-min-w-[50vw]");
 
     const handleSave = (project: ProjectConfig) => {
       this.onSave(project);

--- a/src/components/quick-ask/QuickAskOverlay.tsx
+++ b/src/components/quick-ask/QuickAskOverlay.tsx
@@ -87,8 +87,6 @@ export class QuickAskOverlay {
   private resizeStartMouse: { x: number; y: number } | null = null;
   private resizeRafId: number | null = null;
   // Save original body styles to restore after resize
-  private savedBodyUserSelect: string = "";
-  private savedBodyCursor: string = "";
 
   constructor(private readonly options: QuickAskOverlayOptions) {}
 
@@ -668,20 +666,17 @@ export class QuickAskOverlay {
     const doc = this.ownerDocument ?? activeDocument;
     const body = doc.body;
 
-    // Prevent text selection and set resize cursor on body during drag
-    // Save original values to restore later
-    this.savedBodyUserSelect = body.style.userSelect;
-    this.savedBodyCursor = body.style.cursor;
-    body.classList.add("copilot-quick-ask-resizing");
-    body.style.userSelect = "none";
-    // Set cursor based on direction to ensure consistent feedback
+    // Disable selection and set a direction-specific cursor on the body for
+    // the duration of the resize. Cursor is exposed via a CSS variable that the
+    // Tailwind arbitrary-value class consumes — no inline cursor styles needed.
     const cursorMap: Record<ResizeDirection, string> = {
       right: "ew-resize",
       bottom: "ns-resize",
       "bottom-left": "nesw-resize",
       "bottom-right": "nwse-resize",
     };
-    body.style.cursor = cursorMap[direction] ?? "default";
+    body.style.setProperty("--copilot-resize-cursor", cursorMap[direction] ?? "default");
+    body.classList.add("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
 
     // Bind document-level listeners (use capture for consistency with useRafResizable/useDraggable)
     doc.addEventListener("mousemove", this.handleResizeMove, true);
@@ -725,10 +720,8 @@ export class QuickAskOverlay {
       const body = doc.body;
       doc.removeEventListener("mousemove", this.handleResizeMove, true);
       doc.removeEventListener("mouseup", this.handleResizeEnd, true);
-      body.classList.remove("copilot-quick-ask-resizing");
-      // Restore original body styles
-      body.style.userSelect = this.savedBodyUserSelect;
-      body.style.cursor = this.savedBodyCursor;
+      body.classList.remove("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
+      body.style.removeProperty("--copilot-resize-cursor");
     }
 
     this.isResizing = false;

--- a/src/components/quick-ask/QuickAskOverlay.tsx
+++ b/src/components/quick-ask/QuickAskOverlay.tsx
@@ -675,7 +675,7 @@ export class QuickAskOverlay {
       "bottom-left": "nesw-resize",
       "bottom-right": "nwse-resize",
     };
-    body.style.setProperty("--copilot-resize-cursor", cursorMap[direction] ?? "default");
+    body.setCssProps({ "--copilot-resize-cursor": cursorMap[direction] ?? "default" });
     body.classList.add("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
 
     // Bind document-level listeners (use capture for consistency with useRafResizable/useDraggable)
@@ -721,7 +721,7 @@ export class QuickAskOverlay {
       doc.removeEventListener("mousemove", this.handleResizeMove, true);
       doc.removeEventListener("mouseup", this.handleResizeEnd, true);
       body.classList.remove("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
-      body.style.removeProperty("--copilot-resize-cursor");
+      body.setCssProps({ "--copilot-resize-cursor": "" });
     }
 
     this.isResizing = false;

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,9 +9,12 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
     const adjustHeight = React.useCallback(() => {
       const textarea = textareaRef.current;
       if (textarea) {
-        textarea.style.height = "auto";
+        // Reset to "auto" so scrollHeight reflects the natural content height,
+        // then set the computed pixel value. Consumed by the
+        // `tw-h-[var(--copilot-autosize-height,_auto)]` arbitrary-value class below.
+        textarea.style.setProperty("--copilot-autosize-height", "auto");
         const newHeight = Math.min(textarea.scrollHeight, 300);
-        textarea.style.height = `${newHeight}px`;
+        textarea.style.setProperty("--copilot-autosize-height", `${newHeight}px`);
       }
     }, []);
 
@@ -40,6 +43,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
         className={cn(
           "tw-min-w-fit tw-resize-y tw-overflow-auto tw-border-solid",
           "tw-flex tw-max-h-[300px] tw-min-h-[60px] tw-w-full tw-rounded-md tw-border tw-bg-transparent tw-px-3 tw-py-2 tw-text-base tw-shadow-sm placeholder:tw-text-muted focus-visible:tw-outline-none focus-visible:tw-ring-1 focus-visible:tw-ring-ring disabled:tw-cursor-not-allowed disabled:tw-opacity-50 md:tw-text-sm",
+          "tw-h-[var(--copilot-autosize-height,_auto)]",
           className
         )}
         value={value}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -12,9 +12,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
         // Reset to "auto" so scrollHeight reflects the natural content height,
         // then set the computed pixel value. Consumed by the
         // `tw-h-[var(--copilot-autosize-height,_auto)]` arbitrary-value class below.
-        textarea.style.setProperty("--copilot-autosize-height", "auto");
+        textarea.setCssProps({ "--copilot-autosize-height": "auto" });
         const newHeight = Math.min(textarea.scrollHeight, 300);
-        textarea.style.setProperty("--copilot-autosize-height", `${newHeight}px`);
+        textarea.setCssProps({ "--copilot-autosize-height": `${newHeight}px` });
       }
     }, []);
 

--- a/src/hooks/use-draggable.ts
+++ b/src/hooks/use-draggable.ts
@@ -44,7 +44,8 @@ function clamp(value: number, min: number, max: number): number {
  * A draggable hook optimized for performance:
  * - Optionally writes `left/top` directly to the DOM (no React re-render on mousemove)
  * - Uses `requestAnimationFrame` to throttle updates
- * - Applies `preventDefault()` + `document.body.style.userSelect = "none"` during drag
+ * - Applies `preventDefault()` and disables body selection / sets grabbing cursor
+ *   during drag (the class disables text selection and sets a grabbing cursor)
  *
  * API is kept compatible:
  * `position, setPosition, isDragging, dragRef, handleMouseDown`
@@ -74,10 +75,11 @@ export function useDraggable(options: UseDraggableOptions = {}) {
   const cleanupDragRef = useRef<((commit: boolean) => void) | null>(null);
   const isMountedRef = useRef(true);
 
-  const previousBodyStyleRef = useRef<{ userSelect: string; cursor: string } | null>(null);
-
   /**
-   * Writes position to the drag element via inline styles.
+   * Writes position to the drag element via CSS custom properties.
+   * The consumer must include `!tw-left-[var(--copilot-drag-x,0px)]` and
+   * `!tw-top-[var(--copilot-drag-y,0px)]` (or equivalent) on the element so
+   * these variables map to actual `left`/`top` values.
    */
   const writePositionToDom = useCallback(
     (next: Position): void => {
@@ -86,11 +88,8 @@ export function useDraggable(options: UseDraggableOptions = {}) {
       const el = dragRef.current;
       if (!el) return;
 
-      const left = `${next.x}px`;
-      const top = `${next.y}px`;
-
-      if (el.style.left !== left) el.style.left = left;
-      if (el.style.top !== top) el.style.top = top;
+      el.style.setProperty("--copilot-drag-x", `${next.x}px`);
+      el.style.setProperty("--copilot-drag-y", `${next.y}px`);
     },
     [dragRef, writeToDom]
   );
@@ -154,6 +153,14 @@ export function useDraggable(options: UseDraggableOptions = {}) {
   }, [applyPosition, dragRef]);
 
   /**
+   * Initial mount: write the starting position to CSS variables so the element
+   * paints at the correct location on first render (before any drag occurs).
+   */
+  useLayoutEffect(() => {
+    writePositionToDom(positionRef.current);
+  }, [writePositionToDom]);
+
+  /**
    * Compatible setter: updates state + ref, and also writes to DOM immediately.
    * (No throttling here; `setPosition` is expected to be called infrequently.)
    */
@@ -195,13 +202,8 @@ export function useDraggable(options: UseDraggableOptions = {}) {
       const ownerDocument = dragRef.current?.doc ?? activeDocument;
       const ownerWindow = ownerDocument.defaultView ?? window;
       const body = ownerDocument.body;
-      previousBodyStyleRef.current = {
-        userSelect: body.style.userSelect,
-        cursor: body.style.cursor,
-      };
 
-      body.style.userSelect = "none";
-      body.style.cursor = "grabbing";
+      body.classList.add("tw-select-none", "tw-cursor-grabbing");
 
       /**
        * Mouse move handler: updates pending position and schedules RAF apply.
@@ -233,15 +235,7 @@ export function useDraggable(options: UseDraggableOptions = {}) {
 
         const finalPosition = pending ? applyPosition(pending) : positionRef.current;
 
-        const previous = previousBodyStyleRef.current;
-        if (previous) {
-          body.style.userSelect = previous.userSelect;
-          body.style.cursor = previous.cursor;
-          previousBodyStyleRef.current = null;
-        } else {
-          body.style.userSelect = "";
-          body.style.cursor = "";
-        }
+        body.classList.remove("tw-select-none", "tw-cursor-grabbing");
 
         cleanupDragRef.current = null;
 

--- a/src/hooks/use-draggable.ts
+++ b/src/hooks/use-draggable.ts
@@ -88,8 +88,10 @@ export function useDraggable(options: UseDraggableOptions = {}) {
       const el = dragRef.current;
       if (!el) return;
 
-      el.style.setProperty("--copilot-drag-x", `${next.x}px`);
-      el.style.setProperty("--copilot-drag-y", `${next.y}px`);
+      el.setCssProps({
+        "--copilot-drag-x": `${next.x}px`,
+        "--copilot-drag-y": `${next.y}px`,
+      });
     },
     [dragRef, writeToDom]
   );

--- a/src/hooks/use-resizable.ts
+++ b/src/hooks/use-resizable.ts
@@ -138,7 +138,7 @@ export function useRafResizable(options: UseRafResizableOptions): UseRafResizabl
     const body = ownerDocument.body;
     // Direction-specific cursor is exposed via a CSS variable so the Tailwind
     // arbitrary-value class can consume it without inline cursor styles.
-    body.style.setProperty("--copilot-resize-cursor", cursor);
+    body.setCssProps({ "--copilot-resize-cursor": cursor });
     body.classList.add("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
 
     const cancelRaf = (): void => {
@@ -214,7 +214,7 @@ export function useRafResizable(options: UseRafResizableOptions): UseRafResizabl
       ownerDocument.removeEventListener("mouseup", handleMouseUp, true);
 
       body.classList.remove("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
-      body.style.removeProperty("--copilot-resize-cursor");
+      body.setCssProps({ "--copilot-resize-cursor": "" });
 
       startRef.current = null;
       setIsResizing(false);
@@ -236,7 +236,7 @@ export function useRafResizable(options: UseRafResizableOptions): UseRafResizabl
       ownerDocument.removeEventListener("mouseup", handleMouseUp, true);
 
       body.classList.remove("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
-      body.style.removeProperty("--copilot-resize-cursor");
+      body.setCssProps({ "--copilot-resize-cursor": "" });
     };
   }, [isResizing]);
 

--- a/src/hooks/use-resizable.ts
+++ b/src/hooks/use-resizable.ts
@@ -136,10 +136,10 @@ export function useRafResizable(options: UseRafResizableOptions): UseRafResizabl
     const ownerDocument = ownerDocumentRef.current ?? activeDocument;
     const ownerWindow = ownerWindowRef.current ?? window;
     const body = ownerDocument.body;
-    const previousCursor = body.style.cursor;
-    const previousUserSelect = body.style.userSelect;
-    body.style.cursor = cursor;
-    body.style.userSelect = "none";
+    // Direction-specific cursor is exposed via a CSS variable so the Tailwind
+    // arbitrary-value class can consume it without inline cursor styles.
+    body.style.setProperty("--copilot-resize-cursor", cursor);
+    body.classList.add("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
 
     const cancelRaf = (): void => {
       if (rafIdRef.current === null) return;
@@ -213,8 +213,8 @@ export function useRafResizable(options: UseRafResizableOptions): UseRafResizabl
       ownerDocument.removeEventListener("mousemove", handleMouseMove, true);
       ownerDocument.removeEventListener("mouseup", handleMouseUp, true);
 
-      body.style.cursor = previousCursor;
-      body.style.userSelect = previousUserSelect;
+      body.classList.remove("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
+      body.style.removeProperty("--copilot-resize-cursor");
 
       startRef.current = null;
       setIsResizing(false);
@@ -235,8 +235,8 @@ export function useRafResizable(options: UseRafResizableOptions): UseRafResizabl
       ownerDocument.removeEventListener("mousemove", handleMouseMove, true);
       ownerDocument.removeEventListener("mouseup", handleMouseUp, true);
 
-      body.style.cursor = previousCursor;
-      body.style.userSelect = previousUserSelect;
+      body.classList.remove("tw-select-none", "tw-cursor-[var(--copilot-resize-cursor)]");
+      body.style.removeProperty("--copilot-resize-cursor");
     };
   }, [isResizing]);
 

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -58,7 +58,7 @@ export class CopilotSettingTab extends PluginSettingTab {
   display(): void {
     const { containerEl } = this;
     containerEl.empty();
-    containerEl.style.userSelect = "text";
+    containerEl.addClass("tw-select-text");
     const div = containerEl.createDiv("div");
     const sections = createRoot(div);
 

--- a/src/settings/v2/components/ModelEditDialog.tsx
+++ b/src/settings/v2/components/ModelEditDialog.tsx
@@ -367,7 +367,7 @@ export class ModelEditModal extends Modal {
     const { contentEl, modalEl } = this;
     // It occupies only 80% of the height, leaving a clickable blank area to prevent the close icon from malfunctioning.
     if (Platform.isMobile) {
-      modalEl.style.height = "80%";
+      modalEl.addClass("tw-h-4/5");
     }
     this.root = createRoot(contentEl);
 

--- a/src/system-prompts/SystemPromptAddModal.tsx
+++ b/src/system-prompts/SystemPromptAddModal.tsx
@@ -236,7 +236,7 @@ export class SystemPromptAddModal extends Modal {
     const { contentEl, modalEl } = this;
 
     if (Platform.isMobile) {
-      modalEl.style.height = "80%";
+      modalEl.addClass("tw-h-4/5");
     }
 
     this.root = createRoot(contentEl);

--- a/src/utils/dom/dynamicStyleManager.ts
+++ b/src/utils/dom/dynamicStyleManager.ts
@@ -112,19 +112,23 @@ export function updateDynamicStyleClass(
 
   const previousProperties = previousState?.properties ?? new Set<string>();
   const nextProperties = new Set<string>();
+  const propsToApply: Record<string, string> = {};
 
-  // Remove properties that are no longer present
+  // Clear properties that are no longer present (empty string ≡ removeProperty per CSSOM).
   previousProperties.forEach((property) => {
     if (!normalized.has(property)) {
-      element.style.removeProperty(property);
+      propsToApply[property] = "";
     }
   });
 
-  // Apply current styles
   normalized.forEach((value, property) => {
-    element.style.setProperty(property, value);
+    propsToApply[property] = value;
     nextProperties.add(property);
   });
+
+  if (Object.keys(propsToApply).length > 0) {
+    element.setCssProps(propsToApply);
+  }
 
   if (nextProperties.size === 0) {
     elementState.delete(element);
@@ -141,9 +145,13 @@ export function clearDynamicStyleClass(element: HTMLElement): void {
   const state = elementState.get(element);
   if (!state) return;
 
+  const cleared: Record<string, string> = {};
   state.properties.forEach((property) => {
-    element.style.removeProperty(property);
+    cleared[property] = "";
   });
+  if (Object.keys(cleared).length > 0) {
+    element.setCssProps(cleared);
+  }
   if (state.prefix) {
     removePrefixedClasses(element, state.prefix);
   }


### PR DESCRIPTION
Sixth of nine workspaces splitting #2397 into focused PRs. See [the split plan](https://github.com/logancyang/obsidian-copilot/pull/2397) for the full sequence. **W0 already merged** (#2398).

## Summary

Replaces direct DOM inline-style writes with Tailwind utility classes (via `addClass`) and CSS custom properties for dynamic values. Addresses the `no-static-styles-assignment` family of scorecard warnings.

Key patterns:
- Static style assignments (e.g. `el.style.width = "90vw"`) → `el.addClass("!tw-w-[90vw]")`
- Dynamic positioning in `useDraggable` / `useRafResizable` → writes `--copilot-drag-x/y` and `--copilot-resize-cursor` CSS variables; consumers reference them via Tailwind arbitrary-value classes like `tw-left-[var(--copilot-drag-x,0px)]` and `tw-cursor-[var(--copilot-resize-cursor)]`
- Body select/cursor during drag/resize → `tw-select-none` + `tw-cursor-grabbing` / `tw-cursor-[var(...)]` classes instead of inline `body.style.userSelect/cursor`
- **All remaining dynamic CSS-variable writes now go through Obsidian's `HTMLElement#setCssProps` API** — the scorecard warning's exact recommendation. `element.style.setProperty/removeProperty` no longer appears in `src/` (verified by grep). Empty-string values clear the property per CSSOM spec.

## Files

- `src/components/modals/SourcesModal.tsx` — `addClass` + `tw-*` utilities for list, items, expand indicator, explanation block
- `src/components/modals/AddImageModal.tsx` — `input.style.display = "none"` → `tw-hidden`
- `src/components/modals/CachePreviewModal.ts` — modal width via `!tw-w-[90vw]` / `!tw-max-w-[800px]`
- `src/components/modals/project/AddProjectModal.tsx` — `!tw-max-h-[85vh]`
- `src/components/modals/project/context-manage-modal.tsx` — `tw-min-w-[50vw]`
- `src/components/quick-ask/QuickAskOverlay.tsx` — resize body cursor/select via Tailwind + `--copilot-resize-cursor` CSS variable, written through `setCssProps`
- `src/components/ui/textarea.tsx` — `--copilot-autosize-height` CSS variable + `tw-h-[var(--copilot-autosize-height,_auto)]`, written through `setCssProps`
- `src/components/chat-components/ChatViewLayout.ts` — `--copilot-status-bar-clearance` written through `setCssProps` (clear path uses empty string)
- `src/components/command-ui/draggable-modal.tsx` — position via `tw-left-[var(--copilot-drag-x,0px)]` / `tw-top-[var(--copilot-drag-y,0px)]`
- `src/settings/SettingsPage.tsx` — `tw-select-text`
- `src/settings/v2/components/ModelEditDialog.tsx` and `src/system-prompts/SystemPromptAddModal.tsx` — `tw-h-4/5` on mobile
- `src/hooks/use-draggable.ts` and `src/hooks/use-resizable.ts` — write CSS variables through `setCssProps`; the consumers reference them through Tailwind arbitrary-value classes
- `src/utils/dom/dynamicStyleManager.ts` — generic dynamic-style helper batches set+clear into a single `setCssProps({...})` call per invocation

## Static verification

```bash
grep -rn "\.style\.setProperty\|\.style\.removeProperty" src --include="*.ts" --include="*.tsx"
# → zero hits
```

The only remaining `.style.` reference in `src/` is the *read* at `src/components/CopilotView.tsx:112` (`getPropertyValue("--keyboard-height")`), which is not flagged by the inline-style scorecard rule because it does not mutate the DOM.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (107 suites, 1962 tests, all green)
- [ ] Manual smoke (visual-only, but it is easy to break geometry — please walk through every case below before merging):

### 1. QuickAsk panel (covers `QuickAskOverlay.tsx` + `dynamicStyleManager.ts`)
1. Trigger quick-ask (`Cmd+Shift+P` → "Copilot Plus: Quick Ask" or your bound shortcut).
2. **Position**: panel should appear at the saved/default position. No jump, no flicker.
3. **Drag**: grab the panel header and drag it around the window. Movement should be smooth (RAF-throttled), and the panel must stay within window bounds. Body cursor should become `grabbing` during drag, return to normal on release.
4. **Resize** — test all four handles: right edge (→), bottom edge (↓), bottom-left corner (⤢), bottom-right corner (⤡). During each resize:
   - Body cursor should switch to the direction-appropriate cursor (`ew-resize`, `ns-resize`, `nesw-resize`, `nwse-resize` respectively).
   - Panel should resize smoothly.
   - On mouseup: cursor returns to normal, panel keeps the new size.
5. **Inline pills / typeahead positioning** (exercises `dynamicStyleManager`): type `@` in quick-ask, scroll through the typeahead menu — it must stay anchored to the caret, not drift. Add several `@` pills, then delete some — the inline-pill geometry must not desync.
6. Close + reopen quick-ask: saved position + size should be restored.

### 2. Draggable command-UI modal (covers `use-draggable.ts` + `draggable-modal.tsx`)
1. Open any draggable command-UI modal (e.g. command palette → an inline-edit / agent-mode command that opens a floating modal).
2. Drag the modal by its header. Position must update without flicker.
3. Drag near each window edge — modal must stay inside the viewport (`bounds: "window"`).
4. Close + reopen — initial position should be at the configured default, not stuck at the last drag position (unless the modal explicitly persists position).

### 3. Resizable modal/panel (covers `use-resizable.ts`)
1. Open any panel that uses `useRafResizable` (any modal with corner/edge resize handles — e.g. the ones touched in this PR via `tw-cursor-[var(--copilot-resize-cursor)]`).
2. Test each direction handle as in §1.4 above — cursor must update on body, resize must be smooth.
3. **Important**: while resizing, briefly leave the window (drag the cursor out of the browser/Obsidian window). Re-enter. Cursor must restore correctly on mouseup. (This regression-tests the cleanup path that uses `setCssProps({ "--copilot-resize-cursor": "" })`.)

### 4. Autosize textarea (covers `ui/textarea.tsx`)
1. Open the chat view.
2. Type a single line — textarea should be at its `min-h-[60px]` baseline.
3. Press Enter several times to add empty lines — textarea grows up to the 300px cap, then scrolls.
4. Delete lines back — textarea shrinks back to the minimum.
5. Paste a multi-line block — height adjusts on the next tick.
6. Resize the window/sidebar — textarea height re-measures (the `window` resize listener still fires `adjustHeight`).

### 5. Status bar clearance (covers `ChatViewLayout.ts`)
1. Open chat view on desktop (mobile early-returns, so this is desktop-only).
2. Confirm the chat input is not occluded by the Obsidian status bar.
3. Toggle the Obsidian status bar visibility (Settings → Appearance → "Show status bar" or via theme).
4. Switch themes (try at least one theme that hides the status bar with opacity:0, and one that doesn't). Each theme switch debounces 600ms then re-measures.
5. Open Obsidian DevTools → Elements, inspect `.view-content` inside the Copilot view. The `--copilot-status-bar-clearance` custom property should either be unset (when there's no overlap or the bar is hidden) or set to a pixel value reflecting the overlap.

### 6. Drag + resize together (regression-test for shared body classes)
1. Open the quick-ask panel.
2. Resize from a corner — release.
3. Immediately drag the panel.
4. Resize again from a different corner.
5. Body classes `tw-select-none` and `tw-cursor-[var(--copilot-resize-cursor)]` / `tw-cursor-grabbing` must always clear on release. After all interactions, the page should be selectable again and the cursor back to default.

### 7. Devtools sanity check
After running through the above, open DevTools console and look for:
- No new `TypeError`s mentioning `setCssProps` (would indicate an element that doesn't get the Obsidian patch — should not happen for `HTMLElement` / `SVGElement`).
- No CSS warnings about invalid custom-property values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
