### PR TITLE
Filter Miyo search results by inclusion/exclusion rules and cap output

### DIFF
--- a/src/search/RetrieverFactory.ts
+++ b/src/search/RetrieverFactory.ts
@@ -6,7 +6,6 @@ import { App } from "obsidian";
 import { SelfHostRetriever, VectorSearchBackend } from "./selfHostRetriever";
 import { MiyoSemanticRetriever } from "./miyo/MiyoSemanticRetriever";
 import { MergedSemanticRetriever } from "./v3/MergedSemanticRetriever";
-import { RETURN_ALL_LIMIT } from "./v3/SearchCore";
 import { TieredLexicalRetriever } from "./v3/TieredLexicalRetriever";
 
 /**
@@ -345,10 +344,8 @@ export class RetrieverFactory {
    * @returns Miyo semantic retriever instance.
    */
   static createMiyoRetriever(app: App, options: RetrieverOptions): MiyoSemanticRetriever {
-    const normalized = normalizeOptions(options);
-    const semanticMax = normalized.returnAll
-      ? RETURN_ALL_LIMIT
-      : Math.min(normalized.maxK * 2, RETURN_ALL_LIMIT);
-    return new MiyoSemanticRetriever(app, { ...normalized, maxK: semanticMax });
+    // maxK is the post-filter cap on returned chunks; the retriever over-fetches
+    // candidates internally to compensate for inclusion/exclusion filtering.
+    return new MiyoSemanticRetriever(app, normalizeOptions(options));
   }
 }

--- a/src/search/miyo/MiyoSemanticRetriever.test.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.test.ts
@@ -94,7 +94,7 @@ describe("MiyoSemanticRetriever", () => {
       "http://miyo.local",
       "/vault",
       "query with [[notes/a]] mention",
-      RETURN_ALL_LIMIT,
+      10,
       undefined
     );
     expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
@@ -111,8 +111,11 @@ describe("MiyoSemanticRetriever", () => {
 
     const startTime = 1700000000000;
     const endTime = 1700600000000;
+    // Time-range queries are issued with returnAll enabled by callers, so the
+    // retriever over-fetches the full candidate pool.
     const retriever = createRetriever({
       timeRange: { startTime, endTime },
+      returnAll: true,
     });
 
     await retriever.getRelevantDocuments("show notes from this week");
@@ -146,7 +149,19 @@ describe("MiyoSemanticRetriever", () => {
     );
   });
 
-  it("over-fetches but caps returned chunks to the requested limit", async () => {
+  it("over-fetches but caps returned chunks to the requested limit when a filter is active", async () => {
+    // An active inclusion/exclusion pattern can drop results, so the retriever
+    // over-fetches candidates to still fill the requested cap.
+    (getSettings as jest.Mock).mockReturnValue({
+      miyoServerUrl: "http://miyo.local",
+      debug: false,
+      qaExclusions: "private",
+    });
+    const app = {
+      vault: { getAbstractFileByPath: () => null },
+      metadataCache: {},
+    } as unknown as App;
+
     mockSearch.mockResolvedValue({
       results: Array.from({ length: 5 }, (_, i) => ({
         id: `doc-${i}`,
@@ -157,7 +172,11 @@ describe("MiyoSemanticRetriever", () => {
       })),
     });
 
-    const retriever = createRetriever({ maxK: 2 });
+    const retriever = new MiyoSemanticRetriever(app, {
+      maxK: 2,
+      salientTerms: [],
+      minSimilarityScore: 0.2,
+    });
     const documents = await retriever.getRelevantDocuments("query");
 
     // Over-fetches the full candidate pool but returns only the top maxK.
@@ -173,6 +192,17 @@ describe("MiyoSemanticRetriever", () => {
       "notes/0.md",
       "notes/1.md",
     ]);
+  });
+
+  it("bounds the request to the requested limit when no filter is active", async () => {
+    // With no inclusion/exclusion pattern and returnAll off, over-fetching only
+    // wastes transfer/processing, so the request is bounded to the cap.
+    mockSearch.mockResolvedValue({ results: [] });
+
+    const retriever = createRetriever({ maxK: 3 });
+    await retriever.getRelevantDocuments("query");
+
+    expect(mockSearch).toHaveBeenCalledWith("http://miyo.local", "/vault", "query", 3, undefined);
   });
 
   it("filters chunks by Copilot inclusion/exclusion rules", async () => {

--- a/src/search/miyo/MiyoSemanticRetriever.test.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.test.ts
@@ -1,4 +1,4 @@
-import type { App } from "obsidian";
+import { type App, TFile } from "obsidian";
 import { getMiyoFolderName } from "@/miyo/miyoUtils";
 import { MiyoSemanticRetriever } from "@/search/miyo/MiyoSemanticRetriever";
 import { getSettings } from "@/settings/model";
@@ -94,7 +94,7 @@ describe("MiyoSemanticRetriever", () => {
       "http://miyo.local",
       "/vault",
       "query with [[notes/a]] mention",
-      10,
+      RETURN_ALL_LIMIT,
       undefined
     );
     expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
@@ -121,7 +121,7 @@ describe("MiyoSemanticRetriever", () => {
       "http://miyo.local",
       "/vault",
       "show notes from this week",
-      10,
+      RETURN_ALL_LIMIT,
       [{ field: "mtime", gte: startTime, lte: endTime }]
     );
     expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
@@ -144,5 +144,77 @@ describe("MiyoSemanticRetriever", () => {
       RETURN_ALL_LIMIT,
       undefined
     );
+  });
+
+  it("over-fetches but caps returned chunks to the requested limit", async () => {
+    mockSearch.mockResolvedValue({
+      results: Array.from({ length: 5 }, (_, i) => ({
+        id: `doc-${i}`,
+        score: 0.9 - i * 0.01,
+        path: `/vault/notes/${i}.md`,
+        chunk_index: 0,
+        chunk_text: `chunk ${i}`,
+      })),
+    });
+
+    const retriever = createRetriever({ maxK: 2 });
+    const documents = await retriever.getRelevantDocuments("query");
+
+    // Over-fetches the full candidate pool but returns only the top maxK.
+    expect(mockSearch).toHaveBeenCalledWith(
+      "http://miyo.local",
+      "/vault",
+      "query",
+      RETURN_ALL_LIMIT,
+      undefined
+    );
+    expect(documents).toHaveLength(2);
+    expect(documents.map((doc) => doc.metadata.path as string)).toEqual([
+      "notes/0.md",
+      "notes/1.md",
+    ]);
+  });
+
+  it("filters chunks by Copilot inclusion/exclusion rules", async () => {
+    (getSettings as jest.Mock).mockReturnValue({
+      miyoServerUrl: "http://miyo.local",
+      debug: false,
+      qaExclusions: "private",
+    });
+
+    const TFileConstructor = TFile as unknown as new (filePath: string) => TFile;
+    const filesByPath = new Map<string, TFile>([
+      ["notes/keep.md", new TFileConstructor("notes/keep.md")],
+      ["private/secret.md", new TFileConstructor("private/secret.md")],
+    ]);
+    const app = {
+      vault: { getAbstractFileByPath: (path: string) => filesByPath.get(path) ?? null },
+      metadataCache: {},
+    } as unknown as App;
+
+    mockSearch.mockResolvedValue({
+      results: [
+        {
+          id: "keep",
+          score: 0.9,
+          path: "/vault/notes/keep.md",
+          chunk_index: 0,
+          chunk_text: "keep",
+        },
+        {
+          id: "secret",
+          score: 0.85,
+          path: "/vault/private/secret.md",
+          chunk_index: 0,
+          chunk_text: "secret",
+        },
+      ],
+    });
+
+    const retriever = new MiyoSemanticRetriever(app, { maxK: 10, salientTerms: [] });
+    const documents = await retriever.getRelevantDocuments("query");
+
+    expect(documents).toHaveLength(1);
+    expect(documents[0].metadata.path).toBe("notes/keep.md");
   });
 });

--- a/src/search/miyo/MiyoSemanticRetriever.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.ts
@@ -5,8 +5,12 @@ import { App } from "obsidian";
 import { logInfo, logWarn } from "@/logger";
 import { MiyoClient, MiyoSearchFilter, MiyoSearchResult } from "@/miyo/MiyoClient";
 import { getMiyoCustomUrl, getMiyoFolderName, getVaultRelativeMiyoPath } from "@/miyo/miyoUtils";
+import { createCopilotPatternFilter } from "@/search/searchUtils";
 import { getSettings } from "@/settings/model";
 import { RETURN_ALL_LIMIT } from "@/search/v3/SearchCore";
+
+/** Number of chunks to return when the caller does not request a specific limit. */
+const DEFAULT_FINAL_K = 20;
 
 type MiyoSemanticRetrieverOptions = {
   minSimilarityScore?: number;
@@ -26,7 +30,8 @@ export class MiyoSemanticRetriever extends BaseRetriever {
 
   private client: MiyoClient;
   private readonly returnAll: boolean;
-  private readonly maxK: number;
+  /** Maximum number of chunks returned after inclusion/exclusion filtering. */
+  private readonly finalK: number;
   private readonly minSimilarityScore: number;
 
   /**
@@ -42,7 +47,7 @@ export class MiyoSemanticRetriever extends BaseRetriever {
     super();
     this.client = new MiyoClient();
     this.returnAll = Boolean(options.returnAll);
-    this.maxK = Math.max(1, options.maxK);
+    this.finalK = options.maxK > 0 ? options.maxK : DEFAULT_FINAL_K;
     this.minSimilarityScore = options.minSimilarityScore ?? 0.1;
   }
 
@@ -60,12 +65,45 @@ export class MiyoSemanticRetriever extends BaseRetriever {
   ): Promise<Document[]> {
     const searchChunks = await this.searchMiyo(query);
     const dedupedChunks = this.deduplicateResults(searchChunks);
+    const allowedChunks = this.filterByCopilotPatterns(dedupedChunks);
+    const limitedChunks = allowedChunks.slice(0, this.finalK);
 
     if (getSettings().debug) {
-      this.logDebugInfo(query, searchChunks, dedupedChunks);
+      this.logDebugInfo(query, searchChunks, limitedChunks);
     }
 
-    return dedupedChunks;
+    return limitedChunks;
+  }
+
+  /**
+   * Filter chunks by Copilot's QA inclusion/exclusion rules so Miyo results
+   * honor the same scope as locally-indexed search.
+   *
+   * @param chunks - Deduplicated chunks from Miyo.
+   * @returns Chunks whose source path passes the inclusion/exclusion rules.
+   */
+  private filterByCopilotPatterns(chunks: Document[]): Document[] {
+    const isAllowed = createCopilotPatternFilter(this.app);
+    const allowed: Document[] = [];
+    const excludedPaths: string[] = [];
+    for (const chunk of chunks) {
+      const path = chunk.metadata.path as string;
+      if (isAllowed(path)) {
+        allowed.push(chunk);
+      } else {
+        excludedPaths.push(path);
+      }
+    }
+
+    if (getSettings().debug) {
+      const uniqueExcluded = Array.from(new Set(excludedPaths));
+      logInfo(
+        `MiyoSemanticRetriever: inclusion/exclusion rules kept ${allowed.length}/${chunks.length} chunks` +
+          (uniqueExcluded.length > 0 ? `; excluded ${uniqueExcluded.join(", ")}` : "")
+      );
+    }
+
+    return allowed;
   }
 
   /**
@@ -77,13 +115,15 @@ export class MiyoSemanticRetriever extends BaseRetriever {
   private async searchMiyo(query: string): Promise<Document[]> {
     try {
       const baseUrl = await this.client.resolveBaseUrl(getMiyoCustomUrl(getSettings()));
-      const limit = this.returnAll ? RETURN_ALL_LIMIT : this.maxK;
+      // Over-fetch candidates so inclusion/exclusion filtering still leaves
+      // enough chunks to fill finalK; the result set is capped afterwards.
+      const limit = RETURN_ALL_LIMIT;
       const filters = this.buildSearchFilters();
       if (getSettings().debug) {
         logInfo("MiyoSemanticRetriever: search params:", {
           baseUrl,
           limit,
-          maxK: this.maxK,
+          finalK: this.finalK,
           minSimilarityScore: this.minSimilarityScore,
           returnAll: this.returnAll,
           filters,

--- a/src/search/miyo/MiyoSemanticRetriever.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.ts
@@ -5,7 +5,7 @@ import { App } from "obsidian";
 import { logInfo, logWarn } from "@/logger";
 import { MiyoClient, MiyoSearchFilter, MiyoSearchResult } from "@/miyo/MiyoClient";
 import { getMiyoCustomUrl, getMiyoFolderName, getVaultRelativeMiyoPath } from "@/miyo/miyoUtils";
-import { createCopilotPatternFilter } from "@/search/searchUtils";
+import { createCopilotPatternFilter, hasActiveCopilotPatterns } from "@/search/searchUtils";
 import { getSettings } from "@/settings/model";
 import { RETURN_ALL_LIMIT } from "@/search/v3/SearchCore";
 
@@ -115,9 +115,12 @@ export class MiyoSemanticRetriever extends BaseRetriever {
   private async searchMiyo(query: string): Promise<Document[]> {
     try {
       const baseUrl = await this.client.resolveBaseUrl(getMiyoCustomUrl(getSettings()));
-      // Over-fetch candidates so inclusion/exclusion filtering still leaves
-      // enough chunks to fill finalK; the result set is capped afterwards.
-      const limit = RETURN_ALL_LIMIT;
+      // Over-fetch candidates only when inclusion/exclusion filtering can drop
+      // results (or the caller wants everything), so filtering still leaves
+      // enough chunks to fill finalK and the set is capped afterwards. Without
+      // an active filter, bound the request to finalK so default searches don't
+      // transfer up to RETURN_ALL_LIMIT chunks for no filtering benefit.
+      const limit = this.returnAll || hasActiveCopilotPatterns() ? RETURN_ALL_LIMIT : this.finalK;
       const filters = this.buildSearchFilters();
       if (getSettings().debug) {
         logInfo("MiyoSemanticRetriever: search params:", {

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -171,6 +171,29 @@ export function shouldIndexFile(
 }
 
 /**
+ * Build a predicate that decides whether a vault-relative path passes Copilot's
+ * QA inclusion/exclusion rules. The active patterns are resolved once so the
+ * predicate can be reused across many results. Paths that don't resolve to a
+ * vault {@link TFile} are kept, since the rules can't be evaluated for them.
+ *
+ * @param app - The Obsidian app instance.
+ * @returns Predicate returning true when the path should be kept.
+ */
+export function createCopilotPatternFilter(app: App): (path: string) => boolean {
+  const { inclusions, exclusions } = getMatchingPatterns();
+  if (!inclusions && !exclusions) {
+    return () => true;
+  }
+  return (path: string) => {
+    const file = app.vault.getAbstractFileByPath(path);
+    if (!(file instanceof TFile)) {
+      return true;
+    }
+    return shouldIndexFile(app, file, inclusions, exclusions);
+  };
+}
+
+/**
  * Break down the patterns into their respective categories.
  * @param patterns - The patterns to categorize.
  * @returns An object containing the categorized patterns.

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -194,6 +194,19 @@ export function createCopilotPatternFilter(app: App): (path: string) => boolean 
 }
 
 /**
+ * Whether any QA inclusion/exclusion pattern is currently configured. Callers
+ * use this to decide whether {@link createCopilotPatternFilter} can actually
+ * remove results — when nothing is configured the filter is a no-op, so there
+ * is no point over-fetching candidates to compensate for it.
+ *
+ * @returns True when at least one inclusion or exclusion pattern is active.
+ */
+export function hasActiveCopilotPatterns(): boolean {
+  const { inclusions, exclusions } = getMatchingPatterns();
+  return Boolean(inclusions || exclusions);
+}
+
+/**
  * Break down the patterns into their respective categories.
  * @param patterns - The patterns to categorize.
  * @returns An object containing the categorized patterns.


### PR DESCRIPTION
Ports preview repo #131.

Miyo semantic search results now honor the same QA **inclusion/exclusion** scope as locally-indexed search:

- New reusable `createCopilotPatternFilter(app)` predicate in `searchUtils.ts` resolves the active inclusion/exclusion patterns once and keeps only chunks whose source path passes. Paths that don't resolve to a vault `TFile` are kept (the rules can't be evaluated for them).
- `MiyoSemanticRetriever` over-fetches candidates (`RETURN_ALL_LIMIT`) so filtering still leaves enough chunks to fill the final cap, then slices the result set to `finalK` (the requested `maxK`, or `DEFAULT_FINAL_K = 20` when unspecified).
- The result-sizing math moves out of `RetrieverFactory.createMiyoRetriever` into the retriever itself.

Adds tests covering the over-fetch-then-cap behavior and inclusion/exclusion filtering. All `MiyoSemanticRetriever` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)