### PR TITLE
feat(agent-mode): enable by default on desktop, force off on mobile

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1021,7 +1021,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   autoCompactThreshold: 128000,
   convertedDocOutputFolder: DEFAULT_CONVERTED_DOC_OUTPUT_FOLDER,
   agentMode: {
-    enabled: false,
+    enabled: true,
     byok: {},
     mcpServers: [],
     activeBackend: "opencode",

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -182,7 +182,7 @@ describe("sanitizeSettings - agentMode shape migration", () => {
       agentMode: undefined as unknown as never,
     });
     expect(sanitized.agentMode).toEqual({
-      enabled: false,
+      enabled: true,
       byok: {},
       mcpServers: [],
       activeBackend: "opencode",

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -1,5 +1,6 @@
 import { CustomModel, ProjectConfig } from "@/aiParams";
 import { atom, createStore, useAtomValue } from "jotai";
+import { Platform } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 
 // Type-only import: `CopilotMode` and `ModelSelection` are owned by
@@ -812,10 +813,19 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
 /** Validate the agentMode slice. */
 function sanitizeAgentMode(raw: unknown): CopilotSettings["agentMode"] {
   if (!raw || typeof raw !== "object") {
-    return { ...DEFAULT_SETTINGS.agentMode };
+    return {
+      ...DEFAULT_SETTINGS.agentMode,
+      enabled: Platform.isMobile ? false : DEFAULT_SETTINGS.agentMode.enabled,
+    };
   }
   const r = raw as Record<string, unknown>;
-  const enabled = typeof r.enabled === "boolean" ? r.enabled : DEFAULT_SETTINGS.agentMode.enabled;
+  // Agent Mode requires subprocess support — force off on mobile regardless
+  // of what a synced desktop settings file says.
+  const enabled = Platform.isMobile
+    ? false
+    : typeof r.enabled === "boolean"
+      ? r.enabled
+      : DEFAULT_SETTINGS.agentMode.enabled;
   const byok =
     r.byok && typeof r.byok === "object"
       ? (r.byok as { anthropic?: string; openai?: string; google?: string })


### PR DESCRIPTION
## Summary
- Flip `DEFAULT_SETTINGS.agentMode.enabled` to `true` so new installs start with Agent Mode on.
- Force `enabled = false` inside `sanitizeAgentMode` whenever `Platform.isMobile`, so a desktop-synced settings file can't activate the subprocess-backed flow on mobile.
- Update the corresponding `sanitizeSettings` test expectation.

## Test plan
- [ ] Fresh desktop install: Agent Mode toggle is on by default in settings.
- [ ] Mobile vault with desktop-synced `agentMode.enabled: true`: still reports off; settings screen continues to show the "desktop only" message.
- [ ] `npm test -- model.test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)