### PR TITLE
Ship Copilot Plus tools as builtin Agent Mode skills

### DIFF
--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -18,6 +18,7 @@ import { agentOriginEnabledModelEntries } from "@/agentMode/backends/shared/agen
 import { ClaudeSdkBackendProcess } from "@/agentMode/sdk/ClaudeSdkBackendProcess";
 import { getCachedSdkCatalog, synthesizeEffortConfigOption } from "@/agentMode/sdk/effortOption";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
+import { buildCopilotPlusEnv } from "@/agentMode/backends/shared/copilotPlusEnv";
 import type {
   BackendConfigOption,
   EnabledModelEntry,
@@ -230,6 +231,9 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
       descriptor: args.descriptor,
       getEnableThinking: () => Boolean(getSettings().agentMode?.backends?.claude?.enableThinking),
       getEnvOverrides: () => getSettings().agentMode?.backends?.claude?.envOverrides,
+      // Decrypted Copilot Plus license for builtin skill scripts. Passed as a
+      // callback so `sdk/` need not import `backends/` (lint boundary).
+      getManagedEnv: () => buildCopilotPlusEnv(args.clientVersion),
       checkAuth: async () =>
         (await getClaudeAuthStatus(claudePath, claudeChildEnv(getSettings()))).loggedIn,
       isPlanModePlanFilePath: isClaudePlanModePlanFilePath,

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -2,6 +2,7 @@ import { getSettings } from "@/settings/model";
 import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
 import { buildSimpleSpawnDescriptor } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
+import { buildCopilotPlusEnv } from "@/agentMode/backends/shared/copilotPlusEnv";
 
 /**
  * Spawns the user-provided `codex-acp` binary
@@ -20,7 +21,9 @@ export class CodexBackend implements AcpBackend {
     const descriptor = buildSimpleSpawnDescriptor(
       getSettings().agentMode?.backends?.codex?.binaryPath,
       "Codex binary path not configured. Open Agent Mode settings and set the path to codex-acp.",
-      getSettings().agentMode?.backends?.codex?.envOverrides
+      getSettings().agentMode?.backends?.codex?.envOverrides,
+      // Builtin Copilot Plus skill scripts read the license from the env.
+      await buildCopilotPlusEnv()
     );
     // Forward the shared composed system prompt — the Copilot base framing
     // (unless the user disabled it), the pill-syntax directive, and the user's

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -8,6 +8,7 @@ import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
 import type { CopilotMode } from "@/agentMode/session/types";
 import { composeDenyList, getManagedSkills, SkillManager } from "@/agentMode/skills";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
+import { buildCopilotPlusEnv } from "@/agentMode/backends/shared/copilotPlusEnv";
 import { OpencodeBackendDescriptor } from "./descriptor";
 import { mapProviderToOpencodeId } from "./opencodeModelResolve";
 
@@ -82,6 +83,8 @@ export class OpencodeBackend implements AcpBackend {
 
     const config = await buildOpencodeConfig(getSettings(), this.#deps);
     const envOverrides = getSettings().agentMode?.backends?.opencode?.envOverrides ?? {};
+    // Builtin Copilot Plus skill scripts read the license from the env.
+    const plusEnv = await buildCopilotPlusEnv();
 
     return {
       command: binaryPath,
@@ -89,6 +92,7 @@ export class OpencodeBackend implements AcpBackend {
       env: {
         ...process.env,
         OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
+        ...plusEnv,
         // User overrides last — they can replace OPENCODE_CONFIG_CONTENT
         // intentionally if they need to point opencode at a different config.
         ...envOverrides,

--- a/src/agentMode/backends/shared/agentSystemPrompt.test.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.test.ts
@@ -1,4 +1,4 @@
-import { resetSettings } from "@/settings/model";
+import { resetSettings, updateSetting } from "@/settings/model";
 import {
   setDefaultSystemPromptTitle,
   setDisableBuiltinSystemPrompt,
@@ -6,7 +6,11 @@ import {
   updateCachedSystemPrompts,
 } from "@/system-prompts/state";
 import type { UserSystemPrompt } from "@/system-prompts/type";
-import { buildAgentSystemPrompt, COPILOT_PROMPT_BASE } from "./agentSystemPrompt";
+import {
+  buildAgentSystemPrompt,
+  COPILOT_PLUS_TOOLS_STEERING,
+  COPILOT_PROMPT_BASE,
+} from "./agentSystemPrompt";
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
@@ -76,6 +80,30 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain(COPILOT_PROMPT_BASE);
     expect(prompt).not.toContain("<user_custom_instructions>");
     expect(prompt).toContain("{folder_name}");
+  });
+
+  it("steers toward the builtin Copilot Plus skills regardless of Plus status", () => {
+    // Default settings → NOT a Plus user; steering must still be present so a
+    // self-host user (Plus-enabled but isPlusUser=false) gets it, and non-Plus
+    // users fall back to their own tools via the steering's fallback clause.
+    const nonPlus = buildAgentSystemPrompt();
+    expect(nonPlus).toContain(COPILOT_PLUS_TOOLS_STEERING);
+    expect(nonPlus).toContain("copilot-web-search");
+    expect(nonPlus).toContain("copilot-read-pdf");
+    expect(nonPlus).toContain("copilot-youtube-transcript");
+    expect(nonPlus).toContain("copilot-fetch-x");
+    // Fallback clause so a missing/unlicensed skill never dead-ends.
+    expect(nonPlus).toMatch(/fall back to whatever equivalent capability/i);
+
+    // A Plus user gets the same steering.
+    updateSetting("isPlusUser", true);
+    expect(buildAgentSystemPrompt()).toContain(COPILOT_PLUS_TOOLS_STEERING);
+  });
+
+  it("suppresses the steering when the builtin prompt is disabled", () => {
+    setDisableBuiltinSystemPrompt(true);
+    const prompt = buildAgentSystemPrompt();
+    expect(prompt).not.toContain(COPILOT_PLUS_TOOLS_STEERING);
   });
 });
 

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -12,6 +12,8 @@
  *
  *   1. `COPILOT_PROMPT_BASE` (the Obsidian-vault identity) — unless the user
  *      enabled Settings → System prompts → "Disable builtin system prompt".
+ *      Followed by `COPILOT_PLUS_TOOLS_STEERING` (prefer the builtin Copilot
+ *      Plus skills, with a fallback to the agent's own tools) — sent to everyone.
  *   2. The pill-syntax directive (`buildPillSyntaxDirective`) — always present;
  *      it teaches the agent how to read the chat editor's `[[note]]`/`{folder}`
  *      tokens and is functional wiring, not "builtin framing" the user toggles.
@@ -36,6 +38,23 @@
 import { buildPillSyntaxDirective } from "@/agentMode/skills/pillSyntaxDirective";
 import { getDisableBuiltinSystemPrompt } from "@/system-prompts/state";
 import { getEffectiveUserPrompt } from "@/system-prompts/systemPromptBuilder";
+/**
+ * Steers the agent toward the bundled Copilot Plus skills for the four relay
+ * capabilities (see `skills/builtin/builtinSkills.ts`) instead of its own
+ * built-in web/fetch tools, with an explicit fallback so the request never
+ * dead-ends. Sent to every user regardless of Plus status: if a skill can't
+ * run (no license, self-host, disabled, missing), its script exits with the
+ * upgrade notice and the fallback clause routes the agent back to its own
+ * tools — so steering is safe for everyone.
+ */
+export const COPILOT_PLUS_TOOLS_STEERING = `## Copilot Plus tools
+For these requests, prefer the bundled Copilot skill over any built-in tool of your own:
+- Searching the web → the \`copilot-web-search\` skill
+- Reading a PDF file → the \`copilot-read-pdf\` skill
+- Getting a YouTube video's transcript → the \`copilot-youtube-transcript\` skill
+- Fetching an X (Twitter) post → the \`copilot-fetch-x\` skill
+
+If the matching skill is missing, disabled, or reports that it needs an active Copilot Plus license, fall back to whatever equivalent capability you have (or tell the user it's unavailable) — don't refuse the request.`;
 
 export const COPILOT_PROMPT_BASE = `You are Obsidian Copilot, an AI assistant that helps users work with their Obsidian vault — markdown notes for knowledge management, writing, and research. You are NOT a software-engineering agent or CLI coding tool. The working directory is the user's Obsidian vault: a collection of markdown notes, not a code repository. Disregard any framing in environment metadata that suggests otherwise.
 
@@ -92,6 +111,12 @@ export function buildAgentSystemPrompt(): string {
   // it is always sent.
   if (!getDisableBuiltinSystemPrompt()) {
     parts.push(COPILOT_PROMPT_BASE);
+    // Always steer toward the builtin Copilot Plus skills, regardless of Plus
+    // status. Gating on `isPlusUser` would be wrong anyway — valid self-host
+    // mode is Plus-enabled but reports `isPlusUser: false` — and if a skill
+    // can't run, its script exits with the upgrade notice and the fallback
+    // clause routes the agent back to its own tools. Safe for everyone.
+    parts.push(COPILOT_PLUS_TOOLS_STEERING);
   }
 
   parts.push(buildPillSyntaxDirective());

--- a/src/agentMode/backends/shared/copilotPlusEnv.test.ts
+++ b/src/agentMode/backends/shared/copilotPlusEnv.test.ts
@@ -1,0 +1,61 @@
+import { buildCopilotPlusEnv } from "./copilotPlusEnv";
+import { getSettings } from "@/settings/model";
+import { getDecryptedKey } from "@/encryptionService";
+import { BREVILABS_API_BASE_URL } from "@/constants";
+import { PLUS_ENV } from "@/agentMode/skills/builtin/builtinSkills";
+
+jest.mock("@/settings/model", () => ({ getSettings: jest.fn() }));
+jest.mock("@/encryptionService", () => ({ getDecryptedKey: jest.fn() }));
+jest.mock("@/logger", () => ({ logWarn: jest.fn() }));
+
+const mockGetSettings = getSettings as jest.Mock;
+const mockGetDecryptedKey = getDecryptedKey as jest.Mock;
+
+beforeEach(() => {
+  mockGetSettings.mockReset();
+  mockGetDecryptedKey.mockReset();
+});
+
+describe("buildCopilotPlusEnv", () => {
+  it("returns the decrypted license + relay config for an active Plus user", async () => {
+    mockGetSettings.mockReturnValue({
+      isPlusUser: true,
+      plusLicenseKey: "encrypted-key",
+      userId: "user-123",
+    });
+    mockGetDecryptedKey.mockResolvedValue("plain-key");
+
+    const env = await buildCopilotPlusEnv("4.0.0");
+
+    expect(env).toEqual({
+      [PLUS_ENV.licenseKey]: "plain-key",
+      [PLUS_ENV.baseUrl]: BREVILABS_API_BASE_URL,
+      [PLUS_ENV.userId]: "user-123",
+      [PLUS_ENV.clientVersion]: "4.0.0",
+    });
+  });
+
+  it("returns empty when the user is not a Plus subscriber", async () => {
+    mockGetSettings.mockReturnValue({ isPlusUser: false, plusLicenseKey: "encrypted-key" });
+    expect(await buildCopilotPlusEnv()).toEqual({});
+    expect(mockGetDecryptedKey).not.toHaveBeenCalled();
+  });
+
+  it("returns empty when there is no license key on file", async () => {
+    mockGetSettings.mockReturnValue({ isPlusUser: true, plusLicenseKey: "" });
+    expect(await buildCopilotPlusEnv()).toEqual({});
+    expect(mockGetDecryptedKey).not.toHaveBeenCalled();
+  });
+
+  it("returns empty (not a throw) when decryption fails", async () => {
+    mockGetSettings.mockReturnValue({ isPlusUser: true, plusLicenseKey: "encrypted-key" });
+    mockGetDecryptedKey.mockRejectedValue(new Error("bad key"));
+    expect(await buildCopilotPlusEnv()).toEqual({});
+  });
+
+  it("returns empty when the decrypted key is blank", async () => {
+    mockGetSettings.mockReturnValue({ isPlusUser: true, plusLicenseKey: "encrypted-key" });
+    mockGetDecryptedKey.mockResolvedValue("");
+    expect(await buildCopilotPlusEnv()).toEqual({});
+  });
+});

--- a/src/agentMode/backends/shared/copilotPlusEnv.ts
+++ b/src/agentMode/backends/shared/copilotPlusEnv.ts
@@ -1,0 +1,44 @@
+import { BREVILABS_API_BASE_URL } from "@/constants";
+import { getDecryptedKey } from "@/encryptionService";
+import { logWarn } from "@/logger";
+import { getSettings } from "@/settings/model";
+import { PLUS_ENV } from "@/agentMode/skills/builtin/builtinSkills";
+
+/** Frozen empty result so non-Plus spawns don't allocate a fresh object each time. */
+const EMPTY_PLUS_ENV: Readonly<Record<string, string>> = Object.freeze({});
+
+/**
+ * Build the plugin-managed environment that lets builtin Copilot Plus skill
+ * scripts reach the Brevilabs relay (see `builtinSkills.ts`). Returns the
+ * decrypted license key + relay base URL + user id (and client version) when
+ * the user is an active Plus subscriber with a key on file; otherwise an empty
+ * object, so the skills' scripts exit with the upgrade prompt.
+ *
+ * This is deliberately separate from user-configured `envOverrides`: it is
+ * decrypted fresh at spawn time and must be merged BEFORE user overrides so a
+ * user can still shadow it intentionally. The decrypted key lives only in the
+ * agent subprocess env (never written to disk in the skill files).
+ */
+export async function buildCopilotPlusEnv(
+  clientVersion = ""
+): Promise<Readonly<Record<string, string>>> {
+  const settings = getSettings();
+  if (!settings.isPlusUser) return EMPTY_PLUS_ENV;
+  if (!settings.plusLicenseKey) return EMPTY_PLUS_ENV;
+
+  let licenseKey: string;
+  try {
+    licenseKey = await getDecryptedKey(settings.plusLicenseKey);
+  } catch (e) {
+    logWarn("[AgentMode] could not decrypt Copilot Plus license key for agent env", e);
+    return EMPTY_PLUS_ENV;
+  }
+  if (!licenseKey) return EMPTY_PLUS_ENV;
+
+  return {
+    [PLUS_ENV.licenseKey]: licenseKey,
+    [PLUS_ENV.baseUrl]: BREVILABS_API_BASE_URL,
+    [PLUS_ENV.userId]: settings.userId ?? "",
+    [PLUS_ENV.clientVersion]: clientVersion,
+  };
+}

--- a/src/agentMode/backends/shared/simpleBinaryBackend.ts
+++ b/src/agentMode/backends/shared/simpleBinaryBackend.ts
@@ -15,7 +15,13 @@ import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMod
 export function buildSimpleSpawnDescriptor(
   binaryPath: string | undefined,
   configErrorMessage: string,
-  envOverrides?: Record<string, string>
+  envOverrides?: Record<string, string>,
+  /**
+   * Plugin-managed env (e.g. the decrypted Copilot Plus license for builtin
+   * skill scripts). Merged after `process.env` but BEFORE user `envOverrides`
+   * so a user can still intentionally shadow it.
+   */
+  managedEnv?: Readonly<Record<string, string>>
 ): AcpSpawnDescriptor {
   if (!binaryPath) throw new Error(configErrorMessage);
   return {
@@ -24,6 +30,7 @@ export function buildSimpleSpawnDescriptor(
     env: {
       ...process.env,
       PATH: augmentPathForNodeShebang(binaryPath, process.env.PATH),
+      ...(managedEnv ?? {}),
       ...(envOverrides ?? {}),
     },
   };

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -1,6 +1,7 @@
 import { type App, Platform } from "obsidian";
 import type CopilotPlugin from "@/main";
 import { logError } from "@/logger";
+import { DEFAULT_SKILLS_FOLDER } from "@/constants";
 import { getSettings, subscribeToSettingsChange } from "@/settings/model";
 import { subscribeToSystemPromptChange } from "@/system-prompts/state";
 import { buildAgentSystemPrompt } from "./backends/shared/agentSystemPrompt";
@@ -10,6 +11,7 @@ import { AgentChatPersistenceManager } from "./session/AgentChatPersistenceManag
 import { AgentModelPreloader } from "./session/AgentModelPreloader";
 import { AgentSessionManager } from "./session/AgentSessionManager";
 import { SkillManager } from "./skills";
+import { seedBuiltinSkills } from "./skills/builtin/seedBuiltinSkills";
 import {
   createDefaultAskUserQuestionPrompter,
   createDefaultPermissionPrompter,
@@ -219,6 +221,19 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
     ) {
       restartSystemPromptAffected();
     }
+    // Copilot Plus sign-in/out (or license rotation) changes the managed env
+    // injected at spawn — the decrypted license the builtin Plus skill scripts
+    // read. Restart every backend so the next session sees the license appear
+    // or disappear without a plugin reload.
+    if (prev.isPlusUser !== next.isPlusUser || prev.plusLicenseKey !== next.plusLicenseKey) {
+      for (const descriptor of listBackendDescriptors()) {
+        void manager
+          .restartBackend(descriptor.id, "Copilot Plus license changed")
+          .catch((e) =>
+            logError(`[AgentMode] restart after plus change failed: ${descriptor.id}`, e)
+          );
+      }
+    }
   });
   // A backend's binary path (or a binary install/update) is resolved at spawn
   // time, so a change must reach the running/warm process — otherwise it only
@@ -234,7 +249,26 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
         );
     });
   }
-  void skillManager.refresh().catch((error) => {
+  // Seed plugin-shipped builtin skills (Copilot Plus relay tools) into the
+  // canonical folder, THEN run discovery so the first pass picks them up and
+  // fans them out to the agent dirs. Non-blocking for plugin load.
+  void (async () => {
+    try {
+      const adapter = app.vault.adapter;
+      await seedBuiltinSkills({
+        skillsFolderRelPath: getSettings().agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER,
+        fs: {
+          exists: (p) => adapter.exists(p),
+          read: (p) => adapter.read(p),
+          write: (p, c) => adapter.write(p, c),
+          mkdir: (p) => adapter.mkdir(p),
+        },
+      });
+    } catch (e) {
+      logError("[Skills] builtin skill seeding failed", e);
+    }
+    await skillManager.refresh();
+  })().catch((error) => {
     logError("[Skills] Initial discovery pass failed", error);
   });
   // Non-blocking — plugin load should not wait on disk reconcile.

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -234,6 +234,23 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
           );
       }
     }
+    // When the canonical skills folder changes, seed builtins into the new
+    // folder before discovery runs so the Plus tools appear immediately
+    // without a plugin reload.
+    const prevFolder = prev.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
+    const nextFolder = next.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
+    if (prevFolder !== nextFolder) {
+      const adapter = app.vault.adapter;
+      void seedBuiltinSkills({
+        skillsFolderRelPath: nextFolder,
+        fs: {
+          exists: (p) => adapter.exists(p),
+          read: (p) => adapter.read(p),
+          write: (p, c) => adapter.write(p, c),
+          mkdir: (p) => adapter.mkdir(p),
+        },
+      }).catch((e) => logError("[Skills] builtin skill seeding after folder change failed", e));
+    }
   });
   // A backend's binary path (or a binary install/update) is resolved at spawn
   // time, so a change must reach the running/warm process — otherwise it only

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -249,7 +249,9 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
           write: (p, c) => adapter.write(p, c),
           mkdir: (p) => adapter.mkdir(p),
         },
-      }).catch((e) => logError("[Skills] builtin skill seeding after folder change failed", e));
+      })
+        .then(() => skillManager.refresh())
+        .catch((e) => logError("[Skills] builtin skill seeding after folder change failed", e));
     }
   });
   // A backend's binary path (or a binary install/update) is resolved at spawn

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -133,6 +133,12 @@ export interface ClaudeSdkBackendProcessOptions {
    */
   getEnvOverrides?: () => Record<string, string> | undefined;
   /**
+   * Plugin-managed env merged onto `process.env` before user overrides (e.g.
+   * the decrypted Copilot Plus license for builtin skill scripts). Supplied by
+   * the descriptor so `sdk/` need not import `backends/`. Read per `prompt()`.
+   */
+  getManagedEnv?: () => Promise<Readonly<Record<string, string>>>;
+  /**
    * Resolve whether the `claude` CLI is signed in (OAuth login or env-based
    * credentials). Consulted once before the first prompt; an unauthenticated
    * result makes `prompt()` reject with `AuthRequiredError` instead of
@@ -325,10 +331,15 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
       options.thinking = { type: "adaptive", display: "summarized" };
     }
     const envOverrides = this.opts.getEnvOverrides?.();
-    if (envOverrides && Object.keys(envOverrides).length > 0) {
+    // Builtin Copilot Plus skill scripts read the license from the env. The
+    // descriptor supplies it via `getManagedEnv` (sdk/ can't import backends/);
+    // merged before user overrides so a user can still shadow it.
+    const managedEnv = (await this.opts.getManagedEnv?.()) ?? {};
+    const extraEnv = { ...managedEnv, ...envOverrides };
+    if (Object.keys(extraEnv).length > 0) {
       // Options.env replaces (not merges with) the child env, so include
       // process.env to preserve PATH and friends.
-      options.env = { ...process.env, ...envOverrides };
+      options.env = { ...process.env, ...extraEnv };
     }
 
     logSdkOutbound(

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,0 +1,68 @@
+import { BUILTIN_SKILLS, PLUS_ENV } from "./builtinSkills";
+
+/** The single script file shipped by a skill. */
+function scriptOf(name: string): string {
+  const skill = BUILTIN_SKILLS.find((s) => s.name === name);
+  if (!skill) throw new Error(`no builtin skill ${name}`);
+  return skill.files[0].content;
+}
+
+describe("builtin Copilot Plus skills", () => {
+  it("ships the four Copilot-branded skills, each fanned out to all three agents", () => {
+    expect(BUILTIN_SKILLS.map((s) => s.name)).toEqual([
+      "copilot-web-search",
+      "copilot-read-pdf",
+      "copilot-youtube-transcript",
+      "copilot-fetch-x",
+    ]);
+    for (const skill of BUILTIN_SKILLS) {
+      expect(skill.enabledAgents).toEqual(["claude", "codex", "opencode"]);
+    }
+  });
+
+  it("keeps the SKILL.md frontmatter version in sync with the numeric version", () => {
+    for (const skill of BUILTIN_SKILLS) {
+      expect(skill.skillMd).toContain(`copilot-builtin-version: "${skill.version}"`);
+    }
+  });
+
+  it("invokes the script with sh (not node) and references the matching script file", () => {
+    for (const skill of BUILTIN_SKILLS) {
+      const scriptFile = skill.files[0].path;
+      expect(scriptFile).toMatch(/\.sh$/);
+      expect(skill.skillMd).toContain(`sh "/absolute/path/to/this/skill/directory/${scriptFile}"`);
+      expect(skill.skillMd).not.toContain("node ");
+    }
+  });
+
+  it("reads its config from the injected env and never embeds a key", () => {
+    for (const skill of BUILTIN_SKILLS) {
+      const script = skill.files[0].content;
+      expect(script).toContain(`#!/bin/sh`);
+      expect(script).toContain(PLUS_ENV.licenseKey);
+      expect(script).toContain(PLUS_ENV.baseUrl);
+      // Auth flows through the env var, not a literal embedded key.
+      expect(script).toContain("Authorization: Bearer $KEY");
+      expect(script).toContain("X-Client-Version: $CLIENT_VERSION");
+      // Guard + upgrade prompt when the license/relay config is absent.
+      expect(script).toContain('[ -n "$KEY" ] && [ -n "$BASE" ] || die "$UPGRADE"');
+      expect(script).toContain("Copilot Plus");
+    }
+  });
+
+  it("maps each relay tool to its endpoint and request body", () => {
+    expect(scriptOf("copilot-web-search")).toContain('relay "/websearch"');
+    expect(scriptOf("copilot-web-search")).toContain('\\"query\\"');
+    expect(scriptOf("copilot-youtube-transcript")).toContain('relay "/youtube4llm"');
+    expect(scriptOf("copilot-fetch-x")).toContain('relay "/twitter4llm"');
+    // Single-arg tools JSON-escape the argument they pass.
+    expect(scriptOf("copilot-web-search")).toContain('$(json_escape "$ARG")');
+  });
+
+  it("read-pdf base64-encodes the file into the pdf field", () => {
+    const pdf = scriptOf("copilot-read-pdf");
+    expect(pdf).toContain('relay "/pdf4llm"');
+    expect(pdf).toContain("base64");
+    expect(pdf).toContain('\\"pdf\\"');
+  });
+});

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -7,11 +7,18 @@ import type { BackendId } from "@/agentMode/session/types";
  * `seedBuiltinSkills`) and refreshed when `version` bumps.
  *
  * Each skill ships a `SKILL.md` (instructions the agent reads) plus one
- * Node `.mjs` script the agent runs. The script reads the Copilot Plus
- * license + relay base URL from env vars the plugin injects at spawn time
- * (see `buildCopilotPlusEnv`) and calls the Brevilabs relay directly — no
- * key is embedded in the skill files. A missing/invalid license makes the
- * script exit non-zero with an upgrade prompt the agent relays to the user.
+ * POSIX `sh` script the agent runs with `curl`. The script reads the Copilot
+ * Plus license + relay base URL from env vars the plugin injects at spawn time
+ * (see `buildCopilotPlusEnv`) and calls the Brevilabs relay directly — no key
+ * is embedded in the skill files. A missing/invalid license makes the script
+ * exit non-zero with an upgrade prompt the agent relays to the user.
+ *
+ * Why `sh` + `curl` rather than a Node script: the script runs in the *agent's*
+ * shell, where `node` is not reliably on PATH (Obsidian launches with a minimal
+ * PATH that usually excludes nvm/Volta/Homebrew node). `sh`, `curl`, `sed`, and
+ * `base64` live in `/usr/bin` (and git-bash on Windows), so they are reachable
+ * regardless of the user's node setup. Scripts are POSIX and invoked as
+ * `sh "<path>" <arg>`, so they need neither a node runtime nor an executable bit.
  */
 export interface BuiltinSkill {
   /** Folder name + SKILL.md `name`. Kebab-case, Copilot-branded. */
@@ -40,46 +47,61 @@ export const PLUS_ENV = {
 const UPGRADE_MESSAGE =
   "This is a Copilot Plus feature and needs an active license. Tell the user that web/PDF/YouTube/X tools require Copilot Plus, and to upgrade or renew at https://www.obsidiancopilot.com (then add their license key in Settings → Copilot Plus).";
 
+/** Wrap a string as a single-quoted shell literal (safe for embedding in `sh`). */
+function shSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
 /**
- * Shared preamble every script uses: resolves env, and exits with the
- * upgrade prompt when the license/relay config is absent. Kept inline in
- * each `.mjs` (scripts can't share an import once symlinked into agent dirs).
+ * Shared preamble every script uses: resolves env, defines the relay caller,
+ * and exits with the upgrade prompt when the license/relay config is absent.
+ * Kept inline in each `.sh` (scripts can't share an import once symlinked into
+ * agent dirs).
+ *
+ * `json_escape` covers single-line string values (backslash + double quote);
+ * queries, URLs, and file paths never contain raw newlines, so this is enough
+ * without depending on `jq`, which is not guaranteed to be installed. The
+ * request body is fed to curl over stdin (`--data-binary @-`) so a large
+ * base64 PDF never hits the command-line length limit.
  */
 function scriptPreamble(): string {
-  return `const BASE = process.env.${PLUS_ENV.baseUrl};
-const KEY = process.env.${PLUS_ENV.licenseKey};
-const USER_ID = process.env.${PLUS_ENV.userId} ?? "";
-const CLIENT_VERSION = process.env.${PLUS_ENV.clientVersion} ?? "";
-const UPGRADE = ${JSON.stringify(UPGRADE_MESSAGE)};
-function die(msg, code = 2) {
-  process.stderr.write(msg + "\\n");
-  process.exit(code);
-}
-if (!KEY || !BASE) die(UPGRADE);
+  return `#!/bin/sh
+# Calls the Brevilabs relay with curl and prints the JSON result to stdout.
+# Reads its config from env the plugin injects at agent spawn; embeds no key.
+BASE="\${${PLUS_ENV.baseUrl}:-}"
+KEY="\${${PLUS_ENV.licenseKey}:-}"
+USER_ID="\${${PLUS_ENV.userId}:-}"
+CLIENT_VERSION="\${${PLUS_ENV.clientVersion}:-}"
+UPGRADE=${shSingleQuote(UPGRADE_MESSAGE)}
 
-async function relay(endpoint, body) {
-  let res;
-  try {
-    res = await fetch(BASE + endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer " + KEY,
-        "X-Client-Version": CLIENT_VERSION,
-      },
-      body: JSON.stringify({ ...body, user_id: USER_ID }),
-    });
-  } catch (e) {
-    die("Could not reach the Copilot relay: " + (e && e.message ? e.message : String(e)), 1);
-  }
-  if (res.status === 401 || res.status === 403) die(UPGRADE);
-  if (!res.ok) die("Request failed (HTTP " + res.status + "): " + (await res.text()), 1);
-  return res.json();
+die() {
+  printf '%s\\n' "$1" >&2
+  exit "\${2:-2}"
 }
 
-function emit(data) {
-  process.stdout.write(typeof data === "string" ? data : JSON.stringify(data, null, 2));
-  process.stdout.write("\\n");
+[ -n "$KEY" ] && [ -n "$BASE" ] || die "$UPGRADE"
+
+# JSON-escape a single-line string: backslash first, then double quote.
+json_escape() {
+  printf '%s' "$1" | sed -e 's/\\\\/\\\\\\\\/g' -e 's/"/\\\\"/g'
+}
+
+# relay ENDPOINT JSON_BODY -> prints the response body, mapping HTTP status.
+relay() {
+  resp=$(printf '%s' "$2" | curl -sS -w '\\n%{http_code}' \\
+    -X POST "$BASE$1" \\
+    -H 'Content-Type: application/json' \\
+    -H "Authorization: Bearer $KEY" \\
+    -H "X-Client-Version: $CLIENT_VERSION" \\
+    --data-binary @-)
+  [ $? -eq 0 ] || die "Could not reach the Copilot relay." 1
+  code=$(printf '%s' "$resp" | tail -n1)
+  out=$(printf '%s' "$resp" | sed '$d')
+  case "$code" in
+    401|403) die "$UPGRADE" ;;
+    2*) printf '%s\\n' "$out" ;;
+    *) die "Request failed (HTTP $code): $out" 1 ;;
+  esac
 }
 `;
 }
@@ -102,9 +124,10 @@ function relaySkill(opts: {
   scriptFile: string;
 }): BuiltinSkill {
   const [argKey, argPlaceholder] = opts.arg;
+  const version = 2;
   return {
     name: opts.name,
-    version: 1,
+    version,
     enabledAgents: ["claude", "codex", "opencode"],
     skillMd: `---
 name: ${opts.name}
@@ -112,7 +135,7 @@ description: ${opts.description}
 license: Copilot Plus
 metadata:
   copilot-enabled-agents: claude, codex, opencode
-  copilot-builtin-version: "1"
+  copilot-builtin-version: "${version}"
 ---
 
 # ${opts.heading}
@@ -125,7 +148,7 @@ Find the absolute path to this SKILL.md file on disk, then run the script that
 sits next to it:
 
 \`\`\`bash
-node "/absolute/path/to/this/skill/directory/${opts.scriptFile}" "${argPlaceholder}"
+sh "/absolute/path/to/this/skill/directory/${opts.scriptFile}" "${argPlaceholder}"
 \`\`\`
 
 The script prints the result to stdout.
@@ -140,9 +163,9 @@ or renew — then continue without it.
       {
         path: opts.scriptFile,
         content: `${scriptPreamble()}
-const arg = process.argv.slice(2).join(" ").trim();
-if (!arg) die("Usage: node ${opts.scriptFile} <${argKey}>", 1);
-emit(await relay("${opts.endpoint}", { ${argKey}: arg }));
+ARG="$*"
+[ -n "$ARG" ] || die "Usage: sh ${opts.scriptFile} <${argKey}>" 1
+relay "${opts.endpoint}" "{\\"${argKey}\\":\\"$(json_escape "$ARG")\\",\\"user_id\\":\\"$(json_escape "$USER_ID")\\"}"
 `,
       },
     ],
@@ -157,12 +180,13 @@ const WEB_SEARCH = relaySkill({
   intro: "Search the web through Copilot Plus and return results for the user's query.",
   endpoint: "/websearch",
   arg: ["query", "<your search query>"],
-  scriptFile: "web-search.mjs",
+  scriptFile: "web-search.sh",
 });
 
+const READ_PDF_VERSION = 3;
 const READ_PDF: BuiltinSkill = {
   name: "copilot-read-pdf",
-  version: 2,
+  version: READ_PDF_VERSION,
   enabledAgents: ["claude", "codex", "opencode"],
   skillMd: `---
 name: copilot-read-pdf
@@ -170,7 +194,7 @@ description: Extract the full text of a PDF as Markdown using Copilot Plus. Use 
 license: Copilot Plus
 metadata:
   copilot-enabled-agents: claude, codex, opencode
-  copilot-builtin-version: "2"
+  copilot-builtin-version: "${READ_PDF_VERSION}"
 ---
 
 # Copilot read PDF
@@ -184,7 +208,7 @@ Find the absolute path to this SKILL.md file on disk, then run the script that
 sits next to it:
 
 \`\`\`bash
-node "/absolute/path/to/this/skill/directory/read-pdf.mjs" "<path-to-file.pdf>"
+sh "/absolute/path/to/this/skill/directory/read-pdf.sh" "<path-to-file.pdf>"
 \`\`\`
 
 Pass an absolute path to the PDF file. The script prints the extracted Markdown
@@ -198,23 +222,15 @@ or renew — then continue without it.
 `,
   files: [
     {
-      path: "read-pdf.mjs",
+      path: "read-pdf.sh",
       content: `${scriptPreamble()}
-import { readFile } from "node:fs/promises";
+FILE=\${1:-}
+[ -n "$FILE" ] || die "Usage: sh read-pdf.sh <path-to-file.pdf>" 1
+[ -f "$FILE" ] && [ -r "$FILE" ] || die "Could not read file: $FILE" 1
 
-const file = process.argv[2];
-if (!file) die("Usage: node read-pdf.mjs <path-to-file.pdf>", 1);
-
-let bytes;
-try {
-  bytes = await readFile(file);
-} catch (e) {
-  die("Could not read file '" + file + "': " + (e && e.message ? e.message : String(e)), 1);
-}
-
-// Mirror brevilabsClient.ts pdf4llm: JSON body with base64-encoded pdf field.
-const pdf = Buffer.from(bytes).toString("base64");
-emit(await relay("/pdf4llm", { pdf }));
+# Mirror brevilabsClient.ts pdf4llm: JSON body with base64-encoded pdf field.
+PDF=$(base64 < "$FILE" | tr -d '\\n')
+relay "/pdf4llm" "{\\"pdf\\":\\"$PDF\\",\\"user_id\\":\\"$(json_escape "$USER_ID")\\"}"
 `,
     },
   ],
@@ -228,7 +244,7 @@ const YOUTUBE_TRANSCRIPT = relaySkill({
   intro: "Fetch a YouTube video's transcript through Copilot Plus.",
   endpoint: "/youtube4llm",
   arg: ["url", "<youtube-url>"],
-  scriptFile: "youtube-transcript.mjs",
+  scriptFile: "youtube-transcript.sh",
 });
 
 const FETCH_X = relaySkill({
@@ -239,7 +255,7 @@ const FETCH_X = relaySkill({
   intro: "Fetch the content of an X (Twitter) post through Copilot Plus.",
   endpoint: "/twitter4llm",
   arg: ["url", "<x-or-twitter-url>"],
-  scriptFile: "fetch-x.mjs",
+  scriptFile: "fetch-x.sh",
 });
 
 /** All plugin-shipped builtin skills, in display order. */

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -87,8 +87,8 @@ function emit(data) {
 /**
  * Build a skill that maps a single positional argument onto one relay
  * endpoint (the web/YouTube/X tools are identical apart from the endpoint,
- * argument name, and copy). PDF is hand-written below because it uploads a
- * file as multipart instead.
+ * argument name, and copy). PDF is hand-written below because it reads a
+ * local file and base64-encodes it before calling the relay.
  */
 function relaySkill(opts: {
   name: string;
@@ -121,12 +121,14 @@ ${opts.intro}
 
 ## How to run
 
+Find the absolute path to this SKILL.md file on disk, then run the script that
+sits next to it:
+
 \`\`\`bash
-node "$SKILL_DIR/${opts.scriptFile}" "${argPlaceholder}"
+node "/absolute/path/to/this/skill/directory/${opts.scriptFile}" "${argPlaceholder}"
 \`\`\`
 
-Replace \`$SKILL_DIR\` with this skill's directory. The script prints the result
-to stdout.
+The script prints the result to stdout.
 
 ## If it reports a license problem
 
@@ -178,12 +180,15 @@ summarize, or quote it.
 
 ## How to run
 
+Find the absolute path to this SKILL.md file on disk, then run the script that
+sits next to it:
+
 \`\`\`bash
-node "$SKILL_DIR/read-pdf.mjs" "<path-to-file.pdf>"
+node "/absolute/path/to/this/skill/directory/read-pdf.mjs" "<path-to-file.pdf>"
 \`\`\`
 
-Pass an absolute path, or a path relative to the vault root. The script prints
-the extracted Markdown to stdout.
+Pass an absolute path to the PDF file. The script prints the extracted Markdown
+to stdout.
 
 ## If it reports a license problem
 

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -160,7 +160,7 @@ const WEB_SEARCH = relaySkill({
 
 const READ_PDF: BuiltinSkill = {
   name: "copilot-read-pdf",
-  version: 1,
+  version: 2,
   enabledAgents: ["claude", "codex", "opencode"],
   skillMd: `---
 name: copilot-read-pdf
@@ -168,7 +168,7 @@ description: Extract the full text of a PDF as Markdown using Copilot Plus. Use 
 license: Copilot Plus
 metadata:
   copilot-enabled-agents: claude, codex, opencode
-  copilot-builtin-version: "1"
+  copilot-builtin-version: "2"
 ---
 
 # Copilot read PDF
@@ -196,7 +196,6 @@ or renew — then continue without it.
       path: "read-pdf.mjs",
       content: `${scriptPreamble()}
 import { readFile } from "node:fs/promises";
-import { basename } from "node:path";
 
 const file = process.argv[2];
 if (!file) die("Usage: node read-pdf.mjs <path-to-file.pdf>", 1);
@@ -208,23 +207,9 @@ try {
   die("Could not read file '" + file + "': " + (e && e.message ? e.message : String(e)), 1);
 }
 
-const form = new FormData();
-form.append("file", new Blob([bytes], { type: "application/pdf" }), basename(file));
-form.append("user_id", USER_ID);
-
-let res;
-try {
-  res = await fetch(BASE + "/pdf4llm", {
-    method: "POST",
-    headers: { Authorization: "Bearer " + KEY, "X-Client-Version": CLIENT_VERSION },
-    body: form,
-  });
-} catch (e) {
-  die("Could not reach the Copilot relay: " + (e && e.message ? e.message : String(e)), 1);
-}
-if (res.status === 401 || res.status === 403) die(UPGRADE);
-if (!res.ok) die("PDF extraction failed (HTTP " + res.status + "): " + (await res.text()), 1);
-emit(await res.json());
+// Mirror brevilabsClient.ts pdf4llm: JSON body with base64-encoded pdf field.
+const pdf = Buffer.from(bytes).toString("base64");
+emit(await relay("/pdf4llm", { pdf }));
 `,
     },
   ],

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -1,0 +1,261 @@
+import type { BackendId } from "@/agentMode/session/types";
+
+/**
+ * Plugin-shipped ("builtin") Agent Mode skills that wrap Copilot Plus relay
+ * capabilities (web search, PDF, YouTube, X). Unlike user-authored skills,
+ * these are seeded into the canonical skills folder by the plugin (see
+ * `seedBuiltinSkills`) and refreshed when `version` bumps.
+ *
+ * Each skill ships a `SKILL.md` (instructions the agent reads) plus one
+ * Node `.mjs` script the agent runs. The script reads the Copilot Plus
+ * license + relay base URL from env vars the plugin injects at spawn time
+ * (see `buildCopilotPlusEnv`) and calls the Brevilabs relay directly — no
+ * key is embedded in the skill files. A missing/invalid license makes the
+ * script exit non-zero with an upgrade prompt the agent relays to the user.
+ */
+export interface BuiltinSkill {
+  /** Folder name + SKILL.md `name`. Kebab-case, Copilot-branded. */
+  readonly name: string;
+  /**
+   * Bump when `skillMd` or any script changes so seeded copies refresh.
+   * Stamped into `metadata.copilot-builtin-version` in the seeded SKILL.md.
+   */
+  readonly version: number;
+  /** Agents the skill fans out to (→ `metadata.copilot-enabled-agents`). */
+  readonly enabledAgents: readonly BackendId[];
+  /** Full SKILL.md file contents (frontmatter + body). */
+  readonly skillMd: string;
+  /** Supporting files written alongside SKILL.md (the runnable script). */
+  readonly files: ReadonlyArray<{ readonly path: string; readonly content: string }>;
+}
+
+/** Env var names the plugin injects and the scripts read. Single source of truth. */
+export const PLUS_ENV = {
+  licenseKey: "COPILOT_PLUS_LICENSE_KEY",
+  baseUrl: "COPILOT_API_BASE_URL",
+  userId: "COPILOT_USER_ID",
+  clientVersion: "COPILOT_CLIENT_VERSION",
+} as const;
+
+const UPGRADE_MESSAGE =
+  "This is a Copilot Plus feature and needs an active license. Tell the user that web/PDF/YouTube/X tools require Copilot Plus, and to upgrade or renew at https://www.obsidiancopilot.com (then add their license key in Settings → Copilot Plus).";
+
+/**
+ * Shared preamble every script uses: resolves env, and exits with the
+ * upgrade prompt when the license/relay config is absent. Kept inline in
+ * each `.mjs` (scripts can't share an import once symlinked into agent dirs).
+ */
+function scriptPreamble(): string {
+  return `const BASE = process.env.${PLUS_ENV.baseUrl};
+const KEY = process.env.${PLUS_ENV.licenseKey};
+const USER_ID = process.env.${PLUS_ENV.userId} ?? "";
+const CLIENT_VERSION = process.env.${PLUS_ENV.clientVersion} ?? "";
+const UPGRADE = ${JSON.stringify(UPGRADE_MESSAGE)};
+function die(msg, code = 2) {
+  process.stderr.write(msg + "\\n");
+  process.exit(code);
+}
+if (!KEY || !BASE) die(UPGRADE);
+
+async function relay(endpoint, body) {
+  let res;
+  try {
+    res = await fetch(BASE + endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + KEY,
+        "X-Client-Version": CLIENT_VERSION,
+      },
+      body: JSON.stringify({ ...body, user_id: USER_ID }),
+    });
+  } catch (e) {
+    die("Could not reach the Copilot relay: " + (e && e.message ? e.message : String(e)), 1);
+  }
+  if (res.status === 401 || res.status === 403) die(UPGRADE);
+  if (!res.ok) die("Request failed (HTTP " + res.status + "): " + (await res.text()), 1);
+  return res.json();
+}
+
+function emit(data) {
+  process.stdout.write(typeof data === "string" ? data : JSON.stringify(data, null, 2));
+  process.stdout.write("\\n");
+}
+`;
+}
+
+/**
+ * Build a skill that maps a single positional argument onto one relay
+ * endpoint (the web/YouTube/X tools are identical apart from the endpoint,
+ * argument name, and copy). PDF is hand-written below because it uploads a
+ * file as multipart instead.
+ */
+function relaySkill(opts: {
+  name: string;
+  /** SKILL.md `description` — the agent's "when to use" signal. */
+  description: string;
+  heading: string;
+  intro: string;
+  endpoint: string;
+  /** Relay body key + usage-doc placeholder, e.g. `["query", "<your search query>"]`. */
+  arg: [key: string, placeholder: string];
+  scriptFile: string;
+}): BuiltinSkill {
+  const [argKey, argPlaceholder] = opts.arg;
+  return {
+    name: opts.name,
+    version: 1,
+    enabledAgents: ["claude", "codex", "opencode"],
+    skillMd: `---
+name: ${opts.name}
+description: ${opts.description}
+license: Copilot Plus
+metadata:
+  copilot-enabled-agents: claude, codex, opencode
+  copilot-builtin-version: "1"
+---
+
+# ${opts.heading}
+
+${opts.intro}
+
+## How to run
+
+\`\`\`bash
+node "$SKILL_DIR/${opts.scriptFile}" "${argPlaceholder}"
+\`\`\`
+
+Replace \`$SKILL_DIR\` with this skill's directory. The script prints the result
+to stdout.
+
+## If it reports a license problem
+
+If the script exits with a message about Copilot Plus, do NOT retry. Tell the
+user this capability needs an active Copilot Plus license and where to upgrade
+or renew — then continue without it.
+`,
+    files: [
+      {
+        path: opts.scriptFile,
+        content: `${scriptPreamble()}
+const arg = process.argv.slice(2).join(" ").trim();
+if (!arg) die("Usage: node ${opts.scriptFile} <${argKey}>", 1);
+emit(await relay("${opts.endpoint}", { ${argKey}: arg }));
+`,
+      },
+    ],
+  };
+}
+
+const WEB_SEARCH = relaySkill({
+  name: "copilot-web-search",
+  description:
+    "Search the web for current information using Copilot Plus. Use when the user asks to search online, look something up on the internet, or needs up-to-date facts beyond the vault. Prefer reading the vault for anything about the user's own notes. Requires an active Copilot Plus license.",
+  heading: "Copilot web search",
+  intro: "Search the web through Copilot Plus and return results for the user's query.",
+  endpoint: "/websearch",
+  arg: ["query", "<your search query>"],
+  scriptFile: "web-search.mjs",
+});
+
+const READ_PDF: BuiltinSkill = {
+  name: "copilot-read-pdf",
+  version: 1,
+  enabledAgents: ["claude", "codex", "opencode"],
+  skillMd: `---
+name: copilot-read-pdf
+description: Extract the full text of a PDF as Markdown using Copilot Plus. Use when the user wants to read, summarize, or quote a PDF file (in the vault or an absolute path). Requires an active Copilot Plus license.
+license: Copilot Plus
+metadata:
+  copilot-enabled-agents: claude, codex, opencode
+  copilot-builtin-version: "1"
+---
+
+# Copilot read PDF
+
+Convert a PDF file to Markdown text through Copilot Plus so you can read,
+summarize, or quote it.
+
+## How to run
+
+\`\`\`bash
+node "$SKILL_DIR/read-pdf.mjs" "<path-to-file.pdf>"
+\`\`\`
+
+Pass an absolute path, or a path relative to the vault root. The script prints
+the extracted Markdown to stdout.
+
+## If it reports a license problem
+
+If the script exits with a message about Copilot Plus, do NOT retry. Tell the
+user this capability needs an active Copilot Plus license and where to upgrade
+or renew — then continue without it.
+`,
+  files: [
+    {
+      path: "read-pdf.mjs",
+      content: `${scriptPreamble()}
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+
+const file = process.argv[2];
+if (!file) die("Usage: node read-pdf.mjs <path-to-file.pdf>", 1);
+
+let bytes;
+try {
+  bytes = await readFile(file);
+} catch (e) {
+  die("Could not read file '" + file + "': " + (e && e.message ? e.message : String(e)), 1);
+}
+
+const form = new FormData();
+form.append("file", new Blob([bytes], { type: "application/pdf" }), basename(file));
+form.append("user_id", USER_ID);
+
+let res;
+try {
+  res = await fetch(BASE + "/pdf4llm", {
+    method: "POST",
+    headers: { Authorization: "Bearer " + KEY, "X-Client-Version": CLIENT_VERSION },
+    body: form,
+  });
+} catch (e) {
+  die("Could not reach the Copilot relay: " + (e && e.message ? e.message : String(e)), 1);
+}
+if (res.status === 401 || res.status === 403) die(UPGRADE);
+if (!res.ok) die("PDF extraction failed (HTTP " + res.status + "): " + (await res.text()), 1);
+emit(await res.json());
+`,
+    },
+  ],
+};
+
+const YOUTUBE_TRANSCRIPT = relaySkill({
+  name: "copilot-youtube-transcript",
+  description:
+    "Fetch the transcript of a YouTube video using Copilot Plus. Use when the user shares a YouTube URL and wants its contents, a summary, or quotes. Requires an active Copilot Plus license.",
+  heading: "Copilot YouTube transcript",
+  intro: "Fetch a YouTube video's transcript through Copilot Plus.",
+  endpoint: "/youtube4llm",
+  arg: ["url", "<youtube-url>"],
+  scriptFile: "youtube-transcript.mjs",
+});
+
+const FETCH_X = relaySkill({
+  name: "copilot-fetch-x",
+  description:
+    "Fetch the content of an X (Twitter) post using Copilot Plus. Use when the user shares an x.com or twitter.com URL and wants its text or context. Requires an active Copilot Plus license.",
+  heading: "Copilot fetch X",
+  intro: "Fetch the content of an X (Twitter) post through Copilot Plus.",
+  endpoint: "/twitter4llm",
+  arg: ["url", "<x-or-twitter-url>"],
+  scriptFile: "fetch-x.mjs",
+});
+
+/** All plugin-shipped builtin skills, in display order. */
+export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
+  WEB_SEARCH,
+  READ_PDF,
+  YOUTUBE_TRANSCRIPT,
+  FETCH_X,
+];

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
@@ -32,8 +32,8 @@ function skill(version: number): BuiltinSkill {
   return {
     name: "copilot-web-search",
     version,
-    enabledAgents: ["claude"],
-    skillMd: `---\nname: copilot-web-search\ndescription: d\nmetadata:\n  copilot-builtin-version: "${version}"\n---\nbody v${version}`,
+    enabledAgents: ["claude", "codex", "opencode"],
+    skillMd: `---\nname: copilot-web-search\ndescription: d\nmetadata:\n  copilot-enabled-agents: claude, codex, opencode\n  copilot-builtin-version: "${version}"\n---\nbody v${version}`,
     files: [{ path: "web-search.sh", content: `// script v${version}` }],
   };
 }
@@ -125,5 +125,22 @@ describe("seedBuiltinSkills", () => {
 
     expect(seeded).toEqual(["copilot-web-search"]);
     expect(fs.files.get(SCRIPT)).toBe("// script v1");
+  });
+
+  it("preserves user-modified copilot-enabled-agents when upgrading a builtin", async () => {
+    // User disabled codex and opencode via the toggle UI — SKILL.md was rewritten
+    // on disk to list only 'claude'. On the next version bump the seeder must not
+    // silently restore the full bundled agent list.
+    const disabledMd = skill(1).skillMd.replace(
+      "copilot-enabled-agents: claude, codex, opencode",
+      "copilot-enabled-agents: claude"
+    );
+    const fs = memFs({ [MD]: disabledMd, [SCRIPT]: "// script v1" });
+    await seedBuiltinSkills({ skillsFolderRelPath: FOLDER, fs, skills: [skill(2)] });
+
+    const written = fs.files.get(MD) ?? "";
+    expect(written).toContain("copilot-enabled-agents: claude\n");
+    expect(written).not.toContain("copilot-enabled-agents: claude, codex, opencode");
+    expect(written).toContain("body v2"); // bundled body was updated
   });
 });

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
@@ -1,0 +1,106 @@
+import { seedBuiltinSkills, type BuiltinSeedFs } from "./seedBuiltinSkills";
+import type { BuiltinSkill } from "./builtinSkills";
+
+jest.mock("@/logger", () => ({ logError: jest.fn(), logInfo: jest.fn() }));
+
+/** In-memory FS over vault-relative POSIX paths. */
+function memFs(initialFiles: Record<string, string> = {}): BuiltinSeedFs & {
+  files: Map<string, string>;
+  dirs: Set<string>;
+} {
+  const files = new Map(Object.entries(initialFiles));
+  const dirs = new Set<string>();
+  return {
+    files,
+    dirs,
+    exists: async (p) => files.has(p) || dirs.has(p),
+    read: async (p) => {
+      const v = files.get(p);
+      if (v === undefined) throw new Error(`ENOENT ${p}`);
+      return v;
+    },
+    write: async (p, c) => {
+      files.set(p, c);
+    },
+    mkdir: async (p) => {
+      dirs.add(p);
+    },
+  };
+}
+
+function skill(version: number): BuiltinSkill {
+  return {
+    name: "copilot-web-search",
+    version,
+    enabledAgents: ["claude"],
+    skillMd: `---\nname: copilot-web-search\ndescription: d\nmetadata:\n  copilot-builtin-version: "${version}"\n---\nbody v${version}`,
+    files: [{ path: "web-search.mjs", content: `// script v${version}` }],
+  };
+}
+
+const FOLDER = "copilot/skills";
+const MD = "copilot/skills/copilot-web-search/SKILL.md";
+const SCRIPT = "copilot/skills/copilot-web-search/web-search.mjs";
+
+describe("seedBuiltinSkills", () => {
+  it("writes SKILL.md and scripts when the skill is missing", async () => {
+    const fs = memFs();
+    const { seeded } = await seedBuiltinSkills({
+      skillsFolderRelPath: FOLDER,
+      fs,
+      skills: [skill(1)],
+    });
+
+    expect(seeded).toEqual(["copilot-web-search"]);
+    expect(fs.files.get(MD)).toContain("body v1");
+    expect(fs.files.get(SCRIPT)).toBe("// script v1");
+    expect(fs.dirs.has("copilot/skills/copilot-web-search")).toBe(true);
+  });
+
+  it("is idempotent: skips a skill already present at the current version", async () => {
+    const fs = memFs({ [MD]: skill(1).skillMd, [SCRIPT]: "// user-touched" });
+    const { seeded } = await seedBuiltinSkills({
+      skillsFolderRelPath: FOLDER,
+      fs,
+      skills: [skill(1)],
+    });
+
+    expect(seeded).toEqual([]);
+    // Untouched — the script the user may have inspected stays as-is.
+    expect(fs.files.get(SCRIPT)).toBe("// user-touched");
+  });
+
+  it("re-seeds when the bundled version is newer", async () => {
+    const fs = memFs({ [MD]: skill(1).skillMd, [SCRIPT]: "// script v1" });
+    const { seeded } = await seedBuiltinSkills({
+      skillsFolderRelPath: FOLDER,
+      fs,
+      skills: [skill(2)],
+    });
+
+    expect(seeded).toEqual(["copilot-web-search"]);
+    expect(fs.files.get(MD)).toContain("body v2");
+    expect(fs.files.get(SCRIPT)).toBe("// script v2");
+  });
+
+  it("re-seeds when the SKILL.md was deleted", async () => {
+    // Script lingered but SKILL.md is gone — treat as missing and re-seed.
+    const fs = memFs({ [SCRIPT]: "// stale" });
+    const { seeded } = await seedBuiltinSkills({
+      skillsFolderRelPath: FOLDER,
+      fs,
+      skills: [skill(1)],
+    });
+
+    expect(seeded).toEqual(["copilot-web-search"]);
+    expect(fs.files.get(MD)).toContain("body v1");
+  });
+
+  it("never touches unrelated user skills in the same folder", async () => {
+    const userMd = "copilot/skills/my-skill/SKILL.md";
+    const fs = memFs({ [userMd]: "user content" });
+    await seedBuiltinSkills({ skillsFolderRelPath: FOLDER, fs, skills: [skill(1)] });
+
+    expect(fs.files.get(userMd)).toBe("user content");
+  });
+});

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
@@ -106,10 +106,24 @@ describe("seedBuiltinSkills", () => {
 
   it("does not overwrite a user-authored skill whose name collides with a builtin", async () => {
     // A user created copilot-web-search before it became a builtin — no version marker.
-    const userContent = "---\nname: copilot-web-search\ndescription: my custom search\n---\ncustom body";
+    const userContent =
+      "---\nname: copilot-web-search\ndescription: my custom search\n---\ncustom body";
     const fs = memFs({ [MD]: userContent });
     await seedBuiltinSkills({ skillsFolderRelPath: FOLDER, fs, skills: [skill(1)] });
 
     expect(fs.files.get(MD)).toBe(userContent);
+  });
+
+  it("re-seeds when SKILL.md is current but a support file is missing (partial write recovery)", async () => {
+    // Simulate a crash after SKILL.md was written but before the .mjs script.
+    const fs = memFs({ [MD]: skill(1).skillMd }); // no SCRIPT
+    const { seeded } = await seedBuiltinSkills({
+      skillsFolderRelPath: FOLDER,
+      fs,
+      skills: [skill(1)],
+    });
+
+    expect(seeded).toEqual(["copilot-web-search"]);
+    expect(fs.files.get(SCRIPT)).toBe("// script v1");
   });
 });

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
@@ -34,13 +34,13 @@ function skill(version: number): BuiltinSkill {
     version,
     enabledAgents: ["claude"],
     skillMd: `---\nname: copilot-web-search\ndescription: d\nmetadata:\n  copilot-builtin-version: "${version}"\n---\nbody v${version}`,
-    files: [{ path: "web-search.mjs", content: `// script v${version}` }],
+    files: [{ path: "web-search.sh", content: `// script v${version}` }],
   };
 }
 
 const FOLDER = "copilot/skills";
 const MD = "copilot/skills/copilot-web-search/SKILL.md";
-const SCRIPT = "copilot/skills/copilot-web-search/web-search.mjs";
+const SCRIPT = "copilot/skills/copilot-web-search/web-search.sh";
 
 describe("seedBuiltinSkills", () => {
   it("writes SKILL.md and scripts when the skill is missing", async () => {
@@ -115,7 +115,7 @@ describe("seedBuiltinSkills", () => {
   });
 
   it("re-seeds when SKILL.md is current but a support file is missing (partial write recovery)", async () => {
-    // Simulate a crash after SKILL.md was written but before the .mjs script.
+    // Simulate a crash after SKILL.md was written but before the script.
     const fs = memFs({ [MD]: skill(1).skillMd }); // no SCRIPT
     const { seeded } = await seedBuiltinSkills({
       skillsFolderRelPath: FOLDER,

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
@@ -103,4 +103,13 @@ describe("seedBuiltinSkills", () => {
 
     expect(fs.files.get(userMd)).toBe("user content");
   });
+
+  it("does not overwrite a user-authored skill whose name collides with a builtin", async () => {
+    // A user created copilot-web-search before it became a builtin — no version marker.
+    const userContent = "---\nname: copilot-web-search\ndescription: my custom search\n---\ncustom body";
+    const fs = memFs({ [MD]: userContent });
+    await seedBuiltinSkills({ skillsFolderRelPath: FOLDER, fs, skills: [skill(1)] });
+
+    expect(fs.files.get(MD)).toBe(userContent);
+  });
 });

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.ts
@@ -23,12 +23,17 @@ export interface SeedBuiltinSkillsOptions {
   skills?: readonly BuiltinSkill[];
 }
 
-/** Reads `metadata.copilot-builtin-version` from a seeded SKILL.md, or 0. */
+/**
+ * Matches `metadata.copilot-builtin-version` in a SKILL.md. Absence of this
+ * field means the file is user-authored — we must not overwrite it even if the
+ * folder name collides with a builtin skill name.
+ */
 const VERSION_RE = /copilot-builtin-version:\s*"?(\d+)"?/;
 
-function seededVersion(skillMd: string): number {
+/** Returns the seeded version number, or null if the file is not a builtin. */
+function seededVersion(skillMd: string): number | null {
   const m = skillMd.match(VERSION_RE);
-  return m ? Number.parseInt(m[1], 10) : 0;
+  return m ? Number.parseInt(m[1], 10) : null;
 }
 
 /**
@@ -75,7 +80,9 @@ export async function seedBuiltinSkills(
 
     if (await fs.exists(skillMdPath)) {
       try {
-        if (seededVersion(await fs.read(skillMdPath)) >= skill.version) {
+        const existing = seededVersion(await fs.read(skillMdPath));
+        // null = no copilot-builtin-version marker → user-authored file; skip.
+        if (existing === null || existing >= skill.version) {
           continue;
         }
       } catch (e) {

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.ts
@@ -36,6 +36,21 @@ function seededVersion(skillMd: string): number | null {
   return m ? Number.parseInt(m[1], 10) : null;
 }
 
+const ENABLED_AGENTS_RE = /^([ \t]*copilot-enabled-agents:[ \t]*)(.*)$/m;
+
+/**
+ * Read the `copilot-enabled-agents` line from an existing SKILL.md and splice
+ * it into the bundled replacement, preserving any agent-disable choices the
+ * user made via the UI. Returns the patched content unchanged when the field
+ * is absent in either string.
+ */
+function preserveEnabledAgents(existingMd: string, bundledMd: string): string {
+  const existing = existingMd.match(ENABLED_AGENTS_RE);
+  if (!existing) return bundledMd;
+  // Replace the bundled copilot-enabled-agents value with the existing one.
+  return bundledMd.replace(ENABLED_AGENTS_RE, `$1${existing[2]}`);
+}
+
 /**
  * Create a directory and all missing ancestor segments. Mirrors the
  * segment-by-segment approach of `ensureFolderExists` in `utils.ts` so that
@@ -78,15 +93,18 @@ export async function seedBuiltinSkills(
     const dir = joinPosix(skillsFolderRelPath, skill.name);
     const skillMdPath = joinPosix(dir, "SKILL.md");
 
+    // existingContent is captured here so we can carry the user's
+    // copilot-enabled-agents choice forward when re-seeding an upgrade.
+    let existingContent: string | null = null;
     if (await fs.exists(skillMdPath)) {
       try {
-        const existing = seededVersion(await fs.read(skillMdPath));
+        existingContent = await fs.read(skillMdPath);
+        const existing = seededVersion(existingContent);
         // null = no copilot-builtin-version marker → user-authored file; skip.
         if (existing === null) continue;
         // Version is current — only skip if all support files are also present.
-        // A partial write (e.g. crash after SKILL.md but before .mjs) would
-        // leave the skill advertising a script that doesn't exist; re-seed to
-        // self-heal.
+        // A partial write (e.g. crash after SKILL.md but before the .sh file)
+        // would leave the skill advertising a stale script; re-seed to self-heal.
         if (existing >= skill.version) {
           const allFilesPresent = await Promise.all(
             skill.files.map((f) => fs.exists(joinPosix(dir, f.path)))
@@ -101,6 +119,13 @@ export async function seedBuiltinSkills(
 
     try {
       await ensureDir(fs, dir);
+      // Carry the user's agent-disable choices forward: if they toggled any
+      // agent off via the UI, copilot-enabled-agents was rewritten on disk.
+      // Preserve that value in the bundled replacement so the upgrade doesn't
+      // silently undo the user's preference.
+      const skillMd = existingContent
+        ? preserveEnabledAgents(existingContent, skill.skillMd)
+        : skill.skillMd;
       // Write support files before SKILL.md so the version stamp in SKILL.md
       // only appears once all scripts are on disk. A crash between writes then
       // leaves no SKILL.md (or a stale-version one), so the next startup
@@ -108,7 +133,7 @@ export async function seedBuiltinSkills(
       for (const file of skill.files) {
         await fs.write(joinPosix(dir, file.path), file.content);
       }
-      await fs.write(skillMdPath, skill.skillMd);
+      await fs.write(skillMdPath, skillMd);
       seeded.push(skill.name);
     } catch (e) {
       logError(`[Skills] failed to seed builtin skill ${skill.name}`, e);

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.ts
@@ -31,9 +31,22 @@ function seededVersion(skillMd: string): number {
   return m ? Number.parseInt(m[1], 10) : 0;
 }
 
+/**
+ * Create a directory and all missing ancestor segments. Mirrors the
+ * segment-by-segment approach of `ensureFolderExists` in `utils.ts` so that
+ * seeding into nested paths like `copilot/skills` works on a fresh vault.
+ */
 async function ensureDir(fs: BuiltinSeedFs, relPath: string): Promise<void> {
-  if (!(await fs.exists(relPath))) {
-    await fs.mkdir(relPath);
+  const segments = relPath
+    .replace(/^\/+|\/+$/g, "")
+    .split("/")
+    .filter(Boolean);
+  let current = "";
+  for (const segment of segments) {
+    current = current ? `${current}/${segment}` : segment;
+    if (!(await fs.exists(current))) {
+      await fs.mkdir(current);
+    }
   }
 }
 

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.ts
@@ -82,8 +82,16 @@ export async function seedBuiltinSkills(
       try {
         const existing = seededVersion(await fs.read(skillMdPath));
         // null = no copilot-builtin-version marker → user-authored file; skip.
-        if (existing === null || existing >= skill.version) {
-          continue;
+        if (existing === null) continue;
+        // Version is current — only skip if all support files are also present.
+        // A partial write (e.g. crash after SKILL.md but before .mjs) would
+        // leave the skill advertising a script that doesn't exist; re-seed to
+        // self-heal.
+        if (existing >= skill.version) {
+          const allFilesPresent = await Promise.all(
+            skill.files.map((f) => fs.exists(joinPosix(dir, f.path)))
+          ).then((results) => results.every(Boolean));
+          if (allFilesPresent) continue;
         }
       } catch (e) {
         // Unreadable existing copy — fall through and re-seed.

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.ts
@@ -101,10 +101,14 @@ export async function seedBuiltinSkills(
 
     try {
       await ensureDir(fs, dir);
-      await fs.write(skillMdPath, skill.skillMd);
+      // Write support files before SKILL.md so the version stamp in SKILL.md
+      // only appears once all scripts are on disk. A crash between writes then
+      // leaves no SKILL.md (or a stale-version one), so the next startup
+      // re-seeds the whole skill rather than skipping it as current.
       for (const file of skill.files) {
         await fs.write(joinPosix(dir, file.path), file.content);
       }
+      await fs.write(skillMdPath, skill.skillMd);
       seeded.push(skill.name);
     } catch (e) {
       logError(`[Skills] failed to seed builtin skill ${skill.name}`, e);

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.ts
@@ -1,0 +1,90 @@
+import { logError, logInfo } from "@/logger";
+import { joinPosix } from "@/utils/pathUtils";
+import { BUILTIN_SKILLS, type BuiltinSkill } from "./builtinSkills";
+
+/**
+ * Minimal write-capable FS surface the seeder needs, over vault-relative
+ * POSIX paths. Modelled on the read-only `SkillsFsAdapter` but with the
+ * `write`/`mkdir` the seeder requires. Kept small so unit tests pass a plain
+ * object instead of mocking the Obsidian vault adapter.
+ */
+export interface BuiltinSeedFs {
+  exists(relPath: string): Promise<boolean>;
+  read(relPath: string): Promise<string>;
+  write(relPath: string, content: string): Promise<void>;
+  mkdir(relPath: string): Promise<void>;
+}
+
+export interface SeedBuiltinSkillsOptions {
+  /** Vault-relative POSIX path of the canonical skills folder (e.g. `copilot/skills`). */
+  skillsFolderRelPath: string;
+  fs: BuiltinSeedFs;
+  /** Override the skill set (tests). Defaults to {@link BUILTIN_SKILLS}. */
+  skills?: readonly BuiltinSkill[];
+}
+
+/** Reads `metadata.copilot-builtin-version` from a seeded SKILL.md, or 0. */
+const VERSION_RE = /copilot-builtin-version:\s*"?(\d+)"?/;
+
+function seededVersion(skillMd: string): number {
+  const m = skillMd.match(VERSION_RE);
+  return m ? Number.parseInt(m[1], 10) : 0;
+}
+
+async function ensureDir(fs: BuiltinSeedFs, relPath: string): Promise<void> {
+  if (!(await fs.exists(relPath))) {
+    await fs.mkdir(relPath);
+  }
+}
+
+/**
+ * Write each plugin-shipped builtin skill into the canonical skills folder
+ * when it is missing or older than the bundled `version`. Idempotent: a skill
+ * already present at the current version is left untouched, so this is safe to
+ * run on every plugin load. User-authored skills in the same folder are never
+ * touched. Returns the names actually (re)written.
+ *
+ * Only writes content — symlink fanout to agent dirs is left to the normal
+ * `SkillManager.refresh()` reconcile pass that runs after seeding.
+ */
+export async function seedBuiltinSkills(
+  options: SeedBuiltinSkillsOptions
+): Promise<{ seeded: string[] }> {
+  const { skillsFolderRelPath, fs } = options;
+  const skills = options.skills ?? BUILTIN_SKILLS;
+  const seeded: string[] = [];
+
+  await ensureDir(fs, skillsFolderRelPath);
+
+  for (const skill of skills) {
+    const dir = joinPosix(skillsFolderRelPath, skill.name);
+    const skillMdPath = joinPosix(dir, "SKILL.md");
+
+    if (await fs.exists(skillMdPath)) {
+      try {
+        if (seededVersion(await fs.read(skillMdPath)) >= skill.version) {
+          continue;
+        }
+      } catch (e) {
+        // Unreadable existing copy — fall through and re-seed.
+        logError(`[Skills] could not read builtin skill ${skill.name} for version check`, e);
+      }
+    }
+
+    try {
+      await ensureDir(fs, dir);
+      await fs.write(skillMdPath, skill.skillMd);
+      for (const file of skill.files) {
+        await fs.write(joinPosix(dir, file.path), file.content);
+      }
+      seeded.push(skill.name);
+    } catch (e) {
+      logError(`[Skills] failed to seed builtin skill ${skill.name}`, e);
+    }
+  }
+
+  if (seeded.length > 0) {
+    logInfo(`[Skills] seeded builtin skills: ${seeded.join(", ")}`);
+  }
+  return { seeded };
+}


### PR DESCRIPTION
## Summary

Brings Copilot Plus power tools to all three agents (Claude, Codex, OpenCode) as plugin-shipped **builtin skills**, so paying users keep these capabilities in Agent Mode. Fixes https://github.com/logancyang/obsidian-copilot-preview/issues/104.

Four skills, Copilot-branded so they don't collide with agents' own web/file tools:

| Skill | Relay endpoint |
|---|---|
| `copilot-web-search` | `/websearch` |
| `copilot-read-pdf` | `/pdf4llm` (multipart) |
| `copilot-youtube-transcript` | `/youtube4llm` |
| `copilot-fetch-x` | `/twitter4llm` |

Vault semantic search is intentionally **deferred** — it runs against the in-plugin vector store, not the relay, so it can't be a standalone script.

## How it works

- **Builtin skills** (`skills/builtin/builtinSkills.ts`): each is a `SKILL.md` + a Node `.mjs` script. A `relaySkill` factory generates the three near-identical relay tools; PDF is hand-written (uploads multipart). Scripts read the license/relay config from env and call Brevilabs directly; on a missing/invalid license they exit non-zero with an upgrade/renew message the agent relays to the user.
- **Seeding** (`skills/builtin/seedBuiltinSkills.ts`): idempotent, version-stamped writer into `<vault>/copilot/skills/`. Writes when missing or when the bundled `version` is newer; never touches user skills. Wired into plugin load before the first `SkillManager.refresh()`, so the existing symlink fanout (via `metadata.copilot-enabled-agents`) puts them in `.claude/skills` / `.agents/skills` / `.opencode/skills`.
- **License delivery (Option B)** (`backends/shared/copilotPlusEnv.ts`): the decrypted `plusLicenseKey` + relay base URL + `user_id` are injected into each backend's spawn env, merged *before* user `envOverrides`. Codex via `buildSimpleSpawnDescriptor`'s new `managedEnv` param; OpenCode inline; Claude via a `getManagedEnv` callback (so `sdk/` keeps its lint boundary and never imports `backends/`). Backends restart on Plus sign-in/out so the env refreshes without a reload.

## Testing

- `npm run format` / `npm run lint` — clean
- `npm run build` — `tsc -noEmit` + esbuild succeed
- `npm run test` — **3369/3369 passing**, including new unit tests for the seeder (write-when-missing, idempotent skip, refresh-on-version-bump, re-seed-on-delete, leaves user skills untouched) and `buildCopilotPlusEnv` (env when Plus + key; empty when not Plus / no key / decrypt fails).

Ran `/simplify` (4-agent cleanup): applied a `relaySkill` factory (collapsed 3 copy-pasted skills) and folded a duplicate settings subscription; reviewers confirmed the env-injection altitude and vault-file seeding as correct.

### Verification still wanted before close
- Manual `npm run test:vault` on desktop: with a valid Plus key, run a web search + YouTube transcript through each of Claude/Codex/OpenCode; then remove the key and confirm each agent surfaces the upgrade prompt. (Scripts hit the live relay, so not covered by unit tests.)
- Confirm the relay response shapes render usefully inline (the scripts emit the raw relay JSON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
