### PR TITLE
fix(agent-mode): keep mode picker visible while generating

### DIFF
--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -858,6 +858,8 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
         </div>
 
         <div className="tw-flex tw-items-center tw-gap-1">
+          {!isGenerating && toolControls}
+          {modePickerOverride && <ModePicker override={modePickerOverride} />}
           {isGenerating ? (
             <Button
               size="icon"
@@ -869,8 +871,6 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
             </Button>
           ) : (
             <>
-              {toolControls}
-              {modePickerOverride && <ModePicker override={modePickerOverride} />}
               {editMode && onEditCancel && (
                 <Button
                   variant="ghost2"


### PR DESCRIPTION
## Summary
- Hoist the agent-mode mode picker (Auto / Plan / Safe) out of the `!isGenerating` branch in `ChatInput` so it stays mounted while the agent is streaming.
- Lets users flip modes mid-turn (e.g. Plan → Auto) instead of waiting for generation to stop. Non-agent chats are unaffected since they don't pass `modePickerOverride`.

## Test plan
- [ ] Send a prompt in Agent Mode; while the Stop button is showing, confirm the mode picker is still visible and the dropdown switches modes.
- [ ] Verify regular chats (Vault QA / Copilot+) still collapse the right-hand row to a single Stop button during generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)