### PR TITLE
fix(manifest): restore stable version to 3.2.8, split beta into manifest-beta.json

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "copilot",
   "name": "Copilot",
-  "version": "3.2.8",
+  "version": "3.2.9-beta.0",
   "minAppVersion": "1.7.2",
   "isDesktopOnly": false,
   "description": "Your AI Copilot: Chat with Your Second Brain, Learn Faster, Work Smarter.",


### PR DESCRIPTION
## 🚨 URGENT — please merge immediately

Master's `manifest.json` is currently advertising `version: "3.2.9-beta.0"` to Obsidian's community plugin store. The store reads `manifest.json` from master to decide which GitHub Release to serve to new installers and updaters. With:
- master saying "version is 3.2.9-beta.0"
- the latest non-prerelease GitHub Release being `3.2.8`
- the `3.2.9-beta.0` release marked as prerelease

new installs and auto-updates are broken right now.

## What this PR does

- **`manifest.json`** version reverted to `3.2.8` (the actual latest stable release on GitHub).
  - `minAppVersion: 1.7.2` and `isDesktopOnly: false` are preserved (those land independently of the version field).
- **`manifest-beta.json`** added at the repo root, containing the prerelease manifest (`3.2.9-beta.0` with the same minAppVersion / isDesktopOnly). BRAT and similar beta-installer tools read `manifest-beta.json` instead of `manifest.json` to locate prereleases, so testers retain access via BRAT.

`package.json` and `versions.json` are intentionally left unchanged:
- `package.json` stays at `3.2.9-beta.0` so the next `npm version prerelease --preid=beta` correctly produces `3.2.9-beta.1`.
- `versions.json["3.2.9-beta.0"]: "1.7.2"` is correct and records the prerelease.

## Root cause

The new prerelease agent runs `npm version prepatch --preid=beta`, which via `version-bump.mjs` unconditionally rewrites `manifest.json` with the new version. The script was written for stable releases (where rewriting is correct) and isn't aware of the manifest.json / manifest-beta.json split that Obsidian expects for prereleases.

A follow-up PR will:
- Update `version-bump.mjs` to write to `manifest-beta.json` when the new version is a prerelease, and only update `manifest.json` when it's stable.
- Update the prerelease agent doc to reflect the manifest-beta.json convention.
- Add a pre-flight assertion that master's `manifest.json.version` matches the latest stable GitHub Release tag, so any future drift fails loud.

## Test plan

- [x] `manifest.json` reads `version: 3.2.8` matching the latest stable release.
- [x] `manifest-beta.json` exists at root with valid JSON and version `3.2.9-beta.0`.
- [ ] After merge, confirm a fresh install of Copilot via Obsidian's plugin browser pulls 3.2.8 successfully.
- [ ] Confirm BRAT can still find `3.2.9-beta.0` via `manifest-beta.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)