### PR TITLE
fix(agent-mode): make tool-card verbs status-aware

### DIFF
--- a/designdocs/todo/AGENT_MODE_TODOS.md
+++ b/designdocs/todo/AGENT_MODE_TODOS.md
@@ -70,7 +70,10 @@
   - It makes iterating on plan a lot easier
 - [ ] P2: [UX] Make mode more obvious
   - idea: consider change the chat border color for different modes
-- [ ] P2: [UX] fix the brief moment of "Read Read" tool call message
+- [x] P2: [UX] fix the brief moment of "Read Read" tool call message
+  - Also made every tool-card verb status-aware ("Reading…" / "Read foo.md",
+    "Editing draft.md" / "Edited draft.md", "Fetching url" / "Fetched url",
+    etc.) so in-flight calls no longer render with past-tense verbs.
 - [ ] P2: Edit previous user message
 - [ ] P2: New agent command (/new, /usage)
 - [ ] P2: Claude code / Codex authentication

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -134,6 +134,61 @@ describe("lookupToolSummary", () => {
     const s = lookupToolSummary(t);
     expect(s.collapsedLine(t)).toBe("weirdtool");
   });
+
+  it("hides the duplicated vendor name while Read input is still streaming", () => {
+    // SDK seeds title to the vendor name before any input-JSON has been
+    // parsed. Should render "Reading …" rather than "Reading Read".
+    const t = tool({ vendorToolName: "Read", title: "Read", status: "in_progress" });
+    expect(lookupToolSummary(t).collapsedLine(t)).toBe("Reading …");
+  });
+
+  it("flips Read to past tense once the call completes", () => {
+    const t = tool({
+      vendorToolName: "Read",
+      title: "Read",
+      status: "completed",
+      locations: [{ path: "/Users/me/vault/notes/foo.md" }],
+    });
+    expect(lookupToolSummary(t).collapsedLine(t)).toBe("Read notes/foo.md");
+  });
+
+  it("uses Editing while Edit is in flight and Edited when it completes", () => {
+    const inflight = tool({
+      vendorToolName: "Edit",
+      title: "Edit",
+      status: "in_progress",
+      input: { file_path: "/Users/me/vault/draft.md" },
+    });
+    expect(lookupToolSummary(inflight).collapsedLine(inflight)).toBe("Editing draft.md");
+    const done = tool({ ...inflight, status: "completed" });
+    expect(lookupToolSummary(done).collapsedLine(done)).toBe("Edited draft.md");
+  });
+
+  it("uses Fetching while WebFetch is in flight and Fetched when it completes", () => {
+    const inflight = tool({
+      vendorToolName: "WebFetch",
+      title: "WebFetch",
+      status: "in_progress",
+      input: { url: "https://example.com" },
+    });
+    expect(lookupToolSummary(inflight).collapsedLine(inflight)).toBe(
+      "Fetching https://example.com"
+    );
+    const done = tool({ ...inflight, status: "completed" });
+    expect(lookupToolSummary(done).collapsedLine(done)).toBe("Fetched https://example.com");
+  });
+
+  it("uses Running while Bash is in flight and Ran when it completes", () => {
+    const inflight = tool({
+      vendorToolName: "Bash",
+      title: "Bash",
+      status: "in_progress",
+      input: { description: "Check working tree" },
+    });
+    expect(lookupToolSummary(inflight).collapsedLine(inflight)).toBe("Running Check working tree");
+    const done = tool({ ...inflight, status: "completed" });
+    expect(lookupToolSummary(done).collapsedLine(done)).toBe("Ran Check working tree");
+  });
 });
 
 describe("BASH_SUMMARY.expandedDetails", () => {

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -82,7 +82,24 @@ function pluralize(n: number, singular: string, plural?: string): string {
 }
 
 function targetFromTitle(part: ToolCallPart): string {
-  return part.title || "(no title)";
+  const t = part.title;
+  if (!t) return "…";
+  // SDK seeds title to the vendor tool name (e.g. "Read", "Edit") in the brief
+  // window between content_block_start and the first complete input-JSON parse.
+  // Treat that as a placeholder so verb-prefixed summaries don't render
+  // "Read Read" / "Edited Edit".
+  if (part.vendorToolName && t.toLowerCase() === part.vendorToolName.toLowerCase()) return "…";
+  return t;
+}
+
+/**
+ * Pick the verb form that matches the tool call's current status. Tool calls
+ * still pending / in_progress render with the present participle so the trail
+ * reflects what the agent is doing right now; completed and failed calls flip
+ * to the past tense.
+ */
+function verb(part: ToolCallPart, progressive: string, past: string): string {
+  return part.status === "completed" || part.status === "failed" ? past : progressive;
 }
 
 function targetFromPath(part: ToolCallPart): string | null {
@@ -136,7 +153,7 @@ function approxTokens(part: ToolCallPart): number {
 
 const READ_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "Read" }),
-  collapsedLine: (p) => `Read ${targetFromPath(p) ?? targetFromTitle(p)}`,
+  collapsedLine: (p) => `${verb(p, "Reading", "Read")} ${targetFromPath(p) ?? targetFromTitle(p)}`,
   outcome: (p) => {
     const t = approxTokens(p);
     return t > 0 ? `~${formatTokens(t)} tokens` : null;
@@ -153,8 +170,9 @@ const READ_SUMMARY: ToolSummary = {
 const LIST_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "LS" }),
   collapsedLine: (p) => {
+    const v = verb(p, "Listing", "Listed");
     const path = targetFromPath(p);
-    return path ? `Listed ${path}` : "Listed vault root";
+    return path ? `${v} ${path}` : `${v} vault root`;
   },
   outcome: () => null,
   aggregate: (parts) => ({
@@ -165,7 +183,8 @@ const LIST_SUMMARY: ToolSummary = {
 
 const EDIT_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "Edit" }),
-  collapsedLine: (p) => `Edited ${targetFromPath(p) ?? targetFromTitle(p)}`,
+  collapsedLine: (p) =>
+    `${verb(p, "Editing", "Edited")} ${targetFromPath(p) ?? targetFromTitle(p)}`,
   outcome: (p) => {
     const { added, removed } = diffStats(p);
     if (added === 0 && removed === 0) return null;
@@ -189,15 +208,16 @@ const EDIT_SUMMARY: ToolSummary = {
 const BASH_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "Bash" }),
   collapsedLine: (p) => {
+    const v = verb(p, "Running", "Ran");
     const input = p.input as { command?: unknown; description?: unknown } | null | undefined;
     if (typeof input?.description === "string" && input.description.length > 0) {
-      return `Ran ${input.description}`;
+      return `${v} ${input.description}`;
     }
     if (typeof input?.command === "string") {
       const cmd = input.command.length > 60 ? input.command.slice(0, 60) + "…" : input.command;
-      return `Ran \`${cmd}\``;
+      return `${v} \`${cmd}\``;
     }
-    return `Ran ${targetFromTitle(p)}`;
+    return `${v} ${targetFromTitle(p)}`;
   },
   outcome: () => null,
   aggregate: (parts) => ({
@@ -217,8 +237,9 @@ const BASH_SUMMARY: ToolSummary = {
 const SEARCH_VAULT_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "Grep" }),
   collapsedLine: (p) => {
+    const v = verb(p, "Searching vault", "Searched vault");
     const q = queryFromInput(p);
-    return q ? `Searched vault · "${q}"` : `Searched vault · ${targetFromTitle(p)}`;
+    return q ? `${v} · "${q}"` : `${v} · ${targetFromTitle(p)}`;
   },
   outcome: () => null,
   aggregate: (parts) => ({
@@ -230,8 +251,9 @@ const SEARCH_VAULT_SUMMARY: ToolSummary = {
 const WEB_SEARCH_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "WebSearch" }),
   collapsedLine: (p) => {
+    const v = verb(p, "Searching web", "Searched web");
     const q = queryFromInput(p);
-    return q ? `Searched web · "${q}"` : `Searched web · ${targetFromTitle(p)}`;
+    return q ? `${v} · "${q}"` : `${v} · ${targetFromTitle(p)}`;
   },
   outcome: () => null,
   aggregate: (parts) => ({
@@ -243,9 +265,10 @@ const WEB_SEARCH_SUMMARY: ToolSummary = {
 const WEB_FETCH_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "WebFetch" }),
   collapsedLine: (p) => {
+    const v = verb(p, "Fetching", "Fetched");
     const input = p.input as { url?: unknown } | null | undefined;
-    if (typeof input?.url === "string") return `Fetched ${input.url}`;
-    return `Fetched ${targetFromTitle(p)}`;
+    if (typeof input?.url === "string") return `${v} ${input.url}`;
+    return `${v} ${targetFromTitle(p)}`;
   },
   outcome: () => null,
   aggregate: (parts) => ({
@@ -279,7 +302,7 @@ const TASK_SUMMARY: ToolSummary = {
 
 const TODO_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "TodoWrite" }),
-  collapsedLine: () => "Updated task list",
+  collapsedLine: (p) => `${verb(p, "Updating", "Updated")} task list`,
   outcome: (p) => {
     const input = p.input as { todos?: unknown[] } | null | undefined;
     const n = Array.isArray(input?.todos) ? input.todos.length : 0;
@@ -293,7 +316,7 @@ const TODO_SUMMARY: ToolSummary = {
 
 const EXIT_PLAN_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "ExitPlanMode" }),
-  collapsedLine: () => "Proposed plan",
+  collapsedLine: (p) => `${verb(p, "Proposing", "Proposed")} plan`,
   outcome: () => null,
   aggregate: (parts) => ({
     line: `Proposed ${pluralize(parts.length, "plan")}${statusSuffix(parts)}`,
@@ -326,8 +349,9 @@ const VENDOR_SUMMARIES: Record<string, ToolSummary> = {
 const KIND_SEARCH_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ toolKind: "search" }),
   collapsedLine: (p) => {
+    const v = verb(p, "Searching", "Searched");
     const q = queryFromInput(p);
-    return q ? `Searched · "${q}"` : `Searched · ${targetFromTitle(p)}`;
+    return q ? `${v} · "${q}"` : `${v} · ${targetFromTitle(p)}`;
   },
   outcome: () => null,
   aggregate: (parts) => ({
@@ -345,7 +369,8 @@ const KIND_FETCH_SUMMARY: ToolSummary = {
 };
 const KIND_DELETE_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ toolKind: "delete" }),
-  collapsedLine: (p) => `Deleted ${targetFromPath(p) ?? targetFromTitle(p)}`,
+  collapsedLine: (p) =>
+    `${verb(p, "Deleting", "Deleted")} ${targetFromPath(p) ?? targetFromTitle(p)}`,
   outcome: () => null,
   aggregate: (parts) => ({
     line: `Deleted ${pluralize(parts.length, "item")}${statusSuffix(parts)}`,
@@ -354,7 +379,7 @@ const KIND_DELETE_SUMMARY: ToolSummary = {
 };
 const KIND_MOVE_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ toolKind: "move" }),
-  collapsedLine: (p) => `Moved ${targetFromPath(p) ?? targetFromTitle(p)}`,
+  collapsedLine: (p) => `${verb(p, "Moving", "Moved")} ${targetFromPath(p) ?? targetFromTitle(p)}`,
   outcome: () => null,
   aggregate: (parts) => ({
     line: `Moved ${pluralize(parts.length, "item")}${statusSuffix(parts)}`,
@@ -367,7 +392,7 @@ const KIND_SWITCH_MODE_SUMMARY: ToolSummary = {
 };
 const KIND_THINK_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ toolKind: "think" }),
-  collapsedLine: () => "Thought",
+  collapsedLine: (p) => verb(p, "Thinking", "Thought"),
   outcome: () => null,
   aggregate: (parts) => ({
     line: `Thought · ${pluralize(parts.length, "step")}${statusSuffix(parts)}`,


### PR DESCRIPTION
## Summary

- Replaces the brief "Read Read" / "Edited Edit" flash that appeared while a Claude SDK tool call's input JSON was still streaming: `targetFromTitle` now collapses the SDK's `title === vendorToolName` placeholder to an ellipsis.
- Adds a small `verb(part, progressive, past)` helper and threads it through every verb-prefixed `ToolSummary` (Read, Edit, LS, Bash, Grep, WebSearch, WebFetch, TodoWrite, ExitPlanMode, and the `KIND_*` fallbacks) so pending / in-progress calls render with the present participle ("Reading…", "Fetching url") and switch to past tense ("Read foo.md", "Fetched url") only once the call completes or fails.
- Adds unit coverage for the streaming placeholder and the in-flight → completed verb transition, and checks off the corresponding entry in `designdocs/todo/AGENT_MODE_TODOS.md`.

## Test plan

- [x] `npm run test -- toolSummaries` (161 suites / 2727 tests pass)
- [x] `npm run lint` on touched files (clean)
- [ ] Manual: trigger a Read / Edit / WebFetch in agent mode and confirm the action card now shows the progressive verb until the call completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)