### PR TITLE
fix(chat): keep status-bar clearance in sync so bottom-right banners can't cover the input

### DIFF
--- a/src/components/chat-components/ChatViewLayout.ts
+++ b/src/components/chat-components/ChatViewLayout.ts
@@ -12,6 +12,8 @@ const CSS_CHANGE_DEBOUNCE_MS = 600;
 export class ChatViewLayout {
   private debounceTimer: number | null = null;
   private cssChangeRef: ReturnType<Workspace["on"]> | null = null;
+  private statusBarResizeObserver: ResizeObserver | null = null;
+  private observedStatusBar: HTMLElement | null = null;
 
   constructor(
     private containerEl: HTMLElement,
@@ -32,6 +34,9 @@ export class ChatViewLayout {
       this.workspace.offref(this.cssChangeRef);
       this.cssChangeRef = null;
     }
+    this.statusBarResizeObserver?.disconnect();
+    this.statusBarResizeObserver = null;
+    this.observedStatusBar = null;
   }
 
   /**
@@ -43,6 +48,14 @@ export class ChatViewLayout {
    * reflow so nothing flickers. Themes that already position content above
    * the status bar (no overlap) get 0 clearance automatically. Auto-hide
    * themes (opacity: 0) also get 0 since the bar is transparent.
+   *
+   * The desktop status bar lives in the bottom-right and hosts core and
+   * plugin items (update-available notice, sync status, word count, ...).
+   * When one of those appears or grows -- making the bar taller, e.g. items
+   * wrap to a second line -- the overlap changes without a `css-change`
+   * event, so a ResizeObserver on the bar keeps the clearance in sync and
+   * the chat input from being covered. Measuring the bar's geometry stays
+   * generalizable: no specific banner or plugin is hardcoded.
    */
   private setupStatusBarClearance(): void {
     if (Platform.isMobile) return;
@@ -52,6 +65,8 @@ export class ChatViewLayout {
       const statusBar = this.containerEl.doc.querySelector<HTMLElement>(".status-bar");
       const viewContent = this.containerEl.querySelector<HTMLElement>(".view-content");
       if (!statusBar || !viewContent) return;
+
+      this.observeStatusBar(statusBar, syncClearance);
 
       // Zero out clearance and force reflow to measure natural overlap.
       // Remove any inline override left from a prior run so the CSS default
@@ -80,5 +95,18 @@ export class ChatViewLayout {
       if (this.debounceTimer) window.clearTimeout(this.debounceTimer);
       this.debounceTimer = window.setTimeout(syncClearance, CSS_CHANGE_DEBOUNCE_MS);
     });
+  }
+
+  /**
+   * Keep a single ResizeObserver pointed at the current status bar element so
+   * runtime size changes re-trigger a measurement. Rebinds when the element is
+   * replaced (e.g. after a theme reload swaps the DOM); a no-op otherwise.
+   */
+  private observeStatusBar(statusBar: HTMLElement, onResize: () => void): void {
+    if (this.observedStatusBar === statusBar) return;
+    this.statusBarResizeObserver?.disconnect();
+    this.statusBarResizeObserver = new ResizeObserver(() => onResize());
+    this.statusBarResizeObserver.observe(statusBar);
+    this.observedStatusBar = statusBar;
   }
 }


### PR DESCRIPTION
## Summary

Fixes [logancyang/obsidian-copilot-preview#99](https://github.com/logancyang/obsidian-copilot-preview/issues/99): Obsidian's bottom-right status bar (update-available notice, sync status, and other core/plugin items) can cover the desktop chat input and its send button.

Desktop already reserves space for the floating status bar via the `--copilot-status-bar-clearance` variable, which `ChatViewLayout` measures from the bar's geometric overlap with `.view-content`. The bug: that measurement only re-ran on `css-change`, so when a status-bar item appears or grows at runtime (making the bar taller without a `css-change` event), the stale clearance let the bar overlap the input.

**Fix:** attach a `ResizeObserver` to the status bar so any size change re-runs the existing measurement. No banner, dimension, or plugin is hardcoded; it rebinds across theme reloads that swap the element, disconnects in `destroy()`, and early-returns on mobile (no mobile regression).

## Why this logic is needed (re: #2585, which removes it)

[#2585](https://github.com/logancyang/obsidian-copilot/pull/2585) proposes deleting this entirely, on the premise that Obsidian's default CSS already handles the status bar. It does not, for a pinned chat input. Three reasons:

1. **Obsidian's built-in mitigation is editor-only.** The [official status-bar CSS variables](https://docs.obsidian.md/Reference/CSS+variables/Window/Status+bar) are all cosmetic (background, border, font, position, radius). There is **no height/clearance variable**. The one functional knob, `--status-bar-scroll-padding`, applies `scroll-padding` to the **editor's scroll container** so the cursor can scroll clear of the floating bar. Our chat input is pinned at the bottom of a flex column in a custom `ItemView`, not scrolled, so that mechanism never applies to it.

2. **The clearance is self-disabling, so it cannot be "unnecessary."** The measurement sets clearance to `0` whenever the bar does not actually overlap (theme positions content above it, or the bar is hidden/transparent). In the default-theme, no-banner case shown in #2585's screenshot, our code measures zero overlap and adds **zero** padding. It only reserves space when it measures a *real* overlap. Removing it therefore changes nothing in the cases that already look fine, and reintroduces logancyang/obsidian-copilot-preview#99 in exactly the cases that don't, i.e. a tall/visible bar (update notice, sync status, themes that enlarge or reposition the bar). A clean default-theme screenshot doesn't exercise the banner scenario the bug is about.

3. **The value is dynamic, so a static CSS rule can't replace it.** Status-bar height is content-driven (which core/plugin items are present, font size, wrapping) and changes at runtime, which is the whole reason we measure and now observe rather than hardcode a pixel value.

## Public evidence this is a real, unsolved gap

This floating-bar overlap is a long-standing core limitation that plugin and theme authors repeatedly hit, not something Obsidian auto-solves:

- [Editor status bar covers / makes editing the last line hard](https://forum.obsidian.md/t/editor-status-bar-covers-makes-editing-the-last-line-hard/53046) — same root cause as ours: the floating bar covers content at the bottom of the view (there, the last line of text; for us, the chat input).
- [Stop status bar from hiding text while typing](https://forum.obsidian.md/t/stop-status-bar-from-hiding-text-while-typing-or-hide-status-bar-to-avoid-the-issue/45165) — confirms the bottom-right bar obscures whatever sits at the bottom of the view, which is exactly where our input lives.
- [Status bar occludes buttons (Settings, Help, Open another vault)](https://forum.obsidian.md/t/status-bar-occludes-buttons-settings-help-open-another-vault/54738) — shows the bar overlapping *clickable* controls, the precise failure mode where it covers our send button.
- [Expose sidebar widths through CSS variables](https://forum.obsidian.md/t/expose-sidebar-widths-through-css-variables/51649) — devs asking Obsidian to publish live layout sizes as CSS vars (declined as too dynamic), which is why there is no status-bar-height var to lean on and we must measure it ourselves.

## Testing

- `npm run build` passes (tsc + esbuild + tailwind); no stray `styles.css` changes.
- `npm run format && npm run lint` clean.
- `npm run test` -- 3605 tests pass.
- Manual: with a bottom-right status-bar item present/growing, the chat input and send button stay fully visible and clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
