### PR TITLE
feat(agent-mode): expose Miyo vault search via a bundled `miyo` CLI skill

### DIFF
--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -276,10 +276,16 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
     // same gate-aware seed pass against the current folder.
     const prevFolder = prev.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
     const nextFolder = next.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
+    // `shouldUseMiyo` depends on `isSelfHostAccessValid()`, which reads the
+    // self-host validation fields — and those are refreshed asynchronously at
+    // startup (after the initial seed pass). Watch them too, so the skill is
+    // re-seeded when validation flips invalid→valid without a reload.
     const miyoAvailabilityChanged =
       prev.enableMiyo !== next.enableMiyo ||
       prev.miyoServerUrl !== next.miyoServerUrl ||
-      prev.isPlusUser !== next.isPlusUser;
+      prev.isPlusUser !== next.isPlusUser ||
+      prev.selfHostModeValidatedAt !== next.selfHostModeValidatedAt ||
+      prev.selfHostValidationCount !== next.selfHostValidationCount;
     if (prevFolder !== nextFolder || miyoAvailabilityChanged) {
       void seedManagedBuiltins(nextFolder).catch((e) =>
         logError("[Skills] builtin skill re-seeding failed", e)

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -10,8 +10,14 @@ import type { BackendId } from "./session/types";
 import { AgentChatPersistenceManager } from "./session/AgentChatPersistenceManager";
 import { AgentModelPreloader } from "./session/AgentModelPreloader";
 import { AgentSessionManager } from "./session/AgentSessionManager";
+import { shouldUseMiyo } from "@/miyo/miyoUtils";
 import { SkillManager } from "./skills";
-import { seedBuiltinSkills } from "./skills/builtin/seedBuiltinSkills";
+import { managedBuiltinSkills, MIYO_SEARCH_SKILL } from "./skills/builtin/builtinSkills";
+import {
+  removeSeededBuiltin,
+  seedBuiltinSkills,
+  type BuiltinSeedFs,
+} from "./skills/builtin/seedBuiltinSkills";
 import {
   createDefaultAskUserQuestionPrompter,
   createDefaultPermissionPrompter,
@@ -214,6 +220,36 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
     }
   };
   subscribeToSystemPromptChange(restartSystemPromptAffected);
+  // Seed the plugin-shipped builtin skills into the canonical folder, then run
+  // discovery so the pass picks them up and fans them out to the agent dirs.
+  // The Plus relay skills are always seeded; the Miyo vault-search skill is
+  // gated on Miyo being in use — seeded when on, and the seeded copy pruned
+  // when off — so it only surfaces while Miyo is available. Discovery runs even
+  // when seeding fails so existing skills still reconcile.
+  const seedManagedBuiltins = async (folder: string): Promise<void> => {
+    const adapter = app.vault.adapter;
+    const fs: BuiltinSeedFs = {
+      exists: (p) => adapter.exists(p),
+      read: (p) => adapter.read(p),
+      write: (p, c) => adapter.write(p, c),
+      mkdir: (p) => adapter.mkdir(p),
+      rmRecursive: (p) => adapter.rmdir(p, true),
+    };
+    const useMiyo = shouldUseMiyo(getSettings());
+    try {
+      await seedBuiltinSkills({
+        skillsFolderRelPath: folder,
+        fs,
+        skills: managedBuiltinSkills(useMiyo),
+      });
+      if (!useMiyo) {
+        await removeSeededBuiltin(folder, MIYO_SEARCH_SKILL.name, fs);
+      }
+    } catch (e) {
+      logError("[Skills] builtin skill seeding failed", e);
+    }
+    await skillManager.refresh();
+  };
   subscribeToSettingsChange((prev, next) => {
     if (
       prev.defaultSystemPromptTitle !== next.defaultSystemPromptTitle ||
@@ -234,24 +270,20 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
           );
       }
     }
-    // When the canonical skills folder changes, seed builtins into the new
-    // folder before discovery runs so the Plus tools appear immediately
-    // without a plugin reload.
+    // Re-seed builtins when the canonical skills folder changes (so the tools
+    // appear in the new folder without a reload) or when Miyo availability
+    // flips (so the gated Miyo skill is seeded/pruned to match). Both run the
+    // same gate-aware seed pass against the current folder.
     const prevFolder = prev.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
     const nextFolder = next.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
-    if (prevFolder !== nextFolder) {
-      const adapter = app.vault.adapter;
-      void seedBuiltinSkills({
-        skillsFolderRelPath: nextFolder,
-        fs: {
-          exists: (p) => adapter.exists(p),
-          read: (p) => adapter.read(p),
-          write: (p, c) => adapter.write(p, c),
-          mkdir: (p) => adapter.mkdir(p),
-        },
-      })
-        .then(() => skillManager.refresh())
-        .catch((e) => logError("[Skills] builtin skill seeding after folder change failed", e));
+    const miyoAvailabilityChanged =
+      prev.enableMiyo !== next.enableMiyo ||
+      prev.miyoServerUrl !== next.miyoServerUrl ||
+      prev.isPlusUser !== next.isPlusUser;
+    if (prevFolder !== nextFolder || miyoAvailabilityChanged) {
+      void seedManagedBuiltins(nextFolder).catch((e) =>
+        logError("[Skills] builtin skill re-seeding failed", e)
+      );
     }
   });
   // A backend's binary path (or a binary install/update) is resolved at spawn
@@ -268,28 +300,14 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
         );
     });
   }
-  // Seed plugin-shipped builtin skills (Copilot Plus relay tools) into the
-  // canonical folder, THEN run discovery so the first pass picks them up and
-  // fans them out to the agent dirs. Non-blocking for plugin load.
-  void (async () => {
-    try {
-      const adapter = app.vault.adapter;
-      await seedBuiltinSkills({
-        skillsFolderRelPath: getSettings().agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER,
-        fs: {
-          exists: (p) => adapter.exists(p),
-          read: (p) => adapter.read(p),
-          write: (p, c) => adapter.write(p, c),
-          mkdir: (p) => adapter.mkdir(p),
-        },
-      });
-    } catch (e) {
-      logError("[Skills] builtin skill seeding failed", e);
+  // Seed plugin-shipped builtin skills into the canonical folder, THEN run
+  // discovery so the first pass picks them up and fans them out to the agent
+  // dirs. Non-blocking for plugin load.
+  void seedManagedBuiltins(getSettings().agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER).catch(
+    (error) => {
+      logError("[Skills] Initial discovery pass failed", error);
     }
-    await skillManager.refresh();
-  })().catch((error) => {
-    logError("[Skills] Initial discovery pass failed", error);
-  });
+  );
   // Non-blocking — plugin load should not wait on disk reconcile.
   for (const descriptor of listBackendDescriptors()) {
     descriptor

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,4 +1,4 @@
-import { BUILTIN_SKILLS, PLUS_ENV } from "./builtinSkills";
+import { BUILTIN_SKILLS, managedBuiltinSkills, MIYO_SEARCH_SKILL, PLUS_ENV } from "./builtinSkills";
 
 /** A script file shipped by a skill, matched by extension (".sh" or ".mjs"). */
 function scriptOf(name: string, ext: ".sh" | ".mjs" = ".sh"): string {
@@ -94,5 +94,67 @@ describe("builtin Copilot Plus skills", () => {
     expect(mjs).toContain('await relay("/pdf4llm"');
     expect(mjs).toContain('toString("base64")');
     expect(mjs).toContain("pdf: PDF, user_id: USER_ID");
+  });
+});
+
+describe("miyo-search builtin skill", () => {
+  it("is a separate, Miyo-gated skill — not one of the always-seeded Plus skills", () => {
+    expect(BUILTIN_SKILLS.map((s) => s.name)).not.toContain("miyo-search");
+    expect(MIYO_SEARCH_SKILL.name).toBe("miyo-search");
+    expect(MIYO_SEARCH_SKILL.enabledAgents).toEqual(["claude", "codex", "opencode"]);
+  });
+
+  it("ships no helper script — the miyo CLI is the runnable", () => {
+    expect(MIYO_SEARCH_SKILL.files).toEqual([]);
+  });
+
+  it("keeps the SKILL.md frontmatter version in sync with the numeric version", () => {
+    expect(MIYO_SEARCH_SKILL.skillMd).toContain(
+      `copilot-builtin-version: "${MIYO_SEARCH_SKILL.version}"`
+    );
+  });
+
+  it("embeds no Plus license env — Miyo is a local loopback CLI", () => {
+    expect(MIYO_SEARCH_SKILL.skillMd).not.toContain(PLUS_ENV.licenseKey);
+    expect(MIYO_SEARCH_SKILL.skillMd).not.toContain(PLUS_ENV.baseUrl);
+  });
+
+  it("documents the search + files subcommands with --json output", () => {
+    const md = MIYO_SEARCH_SKILL.skillMd;
+    expect(md).toContain("miyo search");
+    expect(md).toContain("miyo files");
+    expect(md).toContain("--json");
+  });
+
+  it("resolves the binary PATH-first with a per-OS absolute fallback", () => {
+    const md = MIYO_SEARCH_SKILL.skillMd;
+    // macOS / Linux symlink install location.
+    expect(md).toContain("~/.miyo/bin/miyo");
+    // Windows copied install location.
+    expect(md).toContain("\\Miyo\\bin\\miyo\\miyo.exe");
+  });
+
+  it("guides the agent through not-installed and service-down degradation", () => {
+    const md = MIYO_SEARCH_SKILL.skillMd;
+    expect(md).toContain("not installed");
+    expect(md).toContain("Is the Miyo app running?");
+  });
+});
+
+describe("managedBuiltinSkills", () => {
+  it("includes the Miyo skill only when Miyo is in use", () => {
+    expect(managedBuiltinSkills(true)).toContain(MIYO_SEARCH_SKILL);
+    expect(managedBuiltinSkills(false)).not.toContain(MIYO_SEARCH_SKILL);
+  });
+
+  it("appends Miyo after the Plus skills, preserving their order", () => {
+    expect(managedBuiltinSkills(true).map((s) => s.name)).toEqual([
+      ...BUILTIN_SKILLS.map((s) => s.name),
+      "miyo-search",
+    ]);
+  });
+
+  it("returns the stable BUILTIN_SKILLS reference when Miyo is off", () => {
+    expect(managedBuiltinSkills(false)).toBe(BUILTIN_SKILLS);
   });
 });

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -370,10 +370,138 @@ const FETCH_X = relaySkill({
   scriptFile: "fetch-x.sh",
 });
 
-/** All plugin-shipped builtin skills, in display order. */
+/** All plugin-shipped Copilot Plus relay skills, in display order. */
 export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
   WEB_SEARCH,
   READ_PDF,
   YOUTUBE_TRANSCRIPT,
   FETCH_X,
 ];
+
+const MIYO_SEARCH_VERSION = 1;
+
+/**
+ * Vault semantic search via the local Miyo desktop app's `miyo` CLI.
+ *
+ * Unlike the Plus relay skills above, this ships **no helper script**: the
+ * `miyo` binary the Miyo app installs IS the runnable. The skill is a prose
+ * instruction that tells the agent to call `miyo search` / `miyo files`
+ * directly in its own shell, which works under both POSIX shells and Windows
+ * PowerShell with no bash dependency, no MCP server, and no key handed to the
+ * agent (the CLI talks to a loopback service it discovers itself).
+ *
+ * Gated on Miyo being in use: the host only seeds this skill when
+ * `shouldUseMiyo(...)` is true (see `seedManagedBuiltins` in `agentMode/index`),
+ * and prunes the seeded copy when Miyo is turned off — matching the issue's
+ * "surface only when Miyo is installed/running" intent.
+ *
+ * Binary resolution is documented PATH-first with an absolute-path fallback,
+ * because Obsidian-launched shells often inherit a reduced PATH that misses the
+ * `~/.miyo/bin` entry the Miyo installer adds. The absolute install locations
+ * mirror the Miyo desktop app's `cli-installer.ts`:
+ *   - macOS / Linux: `~/.miyo/bin/miyo`
+ *   - Windows:       `%LOCALAPPDATA%\\Miyo\\bin\\miyo\\miyo.exe`
+ */
+export const MIYO_SEARCH_SKILL: BuiltinSkill = {
+  name: "miyo-search",
+  version: MIYO_SEARCH_VERSION,
+  enabledAgents: ["claude", "codex", "opencode"],
+  skillMd: `---
+name: miyo-search
+description: Search the user's Obsidian vault with Miyo local semantic search. Use when the user wants to find notes, recall what they wrote about a topic, or ground an answer in their own vault — prefer this over reading files blindly for meaning-based recall. Needs the Miyo desktop app installed and running.
+metadata:
+  copilot-enabled-agents: claude, codex, opencode
+  copilot-builtin-version: "${MIYO_SEARCH_VERSION}"
+---
+
+# Miyo vault search
+
+Search the user's indexed Obsidian vault through Miyo, a local companion app
+that runs semantic search over their notes on their own machine. Use it to find
+relevant notes by meaning (not just filename) and to browse what Miyo has
+indexed. All calls are local — no network, no API key.
+
+## How to run
+
+Miyo ships a \`miyo\` command-line tool. Run it directly in your shell. First
+try it on the PATH:
+
+\`\`\`bash
+miyo search "<what to look for>" --json
+\`\`\`
+
+If the shell reports the command is not found (Obsidian-launched shells
+sometimes inherit a reduced PATH that misses Miyo's install dir), call the
+binary by its absolute install path instead:
+
+- macOS / Linux:
+
+  \`\`\`bash
+  ~/.miyo/bin/miyo search "<what to look for>" --json
+  \`\`\`
+
+- Windows (PowerShell):
+
+  \`\`\`powershell
+  & "$env:LOCALAPPDATA\\Miyo\\bin\\miyo\\miyo.exe" search "<what to look for>" --json
+  \`\`\`
+
+- Windows (cmd):
+
+  \`\`\`bat
+  "%LOCALAPPDATA%\\Miyo\\bin\\miyo\\miyo.exe" search "<what to look for>" --json
+  \`\`\`
+
+Always pass \`--json\` and read the JSON the command prints to stdout yourself.
+Do not pipe the output through other tools (no \`jq\`, no \`|\`) — those differ
+between shells.
+
+### Useful commands
+
+- Semantic search, capped at N results:
+
+  \`\`\`bash
+  miyo search "<query>" -n 10 --json
+  \`\`\`
+
+- Browse indexed files, with optional filters:
+
+  \`\`\`bash
+  miyo files --json
+  miyo files --title "<text>" --json
+  miyo files --path "<folder or path fragment>" --mtime-after 2024-01-01 --json
+  \`\`\`
+
+The CLI finds the running Miyo service on its own (loopback). Only pass
+\`--url <url>\` if the user explicitly tells you Miyo runs on another machine.
+
+## Reading the results
+
+\`miyo search --json\` prints \`{ "results": [ { "path": ..., "content": ... } ], "count": N }\`.
+\`miyo files --json\` prints \`{ "files": [ { "path": ..., "title": ..., "mtime": ... } ], "total": N }\`.
+Cite the \`path\` of any note you use so the user can open it.
+
+## If Miyo is not available
+
+- **Command not found / not recognized:** you already tried the absolute path
+  above and it is still missing — the Miyo desktop app is not installed on this
+  machine. Tell the user to install and open Miyo, then try again. Do not retry
+  in a loop.
+- **The command runs but reports it cannot reach the service** (for example
+  "Is the Miyo app running?"): the Miyo app is installed but not running. Tell
+  the user to open the Miyo app, then continue without vault search if they
+  can't. Do not retry repeatedly.
+`,
+  files: [],
+};
+
+/**
+ * The builtin skills the host should seed into the canonical folder. The Plus
+ * relay skills are always included; the Miyo skill is gated on Miyo being in
+ * use (the host passes \`includeMiyo = shouldUseMiyo(...)\`). Kept pure so the
+ * gating decision stays in the host layer (the skills layer must not import
+ * \`@/miyo\`), while the composition is unit-testable here.
+ */
+export function managedBuiltinSkills(includeMiyo: boolean): readonly BuiltinSkill[] {
+  return includeMiyo ? [...BUILTIN_SKILLS, MIYO_SEARCH_SKILL] : BUILTIN_SKILLS;
+}

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.test.ts
@@ -1,4 +1,4 @@
-import { seedBuiltinSkills, type BuiltinSeedFs } from "./seedBuiltinSkills";
+import { removeSeededBuiltin, seedBuiltinSkills, type BuiltinSeedFs } from "./seedBuiltinSkills";
 import type { BuiltinSkill } from "./builtinSkills";
 
 jest.mock("@/logger", () => ({ logError: jest.fn(), logInfo: jest.fn() }));
@@ -24,6 +24,15 @@ function memFs(initialFiles: Record<string, string> = {}): BuiltinSeedFs & {
     },
     mkdir: async (p) => {
       dirs.add(p);
+    },
+    rmRecursive: async (p) => {
+      dirs.delete(p);
+      for (const key of [...files.keys()]) {
+        if (key === p || key.startsWith(`${p}/`)) files.delete(key);
+      }
+      for (const key of [...dirs]) {
+        if (key === p || key.startsWith(`${p}/`)) dirs.delete(key);
+      }
     },
   };
 }
@@ -142,5 +151,31 @@ describe("seedBuiltinSkills", () => {
     expect(written).toContain("copilot-enabled-agents: claude\n");
     expect(written).not.toContain("copilot-enabled-agents: claude, codex, opencode");
     expect(written).toContain("body v2"); // bundled body was updated
+  });
+});
+
+describe("removeSeededBuiltin", () => {
+  it("removes a seeded builtin folder and its files", async () => {
+    const fs = memFs({ [MD]: skill(1).skillMd, [SCRIPT]: "// script v1" });
+    const removed = await removeSeededBuiltin(FOLDER, "copilot-web-search", fs);
+
+    expect(removed).toBe(true);
+    expect(fs.files.has(MD)).toBe(false);
+    expect(fs.files.has(SCRIPT)).toBe(false);
+  });
+
+  it("is a no-op when the skill folder is absent", async () => {
+    const fs = memFs();
+    expect(await removeSeededBuiltin(FOLDER, "copilot-web-search", fs)).toBe(false);
+  });
+
+  it("refuses to remove a user-authored skill that lacks the builtin version marker", async () => {
+    const userContent =
+      "---\nname: copilot-web-search\ndescription: my custom search\n---\ncustom body";
+    const fs = memFs({ [MD]: userContent });
+    const removed = await removeSeededBuiltin(FOLDER, "copilot-web-search", fs);
+
+    expect(removed).toBe(false);
+    expect(fs.files.get(MD)).toBe(userContent);
   });
 });

--- a/src/agentMode/skills/builtin/seedBuiltinSkills.ts
+++ b/src/agentMode/skills/builtin/seedBuiltinSkills.ts
@@ -13,6 +13,8 @@ export interface BuiltinSeedFs {
   read(relPath: string): Promise<string>;
   write(relPath: string, content: string): Promise<void>;
   mkdir(relPath: string): Promise<void>;
+  /** Remove a directory and its contents. Used to prune a de-gated builtin. */
+  rmRecursive(relPath: string): Promise<void>;
 }
 
 export interface SeedBuiltinSkillsOptions {
@@ -144,4 +146,35 @@ export async function seedBuiltinSkills(
     logInfo(`[Skills] seeded builtin skills: ${seeded.join(", ")}`);
   }
   return { seeded };
+}
+
+/**
+ * Remove a previously-seeded builtin skill folder. Used to de-gate a
+ * conditionally-seeded builtin (e.g. the Miyo skill when the user turns Miyo
+ * off): once the canonical dir is gone, the next `SkillManager.refresh()`
+ * reverse-sweep prunes the agent-dir symlinks pointing at it.
+ *
+ * Guarded by the same `copilot-builtin-version` marker the seeder uses: a
+ * folder whose SKILL.md lacks the marker is user-authored and is left
+ * untouched, even if its name collides with a builtin. A missing folder is a
+ * no-op. Returns true iff a builtin copy was actually removed.
+ */
+export async function removeSeededBuiltin(
+  skillsFolderRelPath: string,
+  name: string,
+  fs: BuiltinSeedFs
+): Promise<boolean> {
+  const dir = joinPosix(skillsFolderRelPath, name);
+  const skillMdPath = joinPosix(dir, "SKILL.md");
+  try {
+    if (!(await fs.exists(skillMdPath))) return false;
+    // null marker = user-authored file → never delete.
+    if (seededVersion(await fs.read(skillMdPath)) === null) return false;
+    await fs.rmRecursive(dir);
+    logInfo(`[Skills] removed de-gated builtin skill: ${name}`);
+    return true;
+  } catch (e) {
+    logError(`[Skills] failed to remove de-gated builtin skill ${name}`, e);
+    return false;
+  }
 }


### PR DESCRIPTION
Closes logancyang/obsidian-copilot-preview#106.

## What

Ships a bundled `miyo-search` builtin Agent Mode skill that grounds the agent in the user's vault via the Miyo desktop app's `miyo` CLI — no MCP server, no bash dependency, no key handed to the agent.

The skill is a prose `SKILL.md` (no helper script — the `miyo` binary the Miyo app installs *is* the runnable) telling the agent to call:

- `miyo search "<query>" --json` — local semantic search
- `miyo files [--title] [--path] [--mtime-after] --json` — browse the index

The agent parses the JSON itself; no `jq`/pipes/`$(...)`/heredocs, so the same instructions work under POSIX shells **and** Windows PowerShell.

## Cross-platform binary resolution

PATH-first, with a per-OS absolute fallback (verified against Miyo's `desktop/electron/src/main/cli-installer.ts`):

| OS | Absolute install path |
| --- | --- |
| macOS / Linux | `~/.miyo/bin/miyo` (symlink) |
| Windows | `%LOCALAPPDATA%\Miyo\bin\miyo\miyo.exe` (copied) |

The fallback matters because Obsidian-launched shells often inherit a reduced PATH that misses the `~/.miyo/bin` entry Miyo's installer adds. The CLI discovers the running service on its own (`service.json` → `127.0.0.1:8742`), so no `--url` is needed for local Miyo; it's documented only for the explicit remote-Miyo case.

## Gating on Miyo availability

The skill surfaces only while Miyo is in use:

- The host seeds it when `shouldUseMiyo(getSettings())` is true and **prunes** the seeded copy when Miyo is off. Once the canonical dir is gone, `SkillManager.refresh()`'s reverse-sweep removes the agent-dir symlinks.
- Re-runs on canonical-skills-folder change and on Miyo-availability settings flips (`enableMiyo` / `miyoServerUrl` / `isPlusUser`).
- `managedBuiltinSkills(includeMiyo)` keeps the gate decision in the host layer (the `skills/` layer must not import `@/miyo`) while staying unit-testable.
- `removeSeededBuiltin()` deletes only folders carrying the `copilot-builtin-version` marker, never a user-authored skill of the same name.

## Graceful degradation

The `SKILL.md` distinguishes the two failure modes for the agent: **binary not found after trying the absolute path** → Miyo isn't installed; **command runs but can't reach the service** ("Is the Miyo app running?") → Miyo isn't running. Both say "don't retry in a loop."

## Tests

- `builtinSkills.test.ts`: Miyo skill shape (separate from the 4 Plus skills, no script, version/frontmatter sync, no Plus env), documents `search`/`files`/`--json`, per-OS absolute paths, degradation guidance; `managedBuiltinSkills` gating + stable-reference behavior.
- `seedBuiltinSkills.test.ts`: `removeSeededBuiltin` removes a seeded builtin, no-ops when absent, refuses user-authored folders.
- Full suite green (3527 passed), `tsc` + lint clean, production build clean.

## Out of scope / follow-ups

- **Windows installer PATH** (an issue task) is owned by the Miyo repo and already implemented there (`cli-installer.ts` writes the User `Path`); nothing to do here.
- **Remote Miyo (`MIYO_URL`) env injection** for the case where the user runs Miyo on another device: the skill documents `--url`, but auto-injecting `MIYO_URL` into the agent spawn env is left as a follow-up since the success criteria target local-loopback Miyo.
- **Backend coverage**: fanned out to claude/codex/opencode to match the existing builtin-skill precedent; whether Codex/OpenCode consume `SKILL.md` as richly as Claude is the issue's open question and unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
