### PR TITLE
Steer agents toward Copilot Plus builtin skills (with fallback)

### DIFF
--- a/src/agentMode/backends/shared/agentSystemPrompt.test.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.test.ts
@@ -1,4 +1,4 @@
-import { resetSettings } from "@/settings/model";
+import { resetSettings, updateSetting } from "@/settings/model";
 import {
   setDefaultSystemPromptTitle,
   setDisableBuiltinSystemPrompt,
@@ -6,7 +6,11 @@ import {
   updateCachedSystemPrompts,
 } from "@/system-prompts/state";
 import type { UserSystemPrompt } from "@/system-prompts/type";
-import { buildAgentSystemPrompt, COPILOT_PROMPT_BASE } from "./agentSystemPrompt";
+import {
+  buildAgentSystemPrompt,
+  COPILOT_PLUS_TOOLS_STEERING,
+  COPILOT_PROMPT_BASE,
+} from "./agentSystemPrompt";
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
@@ -76,6 +80,32 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain(COPILOT_PROMPT_BASE);
     expect(prompt).not.toContain("<user_custom_instructions>");
     expect(prompt).toContain("{folder_name}");
+  });
+
+  it("does not steer toward Copilot Plus skills for a non-Plus user", () => {
+    // Default settings → not a Plus user.
+    const prompt = buildAgentSystemPrompt();
+    expect(prompt).not.toContain(COPILOT_PLUS_TOOLS_STEERING);
+    expect(prompt).not.toContain("copilot-web-search");
+  });
+
+  it("steers toward the builtin Copilot Plus skills for a Plus user", () => {
+    updateSetting("isPlusUser", true);
+    const prompt = buildAgentSystemPrompt();
+    expect(prompt).toContain(COPILOT_PLUS_TOOLS_STEERING);
+    expect(prompt).toContain("copilot-web-search");
+    expect(prompt).toContain("copilot-read-pdf");
+    expect(prompt).toContain("copilot-youtube-transcript");
+    expect(prompt).toContain("copilot-fetch-x");
+    // Fallback clause so a missing/unlicensed skill never dead-ends.
+    expect(prompt).toMatch(/fall back to whatever equivalent capability/i);
+  });
+
+  it("suppresses the Plus steering when the builtin prompt is disabled", () => {
+    updateSetting("isPlusUser", true);
+    setDisableBuiltinSystemPrompt(true);
+    const prompt = buildAgentSystemPrompt();
+    expect(prompt).not.toContain(COPILOT_PLUS_TOOLS_STEERING);
   });
 });
 

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -12,6 +12,8 @@
  *
  *   1. `COPILOT_PROMPT_BASE` (the Obsidian-vault identity) — unless the user
  *      enabled Settings → System prompts → "Disable builtin system prompt".
+ *      Followed, for Plus users only, by `COPILOT_PLUS_TOOLS_STEERING` (prefer
+ *      the builtin Copilot Plus skills, with a fallback to the agent's own tools).
  *   2. The pill-syntax directive (`buildPillSyntaxDirective`) — always present;
  *      it teaches the agent how to read the chat editor's `[[note]]`/`{folder}`
  *      tokens and is functional wiring, not "builtin framing" the user toggles.
@@ -36,6 +38,24 @@
 import { buildPillSyntaxDirective } from "@/agentMode/skills/pillSyntaxDirective";
 import { getDisableBuiltinSystemPrompt } from "@/system-prompts/state";
 import { getEffectiveUserPrompt } from "@/system-prompts/systemPromptBuilder";
+import { getSettings } from "@/settings/model";
+
+/**
+ * Steers the agent toward the bundled Copilot Plus skills for the four relay
+ * capabilities (see `skills/builtin/builtinSkills.ts`) instead of its own
+ * built-in web/fetch tools, with an explicit fallback so the request never
+ * dead-ends when a skill is missing, disabled, or unlicensed. Only sent to
+ * Plus users (see `buildAgentSystemPrompt`) — without a license the skills
+ * can't run anyway, so a non-Plus agent should just use its own tools.
+ */
+export const COPILOT_PLUS_TOOLS_STEERING = `## Copilot Plus tools
+For these requests, prefer the bundled Copilot skill over any built-in tool of your own:
+- Searching the web → the \`copilot-web-search\` skill
+- Reading a PDF file → the \`copilot-read-pdf\` skill
+- Getting a YouTube video's transcript → the \`copilot-youtube-transcript\` skill
+- Fetching an X (Twitter) post → the \`copilot-fetch-x\` skill
+
+If the matching skill is missing, disabled, or reports that it needs an active Copilot Plus license, fall back to whatever equivalent capability you have (or tell the user it's unavailable) — don't refuse the request.`;
 
 export const COPILOT_PROMPT_BASE = `You are Obsidian Copilot, an AI assistant that helps users work with their Obsidian vault — markdown notes for knowledge management, writing, and research. You are NOT a software-engineering agent or CLI coding tool. The working directory is the user's Obsidian vault: a collection of markdown notes, not a code repository. Disregard any framing in environment metadata that suggests otherwise.
 
@@ -92,6 +112,14 @@ export function buildAgentSystemPrompt(): string {
   // it is always sent.
   if (!getDisableBuiltinSystemPrompt()) {
     parts.push(COPILOT_PROMPT_BASE);
+    // Plus-only: steer toward the builtin Copilot Plus skills. Gated on the
+    // license because the skills can't run without one — a non-Plus agent
+    // should reach for its own tools directly. Backends restart on Plus
+    // sign-in/out (see `createAgentSessionManager`), so this refreshes on the
+    // next session without a reload.
+    if (getSettings().isPlusUser) {
+      parts.push(COPILOT_PLUS_TOOLS_STEERING);
+    }
   }
 
   parts.push(buildPillSyntaxDirective());


### PR DESCRIPTION
## Summary

Companion to #2537 (builtin Copilot Plus skills): a system-prompt nudge so agents actually reach for those skills instead of their own built-in web/fetch tools. This is "Option 2" — steering, not forcing (the agents' native tools stay available as a fallback).

Adds a Plus-only block to the shared agent system prompt (`agentSystemPrompt.ts`):

```
## Copilot Plus tools
For these requests, prefer the bundled Copilot skill over any built-in tool of your own:
- Searching the web → copilot-web-search
- Reading a PDF file → copilot-read-pdf
- Getting a YouTube video's transcript → copilot-youtube-transcript
- Fetching an X (Twitter) post → copilot-fetch-x

If the matching skill is missing, disabled, or reports that it needs an active
Copilot Plus license, fall back to whatever equivalent capability you have (or
tell the user it's unavailable) — don't refuse the request.
```

## Behavior

- **Plus users** get the steering → agents prefer the Copilot skills.
- **Non-Plus users** get nothing (gated on `isPlusUser`) → agents use their own tools directly. The skills can't run without a license, so steering a non-Plus agent would only cause a failed attempt + an upgrade nag on every web search.
- **Suppressed** with the rest of the builtin framing when "Disable builtin system prompt" is on.
- Backends already restart on Plus sign-in/out (from #2537's wiring), so this refreshes on the next session without a reload.

## Why a separate PR (and why merge order doesn't matter)

It touches only `agentSystemPrompt.ts`, which #2537 doesn't, so there's no conflict with #2537's review cycle. The **fallback clause makes it safe to merge in either order**: if this lands before the skills exist, a Plus agent told to "prefer copilot-web-search" simply finds no such skill and falls back to its own tools.

## Caveat (expectation-setting)

Steering raises the hit-rate but is **not deterministic** — skill selection is the agent model's call. Truly guaranteeing the Copilot path would require denying the agents' native web/fetch tools, which is a separate, heavier change (and a product tradeoff). This PR is the cheap, high-leverage lever.

## Testing

- `npm run build` (tsc) clean; `agentSystemPrompt.ts`/test lint clean.
- New unit tests in `agentSystemPrompt.test.ts`: steering present for a Plus user (all four skill names + the fallback clause), absent for a non-Plus user, and suppressed when the builtin prompt is disabled. Full file: 15/15.

Refs https://github.com/logancyang/obsidian-copilot-preview/issues/104

🤖 Generated with [Claude Code](https://claude.com/claude-code)
