### PR TITLE
Show an install prompt when a synced vault's agent binary is missing on this device

### DIFF
--- a/src/agentMode/backends/codex/CodexInstallModal.tsx
+++ b/src/agentMode/backends/codex/CodexInstallModal.tsx
@@ -2,7 +2,7 @@ import { BinaryPathSetting } from "@/agentMode/backends/shared/BinaryPathSetting
 import { ConfigDialogShell, ConfigSection } from "@/agentMode/backends/shared/ConfigDialogShell";
 import { InstallCommandRow } from "@/agentMode/backends/shared/InstallCommandRow";
 import { InstallStatusLine } from "@/agentMode/backends/shared/installStatus";
-import type { InstallState } from "@/agentMode/session/types";
+import { binaryPathInstallState } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import { ReactModal } from "@/components/modals/ReactModal";
 import { useSettingsValue } from "@/settings/model";
 import { validateExecutableFile } from "@/utils/detectBinary";
@@ -24,9 +24,10 @@ import {
 const CodexConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const settings = useSettingsValue();
   const binaryPath = settings.agentMode?.backends?.codex?.binaryPath ?? "";
-  const sessionState: InstallState = binaryPath
-    ? { kind: "ready", source: "custom" }
-    : { kind: "absent" };
+  // Existence-checked (same as descriptor.getInstallState): a synced-but-missing
+  // path reads "absent" here too, not a stale "Ready", so the dialog guides the
+  // user to re-detect or clear the dead path instead of looking configured.
+  const sessionState = binaryPathInstallState(binaryPath);
 
   const onSavePath = React.useCallback(async (path: string): Promise<string | null> => {
     const err = await validateExecutableFile(path);

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -148,7 +148,7 @@ describe("computeInstallState", () => {
   });
 
   it("installed (managed) when source is missing — legacy data defaults to managed", () => {
-    expect(computeInstallState({ binaryPath: "/p", binaryVersion: "1.2.3" })).toEqual({
+    expect(computeInstallState({ binaryPath: "/p", binaryVersion: "1.2.3" }, () => true)).toEqual({
       kind: "installed",
       version: "1.2.3",
       path: "/p",
@@ -158,11 +158,25 @@ describe("computeInstallState", () => {
 
   it("installed with explicit source preserves the value", () => {
     expect(
-      computeInstallState({ binaryPath: "/p", binaryVersion: "1.2.3", binarySource: "custom" })
+      computeInstallState(
+        { binaryPath: "/p", binaryVersion: "1.2.3", binarySource: "custom" },
+        () => true
+      )
     ).toEqual({ kind: "installed", version: "1.2.3", path: "/p", source: "custom" });
     expect(
-      computeInstallState({ binaryPath: "/p", binaryVersion: "1.2.3", binarySource: "managed" })
+      computeInstallState(
+        { binaryPath: "/p", binaryVersion: "1.2.3", binarySource: "managed" },
+        () => true
+      )
     ).toEqual({ kind: "installed", version: "1.2.3", path: "/p", source: "managed" });
+  });
+
+  it("absent when the configured binary is missing on this device (synced vault)", () => {
+    // Fully-configured slice, but the file doesn't exist locally — e.g. the
+    // vault synced from another device where opencode was installed (#123).
+    expect(computeInstallState({ binaryPath: "/p", binaryVersion: "1.2.3" }, () => false)).toEqual({
+      kind: "absent",
+    });
   });
 });
 

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -85,10 +85,22 @@ export function pickMatchingAsset(release: GithubRelease, candidates: string[]):
   );
 }
 
-/** Derive the install state from the persisted `agentMode.backends.opencode` slice. */
-export function computeInstallState(opencode: OpencodeBackendSettings | undefined): InstallState {
+/**
+ * Derive the install state from the persisted `agentMode.backends.opencode`
+ * slice. A configured `binaryPath` whose file is missing on this device counts
+ * as `absent`, not `installed`: when a vault syncs to a second device the path
+ * can be present in settings while the binary was never installed locally
+ * (logancyang/obsidian-copilot-preview#123). Reporting `absent` surfaces the
+ * install prompt and skips the auto-spawn that otherwise fails with a cryptic
+ * error at load. `fileExists` is injected so the branch is unit-testable
+ * without touching disk.
+ */
+export function computeInstallState(
+  opencode: OpencodeBackendSettings | undefined,
+  fileExists: (path: string) => boolean = (p) => fs.existsSync(p)
+): InstallState {
   const s = opencode ?? {};
-  if (s.binaryPath && s.binaryVersion) {
+  if (s.binaryPath && s.binaryVersion && fileExists(s.binaryPath)) {
     return {
       kind: "installed",
       version: s.binaryVersion,
@@ -144,11 +156,14 @@ export class OpencodeBinaryManager {
    * users for transient filesystem hiccups (network mounts, etc.).
    */
   async refreshInstallState(): Promise<void> {
-    const state = this.getInstallState();
-    if (state.kind !== "installed") return;
-    if (state.source !== "managed") return;
-    if (await fileExists(state.path)) return;
-    logWarn(`[AgentMode] persisted opencode binary missing at ${state.path}; clearing settings.`);
+    // Read raw settings (not getInstallState) so we can still see a configured
+    // path whose file is gone — getInstallState now reports that as `absent`.
+    // Only auto-clear a *managed* install whose binary vanished; a custom path
+    // is the user's to manage and may point at a not-yet-mounted volume.
+    const s = readOpencodeSettings();
+    if (!s.binaryPath || (s.binarySource ?? "managed") !== "managed") return;
+    if (await fileExists(s.binaryPath)) return;
+    logWarn(`[AgentMode] persisted opencode binary missing at ${s.binaryPath}; clearing settings.`);
     clearOpencodeBinary();
   }
 

--- a/src/agentMode/backends/shared/binaryPathInstallState.test.ts
+++ b/src/agentMode/backends/shared/binaryPathInstallState.test.ts
@@ -1,0 +1,19 @@
+import { binaryPathInstallState } from "./simpleBinaryBackend";
+
+describe("binaryPathInstallState", () => {
+  it("absent when no path is configured", () => {
+    expect(binaryPathInstallState(undefined)).toEqual({ kind: "absent" });
+    expect(binaryPathInstallState("")).toEqual({ kind: "absent" });
+  });
+
+  it("ready/custom when the configured path exists on disk", () => {
+    expect(binaryPathInstallState("/bin/codex-acp", () => true)).toEqual({
+      kind: "ready",
+      source: "custom",
+    });
+  });
+
+  it("absent when the configured path is missing on this device (synced vault, #123)", () => {
+    expect(binaryPathInstallState("/bin/codex-acp", () => false)).toEqual({ kind: "absent" });
+  });
+});

--- a/src/agentMode/backends/shared/simpleBinaryBackend.ts
+++ b/src/agentMode/backends/shared/simpleBinaryBackend.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import type { App } from "obsidian";
 import type CopilotPlugin from "@/main";
 import { AcpBackendProcess } from "@/agentMode/acp/AcpBackendProcess";
@@ -37,11 +38,19 @@ export function buildSimpleSpawnDescriptor(
 }
 
 /**
- * `InstallState` for the same shape: a binaryPath either is set
- * (`ready/custom`) or it is not (`absent`).
+ * `InstallState` for a user-binary backend: `ready/custom` when the configured
+ * path exists on disk, else `absent`. The existence check matters across synced
+ * vaults — a second device can carry the path in settings without the binary
+ * being installed locally (logancyang/obsidian-copilot-preview#123); reporting
+ * `absent` shows the install prompt instead of failing the spawn cryptically.
+ * `fileExists` is injected so the branch is unit-testable without disk.
  */
-export function binaryPathInstallState(binaryPath: string | undefined): InstallState {
-  return binaryPath ? { kind: "ready", source: "custom" } : { kind: "absent" };
+export function binaryPathInstallState(
+  binaryPath: string | undefined,
+  fileExists: (path: string) => boolean = (p) => fs.existsSync(p)
+): InstallState {
+  if (!binaryPath || !fileExists(binaryPath)) return { kind: "absent" };
+  return { kind: "ready", source: "custom" };
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes logancyang/obsidian-copilot-preview#123. A user installed opencode via the in-settings download on one Mac, synced the vault, and on a second device got a list of cryptic errors instead of a clear "install it here" prompt.

Root cause: install state was derived purely from settings *fields* — `computeInstallState` returned `installed` whenever `binaryPath`+`binaryVersion` were set, and the shared `binaryPathInstallState` (codex) returned `ready` whenever a path string was set — **without checking whether the binary actually exists on this device**. A synced/stale path therefore read as `ready`, the load-time preload probe fired (`index.ts` gates on `getInstallState().kind === "ready"`), and the spawn failed with cryptic errors.

## Change

Make install state reflect the disk, not just the settings:
- **opencode** `computeInstallState`: a configured `binaryPath` must exist on disk to count as `installed`; otherwise `absent`. `fileExists` is injected for testability.
- **shared** `binaryPathInstallState` (used by **codex**): same existence check, so custom-binary backends behave consistently.
- `OpencodeBinaryManager.refreshInstallState` now reads raw settings (rather than the now-existence-checked state) so it can still detect and clear a *managed* binary whose file vanished; custom paths are left untouched (the user may be pointing at a not-yet-mounted volume).

Net effect on a device without the binary: both Agent settings and the chat show the existing **"Install <backend>"** CTA (the `absent` path in `AgentModeStatus`), and the preload probe is skipped — no error spew. (Claude is unaffected: its CLI path is resolved by filesystem detection already.)

## Test plan

- [x] `npm run test` — 3474 passed, incl. new "missing on this device (synced vault)" branches for `computeInstallState` and `binaryPathInstallState`, plus the existing installed-state tests updated to inject a present file.
- [x] `npm run format && npm run lint` — clean
- [x] `npm run build` — clean
- [ ] Manual: configure opencode on device A, sync to device B (binary absent) → device B shows "Install opencode" in chat + settings, no cryptic errors; installing locally makes it work.

Closes logancyang/obsidian-copilot-preview#123

🤖 Generated with [Claude Code](https://claude.com/claude-code)