### PR TITLE
fix(agent-mode): pass model modalities to opencode so images aren't stripped

### DIFF
--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -201,6 +201,65 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     });
   });
 
+  it("injects a vision model's modalities + attachment so opencode won't strip images", async () => {
+    // Copilot Plus / self-hosted providers have no models.dev catalog entry, so
+    // opencode defaults `input.image` to false and strips images. Carrying the
+    // model's own modalities tells opencode it's multimodal.
+    const provider = makeProvider("p-anthropic", {
+      kind: "byok",
+      catalogProviderId: "anthropic",
+    });
+    const model = makeModel("p-anthropic", "claude-sonnet-4-6");
+    model.info.modalities = { input: ["text", "image"], output: ["text"] };
+    const deps = makeDeps({
+      resolved: [okEntry(provider, model)],
+      keys: { "p-anthropic": "anth-123" },
+    });
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, unknown> }>;
+    };
+    expect(cfg.provider.anthropic.models).toEqual({
+      "claude-sonnet-4-6": {
+        modalities: { input: ["text", "image"], output: ["text"] },
+        attachment: true,
+      },
+    });
+  });
+
+  it("injects a text-only model's modalities without the attachment flag", async () => {
+    const provider = makeProvider("p-anthropic", {
+      kind: "byok",
+      catalogProviderId: "anthropic",
+    });
+    const model = makeModel("p-anthropic", "deepseek-v4-flash");
+    model.info.modalities = { input: ["text"], output: ["text"] };
+    const deps = makeDeps({
+      resolved: [okEntry(provider, model)],
+      keys: { "p-anthropic": "anth-123" },
+    });
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, unknown> }>;
+    };
+    expect(cfg.provider.anthropic.models).toEqual({
+      "deepseek-v4-flash": { modalities: { input: ["text"], output: ["text"] } },
+    });
+  });
+
+  it("injects an empty config for a model with no modalities metadata", async () => {
+    const provider = makeProvider("p-anthropic", {
+      kind: "byok",
+      catalogProviderId: "anthropic",
+    });
+    const deps = makeDeps({
+      resolved: [okEntry(provider, makeModel("p-anthropic", "hand-typed-model"))],
+      keys: { "p-anthropic": "anth-123" },
+    });
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, unknown> }>;
+    };
+    expect(cfg.provider.anthropic.models).toEqual({ "hand-typed-model": {} });
+  });
+
   it("registers two distinct providers", async () => {
     const anthropic = makeProvider("p-anthropic", {
       kind: "byok",

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -185,8 +185,22 @@ export async function buildOpencodeConfig(
     }
 
     if (!providerConfig.models) providerConfig.models = {};
-    providerConfig.models[entry.configuredModel.info.id] = {};
-    injected.push(`${mapping.id}/${entry.configuredModel.info.id}`);
+    // Carry the model's known modalities into the config. opencode resolves a
+    // model's capabilities as `injected ?? models.dev-catalog ?? default`, and
+    // `unsupportedParts` strips image/file parts whenever `input.image` is
+    // false. For catalog providers this stays in agreement with opencode's own
+    // catalog; for providers opencode has no catalog entry for (Copilot Plus,
+    // self-hosted OpenAI-compatible) the default is `false`, so a genuinely
+    // multimodal model would have its images silently stripped. Injecting the
+    // modalities we already know prevents that.
+    const { info } = entry.configuredModel;
+    const modelConfig: Record<string, unknown> = {};
+    if (info.modalities) {
+      modelConfig.modalities = info.modalities;
+      if (info.modalities.input?.includes("image")) modelConfig.attachment = true;
+    }
+    providerConfig.models[info.id] = modelConfig;
+    injected.push(`${mapping.id}/${info.id}`);
   }
 
   if (injected.length > 0) {


### PR DESCRIPTION
opencode decides a model's image capability as `injected ?? models.dev catalog ?? false` and strips image parts when `input.image` is false; we injected every model as an empty `{}`, so providers opencode has no catalog entry for (Copilot Plus, self-hosted OpenAI-compatible) defaulted to text-only and had attached images silently replaced with an error note — even for genuinely multimodal models. This carries each model's known `modalities` (plus an `attachment` flag when image input is supported) into the opencode config so those models keep their images. It's generalizable and regression-safe: catalog models (OpenRouter/Anthropic/Google) just agree with opencode's own catalog, and modality-less hand-typed models still inject `{}`. Adds unit tests covering the vision, text-only, and no-modalities injection cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)