### PR TITLE
refactor(agent-mode): centralize the ~/.obsidian-copilot app-data root + guard home dir

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -237,6 +237,7 @@ export default [
   {
     files: [
       "src/agentMode/**",
+      "src/utils/appPaths.ts",
       "src/utils/detectBinary.ts",
       "src/utils/binaryPath.ts",
       "src/utils/nodeToolBinDirs.ts",

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -50,6 +50,7 @@ jest.mock("@/settings/model", () => {
 });
 
 import { OPENCODE_MIN_ACP_VERSION, OPENCODE_PINNED_VERSION } from "@/constants";
+import { copilotAppDataDir } from "@/utils/appPaths";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -414,9 +415,27 @@ describe("install-dir paths (outside the vault)", () => {
     expect(opencodeManagedDataDir("/Users/me")).not.toContain("plugins");
   });
 
+  it("opencodeManagedDataDir composes under the shared app-data root", () => {
+    expect(opencodeManagedDataDir("/Users/me")).toBe(
+      path.join(copilotAppDataDir("/Users/me"), "opencode")
+    );
+  });
+
   it("getDataDir resolves to the home-dir location, not the vault", () => {
     jest.mocked(os.homedir).mockReturnValue("/Users/me");
     const mgr = new OpencodeBinaryManager(vaultPlugin());
     expect(mgr.getDataDir()).toBe(opencodeManagedDataDir("/Users/me"));
   });
+
+  it.each([
+    ["empty home", ""],
+    ["filesystem root", path.parse(process.cwd()).root],
+  ])(
+    "getDataDir throws an actionable error when the home dir is unusable (%s)",
+    (_label, badHome) => {
+      jest.mocked(os.homedir).mockReturnValue(badHome);
+      const mgr = new OpencodeBinaryManager(vaultPlugin());
+      expect(() => mgr.getDataDir()).toThrow(/home directory/i);
+    }
+  );
 });

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -17,6 +17,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { promisify } from "node:util";
 import { renameWithRetry } from "@/agentMode/skills/renameWithRetry";
+import { copilotAppDataDir } from "@/utils/appPaths";
 import { expectedBinaryName, resolveOpencodeTarget } from "./platformResolver";
 
 const execFileAsync = promisify(execFile);
@@ -158,8 +159,10 @@ function clearOpencodeBinary(): void {
 
 /**
  * Per-user, OS-local directory the managed opencode binary installs into,
- * OUTSIDE the Obsidian vault. Mirrors how companion tools install their CLIs
- * under the home dir (e.g. Miyo's `~/.miyo/bin`).
+ * OUTSIDE the Obsidian vault — `~/.obsidian-copilot/opencode`. Composed under
+ * the shared {@link copilotAppDataDir} root so the namespace is defined once.
+ * Mirrors how companion tools install their CLIs under the home dir (e.g.
+ * Miyo's `~/.miyo/bin`).
  *
  * Why not the plugin data dir (`<vault>/.obsidian/plugins/copilot/data/...`):
  * that lives inside the vault, so sync services (Obsidian Sync, iCloud,
@@ -169,7 +172,7 @@ function clearOpencodeBinary(): void {
  * scope while staying per-user.
  */
 export function opencodeManagedDataDir(homeDir: string): string {
-  return path.join(homeDir, ".obsidian-copilot", "opencode");
+  return path.join(copilotAppDataDir(homeDir), "opencode");
 }
 
 /**
@@ -214,7 +217,19 @@ export class OpencodeBinaryManager {
     if (!(adapter instanceof FileSystemAdapter)) {
       throw new Error("Agent Mode requires desktop Obsidian (FileSystemAdapter).");
     }
-    return opencodeManagedDataDir(os.homedir());
+    const home = os.homedir();
+    // Guard against a missing/garbage home dir (empty string, or the filesystem
+    // root) before we build an install path under it: `os.homedir()` can return
+    // "" in broken/sandboxed environments, and installing into `/.obsidian-copilot`
+    // would be wrong and almost certainly unwritable. Fail with an actionable
+    // message instead of a confusing downstream spawn error.
+    if (!home || !path.isAbsolute(home) || path.parse(home).root === home) {
+      throw new Error(
+        "Could not resolve your home directory to install the opencode runtime. " +
+          "Agent Mode installs it under ~/.obsidian-copilot; check that your account has a valid home directory."
+      );
+    }
+    return opencodeManagedDataDir(home);
   }
 
   getPinnedVersion(): string {
@@ -265,7 +280,18 @@ export class OpencodeBinaryManager {
       return { version, path: finalBinPath };
     }
 
-    await fs.promises.mkdir(dataDir, { recursive: true });
+    // Create the OS-local install root up front so an unwritable home dir
+    // (sandboxed/confined HOME on Linux Flatpak/Snap, locked-down accounts)
+    // fails here with an actionable message naming the path, rather than later
+    // mid-extraction.
+    try {
+      await fs.promises.mkdir(dataDir, { recursive: true });
+    } catch (e) {
+      throw new Error(
+        `Could not create the opencode install directory at ${dataDir}: ` +
+          `${e instanceof Error ? e.message : String(e)}. Check that it is writable.`
+      );
+    }
     const tmpDir = path.join(dataDir, `.tmp-${version}-${randomBytes(4).toString("hex")}`);
     await fs.promises.mkdir(tmpDir, { recursive: true });
 

--- a/src/utils/appPaths.test.ts
+++ b/src/utils/appPaths.test.ts
@@ -1,0 +1,14 @@
+import * as path from "node:path";
+import { COPILOT_APP_DIR_NAME, copilotAppDataDir } from "./appPaths";
+
+describe("copilotAppDataDir", () => {
+  it("is ~/.obsidian-copilot under the given home dir", () => {
+    expect(copilotAppDataDir("/Users/me")).toBe(path.join("/Users/me", ".obsidian-copilot"));
+  });
+
+  it("uses the dotted, obsidian-prefixed namespace (not ~/.copilot)", () => {
+    expect(COPILOT_APP_DIR_NAME).toBe(".obsidian-copilot");
+    // Guard against a regression to the GitHub-Copilot-CLI-colliding name.
+    expect(COPILOT_APP_DIR_NAME).not.toBe(".copilot");
+  });
+});

--- a/src/utils/appPaths.ts
+++ b/src/utils/appPaths.ts
@@ -1,0 +1,27 @@
+import * as path from "node:path";
+
+/**
+ * Name of Copilot's per-user, OS-level data directory: `~/.obsidian-copilot`.
+ *
+ * This is the single source of truth for our home-directory namespace. We
+ * deliberately use a dotted, `obsidian-`-prefixed name rather than `~/.copilot`
+ * (which collides with the GitHub Copilot CLI) and rather than OS-native
+ * app-data dirs, to match the convention of the CLI runtimes we manage and sit
+ * beside (`~/.opencode`, `~/.miyo`, `~/.codex`, `~/.claude`).
+ *
+ * Anything Copilot installs at the OS level (managed runtimes, caches) must
+ * live under {@link copilotAppDataDir} so the namespace is defined exactly
+ * once. Note: this dir is shared across every vault under the same OS account,
+ * so consumers must treat it as shared and never perform per-vault destructive
+ * operations on sibling entries.
+ */
+export const COPILOT_APP_DIR_NAME = ".obsidian-copilot";
+
+/**
+ * Absolute path to Copilot's OS-level data root for the given home directory.
+ * Pure (takes `homeDir`) so it's trivially testable; callers pass
+ * `os.homedir()`.
+ */
+export function copilotAppDataDir(homeDir: string): string {
+  return path.join(homeDir, COPILOT_APP_DIR_NAME);
+}


### PR DESCRIPTION
Follow-up hardening to #2569. Relates to logancyang/obsidian-copilot-preview#135.

Moving the managed opencode binary out of the vault (#2569) made `~/.obsidian-copilot` our **first OS-level install namespace**. This locks down its shape before GA, while changing it is still free.

## 1. Single source of truth for the app-data root

New `src/utils/appPaths.ts`:

```ts
export const COPILOT_APP_DIR_NAME = ".obsidian-copilot";
export function copilotAppDataDir(homeDir: string): string;  // ~/.obsidian-copilot
```

- Defines the `~/.obsidian-copilot` root **exactly once** (it was previously a bare string literal inside the opencode backend, and the brand is already duplicated as literals elsewhere: the temp frame-log dir and the ACP client id).
- Documents *why* the name is what it is: not `~/.copilot` (collides with the GitHub Copilot CLI), and dotted/`obsidian-`-prefixed to match the CLI runtimes we sit beside (`~/.opencode`, `~/.miyo`, `~/.codex`, `~/.claude`).
- Documents the **"shared across every vault under one OS account, never per-vault destructive ops"** invariant — the exact constraint that produced the prune bug Codex caught on #2569.
- `opencodeManagedDataDir` now composes `<root>/opencode`, so future managed runtimes/caches compose under the same root instead of re-deriving the name.

## 2. Guard the home dir

- `getDataDir()` now rejects an unusable `os.homedir()` (empty string, or the filesystem root) with an actionable error, instead of building `/.obsidian-copilot` and failing obscurely later.
- The install-time `mkdir(dataDir)` is wrapped so an unwritable root (sandboxed/confined HOME on Linux Flatpak/Snap, locked-down accounts) fails with a message that names the path and says to check it's writable, rather than surfacing mid-extraction.

## Tests

- `appPaths.test.ts`: root is `~/.obsidian-copilot`; guards against a regression to `~/.copilot`.
- `OpencodeBinaryManager.test.ts`: `opencodeManagedDataDir` composes under `copilotAppDataDir`; `getDataDir` throws an actionable error for empty / filesystem-root home dirs.

Full suite green (3543 passed), tsc + lint + build clean.

## Not in scope (follow-up)

The uninstall-orphan problem (binary now survives plugin uninstall in `~/.obsidian-copilot`) is tracked separately as a "Remove downloaded runtimes" settings action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
