### PR TITLE
feat(agent-mode): make note links clickable in chat and tool cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,7 +331,15 @@ The TODO.md should be:
 
 ### Obsidian Plugin Environment
 
-- **Global `app` variable**: In Obsidian plugins, `app` is a globally available variable that provides access to the Obsidian API. It's automatically available in all files without needing to import or declare it.
+#### Accessing the Obsidian `app`
+
+Don't use the global `app`. It's a footgun in popout windows and hides dependencies from tests.
+
+- **React components** → `useApp()` from `@/context`. Don't add `app` as a new prop just to thread it down — call `useApp()` at the leaf.
+- **Non-React modules** → take `app` (or just the slice you need, e.g. `app.vault`) as a parameter.
+- **Plugin entry points** → `this.app` on the `Plugin` instance.
+
+Never write `declare const app: App;` in new code. A few legacy files do — don't follow them.
 
 ### Picking the right `document` / `window` (popout-window safety)
 

--- a/src/agentMode/ui/ActionCard.tsx
+++ b/src/agentMode/ui/ActionCard.tsx
@@ -1,10 +1,12 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, Loader2, Check, X } from "lucide-react";
 import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
 import type { AgentToolStatus } from "@/agentMode/session/types";
 import { lookupToolSummary } from "@/agentMode/ui/toolSummaries";
 import { renderDiff } from "@/agentMode/ui/diffRender";
+import { getVaultBase } from "@/agentMode/ui/vaultPath";
 import { cn } from "@/lib/utils";
+import { useApp } from "@/context";
 
 interface ActionCardProps {
   part: ToolCallPart;
@@ -14,14 +16,24 @@ interface ActionCardProps {
 }
 
 export const ActionCard: React.FC<ActionCardProps> = ({ part, inline }) => {
+  const app = useApp();
   const [open, setOpen] = useState(false);
   const summary = lookupToolSummary(part);
+  // `vaultBase` is stable for the plugin lifetime, but `getVaultBase` is
+  // cheap once cached — memoize to keep the summary inputs referentially
+  // stable across re-renders.
+  const summaryCtx = useMemo(() => ({ vaultBase: getVaultBase(app) }), [app]);
   const Icon = summary.icon;
-  const line = summary.collapsedLine(part);
+  const line = summary.collapsedLine(part, summaryCtx);
   const outcome = summary.outcome(part);
   const outputs = part.output ?? [];
   const details = summary.expandedDetails?.(part) ?? null;
   const expandable = outputs.length > 0 || details !== null;
+  // Only expose a clickable target once the call has completed — opening a
+  // half-written file mid-Edit would race with the tool, and an in-progress
+  // Read has nothing to show yet.
+  const targetPath =
+    part.status === "completed" ? (summary.targetPath?.(part, summaryCtx) ?? null) : null;
 
   const headerClasses = cn(
     "tw-flex tw-items-center tw-gap-1.5 tw-text-sm tw-text-muted",
@@ -38,7 +50,21 @@ export const ActionCard: React.FC<ActionCardProps> = ({ part, inline }) => {
         role={expandable ? "button" : undefined}
       >
         <Icon className="tw-size-3.5 tw-shrink-0 tw-text-muted" />
-        <span className="tw-flex-1 tw-truncate tw-font-medium">{line}</span>
+        {targetPath ? (
+          <a
+            href="#"
+            className="tw-flex-1 tw-truncate tw-font-medium tw-text-inherit hover:tw-text-accent hover:tw-underline"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              void app.workspace.openLinkText(targetPath, "", true);
+            }}
+          >
+            {line}
+          </a>
+        ) : (
+          <span className="tw-flex-1 tw-truncate tw-font-medium">{line}</span>
+        )}
         <StatusBadge status={part.status} />
         {expandable &&
           (open ? (

--- a/src/agentMode/ui/AgentMarkdownText.tsx
+++ b/src/agentMode/ui/AgentMarkdownText.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { logWarn } from "@/logger";
-import { App, Component, MarkdownRenderer } from "obsidian";
+import { renderMarkdown } from "@/utils/renderMarkdown";
+import { App, Component } from "obsidian";
 
 interface AgentMarkdownTextProps {
   text: string;
@@ -22,7 +23,7 @@ export const AgentMarkdownText: React.FC<AgentMarkdownTextProps> = ({ text, app 
     target.empty();
     const component = new Component();
     component.load();
-    MarkdownRenderer.renderMarkdown(text, target, "", component).catch((e: unknown) => {
+    renderMarkdown(app, text, target, "", component).catch((e: unknown) => {
       logWarn("[AgentTrail] markdown render failed", e);
     });
     return () => {

--- a/src/agentMode/ui/AgentMarkdownText.tsx
+++ b/src/agentMode/ui/AgentMarkdownText.tsx
@@ -23,7 +23,10 @@ export const AgentMarkdownText: React.FC<AgentMarkdownTextProps> = ({ text, app 
     target.empty();
     const component = new Component();
     component.load();
-    renderMarkdown(app, text, target, "", component).catch((e: unknown) => {
+    // Resolve internal links against the active note so vaults with
+    // duplicate basenames or heading-only links open the right file.
+    const sourcePath = app.workspace.getActiveFile()?.path ?? "";
+    renderMarkdown(app, text, target, sourcePath, component).catch((e: unknown) => {
       logWarn("[AgentTrail] markdown render failed", e);
     });
     return () => {

--- a/src/agentMode/ui/PlanPreviewView.tsx
+++ b/src/agentMode/ui/PlanPreviewView.tsx
@@ -172,7 +172,10 @@ const PlanPreviewRoot: React.FC<PlanPreviewRootProps> = ({ app, state }) => {
     // the effect — unloading drops every subscription it set up.
     const component = new Component();
     component.load();
-    renderMarkdown(app, planMarkdown, target, "", component).catch((e: unknown) => {
+    // Resolve internal links against the active note so vaults with
+    // duplicate basenames or heading-only links open the right file.
+    const sourcePath = app.workspace.getActiveFile()?.path ?? "";
+    renderMarkdown(app, planMarkdown, target, sourcePath, component).catch((e: unknown) => {
       logWarn("[PlanPreviewView] markdown render failed", e);
     });
     return () => {

--- a/src/agentMode/ui/PlanPreviewView.tsx
+++ b/src/agentMode/ui/PlanPreviewView.tsx
@@ -4,7 +4,8 @@ import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { CurrentPlan, PlanDecisionAction } from "@/agentMode/session/types";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
 import { Check, FileText, X as XIcon } from "lucide-react";
-import { App, Component, ItemView, MarkdownRenderer, WorkspaceLeaf } from "obsidian";
+import { renderMarkdown } from "@/utils/renderMarkdown";
+import { App, Component, ItemView, WorkspaceLeaf } from "obsidian";
 import React, { useEffect, useRef, useState } from "react";
 import { Root } from "react-dom/client";
 
@@ -171,7 +172,7 @@ const PlanPreviewRoot: React.FC<PlanPreviewRootProps> = ({ app, state }) => {
     // the effect — unloading drops every subscription it set up.
     const component = new Component();
     component.load();
-    MarkdownRenderer.renderMarkdown(planMarkdown, target, "", component).catch((e: unknown) => {
+    renderMarkdown(app, planMarkdown, target, "", component).catch((e: unknown) => {
       logWarn("[PlanPreviewView] markdown render failed", e);
     });
     return () => {

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -5,13 +5,10 @@ import {
 } from "@/agentMode/ui/toolSummaries";
 import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
 
-jest.mock("@/agentMode/ui/vaultPath", () => {
-  const actual = jest.requireActual("@/agentMode/ui/vaultPath");
-  return {
-    ...actual,
-    getVaultBase: () => "/Users/me/vault",
-  };
-});
+// Fixed ctx for every test — mirrors what `ActionCard` would resolve via
+// `getVaultBase(app)`. Lets us exercise vault-relative path rendering
+// without mocking the entire `app` object.
+const CTX = { vaultBase: "/Users/me/vault" };
 
 function tool(overrides: Partial<ToolCallPart> = {}): ToolCallPart {
   return {
@@ -31,7 +28,7 @@ describe("lookupToolSummary", () => {
       output: [{ type: "text", text: "hello world".repeat(100) }],
     });
     const s = lookupToolSummary(t);
-    expect(s.collapsedLine(t)).toMatch(/^Read /);
+    expect(s.collapsedLine(t, CTX)).toMatch(/^Read /);
     expect(s.outcome(t)).toMatch(/tokens$/);
   });
 
@@ -41,7 +38,7 @@ describe("lookupToolSummary", () => {
       title: "read",
       locations: [{ path: "/Users/me/vault/notes/music-theory.md" }],
     });
-    expect(lookupToolSummary(t).collapsedLine(t)).toBe("Read notes/music-theory.md");
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Read notes/music-theory.md");
   });
 
   it("falls back to the original path when the file is outside the vault", () => {
@@ -50,7 +47,7 @@ describe("lookupToolSummary", () => {
       title: "read",
       locations: [{ path: "/etc/passwd" }],
     });
-    expect(lookupToolSummary(t).collapsedLine(t)).toBe("Read /etc/passwd");
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Read /etc/passwd");
   });
 
   it("aggregates Edits with combined +/- line counts and counts notes", () => {
@@ -87,7 +84,7 @@ describe("lookupToolSummary", () => {
       },
     });
     const s = lookupToolSummary(t);
-    expect(s.collapsedLine(t)).toBe('research-agent · "find jazz voicings"');
+    expect(s.collapsedLine(t, CTX)).toBe('research-agent · "find jazz voicings"');
   });
 
   it('routes Claude Code\'s "Agent" vendor name to the sub-agent summary', () => {
@@ -107,7 +104,9 @@ describe("lookupToolSummary", () => {
       },
     });
     const s = lookupToolSummary(t);
-    expect(s.collapsedLine(t)).toBe('Explore · "Map user-facing features of obsidian-copilot"');
+    expect(s.collapsedLine(t, CTX)).toBe(
+      'Explore · "Map user-facing features of obsidian-copilot"'
+    );
     // Same summary as the Task vendor name — the alias just routes through.
     const taskEquiv = lookupToolSummary({ ...t, vendorToolName: "Task" });
     expect(s).toBe(taskEquiv);
@@ -120,26 +119,26 @@ describe("lookupToolSummary", () => {
       title: "LS Daily",
       input: { path: "Daily" },
     });
-    expect(lookupToolSummary(list).collapsedLine(list)).toBe("Listed Daily");
+    expect(lookupToolSummary(list).collapsedLine(list, CTX)).toBe("Listed Daily");
   });
 
   it("falls back to ACP toolKind when vendor is missing", () => {
     const t = tool({ toolKind: "edit", title: "wrote thing" });
     const s = lookupToolSummary(t);
-    expect(s.collapsedLine(t)).toMatch(/^Edited /);
+    expect(s.collapsedLine(t, CTX)).toMatch(/^Edited /);
   });
 
   it("falls back to generic when both vendor and toolKind are unknown", () => {
     const t = tool({ title: "weirdtool" });
     const s = lookupToolSummary(t);
-    expect(s.collapsedLine(t)).toBe("weirdtool");
+    expect(s.collapsedLine(t, CTX)).toBe("weirdtool");
   });
 
   it("hides the duplicated vendor name while Read input is still streaming", () => {
     // SDK seeds title to the vendor name before any input-JSON has been
     // parsed. Should render "Reading …" rather than "Reading Read".
     const t = tool({ vendorToolName: "Read", title: "Read", status: "in_progress" });
-    expect(lookupToolSummary(t).collapsedLine(t)).toBe("Reading …");
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Reading …");
   });
 
   it("flips Read to past tense once the call completes", () => {
@@ -149,7 +148,7 @@ describe("lookupToolSummary", () => {
       status: "completed",
       locations: [{ path: "/Users/me/vault/notes/foo.md" }],
     });
-    expect(lookupToolSummary(t).collapsedLine(t)).toBe("Read notes/foo.md");
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Read notes/foo.md");
   });
 
   it("uses Editing while Edit is in flight and Edited when it completes", () => {
@@ -159,9 +158,9 @@ describe("lookupToolSummary", () => {
       status: "in_progress",
       input: { file_path: "/Users/me/vault/draft.md" },
     });
-    expect(lookupToolSummary(inflight).collapsedLine(inflight)).toBe("Editing draft.md");
+    expect(lookupToolSummary(inflight).collapsedLine(inflight, CTX)).toBe("Editing draft.md");
     const done = tool({ ...inflight, status: "completed" });
-    expect(lookupToolSummary(done).collapsedLine(done)).toBe("Edited draft.md");
+    expect(lookupToolSummary(done).collapsedLine(done, CTX)).toBe("Edited draft.md");
   });
 
   it("uses Fetching while WebFetch is in flight and Fetched when it completes", () => {
@@ -171,11 +170,11 @@ describe("lookupToolSummary", () => {
       status: "in_progress",
       input: { url: "https://example.com" },
     });
-    expect(lookupToolSummary(inflight).collapsedLine(inflight)).toBe(
+    expect(lookupToolSummary(inflight).collapsedLine(inflight, CTX)).toBe(
       "Fetching https://example.com"
     );
     const done = tool({ ...inflight, status: "completed" });
-    expect(lookupToolSummary(done).collapsedLine(done)).toBe("Fetched https://example.com");
+    expect(lookupToolSummary(done).collapsedLine(done, CTX)).toBe("Fetched https://example.com");
   });
 
   it("uses Running while Bash is in flight and Ran when it completes", () => {
@@ -185,9 +184,11 @@ describe("lookupToolSummary", () => {
       status: "in_progress",
       input: { description: "Check working tree" },
     });
-    expect(lookupToolSummary(inflight).collapsedLine(inflight)).toBe("Running Check working tree");
+    expect(lookupToolSummary(inflight).collapsedLine(inflight, CTX)).toBe(
+      "Running Check working tree"
+    );
     const done = tool({ ...inflight, status: "completed" });
-    expect(lookupToolSummary(done).collapsedLine(done)).toBe("Ran Check working tree");
+    expect(lookupToolSummary(done).collapsedLine(done, CTX)).toBe("Ran Check working tree");
   });
 });
 
@@ -197,7 +198,7 @@ describe("BASH_SUMMARY.expandedDetails", () => {
       "cd ~/Developer/obsidian-copilot && rg --multiline 'foo bar baz' src/**/*.ts | head -50";
     const t = tool({ vendorToolName: "Bash", input: { command: longCmd } });
     const s = lookupToolSummary(t);
-    expect(s.collapsedLine(t).length).toBeLessThan(longCmd.length); // collapsed truncates
+    expect(s.collapsedLine(t, CTX).length).toBeLessThan(longCmd.length); // collapsed truncates
     expect(s.expandedDetails?.(t)).toBe(longCmd);
   });
 

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -2,7 +2,18 @@ import type { LucideIcon } from "lucide-react";
 import { Bot } from "lucide-react";
 import { pickToolIcon } from "@/agentMode/ui/toolIcons";
 import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
-import { getVaultBase, toVaultRelative } from "@/agentMode/ui/vaultPath";
+import { toVaultRelative } from "@/agentMode/ui/vaultPath";
+
+/**
+ * Render-time context passed through to the summary callbacks that need
+ * vault-relative path resolution. Resolved once by `ActionCard` /
+ * `AggregateCard` (which can call `getVaultBase(app)`), so the summary
+ * objects themselves stay free of any reach into the global `app`.
+ */
+export interface ToolSummaryContext {
+  /** Vault root absolute path, or null when unavailable (mobile, tests). */
+  vaultBase: string | null;
+}
 
 /**
  * Tool-aware presentation for one or more tool_call parts. Each tool
@@ -14,13 +25,19 @@ export interface ToolSummary {
   /** Lucide icon component shown in the collapsed line. */
   icon: LucideIcon;
   /** Single-line "Edited practice-log.md" style verb · target. */
-  collapsedLine: (part: ToolCallPart) => string;
+  collapsedLine: (part: ToolCallPart, ctx?: ToolSummaryContext) => string;
   /** Optional muted line below the title — counts/sizes/duration. Null hides. */
   outcome: (part: ToolCallPart) => string | null;
   /** Tool-aware aggregate stat for N consecutive same-key parts. */
   aggregate: (parts: ToolCallPart[]) => { line: string; outcome: string };
   /** Full tool input shown only in the expanded card. Null hides. */
   expandedDetails?: (part: ToolCallPart) => string | null;
+  /**
+   * Vault-relative path of the note this tool call targets, or null when the
+   * tool has no single file target. When set and the call has completed,
+   * `ActionCard` renders the collapsed line as a clickable internal link.
+   */
+  targetPath?: (part: ToolCallPart, ctx?: ToolSummaryContext) => string | null;
 }
 
 /**
@@ -102,17 +119,16 @@ function verb(part: ToolCallPart, progressive: string, past: string): string {
   return part.status === "completed" || part.status === "failed" ? past : progressive;
 }
 
-function targetFromPath(part: ToolCallPart): string | null {
-  const base = getVaultBase();
+function targetFromPath(part: ToolCallPart, vaultBase: string | null): string | null {
   const loc = part.locations?.[0]?.path;
-  if (typeof loc === "string" && loc.length > 0) return toVaultRelative(loc, base);
+  if (typeof loc === "string" && loc.length > 0) return toVaultRelative(loc, vaultBase);
   const input = part.input as
     | { file_path?: unknown; filePath?: unknown; path?: unknown }
     | null
     | undefined;
-  if (typeof input?.file_path === "string") return toVaultRelative(input.file_path, base);
-  if (typeof input?.filePath === "string") return toVaultRelative(input.filePath, base);
-  if (typeof input?.path === "string") return toVaultRelative(input.path, base);
+  if (typeof input?.file_path === "string") return toVaultRelative(input.file_path, vaultBase);
+  if (typeof input?.filePath === "string") return toVaultRelative(input.filePath, vaultBase);
+  if (typeof input?.path === "string") return toVaultRelative(input.path, vaultBase);
   return null;
 }
 
@@ -153,7 +169,8 @@ function approxTokens(part: ToolCallPart): number {
 
 const READ_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "Read" }),
-  collapsedLine: (p) => `${verb(p, "Reading", "Read")} ${targetFromPath(p) ?? targetFromTitle(p)}`,
+  collapsedLine: (p, ctx) =>
+    `${verb(p, "Reading", "Read")} ${targetFromPath(p, ctx?.vaultBase ?? null) ?? targetFromTitle(p)}`,
   outcome: (p) => {
     const t = approxTokens(p);
     return t > 0 ? `~${formatTokens(t)} tokens` : null;
@@ -165,13 +182,14 @@ const READ_SUMMARY: ToolSummary = {
       outcome: tokens > 0 ? `~${formatTokens(tokens)} tokens` : "",
     };
   },
+  targetPath: (p, ctx) => targetFromPath(p, ctx?.vaultBase ?? null),
 };
 
 const LIST_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "LS" }),
-  collapsedLine: (p) => {
+  collapsedLine: (p, ctx) => {
     const v = verb(p, "Listing", "Listed");
-    const path = targetFromPath(p);
+    const path = targetFromPath(p, ctx?.vaultBase ?? null);
     return path ? `${v} ${path}` : `${v} vault root`;
   },
   outcome: () => null,
@@ -183,8 +201,8 @@ const LIST_SUMMARY: ToolSummary = {
 
 const EDIT_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "Edit" }),
-  collapsedLine: (p) =>
-    `${verb(p, "Editing", "Edited")} ${targetFromPath(p) ?? targetFromTitle(p)}`,
+  collapsedLine: (p, ctx) =>
+    `${verb(p, "Editing", "Edited")} ${targetFromPath(p, ctx?.vaultBase ?? null) ?? targetFromTitle(p)}`,
   outcome: (p) => {
     const { added, removed } = diffStats(p);
     if (added === 0 && removed === 0) return null;
@@ -203,6 +221,7 @@ const EDIT_SUMMARY: ToolSummary = {
       outcome: added + removed > 0 ? `+${added} / −${removed} lines` : "",
     };
   },
+  targetPath: (p, ctx) => targetFromPath(p, ctx?.vaultBase ?? null),
 };
 
 const BASH_SUMMARY: ToolSummary = {
@@ -369,8 +388,8 @@ const KIND_FETCH_SUMMARY: ToolSummary = {
 };
 const KIND_DELETE_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ toolKind: "delete" }),
-  collapsedLine: (p) =>
-    `${verb(p, "Deleting", "Deleted")} ${targetFromPath(p) ?? targetFromTitle(p)}`,
+  collapsedLine: (p, ctx) =>
+    `${verb(p, "Deleting", "Deleted")} ${targetFromPath(p, ctx?.vaultBase ?? null) ?? targetFromTitle(p)}`,
   outcome: () => null,
   aggregate: (parts) => ({
     line: `Deleted ${pluralize(parts.length, "item")}${statusSuffix(parts)}`,
@@ -379,7 +398,8 @@ const KIND_DELETE_SUMMARY: ToolSummary = {
 };
 const KIND_MOVE_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ toolKind: "move" }),
-  collapsedLine: (p) => `${verb(p, "Moving", "Moved")} ${targetFromPath(p) ?? targetFromTitle(p)}`,
+  collapsedLine: (p, ctx) =>
+    `${verb(p, "Moving", "Moved")} ${targetFromPath(p, ctx?.vaultBase ?? null) ?? targetFromTitle(p)}`,
   outcome: () => null,
   aggregate: (parts) => ({
     line: `Moved ${pluralize(parts.length, "item")}${statusSuffix(parts)}`,

--- a/src/agentMode/ui/vaultPath.ts
+++ b/src/agentMode/ui/vaultPath.ts
@@ -1,18 +1,19 @@
 import { App, FileSystemAdapter } from "obsidian";
 
-declare const app: App;
-
 let cachedBase: string | null | undefined;
 
 /**
  * Returns the vault root absolute path on desktop, or null on mobile /
- * test environments where the global `app` or FileSystemAdapter isn't
- * available. Cached after the first successful read.
+ * test environments where the `FileSystemAdapter` isn't available. Cached
+ * after the first successful read because the vault root cannot change
+ * for the lifetime of the plugin instance.
+ *
+ * @param app The Obsidian `App` instance used to access the vault adapter.
  */
-export function getVaultBase(): string | null {
+export function getVaultBase(app: App): string | null {
   if (cachedBase !== undefined) return cachedBase;
   try {
-    const adapter = app?.vault?.adapter;
+    const adapter = app.vault?.adapter;
     cachedBase =
       adapter instanceof FileSystemAdapter ? stripTrailingSep(adapter.getBasePath()) : null;
   } catch {

--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -19,6 +19,7 @@ jest.mock("@/settings/model", () => ({
       },
     ],
   })),
+  getSettings: jest.fn(() => ({ debug: false })),
 }));
 
 jest.mock("@/aiParams", () => ({
@@ -46,6 +47,7 @@ jest.mock("obsidian", () => {
     Component: class {
       load() {}
       unload() {}
+      register(_cb: () => void) {}
     },
     MarkdownView: class {},
     TFile: class {},

--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -36,10 +36,12 @@ jest.mock("@/LLMProviders/chainRunner/utils/citationUtils", () => ({
 }));
 
 jest.mock("obsidian", () => {
-  const renderMarkdown = jest.fn().mockResolvedValue(undefined);
+  // Mirrors the modern `MarkdownRenderer.render(app, md, el, sourcePath, component)`
+  // signature — `md` is the second argument, not the first.
+  const render = jest.fn().mockResolvedValue(undefined);
   return {
     MarkdownRenderer: {
-      renderMarkdown,
+      render,
     },
     Component: class {
       load() {}
@@ -63,12 +65,12 @@ jest.mock("obsidian", () => {
         /* noop */
       }
     },
-    __renderMarkdownMock: renderMarkdown,
+    __renderMock: render,
   };
 });
 
-const { __renderMarkdownMock: renderMarkdownMock } = jest.requireMock<{
-  __renderMarkdownMock: jest.Mock;
+const { __renderMock: renderMarkdownMock } = jest.requireMock<{
+  __renderMock: jest.Mock;
 }>("obsidian");
 
 // ---------------------------------------------------------------------------
@@ -127,7 +129,7 @@ describe("think block rendering — closing tags are not consumed by indented co
     const messageText = `<think>${thinkContent}</think>Here is my answer.`;
 
     const capturedMarkdown: string[] = [];
-    renderMarkdownMock.mockImplementation(async (md: string, el: HTMLElement) => {
+    renderMarkdownMock.mockImplementation(async (_app: unknown, md: string, el: HTMLElement) => {
       capturedMarkdown.push(md);
       el.textContent = "rendered";
     });
@@ -153,7 +155,7 @@ describe("think block rendering — closing tags are not consumed by indented co
     const messageText = `<think>${thinkContent}</think>Response text.`;
 
     const capturedMarkdown: string[] = [];
-    renderMarkdownMock.mockImplementation(async (md: string, el: HTMLElement) => {
+    renderMarkdownMock.mockImplementation(async (_app: unknown, md: string, el: HTMLElement) => {
       capturedMarkdown.push(md);
       el.textContent = "rendered";
     });
@@ -179,7 +181,7 @@ describe("think block rendering — closing tags are not consumed by indented co
     const messageText = "<think>Thinking:\n    *   Still streaming.";
 
     const capturedMarkdown: string[] = [];
-    renderMarkdownMock.mockImplementation(async (md: string, el: HTMLElement) => {
+    renderMarkdownMock.mockImplementation(async (_app: unknown, md: string, el: HTMLElement) => {
       capturedMarkdown.push(md);
       el.textContent = "rendered";
     });
@@ -287,10 +289,11 @@ describe("ChatSingleMessage", () => {
   });
 
   it("normalizes rendered footnotes for assistant messages", async () => {
-    renderMarkdownMock.mockImplementation(async (_markdown: string, el: HTMLElement) => {
-      el.append(
-        ...new DOMParser().parseFromString(
-          `
+    renderMarkdownMock.mockImplementation(
+      async (_app: unknown, _markdown: string, el: HTMLElement) => {
+        el.append(
+          ...new DOMParser().parseFromString(
+            `
         <p>Example <sup><a href="#fn-2">2-1</a></sup></p>
         <hr class="content-hr" />
         <div class="footnotes">
@@ -302,10 +305,11 @@ describe("ChatSingleMessage", () => {
           </ol>
         </div>
       `,
-          "text/html"
-        ).body.children
-      );
-    });
+            "text/html"
+          ).body.children
+        );
+      }
+    );
 
     const { container } = render(
       <TooltipProvider>

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -36,7 +36,8 @@ import { logError } from "@/logger";
 import { ChatMessage } from "@/types/message";
 import { cleanMessageForCopy, extractYoutubeVideoId, insertIntoEditor } from "@/utils";
 import { preprocessAIResponse } from "@/utils/markdownPreprocess";
-import { App, Component, MarkdownRenderer, MarkdownView, TFile } from "obsidian";
+import { renderMarkdown } from "@/utils/renderMarkdown";
+import { App, Component, MarkdownView, TFile } from "obsidian";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSettingsValue } from "@/settings/model";
 import {
@@ -550,14 +551,6 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
         '<span class="copilot-citation-ref">[$1]</span>'
       );
 
-      // Transform [[link]] to clickable format but exclude ![[]] image links
-      const noteLinksProcessed = replaceLinks(
-        citationPlaceholderProcessed,
-        /(?<!!)\[\[([^\]]+)]]/g,
-        (file: TFile) =>
-          `<a href="obsidian://open?file=${encodeURIComponent(file.path)}">${file.basename}</a>`
-      );
-
       /**
        * Converts YouTube video embeds to static thumbnails during streaming.
        * This prevents iframe flickering caused by repeated DOM recreation.
@@ -585,7 +578,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
         });
       };
 
-      return processYouTubeEmbed(noteLinksProcessed);
+      return processYouTubeEmbed(citationPlaceholderProcessed);
     },
     [app, isStreaming, settings.enableInlineCitations, collapsibleOpenStateMap]
   );
@@ -718,14 +711,9 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
               contentRef.current!.appendChild(textDiv);
             }
 
-            void MarkdownRenderer.renderMarkdown(
-              segment.content,
-              textDiv,
-              "",
-              componentRef.current!
-            )
+            void renderMarkdown(app, segment.content, textDiv, "", componentRef.current!)
               .then(() => normalizeFootnoteRendering(textDiv))
-              .catch((err) => logError("renderMarkdown failed", err));
+              .catch((err: unknown) => logError("renderMarkdown failed", err));
             currentIndex++;
           } else if (segment.type === "toolCall" && segment.toolCall) {
             const toolCallId = segment.toolCall.id;

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -675,6 +675,9 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
         // Bind DOM ops to the document that owns the message container so
         // popout-window chats don't pick up the wrong document if focus shifts.
         const doc = contentRef.current.doc;
+        // Resolve internal links against the active note so vaults with
+        // duplicate basenames or heading-only links open the right file.
+        const sourcePath = app.workspace.getActiveFile()?.path ?? "";
         // Track existing tool call and error block IDs
         const existingToolCallIds = new Set<string>();
         const existingErrorIds = new Set<string>();
@@ -711,7 +714,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
               contentRef.current!.appendChild(textDiv);
             }
 
-            void renderMarkdown(app, segment.content, textDiv, "", componentRef.current!)
+            void renderMarkdown(app, segment.content, textDiv, sourcePath, componentRef.current!)
               .then(() => normalizeFootnoteRendering(textDiv))
               .catch((err: unknown) => logError("renderMarkdown failed", err));
             currentIndex++;

--- a/src/components/chat-components/plugins/AtMentionCommandPlugin.tsx
+++ b/src/components/chat-components/plugins/AtMentionCommandPlugin.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import { TFile, App } from "obsidian";
+import { TFile } from "obsidian";
+import { useApp } from "@/context";
 import { TypeaheadMenuPortal } from "@/components/chat-components/TypeaheadMenuPortal";
 import { useTypeaheadPlugin } from "@/components/chat-components/hooks/useTypeaheadPlugin";
 import {
@@ -15,9 +16,6 @@ import {
 } from "@/components/chat-components/hooks/useAtMentionCategories";
 import { useAtMentionSearch } from "@/components/chat-components/hooks/useAtMentionSearch";
 
-// Get app instance
-declare const app: App;
-
 interface AtMentionCommandPluginProps {
   isCopilotPlus?: boolean;
   /** Whether to surface Copilot built-in `@` tools (category + search hits). */
@@ -30,6 +28,7 @@ export function AtMentionCommandPlugin({
   showTools = false,
   currentActiveFile = null,
 }: AtMentionCommandPluginProps): JSX.Element {
+  const app = useApp();
   const [editor] = useLexicalComposerContext();
   const [extendedState, setExtendedState] = useState<{
     mode: "category" | "search";
@@ -51,30 +50,35 @@ export function AtMentionCommandPlugin({
   );
 
   // Load note content for preview using shared utilities
-  const loadNoteContentForPreview = useCallback(async (file: TFile | null) => {
-    if (!file) {
-      setCurrentPreviewContent("");
-      return;
-    }
-    try {
-      // Handle PDF and canvas files - treat as empty content (no preview)
-      if (file.extension === "pdf" || file.extension === "canvas") {
+  const loadNoteContentForPreview = useCallback(
+    async (file: TFile | null) => {
+      if (!file) {
         setCurrentPreviewContent("");
         return;
       }
+      try {
+        // Handle PDF and canvas files - treat as empty content (no preview)
+        if (file.extension === "pdf" || file.extension === "canvas") {
+          setCurrentPreviewContent("");
+          return;
+        }
 
-      const content = await app.vault.cachedRead(file);
-      const contentWithoutFrontmatter = content.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, "").trim();
-      const truncatedContent =
-        contentWithoutFrontmatter.length > 300
-          ? contentWithoutFrontmatter.slice(0, 300) + "..."
-          : contentWithoutFrontmatter;
+        const content = await app.vault.cachedRead(file);
+        const contentWithoutFrontmatter = content
+          .replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, "")
+          .trim();
+        const truncatedContent =
+          contentWithoutFrontmatter.length > 300
+            ? contentWithoutFrontmatter.slice(0, 300) + "..."
+            : contentWithoutFrontmatter;
 
-      setCurrentPreviewContent(truncatedContent);
-    } catch {
-      setCurrentPreviewContent("Failed to load content");
-    }
-  }, []);
+        setCurrentPreviewContent(truncatedContent);
+      } catch {
+        setCurrentPreviewContent("Failed to load content");
+      }
+    },
+    [app]
+  );
 
   // Temporary state for query to resolve circular dependency
   const [currentQuery, setCurrentQuery] = useState("");

--- a/src/components/chat-components/plugins/NoteCommandPlugin.tsx
+++ b/src/components/chat-components/plugins/NoteCommandPlugin.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { TFile } from "obsidian";
+import { useApp } from "@/context";
 import { TypeaheadMenuPortal } from "@/components/chat-components/TypeaheadMenuPortal";
 import { useNoteSearch, NoteSearchOption } from "@/components/chat-components/hooks/useNoteSearch";
 import {
@@ -22,11 +23,12 @@ export function NoteCommandPlugin({
   isCopilotPlus = false,
   currentActiveFile = null,
 }: NoteCommandPluginProps): JSX.Element {
+  const app = useApp();
   const [editor] = useLexicalComposerContext();
   const [currentQuery, setCurrentQuery] = useState("");
 
   // Use shared preview cache
-  const [previewCache] = useState(() => new NotePreviewCache());
+  const [previewCache] = useState(() => new NotePreviewCache(app));
   const [previewContent, setPreviewContent] = useState<Map<string, string>>(() => new Map());
 
   // Function to load note content for preview using shared cache

--- a/src/components/chat-components/plugins/PastePlugin.tsx
+++ b/src/components/chat-components/plugins/PastePlugin.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $getSelection, $isRangeSelection, PASTE_COMMAND, COMMAND_PRIORITY_HIGH } from "lexical";
+import { useApp } from "@/context";
 import {
   parseTextForPills,
   createNodesFromSegments,
@@ -17,6 +18,7 @@ interface PastePluginProps {
  * invalid references are left as plain text.
  */
 export function PastePlugin({ enableURLPills = false, onImagePaste }: PastePluginProps): null {
+  const app = useApp();
   const [editor] = useLexicalComposerContext();
 
   React.useEffect(() => {
@@ -64,7 +66,7 @@ export function PastePlugin({ enableURLPills = false, onImagePaste }: PastePlugi
         }
 
         // Parse the text for all pill types
-        const segments = parseTextForPills(plainText, {
+        const segments = parseTextForPills(app, plainText, {
           includeNotes: true,
           includeURLs: enableURLPills,
           includeTools: true,
@@ -106,7 +108,7 @@ export function PastePlugin({ enableURLPills = false, onImagePaste }: PastePlugi
       },
       COMMAND_PRIORITY_HIGH
     );
-  }, [editor, enableURLPills, onImagePaste]);
+  }, [editor, enableURLPills, onImagePaste, app]);
 
   return null;
 }

--- a/src/components/chat-components/plugins/TextInsertionPlugin.tsx
+++ b/src/components/chat-components/plugins/TextInsertionPlugin.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { COMMAND_PRIORITY_EDITOR } from "lexical";
+import { useApp } from "@/context";
 import {
   INSERT_TEXT_WITH_PILLS_COMMAND,
   $insertTextWithPills,
@@ -12,6 +13,7 @@ import {
  * external components to insert text with automatic pill conversion.
  */
 export function TextInsertionPlugin(): null {
+  const app = useApp();
   const [editor] = useLexicalComposerContext();
 
   React.useEffect(() => {
@@ -21,14 +23,14 @@ export function TextInsertionPlugin(): null {
         const { text, options = {} } = payload;
 
         editor.update(() => {
-          $insertTextWithPills(text, options);
+          $insertTextWithPills(app, text, options);
         });
 
         return true;
       },
       COMMAND_PRIORITY_EDITOR
     );
-  }, [editor]);
+  }, [editor, app]);
 
   return null;
 }

--- a/src/components/chat-components/utils/lexicalTextUtils.test.ts
+++ b/src/components/chat-components/utils/lexicalTextUtils.test.ts
@@ -1,5 +1,5 @@
 import { parseTextForPills } from "./lexicalTextUtils";
-import { TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 import { mockTFolder } from "@/__tests__/mockObsidian";
 
 const MockTFile = TFile as unknown as jest.Mock;
@@ -14,7 +14,7 @@ jest.mock("../constants/tools", () => ({
   AVAILABLE_TOOLS: ["@vault", "@websearch", "@composer"],
 }));
 
-// Create mock global app object
+// Create mock app object passed explicitly to each parseTextForPills call.
 const mockApp = {
   workspace: {
     getActiveFile: jest.fn(),
@@ -28,12 +28,7 @@ const mockApp = {
     getFileCache: jest.fn(),
   },
 };
-
-// Mock global app
-Object.defineProperty(window, "app", {
-  value: mockApp,
-  writable: true,
-});
+const app = mockApp as unknown as App;
 
 describe("parseTextForPills", () => {
   beforeEach(() => {
@@ -43,7 +38,7 @@ describe("parseTextForPills", () => {
   describe("with no options enabled", () => {
     it("should return text as-is when no options are enabled", () => {
       const text = "Some [[note]] text with @tool and #tag and {folder} and https://example.com";
-      const result = parseTextForPills(text, {
+      const result = parseTextForPills(app, text, {
         includeNotes: false,
         includeURLs: false,
         includeTools: false,
@@ -80,7 +75,7 @@ describe("parseTextForPills", () => {
 
     it("should parse valid note references", () => {
       const text = "Check out [[Valid Note]] for more info";
-      const result = parseTextForPills(text, { includeNotes: true });
+      const result = parseTextForPills(app, text, { includeNotes: true });
 
       expect(result).toEqual([
         {
@@ -102,7 +97,7 @@ describe("parseTextForPills", () => {
 
     it("should keep invalid note references as text", () => {
       const text = "Invalid [[Nonexistent Note]] reference";
-      const result = parseTextForPills(text, { includeNotes: true });
+      const result = parseTextForPills(app, text, { includeNotes: true });
 
       expect(result).toEqual([
         {
@@ -122,7 +117,7 @@ describe("parseTextForPills", () => {
 
     it("should handle multiple note references", () => {
       const text = "[[Valid Note]] and [[Nonexistent Note]]";
-      const result = parseTextForPills(text, { includeNotes: true });
+      const result = parseTextForPills(app, text, { includeNotes: true });
 
       expect(result).toHaveLength(3);
       expect(result[0].type).toBe("note-pill");
@@ -135,7 +130,7 @@ describe("parseTextForPills", () => {
   describe("with URLs only", () => {
     it("should parse valid URLs", () => {
       const text = "Visit https://example.com for details";
-      const result = parseTextForPills(text, { includeURLs: true });
+      const result = parseTextForPills(app, text, { includeURLs: true });
 
       expect(result).toEqual([
         {
@@ -156,7 +151,7 @@ describe("parseTextForPills", () => {
 
     it("should handle URLs with trailing commas", () => {
       const text = "Visit https://example.com, for details";
-      const result = parseTextForPills(text, { includeURLs: true });
+      const result = parseTextForPills(app, text, { includeURLs: true });
 
       expect(result[1].content).toBe("https://example.com");
       expect(result[1].url).toBe("https://example.com");
@@ -164,7 +159,7 @@ describe("parseTextForPills", () => {
 
     it("should parse multiple URLs", () => {
       const text = "Visit https://example.com and http://test.org";
-      const result = parseTextForPills(text, { includeURLs: true });
+      const result = parseTextForPills(app, text, { includeURLs: true });
 
       expect(result).toHaveLength(4);
       expect(result[0].content).toBe("Visit ");
@@ -177,7 +172,7 @@ describe("parseTextForPills", () => {
   describe("with tools only", () => {
     it("should parse valid tool references", () => {
       const text = "Use @vault to search files";
-      const result = parseTextForPills(text, { includeTools: true });
+      const result = parseTextForPills(app, text, { includeTools: true });
 
       expect(result).toEqual([
         {
@@ -198,7 +193,7 @@ describe("parseTextForPills", () => {
 
     it("should keep invalid tool references as text", () => {
       const text = "Use @invalid tool";
-      const result = parseTextForPills(text, { includeTools: true });
+      const result = parseTextForPills(app, text, { includeTools: true });
 
       expect(result).toEqual([
         {
@@ -231,7 +226,7 @@ describe("parseTextForPills", () => {
 
     it("should parse valid folder references", () => {
       const text = "Files in {Projects} folder";
-      const result = parseTextForPills(text, { includeCustomTemplates: true });
+      const result = parseTextForPills(app, text, { includeCustomTemplates: true });
 
       expect(result).toEqual([
         {
@@ -252,7 +247,7 @@ describe("parseTextForPills", () => {
 
     it("should keep invalid folder references as text", () => {
       const text = "Files in {Nonexistent} folder";
-      const result = parseTextForPills(text, { includeCustomTemplates: true });
+      const result = parseTextForPills(app, text, { includeCustomTemplates: true });
 
       expect(result).toEqual([
         {
@@ -298,7 +293,7 @@ describe("parseTextForPills", () => {
 
     it("should correctly parse when only notes and URLs are enabled", () => {
       const text = "Check [[Test Note]] and https://example.com";
-      const result = parseTextForPills(text, {
+      const result = parseTextForPills(app, text, {
         includeNotes: true,
         includeURLs: true,
       });
@@ -312,7 +307,7 @@ describe("parseTextForPills", () => {
 
     it("should correctly parse when only URLs and tools are enabled", () => {
       const text = "Visit https://example.com or use @vault";
-      const result = parseTextForPills(text, {
+      const result = parseTextForPills(app, text, {
         includeURLs: true,
         includeTools: true,
       });
@@ -326,7 +321,7 @@ describe("parseTextForPills", () => {
 
     it("should correctly parse when only tools are enabled (tags appear as text)", () => {
       const text = "Use @vault for #test content";
-      const result = parseTextForPills(text, {
+      const result = parseTextForPills(app, text, {
         includeTools: true,
         // Tags are no longer parsed as pills
       });
@@ -339,7 +334,7 @@ describe("parseTextForPills", () => {
 
     it("should correctly parse when all options are enabled (tags as text)", () => {
       const text = "[[Test Note]] https://example.com @vault #test {TestFolder}";
-      const result = parseTextForPills(text, {
+      const result = parseTextForPills(app, text, {
         includeNotes: true,
         includeURLs: true,
         includeTools: true,
@@ -360,7 +355,7 @@ describe("parseTextForPills", () => {
     it("should handle mixed valid and invalid references (tags as text)", () => {
       const text =
         "[[Test Note]] [[Invalid]] @vault @invalid #test #invalid {TestFolder} {Invalid}";
-      const result = parseTextForPills(text, {
+      const result = parseTextForPills(app, text, {
         includeNotes: true,
         includeTools: true,
         // Tags are no longer parsed as pills
@@ -384,13 +379,13 @@ describe("parseTextForPills", () => {
 
   describe("edge cases", () => {
     it("should handle empty text", () => {
-      const result = parseTextForPills("");
+      const result = parseTextForPills(app, "");
       expect(result).toEqual([]);
     });
 
     it("should handle text with no matches", () => {
       const text = "Just plain text without any special patterns";
-      const result = parseTextForPills(text, {
+      const result = parseTextForPills(app, text, {
         includeNotes: true,
         includeURLs: true,
         includeTools: true,
@@ -407,7 +402,7 @@ describe("parseTextForPills", () => {
 
     it("should handle nested brackets correctly", () => {
       const text = "[[Note with [brackets]]]";
-      const result = parseTextForPills(text, { includeNotes: true });
+      const result = parseTextForPills(app, text, { includeNotes: true });
 
       // The regex matches [[Note with [brackets]] and leaves the final ]]
       expect(result).toHaveLength(2);
@@ -424,7 +419,7 @@ describe("parseTextForPills", () => {
       const mockFolder = mockTFolder({ path: "folder with spaces", name: "folder with spaces" });
       mockApp.vault.getAllLoadedFiles.mockReturnValue([mockFolder]);
 
-      const result = parseTextForPills(text, {
+      const result = parseTextForPills(app, text, {
         includeTools: true,
         // Tags are no longer parsed as pills
         includeCustomTemplates: true,

--- a/src/components/chat-components/utils/lexicalTextUtils.ts
+++ b/src/components/chat-components/utils/lexicalTextUtils.ts
@@ -21,8 +21,6 @@ import { $createActiveWebTabPillNode } from "@/components/chat-components/pills/
 import { logInfo } from "@/logger";
 import { AVAILABLE_TOOLS } from "@/components/chat-components/constants/tools";
 
-declare const app: App;
-
 export type PillType = "notes" | "tools" | "folders" | "active-note" | "webTabs" | "activeWebTab";
 
 // Type representing different kinds of parsed content segments
@@ -253,10 +251,11 @@ function resolveToolReference(toolName: string): string | null {
 
 /**
  * Attempts to resolve a folder reference to a TFolder
+ * @param app The Obsidian `App` instance used for vault lookups
  * @param folderName The name of the folder to resolve
  * @returns TFolder if found, null otherwise
  */
-function resolveFolderReference(folderName: string): TFolder | null {
+function resolveFolderReference(app: App, folderName: string): TFolder | null {
   if (!app?.vault) {
     return null;
   }
@@ -301,10 +300,11 @@ function resolveFolderReference(folderName: string): TFolder | null {
 
 /**
  * Attempts to resolve a note reference to a TFile
+ * @param app The Obsidian `App` instance used for vault/metadata lookups
  * @param noteName The name of the note to resolve
  * @returns TFile if found, null otherwise
  */
-function resolveNoteReference(noteName: string): TFile | null {
+function resolveNoteReference(app: App, noteName: string): TFile | null {
   if (!app?.vault || !app?.metadataCache) {
     return null;
   }
@@ -367,11 +367,13 @@ interface PatternInfo {
 
 /**
  * Parses text content to extract [[note name]], @tool, #tag patterns and optionally URLs, converting them to appropriate pills
+ * @param app The Obsidian `App` instance used to resolve note/folder references
  * @param text The text content to parse
  * @param options Options for what types of pills to process
  * @returns Array of parsed content segments with type information
  */
 export function parseTextForPills(
+  app: App,
   text: string,
   options: {
     includeNotes?: boolean;
@@ -453,11 +455,11 @@ export function parseTextForPills(
     } else if (matchedPattern.type === "notes") {
       // This is a note link [[note name]]
       const noteName = match[matchedPattern.startIndex + 1].trim();
-      const file = resolveNoteReference(noteName);
+      const file = resolveNoteReference(app, noteName);
 
       if (file && file instanceof TFile) {
         // Valid note reference - create pill
-        const activeNote = app?.workspace.getActiveFile();
+        const activeNote = app.workspace.getActiveFile();
         const isActive = activeNote?.path === file.path;
 
         segments.push({
@@ -518,7 +520,7 @@ export function parseTextForPills(
           content: "activeNote",
         });
       } else {
-        const resolvedFolder = resolveFolderReference(templateContent);
+        const resolvedFolder = resolveFolderReference(app, templateContent);
 
         if (resolvedFolder) {
           segments.push({
@@ -584,10 +586,15 @@ export function createNodesFromSegments(segments: ParsedContent[]): LexicalNode[
  * Inserts text with automatic conversion of [[note]] references and URLs to pills.
  * This is the main API function that should be used for all programmatic text insertion.
  *
+ * @param app The Obsidian `App` instance used to resolve note/folder references
  * @param text The text to insert, which may contain [[note]] references and URLs
  * @param options Configuration options for the insertion
  */
-export function $insertTextWithPills(text: string, options: InsertTextOptions = {}): void {
+export function $insertTextWithPills(
+  app: App,
+  text: string,
+  options: InsertTextOptions = {}
+): void {
   const { enableURLPills = false, insertAtSelection = true } = options;
 
   if (!text) return;
@@ -599,7 +606,7 @@ export function $insertTextWithPills(text: string, options: InsertTextOptions = 
   }
 
   // Parse the text for note links and optionally URLs
-  const segments = parseTextForPills(text, {
+  const segments = parseTextForPills(app, text, {
     includeNotes: true,
     includeURLs: enableURLPills,
   });
@@ -623,12 +630,14 @@ export function $insertTextWithPills(text: string, options: InsertTextOptions = 
  * Replaces text in a specific range with parsed content.
  * Useful for slash commands and other scenarios where you need to replace a portion of text.
  *
+ * @param app The Obsidian `App` instance used to resolve note/folder references
  * @param startOffset The start position to replace from
  * @param endOffset The end position to replace to
  * @param newText The new text content to insert with pill conversion
  * @param options Configuration options
  */
 export function $replaceTextRangeWithPills(
+  app: App,
   startOffset: number,
   endOffset: number,
   newText: string,
@@ -652,7 +661,7 @@ export function $replaceTextRangeWithPills(
   const textContent = textNode.getTextContent();
 
   // Parse the new text for pills
-  const segments = parseTextForPills(newText, {
+  const segments = parseTextForPills(app, newText, {
     includeNotes: true,
     includeURLs: enableURLPills,
     includeTools: enableToolPills,

--- a/src/components/chat-components/utils/notePreviewUtils.ts
+++ b/src/components/chat-components/utils/notePreviewUtils.ts
@@ -1,17 +1,19 @@
 import { TFile, App } from "obsidian";
 
-// Get app instance
-declare const app: App;
-
 /**
  * Loads and processes note content for preview display.
  * Handles PDF and canvas files, frontmatter stripping, and content truncation.
  *
+ * @param app - Obsidian `App` instance used to read the file
  * @param file - The file to load content from
  * @param maxLength - Maximum length for truncated content (default: 500)
  * @returns Promise resolving to processed content string
  */
-async function loadNoteContentForPreview(file: TFile, maxLength: number = 500): Promise<string> {
+async function loadNoteContentForPreview(
+  app: App,
+  file: TFile,
+  maxLength: number = 500
+): Promise<string> {
   try {
     // Handle PDF and canvas files - treat as empty content (no preview)
     if (file.extension === "pdf" || file.extension === "canvas") {
@@ -42,6 +44,8 @@ async function loadNoteContentForPreview(file: TFile, maxLength: number = 500): 
 export class NotePreviewCache {
   private cache = new Map<string, string>();
 
+  constructor(private readonly app: App) {}
+
   /**
    * Gets cached content or loads it if not cached
    * @param file - The file to get content for
@@ -54,7 +58,7 @@ export class NotePreviewCache {
       return cached;
     }
 
-    const content = await loadNoteContentForPreview(file, maxLength);
+    const content = await loadNoteContentForPreview(this.app, file, maxLength);
     this.cache.set(file.path, content);
     return content;
   }

--- a/src/utils/renderMarkdown.ts
+++ b/src/utils/renderMarkdown.ts
@@ -1,0 +1,73 @@
+import { App, Component, MarkdownRenderer } from "obsidian";
+
+/**
+ * Thin wrapper around the modern `MarkdownRenderer.render(app, …)` API.
+ *
+ * Reason for the cast: the `obsidian@^1.2.5` package pinned in
+ * `package.json` only declares the deprecated
+ * `MarkdownRenderer.renderMarkdown(...)` static. The modern
+ * `MarkdownRenderer.render(app, …)` signature has existed at runtime since
+ * Obsidian 1.4.6 — well below our `minAppVersion: 1.11.4` — but the
+ * bundled `.d.ts` lacks it. Passing `app` lets the renderer resolve
+ * `![[embeds]]` and produce proper `data-href` attributes on
+ * `a.internal-link`. It does **not** wire click handlers — Obsidian's
+ * internal-link click delegate (`registerDomEvents`) is only attached to
+ * the workspace's `markdown-preview-view`, in-process markdown-embed,
+ * and CodeMirror `contentDOM`. Markdown rendered into a plain `<div>`
+ * inside an `ItemView` (chat panel, agent panel, plan preview) never
+ * reaches that delegate, so we attach our own.
+ *
+ * Resolved at call time (not import time) so jest mocks that don't expose
+ * `MarkdownRenderer` at all can still load this module.
+ */
+type ModernRender = (
+  app: App,
+  markdown: string,
+  el: HTMLElement,
+  sourcePath: string,
+  component: Component
+) => Promise<void>;
+
+export async function renderMarkdown(
+  app: App,
+  markdown: string,
+  el: HTMLElement,
+  sourcePath: string,
+  component: Component
+): Promise<void> {
+  const render = (MarkdownRenderer as unknown as { render: ModernRender }).render;
+  await render(app, markdown, el, sourcePath, component);
+  wireInternalLinks(el, app, sourcePath, component);
+}
+
+/**
+ * Delegated handler that routes `a.internal-link` clicks inside `el` to
+ * `app.workspace.openLinkText`. Tied to `component`'s lifecycle so the
+ * listener dies when the caller unloads the component. Left-click opens
+ * in the current pane; middle-click / cmd-click / ctrl-click opens in a
+ * new tab — matching Obsidian's own behavior.
+ */
+function wireInternalLinks(
+  el: HTMLElement,
+  app: App,
+  sourcePath: string,
+  component: Component
+): void {
+  const handleClick = (e: MouseEvent): void => {
+    const target = e.target as HTMLElement | null;
+    const link = target?.closest?.("a.internal-link") as HTMLAnchorElement | null;
+    if (!link || !el.contains(link)) return;
+    if (e.button !== 0 && e.button !== 1) return;
+    e.preventDefault();
+    const href = link.getAttribute("data-href") || link.getAttribute("href");
+    if (!href) return;
+    const newLeaf = e.button === 1 || e.ctrlKey || e.metaKey;
+    void app.workspace.openLinkText(href, sourcePath, newLeaf);
+  };
+  el.addEventListener("click", handleClick);
+  el.addEventListener("auxclick", handleClick);
+  component.register(() => {
+    el.removeEventListener("click", handleClick);
+    el.removeEventListener("auxclick", handleClick);
+  });
+}


### PR DESCRIPTION
## Summary
- Switched chat/agent/plan-preview markdown rendering to the modern `MarkdownRenderer.render(app, …)` via a shared `renderMarkdown` wrapper, which also wires a delegated click handler so `a.internal-link` opens via `app.workspace.openLinkText` (left-click in current pane; cmd/ctrl/middle-click in a new tab).
- Tool ActionCards now expose the collapsed line as a clickable target once the call has completed, opening the referenced note in a new tab.
- Removed reliance on the global `app` in `lexicalTextUtils`, `notePreviewUtils`, `vaultPath`, and the AtMention/Note/Paste/TextInsertion plugins — `app` is now threaded via `useApp()` at the leaf, and `AGENTS.md` is updated to discourage the global going forward.

## Test plan
- [ ] In chat, click an `[[internal link]]` in an assistant message and confirm it opens the note (current pane on left-click, new tab on cmd-click).
- [ ] In agent mode, click a Read/Edit/Delete/Move tool card's title and confirm it opens the targeted note once the call completes.
- [ ] Verify the in-flight tool card title is NOT clickable.
- [ ] `npm run test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)