### PR TITLE
Add miyo:// deeplink to register vault folder when enabling Miyo Search

### DIFF
--- a/src/components/modals/ConfirmModal.tsx
+++ b/src/components/modals/ConfirmModal.tsx
@@ -12,7 +12,7 @@ function ConfirmModalContent({
   confirmButtonText,
   cancelButtonText,
 }: {
-  content: string;
+  content: React.ReactNode;
   onConfirm: () => void;
   onCancel: () => void;
   confirmButtonText: string;
@@ -44,7 +44,7 @@ export class ConfirmModal extends Modal {
   constructor(
     app: App,
     private onConfirm: () => void | Promise<void>,
-    private content: string,
+    private content: React.ReactNode,
     title: string,
     private confirmButtonText: string = "Continue",
     private cancelButtonText: string = "Cancel",

--- a/src/miyo/miyoUtils.ts
+++ b/src/miyo/miyoUtils.ts
@@ -3,6 +3,13 @@ import { CopilotSettings } from "@/settings/model";
 import { App, Platform } from "obsidian";
 
 /**
+ * Deeplink that launches (or focuses) the Miyo desktop app via its registered
+ * URL scheme. Used to send users straight into Miyo to register their vault
+ * folder instead of asking them to open the app manually.
+ */
+export const MIYO_DEEPLINK_URL = "miyo://";
+
+/**
  * Convert backslashes to forward slashes and trim trailing slashes.
  *
  * @param path - Filesystem path.

--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -4,11 +4,11 @@ import { Badge } from "@/components/ui/badge";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { SettingItem } from "@/components/ui/setting-item";
 import { DEFAULT_SETTINGS } from "@/constants";
+import { logInfo } from "@/logger";
 import { MiyoClient } from "@/miyo/MiyoClient";
-import { getMiyoCustomUrl, getMiyoFolderName } from "@/miyo/miyoUtils";
+import { getMiyoCustomUrl, getMiyoFolderName, MIYO_DEEPLINK_URL } from "@/miyo/miyoUtils";
 import { useIsSelfHostEligible, validateSelfHostMode } from "@/plusUtils";
 import { updateSetting, useSettingsValue } from "@/settings/model";
-import { Notice } from "obsidian";
 import React, { useState } from "react";
 import { ToolSettingsSection } from "./ToolSettingsSection";
 
@@ -54,13 +54,38 @@ export const CopilotPlusSettings: React.FC = () => {
       return;
     }
 
+    const customUrl = getMiyoCustomUrl(settings);
+    const folderName = getMiyoFolderName(app);
+    const miyoClient = new MiyoClient();
+
+    // Distinguish two failure modes so we can guide the user precisely. Both
+    // offer a miyo:// deeplink, framed for the case: (1) the app is not running
+    // -> "Open Miyo" to start it; (2) it is running but the vault folder is not
+    // registered yet -> "Open Miyo to add your vault folder".
     setIsValidatingSelfHost(true);
+    let folderRegistered = false;
     try {
-      const miyoClient = new MiyoClient();
-      const isMiyoAvailable = await miyoClient.isBackendAvailable(getMiyoCustomUrl(settings));
+      const isMiyoAvailable = await miyoClient.isBackendAvailable(customUrl);
       if (!isMiyoAvailable) {
-        new Notice("Miyo app is not available. Please start the Miyo app and try again.");
+        new ConfirmModal(
+          app,
+          () => {
+            window.open(MIYO_DEEPLINK_URL, "_blank");
+          },
+          <div>The Miyo app is not running. Open Miyo, then enable Miyo Search again.</div>,
+          "Miyo app not available",
+          "Open Miyo"
+        ).open();
         return;
+      }
+      try {
+        const baseUrl = await miyoClient.resolveBaseUrl(customUrl);
+        await miyoClient.getFolder(baseUrl, folderName);
+        folderRegistered = true;
+      } catch (error) {
+        // A missing folder surfaces as a non-2xx (e.g. 404). The Miyo app is
+        // reachable here, so treat any lookup failure as "not registered yet".
+        logInfo(`Miyo folder "${folderName}" not registered; prompting user to add it: ${error}`);
       }
     } finally {
       setIsValidatingSelfHost(false);
@@ -85,12 +110,32 @@ export const CopilotPlusSettings: React.FC = () => {
       }
     };
 
-    new ConfirmModal(
-      app,
-      confirmChange,
-      `Enabling Miyo Search will use your current vault folder name as the Miyo folder identifier and request a scan from Miyo. Make sure this folder is already registered in Miyo. Embedding Batch Size will be reset to the default (${DEFAULT_SETTINGS.embeddingBatchSize}) for local stability. Continue?`,
-      "Request Miyo Scan"
-    ).open();
+    const modalContent = folderRegistered ? (
+      <div>
+        Enabling Miyo Search will use your vault folder (
+        <span className="tw-font-medium">{folderName}</span>) as the Miyo folder identifier and
+        request a scan from Miyo. Embedding Batch Size will be reset to the default (
+        {DEFAULT_SETTINGS.embeddingBatchSize}) for local stability.
+      </div>
+    ) : (
+      <div className="tw-flex tw-flex-col tw-gap-3">
+        <div>
+          Your vault folder (<span className="tw-font-medium">{folderName}</span>) is not registered
+          in Miyo yet. Add it in Miyo first, then continue to request a scan. Embedding Batch Size
+          will be reset to the default ({DEFAULT_SETTINGS.embeddingBatchSize}) for local stability.
+        </div>
+        <a
+          href={MIYO_DEEPLINK_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="tw-text-accent hover:tw-underline"
+        >
+          Open Miyo to add your vault folder
+        </a>
+      </div>
+    );
+
+    new ConfirmModal(app, confirmChange, modalContent, "Request Miyo Scan").open();
   };
 
   return (

--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -91,38 +91,40 @@ export const CopilotPlusSettings: React.FC = () => {
       setIsValidatingSelfHost(false);
     }
 
-    const confirmChange = async () => {
-      if (enabled && settings.embeddingBatchSize !== DEFAULT_SETTINGS.embeddingBatchSize) {
+    const enableMiyoSearch = async () => {
+      if (settings.embeddingBatchSize !== DEFAULT_SETTINGS.embeddingBatchSize) {
+        // Reset to the default for local stability.
         updateSetting("embeddingBatchSize", DEFAULT_SETTINGS.embeddingBatchSize);
       }
 
-      updateSetting("enableMiyo", enabled);
+      updateSetting("enableMiyo", true);
 
-      if (enabled && !settings.enableSemanticSearchV3) {
+      if (!settings.enableSemanticSearchV3) {
         updateSetting("enableSemanticSearchV3", true);
       }
 
-      if (settings.enableSemanticSearchV3 || enabled) {
-        const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
-        await VectorStoreManager.getInstance().indexVaultToVectorStore(false, {
-          userInitiated: true,
-        });
-      }
+      const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
+      await VectorStoreManager.getInstance().indexVaultToVectorStore(false, {
+        userInitiated: true,
+      });
     };
 
-    const modalContent = folderRegistered ? (
-      <div>
-        Enabling Miyo Search will use your vault folder (
-        <span className="tw-font-medium">{folderName}</span>) as the Miyo folder identifier and
-        request a scan from Miyo. Embedding Batch Size will be reset to the default (
-        {DEFAULT_SETTINGS.embeddingBatchSize}) for local stability.
-      </div>
-    ) : (
+    // Folder already registered in Miyo: enable directly. Miyo owns scanning, so
+    // there's nothing to confirm.
+    if (folderRegistered) {
+      await enableMiyoSearch();
+      return;
+    }
+
+    // Folder not registered yet: guide the user to add it in Miyo via deeplink,
+    // then enable on confirm.
+    new ConfirmModal(
+      app,
+      enableMiyoSearch,
       <div className="tw-flex tw-flex-col tw-gap-3">
         <div>
           Your vault folder (<span className="tw-font-medium">{folderName}</span>) is not registered
-          in Miyo yet. Add it in Miyo first, then continue to request a scan. Embedding Batch Size
-          will be reset to the default ({DEFAULT_SETTINGS.embeddingBatchSize}) for local stability.
+          in Miyo yet. Add it in Miyo first, then continue.
         </div>
         <a
           href={MIYO_DEEPLINK_URL}
@@ -132,10 +134,10 @@ export const CopilotPlusSettings: React.FC = () => {
         >
           Open Miyo to add your vault folder
         </a>
-      </div>
-    );
-
-    new ConfirmModal(app, confirmChange, modalContent, "Request Miyo Scan").open();
+      </div>,
+      "Register vault folder in Miyo",
+      "Enable Miyo Search"
+    ).open();
   };
 
   return (
@@ -277,7 +279,7 @@ export const CopilotPlusSettings: React.FC = () => {
                   <SettingItem
                     type="switch"
                     title="Enable Miyo"
-                    description="Use Miyo as your local search, PDF parsing, and context hub. Copilot will send the current vault folder name to Miyo and can request scans, but folder registration is managed in Miyo."
+                    description="Use Miyo as your local search, PDF parsing, and context hub. Copilot sends the current vault folder name to Miyo; folder registration and scanning are managed in Miyo."
                     checked={settings.enableMiyo}
                     onCheckedChange={(checked) => void handleMiyoSearchToggle(checked)}
                     disabled={isValidatingSelfHost}

--- a/src/settings/v2/components/CopilotPlusSettings.tsx
+++ b/src/settings/v2/components/CopilotPlusSettings.tsx
@@ -3,7 +3,6 @@ import { useApp } from "@/context";
 import { Badge } from "@/components/ui/badge";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { SettingItem } from "@/components/ui/setting-item";
-import { DEFAULT_SETTINGS } from "@/constants";
 import { logInfo } from "@/logger";
 import { MiyoClient } from "@/miyo/MiyoClient";
 import { getMiyoCustomUrl, getMiyoFolderName, MIYO_DEEPLINK_URL } from "@/miyo/miyoUtils";
@@ -91,28 +90,19 @@ export const CopilotPlusSettings: React.FC = () => {
       setIsValidatingSelfHost(false);
     }
 
-    const enableMiyoSearch = async () => {
-      if (settings.embeddingBatchSize !== DEFAULT_SETTINGS.embeddingBatchSize) {
-        // Reset to the default for local stability.
-        updateSetting("embeddingBatchSize", DEFAULT_SETTINGS.embeddingBatchSize);
-      }
-
+    // Miyo owns indexing and scanning (its folder watcher/scanner) and embeds
+    // server-side, so enabling only flips the flags. Switching the active
+    // backend is handled by the settings-change subscriber in VectorStoreManager.
+    const enableMiyoSearch = () => {
       updateSetting("enableMiyo", true);
-
       if (!settings.enableSemanticSearchV3) {
         updateSetting("enableSemanticSearchV3", true);
       }
-
-      const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
-      await VectorStoreManager.getInstance().indexVaultToVectorStore(false, {
-        userInitiated: true,
-      });
     };
 
-    // Folder already registered in Miyo: enable directly. Miyo owns scanning, so
-    // there's nothing to confirm.
+    // Folder already registered in Miyo: enable directly, no confirmation needed.
     if (folderRegistered) {
-      await enableMiyoSearch();
+      enableMiyoSearch();
       return;
     }
 


### PR DESCRIPTION
## What

Improves the **Enable Miyo** flow in Copilot Plus settings so it guides the user with a `miyo://` deeplink and stops doing work that Miyo owns.

## Why

- When the Miyo app isn't running, or the vault folder isn't registered in Miyo yet, enabling Miyo Search silently did nothing useful. Now the user is pointed straight to the fix.
- Miyo owns indexing, scanning, and embeddings. Copilot was confirming a "scan request" and then issuing one (plus resetting the local embedding batch size) — all of which are no-ops or duplicate work on the Miyo path.

## Behavior

On enabling Miyo Search:

1. **Miyo app not running** → `ConfirmModal` with an **Open Miyo** button that fires the `miyo://` deeplink. Enable is aborted; the user re-enables after Miyo launches.
2. **App running, folder not registered** → `ConfirmModal` ("Register vault folder in Miyo") with a deeplink to add the folder, confirm button **Enable Miyo Search**.
3. **App running, folder registered** → enables directly, no dialog.

Enabling only flips `enableMiyo` (and `enableSemanticSearchV3` if needed). The active backend switch/init is handled by `VectorStoreManager`'s settings-change subscriber.

## Removed (Miyo's responsibility, not Copilot's)

- The **"Request Miyo Scan"** confirmation dialog — scanning is handled inside Miyo.
- The explicit `indexVaultToVectorStore` call on enable — on the Miyo path it only issued `requestIndexRefresh → scanFolder` (`POST /v0/scan`), which Miyo's own folder watcher/scanner already does.
- The `embeddingBatchSize` reset — only consumed by local Orama embedding; the Miyo backend reports `requiresEmbeddings() === false` and short-circuits before any batch logic, so it was never read.

Also updated the **Enable Miyo** toggle description to say folder registration and scanning are managed in Miyo (it previously claimed Copilot "can request scans").

## Implementation notes

- `ConfirmModal` now accepts `React.ReactNode` content (was `string`) so the dialogs can render the deeplink and folder name inline.
- New `MIYO_DEEPLINK_URL` constant in `src/miyo/miyoUtils.ts`.

Ported from preview repo (#144), then trimmed per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
