### PR TITLE
fix(bedrock): explain inference-profile requirement when AWS rejects on-demand model ID

### DIFF
--- a/src/LLMProviders/BedrockChatModel.test.ts
+++ b/src/LLMProviders/BedrockChatModel.test.ts
@@ -739,4 +739,30 @@ describe("BedrockChatModel inference-profile error rewriting", () => {
       /Amazon Bedrock request failed with status 500/
     );
   });
+
+  it("rewrites the error even when AWS uses a curly apostrophe in 'isn’t supported'", async () => {
+    const curlyApostropheBody = JSON.stringify({
+      message:
+        "Invocation of model ID anthropic.claude-sonnet-4-5 with on-demand throughput isn’t supported. Retry your request with the ID or ARN of an inference profile that contains this model.",
+    });
+    const fetchMock = jest.fn().mockResolvedValue(makeErrorResponse(400, curlyApostropheBody));
+    const model = createModelWithFetch(fetchMock, { noStream: true });
+
+    const messages = [{ content: "hi", getType: () => "human", type: "human" }];
+    await expect(model._generate(messages as never, {})).rejects.toThrow(
+      /cross-region inference profile ID/
+    );
+  });
+
+  it("uses the provider segment from the bare model ID in the prefix guidance", async () => {
+    const nonAnthropicBody = JSON.stringify({
+      message:
+        "Invocation of model ID meta.llama4-maverick-17b with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model.",
+    });
+    const fetchMock = jest.fn().mockResolvedValue(makeErrorResponse(400, nonAnthropicBody));
+    const model = createModelWithFetch(fetchMock, { noStream: true });
+
+    const messages = [{ content: "hi", getType: () => "human", type: "human" }];
+    await expect(model._generate(messages as never, {})).rejects.toThrow(/global\.meta\.<id>/);
+  });
 });

--- a/src/LLMProviders/BedrockChatModel.test.ts
+++ b/src/LLMProviders/BedrockChatModel.test.ts
@@ -89,6 +89,24 @@ const createModel = (enableThinking = false): BedrockChatModel =>
     fetchImplementation: jest.fn(),
   });
 
+const createModelWithFetch = (
+  fetchMock: jest.Mock,
+  opts?: { modelId?: string; noStream?: boolean }
+): BedrockChatModel =>
+  new BedrockChatModel({
+    modelId: opts?.modelId ?? "anthropic.claude-sonnet-4-5-20250929-v1:0",
+    apiKey: "test-key",
+    endpoint: "https://example.com/model/anthropic.claude-sonnet-4-5-20250929-v1%3A0/invoke",
+    ...(opts?.noStream
+      ? {}
+      : {
+          streamEndpoint:
+            "https://example.com/model/anthropic.claude-sonnet-4-5-20250929-v1%3A0/invoke-with-response-stream",
+        }),
+    anthropicVersion: "bedrock-2023-05-31",
+    fetchImplementation: fetchMock,
+  });
+
 describe("BedrockChatModel streaming decode", () => {
   it("decodes simple base64 JSON payloads", () => {
     const payload = JSON.stringify({
@@ -655,5 +673,70 @@ describe("BedrockChatModel streaming decode", () => {
         expect(requestBody.messages[0].content[1].type).toBe("image");
       });
     });
+  });
+});
+
+describe("BedrockChatModel inference-profile error rewriting", () => {
+  const awsInferenceProfileError = JSON.stringify({
+    message:
+      "Invocation of model ID anthropic.claude-sonnet-4-5 with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model.",
+  });
+
+  const makeErrorResponse = (status: number, body: string): Response =>
+    ({
+      ok: false,
+      status,
+      text: () => Promise.resolve(body),
+    }) as unknown as Response;
+
+  it("rewrites 400 inference-profile error in non-streaming path to actionable message", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeErrorResponse(400, awsInferenceProfileError));
+    const model = createModelWithFetch(fetchMock, { noStream: true });
+
+    const messages = [{ content: "hi", getType: () => "human", type: "human" }];
+    await expect(model._generate(messages as never, {})).rejects.toThrow(
+      /cross-region inference profile ID/
+    );
+  });
+
+  it("rewrites 400 inference-profile error in streaming path to actionable message", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeErrorResponse(400, awsInferenceProfileError));
+    const model = createModelWithFetch(fetchMock);
+
+    const messages = [{ content: "hi", getType: () => "human", type: "human" }];
+    const gen = model._streamResponseChunks(messages as never, {});
+    await expect(gen.next()).rejects.toThrow(/cross-region inference profile ID/);
+  });
+
+  it("includes the bare model ID in the rewritten message", async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeErrorResponse(400, awsInferenceProfileError));
+    const model = createModelWithFetch(fetchMock, { noStream: true });
+
+    const messages = [{ content: "hi", getType: () => "human", type: "human" }];
+    await expect(model._generate(messages as never, {})).rejects.toThrow(
+      /anthropic\.claude-sonnet-4-5/
+    );
+  });
+
+  it("does not rewrite a 400 error that is unrelated to inference profiles", async () => {
+    const genericBody = JSON.stringify({ message: "ValidationException: bad request" });
+    const fetchMock = jest.fn().mockResolvedValue(makeErrorResponse(400, genericBody));
+    const model = createModelWithFetch(fetchMock, { noStream: true });
+
+    const messages = [{ content: "hi", getType: () => "human", type: "human" }];
+    await expect(model._generate(messages as never, {})).rejects.toThrow(
+      /Amazon Bedrock request failed with status 400/
+    );
+  });
+
+  it("does not rewrite non-400 errors", async () => {
+    const body = JSON.stringify({ message: "Internal Server Error" });
+    const fetchMock = jest.fn().mockResolvedValue(makeErrorResponse(500, body));
+    const model = createModelWithFetch(fetchMock, { noStream: true });
+
+    const messages = [{ content: "hi", getType: () => "human", type: "human" }];
+    await expect(model._generate(messages as never, {})).rejects.toThrow(
+      /Amazon Bedrock request failed with status 500/
+    );
   });
 });

--- a/src/LLMProviders/BedrockChatModel.ts
+++ b/src/LLMProviders/BedrockChatModel.ts
@@ -44,25 +44,34 @@ export interface BedrockChatModelFields extends BaseChatModelParams {
 /**
  * Rewrites Bedrock HTTP error messages into actionable text when possible.
  * Falls back to the original "Amazon Bedrock ... failed with status N: body" form.
+ *
+ * The detection uses two stable substrings from the AWS ValidationException body
+ * ("on-demand throughput" and "inference profile") rather than the apostrophe-bearing
+ * phrase "isn't supported", because AWS has been observed serving both straight (')
+ * and curly (’) apostrophe variants. False positives are harmless: the rewritten
+ * message still names the bare model ID from the original body.
  */
 function rewriteBedrockErrorMessage(status: number, body: string, streaming = false): string {
   const prefix = streaming
     ? "Amazon Bedrock streaming request failed with status"
     : "Amazon Bedrock request failed with status";
 
-  if (status === 400) {
-    // Stable AWS error sentinel — matched on substring because the error shape is
-    // documented and unlikely to change.
-    if (body.includes("isn't supported") && body.includes("inference profile")) {
-      const modelIdMatch = body.match(/model ID ([^\s]+) with/);
-      const bareId = modelIdMatch?.[1] ?? "<model-id>";
-      return (
-        `This Bedrock model requires a cross-region inference profile ID, not a bare regional model ID. ` +
-        `Update the model name in Settings → Models to use one of the prefixed forms: ` +
-        `global.anthropic.<id> (recommended), us.anthropic.<id>, eu.anthropic.<id>, or apac.anthropic.<id>. ` +
-        `The current value "${bareId}" is not accepted by AWS on-demand throughput.`
-      );
-    }
+  if (
+    status === 400 &&
+    body.includes("on-demand throughput") &&
+    body.includes("inference profile")
+  ) {
+    const modelIdMatch = body.match(/model ID ([^\s]+) with/);
+    const bareId = modelIdMatch?.[1] ?? "<model-id>";
+    // Provider segment of the model ID (e.g. "anthropic" from "anthropic.claude-...").
+    // Falls back to a generic placeholder when the ID isn't in <provider>.<model> form.
+    const providerSegment = bareId.includes(".") ? bareId.split(".")[0] : "<provider>";
+    return (
+      `This Bedrock model requires a cross-region inference profile ID, not a bare regional model ID. ` +
+      `Update the model name in Settings → Models to use one of the prefixed forms: ` +
+      `global.${providerSegment}.<id> (recommended), us.${providerSegment}.<id>, eu.${providerSegment}.<id>, or apac.${providerSegment}.<id>. ` +
+      `The current value "${bareId}" is not accepted by AWS on-demand throughput.`
+    );
   }
 
   return `${prefix} ${status}: ${body}`;
@@ -168,10 +177,13 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
     return tools.map((tool) => {
       let inputSchema: Record<string, unknown> = { type: "object", properties: {} };
       if (tool.schema) {
-        // Use LangChain's schema conversion utilities
-        inputSchema = isInteropZodSchema(tool.schema)
+        // Use LangChain's schema conversion utilities. The result is cast via `unknown`
+        // because `toJsonSchema` returns a `JsonSchema7Type` union without an index
+        // signature, which TypeScript cannot directly assign to `Record<string, unknown>`.
+        const converted: unknown = isInteropZodSchema(tool.schema)
           ? toJsonSchema(tool.schema)
           : tool.schema;
+        inputSchema = converted as Record<string, unknown>;
       }
       return {
         name: tool.name,

--- a/src/LLMProviders/BedrockChatModel.ts
+++ b/src/LLMProviders/BedrockChatModel.ts
@@ -42,6 +42,33 @@ export interface BedrockChatModelFields extends BaseChatModelParams {
 }
 
 /**
+ * Rewrites Bedrock HTTP error messages into actionable text when possible.
+ * Falls back to the original "Amazon Bedrock ... failed with status N: body" form.
+ */
+function rewriteBedrockErrorMessage(status: number, body: string, streaming = false): string {
+  const prefix = streaming
+    ? "Amazon Bedrock streaming request failed with status"
+    : "Amazon Bedrock request failed with status";
+
+  if (status === 400) {
+    // Stable AWS error sentinel — matched on substring because the error shape is
+    // documented and unlikely to change.
+    if (body.includes("isn't supported") && body.includes("inference profile")) {
+      const modelIdMatch = body.match(/model ID ([^\s]+) with/);
+      const bareId = modelIdMatch?.[1] ?? "<model-id>";
+      return (
+        `This Bedrock model requires a cross-region inference profile ID, not a bare regional model ID. ` +
+        `Update the model name in Settings → Models to use one of the prefixed forms: ` +
+        `global.anthropic.<id> (recommended), us.anthropic.<id>, eu.anthropic.<id>, or apac.anthropic.<id>. ` +
+        `The current value "${bareId}" is not accepted by AWS on-demand throughput.`
+      );
+    }
+  }
+
+  return `${prefix} ${status}: ${body}`;
+}
+
+/**
  * Lightweight ChatModel integration for Amazon Bedrock using a simple API key header.
  * This implementation issues JSON requests against the public Bedrock runtime endpoint.
  */
@@ -142,9 +169,9 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
       let inputSchema: Record<string, unknown> = { type: "object", properties: {} };
       if (tool.schema) {
         // Use LangChain's schema conversion utilities
-        inputSchema = (
-          isInteropZodSchema(tool.schema) ? toJsonSchema(tool.schema) : tool.schema
-        ) as Record<string, unknown>;
+        inputSchema = isInteropZodSchema(tool.schema)
+          ? toJsonSchema(tool.schema)
+          : tool.schema;
       }
       return {
         name: tool.name,
@@ -198,7 +225,7 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(`Amazon Bedrock request failed with status ${response.status}: ${errorText}`);
+      throw new Error(rewriteBedrockErrorMessage(response.status, errorText));
     }
 
     const data = (await response.json()) as Record<string, unknown>;
@@ -280,9 +307,7 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(
-        `Amazon Bedrock streaming request failed with status ${response.status}: ${errorText}`
-      );
+      throw new Error(rewriteBedrockErrorMessage(response.status, errorText, true));
     }
 
     if (!response.body) {


### PR DESCRIPTION
## Summary

- When a user configures a bare regional Bedrock model ID (e.g. `anthropic.claude-sonnet-4-6`) without a cross-region prefix, AWS returns a 400 with: _"Invocation of model ID anthropic.claude-sonnet-4-6 with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model."_
- Today this surfaces as raw JSON in the chat error, giving users no guidance on what to change.
- This PR rewrites that specific 400 into an actionable one-liner pointing to Settings → Models and listing the four valid prefix forms.

## Before / After

**Before:**
```
Amazon Bedrock streaming request failed with status 400: {"message":"Invocation of model ID anthropic.claude-sonnet-4-6 with on-demand throughput isn't supported. Retry your request with the ID or ARN of an inference profile that contains this model."}
```

**After:**
```
This Bedrock model requires a cross-region inference profile ID, not a bare regional model ID. Update the model name in Settings → Models to use one of the prefixed forms: global.anthropic.<id> (recommended), us.anthropic.<id>, eu.anthropic.<id>, or apac.anthropic.<id>. The current value "anthropic.claude-sonnet-4-6" is not accepted by AWS on-demand throughput.
```

## Notes

- UX-only fix — no change to API behavior, retry logic, or model-add UI.
- AGENTS.md already documents the inference-profile preference, but users see it only when adding a model, not when the request fails.
- Both streaming and non-streaming error paths are covered via a shared `rewriteBedrockErrorMessage` helper.
- Non-matching 400s and all non-400 errors pass through unchanged.

## Test plan

- [ ] Unit tests in `BedrockChatModel.test.ts` cover: matching 400 (non-streaming) → rewritten; matching 400 (streaming) → rewritten; bare model ID extracted and included; unrelated 400 → original form; 500 → original form.
- Manual reproduction requires a real AWS Bedrock account with a bare model ID — skipped in CI.