### PR TITLE
fix(agent-mode): translate slash-command syntax to agent chat syntax

### DIFF
--- a/src/agentMode/session/expandCustomCommandPrefix.test.ts
+++ b/src/agentMode/session/expandCustomCommandPrefix.test.ts
@@ -1,33 +1,8 @@
 import { mockTFile } from "@/__tests__/mockObsidian";
 import { expandCustomCommandPrefix } from "@/agentMode/session/expandCustomCommandPrefix";
 import { CustomCommand } from "@/commands/type";
-import { extractTemplateNoteFiles } from "@/utils";
-import { App, Vault } from "obsidian";
 
-jest.mock("obsidian", () => ({
-  Notice: jest.fn(),
-  TFile: jest.fn(),
-  Vault: jest.fn(),
-}));
-
-jest.mock("@/logger", () => ({
-  logWarn: jest.fn(),
-  logInfo: jest.fn(),
-  logError: jest.fn(),
-}));
-
-jest.mock("@/utils", () => {
-  const actual = jest.requireActual<{ stripFrontmatter: unknown }>("@/utils");
-  return {
-    extractTemplateNoteFiles: jest.fn().mockReturnValue([]),
-    getFileContent: jest.fn(),
-    getFileName: jest.fn(),
-    getNotesFromPath: jest.fn(),
-    getNotesFromTags: jest.fn(),
-    processVariableNameForNotePath: jest.fn(),
-    stripFrontmatter: actual.stripFrontmatter,
-  };
-});
+jest.mock("obsidian", () => ({ TFile: jest.fn() }));
 
 const makeCommand = (overrides: Partial<CustomCommand>): CustomCommand => ({
   title: "test",
@@ -41,108 +16,91 @@ const makeCommand = (overrides: Partial<CustomCommand>): CustomCommand => ({
 });
 
 describe("expandCustomCommandPrefix", () => {
-  let vault: Vault;
-  let app: App;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    (extractTemplateNoteFiles as jest.Mock).mockReturnValue([]);
-    vault = {
-      adapter: {
-        stat: jest.fn().mockResolvedValue({ ctime: Date.now(), mtime: Date.now() }),
-      },
-    } as unknown as Vault;
-    app = {
-      vault,
-      metadataCache: { getFileCache: jest.fn() },
-      workspace: { getActiveFile: jest.fn() },
-      fileManager: { processFrontMatter: jest.fn() },
-    } as unknown as App;
-  });
-
   it("returns input unchanged when text does not start with slash", async () => {
-    const result = await expandCustomCommandPrefix("hello world", [], app, "", null);
+    const result = await expandCustomCommandPrefix("hello world", [], "", null);
     expect(result).toEqual({ text: "hello world" });
   });
 
   it("returns input unchanged when no command matches", async () => {
     const cmds = [makeCommand({ title: "foo", content: "FOO BODY" })];
-    const result = await expandCustomCommandPrefix("/unknown", cmds, app, "", null);
+    const result = await expandCustomCommandPrefix("/unknown", cmds, "", null);
     expect(result).toEqual({ text: "/unknown" });
   });
 
   it("returns input unchanged for a lone slash", async () => {
     const cmds = [makeCommand({ title: "foo", content: "FOO BODY" })];
-    const result = await expandCustomCommandPrefix("/", cmds, app, "", null);
+    const result = await expandCustomCommandPrefix("/", cmds, "", null);
     expect(result).toEqual({ text: "/" });
   });
 
   it("returns input unchanged when an empty commands list is given (skill collision case)", async () => {
     // Mirrors composeSlashMenuItems: if a skill shadows the command title,
     // the command never reaches this expander, so an empty list = pass-through.
-    const result = await expandCustomCommandPrefix("/foo", [], app, "", null);
+    const result = await expandCustomCommandPrefix("/foo", [], "", null);
     expect(result).toEqual({ text: "/foo" });
   });
 
   it("expands `/foo` exactly to the command body (no args)", async () => {
     const cmd = makeCommand({ title: "foo", content: "FOO BODY" });
-    const result = await expandCustomCommandPrefix("/foo", [cmd], app, "", null);
+    const result = await expandCustomCommandPrefix("/foo", [cmd], "", null);
     expect(result.matched).toBe(cmd);
-    expect(result.text).toBe("FOO BODY\n\n");
+    expect(result.text).toBe("FOO BODY");
   });
 
   it("is case-insensitive on the command title", async () => {
     const cmd = makeCommand({ title: "Random-Hello", content: "Say hi" });
-    const result = await expandCustomCommandPrefix("/random-hello", [cmd], app, "", null);
+    const result = await expandCustomCommandPrefix("/random-hello", [cmd], "", null);
     expect(result.matched).toBe(cmd);
-    expect(result.text).toBe("Say hi\n\n");
+    expect(result.text).toBe("Say hi");
   });
 
   it("appends trailing args to the body before processing", async () => {
     const cmd = makeCommand({ title: "foo", content: "FOO BODY" });
-    const result = await expandCustomCommandPrefix("/foo bar baz", [cmd], app, "", null);
+    const result = await expandCustomCommandPrefix("/foo bar baz", [cmd], "", null);
     expect(result.matched).toBe(cmd);
-    expect(result.text).toBe("FOO BODY\n\nbar baz\n\n");
+    expect(result.text).toBe("FOO BODY\n\nbar baz");
   });
 
   it("prefers the longest matching title", async () => {
     const fooBar = makeCommand({ title: "foo-bar", content: "LONG" });
     const foo = makeCommand({ title: "foo", content: "SHORT" });
-    const result = await expandCustomCommandPrefix("/foo-bar args", [foo, fooBar], app, "", null);
+    const result = await expandCustomCommandPrefix("/foo-bar args", [foo, fooBar], "", null);
     expect(result.matched).toBe(fooBar);
-    expect(result.text).toBe("LONG\n\nargs\n\n");
+    expect(result.text).toBe("LONG\n\nargs");
   });
 
   it("does not match when the title is a prefix but not followed by whitespace", async () => {
     const foo = makeCommand({ title: "foo", content: "FOO" });
-    const result = await expandCustomCommandPrefix("/foobar", [foo], app, "", null);
+    const result = await expandCustomCommandPrefix("/foobar", [foo], "", null);
     expect(result).toEqual({ text: "/foobar" });
   });
 
-  it("expands `{}` against selected text", async () => {
+  it("inlines selected text for `{}` (translated to Agent chat syntax)", async () => {
     const cmd = makeCommand({ title: "rewrite", content: "Rewrite this: {}" });
     const result = await expandCustomCommandPrefix(
       "/rewrite",
       [cmd],
-      app,
       "the selected paragraph",
       null
     );
     expect(result.matched).toBe(cmd);
-    expect(result.text).toBe(
-      "Rewrite this: {selected_text}\n\n<selected_text>\nthe selected paragraph\n</selected_text>"
-    );
+    expect(result.text).toBe("Rewrite this: the selected paragraph");
   });
 
-  it("treats activeNote as the {} target when no selection is present", async () => {
-    const cmd = makeCommand({ title: "summarize", content: "Summarize: {}" });
-    const activeNote = mockTFile({ path: "notes/today.md", basename: "today" });
-    const utils = jest.requireMock<{ getFileContent: jest.Mock }>("@/utils");
-    utils.getFileContent.mockResolvedValue("note body");
+  it("translates {activeNote} to a [[wikilink]] reference, not an inlined note body", async () => {
+    const cmd = makeCommand({
+      title: "summarize",
+      content: "Summarize the {activeNote} using the [[Some Prompt]].",
+    });
+    const activeNote = mockTFile({
+      path: "00_Inbox/Ruby Mailchimp Changes.md",
+      basename: "Ruby Mailchimp Changes",
+    });
 
-    const result = await expandCustomCommandPrefix("/summarize", [cmd], app, "", activeNote);
+    const result = await expandCustomCommandPrefix("/summarize", [cmd], "", activeNote);
+
     expect(result.matched).toBe(cmd);
-    expect(result.text).toContain('<selected_text type="active_note">');
-    expect(result.text).toContain("note body");
+    expect(result.text).toBe("Summarize the [[Ruby Mailchimp Changes]] using the [[Some Prompt]].");
+    expect(result.text).not.toContain('<variable name="activeNote">');
   });
 });

--- a/src/agentMode/session/expandCustomCommandPrefix.ts
+++ b/src/agentMode/session/expandCustomCommandPrefix.ts
@@ -1,6 +1,6 @@
-import { processPrompt } from "@/commands/customCommandUtils";
+import { translateCommandToAgentText } from "@/agentMode/session/translateCommandToAgentText";
 import type { CustomCommand } from "@/commands/type";
-import type { App, TFile } from "obsidian";
+import type { TFile } from "obsidian";
 
 export interface ExpandCustomCommandResult {
   /** Final text to send to the backend. Equal to input when no command matched. */
@@ -11,12 +11,13 @@ export interface ExpandCustomCommandResult {
 
 /**
  * If `input` starts with `/<command-title>` (optionally followed by
- * whitespace + args), substitute the command's body and return the
- * processed prompt. Otherwise return `input` unchanged.
+ * whitespace + args), substitute the command's body and return it translated
+ * into Agent chat syntax (see {@link translateCommandToAgentText}). Otherwise
+ * return `input` unchanged.
  *
  * Args typed after the command name are appended to the command body
- * (separated by a blank line) so `processPrompt` can resolve `{}` /
- * `{selection}` against either selected text or the trailing args.
+ * (separated by a blank line) so the translator can resolve `{}` /
+ * `{copilot-selection}` against either selected text or the trailing args.
  *
  * Matching is case-insensitive on `title`. When multiple titles share a
  * prefix (e.g. `foo` and `foo-bar`), the longest match wins. The match
@@ -26,7 +27,6 @@ export interface ExpandCustomCommandResult {
 export async function expandCustomCommandPrefix(
   input: string,
   commands: readonly CustomCommand[],
-  app: App,
   selectedText: string,
   activeNote: TFile | null
 ): Promise<ExpandCustomCommandResult> {
@@ -48,6 +48,6 @@ export async function expandCustomCommandPrefix(
   const args = afterSlash.slice(matched.title.length).trim();
   const body = args ? `${matched.content}\n\n${args}` : matched.content;
 
-  const result = await processPrompt(app, body, selectedText, app.vault, activeNote, false);
-  return { text: result.processedPrompt, matched };
+  const text = translateCommandToAgentText(body, selectedText, activeNote);
+  return { text, matched };
 }

--- a/src/agentMode/session/resolveActiveNoteToken.test.ts
+++ b/src/agentMode/session/resolveActiveNoteToken.test.ts
@@ -42,10 +42,10 @@ describe("resolveActiveNoteToken", () => {
     expect(out).toBe("Look in {Projects} and summarize [[Daily]].");
   });
 
-  it("treats `{ActiveNote}` (wrong case) as a non-match — only the reserved literal is replaced", () => {
-    const text = "Mention {ActiveNote} and {activeNote}.";
+  it("matches active-note token casing used by existing custom prompts", () => {
+    const text = "Mention {ActiveNote}, {activenote}, and {activeNote}.";
     expect(resolveActiveNoteToken(text, mockFile("Daily"))).toBe(
-      "Mention {ActiveNote} and [[Daily]]."
+      "Mention [[Daily]], [[Daily]], and [[Daily]]."
     );
   });
 

--- a/src/agentMode/session/resolveActiveNoteToken.ts
+++ b/src/agentMode/session/resolveActiveNoteToken.ts
@@ -3,11 +3,10 @@ import type { TFile } from "obsidian";
 /** Rewrites `{activeNote}` to `[[Title]]` — the agent has no workspace context to resolve the token itself. */
 export function resolveActiveNoteToken(text: string, activeFile: TFile | null): string {
   if (!activeFile) return text;
-  if (!text.includes("{activeNote}")) return text;
   // Mirror NotePillNode.getTextContent: keep the extension for non-markdown attachments
   // (pdf/canvas) so the agent resolves the same path the pill envelope carries.
   const ext = activeFile.extension?.toLowerCase();
   const display =
     ext === "pdf" || ext === "canvas" ? `${activeFile.basename}.${ext}` : activeFile.basename;
-  return text.split("{activeNote}").join(`[[${display}]]`);
+  return text.replace(/\{activenote\}/gi, () => `[[${display}]]`);
 }

--- a/src/agentMode/session/translateCommandToAgentText.test.ts
+++ b/src/agentMode/session/translateCommandToAgentText.test.ts
@@ -1,0 +1,76 @@
+import { mockTFile } from "@/__tests__/mockObsidian";
+import { translateCommandToAgentText } from "@/agentMode/session/translateCommandToAgentText";
+
+jest.mock("obsidian", () => ({ TFile: jest.fn() }));
+
+const mockFile = (basename: string, extension = "md") =>
+  mockTFile({ basename, extension, path: `${basename}.${extension}` });
+
+describe("translateCommandToAgentText", () => {
+  it("leaves a body with no tokens untouched (no trailing whitespace)", () => {
+    expect(translateCommandToAgentText("Summarize this note.", "", null)).toBe(
+      "Summarize this note."
+    );
+  });
+
+  it("rewrites {activeNote} to a [[wikilink]] reference, never an inlined body", () => {
+    const out = translateCommandToAgentText(
+      "Summarize the {activeNote} using the [[Meeting Notes Summarization Prompt]].",
+      "",
+      mockFile("Ruby Mailchimp Changes")
+    );
+    expect(out).toBe(
+      "Summarize the [[Ruby Mailchimp Changes]] using the [[Meeting Notes Summarization Prompt]]."
+    );
+    expect(out).not.toContain('<variable name="activeNote">');
+  });
+
+  it("strips the braces from {[[Note Title]]} into a bare [[wikilink]]", () => {
+    expect(translateCommandToAgentText("Use {[[Some Prompt]]} now.", "", null)).toBe(
+      "Use [[Some Prompt]] now."
+    );
+  });
+
+  it("inlines selected text for {} and {copilot-selection}", () => {
+    expect(translateCommandToAgentText("Rewrite this: {}", "the selected paragraph", null)).toBe(
+      "Rewrite this: the selected paragraph"
+    );
+    expect(translateCommandToAgentText("Fix {copilot-selection}", "broken text", null)).toBe(
+      "Fix broken text"
+    );
+  });
+
+  it("falls back to the active-note reference for {} when there is no selection", () => {
+    expect(translateCommandToAgentText("Summarize: {}", "", mockFile("Today"))).toBe(
+      "Summarize: [[Today]]"
+    );
+  });
+
+  it("does not treat `$` in the selection as a replacement pattern", () => {
+    expect(translateCommandToAgentText("Echo {}", "$1 and $&", null)).toBe("Echo $1 and $&");
+  });
+
+  it("hands a {#tag} reference to the agent as a bare tag, not a pre-expanded note list", () => {
+    expect(translateCommandToAgentText("Review {#meeting, #ruby}", "", null)).toBe(
+      "Review #meeting, #ruby"
+    );
+  });
+
+  it("hands a {folder/path} reference to the agent as a bare path", () => {
+    expect(translateCommandToAgentText("Summarize {00_Inbox}", "", null)).toBe(
+      "Summarize 00_Inbox"
+    );
+  });
+
+  it("leaves {activeWebTab} untouched for the send path to resolve", () => {
+    expect(translateCommandToAgentText("Summarize {activeWebTab}", "", null)).toBe(
+      "Summarize {activeWebTab}"
+    );
+  });
+
+  it("leaves a JSON object literal untouched", () => {
+    expect(translateCommandToAgentText('Return {"key": "value"} as-is', "", null)).toBe(
+      'Return {"key": "value"} as-is'
+    );
+  });
+});

--- a/src/agentMode/session/translateCommandToAgentText.test.ts
+++ b/src/agentMode/session/translateCommandToAgentText.test.ts
@@ -25,6 +25,18 @@ describe("translateCommandToAgentText", () => {
     expect(out).not.toContain('<variable name="activeNote">');
   });
 
+  it("rewrites lowercase {activenote} used by existing custom prompts", () => {
+    expect(translateCommandToAgentText("Summarize {activenote}.", "", mockFile("Daily"))).toBe(
+      "Summarize [[Daily]]."
+    );
+  });
+
+  it("preserves lowercase {activenote} when no active file is available", () => {
+    expect(translateCommandToAgentText("Summarize {activenote}.", "", null)).toBe(
+      "Summarize {activenote}."
+    );
+  });
+
   it("strips the braces from {[[Note Title]]} into a bare [[wikilink]]", () => {
     expect(translateCommandToAgentText("Use {[[Some Prompt]]} now.", "", null)).toBe(
       "Use [[Some Prompt]] now."

--- a/src/agentMode/session/translateCommandToAgentText.ts
+++ b/src/agentMode/session/translateCommandToAgentText.ts
@@ -51,7 +51,7 @@ export function translateCommandToAgentText(
     if (token === ACTIVE_WEB_TAB_MARKER) return token; // live marker, resolved downstream
     const name = rawName.trim();
     if (name.startsWith('"')) return token; // JSON object literal, not a variable
-    if (name === "activeNote") return token; // no active file resolved it above
+    if (name.toLowerCase() === "activenote") return token; // no active file resolved it above
     return name;
   });
 }

--- a/src/agentMode/session/translateCommandToAgentText.ts
+++ b/src/agentMode/session/translateCommandToAgentText.ts
@@ -1,0 +1,57 @@
+import { resolveActiveNoteToken } from "@/agentMode/session/resolveActiveNoteToken";
+import { ACTIVE_WEB_TAB_MARKER } from "@/constants";
+import type { TFile } from "obsidian";
+
+/**
+ * Agent-chat reference for a vault file. Mirrors `NotePillNode.getTextContent`
+ * and `resolveActiveNoteToken`: keep the extension only for pdf/canvas so the
+ * link resolves to the same path the note pills carry.
+ */
+function fileToWikilink(file: TFile): string {
+  const ext = file.extension?.toLowerCase();
+  const display = ext === "pdf" || ext === "canvas" ? `${file.basename}.${ext}` : file.basename;
+  return `[[${display}]]`;
+}
+
+// Any `{variable}` left after the selected-text and `{activeNote}` passes —
+// `{[[Note]]}`, `{#tag}`, `{folder/path}`. We strip the templating braces and
+// hand the bare reference to the agent rather than pre-expanding it: the agent
+// has the vault as its working directory and resolves a tag (grep) or folder
+// (glob/read) itself, so pre-expanding would just bloat the prompt.
+const VARIABLE_REGEX = /\{([^}]+)\}/g;
+
+/**
+ * Translate a custom-command body from custom-prompt template syntax into the
+ * syntax a user would type in the Agent chat: notes/tags/folders become bare
+ * `[[wikilink]]` / `#tag` / `path` references the agent resolves on its own, and
+ * the selected-text placeholder is inlined.
+ *
+ * This is the Agent-Mode counterpart to `processPrompt`. The crucial difference:
+ * it never inlines note content — Agent Mode references notes by path and lets
+ * the agent read them, so dumping `<variable name="activeNote">…</variable>` (as
+ * `processPrompt` does) both bloats the prompt and fights the reference model.
+ */
+export function translateCommandToAgentText(
+  body: string,
+  selectedText: string,
+  activeNote: TFile | null
+): string {
+  // Selected-text placeholders → the selection, else the active-note reference.
+  // split/join (not String.replace) avoids `$&`/`$1` interpretation in the value.
+  const selectionReplacement = selectedText || (activeNote ? fileToWikilink(activeNote) : "");
+  let text = body.split("{copilot-selection}").join(selectionReplacement);
+  text = text.split("{}").join(selectionReplacement);
+
+  // `{activeNote}` → `[[Active Title]]`.
+  text = resolveActiveNoteToken(text, activeNote);
+
+  // Strip the templating braces off the rest, handing the bare reference
+  // (`[[Note]]`, `#tag`, `folder/path`) to the agent to resolve itself.
+  return text.replace(VARIABLE_REGEX, (token, rawName: string) => {
+    if (token === ACTIVE_WEB_TAB_MARKER) return token; // live marker, resolved downstream
+    const name = rawName.trim();
+    if (name.startsWith('"')) return token; // JSON object literal, not a variable
+    if (name === "activeNote") return token; // no active file resolved it above
+    return name;
+  });
+}

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -240,7 +240,6 @@ export const AgentChatInput = memo(function AgentChatInput({
       const expanded = await expandCustomCommandPrefix(
         text,
         getCachedCustomCommands(),
-        app,
         noteSelection?.content ?? "",
         activeFile
       );


### PR DESCRIPTION
Agent Mode custom slash-commands previously ran through `processPrompt`, which inlined the full active-note body as `<variable name="activeNote">…</variable>` — so a one-line command shipped the entire note and fought Agent Mode's reference-by-path model. This replaces that call with a purpose-built `translateCommandToAgentText` that converts command template tokens into the syntax a user would type in chat: `{activeNote}`/`{[[Note]]}` become `[[wikilink]]` references, `{}`/`{copilot-selection}` inline the selection, and `{#tag}`/`{folder}` are handed to the agent bare so it resolves them via its own search/read tools over the vault. Notes are never inlined; the agent reads them. The translator also dropped its `app`/vault dependency, which let `expandCustomCommandPrefix` shed its now-unused `app` parameter (call site updated in `AgentChatInput`). Adds `translateCommandToAgentText.test.ts` and updates `expandCustomCommandPrefix.test.ts`; full unit suite, lint, and format pass.