### PR TITLE
feat(agent-mode): auto-focus chat input on open and activation

### DIFF
--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -8,6 +8,7 @@ import { ProjectPickerList } from "@/agentMode/ui/ProjectPickerList";
 import { useAgentChatRuntimeState } from "@/agentMode/ui/hooks/useAgentChatRuntimeState";
 import { useAgentHistoryControls } from "@/agentMode/ui/hooks/useAgentHistoryControls";
 import { useAgentInputDrafts } from "@/agentMode/ui/hooks/useAgentInputDrafts";
+import { useChatInputAutoFocus } from "@/agentMode/ui/hooks/useChatInputAutoFocus";
 import { useAgentModelPicker } from "@/agentMode/ui/useAgentModelPicker";
 import { useAgentModePicker } from "@/agentMode/ui/useAgentModePicker";
 import { useSessionBackendDescriptor } from "@/agentMode/ui/useBackendDescriptor";
@@ -59,6 +60,12 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   const settings = useSettingsValue();
   const eventTarget = useContext(EventTargetContext);
   const chatInput = useChatInput();
+
+  // Place the caret in the composer when the agent view opens so the user can
+  // type immediately. AgentHome only mounts once preload settles and a session
+  // exists, so this fires when the input actually appears (and again on
+  // close/reopen, which remounts this tree).
+  useChatInputAutoFocus();
 
   // Insert text routed from outside the chat (e.g. the Relevant Notes pane's
   // "Add to Chat") into the active session's composer. The bus latches text

--- a/src/agentMode/ui/hooks/useChatInputAutoFocus.test.tsx
+++ b/src/agentMode/ui/hooks/useChatInputAutoFocus.test.tsx
@@ -1,0 +1,98 @@
+import { useChatInputAutoFocus } from "@/agentMode/ui/hooks/useChatInputAutoFocus";
+import { EVENT_NAMES } from "@/constants";
+import { ChatViewEventTarget, EventTargetContext } from "@/context";
+import { ChatInputProvider, useChatInput } from "@/context/ChatInputContext";
+import { act, renderHook } from "@testing-library/react";
+import React, { useEffect } from "react";
+
+// Stands in for LexicalEditor's FocusPlugin wiring: registers a focus handler
+// with the context once mounted, exactly as the real editor does.
+function FocusRegistrar({ onFocus }: { onFocus: () => void }) {
+  const { registerFocusHandler } = useChatInput();
+  useEffect(() => {
+    registerFocusHandler(onFocus);
+  }, [registerFocusHandler, onFocus]);
+  return null;
+}
+
+function makeWrapper(focus: () => void, eventTarget?: EventTarget) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <EventTargetContext.Provider value={eventTarget}>
+        <ChatInputProvider>
+          <FocusRegistrar onFocus={focus} />
+          {children}
+        </ChatInputProvider>
+      </EventTargetContext.Provider>
+    );
+  };
+}
+
+describe("useChatInputAutoFocus", () => {
+  it("does not focus on a plain mount (no startup focus steal)", () => {
+    const focus = jest.fn();
+    const eventTarget = new ChatViewEventTarget();
+
+    renderHook(() => useChatInputAutoFocus(), { wrapper: makeWrapper(focus, eventTarget) });
+
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("drains a visibility queued before mount (view opened while still mounting)", () => {
+    const focus = jest.fn();
+    const eventTarget = new ChatViewEventTarget();
+    eventTarget.queueVisible(); // latched before the listener / focus handler exist
+
+    renderHook(() => useChatInputAutoFocus(), { wrapper: makeWrapper(focus, eventTarget) });
+
+    // Drained on attach; the context's focus latch fires once the handler
+    // registers — no timer.
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("focuses when visibility is queued after mount (already open)", () => {
+    const focus = jest.fn();
+    const eventTarget = new ChatViewEventTarget();
+
+    renderHook(() => useChatInputAutoFocus(), { wrapper: makeWrapper(focus, eventTarget) });
+    expect(focus).not.toHaveBeenCalled();
+
+    act(() => eventTarget.queueVisible());
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("focuses on a plain CHAT_IS_VISIBLE dispatch (active-leaf-change)", () => {
+    const focus = jest.fn();
+    const eventTarget = new ChatViewEventTarget();
+
+    renderHook(() => useChatInputAutoFocus(), { wrapper: makeWrapper(focus, eventTarget) });
+
+    act(() => {
+      eventTarget.dispatchEvent(new CustomEvent(EVENT_NAMES.CHAT_IS_VISIBLE));
+    });
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops focusing after unmount", () => {
+    const focus = jest.fn();
+    const eventTarget = new ChatViewEventTarget();
+
+    const { unmount } = renderHook(() => useChatInputAutoFocus(), {
+      wrapper: makeWrapper(focus, eventTarget),
+    });
+    unmount();
+
+    act(() => eventTarget.queueVisible());
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op (does not throw) when no eventTarget is provided", () => {
+    expect(() =>
+      renderHook(() => useChatInputAutoFocus(), {
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <ChatInputProvider>{children}</ChatInputProvider>
+        ),
+      })
+    ).not.toThrow();
+  });
+});

--- a/src/agentMode/ui/hooks/useChatInputAutoFocus.ts
+++ b/src/agentMode/ui/hooks/useChatInputAutoFocus.ts
@@ -1,0 +1,35 @@
+import { EVENT_NAMES } from "@/constants";
+import { ChatViewEventTarget, EventTargetContext } from "@/context";
+import { useChatInput } from "@/context/ChatInputContext";
+import { useContext, useEffect } from "react";
+
+/**
+ * Move keyboard focus to the chat composer whenever the agent view is opened or
+ * becomes the active pane — mirroring the main chat (Chat.tsx).
+ *
+ * The plugin signals visibility on the view's eventTarget: `activateAgentView`
+ * latches it via `queueVisible` (so a view opened while still mounting drains it
+ * here on attach), and `active-leaf-change` dispatches CHAT_IS_VISIBLE directly
+ * (the view is already mounted). `focusInput` is itself latched in
+ * ChatInputContext, so it resolves once the editor registers its handler — no
+ * timer or mount-timing guess anywhere. Focus is event-driven, not fired on a
+ * raw mount, so passively restoring a background agent pane on startup doesn't
+ * steal focus from the editor.
+ */
+export function useChatInputAutoFocus(): void {
+  const { focusInput } = useChatInput();
+  const eventTarget = useContext(EventTargetContext);
+
+  useEffect(() => {
+    const bus = eventTarget instanceof ChatViewEventTarget ? eventTarget : null;
+    const handleVisible = () => {
+      bus?.consumePendingVisible();
+      focusInput();
+    };
+    eventTarget?.addEventListener(EVENT_NAMES.CHAT_IS_VISIBLE, handleVisible);
+    // Drain a visibility queued before this listener attached (view opened while
+    // still mounting), mirroring the insert-text latch.
+    if (bus?.consumePendingVisible()) focusInput();
+    return () => eventTarget?.removeEventListener(EVENT_NAMES.CHAT_IS_VISIBLE, handleVisible);
+  }, [eventTarget, focusInput]);
+}

--- a/src/context.ts
+++ b/src/context.ts
@@ -14,6 +14,7 @@ export const AppContext = React.createContext<App | undefined>(undefined);
  */
 export class ChatViewEventTarget extends EventTarget {
   private pendingInsertText: string | null = null;
+  private visiblePending = false;
 
   /** Queue text for the chat input and notify any already-attached listener. */
   queueInsertText(text: string): void {
@@ -26,6 +27,23 @@ export class ChatViewEventTarget extends EventTarget {
     const text = this.pendingInsertText;
     this.pendingInsertText = null;
     return text;
+  }
+
+  /**
+   * Queue a "view became visible" focus request and notify any already-attached
+   * listener. Latches like {@link queueInsertText} so a view opened while still
+   * mounting drains it on attach — no dependence on mount timing.
+   */
+  queueVisible(): void {
+    this.visiblePending = true;
+    this.dispatchEvent(new CustomEvent(EVENT_NAMES.CHAT_IS_VISIBLE));
+  }
+
+  /** Take and clear the latched visibility; returns false once consumed. */
+  consumePendingVisible(): boolean {
+    const pending = this.visiblePending;
+    this.visiblePending = false;
+    return pending;
   }
 }
 

--- a/src/context/ChatInputContext.tsx
+++ b/src/context/ChatInputContext.tsx
@@ -44,6 +44,10 @@ export function ChatInputProvider({ children }: ChatInputProviderProps): JSX.Ele
   // the chat view is still opening). Held here and flushed once the editor
   // registers, so insertion never depends on mount timing.
   const pendingInsertRef = useRef<{ text: string; enableURLPills: boolean } | null>(null);
+  // Focus requested before the Lexical editor registered its focus handler (e.g.
+  // a freshly-opened view focusing on open). Latched here and flushed once the
+  // handler registers, so focus never depends on mount timing.
+  const pendingFocusRef = useRef(false);
 
   const registerEditor = useCallback((editorInstance: LexicalEditor) => {
     setEditor(editorInstance);
@@ -80,6 +84,16 @@ export function ChatInputProvider({ children }: ChatInputProviderProps): JSX.Ele
 
   const focusInput = useCallback(() => {
     if (focusHandler) {
+      focusHandler();
+    } else {
+      pendingFocusRef.current = true;
+    }
+  }, [focusHandler]);
+
+  // Flush a focus requested before the handler was ready.
+  useEffect(() => {
+    if (focusHandler && pendingFocusRef.current) {
+      pendingFocusRef.current = false;
       focusHandler();
     }
   }, [focusHandler]);

--- a/src/main.ts
+++ b/src/main.ts
@@ -545,14 +545,21 @@ export default class CopilotPlugin extends Plugin {
     void this.processText(editor, eventType, eventSubtype);
   }
 
-  emitChatIsVisible() {
-    const activeCopilotView = this.app.workspace
-      .getLeavesOfType(CHAT_VIEWTYPE)
-      .find((leaf) => leaf.view instanceof CopilotView)?.view as CopilotView;
+  emitChatIsVisible(viewType: typeof CHAT_VIEWTYPE | typeof CHAT_AGENT_VIEWTYPE = CHAT_VIEWTYPE) {
+    // Both chat views expose a `ChatViewEventTarget`; the React tree focuses the
+    // composer in response (CopilotView via Chat.tsx, CopilotAgentView via
+    // useChatInputAutoFocus). The instanceof guard skips deferred (unloaded)
+    // leaves, whose placeholder view has no eventTarget.
+    const view = this.app.workspace
+      .getLeavesOfType(viewType)
+      .map((leaf) => leaf.view)
+      .find(
+        (v): v is CopilotView | CopilotAgentView =>
+          v instanceof CopilotView || v instanceof CopilotAgentView
+      );
 
-    if (activeCopilotView) {
-      const event = new CustomEvent(EVENT_NAMES.CHAT_IS_VISIBLE);
-      activeCopilotView.eventTarget.dispatchEvent(event);
+    if (view) {
+      view.eventTarget.dispatchEvent(new CustomEvent(EVENT_NAMES.CHAT_IS_VISIBLE));
     }
   }
 
@@ -562,8 +569,9 @@ export default class CopilotPlugin extends Plugin {
         if (!leaf) {
           return;
         }
-        if (leaf.getViewState().type === CHAT_VIEWTYPE) {
-          this.emitChatIsVisible();
+        const activeViewType = leaf.getViewState().type;
+        if (activeViewType === CHAT_VIEWTYPE || activeViewType === CHAT_AGENT_VIEWTYPE) {
+          this.emitChatIsVisible(activeViewType);
         }
       })
     );
@@ -847,7 +855,17 @@ export default class CopilotPlugin extends Plugin {
 
   async activateAgentView(): Promise<WorkspaceLeaf | null> {
     if (!this.requireAgentView()) return null;
-    return this.openOrRevealView(CHAT_AGENT_VIEWTYPE);
+    const leaf = await this.openOrRevealView(CHAT_AGENT_VIEWTYPE);
+    // Focus the composer on open. Latching the request on the view's event bus
+    // (rather than a setTimeout) means a freshly-opened view drains it once its
+    // React tree mounts and an already-open view focuses immediately — no
+    // mount-timing guess. Also covers the already-open-and-active case, where
+    // revealLeaf fires no active-leaf-change to drive focus.
+    const view = leaf?.view;
+    if (view instanceof CopilotAgentView) {
+      view.eventTarget.queueVisible();
+    }
+    return leaf;
   }
 
   async deactivateAgentView() {


### PR DESCRIPTION
Focuses the Agent Mode message input when the view is opened via the "Open agent chat view" command, revealed, or switched to — including the already-open-and-active-but-unfocused case — so the user can type without clicking. It mirrors the main chat's `CHAT_IS_VISIBLE` wiring (`emitChatIsVisible` generalized over both chat view types + `active-leaf-change`) and reuses the codebase's existing latch patterns rather than a `setTimeout`: `ChatViewEventTarget.queueVisible()` latches the request so a freshly-opened view drains it on mount, and a `pendingFocusRef` in `ChatInputContext` flushes the focus once the Lexical editor registers its handler. Focus is event-driven only, so passively restoring a background agent pane on startup does not steal focus from the editor. A new `useChatInputAutoFocus` hook (called from `AgentHome`) wires this up, covered by 6 unit tests; full suite (225 suites / 3500 tests), lint, and `tsc` all pass.

Fixes logancyang/obsidian-copilot-preview#129

🤖 Generated with [Claude Code](https://claude.com/claude-code)