### PR TITLE
docs(design): refine model management redesign + add Quick Chat follow-up

### DIFF
--- a/designdocs/MODEL_MANAGEMENT_REDESIGN.md
+++ b/designdocs/MODEL_MANAGEMENT_REDESIGN.md
@@ -1,22 +1,22 @@
-# Model Management Redesign — Design Handoff
+# Model Management Redesign — Design Spec
 
-**Status:** Draft for design handoff
-**Audience:** Senior product designer doing UX/mockup work in Claude Design. No codebase access assumed.
+**Status:** Aligned to Claude Design bundle (May 2026)
+**Source of truth:** `copilot-model-settings/project/index.html` exported from Claude Design — specifically the **★ Final flow** in `screens/final.jsx`, which consolidates the picked variants and fills two gap screens (unified Configure Provider, Add Custom Model).
 **Scope:** Provider keys, model catalog, model selection, model visibility, agent backend configuration. Everything a user does to answer the question "what LLM is this plugin going to call?"
-**Out of scope:** Embedding model configuration (lives in its own panel, untouched by this redesign), chat UI redesign, command palette redesign, plus/license management.
+**Out of scope:** Embedding model configuration (separate panel, untouched), chat UI redesign, command palette redesign, Plus/license management.
 
 ---
 
 ## 0. What this product is, in one paragraph
 
-Copilot for Obsidian is a plugin that adds AI capabilities (chat, autocomplete, semantic search, custom commands, agent workflows) to the Obsidian note-taking app. It supports many LLM providers — OpenAI, Anthropic, Google, Groq, Mistral, xAI, DeepSeek, OpenRouter, Azure, AWS Bedrock, GitHub Copilot, Ollama, plus arbitrary OpenAI-compatible endpoints. Users configure provider API keys and select which models they want the plugin to use. The plugin runs in both Obsidian desktop and Obsidian mobile.
+Copilot for Obsidian is a plugin that adds AI capabilities (chat, autocomplete, semantic search, custom commands, agent workflows) to the Obsidian note-taking app. It supports many LLM providers — OpenAI, Anthropic, Google, Groq, Mistral, xAI, DeepSeek, OpenRouter, Azure, AWS Bedrock, GitHub Copilot, Ollama, plus arbitrary OpenAI-compatible endpoints. Users configure provider API keys and select which models they want the plugin to use. The plugin runs in both Obsidian desktop and Obsidian mobile, but the redesigned settings UI is desktop-shaped (mobile gets a stripped-down view of the same surfaces — see §10.1).
 
 The plugin has **two execution modes** that share the same model pool:
 
-- **Chain mode** (legacy / chat / commands) — single-turn LLM calls via LangChain. Used for chat, custom command execution, quick prompts. **Works on mobile.** Always available.
-- **Agent mode** (newer / "OpenCode" et al) — multi-turn agent sessions with tool use, file ops, sessions. Runs by spawning an external binary (OpenCode, Claude Code, or Codex). **Desktop-only.** Optional.
+- **Chain mode** (chat / commands) — single-turn LLM calls via LangChain. Used for chat, custom command execution, quick prompts. **Works on mobile.** Always available.
+- **Agent mode** — multi-turn agent sessions with tool use, file ops, sessions. Runs by spawning an external binary (OpenCode, Claude Code, or Codex). **Desktop-only.**
 
-Today, model configuration is split across three duplicated UI surfaces (Basic Settings provider key panel, Models Settings table, Agent Mode model curation). This redesign consolidates them.
+Today, model configuration is split across three duplicated UI surfaces (Basic Settings provider key panel, Models Settings table, Agent Mode model curation). This redesign consolidates them into a single **BYOK** tab plus a dedicated **Agent** tab.
 
 ---
 
@@ -24,33 +24,34 @@ Today, model configuration is split across three duplicated UI surfaces (Basic S
 
 ### Goals
 
-1. **One canonical place to configure providers, keys, and models.** Currently three places; should be one.
-2. **A user can complete first-run setup in under 60 seconds.** Pick a provider, enter a key, pick a model, done.
-3. **OpenRouter and similar large-catalog providers don't drown the UI.** OpenRouter has hundreds of models. Users see only what they've enabled, with a separate dialog to add more.
-4. **The mobile flow is identical** to the desktop chain-only flow. No "mobile mode" branding — just fewer fields because agent mode isn't possible.
-5. **Visibility curation exists** — users can hide models they don't want cluttering the model picker dropdown next to the chat input.
-6. **Local providers (Ollama, custom OpenAI-compatible endpoints) are first-class**, not a power-user afterthought.
-7. **Non-BYOK models (OpenCode-provided free models like "Big Pickle", and Copilot Plus paid models like "Copilot Plus Flash") appear naturally in the same panel** without surprise; capability badges explain why they only work in agent mode.
-8. **Offline-capable.** The plugin ships with a bundled model catalog so users without internet can still see providers and configure keys.
+1. **One canonical place to configure providers, keys, and models.** Currently three places; one BYOK tab now.
+2. **A user can complete first-run setup in under 60 seconds.** Welcome modal → pick provider → enter key + pick models in one screen → done.
+3. **OpenRouter and similar large-catalog providers don't drown the UI.** Hundreds of models compress into one searchable, filterable list with sticky group headers per upstream provider.
+4. **Visibility curation exists** — the row checkbox in the BYOK table hides a model from the chat input picker without removing it from the registry.
+5. **Local providers (Ollama, custom OpenAI-compatible endpoints) are first-class** — they appear as top-level providers in the same list, not nested under a "Custom" wrapper.
+6. **Non-BYOK models (OpenCode-provided free models like "Big Pickle", and Copilot Plus paid models like "Copilot Plus Flash") appear naturally in the same table** as ordinary rows; the row's "provider" column carries the OpenCode / Copilot Plus origin.
+7. **Offline-capable.** The plugin ships with a bundled model catalog so users without internet can still see providers and configure keys.
+8. **The Configure Provider modal is one component for three jobs** — adding a BYOK provider, adding a custom endpoint, and editing an existing provider. Same fields, same layout; only the footer + subhead adapt.
 
 ### Non-Goals
 
 - Embedding model management (separate, unchanged).
-- Per-model temperature / max_tokens / system prompt overrides. **These are being removed entirely.** All chains use sensible defaults.
-- Reordering models in a custom order (drag-to-reorder is out). Alphabetical or provider-grouped is fine.
+- Per-model temperature / max_tokens / system prompt overrides. **Removed entirely.** All chains use sensible defaults.
+- A user-managed "Default chat model" pointer. The BYOK panel no longer surfaces this — chain-mode chat uses whatever the user last selected in the chat input picker.
+- Reordering models in a custom order (drag-to-reorder is out). Sort defaults are provider order then alphabetical.
 - Adding any new agent backends beyond OpenCode / Claude Code / Codex.
 - Visual restyling of the surrounding Obsidian settings shell.
 
 ---
 
-## 2. Conceptual model (read this before designing anything)
+## 2. Conceptual model
 
 ### Two execution modes, one model pool
 
 ```
                    ┌──────────────────────────────┐
-                   │   ONE Models registry        │
-                   │   (the unified Models panel) │
+                   │   ONE BYOK registry          │
+                   │   (the unified BYOK tab)     │
                    └──────────┬───────────────────┘
                               │
               ┌───────────────┴────────────────┐
@@ -66,54 +67,56 @@ Today, model configuration is split across three duplicated UI surfaces (Basic S
        desktop)
 ```
 
-### What lives in the unified registry
+### What lives in the BYOK registry
 
 Models the user has explicitly enabled. Each model in the registry has one of four origins:
 
 - **BYOK** — User entered a provider API key, then picked which of that provider's models they want enabled. Most common.
-- **Local/Custom** — User defined a custom OpenAI-compatible endpoint (e.g. Ollama at `http://localhost:11434`) and added one or more models running there.
+- **Local/Custom** — User defined a custom OpenAI-compatible endpoint (e.g. Ollama at `http://localhost:11434`) and added one or more models running there. Appears as a top-level provider, **not** nested under a "Custom" wrapper.
 - **OpenCode-provided** — Free models bundled with OpenCode (e.g. **Big Pickle**). No key required. Only available when OpenCode is installed. Only usable in agent mode.
 - **Copilot-provided** — Paid models served by Copilot for **Plus subscribers** (e.g. **Copilot Plus Flash**). No BYOK key required — gated by the user's Copilot Plus license. Routed through OpenCode at runtime. Only usable in agent mode.
+
+OpenCode-provided and Copilot-provided models appear as ordinary rows in the BYOK table (provider column reads "OpenCode" or "Copilot Plus"). They are **not** rendered as special pinned sections — the table treats them like any other row, just sorted to the top.
 
 ### Capability badges
 
 Every model carries up to two capability badges:
 
-- **💬 Chat-capable** — can be called via LangChain. Works in chat, custom commands, mobile.
-- **🤖 Agent-capable** — can be selected as the model an agent backend runs.
+- **💬 chat** — can be called via LangChain. Works in chat, custom commands, mobile.
+- **🤖 agent** — can be selected as the model an agent backend runs.
 
 Examples:
 
-| Model | Provider | 💬 Chat | 🤖 Agent |
-|---|---|:---:|:---:|
-| Claude Sonnet 4.5 | Anthropic | ✓ | ✓ |
-| GPT-5 | OpenAI | ✓ | ✓ |
-| llama3.2 | Ollama (local) | ✓ | ✓ |
-| Big Pickle | OpenCode | ✗ | ✓ |
-| Copilot Plus Flash | Copilot Plus | ✗ | ✓ |
+| Model              | Provider       | 💬 chat | 🤖 agent |
+| ------------------ | -------------- | :-----: | :------: |
+| Claude Sonnet 4.5  | Anthropic      |    ✓    |    ✓     |
+| GPT-5              | OpenAI         |    ✓    |    ✓     |
+| llama3.2           | Ollama (local) |    ✓    |    ✓     |
+| Big Pickle         | OpenCode       |    ✗    |    ✓     |
+| Copilot Plus Flash | Copilot Plus   |    ✗    |    ✓     |
 
-In the chat input model picker, models are grouped by agent backend (OpenCode, Claude Code, Codex) and selecting a model auto-selects the backend. The existing model picker pattern handles this — this redesign does not change it. Mobile / chain-mode-only contexts hide 🤖-only models from the picker.
+In the chat input model picker, models are grouped by agent backend; selecting a model auto-selects the backend. This redesign does not change the chat input picker.
 
 ### Agent backend special case (Claude Code / Codex)
 
-OpenCode is BYOK — it uses the models in the unified registry, augmented by the OpenCode-provided free models and (for Plus subscribers) the Copilot Plus paid models.
+OpenCode is BYOK — it uses the models in the BYOK registry, augmented by the OpenCode-provided free models and (for Plus subscribers) the Copilot Plus paid models.
 
 **Claude Code and Codex are different.** They are subscription-based binaries with their own bundled model lists, authenticated by the user's Anthropic/OpenAI subscription (not the BYOK keys). They cannot accept arbitrary models. So:
 
-- The unified Models registry does **not** include Claude Code's or Codex's models.
-- Each of those backends has its own tiny **visibility panel** inside Agent Settings to let users hide models from that backend's picker (e.g. "I never want Claude Haiku to appear").
-- Switching backend changes which catalog the agent model picker reads from.
+- The BYOK registry does **not** include Claude Code's or Codex's models.
+- Each of those backends has its own **visibility checklist** inside its Agent sub-tab to hide models from that backend's picker (e.g. "I never want Claude Haiku to appear").
+- Switching the active agent backend changes which catalog the agent model picker reads from.
 
 ### Catalog source priority (one source at a time, never merged)
 
-When the Models panel loads, it picks ONE source for "available models per provider":
+When the BYOK panel loads, it picks ONE source for "available models per provider":
 
-1. **OpenCode binary present and reachable** → ask OpenCode for its catalog. Includes OpenCode-provided free models (Big Pickle, etc.), Copilot Plus paid models when the user has a Plus license, any custom providers we've previously registered, and the bundled `models.dev` snapshot OpenCode ships with.
-2. **OpenCode not installed** → use the plugin-bundled `models.dev` snapshot. No 🤖 badges shown on cloud BYOK models (because no agent is available). OpenCode-provided and Copilot Plus models are absent from the catalog (they require OpenCode).
+1. **OpenCode binary present and reachable** → ask OpenCode for its catalog. Includes OpenCode-provided free models (Big Pickle, etc.), Copilot Plus paid models when the user has a Plus license, any custom providers previously registered, and the bundled `models.dev` snapshot OpenCode ships with.
+2. **OpenCode not installed** → use the plugin-bundled `models.dev` snapshot. No 🤖 badges shown on cloud BYOK models (because no agent is available). OpenCode-provided and Copilot Plus rows are absent (they require OpenCode).
 
-**No live refresh from `models.dev/api.json`.** The catalog the user sees is whatever ships with the plugin (bundled snapshot) or whatever OpenCode provides (when installed). New models become available on plugin update or OpenCode update. There is no "Refresh catalog" button, no daily background fetch, no network dependency for the catalog. This keeps the model offline-correct and architecturally simple.
+**No live refresh from `models.dev/api.json`.** The catalog is whatever ships with the plugin (bundled snapshot) or whatever OpenCode provides (when installed). New models become available on plugin update or OpenCode update. No "Refresh catalog" button, no daily background fetch, no network dependency for the catalog.
 
-The bundled snapshot is tree-shaken to ~20 supported providers (Anthropic, OpenAI, Google, Groq, Mistral, xAI, DeepSeek, OpenRouter, Cohere, Azure, AWS Bedrock, GitHub Copilot, Together, Fireworks, Perplexity, plus a few more). For providers outside that set, the user can still add them as a custom provider with manual model entry.
+The bundled snapshot is tree-shaken to ~20 supported providers (Anthropic, OpenAI, Google, Groq, Mistral, xAI, DeepSeek, OpenRouter, Cohere, Azure, AWS Bedrock, GitHub Copilot, Together, Fireworks, Perplexity, plus a few more). For providers outside that set, the user can add them as a custom provider with manual model entry (via Add Custom Model).
 
 ---
 
@@ -124,48 +127,50 @@ The redesigned UI must let a user accomplish every one of these:
 ### First-run setup
 
 - **JTBD-1.** As a new user on desktop, get to a working agent in under 60 seconds via one of three paths: use an existing Claude Code / Codex subscription, bring my own provider key, or subscribe to Copilot Plus.
-- **JTBD-2.** As a new user, understand that Copilot is **agent-first** — the welcome flow surfaces agent setup as the primary action; chain-mode chat is a quieter secondary option.
+- **JTBD-2.** As a new user, understand that Copilot is **agent-first** — the welcome modal surfaces three primary paths; there is no secondary "skip agent" link.
 
 ### Provider key management
 
 - **JTBD-4.** Enter, edit, paste, and remove a provider API key.
-- **JTBD-5.** Verify that a key works (a "Test" or "Verify" affordance, or implicit on key change).
-- **JTBD-6.** See which providers have keys configured at a glance.
+- **JTBD-5.** Verify that a key works (a `[Test]` affordance, or implicit on `[Verify & save]`).
+- **JTBD-6.** See which providers have keys configured at a glance (via the BYOK table's provider column, and via `[Manage providers]`).
 - **JTBD-7.** Get a clear error when a key is invalid, expired, or has insufficient permissions.
 
 ### Model selection (enabling models)
 
-- **JTBD-8.** After entering a provider key, browse the models that provider offers and choose which to enable.
+- **JTBD-8.** After entering a provider key, browse the models that provider offers and choose which to enable — **in the same screen as the key entry** (Configure Provider).
 - **JTBD-9.** Add a model from a provider that has many models (like OpenRouter, with hundreds) without the UI becoming unscannable.
-- **JTBD-10.** Quickly disable a model I no longer want, without removing my provider key.
-- **JTBD-11.** Remove a model entirely (not just disable).
+- **JTBD-10.** Quickly hide a model I no longer want, without removing my provider key (uncheck the row's visibility checkbox).
+- **JTBD-11.** Remove a model entirely from the registry (kebab → Remove from list).
 - **JTBD-12.** See, for each enabled model, where it works (chat, agent, both).
+- **JTBD-13.** Add a model that isn't in the catalog (preview, fine-tune, private deployment) via Add Custom Model — works for **any** provider.
 
 ### Custom / local providers
 
-- **JTBD-13.** Add a local Ollama instance with one or more models, in a single flow.
-- **JTBD-14.** Add a custom OpenAI-compatible endpoint (e.g. self-hosted vLLM, a colleague's Tailscale-hosted server).
-- **JTBD-15.** Edit a custom provider's base URL after adding it.
-- **JTBD-16.** Have local models work in both chat and (when desktop + OpenCode installed) agent.
+- **JTBD-14.** Add a local Ollama instance with one or more models, in a single flow.
+- **JTBD-15.** Add a custom OpenAI-compatible endpoint (e.g. self-hosted vLLM, a colleague's Tailscale-hosted server).
+- **JTBD-16.** Edit a custom provider's base URL after adding it (via the row kebab → Configure provider → edit state).
+- **JTBD-17.** Have local models work in both chat and (when desktop + OpenCode installed) agent.
 
 ### Defaults
 
-- **JTBD-17.** Pick a **Default Chat Model** — used for chain-mode chat (mobile chat, simple chat, custom commands). Filtered to 💬-capable models.
 - **JTBD-18.** Pick a **Default Agent Model per agent backend** — one each for OpenCode, Claude Code, Codex. Filtered to 🤖-capable models for that backend. Used when starting an agent session in that backend.
-- **JTBD-19.** Pick a **Default Reasoning Effort per agent backend** (minimal / low / medium / high) for reasoning-capable models. Maps to the existing per-backend effort knob.
+- **JTBD-19.** Pick a **Default Reasoning Effort per agent backend** (Min / Low / Med / High) for reasoning-capable models.
 
-### Agent backend configuration (desktop only)
+(There is **no** "Default Chat Model" picker. Chain-mode chat uses the model the user last selected in the chat input.)
 
-- **JTBD-20.** Pick which agent backend is active: OpenCode (recommended), Claude Code, or Codex.
+### Agent backend configuration
+
+- **JTBD-20.** Pick which agent backend is **active**: OpenCode (recommended), Claude Code, or Codex. The active backend is set via `[Use this backend]` in the viewed sub-tab's Status card — not via sub-tab selection.
 - **JTBD-21.** Install the OpenCode binary from inside the plugin if I don't have it yet.
 - **JTBD-22.** Point the plugin at an existing binary location, or detect one automatically.
 - **JTBD-23.** When using Claude Code or Codex, curate which of that backend's bundled models show up in the agent model picker dropdown.
-- **JTBD-24.** Switch between backends and see the model picker re-populate appropriately.
+- **JTBD-24.** Switch the viewed backend (sub-tab) without changing the active backend, so I can re-authenticate or pre-configure another backend without disruption.
 
 ### Visibility & cleanup
 
-- **JTBD-25.** Hide models I don't want cluttering the chat input's model picker dropdown, without removing them from the registry.
-- **JTBD-26.** Bulk-disable models from a single provider (e.g. "I deleted my OpenAI key, hide all OpenAI models from the picker").
+- **JTBD-25.** Hide models I don't want cluttering the chat input's model picker dropdown, without removing them from the registry (uncheck the row checkbox).
+- **JTBD-26.** Bulk-remove a provider's models by removing the provider from Configure Provider's edit footer.
 
 ### Offline
 
@@ -173,51 +178,47 @@ The redesigned UI must let a user accomplish every one of these:
 
 ### Mobile
 
-- **JTBD-28.** On mobile, see the Models tab without 🤖 badges and without the OpenCode / Copilot Plus sections. Agent UI is hidden. No dedicated mobile onboarding — mobile uses the same Models tab as desktop, just with the agent surfaces hidden.
+- **JTBD-28.** On mobile, see the BYOK table without 🤖 badges and without OpenCode / Copilot Plus rows. Agent tab and Welcome modal are hidden. Mobile reuses the desktop BYOK panel with agent surfaces hidden.
 
 ---
 
 ## 4. Information architecture
 
-Settings is rendered inside Copilot's settings modal: a horizontal tab strip at the top of the modal, with the content area scrolling beneath. Modal width is ~700–900px (see §10.3).
+Settings is rendered inside Copilot's settings modal — a horizontal tab strip at the top of the modal, with the content area scrolling beneath. Modal width is ~1320px (see §10.3).
 
-The Model Management redesign occupies **two tabs**:
+The Model Management redesign occupies **two tabs** in the settings modal, plus **one standalone modal** for first-run welcome.
 
-### Tab: **Models**
+### Tab: **BYOK** (renamed from "Models")
 
-The unified registry. Source of truth for everything chain-capable, and the BYOK input pathway for OpenCode-capable models.
+The unified registry. A flat table of every model the user has enabled, sorted across all providers (OpenCode-provided, Copilot Plus, BYOK, custom). Provider configuration lives in a separate Configure Provider modal reached via the row kebab.
 
-Always visible. Same on desktop and mobile, with two differences on mobile:
-- The 🤖 column / badge is hidden everywhere.
-- The **OpenCode** and **Copilot Plus** sections are hidden (no agent backend → no consumer).
+The label is **"BYOK"** (Bring Your Own Key) — chosen to make the user's mental model explicit ("these are my keys/models") and to distinguish from the per-backend bundled-model lists in the Agent tab.
 
 ### Tab: **Agent** (desktop only)
 
-Backend picker (OpenCode / Claude Code / Codex), binary path, per-backend visibility curation for Claude Code and Codex. (No per-backend "default model" picker — see §2 and §6.3.)
+Backend selection (OpenCode / Claude Code / Codex) shown as **sub-tabs at the top of the panel**, not a radio. Sub-tab selection ≠ active backend (see §6.2). Per-backend configuration includes: binary path, authentication (CC/Codex only), default agent model, default reasoning effort, and for CC/Codex a visibility checklist of bundled models.
 
-Hidden entirely on mobile. (Existing "Settings → Agent Mode" pattern. Already established in the broader settings redesign.)
+### Standalone modal: **Welcome**
 
-The existing **Chat & Commands** tab is unchanged by this redesign. The chat input's model picker continues to read from the unified Models registry, grouped by agent backend, with selection auto-routing to the right backend.
+First-run only. Lives outside the settings modal — overlays the entire Obsidian window with a dimmed app silhouette underneath. Three primary tiles: "Use my existing subscription", "Bring my own key", "Subscribe to Copilot Plus". No "skip agent" link.
+
+The existing **Chat & Commands** tab is unchanged by this redesign. The chat input's model picker continues to read from the unified BYOK registry, grouped by agent backend.
 
 ---
 
-## 5. The Models panel (detailed)
+## 5. The BYOK panel (detailed)
 
 This is the centerpiece. Mockup priorities are highest for this screen.
 
-The panel has **two visual states**: **empty** (no providers added yet) and **populated** (one or more providers added). Providers do not pre-populate as collapsed cards; users explicitly add the providers they want via a `[+ Add provider]` button.
+The panel has **two visual states**: **empty** (no providers added yet) and **populated** (one or more providers added). Providers are added via the **[+ Add provider]** dialog (§7.1), then configured/edited via the **Configure Provider** modal (§7.2). OpenCode-provided and Copilot Plus-provided models auto-appear as rows when their preconditions are met.
 
-The two non-BYOK sections (**OpenCode** and **Copilot Plus**) auto-appear when their preconditions are met (OpenCode binary detected; Plus license active). They are not user-added and cannot be removed.
-
-### 5.1 Anatomy — empty state (default for new users)
+### 5.1 Anatomy — empty state
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│ Models                                                          │
-│                                                                 │
+│ BYOK                                                            │
 │ Add providers and choose which models you want available        │
 │ throughout Copilot.                                             │
-│                                                                 │
 │                                                                 │
 │             ┌─────────────────────────────────────┐             │
 │             │                                     │             │
@@ -227,517 +228,570 @@ The two non-BYOK sections (**OpenCode** and **Copilot Plus**) auto-appear when t
 │             │   models, or add a custom endpoint  │             │
 │             │   (Ollama, self-hosted, etc.)       │             │
 │             │                                     │             │
-│             │   [ + Add provider ]                │             │
+│             │        [ + Add provider ]           │             │
 │             │                                     │             │
 │             └─────────────────────────────────────┘             │
-│                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### 5.2 Anatomy — populated state
+The only CTA is `[+ Add provider]`. No provider shortcut buttons — selection happens inside the Add Provider dialog (§7.1).
+
+### 5.2 Anatomy — populated state (flat table)
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│ Models                                          [+ Add provider]│
+│ BYOK                            [Manage providers] [+ Add prov] │
+│ All enabled models. Filter, sort, toggle visibility.            │
 │                                                                 │
-│ Default chat model:  [ Claude Sonnet 4.5 ▾ ]                    │
-│ (Used for chain-mode chat and custom commands. Agent defaults   │
-│  are per-backend, set in the Agent tab.)                        │
+│ [🔍 Filter models…]  [All] [💬 chat] [🤖 agent] [local]         │
 │                                                                 │
-│ ──────────────────────────────────────────────────────────────  │
+│ ┌─────────────────────────────────────────────────────────────┐ │
+│ │   MODEL · PROVIDER             CAPABILITY    META           │ │
+│ ├─────────────────────────────────────────────────────────────┤ │
+│ │ ☑ Big Pickle · OpenCode        🤖            Free           │ │
+│ │ ☑ Copilot Plus Flash · …       🤖            Plus           │ │
+│ │ ☑ Claude Sonnet 4.5 · Anthropic 💬 🤖        200k · Vision ⋯│ │
+│ │ ☑ Claude Opus 4.1 · Anthropic   💬 🤖        200k · Reason  │ │
+│ │ ☑ Claude Haiku 4.5 · Anthropic  💬 🤖        200k · Fast    │ │
+│ │ ☑ GPT-5 · OpenAI                💬 🤖        400k · Vision  │ │
+│ │ ☑ llama3.2 · Ollama (local)     💬 🤖        local · 8B     │ │
+│ └─────────────────────────────────────────────────────────────┘ │
 │                                                                 │
-│ ▼ [opencode-logo] OpenCode                        1 model       │
-│   Free models bundled with OpenCode. Agent only.                │
-│                                                  [✓ Detected]   │
-│   ☑ Big Pickle                  🤖   Free                       │
-│                                                                 │
-│ ──────────────────────────────────────────────────────────────  │
-│                                                                 │
-│ ▼ Copilot Plus                                    1 model       │
-│   Hosted models for Copilot Plus subscribers. Agent only.       │
-│                                                  [✓ Plus]       │
-│   ☑ Copilot Plus Flash          🤖   Included with Plus         │
-│                                                                 │
-│ ──────────────────────────────────────────────────────────────  │
-│                                                                 │
-│ ▼ Anthropic                                       4 models      │
-│   API key:  •••••••••••••••••••••••••  [Change] [✓ Verified]    │
-│                                                                 │
-│   ☑ Claude Sonnet 4.5      💬 🤖   200k ctx   ★ Default chat    │
-│   ☑ Claude Opus 4.1        💬 🤖   200k ctx                     │
-│   ☑ Claude Haiku 4.5       💬 🤖   200k ctx                     │
-│   ☑ Claude Sonnet 3.7      💬 🤖   200k ctx                     │
-│                                                                 │
-│   [ + Add models ]                              [Remove provider]│
-│                                                                 │
-│ ──────────────────────────────────────────────────────────────  │
-│                                                                 │
-│ ▼ Ollama (local — custom)                         2 models      │
-│   Base URL: http://localhost:11434  [Change]                    │
-│                                                                 │
-│   ☑ llama3.2:latest        💬 🤖                                │
-│   ☑ qwen2.5-coder:7b       💬 🤖                                │
-│                                                                 │
-│   [ + Add models ]                              [Remove provider]│
-│                                                                 │
+│ 7 enabled · 124 available in catalog                            │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Section ordering rule.** When present, the **OpenCode** and **Copilot Plus** sections always sit at the top of the panel (in that order), immediately under the Default chat model selector. BYOK and custom providers follow in the order the user added them. This ordering surfaces the highest-leverage models (the ones Copilot uniquely provides) first; the user can collapse them if they prefer.
+**Why a flat table instead of per-provider accordion sections?** Two reasons:
 
-**Icon usage note.** The OpenCode section header uses the OpenCode logo icon (small, ~16px). Apply the same OpenCode logo wherever OpenCode is referenced (Agent tab radio option, install button, status badges, in-chat backend indicators). Do not use a generic placeholder.
+1. Power users with 30+ models can scan a single sorted list faster than 5+ collapsible cards.
+2. Provider configuration belongs in its own dedicated modal, not in the line-of-sight of users who just want to find a model. The Configure Provider modal (§7.2) lives one click away via the row kebab.
 
-### 5.3 Provider section behavior
+**Ordering rule.** OpenCode-provided rows appear first, then Copilot Plus rows, then BYOK and custom-provider rows grouped by provider in the order the user added them. The user cannot drag-to-reorder.
 
-A provider section exists in the Models panel only because the user added it (or because it auto-appears — OpenCode/Copilot Plus). Sections are expanded by default after adding. Once collapsed by the user, the collapsed header still shows: provider name, model count, and any status badges.
+### 5.3 Header controls
 
-Each BYOK section contains:
+Top-right of the populated table:
 
-- **Masked API key** with `[Change]` button and verification status (✓ Verified / ⚠ Invalid / ⏳ Checking…).
-- **Enabled models list** — each row is a model the user has added (see §5.4 for row anatomy).
-- **`[+ Add models]`** button — opens the Add Models dialog (§7), pre-scoped to this provider.
-- **`[Remove provider]`** button (right side of the section) — removes the provider, its key, and all its enabled models. Confirmation modal.
+- **[+ Add provider]** — primary action. Opens Add Provider dialog (§7.1).
+- **[Manage providers]** — ghost button. Opens a small list of every configured provider with a "Configure →" link for each. Useful when you want to change a key but don't have a specific model row to kebab into.
 
-OpenCode and Copilot Plus sections have a different structure — see §5.7.
+Below the header, a filter bar:
+
+- **Search box** — fuzzy match against model name and provider.
+- **Capability chips** — `All` / `💬 chat` / `🤖 agent` / `local`. Click to filter; multi-select.
+
+Footer of the panel: a muted line showing `<N> enabled · <M> available in catalog`.
 
 ### 5.4 Model row anatomy
 
-Each row in an enabled-models list shows, left to right:
+Each row in the flat table:
 
-- **Checkbox** (visibility toggle — controls whether the model appears in the chat input's model picker; checked = visible)
-- **Model display name** (provider's preferred name, e.g. "Claude Sonnet 4.5", not the API id `claude-sonnet-4-5-20250929`)
-- **Capability badges** (💬 and/or 🤖 — see §2)
-- **Inline metadata** (context window, "Free", "Reasoning", etc. — small, muted)
-- **★ Default chat** pill if this is the user's Default Chat Model
-- **Row hover menu** (`⋯` button) with: Set as default chat (only for 💬-capable rows), Remove from registry
+- **Checkbox** — visibility toggle. Checked = visible in the chat input's model picker dropdown. Unchecking **does not** remove the model from the registry — it just hides it from the picker.
+- **Model display name** (provider's preferred name, e.g. "Claude Sonnet 4.5", not the API id `claude-sonnet-4-5-20250929`) · **Provider** (muted, smaller, joined by `·`).
+- **Capability badges** — `💬 chat` and/or `🤖 agent` pills.
+- **Inline metadata** — context window, "Free", "Reasoning", "local", etc. — small, muted.
+- **Kebab `⋯`** — opens the row menu:
+  - **⚙ Configure provider (<Provider>) →** — primary action. Opens Configure Provider modal (§7.2) in `edit` state, scoped to this row's provider.
+  - **↗ View model docs** — opens the provider's model page in a browser.
+  - **— Remove from list** — removes the model from the registry. Inline confirmation. (Different from unchecking the visibility checkbox.)
 
-The capability badge has a tooltip on hover explaining what it means.
+Capability badges have a tooltip on hover explaining what they mean.
 
-### 5.5 Default chat model selector
+There is **no ★ Default pill** on rows. The BYOK panel does not surface a "default chat model" — defaults are an Agent-tab concern (per backend), and chain-mode chat uses whatever the user last selected in the chat input.
 
-Sits at the top of the populated panel. Dropdown lists every enabled 💬-capable model, grouped by provider. This default is used by chain-mode contexts only: mobile chat, custom commands, simple one-shot chat. **Agent-mode defaults are per-backend and live in the Agent tab — see §6.**
+### 5.5 OpenCode / Copilot Plus rows
 
-If no chat-capable models are enabled, the dropdown shows "Add a chat-capable model below to set a default."
+When OpenCode is detected, OpenCode-provided models (e.g. Big Pickle) appear as flat-table rows with provider = "OpenCode", caps = `[🤖]`, meta = "Free". When the user has a Copilot Plus license, Copilot Plus-provided models (e.g. Copilot Plus Flash) appear as rows with provider = "Copilot Plus", caps = `[🤖]`, meta = "Plus".
+
+Both kinds of rows behave like any other row (visibility checkbox, capability badges, meta). The kebab menu omits "Configure provider" (provider is system-managed — nothing to configure) but keeps "View model docs" and "Remove from list" (removing hides until the source re-adds it).
+
+When OpenCode isn't installed, OpenCode-provided rows do not appear, and an inline banner at the top of the BYOK panel reads: _"OpenCode isn't installed yet. Models with the 🤖 badge will work once you install it. → Go to Agent tab."_ Copilot Plus rows are similarly absent when the license isn't active; the Welcome modal already pushes Plus to net-new users.
 
 ### 5.6 Mobile differences
 
-- 🤖 badges hidden, header text changed to "Choose which models you want available for chat."
-- **OpenCode** and **Copilot Plus** sections hidden entirely (no agent backend → no consumer).
-- Add Custom Provider dialog hides the "Available in agent mode" toggle (always chat-only on mobile).
+- 🤖 badges hidden everywhere.
+- OpenCode and Copilot Plus rows hidden (no agent backend → no consumer).
+- Header text changes to "Choose which models you want available for chat."
 - Single-column layout, larger touch targets.
-
-### 5.7 OpenCode and Copilot Plus sections — special behavior
-
-Both sections are **system-managed** (auto-appear when conditions are met), unlike BYOK and custom providers which are user-added. **When present, they always render at the top of the panel** (OpenCode first, Copilot Plus second), above any user-added providers.
-
-- **No API key input.** They use either no auth (OpenCode-provided) or the Copilot Plus license (Copilot Plus).
-- **No `[+ Add models]` button.** The catalog is curated by Copilot/OpenCode; users can only toggle visibility of what's offered, not add arbitrary models.
-- **No `[Remove provider]` button.** They can't be removed individually — only by uninstalling OpenCode or letting the Plus license lapse.
-- **Section header shows a status badge** to clarify entitlement:
-  - **OpenCode** section: `[✓ Detected]` or `[⚠ Not installed]`. When not installed, the section is rendered greyed with a "Install OpenCode in the Agent tab to unlock these models" inline link.
-  - **Copilot Plus** section: `[✓ Plus]` or `[🔒 Plus required]`. When the user has no Plus license, the section is rendered greyed with a "Subscribe to Copilot Plus to unlock these models" inline link. The model list is still shown so the user understands what they'd get.
 
 ---
 
 ## 6. The Agent tab (detailed)
 
-Desktop only. Hidden on mobile. **There is no "agent mode" on/off toggle** — desktop is always agent-capable. Mobile simply hides this tab and the agent surfaces in the Models tab.
+Desktop only. Hidden on mobile. There is **no "agent mode" on/off toggle** — desktop is always agent-capable.
 
 ### 6.1 Anatomy
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │ Agent                                                           │
-│                                                                 │
 │ Run multi-turn agent sessions with tool use and file edits.     │
 │                                                                 │
-│ ──────────────────────────────────────────────────────────────  │
+│ [ ▶ OpenCode ]  [ Claude Code ]  [ Codex ]                      │
 │                                                                 │
-│ Active backend:                                                 │
-│   (●) [opencode-logo] OpenCode   (recommended)                  │
-│   ( ) Claude Code                                               │
-│   ( ) Codex                                                     │
+│ ┌─ Status ─────────────────────────────────────────────────┐    │
+│ │ Status                              [✓ Active backend]   │    │
+│ │ v0.4.2 at /usr/local/bin/opencode                        │    │
+│ │ [Use this backend] [Reinstall] [Browse…]                 │    │
+│ └──────────────────────────────────────────────────────────┘    │
 │                                                                 │
-│ ──────────────────────────────────────────────────────────────  │
+│ ┌─ Default agent model ─────┐ ┌─ Default reasoning effort ─┐    │
+│ │ [Claude Sonnet 4.5 ▾]     │ │ [Min] [Low] [●Med] [High]  │    │
+│ │ From Models registry,     │ │                            │    │
+│ │ 🤖-capable.               │ │                            │    │
+│ └───────────────────────────┘ └────────────────────────────┘    │
 │                                                                 │
-│ [OpenCode panel — shown when selected]                          │
-│   Binary: /usr/local/bin/opencode                               │
-│   [Auto-detect] [Browse...] [Install [opencode-logo] OpenCode]  │
-│   Status: ✓ Detected (v0.4.2)                                   │
-│                                                                 │
-│   Default agent model:  [ Claude Sonnet 4.5 ▾ ]                 │
-│     (Filtered to 🤖-capable models registered for OpenCode —    │
-│      BYOK providers, custom providers, Big Pickle, Plus Flash)  │
-│                                                                 │
-│   Default reasoning effort: ( ) Minimal  ( ) Low                │
-│                             (●) Medium   ( ) High               │
-│                                                                 │
-│   Models                                                        │
-│   Managed in Models tab. → Open Models tab                      │
-│                                                                 │
-│                                                                 │
-│ [Claude Code panel — shown when selected]                       │
-│   Binary: /usr/local/bin/claude                                 │
-│   [Auto-detect] [Browse...] [Install Claude Code]               │
-│   Status: ✓ Detected (v1.2.0)                                   │
-│                                                                 │
-│   Subscription: Authenticated as zerolxy@gmail.com              │
-│   [Re-authenticate]                                             │
-│                                                                 │
-│   Visible models in picker:                                     │
-│     ☑ claude-sonnet-4-5                                         │
-│     ☑ claude-opus-4-1                                           │
-│     ☐ claude-haiku-4-5                                          │
-│                                                                 │
-│   Default agent model:  [ claude-sonnet-4-5 ▾ ]                 │
-│     (Filtered to visible models above)                          │
-│                                                                 │
-│   Default reasoning effort: ( ) Minimal  ( ) Low                │
-│                             (●) Medium   ( ) High               │
-│                                                                 │
-│                                                                 │
-│ [Codex panel — shown when selected]                             │
-│   ...analogous to Claude Code: binary, auth, visible models,    │
-│   Default agent model, Default reasoning effort...              │
-│                                                                 │
+│ ┌────────────────────────────────────────────────────────────┐  │
+│ │ Models live in the BYOK tab.   → Open Models               │  │
+│ └────────────────────────────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Icon usage note.** Use the OpenCode logo icon next to the OpenCode radio option, the OpenCode install button, and any other place OpenCode is referenced (Models panel section header, in-chat indicators, status badges). Apply consistently — never substitute a generic placeholder.
+### 6.2 Sub-tabs vs active backend
 
-### 6.2 Backend radio behavior
+Backend selection uses **sub-tabs at the top of the Agent panel**, not a radio list. Sub-tabs swap the whole configuration panel; switching sub-tabs does **not** change the active backend.
 
-Three radio options. Each radio reveals its own configuration block below the selector. Only one backend is "active" at a time; the others stay configured (paths, visibility lists, defaults are preserved per-backend so switching back doesn't lose state). The active backend's Default agent model and Default reasoning effort seed the chat input on session start.
+The **active backend** (the one chat sessions actually use) is separate from the sub-tab currently being viewed. Each backend's Status card shows whether it is active (`✓ Active backend`) or merely configured (`○ Configured, not active`) or unconfigured (`⚠ Not installed`). The **`[Use this backend]`** button in the Status card promotes the viewed backend to active.
+
+This separation lets the user configure a non-active backend (re-authenticate, change visibility, install) without disrupting the currently-running active one.
+
+Each backend remembers its own configuration (binary path, auth, default agent model, default reasoning effort, visibility) — switching sub-tabs preserves state.
 
 ### 6.3 OpenCode panel
 
-Four key elements:
-1. **Binary path + install** — detects existing OpenCode in PATH; if missing, "Install OpenCode" button downloads + installs into the plugin's known location. Status line shows version when detected. Uses the OpenCode logo icon.
-2. **Default agent model** — dropdown filtered to every 🤖-capable model from the unified Models registry (BYOK + custom + Big Pickle + Copilot Plus Flash). This is the model OpenCode boots with for a new agent session. Independent of the Default chat model in the Models tab.
-3. **Default reasoning effort** — radio with four levels (Minimal / Low / Medium / High). Applies to reasoning-capable models when run through OpenCode. Maps to the existing per-backend effort knob in the codebase.
-4. **Models link** — no inline model list. Catalog is managed in the Models tab; one-line explainer and deep link.
+The OpenCode sub-tab contains:
+
+1. **Status card** — version + binary path; `[Use this backend]`, `[Reinstall]`, `[Browse…]` buttons. When the binary is missing, the card shows `⚠ Not installed` and offers `[Install OpenCode]` (primary) + `[I have it elsewhere…]`.
+2. **Default agent model** — dropdown filtered to every 🤖-capable model in the BYOK registry (BYOK + custom + Big Pickle + Copilot Plus Flash). The model OpenCode boots with for a new agent session.
+3. **Default reasoning effort** — **chip group** with four levels: Min / Low / Med / High. Applies to reasoning-capable models when run through OpenCode.
+4. **"Models live in the BYOK tab"** dashed banner — one-line explainer and deep link. No inline model curation on OpenCode (the BYOK registry is the single source of truth).
 
 ### 6.4 Claude Code / Codex panels
 
 Five key elements:
-1. **Binary path + install** — same pattern as OpenCode.
-2. **Authentication** — see §6.5.
-3. **Visible models in picker** — inline checklist of that backend's bundled models. The bundled list is small (4–8 entries), maintained in plugin code, refreshed on plugin update. Each row: checkbox + model id. No 💬/🤖 badges (entire list is 🤖-only by definition).
-4. **Default agent model** — dropdown filtered to the **visible** models in this backend. Used as the seed model when starting a Claude Code / Codex session.
-5. **Default reasoning effort** — radio with four levels (Minimal / Low / Medium / High). Applies to reasoning-capable models in this backend.
 
-If the binary isn't detected, the visible-models list still renders (so the user can pre-configure visibility before installing) but the Default agent model picker shows a "Install [backend] to use" empty state.
+1. **Status card** — same shape as OpenCode (binary path + version + buttons). For CC/Codex the install button reads `[Install Claude Code]` / `[Install Codex]`.
+2. **Subscription card** — "Authenticated as <email>", `[Re-authenticate]` button. Unauthenticated state: "Not signed in to <backend>. [Sign in via <backend>]".
+3. **Visible models in picker** — inline checklist of that backend's bundled models. The list is small (4–8 entries), maintained in plugin code, refreshed on plugin update. Each row: checkbox + model id (monospace). No 💬/🤖 badges (entire list is 🤖-only).
+4. **Default agent model** — dropdown filtered to the **visible** models above. Used as the seed model when starting a session in this backend.
+5. **Default reasoning effort** — chip group (Min / Low / Med / High).
+
+If the binary isn't detected, the visible-models list still renders (pre-configure visibility before installing). The Default agent model picker is gated with "Install <backend> first."
 
 ### 6.5 Authentication state (Claude Code / Codex only)
 
-Claude Code and Codex auth via the binary's own subscription flow (not BYOK). The panel surfaces:
+Claude Code and Codex auth via the binary's own subscription flow (not BYOK). The Subscription card surfaces:
+
 - Authenticated user (e.g. "Authenticated as zerolxy@gmail.com")
-- "Re-authenticate" button → triggers the binary's auth refresh
-- Unauthenticated state: "Not signed in. Open Claude Code to sign in." with helper link.
+- `[Re-authenticate]` button → triggers the binary's auth refresh
+- Unauthenticated state: `⚠ Not signed in` badge + `[Sign in via <backend>]` (opens binary auth flow in a child process). Bundled-models list rendered greyed until signed in.
 
 ---
 
 ## 7. Dialogs (detailed)
 
 Three dialogs in this redesign:
-- **Add Provider** dialog (§7.1) — triggered from `[+ Add provider]` at the top of the Models panel (or from the empty-state CTA). Picks which provider to add.
-- **Add Models** dialog (§7.2) — triggered from `[+ Add models]` inside a provider section. Picks which models from that provider to enable.
-- **Add Custom Provider** dialog (§7.8) — a variant of Add Provider when the user picks the "Custom" option.
+
+- **Add Provider** (§7.1) — provider picker. Opens from `[+ Add provider]`.
+- **Configure Provider** (§7.2) — one shared modal with **three states**: `new-byok`, `new-custom`, `edit`. Replaces what would have been three separate dialogs (Enter API key / Add Models / Add Custom Endpoint). Opens after picking a provider, or from the row kebab on the BYOK table.
+- **Add Custom Model** (§7.3) — first-class modal opened from Configure Provider's Models header to add a model not in the catalog (preview models, fine-tunes, private deployments). Works for **any** provider — BYOK or custom.
 
 ### 7.1 Add Provider dialog
 
-Modal opened by `[+ Add provider]` (top-right of populated Models panel, or center CTA on empty state). Lists every provider the plugin supports, plus a "Custom" option for arbitrary endpoints.
+Modal opened by `[+ Add provider]`. Lists every supported provider plus a "Custom OpenAI-compatible endpoint" option.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │ Add a provider                                            [X]   │
-│                                                                 │
-│ [🔍 Search providers...                                      ]  │
+│ [🔍 Search providers…                                       ]   │
 │                                                                 │
 │  Recommended                                                    │
-│    Anthropic              Claude family                         │
-│    OpenAI                 GPT family                            │
-│    Google                 Gemini family                         │
+│    [An]  Anthropic   — Claude family                  [Add →]   │
+│    [Op]  OpenAI      — GPT family                        ＋     │
+│    [Go]  Google      — Gemini family                     ＋     │
 │                                                                 │
 │  More providers                                                 │
-│    Groq                   Fast inference, open-weight models    │
-│    Mistral                Mistral & Mixtral                     │
-│    xAI                    Grok family                           │
-│    DeepSeek               DeepSeek family                       │
-│    OpenRouter             Aggregator (Anthropic, OpenAI, …)     │
-│    Cohere                                                       │
-│    Azure OpenAI                                                 │
-│    AWS Bedrock                                                  │
-│    GitHub Copilot                                               │
-│    Together                                                     │
-│    Fireworks                                                    │
-│    Perplexity                                                   │
-│                                                                 │
-│  ──────────────────────────────────────────────                 │
+│    [Gr]  Groq                                            ＋     │
+│    [Mi]  Mistral                                         ＋     │
+│    [xA]  xAI                                             ＋     │
+│    [De]  DeepSeek                                        ＋     │
+│    [OR]  OpenRouter                                      ＋     │
+│    [Co]  Cohere                                          ＋     │
+│    [Az]  Azure OpenAI                                    ＋     │
+│    [AW]  AWS Bedrock                                     ＋     │
+│    [Gi]  GitHub Copilot                                  ＋     │
+│    [To]  Together                                        ＋     │
+│    [Fi]  Fireworks                                       ＋     │
+│    [Pe]  Perplexity                                      ＋     │
+│  ────────────────────────────────────                           │
 │    + Custom OpenAI-compatible endpoint                          │
-│      Ollama, vLLM, LM Studio, self-hosted, etc.                 │
-│                                                                 │
+│      Ollama, vLLM, LM Studio, self-hosted, etc.       [Add →]   │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-Selecting a built-in provider closes this dialog and adds a new section to the Models panel for that provider, expanded with the API key input focused. Recommended providers (Anthropic, OpenAI, Google) appear at the top; the rest are alphabetical. Already-added providers are filtered out of the list (and the search) so users can't accidentally add a duplicate. **OpenCode** and **Copilot Plus** never appear in this list — they're system-managed and auto-appear when conditions are met.
+Selecting a built-in provider closes this dialog and opens **Configure Provider** in `new-byok` state (§7.2). Selecting "+ Custom OpenAI-compatible endpoint" opens Configure Provider in `new-custom` state.
 
-Selecting "Custom OpenAI-compatible endpoint" opens the Add Custom Provider dialog (§7.8).
+Recommended providers (Anthropic, OpenAI, Google) appear at the top; the rest follow alphabetically. Already-added providers are filtered out (so users can't accidentally duplicate). **OpenCode** and **Copilot Plus** never appear in this list — they're system-managed.
 
-### 7.2 Add Models dialog (BYOK providers)
+### 7.2 Configure Provider dialog — one screen, three states
 
-Modal dialog. Pre-scoped to the provider the user clicked from. Shows the **full provider catalog** with search and filters. User checks the rows they want; closing the dialog adds them to the enabled list.
+The same screen renders three flavors based on entry point:
+
+- **`new-byok`** — after picking Anthropic/OpenAI/etc. from Add Provider.
+- **`new-custom`** — after picking "Custom endpoint" from Add Provider.
+- **`edit`** — from the row kebab on the BYOK table (or from `[Manage providers]` → Configure).
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│ Add Anthropic models                                       [X]  │
+│ [An] Anthropic              ✓ Verified  (edit state only) [X]   │
+│ Added Mar 4 · 4 models registered · used by chat & agent        │
+│  (or: "Paste your key and pick which models you want." new-byok)│
+│  (or: "OpenAI-, Anthropic-, or Google-compatible servers." cust)│
 │                                                                 │
-│ [🔍 Search models...                                         ]  │
+│ Display name      Ollama (local)              (new-custom only) │
+│ Type              (●) OpenAI-comp  ( ) Anthropic  ( ) Google    │
+│                                       (new-custom only)         │
 │                                                                 │
-│ Filters: [ All ] [ Vision ] [ Reasoning ] [ Tool use ]          │
+│ API key           sk-ant-•••••••••••••••     [Replace]  [Test]  │
+│ Base URL          https://api.anthropic.com                     │
+│ Availability      ☑ chat   ☑ [OC] OpenCode   ☐ mobile           │
 │                                                                 │
-│  ☑ Claude Sonnet 4.5         200k ctx · Vision · Reasoning      │
-│    Latest balanced model                                        │
+│ ── Models ─── (5 in catalog · pick which to register)           │
+│                                  [+ Add from catalog]  (edit)   │
+│                                  [+ Add custom model]           │
 │                                                                 │
-│  ☑ Claude Opus 4.1           200k ctx · Vision · Reasoning      │
-│    Best reasoning                                               │
+│ [🔍 Filter models…] [All][💬 chat][🤖 agent][Vision][Reasoning] │
+│                     [Tool use][≥ 200k ctx][≤ $1/M]              │
 │                                                                 │
-│  ☐ Claude Haiku 4.5          200k ctx · Vision                  │
-│    Fast & cheap                                                 │
+│ ☑ Claude Sonnet 4.5             200k · Vision · Reasoning    ⋯  │
+│ ☑ Claude Opus 4.1               200k · Reasoning             ⋯  │
+│ ☑ Claude Haiku 4.5              200k · Fast                  ⋯  │
+│ ☑ Claude Sonnet 3.7             200k                         ⋯  │
+│ ☐ Claude Haiku 3.5              200k                            │
 │                                                                 │
-│  ☐ Claude Sonnet 3.7         200k ctx · Vision · Reasoning      │
-│    Previous generation                                          │
+│ catalog — known models · custom — preview/fine-tune/private     │
+│ ─────────────────────────────────────────────────────────────   │
+│ [Remove provider]                       [Cancel] [Save changes] │
+│                                                       (edit)    │
 │                                                                 │
-│  ☐ Claude Haiku 3.5          200k ctx                           │
-│                                                                 │
-│  ...more...                                                     │
-│                                                                 │
-│  2 selected           [Cancel]  [Add 2 models]                  │
+│  "3 selected · key stored in OS keychain"                       │
+│                                       [Cancel] [Verify & save]  │
+│                                       (new states)              │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### 7.3 Catalog source for the dialog
+#### 7.2.1 Header
 
-Reads from the same source that powered the Models panel (OpenCode if available, bundled snapshot otherwise — see §2). Already cached, no network call when the dialog opens.
+- **Provider glyph + name** (provider's preferred name).
+- **Status badge** — `✓ Verified` only in `edit` state with a working key. Not shown in new states (no badge until the user clicks Test or Verify & save).
+- **Subhead line** varies by state:
+  - `edit`: context — "Added Mar 4 · 4 models registered · used by chat & agent".
+  - `new-byok`: "Paste your key and pick which models you want available."
+  - `new-custom`: "OpenAI-, Anthropic-, or Google-compatible servers."
 
-### 7.4 Search and filters
+#### 7.2.2 Connection fields
+
+All three states share a 120px label gutter. Fields:
+
+- **Display name** — only in `new-custom`. The user-facing label for the custom provider.
+- **Type** — only in `new-custom`. Radio: OpenAI-compatible / Anthropic / Google. Drives request format.
+- **API key** — always shown. In `edit`: masked value with `[Replace]` button. In `new` states: empty field. `[Test]` button issues a no-cost verification call. In `new-custom`, the field label adds "(optional)" since many local servers don't require auth.
+- **Base URL** — always shown. Read-only in BYOK states (provider's known URL); editable in custom state (e.g. `http://localhost:11434/v1`).
+- **Availability** — three checkboxes: `chat`, `<OpenCode glyph> OpenCode`, `mobile`. Controls which consumers can see this provider's models. (Custom providers often default `mobile` off since custom endpoints typically live on localhost.)
+
+#### 7.2.3 Models section
+
+Header row: `Models <subtitle>` on the left, action buttons on the right.
+
+- Subtitle in `new-byok`: "5 in catalog · pick which to register".
+- Subtitle in `edit`: "4 of 5 catalog registered".
+- Subtitle in `new-custom`: omitted (catalog is auto-discovered from the endpoint's `/models`).
+- Action buttons on the right:
+  - `[+ Add from catalog]` — only in `edit` (re-opens the catalog picker inline).
+  - `[+ Add custom model]` — in all three states (opens Add Custom Model dialog §7.3).
+
+Below the header: a **filter bar** with search + chips for `All` / `💬 chat` / `🤖 agent` / `Vision` / `Reasoning` / `Tool use` / `≥ 200k ctx` / `≤ $1/M`. (The price chip is suppressed for custom providers where pricing isn't applicable.)
+
+The model list is a tight checklist. Each row: checkbox + model display name + meta line. In `edit` state each registered row gets a `⋯` kebab with model-level actions (View docs, Remove from registry).
+
+A helper note appears below the model list (edit state): _"catalog — known models · custom — preview, fine-tune, private deployment"_.
+
+For `new-custom`, the model list is populated by calling the provider's `/models` endpoint. On failure, the list shows an empty state inviting the user to use `[+ Add custom model]`.
+
+#### 7.2.4 Footer
+
+- **New states (`new-byok`, `new-custom`):**
+  - Left: muted info — "3 selected · key stored in OS keychain" (BYOK) or "2 selected · stored locally" (custom).
+  - Right: `[Cancel]` `[Verify & save]`.
+- **Edit state:**
+  - Left: `[Remove provider]` (ghost, danger). Removes the provider, its key, and all its registered models. Confirmation modal.
+  - Right: `[Cancel]` `[Save changes]`.
+
+### 7.3 Add Custom Model dialog (any provider)
+
+Opens from the `[+ Add custom model]` button in any Configure Provider state. The provider's connection (API key, base URL) is reused — this dialog just adds a model entry that the catalog doesn't list (preview models, fine-tunes, private deployments, just-released models).
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ [An] Add custom model · under Anthropic                  [X]    │
+│ Use this for preview models, fine-tunes, private deployments,   │
+│ or anything not in the catalog. The provider's connection       │
+│ (key, base URL) is reused.                                      │
+│                                                                 │
+│ Display name      Claude Sonnet 4.5 (preview)                   │
+│ Model ID          claude-sonnet-4-5-20260601-preview     [Test] │
+│ Context window    200000   tokens — optional, defaults to prov  │
+│                                                                 │
+│ Capabilities      ☑ 💬 chat   ☑ 🤖 agent   ☐ Vision             │
+│                   ☑ Reasoning ☑ Tool use   ☐ JSON mode          │
+│                                                                 │
+│ Availability      ☑ chat   ☑ [OC] OpenCode   ☐ mobile           │
+│ ──────────────────────────────────────────────────────────────  │
+│ Test once before saving — we'll send a minimal "ping" request.  │
+│                                          [Cancel] [Add model]   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Fields:
+
+- **Display name** — what the user sees in pickers.
+- **Model ID** — the string the provider's API expects.
+- **Context window** — optional integer; defaults to the provider's general default.
+- **Capabilities** — six checkboxes: `💬 chat`, `🤖 agent`, `Vision`, `Reasoning`, `Tool use`, `JSON mode`. Explicit because Copilot can't infer capabilities from a model ID alone.
+- **Availability** — same three checkboxes as Configure Provider.
+
+The `[Test]` button next to Model ID issues a minimal "ping" request to verify the model is reachable at the provider before saving. Save creates the entry in the registry under this provider.
+
+### 7.4 Catalog source
+
+Both Configure Provider's catalog list and Add Custom Model's provider context read from the same source that powered the BYOK panel (OpenCode if available, bundled snapshot otherwise — see §2). Already cached; no network call when the dialog opens.
+
+### 7.5 Search and filters (in Configure Provider's model list)
 
 - **Search box** — fuzzy match against model name, family, and description.
-- **Capability filters** — chip buttons for Vision, Reasoning, Tool use, Attachments. Multi-select.
+- **Capability chips** — `All` / `💬 chat` / `🤖 agent` / `Vision` / `Reasoning` / `Tool use` / `≥ 200k ctx` / `≤ $1/M`. Multi-select. The `local` chip from the BYOK table doesn't appear here (scope is one provider).
 - **Sort** — default by recency (release date desc). Optionally by name or context window.
 
-### 7.5 Already-enabled models in the dialog
+### 7.6 Already-registered models
 
-Models already in the registry render with their checkbox pre-checked and disabled (no double-add). A small text label "Already added" replaces the description.
-
-### 7.6 "Custom model" escape hatch
-
-Below the catalog list: a small "+ Add a model not listed here" link that opens a sub-form with three fields:
-- Display name
-- Model ID (the string the API expects)
-- Capabilities (Vision / Reasoning / Tool use checkboxes)
-
-For users who need to use a model the catalog doesn't know about (just-released models, fine-tunes, etc.).
+In `edit` state, registered models are pre-checked. In `new-byok`, recommended models are pre-checked on open. A model already in the registry from a previous open of the dialog renders with its checkbox pre-checked.
 
 ### 7.7 OpenRouter special case
 
-OpenRouter exposes hundreds of models from many upstream providers. The dialog gets a secondary grouping by upstream provider (Anthropic, OpenAI, Mistral, etc.) shown as sticky section headers within the scroll. Search still cross-cuts. The capability filters become especially important here.
+OpenRouter exposes hundreds of models from many upstream providers. Configure Provider's model list groups by upstream provider (Anthropic, OpenAI, Mistral, …) with **sticky section headers** within the scroll. Search still cross-cuts. Capability + price chip filters become especially important.
 
-### 7.8 Add Custom Provider dialog
+### 7.8 Verification on save
 
-Triggered when the user selects "+ Custom OpenAI-compatible endpoint" from the Add Provider dialog (§7.1).
-
-Form fields:
-- **Display name** (e.g. "Ollama local", "Office vLLM")
-- **Provider type** (radio: OpenAI-compatible / Anthropic-compatible / Google-compatible — drives request format)
-- **Base URL** (e.g. `http://localhost:11434/v1`)
-- **API key** (optional — many local servers don't require one)
-- **Available in agent mode** (checkbox, default on; hidden on mobile)
-
-On submit, the provider is created as a new top-level section in the Models panel (alongside Anthropic/OpenAI/etc. — not nested under a "Custom" group). The dialog then transitions to "Add models for [Display name]" (analogous to §7.2) so the user can immediately pick models. For local servers, the dialog tries to call the provider's `/models` endpoint to populate the catalog; on failure, it falls back to the "add manually" form (§7.6).
-
-### 7.9 Verification on add
-
-When the dialog closes with new selections, the plugin verifies each added model by issuing a minimal test call ("hello, reply ok"). On failure, the model appears in the list with a warning icon and a tooltip ("Last verification failed — click to retry"). The user can still keep it (some endpoints don't support the test call but work fine for real prompts).
+When Configure Provider closes via `[Verify & save]` or `[Save changes]`, the plugin verifies each newly-added model by issuing a minimal test call ("hello, reply ok"). On failure, the model appears in the BYOK table with a `⚠` icon and a tooltip ("Last verification failed — click to retry"). The user can still keep it (some endpoints don't support the test call but work fine for real prompts).
 
 ---
 
 ## 8. Critical user journeys (walk-throughs)
 
-These are the journeys the designer should mock in detail. Each is a multi-screen flow.
+These are the journeys the designer mocked in the Final flow. Each is a multi-screen flow.
 
 ### 8.1 First-run desktop (agent-first, three onboarding paths)
 
 **Goal:** New user gets to a working agent in under 60 seconds.
 
-The welcome panel is **agent-first**. Chain-mode chat exists but is intentionally de-emphasized — the welcome doesn't prompt for chat setup. The three primary paths are:
+The Welcome modal is **standalone** — it overlays the entire Obsidian window with a dimmed app silhouette behind. It is **not** rendered inside the settings modal. There is **no** "Just want simple chat? Skip agent setup →" secondary link. The three primary paths are:
 
 - **"Use my existing subscription"** — for users with Claude Code or Codex installed/subscribed. Opens Agent tab pre-selected to whichever backend the plugin can detect.
-- **"Bring my own key"** — for users who already have a provider API key (Anthropic, OpenAI, etc.). Opens Models tab with the Add Provider dialog already showing.
-- **"Subscribe to Copilot Plus"** — for users who'd rather pay Copilot than juggle keys. Opens the Plus subscription flow; on success, the Copilot Plus section auto-appears in the Models panel and the user is dropped into the Agent tab with OpenCode pre-installed.
-
-Below the three primary buttons, a small secondary link reads: "Just want simple chat? Skip agent setup →" — clicking it opens the Models tab without any agent guidance.
+- **"Bring my own key"** — for users who already have a provider API key. Opens Add Provider dialog over the BYOK tab.
+- **"Subscribe to Copilot Plus"** — for users who'd rather pay Copilot than juggle keys. Opens the Plus subscription flow; on success, OpenCode is auto-installed, Copilot Plus rows light up in BYOK, and the user lands in the Agent tab on the OpenCode sub-tab.
 
 **Walkthrough — "Use my existing subscription" (e.g. Claude Code):**
 
-1. User installs the plugin, opens Obsidian, opens Copilot for the first time.
-2. Welcome panel shows the three buttons. User clicks **"Use my existing subscription."**
-3. Sub-picker shows: Claude Code / Codex. User picks Claude Code.
-4. Agent tab opens with Claude Code selected. Binary auto-detected at `/usr/local/bin/claude` → ✓ Detected.
-5. Auth status: "Not signed in. [Sign in via Claude Code]." User clicks → Claude Code's auth flow runs in a child process → user completes auth.
-6. Status updates: "Authenticated as user@example.com." Claude Code's bundled model list lights up. Default agent model = Sonnet (auto). Default effort = Medium (auto).
-7. Done. User closes settings, opens a chat, sends a message. Sonnet runs via Claude Code.
+1. User installs the plugin, opens Obsidian — Welcome modal appears over a dimmed Obsidian.
+2. User clicks **"Use my existing subscription."** Sub-picker shows Claude Code / Codex.
+3. User picks Claude Code. Welcome closes; Settings opens to the Agent tab, Claude Code sub-tab.
+4. Binary auto-detected at `/usr/local/bin/claude` → ✓ Detected.
+5. Subscription card: "Not signed in. [Sign in via Claude Code]." User clicks → Claude Code's auth flow runs in a child process.
+6. Status updates: "Authenticated as user@example.com." Bundled model list lights up. Default agent model auto-set to Sonnet. Default effort = Med.
+7. User clicks `[Use this backend]` to promote Claude Code to active. Done.
 
 **Walkthrough — "Bring my own key":**
 
-1. User clicks **"Bring my own key."**
-2. Models tab opens. Add Provider dialog is **already showing** (no extra click).
-3. User picks Anthropic. Dialog closes; Anthropic section appears expanded with key input focused.
-4. User pastes key. ✓ Verified.
-5. Add Models dialog opens with recommended Anthropic models pre-checked. User accepts.
-6. Default chat model auto-populates with Sonnet 4.5.
-7. A non-intrusive next-step prompt: "Set up the agent so models work in agent sessions too." → Switches to Agent tab, OpenCode pre-selected, **"Install OpenCode"** button prominent.
-8. User clicks Install. Progress, then ✓ Detected.
-9. OpenCode's Default agent model picker auto-populates with Sonnet 4.5 (the BYOK model). Default effort = Medium.
-10. Done.
+1. User clicks **"Bring my own key."** Welcome closes; Settings opens to BYOK tab with **Add Provider** dialog already showing.
+2. User picks Anthropic. Add Provider closes; **Configure Provider** opens in `new-byok` state with the API key field focused.
+3. User pastes the key, clicks `[Test]` → ✓ Verified.
+4. The Models section in the same screen pre-checks recommended Anthropic models (Sonnet 4.5, Opus 4.1).
+5. User leaves defaults, clicks `[Verify & save]`. Configure Provider closes; BYOK table now shows the registered Anthropic rows.
+6. A non-intrusive prompt: "Set up the agent so models work in agent sessions too." → Switches to Agent tab, OpenCode sub-tab, `[Install OpenCode]` prominent.
+7. User clicks Install. Progress, then ✓ Detected.
+8. OpenCode's Default agent model auto-populates with Sonnet 4.5 (from the BYOK registry). Default effort = Med. Done.
 
 **Walkthrough — "Subscribe to Copilot Plus":**
 
 1. User clicks **"Subscribe to Copilot Plus."**
-2. Copilot's Plus subscription flow runs (out of scope for this redesign — handled by license management).
-3. On success, the plugin installs OpenCode automatically in the background.
-4. User is dropped into the Agent tab. OpenCode pre-selected. Status ✓ Detected. The Copilot Plus section in the Models tab is now active with Copilot Plus Flash available.
-5. Default agent model auto-set to Copilot Plus Flash. Default effort = Medium.
-6. Done.
+2. Plus subscription flow runs (out of scope — handled by license management).
+3. On success, the plugin installs OpenCode in the background.
+4. User lands in the Agent tab, OpenCode sub-tab. ✓ Detected. Copilot Plus rows now appear in the BYOK tab.
+5. Default agent model auto-set to Copilot Plus Flash. Default effort = Med. Done.
 
 ### 8.2 Add a model from OpenRouter (hundreds of models)
 
-1. User has already added OpenRouter as a provider and entered the API key.
-2. User clicks `[+ Add models]` in the OpenRouter section.
-3. Add Models dialog opens, scoped to OpenRouter, showing hundreds of models grouped by upstream provider (Anthropic, OpenAI, Mistral, etc.) with sticky section headers.
-4. User types "sonnet" in the search box → list filters live to ~6 matches across upstream providers.
-5. User applies the "Vision" filter → list filters further.
-6. User checks "Claude Sonnet 4.5" and "Gemini 2.5 Flash" → counter at the bottom updates to "2 selected".
-7. User clicks "Add 2 models." Dialog closes. Both models appear in the OpenRouter section's enabled list with verification spinners → ✓ within 2s each.
+1. User has already added OpenRouter as a provider (Configure Provider, `edit` state).
+2. User opens the OpenRouter row's kebab on the BYOK table → "Configure provider (OpenRouter)".
+3. Configure Provider opens in `edit` state, scoped to OpenRouter, showing the catalog grouped by upstream provider with sticky section headers.
+4. User types "sonnet" in the search box → list filters to ~6 matches across upstreams.
+5. User applies the `Vision` chip → list filters further.
+6. User checks "anthropic/claude-sonnet-4-5" and "google/gemini-2.5-flash". Footer shows "5 of 327 selected".
+7. User clicks `[Save changes]`. Configure Provider closes. Both models appear in the BYOK table with verification spinners → ✓ within 2s each.
 
 ### 8.3 Add a local Ollama provider
 
-1. User clicks `[+ Add provider]` at the top of the Models panel.
-2. Add Provider dialog (§7.1) opens. User scrolls down and clicks "+ Custom OpenAI-compatible endpoint."
-3. Add Custom Provider dialog (§7.8) opens.
-4. User fills in: Display name = "Ollama (local)", Provider type = OpenAI-compatible, Base URL = `http://localhost:11434/v1`, API key empty, "Available in agent mode" checked.
-5. User clicks "Continue."
-6. Dialog transitions to "Add models for Ollama (local)." The plugin pinged `http://localhost:11434/v1/models` and got back a list of locally installed Ollama models. The user sees them as a checklist.
-7. User checks "llama3.2:latest" and "qwen2.5-coder:7b." Clicks "Add 2 models."
-8. Dialog closes. The Ollama section now exists in the Models panel at the **top level** alongside Anthropic/OpenAI/etc. (not nested under any "Custom providers" wrapper). Both models showing 💬 🤖 badges.
-9. Both models are immediately available in the chat input picker. If OpenCode is running, both are also runnable in agent mode — the plugin has registered Ollama as a custom provider in OpenCode's config.
+1. User clicks `[+ Add provider]` at the top of the BYOK table.
+2. Add Provider dialog opens. User scrolls down and clicks "+ Custom OpenAI-compatible endpoint."
+3. **Configure Provider** opens in `new-custom` state.
+4. User fills: Display name = "Ollama (local)", Type = OpenAI-compatible, Base URL = `http://localhost:11434/v1`, API key empty.
+5. Plugin pings `http://localhost:11434/v1/models`; the Models section populates with locally-installed Ollama models.
+6. User checks `llama3.2:latest` and `qwen2.5-coder:7b`. Clicks `[Verify & save]`.
+7. Configure Provider closes. BYOK table now has two Ollama rows at the top-level (alongside Anthropic etc., not nested). Both show 💬 🤖 badges (Availability had OpenCode checked).
+8. If OpenCode is running, the plugin registers Ollama as a custom provider in OpenCode's config so the models are usable in agent mode.
 
 ### 8.4 Change Claude Code agent visibility
 
-**Pre-condition:** User has Claude Code as their active agent backend.
+**Pre-condition:** User has Claude Code installed (sub-tab configured), but the active backend is OpenCode.
 
 1. User opens Settings → Agent tab.
-2. Claude Code section is expanded (it's the active backend).
+2. User clicks the Claude Code sub-tab. The panel swaps. Status card shows `○ Configured, not active`.
 3. User scrolls to "Visible models in picker." Sees 4 checkboxes:
    - ☑ claude-sonnet-4-5
    - ☑ claude-opus-4-1
    - ☑ claude-haiku-4-5
    - ☑ claude-sonnet-3-7
-4. User unchecks claude-haiku-4-5 and claude-sonnet-3-7.
-5. State persists immediately (no Save button — inline persistence pattern from existing Copilot settings).
-6. User closes settings, opens the chat input, clicks the agent model picker. Only Sonnet 4.5 and Opus 4.1 appear in the dropdown.
+4. User unchecks `claude-haiku-4-5` and `claude-sonnet-3-7`.
+5. State persists immediately (no Save button — inline persistence). The change applies whether Claude Code is currently active or not.
+6. If the user wants Claude Code to be active too, they click `[Use this backend]` in the Status card. Otherwise OpenCode stays active.
 
 ### 8.5 Switch agent backends (OpenCode → Codex)
 
-1. User opens Settings → Agent tab.
-2. User clicks the "Codex" radio.
-3. OpenCode panel collapses. Codex panel expands.
-4. Codex panel shows: binary not detected, install button, sub-only model checklist (empty defaults).
-5. User clicks "Install Codex." Progress, then ✓ Detected.
-6. User clicks "Sign in to Codex" → opens binary auth flow in a child process. User completes auth in browser. Status updates to "Authenticated as user@example.com."
-7. Codex's bundled model list lights up. User leaves defaults checked.
-8. Default agent model picker now lists Codex's visible models. User picks GPT-5. Default effort = Medium (auto).
-9. Done. The chat input model picker now shows Codex's models under a "Codex" group. The user picks one from there to start a session; the backend switches accordingly.
+1. User opens Settings → Agent tab, clicks the Codex sub-tab.
+2. Codex panel: Status `⚠ Not installed`. `[Install Codex]` (primary) + `[I have it elsewhere…]`.
+3. User clicks Install. Progress, then ✓ Detected.
+4. Subscription card: "Sign in to Codex after install." User clicks `[Sign in]` → child process. Auth completes; status updates to "Authenticated as user@example.com."
+5. Bundled-models list lights up. User leaves defaults.
+6. Default agent model dropdown lists visible models. User picks GPT-5. Default effort = Med.
+7. User clicks `[Use this backend]` in the Status card. Codex is now active. Chat input picker now reads from Codex's visible models.
 
 ### 8.6 Offline (no network)
 
-**Scenario:** User opens Settings → Models on a laptop without internet.
-
-1. Models panel opens normally — the bundled catalog (shipped with the plugin) powers the Add Models dialog. No network call is needed for the catalog to render.
-2. User clicks `[+ Add provider]` → picks Anthropic → enters the key.
-3. Key verification call fails (no network). The key is stored but the section shows "⚠ Couldn't verify — offline. Will verify when online."
-4. User clicks `[+ Add models]` → Add Models dialog opens from the bundled catalog — full provider model list available.
-5. User adds two models. Their verification calls also fail. They appear in the list with ⚠ icons and tooltip "Couldn't verify — offline. Will retry when used."
+1. User opens Settings → BYOK on a laptop without internet.
+2. Panel renders normally — bundled catalog powers Configure Provider's Models section. No network call needed.
+3. User clicks `[+ Add provider]` → Anthropic → Configure Provider opens in `new-byok` state.
+4. User pastes a key, clicks `[Test]` — fails. The key is still saved but the field shows "⚠ Couldn't verify — offline. Will verify when online."
+5. User picks two models, clicks `[Verify & save]`. Verification calls fail. Models appear in the BYOK table with `⚠` icons and tooltip "Couldn't verify — offline. Will retry when used."
 6. Later, when online, the next real use of the models succeeds and the warning icons disappear automatically.
 
 ### 8.7 OpenCode not installed — graceful degradation
 
-1. User has OpenCode selected as backend, but binary is missing.
-2. Models tab still renders. Catalog source falls back to bundled snapshot. The **OpenCode** section is shown but greyed with "Install OpenCode to unlock these models." The **Copilot Plus** section is shown the same way (also requires OpenCode at runtime).
-3. 🤖 badges still appear on cloud BYOK models (because they would work via OpenCode if it were installed). A small banner at the top of the Models tab: "OpenCode isn't installed yet. Models with the 🤖 badge will work once you install it. → Go to Agent tab."
-4. User can keep configuring chat models normally; chain-mode chat works.
-5. When user installs OpenCode (via Agent tab), the banner disappears, the catalog source switches to OpenCode, the OpenCode and (if Plus) Copilot Plus sections light up with their model lists.
+1. User has BYOK providers configured but no OpenCode binary.
+2. BYOK table renders normally. Catalog source falls back to the bundled snapshot. OpenCode-provided rows are absent; Copilot Plus rows are also absent (Plus requires OpenCode at runtime).
+3. 🤖 badges still appear on cloud BYOK models (they would work via OpenCode if it were installed).
+4. A banner at the top of the BYOK panel: "OpenCode isn't installed yet. Models with the 🤖 badge will work once you install it. → Go to Agent tab."
+5. User can configure chat models normally; chain-mode chat works.
+6. When user installs OpenCode (via Agent tab), the banner disappears, the catalog source switches to OpenCode, OpenCode-provided rows and (if Plus) Copilot Plus rows appear in the table.
 
 ### 8.8 Remove a model entirely
 
-1. User in Models tab, hovers a row, clicks `⋯`.
-2. Menu: "Set as default chat" (if 💬-capable) | "Remove from registry"
-3. Clicks Remove. Inline confirmation: "Remove Claude Haiku 4.5? You can add it back from + Add models." [Cancel] [Remove]
-4. Row disappears. If it was the Default Chat Model, the default reverts to the next enabled chat-capable model. If it was a Default Agent Model for any backend, that backend's default reverts to its first visible model.
+1. User in BYOK tab, opens a row's `⋯` kebab.
+2. Menu: ⚙ Configure provider (Anthropic) | ↗ View model docs | — Remove from list
+3. Clicks Remove. Inline confirmation: "Remove Claude Haiku 4.5? You can add it back from + Add from catalog." `[Cancel]` `[Remove]`.
+4. Row disappears. If it was a Default Agent Model for any backend, that backend's default reverts to its first visible model.
+
+(There is no "Set as default chat" menu item — the Default Chat Model concept is gone. The visibility checkbox handles show/hide.)
 
 ### 8.9 Edit a custom provider's base URL
 
-1. User in Models tab finds the Ollama (local) section at the top level (alongside Anthropic etc., not nested).
-2. Clicks `[Change]` next to "Base URL: http://localhost:11434".
-3. Modal opens with the existing fields pre-filled. User changes URL to `http://my-server.tailnet.ts.net:11434/v1`.
-4. Saves. Plugin pings the new URL. ✓ Verified. Existing models stay in the registry.
-5. If the new URL doesn't return the expected model IDs, the models in this provider's enabled list show ⚠ warnings — the user is told "These models weren't found at the new URL. Remove them?" with a [Remove these models] action.
+1. User in BYOK tab opens an Ollama row's `⋯` kebab → "Configure provider (Ollama)".
+2. Configure Provider opens in `edit` state with all fields pre-filled.
+3. User changes Base URL to `http://my-server.tailnet.ts.net:11434/v1`. Clicks `[Test]` → ✓.
+4. Clicks `[Save changes]`. Plugin pings the new URL. Existing models stay in the registry.
+5. If the new URL doesn't return the expected model IDs, the model rows show `⚠` warnings with "These models weren't found at the new URL. Remove them?" → `[Remove these models]`.
 
 ---
 
 ## 9. Empty / loading / error states
 
-The designer must mock these explicitly — they're at least as common as the happy path.
-
 ### 9.1 Empty registry (no providers yet)
 
-This is the **default state** of the Models tab on first launch. See §5.1 for the full anatomy. The single primary CTA is `[+ Add provider]`. Helper copy invites both BYOK and custom endpoints. There are no provider shortcut buttons — selection happens inside the Add Provider dialog (§7.1).
+Default state on first launch of the BYOK tab. See §5.1. The single primary CTA is `[+ Add provider]`. Helper copy invites both BYOK and custom endpoints. No provider shortcut buttons.
 
 ### 9.2 Polling OpenCode for catalog
 
-Brief skeleton state on Models tab open while the plugin queries OpenCode for its live catalog. Usually <500ms — should not flash a heavy spinner. Use shimmer skeletons on the provider sections. When OpenCode isn't installed, this state is skipped — the bundled catalog renders immediately.
+Brief skeleton state on BYOK tab open while the plugin queries OpenCode for its live catalog. Usually <500ms — shimmer skeletons on the table rows. When OpenCode isn't installed, this state is skipped (bundled catalog renders immediately).
 
 ### 9.3 Invalid API key
 
-Inline below the key input, red text:
+Inside Configure Provider, below the key field, red text:
 
 ```
 ⚠ Couldn't verify your key. Check that it's correct and has access to chat models.
-[Re-enter key] [Get a new key]
+[Re-enter key] [Get a new key →]
 ```
 
 The "Get a new key" link goes to the provider's key management page.
 
 ### 9.4 Model verification failed
 
-On adding a model that fails its test call, the row in the enabled list shows ⚠ next to the model name. Tooltip: "Last verification failed: <error message>". Click ⚠ → small popover with [Retry] and [Remove from registry].
+On saving Configure Provider with a model that fails its test call, the row in the BYOK table shows `⚠` next to the model name. Tooltip: "Last verification failed: <error message>". Click `⚠` → popover with `[Retry]` and `[Remove from registry]`.
 
-### 9.5 OpenCode binary detected at unexpected location
+### 9.5 Two OpenCode binaries detected
 
-If the user has both a plugin-installed binary and a system-wide binary, the Agent tab shows both and lets the user pick. Helper text: "Two OpenCode installations detected. Choose which one to use."
+Agent tab → OpenCode sub-tab. Status card shows a radio list:
 
-### 9.6 No models enabled
+```
+(●) /usr/local/bin/opencode        v0.4.2 · system
+( ) ~/Library/.../opencode         v0.4.0 · plugin-installed
+```
 
-Models panel "Default model" picker is empty. Show inline: "No models enabled yet. Add a provider above to pick models."
+Helper text: "Two OpenCode installations detected. Choose which one to use."
+
+### 9.6 No providers, no models
+
+BYOK tab empty state. No "default chat model" picker exists (the concept is removed), so there's no empty-default-picker variant to design.
 
 ### 9.7 Subscription not authenticated (Claude Code / Codex)
 
-Backend panel shows:
+Subscription card in the backend sub-tab:
+
 ```
-Not signed in to Claude Code.
-[Sign in via Claude Code] (opens binary auth flow)
+⚠ Not signed in
+Your subscription auth has expired or never completed.
+[Sign in via Claude Code]   [Helper docs →]
 ```
-Models list is greyed.
+
+Bundled-models card greyed until signed in.
+
+### 9.8 Offline notice
+
+Top of BYOK tab when network is unreachable:
+
+```
+[i] You're offline.
+Catalog still works (bundled). Keys & models will verify when you're online.
+```
+
+### 9.9 OpenCode missing banner
+
+Top of BYOK tab when OpenCode is selected as the active backend but the binary is missing:
+
+```
+[i] OpenCode isn't installed yet.
+Models with the 🤖 badge will work once you install it.  → Go to Agent tab
+```
+
+### 9.10 Remove-model confirmation
+
+Inline mini-modal triggered from the row kebab → Remove from list:
+
+```
+Remove Claude Haiku 4.5?
+Remove from registry? You can add it back from + Add from catalog.
+(If it was a default agent model, the default will revert to next.)
+[Cancel] [Remove]
+```
 
 ---
 
@@ -745,15 +799,19 @@ Models list is greyed.
 
 ### 10.1 Desktop vs mobile
 
-| Aspect | Desktop | Mobile |
-|---|---|---|
-| Agent tab | Visible | Hidden entirely |
-| 🤖 badges | Visible | Hidden everywhere |
-| OpenCode section (Big Pickle, etc.) | Visible | Hidden |
-| Copilot Plus section (Plus Flash, etc.) | Visible | Hidden |
-| Custom provider "Available in agent mode" toggle | Visible | Hidden (default off, can't be enabled) |
-| Settings modal width | ~700–900px | Full-screen overlay |
-| Touch targets | Default | Min 44pt |
+The redesigned settings UI is **desktop-shaped** (90%+ of users). Mobile users get a stripped-down view of the same surfaces:
+
+| Aspect                                                            | Desktop                        | Mobile                                |
+| ----------------------------------------------------------------- | ------------------------------ | ------------------------------------- |
+| Welcome modal                                                     | Standalone modal over Obsidian | Skipped — direct to BYOK tab          |
+| Agent tab                                                         | Visible                        | Hidden entirely                       |
+| 🤖 badges                                                         | Visible                        | Hidden everywhere                     |
+| OpenCode rows (Big Pickle, etc.)                                  | Visible                        | Hidden                                |
+| Copilot Plus rows (Plus Flash, etc.)                              | Visible                        | Hidden                                |
+| Configure Provider "Availability" — `OpenCode` checkbox           | Visible                        | Hidden (forced off)                   |
+| Add Custom Model "Availability" — `OpenCode` + agent capabilities | Visible                        | `OpenCode` hidden, `agent` cap hidden |
+| Settings modal width                                              | ~1320px                        | Full-screen overlay                   |
+| Touch targets                                                     | Default                        | Min 44pt                              |
 
 ### 10.2 Obsidian theme
 
@@ -761,16 +819,17 @@ The Obsidian shell exposes CSS variables for colors, spacing, radii, fonts. Mock
 
 ### 10.3 Settings modal constraints
 
-Copilot's settings live inside the Obsidian modal. The tab list runs **horizontally across the top of the modal** (this is how Copilot's existing settings work — it is not Obsidian's stock left-rail pattern). The content area scrolls vertically below the tabs.
+Copilot's settings live inside the Obsidian modal. The tab list runs **horizontally across the top of the modal** (Copilot's existing pattern — not Obsidian's stock left-rail).
 
-- Width: bounded by Obsidian modal (assume ~800px for mockup).
-- Tabs: horizontal strip at the top of the modal (Basic, Models, Agent, Chat & Commands, …).
+- Width: bounded by Obsidian modal (~1320px for the redesign).
+- Tabs: horizontal strip at the top (BYOK, Agent, Chat & Commands, …).
 - Content: scrolls vertically beneath the tabs.
-- Nested dialogs (Add Provider, Add Models, Add Custom Provider) overlay the modal at ~80% of its area — not full screen.
+- Nested dialogs (Add Provider, Configure Provider, Add Custom Model) overlay the modal at ~80% of its area, max ~820px wide.
+- The Welcome modal is standalone — not nested inside Settings.
 
 ### 10.4 Persistence
 
-All settings persist immediately on change (no Save button). This is the existing Copilot pattern.
+All settings persist immediately on change (no Save button) — the existing Copilot pattern. Configure Provider and Add Custom Model are the exceptions: they use explicit `[Verify & save]` / `[Save changes]` / `[Add model]` buttons because the user is composing multiple fields at once.
 
 ---
 
@@ -778,33 +837,36 @@ All settings persist immediately on change (no Save button). This is the existin
 
 Existing users on the current settings will, on first launch after this redesign ships:
 
-1. Existing provider keys → preserved as-is. Providers with a configured key auto-appear as sections in the new Models panel (without the user having to re-add them via Add Provider).
-2. Existing `activeModels` array → preserved; each model lands in the appropriate provider section.
-3. Existing per-model overrides (temperature, max_tokens, etc.) → **dropped silently.** All chains revert to defaults. No notice shown (the cohort that notices is tiny).
-4. Existing agent-mode-specific model curation (`modelEnabledOverrides` for OpenCode) → merged into the unified registry's enabled state.
-5. Existing default chat model → preserved as the **Default Chat Model** in the Models tab.
-6. Existing per-backend agent defaults (Default Agent Model, Default reasoning effort) → preserved per backend in the Agent tab. If any backend lacks a saved default, seed with the backend's first visible model and Medium effort.
+1. Existing provider keys → preserved. Each provider with a configured key auto-appears in the BYOK registry (no need to re-add via Add Provider). The user can hit the row kebab → Configure provider to inspect.
+2. Existing `activeModels` array → preserved; each model lands as a row in the BYOK table under its provider.
+3. Existing per-model overrides (temperature, max_tokens, etc.) → **dropped silently.** All chains revert to defaults. No notice shown.
+4. Existing agent-mode model curation (`modelEnabledOverrides` for OpenCode) → merged into the BYOK registry's visibility state (the row checkbox).
+5. Existing "Default Chat Model" setting → **discarded.** The concept is removed; chat input remembers the last-selected model.
+6. Existing per-backend agent defaults (Default Agent Model, Default reasoning effort) → preserved per backend in the Agent tab. If any backend lacks a saved default, seed with the backend's first visible model and Med effort.
 7. Existing "agent mode enabled" boolean → **discarded.** Agent capabilities are always available on desktop; the per-user toggle no longer exists.
+8. Existing custom provider definitions → preserved as top-level providers in the BYOK registry. Each gets an `edit`-state row in Configure Provider.
 
-The designer doesn't need to design a migration UI. There isn't one.
+There is no migration UI; the changes are silent on launch.
 
 ---
 
 ## 12. Out of scope (explicit)
 
-- **Embedding models.** They live in a separate "Embeddings" panel that this redesign does not touch.
+- **Embedding models.** Separate "Embeddings" panel, not touched.
 - **Reranker models.** Same — separate, untouched.
 - **License / Plus / Believer tier management.** Separate panel, not part of this redesign.
-- **Chat UI.** The redesigned model picker dropdown inside the chat input is technically a consumer of the unified registry, but its design is owned by the chat redesign work (separate).
+- **Chat UI.** The redesigned chat-input model picker is a consumer of the BYOK registry, but its design is owned by chat redesign work.
 - **Skills / Custom commands / MCP servers.** Separate panels.
-- **Per-model temperature / max_tokens / system prompt.** Removed. Don't design for them.
-- **Drag-to-reorder models.** Out. Sort alphabetically or by provider.
+- **Per-model temperature / max_tokens / system prompt.** Removed.
+- **Default Chat Model picker.** Removed — chain-mode chat uses last-selected.
+- **Drag-to-reorder models.** Out. Sort defaults: provider order then alphabetical.
+- **Special "pinned section" styling for OpenCode / Copilot Plus.** OpenCode and Copilot Plus appear as ordinary table rows, sorted to the top, not as visually-distinct pinned sections.
 
 ---
 
 ## 13. Glossary
 
-- **BYOK** — Bring Your Own Key. The user supplies an API key from their provider account.
+- **BYOK** — Bring Your Own Key. The user supplies an API key from their provider account. Also the name of the consolidated settings **tab** (renamed from "Models").
 - **Chain mode** — Single-turn LLM calls via LangChain. Powers chat, custom commands. Works on mobile.
 - **Agent mode** — Multi-turn agent sessions via an external binary backend. Desktop-only.
 - **OpenCode** — Copilot's recommended agent backend. Open source, BYOK, supports many providers. Ships with a bundled `models.dev` catalog and a set of free models (Big Pickle, etc.).
@@ -813,40 +875,34 @@ The designer doesn't need to design a migration UI. There isn't one.
 - **Big Pickle** — A free model bundled with OpenCode. No BYOK or license required. Agent-only (requires OpenCode installed).
 - **Copilot Plus** — Copilot's paid subscription tier. Unlocks access to hosted models served by Copilot (e.g. Copilot Plus Flash).
 - **Copilot Plus Flash** — A paid hosted model served by Copilot, available to Copilot Plus subscribers. Routed through OpenCode at runtime. Agent-only.
-- **`models.dev`** — An open catalog of LLM models across providers with metadata (context, pricing, modalities, capabilities). The plugin ships a tree-shaken snapshot of this catalog. There is **no live refresh** in this design — the user sees whatever ships with the plugin (or whatever OpenCode provides). Catalog updates ride along with plugin or OpenCode updates.
-- **Capability badges** — 💬 (chat-capable) and 🤖 (agent-capable) icons shown next to each enabled model.
-- **Default Chat Model** — One global setting (lives in Models tab). The model used for chain-mode chat: mobile chat, custom commands, simple chat. Must be 💬-capable.
-- **Default Agent Model** — One **per agent backend** (lives in the Agent tab, inside each backend's panel). The model used when starting an agent session in that backend. Must be 🤖-capable and visible in that backend.
-- **Default Reasoning Effort** — One **per agent backend** (lives in the Agent tab). Four levels: Minimal / Low / Medium / High. Applies to reasoning-capable models in that backend.
-- **Registry** — The user's enabled models. Curated, not the full catalog. The list users see in the Models panel.
+- **`models.dev`** — An open catalog of LLM models across providers with metadata (context, pricing, modalities, capabilities). The plugin ships a tree-shaken snapshot. There is **no live refresh** in this design.
+- **Capability badges** — `💬 chat` and `🤖 agent` pills shown next to each enabled model row.
+- **Default Agent Model** — One **per agent backend** (lives in the Agent tab, inside each backend's sub-tab). The model used when starting an agent session in that backend. Must be 🤖-capable and visible in that backend.
+- **Default Reasoning Effort** — One **per agent backend** (in the Agent tab). Four levels: Min / Low / Med / High. Applies to reasoning-capable models in that backend. Surfaced as a chip group, not a radio.
+- **Registry** — The user's enabled models. Curated, not the full catalog. The list users see in the BYOK panel.
 - **Catalog** — The full list of available models for a provider. Not all of them are in the user's registry.
-- **Provider section** — A collapsible card per provider in the Models panel (Anthropic, OpenAI, Ollama, etc.). Created when the user adds the provider, or auto-created for OpenCode and Copilot Plus when conditions are met.
-- **Custom provider** — A user-defined OpenAI-compatible (or similar) endpoint, e.g. Ollama or a self-hosted server. Appears at the top level of the Models panel alongside built-in providers, **not** nested under a "Custom" wrapper.
+- **Active backend** — The agent backend that chat sessions actually use. Separate from the Agent tab's _viewed sub-tab_. Promoted via `[Use this backend]` on the sub-tab's Status card.
+- **Custom provider** — A user-defined OpenAI-compatible (or Anthropic / Google-compatible) endpoint, e.g. Ollama or a self-hosted server. Appears as a top-level provider in the BYOK registry, **not** nested under a "Custom" wrapper.
+- **Configure Provider** — A single dialog with three states (`new-byok`, `new-custom`, `edit`). Consolidates what would otherwise be three separate dialogs (Enter API key, Add Models, Add Custom Endpoint).
+- **Add Custom Model** — A first-class dialog opened from Configure Provider to register a model that isn't in the catalog. Works for any provider.
 - **LangChain** — The library Copilot uses to instantiate and call provider SDKs in chain mode.
 
 ---
 
-## 14. Design deliverables expected from the next designer
+## 14. Design source
 
-1. **Wireframe designs** for:
-   - Models panel — **empty state** (default for new users; see §5.1)
-   - Models panel — **populated state** with OpenCode + Copilot Plus pinned at the top, BYOK providers (Anthropic, OpenAI, …) and custom providers (Ollama) below in user-added order (§5.2)
-   - Models panel — mobile variant (no 🤖 badges, no OpenCode / Copilot Plus sections; no mobile-specific onboarding — same panel as desktop, fewer surfaces)
-   - **Add Provider dialog** (§7.1) — list of built-in providers + Custom option
-   - **Add Models dialog** — two variants: Anthropic-style (~5 models) and OpenRouter-style (hundreds of models with sticky upstream-provider headers)
-   - **Add Custom Provider dialog** (both step 1 form and step 2 model picklist)
-   - **Agent tab** with OpenCode active — including Default agent model picker and Default reasoning effort radio (§6.1 / §6.3)
-   - **Agent tab** with Claude Code active — visibility checklist + Default agent model + Default reasoning effort (§6.4)
-   - **Agent tab** with Codex active — analogous to Claude Code
-2. **First-run welcome panel** with the **three primary buttons** (Use existing subscription / Bring my own key / Subscribe to Copilot Plus) plus the secondary "Just want simple chat?" link. See §8.1.
-3. **All empty / loading / error states** listed in §9.
-4. **Interaction notes** for hover menus, tooltips on badges, dialog transitions, provider section collapse/expand, and the auto-appearance + top-pinning of OpenCode / Copilot Plus sections.
-5. **OpenCode icon treatment** — define the icon size, where it appears, and how it integrates with section headers, buttons, radios, and status badges.
-6. **A few "before/after" comparison frames** showing how this consolidates the current three surfaces (the existing surfaces are described in §0 and the user requirements in §3 — no codebase access needed).
+The design that this doc reflects is exported from Claude Design as `copilot-model-settings/`. The canonical reference for visuals and interaction details:
 
-Things explicitly **not** to design:
-- An "agent mode on/off" toggle — there is none. Desktop is always agent-capable.
-- A dedicated mobile onboarding flow — mobile is ~1% of traffic; reuse the desktop Models panel with agent surfaces hidden.
-- Chat-first welcome states — the welcome is agent-first; chat-only setup is a secondary link.
+- `project/index.html` — the wireframe app shell.
+- `project/screens/final.jsx` — the **★ Final flow** that consolidates picked variants and adds two gap-filling screens (unified Configure Provider, Add Custom Model). Read this first.
+- `project/screens/welcome.jsx` (V1) — Welcome modal as standalone three-tile picker.
+- `project/screens/models-populated.jsx` (V3) — populated BYOK tab as a flat table.
+- `project/screens/add-provider.jsx` (V1) — provider picker dialog.
+- `project/screens/add-models.jsx` (V2) — OpenRouter-scale picker with sticky upstream-provider headers (now folded into Configure Provider's catalog list).
+- `project/screens/agent-opencode.jsx` (V2) — Agent tab with sub-tabs per backend.
+- `project/screens/agent-cc.jsx` (V1) — Claude Code / Codex internals (subscription + bundled visibility checklist).
+- `project/screens/states.jsx` — all empty / loading / error / offline / auth states.
+- `project/styles.css` and `project/primitives.jsx` — the low-fi component primitives the wireframes use.
+- `chats/chat1.md` and `chats/chat2.md` — design conversation transcripts that document the iterations and final decisions.
 
-When in doubt, optimize for **the first-run user finishing agent setup in under 60 seconds** and **the power user with 30+ enabled models keeping the panel scannable**. Those two opposing forces are the design tension to resolve.
+When in doubt, the design files override anything in this doc. This doc exists to translate design intent into engineering-ready language and to track the constraints (catalog source, migration, mobile differences) that aren't visually obvious in the mocks.

--- a/designdocs/QUICK_CHAT_AGENT_INTEGRATION.md
+++ b/designdocs/QUICK_CHAT_AGENT_INTEGRATION.md
@@ -1,0 +1,367 @@
+# Quick Chat → Agent Integration — Technical Design
+
+> **Status:** Draft, 2026-05-20.
+> **Companion to:** the Model Management Redesign technical plan (shared separately as a handoff artifact for the implementing agent; product UX spec is `designdocs/MODEL_MANAGEMENT_REDESIGN.md`).
+> **Scope owner:** Follow-up workstream after the model management redesign ships. The model management plan creates a Quick Chat **skeleton** sub-tab in the Agent panel — this doc owns the rest: runtime routing, chat-input → backend resolution, and binding LangChain chat into the new chat view as a first-class agent backend.
+
+---
+
+## 0. Why this doc exists
+
+The latest Copilot design (`copilot-model-settings/project/screens/final.jsx`) introduces a fourth agent sub-tab called **Quick chat** sitting alongside OpenCode, Claude Code, and Codex. Conceptually, what used to be "chain mode" — single-turn LangChain calls made directly from the chat input — is being elevated into an _agent backend_ in its own right, so that:
+
+- **All four backends share the same shape** (status card · default model · default reasoning effort · in-session model picker).
+- **The chat input model picker becomes the source of routing.** When the user selects a model, the active agent backend is whichever one curated that model into its picker. Pick a Quick-Chat-curated model → LangChain chat fires. Pick an OpenCode-curated model → OpenCode session fires. The user no longer needs to flip a separate "chain mode vs agent mode" switch.
+- **The "new chat view" (the redesigned chat UI shipping alongside the agent work)** treats Quick Chat the same way it treats every other backend: opens a session, streams messages, surfaces tool calls, renders attachments. The view doesn't branch on "is this LangChain?" — it just talks to the backend through the existing `BackendDescriptor` contract.
+
+The model management redesign plan deliberately stops short of this work because it touches the chat session pipeline, the chat input model picker, the new chat view, and the legacy ChatModelManager call sites — too many surfaces for one ship. This doc plans that follow-up cleanly.
+
+---
+
+## 1. Goals & Non-goals
+
+### Goals
+
+1. **Quick Chat is a real agent backend.** It implements the existing `BackendDescriptor` interface (`src/agentMode/backends/types.ts`) so the chat view, session manager, and `[Use this backend]` button treat it identically to OpenCode et al.
+2. **Chat input model picker = routing decision.** Selecting a model in the chat input resolves to one specific backend; the plugin starts a session in that backend with that model.
+3. **The new chat view renders Quick Chat sessions** using the same primitives it uses for OpenCode/Claude Code/Codex sessions.
+4. **Per-backend curation works for Quick Chat.** The user picks which chat-capable BYOK models surface in Quick Chat's in-session picker (already wired in the model management M6 skeleton; this doc activates the runtime path).
+5. **Migration is silent.** Users with a saved `defaultModelKey` (pre-redesign) keep that same model as their Quick Chat default — already arranged by the model management plan's migration step 7.
+
+### Non-goals
+
+- **No new LLM features.** This is wiring, not capability work. Streaming, tool use, vision — all use the existing LangChain pipeline.
+- **No changes to OpenCode/Claude Code/Codex backends.** They're untouched.
+- **No new settings tabs.** Quick Chat is a sub-tab inside the existing Agent panel.
+- **No legacy chat view changes.** This doc assumes the new chat view is the target. (If a legacy view still ships during transition, Quick Chat falls back to legacy LangChain invocation on that path — see §6.5.)
+
+---
+
+## 2. Conceptual model
+
+### 2.1 Routing — "which backend owns this model right now?"
+
+Today the chat input picker reads from `activeModels` and hands the selection to `ChatModelManager`, which builds a LangChain client. Agent mode is a separate path: a toggle + a per-backend default model.
+
+After this work:
+
+```
+Chat input picker
+    │
+    ▼  user picks "Claude Sonnet 4.5"
+    │
+    ▼
+ChatRoutingService.resolveBackend(modelKey)
+    │
+    ▼
+┌────────────────────────────────────────────────────────┐
+│ For each backend in priority order:                    │
+│   if backend.picker.includes(modelKey): return backend │
+│                                                        │
+│ Priority order: active backend → quickChat →           │
+│   opencode → claude → codex                            │
+└────────────────────────────────────────────────────────┘
+    │
+    ▼
+ChatSessionManager.openSession(backend, modelKey)
+```
+
+**Why this priority order:** It prefers what the user explicitly set as active, then defaults to Quick Chat (the safest, mobile-capable choice), then falls back through the agent backends. A model the user has only added to Quick Chat's picker but is _currently_ active in OpenCode → if the active backend (OpenCode) doesn't have it, we fall to the next backend that does.
+
+**A model can appear in multiple backends' pickers** (e.g., Claude Sonnet 4.5 in both OpenCode's picker AND Quick Chat's picker). The priority rule above resolves the ambiguity deterministically.
+
+### 2.2 Why Quick Chat is conceptually an "agent" with N=1 turn
+
+A Quick Chat "session" is a single-turn LangChain call. Modeling it as an agent (rather than keeping the legacy direct path) buys:
+
+- One unified session-state model in the chat view (message stream, citations, tool results).
+- One unified persistence path (`ChatPersistenceManager` doesn't branch on mode).
+- One unified `[Use this backend]` semantics (cosmetic — Quick Chat is always "available" since it has no install step).
+- The ability to upgrade Quick Chat to multi-turn tool use later without invalidating session storage.
+
+The single-turn vs multi-turn distinction stays inside the backend implementation — callers don't care.
+
+---
+
+## 3. Architecture
+
+### 3.1 The Quick Chat backend
+
+New file: `src/agentMode/backends/quickChat/QuickChatBackend.ts`. Implements `BackendDescriptor`:
+
+```typescript
+const quickChatBackend: BackendDescriptor = {
+  id: "quickChat",
+  displayName: "Quick chat",
+  isAvailable: () => true, // always available
+  detectInstall: async () => ({ installed: true, version: "in-process" }),
+  // No install / auth ceremony.
+  startSession: (opts) => new QuickChatSession(opts),
+  // Reads settings.agentMode.backends.quickChat
+  getSettingsSchema: () => quickChatSettingsSchema,
+};
+```
+
+### 3.2 `QuickChatSession` — wraps existing ChatModelManager
+
+```typescript
+class QuickChatSession implements BackendSession {
+  constructor(private opts: SessionOptions) {}
+
+  async send(message: UserMessage): Promise<AsyncIterable<SessionEvent>> {
+    const provider = await ProviderRegistry.get(this.opts.providerId);
+    const entry = ModelRegistry.get(this.opts.providerId, this.opts.modelId);
+    const config = buildLangChainConfig(provider, entry, getGlobalDefaults());
+    const chain = ChatModelManager.getInstance().buildChain(config);
+
+    // Stream tokens out as standard SessionEvent[]:
+    //   { kind: "message-start" } → { kind: "token", text } * N → { kind: "message-end" }
+    yield * adaptLangChainStream(chain.stream(this.opts.history, message));
+  }
+
+  async close() {
+    /* no-op; nothing to release */
+  }
+}
+```
+
+`adaptLangChainStream` is a new small helper that maps LangChain's stream events to the chat view's `SessionEvent` schema (already defined for OpenCode et al).
+
+### 3.3 `ChatRoutingService`
+
+New file: `src/services/ChatRoutingService.ts`. The single arbiter for "which backend owns this model right now":
+
+```typescript
+class ChatRoutingService {
+  /** Used by the chat input picker to populate its dropdown.
+   *  Returns the union of every backend's curated picker, with an
+   *  origin tag so the UI can group / decorate. */
+  listAllPickableModels(): Array<{ entry: RegistryEntry; backendId: BackendId }>;
+
+  /** Used by the chat send button to resolve which backend will handle. */
+  resolveBackend(providerId: ProviderId, modelId: string): BackendId | null;
+
+  /** Used by the agent settings UI to render the per-backend picker. */
+  listPickerForBackend(backendId: BackendId): RegistryEntry[];
+}
+```
+
+`resolveBackend` follows §2.1's priority order. Returns `null` if the model isn't curated into any backend's picker (this should not happen under normal usage since the chat input only shows pickable models, but defensive code returns null → UI shows "configure this model in a backend first").
+
+### 3.4 Sequence — sending a chat message
+
+```
+User
+ │  picks model in chat input  (model key: "anthropic:claude-sonnet-4-5")
+ │
+ ▼
+ChatInputComponent
+ │  reads ChatRoutingService.resolveBackend(...) → "quickChat"
+ │  reads agentMode.backends.quickChat (default model + effort)
+ │
+ ▼
+ChatSessionManager.openSession({ backendId: "quickChat", modelKey, history })
+ │  delegates to quickChatBackend.startSession({ ... })
+ │
+ ▼
+QuickChatSession.send(userMessage)
+ │  resolves provider creds via ProviderRegistry
+ │  buildLangChainConfig(...) → ChatModelManager.buildChain(...)
+ │  streams events back to the new chat view
+ │
+ ▼
+ChatView renders the stream (same path as OpenCode et al)
+```
+
+---
+
+## 4. Data model additions
+
+The model management plan already declared the structural slot for Quick Chat's settings:
+
+```typescript
+agentMode.backends.quickChat: {
+  defaultModel?: ModelSelection | null;          // { baseModelId, effort }
+  modelEnabledOverrides?: Record<string, boolean>;
+}
+```
+
+This doc adds **no new top-level settings**. All routing logic is derived from existing data:
+
+- Provider creds: `settings.providers`
+- Registered models: `settings.registry`
+- Active backend: `settings.agentMode.activeBackend`
+- Per-backend pickers: `settings.agentMode.backends.<id>.modelEnabledOverrides`
+
+---
+
+## 5. Migration
+
+The model management plan's migration step 7 already seeds `agentMode.backends.quickChat.defaultModel` from the user's pre-redesign `defaultModelKey`. **This doc adds one more migration concern that runs as part of the Quick Chat workstream (not v0→v2 — a new v2→v3 migration, since the v0→v2 migration ships before this doc's implementation):**
+
+### Migration v2 → v3 (Quick Chat enablement)
+
+For each registry entry with `capabilities.includes("chat")` that is NOT currently in any backend's `modelEnabledOverrides`:
+
+- Insert into `agentMode.backends.quickChat.modelEnabledOverrides[<providerId>:<modelId>] = true`.
+
+Why: pre-existing users have models they've used for chat. Without this seeding, Quick Chat's picker would be empty on first launch after the follow-up ships, and selecting a model in the chat input would resolve to `null` (no backend owns it).
+
+The migration is idempotent (no-op once the entry exists). It runs once and stamps `settingsVersion = 3`.
+
+---
+
+## 6. UI surface — what changes vs the skeleton in M6
+
+The model management plan's M6 already ships:
+
+- Quick Chat sub-tab (last, after OpenCode/Claude Code/Codex).
+- Default model dropdown sourced from `ModelRegistry.list({ capability: "chat" })`.
+- Default reasoning effort chip group.
+- `BackendModelPicker` writing to `agentMode.backends.quickChat.modelEnabledOverrides`.
+
+What this doc adds:
+
+### 6.1 Quick Chat status card
+
+The skeleton shows a generic "Active — runs in the plugin" status. This doc replaces that with the real status card:
+
+- **Status badge:** `✓ Active backend` (when `activeBackend === "quickChat"`) or `○ Configured, not active`.
+- **Subtitle:** "Runs in-process. No install or auth required."
+- **Actions:** `[Use this backend]` only. No `[Reinstall]` / `[Browse…]` / `[Sign in]`.
+
+### 6.2 Chat input model picker
+
+Reads `ChatRoutingService.listAllPickableModels()`. Groups by backend (Quick Chat / OpenCode / Claude Code / Codex sections). Renders model name + provider muted + a tiny backend glyph.
+
+When the user picks a model:
+
+1. Resolve backend via `ChatRoutingService.resolveBackend(...)`.
+2. If different from current active session's backend: prompt confirmation (_"Start a new chat with Quick Chat?"_) **only if the current session has messages**. Otherwise switch silently.
+3. Start a session via `ChatSessionManager.openSession(...)`.
+
+### 6.3 New chat view binding
+
+The new chat view's session-open path receives a `BackendId` like any other. No conditional branches for "is this LangChain?" — the view talks to whatever session is returned by `ChatSessionManager.openSession(...)`.
+
+What this means concretely: `src/components/chat-components/*` files that currently dispatch differently for chain mode vs agent mode are reduced to one path. The dispatch happens earlier (at `ChatRoutingService.resolveBackend`).
+
+### 6.4 Legacy chat view (transition)
+
+If the old chat view is still being shipped during this transition: keep its current chain-mode path unchanged. Quick Chat backend's `QuickChatSession` is a no-op consumer for the legacy view — the legacy view continues to call `ChatModelManager` directly. The new chat view is the only consumer of the Quick Chat backend session API.
+
+This separation lets us ship the Quick Chat backend incrementally without forcing the legacy view to rewrite.
+
+### 6.5 Picker source-of-truth chip
+
+Optional polish: when a model is selected, the chat input shows a tiny `via Quick chat` / `via OpenCode` etc. tag next to the model name — so power users can see at a glance which backend is being used. Hidden by default; toggle in Advanced.
+
+---
+
+## 7. Implementation milestones
+
+Each milestone independently verifiable; depends on the model management plan's M2 + M6 being shipped (so the schema and the skeleton UI are in place).
+
+### Q1 — `ChatRoutingService` + routing data model
+
+**Goal:** Pure-logic routing service with full unit tests; no UI changes.
+
+- `src/services/ChatRoutingService.ts` per §3.3.
+- Wires reads from existing `ModelRegistry` + `agentMode.backends.*`.
+- Unit tests covering: priority order (active → quickChat → opencode → claude → codex), model in multiple pickers, model in no pickers (returns null), empty-picker edge cases.
+
+**Verify:** `npm run test -- ChatRoutingService` green; no UI regressions.
+
+### Q2 — Quick Chat backend implementation
+
+**Goal:** `QuickChatBackend` + `QuickChatSession` working end-to-end; can be exercised via a dev command.
+
+- `src/agentMode/backends/quickChat/QuickChatBackend.ts`.
+- `src/agentMode/backends/quickChat/QuickChatSession.ts`.
+- `src/agentMode/backends/quickChat/adaptLangChainStream.ts` — converts LangChain stream events to `SessionEvent`.
+- Registered in `src/agentMode/backends/registry.ts` alongside opencode/claude/codex.
+- Dev command `Copilot: Test Quick Chat backend` — opens a session, sends "hello", logs the streamed events to console.
+- Unit tests for `adaptLangChainStream` (token / message-end / error event shapes).
+
+**Verify:** Dev command produces a complete event stream; tests green.
+
+### Q3 — Settings v2→v3 migration
+
+**Goal:** Seed Quick Chat picker for existing chat-capable models. Stamp `settingsVersion = 3`.
+
+- `src/settings/migrations/v2-to-v3.ts` per §5.
+- `src/settings/migrations/__tests__/v2-to-v3.test.ts` — fixtures.
+- Run only when `settingsVersion === 2`; idempotent.
+
+**Verify:** Test vault with a v2 schema → after load, Quick Chat picker is populated with all chat-capable registered models.
+
+### Q4 — Chat input model picker integration
+
+**Goal:** Chat input picker reads from `ChatRoutingService`; sending a message resolves a backend.
+
+- `src/components/chat-components/ChatInputModelPicker.tsx` — refactor to read `ChatRoutingService.listAllPickableModels()`.
+- `src/state/ChatUIState.ts` — route through `ChatRoutingService.resolveBackend(...)` on send.
+- New session prompt-on-backend-switch logic.
+- Tests: picker renders grouped by backend; send dispatches to correct backend per fixtures.
+
+**Verify:** Open chat → pick a Quick-Chat-only model → send → response streams via QuickChatBackend (verifiable via dev console).
+
+### Q5 — Quick Chat status card + new chat view binding
+
+**Goal:** Real status card (replacing skeleton); new chat view uses Quick Chat session API end-to-end.
+
+- `src/settings/v3/components/backends/QuickChatPanel.tsx` — replace skeleton status with §6.1.
+- New chat view session-open path → `ChatSessionManager.openSession({ backendId: "quickChat", ... })` for Quick-Chat-resolved messages.
+- E2E test: open chat → pick a model → send → message renders in new chat view; provenance shows "Quick chat".
+
+**Verify:** Full user flow works without touching the OpenCode/Claude Code/Codex panels.
+
+### Q6 — Legacy view fallback + cleanup
+
+**Goal:** Old chat view (if still present) continues to work via legacy `ChatModelManager` path. Quick Chat-only consumers go through the backend. Cleanup dead code paths.
+
+- Audit chain-mode vs agent-mode branches in chat components; collapse where the new view is the only consumer.
+- Update docs (`docs/llm-providers.md`, `docs/agent-mode-and-tools.md`).
+- Final lint/format/test/build clean.
+
+**Verify:** Old + new chat views both work; no orphan code from the chain-mode → backend collapse.
+
+---
+
+## 8. Risks
+
+| Risk                                                                                                                  | Mitigation                                                                                                                                         |
+| --------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A model is in multiple backends' pickers, and the priority rule surprises users                                       | Surface the resolved backend via the optional `via <backend>` chip in §6.5; add a one-time toast in Q4 explaining the priority rule.               |
+| Quick Chat's single-turn assumption breaks when LangChain agents (tool use) are wired in later                        | `QuickChatSession.send` already returns an async iterable of events — tool calls just become additional event types. Schema is forward-compatible. |
+| v2→v3 migration runs after a user has already manually curated Quick Chat's picker (deselected models in M6 skeleton) | Migration only **inserts** missing entries; never overwrites `false` overrides. Idempotent.                                                        |
+| New chat view + legacy chat view diverge during transition                                                            | Document the routing contract explicitly; have Q6 audit branch points.                                                                             |
+| LangChain stream events don't map cleanly to `SessionEvent` schema                                                    | Q2 has `adaptLangChainStream` as a unit-tested adapter; add new event types if needed (the schema is open).                                        |
+
+---
+
+## 9. Out-of-scope reminders
+
+- Model management redesign itself (BYOK tab, Configure Provider dialog, catalog service, schema migration v0→v2) → see the Model Management Redesign technical plan (handoff artifact shared separately) and `designdocs/MODEL_MANAGEMENT_REDESIGN.md` for the product UX spec.
+- New chat view design → owned by chat workstream.
+- Embeddings tab → owned by model management redesign M3.
+- Skill/MCP integration in chat → separate workstream.
+
+---
+
+## Appendix — File inventory (Q1–Q6)
+
+| File                                                                   | Milestone |
+| ---------------------------------------------------------------------- | --------- |
+| `src/services/ChatRoutingService.ts`                                   | Q1        |
+| `src/services/__tests__/ChatRoutingService.test.ts`                    | Q1        |
+| `src/agentMode/backends/quickChat/QuickChatBackend.ts`                 | Q2        |
+| `src/agentMode/backends/quickChat/QuickChatSession.ts`                 | Q2        |
+| `src/agentMode/backends/quickChat/adaptLangChainStream.ts` + tests     | Q2        |
+| `src/agentMode/backends/registry.ts` (extended)                        | Q2        |
+| `src/settings/migrations/v2-to-v3.ts` + tests                          | Q3        |
+| `src/components/chat-components/ChatInputModelPicker.tsx` (refactored) | Q4        |
+| `src/state/ChatUIState.ts` (refactored)                                | Q4        |
+| `src/settings/v3/components/backends/QuickChatPanel.tsx` (real status) | Q5        |
+| New chat view session-open path (refactored)                           | Q5        |
+| Legacy chat view audit + docs                                          | Q6        |

--- a/designdocs/todo/AGENT_MODE_TODOS.md
+++ b/designdocs/todo/AGENT_MODE_TODOS.md
@@ -10,15 +10,16 @@
   - [ ] Allow users to share system prompt
   - [ ] Do a quick spike on the concrete behavior
   - [ ] Investigate opencode provider specific prompt
-- [ ] P0: Skills
+- [x] P0: Skills
   - [x] Check out cc-switch to understand how to make skills compatible cross other agents https://github.com/farion1231/cc-switch
 - [ ] P0: Permission management
   - [ ] Permission UI improvement
   - [ ] Permission "always allow" doesn't seem to persist
 - [ ] P0: How to design the settings to configure the provider?
-  - [ ] Redesign the model settings - discussed on May 7 group meeting
-  - [ ] support self host model
-  - [ ] remove built-in models
+  - [x] Redesign the model settings - discussed on May 7 group meeting
+  - [x] support self host model
+  - [x] remove built-in models
+- [ ] P0: Test opencode works well with local models
 - [ ] P0: Fix broken legacy agent mode
   - [ ] Can we only support basic chat - not now but eventually yes
 - [ ] P0: Auto-save chat history controls
@@ -66,9 +67,10 @@
   - [ ] manual trigger
   - [ ] configure when to auto compact
 - [ ] P1: Project mode
+- [ ] P2: Support subscriptions that work with opencode (kimi code)
 - [ ] P2: Claude vscode plugin add comment to plan capability
   - It makes iterating on plan a lot easier
-- [ ] P2: [UX] Make mode more obvious
+- [x] P2: [UX] Make mode more obvious
   - idea: consider change the chat border color for different modes
 - [ ] P2: [UX] fix the brief moment of "Read Read" tool call message
 - [ ] P2: Edit previous user message


### PR DESCRIPTION
## Summary

- **MODEL_MANAGEMENT_REDESIGN.md**: refined the product/UX spec — BYOK is now the central, user-bring-only registry; per-model and per-provider Availability/Capability toggles dropped; populated state is one global table with provider section rows; Quick Chat is added as a 4th agent sub-tab; OpenCode/Plus models stay inside the Agent panel only.
- **QUICK_CHAT_AGENT_INTEGRATION.md** (new): follow-up design for elevating LangChain chat into a first-class agent backend — covers routing service, session adapter, settings migration, and milestones Q1–Q6.
- **AGENT_MODE_TODOS.md**: housekeeping — mark shipped items, add notes for opencode-local-model testing and subscription-based opencode flows.

## Test plan

- [ ] Read the refined UX spec end-to-end and confirm BYOK/Agent/Quick Chat flows are coherent.
- [ ] Confirm the Quick Chat follow-up doc's routing priority and migration story align with intent.