### PR TITLE
feat(agent-mode): unify binary-config title + Apply→Clear toggle

### DIFF
--- a/src/agentMode/backends/claude/ClaudeInstallModal.tsx
+++ b/src/agentMode/backends/claude/ClaudeInstallModal.tsx
@@ -4,7 +4,6 @@ import { InstallCommandRow } from "@/agentMode/backends/shared/InstallCommandRow
 import { InstallStatusLine } from "@/agentMode/backends/shared/installStatus";
 import type { InstallState } from "@/agentMode/session/types";
 import { ReactModal } from "@/components/modals/ReactModal";
-import { Button } from "@/components/ui/button";
 import { setSettings, useSettingsValue } from "@/settings/model";
 import { validateExecutableFile } from "@/utils/detectBinary";
 import { App, Notice } from "obsidian";
@@ -47,7 +46,7 @@ const ClaudeConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         <InstallCommandRow command={CLAUDE_INSTALL_COMMAND} />
       </ConfigSection>
 
-      <ConfigSection title="Use a custom claude path">
+      <ConfigSection title="Use your own binary">
         <p className="tw-my-0 tw-text-sm tw-text-muted">
           Use an existing <code>claude</code> binary you have on disk.
         </p>
@@ -57,16 +56,10 @@ const ClaudeConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
           initialPath={overridePath}
           notFoundHint={`claude not found on disk. Install with \`${CLAUDE_INSTALL_COMMAND}\` and try again, or paste a custom path manually.`}
           onSave={onSaveCustomPath}
+          onClear={clearCustomPath}
           persistOnAutoDetect
           detect={() => Promise.resolve(detectClaudeCliPath())}
         />
-        {isCustom && (
-          <div className="tw-flex tw-justify-end">
-            <Button variant="destructive" size="default" onClick={clearCustomPath}>
-              Clear path
-            </Button>
-          </div>
-        )}
       </ConfigSection>
 
       <ConfigSection title="Authentication">

--- a/src/agentMode/backends/codex/CodexInstallModal.tsx
+++ b/src/agentMode/backends/codex/CodexInstallModal.tsx
@@ -31,13 +31,18 @@ const CodexConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
     return null;
   }, []);
 
+  const clearCodexPath = React.useCallback((): void => {
+    updateCodexFields({ binaryPath: undefined });
+    new Notice("Codex binary path cleared.");
+  }, []);
+
   return (
     <ConfigDialogShell status={<InstallStatusLine state={sessionState} />} onClose={onClose}>
       <ConfigSection title="Install codex-acp">
         <InstallCommandRow command={CODEX_INSTALL_COMMAND} />
       </ConfigSection>
 
-      <ConfigSection title="codex-acp path">
+      <ConfigSection title="Use your own binary">
         <p className="tw-my-0 tw-text-sm tw-text-muted">
           Use an existing <code>{CODEX_BINARY_NAME}</code> binary you have on disk.
         </p>
@@ -47,6 +52,7 @@ const CodexConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
           initialPath={binaryPath}
           notFoundHint={`${CODEX_BINARY_NAME} not found on PATH. Run the install command above, then click Auto-detect again.`}
           onSave={onSavePath}
+          onClear={clearCodexPath}
           persistOnAutoDetect
         />
       </ConfigSection>

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -250,15 +250,9 @@ const OpencodeConfigBody: React.FC<{
           initialPath={customPath}
           notFoundHint="opencode not found on PATH. Install it or paste a custom path manually."
           onSave={onSaveCustomPath}
+          onClear={clearCustomPath}
           persistOnAutoDetect
         />
-        {isCustom && (
-          <div className="tw-flex tw-justify-end">
-            <Button variant="destructive" size="default" onClick={clearCustomPath}>
-              Clear custom path
-            </Button>
-          </div>
-        )}
       </ConfigSection>
     </ConfigDialogShell>
   );

--- a/src/agentMode/backends/shared/BinaryPathSetting.tsx
+++ b/src/agentMode/backends/shared/BinaryPathSetting.tsx
@@ -13,6 +13,11 @@ interface Props {
   notFoundHint?: string;
   /** Validate & persist on Apply. Returns null on success, error message on failure. */
   onSave: (path: string) => Promise<string | null>;
+  /**
+   * Clear the persisted custom path. When provided, the Apply button becomes a
+   * Clear button once a usable path is applied (see `showClear` below).
+   */
+  onClear?: () => void | Promise<void>;
   /** When true, a successful auto-detect immediately invokes `onSave`. */
   persistOnAutoDetect?: boolean;
   /**
@@ -37,6 +42,7 @@ export const BinaryPathSetting: React.FC<Props> = ({
   initialPath,
   notFoundHint,
   onSave,
+  onClear,
   persistOnAutoDetect = false,
   detect,
 }) => {
@@ -62,6 +68,17 @@ export const BinaryPathSetting: React.FC<Props> = ({
     }
     setError(null);
   }, [pathInput, onSave]);
+
+  const clear = React.useCallback(async (): Promise<void> => {
+    if (busy || !onClear) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onClear();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, onClear]);
 
   const autoDetect = React.useCallback(async (): Promise<void> => {
     if (busy) return;
@@ -93,6 +110,12 @@ export const BinaryPathSetting: React.FC<Props> = ({
     }
   }, [binaryName, busy, notFoundHint, onSave, persistOnAutoDetect, detect]);
 
+  // A usable custom path is applied (`initialPath` is the persisted value, validated
+  // on save/auto-detect) and the draft matches it — so re-applying would be a no-op.
+  // An in-flight edit flips the button back to Apply so the new value can be saved.
+  const showClear =
+    Boolean(onClear) && initialPath.trim() !== "" && pathInput.trim() === initialPath.trim();
+
   return (
     <div className="tw-flex tw-w-full tw-flex-col tw-gap-2">
       <div className="tw-flex tw-items-center tw-gap-2">
@@ -106,9 +129,15 @@ export const BinaryPathSetting: React.FC<Props> = ({
         <Button variant="secondary" size="default" onClick={autoDetect} disabled={busy}>
           Auto-detect
         </Button>
-        <Button variant="default" size="default" onClick={apply} disabled={busy}>
-          Apply
-        </Button>
+        {showClear ? (
+          <Button variant="destructive" size="default" onClick={clear} disabled={busy}>
+            Clear
+          </Button>
+        ) : (
+          <Button variant="default" size="default" onClick={apply} disabled={busy}>
+            Apply
+          </Button>
+        )}
       </div>
       {error && <div className="tw-text-sm tw-text-error">{error}</div>}
     </div>


### PR DESCRIPTION
Unifies the custom-path section title to **"Use your own binary"** across the Claude, Codex, and opencode configure-binary dialogs. Moves the clear affordance into the shared `BinaryPathSetting` row so that once a usable path is applied or auto-detected, the **Apply** button becomes a **Clear** button (editing the draft flips it back to Apply). This removes the separate destructive "Clear path" buttons from the Claude and opencode dialogs and gives Codex a clear action it previously lacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)