### PR TITLE
feat(agent-mode): make Uninstall fully reclaim opencode (all copies, incl. in-vault)

### DIFF
--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -56,6 +56,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
   computeInstallState,
+  legacyVaultDataDir,
   opencodeManagedDataDir,
   OpencodeBinaryManager,
   parseVersionFromStdout,
@@ -80,15 +81,19 @@ const FileSystemAdapterMock = jest.requireMock("obsidian").FileSystemAdapter as 
   getBasePath: () => string;
 };
 
+// Deliberately not ".obsidian": the config dir is user-configurable, so using a
+// non-default value proves the legacy-path code reads `vault.configDir`.
+const CONFIG_DIR = "my-config";
+
 /**
  * A desktop CopilotPlugin stand-in whose vault adapter passes the
- * `instanceof FileSystemAdapter` guard so getDataDir() resolves.
+ * `instanceof FileSystemAdapter` guard so getDataDir()/legacy paths resolve.
  */
-function vaultPlugin(pluginId = "copilot-test"): never {
+function vaultPlugin(vaultBase = "/vault", pluginId = "copilot-test"): never {
   const adapter = new FileSystemAdapterMock();
-  adapter.getBasePath = () => "/vault";
+  adapter.getBasePath = () => vaultBase;
   return {
-    app: { vault: { adapter } },
+    app: { vault: { adapter, configDir: CONFIG_DIR } },
     manifest: { id: pluginId },
   } as never;
 }
@@ -438,4 +443,101 @@ describe("install-dir paths (outside the vault)", () => {
       expect(() => mgr.getDataDir()).toThrow(/home directory/i);
     }
   );
+});
+
+describe("OpencodeBinaryManager.uninstall / downloadsSize", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await fs.promises.mkdtemp(path.join(os.tmpdir(), "opencode-home-"));
+    jest.mocked(os.homedir).mockReturnValue(home);
+  });
+
+  afterEach(async () => {
+    jest.mocked(os.homedir).mockReset();
+    await fs.promises.rm(home, { recursive: true, force: true });
+  });
+
+  /** Seed two managed version dirs under the OS-local install root. */
+  async function seedDownloads(mgr: OpencodeBinaryManager): Promise<string> {
+    const dataDir = mgr.getDataDir();
+    for (const [version, bytes] of [
+      ["1.14.0", 10],
+      ["1.15.0", 25],
+    ] as const) {
+      const bin = path.join(dataDir, version, "bin", "opencode");
+      await fs.promises.mkdir(path.dirname(bin), { recursive: true });
+      await fs.promises.writeFile(bin, "x".repeat(bytes));
+    }
+    return dataDir;
+  }
+
+  it("downloadsSize sums every downloaded binary; 0 when none", async () => {
+    const mgr = new OpencodeBinaryManager(vaultPlugin());
+    expect(await mgr.downloadsSize()).toBe(0);
+    await seedDownloads(mgr);
+    expect(await mgr.downloadsSize()).toBe(35);
+  });
+
+  it("uninstall wipes the whole install dir and clears managed settings", async () => {
+    const mgr = new OpencodeBinaryManager(vaultPlugin());
+    const dataDir = await seedDownloads(mgr);
+    settingsMock.__reset({
+      binaryPath: path.join(dataDir, "1.15.0", "bin", "opencode"),
+      binaryVersion: "1.15.0",
+      binarySource: "managed",
+    });
+
+    await mgr.uninstall();
+
+    expect(fs.existsSync(dataDir)).toBe(false);
+    expect(settingsMock.__get()).toEqual({
+      binaryPath: undefined,
+      binaryVersion: undefined,
+      binarySource: undefined,
+    });
+  });
+
+  it("uninstall keeps a custom binary path setting (only reclaims downloads)", async () => {
+    const mgr = new OpencodeBinaryManager(vaultPlugin());
+    const dataDir = await seedDownloads(mgr);
+    settingsMock.__reset({
+      binaryPath: "/usr/local/bin/opencode",
+      binaryVersion: "1.99.0",
+      binarySource: "custom",
+    });
+
+    await mgr.uninstall();
+
+    expect(fs.existsSync(dataDir)).toBe(false);
+    expect(settingsMock.__get().binaryPath).toBe("/usr/local/bin/opencode");
+  });
+
+  it("also counts and removes the pre-migration in-vault copy (one-click migration)", async () => {
+    const vaultBase = await fs.promises.mkdtemp(path.join(os.tmpdir(), "opencode-vault-"));
+    try {
+      const mgr = new OpencodeBinaryManager(vaultPlugin(vaultBase));
+      // Simulate a just-updated tester: binary still lives only inside the vault.
+      const legacy = legacyVaultDataDir(vaultBase, CONFIG_DIR, "copilot-test");
+      const legacyBin = path.join(legacy, "1.14.0", "bin", "opencode");
+      await fs.promises.mkdir(path.dirname(legacyBin), { recursive: true });
+      await fs.promises.writeFile(legacyBin, "z".repeat(40));
+      settingsMock.__reset({
+        binaryPath: legacyBin,
+        binaryVersion: "1.14.0",
+        binarySource: "managed",
+      });
+
+      // Counted even though nothing is in the OS-local dir yet, so the button
+      // isn't a no-op for a freshly-updated tester.
+      expect(await mgr.downloadsSize()).toBe(40);
+
+      await mgr.uninstall();
+
+      expect(fs.existsSync(legacy)).toBe(false);
+      expect(settingsMock.__get().binaryPath).toBeUndefined();
+    } finally {
+      await fs.promises.rm(vaultBase, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -176,6 +176,23 @@ export function opencodeManagedDataDir(homeDir: string): string {
 }
 
 /**
+ * The pre-#2569 in-vault install root,
+ * `<vault>/.obsidian/plugins/<id>/data/opencode`. Managed installs used to
+ * live here and were replicated across devices by every sync service.
+ *
+ * Kept only so the user-triggered {@link OpencodeBinaryManager.uninstall} can
+ * reclaim a preview tester's stale in-vault copy in the same click — there is
+ * no auto-running migration. Never written to.
+ */
+export function legacyVaultDataDir(
+  vaultBasePath: string,
+  configDir: string,
+  pluginId: string
+): string {
+  return path.join(vaultBasePath, configDir, "plugins", pluginId, "data", "opencode");
+}
+
+/**
  * Manages the lifecycle of the opencode binary on disk: platform-aware
  * download from GitHub releases, extraction into a per-user OS-local dir
  * (outside the vault, see {@link opencodeManagedDataDir}), and persistence of
@@ -434,19 +451,52 @@ export class OpencodeBinaryManager {
   }
 
   /**
-   * Remove the active managed version dir and clear settings. For a custom
-   * binary this only clears settings — the binary on disk belongs to the user
-   * and we don't touch it. Other version dirs are kept either way.
+   * Every dir {@link uninstall} reclaims: the OS-local managed root plus the
+   * pre-#2569 in-vault copy (so a tester who just updated, and still has the
+   * binary only inside the vault, isn't told there's nothing to remove).
+   * `getDataDir()` is resolved defensively so a bad home dir doesn't block
+   * reclaiming the in-vault copy.
    */
-  async uninstall(): Promise<void> {
-    const s = readOpencodeSettings();
-    if (s.binarySource === "managed" && s.binaryVersion) {
-      const versionDir = path.join(this.getDataDir(), s.binaryVersion);
-      await removeDir(versionDir).catch((e) =>
-        logError(`[AgentMode] failed to remove ${versionDir}`, e)
+  private reclaimableDirs(): string[] {
+    const dirs: string[] = [];
+    try {
+      dirs.push(this.getDataDir());
+    } catch {
+      /* unusable home dir — nothing managed to reclaim there */
+    }
+    const adapter = this.plugin.app.vault.adapter;
+    if (adapter instanceof FileSystemAdapter) {
+      dirs.push(
+        legacyVaultDataDir(
+          adapter.getBasePath(),
+          this.plugin.app.vault.configDir,
+          this.plugin.manifest.id
+        )
       );
     }
-    clearOpencodeBinary();
+    return dirs;
+  }
+
+  /** Total bytes of every downloaded managed binary (OS-local + legacy in-vault). */
+  async downloadsSize(): Promise<number> {
+    const sizes = await Promise.all(this.reclaimableDirs().map(dirSize));
+    return sizes.reduce((total, n) => total + n, 0);
+  }
+
+  /**
+   * Uninstall the managed opencode binary: remove EVERY downloaded copy — the
+   * whole OS-local `~/.obsidian-copilot/opencode` tree (all versions) AND the
+   * pre-#2569 in-vault copy — then clear managed settings.
+   *
+   * Wiping the legacy in-vault dir here means a preview tester migrates off the
+   * synced copy in one click (Uninstall, then Install). A custom binary path is
+   * left untouched — it lives outside our dirs and belongs to the user.
+   */
+  async uninstall(): Promise<void> {
+    await Promise.all(this.reclaimableDirs().map((dir) => removeDir(dir)));
+    if (readOpencodeSettings().binarySource !== "custom") {
+      clearOpencodeBinary();
+    }
   }
 
   /**
@@ -535,6 +585,29 @@ async function readManifest(p: string): Promise<InstallManifest | null> {
 
 async function removeDir(p: string): Promise<void> {
   await fs.promises.rm(p, { recursive: true, force: true });
+}
+
+/** Recursively sum the byte size of all files under `dir`; 0 if it's absent. */
+async function dirSize(dir: string): Promise<number> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  let total = 0;
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      total += await dirSize(full);
+    } else if (e.isFile()) {
+      total += await fs.promises
+        .stat(full)
+        .then((s) => s.size)
+        .catch(() => 0);
+    }
+  }
+  return total;
 }
 
 /**

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -106,19 +106,26 @@ const OpencodeManagedInstall: React.FC<{
 
   React.useEffect(() => () => abortRef.current?.abort(), []);
 
-  const handleUninstall = React.useCallback(() => {
+  // Uninstall fully reclaims opencode: it removes every downloaded copy — all
+  // versions under ~/.obsidian-copilot/opencode AND the old pre-migration copy
+  // inside the vault — and clears managed settings. The in-vault sweep lets a
+  // preview tester move off the synced binary in one click (Uninstall, then
+  // Install). The confirm shows the reclaimable size.
+  const handleUninstall = React.useCallback(async () => {
+    const bytes = await manager.downloadsSize().catch(() => 0);
     new ConfirmModal(
       app,
       async () => {
         try {
           await manager.uninstall();
-          new Notice("opencode uninstalled.");
+          new Notice(`opencode uninstalled${bytes > 0 ? ` (freed ${formatBytes(bytes)})` : ""}.`);
         } catch (e) {
           logError("[AgentMode] uninstall failed", e);
           new Notice(`Uninstall failed: ${e instanceof Error ? e.message : String(e)}`);
         }
       },
-      "Remove the installed opencode binary? Your BYOK keys and MCP config will be kept.",
+      `Remove all downloaded opencode binaries${bytes > 0 ? ` (${formatBytes(bytes)})` : ""}, ` +
+        "including any old copy inside your vault? Your custom binary path and BYOK keys are kept.",
       "Uninstall opencode",
       "Uninstall"
     ).open();


### PR DESCRIPTION
Closes logancyang/obsidian-copilot-preview#136.

Now that the managed opencode binary installs outside the vault (#2569 / #2571), uninstalling the Copilot plugin no longer removes it — the ~100 MB+ download can be orphaned. And preview testers still have a stale copy inside their vault (the pre-migration path) that a plugin update won't remove.

## Change

Rather than add a second, overlapping "remove" button, this folds the full reclaim into the existing **Uninstall** action (one button, no confusing distinction):

- `OpencodeBinaryManager.uninstall()` now removes **every** downloaded copy:
  - the OS-local `~/.obsidian-copilot/opencode` tree (all versions — previously it removed only the active version), and
  - the pre-#2569 in-vault copy (`<vault>/.obsidian/plugins/<id>/data/opencode`),

  then clears managed settings. A **custom** binary path is left untouched.
- `downloadsSize()` sums both locations, so a tester who just updated (binary still only inside the vault) sees a real size in the confirm, and the dialog reports what was freed.

The in-vault sweep runs **only on user click** — not an auto-running migration — keeping the load path clean (per the #135 decision).

## Why one button, not two

An earlier revision of this PR added a separate "Remove downloads" button. That overlapped Uninstall almost entirely (normally there's one version on disk, no legacy copy), so it was just confusing. Folding everything into Uninstall is simpler and the release note is still trivial.

## One-click migration for preview testers

> Agent Mode now installs the bundled opencode runtime outside your vault. Open Agent Mode → opencode → Configure, click **Uninstall** (this also clears the old copy that was syncing inside your vault), then **Install**. One time, done.

## Tests

`OpencodeBinaryManager.test.ts`:
- `downloadsSize` sums every downloaded binary; 0 when none.
- `uninstall` wipes the whole OS-local install dir and clears managed settings.
- keeps a custom binary path (only reclaims downloads).
- also counts and removes the pre-migration in-vault copy and clears the dangling managed path (one-click migration); uses a non-`.obsidian` config dir to prove `vault.configDir` is honored.

Full suite green (3547 passed), tsc + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
