### PR TITLE
docs: add commit-signing setup; consolidate README ToC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,35 @@ In the case of Copilot for Obsidian, you will need to:
 
 Try to be descriptive in your branch names and pull requests. Happy coding!
 
+## Commit Signing
+
+Commits to `master` must be signed and verified by GitHub. The easiest path is SSH signing using your existing SSH key.
+
+1. Configure git to sign with your SSH key:
+
+   ```bash
+   git config --global gpg.format ssh
+   git config --global user.signingkey ~/.ssh/id_ed25519.pub
+   git config --global commit.gpgsign true
+   ```
+
+   Replace `id_ed25519.pub` with the path to your own public key if different.
+
+2. Register the same key as a **Signing Key** on GitHub at https://github.com/settings/ssh/new. Set "Key type" to `Signing Key` (this is separate from an Authentication Key, even if it's the same key).
+
+3. Confirm your commit email matches a verified email on your GitHub account at https://github.com/settings/emails. Otherwise commits show as Unverified even when signed.
+
+4. Verify locally and on GitHub:
+
+   ```bash
+   git commit --allow-empty -m "test signing"
+   git log --show-signature -1
+   ```
+
+   After pushing, the commit on github.com should display a green **Verified** badge.
+
+If you already use GPG, set `gpg.format openpgp` instead and register the GPG public key at https://github.com/settings/gpg/new. Commits merged via the GitHub web UI are auto-signed by GitHub and don't need this setup.
+
 ## Prompt Testing
 
 If you are making prompt changes, make sure to run the integration tests using the following steps:

--- a/README.md
+++ b/README.md
@@ -53,14 +53,30 @@ This is the future we believe in. If you share this vision, please support this 
 
 ## Table of Contents
 
+- [The What](#the-what)
+- [The Why](#the-why)
+- [Key Features](#key-features)
+- [Copilot V3 is a New Era 🔥](#copilot-v3-is-a-new-era-)
+- [Why People Love It ❤️](#why-people-love-it-️)
 - [Get Started](#get-started)
   - [Install Obsidian Copilot](#install-obsidian-copilot)
   - [Set API Keys](#set-api-keys)
 - [Usage](#usage)
   - [Free User](#free-user)
+    - [**Chat Mode: reference notes and discuss ideas with Copilot**](#chat-mode-reference-notes-and-discuss-ideas-with-copilot)
+    - [**Vault QA Mode: chat with your entire vault**](#vault-qa-mode-chat-with-your-entire-vault)
+    - [Copilot's Command Palette](#copilots-command-palette)
+    - [**Relevant Notes: notes suggestions based on semantic similarity and links**](#relevant-notes-notes-suggestions-based-on-semantic-similarity-and-links)
   - [Copilot Plus/Believer](#copilot-plusbeliever)
-- [Need Help?](#need-help)
-- [FAQ](#faq)
+    - [**Get Precision Insights From a Specific Time Window**](#get-precision-insights-from-a-specific-time-window)
+    - [**Agent Mode: Autonomous Tool Calling**](#agent-mode-autonomous-tool-calling)
+    - [**Understand Images in Your Notes**](#understand-images-in-your-notes)
+    - [**One Prompt, Every Source—Instant Summaries from PDFs, Videos, and Web**](#one-prompt-every-sourceinstant-summaries-from-pdfs-videos-and-web)
+- [**Need Help?**](#need-help)
+- [**FAQ**](#faq)
+- [**🙏 Thank You**](#-thank-you)
+- [**Copilot Plus Disclosure**](#copilot-plus-disclosure)
+- [**Authors**](#authors)
 
 ## Copilot V3 is a New Era 🔥
 
@@ -100,35 +116,6 @@ Read the [Changelog](https://github.com/logancyang/obsidian-copilot/releases/tag
 2. Go to **Obsidian → Settings → Copilot → Basic** and paste the key into in the **Copilot Plus** card.
 
 ## Usage
-
-### Table of Contents
-
-- [The What](#the-what)
-- [The Why](#the-why)
-- [Key Features](#key-features)
-- [Table of Contents](#table-of-contents)
-- [Copilot V3 is a New Era 🔥](#copilot-v3-is-a-new-era-)
-- [Why People Love It ❤️](#why-people-love-it-️)
-- [Get Started](#get-started)
-  - [Install Obsidian Copilot](#install-obsidian-copilot)
-  - [Set API Keys](#set-api-keys)
-- [Usage](#usage)
-  - [Table of Contents](#table-of-contents-1)
-  - [Free User](#free-user)
-    - [**Chat Mode: reference notes and discuss ideas with Copilot**](#chat-mode-reference-notes-and-discuss-ideas-with-copilot)
-    - [**Vault QA Mode: chat with your entire vault**](#vault-qa-mode-chat-with-your-entire-vault)
-    - [Copilot's Command Palette](#copilots-command-palette)
-    - [**Relevant Notes: notes suggestions based on semantic similarity and links**](#relevant-notes-notes-suggestions-based-on-semantic-similarity-and-links)
-  - [Copilot Plus/Believer](#copilot-plusbeliever)
-    - [**Get Precision Insights From a Specific Time Window**](#get-precision-insights-from-a-specific-time-window)
-    - [**Agent Mode: Autonomous Tool Calling**](#agent-mode-autonomous-tool-calling)
-    - [**Understand Images in Your Notes**](#understand-images-in-your-notes)
-    - [**One Prompt, Every Source—Instant Summaries from PDFs, Videos, and Web**](#one-prompt-every-sourceinstant-summaries-from-pdfs-videos-and-web)
-- [**Need Help?**](#need-help)
-- [**FAQ**](#faq)
-- [**🙏 Thank You**](#-thank-you)
-- [**Copilot Plus Disclosure**](#copilot-plus-disclosure)
-- [**Authors**](#authors)
 
 ### Free User
 


### PR DESCRIPTION
## Summary

- **CONTRIBUTING.md**: new "Commit Signing" section walking through the 4-step SSH signing setup (`gpg.format ssh`, register key as Signing Key on GitHub, verify commit email, verify locally). Lands ahead of any future ruleset that flips on "Require signed commits" so the team has documented instructions in place.
- **README.md**: removed the abbreviated ToC stub and promoted the comprehensive ToC out from under `## Usage` to the top-level slot. Also dropped the self-referencing `[Table of Contents]` entry. One ToC instead of two, in the conventional spot.

## Test plan

- [x] `npm run format` clean
- [x] `npm run lint` clean
- [x] `npm test` (107 suites / 1962 tests) pass
- [ ] Render README on GitHub, confirm ToC anchors all resolve
- [ ] Skim CONTRIBUTING.md rendered view to confirm code blocks and links render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)