### PR TITLE
Enforce no-global-app via ESLint and fix all violations

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -108,8 +108,17 @@ export default [
       // no-deprecated: defer — surface the warnings, but don't fail CI yet
       "@typescript-eslint/no-deprecated": "off",
 
-      // SDL / import / no-unsanitized / depend: defer — review separately
-      "no-restricted-globals": "off",
+      // Ban the Obsidian-injected global `app` (footgun in popouts; hides
+      // dependencies from tests). Thread `app` via useApp() in React or as a
+      // parameter in plain modules. See PLUGIN_DEV_GUIDE.md.
+      "no-restricted-globals": [
+        "error",
+        {
+          name: "app",
+          message:
+            "Don't use the global `app` (footgun in popouts). Thread `app` via useApp() or a parameter. See designdocs/agents/PLUGIN_DEV_GUIDE.md.",
+        },
+      ],
     },
   },
 
@@ -163,6 +172,11 @@ export default [
     },
     rules: {
       "import/no-nodejs-modules": "off",
+      // Tests intentionally consume the global `app` mock (window.app, set up in
+      // __mocks__/obsidian.js) to feed it into the parameterized production
+      // functions under test. The footgun the ban guards against (popout windows,
+      // hidden dependencies) is a production concern, so don't enforce it here.
+      "no-restricted-globals": "off",
       // Tests use intentional `any` mocks; disable type-safety rules that flood
       // the test suite without adding signal.
       "@typescript-eslint/no-unsafe-member-access": "off",

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -5,7 +5,7 @@ import { logInfo } from "@/logger";
 import { turnOffPlus, turnOnPlus } from "@/plusUtils";
 import { getSettings } from "@/settings/model";
 import { arrayBufferToBase64 } from "@/utils/base64";
-import { requestUrl } from "obsidian";
+import { App, requestUrl } from "obsidian";
 
 /**
  * Build a multipart/form-data body buffer from a FormData instance.
@@ -253,6 +253,7 @@ export class BrevilabsClient {
    * unknown error.
    */
   async validateLicenseKey(
+    app?: App,
     context?: Record<string, unknown>
   ): Promise<{ isValid: boolean | undefined; plan?: string }> {
     // Build the request body with proper structure
@@ -289,7 +290,7 @@ export class BrevilabsClient {
 
     if (error) {
       if (error.message === "Invalid license key") {
-        turnOffPlus();
+        turnOffPlus(app);
         return { isValid: false };
       }
       // Do nothing if the error is not about the invalid license key

--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -133,7 +133,7 @@ export class AutonomousAgentChainRunner extends CopilotPlusChainRunner {
 
     // Initialize tools if not already done
     if (registry.getAllTools().length === 0) {
-      initializeBuiltinTools(this.chainManager.app?.vault);
+      initializeBuiltinTools(this.chainManager.app);
     }
 
     // Get enabled tool IDs from settings
@@ -386,7 +386,7 @@ export class AutonomousAgentChainRunner extends CopilotPlusChainRunner {
     this.llmFormattedMessages = [];
     this.lastDisplayedContent = "";
 
-    const isPlusUser = await checkIsPlusUser({
+    const isPlusUser = await checkIsPlusUser(this.chainManager.app, {
       isAutonomousAgent: true,
     });
 

--- a/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
+++ b/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
@@ -17,13 +17,13 @@ import { logInfo, logWarn } from "@/logger";
 import { checkIsPlusUser } from "@/plusUtils";
 import { getSettings } from "@/settings/model";
 import { getSystemPromptWithMemory } from "@/system-prompts/systemPromptBuilder";
-import { writeFileTool } from "@/tools/ComposerTools";
+import { createWriteFileTool } from "@/tools/ComposerTools";
 import { ToolManager } from "@/tools/toolManager";
 import { ToolResultFormatter } from "@/tools/ToolResultFormatter";
 import { ToolRegistry } from "@/tools/ToolRegistry";
 import { initializeBuiltinTools } from "@/tools/builtinTools";
-import { localSearchTool, webSearchTool } from "@/tools/SearchTools";
-import { updateMemoryTool } from "@/tools/memoryTools";
+import { createLocalSearchTool, webSearchTool } from "@/tools/SearchTools";
+import { createUpdateMemoryTool } from "@/tools/memoryTools";
 import { extractChatHistory } from "@/utils";
 import { ChatMessage, ResponseMetadata } from "@/types/message";
 import { getApiErrorMessage, getMessageRole, withSuppressedTokenWarnings } from "@/utils";
@@ -84,7 +84,7 @@ export class CopilotPlusChainRunner extends BaseChainRunner {
 
     // Initialize tools if not already done
     if (registry.getAllTools().length === 0) {
-      initializeBuiltinTools(this.chainManager.app?.vault);
+      initializeBuiltinTools(this.chainManager.app);
     }
 
     // Get all tools as StructuredTool instances
@@ -274,7 +274,7 @@ Include your extracted terms as: [SALIENT_TERMS: term1, term2, term3]`;
       const hasLocalSearch = toolCalls.some((tc) => tc.tool.name === "localSearch");
       if (!hasLocalSearch) {
         toolCalls.push({
-          tool: localSearchTool,
+          tool: createLocalSearchTool(this.chainManager.app),
           args: {
             query: cleanQuery,
             salientTerms: context.salientTerms,
@@ -307,7 +307,7 @@ Include your extracted terms as: [SALIENT_TERMS: term1, term2, term3]`;
       const hasUpdateMemory = toolCalls.some((tc) => tc.tool.name === "updateMemory");
       if (!hasUpdateMemory) {
         toolCalls.push({
-          tool: updateMemoryTool,
+          tool: createUpdateMemoryTool(this.chainManager.app),
           args: {
             statement: cleanQuery,
           },
@@ -409,7 +409,10 @@ Include your extracted terms as: [SALIENT_TERMS: term1, term2, term3]`;
 
       // If we have a source path and access to the app, resolve the wikilink
       if (sourcePath) {
-        const resolvedFile = app.metadataCache.getFirstLinkpathDest(imageName, sourcePath);
+        const resolvedFile = this.chainManager.app.metadataCache.getFirstLinkpathDest(
+          imageName,
+          sourcePath
+        );
 
         if (resolvedFile) {
           // Use the resolved path
@@ -446,7 +449,10 @@ Include your extracted terms as: [SALIENT_TERMS: term1, term2, term3]`;
 
       // If we have a source path and access to the app, resolve the path
       if (sourcePath) {
-        const resolvedFile = app.metadataCache.getFirstLinkpathDest(cleanPath, sourcePath);
+        const resolvedFile = this.chainManager.app.metadataCache.getFirstLinkpathDest(
+          cleanPath,
+          sourcePath
+        );
 
         if (resolvedFile) {
           // Use the resolved path
@@ -712,7 +718,10 @@ Include your extracted terms as: [SALIENT_TERMS: term1, term2, term3]`;
       contextEnvelope: userMessage.contextEnvelope,
     });
 
-    const actionStreamer = new ActionBlockStreamer(ToolManager, writeFileTool);
+    const actionStreamer = new ActionBlockStreamer(
+      ToolManager,
+      createWriteFileTool(this.chainManager.app)
+    );
 
     // Wrap the stream call with warning suppression
     const chatStream = await withSuppressedTokenWarnings(() =>
@@ -758,7 +767,7 @@ Include your extracted terms as: [SALIENT_TERMS: term1, term2, term3]`;
     const thinkStreamer = new ThinkBlockStreamer(updateCurrentAiMessage, excludeThinking);
     let sources: { title: string; path: string; score: number; explanation?: unknown }[] = [];
 
-    const isPlusUser = await checkIsPlusUser({
+    const isPlusUser = await checkIsPlusUser(this.chainManager.app, {
       isCopilotPlus: true,
     });
     if (!isPlusUser) {

--- a/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
+++ b/src/LLMProviders/chainRunner/VaultQAChainRunner.ts
@@ -99,7 +99,7 @@ export class VaultQAChainRunner extends BaseChainRunner {
 
       // Step 5a: Run FilterRetriever for guaranteed title/tag matches
       const hasTagTerms = tags.length > 0;
-      const filterRetriever = new FilterRetriever(app, {
+      const filterRetriever = new FilterRetriever(this.chainManager.app, {
         salientTerms: hasTagTerms ? [...tags] : [],
         maxK: settings.maxSourceChunks,
         returnAll: hasTagTerms,
@@ -111,7 +111,7 @@ export class VaultQAChainRunner extends BaseChainRunner {
       // When Miyo is active, Orama isn't initialized either, so also skip semantic → use lexical.
       const miyoActive = RetrieverFactory.isMiyoActive();
       const retrieverResult = await RetrieverFactory.createRetriever(
-        app,
+        this.chainManager.app,
         {
           minSimilarityScore: 0.01,
           maxK: settings.maxSourceChunks,

--- a/src/LLMProviders/projectManager.ts
+++ b/src/LLMProviders/projectManager.ts
@@ -778,7 +778,7 @@ modified: ${stat ? new Date(stat.mtime).toISOString() : "unknown"}`;
         webUrl,
         "web",
         async () => {
-          const result = await mention.processUrls(webUrl);
+          const result = await mention.processUrls(this.app.vault, webUrl);
 
           if (result.processedErrorUrls[webUrl]) {
             throw new Error(result.processedErrorUrls[webUrl]);
@@ -1033,7 +1033,7 @@ modified: ${stat ? new Date(stat.mtime).toISOString() : "unknown"}`;
     });
 
     return this.app.vault.getFiles().filter((file: TFile) => {
-      return shouldIndexFile(file, inclusionPatterns, exclusionPatterns, true);
+      return shouldIndexFile(this.app, file, inclusionPatterns, exclusionPatterns, true);
     });
   }
 

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -52,7 +52,7 @@ export type { ModelEnableGroup, ModelEnableRow } from "./ui/ModelEnableList";
 export { PlanPreviewView, PLAN_PREVIEW_VIEW_TYPE } from "./ui/PlanPreviewView";
 export type { PlanPreviewViewState } from "./ui/PlanPreviewView";
 export { getActiveBackendDescriptor, listBackendDescriptors } from "./backends/registry";
-export { frameSink as acpFrameSink } from "./session/debugSink";
+export { frameSink as acpFrameSink, setFrameSinkVaultBasePath } from "./session/debugSink";
 export { SkillManager, SkillsSettings, useManagedSkills } from "./skills";
 export type { Skill } from "./skills";
 

--- a/src/agentMode/session/AgentChatPersistenceManager.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.ts
@@ -129,7 +129,7 @@ export class AgentChatPersistenceManager {
       const chatContent = this.formatChatContent(messages);
       const firstMessageEpoch = messages[0].timestamp?.epoch ?? Date.now();
 
-      await ensureFolderExists(settings.defaultSaveFolder);
+      await ensureFolderExists(this.app.vault, settings.defaultSaveFolder);
 
       const existingFile = options?.existingPath
         ? this.resolveExistingFile(options.existingPath)

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -149,7 +149,7 @@ export class AgentSessionManager {
     if (!persistence) return [];
     const files = await persistence.getAgentChatHistoryFiles();
     const tracker = this.plugin.getChatHistoryLastAccessedAtManager();
-    return files.map((file) => fileToHistoryItem(file, tracker));
+    return files.map((file) => fileToHistoryItem(this.app, file, tracker));
   }
 
   /** Update the user-visible title (frontmatter `topic`) of a saved chat. */

--- a/src/agentMode/session/debugSink.ts
+++ b/src/agentMode/session/debugSink.ts
@@ -1,5 +1,3 @@
-import { FileSystemAdapter } from "obsidian";
-
 /**
  * Sidecar logger and payload formatter shared by every backend's debug tap.
  * The ACP runtime (`acp/debugTap.ts`) and the SDK adapter
@@ -59,6 +57,18 @@ export interface NodeRuntime {
 export interface FrameSinkOptions {
   vaultBasePath?: string | null;
   runtime?: NodeRuntime | null;
+}
+
+/**
+ * Vault base path seeded once at plugin load (see main.ts). The module-level
+ * `frameSink` singleton can't take `app` at construction, so this provides the
+ * base path it needs without reaching for the global `app`.
+ */
+let seededVaultBasePath: string | null = null;
+
+/** Seed the vault base path used by the module-level `frameSink` singleton. */
+export function setFrameSinkVaultBasePath(basePath: string | null): void {
+  seededVaultBasePath = basePath;
 }
 
 /**
@@ -174,7 +184,7 @@ export class FrameSink {
   private resolvePaths(): FrameLogPaths | null {
     const runtime = this.getRuntime();
     if (!runtime) return null;
-    const vaultBasePath = this.options.vaultBasePath ?? getVaultBasePath();
+    const vaultBasePath = this.options.vaultBasePath ?? seededVaultBasePath;
     if (!vaultBasePath) return null;
     return getFrameLogPaths(vaultBasePath, runtime);
   }
@@ -294,13 +304,6 @@ export function getFrameLogPaths(vaultBasePath: string, runtime: NodeRuntime): F
     logPath: runtime.join(dirPath, LOG_FILE_NAME),
     rotatedPath: runtime.join(dirPath, ROTATED_FILE_NAME),
   };
-}
-
-function getVaultBasePath(): string | null {
-  if (typeof app === "undefined") return null;
-  const adapter = app.vault?.adapter;
-  if (!(adapter instanceof FileSystemAdapter)) return null;
-  return adapter.getBasePath();
 }
 
 function getNodeRuntime(): NodeRuntime | null {

--- a/src/agentMode/session/expandCustomCommandPrefix.test.ts
+++ b/src/agentMode/session/expandCustomCommandPrefix.test.ts
@@ -2,7 +2,7 @@ import { mockTFile } from "@/__tests__/mockObsidian";
 import { expandCustomCommandPrefix } from "@/agentMode/session/expandCustomCommandPrefix";
 import { CustomCommand } from "@/commands/type";
 import { extractTemplateNoteFiles } from "@/utils";
-import { Vault } from "obsidian";
+import { App, Vault } from "obsidian";
 
 jest.mock("obsidian", () => ({
   Notice: jest.fn(),
@@ -42,6 +42,7 @@ const makeCommand = (overrides: Partial<CustomCommand>): CustomCommand => ({
 
 describe("expandCustomCommandPrefix", () => {
   let vault: Vault;
+  let app: App;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -51,49 +52,55 @@ describe("expandCustomCommandPrefix", () => {
         stat: jest.fn().mockResolvedValue({ ctime: Date.now(), mtime: Date.now() }),
       },
     } as unknown as Vault;
+    app = {
+      vault,
+      metadataCache: { getFileCache: jest.fn() },
+      workspace: { getActiveFile: jest.fn() },
+      fileManager: { processFrontMatter: jest.fn() },
+    } as unknown as App;
   });
 
   it("returns input unchanged when text does not start with slash", async () => {
-    const result = await expandCustomCommandPrefix("hello world", [], vault, "", null);
+    const result = await expandCustomCommandPrefix("hello world", [], app, "", null);
     expect(result).toEqual({ text: "hello world" });
   });
 
   it("returns input unchanged when no command matches", async () => {
     const cmds = [makeCommand({ title: "foo", content: "FOO BODY" })];
-    const result = await expandCustomCommandPrefix("/unknown", cmds, vault, "", null);
+    const result = await expandCustomCommandPrefix("/unknown", cmds, app, "", null);
     expect(result).toEqual({ text: "/unknown" });
   });
 
   it("returns input unchanged for a lone slash", async () => {
     const cmds = [makeCommand({ title: "foo", content: "FOO BODY" })];
-    const result = await expandCustomCommandPrefix("/", cmds, vault, "", null);
+    const result = await expandCustomCommandPrefix("/", cmds, app, "", null);
     expect(result).toEqual({ text: "/" });
   });
 
   it("returns input unchanged when an empty commands list is given (skill collision case)", async () => {
     // Mirrors composeSlashMenuItems: if a skill shadows the command title,
     // the command never reaches this expander, so an empty list = pass-through.
-    const result = await expandCustomCommandPrefix("/foo", [], vault, "", null);
+    const result = await expandCustomCommandPrefix("/foo", [], app, "", null);
     expect(result).toEqual({ text: "/foo" });
   });
 
   it("expands `/foo` exactly to the command body (no args)", async () => {
     const cmd = makeCommand({ title: "foo", content: "FOO BODY" });
-    const result = await expandCustomCommandPrefix("/foo", [cmd], vault, "", null);
+    const result = await expandCustomCommandPrefix("/foo", [cmd], app, "", null);
     expect(result.matched).toBe(cmd);
     expect(result.text).toBe("FOO BODY\n\n");
   });
 
   it("is case-insensitive on the command title", async () => {
     const cmd = makeCommand({ title: "Random-Hello", content: "Say hi" });
-    const result = await expandCustomCommandPrefix("/random-hello", [cmd], vault, "", null);
+    const result = await expandCustomCommandPrefix("/random-hello", [cmd], app, "", null);
     expect(result.matched).toBe(cmd);
     expect(result.text).toBe("Say hi\n\n");
   });
 
   it("appends trailing args to the body before processing", async () => {
     const cmd = makeCommand({ title: "foo", content: "FOO BODY" });
-    const result = await expandCustomCommandPrefix("/foo bar baz", [cmd], vault, "", null);
+    const result = await expandCustomCommandPrefix("/foo bar baz", [cmd], app, "", null);
     expect(result.matched).toBe(cmd);
     expect(result.text).toBe("FOO BODY\n\nbar baz\n\n");
   });
@@ -101,14 +108,14 @@ describe("expandCustomCommandPrefix", () => {
   it("prefers the longest matching title", async () => {
     const fooBar = makeCommand({ title: "foo-bar", content: "LONG" });
     const foo = makeCommand({ title: "foo", content: "SHORT" });
-    const result = await expandCustomCommandPrefix("/foo-bar args", [foo, fooBar], vault, "", null);
+    const result = await expandCustomCommandPrefix("/foo-bar args", [foo, fooBar], app, "", null);
     expect(result.matched).toBe(fooBar);
     expect(result.text).toBe("LONG\n\nargs\n\n");
   });
 
   it("does not match when the title is a prefix but not followed by whitespace", async () => {
     const foo = makeCommand({ title: "foo", content: "FOO" });
-    const result = await expandCustomCommandPrefix("/foobar", [foo], vault, "", null);
+    const result = await expandCustomCommandPrefix("/foobar", [foo], app, "", null);
     expect(result).toEqual({ text: "/foobar" });
   });
 
@@ -117,7 +124,7 @@ describe("expandCustomCommandPrefix", () => {
     const result = await expandCustomCommandPrefix(
       "/rewrite",
       [cmd],
-      vault,
+      app,
       "the selected paragraph",
       null
     );
@@ -133,7 +140,7 @@ describe("expandCustomCommandPrefix", () => {
     const utils = jest.requireMock<{ getFileContent: jest.Mock }>("@/utils");
     utils.getFileContent.mockResolvedValue("note body");
 
-    const result = await expandCustomCommandPrefix("/summarize", [cmd], vault, "", activeNote);
+    const result = await expandCustomCommandPrefix("/summarize", [cmd], app, "", activeNote);
     expect(result.matched).toBe(cmd);
     expect(result.text).toContain('<selected_text type="active_note">');
     expect(result.text).toContain("note body");

--- a/src/agentMode/session/expandCustomCommandPrefix.ts
+++ b/src/agentMode/session/expandCustomCommandPrefix.ts
@@ -1,6 +1,6 @@
 import { processPrompt } from "@/commands/customCommandUtils";
 import type { CustomCommand } from "@/commands/type";
-import type { TFile, Vault } from "obsidian";
+import type { App, TFile } from "obsidian";
 
 export interface ExpandCustomCommandResult {
   /** Final text to send to the backend. Equal to input when no command matched. */
@@ -26,7 +26,7 @@ export interface ExpandCustomCommandResult {
 export async function expandCustomCommandPrefix(
   input: string,
   commands: readonly CustomCommand[],
-  vault: Vault,
+  app: App,
   selectedText: string,
   activeNote: TFile | null
 ): Promise<ExpandCustomCommandResult> {
@@ -48,6 +48,6 @@ export async function expandCustomCommandPrefix(
   const args = afterSlash.slice(matched.title.length).trim();
   const body = args ? `${matched.content}\n\n${args}` : matched.content;
 
-  const result = await processPrompt(body, selectedText, vault, activeNote, false);
+  const result = await processPrompt(app, body, selectedText, app.vault, activeNote, false);
   return { text: result.processedPrompt, matched };
 }

--- a/src/agentMode/skills/ui/SkillsSettings.tsx
+++ b/src/agentMode/skills/ui/SkillsSettings.tsx
@@ -24,7 +24,8 @@ import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
 import { updateSetting, useSettingsValue, validateSkillsFolder } from "@/settings/model";
 import { AlertTriangle, Folder, Search } from "lucide-react";
-import { FileSystemAdapter, Notice, TFile, TFolder } from "obsidian";
+import { App, FileSystemAdapter, Notice, TFile, TFolder } from "obsidian";
+import { useApp } from "@/context";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
@@ -56,6 +57,7 @@ const SYNC_BRANDS: ReadonlyArray<{ substr: string; brand: string }> = [
  * and the sync-folder banner.
  */
 export const SkillsSettings: React.FC = () => {
+  const app = useApp();
   const settings = useSettingsValue();
   // Brand projection of every registered backend. Sourced from the public
   // registry — descriptors are module-level constants so the list is stable
@@ -149,14 +151,17 @@ export const SkillsSettings: React.FC = () => {
    * "Folder already exists" error as it tries to create a new note, so we
    * hand those off to the OS default editor via Electron's shell instead.
    */
-  const handleOpenSkillMdAbsPath = useCallback((absPath: string) => {
-    const vaultRel = vaultRelativePath(absPath);
-    if (vaultRel !== null && app.vault.getAbstractFileByPath(vaultRel) instanceof TFile) {
-      void app.workspace.openLinkText(vaultRel, "", true);
-      return;
-    }
-    void openWithSystemDefault(absPath);
-  }, []);
+  const handleOpenSkillMdAbsPath = useCallback(
+    (absPath: string) => {
+      const vaultRel = vaultRelativePath(app, absPath);
+      if (vaultRel !== null && app.vault.getAbstractFileByPath(vaultRel) instanceof TFile) {
+        void app.workspace.openLinkText(vaultRel, "", true);
+        return;
+      }
+      void openWithSystemDefault(absPath);
+    },
+    [app]
+  );
 
   /** Open the canonical SKILL.md of a managed skill in Obsidian's editor. */
   const handleEditSkillMd = useCallback(
@@ -167,14 +172,17 @@ export const SkillsSettings: React.FC = () => {
   );
 
   /** Reveal the canonical skill folder in Obsidian's file explorer. */
-  const handleRevealInVault = useCallback((skill: Skill) => {
-    const folderRel = vaultRelativePath(skill.dirPath);
-    if (folderRel === null) {
-      new Notice("Could not resolve the skill folder inside this vault.");
-      return;
-    }
-    revealInFileExplorer(folderRel);
-  }, []);
+  const handleRevealInVault = useCallback(
+    (skill: Skill) => {
+      const folderRel = vaultRelativePath(app, skill.dirPath);
+      if (folderRel === null) {
+        new Notice("Could not resolve the skill folder inside this vault.");
+        return;
+      }
+      revealInFileExplorer(app, folderRel);
+    },
+    [app]
+  );
 
   const filteredSkills = useMemo(() => filterSkills(skills, searchValue), [skills, searchValue]);
 
@@ -213,7 +221,7 @@ export const SkillsSettings: React.FC = () => {
         }
       ).open();
     },
-    [displayFolder]
+    [app, displayFolder]
   );
 
   /** Open the native delete confirmation modal. */
@@ -233,12 +241,12 @@ export const SkillsSettings: React.FC = () => {
         }
       ).open();
     },
-    [displayFolder]
+    [app, displayFolder]
   );
 
   // Detect a sync-folder vault on every render — the absolute path is
   // stable across the session so the work is trivial.
-  const syncBrand = useMemo(() => detectSyncBrand(), []);
+  const syncBrand = useMemo(() => detectSyncBrand(app), [app]);
 
   return (
     <div ref={containerRef} className="tw-space-y-4">
@@ -492,7 +500,7 @@ async function openWithSystemDefault(absPath: string): Promise<void> {
  * if the vault has no `FileSystemAdapter` or the absolute path lies outside
  * the vault.
  */
-function vaultRelativePath(absPath: string): string | null {
+function vaultRelativePath(app: App, absPath: string): string | null {
   const adapter = app.vault.adapter;
   if (!(adapter instanceof FileSystemAdapter)) return null;
   const base = adapter.getBasePath().replace(/[/\\]+$/, "");
@@ -509,7 +517,7 @@ function vaultRelativePath(absPath: string): string | null {
  * plugin. Falls back to a Notice if the explorer isn't installed or the
  * folder isn't in the vault cache (hidden dotfile folder, etc.).
  */
-function revealInFileExplorer(relPath: string): void {
+function revealInFileExplorer(app: App, relPath: string): void {
   const folder = app.vault.getAbstractFileByPath(relPath);
   if (folder instanceof TFolder) {
     const fileExplorer = (
@@ -544,7 +552,7 @@ function revealInFileExplorer(relPath: string): void {
  * fragment. Returns the brand name to display, or `null` when the vault
  * doesn't appear to be under a known sync root.
  */
-function detectSyncBrand(): string | null {
+function detectSyncBrand(app: App): string | null {
   const adapter = app.vault.adapter;
   if (!(adapter instanceof FileSystemAdapter)) return null;
   const base = adapter.getBasePath().toLowerCase();

--- a/src/agentMode/ui/AgentChat.tsx
+++ b/src/agentMode/ui/AgentChat.tsx
@@ -301,7 +301,7 @@ const AgentChatInternal: React.FC<AgentChatProps> = ({
     const expanded = await expandCustomCommandPrefix(
       text,
       getCachedCustomCommands(),
-      app.vault,
+      app,
       noteSelection?.content ?? "",
       activeFile
     );

--- a/src/cache/fileCache.ts
+++ b/src/cache/fileCache.ts
@@ -1,6 +1,6 @@
 import { logError, logInfo } from "@/logger";
 import { md5 } from "@/utils/hash";
-import { TFile } from "obsidian";
+import { TFile, Vault } from "obsidian";
 
 export interface FileCacheEntry<T> {
   content: T;
@@ -23,10 +23,10 @@ export class FileCache<T> {
     return FileCache.instance as FileCache<T>;
   }
 
-  private async ensureCacheDir() {
-    if (!(await app.vault.adapter.exists(this.cacheDir))) {
+  private async ensureCacheDir(vault: Vault) {
+    if (!(await vault.adapter.exists(this.cacheDir))) {
       logInfo("Creating file cache directory:", this.cacheDir);
-      await app.vault.adapter.mkdir(this.cacheDir);
+      await vault.adapter.mkdir(this.cacheDir);
     }
   }
 
@@ -40,7 +40,7 @@ export class FileCache<T> {
     return `${this.cacheDir}/${cacheKey}.md`;
   }
 
-  async get(cacheKey: string): Promise<T | null> {
+  async get(vault: Vault, cacheKey: string): Promise<T | null> {
     try {
       // Check memory cache first
       const memoryResult = this.memoryCache.get(cacheKey);
@@ -50,9 +50,9 @@ export class FileCache<T> {
       }
 
       const cachePath = this.getCachePath(cacheKey);
-      if (await app.vault.adapter.exists(cachePath)) {
+      if (await vault.adapter.exists(cachePath)) {
         logInfo("File cache hit:", cacheKey);
-        const cacheContent = await app.vault.adapter.read(cachePath);
+        const cacheContent = await vault.adapter.read(cachePath);
 
         // .md files contain either plain string content or JSON-serialized content
         // The safest approach is to go back to a simpler method that doesn't try to embed metadata in the content itself.
@@ -96,9 +96,9 @@ export class FileCache<T> {
     }
   }
 
-  async set(cacheKey: string, content: T): Promise<void> {
+  async set(vault: Vault, cacheKey: string, content: T): Promise<void> {
     try {
-      await this.ensureCacheDir();
+      await this.ensureCacheDir(vault);
       const cachePath = this.getCachePath(cacheKey);
 
       const timestamp = Date.now();
@@ -120,22 +120,22 @@ export class FileCache<T> {
         serializedContent = JSON.stringify(content, null, 2);
       }
 
-      await app.vault.adapter.write(cachePath, serializedContent);
+      await vault.adapter.write(cachePath, serializedContent);
       logInfo("Cached file content:", cacheKey);
     } catch (error) {
       logError("Error writing to file cache:", error);
     }
   }
 
-  async remove(cacheKey: string): Promise<void> {
+  async remove(vault: Vault, cacheKey: string): Promise<void> {
     try {
       // Remove from memory cache
       this.memoryCache.delete(cacheKey);
 
       // Remove from file cache (markdown format)
       const cachePath = this.getCachePath(cacheKey);
-      if (await app.vault.adapter.exists(cachePath)) {
-        await app.vault.adapter.remove(cachePath);
+      if (await vault.adapter.exists(cachePath)) {
+        await vault.adapter.remove(cachePath);
         logInfo("Removed file from cache:", cacheKey);
       }
     } catch (error) {
@@ -143,18 +143,18 @@ export class FileCache<T> {
     }
   }
 
-  async clear(): Promise<void> {
+  async clear(vault: Vault): Promise<void> {
     try {
       // Clear memory cache
       this.memoryCache.clear();
 
       // Clear file cache
-      if (await app.vault.adapter.exists(this.cacheDir)) {
-        const files = await app.vault.adapter.list(this.cacheDir);
+      if (await vault.adapter.exists(this.cacheDir)) {
+        const files = await vault.adapter.list(this.cacheDir);
         logInfo("Clearing file cache, removing files:", files.files.length);
 
         for (const file of files.files) {
-          await app.vault.adapter.remove(file);
+          await vault.adapter.remove(file);
         }
       }
     } catch (error) {

--- a/src/cache/pdfCache.ts
+++ b/src/cache/pdfCache.ts
@@ -1,7 +1,7 @@
 import { Pdf4llmResponse } from "@/LLMProviders/brevilabsClient";
 import { logError, logInfo } from "@/logger";
 import { md5 } from "@/utils/hash";
-import { TFile } from "obsidian";
+import { TFile, Vault } from "obsidian";
 
 export class PDFCache {
   private static instance: PDFCache;
@@ -16,10 +16,10 @@ export class PDFCache {
     return PDFCache.instance;
   }
 
-  private async ensureCacheDir() {
-    if (!(await app.vault.adapter.exists(this.cacheDir))) {
+  private async ensureCacheDir(vault: Vault) {
+    if (!(await vault.adapter.exists(this.cacheDir))) {
       logInfo("Creating PDF cache directory:", this.cacheDir);
-      await app.vault.adapter.mkdir(this.cacheDir);
+      await vault.adapter.mkdir(this.cacheDir);
     }
   }
 
@@ -35,14 +35,14 @@ export class PDFCache {
     return `${this.cacheDir}/${cacheKey}.json`;
   }
 
-  async get(file: TFile): Promise<Pdf4llmResponse | null> {
+  async get(vault: Vault, file: TFile): Promise<Pdf4llmResponse | null> {
     try {
       const cacheKey = this.getCacheKey(file);
       const cachePath = this.getCachePath(cacheKey);
 
-      if (await app.vault.adapter.exists(cachePath)) {
+      if (await vault.adapter.exists(cachePath)) {
         logInfo("Cache hit for PDF:", file.path);
-        const cacheContent = await app.vault.adapter.read(cachePath);
+        const cacheContent = await vault.adapter.read(cachePath);
         return JSON.parse(cacheContent) as Pdf4llmResponse;
       }
       logInfo("Cache miss for PDF:", file.path);
@@ -53,25 +53,25 @@ export class PDFCache {
     }
   }
 
-  async set(file: TFile, response: Pdf4llmResponse): Promise<void> {
+  async set(vault: Vault, file: TFile, response: Pdf4llmResponse): Promise<void> {
     try {
-      await this.ensureCacheDir();
+      await this.ensureCacheDir(vault);
       const cacheKey = this.getCacheKey(file);
       const cachePath = this.getCachePath(cacheKey);
       logInfo("Caching PDF response for:", file.path);
-      await app.vault.adapter.write(cachePath, JSON.stringify(response));
+      await vault.adapter.write(cachePath, JSON.stringify(response));
     } catch (error) {
       logError("Error writing to PDF cache:", error);
     }
   }
 
-  async clear(): Promise<void> {
+  async clear(vault: Vault): Promise<void> {
     try {
-      if (await app.vault.adapter.exists(this.cacheDir)) {
-        const files = await app.vault.adapter.list(this.cacheDir);
+      if (await vault.adapter.exists(this.cacheDir)) {
+        const files = await vault.adapter.list(this.cacheDir);
         logInfo("Clearing PDF cache, removing files:", files.files.length);
         for (const file of files.files) {
-          await app.vault.adapter.remove(file);
+          await vault.adapter.remove(file);
         }
       }
     } catch (error) {

--- a/src/cache/projectContextCache.ts
+++ b/src/cache/projectContextCache.ts
@@ -4,7 +4,7 @@ import { logError, logInfo, logWarn } from "@/logger";
 import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
 import { getCachedProjects } from "@/projects/state";
 import { md5 } from "@/utils/hash";
-import { TAbstractFile, TFile, Vault } from "obsidian";
+import { App, TAbstractFile, TFile, Vault } from "obsidian";
 import { debounce } from "@/utils/debounce";
 import { Mutex } from "async-mutex";
 
@@ -68,21 +68,33 @@ export class ProjectContextCache {
   private static instance: ProjectContextCache;
   private cacheDir: string = ".copilot/project-context-cache";
   private memoryCache: Map<string, ContextCache> = new Map();
+  private app: App;
   private vault: Vault;
   private fileCache: FileCache<string>;
   private static readonly DEBOUNCE_DELAY = 5000; // 5 seconds
   private projectMutexMap: Map<string, Mutex> = new Map();
   private mutexCreationMutex: Mutex = new Mutex(); // Global lock to protect project mutex creation
 
-  private constructor() {
+  private constructor(app: App) {
+    this.app = app;
     this.vault = app.vault;
     this.fileCache = FileCache.getInstance<string>();
     this.initializeEventListeners();
   }
 
-  static getInstance(): ProjectContextCache {
+  /**
+   * Returns the singleton. `app` is required on the first call (which creates
+   * the instance) and ignored afterward; the plugin seeds it once at load
+   * (see main.ts) so subsequent call sites can omit it.
+   */
+  static getInstance(app?: App): ProjectContextCache {
     if (!ProjectContextCache.instance) {
-      ProjectContextCache.instance = new ProjectContextCache();
+      if (!app) {
+        throw new Error(
+          "ProjectContextCache.getInstance() requires `app` on first call (seed it at plugin load)."
+        );
+      }
+      ProjectContextCache.instance = new ProjectContextCache(app);
     }
     return ProjectContextCache.instance;
   }
@@ -136,7 +148,7 @@ export class ProjectContextCache {
           isProject: true,
         });
 
-        if (shouldIndexFile(file, inclusions, exclusions, true)) {
+        if (shouldIndexFile(this.app, file, inclusions, exclusions, true)) {
           // Only invalidate markdown context, keep other contexts
           await this.invalidateMarkdownContext(project);
           logInfo(
@@ -350,7 +362,7 @@ export class ProjectContextCache {
 
       // Only remove the file cache entries that were referenced by projects
       for (const cacheKey of allFileKeysToRemove) {
-        await this.fileCache.remove(cacheKey);
+        await this.fileCache.remove(this.vault, cacheKey);
       }
 
       logInfo(
@@ -381,7 +393,7 @@ export class ProjectContextCache {
           for (const filePath in projectCache.fileContexts) {
             const fileEntry = projectCache.fileContexts[filePath];
             if (fileEntry && fileEntry.cacheKey) {
-              await this.fileCache.remove(fileEntry.cacheKey); // fileCache.remove logs its own success/failure per file
+              await this.fileCache.remove(this.vault, fileEntry.cacheKey); // fileCache.remove logs its own success/failure per file
               filesClearedCount++;
             } else {
               logWarn(
@@ -572,7 +584,7 @@ export class ProjectContextCache {
         return null; // This will prevent fileCache.get from being called with a non-string.
       }
 
-      return await this.fileCache.get(cacheKey); // fileCache.get already logs "Cache miss for file:"
+      return await this.fileCache.get(this.vault, cacheKey); // fileCache.get already logs "Cache miss for file:"
     } catch (error) {
       logError(`Error getting file context for ${filePath} in project ${project.name}:`, error);
       return null;
@@ -598,7 +610,7 @@ export class ProjectContextCache {
       const cacheKey = this.fileCache.getCacheKey(file, project.id);
 
       // Store the file content in FileCache
-      await this.fileCache.set(cacheKey, content);
+      await this.fileCache.set(this.vault, cacheKey, content);
 
       // Store just the metadata in the project context
       cache.fileContexts[filePath] = {
@@ -624,7 +636,7 @@ export class ProjectContextCache {
         delete cache.fileContexts[filePath];
 
         // Remove from file cache
-        await this.fileCache.remove(cacheKey);
+        await this.fileCache.remove(this.vault, cacheKey);
 
         logInfo(`Removed file context for ${filePath} in project ${project.name}`);
       }
@@ -661,7 +673,7 @@ export class ProjectContextCache {
           if (!cacheKey) continue;
 
           // Try to get content from this project's cache
-          const content = await this.fileCache.get(cacheKey);
+          const content = await this.fileCache.get(this.vault, cacheKey);
           if (content) {
             logInfo(`Found content for file ${filePath} in project ${project.name}`);
             return { content, cacheKey };
@@ -723,7 +735,10 @@ export class ProjectContextCache {
       const file = this.vault.getAbstractFileByPath(filePath);
 
       // If file no longer exists or doesn't match patterns, remove its reference
-      if (!(file instanceof TFile) || !shouldIndexFile(file, inclusions, exclusions, true)) {
+      if (
+        !(file instanceof TFile) ||
+        !shouldIndexFile(this.app, file, inclusions, exclusions, true)
+      ) {
         // Note: We don't remove from fileCache to preserve content for future use
         removedCount++;
       } else {
@@ -784,7 +799,7 @@ export class ProjectContextCache {
       let addedCount = 0;
 
       for (const file of allFiles) {
-        if (shouldIndexFile(file, inclusions, exclusions, true)) {
+        if (shouldIndexFile(this.app, file, inclusions, exclusions, true)) {
           if (contextCacheToUpdate.fileContexts[file.path]) {
             continue;
           }

--- a/src/commands/CustomCommandChatModal.tsx
+++ b/src/commands/CustomCommandChatModal.tsx
@@ -1,6 +1,7 @@
 import { CustomModel, useModelKey } from "@/aiParams";
 import { processCommandPrompt } from "@/commands/customCommandUtils";
 import { MenuCommandModal, type ContentState } from "@/components/command-ui";
+import { useApp } from "@/context";
 import {
   MODAL_MIN_HEIGHT_COMPACT,
   MODAL_MIN_HEIGHT_EXPANDED,
@@ -110,6 +111,7 @@ function CustomCommandChatModalContent({
   anchorBottom,
   behaviorConfig,
 }: CustomCommandChatModalContentProps) {
+  const app = useApp();
   // Resolve behavior configuration
   const behavior = useMemo(
     () => resolveBehaviorConfig(command, behaviorConfig),
@@ -300,7 +302,7 @@ function CustomCommandChatModalContent({
       try {
         const result = await runTurn(async (ctx: StreamingChatTurnContext) => {
           if (ctx.signal.aborted) return "";
-          const prompt = await processCommandPrompt(command.content, originalText);
+          const prompt = await processCommandPrompt(app, command.content, originalText);
           lastInputPromptRef.current = prompt;
           return prompt;
         });
@@ -324,7 +326,7 @@ function CustomCommandChatModalContent({
       cancelled = true;
       stopStreaming(ABORT_REASON.UNMOUNT);
     };
-  }, [behavior.autoExecuteOnOpen, command.content, originalText, runTurn, stopStreaming]);
+  }, [app, behavior.autoExecuteOnOpen, command.content, originalText, runTurn, stopStreaming]);
 
   const handleFollowUpSubmit = async () => {
     if (!followUpValue.trim()) return;
@@ -357,7 +359,7 @@ function CustomCommandChatModalContent({
         }
 
         // Process prompt (expand placeholders)
-        const prompt = await processCommandPrompt(rawInput, originalText, !isFirstTurn);
+        const prompt = await processCommandPrompt(app, rawInput, originalText, !isFirstTurn);
         lastInputPromptRef.current = prompt;
         return prompt;
       });
@@ -685,7 +687,7 @@ export class CustomCommandChatModal {
     const { anchorBottom, ...initialPosition } = this.getInitialPosition(activeView);
 
     const handleInsert = (message: string) => {
-      void insertIntoEditor(message);
+      void insertIntoEditor(this.app, message);
       this.close();
     };
 

--- a/src/commands/customCommandManager.ts
+++ b/src/commands/customCommandManager.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 import {
   getCommandFilePath,
   getCustomCommandsFolder,
@@ -25,10 +25,25 @@ import { trashFile } from "@/utils/vaultAdapterUtils";
 
 export class CustomCommandManager {
   private static instance: CustomCommandManager;
+  private app: App;
 
-  static getInstance(): CustomCommandManager {
+  private constructor(app: App) {
+    this.app = app;
+  }
+
+  /**
+   * Returns the singleton. `app` is required on the first call (which creates
+   * the instance) and ignored afterward; the plugin seeds it once at load
+   * (see main.ts) so subsequent call sites can omit it.
+   */
+  static getInstance(app?: App): CustomCommandManager {
     if (!CustomCommandManager.instance) {
-      CustomCommandManager.instance = new CustomCommandManager();
+      if (!app) {
+        throw new Error(
+          "CustomCommandManager.getInstance() requires `app` on first call (seed it at plugin load)."
+        );
+      }
+      CustomCommandManager.instance = new CustomCommandManager(app);
     }
     return CustomCommandManager.instance;
   }
@@ -55,18 +70,18 @@ export class CustomCommandManager {
 
       const folderPath = getCustomCommandsFolder();
       // Ensure nested folders are created cross-platform
-      await ensureFolderExists(folderPath);
+      await ensureFolderExists(this.app.vault, folderPath);
 
-      const existingFile = app.vault.getAbstractFileByPath(filePath);
+      const existingFile = this.app.vault.getAbstractFileByPath(filePath);
       let commandFile: TFile;
       if (existingFile instanceof TFile) {
-        await app.vault.modify(existingFile, command.content);
+        await this.app.vault.modify(existingFile, command.content);
         commandFile = existingFile;
       } else {
-        commandFile = await app.vault.create(filePath, command.content);
+        commandFile = await this.app.vault.create(filePath, command.content);
       }
 
-      await app.fileManager.processFrontMatter(
+      await this.app.fileManager.processFrontMatter(
         commandFile,
         (frontmatter: Record<string, unknown>) => {
           frontmatter[COPILOT_COMMAND_CONTEXT_MENU_ENABLED] = command.showInContextMenu;
@@ -102,20 +117,20 @@ export class CustomCommandManager {
         // Update the cached command first to make UI update immediately.
         updateCachedCommand(command, prevCommandTitle);
       }
-      let commandFile = app.vault.getAbstractFileByPath(filePath);
+      let commandFile = this.app.vault.getAbstractFileByPath(filePath);
       // Verify whether the title has changed to decide whether to rename the file
       if (isRename) {
-        const newFileExists = app.vault.getAbstractFileByPath(filePath);
+        const newFileExists = this.app.vault.getAbstractFileByPath(filePath);
         if (newFileExists) {
           throw new CustomError(
             "Error saving custom prompt. Please check if the title already exists."
           );
         }
-        const prevCommandFile = app.vault.getAbstractFileByPath(prevFilePath);
+        const prevCommandFile = this.app.vault.getAbstractFileByPath(prevFilePath);
         if (prevCommandFile instanceof TFile) {
-          await app.vault.rename(prevCommandFile, filePath);
+          await this.app.vault.rename(prevCommandFile, filePath);
           // Re-fetch the file object after renaming
-          commandFile = app.vault.getAbstractFileByPath(filePath);
+          commandFile = this.app.vault.getAbstractFileByPath(filePath);
         }
       }
 
@@ -124,12 +139,12 @@ export class CustomCommandManager {
         // When creating a new command, we want to auto-order it so it appears
         // at the bottom of the menu.
         await this.createCommand(command, { skipStoreUpdate, autoOrder: true });
-        commandFile = app.vault.getAbstractFileByPath(getCommandFilePath(command.title));
+        commandFile = this.app.vault.getAbstractFileByPath(getCommandFilePath(command.title));
       }
 
       if (commandFile instanceof TFile) {
-        await app.vault.modify(commandFile, command.content);
-        await app.fileManager.processFrontMatter(
+        await this.app.vault.modify(commandFile, command.content);
+        await this.app.fileManager.processFrontMatter(
           commandFile,
           (frontmatter: Record<string, unknown>) => {
             frontmatter[COPILOT_COMMAND_CONTEXT_MENU_ENABLED] = command.showInContextMenu;
@@ -170,9 +185,9 @@ export class CustomCommandManager {
     try {
       addPendingFileWrite(filePath);
       deleteCachedCommand(command.title);
-      const file = app.vault.getAbstractFileByPath(filePath);
+      const file = this.app.vault.getAbstractFileByPath(filePath);
       if (file instanceof TFile) {
-        await trashFile(app, file);
+        await trashFile(this.app, file);
       }
     } finally {
       removePendingFileWrite(filePath);

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -7,7 +7,7 @@ import {
   ensureCommandFrontmatter,
   hasOrderFrontmatter,
 } from "@/commands/customCommandUtils";
-import { Editor, Plugin, TFile, Vault } from "obsidian";
+import { App, Editor, Plugin, TFile, Vault } from "obsidian";
 import { CustomCommandChatModal } from "@/commands/CustomCommandChatModal";
 import { debounce } from "@/utils/debounce";
 import { CustomCommand } from "@/commands/type";
@@ -23,16 +23,18 @@ import { logError } from "@/logger";
 /** This manager is used to register custom commands as obsidian commands */
 export class CustomCommandRegister {
   private plugin: Plugin;
+  private app: App;
   private vault: Vault;
 
-  constructor(plugin: Plugin, vault: Vault) {
+  constructor(plugin: Plugin, app: App) {
     this.plugin = plugin;
-    this.vault = vault;
+    this.app = app;
+    this.vault = app.vault;
     this.initializeEventListeners();
   }
 
   async initialize() {
-    await loadAllCustomCommands();
+    await loadAllCustomCommands(this.app);
     this.registerCommands();
   }
 
@@ -69,7 +71,7 @@ export class CustomCommandRegister {
       if (!isCustomCommandFile(file) || isFileWritePending(file.path)) {
         return;
       }
-      const customCommand = await parseCustomCommandFile(file);
+      const customCommand = await parseCustomCommandFile(this.app, file);
       this.registerCommand(customCommand);
       updateCachedCommand(customCommand, customCommand.title);
     },
@@ -88,13 +90,13 @@ export class CustomCommandRegister {
       return;
     }
     try {
-      let customCommand = await parseCustomCommandFile(file);
-      if (!hasOrderFrontmatter(file)) {
+      let customCommand = await parseCustomCommandFile(this.app, file);
+      if (!hasOrderFrontmatter(this.app, file)) {
         // Compute the correct order for the new command
         const newOrder = getNextCustomCommandOrder();
         customCommand = { ...customCommand, order: newOrder };
       }
-      await ensureCommandFrontmatter(file, customCommand);
+      await ensureCommandFrontmatter(this.app, file, customCommand);
       updateCachedCommand(customCommand, customCommand.title);
       this.registerCommand(customCommand);
     } catch (error) {
@@ -126,10 +128,10 @@ export class CustomCommandRegister {
     }
     // Register the new command if it's still a custom command file
     if (isCustomCommandFile(file)) {
-      const parsedCommand = await parseCustomCommandFile(file);
+      const parsedCommand = await parseCustomCommandFile(this.app, file);
       this.registerCommand(parsedCommand);
       updateCachedCommand(parsedCommand, parsedCommand.title);
-      await ensureCommandFrontmatter(file, parsedCommand);
+      await ensureCommandFrontmatter(this.app, file, parsedCommand);
     }
   };
 

--- a/src/commands/customCommandUtils.test.ts
+++ b/src/commands/customCommandUtils.test.ts
@@ -8,7 +8,7 @@ import {
   getNotesFromPath,
   getNotesFromTags,
 } from "@/utils";
-import { Notice, TFile, Vault } from "obsidian";
+import { App, Notice, TFile, Vault } from "obsidian";
 import * as settingsModelModule from "@/settings/model";
 import { PromptSortStrategy } from "@/types";
 import { sortSlashCommands } from "@/commands/customCommandUtils";
@@ -46,6 +46,7 @@ jest.mock("@/utils", () => {
 
 describe("processedPrompt()", () => {
   let mockVault: Vault;
+  let mockApp: App;
   let mockActiveNote: TFile;
 
   beforeEach(() => {
@@ -65,6 +66,12 @@ describe("processedPrompt()", () => {
         }),
       },
     } as unknown as Vault;
+    mockApp = {
+      vault: mockVault,
+      metadataCache: { getFileCache: jest.fn() },
+      workspace: { getActiveFile: jest.fn() },
+      fileManager: { processFrontMatter: jest.fn() },
+    } as unknown as App;
     mockActiveNote = mockTFile({
       path: "path/to/active/note.md",
       basename: "Active Note",
@@ -87,7 +94,13 @@ describe("processedPrompt()", () => {
     (getFileName as jest.Mock).mockReturnValueOnce("Variable Note");
     (getNotesFromPath as jest.Mock).mockReturnValueOnce([mockActiveNote]);
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       'This is a {variable} and {selected_text}.\n\n<selected_text>\nhere is some selected text 12345\n</selected_text>\n\n<variable name="variable">\n<variable_note>\n<path>path/to/active/note.md</path>\n## Variable Note\n\nhere is the note content for note0\n</variable_note>\n</variable>'
@@ -120,7 +133,13 @@ describe("processedPrompt()", () => {
       .mockReturnValueOnce([mockNote1])
       .mockReturnValueOnce([mockNote2]);
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       'This is a {variable1} and {variable2}.\n\n<variable name="variable1">\n<variable_note>\n<path>path/to/note1.md</path>\n## Variable1 Note\n\nhere is the note content for note0\n</variable_note>\n</variable>\n\n<variable name="variable2">\n<variable_note>\n<path>path/to/note2.md</path>\n## Variable2 Note\n\nnote content for note1\n</variable_note>\n</variable>'
@@ -141,7 +160,13 @@ describe("processedPrompt()", () => {
     };
     const selectedText = "here is some selected text 12345";
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       "Rewrite the following text {selected_text}\n\n<selected_text>\nhere is some selected text 12345\n</selected_text>"
@@ -153,7 +178,14 @@ describe("processedPrompt()", () => {
     const customPrompt = "Rewrite the following text {}";
     const selectedText = "here is some selected text 12345";
 
-    const result = await processPrompt(customPrompt, selectedText, mockVault, mockActiveNote, true);
+    const result = await processPrompt(
+      mockApp,
+      customPrompt,
+      selectedText,
+      mockVault,
+      mockActiveNote,
+      true
+    );
 
     // {} should be preserved as literal, not replaced
     expect(result.processedPrompt).toBe("Rewrite the following text {}\n\n");
@@ -178,7 +210,13 @@ describe("processedPrompt()", () => {
     const { getFileName } = jest.requireMock<{ getFileName: jest.Mock }>("@/utils");
     getFileName.mockReturnValue("Active Note");
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       'This is the active note: {activenote}\n\n<variable name="activenote">\n<variable_note>\n<path>path/to/active/note.md</path>\n## Active Note\n\nContent of the active note\n</variable_note>\n</variable>'
@@ -199,7 +237,7 @@ describe("processedPrompt()", () => {
     };
     const selectedText = "";
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, undefined);
+    const result = await processPrompt(mockApp, doc.content, selectedText, mockVault, undefined);
 
     expect(result.processedPrompt).toBe("This is the active note: {activeNote}\n\n");
     expect(result.includedFiles).toEqual([]);
@@ -218,7 +256,13 @@ describe("processedPrompt()", () => {
     };
     const selectedText = "selected text";
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe("This is a test prompt with no variables.\n\n");
     expect(result.includedFiles).toEqual([]);
@@ -244,7 +288,13 @@ describe("processedPrompt()", () => {
     // Mock getFileContent to return content for the note
     (getFileContent as jest.Mock).mockResolvedValue("Note content for #tag");
 
-    const result = await processPrompt(customPrompt, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      customPrompt,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       'Notes related to {#tag} are:\n\n<variable name="#tag">\n<variable_note>\n<path>path/to/tagged/note.md</path>\n## Tagged Note\n\nNote content for #tag\n</variable_note>\n</variable>'
@@ -283,7 +333,13 @@ describe("processedPrompt()", () => {
       return "";
     });
 
-    const result = await processPrompt(customPrompt, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      customPrompt,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       'Notes related to {#tag1,#tag2,#tag3} are:\n\n<variable name="#tag1,#tag2,#tag3">\n<variable_note>\n<path>path/to/tagged/note1.md</path>\n## Tagged Note 1\n\nNote content for #tag1\n</variable_note>\n\n<variable_note>\n<path>path/to/tagged/note2.md</path>\n## Tagged Note 2\n\nNote content for #tag2\n</variable_note>\n</variable>'
@@ -301,7 +357,13 @@ describe("processedPrompt()", () => {
     (extractTemplateNoteFiles as jest.Mock).mockReturnValue([mockTestNote]);
     (getFileContent as jest.Mock).mockResolvedValue("Test note content");
 
-    const result = await processPrompt(customPrompt, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      customPrompt,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toContain("Content of [[Test Note]] is important");
     expect(result.processedPrompt).toContain("<note_context>");
@@ -332,7 +394,13 @@ describe("processedPrompt()", () => {
     // Mock getNotesFromPath to return our mock note
     (getNotesFromPath as jest.Mock).mockReturnValue([mockNoteFile]);
 
-    const result = await processPrompt(customPrompt, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      customPrompt,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     // Verify the prompt text is preserved
     expect(result.processedPrompt).toContain(
@@ -375,7 +443,13 @@ describe("processedPrompt()", () => {
     // Mock getNotesFromPath to return our mock note
     (getNotesFromPath as jest.Mock).mockReturnValue([mockNote1]);
 
-    const result = await processPrompt(customPrompt, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      customPrompt,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toContain(
       "{[[Note1]]} content and [[Note2]] are both important"
@@ -413,7 +487,13 @@ describe("processedPrompt()", () => {
       return "";
     });
 
-    const result = await processPrompt(customPrompt, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      customPrompt,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toContain(
       "{[[Note1]]} is related to {[[Note2]]} and {[[Note3]]}."
@@ -440,7 +520,13 @@ describe("processedPrompt()", () => {
     // Mock the necessary functions
     (extractTemplateNoteFiles as jest.Mock).mockReturnValue([]); // Assume it returns empty if note doesn't exist
 
-    const result = await processPrompt(customPrompt, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      customPrompt,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe("[[Non-existent Note]] should not cause errors.\n\n");
     expect(result.includedFiles).toEqual([]);
@@ -464,7 +550,13 @@ describe("processedPrompt()", () => {
 
     (getFileContent as jest.Mock).mockResolvedValue("Content of the active note");
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     // Check that getFileContent was called with the active note at least once
     expect(getFileContent).toHaveBeenCalledWith(mockActiveNote, mockVault);
@@ -488,7 +580,13 @@ describe("processedPrompt()", () => {
 
     (getFileContent as jest.Mock).mockResolvedValue("Content of the active note");
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       'Summarize this: {selected_text}\n\n<selected_text type="active_note">\nContent of the active note\n</selected_text>'
@@ -514,7 +612,13 @@ describe("processedPrompt()", () => {
     const { getFileName } = jest.requireMock<{ getFileName: jest.Mock }>("@/utils");
     getFileName.mockReturnValue("Active Note");
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       'Summarize this: {selected_text}. Additional info: {activeNote}\n\n<selected_text type="active_note">\nContent of the active note\n</selected_text>'
@@ -539,7 +643,13 @@ describe("processedPrompt()", () => {
 
     (getFileContent as jest.Mock).mockResolvedValue("Content of the active note");
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       "Analyze this: {selected_text}\n\n<selected_text>\nThis is the selected text\n</selected_text>"
@@ -577,7 +687,13 @@ describe("processedPrompt()", () => {
       return "";
     });
 
-    const result = await processPrompt(doc.content, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      doc.content,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     expect(result.processedPrompt).toBe(
       'This is a test prompt with {invalidVariable} name and {activeNote}\n\n<variable name="activeNote">\n<variable_note>\n<path>path/to/active/note.md</path>\n## Active Note\n\nActive Note Content\n</variable_note>\n</variable>'
@@ -721,7 +837,7 @@ describe("parseCustomCommandFile", () => {
 
   it("parses a custom command file with frontmatter and content", async () => {
     const { parseCustomCommandFile } = await import("@/commands/customCommandUtils");
-    const result = await parseCustomCommandFile(mockFile);
+    const result = await parseCustomCommandFile(window.app, mockFile);
     expect(result).toEqual({
       title: "Test Command",
       modelKey: "gpt-4",
@@ -743,7 +859,7 @@ describe("parseCustomCommandFile", () => {
       window.app.metadataCache as unknown as { getFileCache: jest.Mock }
     ).getFileCache.mockReturnValue({});
     const { parseCustomCommandFile } = await import("@/commands/customCommandUtils");
-    const result = await parseCustomCommandFile(mockFile);
+    const result = await parseCustomCommandFile(window.app, mockFile);
     expect(result).toEqual({
       title: "Test Command",
       modelKey: "",

--- a/src/commands/customCommandUtils.ts
+++ b/src/commands/customCommandUtils.ts
@@ -9,7 +9,7 @@ import {
 } from "@/commands/constants";
 import { CustomCommand } from "@/commands/type";
 import { logWarn } from "@/logger";
-import { normalizePath, Notice, TAbstractFile, TFile, Vault } from "obsidian";
+import { App, normalizePath, Notice, TAbstractFile, TFile, Vault } from "obsidian";
 import { getSettings } from "@/settings/model";
 import {
   updateCachedCommands,
@@ -97,7 +97,7 @@ export function isCustomCommandFile(file: TAbstractFile): boolean {
   return true;
 }
 
-export function hasOrderFrontmatter(file: TFile): boolean {
+export function hasOrderFrontmatter(app: App, file: TFile): boolean {
   const metadata = app.metadataCache.getFileCache(file);
   return metadata?.frontmatter?.[COPILOT_COMMAND_CONTEXT_MENU_ORDER] != null;
 }
@@ -105,7 +105,7 @@ export function hasOrderFrontmatter(file: TFile): boolean {
 /**
  * Parse a TFile as a CustomCommand by reading its content and extracting frontmatter.
  */
-export async function parseCustomCommandFile(file: TFile): Promise<CustomCommand> {
+export async function parseCustomCommandFile(app: App, file: TFile): Promise<CustomCommand> {
   const rawContent = await app.vault.read(file);
   const content = stripFrontmatter(rawContent);
   const metadata = app.metadataCache.getFileCache(file);
@@ -129,9 +129,11 @@ export async function parseCustomCommandFile(file: TFile): Promise<CustomCommand
   };
 }
 
-export async function loadAllCustomCommands(): Promise<CustomCommand[]> {
+export async function loadAllCustomCommands(app: App): Promise<CustomCommand[]> {
   const files = app.vault.getFiles().filter((file) => isCustomCommandFile(file));
-  const commands: CustomCommand[] = await Promise.all(files.map(parseCustomCommandFile));
+  const commands: CustomCommand[] = await Promise.all(
+    files.map((file) => parseCustomCommandFile(app, file))
+  );
   updateCachedCommands(commands);
   return commands;
 }
@@ -184,11 +186,13 @@ export function sortSlashCommands(commands: CustomCommand[]): CustomCommand[] {
  * if it's not already present.
  */
 export async function processCommandPrompt(
+  app: App,
   prompt: string,
   selectedText: string,
   skipAppendingSelectedText = false
 ) {
   const result = await processPrompt(
+    app,
     prompt,
     selectedText,
     app.vault,
@@ -261,6 +265,7 @@ interface VariableProcessingResult {
  * files.
  */
 async function extractVariablesFromPrompt(
+  app: App,
   customPrompt: string,
   vault: Vault,
   activeNote?: TFile | null
@@ -294,7 +299,7 @@ async function extractVariablesFromPrompt(
         .slice(1)
         .split(",")
         .map((tag) => tag.trim());
-      const noteFiles = getNotesFromTags(vault, tagNames);
+      const noteFiles = getNotesFromTags(app, tagNames);
       const notesContent: string[] = [];
       for (const file of noteFiles) {
         const content = await getFileContent(file, vault);
@@ -352,6 +357,7 @@ export interface ProcessedPromptResult {
  * @param skipEmptyBraces - When true, treats `{}` as a literal and skips selected-text/active-note expansion.
  */
 export async function processPrompt(
+  app: App,
   customPrompt: string,
   selectedText: string,
   vault: Vault,
@@ -374,6 +380,7 @@ export async function processPrompt(
 
   // Extract variables and track files included through them
   const { variablesMap, includedFiles: variableFiles } = await extractVariablesFromPrompt(
+    app,
     customPrompt,
     vault,
     activeNote
@@ -489,7 +496,7 @@ export function getNextCustomCommandOrder(): number {
  * adds missing fields, does not overwrite existing values.
  * This is idempotent and does not touch the file content.
  */
-export async function ensureCommandFrontmatter(file: TFile, command: CustomCommand) {
+export async function ensureCommandFrontmatter(app: App, file: TFile, command: CustomCommand) {
   try {
     addPendingFileWrite(file.path);
     await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {

--- a/src/commands/customCommandUtils.xmlescape.test.ts
+++ b/src/commands/customCommandUtils.xmlescape.test.ts
@@ -1,5 +1,5 @@
 import { processPrompt } from "@/commands/customCommandUtils";
-import { TFile, Vault } from "obsidian";
+import { App, TFile, Vault } from "obsidian";
 import { getFileContent, getFileName, getNotesFromPath } from "@/utils";
 import { mockTFile } from "@/__tests__/mockObsidian";
 
@@ -22,6 +22,7 @@ jest.mock("@/settings/model", () => ({
 
 describe("XML Escaping in processPrompt", () => {
   let mockVault: Vault;
+  let mockApp: App;
   let mockActiveNote: TFile;
 
   beforeEach(() => {
@@ -36,6 +37,13 @@ describe("XML Escaping in processPrompt", () => {
       },
     } as unknown as Vault;
 
+    mockApp = {
+      vault: mockVault,
+      metadataCache: { getFileCache: jest.fn() },
+      workspace: { getActiveFile: jest.fn() },
+      fileManager: { processFrontMatter: jest.fn() },
+    } as unknown as App;
+
     mockActiveNote = mockTFile({
       path: "path/to/active/note.md",
       basename: "Active Note",
@@ -46,7 +54,13 @@ describe("XML Escaping in processPrompt", () => {
     const customPrompt = "Process this: {}";
     const selectedText = "<tag>content & \"quotes\" 'apostrophes'</tag>";
 
-    const result = await processPrompt(customPrompt, selectedText, mockVault, mockActiveNote);
+    const result = await processPrompt(
+      mockApp,
+      customPrompt,
+      selectedText,
+      mockVault,
+      mockActiveNote
+    );
 
     // Should contain the original unescaped text
     expect(result.processedPrompt).toContain(selectedText);
@@ -69,7 +83,7 @@ describe("XML Escaping in processPrompt", () => {
     (getFileName as jest.Mock).mockReturnValue(mockNote.basename);
     (getFileContent as jest.Mock).mockResolvedValue('Content with <xml> & special "chars"');
 
-    const result = await processPrompt(customPrompt, "", mockVault, mockActiveNote);
+    const result = await processPrompt(mockApp, customPrompt, "", mockVault, mockActiveNote);
 
     // Check variable name is NOT escaped in attribute
     expect(result.processedPrompt).toContain('name="my"variable<>"');
@@ -91,7 +105,7 @@ describe("XML Escaping in processPrompt", () => {
     );
     (getFileName as jest.Mock).mockReturnValue(mockActiveNote.basename);
 
-    const result = await processPrompt(customPrompt, "", mockVault, mockActiveNote);
+    const result = await processPrompt(mockApp, customPrompt, "", mockVault, mockActiveNote);
 
     // Check basename is NOT escaped
     expect(result.processedPrompt).toContain("Note <with> \"XML\" & 'special' chars");
@@ -114,7 +128,7 @@ describe("XML Escaping in processPrompt", () => {
     ).extractTemplateNoteFiles.mockReturnValue([mockNote]);
     (getFileContent as jest.Mock).mockResolvedValue("Content with & and < and >");
 
-    const result = await processPrompt(customPrompt, "", mockVault, mockActiveNote);
+    const result = await processPrompt(mockApp, customPrompt, "", mockVault, mockActiveNote);
 
     // Check title is NOT escaped
     expect(result.processedPrompt).toContain('<title>Special & "Note"</title>');
@@ -141,7 +155,7 @@ describe("XML Escaping in processPrompt", () => {
     (getFileName as jest.Mock).mockReturnValue(mockNote.basename);
     (getFileContent as jest.Mock).mockResolvedValue("Content: <tag> & </tag>");
 
-    const result = await processPrompt(customPrompt, "", mockVault, mockActiveNote);
+    const result = await processPrompt(mockApp, customPrompt, "", mockVault, mockActiveNote);
 
     // Check tag variable name is NOT escaped
     expect(result.processedPrompt).toContain('name="#tag&special"');

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -144,11 +144,11 @@ export function registerCommands(plugin: CopilotPlugin) {
 
     if (checking) {
       // Return true only if we're not in source mode
-      return !!(!isSourceModeOn() && activeView && activeView.editor);
+      return !!(!isSourceModeOn(plugin.app) && activeView && activeView.editor);
     }
 
     // Need to check this again because it can still be triggered via shortcut.
-    if (isSourceModeOn()) {
+    if (isSourceModeOn(plugin.app)) {
       new Notice("Quick command is not available in source mode.");
       return false;
     }
@@ -338,7 +338,7 @@ export function registerCommands(plugin: CopilotPlugin) {
       // Categorize files
       for (const file of allMarkdownFiles) {
         // Check if file should be indexed based on settings
-        if (!shouldIndexFile(file, inclusions, exclusions)) {
+        if (!shouldIndexFile(plugin.app, file, inclusions, exclusions)) {
           excludedFiles.add(file.path);
           continue;
         }
@@ -394,7 +394,7 @@ export function registerCommands(plugin: CopilotPlugin) {
       const filePath = `${folderPath}/${fileName}`;
 
       // Ensure destination folder exists (supports mobile and nested)
-      await ensureFolderExists(folderPath);
+      await ensureFolderExists(plugin.app.vault, folderPath);
 
       const existingFile = plugin.app.vault.getAbstractFileByPath(filePath);
       if (existingFile instanceof TFile) {
@@ -468,7 +468,7 @@ export function registerCommands(plugin: CopilotPlugin) {
       const folderPath = "copilot";
       const filePath = `${folderPath}/${fileName}`;
 
-      await ensureFolderExists(folderPath);
+      await ensureFolderExists(plugin.app.vault, folderPath);
 
       const existingFile = plugin.app.vault.getAbstractFileByPath(filePath);
       if (existingFile instanceof TFile) {
@@ -491,14 +491,14 @@ export function registerCommands(plugin: CopilotPlugin) {
   // Add clear Copilot cache command
   addCommand(plugin, COMMAND_IDS.CLEAR_COPILOT_CACHE, async () => {
     try {
-      await plugin.fileParserManager.clearPDFCache();
+      await plugin.fileParserManager.clearPDFCache(plugin.app.vault);
 
       // Clear project context cache
       await ProjectContextCache.getInstance().clearAllCache();
 
       // Clear file content cache (get FileCache instance and clear it)
       const fileCache = FileCache.getInstance<string>();
-      await fileCache.clear();
+      await fileCache.clear(plugin.app.vault);
 
       new Notice("All Copilot caches cleared successfully");
     } catch (error) {
@@ -643,7 +643,7 @@ export function registerCommands(plugin: CopilotPlugin) {
 
   // Add command to download YouTube script (Copilot Plus only)
   addCommand(plugin, COMMAND_IDS.DOWNLOAD_YOUTUBE_SCRIPT, async () => {
-    const isPlusUser = await checkIsPlusUser();
+    const isPlusUser = await checkIsPlusUser(plugin.app);
     if (!isPlusUser) {
       new Notice("Download YouTube Script (plus) is a Copilot Plus feature");
       return;
@@ -660,11 +660,11 @@ export function registerCommands(plugin: CopilotPlugin) {
 
     if (checking) {
       // Return true only if we're not in source mode and have an active editor
-      return !!(!isSourceModeOn() && activeView && activeView.editor);
+      return !!(!isSourceModeOn(plugin.app) && activeView && activeView.editor);
     }
 
     // Need to check this again because it can still be triggered via shortcut
-    if (isSourceModeOn()) {
+    if (isSourceModeOn(plugin.app)) {
       new Notice("Quick Ask is not available in source mode.");
       return false;
     }

--- a/src/commands/migrator.ts
+++ b/src/commands/migrator.ts
@@ -1,3 +1,4 @@
+import { App } from "obsidian";
 import { CustomCommandManager } from "@/commands/customCommandManager";
 import { getCustomCommandsFolder, validateCommandName } from "@/commands/customCommandUtils";
 import { CustomCommand } from "@/commands/type";
@@ -15,11 +16,11 @@ import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { getCachedCustomCommands } from "@/commands/state";
 import { logError } from "@/logger";
 
-async function saveUnsupportedCommands(commands: CustomCommand[]) {
+async function saveUnsupportedCommands(app: App, commands: CustomCommand[]) {
   const folderPath = getCustomCommandsFolder();
   const unsupportedFolderPath = `${folderPath}/unsupported`;
   // Ensure nested structure exists regardless of platform
-  await ensureFolderExists(unsupportedFolderPath);
+  await ensureFolderExists(app.vault, unsupportedFolderPath);
   return Promise.all(
     commands.map(async (command) => {
       const filePath = `${unsupportedFolderPath}/${command.title}.md`;
@@ -36,7 +37,7 @@ async function saveUnsupportedCommands(commands: CustomCommand[]) {
 }
 
 /** Migrates the legacy commands in data.json to the new note format. */
-export async function migrateCommands() {
+export async function migrateCommands(app: App) {
   const legacyCommands = getSettings().inlineEditCommands;
   if (!legacyCommands || legacyCommands.length === 0) {
     return;
@@ -78,7 +79,7 @@ export async function migrateCommands() {
 
   let message = `We have upgraded your commands to the new format. They are now also stored as notes in ${getCustomCommandsFolder()}.`;
   if (unsupportedCommands.length > 0) {
-    await saveUnsupportedCommands(unsupportedCommands);
+    await saveUnsupportedCommands(app, unsupportedCommands);
     message += `\n\nWe found ${unsupportedCommands.length} unsupported commands. They are saved in ${getCustomCommandsFolder()}/unsupported. To fix them, please resolve the errors and move the note file out of the unsupported folder.`;
   }
 
@@ -98,7 +99,7 @@ export async function generateDefaultCommands(): Promise<void> {
 }
 
 /** Suggests the default commands if the user has not created any commands yet. */
-export async function suggestDefaultCommands(): Promise<void> {
+export async function suggestDefaultCommands(app: App): Promise<void> {
   const suggestedCommand = getSettings().suggestedDefaultCommands;
   if (suggestedCommand) {
     // We only show the modal once

--- a/src/components/chat-components/ChatContextMenu.tsx
+++ b/src/components/chat-components/ChatContextMenu.tsx
@@ -16,6 +16,7 @@ import { SelectedTextContext, WebTabContext, isWebSelectedTextContext } from "@/
 import { ChainType } from "@/chainType";
 import { Separator } from "@/components/ui/separator";
 import { useChainType, useIndexingProgress } from "@/aiParams";
+import { useApp } from "@/context";
 import { useProjectContextStatus } from "@/hooks/useProjectContextStatus";
 import { getDomainFromUrl, isPlusChain, openFileInWorkspace } from "@/utils";
 import { mergeWebTabContexts } from "@/utils/urlNormalization";
@@ -118,6 +119,7 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
   lexicalEditorRef,
   hideAddContextButton = false,
 }) => {
+  const app = useApp();
   const [currentChain] = useChainType();
   const contextStatus = useProjectContextStatus();
   const [indexingState] = useIndexingProgress();
@@ -149,7 +151,7 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
    * Handles clicking on a badge to open the file in a new tab (or focus existing tab)
    */
   const handleBadgeClick = (file: TFile) => {
-    void openFileInWorkspace(file);
+    void openFileInWorkspace(app, file);
   };
 
   const uniqueNotes = React.useMemo(() => {

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -921,7 +921,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
 
     const editor = leaf.view.editor;
     const hasSelection = editor.getSelection().length > 0;
-    void insertIntoEditor(message.message, hasSelection);
+    void insertIntoEditor(app, message.message, hasSelection);
   };
 
   const renderMessageContent = () => {

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -32,6 +32,7 @@ import { Notice, TFile } from "obsidian";
 import React, { memo, useCallback, useEffect, useState } from "react";
 
 function useRelevantNotes(refresher: number) {
+  const app = useApp();
   const [relevantNotes, setRelevantNotes] = useState<RelevantNoteEntry[]>([]);
   const [signalTick, setSignalTick] = useState(0);
   const activeFile = useActiveFile();
@@ -42,7 +43,7 @@ function useRelevantNotes(refresher: number) {
     async function fetchNotes() {
       if (!activeFile?.path) return;
       try {
-        const notes = await findRelevantNotes({ filePath: activeFile.path });
+        const notes = await findRelevantNotes({ app, filePath: activeFile.path });
         setRelevantNotes(notes);
       } catch (error) {
         logWarn("Failed to fetch relevant notes", error);
@@ -51,7 +52,7 @@ function useRelevantNotes(refresher: number) {
     }
 
     void fetchNotes();
-  }, [activeFile?.path, refresher, signalTick]);
+  }, [app, activeFile?.path, refresher, signalTick]);
 
   return relevantNotes;
 }

--- a/src/components/composer/ApplyView.tsx
+++ b/src/components/composer/ApplyView.tsx
@@ -452,7 +452,7 @@ const ApplyViewRoot: React.FC<ApplyViewRootProps> = ({ app, state, close }) => {
     // Create the folder if it doesn't exist (supports nested paths)
     if (file_path.includes("/")) {
       const folderPath = file_path.split("/").slice(0, -1).join("/");
-      await ensureFolderExists(folderPath);
+      await ensureFolderExists(app.vault, folderPath);
     }
     return await app.vault.create(file_path, "");
   };

--- a/src/components/modals/LoadChatHistoryModal.tsx
+++ b/src/components/modals/LoadChatHistoryModal.tsx
@@ -31,12 +31,12 @@ export class LoadChatHistoryModal extends FuzzySuggestModal<TFile> {
   getItems(): TFile[] {
     const sortStrategy = getSettings().chatHistorySortStrategy;
     return sortByStrategy(this.chatFiles, sortStrategy, {
-      getName: (file) => extractChatTitle(file),
-      getCreatedAtMs: (file) => extractChatDate(file).getTime(),
+      getName: (file) => extractChatTitle(this.app, file),
+      getCreatedAtMs: (file) => extractChatDate(this.app, file).getTime(),
       getLastUsedAtMs: (file) => {
         // Reason: Use getEffectiveLastUsedAt to prefer in-memory value over persisted frontmatter.
         // This ensures the modal reflects recent access immediately, even within the throttle window.
-        const persistedMs = extractChatLastAccessedAtMs(file);
+        const persistedMs = extractChatLastAccessedAtMs(this.app, file);
         return this.chatHistoryLastAccessedAtManager.getEffectiveLastUsedAt(file.path, persistedMs);
       },
     });
@@ -46,7 +46,7 @@ export class LoadChatHistoryModal extends FuzzySuggestModal<TFile> {
    * Render the display label for a chat history file.
    */
   getItemText(file: TFile): string {
-    return getChatDisplayText(file);
+    return getChatDisplayText(this.app, file);
   }
 
   /**

--- a/src/components/modals/TagSearchModal.tsx
+++ b/src/components/modals/TagSearchModal.tsx
@@ -17,7 +17,7 @@ export class TagSearchModal extends FuzzySuggestModal<string> {
     // Loop through each file and extract tags.
     for (const file of files) {
       // Retrieve the metadata cache for the file.
-      const tags = getTagsFromNote(file);
+      const tags = getTagsFromNote(this.app, file);
       tags.forEach((tag) => tagSet.add(tag));
     }
 

--- a/src/components/modals/YoutubeTranscriptModal.tsx
+++ b/src/components/modals/YoutubeTranscriptModal.tsx
@@ -1,6 +1,7 @@
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useApp } from "@/context";
 import { logError } from "@/logger";
 import { formatYoutubeUrl, insertIntoEditor, validateYoutubeUrl } from "@/utils";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
@@ -15,6 +16,7 @@ interface TranscriptData {
 }
 
 function YoutubeTranscriptModalContent({ onClose }: { onClose: () => void }) {
+  const app = useApp();
   const [currentView, setCurrentView] = React.useState<"input" | "display">("input");
   const [url, setUrl] = React.useState("");
   const [isLoading, setIsLoading] = React.useState(false);
@@ -109,7 +111,7 @@ function YoutubeTranscriptModalContent({ onClose }: { onClose: () => void }) {
 
     try {
       const textToInsert = `# YouTube Video Transcript\n\nSource: ${transcriptData.url}\n\n${transcriptData.transcript}`;
-      await insertIntoEditor(textToInsert, false);
+      await insertIntoEditor(app, textToInsert, false);
       onClose();
     } catch (error) {
       logError("Failed to insert to note:", error);

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -501,7 +501,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
       exclusionPatterns: PatternCategory | null
     ): GroupListItem => {
       const projectAllFiles = appFiles.filter((file) =>
-        shouldIndexFile(file, inclusionPatterns, exclusionPatterns, true)
+        shouldIndexFile(app, file, inclusionPatterns, exclusionPatterns, true)
       );
 
       const processPatternGroup = (
@@ -514,7 +514,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
           patterns.forEach((pattern) => {
             const singlePatternConfig = { [patternType]: [pattern] };
             if (
-              shouldIndexFile(file, singlePatternConfig, null, true) &&
+              shouldIndexFile(app, file, singlePatternConfig, null, true) &&
               !targetGroup[pattern].some((item) => item.id === file.path)
             ) {
               targetGroup[pattern].push({
@@ -561,7 +561,13 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
         // note/file
         if (
           inclusionPatterns?.notePatterns &&
-          shouldIndexFile(file, { notePatterns: inclusionPatterns.notePatterns }, null, true) &&
+          shouldIndexFile(
+            app,
+            file,
+            { notePatterns: inclusionPatterns.notePatterns },
+            null,
+            true
+          ) &&
           !notes.some((item) => item.id === file.path)
         ) {
           notes.push({
@@ -578,7 +584,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
         notes,
       };
     },
-    []
+    [app]
   );
 
   const [groupList, setGroupList] = useState<GroupListItem>(() => {
@@ -588,7 +594,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
   const [ignoreItems, setIgnoreItems] = useState<IgnoreItems>(() => {
     // init exclude files
     const excludeFiles = appAllFiles.filter(
-      (file) => exclusionPatterns && shouldIndexFile(file, exclusionPatterns, null, true)
+      (file) => exclusionPatterns && shouldIndexFile(app, file, exclusionPatterns, null, true)
     );
     return {
       files: new Set<TFile>(excludeFiles),
@@ -717,7 +723,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
             parsedQuery.tags.length > 0 &&
             isNote &&
             parsedQuery.tags.some((queryTag) => {
-              const fileTags = getTagsFromNote(fileObj);
+              const fileTags = getTagsFromNote(app, fileObj);
               return fileTags.some((tag) => {
                 const cleanTag = tag.startsWith("#") ? tag.substring(1) : tag;
                 return cleanTag.toLowerCase().includes(queryTag.toLowerCase());
@@ -840,12 +846,12 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
 
     return [];
   }, [
+    app,
     searchTerm,
     activeSection,
     activeItem,
     parseSearchQuery,
     allItems,
-    app.vault,
     groupList.tags,
     groupList.folders,
     groupList.notes,
@@ -878,7 +884,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
     ) => {
       const getMatchingFilesFromApp = (patterns: PatternCategory): GroupItem[] => {
         return appAllFiles
-          .filter((file) => shouldIndexFile(file, patterns, null, true))
+          .filter((file) => shouldIndexFile(app, file, patterns, null, true))
           .map((file) => ({
             id: file.path,
             name: file.basename,
@@ -900,7 +906,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
         },
       }));
     },
-    [appAllFiles]
+    [app, appAllFiles]
   );
 
   const removeFileFromGroupList = useCallback(

--- a/src/components/project/useProjectProcessingData.ts
+++ b/src/components/project/useProjectProcessingData.ts
@@ -105,7 +105,9 @@ export function useProjectProcessingData(
       isProject: true,
     });
     setProjectFiles(
-      app.vault.getFiles().filter((file) => shouldIndexFile(file, inclusions, exclusions, true))
+      app.vault
+        .getFiles()
+        .filter((file) => shouldIndexFile(app, file, inclusions, exclusions, true))
     );
   }, [app, cacheProject, effectiveInclusions, effectiveExclusions]);
 

--- a/src/components/quick-ask/useQuickAskSession.ts
+++ b/src/components/quick-ask/useQuickAskSession.ts
@@ -16,6 +16,7 @@ import {
   appendIncludeNoteContextPlaceholders,
 } from "@/commands/quickCommandPrompts";
 import { processCommandPrompt } from "@/commands/customCommandUtils";
+import { useApp } from "@/context";
 import { findCustomModel } from "@/utils";
 import { logError, logWarn } from "@/logger";
 import type { QuickAskMessage } from "./types";
@@ -40,6 +41,7 @@ interface QuickAskSessionApi {
  * Hook for managing Quick Ask session state and streaming.
  */
 export function useQuickAskSession(params: UseQuickAskSessionParams): QuickAskSessionApi {
+  const app = useApp();
   const { selectedText, selectedModelKey, includeNoteContext, settings } = params;
 
   // Message history (completed messages only)
@@ -122,7 +124,12 @@ export function useQuickAskSession(params: UseQuickAskSessionParams): QuickAskSe
         if (ctx.signal.aborted) return "";
 
         // Process prompt (follow-up messages skip appending selected text)
-        const prompt = await processCommandPrompt(processedInput, selectedText, !ctx.isFirstTurn);
+        const prompt = await processCommandPrompt(
+          app,
+          processedInput,
+          selectedText,
+          !ctx.isFirstTurn
+        );
 
         return prompt;
       });
@@ -159,7 +166,7 @@ export function useQuickAskSession(params: UseQuickAskSessionParams): QuickAskSe
         });
       }
     },
-    [includeNoteContext, runTurn, selectedText]
+    [app, includeNoteContext, runTurn, selectedText]
   );
 
   const stop = useCallback(() => {

--- a/src/contextProcessor.dataview.test.ts
+++ b/src/contextProcessor.dataview.test.ts
@@ -24,7 +24,7 @@ describe("ContextProcessor - Dataview Integration", () => {
   let originalConsoleError: typeof console.error;
 
   beforeEach(() => {
-    contextProcessor = ContextProcessor.getInstance();
+    contextProcessor = ContextProcessor.getInstance(window.app);
     // Reset plugins for each test
     setPlugins({});
     // Save and mock console.error to suppress expected error messages

--- a/src/contextProcessor.embeds.test.ts
+++ b/src/contextProcessor.embeds.test.ts
@@ -19,8 +19,6 @@ describe("ContextProcessor - Embedded Notes", () => {
   let fileIndex: Map<string, TFile>;
 
   beforeEach(() => {
-    contextProcessor = ContextProcessor.getInstance();
-
     fileCaches = {};
     fileContents = {};
     fileIndex = new Map<string, TFile>();
@@ -36,6 +34,8 @@ describe("ContextProcessor - Embedded Notes", () => {
     (window as unknown as Record<string, unknown>).app = {
       metadataCache: metadataCacheMock,
     };
+
+    contextProcessor = ContextProcessor.getInstance(window.app);
 
     vault = {
       adapter: {

--- a/src/contextProcessor.selectedText.test.ts
+++ b/src/contextProcessor.selectedText.test.ts
@@ -26,7 +26,7 @@ describe("ContextProcessor.processSelectedTextContexts", () => {
     mockSelectedTextContexts.length = 0;
 
     // Get singleton instance
-    processor = ContextProcessor.getInstance();
+    processor = ContextProcessor.getInstance(window.app);
   });
 
   it("should return empty string when no selected text contexts", () => {

--- a/src/contextProcessor.ts
+++ b/src/contextProcessor.ts
@@ -8,7 +8,7 @@ import { WebViewerTimeoutError } from "@/services/webViewerService/webViewerServ
 import { FileParserManager } from "@/tools/FileParserManager";
 import { isPlusChain, isTextReadableFile } from "@/utils";
 import { normalizeUrlString } from "@/utils/urlNormalization";
-import { TFile, Vault, Notice } from "obsidian";
+import { App, TFile, Vault, Notice } from "obsidian";
 import {
   NOTE_CONTEXT_PROMPT_TAG,
   EMBEDDED_PDF_TAG,
@@ -59,12 +59,25 @@ interface MarkdownSegment {
 
 export class ContextProcessor {
   private static instance: ContextProcessor;
+  private app: App;
 
-  private constructor() {}
+  private constructor(app: App) {
+    this.app = app;
+  }
 
-  static getInstance(): ContextProcessor {
+  /**
+   * Returns the singleton. `app` is required on the first call (which creates
+   * the instance) and ignored afterward; the plugin seeds it once at load
+   * (see main.ts) so subsequent call sites can omit it.
+   */
+  static getInstance(app?: App): ContextProcessor {
     if (!ContextProcessor.instance) {
-      ContextProcessor.instance = new ContextProcessor();
+      if (!app) {
+        throw new Error(
+          "ContextProcessor.getInstance() requires `app` on first call (seed it at plugin load)."
+        );
+      }
+      ContextProcessor.instance = new ContextProcessor(app);
     }
     return ContextProcessor.instance;
   }
@@ -106,7 +119,7 @@ export class ContextProcessor {
   async processDataviewBlocks(content: string, sourcePath: string): Promise<string> {
     // Check if Dataview plugin is available
     const dataviewPlugin = (
-      app as unknown as { plugins?: { plugins?: { dataview?: { api?: DataviewApi } } } }
+      this.app as unknown as { plugins?: { plugins?: { dataview?: { api?: DataviewApi } } } }
     ).plugins?.plugins?.dataview;
     if (!dataviewPlugin) {
       return content; // Dataview not installed, return content as-is
@@ -356,7 +369,7 @@ export class ContextProcessor {
     const resolvedFile =
       target.path === null
         ? sourceNote
-        : app.metadataCache.getFirstLinkpathDest(target.path, sourceNote.path);
+        : this.app.metadataCache.getFirstLinkpathDest(target.path, sourceNote.path);
 
     if (!(resolvedFile instanceof TFile)) {
       return this.formatEmbeddedNoteBlock({
@@ -460,7 +473,7 @@ export class ContextProcessor {
     fileContent: string,
     focus: EmbeddedLinkTarget
   ): MarkdownSegment {
-    const cache = app.metadataCache.getFileCache(note);
+    const cache = this.app.metadataCache.getFileCache(note);
 
     if (focus.blockId) {
       const block = cache?.blocks?.[focus.blockId];
@@ -829,7 +842,7 @@ export class ContextProcessor {
     const normalTabs: Array<{ url: string; title?: string; faviconUrl?: string }> = [];
     const seenUrls = new Set<string>();
     const seenVideoIds = new Set<string>(); // Deduplicate YouTube videos by videoId
-    const service = getWebViewerService(app);
+    const service = getWebViewerService(this.app);
 
     /**
      * Check if a tab should be skipped due to deduplication.

--- a/src/core/ChatManager.test.ts
+++ b/src/core/ChatManager.test.ts
@@ -196,6 +196,7 @@ describe("ChatManager", () => {
         undefined
       );
       expect(mockContextManager.processMessageContext).toHaveBeenCalledWith(
+        mockPlugin.app,
         mockMessage,
         mockFileParserManager,
         mockPlugin.app.vault,
@@ -306,6 +307,7 @@ describe("ChatManager", () => {
       expect(result).toBe(true);
       expect(mockMessageRepo.editMessage).toHaveBeenCalledWith("msg-1", "Edited message");
       expect(mockContextManager.reprocessMessageContext).toHaveBeenCalledWith(
+        mockPlugin.app,
         "msg-1",
         mockMessageRepo,
         mockFileParserManager,
@@ -401,6 +403,7 @@ describe("ChatManager", () => {
 
       expect(result).toBe(true);
       expect(mockContextManager.reprocessMessageContext).toHaveBeenCalledWith(
+        mockPlugin.app,
         "msg-1",
         expect.anything(), // messageRepo
         expect.anything(), // fileParserManager
@@ -667,6 +670,7 @@ describe("ChatManager", () => {
 
         expect(result).toBe(true);
         expect(mockContextManager.reprocessMessageContext).toHaveBeenCalledWith(
+          mockPlugin.app,
           "msg-1",
           mockMessageRepo,
           mockFileParserManager,
@@ -1282,7 +1286,7 @@ describe("ChatManager", () => {
         expect(processPrompt).not.toHaveBeenCalled();
 
         // Trailing whitespace should be preserved (no trimEnd when templates not processed)
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain(userCustomPrompt);
       });
 
@@ -1320,7 +1324,7 @@ describe("ChatManager", () => {
         expect(processPrompt).toHaveBeenCalled();
 
         // JSON content should be preserved (processPrompt handles it internally)
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain(userCustomPrompt.trimEnd());
       });
 
@@ -1354,6 +1358,7 @@ describe("ChatManager", () => {
 
         // Verify processPrompt was called with skipEmptyBraces: true
         expect(processPrompt).toHaveBeenCalledWith(
+          mockPlugin.app,
           userCustomPrompt,
           "",
           mockPlugin.app.vault,
@@ -1362,7 +1367,7 @@ describe("ChatManager", () => {
         );
 
         // Verify {} is preserved as literal
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain("{}");
       });
 
@@ -1396,7 +1401,7 @@ describe("ChatManager", () => {
         await chatManager.sendMessage("Hello", context, ChainType.LLM_CHAIN);
 
         // Since processPrompt doesn't modify the JSON, trailing whitespace is trimmed by trimEnd()
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain('{"format": "json"}');
       });
 
@@ -1476,6 +1481,7 @@ describe("ChatManager", () => {
 
         // Verify processPrompt was called with correct arguments
         expect(processPrompt).toHaveBeenCalledWith(
+          mockPlugin.app, // app
           userCustomPrompt, // prompt
           "", // selectedText (empty for system prompts)
           mockPlugin.app.vault, // vault
@@ -1513,6 +1519,7 @@ describe("ChatManager", () => {
 
         // Verify contextManager received includedFiles
         expect(mockContextManager.processMessageContext).toHaveBeenCalledWith(
+          mockPlugin.app,
           mockMessage,
           mockFileParserManager,
           mockPlugin.app.vault,
@@ -1558,7 +1565,7 @@ describe("ChatManager", () => {
         await chatManager.sendMessage("Hello", context, ChainType.LLM_CHAIN);
 
         // Verify the system prompt passed to contextManager has injected content
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain("<user_custom_instructions>");
         expect(systemPromptArg).toContain(processedContent.trimEnd());
         expect(systemPromptArg).toContain("</user_custom_instructions>");
@@ -1592,7 +1599,7 @@ describe("ChatManager", () => {
         await chatManager.sendMessage("Hello", context, ChainType.LLM_CHAIN);
 
         // Verify the $ characters are preserved exactly as-is
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain("$100");
         expect(systemPromptArg).toContain("$&");
         expect(systemPromptArg).toContain("$1");
@@ -1646,7 +1653,7 @@ describe("ChatManager", () => {
         await chatManager.sendMessage("Hello", context, ChainType.LLM_CHAIN);
 
         // Verify $ characters from processed content are preserved
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain("$100");
         expect(systemPromptArg).toContain("$50");
         expect(systemPromptArg).toContain("$&");
@@ -1697,6 +1704,7 @@ describe("ChatManager", () => {
         // Verify processPrompt was only called with user custom prompt, not memory
         expect(processPrompt).toHaveBeenCalledTimes(1);
         expect(processPrompt).toHaveBeenCalledWith(
+          mockPlugin.app,
           userCustomPrompt, // Only user custom prompt
           "",
           mockPlugin.app.vault,
@@ -1705,7 +1713,7 @@ describe("ChatManager", () => {
         );
 
         // Verify the final system prompt still contains memory prefix
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain(memoryContent);
       });
     });
@@ -1772,7 +1780,7 @@ describe("ChatManager", () => {
         await chatManager.sendMessage("Hello", context, ChainType.LLM_CHAIN);
 
         // Verify the system prompt is the processed content (not wrapped in block)
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toBe(processedContent.trimEnd());
         // Should NOT contain the original unprocessed prompt
         expect(systemPromptArg).not.toContain(userCustomPrompt);
@@ -1804,7 +1812,7 @@ describe("ChatManager", () => {
 
         await chatManager.sendMessage("Hello", context, ChainType.LLM_CHAIN);
 
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         // Should contain memory prefix
         expect(systemPromptArg).toContain(memoryContent);
         // Should contain processed content
@@ -1848,7 +1856,7 @@ describe("ChatManager", () => {
         expect(mockContextManager.processMessageContext).toHaveBeenCalled();
 
         // In fallback case, should return original basePromptWithMemory unchanged
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toBe("Memory\n\nACTUAL_SYSTEM_PROMPT_THAT_DOESNT_MATCH");
       });
     });
@@ -1902,6 +1910,7 @@ describe("ChatManager", () => {
 
         // Verify processPrompt was called for project system prompt
         expect(processPrompt).toHaveBeenCalledWith(
+          mockPlugin.app,
           mockProject.systemPrompt,
           "",
           mockPlugin.app.vault,
@@ -1910,7 +1919,7 @@ describe("ChatManager", () => {
         );
 
         // Verify the final prompt contains project blocks
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain("<project_system_prompt>");
         expect(systemPromptArg).toContain("PROCESSED_PROJECT_PROMPT");
         expect(systemPromptArg).toContain("</project_system_prompt>");
@@ -1919,7 +1928,7 @@ describe("ChatManager", () => {
         expect(systemPromptArg).toContain("</project_context>");
 
         // Verify includedFiles contains project file
-        const includedFilesArg = mockContextManager.processMessageContext.mock.calls[0][8];
+        const includedFilesArg = mockContextManager.processMessageContext.mock.calls[0][9];
         expect(includedFilesArg).toContainEqual(projectIncludedFile);
       });
 
@@ -1974,7 +1983,7 @@ describe("ChatManager", () => {
         expect(processPrompt).toHaveBeenCalledTimes(2);
 
         // Verify includedFiles contains both files
-        const includedFilesArg = mockContextManager.processMessageContext.mock.calls[0][8];
+        const includedFilesArg = mockContextManager.processMessageContext.mock.calls[0][9];
         expect(includedFilesArg).toContainEqual(userIncludedFile);
         expect(includedFilesArg).toContainEqual(projectIncludedFile);
       });
@@ -2009,7 +2018,7 @@ describe("ChatManager", () => {
 
         await chatManager.sendMessage("Hello", context, ChainType.PROJECT_CHAIN);
 
-        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][7];
+        const systemPromptArg = mockContextManager.processMessageContext.mock.calls[0][8];
         expect(systemPromptArg).toContain("<project_system_prompt>");
         expect(systemPromptArg).not.toContain("<project_context>");
       });

--- a/src/core/ChatManager.ts
+++ b/src/core/ChatManager.ts
@@ -129,7 +129,7 @@ export class ChatManager {
     try {
       // Reason: selectedText is empty because system prompts don't use selection context
       // skipEmptyBraces is true to treat {} as literal in system prompts
-      const result = await processPrompt(prompt, "", vault, activeNote, true);
+      const result = await processPrompt(this.plugin.app, prompt, "", vault, activeNote, true);
 
       // Only trim when the template engine actually ran to avoid mutating user-provided whitespace
       return {
@@ -474,6 +474,7 @@ export class ChatManager {
 
       // Process context to generate LLM content
       const { processedContent, contextEnvelope } = await this.contextManager.processMessageContext(
+        this.plugin.app,
         message,
         this.fileParserManager,
         this.plugin.app.vault,
@@ -528,6 +529,7 @@ export class ChatManager {
       const { processedPrompt: systemPrompt, includedFiles: systemPromptIncludedFiles } =
         await this.getSystemPromptForMessage(chainType, this.plugin.app.vault, activeNote);
       await this.contextManager.reprocessMessageContext(
+        this.plugin.app,
         messageId,
         currentRepo,
         this.fileParserManager,
@@ -617,6 +619,7 @@ export class ChatManager {
         const { processedPrompt: systemPrompt, includedFiles: systemPromptIncludedFiles } =
           await this.getSystemPromptForMessage(chainType, this.plugin.app.vault, activeNote);
         await this.contextManager.reprocessMessageContext(
+          this.plugin.app,
           userMessage.id,
           currentRepo,
           this.fileParserManager,

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -67,7 +67,7 @@ export class ChatPersistenceManager {
       const firstMessageEpoch = messages[0].timestamp?.epoch || Date.now();
 
       // Ensure the save folder exists (supports nested paths) using utility helper.
-      await ensureFolderExists(settings.defaultSaveFolder);
+      await ensureFolderExists(this.app.vault, settings.defaultSaveFolder);
 
       // Check if a file with this epoch already exists
       const existingFile = await this.findFileByEpoch(firstMessageEpoch);

--- a/src/core/ContextManager.ts
+++ b/src/core/ContextManager.ts
@@ -18,7 +18,7 @@ import { getSettings } from "@/settings/model";
 import { FileParserManager } from "@/tools/FileParserManager";
 import { ChatMessage, MessageContext } from "@/types/message";
 import { extractNoteFiles, getNotesFromPath, getNotesFromTags } from "@/utils";
-import { TFile, Vault } from "obsidian";
+import { App, TFile, Vault } from "obsidian";
 import { MessageRepository } from "./MessageRepository";
 
 // Lazy-loaded to avoid circular dependency issues in tests
@@ -64,6 +64,7 @@ export class ContextManager {
    * This generates fresh context content from current file states
    */
   async processMessageContext(
+    app: App,
     message: ChatMessage,
     fileParserManager: FileParserManager,
     vault: Vault,
@@ -82,6 +83,7 @@ export class ContextManager {
 
       // 1. Process custom prompts first
       const { processedPrompt: processedUserMessage, includedFiles } = await processPrompt(
+        app,
         processedMessage,
         "",
         vault,
@@ -95,7 +97,7 @@ export class ContextManager {
       const contextUrls = message.context?.urls || [];
       const urlContextAddition =
         chainType === ChainType.COPILOT_PLUS_CHAIN
-          ? await this.mention.processUrlList(contextUrls)
+          ? await this.mention.processUrlList(vault, contextUrls)
           : { urlContext: "", imageUrls: [] };
 
       // 4. Process context notes (L3 - current turn only, excluding files already in L2 or system prompt)
@@ -147,7 +149,7 @@ export class ContextManager {
 
       if (contextTags.length > 0) {
         // Get all notes that have any of the specified tags (in frontmatter)
-        const taggedNotes = getNotesFromTags(vault, contextTags);
+        const taggedNotes = getNotesFromTags(app, contextTags);
 
         // Filter out already processed notes to avoid duplication
         const filteredTaggedNotes = taggedNotes.filter(
@@ -304,6 +306,7 @@ export class ContextManager {
    * This ensures edited messages get fresh context
    */
   async reprocessMessageContext(
+    app: App,
     messageId: string,
     messageRepo: MessageRepository,
     fileParserManager: FileParserManager,
@@ -323,6 +326,7 @@ export class ContextManager {
     logInfo(`[ContextManager] Reprocessing context for message ${messageId}`);
 
     const { processedContent, contextEnvelope } = await this.processMessageContext(
+      app,
       message,
       fileParserManager,
       vault,

--- a/src/integration_tests/AgentPrompt.test.ts
+++ b/src/integration_tests/AgentPrompt.test.ts
@@ -223,7 +223,7 @@ describe("Agent Prompt Integration Test - Direct Model Testing", () => {
       // Initialize built-in tools with all tools available
       const registry = ToolRegistry.getInstance();
       registry.clear(); // Clear any existing tools
-      initializeBuiltinTools(mockApp.vault as any);
+      initializeBuiltinTools(mockApp as any);
 
       // Get available tools and filter to enabled ones
       const { getSettings } = await import("@/settings/model");

--- a/src/logFileManager.ts
+++ b/src/logFileManager.ts
@@ -1,5 +1,5 @@
 import { err2String } from "@/errorFormat";
-import { TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 import { ensureFolderExists } from "@/utils";
 import { getSettings } from "@/settings/model";
 import { isSensitiveKey } from "@/encryptionService";
@@ -20,12 +20,22 @@ class LogFileManager {
   private buffer: string[] = [];
   private initialized = false;
   private flushing = false;
+  private app: App | null = null;
 
   static getInstance(): LogFileManager {
     if (!LogFileManager.instance) {
       LogFileManager.instance = new LogFileManager();
     }
     return LogFileManager.instance;
+  }
+
+  /**
+   * Seed the Obsidian app. The logger is a module-level singleton created before
+   * plugin load, so `app` is injected here once during onload (see main.ts)
+   * rather than read from the global.
+   */
+  setApp(app: App): void {
+    this.app = app;
   }
 
   getLogPath(): string {
@@ -37,15 +47,6 @@ class LogFileManager {
     if (this.initialized) return;
     // Start with empty buffer - log file is only an export artifact
     this.initialized = true;
-  }
-
-  private hasVault(): boolean {
-    // global `app` is available in Obsidian environment
-    try {
-      return typeof app !== "undefined" && !!app.vault?.adapter;
-    } catch {
-      return false;
-    }
   }
 
   private sanitizeForSingleLine(value: unknown): string {
@@ -121,7 +122,8 @@ class LogFileManager {
   }
 
   async flush(): Promise<void> {
-    if (!this.hasVault()) return;
+    const app = this.app;
+    if (!app?.vault?.adapter) return;
     if (this.flushing) return;
     this.flushing = true;
     try {
@@ -141,7 +143,8 @@ class LogFileManager {
 
   async clear(): Promise<void> {
     this.buffer = [];
-    if (!this.hasVault()) return;
+    const app = this.app;
+    if (!app?.vault?.adapter) return;
     try {
       const path = this.getLogPath();
       if (await app.vault.adapter.exists(path)) {
@@ -203,7 +206,8 @@ class LogFileManager {
   }
 
   async openLogFile(): Promise<void> {
-    if (!this.hasVault()) return;
+    const app = this.app;
+    if (!app?.vault?.adapter) return;
     const path = this.getLogPath();
 
     // Snapshot the current buffer
@@ -226,7 +230,7 @@ class LogFileManager {
       const content = bufferSnapshot.join("\n") + (bufferSnapshot.length ? "\n" : "");
       const folder = path.includes("/") ? path.split("/").slice(0, -1).join("/") : "";
       if (folder) {
-        await ensureFolderExists(folder);
+        await ensureFolderExists(app.vault, folder);
       }
 
       const fileExists = await app.vault.adapter.exists(path);

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   isAgentModeEnabled,
   PlanPreviewView,
   PLAN_PREVIEW_VIEW_TYPE,
+  setFrameSinkVaultBasePath,
   SkillManager,
   type AgentSessionManager,
 } from "@/agentMode";
@@ -74,6 +75,9 @@ import {
   setSettings,
   subscribeToSettingsChange,
 } from "@/settings/model";
+import { ProjectContextCache } from "@/cache/projectContextCache";
+import { ContextProcessor } from "@/contextProcessor";
+import { CustomCommandManager } from "@/commands/customCommandManager";
 import { ChatManagerChatUIState } from "@/state/ChatUIState";
 import { VaultDataManager } from "@/state/vaultDataAtoms";
 import { FileParserManager } from "@/tools/FileParserManager";
@@ -86,6 +90,7 @@ import {
 } from "@/editor";
 import {
   Editor,
+  FileSystemAdapter,
   MarkdownView,
   Menu,
   Notice,
@@ -208,13 +213,20 @@ export default class CopilotPlugin extends Plugin {
 
     // Core plugin initialization
 
-    // Initialize built-in tools with vault access
-    initializeBuiltinTools(this.app.vault);
+    // Initialize built-in tools with app access
+    initializeBuiltinTools(this.app);
+
+    // Seed the ProjectContextCache and ContextProcessor singletons with `app`
+    // before anything reaches for them via the no-arg getInstance().
+    ProjectContextCache.getInstance(this.app);
+    ContextProcessor.getInstance(this.app);
+    CustomCommandManager.getInstance(this.app);
+    logFileManager.setApp(this.app);
 
     // Initialize BrevilabsClient
     this.brevilabsClient = BrevilabsClient.getInstance();
     this.brevilabsClient.setPluginVersion(this.manifest.version);
-    void checkIsPlusUser();
+    void checkIsPlusUser(this.app);
     void refreshSelfHostModeValidation();
 
     // Initialize ProjectManager
@@ -222,6 +234,12 @@ export default class CopilotPlugin extends Plugin {
 
     // Initialize Agent Mode coordinator (desktop only — ACP needs subprocess support).
     if (!Platform.isMobile) {
+      // Seed the frame-log sink with the vault base path (desktop FileSystemAdapter only).
+      const adapter = this.app.vault.adapter;
+      setFrameSinkVaultBasePath(
+        adapter instanceof FileSystemAdapter ? adapter.getBasePath() : null
+      );
+
       this.agentSessionManager = createAgentSessionManager(this.app, this);
       // Enroll agent-reported models on probe settle, even when the settings
       // tab is closed. See `agentModelDiscovery.ts`.
@@ -232,12 +250,12 @@ export default class CopilotPlugin extends Plugin {
     }
 
     // Always construct VectorStoreManager; it internally no-ops when semantic search is disabled
-    this.vectorStoreManager = VectorStoreManager.getInstance();
+    this.vectorStoreManager = VectorStoreManager.getInstance(this.app);
 
     // Initialize VaultDataManager for centralized vault data (notes, folders, tags)
     // Note: VaultDataManager tracks ALL data; hooks filter based on parameters
     const vaultDataManager = VaultDataManager.getInstance();
-    vaultDataManager.initialize();
+    vaultDataManager.initialize(this.app);
 
     // Initialize FileParserManager early with other core services
     this.fileParserManager = new FileParserManager(this.brevilabsClient, this.app.vault);
@@ -324,8 +342,8 @@ export default class CopilotPlugin extends Plugin {
       })
     );
 
-    this.customCommandRegister = new CustomCommandRegister(this, this.app.vault);
-    this.systemPromptRegister = new SystemPromptRegister(this, this.app.vault);
+    this.customCommandRegister = new CustomCommandRegister(this, this.app);
+    this.systemPromptRegister = new SystemPromptRegister(this, this.app);
     this.projectRegister = new ProjectRegister(this.app);
 
     this.app.workspace.onLayoutReady(() => {
@@ -341,13 +359,13 @@ export default class CopilotPlugin extends Plugin {
       // Initialize custom commands
       void this.customCommandRegister
         .initialize()
-        .then(migrateCommands)
-        .then(suggestDefaultCommands);
+        .then(() => migrateCommands(this.app))
+        .then(() => suggestDefaultCommands(this.app));
 
       // Initialize system prompts (independent from custom commands)
       void this.systemPromptRegister
         .initialize()
-        .then(() => migrateSystemPromptsFromSettings(this.app.vault));
+        .then(() => migrateSystemPromptsFromSettings(this.app));
     });
 
     // Initialize automatic selection handler
@@ -853,7 +871,9 @@ export default class CopilotPlugin extends Plugin {
 
   async getChatHistoryItems(): Promise<ChatHistoryItem[]> {
     const files = await this.getChatHistoryFiles();
-    return files.map((file) => fileToHistoryItem(file, this.chatHistoryLastAccessedAtManager));
+    return files.map((file) =>
+      fileToHistoryItem(this.app, file, this.chatHistoryLastAccessedAtManager)
+    );
   }
 
   /**
@@ -868,7 +888,7 @@ export default class CopilotPlugin extends Plugin {
       this.chatHistoryLastAccessedAtManager.touch(file.path);
 
       // Check if we should persist to disk (throttled)
-      const persistedLastAccessedAtMs = extractChatLastAccessedAtMs(file);
+      const persistedLastAccessedAtMs = extractChatLastAccessedAtMs(this.app, file);
       const timestampToPersist = this.chatHistoryLastAccessedAtManager.shouldPersist(
         file.path,
         persistedLastAccessedAtMs

--- a/src/memory/UserMemoryManager.test.ts
+++ b/src/memory/UserMemoryManager.test.ts
@@ -513,7 +513,7 @@ The conversation covered advanced features and included code examples.`,
       );
 
       // Verify folder creation was called
-      expect(ensureFolderExists).toHaveBeenCalledWith("copilot/memory");
+      expect(ensureFolderExists).toHaveBeenCalledWith(mockVault, "copilot/memory");
 
       // Verify file creation was called with proper content
       expect(mockVault.create).toHaveBeenCalledWith(

--- a/src/memory/UserMemoryManager.ts
+++ b/src/memory/UserMemoryManager.ts
@@ -228,7 +228,7 @@ export class UserMemoryManager {
     const settings = getSettings();
     const memoryFolderPath = settings.memoryFolderName;
 
-    await ensureFolderExists(memoryFolderPath);
+    await ensureFolderExists(this.app.vault, memoryFolderPath);
   }
 
   private getRecentConversationFilePath(): string {

--- a/src/mentions/Mention.ts
+++ b/src/mentions/Mention.ts
@@ -4,6 +4,7 @@ import {
   Twitter4llmResponse,
   Url4llmResponse,
 } from "@/LLMProviders/brevilabsClient";
+import { Vault } from "obsidian";
 import { selfHostYoutube4llm } from "@/LLMProviders/selfHostServices";
 import { err2String, isTwitterUrl, isYoutubeUrl } from "@/utils";
 import { logError } from "@/logger";
@@ -89,7 +90,10 @@ export class Mention {
    * @param urls Array of URLs to process
    * @returns Processed URL context and any errors
    */
-  async processUrlList(urls: string[]): Promise<{
+  async processUrlList(
+    vault: Vault,
+    urls: string[]
+  ): Promise<{
     urlContext: string;
     imageUrls: string[];
     processedErrorUrls: Record<string, string>;
@@ -106,7 +110,7 @@ export class Mention {
     // Process all URLs concurrently
     const processPromises = urls.map(async (url) => {
       // Check if it's an image URL
-      if (await ImageProcessor.isImageUrl(url, app.vault)) {
+      if (await ImageProcessor.isImageUrl(url, vault)) {
         imageUrls.push(url);
         return { type: "image", url };
       }
@@ -195,13 +199,16 @@ export class Mention {
    * @param text The user's chat input text
    * @returns Processed URL context and any errors
    */
-  async processUrls(text: string): Promise<{
+  async processUrls(
+    vault: Vault,
+    text: string
+  ): Promise<{
     urlContext: string;
     imageUrls: string[];
     processedErrorUrls: Record<string, string>;
   }> {
     const urls = this.extractUrls(text);
-    return this.processUrlList(urls);
+    return this.processUrlList(vault, urls);
   }
 
   getMentions(): Map<string, MentionData> {

--- a/src/noteUtils.ts
+++ b/src/noteUtils.ts
@@ -1,13 +1,14 @@
 import "./types";
-import { TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 
 /**
  * Get all outgoing links from a note
+ * @param app The Obsidian app instance
  * @param file The note file to analyze
  * @param limit The maximum number of linked notes to return
  * @returns Array of linked note
  */
-export function getLinkedNotes(file: TFile, limit = 20): TFile[] {
+export function getLinkedNotes(app: App, file: TFile, limit = 20): TFile[] {
   // Get the cache for the current file
   const fileCache = app.metadataCache.getFileCache(file);
   const linkedNotes: TFile[] = [];
@@ -43,11 +44,12 @@ export function getLinkedNotes(file: TFile, limit = 20): TFile[] {
 
 /**
  * Get all notes that link to the given note
+ * @param app The Obsidian app instance
  * @param file The note file to analyze
  * @param limit The maximum number of backlinked notes to return
  * @returns Array of backlinked note
  */
-export function getBacklinkedNotes(file: TFile, limit = 20): TFile[] {
+export function getBacklinkedNotes(app: App, file: TFile, limit = 20): TFile[] {
   const backlinkedNotes: TFile[] = [];
 
   // Get the backlinks from metadata cache

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -11,7 +11,7 @@ import {
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import { logError, logInfo } from "@/logger";
 import { getSettings, setSettings, updateSetting, useSettingsValue } from "@/settings/model";
-import { Notice } from "obsidian";
+import { App, Notice } from "obsidian";
 import React from "react";
 
 export const DEFAULT_COPILOT_PLUS_CHAT_MODEL = ChatModels.COPILOT_PLUS_FLASH;
@@ -130,6 +130,7 @@ export function useIsPlusUser(): boolean | undefined {
  * When self-host mode is valid, this returns true to allow offline usage.
  */
 export async function checkIsPlusUser(
+  app?: App,
   context?: Record<string, unknown>
 ): Promise<boolean | undefined> {
   // Self-host mode with valid plan validation bypasses license check
@@ -138,11 +139,11 @@ export async function checkIsPlusUser(
   }
 
   if (!getSettings().plusLicenseKey) {
-    turnOffPlus();
+    turnOffPlus(app);
     return false;
   }
   const brevilabsClient = BrevilabsClient.getInstance();
-  const result = await brevilabsClient.validateLicenseKey(context);
+  const result = await brevilabsClient.validateLicenseKey(app, context);
   return result.isValid;
 }
 
@@ -389,10 +390,13 @@ export function turnOnPlus(): void {
  * DO NOT reset model settings here - it will cause free users to lose their model selections on every app restart.
  * Only update the isPlusUser flag.
  */
-export function turnOffPlus(): void {
+export function turnOffPlus(app?: App): void {
   const previousIsPlusUser = getSettings().isPlusUser;
   updateSetting("isPlusUser", false);
-  if (previousIsPlusUser) {
+  // The expiry modal needs `app`; interactive callers (load, settings, chat)
+  // pass it. Rare background paths (believer-model checks) flip the flag without
+  // a modal — they surface their own Notice instead.
+  if (previousIsPlusUser && app) {
     new CopilotPlusExpiredModal(app).open();
   }
 }

--- a/src/projects/ProjectFileManager.ts
+++ b/src/projects/ProjectFileManager.ts
@@ -88,7 +88,7 @@ export class ProjectFileManager {
   public async initialize(): Promise<void> {
     logInfo("[Projects] Initializing ProjectFileManager");
     await ensureProjectsMigratedIfNeeded(this.app);
-    await loadAllProjects();
+    await loadAllProjects(this.app);
   }
 
   /**
@@ -111,14 +111,14 @@ export class ProjectFileManager {
    * Reload all projects from vault (full scan + cache replace).
    */
   public async reloadProjects(): Promise<ProjectFileRecord[]> {
-    return await loadAllProjects();
+    return await loadAllProjects(this.app);
   }
 
   /**
    * Fetch all projects from vault without updating cache.
    */
   public async fetchProjects(): Promise<ProjectFileRecord[]> {
-    return await fetchAllProjects();
+    return await fetchAllProjects(this.app);
   }
 
   /**
@@ -272,8 +272,8 @@ export class ProjectFileManager {
     try {
       addPendingFileWrite(filePath);
 
-      await ensureFolderExists(getProjectsFolder());
-      await ensureFolderExists(folderPath);
+      await ensureFolderExists(this.vault, getProjectsFolder());
+      await ensureFolderExists(this.vault, folderPath);
 
       // Reason: detect folder name collisions where a different project id sanitizes to the
       // same folder (e.g. "a/b" and "a\\b" both produce "a_b"). Check both cache and filesystem.
@@ -298,7 +298,10 @@ export class ProjectFileManager {
       const file = await this.vault.create(filePath, project.systemPrompt || "");
 
       try {
-        await writeProjectFrontmatter(file, project, folderName, { createdMs, lastUsedMs });
+        await writeProjectFrontmatter(this.app, file, project, folderName, {
+          createdMs,
+          lastUsedMs,
+        });
       } catch (fmError) {
         // Reason: rollback the created file to avoid leaving a "poisoned" file without frontmatter
         await this.rollbackCreatedFile(filePath, folderPath);
@@ -420,7 +423,7 @@ export class ProjectFileManager {
 
       // Reason: use resolveFileByPath to handle both vault-cached and hidden-folder files.
       // getAbstractFileByPath returns null for hidden folders even when the file exists on disk.
-      let file = await resolveFileByPath(app, filePath);
+      let file = await resolveFileByPath(this.app, filePath);
       let materialized = false;
 
       // Reason: if the file doesn't exist anywhere (e.g. legacy project merged into cache before
@@ -428,8 +431,8 @@ export class ProjectFileManager {
       if (!file) {
         logInfo(`[Projects] Materializing missing vault file for project: ${normalizedId}`);
         const folderPath = getProjectFolderPath(folderName);
-        await ensureFolderExists(getProjectsFolder());
-        await ensureFolderExists(folderPath);
+        await ensureFolderExists(this.vault, getProjectsFolder());
+        await ensureFolderExists(this.vault, folderPath);
         file = await this.vault.create(filePath, nextProject.systemPrompt || "");
         materialized = true;
       }
@@ -451,10 +454,10 @@ export class ProjectFileManager {
 
       // Reason: processFrontMatter (used by writeProjectFrontmatter) does not work reliably
       // on synthetic TFiles for hidden folders. Split into cached-file and adapter-based paths.
-      if (isInVaultCache(app, filePath)) {
+      if (isInVaultCache(this.app, filePath)) {
         // Vault-cached file: use processFrontMatter for safe field-level updates
         try {
-          await writeProjectFrontmatter(file, projectForWrite, folderName, {
+          await writeProjectFrontmatter(this.app, file, projectForWrite, folderName, {
             createdMs,
             lastUsedMs,
           });
@@ -590,7 +593,9 @@ export class ProjectFileManager {
 
       // Reason: rescan to re-admit any previously-ignored duplicate-id files.
       // The register won't fire (pending guard), so we trigger rescan here.
-      void loadAllProjects().catch((err) => logError("[Projects] Rescan after delete failed", err));
+      void loadAllProjects(this.app).catch((err) =>
+        logError("[Projects] Rescan after delete failed", err)
+      );
     } finally {
       removePendingFileWrite(existing.filePath);
     }
@@ -617,7 +622,7 @@ export class ProjectFileManager {
       if (timestampToPersist === null) return;
 
       const filePath = normalizePath(record.filePath);
-      const file = await resolveFileByPath(app, filePath);
+      const file = await resolveFileByPath(this.app, filePath);
       if (!file) return;
 
       // Reason: use alreadyPending pattern to avoid clearing another in-flight pending write
@@ -626,23 +631,26 @@ export class ProjectFileManager {
       try {
         if (!alreadyPending) addPendingFileWrite(filePath);
 
-        if (isInVaultCache(app, filePath)) {
+        if (isInVaultCache(this.app, filePath)) {
           // Vault-cached file: use processFrontMatter for safe field-level update
-          await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
-            const existing = Number(frontmatter[COPILOT_PROJECT_LAST_USED]);
-            const existingMs = Number.isFinite(existing) && existing > 0 ? existing : 0;
-            actualPersistedValue = Math.max(existingMs, timestampToPersist);
-            if (existingMs === actualPersistedValue) return;
-            frontmatter[COPILOT_PROJECT_LAST_USED] = actualPersistedValue;
-          });
+          await this.app.fileManager.processFrontMatter(
+            file,
+            (frontmatter: Record<string, unknown>) => {
+              const existing = Number(frontmatter[COPILOT_PROJECT_LAST_USED]);
+              const existingMs = Number.isFinite(existing) && existing > 0 ? existing : 0;
+              actualPersistedValue = Math.max(existingMs, timestampToPersist);
+              if (existingMs === actualPersistedValue) return;
+              frontmatter[COPILOT_PROJECT_LAST_USED] = actualPersistedValue;
+            }
+          );
         } else {
           // Hidden-folder file: use adapter-based frontmatter patch
-          const adapterFm = await readFrontmatterViaAdapter(app, filePath);
+          const adapterFm = await readFrontmatterViaAdapter(this.app, filePath);
           const existing = Number(adapterFm?.[COPILOT_PROJECT_LAST_USED]);
           const existingMs = Number.isFinite(existing) && existing > 0 ? existing : 0;
           actualPersistedValue = Math.max(existingMs, timestampToPersist);
           if (existingMs !== actualPersistedValue) {
-            await patchFrontmatter(app, filePath, {
+            await patchFrontmatter(this.app, filePath, {
               [COPILOT_PROJECT_LAST_USED]: actualPersistedValue,
             });
           }

--- a/src/projects/projectMigration.ts
+++ b/src/projects/projectMigration.ts
@@ -43,7 +43,7 @@ async function saveFailedProjectToUnsupported(
 ): Promise<boolean> {
   try {
     const unsupportedFolder = getProjectsUnsupportedFolder();
-    await ensureFolderExists(unsupportedFolder);
+    await ensureFolderExists(vault, unsupportedFolder);
 
     const safeId = sanitizeVaultPathSegment(project.id || "unknown") || "unknown";
     // Reason: use deterministic base name so repeated migration runs don't create duplicate
@@ -147,8 +147,8 @@ async function writeProjectToVaultFile(
 ): Promise<TFile> {
   const vault = app.vault;
   const projectsFolder = getProjectsFolder();
-  await ensureFolderExists(projectsFolder);
-  await ensureFolderExists(`${projectsFolder}/${folderName}`);
+  await ensureFolderExists(vault, projectsFolder);
+  await ensureFolderExists(vault, `${projectsFolder}/${folderName}`);
 
   const filePath = getProjectConfigFilePath(folderName);
 
@@ -168,7 +168,7 @@ async function writeProjectToVaultFile(
         : 0;
 
     try {
-      await writeProjectFrontmatter(file, project, folderName, { createdMs, lastUsedMs });
+      await writeProjectFrontmatter(app, file, project, folderName, { createdMs, lastUsedMs });
     } catch (fmError) {
       // Reason: rollback the created file to avoid leaving a "poisoned" file without frontmatter
       await rollbackCreatedFile(app, filePath, folderPath);
@@ -352,7 +352,7 @@ export async function migrateProjectsFromSettingsToVault(app: App): Promise<void
           if (existingFile instanceof TFile) {
             try {
               const folderNameForRepair = getMigrationFolderName(id, project.name);
-              await ensureProjectFrontmatter(existingFile, {
+              await ensureProjectFrontmatter(app, existingFile, {
                 project,
                 filePath,
                 folderName: folderNameForRepair,
@@ -511,8 +511,9 @@ export async function migrateProjectsFromSettingsToVault(app: App): Promise<void
  * This is idempotent: projects already using name-based folders are skipped.
  * Collisions are handled gracefully (skip with warning).
  */
-async function migrateProjectFolderNames(vault: Vault): Promise<void> {
-  const { records } = await scanAllProjectConfigFiles();
+async function migrateProjectFolderNames(app: App): Promise<void> {
+  const vault = app.vault;
+  const { records } = await scanAllProjectConfigFiles(app);
   if (records.length === 0) return;
 
   let renamed = 0;
@@ -613,5 +614,5 @@ export async function ensureProjectsMigratedIfNeeded(app: App): Promise<void> {
   // Reason: run naming migration after data.json migration to rename id-based folders
   // to name-based folders. This also handles pre-existing projects from before the
   // naming convention change. Runs before loadAllProjects() in initialization flow.
-  await migrateProjectFolderNames(app.vault);
+  await migrateProjectFolderNames(app);
 }

--- a/src/projects/projectRegister.ts
+++ b/src/projects/projectRegister.ts
@@ -34,6 +34,7 @@ import { App, Notice, TAbstractFile, Vault } from "obsidian";
  * - Avoid event loops from pending file writes
  */
 export class ProjectRegister {
+  private app: App;
   private vault: Vault;
   private manager: ProjectFileManager;
   private settingsUnsubscriber?: () => void;
@@ -43,6 +44,7 @@ export class ProjectRegister {
   private fileModifyDebouncers = new Map<string, ReturnType<typeof debounce>>();
 
   constructor(app: App) {
+    this.app = app;
     this.vault = app.vault;
     this.manager = ProjectFileManager.getInstance(app);
   }
@@ -210,7 +212,7 @@ export class ProjectRegister {
     if (!isProjectConfigFile(file) || isPendingFileWrite(file.path)) return;
 
     try {
-      const record = await parseProjectConfigFile(file);
+      const record = await parseProjectConfigFile(this.app, file);
       if (!record) return;
 
       // Duplicate id: keep first in cache, ignore incoming
@@ -223,8 +225,8 @@ export class ProjectRegister {
         return;
       }
 
-      await ensureProjectFrontmatter(file, record);
-      const updated = await parseProjectConfigFile(file);
+      await ensureProjectFrontmatter(this.app, file, record);
+      const updated = await parseProjectConfigFile(this.app, file);
       if (updated) upsertCachedProjectRecord(updated);
     } catch (error) {
       logError(`[Projects] Error on file creation: ${file.path}`, error);
@@ -266,7 +268,7 @@ export class ProjectRegister {
         // Reason: rescan to re-admit any previously-ignored duplicate-id files
         // that were hidden while the deleted file was the "kept" entry.
         // Re-merge legacy projects after rescan so unmigrated fallback entries stay visible.
-        void loadAllProjects().catch((err) =>
+        void loadAllProjects(this.app).catch((err) =>
           logError("[Projects] Rescan after delete failed", err)
         );
       }
@@ -295,7 +297,7 @@ export class ProjectRegister {
       // Reason: validate the new file before deleting the old cache entry,
       // so a duplicate-ID rename doesn't leave a cache gap.
       if (isValidNow) {
-        const record = await parseProjectConfigFile(file);
+        const record = await parseProjectConfigFile(this.app, file);
         if (!record) {
           if (wasValid) deleteCachedProjectRecordByFilePath(oldPath);
           return;
@@ -316,8 +318,8 @@ export class ProjectRegister {
           return;
         }
 
-        await ensureProjectFrontmatter(file, record);
-        const updated = await parseProjectConfigFile(file);
+        await ensureProjectFrontmatter(this.app, file, record);
+        const updated = await parseProjectConfigFile(this.app, file);
         if (updated) {
           // Reason: use atomic replace to avoid transient disappearance gap.
           // delete+upsert causes the subscriber to see the active project as missing
@@ -351,7 +353,7 @@ export class ProjectRegister {
 
         // Reason: rescan to re-admit any previously-ignored duplicate-id files
         // that were hidden while the moved file was the "kept" entry.
-        void loadAllProjects().catch((err) =>
+        void loadAllProjects(this.app).catch((err) =>
           logError("[Projects] Rescan after rename-out failed", err)
         );
       }
@@ -377,7 +379,7 @@ export class ProjectRegister {
     if (!isProjectConfigFile(file) || isPendingFileWrite(file.path)) return;
 
     try {
-      const record = await parseProjectConfigFile(file);
+      const record = await parseProjectConfigFile(this.app, file);
       if (!record) {
         // Reason: file became invalid YAML — remove stale cache entry and clear selection
         // if this was the active project, so UI and chain don't use stale config.
@@ -390,7 +392,7 @@ export class ProjectRegister {
               logError("[Projects] Failed to clear context cache on invalid edit", err)
             );
           // Reason: rescan to re-admit previously-ignored duplicate-id files
-          void loadAllProjects().catch((err) =>
+          void loadAllProjects(this.app).catch((err) =>
             logError("[Projects] Rescan after invalid edit failed", err)
           );
         }
@@ -409,7 +411,7 @@ export class ProjectRegister {
               logError("[Projects] Failed to clear context cache on duplicate edit", err)
             );
           // Reason: rescan to re-admit previously-ignored duplicate-id files
-          void loadAllProjects().catch((err) =>
+          void loadAllProjects(this.app).catch((err) =>
             logError("[Projects] Rescan after duplicate edit failed", err)
           );
         }

--- a/src/projects/projectUtils.test.ts
+++ b/src/projects/projectUtils.test.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 import { parseProjectConfigFile, sanitizeVaultPathSegment } from "@/projects/projectUtils";
 import { mockTFile } from "@/__tests__/mockObsidian";
 
@@ -33,9 +33,9 @@ function makeMockFile(path: string): TFile {
   });
 }
 
-// Helper: set up the global `app` mock used by parseProjectConfigFile
-function setupAppMock(rawContent: string, frontmatter: Record<string, unknown> | null) {
-  (window as unknown as Record<string, unknown>).app = {
+// Helper: build the `app` mock passed to parseProjectConfigFile
+function setupAppMock(rawContent: string, frontmatter: Record<string, unknown> | null): App {
+  const app = {
     vault: {
       read: jest.fn().mockResolvedValue(rawContent),
       // Reason: parseProjectConfigFile uses `cachedFile instanceof TFile` to detect synthetic TFiles.
@@ -47,7 +47,8 @@ function setupAppMock(rawContent: string, frontmatter: Record<string, unknown> |
       // Reason: returning null forces the fallback YAML parse path in parseProjectConfigFile
       getFileCache: jest.fn().mockReturnValue(frontmatter ? { frontmatter } : null),
     },
-  };
+  } as unknown as App;
+  return app;
 }
 
 describe("parseProjectConfigFile", () => {
@@ -57,10 +58,10 @@ describe("parseProjectConfigFile", () => {
     // Malformed YAML: unbalanced braces cause a parse error
     const malformedContent = "---\nname: {bad: yaml: here\n---\nBody text";
     // Force the metadata-cache miss so the fallback YAML parser runs
-    setupAppMock(malformedContent, null);
+    const app = setupAppMock(malformedContent, null);
 
     const file = makeMockFile(VALID_PATH);
-    const result = await parseProjectConfigFile(file);
+    const result = await parseProjectConfigFile(app, file);
 
     expect(result).toBeNull();
   });
@@ -86,7 +87,7 @@ describe("parseProjectConfigFile", () => {
     ].join("\n");
 
     // Use metadata-cache path (non-null frontmatter) for the happy path
-    setupAppMock(rawContent, {
+    const app = setupAppMock(rawContent, {
       "copilot-project-id": "my-project",
       "copilot-project-name": "My Project",
       "copilot-project-description": "A test project",
@@ -102,7 +103,7 @@ describe("parseProjectConfigFile", () => {
     });
 
     const file = makeMockFile(VALID_PATH);
-    const result = await parseProjectConfigFile(file);
+    const result = await parseProjectConfigFile(app, file);
 
     expect(result).not.toBeNull();
     expect(result!.project.id).toBe("my-project");
@@ -123,12 +124,12 @@ describe("parseProjectConfigFile", () => {
   it("returns null when copilot-project-id is missing from frontmatter", async () => {
     const rawContent = ["---", "copilot-project-name: My Project", "---", "Body text"].join("\n");
 
-    setupAppMock(rawContent, {
+    const app = setupAppMock(rawContent, {
       "copilot-project-name": "My Project",
     });
 
     const file = makeMockFile(VALID_PATH);
-    const result = await parseProjectConfigFile(file);
+    const result = await parseProjectConfigFile(app, file);
 
     // Reason: files without copilot-project-id are treated as corrupted and skipped.
     // With name-based folders, folderName can no longer serve as id fallback.

--- a/src/projects/projectUtils.ts
+++ b/src/projects/projectUtils.ts
@@ -24,7 +24,7 @@ import {
 import { ProjectFileRecord, ProjectScanDiagnostics } from "@/projects/type";
 import { stripFrontmatter } from "@/utils";
 import { logError, logWarn } from "@/logger";
-import { parseYaml, TFile, TFolder } from "obsidian";
+import { App, parseYaml, TFile, TFolder } from "obsidian";
 import {
   addPendingFileWrite,
   isPendingFileWrite,
@@ -54,6 +54,7 @@ export {
  * @param timestamps - Created and last-used timestamps
  */
 export async function writeProjectFrontmatter(
+  app: App,
   file: TFile,
   project: ProjectConfig,
   folderName: string,
@@ -161,7 +162,10 @@ function joinUrlsArrayToString(urls: string[]): string {
  * @param file - project.md TFile
  * @returns ProjectFileRecord, or null if parse fails
  */
-export async function parseProjectConfigFile(file: TFile): Promise<ProjectFileRecord | null> {
+export async function parseProjectConfigFile(
+  app: App,
+  file: TFile
+): Promise<ProjectFileRecord | null> {
   // Reason: vault.read() calls internal TFile.cache which doesn't exist on synthetic TFiles
   // created by resolveFileByPath() for hidden-folder or not-yet-indexed files.
   // Use the cached real TFile for vault API calls; fall back to adapter for synthetic files.
@@ -293,7 +297,7 @@ export async function parseProjectConfigFile(file: TFile): Promise<ProjectFileRe
  *
  * @returns Records and diagnostics
  */
-export async function scanAllProjectConfigFiles(): Promise<{
+export async function scanAllProjectConfigFiles(app: App): Promise<{
   records: ProjectFileRecord[];
   diagnostics: ProjectScanDiagnostics;
 }> {
@@ -339,7 +343,7 @@ export async function scanAllProjectConfigFiles(): Promise<{
   for (const file of files) {
     let record: ProjectFileRecord | null;
     try {
-      record = await parseProjectConfigFile(file);
+      record = await parseProjectConfigFile(app, file);
     } catch (error) {
       logError(`[Projects] Failed to parse project file, skipping: ${file.path}`, error);
       ignoredFiles.push(file.path);
@@ -380,8 +384,8 @@ export async function scanAllProjectConfigFiles(): Promise<{
  *
  * @returns Array of ProjectFileRecord
  */
-export async function loadAllProjects(): Promise<ProjectFileRecord[]> {
-  const { records } = await scanAllProjectConfigFiles();
+export async function loadAllProjects(app: App): Promise<ProjectFileRecord[]> {
+  const { records } = await scanAllProjectConfigFiles(app);
   updateCachedProjectRecords(records);
   return records;
 }
@@ -390,8 +394,8 @@ export async function loadAllProjects(): Promise<ProjectFileRecord[]> {
  * Fetch all projects from vault without updating the cache.
  * @returns Array of ProjectFileRecord
  */
-export async function fetchAllProjects(): Promise<ProjectFileRecord[]> {
-  const { records } = await scanAllProjectConfigFiles();
+export async function fetchAllProjects(app: App): Promise<ProjectFileRecord[]> {
+  const { records } = await scanAllProjectConfigFiles(app);
   return records;
 }
 
@@ -402,6 +406,7 @@ export async function fetchAllProjects(): Promise<ProjectFileRecord[]> {
  * @param record - Parsed record providing default values
  */
 export async function ensureProjectFrontmatter(
+  app: App,
   file: TFile,
   record: ProjectFileRecord
 ): Promise<void> {

--- a/src/search/dbOperations.ts
+++ b/src/search/dbOperations.ts
@@ -576,7 +576,7 @@ export class DBOperations {
       const { inclusions, exclusions } = getMatchingPatterns();
       const allowedPaths = new Set(
         files
-          .filter((file) => shouldIndexFile(file, inclusions, exclusions))
+          .filter((file) => shouldIndexFile(this.app, file, inclusions, exclusions))
           .map((file) => file.path)
       );
       // Get all documents in the database

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -175,7 +175,7 @@ describe("findRelevantNotes", () => {
     mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("second.md")]);
     mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
-    const result = await findRelevantNotes({ filePath: "source.md" });
+    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
     expect(result.map((entry) => entry.note.path)).toEqual([
       "second.md",
@@ -222,7 +222,7 @@ describe("findRelevantNotes", () => {
       ],
     });
 
-    const result = await findRelevantNotes({ filePath: "source.md" });
+    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
     expect(result.map((entry) => entry.note.path)).toEqual(["beta.md", "alpha.md"]);
     expect(result.find((entry) => entry.note.path === "alpha.md")?.metadata.similarityScore).toBe(
@@ -257,7 +257,7 @@ describe("findRelevantNotes", () => {
       ],
     });
 
-    const result = await findRelevantNotes({ filePath: "source.md" });
+    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
     expect(result.map((e) => e.note.path)).toEqual(["alpha.md"]);
     expect(result[0].metadata.similarityScore).toBe(0.75);
@@ -286,7 +286,7 @@ describe("findRelevantNotes", () => {
     mockSearchRelated.mockRejectedValue(new Error("Miyo unavailable"));
     mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
-    const result = await findRelevantNotes({ filePath: "source.md" });
+    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
     expect(result).toHaveLength(1);
     expect(result[0].note.path).toBe("linked-only.md");

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -13,7 +13,7 @@ import type { SemanticIndexDocument } from "@/search/indexBackend/SemanticIndexB
 import VectorStoreManager from "@/search/vectorStoreManager";
 import { getSettings } from "@/settings/model";
 import { InternalTypedDocument, Orama, Result } from "@orama/orama";
-import { TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 
 const MAX_K = 20;
 const ORIGINAL_WEIGHT = 0.7;
@@ -124,10 +124,14 @@ async function calculateSimilarityScoreFromOrama({
 /**
  * Calculate similarity scores using Miyo's related-note endpoint.
  *
+ * @param app - The Obsidian app instance.
  * @param filePath - Source note path.
  * @returns Map of note paths to max similarity score.
  */
-async function calculateSimilarityScoreFromMiyo(filePath: string): Promise<Map<string, number>> {
+async function calculateSimilarityScoreFromMiyo(
+  app: App,
+  filePath: string
+): Promise<Map<string, number>> {
   const settings = getSettings();
   const miyoClient = new MiyoClient();
   const folderName = getMiyoFolderName(app);
@@ -181,12 +185,13 @@ async function calculateSimilarityScoreFromMiyo(filePath: string): Promise<Map<s
 /**
  * Calculate similarity scores by selecting the best available backend strategy.
  *
+ * @param app - The Obsidian app instance.
  * @param filePath - Source note path.
  * @returns Map of note paths to max similarity score.
  */
-async function calculateSimilarityScore(filePath: string): Promise<Map<string, number>> {
+async function calculateSimilarityScore(app: App, filePath: string): Promise<Map<string, number>> {
   if (shouldUseMiyoForRelevantNotes()) {
-    return calculateSimilarityScoreFromMiyo(filePath);
+    return calculateSimilarityScoreFromMiyo(app, filePath);
   }
 
   const currentNoteDocs = await VectorStoreManager.getInstance().getDocumentsByPath(filePath);
@@ -216,24 +221,25 @@ async function calculateSimilarityScore(filePath: string): Promise<Map<string, n
     return new Map();
   }
 
-  return calculateSimilarityScoreFromMiyo(filePath);
+  return calculateSimilarityScoreFromMiyo(app, filePath);
 }
 
 /**
  * Build outgoing/backlink relationship flags for the source note.
  *
+ * @param app - The Obsidian app instance.
  * @param file - Source note file.
  * @returns Map keyed by note path with link metadata.
  */
-function getNoteLinks(file: TFile) {
+function getNoteLinks(app: App, file: TFile) {
   const resultMap = new Map<string, { links: boolean; backlinks: boolean }>();
-  const linkedNotes = getLinkedNotes(file);
+  const linkedNotes = getLinkedNotes(app, file);
   const linkedNotePaths = linkedNotes.map((note) => note.path);
   for (const notePath of linkedNotePaths) {
     resultMap.set(notePath, { links: true, backlinks: false });
   }
 
-  const backlinkedNotes = getBacklinkedNotes(file);
+  const backlinkedNotes = getBacklinkedNotes(app, file);
   const backlinkedNotePaths = backlinkedNotes.map((note) => note.path);
   for (const notePath of backlinkedNotePaths) {
     if (resultMap.has(notePath)) {
@@ -294,13 +300,16 @@ export type RelevantNoteEntry = {
 /**
  * Finds the relevant notes for the given file path.
  *
+ * @param app - The Obsidian app instance.
  * @param filePath - The file path to find relevant notes for.
  * @returns The relevant notes hits for the given file path. Empty array if no
  *   relevant notes are found or the index does not exist.
  */
 export async function findRelevantNotes({
+  app,
   filePath,
 }: {
+  app: App;
   filePath: string;
 }): Promise<RelevantNoteEntry[]> {
   const file = app.vault.getAbstractFileByPath(filePath);
@@ -308,8 +317,8 @@ export async function findRelevantNotes({
     return [];
   }
 
-  const similarityScoreMap = await calculateSimilarityScore(filePath);
-  const noteLinks = getNoteLinks(file);
+  const similarityScoreMap = await calculateSimilarityScore(app, filePath);
+  const noteLinks = getNoteLinks(app, file);
   const mergedScoreMap = mergeScoreMaps(similarityScoreMap, noteLinks);
   const sortedHits = Array.from(mergedScoreMap.entries()).sort((a, b) => {
     const aPath = a[0];

--- a/src/search/hybridRetriever.ts
+++ b/src/search/hybridRetriever.ts
@@ -8,7 +8,7 @@ import { extractNoteFiles, withSuppressedTokenWarnings } from "@/utils";
 import { Document } from "@langchain/core/documents";
 import { BaseRetriever } from "@langchain/core/retrievers";
 import { search } from "@orama/orama";
-import { TFile } from "obsidian";
+import { TFile, Vault } from "obsidian";
 
 export class HybridRetriever extends BaseRetriever {
   public lc_namespace = ["hybrid_retriever"];
@@ -22,7 +22,8 @@ export class HybridRetriever extends BaseRetriever {
       textWeight?: number;
       returnAll?: boolean;
       useRerankerThreshold?: number; // reranking API is only called with this set
-    }
+    },
+    private vault: Vault
   ) {
     super();
   }
@@ -31,7 +32,7 @@ export class HybridRetriever extends BaseRetriever {
     // Wrap the entire function in token warning suppression
     return withSuppressedTokenWarnings(async () => {
       // Extract note TFiles wrapped in [[]] from the query
-      const noteFiles = extractNoteFiles(query, app.vault);
+      const noteFiles = extractNoteFiles(query, this.vault);
       // Add note titles to salient terms
       const noteTitles = noteFiles.map((file) => file.basename);
       // Use Set to ensure uniqueness when combining terms
@@ -220,7 +221,7 @@ export class HybridRetriever extends BaseRetriever {
       logInfo("Daily note date range:", dailyNotes[0], dailyNotes[dailyNotes.length - 1]);
 
       // Perform the first search with title filter
-      const dailyNoteFiles = extractNoteFiles(dailyNotes.join(", "), app.vault);
+      const dailyNoteFiles = extractNoteFiles(dailyNotes.join(", "), this.vault);
       const dailyNoteResults = await this.getExplicitChunks(dailyNoteFiles);
 
       // Set includeInContext to true for all dailyNoteResults

--- a/src/search/indexEventHandler.ts
+++ b/src/search/indexEventHandler.ts
@@ -111,7 +111,7 @@ export class IndexEventHandler {
     // Only process markdown files that match inclusion/exclusion patterns
     if (fileToCheck.extension === "md") {
       const { inclusions, exclusions } = getMatchingPatterns();
-      const shouldProcess = shouldIndexFile(fileToCheck, inclusions, exclusions);
+      const shouldProcess = shouldIndexFile(this.app, fileToCheck, inclusions, exclusions);
 
       // Check if file was modified while it was active
       const wasModified = previousMtime !== null && fileToCheck.stat.mtime > previousMtime;

--- a/src/search/indexOperations.ts
+++ b/src/search/indexOperations.ts
@@ -393,7 +393,7 @@ export class IndexOperations {
     // If overwrite is true, return all markdown files that match current filters
     if (overwrite) {
       return allMarkdownFiles.filter((file) => {
-        return shouldIndexFile(file, inclusions, exclusions);
+        return shouldIndexFile(this.app, file, inclusions, exclusions);
       });
     }
 
@@ -407,7 +407,7 @@ export class IndexOperations {
     const emptyFiles = new Set<string>();
 
     for (const file of allMarkdownFiles) {
-      if (!shouldIndexFile(file, inclusions, exclusions)) {
+      if (!shouldIndexFile(this.app, file, inclusions, exclusions)) {
         continue;
       }
 

--- a/src/search/searchUtils.test.ts
+++ b/src/search/searchUtils.test.ts
@@ -96,7 +96,7 @@ describe("searchUtils", () => {
   describe("shouldIndexFile", () => {
     it("should return true when no inclusions or exclusions are specified", () => {
       const file = createTestFile("test.md");
-      expect(shouldIndexFile(file, null, null)).toBe(true);
+      expect(shouldIndexFile(window.app, file, null, null)).toBe(true);
     });
 
     it("should return false when file matches exclusion pattern", () => {
@@ -104,7 +104,7 @@ describe("searchUtils", () => {
       const exclusions = {
         folderPatterns: ["private"],
       };
-      expect(shouldIndexFile(file, null, exclusions)).toBe(false);
+      expect(shouldIndexFile(window.app, file, null, exclusions)).toBe(false);
     });
 
     it("should return false when file matches exclusion extension pattern", () => {
@@ -112,7 +112,7 @@ describe("searchUtils", () => {
       const exclusions = {
         extensionPatterns: ["*.excalidraw.md"],
       };
-      expect(shouldIndexFile(file, null, exclusions)).toBe(false);
+      expect(shouldIndexFile(window.app, file, null, exclusions)).toBe(false);
     });
 
     it("should return true when file matches inclusion pattern", () => {
@@ -120,7 +120,7 @@ describe("searchUtils", () => {
       const inclusions = {
         folderPatterns: ["notes"],
       };
-      expect(shouldIndexFile(file, inclusions, null)).toBe(true);
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(true);
     });
 
     it("should return false when file doesn't match inclusion pattern", () => {
@@ -128,7 +128,7 @@ describe("searchUtils", () => {
       const inclusions = {
         folderPatterns: ["notes"],
       };
-      expect(shouldIndexFile(file, inclusions, null)).toBe(false);
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(false);
     });
 
     it("should prioritize exclusions over inclusions", () => {
@@ -139,7 +139,7 @@ describe("searchUtils", () => {
       const exclusions = {
         folderPatterns: ["notes/private"],
       };
-      expect(shouldIndexFile(file, inclusions, exclusions)).toBe(false);
+      expect(shouldIndexFile(window.app, file, inclusions, exclusions)).toBe(false);
     });
 
     it("should handle multiple inclusion patterns", () => {
@@ -147,7 +147,7 @@ describe("searchUtils", () => {
       const inclusions = {
         folderPatterns: ["notes", "blog", "docs"],
       };
-      expect(shouldIndexFile(file, inclusions, null)).toBe(true);
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(true);
     });
 
     it("should handle inclusion patterns with folders with slashes and spaces", () => {
@@ -155,7 +155,7 @@ describe("searchUtils", () => {
       const inclusions = {
         folderPatterns: ["folder/with/100 spaces"],
       };
-      expect(shouldIndexFile(file, inclusions, null)).toBe(true);
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(true);
     });
 
     it("should handle multiple exclusion patterns", () => {
@@ -163,7 +163,7 @@ describe("searchUtils", () => {
       const exclusions = {
         folderPatterns: ["private", "temp", "archive"],
       };
-      expect(shouldIndexFile(file, null, exclusions)).toBe(false);
+      expect(shouldIndexFile(window.app, file, null, exclusions)).toBe(false);
     });
 
     it("should handle tag-based inclusion patterns", () => {
@@ -174,7 +174,7 @@ describe("searchUtils", () => {
       const inclusions = {
         tagPatterns: ["#important"],
       };
-      expect(shouldIndexFile(file, inclusions, null)).toBe(true);
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(true);
     });
 
     it("should handle tag-based exclusion patterns", () => {
@@ -185,7 +185,7 @@ describe("searchUtils", () => {
       const exclusions = {
         tagPatterns: ["#private"],
       };
-      expect(shouldIndexFile(file, null, exclusions)).toBe(false);
+      expect(shouldIndexFile(window.app, file, null, exclusions)).toBe(false);
     });
 
     it("should handle file extension patterns in inclusions", () => {
@@ -193,7 +193,7 @@ describe("searchUtils", () => {
       const inclusions = {
         extensionPatterns: ["*.pdf"],
       };
-      expect(shouldIndexFile(file, inclusions, null)).toBe(true);
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(true);
     });
 
     it("should handle file extension patterns in exclusions", () => {
@@ -201,17 +201,17 @@ describe("searchUtils", () => {
       const exclusions = {
         extensionPatterns: ["*.pdf"],
       };
-      expect(shouldIndexFile(file, null, exclusions)).toBe(false);
+      expect(shouldIndexFile(window.app, file, null, exclusions)).toBe(false);
     });
 
-    it("should return false when tag check fails due to file not found", () => {
+    it("should return false when the note has no matching tags", () => {
       const file = createTestFile("notes/tagged.md");
-      mockGetAbstractFileByPath.mockReturnValue(null);
+      (utils.getTagsFromNote as jest.Mock).mockReturnValue([]);
 
       const inclusions = {
         tagPatterns: ["#important"],
       };
-      expect(shouldIndexFile(file, inclusions, null)).toBe(false);
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(false);
     });
 
     it("should handle note-based inclusion patterns", () => {
@@ -221,7 +221,7 @@ describe("searchUtils", () => {
       const inclusions = {
         notePatterns: ["[[referenced]]"],
       };
-      expect(shouldIndexFile(file, inclusions, null)).toBe(true);
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(true);
     });
 
     it("should handle note-based exclusion patterns", () => {
@@ -231,7 +231,7 @@ describe("searchUtils", () => {
       const exclusions = {
         notePatterns: ["[[draft]]"],
       };
-      expect(shouldIndexFile(file, null, exclusions)).toBe(false);
+      expect(shouldIndexFile(window.app, file, null, exclusions)).toBe(false);
     });
   });
 

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -44,7 +44,7 @@ export async function getAllQAMarkdownContent(app: App): Promise<string> {
   const { inclusions, exclusions } = getMatchingPatterns();
 
   const filteredFiles = app.vault.getMarkdownFiles().filter((file) => {
-    return shouldIndexFile(file, inclusions, exclusions);
+    return shouldIndexFile(app, file, inclusions, exclusions);
   });
 
   await Promise.all(filteredFiles.map((file) => app.vault.cachedRead(file))).then((contents) =>
@@ -145,6 +145,7 @@ export function getMatchingPatterns(options?: {
  * @returns True if the file should be indexed, false otherwise.
  */
 export function shouldIndexFile(
+  app: App,
   file: TFile,
   inclusions: PatternCategory | null,
   exclusions: PatternCategory | null,
@@ -154,10 +155,10 @@ export function shouldIndexFile(
   if (isInternalExcludedFile(file)) {
     return false;
   }
-  if (exclusions && matchFilePathWithPatterns(file.path, exclusions)) {
+  if (exclusions && matchFilePathWithPatterns(app, file, exclusions)) {
     return false;
   }
-  if (inclusions && !matchFilePathWithPatterns(file.path, inclusions)) {
+  if (inclusions && !matchFilePathWithPatterns(app, file, inclusions)) {
     return false;
   }
 
@@ -239,21 +240,13 @@ export function createPatternSettingsValue({
  * @param tagPatterns - The tag patterns to match the file path with.
  * @returns True if the file path matches the tags, false otherwise.
  */
-function matchFilePathWithTags(filePath: string, tagPatterns: string[]): boolean {
+function matchFilePathWithTags(app: App, file: TFile, tagPatterns: string[]): boolean {
   if (tagPatterns.length === 0) return false;
 
-  const file = app.vault.getAbstractFileByPath(filePath);
-  if (file instanceof TFile) {
-    const tags = getTagsFromNote(file);
-    if (
-      tagPatterns.some((pattern) =>
-        tags.some((tag) => tag.toLowerCase() === stripHash(pattern).toLowerCase())
-      )
-    ) {
-      return true;
-    }
-  }
-  return false;
+  const tags = getTagsFromNote(app, file);
+  return tagPatterns.some((pattern) =>
+    tags.some((tag) => tag.toLowerCase() === stripHash(pattern).toLowerCase())
+  );
 }
 
 /**
@@ -308,16 +301,10 @@ function matchFilePathWithFolders(filePath: string, folderPatterns: string[]): b
  * @param notePatterns - The note patterns to match the file path with.
  * @returns True if the file path matches the note titles, false otherwise.
  */
-function matchFilePathWithNotes(filePath: string, noteTitles: string[]): boolean {
+function matchFilePathWithNotes(file: TFile, noteTitles: string[]): boolean {
   if (noteTitles.length === 0) return false;
 
-  const file = app.vault.getAbstractFileByPath(filePath);
-  if (file instanceof TFile) {
-    if (noteTitles.some((title) => title.slice(2, -2) === file.basename)) {
-      return true;
-    }
-  }
-  return false;
+  return noteTitles.some((title) => title.slice(2, -2) === file.basename);
 }
 
 /**
@@ -326,16 +313,16 @@ function matchFilePathWithNotes(filePath: string, noteTitles: string[]): boolean
  * @param patterns - The patterns to match the file path with.
  * @returns True if the file path matches the patterns, false otherwise.
  */
-function matchFilePathWithPatterns(filePath: string, patterns: PatternCategory): boolean {
+function matchFilePathWithPatterns(app: App, file: TFile, patterns: PatternCategory): boolean {
   if (!patterns) return false;
 
   const { tagPatterns, extensionPatterns, folderPatterns, notePatterns } = patterns;
 
   return (
-    matchFilePathWithTags(filePath, tagPatterns ?? []) ||
-    matchFilePathWithExtensions(filePath, extensionPatterns ?? []) ||
-    matchFilePathWithFolders(filePath, folderPatterns ?? []) ||
-    matchFilePathWithNotes(filePath, notePatterns ?? [])
+    matchFilePathWithTags(app, file, tagPatterns ?? []) ||
+    matchFilePathWithExtensions(file.path, extensionPatterns ?? []) ||
+    matchFilePathWithFolders(file.path, folderPatterns ?? []) ||
+    matchFilePathWithNotes(file, notePatterns ?? [])
   );
 }
 

--- a/src/search/v3/FilterRetriever.test.ts
+++ b/src/search/v3/FilterRetriever.test.ts
@@ -293,7 +293,7 @@ describe("FilterRetriever", () => {
         ctime: now - 2000,
       });
 
-      shouldIndexFile.mockImplementation((file: TFile) => !file.path.startsWith("copilot/"));
+      shouldIndexFile.mockImplementation((_app, file: TFile) => !file.path.startsWith("copilot/"));
       mockApp.vault.getMarkdownFiles.mockReturnValue([validFile, excludedFile]);
       mockApp.vault.cachedRead.mockResolvedValue("Content");
       mockApp.metadataCache.getFileCache.mockReturnValue({ tags: [] });

--- a/src/search/v3/FilterRetriever.ts
+++ b/src/search/v3/FilterRetriever.ts
@@ -85,7 +85,7 @@ export class FilterRetriever {
 
     const dailyNoteQuery = dailyNoteTitles.join(", ");
     const dailyNoteFiles = extractNoteFiles(dailyNoteQuery, this.app.vault).filter((f) =>
-      shouldIndexFile(f, inclusions, exclusions)
+      shouldIndexFile(this.app, f, inclusions, exclusions)
     );
 
     const dailyNoteDocuments = await this.getTitleMatches(dailyNoteFiles);
@@ -97,7 +97,7 @@ export class FilterRetriever {
 
     const allFiles = this.app.vault
       .getMarkdownFiles()
-      .filter((f) => shouldIndexFile(f, inclusions, exclusions));
+      .filter((f) => shouldIndexFile(this.app, f, inclusions, exclusions));
     const timeFilteredDocuments: Document[] = [];
 
     const maxTimeFilteredDocs = this.options.returnAll
@@ -325,7 +325,10 @@ export class FilterRetriever {
     for (const file of allFiles) {
       if (documents.length >= limit) break;
 
-      if (!shouldIndexFile(file, inclusions, exclusions) || isInternalExcludedFile(file)) {
+      if (
+        !shouldIndexFile(this.app, file, inclusions, exclusions) ||
+        isInternalExcludedFile(file)
+      ) {
         continue;
       }
 

--- a/src/search/v3/MergedSemanticRetriever.ts
+++ b/src/search/v3/MergedSemanticRetriever.ts
@@ -72,15 +72,18 @@ export class MergedSemanticRetriever extends BaseRetriever {
 
     this.semanticRetriever =
       semanticRetriever ||
-      new HybridRetriever({
-        minSimilarityScore: options.minSimilarityScore ?? 0.1,
-        maxK: semanticMax,
-        salientTerms: options.salientTerms,
-        timeRange: options.timeRange,
-        textWeight: options.textWeight,
-        returnAll: this.returnAll,
-        useRerankerThreshold: options.useRerankerThreshold,
-      });
+      new HybridRetriever(
+        {
+          minSimilarityScore: options.minSimilarityScore ?? 0.1,
+          maxK: semanticMax,
+          salientTerms: options.salientTerms,
+          timeRange: options.timeRange,
+          textWeight: options.textWeight,
+          returnAll: this.returnAll,
+          useRerankerThreshold: options.useRerankerThreshold,
+        },
+        this.app.vault
+      );
   }
 
   /**

--- a/src/search/v3/scanners/GrepScanner.ts
+++ b/src/search/v3/scanners/GrepScanner.ts
@@ -32,7 +32,9 @@ export class GrepScanner {
 
     // Filter files based on inclusion/exclusion patterns
     const allFiles = this.app.vault.getMarkdownFiles();
-    const files = allFiles.filter((file) => shouldIndexFile(file, inclusions, exclusions));
+    const files = allFiles.filter((file) =>
+      shouldIndexFile(this.app, file, inclusions, exclusions)
+    );
     const batchSize = GrepScanner.CONFIG.BATCH_SIZE;
 
     // Normalize queries for case-insensitive search, filtering out terms too short for meaningful grep

--- a/src/search/vectorStoreManager.ts
+++ b/src/search/vectorStoreManager.ts
@@ -7,7 +7,7 @@ import EmbeddingsManager from "@/LLMProviders/embeddingManager";
 import { shouldUseMiyo } from "@/miyo/miyoUtils";
 import { CopilotSettings, getSettings, subscribeToSettingsChange } from "@/settings/model";
 import { Orama } from "@orama/orama";
-import { Notice, Platform, TFile } from "obsidian";
+import { App, Notice, Platform, TFile } from "obsidian";
 import { MiyoIndexBackend } from "./indexBackend/MiyoIndexBackend";
 import { OramaIndexBackend } from "./indexBackend/OramaIndexBackend";
 import type {
@@ -29,8 +29,10 @@ export default class VectorStoreManager {
   private oramaBackend: OramaIndexBackend;
   private miyoBackend: MiyoIndexBackend;
   private activeBackendKey: "orama" | "miyo";
+  private app: App;
 
-  private constructor() {
+  private constructor(app: App) {
+    this.app = app;
     this.embeddingsManager = EmbeddingsManager.getInstance();
     this.oramaBackend = new OramaIndexBackend(app);
     this.miyoBackend = new MiyoIndexBackend(app);
@@ -43,9 +45,19 @@ export default class VectorStoreManager {
     this.setupSettingsSubscription();
   }
 
-  static getInstance(): VectorStoreManager {
+  /**
+   * Returns the singleton. `app` is required on the first call (which creates
+   * the instance) and ignored afterward; the plugin seeds it once at load
+   * (see main.ts) so subsequent call sites can omit it.
+   */
+  static getInstance(app?: App): VectorStoreManager {
     if (!VectorStoreManager.instance) {
-      VectorStoreManager.instance = new VectorStoreManager();
+      if (!app) {
+        throw new Error(
+          "VectorStoreManager.getInstance() requires `app` on first call (seed it at plugin load)."
+        );
+      }
+      VectorStoreManager.instance = new VectorStoreManager(app);
     }
     return VectorStoreManager.instance;
   }
@@ -247,9 +259,9 @@ export default class VectorStoreManager {
 
     this.activeBackendKey = nextBackendKey;
     this.indexBackend = nextBackendKey === "miyo" ? this.miyoBackend : this.oramaBackend;
-    this.indexOps = new IndexOperations(app, this.indexBackend, this.embeddingsManager);
+    this.indexOps = new IndexOperations(this.app, this.indexBackend, this.embeddingsManager);
     this.eventHandler.cleanup();
-    this.eventHandler = new IndexEventHandler(app, this.indexOps, this.indexBackend);
+    this.eventHandler = new IndexEventHandler(this.app, this.indexOps, this.indexBackend);
 
     if (getSettings().debug) {
       logInfo(`VectorStoreManager: switched backend to ${nextBackendKey}`);

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -423,7 +423,7 @@ export const CommandSettings: React.FC = () => {
           value={settings.customPromptsFolder}
           onChange={(value) => {
             updateSetting("customPromptsFolder", value);
-            void loadAllCustomCommands().catch((err) =>
+            void loadAllCustomCommands(app).catch((err) =>
               logError("loadAllCustomCommands failed", err)
             );
           }}

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -56,7 +56,7 @@ export function PlusSettings() {
           onClick={async () => {
             updateSetting("plusLicenseKey", localLicenseKey);
             setIsChecking(true);
-            const result = await checkIsPlusUser();
+            const result = await checkIsPlusUser(app);
             setIsChecking(false);
             if (!result) {
               setError("Invalid license key");

--- a/src/state/vaultDataAtoms.ts
+++ b/src/state/vaultDataAtoms.ts
@@ -1,5 +1,5 @@
 import { atom } from "jotai";
-import { TFile, TFolder, TAbstractFile } from "obsidian";
+import { App, TFile, TFolder, TAbstractFile } from "obsidian";
 import { debounce } from "@/utils/debounce";
 import { settingsStore } from "@/settings/model";
 import { getTagsFromNote, isAllowedFileForNoteContext } from "@/utils";
@@ -43,6 +43,7 @@ export const tagsAllAtom = atom<string[]>([]);
 export class VaultDataManager {
   private static instance: VaultDataManager | null = null;
   private initialized = false;
+  private app: App | null = null;
 
   private constructor() {
     // Private constructor for singleton pattern
@@ -65,7 +66,7 @@ export class VaultDataManager {
    * Note: VaultDataManager tracks ALL files (md + PDFs + canvas) and ALL tags.
    * Filtering is done by hooks based on parameters.
    */
-  public initialize(): void {
+  public initialize(app: App): void {
     if (this.initialized) {
       logInfo("VaultDataManager: Already initialized, skipping");
       return;
@@ -75,6 +76,8 @@ export class VaultDataManager {
       logInfo("VaultDataManager: app.vault not available, deferring initialization");
       return;
     }
+
+    this.app = app;
 
     logInfo("VaultDataManager: Initializing with vault event listeners");
 
@@ -201,9 +204,9 @@ export class VaultDataManager {
    * Hooks will filter based on their parameters.
    */
   private refreshNotes = (): void => {
-    if (!app?.vault) return;
+    if (!this.app?.vault) return;
 
-    const allFiles = app.vault.getFiles();
+    const allFiles = this.app.vault.getFiles();
     const newFiles = allFiles.filter(
       (file): file is TFile => file instanceof TFile && isAllowedFileForNoteContext(file)
     );
@@ -218,9 +221,9 @@ export class VaultDataManager {
    * Refreshes the folders atom with current vault folders
    */
   private refreshFolders = (): void => {
-    if (!app?.vault) return;
+    if (!this.app?.vault) return;
 
-    const newFolders = app.vault
+    const newFolders = this.app.vault
       .getAllLoadedFiles()
       .filter((file: TAbstractFile): file is TFolder => file instanceof TFolder);
 
@@ -232,12 +235,13 @@ export class VaultDataManager {
    * Refreshes the frontmatter tags atom with current vault tags (frontmatter only)
    */
   private refreshTagsFrontmatter = (): void => {
-    if (!app?.vault || !app?.metadataCache) return;
+    if (!this.app?.vault || !this.app?.metadataCache) return;
+    const app = this.app;
 
     const tagSet = new Set<string>();
 
     app.vault.getMarkdownFiles().forEach((file: TFile) => {
-      const fileTags = getTagsFromNote(file, true); // frontmatterOnly = true
+      const fileTags = getTagsFromNote(app, file, true); // frontmatterOnly = true
       fileTags.forEach((tag) => {
         const tagWithHash = tag.startsWith("#") ? tag : `#${tag}`;
         tagSet.add(tagWithHash);
@@ -254,12 +258,13 @@ export class VaultDataManager {
    * Refreshes the all tags atom with current vault tags (frontmatter + inline)
    */
   private refreshTagsAll = (): void => {
-    if (!app?.vault || !app?.metadataCache) return;
+    if (!this.app?.vault || !this.app?.metadataCache) return;
+    const app = this.app;
 
     const tagSet = new Set<string>();
 
     app.vault.getMarkdownFiles().forEach((file: TFile) => {
-      const fileTags = getTagsFromNote(file, false); // frontmatterOnly = false (all tags)
+      const fileTags = getTagsFromNote(app, file, false); // frontmatterOnly = false (all tags)
       fileTags.forEach((tag) => {
         const tagWithHash = tag.startsWith("#") ? tag : `#${tag}`;
         tagSet.add(tagWithHash);
@@ -290,14 +295,14 @@ export class VaultDataManager {
     this.debouncedRefreshTagsAll.cancel();
 
     // Remove event listeners
-    if (app?.vault) {
-      app.vault.off("create", this.handleFileCreate);
-      app.vault.off("delete", this.handleFileDelete);
-      app.vault.off("rename", this.handleFileRename);
-      app.vault.off("modify", this.handleFileModify);
+    if (this.app?.vault) {
+      this.app.vault.off("create", this.handleFileCreate);
+      this.app.vault.off("delete", this.handleFileDelete);
+      this.app.vault.off("rename", this.handleFileRename);
+      this.app.vault.off("modify", this.handleFileModify);
     }
-    if (app?.metadataCache) {
-      app.metadataCache.off("changed", this.handleMetadataChange);
+    if (this.app?.metadataCache) {
+      this.app.metadataCache.off("changed", this.handleMetadataChange);
     }
 
     this.initialized = false;

--- a/src/system-prompts/migration.test.ts
+++ b/src/system-prompts/migration.test.ts
@@ -90,7 +90,7 @@ describe("migrateSystemPromptsFromSettings", () => {
       userSystemPrompt: "",
     });
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(logger.logInfo).toHaveBeenCalledWith("No legacy userSystemPrompt to migrate");
     expect(mockVault.create).not.toHaveBeenCalled();
@@ -101,7 +101,7 @@ describe("migrateSystemPromptsFromSettings", () => {
       userSystemPrompt: "   ",
     });
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(logger.logInfo).toHaveBeenCalledWith("No legacy userSystemPrompt to migrate");
     expect(mockVault.create).not.toHaveBeenCalled();
@@ -119,9 +119,9 @@ describe("migrateSystemPromptsFromSettings", () => {
         })
       ); // File created
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
-    expect(utils.ensureFolderExists).toHaveBeenCalledWith("SystemPrompts");
+    expect(utils.ensureFolderExists).toHaveBeenCalledWith(mockVault, "SystemPrompts");
   });
 
   it("does not create folder if it already exists", async () => {
@@ -136,10 +136,10 @@ describe("migrateSystemPromptsFromSettings", () => {
         })
       ); // File created
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     // ensureFolderExists is always called, but it handles existing folders gracefully
-    expect(utils.ensureFolderExists).toHaveBeenCalledWith("SystemPrompts");
+    expect(utils.ensureFolderExists).toHaveBeenCalledWith(mockVault, "SystemPrompts");
   });
 
   it("migrates legacy prompt to file with correct content", async () => {
@@ -155,7 +155,7 @@ describe("migrateSystemPromptsFromSettings", () => {
         })
       ); // File created
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(mockVault.create).toHaveBeenCalledWith(
       "SystemPrompts/Migrated Custom System Prompt.md",
@@ -177,7 +177,7 @@ describe("migrateSystemPromptsFromSettings", () => {
         })
       );
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     // Whitespace should be preserved (only line endings normalized)
     expect(mockVault.create).toHaveBeenCalledWith(
@@ -201,9 +201,10 @@ describe("migrateSystemPromptsFromSettings", () => {
 
     Object.setPrototypeOf(mockFile, TFile.prototype);
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(systemPromptUtils.ensurePromptFrontmatter).toHaveBeenCalledWith(
+      window.app,
       mockFile,
       expect.objectContaining({
         title: "Migrated Custom System Prompt",
@@ -227,7 +228,7 @@ describe("migrateSystemPromptsFromSettings", () => {
 
     Object.setPrototypeOf(mockFile, TFile.prototype);
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(settingsModel.updateSetting).toHaveBeenCalledWith("userSystemPrompt", "");
   });
@@ -247,7 +248,7 @@ describe("migrateSystemPromptsFromSettings", () => {
 
     Object.setPrototypeOf(mockFile, TFile.prototype);
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(settingsModel.updateSetting).toHaveBeenCalledWith(
       "defaultSystemPromptTitle",
@@ -270,7 +271,7 @@ describe("migrateSystemPromptsFromSettings", () => {
 
     Object.setPrototypeOf(mockFile, TFile.prototype);
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(systemPromptUtils.loadAllSystemPrompts).toHaveBeenCalled();
   });
@@ -298,7 +299,7 @@ describe("migrateSystemPromptsFromSettings", () => {
       .mockReturnValueOnce(null) // "...Prompt 2" doesn't exist
       .mockReturnValueOnce(newFile); // File created
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     // Should create file with unique name
     expect(mockVault.create).toHaveBeenCalledWith(
@@ -333,7 +334,7 @@ describe("migrateSystemPromptsFromSettings", () => {
       .mockReturnValueOnce(null) // "...Prompt 3" doesn't exist
       .mockReturnValueOnce(newFile); // File created
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(mockVault.create).toHaveBeenCalledWith(
       "SystemPrompts/Migrated Custom System Prompt 3.md",
@@ -356,7 +357,7 @@ describe("migrateSystemPromptsFromSettings", () => {
 
     Object.setPrototypeOf(mockFile, TFile.prototype);
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(logger.logInfo).toHaveBeenCalledWith("Cleared legacy userSystemPrompt field");
   });
@@ -372,7 +373,7 @@ describe("migrateSystemPromptsFromSettings", () => {
     // Fail on initial folder creation and unsupported folder creation
     (utils.ensureFolderExists as jest.Mock).mockRejectedValue(error);
 
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
 
     expect(logger.logError).toHaveBeenCalledWith(
       "Failed to migrate legacy userSystemPrompt:",
@@ -392,7 +393,7 @@ describe("migrateSystemPromptsFromSettings", () => {
     (mockVault.getAbstractFileByPath as jest.Mock).mockReturnValue(null);
     (utils.ensureFolderExists as jest.Mock).mockRejectedValue(error);
 
-    await expect(migrateSystemPromptsFromSettings(mockVault)).resolves.not.toThrow();
+    await expect(migrateSystemPromptsFromSettings(window.app)).resolves.not.toThrow();
   });
 
   it("sets correct timestamps for migrated prompt", async () => {
@@ -411,10 +412,11 @@ describe("migrateSystemPromptsFromSettings", () => {
     Object.setPrototypeOf(mockFile, TFile.prototype);
 
     const beforeTime = Date.now();
-    await migrateSystemPromptsFromSettings(mockVault);
+    await migrateSystemPromptsFromSettings(window.app);
     const afterTime = Date.now();
 
     expect(systemPromptUtils.ensurePromptFrontmatter).toHaveBeenCalledWith(
+      window.app,
       mockFile,
       expect.objectContaining({
         title: "Migrated Custom System Prompt",
@@ -423,7 +425,7 @@ describe("migrateSystemPromptsFromSettings", () => {
       })
     );
 
-    const callArgs = (systemPromptUtils.ensurePromptFrontmatter as jest.Mock).mock.calls[0][1] as {
+    const callArgs = (systemPromptUtils.ensurePromptFrontmatter as jest.Mock).mock.calls[0][2] as {
       createdMs: number;
       modifiedMs: number;
     };
@@ -456,7 +458,7 @@ describe("migrateSystemPromptsFromSettings", () => {
         `---\ntest: true\n---\nDifferent content that does not match!`
       );
 
-      await migrateSystemPromptsFromSettings(mockVault);
+      await migrateSystemPromptsFromSettings(window.app);
 
       // Should save to unsupported folder
       expect(mockVault.create).toHaveBeenCalledWith(
@@ -482,7 +484,7 @@ describe("migrateSystemPromptsFromSettings", () => {
         .mockRejectedValueOnce(error) // First call fails (main migration)
         .mockRejectedValueOnce(error); // Second call fails (unsupported save)
 
-      await migrateSystemPromptsFromSettings(mockVault);
+      await migrateSystemPromptsFromSettings(window.app);
 
       // Should NOT clear userSystemPrompt when all save attempts fail
       expect(settingsModel.updateSetting).not.toHaveBeenCalledWith("userSystemPrompt", "");
@@ -507,7 +509,7 @@ describe("migrateSystemPromptsFromSettings", () => {
       // Simulate vault.read throwing an error during verification
       (mockVault.read as jest.Mock).mockRejectedValueOnce(new Error("Failed to read file"));
 
-      await migrateSystemPromptsFromSettings(mockVault);
+      await migrateSystemPromptsFromSettings(window.app);
 
       // Should save to unsupported folder
       expect(mockVault.create).toHaveBeenCalledWith(
@@ -534,7 +536,7 @@ describe("migrateSystemPromptsFromSettings", () => {
         .mockReturnValueOnce(null) // File does not exist check
         .mockReturnValueOnce(null); // unsupported file does not exist
 
-      await migrateSystemPromptsFromSettings(mockVault);
+      await migrateSystemPromptsFromSettings(window.app);
 
       // Should save to unsupported folder
       expect(mockVault.create).toHaveBeenCalledWith(
@@ -563,7 +565,7 @@ describe("migrateSystemPromptsFromSettings", () => {
 
       // Default vault.read mock will return content matching legacyPrompt
 
-      await migrateSystemPromptsFromSettings(mockVault);
+      await migrateSystemPromptsFromSettings(window.app);
 
       // Should clear userSystemPrompt after successful verification
       expect(settingsModel.updateSetting).toHaveBeenCalledWith("userSystemPrompt", "");
@@ -590,7 +592,7 @@ describe("migrateSystemPromptsFromSettings", () => {
 
       // Default vault.read mock will return content matching legacyPrompt (whitespace preserved)
 
-      await migrateSystemPromptsFromSettings(mockVault);
+      await migrateSystemPromptsFromSettings(window.app);
 
       // Should succeed - whitespace is preserved exactly
       expect(settingsModel.updateSetting).toHaveBeenCalledWith("userSystemPrompt", "");
@@ -617,7 +619,7 @@ describe("migrateSystemPromptsFromSettings", () => {
         `---\ntest: true\n---\nLine 1\nLine 2\nLine 3`
       );
 
-      await migrateSystemPromptsFromSettings(mockVault);
+      await migrateSystemPromptsFromSettings(window.app);
 
       // Should succeed - CRLF/LF differences are normalized
       expect(settingsModel.updateSetting).toHaveBeenCalledWith("userSystemPrompt", "");
@@ -646,7 +648,7 @@ describe("migrateSystemPromptsFromSettings", () => {
         `---\ntest: true\n---\n\n${legacyPrompt}`
       );
 
-      await migrateSystemPromptsFromSettings(mockVault);
+      await migrateSystemPromptsFromSettings(window.app);
 
       // Should succeed - leading newlines are now stripped before comparison
       expect(settingsModel.updateSetting).toHaveBeenCalledWith("userSystemPrompt", "");

--- a/src/system-prompts/migration.ts
+++ b/src/system-prompts/migration.ts
@@ -1,4 +1,4 @@
-import { TFile, Vault } from "obsidian";
+import { App, TFile, Vault } from "obsidian";
 import {
   ensurePromptFrontmatter,
   getPromptFilePath,
@@ -58,7 +58,7 @@ async function saveFailedMigrationToUnsupported(
 ): Promise<string> {
   const folder = getSystemPromptsFolder();
   const unsupportedFolder = `${folder}/unsupported`;
-  await ensureFolderExists(unsupportedFolder);
+  await ensureFolderExists(vault, unsupportedFolder);
 
   // Generate unique filename to avoid conflicts
   const baseName = "Migrated System Prompt (Failed Verification)";
@@ -133,7 +133,8 @@ async function verifyMigratedContent(
  * 4. Only clears userSystemPrompt after successfully saving to file system (normal or unsupported)
  * 5. If all save attempts fail, preserves userSystemPrompt for data safety
  */
-export async function migrateSystemPromptsFromSettings(vault: Vault): Promise<void> {
+export async function migrateSystemPromptsFromSettings(app: App): Promise<void> {
+  const vault = app.vault;
   const settings = getSettings();
   const legacyPrompt = settings.userSystemPrompt;
 
@@ -148,7 +149,7 @@ export async function migrateSystemPromptsFromSettings(vault: Vault): Promise<vo
 
     // Ensure the system prompts folder exists (creates nested folders recursively)
     const folder = getSystemPromptsFolder();
-    await ensureFolderExists(folder);
+    await ensureFolderExists(vault, folder);
 
     // Generate a unique name if default name already exists
     // Reason: Prevents data loss when file exists with different content
@@ -179,7 +180,7 @@ export async function migrateSystemPromptsFromSettings(vault: Vault): Promise<vo
       throw new Error("File not found after creation");
     }
 
-    await ensurePromptFrontmatter(file, newPrompt);
+    await ensurePromptFrontmatter(app, file, newPrompt);
 
     // Step 3: Write-then-verify - read back and confirm content matches
     // Reason: Ensures data was actually persisted before marking migration complete
@@ -191,7 +192,7 @@ export async function migrateSystemPromptsFromSettings(vault: Vault): Promise<vo
 
       // Best-effort: Try to reload prompts, but don't fail migration if reload fails
       try {
-        await loadAllSystemPrompts();
+        await loadAllSystemPrompts(app);
       } catch (loadError) {
         logWarn("Failed to reload prompts after migration:", loadError);
       }
@@ -218,7 +219,7 @@ export async function migrateSystemPromptsFromSettings(vault: Vault): Promise<vo
 
       // Best-effort: Try to reload prompts, but don't fail if reload fails
       try {
-        await loadAllSystemPrompts();
+        await loadAllSystemPrompts(app);
       } catch (loadError) {
         logWarn("Failed to reload prompts after failed migration:", loadError);
       }

--- a/src/system-prompts/systemPromptManager.test.ts
+++ b/src/system-prompts/systemPromptManager.test.ts
@@ -77,7 +77,7 @@ describe("SystemPromptManager", () => {
     } as unknown as typeof window.app;
 
     // Initialize manager
-    manager = SystemPromptManager.getInstance(mockVault);
+    manager = SystemPromptManager.getInstance(window.app);
   });
 
   afterEach(() => {
@@ -91,15 +91,15 @@ describe("SystemPromptManager", () => {
       expect(instance1).toBe(instance2);
     });
 
-    it("throws error if vault not provided on first call", () => {
+    it("throws error if app not provided on first call", () => {
       (SystemPromptManager as unknown as Record<string, unknown>).instance = undefined;
       expect(() => SystemPromptManager.getInstance()).toThrow(
-        "Vault is required for first initialization"
+        "App is required for first initialization"
       );
     });
 
-    it("does not require vault on subsequent calls", () => {
-      const instance1 = SystemPromptManager.getInstance(mockVault);
+    it("does not require app on subsequent calls", () => {
+      const instance1 = SystemPromptManager.getInstance(window.app);
       const instance2 = SystemPromptManager.getInstance();
       expect(instance1).toBe(instance2);
     });
@@ -136,9 +136,13 @@ describe("SystemPromptManager", () => {
 
       await manager.createPrompt(newPrompt);
 
-      expect(utils.ensureFolderExists).toHaveBeenCalledWith("SystemPrompts");
+      expect(utils.ensureFolderExists).toHaveBeenCalledWith(mockVault, "SystemPrompts");
       expect(mockVault.create).toHaveBeenCalledWith("SystemPrompts/New Prompt.md", "Test content");
-      expect(systemPromptUtils.ensurePromptFrontmatter).toHaveBeenCalledWith(mockFile, newPrompt);
+      expect(systemPromptUtils.ensurePromptFrontmatter).toHaveBeenCalledWith(
+        window.app,
+        mockFile,
+        newPrompt
+      );
     });
 
     it("updates cache after creation", async () => {

--- a/src/system-prompts/systemPromptManager.ts
+++ b/src/system-prompts/systemPromptManager.ts
@@ -1,4 +1,4 @@
-import { TFile, Vault } from "obsidian";
+import { App, TFile, Vault } from "obsidian";
 import { UserSystemPrompt } from "@/system-prompts/type";
 import {
   ensurePromptFrontmatter,
@@ -34,21 +34,23 @@ import { getSettings, updateSetting } from "@/settings/model";
  */
 export class SystemPromptManager {
   private static instance: SystemPromptManager;
+  private app: App;
   private vault: Vault;
 
-  private constructor(vault: Vault) {
-    this.vault = vault;
+  private constructor(app: App) {
+    this.app = app;
+    this.vault = app.vault;
   }
 
   /**
    * Get the singleton instance
    */
-  public static getInstance(vault?: Vault): SystemPromptManager {
+  public static getInstance(app?: App): SystemPromptManager {
     if (!SystemPromptManager.instance) {
-      if (!vault) {
-        throw new Error("Vault is required for first initialization");
+      if (!app) {
+        throw new Error("App is required for first initialization");
       }
-      SystemPromptManager.instance = new SystemPromptManager(vault);
+      SystemPromptManager.instance = new SystemPromptManager(app);
     }
     return SystemPromptManager.instance;
   }
@@ -58,7 +60,7 @@ export class SystemPromptManager {
    */
   public async initialize(): Promise<void> {
     logInfo("Initializing SystemPromptManager");
-    await loadAllSystemPrompts();
+    await loadAllSystemPrompts(this.app);
   }
 
   /**
@@ -81,7 +83,7 @@ export class SystemPromptManager {
       addPendingFileWrite(filePath);
 
       // Ensure nested folders are created cross-platform
-      await ensureFolderExists(folderPath);
+      await ensureFolderExists(this.vault, folderPath);
 
       // Create the file
       await this.vault.create(filePath, prompt.content);
@@ -89,7 +91,7 @@ export class SystemPromptManager {
       // Add frontmatter
       const file = this.vault.getAbstractFileByPath(filePath);
       if (file instanceof TFile) {
-        await ensurePromptFrontmatter(file, prompt);
+        await ensurePromptFrontmatter(this.app, file, prompt);
       }
 
       // Update cache directly instead of reloading all files
@@ -137,7 +139,7 @@ export class SystemPromptManager {
       if (isRename) {
         const oldFile = this.vault.getAbstractFileByPath(oldPath);
         if (oldFile instanceof TFile) {
-          await app.fileManager.renameFile(oldFile, newPath);
+          await this.app.fileManager.renameFile(oldFile, newPath);
         }
       }
 
@@ -148,11 +150,14 @@ export class SystemPromptManager {
 
         // Update frontmatter - write back ALL fields since vault.modify clears frontmatter
         // Reference: Command module writes all fields in processFrontMatter
-        await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
-          frontmatter[COPILOT_SYSTEM_PROMPT_CREATED] = newPrompt.createdMs;
-          frontmatter[COPILOT_SYSTEM_PROMPT_MODIFIED] = newPrompt.modifiedMs;
-          frontmatter[COPILOT_SYSTEM_PROMPT_LAST_USED] = newPrompt.lastUsedMs;
-        });
+        await this.app.fileManager.processFrontMatter(
+          file,
+          (frontmatter: Record<string, unknown>) => {
+            frontmatter[COPILOT_SYSTEM_PROMPT_CREATED] = newPrompt.createdMs;
+            frontmatter[COPILOT_SYSTEM_PROMPT_MODIFIED] = newPrompt.modifiedMs;
+            frontmatter[COPILOT_SYSTEM_PROMPT_LAST_USED] = newPrompt.lastUsedMs;
+          }
+        );
       }
 
       // Update cache directly instead of reloading all files
@@ -193,7 +198,7 @@ export class SystemPromptManager {
       // Delete the file first
       const file = this.vault.getAbstractFileByPath(filePath);
       if (file instanceof TFile) {
-        await trashFile(app, file);
+        await trashFile(this.app, file);
       }
 
       // Clear state only after successful deletion to maintain consistency
@@ -251,7 +256,7 @@ export class SystemPromptManager {
    * Reload all prompts from file system and update cache
    */
   public async reloadPrompts(): Promise<UserSystemPrompt[]> {
-    return await loadAllSystemPrompts();
+    return await loadAllSystemPrompts(this.app);
   }
 
   /**
@@ -259,6 +264,6 @@ export class SystemPromptManager {
    * Use this when you need to control cache updates yourself (e.g., for latest-wins semantics)
    */
   public async fetchPrompts(): Promise<UserSystemPrompt[]> {
-    return await fetchAllSystemPrompts();
+    return await fetchAllSystemPrompts(this.app);
   }
 }

--- a/src/system-prompts/systemPromptRegister.test.ts
+++ b/src/system-prompts/systemPromptRegister.test.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin, Vault } from "obsidian";
+import { App, Notice, Plugin, Vault } from "obsidian";
 import { SystemPromptRegister } from "@/system-prompts/systemPromptRegister";
 import * as state from "@/system-prompts/state";
 import * as systemPromptUtils from "@/system-prompts/systemPromptUtils";
@@ -85,7 +85,7 @@ describe("SystemPromptRegister", () => {
       off: jest.fn(),
     } as unknown as Vault;
 
-    register = new SystemPromptRegister(mockPlugin, mockVault);
+    register = new SystemPromptRegister(mockPlugin, { vault: mockVault } as unknown as App);
   });
 
   afterEach(() => {

--- a/src/system-prompts/systemPromptRegister.ts
+++ b/src/system-prompts/systemPromptRegister.ts
@@ -1,4 +1,4 @@
-import { Notice, Plugin, TAbstractFile, Vault } from "obsidian";
+import { App, Notice, Plugin, TAbstractFile, Vault } from "obsidian";
 import {
   isSystemPromptFile,
   getSystemPromptsFolder,
@@ -26,16 +26,18 @@ import { logError, logInfo } from "@/logger";
  */
 export class SystemPromptRegister {
   private plugin: Plugin;
+  private app: App;
   private vault: Vault;
   private manager: SystemPromptManager;
   private settingsUnsubscriber?: () => void;
   /** Monotonically increasing request ID for latest-wins semantics */
   private folderChangeRequestId = 0;
 
-  constructor(plugin: Plugin, vault: Vault) {
+  constructor(plugin: Plugin, app: App) {
     this.plugin = plugin;
-    this.vault = vault;
-    this.manager = SystemPromptManager.getInstance(vault);
+    this.app = app;
+    this.vault = app.vault;
+    this.manager = SystemPromptManager.getInstance(app);
     this.initializeEventListeners();
   }
 
@@ -124,10 +126,10 @@ export class SystemPromptRegister {
   ): Promise<void> {
     try {
       if (oldTitle) {
-        await updatePromptDefaultFlag(oldTitle, false, oldFolder);
+        await updatePromptDefaultFlag(this.app, oldTitle, false, oldFolder);
       }
       if (newTitle) {
-        await updatePromptDefaultFlag(newTitle, true);
+        await updatePromptDefaultFlag(this.app, newTitle, true);
       }
       logInfo(`Default system prompt changed: "${oldTitle}" -> "${newTitle}"`);
     } catch (error) {
@@ -217,7 +219,7 @@ export class SystemPromptRegister {
         return;
       }
       try {
-        const prompt = await parseSystemPromptFile(file);
+        const prompt = await parseSystemPromptFile(this.app, file);
         upsertCachedSystemPrompt(prompt);
       } catch (error) {
         logError(`Error processing system prompt modification: ${file.path}`, error);
@@ -238,11 +240,11 @@ export class SystemPromptRegister {
       return;
     }
     try {
-      const prompt = await parseSystemPromptFile(file);
+      const prompt = await parseSystemPromptFile(this.app, file);
       // Ensure frontmatter is properly set
-      await ensurePromptFrontmatter(file, prompt);
+      await ensurePromptFrontmatter(this.app, file, prompt);
       // Re-parse to get updated timestamps after frontmatter is written
-      const updatedPrompt = await parseSystemPromptFile(file);
+      const updatedPrompt = await parseSystemPromptFile(this.app, file);
       upsertCachedSystemPrompt(updatedPrompt);
     } catch (error) {
       logError(`Error processing system prompt creation: ${file.path}`, error);
@@ -339,10 +341,10 @@ export class SystemPromptRegister {
 
       // Add the new prompt to cache if it's still in the folder
       if (promptFile) {
-        const prompt = await parseSystemPromptFile(promptFile);
-        await ensurePromptFrontmatter(promptFile, prompt);
+        const prompt = await parseSystemPromptFile(this.app, promptFile);
+        await ensurePromptFrontmatter(this.app, promptFile, prompt);
         // Re-parse to get updated timestamps after frontmatter is written
-        const updatedPrompt = await parseSystemPromptFile(promptFile);
+        const updatedPrompt = await parseSystemPromptFile(this.app, promptFile);
         upsertCachedSystemPrompt(updatedPrompt);
       }
     } catch (error) {

--- a/src/system-prompts/systemPromptUtils.test.ts
+++ b/src/system-prompts/systemPromptUtils.test.ts
@@ -289,7 +289,7 @@ This is the prompt content.`;
       },
     });
 
-    const result = await parseSystemPromptFile(mockFile);
+    const result = await parseSystemPromptFile(app, mockFile);
 
     expect(result).toEqual({
       title: "Test Prompt",
@@ -306,7 +306,7 @@ This is the prompt content.`;
     (app.vault.read as jest.Mock).mockResolvedValue(rawContent);
     (app.metadataCache.getFileCache as jest.Mock).mockReturnValue({});
 
-    const result = await parseSystemPromptFile(mockFile);
+    const result = await parseSystemPromptFile(app, mockFile);
 
     expect(result).toEqual({
       title: "Test Prompt",
@@ -330,7 +330,7 @@ Content here.`;
       },
     });
 
-    const result = await parseSystemPromptFile(mockFile);
+    const result = await parseSystemPromptFile(app, mockFile);
 
     expect(result).toEqual({
       title: "Test Prompt",
@@ -355,7 +355,7 @@ Line 2`;
       },
     });
 
-    const result = await parseSystemPromptFile(mockFile);
+    const result = await parseSystemPromptFile(app, mockFile);
 
     expect(result.content).toBe("Line 1\nLine 2");
     expect(result.content).not.toContain("---");
@@ -374,7 +374,7 @@ Content with --- separator in the middle.`;
       },
     });
 
-    const result = await parseSystemPromptFile(mockFile);
+    const result = await parseSystemPromptFile(app, mockFile);
 
     expect(result.content).toBe("Content with --- separator in the middle.");
   });

--- a/src/system-prompts/systemPromptUtils.ts
+++ b/src/system-prompts/systemPromptUtils.ts
@@ -6,7 +6,7 @@ import {
   EMPTY_SYSTEM_PROMPT,
 } from "@/system-prompts/constants";
 import { UserSystemPrompt } from "@/system-prompts/type";
-import { normalizePath, TAbstractFile, TFile } from "obsidian";
+import { App, normalizePath, TAbstractFile, TFile } from "obsidian";
 import { getSettings } from "@/settings/model";
 import { stripFrontmatter } from "@/utils";
 import {
@@ -117,7 +117,7 @@ function coerceFrontmatterNumber(value: unknown, fallback: number): number {
 /**
  * Parse a TFile as a UserSystemPrompt by reading its content and extracting frontmatter
  */
-export async function parseSystemPromptFile(file: TFile): Promise<UserSystemPrompt> {
+export async function parseSystemPromptFile(app: App, file: TFile): Promise<UserSystemPrompt> {
   const rawContent = await app.vault.read(file);
   const content = stripFrontmatter(rawContent);
   const metadata = app.metadataCache.getFileCache(file);
@@ -149,16 +149,16 @@ export async function parseSystemPromptFile(file: TFile): Promise<UserSystemProm
  * Fetch all system prompts from the vault without updating cache
  * Use this when you need to control cache updates yourself (e.g., for latest-wins semantics)
  */
-export async function fetchAllSystemPrompts(): Promise<UserSystemPrompt[]> {
+export async function fetchAllSystemPrompts(app: App): Promise<UserSystemPrompt[]> {
   const files = app.vault.getFiles().filter((file) => isSystemPromptFile(file));
-  return await Promise.all(files.map(parseSystemPromptFile));
+  return await Promise.all(files.map((file) => parseSystemPromptFile(app, file)));
 }
 
 /**
  * Load all system prompts from the vault and update cache
  */
-export async function loadAllSystemPrompts(): Promise<UserSystemPrompt[]> {
-  const prompts = await fetchAllSystemPrompts();
+export async function loadAllSystemPrompts(app: App): Promise<UserSystemPrompt[]> {
+  const prompts = await fetchAllSystemPrompts(app);
   updateCachedSystemPrompts(prompts);
   return prompts;
 }
@@ -168,7 +168,7 @@ export async function loadAllSystemPrompts(): Promise<UserSystemPrompt[]> {
  * Only adds missing fields, does not overwrite existing values.
  * This is idempotent and does not touch the file content.
  */
-export async function ensurePromptFrontmatter(file: TFile, prompt: UserSystemPrompt) {
+export async function ensurePromptFrontmatter(app: App, file: TFile, prompt: UserSystemPrompt) {
   // Check if already pending to avoid nested add/remove issues
   const alreadyPending = isPendingFileWrite(file.path);
   const now = Date.now();
@@ -230,6 +230,7 @@ export function generateCopyPromptName(
  * @param folder - Optional folder path (defaults to current settings folder)
  */
 export async function updatePromptDefaultFlag(
+  app: App,
   title: string,
   isDefault: boolean,
   folder?: string

--- a/src/tests/context-manage-modal.test.ts
+++ b/src/tests/context-manage-modal.test.ts
@@ -1,10 +1,13 @@
-import { TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 import {
   createPatternSettingsValue,
   getFilePattern,
   shouldIndexFile,
   PatternCategory,
 } from "@/search/searchUtils";
+
+// shouldIndexFile is mocked, so the app is only threaded through and never inspected.
+const mockApp = {} as unknown as App;
 
 // Mock dependencies
 jest.mock("obsidian", () => ({
@@ -76,7 +79,7 @@ const createAndPopulateGroupList = (
   exclusionPatterns: PatternCategory | null
 ): GroupListItem => {
   const projectAllFiles = appFiles.filter((file) =>
-    shouldIndexFile(file, inclusionPatterns, exclusionPatterns, true)
+    shouldIndexFile(mockApp, file, inclusionPatterns, exclusionPatterns, true)
   );
 
   // Initialize groups

--- a/src/tests/projectContextCache.test.ts
+++ b/src/tests/projectContextCache.test.ts
@@ -1,6 +1,6 @@
 import { ProjectConfig } from "@/aiParams";
 import { ContextCache, ProjectContextCache } from "@/cache/projectContextCache";
-import type { TFile } from "obsidian";
+import type { App, TFile } from "obsidian";
 
 // Mock dependencies
 interface MockFileStat {
@@ -160,7 +160,7 @@ describe("ProjectContextCache", () => {
     mockApp.vault.adapter.write.mockResolvedValue(undefined);
 
     // Get actual instance and clear any existing cache
-    projectContextCache = ProjectContextCache.getInstance();
+    projectContextCache = ProjectContextCache.getInstance(mockApp as unknown as App);
 
     // Mock project with minimal properties for testing
     mockProject = {

--- a/src/tools/ComposerTools.ts
+++ b/src/tools/ComposerTools.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 import { APPLY_VIEW_TYPE } from "@/components/composer/ApplyView";
 import { diffTrimmedLines } from "diff";
 import { ApplyViewResult } from "@/types";
@@ -8,7 +8,7 @@ import { ensureFolderExists, sanitizeFilePath } from "@/utils";
 import { getSettings } from "@/settings/model";
 import { logWarn } from "@/logger";
 
-async function getFile(file_path: string): Promise<TFile> {
+async function getFile(app: App, file_path: string): Promise<TFile> {
   let file = app.vault.getAbstractFileByPath(file_path);
   if (file && file instanceof TFile) {
     return file;
@@ -22,7 +22,7 @@ async function getFile(file_path: string): Promise<TFile> {
   try {
     const folder = file_path.includes("/") ? file_path.split("/").slice(0, -1).join("/") : "";
     if (folder) {
-      await ensureFolderExists(folder);
+      await ensureFolderExists(app.vault, folder);
     }
 
     // Double-check if file was created by another process
@@ -49,11 +49,12 @@ async function getFile(file_path: string): Promise<TFile> {
  * @param content - Target content to compare against current file content
  */
 async function show_preview(
+  app: App,
   file_path: string,
   content: string,
   simple = false
 ): Promise<ApplyViewResult> {
-  const file = await getFile(file_path);
+  const file = await getFile(app, file_path);
   const activeFile = app.workspace.getActiveFile();
 
   if (file && (!activeFile || activeFile.path !== file_path)) {
@@ -140,62 +141,64 @@ const writeFileSchema = z.object({
     ),
 });
 
-const writeFileTool = createLangChainTool({
-  name: "writeFile",
-  description: `Request to write content to a file at the specified path and show the changes in a Change Preview UI.
+const createWriteFileTool = (app: App) =>
+  createLangChainTool({
+    name: "writeFile",
+    description: `Request to write content to a file at the specified path and show the changes in a Change Preview UI.
 
       # Steps to find the the target path
       1. Extract the target file information from user message and find out the file path from the context.
       2. If target file is not specified, use the active note as the target file.
       3. If still failed to find the target file or the file path, ask the user to specify the target file.
       `,
-  schema: writeFileSchema,
-  func: async ({ path, content, confirmation = true }) => {
-    // Sanitize path to prevent ENAMETOOLONG errors on filesystems with 255-byte limits.
-    // Must happen here (not just in getFile) so show_preview also receives the sanitized path,
-    // since ApplyView uses state.path with its own getFile that doesn't sanitize.
-    const sanitizedPath = sanitizeFilePath(path);
-    if (sanitizedPath !== path) {
-      logWarn(
-        `Filename too long, truncated for filesystem compatibility: "${path}" → "${sanitizedPath}"`
-      );
-      path = sanitizedPath;
-    }
-
-    // Convert object content to JSON string if needed
-    const contentString = typeof content === "string" ? content : JSON.stringify(content, null, 2);
-
-    // Only bypass confirmation when the user has explicitly enabled auto-accept in settings.
-    // The LLM may pass confirmation=false, but that alone should not skip preview.
-    const settings = getSettings();
-    const shouldBypassConfirmation = settings.autoAcceptEdits;
-
-    if (shouldBypassConfirmation) {
-      try {
-        const file = await getFile(path);
-        await app.vault.modify(file, contentString);
-        return {
-          result: "accepted" as ApplyViewResult,
-          message:
-            "File changes applied without preview. Do not retry or attempt alternative approaches to modify this file in response to the current user request.",
-        };
-      } catch (error: unknown) {
-        const message = error instanceof Error ? error.message : String(error);
-        return {
-          result: "failed" as ApplyViewResult,
-          message: `Error writing to file without preview: ${message}`,
-        };
+    schema: writeFileSchema,
+    func: async ({ path, content, confirmation = true }) => {
+      // Sanitize path to prevent ENAMETOOLONG errors on filesystems with 255-byte limits.
+      // Must happen here (not just in getFile) so show_preview also receives the sanitized path,
+      // since ApplyView uses state.path with its own getFile that doesn't sanitize.
+      const sanitizedPath = sanitizeFilePath(path);
+      if (sanitizedPath !== path) {
+        logWarn(
+          `Filename too long, truncated for filesystem compatibility: "${path}" → "${sanitizedPath}"`
+        );
+        path = sanitizedPath;
       }
-    }
 
-    const result = await show_preview(path, contentString);
-    // Simple JSON wrapper for consistent parsing
-    return {
-      result: result,
-      message: `File change result: ${result}. Do not retry or attempt alternative approaches to modify this file in response to the current user request.`,
-    };
-  },
-});
+      // Convert object content to JSON string if needed
+      const contentString =
+        typeof content === "string" ? content : JSON.stringify(content, null, 2);
+
+      // Only bypass confirmation when the user has explicitly enabled auto-accept in settings.
+      // The LLM may pass confirmation=false, but that alone should not skip preview.
+      const settings = getSettings();
+      const shouldBypassConfirmation = settings.autoAcceptEdits;
+
+      if (shouldBypassConfirmation) {
+        try {
+          const file = await getFile(app, path);
+          await app.vault.modify(file, contentString);
+          return {
+            result: "accepted" as ApplyViewResult,
+            message:
+              "File changes applied without preview. Do not retry or attempt alternative approaches to modify this file in response to the current user request.",
+          };
+        } catch (error: unknown) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            result: "failed" as ApplyViewResult,
+            message: `Error writing to file without preview: ${message}`,
+          };
+        }
+      }
+
+      const result = await show_preview(app, path, contentString);
+      // Simple JSON wrapper for consistent parsing
+      return {
+        result: result,
+        message: `File change result: ${result}. Do not retry or attempt alternative approaches to modify this file in response to the current user request.`,
+      };
+    },
+  });
 
 const editFileSchema = z.object({
   path: z
@@ -521,70 +524,79 @@ export function applyEditToContent(
   return { ok: true, content: modifiedContent };
 }
 
-const editFileTool = createLangChainTool({
-  name: "editFile",
-  description: `Request to make a targeted change to an existing file by specifying the exact text to find and its replacement. Use this tool for precise, surgical edits to specific parts of a file.`,
-  schema: editFileSchema,
-  func: async ({ path, oldText, newText }: { path: string; oldText: string; newText: string }) => {
-    const sanitizedPath = sanitizeFilePath(path);
-    const file = app.vault.getAbstractFileByPath(sanitizedPath);
+const createEditFileTool = (app: App) =>
+  createLangChainTool({
+    name: "editFile",
+    description: `Request to make a targeted change to an existing file by specifying the exact text to find and its replacement. Use this tool for precise, surgical edits to specific parts of a file.`,
+    schema: editFileSchema,
+    func: async ({
+      path,
+      oldText,
+      newText,
+    }: {
+      path: string;
+      oldText: string;
+      newText: string;
+    }) => {
+      const sanitizedPath = sanitizeFilePath(path);
+      const file = app.vault.getAbstractFileByPath(sanitizedPath);
 
-    if (!file || !(file instanceof TFile)) {
-      return {
-        result: "failed" as ApplyViewResult,
-        message: `File not found at path: ${sanitizedPath}. Please check the file path and try again.`,
-      };
-    }
-
-    try {
-      const rawContent = await app.vault.read(file);
-      const editResult = applyEditToContent(rawContent, oldText, newText);
-
-      if (!editResult.ok) {
-        if (editResult.reason === "NOT_FOUND") {
-          return {
-            result: "failed" as ApplyViewResult,
-            message: `Could not find the specified text in ${sanitizedPath}. The oldText must match the file content — try including more surrounding context lines to locate the right spot.`,
-          };
-        }
+      if (!file || !(file instanceof TFile)) {
         return {
           result: "failed" as ApplyViewResult,
-          message: `Found ${editResult.occurrences} occurrences of the search text in ${sanitizedPath}. The text must be unique — add more surrounding context to make it unambiguous.`,
+          message: `File not found at path: ${sanitizedPath}. Please check the file path and try again.`,
         };
       }
 
-      const modifiedContent = editResult.content;
+      try {
+        const rawContent = await app.vault.read(file);
+        const editResult = applyEditToContent(rawContent, oldText, newText);
 
-      // No-op detection: content is unchanged after replacement
-      if (rawContent === modifiedContent) {
+        if (!editResult.ok) {
+          if (editResult.reason === "NOT_FOUND") {
+            return {
+              result: "failed" as ApplyViewResult,
+              message: `Could not find the specified text in ${sanitizedPath}. The oldText must match the file content — try including more surrounding context lines to locate the right spot.`,
+            };
+          }
+          return {
+            result: "failed" as ApplyViewResult,
+            message: `Found ${editResult.occurrences} occurrences of the search text in ${sanitizedPath}. The text must be unique — add more surrounding context to make it unambiguous.`,
+          };
+        }
+
+        const modifiedContent = editResult.content;
+
+        // No-op detection: content is unchanged after replacement
+        if (rawContent === modifiedContent) {
+          return {
+            result: "accepted" as ApplyViewResult,
+            message: `No changes made to ${sanitizedPath}. The replacement produced identical content. Use writeFile if the file needs a broader rewrite.`,
+          };
+        }
+
+        const settings = getSettings();
+        if (settings.autoAcceptEdits) {
+          await app.vault.modify(file, modifiedContent);
+          return {
+            result: "accepted" as ApplyViewResult,
+            message:
+              "File changes applied without preview. Do not retry or attempt alternative approaches to modify this file in response to the current user request.",
+          };
+        }
+
+        const result = await show_preview(app, sanitizedPath, modifiedContent, true);
         return {
-          result: "accepted" as ApplyViewResult,
-          message: `No changes made to ${sanitizedPath}. The replacement produced identical content. Use writeFile if the file needs a broader rewrite.`,
+          result: result,
+          message: `File change result: ${result}. Do not retry or attempt alternative approaches to modify this file in response to the current user request.`,
         };
-      }
-
-      const settings = getSettings();
-      if (settings.autoAcceptEdits) {
-        await app.vault.modify(file, modifiedContent);
+      } catch (error) {
         return {
-          result: "accepted" as ApplyViewResult,
-          message:
-            "File changes applied without preview. Do not retry or attempt alternative approaches to modify this file in response to the current user request.",
+          result: "failed" as ApplyViewResult,
+          message: `Error modifying ${sanitizedPath}: ${error}. Please check the file path and try again.`,
         };
       }
+    },
+  });
 
-      const result = await show_preview(sanitizedPath, modifiedContent, true);
-      return {
-        result: result,
-        message: `File change result: ${result}. Do not retry or attempt alternative approaches to modify this file in response to the current user request.`,
-      };
-    } catch (error) {
-      return {
-        result: "failed" as ApplyViewResult,
-        message: `Error modifying ${sanitizedPath}: ${error}. Please check the file path and try again.`,
-      };
-    }
-  },
-});
-
-export { writeFileTool, editFileTool, normalizeLineEndings, normalizeForFuzzyMatch };
+export { createWriteFileTool, createEditFileTool, normalizeLineEndings, normalizeForFuzzyMatch };

--- a/src/tools/FileParserManager.ts
+++ b/src/tools/FileParserManager.ts
@@ -101,7 +101,7 @@ class PDFParser implements FileParser {
       logInfo("Parsing PDF file:", file.path);
 
       // Try to get from cache first
-      const cachedResponse = await this.pdfCache.get(file);
+      const cachedResponse = await this.pdfCache.get(vault, file);
       if (cachedResponse) {
         logInfo("Using cached PDF content for:", file.path);
         // Ensure output file exists even on cache hit (user may have just enabled the setting)
@@ -113,7 +113,7 @@ class PDFParser implements FileParser {
       if (isSelfHostModeValid() && settings.enableMiyo && file.extension.toLowerCase() === "pdf") {
         const miyoResult = await this.selfHostPdfParser.parsePdf(file, vault);
         if (miyoResult && "content" in miyoResult) {
-          await this.pdfCache.set(file, {
+          await this.pdfCache.set(vault, file, {
             response: miyoResult.content,
             elapsed_time_ms: 0,
           });
@@ -132,7 +132,7 @@ class PDFParser implements FileParser {
       const binaryContent = await vault.readBinary(file);
       logInfo("Calling pdf4llm API for:", file.path);
       const pdf4llmResponse = await this.brevilabsClient.pdf4llm(binaryContent);
-      await this.pdfCache.set(file, pdf4llmResponse);
+      await this.pdfCache.set(vault, file, pdf4llmResponse);
       await saveConvertedDocOutput(file, pdf4llmResponse.response, vault);
       return pdf4llmResponse.response;
     } catch (error) {
@@ -141,9 +141,9 @@ class PDFParser implements FileParser {
     }
   }
 
-  async clearCache(): Promise<void> {
+  async clearCache(vault: Vault): Promise<void> {
     logInfo("Clearing PDF cache");
-    await this.pdfCache.clear();
+    await this.pdfCache.clear(vault);
   }
 }
 
@@ -527,10 +527,10 @@ export class FileParserManager {
     return this.parsers.has(extension);
   }
 
-  async clearPDFCache(): Promise<void> {
+  async clearPDFCache(vault: Vault): Promise<void> {
     const pdfParser = this.parsers.get("pdf");
     if (pdfParser instanceof PDFParser) {
-      await pdfParser.clearCache();
+      await pdfParser.clearCache(vault);
     }
   }
 }

--- a/src/tools/FileTreeTools.test.ts
+++ b/src/tools/FileTreeTools.test.ts
@@ -1,8 +1,11 @@
 import * as searchUtils from "@/search/searchUtils";
 import { mockTFile, mockTFolder } from "@/__tests__/mockObsidian";
 import { ToolManager } from "@/tools/toolManager";
-import { TFile, TFolder } from "obsidian";
+import { App, TFile, TFolder } from "obsidian";
 import { buildFileTree, createGetFileTreeTool } from "./FileTreeTools";
+
+// shouldIndexFile is mocked, so the app is only threaded through and never inspected.
+const mockApp = {} as unknown as App;
 
 // Mock the searchUtils functions
 jest.mock("@/search/searchUtils", () => ({
@@ -85,7 +88,7 @@ describe("FileTreeTools", () => {
 
   it("should generate correct file tree structure with files and extension counts", async () => {
     // Test buildFileTree function directly
-    const tree = buildFileTree(root);
+    const tree = buildFileTree(mockApp, root);
 
     // Define expected tree structure
     const expectedTree = {
@@ -114,7 +117,7 @@ describe("FileTreeTools", () => {
     expect(tree).toEqual(expectedTree);
 
     // Also test the tool to ensure it uses buildFileTree correctly
-    const tool = createGetFileTreeTool(root);
+    const tool = createGetFileTreeTool(mockApp, root);
     const result = (await ToolManager.callTool(tool, {})) as string;
 
     // Extract JSON part after the prompt
@@ -126,7 +129,7 @@ describe("FileTreeTools", () => {
 
   it("should handle size limit by rebuilding without files", async () => {
     // Test buildFileTree with size limit handling
-    const tree = buildFileTree(root, false);
+    const tree = buildFileTree(mockApp, root, false);
 
     // Define expected simplified tree structure
     const expectedTree = {
@@ -153,12 +156,14 @@ describe("FileTreeTools", () => {
 
   it("should exclude files based on patterns", async () => {
     // Mock shouldIndexFile to exclude all files in projects folder
-    (searchUtils.shouldIndexFile as jest.Mock).mockImplementation((file: { path: string }) => {
-      return !file.path.includes("projects");
-    });
+    (searchUtils.shouldIndexFile as jest.Mock).mockImplementation(
+      (_app: unknown, file: { path: string }) => {
+        return !file.path.includes("projects");
+      }
+    );
 
     // Test buildFileTree with exclusion patterns
-    const tree = buildFileTree(root);
+    const tree = buildFileTree(mockApp, root);
 
     // Define expected tree with projects excluded
     const expectedTree = {
@@ -188,7 +193,7 @@ describe("FileTreeTools", () => {
     (searchUtils.shouldIndexFile as jest.Mock).mockReturnValue(false);
 
     // Test buildFileTree with all files excluded
-    const tree = buildFileTree(root);
+    const tree = buildFileTree(mockApp, root);
 
     const expectedTree = {};
 

--- a/src/tools/FileTreeTools.ts
+++ b/src/tools/FileTreeTools.ts
@@ -1,4 +1,4 @@
-import { TFile, TFolder } from "obsidian";
+import { App, TFile, TFolder } from "obsidian";
 import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
 import { z } from "zod";
 import { createLangChainTool } from "./createLangChainTool";
@@ -23,6 +23,7 @@ function getFileExtension(filename: string): string {
 }
 
 function buildFileTree(
+  app: App,
   folder: TFolder,
   includeFiles: boolean = true
 ): Record<string, FileTreeNode> {
@@ -37,7 +38,7 @@ function buildFileTree(
   for (const child of folder.children) {
     if (isTFile(child)) {
       // Only include file if it passes the pattern checks
-      if (shouldIndexFile(child, inclusions, exclusions)) {
+      if (shouldIndexFile(app, child, inclusions, exclusions)) {
         // Only add to files array if we're including files
         if (includeFiles) {
           files.push(child.name);
@@ -50,7 +51,7 @@ function buildFileTree(
         }
       }
     } else if (isTFolder(child)) {
-      const subResult = buildFileTree(child, includeFiles);
+      const subResult = buildFileTree(app, child, includeFiles);
       // Only include folder if it has any content after filtering
       if (Object.keys(subResult).length > 0) {
         subFolders[child.name] = subResult[child.name];
@@ -93,14 +94,14 @@ function buildFileTree(
   return { vault: node };
 }
 
-const createGetFileTreeTool = (root: TFolder) =>
+const createGetFileTreeTool = (app: App, root: TFolder) =>
   createLangChainTool({
     name: "getFileTree",
     description: "Get the file tree as a nested structure of folders and files",
     schema: z.object({}),
     func: async () => {
       // First try building the tree with files included
-      const tree = buildFileTree(root, true);
+      const tree = buildFileTree(app, root, true);
 
       const prompt = `A JSON represents the file tree as a nested structure:
 * The root object has a key "vault" which contains a FileTreeNode object.
@@ -115,7 +116,7 @@ const createGetFileTreeTool = (root: TFolder) =>
       // If the file tree is larger than 0.5MB, use the simplified version instead.
       if (jsonResult.length > 500000) {
         // Rebuild tree without file lists
-        const simplifiedTree = buildFileTree(root, false);
+        const simplifiedTree = buildFileTree(app, root, false);
         return prompt + JSON.stringify(simplifiedTree);
       }
 

--- a/src/tools/NoteTools.ts
+++ b/src/tools/NoteTools.ts
@@ -1,4 +1,4 @@
-import { TFile } from "obsidian";
+import { App, TFile } from "obsidian";
 import { z } from "zod";
 import { logInfo, logWarn } from "@/logger";
 import { createLangChainTool } from "./createLangChainTool";
@@ -98,7 +98,7 @@ function pathHasExtension(value: string): boolean {
   return /\.[^/]+$/.test(value);
 }
 
-async function resolveNoteFile(notePath: string): Promise<ResolveNoteOutcome> {
+async function resolveNoteFile(app: App, notePath: string): Promise<ResolveNoteOutcome> {
   const tryResolve = (path: string) => {
     const maybeFile = app.vault.getAbstractFileByPath(path);
     return maybeFile instanceof TFile ? maybeFile : null;
@@ -215,7 +215,7 @@ async function resolveNoteFile(notePath: string): Promise<ResolveNoteOutcome> {
   return { type: "not_found" };
 }
 
-async function readNoteText(file: TFile): Promise<string> {
+async function readNoteText(app: App, file: TFile): Promise<string> {
   try {
     return await app.vault.read(file);
   } catch (error) {
@@ -224,7 +224,7 @@ async function readNoteText(file: TFile): Promise<string> {
   }
 }
 
-function buildBasenameIndex(): Map<string, TFile[]> {
+function buildBasenameIndex(app: App): Map<string, TFile[]> {
   const index = new Map<string, TFile[]>();
   const files = app.vault.getMarkdownFiles?.() ?? [];
 
@@ -240,6 +240,7 @@ function buildBasenameIndex(): Map<string, TFile[]> {
 }
 
 function resolveWikiLinkTargets(
+  app: App,
   rawTarget: string,
   sourcePath: string,
   basenameIndex: Map<string, TFile[]>
@@ -266,7 +267,11 @@ function resolveWikiLinkTargets(
   return Array.from(results.values());
 }
 
-function extractLinkedNoteMetadata(content: string, sourceFile: TFile): LinkedNoteMetadata[] {
+function extractLinkedNoteMetadata(
+  app: App,
+  content: string,
+  sourceFile: TFile
+): LinkedNoteMetadata[] {
   if (!content) {
     return [];
   }
@@ -299,10 +304,15 @@ function extractLinkedNoteMetadata(content: string, sourceFile: TFile): LinkedNo
     }
 
     if (!basenameIndex) {
-      basenameIndex = buildBasenameIndex();
+      basenameIndex = buildBasenameIndex(app);
     }
 
-    const candidateFiles = resolveWikiLinkTargets(normalizedTarget, sourceFile.path, basenameIndex);
+    const candidateFiles = resolveWikiLinkTargets(
+      app,
+      normalizedTarget,
+      sourceFile.path,
+      basenameIndex
+    );
 
     matches.set(key, {
       linkText: normalizedTarget,
@@ -380,91 +390,94 @@ const readNoteSchema = z.object({
     .describe("0-based chunk index to read. Omit to read the first chunk."),
 });
 
-const readNoteTool = createLangChainTool({
-  name: "readNote",
-  description:
-    "Read a single note in search v3 sized chunks. Use only when you already know the exact note path and need its contents.",
-  schema: readNoteSchema,
-  func: async ({ notePath, chunkIndex = 0 }) => {
-    const sanitizedPath = notePath.trim();
+const createReadNoteTool = (app: App) =>
+  createLangChainTool({
+    name: "readNote",
+    description:
+      "Read a single note in search v3 sized chunks. Use only when you already know the exact note path and need its contents.",
+    schema: readNoteSchema,
+    func: async ({ notePath, chunkIndex = 0 }) => {
+      const sanitizedPath = notePath.trim();
 
-    if (sanitizedPath.startsWith("/")) {
-      return {
-        notePath: sanitizedPath,
-        status: "invalid_path",
-        message: "Provide the note path relative to the vault root without a leading slash.",
-      };
-    }
+      if (sanitizedPath.startsWith("/")) {
+        return {
+          notePath: sanitizedPath,
+          status: "invalid_path",
+          message: "Provide the note path relative to the vault root without a leading slash.",
+        };
+      }
 
-    const resolution = await resolveNoteFile(sanitizedPath);
-    if (resolution.type === "not_found") {
-      logWarn(`readNote: note not found or not a file (${sanitizedPath})`);
-      return {
-        notePath: sanitizedPath,
-        status: "not_found",
-        message: `Note "${sanitizedPath}" was not found or is not a readable file.`,
-      };
-    }
+      const resolution = await resolveNoteFile(app, sanitizedPath);
+      if (resolution.type === "not_found") {
+        logWarn(`readNote: note not found or not a file (${sanitizedPath})`);
+        return {
+          notePath: sanitizedPath,
+          status: "not_found",
+          message: `Note "${sanitizedPath}" was not found or is not a readable file.`,
+        };
+      }
 
-    if (resolution.type === "not_unique") {
-      logWarn(
-        `readNote: ambiguous note path "${sanitizedPath}" matched multiple files`,
-        resolution.matches.map((file) => file.path)
+      if (resolution.type === "not_unique") {
+        logWarn(
+          `readNote: ambiguous note path "${sanitizedPath}" matched multiple files`,
+          resolution.matches.map((file) => file.path)
+        );
+        return {
+          notePath: sanitizedPath,
+          status: "not_unique",
+          message: `Multiple notes match "${sanitizedPath}". Provide a more specific path.`,
+          candidates: resolution.matches.map((file) => ({
+            path: file.path,
+            title: file.basename,
+          })),
+        };
+      }
+
+      const file = resolution.file;
+      const canonicalPath = file.path;
+      const text = await readNoteText(app, file);
+      const chunks = chunkContentByLines(file, text);
+      const totalChunks = chunks.length;
+
+      if (totalChunks === 0) {
+        return {
+          notePath: canonicalPath,
+          status: "empty",
+          message: `No readable content was found in "${canonicalPath}".`,
+        };
+      }
+
+      if (chunkIndex >= totalChunks) {
+        return {
+          notePath: canonicalPath,
+          status: "out_of_range",
+          message: `Chunk index ${chunkIndex} exceeds available chunks (last index ${totalChunks - 1}).`,
+          totalChunks,
+        };
+      }
+
+      const chunk = chunks[chunkIndex];
+      logInfo(
+        `readNote: returning chunk ${chunk.chunkIndex} of ${totalChunks} for ${canonicalPath}`
       );
-      return {
-        notePath: sanitizedPath,
-        status: "not_unique",
-        message: `Multiple notes match "${sanitizedPath}". Provide a more specific path.`,
-        candidates: resolution.matches.map((file) => ({
-          path: file.path,
-          title: file.basename,
-        })),
-      };
-    }
 
-    const file = resolution.file;
-    const canonicalPath = file.path;
-    const text = await readNoteText(file);
-    const chunks = chunkContentByLines(file, text);
-    const totalChunks = chunks.length;
+      const hasMore = chunk.chunkIndex < totalChunks - 1;
+      const linkedNotes = extractLinkedNoteMetadata(app, chunk.content, file);
 
-    if (totalChunks === 0) {
       return {
         notePath: canonicalPath,
-        status: "empty",
-        message: `No readable content was found in "${canonicalPath}".`,
-      };
-    }
-
-    if (chunkIndex >= totalChunks) {
-      return {
-        notePath: canonicalPath,
-        status: "out_of_range",
-        message: `Chunk index ${chunkIndex} exceeds available chunks (last index ${totalChunks - 1}).`,
+        noteTitle: file.basename,
+        heading: chunk.heading,
+        chunkId: chunk.id,
+        chunkIndex: chunk.chunkIndex,
         totalChunks,
+        hasMore,
+        nextChunkIndex: hasMore ? chunk.chunkIndex + 1 : null,
+        content: chunk.content,
+        mtime: file.stat.mtime,
+        linkedNotes: linkedNotes.length > 0 ? linkedNotes : undefined,
       };
-    }
+    },
+  });
 
-    const chunk = chunks[chunkIndex];
-    logInfo(`readNote: returning chunk ${chunk.chunkIndex} of ${totalChunks} for ${canonicalPath}`);
-
-    const hasMore = chunk.chunkIndex < totalChunks - 1;
-    const linkedNotes = extractLinkedNoteMetadata(chunk.content, file);
-
-    return {
-      notePath: canonicalPath,
-      noteTitle: file.basename,
-      heading: chunk.heading,
-      chunkId: chunk.id,
-      chunkIndex: chunk.chunkIndex,
-      totalChunks,
-      hasMore,
-      nextChunkIndex: hasMore ? chunk.chunkIndex + 1 : null,
-      content: chunk.content,
-      mtime: file.stat.mtime,
-      linkedNotes: linkedNotes.length > 0 ? linkedNotes : undefined,
-    };
-  },
-});
-
-export { readNoteTool };
+export { createReadNoteTool };

--- a/src/tools/ReadNoteTool.test.ts
+++ b/src/tools/ReadNoteTool.test.ts
@@ -83,7 +83,8 @@ describe("readNoteTool", () => {
       },
     } as unknown as typeof window.app;
 
-    ({ readNoteTool } = await import("./NoteTools"));
+    const { createReadNoteTool } = await import("./NoteTools");
+    readNoteTool = createReadNoteTool(window.app);
   });
 
   afterEach(() => {

--- a/src/tools/SearchTools.ts
+++ b/src/tools/SearchTools.ts
@@ -7,6 +7,7 @@ import { shouldUseMiyo } from "@/miyo/miyoUtils";
 import { isSelfHostModeValid } from "@/plusUtils";
 import { RetrieverFactory } from "@/search/RetrieverFactory";
 import { getSettings } from "@/settings/model";
+import { App } from "obsidian";
 import { z } from "zod";
 import { deduplicateSources } from "@/LLMProviders/chainRunner/utils/toolExecution";
 import { createLangChainTool } from "./createLangChainTool";
@@ -90,12 +91,14 @@ const localSearchSchema = z.object({
 
 // Core lexical search function (shared by lexicalSearchTool and localSearchTool)
 async function performLexicalSearch({
+  app,
   timeRange,
   query,
   salientTerms,
   forceLexical = false,
   preExpandedQuery,
 }: {
+  app: App;
   timeRange?: { startTime: number; endTime: number };
   query: string;
   salientTerms: string[];
@@ -255,95 +258,101 @@ async function performLexicalSearch({
 }
 
 // Local search tool using RetrieverFactory (handles Self-hosted > Semantic > Lexical priority)
-const lexicalSearchTool = createLangChainTool({
-  name: "lexicalSearch",
-  description: "Search for notes using lexical/keyword-based search",
-  schema: localSearchSchema,
-  func: async ({ timeRange: rawTimeRange, query, salientTerms }) => {
-    const timeRange = validateTimeRange(rawTimeRange);
-    return await performLexicalSearch({
-      timeRange,
-      query,
-      salientTerms,
-    });
-  },
-});
+const createLexicalSearchTool = (app: App) =>
+  createLangChainTool({
+    name: "lexicalSearch",
+    description: "Search for notes using lexical/keyword-based search",
+    schema: localSearchSchema,
+    func: async ({ timeRange: rawTimeRange, query, salientTerms }) => {
+      const timeRange = validateTimeRange(rawTimeRange);
+      return await performLexicalSearch({
+        app,
+        timeRange,
+        query,
+        salientTerms,
+      });
+    },
+  });
 
 // Semantic search tool using Orama-based HybridRetriever
-const semanticSearchTool = createLangChainTool({
-  name: "semanticSearch",
-  description: "Search for notes using semantic/meaning-based search with embeddings",
-  schema: localSearchSchema,
-  func: async ({ timeRange: rawTimeRange, query, salientTerms }) => {
-    const timeRange = validateTimeRange(rawTimeRange);
-    const settings = getSettings();
+const createSemanticSearchTool = (app: App) =>
+  createLangChainTool({
+    name: "semanticSearch",
+    description: "Search for notes using semantic/meaning-based search with embeddings",
+    schema: localSearchSchema,
+    func: async ({ timeRange: rawTimeRange, query, salientTerms }) => {
+      const timeRange = validateTimeRange(rawTimeRange);
+      const settings = getSettings();
 
-    const tagTerms = salientTerms.filter((term) => term.startsWith("#"));
-    const needsExpandedLimits = timeRange !== undefined || tagTerms.length > 0;
-    const effectiveMaxK = needsExpandedLimits ? RETURN_ALL_LIMIT : settings.maxSourceChunks;
+      const tagTerms = salientTerms.filter((term) => term.startsWith("#"));
+      const needsExpandedLimits = timeRange !== undefined || tagTerms.length > 0;
+      const effectiveMaxK = needsExpandedLimits ? RETURN_ALL_LIMIT : settings.maxSourceChunks;
 
-    logInfo(`semanticSearch effectiveMaxK: ${effectiveMaxK} (expanded: ${needsExpandedLimits})`);
+      logInfo(`semanticSearch effectiveMaxK: ${effectiveMaxK} (expanded: ${needsExpandedLimits})`);
 
-    // Always use HybridRetriever for semantic search
-    const retriever = new (await import("@/search/hybridRetriever")).HybridRetriever({
-      minSimilarityScore: needsExpandedLimits ? 0.0 : 0.1,
-      maxK: effectiveMaxK,
-      salientTerms,
-      timeRange,
-      textWeight: TEXT_WEIGHT,
-      returnAll: needsExpandedLimits,
-      useRerankerThreshold: 0.5,
-    });
-
-    const documents = await retriever.getRelevantDocuments(query);
-
-    logInfo(`semanticSearch found ${documents.length} documents for query: "${query}"`);
-    if (timeRange) {
-      logInfo(
-        `Time range search from ${new Date(timeRange.startTime).toISOString()} to ${new Date(timeRange.endTime).toISOString()}`
+      // Always use HybridRetriever for semantic search
+      const retriever = new (await import("@/search/hybridRetriever")).HybridRetriever(
+        {
+          minSimilarityScore: needsExpandedLimits ? 0.0 : 0.1,
+          maxK: effectiveMaxK,
+          salientTerms,
+          timeRange,
+          textWeight: TEXT_WEIGHT,
+          returnAll: needsExpandedLimits,
+          useRerankerThreshold: 0.5,
+        },
+        app.vault
       );
-    }
 
-    const formattedResults = documents.map((doc) => {
-      const scored = doc.metadata.rerank_score ?? doc.metadata.score ?? 0;
-      return {
-        title: doc.metadata.title || "Untitled",
-        content: doc.pageContent,
-        path: doc.metadata.path || "",
-        score: scored,
-        rerank_score: scored,
-        includeInContext: doc.metadata.includeInContext ?? true,
-        source: doc.metadata.source,
-        mtime: doc.metadata.mtime ?? null,
-        ctime: doc.metadata.ctime ?? null,
-        chunkId: (doc.metadata as Record<string, unknown>).chunkId ?? null,
-        isChunk: (doc.metadata as Record<string, unknown>).isChunk ?? false,
-        explanation: doc.metadata.explanation ?? null,
-      };
-    });
-    // Reuse the same dedupe logic used by Show Sources
-    const sourcesLike = formattedResults.map((d) => ({
-      title: d.title || d.path || "Untitled",
-      path: d.path || d.title || "",
-      score: d.rerank_score || d.score || 0,
-    }));
-    const dedupedSources = deduplicateSources(sourcesLike);
+      const documents = await retriever.getRelevantDocuments(query);
 
-    const bestByKey = new Map<string, { rerank_score?: number }>();
-    for (const d of formattedResults) {
-      const key = ((d.path as string) || (d.title as string)).toLowerCase();
-      const existing = bestByKey.get(key);
-      if (!existing || (d.rerank_score || 0) > (existing.rerank_score || 0)) {
-        bestByKey.set(key, d);
+      logInfo(`semanticSearch found ${documents.length} documents for query: "${query}"`);
+      if (timeRange) {
+        logInfo(
+          `Time range search from ${new Date(timeRange.startTime).toISOString()} to ${new Date(timeRange.endTime).toISOString()}`
+        );
       }
-    }
-    const dedupedDocs = dedupedSources
-      .map((s) => bestByKey.get((s.path || s.title).toLowerCase()))
-      .filter(Boolean);
 
-    return { type: "local_search", documents: dedupedDocs };
-  },
-});
+      const formattedResults = documents.map((doc) => {
+        const scored = doc.metadata.rerank_score ?? doc.metadata.score ?? 0;
+        return {
+          title: doc.metadata.title || "Untitled",
+          content: doc.pageContent,
+          path: doc.metadata.path || "",
+          score: scored,
+          rerank_score: scored,
+          includeInContext: doc.metadata.includeInContext ?? true,
+          source: doc.metadata.source,
+          mtime: doc.metadata.mtime ?? null,
+          ctime: doc.metadata.ctime ?? null,
+          chunkId: (doc.metadata as Record<string, unknown>).chunkId ?? null,
+          isChunk: (doc.metadata as Record<string, unknown>).isChunk ?? false,
+          explanation: doc.metadata.explanation ?? null,
+        };
+      });
+      // Reuse the same dedupe logic used by Show Sources
+      const sourcesLike = formattedResults.map((d) => ({
+        title: d.title || d.path || "Untitled",
+        path: d.path || d.title || "",
+        score: d.rerank_score || d.score || 0,
+      }));
+      const dedupedSources = deduplicateSources(sourcesLike);
+
+      const bestByKey = new Map<string, { rerank_score?: number }>();
+      for (const d of formattedResults) {
+        const key = ((d.path as string) || (d.title as string)).toLowerCase();
+        const existing = bestByKey.get(key);
+        if (!existing || (d.rerank_score || 0) > (existing.rerank_score || 0)) {
+          bestByKey.set(key, d);
+        }
+      }
+      const dedupedDocs = dedupedSources
+        .map((s) => bestByKey.get((s.path || s.title).toLowerCase()))
+        .filter(Boolean);
+
+      return { type: "local_search", documents: dedupedDocs };
+    },
+  });
 
 /**
  * Validate and sanitize time range to prevent LLM hallucinations.
@@ -379,10 +388,12 @@ function validateTimeRange(timeRange?: {
  * Miyo replaces local lexical/semantic search entirely.
  */
 async function performMiyoSearch({
+  app,
   query,
   salientTerms,
   timeRange,
 }: {
+  app: App;
   query: string;
   salientTerms: string[];
   timeRange?: { startTime: number; endTime: number };
@@ -449,54 +460,58 @@ async function performMiyoSearch({
 }
 
 // Smart wrapper that uses RetrieverFactory for unified retriever selection
-const localSearchTool = createLangChainTool({
-  name: "localSearch",
-  description:
-    "Search for notes in the vault based on query, salient terms, and optional time range",
-  schema: localSearchSchema,
-  func: async ({ timeRange: rawTimeRange, query, salientTerms, _preExpandedQuery }) => {
-    // Validate time range to prevent LLM hallucinations (e.g., {startTime: 0, endTime: 0})
-    const timeRange = validateTimeRange(rawTimeRange);
+const createLocalSearchTool = (app: App) =>
+  createLangChainTool({
+    name: "localSearch",
+    description:
+      "Search for notes in the vault based on query, salient terms, and optional time range",
+    schema: localSearchSchema,
+    func: async ({ timeRange: rawTimeRange, query, salientTerms, _preExpandedQuery }) => {
+      // Validate time range to prevent LLM hallucinations (e.g., {startTime: 0, endTime: 0})
+      const timeRange = validateTimeRange(rawTimeRange);
 
-    // Miyo handles search server-side — use separate path (no local lexical search)
-    if (RetrieverFactory.isMiyoActive()) {
-      logInfo("localSearch: Using Miyo search path");
-      return await performMiyoSearch({
-        query,
-        salientTerms,
-        timeRange,
-      });
-    }
+      // Miyo handles search server-side — use separate path (no local lexical search)
+      if (RetrieverFactory.isMiyoActive()) {
+        logInfo("localSearch: Using Miyo search path");
+        return await performMiyoSearch({
+          app,
+          query,
+          salientTerms,
+          timeRange,
+        });
+      }
 
-    const tagTerms = salientTerms.filter((term) => term.startsWith("#"));
-    const shouldForceLexical = timeRange !== undefined || tagTerms.length > 0;
+      const tagTerms = salientTerms.filter((term) => term.startsWith("#"));
+      const shouldForceLexical = timeRange !== undefined || tagTerms.length > 0;
 
-    // For time-range and tag queries, force lexical search for better filtering
-    // Otherwise, let RetrieverFactory handle the priority (Self-hosted > Semantic > Lexical)
-    if (shouldForceLexical) {
-      logInfo("localSearch: Forcing lexical search (time range or tags present)");
+      // For time-range and tag queries, force lexical search for better filtering
+      // Otherwise, let RetrieverFactory handle the priority (Self-hosted > Semantic > Lexical)
+      if (shouldForceLexical) {
+        logInfo("localSearch: Forcing lexical search (time range or tags present)");
+        return await performLexicalSearch({
+          app,
+          timeRange,
+          query,
+          salientTerms,
+          forceLexical: true,
+          preExpandedQuery: _preExpandedQuery,
+        });
+      }
+
+      // Use RetrieverFactory which handles priority: Self-hosted > Semantic > Lexical
+      const retrieverType = RetrieverFactory.getRetrieverType();
+      logInfo(`localSearch: Using ${retrieverType} retriever via factory`);
+
+      // Delegate to shared function which uses RetrieverFactory internally
       return await performLexicalSearch({
+        app,
         timeRange,
         query,
         salientTerms,
-        forceLexical: true,
         preExpandedQuery: _preExpandedQuery,
       });
-    }
-
-    // Use RetrieverFactory which handles priority: Self-hosted > Semantic > Lexical
-    const retrieverType = RetrieverFactory.getRetrieverType();
-    logInfo(`localSearch: Using ${retrieverType} retriever via factory`);
-
-    // Delegate to shared function which uses RetrieverFactory internally
-    return await performLexicalSearch({
-      timeRange,
-      query,
-      salientTerms,
-      preExpandedQuery: _preExpandedQuery,
-    });
-  },
-});
+    },
+  });
 
 // Note: indexTool behavior depends on which retriever is active
 const indexTool = createLangChainTool({
@@ -598,4 +613,10 @@ const webSearchTool = createLangChainTool({
   },
 });
 
-export { indexTool, lexicalSearchTool, localSearchTool, semanticSearchTool, webSearchTool };
+export {
+  indexTool,
+  createLexicalSearchTool,
+  createLocalSearchTool,
+  createSemanticSearchTool,
+  webSearchTool,
+};

--- a/src/tools/TagTools.test.ts
+++ b/src/tools/TagTools.test.ts
@@ -70,7 +70,9 @@ describe("TagTools", () => {
   });
 
   it("returns combined tag statistics by default", async () => {
-    const tool = createGetTagListTool();
+    const tool = createGetTagListTool(
+      getMockApp() as unknown as Parameters<typeof createGetTagListTool>[0]
+    );
     const result = (await ToolManager.callTool(tool, {})) as string;
 
     const payload = parsePayload(result);
@@ -105,7 +107,9 @@ describe("TagTools", () => {
   });
 
   it("supports frontmatter-only mode", async () => {
-    const tool = createGetTagListTool();
+    const tool = createGetTagListTool(
+      getMockApp() as unknown as Parameters<typeof createGetTagListTool>[0]
+    );
     const result = (await ToolManager.callTool(tool, { includeInline: false })) as string;
 
     const payload = parsePayload(result);
@@ -131,7 +135,9 @@ describe("TagTools", () => {
   });
 
   it("limits entries when maxEntries is provided", async () => {
-    const tool = createGetTagListTool();
+    const tool = createGetTagListTool(
+      getMockApp() as unknown as Parameters<typeof createGetTagListTool>[0]
+    );
     const result = (await ToolManager.callTool(tool, { maxEntries: 2 })) as string;
 
     const payload = parsePayload(result);
@@ -148,7 +154,9 @@ describe("TagTools", () => {
     getMockApp().metadataCache.getTags.mockReturnValue({});
     getMockApp().metadataCache.getFrontmatterTags.mockReturnValue({});
 
-    const tool = createGetTagListTool();
+    const tool = createGetTagListTool(
+      getMockApp() as unknown as Parameters<typeof createGetTagListTool>[0]
+    );
     const result = (await ToolManager.callTool(tool, {})) as string;
 
     const payload = parsePayload(result);
@@ -168,7 +176,9 @@ describe("TagTools", () => {
       "##Weird/Tag": 1,
     });
 
-    const tool = createGetTagListTool();
+    const tool = createGetTagListTool(
+      getMockApp() as unknown as Parameters<typeof createGetTagListTool>[0]
+    );
     const result = (await ToolManager.callTool(tool, {})) as string;
 
     const payload = parsePayload(result);
@@ -197,7 +207,9 @@ describe("TagTools", () => {
       "#project": 3,
     });
 
-    const tool = createGetTagListTool();
+    const tool = createGetTagListTool(
+      getMockApp() as unknown as Parameters<typeof createGetTagListTool>[0]
+    );
     const result = (await ToolManager.callTool(tool, {})) as string;
 
     const payload = parsePayload(result);

--- a/src/tools/TagTools.ts
+++ b/src/tools/TagTools.ts
@@ -1,4 +1,4 @@
-import { MetadataCache } from "obsidian";
+import { App, MetadataCache } from "obsidian";
 import { z } from "zod";
 import { createLangChainTool } from "./createLangChainTool";
 
@@ -47,12 +47,12 @@ interface TagListPayload {
 }
 
 /**
- * Safely retrieves the metadata cache from the global Obsidian app instance.
+ * Safely retrieves the metadata cache from the given Obsidian app instance.
  *
  * @returns The metadata cache when available, otherwise null.
  */
-function getMetadataCache(): MetadataCache | null {
-  if (typeof app === "undefined" || !app?.metadataCache) {
+function getMetadataCache(app: App): MetadataCache | null {
+  if (!app?.metadataCache) {
     return null;
   }
   return app.metadataCache;
@@ -236,13 +236,13 @@ function formatTagListResult(payload: TagListPayload): string {
  *
  * @returns A tool for retrieving vault tag statistics.
  */
-export const createGetTagListTool = () =>
+export const createGetTagListTool = (app: App) =>
   createLangChainTool({
     name: "getTagList",
     description: "Get the list of tags in the vault with occurrence statistics.",
     schema: TagListToolSchema,
     func: async (args) => {
-      const metadataCache = getMetadataCache();
+      const metadataCache = getMetadataCache(app);
       const includeInline = args?.includeInline ?? true;
       const maxEntries = args?.maxEntries ?? DEFAULT_MAX_TAG_ENTRIES;
 

--- a/src/tools/builtinTools.ts
+++ b/src/tools/builtinTools.ts
@@ -1,10 +1,10 @@
 import { getSettings } from "@/settings/model";
-import { Vault } from "obsidian";
+import { App } from "obsidian";
 import { isDesktopRuntime } from "@/services/obsidianCli/ObsidianCliClient";
-import { editFileTool, writeFileTool } from "./ComposerTools";
+import { createEditFileTool, createWriteFileTool } from "./ComposerTools";
 import { createGetFileTreeTool } from "./FileTreeTools";
-import { updateMemoryTool } from "./memoryTools";
-import { readNoteTool } from "./NoteTools";
+import { createUpdateMemoryTool } from "./memoryTools";
+import { createReadNoteTool } from "./NoteTools";
 import { obsidianRandomReadTool } from "./ObsidianCliDailyTools";
 import {
   obsidianBasesTool,
@@ -14,7 +14,7 @@ import {
   obsidianTasksTool,
   obsidianTemplatesTool,
 } from "./ObsidianCliTools";
-import { localSearchTool, webSearchTool } from "./SearchTools";
+import { createLocalSearchTool, webSearchTool } from "./SearchTools";
 import { createGetTagListTool } from "./TagTools";
 import {
   convertTimeBetweenTimezonesTool,
@@ -26,19 +26,21 @@ import { ToolDefinition, ToolRegistry } from "./ToolRegistry";
 import { youtubeTranscriptionTool } from "./YoutubeTools";
 
 /**
- * Define all built-in tools with their metadata
+ * Define all built-in tools with their metadata. App-dependent tools are
+ * instantiated from their factories with the provided `app`.
  */
-export const BUILTIN_TOOLS: ToolDefinition[] = [
-  // Search tools
-  {
-    tool: localSearchTool,
-    metadata: {
-      id: "localSearch",
-      displayName: "Vault Search",
-      description: "Search through your vault notes",
-      category: "search",
-      copilotCommands: ["@vault"],
-      customPromptInstructions: `For localSearch (searching notes based on their contents in the vault):
+function getBuiltinTools(app: App): ToolDefinition[] {
+  return [
+    // Search tools
+    {
+      tool: createLocalSearchTool(app),
+      metadata: {
+        id: "localSearch",
+        displayName: "Vault Search",
+        description: "Search through your vault notes",
+        category: "search",
+        copilotCommands: ["@vault"],
+        customPromptInstructions: `For localSearch (searching notes based on their contents in the vault):
 - You MUST always provide both "query" (string) and "salientTerms" (array of strings)
 - salientTerms MUST be extracted from the user's original query - never invent new terms
 - They are keywords used for BM25 full-text search to find notes containing those exact words
@@ -72,37 +74,37 @@ For time-based searches with meaningful terms (e.g., "python debugging notes fro
 
 For broad searches:
 - If the user wants a comprehensive list, use getFileTree to get all note titles as reference. This helps verify search completeness and identify notes the search may have missed.`,
+      },
     },
-  },
-  {
-    tool: webSearchTool,
-    metadata: {
-      id: "webSearch",
-      displayName: "Web Search",
-      description:
-        "Search the INTERNET (NOT vault notes) when user explicitly asks for web/online information",
-      category: "search",
-      copilotCommands: ["@websearch", "@web"],
-      customPromptInstructions: `For webSearch:
+    {
+      tool: webSearchTool,
+      metadata: {
+        id: "webSearch",
+        displayName: "Web Search",
+        description:
+          "Search the INTERNET (NOT vault notes) when user explicitly asks for web/online information",
+        category: "search",
+        copilotCommands: ["@websearch", "@web"],
+        customPromptInstructions: `For webSearch:
 - ONLY use when the user's query contains explicit web-search intent like:
   * "web search", "internet search", "online search"
   * "Google", "search online", "look up online", "search the web"
 - Always provide an empty chatHistory array
 
 Example: "search the web for python tutorials" → query: "python tutorials", chatHistory: []`,
+      },
     },
-  },
 
-  // Time tools (always enabled)
-  {
-    tool: getCurrentTimeTool,
-    metadata: {
-      id: "getCurrentTime",
-      displayName: "Get Current Time",
-      description: "Get the current time in any timezone",
-      category: "time",
-      isAlwaysEnabled: true,
-      customPromptInstructions: `For time queries (IMPORTANT: Always use UTC offsets, not timezone names):
+    // Time tools (always enabled)
+    {
+      tool: getCurrentTimeTool,
+      metadata: {
+        id: "getCurrentTime",
+        displayName: "Get Current Time",
+        description: "Get the current time in any timezone",
+        category: "time",
+        isAlwaysEnabled: true,
+        customPromptInstructions: `For time queries (IMPORTANT: Always use UTC offsets, not timezone names):
 
 - If the user mentions a specific city, country, or timezone name (e.g., "Tokyo", "Japan", "JST"), you MUST convert it to the correct UTC offset and pass it via the timezoneOffset parameter (e.g., "+9").
 - Only omit timezoneOffset when the user asks for the current local time without naming any location or timezone.
@@ -112,58 +114,58 @@ Examples:
 - "what time is it" (local time) → call with no parameters
 - "what time is it in Tokyo" (UTC+9) → timezoneOffset: "+9"
 - "what time is it in New York" (UTC-5 or UTC-4 depending on DST) → timezoneOffset: "-5"`,
+      },
     },
-  },
-  {
-    tool: getTimeInfoByEpochTool,
-    metadata: {
-      id: "getTimeInfoByEpoch",
-      displayName: "Get Time Info",
-      description: "Convert epoch timestamp to human-readable format",
-      category: "time",
-      isAlwaysEnabled: true,
+    {
+      tool: getTimeInfoByEpochTool,
+      metadata: {
+        id: "getTimeInfoByEpoch",
+        displayName: "Get Time Info",
+        description: "Convert epoch timestamp to human-readable format",
+        category: "time",
+        isAlwaysEnabled: true,
+      },
     },
-  },
-  {
-    tool: getTimeRangeMsTool,
-    metadata: {
-      id: "getTimeRangeMs",
-      displayName: "Get Time Range",
-      description: "Convert time expressions to date ranges",
-      category: "time",
-      isAlwaysEnabled: true,
-      customPromptInstructions: `For time-based queries:
+    {
+      tool: getTimeRangeMsTool,
+      metadata: {
+        id: "getTimeRangeMs",
+        displayName: "Get Time Range",
+        description: "Convert time expressions to date ranges",
+        category: "time",
+        isAlwaysEnabled: true,
+        customPromptInstructions: `For time-based queries:
 - Use this tool to convert time expressions like "last week", "yesterday", "last month" to proper time ranges
 - This is typically the first step before using localSearch with a time range
 
 Example: For "last week" → timeExpression: "last week"`,
+      },
     },
-  },
-  {
-    tool: convertTimeBetweenTimezonesTool,
-    metadata: {
-      id: "convertTimeBetweenTimezones",
-      displayName: "Convert Timezones",
-      description: "Convert time between different timezones",
-      category: "time",
-      isAlwaysEnabled: true,
-      customPromptInstructions: `For timezone conversions:
+    {
+      tool: convertTimeBetweenTimezonesTool,
+      metadata: {
+        id: "convertTimeBetweenTimezones",
+        displayName: "Convert Timezones",
+        description: "Convert time between different timezones",
+        category: "time",
+        isAlwaysEnabled: true,
+        customPromptInstructions: `For timezone conversions:
 
 Example: "what time is 6pm PT in Tokyo" (PT is UTC-8 or UTC-7, Tokyo is UTC+9) → time: "6pm", fromOffset: "-8", toOffset: "+9"`,
+      },
     },
-  },
 
-  // File tools
-  {
-    tool: readNoteTool,
-    metadata: {
-      id: "readNote",
-      displayName: "Read Note",
-      description: "Read a specific note in sequential chunks using its own line-chunking logic.",
-      category: "file",
-      requiresVault: true,
-      isAlwaysEnabled: true,
-      customPromptInstructions: `For readNote:
+    // File tools
+    {
+      tool: createReadNoteTool(app),
+      metadata: {
+        id: "readNote",
+        displayName: "Read Note",
+        description: "Read a specific note in sequential chunks using its own line-chunking logic.",
+        category: "file",
+        requiresVault: true,
+        isAlwaysEnabled: true,
+        customPromptInstructions: `For readNote:
 - Decide based on the user's request: only call this tool when the question requires reading note content.
 - If the user asks about a note title that is already mentioned in the current or previous turns of the conversation, or linked in <active_note> or <note_context> blocks, call readNote directly—do not use localSearch to look it up. Even if the note title mention is partial but similar to what you have seen in the context, try to infer the correct note path from context. Skip the tool when a note is irrelevant to the user query.
 - If the user asks about notes linked from that note, read the original note first, then follow the "linkedNotes" paths returned in the tool result to inspect those linked notes.
@@ -176,19 +178,19 @@ Example: "what time is 6pm PT in Tokyo" (PT is UTC-8 or UTC-7, Tokyo is UTC+9) �
 Examples:
 - First chunk: notePath: "Projects/launch-plan.md" (chunkIndex omitted or 0)
 - Next chunk: notePath: "Projects/launch-plan.md", chunkIndex: 1`,
+      },
     },
-  },
-  {
-    tool: writeFileTool,
-    metadata: {
-      id: "writeFile",
-      displayName: "Write to File",
-      description: "Create or rewrite files in your vault",
-      category: "file",
-      requiresVault: true,
-      timeoutMs: 0, // No timeout - waits for user preview decision
-      copilotCommands: ["@composer"],
-      customPromptInstructions: `For writeFile:
+    {
+      tool: createWriteFileTool(app),
+      metadata: {
+        id: "writeFile",
+        displayName: "Write to File",
+        description: "Create or rewrite files in your vault",
+        category: "file",
+        requiresVault: true,
+        timeoutMs: 0, // No timeout - waits for user preview decision
+        copilotCommands: ["@composer"],
+        customPromptInstructions: `For writeFile:
 - NEVER display the file content directly in your response
 - Always pass the complete file content to the tool
 - Include the full path to the file
@@ -200,18 +202,18 @@ Examples:
 Examples:
 - Basic: path: "path/to/note.md", content: "FULL CONTENT OF THE NOTE"
 - Skip confirmation: path: "path/to/note.md", content: "FULL CONTENT", confirmation: false`,
+      },
     },
-  },
-  {
-    tool: editFileTool,
-    metadata: {
-      id: "editFile",
-      displayName: "Edit File",
-      description: "Make a targeted, single-match edit to an existing file",
-      category: "file",
-      requiresVault: true,
-      timeoutMs: 0, // No timeout - waits for user preview decision
-      customPromptInstructions: `For editFile:
+    {
+      tool: createEditFileTool(app),
+      metadata: {
+        id: "editFile",
+        displayName: "Edit File",
+        description: "Make a targeted, single-match edit to an existing file",
+        category: "file",
+        requiresVault: true,
+        timeoutMs: 0, // No timeout - waits for user preview decision
+        customPromptInstructions: `For editFile:
 - Use for targeted edits; use writeFile for major rewrites or new files
 - oldText must uniquely identify the location — include surrounding context lines if needed
 - The tool automatically handles minor whitespace/quote differences (fuzzy matching)
@@ -221,34 +223,35 @@ Example: Add "Bob Johnson" to attendees in notes/meeting.md:
 path: "notes/meeting.md"
 oldText: "## Attendees\\n- John Smith\\n- Jane Doe"
 newText: "## Attendees\\n- John Smith\\n- Jane Doe\\n- Bob Johnson"`,
+      },
     },
-  },
 
-  // Media tools
-  {
-    tool: youtubeTranscriptionTool,
-    metadata: {
-      id: "youtubeTranscription",
-      displayName: "YouTube Transcription",
-      description: "Get transcripts from YouTube videos",
-      category: "media",
-      isPlusOnly: true,
-      requiresUserMessageContent: true,
-      customPromptInstructions: `For youtubeTranscription:
+    // Media tools
+    {
+      tool: youtubeTranscriptionTool,
+      metadata: {
+        id: "youtubeTranscription",
+        displayName: "YouTube Transcription",
+        description: "Get transcripts from YouTube videos",
+        category: "media",
+        isPlusOnly: true,
+        requiresUserMessageContent: true,
+        customPromptInstructions: `For youtubeTranscription:
 - Use when user provides YouTube URLs
 - No parameters needed - the tool will process URLs from the conversation`,
+      },
     },
-  },
-];
+  ];
+}
 
 /**
  * Register the file tree tool separately as it needs vault access
  */
-export function registerFileTreeTool(vault: Vault): void {
+export function registerFileTreeTool(app: App): void {
   const registry = ToolRegistry.getInstance();
 
   registry.register({
-    tool: createGetFileTreeTool(vault.getRoot()),
+    tool: createGetFileTreeTool(app, app.vault.getRoot()),
     metadata: {
       id: "getFileTree",
       displayName: "File Tree",
@@ -274,11 +277,11 @@ Example queries that should use getFileTree:
 /**
  * Register the tag list tool separately to ensure metadata cache access is available.
  */
-export function registerTagListTool(): void {
+export function registerTagListTool(app: App): void {
   const registry = ToolRegistry.getInstance();
 
   registry.register({
-    tool: createGetTagListTool(),
+    tool: createGetTagListTool(app),
     metadata: {
       id: "getTagList",
       displayName: "Tag List",
@@ -303,11 +306,11 @@ Examples:
 /**
  * Register the memory tool separately as it depends on saved memory setting
  */
-export function registerMemoryTool(): void {
+export function registerMemoryTool(app: App): void {
   const registry = ToolRegistry.getInstance();
 
   registry.register({
-    tool: updateMemoryTool,
+    tool: createUpdateMemoryTool(app),
     metadata: {
       id: "updateMemory",
       displayName: "Update Memory",
@@ -482,15 +485,15 @@ Base file YAML reference (for creating new .base files with writeFile):
  * This function registers tool definitions, not user preferences.
  * User-enabled tools are filtered dynamically when retrieved.
  *
- * @param vault - Optional Obsidian vault. When provided, enables registration of vault-dependent tools like file tree
+ * @param app - Optional Obsidian app. When provided, enables registration of app-dependent tools (search, readNote, writeFile, editFile, file tree, tag list, memory).
  */
-export function initializeBuiltinTools(vault?: Vault): void {
+export function initializeBuiltinTools(app?: App): void {
   const registry = ToolRegistry.getInstance();
   const settings = getSettings();
 
-  // Only reinitialize if tools have changed or vault/memory status has changed
+  // Only reinitialize if tools have changed or app/memory status has changed
   const hasFileTree = registry.getToolMetadata("getFileTree") !== undefined;
-  const shouldHaveFileTree = vault !== undefined;
+  const shouldHaveFileTree = app !== undefined;
   const hasUpdateMemoryTool = registry.getToolMetadata("updateMemory") !== undefined;
   const shouldHaveMemoryTool = settings.enableSavedMemory;
 
@@ -502,18 +505,17 @@ export function initializeBuiltinTools(vault?: Vault): void {
     // Clear any existing tools
     registry.clear();
 
-    // Register all built-in tools
-    registry.registerAll(BUILTIN_TOOLS);
+    // Register app-dependent built-in tools (most built-ins need the vault or
+    // metadata cache; they're instantiated from factories with `app`).
+    if (app) {
+      registry.registerAll(getBuiltinTools(app));
+      registerFileTreeTool(app);
+      registerTagListTool(app);
 
-    // Register vault-dependent tools if vault is available
-    if (vault) {
-      registerFileTreeTool(vault);
-      registerTagListTool();
-    }
-
-    // Register memory tool if saved memory is enabled
-    if (settings.enableSavedMemory) {
-      registerMemoryTool();
+      // Register memory tool if saved memory is enabled
+      if (settings.enableSavedMemory) {
+        registerMemoryTool(app);
+      }
     }
 
     // Register desktop-only CLI tools (invisible on mobile)

--- a/src/tools/memoryTools.ts
+++ b/src/tools/memoryTools.ts
@@ -1,3 +1,4 @@
+import { App } from "obsidian";
 import { z } from "zod";
 import { createLangChainTool } from "./createLangChainTool";
 import { UserMemoryManager } from "@/memory/UserMemoryManager";
@@ -15,35 +16,36 @@ const memorySchema = z.object({
 /**
  * Memory tool for saving information that the user explicitly asks the assistant to remember
  */
-export const updateMemoryTool = createLangChainTool({
-  name: "updateMemory",
-  description: "Update the user memory when the user explicitly asks to update the memory",
-  schema: memorySchema,
-  func: async ({ statement }) => {
-    try {
-      const memoryManager = new UserMemoryManager(app);
-      const chatModel = ChatModelManager.getInstance().getChatModel();
-      const result = await memoryManager.updateSavedMemory(statement, chatModel);
+export const createUpdateMemoryTool = (app: App) =>
+  createLangChainTool({
+    name: "updateMemory",
+    description: "Update the user memory when the user explicitly asks to update the memory",
+    schema: memorySchema,
+    func: async ({ statement }) => {
+      try {
+        const memoryManager = new UserMemoryManager(app);
+        const chatModel = ChatModelManager.getInstance().getChatModel();
+        const result = await memoryManager.updateSavedMemory(statement, chatModel);
 
-      if (result.error) {
+        if (result.error) {
+          return {
+            success: false,
+            message: result.error,
+          };
+        }
+
+        const memoryFilePath = memoryManager.getSavedMemoriesFilePath();
+        return {
+          success: true,
+          message: `Memory updated successfully into ${memoryFilePath}: ${result.content}`,
+        };
+      } catch (error: unknown) {
+        logError("[updateMemoryTool] Error updating memory:", error);
+
         return {
           success: false,
-          message: result.error,
+          message: `Failed to save memory: ${error instanceof Error ? error.message : String(error)}`,
         };
       }
-
-      const memoryFilePath = memoryManager.getSavedMemoriesFilePath();
-      return {
-        success: true,
-        message: `Memory updated successfully into ${memoryFilePath}: ${result.content}`,
-      };
-    } catch (error: unknown) {
-      logError("[updateMemoryTool] Error updating memory:", error);
-
-      return {
-        success: false,
-        message: `Failed to save memory: ${error instanceof Error ? error.message : String(error)}`,
-      };
-    }
-  },
-});
+    },
+  });

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -286,11 +286,10 @@ describe("getNotesFromTags", () => {
   });
 
   it("should return files with specified tags 1", async () => {
-    const mockVault = new Obsidian.Vault();
     const tags = ["#tag1"];
     const expectedPaths = ["test/test2/note1.md", "note4.md"];
 
-    const result = getNotesFromTags(mockVault, tags);
+    const result = getNotesFromTags(mockApp, tags);
     const resultPaths = result.map((fileWithTags) => fileWithTags.path);
 
     expect(resultPaths).toEqual(expect.arrayContaining(expectedPaths));
@@ -298,21 +297,19 @@ describe("getNotesFromTags", () => {
   });
 
   it("should return an empty array if no files match the specified nonexistent tags", async () => {
-    const mockVault = new Obsidian.Vault();
     const tags = ["#nonexistentTag"];
     const expected: string[] = [];
 
-    const result = getNotesFromTags(mockVault, tags);
+    const result = getNotesFromTags(mockApp, tags);
 
     expect(result).toEqual(expected);
   });
 
   it("should handle multiple tags, returning files that match any of them", async () => {
-    const mockVault = new Obsidian.Vault();
     const tags = ["#tag2", "#tag4"];
     const expectedPaths = ["test/test2/note1.md", "test/note2.md", "note4.md"];
 
-    const result = getNotesFromTags(mockVault, tags);
+    const result = getNotesFromTags(mockApp, tags);
     const resultPaths = result.map((fileWithTags) => fileWithTags.path);
 
     expect(resultPaths).toEqual(expect.arrayContaining(expectedPaths));
@@ -320,7 +317,6 @@ describe("getNotesFromTags", () => {
   });
 
   it("should handle both path and tags, returning files under the specified path with the specified tags", async () => {
-    const mockVault = new Obsidian.Vault();
     const tags = ["#tag1"];
     type TFileCtor = new (path: string) => TFile;
     const noteFiles: TFile[] = [
@@ -329,7 +325,7 @@ describe("getNotesFromTags", () => {
     ];
     const expectedPaths = ["test/test2/note1.md"];
 
-    const result = getNotesFromTags(mockVault, tags, noteFiles);
+    const result = getNotesFromTags(mockApp, tags, noteFiles);
     const resultPaths = result.map((fileWithTags) => fileWithTags.path);
 
     expect(resultPaths).toEqual(expect.arrayContaining(expectedPaths));
@@ -337,10 +333,8 @@ describe("getNotesFromTags", () => {
   });
 
   it("should ignore inline tags and only consider frontmatter tags", async () => {
-    const mockVault = new Obsidian.Vault();
-
     const tags = ["#inlineTag1"];
-    const result = getNotesFromTags(mockVault, tags);
+    const result = getNotesFromTags(mockApp, tags);
 
     expect(result).toEqual([]); // Should return empty since inline tags are ignored
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,7 @@ import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { Document } from "@langchain/core/documents";
 import { MemoryVariables } from "@langchain/core/memory";
 import { DateTime } from "luxon";
-import { MarkdownView, Notice, TFile, Vault, normalizePath, requestUrl } from "obsidian";
+import { App, MarkdownView, Notice, TFile, Vault, normalizePath, requestUrl } from "obsidian";
 import { CustomModel } from "./aiParams";
 import { getApiKeyForProvider } from "@/utils/modelUtils";
 export { err2String } from "@/errorFormat";
@@ -193,11 +193,12 @@ export function stripFrontmatter(content: string, options: StripFrontmatterOptio
 }
 
 /**
+ * @param app - The Obsidian app instance.
  * @param file - The note file to get tags from.
  * @param frontmatterOnly - Whether to only get tags from frontmatter.
  * @returns An array of lowercase tags without the hash symbol.
  */
-export function getTagsFromNote(file: TFile, frontmatterOnly = true): string[] {
+export function getTagsFromNote(app: App, file: TFile, frontmatterOnly = true): string[] {
   const metadata = app.metadataCache.getFileCache(file);
   const frontmatterTags = metadata?.frontmatter?.tags;
   const allTags = new Set<string>();
@@ -227,23 +228,23 @@ export function getTagsFromNote(file: TFile, frontmatterOnly = true): string[] {
 
 /**
  * Get notes from tags.
- * @param vault - The vault to get notes from.
+ * @param app - The Obsidian app instance.
  * @param tags - The tags to get notes from. Tags should be with the hash symbol.
  * @param noteFiles - The notes to get notes from.
  * @returns An array of note files.
  */
-export function getNotesFromTags(vault: Vault, tags: string[], noteFiles?: TFile[]): TFile[] {
+export function getNotesFromTags(app: App, tags: string[], noteFiles?: TFile[]): TFile[] {
   if (tags.length === 0) {
     return [];
   }
 
   tags = tags.map((tag) => stripHash(tag));
 
-  const files = noteFiles && noteFiles.length > 0 ? noteFiles : getNotesFromPath(vault, "/");
+  const files = noteFiles && noteFiles.length > 0 ? noteFiles : getNotesFromPath(app.vault, "/");
   const filesWithTag = [];
 
   for (const file of files) {
-    const noteTags = getTagsFromNote(file);
+    const noteTags = getTagsFromNote(app, file);
     if (tags.some((tag) => noteTags.includes(tag))) {
       filesWithTag.push(file);
     }
@@ -281,7 +282,7 @@ export const formatDateTime = (
  *
  * Throws if any segment conflicts with an existing file.
  */
-export async function ensureFolderExists(folderPath: string): Promise<void> {
+export async function ensureFolderExists(vault: Vault, folderPath: string): Promise<void> {
   const path = normalizePath(folderPath).replace(/^\/+/, "").replace(/\/+$/, "");
   if (!path) return; // nothing to ensure
 
@@ -291,7 +292,7 @@ export async function ensureFolderExists(folderPath: string): Promise<void> {
   for (const part of parts) {
     current = current ? `${current}/${part}` : part;
 
-    const existing = app.vault.getAbstractFileByPath(current);
+    const existing = vault.getAbstractFileByPath(current);
     if (existing) {
       if (existing instanceof TFile) {
         throw new Error(`Path conflict: "${current}" exists as a file, expected folder.`);
@@ -301,7 +302,7 @@ export async function ensureFolderExists(folderPath: string): Promise<void> {
     }
 
     // Create this level; parents are guaranteed to exist from previous iterations
-    await app.vault.adapter.mkdir(current);
+    await vault.adapter.mkdir(current);
   }
 }
 
@@ -883,7 +884,7 @@ export function cleanMessageForCopy(message: string): string {
  * Uses a single CM6 transaction to avoid undo stack splitting.
  * Ensures the inserted/replaced range is selected after the operation.
  */
-export async function insertIntoEditor(message: string, replace: boolean = false) {
+export async function insertIntoEditor(app: App, message: string, replace: boolean = false) {
   let leaf = app.workspace.getMostRecentLeaf();
   if (!leaf) {
     new Notice("No active leaf found.");
@@ -1300,7 +1301,7 @@ export async function withTimeout<T>(
 /**
  * Check if the current Obsidian editor setting is in source mode
  */
-export function isSourceModeOn(): boolean {
+export function isSourceModeOn(app: App): boolean {
   const view = app.workspace.getActiveViewOfType(MarkdownView);
   if (!view) return true;
 
@@ -1396,10 +1397,15 @@ export function sanitizeFilePath(filePath: string): string {
 
 /**
  * Opens a file in the workspace, reusing an existing tab if the file is already open.
+ * @param app - The Obsidian app instance
  * @param file - The TFile to open
  * @param focusIfOpen - If true, focuses the existing leaf if the file is already open (default: true)
  */
-export async function openFileInWorkspace(file: TFile, focusIfOpen: boolean = true): Promise<void> {
+export async function openFileInWorkspace(
+  app: App,
+  file: TFile,
+  focusIfOpen: boolean = true
+): Promise<void> {
   // Check if the file is already open in any leaf
   let existingLeaf = null;
   app.workspace.iterateAllLeaves((leaf) => {

--- a/src/utils/chatHistoryUtils.ts
+++ b/src/utils/chatHistoryUtils.ts
@@ -123,7 +123,7 @@ export async function filterChatHistoryFiles(
  * First checks frontmatter.topic, then extracts from filename by removing
  * project ID prefix, date/time patterns, and normalizing separators.
  */
-export function extractChatTitle(file: TFile): string {
+export function extractChatTitle(app: App, file: TFile): string {
   // Read the file's front matter
   const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
 
@@ -172,7 +172,7 @@ export function extractChatTitle(file: TFile): string {
  * Extract chat creation date from a file.
  * Uses frontmatter.epoch if available, falls back to file creation time.
  */
-export function extractChatDate(file: TFile): Date {
+export function extractChatDate(app: App, file: TFile): Date {
   const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
 
   if (frontmatter && frontmatter.epoch) {
@@ -188,7 +188,7 @@ export function extractChatDate(file: TFile): Date {
  * Extract chat last accessed time (epoch ms) from a file.
  * Uses frontmatter.lastAccessedAt if available, returns null otherwise.
  */
-export function extractChatLastAccessedAtMs(file: TFile): number | null {
+export function extractChatLastAccessedAtMs(app: App, file: TFile): number | null {
   const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
   const rawValue = frontmatter?.lastAccessedAt;
 
@@ -215,8 +215,8 @@ export function extractChatLastAccessedAtMs(file: TFile): number | null {
  * Extract chat last accessed date from a file.
  * Uses extractChatLastAccessedAtMs and returns a Date when available, null otherwise.
  */
-export function extractChatLastAccessedAt(file: TFile): Date | null {
-  const lastAccessedAtMs = extractChatLastAccessedAtMs(file);
+export function extractChatLastAccessedAt(app: App, file: TFile): Date | null {
+  const lastAccessedAtMs = extractChatLastAccessedAtMs(app, file);
   return lastAccessedAtMs ? new Date(lastAccessedAtMs) : null;
 }
 
@@ -227,11 +227,12 @@ export function extractChatLastAccessedAt(file: TFile): Date | null {
  * chat-history flows so the two lists rank identically.
  */
 export function fileToHistoryItem(
+  app: App,
   file: TFile,
   lastAccessedAtManager: RecentUsageManager<string>
 ): ChatHistoryItem {
-  const createdAt = extractChatDate(file);
-  const persistedLastAccessedAtMs = extractChatLastAccessedAtMs(file);
+  const createdAt = extractChatDate(app, file);
+  const persistedLastAccessedAtMs = extractChatLastAccessedAtMs(app, file);
   const effectiveLastAccessedAtMs = lastAccessedAtManager.getEffectiveLastUsedAt(
     file.path,
     persistedLastAccessedAtMs ?? createdAt.getTime()
@@ -241,7 +242,7 @@ export function fileToHistoryItem(
     typeof rawBackendId === "string" && rawBackendId.trim() ? rawBackendId.trim() : undefined;
   return {
     id: file.path,
-    title: extractChatTitle(file),
+    title: extractChatTitle(app, file),
     createdAt,
     lastAccessedAt: new Date(effectiveLastAccessedAtMs),
     backendId,
@@ -252,9 +253,9 @@ export function fileToHistoryItem(
  * Get formatted display text for a chat file (title + formatted date).
  * Used in chat history modals and similar UI components.
  */
-export function getChatDisplayText(file: TFile): string {
-  const title = extractChatTitle(file);
-  const date = extractChatDate(file);
+export function getChatDisplayText(app: App, file: TFile): string {
+  const title = extractChatTitle(app, file);
+  const date = extractChatDate(app, file);
   const formattedDateTime = formatDateTime(date);
   return `${title} - ${formattedDateTime.display}`;
 }

--- a/src/utils/convertedDocOutput.ts
+++ b/src/utils/convertedDocOutput.ts
@@ -29,7 +29,7 @@ export async function saveConvertedDocOutput(
   if (!content || content.startsWith("[Error:")) return;
 
   try {
-    await ensureFolderExists(trimmed);
+    await ensureFolderExists(vault, trimmed);
 
     let outputPath = `${trimmed}/${file.basename}.md`;
 


### PR DESCRIPTION
Flips on the `no-restricted-globals` ESLint rule with an `app` entry (error) for production `src/**/*.{ts,tsx}`, making the existing "don't use the global `app`" convention mechanically enforceable; test files are exempt since they intentionally consume the `window.app` mock. Sweeps the entire codebase to **0 violations** by threading `app` explicitly: `useApp()` in React components/hooks, `this.app` / `this.chainManager.app` in classes and chain runners, and explicit `app`/`vault` parameters in plain modules. App-using no-arg `getInstance()` singletons (ProjectContextCache, VectorStoreManager, ContextProcessor, CustomCommandManager) adopt a seed-on-first-call pattern wired once in `main.ts onload`; eager module-level singletons (`logFileManager`, `frameSink`) gain one-time setters; and app-dependent built-in tools (`writeFile`, `localSearch`, `readNote`, etc.) become factory functions threaded through `initializeBuiltinTools(app)`. The ambient `var app: App` in `typings/global.d.ts` stays so tests still type-check — the lint rule (not TypeScript) is the enforcement. Verified green: `tsc`, `eslint .`, `prettier --check`, and the full Jest suite (3331 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)