### PR TITLE
fix(vault): respect user trash preference via FileManager.trashFile (W7/9)

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -104,4 +104,7 @@ global.app = {
     getFirstLinkpathDest: jest.fn().mockReturnValue(null),
     getFileCache: jest.fn().mockReturnValue(null),
   },
+  fileManager: {
+    trashFile: jest.fn().mockResolvedValue(undefined),
+  },
 };

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "copilot",
   "name": "Copilot",
   "version": "3.2.8",
-  "minAppVersion": "0.15.0",
+  "minAppVersion": "1.4.0",
   "description": "Your AI Copilot: Chat with Your Second Brain, Learn Faster, Work Smarter.",
   "author": "Logan Yang",
   "authorUrl": "https://twitter.com/logancyang",

--- a/src/LLMProviders/projectManager.ts
+++ b/src/LLMProviders/projectManager.ts
@@ -187,7 +187,7 @@ export default class ProjectManager {
    * Delegates to ProjectFileManager for vault file writes.
    */
   private touchProjectUsageTimestamps(project: ProjectConfig): void {
-    const manager = ProjectFileManager.getInstance(this.app.vault);
+    const manager = ProjectFileManager.getInstance(this.app);
     void manager.touchProjectLastUsed(project.id);
   }
 
@@ -196,7 +196,7 @@ export default class ProjectManager {
    * This allows UI components to use in-memory values for immediate feedback.
    */
   public getProjectUsageTimestampsManager(): RecentUsageManager<string> {
-    return ProjectFileManager.getInstance(this.app.vault).getProjectUsageTimestampsManager();
+    return ProjectFileManager.getInstance(this.app).getProjectUsageTimestampsManager();
   }
 
   public async switchProject(project: ProjectConfig | null): Promise<void> {

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -21,6 +21,7 @@ import {
   updateCachedCommands,
 } from "./state";
 import { ensureFolderExists } from "@/utils";
+import { trashFile } from "@/utils/vaultAdapterUtils";
 
 export class CustomCommandManager {
   private static instance: CustomCommandManager;
@@ -165,7 +166,7 @@ export class CustomCommandManager {
       deleteCachedCommand(command.title);
       const file = app.vault.getAbstractFileByPath(filePath);
       if (file instanceof TFile) {
-        await app.vault.delete(file);
+        await trashFile(app, file);
       }
     } finally {
       removePendingFileWrite(filePath);

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -560,7 +560,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
 
   const handleAddProject = useCallback(
     async (project: ProjectConfig) => {
-      const manager = ProjectFileManager.getInstance(plugin.app.vault);
+      const manager = ProjectFileManager.getInstance(plugin.app);
       await manager.createProject(project);
       new Notice(`${project.name} added successfully`);
 
@@ -572,12 +572,12 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
         void reloadCurrentProject();
       }
     },
-    [plugin.app.vault]
+    [plugin.app]
   );
 
   const handleEditProject = useCallback(
     async (originP: ProjectConfig, updateP: ProjectConfig) => {
-      const manager = ProjectFileManager.getInstance(plugin.app.vault);
+      const manager = ProjectFileManager.getInstance(plugin.app);
       await manager.updateProject(originP.id, updateP);
       new Notice(`${originP.name} updated successfully`);
       // Reason: no explicit reload needed here — ProjectManager's project-record subscriber
@@ -585,7 +585,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
       // setCurrentProject + loadProjectContext + createChainWithNewModel.
       // Doing it here too would duplicate expensive work (URL fetches, chain recreation).
     },
-    [plugin.app.vault]
+    [plugin.app]
   );
 
   const handleRemoveSelectedText = useCallback(

--- a/src/components/chat-components/ProjectList.tsx
+++ b/src/components/chat-components/ProjectList.tsx
@@ -302,7 +302,7 @@ export const ProjectList = memo(
     };
 
     const handleDeleteProject = async (project: ProjectConfig) => {
-      const manager = ProjectFileManager.getInstance(app.vault);
+      const manager = ProjectFileManager.getInstance(app);
       try {
         await manager.deleteProject(project.id);
         // Reason: only clear UI selection — don't call setCurrentProject(null) here

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,12 @@ import {
   filterChatHistoryFiles,
 } from "@/utils/chatHistoryUtils";
 import { RecentUsageManager } from "@/utils/recentUsageManager";
-import { listMarkdownFiles, patchFrontmatter, resolveFileByPath } from "@/utils/vaultAdapterUtils";
+import {
+  listMarkdownFiles,
+  patchFrontmatter,
+  resolveFileByPath,
+  trashFile,
+} from "@/utils/vaultAdapterUtils";
 import { v4 as uuidv4 } from "uuid";
 
 // Removed unused FileTrackingState interface
@@ -207,7 +212,7 @@ export default class CopilotPlugin extends Plugin {
 
     this.customCommandRegister = new CustomCommandRegister(this, this.app.vault);
     this.systemPromptRegister = new SystemPromptRegister(this, this.app.vault);
-    this.projectRegister = new ProjectRegister(this.app.vault);
+    this.projectRegister = new ProjectRegister(this.app);
 
     this.app.workspace.onLayoutReady(() => {
       // Reason: projects must initialize after vault file tree is indexed (onLayoutReady),
@@ -836,7 +841,7 @@ export default class CopilotPlugin extends Plugin {
   async deleteChatHistory(fileId: string): Promise<void> {
     const file = this.app.vault.getAbstractFileByPath(fileId);
     if (file instanceof TFile) {
-      await this.app.vault.delete(file);
+      await trashFile(this.app, file);
       new Notice("Chat deleted.");
     } else if (await this.app.vault.adapter.exists(fileId)) {
       await this.app.vault.adapter.remove(fileId);

--- a/src/projects/ProjectFileManager.test.ts
+++ b/src/projects/ProjectFileManager.test.ts
@@ -1,4 +1,4 @@
-import { TFile, Vault } from "obsidian";
+import { App, TFile, Vault } from "obsidian";
 import { ProjectConfig } from "@/aiParams";
 import { ProjectFileManager } from "@/projects/ProjectFileManager";
 
@@ -87,11 +87,23 @@ function makeConfig(
 /** Build a minimal Vault mock. */
 function makeMockVault(): jest.Mocked<Vault> {
   return {
-    create: jest.fn(async (path: string) => ({ path }) as TFile),
+    create: jest.fn(async (path: string) => {
+      const file = Object.create(TFile.prototype);
+      Object.assign(file, { path });
+      return file;
+    }),
     // Reason: null = file does not exist yet, avoids collision error in createProject
     getAbstractFileByPath: jest.fn(() => null),
     adapter: { exists: jest.fn(async () => false) },
   } as unknown as jest.Mocked<Vault>;
+}
+
+/** Build a minimal App mock wrapping a vault. */
+function makeMockApp(vault: Vault): App {
+  return {
+    vault,
+    fileManager: { trashFile: jest.fn(async () => {}) },
+  } as unknown as App;
 }
 
 /** Reset the singleton so each test gets a fresh instance. */
@@ -123,7 +135,7 @@ describe("ProjectFileManager.createProject", () => {
       },
     ]);
 
-    const manager = ProjectFileManager.getInstance(vault);
+    const manager = ProjectFileManager.getInstance(makeMockApp(vault));
 
     // "my project" (lowercase) collides with "My Project"
     await expect(
@@ -132,7 +144,7 @@ describe("ProjectFileManager.createProject", () => {
   });
 
   it("rejects empty project id", async () => {
-    const manager = ProjectFileManager.getInstance(vault);
+    const manager = ProjectFileManager.getInstance(makeMockApp(vault));
 
     await expect(manager.createProject(makeConfig({ id: "", name: "Valid Name" }))).rejects.toThrow(
       /cannot be empty/i
@@ -140,7 +152,7 @@ describe("ProjectFileManager.createProject", () => {
   });
 
   it("rejects whitespace-only project id", async () => {
-    const manager = ProjectFileManager.getInstance(vault);
+    const manager = ProjectFileManager.getInstance(makeMockApp(vault));
 
     await expect(
       manager.createProject(makeConfig({ id: "   ", name: "Valid Name" }))

--- a/src/projects/ProjectFileManager.ts
+++ b/src/projects/ProjectFileManager.ts
@@ -43,8 +43,9 @@ import {
   patchFrontmatter,
   readFrontmatterViaAdapter,
   resolveFileByPath,
+  trashFile,
 } from "@/utils/vaultAdapterUtils";
-import { normalizePath, stringifyYaml, TFile, TFolder, Vault } from "obsidian";
+import { App, normalizePath, stringifyYaml, TFile, TFolder, Vault } from "obsidian";
 import { ensureProjectsMigratedIfNeeded } from "@/projects/projectMigration";
 
 /**
@@ -57,22 +58,24 @@ import { ensureProjectsMigratedIfNeeded } from "@/projects/projectMigration";
  */
 export class ProjectFileManager {
   private static instance: ProjectFileManager;
+  private app: App;
   private vault: Vault;
   private readonly projectLastUsedManager = new RecentUsageManager<string>();
 
-  private constructor(vault: Vault) {
-    this.vault = vault;
+  private constructor(app: App) {
+    this.app = app;
+    this.vault = app.vault;
   }
 
   /**
    * Get singleton instance.
-   * @param vault - Obsidian Vault (required on first call)
+   * @param app - Obsidian App (required on first call)
    * @returns ProjectFileManager singleton
    */
-  public static getInstance(vault?: Vault): ProjectFileManager {
+  public static getInstance(app?: App): ProjectFileManager {
     if (!ProjectFileManager.instance) {
-      if (!vault) throw new Error("Vault is required for first initialization");
-      ProjectFileManager.instance = new ProjectFileManager(vault);
+      if (!app) throw new Error("App is required for first initialization");
+      ProjectFileManager.instance = new ProjectFileManager(app);
     }
     return ProjectFileManager.instance;
   }
@@ -84,7 +87,7 @@ export class ProjectFileManager {
    */
   public async initialize(): Promise<void> {
     logInfo("[Projects] Initializing ProjectFileManager");
-    await ensureProjectsMigratedIfNeeded(this.vault);
+    await ensureProjectsMigratedIfNeeded(this.app);
     await loadAllProjects();
   }
 
@@ -148,7 +151,7 @@ export class ProjectFileManager {
     try {
       const file = this.vault.getAbstractFileByPath(filePath);
       if (file instanceof TFile) {
-        await this.vault.delete(file, true);
+        await trashFile(this.app, file);
       } else if (await this.vault.adapter.exists(filePath)) {
         // Reason: hidden-folder files are not indexed by vault cache.
         // Fall back to adapter-based deletion for consistent hidden-folder support.
@@ -156,7 +159,7 @@ export class ProjectFileManager {
       }
       const folder = this.vault.getAbstractFileByPath(folderPath);
       if (folder instanceof TFolder && folder.children.length === 0) {
-        await this.vault.delete(folder, true);
+        await trashFile(this.app, folder);
       } else if (await this.vault.adapter.exists(folderPath)) {
         const listing = await this.vault.adapter.list(folderPath);
         if (listing.files.length === 0 && listing.folders.length === 0) {
@@ -545,11 +548,11 @@ export class ProjectFileManager {
       addPendingFileWrite(existing.filePath);
 
       // Reason: delete only the managed config file to avoid destroying user files
-      // that may have been placed in the project folder. Use non-force delete so
-      // Obsidian respects the user's trash behavior (system trash / .trash folder).
+      // that may have been placed in the project folder. trashFile respects the
+      // user's trash behavior (system trash / .trash folder / permanent).
       const configFile = this.vault.getAbstractFileByPath(existing.filePath);
       if (configFile instanceof TFile) {
-        await this.vault.delete(configFile);
+        await trashFile(this.app, configFile);
       } else if (await this.vault.adapter.exists(existing.filePath)) {
         // Reason: hidden-folder files are not indexed by vault cache.
         // Fall back to adapter-based deletion for consistent hidden-folder support.
@@ -566,7 +569,7 @@ export class ProjectFileManager {
       try {
         const folder = this.vault.getAbstractFileByPath(folderPath);
         if (folder instanceof TFolder && folder.children.length === 0) {
-          await this.vault.delete(folder);
+          await trashFile(this.app, folder);
         } else if (await this.vault.adapter.exists(folderPath)) {
           const listing = await this.vault.adapter.list(folderPath);
           if (listing.files.length === 0 && listing.folders.length === 0) {

--- a/src/projects/projectMigration.ts
+++ b/src/projects/projectMigration.ts
@@ -16,7 +16,8 @@ import {
 import { addPendingFileWrite, removePendingFileWrite } from "@/projects/state";
 import { getSettings, updateSetting } from "@/settings/model";
 import { ensureFolderExists, stripFrontmatter } from "@/utils";
-import { Notice, parseYaml, TFile, TFolder, Vault } from "obsidian";
+import { App, Notice, parseYaml, TFile, TFolder, Vault } from "obsidian";
+import { trashFile } from "@/utils/vaultAdapterUtils";
 
 /**
  * Normalize line endings for content comparison (avoid CRLF/LF mismatches).
@@ -106,15 +107,12 @@ async function saveFailedProjectToUnsupported(
  * Best-effort rollback: delete a file and its parent folder if empty.
  * Logs errors but never throws.
  */
-async function rollbackCreatedFile(
-  vault: Vault,
-  filePath: string,
-  folderPath: string
-): Promise<void> {
+async function rollbackCreatedFile(app: App, filePath: string, folderPath: string): Promise<void> {
+  const vault = app.vault;
   try {
     const file = vault.getAbstractFileByPath(filePath);
     if (file instanceof TFile) {
-      await vault.delete(file, true);
+      await trashFile(app, file);
     } else if (await vault.adapter.exists(filePath)) {
       // Reason: hidden-folder files are not indexed by vault cache.
       // Fall back to adapter-based deletion for consistent hidden-folder support.
@@ -122,7 +120,7 @@ async function rollbackCreatedFile(
     }
     const folder = vault.getAbstractFileByPath(folderPath);
     if (folder instanceof TFolder && folder.children.length === 0) {
-      await vault.delete(folder, true);
+      await trashFile(app, folder);
     } else if (await vault.adapter.exists(folderPath)) {
       const listing = await vault.adapter.list(folderPath);
       if (listing.files.length === 0 && listing.folders.length === 0) {
@@ -143,10 +141,11 @@ async function rollbackCreatedFile(
  * @returns The created TFile (for hidden-folder compatibility, avoids re-fetching via vault cache)
  */
 async function writeProjectToVaultFile(
-  vault: Vault,
+  app: App,
   project: ProjectConfig,
   folderName: string
 ): Promise<TFile> {
+  const vault = app.vault;
   const projectsFolder = getProjectsFolder();
   await ensureFolderExists(projectsFolder);
   await ensureFolderExists(`${projectsFolder}/${folderName}`);
@@ -172,7 +171,7 @@ async function writeProjectToVaultFile(
       await writeProjectFrontmatter(file, project, folderName, { createdMs, lastUsedMs });
     } catch (fmError) {
       // Reason: rollback the created file to avoid leaving a "poisoned" file without frontmatter
-      await rollbackCreatedFile(vault, filePath, folderPath);
+      await rollbackCreatedFile(app, filePath, folderPath);
       throw fmError;
     }
 
@@ -238,9 +237,10 @@ function getMigrationFolderName(projectId: string, projectName?: string): string
  * - retry-safe: already-migrated projects (target file exists with matching id) are skipped
  * - clear-on-success: projectList entries are removed only for successfully migrated projects
  *
- * @param vault - Vault instance
+ * @param app - Obsidian App instance
  */
-export async function migrateProjectsFromSettingsToVault(vault: Vault): Promise<void> {
+export async function migrateProjectsFromSettingsToVault(app: App): Promise<void> {
+  const vault = app.vault;
   const settings = getSettings();
   const legacyProjects = settings.projectList || [];
 
@@ -395,7 +395,7 @@ export async function migrateProjectsFromSettingsToVault(vault: Vault): Promise<
     }
 
     try {
-      const file = await writeProjectToVaultFile(vault, project, folderName);
+      const file = await writeProjectToVaultFile(app, project, folderName);
 
       const verified = await verifyMigratedContent(vault, file, project.systemPrompt || "");
       if (!verified) {
@@ -403,7 +403,7 @@ export async function migrateProjectsFromSettingsToVault(vault: Vault): Promise<
         // Without this, the existing-file branch on next restart re-detects, re-verifies,
         // and fails again indefinitely.
         const folderPath = `${getProjectsFolder()}/${folderName}`;
-        await rollbackCreatedFile(vault, file.path, folderPath);
+        await rollbackCreatedFile(app, file.path, folderPath);
         await saveFailedProjectToUnsupported(vault, project, "content verification mismatch");
       } else {
         migratedEntries.push(project);
@@ -594,14 +594,14 @@ async function migrateProjectFolderNames(vault: Vault): Promise<void> {
   }
 }
 
-export async function ensureProjectsMigratedIfNeeded(vault: Vault): Promise<void> {
+export async function ensureProjectsMigratedIfNeeded(app: App): Promise<void> {
   const legacyProjects = getSettings().projectList || [];
   if (legacyProjects.length > 0) {
-    await migrateProjectsFromSettingsToVault(vault);
+    await migrateProjectsFromSettingsToVault(app);
   }
 
   // Reason: run naming migration after data.json migration to rename id-based folders
   // to name-based folders. This also handles pre-existing projects from before the
   // naming convention change. Runs before loadAllProjects() in initialization flow.
-  await migrateProjectFolderNames(vault);
+  await migrateProjectFolderNames(app.vault);
 }

--- a/src/projects/projectRegister.ts
+++ b/src/projects/projectRegister.ts
@@ -22,7 +22,7 @@ import { loadAllProjects } from "@/projects/projectUtils";
 import { PROJECT_CONFIG_FILE_NAME, PROJECTS_UNSUPPORTED_FOLDER_NAME } from "@/projects/constants";
 import { getSettings, subscribeToSettingsChange } from "@/settings/model";
 import debounce from "lodash.debounce";
-import { Notice, TAbstractFile, Vault } from "obsidian";
+import { App, Notice, TAbstractFile, Vault } from "obsidian";
 
 /**
  * Project Register: manages vault event listeners and cache synchronization.
@@ -42,9 +42,9 @@ export class ProjectRegister {
   /** Per-file debounced modify handlers to avoid cross-file debounce collisions. */
   private fileModifyDebouncers = new Map<string, ReturnType<typeof debounce>>();
 
-  constructor(vault: Vault) {
-    this.vault = vault;
-    this.manager = ProjectFileManager.getInstance(vault);
+  constructor(app: App) {
+    this.vault = app.vault;
+    this.manager = ProjectFileManager.getInstance(app);
   }
 
   /**

--- a/src/system-prompts/systemPromptManager.test.ts
+++ b/src/system-prompts/systemPromptManager.test.ts
@@ -72,6 +72,7 @@ describe("SystemPromptManager", () => {
       fileManager: {
         processFrontMatter: jest.fn(),
         renameFile: jest.fn(),
+        trashFile: jest.fn().mockResolvedValue(undefined),
       },
     } as any;
 
@@ -317,7 +318,9 @@ describe("SystemPromptManager", () => {
 
       await manager.deletePrompt("Test Prompt");
 
-      expect(mockVault.delete).toHaveBeenCalledWith(mockFile);
+      expect(
+        (app.fileManager as unknown as { trashFile: jest.Mock }).trashFile
+      ).toHaveBeenCalledWith(mockFile);
     });
 
     it("removes prompt from cache", async () => {
@@ -335,7 +338,9 @@ describe("SystemPromptManager", () => {
 
       await manager.deletePrompt("Non-existent Prompt");
 
-      expect(mockVault.delete).not.toHaveBeenCalled();
+      expect(
+        (app.fileManager as unknown as { trashFile: jest.Mock }).trashFile
+      ).not.toHaveBeenCalled();
       expect(state.deleteCachedSystemPrompt).toHaveBeenCalledWith("Non-existent Prompt");
     });
 

--- a/src/system-prompts/systemPromptManager.ts
+++ b/src/system-prompts/systemPromptManager.ts
@@ -25,6 +25,7 @@ import {
 } from "@/system-prompts/constants";
 import { logInfo } from "@/logger";
 import { ensureFolderExists } from "@/utils";
+import { trashFile } from "@/utils/vaultAdapterUtils";
 import { getSettings, updateSetting } from "@/settings/model";
 
 /**
@@ -192,7 +193,7 @@ export class SystemPromptManager {
       // Delete the file first
       const file = this.vault.getAbstractFileByPath(filePath);
       if (file instanceof TFile) {
-        await this.vault.delete(file);
+        await trashFile(app, file);
       }
 
       // Clear state only after successful deletion to maintain consistency

--- a/src/utils/vaultAdapterUtils.ts
+++ b/src/utils/vaultAdapterUtils.ts
@@ -1,4 +1,16 @@
-import { App, TFile, TFolder } from "obsidian";
+import { App, TAbstractFile, TFile, TFolder } from "obsidian";
+
+/**
+ * Move a file or folder to the user's configured trash via FileManager.trashFile (Obsidian 1.4+).
+ * Respects the user's deletion preference (system trash / vault .trash / permanent).
+ * Cast is needed because the bundled `obsidian.d.ts` doesn't yet expose this method.
+ */
+export async function trashFile(app: App, file: TAbstractFile): Promise<void> {
+  const fileManager = app.fileManager as unknown as {
+    trashFile(f: TAbstractFile): Promise<void>;
+  };
+  await fileManager.trashFile(file);
+}
 
 /**
  * Resolve a file path to a TFile, with adapter fallback for hidden directories.
@@ -127,7 +139,8 @@ export async function readFrontmatterViaAdapter(
 async function createSyntheticTFile(app: App, filePath: string): Promise<TFile> {
   const stat = await app.vault.adapter.stat(filePath);
   const name = filePath.split("/").pop() ?? "";
-  return {
+  const synthetic: TFile = Object.create(TFile.prototype);
+  Object.assign(synthetic, {
     path: filePath,
     name,
     basename: name.replace(/\.md$/, ""),
@@ -135,5 +148,6 @@ async function createSyntheticTFile(app: App, filePath: string): Promise<TFile> 
     stat: stat ?? { ctime: Date.now(), mtime: Date.now(), size: 0 },
     vault: app.vault,
     parent: null,
-  } as unknown as TFile;
+  });
+  return synthetic;
 }


### PR DESCRIPTION
## Summary

Eighth of nine workspaces splitting #2397 (zeroliu/fix-scorecard-warnings, 906 scorecard warnings) into focused PRs. **Intentional, user-visible behavior change**: file deletions now honor the user's Settings -> Files and links -> Deleted files preference (system trash / vault .trash / permanent), instead of unconditionally calling `vault.delete(file, true)`.

Prior workspaces already landed: W0 (#2398 deps), #2402 (perf: Cohere/Mistral OpenAI-compat), W1 (#2403 types). Still open: W8 (#2399 brevilabs), W5 (#2400 styles), W3 (#2401 popout APIs).

## Behavior change (important)

Before: deletes were forced (`vault.delete(file, true)`), bypassing the user's trash preference. Project-create rollback used `force: true` so partially-written project files vanished permanently on error.

After: deletes route through `app.fileManager.trashFile(file)` (Obsidian 1.4+), which respects the user's "Deleted files" setting. Recoverable for users with system trash or `.trash` configured.

Sites swapped:
- Chat history delete (`deleteChatHistory` in `main.ts`)
- Project file/folder delete (`ProjectFileManager.deleteProject`, `rollbackCreatedFile`)
- Project migration rollback (`projectMigration.ts`)
- System prompt delete
- Custom command delete

## Implementation

- `src/utils/vaultAdapterUtils.ts`:
  - New `trashFile(app, file)` helper that casts past the missing `app.fileManager.trashFile` typedef.
  - `createSyntheticTFile` now uses `Object.create(TFile.prototype)` so `instanceof TFile` returns true (needed since W1 changed several callers to use `instanceof TFile` narrowing).
- `src/projects/ProjectFileManager.ts`: constructor takes `App` instead of `Vault`; stores both `this.app` and `this.vault = app.vault`. All `vault.delete` swapped to `trashFile`.
- `src/projects/projectRegister.ts`: constructor takes `App`.
- `src/projects/projectMigration.ts`: `rollbackCreatedFile(app, ...)`, `writeProjectToVaultFile(app, ...)`, `migrateProjectsFromSettingsToVault(app)`, `ensureProjectsMigratedIfNeeded(app)`.
- `src/main.ts`: imports `trashFile`; `deleteChatHistory` uses `trashFile(this.app, file)`; `new ProjectRegister(this.app)`.
- `src/system-prompts/systemPromptManager.ts`, `src/commands/customCommandManager.ts`: prompt/command delete via `trashFile`.
- `src/LLMProviders/projectManager.ts`, `src/components/Chat.tsx`, `src/components/chat-components/ProjectList.tsx`: pass `app` (not `vault`) to `ProjectFileManager.getInstance`.
- `__mocks__/obsidian.js`: adds `app.fileManager.trashFile` jest mock.
- Tests updated to assert on `trashFile` and to pass `App` constructor arg.

## Verification

- `npm run format` clean
- `npm run lint` clean
- `npm run build` succeeds (tsc + esbuild)
- `npm test` -- 107 suites / 1962 tests all pass

## Test plan (manual, not yet verified)

Behavior change requires real-vault verification before merging. From `designdocs/todo/SCORECARD_WARNINGS_TEST_PLAN.md` section 1 + section 6:

- [ ] Section 1.1: Delete a chat history file -- ends up in the configured trash location, not permanent-deleted.
- [ ] Section 1.2: Delete a project -- `project.md` is trashed (not nuked); empty project folder is trashed; non-empty project folders are preserved (user files inside are kept).
- [ ] Section 1.3: Force a project-create failure (e.g. invalid frontmatter, write error) -- partial files are trashed (recoverable from system trash), not permanent-deleted.
- [ ] Section 1.4: Delete a system prompt -- file trashed, respects preference.
- [ ] Section 1.5: Delete a custom command -- file trashed, respects preference.
- [ ] Section 6: Toggle the user's "Deleted files" preference between system trash, `.trash`, and permanent -- behavior follows the setting in all five sites above.

## Plan reference

See `/Users/zeroliu/.claude/plans/i-want-you-to-smooth-dusk.md` W7 for the full split context.