### PR TITLE
chore(lint): enable obsidianmd/vault/iterate and fix violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,7 +73,7 @@ export default [
       "tailwindcss/no-contradicting-classname": "error",
 
       // obsidianmd: defer to follow-up PRs
-      "obsidianmd/vault/iterate": "off",
+      "obsidianmd/vault/iterate": "error",
       "obsidianmd/prefer-active-doc": "off",
       "obsidianmd/object-assign": "off",
       "obsidianmd/ui/sentence-case": "off",

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -609,8 +609,8 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
       const extensionPatterns = Object.keys(list.extensions);
       const notePatterns = list.notes
         .map((note) => {
-          const file = appFiles.find((file) => file.path === note.id);
-          if (file) {
+          const file = app.vault.getAbstractFileByPath(note.id);
+          if (file instanceof TFile) {
             return getFilePattern(file);
           }
         })
@@ -623,7 +623,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
         notePatterns,
       });
     },
-    []
+    [app.vault]
   );
 
   // ignore file items convert to exclusions format
@@ -707,8 +707,8 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
       const parsedQuery = parseSearchQuery(searchTerm);
       return allItems
         .filter((item) => {
-          const fileObj = appAllFiles.find((f) => f.path === item.id);
-          if (!fileObj) return false;
+          const fileObj = app.vault.getAbstractFileByPath(item.id);
+          if (!(fileObj instanceof TFile)) return false;
 
           const isNote = fileObj.extension === "md";
 
@@ -844,7 +844,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
     activeItem,
     parseSearchQuery,
     allItems,
-    appAllFiles,
+    app.vault,
     groupList.tags,
     groupList.folders,
     groupList.notes,
@@ -1102,8 +1102,8 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
   const handleDeleteItem = (e: React.MouseEvent, item: GroupItem) => {
     e.stopPropagation();
 
-    const file = appAllFiles.find((file) => file.path === item.id);
-    if (file) {
+    const file = app.vault.getAbstractFileByPath(item.id);
+    if (file instanceof TFile) {
       // add file to ignore
       setIgnoreItems((prev) => {
         const newFiles = new Set(prev.files);
@@ -1137,9 +1137,9 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
   const handleDeleteIgnoreItem = (e: React.MouseEvent, item: GroupItem) => {
     e.stopPropagation();
 
-    const file = appAllFiles.find((file) => file.path === item.id);
+    const file = app.vault.getAbstractFileByPath(item.id);
 
-    if (file) {
+    if (file instanceof TFile) {
       setIgnoreItems((prev) => {
         const newFiles = new Set(prev.files);
         newFiles.delete(file);


### PR DESCRIPTION
## Summary
- Flips `obsidianmd/vault/iterate` from `off` → `error` in `eslint.config.mjs` (one of the deferred rules from #2410).
- Fixes 4 violations in `context-manage-modal.tsx` by swapping `appAllFiles.find(f => f.path === id)` for `app.vault.getAbstractFileByPath(id)` + `instanceof TFile` narrowing — a direct hash lookup instead of a full-vault scan.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [ ] Open the Project Context Manage modal in Obsidian: search/filter notes, delete a note from a group, restore from ignore list, save the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)