### PR TITLE
fix(agent-mode): auto-detect agent binaries under Node version managers

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -217,10 +217,17 @@ export default [
   // SDK uses node:async_hooks. The plugin runs in Electron renderer where
   // these modules are available; the desktop-only Agent Mode is also gated by
   // `Platform.isMobile` at runtime in main.ts.
-  // detectBinary / rendererEventsShim are sibling utilities pulled in by
-  // agent-mode wiring and share the same Electron-renderer assumptions.
+  // detectBinary / binaryPath / nodeToolBinDirs / rendererEventsShim are
+  // sibling utilities pulled in by agent-mode wiring and share the same
+  // Electron-renderer assumptions.
   {
-    files: ["src/agentMode/**", "src/utils/detectBinary.ts", "src/utils/rendererEventsShim.ts"],
+    files: [
+      "src/agentMode/**",
+      "src/utils/detectBinary.ts",
+      "src/utils/binaryPath.ts",
+      "src/utils/nodeToolBinDirs.ts",
+      "src/utils/rendererEventsShim.ts",
+    ],
     rules: {
       "import/no-nodejs-modules": "off",
     },

--- a/src/agentMode/acp/nodeShebangPath.ts
+++ b/src/agentMode/acp/nodeShebangPath.ts
@@ -1,6 +1,6 @@
 import * as path from "node:path";
 
-import { WELL_KNOWN_BIN_DIRS, mergePath } from "@/utils/binaryPath";
+import { detectionSearchDirs, mergePath } from "@/utils/binaryPath";
 
 /**
  * macOS GUI apps (Obsidian) inherit a minimal PATH that omits Homebrew and
@@ -9,12 +9,15 @@ import { WELL_KNOWN_BIN_DIRS, mergePath } from "@/utils/binaryPath";
  * unless we put `node` on PATH ourselves.
  *
  * Prepend the directory containing the binary (npm globals install the
- * launcher script next to `node`) plus the well-known Homebrew / system
- * prefixes, then keep the inherited PATH for everything else.
+ * launcher script next to `node`) plus the same version-manager and
+ * well-known dirs detection searches, then keep the inherited PATH for
+ * everything else. Reusing {@link detectionSearchDirs} keeps spawn-time and
+ * detect-time PATH in lockstep: a binary detected under nvm/fnm/asdf spawns
+ * with that same version manager's `node` resolvable.
  */
 export function augmentPathForNodeShebang(
   binaryPath: string,
   inherited: string | undefined
 ): string {
-  return mergePath([path.dirname(binaryPath), ...WELL_KNOWN_BIN_DIRS], inherited);
+  return mergePath([path.dirname(binaryPath), ...detectionSearchDirs()], inherited);
 }

--- a/src/agentMode/backends/claude/claudeBinaryResolver.test.ts
+++ b/src/agentMode/backends/claude/claudeBinaryResolver.test.ts
@@ -6,13 +6,20 @@ import {
 
 function makeFs(
   paths: Iterable<string>,
-  contents: Record<string, string> = {}
+  contents: Record<string, string> = {},
+  listings: Record<string, string[]> = {}
 ): ClaudeBinaryResolverFs {
   const set = new Set(paths);
   return {
     existsSync: (p: string) => set.has(p),
     readFileSync: (p: string) => {
       if (p in contents) return contents[p];
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${p}`);
+      err.code = "ENOENT";
+      throw err;
+    },
+    readdirSync: (p: string) => {
+      if (p in listings) return listings[p];
       const err: NodeJS.ErrnoException = new Error(`ENOENT: ${p}`);
       err.code = "ENOENT";
       throw err;
@@ -94,15 +101,41 @@ describe("resolveClaudeBinary — Unix", () => {
   it("falls back to NVM default alias when no other candidate exists", () => {
     const aliasPath = "/home/me/.nvm/alias/default";
     const claudePath = "/home/me/.nvm/versions/node/v20.11.0/bin/claude";
-    const fs = makeFs([aliasPath, claudePath], { [aliasPath]: "v20.11.0\n" });
+    const fs = makeFs(
+      [aliasPath, claudePath],
+      { [aliasPath]: "v20.11.0\n" },
+      { "/home/me/.nvm/versions/node": ["v20.11.0"] }
+    );
     expect(resolveClaudeBinary(unixInput(fs))).toBe(claudePath);
   });
 
   it("accepts NVM alias contents without the leading 'v'", () => {
     const aliasPath = "/home/me/.nvm/alias/default";
     const claudePath = "/home/me/.nvm/versions/node/v18.19.0/bin/claude";
-    const fs = makeFs([aliasPath, claudePath], { [aliasPath]: "18.19.0" });
+    const fs = makeFs(
+      [aliasPath, claudePath],
+      { [aliasPath]: "18.19.0" },
+      { "/home/me/.nvm/versions/node": ["v18.19.0"] }
+    );
     expect(resolveClaudeBinary(unixInput(fs))).toBe(claudePath);
+  });
+
+  it("finds claude under a non-default nvm version via enumeration", () => {
+    // `nvm use 20 && npm i -g @anthropic-ai/claude-code` with the default still 18.
+    const claudePath = "/home/me/.nvm/versions/node/v20.18.0/bin/claude";
+    const fs = makeFs(
+      [claudePath],
+      {},
+      { "/home/me/.nvm/versions/node": ["v18.20.0", "v20.18.0"] }
+    );
+    expect(resolveClaudeBinary(unixInput(fs))).toBe(claudePath);
+  });
+
+  it("finds claude under an fnm-managed Node", () => {
+    const base = "/home/me/Library/Application Support/fnm/node-versions";
+    const claudePath = `${base}/v20.18.0/installation/bin/claude`;
+    const fs = makeFs([claudePath], {}, { [base]: ["v20.18.0"] });
+    expect(resolveClaudeBinary(unixInput(fs, { platform: "darwin" }))).toBe(claudePath);
   });
 
   it("returns null when NVM alias is unparseable (e.g. 'lts/*')", () => {

--- a/src/agentMode/backends/claude/claudeBinaryResolver.ts
+++ b/src/agentMode/backends/claude/claudeBinaryResolver.ts
@@ -3,22 +3,26 @@
  * `pathToClaudeCodeExecutable`. The SDK's auto-discovery walks
  * `import.meta.url`, which fails inside Obsidian's bundled `main.js`.
  *
+ * Directory discovery is shared with the generic backend detector via
+ * {@link nodeToolBinDirCandidates} (nvm/fnm/Volta/asdf/n/npm-global); this
+ * resolver only layers on the Claude-specific filenames and package fallbacks.
+ *
  * Pure leaf: callers inject `homeDir`, `platform`, `env`, and `fs` so tests
  * don't touch real disk.
  */
 import * as path from "node:path";
 
-export interface ClaudeBinaryResolverFs {
-  existsSync: (path: string) => boolean;
-  readFileSync: (path: string, encoding: "utf8") => string;
-}
+import { WELL_KNOWN_BIN_DIRS } from "@/utils/binaryPath";
+import { nodeToolBinDirCandidates, type NodeToolFs } from "@/utils/nodeToolBinDirs";
+
+export type ClaudeBinaryResolverFs = NodeToolFs;
 
 export interface ClaudeBinaryResolverInput {
   /** User-configured override path. If set and exists, returned as-is. */
   override?: string;
   homeDir: string;
   platform: NodeJS.Platform;
-  env: { NVM_BIN?: string; npm_config_prefix?: string; APPDATA?: string };
+  env: NodeJS.ProcessEnv;
   fs: ClaudeBinaryResolverFs;
 }
 
@@ -44,19 +48,14 @@ const posix = path.posix;
 const win = path.win32;
 
 function unixCandidates(input: ClaudeBinaryResolverInput): Array<string | null> {
-  const { homeDir, env, fs } = input;
+  const { homeDir, env } = input;
+  // Every bin dir a Node version manager / npm-global install might use, plus
+  // the well-known system prefixes — then `claude` under each.
+  const dirs = [...nodeToolBinDirCandidates(input), ...WELL_KNOWN_BIN_DIRS];
   return [
     posix.join(homeDir, ".claude", "local", "claude"),
-    posix.join(homeDir, ".local", "bin", "claude"),
-    posix.join(homeDir, ".volta", "bin", "claude"),
-    posix.join(homeDir, ".asdf", "shims", "claude"),
-    posix.join(homeDir, ".asdf", "bin", "claude"),
-    "/usr/local/bin/claude",
-    "/opt/homebrew/bin/claude",
-    posix.join(homeDir, ".npm-global", "bin", "claude"),
-    env.npm_config_prefix ? posix.join(env.npm_config_prefix, "bin", "claude") : null,
-    env.NVM_BIN ? posix.join(env.NVM_BIN, "claude") : null,
-    resolveNvmDefaultClaude(homeDir, fs),
+    ...dirs.map((dir) => posix.join(dir, "claude")),
+    // `npm i -g @anthropic-ai/claude-code` package fallbacks (no `bin` shim).
     posix.join(
       homeDir,
       ".npm-global",
@@ -82,42 +81,13 @@ function unixCandidates(input: ClaudeBinaryResolverInput): Array<string | null> 
 }
 
 function windowsCandidates(input: ClaudeBinaryResolverInput): Array<string | null> {
-  const { homeDir, env } = input;
   // Per-dir, prefer `claude.exe`, then `cli.js` under that dir's
   // node_modules. Never pick `claude.cmd` — it requires `shell: true` and
   // breaks SDK stdio streaming.
-  const dirs = [
-    env.APPDATA ? win.join(env.APPDATA, "npm") : null,
-    env.npm_config_prefix ?? null,
-    win.join(homeDir, "AppData", "Roaming", "npm"),
-  ];
   const out: Array<string | null> = [];
-  for (const dir of dirs) {
-    if (!dir) continue;
+  for (const dir of nodeToolBinDirCandidates(input)) {
     out.push(win.join(dir, "claude.exe"));
     out.push(win.join(dir, "node_modules", "@anthropic-ai", "claude-code", "cli.js"));
   }
   return out;
-}
-
-/**
- * NVM doesn't export `NVM_BIN` to GUI applications on macOS, so reading
- * `~/.nvm/alias/default` is the most reliable way to find the user's default
- * Node install. The file may contain `vX.Y.Z`, `X.Y.Z`, or an unresolvable
- * alias like `lts/*` — the latter we silently skip.
- */
-function resolveNvmDefaultClaude(homeDir: string, fs: ClaudeBinaryResolverFs): string | null {
-  const aliasPath = posix.join(homeDir, ".nvm", "alias", "default");
-  let raw: string;
-  try {
-    raw = fs.readFileSync(aliasPath, "utf8");
-  } catch {
-    return null;
-  }
-  const trimmed = raw.trim();
-  if (!trimmed) return null;
-  const versionPattern = /^v?\d+\.\d+\.\d+/;
-  if (!versionPattern.test(trimmed)) return null;
-  const version = trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
-  return posix.join(homeDir, ".nvm", "versions", "node", version, "bin", "claude");
 }

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -57,21 +57,19 @@ const claudeWire: ModelWireCodec = {
 
 /**
  * Build the environment input shared by both override-aware resolution and
- * fresh auto-detection. Pulls `os.homedir()`, `process.platform`, and a
- * minimal env subset that the resolver consults for Volta/NVM/npm-global.
+ * fresh auto-detection. Pulls `os.homedir()`, `process.platform`, the full
+ * `process.env` (the shared dir resolver reads NVM/FNM/asdf/Volta/n/npm vars),
+ * and real `fs` accessors.
  */
 function claudeResolverEnv(): Omit<Parameters<typeof resolveClaudeBinary>[0], "override"> {
   return {
     homeDir: os.homedir(),
     platform: process.platform,
-    env: {
-      NVM_BIN: process.env.NVM_BIN,
-      npm_config_prefix: process.env.npm_config_prefix,
-      APPDATA: process.env.APPDATA,
-    },
+    env: process.env,
     fs: {
       existsSync: (p) => fs.existsSync(p),
       readFileSync: (p, encoding) => fs.readFileSync(p, encoding),
+      readdirSync: (p) => fs.readdirSync(p),
     },
   };
 }

--- a/src/agentMode/backends/shared/BinaryPathSetting.tsx
+++ b/src/agentMode/backends/shared/BinaryPathSetting.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { logError } from "@/logger";
+import { detectionSearchDirs } from "@/utils/binaryPath";
 import { detectBinary } from "@/utils/detectBinary";
 import { Notice } from "obsidian";
 import React from "react";
@@ -22,6 +23,12 @@ interface Props {
    * {@link detectBinary} when omitted.
    */
   detect?: () => Promise<string | null>;
+  /**
+   * Directories the detector searched, listed under the "not found" hint so
+   * users can self-diagnose. Defaults to {@link detectionSearchDirs} (what the
+   * generic `which`/`where` path actually searches) when omitted.
+   */
+  searchedDirs?: () => string[];
 }
 
 /**
@@ -39,9 +46,11 @@ export const BinaryPathSetting: React.FC<Props> = ({
   onSave,
   persistOnAutoDetect = false,
   detect,
+  searchedDirs,
 }) => {
   const [pathInput, setPathInput] = React.useState(initialPath);
   const [error, setError] = React.useState<string | null>(null);
+  const [searched, setSearched] = React.useState<string[]>([]);
   const [busy, setBusy] = React.useState(false);
 
   React.useEffect(() => {
@@ -61,12 +70,14 @@ export const BinaryPathSetting: React.FC<Props> = ({
       return;
     }
     setError(null);
+    setSearched([]);
   }, [pathInput, onSave]);
 
   const autoDetect = React.useCallback(async (): Promise<void> => {
     if (busy) return;
     setBusy(true);
     setError(null);
+    setSearched([]);
     try {
       const found = detect ? await detect() : await detectBinary(binaryName);
       if (!found) {
@@ -74,6 +85,9 @@ export const BinaryPathSetting: React.FC<Props> = ({
           notFoundHint ??
             `${binaryName} not found on PATH. Install it or paste a custom path manually.`
         );
+        // Without a custom detector we know exactly which dirs were searched.
+        const dirs = searchedDirs ?? (detect ? undefined : detectionSearchDirs);
+        setSearched(dirs?.() ?? []);
         return;
       }
       setPathInput(found);
@@ -91,7 +105,7 @@ export const BinaryPathSetting: React.FC<Props> = ({
     } finally {
       setBusy(false);
     }
-  }, [binaryName, busy, notFoundHint, onSave, persistOnAutoDetect, detect]);
+  }, [binaryName, busy, notFoundHint, onSave, persistOnAutoDetect, detect, searchedDirs]);
 
   return (
     <div className="tw-flex tw-w-full tw-flex-col tw-gap-2">
@@ -110,7 +124,21 @@ export const BinaryPathSetting: React.FC<Props> = ({
           Apply
         </Button>
       </div>
-      {error && <div className="tw-text-sm tw-text-error">{error}</div>}
+      {error && (
+        <div className="tw-flex tw-flex-col tw-gap-1 tw-text-sm tw-text-error">
+          <span>{error}</span>
+          {searched.length > 0 && (
+            <div className="tw-text-muted">
+              <span>Searched:</span>
+              <ul className="tw-my-0 tw-pl-4">
+                {searched.map((dir) => (
+                  <li key={dir}>{dir}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/utils/binaryPath.test.ts
+++ b/src/utils/binaryPath.test.ts
@@ -1,4 +1,19 @@
-import { augmentPathForDetection, mergePath, WELL_KNOWN_BIN_DIRS } from "./binaryPath";
+import { resolveNodeToolBinDirs } from "@/utils/nodeToolBinDirs";
+
+import {
+  augmentPathForDetection,
+  detectionSearchDirs,
+  mergePath,
+  WELL_KNOWN_BIN_DIRS,
+} from "./binaryPath";
+
+// Isolate binaryPath's merging/ordering from the live version-manager probe;
+// the resolver's own behavior is covered in nodeToolBinDirs.test.ts.
+jest.mock("@/utils/nodeToolBinDirs", () => ({ resolveNodeToolBinDirs: jest.fn(() => []) }));
+
+const resolveMock = resolveNodeToolBinDirs as jest.MockedFunction<typeof resolveNodeToolBinDirs>;
+
+afterEach(() => resolveMock.mockReturnValue([]));
 
 describe("mergePath", () => {
   test("prepends candidates and dedupes against inherited PATH", () => {
@@ -17,6 +32,17 @@ describe("mergePath", () => {
   });
 });
 
+describe("detectionSearchDirs", () => {
+  test("lists version-manager bins ahead of the well-known dirs", () => {
+    const nvmBin = "/home/me/.nvm/versions/node/v20.18.0/bin";
+    resolveMock.mockReturnValue([nvmBin]);
+    const dirs = detectionSearchDirs();
+    expect(dirs[0]).toBe(nvmBin);
+    expect(dirs.indexOf(nvmBin)).toBeLessThan(dirs.indexOf("/opt/homebrew/bin"));
+    expect(dirs).toEqual([nvmBin, ...WELL_KNOWN_BIN_DIRS]);
+  });
+});
+
 describe("augmentPathForDetection", () => {
   test("prepends all well-known dirs ahead of the inherited PATH", () => {
     const result = augmentPathForDetection("/usr/bin:/bin");
@@ -26,6 +52,14 @@ describe("augmentPathForDetection", () => {
     }
     // Homebrew must come before whatever launchd already had.
     expect(parts.indexOf("/opt/homebrew/bin")).toBeLessThan(parts.indexOf("/usr/bin"));
+  });
+
+  test("prepends a discovered version-manager dir ahead of the inherited PATH", () => {
+    const nvmBin = "/home/me/.nvm/versions/node/v20.18.0/bin";
+    resolveMock.mockReturnValue([nvmBin]);
+    const parts = augmentPathForDetection("/usr/bin:/bin:/usr/sbin:/sbin").split(":");
+    expect(parts[0]).toBe(nvmBin);
+    expect(parts.indexOf(nvmBin)).toBeLessThan(parts.indexOf("/usr/bin"));
   });
 
   test("covers the sparse launchd PATH that triggers the bug", () => {

--- a/src/utils/binaryPath.ts
+++ b/src/utils/binaryPath.ts
@@ -1,3 +1,8 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+
+import { resolveNodeToolBinDirs } from "@/utils/nodeToolBinDirs";
+
 /**
  * Well-known POSIX install prefixes that macOS GUI apps' inherited PATH
  * typically omits. Shared between spawn-time PATH augmentation (so
@@ -36,11 +41,47 @@ export function mergePath(candidates: readonly string[], inherited: string | und
 }
 
 /**
+ * Read the live Node version-manager bin dirs (nvm/fnm/Volta/asdf/n/npm-global)
+ * from the real environment + filesystem. Shared by detect-time and spawn-time
+ * PATH augmentation so a binary found under e.g. nvm also spawns with the same
+ * nvm `node` on PATH.
+ */
+function nodeToolBinDirs(): string[] {
+  return resolveNodeToolBinDirs({
+    homeDir: os.homedir(),
+    platform: process.platform,
+    env: process.env,
+    fs: {
+      existsSync: (p) => fs.existsSync(p),
+      readFileSync: (p, encoding) => fs.readFileSync(p, encoding),
+      readdirSync: (p) => fs.readdirSync(p),
+    },
+  });
+}
+
+/**
+ * Directories searched during detection, in priority order: version-manager
+ * bins ahead of {@link WELL_KNOWN_BIN_DIRS}. Surfaced in the UI's "not found"
+ * hint so users can see where we actually looked. Spawn-time augmentation
+ * (`augmentPathForNodeShebang`) reuses this so detect-time and spawn-time PATH
+ * stay in lockstep.
+ *
+ * {@link WELL_KNOWN_BIN_DIRS} are POSIX prefixes that never resolve on Windows,
+ * so they're omitted there — otherwise they'd only clutter the Windows PATH and
+ * mislead the "Searched:" hint with `/usr/bin`-style paths.
+ */
+export function detectionSearchDirs(): string[] {
+  const wellKnown = process.platform === "win32" ? [] : WELL_KNOWN_BIN_DIRS;
+  return [...nodeToolBinDirs(), ...wellKnown];
+}
+
+/**
  * Augment PATH for the *detection* step, where we don't yet know the
- * binary's location. Prepends {@link WELL_KNOWN_BIN_DIRS} to the inherited
- * PATH so `which <name>` invoked from a macOS GUI app finds Homebrew /
- * `/usr/local/bin` installs that `launchd`'s sparse default PATH omits.
+ * binary's location. Prepends the live version-manager bin dirs and
+ * {@link WELL_KNOWN_BIN_DIRS} to the inherited PATH so `which`/`where` invoked
+ * from a macOS GUI app finds Homebrew, npm-global, and nvm/fnm/asdf/Volta
+ * installs that `launchd`'s sparse default PATH omits.
  */
 export function augmentPathForDetection(inherited: string | undefined): string {
-  return mergePath(WELL_KNOWN_BIN_DIRS, inherited);
+  return mergePath(detectionSearchDirs(), inherited);
 }

--- a/src/utils/detectBinary.test.ts
+++ b/src/utils/detectBinary.test.ts
@@ -117,6 +117,22 @@ describe("detectBinary", () => {
     await expect(detectBinary("codex-acp")).resolves.toBeNull();
   });
 
+  test("windows: prefers the .exe over a sibling extensionless cmd-shim", async () => {
+    setPlatform("win32");
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+      cb(null, "C:\\npm\\codex-acp\r\nC:\\npm\\codex-acp.exe\r\n", "")
+    );
+    await expect(detectBinary("codex-acp")).resolves.toBe("C:\\npm\\codex-acp.exe");
+  });
+
+  test("windows: treats an extensionless cmd-shim-only result as not found", async () => {
+    setPlatform("win32");
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+      cb(null, "C:\\npm\\codex-acp\r\nC:\\npm\\codex-acp.ps1\r\n", "")
+    );
+    await expect(detectBinary("codex-acp")).resolves.toBeNull();
+  });
+
   test("returns null when the lookup tool exits non-zero", async () => {
     setPlatform("darwin");
     execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>

--- a/src/utils/detectBinary.test.ts
+++ b/src/utils/detectBinary.test.ts
@@ -2,6 +2,10 @@ import { promisify } from "node:util";
 
 import { detectBinary } from "./detectBinary";
 
+// Keep the augmented PATH deterministic across CI/dev machines; the live
+// version-manager probe is covered in nodeToolBinDirs.test.ts.
+jest.mock("@/utils/nodeToolBinDirs", () => ({ resolveNodeToolBinDirs: jest.fn(() => []) }));
+
 type ExecFileCallback = (err: Error | null, stdout: string, stderr: string) => void;
 type ExecFileArgs = [
   string,
@@ -78,7 +82,7 @@ describe("detectBinary", () => {
     expect(pathParts.indexOf("/opt/homebrew/bin")).toBeLessThan(pathParts.indexOf("/usr/bin"));
   });
 
-  test("windows: leaves PATH untouched and calls `where`", async () => {
+  test("windows: augments PATH and calls `where`", async () => {
     setPlatform("win32");
     process.env.PATH = "C:\\Windows\\System32;C:\\Windows";
 
@@ -91,8 +95,26 @@ describe("detectBinary", () => {
 
     const [cmd, , opts] = execFileMock.mock.calls[0];
     expect(cmd).toBe("where");
-    // On Windows we hand the inherited env through unchanged.
-    expect(opts.env).toBe(process.env);
+    // A fresh env object (not process.env) with an augmented PATH, so the
+    // GUI-app sparse PATH still reaches %APPDATA%\npm etc.
+    expect(opts.env).not.toBe(process.env);
+    expect(opts.env?.PATH).toContain("C:\\Windows\\System32");
+  });
+
+  test("windows: prefers the .exe over a sibling .cmd shim", async () => {
+    setPlatform("win32");
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+      cb(null, "C:\\npm\\codex-acp.cmd\r\nC:\\npm\\codex-acp.exe\r\n", "")
+    );
+    await expect(detectBinary("codex-acp")).resolves.toBe("C:\\npm\\codex-acp.exe");
+  });
+
+  test("windows: treats a .cmd-only result as not found (unspawnable over stdio)", async () => {
+    setPlatform("win32");
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+      cb(null, "C:\\npm\\codex-acp.cmd\r\nC:\\npm\\codex-acp.ps1\r\n", "")
+    );
+    await expect(detectBinary("codex-acp")).resolves.toBeNull();
   });
 
   test("returns null when the lookup tool exits non-zero", async () => {

--- a/src/utils/detectBinary.ts
+++ b/src/utils/detectBinary.ts
@@ -28,12 +28,16 @@ const BINARY_NAME_PATTERN = /^[A-Za-z0-9._+-]+$/;
  * than parsing `PATH` ourselves so we honor the user's shell-equivalent
  * resolution rules (PATHEXT on Windows, symlink chasing, etc.).
  *
- * On POSIX we augment PATH with well-known install prefixes before invoking
- * `which`. macOS GUI apps (Obsidian launched from Finder/Dock) inherit a
- * sparse `launchd` PATH that omits `/opt/homebrew/bin` and `/usr/local/bin`,
- * so user-installed binaries (Homebrew, `npm install -g`) would otherwise
- * fail to detect. Windows GUI apps inherit the system PATH and don't need
- * this.
+ * We augment PATH with well-known install prefixes and live version-manager
+ * bin dirs before invoking the lookup. macOS GUI apps (Obsidian launched from
+ * Finder/Dock) inherit a sparse `launchd` PATH that omits `/opt/homebrew/bin`
+ * and nvm/fnm/asdf/Volta dirs; Windows GUI apps similarly miss `%APPDATA%\npm`,
+ * so user-installed binaries (Homebrew, `npm install -g`, version managers)
+ * would otherwise fail to detect.
+ *
+ * On Windows we drop `.cmd`/`.bat`/`.ps1` matches and prefer `.exe`: ACP
+ * backends spawn over stdio without `shell: true`, where a `.cmd` shim can't
+ * launch and breaks stdio streaming (same rule as `claudeBinaryResolver.ts`).
  */
 export async function detectBinary(name: string): Promise<string | null> {
   if (!BINARY_NAME_PATTERN.test(name)) {
@@ -41,19 +45,30 @@ export async function detectBinary(name: string): Promise<string | null> {
   }
   const isWindows = process.platform === "win32";
   const cmd = isWindows ? "where" : "which";
-  const env = isWindows
-    ? process.env
-    : { ...process.env, PATH: augmentPathForDetection(process.env.PATH) };
+  const env = { ...process.env, PATH: augmentPathForDetection(process.env.PATH) };
   try {
     const { stdout } = await execFileAsync(cmd, [name], { timeout: 5000, env });
-    const first = stdout
+    const matches = stdout
       .split(/\r?\n/)
       .map((s) => s.trim())
-      .find(Boolean);
-    return first ?? null;
+      .filter(Boolean);
+    return isWindows ? pickWindowsExecutable(matches) : (matches[0] ?? null);
   } catch {
     return null;
   }
+}
+
+/**
+ * Pick the first stdio-spawnable match from `where` output. Drops `.cmd` /
+ * `.bat` / `.ps1` shims (they require `shell: true` and break stdio) and
+ * prefers a native `.exe`. Returns null — i.e. treat as not-found — when only
+ * an unspawnable shim exists, rather than handing back a path that fails to
+ * launch.
+ */
+function pickWindowsExecutable(matches: string[]): string | null {
+  const spawnable = matches.filter((m) => !/\.(cmd|bat|ps1)$/i.test(m));
+  const exe = spawnable.find((m) => /\.exe$/i.test(m));
+  return exe ?? spawnable[0] ?? null;
 }
 
 /**

--- a/src/utils/detectBinary.ts
+++ b/src/utils/detectBinary.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { promisify } from "node:util";
 
 import { augmentPathForDetection } from "@/utils/binaryPath";
@@ -35,9 +36,10 @@ const BINARY_NAME_PATTERN = /^[A-Za-z0-9._+-]+$/;
  * so user-installed binaries (Homebrew, `npm install -g`, version managers)
  * would otherwise fail to detect.
  *
- * On Windows we drop `.cmd`/`.bat`/`.ps1` matches and prefer `.exe`: ACP
- * backends spawn over stdio without `shell: true`, where a `.cmd` shim can't
- * launch and breaks stdio streaming (same rule as `claudeBinaryResolver.ts`).
+ * On Windows we drop `.cmd`/`.bat`/`.ps1` and extensionless matches and prefer
+ * `.exe`: ACP backends spawn over stdio without `shell: true`, where a `.cmd`
+ * shim can't launch and breaks stdio streaming (same rule as
+ * `claudeBinaryResolver.ts`).
  */
 export async function detectBinary(name: string): Promise<string | null> {
   if (!BINARY_NAME_PATTERN.test(name)) {
@@ -61,12 +63,16 @@ export async function detectBinary(name: string): Promise<string | null> {
 /**
  * Pick the first stdio-spawnable match from `where` output. Drops `.cmd` /
  * `.bat` / `.ps1` shims (they require `shell: true` and break stdio) and
- * prefers a native `.exe`. Returns null — i.e. treat as not-found — when only
- * an unspawnable shim exists, rather than handing back a path that fails to
- * launch.
+ * prefers a native `.exe`. Also drops extensionless matches: npm's cmd-shim
+ * writes a `#!/bin/sh` POSIX shim with no extension alongside the `.cmd`/`.ps1`
+ * pair, and `child_process.spawn` (no shell) can't launch that either. Returns
+ * null — i.e. treat as not-found — when only an unspawnable shim exists, rather
+ * than handing back a path that fails to launch.
  */
 function pickWindowsExecutable(matches: string[]): string | null {
-  const spawnable = matches.filter((m) => !/\.(cmd|bat|ps1)$/i.test(m));
+  const spawnable = matches.filter(
+    (m) => !/\.(cmd|bat|ps1)$/i.test(m) && path.win32.extname(m) !== ""
+  );
   const exe = spawnable.find((m) => /\.exe$/i.test(m));
   return exe ?? spawnable[0] ?? null;
 }

--- a/src/utils/nodeToolBinDirs.test.ts
+++ b/src/utils/nodeToolBinDirs.test.ts
@@ -1,0 +1,207 @@
+import { resolveNodeToolBinDirs } from "@/utils/nodeToolBinDirs";
+import type { NodeToolBinDirsInput, NodeToolFs } from "@/utils/nodeToolBinDirs";
+
+/**
+ * Fake fs: `dirs` are the directories that exist (`existsSync`), `files` maps
+ * a readable file path to its contents (`readFileSync`), and `listings` maps a
+ * directory to its `readdirSync` entries. Anything unlisted throws ENOENT,
+ * mirroring real `fs`.
+ */
+function makeFs(opts: {
+  dirs?: Iterable<string>;
+  files?: Record<string, string>;
+  listings?: Record<string, string[]>;
+}): NodeToolFs {
+  const dirs = new Set(opts.dirs ?? []);
+  const files = opts.files ?? {};
+  const listings = opts.listings ?? {};
+  return {
+    existsSync: (p) => dirs.has(p),
+    readFileSync: (p) => {
+      if (p in files) return files[p];
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${p}`);
+      err.code = "ENOENT";
+      throw err;
+    },
+    readdirSync: (p) => {
+      if (p in listings) return listings[p];
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${p}`);
+      err.code = "ENOENT";
+      throw err;
+    },
+  };
+}
+
+function unixInput(overrides: Partial<NodeToolBinDirsInput> = {}): NodeToolBinDirsInput {
+  return {
+    homeDir: "/home/me",
+    platform: "linux",
+    env: {},
+    fs: makeFs({}),
+    ...overrides,
+  };
+}
+
+describe("resolveNodeToolBinDirs (unix)", () => {
+  test("returns NVM_BIN when set and present", () => {
+    const dir = "/home/me/.nvm/versions/node/v20.18.0/bin";
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({ env: { NVM_BIN: dir }, fs: makeFs({ dirs: [dir] }) })
+    );
+    expect(dirs).toContain(dir);
+  });
+
+  test("resolves the nvm default alias to its version's bin dir", () => {
+    const versions = "/home/me/.nvm/versions/node";
+    const v20 = `${versions}/v20.18.0/bin`;
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        fs: makeFs({
+          dirs: [v20, `${versions}/v18.20.0/bin`],
+          files: { "/home/me/.nvm/alias/default": "20\n" },
+          listings: { [versions]: ["v18.20.0", "v20.18.0"] },
+        }),
+      })
+    );
+    expect(dirs).toContain(v20);
+  });
+
+  test("follows nvm alias chains (default -> lts/* -> version)", () => {
+    const versions = "/home/me/.nvm/versions/node";
+    const v18 = `${versions}/v18.20.0/bin`;
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        fs: makeFs({
+          dirs: [v18],
+          files: {
+            "/home/me/.nvm/alias/default": "lts/*",
+            "/home/me/.nvm/alias/lts/*": "lts/hydrogen",
+            "/home/me/.nvm/alias/lts/hydrogen": "v18.20.0",
+          },
+          listings: { [versions]: ["v18.20.0"] },
+        }),
+      })
+    );
+    expect(dirs).toContain(v18);
+  });
+
+  test("enumerates every installed nvm version newest-first, default first", () => {
+    const versions = "/home/me/.nvm/versions/node";
+    const v18 = `${versions}/v18.20.0/bin`;
+    const v20 = `${versions}/v20.18.0/bin`;
+    const v22 = `${versions}/v22.1.0/bin`;
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        fs: makeFs({
+          dirs: [v18, v20, v22],
+          files: { "/home/me/.nvm/alias/default": "18" },
+          listings: { [versions]: ["v18.20.0", "v20.18.0", "v22.1.0"] },
+        }),
+      })
+    );
+    // Default (v18) wins, then the rest sorted newest-first.
+    expect(dirs).toEqual([v18, v22, v20]);
+  });
+
+  test("ignores an unparseable nvm default alias but still enumerates versions", () => {
+    const versions = "/home/me/.nvm/versions/node";
+    const v20 = `${versions}/v20.18.0/bin`;
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        fs: makeFs({
+          dirs: [v20],
+          files: { "/home/me/.nvm/alias/default": "lts/argon" }, // not installed
+          listings: { [versions]: ["v20.18.0"] },
+        }),
+      })
+    );
+    expect(dirs).toEqual([v20]);
+  });
+
+  test("honors $NVM_DIR over the default ~/.nvm location", () => {
+    const versions = "/opt/nvm/versions/node";
+    const v20 = `${versions}/v20.18.0/bin`;
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        env: { NVM_DIR: "/opt/nvm" },
+        fs: makeFs({ dirs: [v20], listings: { [versions]: ["v20.18.0"] } }),
+      })
+    );
+    expect(dirs).toContain(v20);
+  });
+
+  test("finds fnm's active multishell bin", () => {
+    const bin = "/run/fnm/abc/bin";
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({ env: { FNM_MULTISHELL_PATH: "/run/fnm/abc" }, fs: makeFs({ dirs: [bin] }) })
+    );
+    expect(dirs).toContain(bin);
+  });
+
+  test("enumerates fnm node-versions under the macOS base dir", () => {
+    const base = "/home/me/Library/Application Support/fnm/node-versions";
+    const v20 = `${base}/v20.18.0/installation/bin`;
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        platform: "darwin",
+        fs: makeFs({ dirs: [v20], listings: { [base]: ["v20.18.0"] } }),
+      })
+    );
+    expect(dirs).toContain(v20);
+  });
+
+  test("finds asdf shims, Volta, n, and npm_config_prefix bins", () => {
+    const shims = "/home/me/.asdf/shims";
+    const volta = "/home/me/.volta/bin";
+    const nbin = "/usr/local/n/bin";
+    const npmPrefix = "/home/me/.npm-global/custom/bin";
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        env: { N_PREFIX: "/usr/local/n", npm_config_prefix: "/home/me/.npm-global/custom" },
+        fs: makeFs({ dirs: [shims, volta, nbin, npmPrefix] }),
+      })
+    );
+    expect(dirs).toEqual(expect.arrayContaining([shims, volta, nbin, npmPrefix]));
+  });
+
+  test("drops candidate dirs that do not exist", () => {
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({ env: { VOLTA_HOME: "/home/me/.volta" }, fs: makeFs({ dirs: [] }) })
+    );
+    expect(dirs).toEqual([]);
+  });
+
+  test("~/.local/bin is included when present", () => {
+    const local = "/home/me/.local/bin";
+    const dirs = resolveNodeToolBinDirs(unixInput({ fs: makeFs({ dirs: [local] }) }));
+    expect(dirs).toContain(local);
+  });
+});
+
+describe("resolveNodeToolBinDirs (windows)", () => {
+  function winInput(overrides: Partial<NodeToolBinDirsInput> = {}): NodeToolBinDirsInput {
+    return {
+      homeDir: "C:\\Users\\me",
+      platform: "win32",
+      env: {},
+      fs: makeFs({}),
+      ...overrides,
+    };
+  }
+
+  test("finds the npm global dir under %APPDATA%", () => {
+    const npm = "C:\\Users\\me\\AppData\\Roaming\\npm";
+    const dirs = resolveNodeToolBinDirs(
+      winInput({ env: { APPDATA: "C:\\Users\\me\\AppData\\Roaming" }, fs: makeFs({ dirs: [npm] }) })
+    );
+    expect(dirs).toContain(npm);
+  });
+
+  test("finds the nvm-windows symlink dir", () => {
+    const symlink = "C:\\nvm4w\\nodejs";
+    const dirs = resolveNodeToolBinDirs(
+      winInput({ env: { NVM_SYMLINK: symlink }, fs: makeFs({ dirs: [symlink] }) })
+    );
+    expect(dirs).toContain(symlink);
+  });
+});

--- a/src/utils/nodeToolBinDirs.test.ts
+++ b/src/utils/nodeToolBinDirs.test.ts
@@ -164,6 +164,41 @@ describe("resolveNodeToolBinDirs (unix)", () => {
     expect(dirs).toEqual(expect.arrayContaining([shims, volta, nbin, npmPrefix]));
   });
 
+  test("prefers an existing ~/.asdf data dir over an ASDF_DIR install path", () => {
+    // Homebrew-style: ASDF_DIR points at the install dir, shims stay under the
+    // default ~/.asdf data dir. The install dir has no shims/bin of its own.
+    const shims = "/home/me/.asdf/shims";
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        env: { ASDF_DIR: "/opt/homebrew/opt/asdf/libexec" },
+        fs: makeFs({ dirs: [shims] }),
+      })
+    );
+    expect(dirs).toContain(shims);
+  });
+
+  test("honors ASDF_DATA_DIR over both ~/.asdf and ASDF_DIR", () => {
+    const shims = "/custom/asdf/shims";
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        env: { ASDF_DATA_DIR: "/custom/asdf", ASDF_DIR: "/opt/homebrew/opt/asdf/libexec" },
+        fs: makeFs({ dirs: [shims, "/home/me/.asdf/shims"] }),
+      })
+    );
+    expect(dirs).toContain(shims);
+  });
+
+  test("falls back to ASDF_DIR shims when no ~/.asdf data dir exists", () => {
+    const shims = "/opt/asdf/shims";
+    const dirs = resolveNodeToolBinDirs(
+      unixInput({
+        env: { ASDF_DIR: "/opt/asdf" },
+        fs: makeFs({ dirs: [shims] }),
+      })
+    );
+    expect(dirs).toContain(shims);
+  });
+
   test("drops candidate dirs that do not exist", () => {
     const dirs = resolveNodeToolBinDirs(
       unixInput({ env: { VOLTA_HOME: "/home/me/.volta" }, fs: makeFs({ dirs: [] }) })

--- a/src/utils/nodeToolBinDirs.ts
+++ b/src/utils/nodeToolBinDirs.ts
@@ -1,0 +1,237 @@
+/**
+ * Resolve the bin directories where Node-based CLI tools live under common
+ * version managers (nvm, fnm, Volta, asdf, n) and `npm install -g` prefixes.
+ *
+ * macOS GUI apps (Obsidian launched from Finder/Dock) inherit a sparse
+ * `launchd` PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that omits Homebrew and
+ * every version-manager `bin` dir, so neither `which <binary>` (detection) nor
+ * a `#!/usr/bin/env node` spawn can see them. This is the single source of
+ * truth for the extra directories both paths prepend, so detect-time and
+ * spawn-time PATH stay in lockstep.
+ *
+ * Deliberately a static, deterministic resolver rather than spawning a login
+ * shell to import the user's real PATH: no subprocess cost, no shell-choice
+ * ambiguity, no executing arbitrary user rc code.
+ *
+ * Pure leaf: callers inject `homeDir`, `platform`, `env`, and `fs` so tests
+ * don't touch real disk.
+ */
+import * as path from "node:path";
+
+export interface NodeToolFs {
+  existsSync: (p: string) => boolean;
+  readFileSync: (p: string, encoding: "utf8") => string;
+  readdirSync: (p: string) => string[];
+}
+
+export interface NodeToolBinDirsInput {
+  homeDir: string;
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  fs: NodeToolFs;
+}
+
+/**
+ * Ordered, deduped list of candidate bin directories — version-manager layouts
+ * that may or may not exist on disk. Earlier entries win during `which`/`where`
+ * resolution, so a version manager's "active" install is listed before its
+ * other versions. Callers that build PATH should use
+ * {@link resolveNodeToolBinDirs} (existence-filtered); callers that probe for a
+ * specific file under each dir (e.g. the Claude resolver) want this unfiltered
+ * list so a present binary is found even when its parent dir wasn't otherwise
+ * registered.
+ */
+export function nodeToolBinDirCandidates(input: NodeToolBinDirsInput): string[] {
+  const candidates = input.platform === "win32" ? windowsCandidates(input) : unixCandidates(input);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const dir of candidates) {
+    if (!dir || seen.has(dir)) continue;
+    seen.add(dir);
+    out.push(dir);
+  }
+  return out;
+}
+
+/**
+ * {@link nodeToolBinDirCandidates} filtered to directories that exist — the set
+ * to prepend to PATH for `which`/`where` and `#!/usr/bin/env node` spawns.
+ */
+export function resolveNodeToolBinDirs(input: NodeToolBinDirsInput): string[] {
+  return nodeToolBinDirCandidates(input).filter((dir) => dirExists(input.fs, dir));
+}
+
+function dirExists(fs: NodeToolFs, dir: string): boolean {
+  try {
+    return fs.existsSync(dir);
+  } catch {
+    return false;
+  }
+}
+
+function unixCandidates(input: NodeToolBinDirsInput): Array<string | null> {
+  const { homeDir, env, fs, platform } = input;
+  const p = path.posix;
+  const dirs: Array<string | null> = [];
+
+  // nvm — NVM_BIN (set only inside an interactive shell) plus the default and
+  // every installed version's bin dir, so a binary installed under a
+  // non-default version (`nvm use 20 && npm i -g ...`) is still found.
+  dirs.push(env.NVM_BIN ?? null);
+  const nvmDir = env.NVM_DIR ?? p.join(homeDir, ".nvm");
+  const nvmVersions = p.join(nvmDir, "versions", "node");
+  const nvmDefault = resolveNvmDefaultBin(nvmDir, nvmVersions, fs);
+  if (nvmDefault) dirs.push(nvmDefault);
+  dirs.push(...enumerateVersionBins(fs, nvmVersions, ["bin"], p));
+
+  // fnm — active shell's symlinked bin, then every installed version.
+  if (env.FNM_MULTISHELL_PATH) dirs.push(p.join(env.FNM_MULTISHELL_PATH, "bin"));
+  for (const base of fnmBaseDirs(homeDir, env, platform, p)) {
+    dirs.push(
+      ...enumerateVersionBins(fs, p.join(base, "node-versions"), ["installation", "bin"], p)
+    );
+  }
+
+  // Volta
+  dirs.push(env.VOLTA_HOME ? p.join(env.VOLTA_HOME, "bin") : p.join(homeDir, ".volta", "bin"));
+
+  // asdf — shims wrap every managed tool; bin is the asdf CLI itself.
+  const asdfRoot = env.ASDF_DATA_DIR ?? env.ASDF_DIR ?? p.join(homeDir, ".asdf");
+  dirs.push(p.join(asdfRoot, "shims"));
+  dirs.push(p.join(asdfRoot, "bin"));
+
+  // n — installs to $N_PREFIX (default /usr/local, already a well-known dir).
+  if (env.N_PREFIX) dirs.push(p.join(env.N_PREFIX, "bin"));
+
+  // npm global prefixes
+  if (env.npm_config_prefix) dirs.push(p.join(env.npm_config_prefix, "bin"));
+  dirs.push(p.join(homeDir, ".npm-global", "bin"));
+  dirs.push(p.join(homeDir, ".local", "bin"));
+
+  return dirs;
+}
+
+function windowsCandidates(input: NodeToolBinDirsInput): Array<string | null> {
+  const { homeDir, env } = input;
+  const p = path.win32;
+  const dirs: Array<string | null> = [];
+
+  // npm global (`npm i -g` drops shims here) — the most common GUI-app gap.
+  dirs.push(env.npm_config_prefix ?? null);
+  dirs.push(env.APPDATA ? p.join(env.APPDATA, "npm") : null);
+  dirs.push(p.join(homeDir, "AppData", "Roaming", "npm"));
+
+  // nvm-windows points the active version at a stable symlink.
+  dirs.push(env.NVM_SYMLINK ?? null);
+  dirs.push(env.NVM_HOME ?? null);
+
+  // fnm on Windows puts node.exe directly under the multishell dir (no /bin).
+  if (env.FNM_MULTISHELL_PATH) dirs.push(env.FNM_MULTISHELL_PATH);
+
+  // Volta
+  dirs.push(env.VOLTA_HOME ? p.join(env.VOLTA_HOME, "bin") : p.join(homeDir, ".volta", "bin"));
+
+  return dirs;
+}
+
+function fnmBaseDirs(
+  homeDir: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  p: path.PlatformPath
+): string[] {
+  if (env.FNM_DIR) return [env.FNM_DIR];
+  if (platform === "darwin") {
+    return [
+      p.join(homeDir, "Library", "Application Support", "fnm"),
+      p.join(homeDir, ".local", "share", "fnm"),
+    ];
+  }
+  return [p.join(homeDir, ".local", "share", "fnm")];
+}
+
+/**
+ * Read a version manager's `versions` directory and return the per-version bin
+ * dirs, newest-first (numeric sort). `subPath` is appended after the version
+ * folder (e.g. `["bin"]` for nvm, `["installation", "bin"]` for fnm).
+ */
+function enumerateVersionBins(
+  fs: NodeToolFs,
+  versionsDir: string,
+  subPath: string[],
+  p: path.PlatformPath
+): string[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(versionsDir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => /^v?\d/.test(e))
+    .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }))
+    .map((e) => p.join(versionsDir, e, ...subPath));
+}
+
+const NVM_LATEST_ALIASES = new Set(["node", "stable"]);
+
+/**
+ * Resolve nvm's `default` alias to a concrete version's bin dir. nvm doesn't
+ * export `NVM_BIN` to GUI children, so the alias file is the most reliable
+ * pointer to the user's chosen default. Aliases can chain (`default → lts/* →
+ * lts/hydrogen → vX.Y.Z`); unresolvable ones yield null.
+ */
+function resolveNvmDefaultBin(nvmDir: string, versionsDir: string, fs: NodeToolFs): string | null {
+  let alias: string;
+  try {
+    alias = fs.readFileSync(path.posix.join(nvmDir, "alias", "default"), "utf8").trim();
+  } catch {
+    return null;
+  }
+  if (!alias) return null;
+
+  const resolved = resolveNvmAlias(nvmDir, alias, fs, 0);
+  if (!resolved) return null;
+
+  let entries: string[];
+  try {
+    entries = fs
+      .readdirSync(versionsDir)
+      .filter((e) => e.startsWith("v"))
+      .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+  } catch {
+    return null;
+  }
+
+  const matched = matchNvmVersion(entries, resolved);
+  return matched ? path.posix.join(versionsDir, matched, "bin") : null;
+}
+
+function resolveNvmAlias(
+  nvmDir: string,
+  alias: string,
+  fs: NodeToolFs,
+  depth: number
+): string | null {
+  if (depth > 5) return null;
+  if (/^\d/.test(alias) || alias.startsWith("v")) return alias;
+  if (NVM_LATEST_ALIASES.has(alias)) return alias;
+  try {
+    const target = fs
+      .readFileSync(path.posix.join(nvmDir, "alias", ...alias.split("/")), "utf8")
+      .trim();
+    if (!target) return null;
+    return resolveNvmAlias(nvmDir, target, fs, depth + 1);
+  } catch {
+    return null;
+  }
+}
+
+function matchNvmVersion(entries: string[], resolvedAlias: string): string | undefined {
+  if (NVM_LATEST_ALIASES.has(resolvedAlias)) return entries[0];
+  const version = resolvedAlias.replace(/^v/, "");
+  return entries.find((entry) => {
+    const entryVersion = entry.slice(1);
+    return entryVersion === version || entryVersion.startsWith(version + ".");
+  });
+}

--- a/src/utils/nodeToolBinDirs.ts
+++ b/src/utils/nodeToolBinDirs.ts
@@ -98,12 +98,16 @@ function unixCandidates(input: NodeToolBinDirsInput): Array<string | null> {
   // asdf — shims wrap every managed tool; bin is the asdf CLI itself. The data
   // dir (where shims live) is NOT the install dir: Homebrew-style setups point
   // ASDF_DIR at the install path while shims stay under the default ~/.asdf
-  // data dir. So prefer ASDF_DATA_DIR, then an existing ~/.asdf, and only fall
-  // back to ASDF_DIR — otherwise a present ~/.asdf/shims would be missed.
+  // data dir. So prefer ASDF_DATA_DIR, then a default ~/.asdf with real shims,
+  // and only fall back to ASDF_DIR — otherwise a present ~/.asdf/shims would be
+  // missed. Probe the shims dir itself, not the data dir: an empty ~/.asdf with
+  // shims under ASDF_DIR must not shadow the real install.
   const defaultAsdfData = p.join(homeDir, ".asdf");
   const asdfRoot =
     env.ASDF_DATA_DIR ??
-    (dirExists(fs, defaultAsdfData) ? defaultAsdfData : (env.ASDF_DIR ?? defaultAsdfData));
+    (dirExists(fs, p.join(defaultAsdfData, "shims"))
+      ? defaultAsdfData
+      : (env.ASDF_DIR ?? defaultAsdfData));
   dirs.push(p.join(asdfRoot, "shims"));
   dirs.push(p.join(asdfRoot, "bin"));
 

--- a/src/utils/nodeToolBinDirs.ts
+++ b/src/utils/nodeToolBinDirs.ts
@@ -95,8 +95,15 @@ function unixCandidates(input: NodeToolBinDirsInput): Array<string | null> {
   // Volta
   dirs.push(env.VOLTA_HOME ? p.join(env.VOLTA_HOME, "bin") : p.join(homeDir, ".volta", "bin"));
 
-  // asdf — shims wrap every managed tool; bin is the asdf CLI itself.
-  const asdfRoot = env.ASDF_DATA_DIR ?? env.ASDF_DIR ?? p.join(homeDir, ".asdf");
+  // asdf — shims wrap every managed tool; bin is the asdf CLI itself. The data
+  // dir (where shims live) is NOT the install dir: Homebrew-style setups point
+  // ASDF_DIR at the install path while shims stay under the default ~/.asdf
+  // data dir. So prefer ASDF_DATA_DIR, then an existing ~/.asdf, and only fall
+  // back to ASDF_DIR — otherwise a present ~/.asdf/shims would be missed.
+  const defaultAsdfData = p.join(homeDir, ".asdf");
+  const asdfRoot =
+    env.ASDF_DATA_DIR ??
+    (dirExists(fs, defaultAsdfData) ? defaultAsdfData : (env.ASDF_DIR ?? defaultAsdfData));
   dirs.push(p.join(asdfRoot, "shims"));
   dirs.push(p.join(asdfRoot, "bin"));
 


### PR DESCRIPTION
Agent Mode "Auto-detect" now finds `opencode`/`codex-acp`/`claude` binaries installed under nvm, fnm, n, Volta, asdf, and `npm i -g` (against an nvm-managed Node) — not just Homebrew and `/usr/local/bin` — fixing failures on macOS GUI launches that inherit a sparse `launchd` PATH. A new shared resolver (`nodeToolBinDirs`) enumerates every version manager's bin dirs and feeds both detect-time (`which`/`where`) and spawn-time (`#!/usr/bin/env node`) PATH so a binary that detects also spawns. Windows now augments PATH too and prefers `.exe` over unspawnable `.cmd` shims, the Claude resolver reuses the same directory discovery (gaining fnm/n), and the not-found hint lists the directories actually searched. A static deterministic resolver was chosen over importing the user's real PATH via a login shell (rejected for cost/shell-ambiguity/security). Verified: `npm run format && lint` clean, `npm run test` (3261 passing incl. new nvm/fnm/Windows suites), and `npm run build` succeeds.

Closes logancyang/obsidian-copilot-preview#66

🤖 Generated with [Claude Code](https://claude.com/claude-code)