### PR TITLE
chore(release): make prerelease tooling stop poisoning master's manifest.json

### DIFF
--- a/.claude/agents/prerelease.md
+++ b/.claude/agents/prerelease.md
@@ -10,9 +10,10 @@ You are a prerelease manager for the Copilot for Obsidian plugin. Your job is to
 ## How Prereleases Differ from Stable Releases
 
 - The PR title is a prerelease semver: `X.Y.Z-<tag>.<N>`, e.g. `3.2.9-beta.1`, `3.3.0-rc.0`, `4.0.0-alpha.2`.
-- The release workflow (`.github/workflows/release.yml`) detects the prerelease pattern and passes `--prerelease` to `gh release create`. The GitHub Release is then marked as "prerelease" and Obsidian's plugin browser will not offer it as an automatic update.
-- `versions.json` is still updated by `version-bump.mjs` for the prerelease version. This is intentional: testers who manually install the prerelease via the Obsidian community-plugin sideloading flow or a developer-mode setup get the right `minAppVersion` mapping.
-- The actual release artifact (`main.js`, `manifest.json`, `styles.css`) is built and uploaded the same way as a stable release.
+- The release workflow (`.github/workflows/release.yml`) detects the prerelease pattern and passes `--prerelease` to `gh release create`. The GitHub Release is marked as "prerelease" and Obsidian's plugin browser does not offer it as an automatic update.
+- **Master's `manifest.json` is NEVER modified by a prerelease.** Obsidian's community plugin store reads `manifest.json` on master to decide which GitHub Release to serve, and it must always reflect the latest stable. The prerelease manifest lives in `manifest-beta.json` instead. `version-bump.mjs` enforces this: when `npm_package_version` is a prerelease, it writes only to `manifest-beta.json` and `versions.json`.
+- `package.json` is updated by npm itself with the prerelease version. That's the source of truth the agent reads to know the current version.
+- The release workflow swaps `manifest-beta.json` into `manifest.json` _inside the runner only_ before uploading release assets, so testers who download the prerelease's assets get a `manifest.json` carrying the prerelease version. The committed `manifest.json` on master stays pinned to the latest stable.
 
 ## Step-by-Step Process
 
@@ -48,11 +49,41 @@ Before doing any version bumping, validate the repo is releasable. Stop and surf
 
    If `main.js` is over 5 MB, surface the size to the user. Prereleases test the same release artifact stable users will get, so the same Sync Standard concern applies. Ask whether to ship the prerelease anyway or hold.
 
-4. **Verify `manifest.json` integrity.**
+4. **Verify manifest integrity (both files).**
 
-   Same checks as the stable release agent: confirm `isDesktopOnly` and `minAppVersion` reflect actual code dependencies. A prerelease intended for testing must accurately advertise its own requirements.
+   For the stable manifest:
 
-5. **Confirm there are merged PRs to prerelease.**
+   ```bash
+   node -p "JSON.stringify(require('./manifest.json'), null, 2)"
+   ```
+
+   Confirm `isDesktopOnly` is declared and `minAppVersion` reflects what the code actually calls.
+
+   If `manifest-beta.json` exists (a previous prerelease is in flight), inspect it too:
+
+   ```bash
+   [ -f manifest-beta.json ] && node -p "JSON.stringify(require('./manifest-beta.json'), null, 2)"
+   ```
+
+   `manifest-beta.json`'s `minAppVersion` and other metadata must match `manifest.json`'s (we don't test different minimums in the prerelease channel).
+
+5. **Assert master's `manifest.json.version` matches the latest stable GitHub Release.**
+
+   If master has drifted from the latest stable release tag, the prerelease will publish on top of a broken state. Catch the drift before doing anything else:
+
+   ```bash
+   LATEST_STABLE=$(gh release list --repo logancyang/obsidian-copilot --json tagName,isPrerelease \
+     -q '[.[] | select(.isPrerelease == false) | .tagName] | .[0]')
+   MASTER_VERSION=$(node -p "require('./manifest.json').version")
+   if [ "$LATEST_STABLE" != "$MASTER_VERSION" ]; then
+     echo "DRIFT: master manifest.json.version='$MASTER_VERSION' but latest stable Release='$LATEST_STABLE'. Stop." >&2
+     exit 1
+   fi
+   ```
+
+   Stop and tell the user if this fails. Do not "fix" master's manifest.json inside a prerelease PR.
+
+6. **Confirm there are merged PRs to prerelease.**
 
    ```bash
    git describe --tags --abbrev=0
@@ -61,7 +92,7 @@ Before doing any version bumping, validate the repo is releasable. Stop and surf
 
    If empty, there is nothing new to test. Stop and tell the user.
 
-Only proceed once all five checks pass.
+Only proceed once all six checks pass.
 
 ### Step 1: Determine Prerelease Identity
 
@@ -109,7 +140,7 @@ Examples:
 - `3.2.9-beta.0` + `npm version prerelease --preid=beta --no-git-tag-version` → `3.2.9-beta.1`
 - `3.2.9-beta.5` + `npm version prerelease --preid=rc --no-git-tag-version` → `3.2.9-rc.0`
 
-`version-bump.mjs` will update `manifest.json` and `versions.json` to match. After bumping, read the new version from `package.json` to use in subsequent steps.
+`version-bump.mjs` will update `manifest-beta.json` (creating it if it doesn't already exist by seeding from `manifest.json`) and `versions.json` to match. **It does NOT modify `manifest.json`.** After bumping, read the new version from `package.json` to use in subsequent steps.
 
 ### Step 4: Gather and Understand Merged PRs
 
@@ -175,11 +206,13 @@ When the corresponding stable release ships, that release's notes are appended a
 
 ### Step 7: Commit and Create PR
 
-Stage all changed files:
+Stage all changed files. Note that `manifest-beta.json` is what gets touched for prereleases, NOT `manifest.json`:
 
 ```bash
-git add package.json package-lock.json manifest.json versions.json RELEASES.md
+git add package.json package-lock.json manifest-beta.json versions.json RELEASES.md
 ```
+
+If `git status` shows `manifest.json` modified, something went wrong. `version-bump.mjs` should never touch `manifest.json` during a prerelease bump. Stop and tell the user.
 
 Commit with message: `prerelease: vX.Y.Z-<tag>.<N>`
 
@@ -219,4 +252,5 @@ Share the PR URL with the user and summarize:
 - **Be honest about what is unverified.** Prereleases exist to surface bugs, not to oversell stability. If you would not bet your reputation on a feature, say so in the notes.
 - **Stop on any pre-flight failure.** Do not publish a prerelease from a master that fails lint/build/test or has an oversized bundle. Report and ask, do not paper over.
 - **Do not silently change `manifest.minAppVersion` or `manifest.isDesktopOnly`** in a prerelease PR. Same rule as stable releases: those changes belong in dedicated PRs.
-- If `npm version` fails or `version-bump.mjs` doesn't run, manually update `manifest.json` and `versions.json` to match the prerelease semver.
+- **Never modify master's `manifest.json` from a prerelease.** It must always reflect the latest stable release. Obsidian's plugin store relies on this. Prerelease metadata goes into `manifest-beta.json` only.
+- If `npm version` fails or `version-bump.mjs` doesn't run, manually update `manifest-beta.json` and `versions.json` to match the prerelease semver. Do NOT touch `manifest.json`.

--- a/.claude/agents/prerelease.md
+++ b/.claude/agents/prerelease.md
@@ -72,8 +72,10 @@ Before doing any version bumping, validate the repo is releasable. Stop and surf
    If master has drifted from the latest stable release tag, the prerelease will publish on top of a broken state. Catch the drift before doing anything else:
 
    ```bash
-   LATEST_STABLE=$(gh release list --repo logancyang/obsidian-copilot --json tagName,isPrerelease \
-     -q '[.[] | select(.isPrerelease == false) | .tagName] | .[0]')
+   # Use /releases/latest which returns only the most-recent non-prerelease,
+   # non-draft release in a single call — works regardless of how many
+   # prereleases have accumulated since the last stable.
+   LATEST_STABLE=$(gh api repos/logancyang/obsidian-copilot/releases/latest -q .tag_name)
    MASTER_VERSION=$(node -p "require('./manifest.json').version")
    if [ "$LATEST_STABLE" != "$MASTER_VERSION" ]; then
      echo "DRIFT: master manifest.json.version='$MASTER_VERSION' but latest stable Release='$LATEST_STABLE'. Stop." >&2

--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -62,7 +62,23 @@ Before doing any version bumping, validate the repo is releasable. Stop and surf
    - `isDesktopOnly` is declared (currently `false`; do not silently change this).
    - `minAppVersion` matches the Obsidian APIs the code actually uses. If a commit since the last release introduced a call that needs a newer minimum, the `minAppVersion` bump belongs in its own dedicated PR with its own review window, not bundled inside this release PR. Stop and tell the user.
 
-5. **Confirm there are merged PRs to release.**
+5. **Assert that `manifest.json.version` matches the latest stable GitHub Release.**
+
+   Obsidian's community plugin store reads `manifest.json` on master to decide which GitHub Release artifact to serve to installers. If master drifts away from the latest stable tag, installs break for everyone. Catch the drift loudly before doing anything else:
+
+   ```bash
+   LATEST_STABLE=$(gh release list --repo logancyang/obsidian-copilot --json tagName,isPrerelease \
+     -q '[.[] | select(.isPrerelease == false) | .tagName] | .[0]')
+   MASTER_VERSION=$(node -p "require('./manifest.json').version")
+   if [ "$LATEST_STABLE" != "$MASTER_VERSION" ]; then
+     echo "DRIFT: master manifest.json.version='$MASTER_VERSION' but latest stable Release='$LATEST_STABLE'. Stop." >&2
+     exit 1
+   fi
+   ```
+
+   Stop and tell the user if this fails. Do not "fix" the drift by bumping `manifest.json` inside a release PR — that needs its own dedicated PR.
+
+6. **Confirm there are merged PRs to release.**
 
    ```bash
    git describe --tags --abbrev=0
@@ -71,7 +87,7 @@ Before doing any version bumping, validate the repo is releasable. Stop and surf
 
    If the diff is empty, there is nothing to release. Stop and tell the user.
 
-Only proceed to Step 1 once all five checks pass.
+Only proceed to Step 1 once all six checks pass.
 
 ### Step 1: Determine Release Type
 
@@ -221,3 +237,4 @@ Share the PR URL with the user and summarize what was included in the release.
 - **Do not silently change `manifest.minAppVersion` or `manifest.isDesktopOnly`** in a release PR. Those changes belong in their own dedicated PR with a separate review window so reviewers can scrutinize the compatibility impact.
 - **Surface bundle-size growth in the release notes** if `main.js` grew significantly since the last release. Users notice, and reviewers do too.
 - **Stop on any pre-flight failure.** Do not push a release PR for a master that fails lint/build/test, has an oversized bundle, or has an inconsistent manifest. Report and ask, do not paper over.
+- **Stable releases delete `manifest-beta.json` automatically.** `version-bump.mjs` `git rm`s it when bumping to a stable version, on the rationale that the new stable supersedes any in-flight prerelease. This happens in the version-bump commit; nothing extra to do, but be aware that the diff will show the deletion.

--- a/.claude/agents/release.md
+++ b/.claude/agents/release.md
@@ -67,8 +67,10 @@ Before doing any version bumping, validate the repo is releasable. Stop and surf
    Obsidian's community plugin store reads `manifest.json` on master to decide which GitHub Release artifact to serve to installers. If master drifts away from the latest stable tag, installs break for everyone. Catch the drift loudly before doing anything else:
 
    ```bash
-   LATEST_STABLE=$(gh release list --repo logancyang/obsidian-copilot --json tagName,isPrerelease \
-     -q '[.[] | select(.isPrerelease == false) | .tagName] | .[0]')
+   # Use /releases/latest which returns only the most-recent non-prerelease,
+   # non-draft release in a single call — works regardless of how many
+   # prereleases have accumulated since the last stable.
+   LATEST_STABLE=$(gh api repos/logancyang/obsidian-copilot/releases/latest -q .tag_name)
    MASTER_VERSION=$(node -p "require('./manifest.json').version")
    if [ "$LATEST_STABLE" != "$MASTER_VERSION" ]; then
      echo "DRIFT: master manifest.json.version='$MASTER_VERSION' but latest stable Release='$LATEST_STABLE'. Stop." >&2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,34 @@ jobs:
       # Obsidian plugin store reads). For prereleases the source of truth is
       # manifest-beta.json (manifest.json must stay pinned at the latest stable
       # so the plugin store keeps serving installs correctly).
+      #
+      # For prereleases we ALSO assert that manifest.json on the merge commit
+      # still matches the latest stable GitHub Release tag. This defends against
+      # an old-style version-bump or hand edit accidentally re-poisoning master.
       - name: Verify version matches manifest
         if: steps.semver.outputs.is_release == 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.semver.outputs.version }}
           IS_PRERELEASE: ${{ steps.semver.outputs.is_prerelease }}
         run: |
           if [ "$IS_PRERELEASE" = "true" ]; then
             MANIFEST_FILE="manifest-beta.json"
+
+            # Guard: master's manifest.json must still equal the latest stable Release tag.
+            LATEST_STABLE=$(gh release list --json tagName,isPrerelease \
+              -q '[.[] | select(.isPrerelease == false) | .tagName] | .[0]')
+            STABLE_MANIFEST_VERSION=$(node -p "require('./manifest.json').version")
+            if [ -z "$LATEST_STABLE" ]; then
+              echo "Could not determine latest stable GitHub Release tag; aborting to avoid poisoning manifest.json"
+              exit 1
+            fi
+            if [ "$STABLE_MANIFEST_VERSION" != "$LATEST_STABLE" ]; then
+              echo "manifest.json on merge commit ('$STABLE_MANIFEST_VERSION') drifted from latest stable Release ('$LATEST_STABLE')."
+              echo "A prerelease PR must not modify manifest.json. Refusing to publish."
+              exit 1
+            fi
+            echo "manifest.json drift check passed: $STABLE_MANIFEST_VERSION matches latest stable."
           else
             MANIFEST_FILE="manifest.json"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,18 +64,32 @@ jobs:
           # master don't cause this workflow to build the wrong code.
           ref: ${{ github.event.pull_request.merge_commit_sha }}
 
-      # ── Step 3: Verify PR title version matches manifest.json ───────────────
-      - name: Verify version matches manifest.json
+      # ── Step 3: Verify PR title version matches the source-of-truth manifest ──
+      # For stable releases the source of truth is manifest.json (which the
+      # Obsidian plugin store reads). For prereleases the source of truth is
+      # manifest-beta.json (manifest.json must stay pinned at the latest stable
+      # so the plugin store keeps serving installs correctly).
+      - name: Verify version matches manifest
         if: steps.semver.outputs.is_release == 'true'
         env:
           VERSION: ${{ steps.semver.outputs.version }}
+          IS_PRERELEASE: ${{ steps.semver.outputs.is_prerelease }}
         run: |
-          MANIFEST_VERSION=$(node -p "require('./manifest.json').version")
-          if [ "$VERSION" != "$MANIFEST_VERSION" ]; then
-            echo "Version mismatch: PR title='$VERSION', manifest.json='$MANIFEST_VERSION'"
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            MANIFEST_FILE="manifest-beta.json"
+          else
+            MANIFEST_FILE="manifest.json"
+          fi
+          if [ ! -f "$MANIFEST_FILE" ]; then
+            echo "Expected $MANIFEST_FILE to exist for this release type but it does not."
             exit 1
           fi
-          echo "Version check passed: $VERSION"
+          MANIFEST_VERSION=$(node -p "require('./$MANIFEST_FILE').version")
+          if [ "$VERSION" != "$MANIFEST_VERSION" ]; then
+            echo "Version mismatch: PR title='$VERSION', $MANIFEST_FILE='$MANIFEST_VERSION'"
+            exit 1
+          fi
+          echo "Version check passed: $VERSION (verified against $MANIFEST_FILE)"
 
       # ── Step 4: Set up Node.js ───────────────────────────────────────────────
       - name: Setup Node.js 22.x
@@ -119,7 +133,21 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # ── Step 9: Create GitHub Release ────────────────────────────────────────
+      # ── Step 9: Prepare release-asset manifest ──────────────────────────────
+      # For a prerelease, the manifest.json asset uploaded to the GitHub
+      # Release must carry the prerelease version (so testers who sideload
+      # the assets get a manifest matching what they downloaded). We swap
+      # manifest-beta.json into manifest.json's place IN THE RUNNER only —
+      # this never gets pushed back to master, so the committed manifest.json
+      # stays pinned to the latest stable.
+      - name: Prepare release-asset manifest
+        if: steps.semver.outputs.is_release == 'true' && steps.semver.outputs.is_prerelease == 'true'
+        run: |
+          cp manifest-beta.json manifest.json
+          echo "Release-asset manifest.json (prerelease):"
+          cat manifest.json
+
+      # ── Step 10: Create GitHub Release ───────────────────────────────────────
       # --target pins the tag to the exact merge commit SHA so concurrent
       # merges cannot cause the release tag to point at a different commit.
       # When the PR title is a prerelease semver (X.Y.Z-tag.N), pass --prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,10 @@ jobs:
             MANIFEST_FILE="manifest-beta.json"
 
             # Guard: master's manifest.json must still equal the latest stable Release tag.
-            LATEST_STABLE=$(gh release list --json tagName,isPrerelease \
-              -q '[.[] | select(.isPrerelease == false) | .tagName] | .[0]')
+            # Use /releases/latest which (per GitHub API) returns only the most-recent
+            # non-prerelease, non-draft release in one call — no pagination concerns
+            # even if many prereleases have accumulated since the last stable.
+            LATEST_STABLE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" -q .tag_name 2>/dev/null || true)
             STABLE_MANIFEST_VERSION=$(node -p "require('./manifest.json').version")
             if [ -z "$LATEST_STABLE" ]; then
               echo "Could not determine latest stable GitHub Release tag; aborting to avoid poisoning manifest.json"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write 'src/**/*.{js,ts,tsx,md}'",
     "format:check": "prettier --check 'src/**/*.{js,ts,tsx,md}'",
-    "version": "node version-bump.mjs && git add manifest.json versions.json",
+    "version": "node version-bump.mjs",
     "test": "jest --testPathIgnorePatterns=src/integration_tests/",
     "test:integration": "jest src/integration_tests/",
     "prepare": "husky",

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -1,14 +1,43 @@
-import { readFileSync, writeFileSync } from "fs";
+import { execSync } from "child_process";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 
 const targetVersion = process.env.npm_package_version;
+const isPrerelease = targetVersion.includes("-");
 
-// read minAppVersion from manifest.json and bump version to target version
-let manifest = JSON.parse(readFileSync("manifest.json", "utf8"));
+// Obsidian's community plugin store reads manifest.json on master to decide
+// which GitHub Release to serve. It MUST stay at the latest stable version.
+// Prereleases live in manifest-beta.json instead. See:
+//   https://github.com/obsidianmd/obsidian-releases#submit-your-plugin
+const manifestPath = isPrerelease ? "manifest-beta.json" : "manifest.json";
+
+// When cutting the first prerelease of a line, manifest-beta.json may not
+// exist yet. Seed it from manifest.json so it inherits the stable manifest's
+// fields (description, fundingUrl, etc.) and minAppVersion.
+const sourceManifestPath =
+  isPrerelease && !existsSync(manifestPath) ? "manifest.json" : manifestPath;
+
+const manifest = JSON.parse(readFileSync(sourceManifestPath, "utf8"));
 const { minAppVersion } = manifest;
 manifest.version = targetVersion;
-writeFileSync("manifest.json", JSON.stringify(manifest, null, "\t"));
+writeFileSync(manifestPath, JSON.stringify(manifest, null, "\t") + "\n");
 
-// update versions.json with target version and minAppVersion from manifest.json
-let versions = JSON.parse(readFileSync("versions.json", "utf8"));
+// versions.json records every version's minimum Obsidian app version so
+// Obsidian's installer can pick the right plugin version for the user's
+// Obsidian build. Both stable and prerelease entries belong here.
+const versions = JSON.parse(readFileSync("versions.json", "utf8"));
 versions[targetVersion] = minAppVersion;
-writeFileSync("versions.json", JSON.stringify(versions, null, "\t"));
+writeFileSync("versions.json", JSON.stringify(versions, null, "\t") + "\n");
+
+// Stage the files we modified. npm version's auto-commit (or the agent's
+// later explicit commit) picks them up.
+execSync(`git add ${manifestPath} versions.json`);
+
+// When a stable release ships, an existing manifest-beta.json is now
+// historical. Remove it so BRAT and similar tools don't keep surfacing the
+// older prerelease entry alongside the new stable.
+if (!isPrerelease && existsSync("manifest-beta.json")) {
+  execSync("git rm manifest-beta.json");
+  console.log("Removed manifest-beta.json (stable release supersedes prerelease).");
+}
+
+console.log(`version-bump: wrote ${targetVersion} to ${manifestPath} and versions.json.`);

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -1,5 +1,5 @@
 import { execSync } from "child_process";
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 
 const targetVersion = process.env.npm_package_version;
 const isPrerelease = targetVersion.includes("-");
@@ -35,9 +35,28 @@ execSync(`git add ${manifestPath} versions.json`);
 // When a stable release ships, an existing manifest-beta.json is now
 // historical. Remove it so BRAT and similar tools don't keep surfacing the
 // older prerelease entry alongside the new stable.
+//
+// `git rm` fails on untracked files or files with local modifications, so
+// check trackedness first and fall back to a plain unlink when the file is
+// only in the working tree. This keeps stable bumps robust against a partial
+// or in-progress prerelease state on the local machine.
 if (!isPrerelease && existsSync("manifest-beta.json")) {
-  execSync("git rm manifest-beta.json");
-  console.log("Removed manifest-beta.json (stable release supersedes prerelease).");
+  let isTracked = false;
+  try {
+    execSync("git ls-files --error-unmatch manifest-beta.json", { stdio: "ignore" });
+    isTracked = true;
+  } catch {
+    isTracked = false;
+  }
+
+  if (isTracked) {
+    execSync("git rm -f manifest-beta.json");
+  } else {
+    unlinkSync("manifest-beta.json");
+  }
+  console.log(
+    `Removed manifest-beta.json (${isTracked ? "tracked, staged deletion" : "untracked, removed from working tree"}).`
+  );
 }
 
 console.log(`version-bump: wrote ${targetVersion} to ${manifestPath} and versions.json.`);


### PR DESCRIPTION
## Summary

Permanent fix for the bug that hotfix #2428 patched. Master's `manifest.json` is what the Obsidian community plugin store reads to decide which GitHub Release to serve installers — and the previous prerelease tooling was rewriting that file every time `npm version prepatch --preid=beta` ran. The hotfix reverted the immediate damage; this PR makes the tooling correct so the bug can't recur.

## Changes

### `version-bump.mjs`
Branches on whether `npm_package_version` contains a hyphen (i.e., is a prerelease):
- **Stable**: writes to `manifest.json` + `versions.json` as before. If `manifest-beta.json` exists, `git rm`s it (the new stable supersedes the in-flight beta).
- **Prerelease**: writes to `manifest-beta.json` + `versions.json`. **Never touches `manifest.json`.** Seeds `manifest-beta.json` from `manifest.json` when it doesn't exist yet (first prerelease of a line inherits the stable's `minAppVersion`, `isDesktopOnly`, etc.).
- Stages the files itself, so `package.json`'s `version` script simplifies to just `node version-bump.mjs`.

### `.github/workflows/release.yml`
- **Verify version step** picks the right manifest based on `is_prerelease`: `manifest.json` for stable, `manifest-beta.json` for prerelease.
- **New "Prepare release-asset manifest" step** for prereleases: copies `manifest-beta.json` over `manifest.json` IN THE RUNNER ONLY. This makes the uploaded `manifest.json` release asset carry the prerelease version so testers sideloading the assets get a consistent manifest. The committed `manifest.json` on master is never touched (the workflow doesn't push back).

### `.claude/agents/release.md` and `.claude/agents/prerelease.md`
- Add a Step 0 pre-flight assertion that master's `manifest.json.version` equals the latest non-prerelease GitHub Release tag. Catches drift loudly before doing any work — if today's bug recurs, the next agent stops immediately instead of compounding.
- Prerelease agent: update the `git add` step to stage `manifest-beta.json` instead of `manifest.json`, with an explicit guard rule that `manifest.json` must NOT be modified during a prerelease bump.
- Release agent: note that `manifest-beta.json` is automatically removed on stable releases (the diff will show the deletion).

## Verified locally

Exercised `version-bump.mjs` in a throwaway repo across all four scenarios:

| Scenario | Before | After | Result |
|---|---|---|---|
| Stable bump | `3.2.8` | `3.2.9` | `manifest.json` updated, `versions.json` updated, no beta side |
| First prerelease | `3.2.8` | `3.2.9-beta.0` | `manifest-beta.json` created, `manifest.json` untouched (still `3.2.8`) |
| Prerelease iteration | `3.2.9-beta.0` | `3.2.9-beta.1` | `manifest-beta.json` updated, `manifest.json` untouched |
| Stable supersedes beta | `3.2.9-beta.1` | `3.2.9` | `manifest.json` updated, `manifest-beta.json` removed (`git rm`) |

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` (107 suites / 1972 tests) pass
- [x] `version-bump.mjs` smoke-tested across the four scenarios above
- [ ] After merge, dry-run the prerelease agent against the now-corrected master and confirm `manifest.json` stays at `3.2.8`
- [ ] When the next real prerelease ships, confirm the GitHub Release asset's `manifest.json` carries the prerelease version while the committed `manifest.json` on master does not

## Doesn't change

- `package.json` and `versions.json` continue to track every version (stable and prerelease) — those are not consumed by the Obsidian plugin store.
- The release workflow's PR-title regex contract is unchanged.
- `manifest-beta.json` is committed to the repo when a prerelease is active. This is not a convention BRAT consumes (BRAT v1.1.0+ explicitly ignores `manifest-beta.json` at root), but it's a useful in-repo signal that a prerelease is currently in flight, and the workflow needs it to construct the release asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)