### PR TITLE
fix(miyo): make the Miyo backend failure notice user-facing

### DIFF
--- a/src/search/indexBackend/MiyoIndexBackend.test.ts
+++ b/src/search/indexBackend/MiyoIndexBackend.test.ts
@@ -1,0 +1,56 @@
+jest.mock("obsidian", () => ({ Notice: jest.fn(), App: class {} }));
+jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
+jest.mock("@/settings/model", () => ({ getSettings: () => ({}) }));
+jest.mock("@/miyo/miyoUtils", () => ({
+  getMiyoCustomUrl: () => "",
+  getMiyoFolderName: () => "MyVault",
+  getMiyoFilePath: jest.fn(),
+  getVaultRelativeMiyoPath: jest.fn(),
+}));
+
+const getFolderMock = jest.fn();
+jest.mock("@/miyo/MiyoClient", () => ({
+  MiyoClient: class {
+    resolveBaseUrl = jest.fn().mockResolvedValue("http://127.0.0.1:8742");
+    getFolder = getFolderMock;
+  },
+}));
+
+import { Notice } from "obsidian";
+import { MiyoIndexBackend } from "./MiyoIndexBackend";
+
+const NoticeMock = Notice as unknown as jest.Mock;
+
+describe("MiyoIndexBackend.initialize failure notice", () => {
+  beforeEach(() => {
+    NoticeMock.mockClear();
+    getFolderMock.mockReset();
+  });
+
+  it("shows user-facing guidance naming the vault when Miyo can't be reached", async () => {
+    getFolderMock.mockRejectedValue(new Error("connection refused"));
+    const backend = new MiyoIndexBackend({} as never);
+
+    await backend.initialize(undefined);
+
+    expect(NoticeMock).toHaveBeenCalledTimes(1);
+    const msg = String(NoticeMock.mock.calls[0][0]);
+    // Names the vault and tells the user to add it to Miyo.
+    expect(msg).toContain('"MyVault"');
+    expect(msg).toContain("Miyo");
+    expect(msg.toLowerCase()).toContain("added to it");
+    // No developer jargon.
+    expect(msg).not.toContain("service discovery");
+    expect(msg.toLowerCase()).not.toContain("initialize");
+    expect(msg.toLowerCase()).not.toContain("backend");
+  });
+
+  it("does not show a notice when the folder check succeeds", async () => {
+    getFolderMock.mockResolvedValue({});
+    const backend = new MiyoIndexBackend({} as never);
+
+    await backend.initialize(undefined);
+
+    expect(NoticeMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/search/indexBackend/MiyoIndexBackend.ts
+++ b/src/search/indexBackend/MiyoIndexBackend.ts
@@ -42,9 +42,15 @@ export class MiyoIndexBackend implements SemanticIndexBackend {
       const baseUrl = await this.getBaseUrl();
       await this.client.getFolder(baseUrl, this.getFolderName());
     } catch (error) {
+      // Keep the raw cause in the console for devs; the user gets plain,
+      // actionable guidance. The usual cause is that Miyo isn't running or this
+      // vault hasn't been added to Miyo as a folder.
       logWarn(`Miyo backend initialization failed: ${error}`);
+      const folderName = this.getFolderName();
+      const named = folderName ? ` ("${folderName}")` : "";
       new Notice(
-        "Failed to initialize Miyo backend. Check Miyo service discovery or folder setup."
+        `Miyo isn't available for this vault${named}. ` +
+          `Make sure Miyo is running and this vault is added to it.`
       );
     }
   }


### PR DESCRIPTION
Closes logancyang/obsidian-copilot-preview#139.

## Problem

When `MiyoIndexBackend.initialize()` can't reach Miyo or this vault's folder isn't registered there, it showed:

> Failed to initialize Miyo backend. Check Miyo service discovery or folder setup.

That's developer language ("initialize backend", "service discovery") and doesn't tell the user the actual fix — the usual cause is **Miyo isn't running, or this vault hasn't been added to Miyo as a folder**.

## Change

Replace the notice (in `src/search/indexBackend/MiyoIndexBackend.ts`) with a concise, actionable message that names the vault:

> Miyo isn't available for this vault ("<vault name>"). Make sure Miyo is running and this vault is added to it.

The raw error is still logged via `logWarn` so devs keep the detail in the console.

## Tests

New `MiyoIndexBackend.test.ts`:
- the failure notice names the vault and tells the user it must be added to Miyo, with no "service discovery" / "initialize" / "backend" jargon;
- no notice fires when the folder check succeeds.

Full suite green (3577 passed), tsc + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
