### PR TITLE
chore(providers): adopt non-deprecated LangChain APIs + remaining type cleanup (W6/9)

### DIFF
--- a/src/LLMProviders/BedrockChatModel.test.ts
+++ b/src/LLMProviders/BedrockChatModel.test.ts
@@ -338,7 +338,7 @@ describe("BedrockChatModel streaming decode", () => {
     it("includes thinking parameter when enableThinking is true", () => {
       const model = createModel(true);
       const requestBody = (model as any).buildRequestBody([
-        { role: "user", content: "test", _getType: () => "human" },
+        { role: "user", content: "test", getType: () => "human" },
       ]);
 
       expect(requestBody.thinking).toEqual({
@@ -352,7 +352,7 @@ describe("BedrockChatModel streaming decode", () => {
     it("does not include thinking parameter when enableThinking is false", () => {
       const model = createModel(false);
       const requestBody = (model as any).buildRequestBody(
-        [{ role: "user", content: "test", _getType: () => "human" }],
+        [{ role: "user", content: "test", getType: () => "human" }],
         { temperature: 0.7 }
       );
 
@@ -365,7 +365,7 @@ describe("BedrockChatModel streaming decode", () => {
     it("respects user temperature when thinking is disabled", () => {
       const model = createModel(false);
       const requestBody = (model as any).buildRequestBody(
-        [{ role: "user", content: "test", _getType: () => "human" }],
+        [{ role: "user", content: "test", getType: () => "human" }],
         { temperature: 0.5 }
       );
 
@@ -376,7 +376,7 @@ describe("BedrockChatModel streaming decode", () => {
     it("forces temperature to 1 when thinking is enabled", () => {
       const model = createModel(true);
       const requestBody = (model as any).buildRequestBody(
-        [{ role: "user", content: "test", _getType: () => "human" }],
+        [{ role: "user", content: "test", getType: () => "human" }],
         { temperature: 0.5 } // User tries to set 0.5, should be overridden to 1
       );
 
@@ -445,7 +445,7 @@ describe("BedrockChatModel streaming decode", () => {
               image_url: { url: "data:image/jpeg;base64,/9j/4AAQSkZJRg==" },
             },
           ],
-          _getType: () => "human",
+          getType: () => "human",
         };
 
         const result = (model as any).normaliseMessageContent(message);
@@ -466,7 +466,7 @@ describe("BedrockChatModel streaming decode", () => {
             { type: "text", text: "Hello " },
             { type: "text", text: "world!" },
           ],
-          _getType: () => "human",
+          getType: () => "human",
         };
 
         const result = (model as any).normaliseMessageContent(message);
@@ -479,7 +479,7 @@ describe("BedrockChatModel streaming decode", () => {
         const model = createModel();
         const message = {
           content: "Simple text message",
-          _getType: () => "human",
+          getType: () => "human",
         };
 
         const result = (model as any).normaliseMessageContent(message);
@@ -500,7 +500,7 @@ describe("BedrockChatModel streaming decode", () => {
                 image_url: { url: "data:image/jpeg;base64,/9j/4AAQSkZJRg==" },
               },
             ],
-            _getType: () => "human",
+            getType: () => "human",
           },
         ];
 
@@ -541,7 +541,7 @@ describe("BedrockChatModel streaming decode", () => {
                 image_url: { url: "data:image/png;base64,IMAGE2DATA" },
               },
             ],
-            _getType: () => "human",
+            getType: () => "human",
           },
         ];
 
@@ -560,7 +560,7 @@ describe("BedrockChatModel streaming decode", () => {
         const messages = [
           {
             content: "Just text, no images",
-            _getType: () => "human",
+            getType: () => "human",
           },
         ];
 
@@ -589,7 +589,7 @@ describe("BedrockChatModel streaming decode", () => {
                 image_url: { url: "data:image/jpeg;base64,VALIDDATA" }, // Valid
               },
             ],
-            _getType: () => "human",
+            getType: () => "human",
           },
         ];
 

--- a/src/LLMProviders/BedrockChatModel.ts
+++ b/src/LLMProviders/BedrockChatModel.ts
@@ -1243,7 +1243,7 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
     const systemPrompts: string[] = [];
 
     messages.forEach((message) => {
-      const messageType = message._getType();
+      const messageType = message.getType();
 
       // Handle system messages (always text-only)
       if (messageType === "system") {

--- a/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
+++ b/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
@@ -180,7 +180,7 @@ Include your extracted terms as: [SALIENT_TERMS: term1, term2, term3]`;
     // Extract tool calls from native response
     const nativeToolCalls = response.tool_calls || [];
     const responseText =
-      typeof response.content === "string" ? response.content : String(response.content);
+      typeof response.content === "string" ? response.content : JSON.stringify(response.content);
 
     logInfo("[CopilotPlus] Native tool calls:", nativeToolCalls.length);
 


### PR DESCRIPTION
## Summary

Seventh of nine workspaces splitting #2397 (the 906-warning scorecard fix). Picks up the LLM provider-file changes W1 deliberately deferred — primarily LangChain public-API renames that aren't pure type changes.

- `src/LLMProviders/BedrockChatModel.ts`: `_getType()` -> `getType()` (non-deprecated public-API method, same runtime behavior)
- `src/LLMProviders/BedrockChatModel.test.ts`: matching mock-message rename across all streaming-decode tests
- `src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts`: stringify non-string `response.content` via `JSON.stringify` instead of `String()` (avoids `[object Object]` when content is structured)

No semantic message-handling changes. All behavior preserved.

## Context

Already merged on master: W0 (#2398), #2402, W1 (#2403). Most provider-file type cleanups landed in W1; this PR is the tiny remainder.

Out-of-scope hunks remaining in the provider files (left for their owning workspaces):
- W3 — `setTimeout`/`clearTimeout` -> `window.*`, `globalThis` -> `window`, base64 simplification, `fetch.bind(globalThis)` -> `fetch.bind(window)` (Bedrock, ChatLMStudio, AutonomousAgentChainRunner, GitHubCopilotProvider, toolExecution)
- W7 — `Vault` -> `App` constructor refactors (`projectManager.ts`)
- W8 — `requestUrl` rewrites (`CustomOpenAIEmbeddings.ts`, `selfHostServices.ts`, `brevilabsClient.ts`)
- W2 — promise-safety adjustments (`chainManager.ts`)

## Test plan

CI must pass:
- `npm run lint`
- `npm run build`
- `npm test` (107 suites / 1962 tests)

Manual smoke (test plan §5 + §10d in `designdocs/todo/SCORECARD_WARNINGS_TEST_PLAN.md`):
- [ ] AWS Bedrock chat — send a message, verify response streams correctly (exercises `getType()` rename in `buildRequestBody`)
- [ ] CopilotPlus chain with tool calls — verify response text is captured correctly for the rare non-string content case

🤖 Generated with [Claude Code](https://claude.com/claude-code)