### PR TITLE
Expand Windows auto-detect for Claude and opencode binaries

### DIFF
--- a/src/agentMode/backends/claude/claudeBinaryResolver.test.ts
+++ b/src/agentMode/backends/claude/claudeBinaryResolver.test.ts
@@ -185,4 +185,57 @@ describe("resolveClaudeBinary — Windows", () => {
     const fs = makeFs([override]);
     expect(resolveClaudeBinary(winInput(fs, { override }))).toBe(override);
   });
+
+  it("finds the native-installer claude.exe under ~/.local/bin", () => {
+    const p = "C:\\Users\\me\\.local\\bin\\claude.exe";
+    expect(resolveClaudeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("finds the legacy local install at ~/.claude/local/claude.exe", () => {
+    const p = "C:\\Users\\me\\.claude\\local\\claude.exe";
+    expect(resolveClaudeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("finds %LOCALAPPDATA%\\Claude\\claude.exe via the LOCALAPPDATA env var", () => {
+    const p = "D:\\AppData\\Local\\Claude\\claude.exe";
+    expect(
+      resolveClaudeBinary(winInput(makeFs([p]), { env: { LOCALAPPDATA: "D:\\AppData\\Local" } }))
+    ).toBe(p);
+  });
+
+  it("falls back to <homeDir>\\AppData\\Local\\Claude\\claude.exe when LOCALAPPDATA is unset", () => {
+    const p = "C:\\Users\\me\\AppData\\Local\\Claude\\claude.exe";
+    expect(resolveClaudeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("finds %ProgramFiles%\\Claude\\claude.exe (default C:\\Program Files)", () => {
+    const p = "C:\\Program Files\\Claude\\claude.exe";
+    expect(resolveClaudeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("finds %ProgramFiles(x86)%\\Claude\\claude.exe (default C:\\Program Files (x86))", () => {
+    const p = "C:\\Program Files (x86)\\Claude\\claude.exe";
+    expect(resolveClaudeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("prefers the native ~/.local/bin install over an npm-global claude.exe", () => {
+    const native = "C:\\Users\\me\\.local\\bin\\claude.exe";
+    const npm = "C:\\Users\\me\\AppData\\Roaming\\npm\\claude.exe";
+    expect(resolveClaudeBinary(winInput(makeFs([native, npm])))).toBe(native);
+  });
+
+  it("prefers cli-wrapper.cjs over cli.js when both exist", () => {
+    const base = "C:\\Users\\me\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code";
+    const wrapper = `${base}\\cli-wrapper.cjs`;
+    const cliJs = `${base}\\cli.js`;
+    expect(resolveClaudeBinary(winInput(makeFs([wrapper, cliJs])))).toBe(wrapper);
+  });
+
+  it("never picks the desktop app's WindowsApps GUI launcher", () => {
+    // `Claude.exe` registered by the desktop app under
+    // %LOCALAPPDATA%\Microsoft\WindowsApps opens a GUI window instead of
+    // running headless. Auto-detect must never select it.
+    const guiLauncher = "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\Claude.exe";
+    expect(resolveClaudeBinary(winInput(makeFs([guiLauncher])))).toBeNull();
+  });
 });

--- a/src/agentMode/backends/claude/claudeBinaryResolver.ts
+++ b/src/agentMode/backends/claude/claudeBinaryResolver.ts
@@ -81,12 +81,29 @@ function unixCandidates(input: ClaudeBinaryResolverInput): Array<string | null> 
 }
 
 function windowsCandidates(input: ClaudeBinaryResolverInput): Array<string | null> {
-  // Per-dir, prefer `claude.exe`, then `cli.js` under that dir's
-  // node_modules. Never pick `claude.cmd` — it requires `shell: true` and
-  // breaks SDK stdio streaming.
-  const out: Array<string | null> = [];
+  const { homeDir, env } = input;
+  const localAppData = env.LOCALAPPDATA ?? win.join(homeDir, "AppData", "Local");
+  const programFiles = env.ProgramFiles ?? "C:\\Program Files";
+  const programFilesX86 = env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+
+  // Native-installer (`irm https://claude.ai/install.ps1 | iex`) destinations
+  // probed before the node-tool layout. Fixed list — no PATH walk. A PATH walk
+  // on Windows risks `WindowsApps\Claude.exe`, the desktop app's GUI launcher
+  // (opens a window instead of streaming stream-json).
+  const out: Array<string | null> = [
+    win.join(homeDir, ".local", "bin", "claude.exe"),
+    win.join(homeDir, ".claude", "local", "claude.exe"),
+    win.join(localAppData, "Claude", "claude.exe"),
+    win.join(programFiles, "Claude", "claude.exe"),
+    win.join(programFilesX86, "Claude", "claude.exe"),
+  ];
+  // Per-dir, prefer `claude.exe`, then `cli-wrapper.cjs` (newer Claude Code
+  // packaging), then `cli.js` (legacy) under that dir's node_modules. Never
+  // pick `claude.cmd` — it requires `shell: true` and breaks SDK stdio
+  // streaming.
   for (const dir of nodeToolBinDirCandidates(input)) {
     out.push(win.join(dir, "claude.exe"));
+    out.push(win.join(dir, "node_modules", "@anthropic-ai", "claude-code", "cli-wrapper.cjs"));
     out.push(win.join(dir, "node_modules", "@anthropic-ai", "claude-code", "cli.js"));
   }
   return out;

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -8,6 +8,7 @@ import {
   ProgressEvent,
 } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
 import type { OpencodeBinaryManager } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
+import { detectOpencodeCliPath } from "@/agentMode/backends/opencode/descriptor";
 import type { InstallState } from "@/agentMode/session/types";
 import { ReactModal } from "@/components/modals/ReactModal";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
@@ -248,10 +249,11 @@ const OpencodeConfigBody: React.FC<{
           binaryName="opencode"
           placeholder="/absolute/path/to/opencode"
           initialPath={customPath}
-          notFoundHint="opencode not found on PATH. Install it or paste a custom path manually."
+          notFoundHint="opencode not found. Install it natively (`~/.opencode/bin/opencode[.exe]`), via bun/npm, or paste a custom path manually."
           onSave={onSaveCustomPath}
           onClear={clearCustomPath}
           persistOnAutoDetect
+          detect={detectOpencodeCliPath}
         />
       </ConfigSection>
     </ConfigDialogShell>

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
 import { OpencodeInstallModal } from "@/agentMode/backends/opencode/OpencodeInstallModal";
 import OpencodeLogo from "@/agentMode/backends/opencode/logo.svg";
 import type CopilotPlugin from "@/main";
@@ -14,7 +16,9 @@ import {
 import { computeInstallState, OpencodeBinaryManager } from "./OpencodeBinaryManager";
 import { opencodeEnabledModelEntries } from "./opencodeModelResolve";
 import { OpencodeSettingsPanel } from "./OpencodeSettingsPanel";
+import { resolveOpencodeBinary } from "./opencodeBinaryResolver";
 import { mapNodeArch, mapNodePlatform } from "./platformResolver";
+import { detectBinary } from "@/utils/detectBinary";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { simpleBinaryBackendProcess } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import type {
@@ -85,6 +89,31 @@ const opencodeWire: ModelWireCodec = {
 export function getOpencodeBinaryManager(plugin: CopilotPlugin): OpencodeBinaryManager {
   if (!managerRef) managerRef = new OpencodeBinaryManager(plugin);
   return managerRef;
+}
+
+/**
+ * Run an auto-detect for an externally-installed `opencode`, ignoring any
+ * stale custom-path override (e.g. a POSIX path synced from a macOS profile
+ * onto Windows). Walks well-known native-install layouts (`~/.opencode/bin`,
+ * `~/.bun/bin`, `~/.local/bin`, `%LOCALAPPDATA%\opencode\bin`, ProgramFiles)
+ * plus the shared node-tool dirs, then falls back to a PATH walk via
+ * `detectBinary` so users with a non-standard install dir on PATH still match.
+ * Independent of the managed binary.
+ */
+export async function detectOpencodeCliPath(): Promise<string | null> {
+  const fromResolver = resolveOpencodeBinary({
+    override: undefined,
+    homeDir: os.homedir(),
+    platform: process.platform,
+    env: process.env,
+    fs: {
+      existsSync: (p) => fs.existsSync(p),
+      readFileSync: (p, encoding) => fs.readFileSync(p, encoding),
+      readdirSync: (p) => fs.readdirSync(p),
+    },
+  });
+  if (fromResolver) return fromResolver;
+  return detectBinary("opencode");
 }
 
 /**

--- a/src/agentMode/backends/opencode/opencodeBinaryResolver.test.ts
+++ b/src/agentMode/backends/opencode/opencodeBinaryResolver.test.ts
@@ -1,0 +1,156 @@
+import {
+  resolveOpencodeBinary,
+  type OpencodeBinaryResolverFs,
+  type OpencodeBinaryResolverInput,
+} from "./opencodeBinaryResolver";
+
+function makeFs(paths: Iterable<string>): OpencodeBinaryResolverFs {
+  const set = new Set(paths);
+  return {
+    existsSync: (p: string) => set.has(p),
+    readFileSync: (p: string) => {
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${p}`);
+      err.code = "ENOENT";
+      throw err;
+    },
+    readdirSync: (p: string) => {
+      const err: NodeJS.ErrnoException = new Error(`ENOENT: ${p}`);
+      err.code = "ENOENT";
+      throw err;
+    },
+  };
+}
+
+function unixInput(
+  fs: OpencodeBinaryResolverFs,
+  overrides: Partial<OpencodeBinaryResolverInput> = {}
+): OpencodeBinaryResolverInput {
+  return {
+    homeDir: "/home/me",
+    platform: "linux",
+    env: {},
+    fs,
+    ...overrides,
+  };
+}
+
+function winInput(
+  fs: OpencodeBinaryResolverFs,
+  overrides: Partial<OpencodeBinaryResolverInput> = {}
+): OpencodeBinaryResolverInput {
+  return {
+    homeDir: "C:\\Users\\me",
+    platform: "win32",
+    env: { APPDATA: "C:\\Users\\me\\AppData\\Roaming" },
+    fs,
+    ...overrides,
+  };
+}
+
+describe("resolveOpencodeBinary — Unix", () => {
+  it("returns the override when it exists", () => {
+    const fs = makeFs(["/custom/opencode"]);
+    expect(resolveOpencodeBinary(unixInput(fs, { override: "/custom/opencode" }))).toBe(
+      "/custom/opencode"
+    );
+  });
+
+  it("ignores a stale override (e.g. cross-OS sync) and falls back to detection", () => {
+    // The bug this resolver guards against: a user's settings sync pulls in
+    // a POSIX override path onto Windows, or vice versa. The override doesn't
+    // exist on the new platform, so the resolver must keep walking.
+    const native = "/home/me/.opencode/bin/opencode";
+    const fs = makeFs([native]);
+    expect(
+      resolveOpencodeBinary(
+        unixInput(fs, { override: "C:\\Users\\someone\\.opencode\\bin\\opencode.exe" })
+      )
+    ).toBe(native);
+  });
+
+  it("finds the native installer at ~/.opencode/bin/opencode", () => {
+    const fs = makeFs(["/home/me/.opencode/bin/opencode"]);
+    expect(resolveOpencodeBinary(unixInput(fs))).toBe("/home/me/.opencode/bin/opencode");
+  });
+
+  it("finds the bun install at ~/.bun/bin/opencode", () => {
+    const fs = makeFs(["/home/me/.bun/bin/opencode"]);
+    expect(resolveOpencodeBinary(unixInput(fs))).toBe("/home/me/.bun/bin/opencode");
+  });
+
+  it("finds /opt/homebrew/bin/opencode via WELL_KNOWN_BIN_DIRS", () => {
+    const fs = makeFs(["/opt/homebrew/bin/opencode"]);
+    expect(resolveOpencodeBinary(unixInput(fs))).toBe("/opt/homebrew/bin/opencode");
+  });
+
+  it("prefers ~/.opencode/bin/opencode over later candidates", () => {
+    const fs = makeFs(["/home/me/.opencode/bin/opencode", "/usr/local/bin/opencode"]);
+    expect(resolveOpencodeBinary(unixInput(fs))).toBe("/home/me/.opencode/bin/opencode");
+  });
+
+  it("returns null when nothing is found", () => {
+    expect(resolveOpencodeBinary(unixInput(makeFs([])))).toBeNull();
+  });
+});
+
+describe("resolveOpencodeBinary — Windows", () => {
+  it("returns the override when it exists", () => {
+    const override = "C:\\tools\\opencode.exe";
+    expect(resolveOpencodeBinary(winInput(makeFs([override]), { override }))).toBe(override);
+  });
+
+  it("ignores a POSIX override synced from another OS", () => {
+    // Concrete repro: settings sync brings `/Users/<them>/.opencode/bin/opencode`
+    // from a macOS install onto a Windows machine where a native opencode
+    // exists. Auto-detect must skip the dead POSIX path and find the local
+    // .exe instead.
+    const native = "C:\\Users\\me\\.opencode\\bin\\opencode.exe";
+    expect(
+      resolveOpencodeBinary(
+        winInput(makeFs([native]), { override: "/Users/them/.opencode/bin/opencode" })
+      )
+    ).toBe(native);
+  });
+
+  it("finds the native installer at ~/.opencode/bin/opencode.exe", () => {
+    const p = "C:\\Users\\me\\.opencode\\bin\\opencode.exe";
+    expect(resolveOpencodeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("finds the bun-global install at ~/.bun/bin/opencode.exe", () => {
+    const p = "C:\\Users\\me\\.bun\\bin\\opencode.exe";
+    expect(resolveOpencodeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("finds ~/.local/bin/opencode.exe", () => {
+    const p = "C:\\Users\\me\\.local\\bin\\opencode.exe";
+    expect(resolveOpencodeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("finds %LOCALAPPDATA%\\opencode\\bin\\opencode.exe via env var", () => {
+    const p = "D:\\AppData\\Local\\opencode\\bin\\opencode.exe";
+    expect(
+      resolveOpencodeBinary(winInput(makeFs([p]), { env: { LOCALAPPDATA: "D:\\AppData\\Local" } }))
+    ).toBe(p);
+  });
+
+  it("falls back to <homeDir>\\AppData\\Local\\opencode\\bin when LOCALAPPDATA is unset", () => {
+    const p = "C:\\Users\\me\\AppData\\Local\\opencode\\bin\\opencode.exe";
+    expect(resolveOpencodeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("finds %ProgramFiles%\\opencode\\bin\\opencode.exe", () => {
+    const p = "C:\\Program Files\\opencode\\bin\\opencode.exe";
+    expect(resolveOpencodeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("finds opencode.exe under %APPDATA%\\npm (node-tool bin dir)", () => {
+    const p = "C:\\Users\\me\\AppData\\Roaming\\npm\\opencode.exe";
+    expect(resolveOpencodeBinary(winInput(makeFs([p])))).toBe(p);
+  });
+
+  it("never picks opencode.cmd even when it is the only file present", () => {
+    const fs = makeFs(["C:\\Users\\me\\AppData\\Roaming\\npm\\opencode.cmd"]);
+    expect(resolveOpencodeBinary(winInput(fs))).toBeNull();
+  });
+});

--- a/src/agentMode/backends/opencode/opencodeBinaryResolver.ts
+++ b/src/agentMode/backends/opencode/opencodeBinaryResolver.ts
@@ -1,0 +1,85 @@
+/**
+ * Locate a user-installed `opencode` binary for the "Use your own binary"
+ * Auto-detect button. Independent of the managed-binary path (which
+ * `OpencodeBinaryManager` owns) — this resolver only walks well-known
+ * native-install and node-tool layouts to find an externally installed CLI.
+ *
+ * Mirrors {@link ./claudeBinaryResolver.ts}: pure leaf with injected `homeDir`,
+ * `platform`, `env`, and `fs` so tests don't touch real disk. On Windows we
+ * never emit `.cmd` / `.bat` / `.ps1` shims — ACP spawns over stdio without
+ * `shell: true`, so those break stream-json.
+ */
+import * as path from "node:path";
+
+import { WELL_KNOWN_BIN_DIRS } from "@/utils/binaryPath";
+import { nodeToolBinDirCandidates, type NodeToolFs } from "@/utils/nodeToolBinDirs";
+
+export type OpencodeBinaryResolverFs = NodeToolFs;
+
+export interface OpencodeBinaryResolverInput {
+  /** User-configured override path. If set and exists, returned as-is. */
+  override?: string;
+  homeDir: string;
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  fs: OpencodeBinaryResolverFs;
+}
+
+export function resolveOpencodeBinary(input: OpencodeBinaryResolverInput): string | null {
+  const { override, fs } = input;
+
+  if (override && fs.existsSync(override)) {
+    return override;
+  }
+
+  const candidates = input.platform === "win32" ? windowsCandidates(input) : unixCandidates(input);
+
+  for (const candidate of candidates) {
+    if (candidate && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+const posix = path.posix;
+const win = path.win32;
+
+function unixCandidates(input: OpencodeBinaryResolverInput): Array<string | null> {
+  const { homeDir } = input;
+  // Native installer (`curl -fsSL https://opencode.ai/install | bash`) lands at
+  // ~/.opencode/bin/opencode; `bun install -g` lands at ~/.bun/bin. Probe these
+  // first, then every node-tool bin dir, then well-known system prefixes.
+  const dirs = [...nodeToolBinDirCandidates(input), ...WELL_KNOWN_BIN_DIRS];
+  return [
+    posix.join(homeDir, ".opencode", "bin", "opencode"),
+    posix.join(homeDir, ".bun", "bin", "opencode"),
+    posix.join(homeDir, ".local", "bin", "opencode"),
+    ...dirs.map((dir) => posix.join(dir, "opencode")),
+  ];
+}
+
+function windowsCandidates(input: OpencodeBinaryResolverInput): Array<string | null> {
+  const { homeDir, env } = input;
+  const localAppData = env.LOCALAPPDATA ?? win.join(homeDir, "AppData", "Local");
+  const programFiles = env.ProgramFiles ?? "C:\\Program Files";
+  const programFilesX86 = env["ProgramFiles(x86)"] ?? "C:\\Program Files (x86)";
+
+  // Native-installer / package-manager destinations probed before the node-tool
+  // layout. Fixed list — no PATH walk.
+  const out: Array<string | null> = [
+    win.join(homeDir, ".opencode", "bin", "opencode.exe"),
+    win.join(homeDir, ".bun", "bin", "opencode.exe"),
+    win.join(homeDir, ".local", "bin", "opencode.exe"),
+    win.join(localAppData, "opencode", "bin", "opencode.exe"),
+    win.join(programFiles, "opencode", "bin", "opencode.exe"),
+    win.join(programFilesX86, "opencode", "bin", "opencode.exe"),
+  ];
+  // Per-dir, probe `opencode.exe` only. Never pick `.cmd` / `.bat` / `.ps1` —
+  // ACP spawns over stdio without `shell: true`, which breaks them.
+  for (const dir of nodeToolBinDirCandidates(input)) {
+    out.push(win.join(dir, "opencode.exe"));
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- **Claude (logancyang/obsidian-copilot-preview#110)**: extend `windowsCandidates` in `claudeBinaryResolver.ts` to probe native-installer destinations — `~/.local/bin/claude.exe` (the path `irm claude.ai/install.ps1 | iex` lands at, recommended in the Windows setup docs in logancyang/obsidian-copilot-preview#108), `~/.claude/local/claude.exe`, `%LOCALAPPDATA%\Claude\claude.exe`, and the two `Program Files\Claude` variants. Also probe `cli-wrapper.cjs` (newer Claude Code packaging) alongside `cli.js`. Deliberately omit `WindowsApps\Claude.exe` (desktop GUI launcher) and any PATH walk — that validation work stays scoped to logancyang/obsidian-copilot-preview#107.
- **opencode**: add a parallel `opencodeBinaryResolver.ts` (pure-leaf, mirrors Claude's shape) and wire it as the `detect` callback for the "Use your own binary" picker. Probes `~/.opencode/bin`, `~/.bun/bin`, `~/.local/bin`, `%LOCALAPPDATA%\opencode\bin`, ProgramFiles variants, and each node-tool bin dir for `opencode.exe`. Falls back to `detectBinary("opencode")` (PATH walk) so users with a non-standard install dir on PATH still match. Fixes the cross-OS sync case where a stale POSIX override path from another machine left auto-detect with nowhere useful to look.

## Test plan
- [x] `npm run test` — 3406 passed (+44 from new tests, 2 new test files)
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [ ] Manual on Windows 11: install Claude Code via `irm https://claude.ai/install.ps1 | iex`, open Configure Claude → Auto-detect, verify `C:\Users\<you>\.local\bin\claude.exe` is found
- [ ] Manual on Windows 11: install opencode natively, Configure opencode → Auto-detect under "Use your own binary", verify `~/.opencode/bin/opencode.exe` is found
- [ ] Manual on Windows 11: confirm a stale POSIX path in the opencode override (e.g. synced from macOS) does NOT match — Auto-detect falls through to the Windows native paths
- [ ] Manual on macOS/Linux: confirm no regression in either backend's existing auto-detect behavior
