### PR TITLE
chore(promises): explicit handling of floating promises (W2/9)

### DIFF
--- a/src/LLMProviders/chainManager.ts
+++ b/src/LLMProviders/chainManager.ts
@@ -60,10 +60,12 @@ export default class ChainManager {
     this.userMemoryManager = new UserMemoryManager(app);
 
     // Initialize async operations
-    this.initialize();
+    void this.initialize().catch((err) => logError("ChainManager initialize failed", err));
 
-    subscribeToSettingsChange(async () => {
-      await this.createChainWithNewModel();
+    subscribeToSettingsChange(() => {
+      void this.createChainWithNewModel().catch((err) =>
+        logError("createChainWithNewModel failed", err)
+      );
     });
   }
 
@@ -102,7 +104,9 @@ export default class ChainManager {
   private validateChainInitialization() {
     if (!this.chain || !isSupportedChain(this.chain)) {
       logInfo("Reinitializing chat chain after detecting missing or unsupported instance.");
-      this.createChainWithNewModel({}, false);
+      void this.createChainWithNewModel({}, false).catch((err) =>
+        logError("createChainWithNewModel failed", err)
+      );
     }
   }
 
@@ -173,7 +177,7 @@ export default class ChainManager {
       // Must update the chatModel for chain because ChainFactory always
       // retrieves the old chain without the chatModel change if it exists!
       // Create a new chain with the new chatModel
-      this.setChain(chainType, options);
+      await this.setChain(chainType, options);
       logInfo(`Setting model to ${newModelKey}`);
     } catch (error) {
       this.pendingModelError = error instanceof Error ? error : new Error(String(error));
@@ -359,7 +363,9 @@ export default class ChainManager {
         ]);
       }
 
-      this.createChainWithNewModel({ prompt: effectivePrompt }, false);
+      void this.createChainWithNewModel({ prompt: effectivePrompt }, false).catch((err) =>
+        logError("createChainWithNewModel failed", err)
+      );
       /*this.setChain(getChainType(), {
         prompt: effectivePrompt,
       });*/

--- a/src/commands/CustomCommandSettingsModal.tsx
+++ b/src/commands/CustomCommandSettingsModal.tsx
@@ -181,7 +181,7 @@ export class CustomCommandSettingsModal extends Modal {
     app: App,
     private commands: CustomCommand[],
     private command: CustomCommand,
-    private onUpdate: (command: CustomCommand) => void
+    private onUpdate: (command: CustomCommand) => void | Promise<void>
   ) {
     super(app);
     // https://docs.obsidian.md/Reference/TypeScript+API/Modal/setTitle

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -142,7 +142,9 @@ export class CustomCommandRegister {
           selectedText: editor.getSelection(),
           command: customCommand,
         }).open();
-        CustomCommandManager.getInstance().recordUsage(customCommand);
+        void CustomCommandManager.getInstance()
+          .recordUsage(customCommand)
+          .catch((err) => logError("recordUsage failed", err));
       },
     });
   }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -36,28 +36,42 @@ import { setSelectedTextContexts } from "@/aiParams";
 /**
  * Add a command to the plugin. Supports async callbacks; errors are logged.
  */
-export function addCommand(plugin: CopilotPlugin, id: CommandId, callback: () => void) {
-  plugin.addCommand({
-    id,
-    name: COMMAND_NAMES[id],
-    icon: COMMAND_ICONS[id],
-    callback,
-  });
-}
-
-/**
- * Add an editor command to the plugin.
- */
-function addEditorCommand(
+export function addCommand(
   plugin: CopilotPlugin,
   id: CommandId,
-  callback: (editor: Editor) => void
+  callback: () => void | Promise<void>
 ) {
   plugin.addCommand({
     id,
     name: COMMAND_NAMES[id],
     icon: COMMAND_ICONS[id],
-    editorCallback: callback,
+    callback: () => {
+      const result = callback();
+      if (result instanceof Promise) {
+        result.catch((err) => logError(`Command ${id} failed`, err));
+      }
+    },
+  });
+}
+
+/**
+ * Add an editor command to the plugin. Supports async callbacks; errors are logged.
+ */
+function addEditorCommand(
+  plugin: CopilotPlugin,
+  id: CommandId,
+  callback: (editor: Editor) => void | Promise<void>
+) {
+  plugin.addCommand({
+    id,
+    name: COMMAND_NAMES[id],
+    icon: COMMAND_ICONS[id],
+    editorCallback: (editor) => {
+      const result = callback(editor);
+      if (result instanceof Promise) {
+        result.catch((err) => logError(`Editor command ${id} failed`, err));
+      }
+    },
   });
 }
 

--- a/src/commands/migrator.ts
+++ b/src/commands/migrator.ts
@@ -13,6 +13,7 @@ import {
 import { COPILOT_COMMAND_CONTEXT_MENU_ENABLED } from "@/commands/constants";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { getCachedCustomCommands } from "@/commands/state";
+import { logError } from "@/logger";
 
 async function saveUnsupportedCommands(commands: CustomCommand[]) {
   const folderPath = getCustomCommandsFolder();
@@ -108,7 +109,9 @@ export async function suggestDefaultCommands(): Promise<void> {
     new ConfirmModal(
       app,
       () => {
-        generateDefaultCommands();
+        void generateDefaultCommands().catch((err) =>
+          logError("generateDefaultCommands failed", err)
+        );
       },
       "Would you like to add Copilot recommended commands in your custom prompts folder? These commands will be available through the right-click context menu and slash commands in chat.",
       "Welcome to Copilot",

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -349,7 +349,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
 
       // Autosave if enabled
       if (settings.autosaveChat) {
-        handleSaveAsNote();
+        await handleSaveAsNote();
       }
 
       // Get the LLM message for AI processing
@@ -367,7 +367,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
 
       // Autosave again after AI response
       if (settings.autosaveChat) {
-        handleSaveAsNote();
+        await handleSaveAsNote();
       }
     } catch (error) {
       logError("Error sending message:", error);
@@ -452,7 +452,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
 
         // Autosave the chat if the setting is enabled
         if (settings.autosaveChat) {
-          handleSaveAsNote();
+          await handleSaveAsNote();
         }
       } catch (error) {
         logError("Error regenerating message:", error);
@@ -529,7 +529,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
 
         // Autosave the chat if the setting is enabled
         if (settings.autosaveChat) {
-          handleSaveAsNote();
+          await handleSaveAsNote();
         }
       } catch (error) {
         logError("Error editing message:", error);
@@ -845,17 +845,17 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
           <div className="tw-inset-0 tw-z-modal tw-flex tw-items-center tw-justify-center tw-rounded-xl">
             <IndexingProgressCard
               onClose={handleIndexingCardClose}
-              onPause={handleIndexingPause}
-              onResume={handleIndexingResume}
-              onStop={handleIndexingStop}
+              onPause={() => void handleIndexingPause()}
+              onResume={() => void handleIndexingResume()}
+              onStop={() => void handleIndexingStop()}
             />
           </div>
         ) : (
           <>
             <ChatControls
-              onNewChat={handleNewChat}
+              onNewChat={() => void handleNewChat()}
               onSaveAsNote={() => handleSaveAsNote()}
-              onLoadHistory={handleLoadChatHistory}
+              onLoadHistory={() => void handleLoadChatHistory()}
               onModeChange={(newMode) => {
                 setPreviousMode(selectedChain);
                 // Hide chat UI when switching to project mode

--- a/src/components/chat-components/ChatContextMenu.tsx
+++ b/src/components/chat-components/ChatContextMenu.tsx
@@ -139,7 +139,7 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
    * Handles clicking on a badge to open the file in a new tab (or focus existing tab)
    */
   const handleBadgeClick = (file: TFile) => {
-    openFileInWorkspace(file);
+    void openFileInWorkspace(file);
   };
 
   const uniqueNotes = React.useMemo(() => {

--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -255,14 +255,14 @@ export function ChatControls({
           <DropdownMenuContent align="start">
             <DropdownMenuItem
               onSelect={() => {
-                handleModeChange(ChainType.LLM_CHAIN);
+                void handleModeChange(ChainType.LLM_CHAIN);
               }}
             >
               chat (free)
             </DropdownMenuItem>
             <DropdownMenuItem
               onSelect={() => {
-                handleModeChange(ChainType.VAULT_QA_CHAIN);
+                void handleModeChange(ChainType.VAULT_QA_CHAIN);
               }}
             >
               vault QA (free)
@@ -270,7 +270,7 @@ export function ChatControls({
             {isPlusUser ? (
               <DropdownMenuItem
                 onSelect={() => {
-                  handleModeChange(ChainType.COPILOT_PLUS_CHAIN);
+                  void handleModeChange(ChainType.COPILOT_PLUS_CHAIN);
                 }}
               >
                 <div className="tw-flex tw-items-center tw-gap-1">
@@ -294,7 +294,7 @@ export function ChatControls({
               <DropdownMenuItem
                 className="tw-flex tw-items-center tw-gap-1"
                 onSelect={() => {
-                  handleModeChange(ChainType.PROJECT_CHAIN);
+                  void handleModeChange(ChainType.PROJECT_CHAIN);
                 }}
               >
                 <LibraryBig className="tw-size-4" />
@@ -330,7 +330,12 @@ export function ChatControls({
         {!settings.autosaveChat && (
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="ghost2" size="icon" title="Save Chat as Note" onClick={onSaveAsNote}>
+              <Button
+                variant="ghost2"
+                size="icon"
+                title="Save Chat as Note"
+                onClick={() => void onSaveAsNote()}
+              >
                 <Download className="tw-size-4" />
               </Button>
             </TooltipTrigger>
@@ -404,14 +409,14 @@ export function ChatControls({
               <>
                 <DropdownMenuItem
                   className="tw-flex tw-items-center tw-gap-2"
-                  onSelect={() => reloadCurrentProject()}
+                  onSelect={() => void reloadCurrentProject()}
                 >
                   <RefreshCw className="tw-size-4" />
                   Reload Current Project
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   className="tw-flex tw-items-center tw-gap-2"
-                  onSelect={() => forceRebuildCurrentProjectContext()}
+                  onSelect={() => void forceRebuildCurrentProjectContext()}
                 >
                   <AlertTriangle className="tw-size-4" />
                   Force Rebuild Context
@@ -421,7 +426,7 @@ export function ChatControls({
               <>
                 <DropdownMenuItem
                   className="tw-flex tw-items-center tw-gap-2"
-                  onSelect={() => refreshVaultIndex()}
+                  onSelect={() => void refreshVaultIndex()}
                 >
                   <RefreshCw className="tw-size-4" />
                   Refresh Vault Index

--- a/src/components/chat-components/ChatSettingsPopover.tsx
+++ b/src/components/chat-components/ChatSettingsPopover.tsx
@@ -199,7 +199,7 @@ export function ChatSettingsPopover() {
   const handleOpenSourceFile = () => {
     if (!displayValue) return;
     const filePath = getPromptFilePath(displayValue);
-    app.workspace.openLinkText(filePath, "", true);
+    void app.workspace.openLinkText(filePath, "", true);
   };
 
   if (!localModel) {

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -32,6 +32,7 @@ import { cn } from "@/lib/utils";
 import { parseToolCallMarkers } from "@/LLMProviders/chainRunner/utils/toolCallParser";
 import { parseReasoningBlock } from "@/LLMProviders/chainRunner/utils/AgentReasoningState";
 import { processInlineCitations } from "@/LLMProviders/chainRunner/utils/citationUtils";
+import { logError } from "@/logger";
 import { ChatMessage } from "@/types/message";
 import { cleanMessageForCopy, extractYoutubeVideoId, insertIntoEditor } from "@/utils";
 import { preprocessAIResponse } from "@/utils/markdownPreprocess";
@@ -345,13 +346,16 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
     }
 
     const cleanedContent = cleanMessageForCopy(message.message);
-    navigator.clipboard.writeText(cleanedContent).then(() => {
-      setIsCopied(true);
+    navigator.clipboard
+      .writeText(cleanedContent)
+      .then(() => {
+        setIsCopied(true);
 
-      setTimeout(() => {
-        setIsCopied(false);
-      }, 2000);
-    });
+        setTimeout(() => {
+          setIsCopied(false);
+        }, 2000);
+      })
+      .catch((err) => logError("Clipboard writeText failed", err));
   };
 
   const preprocess = useCallback(
@@ -700,8 +704,14 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
               contentRef.current!.appendChild(textDiv);
             }
 
-            MarkdownRenderer.renderMarkdown(segment.content, textDiv, "", componentRef.current!);
-            normalizeFootnoteRendering(textDiv);
+            void MarkdownRenderer.renderMarkdown(
+              segment.content,
+              textDiv,
+              "",
+              componentRef.current!
+            )
+              .then(() => normalizeFootnoteRendering(textDiv))
+              .catch((err) => logError("renderMarkdown failed", err));
             currentIndex++;
           } else if (segment.type === "toolCall" && segment.toolCall) {
             const toolCallId = segment.toolCall.id;

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -8,7 +8,7 @@ import { useChatInput } from "@/context/ChatInputContext";
 import { useActiveFile } from "@/hooks/useActiveFile";
 import { useNoteDrag } from "@/hooks/useNoteDrag";
 import { cn } from "@/lib/utils";
-import { logWarn } from "@/logger";
+import { logError, logWarn } from "@/logger";
 import { SemanticSearchToggleModal } from "@/components/modals/SemanticSearchToggleModal";
 import { shouldUseMiyo } from "@/miyo/miyoUtils";
 import {
@@ -49,7 +49,7 @@ function useRelevantNotes(refresher: number) {
       }
     }
 
-    fetchNotes();
+    void fetchNotes();
   }, [activeFile?.path, refresher, signalTick]);
 
   return relevantNotes;
@@ -84,7 +84,7 @@ function useHasIndex(notePath: string, refresher: number) {
       }
     }
 
-    fetchHasIndex();
+    void fetchHasIndex();
   }, [notePath, refresher, signalTick]);
   return hasIndex;
 }
@@ -132,7 +132,7 @@ function RelevantNote({
 
   useEffect(() => {
     if (isOpen) {
-      loadContent();
+      void loadContent();
     }
   }, [isOpen, loadContent]);
 
@@ -283,7 +283,7 @@ export const RelevantNotes = memo(
       const file = app.vault.getAbstractFileByPath(notePath);
       if (file instanceof TFile) {
         const leaf = app.workspace.getLeaf(openInNewLeaf);
-        leaf.openFile(file);
+        void leaf.openFile(file).catch((err) => logError("openFile failed", err));
       }
     };
     const addToChat = (prompt: string) => {
@@ -347,14 +347,14 @@ export const RelevantNotes = memo(
               {hasIndex ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Button variant="ghost2" size="icon" onClick={refreshIndex}>
+                    <Button variant="ghost2" size="icon" onClick={() => void refreshIndex()}>
                       <RefreshCcw className="tw-size-4" />
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent side="bottom">Reindex Current Note</TooltipContent>
                 </Tooltip>
               ) : (
-                <Button variant="secondary" size="sm" onClick={handleBuildIndex}>
+                <Button variant="secondary" size="sm" onClick={() => void handleBuildIndex()}>
                   Build Index
                 </Button>
               )}

--- a/src/components/chat-components/plugins/AtMentionCommandPlugin.tsx
+++ b/src/components/chat-components/plugins/AtMentionCommandPlugin.tsx
@@ -157,7 +157,7 @@ export function AtMentionCommandPlugin({
       selectedOption.category === "notes" &&
       selectedOption.data instanceof TFile
     ) {
-      loadNoteContentForPreview(selectedOption.data);
+      void loadNoteContentForPreview(selectedOption.data);
     } else {
       setCurrentPreviewContent("");
     }

--- a/src/components/chat-components/plugins/NoteCommandPlugin.tsx
+++ b/src/components/chat-components/plugins/NoteCommandPlugin.tsx
@@ -102,7 +102,7 @@ export function NoteCommandPlugin({
     onHighlight: (_index: number, option: NoteSearchOption) => {
       // Load content for the highlighted note if not already loaded
       if (option && !previewContent.has(option.file.path)) {
-        loadNoteContent(option.file);
+        void loadNoteContent(option.file);
       }
     },
   });
@@ -110,7 +110,7 @@ export function NoteCommandPlugin({
   // Load content for the first note when filteredNotes change
   useEffect(() => {
     if (filteredNotes.length > 0 && !previewContent.has(filteredNotes[0].file.path)) {
-      loadNoteContent(filteredNotes[0].file);
+      void loadNoteContent(filteredNotes[0].file);
     }
   }, [filteredNotes, previewContent, loadNoteContent]);
 

--- a/src/components/chat-components/plugins/SlashCommandPlugin.tsx
+++ b/src/components/chat-components/plugins/SlashCommandPlugin.tsx
@@ -67,7 +67,7 @@ export function SlashCommandPlugin(): JSX.Element {
   const handleSelect = useCallback(
     (option: SlashCommandOption) => {
       // Record usage to update lastUsedMs for recency sorting
-      CustomCommandManager.getInstance().recordUsage(option.command);
+      void CustomCommandManager.getInstance().recordUsage(option.command);
 
       editor.update(() => {
         const selection = $getSelection();

--- a/src/components/modals/ApplyCustomCommandModal.tsx
+++ b/src/components/modals/ApplyCustomCommandModal.tsx
@@ -54,7 +54,7 @@ export class ApplyCustomCommandModal extends FuzzySuggestModal<CustomCommand> {
 
   private openCommandModal(command: CustomCommand, selectedText: string) {
     // Record usage of the command
-    CustomCommandManager.getInstance().recordUsage(command);
+    void CustomCommandManager.getInstance().recordUsage(command);
 
     // Open the CustomCommandChatModal with the selected command
     const modal = new CustomCommandChatModal(this.app, {

--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { logError } from "@/logger";
 import { App, Modal } from "obsidian";
 import React from "react";
 import { createRoot, Root } from "react-dom/client";
@@ -41,12 +42,12 @@ export class ConfirmModal extends Modal {
 
   constructor(
     app: App,
-    private onConfirm: () => void,
+    private onConfirm: () => void | Promise<void>,
     private content: string,
     title: string,
     private confirmButtonText: string = "Continue",
     private cancelButtonText: string = "Cancel",
-    private onCancel?: () => void
+    private onCancel?: () => void | Promise<void>
   ) {
     super(app);
     // https://docs.obsidian.md/Reference/TypeScript+API/Modal/setTitle
@@ -60,7 +61,10 @@ export class ConfirmModal extends Modal {
 
     const handleConfirm = () => {
       this.confirmed = true;
-      this.onConfirm();
+      const result = this.onConfirm();
+      if (result instanceof Promise) {
+        result.catch((err) => logError("ConfirmModal onConfirm failed", err));
+      }
       this.close();
     };
 
@@ -81,7 +85,10 @@ export class ConfirmModal extends Modal {
 
   onClose() {
     if (!this.confirmed) {
-      this.onCancel?.();
+      const result = this.onCancel?.();
+      if (result instanceof Promise) {
+        result.catch((err) => logError("ConfirmModal onCancel failed", err));
+      }
     }
     this.root.unmount();
   }

--- a/src/components/modals/SemanticSearchToggleModal.tsx
+++ b/src/components/modals/SemanticSearchToggleModal.tsx
@@ -2,7 +2,7 @@ import { App } from "obsidian";
 import { ConfirmModal } from "./ConfirmModal";
 
 export class SemanticSearchToggleModal extends ConfirmModal {
-  constructor(app: App, onConfirm: () => void, enabling: boolean) {
+  constructor(app: App, onConfirm: () => void | Promise<void>, enabling: boolean) {
     const content = enabling
       ? "Semantic search requires building an embedding index for your vault.\n\nUse 'Refresh Vault Index' or 'Force Reindex Vault' commands to build the index after enabling. Pick your embedding model below."
       : "Disabling semantic search will fall back to index-free lexical search (less resource-intensive, could be less accurate).\n\nYour existing index will be preserved but not used.";

--- a/src/components/modals/SourcesModal.tsx
+++ b/src/components/modals/SourcesModal.tsx
@@ -1,4 +1,5 @@
 // src/components/SourcesModal.tsx
+import { logError } from "@/logger";
 import { App, Modal, TFile } from "obsidian";
 
 export class SourcesModal extends Modal {
@@ -72,7 +73,7 @@ export class SourcesModal extends Modal {
         e.preventDefault();
         e.stopPropagation();
         // Use the path if available, otherwise fall back to title
-        this.app.workspace.openLinkText(source.path || source.title, "");
+        this.app.workspace.openLinkText(source.path || source.title, "").catch(logError);
       });
 
       // Display with 4 decimals to match SearchCore logs and avoid apparent ties

--- a/src/components/modals/YoutubeTranscriptModal.tsx
+++ b/src/components/modals/YoutubeTranscriptModal.tsx
@@ -125,7 +125,7 @@ function YoutubeTranscriptModalContent({ onClose }: { onClose: () => void }) {
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" && !isLoading && isValidUrl) {
-      handleDownload();
+      void handleDownload();
     }
   };
 
@@ -156,10 +156,10 @@ function YoutubeTranscriptModalContent({ onClose }: { onClose: () => void }) {
           <Button variant="ghost" onClick={handleDownloadAnother}>
             Download Another
           </Button>
-          <Button variant="default" onClick={handleCopyToClipboard}>
+          <Button variant="default" onClick={() => void handleCopyToClipboard()}>
             Copy to Clipboard
           </Button>
-          <Button variant="default" onClick={handleInsertToNote}>
+          <Button variant="default" onClick={() => void handleInsertToNote()}>
             Insert at Cursor
           </Button>
           <Button variant="secondary" onClick={onClose}>
@@ -190,7 +190,11 @@ function YoutubeTranscriptModalContent({ onClose }: { onClose: () => void }) {
         <Button variant="secondary" onClick={onClose} disabled={isLoading}>
           Cancel
         </Button>
-        <Button variant="default" onClick={handleDownload} disabled={isLoading || !isValidUrl}>
+        <Button
+          variant="default"
+          onClick={() => void handleDownload()}
+          disabled={isLoading || !isValidUrl}
+        >
           {isLoading ? "Downloading..." : "Download Transcript"}
         </Button>
       </div>

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -41,7 +41,7 @@ export function PasswordInput({
       }
     };
 
-    processValue();
+    void processValue();
   }, [value]);
 
   return (

--- a/src/core/ChatManager.ts
+++ b/src/core/ChatManager.ts
@@ -6,7 +6,7 @@ import {
 } from "@/system-prompts/systemPromptBuilder";
 import { ChainType } from "@/chainFactory";
 import { getChainType, getCurrentProject } from "@/aiParams";
-import { logInfo, logWarn } from "@/logger";
+import { logError, logInfo, logWarn } from "@/logger";
 import { ChatMessage, MessageContext, WebTabContext } from "@/types/message";
 import { processPrompt, type ProcessedPromptResult } from "@/commands/customCommandUtils";
 import { FileParserManager } from "@/tools/FileParserManager";
@@ -687,8 +687,10 @@ export class ChatManager {
   clearMessages(): void {
     const currentRepo = this.getCurrentMessageRepo();
     currentRepo.clear();
-    // Clear chain memory directly
-    this.chainManager.memoryManager.clearChatMemory();
+    // Clear chain memory directly (fire-and-forget; errors are logged but do not block UI)
+    void this.chainManager.memoryManager
+      .clearChatMemory()
+      .catch((err) => logError("clearChatMemory failed", err));
     logInfo(`[ChatManager] Cleared all messages`);
   }
 

--- a/src/hooks/useChatManager.ts
+++ b/src/hooks/useChatManager.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { logError } from "@/logger";
 import { ChainType } from "@/chainFactory";
 import { ChatMessage, MessageContext } from "@/types/message";
 import { ChatUIState } from "@/state/ChatUIState";
@@ -110,7 +111,7 @@ export function useChatManager(chatUIState: ChatUIState) {
 
   const loadMessages = useCallback(
     (messages: ChatMessage[]): void => {
-      chatUIState.loadMessages(messages);
+      void chatUIState.loadMessages(messages).catch((err) => logError("loadMessages failed", err));
     },
     [chatUIState]
   );

--- a/src/hooks/useLatestVersion.ts
+++ b/src/hooks/useLatestVersion.ts
@@ -1,3 +1,4 @@
+import { logError } from "@/logger";
 import { checkLatestVersion, isNewerVersion } from "@/utils";
 import { useEffect, useState } from "react";
 
@@ -16,7 +17,7 @@ export function useLatestVersion(currentVersion: string): UseLatestVersionResult
         setLatestVersion(result.version);
       }
     };
-    checkVersion();
+    void checkVersion().catch((err) => logError("checkVersion failed", err));
   }, []);
 
   const hasUpdate = latestVersion !== null && isNewerVersion(latestVersion, currentVersion);

--- a/src/search/dbOperations.ts
+++ b/src/search/dbOperations.ts
@@ -44,28 +44,34 @@ export class DBOperations {
 
   constructor(private app: App) {
     // Subscribe to settings changes
-    subscribeToSettingsChange(async () => {
-      const settings = getSettings();
+    subscribeToSettingsChange(() => {
+      void (async () => {
+        try {
+          const settings = getSettings();
 
-      // Handle mobile index loading setting change
-      if (Platform.isMobile && settings.disableIndexOnMobile) {
-        this.isIndexLoaded = false;
-        this.oramaDb = undefined;
-      } else if (Platform.isMobile && !settings.disableIndexOnMobile && !this.oramaDb) {
-        // Re-initialize DB if mobile setting is enabled
-        await this.initializeDB(await EmbeddingsManager.getInstance().getEmbeddingsAPI());
-      }
+          // Handle mobile index loading setting change
+          if (Platform.isMobile && settings.disableIndexOnMobile) {
+            this.isIndexLoaded = false;
+            this.oramaDb = undefined;
+          } else if (Platform.isMobile && !settings.disableIndexOnMobile && !this.oramaDb) {
+            // Re-initialize DB if mobile setting is enabled
+            await this.initializeDB(await EmbeddingsManager.getInstance().getEmbeddingsAPI());
+          }
 
-      // Handle index sync setting change
-      const newPath = await this.getDbPath();
+          // Handle index sync setting change
+          const newPath = await this.getDbPath();
 
-      if (this.dbPath && newPath !== this.dbPath) {
-        logInfo("Path change detected, reinitializing database...");
-        this.dbPath = newPath;
-        await this.initializeChunkedStorage();
-        await this.initializeDB(await EmbeddingsManager.getInstance().getEmbeddingsAPI());
-        logInfo("Database reinitialized with new path:", newPath);
-      }
+          if (this.dbPath && newPath !== this.dbPath) {
+            logInfo("Path change detected, reinitializing database...");
+            this.dbPath = newPath;
+            await this.initializeChunkedStorage();
+            await this.initializeDB(await EmbeddingsManager.getInstance().getEmbeddingsAPI());
+            logInfo("Database reinitialized with new path:", newPath);
+          }
+        } catch (error) {
+          logError("DBOperations settings change handler failed", error);
+        }
+      })();
     });
   }
 
@@ -220,7 +226,7 @@ export class DBOperations {
 
   public onunload() {
     if (this.hasUnsavedChanges) {
-      this.saveDB();
+      void this.saveDB().catch((err) => logError("saveDB on unload failed", err));
     }
   }
 

--- a/src/search/indexEventHandler.ts
+++ b/src/search/indexEventHandler.ts
@@ -1,6 +1,6 @@
 import { getChainType } from "@/aiParams";
 import { ChainType } from "@/chainFactory";
-import { logInfo } from "@/logger";
+import { logError, logInfo } from "@/logger";
 import { getSettings, subscribeToSettingsChange } from "@/settings/model";
 import { App, MarkdownView, Platform, TAbstractFile, TFile } from "obsidian";
 import type { SemanticIndexBackend } from "./indexBackend/SemanticIndexBackend";
@@ -134,7 +134,7 @@ export class IndexEventHandler {
       if (getSettings().debug) {
         console.log("Copilot Plus: Triggering reindex for file ", file.path);
       }
-      this.indexOps.reindexFile(file);
+      void this.indexOps.reindexFile(file).catch((err) => logError("reindexFile failed", err));
       this.debounceTimer = null;
     }, DEBOUNCE_DELAY);
   };

--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -30,7 +30,7 @@ export const AdvancedSettings: React.FC = () => {
     const filePath = getPromptFilePath(displayValue);
     // Close the settings modal before opening the file
     (app as any).setting.close();
-    app.workspace.openLinkText(filePath, "", true);
+    void app.workspace.openLinkText(filePath, "", true);
   };
 
   const handleAddPrompt = () => {
@@ -123,10 +123,12 @@ export const AdvancedSettings: React.FC = () => {
           <Button
             variant="secondary"
             size="sm"
-            onClick={async () => {
-              await flushRecordedPromptPayloadToLog();
-              await logFileManager.flush();
-              await logFileManager.openLogFile();
+            onClick={() => {
+              void (async () => {
+                await flushRecordedPromptPayloadToLog();
+                await logFileManager.flush();
+                await logFileManager.openLogFile();
+              })();
             }}
           >
             Create Log File

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -52,9 +52,9 @@ import { Notice } from "obsidian";
 const MobileCommandCard: React.FC<{
   command: CustomCommand;
   commands: CustomCommand[];
-  onUpdate: (newCommand: CustomCommand, prevCommandTitle: string) => void;
-  onRemove: (command: CustomCommand) => void;
-  onCopy: (command: CustomCommand) => void;
+  onUpdate: (newCommand: CustomCommand, prevCommandTitle: string) => void | Promise<void>;
+  onRemove: (command: CustomCommand) => void | Promise<void>;
+  onCopy: (command: CustomCommand) => void | Promise<void>;
   containerRef: React.RefObject<HTMLDivElement>;
 }> = ({ command, commands, onUpdate, onRemove, onCopy, containerRef }) => {
   const handleEdit = (cmd: CustomCommand) => {
@@ -168,9 +168,9 @@ const MobileCommandCard: React.FC<{
 const SortableTableRow: React.FC<{
   command: CustomCommand;
   commands: CustomCommand[];
-  onUpdate: (newCommand: CustomCommand, prevCommandTitle: string) => void;
-  onRemove: (command: CustomCommand) => void;
-  onCopy: (command: CustomCommand) => void;
+  onUpdate: (newCommand: CustomCommand, prevCommandTitle: string) => void | Promise<void>;
+  onRemove: (command: CustomCommand) => void | Promise<void>;
+  onCopy: (command: CustomCommand) => void | Promise<void>;
 }> = ({ command, commands, onUpdate, onRemove, onCopy }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: command.title,
@@ -367,7 +367,11 @@ export const CommandSettings: React.FC = () => {
   // Mobile view rendering
   const renderMobileView = () => (
     <div className="tw-relative md:tw-hidden">
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={(event) => void handleDragEnd(event)}
+      >
         <SortableContext
           items={commands.map((command) => command.title)}
           strategy={verticalListSortingStrategy}
@@ -415,7 +419,9 @@ export const CommandSettings: React.FC = () => {
           value={settings.customPromptsFolder}
           onChange={(value) => {
             updateSetting("customPromptsFolder", value);
-            loadAllCustomCommands();
+            void loadAllCustomCommands().catch((err) =>
+              logError("loadAllCustomCommands failed", err)
+            );
           }}
           placeholder="copilot/copilot-custom-prompts"
         />
@@ -495,7 +501,7 @@ export const CommandSettings: React.FC = () => {
             <DndContext
               sensors={sensors}
               collisionDetection={closestCenter}
-              onDragEnd={handleDragEnd}
+              onDragEnd={(event) => void handleDragEnd(event)}
             >
               <Table>
                 <TableHeader>

--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -213,7 +213,7 @@ export const CopilotPlusSettings: React.FC = () => {
                   </div>
                 }
                 checked={settings.enableSelfHostMode}
-                onCheckedChange={handleSelfHostModeToggle}
+                onCheckedChange={(checked) => void handleSelfHostModeToggle(checked)}
                 disabled={isValidatingSelfHost}
               />
 
@@ -232,7 +232,7 @@ export const CopilotPlusSettings: React.FC = () => {
                     title="Enable Miyo"
                     description="Use Miyo as your local search, PDF parsing, and context hub. Copilot will send the current vault folder name to Miyo and can request scans, but folder registration is managed in Miyo."
                     checked={settings.enableMiyo}
-                    onCheckedChange={handleMiyoSearchToggle}
+                    onCheckedChange={(checked) => void handleMiyoSearchToggle(checked)}
                     disabled={isValidatingSelfHost}
                   />
 

--- a/src/state/ChatUIState.ts
+++ b/src/state/ChatUIState.ts
@@ -214,8 +214,8 @@ export class ChatUIState {
   /**
    * Legacy compatibility - replace messages
    */
-  replaceMessages(messages: ChatMessage[]): void {
-    this.chatManager.loadMessages(messages);
+  async replaceMessages(messages: ChatMessage[]): Promise<void> {
+    await this.chatManager.loadMessages(messages);
     this.notifyListeners();
   }
 

--- a/src/tools/ComposerTools.ts
+++ b/src/tools/ComposerTools.ts
@@ -71,7 +71,7 @@ async function show_preview(
   return new Promise((resolve) => {
     // Open the Apply View in a new leaf with the processed content and the callback
     const leaf = app.workspace.getLeaf(true);
-    leaf.setViewState({
+    void leaf.setViewState({
       type: APPLY_VIEW_TYPE,
       active: true,
       state: {


### PR DESCRIPTION
## Summary

Third of nine workspaces splitting #2397. Makes promise handling explicit across the codebase: floating promises now use `void` / `.catch(logError)`, Promise-returning callbacks where a void return was expected are wrapped, and `ConfirmModal` accepts `() => void | Promise<void>` for `onConfirm`/`onCancel`.

**Behavior change: errors previously hidden by floating promises now log via `@/logger`. No code paths changed.**

W0 (#2398), W1 (#2403), and #2402 are already merged.

## Changes by category

### Floating promises (`void` / `.catch(logError)`)
- `void openFileInWorkspace(file)` in event handlers (`ChatContextMenu`)
- `void app.workspace.openLinkText(...)` (`ChatSettingsPopover`, `AdvancedSettings`)
- `void fetchNotes()`, `void fetchHasIndex()`, `void loadContent()`, `void leaf.openFile(file).catch(logError)` (`RelevantNotes`)
- `void loadNoteContent(...)`, `void loadNoteContentForPreview(...)` (note/at-mention plugins)
- `void CustomCommandManager.getInstance().recordUsage(...)` (slash plugin, modals, register)
- `void processValue()` (`password-input`)
- `void checkVersion().catch(logError)` (`useLatestVersion`)
- `void this.saveDB().catch(logError)` (`dbOperations.onunload`)
- `void this.indexOps.reindexFile(file).catch(logError)` (`indexEventHandler`)
- `void this.initialize().catch(logError)`, `void this.createChainWithNewModel(...).catch(logError)` (`chainManager`)
- `void chatUIState.loadMessages(...).catch(logError)` (`useChatManager`)
- `void generateDefaultCommands().catch(logError)` (`migrator`)
- `void loadAllCustomCommands().catch(logError)` (`CommandSettings`)
- `void this.chainManager.memoryManager.clearChatMemory().catch(logError)` (`ChatManager`)
- `void leaf.setViewState(...)` (`ComposerTools`)
- `.openLinkText(...).catch(logError)` (`SourcesModal`)
- `navigator.clipboard.writeText(...).then(...).catch(logError)` (`ChatSingleMessage`)
- `void MarkdownRenderer.renderMarkdown(...).then(...).catch(logError)` (`ChatSingleMessage`)

### Promise-returning callbacks where `void` was expected
- `onPause`, `onResume`, `onStop`, `onNewChat`, `onLoadHistory` JSX handlers wrapped with `() => void X()` (`Chat`)
- `onClick={() => void onSaveAsNote()}`, `onSelect={() => void X()}` (`ChatControls`, `RelevantNotes`, `YoutubeTranscriptModal`)
- `onCheckedChange={(checked) => void X(checked)}` (`CopilotPlusSettings`)
- `onDragEnd={(event) => void handleDragEnd(event)}` (`CommandSettings`)
- `handleModeChange(ChainType.X)` wrapped with `void` (`ChatControls`)
- `await handleSaveAsNote()` in async handlers (`Chat`)

### `() => void | Promise<void>` callback signature broadening
- `ConfirmModal` constructor: `onConfirm` and `onCancel` accept async functions; rejections logged via `logError`
- `SemanticSearchToggleModal` constructor: `onConfirm` accepts async
- `CustomCommandSettingsModal` constructor: `onUpdate` accepts async
- `CommandSettings`: `MobileCommandCard` / `SortableTableRow` props `onUpdate` / `onRemove` / `onCopy` accept async

### `result instanceof Promise` callback wrappers
- `addCommand` / `addEditorCommand` in `src/commands/index.ts` wrap user callbacks; if the result is a Promise, errors log via `logError`

### Other
- `ChatUIState.replaceMessages` becomes async to await `chatManager.loadMessages`
- `await this.setChain(...)` in `chainManager.createChainWithNewModel`
- `dbOperations` `subscribeToSettingsChange` switched to a `void (async () => { try {...} catch (error) { logError(...) } })()` IIFE so the async work is explicitly handled
- `AdvancedSettings` "Create Log File" button uses `onClick={() => { void (async () => { ... })(); }}`

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` passes (tsc + esbuild)
- [x] `npm test` - all 107 suites / 1962 tests pass
- [x] Smoke: send a chat message, regenerate a message, edit a message (autosave path uses `await handleSaveAsNote`)
- [x] Smoke: open the ConfirmModal flows (e.g. enable/disable semantic search) - no UX regression
- [x] Smoke: trigger a custom command - errors should log instead of vanish
- [x] Smoke: open RelevantNotes panel, click "Build Index", "Reindex Current Note"
- [x] Smoke: clipboard copy of a message + "Save chat as note" button

Plan: `/Users/zeroliu/.claude/plans/i-want-you-to-smooth-dusk.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>