### PR TITLE
fix(agent-mode): preserve persisted enabled flag on mobile

### DIFF
--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -1,7 +1,11 @@
-import type { App } from "obsidian";
+import { type App, Platform } from "obsidian";
 import type CopilotPlugin from "@/main";
 import { logError } from "@/logger";
-import { getSettings } from "@/settings/model";
+import {
+  type CopilotSettings,
+  getSettings,
+  useSettingsValue,
+} from "@/settings/model";
 import { backendRegistry, listBackendDescriptors } from "./backends/registry";
 import { AgentChatPersistenceManager } from "./session/AgentChatPersistenceManager";
 import { AgentModelPreloader } from "./session/AgentModelPreloader";
@@ -43,6 +47,20 @@ export { getActiveBackendDescriptor, listBackendDescriptors } from "./backends/r
 export { frameSink as acpFrameSink } from "./session/debugSink";
 export { SkillManager, SkillsSettings, useManagedSkills } from "./skills";
 export type { Skill } from "./skills";
+
+/**
+ * True when Agent Mode is enabled and the platform supports it. Agent Mode
+ * requires subprocess support, so this is always false on mobile regardless
+ * of the persisted `enabled` flag (which may have been synced from desktop).
+ */
+export function isAgentModeEnabled(settings: CopilotSettings = getSettings()): boolean {
+  return !Platform.isMobile && !!settings.agentMode?.enabled;
+}
+
+/** React hook variant — re-renders when the setting or platform-derived value changes. */
+export function useIsAgentModeEnabled(): boolean {
+  return isAgentModeEnabled(useSettingsValue());
+}
 
 /**
  * Collect each registered backend's project-relative skills directory into
@@ -118,7 +136,7 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   }
 
   const settings = getSettings();
-  if (!settings.agentMode?.enabled) return manager;
+  if (!isAgentModeEnabled(settings)) return manager;
   const preloads: Promise<void>[] = [];
   for (const descriptor of listBackendDescriptors()) {
     if (descriptor.getInstallState(settings).kind !== "ready") continue;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -29,6 +29,7 @@ import { CopilotSettings } from "@/settings/model";
 import { NoteSelectedTextContext, WebSelectedTextContext } from "@/types/message";
 import { ensureFolderExists, isSourceModeOn } from "@/utils";
 import { Editor, MarkdownView, Notice, Platform, TFile } from "obsidian";
+import { isAgentModeEnabled } from "@/agentMode";
 import { v4 as uuidv4 } from "uuid";
 import { COMMAND_IDS, COMMAND_ICONS, COMMAND_NAMES, CommandId } from "@/constants";
 import { setSelectedTextContexts } from "@/aiParams";
@@ -127,11 +128,9 @@ export function registerCommands(
     await plugin.newChat();
   });
 
-  // Agent Chat commands. Gated by `agentMode.enabled` and desktop because the
-  // ACP backend needs subprocess support. The settings-change subscription in
-  // main.ts re-runs `registerCommands` so toggling the setting reflects in the
-  // command palette.
-  if (Platform.isDesktopApp && next.agentMode?.enabled) {
+  // Re-runs from the settings subscription in main.ts so toggling the
+  // master switch refreshes the command palette.
+  if (isAgentModeEnabled(next)) {
     addCommand(plugin, COMMAND_IDS.OPEN_AGENT_CHAT_WINDOW, () => {
       void plugin.activateAgentView();
     });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -28,7 +28,7 @@ import { getAllQAMarkdownContent } from "@/search/searchUtils";
 import { CopilotSettings } from "@/settings/model";
 import { NoteSelectedTextContext, WebSelectedTextContext } from "@/types/message";
 import { ensureFolderExists, isSourceModeOn } from "@/utils";
-import { Editor, MarkdownView, Notice, Platform, TFile } from "obsidian";
+import { Editor, MarkdownView, Notice, TFile } from "obsidian";
 import { isAgentModeEnabled } from "@/agentMode";
 import { v4 as uuidv4 } from "uuid";
 import { COMMAND_IDS, COMMAND_ICONS, COMMAND_NAMES, CommandId } from "@/constants";

--- a/src/components/chat-components/plugins/SlashCommandPlugin.tsx
+++ b/src/components/chat-components/plugins/SlashCommandPlugin.tsx
@@ -3,7 +3,7 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import { $getSelection, $isRangeSelection, TextNode } from "lexical";
 import fuzzysort from "fuzzysort";
 
-import { listBackendDescriptors, useManagedSkills } from "@/agentMode";
+import { listBackendDescriptors, useIsAgentModeEnabled, useManagedSkills } from "@/agentMode";
 import type { BackendId } from "@/agentMode";
 import { useCustomCommands } from "@/commands/state";
 import { CustomCommandManager } from "@/commands/customCommandManager";
@@ -31,7 +31,8 @@ interface SlashCommandOption extends TypeaheadOption {
  */
 function useActiveSlashBackend(): BackendId | null {
   const settings = useSettingsValue();
-  if (!settings.agentMode?.enabled) return null;
+  const agentModeEnabled = useIsAgentModeEnabled();
+  if (!agentModeEnabled) return null;
   const activeBackend = settings.agentMode?.activeBackend;
   if (typeof activeBackend !== "string" || activeBackend.length === 0) return null;
   const known = listBackendDescriptors().some((d) => d.id === activeBackend);

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
   AGENT_CHAT_MODE,
   CopilotAgentView,
   createAgentSessionManager,
+  isAgentModeEnabled,
   PlanPreviewView,
   PLAN_PREVIEW_VIEW_TYPE,
   SkillManager,
@@ -730,7 +731,7 @@ export default class CopilotPlugin extends Plugin {
       new Notice("Agent Chat is not available on mobile.");
       return null;
     }
-    if (!getSettings().agentMode?.enabled) {
+    if (!isAgentModeEnabled()) {
       new Notice("Enable Agent Mode in Copilot settings first.");
       return null;
     }
@@ -742,7 +743,7 @@ export default class CopilotPlugin extends Plugin {
   }
 
   private canUseAgentView(): boolean {
-    return !Platform.isMobile && !!this.agentSessionManager && !!getSettings().agentMode?.enabled;
+    return !!this.agentSessionManager && isAgentModeEnabled();
   }
 
   private refreshRibbonIcon() {

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -1,6 +1,5 @@
 import { CustomModel, ProjectConfig } from "@/aiParams";
 import { atom, createStore, useAtomValue } from "jotai";
-import { Platform } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 
 // Type-only import: `CopilotMode` and `ModelSelection` are owned by
@@ -813,19 +812,11 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
 /** Validate the agentMode slice. */
 function sanitizeAgentMode(raw: unknown): CopilotSettings["agentMode"] {
   if (!raw || typeof raw !== "object") {
-    return {
-      ...DEFAULT_SETTINGS.agentMode,
-      enabled: Platform.isMobile ? false : DEFAULT_SETTINGS.agentMode.enabled,
-    };
+    return { ...DEFAULT_SETTINGS.agentMode };
   }
   const r = raw as Record<string, unknown>;
-  // Agent Mode requires subprocess support — force off on mobile regardless
-  // of what a synced desktop settings file says.
-  const enabled = Platform.isMobile
-    ? false
-    : typeof r.enabled === "boolean"
-      ? r.enabled
-      : DEFAULT_SETTINGS.agentMode.enabled;
+  const enabled =
+    typeof r.enabled === "boolean" ? r.enabled : DEFAULT_SETTINGS.agentMode.enabled;
   const byok =
     r.byok && typeof r.byok === "object"
       ? (r.byok as { anthropic?: string; openai?: string; google?: string })


### PR DESCRIPTION
## Summary

Mobile no longer rewrites `agentMode.enabled` to `false` during settings sanitization, so a desktop-synced preference is preserved instead of being silently flipped off the next time mobile persists settings. Mobile gating now happens at runtime/UI sites via a shared `isAgentModeEnabled(settings?)` helper (and a `useIsAgentModeEnabled()` hook), with all existing call sites — `main.ts` (`canUseAgentView`, `requireAgentView`), `commands/index.ts` (Agent Chat command registration), `SlashCommandPlugin`, and `createAgentSessionManager` — switched over. The sanitizer keeps the raw `enabled` value, the settings UI still reflects the stored toggle on desktop, and defensive `Platform.isMobile` guards inside the agentMode layer are left in place.

## Test plan

- [ ] On mobile, open a vault with `agentMode.enabled: true` synced from desktop, change an unrelated setting, sync back, confirm desktop still reads `enabled: true`.
- [ ] On mobile, confirm Agent Chat commands, slash-menu agent skills, and the agent ribbon icon remain disabled.
- [ ] On desktop, confirm toggling Agent Mode still registers/unregisters the Agent Chat commands and updates the ribbon icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)