### PR TITLE
fix(agent-mode): stop chat file links from recreating the vault path on click

### DIFF
--- a/src/agentMode/skills/ui/SkillsSettings.tsx
+++ b/src/agentMode/skills/ui/SkillsSettings.tsx
@@ -22,6 +22,8 @@ import { Input } from "@/components/ui/input";
 import { SettingItem } from "@/components/ui/setting-item";
 import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
+import { openWithSystemDefault } from "@/utils/openWithSystemDefault";
+import { getVaultBase, toVaultRelative } from "@/utils/vaultPath";
 import { updateSetting, useSettingsValue, validateSkillsFolder } from "@/settings/model";
 import { AlertTriangle, Folder, Search } from "lucide-react";
 import { App, FileSystemAdapter, Notice, TFile, TFolder } from "obsidian";
@@ -153,8 +155,8 @@ export const SkillsSettings: React.FC = () => {
    */
   const handleOpenSkillMdAbsPath = useCallback(
     (absPath: string) => {
-      const vaultRel = vaultRelativePath(app, absPath);
-      if (vaultRel !== null && app.vault.getAbstractFileByPath(vaultRel) instanceof TFile) {
+      const vaultRel = toVaultRelative(absPath, getVaultBase(app));
+      if (vaultRel !== absPath && app.vault.getAbstractFileByPath(vaultRel) instanceof TFile) {
         void app.workspace.openLinkText(vaultRel, "", true);
         return;
       }
@@ -174,8 +176,8 @@ export const SkillsSettings: React.FC = () => {
   /** Reveal the canonical skill folder in Obsidian's file explorer. */
   const handleRevealInVault = useCallback(
     (skill: Skill) => {
-      const folderRel = vaultRelativePath(app, skill.dirPath);
-      if (folderRel === null) {
+      const folderRel = toVaultRelative(skill.dirPath, getVaultBase(app));
+      if (folderRel === skill.dirPath) {
         new Notice("Could not resolve the skill folder inside this vault.");
         return;
       }
@@ -463,53 +465,6 @@ function filterSkills(skills: Skill[], query: string): Skill[] {
 /** Pluralise the skill count for the toolbar. */
 function formatSkillCount(n: number): string {
   return `${n} skill${n === 1 ? "" : "s"}`;
-}
-
-/**
- * Open an absolute file path with the OS default app. Used when a SKILL.md
- * lives under an agent dotfile folder that Obsidian doesn't index. Returns
- * via a `Notice` on failure so the user still sees a path they can paste
- * into their own editor.
- */
-async function openWithSystemDefault(absPath: string): Promise<void> {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const electron = require("electron") as {
-      shell?: { openPath?: (path: string) => Promise<string> };
-      remote?: { shell?: { openPath?: (path: string) => Promise<string> } };
-    };
-    const shell = electron.shell ?? electron.remote?.shell;
-    if (!shell?.openPath) {
-      new Notice(`Open this file to edit it: ${absPath}`);
-      return;
-    }
-    const errMsg = await shell.openPath(absPath);
-    if (typeof errMsg === "string" && errMsg.length > 0) {
-      logError(`[skills] shell.openPath failed for ${absPath}: ${errMsg}`);
-      new Notice(`Could not open SKILL.md: ${errMsg}`);
-    }
-  } catch (err) {
-    logError(`[skills] openWithSystemDefault failed for ${absPath}:`, err);
-    new Notice(`Open this file to edit it: ${absPath}`);
-  }
-}
-
-/**
- * Convert an absolute path returned by `SkillManager` into a vault-relative
- * POSIX path suitable for `openLinkText` / `revealInFolder`. Returns `null`
- * if the vault has no `FileSystemAdapter` or the absolute path lies outside
- * the vault.
- */
-function vaultRelativePath(app: App, absPath: string): string | null {
-  const adapter = app.vault.adapter;
-  if (!(adapter instanceof FileSystemAdapter)) return null;
-  const base = adapter.getBasePath().replace(/[/\\]+$/, "");
-  const norm = absPath.replace(/\\/g, "/");
-  const baseNorm = base.replace(/\\/g, "/");
-  if (norm === baseNorm) return "";
-  const prefix = `${baseNorm}/`;
-  if (!norm.startsWith(prefix)) return null;
-  return norm.slice(prefix.length);
 }
 
 /**

--- a/src/agentMode/ui/ActionCard.tsx
+++ b/src/agentMode/ui/ActionCard.tsx
@@ -4,7 +4,7 @@ import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
 import type { AgentToolStatus } from "@/agentMode/session/types";
 import { lookupToolSummary } from "@/agentMode/ui/toolSummaries";
 import { renderDiff } from "@/agentMode/ui/diffRender";
-import { getVaultBase } from "@/agentMode/ui/vaultPath";
+import { getVaultBase } from "@/utils/vaultPath";
 import { cn } from "@/lib/utils";
 import { useApp } from "@/context";
 

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -2,7 +2,7 @@ import type { LucideIcon } from "lucide-react";
 import { Bot, MessageCircleQuestion } from "lucide-react";
 import { pickToolIcon } from "@/agentMode/ui/toolIcons";
 import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
-import { toVaultRelative } from "@/agentMode/ui/vaultPath";
+import { toVaultRelative } from "@/utils/vaultPath";
 
 /**
  * Render-time context passed through to the summary callbacks that need

--- a/src/utils/openWithSystemDefault.ts
+++ b/src/utils/openWithSystemDefault.ts
@@ -1,0 +1,34 @@
+import { logError } from "@/logger";
+import { Notice } from "obsidian";
+
+/**
+ * Open an absolute filesystem path with the OS default application via
+ * Electron's shell. Used for paths that should not be routed through
+ * `app.workspace.openLinkText` — e.g. files outside the vault, or under
+ * agent dotfile folders Obsidian doesn't index — because `openLinkText`
+ * would otherwise materialize a phantom note (and its parent folders) for
+ * an unresolved target. Surfaces the path via a `Notice` on failure so the
+ * user can still open it manually.
+ */
+export async function openWithSystemDefault(absPath: string): Promise<void> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const electron = require("electron") as {
+      shell?: { openPath?: (path: string) => Promise<string> };
+      remote?: { shell?: { openPath?: (path: string) => Promise<string> } };
+    };
+    const shell = electron.shell ?? electron.remote?.shell;
+    if (!shell?.openPath) {
+      new Notice(`Open this file manually: ${absPath}`);
+      return;
+    }
+    const errMsg = await shell.openPath(absPath);
+    if (typeof errMsg === "string" && errMsg.length > 0) {
+      logError(`openWithSystemDefault: shell.openPath failed for ${absPath}: ${errMsg}`);
+      new Notice(`Could not open file: ${errMsg}`);
+    }
+  } catch (err) {
+    logError(`openWithSystemDefault failed for ${absPath}:`, err);
+    new Notice(`Open this file manually: ${absPath}`);
+  }
+}

--- a/src/utils/renderMarkdown.test.ts
+++ b/src/utils/renderMarkdown.test.ts
@@ -26,14 +26,19 @@ const VAULT = "/Users/me/vault";
 
 interface TestApp {
   workspace: { openLinkText: jest.Mock; getActiveFile: () => null };
-  vault: { adapter: unknown };
+  vault: { adapter: unknown; getAbstractFileByPath: jest.Mock };
 }
 
-function buildApp(base = VAULT): TestApp {
+function buildApp(base = VAULT, indexedFiles: string[] = []): TestApp {
   const adapter = new (FileSystemAdapter as unknown as new (b: string) => unknown)(base);
   return {
     workspace: { openLinkText: jest.fn(), getActiveFile: () => null },
-    vault: { adapter },
+    vault: {
+      adapter,
+      getAbstractFileByPath: jest.fn((path: string) =>
+        indexedFiles.includes(path) ? { path } : null
+      ),
+    },
   };
 }
 
@@ -83,6 +88,24 @@ describe("renderMarkdown internal-link handling", () => {
     await clickInternalLink(app, "/etc/passwd");
     expect(app.workspace.openLinkText).not.toHaveBeenCalled();
     expect(openWithSystemDefault).toHaveBeenCalledWith("/etc/passwd");
+  });
+
+  it("opens root-relative vault links through openLinkText", async () => {
+    const app = buildApp(VAULT, ["Folder/Foo.md"]);
+    await clickInternalLink(app, "/Folder/Foo.md");
+    expect(app.workspace.openLinkText).toHaveBeenCalledWith("Folder/Foo.md", "source.md", false);
+    expect(openWithSystemDefault).not.toHaveBeenCalled();
+  });
+
+  it("opens root-relative vault links with headings through openLinkText", async () => {
+    const app = buildApp(VAULT, ["Folder/Foo.md"]);
+    await clickInternalLink(app, "/Folder/Foo.md#Heading");
+    expect(app.workspace.openLinkText).toHaveBeenCalledWith(
+      "Folder/Foo.md#Heading",
+      "source.md",
+      false
+    );
+    expect(openWithSystemDefault).not.toHaveBeenCalled();
   });
 
   it("passes plain relative wikilinks through unchanged", async () => {

--- a/src/utils/renderMarkdown.test.ts
+++ b/src/utils/renderMarkdown.test.ts
@@ -1,0 +1,100 @@
+/* eslint-disable obsidianmd/prefer-active-doc -- jsdom unit test runs in a single realm; activeDocument is unavailable */
+import { openWithSystemDefault } from "@/utils/openWithSystemDefault";
+import { renderMarkdown } from "@/utils/renderMarkdown";
+import { __resetVaultBaseCache } from "@/utils/vaultPath";
+import { App, FileSystemAdapter } from "obsidian";
+
+jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
+jest.mock("@/utils/openWithSystemDefault", () => ({ openWithSystemDefault: jest.fn() }));
+jest.mock("obsidian", () => ({
+  FileSystemAdapter: class FileSystemAdapter {
+    private readonly base: string;
+    constructor(base = "/vault") {
+      this.base = base;
+    }
+    getBasePath(): string {
+      return this.base;
+    }
+  },
+  Notice: jest.fn(),
+  // Mirror the modern MarkdownRenderer.render(app, md, el, sourcePath, component)
+  // signature; a no-op is enough since the tests inject their own anchors.
+  MarkdownRenderer: { render: jest.fn().mockResolvedValue(undefined) },
+}));
+
+const VAULT = "/Users/me/vault";
+
+interface TestApp {
+  workspace: { openLinkText: jest.Mock; getActiveFile: () => null };
+  vault: { adapter: unknown };
+}
+
+function buildApp(base = VAULT): TestApp {
+  const adapter = new (FileSystemAdapter as unknown as new (b: string) => unknown)(base);
+  return {
+    workspace: { openLinkText: jest.fn(), getActiveFile: () => null },
+    vault: { adapter },
+  };
+}
+
+/** Render into a div, inject an `a.internal-link`, and dispatch a click on it. */
+async function clickInternalLink(
+  app: TestApp,
+  dataHref: string,
+  init: MouseEventInit = { button: 0 }
+): Promise<void> {
+  const el = document.createElement("div");
+  document.body.appendChild(el);
+  const component = { register: jest.fn() } as unknown as Parameters<typeof renderMarkdown>[4];
+  await renderMarkdown(app as unknown as App, "irrelevant", el, "source.md", component);
+  const a = document.createElement("a");
+  a.className = "internal-link";
+  a.setAttribute("data-href", dataHref);
+  el.appendChild(a);
+  a.dispatchEvent(new MouseEvent("click", { bubbles: true, ...init }));
+}
+
+describe("renderMarkdown internal-link handling", () => {
+  beforeEach(() => {
+    __resetVaultBaseCache();
+    jest.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("converts an absolute in-vault path to vault-relative before openLinkText", async () => {
+    const app = buildApp();
+    await clickInternalLink(app, "/Users/me/vault/00_Inbox/Foo.md");
+    expect(app.workspace.openLinkText).toHaveBeenCalledWith("00_Inbox/Foo.md", "source.md", false);
+    expect(openWithSystemDefault).not.toHaveBeenCalled();
+  });
+
+  it("decodes percent-encoded absolute paths before converting", async () => {
+    const app = buildApp();
+    await clickInternalLink(app, "/Users/me/vault/00_Inbox/Foo%20Bar.md");
+    expect(app.workspace.openLinkText).toHaveBeenCalledWith(
+      "00_Inbox/Foo Bar.md",
+      "source.md",
+      false
+    );
+  });
+
+  it("does not open (or create) an absolute path outside the vault — hands off to the OS", async () => {
+    const app = buildApp();
+    await clickInternalLink(app, "/etc/passwd");
+    expect(app.workspace.openLinkText).not.toHaveBeenCalled();
+    expect(openWithSystemDefault).toHaveBeenCalledWith("/etc/passwd");
+  });
+
+  it("passes plain relative wikilinks through unchanged", async () => {
+    const app = buildApp();
+    await clickInternalLink(app, "Some Note");
+    expect(app.workspace.openLinkText).toHaveBeenCalledWith("Some Note", "source.md", false);
+    expect(openWithSystemDefault).not.toHaveBeenCalled();
+  });
+
+  it("opens in a new leaf on cmd/ctrl-click", async () => {
+    const app = buildApp();
+    await clickInternalLink(app, "/Users/me/vault/00_Inbox/Foo.md", { button: 0, ctrlKey: true });
+    expect(app.workspace.openLinkText).toHaveBeenCalledWith("00_Inbox/Foo.md", "source.md", true);
+  });
+});

--- a/src/utils/renderMarkdown.ts
+++ b/src/utils/renderMarkdown.ts
@@ -1,3 +1,5 @@
+import { openWithSystemDefault } from "@/utils/openWithSystemDefault";
+import { getVaultBase, isAbsolutePath, toVaultRelative } from "@/utils/vaultPath";
 import { App, Component, MarkdownRenderer } from "obsidian";
 
 /**
@@ -59,8 +61,30 @@ function wireInternalLinks(
     if (!link || !el.contains(link)) return;
     if (e.button !== 0 && e.button !== 1) return;
     e.preventDefault();
-    const href = link.getAttribute("data-href") || link.getAttribute("href");
-    if (!href) return;
+    const raw = link.getAttribute("data-href") || link.getAttribute("href");
+    if (!raw) return;
+    // Coding agents that run with the vault as their cwd emit links with the
+    // note's absolute on-disk path (e.g. `/Users/me/Vault/Inbox/Foo.md`).
+    // `openLinkText` resolves its target relative to the vault root, dropping
+    // the leading slash — so an absolute path becomes a bogus vault-relative
+    // path that materializes the whole `Users/me/Vault/...` folder chain as a
+    // phantom note. Normalize before opening; mirror `ActionCard`.
+    let href = raw;
+    try {
+      href = decodeURIComponent(raw);
+    } catch {
+      // keep raw on malformed percent escapes
+    }
+    if (isAbsolutePath(href)) {
+      const rel = toVaultRelative(href, getVaultBase(app));
+      if (rel === href) {
+        // Absolute path outside the vault — don't let openLinkText fabricate a
+        // phantom note; hand off to the OS default app instead.
+        void openWithSystemDefault(href);
+        return;
+      }
+      href = rel;
+    }
     const newLeaf = e.button === 1 || e.ctrlKey || e.metaKey;
     void app.workspace.openLinkText(href, sourcePath, newLeaf);
   };

--- a/src/utils/renderMarkdown.ts
+++ b/src/utils/renderMarkdown.ts
@@ -75,6 +75,7 @@ function wireInternalLinks(
     } catch {
       // keep raw on malformed percent escapes
     }
+    href = toExistingRootRelativeVaultPath(app, href) ?? href;
     if (isAbsolutePath(href)) {
       const rel = toVaultRelative(href, getVaultBase(app));
       if (rel === href) {
@@ -94,4 +95,14 @@ function wireInternalLinks(
     el.removeEventListener("click", handleClick);
     el.removeEventListener("auxclick", handleClick);
   });
+}
+
+function toExistingRootRelativeVaultPath(app: App, href: string): string | null {
+  if (!href.startsWith("/") || href.startsWith("//")) return null;
+  const rel = href.replace(/^\/+/, "");
+  if (!rel) return null;
+  const anchorIndex = rel.indexOf("#");
+  const filePath = anchorIndex === -1 ? rel : rel.slice(0, anchorIndex);
+  if (!filePath) return null;
+  return app.vault.getAbstractFileByPath(filePath) ? rel : null;
 }

--- a/src/utils/vaultPath.test.ts
+++ b/src/utils/vaultPath.test.ts
@@ -1,4 +1,4 @@
-import { toVaultRelative } from "@/agentMode/ui/vaultPath";
+import { isAbsolutePath, toVaultRelative } from "@/utils/vaultPath";
 
 describe("toVaultRelative", () => {
   const base = "/Users/me/vault";
@@ -29,5 +29,25 @@ describe("toVaultRelative", () => {
 
   it("handles nested subdirectories", () => {
     expect(toVaultRelative("/Users/me/vault/a/b/c/d.md", base)).toBe("a/b/c/d.md");
+  });
+
+  it("does not treat a sibling vault as inside (path-segment boundary)", () => {
+    expect(toVaultRelative("/Users/me/vault-other/x.md", base)).toBe("/Users/me/vault-other/x.md");
+  });
+});
+
+describe("isAbsolutePath", () => {
+  it("detects POSIX absolute paths", () => {
+    expect(isAbsolutePath("/Users/me/vault/a.md")).toBe(true);
+  });
+
+  it("detects Windows drive-letter absolute paths", () => {
+    expect(isAbsolutePath("C:\\Users\\me\\a.md")).toBe(true);
+    expect(isAbsolutePath("C:/Users/me/a.md")).toBe(true);
+  });
+
+  it("treats relative paths as not absolute", () => {
+    expect(isAbsolutePath("notes/a.md")).toBe(false);
+    expect(isAbsolutePath("Some Note")).toBe(false);
   });
 });

--- a/src/utils/vaultPath.ts
+++ b/src/utils/vaultPath.ts
@@ -47,7 +47,7 @@ export function toVaultRelative(p: string, vaultBase: string | null): string {
   return rel || p;
 }
 
-function isAbsolutePath(p: string): boolean {
+export function isAbsolutePath(p: string): boolean {
   return p.startsWith("/") || /^[A-Za-z]:[\\/]/.test(p);
 }
 


### PR DESCRIPTION
Agents emit chat links to notes using the note's absolute on-disk path (e.g. `/Users/me/Vault/Inbox/Foo.md`), and the shared markdown link handler (`wireInternalLinks`) passed that href straight to `openLinkText`, which resolves relative to the vault root — so clicking the link created the whole `Users/me/Vault/…` chain as a phantom note and folders instead of opening the existing note. This normalizes the clicked href: decode percent-encoding, convert in-vault absolute paths to vault-relative before `openLinkText`, and route out-of-vault absolute paths to the OS opener so no phantom note is created. The vault-path helpers move to `src/utils/vaultPath.ts` and a shared `openWithSystemDefault` is extracted, de-duping the copies in `SkillsSettings`. Because the one handler is shared, this also fixes regular chat, plan preview, and quick-ask. Added `src/utils/renderMarkdown.test.ts` plus the relocated vault-path tests; full suite, lint, and tsc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
