### PR TITLE
fix(quick-ask): provide AppContext to overlay panel

### DIFF
--- a/src/components/quick-ask/QuickAskOverlay.tsx
+++ b/src/components/quick-ask/QuickAskOverlay.tsx
@@ -12,6 +12,7 @@ import React from "react";
 import { createRoot, Root } from "react-dom/client";
 import { updateDynamicStyleClass, clearDynamicStyleClass } from "@/utils/dom/dynamicStyleManager";
 import { QuickAskPanel } from "./QuickAskPanel";
+import { AppContext } from "@/context";
 import type CopilotPlugin from "@/main";
 import type { ReplaceGuard } from "@/editor/replaceGuard";
 import type { ResizeDirection } from "@/hooks/use-resizable";
@@ -239,17 +240,19 @@ export class QuickAskOverlay {
     }
 
     this.root.render(
-      <QuickAskPanel
-        plugin={this.options.plugin}
-        editor={this.options.editor}
-        view={this.options.view}
-        selectedText={this.options.selectedText}
-        replaceGuard={this.options.replaceGuard}
-        onClose={this.closeWithAnimation}
-        onDragOffset={this.handleDragOffset}
-        onResizeStart={this.handleResizeStart}
-        hasCustomHeight={this.hasUserResizedHeight}
-      />
+      <AppContext.Provider value={this.options.plugin.app}>
+        <QuickAskPanel
+          plugin={this.options.plugin}
+          editor={this.options.editor}
+          view={this.options.view}
+          selectedText={this.options.selectedText}
+          replaceGuard={this.options.replaceGuard}
+          onClose={this.closeWithAnimation}
+          onDragOffset={this.handleDragOffset}
+          onResizeStart={this.handleResizeStart}
+          hasCustomHeight={this.hasUserResizedHeight}
+        />
+      </AppContext.Provider>
     );
   }
 


### PR DESCRIPTION
## Summary
- Opening Quick Ask crashed with `useApp() called outside of an <AppContext.Provider>` because `QuickAskOverlay` mounts its own React root via `createRoot` without providing `AppContext`. The at-mention plugin transitively calls `useApp()` via `useOpenWebTabs`.
- Wrap the rendered `QuickAskPanel` in `<AppContext.Provider value={plugin.app}>`, matching how `CopilotView` provides the context for the main chat root.

## Test plan
- [ ] Open Quick Ask on a note and confirm the panel mounts without console errors.
- [ ] Trigger `@` mentions and verify category/search results (including Web Tabs on desktop) render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)