### PR TITLE
fix(tools): remove zod transforms that break autonomous agent tool binding

### DIFF
--- a/src/tools/ComposerTools.ts
+++ b/src/tools/ComposerTools.ts
@@ -125,17 +125,13 @@ const writeFileSchema = z.object({
               {"id": "e1-2", "fromNode": "1", "toNode": "2", "fromSide": "right", "toSide": "left", "color": "3", "label": "links to"}
             ]
           }`),
+  // Accept boolean or string (some models stringify) without a schema-level transform: a
+  // transform/preprocess cannot be represented in JSON Schema, which breaks bindTools() ->
+  // toJSONSchema() for the autonomous agent. The value is only a hint and is not read at
+  // runtime — preview is gated solely by settings.autoAcceptEdits below.
   confirmation: z
-    .preprocess((val) => {
-      if (typeof val === "string") {
-        const lc = val.trim().toLowerCase();
-        if (lc === "true") return true;
-        if (lc === "false") return false;
-      }
-      return val;
-    }, z.boolean())
+    .union([z.boolean(), z.string()])
     .optional()
-    .default(true)
     .describe(
       `(Optional) Hint for confirmation preference. Note: preview is always shown unless the user has enabled auto-accept in settings.`
     ),

--- a/src/tools/NoteTools.ts
+++ b/src/tools/NoteTools.ts
@@ -367,18 +367,22 @@ function chunkContentByLines(file: TFile, content: string): NoteChunk[] {
   return chunks;
 }
 
-// Models occasionally send numeric tool args as strings; coerce here rather than in the
-// schema. A schema-level transform/preprocess cannot be represented in JSON Schema, which
-// breaks bindTools() -> toJSONSchema() for the autonomous agent.
-const coerceChunkIndex = (value: number | string | undefined): number => {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : 0;
+// Models occasionally send numeric tool args as strings, so the schema accepts a string and
+// we coerce here rather than in the schema: a schema-level transform/preprocess cannot be
+// represented in JSON Schema, which breaks bindTools() -> toJSONSchema() for the autonomous
+// agent. Validation that the old `z.number().int().min(0)` schema performed now lives here:
+// an omitted value defaults to the first chunk (0); anything that is not a non-negative
+// integer returns null so the caller can surface a validation error instead of indexing the
+// chunk array out of bounds.
+const coerceChunkIndex = (value: number | string | undefined): number | null => {
+  if (value === undefined) {
+    return 0;
   }
-  if (typeof value === "string") {
-    const parsed = Number(value.trim());
-    return Number.isFinite(parsed) ? parsed : 0;
+  const parsed = typeof value === "string" ? Number(value.trim()) : value;
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return null;
   }
-  return 0;
+  return parsed;
 };
 
 const readNoteSchema = z.object({
@@ -409,6 +413,15 @@ const createReadNoteTool = (app: App) =>
           notePath: sanitizedPath,
           status: "invalid_path",
           message: "Provide the note path relative to the vault root without a leading slash.",
+        };
+      }
+
+      if (chunkIndex === null) {
+        return {
+          notePath: sanitizedPath,
+          status: "invalid_chunk_index",
+          message:
+            "chunkIndex must be a non-negative integer (0-based). Omit it to read the first chunk.",
         };
       }
 

--- a/src/tools/NoteTools.ts
+++ b/src/tools/NoteTools.ts
@@ -367,6 +367,20 @@ function chunkContentByLines(file: TFile, content: string): NoteChunk[] {
   return chunks;
 }
 
+// Models occasionally send numeric tool args as strings; coerce here rather than in the
+// schema. A schema-level transform/preprocess cannot be represented in JSON Schema, which
+// breaks bindTools() -> toJSONSchema() for the autonomous agent.
+const coerceChunkIndex = (value: number | string | undefined): number => {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+};
+
 const readNoteSchema = z.object({
   notePath: z
     .string()
@@ -375,17 +389,7 @@ const readNoteSchema = z.object({
       "Full path to the note (relative to the vault root) that needs to be read, such as 'Projects/plan.md'."
     ),
   chunkIndex: z
-    .preprocess((value) => {
-      if (typeof value === "string") {
-        const trimmed = value.trim();
-        if (trimmed.length === 0) {
-          return undefined;
-        }
-        const parsed = Number(trimmed);
-        return Number.isFinite(parsed) ? parsed : value;
-      }
-      return value;
-    }, z.number().int().min(0))
+    .union([z.number().int().min(0), z.string()])
     .optional()
     .describe("0-based chunk index to read. Omit to read the first chunk."),
 });
@@ -396,7 +400,8 @@ const createReadNoteTool = (app: App) =>
     description:
       "Read a single note in search v3 sized chunks. Use only when you already know the exact note path and need its contents.",
     schema: readNoteSchema,
-    func: async ({ notePath, chunkIndex = 0 }) => {
+    func: async ({ notePath, chunkIndex: rawChunkIndex }) => {
+      const chunkIndex = coerceChunkIndex(rawChunkIndex);
       const sanitizedPath = notePath.trim();
 
       if (sanitizedPath.startsWith("/")) {

--- a/src/tools/ReadNoteTool.test.ts
+++ b/src/tools/ReadNoteTool.test.ts
@@ -133,6 +133,21 @@ describe("readNoteTool", () => {
     expect(result.content).toBe(lines.slice(200).join("\n"));
   });
 
+  it.each(["-1", "1.5", "abc"])(
+    "returns invalid_chunk_index for non-negative-integer chunkIndex %p",
+    async (chunkIndex) => {
+      const notePath = "Notes/bad-index.md";
+      const file = new MockTFile(notePath);
+      getAbstractFileByPathMock.mockReturnValue(file);
+      mockRead.mockResolvedValue(["Line 1", "Line 2"].join("\n"));
+
+      const result = await invokeReadNoteTool(readNoteTool, { notePath, chunkIndex });
+
+      expect(result.status).toBe("invalid_chunk_index");
+      expect(result.content).toBeUndefined();
+    }
+  );
+
   it("returns not_found when the note cannot be resolved", async () => {
     const notePath = "Notes/missing.md";
     getAbstractFileByPathMock.mockReturnValue(null);

--- a/src/tools/toolSchemas.jsonschema.test.ts
+++ b/src/tools/toolSchemas.jsonschema.test.ts
@@ -1,0 +1,40 @@
+import type { App } from "obsidian";
+import { toJsonSchema } from "@langchain/core/utils/json_schema";
+import { createReadNoteTool } from "./NoteTools";
+import { createWriteFileTool, createEditFileTool } from "./ComposerTools";
+
+/**
+ * Regression guard for the "Transforms cannot be represented in JSON Schema" failure.
+ *
+ * When the autonomous agent binds tools, LangChain serializes each tool's zod schema for
+ * the model request via `toJsonSchema()`. LangChain first rewrites the schema to its INPUT
+ * form (`interopZodTransformInputSchema`) and then runs zod v4's `toJSONSchema()`; a
+ * schema-level `.transform()` / `.preprocess()` left in that input form has no JSON Schema
+ * representation and throws at request time (surfaced as "Model request failed: ...").
+ *
+ * `readNote.chunkIndex` previously used `.preprocess()` and broke the agent this way.
+ * Note: the throw only reproduces through LangChain's `toJsonSchema` path, not a bare
+ * `z.toJSONSchema(schema)` — the rewrite step is what exposes the transform.
+ *
+ * Scoped to these factories rather than the full ToolRegistry because pulling in
+ * builtinTools transitively imports chatModelManager / @langchain/anthropic, which fails to
+ * resolve under jest.
+ */
+
+const mockApp = {} as unknown as App;
+
+const toolFactories = [
+  { name: "readNote", create: createReadNoteTool },
+  { name: "writeFile", create: createWriteFileTool },
+  { name: "editFile", create: createEditFileTool },
+];
+
+describe("tool schemas are JSON-Schema serializable for tool binding", () => {
+  test.each(toolFactories)(
+    "$name schema serializes via LangChain toJsonSchema without throwing",
+    ({ create }) => {
+      const tool = create(mockApp);
+      expect(() => toJsonSchema(tool.schema)).not.toThrow();
+    }
+  );
+});


### PR DESCRIPTION
## Problem

The legacy autonomous agent (brain-icon ReAct loop in Plus chat) crashes with:

```
Model request failed: Error: Transforms cannot be represented in JSON Schema
    at transformProcessor (json-schema-processors.js:247:15)
    at optionalProcessor (json-schema-processors.js:511:5)
    at objectProcessor (json-schema-processors.js:282:32)
    at toJSONSchema (json-schema-processors.js:598:5)
```

## Root cause

`readNote.chunkIndex` (`src/tools/NoteTools.ts`) was `z.preprocess(...).optional()`, which is a zod transform/pipe. When the autonomous agent binds tools (`AutonomousAgentChainRunner.ts:559`), the model request serializes each tool's zod schema via LangChain's `toJsonSchema()` (`@langchain/core/utils/json_schema`). LangChain first rewrites the schema to its **input** form via `interopZodTransformInputSchema`, exposing the transform node, then zod v4's `toJSONSchema()` throws because a transform has no JSON Schema representation. The error surfaces at `src/langchainStream.ts:35-36` as "Model request failed: …", which is why it reads like a model error rather than a bind error.

Notes from the investigation:
- A bare `z.toJSONSchema(readNoteSchema)` does **not** throw — only LangChain's input-rewrite path does. That's why this manifests only through `bindTools`.
- `writeFile.confirmation` used the same `.preprocess()` pattern but its `.optional().default(true)` wrapper happened to dodge the throw. Fixed defensively anyway.
- The non-agent `CopilotPlusChainRunner` planning path binds only clean utility tools (`getAvailableToolsForPlanning()`), so plain Plus mode never hit this.

## Fix

- `readNote.chunkIndex` → `z.union([z.number().int().min(0), z.string()]).optional()`, with string→number coercion moved into the tool's `func`.
- `writeFile.confirmation` → `z.union([z.boolean(), z.string()]).optional()` (the value is only a hint and is not read at runtime; preview is gated by `settings.autoAcceptEdits`).
- No `.transform()` / `.preprocess()` / `.pipe()` remains on any schema passed to `bindTools`.
- New regression test `src/tools/toolSchemas.jsonschema.test.ts` runs LangChain's `toJsonSchema()` over the read/composer tools so a future transform in a tool schema fails in CI instead of at runtime.

## Testing

- `npm run test` for the affected tool suites (`ReadNoteTool`, `ComposerTools`, `allTools.validation`, new `toolSchemas.jsonschema`) — all pass.
- Confirmed the old `readNote` schema throws through LangChain's `toJsonSchema()` and the new one passes.
- `npm run format && npm run lint` clean.

Refs logancyang/obsidian-copilot-preview#69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
