### PR TITLE
chore(eslint): enable @typescript-eslint/no-floating-promises

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,7 +94,7 @@ export default [
 
       // --- Medium: promise / method ergonomics ---
       "@typescript-eslint/unbound-method": "off", // 68 violations
-      "@typescript-eslint/no-floating-promises": "off", // 39 violations
+      // Enabled in the TS-only block below.
 
       // --- Quick wins: small enough to fix and enable in a single PR ---
       "@typescript-eslint/no-unsafe-enum-comparison": "off", // 11 violations
@@ -177,6 +177,7 @@ export default [
         "error",
         { checksVoidReturn: { attributes: false, inheritedMethods: false } },
       ],
+      "@typescript-eslint/no-floating-promises": "error",
       // TypeScript handles undefined-identifier detection (and does so cross-realm
       // correctly); per typescript-eslint's own guidance, disable no-undef on TS.
       "no-undef": "off",

--- a/src/commands/CustomCommandChatModal.tsx
+++ b/src/commands/CustomCommandChatModal.tsx
@@ -332,7 +332,7 @@ function CustomCommandChatModalContent({
       }
     }
 
-    generateInitialResponse();
+    void generateInitialResponse();
 
     return () => {
       cancelled = true;
@@ -690,7 +690,7 @@ export class CustomCommandChatModal {
     const { anchorBottom, ...initialPosition } = this.getInitialPosition(activeView);
 
     const handleInsert = (message: string) => {
-      insertIntoEditor(message);
+      void insertIntoEditor(message);
       this.close();
     };
 

--- a/src/commands/CustomCommandSettingsModal.tsx
+++ b/src/commands/CustomCommandSettingsModal.tsx
@@ -194,7 +194,7 @@ export class CustomCommandSettingsModal extends Modal {
     this.root = createRoot(contentEl);
 
     const handleConfirm = (command: CustomCommand) => {
-      this.onUpdate(command);
+      void this.onUpdate(command);
       this.close();
     };
 

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -83,7 +83,7 @@ export class CustomCommandManager {
   }
 
   async recordUsage(command: CustomCommand) {
-    this.updateCommand({ ...command, lastUsedMs: Date.now() }, command.title);
+    await this.updateCommand({ ...command, lastUsedMs: Date.now() }, command.title);
   }
 
   async updateCommand(command: CustomCommand, prevCommandTitle: string, skipStoreUpdate = false) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -606,7 +606,7 @@ export function registerCommands(
       setSelectedTextContexts([webSelectedTextContext]);
 
       // Open chat window to show the context was added
-      plugin.activateView();
+      await plugin.activateView();
     } catch (error) {
       logError("Error adding web selection to context:", error);
       new Notice("Failed to get web selection");

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -833,7 +833,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
                   new ContextManageModal(
                     app,
                     (updatedProject) => {
-                      handleEditProject(currentProject, updatedProject);
+                      void handleEditProject(currentProject, updatedProject);
                     },
                     currentProject
                   ).open();

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -913,7 +913,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
 
     const editor = leaf.view.editor;
     const hasSelection = editor.getSelection().length > 0;
-    insertIntoEditor(message.message, hasSelection);
+    void insertIntoEditor(message.message, hasSelection);
   };
 
   const renderMessageContent = () => {

--- a/src/components/chat-components/ProjectList.tsx
+++ b/src/components/chat-components/ProjectList.tsx
@@ -140,7 +140,7 @@ function ProjectItem({
                   // Reason: hidden-folder files are not in vault cache, so openLinkText silently fails.
                   const fileInCache = app.vault.getAbstractFileByPath(record.filePath);
                   if (fileInCache) {
-                    app.workspace.openLinkText(record.filePath, "", true);
+                    void app.workspace.openLinkText(record.filePath, "", true);
                   } else {
                     new Notice(
                       "Project file is in a hidden folder and cannot be opened from the file explorer."

--- a/src/components/modals/CachePreviewModal.ts
+++ b/src/components/modals/CachePreviewModal.ts
@@ -81,7 +81,7 @@ export class CachePreviewModal extends Modal {
     });
 
     // Reason: pass empty sourcePath to prevent vault link resolution
-    MarkdownRenderer.renderMarkdown(this.content, mdContainer, "", this.component);
+    void MarkdownRenderer.renderMarkdown(this.content, mdContainer, "", this.component);
   }
 
   onClose(): void {

--- a/src/components/modals/project/AddProjectModal.tsx
+++ b/src/components/modals/project/AddProjectModal.tsx
@@ -177,7 +177,7 @@ function AddProjectModalContent({
 
   /** Handle opening cached parsed content for any item (file or URL) */
   const handleOpenCachedItem = (item: ProcessingItem) => {
-    openCachedItemPreview(app, projectCache, item);
+    void openCachedItemPreview(app, projectCache, item);
   };
 
   /** Handle removing a failed URL from the project config via ProcessingStatus × button */
@@ -196,7 +196,7 @@ function AddProjectModalContent({
     if (!plugin?.projectManager || !processingData) return;
     const failedItem = processingData.failedItemMap.get(itemId);
     if (failedItem) {
-      plugin.projectManager.retryFailedItem(failedItem);
+      void plugin.projectManager.retryFailedItem(failedItem);
     }
   };
 

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -436,7 +436,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
         setProjectCache(cache);
       }
     };
-    loadCache();
+    void loadCache();
     return () => {
       isMounted = false;
     };
@@ -1331,7 +1331,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
                                 !item.isIgnored && item.id.split(".").pop()?.toLowerCase() !== "md"
                                   ? () => {
                                       const name = item.name || item.id.split("/").pop() || item.id;
-                                      openCachedProjectFile(app, projectCache, item.id, name);
+                                      void openCachedProjectFile(app, projectCache, item.id, name);
                                     }
                                   : undefined
                               }

--- a/src/components/project/progress-card.tsx
+++ b/src/components/project/progress-card.tsx
@@ -105,7 +105,7 @@ export default function ProgressCard({ plugin, setHiddenCard, onEditContext }: P
 
   /** Open parsed content preview for a cached item. */
   const handleOpenCachedItem = (item: ProcessingItem) => {
-    openCachedItemPreview(app, projectCache, item);
+    void openCachedItemPreview(app, projectCache, item);
   };
 
   return (

--- a/src/components/project/useProjectProcessingData.ts
+++ b/src/components/project/useProjectProcessingData.ts
@@ -71,7 +71,7 @@ export function useProjectProcessingData(
       return;
     }
     let mounted = true;
-    ProjectContextCache.getInstance()
+    void ProjectContextCache.getInstance()
       .get(cacheProject)
       .then((cache) => {
         if (mounted) setProjectCache(cache);

--- a/src/components/ui/mobile-card.tsx
+++ b/src/components/ui/mobile-card.tsx
@@ -178,7 +178,7 @@ export function MobileCard<T extends object>({
                       key={index}
                       onClick={(e) => {
                         e.stopPropagation();
-                        action.onClick(item);
+                        void action.onClick(item);
                       }}
                       className={cn(action.variant === "destructive" && "tw-text-error")}
                     >

--- a/src/core/ChatManager.test.ts
+++ b/src/core/ChatManager.test.ts
@@ -537,13 +537,13 @@ describe("ChatManager", () => {
   });
 
   describe("loadMessages", () => {
-    it("should load messages from array", () => {
+    it("should load messages from array", async () => {
       const messages: ChatMessage[] = [
         createMockMessage("msg-1", "Hello", USER_SENDER),
         createMockMessage("msg-2", "Response", "AI"),
       ];
 
-      chatManager.loadMessages(messages);
+      await chatManager.loadMessages(messages);
 
       expect(mockMessageRepo.clear).toHaveBeenCalled();
       expect(mockMessageRepo.addMessage).toHaveBeenCalledTimes(2);

--- a/src/integration_tests/composerPrompt.test.ts
+++ b/src/integration_tests/composerPrompt.test.ts
@@ -68,7 +68,7 @@ describe.skip("Composer Instructions - Integration Tests", () => {
   });
 
   // Helper function to run a test with a given prompt and check for writeFile blocks
-  const testComposerResponse = async (
+  const testComposerResponse = (
     testName: string,
     userPrompt: string,
     expectedBlocks: number = 1

--- a/src/main.ts
+++ b/src/main.ts
@@ -124,8 +124,8 @@ export default class CopilotPlugin extends Plugin {
     // Initialize BrevilabsClient
     this.brevilabsClient = BrevilabsClient.getInstance();
     this.brevilabsClient.setPluginVersion(this.manifest.version);
-    checkIsPlusUser();
-    refreshSelfHostModeValidation();
+    void checkIsPlusUser();
+    void refreshSelfHostModeValidation();
 
     // Initialize ProjectManager
     this.projectManager = ProjectManager.getInstance(this.app, this);
@@ -177,7 +177,7 @@ export default class CopilotPlugin extends Plugin {
     this.initActiveLeafChangeHandler();
 
     this.addRibbonIcon("message-square", "Open Copilot Chat", (evt: MouseEvent) => {
-      this.activateView();
+      void this.activateView();
     });
 
     registerCommands(this, undefined, getSettings());
@@ -228,10 +228,13 @@ export default class CopilotPlugin extends Plugin {
       });
 
       // Initialize custom commands
-      this.customCommandRegister.initialize().then(migrateCommands).then(suggestDefaultCommands);
+      void this.customCommandRegister
+        .initialize()
+        .then(migrateCommands)
+        .then(suggestDefaultCommands);
 
       // Initialize system prompts (independent from custom commands)
-      this.systemPromptRegister
+      void this.systemPromptRegister
         .initialize()
         .then(() => migrateSystemPromptsFromSettings(this.app.vault));
     });
@@ -343,7 +346,7 @@ export default class CopilotPlugin extends Plugin {
   }
 
   processSelection(editor: Editor, eventType: string, eventSubtype?: string) {
-    this.processText(editor, eventType, eventSubtype);
+    void this.processText(editor, eventType, eventSubtype);
   }
 
   emitChatIsVisible() {
@@ -576,15 +579,15 @@ export default class CopilotPlugin extends Plugin {
 
   processCustomPrompt(eventType: string, customPrompt: string) {
     const editor = this.getCurrentEditorOrDummy();
-    this.processText(editor, eventType, customPrompt, false);
+    void this.processText(editor, eventType, customPrompt, false);
   }
 
   toggleView() {
     const leaves = this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE);
     if (leaves.length > 0) {
-      this.deactivateView();
+      void this.deactivateView();
     } else {
-      this.activateView();
+      void this.activateView();
     }
   }
 
@@ -764,7 +767,7 @@ export default class CopilotPlugin extends Plugin {
     const existingView = this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE)[0];
     if (!existingView) {
       // Only activate the view if it's not already open
-      this.activateView();
+      await this.activateView();
     }
 
     // Load messages using ChatUIState (which now uses ChatPersistenceManager internally)

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -109,7 +109,7 @@ const MobileCommandCard: React.FC<{
         <Checkbox
           checked={command.showInContextMenu}
           onCheckedChange={(checked) => {
-            onUpdate(
+            void onUpdate(
               {
                 ...command,
                 showInContextMenu: checked === true,
@@ -182,7 +182,7 @@ const SortableTableRow: React.FC<{
   };
 
   const handleDelete = () => {
-    onRemove(command);
+    void onRemove(command);
   };
 
   return (
@@ -209,7 +209,7 @@ const SortableTableRow: React.FC<{
         <Checkbox
           checked={command.showInContextMenu}
           onCheckedChange={(checked) => {
-            onUpdate(
+            void onUpdate(
               {
                 ...command,
                 showInContextMenu: checked === true,

--- a/src/settings/v2/components/GitHubCopilotAuth.tsx
+++ b/src/settings/v2/components/GitHubCopilotAuth.tsx
@@ -270,7 +270,7 @@ export function GitHubCopilotAuth() {
             <Button
               onClick={() => {
                 if (!isAuthenticated && !isAuthenticating) {
-                  handleStartAuth();
+                  void handleStartAuth();
                 } else {
                   setExpanded(!expanded);
                 }

--- a/src/settings/v2/components/LocalServicesSection.tsx
+++ b/src/settings/v2/components/LocalServicesSection.tsx
@@ -85,7 +85,7 @@ function LocalServiceItem({ service, expanded, onToggleExpand }: LocalServiceIte
   const handleAddModelClick = () => {
     onToggleExpand();
     if (!expanded && !models && !loading) {
-      fetchModels();
+      void fetchModels();
     }
   };
 

--- a/src/settings/v2/components/ModelImporter.tsx
+++ b/src/settings/v2/components/ModelImporter.tsx
@@ -128,7 +128,7 @@ export function ModelImporter({
   // Auto-load models when expanded and ready
   useEffect(() => {
     if (expanded && isReady && models === null && !loading && !error) {
-      loadModels();
+      void loadModels();
     }
   }, [expanded, isReady, models, loading, error, loadModels]);
 
@@ -216,7 +216,7 @@ export function ModelImporter({
               }}
               onClick={() => {
                 if (models === null && !loading) {
-                  loadModels();
+                  void loadModels();
                 }
               }}
               value={selectedModel?.id || ""}


### PR DESCRIPTION
## Summary

- Enables `@typescript-eslint/no-floating-promises` as an error in the TypeScript-only block of `eslint.config.mjs`.
- Fixes 39 violations across 17 files — most prefixed with `void` for fire-and-forget calls (event handlers, ribbon icons, modal openers, `useEffect` bodies), a few converted to `await` where the surrounding function was already async, and one test helper in `composerPrompt.test.ts` made sync since it only registers `test()` calls.

## Test plan

- [x] `npm run lint` passes
- [x] `npx tsc --noEmit` passes
- [x] `ChatManager` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)