### PR TITLE
chore(eslint): enable no-restricted-imports; moment → luxon

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -109,7 +109,6 @@ export default [
       "@typescript-eslint/no-deprecated": "off",
 
       // SDL / import / no-unsanitized / depend: defer — review separately
-      "no-restricted-imports": "off",
       "no-restricted-globals": "off",
     },
   },
@@ -125,6 +124,15 @@ export default [
     },
     rules: {
       "import/no-nodejs-modules": "off",
+    },
+  },
+
+  // Integration tests bootstrap jsdom fetch via `node-fetch` polyfill —
+  // allow the otherwise-banned import here only.
+  {
+    files: ["src/integration_tests/**"],
+    rules: {
+      "no-restricted-imports": "off",
     },
   },
 


### PR DESCRIPTION
## Summary

- Removes `"no-restricted-imports": "off"` from `eslint.config.mjs` so the obsidianmd-recommended rule activates (bans `axios`, `node-fetch`, `moment`, etc.). Continues the incremental rule-enablement series (#2410, #2412, #2411).
- Replaces the two `moment(...)` call sites in `src/utils.ts` (`formatDateTime`, `stringToFormattedDateTime`) with `luxon`'s `DateTime` — luxon is already a dep and used in `src/tools/TimeTools.ts`. Adds 7 unit tests covering local/UTC formatting, zero-padding, immutability, valid round-trip, and the invalid-input fallback path.
- Adds a per-file ESLint override for `src/integration_tests/**` so the existing `node-fetch` jsdom polyfill stays allowed. `no-restricted-globals` stays disabled in this PR — banning the global `app` requires refactoring ~248 call sites and will land separately.

## Test plan

- [x] `npm run lint` (clean)
- [x] `npm run format:check` (clean)
- [x] `npm test` — 1969/1969 pass
- [x] `npm run build` — `tsc -noEmit` + esbuild succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)