### PR TITLE
feat(agent-mode): copy/insert message actions + shared action buttons

### DIFF
--- a/src/agentMode/ui/AgentChat.tsx
+++ b/src/agentMode/ui/AgentChat.tsx
@@ -387,19 +387,6 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
     clearSelectedTextContexts();
   }, [manager]);
 
-  const handleDelete = useCallback(
-    async (messageId: string) => {
-      try {
-        const ok = await backend.deleteMessage(messageId);
-        if (!ok) new Notice("Failed to delete message. Please try again.");
-      } catch (error) {
-        logError("Error deleting agent message:", error);
-        new Notice("Failed to delete message. Please try again.");
-      }
-    },
-    [backend]
-  );
-
   const descriptor = useSessionBackendDescriptor(manager);
   const handleInstall = useCallback(() => {
     descriptor.openInstallUI(plugin);
@@ -505,7 +492,6 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
             <AgentChatMessages
               messages={messages}
               app={app}
-              onDelete={handleDelete}
               currentPlan={currentPlan}
               pendingToolPermissions={pendingToolPermissions}
               chatBackend={backend}

--- a/src/agentMode/ui/AgentChatMessages.tsx
+++ b/src/agentMode/ui/AgentChatMessages.tsx
@@ -14,7 +14,6 @@ import React, { memo, useMemo } from "react";
 interface AgentChatMessagesProps {
   messages: AgentChatMessage[];
   app: App;
-  onDelete: (messageId: string) => void;
   currentPlan: CurrentPlan | null;
   pendingToolPermissions: PermissionPrompt[];
   chatBackend: AgentChatBackend;
@@ -45,7 +44,6 @@ const AgentChatMessages = memo(
   ({
     messages,
     app,
-    onDelete,
     currentPlan,
     pendingToolPermissions,
     chatBackend,
@@ -157,12 +155,11 @@ const AgentChatMessages = memo(
                     />
                   </div>
                 ) : (
-                  <ChatSingleMessage
-                    message={adaptedMessage}
-                    app={app}
-                    isStreaming={false}
-                    onDelete={() => onDelete(message.id)}
-                  />
+                  // Agent Mode has no per-message regenerate / edit / delete flow
+                  // yet (ACP owns conversation history server-side), so no
+                  // lifecycle handlers are wired — ChatButtons renders only the
+                  // copy / insert actions it can honor.
+                  <ChatSingleMessage message={adaptedMessage} app={app} isStreaming={false} />
                 )}
               </div>
             );

--- a/src/agentMode/ui/AgentMessageActions.tsx
+++ b/src/agentMode/ui/AgentMessageActions.tsx
@@ -1,0 +1,35 @@
+import { CopyButton } from "@/components/chat-components/CopyButton";
+import { MessageActionButton } from "@/components/chat-components/MessageActionButton";
+import { cn } from "@/lib/utils";
+import { insertAtCursor } from "@/utils";
+import { TextCursorInput } from "lucide-react";
+import { App, Platform } from "obsidian";
+import React from "react";
+
+interface AgentMessageActionsProps {
+  /** The cleaned, user-visible final answer — already run through
+   *  `cleanMessageForCopy` by the trail. Copied / inserted verbatim. */
+  text: string;
+  app: App;
+}
+
+/**
+ * Copy / Insert action row beneath a completed assistant turn in Agent Mode.
+ * Shares `MessageActionButton` / `CopyButton` with legacy chat's `ChatButtons`,
+ * but acts on the trail's final answer text rather than a `ChatMessage` —
+ * regenerate / edit / delete can slot into this same row later.
+ */
+export const AgentMessageActions: React.FC<AgentMessageActionsProps> = ({ text, app }) => (
+  <div
+    className={cn("tw-flex tw-justify-end tw-gap-1", {
+      "group-hover:opacity-100 opacity-0": !Platform.isMobile,
+    })}
+  >
+    <MessageActionButton
+      label="Insert / Replace at cursor"
+      icon={TextCursorInput}
+      onClick={() => void insertAtCursor(app, text)}
+    />
+    <CopyButton text={text} />
+  </div>
+);

--- a/src/agentMode/ui/AgentTrailView.test.tsx
+++ b/src/agentMode/ui/AgentTrailView.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { AppContext } from "@/context";
+import { AgentTrail } from "@/agentMode/ui/AgentTrailView";
+import type { AgentMessagePart } from "@/agentMode/session/types";
+
+// Render `text` parts as plain text so the test doesn't pull in Obsidian's
+// markdown renderer (`MarkdownRenderer.render` / `Component`).
+jest.mock("@/agentMode/ui/AgentMarkdownText", () => ({
+  AgentMarkdownText: ({ text }: { text: string }) => <div data-testid="agent-md">{text}</div>,
+}));
+
+// `insertAtCursor` is a spy (its selection→replace logic is covered by the
+// `insertAtCursor` unit test in utils.test.ts); `cleanMessageForCopy` is a thin
+// stand-in (real sanitization is covered by the `finalAnswerText` unit test) so
+// the cleaned text the buttons act on is deterministic here.
+jest.mock("@/utils", () => ({
+  cleanMessageForCopy: (s: string) => s.trim(),
+  insertAtCursor: jest.fn(),
+}));
+
+jest.mock("obsidian", () => {
+  class MarkdownView {}
+  return {
+    MarkdownView,
+    Component: class {
+      load() {}
+      unload() {}
+      register() {}
+    },
+    App: class {},
+    WorkspaceLeaf: class {},
+    Notice: class {},
+    Platform: { isMobile: false },
+  };
+});
+
+const { insertAtCursor } = jest.requireMock<{ insertAtCursor: jest.Mock }>("@/utils");
+
+const text = (value: string): AgentMessagePart => ({ kind: "text", text: value });
+
+function makeApp() {
+  return { workspace: { getActiveFile: jest.fn(() => null) } } as never;
+}
+
+function renderTrail(props: Partial<React.ComponentProps<typeof AgentTrail>> = {}) {
+  const app = props.app ?? makeApp();
+  const result = render(
+    <AppContext.Provider value={app}>
+      <TooltipProvider>
+        <AgentTrail
+          parts={[text("The final answer.  ")]}
+          isStreaming={false}
+          turnStopReason="end_turn"
+          app={app}
+          {...props}
+        />
+      </TooltipProvider>
+    </AppContext.Provider>
+  );
+  return { ...result, app };
+}
+
+describe("AgentTrail copy / insert actions", () => {
+  let writeText: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Radix tooltip portals render into Obsidian's `activeDocument` global.
+    (window as unknown as { activeDocument: Document }).activeDocument = window.document;
+    writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+  });
+
+  it("renders both buttons under a completed message and wires each to the cleaned final text", () => {
+    const { app } = renderTrail();
+
+    expect(screen.getByTitle("Copy")).toBeTruthy();
+    expect(screen.getByTitle("Insert / Replace at cursor")).toBeTruthy();
+
+    fireEvent.click(screen.getByTitle("Copy"));
+    expect(writeText).toHaveBeenCalledWith("The final answer.");
+
+    fireEvent.click(screen.getByTitle("Insert / Replace at cursor"));
+    expect(insertAtCursor).toHaveBeenCalledWith(app, "The final answer.");
+  });
+
+  it("renders neither button while the message is still streaming", () => {
+    renderTrail({ isStreaming: true, turnStopReason: undefined });
+    expect(screen.queryByTitle("Copy")).toBeNull();
+    expect(screen.queryByTitle("Insert / Replace at cursor")).toBeNull();
+  });
+
+  it("renders neither button when the turn was cancelled", () => {
+    renderTrail({ turnStopReason: "cancelled" });
+    expect(screen.queryByTitle("Copy")).toBeNull();
+    expect(screen.queryByTitle("Insert / Replace at cursor")).toBeNull();
+  });
+
+  it("renders neither button when the turn produced no trailing prose", () => {
+    renderTrail({ parts: [{ kind: "tool_call", id: "t1", title: "Read", status: "completed" }] });
+    expect(screen.queryByTitle("Copy")).toBeNull();
+    expect(screen.queryByTitle("Insert / Replace at cursor")).toBeNull();
+  });
+});

--- a/src/agentMode/ui/AgentTrailView.tsx
+++ b/src/agentMode/ui/AgentTrailView.tsx
@@ -1,7 +1,13 @@
 import React, { useState } from "react";
-import { buildAgentTrail, splitTrailingText, type RenderNode } from "@/agentMode/ui/agentTrail";
+import {
+  buildAgentTrail,
+  finalAnswerText,
+  splitTrailingText,
+  type RenderNode,
+} from "@/agentMode/ui/agentTrail";
 import type { AgentMessagePart, StopReason } from "@/agentMode/session/types";
 import { ActionCard } from "@/agentMode/ui/ActionCard";
+import { AgentMessageActions } from "@/agentMode/ui/AgentMessageActions";
 import { AggregateCard } from "@/agentMode/ui/AggregateCard";
 import { SubAgentCard } from "@/agentMode/ui/SubAgentCard";
 import { ReasoningBlock } from "@/agentMode/ui/ReasoningBlock";
@@ -52,6 +58,15 @@ export const AgentTrail: React.FC<AgentTrailProps> = ({
     typeof turnDurationMs === "number" &&
     parts.length > 0;
 
+  // Copy / Insert act on the turn's final answer only. Gate them off while the
+  // message is still streaming and on cancelled turns (treated as having no
+  // user-visible answer), plus whenever there is no trailing prose to act on.
+  const answer = finalAnswerText(parts);
+  const actions =
+    !isStreaming && turnStopReason !== "cancelled" && answer.length > 0 ? (
+      <AgentMessageActions text={answer} app={app} />
+    ) : null;
+
   if (canCollapse) {
     const { research, final } = splitTrailingText(parts);
     // Both halves must be non-empty for a collapse to be meaningful: research
@@ -61,24 +76,28 @@ export const AgentTrail: React.FC<AgentTrailProps> = ({
     const finalHasContent = final.some((p) => p.text.trim().length > 0);
     if (researchHasContent && finalHasContent) {
       return (
-        <div className="tw-flex tw-flex-col tw-gap-1">
+        <div className="tw-group tw-flex tw-flex-col tw-gap-1">
           <WorkedForBlock research={research} durationMs={turnDurationMs} app={app} />
           {final.map((p, i) => (
             // eslint-disable-next-line @eslint-react/no-array-index-key -- text parts are append-only and may contain duplicate text
             <AgentMarkdownText key={`final-${i}`} text={p.text} app={app} />
           ))}
+          {actions}
         </div>
       );
     }
   }
 
   return (
-    <LinearTrail
-      parts={parts}
-      isStreaming={isStreaming}
-      showThinkingTail={showThinkingTail}
-      app={app}
-    />
+    <div className="tw-group tw-flex tw-flex-col tw-gap-1">
+      <LinearTrail
+        parts={parts}
+        isStreaming={isStreaming}
+        showThinkingTail={showThinkingTail}
+        app={app}
+      />
+      {actions}
+    </div>
   );
 };
 

--- a/src/agentMode/ui/agentTrail.test.ts
+++ b/src/agentMode/ui/agentTrail.test.ts
@@ -1,4 +1,9 @@
-import { buildAgentTrail, splitTrailingText, type RenderNode } from "@/agentMode/ui/agentTrail";
+import {
+  buildAgentTrail,
+  finalAnswerText,
+  splitTrailingText,
+  type RenderNode,
+} from "@/agentMode/ui/agentTrail";
 import type { AgentMessagePart } from "@/agentMode/session/types";
 
 function tool(
@@ -338,5 +343,33 @@ describe("splitTrailingText", () => {
     const { research, final } = splitTrailingText(parts);
     expect(research).toHaveLength(2);
     expect(final).toEqual([]);
+  });
+});
+
+describe("finalAnswerText", () => {
+  it("returns only the trailing run of text parts, ignoring the research half", () => {
+    const parts: AgentMessagePart[] = [
+      thought("let me search the vault"),
+      tool("a", { vendorToolName: "Grep" }),
+      text("Here is an early note that should NOT be copied."),
+      tool("b", { vendorToolName: "Read" }),
+      text("This is the final answer."),
+    ];
+    expect(finalAnswerText(parts)).toBe("This is the final answer.");
+  });
+
+  it("sanitizes the trailing text the same way legacy chat copy does", () => {
+    const parts: AgentMessagePart[] = [
+      tool("a"),
+      text("<think>internal</think>The answer.\n\n\n\nMore.   "),
+    ];
+    // removeThinkTags strips the think block, 3+ newlines collapse to 2, and
+    // trailing whitespace is trimmed — matching `cleanMessageForCopy`.
+    expect(finalAnswerText(parts)).toBe("The answer.\n\nMore.");
+  });
+
+  it("returns an empty string when the turn produced no trailing prose", () => {
+    expect(finalAnswerText([thought("..."), tool("a")])).toBe("");
+    expect(finalAnswerText([])).toBe("");
   });
 });

--- a/src/agentMode/ui/agentTrail.ts
+++ b/src/agentMode/ui/agentTrail.ts
@@ -1,4 +1,5 @@
 import type { AgentMessagePart } from "@/agentMode/session/types";
+import { cleanMessageForCopy } from "@/utils";
 
 export type ToolCallPart = Extract<AgentMessagePart, { kind: "tool_call" }>;
 export type ThoughtPart = Extract<AgentMessagePart, { kind: "thought" }>;
@@ -51,6 +52,20 @@ export function splitTrailingText(parts: AgentMessagePart[]): {
     break;
   }
   return { research: parts.slice(0, boundary), final };
+}
+
+/**
+ * The turn's user-visible final answer, ready for the clipboard or the editor:
+ * the trailing run of `text` parts (per `splitTrailingText`) joined and run
+ * through the same sanitization legacy chat applies (`cleanMessageForCopy`),
+ * so tool-call cards, reasoning, plans, and chat-only artifacts never leak in.
+ * Returns `""` when the turn produced no trailing prose (a tool-only turn, or
+ * one cancelled mid-tool) — the trail UI uses that to gate the Copy / Insert
+ * affordances off so they never sit under an empty bubble.
+ */
+export function finalAnswerText(parts: AgentMessagePart[]): string {
+  const { final } = splitTrailingText(parts);
+  return cleanMessageForCopy(final.map((p) => p.text).join("\n\n"));
 }
 
 /**

--- a/src/commands/CustomCommandChatModal.tsx
+++ b/src/commands/CustomCommandChatModal.tsx
@@ -685,7 +685,7 @@ export class CustomCommandChatModal {
     const { anchorBottom, ...initialPosition } = this.getInitialPosition(activeView);
 
     const handleInsert = (message: string) => {
-      void insertIntoEditor(message);
+      void insertIntoEditor(this.app, message);
       this.close();
     };
 

--- a/src/components/chat-components/ChatButtons.test.tsx
+++ b/src/components/chat-components/ChatButtons.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { ChatButtons } from "@/components/chat-components/ChatButtons";
+import { USER_SENDER } from "@/constants";
+import type { ChatMessage } from "@/types/message";
+
+// `cleanMessageForCopy` is a thin stand-in here — its real sanitization is
+// covered in utils.test.ts. This keeps the heavy `@/utils` module (langchain,
+// luxon, obsidian) out of the component test.
+jest.mock("@/utils", () => ({
+  cleanMessageForCopy: (s: string) => s,
+}));
+
+jest.mock("obsidian", () => ({
+  Platform: { isMobile: false },
+}));
+
+function message(sender: string): ChatMessage {
+  return { sender, message: "body", isVisible: true, timestamp: null };
+}
+
+function renderButtons(props: Partial<React.ComponentProps<typeof ChatButtons>>) {
+  return render(
+    <TooltipProvider>
+      <ChatButtons message={message(USER_SENDER)} hasSources={false} {...props} />
+    </TooltipProvider>
+  );
+}
+
+beforeAll(() => {
+  // Radix tooltip portals render into Obsidian's `activeDocument` global.
+  (window as unknown as { activeDocument: Document }).activeDocument = window.document;
+});
+
+describe("ChatButtons lifecycle-action gating", () => {
+  describe("user message", () => {
+    it("shows Edit and Delete when their handlers are provided", () => {
+      renderButtons({ message: message(USER_SENDER), onEdit: () => {}, onDelete: () => {} });
+      expect(screen.getByTitle("Copy")).toBeTruthy();
+      expect(screen.getByTitle("Edit")).toBeTruthy();
+      expect(screen.getByTitle("Delete")).toBeTruthy();
+    });
+
+    it("hides Edit and Delete when no handlers are provided (Agent Mode)", () => {
+      renderButtons({ message: message(USER_SENDER) });
+      expect(screen.getByTitle("Copy")).toBeTruthy();
+      expect(screen.queryByTitle("Edit")).toBeNull();
+      expect(screen.queryByTitle("Delete")).toBeNull();
+    });
+  });
+
+  describe("assistant message", () => {
+    it("shows Regenerate and Delete when their handlers are provided", () => {
+      renderButtons({
+        message: message("AI"),
+        onInsertIntoEditor: () => {},
+        onRegenerate: () => {},
+        onDelete: () => {},
+      });
+      expect(screen.getByTitle("Insert / Replace at cursor")).toBeTruthy();
+      expect(screen.getByTitle("Copy")).toBeTruthy();
+      expect(screen.getByTitle("Regenerate")).toBeTruthy();
+      expect(screen.getByTitle("Delete")).toBeTruthy();
+    });
+
+    it("keeps Insert / Copy but hides Regenerate and Delete with no handlers (Agent Mode)", () => {
+      renderButtons({ message: message("AI"), onInsertIntoEditor: () => {} });
+      expect(screen.getByTitle("Insert / Replace at cursor")).toBeTruthy();
+      expect(screen.getByTitle("Copy")).toBeTruthy();
+      expect(screen.queryByTitle("Regenerate")).toBeNull();
+      expect(screen.queryByTitle("Delete")).toBeNull();
+    });
+  });
+});

--- a/src/components/chat-components/ChatButtons.tsx
+++ b/src/components/chat-components/ChatButtons.tsx
@@ -1,36 +1,25 @@
-import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { CopyButton } from "@/components/chat-components/CopyButton";
+import { MessageActionButton } from "@/components/chat-components/MessageActionButton";
 import { USER_SENDER } from "@/constants";
 import { cn } from "@/lib/utils";
 import { ChatMessage } from "@/types/message";
-import {
-  Check,
-  Copy,
-  LibraryBig,
-  PenSquare,
-  RotateCw,
-  TextCursorInput,
-  Trash2,
-} from "lucide-react";
+import { cleanMessageForCopy } from "@/utils";
+import { LibraryBig, PenSquare, RotateCw, TextCursorInput, Trash2 } from "lucide-react";
 import { Platform } from "obsidian";
 import React from "react";
 
 interface ChatButtonsProps {
   message: ChatMessage;
-  onCopy: () => void;
-  isCopied: boolean;
   onInsertIntoEditor?: () => void;
   onRegenerate?: () => void;
   onEdit?: () => void;
-  onDelete: () => void;
+  onDelete?: () => void;
   onShowSources?: () => void;
   hasSources: boolean;
 }
 
 export const ChatButtons: React.FC<ChatButtonsProps> = ({
   message,
-  onCopy,
-  isCopied,
   onInsertIntoEditor,
   onRegenerate,
   onEdit,
@@ -46,80 +35,25 @@ export const ChatButtons: React.FC<ChatButtonsProps> = ({
     >
       {message.sender === USER_SENDER ? (
         <>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button variant="ghost2" size="fit" onClick={onCopy} title="Copy">
-                {isCopied ? <Check className="tw-size-4" /> : <Copy className="tw-size-4" />}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Copy</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button onClick={onEdit} variant="ghost2" size="fit" title="Edit">
-                <PenSquare className="tw-size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Edit</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button onClick={onDelete} variant="ghost2" size="fit" title="Delete">
-                <Trash2 className="tw-size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Delete</TooltipContent>
-          </Tooltip>
+          <CopyButton text={cleanMessageForCopy(message.message)} />
+          {onEdit && <MessageActionButton label="Edit" icon={PenSquare} onClick={onEdit} />}
+          {onDelete && <MessageActionButton label="Delete" icon={Trash2} onClick={onDelete} />}
         </>
       ) : (
         <>
           {hasSources && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button onClick={onShowSources} variant="ghost2" size="fit" title="Show Sources">
-                  <LibraryBig className="tw-size-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Show Sources</TooltipContent>
-            </Tooltip>
+            <MessageActionButton label="Show Sources" icon={LibraryBig} onClick={onShowSources} />
           )}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                onClick={onInsertIntoEditor}
-                variant="ghost2"
-                size="fit"
-                title="Insert / Replace at cursor"
-              >
-                <TextCursorInput className="tw-size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Insert / Replace at cursor</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button variant="ghost2" size="fit" onClick={onCopy} title="Copy">
-                {isCopied ? <Check className="tw-size-4" /> : <Copy className="tw-size-4" />}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Copy</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button onClick={onRegenerate} variant="ghost2" size="fit" title="Regenerate">
-                <RotateCw className="tw-size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Regenerate</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button onClick={onDelete} variant="ghost2" size="fit" title="Delete">
-                <Trash2 className="tw-size-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>Delete</TooltipContent>
-          </Tooltip>
+          <MessageActionButton
+            label="Insert / Replace at cursor"
+            icon={TextCursorInput}
+            onClick={onInsertIntoEditor}
+          />
+          <CopyButton text={cleanMessageForCopy(message.message)} />
+          {onRegenerate && (
+            <MessageActionButton label="Regenerate" icon={RotateCw} onClick={onRegenerate} />
+          )}
+          {onDelete && <MessageActionButton label="Delete" icon={Trash2} onClick={onDelete} />}
         </>
       )}
     </div>

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -34,10 +34,10 @@ import { parseReasoningBlock } from "@/LLMProviders/chainRunner/utils/AgentReaso
 import { processInlineCitations } from "@/LLMProviders/chainRunner/utils/citationUtils";
 import { logError } from "@/logger";
 import { ChatMessage } from "@/types/message";
-import { cleanMessageForCopy, extractYoutubeVideoId, insertIntoEditor } from "@/utils";
+import { extractYoutubeVideoId, insertAtCursor } from "@/utils";
 import { preprocessAIResponse } from "@/utils/markdownPreprocess";
 import { renderMarkdown } from "@/utils/renderMarkdown";
-import { App, Component, MarkdownView, TFile } from "obsidian";
+import { App, Component, TFile } from "obsidian";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSettingsValue } from "@/settings/model";
 import {
@@ -302,7 +302,7 @@ interface ChatSingleMessageProps {
   isStreaming: boolean;
   onRegenerate?: () => void;
   onEdit?: (newMessage: string) => void;
-  onDelete: () => void;
+  onDelete?: () => void;
 }
 
 const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
@@ -313,7 +313,6 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
   onEdit,
   onDelete,
 }) => {
-  const [isCopied, setIsCopied] = useState<boolean>(false);
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const parsedReasoningBlock = useMemo(
     () => parseReasoningBlock(message.message),
@@ -363,24 +362,6 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
 
   // Check if current model has reasoning capability
   const settings = useSettingsValue();
-
-  const copyToClipboard = () => {
-    if (!navigator.clipboard || !navigator.clipboard.writeText) {
-      return;
-    }
-
-    const cleanedContent = cleanMessageForCopy(message.message);
-    navigator.clipboard
-      .writeText(cleanedContent)
-      .then(() => {
-        setIsCopied(true);
-
-        window.setTimeout(() => {
-          setIsCopied(false);
-        }, 2000);
-      })
-      .catch((err) => logError("Clipboard writeText failed", err));
-  };
 
   const preprocess = useCallback(
     (content: string): string => {
@@ -913,15 +894,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
   };
 
   const handleInsertIntoEditor = () => {
-    let leaf = app.workspace.getMostRecentLeaf();
-    if (!leaf || !(leaf.view instanceof MarkdownView)) {
-      leaf = app.workspace.getLeaf(false);
-      if (!leaf || !(leaf.view instanceof MarkdownView)) return;
-    }
-
-    const editor = leaf.view.editor;
-    const hasSelection = editor.getSelection().length > 0;
-    void insertIntoEditor(message.message, hasSelection);
+    void insertAtCursor(app, message.message);
   };
 
   const renderMessageContent = () => {
@@ -1029,11 +1002,9 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
               <div className="tw-text-xs tw-text-faint">{message.timestamp?.display}</div>
               <ChatButtons
                 message={message}
-                onCopy={copyToClipboard}
-                isCopied={isCopied}
                 onInsertIntoEditor={handleInsertIntoEditor}
                 onRegenerate={onRegenerate}
-                onEdit={handleEdit}
+                onEdit={onEdit ? handleEdit : undefined}
                 onDelete={onDelete}
                 onShowSources={handleShowSources}
                 hasSources={message.sources && message.sources.length > 0 ? true : false}

--- a/src/components/chat-components/CopyButton.tsx
+++ b/src/components/chat-components/CopyButton.tsx
@@ -1,0 +1,17 @@
+import { MessageActionButton } from "@/components/chat-components/MessageActionButton";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { Check, Copy } from "lucide-react";
+import React from "react";
+
+interface CopyButtonProps {
+  /** Final text copied verbatim — callers clean/format before passing. */
+  text: string;
+}
+
+/** Copy-to-clipboard action button that swaps to a check mark for 2s after copying. */
+export const CopyButton: React.FC<CopyButtonProps> = ({ text }) => {
+  const { isCopied, copy } = useCopyToClipboard();
+  return (
+    <MessageActionButton label="Copy" icon={isCopied ? Check : Copy} onClick={() => copy(text)} />
+  );
+};

--- a/src/components/chat-components/MessageActionButton.tsx
+++ b/src/components/chat-components/MessageActionButton.tsx
@@ -1,0 +1,31 @@
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { LucideIcon } from "lucide-react";
+import React from "react";
+
+interface MessageActionButtonProps {
+  /** Tooltip text and native button title. */
+  label: string;
+  /** Lucide icon rendered at the standard `tw-size-4`. */
+  icon: LucideIcon;
+  onClick?: () => void;
+}
+
+/**
+ * One ghost icon button in a message-action row (Copy / Insert / Edit / …),
+ * shared between legacy chat's `ChatButtons` and Agent Mode's action row.
+ */
+export const MessageActionButton: React.FC<MessageActionButtonProps> = ({
+  label,
+  icon: Icon,
+  onClick,
+}) => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <Button onClick={onClick} variant="ghost2" size="fit" title={label}>
+        <Icon className="tw-size-4" />
+      </Button>
+    </TooltipTrigger>
+    <TooltipContent>{label}</TooltipContent>
+  </Tooltip>
+);

--- a/src/components/modals/YoutubeTranscriptModal.tsx
+++ b/src/components/modals/YoutubeTranscriptModal.tsx
@@ -1,6 +1,7 @@
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useApp } from "@/context";
 import { logError } from "@/logger";
 import { formatYoutubeUrl, insertIntoEditor, validateYoutubeUrl } from "@/utils";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
@@ -15,6 +16,7 @@ interface TranscriptData {
 }
 
 function YoutubeTranscriptModalContent({ onClose }: { onClose: () => void }) {
+  const app = useApp();
   const [currentView, setCurrentView] = React.useState<"input" | "display">("input");
   const [url, setUrl] = React.useState("");
   const [isLoading, setIsLoading] = React.useState(false);
@@ -109,7 +111,7 @@ function YoutubeTranscriptModalContent({ onClose }: { onClose: () => void }) {
 
     try {
       const textToInsert = `# YouTube Video Transcript\n\nSource: ${transcriptData.url}\n\n${transcriptData.transcript}`;
-      await insertIntoEditor(textToInsert, false);
+      await insertIntoEditor(app, textToInsert, false);
       onClose();
     } catch (error) {
       logError("Failed to insert to note:", error);

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,25 @@
+import { logError } from "@/logger";
+import { useState } from "react";
+
+/**
+ * Copy-to-clipboard with a transient "copied" flag that auto-resets after 2s.
+ * Copies the string verbatim — callers clean/format the text before passing it.
+ */
+export function useCopyToClipboard(): { isCopied: boolean; copy: (text: string) => void } {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const copy = (text: string) => {
+    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+      return;
+    }
+    navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setIsCopied(true);
+        window.setTimeout(() => setIsCopied(false), 2000);
+      })
+      .catch((err) => logError("Clipboard writeText failed", err));
+  };
+
+  return { isCopied, copy };
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1017,15 +1017,8 @@ describe("insertAtCursor", () => {
     return { app, editor };
   }
 
-  afterEach(() => {
-    // @ts-ignore
-    delete window.app;
-  });
-
   it("inserts at the cursor when there is no selection", async () => {
     const { app, editor } = makeApp("");
-    // @ts-ignore — `insertIntoEditor` resolves the editor via the global app.
-    window.app = app;
 
     await insertAtCursor(app as never, "hello");
 
@@ -1034,12 +1027,20 @@ describe("insertAtCursor", () => {
 
   it("replaces from the selection start when text is selected", async () => {
     const { app, editor } = makeApp("selected");
-    // @ts-ignore
-    window.app = app;
 
     await insertAtCursor(app as never, "hello");
 
     expect(editor.replaceRange).toHaveBeenCalledWith("hello", from, to);
+  });
+
+  it("threads the passed app into the insertion (no global app)", async () => {
+    const { app, editor } = makeApp("");
+
+    await insertAtCursor(app as never, "hello");
+
+    // The write resolves its leaf through the passed app, not a global one.
+    expect(app.workspace.getMostRecentLeaf).toHaveBeenCalled();
+    expect(editor.replaceRange).toHaveBeenCalled();
   });
 
   it("does nothing when there is no markdown view to insert into", async () => {
@@ -1050,8 +1051,6 @@ describe("insertAtCursor", () => {
         getLeaf: jest.fn(() => leaf),
       },
     };
-    // @ts-ignore
-    window.app = app;
 
     await expect(insertAtCursor(app as never, "hello")).resolves.toBeUndefined();
   });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -8,6 +8,7 @@ import {
   getNotesFromPath,
   getNotesFromTags,
   getUtf8ByteLength,
+  insertAtCursor,
   isFolderMatch,
   shouldUseGitHubCopilotResponsesApi,
   processVariableNameForNotePath,
@@ -68,6 +69,8 @@ jest.mock("obsidian", () => {
   return {
     TFile: MockTFile,
     Vault: MockVault,
+    MarkdownView: class MockMarkdownView {},
+    Notice: class MockNotice {},
   };
 });
 
@@ -983,5 +986,73 @@ describe("getModelInfo", () => {
     expect(getModelInfo("claude-opus-4-1-20250805").usesAdaptiveThinking).toBe(false);
     // Dated 4.7 still matches because the minor is delimited by "-".
     expect(getModelInfo("claude-opus-4-7-20260115").usesAdaptiveThinking).toBe(true);
+  });
+});
+
+describe("insertAtCursor", () => {
+  const from = { line: 0, ch: 0 };
+  const to = { line: 0, ch: 5 };
+
+  // Builds an app whose most-recent leaf is a markdown view with the given
+  // selection. `editor.cm` is undefined so `insertIntoEditor` takes its Editor
+  // API fallback path, letting us assert on `replaceRange`.
+  function makeApp(selection: string) {
+    const editor = {
+      getSelection: jest.fn(() => selection),
+      getCursor: jest.fn((which: string) => (which === "from" ? from : to)),
+      replaceRange: jest.fn(),
+      setSelection: jest.fn(),
+      focus: jest.fn(),
+      cm: undefined,
+    };
+    const view = new (Obsidian.MarkdownView as unknown as new () => { editor: unknown })();
+    view.editor = editor;
+    const leaf = { view };
+    const app = {
+      workspace: {
+        getMostRecentLeaf: jest.fn(() => leaf),
+        getLeaf: jest.fn(() => leaf),
+      },
+    };
+    return { app, editor };
+  }
+
+  afterEach(() => {
+    // @ts-ignore
+    delete window.app;
+  });
+
+  it("inserts at the cursor when there is no selection", async () => {
+    const { app, editor } = makeApp("");
+    // @ts-ignore — `insertIntoEditor` resolves the editor via the global app.
+    window.app = app;
+
+    await insertAtCursor(app as never, "hello");
+
+    expect(editor.replaceRange).toHaveBeenCalledWith("hello", to, to);
+  });
+
+  it("replaces from the selection start when text is selected", async () => {
+    const { app, editor } = makeApp("selected");
+    // @ts-ignore
+    window.app = app;
+
+    await insertAtCursor(app as never, "hello");
+
+    expect(editor.replaceRange).toHaveBeenCalledWith("hello", from, to);
+  });
+
+  it("does nothing when there is no markdown view to insert into", async () => {
+    const leaf = { view: {} };
+    const app = {
+      workspace: {
+        getMostRecentLeaf: jest.fn(() => leaf),
+        getLeaf: jest.fn(() => leaf),
+      },
+    };
+    // @ts-ignore
+    window.app = app;
+
+    await expect(insertAtCursor(app as never, "hello")).resolves.toBeUndefined();
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,7 @@ import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { Document } from "@langchain/core/documents";
 import { MemoryVariables } from "@langchain/core/memory";
 import { DateTime } from "luxon";
-import { MarkdownView, Notice, TFile, Vault, normalizePath, requestUrl } from "obsidian";
+import { App, MarkdownView, Notice, TFile, Vault, normalizePath, requestUrl } from "obsidian";
 import { CustomModel } from "./aiParams";
 import { getApiKeyForProvider } from "@/utils/modelUtils";
 export { err2String } from "@/errorFormat";
@@ -876,6 +876,21 @@ export function cleanMessageForCopy(message: string): string {
   cleanedMessage = cleanedMessage.trim();
 
   return cleanedMessage;
+}
+
+/**
+ * Inserts text at the cursor of the most recent markdown editor, replacing the
+ * current selection when there is one. Resolves the target leaf via the passed
+ * `app` (no global `app`) and delegates the actual write to `insertIntoEditor`.
+ */
+export async function insertAtCursor(app: App, text: string) {
+  let leaf = app.workspace.getMostRecentLeaf();
+  if (!leaf || !(leaf.view instanceof MarkdownView)) {
+    leaf = app.workspace.getLeaf(false);
+    if (!leaf || !(leaf.view instanceof MarkdownView)) return;
+  }
+  const hasSelection = leaf.view.editor.getSelection().length > 0;
+  await insertIntoEditor(text, hasSelection);
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -881,7 +881,9 @@ export function cleanMessageForCopy(message: string): string {
 /**
  * Inserts text at the cursor of the most recent markdown editor, replacing the
  * current selection when there is one. Resolves the target leaf via the passed
- * `app` (no global `app`) and delegates the actual write to `insertIntoEditor`.
+ * `app` (no global `app`) and threads that same `app` into `insertIntoEditor`
+ * so selection detection and insertion always target the same editor — even in
+ * a popout window where the global `app` would resolve a different leaf.
  */
 export async function insertAtCursor(app: App, text: string) {
   let leaf = app.workspace.getMostRecentLeaf();
@@ -890,15 +892,18 @@ export async function insertAtCursor(app: App, text: string) {
     if (!leaf || !(leaf.view instanceof MarkdownView)) return;
   }
   const hasSelection = leaf.view.editor.getSelection().length > 0;
-  await insertIntoEditor(text, hasSelection);
+  await insertIntoEditor(app, text, hasSelection);
 }
 
 /**
  * Inserts a message into the active markdown editor, optionally replacing the current selection.
  * Uses a single CM6 transaction to avoid undo stack splitting.
  * Ensures the inserted/replaced range is selected after the operation.
+ *
+ * Resolves the target leaf from the passed `app` (not the global) so the write
+ * lands in the caller's window — critical for popout-window chats.
  */
-export async function insertIntoEditor(message: string, replace: boolean = false) {
+export async function insertIntoEditor(app: App, message: string, replace: boolean = false) {
   let leaf = app.workspace.getMostRecentLeaf();
   if (!leaf) {
     new Notice("No active leaf found.");


### PR DESCRIPTION
Adds a **Copy / Insert** action row beneath completed assistant turns in Agent Mode, gated on streaming completion, non-cancelled turns, and a non-empty trailing answer (`finalAnswerText`). Extracts shared `MessageActionButton`, `CopyButton`, and `useCopyToClipboard` primitives out of `ChatButtons`, which is now a thin composition reused by both legacy chat and the agent trail. Lifecycle buttons (Edit / Regenerate / Delete) now render only when a handler is wired, so Agent Mode — which can't regenerate or delete yet — shows only Copy / Insert for both user and assistant messages, and the orphaned delete wiring was removed. Also adds an `insertAtCursor(app, text)` helper that threads `app` instead of the global, plus tests for the button gating, trail actions, `finalAnswerText`, and `insertAtCursor`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)