### PR TITLE
fix(bedrock): omit temperature for Claude Opus 4.7+ when thinking is off

### DIFF
--- a/src/LLMProviders/BedrockChatModel.test.ts
+++ b/src/LLMProviders/BedrockChatModel.test.ts
@@ -523,6 +523,72 @@ describe("BedrockChatModel streaming decode", () => {
     });
   });
 
+  describe("temperature handling for Opus 4.7+", () => {
+    // Opus 4.7+ rejects any `temperature` with a 400
+    // ("`temperature` is deprecated for this model."), so it must be omitted
+    // when thinking is disabled. Other models keep receiving the user's value.
+    const userMessage = { role: "user", content: "test", getType: () => "human" };
+
+    it("omits temperature for opus-4-7 when thinking is disabled", () => {
+      const model = createModel(false, "anthropic.claude-opus-4-7-20260115-v1:0");
+      const requestBody = asInternal(model).buildRequestBody([userMessage], { temperature: 0.1 });
+
+      expect(requestBody.temperature).toBeUndefined();
+    });
+
+    it("omits temperature for opus-4-8 when thinking is disabled", () => {
+      const model = createModel(false, "anthropic.claude-opus-4-8");
+      const requestBody = asInternal(model).buildRequestBody([userMessage], { temperature: 0.1 });
+
+      expect(requestBody.temperature).toBeUndefined();
+    });
+
+    it("omits temperature for opus-4-7 cross-region inference profiles", () => {
+      const model = createModel(false, "us.anthropic.claude-opus-4-8");
+      const requestBody = asInternal(model).buildRequestBody([userMessage], { temperature: 0.7 });
+
+      expect(requestBody.temperature).toBeUndefined();
+    });
+
+    it("still sends temperature for opus-4-6 and earlier", () => {
+      const model = createModel(false, "anthropic.claude-opus-4-6-20250115-v1:0");
+      const requestBody = asInternal(model).buildRequestBody([userMessage], { temperature: 0.1 });
+
+      expect(requestBody.temperature).toBe(0.1);
+    });
+
+    it("still sends temperature for sonnet-4-5 and haiku", () => {
+      const sonnet = createModel(false, "anthropic.claude-sonnet-4-5-20250929-v1:0");
+      expect(
+        asInternal(sonnet).buildRequestBody([userMessage], { temperature: 0.3 }).temperature
+      ).toBe(0.3);
+
+      const haiku = createModel(false, "anthropic.claude-haiku-4-5-20251001-v1:0");
+      expect(
+        asInternal(haiku).buildRequestBody([userMessage], { temperature: 0.3 }).temperature
+      ).toBe(0.3);
+    });
+
+    it("still sends temperature for dated Opus 4.0 snapshot IDs", () => {
+      // anthropic.claude-opus-4-20250514-v1:0 is the dated snapshot of Opus 4.0,
+      // not 4.20250514, so it must not be treated as 4.7+.
+      const opus40 = createModel(false, "anthropic.claude-opus-4-20250514-v1:0");
+      const requestBody = asInternal(opus40).buildRequestBody([userMessage], { temperature: 0.1 });
+
+      expect(requestBody.temperature).toBe(0.1);
+    });
+
+    it("forces temperature to 1 for opus-4-8 when thinking is enabled", () => {
+      // Thinking mode still pins temperature to 1, which Opus 4.7+ accepts
+      // alongside adaptive thinking; only the thinking-disabled path omits it.
+      const model = createModel(true, "anthropic.claude-opus-4-8");
+      const requestBody = asInternal(model).buildRequestBody([userMessage], { temperature: 0.1 });
+
+      expect(requestBody.temperature).toBe(1);
+      expect(requestBody.thinking).toEqual({ type: "adaptive", display: "summarized" });
+    });
+  });
+
   describe("vision support", () => {
     describe("convertImageContent", () => {
       it("converts valid data URL to Claude image format", () => {

--- a/src/LLMProviders/BedrockChatModel.test.ts
+++ b/src/LLMProviders/BedrockChatModel.test.ts
@@ -544,7 +544,7 @@ describe("BedrockChatModel streaming decode", () => {
     });
 
     it("omits temperature for opus-4-7 cross-region inference profiles", () => {
-      const model = createModel(false, "us.anthropic.claude-opus-4-8");
+      const model = createModel(false, "global.anthropic.claude-opus-4-7-20260115-v1:0");
       const requestBody = asInternal(model).buildRequestBody([userMessage], { temperature: 0.7 });
 
       expect(requestBody.temperature).toBeUndefined();

--- a/src/LLMProviders/BedrockChatModel.ts
+++ b/src/LLMProviders/BedrockChatModel.ts
@@ -1312,6 +1312,26 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
     }
   }
 
+  /**
+   * Whether this model is Claude Opus 4.7 or newer.
+   *
+   * Opus 4.7+ changed behavior in two ways that the request body must respect:
+   * 1. extended thinking requires `{ type: "adaptive" }` instead of
+   *    `{ type: "enabled", budget_tokens }`, and
+   * 2. the `temperature` parameter is no longer supported — sending any
+   *    `temperature` (even the default) makes Bedrock reject the request with
+   *    `400 \`temperature\` is deprecated for this model.`
+   *
+   * Unanchored match because Bedrock IDs include provider/profile prefixes
+   * (e.g. "global.anthropic.claude-opus-4-7-20260115-v1:0"). The minor version
+   * is constrained to 1-2 digits followed by a delimiter so dated snapshot IDs
+   * like "claude-opus-4-20250514-v1:0" aren't misread as Opus 4.20250514.
+   */
+  private isOpus47OrNewer(): boolean {
+    const opusMinorMatch = this.modelName.match(/claude-opus-4-(\d{1,2})(?:[-.]|$)/);
+    return opusMinorMatch ? parseInt(opusMinorMatch[1], 10) >= 7 : false;
+  }
+
   private buildRequestBody(
     messages: BaseMessage[],
     options?: BedrockChatModelCallOptions
@@ -1474,12 +1494,8 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
     // Only enable if user has explicitly enabled REASONING capability for this model
     if (this.enableThinking) {
       // claude-opus-4-7+ rejects { type: "enabled", budget_tokens } with a 400 and requires
-      // { type: "adaptive" }. Unanchored match because Bedrock IDs include provider/profile
-      // prefixes (e.g. "global.anthropic.claude-opus-4-7-20260115-v1:0"). Constrain the minor
-      // to 1-2 digits followed by a delimiter so dated snapshot IDs like
-      // "claude-opus-4-20250514-v1:0" aren't misread as Opus 4.20250514.
-      const opusMinorMatch = this.modelName.match(/claude-opus-4-(\d{1,2})(?:[-.]|$)/);
-      const usesAdaptiveThinking = opusMinorMatch ? parseInt(opusMinorMatch[1], 10) >= 7 : false;
+      // { type: "adaptive" }.
+      const usesAdaptiveThinking = this.isOpus47OrNewer();
       // Opus 4.7+ defaults thinking.display to "omitted" so thinking summaries
       // never reach the UI; force "summarized" for the adaptive branch. Pre-4.7
       // models default to "summarized" server-side.
@@ -1490,11 +1506,11 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
       // https://docs.claude.com/en/docs/build-with-claude/extended-thinking#important-considerations-when-using-extended-thinking
       payload.temperature = 1;
       logInfo("[BedrockChatModel] Enabled thinking mode for Claude model with temperature=1");
-    } else {
-      // Only set temperature if thinking is NOT enabled
-      if (resolvedTemperature !== undefined) {
-        payload.temperature = resolvedTemperature;
-      }
+    } else if (resolvedTemperature !== undefined && !this.isOpus47OrNewer()) {
+      // Only set temperature when thinking is NOT enabled.
+      // Opus 4.7+ rejects any `temperature` with a 400
+      // ("`temperature` is deprecated for this model."), so omit it for those models.
+      payload.temperature = resolvedTemperature;
     }
 
     if (resolvedTopP !== undefined) {


### PR DESCRIPTION
## Thank you 🙏

Thanks so much for Copilot and the Amazon Bedrock provider — it's been great to use with Claude on AWS. This is a small fix for the latest Opus models.

Fixes #2600

## Problem

With the Bedrock provider, chatting with **Claude Opus 4.7 / 4.8** fails for every message when the model's `REASONING` capability is **off** (the default):

```
Amazon Bedrock streaming request failed with status 400:
{"message":"`temperature` is deprecated for this model."}
```

Opus 4.6 and earlier, Sonnet (4 / 4.5 / 4.6), and Haiku 4.5 are unaffected.

## Root cause

Opus 4.7+ no longer accepts the `temperature` parameter at all — Bedrock rejects any value, including the default. In `BedrockChatModel.buildRequestBody()`, the thinking-disabled branch always attached the resolved `temperature`:

```ts
} else {
  // Only set temperature if thinking is NOT enabled
  if (resolvedTemperature !== undefined) {
    payload.temperature = resolvedTemperature;
  }
}
```

The thinking-**enabled** path already special-cases Opus 4.7+ (adaptive thinking) and pins `temperature: 1`, which Opus 4.7+ accepts alongside adaptive thinking — so the model only worked when reasoning was turned on. With reasoning off, it always 400s.

## Change

- Extract the existing Opus 4.7+ detection (previously inline in the thinking branch) into a small `isOpus47OrNewer()` helper, and reuse it.
- In the thinking-disabled path, omit `temperature` for Opus 4.7+. **Every other model keeps its current behavior**, and the thinking-enabled path is untouched.

The diff is intentionally minimal — no behavior change for any model other than Opus 4.7+ with thinking off.

## Before / After (live Bedrock, Opus 4.8, reasoning off)

Same prompt (“What is the capital of France?”), same model (`us.anthropic.claude-opus-4-8`), reasoning off — built this branch and loaded it into Obsidian.

| Before (current `master`) | After (this PR) |
|---|---|
| ![before](https://raw.githubusercontent.com/kimnamu/obsidian-copilot/pr-2601-assets/assets/opus48-before.png) | ![after](https://raw.githubusercontent.com/kimnamu/obsidian-copilot/pr-2601-assets/assets/opus48-after.png) |
| ❌ `400 \`temperature\` is deprecated for this model.` | ✅ `The capital of France is Paris.` (no console errors) |

Behavior across the rest of the lineup is unchanged:

| Model | Before | After |
|---|---|---|
| **Opus 4.8 / 4.7** | ❌ 400 | ✅ replies normally |
| Sonnet 4.6 / Haiku 4.5 | ✅ works | ✅ works (unchanged) |
| Opus 4.6 and earlier | ✅ works | ✅ works (unchanged) |

I also confirmed the deprecation boundary directly against the Bedrock runtime API (only `temperature` differs between requests):

| Request to `us.anthropic.claude-opus-4-8` | Result |
|---|---|
| `temperature: 0.1` | ❌ `400 \`temperature\` is deprecated for this model.` |
| `temperature` omitted | ✅ `200` |
| `temperature: 1` + `thinking: adaptive` | ✅ `200` |

## Tests

Added a `temperature handling for Opus 4.7+` suite covering Opus 4.7/4.8 (bare + cross-region), Opus 4.6 and earlier, Sonnet/Haiku, the dated Opus 4.0 snapshot ID (`claude-opus-4-20250514`, which must **not** be treated as 4.7+), and the thinking-enabled case (still pins `temperature: 1`).

The new tests fail on `master` (they catch the bug) and pass with this fix:

**Before (fix reverted, new tests run against current `master` logic):**

```
✕ omits temperature for opus-4-7 when thinking is disabled
    expect(received).toBeUndefined()
    Received: 0.1
✕ omits temperature for opus-4-8 when thinking is disabled
    Received: 0.1
✕ omits temperature for opus-4-7 cross-region inference profiles
    Received: 0.7
✓ still sends temperature for opus-4-6 and earlier
✓ still sends temperature for sonnet-4-5 and haiku
✓ still sends temperature for dated Opus 4.0 snapshot IDs
Tests: 3 failed, 4 passed
```

**After (this PR):**

```
✓ omits temperature for opus-4-7 when thinking is disabled
✓ omits temperature for opus-4-8 when thinking is disabled
✓ omits temperature for opus-4-7 cross-region inference profiles
✓ still sends temperature for opus-4-6 and earlier
✓ still sends temperature for sonnet-4-5 and haiku
✓ still sends temperature for dated Opus 4.0 snapshot IDs
✓ forces temperature to 1 for opus-4-8 when thinking is enabled
Tests: 7 passed
```

- `npm test` → all suites pass (added 7 tests).
- `npm run format` / `npm run lint` → clean.
- `npm run build` → type-check + bundle succeed.

## Checklist

- [x] Code style consistent with the existing file (reuses the existing detection regex/comment style)
- [x] Tested changes (unit tests + manual chat against live Bedrock)
- [x] Linked to the issue (#2600)
- [x] Minimal, focused diff
