### PR TITLE
fix(agent-mode): disable Claude thinking when the toggle is off

### DIFF
--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -508,6 +508,44 @@ describe("ClaudeSdkBackendProcess.newSession dynamic catalog", () => {
     const call = promptCalls[0][0] as { options: { effort?: string } };
     expect(call.options.effort).toBe("high");
   });
+
+  it("disables thinking when the extended-thinking toggle is off", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const proc = new ClaudeSdkBackendProcess({
+      pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: { vault: {} } as any,
+      clientVersion: "1.2.3",
+      descriptor: fakeDescriptor(),
+      getEnableThinking: () => false,
+    });
+
+    const { sessionId } = await proc.newSession({ cwd: "/vault", mcpServers: [] });
+    proc.registerSessionHandler(sessionId, () => {});
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    const call = getPromptQueryCalls()[0][0] as { options: { thinking?: unknown } };
+    expect(call.options.thinking).toEqual({ type: "disabled" });
+  });
+
+  it("requests summarized adaptive thinking when the toggle is on", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const proc = new ClaudeSdkBackendProcess({
+      pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: { vault: {} } as any,
+      clientVersion: "1.2.3",
+      descriptor: fakeDescriptor(),
+      getEnableThinking: () => true,
+    });
+
+    const { sessionId } = await proc.newSession({ cwd: "/vault", mcpServers: [] });
+    proc.registerSessionHandler(sessionId, () => {});
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    const call = getPromptQueryCalls()[0][0] as { options: { thinking?: unknown } };
+    expect(call.options.thinking).toEqual({ type: "adaptive", display: "summarized" });
+  });
 });
 
 function errorResultMessage(errors: string[]): SDKMessage {

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -325,11 +325,14 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     if (session.model) options.model = session.model;
     if (session.permissionMode) options.permissionMode = session.permissionMode;
     if (session.effort) options.effort = session.effort;
-    if (this.opts.getEnableThinking?.()) {
-      // Opus 4.7+ defaults thinking.display to "omitted", so summaries never
-      // reach the UI; force "summarized" (pre-4.7 models default to summarized).
-      options.thinking = { type: "adaptive", display: "summarized" };
-    }
+    // Keep the toggle authoritative. Leaving `thinking` unset when off lets the
+    // model's default take over — Sonnet 4.6 / Opus 4.6 default to adaptive
+    // "summarized", so reasoning keeps streaming — so disable it explicitly.
+    // When on, Opus 4.7+ defaults display to "omitted" (summaries never reach
+    // the UI), so force "summarized" (pre-4.7 models default to summarized).
+    options.thinking = this.opts.getEnableThinking?.()
+      ? { type: "adaptive", display: "summarized" }
+      : { type: "disabled" };
     const envOverrides = this.opts.getEnvOverrides?.();
     // Builtin Copilot Plus skill scripts read the license from the env. The
     // descriptor supplies it via `getManagedEnv` (sdk/ can't import backends/);


### PR DESCRIPTION
Turning off **Show extended thinking** for the Claude agent left `options.thinking` unset, so the Claude Agent SDK fell back to the model's default — Sonnet 4.6 / Opus 4.6 default to adaptive `summarized`, so reasoning blocks kept streaming into the chat. This was confirmed by tracing the latest Agent Mode frame log, which showed live `claude-sdk` `thinking_delta` frames on `sonnet` despite the toggle being meant to suppress them. The fix makes the toggle authoritative: `options.thinking` is now always set, to `{ type: "disabled" }` when off (no reasoning, saves tokens) and `{ type: "adaptive", display: "summarized" }` when on. Added two unit tests covering both branches; full suite, lint, and format pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)