### PR TITLE
fix(agent-mode): start a fresh opencode session for every new chat

### DIFF
--- a/src/agentMode/session/AgentModelPreloader.ts
+++ b/src/agentMode/session/AgentModelPreloader.ts
@@ -17,9 +17,11 @@ import type {
  * Warm result of a successful preload — the still-running backend process,
  * the probe session id it owns, and the state snapshot it reported. Handed
  * off via `takeWarm()` so the manager can skip a fresh subprocess spawn +
- * `initialize` handshake on the first chat open, and (when the user opens
- * a fresh chat on that backend) adopt the probe session as the user's
- * session instead of paying another `newSession` round-trip.
+ * `initialize` handshake on the first chat open. The manager reuses the
+ * process but starts its own `newSession` for the chat — the probe session
+ * is never adopted as a user chat, since opencode persists and resumes it
+ * (transcript and title intact) and reusing it would leak a prior
+ * conversation into a supposedly fresh chat. `state` still seeds the picker.
  */
 export interface WarmBackend {
   proc: BackendProcess;

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -317,28 +317,24 @@ describe("AgentSessionManager.createSession", () => {
   });
 });
 
-describe("AgentSessionManager warm-backend adoption", () => {
-  it("reuses the preloader's warm proc instead of spawning a fresh one", async () => {
-    // A warm proc is just another mock backend — the manager doesn't care
-    // it came from the preloader, only that it skips start() / newSession.
-    const warmProc = makeMockBackendProcess();
+describe("AgentSessionManager warm-backend reuse", () => {
+  const probeState = {
+    model: {
+      current: { baseModelId: "anthropic/sonnet", effort: null },
+      availableModels: [
+        { baseModelId: "anthropic/sonnet", name: "Sonnet", provider: null, effortOptions: [] },
+      ],
+    },
+    mode: null,
+  };
+
+  // Build a manager whose preloader hands out exactly one warm proc (with a
+  // persisted probe session id) on the first `takeWarm`, then null.
+  function buildManagerWithWarm(warmProc: ReturnType<typeof makeMockBackendProcess>) {
     const descriptor = buildDescriptor();
-    const probeState = {
-      model: {
-        current: { baseModelId: "anthropic/sonnet", effort: null },
-        availableModels: [
-          { baseModelId: "anthropic/sonnet", name: "Sonnet", provider: null, effortOptions: [] },
-        ],
-      },
-      mode: null,
-    };
     const takeWarmMock = jest
       .fn()
-      .mockReturnValueOnce({
-        proc: warmProc,
-        probeSessionId: "probe-1",
-        state: probeState,
-      })
+      .mockReturnValueOnce({ proc: warmProc, probeSessionId: "probe-1", state: probeState })
       .mockReturnValue(null);
     const modelPreloader = {
       getCachedBackendState: jest.fn(() => probeState),
@@ -360,21 +356,41 @@ describe("AgentSessionManager warm-backend adoption", () => {
         >[2]["modelPreloader"],
       }
     );
+    return { mgr, descriptor };
+  }
+
+  it("reuses the preloader's warm proc instead of spawning a fresh one", async () => {
+    const warmProc = makeMockBackendProcess();
+    const { mgr, descriptor } = buildManagerWithWarm(warmProc);
 
     await mgr.createSession();
 
     // start() on the warm proc must not be re-invoked — preload already did it.
     expect(mockBackendStart).not.toHaveBeenCalled();
-    // The session should NOT have gone through AgentSession.start (that path
-    // is for newSession-driven creates). Warm adoption uses the constructor
-    // directly.
-    expect(sessionCreateSpy).not.toHaveBeenCalled();
     // No fresh backend was created either — descriptor.createBackendProcess
     // is the spawn primitive.
     expect(descriptor.createBackendProcess).not.toHaveBeenCalled();
     // Active session is the warm one.
     expect(mgr.getActiveSession()).not.toBeNull();
     expect(mgr.getActiveSession()?.backendId).toBe("opencode");
+  });
+
+  it("starts a fresh session on the warm proc instead of adopting the probe session", async () => {
+    // Regression guard for the opencode "new chat replays prior conversation"
+    // bug: opencode resumes its persisted probe session (transcript + title
+    // intact), so the warm probe's *session* must never be adopted as the
+    // user's chat — only the subprocess is reused.
+    const warmProc = makeMockBackendProcess();
+    const { mgr } = buildManagerWithWarm(warmProc);
+
+    await mgr.createSession();
+
+    // The chat went through the newSession-driven start path, on the warm proc.
+    expect(sessionCreateSpy).toHaveBeenCalledTimes(1);
+    const opts = sessionCreateSpy.mock.calls[0][0];
+    expect(opts.backend).toBe(warmProc);
+    // The probe session id is never threaded in as a session to adopt.
+    expect(opts).not.toHaveProperty("backendSessionId");
   });
 
   it("falls back to a fresh spawn when no warm entry is available", async () => {

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -241,36 +241,28 @@ export class AgentSessionManager {
 
     const seedSelection = this.getDefaultSelection(resolvedId) ?? undefined;
 
-    let session: AgentSession;
+    // A new chat must always start from a brand-new backend session. When a
+    // warm preload probe is available we reuse its already-spawned and
+    // initialize-handshaken subprocess (the expensive part), but never its
+    // *session*: opencode persists its probe session id and resumes it from
+    // disk on the next preload, so adopting that session as the chat would
+    // replay the previous conversation's transcript and auto-title into a
+    // supposedly fresh chat. `AgentSession.start` runs `newSession` on the
+    // (warm or cold) proc; the probe's state still seeds the picker so it
+    // doesn't blink while that round-trip is in flight.
+    const session = AgentSession.start({
+      backend,
+      cwd: vaultBasePath,
+      internalId: uuidv4(),
+      backendId: resolvedId,
+      defaultModelSelection: seedSelection,
+      initialCachedState: warm?.state ?? this.preloader.getCachedBackendState(resolvedId),
+      getDescriptor: () => this.opts.resolveDescriptor(resolvedId),
+    });
     if (warm) {
-      // The probe session that preload created is reused as the user's
-      // session: skips an extra `newSession` round-trip on the warm proc.
-      // The probe ran with no user preferences, so `defaultModelSelection`
-      // is what makes the session apply the persisted preference (with the
-      // optimistic seed so the picker never flashes the probe's default).
-      session = new AgentSession({
-        backend,
-        backendSessionId: warm.probeSessionId,
-        internalId: uuidv4(),
-        backendId: resolvedId,
-        initialState: warm.state,
-        defaultModelSelection: seedSelection,
-        cwd: vaultBasePath,
-        getDescriptor: () => this.opts.resolveDescriptor(resolvedId),
-      });
       logInfo(
-        `[AgentMode] session adopted warm probe (internal=${session.internalId} backend-id=${warm.probeSessionId} backend=${resolvedId})`
+        `[AgentMode] session reused warm proc with a fresh session (internal=${session.internalId} backend=${resolvedId})`
       );
-    } else {
-      session = AgentSession.start({
-        backend,
-        cwd: vaultBasePath,
-        internalId: uuidv4(),
-        backendId: resolvedId,
-        defaultModelSelection: seedSelection,
-        initialCachedState: this.preloader.getCachedBackendState(resolvedId),
-        getDescriptor: () => this.opts.resolveDescriptor(resolvedId),
-      });
     }
     this.sessions.set(session.internalId, session);
     this.chatUIStates.set(session.internalId, new AgentChatUIState(session));


### PR DESCRIPTION
## Problem

Starting a **new chat** with the opencode backend silently reuses the previous session's transcript and tab title. Confirmed from an LM Studio request log: a fresh chat asking an unrelated question sent the model 28 messages beginning with an old, unrelated Q&A ("how many ml is 1 cup of water"), and the tab showed the prior session's auto-summary ("milliliters in 1 ...") instead of the new topic.

This is a privacy + correctness regression: unrelated prior conversation content (and attached note context) is leaked to the model on every new chat after the first, every new chat re-sends the whole accumulated transcript, and tab titles are wrong.

Tracking issue: logancyang/obsidian-copilot-preview#148 (cross-repo, so this PR does not auto-close it).

## Root cause

opencode-specific. The preloader creates a warm-up **probe** session via `newSession()` and **persists its id** (`AgentModelPreloader.fetchInitialState` → `descriptor.persistProbeSessionId`). On the next preload it **resumes** that persisted id before falling back to `newSession()`. Separately, `createSession()` **adopted the warm probe's session** as the user's chat (`new AgentSession({ backendSessionId: warm.probeSessionId, ... })`).

Combined: once a real conversation happens in the adopted probe, its id (now pointing at a transcript-bearing session) is persisted; the next launch resumes it as the warm probe, and the next "new chat" adopts it again — replaying the whole prior conversation and keeping opencode's stale auto-title.

Codex and Claude are unaffected: they don't implement the probe-persistence hooks, so their probe is always freshly created and single-use.

## Fix

Reuse the warm **subprocess** (the expensive spawn + initialize handshake) but never its **session**. `createSession()` now always runs `AgentSession.start()` (which calls `newSession()`) on the warm-or-cold proc, seeding the picker from the probe's cached state so it doesn't blink. The persisted probe session is now never fed user messages, so it stays a pristine catalog-only session across launches.

The legitimate resume-from-history path (`tryResumeSessionFromHistory`, which intentionally replays a saved chat) is untouched.

## Tests

- Updated `AgentSessionManager` warm-backend tests: the warm proc is still reused (no re-`start()`, no fresh `createBackendProcess`), but the chat now goes through the `newSession`-driven start path.
- Added a regression guard asserting `createSession` with a warm probe present starts a fresh session on the warm proc and never threads `backendSessionId` (the probe session) in for adoption.
- `npm run test` (agentMode/session suite, 263 tests), `npm run format`, `npm run lint`, and `tsc --noEmit` all pass.

## Manual verification

Start an opencode chat and ask question A, click "new chat", ask unrelated question B. Inspect the backend request (Settings → Advanced → Log Full Agent Mode Frames → `acp-frames.ndjson` `session/prompt` payload, or the LM Studio log): it contains only B, and the new tab is not titled from A. Holds across plugin reload and full relaunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
