### PR TITLE
fix(agent-mode): surface Codex provider errors hidden as Internal error

### DIFF
--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -346,6 +346,39 @@ describe("AgentSession.sendPrompt", () => {
     expect(placeholder?.message).toContain("Rate limit exceeded");
   });
 
+  it("surfaces a provider error stringified inside data.message (codex-acp)", async () => {
+    const mock = makeMockBackend();
+    // codex-acp reports JSON-RPC -32603 "Internal error" with the real provider
+    // error nested as a JSON *string* in data.message.
+    const error = new Error("Internal error");
+    (error as { data?: unknown }).data = {
+      message: JSON.stringify({
+        type: "error",
+        status: 400,
+        error: {
+          type: "invalid_request_error",
+          message:
+            "The 'gpt-5.5' model requires a newer version of Codex. Please upgrade to the latest app or CLI and try again.",
+        },
+      }),
+      codex_error_info: "other",
+    };
+    mock.prompt.mockRejectedValueOnce(error);
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "codex",
+    });
+
+    await expect(session.sendPrompt("hi").turn).rejects.toThrow("Internal error");
+
+    const placeholder = session.store.getDisplayMessages().find((m) => m.sender === AI_SENDER);
+    expect(placeholder?.isErrorMessage).toBe(true);
+    expect(placeholder?.message).toContain("invalid_request_error");
+    expect(placeholder?.message).toContain("requires a newer version of Codex");
+  });
+
   it("renders a visible error (not an empty bubble) when the backend reports auth required", async () => {
     const mock = makeMockBackend();
     mock.prompt.mockRejectedValueOnce(new AuthRequiredError("You're not signed in to Claude."));

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1407,6 +1407,16 @@ function findProviderErrorPayload(
       return { type: errorRecord.type, message: errorRecord.message };
     }
   }
+  // Some agents (e.g. codex-acp) stringify the upstream provider error as JSON
+  // inside a `message` field. Parse and recurse so the real reason surfaces
+  // instead of a bare "Internal error".
+  if (typeof record.message === "string") {
+    const parsed = tryParseJsonObject(record.message);
+    if (parsed) {
+      const nested = findProviderErrorPayload(parsed, seen);
+      if (nested) return nested;
+    }
+  }
   if (record.data) {
     const nested = findProviderErrorPayload(record.data, seen);
     if (nested) return nested;
@@ -1420,6 +1430,18 @@ function findProviderErrorPayload(
   const cause = record.cause;
   if (cause) return findProviderErrorPayload(cause, seen);
   return null;
+}
+
+/** Parse a string into a plain object, or null if it isn't JSON-object-shaped. */
+function tryParseJsonObject(s: string): Record<string, unknown> | null {
+  const t = s.trim();
+  if (!t.startsWith("{")) return null; // cheap guard; don't parse plain text
+  try {
+    const v = JSON.parse(t);
+    return v && typeof v === "object" ? (v as Record<string, unknown>) : null;
+  } catch {
+    return null;
+  }
 }
 
 export function buildPromptBlocks(


### PR DESCRIPTION
codex-acp wraps the upstream provider error as a JSON string inside `error.data.message`, but `findProviderErrorPayload` only walked nested *objects*, so users saw a bare "Internal error" with no actionable text. This adds a guarded branch that parses a JSON-object `message` and recurses, surfacing the real reason — e.g. *"The 'gpt-5.5' model requires a newer version of Codex. Please upgrade…"* when an outdated codex-acp can't run a newer model. The fix is generic across providers, with no codex- or model-specific branching, and a regression test covers the stringified-`data.message` shape while the existing object-nested path stays green.

Diagnosed from an ACP frame capture: the reporter's codex-acp is v0.11.1, which predates GPT-5.5 (hence the missing Thinking Effort selector and the 400) — this change just makes the plugin show the agent's own message pointing at the real fix (upgrade codex-acp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)