### PR TITLE
Persist the last-selected Agent Mode permission mode across new conversations

### DIFF
--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -12,6 +12,7 @@ import type { AgentChatPersistenceManager } from "./AgentChatPersistenceManager"
 import type { AgentModelPreloader, WarmBackend } from "./AgentModelPreloader";
 import { MethodUnsupportedError } from "./errors";
 import { resolveMcpServers } from "./mcpResolver";
+import { replayPersistedMode } from "./replayPersistedMode";
 import type {
   AgentQuestionAnswers,
   AskUserQuestionPrompt,
@@ -19,6 +20,7 @@ import type {
   BackendId,
   BackendProcess,
   BackendState,
+  CopilotMode,
   ModeApplySpec,
   ModelSelection,
   PermissionDecision,
@@ -299,6 +301,11 @@ export class AgentSessionManager {
         logInfo(
           `[AgentMode] session ready (internal=${session.internalId} backend-id=${session.getBackendSessionId()} backend=${resolvedId}); pool size=${this.sessions.size}`
         );
+        // Seed the user's sticky mode preference so a new conversation reopens
+        // in the mode they last chose (e.g. `auto`). Generic across backends;
+        // `replayPersistedMode` swallows its own errors so it never blocks ready.
+        // Runs last so it can't perturb the lastError/ready ordering above.
+        await replayPersistedMode(session, this.getDefaultMode(resolvedId));
       })
       .catch((err) => {
         this.lastError = err2String(err);
@@ -396,10 +403,12 @@ export class AgentSessionManager {
 
   /**
    * Apply a canonical mode change against the active session. `spec` carries
-   * the native dispatch info (which ACP RPC + payload). The selection is not
-   * persisted — every fresh session starts in canonical `default`.
+   * the native dispatch info (which ACP RPC + payload); `mode` is the canonical
+   * id to persist. After a successful apply, `mode` becomes the backend's sticky
+   * default so the next new conversation reopens in it — symmetric with
+   * `applySelection`. If the apply throws, no persistence occurs.
    */
-  async applyMode(backendId: BackendId, spec: ModeApplySpec): Promise<void> {
+  async applyMode(backendId: BackendId, mode: CopilotMode, spec: ModeApplySpec): Promise<void> {
     const session = this.getActiveSession();
     if (!session || session.backendId !== backendId) return;
     if (spec.kind === "setMode") {
@@ -407,6 +416,33 @@ export class AgentSessionManager {
     } else {
       await session.setConfigOption(spec.configId, spec.value);
     }
+    await this.persistDefaultMode(backendId, mode);
+  }
+
+  /** Read the user's sticky mode preference for `backendId`, or `null` if none. */
+  getDefaultMode(backendId: BackendId): CopilotMode | null {
+    const backends = getSettings().agentMode?.backends as
+      | Record<string, { defaultMode?: CopilotMode | null } | undefined>
+      | undefined;
+    return backends?.[backendId]?.defaultMode ?? null;
+  }
+
+  /** Persist a sticky mode preference for `backendId`. Pass `null` to clear. */
+  async persistDefaultMode(backendId: BackendId, mode: CopilotMode | null): Promise<void> {
+    setSettings((cur) => {
+      const existing = (cur.agentMode.backends as Record<string, unknown> | undefined)?.[
+        backendId
+      ] as Record<string, unknown> | undefined;
+      return {
+        agentMode: {
+          ...cur.agentMode,
+          backends: {
+            ...cur.agentMode.backends,
+            [backendId]: { ...(existing ?? {}), defaultMode: mode },
+          },
+        },
+      };
+    });
   }
 
   getBackendProcess(backendId: BackendId): BackendProcess | null {

--- a/src/agentMode/session/replayPersistedMode.test.ts
+++ b/src/agentMode/session/replayPersistedMode.test.ts
@@ -1,0 +1,109 @@
+import type { AgentSession } from "./AgentSession";
+import { MethodUnsupportedError } from "./errors";
+import { replayPersistedMode } from "./replayPersistedMode";
+import type { BackendState, CopilotMode } from "./types";
+
+type ModeState = NonNullable<BackendState["mode"]>;
+
+interface MockSessionParts {
+  mode: ModeState | null;
+  setMode?: jest.Mock;
+  setConfigOption?: jest.Mock;
+}
+
+function makeSession({ mode, setMode, setConfigOption }: MockSessionParts): {
+  session: AgentSession;
+  setMode: jest.Mock;
+  setConfigOption: jest.Mock;
+} {
+  const setModeMock = setMode ?? jest.fn().mockResolvedValue(undefined);
+  const setConfigOptionMock = setConfigOption ?? jest.fn().mockResolvedValue(undefined);
+  const session = {
+    getState: (): BackendState => ({ model: null, mode }),
+    setMode: setModeMock,
+    setConfigOption: setConfigOptionMock,
+  } as unknown as AgentSession;
+  return { session, setMode: setModeMock, setConfigOption: setConfigOptionMock };
+}
+
+const modeState = (current: CopilotMode | null, apply: ModeState["apply"]): ModeState => ({
+  current,
+  options: [
+    { value: "default", label: "Default" },
+    { value: "plan", label: "Plan" },
+    { value: "auto", label: "Auto" },
+  ],
+  apply,
+});
+
+describe("replayPersistedMode", () => {
+  it("applies the persisted mode via setMode when it differs from current", async () => {
+    const { session, setMode } = makeSession({
+      mode: modeState("default", { auto: { kind: "setMode", nativeId: "bypassPermissions" } }),
+    });
+    await replayPersistedMode(session, "auto");
+    expect(setMode).toHaveBeenCalledWith("bypassPermissions");
+  });
+
+  it("applies the persisted mode via setConfigOption for configOption-style backends", async () => {
+    const { session, setConfigOption } = makeSession({
+      mode: modeState("default", {
+        plan: { kind: "setConfigOption", configId: "approval", value: "plan" },
+      }),
+    });
+    await replayPersistedMode(session, "plan");
+    expect(setConfigOption).toHaveBeenCalledWith("approval", "plan");
+  });
+
+  it("is a no-op when no mode is persisted", async () => {
+    const { session, setMode } = makeSession({
+      mode: modeState("default", { auto: { kind: "setMode", nativeId: "bypassPermissions" } }),
+    });
+    await replayPersistedMode(session, null);
+    expect(setMode).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the backend exposes no modes", async () => {
+    const { session, setMode } = makeSession({ mode: null });
+    await replayPersistedMode(session, "auto");
+    expect(setMode).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the session is already in the persisted mode", async () => {
+    const { session, setMode } = makeSession({
+      mode: modeState("auto", { auto: { kind: "setMode", nativeId: "bypassPermissions" } }),
+    });
+    await replayPersistedMode(session, "auto");
+    expect(setMode).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a no-op when the backend doesn't offer the persisted mode", async () => {
+    // Persisted "auto" but this backend only advertises an apply spec for "plan".
+    const { session, setMode, setConfigOption } = makeSession({
+      mode: modeState("default", {
+        plan: { kind: "setConfigOption", configId: "approval", value: "plan" },
+      }),
+    });
+    await replayPersistedMode(session, "auto");
+    expect(setMode).not.toHaveBeenCalled();
+    expect(setConfigOption).not.toHaveBeenCalled();
+  });
+
+  it("swallows MethodUnsupportedError without throwing", async () => {
+    const setMode = jest.fn().mockRejectedValue(new MethodUnsupportedError("session/set_mode"));
+    const { session } = makeSession({
+      mode: modeState("default", { auto: { kind: "setMode", nativeId: "bypassPermissions" } }),
+      setMode,
+    });
+    await expect(replayPersistedMode(session, "auto")).resolves.toBeUndefined();
+  });
+
+  it("swallows unexpected apply errors without throwing", async () => {
+    const setMode = jest.fn().mockRejectedValue(new Error("boom"));
+    const { session } = makeSession({
+      mode: modeState("default", { auto: { kind: "setMode", nativeId: "bypassPermissions" } }),
+      setMode,
+    });
+    await expect(replayPersistedMode(session, "auto")).resolves.toBeUndefined();
+  });
+});

--- a/src/agentMode/session/replayPersistedMode.ts
+++ b/src/agentMode/session/replayPersistedMode.ts
@@ -1,0 +1,41 @@
+import { logWarn } from "@/logger";
+import type { AgentSession } from "./AgentSession";
+import { MethodUnsupportedError } from "./errors";
+import type { CopilotMode } from "./types";
+
+/**
+ * Re-apply the user's sticky permission-mode preference to a freshly created
+ * session, so a new conversation reopens in the mode they last chose (e.g.
+ * `auto`) instead of always resetting to the agent's natural starting mode.
+ *
+ * Backend-agnostic: it dispatches through the canonical `mode.apply` spec the
+ * session already exposes (`setMode` vs `setConfigOption`), so it needs no
+ * per-backend branching. A backend that has no modes, hasn't advertised this
+ * mode, or is already in it is a no-op. Mode state ships with the session's
+ * initial `BackendState`, so a single attempt at `ready` suffices — unlike
+ * effort, which can arrive late and needs a subscription.
+ *
+ * @param session The session to seed (the one being initialized, not "active").
+ * @param mode The persisted canonical mode, or `null` when none is stored.
+ */
+export async function replayPersistedMode(
+  session: AgentSession,
+  mode: CopilotMode | null
+): Promise<void> {
+  if (!mode) return;
+  const modeState = session.getState()?.mode;
+  if (!modeState) return; // backend exposes no modes
+  if (modeState.current === mode) return; // already there — nothing to do
+  const spec = modeState.apply[mode];
+  if (!spec) return; // this backend doesn't offer the persisted mode
+  try {
+    if (spec.kind === "setMode") {
+      await session.setMode(spec.nativeId);
+    } else {
+      await session.setConfigOption(spec.configId, spec.value);
+    }
+  } catch (e) {
+    if (e instanceof MethodUnsupportedError) return;
+    logWarn(`[AgentMode] could not replay persisted mode "${mode}"`, e);
+  }
+}

--- a/src/agentMode/ui/agentModePickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModePickerHelpers.test.ts
@@ -105,7 +105,7 @@ describe("buildAgentModePicker", () => {
     ).toBe(false);
   });
 
-  it("onChange dispatches manager.applyMode with the per-option spec", () => {
+  it("onChange dispatches manager.applyMode with the canonical mode and per-option spec", () => {
     const applyMode = jest.fn().mockResolvedValue(undefined);
     const spec = { kind: "setMode" as const, nativeId: "plan" };
     const picker = buildAgentModePicker({
@@ -126,7 +126,7 @@ describe("buildAgentModePicker", () => {
       }),
     });
     picker?.onChange("plan");
-    expect(applyMode).toHaveBeenCalledWith("codex", spec);
+    expect(applyMode).toHaveBeenCalledWith("codex", "plan", spec);
   });
 
   it("onChange ignores selections without an apply spec", () => {

--- a/src/agentMode/ui/agentModePickerHelpers.ts
+++ b/src/agentMode/ui/agentModePickerHelpers.ts
@@ -47,7 +47,7 @@ export function buildAgentModePicker(args: {
     onChange: (value) => {
       const spec = activeMode.apply[value];
       if (!spec) return;
-      manager.applyMode(activeBackendId, spec).catch((err) => {
+      manager.applyMode(activeBackendId, value, spec).catch((err) => {
         handlePickerSwitchError(err, "mode");
       });
     },

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -2,7 +2,7 @@ import { CustomModel, ProjectConfig } from "@/aiParams";
 import { atom, createStore, useAtomValue } from "jotai";
 import { v4 as uuidv4 } from "uuid";
 
-import type { ModelSelection } from "@/agentMode";
+import type { CopilotMode, ModelSelection } from "@/agentMode";
 import { type ChainType } from "@/chainType";
 import type { BackendConfig, BackendType, ConfiguredModel, Provider } from "@/modelManagement";
 import { type SortStrategy, isSortStrategy } from "@/utils/recentUsageManager";
@@ -309,6 +309,8 @@ export interface CopilotSettings {
 export interface ClaudeBackendSettings {
   /** Sticky model preference — `{ baseModelId, effort }`. Unset = use the agent's default. */
   defaultModel?: ModelSelection | null;
+  /** Sticky permission-mode preference (default/plan/auto). Unset = the agent's natural starting mode. */
+  defaultMode?: CopilotMode | null;
   /**
    * Opt-in: pass `thinking: { type: "enabled" }` to the SDK so the agent
    * surfaces reasoning chunks. Off by default (matches SDK default).
@@ -329,6 +331,8 @@ export interface CodexBackendSettings {
   binaryPath?: string;
   /** Sticky model preference — `{ baseModelId, effort }`. Unset = use the agent's default. */
   defaultModel?: ModelSelection | null;
+  /** Sticky permission-mode preference (default/plan/auto). Unset = the agent's natural starting mode. */
+  defaultMode?: CopilotMode | null;
   /** See `ClaudeBackendSettings.envOverrides`. Applied to the spawned `codex-acp` subprocess. */
   envOverrides?: Record<string, string>;
 }
@@ -349,6 +353,8 @@ export interface OpencodeBackendSettings {
    * `baseModelId` is the `<provider>/<model>` form (no effort suffix).
    */
   defaultModel?: ModelSelection | null;
+  /** Sticky permission-mode preference (default/plan/auto). Unset = the agent's natural starting mode. */
+  defaultMode?: CopilotMode | null;
   /**
    * ACP sessionId of the dedicated "probe session" used by AgentModelPreloader
    * to enumerate live models without disturbing user chats. Persisted across
@@ -1043,6 +1049,15 @@ function sanitizeDefaultModel(raw: unknown): ModelSelection | undefined {
   return { baseModelId, effort };
 }
 
+// Closed set mirroring the `CopilotMode` union; an unknown/legacy value is
+// dropped so a corrupt data.json can't seed a mode the picker can't render.
+const COPILOT_MODES: readonly CopilotMode[] = ["default", "plan", "auto"];
+function sanitizeDefaultMode(raw: unknown): CopilotMode | undefined {
+  return typeof raw === "string" && (COPILOT_MODES as readonly string[]).includes(raw)
+    ? (raw as CopilotMode)
+    : undefined;
+}
+
 /**
  * Strict env-var key check: POSIX-style identifier. Rejects empty strings,
  * leading digits, `=`, whitespace, dots, hyphens, and control chars. Shared
@@ -1076,6 +1091,7 @@ function sanitizeClaudeBackendSettings(raw: unknown): ClaudeBackendSettings {
   const r = raw as Record<string, unknown>;
   return {
     defaultModel: sanitizeDefaultModel(r.defaultModel),
+    defaultMode: sanitizeDefaultMode(r.defaultMode),
     enableThinking: typeof r.enableThinking === "boolean" ? r.enableThinking : undefined,
     envOverrides: sanitizeEnvOverrides(r.envOverrides),
   };
@@ -1087,6 +1103,7 @@ function sanitizeCodexBackendSettings(raw: unknown): CodexBackendSettings {
   return {
     binaryPath: nonEmptyString(r.binaryPath),
     defaultModel: sanitizeDefaultModel(r.defaultModel),
+    defaultMode: sanitizeDefaultMode(r.defaultMode),
     envOverrides: sanitizeEnvOverrides(r.envOverrides),
   };
 }
@@ -1108,6 +1125,7 @@ function sanitizeOpencodeBackendSettings(raw: unknown): OpencodeBackendSettings 
     binaryVersion,
     binarySource,
     defaultModel: sanitizeDefaultModel(r.defaultModel),
+    defaultMode: sanitizeDefaultMode(r.defaultMode),
     probeSessionId: nonEmptyString(r.probeSessionId),
     envOverrides: sanitizeEnvOverrides(r.envOverrides),
   };


### PR DESCRIPTION
## Summary

Fixes a reported annoyance: every new Agent Mode conversation reset the permission mode to the backend's natural default, so a user who works in `auto` had to re-select it each time (and this differs from other agent tools, which remember the choice).

Root cause: the mode picker (`agentModePickerHelpers.ts`) only reflects live session state (`value: activeMode.current`), and nothing seeded a fresh session — the Claude descriptor's `applyInitialSessionConfig` replays the persisted model *effort* but explicitly not the mode. There was a persisted `defaultModel` per backend but no `defaultMode`.

This makes the mode sticky, mirroring the existing model/effort persistence:

- **Settings**: added `defaultMode?: CopilotMode | null` to each backend slice in `src/settings/model.ts`, plus a `sanitizeDefaultMode` helper wired into all three sanitizers (the sanitizer allowlists fields, so without this the value would be dropped on reload).
- **Persist on change**: `AgentSessionManager.applyMode` now takes the canonical mode and writes it via `persistDefaultMode` after a successful apply — symmetric with `applySelection`; if the apply throws, nothing is persisted.
- **Replay on new session**: a new generic `replayPersistedMode(session, mode)` helper runs once the session is ready. It dispatches through the session's own canonical `mode.apply` spec (`setMode` vs `setConfigOption`), so there's **no per-backend or per-mode branching**. A backend with no modes, or that doesn't advertise the stored mode, is a no-op (falls back to its natural default).

Persistence is **per-backend**, so each agent (Claude / Codex / opencode) reopens in its own last-used mode and an unsupported mode never leaks across backends.

## Design decisions (from the issue's open questions)

- **All modes persist uniformly**, including `plan` and `auto` — "remember exactly what I last chose," with no special-casing (per the repo's generalizable-solution principle). `plan` sticking is the natural consequence; if product wants `plan` treated as one-off, that's a follow-up.
- **`auto` (Claude `bypassPermissions`) persisting is intentional** — it's the whole point of the report. New chats will auto-approve once the user has opted into `auto`; flagged here for visibility.

## Test plan

- [x] `npm run test` — 3464 passed, including a new `replayPersistedMode` unit suite (apply via `setMode`/`setConfigOption`, no-op when unpersisted / no modes / already-in-mode, **unsupported-mode fallback**, and error swallowing) and an updated picker dispatch test.
- [x] `npm run format && npm run lint` — clean
- [x] `npm run build` (tsc) — clean
- [ ] Manual (`test:vault`): pick `auto`, start a new chat → opens in `auto`; reload Obsidian → still `auto`; switch backend → reopens in that backend's own last-used mode.

Note: the v4 permission-mode picker isn't covered in `docs/` yet (that doc describes the older Plus agent), so there's nothing to keep in sync here.

Closes logancyang/obsidian-copilot-preview#117

🤖 Generated with [Claude Code](https://claude.com/claude-code)