### PR TITLE
fix(agent-mode): route add-to-context commands to focused chat view

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -568,7 +568,7 @@ export function registerCommands(plugin: CopilotPlugin) {
     setSelectedTextContexts([selectedTextContext]);
 
     // Open chat window to show the context was added
-    await plugin.activateView();
+    await plugin.activateChatViewForContext();
   });
 
   // Add web selection to chat context command (manual)
@@ -613,7 +613,7 @@ export function registerCommands(plugin: CopilotPlugin) {
       setSelectedTextContexts([webSelectedTextContext]);
 
       // Open chat window to show the context was added
-      await plugin.activateView();
+      await plugin.activateChatViewForContext();
     } catch (error) {
       logError("Error adding web selection to context:", error);
       new Notice("Failed to get web selection");

--- a/src/components/chat-components/ChatContextMenu.tsx
+++ b/src/components/chat-components/ChatContextMenu.tsx
@@ -1,8 +1,7 @@
-import { AlertCircle, CheckCircle, CircleDashed, FileText, Loader2, X } from "lucide-react";
+import { AlertCircle, CheckCircle, CircleDashed, Loader2 } from "lucide-react";
 import { Platform, TFile, TFolder } from "obsidian";
 import React, { useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import {
   ContextNoteBadge,
   ContextActiveNoteBadge,
@@ -10,15 +9,15 @@ import {
   ContextWebTabBadge,
   ContextUrlBadge,
   ContextFolderBadge,
-  FaviconOrGlobe,
+  ContextSelectedTextBadge,
 } from "@/components/chat-components/ContextBadges";
-import { SelectedTextContext, WebTabContext, isWebSelectedTextContext } from "@/types/message";
+import { SelectedTextContext, WebTabContext } from "@/types/message";
 import { ChainType } from "@/chainType";
 import { Separator } from "@/components/ui/separator";
 import { useChainType, useIndexingProgress } from "@/aiParams";
 import { useApp } from "@/context";
 import { useProjectContextStatus } from "@/hooks/useProjectContextStatus";
-import { getDomainFromUrl, isPlusChain, openFileInWorkspace } from "@/utils";
+import { isPlusChain, openFileInWorkspace } from "@/utils";
 import { mergeWebTabContexts } from "@/utils/urlNormalization";
 import { AtMentionTypeahead } from "./AtMentionTypeahead";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -44,62 +43,6 @@ interface ChatContextMenuProps {
   ) => void;
   lexicalEditorRef?: React.RefObject<{ focus: () => void }>;
   hideAddContextButton?: boolean;
-}
-
-function ContextSelection({
-  selectedText,
-  onRemoveContext,
-}: {
-  selectedText: SelectedTextContext;
-  onRemoveContext: (category: string, data: string) => void;
-}) {
-  // Handle web selected text
-  if (isWebSelectedTextContext(selectedText)) {
-    const domain = getDomainFromUrl(selectedText.url);
-    return (
-      <Badge className="tw-items-center tw-py-0 tw-pl-2 tw-pr-0.5 tw-text-xs">
-        <div className="tw-flex tw-items-center tw-gap-1">
-          <FaviconOrGlobe faviconUrl={selectedText.faviconUrl} />
-          <span className="tw-max-w-40 tw-truncate">{selectedText.title || domain}</span>
-          <span className="tw-text-xs tw-text-faint">Selection</span>
-        </div>
-        <Button
-          variant="ghost2"
-          size="fit"
-          onClick={() => onRemoveContext("selectedText", selectedText.id)}
-          aria-label="Remove from context"
-          className="tw-text-muted"
-        >
-          <X className="tw-size-4" />
-        </Button>
-      </Badge>
-    );
-  }
-
-  // Handle note selected text (default)
-  const lineRange =
-    selectedText.startLine === selectedText.endLine
-      ? `L${selectedText.startLine}`
-      : `L${selectedText.startLine}-${selectedText.endLine}`;
-
-  return (
-    <Badge className="tw-items-center tw-py-0 tw-pl-2 tw-pr-0.5 tw-text-xs">
-      <div className="tw-flex tw-items-center tw-gap-1">
-        <FileText className="tw-size-3" />
-        <span className="tw-max-w-40 tw-truncate">{selectedText.noteTitle}</span>
-        <span className="tw-text-xs tw-text-faint">{lineRange}</span>
-      </div>
-      <Button
-        variant="ghost2"
-        size="fit"
-        onClick={() => onRemoveContext("selectedText", selectedText.id)}
-        aria-label="Remove from context"
-        className="tw-text-muted"
-      >
-        <X className="tw-size-4" />
-      </Button>
-    </Badge>
-  );
 }
 
 export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
@@ -264,10 +207,10 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
           />
         ))}
         {selectedTextContexts.map((selectedText) => (
-          <ContextSelection
+          <ContextSelectedTextBadge
             key={selectedText.id}
             selectedText={selectedText}
-            onRemoveContext={onRemoveContext}
+            onRemove={() => onRemoveContext("selectedText", selectedText.id)}
           />
         ))}
       </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,6 +142,10 @@ export default class CopilotPlugin extends Plugin {
   userMemoryManager: UserMemoryManager;
   quickAskController: QuickAskController;
   chatSelectionHighlightController: ChatSelectionHighlightController;
+  // Most-recently-focused chat view, used to route "add … to chat context"
+  // commands when both chat views are open. Defaults to legacy so a
+  // never-focused-a-chat state is harmless.
+  private lastActiveChatViewType: typeof CHAT_VIEWTYPE | typeof CHAT_AGENT_VIEWTYPE = CHAT_VIEWTYPE;
   private selectionDebounceTimer?: number;
   private selectionChangeHandler?: () => void;
   private selectionListenerDocument?: Document;
@@ -336,6 +340,11 @@ export default class CopilotPlugin extends Plugin {
       this.app.workspace.on("active-leaf-change", (leaf) => {
         // Delegate to chat selection highlight controller
         this.chatSelectionHighlightController.handleActiveLeafChange(leaf ?? null);
+
+        const activeViewType = leaf?.getViewState().type;
+        if (activeViewType === CHAT_VIEWTYPE || activeViewType === CHAT_AGENT_VIEWTYPE) {
+          this.lastActiveChatViewType = activeViewType;
+        }
 
         if (leaf && leaf.view instanceof MarkdownView) {
           const file = leaf.view.file;
@@ -778,6 +787,35 @@ export default class CopilotPlugin extends Plugin {
     window.setTimeout(() => {
       this.emitChatIsVisible();
     }, 50);
+  }
+
+  /**
+   * The "add … to chat context" commands write into a shared atom that both chat
+   * views render, so this only picks which chat to bring into focus:
+   *   - both chat views open → the one focused most recently
+   *   - exactly one open      → that one
+   *   - none open             → the agent chat when available, else the legacy chat
+   */
+  async activateChatViewForContext(): Promise<void> {
+    const agentUsable = this.canUseAgentView();
+    const agentOpen =
+      agentUsable && this.app.workspace.getLeavesOfType(CHAT_AGENT_VIEWTYPE).length > 0;
+    const legacyOpen = this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE).length > 0;
+
+    let useAgent: boolean;
+    if (agentOpen && legacyOpen) {
+      useAgent = this.lastActiveChatViewType === CHAT_AGENT_VIEWTYPE;
+    } else if (agentOpen || legacyOpen) {
+      useAgent = agentOpen;
+    } else {
+      useAgent = agentUsable;
+    }
+
+    if (useAgent) {
+      await this.activateAgentView();
+    } else {
+      await this.activateView();
+    }
   }
 
   async deactivateView() {


### PR DESCRIPTION
The "Add selection to chat context" and "Add web selection to chat context" commands always called `activateView()`, forcing focus into the legacy chat even when the user was working in the agent chat. Because the selected-text atom is shared and both views already render it, this only changes which chat gets revealed: a new `activateChatViewForContext()` helper picks the most-recently-focused chat when both are open, the open one when exactly one is, and the agent chat (when available, else legacy) when none is. To support the "both open" case, the plugin now tracks the last-focused chat view via the existing `active-leaf-change` handler. Both commands (and the editor right-click menu, which dispatches the same command) now route through the helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)