### PR TITLE
fix(skills): eliminate Skills Settings UI lag from watcher-driven refreshes

### DIFF
--- a/src/agentMode/skills/SkillManager.test.ts
+++ b/src/agentMode/skills/SkillManager.test.ts
@@ -1,7 +1,14 @@
 import { FileSystemAdapter, type App, type EventRef } from "obsidian";
 import { discoverManagedSkills } from "./discoverManagedSkills";
-import { computeSkillSetSignature, SkillManager, type RefreshResult } from "./SkillManager";
-import { runRenameSkill } from "./updateProperties";
+import { reconcile } from "./reconcile";
+import {
+  computeSkillSetSignature,
+  getManagedSkills,
+  SkillManager,
+  type RefreshResult,
+} from "./SkillManager";
+import { runDeleteSkill, runToggleAgent } from "./toggleAgent";
+import { runRenameSkill, runUpdateProperties } from "./updateProperties";
 import type { Skill } from "./types";
 
 jest.mock("@/logger", () => ({
@@ -52,12 +59,22 @@ const mockedDiscoverManagedSkills = discoverManagedSkills as jest.MockedFunction
   typeof discoverManagedSkills
 >;
 const mockedRunRenameSkill = runRenameSkill as jest.MockedFunction<typeof runRenameSkill>;
+const mockedRunUpdateProperties = runUpdateProperties as jest.MockedFunction<
+  typeof runUpdateProperties
+>;
+const mockedRunToggleAgent = runToggleAgent as jest.MockedFunction<typeof runToggleAgent>;
+const mockedRunDeleteSkill = runDeleteSkill as jest.MockedFunction<typeof runDeleteSkill>;
+const mockedReconcile = reconcile as jest.MockedFunction<typeof reconcile>;
 
 describe("SkillManager orchestration", () => {
   beforeEach(() => {
     skillsFolder = "copilot/skills";
     mockedDiscoverManagedSkills.mockReset();
+    mockedReconcile.mockClear();
     mockedRunRenameSkill.mockReset();
+    mockedRunUpdateProperties.mockReset();
+    mockedRunToggleAgent.mockReset();
+    mockedRunDeleteSkill.mockReset();
     SkillManager.resetForTesting();
     jest.useRealTimers();
   });
@@ -139,6 +156,296 @@ describe("SkillManager orchestration", () => {
     expect(refreshSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("toggleAgent publishes an incremental update without full discovery or reconcile", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill({ enabledAgents: [] });
+    await seedSkills(manager, [skill]);
+    mockedRunToggleAgent.mockResolvedValueOnce({ ok: true });
+    mockedDiscoverManagedSkills.mockClear();
+    mockedReconcile.mockClear();
+
+    const result = await manager.toggleAgent(skill, "claude", true);
+
+    expect(result).toEqual({ ok: true });
+    expect(mockedDiscoverManagedSkills).not.toHaveBeenCalled();
+    expect(mockedReconcile).not.toHaveBeenCalled();
+    expect(getManagedSkills()[0].enabledAgents).toEqual(["claude"]);
+  });
+
+  it("updateProperties publishes an incremental update without full discovery or reconcile", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill();
+    await seedSkills(manager, [skill]);
+    mockedRunUpdateProperties.mockResolvedValueOnce({ ok: true });
+    mockedDiscoverManagedSkills.mockClear();
+    mockedReconcile.mockClear();
+
+    const result = await manager.updateProperties(skill, {
+      description: "Updated description.",
+      model: "claude-sonnet",
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockedDiscoverManagedSkills).not.toHaveBeenCalled();
+    expect(mockedReconcile).not.toHaveBeenCalled();
+    expect(getManagedSkills()[0]).toMatchObject({
+      description: "Updated description.",
+      model: "claude-sonnet",
+    });
+  });
+
+  it("deleteSkill removes one row without full discovery or reconcile", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill();
+    const other = makeSkill({ name: "bar", dirPath: "/vault/copilot/skills/bar" });
+    await seedSkills(manager, [skill, other]);
+    mockedRunDeleteSkill.mockResolvedValueOnce({ ok: true });
+    mockedDiscoverManagedSkills.mockClear();
+    mockedReconcile.mockClear();
+
+    const result = await manager.deleteSkill(skill);
+
+    expect(result).toEqual({ ok: true });
+    expect(mockedDiscoverManagedSkills).not.toHaveBeenCalled();
+    expect(mockedReconcile).not.toHaveBeenCalled();
+    expect(getManagedSkills().map((s) => s.name)).toEqual(["bar"]);
+  });
+
+  it("renameSkill renames one row without full discovery or reconcile", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill();
+    await seedSkills(manager, [skill]);
+    mockedRunRenameSkill.mockResolvedValueOnce({
+      ok: true,
+      newDirPath: "/vault/copilot/skills/bar",
+      newFilePath: "/vault/copilot/skills/bar/SKILL.md",
+    });
+    mockedDiscoverManagedSkills.mockClear();
+    mockedReconcile.mockClear();
+
+    const result = await manager.renameSkill(skill, "bar");
+
+    expect(result).toEqual({ ok: true });
+    expect(mockedDiscoverManagedSkills).not.toHaveBeenCalled();
+    expect(mockedReconcile).not.toHaveBeenCalled();
+    expect(getManagedSkills()[0]).toMatchObject({
+      name: "bar",
+      dirPath: "/vault/copilot/skills/bar",
+      filePath: "/vault/copilot/skills/bar/SKILL.md",
+    });
+  });
+
+  it("saveProperties emits one skill-set notification for rename plus patch", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { opencode: ".opencode/skills" });
+    const listener = jest.fn();
+    const skill = makeSkill({ enabledAgents: ["opencode"] });
+    manager.subscribeToSkillSetChange(listener);
+    await seedSkills(manager, [skill]);
+    listener.mockClear();
+    mockedRunRenameSkill.mockResolvedValueOnce({
+      ok: true,
+      newDirPath: "/vault/copilot/skills/bar",
+      newFilePath: "/vault/copilot/skills/bar/SKILL.md",
+    });
+    mockedRunUpdateProperties.mockResolvedValueOnce({ ok: true });
+
+    const result = await manager.saveProperties(skill, {
+      newName: "bar",
+      patch: { description: "Updated description." },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(getManagedSkills()[0]).toMatchObject({
+      name: "bar",
+      description: "Updated description.",
+    });
+  });
+
+  it("saveProperties handles a description-only patch", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill();
+    await seedSkills(manager, [skill]);
+    mockedRunUpdateProperties.mockResolvedValueOnce({ ok: true });
+
+    const result = await manager.saveProperties(skill, {
+      patch: { description: "Updated description." },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(mockedRunRenameSkill).not.toHaveBeenCalled();
+    expect(getManagedSkills()[0]).toMatchObject({
+      name: "foo",
+      description: "Updated description.",
+    });
+  });
+
+  it("saveProperties handles a rename-only update", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill();
+    await seedSkills(manager, [skill]);
+    mockedRunRenameSkill.mockResolvedValueOnce({
+      ok: true,
+      newDirPath: "/vault/copilot/skills/bar",
+      newFilePath: "/vault/copilot/skills/bar/SKILL.md",
+    });
+    mockedRunUpdateProperties.mockResolvedValueOnce({ ok: true });
+
+    const result = await manager.saveProperties(skill, {
+      newName: "bar",
+      patch: {},
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(getManagedSkills()[0]).toMatchObject({
+      name: "bar",
+      description: "A skill.",
+    });
+  });
+
+  it("saveProperties returns collision without patching when rename collides", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill();
+    await seedSkills(manager, [skill]);
+    mockedRunRenameSkill.mockResolvedValueOnce({ ok: false, reason: "collision" });
+
+    const result = await manager.saveProperties(skill, {
+      newName: "bar",
+      patch: { description: "Updated description." },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "collision",
+      message: "A skill with that name already exists.",
+    });
+    expect(mockedRunUpdateProperties).not.toHaveBeenCalled();
+  });
+
+  it("saveProperties closes successfully when rename reports EPERM but patch succeeds", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill();
+    await seedSkills(manager, [skill]);
+    mockedRunRenameSkill.mockResolvedValueOnce({ ok: false, reason: "eperm", mutated: true });
+    mockedRunUpdateProperties.mockResolvedValueOnce({ ok: true });
+
+    const result = await manager.saveProperties(skill, {
+      newName: "bar",
+      patch: { description: "Updated description." },
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(getManagedSkills()[0]).toMatchObject({
+      name: "bar",
+      description: "Updated description.",
+    });
+  });
+
+  it("saveProperties publishes the rename when the follow-up patch fails", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill();
+    await seedSkills(manager, [skill]);
+    mockedRunRenameSkill.mockResolvedValueOnce({
+      ok: true,
+      newDirPath: "/vault/copilot/skills/bar",
+      newFilePath: "/vault/copilot/skills/bar/SKILL.md",
+    });
+    mockedRunUpdateProperties.mockResolvedValueOnce({ ok: false, reason: "write failed" });
+
+    const result = await manager.saveProperties(skill, {
+      newName: "bar",
+      patch: { description: "Updated description." },
+    });
+
+    expect(result).toEqual({ ok: false, code: "fs-error", message: "write failed" });
+    expect(getManagedSkills()[0]).toMatchObject({
+      name: "bar",
+      description: "A skill.",
+    });
+  });
+
+  it("suppresses a vault event that matches a pending expectation", async () => {
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill({ enabledAgents: [] });
+    await seedSkills(manager, [skill]);
+    mockedRunToggleAgent.mockResolvedValueOnce({ ok: true });
+    const refreshResult: RefreshResult = {
+      ok: true,
+      folder: "copilot/skills",
+      skillCount: 0,
+      reconcileErrorCount: 0,
+    };
+    const refreshSpy = jest.spyOn(manager, "refresh").mockResolvedValue(refreshResult);
+
+    await manager.toggleAgent(skill, "claude", true);
+    refreshSpy.mockClear();
+
+    fireVaultEvent(app, "create", { path: ".claude/skills/foo" });
+    await flushMicrotasks();
+    jest.useFakeTimers();
+    jest.advanceTimersByTime(250);
+    expect(refreshSpy).not.toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  it("passes through a vault event that does not match any expectation", async () => {
+    jest.useFakeTimers();
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill({ enabledAgents: [] });
+    mockedDiscoverManagedSkills.mockResolvedValueOnce([skill]);
+    await manager.refresh();
+    mockedRunToggleAgent.mockResolvedValueOnce({ ok: true });
+    await manager.toggleAgent(skill, "claude", true);
+
+    const refreshResult: RefreshResult = {
+      ok: true,
+      folder: "copilot/skills",
+      skillCount: 1,
+      reconcileErrorCount: 0,
+    };
+    const refreshSpy = jest.spyOn(manager, "refresh").mockResolvedValue(refreshResult);
+
+    fireVaultEvent(app, "create", { path: "copilot/skills/unrelated/SKILL.md" });
+    jest.advanceTimersByTime(250);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("safety timer clears stale expectations after the timeout", async () => {
+    jest.useFakeTimers();
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill({ enabledAgents: [] });
+    mockedDiscoverManagedSkills.mockResolvedValueOnce([skill]);
+    await manager.refresh();
+    mockedRunToggleAgent.mockResolvedValueOnce({ ok: true });
+    await manager.toggleAgent(skill, "claude", true);
+
+    const refreshResult: RefreshResult = {
+      ok: true,
+      folder: "copilot/skills",
+      skillCount: 1,
+      reconcileErrorCount: 0,
+    };
+    const refreshSpy = jest.spyOn(manager, "refresh").mockResolvedValue(refreshResult);
+
+    jest.advanceTimersByTime(10_000);
+    fireVaultEvent(app, "create", { path: ".claude/skills/foo" });
+    jest.advanceTimersByTime(250);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("notifies when a backend-visible skill signature changes", async () => {
     const app = makeApp();
     const manager = SkillManager.initialize(app, { opencode: ".opencode/skills" });
@@ -196,12 +503,39 @@ function makeApp(): App & {
   };
 }
 
+async function seedSkills(manager: SkillManager, skills: Skill[]): Promise<void> {
+  mockedDiscoverManagedSkills.mockResolvedValueOnce(skills);
+  await manager.refresh();
+}
+
+function fireVaultEvent(
+  app: ReturnType<typeof makeApp>,
+  event: string,
+  file: { path: string },
+  oldPath?: string
+): void {
+  const call = app.vault.on.mock.calls.find(([e]) => e === event);
+  if (call === undefined) throw new Error(`No handler registered for "${event}"`);
+  if (oldPath !== undefined) {
+    call[1](file, oldPath);
+  } else {
+    call[1](file);
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 function makeSkill(overrides: Partial<Skill> = {}): Skill {
+  const name = overrides.name ?? "foo";
+  const dirPath = overrides.dirPath ?? `/vault/copilot/skills/${name}`;
   return {
     name: "foo",
     description: "A skill.",
-    filePath: "/vault/copilot/skills/foo/SKILL.md",
-    dirPath: "/vault/copilot/skills/foo",
+    filePath: `${dirPath}/SKILL.md`,
+    dirPath,
     body: "body",
     enabledAgents: ["claude"],
     ...overrides,

--- a/src/agentMode/skills/SkillManager.test.ts
+++ b/src/agentMode/skills/SkillManager.test.ts
@@ -422,7 +422,7 @@ describe("SkillManager orchestration", () => {
     expect(refreshSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("safety timer clears stale expectations after the timeout", async () => {
+  it("safety timer schedules a reconcile when expectations were never satisfied", async () => {
     jest.useFakeTimers();
     const app = makeApp();
     const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
@@ -440,8 +440,43 @@ describe("SkillManager orchestration", () => {
     };
     const refreshSpy = jest.spyOn(manager, "refresh").mockResolvedValue(refreshResult);
 
+    // No vault event arrives to satisfy the expectations. The safety timer
+    // fires, clears the stale predicates, and queues a healing reconcile.
     jest.advanceTimersByTime(10_000);
-    fireVaultEvent(app, "create", { path: ".claude/skills/foo" });
+    jest.advanceTimersByTime(250);
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves a pre-existing scheduled reconcile across an internal mutation", async () => {
+    jest.useFakeTimers();
+    const app = makeApp();
+    const manager = SkillManager.initialize(app, { claude: ".claude/skills" });
+    const skill = makeSkill({ enabledAgents: [] });
+    mockedDiscoverManagedSkills.mockResolvedValueOnce([skill]);
+    await manager.refresh();
+
+    const refreshResult: RefreshResult = {
+      ok: true,
+      folder: "copilot/skills",
+      skillCount: 1,
+      reconcileErrorCount: 0,
+    };
+    const refreshSpy = jest.spyOn(manager, "refresh").mockResolvedValue(refreshResult);
+
+    // External vault rename schedules a reconcile (250ms debounce).
+    fireVaultEvent(
+      app,
+      "rename",
+      { path: "elsewhere/foo/SKILL.md" },
+      "copilot/skills/foo/SKILL.md"
+    );
+
+    // Before the debounce expires, the user toggles an agent.
+    mockedRunToggleAgent.mockResolvedValueOnce({ ok: true });
+    await manager.toggleAgent(skill, "claude", true);
+
+    // The pre-existing reconcile timer must still fire — the external work
+    // hasn't been serviced yet.
     jest.advanceTimersByTime(250);
     expect(refreshSpy).toHaveBeenCalledTimes(1);
   });

--- a/src/agentMode/skills/SkillManager.ts
+++ b/src/agentMode/skills/SkillManager.ts
@@ -716,6 +716,12 @@ export class SkillManager {
    * the FS write should produce — those are installed as path-scoped
    * predicates so the matching events are suppressed without affecting
    * unrelated changes.
+   *
+   * Any reconcile debounce timer left armed when this mutation finishes was
+   * scheduled by an external event *before* the mutation started — the
+   * depth gate in {@link handleVaultEvent} ensures in-mutation events can't
+   * schedule one. We deliberately do not cancel it: the external work
+   * still needs reconciliation.
    */
   private async runInternalMutation<T>(
     task: () => Promise<T>,
@@ -730,7 +736,6 @@ export class SkillManager {
       return result;
     } finally {
       this.internalMutationDepth -= 1;
-      this.clearScheduledReconcile();
     }
   }
 
@@ -748,7 +753,13 @@ export class SkillManager {
     this.armSafetyTimer();
   }
 
-  /** Restart the safety timer that backstops any never-arriving vault events. */
+  /**
+   * Restart the safety timer that backstops any never-arriving vault events.
+   * If the timer fires with expectations still pending, the predicates were
+   * never observed as satisfied — that's drift (external process undid our
+   * change, or the watcher missed events). Schedule a debounced reconcile
+   * before clearing so we re-discover instead of silently dropping the state.
+   */
   private armSafetyTimer(): void {
     this.clearSafetyTimer();
     this.safetyTimer = window.setTimeout(() => {
@@ -757,6 +768,7 @@ export class SkillManager {
       const paths = this.pendingExpectations.map((e) => e.vaultRelPath).join(", ");
       logWarn(`[skills] Gave up waiting for vault events on: ${paths}`);
       this.pendingExpectations = [];
+      this.scheduleReconcile();
     }, EXPECTATION_TIMEOUT_MS);
   }
 

--- a/src/agentMode/skills/SkillManager.ts
+++ b/src/agentMode/skills/SkillManager.ts
@@ -2,6 +2,7 @@ import { logError, logInfo, logWarn } from "@/logger";
 import { getSettings, updateSetting } from "@/settings/model";
 import { atom, createStore, useAtomValue } from "jotai";
 import { FileSystemAdapter, type App, type EventRef, type TAbstractFile } from "obsidian";
+import { normalizeAbsPath } from "@/utils/pathUtils";
 import { agentSkillsDirAbs, DEFAULT_SKILLS_FOLDER } from "./agentPaths";
 import { runBulkMove, type BulkMoveResult } from "./bulkMove";
 import { discoverManagedSkills, type SkillsFsAdapter } from "./discoverManagedSkills";
@@ -18,12 +19,29 @@ import {
 } from "./nodeFsAdapters";
 import { reconcile, type ReconcileReport } from "./reconcile";
 import type { SkillFrontmatterPatch } from "./skillFormat";
+import { removeAgentLinksPointingTo } from "./symlinks";
 import { runDeleteSkill, runToggleAgent } from "./toggleAgent";
 import type { BackendId, ImportCandidate, Skill } from "./types";
 import { runRenameSkill, runUpdateProperties } from "./updateProperties";
+import {
+  buildDeleteExpectations,
+  buildReconcileExpectations,
+  buildRenameExpectations,
+  buildToggleExpectations,
+  buildUpdatePropertiesExpectations,
+  matchExpectation,
+  type Expectation,
+} from "./vaultEventExpectations";
 
 /** Debounce window for vault-watch-driven reconciliation, per spec. */
 const RECONCILE_DEBOUNCE_MS = 250;
+/**
+ * Maximum time to keep a pending vault-event expectation alive before
+ * giving up and lifting suppression. The watcher is expected to fire
+ * within milliseconds on local disks; this 10s cap is the backstop for
+ * cloud-synced vaults and watcher misfires.
+ */
+const EXPECTATION_TIMEOUT_MS = 10_000;
 
 const skillManagerStore = createStore();
 const skillsAtom = atom<Skill[]>([]);
@@ -55,6 +73,11 @@ export type UpdatePropertiesResult = SkillOperationResult<"fs-error">;
 
 /** Result of {@link SkillManager.renameSkill}. */
 export type RenameSkillResult = SkillOperationResult<
+  "no-vault-path" | "invalid" | "collision" | "eperm" | "fs-error"
+>;
+
+/** Result of {@link SkillManager.saveProperties}. */
+export type SavePropertiesResult = SkillOperationResult<
   "no-vault-path" | "invalid" | "collision" | "eperm" | "fs-error"
 >;
 
@@ -95,6 +118,16 @@ export class SkillManager {
   private readonly skillSetListeners = new Set<SkillSetChangeListener>();
   /** Pre-normalized agent dir set used by the vault-watcher hot path. */
   private readonly normalizedAgentDirs: ReadonlyArray<string>;
+  /** Nesting counter for SkillManager-owned filesystem writes. */
+  private internalMutationDepth = 0;
+  /**
+   * Vault-event predicates installed after each mutation. While any
+   * expectation is live, watcher events matching one of them are dropped
+   * (they describe FS state we just wrote). See `vaultEventExpectations.ts`.
+   */
+  private pendingExpectations: Expectation[] = [];
+  /** Backstop timer that clears stale expectations if the watcher never fires. */
+  private safetyTimer: number | null = null;
 
   /** App handle is captured at the plugin edge; inner helpers stay pure. */
   private constructor(
@@ -178,6 +211,9 @@ export class SkillManager {
     this.inFlight = null;
     this.inFlightFolder = null;
     this.queuedRefresh = false;
+    this.internalMutationDepth = 0;
+    this.pendingExpectations = [];
+    this.clearSafetyTimer();
     if (SkillManager.instance === this) {
       SkillManager.instance = null;
     }
@@ -262,12 +298,16 @@ export class SkillManager {
       let reconcileError: string | undefined;
       if (vaultRoot !== null && absRoot !== null) {
         try {
-          const report = await reconcile({
-            skills,
-            canonicalAbsRoot: absRoot,
-            agentDirsAbs: this.resolveAgentDirsAbs(vaultRoot),
-            fs: createNodeReconcileFs(),
-          });
+          const report = await this.runInternalMutation(
+            () =>
+              reconcile({
+                skills,
+                canonicalAbsRoot: absRoot,
+                agentDirsAbs: this.resolveAgentDirsAbs(vaultRoot),
+                fs: createNodeReconcileFs(),
+              }),
+            (r) => buildReconcileExpectations(r, vaultRoot)
+          );
           reconcileErrorCount = report.errors.length;
           recordReconcileReport(report);
         } catch (err) {
@@ -311,7 +351,8 @@ export class SkillManager {
    *    On Windows EPERM the frontmatter is **not** rolled back —
    *    reconciliation reattempts the link on every subsequent pass once
    *    the user enables Developer Mode.
-   * 3. Refresh the in-memory skill list so the grid reflects the new state.
+   * 3. Publish an incremental in-memory update so the grid reflects the
+   *    changed row without rereading every managed skill.
    */
   async toggleAgent(skill: Skill, agent: BackendId, enabled: boolean): Promise<ToggleAgentResult> {
     const vaultRoot = resolveVaultRootAbs(this.app);
@@ -328,27 +369,39 @@ export class SkillManager {
     if (agentDir === null) {
       return { ok: false, code: "unknown-agent", message: `Unknown agent: ${agent}` };
     }
-    const result = await runToggleAgent({
-      skill,
-      agent,
-      enabled,
-      agentDirAbs: agentDir,
-      fs,
-    });
+    const result = await this.runInternalMutation(
+      () =>
+        runToggleAgent({
+          skill,
+          agent,
+          enabled,
+          agentDirAbs: agentDir,
+          fs,
+        }),
+      (r) =>
+        r.ok || (!r.ok && r.reason === "eperm")
+          ? buildToggleExpectations(skill, enabled, agentDir, vaultRoot)
+          : []
+    );
 
     if (!result.ok && result.reason === "eperm") {
       skillManagerStore.set(epermSeenAtom, true);
     }
 
-    await this.refresh();
+    if (result.ok || (!result.ok && result.reason === "eperm")) {
+      this.replaceManagedSkill(skill, {
+        ...skill,
+        enabledAgents: computeNextAgents(skill.enabledAgents, agent, enabled),
+      });
+    }
     return result.ok ? { ok: true } : failureFromReason(result.reason);
   }
 
   /**
    * Delete a managed skill end-to-end: remove every enabled agent's
-   * symlink, then remove the canonical directory recursively, then
-   * refresh the in-memory list. The action is irreversible — the UI
-   * gates this behind a confirmation modal.
+   * symlink, then remove the canonical directory recursively, then publish
+   * an incremental removal. The action is irreversible — the UI gates this
+   * behind a confirmation modal.
    */
   async deleteSkill(skill: Skill): Promise<DeleteSkillResult> {
     const vaultRoot = resolveVaultRootAbs(this.app);
@@ -356,12 +409,19 @@ export class SkillManager {
       return noVaultPathFailure();
     }
     const fs = createNodeReconcileFs();
-    const result = await runDeleteSkill({
-      skill,
-      agentDirsAbs: this.resolveAgentDirsAbs(vaultRoot),
-      fs,
-    });
-    await this.refresh();
+    const agentDirsAbs = this.resolveAgentDirsAbs(vaultRoot);
+    const result = await this.runInternalMutation(
+      () =>
+        runDeleteSkill({
+          skill,
+          agentDirsAbs,
+          fs,
+        }),
+      (r) => (r.ok ? buildDeleteExpectations(skill, agentDirsAbs, vaultRoot) : [])
+    );
+    if (result.ok) {
+      this.removeManagedSkill(skill);
+    }
     return result.ok ? { ok: true } : fsFailure(result.reason ?? "Unknown filesystem error.");
   }
 
@@ -371,19 +431,114 @@ export class SkillManager {
    * {@link renameSkill} first.
    *
    * Preserves every unknown top-level key and unknown `metadata.*` key
-   * byte-for-byte (delegated to `serializeSkillFile`). On success, runs a
-   * refresh so the in-memory grid reflects the new state.
+   * byte-for-byte (delegated to `serializeSkillFile`). On success, publishes
+   * an incremental row update.
    */
   async updateProperties(
     skill: Skill,
     patch: Omit<SkillFrontmatterPatch, "name" | "enabledAgents">
   ): Promise<UpdatePropertiesResult> {
     const fs = createNodeReconcileFs();
-    const result = await runUpdateProperties({ skill, patch, fs });
+    const vaultRoot = resolveVaultRootAbs(this.app);
+    const result = await this.runInternalMutation(
+      () => runUpdateProperties({ skill, patch, fs }),
+      (r) => (r.ok && vaultRoot !== null ? buildUpdatePropertiesExpectations(skill, vaultRoot) : [])
+    );
     if (result.ok) {
-      await this.refresh();
+      this.replaceManagedSkill(skill, applyPropertiesPatch(skill, patch));
     }
     return result.ok ? { ok: true } : fsFailure(result.reason);
+  }
+
+  /**
+   * Save the Properties modal in one manager operation. A rename and a
+   * frontmatter patch publish one in-memory change and therefore emit one
+   * backend-visible skill-set notification.
+   */
+  async saveProperties(
+    skill: Skill,
+    req: {
+      newName?: string;
+      patch: Omit<SkillFrontmatterPatch, "name" | "enabledAgents">;
+    }
+  ): Promise<SavePropertiesResult> {
+    const fs = createNodeReconcileFs();
+    const newName =
+      req.newName !== undefined && req.newName !== skill.name ? req.newName : undefined;
+    const vaultRoot = resolveVaultRootAbs(this.app);
+    let activeSkill = skill;
+
+    if (newName !== undefined) {
+      if (vaultRoot === null) {
+        return noVaultPathFailure();
+      }
+      const folder = resolveSkillsFolder();
+      const canonical = resolveAbsolutePath(this.app, folder);
+      if (canonical === null) {
+        return noVaultPathFailure();
+      }
+
+      const agentDirsAbs = this.resolveAgentDirsAbs(vaultRoot);
+      const renameResult = await this.runInternalMutation(
+        async () => {
+          const result = await runRenameSkill({
+            skill,
+            newName,
+            canonicalAbsRoot: canonical,
+            agentDirsAbs,
+            fs,
+          });
+          if (result.ok || (!result.ok && result.reason === "eperm")) {
+            await this.cleanupLinksToSkill(fs, vaultRoot, skill.dirPath);
+          }
+          return result;
+        },
+        (r) =>
+          r.ok || (!r.ok && r.reason === "eperm")
+            ? buildRenameExpectations(skill, newName, canonical, agentDirsAbs, vaultRoot)
+            : []
+      );
+
+      if (!renameResult.ok && renameResult.reason === "eperm") {
+        skillManagerStore.set(epermSeenAtom, true);
+      }
+
+      if (!renameResult.ok && renameResult.reason !== "eperm") {
+        if (renameResult.reason === "invalid") {
+          return { ok: false, code: "invalid", message: "Skill name is invalid." };
+        }
+        if (renameResult.reason === "collision") {
+          return {
+            ok: false,
+            code: "collision",
+            message: "A skill with that name already exists.",
+          };
+        }
+        if (renameResult.mutated === true) {
+          void this.refresh();
+        }
+        return fsFailure(renameResult.reason);
+      }
+
+      activeSkill = buildRenamedSkill(skill, newName, canonical);
+    }
+
+    const patchResult = await this.runInternalMutation(
+      () => runUpdateProperties({ skill: activeSkill, patch: req.patch, fs }),
+      (r) =>
+        r.ok && vaultRoot !== null
+          ? buildUpdatePropertiesExpectations(activeSkill, vaultRoot)
+          : []
+    );
+    if (!patchResult.ok) {
+      if (newName !== undefined) {
+        this.replaceManagedSkill(skill, activeSkill);
+      }
+      return fsFailure(patchResult.reason);
+    }
+
+    this.replaceManagedSkill(skill, applyPropertiesPatch(activeSkill, req.patch));
+    return { ok: true };
   }
 
   /**
@@ -406,22 +561,35 @@ export class SkillManager {
     }
 
     const fs = createNodeReconcileFs();
-    const result = await runRenameSkill({
-      skill,
-      newName,
-      canonicalAbsRoot: canonical,
-      agentDirsAbs: this.resolveAgentDirsAbs(vaultRoot),
-      fs,
-    });
+    const agentDirsAbs = this.resolveAgentDirsAbs(vaultRoot);
+    const result = await this.runInternalMutation(
+      async () => {
+        const renameResult = await runRenameSkill({
+          skill,
+          newName,
+          canonicalAbsRoot: canonical,
+          agentDirsAbs,
+          fs,
+        });
+        if (renameResult.ok || (!renameResult.ok && renameResult.reason === "eperm")) {
+          await this.cleanupLinksToSkill(fs, vaultRoot, skill.dirPath);
+        }
+        return renameResult;
+      },
+      (r) =>
+        r.ok || (!r.ok && r.reason === "eperm")
+          ? buildRenameExpectations(skill, newName, canonical, agentDirsAbs, vaultRoot)
+          : []
+    );
 
     if (!result.ok && result.reason === "eperm") {
       skillManagerStore.set(epermSeenAtom, true);
     }
 
-    // Refresh after any mutation beyond validation/collision, so the grid
-    // reflects the canonical filesystem even when a late step failed.
-    if (result.ok || (!result.ok && result.mutated === true)) {
-      await this.refresh();
+    if (result.ok || (!result.ok && result.reason === "eperm")) {
+      this.replaceManagedSkill(skill, buildRenamedSkill(skill, newName, canonical));
+    } else if (result.mutated === true) {
+      void this.refresh();
     }
     if (result.ok) return { ok: true };
     if (result.reason === "invalid") {
@@ -541,6 +709,154 @@ export class SkillManager {
   }
 
   /**
+   * Run a SkillManager-owned filesystem write under vault-watcher
+   * suppression. While `task` is in flight every vault event is dropped
+   * (depth-based). On success, the optional `buildExpectations` callback
+   * receives the task result and returns the set of watcher events that
+   * the FS write should produce — those are installed as path-scoped
+   * predicates so the matching events are suppressed without affecting
+   * unrelated changes.
+   */
+  private async runInternalMutation<T>(
+    task: () => Promise<T>,
+    buildExpectations?: (result: T) => Expectation[]
+  ): Promise<T> {
+    this.internalMutationDepth += 1;
+    try {
+      const result = await task();
+      if (buildExpectations !== undefined) {
+        this.installExpectations(buildExpectations(result));
+      }
+      return result;
+    } finally {
+      this.internalMutationDepth -= 1;
+      this.clearScheduledReconcile();
+    }
+  }
+
+  /** Cancel any pending watcher-driven reconciliation pass. */
+  private clearScheduledReconcile(): void {
+    if (this.reconcileDebounceTimer === null) return;
+    window.clearTimeout(this.reconcileDebounceTimer);
+    this.reconcileDebounceTimer = null;
+  }
+
+  /** Append new expectations and (re)arm the safety timer. */
+  private installExpectations(expectations: Expectation[]): void {
+    if (expectations.length === 0) return;
+    this.pendingExpectations.push(...expectations);
+    this.armSafetyTimer();
+  }
+
+  /** Restart the safety timer that backstops any never-arriving vault events. */
+  private armSafetyTimer(): void {
+    this.clearSafetyTimer();
+    this.safetyTimer = window.setTimeout(() => {
+      this.safetyTimer = null;
+      if (this.pendingExpectations.length === 0) return;
+      const paths = this.pendingExpectations.map((e) => e.vaultRelPath).join(", ");
+      logWarn(`[skills] Gave up waiting for vault events on: ${paths}`);
+      this.pendingExpectations = [];
+    }, EXPECTATION_TIMEOUT_MS);
+  }
+
+  /** Clear the safety timer without touching the pending expectation list. */
+  private clearSafetyTimer(): void {
+    if (this.safetyTimer === null) return;
+    window.clearTimeout(this.safetyTimer);
+    this.safetyTimer = null;
+  }
+
+  /**
+   * If the path matches any pending expectation, drop the event and
+   * asynchronously verify the predicate so satisfied expectations are
+   * removed from the pending list.
+   */
+  private tryMatchAndSuppress(eventPath: string): boolean {
+    const matches = this.pendingExpectations.filter((exp) => matchExpectation(exp, eventPath));
+    if (matches.length === 0) return false;
+    for (const exp of matches) {
+      void this.verifyAndMaybeConsume(exp);
+    }
+    return true;
+  }
+
+  /** Re-check the predicate now that an event arrived; consume if satisfied. */
+  private async verifyAndMaybeConsume(expectation: Expectation): Promise<void> {
+    let satisfied: boolean;
+    try {
+      satisfied = await this.evaluateExpectation(expectation);
+    } catch {
+      satisfied = false;
+    }
+    if (!satisfied) return;
+    this.consumeExpectation(expectation);
+  }
+
+  /** Evaluate the predicate behind one expectation against the live vault. */
+  private async evaluateExpectation(expectation: Expectation): Promise<boolean> {
+    switch (expectation.kind) {
+      case "exists":
+      case "subtree-exists":
+        return this.app.vault.adapter.exists(expectation.vaultRelPath);
+      case "missing":
+      case "subtree-missing":
+        return !(await this.app.vault.adapter.exists(expectation.vaultRelPath));
+      case "modified":
+        return true;
+    }
+  }
+
+  /** Remove a satisfied expectation from the pending list. */
+  private consumeExpectation(expectation: Expectation): void {
+    const idx = this.pendingExpectations.indexOf(expectation);
+    if (idx === -1) return;
+    this.pendingExpectations.splice(idx, 1);
+    if (this.pendingExpectations.length === 0) {
+      this.clearSafetyTimer();
+    }
+  }
+
+  /** Publish a single changed skill without running discovery. */
+  private replaceManagedSkill(previous: Skill, next: Skill): void {
+    const skills = skillManagerStore.get(skillsAtom);
+    const index = skills.findIndex((s) => sameSkillIdentity(s, previous));
+    const nextSkills =
+      index === -1
+        ? [...skills, next]
+        : [...skills.slice(0, index), next, ...skills.slice(index + 1)];
+    this.publishManagedSkills(sortSkills(nextSkills));
+  }
+
+  /** Publish removal of one managed skill without running discovery. */
+  private removeManagedSkill(skill: Skill): void {
+    const skills = skillManagerStore.get(skillsAtom);
+    this.publishManagedSkills(skills.filter((s) => !sameSkillIdentity(s, skill)));
+  }
+
+  /** Store and notify a managed-skill list snapshot. */
+  private publishManagedSkills(skills: Skill[]): void {
+    skillManagerStore.set(skillsAtom, skills);
+    this.publishSkillSetChanges(skills);
+  }
+
+  /** Remove stale symlinks that still point at one canonical skill dir. */
+  private async cleanupLinksToSkill(
+    fs: ReturnType<typeof createNodeReconcileFs>,
+    vaultRootAbs: string,
+    skillDirPath: string
+  ): Promise<void> {
+    const report = await removeAgentLinksPointingTo(
+      fs,
+      this.resolveAgentDirsAbs(vaultRootAbs),
+      skillDirPath
+    );
+    for (const error of report.errors) {
+      logWarn(`[skills] Failed to remove stale skill link ${error.path}: ${error.reason}`);
+    }
+  }
+
+  /**
    * Subscribe to vault file events that touch the canonical skills folder
    * or any registered agent skill directory. Mutations there can
    * desync the symlink fanout — we debounce by 250ms so a bulk rename
@@ -548,8 +864,7 @@ export class SkillManager {
    */
   private subscribeToVaultEvents(): void {
     const handler = (file: TAbstractFile): void => {
-      if (!this.isWatchedPath(file.path)) return;
-      this.scheduleReconcile();
+      this.handleVaultEvent(file.path);
     };
 
     // Rename includes the previous path; schedule if either side of the move
@@ -559,11 +874,26 @@ export class SkillManager {
     this.vaultEventRefs.push(this.app.vault.on("modify", handler));
     this.vaultEventRefs.push(
       this.app.vault.on("rename", (file: TAbstractFile, oldPath: string) => {
-        if (this.isWatchedPath(file.path) || this.isWatchedPath(oldPath)) {
-          this.scheduleReconcile();
-        }
+        this.handleVaultEvent(file.path, oldPath);
       })
     );
+  }
+
+  /**
+   * Decide what to do with one vault event:
+   *   - while a mutation is in flight, drop every event;
+   *   - if the path (or rename source) matches a pending expectation, drop
+   *     and verify the predicate;
+   *   - otherwise, debounce a reconcile pass when the path is watched.
+   */
+  private handleVaultEvent(newPath: string, oldPath?: string): void {
+    if (this.internalMutationDepth > 0) return;
+    const matchedNew = this.tryMatchAndSuppress(newPath);
+    const matchedOld = oldPath !== undefined && this.tryMatchAndSuppress(oldPath);
+    if (matchedNew || matchedOld) return;
+    if (this.isWatchedPath(newPath) || (oldPath !== undefined && this.isWatchedPath(oldPath))) {
+      this.scheduleReconcile();
+    }
   }
 
   /** Is this vault-relative path inside one of the watched roots? */
@@ -592,9 +922,7 @@ export class SkillManager {
 
   /** Trailing-edge debounce wrapper around {@link refresh}. */
   private scheduleReconcile(): void {
-    if (this.reconcileDebounceTimer !== null) {
-      window.clearTimeout(this.reconcileDebounceTimer);
-    }
+    this.clearScheduledReconcile();
     this.reconcileDebounceTimer = window.setTimeout(() => {
       this.reconcileDebounceTimer = null;
       void this.refresh();
@@ -631,7 +959,7 @@ export { totalCandidates };
 function resolveVaultRootAbs(app: App): string | null {
   const adapter = app.vault.adapter;
   if (!(adapter instanceof FileSystemAdapter)) return null;
-  return adapter.getBasePath().replace(/[/\\]+$/, "");
+  return normalizeAbsPath(adapter.getBasePath());
 }
 
 /**
@@ -659,6 +987,55 @@ export function dismissEpermBanner(): void {
 /** Synchronous getter — useful from non-React code (e.g. spawn descriptors). */
 export function getManagedSkills(): Skill[] {
   return skillManagerStore.get(skillsAtom);
+}
+
+/** Compute the next enabled-agent list for an incremental toggle update. */
+function computeNextAgents(current: BackendId[], agent: BackendId, enabled: boolean): BackendId[] {
+  const has = current.includes(agent);
+  if (enabled && !has) return [...current, agent];
+  if (!enabled && has) return current.filter((a) => a !== agent);
+  return current;
+}
+
+/** Apply a non-name frontmatter patch to an in-memory Skill snapshot. */
+function applyPropertiesPatch(
+  skill: Skill,
+  patch: Omit<SkillFrontmatterPatch, "name" | "enabledAgents">
+): Skill {
+  const next: Skill = { ...skill };
+  if ("description" in patch && typeof patch.description === "string") {
+    next.description = patch.description;
+  }
+  if ("license" in patch) next.license = patch.license;
+  if ("compatibility" in patch) next.compatibility = patch.compatibility;
+  if ("allowedTools" in patch) next.allowedTools = patch.allowedTools;
+  if ("model" in patch) next.model = patch.model;
+  if ("disableModelInvocation" in patch) {
+    next.disableModelInvocation = patch.disableModelInvocation;
+  }
+  if ("userInvocable" in patch) next.userInvocable = patch.userInvocable;
+  return next;
+}
+
+/** Build the in-memory Skill shape after a successful canonical rename. */
+function buildRenamedSkill(skill: Skill, newName: string, canonicalAbsRoot: string): Skill {
+  const dirPath = `${normalizeAbsPath(canonicalAbsRoot)}/${newName}`;
+  return {
+    ...skill,
+    name: newName,
+    dirPath,
+    filePath: `${dirPath}/SKILL.md`,
+  };
+}
+
+/** Compare stable skill identities before and after an incremental edit. */
+function sameSkillIdentity(a: Skill, b: Skill): boolean {
+  return a.dirPath === b.dirPath;
+}
+
+/** Keep incremental publishes in the same order as full discovery. */
+function sortSkills(skills: Skill[]): Skill[] {
+  return [...skills].sort((a, b) => a.dirPath.localeCompare(b.dirPath));
 }
 
 const EMPTY_SKILL_SET_SIGNATURE = "skills:v1:0";

--- a/src/agentMode/skills/concurrency.ts
+++ b/src/agentMode/skills/concurrency.ts
@@ -1,0 +1,22 @@
+/** Run async work with a fixed concurrency limit while preserving order. */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R> | R
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(limit, items.length);
+
+  await Promise.all(
+    Array.from({ length: workerCount }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await worker(items[index], index);
+      }
+    })
+  );
+
+  return results;
+}

--- a/src/agentMode/skills/discoverManagedSkills.test.ts
+++ b/src/agentMode/skills/discoverManagedSkills.test.ts
@@ -142,6 +142,29 @@ describe("discoverManagedSkills", () => {
     expect(mockedLogWarn).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps sorted output order when reads resolve out of order", async () => {
+    const adapter = makeAdapter({
+      [`${SKILLS_ROOT}/alpha/SKILL.md`]: validSkillMd({ name: "alpha" }),
+      [`${SKILLS_ROOT}/beta/SKILL.md`]: validSkillMd({ name: "beta" }),
+      [`${SKILLS_ROOT}/gamma/SKILL.md`]: validSkillMd({ name: "gamma" }),
+    });
+    const read = adapter.read.bind(adapter);
+    adapter.read = jest.fn(async (rel) => {
+      if (rel.includes("alpha")) {
+        await new Promise((resolve) => window.setTimeout(resolve, 5));
+      }
+      return read(rel);
+    });
+
+    const skills = await discoverManagedSkills({
+      skillsFolderRelPath: SKILLS_ROOT,
+      skillsFolderAbsPath: null,
+      adapter,
+    });
+
+    expect(skills.map((s) => s.name)).toEqual(["alpha", "beta", "gamma"]);
+  });
+
   it("parses metadata.copilot-enabled-agents into BackendId[]", async () => {
     const content = [
       "---",

--- a/src/agentMode/skills/discoverManagedSkills.ts
+++ b/src/agentMode/skills/discoverManagedSkills.ts
@@ -1,7 +1,11 @@
 import { logWarn } from "@/logger";
 import { basename, joinPosix } from "@/utils/pathUtils";
+import { mapWithConcurrency } from "./concurrency";
 import { parseSkillFile, SkillFormatError } from "./skillFormat";
 import type { Skill } from "./types";
+
+/** Maximum concurrent SKILL.md reads during discovery. */
+const DISCOVERY_CONCURRENCY = 16;
 
 /**
  * Minimal adapter the discovery walker depends on. Modelled after
@@ -55,59 +59,62 @@ export async function discoverManagedSkills(
   }
 
   const listing = await adapter.list(skillsFolderRelPath);
-  const skills: Skill[] = [];
 
   // Subdirectory paths come back as full vault-relative paths from
   // `adapter.list` (e.g. `copilot/skills/foo`). Sort for stable ordering
   // so the UI doesn't reshuffle on every reload.
-  for (const folderPath of [...listing.folders].sort()) {
-    const dirName = basename(folderPath);
-    const skillMdRelPath = joinPosix(folderPath, "SKILL.md");
+  const results = await mapWithConcurrency(
+    [...listing.folders].sort(),
+    DISCOVERY_CONCURRENCY,
+    async (folderPath): Promise<Skill | null> => {
+      const dirName = basename(folderPath);
+      const skillMdRelPath = joinPosix(folderPath, "SKILL.md");
 
-    let content: string;
-    try {
-      content = await adapter.read(skillMdRelPath);
-    } catch {
-      // Missing SKILL.md is expected — many subdirs are staging or asset
-      // folders. Read failure on an existing file is the same surface from
-      // Obsidian's adapter, so we can't distinguish; either way, skip.
-      continue;
-    }
+      let content: string;
+      try {
+        content = await adapter.read(skillMdRelPath);
+      } catch {
+        // Missing SKILL.md is expected — many subdirs are staging or asset
+        // folders. Read failure on an existing file is the same surface from
+        // Obsidian's adapter, so we can't distinguish; either way, skip.
+        return null;
+      }
 
-    let parsed;
-    try {
-      parsed = parseSkillFile(content, dirName);
-    } catch (err) {
-      const reason =
-        err instanceof SkillFormatError
-          ? err.message
-          : err instanceof Error
+      let parsed;
+      try {
+        parsed = parseSkillFile(content, dirName);
+      } catch (err) {
+        const reason =
+          err instanceof SkillFormatError
             ? err.message
-            : String(err);
-      logWarn(`[skills] Skipping ${skillMdRelPath}: ${reason}`);
-      continue;
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        logWarn(`[skills] Skipping ${skillMdRelPath}: ${reason}`);
+        return null;
+      }
+
+      const fm = parsed.frontmatter;
+      const absDir =
+        skillsFolderAbsPath !== null ? joinPosix(skillsFolderAbsPath, dirName) : folderPath;
+      const absFile = joinPosix(absDir, "SKILL.md");
+
+      return {
+        name: fm.name,
+        description: fm.description,
+        filePath: absFile,
+        dirPath: absDir,
+        body: parsed.body,
+        license: fm.license,
+        compatibility: fm.compatibility,
+        allowedTools: fm.allowedTools,
+        model: fm.model,
+        disableModelInvocation: fm.disableModelInvocation,
+        userInvocable: fm.userInvocable,
+        enabledAgents: fm.enabledAgents,
+      };
     }
+  );
 
-    const fm = parsed.frontmatter;
-    const absDir =
-      skillsFolderAbsPath !== null ? joinPosix(skillsFolderAbsPath, dirName) : folderPath;
-    const absFile = joinPosix(absDir, "SKILL.md");
-
-    skills.push({
-      name: fm.name,
-      description: fm.description,
-      filePath: absFile,
-      dirPath: absDir,
-      body: parsed.body,
-      license: fm.license,
-      compatibility: fm.compatibility,
-      allowedTools: fm.allowedTools,
-      model: fm.model,
-      disableModelInvocation: fm.disableModelInvocation,
-      userInvocable: fm.userInvocable,
-      enabledAgents: fm.enabledAgents,
-    });
-  }
-
-  return skills;
+  return results.filter((skill): skill is Skill => skill !== null);
 }

--- a/src/agentMode/skills/reconcile.test.ts
+++ b/src/agentMode/skills/reconcile.test.ts
@@ -205,6 +205,53 @@ describe("reconcile", () => {
     });
   });
 
+  it("removes a managed link when that skill is no longer enabled for the agent", async () => {
+    const fs = mkFs({
+      [`${CANONICAL}/foo`]: { kind: "dir" },
+      [`${CANONICAL}/foo/SKILL.md`]: { kind: "file" },
+      "/vault/.claude/skills/foo": { kind: "link", target: `${CANONICAL}/foo` },
+      "/vault/.opencode/skills/foo": { kind: "link", target: `${CANONICAL}/foo` },
+    });
+    const skills = [mkSkill("foo", ["claude"])];
+
+    const report = await reconcile({
+      skills,
+      canonicalAbsRoot: CANONICAL,
+      agentDirsAbs: AGENT_DIRS_ABS,
+      fs,
+    });
+
+    expect(report.removedOrphans).toContain("/vault/.opencode/skills/foo");
+    expect(fs.__dump()["/vault/.claude/skills/foo"]).toEqual({
+      kind: "link",
+      target: `${CANONICAL}/foo`,
+    });
+    expect(fs.__dump()["/vault/.opencode/skills/foo"]).toBeUndefined();
+  });
+
+  it("leaves unrelated links untouched during orphan cleanup", async () => {
+    const fs = mkFs({
+      [`${CANONICAL}/foo`]: { kind: "dir" },
+      [`${CANONICAL}/foo/SKILL.md`]: { kind: "file" },
+      "/vault/.claude/skills/foo": { kind: "link", target: `${CANONICAL}/foo` },
+      "/vault/.claude/skills/external": { kind: "link", target: "/elsewhere/external" },
+    });
+    const skills = [mkSkill("foo", ["claude"])];
+
+    const report = await reconcile({
+      skills,
+      canonicalAbsRoot: CANONICAL,
+      agentDirsAbs: AGENT_DIRS_ABS,
+      fs,
+    });
+
+    expect(report.removedOrphans).not.toContain("/vault/.claude/skills/external");
+    expect(fs.__dump()["/vault/.claude/skills/external"]).toEqual({
+      kind: "link",
+      target: "/elsewhere/external",
+    });
+  });
+
   it("never touches a real directory sitting in an agent path", async () => {
     const fs = mkFs({
       [`${CANONICAL}/foo`]: { kind: "dir" },

--- a/src/agentMode/skills/reconcile.ts
+++ b/src/agentMode/skills/reconcile.ts
@@ -1,7 +1,11 @@
 import { logWarn } from "@/logger";
 import { basename, joinPosix, normalizeAbsPath, resolvesInto } from "@/utils/pathUtils";
+import { mapWithConcurrency } from "./concurrency";
 import { createAgentLink, removeAgentLink, replaceAgentLink, type SymlinksFs } from "./symlinks";
 import type { BackendId, Skill } from "./types";
+
+/** Maximum concurrent filesystem checks during reconciliation. */
+const RECONCILE_CONCURRENCY = 32;
 
 /**
  * FS surface for reconciliation. Extends {@link SymlinksFs} with the bare
@@ -82,20 +86,19 @@ export async function reconcile(options: ReconcileOptions): Promise<ReconcileRep
   };
 
   // Pre-index managed skills by name for the orphan-removal phase.
-  const managedNames = new Set(skills.map((s) => s.name));
+  const skillByName = new Map(skills.map((skill) => [skill.name, skill]));
 
   // -- Phase 1: forward sync ----------------------------------------------
-  // Each (skill, agent) pair is independent: launch in parallel and merge
-  // results so a vault with N skills × M agents costs ~max(per-pair latency)
-  // rather than the sum.
+  // Each (skill, agent) pair is independent; keep concurrency bounded so a
+  // large skill set does not flood the filesystem with hundreds of lstat calls.
   const forwardOps = skills.flatMap((skill) =>
     skill.enabledAgents.flatMap((agent) => {
       const agentDir = agentDirsAbs[agent];
       if (agentDir === undefined) return [];
-      return [syncOneLink(fs, agentDir, skill)];
+      return [() => syncOneLink(fs, agentDir, skill)];
     })
   );
-  for (const entry of await Promise.all(forwardOps)) {
+  for (const entry of await mapWithConcurrency(forwardOps, RECONCILE_CONCURRENCY, (op) => op())) {
     if (entry.created !== undefined) report.created.push(entry.created);
     if (entry.error !== undefined) report.errors.push(entry.error);
   }
@@ -112,48 +115,23 @@ export async function reconcile(options: ReconcileOptions): Promise<ReconcileRep
     })
   );
 
-  for (const { agent, agentDir, entries } of agentEntries) {
-    for (const name of entries) {
-      // Skip aside-during-rename markers used by replaceAgentLink.
-      if (name.endsWith(".replacing")) continue;
-      const linkPath = joinPosix(agentDir, name);
+  const reverseOps = agentEntries.flatMap(({ agent, agentDir, entries }) =>
+    entries.map(
+      (name) => () =>
+        sweepOneReverseEntry({
+          fs,
+          canonicalAbsRoot,
+          skillByName,
+          agent,
+          agentDir,
+          name,
+        })
+    )
+  );
 
-      let isLink = false;
-      try {
-        isLink = await fs.isSymlink(linkPath);
-      } catch {
-        // Treat unreadable lstat as non-link — never delete real dirs.
-        continue;
-      }
-      if (!isLink) continue;
-
-      const target = await fs.readlinkAbs(linkPath);
-      if (target === null) continue;
-
-      // Only touch links pointing into the canonical store. Anything else
-      // is user-owned per the design spec.
-      if (!resolvesInto(target, canonicalAbsRoot)) continue;
-
-      // Determine the expected managed name from the link's basename. Orphan
-      // = (a) basename has no matching managed skill, or (b) the link's
-      // basename doesn't match its target's parent dir basename.
-      const targetBase = basename(target);
-      const basenameMatches = targetBase === name;
-      const managed = managedNames.has(name);
-      // Also ensure the matched managed skill actually enables this agent.
-      const skill = skills.find((s) => s.name === name);
-      const agentEnabled = skill !== undefined && skill.enabledAgents.includes(agent);
-
-      if (managed && basenameMatches && agentEnabled) continue;
-
-      try {
-        await removeAgentLink(fs, agentDir, name);
-        report.removedOrphans.push(linkPath);
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        report.errors.push({ path: linkPath, reason });
-      }
-    }
+  for (const entry of await mapWithConcurrency(reverseOps, RECONCILE_CONCURRENCY, (op) => op())) {
+    if (entry?.removed !== undefined) report.removedOrphans.push(entry.removed);
+    if (entry?.error !== undefined) report.errors.push(entry.error);
   }
 
   return report;
@@ -169,6 +147,20 @@ export function getAgentDirs(
 interface ForwardSyncEntry {
   created?: string;
   error?: { path: string; reason: string };
+}
+
+interface ReverseSweepEntry {
+  removed?: string;
+  error?: { path: string; reason: string };
+}
+
+interface ReverseSweepOptions {
+  fs: ReconcileFs;
+  canonicalAbsRoot: string;
+  skillByName: ReadonlyMap<string, Skill>;
+  agent: BackendId;
+  agentDir: string;
+  name: string;
 }
 
 /** Reconcile a single (skill, agent) slot. Returns the report deltas. */
@@ -200,6 +192,41 @@ async function syncOneLink(
 
     const result = await replaceAgentLink(fs, agentDir, skill.name, skill.dirPath);
     return result.ok ? { created: linkPath } : { error: { path: linkPath, reason: result.reason } };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { error: { path: linkPath, reason } };
+  }
+}
+
+/** Inspect and possibly remove one reverse-sweep entry. */
+async function sweepOneReverseEntry(options: ReverseSweepOptions): Promise<ReverseSweepEntry> {
+  const { fs, canonicalAbsRoot, skillByName, agent, agentDir, name } = options;
+  if (name.endsWith(".replacing")) return {};
+  const linkPath = joinPosix(agentDir, name);
+
+  let isLink = false;
+  try {
+    isLink = await fs.isSymlink(linkPath);
+  } catch {
+    // Treat unreadable lstat as non-link — never delete real dirs.
+    return {};
+  }
+  if (!isLink) return {};
+
+  const target = await fs.readlinkAbs(linkPath);
+  if (target === null) return {};
+
+  // Only touch links pointing into the canonical store. Anything else is
+  // user-owned per the design spec.
+  if (!resolvesInto(target, canonicalAbsRoot)) return {};
+
+  const basenameMatches = basename(target) === name;
+  const skill = skillByName.get(name);
+  if (skill !== undefined && basenameMatches && skill.enabledAgents.includes(agent)) return {};
+
+  try {
+    await removeAgentLink(fs, agentDir, name);
+    return { removed: linkPath };
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     return { error: { path: linkPath, reason } };

--- a/src/agentMode/skills/symlinks.ts
+++ b/src/agentMode/skills/symlinks.ts
@@ -1,6 +1,6 @@
 import { logWarn } from "@/logger";
 import { errCode } from "@/utils/errorUtils";
-import { joinPosix } from "@/utils/pathUtils";
+import { joinPosix, normalizeAbsPath } from "@/utils/pathUtils";
 import { renameWithRetry } from "./renameWithRetry";
 
 /**
@@ -28,6 +28,18 @@ export interface SymlinksFs {
   unlink(absPath: string): Promise<void>;
   /** Recursively remove a real directory at `absPath`. */
   rmRecursive(absPath: string): Promise<void>;
+}
+
+/**
+ * FS surface for targeted link sweeps. Used by single-skill delete/rename
+ * flows so they can clean stale managed links without running a full
+ * repository reconciliation pass.
+ */
+export interface LinkSweepFs extends SymlinksFs {
+  /** List immediate entries under an agent skills directory. */
+  list(absPath: string): Promise<string[]>;
+  /** Resolve a symlink or junction to an absolute target. */
+  readlinkAbs(absPath: string): Promise<string | null>;
 }
 
 /**
@@ -196,4 +208,66 @@ export async function replaceAgentLink(
   }
 
   return { ok: true };
+}
+
+/**
+ * Remove symlinks in every agent skills directory that point exactly at
+ * `targetAbs`. Real directories and symlinks to any other target are left
+ * untouched.
+ */
+export async function removeAgentLinksPointingTo(
+  fs: LinkSweepFs,
+  agentDirsAbs: Readonly<Record<string, string>>,
+  targetAbs: string
+): Promise<{ removed: string[]; errors: Array<{ path: string; reason: string }> }> {
+  const normalizedTarget = normalizeAbsPath(targetAbs);
+  const results = await Promise.all(
+    Object.values(agentDirsAbs).map((agentDir) => sweepAgentDir(fs, agentDir, normalizedTarget))
+  );
+  return {
+    removed: results.flatMap((result) => result.removed),
+    errors: results.flatMap((result) => result.errors),
+  };
+}
+
+/** Sweep one agent directory for symlinks whose target matches `normalizedTarget`. */
+async function sweepAgentDir(
+  fs: LinkSweepFs,
+  agentDir: string,
+  normalizedTarget: string
+): Promise<{ removed: string[]; errors: Array<{ path: string; reason: string }> }> {
+  let entries: string[];
+  try {
+    entries = await fs.list(agentDir);
+  } catch {
+    return { removed: [], errors: [] };
+  }
+
+  const removed: string[] = [];
+  const errors: Array<{ path: string; reason: string }> = [];
+  await Promise.all(
+    entries.map(async (name) => {
+      const linkPath = joinPosix(agentDir, name);
+      let isLink = false;
+      try {
+        isLink = await fs.isSymlink(linkPath);
+      } catch {
+        return;
+      }
+      if (!isLink) return;
+
+      const target = await fs.readlinkAbs(linkPath);
+      if (target === null || normalizeAbsPath(target) !== normalizedTarget) return;
+
+      try {
+        await fs.unlink(linkPath);
+        removed.push(linkPath);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        errors.push({ path: linkPath, reason });
+      }
+    })
+  );
+
+  return { removed, errors };
 }

--- a/src/agentMode/skills/toggleAgent.test.ts
+++ b/src/agentMode/skills/toggleAgent.test.ts
@@ -1,4 +1,4 @@
-import { runDeleteSkill, runToggleAgent, type ToggleAgentFs } from "./toggleAgent";
+import { runDeleteSkill, runToggleAgent, type DeleteSkillFs } from "./toggleAgent";
 import type { Skill } from "./types";
 
 jest.mock("@/logger", () => ({
@@ -20,7 +20,7 @@ jest.mock("./renameWithRetry", () => ({
 
 type Node = { kind: "dir" } | { kind: "file"; content: string } | { kind: "link"; target: string };
 
-function mkFs(initial: Record<string, Node> = {}): ToggleAgentFs & {
+function mkFs(initial: Record<string, Node> = {}): DeleteSkillFs & {
   __dump(): Record<string, Node>;
   __setSymlinkBlocked(blocked: boolean): void;
 } {
@@ -50,6 +50,21 @@ function mkFs(initial: Record<string, Node> = {}): ToggleAgentFs & {
     },
     async isSymlink(p) {
       return map.get(p)?.kind === "link";
+    },
+    async readlinkAbs(p) {
+      const n = map.get(p);
+      return n !== undefined && n.kind === "link" ? n.target : null;
+    },
+    async list(p) {
+      const prefix = p.replace(/\/+$/, "") + "/";
+      const out = new Set<string>();
+      for (const k of map.keys()) {
+        if (!k.startsWith(prefix)) continue;
+        const rest = k.slice(prefix.length);
+        if (rest.length === 0) continue;
+        out.add(rest.split("/")[0]);
+      }
+      return Array.from(out);
     },
     async symlink(target, linkPath) {
       if (symlinkBlocked) {
@@ -253,5 +268,31 @@ describe("runDeleteSkill", () => {
 
     expect(result).toEqual({ ok: true });
     expect(fs.__dump()[`${CANON}/foo`]).toBeUndefined();
+  });
+
+  it("removes stale symlinks pointing at the deleted skill in disabled agent dirs", async () => {
+    const fs = mkFs({
+      [`${CANON}/foo/SKILL.md`]: { kind: "file", content: SKILL_MD("foo", "claude") },
+      "/vault/.claude/skills/foo": { kind: "link", target: `${CANON}/foo` },
+      "/vault/.agents/skills/foo": { kind: "link", target: `${CANON}/foo` },
+      "/vault/.opencode/skills/unrelated": { kind: "link", target: "/elsewhere/unrelated" },
+      "/vault/.opencode/skills/foo": { kind: "dir" },
+      "/vault/.opencode/skills/foo/SKILL.md": { kind: "file", content: SKILL_MD("foo") },
+    });
+
+    const result = await runDeleteSkill({
+      skill: mkSkill("foo", ["claude"]),
+      agentDirsAbs: AGENT_DIRS_ABS,
+      fs,
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fs.__dump()["/vault/.claude/skills/foo"]).toBeUndefined();
+    expect(fs.__dump()["/vault/.agents/skills/foo"]).toBeUndefined();
+    expect(fs.__dump()["/vault/.opencode/skills/unrelated"]).toEqual({
+      kind: "link",
+      target: "/elsewhere/unrelated",
+    });
+    expect(fs.__dump()["/vault/.opencode/skills/foo"]).toEqual({ kind: "dir" });
   });
 });

--- a/src/agentMode/skills/toggleAgent.ts
+++ b/src/agentMode/skills/toggleAgent.ts
@@ -1,6 +1,12 @@
 import { logError, logWarn } from "@/logger";
 import { parseSkillFile, serializeSkillFile } from "./skillFormat";
-import { removeAgentLink, replaceAgentLink, type SymlinkResult } from "./symlinks";
+import {
+  removeAgentLink,
+  removeAgentLinksPointingTo,
+  replaceAgentLink,
+  type LinkSweepFs,
+  type SymlinkResult,
+} from "./symlinks";
 import type { BackendId, Skill } from "./types";
 
 /**
@@ -27,6 +33,9 @@ export interface ToggleAgentFs {
   /** Write a UTF-8 file (overwriting). */
   writeFile(absPath: string, content: string): Promise<void>;
 }
+
+/** FS surface for delete, including targeted stale-link sweeps. */
+export type DeleteSkillFs = ToggleAgentFs & LinkSweepFs;
 
 /** Discriminated result identical to {@link SymlinkResult}, re-exported for callers. */
 export type ToggleAgentResult = { ok: true } | { ok: false; reason: string };
@@ -90,7 +99,7 @@ export interface DeleteSkillOptions {
   skill: Skill;
   /** Absolute path of each registered agent's project skills directory. */
   agentDirsAbs: Readonly<Record<BackendId, string>>;
-  fs: ToggleAgentFs;
+  fs: DeleteSkillFs;
 }
 
 /**
@@ -117,6 +126,11 @@ export async function runDeleteSkill(
       }
     })
   );
+
+  const sweep = await removeAgentLinksPointingTo(fs, agentDirsAbs, skill.dirPath);
+  for (const error of sweep.errors) {
+    logWarn(`[skills] deleteSkill: failed to remove stale link ${error.path}: ${error.reason}`);
+  }
 
   try {
     await fs.rmRecursive(skill.dirPath);

--- a/src/agentMode/skills/ui/SkillsSettings.tsx
+++ b/src/agentMode/skills/ui/SkillsSettings.tsx
@@ -16,7 +16,6 @@ import {
 } from "./PropertiesDialog";
 import {
   dismissEpermBanner,
-  getManagedSkills,
   SkillManager,
   totalCandidates,
   useEpermSeen,
@@ -29,7 +28,6 @@ import { Input } from "@/components/ui/input";
 import { SettingItem } from "@/components/ui/setting-item";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
-import { parentDir } from "@/utils/pathUtils";
 import { updateSetting, useSettingsValue, validateSkillsFolder } from "@/settings/model";
 import { AlertTriangle, Folder, RotateCcw, Search } from "lucide-react";
 import { FileSystemAdapter, Notice, TFile, TFolder } from "obsidian";
@@ -305,47 +303,19 @@ export const SkillsSettings: React.FC = () => {
         displayFolder,
         async (req: PropertiesSaveRequest): Promise<PropertiesSaveOutcome> => {
           const manager = SkillManager.getInstance();
-
-          let activeDirPath = skill.dirPath;
-          let renamedSkillName = skill.name;
-
-          if (req.nameChanged) {
-            const renameResult = await manager.renameSkill(skill, req.newName);
-            if (!renameResult.ok) {
-              if (renameResult.code === "collision") return "collision";
-              if (renameResult.code === "invalid") {
-                // Shouldn't happen — the modal gates Save on inline validation.
-                return "stay";
-              }
-              if (renameResult.code === "eperm") {
-                // Canonical rename succeeded; one or more symlinks failed.
-                // The EPERM banner has already been raised by SkillManager.
-                renamedSkillName = req.newName;
-                activeDirPath = computeNewDirPath(skill.dirPath, req.newName);
-              } else {
-                new Notice(`Could not rename ${skill.name}: ${renameResult.message}`);
-                return "stay";
-              }
-            } else {
-              renamedSkillName = req.newName;
-              activeDirPath = computeNewDirPath(skill.dirPath, req.newName);
+          const result = await manager.saveProperties(skill, {
+            newName: req.nameChanged ? req.newName : undefined,
+            patch: req.patch,
+          });
+          if (!result.ok) {
+            if (result.code === "collision") return "collision";
+            if (result.code === "invalid") {
+              // Shouldn't happen — the modal gates Save on inline validation.
+              return "stay";
             }
-          }
-
-          // Look up the (possibly renamed) canonical from the live store.
-          // `manager.renameSkill` triggers a refresh, so the new state should
-          // be in `getManagedSkills()`; fall back to a synthesized reference
-          // if not.
-          const liveSkills = getManagedSkills();
-          const target =
-            liveSkills.find((s) => s.dirPath === activeDirPath) ??
-            (req.nameChanged
-              ? { ...skill, name: renamedSkillName, dirPath: activeDirPath }
-              : skill);
-
-          const patchResult = await manager.updateProperties(target, req.patch);
-          if (!patchResult.ok) {
-            new Notice(`Could not update ${renamedSkillName}: ${patchResult.message}`);
+            new Notice(
+              `Could not update ${req.nameChanged ? req.newName : skill.name}: ${result.message}`
+            );
             return "stay";
           }
           return "close";
@@ -615,15 +585,6 @@ function filterSkills(skills: Skill[], query: string): Skill[] {
 /** Pluralise the skill count for the toolbar. */
 function formatSkillCount(n: number): string {
   return `${n} skill${n === 1 ? "" : "s"}`;
-}
-
-/**
- * Replace the trailing basename of an absolute canonical skill directory
- * with `newName`. Used to look up the renamed skill in the live grid after
- * `SkillManager.renameSkill` refreshes state.
- */
-function computeNewDirPath(oldDirPath: string, newName: string): string {
-  return `${parentDir(oldDirPath)}/${newName}`;
 }
 
 /**

--- a/src/agentMode/skills/vaultEventExpectations.test.ts
+++ b/src/agentMode/skills/vaultEventExpectations.test.ts
@@ -1,0 +1,146 @@
+import {
+  absToVaultRel,
+  buildDeleteExpectations,
+  buildReconcileExpectations,
+  buildRenameExpectations,
+  buildToggleExpectations,
+  buildUpdatePropertiesExpectations,
+  matchExpectation,
+  type Expectation,
+} from "./vaultEventExpectations";
+import type { Skill } from "./types";
+
+describe("vaultEventExpectations", () => {
+  describe("absToVaultRel", () => {
+    it("strips a vault-root prefix", () => {
+      expect(absToVaultRel("/vault/copilot/skills/foo", "/vault")).toBe("copilot/skills/foo");
+    });
+
+    it("returns empty string when the path is the vault root", () => {
+      expect(absToVaultRel("/vault", "/vault")).toBe("");
+    });
+
+    it("normalizes trailing slashes on the vault root", () => {
+      expect(absToVaultRel("/vault/foo", "/vault/")).toBe("foo");
+    });
+
+    it("returns null for a path that escapes the vault", () => {
+      expect(absToVaultRel("/other/foo", "/vault")).toBeNull();
+    });
+  });
+
+  describe("matchExpectation", () => {
+    it("matches an exact path expectation by path equality only", () => {
+      const exp: Expectation = { kind: "exists", vaultRelPath: "copilot/skills/foo/SKILL.md" };
+      expect(matchExpectation(exp, "copilot/skills/foo/SKILL.md")).toBe(true);
+      expect(matchExpectation(exp, "copilot/skills/foo")).toBe(false);
+    });
+
+    it("matches a subtree expectation on the root and any descendant", () => {
+      const exp: Expectation = { kind: "subtree-missing", vaultRelPath: "copilot/skills/foo" };
+      expect(matchExpectation(exp, "copilot/skills/foo")).toBe(true);
+      expect(matchExpectation(exp, "copilot/skills/foo/SKILL.md")).toBe(true);
+      expect(matchExpectation(exp, "copilot/skills/foo/nested/file.md")).toBe(true);
+      expect(matchExpectation(exp, "copilot/skills/foobar")).toBe(false);
+    });
+  });
+
+  describe("buildToggleExpectations", () => {
+    it("on enable, expects the symlink to exist and SKILL.md to be modified", () => {
+      const skill = makeSkill();
+      const exps = buildToggleExpectations(skill, true, "/vault/.claude/skills", "/vault");
+      expect(exps).toEqual([
+        { kind: "modified", vaultRelPath: "copilot/skills/foo/SKILL.md" },
+        { kind: "exists", vaultRelPath: ".claude/skills/foo" },
+      ]);
+    });
+
+    it("on disable, expects the symlink to be missing", () => {
+      const skill = makeSkill();
+      const exps = buildToggleExpectations(skill, false, "/vault/.claude/skills", "/vault");
+      expect(exps).toEqual([
+        { kind: "modified", vaultRelPath: "copilot/skills/foo/SKILL.md" },
+        { kind: "missing", vaultRelPath: ".claude/skills/foo" },
+      ]);
+    });
+  });
+
+  describe("buildDeleteExpectations", () => {
+    it("expects the subtree to be gone and each link to be missing", () => {
+      const skill = makeSkill();
+      const exps = buildDeleteExpectations(
+        skill,
+        { claude: "/vault/.claude/skills", opencode: "/vault/.opencode/skills" },
+        "/vault"
+      );
+      expect(exps).toEqual([
+        { kind: "subtree-missing", vaultRelPath: "copilot/skills/foo" },
+        { kind: "missing", vaultRelPath: ".claude/skills/foo" },
+        { kind: "missing", vaultRelPath: ".opencode/skills/foo" },
+      ]);
+    });
+  });
+
+  describe("buildUpdatePropertiesExpectations", () => {
+    it("expects one modify event on the canonical SKILL.md", () => {
+      const skill = makeSkill();
+      const exps = buildUpdatePropertiesExpectations(skill, "/vault");
+      expect(exps).toEqual([{ kind: "modified", vaultRelPath: "copilot/skills/foo/SKILL.md" }]);
+    });
+  });
+
+  describe("buildRenameExpectations", () => {
+    it("expects the old subtree to vanish and the new one to appear", () => {
+      const skill = makeSkill();
+      const exps = buildRenameExpectations(
+        skill,
+        "bar",
+        "/vault/copilot/skills",
+        { claude: "/vault/.claude/skills" },
+        "/vault"
+      );
+      expect(exps).toEqual([
+        { kind: "subtree-missing", vaultRelPath: "copilot/skills/foo" },
+        { kind: "subtree-exists", vaultRelPath: "copilot/skills/bar" },
+        { kind: "missing", vaultRelPath: ".claude/skills/foo" },
+        { kind: "exists", vaultRelPath: ".claude/skills/bar" },
+      ]);
+    });
+  });
+
+  describe("buildReconcileExpectations", () => {
+    it("turns created/removedOrphans into exists/missing expectations", () => {
+      const exps = buildReconcileExpectations(
+        {
+          created: ["/vault/.claude/skills/foo"],
+          removedOrphans: ["/vault/.opencode/skills/stale"],
+        },
+        "/vault"
+      );
+      expect(exps).toEqual([
+        { kind: "exists", vaultRelPath: ".claude/skills/foo" },
+        { kind: "missing", vaultRelPath: ".opencode/skills/stale" },
+      ]);
+    });
+
+    it("drops paths outside the vault", () => {
+      const exps = buildReconcileExpectations(
+        { created: ["/elsewhere/foo"], removedOrphans: [] },
+        "/vault"
+      );
+      expect(exps).toEqual([]);
+    });
+  });
+});
+
+function makeSkill(overrides: Partial<Skill> = {}): Skill {
+  return {
+    name: "foo",
+    description: "A skill.",
+    filePath: "/vault/copilot/skills/foo/SKILL.md",
+    dirPath: "/vault/copilot/skills/foo",
+    body: "body",
+    enabledAgents: [],
+    ...overrides,
+  };
+}

--- a/src/agentMode/skills/vaultEventExpectations.ts
+++ b/src/agentMode/skills/vaultEventExpectations.ts
@@ -1,0 +1,182 @@
+import { normalizeAbsPath } from "@/utils/pathUtils";
+import type { BackendId, Skill } from "./types";
+
+/**
+ * A predicate describing a vault-relative path that the {@link SkillManager}
+ * just touched. While an expectation is live, watcher events for that path
+ * are dropped: they were caused by our own write, not by the user.
+ *
+ * Each expectation is cleared as soon as the desired on-disk state for the
+ * path is observed (predicate satisfied), or as a backstop when the
+ * SkillManager's safety timer fires. Predicates therefore replace the
+ * previous time-based heuristic — slow watchers extend the wait
+ * automatically, fast watchers lift it immediately.
+ *
+ * - `exists` / `missing`: exact-path predicates against `vault.adapter.exists`.
+ * - `subtree-exists` / `subtree-missing`: prefix match. Used for recursive
+ *   create/delete where many nested events fire and only the root state is
+ *   meaningful.
+ * - `modified`: consumed by any matching event without an FS check. Used
+ *   for in-place rewrites (e.g. SKILL.md frontmatter patch) where the file
+ *   stays at the same path.
+ */
+export type Expectation =
+  | { kind: "exists"; vaultRelPath: string }
+  | { kind: "missing"; vaultRelPath: string }
+  | { kind: "subtree-exists"; vaultRelPath: string }
+  | { kind: "subtree-missing"; vaultRelPath: string }
+  | { kind: "modified"; vaultRelPath: string };
+
+/**
+ * True when this vault event path is described by the expectation.
+ * `exp.vaultRelPath` is expected to already be normalized (slash-only, no
+ * leading/trailing slashes) — see {@link absToVaultRel}.
+ */
+export function matchExpectation(exp: Expectation, eventPath: string): boolean {
+  const path = normalizeRel(eventPath);
+  if (exp.kind === "subtree-exists" || exp.kind === "subtree-missing") {
+    return path === exp.vaultRelPath || path.startsWith(`${exp.vaultRelPath}/`);
+  }
+  return path === exp.vaultRelPath;
+}
+
+/**
+ * Strip a vault-root prefix from an absolute path. Returns `null` when
+ * `absPath` is not under `vaultRootAbs` — the caller should skip the
+ * expectation rather than match a foreign event.
+ */
+export function absToVaultRel(absPath: string, vaultRootAbs: string): string | null {
+  const abs = normalizeAbsPath(absPath);
+  const root = normalizeAbsPath(vaultRootAbs);
+  if (abs === root) return "";
+  if (abs.startsWith(`${root}/`)) return abs.slice(root.length + 1);
+  return null;
+}
+
+function normalizeRel(path: string): string {
+  return path.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
+}
+
+/**
+ * Expectations after `toggleAgent`: a frontmatter rewrite of the canonical
+ * SKILL.md and a symlink that should now exist (enable) or be gone (disable).
+ */
+export function buildToggleExpectations(
+  skill: Skill,
+  enabled: boolean,
+  agentDirAbs: string,
+  vaultRootAbs: string
+): Expectation[] {
+  const exps: Expectation[] = [];
+  pushIfRel(exps, skill.filePath, vaultRootAbs, (path) => ({
+    kind: "modified",
+    vaultRelPath: path,
+  }));
+  pushIfRel(exps, `${agentDirAbs}/${skill.name}`, vaultRootAbs, (path) => ({
+    kind: enabled ? "exists" : "missing",
+    vaultRelPath: path,
+  }));
+  return exps;
+}
+
+/**
+ * Expectations after `deleteSkill`: the canonical dir is gone (subtree) and
+ * each agent symlink that pointed at it is gone.
+ */
+export function buildDeleteExpectations(
+  skill: Skill,
+  agentDirsAbs: Readonly<Record<BackendId, string>>,
+  vaultRootAbs: string
+): Expectation[] {
+  const exps: Expectation[] = [];
+  pushIfRel(exps, skill.dirPath, vaultRootAbs, (path) => ({
+    kind: "subtree-missing",
+    vaultRelPath: path,
+  }));
+  for (const agentDir of Object.values(agentDirsAbs)) {
+    pushIfRel(exps, `${agentDir}/${skill.name}`, vaultRootAbs, (path) => ({
+      kind: "missing",
+      vaultRelPath: path,
+    }));
+  }
+  return exps;
+}
+
+/** Expectation after `updateProperties`: SKILL.md was rewritten in place. */
+export function buildUpdatePropertiesExpectations(
+  skill: Skill,
+  vaultRootAbs: string
+): Expectation[] {
+  const exps: Expectation[] = [];
+  pushIfRel(exps, skill.filePath, vaultRootAbs, (path) => ({
+    kind: "modified",
+    vaultRelPath: path,
+  }));
+  return exps;
+}
+
+/**
+ * Expectations after `renameSkill`: the old canonical dir disappears, the
+ * new one appears, and per-agent links flip from the old basename to the
+ * new one.
+ */
+export function buildRenameExpectations(
+  oldSkill: Skill,
+  newName: string,
+  canonicalAbsRoot: string,
+  agentDirsAbs: Readonly<Record<BackendId, string>>,
+  vaultRootAbs: string
+): Expectation[] {
+  const exps: Expectation[] = [];
+  const root = normalizeAbsPath(canonicalAbsRoot);
+  pushIfRel(exps, oldSkill.dirPath, vaultRootAbs, (path) => ({
+    kind: "subtree-missing",
+    vaultRelPath: path,
+  }));
+  pushIfRel(exps, `${root}/${newName}`, vaultRootAbs, (path) => ({
+    kind: "subtree-exists",
+    vaultRelPath: path,
+  }));
+  for (const agentDir of Object.values(agentDirsAbs)) {
+    pushIfRel(exps, `${agentDir}/${oldSkill.name}`, vaultRootAbs, (path) => ({
+      kind: "missing",
+      vaultRelPath: path,
+    }));
+    pushIfRel(exps, `${agentDir}/${newName}`, vaultRootAbs, (path) => ({
+      kind: "exists",
+      vaultRelPath: path,
+    }));
+  }
+  return exps;
+}
+
+/**
+ * Expectations after a `reconcile` pass: every created link should now
+ * exist and every removed orphan should now be gone. Errors do not get an
+ * expectation — the next refresh will retry them.
+ */
+export function buildReconcileExpectations(
+  report: { created: readonly string[]; removedOrphans: readonly string[] },
+  vaultRootAbs: string
+): Expectation[] {
+  const exps: Expectation[] = [];
+  for (const path of report.created) {
+    pushIfRel(exps, path, vaultRootAbs, (rel) => ({ kind: "exists", vaultRelPath: rel }));
+  }
+  for (const path of report.removedOrphans) {
+    pushIfRel(exps, path, vaultRootAbs, (rel) => ({ kind: "missing", vaultRelPath: rel }));
+  }
+  return exps;
+}
+
+/** Helper: build an expectation only when the absolute path lies inside the vault. */
+function pushIfRel(
+  exps: Expectation[],
+  absPath: string,
+  vaultRootAbs: string,
+  build: (vaultRelPath: string) => Expectation
+): void {
+  const rel = absToVaultRel(absPath, vaultRootAbs);
+  if (rel === null) return;
+  exps.push(build(rel));
+}


### PR DESCRIPTION
## Summary

- Replaces time-based vault-watcher suppression with path-scoped expectations: every `SkillManager` FS write registers exists/missing/modified/subtree-* predicates (`vaultEventExpectations.ts`), so matching events are dropped without triggering a debounced reconcile. A 10s safety timer backstops never-arriving events.
- Toggle/delete/rename/saveProperties now publish incremental in-memory updates (`replaceManagedSkill` / `removeManagedSkill`) instead of running full discovery — the Properties modal returns synchronously and the grid renders the change immediately.
- Consolidates rename + frontmatter patch into a single `saveProperties` operation so the UI emits one skill-set change notification instead of three.
- Shared `mapWithConcurrency` extracted to `concurrency.ts` (was duplicated in `discoverManagedSkills.ts` and `reconcile.ts`); path normalization now goes through the existing `normalizeAbsPath` utility.

## Test plan

- [x] `npm test -- --testPathPattern="src/agentMode/skills"` — 122 tests pass, including new `vaultEventExpectations.test.ts`
- [x] `npx tsc --noEmit` clean; `npm run lint` clean for changed files
- [ ] Manual: toggle/rename/delete/save-properties in Skills Settings and confirm the grid updates without perceptible lag