### PR TITLE
fix(mobile): don't evaluate node:events at load — fixes plugin failing to load

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,3 @@
-// Must be the first import — patches Node's `events.setMaxListeners` so the
-// Claude Agent SDK's call with a web-realm AbortSignal stops throwing in
-// Electron's renderer. See file for details.
-import "@/utils/rendererEventsShim";
-
 import {
   AGENT_CHAT_MODE,
   CopilotAgentView,
@@ -82,6 +77,7 @@ import {
 } from "@/settings/model";
 import { dehydrateDeviceProfile, hydrateDeviceProfile } from "@/settings/deviceProfiles";
 import { getDeviceId } from "@/utils/deviceId";
+import { installRendererEventsShim } from "@/utils/rendererEventsShim";
 import { ProjectContextCache } from "@/cache/projectContextCache";
 import { ContextProcessor } from "@/contextProcessor";
 import { CustomCommandManager } from "@/commands/customCommandManager";
@@ -155,6 +151,12 @@ export default class CopilotPlugin extends Plugin {
   private webSelectionTracker?: WebSelectionTracker;
   private readonly chatHistoryLastAccessedAtManager = new RecentUsageManager<string>();
   async onload(): Promise<void> {
+    // Patch Node's `events.setMaxListeners` so the Claude Agent SDK's call with
+    // a web-realm AbortSignal stops throwing in Electron's renderer. No-ops on
+    // mobile (no node:events / no SDK). Must run before any Agent Mode session;
+    // doing it here (not as a module-load side effect) keeps mobile from
+    // evaluating `node:events` at import and crashing the whole plugin.
+    installRendererEventsShim();
     // Reason: clear stale module-level persistence state + KeychainService
     // singleton left over from a previous plugin lifecycle in the same
     // process (disable→enable, dev hot reload, "Open another vault" without

--- a/src/utils/rendererEventsShim.test.ts
+++ b/src/utils/rendererEventsShim.test.ts
@@ -1,0 +1,52 @@
+jest.mock("obsidian", () => ({ Platform: { isMobile: false } }));
+
+import { EventEmitter } from "node:events";
+import { installRendererEventsShim } from "./rendererEventsShim";
+
+const obsidian: { Platform: { isMobile: boolean } } = jest.requireMock("obsidian");
+
+describe("installRendererEventsShim", () => {
+  let original: typeof EventEmitter.setMaxListeners;
+
+  beforeEach(() => {
+    original = EventEmitter.setMaxListeners;
+    obsidian.Platform.isMobile = false;
+  });
+
+  afterEach(() => {
+    EventEmitter.setMaxListeners = original;
+  });
+
+  it("is a no-op on mobile — never touches EventEmitter", () => {
+    // The whole point of the #125 fix: on mobile node:events is undefined, so
+    // the shim must not reference EventEmitter at all. Guard returns first.
+    obsidian.Platform.isMobile = true;
+    installRendererEventsShim();
+    expect(EventEmitter.setMaxListeners).toBe(original);
+  });
+
+  it("has no load-time side effect — patching only happens when called", () => {
+    // Importing the module above must not have patched anything on its own.
+    expect(EventEmitter.setMaxListeners).toBe(original);
+  });
+
+  it("on desktop, swallows setMaxListeners misuse with AbortSignal-shaped targets", () => {
+    installRendererEventsShim();
+    const signalLike = { aborted: false, dispatchEvent: () => true };
+    // Node's setMaxListeners rejects a non-EventTarget target; the shim drops
+    // that throw only for AbortSignal-shaped targets.
+    expect(() => EventEmitter.setMaxListeners(5, signalLike as never)).not.toThrow();
+  });
+
+  it("on desktop, still throws for unrelated misuse", () => {
+    installRendererEventsShim();
+    expect(() => EventEmitter.setMaxListeners(5, {} as never)).toThrow();
+  });
+
+  it("is idempotent — re-applying does not double-wrap", () => {
+    installRendererEventsShim();
+    const afterFirst = EventEmitter.setMaxListeners;
+    installRendererEventsShim();
+    expect(EventEmitter.setMaxListeners).toBe(afterFirst);
+  });
+});

--- a/src/utils/rendererEventsShim.ts
+++ b/src/utils/rendererEventsShim.ts
@@ -1,3 +1,4 @@
+import { Platform } from "obsidian";
 import { EventEmitter } from "node:events";
 
 type SetMaxListenersFn = (n?: number, ...targets: unknown[]) => void;
@@ -39,8 +40,16 @@ function hasAbortSignalShape(value: unknown): boolean {
  *
  * The wrapper drops the throw only when every supplied target looks like an
  * `AbortSignal`; unrelated misuse still propagates.
+ *
+ * Desktop (Electron renderer) only. On mobile there is no `node:events` (it's
+ * marked external and resolves to `undefined`) and no Claude Agent SDK to shim,
+ * so this is a no-op there. The mobile guard returns BEFORE any `EventEmitter`
+ * access, which is why this must not run at module load: a side-effect call
+ * referencing `EventEmitter` crashes the whole plugin on mobile during import
+ * (`undefined is not an object`). Call it once from `onload` instead.
  */
-function installShim(): void {
+export function installRendererEventsShim(): void {
+  if (Platform.isMobile) return;
   const target = EventEmitter as unknown as { setMaxListeners: MarkedFn };
   const original = target.setMaxListeners;
   if (original[APPLIED]) return;
@@ -57,5 +66,3 @@ function installShim(): void {
 
   target.setMaxListeners = wrapped;
 }
-
-installShim();


### PR DESCRIPTION
Closes logancyang/obsidian-copilot-preview#125.

## Symptom

On mobile, the Copilot plugin fails to load at all:

> Plugin failure: copilot — TypeError: undefined is not an object (evaluating 'DKe.EventEmitter')

## Cause

`src/utils/rendererEventsShim.ts` imported `EventEmitter` from `node:events` (marked `external` in esbuild → resolves to `undefined` on mobile) and called `installShim()` **as a module-load side effect**, pulled in via the side-effect import `import "@/utils/rendererEventsShim"` at the top of `main.ts`.

On mobile, evaluating that shim reads `.EventEmitter` off the undefined `node:events` module — `DKe.EventEmitter` — which throws **during import**, before `onload` or any `Platform.isMobile` guard runs. So the whole plugin dies at load.

The shim is a desktop-only workaround (it patches `EventEmitter.setMaxListeners` so the Claude Agent SDK's web-realm `AbortSignal` doesn't trip Node's `isEventTarget` check in Electron's renderer). It has no purpose on mobile — there's no `node:events`, no Agent Mode, no SDK.

## Fix

- Export `installRendererEventsShim()` instead of running `installShim()` at module scope (no more load-time side effect).
- Guard it with `Platform.isMobile` — the guard returns **before** any `EventEmitter` reference, so mobile never evaluates `node:events`.
- Call it once from `onload` (runs before any Agent Mode session, same effective ordering as before).

Desktop behavior is unchanged; mobile no longer crashes at import.

## Tests

New `rendererEventsShim.test.ts`:
- no-op on mobile (never touches `EventEmitter`);
- no load-time side effect (importing the module doesn't patch anything);
- on desktop, swallows `setMaxListeners` misuse with AbortSignal-shaped targets, still throws for unrelated misuse;
- idempotent.

Full suite green (3580 passed), tsc + lint + build clean.

> Note: I can't run mobile here, so this is verified by code + the regression tests; please confirm load on a mobile device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
