### PR TITLE
chore(types): tighten any types and fix langchain getType deprecation

### DIFF
--- a/src/LLMProviders/BedrockChatModel.ts
+++ b/src/LLMProviders/BedrockChatModel.ts
@@ -391,13 +391,14 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
       const fallback = await this._generate(messages, options, runManager);
       const fallbackText = fallback.generations[0]?.text ?? "";
       if (fallbackText) {
+        const fallbackMetadata: Record<string, unknown> = fallback.llmOutput ?? {};
         yield new ChatGenerationChunk({
           message: new AIMessageChunk({
             content: fallbackText,
-            response_metadata: fallback.llmOutput ?? {},
+            response_metadata: fallbackMetadata,
           }),
           text: fallbackText,
-          generationInfo: fallback.llmOutput ?? {},
+          generationInfo: fallbackMetadata,
         });
       }
     }
@@ -1251,7 +1252,7 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
     const systemPrompts: string[] = [];
 
     messages.forEach((message) => {
-      const messageType = message.getType();
+      const messageType = message.type;
 
       // Handle system messages (always text-only)
       if (messageType === "system") {

--- a/src/search/dbOperations.ts
+++ b/src/search/dbOperations.ts
@@ -368,7 +368,7 @@ export class DBOperations {
     };
   }
 
-  async upsert(docToSave: any): Promise<unknown> {
+  async upsert(docToSave: OramaDocument): Promise<unknown> {
     if (!this.oramaDb) throw new Error("DB not initialized");
     const db = this.oramaDb;
 

--- a/src/search/dbOperations.ts
+++ b/src/search/dbOperations.ts
@@ -400,7 +400,7 @@ export class DBOperations {
           );
 
           this.markUnsavedChanges();
-          return docToSave as unknown;
+          return docToSave;
         } catch (insertErr) {
           logError(
             `Failed to ${existingDoc.hits.length > 0 ? "update" : "insert"} document ${docToSave.id}:`,

--- a/src/search/v3/utils/ScoreNormalizer.ts
+++ b/src/search/v3/utils/ScoreNormalizer.ts
@@ -1,4 +1,4 @@
-import { NoteIdRank } from "../interfaces";
+import { NoteIdRank, SearchExplanation } from "../interfaces";
 
 /**
  * Configuration for score normalization
@@ -29,7 +29,11 @@ export class ScoreNormalizer {
   /**
    * Update explanation with normalized scores
    */
-  private updateExplanation(explanation: any, originalScore: number, normalizedScore: number): any {
+  private updateExplanation(
+    explanation: SearchExplanation | undefined,
+    originalScore: number,
+    normalizedScore: number
+  ): SearchExplanation | undefined {
     if (!explanation) return undefined;
 
     return {


### PR DESCRIPTION
## Summary
- Replace deprecated `message.getType()` with `message.type` in `BedrockChatModel`
- Type `docToSave` as `OramaDocument` and `explanation` as `SearchExplanation` instead of `any`
- Extract a typed `fallbackMetadata: Record<string, unknown>` to avoid the union-with-`any` warning on the streaming fallback chunk

## Test plan
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] Verify IDE no longer reports the four "any overrides all other types" warnings or the `getType` deprecation

🤖 Generated with [Claude Code](https://claude.com/claude-code)