### PR TITLE
docs: Windows setup guide for Claude and Codex Agent Mode

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -26,6 +26,8 @@ When the autonomous agent is enabled, Copilot can:
 
 The agent activates automatically when you're in **Copilot Plus** mode. You don't need to do anything special — just ask your question.
 
+> **On Windows?** If you're using a coding agent backend like Claude Code, see [Windows Setup for Claude Code Agent Mode](agent-mode-windows-setup.md) to install it and connect it to Copilot.
+
 ### Max Iterations
 
 The agent works in iteration cycles (think → use a tool → think → use a tool → answer). You can control the maximum number of iterations before the agent stops:
@@ -47,27 +49,35 @@ Copilot Plus has 13 built-in tools. Some are always active; others can be enable
 These tools are always available and cannot be disabled:
 
 #### Get Current Time
+
 Gets the current time in any timezone. Useful for time-aware queries like "what should I do today?"
 
 #### Get Time Range
+
 Converts natural time expressions (like "last week" or "yesterday") into exact date ranges. Usually called automatically before a time-based vault search.
 
 #### Get Time Info
+
 Converts an epoch timestamp to a human-readable date and time.
 
 #### Convert Timezones
+
 Converts a time from one timezone to another. Ask: "What time is 3pm EST in Tokyo?"
 
 #### Read Note
+
 Reads the content of a specific note. The agent uses this to inspect a note it found via search, or that you mentioned explicitly. Works on large notes by reading them in chunks.
 
 #### File Tree
+
 Browses the file structure of your vault. The agent uses this to find folder paths before creating new notes or to count files in a folder.
 
 #### Tag List
+
 Lists all tags in your vault with usage statistics. Useful for tag reorganization or finding notes by tag patterns.
 
 #### Update Memory
+
 Saves information to your memory when you explicitly ask the AI to remember something. See [Copilot Plus and Self-Host](copilot-plus-and-self-host.md#memory-system) for details.
 
 > **Requires**: **Settings → Copilot → Plus → Reference Saved Memories** must be enabled. If this setting is off, the tool is not registered and memory commands will not work.
@@ -77,18 +87,21 @@ Saves information to your memory when you explicitly ask the AI to remember some
 These tools can be individually enabled or disabled in **Settings → Copilot → Plus → Tool Settings**:
 
 #### Vault Search
+
 Searches your vault notes by content. The agent uses this to find notes relevant to your question.
 
 - **Trigger**: Automatically for vault-related questions, or explicitly with `@vault`
 - **Uses**: Both semantic search (if enabled) and lexical search
 
 #### Web Search
+
 Searches the internet for current information.
 
 - **Trigger**: Automatically when your question implies web/online content, or explicitly with `@websearch` or `@web`
 - **Requires**: A web search service configured (Firecrawl or Perplexity in self-host mode, or handled by Plus)
 
 #### Write to File
+
 Creates a new note or overwrites an existing one entirely.
 
 - **Trigger**: Automatically for "create a note" requests, or explicitly with `@composer` (available in both Copilot Plus and Projects mode)
@@ -96,6 +109,7 @@ Creates a new note or overwrites an existing one entirely.
 - **Auto-accept**: Enable **Settings → Copilot → Plus → Auto-accept edits** to skip the preview
 
 #### Replace in File
+
 Makes targeted changes to an existing note using search-and-replace blocks.
 
 - **Use case**: Small edits (adding a bullet, updating a section) — more precise than rewriting the whole note
@@ -103,6 +117,7 @@ Makes targeted changes to an existing note using search-and-replace blocks.
 - **Auto-accept**: Same setting as Write to File
 
 #### YouTube Transcription
+
 Fetches the transcript of a YouTube video.
 
 - **Trigger**: Automatically when you paste a YouTube URL in your message
@@ -114,6 +129,7 @@ Fetches the transcript of a YouTube video.
 ## Tool Settings
 
 Go to **Settings → Copilot → Plus → Tool Settings** to:
+
 - See all available tools
 - Enable or disable individual configurable tools
 - View what each tool does
@@ -138,6 +154,7 @@ See [Context and Mentions](context-and-mentions.md) for the full @-mention refer
 ## Tool Call Indicators
 
 While the agent is working, the chat shows status indicators for each tool call:
+
 - "Reading files"
 - "Searching the web"
 - "Reading file tree"
@@ -157,6 +174,7 @@ When the agent uses **Write to File** or **Replace in File**, it shows a preview
 You can choose your preferred diff view in **Settings → Copilot → Plus → Diff View Mode**.
 
 Review the proposed change and click:
+
 - **Accept** — Apply the change to your note
 - **Reject** — Discard without making any changes
 - **Revert** — Undo a change that was already accepted

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -26,8 +26,6 @@ When the autonomous agent is enabled, Copilot can:
 
 The agent activates automatically when you're in **Copilot Plus** mode. You don't need to do anything special — just ask your question.
 
-> **On Windows?** If you're using a coding agent backend like Claude Code, see [Windows Setup for Claude Code Agent Mode](agent-mode-windows-setup.md) to install it and connect it to Copilot.
-
 ### Max Iterations
 
 The agent works in iteration cycles (think → use a tool → think → use a tool → answer). You can control the maximum number of iterations before the agent stops:

--- a/docs/agent-mode-windows-setup.md
+++ b/docs/agent-mode-windows-setup.md
@@ -1,0 +1,80 @@
+# Windows Setup for Claude Code Agent Mode
+
+This guide helps Windows users install Claude Code and connect it to Copilot's Agent Mode. You don't need any developer tools or experience.
+
+> **Read this first.** The installer does **not** add Claude to your system PATH. This means typing `claude` in a terminal will say "not found" even when the install worked perfectly. **That's expected and it does not matter** — Copilot finds Claude by its file location, not your PATH. A failed `claude` command in the terminal does **not** mean something is broken.
+
+## What you need
+
+- Windows 10 or 11
+- Obsidian with the Copilot plugin installed
+- A Claude (Anthropic) account, with [Copilot Plus](copilot-plus-and-self-host.md) for Agent Mode
+
+## Step 1: Install Claude Code
+
+1. Open **PowerShell**: press the `Windows` key, type `PowerShell`, and press `Enter`.
+2. Paste this command and press `Enter`:
+
+   ```powershell
+   irm https://claude.ai/install.ps1 | iex
+   ```
+
+3. Wait until you see **`Installation complete!`**.
+
+In the output, look for the **Location** line and note the path. It is almost always:
+
+```
+C:\Users\<your-username>\.local\bin\claude.exe
+```
+
+You may also see a warning that this folder is "not in your PATH." **Ignore it** — Copilot does not use your PATH. This installer does not require Node.js.
+
+> **Already have Node.js?** You can instead run `npm install -g @anthropic-ai/claude-code`. The native installer above is recommended because it needs nothing else.
+
+## Step 2: Sign in to Claude
+
+Sign in to the **Claude desktop app**, or run `claude` once in a terminal if it happens to work on your machine. Copilot reuses this sign-in automatically. Without signing in, Agent Mode will start but every request will fail with an authentication error.
+
+## Step 3: Connect Copilot to Claude
+
+1. Open **Settings → Copilot → Agent Mode**.
+2. Under the **Claude** backend, click **Configure**.
+3. Click **Auto-detect**.
+
+Auto-detect checks the standard install location, so it should find Claude right away — even though the `claude` command doesn't work in your terminal.
+
+**If Auto-detect doesn't find it**, paste the path manually into the binary path field. To get the exact path, run this in PowerShell and copy the line it prints:
+
+```powershell
+(Resolve-Path "$env:USERPROFILE\.local\bin\claude.exe").Path
+```
+
+> Use a file ending in `.exe` (or `cli.js` for npm installs). Do **not** use a file ending in `.cmd` — Copilot cannot run those.
+
+## Step 4: Start using Agent Mode
+
+Open a Copilot chat, switch to **Agent Mode**, choose the **Claude** backend, and send a message. You're all set.
+
+## Troubleshooting
+
+**`claude` is "not found" in the terminal.**
+Expected — the installer skips your PATH. This does not affect Copilot. Use Auto-detect (Step 3) or paste the path manually.
+
+**Auto-detect can't find Claude.**
+Paste the path manually using the `Resolve-Path` command in Step 3. If that command shows an error instead of a path, the install didn't complete — run Step 1 again.
+
+**You see an error mentioning `node` (npm installs only).**
+The npm version of Claude needs Node.js available. Either switch to the native installer in Step 1 (recommended), or add your Node.js folder to the **Environment variables** field in Configure Claude (for example, `PATH=C:\path\to\node`).
+
+**`irm ... | iex` is blocked.**
+Your security settings may block the install command. In PowerShell, run `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`, then try Step 1 again.
+
+## Optional: make `claude` work in the terminal too
+
+This is **not needed for Copilot**. Only do this if you want to run `claude` directly in a terminal.
+
+1. Press the `Windows` key, type **Environment Variables**, and open **Edit the system environment variables → Environment Variables…**.
+2. Under **User variables**, select **Path → Edit → New**.
+3. Add: `%USERPROFILE%\.local\bin`
+4. Click **OK** on all dialogs, then close and reopen PowerShell.
+5. Verify with `claude --help`.

--- a/docs/agent-mode-windows-setup.md
+++ b/docs/agent-mode-windows-setup.md
@@ -1,6 +1,10 @@
-# Windows Setup for Claude Code Agent Mode
+# Windows Setup for Agent Mode
 
-Run these in **PowerShell**, in order.
+Use this guide to connect Claude Code or Codex to Copilot Agent Mode on Windows.
+
+## Claude Code
+
+Run these in **PowerShell**, in order:
 
 ```powershell
 # 1. Install Claude Code (standalone, no Node.js needed)
@@ -18,8 +22,24 @@ Finish signing in when `claude` opens, then close it.
 (Resolve-Path "$env:USERPROFILE\.local\bin\claude.exe").Path
 ```
 
-In Obsidian: **Settings → Copilot → Agent Mode → Claude → Configure → Auto-detect**. If it doesn't find Claude, paste the path from step 3 into the binary path field.
+In Obsidian: **Settings -> Copilot -> Agent Mode -> Claude -> Configure -> Auto-detect**. If it doesn't find Claude, paste the path from step 3 into the binary path field.
 
-That's it. Open a Copilot chat, switch to **Agent Mode**, pick **Claude**, and send a message.
+Open a Copilot chat, switch to **Agent Mode**, pick **Claude**, and send a message.
 
-> A "not in your PATH" warning after step 1 is normal and does not matter — Copilot finds Claude by file path, not PATH.
+> A "not in your PATH" warning after step 1 is normal and does not matter: Copilot finds Claude by file path, not PATH.
+
+## Codex
+
+Run this in **PowerShell**:
+
+```powershell
+irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/docs/install-codex-agent-mode-windows.ps1 | iex
+```
+
+When Codex asks you to sign in, finish the login. The installer copies the `codex-acp.exe` path to your clipboard.
+
+In Obsidian: **Settings -> Copilot -> Agent Mode -> Codex -> Configure**. Paste the copied path into the binary path field, leave **Environment variables** empty, then save.
+
+Open a Copilot chat, switch to **Agent Mode**, pick **Codex**, and send a message.
+
+> Use the copied `codex-acp.exe` path only. Do not use `codex.exe`, `codex.cmd`, or `codex-acp.cmd`.

--- a/docs/agent-mode-windows-setup.md
+++ b/docs/agent-mode-windows-setup.md
@@ -10,9 +10,9 @@ Run this in **PowerShell**:
 irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/docs/install-claude-agent-mode-windows.ps1 | iex
 ```
 
-When Claude asks you to sign in, finish the login, then close Claude. The installer copies the `claude.exe` path to your clipboard.
+When Claude asks you to sign in, finish the browser login. The installer copies the `claude.exe` path to your clipboard.
 
-In Obsidian: **Settings -> Copilot -> Agent Mode -> Claude -> Configure -> Auto-detect**. If it doesn't find Claude, paste the copied path into the binary path field, then save.
+In Obsidian: **Settings -> Copilot -> Agents -> Claude -> Configure -> Auto-detect**. If it doesn't find Claude, paste the copied path into the binary path field, then save.
 
 Open a Copilot chat, switch to **Agent Mode**, pick **Claude**, and send a message.
 
@@ -28,7 +28,7 @@ irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/doc
 
 When Codex asks you to sign in, finish the login. The installer copies the `codex-acp.exe` path to your clipboard.
 
-In Obsidian: **Settings -> Copilot -> Agent Mode -> Codex -> Configure**. Paste the copied path into the binary path field, leave **Environment variables** empty, then save.
+In Obsidian: **Settings -> Copilot -> Agents -> Codex -> Configure**. Paste the copied path into the binary path field, leave **Environment variables** empty, then save.
 
 Open a Copilot chat, switch to **Agent Mode**, pick **Codex**, and send a message.
 

--- a/docs/agent-mode-windows-setup.md
+++ b/docs/agent-mode-windows-setup.md
@@ -4,29 +4,19 @@ Use this guide to connect Claude Code or Codex to Copilot Agent Mode on Windows.
 
 ## Claude Code
 
-Run these in **PowerShell**, in order:
+Run this in **PowerShell**:
 
 ```powershell
-# 1. Install Claude Code (standalone, no Node.js needed)
-irm https://claude.ai/install.ps1 | iex
-
-# 2. Add it to PATH for this session and sign in
-$env:Path += ";$env:USERPROFILE\.local\bin"
-claude
+irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/docs/install-claude-agent-mode-windows.ps1 | iex
 ```
 
-Finish signing in when `claude` opens, then close it.
+When Claude asks you to sign in, finish the login, then close Claude. The installer copies the `claude.exe` path to your clipboard.
 
-```powershell
-# 3. Print the exact binary path to paste into Copilot
-(Resolve-Path "$env:USERPROFILE\.local\bin\claude.exe").Path
-```
-
-In Obsidian: **Settings -> Copilot -> Agent Mode -> Claude -> Configure -> Auto-detect**. If it doesn't find Claude, paste the path from step 3 into the binary path field.
+In Obsidian: **Settings -> Copilot -> Agent Mode -> Claude -> Configure -> Auto-detect**. If it doesn't find Claude, paste the copied path into the binary path field, then save.
 
 Open a Copilot chat, switch to **Agent Mode**, pick **Claude**, and send a message.
 
-> A "not in your PATH" warning after step 1 is normal and does not matter: Copilot finds Claude by file path, not PATH.
+> A "not in your PATH" warning is normal and does not matter: Copilot finds Claude by file path, not PATH.
 
 ## Codex
 

--- a/docs/agent-mode-windows-setup.md
+++ b/docs/agent-mode-windows-setup.md
@@ -1,80 +1,25 @@
 # Windows Setup for Claude Code Agent Mode
 
-This guide helps Windows users install Claude Code and connect it to Copilot's Agent Mode. You don't need any developer tools or experience.
-
-> **Read this first.** The installer does **not** add Claude to your system PATH. This means typing `claude` in a terminal will say "not found" even when the install worked perfectly. **That's expected and it does not matter** — Copilot finds Claude by its file location, not your PATH. A failed `claude` command in the terminal does **not** mean something is broken.
-
-## What you need
-
-- Windows 10 or 11
-- Obsidian with the Copilot plugin installed
-- A Claude (Anthropic) account, with [Copilot Plus](copilot-plus-and-self-host.md) for Agent Mode
-
-## Step 1: Install Claude Code
-
-1. Open **PowerShell**: press the `Windows` key, type `PowerShell`, and press `Enter`.
-2. Paste this command and press `Enter`:
-
-   ```powershell
-   irm https://claude.ai/install.ps1 | iex
-   ```
-
-3. Wait until you see **`Installation complete!`**.
-
-In the output, look for the **Location** line and note the path. It is almost always:
-
-```
-C:\Users\<your-username>\.local\bin\claude.exe
-```
-
-You may also see a warning that this folder is "not in your PATH." **Ignore it** — Copilot does not use your PATH. This installer does not require Node.js.
-
-> **Already have Node.js?** You can instead run `npm install -g @anthropic-ai/claude-code`. The native installer above is recommended because it needs nothing else.
-
-## Step 2: Sign in to Claude
-
-Sign in to the **Claude desktop app**, or run `claude` once in a terminal if it happens to work on your machine. Copilot reuses this sign-in automatically. Without signing in, Agent Mode will start but every request will fail with an authentication error.
-
-## Step 3: Connect Copilot to Claude
-
-1. Open **Settings → Copilot → Agent Mode**.
-2. Under the **Claude** backend, click **Configure**.
-3. Click **Auto-detect**.
-
-Auto-detect checks the standard install location, so it should find Claude right away — even though the `claude` command doesn't work in your terminal.
-
-**If Auto-detect doesn't find it**, paste the path manually into the binary path field. To get the exact path, run this in PowerShell and copy the line it prints:
+Run these in **PowerShell**, in order.
 
 ```powershell
+# 1. Install Claude Code (standalone, no Node.js needed)
+irm https://claude.ai/install.ps1 | iex
+
+# 2. Add it to PATH for this session and sign in
+$env:Path += ";$env:USERPROFILE\.local\bin"
+claude
+```
+
+Finish signing in when `claude` opens, then close it.
+
+```powershell
+# 3. Print the exact binary path to paste into Copilot
 (Resolve-Path "$env:USERPROFILE\.local\bin\claude.exe").Path
 ```
 
-> Use a file ending in `.exe` (or `cli.js` for npm installs). Do **not** use a file ending in `.cmd` — Copilot cannot run those.
+In Obsidian: **Settings → Copilot → Agent Mode → Claude → Configure → Auto-detect**. If it doesn't find Claude, paste the path from step 3 into the binary path field.
 
-## Step 4: Start using Agent Mode
+That's it. Open a Copilot chat, switch to **Agent Mode**, pick **Claude**, and send a message.
 
-Open a Copilot chat, switch to **Agent Mode**, choose the **Claude** backend, and send a message. You're all set.
-
-## Troubleshooting
-
-**`claude` is "not found" in the terminal.**
-Expected — the installer skips your PATH. This does not affect Copilot. Use Auto-detect (Step 3) or paste the path manually.
-
-**Auto-detect can't find Claude.**
-Paste the path manually using the `Resolve-Path` command in Step 3. If that command shows an error instead of a path, the install didn't complete — run Step 1 again.
-
-**You see an error mentioning `node` (npm installs only).**
-The npm version of Claude needs Node.js available. Either switch to the native installer in Step 1 (recommended), or add your Node.js folder to the **Environment variables** field in Configure Claude (for example, `PATH=C:\path\to\node`).
-
-**`irm ... | iex` is blocked.**
-Your security settings may block the install command. In PowerShell, run `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned`, then try Step 1 again.
-
-## Optional: make `claude` work in the terminal too
-
-This is **not needed for Copilot**. Only do this if you want to run `claude` directly in a terminal.
-
-1. Press the `Windows` key, type **Environment Variables**, and open **Edit the system environment variables → Environment Variables…**.
-2. Under **User variables**, select **Path → Edit → New**.
-3. Add: `%USERPROFILE%\.local\bin`
-4. Click **OK** on all dialogs, then close and reopen PowerShell.
-5. Verify with `claude --help`.
+> A "not in your PATH" warning after step 1 is normal and does not matter — Copilot finds Claude by file path, not PATH.

--- a/docs/agent-mode-windows-setup.md
+++ b/docs/agent-mode-windows-setup.md
@@ -7,7 +7,7 @@ Use this guide to connect Claude Code or Codex to Copilot Agent Mode on Windows.
 Run this in **PowerShell**:
 
 ```powershell
-irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/docs/install-claude-agent-mode-windows.ps1 | iex
+irm https://gist.githubusercontent.com/logancyang/7a87eb38d91015eac567521f8cc9c729/raw/install-claude-agent-mode-windows.ps1 | iex
 ```
 
 When Claude asks you to sign in, finish the browser login. The installer copies the `claude.exe` path to your clipboard.
@@ -23,7 +23,7 @@ Open a Copilot chat, switch to **Agent Mode**, pick **Claude**, and send a messa
 Run this in **PowerShell**:
 
 ```powershell
-irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/docs/install-codex-agent-mode-windows.ps1 | iex
+irm https://gist.githubusercontent.com/logancyang/380ef4dbf9f98900771da76eca3d21e6/raw/install-codex-agent-mode-windows.ps1 | iex
 ```
 
 When Codex asks you to sign in, finish the login. The installer copies the `codex-acp.exe` path to your clipboard.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,21 +4,21 @@ Welcome to the official documentation for **Copilot for Obsidian**, an AI-powere
 
 ## Table of Contents
 
-| Document                                                                | What it covers                                                                  |
-| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Getting Started](getting-started.md)                                   | Installation, first-time setup, opening the chat panel, keyboard shortcuts      |
-| [Chat Interface](chat-interface.md)                                     | Chat modes, sending messages, history, settings, auto-compact                   |
-| [LLM Providers](llm-providers.md)                                       | All 16+ supported providers and how to set them up                              |
-| [Models and Parameters](models-and-parameters.md)                       | Chat models, embedding models, temperature, max tokens, and other parameters    |
-| [Context and Mentions](context-and-mentions.md)                         | Active note context, @-mentions, URLs, tags, and the web viewer                 |
-| [Custom Commands](custom-commands.md)                                   | Creating and using preset prompts, template variables, Quick Command, Quick Ask |
-| [Vault Search and Indexing](vault-search-and-indexing.md)               | Lexical search, semantic search, index management, exclusions                   |
-| [Agent Mode and Tools](agent-mode-and-tools.md)                         | Autonomous agent, all 13 tools, file editing, web search                        |
-| [Windows Setup for Claude Code Agent Mode](agent-mode-windows-setup.md) | Installing Claude Code on Windows and connecting it to Agent Mode               |
-| [Projects](projects.md)                                                 | Focused workspaces with isolated context, model, and chat history               |
-| [System Prompts](system-prompts.md)                                     | Customizing AI behavior with built-in and custom system prompts                 |
-| [Copilot Plus and Self-Host](copilot-plus-and-self-host.md)             | Copilot Plus features, memory system, self-host mode, Miyo                      |
-| [Troubleshooting and FAQ](troubleshooting-and-faq.md)                   | Common errors, provider-specific issues, performance, FAQ                       |
+| Document                                                    | What it covers                                                                  |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [Getting Started](getting-started.md)                       | Installation, first-time setup, opening the chat panel, keyboard shortcuts      |
+| [Chat Interface](chat-interface.md)                         | Chat modes, sending messages, history, settings, auto-compact                   |
+| [LLM Providers](llm-providers.md)                           | All 16+ supported providers and how to set them up                              |
+| [Models and Parameters](models-and-parameters.md)           | Chat models, embedding models, temperature, max tokens, and other parameters    |
+| [Context and Mentions](context-and-mentions.md)             | Active note context, @-mentions, URLs, tags, and the web viewer                 |
+| [Custom Commands](custom-commands.md)                       | Creating and using preset prompts, template variables, Quick Command, Quick Ask |
+| [Vault Search and Indexing](vault-search-and-indexing.md)   | Lexical search, semantic search, index management, exclusions                   |
+| [Agent Mode and Tools](agent-mode-and-tools.md)             | Autonomous agent, all 13 tools, file editing, web search                        |
+| [Windows Setup for Agent Mode](agent-mode-windows-setup.md) | Installing Claude Code or Codex on Windows and connecting it to Agent Mode      |
+| [Projects](projects.md)                                     | Focused workspaces with isolated context, model, and chat history               |
+| [System Prompts](system-prompts.md)                         | Customizing AI behavior with built-in and custom system prompts                 |
+| [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) | Copilot Plus features, memory system, self-host mode, Miyo                      |
+| [Troubleshooting and FAQ](troubleshooting-and-faq.md)       | Common errors, provider-specific issues, performance, FAQ                       |
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,20 +4,21 @@ Welcome to the official documentation for **Copilot for Obsidian**, an AI-powere
 
 ## Table of Contents
 
-| Document | What it covers |
-|---|---|
-| [Getting Started](getting-started.md) | Installation, first-time setup, opening the chat panel, keyboard shortcuts |
-| [Chat Interface](chat-interface.md) | Chat modes, sending messages, history, settings, auto-compact |
-| [LLM Providers](llm-providers.md) | All 16+ supported providers and how to set them up |
-| [Models and Parameters](models-and-parameters.md) | Chat models, embedding models, temperature, max tokens, and other parameters |
-| [Context and Mentions](context-and-mentions.md) | Active note context, @-mentions, URLs, tags, and the web viewer |
-| [Custom Commands](custom-commands.md) | Creating and using preset prompts, template variables, Quick Command, Quick Ask |
-| [Vault Search and Indexing](vault-search-and-indexing.md) | Lexical search, semantic search, index management, exclusions |
-| [Agent Mode and Tools](agent-mode-and-tools.md) | Autonomous agent, all 13 tools, file editing, web search |
-| [Projects](projects.md) | Focused workspaces with isolated context, model, and chat history |
-| [System Prompts](system-prompts.md) | Customizing AI behavior with built-in and custom system prompts |
-| [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) | Copilot Plus features, memory system, self-host mode, Miyo |
-| [Troubleshooting and FAQ](troubleshooting-and-faq.md) | Common errors, provider-specific issues, performance, FAQ |
+| Document                                                                | What it covers                                                                  |
+| ----------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [Getting Started](getting-started.md)                                   | Installation, first-time setup, opening the chat panel, keyboard shortcuts      |
+| [Chat Interface](chat-interface.md)                                     | Chat modes, sending messages, history, settings, auto-compact                   |
+| [LLM Providers](llm-providers.md)                                       | All 16+ supported providers and how to set them up                              |
+| [Models and Parameters](models-and-parameters.md)                       | Chat models, embedding models, temperature, max tokens, and other parameters    |
+| [Context and Mentions](context-and-mentions.md)                         | Active note context, @-mentions, URLs, tags, and the web viewer                 |
+| [Custom Commands](custom-commands.md)                                   | Creating and using preset prompts, template variables, Quick Command, Quick Ask |
+| [Vault Search and Indexing](vault-search-and-indexing.md)               | Lexical search, semantic search, index management, exclusions                   |
+| [Agent Mode and Tools](agent-mode-and-tools.md)                         | Autonomous agent, all 13 tools, file editing, web search                        |
+| [Windows Setup for Claude Code Agent Mode](agent-mode-windows-setup.md) | Installing Claude Code on Windows and connecting it to Agent Mode               |
+| [Projects](projects.md)                                                 | Focused workspaces with isolated context, model, and chat history               |
+| [System Prompts](system-prompts.md)                                     | Customizing AI behavior with built-in and custom system prompts                 |
+| [Copilot Plus and Self-Host](copilot-plus-and-self-host.md)             | Copilot Plus features, memory system, self-host mode, Miyo                      |
+| [Troubleshooting and FAQ](troubleshooting-and-faq.md)                   | Common errors, provider-specific issues, performance, FAQ                       |
 
 ## Quick Start
 

--- a/docs/install-claude-agent-mode-windows.ps1
+++ b/docs/install-claude-agent-mode-windows.ps1
@@ -21,6 +21,21 @@ function Add-PathEntryForThisSession {
     $env:Path = "$PathEntry;$env:Path"
 }
 
+function Test-ClaudeLoggedIn {
+    param([string]$ClaudeCommand)
+
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $status = & $ClaudeCommand auth status --json 2>$null
+        return ($LASTEXITCODE -eq 0 -and (($status -join "`n") -match '"loggedIn"\s*:\s*true'))
+    } catch {
+        return $false
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
+}
+
 Write-Step "Installing Claude Code"
 Invoke-RestMethod "https://claude.ai/install.ps1" | Invoke-Expression
 
@@ -32,8 +47,15 @@ if (-not (Test-Path -LiteralPath $claude -PathType Leaf)) {
 Add-PathEntryForThisSession -PathEntry $claudeBin
 
 Write-Step "Signing in to Claude"
-Write-Host "Follow the Claude login prompts, then close Claude. This script will continue after Claude exits."
-& $claude
+if (Test-ClaudeLoggedIn -ClaudeCommand $claude) {
+    Write-Host "Claude is already signed in."
+} else {
+    Write-Host "Follow the Claude login prompts. This script will continue after login finishes."
+    & $claude auth login --claudeai
+    if (-not (Test-ClaudeLoggedIn -ClaudeCommand $claude)) {
+        throw "Claude login did not complete. Run this script again after signing in."
+    }
+}
 
 try {
     Set-Clipboard -Value $claude
@@ -46,5 +68,5 @@ Write-Host ""
 Write-Host "Done. $clipboardMessage"
 Write-Host $claude
 Write-Host ""
-Write-Host "Next: Obsidian -> Settings -> Copilot -> Agent Mode -> Claude -> Configure"
+Write-Host "Next: Obsidian -> Settings -> Copilot -> Agents -> Claude -> Configure"
 Write-Host "Click Auto-detect. If needed, paste this path into the binary path field, then save."

--- a/docs/install-claude-agent-mode-windows.ps1
+++ b/docs/install-claude-agent-mode-windows.ps1
@@ -1,0 +1,50 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "==> $Message"
+}
+
+function Add-PathEntryForThisSession {
+    param([string]$PathEntry)
+
+    $needle = $PathEntry.TrimEnd("\")
+    foreach ($segment in $env:Path.Split(";", [System.StringSplitOptions]::RemoveEmptyEntries)) {
+        if ($segment.TrimEnd("\") -ieq $needle) {
+            return
+        }
+    }
+
+    $env:Path = "$PathEntry;$env:Path"
+}
+
+Write-Step "Installing Claude Code"
+Invoke-RestMethod "https://claude.ai/install.ps1" | Invoke-Expression
+
+$claudeBin = Join-Path $env:USERPROFILE ".local\bin"
+$claude = Join-Path $claudeBin "claude.exe"
+if (-not (Test-Path -LiteralPath $claude -PathType Leaf)) {
+    throw "claude.exe was not found at $claude"
+}
+Add-PathEntryForThisSession -PathEntry $claudeBin
+
+Write-Step "Signing in to Claude"
+Write-Host "Follow the Claude login prompts, then close Claude. This script will continue after Claude exits."
+& $claude
+
+try {
+    Set-Clipboard -Value $claude
+    $clipboardMessage = "The claude.exe path has been copied to your clipboard."
+} catch {
+    $clipboardMessage = "Copy this claude.exe path:"
+}
+
+Write-Host ""
+Write-Host "Done. $clipboardMessage"
+Write-Host $claude
+Write-Host ""
+Write-Host "Next: Obsidian -> Settings -> Copilot -> Agent Mode -> Claude -> Configure"
+Write-Host "Click Auto-detect. If needed, paste this path into the binary path field, then save."

--- a/docs/install-codex-agent-mode-windows.ps1
+++ b/docs/install-codex-agent-mode-windows.ps1
@@ -171,5 +171,5 @@ Write-Host ""
 Write-Host "Done. $clipboardMessage"
 Write-Host $acp
 Write-Host ""
-Write-Host "Next: Obsidian -> Settings -> Copilot -> Agent Mode -> Codex -> Configure"
+Write-Host "Next: Obsidian -> Settings -> Copilot -> Agents -> Codex -> Configure"
 Write-Host "Paste this path into the binary path field, leave Environment variables empty, then save."

--- a/docs/install-codex-agent-mode-windows.ps1
+++ b/docs/install-codex-agent-mode-windows.ps1
@@ -21,6 +21,46 @@ function Add-PathEntryForThisSession {
     $env:Path = "$PathEntry;$env:Path"
 }
 
+function Find-CodexCommand {
+    $candidateBins = @()
+    if (-not [string]::IsNullOrWhiteSpace($env:CODEX_INSTALL_DIR)) {
+        $candidateBins += $env:CODEX_INSTALL_DIR
+    }
+
+    $pathCommand = Get-Command "codex" -ErrorAction SilentlyContinue
+    if ($null -ne $pathCommand -and -not [string]::IsNullOrWhiteSpace($pathCommand.Source)) {
+        $candidateBins += (Split-Path -Parent $pathCommand.Source)
+    }
+
+    $candidateBins += (Join-Path $env:LOCALAPPDATA "Programs\OpenAI\Codex\bin")
+    $candidateBins += (Join-Path $env:LOCALAPPDATA "OpenAI\Codex\bin")
+
+    $seen = @{}
+    $checked = @()
+    foreach ($bin in $candidateBins) {
+        if ([string]::IsNullOrWhiteSpace($bin)) {
+            continue
+        }
+
+        $key = $bin.TrimEnd("\").ToLowerInvariant()
+        if ($seen.ContainsKey($key)) {
+            continue
+        }
+        $seen[$key] = $true
+
+        $candidate = Join-Path $bin "codex.exe"
+        $checked += $candidate
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return [PSCustomObject]@{
+                Bin  = $bin
+                Path = $candidate
+            }
+        }
+    }
+
+    throw "codex.exe was not found. Checked: $($checked -join '; ')"
+}
+
 Write-Step "Installing Codex CLI"
 $previousNonInteractive = $env:CODEX_NON_INTERACTIVE
 $env:CODEX_NON_INTERACTIVE = "1"
@@ -34,15 +74,9 @@ try {
     }
 }
 
-$codexBin = if ([string]::IsNullOrWhiteSpace($env:CODEX_INSTALL_DIR)) {
-    Join-Path $env:LOCALAPPDATA "Programs\OpenAI\Codex\bin"
-} else {
-    $env:CODEX_INSTALL_DIR
-}
-$codex = Join-Path $codexBin "codex.exe"
-if (-not (Test-Path -LiteralPath $codex -PathType Leaf)) {
-    throw "codex.exe was not found at $codex"
-}
+$resolvedCodex = Find-CodexCommand
+$codexBin = $resolvedCodex.Bin
+$codex = $resolvedCodex.Path
 Add-PathEntryForThisSession -PathEntry $codexBin
 
 Write-Step "Signing in to Codex"

--- a/docs/install-codex-agent-mode-windows.ps1
+++ b/docs/install-codex-agent-mode-windows.ps1
@@ -61,6 +61,31 @@ function Find-CodexCommand {
     throw "codex.exe was not found. Checked: $($checked -join '; ')"
 }
 
+function Test-CodexLoggedIn {
+    param([string]$CodexCommand)
+
+    $status = & $CodexCommand login status 2>&1
+    return ($LASTEXITCODE -eq 0 -and (($status -join "`n") -match "Logged in"))
+}
+
+function Wait-CodexLogin {
+    param(
+        [string]$CodexCommand,
+        [int]$TimeoutSeconds = 600
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        if (Test-CodexLoggedIn -CodexCommand $CodexCommand) {
+            return
+        }
+
+        Start-Sleep -Seconds 2
+    }
+
+    throw "Codex login was not completed within $TimeoutSeconds seconds. Run this script again after signing in."
+}
+
 Write-Step "Installing Codex CLI"
 $previousNonInteractive = $env:CODEX_NON_INTERACTIVE
 $env:CODEX_NON_INTERACTIVE = "1"
@@ -80,8 +105,13 @@ $codex = $resolvedCodex.Path
 Add-PathEntryForThisSession -PathEntry $codexBin
 
 Write-Step "Signing in to Codex"
-Write-Host "Follow the Codex login prompts. This script will continue after login finishes."
-& $codex login
+if (Test-CodexLoggedIn -CodexCommand $codex) {
+    Write-Host "Codex is already signed in."
+} else {
+    Write-Host "Follow the Codex login prompts. This script will continue after login finishes."
+    & $codex login
+    Wait-CodexLogin -CodexCommand $codex
+}
 
 Write-Step "Installing codex-acp"
 $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq "Arm64") {

--- a/docs/install-codex-agent-mode-windows.ps1
+++ b/docs/install-codex-agent-mode-windows.ps1
@@ -1,0 +1,91 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "==> $Message"
+}
+
+function Add-PathEntryForThisSession {
+    param([string]$PathEntry)
+
+    $needle = $PathEntry.TrimEnd("\")
+    foreach ($segment in $env:Path.Split(";", [System.StringSplitOptions]::RemoveEmptyEntries)) {
+        if ($segment.TrimEnd("\") -ieq $needle) {
+            return
+        }
+    }
+
+    $env:Path = "$PathEntry;$env:Path"
+}
+
+Write-Step "Installing Codex CLI"
+$previousNonInteractive = $env:CODEX_NON_INTERACTIVE
+$env:CODEX_NON_INTERACTIVE = "1"
+try {
+    Invoke-RestMethod "https://github.com/openai/codex/releases/latest/download/install.ps1" | Invoke-Expression
+} finally {
+    if ([string]::IsNullOrWhiteSpace($previousNonInteractive)) {
+        Remove-Item Env:\CODEX_NON_INTERACTIVE -ErrorAction SilentlyContinue
+    } else {
+        $env:CODEX_NON_INTERACTIVE = $previousNonInteractive
+    }
+}
+
+$codexBin = if ([string]::IsNullOrWhiteSpace($env:CODEX_INSTALL_DIR)) {
+    Join-Path $env:LOCALAPPDATA "Programs\OpenAI\Codex\bin"
+} else {
+    $env:CODEX_INSTALL_DIR
+}
+$codex = Join-Path $codexBin "codex.exe"
+if (-not (Test-Path -LiteralPath $codex -PathType Leaf)) {
+    throw "codex.exe was not found at $codex"
+}
+Add-PathEntryForThisSession -PathEntry $codexBin
+
+Write-Step "Signing in to Codex"
+Write-Host "Follow the Codex login prompts. This script will continue after login finishes."
+& $codex login
+
+Write-Step "Installing codex-acp"
+$arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq "Arm64") {
+    "aarch64"
+} else {
+    "x86_64"
+}
+$acpDir = Join-Path $env:LOCALAPPDATA "Programs\codex-acp"
+$zip = Join-Path $env:TEMP "codex-acp.zip"
+
+$release = Invoke-RestMethod "https://api.github.com/repos/zed-industries/codex-acp/releases/latest"
+$asset = $release.assets |
+    Where-Object { $_.name -like "codex-acp-*-$arch-pc-windows-msvc.zip" } |
+    Select-Object -First 1
+
+if ($null -eq $asset) {
+    throw "No codex-acp Windows release was found for $arch."
+}
+
+New-Item -ItemType Directory -Force -Path $acpDir | Out-Null
+Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zip
+Expand-Archive -Path $zip -DestinationPath $acpDir -Force
+
+$acp = Join-Path $acpDir "codex-acp.exe"
+if (-not (Test-Path -LiteralPath $acp -PathType Leaf)) {
+    throw "codex-acp.exe was not found at $acp"
+}
+
+try {
+    Set-Clipboard -Value $acp
+    $clipboardMessage = "The codex-acp.exe path has been copied to your clipboard."
+} catch {
+    $clipboardMessage = "Copy this codex-acp.exe path:"
+}
+
+Write-Host ""
+Write-Host "Done. $clipboardMessage"
+Write-Host $acp
+Write-Host ""
+Write-Host "Next: Obsidian -> Settings -> Copilot -> Agent Mode -> Codex -> Configure"
+Write-Host "Paste this path into the binary path field, leave Environment variables empty, then save."

--- a/docs/install-codex-agent-mode-windows.ps1
+++ b/docs/install-codex-agent-mode-windows.ps1
@@ -22,50 +22,70 @@ function Add-PathEntryForThisSession {
 }
 
 function Find-CodexCommand {
-    $candidateBins = @()
+    $candidatePaths = @()
     if (-not [string]::IsNullOrWhiteSpace($env:CODEX_INSTALL_DIR)) {
-        $candidateBins += $env:CODEX_INSTALL_DIR
+        $candidatePaths += (Join-Path $env:CODEX_INSTALL_DIR "codex.exe")
+    }
+
+    $candidatePaths += (Join-Path $env:LOCALAPPDATA "Programs\OpenAI\Codex\bin\codex.exe")
+    $candidatePaths += (Join-Path $env:LOCALAPPDATA "OpenAI\Codex\bin\codex.exe")
+
+    $localOpenAIBin = Join-Path $env:LOCALAPPDATA "OpenAI\Codex\bin"
+    if (Test-Path -LiteralPath $localOpenAIBin -PathType Container) {
+        $candidatePaths += Get-ChildItem -LiteralPath $localOpenAIBin -Directory -ErrorAction SilentlyContinue |
+            ForEach-Object { Join-Path $_.FullName "codex.exe" }
     }
 
     $pathCommand = Get-Command "codex" -ErrorAction SilentlyContinue
     if ($null -ne $pathCommand -and -not [string]::IsNullOrWhiteSpace($pathCommand.Source)) {
-        $candidateBins += (Split-Path -Parent $pathCommand.Source)
+        $candidatePaths += $pathCommand.Source
     }
-
-    $candidateBins += (Join-Path $env:LOCALAPPDATA "Programs\OpenAI\Codex\bin")
-    $candidateBins += (Join-Path $env:LOCALAPPDATA "OpenAI\Codex\bin")
 
     $seen = @{}
     $checked = @()
-    foreach ($bin in $candidateBins) {
-        if ([string]::IsNullOrWhiteSpace($bin)) {
+    foreach ($candidate in $candidatePaths) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) {
             continue
         }
 
-        $key = $bin.TrimEnd("\").ToLowerInvariant()
+        $key = $candidate.ToLowerInvariant()
         if ($seen.ContainsKey($key)) {
             continue
         }
         $seen[$key] = $true
 
-        $candidate = Join-Path $bin "codex.exe"
         $checked += $candidate
         if (Test-Path -LiteralPath $candidate -PathType Leaf) {
-            return [PSCustomObject]@{
-                Bin  = $bin
-                Path = $candidate
+            try {
+                & $candidate --version *> $null
+                if ($LASTEXITCODE -eq 0) {
+                    return [PSCustomObject]@{
+                        Bin  = Split-Path -Parent $candidate
+                        Path = $candidate
+                    }
+                }
+            } catch {
+                continue
             }
         }
     }
 
-    throw "codex.exe was not found. Checked: $($checked -join '; ')"
+    throw "A runnable codex.exe was not found. Checked: $($checked -join '; ')"
 }
 
 function Test-CodexLoggedIn {
     param([string]$CodexCommand)
 
-    $status = & $CodexCommand login status 2>&1
-    return ($LASTEXITCODE -eq 0 -and (($status -join "`n") -match "Logged in"))
+    $previousErrorActionPreference = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
+    try {
+        $status = & $CodexCommand login status 2>&1
+        return ($LASTEXITCODE -eq 0 -and (($status -join "`n") -match "Logged in"))
+    } catch {
+        return $false
+    } finally {
+        $ErrorActionPreference = $previousErrorActionPreference
+    }
 }
 
 function Wait-CodexLogin {

--- a/src/agentMode/backends/claude/ClaudeInstallModal.tsx
+++ b/src/agentMode/backends/claude/ClaudeInstallModal.tsx
@@ -8,7 +8,12 @@ import { setSettings, useSettingsValue } from "@/settings/model";
 import { validateExecutableFile } from "@/utils/detectBinary";
 import { App, Notice } from "obsidian";
 import React from "react";
-import { CLAUDE_INSTALL_COMMAND, detectClaudeCliPath, resolveClaudeCliPath } from "./descriptor";
+import {
+  CLAUDE_INSTALL_COMMAND,
+  claudeCliDetectionSearchDirs,
+  detectClaudeCliPath,
+  resolveClaudeCliPath,
+} from "./descriptor";
 
 /**
  * Configure dialog for the Claude (Agent SDK) backend. The SDK auto-detects the
@@ -52,21 +57,25 @@ const ClaudeConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         </p>
         <BinaryPathSetting
           binaryName="claude"
-          placeholder="/absolute/path/to/claude"
+          placeholder={
+            process.platform === "win32"
+              ? "/absolute/path/to/claude.exe"
+              : "/absolute/path/to/claude"
+          }
           initialPath={overridePath}
-          notFoundHint={`claude not found on disk. Install with \`${CLAUDE_INSTALL_COMMAND}\` and try again, or paste a custom path manually.`}
+          notFoundHint="claude not found in known install locations. Run the install command above, then click Auto-detect again."
           onSave={onSaveCustomPath}
           onClear={clearCustomPath}
           persistOnAutoDetect
           detect={() => Promise.resolve(detectClaudeCliPath())}
+          searchedDirs={claudeCliDetectionSearchDirs}
         />
       </ConfigSection>
 
       <ConfigSection title="Authentication">
         <p className="tw-my-0 tw-text-sm tw-text-muted">
-          Credentials inherit from the <code>claude</code> CLI login state — run <code>claude</code>{" "}
-          once to sign in — or set <code>ANTHROPIC_API_KEY</code> (or Bedrock / Vertex env) in your
-          shell.
+          Claude inherits auth from your local <code>claude auth login --claudeai</code>{" "}
+          credentials.
         </p>
       </ConfigSection>
     </ConfigDialogShell>

--- a/src/agentMode/backends/claude/claudeBinaryResolver.test.ts
+++ b/src/agentMode/backends/claude/claudeBinaryResolver.test.ts
@@ -1,4 +1,5 @@
 import {
+  claudeBinarySearchDirs,
   resolveClaudeBinary,
   type ClaudeBinaryResolverFs,
   type ClaudeBinaryResolverInput,
@@ -237,5 +238,10 @@ describe("resolveClaudeBinary — Windows", () => {
     // running headless. Auto-detect must never select it.
     const guiLauncher = "C:\\Users\\me\\AppData\\Local\\Microsoft\\WindowsApps\\Claude.exe";
     expect(resolveClaudeBinary(winInput(makeFs([guiLauncher])))).toBeNull();
+  });
+
+  it("reports Windows searched dirs with Windows path semantics", () => {
+    const dirs = claudeBinarySearchDirs(winInput(makeFs([])));
+    expect(dirs).toContain("C:\\Users\\me\\.local\\bin");
   });
 });

--- a/src/agentMode/backends/claude/claudeBinaryResolver.ts
+++ b/src/agentMode/backends/claude/claudeBinaryResolver.ts
@@ -44,6 +44,18 @@ export function resolveClaudeBinary(input: ClaudeBinaryResolverInput): string | 
   return null;
 }
 
+export function claudeBinarySearchDirs(input: ClaudeBinaryResolverInput): string[] {
+  const candidates = input.platform === "win32" ? windowsCandidates(input) : unixCandidates(input);
+  const pathImpl = input.platform === "win32" ? path.win32 : path.posix;
+  return Array.from(
+    new Set(
+      candidates
+        .filter((candidate): candidate is string => Boolean(candidate))
+        .map((candidate) => pathImpl.dirname(candidate))
+    )
+  );
+}
+
 const posix = path.posix;
 const win = path.win32;
 

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -33,7 +33,7 @@ import { ClaudeSettingsPanel } from "./ClaudeSettingsPanel";
 
 export const CLAUDE_INSTALL_COMMAND =
   process.platform === "win32"
-    ? "irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/docs/install-claude-agent-mode-windows.ps1 | iex"
+    ? "irm https://gist.githubusercontent.com/logancyang/7a87eb38d91015eac567521f8cc9c729/raw/install-claude-agent-mode-windows.ps1 | iex"
     : "npm install -g @anthropic-ai/claude-code";
 
 export function updateClaudeFields(partial: Partial<ClaudeBackendSettings>): void {

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -12,7 +12,7 @@ import {
 } from "@/settings/model";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { MethodUnsupportedError } from "@/agentMode/session/errors";
-import { resolveClaudeBinary } from "./claudeBinaryResolver";
+import { claudeBinarySearchDirs, resolveClaudeBinary } from "./claudeBinaryResolver";
 import { getClaudeAuthStatus, signInToClaude } from "./claudeAuth";
 import { agentOriginEnabledModelEntries } from "@/agentMode/backends/shared/agentEnabledModels";
 import { ClaudeSdkBackendProcess } from "@/agentMode/sdk/ClaudeSdkBackendProcess";
@@ -31,7 +31,10 @@ import { ClaudeInstallModal } from "./ClaudeInstallModal";
 import ClaudeLogo from "./logo.svg";
 import { ClaudeSettingsPanel } from "./ClaudeSettingsPanel";
 
-export const CLAUDE_INSTALL_COMMAND = "npm install -g @anthropic-ai/claude-code";
+export const CLAUDE_INSTALL_COMMAND =
+  process.platform === "win32"
+    ? "irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/docs/install-claude-agent-mode-windows.ps1 | iex"
+    : "npm install -g @anthropic-ai/claude-code";
 
 export function updateClaudeFields(partial: Partial<ClaudeBackendSettings>): void {
   updateAgentModeBackendFields("claude", partial);
@@ -108,6 +111,10 @@ export function resolveClaudeCliPath(settings: CopilotSettings): string | null {
  */
 export function detectClaudeCliPath(): string | null {
   return resolveClaudeBinary({ override: undefined, ...claudeResolverEnv() });
+}
+
+export function claudeCliDetectionSearchDirs(): string[] {
+  return claudeBinarySearchDirs({ override: undefined, ...claudeResolverEnv() });
 }
 
 /**

--- a/src/agentMode/backends/codex/CodexInstallModal.tsx
+++ b/src/agentMode/backends/codex/CodexInstallModal.tsx
@@ -8,13 +8,18 @@ import { useSettingsValue } from "@/settings/model";
 import { validateExecutableFile } from "@/utils/detectBinary";
 import { App, Notice } from "obsidian";
 import React from "react";
-import { CODEX_BINARY_NAME, CODEX_INSTALL_COMMAND, updateCodexFields } from "./descriptor";
+import {
+  CODEX_BINARY_NAME,
+  CODEX_INSTALL_COMMAND,
+  codexAcpDetectionSearchDirs,
+  detectCodexAcpPath,
+  updateCodexFields,
+} from "./descriptor";
 
 /**
- * Configure dialog for the Codex backend. Codex spawns the self-contained
- * `codex-acp` binary (it bundles the Codex engine as Rust crates — no separate
- * `codex` CLI is needed at runtime). The dialog configures the codex-acp path
- * and gives auth guidance; the `codex` CLI is only relevant for `codex login`.
+ * Configure dialog for the Codex backend. Copilot spawns the native
+ * `codex-acp` ACP adapter. The dialog configures the codex-acp path
+ * and gives auth guidance; `codex login` owns the user's auth state.
  */
 const CodexConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const settings = useSettingsValue();
@@ -48,9 +53,11 @@ const CodexConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
         </p>
         <BinaryPathSetting
           binaryName={CODEX_BINARY_NAME}
-          placeholder="/absolute/path/to/codex-acp"
+          placeholder="/absolute/path/to/codex-acp.exe"
           initialPath={binaryPath}
-          notFoundHint={`${CODEX_BINARY_NAME} not found on PATH. Run the install command above, then click Auto-detect again.`}
+          notFoundHint={`${CODEX_BINARY_NAME} not found in known install locations or PATH. Run the install command above, then click Auto-detect again.`}
+          detect={detectCodexAcpPath}
+          searchedDirs={codexAcpDetectionSearchDirs}
           onSave={onSavePath}
           onClear={clearCodexPath}
           persistOnAutoDetect
@@ -59,8 +66,7 @@ const CodexConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
 
       <ConfigSection title="Authentication">
         <p className="tw-my-0 tw-text-sm tw-text-muted">
-          Codex inherits auth from your local <code>codex login</code> credentials, or from{" "}
-          <code>OPENAI_API_KEY</code> / <code>CODEX_API_KEY</code> exported in your shell.
+          Codex inherits auth from your local <code>codex login</code> credentials.
         </p>
       </ConfigSection>
     </ConfigDialogShell>

--- a/src/agentMode/backends/codex/codexBinaryResolver.test.ts
+++ b/src/agentMode/backends/codex/codexBinaryResolver.test.ts
@@ -1,0 +1,97 @@
+import * as path from "node:path";
+
+import { codexAcpSearchDirs, resolveCodexAcpBinary } from "./codexBinaryResolver";
+
+function fsWith(paths: string[]) {
+  const existing = new Set(paths);
+  return {
+    existsSync: (p: string): boolean => existing.has(p),
+    readFileSync: (): string => "",
+    readdirSync: (): string[] => [],
+  };
+}
+
+describe("resolveCodexAcpBinary", () => {
+  it("finds the Windows helper-script install path", () => {
+    const expected = path.win32.join(
+      "C:\\Users\\me",
+      "AppData",
+      "Local",
+      "Programs",
+      "codex-acp",
+      "codex-acp.exe"
+    );
+
+    expect(
+      resolveCodexAcpBinary({
+        homeDir: "C:\\Users\\me",
+        platform: "win32",
+        env: { LOCALAPPDATA: path.win32.join("C:\\Users\\me", "AppData", "Local") },
+        fs: fsWith([expected]),
+      })
+    ).toBe(expected);
+  });
+
+  it("finds the direct npm platform tarball extraction path", () => {
+    const expected = path.win32.join(
+      "C:\\Users\\me",
+      "AppData",
+      "Local",
+      "codex-acp",
+      "package",
+      "bin",
+      "codex-acp.exe"
+    );
+
+    expect(
+      resolveCodexAcpBinary({
+        homeDir: "C:\\Users\\me",
+        platform: "win32",
+        env: { LOCALAPPDATA: path.win32.join("C:\\Users\\me", "AppData", "Local") },
+        fs: fsWith([expected]),
+      })
+    ).toBe(expected);
+  });
+
+  it("finds native npm optional-dependency binaries without selecting cmd shims", () => {
+    const expected = path.win32.join(
+      "C:\\Users\\me",
+      "AppData",
+      "Roaming",
+      "npm",
+      "node_modules",
+      "@zed-industries",
+      "codex-acp",
+      "node_modules",
+      "@zed-industries",
+      "codex-acp-win32-x64",
+      "bin",
+      "codex-acp.exe"
+    );
+
+    expect(
+      resolveCodexAcpBinary({
+        homeDir: "C:\\Users\\me",
+        platform: "win32",
+        env: { APPDATA: path.win32.join("C:\\Users\\me", "AppData", "Roaming") },
+        fs: fsWith([
+          path.win32.join("C:\\Users\\me", "AppData", "Roaming", "npm", "codex-acp.cmd"),
+          expected,
+        ]),
+      })
+    ).toBe(expected);
+  });
+
+  it("reports the Windows helper install directory in searched dirs", () => {
+    const dirs = codexAcpSearchDirs({
+      homeDir: "C:\\Users\\me",
+      platform: "win32",
+      env: { LOCALAPPDATA: path.win32.join("C:\\Users\\me", "AppData", "Local") },
+      fs: fsWith([]),
+    });
+
+    expect(dirs).toContain(
+      path.win32.join("C:\\Users\\me", "AppData", "Local", "Programs", "codex-acp")
+    );
+  });
+});

--- a/src/agentMode/backends/codex/codexBinaryResolver.ts
+++ b/src/agentMode/backends/codex/codexBinaryResolver.ts
@@ -31,7 +31,8 @@ export function resolveCodexAcpBinary(input: CodexAcpBinaryResolverInput): strin
 
 export function codexAcpSearchDirs(input: CodexAcpBinaryResolverInput): string[] {
   const candidates = input.platform === "win32" ? windowsCandidates(input) : unixCandidates(input);
-  return Array.from(new Set(candidates.map((candidate) => path.dirname(candidate))));
+  const pathImpl = input.platform === "win32" ? path.win32 : path.posix;
+  return Array.from(new Set(candidates.map((candidate) => pathImpl.dirname(candidate))));
 }
 
 const posix = path.posix;

--- a/src/agentMode/backends/codex/codexBinaryResolver.ts
+++ b/src/agentMode/backends/codex/codexBinaryResolver.ts
@@ -1,0 +1,118 @@
+/**
+ * Locate a user-installed native `codex-acp` binary for the Codex Configure
+ * dialog. On Windows, the npm shim (`codex-acp.cmd`) is not spawnable through
+ * Agent Mode's no-shell ACP process path, so this resolver probes native
+ * `.exe` locations first and only falls back to the generic PATH detector.
+ */
+import * as path from "node:path";
+
+import { nodeToolBinDirCandidates, type NodeToolFs } from "@/utils/nodeToolBinDirs";
+
+export type CodexAcpBinaryResolverFs = NodeToolFs;
+
+export interface CodexAcpBinaryResolverInput {
+  homeDir: string;
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  fs: CodexAcpBinaryResolverFs;
+}
+
+export function resolveCodexAcpBinary(input: CodexAcpBinaryResolverInput): string | null {
+  const candidates = input.platform === "win32" ? windowsCandidates(input) : unixCandidates(input);
+
+  for (const candidate of candidates) {
+    if (candidate && input.fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+export function codexAcpSearchDirs(input: CodexAcpBinaryResolverInput): string[] {
+  const candidates = input.platform === "win32" ? windowsCandidates(input) : unixCandidates(input);
+  return Array.from(new Set(candidates.map((candidate) => path.dirname(candidate))));
+}
+
+const posix = path.posix;
+const win = path.win32;
+
+function unixCandidates(input: CodexAcpBinaryResolverInput): string[] {
+  const { homeDir } = input;
+  const dirs = [
+    posix.join(homeDir, ".local", "bin"),
+    posix.join(homeDir, ".codex-acp", "bin"),
+    ...nodeToolBinDirCandidates(input),
+    "/usr/local/bin",
+    "/opt/homebrew/bin",
+  ];
+  return dirs.map((dir) => posix.join(dir, "codex-acp"));
+}
+
+function windowsCandidates(input: CodexAcpBinaryResolverInput): string[] {
+  const { homeDir, env } = input;
+  const localAppData = env.LOCALAPPDATA ?? win.join(homeDir, "AppData", "Local");
+  const appData = env.APPDATA ?? win.join(homeDir, "AppData", "Roaming");
+  const npmGlobal = win.join(appData, "npm");
+  const out: string[] = [
+    // Copilot's docs helper installs the native release zip here.
+    win.join(localAppData, "Programs", "codex-acp", "codex-acp.exe"),
+    // Earlier direct-tarball docs extracted the npm platform package here.
+    win.join(localAppData, "codex-acp", "package", "bin", "codex-acp.exe"),
+    // Allow users who manually extracted the release zip to this simpler dir.
+    win.join(localAppData, "codex-acp", "codex-acp.exe"),
+    win.join(homeDir, ".local", "bin", "codex-acp.exe"),
+  ];
+
+  for (const dir of [...nodeToolBinDirCandidates(input), npmGlobal]) {
+    out.push(win.join(dir, "codex-acp.exe"));
+    out.push(
+      win.join(
+        dir,
+        "node_modules",
+        "@zed-industries",
+        "codex-acp-win32-x64",
+        "bin",
+        "codex-acp.exe"
+      )
+    );
+    out.push(
+      win.join(
+        dir,
+        "node_modules",
+        "@zed-industries",
+        "codex-acp-win32-arm64",
+        "bin",
+        "codex-acp.exe"
+      )
+    );
+    out.push(
+      win.join(
+        dir,
+        "node_modules",
+        "@zed-industries",
+        "codex-acp",
+        "node_modules",
+        "@zed-industries",
+        "codex-acp-win32-x64",
+        "bin",
+        "codex-acp.exe"
+      )
+    );
+    out.push(
+      win.join(
+        dir,
+        "node_modules",
+        "@zed-industries",
+        "codex-acp",
+        "node_modules",
+        "@zed-industries",
+        "codex-acp-win32-arm64",
+        "bin",
+        "codex-acp.exe"
+      )
+    );
+  }
+
+  return out;
+}

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -30,7 +30,7 @@ import { codexAcpSearchDirs, resolveCodexAcpBinary } from "./codexBinaryResolver
 export const CODEX_BINARY_NAME = "codex-acp";
 export const CODEX_INSTALL_COMMAND =
   process.platform === "win32"
-    ? "irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/docs/install-codex-agent-mode-windows.ps1 | iex"
+    ? "irm https://gist.githubusercontent.com/logancyang/380ef4dbf9f98900771da76eca3d21e6/raw/install-codex-agent-mode-windows.ps1 | iex"
     : "npm install -g @zed-industries/codex-acp";
 
 /**

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
 import type CopilotPlugin from "@/main";
 import {
   subscribeToSettingsChange,
@@ -22,9 +24,14 @@ import type {
   ModelWireCodec,
 } from "@/agentMode/session/types";
 import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
+import { detectBinary } from "@/utils/detectBinary";
+import { codexAcpSearchDirs, resolveCodexAcpBinary } from "./codexBinaryResolver";
 
 export const CODEX_BINARY_NAME = "codex-acp";
-export const CODEX_INSTALL_COMMAND = "npm install -g @zed-industries/codex-acp";
+export const CODEX_INSTALL_COMMAND =
+  process.platform === "win32"
+    ? "irm https://raw.githubusercontent.com/logancyang/obsidian-copilot/v4-preview/docs/install-codex-agent-mode-windows.ps1 | iex"
+    : "npm install -g @zed-industries/codex-acp";
 
 /**
  * Vocabulary mirrors codex-acp's advertised efforts. `minimal` is included
@@ -35,6 +42,29 @@ const KNOWN_CODEX_EFFORTS = new Set(["minimal", "low", "medium", "high", "xhigh"
 
 export function updateCodexFields(partial: Partial<CodexBackendSettings>): void {
   updateAgentModeBackendFields("codex", partial);
+}
+
+function codexAcpResolverEnv(): Parameters<typeof resolveCodexAcpBinary>[0] {
+  return {
+    homeDir: os.homedir(),
+    platform: process.platform,
+    env: process.env,
+    fs: {
+      existsSync: (p) => fs.existsSync(p),
+      readFileSync: (p, encoding) => fs.readFileSync(p, encoding),
+      readdirSync: (p) => fs.readdirSync(p),
+    },
+  };
+}
+
+export async function detectCodexAcpPath(): Promise<string | null> {
+  const fromResolver = resolveCodexAcpBinary(codexAcpResolverEnv());
+  if (fromResolver) return fromResolver;
+  return detectBinary(CODEX_BINARY_NAME);
+}
+
+export function codexAcpDetectionSearchDirs(): string[] {
+  return codexAcpSearchDirs(codexAcpResolverEnv());
 }
 
 /**

--- a/src/agentMode/backends/shared/InstallCommandRow.tsx
+++ b/src/agentMode/backends/shared/InstallCommandRow.tsx
@@ -15,7 +15,7 @@ interface Props {
  * Shared by the Claude and Codex Configure dialogs.
  */
 const DEFAULT_LABEL =
-  process.platform === "win32" ? "Install command (Windows)" : "Install command";
+  process.platform === "win32" ? "Install command (Windows PowerShell)" : "Install command";
 
 export const InstallCommandRow: React.FC<Props> = ({ command, label = DEFAULT_LABEL }) => {
   const copy = React.useCallback((): void => {

--- a/src/agentMode/backends/shared/InstallCommandRow.tsx
+++ b/src/agentMode/backends/shared/InstallCommandRow.tsx
@@ -6,7 +6,7 @@ import React from "react";
 interface Props {
   /** Shell command to display and copy. */
   command: string;
-  /** Label above the command block. Defaults to "Install command". */
+  /** Label above the command block. Defaults to the platform-aware install label. */
   label?: string;
 }
 
@@ -14,7 +14,10 @@ interface Props {
  * A copy-able shell command block (install instructions) with a Copy button.
  * Shared by the Claude and Codex Configure dialogs.
  */
-export const InstallCommandRow: React.FC<Props> = ({ command, label = "Install command" }) => {
+const DEFAULT_LABEL =
+  process.platform === "win32" ? "Install command (Windows)" : "Install command";
+
+export const InstallCommandRow: React.FC<Props> = ({ command, label = DEFAULT_LABEL }) => {
   const copy = React.useCallback((): void => {
     navigator.clipboard.writeText(command).catch((e) => {
       logError("[AgentMode] copy install command failed", e);


### PR DESCRIPTION
## Summary

Adds a Windows setup guide for Agent Mode backends and links it from the docs index.

This now covers:

- Claude Code: run a one-line Copilot helper script that installs Claude Code with Anthropic's standalone Windows installer, launches Claude for sign-in, copies the `claude.exe` path, and tells the user where to paste it if Auto-detect misses it.
- Codex: run a one-line Copilot helper script that installs the official Codex CLI, starts `codex login`, downloads native `codex-acp.exe`, copies that path to the clipboard, and tells the user where to paste it.

## Why the Codex helper script exists

Copilot launches Agent Mode backends with Node `child_process.spawn(command, args, ...)` and no shell. On Windows, the npm `codex-acp.cmd` shim can fail under that spawn path, so the guide must land users on the native `codex-acp.exe` instead.

The Codex helper script intentionally uses Codex CLI login, not API-key environment variables. Users leave Copilot's Codex environment variables empty.

## Changes

- Retitles `docs/agent-mode-windows-setup.md` to cover Agent Mode on Windows rather than Claude only.
- Replaces the Claude manual command sequence with a concise one-line helper script.
- Adds a concise Codex section with the one-line PowerShell installer command.
- Adds `docs/install-claude-agent-mode-windows.ps1` to install Claude Code, run Claude sign-in, copy the resolved `claude.exe` path, and print next steps.
- Adds `docs/install-codex-agent-mode-windows.ps1` to install Codex CLI, run `codex login`, install native `codex-acp.exe`, copy the path, and print next steps.
- Hardens Codex CLI lookup to check `CODEX_INSTALL_DIR`, PATH, `%LOCALAPPDATA%\Programs\OpenAI\Codex\bin`, and `%LOCALAPPDATA%\OpenAI\Codex\bin`.
- Updates the docs index row to mention Claude Code and Codex.

## Scope

This is the docs-only slice of preview-repo issues #108 (Claude) and #109 (Codex). The in-plugin "not found" message edits are a separate follow-up and are intentionally not included here.

## Caveat

Codex path/spawn behavior is verified from package metadata plus Copilot's spawn code, and both helper scripts pass PowerShell syntax checks. The full Claude/Codex flows have not yet been run end-to-end on a clean real Windows machine.

## Test plan

- [x] PowerShell parser check for `docs/install-claude-agent-mode-windows.ps1`
- [x] PowerShell parser check for `docs/install-codex-agent-mode-windows.ps1`
- [x] Simulated Codex CLI lookup for `%LOCALAPPDATA%\OpenAI\Codex\bin\codex.exe`
- [x] Verified latest `codex-acp` Windows release asset lookup returns the native x64 zip
- [x] Verified `@zed-industries/codex-acp-win32-x64@0.15.0` contains `package/bin/codex-acp.exe`
- [x] Ran Prettier on the Markdown docs with the repo's pinned Prettier version
- [ ] Verify the new page renders on the published docs site and the index link resolves
- [ ] Manual Windows 11 blank-state test: run the Claude helper script, complete sign-in, paste copied `claude.exe`, run one Claude Agent Mode turn
- [ ] Manual Windows 11 blank-state test: run the Codex helper script, complete `codex login`, paste copied `codex-acp.exe`, run one Codex Agent Mode turn

Relates to logancyang/obsidian-copilot-preview#108
Relates to logancyang/obsidian-copilot-preview#109