### PR TITLE
ci(release): publish artifact attestations for release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write  # required to create GitHub releases and tags
+      contents: write       # required to create GitHub releases and tags
+      attestations: write   # required to publish artifact attestations
+      id-token: write       # required for the workflow's OIDC token (used to sign attestations)
 
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -169,7 +171,25 @@ jobs:
           echo "Release-asset manifest.json (prerelease):"
           cat manifest.json
 
-      # ── Step 10: Create GitHub Release ───────────────────────────────────────
+      # ── Step 10: Generate build provenance attestation ──────────────────────
+      # Cryptographically signs main.js / manifest.json / styles.css with the
+      # workflow's OIDC identity and publishes the attestation to Sigstore's
+      # public transparency log. Anyone can later verify a downloaded asset
+      # was actually built by this workflow on this commit with:
+      #   gh attestation verify main.js --owner logancyang --repo logancyang/obsidian-copilot
+      #
+      # Runs AFTER the prerelease manifest swap so the attested manifest.json
+      # exactly matches the file uploaded to the GitHub Release.
+      - name: Generate artifact attestation
+        if: steps.semver.outputs.is_release == 'true' && steps.check_existing.outputs.exists != 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
+
+      # ── Step 11: Create GitHub Release ───────────────────────────────────────
       # --target pins the tag to the exact merge commit SHA so concurrent
       # merges cannot cause the release tag to point at a different commit.
       # When the PR title is a prerelease semver (X.Y.Z-tag.N), pass --prerelease


### PR DESCRIPTION
## Summary

Adds GitHub artifact attestations to the release workflow so that `main.js`, `manifest.json`, and `styles.css` get cryptographically signed by the workflow's OIDC identity and the signatures get published to Sigstore's public transparency log.

Anyone (Obsidian's plugin review tooling, security researchers, end users) can then verify that a downloaded asset was actually built by this exact workflow on this exact commit:

```
gh attestation verify main.js --owner logancyang --repo logancyang/obsidian-copilot
```

## Why

Obsidian's plugin review tooling flags release assets without an attestation as a soft warning ("The main.js release asset does not have a GitHub artifact attestation"). The attestation closes a real supply-chain gap: a maintainer (or compromised maintainer credential) can today replace `main.js` on an existing GitHub Release without anyone noticing. With attestations, a swapped asset fails verification — the attacker would need to also forge a Sigstore log entry signed by GitHub's OIDC provider, which is impractical.

Free for public repos. No secrets to rotate.

## Changes

`.github/workflows/release.yml`:

- Adds `attestations: write` + `id-token: write` to the release job's permissions block. `id-token: write` is what lets the workflow request an OIDC token from GitHub; the attest action presents that token as proof of identity when signing.
- New step 10 ("Generate artifact attestation") runs `actions/attest-build-provenance@v2` with `main.js`, `manifest.json`, `styles.css` as subjects. Step 11 is the renamed "Create GitHub Release" step.

## Placement detail

The new step sits **after** the prerelease manifest swap (step 9) and **before** `gh release create` (step 11). That order is deliberate: for prereleases the workflow copies `manifest-beta.json` over `manifest.json` in the runner before upload, so we want the attestation to sign the *post-swap* `manifest.json` — the bytes that actually get uploaded — not the unswapped committed copy. For stable releases the order doesn't matter (no swap happens), so this placement is correct in both modes.

## Test plan

- [ ] Workflow YAML parses (verified locally via `js-yaml`; step ordering and `if:` conditions match the existing pattern)
- [ ] On the next release after merge, confirm the workflow's "Generate artifact attestation" step runs successfully and publishes an attestation
- [ ] After release, run `gh attestation verify main.js --owner logancyang --repo logancyang/obsidian-copilot` and confirm verification passes
- [ ] After release, check that Obsidian's review check stops flagging the missing-attestation warning

## Doesn't change

- The PR-title semver contract, the stable/prerelease split, or any artifact contents.
- Existing releases (`3.3.0` and earlier) remain unattested — attestations are forward-looking.
- No new secrets or repo settings required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)