### PR TITLE
chore(eslint): remove redundant non-TS rule overrides

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -180,18 +180,15 @@ export default [
   },
 
   // Non-TS files aren't in tsconfig.json — disable type-aware rules that
-  // obsidianmd's recommended config enables globally. (The plugin lists some
-  // typed rules in its general rule bundle, not just the TS-only bundle, so
-  // they cascade to .js / package.json without parser services.)
+  // obsidianmd's recommended config enables globally. Most typed obsidianmd
+  // rules are already gated to **/*.ts(x); only no-plugin-as-component leaks
+  // out via recommendedPluginRulesConfig, and @typescript-eslint/no-deprecated
+  // is enabled globally.
   {
     files: ["**/*.js", "**/*.mjs", "**/*.cjs", "**/*.jsx", "**/package.json"],
     rules: {
       "@typescript-eslint/no-deprecated": "off",
       "obsidianmd/no-plugin-as-component": "off",
-      "obsidianmd/no-view-references-in-plugin": "off",
-      "obsidianmd/no-unsupported-api": "off",
-      "obsidianmd/prefer-file-manager-trash-file": "off",
-      "obsidianmd/prefer-instanceof": "off",
     },
   },
 


### PR DESCRIPTION
## Summary

The non-TS override block in \`eslint.config.mjs\` disabled six rules to keep type-aware rules from crashing on \`.js\` / \`package.json\` files. Four of them were unnecessary: \`obsidianmd/no-view-references-in-plugin\`, \`obsidianmd/no-unsupported-api\`, \`obsidianmd/prefer-file-manager-trash-file\`, and \`obsidianmd/prefer-instanceof\` are already gated to \`**/*.ts(x)\` by the plugin's \`hybridRecommendedConfig\`. Only \`obsidianmd/no-plugin-as-component\` (listed in the always-on \`recommendedPluginRulesConfig\`) and \`@typescript-eslint/no-deprecated\` actually leak onto non-TS files, so those two stay disabled.

## Test plan

- [x] \`npm run lint\` passes clean
- [x] Verified each removed rule individually — none cause crashes on \`.js\` / \`.mjs\` / \`package.json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)