### PR TITLE
Recover the agent pane after cancelling the image attachment picker

### DIFF
--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -33,6 +33,7 @@ import React, {
 import { $getSelection, $isRangeSelection, LexicalEditor as LexicalEditorType } from "lexical";
 import { ContextControl } from "./ContextControl";
 import { AddContextButton } from "./AddContextButton";
+import { openImagePicker } from "./openImagePicker";
 import { shouldShowAtMentionTools } from "./hooks/useAtMentionCategories";
 import { ModelEffortPicker } from "@/components/ui/ModelEffortPicker";
 import { ModePicker } from "@/components/ui/ModePicker";
@@ -495,14 +496,12 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
         // hosting this chat view (popout-safe), not whichever window is focused.
         const doc = containerRef.current?.doc;
         if (!doc) break;
-        const input = doc.createElement("input");
-        input.type = "file";
-        input.accept = "image/*";
-        input.multiple = true;
-        input.addEventListener("change", () => onAddImage(Array.from(input.files || [])), {
-          once: true,
+        openImagePicker(doc, {
+          onFiles: onAddImage,
+          // Restore focus to the composer so cancelling the dialog doesn't
+          // leave the pane unresponsive (#119).
+          onSettle: () => lexicalEditorRef.current?.focus(),
         });
-        input.click();
         break;
       }
     }

--- a/src/components/chat-components/openImagePicker.test.ts
+++ b/src/components/chat-components/openImagePicker.test.ts
@@ -5,21 +5,23 @@ describe("openImagePicker", () => {
   // that can pop a native dialog under Electron; stub it so tests stay inert.
   let clickSpy: jest.SpyInstance;
   beforeEach(() => {
+    // Obsidian exposes `activeDocument`; jsdom doesn't, so point it at the test doc.
+    (window as unknown as { activeDocument: Document }).activeDocument = window.document;
     clickSpy = jest.spyOn(HTMLInputElement.prototype, "click").mockImplementation(() => {});
   });
   afterEach(() => {
     clickSpy.mockRestore();
-    document.body.innerHTML = "";
+    activeDocument.body.innerHTML = "";
   });
 
   const pickerInput = (): HTMLInputElement => {
-    const input = document.body.querySelector('input[type="file"]');
+    const input = activeDocument.body.querySelector('input[type="file"]');
     if (!input) throw new Error("picker input not found in DOM");
     return input as HTMLInputElement;
   };
 
   it("appends a configured file input to the DOM and clicks it", () => {
-    openImagePicker(document, { onFiles: jest.fn() });
+    openImagePicker(activeDocument, { onFiles: jest.fn() });
     const input = pickerInput();
     expect(input.accept).toBe("image/*");
     expect(input.multiple).toBe(true);
@@ -29,20 +31,20 @@ describe("openImagePicker", () => {
   it("on cancel: removes the input and calls onSettle, never onFiles", () => {
     const onFiles = jest.fn();
     const onSettle = jest.fn();
-    openImagePicker(document, { onFiles, onSettle });
+    openImagePicker(activeDocument, { onFiles, onSettle });
     const input = pickerInput();
 
     input.dispatchEvent(new Event("cancel"));
 
     expect(onSettle).toHaveBeenCalledTimes(1);
     expect(onFiles).not.toHaveBeenCalled();
-    expect(document.body.contains(input)).toBe(false);
+    expect(activeDocument.body.contains(input)).toBe(false);
   });
 
   it("on change: forwards files, removes the input, and calls onSettle", () => {
     const onFiles = jest.fn();
     const onSettle = jest.fn();
-    openImagePicker(document, { onFiles, onSettle });
+    openImagePicker(activeDocument, { onFiles, onSettle });
     const input = pickerInput();
 
     input.dispatchEvent(new Event("change"));
@@ -50,13 +52,13 @@ describe("openImagePicker", () => {
     expect(onFiles).toHaveBeenCalledTimes(1);
     expect(Array.isArray(onFiles.mock.calls[0][0])).toBe(true);
     expect(onSettle).toHaveBeenCalledTimes(1);
-    expect(document.body.contains(input)).toBe(false);
+    expect(activeDocument.body.contains(input)).toBe(false);
   });
 
   it("works without an onSettle handler", () => {
-    openImagePicker(document, { onFiles: jest.fn() });
+    openImagePicker(activeDocument, { onFiles: jest.fn() });
     const input = pickerInput();
     expect(() => input.dispatchEvent(new Event("cancel"))).not.toThrow();
-    expect(document.body.contains(input)).toBe(false);
+    expect(activeDocument.body.contains(input)).toBe(false);
   });
 });

--- a/src/components/chat-components/openImagePicker.test.ts
+++ b/src/components/chat-components/openImagePicker.test.ts
@@ -1,0 +1,62 @@
+import { openImagePicker } from "./openImagePicker";
+
+describe("openImagePicker", () => {
+  // jsdom would open nothing, but `.click()` on a file input is also a no-op
+  // that can pop a native dialog under Electron; stub it so tests stay inert.
+  let clickSpy: jest.SpyInstance;
+  beforeEach(() => {
+    clickSpy = jest.spyOn(HTMLInputElement.prototype, "click").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    clickSpy.mockRestore();
+    document.body.innerHTML = "";
+  });
+
+  const pickerInput = (): HTMLInputElement => {
+    const input = document.body.querySelector('input[type="file"]');
+    if (!input) throw new Error("picker input not found in DOM");
+    return input as HTMLInputElement;
+  };
+
+  it("appends a configured file input to the DOM and clicks it", () => {
+    openImagePicker(document, { onFiles: jest.fn() });
+    const input = pickerInput();
+    expect(input.accept).toBe("image/*");
+    expect(input.multiple).toBe(true);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("on cancel: removes the input and calls onSettle, never onFiles", () => {
+    const onFiles = jest.fn();
+    const onSettle = jest.fn();
+    openImagePicker(document, { onFiles, onSettle });
+    const input = pickerInput();
+
+    input.dispatchEvent(new Event("cancel"));
+
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(onFiles).not.toHaveBeenCalled();
+    expect(document.body.contains(input)).toBe(false);
+  });
+
+  it("on change: forwards files, removes the input, and calls onSettle", () => {
+    const onFiles = jest.fn();
+    const onSettle = jest.fn();
+    openImagePicker(document, { onFiles, onSettle });
+    const input = pickerInput();
+
+    input.dispatchEvent(new Event("change"));
+
+    expect(onFiles).toHaveBeenCalledTimes(1);
+    expect(Array.isArray(onFiles.mock.calls[0][0])).toBe(true);
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    expect(document.body.contains(input)).toBe(false);
+  });
+
+  it("works without an onSettle handler", () => {
+    openImagePicker(document, { onFiles: jest.fn() });
+    const input = pickerInput();
+    expect(() => input.dispatchEvent(new Event("cancel"))).not.toThrow();
+    expect(document.body.contains(input)).toBe(false);
+  });
+});

--- a/src/components/chat-components/openImagePicker.ts
+++ b/src/components/chat-components/openImagePicker.ts
@@ -1,0 +1,52 @@
+interface ImagePickerHandlers {
+  /** Called with the chosen files when the user picks one or more. */
+  onFiles: (files: File[]) => void;
+  /**
+   * Called once the dialog closes for ANY reason (picked or cancelled), after
+   * the input is torn down. Use it to restore focus to the composer.
+   */
+  onSettle?: () => void;
+}
+
+/**
+ * Open a native image file picker that cleans up after itself on BOTH
+ * outcomes — a file chosen (`change`) and the dialog dismissed (`cancel`).
+ *
+ * Why append to the DOM instead of clicking a detached input: a detached
+ * `<input>` that receives focus from `.click()` leaves focus on a node outside
+ * the document tree. When the dialog is cancelled, no `change` fires and that
+ * stale focus stays put — on Electron/Windows it swallows subsequent clicks
+ * and keystrokes in the pane and dings (logancyang/obsidian-copilot-preview#119).
+ * Appending the input, removing it on settle, and restoring composer focus via
+ * `onSettle` keeps the pane interactive in every path.
+ *
+ * `doc` is the chat view's own `Document` (`element.doc`) so the picker opens
+ * in the window hosting the view, not whichever window is focused (popout-safe).
+ */
+export function openImagePicker(doc: Document, handlers: ImagePickerHandlers): void {
+  const input = doc.createElement("input");
+  input.type = "file";
+  input.accept = "image/*";
+  input.multiple = true;
+  input.classList.add("tw-hidden");
+  doc.body.appendChild(input);
+
+  const settle = (): void => {
+    input.remove();
+    handlers.onSettle?.();
+  };
+
+  input.addEventListener(
+    "change",
+    () => {
+      handlers.onFiles(Array.from(input.files ?? []));
+      settle();
+    },
+    { once: true }
+  );
+  // Chromium/Electron fire `cancel` when the dialog is dismissed with no
+  // selection — the path that previously left the pane unresponsive.
+  input.addEventListener("cancel", settle, { once: true });
+
+  input.click();
+}


### PR DESCRIPTION
## Summary

Fixes logancyang/obsidian-copilot-preview#119. With opencode installed, **+ → image → Cancel** left the agent pane dead: clicking it produced the Windows error ding and the pane stopped accepting input.

Root cause (`ChatInput.tsx`): the image option created a `<input type="file">` via `createElement` but **never appended it to the DOM**, and only listened for `change`. On Cancel no `change` fires, so focus was left on a detached node outside the document tree — which Electron on Windows treats as a dead focus target that swallows subsequent clicks and keystrokes.

## Change

Extracted a small, testable `openImagePicker(doc, { onFiles, onSettle })` helper that:
- appends a hidden input to the **view's own document** (`element.doc`) so the dialog opens in the window hosting the chat (popout-safe), and
- handles **both** outcomes — `change` (files chosen) and `cancel` (dialog dismissed, the previously-broken path) — tearing the input down on either, then
- calls `onSettle` so the caller restores composer focus (`lexicalEditorRef.current?.focus()`), keeping the pane interactive.

## Test plan

- [x] `npm run test` — 3474 passed, incl. a new `openImagePicker` suite: cancel runs `onSettle` and never `onFiles`; change forwards files; the input is removed from the DOM in both paths; works with no `onSettle`.
- [x] `npm run format && npm run lint` — clean (0 errors)
- [x] `npm run build` — clean
- [ ] Manual (Windows, opencode): + → image → Cancel, then click and type in the agent input — accepts input, no error ding.

Closes logancyang/obsidian-copilot-preview#119

🤖 Generated with [Claude Code](https://claude.com/claude-code)