### PR TITLE
fix(agent-mode): clarify GFM table rule to prevent broken caption pipes

### DIFF
--- a/src/agentMode/backends/shared/agentSystemPrompt.test.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.test.ts
@@ -107,8 +107,14 @@ describe("COPILOT_PROMPT_BASE", () => {
     expect(COPILOT_PROMPT_BASE).toMatch(/!\[alt\]\(url\)[^\n]*never wrap them in backticks/i);
   });
 
-  it("ports the v3 GitHub-table heading convention (rule 10)", () => {
-    expect(COPILOT_PROMPT_BASE).toContain("immediately add ` |` after the table heading");
+  it("specifies valid GitHub-flavored tables and forbids stray trailing pipes on caption lines", () => {
+    expect(COPILOT_PROMPT_BASE).toContain("a delimiter row of dashes");
+    expect(COPILOT_PROMPT_BASE).toMatch(
+      /never append a trailing `\|` to a caption, heading, or any line that is not itself a table row/
+    );
+    // The old ambiguous wording made the agent append ` |` to a table's caption
+    // line, producing an orphan pipe row that breaks GFM rendering.
+    expect(COPILOT_PROMPT_BASE).not.toContain("immediately add ` |` after the table heading");
   });
 
   it("retains the LaTeX and bullet-list formatting rules", () => {

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -62,7 +62,7 @@ export const COPILOT_PROMPT_BASE = `You are Obsidian Copilot, an AI assistant th
 - When showing note titles, use the \`[[title]]\` wikilink format and never wrap them in backticks or quotes.
 - For Obsidian-internal image links, use the \`![[link]]\` format and never wrap them in backticks.
 - For web image links, use the \`![alt](url)\` format and never wrap them in backticks.
-- For tables, use GitHub-flavored markdown. For table headings, immediately add \` |\` after the table heading.`;
+- For tables, use valid GitHub-flavored markdown: a header row, then a delimiter row of dashes (e.g. \`| --- | --- |\`), then one row per record — every row wrapped in leading and trailing \`|\`. Put a blank line before the table. If you label the table, put the label on its own line above that blank line; never append a trailing \`|\` to a caption, heading, or any line that is not itself a table row.`;
 
 /**
  * Compose the full system prompt every Agent Mode backend forwards. See the


### PR DESCRIPTION
The shared Agent Mode system prompt told the model to "immediately add ` |` after the table heading," which it interpreted as appending a trailing pipe to a table's caption/title line — producing an orphan pipe-terminated line above the real header with no delimiter row, which corrupts GFM table rendering. This replaces that ambiguous rule with an unambiguous GFM table spec (header row → dash delimiter row → data rows, blank line before the table) that explicitly forbids trailing pipes on any non-table-row line. The `COPILOT_PROMPT_BASE` test is updated to assert the new wording and that the old phrasing is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)