### PR TITLE
Isolate agent backend init failures from plugin onload/onunload crashes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -97,6 +97,7 @@ import {
   Platform,
   Plugin,
   TFile,
+  ViewCreator,
   WorkspaceLeaf,
 } from "obsidian";
 import { ChatHistoryItem } from "@/components/chat-components/ChatHistoryPopover";
@@ -290,14 +291,17 @@ export default class CopilotPlugin extends Plugin {
       this.registerEvent(layoutRef);
     }
 
-    this.registerView(CHAT_VIEWTYPE, (leaf: WorkspaceLeaf) => new CopilotView(leaf, this));
-    this.registerView(APPLY_VIEW_TYPE, (leaf: WorkspaceLeaf) => new ApplyView(leaf));
+    this.safeRegisterView(CHAT_VIEWTYPE, (leaf: WorkspaceLeaf) => new CopilotView(leaf, this));
+    this.safeRegisterView(APPLY_VIEW_TYPE, (leaf: WorkspaceLeaf) => new ApplyView(leaf));
     if (!Platform.isMobile) {
-      this.registerView(
+      this.safeRegisterView(
         CHAT_AGENT_VIEWTYPE,
         (leaf: WorkspaceLeaf) => new CopilotAgentView(leaf, this)
       );
-      this.registerView(PLAN_PREVIEW_VIEW_TYPE, (leaf: WorkspaceLeaf) => new PlanPreviewView(leaf));
+      this.safeRegisterView(
+        PLAN_PREVIEW_VIEW_TYPE,
+        (leaf: WorkspaceLeaf) => new PlanPreviewView(leaf)
+      );
     }
 
     this.initActiveLeafChangeHandler();
@@ -375,6 +379,23 @@ export default class CopilotPlugin extends Plugin {
     this.initWebSelectionWatcher();
   }
 
+  /**
+   * Register a view, tolerating a type that is already registered. Obsidian
+   * throws "Attempting to register an existing view type" when a prior plugin
+   * lifecycle left a stale registration behind (e.g. an `onunload` that threw
+   * before its teardown completed). Swallowing here keeps one stale view type
+   * from aborting the rest of `onload` and leaving a half-initialized plugin
+   * that then crashes on `onunload`. The null-safe `onunload` below is the
+   * primary fix that prevents the stale state; this is defense-in-depth.
+   */
+  private safeRegisterView(type: string, viewCreator: ViewCreator): void {
+    try {
+      this.registerView(type, viewCreator);
+    } catch (error) {
+      logWarn(`Copilot: view type "${type}" already registered; skipping re-registration.`, error);
+    }
+  }
+
   async onunload() {
     // Best-effort flush of pending keychain/data.json writes.
     // Reason: onunload() is void in Obsidian's type system, but awaiting here
@@ -402,9 +423,13 @@ export default class CopilotPlugin extends Plugin {
     const vaultDataManager = VaultDataManager.getInstance();
     vaultDataManager.cleanup();
 
-    this.customCommandRegister.cleanup();
-    this.systemPromptRegister.cleanup();
-    this.projectRegister.cleanup();
+    // Optional-chained because `onload` assigns these late: if it threw before
+    // reaching their construction, the fields are undefined at unload time and
+    // an unguarded `.cleanup()` would throw `Cannot read properties of
+    // undefined`, aborting the rest of teardown.
+    this.customCommandRegister?.cleanup();
+    this.systemPromptRegister?.cleanup();
+    this.projectRegister?.cleanup();
     this.settingsUnsubscriber?.();
 
     // Tear down skills vault watchers + debounce timers.


### PR DESCRIPTION
## Summary

Fixes the crash cascade in https://github.com/logancyang/obsidian-copilot-preview/issues/101 where a single misconfigured agent backend (e.g. codex `.cmd` spawn `EINVAL` on Windows) took down the entire plugin: `onload` failed, then `onunload` threw again.

The root trigger (codex-acp `.cmd` spawn) is out of scope and tracked separately. This PR fixes the **robustness gaps that let one backend failure cascade**.

## Changes

- **`onunload` tolerates partial init.** `customCommandRegister`, `systemPromptRegister`, and `projectRegister` are assigned late in `onload`. If `onload` threw before constructing them, they were `undefined` and the unguarded `.cleanup()` threw `Cannot read properties of undefined`, aborting the rest of teardown (and leaving views registered). Now optional-chained, matching the `?.` / `if`-guard style already used for the other fields in `onunload`.
- **`registerView` no longer aborts `onload`.** A stale registration from a prior partial unload made `registerView` throw "Attempting to register an existing view type", which aborted `onload` mid-way and re-entered the cascade. The four registrations now go through a `safeRegisterView` helper that logs and continues. Fixing the unload path is the primary fix that prevents the stale state; this is defense-in-depth.

## Already handled (no change needed)

Gap 1 from the issue — backend preload failures must be caught and surfaced, not abort `onload` — is already satisfied in current code:
- `AgentModelPreloader.runProbe` wraps `proc.start()` + initial-state fetch in a try/catch and logs `preload <id> failed`.
- `AgentSessionManager.registerPreload` consumes the rejection and records a `"error"` status surfaced to the picker via `getPreloadStatus`.
- The preload is fire-and-forget (`createAgentSessionManager` returns synchronously; `onload` does not await it).

## Testing

- `npm run format` — clean
- `npm run lint` — clean
- `npm run build` — `tsc -noEmit` + esbuild succeed
- `npm run test` — 3346/3346 passing

`main.ts` has no unit-test harness (its import chain pulls in the full plugin runtime + Obsidian, which can't be loaded under Jest), so these two lifecycle fixes are validated by typecheck/build/lint and the full regression suite rather than a dedicated unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
