### PR TITLE
feat(agent-mode): port v3 markdown formatting rules into shared agent prompt

### DIFF
--- a/src/agentMode/backends/shared/agentSystemPrompt.test.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.test.ts
@@ -95,4 +95,24 @@ describe("COPILOT_PROMPT_BASE", () => {
   it("ports AGENT_LOOP_GUIDANCE behavior bullets", () => {
     expect(COPILOT_PROMPT_BASE).toMatch(/NEVER search for the same/);
   });
+
+  it("renders note titles as bare [[wikilinks]], never backticked (v3 rule 7)", () => {
+    expect(COPILOT_PROMPT_BASE).toMatch(
+      /note titles[^\n]*\[\[title\]\][^\n]*never wrap them in backticks/i
+    );
+  });
+
+  it("renders image links without wrapping them in backticks (v3 rules 8-9)", () => {
+    expect(COPILOT_PROMPT_BASE).toMatch(/!\[\[link\]\][^\n]*never wrap them in backticks/i);
+    expect(COPILOT_PROMPT_BASE).toMatch(/!\[alt\]\(url\)[^\n]*never wrap them in backticks/i);
+  });
+
+  it("ports the v3 GitHub-table heading convention (rule 10)", () => {
+    expect(COPILOT_PROMPT_BASE).toContain("immediately add ` |` after the table heading");
+  });
+
+  it("retains the LaTeX and bullet-list formatting rules", () => {
+    expect(COPILOT_PROMPT_BASE).toMatch(/\$\.\.\.\$/);
+    expect(COPILOT_PROMPT_BASE).toContain("Never use `*` for bullets");
+  });
 });

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -58,9 +58,11 @@ export const COPILOT_PROMPT_BASE = `You are Obsidian Copilot, an AI assistant th
 
 ## Markdown Formatting
 - Use \`$...$\` for LaTeX equations, never \`\\[...\\]\` or \`\\(...\\)\`.
-- For markdown lists, always use \`- \` (hyphen followed by exactly one space) for bullet points. Never use \`*\` for bullets.
-- For tables, use GitHub-flavored markdown.
-- For Obsidian-internal image links, use \`![[link]]\` format. For web image links, use \`![alt](url)\` format.`;
+- For markdown lists, always use \`- \` (hyphen followed by exactly one space) for bullet points, with no leading spaces. Never use \`*\` for bullets.
+- When showing note titles, use the \`[[title]]\` wikilink format and never wrap them in backticks or quotes.
+- For Obsidian-internal image links, use the \`![[link]]\` format and never wrap them in backticks.
+- For web image links, use the \`![alt](url)\` format and never wrap them in backticks.
+- For tables, use GitHub-flavored markdown. For table headings, immediately add \` |\` after the table heading.`;
 
 /**
  * Compose the full system prompt every Agent Mode backend forwards. See the


### PR DESCRIPTION
Ports the missing v3 chat-prompt formatting conventions (`DEFAULT_SYSTEM_PROMPT` rules 7–10) into `COPILOT_PROMPT_BASE` so all three agent backends (Claude SDK, Codex, OpenCode) follow Copilot's vault-native formatting. The core fix tells agents to render note titles as bare `[[title]]` wikilinks and never wrap them in backticks — previously they emitted `` `[[Note]]` ``, which Obsidian won't resolve as a link — and likewise strengthens the image-link rules and ports the GitHub-table heading convention. The new rules stay inside `COPILOT_PROMPT_BASE` (still suppressed by the "Disable builtin system prompt" toggle) and are model/provider-agnostic. Added pin tests for each ported rule in `agentSystemPrompt.test.ts`; `npm run test`, `npm run format`, and `npm run lint` all pass.

Closes logancyang/obsidian-copilot-preview#100

🤖 Generated with [Claude Code](https://claude.com/claude-code)