### PR TITLE
fix(agent-mode): reject invalid env variable names before commit

### DIFF
--- a/src/agentMode/backends/shared/EnvOverridesSetting.tsx
+++ b/src/agentMode/backends/shared/EnvOverridesSetting.tsx
@@ -43,6 +43,10 @@ function rowsToRecord(rows: Row[]): Record<string, string> | undefined {
   for (const row of rows) {
     const name = row.name.trim();
     if (!name) continue;
+    // Skip names that fail validation so malformed keys never reach
+    // backend spawn paths, which read `envOverrides` from settings
+    // directly without re-sanitizing.
+    if (!ENV_VAR_NAME_RE.test(name)) continue;
     out[name] = row.value;
   }
   return Object.keys(out).length > 0 ? out : undefined;
@@ -60,9 +64,10 @@ const COMMIT_DEBOUNCE_MS = 400;
  * the last edit always lands. The parent's `value` is consulted only at
  * mount — external reloads while the editor is open are uncommon.
  *
- * Validation is permissive: invalid names surface an inline warning but
- * don't block typing. `sanitizeEnvOverrides` drops anything malformed at
- * save time, so the persisted shape is always safe.
+ * Validation is permissive in the input: invalid names surface an inline
+ * warning but don't block typing. `rowsToRecord` then drops malformed
+ * rows before commit, so the persisted record (and the env passed to
+ * backend subprocesses) only ever contains valid POSIX identifiers.
  */
 export const EnvOverridesSetting: React.FC<Props> = ({
   value,


### PR DESCRIPTION
## Summary
- `rowsToRecord` in `EnvOverridesSetting` was persisting every non-empty trimmed key, so names failing `ENV_VAR_NAME_RE` (e.g. `BAD KEY`, `FOO=BAR`) flowed through `onChange` into settings.
- Backend spawn paths (`ClaudeSdkBackendProcess`, `CodexBackend`, `OpencodeBackend`) read `envOverrides` from settings directly without re-running `sanitizeEnvOverrides`, so malformed keys could reach subprocess env with platform-dependent behavior.
- Filter invalid rows at the commit boundary and update the JSDoc to reflect that sanitization now happens at commit, not at load.

## Test plan
- [ ] Add a row with an invalid name (e.g. `BAD KEY`) in the Claude/Codex/opencode settings panel; inline warning appears and the value is not persisted.
- [ ] Add a valid row (e.g. `HTTPS_PROXY=...`) and confirm it persists and reaches the spawned backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)