### PR TITLE
chore(lint): enable no-unsanitized/method and no-unsanitized/property

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,8 +109,6 @@ export default [
       "@typescript-eslint/no-deprecated": "off",
 
       // SDL / import / no-unsanitized / depend: defer — review separately
-      "no-unsanitized/method": "off",
-      "no-unsanitized/property": "off",
       "import/no-nodejs-modules": "off",
       "import/no-extraneous-dependencies": "off",
       "no-restricted-imports": "off",

--- a/scripts/printPromptDebug.js
+++ b/scripts/printPromptDebug.js
@@ -46,6 +46,7 @@ async function main() {
   });
 
   try {
+    // eslint-disable-next-line no-unsanitized/method -- outfile is a controlled path under os.tmpdir(), produced by the esbuild step above.
     const module = await import(url.pathToFileURL(outfile).href);
     await module.run(process.argv.slice(2));
   } finally {


### PR DESCRIPTION
## Summary

- Drop the explicit \`"off"\` overrides for \`no-unsanitized/method\` and \`no-unsanitized/property\` in \`eslint.config.mjs\` so the rules from \`obsidianmd.configs.recommended\` apply as errors.
- Add a scoped \`eslint-disable-next-line\` to \`scripts/printPromptDebug.js\` — the dynamic \`import()\` there targets a controlled path under \`os.tmpdir()\` produced by the esbuild step immediately above it.

## Test plan

- [ ] \`npm run lint\` passes
- [ ] \`npm run format:check\` passes
- [ ] Sanity-check: temporarily add \`el.innerHTML = userInput\` in a scratch \`.ts\` file → lint fails with \`no-unsanitized/property\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)