### PR TITLE
fix(agent-mode): make binary auto-detect work under Obsidian's sparse GUI PATH

### DIFF
--- a/src/agentMode/acp/nodeShebangPath.ts
+++ b/src/agentMode/acp/nodeShebangPath.ts
@@ -1,5 +1,7 @@
 import * as path from "node:path";
 
+import { WELL_KNOWN_BIN_DIRS, mergePath } from "@/utils/binaryPath";
+
 /**
  * macOS GUI apps (Obsidian) inherit a minimal PATH that omits Homebrew and
  * common Node installer locations. Adapters that ship as `#!/usr/bin/env
@@ -14,22 +16,5 @@ export function augmentPathForNodeShebang(
   binaryPath: string,
   inherited: string | undefined
 ): string {
-  const sep = process.platform === "win32" ? ";" : ":";
-  const candidates = [
-    path.dirname(binaryPath),
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
-    "/usr/bin",
-    "/bin",
-  ];
-  const inheritedParts = (inherited ?? "").split(sep).filter(Boolean);
-  const seen = new Set<string>();
-  const merged: string[] = [];
-  for (const p of [...candidates, ...inheritedParts]) {
-    if (!seen.has(p)) {
-      seen.add(p);
-      merged.push(p);
-    }
-  }
-  return merged.join(sep);
+  return mergePath([path.dirname(binaryPath), ...WELL_KNOWN_BIN_DIRS], inherited);
 }

--- a/src/agentMode/backends/claude/ClaudeSettingsPanel.tsx
+++ b/src/agentMode/backends/claude/ClaudeSettingsPanel.tsx
@@ -7,7 +7,12 @@ import { validateExecutableFile } from "@/utils/detectBinary";
 import type { App } from "obsidian";
 import { Notice } from "obsidian";
 import React from "react";
-import { CLAUDE_INSTALL_COMMAND, resolveClaudeCliPath, updateClaudeFields } from "./descriptor";
+import {
+  CLAUDE_INSTALL_COMMAND,
+  detectClaudeCliPath,
+  resolveClaudeCliPath,
+  updateClaudeFields,
+} from "./descriptor";
 
 interface Props {
   plugin: CopilotPlugin;
@@ -122,9 +127,10 @@ export const ClaudeSettingsPanel: React.FC<Props> = () => {
           binaryName="claude"
           placeholder="/absolute/path/to/claude"
           initialPath={overridePath}
-          notFoundHint={`claude not found on PATH. Install with \`${CLAUDE_INSTALL_COMMAND}\` and try again.`}
+          notFoundHint={`claude not found on disk. Install with \`${CLAUDE_INSTALL_COMMAND}\` and try again, or paste a custom path manually.`}
           onSave={onSaveCustomPath}
           persistOnAutoDetect
+          detect={() => Promise.resolve(detectClaudeCliPath())}
         />
       </SettingItem>
 

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -61,14 +61,12 @@ const claudeWire: ModelWireCodec = {
 };
 
 /**
- * Resolve the `claude` CLI path from settings + auto-detection. Mirrors the
- * `getInstallState` logic: explicit override wins, otherwise the resolver
- * walks Volta/asdf/NVM/Homebrew/npm-global.
+ * Build the environment input shared by both override-aware resolution and
+ * fresh auto-detection. Pulls `os.homedir()`, `process.platform`, and a
+ * minimal env subset that the resolver consults for Volta/NVM/npm-global.
  */
-export function resolveClaudeCliPath(settings: CopilotSettings): string | null {
-  const override = settings.agentMode?.claudeCli?.path;
-  return resolveClaudeBinary({
-    override,
+function claudeResolverEnv(): Omit<Parameters<typeof resolveClaudeBinary>[0], "override"> {
+  return {
     homeDir: os.homedir(),
     platform: process.platform,
     env: {
@@ -80,7 +78,29 @@ export function resolveClaudeCliPath(settings: CopilotSettings): string | null {
       existsSync: (p) => fs.existsSync(p),
       readFileSync: (p, encoding) => fs.readFileSync(p, encoding),
     },
+  };
+}
+
+/**
+ * Resolve the `claude` CLI path from settings + auto-detection. Mirrors the
+ * `getInstallState` logic: explicit override wins, otherwise the resolver
+ * walks Volta/asdf/NVM/Homebrew/npm-global.
+ */
+export function resolveClaudeCliPath(settings: CopilotSettings): string | null {
+  return resolveClaudeBinary({
+    override: settings.agentMode?.claudeCli?.path,
+    ...claudeResolverEnv(),
   });
+}
+
+/**
+ * Run a fresh auto-detect, ignoring any previously saved override. Used by
+ * the settings panel's "Auto-detect" button so users get the resolver's full
+ * candidate list (Volta/asdf/NVM/Homebrew/npm-global/`~/.local/bin`) instead
+ * of the generic `which`-based fallback that only sees `PATH`.
+ */
+export function detectClaudeCliPath(): string | null {
+  return resolveClaudeBinary({ override: undefined, ...claudeResolverEnv() });
 }
 
 /**

--- a/src/components/agent/BinaryPathSetting.tsx
+++ b/src/components/agent/BinaryPathSetting.tsx
@@ -15,6 +15,13 @@ interface Props {
   onSave: (path: string) => Promise<string | null>;
   /** When true, a successful auto-detect immediately invokes `onSave`. */
   persistOnAutoDetect?: boolean;
+  /**
+   * Custom detector. Used when the backend has a richer install lookup than
+   * a generic `which`/`where` PATH search — e.g. Claude knows about
+   * `~/.local/bin/claude`, Volta, asdf, NVM. Falls back to
+   * {@link detectBinary} when omitted.
+   */
+  detect?: () => Promise<string | null>;
 }
 
 /**
@@ -31,6 +38,7 @@ export const BinaryPathSetting: React.FC<Props> = ({
   notFoundHint,
   onSave,
   persistOnAutoDetect = false,
+  detect,
 }) => {
   const [pathInput, setPathInput] = React.useState(initialPath);
   const [error, setError] = React.useState<string | null>(null);
@@ -59,7 +67,7 @@ export const BinaryPathSetting: React.FC<Props> = ({
     setBusy(true);
     setError(null);
     try {
-      const found = await detectBinary(binaryName);
+      const found = detect ? await detect() : await detectBinary(binaryName);
       if (!found) {
         setError(
           notFoundHint ??
@@ -82,7 +90,7 @@ export const BinaryPathSetting: React.FC<Props> = ({
     } finally {
       setBusy(false);
     }
-  }, [binaryName, busy, notFoundHint, onSave, persistOnAutoDetect]);
+  }, [binaryName, busy, notFoundHint, onSave, persistOnAutoDetect, detect]);
 
   return (
     <div className="tw-flex tw-w-full tw-flex-col tw-gap-2 sm:tw-w-[360px]">

--- a/src/utils/binaryPath.test.ts
+++ b/src/utils/binaryPath.test.ts
@@ -1,0 +1,36 @@
+import { augmentPathForDetection, mergePath, WELL_KNOWN_BIN_DIRS } from "./binaryPath";
+
+describe("mergePath", () => {
+  test("prepends candidates and dedupes against inherited PATH", () => {
+    const result = mergePath(["/opt/homebrew/bin", "/usr/local/bin"], "/usr/bin:/bin");
+    expect(result).toBe("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin");
+  });
+
+  test("drops duplicates while preserving first-seen order", () => {
+    const result = mergePath(["/opt/homebrew/bin", "/usr/bin"], "/usr/bin:/bin:/opt/homebrew/bin");
+    expect(result).toBe("/opt/homebrew/bin:/usr/bin:/bin");
+  });
+
+  test("handles undefined / empty inherited PATH", () => {
+    expect(mergePath(["/opt/homebrew/bin"], undefined)).toBe("/opt/homebrew/bin");
+    expect(mergePath(["/opt/homebrew/bin"], "")).toBe("/opt/homebrew/bin");
+  });
+});
+
+describe("augmentPathForDetection", () => {
+  test("prepends all well-known dirs ahead of the inherited PATH", () => {
+    const result = augmentPathForDetection("/usr/bin:/bin");
+    const parts = result.split(":");
+    for (const dir of WELL_KNOWN_BIN_DIRS) {
+      expect(parts).toContain(dir);
+    }
+    // Homebrew must come before whatever launchd already had.
+    expect(parts.indexOf("/opt/homebrew/bin")).toBeLessThan(parts.indexOf("/usr/bin"));
+  });
+
+  test("covers the sparse launchd PATH that triggers the bug", () => {
+    // This is the exact PATH Obsidian sees when launched from Finder/Dock.
+    const result = augmentPathForDetection("/usr/bin:/bin:/usr/sbin:/sbin");
+    expect(result.split(":")).toContain("/opt/homebrew/bin");
+  });
+});

--- a/src/utils/binaryPath.ts
+++ b/src/utils/binaryPath.ts
@@ -1,0 +1,46 @@
+/**
+ * Well-known POSIX install prefixes that macOS GUI apps' inherited PATH
+ * typically omits. Shared between spawn-time PATH augmentation (so
+ * `#!/usr/bin/env node` shebangs resolve) and detect-time PATH augmentation
+ * (so `which <binary>` finds Homebrew / npm-global installs).
+ *
+ * macOS GUI apps launched from Finder/Dock get a sparse PATH from `launchd`
+ * (typically `/usr/bin:/bin:/usr/sbin:/sbin`) and do NOT inherit the user's
+ * shell rc PATH.
+ */
+export const WELL_KNOWN_BIN_DIRS = [
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  "/usr/bin",
+  "/bin",
+] as const;
+
+const PATH_SEPARATOR = process.platform === "win32" ? ";" : ":";
+
+/**
+ * Merge `candidates` with the inherited PATH, deduping while preserving
+ * order. Candidates are prepended so they take priority over whatever the
+ * GUI shell already had.
+ */
+export function mergePath(candidates: readonly string[], inherited: string | undefined): string {
+  const inheritedParts = (inherited ?? "").split(PATH_SEPARATOR).filter(Boolean);
+  const seen = new Set<string>();
+  const merged: string[] = [];
+  for (const p of [...candidates, ...inheritedParts]) {
+    if (!seen.has(p)) {
+      seen.add(p);
+      merged.push(p);
+    }
+  }
+  return merged.join(PATH_SEPARATOR);
+}
+
+/**
+ * Augment PATH for the *detection* step, where we don't yet know the
+ * binary's location. Prepends {@link WELL_KNOWN_BIN_DIRS} to the inherited
+ * PATH so `which <name>` invoked from a macOS GUI app finds Homebrew /
+ * `/usr/local/bin` installs that `launchd`'s sparse default PATH omits.
+ */
+export function augmentPathForDetection(inherited: string | undefined): string {
+  return mergePath(WELL_KNOWN_BIN_DIRS, inherited);
+}

--- a/src/utils/detectBinary.test.ts
+++ b/src/utils/detectBinary.test.ts
@@ -1,0 +1,113 @@
+import { promisify } from "node:util";
+
+import { detectBinary } from "./detectBinary";
+
+type ExecFileCallback = (err: Error | null, stdout: string, stderr: string) => void;
+type ExecFileArgs = [
+  string,
+  readonly string[],
+  { timeout?: number; env?: NodeJS.ProcessEnv },
+  ExecFileCallback,
+];
+
+const execFileMock = jest.fn<void, ExecFileArgs>();
+
+jest.mock("node:child_process", () => {
+  const fn = (...args: ExecFileArgs): void => execFileMock(...args);
+  // `node:util.promisify` consults this symbol to resolve to `{ stdout, stderr }`.
+  // Without it the promisified call resolves to just `stdout`, which would
+  // then be destructured as `undefined` in detectBinary.
+  (fn as unknown as Record<symbol, unknown>)[promisify.custom] = (
+    cmd: string,
+    args: readonly string[],
+    options: { timeout?: number; env?: NodeJS.ProcessEnv }
+  ): Promise<{ stdout: string; stderr: string }> =>
+    new Promise((resolve, reject) => {
+      execFileMock(cmd, args, options, (err, stdout, stderr) => {
+        if (err) reject(err);
+        else resolve({ stdout, stderr });
+      });
+    });
+  return { execFile: fn };
+});
+
+describe("detectBinary", () => {
+  const originalPlatform = process.platform;
+  const originalPath = process.env.PATH;
+
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    process.env.PATH = originalPath;
+  });
+
+  function setPlatform(p: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", { value: p });
+  }
+
+  test("rejects binary names with invalid characters", async () => {
+    await expect(detectBinary("../evil")).rejects.toThrow(/Invalid binary name/);
+    await expect(detectBinary("a b")).rejects.toThrow(/Invalid binary name/);
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  test("posix: augments PATH with /opt/homebrew/bin and /usr/local/bin ahead of inherited PATH", async () => {
+    setPlatform("darwin");
+    // The sparse launchd PATH that triggers the bug on macOS GUI launches.
+    process.env.PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+      cb(null, "/opt/homebrew/bin/codex-acp\n", "")
+    );
+
+    const found = await detectBinary("codex-acp");
+    expect(found).toBe("/opt/homebrew/bin/codex-acp");
+
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = execFileMock.mock.calls[0];
+    expect(cmd).toBe("which");
+    expect(args).toEqual(["codex-acp"]);
+    expect(opts.env).toBeDefined();
+    const pathParts = (opts.env?.PATH ?? "").split(":");
+    expect(pathParts).toContain("/opt/homebrew/bin");
+    expect(pathParts).toContain("/usr/local/bin");
+    // Augmented dirs must precede whatever the GUI shell already had.
+    expect(pathParts.indexOf("/opt/homebrew/bin")).toBeLessThan(pathParts.indexOf("/usr/bin"));
+  });
+
+  test("windows: leaves PATH untouched and calls `where`", async () => {
+    setPlatform("win32");
+    process.env.PATH = "C:\\Windows\\System32;C:\\Windows";
+
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+      cb(null, "C:\\tools\\codex-acp.exe\r\n", "")
+    );
+
+    const found = await detectBinary("codex-acp");
+    expect(found).toBe("C:\\tools\\codex-acp.exe");
+
+    const [cmd, , opts] = execFileMock.mock.calls[0];
+    expect(cmd).toBe("where");
+    // On Windows we hand the inherited env through unchanged.
+    expect(opts.env).toBe(process.env);
+  });
+
+  test("returns null when the lookup tool exits non-zero", async () => {
+    setPlatform("darwin");
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+      cb(new Error("exit code 1"), "", "")
+    );
+    await expect(detectBinary("missing")).resolves.toBeNull();
+  });
+
+  test("returns only the first match when `which`/`where` print several", async () => {
+    setPlatform("darwin");
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+      cb(null, "/opt/homebrew/bin/codex-acp\n/usr/local/bin/codex-acp\n", "")
+    );
+    await expect(detectBinary("codex-acp")).resolves.toBe("/opt/homebrew/bin/codex-acp");
+  });
+});

--- a/src/utils/detectBinary.ts
+++ b/src/utils/detectBinary.ts
@@ -2,6 +2,8 @@ import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import { promisify } from "node:util";
 
+import { augmentPathForDetection } from "@/utils/binaryPath";
+
 const execFileAsync = promisify(execFile);
 
 /**
@@ -25,14 +27,25 @@ const BINARY_NAME_PATTERN = /^[A-Za-z0-9._+-]+$/;
  * Implementation deliberately uses `which` (POSIX) / `where` (Windows) rather
  * than parsing `PATH` ourselves so we honor the user's shell-equivalent
  * resolution rules (PATHEXT on Windows, symlink chasing, etc.).
+ *
+ * On POSIX we augment PATH with well-known install prefixes before invoking
+ * `which`. macOS GUI apps (Obsidian launched from Finder/Dock) inherit a
+ * sparse `launchd` PATH that omits `/opt/homebrew/bin` and `/usr/local/bin`,
+ * so user-installed binaries (Homebrew, `npm install -g`) would otherwise
+ * fail to detect. Windows GUI apps inherit the system PATH and don't need
+ * this.
  */
 export async function detectBinary(name: string): Promise<string | null> {
   if (!BINARY_NAME_PATTERN.test(name)) {
     throw new Error(`Invalid binary name: ${JSON.stringify(name)}`);
   }
-  const cmd = process.platform === "win32" ? "where" : "which";
+  const isWindows = process.platform === "win32";
+  const cmd = isWindows ? "where" : "which";
+  const env = isWindows
+    ? process.env
+    : { ...process.env, PATH: augmentPathForDetection(process.env.PATH) };
   try {
-    const { stdout } = await execFileAsync(cmd, [name], { timeout: 5000 });
+    const { stdout } = await execFileAsync(cmd, [name], { timeout: 5000, env });
     const first = stdout
       .split(/\r?\n/)
       .map((s) => s.trim())


### PR DESCRIPTION
## Summary
- Auto-detect for Codex / Claude / Opencode binaries silently failed in Agent Mode because macOS GUI apps launched from Finder/Dock inherit a minimal `launchd` PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that omits Homebrew and user install prefixes. `which codex-acp` returned nothing even when the binary was installed at `/opt/homebrew/bin/codex-acp`.
- Augmented PATH before invoking `which` with the same well-known prefixes already used at spawn time (`augmentPathForNodeShebang`), extracted into a shared `src/utils/binaryPath.ts` so detect-time and spawn-time stay in sync.
- For Claude, the "Auto-detect" button on the custom-path setting now routes through the existing `resolveClaudeBinary` resolver (`~/.claude/local`, `~/.local/bin`, Volta, asdf, NVM, Homebrew, npm-global) via a new optional `detect` prop on `BinaryPathSetting`, matching the candidate list the top status row already uses.
- New unit coverage for `mergePath`, `augmentPathForDetection`, and `detectBinary` (PATH augmentation on POSIX, Windows untouched, BINARY_NAME_PATTERN rejection, multi-line `which` output).

## Test plan
- [x] `npm run test` — 2741 unit tests pass
- [x] `npm run lint` — no new errors
- [ ] Manual: open Settings → Agent Mode → Codex / Claude → Auto-detect, confirm the resolved path appears (Codex at `/opt/homebrew/bin/codex-acp`, Claude at `~/.local/bin/claude`)