### PR TITLE
feat(agent-mode): detect Claude CLI sign-in and add in-app OAuth

### DIFF
--- a/src/agentMode/backends/claude/claudeAuth.test.ts
+++ b/src/agentMode/backends/claude/claudeAuth.test.ts
@@ -1,0 +1,46 @@
+import { parseClaudeAuthStatusOutput } from "./claudeAuth";
+
+describe("parseClaudeAuthStatusOutput", () => {
+  it("reports signed in with a label from email + subscription", () => {
+    const out = JSON.stringify({
+      loggedIn: true,
+      authMethod: "claude.ai",
+      apiProvider: "firstParty",
+      email: "zero@example.com",
+      subscriptionType: "max",
+    });
+    expect(parseClaudeAuthStatusOutput(out)).toEqual({
+      loggedIn: true,
+      label: "zero@example.com (max)",
+    });
+  });
+
+  it("falls back to apiProvider + authMethod when email/subscription are absent", () => {
+    const out = JSON.stringify({
+      loggedIn: true,
+      apiProvider: "bedrock",
+      authMethod: "aws",
+    });
+    expect(parseClaudeAuthStatusOutput(out)).toEqual({
+      loggedIn: true,
+      label: "bedrock (aws)",
+    });
+  });
+
+  it("reports signed out for loggedIn:false", () => {
+    expect(parseClaudeAuthStatusOutput(JSON.stringify({ loggedIn: false }))).toEqual({
+      loggedIn: false,
+    });
+  });
+
+  it("treats malformed / non-JSON output as signed out", () => {
+    expect(parseClaudeAuthStatusOutput("not json")).toEqual({ loggedIn: false });
+    expect(parseClaudeAuthStatusOutput("")).toEqual({ loggedIn: false });
+  });
+
+  it("treats a payload missing loggedIn as signed out", () => {
+    expect(parseClaudeAuthStatusOutput(JSON.stringify({ email: "x@y.z" }))).toEqual({
+      loggedIn: false,
+    });
+  });
+});

--- a/src/agentMode/backends/claude/claudeAuth.ts
+++ b/src/agentMode/backends/claude/claudeAuth.ts
@@ -1,0 +1,177 @@
+/**
+ * Sign-in state and OAuth sign-in for the user-installed `claude` CLI.
+ *
+ * The Claude Agent SDK exposes no public login API, so authentication is owned
+ * entirely by the CLI: `claude auth status --json` is the source of truth (it
+ * reflects an interactive OAuth login *and* env-based credentials like
+ * `ANTHROPIC_API_KEY` / Bedrock / Vertex), and `claude auth login` runs the
+ * OAuth flow — auto-opening the system browser, running a loopback callback
+ * listener, and persisting credentials to the OS keychain. We never read or
+ * write the token ourselves; we only invoke the CLI and re-read its status.
+ */
+import { execFile, spawn } from "node:child_process";
+import { type Readable } from "node:stream";
+import { promisify } from "node:util";
+import { logInfo, logWarn } from "@/logger";
+import { err2String } from "@/utils";
+
+const execFileAsync = promisify(execFile);
+
+/** `claude auth status` is a quick local read; cap it so a wedged CLI can't hang the UI. */
+const STATUS_TIMEOUT_MS = 10_000;
+
+/** First http(s) URL on a line — the OAuth page the CLI prints as a browser fallback. */
+const URL_PATTERN = /\bhttps?:\/\/[^\s'"]+/;
+
+export interface ClaudeAuthStatus {
+  loggedIn: boolean;
+  /** Display string for a signed-in account, e.g. `"zero@x.com (max)"`. */
+  label?: string;
+}
+
+/** Subset of `claude auth status --json` we read. Extra fields are ignored. */
+interface ClaudeAuthStatusJson {
+  loggedIn?: boolean;
+  email?: string;
+  subscriptionType?: string;
+  authMethod?: string;
+  apiProvider?: string;
+}
+
+/**
+ * Parse `claude auth status --json` output into a {@link ClaudeAuthStatus}.
+ * Pure (no I/O) so the detection contract is unit-testable. Any non-JSON or
+ * non-`loggedIn` payload resolves to signed-out.
+ */
+export function parseClaudeAuthStatusOutput(stdout: string): ClaudeAuthStatus {
+  let parsed: ClaudeAuthStatusJson;
+  try {
+    parsed = JSON.parse(stdout) as ClaudeAuthStatusJson;
+  } catch {
+    return { loggedIn: false };
+  }
+  if (parsed.loggedIn !== true) return { loggedIn: false };
+  return { loggedIn: true, label: buildAccountLabel(parsed) };
+}
+
+function buildAccountLabel(s: ClaudeAuthStatusJson): string | undefined {
+  const who = s.email ?? s.apiProvider;
+  const detail = s.subscriptionType ?? s.authMethod;
+  if (who && detail) return `${who} (${detail})`;
+  return who ?? detail;
+}
+
+/**
+ * Probe the CLI's sign-in state. Treats any failure (spawn error, non-JSON
+ * output, timeout) as signed-out so the UI surfaces the recoverable Sign-in CTA
+ * rather than silently assuming auth. A non-zero exit still carries stdout on
+ * some CLI builds, so we parse that before giving up.
+ */
+export async function getClaudeAuthStatus(
+  claudePath: string,
+  env: NodeJS.ProcessEnv
+): Promise<ClaudeAuthStatus> {
+  try {
+    const { stdout } = await execFileAsync(claudePath, ["auth", "status", "--json"], {
+      timeout: STATUS_TIMEOUT_MS,
+      env,
+    });
+    return parseClaudeAuthStatusOutput(stdout);
+  } catch (e) {
+    const stdout = (e as { stdout?: unknown }).stdout;
+    if (typeof stdout === "string" && stdout.trim().length > 0) {
+      return parseClaudeAuthStatusOutput(stdout);
+    }
+    logWarn("[AgentMode] claude auth status failed", err2String(e));
+    return { loggedIn: false };
+  }
+}
+
+export interface SignInHandlers {
+  /** Called once with the OAuth URL the CLI prints (browser-open fallback). */
+  onUrl?: (url: string) => void;
+  /** Called per stdout/stderr line for progress display. */
+  onLine?: (line: string) => void;
+}
+
+export interface ClaudeSignInController {
+  /** Resolves with the post-login status once the CLI exits. Never rejects. */
+  done: Promise<ClaudeAuthStatus>;
+  /** Terminate the login subprocess (SIGTERM) — for teardown. */
+  cancel: () => void;
+}
+
+/**
+ * Run `claude auth login`. The CLI opens the system browser itself and runs a
+ * loopback callback listener; we stream its output (so callers can show the
+ * printed URL as a clickable fallback) and, on exit, re-read `auth status` as
+ * the source of truth. stdin is closed so a CLI build that would otherwise wait
+ * for a pasted code fails fast instead of hanging.
+ */
+export function signInToClaude(
+  claudePath: string,
+  env: NodeJS.ProcessEnv,
+  handlers: SignInHandlers = {}
+): ClaudeSignInController {
+  logInfo("[AgentMode] spawning claude auth login");
+  const child = spawn(claudePath, ["auth", "login", "--claudeai"], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  let urlSeen = false;
+  const handleLine = (line: string): void => {
+    handlers.onLine?.(line);
+    if (urlSeen) return;
+    const match = URL_PATTERN.exec(line);
+    if (match) {
+      urlSeen = true;
+      handlers.onUrl?.(match[0]);
+    }
+  };
+  attachLineReader(child.stdout, handleLine);
+  attachLineReader(child.stderr, handleLine);
+
+  const done = new Promise<ClaudeAuthStatus>((resolve) => {
+    child.on("error", (err) => {
+      logWarn("[AgentMode] claude auth login spawn error", err2String(err));
+      resolve({ loggedIn: false });
+    });
+    child.on("close", () => {
+      void getClaudeAuthStatus(claudePath, env).then(resolve, () => resolve({ loggedIn: false }));
+    });
+  });
+
+  return {
+    done,
+    cancel: () => {
+      try {
+        child.kill("SIGTERM");
+      } catch (e) {
+        logWarn("[AgentMode] claude auth login kill failed", err2String(e));
+      }
+    },
+  };
+}
+
+/** Emit complete (newline-delimited) lines from a piped child stream. */
+function attachLineReader(stream: Readable | null, onLine: (line: string) => void): void {
+  if (!stream) return;
+  stream.setEncoding("utf8");
+  let buffer = "";
+  stream.on("data", (chunk: string) => {
+    buffer += chunk;
+    let idx = buffer.indexOf("\n");
+    while (idx >= 0) {
+      const line = buffer.slice(0, idx).replace(/\r$/, "");
+      buffer = buffer.slice(idx + 1);
+      if (line.length > 0) onLine(line);
+      idx = buffer.indexOf("\n");
+    }
+  });
+  stream.on("end", () => {
+    const rest = buffer.trim();
+    if (rest.length > 0) onLine(rest);
+  });
+}

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -13,6 +13,7 @@ import {
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { MethodUnsupportedError } from "@/agentMode/session/errors";
 import { resolveClaudeBinary } from "./claudeBinaryResolver";
+import { getClaudeAuthStatus, signInToClaude } from "./claudeAuth";
 import { agentOriginEnabledModelEntries } from "@/agentMode/backends/shared/agentEnabledModels";
 import { ClaudeSdkBackendProcess } from "@/agentMode/sdk/ClaudeSdkBackendProcess";
 import { getCachedSdkCatalog, synthesizeEffortConfigOption } from "@/agentMode/sdk/effortOption";
@@ -73,6 +74,18 @@ function claudeResolverEnv(): Omit<Parameters<typeof resolveClaudeBinary>[0], "o
       readdirSync: (p) => fs.readdirSync(p),
     },
   };
+}
+
+/**
+ * Environment for spawning the `claude` CLI for auth checks: `process.env`
+ * plus the user's Claude env overrides. Mirrors how `prompt()` composes env so
+ * `claude auth status` resolves the same credentials the SDK turn would.
+ */
+function claudeChildEnv(settings: CopilotSettings): NodeJS.ProcessEnv {
+  const overrides = settings.agentMode?.backends?.claude?.envOverrides;
+  return overrides && Object.keys(overrides).length > 0
+    ? { ...process.env, ...overrides }
+    : process.env;
 }
 
 /**
@@ -165,6 +178,21 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
     new ClaudeInstallModal(plugin.app).open();
   },
 
+  auth: {
+    async getStatus(settings) {
+      const claudePath = resolveClaudeCliPath(settings);
+      if (!claudePath) return { signedIn: false };
+      const status = await getClaudeAuthStatus(claudePath, claudeChildEnv(settings));
+      return { signedIn: status.loggedIn, label: status.label };
+    },
+    async signIn(settings, handlers) {
+      const claudePath = resolveClaudeCliPath(settings);
+      if (!claudePath) return { signedIn: false };
+      const status = await signInToClaude(claudePath, claudeChildEnv(settings), handlers).done;
+      return { signedIn: status.loggedIn, label: status.label };
+    },
+  },
+
   isPlanModePlanFilePath(absolutePath: string): boolean {
     return isClaudePlanModePlanFilePath(absolutePath);
   },
@@ -204,6 +232,8 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
       askUserQuestion: (questions) => openAskUserQuestionModal(args.app, questions),
       getEnableThinking: () => Boolean(getSettings().agentMode?.backends?.claude?.enableThinking),
       getEnvOverrides: () => getSettings().agentMode?.backends?.claude?.envOverrides,
+      checkAuth: async () =>
+        (await getClaudeAuthStatus(claudePath, claudeChildEnv(getSettings()))).loggedIn,
       isPlanModePlanFilePath: isClaudePlanModePlanFilePath,
       getDefaultModelId: () => getSettings().agentMode?.backends?.claude?.defaultModel?.baseModelId,
       // Forward the shared composed system prompt — the Copilot base framing

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -53,6 +53,7 @@ jest.mock("./effortOption", () => ({
 
 import { ClaudeSdkBackendProcess, promptInputToAnthropicContent } from "./ClaudeSdkBackendProcess";
 import { getCachedSdkCatalog } from "./effortOption";
+import { AuthRequiredError } from "@/agentMode/session/errors";
 
 beforeEach(() => {
   (getCachedSdkCatalog as jest.Mock).mockReturnValue(FAKE_CATALOG);
@@ -506,5 +507,90 @@ describe("ClaudeSdkBackendProcess.newSession dynamic catalog", () => {
     expect(promptCalls).toHaveLength(1);
     const call = promptCalls[0][0] as { options: { effort?: string } };
     expect(call.options.effort).toBe("high");
+  });
+});
+
+function errorResultMessage(errors: string[]): SDKMessage {
+  return {
+    type: "result",
+    subtype: "error_during_execution",
+    duration_ms: 1,
+    duration_api_ms: 1,
+    is_error: true,
+    num_turns: 1,
+    stop_reason: null,
+    total_cost_usd: 0,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    usage: {} as any,
+    modelUsage: {},
+    permission_denials: [],
+    errors,
+    uuid: "uuid-e" as `${string}-${string}-${string}-${string}-${string}`,
+    session_id: "irrelevant",
+  };
+}
+
+describe("ClaudeSdkBackendProcess.prompt auth gate", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    createSdkMcpServerMock.mockClear();
+  });
+
+  function makeProc(checkAuth: jest.Mock) {
+    return new ClaudeSdkBackendProcess({
+      pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: { vault: {} } as any,
+      clientVersion: "1.2.3",
+      descriptor: fakeDescriptor(),
+      checkAuth,
+    });
+  }
+
+  it("rejects with AuthRequiredError and never spawns query when not signed in", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const checkAuth = jest.fn().mockResolvedValue(false);
+    const proc = makeProc(checkAuth);
+
+    const { sessionId } = await proc.newSession({ cwd: "/vault", mcpServers: [] });
+    proc.registerSessionHandler(sessionId, () => {});
+
+    await expect(
+      proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+    ).rejects.toBeInstanceOf(AuthRequiredError);
+    expect(getPromptQueryCalls()).toHaveLength(0);
+  });
+
+  it("checks auth only once across turns once signed in (cached)", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const checkAuth = jest.fn().mockResolvedValue(true);
+    const proc = makeProc(checkAuth);
+
+    const { sessionId } = await proc.newSession({ cwd: "/vault", mcpServers: [] });
+    proc.registerSessionHandler(sessionId, () => {});
+
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "1" }] });
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "2" }] });
+
+    expect(checkAuth).toHaveBeenCalledTimes(1);
+    expect(getPromptQueryCalls()).toHaveLength(2);
+  });
+
+  it("re-checks auth on the next turn when a turn ends non-success with no errors", async () => {
+    const checkAuth = jest.fn().mockResolvedValue(true);
+    const proc = makeProc(checkAuth);
+
+    const { sessionId } = await proc.newSession({ cwd: "/vault", mcpServers: [] });
+    proc.registerSessionHandler(sessionId, () => {});
+
+    // First turn ends with a non-success result carrying no error detail
+    // (the "saved login expired" shape) → cache is invalidated.
+    queryMock.mockImplementationOnce(() => makeQuery([errorResultMessage([])]));
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "1" }] });
+    expect(checkAuth).toHaveBeenCalledTimes(1);
+
+    queryMock.mockImplementationOnce(() => makeQuery([resultMessage()]));
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "2" }] });
+    expect(checkAuth).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -50,7 +50,7 @@ import type {
   SessionUpdateHandler,
   StopReason,
 } from "@/agentMode/session/types";
-import { MethodUnsupportedError } from "@/agentMode/session/errors";
+import { AuthRequiredError, MethodUnsupportedError } from "@/agentMode/session/errors";
 import { createTranslatorState, mapStopReason, translateSdkMessage } from "./sdkMessageTranslator";
 import { PermissionBridge, type AskUserQuestionHandler } from "./permissionBridge";
 import {
@@ -133,6 +133,14 @@ export interface ClaudeSdkBackendProcessOptions {
    * CLI. Read per `prompt()` so settings edits apply on the next turn.
    */
   getEnvOverrides?: () => Record<string, string> | undefined;
+  /**
+   * Resolve whether the `claude` CLI is signed in (OAuth login or env-based
+   * credentials). Consulted once before the first prompt; an unauthenticated
+   * result makes `prompt()` reject with `AuthRequiredError` instead of
+   * silently resolving with an empty turn. The result is cached until a turn
+   * ends without output, which forces a re-check (covers mid-session expiry).
+   */
+  checkAuth?: () => Promise<boolean>;
 }
 
 /**
@@ -165,6 +173,11 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
    */
   private cachedModels: ModelInfo[] | null = null;
   private cachedModelsProbe: Promise<ModelInfo[]> | null = null;
+  /**
+   * Cleared whenever a turn ends without output so the next prompt re-checks
+   * sign-in state; set true once `checkAuth` confirms the CLI is signed in.
+   */
+  private authConfirmed = false;
 
   constructor(private readonly opts: ClaudeSdkBackendProcessOptions) {
     this.bridge = new PermissionBridge({
@@ -247,6 +260,21 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     const session = this.sessions.get(params.sessionId);
     if (!session) {
       throw new Error(`Unknown session ${params.sessionId}`);
+    }
+
+    // Deterministic sign-in gate. Without it, an unauthenticated CLI yields a
+    // non-success result with an empty `errors` array, which maps to
+    // `stopReason: "cancelled"` and slips past `runTurn`'s empty-turn net —
+    // leaving an empty assistant bubble and no error. Checked once per backend
+    // lifetime (cached) so signed-in turns pay nothing.
+    if (this.opts.checkAuth && !this.authConfirmed) {
+      if (await this.opts.checkAuth()) {
+        this.authConfirmed = true;
+      } else {
+        throw new AuthRequiredError(
+          "You're not signed in to Claude. Use the Sign in button above the chat box to continue."
+        );
+      }
     }
 
     // Streaming-input mode (AsyncIterable) is required to expose
@@ -333,6 +361,11 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
             const errs = "errors" in sdkMsg ? sdkMsg.errors : undefined;
             if (errs && errs.length > 0) {
               resultErrorMessage = errs.join("; ");
+            } else {
+              // Non-success with no error detail can mean the saved login
+              // expired mid-session. Force the next prompt to re-verify auth
+              // rather than trusting the cached "signed in" flag.
+              this.authConfirmed = false;
             }
           }
           break;

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -1,7 +1,7 @@
 import { AI_SENDER, USER_SENDER } from "@/constants";
 import type { TFile } from "obsidian";
 import { AgentSession, buildPromptBlocks, tryReadExitPlanModeCall } from "./AgentSession";
-import { MethodUnsupportedError } from "./errors";
+import { AuthRequiredError, MethodUnsupportedError } from "./errors";
 import type {
   BackendDescriptor,
   BackendProcess,
@@ -295,6 +295,24 @@ describe("AgentSession.sendPrompt", () => {
     expect(placeholder?.isErrorMessage).toBe(true);
     expect(placeholder?.message).toContain("FreeUsageLimitError");
     expect(placeholder?.message).toContain("Rate limit exceeded");
+  });
+
+  it("renders a visible error (not an empty bubble) when the backend reports auth required", async () => {
+    const mock = makeMockBackend();
+    mock.prompt.mockRejectedValueOnce(new AuthRequiredError("You're not signed in to Claude."));
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "claude",
+    });
+
+    await expect(session.sendPrompt("hi").turn).rejects.toBeInstanceOf(AuthRequiredError);
+
+    const placeholder = session.store.getDisplayMessages().find((m) => m.sender === AI_SENDER);
+    expect(placeholder?.isErrorMessage).toBe(true);
+    expect(placeholder?.message).toContain("not signed in to Claude");
+    expect(session.getStatus()).toBe("error");
   });
 
   it("agent_message_chunk is appended to placeholder displayText", async () => {

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -20,6 +20,33 @@ export type InstallState =
   | { kind: "ready"; source: "managed" | "custom" }
   | { kind: "error"; message: string };
 
+/** Sign-in state for backends that authenticate via a CLI / external account. */
+export interface BackendAuthStatus {
+  signedIn: boolean;
+  /** Display string for a signed-in account, e.g. `"zero@x.com (max)"`. */
+  label?: string;
+}
+
+/** Progress callbacks for an interactive sign-in flow. */
+export interface BackendSignInHandlers {
+  /** The OAuth URL to surface as a clickable browser-open fallback. */
+  onUrl?: (url: string) => void;
+  /** Per-line progress from the sign-in subprocess. */
+  onLine?: (line: string) => void;
+}
+
+/**
+ * Optional auth capability. Backends whose readiness depends on an external
+ * sign-in (the Claude CLI's login state) implement this so generic `ui/` can
+ * surface a "Sign in" CTA without knowing the backend's auth mechanism.
+ */
+export interface BackendAuth {
+  /** Probe current sign-in state (may spawn the CLI). */
+  getStatus(settings: CopilotSettings): Promise<BackendAuthStatus>;
+  /** Run the interactive sign-in flow; resolves with the post-login state. */
+  signIn(settings: CopilotSettings, handlers?: BackendSignInHandlers): Promise<BackendAuthStatus>;
+}
+
 /**
  * Backend-agnostic descriptor consumed by `session/` and `ui/`. Each backend
  * exports one of these from its own folder; the registry maps `BackendId →
@@ -118,6 +145,14 @@ export interface BackendDescriptor {
 
   /** Open backend-specific install/setup modal. */
   openInstallUI(plugin: CopilotPlugin): void;
+
+  /**
+   * Optional: sign-in capability for backends gated on an external account
+   * (e.g. the Claude CLI's login state). When present, generic UI surfaces a
+   * "Sign in" CTA while signed-out. Absent backends are assumed always-ready
+   * once installed.
+   */
+  auth?: BackendAuth;
 
   /**
    * Construct the backend process the session manager will drive. ACP-style

--- a/src/agentMode/session/errors.ts
+++ b/src/agentMode/session/errors.ts
@@ -19,5 +19,21 @@ export class MethodUnsupportedError extends Error {
   }
 }
 
+/**
+ * Thrown by a backend's `prompt()` when it determines the agent is not signed
+ * in (e.g. the Claude CLI has no saved login and no env-based credentials).
+ * `runTurn` catches it like any prompt failure — replacing the empty
+ * placeholder with a visible error and ending the session in `"error"` — while
+ * the actionable "Sign in" CTA is surfaced separately by the status pill. A
+ * distinct type (rather than a bare `Error`) lets callers and tests recognize
+ * the recoverable auth case deterministically.
+ */
+export class AuthRequiredError extends Error {
+  constructor(message = "Not signed in. Use the Sign in button above to continue.") {
+    super(message);
+    this.name = "AuthRequiredError";
+  }
+}
+
 /** JSON-RPC standard "Method not found" error code. */
 export const JSONRPC_METHOD_NOT_FOUND = -32601;

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -1,7 +1,13 @@
 import type React from "react";
 import type { FormattedDateTime, MessageContext } from "@/types/message";
 
-export type { BackendDescriptor, InstallState } from "./descriptor";
+export type {
+  BackendAuth,
+  BackendAuthStatus,
+  BackendDescriptor,
+  BackendSignInHandlers,
+  InstallState,
+} from "./descriptor";
 export type { CurrentPlan, PlanDecisionAction, PlanProposalDecision } from "./plan";
 
 /** Stable identifier for a registered backend. New backends extend the registry; the type stays open. */

--- a/src/agentMode/ui/AgentModeStatus.tsx
+++ b/src/agentMode/ui/AgentModeStatus.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import {
+  useBackendAuthState,
   useBackendInstallState,
   useSessionBackendDescriptor,
 } from "@/agentMode/ui/useBackendDescriptor";
@@ -23,6 +24,7 @@ interface Props {
 export const AgentModeStatus: React.FC<Props> = ({ manager, onInstallClick }) => {
   const descriptor = useSessionBackendDescriptor(manager);
   const installState = useBackendInstallState(descriptor);
+  const auth = useBackendAuthState(descriptor);
 
   // Re-render on manager notify so `lastError` flips are picked up.
   const [, setTick] = React.useState(0);
@@ -38,6 +40,33 @@ export const AgentModeStatus: React.FC<Props> = ({ manager, onInstallClick }) =>
         <Button variant="default" size="sm" onClick={onInstallClick}>
           Install {descriptor.displayName}
         </Button>
+      </div>
+    );
+  }
+
+  // Installed but the CLI isn't signed in: surface a recoverable Sign-in CTA
+  // instead of letting a sent chat fail silently. While signing in, the CLI
+  // opens the browser itself; we show its printed URL as a clickable fallback.
+  if (descriptor.auth && auth.status && !auth.status.signedIn) {
+    return (
+      <div className="tw-flex tw-items-center tw-justify-between tw-rounded tw-bg-secondary tw-px-3 tw-py-2 tw-text-xs">
+        {auth.signingIn ? (
+          <>
+            <span className="tw-text-muted">Signing in to {descriptor.displayName}…</span>
+            {auth.url && (
+              <a href={auth.url} target="_blank" rel="noopener noreferrer">
+                Open sign-in page
+              </a>
+            )}
+          </>
+        ) : (
+          <>
+            <span className="tw-text-muted">{descriptor.displayName} not signed in</span>
+            <Button variant="default" size="sm" onClick={auth.signIn}>
+              Sign in to {descriptor.displayName}
+            </Button>
+          </>
+        )}
       </div>
     );
   }

--- a/src/agentMode/ui/useBackendDescriptor.ts
+++ b/src/agentMode/ui/useBackendDescriptor.ts
@@ -1,7 +1,9 @@
 import { backendRegistry, getActiveBackendDescriptor } from "@/agentMode/backends/registry";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
-import type { BackendDescriptor, InstallState } from "@/agentMode/session/types";
+import type { BackendAuthStatus, BackendDescriptor, InstallState } from "@/agentMode/session/types";
+import { logError } from "@/logger";
 import { useSettingsValue } from "@/settings/model";
+import { Notice } from "obsidian";
 import React from "react";
 
 /** Resolve the active (default) backend descriptor from settings. */
@@ -40,4 +42,82 @@ export function useSessionBackendDescriptor(
 /** Compute the descriptor's current install state. Recomputes each render. */
 export function useBackendInstallState(descriptor: BackendDescriptor): InstallState {
   return descriptor.getInstallState(useSettingsValue());
+}
+
+export interface BackendAuthUiState {
+  /**
+   * Latest sign-in state, or `null` while the initial probe is in flight or
+   * when the backend has no `auth` capability. Consumers should render the
+   * Sign-in CTA only when `status?.signedIn === false`.
+   */
+  status: BackendAuthStatus | null;
+  /** True while an interactive sign-in is running. */
+  signingIn: boolean;
+  /** OAuth fallback URL to surface as a clickable link while signing in. */
+  url: string | null;
+  /** Start the interactive sign-in flow (no-op if already running). */
+  signIn: () => void;
+}
+
+/**
+ * Probe and drive a backend's sign-in state for the status pill. Checks once on
+ * mount (proactive — a signed-out backend shows the CTA before the user types)
+ * and again after a sign-in completes; reports start/result via `Notice`.
+ * Backends without an `auth` capability always report `status: null`.
+ */
+export function useBackendAuthState(descriptor: BackendDescriptor): BackendAuthUiState {
+  const settings = useSettingsValue();
+  // Latest settings without making the mount probe re-fire on unrelated edits.
+  const settingsRef = React.useRef(settings);
+  settingsRef.current = settings;
+
+  const auth = descriptor.auth;
+  const [status, setStatus] = React.useState<BackendAuthStatus | null>(null);
+  const [signingIn, setSigningIn] = React.useState(false);
+  const [url, setUrl] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!auth) {
+      setStatus(null);
+      return;
+    }
+    let cancelled = false;
+    void auth.getStatus(settingsRef.current).then(
+      (s) => !cancelled && setStatus(s),
+      (e) => {
+        logError("[AgentMode] auth status probe failed", e);
+        if (!cancelled) setStatus({ signedIn: false });
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [auth]);
+
+  const signIn = React.useCallback(() => {
+    if (!auth || signingIn) return;
+    setSigningIn(true);
+    setUrl(null);
+    new Notice(`Opening your browser to sign in to ${descriptor.displayName}…`);
+    auth
+      .signIn(settingsRef.current, { onUrl: (u) => setUrl(u) })
+      .then((s) => {
+        setStatus(s);
+        new Notice(
+          s.signedIn
+            ? `Signed in to ${descriptor.displayName}${s.label ? ` as ${s.label}` : ""}.`
+            : `Sign-in didn't complete. Please try again.`
+        );
+      })
+      .catch((e) => {
+        logError("[AgentMode] sign-in failed", e);
+        new Notice(`Sign-in to ${descriptor.displayName} failed. Please try again.`);
+      })
+      .finally(() => {
+        setSigningIn(false);
+        setUrl(null);
+      });
+  }, [auth, signingIn, descriptor.displayName]);
+
+  return { status, signingIn, url, signIn };
 }


### PR DESCRIPTION
Fixes the silent login failure ([logancyang/obsidian-copilot-preview#65](https://github.com/logancyang/obsidian-copilot-preview/issues/65)): when the `claude` CLI is signed out, sending an Agent Mode chat previously resolved with an empty assistant bubble and no error. The Claude adapter now gates `prompt()` on a deterministic `claude auth status --json` check (cached, reflects OAuth login *and* env-based credentials), throwing a typed `AuthRequiredError` so the turn surfaces a visible error instead of failing silently. The chat status pill gains a recoverable "Sign in to Claude" CTA that runs `claude auth login` — the CLI opens the system browser itself and we surface its printed URL as a clickable fallback, reporting results via Notices. The work adds an optional backend-agnostic `auth` capability to `BackendDescriptor`, a `claudeAuth.ts` helper, and a `useBackendAuthState` hook, keeping all Claude-specific logic in `backends/claude/`. Includes unit tests for the status parser, the adapter auth gate, and the session error rendering; `format`, `lint`, `tsc`, and the full suite (3336 tests) pass.