### PR TITLE
style(css): expand #ccc to 6-digit hex format for consistency

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -522,11 +522,11 @@ If your plugin does not need CSS, delete this file.
 }
 
 .switch.disabled input:checked + .slider {
-  background-color: #ccc;
+  background-color: #cccccc;
 }
 
 .switch.disabled input:focus + .slider {
-  box-shadow: 0 0 1px #ccc;
+  box-shadow: 0 0 1px #cccccc;
 }
 
 .switch.disabled input:checked + .slider:before {
@@ -561,7 +561,7 @@ If your plugin does not need CSS, delete this file.
   padding: 8px;
   font-size: 14px;
   line-height: 1.5;
-  border: 1px solid #ccc;
+  border: 1px solid #cccccc;
   border-radius: 4px;
   resize: vertical;
   overflow-y: hidden;


### PR DESCRIPTION
## Summary
- Expand three `#ccc` shorthand color values in `src/styles/tailwind.css` to the full 6-digit `#cccccc` form for consistency with the rest of the stylesheet.

## Test plan
- [ ] Visual check of disabled switch and edit-textarea — appearance unchanged.