### PR TITLE
Raise the tool-output display cap to a 256k runaway backstop

### DIFF
--- a/src/agentMode/session/AgentMessageStore.test.ts
+++ b/src/agentMode/session/AgentMessageStore.test.ts
@@ -138,17 +138,7 @@ describe("AgentMessageStore", () => {
       title: "Search",
       status: "completed",
       input: { query: "communication drill", nested: { text: "x".repeat(20_000) } },
-      output: [
-        {
-          type: "text",
-          text:
-            "a".repeat(12_000) +
-            "\n\n[Tool output truncated in Copilot UI: 8,000 characters omitted.]",
-          truncated: true,
-          originalLength: 20_000,
-          omittedLength: 8_000,
-        },
-      ],
+      output: [{ type: "text", text: "a".repeat(20_000) }],
     };
 
     expect(store.upsertAgentPart(id, part)).toBe(true);

--- a/src/agentMode/session/AgentMessageStore.ts
+++ b/src/agentMode/session/AgentMessageStore.ts
@@ -125,12 +125,7 @@ function toolOutputsEqual(
       );
     }
     if (output.type === "text" && other.type === "text") {
-      return (
-        output.truncated === other.truncated &&
-        output.originalLength === other.originalLength &&
-        output.omittedLength === other.omittedLength &&
-        textFingerprint(output.text) === textFingerprint(other.text)
-      );
+      return textFingerprint(output.text) === textFingerprint(other.text);
     }
     return false;
   });

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -3,6 +3,7 @@ import type { TFile } from "obsidian";
 import { AgentSession, buildPromptBlocks, tryReadExitPlanModeCall } from "./AgentSession";
 import { AuthRequiredError, MethodUnsupportedError } from "./errors";
 import type {
+  AgentToolCallOutput,
   BackendDescriptor,
   BackendProcess,
   BackendState,
@@ -400,7 +401,8 @@ describe("AgentSession.sendPrompt", () => {
     await turn;
   });
 
-  it("truncates large text tool outputs before storing them in UI state", async () => {
+  // Emit one completed tool call with `text` output and return the stored output.
+  const storedToolOutput = async (text: string): Promise<AgentToolCallOutput | undefined> => {
     const mock = makeMockBackend();
     let resolvePrompt: ((v: { stopReason: "end_turn" }) => void) | null = null;
     mock.prompt.mockImplementation(
@@ -413,36 +415,34 @@ describe("AgentSession.sendPrompt", () => {
       backendId: "codex",
     });
     const { turn } = session.sendPrompt("hi");
-    const hugeOutput = "x".repeat(20_000);
-
     mock.emit({
       sessionId: "acp-1",
       update: {
         sessionUpdate: "tool_call_update",
         toolCallId: "tc1",
         status: "completed",
-        content: [{ type: "content", content: { type: "text", text: hugeOutput } }],
+        content: [{ type: "content", content: { type: "text", text } }],
       },
     });
-
-    const placeholder = session.store.getDisplayMessages().find((m) => m.sender === AI_SENDER);
-    const part = placeholder?.parts?.[0];
-    expect(part).toMatchObject({ kind: "tool_call", id: "tc1" });
-    if (part?.kind !== "tool_call") throw new Error("expected tool_call part");
-    const output = part.output?.[0];
-    expect(output).toMatchObject({
-      type: "text",
-      truncated: true,
-      originalLength: hugeOutput.length,
-      omittedLength: 8_000,
-    });
-    expect(output?.type === "text" ? output.text.length : 0).toBeLessThan(13_000);
-    expect(output?.type === "text" ? output.text : "").toContain(
-      "Tool output truncated in Copilot UI"
-    );
-
+    const part = session.store.getDisplayMessages().find((m) => m.sender === AI_SENDER)?.parts?.[0];
     resolvePrompt!({ stopReason: "end_turn" });
     await turn;
+    if (part?.kind !== "tool_call") throw new Error("expected tool_call part");
+    return part.output?.[0];
+  };
+
+  it("stores a large (but under-cap) text tool output in full", async () => {
+    const text = "x".repeat(100_000);
+    // 100k is far below the 256k runaway backstop, so it's preserved verbatim.
+    expect(await storedToolOutput(text)).toEqual({ type: "text", text });
+  });
+
+  it("trims a runaway tool output above the backstop, noting the agent got it all", async () => {
+    const output = await storedToolOutput("y".repeat(300_000));
+    if (output?.type !== "text") throw new Error("expected text output");
+    expect(output.text.length).toBeLessThan(300_000);
+    expect(output.text).toContain("Display trimmed");
+    expect(output.text).toContain("The agent received the full output");
   });
 
   it("cancel() sends cancel and aborts local controller", async () => {

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -40,7 +40,15 @@ import { getSettings } from "@/settings/model";
  * showing "New session - 2026-…" before the LLM-generated label arrives.
  */
 const DEFAULT_TITLE_PREFIX = "New session";
-const MAX_TOOL_OUTPUT_TEXT_CHARS = 12_000;
+/**
+ * Memory backstop for tool output kept in long-lived React state — NOT a
+ * display cap. At ~256KB it sits far above any realistic command/search/file
+ * result (the chat renders output collapsed in a scrollable box, so normal and
+ * large outputs show in full), and only a runaway multi-hundred-KB blob is
+ * trimmed to stop the message store from holding it for the whole session. The
+ * agent's own context always receives the full output regardless.
+ */
+const MAX_TOOL_OUTPUT_TEXT_CHARS = 256_000;
 // Shared sentinel so `getPendingToolPermissions()` returns a stable reference
 // when nothing is pending — preserves React `useState` setter bail-out
 // behavior on idle subscription ticks.
@@ -1459,7 +1467,7 @@ function extractToolCallOutputs(
   const outputs: AgentToolCallOutput[] = [];
   for (const item of content) {
     if (item.type === "content" && item.content.type === "text") {
-      outputs.push(truncateToolOutputText(item.content.text));
+      outputs.push(capToolOutputText(item.content.text));
     } else if (item.type === "diff") {
       outputs.push({
         type: "diff",
@@ -1473,24 +1481,19 @@ function extractToolCallOutputs(
 }
 
 /**
- * Keep large command/search results out of long-lived React state. The full
- * frame log still captures diagnostic summaries; the UI only needs enough
- * text to identify the result and avoid runaway memory growth.
+ * Pass tool-output text through untouched unless it exceeds the runaway
+ * backstop ({@link MAX_TOOL_OUTPUT_TEXT_CHARS}). The marker is explicit that
+ * only the *display* copy is trimmed and the agent still got everything, so a
+ * user never reads it as lost data.
  */
-function truncateToolOutputText(text: string): AgentToolCallOutput {
-  if (text.length <= MAX_TOOL_OUTPUT_TEXT_CHARS) {
-    return { type: "text", text };
-  }
-
-  const omittedLength = text.length - MAX_TOOL_OUTPUT_TEXT_CHARS;
+function capToolOutputText(text: string): AgentToolCallOutput {
+  if (text.length <= MAX_TOOL_OUTPUT_TEXT_CHARS) return { type: "text", text };
+  const omitted = text.length - MAX_TOOL_OUTPUT_TEXT_CHARS;
   return {
     type: "text",
     text:
       text.slice(0, MAX_TOOL_OUTPUT_TEXT_CHARS) +
-      `\n\n[Tool output truncated in Copilot UI: ${omittedLength.toLocaleString()} characters omitted.]`,
-    truncated: true,
-    originalLength: text.length,
-    omittedLength,
+      `\n\n[Display trimmed: ${omitted.toLocaleString()} more characters. The agent received the full output.]`,
   };
 }
 

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -344,13 +344,7 @@ export type AgentToolStatus = "pending" | "in_progress" | "completed" | "failed"
  * Mirrors a subset of ACP's `ToolCallContent` we render inline.
  */
 export type AgentToolCallOutput =
-  | {
-      type: "text";
-      text: string;
-      truncated?: boolean;
-      originalLength?: number;
-      omittedLength?: number;
-    }
+  | { type: "text"; text: string }
   | { type: "diff"; path: string; oldText: string | null; newText: string };
 
 /**


### PR DESCRIPTION
## The problem (plain English)

A local-model user saw `[Tool output truncated in Copilot UI: 39,166 characters omitted.]` and reasonably thought the agent had lost most of the tool's output.

It hadn't. The 12,000-char cap (`MAX_TOOL_OUTPUT_TEXT_CHARS` in `AgentSession.ts`) only trimmed what **Copilot displayed**. The backend (opencode / Claude SDK) owns the agent's context and always received the **full** output, the trimmed text isn't persisted, and the chat already renders output **collapsed in a scrollable box** (`ActionCard`'s `tw-max-h-40 tw-overflow-auto`). So the low cap gave nothing and cost visibility — and a *setting* for it would just push our bad default onto the user.

## Why not just delete the cap

I traced its origin: it was added in the very first Agent Mode commit as a **heap-memory guard** ("keep large results out of long-lived React state"), not a render-perf fix. Confirmed it was never doing perf work:
- Output renders in a plain, collapsed-by-default, scroll-bounded `<pre>` (no markdown parsing) — no paint blowup at any size.
- Message-store dedup already bounds comparison cost via `textFingerprint` (samples `length:first512:last512` for large strings), independent of the cap.

So the only thing a full removal would undo is that minor heap guard for pathological multi-MB outputs.

## Decision

Keep the guard but raise it far above any realistic output: a **256KB runaway backstop** (≈6.5× the reported 39k case). Normal and large outputs render in full; only a genuinely runaway blob is trimmed — with a marker that's explicit the agent still got everything (`[Display trimmed: N more characters. The agent received the full output.]`).

- `MAX_TOOL_OUTPUT_TEXT_CHARS` 12,000 → 256,000, repurposed as a memory backstop (not a display cap).
- Clearer marker so it can't be misread as lost data.
- Dropped the dead `truncated`/`originalLength`/`omittedLength` fields (never read by the UI) from `AgentToolCallOutput` and the `AgentMessageStore` equality check.
- No setting.

## Test plan

- [x] `npm run test` — 3471 passed. A 100k output is stored verbatim; a 300k output is trimmed with the "agent received the full output" marker.
- [x] `npm run format && npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Manual: trigger a ~40k-char tool call → full output shown (scrollable), no marker; a >256k output → trimmed with the marker, agent behavior unchanged.

Closes logancyang/obsidian-copilot-preview#121

🤖 Generated with [Claude Code](https://claude.com/claude-code)