### PR TITLE
fix(skills): keep overflow menu non-modal so Reveal in vault can't strand a scroll lock

### DIFF
--- a/src/agentMode/skills/ui/SkillRow.test.tsx
+++ b/src/agentMode/skills/ui/SkillRow.test.tsx
@@ -1,0 +1,89 @@
+import { AppContext } from "@/context";
+import type { Skill } from "@/agentMode/skills/types";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { App } from "obsidian";
+import React from "react";
+import { SkillRow } from "./SkillRow";
+
+// Radix DropdownMenu portals resolve `activeDocument` at render time, and its
+// trigger relies on Pointer Capture + PointerEvent, neither of which jsdom
+// implements. Polyfill the minimum so the menu can actually open in the test.
+beforeAll(() => {
+  (window as unknown as { activeDocument: Document }).activeDocument = window.document;
+  if (!("PointerEvent" in window)) {
+    (window as unknown as { PointerEvent: typeof MouseEvent }).PointerEvent = MouseEvent;
+  }
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.releasePointerCapture = () => {};
+  Element.prototype.scrollIntoView = () => {};
+});
+
+// react-remove-scroll-bar marks an active body scroll lock by stamping this
+// attribute (a use-counter) on <body>. Radix engages it only when the menu is
+// modal — which is exactly the state issue #118 must avoid.
+const SCROLL_LOCK_ATTR = "data-scroll-locked";
+
+const canonicalSkill: Skill = {
+  name: "writing-helper",
+  description: "Helps with writing.",
+  filePath: "/vault/.copilot/skills/writing-helper/SKILL.md",
+  dirPath: "/vault/.copilot/skills/writing-helper",
+  body: "",
+  enabledAgents: [],
+  location: { kind: "canonical" },
+};
+
+// Radix's DropdownMenuTrigger opens on primary-button pointerDown, not click.
+function openMenu() {
+  fireEvent.pointerDown(screen.getByLabelText(/More actions/i), { button: 0, ctrlKey: false });
+}
+
+function renderRow(onRevealInVault: () => void) {
+  // A plain ref object rather than useRef — renderRow is a helper, not a hook context.
+  const containerRef: React.RefObject<HTMLDivElement> = { current: null };
+  const utils = render(
+    <AppContext.Provider value={{} as App}>
+      <div ref={containerRef} />
+      <SkillRow
+        skill={canonicalSkill}
+        agents={[]}
+        agentDirsProjectRel={{}}
+        onRevealInVault={onRevealInVault}
+        containerRef={containerRef}
+      />
+    </AppContext.Provider>
+  );
+  return { ...utils, containerRef };
+}
+
+describe("SkillRow overflow menu", () => {
+  afterEach(() => {
+    activeDocument.body.removeAttribute(SCROLL_LOCK_ATTR);
+  });
+
+  // Regression guard for issue #118: a modal dropdown engages
+  // react-remove-scroll's document-level wheel listener. "Reveal in vault"
+  // moves focus into the file-explorer leaf, which can interrupt the menu's
+  // close/unmount and strand that listener, killing wheel scrolling vault-wide
+  // until restart. Keeping the menu non-modal means the lock is never engaged.
+  it("does not engage a body scroll lock when the menu opens", () => {
+    renderRow(() => {});
+
+    openMenu();
+
+    // The menu is open (its items are mounted)…
+    expect(screen.getByText("Reveal in vault")).not.toBeNull();
+    // …but the body must not be scroll-locked.
+    expect(activeDocument.body.hasAttribute(SCROLL_LOCK_ATTR)).toBe(false);
+  });
+
+  it("invokes the reveal handler when Reveal in vault is selected", () => {
+    const onRevealInVault = jest.fn();
+    renderRow(onRevealInVault);
+
+    openMenu();
+    fireEvent.click(screen.getByText("Reveal in vault"));
+
+    expect(onRevealInVault).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agentMode/skills/ui/SkillRow.tsx
+++ b/src/agentMode/skills/ui/SkillRow.tsx
@@ -212,8 +212,12 @@ export const SkillRow: React.FC<SkillRowProps> = ({
         })}
       </div>
 
-      {/* Overflow popover — Edit / Properties / Reveal / Delete (or Migrate when locked down) */}
-      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+      {/* Overflow popover — Edit / Properties / Reveal / Delete (or Migrate when locked down).
+          modal={false} keeps Radix from engaging react-remove-scroll's body scroll lock:
+          "Reveal in vault" moves focus into the file-explorer leaf, which can interrupt the
+          menu's close/unmount and strand the document-level wheel listener, killing scroll
+          everywhere until restart (issue #118). The sibling menu in AgentTabStrip does the same. */}
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen} modal={false}>
         <DropdownMenuTrigger asChild>
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary

Fixes the critical scroll-lock bug reported in logancyang/obsidian-copilot-preview#118: after **Settings → Skills → Reveal in vault**, the mouse wheel stops scrolling notes and the file tree until Obsidian restarts.

### Root cause

The Skills overflow menu (`SkillRow.tsx`) rendered a Radix `DropdownMenu` with its default `modal={true}`. A modal Radix menu engages `react-remove-scroll`, which attaches a non-passive document-level `wheel`/`touchmove` listener that `preventDefault`s scrolling outside the menu. "Reveal in vault" calls Obsidian's `revealInFolder`, which **synchronously moves focus into the file-explorer leaf**. That focus jump interrupts Radix's close/unmount sequence, so the scroll-lock listener is never torn down and wheel scrolling dies app-wide. Clicks and keyboard still work, which matches the testers' reports.

### Fix

Set `modal={false}` on the menu, matching the sibling overflow menu in `AgentTabStrip.tsx:263` (same pattern, already non-modal). With a non-modal menu, Radix never engages the scroll lock, so there is nothing to strand. No behavior is lost — the menu still closes on outside click / Escape / select.

## Testing

- New `SkillRow.test.tsx`:
  - Opens the overflow menu and asserts `<body>` carries **no** `data-scroll-locked` marker (the `react-remove-scroll-bar` lock counter).
  - Asserts "Reveal in vault" still invokes its handler.
- **Mutation-verified**: flipping back to `modal={true}` makes the scroll-lock test fail (body gets `data-scroll-locked`); `modal={false}` makes it pass. The test genuinely guards the regression.
- Full suite: `238 passed`, `3600 tests` green. `npm run lint` and Prettier clean.

## Manual verification

Per the issue's success criteria: open Settings → Skills → Reveal in vault, close settings, then scroll the file tree and an open note with the wheel — both scroll normally.

## Resolves

Resolves logancyang/obsidian-copilot-preview#118 — cross-repo, so this won't auto-close; the issue must be closed manually on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
