### PR TITLE
Apply agent binary-path and install changes without a plugin reload

### DIFF
--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -119,7 +119,15 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
 
   subscribeInstallState(_plugin: CopilotPlugin, cb: () => void): () => void {
     return subscribeToSettingsChange((prev, next) => {
-      if (prev.agentMode?.backends?.opencode !== next.agentMode?.backends?.opencode) {
+      const p = prev.agentMode?.backends?.opencode;
+      const n = next.agentMode?.backends?.opencode;
+      // Only the binary/install fields affect install state; model selection
+      // and probe-session writes on the same object must not trigger a restart.
+      if (
+        p?.binaryPath !== n?.binaryPath ||
+        p?.binaryVersion !== n?.binaryVersion ||
+        p?.binarySource !== n?.binarySource
+      ) {
         cb();
       }
     });

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -220,6 +220,20 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
       restartSystemPromptAffected();
     }
   });
+  // A backend's binary path (or a binary install/update) is resolved at spawn
+  // time, so a change must reach the running/warm process — otherwise it only
+  // updates the settings status line and the agent keeps the old binary until
+  // a plugin reload. Each descriptor's `subscribeInstallState` already fires
+  // only on its own path/install field, so this won't churn on unrelated saves.
+  for (const descriptor of listBackendDescriptors()) {
+    descriptor.subscribeInstallState(plugin, () => {
+      void manager
+        .onInstallStateChanged(descriptor.id)
+        .catch((error) =>
+          logError(`[AgentMode] install-state refresh failed: ${descriptor.id}`, error)
+        );
+    });
+  }
   void skillManager.refresh().catch((error) => {
     logError("[Skills] Initial discovery pass failed", error);
   });

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -137,7 +137,10 @@ function buildDescriptor(): BackendDescriptor {
   return {
     id: "opencode",
     displayName: "opencode",
-    getInstallState: jest.fn(),
+    // Default to installed: a manager that owns a running backend is, in
+    // production, always operating on an installed one. Tests that exercise
+    // the uninstalled path override this per-case.
+    getInstallState: jest.fn(() => ({ kind: "ready" })),
     subscribeInstallState: jest.fn(),
     openInstallUI: jest.fn(),
     createBackendProcess: jest.fn(() => makeMockBackendProcess()),
@@ -1067,6 +1070,103 @@ describe("AgentSessionManager.applySelection", () => {
     ).rejects.toThrow("nope");
     // No persistence after a failed apply.
     expect(readPersistedDefault(mockedSetSettings as jest.Mock, "opencode")).toBeUndefined();
+  });
+});
+
+describe("AgentSessionManager.onInstallStateChanged", () => {
+  // Builds a manager whose install state is mutable mid-test (mirrors a user
+  // applying/clearing a binary path) and exposes the preloader spies.
+  function buildInstallStateManager(opts: {
+    installed: boolean;
+    cachedState?: unknown;
+    refreshResult?: Promise<void> | null;
+  }) {
+    let installed = opts.installed;
+    const preloader = {
+      getCachedBackendState: jest.fn(() => opts.cachedState ?? null),
+      preload: jest.fn(async () => undefined),
+      refresh: jest.fn(() => opts.refreshResult ?? null),
+      subscribe: jest.fn(() => () => {}),
+      shutdown: jest.fn(),
+      setCached: jest.fn(),
+      clearCached: jest.fn(),
+      takeWarm: jest.fn(() => null),
+    };
+    const descriptor = {
+      ...buildDescriptor(),
+      getInstallState: jest.fn(() => ({ kind: installed ? "ready" : "absent" })),
+    } as unknown as BackendDescriptor;
+    const mgr = new AgentSessionManager(
+      buildApp(),
+      buildPlugin() as unknown as ConstructorParameters<typeof AgentSessionManager>[1],
+      {
+        permissionPrompter: jest.fn(),
+        resolveDescriptor: (id) => (id === descriptor.id ? descriptor : undefined),
+        modelPreloader: preloader as unknown as ConstructorParameters<
+          typeof AgentSessionManager
+        >[2]["modelPreloader"],
+      }
+    );
+    return { mgr, preloader, setInstalled: (v: boolean) => (installed = v) };
+  }
+
+  it("preloads a freshly-installed backend that was never probed", async () => {
+    // Newly installed: nothing warm, nothing live. `restartBackend` returns
+    // false, so the manager must kick a first preload — without it the picker
+    // would stay empty until a plugin reload.
+    const { mgr, preloader } = buildInstallStateManager({ installed: true });
+
+    await mgr.onInstallStateChanged("opencode");
+
+    expect(preloader.preload).toHaveBeenCalledWith("opencode");
+    expect(preloader.clearCached).not.toHaveBeenCalled();
+    expect(mockBackendShutdown).not.toHaveBeenCalled();
+  });
+
+  it("refreshes a warm probe against the new binary without a fresh preload", async () => {
+    // A warm probe (from load-time preload) carries the old binary; re-probe
+    // it rather than spinning up a second one.
+    const { mgr, preloader } = buildInstallStateManager({
+      installed: true,
+      cachedState: { model: null, mode: null },
+      refreshResult: Promise.resolve(),
+    });
+
+    await mgr.onInstallStateChanged("opencode");
+
+    expect(preloader.refresh).toHaveBeenCalledWith("opencode");
+    expect(preloader.preload).not.toHaveBeenCalled();
+  });
+
+  it("restarts a live backend against the new binary", async () => {
+    const { mgr, preloader } = buildInstallStateManager({ installed: true });
+    await mgr.createSession();
+    mockBackendShutdown.mockClear();
+    preloader.preload.mockClear();
+
+    await mgr.onInstallStateChanged("opencode");
+
+    // The old proc is torn down (re-probe). No standalone preload — the restart
+    // path repopulates the cache itself.
+    expect(mockBackendShutdown).toHaveBeenCalled();
+    expect(preloader.preload).not.toHaveBeenCalled();
+  });
+
+  it("tears down and drops the warm probe when the binary is no longer available", async () => {
+    const { mgr, preloader, setInstalled } = buildInstallStateManager({ installed: true });
+    await mgr.createSession();
+    mockBackendShutdown.mockClear();
+    sessionCreateSpy.mockClear();
+
+    // Path cleared / binary removed.
+    setInstalled(false);
+    await mgr.onInstallStateChanged("opencode");
+
+    expect(mockBackendShutdown).toHaveBeenCalled();
+    // No replacement session is spawned for an uninstalled backend.
+    expect(sessionCreateSpy).not.toHaveBeenCalled();
+    expect(preloader.clearCached).toHaveBeenCalledWith("opencode");
+    expect(preloader.preload).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -444,6 +444,44 @@ export class AgentSessionManager {
   }
 
   /**
+   * React to a backend's install state changing at runtime — a binary path
+   * applied/cleared, or a binary installed/updated from the Configure dialog.
+   * Without this, the change only re-renders the settings status line: the
+   * running or warm process keeps the old binary, and a backend installed
+   * after plugin load is never spawned, so the user has to reload the plugin.
+   *
+   * Three transitions, all reusing the existing restart/refresh coalescing so
+   * a burst of edits folds into one re-probe:
+   *   - now uninstalled → tear down any live proc and drop the warm probe so
+   *     the picker stops offering a backend that can no longer spawn;
+   *   - installed with a live/warm process → restart/refresh it against the
+   *     new binary;
+   *   - installed but never probed (freshly installed) → kick a first preload
+   *     (`restartBackend` returns `false` here, since nothing is warm yet).
+   *
+   * The fresh-preload case is unique to this signal: the load-time preload
+   * loop skips backends that aren't installed yet, so install-state is the
+   * only event that can flip a backend from "never preloaded" into "should
+   * preload". The provider/system-prompt restart subscriptions always act on
+   * an already-installed (already-preloaded) backend, so they only ever need
+   * `restartBackend`'s restart/refresh — never a first preload.
+   */
+  async onInstallStateChanged(backendId: BackendId): Promise<void> {
+    if (this.disposed) return;
+    if (!this.isBackendInstalled(backendId)) {
+      // Tears down a live proc (the install guard in `restartBackendNow` keeps
+      // it from respawning); `clearCached` then drops any warm probe.
+      await this.restartBackend(backendId, "binary no longer available");
+      this.preloader.clearCached(backendId);
+      return;
+    }
+    const refreshed = await this.restartBackend(backendId, "binary path changed");
+    if (!refreshed) {
+      this.registerPreload(backendId, this.preloader.preload(backendId));
+    }
+  }
+
+  /**
    * Refresh a preloader warm probe when the manager owns no process yet.
    * Spawn-time config (provider keys, enabled models, native skills, system
    * prompt) is baked into the warm probe when it spawns, so a config change
@@ -1211,8 +1249,15 @@ export class AgentSessionManager {
     logInfo(`[AgentMode] restarting ${backendId} backend: ${reason}`);
     try {
       const affected = Array.from(this.sessions.values()).filter((s) => s.backendId === backendId);
+      // Don't respawn a replacement for a backend that is no longer installed
+      // (e.g. its custom path was just cleared) — the spawn would fail. The
+      // affected sessions are still closed; the tab falls back to its
+      // needs-setup state. `restartBackendNow` is otherwise only reached for an
+      // installed backend, so this is a no-op for the normal restart path.
       const shouldCreateReplacement =
-        affected.length > 0 && affected.some((s) => s.internalId === this.activeSessionId);
+        this.isBackendInstalled(backendId) &&
+        affected.length > 0 &&
+        affected.some((s) => s.internalId === this.activeSessionId);
       for (const session of affected) {
         await this.closeSession(session.internalId);
       }


### PR DESCRIPTION
## Summary

Fixes https://github.com/logancyang/obsidian-copilot-preview/issues/102.

Applying a backend binary path in Agent Mode settings (or installing/updating a binary from the Configure dialog) only re-rendered the settings status line. The running/warm backend process kept the **old** binary, and a backend installed *after* plugin load was never spawned at all — so users had to toggle the plugin off/on for changes to take effect.

## Root cause

- The per-backend preload loop in `src/agentMode/index.ts` runs once at `onload` and skips any backend that isn't `ready` at that instant.
- Nothing in the session layer reacted to install-state changes: `descriptor.subscribeInstallState` had **no non-test callers**. The settings UI just re-derives its status line from the settings atom (`getInstallState(useSettingsValue())`), which is why the status updated but the agent didn't.

## Fix

Wire each descriptor's install-state change into a new `AgentSessionManager.onInstallStateChanged`, mirroring the existing `restartProviderAffected` / skills / system-prompt restart subscriptions. It dispatches on three transitions, **reusing the existing restart/refresh coalescing** (so a burst of path edits folds into one re-probe):

| Transition | Action |
|---|---|
| Now uninstalled (path cleared) | tear down the live proc + drop the warm probe via `clearCached` |
| Installed, has live/warm process (path changed / binary updated) | `restartBackend` → restart or warm-refresh against the new binary |
| Installed, never probed (freshly installed after load) | first `preload` (`restartBackend` returns `false` here) |

Also guards `restartBackendNow`'s replacement-session spawn on `isBackendInstalled`, so clearing a path mid-use doesn't try to respawn against a missing binary.

This reuses the existing busy-session deferral (won't yank a backend mid-turn), the "<Backend> refreshed" notice, and the picker's per-backend loading/error status.

## Testing

- `npm run format` / `npm run lint` — clean
- `npm run build` — `tsc -noEmit` + esbuild succeed
- `npm run test` — **3359/3359 passing**, including 4 new `onInstallStateChanged` tests covering all transitions (freshly-installed → preload, warm → refresh, live → restart, uninstalled → teardown).

Ran `/simplify` (4-agent cleanup pass): code was already minimal; only a docstring clarification was applied (why the freshly-installed preload is unique to this signal vs. provider/prompt restarts).

Manual verification of the live UX (install/apply/clear with no reload) still wants a `npm run test:vault` pass on desktop before close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
