### PR TITLE
fix(agent-mode): mask the home dir in the opencode config Destination path

### DIFF
--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -15,6 +15,7 @@ import { ReactModal } from "@/components/modals/ReactModal";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
+import { formatBinaryPathForDisplay } from "@/utils/binaryPath";
 import { OPENCODE_MIN_ACP_VERSION, OPENCODE_PINNED_VERSION } from "@/constants";
 import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
@@ -158,7 +159,9 @@ const OpencodeManagedInstall: React.FC<{
         <dt className="tw-text-muted">Version</dt>
         <dd className="tw-font-mono">v{OPENCODE_PINNED_VERSION} (pinned)</dd>
         <dt className="tw-text-muted">Destination</dt>
-        <dd className="tw-break-all tw-font-mono tw-text-xs">{manager.getDataDir()}</dd>
+        <dd className="tw-break-all tw-font-mono tw-text-xs">
+          {formatBinaryPathForDisplay(manager.getDataDir())}
+        </dd>
       </dl>
       {run.kind === "error" && (
         <pre className="tw-max-h-32 tw-overflow-auto tw-whitespace-pre-wrap tw-rounded tw-bg-secondary tw-p-2 tw-text-xs tw-text-error">


### PR DESCRIPTION
## Problem

The opencode **Configure** dialog prints the managed binary's install path raw in the "Destination" row:

```
Destination   /Users/<user>/.obsidian-copilot/opencode
```

That leaks the OS username in the UI and in any screenshot a user shares. We collapse every other agent-settings path to `~` for exactly this privacy reason (#2546) — this Destination row was missed.

## Fix

Wrap the displayed path in the existing, tested `formatBinaryPathForDisplay()` helper, so it renders:

```
Destination   ~/.obsidian-copilot/opencode
```

Display-only — the stored/spawned path keeps its real absolute form. The "Use your own binary" field is unchanged: it's an editable input showing the user's own typed path, not plugin-generated text.

## Tests

`formatBinaryPathForDisplay` / `collapseHomeDir` are already covered in `pathUtils.test.ts`. opencode suite green (150 passed), tsc + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
