### PR TITLE
chore(opencode): bump pinned binary to v1.15.11

### DIFF
--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -42,6 +42,7 @@ jest.mock("@/settings/model", () => {
   };
 });
 
+import { OPENCODE_PINNED_VERSION } from "@/constants";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -66,7 +67,7 @@ const fakePlugin = {
 
 describe("pickMatchingAsset", () => {
   const release = {
-    tag_name: "v1.14.24",
+    tag_name: `v${OPENCODE_PINNED_VERSION}`,
     assets: [
       {
         name: "opencode-darwin-arm64.zip",
@@ -166,13 +167,14 @@ describe("computeInstallState", () => {
 });
 
 describe("parseVersionFromStdout", () => {
+  const V = OPENCODE_PINNED_VERSION;
   it.each([
-    ["1.14.24", "1.14.24"],
-    ["v1.14.24", "1.14.24"],
-    ["opencode 1.14.24", "1.14.24"],
-    ["opencode\nversion: 1.14.24\n", "1.14.24"],
-    ["1.14.24-rc.1", "1.14.24-rc.1"],
-    ["1.14.24+build.5", "1.14.24+build.5"],
+    [V, V],
+    [`v${V}`, V],
+    [`opencode ${V}`, V],
+    [`opencode\nversion: ${V}\n`, V],
+    [`${V}-rc.1`, `${V}-rc.1`],
+    [`${V}+build.5`, `${V}+build.5`],
   ])("parses %j → %s", (input, expected) => {
     expect(parseVersionFromStdout(input)).toBe(expected);
   });
@@ -208,14 +210,14 @@ describe("OpencodeBinaryManager.refreshInstallState", () => {
     const ghost = path.join(tmpDir, "does-not-exist", "opencode");
     settingsMock.__reset({
       binaryPath: ghost,
-      binaryVersion: "1.14.24",
+      binaryVersion: OPENCODE_PINNED_VERSION,
       binarySource: "custom",
     });
     const mgr = new OpencodeBinaryManager(fakePlugin);
     await mgr.refreshInstallState();
     expect(settingsMock.__get()).toEqual({
       binaryPath: ghost,
-      binaryVersion: "1.14.24",
+      binaryVersion: OPENCODE_PINNED_VERSION,
       binarySource: "custom",
     });
   });
@@ -224,7 +226,7 @@ describe("OpencodeBinaryManager.refreshInstallState", () => {
     const ghost = path.join(tmpDir, "does-not-exist", "opencode");
     settingsMock.__reset({
       binaryPath: ghost,
-      binaryVersion: "1.14.24",
+      binaryVersion: OPENCODE_PINNED_VERSION,
       binarySource: "managed",
     });
     const mgr = new OpencodeBinaryManager(fakePlugin);
@@ -241,14 +243,14 @@ describe("OpencodeBinaryManager.refreshInstallState", () => {
     await fs.promises.writeFile(realFile, "");
     settingsMock.__reset({
       binaryPath: realFile,
-      binaryVersion: "1.14.24",
+      binaryVersion: OPENCODE_PINNED_VERSION,
       binarySource: "managed",
     });
     const mgr = new OpencodeBinaryManager(fakePlugin);
     await mgr.refreshInstallState();
     expect(settingsMock.__get()).toEqual({
       binaryPath: realFile,
-      binaryVersion: "1.14.24",
+      binaryVersion: OPENCODE_PINNED_VERSION,
       binarySource: "managed",
     });
   });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -896,7 +896,7 @@ export const RESTRICTION_MESSAGES = {
     `${extension.toUpperCase()} files are not supported in the current mode.`,
 } as const;
 
-export const OPENCODE_PINNED_VERSION = "1.14.24";
+export const OPENCODE_PINNED_VERSION = "1.15.11";
 export const OPENCODE_RELEASE_TAG = `v${OPENCODE_PINNED_VERSION}`;
 export const OPENCODE_RELEASE_URL_TEMPLATE =
   "https://github.com/sst/opencode/releases/download/v{version}/{asset}";


### PR DESCRIPTION
Bumps `OPENCODE_PINNED_VERSION` from `1.14.24` to `1.15.11` (closes #59), the latest dogfood-baked `sst/opencode` release whose darwin-arm64, linux-x64, and windows-x64 CLI asset stems were verified against `platformResolver` candidates. Refactors `OpencodeBinaryManager.test.ts` to import `OPENCODE_PINNED_VERSION` so its fixtures and parser table no longer hard-code a version literal, making future bumps a single-line change in `constants.ts`. The install modal's confirm screen and all release URLs already derive from the constant, so no other edits are needed. Verified with `npm run test` (3196 passing), `npm run format`, and `npm run lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)