### PR TITLE
feat(agent-mode): support web tab and web selection as context

### DIFF
--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -171,7 +171,7 @@ describe("buildPromptBlocks", () => {
     expect(blocks[2]).toEqual({ type: "image", mimeType: "image/jpeg", data: "ZmFrZQ==" });
   });
 
-  it("ignores web-source selected text excerpts", () => {
+  it("serializes web-source selected text excerpts as <web_selected_text>", () => {
     const blocks = buildPromptBlocks("explain", {
       notes: [],
       urls: [],
@@ -185,7 +185,55 @@ describe("buildPromptBlocks", () => {
         },
       ],
     });
-    expect(blocks).toEqual([{ type: "text", text: "explain" }]);
+    const text = (blocks[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("<web_selected_text>");
+    expect(text).toContain("<title>Example</title>");
+    expect(text).toContain("<url>https://example.com</url>");
+    expect(text).toContain("web snippet");
+    expect(text).toContain("<user-message>\nexplain\n</user-message>");
+  });
+
+  it("weaves the web-tab block before the user message", () => {
+    const webTabBlock =
+      "<active_web_tab>\n<title>Docs</title>\n<url>https://x.dev</url>\n<content>\nhello\n</content>\n</active_web_tab>";
+    const blocks = buildPromptBlocks("read it", { notes: [], urls: [] }, undefined, webTabBlock);
+    expect(blocks).toHaveLength(1);
+    const text = (blocks[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("<active_web_tab>");
+    expect(text).toContain("<url>https://x.dev</url>");
+    expect(text).toContain("<user-message>\nread it\n</user-message>");
+    // Context (web-tab content) precedes the user message.
+    expect(text.indexOf("<active_web_tab>")).toBeLessThan(text.indexOf("<user-message>"));
+  });
+
+  it("emits plain text when the web-tab block is empty/whitespace", () => {
+    const blocks = buildPromptBlocks("hi", undefined, undefined, "   ");
+    expect(blocks).toEqual([{ type: "text", text: "hi" }]);
+  });
+
+  it("orders the envelope, web selections, and web-tab block before the message", () => {
+    const webTabBlock = "<web_tab_context>\n<url>https://x.dev</url>\n</web_tab_context>";
+    const blocks = buildPromptBlocks(
+      "look",
+      {
+        notes: [makeFile("a.md")],
+        urls: [],
+        selectedTextContexts: [
+          { id: "w1", sourceType: "web", title: "W", url: "https://w.dev", content: "snip" },
+        ],
+      },
+      undefined,
+      webTabBlock
+    );
+    const text = (blocks[0] as { type: "text"; text: string }).text;
+    const envelopePos = text.indexOf("<copilot-context>");
+    const selectionPos = text.indexOf("<web_selected_text>");
+    const webTabPos = text.indexOf("<web_tab_context>");
+    const messagePos = text.indexOf("<user-message>");
+    expect(envelopePos).toBeGreaterThanOrEqual(0);
+    expect(envelopePos).toBeLessThan(selectionPos);
+    expect(selectionPos).toBeLessThan(webTabPos);
+    expect(webTabPos).toBeLessThan(messagePos);
   });
 });
 

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -717,8 +717,11 @@ export class AgentSession {
     try {
       // Extract live Web Viewer content (reader-mode markdown, YouTube
       // transcripts) just before the prompt is built so it reflects the page
-      // at send/flush time, not at compose time.
-      const webTabBlock = await serializeWebTabContext(context);
+      // at send/flush time, not at compose time. Only take the async hop when
+      // there are web tabs — otherwise `backend.prompt` must be invoked
+      // synchronously within this turn (callers rely on that timing).
+      const hasWebTabs = (context?.webTabs?.length ?? 0) > 0;
+      const webTabBlock = hasWebTabs ? await serializeWebTabContext(context) : "";
       const promptBlocks = buildPromptBlocks(displayText, context, promptContent, webTabBlock);
       const req: PromptInput = {
         sessionId,

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1,4 +1,4 @@
-import { AI_SENDER, USER_SENDER } from "@/constants";
+import { AI_SENDER, USER_SENDER, WEB_SELECTED_TEXT_TAG } from "@/constants";
 import { logInfo, logWarn } from "@/logger";
 import { AgentMessageStore } from "@/agentMode/session/AgentMessageStore";
 import {
@@ -28,11 +28,17 @@ import {
   ToolCallDelta,
   ToolCallSnapshot,
 } from "@/agentMode/session/types";
-import { isNoteSelectedTextContext, MessageContext } from "@/types/message";
+import {
+  isNoteSelectedTextContext,
+  isWebSelectedTextContext,
+  MessageContext,
+} from "@/types/message";
 import { err2String, formatDateTime } from "@/utils";
 import { MethodUnsupportedError } from "@/agentMode/session/errors";
 import { resolveMcpServers } from "@/agentMode/session/mcpResolver";
 import { getSettings } from "@/settings/model";
+import { ContextProcessor } from "@/contextProcessor";
+import { escapeXml } from "@/LLMProviders/chainRunner/utils/xmlParsing";
 
 /**
  * Prefix opencode uses for placeholder titles before its title-summarizer
@@ -709,7 +715,11 @@ export class AgentSession {
     const sessionId = this.backendSessionId!;
     const turnStartedAt = Date.now();
     try {
-      const promptBlocks = buildPromptBlocks(displayText, context, promptContent);
+      // Extract live Web Viewer content (reader-mode markdown, YouTube
+      // transcripts) just before the prompt is built so it reflects the page
+      // at send/flush time, not at compose time.
+      const webTabBlock = await serializeWebTabContext(context);
+      const promptBlocks = buildPromptBlocks(displayText, context, promptContent, webTabBlock);
       const req: PromptInput = {
         sessionId,
         prompt: promptBlocks,
@@ -1353,15 +1363,57 @@ function findProviderErrorPayload(
 export function buildPromptBlocks(
   displayText: string,
   context?: MessageContext,
-  content?: PromptContent[]
+  content?: PromptContent[],
+  webTabBlock?: string
 ): PromptContent[] {
-  const envelope = buildContextEnvelope(context);
-  const headText = envelope
-    ? `${envelope}\n\n<user-message>\n${displayText}\n</user-message>`
+  // Context sections precede the user message: the vault envelope (notes +
+  // note excerpts), web-selection excerpts, then live web-tab content. Web
+  // tab/selection blocks reuse the legacy `<web_*>` tags so the model reads
+  // the same shapes it does in the non-agent chat.
+  const sections = [
+    buildContextEnvelope(context),
+    buildWebSelectionBlocks(context),
+    webTabBlock?.trim() || null,
+  ].filter((s): s is string => Boolean(s));
+  const head = sections.length > 0 ? sections.join("\n\n") : null;
+  const headText = head
+    ? `${head}\n\n<user-message>\n${displayText}\n</user-message>`
     : displayText;
   const extras = content ?? [];
   if (extras.length === 0) return [{ type: "text", text: headText }];
   return [{ type: "text", text: headText }, ...extras];
+}
+
+/**
+ * Extract live Web Viewer content for the attached web tabs, reusing the
+ * non-agent chat's processor (reader-mode markdown, YouTube transcripts,
+ * timeouts, dedup, availability handling). Returns "" when there are no tabs.
+ */
+async function serializeWebTabContext(context: MessageContext | undefined): Promise<string> {
+  const webTabs = context?.webTabs;
+  if (!webTabs || webTabs.length === 0) return "";
+  return (await ContextProcessor.getInstance().processContextWebTabs(webTabs)).trim();
+}
+
+/**
+ * Serialize web-page text selections as `<web_selected_text>` blocks. The
+ * content is already captured at selection time, so this is synchronous (no
+ * webview round-trip). Note excerpts are handled by {@link buildContextEnvelope}.
+ */
+function buildWebSelectionBlocks(context: MessageContext | undefined): string | null {
+  const selections = (context?.selectedTextContexts ?? []).filter(isWebSelectedTextContext);
+  if (selections.length === 0) return null;
+  return selections
+    .map((s) =>
+      [
+        `<${WEB_SELECTED_TEXT_TAG}>`,
+        `<title>${escapeXml(s.title)}</title>`,
+        `<url>${escapeXml(s.url)}</url>`,
+        `<content>\n${escapeXml(s.content)}\n</content>`,
+        `</${WEB_SELECTED_TEXT_TAG}>`,
+      ].join("\n")
+    )
+    .join("\n\n");
 }
 
 /**

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -14,17 +14,20 @@ import {
 import { CustomCommandManager } from "@/commands/customCommandManager";
 import { getCachedCustomCommands } from "@/commands/state";
 import ChatInput, { type ChatInputProps } from "@/components/chat-components/ChatInput";
+import { useActiveWebTabState } from "@/components/chat-components/hooks/useActiveWebTabState";
 import { Button } from "@/components/ui/button";
-import { EVENT_NAMES } from "@/constants";
+import { ACTIVE_WEB_TAB_MARKER, EVENT_NAMES } from "@/constants";
 import { EventTargetContext } from "@/context";
 import { logError, logWarn } from "@/logger";
+import { buildWebTabsWithActiveSnapshot } from "@/services/webViewerService/activeWebTabSnapshot";
 import {
   isNoteSelectedTextContext,
-  isWebSelectedTextContext,
   type MessageContext,
   type SelectedTextContext,
+  type WebTabContext,
 } from "@/types/message";
 import { arrayBufferToBase64 } from "@/utils/base64";
+import { mergeWebTabContexts } from "@/utils/urlNormalization";
 import { Clock, X } from "lucide-react";
 import { App, Notice, TFile } from "obsidian";
 import React, { memo, useCallback, useContext, useEffect, useRef } from "react";
@@ -68,13 +71,15 @@ const dedupeBy = <T,>(items: Iterable<T>, key: (item: T) => string): T[] => {
 
 const buildMessageContext = (
   notes: TFile[],
-  selected: readonly SelectedTextContext[]
+  selected: readonly SelectedTextContext[],
+  webTabs: readonly WebTabContext[] = []
 ): MessageContext | undefined => {
-  if (notes.length === 0 && selected.length === 0) return undefined;
+  if (notes.length === 0 && selected.length === 0 && webTabs.length === 0) return undefined;
   return {
     notes,
     urls: [],
     selectedTextContexts: selected.length > 0 ? [...selected] : undefined,
+    webTabs: webTabs.length > 0 ? [...webTabs] : undefined,
   };
 };
 
@@ -83,6 +88,7 @@ const combineQueuedMessages = (items: QueuedAgentMessage[]): QueuedAgentMessage 
 
   const allNotes = items.flatMap((i) => i.context?.notes ?? []);
   const allSelected = items.flatMap((i) => i.context?.selectedTextContexts ?? []);
+  const allWebTabs = items.flatMap((i) => i.context?.webTabs ?? []);
   const allPromptContent = items.flatMap((i) => i.promptContent ?? []);
 
   return {
@@ -91,10 +97,10 @@ const combineQueuedMessages = (items: QueuedAgentMessage[]): QueuedAgentMessage 
     rawInput: items.map((i) => i.rawInput).join("\n\n"),
     context: buildMessageContext(
       dedupeBy(allNotes, (n) => n.path),
-      dedupeBy(allSelected, (s) => s.id)
+      dedupeBy(allSelected, (s) => s.id),
+      mergeWebTabContexts(allWebTabs)
     ),
     promptContent: allPromptContent.length > 0 ? allPromptContent : undefined,
-    hadUnsupportedAttachments: items.some((i) => i.hadUnsupportedAttachments),
   };
 };
 
@@ -135,6 +141,11 @@ export const AgentChatInput = memo(function AgentChatInput({
 }: AgentChatInputProps) {
   const eventTarget = useContext(EventTargetContext);
   const [selectedTextContexts] = useSelectedTextContexts();
+  // SSoT for the Active Web Tab; `activeWebTabForMentions` matches the send
+  // snapshot (preserved only when focusing the chat panel). Drives the
+  // ChatInput "Active Web Tab" affordance and is resolved into the outgoing
+  // webTabs at send time below.
+  const { activeWebTabForMentions } = useActiveWebTabState();
 
   const isMountedRef = useRef(false);
   const previousSessionIdRef = useRef(sessionId);
@@ -190,9 +201,6 @@ export const AgentChatInput = memo(function AgentChatInput({
 
   const runSend = useCallback(
     async (item: QueuedAgentMessage) => {
-      if (item.hadUnsupportedAttachments) {
-        new Notice("Web tab attachments aren't supported in Agent Mode yet.");
-      }
       setLoading(true);
       try {
         const { turn } = backend.sendMessage(item.text, item.context, item.promptContent);
@@ -208,91 +216,99 @@ export const AgentChatInput = memo(function AgentChatInput({
     [backend, setLoading, updateUserMessageHistory]
   );
 
-  const handleSendMessage = useCallback(async () => {
-    const text = inputMessage.trim();
-    if (!text) return;
-    const rawInput = inputMessage;
+  const handleSendMessage = useCallback(
+    async (webTabs?: WebTabContext[]) => {
+      const text = inputMessage.trim();
+      if (!text) return;
+      const rawInput = inputMessage;
 
-    // Web tab / web-excerpt attachments still aren't wired through.
-    // Images are handled below. PDFs stay in note context so the agent can
-    // inspect them with its built-in Read tool instead of blocking send.
-    const hasWebExcerpt = selectedTextContexts.some(isWebSelectedTextContext);
-    const hadUnsupportedAttachments = includeActiveWebTab || hasWebExcerpt;
+      const activeFile = app.workspace.getActiveFile();
 
-    const activeFile = app.workspace.getActiveFile();
+      const candidateNotes: TFile[] = [];
+      if (includeActiveNote && activeFile) {
+        candidateNotes.push(activeFile);
+      }
+      candidateNotes.push(...contextNotes);
+      const notes = dedupeBy(candidateNotes, (n) => n.path);
 
-    const candidateNotes: TFile[] = [];
-    if (includeActiveNote && activeFile) {
-      candidateNotes.push(activeFile);
-    }
-    candidateNotes.push(...contextNotes);
-    const notes = dedupeBy(candidateNotes, (n) => n.path);
+      // Slash-menu CustomCommands are inserted as literal `/<title>` text by
+      // SlashCommandPlugin. Skills are recognized by the backend via its
+      // command catalog, but CustomCommands aren't — expand the body here so
+      // the backend sees the real prompt. (Mirrors ChatManager's processPrompt
+      // call on the non-agent path.)
+      const noteSelection = selectedTextContexts.find(isNoteSelectedTextContext);
+      const expanded = await expandCustomCommandPrefix(
+        text,
+        getCachedCustomCommands(),
+        app,
+        noteSelection?.content ?? "",
+        activeFile
+      );
+      if (expanded.matched) {
+        void CustomCommandManager.getInstance().recordUsage(expanded.matched);
+      }
+      const resolvedText = resolveActiveNoteToken(expanded.text, activeFile);
 
-    // Slash-menu CustomCommands are inserted as literal `/<title>` text by
-    // SlashCommandPlugin. Skills are recognized by the backend via its
-    // command catalog, but CustomCommands aren't — expand the body here so
-    // the backend sees the real prompt. (Mirrors ChatManager's processPrompt
-    // call on the non-agent path.)
-    const noteSelection = selectedTextContexts.find(isNoteSelectedTextContext);
-    const expanded = await expandCustomCommandPrefix(
-      text,
-      getCachedCustomCommands(),
+      // Resolve the Active Web Tab into the outgoing webTabs (snapshot at send
+      // time). Mirrors ChatManager: any text selection suppresses the active
+      // tab to avoid redundant context.
+      const hasAnySelection = selectedTextContexts.length > 0;
+      const shouldIncludeActiveWebTab =
+        !hasAnySelection && (includeActiveWebTab || resolvedText.includes(ACTIVE_WEB_TAB_MARKER));
+      const resolvedWebTabs = buildWebTabsWithActiveSnapshot(
+        app,
+        webTabs ?? [],
+        shouldIncludeActiveWebTab
+      );
+
+      const content: PromptContent[] = [];
+
+      // Convert attached images to base64 image content blocks.
+      for (const image of selectedImages) {
+        const block = await fileToImageBlock(image);
+        if (block) content.push(block);
+      }
+
+      const item: QueuedAgentMessage = {
+        id: `queued-${uuidv4()}`,
+        text: resolvedText,
+        rawInput,
+        context: buildMessageContext(notes, selectedTextContexts, resolvedWebTabs),
+        promptContent: content.length > 0 ? content : undefined,
+      };
+
+      resetCompose();
+      // The message context was already snapshotted above from this render's
+      // captured `selectedTextContexts`, so clearing the global atom here is safe
+      // for this send. The narrow window where the awaits above let the user
+      // switch sessions and start a new selection before this clear fires is
+      // accepted as-is (carried over verbatim from the pre-split AgentChat, and a
+      // cleared selection is trivially recoverable). If a future review flags this
+      // again, point them here.
+      clearSelectedTextContexts();
+
+      if (loading || isStarting) {
+        setQueuedMessages((q) => [...q, item]);
+        return;
+      }
+
+      await runSend(item);
+    },
+    [
       app,
-      noteSelection?.content ?? "",
-      activeFile
-    );
-    if (expanded.matched) {
-      void CustomCommandManager.getInstance().recordUsage(expanded.matched);
-    }
-    const resolvedText = resolveActiveNoteToken(expanded.text, activeFile);
-
-    const content: PromptContent[] = [];
-
-    // Convert attached images to base64 image content blocks.
-    for (const image of selectedImages) {
-      const block = await fileToImageBlock(image);
-      if (block) content.push(block);
-    }
-
-    const item: QueuedAgentMessage = {
-      id: `queued-${uuidv4()}`,
-      text: resolvedText,
-      rawInput,
-      context: buildMessageContext(notes, selectedTextContexts),
-      promptContent: content.length > 0 ? content : undefined,
-      hadUnsupportedAttachments,
-    };
-
-    resetCompose();
-    // The message context was already snapshotted above from this render's
-    // captured `selectedTextContexts`, so clearing the global atom here is safe
-    // for this send. The narrow window where the awaits above let the user
-    // switch sessions and start a new selection before this clear fires is
-    // accepted as-is (carried over verbatim from the pre-split AgentChat, and a
-    // cleared selection is trivially recoverable). If a future review flags this
-    // again, point them here.
-    clearSelectedTextContexts();
-
-    if (loading || isStarting) {
-      setQueuedMessages((q) => [...q, item]);
-      return;
-    }
-
-    await runSend(item);
-  }, [
-    app,
-    inputMessage,
-    selectedImages,
-    contextNotes,
-    includeActiveNote,
-    includeActiveWebTab,
-    selectedTextContexts,
-    loading,
-    isStarting,
-    resetCompose,
-    runSend,
-    setQueuedMessages,
-  ]);
+      inputMessage,
+      selectedImages,
+      contextNotes,
+      includeActiveNote,
+      includeActiveWebTab,
+      selectedTextContexts,
+      loading,
+      isStarting,
+      resetCompose,
+      runSend,
+      setQueuedMessages,
+    ]
+  );
 
   // When a turn ends, flush the queue as one combined message. The
   // `loading` and `queuedMessages.length` guards prevent re-entry: the
@@ -364,7 +380,7 @@ export const AgentChatInput = memo(function AgentChatInput({
           isAgentMode
           inputMessage={inputMessage}
           setInputMessage={setInputMessage}
-          handleSendMessage={() => handleSendMessage()}
+          handleSendMessage={(meta) => handleSendMessage(meta?.webTabs)}
           isGenerating={loading}
           onStopGenerating={handleStopGenerating}
           onEscape={loading ? handleStopGenerating : undefined}
@@ -376,7 +392,7 @@ export const AgentChatInput = memo(function AgentChatInput({
           setIncludeActiveNote={setIncludeActiveNote}
           includeActiveWebTab={includeActiveWebTab}
           setIncludeActiveWebTab={setIncludeActiveWebTab}
-          activeWebTab={null}
+          activeWebTab={activeWebTabForMentions}
           selectedImages={selectedImages}
           onAddImage={addImages}
           setSelectedImages={setSelectedImages}

--- a/src/agentMode/ui/hooks/useAgentInputDrafts.test.tsx
+++ b/src/agentMode/ui/hooks/useAgentInputDrafts.test.tsx
@@ -11,7 +11,6 @@ const queued = (id: string): QueuedAgentMessage => ({
   id,
   text: id,
   rawInput: id,
-  hadUnsupportedAttachments: false,
 });
 
 interface Props {

--- a/src/agentMode/ui/hooks/useAgentInputDrafts.ts
+++ b/src/agentMode/ui/hooks/useAgentInputDrafts.ts
@@ -12,7 +12,6 @@ export interface QueuedAgentMessage {
   context?: MessageContext;
   /** Image blocks for the backend prompt. */
   promptContent?: PromptContent[];
-  hadUnsupportedAttachments: boolean;
 }
 
 /**

--- a/src/core/ChatManager.ts
+++ b/src/core/ChatManager.ts
@@ -7,7 +7,7 @@ import {
 import { ChainType } from "@/chainType";
 import { getChainType, getCurrentProject } from "@/aiParams";
 import { logError, logInfo, logWarn } from "@/logger";
-import { ChatMessage, MessageContext, WebTabContext } from "@/types/message";
+import { ChatMessage, MessageContext } from "@/types/message";
 import { processPrompt, type ProcessedPromptResult } from "@/commands/customCommandUtils";
 import { FileParserManager } from "@/tools/FileParserManager";
 import ChainManager from "@/LLMProviders/chainManager";
@@ -20,12 +20,7 @@ import { ChatPersistenceManager } from "./ChatPersistenceManager";
 import { ACTIVE_WEB_TAB_MARKER, USER_SENDER } from "@/constants";
 import { MessageContent } from "@/imageProcessing/imageProcessor";
 import { TFile, Vault } from "obsidian";
-import { getWebViewerService } from "@/services/webViewerService/webViewerServiceSingleton";
-import {
-  normalizeUrlForMatching,
-  normalizeUrlString,
-  sanitizeWebTabContexts,
-} from "@/utils/urlNormalization";
+import { buildWebTabsWithActiveSnapshot } from "@/services/webViewerService/activeWebTabSnapshot";
 
 /**
  * ChatManager - Central business logic coordinator
@@ -321,94 +316,6 @@ export class ChatManager {
   }
 
   /**
-   * Build webTabs array with Active Web Tab snapshot injected.
-   *
-   * This implements snapshot semantics:
-   * - Active Web Tab URL is resolved at message creation time
-   * - The URL is stored in message.context.webTabs with isActive: true
-   * - Edit/reprocess will use the stored URL, not the current active tab
-   *
-   * @param existingWebTabs - Existing webTabs from context
-   * @param shouldIncludeActiveWebTab - Pre-computed flag for whether to include active web tab
-   * @returns Updated webTabs array with active tab snapshot
-   */
-  private buildWebTabsWithActiveSnapshot(
-    existingWebTabs: WebTabContext[],
-    shouldIncludeActiveWebTab: boolean
-  ): WebTabContext[] {
-    // Always sanitize existing webTabs (normalize URLs, dedupe, ensure single isActive)
-    const sanitizedTabs = sanitizeWebTabContexts(existingWebTabs);
-
-    if (!shouldIncludeActiveWebTab) {
-      return sanitizedTabs;
-    }
-
-    try {
-      // Get active web tab from WebViewerService
-      // Use activeWebTabForMentions to match UI behavior:
-      // - Preserved only when switching directly to chat panel
-      // - Cleared when switching to other views (e.g., note tab)
-      const service = getWebViewerService(this.plugin.app);
-      const state = service.getActiveWebTabState();
-      const activeTab = state.activeWebTabForMentions;
-
-      const activeUrl = normalizeUrlForMatching(activeTab?.url);
-      if (!activeUrl) {
-        // No active web tab available, return sanitized tabs unchanged
-        return sanitizedTabs;
-      }
-
-      // Clear any existing isActive flags to ensure only one active tab
-      const clearedTabs: WebTabContext[] = sanitizedTabs.map((tab) => {
-        if (tab.isActive) {
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const { isActive: _unused, ...rest } = tab;
-          return rest;
-        }
-        return tab;
-      });
-
-      // Check if active URL already exists in the list (using normalized matching)
-      const existingIndex = clearedTabs.findIndex(
-        (tab) => normalizeUrlForMatching(tab.url) === activeUrl
-      );
-
-      if (existingIndex >= 0) {
-        // Merge metadata and mark as active
-        // Prefer activeTab.url to preserve hash fragments for SPA routing
-        // Use normalizeUrlString to trim whitespace while keeping hash/query intact
-        const existing = clearedTabs[existingIndex];
-        clearedTabs[existingIndex] = {
-          ...existing,
-          url: normalizeUrlString(activeTab?.url) ?? existing.url,
-          title: activeTab?.title ?? existing.title,
-          faviconUrl: activeTab?.faviconUrl ?? existing.faviconUrl,
-          isActive: true,
-        };
-        return clearedTabs;
-      }
-
-      // Add new active tab entry
-      // Store the raw URL to preserve hash fragments and query params for SPA routing
-      // Use normalizeUrlString to trim whitespace while keeping hash/query intact
-      // (activeUrl is only used for comparison/deduplication above)
-      return [
-        ...clearedTabs,
-        {
-          url: normalizeUrlString(activeTab?.url) ?? activeUrl,
-          title: activeTab?.title,
-          faviconUrl: activeTab?.faviconUrl,
-          isActive: true,
-        },
-      ];
-    } catch (error) {
-      // Web Viewer not available (e.g., mobile platform) - don't fail the message
-      logWarn("[ChatManager] Failed to resolve active web tab:", error);
-      return sanitizedTabs;
-    }
-  }
-
-  /**
    * Send a new message with context processing
    */
   async sendMessage(
@@ -442,7 +349,8 @@ export class ChatManager {
       const hasAnySelection = (updatedContext.selectedTextContexts || []).length > 0;
       const shouldIncludeActiveWebTab =
         !hasAnySelection && (includeActiveWebTab || displayText.includes(ACTIVE_WEB_TAB_MARKER));
-      updatedContext.webTabs = this.buildWebTabsWithActiveSnapshot(
+      updatedContext.webTabs = buildWebTabsWithActiveSnapshot(
+        this.plugin.app,
         updatedContext.webTabs || [],
         shouldIncludeActiveWebTab
       );

--- a/src/services/webViewerService/activeWebTabSnapshot.test.ts
+++ b/src/services/webViewerService/activeWebTabSnapshot.test.ts
@@ -1,0 +1,86 @@
+import type { App } from "obsidian";
+
+import { buildWebTabsWithActiveSnapshot } from "./activeWebTabSnapshot";
+import { getWebViewerService } from "./webViewerServiceSingleton";
+
+jest.mock("./webViewerServiceSingleton", () => ({
+  getWebViewerService: jest.fn(),
+}));
+
+const mockGetWebViewerService = getWebViewerService as jest.Mock;
+
+// The helper only forwards `app` to the mocked service; an empty stub suffices.
+const app = {} as App;
+
+const mockActiveTab = (activeWebTabForMentions: unknown) => {
+  mockGetWebViewerService.mockReturnValue({
+    getActiveWebTabState: () => ({ activeWebTabForMentions }),
+  });
+};
+
+describe("buildWebTabsWithActiveSnapshot", () => {
+  beforeEach(() => {
+    mockGetWebViewerService.mockReset();
+  });
+
+  it("returns sanitized tabs unchanged when not including the active tab", () => {
+    const result = buildWebTabsWithActiveSnapshot(
+      app,
+      [{ url: "https://a.dev", title: "A" }],
+      false
+    );
+    expect(result).toEqual([{ url: "https://a.dev", title: "A" }]);
+    expect(mockGetWebViewerService).not.toHaveBeenCalled();
+  });
+
+  it("appends the active tab with isActive: true", () => {
+    mockActiveTab({
+      url: "https://active.dev",
+      title: "Active",
+      faviconUrl: "https://active.dev/f.ico",
+    });
+    const result = buildWebTabsWithActiveSnapshot(app, [{ url: "https://a.dev" }], true);
+    expect(result).toContainEqual(
+      expect.objectContaining({ url: "https://active.dev", isActive: true })
+    );
+    expect(result.filter((t) => t.isActive)).toHaveLength(1);
+  });
+
+  it("merges the active tab into a matching existing URL", () => {
+    mockActiveTab({ url: "https://same.dev", title: "New" });
+    const result = buildWebTabsWithActiveSnapshot(
+      app,
+      [{ url: "https://same.dev", title: "Old" }],
+      true
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual(
+      expect.objectContaining({ url: "https://same.dev", title: "New", isActive: true })
+    );
+  });
+
+  it("enforces a single isActive tab", () => {
+    mockActiveTab({ url: "https://active.dev" });
+    const result = buildWebTabsWithActiveSnapshot(
+      app,
+      [{ url: "https://other.dev", isActive: true }, { url: "https://active.dev" }],
+      true
+    );
+    expect(result.filter((t) => t.isActive)).toHaveLength(1);
+    expect(result.find((t) => t.isActive)?.url).toBe("https://active.dev");
+  });
+
+  it("returns sanitized tabs when there is no active tab", () => {
+    mockActiveTab(null);
+    const result = buildWebTabsWithActiveSnapshot(app, [{ url: "https://a.dev" }], true);
+    expect(result).toEqual([{ url: "https://a.dev" }]);
+  });
+
+  it("does not throw when the Web Viewer service is unavailable", () => {
+    mockGetWebViewerService.mockImplementation(() => {
+      throw new Error("Web Viewer unsupported");
+    });
+    const result = buildWebTabsWithActiveSnapshot(app, [{ url: "https://a.dev" }], true);
+    expect(result).toEqual([{ url: "https://a.dev" }]);
+  });
+});

--- a/src/services/webViewerService/activeWebTabSnapshot.ts
+++ b/src/services/webViewerService/activeWebTabSnapshot.ts
@@ -1,0 +1,107 @@
+/**
+ * Active Web Tab snapshot resolution.
+ *
+ * Shared by the legacy chat (`ChatManager`) and Agent Mode (`AgentChatInput`).
+ * Resolves the current Active Web Tab into the outgoing `webTabs` list with
+ * snapshot semantics: the active tab's URL is captured at message-creation
+ * time and marked `isActive: true`, so a later edit/reprocess uses the stored
+ * URL rather than whatever tab happens to be active then.
+ */
+
+import type { App } from "obsidian";
+
+import { logWarn } from "@/logger";
+import { getWebViewerService } from "@/services/webViewerService/webViewerServiceSingleton";
+import type { WebTabContext } from "@/types/message";
+import {
+  normalizeUrlForMatching,
+  normalizeUrlString,
+  sanitizeWebTabContexts,
+} from "@/utils/urlNormalization";
+
+/**
+ * Merge the Active Web Tab into `existingWebTabs` when requested.
+ *
+ * Always sanitizes the incoming tabs (normalizes URLs, dedupes, enforces a
+ * single `isActive`). When `shouldIncludeActiveWebTab` is true, resolves the
+ * active tab from {@link getWebViewerService} and either marks the matching
+ * existing entry active or appends a new active entry. Web Viewer being
+ * unavailable (e.g. mobile) is non-fatal: the sanitized tabs are returned
+ * unchanged.
+ */
+export function buildWebTabsWithActiveSnapshot(
+  app: App,
+  existingWebTabs: WebTabContext[],
+  shouldIncludeActiveWebTab: boolean
+): WebTabContext[] {
+  // Always sanitize existing webTabs (normalize URLs, dedupe, ensure single isActive)
+  const sanitizedTabs = sanitizeWebTabContexts(existingWebTabs);
+
+  if (!shouldIncludeActiveWebTab) {
+    return sanitizedTabs;
+  }
+
+  try {
+    // Get active web tab from WebViewerService
+    // Use activeWebTabForMentions to match UI behavior:
+    // - Preserved only when switching directly to chat panel
+    // - Cleared when switching to other views (e.g., note tab)
+    const service = getWebViewerService(app);
+    const state = service.getActiveWebTabState();
+    const activeTab = state.activeWebTabForMentions;
+
+    const activeUrl = normalizeUrlForMatching(activeTab?.url);
+    if (!activeUrl) {
+      // No active web tab available, return sanitized tabs unchanged
+      return sanitizedTabs;
+    }
+
+    // Clear any existing isActive flags to ensure only one active tab
+    const clearedTabs: WebTabContext[] = sanitizedTabs.map((tab) => {
+      if (tab.isActive) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { isActive: _unused, ...rest } = tab;
+        return rest;
+      }
+      return tab;
+    });
+
+    // Check if active URL already exists in the list (using normalized matching)
+    const existingIndex = clearedTabs.findIndex(
+      (tab) => normalizeUrlForMatching(tab.url) === activeUrl
+    );
+
+    if (existingIndex >= 0) {
+      // Merge metadata and mark as active
+      // Prefer activeTab.url to preserve hash fragments for SPA routing
+      // Use normalizeUrlString to trim whitespace while keeping hash/query intact
+      const existing = clearedTabs[existingIndex];
+      clearedTabs[existingIndex] = {
+        ...existing,
+        url: normalizeUrlString(activeTab?.url) ?? existing.url,
+        title: activeTab?.title ?? existing.title,
+        faviconUrl: activeTab?.faviconUrl ?? existing.faviconUrl,
+        isActive: true,
+      };
+      return clearedTabs;
+    }
+
+    // Add new active tab entry
+    // Store the raw URL to preserve hash fragments and query params for SPA routing
+    // Use normalizeUrlString to trim whitespace while keeping hash/query intact
+    // (activeUrl is only used for comparison/deduplication above)
+    return [
+      ...clearedTabs,
+      {
+        url: normalizeUrlString(activeTab?.url) ?? activeUrl,
+        title: activeTab?.title,
+        faviconUrl: activeTab?.faviconUrl,
+        isActive: true,
+      },
+    ];
+  } catch (error) {
+    // Web Viewer not available (e.g., mobile platform) - don't fail the message
+    logWarn("[ActiveWebTabSnapshot] Failed to resolve active web tab:", error);
+    return sanitizedTabs;
+  }
+}


### PR DESCRIPTION
Brings the legacy chat's web-context support to Agent Mode: the active Web Viewer tab, manually @-added open tabs (with YouTube transcripts), and text selected inside a web page can now be attached as context. The shared `ChatInput` already rendered these affordances in Agent Mode, but the data was dropped at two seams — `AgentChatInput` discarded the `webTabs` send payload and hard-coded `activeWebTab=null`, and the session never serialized `context.webTabs` — so this wires both through. Extraction reuses the existing `ContextProcessor.processContextWebTabs` (reader-mode markdown, transcripts, timeouts, dedup), and the active-tab snapshot logic is extracted from `ChatManager` into a shared `buildWebTabsWithActiveSnapshot` helper that both chat paths now use; web selections serialize as `<web_selected_text>`. Selection-priority mirrors legacy exactly (an active text selection suppresses the active web tab). Verified with the full unit suite (3352 tests), `tsc`, ESLint (the `session/ → host` import is boundary-allowed), and Prettier; the live desktop Web Viewer E2E still needs a manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)