### PR TITLE
fix(skills): allow assigning Claude-only skills to any agent

### DIFF
--- a/src/agentMode/skills/ui/AgentIconButton.tsx
+++ b/src/agentMode/skills/ui/AgentIconButton.tsx
@@ -14,12 +14,6 @@ interface AgentIconButtonProps {
   agentName?: string;
   /** Toggled-on state — filled brand colour vs. dashed outline. */
   enabled: boolean;
-  /**
-   * Hard-disabled — used when a skill carries a Claude-only flag that the
-   * agent silently ignores (e.g. Codex on a `disable-model-invocation`
-   * skill). Click is suppressed and the button is dimmed.
-   */
-  disabled?: boolean;
   onClick?: () => void;
   title?: string;
   size?: "sm" | "md";
@@ -31,29 +25,24 @@ export const AgentIconButton: React.FC<AgentIconButtonProps> = ({
   agentId,
   agentName,
   enabled,
-  disabled = false,
   onClick,
   title,
   size = "md",
 }) => {
-  const handleClick = () => {
-    if (!disabled) onClick?.();
-  };
   const label = agentName ?? agentId;
   return (
     <div
       role="button"
-      tabIndex={disabled ? -1 : 0}
-      onClick={handleClick}
+      tabIndex={0}
+      onClick={onClick}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
-          handleClick();
+          onClick?.();
         }
       }}
       title={title}
       aria-pressed={enabled}
-      aria-disabled={disabled}
       aria-label={title ?? `${enabled ? "Disable" : "Enable"} ${label}`}
       className={cn(
         "tw-flex tw-items-center tw-justify-center tw-transition-transform",
@@ -61,8 +50,7 @@ export const AgentIconButton: React.FC<AgentIconButtonProps> = ({
         size === "md" ? "tw-size-[26px] tw-rounded-[7px]" : "tw-size-5 tw-rounded-[5px]",
         enabled
           ? "tw-bg-interactive-accent tw-text-on-accent"
-          : "tw-border tw-border-dashed tw-border-[var(--text-faint)] tw-bg-primary tw-text-faint tw-opacity-60 hover:tw-opacity-100",
-        disabled && "tw-pointer-events-none tw-cursor-not-allowed tw-opacity-50"
+          : "tw-border tw-border-dashed tw-border-[var(--text-faint)] tw-bg-primary tw-text-faint tw-opacity-60 hover:tw-opacity-100"
       )}
     >
       <Icon className="tw-size-3.5" />

--- a/src/agentMode/skills/ui/SkillRow.tsx
+++ b/src/agentMode/skills/ui/SkillRow.tsx
@@ -58,10 +58,6 @@ export const SkillRow: React.FC<SkillRowProps> = ({
   const [menuOpen, setMenuOpen] = React.useState(false);
   const chips = computeChips(skill);
   const enabledAgents = new Set(skill.enabledAgents);
-  // Codex silently ignores the three Claude-only flags. We surface this by
-  // hard-disabling the Codex toggle when any of those flags are set so the
-  // user understands the row is Claude-only territory.
-  const claudeOnlySkill = isClaudeOnlySkill(skill);
 
   return (
     <div
@@ -93,12 +89,6 @@ export const SkillRow: React.FC<SkillRowProps> = ({
       <div className="tw-flex tw-items-center tw-gap-1.5">
         {agents.map((agent) => {
           const enabled = enabledAgents.has(agent.id);
-          // Codex silently ignores the Claude-only frontmatter flags
-          // (`disable-model-invocation`, explicit `model:`, `user-invocable:
-          // false`). When those flags are set we hard-disable the Codex toggle
-          // to communicate that the row is Claude-only territory. Other
-          // backends are unaffected.
-          const hardDisabled = agent.id === "codex" && claudeOnlySkill;
           return (
             <AgentIconButton
               key={agent.id}
@@ -106,15 +96,14 @@ export const SkillRow: React.FC<SkillRowProps> = ({
               agentId={agent.id}
               agentName={agent.displayName}
               enabled={enabled}
-              disabled={hardDisabled}
               onClick={
-                onToggleAgent !== undefined && !hardDisabled
+                onToggleAgent !== undefined
                   ? () => {
                       void onToggleAgent(agent.id);
                     }
                   : undefined
               }
-              title={tooltipFor(agent.displayName, enabled, hardDisabled)}
+              title={tooltipFor(agent.displayName, enabled)}
             />
           );
         })}
@@ -191,24 +180,8 @@ function truncateModel(model: string): string {
   return model.length <= 22 ? model : `${model.slice(0, 21)}…`;
 }
 
-/**
- * A skill is "Claude-only" if any of the three Claude-native flags are set
- * — Codex and (for `user-invocable`) OpenCode silently ignore them. We
- * only surface this state on the Codex toggle.
- */
-function isClaudeOnlySkill(skill: Skill): boolean {
-  return (
-    skill.model !== undefined ||
-    skill.disableModelInvocation === true ||
-    skill.userInvocable === false
-  );
-}
-
 /** Tooltip copy for a single agent icon in its current state. */
-function tooltipFor(agentName: string, enabled: boolean, disabled: boolean): string {
-  if (disabled) {
-    return `${agentName} ignores this skill's Claude-only flag`;
-  }
+function tooltipFor(agentName: string, enabled: boolean): string {
   return enabled ? `Enabled for ${agentName}` : `Disabled for ${agentName} · click to enable`;
 }
 


### PR DESCRIPTION
## Summary
- Removes the hard-disable on the Codex (and other non-Claude) agent toggles for skills that carry Claude-only frontmatter flags (`disable-model-invocation`, `user-invocable`, `model`).
- Those flags are silently ignored by non-Claude agents, so blocking assignment was unnecessarily restrictive; the inline row chips already communicate which fields are Claude-specific.
- Drops the now-unused `disabled` prop and "ignores this skill's Claude-only flag" tooltip from `AgentIconButton`.

## Test plan
- [ ] Open Settings → Skills, find a skill with `disable-model-invocation`, `user-invocable: false`, or an explicit `model:` and confirm the Codex toggle is interactive.
- [ ] Toggle Codex on/off and verify the symlink fanout still updates and the chip row still shows the Claude-only markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)