### PR TITLE
feat(settings): rename autosave to 'Autosave Chat as Markdown' and always generate AI titles on save

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -977,7 +977,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   defaultSaveFolder: DEFAULT_CHAT_HISTORY_FOLDER,
   defaultConversationTag: "copilot-conversation",
   autosaveChat: true,
-  generateAIChatTitleOnSave: true,
   autoAddActiveContentToContext: true,
   defaultOpenArea: DEFAULT_OPEN_AREA.VIEW,
   defaultSendShortcut: SEND_SHORTCUT.ENTER,

--- a/src/core/ChatPersistenceManager.test.ts
+++ b/src/core/ChatPersistenceManager.test.ts
@@ -27,7 +27,6 @@ jest.mock("@/settings/model", () => ({
     defaultSaveFolder: "test-folder",
     defaultConversationTag: "copilot-conversation",
     defaultConversationNoteName: "{$topic}@{$date}_{$time}",
-    generateAIChatTitleOnSave: true,
   }),
 }));
 jest.mock("@/aiParams", () => ({

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -818,9 +818,9 @@ ${chatContent}`;
     messages: ChatMessage[],
     existingTopic?: string
   ): void {
-    const settings = getSettings();
-
-    if (!settings.generateAIChatTitleOnSave || !file || existingTopic) {
+    // AI title generation on save is always on for saved (legacy) chat notes;
+    // skip only when there's no file or the note already carries a topic.
+    if (!file || existingTopic) {
       return;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1227,7 +1227,7 @@ export default class CopilotPlugin extends Plugin {
   async openChatSourceFile(fileId: string): Promise<void> {
     if (isNativeChatId(fileId)) {
       new Notice(
-        "This chat has no saved note. Turn on Autosave Chat to save chats as notes in your vault."
+        "This chat has no saved note. Turn on Autosave Chat as Markdown to save chats as notes in your vault."
       );
       return;
     }

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -88,11 +88,6 @@ export interface CopilotSettings {
   defaultSaveFolder: string;
   defaultConversationTag: string;
   autosaveChat: boolean;
-  /**
-   * When enabled, generate a short AI title for chat notes on save.
-   * When disabled (default), use the first 10 words of the first user message.
-   */
-  generateAIChatTitleOnSave: boolean;
   autoAddActiveContentToContext: boolean;
   customPromptsFolder: string;
   indexVaultToVectorStore: string;
@@ -663,11 +658,6 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
       sanitizedSettings.autoAddActiveContentToContext =
         DEFAULT_SETTINGS.autoAddActiveContentToContext;
     }
-  }
-
-  // Ensure generateAIChatTitleOnSave has a default value
-  if (typeof sanitizedSettings.generateAIChatTitleOnSave !== "boolean") {
-    sanitizedSettings.generateAIChatTitleOnSave = DEFAULT_SETTINGS.generateAIChatTitleOnSave;
   }
 
   // Ensure enableMiyo has a default value

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -260,18 +260,10 @@ export const BasicSettings: React.FC = () => {
         <div className="tw-space-y-4">
           <SettingItem
             type="switch"
-            title="Autosave Chat"
-            description="Automatically saves the chat after every user message and AI response."
+            title="Autosave Chat as Markdown"
+            description="Writes each chat to a Markdown note in your vault after every user message and AI response. With this off, agent chats still appear in Recent Chats from session history; only the Markdown note is skipped."
             checked={settings.autosaveChat}
             onCheckedChange={(checked) => updateSetting("autosaveChat", checked)}
-          />
-
-          <SettingItem
-            type="switch"
-            title="Generate AI Chat Title on Save"
-            description="When enabled, uses an AI model to generate a concise title for saved chat notes. When disabled, uses the first 10 words of the first user message."
-            checked={settings.generateAIChatTitleOnSave}
-            onCheckedChange={(checked) => updateSetting("generateAIChatTitleOnSave", checked)}
           />
 
           <SettingItem


### PR DESCRIPTION
Follow-up settings cleanup for the agent Recent Chats work in logancyang/obsidian-copilot-preview#151 (shipped in #2591).

## What

Two related settings changes in the "Saving Conversations" section.

### 1. Rename "Autosave Chat" → "Autosave Chat as Markdown"

With native session history, agent chats now appear in Recent Chats regardless of whether a Markdown note was saved. The old "Autosave Chat" label implied the toggle controlled visibility in history; it doesn't anymore — it only controls whether a Markdown note is written. The rename + description make that explicit.

- Title: `Autosave Chat` → `Autosave Chat as Markdown`
- Description now reads: "Writes each chat to a Markdown note in your vault after every user message and AI response. With this off, agent chats still appear in Recent Chats from session history; only the Markdown note is skipped."
- Updated the matching Notice shown when opening a native chat's (missing) source note.
- The internal setting key `autosaveChat` is unchanged (no migration needed).

### 2. Remove "Generate AI Chat Title on Save", make it always on

That toggle only ever governed the **legacy** (non-agent) chat's saved-note title — agent titles come from the backend summarizer (opencode/codex) or a first-message derivation (Claude), independent of this setting. So a user-facing toggle was confusing (it appeared to do nothing for agent users). AI title generation on save is now unconditional for saved chat notes.

- Removed the toggle from the v2 settings UI.
- `generateTopicAsyncIfNeeded` now only skips when there's no file or the note already has a topic.
- Dropped the `generateAIChatTitleOnSave` field, its `DEFAULT_SETTINGS` value, its sanitizer default, and the test mock entry.

## Testing

- `npm run format`, `npm run lint`, `npm run build` clean.
- `npm run test`: 3656 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)