### PR TITLE
fix(agent-mode): support opencode 1.15.13 model API + force-upgrade older

### DIFF
--- a/src/agentMode/acp/AcpBackendProcess.ts
+++ b/src/agentMode/acp/AcpBackendProcess.ts
@@ -95,6 +95,22 @@ interface SessionWireState {
 }
 
 /**
+ * Return a copy of `options` with the `category:"model"` select's currentValue
+ * set to `modelId`, or the input unchanged when there's no such option. Lets an
+ * optimistic model switch be reflected for backends whose catalog lives in a
+ * config option (opencode ≥ 1.15.13) rather than a dedicated `models` state.
+ */
+function updateModelConfigOptionValue(
+  options: SessionConfigOption[] | null,
+  modelId: string
+): SessionConfigOption[] | null {
+  if (!options) return options;
+  return options.map((o) =>
+    o.type === "select" && o.category === "model" ? { ...o, currentValue: modelId } : o
+  );
+}
+
+/**
  * One-per-vault wrapper around an ACP-speaking subprocess. Owns the
  * `ClientSideConnection`, the `AcpProcessManager`, and the demultiplexer
  * that fans `session/update` notifications out to the right `AgentSession`.
@@ -300,10 +316,16 @@ export class AcpBackendProcess implements BackendProcess {
     );
     const wire = this.sessionWireState.get(params.sessionId);
     if (wire) {
-      const current = wire.models;
-      wire.models = current
-        ? { ...current, currentModelId: params.modelId }
-        : { availableModels: [], currentModelId: params.modelId };
+      if (wire.models) {
+        wire.models = { ...wire.models, currentModelId: params.modelId };
+      } else {
+        // No dedicated `models` state (opencode ≥ 1.15.13 exposes the catalog
+        // only as a `category:"model"` config option). Update that option's
+        // currentValue so `computeState` recomputes from the real catalog —
+        // never fabricate an empty `models` state (that strands the picker on
+        // a raw wire id with everything else "not offered by agent").
+        wire.configOptions = updateModelConfigOptionValue(wire.configOptions, params.modelId);
+      }
     }
     return this.computeState(params.sessionId);
   }

--- a/src/agentMode/agentModelDiscovery.test.ts
+++ b/src/agentMode/agentModelDiscovery.test.ts
@@ -91,6 +91,7 @@ function stateWithModels(baseIds: string[], currentBaseId?: string): BackendStat
   return {
     model: {
       current: { baseModelId: currentBaseId ?? baseIds[0] ?? "", effort: null },
+      apply: { kind: "setModel" },
       availableModels: baseIds.map((baseModelId) => ({
         baseModelId,
         name: baseModelId,
@@ -230,6 +231,7 @@ describe("wireAgentModelDiscovery", () => {
     m.setState("codex", {
       model: {
         current: { baseModelId: "gpt-5", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [
           { baseModelId: "gpt-5", name: "GPT-5", provider: null, effortOptions: [] },
           { baseModelId: "blank", name: "", provider: null, effortOptions: [] },

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -211,7 +211,7 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
     // pointless `setSessionModel` on every slider drag.
     const currentBase = session.getState()?.model?.current.baseModelId;
     if (currentBase !== selection.baseModelId) {
-      await session.setModel(claudeWire.encode(selection));
+      await session.applyModelWireId(claudeWire.encode(selection));
     }
     if (selection.effort === null) return;
     const cfgOpt = claudeWire.effortConfigFor?.(selection.baseModelId);

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -154,7 +154,7 @@ export const CodexBackendDescriptor: BackendDescriptor = {
   },
 
   async applySelection(session: AgentSession, selection: ModelSelection): Promise<void> {
-    await session.setModel(codexWire.encode(selection));
+    await session.applyModelWireId(codexWire.encode(selection));
   },
 
   createBackendProcess(args): BackendProcess {

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -42,7 +42,7 @@ jest.mock("@/settings/model", () => {
   };
 });
 
-import { OPENCODE_PINNED_VERSION } from "@/constants";
+import { OPENCODE_MIN_ACP_VERSION, OPENCODE_PINNED_VERSION } from "@/constants";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -315,5 +315,49 @@ describe("OpencodeBinaryManager.setCustomBinaryPath", () => {
     expect(stored.binaryPath).toBe(process.execPath);
     expect(stored.binarySource).toBe("custom");
     expect(stored.binaryVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("OpencodeBinaryManager.upgradeCustomBinary", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "opencode-upgrade-"));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rejects when opencode upgrade exits successfully but leaves an outdated binary", async () => {
+    if (process.platform === "win32") return;
+    const file = path.join(tmpDir, "opencode");
+    await fs.promises.writeFile(
+      file,
+      `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "1.15.11"
+  exit 0
+fi
+if [ "$1" = "upgrade" ]; then
+  echo "Upgrade failed" >&2
+  exit 0
+fi
+`
+    );
+    await fs.promises.chmod(file, 0o755);
+    settingsMock.__reset({
+      binaryPath: file,
+      binaryVersion: "1.15.11",
+      binarySource: "custom",
+    });
+
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+    await expect(mgr.upgradeCustomBinary()).rejects.toThrow(OPENCODE_MIN_ACP_VERSION);
+    expect(settingsMock.__get()).toEqual({
+      binaryPath: file,
+      binaryVersion: "1.15.11",
+      binarySource: "custom",
+    });
   });
 });

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -1,4 +1,9 @@
-import { OPENCODE_PINNED_VERSION, OPENCODE_RELEASE_API_URL_TEMPLATE } from "@/constants";
+import {
+  OPENCODE_MIN_ACP_VERSION,
+  OPENCODE_PINNED_VERSION,
+  OPENCODE_RELEASE_API_URL_TEMPLATE,
+} from "@/constants";
+import { compareSemver } from "@/utils/semver";
 import { logError, logInfo, logWarn } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { getSettings, setSettings, type OpencodeBackendSettings } from "@/settings/model";
@@ -18,6 +23,8 @@ const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000;
 // Generous: first-run on Windows (Defender real-time scan) and macOS
 // (Gatekeeper translocation) can add a few seconds before the binary responds.
 const VERIFY_BINARY_TIMEOUT_MS = 8_000;
+// `opencode upgrade` downloads and swaps a release binary — give it room.
+const UPGRADE_BINARY_TIMEOUT_MS = 180_000;
 
 export type ProgressEvent =
   | { phase: "resolve"; message: string }
@@ -102,6 +109,18 @@ export function computeInstallState(opencode: OpencodeBackendSettings | undefine
 /** Read the OpenCode-specific settings slice from current settings. */
 export function readOpencodeSettings(): OpencodeBackendSettings {
   return getSettings().agentMode?.backends?.opencode ?? {};
+}
+
+/**
+ * Whether an installed opencode version predates the minimum the plugin
+ * supports ({@link OPENCODE_MIN_ACP_VERSION}). Older binaries advertise models
+ * through the now-removed ACP `models` state, so the picker can't surface them.
+ * An unknown version isn't flagged — we can't prove it's old, and a missing
+ * install is handled by the install prompt instead.
+ */
+export function isOpencodeVersionOutdated(version: string | undefined): boolean {
+  if (!version) return false;
+  return compareSemver(version, OPENCODE_MIN_ACP_VERSION) < 0;
 }
 
 function updateOpencodeFields(partial: Partial<OpencodeBackendSettings>): void {
@@ -293,6 +312,58 @@ export class OpencodeBinaryManager {
     } finally {
       await removeDir(tmpDir).catch(() => {});
     }
+  }
+
+  /**
+   * Upgrade a managed install to the pinned version: install the pinned binary
+   * (atomic — the existing one keeps working until the new one is staged in),
+   * then remove the previously-active managed version dir when it differs.
+   */
+  async upgradeManaged(opts: InstallOptions = {}): Promise<{ version: string; path: string }> {
+    const prev = readOpencodeSettings();
+    const result = await this.install({ ...opts, version: OPENCODE_PINNED_VERSION });
+    if (
+      prev.binarySource === "managed" &&
+      prev.binaryVersion &&
+      prev.binaryVersion !== result.version
+    ) {
+      const oldDir = path.join(this.getDataDir(), prev.binaryVersion);
+      await removeDir(oldDir).catch((e) =>
+        logWarn(`[AgentMode] failed to remove old opencode ${oldDir}: ${e}`)
+      );
+    }
+    return result;
+  }
+
+  /**
+   * Upgrade a user-supplied opencode binary in place via its own
+   * `<binary> upgrade`, then re-verify and persist the new version. The binary
+   * stays where the user put it (`binarySource:"custom"`); managed version dirs
+   * are untouched. Throws with a readable message on failure.
+   */
+  async upgradeCustomBinary(): Promise<{ version: string; path: string }> {
+    const s = readOpencodeSettings();
+    if (s.binarySource !== "custom" || !s.binaryPath) {
+      throw new Error("No custom opencode binary is configured to upgrade.");
+    }
+    const binaryPath = s.binaryPath;
+    try {
+      await execFileAsync(binaryPath, ["upgrade"], {
+        timeout: UPGRADE_BINARY_TIMEOUT_MS,
+        windowsHide: true,
+      });
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      throw new Error(`\`${binaryPath} upgrade\` failed: ${err.message ?? String(err)}`);
+    }
+    const { stdout } = await verifyOpencodeBinary(binaryPath);
+    const version = parseVersionFromStdout(stdout);
+    if (!version) {
+      throw new Error(`${binaryPath} --version didn't report a version after upgrade.`);
+    }
+    updateOpencodeFields({ binaryVersion: version, binaryPath, binarySource: "custom" });
+    logInfo(`[AgentMode] upgraded custom opencode to ${version}`);
+    return { version, path: binaryPath };
   }
 
   /**

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -361,6 +361,12 @@ export class OpencodeBinaryManager {
     if (!version) {
       throw new Error(`${binaryPath} --version didn't report a version after upgrade.`);
     }
+    if (isOpencodeVersionOutdated(version)) {
+      throw new Error(
+        `opencode upgrade did not reach the required version ${OPENCODE_MIN_ACP_VERSION}+ ` +
+          `(still v${version}).`
+      );
+    }
     updateOpencodeFields({ binaryVersion: version, binaryPath, binarySource: "custom" });
     logInfo(`[AgentMode] upgraded custom opencode to ${version}`);
     return { version, path: binaryPath };

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -5,6 +5,7 @@ import {
   AbortError,
   computeInstallState,
   InstallOptions,
+  isOpencodeVersionOutdated,
   ProgressEvent,
 } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
 import type { OpencodeBinaryManager } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
@@ -14,7 +15,8 @@ import { ReactModal } from "@/components/modals/ReactModal";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
-import { OPENCODE_PINNED_VERSION } from "@/constants";
+import { OPENCODE_MIN_ACP_VERSION, OPENCODE_PINNED_VERSION } from "@/constants";
+import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
 import { useSettingsValue } from "@/settings/model";
 import { App, Notice } from "obsidian";
@@ -199,6 +201,27 @@ const OpencodeConfigBody: React.FC<{
     local.kind === "installed" ? { kind: "ready", source: local.source } : { kind: "absent" };
   const detail = local.kind === "installed" ? `opencode v${local.version}` : undefined;
 
+  const installedVersion = local.kind === "installed" ? local.version : null;
+  const outdated = !!installedVersion && isOpencodeVersionOutdated(installedVersion);
+  const [upgradeRun, setUpgradeRun] = React.useState<RunState>({ kind: "idle" });
+  const handleUpgrade = React.useCallback(() => {
+    setUpgradeRun({ kind: "running", progress: null });
+    const action = isCustom
+      ? manager.upgradeCustomBinary()
+      : manager.upgradeManaged({
+          onProgress: (e) => setUpgradeRun({ kind: "running", progress: e }),
+        });
+    action
+      .then(({ version }) => {
+        setUpgradeRun({ kind: "idle" });
+        new Notice(`opencode upgraded to v${version}.`);
+      })
+      .catch((err: unknown) => {
+        logError("[AgentMode] opencode upgrade failed", err);
+        setUpgradeRun({ kind: "error", message: err instanceof Error ? err.message : String(err) });
+      });
+  }, [manager, isCustom]);
+
   const onSaveCustomPath = React.useCallback(
     async (path: string): Promise<string | null> => {
       try {
@@ -222,6 +245,35 @@ const OpencodeConfigBody: React.FC<{
       status={<InstallStatusLine state={sessionState} detail={detail} />}
       onClose={onClose}
     >
+      {outdated && (
+        <div
+          className={cn(
+            "tw-flex tw-flex-col tw-gap-2 tw-rounded tw-bg-callout-warning/20 tw-p-3",
+            "tw-text-sm tw-text-warning"
+          )}
+          role="alert"
+        >
+          <span>
+            opencode v{installedVersion} is out of date. Update to v{OPENCODE_MIN_ACP_VERSION}+ —
+            older versions can&apos;t report their models to the picker.
+          </span>
+          {upgradeRun.kind === "running" ? (
+            <>
+              <p className="tw-my-0 tw-text-xs">{phaseLabel(upgradeRun.progress)}</p>
+              <Progress value={phaseProgress(upgradeRun.progress) ?? 0} />
+            </>
+          ) : (
+            <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
+              {upgradeRun.kind === "error" && (
+                <span className="tw-text-xs tw-text-error">{upgradeRun.message}</span>
+              )}
+              <Button variant="default" size="sm" onClick={handleUpgrade}>
+                {isCustom ? "Run opencode upgrade" : "Upgrade to latest"}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
       <ConfigSection title="Download managed binary">
         <p className="tw-my-0 tw-text-sm tw-text-muted">
           Let Copilot download and manage the official opencode binary from its GitHub repo.

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -1,6 +1,12 @@
 import { OpencodeBackendDescriptor } from "./descriptor";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
-import type { BackendState } from "@/agentMode/session/types";
+import type {
+  BackendProcess,
+  BackendState,
+  EffortOption,
+  EnabledModelEntry,
+  ModelState,
+} from "@/agentMode/session/types";
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
@@ -225,5 +231,130 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
     expect(applyModelWireId.mock.invocationCallOrder[0]).toBeLessThan(
       setConfigOption.mock.invocationCallOrder[0]
     );
+  });
+});
+
+describe("OpencodeBackendDescriptor.prefetchEffortCatalog", () => {
+  const GPT = "github-copilot/gpt-5.4";
+  const QWEN = "openrouter/qwen/qwen3.7-max";
+  const NEMOTRON = "opencode/nemotron-3-super-free";
+  const EFFORTS: Record<string, EffortOption[]> = {
+    [GPT]: [
+      { value: "low", label: "low" },
+      { value: "high", label: "high" },
+    ],
+    [QWEN]: [],
+  };
+
+  function stateFor(baseModelId: string): BackendState {
+    return {
+      model: {
+        current: { baseModelId, effort: null },
+        apply: { kind: "setConfigOption", configId: "model" },
+        availableModels: [
+          {
+            baseModelId,
+            name: baseModelId,
+            provider: null,
+            effortOptions: EFFORTS[baseModelId] ?? [],
+          },
+        ],
+      },
+      mode: null,
+    };
+  }
+
+  const modelState: ModelState = {
+    current: { baseModelId: "orig/model", effort: null },
+    apply: { kind: "setConfigOption", configId: "model" },
+    availableModels: [],
+  };
+
+  function makeProc(impl: (value: string) => Promise<BackendState>): {
+    proc: BackendProcess;
+    setSessionConfigOption: jest.Mock;
+  } {
+    const setSessionConfigOption = jest.fn(
+      async ({ value }: { sessionId: string; configId: string; value: string }) => impl(value)
+    );
+    return {
+      proc: { setSessionConfigOption } as unknown as BackendProcess,
+      setSessionConfigOption,
+    };
+  }
+
+  const run = (
+    proc: BackendProcess,
+    enabledModels: EnabledModelEntry[],
+    isAborted: () => boolean = () => false,
+    state: ModelState = modelState
+  ) =>
+    OpencodeBackendDescriptor.prefetchEffortCatalog!({
+      proc,
+      sessionId: "ses_1",
+      modelState: state,
+      enabledModels,
+      isAborted,
+    });
+
+  it("collects effort only for models that report it, skips missing_key, and restores the original", async () => {
+    const { proc, setSessionConfigOption } = makeProc((value) => Promise.resolve(stateFor(value)));
+    const result = await run(proc, [
+      { baseModelId: GPT, name: "GPT-5.4", credentialState: "ok" },
+      { baseModelId: QWEN, name: "Qwen", credentialState: "ok" },
+      { baseModelId: NEMOTRON, name: "Nemotron", credentialState: "missing_key" },
+    ]);
+
+    expect(result).toEqual({ [GPT]: EFFORTS[GPT] });
+    const values = setSessionConfigOption.mock.calls.map((c) => c[0].value);
+    expect(values).not.toContain(NEMOTRON); // missing_key never probed
+    expect(values).toEqual([GPT, QWEN, "orig/model"]); // restore is last
+  });
+
+  it("returns a frozen empty catalog and probes nothing when the catalog is not config-option-backed", async () => {
+    const { proc, setSessionConfigOption } = makeProc((value) => Promise.resolve(stateFor(value)));
+    const result = await run(
+      proc,
+      [{ baseModelId: GPT, name: "GPT", credentialState: "ok" }],
+      () => false,
+      {
+        ...modelState,
+        apply: { kind: "setModel" },
+      }
+    );
+    expect(Object.keys(result)).toHaveLength(0);
+    expect(setSessionConfigOption).not.toHaveBeenCalled();
+  });
+
+  it("stops probing once isAborted() is true but still restores", async () => {
+    const { proc, setSessionConfigOption } = makeProc((value) => Promise.resolve(stateFor(value)));
+    let probed = 0;
+    await run(
+      proc,
+      [
+        { baseModelId: GPT, name: "GPT", credentialState: "ok" },
+        { baseModelId: QWEN, name: "Qwen", credentialState: "ok" },
+      ],
+      () => probed++ >= 1 // false for the first model, true thereafter
+    );
+    const values = setSessionConfigOption.mock.calls.map((c) => c[0].value);
+    expect(values).toEqual([GPT, "orig/model"]); // QWEN skipped, restore still runs
+  });
+
+  it("survives a throwing probe, keeps going, and still restores", async () => {
+    const { proc, setSessionConfigOption } = makeProc((value) => {
+      if (value === GPT) return Promise.reject(new Error("boom"));
+      return Promise.resolve(stateFor(value));
+    });
+    const result = await run(proc, [
+      { baseModelId: GPT, name: "GPT", credentialState: "ok" },
+      { baseModelId: QWEN, name: "Qwen", credentialState: "ok" },
+    ]);
+    expect(result).toEqual({}); // GPT threw, QWEN has no effort
+    expect(setSessionConfigOption.mock.calls.map((c) => c[0].value)).toEqual([
+      GPT,
+      QWEN,
+      "orig/model",
+    ]);
   });
 });

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -1,4 +1,6 @@
 import { OpencodeBackendDescriptor } from "./descriptor";
+import type { AgentSession } from "@/agentMode/session/AgentSession";
+import type { BackendState } from "@/agentMode/session/types";
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
@@ -150,5 +152,78 @@ describe("OpencodeBackendDescriptor.wire.encode", () => {
       provider: null,
     });
     expect(OpencodeBackendDescriptor.wire.encode(decoded.selection)).toBe(wireId);
+  });
+});
+
+describe("OpencodeBackendDescriptor.applySelection", () => {
+  function makeSession(state: BackendState): {
+    session: AgentSession;
+    applyModelWireId: jest.Mock;
+    setConfigOption: jest.Mock;
+  } {
+    let currentState = state;
+    const applyModelWireId = jest.fn(async () => {
+      currentState = {
+        ...currentState,
+        model: currentState.model
+          ? {
+              ...currentState.model,
+              current: { baseModelId: "openai/gpt-5", effort: "low" },
+              apply: {
+                kind: "setConfigOption",
+                configId: "model",
+                effortConfigId: "effort",
+              },
+            }
+          : null,
+      };
+    });
+    const setConfigOption = jest.fn(async () => undefined);
+    return {
+      session: {
+        getState: () => currentState,
+        applyModelWireId,
+        setConfigOption,
+      } as unknown as AgentSession,
+      applyModelWireId,
+      setConfigOption,
+    };
+  }
+
+  it("routes config-option-backed effort through the thought-level option", async () => {
+    const { session, applyModelWireId, setConfigOption } = makeSession({
+      model: {
+        current: { baseModelId: "openai/gpt-5", effort: "low" },
+        availableModels: [],
+        apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
+      },
+      mode: null,
+    });
+    await OpencodeBackendDescriptor.applySelection(session, {
+      baseModelId: "openai/gpt-5",
+      effort: "high",
+    });
+    expect(applyModelWireId).not.toHaveBeenCalled();
+    expect(setConfigOption).toHaveBeenCalledWith("effort", "high");
+  });
+
+  it("switches the base model before applying its config-option-backed effort", async () => {
+    const { session, applyModelWireId, setConfigOption } = makeSession({
+      model: {
+        current: { baseModelId: "anthropic/claude-sonnet", effort: "low" },
+        availableModels: [],
+        apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
+      },
+      mode: null,
+    });
+    await OpencodeBackendDescriptor.applySelection(session, {
+      baseModelId: "openai/gpt-5",
+      effort: "high",
+    });
+    expect(applyModelWireId).toHaveBeenCalledWith("openai/gpt-5");
+    expect(setConfigOption).toHaveBeenCalledWith("effort", "high");
+    expect(applyModelWireId.mock.invocationCallOrder[0]).toBeLessThan(
+      setConfigOption.mock.invocationCallOrder[0]
+    );
   });
 });

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -4,6 +4,7 @@ import { OpencodeInstallModal } from "@/agentMode/backends/opencode/OpencodeInst
 import OpencodeLogo from "@/agentMode/backends/opencode/logo.svg";
 import type CopilotPlugin from "@/main";
 import { OPENCODE_MIN_ACP_VERSION } from "@/constants";
+import { logWarn } from "@/logger";
 import {
   getSettings,
   subscribeToSettingsChange,
@@ -28,10 +29,13 @@ import { detectBinary } from "@/utils/detectBinary";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { simpleBinaryBackendProcess } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import type {
+  EffortOption,
   EnabledModelEntry,
   ModeMapping,
   ModelSelection,
+  ModelState,
   ModelWireCodec,
+  SessionId,
 } from "@/agentMode/session/types";
 import type {
   BackendDescriptor,
@@ -42,6 +46,9 @@ import type {
 
 /** Config option id OpenCode uses to switch the active agent at runtime. */
 const OPENCODE_MODE_CONFIG_OPTION_ID = "mode";
+
+/** Frozen empty effort catalog — referential stability for the "no effort" case. */
+const EMPTY_EFFORT_CATALOG: Record<string, EffortOption[]> = Object.freeze({});
 
 // Lazy-created singleton manager. The first plugin to ask for it wins; in a
 // running Obsidian instance there's exactly one CopilotPlugin so this is safe.
@@ -223,6 +230,63 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
       return;
     }
     await session.applyModelWireId(opencodeWire.encode(selection));
+  },
+
+  async prefetchEffortCatalog({
+    proc,
+    sessionId,
+    modelState,
+    enabledModels,
+    isAborted,
+  }: {
+    proc: BackendProcess;
+    sessionId: SessionId;
+    modelState: ModelState;
+    enabledModels: ReadonlyArray<EnabledModelEntry>;
+    isAborted: () => boolean;
+  }): Promise<Record<string, EffortOption[]>> {
+    // opencode ≥ 1.15.13 advertises its catalog via a `category:"model"` config
+    // option; effort is a sibling `category:"thought_level"` option opencode only
+    // surfaces for the active model. Switch to each enabled model in turn and read
+    // the effort options the refreshed state reports for it.
+    if (modelState.apply.kind !== "setConfigOption") return EMPTY_EFFORT_CATALOG;
+    const configId = modelState.apply.configId;
+    const originalWire = opencodeWire.encode({
+      baseModelId: modelState.current.baseModelId,
+      effort: null,
+    });
+    const out: Record<string, EffortOption[]> = {};
+    try {
+      for (const model of enabledModels) {
+        if (isAborted()) break;
+        // Skip models the agent can't serve — switching to them just errors.
+        if (model.credentialState !== "ok") continue;
+        try {
+          const next = await proc.setSessionConfigOption({
+            sessionId,
+            configId,
+            value: opencodeWire.encode({ baseModelId: model.baseModelId, effort: null }),
+          });
+          const entry = next.model?.availableModels.find(
+            (e) => e.baseModelId === model.baseModelId
+          );
+          if (entry && entry.effortOptions.length > 0) {
+            out[model.baseModelId] = entry.effortOptions;
+          }
+        } catch (e) {
+          logWarn(`[AgentMode] opencode effort prefetch for ${model.baseModelId} failed`, e);
+        }
+      }
+    } finally {
+      // Restore the probe session's model so the adopted session isn't left on
+      // the last probed model.
+      try {
+        await proc.setSessionConfigOption({ sessionId, configId, value: originalWire });
+      } catch (e) {
+        logWarn("[AgentMode] opencode effort prefetch: restore failed", e);
+      }
+    }
+    return Object.keys(out).length > 0 ? out : EMPTY_EFFORT_CATALOG;
   },
 
   createBackendProcess(args): BackendProcess {

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -3,7 +3,9 @@ import * as os from "node:os";
 import { OpencodeInstallModal } from "@/agentMode/backends/opencode/OpencodeInstallModal";
 import OpencodeLogo from "@/agentMode/backends/opencode/logo.svg";
 import type CopilotPlugin from "@/main";
+import { OPENCODE_MIN_ACP_VERSION } from "@/constants";
 import {
+  getSettings,
   subscribeToSettingsChange,
   updateAgentModeBackendFields,
   type CopilotSettings,
@@ -13,7 +15,11 @@ import {
   OpencodeBackend,
   OPENCODE_PROVIDER_MAP,
 } from "./OpencodeBackend";
-import { computeInstallState, OpencodeBinaryManager } from "./OpencodeBinaryManager";
+import {
+  computeInstallState,
+  isOpencodeVersionOutdated,
+  OpencodeBinaryManager,
+} from "./OpencodeBinaryManager";
 import { opencodeEnabledModelEntries } from "./opencodeModelResolve";
 import { OpencodeSettingsPanel } from "./OpencodeSettingsPanel";
 import { resolveOpencodeBinary } from "./opencodeBinaryResolver";
@@ -27,7 +33,12 @@ import type {
   ModelSelection,
   ModelWireCodec,
 } from "@/agentMode/session/types";
-import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
+import type {
+  BackendDescriptor,
+  BackendProcess,
+  BackendUpgradeInfo,
+  InstallState,
+} from "@/agentMode/session/types";
 
 /** Config option id OpenCode uses to switch the active agent at runtime. */
 const OPENCODE_MODE_CONFIG_OPTION_ID = "mode";
@@ -169,8 +180,32 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
     }).open();
   },
 
+  getUpgradeInfo(settings: CopilotSettings): BackendUpgradeInfo | null {
+    const state = computeInstallState(settings.agentMode?.backends?.opencode);
+    if (state.kind !== "installed" || !isOpencodeVersionOutdated(state.version)) return null;
+    return {
+      currentVersion: state.version,
+      minVersion: OPENCODE_MIN_ACP_VERSION,
+      source: state.source,
+    };
+  },
+
+  async upgrade(plugin: CopilotPlugin): Promise<void> {
+    const manager = getOpencodeBinaryManager(plugin);
+    const state = computeInstallState(getSettings().agentMode?.backends?.opencode);
+    if (state.kind !== "installed") return;
+    if (state.source === "custom") {
+      await manager.upgradeCustomBinary();
+    } else {
+      await manager.upgradeManaged();
+    }
+  },
+
   async applySelection(session: AgentSession, selection: ModelSelection): Promise<void> {
-    await session.setModel(opencodeWire.encode(selection));
+    // opencode ≥ 1.15.13 advertises models as a `category:"model"` config
+    // option; `applyModelWireId` routes through `set_config_option` when the
+    // state says so, falling back to `set_model` otherwise.
+    await session.applyModelWireId(opencodeWire.encode(selection));
   },
 
   createBackendProcess(args): BackendProcess {

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -202,9 +202,26 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
   },
 
   async applySelection(session: AgentSession, selection: ModelSelection): Promise<void> {
-    // opencode ≥ 1.15.13 advertises models as a `category:"model"` config
-    // option; `applyModelWireId` routes through `set_config_option` when the
-    // state says so, falling back to `set_model` otherwise.
+    const apply = session.getState()?.model?.apply;
+    if (apply?.kind === "setConfigOption" && apply.effortConfigId) {
+      // The effort option is model-specific, so activate the bare model first
+      // and use the option id from the refreshed state.
+      const currentBase = session.getState()?.model?.current.baseModelId;
+      if (currentBase !== selection.baseModelId) {
+        await session.applyModelWireId(
+          opencodeWire.encode({ baseModelId: selection.baseModelId, effort: null })
+        );
+      }
+      if (selection.effort !== null) {
+        const refreshedApply = session.getState()?.model?.apply;
+        const effortConfigId =
+          refreshedApply?.kind === "setConfigOption" ? refreshedApply.effortConfigId : undefined;
+        if (effortConfigId) {
+          await session.setConfigOption(effortConfigId, selection.effort);
+        }
+      }
+      return;
+    }
     await session.applyModelWireId(opencodeWire.encode(selection));
   },
 

--- a/src/agentMode/session/AgentModelPreloader.test.ts
+++ b/src/agentMode/session/AgentModelPreloader.test.ts
@@ -51,6 +51,7 @@ function makeMockProc(opts?: { newSessionState?: BackendState }): MockProcHandle
           effortOptions: [],
         },
       ],
+      apply: { kind: "setModel" },
     },
     mode: null,
   };

--- a/src/agentMode/session/AgentModelPreloader.ts
+++ b/src/agentMode/session/AgentModelPreloader.ts
@@ -9,6 +9,7 @@ import type {
   BackendId,
   BackendProcess,
   BackendState,
+  EffortOption,
   SessionId,
 } from "./types";
 
@@ -50,6 +51,11 @@ export class AgentModelPreloader {
   // consumed (or that pushed updates after consumption via `setCached`).
   // The active session's `attachModelCacheSync` writes here.
   private readonly cache = new Map<BackendId, BackendState>();
+  // Per-backend effort options keyed by baseModelId, discovered by probing each
+  // enabled model once after the catalog loads (opencode only advertises effort
+  // for the active model, so the catalog itself carries none). Read by the
+  // picker via `AgentSessionManager.getEffortCatalog`.
+  private readonly effortCatalog = new Map<BackendId, Record<string, EffortOption[]>>();
   private readonly inflight = new Map<BackendId, Promise<void>>();
   // Backends whose in-flight probe baked stale spawn config and must re-probe
   // once it settles. Set by `refresh`, drained by the probe chain. Coalesces
@@ -70,6 +76,11 @@ export class AgentModelPreloader {
 
   getCachedBackendState(backendId: BackendId): BackendState | null {
     return this.warm.get(backendId)?.state ?? this.cache.get(backendId) ?? null;
+  }
+
+  /** Per-model effort options discovered by the post-catalog prefetch, or null. */
+  getEffortCatalog(backendId: BackendId): Record<string, EffortOption[]> | null {
+    return this.effortCatalog.get(backendId) ?? null;
   }
 
   /**
@@ -93,6 +104,7 @@ export class AgentModelPreloader {
   clearCached(backendId: BackendId): void {
     if (this.disposed) return;
     let changed = this.cache.delete(backendId);
+    if (this.effortCatalog.delete(backendId)) changed = true;
     const warm = this.warm.get(backendId);
     if (warm) {
       this.warm.delete(backendId);
@@ -199,6 +211,7 @@ export class AgentModelPreloader {
   shutdown(): void {
     this.disposed = true;
     this.cache.clear();
+    this.effortCatalog.clear();
     this.inflight.clear();
     this.pendingRefresh.clear();
     this.listeners.clear();
@@ -263,6 +276,13 @@ export class AgentModelPreloader {
       return;
     }
 
+    // Discover each enabled model's effort options before exposing the warm
+    // entry. The probe loop switches the probe session's model and restores it,
+    // so doing it now (rather than after the manager adopts the session) keeps
+    // the adopted session on the original model. Cheap (~ms per switch) and
+    // best-effort — failures leave the picker without prefetched effort.
+    await this.runEffortPrefetch(backendId, descriptor, proc, probe.sessionId, probe.state);
+
     // Probe succeeded — retain the running subprocess as a warm entry so
     // the first chat-open can adopt it instead of paying another spawn +
     // initialize round-trip.
@@ -286,6 +306,37 @@ export class AgentModelPreloader {
     this.warmExitUnsubs.set(backendId, exitUnsub);
     logProbeResult(backendId, "session probe", probe.state);
     this.notify();
+  }
+
+  /**
+   * Probe each enabled model's effort options on the just-created probe session
+   * via the descriptor's optional `prefetchEffortCatalog`, caching the result so
+   * the picker can show effort steppers for every model before one is selected.
+   * Best-effort: no hook, no model state, or any error leaves the catalog empty.
+   */
+  private async runEffortPrefetch(
+    backendId: BackendId,
+    descriptor: BackendDescriptor,
+    proc: BackendProcess,
+    sessionId: SessionId,
+    state: BackendState
+  ): Promise<void> {
+    if (!descriptor.prefetchEffortCatalog || !state.model) return;
+    const enabledModels = descriptor.getEnabledModelEntries?.(getSettings());
+    if (!enabledModels || enabledModels.length === 0) return;
+    try {
+      const catalog = await descriptor.prefetchEffortCatalog({
+        proc,
+        sessionId,
+        modelState: state.model,
+        enabledModels,
+        isAborted: () => this.disposed,
+      });
+      if (this.disposed) return;
+      if (Object.keys(catalog).length > 0) this.effortCatalog.set(backendId, catalog);
+    } catch (e) {
+      logWarn(`[AgentMode] preload ${backendId}: effort prefetch failed`, e);
+    }
   }
 
   private async fetchInitialState(

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -471,6 +471,7 @@ describe("AgentSession.create (via start)", () => {
     const stateWithModel: BackendState = {
       model: {
         current: { baseModelId: "anthropic/sonnet", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [
           {
             baseModelId: "anthropic/sonnet",
@@ -513,6 +514,7 @@ describe("AgentSession.create (via start)", () => {
     const stateWithSonnet: BackendState = {
       model: {
         current: { baseModelId: "anthropic/sonnet", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [
           {
             baseModelId: "anthropic/sonnet",
@@ -541,11 +543,64 @@ describe("AgentSession.create (via start)", () => {
     });
   });
 
+  it("applyModelWireId routes through set_config_option when the catalog is config-option-backed", async () => {
+    const mock = makeMockBackend();
+    const configBackedState: BackendState = {
+      model: {
+        current: { baseModelId: "omlx/a", effort: null },
+        apply: { kind: "setConfigOption", configId: "model" },
+        availableModels: [{ baseModelId: "omlx/a", name: "A", provider: null, effortOptions: [] }],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: configBackedState });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+    await session.ready;
+    await session.applyModelWireId("omlx/b");
+    expect(mock.setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: "acp-1",
+      configId: "model",
+      value: "omlx/b",
+    });
+    expect(mock.setSessionModel).not.toHaveBeenCalled();
+  });
+
+  it("applyModelWireId routes through set_model when the catalog is models-backed", async () => {
+    const mock = makeMockBackend();
+    const modelsBackedState: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: null, effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: modelsBackedState });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "codex",
+    });
+    await session.ready;
+    await session.applyModelWireId("o3");
+    expect(mock.setSessionModel).toHaveBeenCalledWith({ sessionId: "acp-1", modelId: "o3" });
+    expect(mock.setSessionConfigOption).not.toHaveBeenCalled();
+  });
+
   it("seeds currentState with the persisted selection before notifying listeners", async () => {
     const mock = makeMockBackend();
     const stateWithSonnet: BackendState = {
       model: {
         current: { baseModelId: "anthropic/sonnet", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [
           {
             baseModelId: "anthropic/sonnet",
@@ -595,6 +650,7 @@ describe("AgentSession.create (via start)", () => {
     const cachedState: BackendState = {
       model: {
         current: { baseModelId: "kimi-2.6", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [
           { baseModelId: "kimi-2.6", name: "Kimi 2.6", provider: "moon", effortOptions: [] },
           {
@@ -643,6 +699,7 @@ describe("AgentSession.create (via start)", () => {
     const backendState: BackendState = {
       model: {
         current: { baseModelId: "anthropic/sonnet", effort: "low" },
+        apply: { kind: "setModel" },
         availableModels: [
           {
             baseModelId: "anthropic/sonnet",
@@ -680,6 +737,7 @@ describe("AgentSession.create (via start)", () => {
     const stateWithSonnet: BackendState = {
       model: {
         current: { baseModelId: "anthropic/sonnet", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [
           {
             baseModelId: "anthropic/sonnet",
@@ -729,6 +787,7 @@ describe("AgentSession warm-adoption ready gating", () => {
     const probeState: BackendState = {
       model: {
         current: { baseModelId: "anthropic/sonnet", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [
           {
             baseModelId: "anthropic/sonnet",
@@ -817,6 +876,7 @@ describe("AgentSession.setModel", () => {
     const newState: BackendState = {
       model: {
         current: { baseModelId: "x/y", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [{ baseModelId: "x/y", name: "X Y", provider: null, effortOptions: [] }],
       },
       mode: null,

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -403,6 +403,22 @@ export class AgentSession {
   }
 
   /**
+   * Apply an encoded model wire id through whichever channel the current model
+   * state declares. Backends whose catalog comes from a `category:"model"`
+   * config option (opencode ≥ 1.15.13) switch via `session/set_config_option`;
+   * everyone else via `session/set_model`. Falls back to `setModel` before any
+   * model state is known. The encoded wire id is identical for both channels.
+   */
+  async applyModelWireId(wireId: string): Promise<void> {
+    const apply = this.currentState?.model?.apply;
+    if (apply?.kind === "setConfigOption") {
+      await this.setConfigOption(apply.configId, wireId);
+      return;
+    }
+    await this.setModel(wireId);
+  }
+
+  /**
    * Apply the persisted user selection to the backend via `setModel`.
    * Runs whenever `defaultModelSelection` is supplied — `setModel` is
    * idempotent, and the wire-encoding short-circuit below makes it a
@@ -430,7 +446,7 @@ export class AgentSession {
       : null;
     if (encoded === originalEncoded) return;
     try {
-      await this.setModel(encoded);
+      await this.applyModelWireId(encoded);
     } catch (e) {
       logWarn(`[AgentMode] could not apply default model ${encoded}; reverting seed`, e);
       this.currentState = originalState;
@@ -476,22 +492,31 @@ export class AgentSession {
     this.clearCurrentPlanIfModeLeft();
   }
 
-  /** Whether the user can swap the active model on this session. */
+  /**
+   * Whether the user can swap the active model on this session. Config-option-
+   * backed catalogs (opencode ≥ 1.15.13) switch via `setConfigOption`; everyone
+   * else via `setModel`.
+   */
   canSwitchModel(): boolean | null {
     if (this.getStatus() === "starting") return false;
-    return this.backend.isSetSessionModelSupported();
+    return this.currentState?.model?.apply.kind === "setConfigOption"
+      ? this.backend.isSetSessionConfigOptionSupported()
+      : this.backend.isSetSessionModelSupported();
   }
 
   /**
-   * Whether the user can swap effort. Descriptor-style backends route
-   * effort via `setConfigOption`; suffix-style via `setModel`. The wire
-   * routing is encapsulated here — UI consumers ask intent only.
+   * Whether the user can swap effort. Descriptor-style backends (claude) and
+   * config-option-backed models (opencode ≥ 1.15.13) route effort via
+   * `setConfigOption`; suffix-style models that pack effort into the wire id
+   * (codex, older opencode) via `setModel`. The wire routing is encapsulated
+   * here — UI consumers ask intent only.
    */
   canSwitchEffort(): boolean | null {
     if (this.getStatus() === "starting") return false;
     const descriptor = this.getDescriptor?.();
     if (!descriptor) return null;
-    return descriptor.wire.effortConfigFor
+    if (descriptor.wire.effortConfigFor) return this.backend.isSetSessionConfigOptionSupported();
+    return this.currentState?.model?.apply.kind === "setConfigOption"
       ? this.backend.isSetSessionConfigOptionSupported()
       : this.backend.isSetSessionModelSupported();
   }

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -659,6 +659,61 @@ describe("AgentSessionManager.restartBackend", () => {
     expect(mgr.getActiveSession()?.backendId).toBe("opencode");
   });
 
+  it("re-probes before creating the replacement so the effort catalog is rebuilt", async () => {
+    // The active tab is on this backend, so the restart creates a replacement
+    // session. `restartBackendNow` cleared the (now stale) effort catalog, and
+    // a live session's attachModelCacheSync mirrors catalog state but NOT the
+    // effort catalog — so the manager must re-probe before the replacement, or
+    // the picker loses every model's effort stepper until a reload.
+    const preload = jest.fn(async () => undefined);
+    const modelPreloader = {
+      getCachedBackendState: jest.fn(() => null),
+      preload,
+      refresh: jest.fn(() => null),
+      subscribe: jest.fn(() => () => {}),
+      shutdown: jest.fn(),
+      setCached: jest.fn(),
+      clearCached: jest.fn(),
+      takeWarm: jest.fn(() => null),
+    };
+    const descriptor = {
+      ...buildDescriptor(),
+      getInstallState: jest.fn(() => ({ kind: "ready" })),
+    } as unknown as BackendDescriptor;
+    const mgr = new AgentSessionManager(
+      buildApp(),
+      buildPlugin() as unknown as ConstructorParameters<typeof AgentSessionManager>[1],
+      {
+        permissionPrompter: jest.fn(),
+        resolveDescriptor: (id) => (id === descriptor.id ? descriptor : undefined),
+        modelPreloader: modelPreloader as unknown as ConstructorParameters<
+          typeof AgentSessionManager
+        >[2]["modelPreloader"],
+      }
+    );
+
+    const first = await mgr.createSession();
+    // Drop the initial-create probe/spawn bookkeeping so we assert only on the
+    // restart's re-probe + replacement ordering.
+    preload.mockClear();
+    sessionCreateSpy.mockClear();
+
+    await expect(mgr.restartBackend("opencode", "backend enabled models changed")).resolves.toBe(
+      true
+    );
+
+    // Re-probed once, and the probe ran before the replacement session spawned.
+    expect(preload).toHaveBeenCalledTimes(1);
+    expect(preload).toHaveBeenCalledWith("opencode");
+    expect(sessionCreateSpy).toHaveBeenCalledTimes(1);
+    expect(preload.mock.invocationCallOrder[0]).toBeLessThan(
+      sessionCreateSpy.mock.invocationCallOrder[0]
+    );
+    // The replacement still becomes the active session on this backend.
+    expect(mgr.getActiveSession()).not.toBe(first);
+    expect(mgr.getActiveSession()?.backendId).toBe("opencode");
+  });
+
   it("defers restart until an active turn leaves running", async () => {
     const mgr = buildManager();
     const first = await mgr.createSession();
@@ -1146,10 +1201,11 @@ describe("AgentSessionManager.onInstallStateChanged", () => {
 
     await mgr.onInstallStateChanged("opencode");
 
-    // The old proc is torn down (re-probe). No standalone preload — the restart
-    // path repopulates the cache itself.
+    // The old proc is torn down and the backend re-probed: a live session
+    // mirrors catalog state but not the derived effort catalog, so the restart
+    // re-probes (the replacement then adopts that warm proc).
     expect(mockBackendShutdown).toHaveBeenCalled();
-    expect(preloader.preload).not.toHaveBeenCalled();
+    expect(preloader.preload).toHaveBeenCalledWith("opencode");
   });
 
   it("tears down and drops the warm probe when the binary is no longer available", async () => {

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -21,6 +21,7 @@ import type {
   BackendProcess,
   BackendState,
   CopilotMode,
+  EffortOption,
   ModeApplySpec,
   ModelSelection,
   PermissionDecision,
@@ -549,6 +550,15 @@ export class AgentSessionManager {
   /** Cached unified backend state for `backendId`, populated by the model preloader. */
   getCachedBackendState(backendId: BackendId): BackendState | null {
     return this.preloader.getCachedBackendState(backendId);
+  }
+
+  /**
+   * Per-model effort options (baseModelId → options) discovered by the
+   * preloader's post-catalog prefetch, or `null`. The picker reads this to show
+   * effort steppers for models that aren't currently active.
+   */
+  getEffortCatalog(backendId: BackendId): Record<string, EffortOption[]> | null {
+    return this.preloader.getEffortCatalog(backendId);
   }
 
   /**

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -1313,14 +1313,21 @@ export class AgentSessionManager {
       }
       this.preloader.clearCached(backendId);
       new Notice(`${this.resolveDescriptor(backendId).displayName} refreshed.`);
-      if (shouldCreateReplacement && !this.disposed) {
-        await this.createSession(backendId);
-      } else if (!this.disposed && this.isBackendInstalled(backendId)) {
-        // No live session will repopulate the cache we just cleared (the
-        // active tab is on a different backend, or there are no tabs). Re-probe
-        // so the picker reflects the new spawn config instead of flagging
-        // freshly-enabled models as "not offered by agent" until a reload.
-        this.registerPreload(backendId, this.preloader.preload(backendId));
+      if (!this.disposed && this.isBackendInstalled(backendId)) {
+        // Spawn config (enabled models, keys, prompt, skills) is rebuilt on
+        // every restart, and the picker's catalog *and* per-model effort
+        // catalog both derive from it. A live session mirrors catalog state via
+        // attachModelCacheSync but NOT the effort catalog, so always re-probe —
+        // the prefetch repopulates effort for every enabled model. When a tab
+        // on this backend is active, await the probe and let the replacement
+        // adopt its warm proc: one spawn, and the per-model switch flicker
+        // stays on the throwaway probe session instead of the user's.
+        const probe = this.preloader.preload(backendId);
+        this.registerPreload(backendId, probe);
+        if (shouldCreateReplacement && !this.disposed) {
+          await probe;
+          await this.createSession(backendId);
+        }
       }
       this.notify();
     } finally {

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -7,11 +7,14 @@ import type {
   BackendConfigOption,
   BackendId,
   BackendProcess,
+  EffortOption,
   EnabledModelEntry,
   ModelSelection,
+  ModelState,
   ModelWireCodec,
   ModeMapping,
   RawModeState,
+  SessionId,
 } from "./types";
 
 /** UI-facing install/setup state for a backend. */
@@ -312,4 +315,23 @@ export interface BackendDescriptor {
    * `resumeSession` or `loadSession`. Only called by `AgentModelPreloader`.
    */
   persistProbeSessionId?(sessionId: string, plugin: CopilotPlugin): Promise<void>;
+
+  /**
+   * Optional: eagerly discover each enabled model's effort options right after
+   * the initial catalog probe. opencode only reports a model's effort as a
+   * `category:"thought_level"` config option once that model is the *active*
+   * model, so the catalog carries no per-model effort and the only way to learn
+   * a non-active model's effort is to switch to it. Runs on the existing probe
+   * `sessionId` (cheap: a switch is ~ms, a new session is ~1s) and MUST restore
+   * `modelState.current` before returning so the session the manager adopts is
+   * never left on a probed model. Returns baseModelId → effortOptions for models
+   * that expose effort. Best-effort; `AgentModelPreloader` swallows failures.
+   */
+  prefetchEffortCatalog?(args: {
+    proc: BackendProcess;
+    sessionId: SessionId;
+    modelState: ModelState;
+    enabledModels: ReadonlyArray<EnabledModelEntry>;
+    isAborted: () => boolean;
+  }): Promise<Record<string, EffortOption[]>>;
 }

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -20,6 +20,18 @@ export type InstallState =
   | { kind: "ready"; source: "managed" | "custom" }
   | { kind: "error"; message: string };
 
+/**
+ * Reported by `getUpgradeInfo` when the installed binary is too old for the
+ * plugin to drive (e.g. opencode < 1.15.13 lacks the config-option model API).
+ * Generic UI renders an upgrade CTA from this; `source` selects the mechanism
+ * (`upgrade` reinstalls managed binaries, runs `<cli> upgrade` for custom ones).
+ */
+export interface BackendUpgradeInfo {
+  currentVersion: string;
+  minVersion: string;
+  source: "managed" | "custom";
+}
+
 /** Sign-in state for backends that authenticate via a CLI / external account. */
 export interface BackendAuthStatus {
   signedIn: boolean;
@@ -145,6 +157,22 @@ export interface BackendDescriptor {
 
   /** Open backend-specific install/setup modal. */
   openInstallUI(plugin: CopilotPlugin): void;
+
+  /**
+   * Optional: report that the installed binary is too old for the plugin, so
+   * generic UI can surface an upgrade CTA. Returns `null` when current,
+   * unknown, not installed, or not applicable (claude/codex don't implement it).
+   */
+  getUpgradeInfo?(settings: CopilotSettings): BackendUpgradeInfo | null;
+
+  /**
+   * Optional: upgrade the installed binary in place (managed reinstall, or the
+   * CLI's own `upgrade`). Resolves when done. Changing the persisted version
+   * restarts the backend via the `subscribeInstallState` subscription, so the
+   * next session boots on the new binary. Throws with a readable message on
+   * failure; callers surface progress/errors.
+   */
+  upgrade?(plugin: CopilotPlugin): Promise<void>;
 
   /**
    * Optional: sign-in capability for backends gated on an external account

--- a/src/agentMode/session/translateBackendState.test.ts
+++ b/src/agentMode/session/translateBackendState.test.ts
@@ -64,12 +64,13 @@ function suffixDescriptor(extra: Partial<BackendDescriptor> = {}): BackendDescri
 function selectOption(
   id: string,
   values: { value: string; name?: string }[],
-  current?: string
+  current?: string,
+  category: string | null = null
 ): BackendConfigOption {
   return {
     id,
     type: "select",
-    category: null,
+    category,
     name: id,
     currentValue: current ?? values[0]?.value,
     options: values.map((v) => ({ value: v.value, name: v.name ?? v.value })),
@@ -83,6 +84,87 @@ describe("translateBackendState — model: null cases", () => {
       descriptor()
     );
     expect(state.model).toBeNull();
+  });
+});
+
+describe("translateBackendState — model catalog from config option (opencode ≥ 1.15.13)", () => {
+  it("builds the catalog from a category:'model' select when models is null", () => {
+    // opencode 1.15.13 drops the `models` state and reports the catalog as a
+    // generic select with category "model".
+    const modelOpt = selectOption(
+      "model",
+      [
+        { value: "omlx/gemma-4-e4b-it-8bit", name: "oMLX/gemma-4-e4b-it-8bit" },
+        { value: "omlx/Qwen3.6-35B-A3B-UD-MLX-4bit", name: "oMLX/Qwen3.6-35B-A3B-UD-MLX-4bit" },
+      ],
+      "omlx/Qwen3.6-35B-A3B-UD-MLX-4bit",
+      "model"
+    );
+    const state = translateBackendState(
+      { models: null, modes: null, configOptions: [modelOpt] },
+      suffixDescriptor()
+    );
+    expect(state.model?.availableModels.map((m) => m.baseModelId)).toEqual([
+      "omlx/gemma-4-e4b-it-8bit",
+      "omlx/Qwen3.6-35B-A3B-UD-MLX-4bit",
+    ]);
+    // Friendly names come from the option, not the raw wire id.
+    expect(state.model?.availableModels[0]?.name).toBe("oMLX/gemma-4-e4b-it-8bit");
+    expect(state.model?.current.baseModelId).toBe("omlx/Qwen3.6-35B-A3B-UD-MLX-4bit");
+    expect(state.model?.apply).toEqual({ kind: "setConfigOption", configId: "model" });
+  });
+
+  it("prefers the dedicated models state when present (older opencode sends both)", () => {
+    const models: RawModelState = {
+      currentModelId: "omlx/gemma-4-e4b-it-8bit",
+      availableModels: [{ modelId: "omlx/gemma-4-e4b-it-8bit", name: "oMLX/gemma" }],
+    };
+    const modelOpt = selectOption(
+      "model",
+      [{ value: "omlx/other", name: "Other" }],
+      "omlx/other",
+      "model"
+    );
+    const state = translateBackendState(
+      { models, modes: null, configOptions: [modelOpt] },
+      suffixDescriptor()
+    );
+    // `models` wins → setModel channel, catalog from `models` not the option.
+    expect(state.model?.current.baseModelId).toBe("omlx/gemma-4-e4b-it-8bit");
+    expect(state.model?.apply).toEqual({ kind: "setModel" });
+  });
+
+  it("does not treat a category:'mode' select as the model catalog", () => {
+    const modeOpt = selectOption("mode", [{ value: "build", name: "Build" }], "build", "mode");
+    const state = translateBackendState(
+      { models: null, modes: null, configOptions: [modeOpt] },
+      suffixDescriptor()
+    );
+    expect(state.model).toBeNull();
+  });
+
+  it("flattens grouped options under the model select", () => {
+    const grouped: BackendConfigOption = {
+      id: "model",
+      type: "select",
+      category: "model",
+      name: "model",
+      currentValue: "omlx/a",
+      options: [
+        {
+          name: "oMLX",
+          options: [
+            { value: "omlx/a", name: "A" },
+            { value: "omlx/b", name: "B" },
+          ],
+        },
+      ],
+    };
+    const state = translateBackendState(
+      { models: null, modes: null, configOptions: [grouped] },
+      suffixDescriptor()
+    );
+    expect(state.model?.availableModels.map((m) => m.baseModelId)).toEqual(["omlx/a", "omlx/b"]);
   });
 });
 
@@ -675,6 +757,7 @@ describe("modelStateSignature", () => {
   it("is identical for equivalent model slices regardless of mode", () => {
     const sharedModel: BackendState["model"] = {
       current: { baseModelId: "x", effort: null },
+      apply: { kind: "setModel" },
       availableModels: [{ baseModelId: "x", name: "X", provider: null, effortOptions: [] }],
     };
     const a: BackendState = { model: sharedModel, mode: null };
@@ -689,6 +772,7 @@ describe("modelStateSignature", () => {
     const a: BackendState = {
       model: {
         current: { baseModelId: "x", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [
           { baseModelId: "x", name: "X", provider: null, effortOptions: [] },
           { baseModelId: "y", name: "Y", provider: null, effortOptions: [] },
@@ -699,6 +783,20 @@ describe("modelStateSignature", () => {
     const b: BackendState = {
       ...a,
       model: { ...a.model!, current: { baseModelId: "y", effort: null } },
+    };
+    expect(modelStateSignature(a)).not.toBe(modelStateSignature(b));
+  });
+
+  it("differs when the apply channel flips (setModel vs setConfigOption)", () => {
+    const base: NonNullable<BackendState["model"]> = {
+      current: { baseModelId: "x", effort: null },
+      availableModels: [{ baseModelId: "x", name: "X", provider: null, effortOptions: [] }],
+      apply: { kind: "setModel" },
+    };
+    const a: BackendState = { model: base, mode: null };
+    const b: BackendState = {
+      model: { ...base, apply: { kind: "setConfigOption", configId: "model" } },
+      mode: null,
     };
     expect(modelStateSignature(a)).not.toBe(modelStateSignature(b));
   });
@@ -720,6 +818,7 @@ describe("modeStateSignature", () => {
     const b: BackendState = {
       model: {
         current: { baseModelId: "x", effort: null },
+        apply: { kind: "setModel" },
         availableModels: [{ baseModelId: "x", name: "X", provider: null, effortOptions: [] }],
       },
       mode: sharedMode,

--- a/src/agentMode/session/translateBackendState.test.ts
+++ b/src/agentMode/session/translateBackendState.test.ts
@@ -166,6 +166,42 @@ describe("translateBackendState — model catalog from config option (opencode �
     );
     expect(state.model?.availableModels.map((m) => m.baseModelId)).toEqual(["omlx/a", "omlx/b"]);
   });
+
+  it("maps the current model's thought-level option into effort state", () => {
+    const modelOpt = selectOption(
+      "model",
+      [
+        { value: "omlx/a", name: "A" },
+        { value: "omlx/b", name: "B" },
+      ],
+      "omlx/a",
+      "model"
+    );
+    const effortOpt = selectOption(
+      "effort",
+      [
+        { value: "low", name: "Low" },
+        { value: "high", name: "High" },
+      ],
+      "high",
+      "thought_level"
+    );
+    const state = translateBackendState(
+      { models: null, modes: null, configOptions: [modelOpt, effortOpt] },
+      suffixDescriptor()
+    );
+    expect(state.model?.current).toEqual({ baseModelId: "omlx/a", effort: "high" });
+    expect(state.model?.availableModels[0]?.effortOptions).toEqual([
+      { value: "low", label: "low" },
+      { value: "high", label: "high" },
+    ]);
+    expect(state.model?.availableModels[1]?.effortOptions).toEqual([]);
+    expect(state.model?.apply).toEqual({
+      kind: "setConfigOption",
+      configId: "model",
+      effortConfigId: "effort",
+    });
+  });
 });
 
 describe("translateBackendState — name normalization + description", () => {
@@ -796,6 +832,23 @@ describe("modelStateSignature", () => {
     const a: BackendState = { model: base, mode: null };
     const b: BackendState = {
       model: { ...base, apply: { kind: "setConfigOption", configId: "model" } },
+      mode: null,
+    };
+    expect(modelStateSignature(a)).not.toBe(modelStateSignature(b));
+  });
+
+  it("differs when a config-option-backed effort channel appears", () => {
+    const base: NonNullable<BackendState["model"]> = {
+      current: { baseModelId: "x", effort: null },
+      availableModels: [{ baseModelId: "x", name: "X", provider: null, effortOptions: [] }],
+      apply: { kind: "setConfigOption", configId: "model" },
+    };
+    const a: BackendState = { model: base, mode: null };
+    const b: BackendState = {
+      model: {
+        ...base,
+        apply: { kind: "setConfigOption", configId: "model", effortConfigId: "effort" },
+      },
       mode: null,
     };
     expect(modelStateSignature(a)).not.toBe(modelStateSignature(b));

--- a/src/agentMode/session/translateBackendState.ts
+++ b/src/agentMode/session/translateBackendState.ts
@@ -75,8 +75,13 @@ function translateModel(
   const fromConfig = inputs.models ? null : modelStateFromConfigOption(inputs.configOptions);
   const modelState = inputs.models ?? fromConfig?.state ?? null;
   if (!modelState) return null;
+  const effortFromConfig = fromConfig ? effortConfigOption(inputs.configOptions) : null;
   const apply: ModelApplySpec = fromConfig
-    ? { kind: "setConfigOption", configId: fromConfig.configId }
+    ? {
+        kind: "setConfigOption",
+        configId: fromConfig.configId,
+        ...(effortFromConfig ? { effortConfigId: effortFromConfig.id } : {}),
+      }
     : { kind: "setModel" };
 
   // Group advertised wire ids by baseModelId, preserving first-seen order.
@@ -151,6 +156,11 @@ function translateModel(
     };
     availableModels.push(currentEntry);
   }
+  // A thought-level option describes only the currently selected model; other
+  // models may expose a different variant set after they become active.
+  if (effortFromConfig) {
+    currentEntry.effortOptions = optionsFromConfigOption(effortFromConfig);
+  }
 
   const current: ModelSelection = {
     baseModelId: currentEntry.baseModelId,
@@ -158,7 +168,8 @@ function translateModel(
       decodedCurrent.selection.effort,
       currentEntry,
       descriptor,
-      inputs.configOptions
+      inputs.configOptions,
+      effortFromConfig
     ),
   };
 
@@ -203,6 +214,12 @@ function modelStateFromConfigOption(
     state: { currentModelId: String(opt.currentValue), availableModels },
     configId: opt.id,
   };
+}
+
+function effortConfigOption(
+  configOptions: BackendConfigOption[] | null
+): BackendConfigOption | null {
+  return configOptions?.find((o) => o.category === "thought_level" && o.type === "select") ?? null;
 }
 
 function deriveEffortOptions(
@@ -255,9 +272,13 @@ function resolveCurrentEffort(
   decodedEffort: string | null,
   currentEntry: ModelEntry,
   descriptor: BackendDescriptor,
-  configOptions: BackendConfigOption[] | null
+  configOptions: BackendConfigOption[] | null,
+  effortFromConfig: BackendConfigOption | null = null
 ): string | null {
   let candidate: string | null = decodedEffort;
+  if (candidate === null && effortFromConfig?.type === "select") {
+    candidate = String(effortFromConfig.currentValue);
+  }
   if (candidate === null && descriptor.wire.effortConfigFor) {
     const spec = descriptor.wire.effortConfigFor(currentEntry.baseModelId);
     if (spec && spec.type === "select") {
@@ -373,7 +394,9 @@ export function modelStateSignature(state: BackendState | null): string {
   const m = state?.model;
   if (!m) return "";
   const apply =
-    m.apply.kind === "setConfigOption" ? `setConfigOption:${m.apply.configId}` : m.apply.kind;
+    m.apply.kind === "setConfigOption"
+      ? `setConfigOption:${m.apply.configId}:${m.apply.effortConfigId ?? ""}`
+      : m.apply.kind;
   return [
     m.current.baseModelId,
     m.current.effort ?? "",

--- a/src/agentMode/session/translateBackendState.ts
+++ b/src/agentMode/session/translateBackendState.ts
@@ -1,6 +1,7 @@
 import type {
   BackendConfigOption,
   BackendDescriptor,
+  BackendModelInfo,
   RawModelState,
   RawModeState,
   BackendState,
@@ -9,6 +10,7 @@ import type {
   ModeApplySpec,
   ModeMapping,
   ModeOption,
+  ModelApplySpec,
   ModelEntry,
   ModelSelection,
   ModelState,
@@ -66,8 +68,16 @@ function translateModel(
   inputs: BackendStateInputs,
   descriptor: BackendDescriptor
 ): ModelState | null {
-  const modelState = inputs.models;
+  // Prefer the dedicated `models` state (codex, claude, opencode ≤ 1.15.12).
+  // Newer opencode (≥ 1.15.13) dropped that field and advertises its catalog
+  // only through a generic `category:"model"` select config option, switched
+  // via `session/set_config_option` instead of `session/set_model`.
+  const fromConfig = inputs.models ? null : modelStateFromConfigOption(inputs.configOptions);
+  const modelState = inputs.models ?? fromConfig?.state ?? null;
   if (!modelState) return null;
+  const apply: ModelApplySpec = fromConfig
+    ? { kind: "setConfigOption", configId: fromConfig.configId }
+    : { kind: "setModel" };
 
   // Group advertised wire ids by baseModelId, preserving first-seen order.
   type Group = {
@@ -152,7 +162,47 @@ function translateModel(
     ),
   };
 
-  return { current, availableModels };
+  return { current, availableModels, apply };
+}
+
+/**
+ * Fallback model source for backends that advertise their catalog only via a
+ * generic `category:"model"` select config option (opencode ≥ 1.15.13) instead
+ * of a dedicated `RawModelState`. Flattens grouped options like
+ * `optionsFromConfigOption`. Returns the synthesized `RawModelState` plus the
+ * option id (so the caller can route switches through `set_config_option`), or
+ * `null` when no populated model option exists — leaving `model` null for
+ * backends that report nothing.
+ */
+function modelStateFromConfigOption(
+  configOptions: BackendConfigOption[] | null
+): { state: RawModelState; configId: string } | null {
+  if (!configOptions) return null;
+  const opt = configOptions.find((o) => o.category === "model" && o.type === "select");
+  if (!opt || opt.type !== "select") return null;
+  const availableModels: BackendModelInfo[] = [];
+  for (const entry of opt.options) {
+    if ("options" in entry) {
+      for (const inner of entry.options) {
+        availableModels.push({
+          modelId: inner.value,
+          name: inner.name,
+          description: inner.description,
+        });
+      }
+    } else {
+      availableModels.push({
+        modelId: entry.value,
+        name: entry.name,
+        description: entry.description,
+      });
+    }
+  }
+  if (availableModels.length === 0) return null;
+  return {
+    state: { currentModelId: String(opt.currentValue), availableModels },
+    configId: opt.id,
+  };
 }
 
 function deriveEffortOptions(
@@ -322,9 +372,12 @@ function stripEffortSuffix(name: string, variants: { effort: string | null }[]):
 export function modelStateSignature(state: BackendState | null): string {
   const m = state?.model;
   if (!m) return "";
+  const apply =
+    m.apply.kind === "setConfigOption" ? `setConfigOption:${m.apply.configId}` : m.apply.kind;
   return [
     m.current.baseModelId,
     m.current.effort ?? "",
+    apply,
     m.availableModels
       .map(
         (e) =>

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -220,9 +220,12 @@ export type ModeApplySpec =
  * `setModel` issues ACP `session/set_model` (codex, claude, and opencode
  * ≤ 1.15.12). `setConfigOption` issues `session/set_config_option` against the
  * `category:"model"` select id (opencode ≥ 1.15.13). The encoded wire id is the
- * same string in both channels; only the RPC differs.
+ * same string in both channels; only the RPC differs. `effortConfigId` records
+ * a separate `category:"thought_level"` selector when the backend exposes one.
  */
-export type ModelApplySpec = { kind: "setModel" } | { kind: "setConfigOption"; configId: string };
+export type ModelApplySpec =
+  | { kind: "setModel" }
+  | { kind: "setConfigOption"; configId: string; effortConfigId?: string };
 
 /**
  * Normalized, consumer-facing slice of session state. Produced by

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -6,6 +6,7 @@ export type {
   BackendAuthStatus,
   BackendDescriptor,
   BackendSignInHandlers,
+  BackendUpgradeInfo,
   InstallState,
 } from "./descriptor";
 export type { CurrentPlan, PlanDecisionAction, PlanProposalDecision } from "./plan";
@@ -160,6 +161,15 @@ export interface ModelSelection {
 export interface ModelState {
   current: ModelSelection;
   availableModels: ModelEntry[];
+  /**
+   * Which RPC a model switch should dispatch. `setModel` is the default ACP
+   * channel (`session/set_model`). `setConfigOption` is used when the backend
+   * advertises its catalog through a generic `category:"model"` select config
+   * option (opencode ≥ 1.15.13, where `session/set_model` is gone and the
+   * canonical switch is `session/set_config_option`). Set by the translator
+   * from which source produced the catalog.
+   */
+  apply: ModelApplySpec;
 }
 
 /**
@@ -204,6 +214,15 @@ export interface ModelWireCodec {
 export type ModeApplySpec =
   | { kind: "setMode"; nativeId: string }
   | { kind: "setConfigOption"; configId: string; value: string };
+
+/**
+ * Apply spec for a model change — the dispatch channel for `ModelState`.
+ * `setModel` issues ACP `session/set_model` (codex, claude, and opencode
+ * ≤ 1.15.12). `setConfigOption` issues `session/set_config_option` against the
+ * `category:"model"` select id (opencode ≥ 1.15.13). The encoded wire id is the
+ * same string in both channels; only the RPC differs.
+ */
+export type ModelApplySpec = { kind: "setModel" } | { kind: "setConfigOption"; configId: string };
 
 /**
  * Normalized, consumer-facing slice of session state. Produced by

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -39,9 +39,7 @@ describe("builtin Copilot Plus skills", () => {
       // SKILL.md tells the agent to prefer sh, fall back to node, then prompt
       // for a Node install if neither runtime is available.
       expect(skill.skillMd).toContain(`sh "/absolute/path/to/this/skill/directory/${sh!.path}"`);
-      expect(skill.skillMd).toContain(
-        `node "/absolute/path/to/this/skill/directory/${mjs!.path}"`
-      );
+      expect(skill.skillMd).toContain(`node "/absolute/path/to/this/skill/directory/${mjs!.path}"`);
       expect(skill.skillMd).toContain("install Node.js");
     }
   });

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -234,7 +234,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
                 }
                 data-agent-landing={isGlobalLanding ? "global" : "conversation"}
               >
-                <AgentModeStatus manager={manager} onInstallClick={handleInstall} />
+                <AgentModeStatus manager={manager} plugin={plugin} onInstallClick={handleInstall} />
                 {isGlobalLanding ? (
                   <>
                     {/* Top spacer biases the composer into the lower portion of

--- a/src/agentMode/ui/AgentModeChat.tsx
+++ b/src/agentMode/ui/AgentModeChat.tsx
@@ -104,7 +104,7 @@ export const AgentModeChat: React.FC<Props> = ({
   return (
     <div className="tw-flex tw-size-full tw-flex-col tw-overflow-hidden">
       <div className="tw-flex-1" />
-      <AgentModeStatus manager={manager} onInstallClick={handleInstall} />
+      <AgentModeStatus manager={manager} plugin={plugin} onInstallClick={handleInstall} />
       <AgentChatControls />
     </div>
   );

--- a/src/agentMode/ui/AgentModeStatus.tsx
+++ b/src/agentMode/ui/AgentModeStatus.tsx
@@ -5,12 +5,18 @@ import {
   useSessionBackendDescriptor,
 } from "@/agentMode/ui/useBackendDescriptor";
 import { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
+import type CopilotPlugin from "@/main";
+import { useSettingsValue } from "@/settings/model";
+import { Notice } from "obsidian";
 import React from "react";
 
 interface Props {
   /** Plugin's AgentSessionManager. May be undefined on mobile. */
   manager?: AgentSessionManager;
+  /** The plugin — needed to drive the install/upgrade actions. */
+  plugin: CopilotPlugin;
   /** Click handler for the "Install …" CTA when the backend isn't installed. */
   onInstallClick: () => void;
 }
@@ -21,10 +27,13 @@ interface Props {
  * (Retry). Every healthy state renders nothing — the chat input already
  * conveys readiness.
  */
-export const AgentModeStatus: React.FC<Props> = ({ manager, onInstallClick }) => {
+export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallClick }) => {
   const descriptor = useSessionBackendDescriptor(manager);
   const installState = useBackendInstallState(descriptor);
   const auth = useBackendAuthState(descriptor);
+  const settings = useSettingsValue();
+  const upgradeInfo = descriptor.getUpgradeInfo?.(settings) ?? null;
+  const [upgrading, setUpgrading] = React.useState(false);
 
   // Re-render on manager notify so `lastError` flips are picked up.
   const [, setTick] = React.useState(0);
@@ -33,12 +42,48 @@ export const AgentModeStatus: React.FC<Props> = ({ manager, onInstallClick }) =>
     return manager.subscribe(() => setTick((v) => v + 1));
   }, [manager]);
 
+  const handleUpgrade = React.useCallback(() => {
+    if (!descriptor.upgrade || upgrading) return;
+    setUpgrading(true);
+    new Notice(`Upgrading ${descriptor.displayName}…`);
+    descriptor
+      .upgrade(plugin)
+      .then(() => new Notice(`${descriptor.displayName} upgraded.`))
+      .catch((e) => {
+        logError("[AgentMode] upgrade failed", e);
+        new Notice(`Failed to upgrade ${descriptor.displayName}. See console for details.`);
+      })
+      .finally(() => setUpgrading(false));
+  }, [descriptor, plugin, upgrading]);
+
   if (installState.kind === "absent") {
     return (
       <div className="tw-flex tw-items-center tw-justify-between tw-rounded tw-bg-secondary tw-px-3 tw-py-2 tw-text-xs">
         <span className="tw-text-muted">{descriptor.displayName} not installed</span>
         <Button variant="default" size="sm" onClick={onInstallClick}>
           Install {descriptor.displayName}
+        </Button>
+      </div>
+    );
+  }
+
+  // An outdated binary can't drive the model picker (opencode < 1.15.13 lost the
+  // model API), so prompt an upgrade before auth or anything else.
+  if (upgradeInfo) {
+    return (
+      <div
+        className={cn(
+          "tw-flex tw-items-center tw-justify-between tw-gap-2 tw-rounded",
+          "tw-bg-callout-warning/20 tw-px-3 tw-py-2 tw-text-xs tw-text-warning"
+        )}
+        role="alert"
+      >
+        <span>
+          {descriptor.displayName} {upgradeInfo.currentVersion} is out of date — update to{" "}
+          {upgradeInfo.minVersion}+ to choose models.
+        </span>
+        <Button variant="default" size="sm" disabled={upgrading} onClick={handleUpgrade}>
+          {upgrading ? "Upgrading…" : "Upgrade"}
         </Button>
       </div>
     );

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -55,7 +55,11 @@ function makeState(modelId: string): BackendState {
     effortOptions: [],
   };
   return {
-    model: { current: { baseModelId: modelId, effort: null }, availableModels: [entry] },
+    model: {
+      current: { baseModelId: modelId, effort: null },
+      availableModels: [entry],
+      apply: { kind: "setModel" },
+    },
     mode: null,
   };
 }
@@ -118,6 +122,7 @@ function makeModelState(currentBaseId: string, available: ModelEntry[]): ModelSt
   return {
     current: { baseModelId: currentBaseId, effort: null },
     availableModels: available,
+    apply: { kind: "setModel" },
   };
 }
 

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -1,14 +1,18 @@
 import {
   appendBackendSection,
+  buildEffortOptionsByModelKey,
   buildEffortSibling,
   buildModelOnChange,
   buildPickerEntries,
   resolveActiveDisplayState,
+  synthesizeAgentEntry,
 } from "./agentModelPickerHelpers";
+import { getModelKeyFromModel } from "@/settings/model";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import type {
   BackendDescriptor,
   BackendState,
+  EffortOption,
   EnabledModelEntry,
   ModelEntry,
   ModelState,
@@ -140,6 +144,7 @@ function makeUIState(opts: {
 
 function makeManager(opts: {
   cachedStateById?: Record<string, BackendState | null>;
+  effortCatalogById?: Record<string, Record<string, EffortOption[]>>;
   defaultSelectionById?: Record<string, { baseModelId: string; effort: string | null } | null>;
   setDefaultBackend?: jest.Mock;
   applySelection?: jest.Mock;
@@ -149,6 +154,7 @@ function makeManager(opts: {
 }): AgentSessionManager {
   return {
     getCachedBackendState: (id: string) => opts.cachedStateById?.[id] ?? null,
+    getEffortCatalog: (id: string) => opts.effortCatalogById?.[id] ?? null,
     getDefaultSelection: (id: string) => opts.defaultSelectionById?.[id] ?? null,
     setDefaultBackend: opts.setDefaultBackend ?? jest.fn(),
     applySelection: opts.applySelection ?? jest.fn().mockResolvedValue(undefined),
@@ -622,5 +628,75 @@ describe("buildModelOnChange", () => {
     onChange("no-backend|agent");
     expect(setDefaultBackend).not.toHaveBeenCalled();
     expect(applySelection).not.toHaveBeenCalled();
+  });
+});
+
+// ---- buildEffortOptionsByModelKey ----
+
+describe("buildEffortOptionsByModelKey", () => {
+  const ACTIVE = "github-copilot/gpt-5.4";
+  const OTHER = "opencode/nemotron-3-super-free";
+
+  function stateWithEffort(
+    currentBaseId: string,
+    available: { baseModelId: string; effortOptions: EffortOption[] }[]
+  ): BackendState {
+    return {
+      model: {
+        current: { baseModelId: currentBaseId, effort: null },
+        apply: { kind: "setConfigOption", configId: "model" },
+        availableModels: available.map((a) => ({
+          baseModelId: a.baseModelId,
+          name: a.baseModelId,
+          provider: null,
+          effortOptions: a.effortOptions,
+        })),
+      },
+      mode: null,
+    };
+  }
+
+  it("prefers live effort for the active model and falls back to the prefetch cache for others", () => {
+    const opencode = makeDescriptor("opencode");
+    const manager = makeManager({
+      cachedStateById: {
+        opencode: stateWithEffort(ACTIVE, [
+          { baseModelId: ACTIVE, effortOptions: [{ value: "high", label: "high" }] },
+          { baseModelId: OTHER, effortOptions: [] }, // not active → no live effort
+        ]),
+      },
+      effortCatalogById: {
+        opencode: {
+          [ACTIVE]: [{ value: "low", label: "low" }], // ignored — live wins
+          [OTHER]: [
+            { value: "minimal", label: "minimal" },
+            { value: "max", label: "max" },
+          ],
+        },
+      },
+    });
+    const entries = [
+      synthesizeAgentEntry(ACTIVE, ACTIVE, opencode),
+      synthesizeAgentEntry(OTHER, OTHER, opencode),
+    ];
+    const out = buildEffortOptionsByModelKey(manager, [opencode], entries);
+    expect(out[getModelKeyFromModel(entries[0])]).toEqual([{ value: "high", label: "high" }]);
+    expect(out[getModelKeyFromModel(entries[1])]).toEqual([
+      { value: "minimal", label: "minimal" },
+      { value: "max", label: "max" },
+    ]);
+  });
+
+  it("returns empty when neither live nor cached effort exists", () => {
+    const opencode = makeDescriptor("opencode");
+    const manager = makeManager({
+      cachedStateById: {
+        opencode: stateWithEffort(OTHER, [{ baseModelId: OTHER, effortOptions: [] }]),
+      },
+      effortCatalogById: { opencode: {} },
+    });
+    const entries = [synthesizeAgentEntry(OTHER, OTHER, opencode)];
+    const out = buildEffortOptionsByModelKey(manager, [opencode], entries);
+    expect(out[getModelKeyFromModel(entries[0])]).toEqual([]);
   });
 });

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -447,7 +447,12 @@ export function buildEffortOptionsByModelKey(
     const catalog = catalogByBackendId.get(backendId);
     if (!catalog) continue;
     const found = catalog.find((m) => m.baseModelId === baseModelId);
-    out[getModelKeyFromModel(entry)] = found ? found.effortOptions : [];
+    // The reported catalog only carries effort for the *active* model (opencode
+    // surfaces it only for the current model); fall back to the preloader's
+    // prefetched effort catalog for every other row.
+    const live = found?.effortOptions ?? [];
+    out[getModelKeyFromModel(entry)] =
+      live.length > 0 ? live : (manager.getEffortCatalog(backendId)?.[baseModelId] ?? []);
   }
   return out;
 }

--- a/src/agentMode/ui/useAgentModelPicker.ts
+++ b/src/agentMode/ui/useAgentModelPicker.ts
@@ -73,7 +73,9 @@ function useAgentModelSignal(
       parts.push(
         `${d.id}:${manager.getPreloadStatus(d.id)}:${modelStateSignature(
           manager.getCachedBackendState(d.id)
-        )}`
+        )}:${Object.keys(manager.getEffortCatalog(d.id) ?? {})
+          .sort()
+          .join(",")}`
       );
     }
     return parts.join("|");

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -904,8 +904,15 @@ export const RESTRICTION_MESSAGES = {
     `${extension.toUpperCase()} files are not supported in the current mode.`,
 } as const;
 
-export const OPENCODE_PINNED_VERSION = "1.15.11";
+export const OPENCODE_PINNED_VERSION = "1.15.13";
 export const OPENCODE_RELEASE_TAG = `v${OPENCODE_PINNED_VERSION}`;
+/**
+ * Minimum opencode the plugin supports. v1.15.13 (PR sst/opencode#29929,
+ * "promote next ACP implementation") dropped the dedicated ACP `models` state
+ * and moved the model catalog to a `category:"model"` config option; older
+ * binaries report no models to our picker, so we force an upgrade.
+ */
+export const OPENCODE_MIN_ACP_VERSION = "1.15.13";
 export const OPENCODE_RELEASE_URL_TEMPLATE =
   "https://github.com/sst/opencode/releases/download/v{version}/{asset}";
 export const OPENCODE_RELEASE_API_URL_TEMPLATE =

--- a/src/utils/semver.test.ts
+++ b/src/utils/semver.test.ts
@@ -1,0 +1,25 @@
+import { compareSemver } from "./semver";
+
+describe("compareSemver", () => {
+  it("orders by major, minor, then patch", () => {
+    expect(compareSemver("1.15.11", "1.15.13")).toBeLessThan(0);
+    expect(compareSemver("1.15.13", "1.15.11")).toBeGreaterThan(0);
+    expect(compareSemver("1.16.0", "1.15.13")).toBeGreaterThan(0);
+    expect(compareSemver("2.0.0", "1.99.99")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for equal versions", () => {
+    expect(compareSemver("1.15.13", "1.15.13")).toBe(0);
+  });
+
+  it("ignores a leading v and any prerelease/build suffix", () => {
+    expect(compareSemver("v1.15.13", "1.15.13")).toBe(0);
+    expect(compareSemver("1.15.13-beta.1", "1.15.13")).toBe(0);
+    expect(compareSemver("1.15.13+build.7", "1.15.13")).toBe(0);
+  });
+
+  it("treats an unparseable version as the lowest (behind everything)", () => {
+    expect(compareSemver("garbage", "1.15.13")).toBeLessThan(0);
+    expect(compareSemver("", "0.0.1")).toBeLessThan(0);
+  });
+});

--- a/src/utils/semver.ts
+++ b/src/utils/semver.ts
@@ -1,0 +1,19 @@
+/**
+ * Compare two dotted version strings by numeric major/minor/patch, ignoring any
+ * leading `v` and any prerelease/build suffix (`v1.15.13-beta` compares as
+ * `1.15.13`). Returns a negative number when `a < b`, `0` when equal, and a
+ * positive number when `a > b`. A version with no parseable `x.y.z` sorts as
+ * the lowest, so callers treat a malformed/unknown version as "behind".
+ */
+export function compareSemver(a: string, b: string): number {
+  const parse = (v: string): [number, number, number] => {
+    const m = v.match(/(\d+)\.(\d+)\.(\d+)/);
+    return m ? [Number(m[1]), Number(m[2]), Number(m[3])] : [0, 0, 0];
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i];
+  }
+  return 0;
+}


### PR DESCRIPTION
Fixes the agent-mode bug from #2547 where opencode BYOK models showed as "Not offered by agent" and the selected model rendered as a raw provider UUID that failed to run. The cause: opencode 1.15.13 ([sst/opencode#29929](https://github.com/sst/opencode/pull/29929), "promote next ACP implementation") dropped the dedicated ACP `models` state and moved the model catalog into a `category:"model"` config option, which the plugin never read. This PR derives the catalog from that config option when `models` is absent and routes model switching through `session/set_config_option` (via a new `ModelState.apply` spec), with codex/claude unaffected. It also pins the managed binary to 1.15.13 and prompts users on older opencode to upgrade — managed reinstall or `opencode upgrade` for a custom binary — from both the chat view and the configure dialog. Verified with `tsc`, eslint, the production esbuild build, and the full jest suite (all green, plus new tests for the config-option catalog, the apply spec, `applyModelWireId` dispatch, and a `compareSemver` util).

🤖 Generated with [Claude Code](https://claude.com/claude-code)