### PR TITLE
feat(agent-home): disable Projects until supported; lead with Recent chats

### DIFF
--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -164,12 +164,11 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
 
   const projects = useProjects();
 
-  // Read-only landing in PR1: selecting a project only surfaces a coming-soon
-  // notice — no project entry, no setCurrentProject, no usage touch, no session
-  // or history-scope change.
-  const handleProjectComingSoon = useCallback(() => {
-    new Notice("Projects are coming soon.");
-  }, []);
+  // Projects aren't shipped yet, so the Projects tab is disabled on the shelf
+  // (greyed, "Coming soon" on hover) and its list never mounts. This no-op
+  // stands in for ProjectPickerList's required handlers until selection lands;
+  // it's unreachable while the tab is disabled.
+  const handleProjectComingSoon = useCallback(() => {}, []);
 
   // Landing "New chat": spin up a fresh session in a new tab, the same path the
   // tab strip's "+" uses. Guard on getIsStarting() like handleNewChat above and
@@ -252,19 +251,6 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   const landingSections = useMemo<AgentHomeShelfSection[]>(
     () => [
       {
-        id: "projects",
-        icon: <Folder className="tw-size-4" />,
-        title: "Projects",
-        count: projects.length,
-        renderBody: () => (
-          <ProjectPickerList
-            projects={projects}
-            onSelect={handleProjectComingSoon}
-            onCreate={handleProjectComingSoon}
-          />
-        ),
-      },
-      {
         id: "chats",
         icon: <MessageSquare className="tw-size-4" />,
         title: "Recent Chats",
@@ -278,6 +264,24 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
             onOpenSourceFile={handleOpenSourceFile}
             onLoadHistory={handleLoadChatHistory}
             onCreate={handleCreateChat}
+          />
+        ),
+      },
+      {
+        // Projects isn't shipped yet: greyed on the right, "Coming soon" on
+        // hover, and its list never mounts (the shelf won't make a disabled
+        // tab active). Kept wired to ProjectPickerList for when selection lands.
+        id: "projects",
+        icon: <Folder className="tw-size-4" />,
+        title: "Projects",
+        count: projects.length,
+        disabled: true,
+        disabledTooltip: "Coming soon",
+        renderBody: () => (
+          <ProjectPickerList
+            projects={projects}
+            onSelect={handleProjectComingSoon}
+            onCreate={handleProjectComingSoon}
           />
         ),
       },

--- a/src/agentMode/ui/AgentHomeShelf.test.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.test.tsx
@@ -1,0 +1,59 @@
+import { AgentHomeShelf, type AgentHomeShelfSection } from "@/agentMode/ui/AgentHomeShelf";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+// The tooltip portal targets Obsidian's `activeDocument` global (popout-safe);
+// jsdom has no such global, so point it at the test document.
+beforeAll(() => {
+  (window as unknown as { activeDocument: Document }).activeDocument = window.document;
+});
+
+function renderShelf(sections: AgentHomeShelfSection[]) {
+  return render(
+    <TooltipProvider>
+      <AgentHomeShelf sections={sections} />
+    </TooltipProvider>
+  );
+}
+
+const chats: AgentHomeShelfSection = {
+  id: "chats",
+  icon: <span />,
+  title: "Recent Chats",
+  count: 2,
+  renderBody: () => <div>CHATS BODY</div>,
+};
+
+const projectsDisabled: AgentHomeShelfSection = {
+  id: "projects",
+  icon: <span />,
+  title: "Projects",
+  count: 5,
+  disabled: true,
+  disabledTooltip: "Coming soon",
+  renderBody: () => <div>PROJECTS BODY</div>,
+};
+
+describe("AgentHomeShelf with a disabled section", () => {
+  it("activates the first selectable section, not the disabled one", () => {
+    renderShelf([chats, projectsDisabled]);
+    expect(screen.queryByText("CHATS BODY")).not.toBeNull();
+    // The disabled section's body never mounts.
+    expect(screen.queryByText("PROJECTS BODY")).toBeNull();
+  });
+
+  it("marks the disabled tab aria-disabled and hides its count", () => {
+    renderShelf([chats, projectsDisabled]);
+    const projectsTab = screen.getByRole("tab", { name: /Projects/ });
+    expect(projectsTab.getAttribute("aria-disabled")).toBe("true");
+    expect(projectsTab.textContent ?? "").not.toContain("5");
+  });
+
+  it("does not activate the disabled tab on click", () => {
+    renderShelf([chats, projectsDisabled]);
+    fireEvent.click(screen.getByRole("tab", { name: /Projects/ }));
+    expect(screen.queryByText("PROJECTS BODY")).toBeNull();
+    expect(screen.queryByText("CHATS BODY")).not.toBeNull();
+  });
+});

--- a/src/agentMode/ui/AgentHomeShelf.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.tsx
@@ -11,6 +11,14 @@ export interface AgentHomeShelfSection {
   count: number;
   /** Rendered into the panel while this tab is the selected one. */
   renderBody: () => React.ReactNode;
+  /**
+   * When true, the tab is greyed out and cannot be selected, and its body is
+   * never mounted (used for features that aren't shipped yet). The shelf keeps
+   * a disabled section from becoming active, so its `renderBody` never runs.
+   */
+  disabled?: boolean;
+  /** Hover hint shown over a disabled tab (e.g. "Coming soon"). */
+  disabledTooltip?: string;
 }
 
 interface AgentHomeShelfProps {
@@ -26,8 +34,12 @@ interface AgentHomeShelfProps {
  * tabs doesn't change the card height.
  */
 export function AgentHomeShelf({ sections, className }: AgentHomeShelfProps): React.ReactElement {
-  const [activeId, setActiveId] = useState<string | null>(sections[0]?.id ?? null);
-  const active = sections.find((s) => s.id === activeId) ?? sections[0] ?? null;
+  // Default to (and only ever resolve to) the first selectable section — a
+  // disabled tab can't be activated, so its body never mounts.
+  const firstSelectable = sections.find((s) => !s.disabled) ?? null;
+  const [activeId, setActiveId] = useState<string | null>(firstSelectable?.id ?? null);
+  const requested = sections.find((s) => s.id === activeId);
+  const active = requested && !requested.disabled ? requested : firstSelectable;
   const panelId = useId();
 
   // Stable per-tab id so the single shared panel can point back at the *active*
@@ -65,6 +77,8 @@ export function AgentHomeShelf({ sections, className }: AgentHomeShelfProps): Re
             count={section.count}
             active={section.id === active.id}
             controlsId={panelId}
+            disabled={section.disabled}
+            disabledTooltip={section.disabledTooltip}
             onClick={() => setActiveId(section.id)}
           />
         ))}

--- a/src/agentMode/ui/AgentHomeTab.tsx
+++ b/src/agentMode/ui/AgentHomeTab.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import React, { memo } from "react";
 
@@ -14,6 +15,10 @@ interface AgentHomeTabProps {
   onClick: () => void;
   /** id of the panel this tab controls, for `aria-controls`. */
   controlsId: string;
+  /** When true, the tab is greyed out and cannot be selected. */
+  disabled?: boolean;
+  /** Hover hint shown over a disabled tab (e.g. "Coming soon"). */
+  disabledTooltip?: string;
 }
 
 /**
@@ -23,6 +28,12 @@ interface AgentHomeTabProps {
  * no shadow. Built on the shared {@link Button} with the `ghost2` variant (which
  * carries `clickable-icon`, resetting Obsidian's native button chrome so a tab
  * doesn't render as a raised default button) and `role="tab"` for the tablist.
+ *
+ * A `disabled` tab is greyed and non-activating (a feature not yet shipped). We
+ * use `aria-disabled` + a no-op click rather than the native `disabled`
+ * attribute so the element still receives the pointer events the hover tooltip
+ * needs; the shelf also refuses to make a disabled tab active. The count is
+ * hidden while disabled so an unreleased feature doesn't surface a tally.
  */
 export const AgentHomeTab = memo(function AgentHomeTab({
   id,
@@ -32,8 +43,10 @@ export const AgentHomeTab = memo(function AgentHomeTab({
   active,
   onClick,
   controlsId,
+  disabled = false,
+  disabledTooltip,
 }: AgentHomeTabProps): React.ReactElement {
-  return (
+  const tab = (
     <Button
       id={id}
       type="button"
@@ -41,20 +54,35 @@ export const AgentHomeTab = memo(function AgentHomeTab({
       variant="ghost2"
       aria-selected={active}
       aria-controls={controlsId}
-      onClick={onClick}
+      aria-disabled={disabled || undefined}
+      onClick={disabled ? undefined : onClick}
       className={cn(
         "tw-h-auto tw-flex-1 tw-gap-2 tw-rounded-md tw-px-3 tw-py-1.5",
         "tw-text-ui-small tw-font-medium tw-duration-200",
-        active
-          ? "tw-bg-primary tw-text-normal hover:tw-bg-primary"
-          : "tw-bg-transparent tw-text-muted hover:tw-bg-modifier-hover hover:tw-text-normal"
+        disabled
+          ? "tw-cursor-not-allowed tw-bg-transparent tw-text-muted tw-opacity-50"
+          : active
+            ? "tw-bg-primary tw-text-normal hover:tw-bg-primary"
+            : "tw-bg-transparent tw-text-muted hover:tw-bg-modifier-hover hover:tw-text-normal"
       )}
     >
       <span className="tw-flex tw-shrink-0 tw-items-center tw-text-muted">{icon}</span>
       <span>{title}</span>
-      <span className={cn("tw-text-ui-smaller", active ? "tw-text-muted" : "tw-text-faint")}>
-        {count}
-      </span>
+      {!disabled && (
+        <span className={cn("tw-text-ui-smaller", active ? "tw-text-muted" : "tw-text-faint")}>
+          {count}
+        </span>
+      )}
     </Button>
   );
+
+  if (disabled && disabledTooltip) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{tab}</TooltipTrigger>
+        <TooltipContent side="top">{disabledTooltip}</TooltipContent>
+      </Tooltip>
+    );
+  }
+  return tab;
 });


### PR DESCRIPTION
Closes logancyang/obsidian-copilot-preview#137.

## Problem

The Agent Home shelf (`AgentHomeShelf` / `AgentHomeTab`) listed **Projects** first (left) and rendered a full, clickable project list via `ProjectPickerList` — even though projects aren't wired yet (selecting/creating only fired `new Notice("Projects are coming soon.")`). So it read as an available feature, and leaked the project list into a UI that can't act on it.

## Change

- **Recent chats leads** (left, default-active). **Projects sits on the right, greyed and non-selectable**, with a **"Coming soon"** tooltip on hover. Its list never mounts.
- `AgentHomeShelf`: a section can now be `disabled` (+ `disabledTooltip`). The shelf defaults to — and only ever resolves the active tab to — the first **selectable** section, so a disabled tab's `renderBody` never runs (the project list is never built).
- `AgentHomeTab`: greyed + `aria-disabled` + a no-op click. Kept **non-native** (`aria-disabled`, not the `disabled` attribute) so the element still receives the pointer events the hover tooltip needs; the count is hidden so an unshipped feature shows no tally; wrapped in the shared `Tooltip` when a hint is set.
- Dropped the "Projects are coming soon" `Notice` — the disabled tab + tooltip is the affordance. `ProjectPickerList` and the projects state stay wired for when selection lands.

This is the minimal interpretation from the issue's open question: tab reorder + a disabled right tab, not a structural side-by-side split of the shelf.

## Tests

New `AgentHomeShelf.test.tsx`:
- activates the first selectable section, not the disabled one (disabled body never mounts);
- the disabled tab is `aria-disabled` and hides its count;
- clicking the disabled tab does not activate it.

Full suite green (3575 passed), tsc + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
