### PR TITLE
fix(agent-mode): show the invoked skill name in the tool-call render

### DIFF
--- a/src/agentMode/ui/toolIcons.ts
+++ b/src/agentMode/ui/toolIcons.ts
@@ -8,6 +8,7 @@ import {
   ListChecks,
   Pencil,
   Search,
+  Sparkles,
   Terminal,
   Trash2,
   ArrowRightLeft,
@@ -41,6 +42,7 @@ const VENDOR_ICONS: Record<string, LucideIcon> = {
   Agent: Bot,
   TodoWrite: ListChecks,
   ExitPlanMode: ClipboardList,
+  Skill: Sparkles,
 };
 
 const KIND_ICONS: Record<string, LucideIcon> = {

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -210,6 +210,47 @@ describe("lookupToolSummary", () => {
     expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Asked a question");
   });
 
+  it("names the invoked skill from input.skill", () => {
+    const t = tool({
+      vendorToolName: "Skill",
+      title: "Skill",
+      status: "completed",
+      input: { skill: "copilot-read-pdf", args: "notes/foo.pdf — read chapter one" },
+    });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Ran skill copilot-read-pdf");
+  });
+
+  it("renders the skill in present tense while in flight", () => {
+    const t = tool({
+      vendorToolName: "Skill",
+      title: "Skill",
+      status: "in_progress",
+      input: { skill: "copilot-read-pdf" },
+    });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Running skill copilot-read-pdf");
+  });
+
+  it("falls back to a generic skill line before input has streamed in", () => {
+    const t = tool({ vendorToolName: "Skill", title: "Skill", status: "completed" });
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Ran a skill");
+  });
+
+  it("surfaces the skill args in the expanded card", () => {
+    const t = tool({
+      vendorToolName: "Skill",
+      title: "Skill",
+      status: "completed",
+      input: { skill: "copilot-read-pdf", args: "notes/foo.pdf — read chapter one" },
+    });
+    expect(lookupToolSummary(t).expandedDetails?.(t)).toBe("notes/foo.pdf — read chapter one");
+  });
+
+  it("aggregates consecutive skill calls", () => {
+    const s1 = tool({ vendorToolName: "Skill", status: "completed", input: { skill: "a" } });
+    const s2 = tool({ vendorToolName: "Skill", status: "completed", input: { skill: "b" } });
+    expect(lookupToolSummary(s1).aggregate([s1, s2]).line).toBe("Ran 2 skills");
+  });
+
   it("hides the duplicated vendor name while Read input is still streaming", () => {
     // SDK seeds title to the vendor name before any input-JSON has been
     // parsed. Should render "Reading …" rather than "Reading Read".

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -202,6 +202,19 @@ function targetFromPath(part: ToolCallPart, vaultBase: string | null): string | 
   return null;
 }
 
+/**
+ * The skill identifier from a `Skill` tool call's input (Claude Code logs the
+ * slash-command name as `input.skill`, e.g. "copilot-read-pdf"). Returns the
+ * trimmed name, or null while the input is still streaming in.
+ */
+function skillNameFromInput(part: ToolCallPart): string | null {
+  const input = part.input as { skill?: unknown } | null | undefined;
+  const skill = input?.skill;
+  if (typeof skill !== "string") return null;
+  const trimmed = skill.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 function queryFromInput(part: ToolCallPart): string | null {
   const input = part.input as
     | { query?: unknown; pattern?: unknown; q?: unknown }
@@ -427,6 +440,24 @@ const ASK_USER_QUESTION_SUMMARY: ToolSummary = {
   }),
 };
 
+const SKILL_SUMMARY: ToolSummary = {
+  icon: pickToolIcon({ vendorToolName: "Skill" }),
+  collapsedLine: (p) => {
+    const v = verb(p, "Running", "Ran");
+    const name = skillNameFromInput(p);
+    return name ? `${v} skill ${name}` : `${v} a skill`;
+  },
+  outcome: () => null,
+  aggregate: (parts) => ({
+    line: `Ran ${pluralize(parts.length, "skill")}${statusSuffix(parts)}`,
+    outcome: "",
+  }),
+  expandedDetails: (p) => {
+    const input = p.input as { args?: unknown } | null | undefined;
+    return typeof input?.args === "string" && input.args.length > 0 ? input.args : null;
+  },
+};
+
 const VENDOR_SUMMARIES: Record<string, ToolSummary> = {
   Read: READ_SUMMARY,
   Edit: EDIT_SUMMARY,
@@ -446,6 +477,7 @@ const VENDOR_SUMMARIES: Record<string, ToolSummary> = {
   ExitPlanMode: EXIT_PLAN_SUMMARY,
   AskUserQuestion: ASK_USER_QUESTION_SUMMARY,
   LS: LIST_SUMMARY,
+  Skill: SKILL_SUMMARY,
 };
 
 // ---- ACP-kind fallbacks (work for opencode, codex, future backends) ----


### PR DESCRIPTION
In Agent Mode, the Claude harness logs a skill invocation as a `tool_use` named `Skill` with the real skill in `input.skill`, but `toolSummaries` had no `Skill` entry, so the trail fell through to the generic label and rendered a bare "Skill" card with a Hammer icon — dropping which skill actually ran. This adds a dedicated `Skill` summary that reads `input.skill` (e.g. "Ran skill copilot-read-pdf", with `args` shown in the expanded card) plus a Sparkles icon, following the existing vendor-registry pattern, and covers it with unit tests for present/past tense, the pre-stream fallback, aggregation, and expanded args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)