### PR TITLE
fix(agent-mode): steer the agent to miyo-search for vault search, gated on Miyo enabled

### DIFF
--- a/src/agentMode/backends/shared/agentSystemPrompt.test.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.test.ts
@@ -6,8 +6,10 @@ import {
   updateCachedSystemPrompts,
 } from "@/system-prompts/state";
 import type { UserSystemPrompt } from "@/system-prompts/type";
+import { shouldUseMiyo } from "@/miyo/miyoUtils";
 import {
   buildAgentSystemPrompt,
+  COPILOT_MIYO_SEARCH_STEERING,
   COPILOT_PLUS_TOOLS_STEERING,
   COPILOT_PROMPT_BASE,
 } from "./agentSystemPrompt";
@@ -17,6 +19,14 @@ jest.mock("@/logger", () => ({
   logWarn: jest.fn(),
   logError: jest.fn(),
 }));
+
+// The Miyo steering is gated on `shouldUseMiyo`; mock it so tests can flip the
+// gate without standing up self-host validation state.
+jest.mock("@/miyo/miyoUtils", () => ({
+  shouldUseMiyo: jest.fn(() => false),
+}));
+
+const mockShouldUseMiyo = shouldUseMiyo as jest.MockedFunction<typeof shouldUseMiyo>;
 
 function makePrompt(title: string, content: string): UserSystemPrompt {
   return { title, content, createdMs: 0, modifiedMs: 0, lastUsedMs: 0 };
@@ -34,6 +44,7 @@ describe("buildAgentSystemPrompt", () => {
   beforeEach(() => {
     resetSettings();
     resetPromptState();
+    mockShouldUseMiyo.mockReturnValue(false);
   });
 
   it("includes the Copilot base prompt and the pill-syntax directive by default", () => {
@@ -104,6 +115,30 @@ describe("buildAgentSystemPrompt", () => {
     setDisableBuiltinSystemPrompt(true);
     const prompt = buildAgentSystemPrompt();
     expect(prompt).not.toContain(COPILOT_PLUS_TOOLS_STEERING);
+  });
+
+  it("omits the Miyo steering when Miyo is not in use", () => {
+    mockShouldUseMiyo.mockReturnValue(false);
+    const prompt = buildAgentSystemPrompt();
+    expect(prompt).not.toContain(COPILOT_MIYO_SEARCH_STEERING);
+    expect(prompt).not.toContain("miyo-search");
+  });
+
+  it("appends the Miyo steering only when Miyo is in use", () => {
+    mockShouldUseMiyo.mockReturnValue(true);
+    const prompt = buildAgentSystemPrompt();
+    expect(prompt).toContain(COPILOT_MIYO_SEARCH_STEERING);
+    // Names the skill and gives concrete triggers for when to call it.
+    expect(prompt).toContain("miyo-search");
+    expect(prompt).toMatch(/too slow|enough relevant/i);
+    expect(prompt).toMatch(/explicitly asks/i);
+  });
+
+  it("suppresses the Miyo steering when the builtin prompt is disabled, even if Miyo is in use", () => {
+    mockShouldUseMiyo.mockReturnValue(true);
+    setDisableBuiltinSystemPrompt(true);
+    const prompt = buildAgentSystemPrompt();
+    expect(prompt).not.toContain(COPILOT_MIYO_SEARCH_STEERING);
   });
 });
 

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -14,6 +14,9 @@
  *      enabled Settings → System prompts → "Disable builtin system prompt".
  *      Followed by `COPILOT_PLUS_TOOLS_STEERING` (prefer the builtin Copilot
  *      Plus skills, with a fallback to the agent's own tools) — sent to everyone.
+ *      Then `COPILOT_MIYO_SEARCH_STEERING` — appended only when `shouldUseMiyo`
+ *      is true, so the agent is pointed at the `miyo-search` skill only while
+ *      Miyo is enabled and available.
  *   2. The pill-syntax directive (`buildPillSyntaxDirective`) — always present;
  *      it teaches the agent how to read the chat editor's `[[note]]`/`{folder}`
  *      tokens and is functional wiring, not "builtin framing" the user toggles.
@@ -36,6 +39,8 @@
 // system-prompt builder needs only this one pure function, not SkillManager,
 // discovery, or the Skills UI the barrel also re-exports.
 import { buildPillSyntaxDirective } from "@/agentMode/skills/pillSyntaxDirective";
+import { shouldUseMiyo } from "@/miyo/miyoUtils";
+import { getSettings } from "@/settings/model";
 import { getDisableBuiltinSystemPrompt } from "@/system-prompts/state";
 import { getEffectiveUserPrompt } from "@/system-prompts/systemPromptBuilder";
 /**
@@ -57,6 +62,22 @@ For these requests, prefer the bundled Copilot skill over any built-in tool of y
 Each skill ships both a \`.sh\` and a \`.mjs\` script. Run the \`.sh\` with \`sh\` first; if the platform can't run \`sh\` (for example, Windows without Git Bash), run the matching \`.mjs\` with \`node\` instead. If neither \`sh\` nor \`node\` is available, tell the user to install Node.js from https://nodejs.org and try again.
 
 If the matching skill is missing, disabled, or reports that it needs an active Copilot Plus license, fall back to whatever equivalent capability you have (or tell the user it's unavailable) — don't refuse the request.`;
+
+/**
+ * Steers the agent toward the bundled `miyo-search` skill for vault search. A
+ * prose skill is only invoked if the model thinks to use it, and the SKILL.md
+ * description alone proved unreliable, so we name it explicitly in the system
+ * prompt the way `COPILOT_PLUS_TOOLS_STEERING` names the relay skills, with
+ * concrete triggers (grep too slow / too few relevant hits / explicit request).
+ *
+ * Unlike the Plus steering, this is gated: it is appended only when
+ * `shouldUseMiyo(...)` is true, so it never tells the agent to reach for a
+ * skill that isn't seeded. That keeps the prompt in lockstep with the
+ * seeding gate in `agentMode/index.ts` (both key off `shouldUseMiyo`), which is
+ * how the skill respects the user's "Miyo enabled" setting.
+ */
+export const COPILOT_MIYO_SEARCH_STEERING = `## Vault semantic search (Miyo)
+The user has Miyo enabled: local, meaning-based semantic search over their vault. For any vault-search intent, use the \`miyo-search\` skill when your builtin \`grep\` search is too slow or doesn't surface enough relevant notes, or whenever the user explicitly asks for Miyo search. Follow the skill's own instructions to run it.`;
 
 export const COPILOT_PROMPT_BASE = `You are Obsidian Copilot, an AI assistant that helps users work with their Obsidian vault — markdown notes for knowledge management, writing, and research. You are NOT a software-engineering agent or CLI coding tool. The working directory is the user's Obsidian vault: a collection of markdown notes, not a code repository. Disregard any framing in environment metadata that suggests otherwise.
 
@@ -119,6 +140,12 @@ export function buildAgentSystemPrompt(): string {
     // can't run, its script exits with the upgrade notice and the fallback
     // clause routes the agent back to its own tools. Safe for everyone.
     parts.push(COPILOT_PLUS_TOOLS_STEERING);
+    // Miyo steering is gated on the same `shouldUseMiyo` check that seeds the
+    // skill, so we only point the agent at `miyo-search` when it's actually
+    // available — the prompt-side half of respecting the "Miyo enabled" setting.
+    if (shouldUseMiyo(getSettings())) {
+      parts.push(COPILOT_MIYO_SEARCH_STEERING);
+    }
   }
 
   parts.push(buildPillSyntaxDirective());

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -287,18 +287,23 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
       prev.selfHostModeValidatedAt !== next.selfHostModeValidatedAt ||
       prev.selfHostValidationCount !== next.selfHostValidationCount;
     if (prevFolder !== nextFolder || miyoAvailabilityChanged) {
-      void seedManagedBuiltins(nextFolder).catch((e) =>
-        logError("[Skills] builtin skill re-seeding failed", e)
-      );
-    }
-    // Miyo availability also gates the `miyo-search` system-prompt steering
-    // (see `buildAgentSystemPrompt`). codex/opencode bake the prompt at spawn,
-    // so a mid-session flip needs a restart to apply — otherwise the skill is
-    // (un)seeded but the running agent never (loses)/gains the steering until a
-    // manual reload. `restartSystemPromptAffected` dedupes on the real prompt
-    // key, so it's a no-op when the rebuilt prompt is unchanged.
-    if (miyoAvailabilityChanged) {
-      restartSystemPromptAffected();
+      // Miyo availability also gates the `miyo-search` system-prompt steering
+      // (see `buildAgentSystemPrompt`). codex/opencode bake the prompt at spawn,
+      // so a mid-session flip needs a restart to apply. Chain the restart AFTER
+      // the seed + `skillManager.refresh()` resolve so the skill is written and
+      // reconciled into the agent dirs before the agent respawns — otherwise
+      // codex (which has `restartOnManagedSkillsChange: false`) could come back
+      // with steering pointing at a skill that isn't on disk yet. The seed pass
+      // swallows its own errors and always refreshes, so this normally runs
+      // after reconcile; `restartSystemPromptAffected` dedupes on the real prompt
+      // key, so it's a no-op when the rebuilt prompt is unchanged.
+      void seedManagedBuiltins(nextFolder)
+        .then(() => {
+          if (miyoAvailabilityChanged) {
+            restartSystemPromptAffected();
+          }
+        })
+        .catch((e) => logError("[Skills] builtin skill re-seeding failed", e));
     }
   });
   // A backend's binary path (or a binary install/update) is resolved at spawn

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -291,6 +291,15 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
         logError("[Skills] builtin skill re-seeding failed", e)
       );
     }
+    // Miyo availability also gates the `miyo-search` system-prompt steering
+    // (see `buildAgentSystemPrompt`). codex/opencode bake the prompt at spawn,
+    // so a mid-session flip needs a restart to apply — otherwise the skill is
+    // (un)seeded but the running agent never (loses)/gains the steering until a
+    // manual reload. `restartSystemPromptAffected` dedupes on the real prompt
+    // key, so it's a no-op when the rebuilt prompt is unchanged.
+    if (miyoAvailabilityChanged) {
+      restartSystemPromptAffected();
+    }
   });
   // A backend's binary path (or a binary install/update) is resolved at spawn
   // time, so a change must reach the running/warm process — otherwise it only

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -119,6 +119,16 @@ describe("miyo-search builtin skill", () => {
     expect(MIYO_SEARCH_SKILL.skillMd).not.toContain(PLUS_ENV.baseUrl);
   });
 
+  it("documents concrete triggers for when to call it", () => {
+    const md = MIYO_SEARCH_SKILL.skillMd;
+    // The description is the agent's primary "when to use" signal.
+    expect(md).toMatch(/description:[^\n]*too slow/i);
+    expect(md).toMatch(/description:[^\n]*explicitly asks for Miyo search/i);
+    // The body reinforces the same triggers.
+    expect(md).toMatch(/When to use it/);
+    expect(md).toMatch(/doesn't surface enough relevant notes/i);
+  });
+
   it("documents the search + files subcommands with --json output", () => {
     const md = MIYO_SEARCH_SKILL.skillMd;
     expect(md).toContain("miyo search");

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -408,7 +408,7 @@ export const MIYO_SEARCH_SKILL: BuiltinSkill = {
   enabledAgents: ["claude", "codex", "opencode"],
   skillMd: `---
 name: miyo-search
-description: Search the user's Obsidian vault with Miyo local semantic search. Use when the user wants to find notes, recall what they wrote about a topic, or ground an answer in their own vault — prefer this over reading files blindly for meaning-based recall. Needs the Miyo desktop app installed and running.
+description: Semantic (meaning-based) search over the user's Obsidian vault via the local Miyo app. For any vault-search intent, use it when builtin grep search is too slow or doesn't surface enough relevant notes, or when the user explicitly asks for Miyo search. Needs the Miyo desktop app installed and running.
 metadata:
   copilot-enabled-agents: claude, codex, opencode
   copilot-builtin-version: "${MIYO_SEARCH_VERSION}"
@@ -417,9 +417,13 @@ metadata:
 # Miyo vault search
 
 Search the user's indexed Obsidian vault through Miyo, a local companion app
-that runs semantic search over their notes on their own machine. Use it to find
-relevant notes by meaning (not just filename) and to browse what Miyo has
+that runs semantic search over their notes on their own machine. It finds
+relevant notes by meaning (not just filename) and can browse what Miyo has
 indexed. All calls are local — no network, no API key.
+
+When to use it: for any vault-search intent, reach for Miyo when your builtin
+\`grep\` search is too slow or doesn't surface enough relevant notes, or when
+the user explicitly asks for Miyo search.
 
 ## How to run
 


### PR DESCRIPTION
## Summary

Follow-up to logancyang/obsidian-copilot-preview#106 / #2566. The bundled `miyo-search` skill was being invoked unreliably — a prose skill only runs if the model thinks to use it, and the SKILL.md `description` alone wasn't a strong enough trigger.

## Changes

- **System-prompt steering.** Name `miyo-search` explicitly in the Agent Mode system prompt, the same way `COPILOT_PLUS_TOOLS_STEERING` names the relay skills, with concrete triggers: for any vault-search intent, use it when builtin `grep` is too slow or doesn't surface enough relevant notes, or when the user explicitly asks for Miyo search.
- **SKILL.md description + body.** Mirror the same concise triggers so the skill's own "when to use" signal matches the prompt.

## Respects the "Miyo enabled" setting

The new steering is appended **only when `shouldUseMiyo(getSettings())` is true** — the exact same gate that seeds/prunes the skill in `agentMode/index.ts`. So:

- When Miyo is disabled, the skill isn't seeded **and** the prompt never mentions it.
- When Miyo is enabled, both appear together.

The prompt and the on-disk skill stay in lockstep with the setting, and the prompt never points the agent at a skill that isn't there.

## Notes

- The `miyo-search` builtin version stays at **1** (no release yet, so no seeded copies to refresh).
- Steering lives inside the "Disable builtin system prompt" gate, alongside the Plus steering, so disabling the builtin prompt suppresses it too.

## Testing

- `agentSystemPrompt.test.ts`: steering present only when `shouldUseMiyo` is true, absent when false, and suppressed when the builtin prompt is disabled even if Miyo is in use. Asserts the concrete triggers and that the skill is named.
- `builtinSkills.test.ts`: description + body document the triggers.
- Full suite: `238 passed`, `3604 tests` green. `npm run lint` + Prettier clean.

Relates to logancyang/obsidian-copilot-preview#106 (cross-repo, won't auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
