### PR TITLE
feat(relevant-notes): dedicated pane with redesigned populated view

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Type `/` to use Command Palette in chat window.
 
 #### **Relevant Notes: notes suggestions based on semantic similarity and links**
 
-Appears automatically when there's useful related content and links.
+Open it from the command palette (**Open Relevant Notes**) to get its own pane that surfaces related content and links for whatever note you're viewing.
 
 Use it to quickly reference past research, ideas, or decisions—no need to search or switch tabs.
 

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -9,19 +9,24 @@ The Copilot chat panel is the main way you interact with AI in Obsidian. This gu
 Copilot offers four modes. You can switch between them using the mode selector at the top of the chat panel.
 
 ### Chat
+
 General-purpose conversation. Good for writing, brainstorming, summarizing, or any task where you want to talk to an AI. Your currently open note and selected text are automatically included as context.
 
 ### Vault QA (Basic)
+
 Ask questions about your vault content. Copilot uses lexical search (keyword matching) to find relevant notes and passes them as context to the AI. No indexing required. Good for quick questions about your notes.
 
 ### Copilot Plus
+
 The most powerful mode. Requires a [Copilot Plus](copilot-plus-and-self-host.md) license. Combines Chat and Vault QA with an autonomous agent that can:
+
 - Search your vault and the web
 - Read and edit notes
 - Remember things across conversations
 - Use a growing set of tools automatically
 
 ### Projects (alpha)
+
 Focused workspaces with their own context, model, system prompt, and isolated chat history. Useful for keeping separate AI conversations per project. See [Projects](projects.md) for details.
 
 ---
@@ -45,6 +50,7 @@ Copilot adds the note's content to your message as context in the background. Th
 ### User Message Buttons
 
 Each message you send has action buttons that appear on hover:
+
 - **Edit** — Modify your prompt. Press Enter to re-send the edited message to the AI.
 - **Copy** — Copy the message text to clipboard
 - **Delete** — Remove this message from the conversation
@@ -52,6 +58,7 @@ Each message you send has action buttons that appear on hover:
 ### AI Message Buttons
 
 Each AI response has action buttons:
+
 - **Insert at cursor** — Insert the AI's response at your cursor position in the active note
 - **Replace at cursor** — Replace the selected text in your note with the AI's response
 - **Copy** — Copy the response to clipboard
@@ -77,6 +84,7 @@ The filename template controls how saved chats are named. The default is:
 ```
 
 Where:
+
 - `{$topic}` — An AI-generated title (or the first few words of your first message if AI titles are off)
 - `{$date}` — Date in YYYY-MM-DD format
 - `{$time}` — Time in HH-MM-SS format
@@ -90,6 +98,7 @@ When **Generate AI chat title on save** is enabled (default), Copilot asks the A
 ### Loading Previous Chats
 
 Click the **clock/history icon** in the chat panel toolbar to open the Chat History list. You can:
+
 - Browse previous conversations
 - Click a conversation to load it and continue from where you left off
 - Delete conversations you no longer need
@@ -130,9 +139,9 @@ When starting a new chat, Copilot may show suggested prompts based on your activ
 
 ## Relevant Notes
 
-Copilot can display a list of notes related to your currently active note in the chat panel. This helps surface notes you might want to reference without manually searching.
+Copilot can display a list of notes related to your currently active note. This helps surface notes you might want to reference without manually searching. Each note can be opened, dragged in as a wikilink, or sent to the open chat with **Add to Chat**.
 
-Enable in **Settings → Copilot → Basic → Relevant Notes** (on by default).
+Relevant Notes lives in its own pane. Open it from the command palette: **Open Relevant Notes**. The pane tracks whichever note you're viewing.
 
 ## Saving a Chat Manually
 
@@ -143,6 +152,7 @@ If autosave is off, or you want to save mid-conversation, click the **Save Chat 
 ## New Chat Behavior
 
 Click the **pencil/new chat icon** to start a fresh conversation. This:
+
 1. Saves the current conversation (if autosave is enabled)
 2. Clears the chat window
 3. Resets the context to your currently active note

--- a/docs/models-and-parameters.md
+++ b/docs/models-and-parameters.md
@@ -98,7 +98,7 @@ If you change embedding models, you must rebuild the vault index because the old
 
 - **Vault QA mode** — Uses embeddings to find relevant notes by meaning
 - **Semantic Search** — The "Enable Semantic Search" toggle in QA settings
-- **Relevant Notes** — Shows semantically similar notes in the sidebar
+- **Relevant Notes** — Shows semantically similar notes in its own pane (command palette: **Open Relevant Notes**)
 
 ---
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -39,9 +39,7 @@ describe("builtin Copilot Plus skills", () => {
       // SKILL.md tells the agent to prefer sh, fall back to node, then prompt
       // for a Node install if neither runtime is available.
       expect(skill.skillMd).toContain(`sh "/absolute/path/to/this/skill/directory/${sh!.path}"`);
-      expect(skill.skillMd).toContain(
-        `node "/absolute/path/to/this/skill/directory/${mjs!.path}"`
-      );
+      expect(skill.skillMd).toContain(`node "/absolute/path/to/this/skill/directory/${mjs!.path}"`);
       expect(skill.skillMd).toContain("install Node.js");
     }
   });

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -14,7 +14,7 @@ import { useSessionBackendDescriptor } from "@/agentMode/ui/useBackendDescriptor
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import { EVENT_NAMES } from "@/constants";
-import { AppContext, EventTargetContext } from "@/context";
+import { AppContext, ChatViewEventTarget, EventTargetContext } from "@/context";
 import { ChatInputProvider, useChatInput } from "@/context/ChatInputContext";
 import { useChatFileDrop } from "@/hooks/useChatFileDrop";
 import { logError } from "@/logger";
@@ -61,13 +61,19 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   const chatInput = useChatInput();
 
   // Insert text routed from outside the chat (e.g. the Relevant Notes pane's
-  // "Add to Chat") into the active session's composer.
+  // "Add to Chat") into the active session's composer. The bus latches text
+  // queued before this listener attaches, so a freshly-opened view still
+  // receives it on mount.
   useEffect(() => {
+    const bus = eventTarget instanceof ChatViewEventTarget ? eventTarget : null;
     const handleInsertText = (e: Event) => {
+      bus?.consumePendingInsertText();
       const text = (e as CustomEvent<{ text?: string }>).detail?.text;
       if (typeof text === "string") chatInput.insertTextWithPills(text, true);
     };
     eventTarget?.addEventListener(EVENT_NAMES.INSERT_TEXT_TO_CHAT, handleInsertText);
+    const pending = bus?.consumePendingInsertText();
+    if (typeof pending === "string") chatInput.insertTextWithPills(pending, true);
     return () => {
       eventTarget?.removeEventListener(EVENT_NAMES.INSERT_TEXT_TO_CHAT, handleInsertText);
     };

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -13,8 +13,9 @@ import { useAgentModePicker } from "@/agentMode/ui/useAgentModePicker";
 import { useSessionBackendDescriptor } from "@/agentMode/ui/useBackendDescriptor";
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
-import { AppContext } from "@/context";
-import { ChatInputProvider } from "@/context/ChatInputContext";
+import { EVENT_NAMES } from "@/constants";
+import { AppContext, EventTargetContext } from "@/context";
+import { ChatInputProvider, useChatInput } from "@/context/ChatInputContext";
 import { useChatFileDrop } from "@/hooks/useChatFileDrop";
 import { logError } from "@/logger";
 import type CopilotPlugin from "@/main";
@@ -56,6 +57,21 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   const appContext = useContext(AppContext);
   const app = plugin.app || appContext;
   const settings = useSettingsValue();
+  const eventTarget = useContext(EventTargetContext);
+  const chatInput = useChatInput();
+
+  // Insert text routed from outside the chat (e.g. the Relevant Notes pane's
+  // "Add to Chat") into the active session's composer.
+  useEffect(() => {
+    const handleInsertText = (e: Event) => {
+      const text = (e as CustomEvent<{ text?: string }>).detail?.text;
+      if (typeof text === "string") chatInput.insertTextWithPills(text, true);
+    };
+    eventTarget?.addEventListener(EVENT_NAMES.INSERT_TEXT_TO_CHAT, handleInsertText);
+    return () => {
+      eventTarget?.removeEventListener(EVENT_NAMES.INSERT_TEXT_TO_CHAT, handleInsertText);
+    };
+  }, [eventTarget, chatInput]);
 
   const {
     messages,

--- a/src/agentMode/ui/CopilotAgentView.tsx
+++ b/src/agentMode/ui/CopilotAgentView.tsx
@@ -2,7 +2,7 @@ import { AgentModeChat } from "@/agentMode/ui/AgentModeChat";
 import { attachChatViewLayoutObservers } from "@/components/chat-components/attachChatViewLayoutObservers";
 import { ChatViewLayout } from "@/components/chat-components/ChatViewLayout";
 import { CHAT_AGENT_VIEWTYPE, COPILOT_AGENT_ICON_ID } from "@/constants";
-import { EventTargetContext } from "@/context";
+import { ChatViewEventTarget, EventTargetContext } from "@/context";
 import CopilotPlugin from "@/main";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
 import * as Tooltip from "@radix-ui/react-tooltip";
@@ -15,7 +15,7 @@ export default class CopilotAgentView extends ItemView {
   private handleSaveAsNote: (() => Promise<void>) | null = null;
   private layout: ChatViewLayout | null = null;
   private disposeLayoutObservers: (() => void) | null = null;
-  eventTarget: EventTarget;
+  eventTarget: ChatViewEventTarget;
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -23,7 +23,7 @@ export default class CopilotAgentView extends ItemView {
   ) {
     super(leaf);
     this.app = plugin.app;
-    this.eventTarget = new EventTarget();
+    this.eventTarget = new ChatViewEventTarget();
     this.plugin = plugin;
   }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -118,6 +118,10 @@ export function registerCommands(plugin: CopilotPlugin) {
     await plugin.activateView();
   });
 
+  addCommand(plugin, COMMAND_IDS.OPEN_RELEVANT_NOTES_VIEW, async () => {
+    await plugin.activateRelevantNotesView();
+  });
+
   addCommand(plugin, COMMAND_IDS.NEW_CHAT, async () => {
     clearRecordedPromptPayload();
     await plugin.newChat();

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -644,6 +644,19 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
     };
   }, [eventTarget, chatInput]);
 
+  // Insert text routed from outside the chat (e.g. the Relevant Notes pane's
+  // "Add to Chat") into this chat's input.
+  useEffect(() => {
+    const handleInsertText = (e: Event) => {
+      const text = (e as CustomEvent<{ text?: string }>).detail?.text;
+      if (typeof text === "string") chatInput.insertTextWithPills(text, true);
+    };
+    eventTarget?.addEventListener(EVENT_NAMES.INSERT_TEXT_TO_CHAT, handleInsertText);
+    return () => {
+      eventTarget?.removeEventListener(EVENT_NAMES.INSERT_TEXT_TO_CHAT, handleInsertText);
+    };
+  }, [eventTarget, chatInput]);
+
   const handleDelete = useCallback(
     async (messageIndex: number) => {
       const messageToDelete = chatHistory[messageIndex];

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -31,7 +31,7 @@ import {
   RESTRICTION_MESSAGES,
   USER_SENDER,
 } from "@/constants";
-import { AppContext, EventTargetContext } from "@/context";
+import { AppContext, ChatViewEventTarget, EventTargetContext } from "@/context";
 import { ChatInputProvider, useChatInput } from "@/context/ChatInputContext";
 import { useChatManager } from "@/hooks/useChatManager";
 import { useChatFileDrop } from "@/hooks/useChatFileDrop";
@@ -645,13 +645,18 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
   }, [eventTarget, chatInput]);
 
   // Insert text routed from outside the chat (e.g. the Relevant Notes pane's
-  // "Add to Chat") into this chat's input.
+  // "Add to Chat") into this chat's input. The bus latches text queued before
+  // this listener attaches, so a freshly-opened view still receives it on mount.
   useEffect(() => {
+    const bus = eventTarget instanceof ChatViewEventTarget ? eventTarget : null;
     const handleInsertText = (e: Event) => {
+      bus?.consumePendingInsertText();
       const text = (e as CustomEvent<{ text?: string }>).detail?.text;
       if (typeof text === "string") chatInput.insertTextWithPills(text, true);
     };
     eventTarget?.addEventListener(EVENT_NAMES.INSERT_TEXT_TO_CHAT, handleInsertText);
+    const pending = bus?.consumePendingInsertText();
+    if (typeof pending === "string") chatInput.insertTextWithPills(pending, true);
     return () => {
       eventTarget?.removeEventListener(EVENT_NAMES.INSERT_TEXT_TO_CHAT, handleInsertText);
     };

--- a/src/components/CopilotView.tsx
+++ b/src/components/CopilotView.tsx
@@ -2,7 +2,7 @@ import ChainManager from "@/LLMProviders/chainManager";
 import Chat from "@/components/Chat";
 import { ChatViewLayout } from "@/components/chat-components/ChatViewLayout";
 import { CHAT_VIEWTYPE } from "@/constants";
-import { EventTargetContext } from "@/context";
+import { ChatViewEventTarget, EventTargetContext } from "@/context";
 import CopilotPlugin from "@/main";
 import { FileParserManager } from "@/tools/FileParserManager";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
@@ -24,7 +24,7 @@ export default class CopilotView extends ItemView {
   private layout: ChatViewLayout | null = null;
   private lastDrawerEl: HTMLElement | null = null;
   private windowMigrationDestroy: (() => void) | null = null;
-  eventTarget: EventTarget;
+  eventTarget: ChatViewEventTarget;
 
   constructor(
     leaf: WorkspaceLeaf,
@@ -33,7 +33,7 @@ export default class CopilotView extends ItemView {
     super(leaf);
     this.app = plugin.app;
     this.fileParserManager = plugin.fileParserManager;
-    this.eventTarget = new EventTarget();
+    this.eventTarget = new ChatViewEventTarget();
     this.plugin = plugin;
   }
 

--- a/src/components/RelevantNotesView.tsx
+++ b/src/components/RelevantNotesView.tsx
@@ -10,11 +10,11 @@ import { Root } from "react-dom/client";
 /**
  * Standalone pane for the Relevant Notes panel, isolated from the chat views.
  *
- * `RelevantNotes` reads the active file via `useActiveFile`, which is driven by
- * the `ACTIVE_LEAF_CHANGE` event on this view's own `eventTarget`. The plugin's
- * global handler dispatches that event only to the legacy chat view, so this
- * view feeds its own `eventTarget` (mirroring that handler's condition) and
- * fires once on open to populate for the currently-active note.
+ * `RelevantNotes` reads the active file via `useActiveFile`, which seeds from
+ * the current active file on mount and then updates on the `ACTIVE_LEAF_CHANGE`
+ * event on this view's own `eventTarget`. The plugin's global handler dispatches
+ * that event only to the legacy chat view, so this view feeds its own
+ * `eventTarget` (mirroring that handler's condition) on subsequent leaf changes.
  */
 export default class RelevantNotesView extends ItemView {
   private root: Root | null = null;
@@ -56,13 +56,6 @@ export default class RelevantNotesView extends ItemView {
         }
       })
     );
-
-    // Initialize with the currently-active note once the React listener has
-    // attached. Mirrors the 50ms `activateView → emitChatIsVisible` delay the
-    // plugin already uses to wait out a freshly-mounted view's effects.
-    window.setTimeout(() => {
-      this.eventTarget.dispatchEvent(new CustomEvent(EVENT_NAMES.ACTIVE_LEAF_CHANGE));
-    }, 50);
   }
 
   private renderView(): void {

--- a/src/components/RelevantNotesView.tsx
+++ b/src/components/RelevantNotesView.tsx
@@ -1,0 +1,86 @@
+import { RelevantNotes } from "@/components/chat-components/RelevantNotes";
+import { EVENT_NAMES, RELEVANT_NOTES_VIEWTYPE } from "@/constants";
+import { EventTargetContext } from "@/context";
+import CopilotPlugin from "@/main";
+import { createPluginRoot } from "@/utils/react/createPluginRoot";
+import { ItemView, MarkdownView, WorkspaceLeaf } from "obsidian";
+import * as React from "react";
+import { Root } from "react-dom/client";
+
+/**
+ * Standalone pane for the Relevant Notes panel, isolated from the chat views.
+ *
+ * `RelevantNotes` reads the active file via `useActiveFile`, which is driven by
+ * the `ACTIVE_LEAF_CHANGE` event on this view's own `eventTarget`. The plugin's
+ * global handler dispatches that event only to the legacy chat view, so this
+ * view feeds its own `eventTarget` (mirroring that handler's condition) and
+ * fires once on open to populate for the currently-active note.
+ */
+export default class RelevantNotesView extends ItemView {
+  private root: Root | null = null;
+  eventTarget: EventTarget;
+
+  constructor(
+    leaf: WorkspaceLeaf,
+    private plugin: CopilotPlugin
+  ) {
+    super(leaf);
+    this.app = plugin.app;
+    this.eventTarget = new EventTarget();
+  }
+
+  getViewType(): string {
+    return RELEVANT_NOTES_VIEWTYPE;
+  }
+
+  getIcon(): string {
+    return "files";
+  }
+
+  getTitle(): string {
+    return "Copilot Relevant Notes";
+  }
+
+  getDisplayText(): string {
+    return "Copilot Relevant Notes";
+  }
+
+  async onOpen(): Promise<void> {
+    this.root = createPluginRoot(this.containerEl.children[1], this.app);
+    this.renderView();
+
+    this.registerEvent(
+      this.app.workspace.on("active-leaf-change", (leaf) => {
+        if (leaf?.view instanceof MarkdownView && leaf.view.file) {
+          this.eventTarget.dispatchEvent(new CustomEvent(EVENT_NAMES.ACTIVE_LEAF_CHANGE));
+        }
+      })
+    );
+
+    // Initialize with the currently-active note once the React listener has
+    // attached. Mirrors the 50ms `activateView → emitChatIsVisible` delay the
+    // plugin already uses to wait out a freshly-mounted view's effects.
+    window.setTimeout(() => {
+      this.eventTarget.dispatchEvent(new CustomEvent(EVENT_NAMES.ACTIVE_LEAF_CHANGE));
+    }, 50);
+  }
+
+  private renderView(): void {
+    if (!this.root) return;
+
+    this.root.render(
+      <EventTargetContext.Provider value={this.eventTarget}>
+        <div className="tw-flex tw-size-full tw-flex-col tw-overflow-hidden">
+          <RelevantNotes onAddToChat={(text) => void this.plugin.insertTextIntoActiveChat(text)} />
+        </div>
+      </EventTargetContext.Provider>
+    );
+  }
+
+  async onClose(): Promise<void> {
+    if (this.root) {
+      this.root.unmount();
+      this.root = null;
+    }
+  }
+}

--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -20,7 +20,6 @@ import {
   CheckCircle,
   ChevronDown,
   Download,
-  FileText,
   History,
   LibraryBig,
   MessageCirclePlus,
@@ -394,19 +393,6 @@ export function ChatControls({
                 Suggested Prompt
               </div>
               <SettingSwitch checked={settings.showSuggestedPrompts} />
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="tw-flex tw-justify-between"
-              onSelect={(e) => {
-                e.preventDefault();
-                updateSetting("showRelevantNotes", !settings.showRelevantNotes);
-              }}
-            >
-              <div className="tw-flex tw-items-center tw-gap-2">
-                <FileText className="tw-size-4" />
-                Relevant Note
-              </div>
-              <SettingSwitch checked={settings.showRelevantNotes} />
             </DropdownMenuItem>
             <DropdownMenuItem
               className="tw-flex tw-justify-between"

--- a/src/components/chat-components/ChatMessages.tsx
+++ b/src/components/chat-components/ChatMessages.tsx
@@ -1,6 +1,5 @@
 import { BottomLoadingIndicator } from "@/components/chat-components/BottomLoadingIndicator";
 import ChatSingleMessage from "@/components/chat-components/ChatSingleMessage";
-import { RelevantNotes } from "@/components/chat-components/RelevantNotes";
 import { SuggestedPrompts } from "@/components/chat-components/SuggestedPrompts";
 import { USER_SENDER } from "@/constants";
 import { useChatScrolling } from "@/hooks/useChatScrolling";
@@ -48,9 +47,6 @@ const ChatMessages = memo(
     if (!chatHistory.filter((message) => message.isVisible).length && !currentAiMessage) {
       return (
         <div className="tw-flex tw-size-full tw-flex-col tw-gap-2 tw-overflow-y-auto">
-          {showHelperComponents && settings.showRelevantNotes && (
-            <RelevantNotes defaultOpen={true} key="relevant-notes-before-chat" />
-          )}
           {showHelperComponents && settings.showSuggestedPrompts && (
             <SuggestedPrompts onClick={onReplaceChat} />
           )}
@@ -61,9 +57,6 @@ const ChatMessages = memo(
 
     return (
       <div className="tw-flex tw-h-full tw-flex-1 tw-flex-col tw-overflow-hidden">
-        {showHelperComponents && settings.showRelevantNotes && (
-          <RelevantNotes className="tw-mb-4" defaultOpen={false} key="relevant-notes-in-chat" />
-        )}
         <div
           ref={scrollContainerCallbackRef}
           data-testid="chat-messages"

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -157,8 +157,7 @@ function RelevantNoteHoverCard({
         }
       }
 
-      // Take first 1000 characters as preview
-      setFileContent(cleanContent.slice(0, 1000) + (cleanContent.length > 1000 ? "..." : ""));
+      setFileContent(cleanContent);
     }
   }, [app, fileContent, note.note.path]);
 
@@ -193,7 +192,7 @@ function RelevantNoteHoverCard({
         </div>
 
         {fileContent && (
-          <p className="tw-m-0 tw-line-clamp-4 tw-whitespace-pre-line tw-text-xs tw-leading-normal tw-text-muted">
+          <p className="tw-m-0 tw-max-h-64 tw-overflow-y-auto tw-whitespace-pre-line tw-text-xs tw-leading-normal tw-text-muted">
             {fileContent}
           </p>
         )}

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -11,8 +11,11 @@ import { logError, logWarn } from "@/logger";
 import { shouldUseMiyo } from "@/miyo/miyoUtils";
 import { findRelevantNotes, RelevantNoteEntry } from "@/search/findRelevantNotes";
 import { onIndexChanged } from "@/search/indexSignal";
+import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
+import { useSettingsValue } from "@/settings/model";
 import {
   ArrowRight,
+  EyeOff,
   FileInput,
   FileOutput,
   FileText,
@@ -22,7 +25,7 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { TFile } from "obsidian";
-import React, { memo, useCallback, useEffect, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 
 function useRelevantNotes(refresher: number) {
   const app = useApp();
@@ -84,13 +87,9 @@ function useHasIndex(notePath: string, refresher: number) {
   return hasIndex;
 }
 
-/**
- * Map a 0–1 similarity score to a meter fill width (clamped 8–100%) so even weak
- * matches stay visible.
- */
+/** Map a 0–1 similarity score directly to the meter fill width (70% → 70%). */
 function meterWidth(score: number): string {
-  const pct = score * 100;
-  return `${Math.max(8, Math.min(100, ((pct - 25) / 50) * 100))}%`;
+  return `${Math.max(0, Math.min(100, score * 100))}%`;
 }
 
 /** Color-grade the meter: stronger matches lean fully into the theme accent. */
@@ -113,6 +112,17 @@ function RelevanceMeter({ score, className }: { score: number; className?: strin
         style={{ width: meterWidth(score), background: meterColor(score) }}
       />
     </div>
+  );
+}
+
+function LinkBadge({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <span
+      title={label}
+      className="tw-flex tw-items-center tw-justify-center tw-rounded-sm tw-bg-modifier-hover tw-p-1 tw-text-faint"
+    >
+      {icon}
+    </span>
   );
 }
 
@@ -183,7 +193,7 @@ function RelevantNoteHoverCard({
         </div>
 
         {fileContent && (
-          <p className="tw-m-0 tw-line-clamp-4 tw-text-xs tw-leading-normal tw-text-muted">
+          <p className="tw-m-0 tw-line-clamp-4 tw-whitespace-pre-line tw-text-xs tw-leading-normal tw-text-muted">
             {fileContent}
           </p>
         )}
@@ -242,12 +252,10 @@ function RelevantNoteHoverCard({
 
 function RelevantNoteRow({
   note,
-  isTop,
   onAddToChat,
   onNavigateToNote,
 }: {
   note: RelevantNoteEntry;
-  isTop: boolean;
   onAddToChat: () => void;
   onNavigateToNote: (openInNewLeaf: boolean) => void;
 }) {
@@ -261,8 +269,8 @@ function RelevantNoteRow({
       onAddToChat={onAddToChat}
       onNavigateToNote={onNavigateToNote}
     >
-      <div className="tw-group tw-relative tw-rounded-md tw-px-2.5 tw-py-1.5 tw-transition-colors hover:tw-bg-modifier-hover">
-        <div className="tw-flex tw-items-center tw-gap-2">
+      <div className="tw-group tw-rounded-md tw-px-2.5 tw-py-1.5 tw-transition-colors hover:tw-bg-modifier-hover">
+        <div className="tw-flex tw-min-h-6 tw-items-center tw-gap-2">
           <a
             draggable
             onDragStart={(e) => {
@@ -287,19 +295,21 @@ function RelevantNoteRow({
             {note.note.title}
           </a>
 
-          {isTop && similarity != null && (
-            <span className="tw-shrink-0 tw-rounded-sm tw-px-1.5 tw-py-0.5 tw-text-smallest tw-font-bold tw-uppercase tw-tracking-wide tw-text-accent tw-bg-interactive-accent/20">
-              Best
-            </span>
-          )}
+          <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-1.5 group-hover:tw-hidden">
+            {note.metadata.hasOutgoingLinks && (
+              <LinkBadge icon={<FileOutput className="tw-size-3" />} label="Outgoing link" />
+            )}
+            {note.metadata.hasBacklinks && (
+              <LinkBadge icon={<FileInput className="tw-size-3" />} label="Backlink" />
+            )}
+            {similarity != null && (
+              <span className="tw-text-xs tw-font-medium tw-tabular-nums tw-text-muted">
+                {Math.round(similarity * 100)}%
+              </span>
+            )}
+          </div>
 
-          {similarity != null && (
-            <span className="tw-shrink-0 tw-text-xs tw-font-medium tw-tabular-nums tw-text-muted tw-transition-opacity group-hover:tw-opacity-0">
-              {Math.round(similarity * 100)}%
-            </span>
-          )}
-
-          <div className="tw-absolute tw-right-2 tw-top-1/2 tw-flex -tw-translate-y-1/2 tw-gap-0.5 tw-opacity-0 tw-transition-opacity group-hover:tw-opacity-100">
+          <div className="tw-hidden tw-shrink-0 tw-items-center tw-gap-0.5 group-hover:tw-flex">
             <Button
               variant="ghost2"
               size="icon"
@@ -400,6 +410,20 @@ export const RelevantNotes = memo(
     const activeFile = useActiveFile();
     const hasIndex = useHasIndex(activeFile?.path ?? "", refresher);
     const [indexingState] = useIndexingProgress();
+    const settings = useSettingsValue();
+
+    // The active note itself is excluded from the index (by the QA
+    // inclusion/exclusion settings or an internal exclusion), so no relevant
+    // notes can ever be computed for it — surface that instead of a build
+    // prompt or a bare "none found".
+    const isActiveFileExcluded = useMemo(() => {
+      if (!activeFile) return false;
+      const { inclusions, exclusions } = getMatchingPatterns({
+        inclusions: settings.qaInclusions,
+        exclusions: settings.qaExclusions,
+      });
+      return !shouldIndexFile(app, activeFile, inclusions, exclusions);
+    }, [app, activeFile, settings.qaInclusions, settings.qaExclusions]);
     const navigateToNote = (notePath: string, openInNewLeaf = false) => {
       const file = app.vault.getAbstractFileByPath(notePath);
       if (file instanceof TFile) {
@@ -441,7 +465,26 @@ export const RelevantNotes = memo(
 
     return (
       <div className={cn("tw-flex tw-min-h-full tw-w-full tw-flex-1 tw-flex-col", className)}>
-        {!hasIndex && (
+        {isActiveFileExcluded && (
+          <div className="tw-flex tw-flex-1 tw-flex-col tw-items-center tw-justify-center tw-px-6">
+            <div className="tw-flex tw-w-full tw-max-w-xs tw-flex-col tw-items-center tw-gap-6 tw-text-center">
+              <div className="tw-flex tw-size-16 tw-items-center tw-justify-center tw-rounded-xl tw-border tw-border-solid tw-border-border tw-bg-secondary">
+                <EyeOff className="tw-size-7 tw-text-muted" />
+              </div>
+              <div className="tw-flex tw-flex-col tw-gap-1.5">
+                <span className="tw-text-lg tw-font-semibold tw-text-normal">
+                  This note is excluded
+                </span>
+                <span className="tw-text-sm tw-text-muted">
+                  It falls outside your semantic index settings, so related notes can&apos;t be
+                  shown here. Adjust inclusions or exclusions in Copilot settings to include it.
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {!isActiveFileExcluded && !hasIndex && (
           <div className="tw-flex tw-flex-1 tw-flex-col tw-items-center tw-justify-center tw-px-6">
             <div className="tw-flex tw-w-full tw-max-w-xs tw-flex-col tw-items-center tw-gap-6 tw-text-center">
               <div className="tw-flex tw-size-16 tw-items-center tw-justify-center tw-rounded-xl tw-border tw-border-solid tw-border-border tw-bg-secondary">
@@ -469,7 +512,7 @@ export const RelevantNotes = memo(
           </div>
         )}
 
-        {hasIndex && (
+        {!isActiveFileExcluded && hasIndex && (
           <>
             <RelevantNotesToolbar
               activeFileName={activeFile?.basename}
@@ -484,11 +527,10 @@ export const RelevantNotes = memo(
                   </div>
                 ) : (
                   <div className="tw-flex tw-flex-col tw-gap-0.5">
-                    {relevantNotes.map((note, i) => (
+                    {relevantNotes.map((note) => (
                       <RelevantNoteRow
                         key={note.note.path}
                         note={note}
-                        isTop={i === 0}
                         onAddToChat={() => addToChat(note.note.title)}
                         onNavigateToNote={(openInNewLeaf: boolean) =>
                           navigateToNote(note.note.path, openInNewLeaf)

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -108,8 +108,13 @@ function RelevanceMeter({ score, className }: { score: number; className?: strin
       )}
     >
       <div
-        className="tw-h-full tw-rounded-full"
-        style={{ width: meterWidth(score), background: meterColor(score) }}
+        className={cn("copilot-relevance-meter-fill tw-h-full tw-rounded-full")}
+        style={
+          {
+            "--relevance-meter-fill": meterWidth(score),
+            "--relevance-meter-color": meterColor(score),
+          } as React.CSSProperties
+        }
       />
     </div>
   );

--- a/src/components/chat-components/RelevantNotes.tsx
+++ b/src/components/chat-components/RelevantNotes.tsx
@@ -1,34 +1,27 @@
-import { Badge } from "@/components/ui/badge";
+import { useIndexingProgress } from "@/aiParams";
+import { SemanticSearchToggleModal } from "@/components/modals/SemanticSearchToggleModal";
 import { Button } from "@/components/ui/button";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { Progress } from "@/components/ui/progress";
 import { useApp } from "@/context";
-import { HelpTooltip } from "@/components/ui/help-tooltip";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { useChatInput } from "@/context/ChatInputContext";
 import { useActiveFile } from "@/hooks/useActiveFile";
 import { useNoteDrag } from "@/hooks/useNoteDrag";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
-import { SemanticSearchToggleModal } from "@/components/modals/SemanticSearchToggleModal";
 import { shouldUseMiyo } from "@/miyo/miyoUtils";
-import {
-  findRelevantNotes,
-  getSimilarityCategory,
-  RelevantNoteEntry,
-} from "@/search/findRelevantNotes";
+import { findRelevantNotes, RelevantNoteEntry } from "@/search/findRelevantNotes";
 import { onIndexChanged } from "@/search/indexSignal";
 import {
   ArrowRight,
-  ChevronDown,
-  ChevronRight,
-  ChevronUp,
   FileInput,
   FileOutput,
+  FileText,
+  GitFork,
+  Loader2,
   PlusCircle,
-  RefreshCcw,
+  RefreshCw,
 } from "lucide-react";
-import { Notice, TFile } from "obsidian";
+import { TFile } from "obsidian";
 import React, { memo, useCallback, useEffect, useState } from "react";
 
 function useRelevantNotes(refresher: number) {
@@ -91,30 +84,56 @@ function useHasIndex(notePath: string, refresher: number) {
   return hasIndex;
 }
 
-function SimilarityBadge({ score }: { score: number }) {
-  const category = getSimilarityCategory(score);
-  let text = "🔴";
-  if (category === 2) text = "🟠";
-  if (category === 3) text = "🟢";
-  return <span className="tw-text-sm">{text}</span>;
+/**
+ * Map a 0–1 similarity score to a meter fill width (clamped 8–100%) so even weak
+ * matches stay visible.
+ */
+function meterWidth(score: number): string {
+  const pct = score * 100;
+  return `${Math.max(8, Math.min(100, ((pct - 25) / 50) * 100))}%`;
 }
 
-function RelevantNote({
+/** Color-grade the meter: stronger matches lean fully into the theme accent. */
+function meterColor(score: number): string {
+  const pct = score * 100;
+  const k = Math.max(0, Math.min(1, (pct - 30) / 45));
+  return `color-mix(in srgb, var(--interactive-accent) ${Math.round(40 + 60 * k)}%, var(--text-faint))`;
+}
+
+function RelevanceMeter({ score, className }: { score: number; className?: string }) {
+  return (
+    <div
+      className={cn(
+        "tw-h-[3px] tw-w-full tw-overflow-hidden tw-rounded-full tw-bg-modifier-hover",
+        className
+      )}
+    >
+      <div
+        className="tw-h-full tw-rounded-full"
+        style={{ width: meterWidth(score), background: meterColor(score) }}
+      />
+    </div>
+  );
+}
+
+function RelevantNoteHoverCard({
   note,
   onAddToChat,
   onNavigateToNote,
+  children,
 }: {
   note: RelevantNoteEntry;
   onAddToChat: () => void;
   onNavigateToNote: (openInNewLeaf: boolean) => void;
+  children: React.ReactNode;
 }) {
   const app = useApp();
-  const [isOpen, setIsOpen] = useState(false);
+  const [open, setOpen] = useState(false);
   const [fileContent, setFileContent] = useState<string | null>(null);
-  const handleDragStart = useNoteDrag();
+  const similarity = note.metadata.similarityScore;
 
   const loadContent = useCallback(async () => {
-    if (fileContent) return; // Don't load if we already have content
+    if (fileContent) return; // Don't reload once cached
     const file = app.vault.getAbstractFileByPath(note.note.path);
     if (file instanceof TFile) {
       const content = await app.vault.cachedRead(file);
@@ -134,33 +153,116 @@ function RelevantNote({
   }, [app, fileContent, note.note.path]);
 
   useEffect(() => {
-    if (isOpen) {
+    if (open) {
       void loadContent();
     }
-  }, [isOpen, loadContent]);
+  }, [open, loadContent]);
 
   return (
-    <Collapsible
-      open={isOpen}
-      onOpenChange={setIsOpen}
-      className="tw-rounded-md tw-border tw-border-solid tw-border-border"
-    >
-      <div className={cn("tw-flex tw-items-center tw-justify-between tw-gap-2 tw-p-2")}>
-        <Button variant="ghost2" size="icon" className="tw-shrink-0" asChild>
-          <CollapsibleTrigger>
-            <ChevronRight
-              className={cn("tw-size-4 tw-transition-transform tw-duration-200", {
-                "rotate-90": isOpen,
-              })}
-            />
-          </CollapsibleTrigger>
-        </Button>
-
-        <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-2">
-          <SimilarityBadge score={note.metadata.similarityScore ?? 0} />
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div onMouseEnter={() => setOpen(true)} onMouseLeave={() => setOpen(false)}>
+          {children}
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        side="left"
+        align="start"
+        sideOffset={0}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        className="tw-flex tw-w-fit tw-min-w-72 tw-max-w-96 tw-flex-col tw-gap-3 tw-overflow-hidden tw-p-3"
+      >
+        <div className="tw-flex tw-flex-col tw-gap-1">
+          <span className="tw-text-sm tw-font-semibold tw-text-normal">{note.note.title}</span>
+          <span className="tw-flex tw-items-center tw-gap-1.5 tw-text-xs tw-text-faint">
+            <FileText className="tw-size-3.5 tw-shrink-0" />
+            <span className="tw-truncate">{note.note.path}</span>
+          </span>
         </div>
 
-        <div className="tw-flex-1 tw-overflow-hidden">
+        {fileContent && (
+          <p className="tw-m-0 tw-line-clamp-4 tw-text-xs tw-leading-normal tw-text-muted">
+            {fileContent}
+          </p>
+        )}
+
+        {similarity != null && (
+          <div className="tw-flex tw-items-center tw-gap-2">
+            <span className="tw-shrink-0 tw-text-xs tw-text-faint">Similarity</span>
+            <RelevanceMeter score={similarity} className="tw-h-1 tw-flex-1" />
+            <span className="tw-shrink-0 tw-text-xs tw-font-medium tw-tabular-nums tw-text-normal">
+              {(similarity * 100).toFixed(1)}%
+            </span>
+          </div>
+        )}
+
+        {(note.metadata.hasOutgoingLinks || note.metadata.hasBacklinks) && (
+          <div className="tw-flex tw-items-center tw-gap-4 tw-text-xs tw-text-faint">
+            {note.metadata.hasOutgoingLinks && (
+              <span className="tw-flex tw-items-center tw-gap-1">
+                <FileOutput className="tw-size-3.5" />
+                Outgoing links
+              </span>
+            )}
+            {note.metadata.hasBacklinks && (
+              <span className="tw-flex tw-items-center tw-gap-1">
+                <FileInput className="tw-size-3.5" />
+                Backlinks
+              </span>
+            )}
+          </div>
+        )}
+
+        <div className="tw-flex tw-gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onAddToChat}
+            className="tw-flex-1 tw-gap-1.5"
+          >
+            <PlusCircle className="tw-size-4" />
+            Add to Chat
+          </Button>
+          <Button
+            variant="default"
+            size="sm"
+            onClick={(e) => onNavigateToNote(e.metaKey || e.ctrlKey)}
+            className="tw-flex-1 tw-gap-1.5"
+          >
+            Open note
+            <ArrowRight className="tw-size-4" />
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function RelevantNoteRow({
+  note,
+  isTop,
+  onAddToChat,
+  onNavigateToNote,
+}: {
+  note: RelevantNoteEntry;
+  isTop: boolean;
+  onAddToChat: () => void;
+  onNavigateToNote: (openInNewLeaf: boolean) => void;
+}) {
+  const app = useApp();
+  const handleDragStart = useNoteDrag();
+  const similarity = note.metadata.similarityScore;
+
+  return (
+    <RelevantNoteHoverCard
+      note={note}
+      onAddToChat={onAddToChat}
+      onNavigateToNote={onNavigateToNote}
+    >
+      <div className="tw-group tw-relative tw-rounded-md tw-px-2.5 tw-py-1.5 tw-transition-colors hover:tw-bg-modifier-hover">
+        <div className="tw-flex tw-items-center tw-gap-2">
           <a
             draggable
             onDragStart={(e) => {
@@ -171,120 +273,133 @@ function RelevantNote({
             }}
             onClick={(e) => {
               e.preventDefault();
-              const openInNewLeaf = e.metaKey || e.ctrlKey;
-              onNavigateToNote(openInNewLeaf);
+              onNavigateToNote(e.metaKey || e.ctrlKey);
             }}
             onAuxClick={(e) => {
               if (e.button === 1) {
-                // Middle click
+                // Middle click opens in a new leaf
                 e.preventDefault();
                 onNavigateToNote(true);
               }
             }}
-            className="tw-block tw-w-full tw-truncate tw-text-sm tw-font-bold tw-text-normal"
-            title={`${note.note.title} - drag to insert wikilink`}
+            className="tw-min-w-0 tw-flex-1 tw-cursor-pointer tw-truncate tw-text-sm tw-font-medium tw-text-normal !tw-no-underline"
           >
             {note.note.title}
           </a>
-        </div>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="ghost2" size="icon" onClick={onAddToChat} className="tw-shrink-0">
+          {isTop && similarity != null && (
+            <span className="tw-shrink-0 tw-rounded-sm tw-px-1.5 tw-py-0.5 tw-text-smallest tw-font-bold tw-uppercase tw-tracking-wide tw-text-accent tw-bg-interactive-accent/20">
+              Best
+            </span>
+          )}
+
+          {similarity != null && (
+            <span className="tw-shrink-0 tw-text-xs tw-font-medium tw-tabular-nums tw-text-muted tw-transition-opacity group-hover:tw-opacity-0">
+              {Math.round(similarity * 100)}%
+            </span>
+          )}
+
+          <div className="tw-absolute tw-right-2 tw-top-1/2 tw-flex -tw-translate-y-1/2 tw-gap-0.5 tw-opacity-0 tw-transition-opacity group-hover:tw-opacity-100">
+            <Button
+              variant="ghost2"
+              size="icon"
+              title="Add to Chat"
+              className="tw-size-6 tw-p-0"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAddToChat();
+              }}
+            >
               <PlusCircle className="tw-size-4" />
             </Button>
-          </TooltipTrigger>
-          <TooltipContent>Add to Chat</TooltipContent>
-        </Tooltip>
-      </div>
-
-      <CollapsibleContent>
-        <div className="tw-border-[0px] tw-border-t tw-border-solid tw-border-border tw-px-4 tw-py-2">
-          <div className="tw-whitespace-pre-wrap tw-text-wrap tw-break-all tw-text-xs tw-text-muted tw-opacity-75">
-            {note.note.path}
+            <Button
+              variant="ghost2"
+              size="icon"
+              title="Open note"
+              className="tw-size-6 tw-p-0"
+              onClick={(e) => {
+                e.stopPropagation();
+                onNavigateToNote(e.metaKey || e.ctrlKey);
+              }}
+            >
+              <ArrowRight className="tw-size-4" />
+            </Button>
           </div>
-          {fileContent && (
-            <div className="tw-overflow-hidden tw-whitespace-pre-wrap tw-border-t tw-border-border tw-pb-4 tw-pt-2 tw-text-xs tw-text-normal">
-              {fileContent}
-            </div>
-          )}
         </div>
 
-        <div className="tw-flex tw-items-center tw-gap-4 tw-border-[0px] tw-border-t tw-border-solid tw-border-border tw-px-4 tw-py-2 tw-text-xs tw-text-muted">
-          {note.metadata.similarityScore != null && (
-            <div className="tw-flex tw-items-center tw-gap-1">
-              <span>Similarity: {(note.metadata.similarityScore * 100).toFixed(1)}%</span>
-            </div>
-          )}
-          {note.metadata.hasOutgoingLinks && (
-            <div className="tw-flex tw-items-center tw-gap-1">
-              <FileOutput className="tw-size-4" />
-              <span>Outgoing links</span>
-            </div>
-          )}
-          {note.metadata.hasBacklinks && (
-            <div className="tw-flex tw-items-center tw-gap-1">
-              <FileInput className="tw-size-4" />
-              <span>Backlinks</span>
-            </div>
-          )}
-        </div>
-      </CollapsibleContent>
-    </Collapsible>
+        {similarity != null && <RelevanceMeter score={similarity} className="tw-mt-1.5" />}
+      </div>
+    </RelevantNoteHoverCard>
   );
 }
 
-function RelevantNotePopover({
-  note,
-  onAddToChat,
-  onNavigateToNote,
-  children,
+function RelevantNotesToolbar({
+  activeFileName,
+  isBuilding,
+  onBuild,
 }: {
-  note: RelevantNoteEntry;
-  onAddToChat: () => void;
-  onNavigateToNote: (openInNewLeaf: boolean) => void;
-  children: React.ReactNode;
+  activeFileName: string | undefined;
+  isBuilding: boolean;
+  onBuild: () => void;
 }) {
   return (
-    <Popover key={note.note.path}>
-      <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent className="tw-flex tw-w-fit tw-min-w-72 tw-max-w-96 tw-flex-col tw-gap-2 tw-overflow-hidden">
-        <span className="tw-text-sm tw-text-normal">{note.note.title}</span>
-        <span className="tw-text-xs tw-text-muted">{note.note.path}</span>
-        <div className="tw-flex tw-gap-2">
-          <button
-            type="button"
-            onClick={onAddToChat}
-            className="tw-inline-flex tw-items-center tw-gap-2 tw-border tw-border-solid tw-border-border !tw-bg-transparent !tw-shadow-none hover:!tw-bg-interactive-hover"
-          >
-            Add to Chat <PlusCircle className="tw-size-4" />
-          </button>
-          <button
-            type="button"
-            onClick={(e) => {
-              const openInNewLeaf = e.metaKey || e.ctrlKey;
-              onNavigateToNote(openInNewLeaf);
-            }}
-            className="tw-inline-flex tw-items-center tw-gap-2 tw-border tw-border-solid tw-border-border !tw-bg-transparent !tw-shadow-none hover:!tw-bg-interactive-hover"
-          >
-            Navigate to Note <ArrowRight className="tw-size-4" />
-          </button>
-        </div>
-      </PopoverContent>
-    </Popover>
+    <div className="tw-flex tw-flex-none tw-items-center tw-gap-2 tw-border-[0px] tw-border-b tw-border-solid tw-border-border tw-px-3 tw-py-2">
+      <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1.5 tw-text-xs tw-text-faint">
+        <span className="tw-shrink-0">Relevant to</span>
+        {activeFileName ? (
+          <span className="tw-flex tw-min-w-0 tw-items-center tw-gap-1 tw-text-muted">
+            <FileText className="tw-size-3.5 tw-shrink-0" />
+            <span className="tw-truncate tw-font-medium tw-text-normal">{activeFileName}</span>
+          </span>
+        ) : (
+          <span className="tw-text-muted">—</span>
+        )}
+      </div>
+      <Button
+        variant="secondary"
+        size="sm"
+        disabled={isBuilding}
+        onClick={onBuild}
+        className="tw-ml-auto tw-shrink-0 tw-gap-1.5"
+      >
+        <RefreshCw className={cn("tw-size-3.5", isBuilding && "tw-animate-spin")} />
+        {isBuilding ? "Building…" : "Build index"}
+      </Button>
+    </div>
+  );
+}
+
+function BuildOverlay({ indexedCount, totalFiles }: { indexedCount: number; totalFiles: number }) {
+  const progress = totalFiles > 0 ? Math.round((indexedCount / totalFiles) * 100) : 0;
+  return (
+    <div className="tw-absolute tw-inset-0 tw-flex tw-flex-col tw-items-center tw-justify-center tw-gap-4 tw-px-10 tw-text-center tw-backdrop-blur-sm tw-bg-primary/90">
+      <Loader2 className="tw-size-6 tw-animate-spin tw-text-accent" />
+      <span className="tw-text-sm tw-font-semibold tw-text-normal">Indexing your vault</span>
+      <Progress value={progress} className="tw-h-1 tw-w-48" />
+      {totalFiles > 0 && (
+        <span className="tw-text-xs tw-tabular-nums tw-text-faint">
+          {indexedCount} / {totalFiles} notes embedded
+        </span>
+      )}
+    </div>
   );
 }
 
 export const RelevantNotes = memo(
-  ({ className, defaultOpen = false }: { className?: string; defaultOpen?: boolean }) => {
+  ({
+    className,
+    onAddToChat,
+  }: {
+    className?: string;
+    /** Insert text (a `[[wikilink]]`) into the target chat input. */
+    onAddToChat: (text: string) => void;
+  }) => {
     const app = useApp();
     const [refresher, setRefresher] = useState(0);
-    const [isOpen, setIsOpen] = useState(defaultOpen);
     const relevantNotes = useRelevantNotes(refresher);
     const activeFile = useActiveFile();
-    const chatInput = useChatInput();
     const hasIndex = useHasIndex(activeFile?.path ?? "", refresher);
-    const handleDragStart = useNoteDrag();
+    const [indexingState] = useIndexingProgress();
     const navigateToNote = (notePath: string, openInNewLeaf = false) => {
       const file = app.vault.getAbstractFileByPath(notePath);
       if (file instanceof TFile) {
@@ -293,15 +408,7 @@ export const RelevantNotes = memo(
       }
     };
     const addToChat = (prompt: string) => {
-      chatInput.insertTextWithPills(`[[${prompt}]]`, true);
-    };
-    const refreshIndex = async () => {
-      if (activeFile) {
-        const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
-        await VectorStoreManager.getInstance().reindexFile(activeFile);
-        new Notice(`Refreshed index for ${activeFile.basename}`);
-        setRefresher(refresher + 1);
-      }
+      onAddToChat(`[[${prompt}]]`);
     };
 
     const handleBuildIndex = async () => {
@@ -333,100 +440,73 @@ export const RelevantNotes = memo(
     };
 
     return (
-      <div
-        className={cn(
-          "tw-w-full tw-border tw-border-solid tw-border-transparent tw-border-b-border tw-pb-2",
-          className
-        )}
-      >
-        <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-          <div className="tw-flex tw-items-center tw-justify-between tw-pb-2 tw-pl-1">
-            <div className="tw-flex tw-flex-1 tw-items-center tw-gap-2">
-              <span className="tw-font-semibold tw-text-normal">Relevant Notes</span>
-              <HelpTooltip
-                content="Relevance is a combination of semantic similarity and links. Requires semantic search setting on."
-                contentClassName="tw-w-64"
-                buttonClassName="tw-size-4 tw-text-muted"
-              />
-            </div>
-            <div className="tw-flex tw-items-center">
-              {hasIndex ? (
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button variant="ghost2" size="icon" onClick={() => void refreshIndex()}>
-                      <RefreshCcw className="tw-size-4" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Reindex Current Note</TooltipContent>
-                </Tooltip>
-              ) : (
-                <Button variant="secondary" size="sm" onClick={() => void handleBuildIndex()}>
-                  Build Index
+      <div className={cn("tw-flex tw-min-h-full tw-w-full tw-flex-1 tw-flex-col", className)}>
+        {!hasIndex && (
+          <div className="tw-flex tw-flex-1 tw-flex-col tw-items-center tw-justify-center tw-px-6">
+            <div className="tw-flex tw-w-full tw-max-w-xs tw-flex-col tw-items-center tw-gap-6 tw-text-center">
+              <div className="tw-flex tw-size-16 tw-items-center tw-justify-center tw-rounded-xl tw-border tw-border-solid tw-border-border tw-bg-secondary">
+                <GitFork className="tw-size-7 tw-text-accent" />
+              </div>
+              <div className="tw-flex tw-flex-col tw-gap-1.5">
+                <span className="tw-text-lg tw-font-semibold tw-text-normal">
+                  No semantic index yet
+                </span>
+                <span className="tw-text-sm tw-text-muted">
+                  {"Build it once to surface notes related to whatever you're writing."}
+                </span>
+              </div>
+              <div className="tw-flex tw-w-full tw-flex-col tw-items-center tw-gap-3">
+                <Button
+                  variant="default"
+                  onClick={() => void handleBuildIndex()}
+                  className="tw-h-11 tw-w-full tw-gap-2 tw-rounded-lg"
+                >
+                  <GitFork className="tw-size-4" />
+                  Build index
                 </Button>
-              )}
-              {relevantNotes.length > 0 && (
-                <CollapsibleTrigger asChild>
-                  <Button variant="ghost2" size="icon">
-                    {isOpen ? (
-                      <ChevronUp className="tw-size-5" />
-                    ) : (
-                      <ChevronDown className="tw-size-5" />
-                    )}
-                  </Button>
-                </CollapsibleTrigger>
-              )}
+              </div>
             </div>
           </div>
-          {relevantNotes.length === 0 && hasIndex && (
-            <div className="tw-flex tw-max-h-12 tw-flex-wrap tw-items-center tw-gap-x-2 tw-gap-y-1 tw-overflow-y-hidden tw-px-1">
-              <span className="tw-text-xs tw-text-muted">No relevant notes found</span>
-            </div>
-          )}
-          {!isOpen && relevantNotes.length > 0 && (
-            <div className="tw-flex tw-max-h-6 tw-flex-wrap tw-gap-x-2 tw-gap-y-1 tw-overflow-y-hidden tw-px-1">
-              {relevantNotes.map((note) => (
-                <RelevantNotePopover
-                  key={note.note.path}
-                  note={note}
-                  onAddToChat={() => addToChat(note.note.title)}
-                  onNavigateToNote={(openInNewLeaf: boolean) =>
-                    navigateToNote(note.note.path, openInNewLeaf)
-                  }
-                >
-                  <Badge
-                    variant="outline"
-                    key={note.note.path}
-                    draggable
-                    onDragStart={(e) => {
-                      const file = app.vault.getAbstractFileByPath(note.note.path);
-                      if (file instanceof TFile) {
-                        handleDragStart(e, file);
-                      }
-                    }}
-                    className="tw-max-w-40 tw-text-xs tw-text-muted hover:tw-cursor-pointer hover:tw-bg-interactive-hover"
-                    title={`${note.note.title} - drag to insert wikilink`}
-                  >
-                    <span className="tw-truncate">{note.note.title}</span>
-                  </Badge>
-                </RelevantNotePopover>
-              ))}
-            </div>
-          )}
-          <CollapsibleContent>
-            <div className="tw-flex tw-max-h-screen tw-flex-col tw-gap-2 tw-overflow-y-auto tw-px-1 tw-py-2">
-              {relevantNotes.map((note) => (
-                <RelevantNote
-                  note={note}
-                  key={note.note.path}
-                  onAddToChat={() => addToChat(note.note.title)}
-                  onNavigateToNote={(openInNewLeaf: boolean) =>
-                    navigateToNote(note.note.path, openInNewLeaf)
-                  }
+        )}
+
+        {hasIndex && (
+          <>
+            <RelevantNotesToolbar
+              activeFileName={activeFile?.basename}
+              isBuilding={indexingState.isActive}
+              onBuild={() => void handleBuildIndex()}
+            />
+            <div className="tw-relative tw-min-h-0 tw-flex-1">
+              <div className="tw-absolute tw-inset-0 tw-overflow-y-auto tw-p-2">
+                {relevantNotes.length === 0 ? (
+                  <div className="tw-flex tw-h-full tw-items-center tw-justify-center tw-px-4 tw-text-center">
+                    <span className="tw-text-sm tw-text-muted">No relevant notes found</span>
+                  </div>
+                ) : (
+                  <div className="tw-flex tw-flex-col tw-gap-0.5">
+                    {relevantNotes.map((note, i) => (
+                      <RelevantNoteRow
+                        key={note.note.path}
+                        note={note}
+                        isTop={i === 0}
+                        onAddToChat={() => addToChat(note.note.title)}
+                        onNavigateToNote={(openInNewLeaf: boolean) =>
+                          navigateToNote(note.note.path, openInNewLeaf)
+                        }
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+              {indexingState.isActive && (
+                <BuildOverlay
+                  indexedCount={indexingState.indexedCount}
+                  totalFiles={indexingState.totalFiles}
                 />
-              ))}
+              )}
             </div>
-          </CollapsibleContent>
-        </Collapsible>
+          </>
+        )}
       </div>
     );
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export const BREVILABS_API_BASE_URL = "https://api.brevilabs.com/v1";
 export const BREVILABS_MODELS_BASE_URL = "https://models.brevilabs.com/v1";
 export const CHAT_VIEWTYPE = "copilot-chat-view";
 export const CHAT_AGENT_VIEWTYPE = "copilot-agent-chat-view";
+export const RELEVANT_NOTES_VIEWTYPE = "copilot-relevant-notes-view";
 
 // Custom Obsidian icon for Agent Mode surfaces (view tab, ribbon, commands).
 // The v4 monochrome brand mark, normalized from its source viewBox "4 4 152 127"
@@ -805,6 +806,7 @@ export const COMMAND_IDS = {
   NEW_AGENT_CHAT: "new-agent-chat",
   OPEN_COPILOT_CHAT_WINDOW: "chat-open-window",
   OPEN_AGENT_CHAT_WINDOW: "agent-chat-open-window",
+  OPEN_RELEVANT_NOTES_VIEW: "open-relevant-notes-view",
   SEARCH_ORAMA_DB: "copilot-search-orama-db",
   TOGGLE_COPILOT_CHAT_WINDOW: "chat-toggle-window",
   TOGGLE_AGENT_CHAT_WINDOW: "agent-chat-toggle-window",
@@ -836,6 +838,7 @@ export const COMMAND_NAMES: Record<CommandId, string> = {
   [COMMAND_IDS.NEW_AGENT_CHAT]: "New Copilot Agent Chat",
   [COMMAND_IDS.OPEN_COPILOT_CHAT_WINDOW]: "Open Copilot Chat Window",
   [COMMAND_IDS.OPEN_AGENT_CHAT_WINDOW]: "Open Copilot Agent Chat Window",
+  [COMMAND_IDS.OPEN_RELEVANT_NOTES_VIEW]: "Open Relevant Notes",
   [COMMAND_IDS.SEARCH_ORAMA_DB]: "Search semantic index (debug)",
   [COMMAND_IDS.TOGGLE_COPILOT_CHAT_WINDOW]: "Toggle Copilot Chat Window",
   [COMMAND_IDS.TOGGLE_AGENT_CHAT_WINDOW]: "Toggle Copilot Agent Chat Window",
@@ -860,6 +863,7 @@ export const COMMAND_ICONS: Partial<Record<CommandId, string>> = {
   [COMMAND_IDS.NEW_AGENT_CHAT]: COPILOT_AGENT_ICON_ID,
   [COMMAND_IDS.OPEN_COPILOT_CHAT_WINDOW]: "message-square",
   [COMMAND_IDS.OPEN_AGENT_CHAT_WINDOW]: COPILOT_AGENT_ICON_ID,
+  [COMMAND_IDS.OPEN_RELEVANT_NOTES_VIEW]: "files",
   [COMMAND_IDS.TOGGLE_COPILOT_CHAT_WINDOW]: "message-square",
   [COMMAND_IDS.TOGGLE_AGENT_CHAT_WINDOW]: COPILOT_AGENT_ICON_ID,
   [COMMAND_IDS.LOAD_COPILOT_CHAT_CONVERSATION]: "history",
@@ -972,7 +976,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   embeddingBatchSize: 16,
   disableIndexOnMobile: true,
   showSuggestedPrompts: true,
-  showRelevantNotes: true,
   numPartitions: 1,
   lexicalSearchRamLimit: 100, // Default 100 MB
   promptUsageTimestamps: {},
@@ -1049,6 +1052,7 @@ export const EVENT_NAMES = {
   CHAT_IS_VISIBLE: "chat-is-visible",
   ACTIVE_LEAF_CHANGE: "active-leaf-change",
   ABORT_STREAM: "abort-stream",
+  INSERT_TEXT_TO_CHAT: "insert-text-to-chat",
 };
 
 export enum ABORT_REASON {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,8 +1,33 @@
+import { EVENT_NAMES } from "@/constants";
 import { App } from "obsidian";
 import * as React from "react";
 
 // App context
 export const AppContext = React.createContext<App | undefined>(undefined);
+
+/**
+ * Per-chat-view event bus. Beyond plain pub/sub it *latches* a queued
+ * "insert text" payload so a consumer that subscribes after the text was
+ * queued — e.g. a chat view still mounting when the Relevant Notes pane routes
+ * a wikilink to it — still receives it. This removes any dependence on a
+ * freshly-opened view's mount timing (previously papered over with a setTimeout).
+ */
+export class ChatViewEventTarget extends EventTarget {
+  private pendingInsertText: string | null = null;
+
+  /** Queue text for the chat input and notify any already-attached listener. */
+  queueInsertText(text: string): void {
+    this.pendingInsertText = text;
+    this.dispatchEvent(new CustomEvent(EVENT_NAMES.INSERT_TEXT_TO_CHAT, { detail: { text } }));
+  }
+
+  /** Take and clear the latched text; returns null once it has been consumed. */
+  consumePendingInsertText(): string | null {
+    const text = this.pendingInsertText;
+    this.pendingInsertText = null;
+    return text;
+  }
+}
 
 // Event target context
 export const EventTargetContext = React.createContext<EventTarget | undefined>(undefined);

--- a/src/context/ChatInputContext.tsx
+++ b/src/context/ChatInputContext.tsx
@@ -1,4 +1,12 @@
-import React, { createContext, useContext, useCallback, useMemo, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { INSERT_TEXT_WITH_PILLS_COMMAND } from "@/components/chat-components/utils/lexicalTextUtils";
 import { LexicalEditor } from "lexical";
 
@@ -32,6 +40,10 @@ interface ChatInputProviderProps {
 export function ChatInputProvider({ children }: ChatInputProviderProps): JSX.Element {
   const [editor, setEditor] = useState<LexicalEditor | null>(null);
   const [focusHandler, setFocusHandler] = useState<(() => void) | null>(null);
+  // Text requested before the Lexical editor has mounted (e.g. routed in while
+  // the chat view is still opening). Held here and flushed once the editor
+  // registers, so insertion never depends on mount timing.
+  const pendingInsertRef = useRef<{ text: string; enableURLPills: boolean } | null>(null);
 
   const registerEditor = useCallback((editorInstance: LexicalEditor) => {
     setEditor(editorInstance);
@@ -48,10 +60,23 @@ export function ChatInputProvider({ children }: ChatInputProviderProps): JSX.Ele
           text,
           options: { enableURLPills, insertAtSelection: true },
         });
+      } else {
+        pendingInsertRef.current = { text, enableURLPills };
       }
     },
     [editor]
   );
+
+  // Flush any text buffered before the editor was ready.
+  useEffect(() => {
+    if (!editor || !pendingInsertRef.current) return;
+    const { text, enableURLPills } = pendingInsertRef.current;
+    pendingInsertRef.current = null;
+    editor.dispatchCommand(INSERT_TEXT_WITH_PILLS_COMMAND, {
+      text,
+      options: { enableURLPills, insertAtSelection: true },
+    });
+  }, [editor]);
 
   const focusInput = useCallback(() => {
     if (focusHandler) {

--- a/src/hooks/useActiveFile.ts
+++ b/src/hooks/useActiveFile.ts
@@ -5,7 +5,10 @@ import { useContext, useEffect, useState } from "react";
 
 export function useActiveFile() {
   const app = useApp();
-  const [activeFile, setActiveFile] = useState<TFile | null>(null);
+  // Seed from the current active file so a freshly-mounted consumer (e.g. the
+  // Relevant Notes pane) renders for the open note immediately, rather than
+  // waiting on an ACTIVE_LEAF_CHANGE event that only fires on later switches.
+  const [activeFile, setActiveFile] = useState<TFile | null>(() => app.workspace.getActiveFile());
   const eventTarget = useContext(EventTargetContext);
 
   useEffect(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -796,13 +796,12 @@ export default class CopilotPlugin extends Plugin {
   }
 
   /**
-   * The "add … to chat context" commands write into a shared atom that both chat
-   * views render, so this only picks which chat to bring into focus:
-   *   - both chat views open → the one focused most recently
+   * Which chat view "add … to chat" actions should target:
+   *   - both chat views open → the one focused most recently (`lastActiveChatViewType`)
    *   - exactly one open      → that one
-   *   - none open             → the agent chat when available, else the legacy chat
+   *   - none open             → the agent chat when usable, else the legacy chat
    */
-  async activateChatViewForContext(): Promise<void> {
+  private pickContextChatViewType(): typeof CHAT_VIEWTYPE | typeof CHAT_AGENT_VIEWTYPE {
     const agentUsable = this.canUseAgentView();
     const agentOpen =
       agentUsable && this.app.workspace.getLeavesOfType(CHAT_AGENT_VIEWTYPE).length > 0;
@@ -816,8 +815,16 @@ export default class CopilotPlugin extends Plugin {
     } else {
       useAgent = agentUsable;
     }
+    return useAgent ? CHAT_AGENT_VIEWTYPE : CHAT_VIEWTYPE;
+  }
 
-    if (useAgent) {
+  /**
+   * The "add … to chat context" commands write into a shared atom that both chat
+   * views render, so this only picks which chat to bring into focus (see
+   * `pickContextChatViewType`).
+   */
+  async activateChatViewForContext(): Promise<void> {
+    if (this.pickContextChatViewType() === CHAT_AGENT_VIEWTYPE) {
       await this.activateAgentView();
     } else {
       await this.activateView();
@@ -852,28 +859,24 @@ export default class CopilotPlugin extends Plugin {
   }
 
   /**
-   * Insert text (a `[[wikilink]]` from the Relevant Notes pane) into whichever
-   * Copilot chat is currently open — agent view first, then the legacy chat —
-   * opening the platform default if none is open. Routes via the target view's
-   * `eventTarget`, the same seam `processText`/`emitChatIsVisible` use, so the
-   * standalone pane never needs the chat's Lexical editor directly.
+   * Insert text (a `[[wikilink]]` from the Relevant Notes pane) into the chat view
+   * the user last focused (see `pickContextChatViewType`), opening that view if none
+   * is open. Routes via the target view's `eventTarget`, the same seam
+   * `processText`/`emitChatIsVisible` use, so the standalone pane never needs the
+   * chat's Lexical editor directly.
    */
   async insertTextIntoActiveChat(text: string): Promise<void> {
-    const findChatLeaf = (): WorkspaceLeaf | null =>
-      this.app.workspace.getLeavesOfType(CHAT_AGENT_VIEWTYPE)[0] ??
-      this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE)[0] ??
-      null;
-
-    let leaf = findChatLeaf();
+    const viewType = this.pickContextChatViewType();
+    let leaf = this.app.workspace.getLeavesOfType(viewType)[0] ?? null;
     if (!leaf) {
-      if (this.canUseAgentView()) {
+      if (viewType === CHAT_AGENT_VIEWTYPE) {
         await this.activateAgentView();
       } else {
         await this.activateView();
       }
       // Give the freshly-opened view a tick to mount its event listener.
       await new Promise((resolve) => window.setTimeout(resolve, 50));
-      leaf = findChatLeaf();
+      leaf = this.app.workspace.getLeavesOfType(viewType)[0] ?? null;
     }
     if (!leaf) return;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import {
 import { NoteSelectedTextContext, SelectedTextContext } from "@/types/message";
 import { registerCommands } from "@/commands";
 import CopilotView from "@/components/CopilotView";
+import RelevantNotesView from "@/components/RelevantNotesView";
 import { APPLY_VIEW_TYPE, ApplyView } from "@/components/composer/ApplyView";
 import { LoadChatHistoryModal } from "@/components/modals/LoadChatHistoryModal";
 
@@ -43,6 +44,7 @@ import {
   COPILOT_AGENT_ICON_SVG,
   DEFAULT_OPEN_AREA,
   EVENT_NAMES,
+  RELEVANT_NOTES_VIEWTYPE,
 } from "@/constants";
 import { ChatManager } from "@/core/ChatManager";
 import { MessageRepository } from "@/core/MessageRepository";
@@ -306,6 +308,10 @@ export default class CopilotPlugin extends Plugin {
 
     this.safeRegisterView(CHAT_VIEWTYPE, (leaf: WorkspaceLeaf) => new CopilotView(leaf, this));
     this.safeRegisterView(APPLY_VIEW_TYPE, (leaf: WorkspaceLeaf) => new ApplyView(leaf));
+    this.safeRegisterView(
+      RELEVANT_NOTES_VIEWTYPE,
+      (leaf: WorkspaceLeaf) => new RelevantNotesView(leaf, this)
+    );
     if (!Platform.isMobile) {
       this.safeRegisterView(
         CHAT_AGENT_VIEWTYPE,
@@ -839,6 +845,43 @@ export default class CopilotPlugin extends Plugin {
 
   async deactivateAgentView() {
     this.app.workspace.detachLeavesOfType(CHAT_AGENT_VIEWTYPE);
+  }
+
+  async activateRelevantNotesView(): Promise<WorkspaceLeaf | null> {
+    return this.openOrRevealView(RELEVANT_NOTES_VIEWTYPE);
+  }
+
+  /**
+   * Insert text (a `[[wikilink]]` from the Relevant Notes pane) into whichever
+   * Copilot chat is currently open — agent view first, then the legacy chat —
+   * opening the platform default if none is open. Routes via the target view's
+   * `eventTarget`, the same seam `processText`/`emitChatIsVisible` use, so the
+   * standalone pane never needs the chat's Lexical editor directly.
+   */
+  async insertTextIntoActiveChat(text: string): Promise<void> {
+    const findChatLeaf = (): WorkspaceLeaf | null =>
+      this.app.workspace.getLeavesOfType(CHAT_AGENT_VIEWTYPE)[0] ??
+      this.app.workspace.getLeavesOfType(CHAT_VIEWTYPE)[0] ??
+      null;
+
+    let leaf = findChatLeaf();
+    if (!leaf) {
+      if (this.canUseAgentView()) {
+        await this.activateAgentView();
+      } else {
+        await this.activateView();
+      }
+      // Give the freshly-opened view a tick to mount its event listener.
+      await new Promise((resolve) => window.setTimeout(resolve, 50));
+      leaf = findChatLeaf();
+    }
+    if (!leaf) return;
+
+    this.app.workspace.revealLeaf(leaf);
+    const view = leaf.view as CopilotView | CopilotAgentView;
+    view.eventTarget.dispatchEvent(
+      new CustomEvent(EVENT_NAMES.INSERT_TEXT_TO_CHAT, { detail: { text } })
+    );
   }
 
   async newAgentChat(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -874,17 +874,16 @@ export default class CopilotPlugin extends Plugin {
       } else {
         await this.activateView();
       }
-      // Give the freshly-opened view a tick to mount its event listener.
-      await new Promise((resolve) => window.setTimeout(resolve, 50));
       leaf = this.app.workspace.getLeavesOfType(viewType)[0] ?? null;
     }
     if (!leaf) return;
 
     this.app.workspace.revealLeaf(leaf);
     const view = leaf.view as CopilotView | CopilotAgentView;
-    view.eventTarget.dispatchEvent(
-      new CustomEvent(EVENT_NAMES.INSERT_TEXT_TO_CHAT, { detail: { text } })
-    );
+    // The bus latches the text if the view's React tree hasn't mounted its
+    // listener yet, so a freshly-opened view drains it on mount — delivery no
+    // longer depends on guessing how long mounting takes.
+    view.eventTarget.queueInsertText(text);
   }
 
   async newAgentChat(): Promise<void> {

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -190,6 +190,26 @@ describe("findRelevantNotes", () => {
     expect(mockSearchRelated).not.toHaveBeenCalled();
   });
 
+  it("ranks by similarity only — a backlink does not boost a lower-similarity note above a higher one", async () => {
+    mockGetDocumentsByPath.mockResolvedValue([
+      { id: "chunk-1", path: "source.md", content: "chunk one", embedding: [0.1, 0.2] },
+    ]);
+    mockGetDb.mockResolvedValue({ db: "orama" });
+    // alpha (0.6) has no links; beta (0.58) is backlinked. The old merged-score
+    // ranking boosted beta above alpha despite its lower similarity.
+    mockGetDocsByEmbedding.mockResolvedValueOnce([
+      { score: 0.6, document: { path: "alpha.md" } },
+      { score: 0.58, document: { path: "beta.md" } },
+    ]);
+    mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("beta.md")]);
+
+    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+    expect(result.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
+    expect(result[0].metadata.similarityScore).toBe(0.6);
+    expect(result.find((entry) => entry.note.path === "beta.md")?.metadata.hasBacklinks).toBe(true);
+  });
+
   it("uses Miyo when shouldUseMiyoForRelevantNotes is true (enableMiyo=true and valid self-host)", async () => {
     mockedShouldUseMiyo.mockReturnValue(true);
     mockedGetSettings.mockReturnValue({

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -16,8 +16,6 @@ import { InternalTypedDocument, Orama, Result } from "@orama/orama";
 import { App, TFile } from "obsidian";
 
 const MAX_K = 20;
-const ORIGINAL_WEIGHT = 0.7;
-const LINKS_WEIGHT = 0.3;
 
 /**
  * Determine whether Miyo-backed relevant-note scoring should be used.
@@ -252,38 +250,6 @@ function getNoteLinks(app: App, file: TFile) {
   return resultMap;
 }
 
-/**
- * Merge semantic similarity scores with note link heuristics.
- *
- * @param similarityScoreMap - Semantic score map.
- * @param noteLinks - Outgoing/backlink flags map.
- * @returns Combined score map used for ranking.
- */
-function mergeScoreMaps(
-  similarityScoreMap: Map<string, number>,
-  noteLinks: Map<string, { links: boolean; backlinks: boolean }>
-) {
-  const mergedMap = new Map<string, number>();
-  const totalWeight = ORIGINAL_WEIGHT + LINKS_WEIGHT;
-  for (const [key, value] of similarityScoreMap) {
-    mergedMap.set(key, (value * ORIGINAL_WEIGHT) / totalWeight);
-  }
-  for (const [key, value] of noteLinks) {
-    let score = 0;
-    if (value.links && value.backlinks) {
-      score = LINKS_WEIGHT;
-    } else if (value.links) {
-      // If the note only has outgoing or incoming links, give it a 80% links
-      // weight.
-      score = LINKS_WEIGHT * 0.8;
-    } else if (value.backlinks) {
-      score = LINKS_WEIGHT * 0.8;
-    }
-    mergedMap.set(key, (mergedMap.get(key) ?? 0) + score);
-  }
-  return mergedMap;
-}
-
 export type RelevantNoteEntry = {
   note: {
     path: string;
@@ -319,48 +285,40 @@ export async function findRelevantNotes({
 
   const similarityScoreMap = await calculateSimilarityScore(app, filePath);
   const noteLinks = getNoteLinks(app, file);
-  const mergedScoreMap = mergeScoreMaps(similarityScoreMap, noteLinks);
-  const sortedHits = Array.from(mergedScoreMap.entries()).sort((a, b) => {
-    const aPath = a[0];
-    const bPath = b[0];
-    const aCategory = getSimilarityCategory(similarityScoreMap.get(aPath) ?? 0);
-    const bCategory = getSimilarityCategory(similarityScoreMap.get(bPath) ?? 0);
 
-    if (aCategory !== bCategory) {
-      return bCategory - aCategory;
-    }
-
-    return b[1] - a[1];
+  // Rank purely by semantic similarity so the displayed percentages stay
+  // monotonic down the list. Linked/backlinked notes still appear, but a link
+  // never boosts ranking: link-only notes have no similarity score and sort to
+  // the bottom (they render without a meter in the UI).
+  const candidatePaths = new Set<string>([...similarityScoreMap.keys(), ...noteLinks.keys()]);
+  candidatePaths.delete(filePath);
+  const sortedPaths = Array.from(candidatePaths).sort((aPath, bPath) => {
+    const aScore = similarityScoreMap.get(aPath);
+    const bScore = similarityScoreMap.get(bPath);
+    if (aScore == null && bScore == null) return 0;
+    if (aScore == null) return 1;
+    if (bScore == null) return -1;
+    return bScore - aScore;
   });
-  return sortedHits
-    .map(([path, score]) => {
+  return sortedPaths
+    .map((path) => {
       const file = app.vault.getAbstractFileByPath(path);
       if (!(file instanceof TFile) || file.extension !== "md") {
         return null;
       }
+      const similarityScore = similarityScoreMap.get(path);
       return {
         note: {
           path,
           title: file.basename,
         },
         metadata: {
-          score,
-          similarityScore: similarityScoreMap.get(path),
+          score: similarityScore ?? 0,
+          similarityScore,
           hasOutgoingLinks: noteLinks.get(path)?.links ?? false,
           hasBacklinks: noteLinks.get(path)?.backlinks ?? false,
         },
       };
     })
     .filter((entry) => entry !== null);
-}
-
-/**
- * Gets the similarity category for the given score.
- * @param score - The score to get the similarity category for.
- * @returns The similarity category. 1 is low, 2 is medium, 3 is high.
- */
-export function getSimilarityCategory(score: number): number {
-  if (score > 0.7) return 3;
-  if (score > 0.55) return 2;
-  return 1;
 }

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -121,7 +121,6 @@ export interface CopilotSettings {
   defaultSendShortcut: SEND_SHORTCUT;
   disableIndexOnMobile: boolean;
   showSuggestedPrompts: boolean;
-  showRelevantNotes: boolean;
   numPartitions: number;
   defaultConversationNoteName: string;
   // undefined means never checked

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -266,14 +266,6 @@ export const BasicSettings: React.FC = () => {
             checked={settings.showSuggestedPrompts}
             onCheckedChange={(checked) => updateSetting("showSuggestedPrompts", checked)}
           />
-
-          <SettingItem
-            type="switch"
-            title="Relevant Notes"
-            description="Show relevant notes in the chat view"
-            checked={settings.showRelevantNotes}
-            onCheckedChange={(checked) => updateSetting("showRelevantNotes", checked)}
-          />
         </div>
       </section>
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -30,6 +30,13 @@ If your plugin does not need CSS, delete this file.
   border-top: 1px solid var(--background-modifier-border);
 }
 
+/* Relevance meter fill. Width and color are score-driven, so they arrive as
+   per-element CSS variables rather than static utilities. */
+.copilot-relevance-meter-fill {
+  width: var(--relevance-meter-fill, 0%);
+  background: var(--relevance-meter-color, var(--text-faint));
+}
+
 .button-container {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
Moves Relevant Notes out of the chat into its own command-opened pane (**Open Relevant Notes**) that tracks whichever note you're viewing, and removes the old in-chat block along with its `showRelevantNotes` setting.

The redesigned pane includes:

- a toolbar with the active-note context line ("Relevant to …") and a **Build index** button, plus a live indexing overlay that shows embedding progress;
- per-note rows with a color-graded relevance meter whose width maps 1:1 to the similarity score (70% → 70%) and a percentage;
- **Outgoing link** / **Backlink** badges that swap to hover quick actions (**Add to Chat**, **Open note**);
- a hover preview card that renders the note's full content in a scrollable area;
- dedicated empty states for "No semantic index yet" and for a note that's excluded by your index inclusion/exclusion settings.

**Add to Chat** inserts a `[[wikilink]]` into the last-focused chat or agent view via a new `INSERT_TEXT_TO_CHAT` event; the chat views latch the queued text and drain it on mount, so delivery no longer depends on timing.

Relevant notes are now ranked by semantic similarity only so the displayed percentages stay monotonic — links no longer boost the score (link-only notes still appear, without a meter), with a regression test added.

README and docs are updated to describe the new pane.

<img width="754" height="470" alt="Screenshot 2026-06-04 at 9 44 09 PM" src="https://github.com/user-attachments/assets/b4c3db0d-0134-49df-956b-0946f82d7d38" />

<img width="372" height="397" alt="Screenshot 2026-06-04 at 9 44 24 PM" src="https://github.com/user-attachments/assets/dde4c721-fd27-49b2-9f7a-c3eab5a4ca92" />
