### PR TITLE
Support agent image and PDF context

### DIFF
--- a/designdocs/todo/AGENT_MODE_TODOS.md
+++ b/designdocs/todo/AGENT_MODE_TODOS.md
@@ -43,6 +43,11 @@
     dropped before the prompt is built. Wire them into the
     `<copilot-context>` envelope (e.g. a `Web excerpts:` section with
     `title (url): content`) so the agent can actually read them.
+- [ ] P1: Move PDF parsing into an agent tool
+  - Inline PDF parsing during send can take too long and blocks the user
+    before the agent starts. Keep PDF attachments as vault paths for the
+    built-in Read tool for now, then expose Copilot PDF parsing as an
+    explicit tool the agent can call when it needs extracted PDF text.
 - [ ] P1: Token counter
   - To know how many context is left in the current session
   - Nice-to-have: Cost estimate

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -51,7 +51,7 @@ jest.mock("./effortOption", () => ({
   getCachedSdkCatalog: jest.fn(),
 }));
 
-import { ClaudeSdkBackendProcess } from "./ClaudeSdkBackendProcess";
+import { ClaudeSdkBackendProcess, promptInputToAnthropicContent } from "./ClaudeSdkBackendProcess";
 import { getCachedSdkCatalog } from "./effortOption";
 
 beforeEach(() => {
@@ -133,6 +133,86 @@ function getPromptQueryCalls(): unknown[][] {
     return opts?.cwd !== undefined;
   });
 }
+
+describe("promptInputToAnthropicContent", () => {
+  it("returns a plain string when the prompt is text-only", () => {
+    const result = promptInputToAnthropicContent({
+      sessionId: "s1",
+      prompt: [
+        { type: "text", text: "hello" },
+        { type: "text", text: "world" },
+      ],
+    });
+    expect(result).toBe("hello\nworld");
+  });
+
+  it("returns content blocks when an image is attached", () => {
+    const result = promptInputToAnthropicContent({
+      sessionId: "s1",
+      prompt: [
+        { type: "text", text: "describe" },
+        { type: "image", mimeType: "image/png", data: "aGVsbG8=" },
+      ],
+    });
+    expect(result).toEqual([
+      { type: "text", text: "describe" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "aGVsbG8=" },
+      },
+    ]);
+  });
+
+  it("normalizes jpg media types before sending image blocks", () => {
+    const result = promptInputToAnthropicContent({
+      sessionId: "s1",
+      prompt: [
+        { type: "text", text: "describe" },
+        { type: "image", mimeType: "image/jpg", data: "aGVsbG8=" },
+      ],
+    });
+    expect(result).toEqual([
+      { type: "text", text: "describe" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/jpeg", data: "aGVsbG8=" },
+      },
+    ]);
+  });
+
+  it("omits image media types Anthropic does not accept", () => {
+    const result = promptInputToAnthropicContent({
+      sessionId: "s1",
+      prompt: [
+        { type: "text", text: "describe" },
+        { type: "image", mimeType: "image/heic", data: "aGVsbG8=" },
+      ],
+    });
+    expect(result).toEqual([
+      { type: "text", text: "describe" },
+      { type: "text", text: "[Unsupported image attachment omitted: image/heic]" },
+    ]);
+  });
+
+  it("represents resource_link as a defensive text reference", () => {
+    const result = promptInputToAnthropicContent({
+      sessionId: "s1",
+      prompt: [
+        { type: "text", text: "see the doc" },
+        { type: "resource_link", uri: "vault://README.md", name: "README" },
+        { type: "image", mimeType: "image/jpeg", data: "ZmFrZQ==" },
+      ],
+    });
+    expect(result).toEqual([
+      { type: "text", text: "see the doc" },
+      { type: "text", text: "[Attached resource: README]" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/jpeg", data: "ZmFrZQ==" },
+      },
+    ]);
+  });
+});
 
 describe("ClaudeSdkBackendProcess.prompt happy path", () => {
   beforeEach(() => {

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -246,8 +246,8 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     // Streaming-input mode (AsyncIterable) is required to expose
     // interrupt/setModel/setPermissionMode on the returned Query — without it
     // those control calls reject with "only available in streaming input mode".
-    const promptText = extractPromptText(params);
-    const promptStream = makePromptStream(promptText, params.sessionId);
+    const messageContent = promptInputToAnthropicContent(params);
+    const promptStream = makePromptStream(messageContent, params.sessionId);
 
     this.bridge.setSessionContext(params.sessionId);
 
@@ -286,7 +286,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     logSdkOutbound(
       "prompt",
       {
-        prompt: promptText,
+        prompt: summarizePromptContent(messageContent),
         resume: options.resume ?? null,
         sessionIdSeed: options.sessionId ?? null,
         model: options.model ?? null,
@@ -562,21 +562,98 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
   }
 }
 
-function extractPromptText(req: PromptInput): string {
-  const parts: string[] = [];
-  for (const block of req.prompt) {
-    if (block.type === "text" && block.text.length > 0) parts.push(block.text);
+type AnthropicContentBlock =
+  | { type: "text"; text: string }
+  | {
+      type: "image";
+      source: { type: "base64"; media_type: AnthropicImageMediaType; data: string };
+    };
+
+type AnthropicImageMediaType = "image/jpeg" | "image/png" | "image/gif" | "image/webp";
+
+/**
+ * Normalize image media types to the exact set Anthropic accepts for base64
+ * image sources. Returns null for image types the SDK request cannot carry.
+ */
+function normalizeAnthropicImageMediaType(mimeType: string): AnthropicImageMediaType | null {
+  const normalized = mimeType.toLowerCase();
+  if (normalized === "image/jpg") return "image/jpeg";
+  if (
+    normalized === "image/jpeg" ||
+    normalized === "image/png" ||
+    normalized === "image/gif" ||
+    normalized === "image/webp"
+  ) {
+    return normalized;
   }
-  return parts.join("\n");
+  return null;
+}
+
+/**
+ * Map a `PromptInput` to the `MessageParam.content` shape the Claude Agent
+ * SDK forwards to Anthropic. Returns a plain string when the prompt is pure
+ * text (the SDK accepts either, and the string form keeps the prior wire
+ * shape for text-only turns) and a content-block array otherwise.
+ */
+export function promptInputToAnthropicContent(req: PromptInput): string | AnthropicContentBlock[] {
+  const hasNonText = req.prompt.some((b) => b.type !== "text");
+  if (!hasNonText) {
+    const parts: string[] = [];
+    for (const block of req.prompt) {
+      if (block.type === "text" && block.text.length > 0) parts.push(block.text);
+    }
+    return parts.join("\n");
+  }
+
+  const blocks: AnthropicContentBlock[] = [];
+  for (const block of req.prompt) {
+    if (block.type === "text") {
+      if (block.text.length > 0) blocks.push({ type: "text", text: block.text });
+    } else if (block.type === "image") {
+      const mediaType = normalizeAnthropicImageMediaType(block.mimeType);
+      if (!mediaType) {
+        logWarn(`[AgentMode] unsupported image media type for Claude SDK: ${block.mimeType}`);
+        blocks.push({
+          type: "text",
+          text: `[Unsupported image attachment omitted: ${block.mimeType}]`,
+        });
+        continue;
+      }
+      blocks.push({
+        type: "image",
+        source: { type: "base64", media_type: mediaType, data: block.data },
+      });
+    } else {
+      // resource_link — we don't currently emit these from buildPromptBlocks,
+      // but render a defensive textual reference so anything that slips
+      // through is at least visible to the model.
+      blocks.push({
+        type: "text",
+        text: `[Attached resource: ${block.name ?? block.uri}]`,
+      });
+    }
+  }
+  return blocks;
+}
+
+/** Short log summary that elides base64 image payloads. */
+function summarizePromptContent(content: string | AnthropicContentBlock[]): unknown {
+  if (typeof content === "string") return content;
+  return content.map((b) =>
+    b.type === "image"
+      ? { type: "image", media_type: b.source.media_type, dataLength: b.source.data.length }
+      : b
+  );
 }
 
 async function* makePromptStream(
-  text: string,
+  content: string | AnthropicContentBlock[],
   sessionId: SessionId
 ): AsyncIterable<SDKUserMessage> {
   yield {
     type: "user",
-    message: { role: "user", content: text },
+    // SDK's MessageParam accepts `string | Array<ContentBlockParam>`.
+    message: { role: "user", content },
     parent_tool_use_id: null,
     session_id: sessionId,
   };

--- a/src/agentMode/session/AgentChatBackend.ts
+++ b/src/agentMode/session/AgentChatBackend.ts
@@ -1,5 +1,11 @@
 import type { MessageContext } from "@/types/message";
-import type { AgentChatMessage, BackendState, CurrentPlan, PlanDecisionAction } from "./types";
+import type {
+  AgentChatMessage,
+  BackendState,
+  CurrentPlan,
+  PlanDecisionAction,
+  PromptContent,
+} from "./types";
 
 /**
  * Narrow interface the Agent Mode UI tree consumes. Implemented by
@@ -16,7 +22,7 @@ export interface AgentChatBackend {
   sendMessage(
     text: string,
     context?: MessageContext,
-    content?: unknown[]
+    promptContent?: PromptContent[]
   ): { id: string; turn: Promise<void> };
   cancel(): Promise<void>;
   deleteMessage(id: string): Promise<boolean>;

--- a/src/agentMode/session/AgentChatUIState.ts
+++ b/src/agentMode/session/AgentChatUIState.ts
@@ -6,6 +6,7 @@ import type {
   BackendState,
   CurrentPlan,
   PlanDecisionAction,
+  PromptContent,
 } from "@/agentMode/session/types";
 import type { MessageContext } from "@/types/message";
 
@@ -55,9 +56,9 @@ export class AgentChatUIState implements AgentChatBackend {
   sendMessage(
     text: string,
     context?: MessageContext,
-    content?: unknown[]
+    promptContent?: PromptContent[]
   ): { id: string; turn: Promise<void> } {
-    const { userMessageId, turn } = this.session.sendPrompt(text, context, content);
+    const { userMessageId, turn } = this.session.sendPrompt(text, context, promptContent);
     this.notifyListeners();
     const wrapped = turn.then(
       () => undefined,

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -136,6 +136,41 @@ describe("buildPromptBlocks", () => {
     expect(text).toContain("  line two");
   });
 
+  it("appends image content blocks after the text envelope", () => {
+    const blocks = buildPromptBlocks("here", undefined, [
+      { type: "image", mimeType: "image/png", data: "aGVsbG8=" },
+    ]);
+    expect(blocks).toEqual([
+      { type: "text", text: "here" },
+      { type: "image", mimeType: "image/png", data: "aGVsbG8=" },
+    ]);
+  });
+
+  it("combines envelope, text, and content blocks in order", () => {
+    const blocks = buildPromptBlocks(
+      "look at this",
+      {
+        notes: [makeFile("a.md")],
+        urls: [],
+      },
+      [
+        { type: "text", text: "<attached-pdf path='b.pdf'>parsed body</attached-pdf>" },
+        { type: "image", mimeType: "image/jpeg", data: "ZmFrZQ==" },
+      ]
+    );
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0].type).toBe("text");
+    const head = (blocks[0] as { type: "text"; text: string }).text;
+    expect(head).toContain("<copilot-context>");
+    expect(head).toContain("- a.md");
+    expect(head).toContain("<user-message>\nlook at this\n</user-message>");
+    expect(blocks[1]).toEqual({
+      type: "text",
+      text: "<attached-pdf path='b.pdf'>parsed body</attached-pdf>",
+    });
+    expect(blocks[2]).toEqual({ type: "image", mimeType: "image/jpeg", data: "ZmFrZQ==" });
+  });
+
   it("ignores web-source selected text excerpts", () => {
     const blocks = buildPromptBlocks("explain", {
       notes: [],
@@ -181,6 +216,29 @@ describe("AgentSession.sendPrompt", () => {
     expect(mock.prompt).toHaveBeenCalledWith({
       sessionId: "acp-1",
       prompt: [{ type: "text", text: "Hi there" }],
+    });
+  });
+
+  it("forwards image content blocks to the backend prompt", async () => {
+    const mock = makeMockBackend();
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+    await session.sendPrompt("describe", undefined, [
+      { type: "image", mimeType: "image/png", data: "aGVsbG8=" },
+    ]).turn;
+    const messages = session.store.getDisplayMessages();
+    expect(messages[0].message).toBe("describe");
+    expect(messages[0].content).toBeUndefined();
+    expect(mock.prompt).toHaveBeenCalledWith({
+      sessionId: "acp-1",
+      prompt: [
+        { type: "text", text: "describe" },
+        { type: "image", mimeType: "image/png", data: "aGVsbG8=" },
+      ],
     });
   });
 

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -462,7 +462,7 @@ export class AgentSession {
   sendPrompt(
     displayText: string,
     context?: MessageContext,
-    content?: unknown[]
+    promptContent?: PromptContent[]
   ): { userMessageId: string; turn: Promise<StopReason> } {
     if (this.status === "starting") {
       throw new Error("Session is still starting");
@@ -480,7 +480,6 @@ export class AgentSession {
       timestamp: formatDateTime(new Date()),
       isVisible: true,
       context,
-      content,
     };
     const userMessageId = this.store.addMessage(userMessage);
 
@@ -497,20 +496,20 @@ export class AgentSession {
     this.abortController = new AbortController();
     this.setStatus("running");
 
-    const turn = this.runTurn(displayText, context, content);
+    const turn = this.runTurn(displayText, context, promptContent);
     return { userMessageId, turn };
   }
 
   private async runTurn(
     displayText: string,
     context: MessageContext | undefined,
-    content?: unknown[]
+    promptContent?: PromptContent[]
   ): Promise<StopReason> {
     const placeholderId = this.placeholderId;
     const sessionId = this.backendSessionId!;
     const turnStartedAt = Date.now();
     try {
-      const promptBlocks = buildPromptBlocks(displayText, context, content);
+      const promptBlocks = buildPromptBlocks(displayText, context, promptContent);
       const req: PromptInput = {
         sessionId,
         prompt: promptBlocks,
@@ -1014,15 +1013,15 @@ function findProviderErrorPayload(
 export function buildPromptBlocks(
   displayText: string,
   context?: MessageContext,
-  content?: unknown[]
+  content?: PromptContent[]
 ): PromptContent[] {
-  // TODO(agent-mode): map `content` (image_url / etc.) to PromptContent
-  // image/resource entries so attachments aren't silently dropped. Today
-  // `AgentChat` strips images before calling sendMessage and surfaces a Notice.
-  void content;
   const envelope = buildContextEnvelope(context);
-  if (!envelope) return [{ type: "text", text: displayText }];
-  return [{ type: "text", text: `${envelope}\n\n<user-message>\n${displayText}\n</user-message>` }];
+  const headText = envelope
+    ? `${envelope}\n\n<user-message>\n${displayText}\n</user-message>`
+    : displayText;
+  const extras = content ?? [];
+  if (extras.length === 0) return [{ type: "text", text: headText }];
+  return [{ type: "text", text: headText }, ...extras];
 }
 
 /**

--- a/src/agentMode/ui/AgentChat.tsx
+++ b/src/agentMode/ui/AgentChat.tsx
@@ -17,7 +17,6 @@ import type { AgentChatMessage, CurrentPlan, PromptContent } from "@/agentMode/s
 import { CustomCommandManager } from "@/commands/customCommandManager";
 import { getCachedCustomCommands } from "@/commands/state";
 import { logError, logWarn } from "@/logger";
-import { isPlusEnabled } from "@/plusUtils";
 import { arrayBufferToBase64 } from "@/utils/base64";
 import type CopilotPlugin from "@/main";
 import {
@@ -57,7 +56,7 @@ interface QueuedAgentMessage {
   text: string;
   rawInput: string;
   context?: MessageContext;
-  /** Image blocks + inlined PDF text blocks for the backend prompt. */
+  /** Image blocks for the backend prompt. */
   promptContent?: PromptContent[];
   hadUnsupportedAttachments: boolean;
 }
@@ -244,7 +243,8 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
     const rawInput = inputMessage;
 
     // Web tab / web-excerpt attachments still aren't wired through.
-    // Images and PDFs are handled below.
+    // Images are handled below. PDFs stay in note context so the agent can
+    // inspect them with its built-in Read tool instead of blocking send.
     const hasWebExcerpt = selectedTextContexts.some(isWebSelectedTextContext);
     const hadUnsupportedAttachments = includeActiveWebTab || hasWebExcerpt;
 
@@ -275,27 +275,6 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
 
     const content: PromptContent[] = [];
 
-    // Inline PDFs as text when the parser is available (Plus or self-host).
-    // Free users fall through: the PDF stays in `notes` so the agent sees
-    // the path in the envelope and can try its own Read tool.
-    const remainingNotes: TFile[] = [];
-    const canParsePdfs = isPlusEnabled();
-    for (const note of notes) {
-      if (note.extension.toLowerCase() === "pdf" && canParsePdfs) {
-        try {
-          const parsed = await plugin.fileParserManager.parseFile(note, app.vault);
-          content.push({
-            type: "text",
-            text: `<attached-pdf path="${note.path}">\n${parsed}\n</attached-pdf>`,
-          });
-          continue;
-        } catch (e) {
-          logWarn(`[AgentMode] PDF parse failed for ${note.path}; falling back to path`, e);
-        }
-      }
-      remainingNotes.push(note);
-    }
-
     // Convert attached images to base64 image content blocks.
     for (const image of selectedImages) {
       const block = await fileToImageBlock(image);
@@ -306,7 +285,7 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
       id: `queued-${uuidv4()}`,
       text: expanded.text,
       rawInput,
-      context: buildMessageContext(remainingNotes, selectedTextContexts),
+      context: buildMessageContext(notes, selectedTextContexts),
       promptContent: content.length > 0 ? content : undefined,
       hadUnsupportedAttachments,
     };
@@ -326,7 +305,6 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
     await runSend(item);
   }, [
     app,
-    plugin,
     inputMessage,
     selectedImages,
     contextNotes,

--- a/src/agentMode/ui/AgentChat.tsx
+++ b/src/agentMode/ui/AgentChat.tsx
@@ -13,10 +13,12 @@ import { useChatFileDrop } from "@/hooks/useChatFileDrop";
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import { expandCustomCommandPrefix } from "@/agentMode/session/expandCustomCommandPrefix";
-import type { AgentChatMessage, CurrentPlan } from "@/agentMode/session/types";
+import type { AgentChatMessage, CurrentPlan, PromptContent } from "@/agentMode/session/types";
 import { CustomCommandManager } from "@/commands/customCommandManager";
 import { getCachedCustomCommands } from "@/commands/state";
-import { logError } from "@/logger";
+import { logError, logWarn } from "@/logger";
+import { isPlusEnabled } from "@/plusUtils";
+import { arrayBufferToBase64 } from "@/utils/base64";
 import type CopilotPlugin from "@/main";
 import {
   clearSelectedTextContexts,
@@ -55,6 +57,8 @@ interface QueuedAgentMessage {
   text: string;
   rawInput: string;
   context?: MessageContext;
+  /** Image blocks + inlined PDF text blocks for the backend prompt. */
+  promptContent?: PromptContent[];
   hadUnsupportedAttachments: boolean;
 }
 
@@ -87,6 +91,7 @@ const combineQueuedMessages = (items: QueuedAgentMessage[]): QueuedAgentMessage 
 
   const allNotes = items.flatMap((i) => i.context?.notes ?? []);
   const allSelected = items.flatMap((i) => i.context?.selectedTextContexts ?? []);
+  const allPromptContent = items.flatMap((i) => i.promptContent ?? []);
 
   return {
     id: `queued-combined-${uuidv4()}`,
@@ -96,9 +101,26 @@ const combineQueuedMessages = (items: QueuedAgentMessage[]): QueuedAgentMessage 
       dedupeBy(allNotes, (n) => n.path),
       dedupeBy(allSelected, (s) => s.id)
     ),
+    promptContent: allPromptContent.length > 0 ? allPromptContent : undefined,
     hadUnsupportedAttachments: items.some((i) => i.hadUnsupportedAttachments),
   };
 };
+
+/**
+ * Convert a `File` (from `<input type="file">` or paste/drop) into a base64
+ * image `PromptContent` block. Returns `null` when the file is empty or
+ * fails to read so the caller can skip it instead of breaking the turn.
+ */
+async function fileToImageBlock(file: File): Promise<PromptContent | null> {
+  try {
+    const buf = await file.arrayBuffer();
+    if (buf.byteLength === 0) return null;
+    return { type: "image", mimeType: file.type || "image/png", data: arrayBufferToBase64(buf) };
+  } catch (e) {
+    logWarn("[AgentMode] failed to read attached image", e);
+    return null;
+  }
+}
 
 const AgentChatInternal: React.FC<AgentChatProps> = ({
   backend,
@@ -199,11 +221,11 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
   const runSend = useCallback(
     async (item: QueuedAgentMessage) => {
       if (item.hadUnsupportedAttachments) {
-        new Notice("Image and web attachments aren't supported in Agent Mode yet.");
+        new Notice("Web tab attachments aren't supported in Agent Mode yet.");
       }
       setLoading(true);
       try {
-        const { turn } = backend.sendMessage(item.text, item.context);
+        const { turn } = backend.sendMessage(item.text, item.context, item.promptContent);
         if (item.rawInput) updateUserMessageHistory(item.rawInput);
         await turn;
       } catch (error) {
@@ -221,11 +243,10 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
     if (!text) return;
     const rawInput = inputMessage;
 
-    // Image and web attachments aren't wired through ACP content blocks yet
-    // (see buildPromptBlocks TODO in AgentSession.ts).
+    // Web tab / web-excerpt attachments still aren't wired through.
+    // Images and PDFs are handled below.
     const hasWebExcerpt = selectedTextContexts.some(isWebSelectedTextContext);
-    const hadUnsupportedAttachments =
-      selectedImages.length > 0 || includeActiveWebTab || hasWebExcerpt;
+    const hadUnsupportedAttachments = includeActiveWebTab || hasWebExcerpt;
 
     const candidateNotes: TFile[] = [];
     if (includeActiveNote) {
@@ -252,11 +273,41 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
       void CustomCommandManager.getInstance().recordUsage(expanded.matched);
     }
 
+    const content: PromptContent[] = [];
+
+    // Inline PDFs as text when the parser is available (Plus or self-host).
+    // Free users fall through: the PDF stays in `notes` so the agent sees
+    // the path in the envelope and can try its own Read tool.
+    const remainingNotes: TFile[] = [];
+    const canParsePdfs = isPlusEnabled();
+    for (const note of notes) {
+      if (note.extension.toLowerCase() === "pdf" && canParsePdfs) {
+        try {
+          const parsed = await plugin.fileParserManager.parseFile(note, app.vault);
+          content.push({
+            type: "text",
+            text: `<attached-pdf path="${note.path}">\n${parsed}\n</attached-pdf>`,
+          });
+          continue;
+        } catch (e) {
+          logWarn(`[AgentMode] PDF parse failed for ${note.path}; falling back to path`, e);
+        }
+      }
+      remainingNotes.push(note);
+    }
+
+    // Convert attached images to base64 image content blocks.
+    for (const image of selectedImages) {
+      const block = await fileToImageBlock(image);
+      if (block) content.push(block);
+    }
+
     const item: QueuedAgentMessage = {
       id: `queued-${uuidv4()}`,
       text: expanded.text,
       rawInput,
-      context: buildMessageContext(notes, selectedTextContexts),
+      context: buildMessageContext(remainingNotes, selectedTextContexts),
+      promptContent: content.length > 0 ? content : undefined,
       hadUnsupportedAttachments,
     };
 
@@ -275,6 +326,7 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
     await runSend(item);
   }, [
     app,
+    plugin,
     inputMessage,
     selectedImages,
     contextNotes,

--- a/src/hooks/useChatFileDrop.ts
+++ b/src/hooks/useChatFileDrop.ts
@@ -80,6 +80,15 @@ function parseObsidianUris(app: App, uriString: string): TFile[] {
 }
 
 /**
+ * Return a browser/Anthropic-compatible MIME type for vault image files.
+ */
+function getImageMimeType(extension: string): string {
+  const normalized = extension.toLowerCase();
+  if (normalized === "jpg") return "image/jpeg";
+  return `image/${normalized}`;
+}
+
+/**
  * Custom hook to handle drag-and-drop of files into the chat.
  * Supports:
  * - Dropping files from Obsidian nav bar (md, pdf, canvas, images)
@@ -203,7 +212,7 @@ export function useChatFileDrop(props: UseChatFileDropProps): UseChatFileDropRet
             const arrayBuffer = await app.vault.readBinary(file);
             const blob = new Blob([arrayBuffer]);
             const imageFile = new File([blob], file.name, {
-              type: `image/${file.extension}`,
+              type: getImageMimeType(file.extension),
             });
             onAddImage([imageFile]);
           } else if (isAllowedFileForNoteContext(file)) {


### PR DESCRIPTION
## Summary
- Wires Agent Mode image attachments and parsed PDF text into backend prompt content while keeping display messages separate.
- Sends multimodal prompt blocks through the Claude SDK adapter with safe logging and resource-link fallbacks.
- Normalizes vault-dropped JPG MIME types and filters unsupported Anthropic image media types.

## Tests
- npm test -- --runTestsByPath src/agentMode/session/AgentSession.test.ts src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
- npx eslint on touched files
- npx prettier --check on touched files