### PR TITLE
fix(agent-mode): MCP server prefix + humanized tool-call labels

### DIFF
--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -50,6 +50,7 @@ import type {
   ToolCallSnapshot,
 } from "@/agentMode/session/types";
 import { PERMISSION_OPTION_KINDS } from "@/agentMode/session/types";
+import { resolveToolName } from "@/agentMode/session/toolName";
 import { translateBackendState } from "@/agentMode/session/translateBackendState";
 
 // ---- Catalog wire → neutral (pass-through, structural alias) -----------
@@ -226,14 +227,16 @@ function toolCallContentFromAcp(
 function toolCallSnapshotFromAcp(
   call: ToolCall & { sessionUpdate?: "tool_call" }
 ): ToolCallSnapshot {
+  const { tool: title, mcpServer } = resolveToolName(call.title);
   return {
     toolCallId: call.toolCallId,
-    title: call.title,
+    title,
     kind: toolKindFromAcp(call.kind),
     status: toolStatusFromAcp(call.status),
     rawInput: call.rawInput,
     content: toolCallContentFromAcp(call.content),
     locations: call.locations?.map((l) => ({ path: l.path, line: l.line ?? undefined })),
+    mcpServer,
   };
 }
 
@@ -246,9 +249,10 @@ function mapNullable<T, R>(value: T | null | undefined, fn: (value: T) => R): R 
 function toolCallDeltaFromAcp(
   upd: ToolCallUpdate & { sessionUpdate?: "tool_call_update" }
 ): ToolCallDelta {
+  const resolved = upd.title != null ? resolveToolName(upd.title) : null;
   return {
     toolCallId: upd.toolCallId,
-    title: upd.title ?? undefined,
+    title: resolved?.tool,
     kind: toolKindFromAcp(upd.kind ?? undefined),
     status: toolStatusFromAcp(upd.status as string | undefined),
     rawInput: upd.rawInput,
@@ -256,6 +260,7 @@ function toolCallDeltaFromAcp(
     locations: mapNullable(upd.locations, (locs) =>
       locs.map((l) => ({ path: l.path, line: l.line ?? undefined }))
     ),
+    mcpServer: resolved?.mcpServer,
   };
 }
 

--- a/src/agentMode/sdk/permissionBridge.test.ts
+++ b/src/agentMode/sdk/permissionBridge.test.ts
@@ -275,5 +275,17 @@ describe("PermissionBridge.canUseTool", () => {
       await bridge.canUseTool("Bash", { command: "ls" }, ctx);
       expect(captured!.toolCall.isPlanProposal).toBeUndefined();
     });
+
+    it("keeps an MCP tool whose bare name is ExitPlanMode out of the plan flow", async () => {
+      let captured: PermissionPrompt | null = null;
+      const bridge = makeBridge(async (req) => {
+        captured = req;
+        return { outcome: { outcome: "selected", optionId: "allow_once" } };
+      });
+      await bridge.canUseTool("mcp__srv__ExitPlanMode", { plan: "unrelated" }, ctx);
+      expect(captured!.toolCall.mcpServer).toBe("srv");
+      expect(captured!.toolCall.isPlanProposal).toBeUndefined();
+      expect(captured!.toolCall.kind).not.toBe("switch_mode");
+    });
   });
 });

--- a/src/agentMode/sdk/permissionBridge.ts
+++ b/src/agentMode/sdk/permissionBridge.ts
@@ -18,6 +18,7 @@ import type {
   SessionId,
 } from "@/agentMode/session/types";
 import { PERMISSION_OPTION_KINDS } from "@/agentMode/session/types";
+import { resolveToolName } from "@/agentMode/session/toolName";
 import { err2String } from "@/utils";
 import { logSdkInbound, logSdkOutbound } from "./sdkDebugTap";
 import { deriveToolKind, deriveToolTitle, vendorMetaFields } from "./toolMeta";
@@ -160,21 +161,19 @@ function synthesizePermissionPrompt(
   sessionId: SessionId,
   ctx: Parameters<CanUseTool>[2]
 ): PermissionPrompt {
+  const { tool: name, mcpServer } = resolveToolName(toolName);
   return {
     sessionId,
     toolCall: {
       // Reuse the SDK's `tool_use_id` so prompt and `tool_call` notification
       // share an id — the trail UI and plan-card resolver pair them by id.
       toolCallId: ctx.toolUseID,
-      kind: deriveToolKind(toolName),
+      kind: deriveToolKind(name),
       status: "pending",
-      title: deriveToolTitle(
-        toolName,
-        input,
-        typeof ctx.title === "string" ? ctx.title : undefined
-      ),
+      title: deriveToolTitle(name, input, typeof ctx.title === "string" ? ctx.title : undefined),
       rawInput: input,
-      ...vendorMetaFields(toolName),
+      mcpServer,
+      ...vendorMetaFields(name),
     },
     options: STANDARD_OPTIONS,
   };

--- a/src/agentMode/sdk/permissionBridge.ts
+++ b/src/agentMode/sdk/permissionBridge.ts
@@ -168,12 +168,12 @@ function synthesizePermissionPrompt(
       // Reuse the SDK's `tool_use_id` so prompt and `tool_call` notification
       // share an id — the trail UI and plan-card resolver pair them by id.
       toolCallId: ctx.toolUseID,
-      kind: deriveToolKind(name),
+      kind: deriveToolKind(name, mcpServer),
       status: "pending",
       title: deriveToolTitle(name, input, typeof ctx.title === "string" ? ctx.title : undefined),
       rawInput: input,
       mcpServer,
-      ...vendorMetaFields(name),
+      ...vendorMetaFields(name, undefined, mcpServer),
     },
     options: STANDARD_OPTIONS,
   };

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -390,6 +390,54 @@ describe("translateSdkMessage", () => {
     });
   });
 
+  it("does not treat an MCP tool whose bare name is ExitPlanMode as a plan proposal", () => {
+    const state = createTranslatorState();
+    const out = translateSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "tu-mcp-exit",
+          name: "mcp__srv__ExitPlanMode",
+          input: { plan: "not Copilot's plan flow" },
+        },
+      }),
+      SESSION_ID,
+      state
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "tu-mcp-exit",
+      vendorToolName: "ExitPlanMode",
+      mcpServer: "srv",
+    });
+    expect(out[0].update).not.toMatchObject({ isPlanProposal: true });
+    expect(out[0].update).not.toMatchObject({ kind: "switch_mode" });
+  });
+
+  it("does not flip into plan mode for an MCP tool whose bare name is EnterPlanMode", () => {
+    const state = createTranslatorState();
+    const out = translateSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "tu-mcp-enter",
+          name: "mcp__srv__EnterPlanMode",
+          input: {},
+        },
+      }),
+      SESSION_ID,
+      state
+    );
+    // Only the tool_call — no current_mode_update.
+    expect(out).toHaveLength(1);
+    expect(out[0].update).toMatchObject({ sessionUpdate: "tool_call", mcpServer: "srv" });
+  });
+
   it("threads parent_tool_use_id into parentToolCallId on streamed tool_use", () => {
     const state = createTranslatorState();
     const out = translateSdkMessage(

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -339,6 +339,7 @@ describe("translateSdkMessage", () => {
       sessionUpdate: "tool_call",
       toolCallId: "tu-mcp-underscored",
       vendorToolName: "do_thing",
+      mcpServer: "my_server",
     });
   });
 
@@ -364,6 +365,7 @@ describe("translateSdkMessage", () => {
       toolCallId: "tu-mcp",
       title: "do_thing Daily/2026-05-01.md",
       vendorToolName: "do_thing",
+      mcpServer: "custom-server",
     });
   });
 

--- a/src/agentMode/sdk/sdkMessageTranslator.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.ts
@@ -26,6 +26,7 @@ export interface TranslatorState {
     {
       id: string;
       name: string;
+      mcpServer?: string;
       inputJsonAcc: string;
       lastParsedInput: unknown;
       emittedToolCall: boolean;
@@ -110,10 +111,11 @@ function translateStreamEvent(
     case "content_block_start": {
       const block = sdkEvent.content_block;
       if (block.type === "tool_use") {
-        const { tool: name } = resolveToolName(block.name);
+        const { tool: name, mcpServer } = resolveToolName(block.name);
         state.toolUseBlocks.set(sdkEvent.index, {
           id: block.id,
           name,
+          mcpServer,
           inputJsonAcc: "",
           lastParsedInput: block.input ?? {},
           emittedToolCall: true,
@@ -125,7 +127,9 @@ function translateStreamEvent(
             makeToolCallUpdate(block.id, block.name, block.input ?? {}, parentToolUseId)
           ),
         ];
-        if (name === "EnterPlanMode") {
+        // Native plan tool only — an MCP tool sharing the bare name must not
+        // flip the UI into plan mode.
+        if (!mcpServer && name === "EnterPlanMode") {
           out.push(
             event(sessionId, {
               sessionUpdate: "current_mode_update",
@@ -173,7 +177,7 @@ function translateStreamEvent(
             sessionUpdate: "tool_call_update",
             toolCallId: block.id,
             rawInput: parsed.value,
-            ...vendorMetaFields(block.name, parentToolUseId),
+            ...vendorMetaFields(block.name, parentToolUseId, block.mcpServer),
           }),
         ];
       }
@@ -191,7 +195,7 @@ function translateStreamEvent(
           toolCallId: block.id,
           rawInput: finalInput,
           status: "in_progress" as AgentToolStatus,
-          ...vendorMetaFields(block.name, parentToolUseId),
+          ...vendorMetaFields(block.name, parentToolUseId, block.mcpServer),
         }),
       ];
     }
@@ -262,11 +266,11 @@ function makeToolCallUpdate(
     sessionUpdate: "tool_call",
     toolCallId,
     title: deriveToolTitle(name, rawInput),
-    kind: deriveToolKind(name),
+    kind: deriveToolKind(name, mcpServer),
     status: "in_progress" as AgentToolStatus,
     rawInput,
     mcpServer,
-    ...vendorMetaFields(name, parentToolUseId),
+    ...vendorMetaFields(name, parentToolUseId, mcpServer),
   };
 }
 

--- a/src/agentMode/sdk/sdkMessageTranslator.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.ts
@@ -13,6 +13,7 @@ import type {
   SessionUpdate,
   ToolCallContent,
 } from "@/agentMode/session/types";
+import { resolveToolName } from "@/agentMode/session/toolName";
 import { deriveToolKind, deriveToolTitle, vendorMetaFields } from "./toolMeta";
 
 /**
@@ -109,7 +110,7 @@ function translateStreamEvent(
     case "content_block_start": {
       const block = sdkEvent.content_block;
       if (block.type === "tool_use") {
-        const name = normalizeToolName(block.name);
+        const { tool: name } = resolveToolName(block.name);
         state.toolUseBlocks.set(sdkEvent.index, {
           id: block.id,
           name,
@@ -119,7 +120,10 @@ function translateStreamEvent(
         });
         state.emittedToolUseIds.add(block.id);
         const out: SessionEvent[] = [
-          event(sessionId, makeToolCallUpdate(block.id, name, block.input ?? {}, parentToolUseId)),
+          event(
+            sessionId,
+            makeToolCallUpdate(block.id, block.name, block.input ?? {}, parentToolUseId)
+          ),
         ];
         if (name === "EnterPlanMode") {
           out.push(
@@ -249,29 +253,21 @@ function translateUserMessage(
 
 function makeToolCallUpdate(
   toolCallId: string,
-  normalizedName: string,
+  rawName: string,
   rawInput: unknown,
   parentToolUseId?: string
 ): SessionUpdate {
+  const { tool: name, mcpServer } = resolveToolName(rawName);
   return {
     sessionUpdate: "tool_call",
     toolCallId,
-    title: deriveToolTitle(normalizedName, rawInput),
-    kind: deriveToolKind(normalizedName),
+    title: deriveToolTitle(name, rawInput),
+    kind: deriveToolKind(name),
     status: "in_progress" as AgentToolStatus,
     rawInput,
-    ...vendorMetaFields(normalizedName, parentToolUseId),
+    mcpServer,
+    ...vendorMetaFields(name, parentToolUseId),
   };
-}
-
-/**
- * Strip the SDK's `mcp__<server>__` prefix on MCP tool names so downstream UI
- * mapping (kind / title / vendorToolName) sees the bare tool name. The
- * non-greedy middle segment tolerates server names containing underscores.
- */
-function normalizeToolName(name: string): string {
-  const m = /^mcp__.+?__(.+)$/.exec(name);
-  return m ? m[1] : name;
 }
 
 function toolResultContent(content: unknown): ToolCallContent[] | undefined {

--- a/src/agentMode/sdk/toolMeta.ts
+++ b/src/agentMode/sdk/toolMeta.ts
@@ -8,21 +8,32 @@ export interface VendorMetaFields {
 
 /**
  * Caller passes the normalized tool name (any `mcp__server__` prefix
- * already stripped). `isPlanProposal` is omitted unless true so the flag
- * doesn't leak onto unrelated tool calls.
+ * already stripped) plus its `mcpServer` when the name came from an MCP tool.
+ * `isPlanProposal` is omitted unless true so the flag doesn't leak onto
+ * unrelated tool calls. `ExitPlanMode` is a *native* Claude tool; an MCP tool
+ * sharing the bare name (`mcp__srv__ExitPlanMode`) must not be routed through
+ * the plan-approval flow, so the flag is gated on `mcpServer` being absent.
  */
 export function vendorMetaFields(
   normalizedName: string,
-  parentToolCallId?: string
+  parentToolCallId?: string,
+  mcpServer?: string
 ): VendorMetaFields {
   const fields: VendorMetaFields = { vendorToolName: normalizedName };
   if (parentToolCallId) fields.parentToolCallId = parentToolCallId;
-  if (normalizedName === "ExitPlanMode") fields.isPlanProposal = true;
+  if (!mcpServer && normalizedName === "ExitPlanMode") fields.isPlanProposal = true;
   return fields;
 }
 
-export function deriveToolKind(toolName: string): AgentToolKind {
-  if (toolName === "ExitPlanMode" || toolName === "EnterPlanMode") return "switch_mode";
+/**
+ * `mcpServer` is passed when the name came from an MCP tool. `switch_mode` is
+ * reserved for the native plan tools; an MCP tool sharing the bare name must
+ * not map to it, since `switch_mode` feeds plan-card publishing.
+ */
+export function deriveToolKind(toolName: string, mcpServer?: string): AgentToolKind {
+  if (!mcpServer && (toolName === "ExitPlanMode" || toolName === "EnterPlanMode")) {
+    return "switch_mode";
+  }
   const lower = toolName.toLowerCase();
   if (lower === "read" || lower === "glob" || lower === "grep" || lower === "ls") {
     return "read";

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1304,6 +1304,7 @@ function toolCallToPart(
     output: extractToolCallOutputs(call.content),
     locations: call.locations?.map((l) => ({ path: l.path, line: l.line ?? undefined })),
     vendorToolName: call.vendorToolName,
+    mcpServer: call.mcpServer,
     parentToolCallId: call.parentToolCallId,
   };
 }
@@ -1364,6 +1365,7 @@ function mergeToolCallUpdate(
         ? upd.locations.map((l) => ({ path: l.path, line: l.line ?? undefined }))
         : base.locations,
     vendorToolName: upd.vendorToolName ?? base.vendorToolName,
+    mcpServer: upd.mcpServer ?? base.mcpServer,
     parentToolCallId: upd.parentToolCallId ?? base.parentToolCallId,
   };
 }

--- a/src/agentMode/session/toolName.test.ts
+++ b/src/agentMode/session/toolName.test.ts
@@ -1,0 +1,31 @@
+import { parseMcpToolName } from "@/agentMode/session/toolName";
+
+describe("parseMcpToolName", () => {
+  it("splits a qualified MCP name into server and tool", () => {
+    expect(parseMcpToolName("mcp__context7__query-docs")).toEqual({
+      server: "context7",
+      tool: "query-docs",
+    });
+  });
+
+  it("treats the first '__' after the prefix as the separator (single-underscore server)", () => {
+    expect(parseMcpToolName("mcp__my_server__do_thing")).toEqual({
+      server: "my_server",
+      tool: "do_thing",
+    });
+  });
+
+  it("keeps trailing '__' inside the tool segment", () => {
+    expect(parseMcpToolName("mcp__srv__tool__name")).toEqual({
+      server: "srv",
+      tool: "tool__name",
+    });
+  });
+
+  it("returns null for non-MCP names", () => {
+    expect(parseMcpToolName("Read")).toBeNull();
+    expect(parseMcpToolName("AskUserQuestion")).toBeNull();
+    expect(parseMcpToolName("mcp__incomplete")).toBeNull();
+    expect(parseMcpToolName("")).toBeNull();
+  });
+});

--- a/src/agentMode/session/toolName.ts
+++ b/src/agentMode/session/toolName.ts
@@ -1,0 +1,25 @@
+/**
+ * MCP tools are namespaced `mcp__<server>__<tool>` by the Claude Agent SDK (and
+ * surfaced the same way by ACP backends that pass the qualified name through as
+ * the tool-call title). Parsing splits the server from the bare tool name so the
+ * UI can render a `server · tool` label and lookups see the bare name.
+ *
+ * The server group is non-greedy, so the first `__` after the prefix is treated
+ * as the separator — correct for single-underscore server names. Returns null
+ * for any non-MCP name; callers degrade gracefully (show the name as-is).
+ */
+export function parseMcpToolName(name: string): { server: string; tool: string } | null {
+  const m = /^mcp__(.+?)__(.+)$/.exec(name);
+  return m ? { server: m[1], tool: m[2] } : null;
+}
+
+/**
+ * Resolve any tool name to its bare `tool` and (for an `mcp__<server>__<tool>`
+ * name) the `mcpServer`. Non-MCP names pass through unchanged with no server.
+ * Centralizes the parse-then-fall-back pattern the translators and permission
+ * bridge run on every tool: `const { tool, mcpServer } = resolveToolName(name)`.
+ */
+export function resolveToolName(name: string): { tool: string; mcpServer?: string } {
+  const mcp = parseMcpToolName(name);
+  return mcp ? { tool: mcp.tool, mcpServer: mcp.server } : { tool: name };
+}

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -345,6 +345,12 @@ export interface ToolCallSnapshot {
   locations?: Array<{ path: string; line?: number | null }>;
   /** Vendor-original tool identity (e.g. "Read", "Edit", "ExitPlanMode"). */
   vendorToolName?: string;
+  /**
+   * MCP server name parsed from a `mcp__<server>__<tool>` qualified name. The
+   * UI renders it as a `server · tool` prefix; `vendorToolName` holds the bare
+   * tool name. Absent for non-MCP tools.
+   */
+  mcpServer?: string;
   /** Parent tool-call id, for nested tools (e.g. Claude's Task subagents). */
   parentToolCallId?: string;
   /** True iff this tool call is the agent's plan-finalization signal. */
@@ -363,6 +369,8 @@ export interface ToolCallDelta {
   content?: ToolCallContent[] | null;
   locations?: Array<{ path: string; line?: number | null }> | null;
   vendorToolName?: string;
+  /** MCP server name; see `ToolCallSnapshot.mcpServer`. */
+  mcpServer?: string;
   parentToolCallId?: string;
   isPlanProposal?: boolean;
 }
@@ -609,6 +617,12 @@ export type AgentMessagePart =
        * Absent for backends that surface no vendor identity (opencode, codex).
        */
       vendorToolName?: string;
+      /**
+       * MCP server name parsed from a `mcp__<server>__<tool>` qualified name.
+       * Rendered as a `server · tool` prefix in the trail; `vendorToolName`
+       * holds the bare tool name. Absent for non-MCP tools.
+       */
+      mcpServer?: string;
       /**
        * Parent tool-call id for sub-agent children. Today only Claude
        * Code emits this (Task → child tool calls). Absent → the part is

--- a/src/agentMode/ui/agentTrail.test.ts
+++ b/src/agentMode/ui/agentTrail.test.ts
@@ -67,6 +67,37 @@ describe("buildAgentTrail", () => {
     }
   });
 
+  it("compacts same-server MCP calls under a server-namespaced toolKey", () => {
+    const parts = [
+      tool("m0", { vendorToolName: "Read", mcpServer: "srv" }),
+      tool("m1", { vendorToolName: "Read", mcpServer: "srv" }),
+    ];
+    const tree = buildAgentTrail(parts);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].type).toBe("aggregate");
+    if (tree[0].type === "aggregate") {
+      expect(tree[0].toolKey).toBe("mcp:srv:Read");
+    }
+  });
+
+  it("does not fold an MCP call into a same-bare-named native tool's aggregate", () => {
+    const parts = [
+      tool("n", { vendorToolName: "Read" }),
+      tool("m", { vendorToolName: "Read", mcpServer: "srv" }),
+    ];
+    const tree = buildAgentTrail(parts);
+    expect(tree.map((n) => n.type)).toEqual(["action", "action"]);
+  });
+
+  it("does not merge MCP calls across servers", () => {
+    const parts = [
+      tool("a", { vendorToolName: "Read", mcpServer: "srvA" }),
+      tool("b", { vendorToolName: "Read", mcpServer: "srvB" }),
+    ];
+    const tree = buildAgentTrail(parts);
+    expect(tree.map((n) => n.type)).toEqual(["action", "action"]);
+  });
+
   it("compacts five consecutive Edits inside a sub-agent into one aggregate", () => {
     const edits = Array.from({ length: 5 }, (_, i) => tool(`e${i}`, { vendorToolName: "Edit" }));
     const tree = buildAgentTrail(withSubagent("task1", edits));

--- a/src/agentMode/ui/agentTrail.ts
+++ b/src/agentMode/ui/agentTrail.ts
@@ -60,7 +60,12 @@ export function splitTrailingText(parts: AgentMessagePart[]): {
  * fallback.
  */
 export function toolKeyFor(part: ToolCallPart): string {
-  return part.vendorToolName ?? part.toolKind ?? "other";
+  const base = part.vendorToolName ?? part.toolKind ?? "other";
+  // MCP calls key per-server so they neither fold into a same-bare-named
+  // native tool's aggregate nor merge across servers. That keeps the
+  // `server ·` prefix on the aggregate line (see `lookupToolSummary`) accurate
+  // for the whole group.
+  return part.mcpServer ? `mcp:${part.mcpServer}:${base}` : base;
 }
 
 /**

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -163,6 +163,16 @@ describe("lookupToolSummary", () => {
     expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("srv · Read notes/x.md");
   });
 
+  it("keeps the 'server ·' prefix on the compacted aggregate line", () => {
+    // Two consecutive MCP reads fold into an AggregateCard, which renders
+    // `summary.aggregate(parts).line` rather than `collapsedLine`. The server
+    // prefix must survive compaction so the aggregate doesn't masquerade as a
+    // native "Read 2 notes".
+    const r1 = tool({ vendorToolName: "Read", mcpServer: "srv" });
+    const r2 = tool({ vendorToolName: "Read", mcpServer: "srv" });
+    expect(lookupToolSummary(r1).aggregate([r1, r2]).line).toBe("srv · Read 2 notes");
+  });
+
   it("shows an ACP backend's friendly multi-word title verbatim", () => {
     const t = tool({ title: "Querying the database" });
     expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Querying the database");

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -131,7 +131,73 @@ describe("lookupToolSummary", () => {
   it("falls back to generic when both vendor and toolKind are unknown", () => {
     const t = tool({ title: "weirdtool" });
     const s = lookupToolSummary(t);
-    expect(s.collapsedLine(t, CTX)).toBe("weirdtool");
+    expect(s.collapsedLine(t, CTX)).toBe("Weirdtool");
+  });
+
+  it("humanizes a generic tool name instead of rendering '…'", () => {
+    // SDK seeds title to the (bare) tool name, so title === vendorToolName.
+    // Without the generic label this collapsed to "…".
+    const t = tool({ vendorToolName: "do_thing", title: "do_thing" });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Do thing");
+  });
+
+  it("renders an MCP tool as 'server · Tool name'", () => {
+    const t = tool({
+      vendorToolName: "query-docs",
+      title: "query-docs",
+      mcpServer: "context7",
+    });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("context7 · Query docs");
+  });
+
+  it("keeps the 'server ·' prefix when an MCP tool's bare name collides with a native tool", () => {
+    // `mcp__srv__read` strips to bare `read`, which resolves to the Read/kind
+    // summary; the server prefix must still surface so it doesn't masquerade
+    // as the native Read tool.
+    const t = tool({
+      vendorToolName: "Read",
+      title: "read notes/x.md",
+      mcpServer: "srv",
+      locations: [{ path: "/Users/me/vault/notes/x.md" }],
+    });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("srv · Read notes/x.md");
+  });
+
+  it("shows an ACP backend's friendly multi-word title verbatim", () => {
+    const t = tool({ title: "Querying the database" });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Querying the database");
+  });
+
+  it("falls back to 'Tool call' when there is no tool identity", () => {
+    const t = tool({ title: "" });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Tool call");
+  });
+
+  it("summarizes AskUserQuestion with the question header", () => {
+    const t = tool({
+      vendorToolName: "AskUserQuestion",
+      title: "AskUserQuestion",
+      status: "completed",
+      input: {
+        questions: [{ header: "Pick a backend", question: "Which backend?", options: [] }],
+      },
+    });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe('Asked: "Pick a backend"');
+  });
+
+  it("falls back to the question text (present tense while in flight) when there is no header", () => {
+    const t = tool({
+      vendorToolName: "AskUserQuestion",
+      title: "AskUserQuestion",
+      status: "in_progress",
+      input: { questions: [{ question: "Which backend?", options: [] }] },
+    });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe('Asking: "Which backend?"');
+  });
+
+  it("uses a generic AskUserQuestion line before input has streamed in", () => {
+    const t = tool({ vendorToolName: "AskUserQuestion", title: "AskUserQuestion" });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Asked a question");
   });
 
   it("hides the duplicated vendor name while Read input is still streaming", () => {

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from "lucide-react";
-import { Bot } from "lucide-react";
+import { Bot, MessageCircleQuestion } from "lucide-react";
 import { pickToolIcon } from "@/agentMode/ui/toolIcons";
 import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
 import { toVaultRelative } from "@/agentMode/ui/vaultPath";
@@ -45,6 +45,20 @@ export interface ToolSummary {
  * `lookupToolSummaryForAggregate` when they have a homogenous group.
  */
 export function lookupToolSummary(part: ToolCallPart): ToolSummary {
+  const base = selectToolSummary(part);
+  if (!part.mcpServer) return base;
+  // An MCP tool whose bare name collides with a native tool (e.g.
+  // `mcp__srv__read` → bare `read` → the Read/kind summary) would otherwise
+  // masquerade as that native tool. Prepend the server to the collapsed line
+  // for every MCP call so it always reads as `server · …`.
+  const server = part.mcpServer;
+  return {
+    ...base,
+    collapsedLine: (p, ctx) => `${server} · ${base.collapsedLine(p, ctx)}`,
+  };
+}
+
+function selectToolSummary(part: ToolCallPart): ToolSummary {
   // Heuristic: opencode's `task` tool is a sub-agent invocation but
   // surfaces no `vendorToolName` and maps to `kind: "other"`. Recognize
   // it by data shape so the registry stays backend-id-free.
@@ -107,6 +121,55 @@ function targetFromTitle(part: ToolCallPart): string {
   // "Read Read" / "Edited Edit".
   if (part.vendorToolName && t.toLowerCase() === part.vendorToolName.toLowerCase()) return "…";
   return t;
+}
+
+/**
+ * Turn a tool identifier into a readable label: split camelCase / PascalCase /
+ * snake_case / kebab-case into words, lowercase, then capitalize the first
+ * letter. "AskUserQuestion" → "Ask user question"; "query-docs" → "Query docs".
+ */
+function humanizeToolName(name: string): string {
+  const words = name
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .toLowerCase();
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : "";
+}
+
+/**
+ * Readable label for a tool with no dedicated summary (MCP tools,
+ * AskUserQuestion before its summary matches, unknown vendor tools). Never
+ * returns the "…" placeholder: a humanized identifier, or the verbatim
+ * friendly title for ACP tools that supply one, falling back to "Tool call".
+ * The `server ·` prefix for MCP tools is applied uniformly in
+ * `lookupToolSummary` so it survives even when an MCP tool routes to a
+ * native summary — see that function.
+ */
+function genericToolLabel(part: ToolCallPart): string {
+  // ACP backends with no vendor identity may supply a friendly multi-word
+  // title — show it verbatim rather than mangling it.
+  if (!part.vendorToolName && /\s/.test(part.title)) return part.title;
+  const bare = part.vendorToolName ?? part.title;
+  return humanizeToolName(bare) || "Tool call";
+}
+
+/**
+ * The first question's short header (preferred) or full text from an
+ * AskUserQuestion tool input. Null until the input has streamed in.
+ */
+function firstQuestionText(part: ToolCallPart): string | null {
+  const input = part.input as
+    | { questions?: Array<{ question?: unknown; header?: unknown }> }
+    | null
+    | undefined;
+  const first = input?.questions?.[0];
+  if (!first) return null;
+  const header = typeof first.header === "string" ? first.header.trim() : "";
+  if (header) return header;
+  const question = typeof first.question === "string" ? first.question.trim() : "";
+  return question || null;
 }
 
 /**
@@ -343,6 +406,20 @@ const EXIT_PLAN_SUMMARY: ToolSummary = {
   }),
 };
 
+const ASK_USER_QUESTION_SUMMARY: ToolSummary = {
+  icon: MessageCircleQuestion,
+  collapsedLine: (p) => {
+    const v = verb(p, "Asking", "Asked");
+    const q = firstQuestionText(p);
+    return q ? `${v}: "${q}"` : `${v} a question`;
+  },
+  outcome: () => null,
+  aggregate: (parts) => ({
+    line: `Asked ${pluralize(parts.length, "question")}${statusSuffix(parts)}`,
+    outcome: "",
+  }),
+};
+
 const VENDOR_SUMMARIES: Record<string, ToolSummary> = {
   Read: READ_SUMMARY,
   Edit: EDIT_SUMMARY,
@@ -360,6 +437,7 @@ const VENDOR_SUMMARIES: Record<string, ToolSummary> = {
   Agent: TASK_SUMMARY,
   TodoWrite: TODO_SUMMARY,
   ExitPlanMode: EXIT_PLAN_SUMMARY,
+  AskUserQuestion: ASK_USER_QUESTION_SUMMARY,
   LS: LIST_SUMMARY,
 };
 
@@ -434,7 +512,7 @@ const KIND_SUMMARIES: Record<string, ToolSummary> = {
 
 const GENERIC_SUMMARY: ToolSummary = {
   icon: pickToolIcon({}),
-  collapsedLine: (p) => targetFromTitle(p),
+  collapsedLine: (p) => genericToolLabel(p),
   outcome: () => null,
   aggregate: (parts) => ({
     line: `${pluralize(parts.length, "tool call")}${statusSuffix(parts)}`,

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -49,12 +49,19 @@ export function lookupToolSummary(part: ToolCallPart): ToolSummary {
   if (!part.mcpServer) return base;
   // An MCP tool whose bare name collides with a native tool (e.g.
   // `mcp__srv__read` → bare `read` → the Read/kind summary) would otherwise
-  // masquerade as that native tool. Prepend the server to the collapsed line
-  // for every MCP call so it always reads as `server · …`.
+  // masquerade as that native tool. Prepend the server to both the collapsed
+  // line and the compacted aggregate line so it always reads as `server · …`,
+  // even when two consecutive MCP calls fold into an `AggregateCard`.
+  // `toolKeyFor` namespaces MCP calls per-server, so every part in an
+  // aggregate shares this server — prefixing the aggregate line is safe.
   const server = part.mcpServer;
   return {
     ...base,
     collapsedLine: (p, ctx) => `${server} · ${base.collapsedLine(p, ctx)}`,
+    aggregate: (parts) => {
+      const agg = base.aggregate(parts);
+      return { ...agg, line: `${server} · ${agg.line}` };
+    },
   };
 }
 


### PR DESCRIPTION
Tool-call labels in the agent trail were mangled: MCP tools whose bare name collided with a native tool (e.g. `mcp__srv__read`) masqueraded as that native tool, and generic/unknown tools collapsed to a bare "…". This change adds a shared `resolveToolName` helper that splits a `mcp__<server>__<tool>` qualified name into a bare tool name plus an `mcpServer` field, threaded through the ACP and SDK translators, session types, and merge logic. The trail now renders MCP calls as `server · Tool name`, humanizes generic/unknown tool names (camelCase/snake_case/kebab-case → readable words) instead of showing "…", and adds a dedicated AskUserQuestion summary. It also fixes a `string | null` type error in `wireTranslate.ts` where a null tool-call title could reach `resolveToolName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)