### PR TITLE
chore(lint): enable @microsoft/sdl/no-inner-html and fix violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -100,7 +100,6 @@ export default [
       "@typescript-eslint/no-deprecated": "off",
 
       // SDL / import / no-unsanitized / depend: defer — review separately
-      "@microsoft/sdl/no-inner-html": "off",
       "no-unsanitized/method": "off",
       "no-unsanitized/property": "off",
       "import/no-nodejs-modules": "off",

--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -125,7 +125,7 @@ describe("think block rendering — closing tags are not consumed by indented co
     const capturedMarkdown: string[] = [];
     renderMarkdownMock.mockImplementation(async (md: string, el: HTMLElement) => {
       capturedMarkdown.push(md);
-      el.innerHTML = "<p>rendered</p>";
+      el.textContent = "rendered";
     });
 
     render(
@@ -151,7 +151,7 @@ describe("think block rendering — closing tags are not consumed by indented co
     const capturedMarkdown: string[] = [];
     renderMarkdownMock.mockImplementation(async (md: string, el: HTMLElement) => {
       capturedMarkdown.push(md);
-      el.innerHTML = "<p>rendered</p>";
+      el.textContent = "rendered";
     });
 
     render(
@@ -177,7 +177,7 @@ describe("think block rendering — closing tags are not consumed by indented co
     const capturedMarkdown: string[] = [];
     renderMarkdownMock.mockImplementation(async (md: string, el: HTMLElement) => {
       capturedMarkdown.push(md);
-      el.innerHTML = "<p>rendered</p>";
+      el.textContent = "rendered";
     });
 
     render(
@@ -205,7 +205,9 @@ describe("normalizeFootnoteRendering", () => {
 
   it("removes separator and backref while preserving non-footnote elements", () => {
     const container = window.document.createElement("div");
-    container.innerHTML = `
+    container.append(
+      ...new DOMParser().parseFromString(
+        `
       <div>
         <p>Body <sup><a href="#fn-1">1-1</a></sup></p>
         <hr class="content-separator" />
@@ -218,7 +220,10 @@ describe("normalizeFootnoteRendering", () => {
           </ol>
         </div>
       </div>
-    `;
+    `,
+        "text/html"
+      ).body.children
+    );
 
     normalizeFootnoteRendering(container);
 
@@ -230,10 +235,15 @@ describe("normalizeFootnoteRendering", () => {
 
   it("leaves non-numeric footnote references untouched", () => {
     const container = window.document.createElement("div");
-    container.innerHTML = `
+    container.append(
+      ...new DOMParser().parseFromString(
+        `
       <p>Body <sup><a href="#fn-note">Note-A</a></sup></p>
       <a class="footnote-backref" href="#ref">↩</a>
-    `;
+    `,
+        "text/html"
+      ).body.children
+    );
 
     normalizeFootnoteRendering(container);
 
@@ -274,7 +284,9 @@ describe("ChatSingleMessage", () => {
 
   it("normalizes rendered footnotes for assistant messages", async () => {
     renderMarkdownMock.mockImplementation(async (_markdown: string, el: HTMLElement) => {
-      el.innerHTML = `
+      el.append(
+        ...new DOMParser().parseFromString(
+          `
         <p>Example <sup><a href="#fn-2">2-1</a></sup></p>
         <hr class="content-hr" />
         <div class="footnotes">
@@ -285,7 +297,10 @@ describe("ChatSingleMessage", () => {
             </li>
           </ol>
         </div>
-      `;
+      `,
+          "text/html"
+        ).body.children
+      );
     });
 
     const { container } = render(

--- a/src/components/command-ui/markdown-preview.tsx
+++ b/src/components/command-ui/markdown-preview.tsx
@@ -27,7 +27,7 @@ export function MarkdownPreview({ content, renderMarkdown, className }: Markdown
     // Reason: Use the target's doc for popout-window safety in Obsidian
     const scratchEl = targetEl.doc.createElement("div");
 
-    targetEl.innerHTML = "";
+    targetEl.replaceChildren();
     renderMarkdown(content, scratchEl)
       .then(() => {
         if (currentGen !== renderGenRef.current) return;


### PR DESCRIPTION
## Summary

- Drops the `"@microsoft/sdl/no-inner-html": "off"` override in `eslint.config.mjs`; the rule (already set to `error` by obsidianmd's recommended config) is now enforced everywhere.
- Fixes the one production violation in `src/components/command-ui/markdown-preview.tsx` by clearing via `replaceChildren()` instead of `innerHTML = ""` — matches the safe DOM API already used 4 lines below.
- Rewrites the 6 test violations in `ChatSingleMessage.test.tsx`: mock `renderMarkdown` impls now use `textContent` (tests only assert on captured markdown input), and the 3 fixture blocks use `DOMParser` so the rule stays on for tests too.

## Test plan

- [x] `npm run lint` passes (rule active across production and tests)
- [x] `npm test -- ChatSingleMessage` — all 6 tests pass
- [x] `npm run format` clean
- [x] Probe confirmed the rule fires on a new production `innerHTML` assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)