### PR TITLE
fix(agent-mode): coalesce streamed-token re-renders

### DIFF
--- a/src/agentMode/session/AgentMessageStore.test.ts
+++ b/src/agentMode/session/AgentMessageStore.test.ts
@@ -210,4 +210,99 @@ describe("AgentMessageStore", () => {
     store.truncateAfterMessageId(a);
     expect(store.getDisplayMessages()).toHaveLength(1);
   });
+
+  describe("getDisplayMessages memoization (streaming re-render coalescing)", () => {
+    it("returns the same array reference when nothing changed", () => {
+      const store = new AgentMessageStore();
+      store.addMessage(placeholder());
+      const first = store.getDisplayMessages();
+      const second = store.getDisplayMessages();
+      // An idle subscription tick (no mutation) must hand back the exact same
+      // array so the top-level `messages` memo bails out without diffing.
+      expect(second).toBe(first);
+    });
+
+    it("keeps stable identities for unchanged messages while one streams", () => {
+      const store = new AgentMessageStore();
+      const stable = store.addMessage({
+        message: "done",
+        sender: AI_SENDER,
+        timestamp: formatDateTime(new Date()),
+        isVisible: true,
+      });
+      const streaming = store.addMessage(placeholder());
+
+      const before = store.getDisplayMessages();
+      const stableBefore = before.find((m) => m.id === stable);
+      const streamingBefore = before.find((m) => m.id === streaming);
+
+      // Stream a token into only the second message.
+      store.appendAgentText(streaming, "Hello");
+
+      const after = store.getDisplayMessages();
+      const stableAfter = after.find((m) => m.id === stable);
+      const streamingAfter = after.find((m) => m.id === streaming);
+
+      // The array is rebuilt (something changed)...
+      expect(after).not.toBe(before);
+      // ...but the untouched message keeps its identity so its memoized React
+      // component skips re-rendering...
+      expect(stableAfter).toBe(stableBefore);
+      // ...while the streamed message gets a fresh object reflecting the new text.
+      expect(streamingAfter).not.toBe(streamingBefore);
+      expect(streamingAfter?.message).toBe("Hello");
+    });
+
+    it("re-adapts a message after every kind of in-place mutation", () => {
+      const store = new AgentMessageStore();
+      const id = store.addMessage(placeholder());
+
+      const v0 = store.getDisplayMessages()[0];
+      store.appendDisplayText(id, "x");
+      const v1 = store.getDisplayMessages()[0];
+      expect(v1).not.toBe(v0);
+
+      store.upsertAgentPart(id, { kind: "tool_call", id: "tc1", title: "t", status: "pending" });
+      const v2 = store.getDisplayMessages()[0];
+      expect(v2).not.toBe(v1);
+
+      store.markTurnComplete(id, "end_turn", 10);
+      const v3 = store.getDisplayMessages()[0];
+      expect(v3).not.toBe(v2);
+      expect(v3.turnStopReason).toBe("end_turn");
+    });
+
+    it("does not re-adapt when upsertAgentPart is a no-op", () => {
+      const store = new AgentMessageStore();
+      const id = store.addMessage(placeholder());
+      const part: AgentMessagePart = {
+        kind: "tool_call",
+        id: "tc1",
+        title: "Read README",
+        status: "pending",
+      };
+      store.upsertAgentPart(id, part);
+      const before = store.getDisplayMessages()[0];
+      // Re-applying an identical snapshot is a no-op, so the cached view must
+      // survive — no spurious identity churn for the React tree.
+      expect(store.upsertAgentPart(id, { ...part })).toBe(false);
+      const after = store.getDisplayMessages()[0];
+      expect(after).toBe(before);
+    });
+
+    it("drops cached views for deleted and truncated messages", () => {
+      const store = new AgentMessageStore();
+      const a = store.addMessage(placeholder());
+      const b = store.addMessage(placeholder());
+      store.getDisplayMessages();
+
+      store.deleteMessage(b);
+      expect(store.getDisplayMessages().map((m) => m.id)).toEqual([a]);
+
+      const c = store.addMessage(placeholder());
+      store.truncateAfterMessageId(a);
+      expect(store.getDisplayMessages().map((m) => m.id)).toEqual([a]);
+      expect(store.getMessage(c)).toBeUndefined();
+    });
+  });
 });

--- a/src/agentMode/session/AgentMessageStore.ts
+++ b/src/agentMode/session/AgentMessageStore.ts
@@ -26,6 +26,12 @@ interface StoredAgentMessage {
   content?: unknown[];
   turnStopReason?: StopReason;
   turnDurationMs?: number;
+  // Bumped on every in-place mutation of this message so `getDisplayMessages`
+  // can cache the adapted view and only re-adapt when the version moves. The
+  // streaming append paths mutate `parts`/`displayText` in place (same array
+  // and object references), so a structural diff would miss them — the
+  // version counter is the source of truth for "this message changed".
+  version: number;
 }
 
 const MAX_COMPARE_JSON_CHARS = 8_000;
@@ -171,9 +177,25 @@ function textFingerprint(text: string): string {
  */
 export class AgentMessageStore {
   private messages: StoredAgentMessage[] = [];
+  // Per-message memo of the adapted `AgentChatMessage` plus the `version` it
+  // was built from. `getDisplayMessages` reuses the cached object when the
+  // version is unchanged, so unchanged messages keep a stable identity across
+  // streaming ticks — letting the memoized React message components skip them
+  // instead of re-rendering the whole transcript once per streamed token.
+  private displayCache = new Map<string, { version: number; view: AgentChatMessage }>();
+  // Memo of the last `getDisplayMessages` array so an idle subscription tick
+  // (notification with no content change) returns the same reference and the
+  // top-level `messages` memo bails out entirely.
+  private lastDisplay: AgentChatMessage[] | null = null;
 
   private generateId(): string {
     return `msg-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`;
+  }
+
+  /** Bump a message's version so its cached adapted view is rebuilt. */
+  private touch(msg: StoredAgentMessage): void {
+    msg.version += 1;
+    this.lastDisplay = null;
   }
 
   /** Add a message; returns its assigned id. */
@@ -192,7 +214,9 @@ export class AgentMessageStore {
       parts: message.parts,
       turnStopReason: message.turnStopReason,
       turnDurationMs: message.turnDurationMs,
+      version: 0,
     });
+    this.lastDisplay = null;
     return id;
   }
 
@@ -207,6 +231,7 @@ export class AgentMessageStore {
     if (msg.turnStopReason !== undefined) return false;
     msg.turnStopReason = stopReason;
     msg.turnDurationMs = durationMs;
+    this.touch(msg);
     return true;
   }
 
@@ -219,6 +244,7 @@ export class AgentMessageStore {
     const msg = this.messages.find((m) => m.id === id);
     if (!msg) return false;
     msg.displayText += chunk;
+    this.touch(msg);
     return true;
   }
 
@@ -241,6 +267,7 @@ export class AgentMessageStore {
     } else {
       msg.parts.push({ kind: "text", text });
     }
+    this.touch(msg);
     return true;
   }
 
@@ -259,6 +286,7 @@ export class AgentMessageStore {
     } else {
       msg.parts.push({ kind: "thought", text });
     }
+    this.touch(msg);
     return true;
   }
 
@@ -278,10 +306,12 @@ export class AgentMessageStore {
       if (idx !== -1) {
         if (partsEqual(msg.parts[idx], part)) return false;
         msg.parts[idx] = part;
+        this.touch(msg);
         return true;
       }
     }
     msg.parts.push(part);
+    this.touch(msg);
     return true;
   }
 
@@ -296,6 +326,7 @@ export class AgentMessageStore {
     msg.isErrorMessage = true;
     const suffix = msg.displayText.length > 0 ? "\n\n" : "";
     msg.displayText += `${suffix}**Error:** ${errorText}`;
+    this.touch(msg);
     return true;
   }
 
@@ -320,28 +351,61 @@ export class AgentMessageStore {
     const idx = this.messages.findIndex((m) => m.id === id);
     if (idx === -1) return false;
     this.messages.splice(idx, 1);
+    this.displayCache.delete(id);
+    this.lastDisplay = null;
     return true;
   }
 
   clear(): void {
     this.messages = [];
+    this.displayCache.clear();
+    this.lastDisplay = null;
   }
 
   truncateAfterMessageId(messageId: string): void {
     const idx = this.messages.findIndex((m) => m.id === messageId);
     if (idx !== -1) {
+      for (const dropped of this.messages.slice(idx + 1)) {
+        this.displayCache.delete(dropped.id);
+      }
       this.messages = this.messages.slice(0, idx + 1);
+      this.lastDisplay = null;
     }
   }
 
-  /** Visible messages, shaped for the UI. */
+  /**
+   * Visible messages, shaped for the UI. Memoized two ways so a fast token
+   * stream doesn't rebuild the whole transcript per notification:
+   *   - Each adapted message is cached by `version`, so an unchanged message
+   *     keeps the SAME object reference across ticks. Downstream React message
+   *     components are memoized on that reference and skip re-rendering.
+   *   - The returned array is itself cached (`lastDisplay`) and only rebuilt
+   *     when a mutation cleared it, so an idle notification returns the exact
+   *     same array and the top-level consumer bails out without diffing.
+   */
   getDisplayMessages(): AgentChatMessage[] {
-    return this.messages.filter((m) => m.isVisible).map((m) => this.toAgentChatMessage(m));
+    if (this.lastDisplay !== null) return this.lastDisplay;
+    const display = this.messages.filter((m) => m.isVisible).map((m) => this.adaptCached(m));
+    this.lastDisplay = display;
+    return display;
   }
 
   getMessage(id: string): AgentChatMessage | undefined {
     const msg = this.messages.find((m) => m.id === id);
-    return msg ? this.toAgentChatMessage(msg) : undefined;
+    return msg ? this.adaptCached(msg) : undefined;
+  }
+
+  /**
+   * Return the adapted view for a stored message, reusing the cached object
+   * when its `version` is unchanged so the identity stays stable across
+   * streaming ticks.
+   */
+  private adaptCached(m: StoredAgentMessage): AgentChatMessage {
+    const cached = this.displayCache.get(m.id);
+    if (cached && cached.version === m.version) return cached.view;
+    const view = this.toAgentChatMessage(m);
+    this.displayCache.set(m.id, { version: m.version, view });
+    return view;
   }
 
   loadMessages(messages: AgentChatMessage[]): void {
@@ -359,6 +423,7 @@ export class AgentMessageStore {
         parts: msg.parts,
         turnStopReason: msg.turnStopReason,
         turnDurationMs: msg.turnDurationMs,
+        version: 0,
       });
     }
     logInfo(`[AgentMessageStore] Loaded ${messages.length} messages`);

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2340,3 +2340,127 @@ describe("tryReadExitPlanModeCall", () => {
     expect(tryReadExitPlanModeCall({ kind: "switch_mode", rawInput: undefined })).toBeNull();
   });
 });
+
+describe("AgentSession streamed-token notification coalescing", () => {
+  // Controllable rAF: streaming notifications are rAF-batched, so we drive the
+  // frame boundary manually to assert how many `onMessagesChanged` fires the
+  // UI actually sees. Without this they'd coalesce on jsdom's timer and the
+  // assertions would be timing-dependent.
+  let rafQueue: FrameRequestCallback[];
+  let originalRaf: typeof window.requestAnimationFrame;
+  let originalCancelRaf: typeof window.cancelAnimationFrame;
+
+  const flushFrame = () => {
+    const pending = rafQueue;
+    rafQueue = [];
+    for (const cb of pending) cb(performance.now());
+  };
+
+  beforeEach(() => {
+    rafQueue = [];
+    originalRaf = window.requestAnimationFrame;
+    originalCancelRaf = window.cancelAnimationFrame;
+    window.requestAnimationFrame = (cb: FrameRequestCallback): number => {
+      rafQueue.push(cb);
+      return rafQueue.length; // 1-based handle
+    };
+    window.cancelAnimationFrame = (handle: number): void => {
+      const idx = handle - 1;
+      if (idx >= 0 && idx < rafQueue.length) rafQueue.splice(idx, 1);
+    };
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRaf;
+    window.cancelAnimationFrame = originalCancelRaf;
+  });
+
+  const streamChunk = (mock: MockBackend, text: string) =>
+    mock.emit({
+      sessionId: "acp-1",
+      update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text } },
+    });
+
+  it("collapses a burst of streamed chunks into one notification per frame", async () => {
+    const mock = makeMockBackend();
+    let resolvePrompt: ((v: { stopReason: "end_turn" }) => void) | null = null;
+    mock.prompt.mockImplementation(
+      () => new Promise((resolve) => (resolvePrompt = resolve as typeof resolvePrompt))
+    );
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+
+    const onMessagesChanged = jest.fn();
+    session.subscribe({ onMessagesChanged, onStatusChanged: () => {} });
+
+    const { turn } = session.sendPrompt("hi");
+    // The synchronous user-message + placeholder append notifies immediately so
+    // the user's message paints within one frame — NOT rAF-deferred.
+    expect(onMessagesChanged).toHaveBeenCalledTimes(1);
+
+    // A fast token burst within one frame schedules a single rAF.
+    onMessagesChanged.mockClear();
+    streamChunk(mock, "Hel");
+    streamChunk(mock, "lo");
+    streamChunk(mock, ", world");
+    // No notification yet — they were coalesced behind the frame.
+    expect(onMessagesChanged).not.toHaveBeenCalled();
+    // Store is updated synchronously regardless of the deferred notification.
+    expect(session.store.getDisplayMessages().find((m) => m.sender === AI_SENDER)?.message).toBe(
+      "Hello, world"
+    );
+
+    flushFrame();
+    // The whole burst collapsed into exactly one re-render.
+    expect(onMessagesChanged).toHaveBeenCalledTimes(1);
+
+    resolvePrompt!({ stopReason: "end_turn" });
+    await turn;
+    flushFrame();
+  });
+
+  it("always delivers the trailing turn-complete notification (no dropped final state)", async () => {
+    const mock = makeMockBackend();
+    let resolvePrompt: ((v: { stopReason: "end_turn" }) => void) | null = null;
+    mock.prompt.mockImplementation(
+      () => new Promise((resolve) => (resolvePrompt = resolve as typeof resolvePrompt))
+    );
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+
+    const onMessagesChanged = jest.fn();
+    session.subscribe({ onMessagesChanged, onStatusChanged: () => {} });
+
+    const { turn } = session.sendPrompt("hi");
+    onMessagesChanged.mockClear();
+
+    // A chunk arrives and schedules a rAF that has NOT fired yet.
+    streamChunk(mock, "partial");
+    expect(rafQueue).toHaveLength(1);
+    expect(onMessagesChanged).not.toHaveBeenCalled();
+
+    // The turn completes before the scheduled frame runs. The turn-complete
+    // notification must fire immediately (trailing edge) and cancel the stale
+    // pending rAF so the message settles to its complete final state — even if
+    // the browser never grants another animation frame.
+    resolvePrompt!({ stopReason: "end_turn" });
+    await turn;
+
+    expect(onMessagesChanged).toHaveBeenCalled();
+    // The pending streaming frame was cancelled by the immediate flush, so a
+    // later frame can't fire a duplicate/stale notification.
+    expect(rafQueue).toHaveLength(0);
+
+    const placeholder = session.store.getDisplayMessages().find((m) => m.sender === AI_SENDER);
+    expect(placeholder?.message).toBe("partial");
+    expect(placeholder?.turnStopReason).toBe("end_turn");
+  });
+});


### PR DESCRIPTION
## Summary

Agent Mode rebuilt the **entire** chat transcript on every streamed-token notification. `AgentMessageStore.getDisplayMessages()` mapped over and re-adapted every visible message into fresh objects on each call, so the memoized `AgentChatMessages` component (and every `AgentTrail` under it) re-rendered once per token. On a fast token stream this drove one full main-thread re-render per token, producing the reported lag between hitting Enter and the user message appearing, plus stuttering of the `CopilotSpinner` sigma dots.

Streamed-token notifications were *already* rAF-coalesced at the `AgentSession` boundary (`scheduleNotifyMessages`), with discrete events (send, turn-complete, error, permission prompts) flushing immediately via `notifyMessages()`. The remaining cost was the per-notification rebuild inside the store. This PR **memoizes `getDisplayMessages()`** so message identity is stable:

- Each stored message carries a `version`, bumped on every in-place mutation. The adapted `AgentChatMessage` is cached by `version`, so an unchanged message keeps the **same object reference** across ticks and its memoized React component skips re-rendering. (The streaming append paths mutate `parts`/`displayText` in place, so a structural diff would miss them — the version counter is the source of truth.)
- The returned array is itself cached and only rebuilt after a mutation, so an idle notification returns the exact same reference and the top-level `messages` memo bails out without diffing.

This is the "memoize `getDisplayMessages()` so unchanged messages reuse adapted objects" approach from the issue. No double-buffering; existing referential-stability contracts (`useAgentInputDrafts`) are untouched.

### Streaming correctness preserved
- The store still mutates **synchronously**, so no tokens are dropped — only the React-facing notification is coalesced.
- The trailing **turn-complete** notification still flushes immediately: `notifyMessages()` cancels any pending streaming rAF, so the message always settles to its complete final state even if the browser never grants another animation frame.
- User's message appears within one frame: `sendPrompt` notifies synchronously (not rAF-deferred).

## How verified
- `npm run format` — clean
- `npm run lint` — clean
- `npm test` — **3686 passed, 244 suites**

New tests:
- `AgentMessageStore.test.ts`: stable identity for unchanged messages while one streams; re-adaptation after each mutation kind; no-op `upsertAgentPart` preserves identity; cache eviction on delete/truncate; idle call returns same array reference.
- `AgentSession.test.ts`: a burst of streamed chunks collapses to one `onMessagesChanged` per frame; **the trailing turn-complete notification is always delivered and cancels the stale pending frame** (no dropped final state).

## Files changed
- `src/agentMode/session/AgentMessageStore.ts`
- `src/agentMode/session/AgentMessageStore.test.ts`
- `src/agentMode/session/AgentSession.test.ts`

Closes logancyang/obsidian-copilot-preview#154

🤖 Generated with [Claude Code](https://claude.com/claude-code)