### PR TITLE
feat(agent-settings): show resolved binary path under each agent title

### DIFF
--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -146,6 +146,10 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
     };
   },
 
+  getResolvedBinaryPath(settings: CopilotSettings): string | null {
+    return resolveClaudeCliPath(settings);
+  },
+
   subscribeInstallState(_plugin: CopilotPlugin, cb: () => void): () => void {
     return subscribeToSettingsChange((prev, next) => {
       if (prev.agentMode?.claudeCli?.path !== next.agentMode?.claudeCli?.path) {

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -98,6 +98,10 @@ export const CodexBackendDescriptor: BackendDescriptor = {
     return binaryPathInstallState(settings.agentMode?.backends?.codex?.binaryPath);
   },
 
+  getResolvedBinaryPath(settings: CopilotSettings): string | null {
+    return settings.agentMode?.backends?.codex?.binaryPath ?? null;
+  },
+
   subscribeInstallState(_plugin: CopilotPlugin, cb: () => void): () => void {
     return subscribeToSettingsChange((prev, next) => {
       if (

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -108,6 +108,10 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
     return { kind: "ready", source: raw.source };
   },
 
+  getResolvedBinaryPath(settings: CopilotSettings): string | null {
+    return settings.agentMode?.backends?.opencode?.binaryPath ?? null;
+  },
+
   subscribeInstallState(_plugin: CopilotPlugin, cb: () => void): () => void {
     return subscribeToSettingsChange((prev, next) => {
       if (prev.agentMode?.backends?.opencode !== next.agentMode?.backends?.opencode) {

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -105,6 +105,13 @@ export interface BackendDescriptor {
   /** Sync read of install/setup state from settings + last-known disk reconcile. */
   getInstallState(settings: CopilotSettings): InstallState;
 
+  /**
+   * Optional: the resolved filesystem path of the binary/executable this
+   * backend runs, for display in settings. `null` when not configured or not
+   * resolvable. Distinct from install state — purely informational.
+   */
+  getResolvedBinaryPath?(settings: CopilotSettings): string | null;
+
   /** Subscribe to settings/disk changes affecting install state. Returns unsubscribe. */
   subscribeInstallState(plugin: CopilotPlugin, cb: () => void): () => void;
 

--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -85,6 +85,7 @@ const BackendSection: React.FC<{
   const manager = plugin.agentSessionManager;
 
   const installState = descriptor.getInstallState(settings);
+  const resolvedPath = descriptor.getResolvedBinaryPath?.(settings) ?? null;
 
   // Probe when ready but uncached — the load-time preload may have skipped this
   // backend (binary installed after plugin start).
@@ -104,8 +105,17 @@ const BackendSection: React.FC<{
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
         <div className="tw-flex tw-items-center tw-gap-2">
           <Icon className="tw-size-4" />
-          <span className="tw-text-base tw-font-semibold">{descriptor.displayName}</span>
-          <InstallBadge state={installState} />
+          <div className="tw-flex tw-flex-col">
+            <div className="tw-flex tw-items-center tw-gap-2">
+              <span className="tw-text-base tw-font-semibold">{descriptor.displayName}</span>
+              <InstallBadge state={installState} />
+            </div>
+            {resolvedPath && (
+              <span className="tw-break-all tw-font-mono tw-text-xs tw-text-muted">
+                {resolvedPath}
+              </span>
+            )}
+          </div>
         </div>
         <Button
           size="default"

--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -112,7 +112,7 @@ const BackendSection: React.FC<{
               <InstallBadge state={installState} />
             </div>
             {resolvedPath && (
-              <TruncatedText className="tw-font-mono tw-text-xs tw-text-muted">
+              <TruncatedText className="tw-max-w-[80%] tw-font-mono tw-text-xs tw-text-muted">
                 {resolvedPath}
               </TruncatedText>
             )}

--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/agentMode";
 import { Button } from "@/components/ui/button";
 import { SettingItem } from "@/components/ui/setting-item";
+import { TruncatedText } from "@/components/TruncatedText";
 import { usePlugin } from "@/contexts/PluginContext";
 import { logError } from "@/logger";
 import { setSettings, useSettingsValue } from "@/settings/model";
@@ -103,21 +104,22 @@ const BackendSection: React.FC<{
   return (
     <div className="tw-space-y-3 tw-rounded-md tw-border tw-border-solid tw-border-border tw-p-3">
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
-        <div className="tw-flex tw-items-center tw-gap-2">
-          <Icon className="tw-size-4" />
-          <div className="tw-flex tw-flex-col">
+        <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
+          <Icon className="tw-size-4 tw-shrink-0" />
+          <div className="tw-flex tw-min-w-0 tw-flex-col">
             <div className="tw-flex tw-items-center tw-gap-2">
               <span className="tw-text-base tw-font-semibold">{descriptor.displayName}</span>
               <InstallBadge state={installState} />
             </div>
             {resolvedPath && (
-              <span className="tw-break-all tw-font-mono tw-text-xs tw-text-muted">
+              <TruncatedText className="tw-font-mono tw-text-xs tw-text-muted">
                 {resolvedPath}
-              </span>
+              </TruncatedText>
             )}
           </div>
         </div>
         <Button
+          className="tw-shrink-0"
           size="default"
           variant={installState.kind === "ready" ? "secondary" : "default"}
           onClick={() => descriptor.openInstallUI(plugin)}

--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -112,7 +112,7 @@ const BackendSection: React.FC<{
               <InstallBadge state={installState} />
             </div>
             {resolvedPath && (
-              <TruncatedText className="tw-max-w-[80%] tw-font-mono tw-text-xs tw-text-muted">
+              <TruncatedText className="tw-max-w-[90%] tw-font-mono tw-text-xs tw-text-muted">
                 {resolvedPath}
               </TruncatedText>
             )}


### PR DESCRIPTION
In **Settings → Agents**, each agent backend now shows the resolved path of the binary it runs as a muted, monospace line directly beneath the agent title — so users can see which install (e.g. nvm/fnm/Volta Claude CLI, managed vs. custom opencode binary, a hand-set `codex-acp` path) each agent actually uses. The path is exposed through a new optional `getResolvedBinaryPath(settings)` on `BackendDescriptor`, implemented by each backend by reusing its existing resolution logic, rather than branching on backend id in the UI. The line only appears when a path resolves (i.e. the agent is configured), wraps on long paths, and updates live when the path is changed via Configure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)