### PR TITLE
feat(agent-mode): mask home dir with ~ in Agent settings binary paths

### DIFF
--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -11,6 +11,7 @@ import { TruncatedText } from "@/components/TruncatedText";
 import { usePlugin } from "@/contexts/PluginContext";
 import { logError } from "@/logger";
 import { setSettings, useSettingsValue } from "@/settings/model";
+import { formatBinaryPathForDisplay } from "@/utils/binaryPath";
 import { Platform } from "obsidian";
 import React from "react";
 import { ConfiguredModelEnableList } from "./ConfiguredModelEnableList";
@@ -113,7 +114,7 @@ const BackendSection: React.FC<{
             </div>
             {resolvedPath && (
               <TruncatedText className="tw-max-w-[90%] tw-font-mono tw-text-xs tw-text-muted">
-                {resolvedPath}
+                {formatBinaryPathForDisplay(resolvedPath)}
               </TruncatedText>
             )}
           </div>

--- a/src/utils/binaryPath.ts
+++ b/src/utils/binaryPath.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 
+import { collapseHomeDir } from "@/utils/pathUtils";
 import { resolveNodeToolBinDirs } from "@/utils/nodeToolBinDirs";
 
 /**
@@ -84,4 +85,16 @@ export function detectionSearchDirs(): string[] {
  */
 export function augmentPathForDetection(inherited: string | undefined): string {
   return mergePath(detectionSearchDirs(), inherited);
+}
+
+/**
+ * Format an absolute binary path for display by collapsing the user's home
+ * directory to `~` (e.g. `/Users/alice/.local/bin/claude` →
+ * `~/.local/bin/claude`). Avoids leaking the OS username in the settings UI
+ * and in screenshots users share when reporting issues.
+ *
+ * Display-only — the stored/spawned path keeps its real absolute form.
+ */
+export function formatBinaryPathForDisplay(absolutePath: string): string {
+  return collapseHomeDir(absolutePath, os.homedir(), process.platform === "win32");
 }

--- a/src/utils/pathUtils.test.ts
+++ b/src/utils/pathUtils.test.ts
@@ -134,4 +134,25 @@ describe("collapseHomeDir", () => {
   it("returns the input unchanged when home is empty", () => {
     expect(collapseHomeDir("/Users/alice/bin", "")).toBe("/Users/alice/bin");
   });
+
+  // Windows: path stored with forward slashes, os.homedir() returns backslashes.
+  it("matches when absolutePath uses forward slashes but homeDir uses backslashes", () => {
+    expect(collapseHomeDir("C:/Users/Alice/bin/codex.exe", "C:\\Users\\Alice", true)).toBe(
+      "~/bin/codex.exe"
+    );
+  });
+
+  // Windows: path stored with backslashes, os.homedir() returns forward slashes.
+  it("matches when absolutePath uses backslashes but homeDir uses forward slashes", () => {
+    expect(collapseHomeDir("C:\\Users\\Alice\\bin\\codex.exe", "C:/Users/Alice", true)).toBe(
+      "~\\bin\\codex.exe"
+    );
+  });
+
+  // Mixed separators in the suffix must be preserved as-is after the tilde.
+  it("preserves original suffix separators when separators are mixed", () => {
+    expect(collapseHomeDir("C:/Users/Alice\\bin/codex.exe", "C:\\Users\\Alice", true)).toBe(
+      "~\\bin/codex.exe"
+    );
+  });
 });

--- a/src/utils/pathUtils.test.ts
+++ b/src/utils/pathUtils.test.ts
@@ -1,4 +1,4 @@
-import { basename, joinPosix, normalizeAbsPath, parentDir } from "./pathUtils";
+import { basename, collapseHomeDir, joinPosix, normalizeAbsPath, parentDir } from "./pathUtils";
 
 describe("normalizeAbsPath", () => {
   it("converts backslashes to forward slashes", () => {
@@ -89,5 +89,49 @@ describe("basename", () => {
 
   it("normalizes backslashes before extracting", () => {
     expect(basename("C:\\a\\b\\c.md")).toBe("c.md");
+  });
+});
+
+describe("collapseHomeDir", () => {
+  it("replaces a leading home prefix with ~", () => {
+    expect(collapseHomeDir("/Users/alice/.local/bin/claude", "/Users/alice")).toBe(
+      "~/.local/bin/claude"
+    );
+  });
+
+  it("collapses a path equal to the home directory to ~", () => {
+    expect(collapseHomeDir("/Users/alice", "/Users/alice")).toBe("~");
+  });
+
+  it("tolerates a trailing slash on the home directory", () => {
+    expect(collapseHomeDir("/Users/alice/bin", "/Users/alice/")).toBe("~/bin");
+  });
+
+  it("leaves paths outside the home directory unchanged", () => {
+    expect(collapseHomeDir("/opt/homebrew/bin/codex", "/Users/alice")).toBe(
+      "/opt/homebrew/bin/codex"
+    );
+  });
+
+  it("does not match a sibling dir that shares the home prefix", () => {
+    expect(collapseHomeDir("/Users/alice2/bin", "/Users/alice")).toBe("/Users/alice2/bin");
+  });
+
+  it("preserves Windows separators in the suffix", () => {
+    expect(collapseHomeDir("C:\\Users\\alice\\bin\\codex.exe", "C:\\Users\\alice")).toBe(
+      "~\\bin\\codex.exe"
+    );
+  });
+
+  it("matches case-insensitively when requested (Windows)", () => {
+    expect(collapseHomeDir("C:\\USERS\\Alice\\bin", "C:\\Users\\alice", true)).toBe("~\\bin");
+  });
+
+  it("matches case-sensitively by default", () => {
+    expect(collapseHomeDir("/USERS/alice/bin", "/Users/alice")).toBe("/USERS/alice/bin");
+  });
+
+  it("returns the input unchanged when home is empty", () => {
+    expect(collapseHomeDir("/Users/alice/bin", "")).toBe("/Users/alice/bin");
   });
 });

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -62,6 +62,13 @@ export function resolvesInto(targetAbs: string, rootAbs: string): boolean {
  * not inside the home directory are returned unchanged. Never reuse the result
  * as a real path — it is not resolvable.
  *
+ * The home-prefix comparison is done on separator-normalized views of both
+ * strings (backslash → forward slash) so that a path stored with forward
+ * slashes (`C:/Users/Alice/bin`) still matches an `os.homedir()` that uses
+ * backslashes (`C:\Users\Alice`), and vice-versa. The suffix is sliced from
+ * the original `absolutePath` so its real separator style is preserved for
+ * display.
+ *
  * @param absolutePath The path to format.
  * @param homeDir The user's home directory (injected so this stays pure/testable).
  * @param caseInsensitive Match the home prefix case-insensitively (for Windows).
@@ -77,12 +84,18 @@ export function collapseHomeDir(
   const normHome = homeDir.replace(/[/\\]+$/, "");
   if (!normHome) return absolutePath;
 
-  const head = absolutePath.slice(0, normHome.length);
+  // Normalize separators to forward slashes for comparison only.
+  // Since `\` and `/` are both single characters, normHome.length equals the
+  // number of characters in the home-prefix portion of absolutePath, so we can
+  // use it as a slice index against the original strings below.
+  const normHomeFwd = normHome.replace(/\\/g, "/");
+  const headFwd = absolutePath.slice(0, normHome.length).replace(/\\/g, "/");
   const matches = caseInsensitive
-    ? head.toLowerCase() === normHome.toLowerCase()
-    : head === normHome;
+    ? headFwd.toLowerCase() === normHomeFwd.toLowerCase()
+    : headFwd === normHomeFwd;
   if (!matches) return absolutePath;
 
+  // Slice the suffix from the *original* path to preserve its real separators.
   const rest = absolutePath.slice(normHome.length);
   if (rest === "") return "~";
   // Require a real path boundary so `/Users/alice2/...` doesn't match `/Users/alice`.

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -52,3 +52,40 @@ export function resolvesInto(targetAbs: string, rootAbs: string): boolean {
   const r = normalizeAbsPath(rootAbs);
   return t === r || t.startsWith(r + "/");
 }
+
+/**
+ * Collapse a leading home-directory prefix to `~` for privacy-preserving
+ * display, e.g. `/Users/alice/.local/bin/claude` → `~/.local/bin/claude`.
+ *
+ * Display-only: the original separator style is preserved in the suffix
+ * (so a Windows `C:\Users\alice\bin` renders as `~\bin`), and paths that are
+ * not inside the home directory are returned unchanged. Never reuse the result
+ * as a real path — it is not resolvable.
+ *
+ * @param absolutePath The path to format.
+ * @param homeDir The user's home directory (injected so this stays pure/testable).
+ * @param caseInsensitive Match the home prefix case-insensitively (for Windows).
+ * @returns The path with the home prefix replaced by `~`, or unchanged.
+ */
+export function collapseHomeDir(
+  absolutePath: string,
+  homeDir: string,
+  caseInsensitive = false
+): string {
+  if (!absolutePath || !homeDir) return absolutePath;
+  // Strip trailing separators so `/Users/alice/` still matches `/Users/alice`.
+  const normHome = homeDir.replace(/[/\\]+$/, "");
+  if (!normHome) return absolutePath;
+
+  const head = absolutePath.slice(0, normHome.length);
+  const matches = caseInsensitive
+    ? head.toLowerCase() === normHome.toLowerCase()
+    : head === normHome;
+  if (!matches) return absolutePath;
+
+  const rest = absolutePath.slice(normHome.length);
+  if (rest === "") return "~";
+  // Require a real path boundary so `/Users/alice2/...` doesn't match `/Users/alice`.
+  if (rest[0] === "/" || rest[0] === "\\") return "~" + rest;
+  return absolutePath;
+}


### PR DESCRIPTION
## Summary

The OpenCode / Claude / Codex entries in **Agent settings** render the resolved binary path verbatim (`AgentSettings.tsx`), exposing the user's OS username, e.g. `/Users/<username>/.local/bin/claude`. Users frequently share settings screenshots when reporting issues, leaking that path info.

This collapses a leading home-directory prefix to `~` for **display only**:

- `collapseHomeDir()` — pure, testable helper in `src/utils/pathUtils.ts`. Takes an injected `homeDir`, optional case-insensitive match (Windows), preserves the original separator style in the suffix, and requires a real path boundary so `/Users/alice2/...` doesn't match `/Users/alice`.
- `formatBinaryPathForDisplay()` — thin `os.homedir()` / `process.platform` wrapper in `src/utils/binaryPath.ts`, used in `AgentSettings.tsx`.

The stored and spawned path keeps its real absolute form — this is purely presentation. The truncation tooltip also shows the masked path, so there's no leak on hover.

Closes logancyang/obsidian-copilot-preview#114

## Examples

| Before | After |
| --- | --- |
| `/Users/alice/.local/bin/claude` | `~/.local/bin/claude` |
| `C:\Users\alice\bin\codex.exe` | `~\bin\codex.exe` |
| `/opt/homebrew/bin/codex` | `/opt/homebrew/bin/codex` (unchanged) |

## Testing

- [x] `npm run test` — 3435 passed (added 10 `collapseHomeDir` cases covering boundary, equality, trailing slash, Windows separators, case sensitivity, and the empty-home guard)
- [x] `npm run format && npm run lint` — clean
- [x] `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)