### PR TITLE
fix(mobile): import Buffer from the polyfill so image send works on mobile

### DIFF
--- a/src/LLMProviders/BedrockChatModel.ts
+++ b/src/LLMProviders/BedrockChatModel.ts
@@ -1,3 +1,8 @@
+// Reason: `buffer` is the npm polyfill (browser-compatible), bundled by esbuild
+// so the same Buffer code path works on desktop (Electron) and mobile (WebView).
+// eslint-disable-next-line import/no-nodejs-modules
+import { Buffer } from "buffer";
+
 import {
   BaseChatModel,
   type BaseChatModelCallOptions,
@@ -793,6 +798,8 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
 
   private decodeBase64ToUint8Array(encoded: string): Uint8Array | null {
     try {
+      // Reason: Buffer (from the `buffer` polyfill imported above) is the
+      // cross-platform path — bare global Buffer is undefined in mobile WebView.
       return new Uint8Array(Buffer.from(encoded, "base64"));
     } catch {
       return null;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,8 @@
+// Reason: `buffer` is the npm polyfill (browser-compatible), bundled by esbuild
+// so the same Buffer code path works on desktop (Electron) and mobile (WebView).
+// eslint-disable-next-line import/no-nodejs-modules
+import { Buffer } from "buffer";
+
 import { Document } from "@/chainFactory";
 import { ChainType } from "@/chainType";
 import {
@@ -883,6 +888,8 @@ export async function safeFetch(
         return response.arrayBuffer;
       }
       const base64 = response.text.replace(/^data:.*;base64,/, "");
+      // Reason: Buffer (from the `buffer` polyfill imported above) is the
+      // cross-platform path — bare global Buffer is undefined in mobile WebView.
       const buf = Buffer.from(base64, "base64");
       return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
     },

--- a/src/utils/base64.test.ts
+++ b/src/utils/base64.test.ts
@@ -1,0 +1,37 @@
+import { arrayBufferToBase64, base64ToArrayBuffer } from "./base64";
+
+describe("base64 utils", () => {
+  it("round-trips a small ArrayBuffer", () => {
+    const original = new Uint8Array([0, 1, 2, 3, 127, 128, 255]).buffer;
+    const encoded = arrayBufferToBase64(original);
+    const decoded = base64ToArrayBuffer(encoded);
+    expect(new Uint8Array(decoded)).toEqual(new Uint8Array(original));
+  });
+
+  it("matches a known base64 fixture", () => {
+    const bytes = new TextEncoder().encode("Copilot 🚀");
+    expect(arrayBufferToBase64(bytes.buffer as ArrayBuffer)).toBe("Q29waWxvdCDwn5qA");
+  });
+
+  // Reason: regression guard for the 3.3.0 mobile bug. Mobile Obsidian's
+  // WebView runtime has no Node.js globals — bare `Buffer` is undefined.
+  // The helpers must import Buffer from the `buffer` npm polyfill (bundled
+  // by esbuild) and not rely on `globalThis.Buffer`. This test deletes the
+  // global to make sure the imported binding is what's actually being used.
+  it("works without relying on globalThis.Buffer (mobile WebView simulation)", () => {
+    // eslint-disable-next-line obsidianmd/no-global-this -- jsdom test needs to mutate the actual global runtime, not a per-window scope
+    const g = globalThis as { Buffer?: unknown };
+    const originalBuffer = g.Buffer;
+    try {
+      delete g.Buffer;
+      const bytes = new Uint8Array([10, 20, 30, 40]).buffer;
+      const encoded = arrayBufferToBase64(bytes);
+      const decoded = base64ToArrayBuffer(encoded);
+      expect(new Uint8Array(decoded)).toEqual(new Uint8Array(bytes));
+    } finally {
+      if (originalBuffer !== undefined) {
+        g.Buffer = originalBuffer;
+      }
+    }
+  });
+});

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,7 +1,16 @@
+// Reason: explicit import from the `buffer` npm polyfill (a browser-compatible
+// drop-in, not a runtime use of Node's built-in). Mobile Obsidian's WebView has
+// no Node globals, so bare `Buffer` throws "Can't find variable: Buffer" on iOS
+// WebKit. esbuild bundles this polyfill into main.js so the same code path
+// works on both desktop and mobile.
+// eslint-disable-next-line import/no-nodejs-modules
+import { Buffer } from "buffer";
+
 export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   return Buffer.from(buffer).toString("base64");
 }
 
 export function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  return new Uint8Array(Buffer.from(base64, "base64")).buffer;
+  const buf = Buffer.from(base64, "base64");
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
 }


### PR DESCRIPTION
## Summary

Mobile Obsidian (3.3.0) cannot send images: `Can't find variable: Buffer`. Desktop is unaffected. Root cause is two PRs in 3.3.0 (#2403 and #2401) that replaced cross-platform code with bare `Buffer.from(...)` in image-handling paths, on the rationale "Buffer is global." That's true on Electron (desktop) but **not** in mobile Obsidian's Capacitor + WebView runtime, which has no Node.js globals.

This PR adds an explicit `import { Buffer } from "buffer"` (the npm polyfill, already in `dependencies`) at each affected call site. esbuild bundles the polyfill into `main.js`, so the same `Buffer` code path works on both desktop and mobile.

## User report

```
2026-05-14T05:30:49.936Z ERROR Error sending message: Can't find variable: Buffer
2026-05-14T05:30:51.644Z ERROR Error sending message: Can't find variable: Buffer
...
```

`Can't find variable: Buffer` is Safari/WebKit's exact phrasing for a `ReferenceError` on an undeclared identifier. Obsidian Mobile on iOS uses WKWebView (Safari/WebKit).

## Call chain (image attachment on mobile)

1. User taps image icon → file picker → `onAddImage(files)`
2. Send → `CopilotPlusChainRunner.processChatInputImages` → `ImageProcessor`
3. `ImageProcessor.handleVaultImage` / `handleWebImage` calls `arrayBufferToBase64(arrayBuffer)` at `src/imageProcessing/imageProcessor.ts:202,239,272`
4. `arrayBufferToBase64` (before this PR) → bare `Buffer.from(buffer).toString("base64")` → **ReferenceError: Buffer is not defined** → "failed to send image, please try again"

## Why polyfill, not `btoa`/`atob`

Two lint rules pull in opposite directions:

- Obsidian's official scorecard flags `btoa`/`atob` as deprecated and tells you to use `Buffer.from`.
- The repo's own `import/no-nodejs-modules` blocks `import from "buffer"`.

The `buffer` npm package is **a browser-compatible polyfill**, not Node's built-in being used at runtime. It's been in `dependencies` since long before this PR. The `import/no-nodejs-modules` rule can't distinguish it from the Node built-in by name, so it's suppressed inline at each import site with a justification comment. This satisfies Obsidian's scorecard and runs correctly on mobile.

## Changes

- **`src/utils/base64.ts`** — adds `import { Buffer } from "buffer"`. This is the call site the image processor hits *and* the path `encryptionService.ts` uses for `WEBCRYPTO_PREFIX` (mobile encryption), so **mobile encryption is also fixed transitively**.
- **`src/utils.ts`** — same import; `safeFetch`'s `arrayBuffer()` fallback now uses the polyfill.
- **`src/LLMProviders/BedrockChatModel.ts`** — same import; `decodeBase64ToUint8Array` now uses the polyfill. The `Buffer.from(...).toString("utf-8")` at line 835 is left alone because it's already guarded with `typeof Buffer !== "undefined"`, which mobile lazily skips.
- **`src/utils/base64.test.ts`** (new) — round-trip tests + a regression guard that deletes `globalThis.Buffer` before calling the helpers. This confirms the imported polyfill binding is what's actually being used, so any future revert to a bare global usage fails CI.

## Out of scope

`src/encryptionService.ts` has `Buffer.from` references at lines 119, 137 that I deliberately did not touch:

- They sit inside DESKTOP_PREFIX / `getSafeStorage().isEncryptionAvailable()` guards, which mobile never enters in the first place.
- The mobile encryption path (WEBCRYPTO_PREFIX) goes through `base64ToArrayBuffer` in `utils/base64.ts`, which is now polyfilled, so mobile decryption is already fixed.
- Touching desktop-only encryption from a mobile hotfix expands blast radius unnecessarily.

## Verification

```
$ npm run lint    # passes (only pre-existing unrelated warning in commands/index.ts)
$ npm test         # 108 suites, 1975 tests pass (+1 suite, +3 tests)
$ npm run build    # passes, bundle size unchanged at 3.3 MB
```

Test cases in `src/utils/base64.test.ts`:
1. Round-trip of a small `ArrayBuffer`
2. Known fixture (`Copilot 🚀` → `Q29waWxvdCDwn5qA`)
3. **Mobile WebView simulation**: deletes `globalThis.Buffer` before calling helpers, confirms the imported polyfill binding still works

## Test plan

- [x] Unit tests pass with `globalThis.Buffer` deleted (simulated WebView)
- [ ] Manual mobile verification (iOS): attach image → send → no "failed to send" toast, image visible in conversation
- [ ] Manual mobile verification (Android, ideally)
- [ ] Manual desktop regression: confirm image attachment still works
- [ ] Mobile API key load: confirm encryption still works on mobile (WEBCRYPTO_PREFIX path now benefits from the polyfill fix)

## Suggested follow-up

Cut **3.3.1** patch release with just this fix once it's merged. Image send is 100% broken for any mobile user since 3.3.0 shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)