### PR TITLE
chore(eslint): enable @typescript-eslint/await-thenable and fix violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,7 +98,6 @@ export default [
       "@typescript-eslint/no-misused-promises": "off", // 46 violations
       "@typescript-eslint/no-unnecessary-type-assertion": "off", // 40 violations
       "@typescript-eslint/no-floating-promises": "off", // 39 violations
-      "@typescript-eslint/await-thenable": "off", // 20 violations
 
       // --- Quick wins: small enough to fix and enable in a single PR ---
       "@typescript-eslint/no-unsafe-enum-comparison": "off", // 11 violations

--- a/src/main.ts
+++ b/src/main.ts
@@ -319,7 +319,7 @@ export default class CopilotPlugin extends Plugin {
     eventSubtype?: string,
     checkSelectedText = true
   ) {
-    const selectedText = await editor.getSelection();
+    const selectedText = editor.getSelection();
 
     const isChatWindowActive = this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE).length > 0;
 

--- a/src/system-prompts/systemPromptRegister.test.ts
+++ b/src/system-prompts/systemPromptRegister.test.ts
@@ -69,7 +69,7 @@ describe("SystemPromptRegister", () => {
   let mockVault: Vault;
   let register: SystemPromptRegister;
 
-  let vaultEventHandlers: Record<string, (...args: any[]) => void>;
+  let vaultEventHandlers: Record<string, (...args: any[]) => unknown>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -79,7 +79,7 @@ describe("SystemPromptRegister", () => {
 
     mockPlugin = {} as Plugin;
     mockVault = {
-      on: jest.fn((event: string, handler: (...args: any[]) => void) => {
+      on: jest.fn((event: string, handler: (...args: any[]) => unknown) => {
         vaultEventHandlers[event] = handler;
       }),
       off: jest.fn(),

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -151,7 +151,7 @@ describe("Vault", () => {
 describe("getNotesFromPath", () => {
   it("should return all markdown files", async () => {
     const vault = new Obsidian.Vault();
-    const files = await getNotesFromPath(vault, "/");
+    const files = getNotesFromPath(vault, "/");
     expect(files.map((f) => f.path)).toEqual([
       "test/test2/note1.md",
       "test/note2.md",
@@ -169,31 +169,31 @@ describe("getNotesFromPath", () => {
 
   it("should return filtered markdown files 1", async () => {
     const vault = new Obsidian.Vault();
-    const files = await getNotesFromPath(vault, "test2");
+    const files = getNotesFromPath(vault, "test2");
     expect(files.map((f) => f.path)).toEqual(["test/test2/note1.md", "test2/note3.md"]);
   });
 
   it("should return filtered markdown files 2", async () => {
     const vault = new Obsidian.Vault();
-    const files = await getNotesFromPath(vault, "test");
+    const files = getNotesFromPath(vault, "test");
     expect(files.map((f) => f.path)).toEqual(["test/test2/note1.md", "test/note2.md"]);
   });
 
   it("should return filtered markdown files 3", async () => {
     const vault = new Obsidian.Vault();
-    const files = await getNotesFromPath(vault, "note4.md");
+    const files = getNotesFromPath(vault, "note4.md");
     expect(files.map((f) => f.path)).toEqual(["note4.md"]);
   });
 
   it("should return filtered markdown files 4", async () => {
     const vault = new Obsidian.Vault();
-    const files = await getNotesFromPath(vault, "/test");
+    const files = getNotesFromPath(vault, "/test");
     expect(files.map((f) => f.path)).toEqual(["test/test2/note1.md", "test/note2.md"]);
   });
 
   it("should not return markdown files", async () => {
     const vault = new Obsidian.Vault();
-    const files = await getNotesFromPath(vault, "");
+    const files = getNotesFromPath(vault, "");
     expect(files).toEqual([]);
   });
 
@@ -209,7 +209,7 @@ describe("getNotesFromPath", () => {
         { path: "folder/other/note.md" },
       ]);
 
-    const files = await getNotesFromPath(vault, "folder/subfolder 1/eng");
+    const files = getNotesFromPath(vault, "folder/subfolder 1/eng");
     expect(files).toEqual([
       { path: "folder/subfolder 1/eng/1.md" },
       { path: "folder/subfolder 1/eng/2.md" },
@@ -289,7 +289,7 @@ describe("getNotesFromTags", () => {
     const tags = ["#tag1"];
     const expectedPaths = ["test/test2/note1.md", "note4.md"];
 
-    const result = await getNotesFromTags(mockVault, tags);
+    const result = getNotesFromTags(mockVault, tags);
     const resultPaths = result.map((fileWithTags) => fileWithTags.path);
 
     expect(resultPaths).toEqual(expect.arrayContaining(expectedPaths));
@@ -301,7 +301,7 @@ describe("getNotesFromTags", () => {
     const tags = ["#nonexistentTag"];
     const expected: string[] = [];
 
-    const result = await getNotesFromTags(mockVault, tags);
+    const result = getNotesFromTags(mockVault, tags);
 
     expect(result).toEqual(expected);
   });
@@ -311,7 +311,7 @@ describe("getNotesFromTags", () => {
     const tags = ["#tag2", "#tag4"];
     const expectedPaths = ["test/test2/note1.md", "test/note2.md", "note4.md"];
 
-    const result = await getNotesFromTags(mockVault, tags);
+    const result = getNotesFromTags(mockVault, tags);
     const resultPaths = result.map((fileWithTags) => fileWithTags.path);
 
     expect(resultPaths).toEqual(expect.arrayContaining(expectedPaths));
@@ -327,7 +327,7 @@ describe("getNotesFromTags", () => {
     ];
     const expectedPaths = ["test/test2/note1.md"];
 
-    const result = await getNotesFromTags(mockVault, tags, noteFiles);
+    const result = getNotesFromTags(mockVault, tags, noteFiles);
     const resultPaths = result.map((fileWithTags) => fileWithTags.path);
 
     expect(resultPaths).toEqual(expect.arrayContaining(expectedPaths));
@@ -338,7 +338,7 @@ describe("getNotesFromTags", () => {
     const mockVault = new Obsidian.Vault();
 
     const tags = ["#inlineTag1"];
-    const result = await getNotesFromTags(mockVault, tags);
+    const result = getNotesFromTags(mockVault, tags);
 
     expect(result).toEqual([]); // Should return empty since inline tags are ignored
   });


### PR DESCRIPTION
## Summary
- Enables `@typescript-eslint/await-thenable` (was disabled with 20 noted violations) by removing the override in `eslint.config.mjs` so the rule is enforced via `recommendedTypeChecked`.
- Fixes the 20 violations: drops a stray `await` on synchronous `editor.getSelection()` in `src/main.ts`, removes `await` from 12 synchronous `getNotesFromPath` / `getNotesFromTags` calls in `src/utils.test.ts`, and widens the captured vault-event handler type in `src/system-prompts/systemPromptRegister.test.ts` from `() => void` to `() => unknown` so the intentionally-async handlers' Promise return is preserved.

## Test plan
- [x] \`npm run lint\` passes
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test -- --testPathPattern='(utils|systemPromptRegister)'\` — 801 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)