### PR TITLE
feat(agent-mode): tint chat input border and mode picker by mode

### DIFF
--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -727,7 +727,13 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
 
   return (
     <div
-      className="tw-flex tw-w-full tw-flex-col tw-gap-0.5 tw-rounded-md tw-border tw-border-solid tw-border-border tw-px-1 tw-pb-1 tw-pt-2 tw-@container/chat-input"
+      className={cn(
+        "tw-flex tw-w-full tw-flex-col tw-gap-0.5 tw-rounded-md tw-border tw-border-solid tw-border-border tw-px-1 tw-pb-1 tw-pt-2 tw-@container/chat-input",
+        modePickerOverride?.value === "plan" &&
+          "tw-shadow-[0_0_10px_rgba(var(--color-blue-rgb),0.18)] tw-border-blue/60",
+        modePickerOverride?.value === "auto" &&
+          "tw-shadow-[0_0_10px_rgba(var(--color-red-rgb),0.18)] tw-border-red/60"
+      )}
       ref={containerRef}
     >
       {/* Hide context controls in edit mode - editing only changes text, not context */}

--- a/src/components/ui/ModePicker.tsx
+++ b/src/components/ui/ModePicker.tsx
@@ -51,7 +51,12 @@ export function ModePicker({ override, className }: ModePickerProps) {
           variant="ghost2"
           size="sm"
           disabled={disabled}
-          className={cn("tw-shrink-0 tw-text-muted", className)}
+          className={cn(
+            "tw-shrink-0 tw-text-muted",
+            value === "plan" && "tw-text-blue/70 hover:tw-text-blue/100 focus:tw-text-blue/100",
+            value === "auto" && "tw-text-red/70 hover:tw-text-red/100 focus:tw-text-red/100",
+            className
+          )}
           title="Operational mode"
         >
           <span className="tw-truncate">{triggerLabel}</span>

--- a/src/components/ui/ModePicker.tsx
+++ b/src/components/ui/ModePicker.tsx
@@ -53,8 +53,10 @@ export function ModePicker({ override, className }: ModePickerProps) {
           disabled={disabled}
           className={cn(
             "tw-shrink-0 tw-text-muted",
-            value === "plan" && "tw-text-blue/70 hover:tw-text-blue/100 focus:tw-text-blue/100",
-            value === "auto" && "tw-text-red/70 hover:tw-text-red/100 focus:tw-text-red/100",
+            value === "plan" &&
+              "tw-text-blue/70 hover:tw-text-blue/100 focus-visible:tw-text-blue/100",
+            value === "auto" &&
+              "tw-text-red/70 hover:tw-text-red/100 focus-visible:tw-text-red/100",
             className
           )}
           title="Operational mode"


### PR DESCRIPTION
## Summary
- Tint the chat input border with a soft glow when Agent Mode has a non-default mode active — blue for **Plan**, red for **Auto**.
- Color the `ModePicker` trigger label to match: faded by default, full color on hover/focus.

Makes the active agent mode obvious at a glance without intruding on the input itself (no background fill, just the border + a subtle glow).

## Test plan
- [ ] Open Agent Mode chat input.
- [ ] Switch mode to **Plan** → input border turns blue with a light blue glow, picker label faded blue (brightens on hover/focus).
- [ ] Switch to **Auto** → input border turns red with a light red glow, picker label faded red.
- [ ] Switch back to **Safe** → border/glow/label return to neutral.
- [ ] Confirm non-agent chat input is unaffected (no `modePickerOverride` prop = no tint).