### PR TITLE
feat(agent-mode): teach backends about @-mention pill syntax

### DIFF
--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -16,6 +16,7 @@ import { resolveClaudeBinary } from "./claudeBinaryResolver";
 import { ClaudeSdkBackendProcess } from "@/agentMode/sdk/ClaudeSdkBackendProcess";
 import { getCachedSdkCatalog, synthesizeEffortConfigOption } from "@/agentMode/sdk/effortOption";
 import {
+  buildPillSyntaxDirective,
   buildSkillCreationDirective,
   DEFAULT_SKILLS_FOLDER,
   SkillManager,
@@ -205,7 +206,12 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
       getSkillCreationDirective: () => {
         const folder = getSettings().agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
         const dirs = Object.values(SkillManager.getInstance().getAgentDirsProjectRel());
-        return buildSkillCreationDirective("claude", folder, dirs);
+        // Pill-syntax directive precedes the skill-creation directive —
+        // input-parsing rules come before skill-authoring rules. The
+        // closure name is unchanged to keep the `BackendProcess` surface
+        // stable; semantically it's now "system prompt append," carrying
+        // both directives.
+        return `${buildPillSyntaxDirective()}\n\n${buildSkillCreationDirective("claude", folder, dirs)}`;
       },
     });
   },

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -206,11 +206,6 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
       getSkillCreationDirective: () => {
         const folder = getSettings().agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
         const dirs = Object.values(SkillManager.getInstance().getAgentDirsProjectRel());
-        // Pill-syntax directive precedes the skill-creation directive —
-        // input-parsing rules come before skill-authoring rules. The
-        // closure name is unchanged to keep the `BackendProcess` surface
-        // stable; semantically it's now "system prompt append," carrying
-        // both directives.
         return `${buildPillSyntaxDirective()}\n\n${buildSkillCreationDirective("claude", folder, dirs)}`;
       },
     });

--- a/src/agentMode/backends/codex/CodexBackend.test.ts
+++ b/src/agentMode/backends/codex/CodexBackend.test.ts
@@ -50,13 +50,8 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
     expect(cIdx).toBeGreaterThanOrEqual(0);
     const value = desc.args[cIdx + 1];
     expect(value.startsWith("developer_instructions=")).toBe(true);
-    // Pill-syntax directive presence — `{` is TOML-safe so the literal
-    // tokens survive escaping unchanged.
     expect(value).toContain("{folder_name}");
     expect(value).toContain("{activeNote}");
-    // Skill-creation directive presence. The TOML value carries the
-    // directive text with newlines escaped as `\n` and inner double quotes
-    // as `\"`.
     expect(value).toContain('metadata.copilot-enabled-agents: \\"codex\\"');
     expect(value).toContain("copilot/skills/<name>/SKILL.md");
     expect(value).toContain(".claude/skills/");

--- a/src/agentMode/backends/codex/CodexBackend.test.ts
+++ b/src/agentMode/backends/codex/CodexBackend.test.ts
@@ -42,7 +42,7 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
     });
   });
 
-  it("injects the skill-creation directive via -c developer_instructions", async () => {
+  it("injects the pill-syntax + skill-creation directives via -c developer_instructions", async () => {
     const backend = new CodexBackend();
     const desc = await backend.buildSpawnDescriptor({ vaultBasePath: "/vault" });
     expect(desc.command).toBe("/usr/local/bin/codex-acp");
@@ -50,7 +50,13 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
     expect(cIdx).toBeGreaterThanOrEqual(0);
     const value = desc.args[cIdx + 1];
     expect(value.startsWith("developer_instructions=")).toBe(true);
-    // The TOML value carries the directive text (newlines escaped as \n).
+    // Pill-syntax directive presence — `{` is TOML-safe so the literal
+    // tokens survive escaping unchanged.
+    expect(value).toContain("{folder_name}");
+    expect(value).toContain("{activeNote}");
+    // Skill-creation directive presence. The TOML value carries the
+    // directive text with newlines escaped as `\n` and inner double quotes
+    // as `\"`.
     expect(value).toContain('metadata.copilot-enabled-agents: \\"codex\\"');
     expect(value).toContain("copilot/skills/<name>/SKILL.md");
     expect(value).toContain(".claude/skills/");

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -37,8 +37,6 @@ export class CodexBackend implements AcpBackend {
     // session. See the Skills Management spec.
     const skillsFolder = getSettings().agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
     const dirs = Object.values(SkillManager.getInstance().getAgentDirsProjectRel());
-    // Pill-syntax directive precedes the skill-creation directive so
-    // input-parsing rules come before skill-authoring rules.
     const directive = `${buildPillSyntaxDirective()}\n\n${buildSkillCreationDirective("codex", skillsFolder, dirs)}`;
     descriptor.args = [
       ...descriptor.args,

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -2,6 +2,7 @@ import { getSettings } from "@/settings/model";
 import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
 import { buildSimpleSpawnDescriptor } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import {
+  buildPillSyntaxDirective,
   buildSkillCreationDirective,
   DEFAULT_SKILLS_FOLDER,
   SkillManager,
@@ -36,7 +37,9 @@ export class CodexBackend implements AcpBackend {
     // session. See the Skills Management spec.
     const skillsFolder = getSettings().agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
     const dirs = Object.values(SkillManager.getInstance().getAgentDirsProjectRel());
-    const directive = buildSkillCreationDirective("codex", skillsFolder, dirs);
+    // Pill-syntax directive precedes the skill-creation directive so
+    // input-parsing rules come before skill-authoring rules.
+    const directive = `${buildPillSyntaxDirective()}\n\n${buildSkillCreationDirective("codex", skillsFolder, dirs)}`;
     descriptor.args = [
       ...descriptor.args,
       "-c",

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -326,17 +326,11 @@ describe("buildOpencodeConfig", () => {
     const cfg = (await buildOpencodeConfig()) as {
       agent: Record<string, { prompt?: string; permission?: unknown; mode?: string }>;
     };
-    // Prompt is composed as: COPILOT_PROMPT_BASE + pill-syntax directive +
-    // skill-creation directive. Assert the base is the prefix and both
-    // directives are present so future directive changes don't break this test.
     expect(cfg.agent["copilot-build"].prompt?.startsWith(COPILOT_PROMPT_BASE)).toBe(true);
     expect(cfg.agent.build.prompt?.startsWith(COPILOT_PROMPT_BASE)).toBe(true);
-    // Pill-syntax directive presence (signature substrings — see
-    // `buildPillSyntaxDirective`).
     expect(cfg.agent["copilot-build"].prompt).toContain("{folder_name}");
     expect(cfg.agent["copilot-build"].prompt).toContain("{activeNote}");
     expect(cfg.agent.build.prompt).toContain("{folder_name}");
-    // Skill-creation directive presence.
     expect(cfg.agent["copilot-build"].prompt).toContain(
       'metadata.copilot-enabled-agents: "opencode"'
     );

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -326,12 +326,17 @@ describe("buildOpencodeConfig", () => {
     const cfg = (await buildOpencodeConfig()) as {
       agent: Record<string, { prompt?: string; permission?: unknown; mode?: string }>;
     };
-    // Prompt now starts with the COPILOT_PROMPT_BASE and ends with the
-    // spawn-time skill-creation directive (see the Skills Management
-    // spec). Assert the base is the prefix so future directive changes
-    // don't break this test.
+    // Prompt is composed as: COPILOT_PROMPT_BASE + pill-syntax directive +
+    // skill-creation directive. Assert the base is the prefix and both
+    // directives are present so future directive changes don't break this test.
     expect(cfg.agent["copilot-build"].prompt?.startsWith(COPILOT_PROMPT_BASE)).toBe(true);
     expect(cfg.agent.build.prompt?.startsWith(COPILOT_PROMPT_BASE)).toBe(true);
+    // Pill-syntax directive presence (signature substrings — see
+    // `buildPillSyntaxDirective`).
+    expect(cfg.agent["copilot-build"].prompt).toContain("{folder_name}");
+    expect(cfg.agent["copilot-build"].prompt).toContain("{activeNote}");
+    expect(cfg.agent.build.prompt).toContain("{folder_name}");
+    // Skill-creation directive presence.
     expect(cfg.agent["copilot-build"].prompt).toContain(
       'metadata.copilot-enabled-agents: "opencode"'
     );

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -230,11 +230,6 @@ export async function buildOpencodeConfig(): Promise<Record<string, unknown>> {
   const skillsDirs = skillManagerReady
     ? Object.values(SkillManager.getInstance().getAgentDirsProjectRel())
     : [];
-  // Pill-syntax directive teaches every backend how to interpret the
-  // `[[note]]` / `{folder}` / `{activeNote}` tokens the chat editor emits
-  // from @-mention pills. Composed between the base prompt and the
-  // skill-creation directive so a fresh reader encounters input-parsing
-  // rules before skill-authoring rules.
   const prompt = `${basePrompt}\n\n${buildPillSyntaxDirective()}\n\n${buildSkillCreationDirective("opencode", skillsFolder, skillsDirs)}`;
   config.agent = {
     [OPENCODE_BUILTIN_BUILD_AGENT_ID]: {

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -5,6 +5,7 @@ import { getSettings } from "@/settings/model";
 import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
 import type { CopilotMode } from "@/agentMode/session/types";
 import {
+  buildPillSyntaxDirective,
   buildSkillCreationDirective,
   composeDenyList,
   DEFAULT_SKILLS_FOLDER,
@@ -229,7 +230,12 @@ export async function buildOpencodeConfig(): Promise<Record<string, unknown>> {
   const skillsDirs = skillManagerReady
     ? Object.values(SkillManager.getInstance().getAgentDirsProjectRel())
     : [];
-  const prompt = `${basePrompt}\n\n${buildSkillCreationDirective("opencode", skillsFolder, skillsDirs)}`;
+  // Pill-syntax directive teaches every backend how to interpret the
+  // `[[note]]` / `{folder}` / `{activeNote}` tokens the chat editor emits
+  // from @-mention pills. Composed between the base prompt and the
+  // skill-creation directive so a fresh reader encounters input-parsing
+  // rules before skill-authoring rules.
+  const prompt = `${basePrompt}\n\n${buildPillSyntaxDirective()}\n\n${buildSkillCreationDirective("opencode", skillsFolder, skillsDirs)}`;
   config.agent = {
     [OPENCODE_BUILTIN_BUILD_AGENT_ID]: {
       prompt,

--- a/src/agentMode/backends/opencode/prompts.ts
+++ b/src/agentMode/backends/opencode/prompts.ts
@@ -49,7 +49,6 @@ export const COPILOT_PROMPT_BASE = `You are Obsidian Copilot, an AI assistant th
 - Use \`$...$\` for LaTeX equations, never \`\\[...\\]\` or \`\\(...\\)\`.
 - For markdown lists, always use \`- \` (hyphen followed by exactly one space) for bullet points. Never use \`*\` for bullets.
 - For tables, use GitHub-flavored markdown.
-- When referring to an Obsidian note in your written reply, use \`[[title]]\` format (no backticks around it). To actually read or modify a note, call the \`read\` or \`edit\` tool — don't infer note contents from a wikilink title alone.
 - For Obsidian-internal image links, use \`![[link]]\` format. For web image links, use \`![alt](url)\` format.`;
 
 /**

--- a/src/agentMode/session/resolveActiveNoteToken.test.ts
+++ b/src/agentMode/session/resolveActiveNoteToken.test.ts
@@ -1,0 +1,62 @@
+import { mockTFile } from "@/__tests__/mockObsidian";
+import { resolveActiveNoteToken } from "./resolveActiveNoteToken";
+
+jest.mock("obsidian", () => ({
+  TFile: jest.fn(),
+}));
+
+const mockFile = (basename: string) => mockTFile({ basename, path: `${basename}.md` });
+
+describe("resolveActiveNoteToken", () => {
+  it("replaces {activeNote} with the active file's wikilink form", () => {
+    const out = resolveActiveNoteToken(
+      "Summarize {activeNote} in 3 bullets.",
+      mockFile("Today's Standup")
+    );
+    expect(out).toBe("Summarize [[Today's Standup]] in 3 bullets.");
+  });
+
+  it("replaces every occurrence", () => {
+    const out = resolveActiveNoteToken(
+      "Compare {activeNote} against {activeNote}.",
+      mockFile("Notes")
+    );
+    expect(out).toBe("Compare [[Notes]] against [[Notes]].");
+  });
+
+  it("leaves the token untouched when there is no active file", () => {
+    expect(resolveActiveNoteToken("Summarize {activeNote}", null)).toBe("Summarize {activeNote}");
+  });
+
+  it("is a no-op when the token is absent", () => {
+    const text = "Summarize [[Some Other Note]] please.";
+    expect(resolveActiveNoteToken(text, mockFile("Active"))).toBe(text);
+  });
+
+  it("does not touch folder tokens or other curly-brace content", () => {
+    const out = resolveActiveNoteToken(
+      "Look in {Projects} and summarize {activeNote}.",
+      mockFile("Daily")
+    );
+    expect(out).toBe("Look in {Projects} and summarize [[Daily]].");
+  });
+
+  it("treats `{ActiveNote}` (wrong case) as a non-match — only the reserved literal is replaced", () => {
+    // `parseTextForPills` matches the reserved token case-sensitively against
+    // the literal `activeNote`, so this helper does the same.
+    const text = "Mention {ActiveNote} and {activeNote}.";
+    expect(resolveActiveNoteToken(text, mockFile("Daily"))).toBe(
+      "Mention {ActiveNote} and [[Daily]]."
+    );
+  });
+
+  it("preserves `$` characters in the basename (no regex-replacement surprises)", () => {
+    // Using split/join (not String.prototype.replace with a string pattern,
+    // which has no $-interpretation either but is easier to misread). This
+    // test pins the safe behavior so future refactors don't reach for
+    // replace() and accidentally interpret $1/$& in the basename.
+    expect(resolveActiveNoteToken("ref {activeNote} here", mockFile("Q1 $revenue"))).toBe(
+      "ref [[Q1 $revenue]] here"
+    );
+  });
+});

--- a/src/agentMode/session/resolveActiveNoteToken.test.ts
+++ b/src/agentMode/session/resolveActiveNoteToken.test.ts
@@ -5,7 +5,8 @@ jest.mock("obsidian", () => ({
   TFile: jest.fn(),
 }));
 
-const mockFile = (basename: string) => mockTFile({ basename, path: `${basename}.md` });
+const mockFile = (basename: string, extension = "md") =>
+  mockTFile({ basename, extension, path: `${basename}.${extension}` });
 
 describe("resolveActiveNoteToken", () => {
   it("replaces {activeNote} with the active file's wikilink form", () => {
@@ -52,6 +53,15 @@ describe("resolveActiveNoteToken", () => {
   it("preserves `$` characters in the basename (no regex-replacement surprises)", () => {
     expect(resolveActiveNoteToken("ref {activeNote} here", mockFile("Q1 $revenue"))).toBe(
       "ref [[Q1 $revenue]] here"
+    );
+  });
+
+  it("keeps the extension on non-markdown active files (matches NotePillNode serialization)", () => {
+    expect(resolveActiveNoteToken("Summarize {activeNote}", mockFile("Spec", "pdf"))).toBe(
+      "Summarize [[Spec.pdf]]"
+    );
+    expect(resolveActiveNoteToken("Open {activeNote}", mockFile("Mindmap", "canvas"))).toBe(
+      "Open [[Mindmap.canvas]]"
     );
   });
 });

--- a/src/agentMode/session/resolveActiveNoteToken.test.ts
+++ b/src/agentMode/session/resolveActiveNoteToken.test.ts
@@ -42,19 +42,14 @@ describe("resolveActiveNoteToken", () => {
   });
 
   it("treats `{ActiveNote}` (wrong case) as a non-match — only the reserved literal is replaced", () => {
-    // `parseTextForPills` matches the reserved token case-sensitively against
-    // the literal `activeNote`, so this helper does the same.
     const text = "Mention {ActiveNote} and {activeNote}.";
     expect(resolveActiveNoteToken(text, mockFile("Daily"))).toBe(
       "Mention {ActiveNote} and [[Daily]]."
     );
   });
 
+  // split/join (not String.prototype.replace) avoids `$&`/`$1` interpretation in the basename.
   it("preserves `$` characters in the basename (no regex-replacement surprises)", () => {
-    // Using split/join (not String.prototype.replace with a string pattern,
-    // which has no $-interpretation either but is easier to misread). This
-    // test pins the safe behavior so future refactors don't reach for
-    // replace() and accidentally interpret $1/$& in the basename.
     expect(resolveActiveNoteToken("ref {activeNote} here", mockFile("Q1 $revenue"))).toBe(
       "ref [[Q1 $revenue]] here"
     );

--- a/src/agentMode/session/resolveActiveNoteToken.ts
+++ b/src/agentMode/session/resolveActiveNoteToken.ts
@@ -4,5 +4,10 @@ import type { TFile } from "obsidian";
 export function resolveActiveNoteToken(text: string, activeFile: TFile | null): string {
   if (!activeFile) return text;
   if (!text.includes("{activeNote}")) return text;
-  return text.split("{activeNote}").join(`[[${activeFile.basename}]]`);
+  // Mirror NotePillNode.getTextContent: keep the extension for non-markdown attachments
+  // (pdf/canvas) so the agent resolves the same path the pill envelope carries.
+  const ext = activeFile.extension?.toLowerCase();
+  const display =
+    ext === "pdf" || ext === "canvas" ? `${activeFile.basename}.${ext}` : activeFile.basename;
+  return text.split("{activeNote}").join(`[[${display}]]`);
 }

--- a/src/agentMode/session/resolveActiveNoteToken.ts
+++ b/src/agentMode/session/resolveActiveNoteToken.ts
@@ -1,22 +1,6 @@
 import type { TFile } from "obsidian";
 
-/**
- * Replace the literal `{activeNote}` token (emitted by `ActiveNotePillNode`
- * via `getTextContent()`) with the `[[Note Title]]` wikilink form the agent
- * already knows how to handle.
- *
- * Why this exists: the active file is a client-side concept that exists only
- * inside the Obsidian workspace. The agent (running in a separate process /
- * SDK) has no way to ask "what is the user currently viewing?", so the
- * resolution has to happen on the host before the message is sent. The
- * companion `ActiveNotePillSyncPlugin` already auto-attaches the active file
- * to the `<copilot-context>` envelope, so once the inline token is rewritten,
- * the agent can `read` the note by the path the envelope carries.
- *
- * When no active note is available, the token is left untouched. The
- * pill-syntax directive tells the agent how to interpret the literal — the
- * agent will tell the user no note is currently active rather than guess.
- */
+/** Rewrites `{activeNote}` to `[[Title]]` — the agent has no workspace context to resolve the token itself. */
 export function resolveActiveNoteToken(text: string, activeFile: TFile | null): string {
   if (!activeFile) return text;
   if (!text.includes("{activeNote}")) return text;

--- a/src/agentMode/session/resolveActiveNoteToken.ts
+++ b/src/agentMode/session/resolveActiveNoteToken.ts
@@ -1,0 +1,24 @@
+import type { TFile } from "obsidian";
+
+/**
+ * Replace the literal `{activeNote}` token (emitted by `ActiveNotePillNode`
+ * via `getTextContent()`) with the `[[Note Title]]` wikilink form the agent
+ * already knows how to handle.
+ *
+ * Why this exists: the active file is a client-side concept that exists only
+ * inside the Obsidian workspace. The agent (running in a separate process /
+ * SDK) has no way to ask "what is the user currently viewing?", so the
+ * resolution has to happen on the host before the message is sent. The
+ * companion `ActiveNotePillSyncPlugin` already auto-attaches the active file
+ * to the `<copilot-context>` envelope, so once the inline token is rewritten,
+ * the agent can `read` the note by the path the envelope carries.
+ *
+ * When no active note is available, the token is left untouched. The
+ * pill-syntax directive tells the agent how to interpret the literal — the
+ * agent will tell the user no note is currently active rather than guess.
+ */
+export function resolveActiveNoteToken(text: string, activeFile: TFile | null): string {
+  if (!activeFile) return text;
+  if (!text.includes("{activeNote}")) return text;
+  return text.split("{activeNote}").join(`[[${activeFile.basename}]]`);
+}

--- a/src/agentMode/skills/index.ts
+++ b/src/agentMode/skills/index.ts
@@ -28,6 +28,7 @@ export { reconcile, getAgentDirs } from "./reconcile";
 export type { ReconcileFs, ReconcileOptions, ReconcileReport } from "./reconcile";
 export { agentSkillsDirAbs, DEFAULT_SKILLS_FOLDER } from "./agentPaths";
 export { buildSkillCreationDirective } from "./spawnDirective";
+export { buildPillSyntaxDirective } from "./pillSyntaxDirective";
 export { composeDenyList } from "./denyListComposer";
 export { DeleteConfirmModal } from "./ui/DeleteConfirmDialog";
 export { PropertiesModal } from "./ui/PropertiesDialog";

--- a/src/agentMode/skills/pillSyntaxDirective.test.ts
+++ b/src/agentMode/skills/pillSyntaxDirective.test.ts
@@ -1,0 +1,43 @@
+import { buildPillSyntaxDirective } from "./pillSyntaxDirective";
+
+describe("buildPillSyntaxDirective", () => {
+  const directive = buildPillSyntaxDirective();
+
+  it("documents the three pill token shapes", () => {
+    expect(directive).toContain("[[note_title]]");
+    expect(directive).toContain("{folder_name}");
+    expect(directive).toContain("{activeNote}");
+  });
+
+  it("frames the tokens as concrete references, not template placeholders", () => {
+    expect(directive).toMatch(/concrete references/i);
+    expect(directive).toMatch(/NOT as template placeholders/);
+  });
+
+  it("gives the agent a usable folder-scoping pattern", () => {
+    // The agent has no folder/path parameter on search tools — the
+    // directive must suggest path-prefix patterns it can actually call.
+    expect(directive).toContain("folder_name/**");
+    expect(directive).toMatch(/\bglob\b/);
+    expect(directive).toMatch(/\bgrep\b/);
+  });
+
+  it("tells the agent to use `read`/`edit` for notes, not infer from title", () => {
+    expect(directive).toMatch(/\bread\b/);
+    expect(directive).toMatch(/never infer/i);
+  });
+
+  it("instructs the agent to cite notes with `[[title]]` in replies", () => {
+    expect(directive).toMatch(/\[\[title\]\]/);
+  });
+
+  it("takes no arguments and produces a stable string", () => {
+    // Pure function — same input (none) yields the same output. Pinning
+    // this lets callers safely cache the value across spawns.
+    expect(buildPillSyntaxDirective()).toBe(directive);
+  });
+
+  it("has no leading or trailing whitespace", () => {
+    expect(directive).toBe(directive.trim());
+  });
+});

--- a/src/agentMode/skills/pillSyntaxDirective.test.ts
+++ b/src/agentMode/skills/pillSyntaxDirective.test.ts
@@ -15,8 +15,6 @@ describe("buildPillSyntaxDirective", () => {
   });
 
   it("gives the agent a usable folder-scoping pattern", () => {
-    // The agent has no folder/path parameter on search tools — the
-    // directive must suggest path-prefix patterns it can actually call.
     expect(directive).toContain("folder_name/**");
     expect(directive).toMatch(/\bglob\b/);
     expect(directive).toMatch(/\bgrep\b/);
@@ -32,8 +30,6 @@ describe("buildPillSyntaxDirective", () => {
   });
 
   it("takes no arguments and produces a stable string", () => {
-    // Pure function — same input (none) yields the same output. Pinning
-    // this lets callers safely cache the value across spawns.
     expect(buildPillSyntaxDirective()).toBe(directive);
   });
 

--- a/src/agentMode/skills/pillSyntaxDirective.ts
+++ b/src/agentMode/skills/pillSyntaxDirective.ts
@@ -1,0 +1,43 @@
+/**
+ * Build the spawn-time directive that teaches every backend how to interpret
+ * the @-mention pill tokens that appear in user messages. Copilot's chat
+ * editor lets the user @-mention vault items inline; when the editor
+ * extracts text for the LLM, each pill serializes to a literal token
+ * (`[[title]]`, `{folder}`, `{activeNote}`). Without this directive the
+ * agent has no way to know these are concrete vault references rather than
+ * template placeholders to substitute.
+ *
+ * Composed into whatever existing system-prompt / instructions surface
+ * each backend supports at spawn time, alongside `buildSkillCreationDirective`.
+ * Pure leaf module — no Obsidian imports, no singletons, no arguments —
+ * suitable for unit testing.
+ *
+ * The token shapes mirror the pill serializers:
+ *   - `NotePillNode.getTextContent()` → `[[title]]`
+ *   - `FolderPillNode.getTextContent()` → `{folderPath}`
+ *   - Reserved `{activeNote}` template (handled in `parseTextForPills`)
+ *
+ * Folder mentions are framed as a natural-language hint rather than a
+ * tool-level filter because today's search tools (`localSearch`,
+ * `semanticSearch`, etc.) do not accept a `folder`/`path` parameter — the
+ * agent must apply the scope itself via `glob`/`grep`/`read` path prefixes.
+ */
+export function buildPillSyntaxDirective(): string {
+  return (
+    `The user composes messages in a rich editor that supports @-mentions of vault items.\n` +
+    `Mentioned items appear inline in your input as the following literal tokens — treat\n` +
+    `them as concrete references the user picked, NOT as template placeholders to substitute.\n` +
+    `\n` +
+    `- \`[[note_title]]\` — a specific note in the vault. To read or modify it, call \`read\`\n` +
+    `  or \`edit\` with the resolved path; never infer a note's contents from its title alone.\n` +
+    `  When you cite a note in your written reply, use the same \`[[title]]\` form (no backticks).\n` +
+    `- \`{folder_name}\` — a vault folder the user wants you to focus on. To scope work to that\n` +
+    `  folder, pass \`folder_name/**\` to \`glob\`, or include \`folder_name/\` as a path prefix\n` +
+    `  when calling \`read\`, \`grep\`, or other path-aware tools.\n` +
+    `- \`{activeNote}\` — the user's currently active note (reserved special token). Resolve it\n` +
+    `  the same way as \`[[note_title]]\`.\n` +
+    `\n` +
+    `Any other \`{...}\` token in the user's message refers to a folder by that name, not a\n` +
+    `placeholder to fill in.`
+  );
+}

--- a/src/agentMode/skills/pillSyntaxDirective.ts
+++ b/src/agentMode/skills/pillSyntaxDirective.ts
@@ -1,27 +1,4 @@
-/**
- * Build the spawn-time directive that teaches every backend how to interpret
- * the @-mention pill tokens that appear in user messages. Copilot's chat
- * editor lets the user @-mention vault items inline; when the editor
- * extracts text for the LLM, each pill serializes to a literal token
- * (`[[title]]`, `{folder}`, `{activeNote}`). Without this directive the
- * agent has no way to know these are concrete vault references rather than
- * template placeholders to substitute.
- *
- * Composed into whatever existing system-prompt / instructions surface
- * each backend supports at spawn time, alongside `buildSkillCreationDirective`.
- * Pure leaf module — no Obsidian imports, no singletons, no arguments —
- * suitable for unit testing.
- *
- * The token shapes mirror the pill serializers:
- *   - `NotePillNode.getTextContent()` → `[[title]]`
- *   - `FolderPillNode.getTextContent()` → `{folderPath}`
- *   - Reserved `{activeNote}` template (handled in `parseTextForPills`)
- *
- * Folder mentions are framed as a natural-language hint rather than a
- * tool-level filter because today's search tools (`localSearch`,
- * `semanticSearch`, etc.) do not accept a `folder`/`path` parameter — the
- * agent must apply the scope itself via `glob`/`grep`/`read` path prefixes.
- */
+/** Teaches backends how to interpret the literal @-mention pill tokens (`[[title]]`, `{folder}`, `{activeNote}`) the chat editor emits. */
 export function buildPillSyntaxDirective(): string {
   return (
     `The user composes messages in a rich editor that supports @-mentions of vault items.\n` +

--- a/src/agentMode/ui/AgentChat.tsx
+++ b/src/agentMode/ui/AgentChat.tsx
@@ -13,6 +13,7 @@ import { useChatFileDrop } from "@/hooks/useChatFileDrop";
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import { expandCustomCommandPrefix } from "@/agentMode/session/expandCustomCommandPrefix";
+import { resolveActiveNoteToken } from "@/agentMode/session/resolveActiveNoteToken";
 import type {
   AgentChatMessage,
   CurrentPlan,
@@ -273,10 +274,14 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
     const hasWebExcerpt = selectedTextContexts.some(isWebSelectedTextContext);
     const hadUnsupportedAttachments = includeActiveWebTab || hasWebExcerpt;
 
+    // Resolve `app.workspace.getActiveFile()` once — it's used to build the
+    // candidate-note set, to expand slash-command active-note placeholders,
+    // and to rewrite the `{activeNote}` pill token in the message body.
+    const activeFile = app.workspace.getActiveFile();
+
     const candidateNotes: TFile[] = [];
-    if (includeActiveNote) {
-      const active = app.workspace.getActiveFile();
-      if (active) candidateNotes.push(active);
+    if (includeActiveNote && activeFile) {
+      candidateNotes.push(activeFile);
     }
     candidateNotes.push(...contextNotes);
     const notes = dedupeBy(candidateNotes, (n) => n.path);
@@ -292,11 +297,18 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
       getCachedCustomCommands(),
       app.vault,
       noteSelection?.content ?? "",
-      app.workspace.getActiveFile()
+      activeFile
     );
     if (expanded.matched) {
       void CustomCommandManager.getInstance().recordUsage(expanded.matched);
     }
+    // Replace the `{activeNote}` pill token with the actual `[[Note Title]]`
+    // wikilink form. The active file is a client-side concept the agent has
+    // no way to query; we resolve it here so the agent sees a concrete
+    // reference. `ActiveNotePillSyncPlugin` already pushes the active file
+    // onto `candidateNotes` (via `includeActiveNote`), so the resolved path
+    // is also in the `<copilot-context>` envelope for the agent to `read`.
+    const resolvedText = resolveActiveNoteToken(expanded.text, activeFile);
 
     const content: PromptContent[] = [];
 
@@ -308,7 +320,7 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
 
     const item: QueuedAgentMessage = {
       id: `queued-${uuidv4()}`,
-      text: expanded.text,
+      text: resolvedText,
       rawInput,
       context: buildMessageContext(notes, selectedTextContexts),
       promptContent: content.length > 0 ? content : undefined,

--- a/src/agentMode/ui/AgentChat.tsx
+++ b/src/agentMode/ui/AgentChat.tsx
@@ -274,9 +274,6 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
     const hasWebExcerpt = selectedTextContexts.some(isWebSelectedTextContext);
     const hadUnsupportedAttachments = includeActiveWebTab || hasWebExcerpt;
 
-    // Resolve `app.workspace.getActiveFile()` once — it's used to build the
-    // candidate-note set, to expand slash-command active-note placeholders,
-    // and to rewrite the `{activeNote}` pill token in the message body.
     const activeFile = app.workspace.getActiveFile();
 
     const candidateNotes: TFile[] = [];
@@ -302,12 +299,6 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
     if (expanded.matched) {
       void CustomCommandManager.getInstance().recordUsage(expanded.matched);
     }
-    // Replace the `{activeNote}` pill token with the actual `[[Note Title]]`
-    // wikilink form. The active file is a client-side concept the agent has
-    // no way to query; we resolve it here so the agent sees a concrete
-    // reference. `ActiveNotePillSyncPlugin` already pushes the active file
-    // onto `candidateNotes` (via `includeActiveNote`), so the resolved path
-    // is also in the `<copilot-context>` envelope for the agent to `read`.
     const resolvedText = resolveActiveNoteToken(expanded.text, activeFile);
 
     const content: PromptContent[] = [];


### PR DESCRIPTION
## Summary

- The chat editor serializes @-mention pills to `[[note]]`, `{folder}`, and `{activeNote}` tokens, but only the wiki-link was implicitly understood — `{folder}` and `{activeNote}` reached the agent as opaque literals.
- Adds a shared `buildPillSyntaxDirective()` appended to all three backends' spawn-time instruction surfaces (opencode's `cfg.agent.<id>.prompt`, codex's `developer_instructions` TOML, and the Claude SDK's `systemPrompt.append`), mirroring the existing `buildSkillCreationDirective` plumbing.
- Resolves `{activeNote}` to the actual `[[Note Title]]` at send time in `AgentChat.handleSendMessage` — the active file is a client-side concept the agent can't query, and `ActiveNotePillSyncPlugin` already attaches the file to the `<copilot-context>` envelope so the agent can `read` it by path.
- Removes the now-redundant `[[title]]` bullet from `COPILOT_PROMPT_BASE` so the shared directive is the single source of truth across backends.

## Test plan

- [x] `npm test` (2773/2773 pass)
- [x] `npm run lint` (0 errors)
- [x] `npx tsc --noEmit` (clean)
- [ ] In agent chat, `@`-mention a folder (`@Projects`), send a message, confirm via the Agent Mode Frame Log that the agent acts on `Projects/` rather than echoing `{Projects}` literally — across opencode, claude, and codex.
- [ ] `@activeNote` in agent chat: confirm the agent receives `[[Note Title]]` in the message body and the path in the `<copilot-context>` envelope. With no active file open, confirm graceful degradation (token left as `{activeNote}`).
- [ ] Paste regression: paste `{SomeFolder}` into the chat editor and confirm it still rehydrates into a folder pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)