### PR TITLE
fix(chain): stop writing chainType back inside setChain (apply-Plus freeze)

### DIFF
--- a/scripts/test-vault.sh
+++ b/scripts/test-vault.sh
@@ -49,13 +49,28 @@ PLUGIN_DIR="$VAULT_PATH/.obsidian/plugins/$PLUGIN_ID"
 mkdir -p "$PLUGIN_DIR"
 
 echo "==> Linking artifacts into $PLUGIN_DIR"
-for f in main.js manifest.json styles.css; do
+for f in main.js styles.css; do
   if [[ ! -f "$WORKTREE_ROOT/$f" ]]; then
     echo "error: expected build artifact missing: $WORKTREE_ROOT/$f" >&2
     exit 1
   fi
   ln -sfn "$WORKTREE_ROOT/$f" "$PLUGIN_DIR/$f"
 done
+
+# Write a branch- and timestamp-tagged manifest.json (real file, not a symlink)
+# so Obsidian's Community plugins list visibly reflects which worktree/branch
+# is loaded and when this build was deployed.
+BRANCH="$(git -C "$WORKTREE_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+BUILD_TS="$(date +%Y%m%d-%H%M%S)"
+echo "==> Writing branch-tagged manifest.json (branch: $BRANCH, build: $BUILD_TS)"
+rm -f "$PLUGIN_DIR/manifest.json"
+SRC="$WORKTREE_ROOT/manifest.json" DEST="$PLUGIN_DIR/manifest.json" BRANCH="$BRANCH" BUILD_TS="$BUILD_TS" node -e '
+  const fs = require("fs");
+  const m = JSON.parse(fs.readFileSync(process.env.SRC, "utf8"));
+  m.name = m.name + " [" + process.env.BRANCH + " @ " + process.env.BUILD_TS + "]";
+  m.description = "[branch: " + process.env.BRANCH + " | build: " + process.env.BUILD_TS + "] " + m.description;
+  fs.writeFileSync(process.env.DEST, JSON.stringify(m, null, 2) + "\n");
+'
 
 echo "==> Reloading plugin in Obsidian"
 if [[ ! -x "$OBSIDIAN_BIN" ]]; then
@@ -70,5 +85,7 @@ fi
 echo
 echo "Done."
 echo "  worktree: $WORKTREE_ROOT"
+echo "  branch:   $BRANCH"
+echo "  build:    $BUILD_TS"
 echo "  vault:    $VAULT_PATH"
 echo "  plugin:   $PLUGIN_ID"

--- a/src/LLMProviders/chainManager.ts
+++ b/src/LLMProviders/chainManager.ts
@@ -143,11 +143,13 @@ export default class ChainManager {
         this.pendingModelError = null;
       }
 
-      // Chain-type housekeeping. Inlined (was once a separate `setChain` method)
-      // because it does NOT actually set chain type — the atom is owned by the
-      // caller (UI dropdowns / `applyPlusSettings`). Writing the captured local
-      // `chainType` back to the atom here is what caused an infinite
-      // stale-closure bounce on apply-Plus-key. See chainManager.test.ts.
+      // Chain-type housekeeping. Do NOT write `chainType` back to the atom —
+      // the atom is owned by the UI dropdowns and `applyPlusSettings`. The
+      // captured local `chainType` may already be stale by the time we reach
+      // here (we just awaited `setChatModel(...)`), and writing it back used
+      // to create a self-sustaining `setChainType` → ProjectManager
+      // subscriber → `createChainWithNewModel` loop that froze Obsidian on
+      // apply-Plus-key.
       if (this.chatModelManager.validateChatModel(this.chatModelManager.getChatModel())) {
         this.validateChainType(chainType);
         if (options.refreshIndex) {

--- a/src/LLMProviders/chainManager.ts
+++ b/src/LLMProviders/chainManager.ts
@@ -1,10 +1,4 @@
-import {
-  getChainType,
-  getCurrentProject,
-  getModelKey,
-  SetChainOptions,
-  setChainType,
-} from "@/aiParams";
+import { getChainType, getCurrentProject, getModelKey, SetChainOptions } from "@/aiParams";
 import { ChainType } from "@/chainType";
 import { BUILTIN_CHAT_MODELS, USER_SENDER } from "@/constants";
 import {
@@ -149,28 +143,27 @@ export default class ChainManager {
         this.pendingModelError = null;
       }
 
-      await this.setChain(chainType, options);
+      // Chain-type housekeeping. Inlined (was once a separate `setChain` method)
+      // because it does NOT actually set chain type — the atom is owned by the
+      // caller (UI dropdowns / `applyPlusSettings`). Writing the captured local
+      // `chainType` back to the atom here is what caused an infinite
+      // stale-closure bounce on apply-Plus-key. See chainManager.test.ts.
+      if (this.chatModelManager.validateChatModel(this.chatModelManager.getChatModel())) {
+        this.validateChainType(chainType);
+        if (options.refreshIndex) {
+          await this.refreshVaultIndex();
+        }
+      } else {
+        console.error(
+          "createChainWithNewModel: skipping chain-type housekeeping — no chat model set."
+        );
+      }
       logInfo(`Setting model to ${newModelKey}`);
     } catch (error) {
       this.pendingModelError = error instanceof Error ? error : new Error(String(error));
       logError(`createChainWithNewModel failed: ${error}`);
       logInfo(`modelKey: ${newModelKey || getModelKey()}`);
     }
-  }
-
-  async setChain(chainType: ChainType, options: SetChainOptions = {}): Promise<void> {
-    if (!this.chatModelManager.validateChatModel(this.chatModelManager.getChatModel())) {
-      console.error("setChain failed: No chat model set.");
-      return;
-    }
-
-    this.validateChainType(chainType);
-
-    if (options.refreshIndex) {
-      await this.refreshVaultIndex();
-    }
-
-    setChainType(chainType);
   }
 
   private getChainRunner(): ChainRunner {


### PR DESCRIPTION
## Summary

- **Fix the apply-Plus-key freeze.** Inlined the (single-caller, misnamed) `setChain` into `createChainWithNewModel` and dropped its redundant `setChainType(chainType)` write-back. Root cause: multiple concurrent `createChainWithNewModel` invocations (from the constructor's `initialize()` plus the settings/model-key/chain-type subscribers that fire on `applyPlusSettings`) each captured `chainType` locally, awaited `setChatModel(...)`, then resumed with stale values and wrote them back via `setChain` → `setChainType`. That re-fired the chain-type subscriber in `ProjectManager`, scheduling another stale-closure rebuild — `chainTypeAtom` bounced indefinitely between `LLM_CHAIN` and `COPILOT_PLUS_CHAIN` and Obsidian froze.
- **Dev experience: tag the deployed manifest.** `npm run test:vault` now writes a real `manifest.json` (not a symlink) with the current git branch and `yyyymmdd-HHMMSS` build timestamp baked into `name` and `description`, so "is my latest build actually loaded?" is a glance at Obsidian's Community plugins list instead of a guess.

## Test plan

- [x] `npm test` — full unit suite passes (2123 tests).
- [x] Manual: apply Copilot Plus key in test vault on the deployed build — no freeze; one `Setting model to copilot-plus-flash|copilot-plus` log; UI remains responsive.
- [x] Manual: switch chain types via UI dropdown — no loop.
- [x] Manual: cold start with Plus already applied — single startup rebuild; no extra fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)