### PR TITLE
chore(lint): enable obsidianmd/no-unsupported-api

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -77,7 +77,6 @@ export default [
       "obsidianmd/prefer-active-doc": "error",
       "obsidianmd/object-assign": "off",
       "obsidianmd/ui/sentence-case": "off",
-      "obsidianmd/no-unsupported-api": "off",
 
       // obsidianmd: disabled intentionally — Platform.isMacOS branching is on-purpose
       "obsidianmd/platform": "off",


### PR DESCRIPTION
## Summary
- Removes the deferred `"off"` override for `obsidianmd/no-unsupported-api` so it runs at the severity from `obsidianmd.configs.recommended` (error) on `.ts`/`.tsx`.
- The rule reads `manifest.json`'s `minAppVersion` (1.4.0) and flags Obsidian APIs whose `@since` tag is newer. With our pinned `obsidian@1.2.5` devDep (no `@since` tags), it fires on nothing today — it acts as a guard that activates the next time someone bumps the obsidian type-stubs.
- Kept off in the non-TS override block since the rule requires `@typescript-eslint` parser services.

## Test plan
- [x] `npm run lint` passes
- [x] Sanity-probed with `--rule '{"obsidianmd/no-unsupported-api":["error",{"minAppVersion":"0.0.1"}]}'` — confirms rule is wired up (no fires expected at obsidian@1.2.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)