### PR TITLE
feat(agent-mode): honor auto-add active note setting

### DIFF
--- a/src/agentMode/ui/AgentChat.tsx
+++ b/src/agentMode/ui/AgentChat.tsx
@@ -23,6 +23,7 @@ import type {
 import { CustomCommandManager } from "@/commands/customCommandManager";
 import { getCachedCustomCommands } from "@/commands/state";
 import { logError, logWarn } from "@/logger";
+import { useSettingsValue } from "@/settings/model";
 import { arrayBufferToBase64 } from "@/utils/base64";
 import type CopilotPlugin from "@/main";
 import {
@@ -137,12 +138,15 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
   const eventTarget = useContext(EventTargetContext);
   const appContext = useContext(AppContext);
   const app = plugin.app || appContext;
+  const settings = useSettingsValue();
 
   const [messages, setMessages] = useState<AgentChatMessage[]>(() => backend.getMessages());
   const [inputMessage, setInputMessage] = useState("");
   const [selectedImages, setSelectedImages] = useState<File[]>([]);
   const [contextNotes, setContextNotes] = useState<TFile[]>([]);
-  const [includeActiveNote, setIncludeActiveNote] = useState(false);
+  const [includeActiveNote, setIncludeActiveNote] = useState(
+    settings.autoAddActiveContentToContext === true
+  );
   const [includeActiveWebTab, setIncludeActiveWebTab] = useState(false);
   const [loading, setLoading] = useState(false);
   const [isStarting, setIsStarting] = useState(() => backend.isStarting());


### PR DESCRIPTION
Agent chat mode now honors the **Auto-Add Active Content to Context** setting (`autoAddActiveContentToContext`), matching legacy chat mode, which previously hardcoded the active-note toggle to `false` and ignored the setting. The toggle is now initialized from the setting at mount, and since `AgentChat` remounts on every new chat / tab switch, it re-syncs there. Behavior is scoped to the active note only (web-tab attachments stay unsupported in agent mode), and the existing attach-once reset after the first send is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)