### PR TITLE
chore(eslint): enable @typescript-eslint/unbound-method

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -92,7 +92,6 @@ export default [
       "@typescript-eslint/no-unsafe-call": "off", // 679 violations
 
       // --- Medium: promise / method ergonomics ---
-      "@typescript-eslint/unbound-method": "off", // 68 violations
       // Enabled in the TS-only block below.
 
       // no-deprecated: defer — surface the warnings, but don't fail CI yet
@@ -173,6 +172,7 @@ export default [
       ],
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-unsafe-return": "error",
+      "@typescript-eslint/unbound-method": "error",
       // TypeScript handles undefined-identifier detection (and does so cross-realm
       // correctly); per typescript-eslint's own guidance, disable no-undef on TS.
       "no-undef": "off",
@@ -221,6 +221,19 @@ export default [
     files: ["src/logger.ts", "scripts/**"],
     rules: {
       "obsidianmd/rule-custom-message": "off",
+    },
+  },
+
+  // Jest assertions like `expect(mock.method).toHaveBeenCalled()` reference
+  // methods unbound by design. The rule has no clean workaround for jest
+  // patterns (binding changes the reference identity and breaks the assertion),
+  // so disable it in tests. Scoped to .ts/.tsx because the @typescript-eslint
+  // plugin is only registered for those files. Placed last so it overrides the
+  // TS-only block above.
+  {
+    files: ["**/*.test.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/unbound-method": "off",
     },
   },
 ];

--- a/src/lib/plugins/colorOpacityPlugin.ts
+++ b/src/lib/plugins/colorOpacityPlugin.ts
@@ -86,7 +86,8 @@ const processColorObject =
  * bg-modifier-error/50
  * text-background-modifier-success/30
  */
-export const colorOpacityPlugin = plugin(function (this: void, { addUtilities, theme, e }) {
+export const colorOpacityPlugin = plugin(function (this: void, api) {
+  const { theme, e } = api;
   const opacityUtilities: Record<string, any> = {};
 
   // 处理所有颜色相关的主题配置
@@ -104,5 +105,5 @@ export const colorOpacityPlugin = plugin(function (this: void, { addUtilities, t
   processThemeColors("borderColor", "");
   processThemeColors("colors");
 
-  addUtilities(opacityUtilities);
+  api.addUtilities(opacityUtilities);
 });


### PR DESCRIPTION
## Summary

- Enabled `@typescript-eslint/unbound-method` in the TS-only override block.
- Added a final override block disabling the rule for `**/*.test.{ts,tsx}` — jest assertion patterns like \`expect(mock.method).toHaveBeenCalled()\` reference methods unbound by design and have no clean structural workaround (binding changes reference identity and breaks the assertion).
- Fixed the single real source violation in \`src/lib/plugins/colorOpacityPlugin.ts\` by calling \`api.addUtilities(...)\` directly instead of destructuring it from the plugin API object.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run format\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)