### PR TITLE
feat(agent-projects): project-scoped Agent Mode — Agent Home PR2

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -53,9 +53,15 @@ module.exports = {
       this.write = jest.fn();
       this.exists = jest.fn().mockResolvedValue(true);
       this.mkdir = jest.fn().mockResolvedValue(undefined);
+      this.list = jest.fn().mockResolvedValue({ files: [], folders: [] });
+      this.remove = jest.fn().mockResolvedValue(undefined);
     }
     getBasePath() {
       return this._basePath;
+    }
+    getFullPath(p) {
+      const rel = String(p).replace(/\\/g, "/").replace(/^\/+/, "");
+      return rel ? `${this._basePath}/${rel}` : this._basePath;
     }
   },
   normalizePath: (p) => String(p).replace(/\\\\/g, "/").replace(/\/+/g, "/"),
@@ -68,6 +74,16 @@ module.exports = {
       this.close = jest.fn();
       this.onOpen = jest.fn();
       this.onClose = jest.fn();
+    }
+  },
+  // Base class for FolderSearchModal & friends; subclasses only need it to be
+  // constructable so suites that pull them into the module graph can load.
+  FuzzySuggestModal: class FuzzySuggestModal {
+    constructor(app) {
+      this.app = app;
+      this.open = jest.fn();
+      this.close = jest.fn();
+      this.setPlaceholder = jest.fn();
     }
   },
   App: jest.fn().mockImplementation(() => ({

--- a/__mocks__/react-resizable-panels.js
+++ b/__mocks__/react-resizable-panels.js
@@ -1,0 +1,15 @@
+// react-resizable-panels ships ESM-only (no CJS dist entry), which Jest can't
+// parse. Tests never exercise the resize behavior — they only pull the package
+// in transitively via UI modals — so stub the three primitives `resizable.tsx`
+// consumes with passthrough components that render their children.
+import React from "react";
+
+const passthrough = (displayName) => {
+  const Component = ({ children, ...props }) => React.createElement("div", props, children);
+  Component.displayName = displayName;
+  return Component;
+};
+
+export const PanelGroup = passthrough("PanelGroup");
+export const Panel = passthrough("Panel");
+export const PanelResizeHandle = passthrough("PanelResizeHandle");

--- a/designdocs/AGENT_HOME_ARCHITECTURE.md
+++ b/designdocs/AGENT_HOME_ARCHITECTURE.md
@@ -384,9 +384,6 @@ the awaited spawn means the user has moved on).
   from under the user), the composer blocks both keyboard sends and the
   queued-message flush, not just pointer events, so a turn can't drain into a dead
   project.
-- **Attachment envelope rename** — the per-message attachment envelope is
-  `<attached_context>` (renamed from `<copilot-context>`) to disambiguate it from
-  the project-wide `<project_context>` block.
 - **Unified todo / plan** — backend todo lists across claude / codex / opencode
   are normalized into one plan model feeding the project info popover, with
   per-session todo-id tracking and symmetric plan-clear on empty.

--- a/designdocs/AGENT_HOME_ARCHITECTURE.md
+++ b/designdocs/AGENT_HOME_ARCHITECTURE.md
@@ -1,93 +1,43 @@
-# Agent Home Architecture (PR1)
+# Agent Home & Project Workspace Architecture
 
-How the Agent Mode chat surface is structured after the "Agent Home" PR1
-(frontend-only) refactor. PR1 dismantled the monolithic `AgentChat` into a
-persistent shell plus focused leaf components, added a centered landing homepage
-for empty sessions, and introduced a landing with a **read-only Projects list**
-and a **fully manageable Recent Chats list** (the latter reuses the existing
-`ChatHistoryPopover`, so it gains search / rename / delete / open-source with no
-new backend). No backend, persistence, or project-scope behavior changed in PR1.
+How the Agent Mode chat surface is structured, from the "Agent Home" landing
+shell through project-scoped workspaces. The work landed in two increments on a
+single axis — **does it touch the backend?**
 
-## Scope: PR1 vs PR2
+- **PR1 (frontend-only)** dismantled the monolithic `AgentChat` into a persistent
+  shell plus focused leaf components, added a centered landing homepage for empty
+  sessions, and introduced a landing with a read-only Projects list and a fully
+  manageable Recent Chats list. No backend, persistence, or project-scope
+  behavior changed.
+- **PR2 (project workspaces + backend)** turned Agent Mode "projects" into Claude
+  Projects-style workspaces: entering a project gives a scoped workspace with its
+  own sessions, chat history, and materialized context, while the global
+  workspace becomes one special scope sharing the same code path.
 
-The full Agent Home vision (project workspaces, per-project sessions, context
-indexing) is large and almost all the risk lives in the backend. So the work is
-split on a single axis — **does it touch the backend?** PR1 is the pure-frontend
-slice; PR2 is the project workspace plus all backend work.
+This doc describes the **current** architecture (PR1 + PR2). Two follow-on areas —
+a built-in Obsidian MCP tool surface, and Outputs / Discover-URLs — are **PR3**
+and are not covered here.
 
-| Capability                                                     | PR1                                              | PR2+                                                |
-| -------------------------------------------------------------- | ------------------------------------------------ | --------------------------------------------------- |
-| AgentHome layout shell                                         | ✅ build (no-project state only)                 | + project state                                     |
-| No-project landing (centered composer → pin to bottom)         | ✅                                               | —                                                   |
-| Landing title + backend·mode subtitle                          | ✅                                               | —                                                   |
-| Multi-session tabs (`AgentTabStrip`)                           | ✅ reuse, untouched                              | project-scoped                                      |
-| Recent Chats section (global `getChatHistoryItems`)            | ✅ inline 3 + full `ChatHistoryPopover` View-all | per-project filter                                  |
-| Dismantle AgentChat → transcript / input + hooks               | ✅                                               | —                                                   |
-| Per-session drafts (replacing `key` remount)                   | ✅ queue survives switch, foreground flush       | background queue auto-flush (sink to session layer) |
-| Projects section (read-only list + read-only sort)             | ✅ inline 3 + `+` → coming-soon                  | —                                                   |
-| Read-only Project Picker (View-all + search + lazy paging)     | ✅                                               | —                                                   |
-| Shared section primitives (`AgentHomeSection`/`Row`/`ViewAll`) | ✅ new                                           | project reuse                                       |
-| Optimizations ported from existing components                  | ✅ (see below)                                   | —                                                   |
-| Project click                                                  | ✅ **coming-soon `Notice` only**                 | real project entry                                  |
-| Project workspace (header + per-project sessions + Context)    | ❌                                               | ✅                                                  |
-| Sort-strategy switcher (writes `settings`)                     | ❌                                               | ✅                                                  |
-| Create / rename / delete / duplicate / archive + `⋯` menu      | ❌                                               | ✅                                                  |
-| Chat rename / delete / open-source (chat View-all popover)     | ✅ reuse `ChatHistoryPopover`                    | + project-scoped history                            |
-| Chat time-group headers (Today / Yesterday / 1w ago)           | ✅ (via `ChatHistoryPopover`)                    | —                                                   |
-| Mobile always-visible row actions (chat View-all)              | ✅ (via `ChatHistoryPopover`)                    | + project rows                                      |
-| Drag-to-add context                                            | ❌                                               | ✅                                                  |
-| Welcome onboarding card                                        | ❌                                               | ✅                                                  |
-| `setCurrentProject` / `projectId` on sessions / usage touch    | ❌                                               | ✅                                                  |
-| Project scope envelope / `scopeStatus` gate                    | ❌                                               | ✅                                                  |
-| Switch project = switch history                                | ❌                                               | ✅                                                  |
-| Indexing card / permission above composer                      | ❌                                               | ✅                                                  |
-| Outputs generation / Discover URLs                             | ❌                                               | PR2+ / later                                        |
+## Increments at a glance
 
-**Why project click is coming-soon in PR1, not a real entry:** a project's full
-form is "project header + its own per-project sessions", which requires
-`AgentSessionManager` to know each session's `projectId` — backend-only, hence
-PR2. If PR1 forced a project page it would be a chimera: global multi-session
-tabs on top, one project in the middle. So PR1 stops at the read-only list.
+| Capability                                                | PR1                                        | PR2                                     |
+| --------------------------------------------------------- | ------------------------------------------ | --------------------------------------- |
+| AgentHome layout shell, persistent (no `key` remount)     | ✅ build (no-project state)                | + project state                         |
+| No-project landing (centered composer → pin to bottom)    | ✅                                         | —                                       |
+| Multi-session tabs (`AgentTabStrip`)                      | ✅ reuse, global                           | project-scoped                          |
+| Recent Chats section                                      | ✅ inline 3 + `ChatHistoryPopover`         | per-scope                               |
+| Per-session compose drafts                                | ✅ queue survives switch, foreground flush | session-layer auto-flush still deferred |
+| Projects section                                          | ✅ read-only list + picker                 | real entry + CRUD                       |
+| Enter a project (header + per-project sessions + Context) | ❌ coming-soon `Notice`                    | ✅                                      |
+| `projectId` on sessions, scoped history, scope cwd        | ❌                                         | ✅                                      |
+| Project context materialization (URL/YouTube/PDF)         | ❌                                         | ✅ off-vault shared cache               |
+| Project instructions (`project.md` + `AGENTS.md` mirror)  | ❌                                         | ✅                                      |
+| Drag-to-add context, Welcome onboarding card              | ❌                                         | ✅                                      |
+| Built-in MCP tool surface, Outputs / Discover URLs        | ❌                                         | PR3                                     |
 
-## Why dismantle AgentChat (approach A), not parallel-isolation (B)
+---
 
-The design handoff laid out two ways to land the same UI:
-
-- **A — direct refactor:** dismantle the monolithic `AgentChat` into the shell +
-  leaf components + hooks described below (what PR1 did).
-- **B — parallel isolation:** build `AgentHome` alongside an untouched
-  `AgentChat`, switch between them with a feature flag, and delete the old path
-  in a later cleanup PR.
-
-The handoff **recommended B** for the dense-iteration period, on the grounds
-that A's defining cost is _high conflict — textual merge conflicts plus silent
-semantic conflicts_ — whenever someone keeps changing `AgentChat` in parallel.
-
-The executed direction was: ship Agent Home as a standalone, frontend-only PR
-(home + chat history first, project workspace on top later), accepting that it
-**touches** `AgentChat`. That was implemented as **A** (dismantle), not B. The
-"why A over B" was never written down at decision time; this note records it
-retroactively so the tradeoff is visible.
-
-**A's predicted cost materialized — and is by design.** While PR1 was in flight
-the base gained `#2530` (inline ask-user questions), `#2531` (copy/insert
-message actions, which removed message-delete), and `#2533` (no-global-app:
-`app.vault`→`app`) — all of which modified the now-deleted `AgentChat`. Rebasing
-PR1 onto that base surfaced **one** textual conflict (the modify/delete on
-`AgentChat.tsx`, resolved by `git rm`) but required **manually porting** those
-three deltas into the split files (runtime hook / composer) — git does **not**
-flag those, because the new files don't textually overlap the deleted one.
-
-**Standing consequence:** with `AgentChat` gone there is no single merge point.
-Any future base change to message-stream or composer behavior must be
-re-threaded into the split files by hand. That is the inherent, accepted cost of
-choosing A; B would have deferred it to the cleanup PR instead. The split is
-otherwise behavior-equivalent to the old monolith (see "Migration invariants").
-A later rebase onto a base carrying `#2537` / `#2540` / the new-logo commit
-needed **zero** re-thread — those land entirely in layers orthogonal to `ui/`
-(backends / skills / plugin wiring, no `ui/` edits), so it was textually clean
-with `tsc` and the agentMode test suite green. The re-thread tax only comes due
-when a base change actually touches message-stream or composer behavior.
+# Part I — Agent Home shell (PR1, frontend)
 
 ## Component tree
 
@@ -96,289 +46,358 @@ CopilotAgentView
 └── AgentModeChat                preload gate · auto-spawn · no-session fallback
     └── AgentHome                persistent shell for the active session
         └── ChatInputProvider
-            ├── AgentTabStrip            multi-session tabs (unchanged)
+            ├── AgentTabStrip            multi-session tabs
             ├── AgentModeStatus          install / boot status pill
             ├── (landing header)*        landing title + backend·mode subtitle
             │       ⟷ AgentChatMessages      (conversation state — reused base leaf)
             ├── AgentChatInput           composer: controlled by a `draft` prop; send/queue/stop
-            ├── AgentChatControls        new chat / save / history (conversation state)
-            └── (landing sections)*      ProjectPickerList · GlobalRecentChatsSection
+            ├── AgentChatControls        new chat / save / history
+            └── (landing sections)*      project/recent-chat shelves
 ```
 
-`*` The landing header and landing sections are inlined in `AgentHome` rather
-than a standalone `AgentLandingPane` file — they are static layout, and a
-separate component would only add indirection. The shared section building
-blocks live in `AgentHomeSection.tsx` (see "Shared section primitives").
+`*` The landing header and sections are inlined in `AgentHome` (static layout; a
+separate component would only add indirection). The shared section building
+blocks live in `AgentHomeSection.tsx`.
 
-In the conversation state `AgentHome` renders the reused `AgentChatMessages`
-leaf **directly** — there is no thin transcript wrapper. An earlier
-`AgentChatTranscript` pass-through was removed because it owned nothing (1:1
-prop forward) and its `memo` was redundant: the real per-token boundary is
-`AgentChatMessages`'s own `memo` plus the memoized `AgentChatInput`. Message
-content, the scroll container, the empty state, and the plan/tool/ask-user tail
-cards all stay in `AgentChatMessages` (base, reused, also rendered by the
-non-agent chat) — pulling them up into an Agent-only layer would fork a
-base-maintained component and re-create merge conflicts. If PR2 needs
-Agent-specific transcript chrome that should _not_ live in the shared base
-(timeline grouping, "load older", etc.), reintroduce a transcript layer then —
-with real responsibilities, not as an empty seam.
+In the conversation state `AgentHome` renders the reused `AgentChatMessages` leaf
+**directly** — no thin transcript wrapper. An earlier `AgentChatTranscript`
+pass-through was removed because it owned nothing (1:1 prop forward) and its
+`memo` was redundant: the real per-token boundary is `AgentChatMessages`'s own
+`memo` plus the memoized `AgentChatInput`. Message content, the scroll container,
+the empty state, and the plan/tool/ask-user tail cards stay in
+`AgentChatMessages` (base, reused, also rendered by the non-agent chat) — pulling
+them into an Agent-only layer would fork a base-maintained component and
+re-create merge conflicts.
 
 ### Why `AgentHome` is persistent (no `key` remount)
 
 Previously `AgentModeChat` rendered `<AgentChat key={session.internalId} />`, so
-switching tabs remounted the whole surface and discarded any unsent input. PR1
-removes that key: `AgentHome` persists and the tab strip swaps the `sessionId` /
-`backend` props instead. Per-session input state lives in a draft store owned by
-`AgentHome` (below) and passed down to the composer, so switching tabs swaps the
-active draft rather than throwing it away.
+switching tabs remounted the whole surface and discarded unsent input. The shell
+is now persistent: the tab strip swaps the `sessionId` / `backend` props instead.
+Per-session input state lives in a draft store owned by `AgentHome` and passed to
+the composer, so switching tabs swaps the active draft rather than throwing it
+away.
 
 ## State ownership
 
-| State                                                         | Owner                                                                                | Notes                                                                                                                                                                                                                         |
-| ------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `messages`, `isStarting`, plan/permission, ask-user-questions | `useAgentChatRuntimeState(backend)`                                                  | Single backend subscription; one `sync()` keeps all fields consistent (incl. `pendingAskUserQuestions`). `messages` flow only to `AgentChatMessages`, which (with the memoized composer) is the per-token re-render boundary. |
-| chat history items + handlers                                 | `useAgentHistoryControls(manager, plugin)`                                           | load / open / rename / delete / open-source.                                                                                                                                                                                  |
-| per-session compose drafts                                    | `useAgentInputDrafts({ activeSessionId, liveSessionIds, defaultIncludeActiveNote })` | input / images / contextNotes / include-flags / `loading` / `queue`, keyed by session id. **Owned by `AgentHome`**, which passes the (referentially stable) controls object down to `AgentChatInput` as a `draft` prop.       |
-| active turn `loading`, drag overlay                           | `AgentHome` (owns `useAgentInputDrafts` + `useChatFileDrop` directly)                | Reads `draft.loading` (transcript spinner) and `isDragActive` (whole-area overlay) straight from the hooks it owns — **not** mirrored up from the composer via effect callbacks.                                              |
+| State                                                         | Owner                                      | Notes                                                                                                                                                                              |
+| ------------------------------------------------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `messages`, `isStarting`, plan/permission, ask-user-questions | `useAgentChatRuntimeState(backend)`        | Single backend subscription; one `sync()` keeps all fields consistent. `messages` flow only to `AgentChatMessages`, the per-token re-render boundary.                              |
+| chat history items + handlers                                 | `useAgentHistoryControls(manager, plugin)` | load / open / rename / delete / open-source.                                                                                                                                       |
+| per-session compose drafts                                    | `useAgentInputDrafts(...)`                 | input / images / contextNotes / include-flags / `loading` / `queue`, keyed by session id. Owned by `AgentHome`, passed to `AgentChatInput` as a referentially-stable `draft` prop. |
+| active turn `loading`, drag overlay                           | `AgentHome`                                | Reads `draft.loading` and `isDragActive` straight from the hooks it owns — not mirrored up from the composer via effect callbacks.                                                 |
 
 ### Migration invariants (must survive dismantling AgentChat)
 
-Splitting the monolithic `AgentChat` into shell + leaves must NOT drop these
-behaviors; each was load-bearing in the original and is easy to lose in a
-refactor:
+Splitting the monolith into shell + leaves must NOT drop these load-bearing
+behaviors:
 
-- **Plan/permission gating** — while a plan permission is pending the composer
-  is inert: `hasPendingPlanPermission` wraps `AgentChatInput`'s output in
-  `pointer-events-none` (+ dimmed), and the permission card still resolves.
-- **`onSaveChat` registration** — the global autosave path
-  (`CopilotAgentView.saveChat` → `manager.saveActiveSession()`) must always be
+- **Plan/permission gating** — while a plan permission is pending the composer is
+  inert (`pointer-events-none` + dimmed) and the permission card still resolves.
+- **`onSaveChat` registration** — the global autosave path must always be
   registered against the **current active session**, never a stale one.
-- **Whole-area file drop** — `AgentHome` runs `useChatFileDrop` bound to the
-  chat container (`chatContainerRef`), not just the composer, so files dropped
-  anywhere in the chat area attach to the active draft (the drop hook writes the
-  draft's `contextNotes`/`images` that `AgentHome` owns), and `isDragActive`
-  drives the whole-area overlay.
+- **Whole-area file drop** — `useChatFileDrop` is bound to the chat container, so
+  files dropped anywhere in the chat area attach to the active draft, and
+  `isDragActive` drives the whole-area overlay.
 
-### Two-state derivation
+### Two-state derivation & composer placement
 
-`AgentModeChat` owns the no-session fallback (binary missing / booting / boot
-error). Within an active session, `AgentHome` derives `isGlobalLanding`
-(exposed as `data-agent-landing="global" | "conversation"`):
+Within an active session, `AgentHome` derives `isGlobalLanding` (exposed as
+`data-agent-landing`):
 
-- **global landing** — active session has no user-visible messages
-  (`!session.hasUserVisibleMessages()`): centered title + composer + landing
-  sections. "Global" distinguishes this no-project landing from the per-project
-  landing PR2 adds (`data-agent-landing="project"`).
-- **conversation** — the session has messages: transcript fills, composer
-  pinned bottom.
+- **global landing** — active session has no user-visible messages: centered
+  title + composer + landing sections.
+- **conversation** — the session has messages: transcript fills, composer pinned
+  to bottom.
 
-Because the runtime subscription re-renders `AgentHome` as the stream updates,
-this re-derives the instant the first user message lands.
-
-### Composer placement (center ⟷ bottom)
-
-`AgentChatInput` is a **position-stable node at a fixed sibling index**. The
-slots around it toggle (`landing header | transcript`, `null | controls`,
-composer, `landing sections | null`); on the landing the column scrolls as one
-unit (`overflow-y-auto` + a shared `tw-px-2`) with flex spacers above/below the
-composer keeping it centered (biased lower), while in conversation the
-transcript (`flex-1`) pushes the composer to the bottom. The composer never
-remounts across the flip, so the draft and focus survive. (The flip is currently
-instant; a smooth transition is a future polish.)
+The composer (`composerNode`) is the same element in both branches, but it sits
+at a different tree position in each, so it **remounts** on the
+landing→conversation flip. That is safe because the flip only fires right after a
+send (which already reset the draft) or on a chat load (which changes `sessionId`
+and remounts anyway), and the per-session draft lives in `AgentHome` — not in the
+composer — so it survives the remount.
 
 ### Per-session draft lifecycle
 
 - **switch session** → load that session's draft (or a fresh default seeded from
-  `autoAddActiveContentToContext`); global `selectedTextContexts` are cleared so
-  a selection can't drift between sessions.
-- **send** → snapshot context into the queued item, then `resetCompose()` clears
-  the compose box (input / images / notes / flags); `loading` + `queue` are
-  per-session so a backgrounded turn never bleeds into the foregrounded session.
+  `autoAddActiveContentToContext`); global `selectedTextContexts` are cleared.
+- **send** → snapshot context into the queued item, then `resetCompose()`;
+  `loading` + `queue` are per-session so a backgrounded turn never bleeds into the
+  foregrounded session.
 - **turn resolves after a tab switch** → the send-time `setLoading` closure is
-  bound to the originating session, and a live-session guard prevents a late
-  update from resurrecting a closed/replaced session's draft.
+  bound to the originating session; a live-session guard prevents a late update
+  from resurrecting a closed/replaced session's draft.
 - **close / `replaceSessionInPlace`** → the session id leaves `liveSessionIds`;
-  the draft (and its `File[]`) is pruned. `replaceSessionInPlace` mints a new id,
-  so "new chat" naturally lands on a fresh empty draft.
-- `selectedTextContexts` is intentionally **not** in the draft — it is a global
-  ephemeral atom, snapshotted into the queued message at send time.
+  the draft (and its `File[]`) is pruned.
 
 ### Backend restart (how the UI absorbs it)
 
-A backend can be restarted at runtime so its next spawn picks up new config:
-binary path / install changes, system-prompt changes, provider config (filtered
-by `restartOnProviderConfigChange`), and — added by `#2537` — a Copilot Plus
-sign-in/out or license rotation, which restarts **every** backend (unfiltered),
-because the decrypted license is injected into each backend's spawn env. All of
-these funnel through `AgentSessionManager.restartBackend → restartBackendNow`.
+A backend can be restarted at runtime (binary/install change, system-prompt
+change, filtered provider config, or a Copilot Plus sign-in/out that restarts
+every backend). All funnel through `AgentSessionManager.restartBackend →
+restartBackendNow`. The UI needs **no special restart listener**: a restart rides
+the same seam every session change uses — `manager.subscribe()` → `AgentModeChat`
+re-reads `getActiveSession()` and feeds fresh props to `AgentHome`.
+`restartBackendNow` closes every session on that backend (draining a pending
+auto-save first), so their drafts are pruned; only when the _active_ session was
+on that backend is one fresh replacement created. An in-flight turn is not
+interrupted — the restart defers until the busy session goes idle.
 
-The UI needs **no special restart listener**: a restart rides the same seam
-every session change uses — `manager.subscribe()` → `AgentModeChat` re-reads
-`getActiveSession()` / `getActiveChatUIState()` → feeds fresh `sessionId` /
-`backend` to `AgentHome`. `restartBackendNow` closes every session on that
-backend (`closeSession`, which first drains a pending auto-save), so their ids
-leave `liveSessionIds` and their drafts are pruned by `useAgentInputDrafts`;
-only when the _active_ session was on that backend is one fresh replacement
-session created. An in-flight turn is **not** interrupted — the restart defers
-until the busy session goes idle.
+PR2 keeps project / scope state **derived from the manager through this same
+subscribe seam** (never cached independently in `AgentHome`), so a restart can't
+strand it; the replacement session inherits the replaced session's `projectId`
+(see Part II).
 
-Consequences worth knowing (session-layer behavior, **not** PR1-introduced — the
-legacy `AgentChat` took the same path and additionally discarded drafts on its
-`key` remount):
+## Landing sections, shared primitives & asset reuse
 
-- A Plus-license change restarts all backends, so **every open tab closes at
-  once**: the active backend keeps one fresh empty session (which re-derives
-  `isGlobalLanding` → the landing reappears), the rest just vanish. Unsent
-  drafts / queued follow-ups in every closed tab are lost.
-- A closed conversation survives on disk **only if `autosaveChat` is on**
-  (`closeSession` drains the debounced auto-save, which is gated on that
-  setting); with it off, an in-progress chat that was never manually saved is
-  gone. This is the sharp edge — a Plus sign-in resets whatever you were doing.
+The landing's two shelves sit at different capability levels on purpose: in PR1
+Projects was read-only (a coming-soon `Notice`) because real project management
+is backend work, while Recent Chats was fully manageable by reusing the existing
+`ChatHistoryPopover` (search / rename / delete / open-source). The shared shelf
+building blocks live in `AgentHomeSection.tsx` (`AgentHomeSection` /
+`AgentHomeListRow` / generic `AgentHomeViewAll<TItem>` with lazy
+`IntersectionObserver` paging), kept generic so PR2's project-scoped shelves
+reuse them.
 
-**PR2 caution.** When sessions gain a `projectId` and history becomes
-project-scoped, keep project / scope state **derived from the manager through
-this same subscribe seam** — don't cache it independently in `AgentHome`, or a
-restart strands it. And `restartBackendNow`'s replacement session has no
-`projectId` today; PR2 must decide which project it belongs to (and whether to
-auto-replace inside a project at all, versus falling back to the project
-landing). The deferred "background-session queue auto-flush" seam must likewise
-survive — or explicitly accept losing — a restart that closes background
-sessions.
+The reuse rule of thumb: **a pure function, read-only selector, or side-effect-free
+hook is reused; a controller component or a hook that writes global state is
+rebuilt.** `ChatInput` is a shared hotspot (Agent + legacy Chat both render it),
+so it stays a black box — centering vs pinning is solved by the outer layout's
+CSS, never by editing `ChatInput`.
 
-## Landing sections (Projects + Recent Chats)
+---
 
-Visible only in the global-landing state. The two sections sit at **different
-capability levels on purpose**: Projects is read-only because real project
-management (CRUD, entering a project) is PR2 backend work, while Recent Chats is
-fully manageable because chat management already exists in PR1 — the conversation
-control bar uses the same `ChatHistoryPopover`, every handler already lives in
-`useAgentHistoryControls`, so the landing **reuses** it rather than shipping a
-weaker read-only twin.
+# Part II — Project workspaces (PR2, backend)
 
-- `ProjectPickerList` — **read-only.** `projects` from `useProjects()` (read-only
-  `sortByStrategy("recent")` inside), inline list capped at `INLINE_LIMIT` (3)
-  with an in-pane `AgentHomeViewAll` popover + search. A header `+` button and row
-  clicks both fire a coming-soon `Notice` only — **no** `setCurrentProject`, no
-  `touch`, no session creation, no history-scope change.
-- `GlobalRecentChatsSection` — **inline preview read-only, View-all fully
-  manageable.** The inline 3 rows open-on-click and are pinned to
-  `sortByStrategy("recent")` (the section is literally "Recent Chats"). The "View
-  all chats" trigger opens the full `ChatHistoryPopover` — search, time grouping,
-  rename, delete, open-source, backend icon — which follows the user's configured
-  `chatHistorySortStrategy`. So the inline order (always recent) and the popover
-  order (user setting) can differ by design. Every mutation routes through the
-  same `useAgentHistoryControls` handlers the conversation control bar uses; no
-  new backend.
+Entering a project gives it its own sessions, chat history, and materialized
+context. The global workspace is modeled as one special scope (the
+`GLOBAL_SCOPE` sentinel) running the same code path, so there is no separate
+"no-project" branch to keep in sync.
 
-## Shared section primitives
+## Session scope
 
-`AgentHomeSection.tsx` holds the building blocks the landing lists render
-through. Both sections share the header + inline-rows shape; they diverge at
-"View all" — Projects opens `AgentHomeViewAll`, Recent Chats opens the full
-`ChatHistoryPopover` (so `AgentHomeViewAll` currently has a **single consumer**,
-kept generic for the project-scoped section PR2 adds rather than specialized now):
+`AgentSessionManager` stores sessions in a `Map<string, AgentSession>` keyed by an
+internal session id, but **binds each session to an immutable `projectId`**. All
+scope behavior keys off that `projectId`, not off the map key:
 
-- `AgentHomeSection` — section header (icon + title + bracketed count + optional
-  trailing action) over its rows.
-- `AgentHomeListRow` — generic row: optional leading icon, truncated label
-  (with full-text `title` tooltip), relative time (with absolute-time tooltip).
-  No icon by default (the header carries the type icon); an icon is passed only
-  when it's _informational_ — see the backend icon below.
-- `AgentHomeViewAll<TItem>` — generic "View all" trigger + in-pane search
-  popover, generic over the item type so the domain doesn't leak into the
-  primitive. Pages the full list with `VIEW_ALL_PAGE_SIZE` (50) via an
-  `IntersectionObserver` sentinel. **Used by the Projects "View all" only**; kept
-  generic for PR2's project-scoped section (Recent Chats reuses the richer
-  `ChatHistoryPopover` instead).
+- **per-scope MRU** and `getSessionsForScope(projectId)` — the tab strip and
+  history filter to the active scope.
+- `resolveSessionCwd` / `resolveScopeCwd` — a project's working directory is its
+  own folder (the directory holding its `project.md`); the global scope falls
+  back to the vault root.
+- `enterProject` / `exitProject` — switch the active scope.
+- **Active-session invariant**: `getActiveSession().projectId === activeProjectId`.
+  Existing UI helpers that read the active session stay correct without knowing
+  about scopes.
 
-### Optimizations ported from existing components
+Two behaviors preserve the invariant across the rough edges:
 
-PR1 (zero backend), lifted from mature components so the landing matches their
-proven behavior. These apply to what PR1 actually built — the inline rows and the
-Projects `AgentHomeViewAll`; the Recent Chats View-all gets the same behaviors
-natively because it _is_ the reused `ChatHistoryPopover`:
+- **Backend restart / in-place replacement inherits the replaced session's
+  `projectId`** — a project scope reuses its warm process instead of adopting the
+  vault-root probe session.
+- **Re-entering a project opens as a fresh visit**: in-progress conversational
+  chats detach from the tab strip (kept live in the pool, listed in chat history
+  with a running indicator) instead of dragging every prior tab back, while an
+  unused empty landing is reused rather than stacked. The global workspace keeps
+  its restore-the-last-tab behavior.
 
-- **Lazy pagination** (`IntersectionObserver` + sentinel, callback-ref for
-  Radix's deferred mount) — copied from `ChatHistoryPopover` into
-  `AgentHomeViewAll` (the Projects View-all) so a long list renders incrementally.
-  The Recent Chats View-all is `ChatHistoryPopover` itself, so it paginates
-  natively without this port.
-- **`sortByStrategy("recent")`** — from `ChatHistoryPopover` / the project list.
-  The Projects list and the Recent Chats **inline preview** sort by it (last-used
-  desc → created → name). The Recent Chats View-all is the real
-  `ChatHistoryPopover`, which follows the user's `chatHistorySortStrategy`
-  instead. The inline preview owns its sort because the PR1-frozen
-  `getChatHistoryItems()` returns vault-scan order.
-- **Row tooltips** (full label + absolute time) — the glanceable compact labels
-  stay; hover reveals the full value.
-- **Backend brand icon on Recent Chats rows** — reuses `backendRegistry[id].Icon`
-  (same resolver as `AgentChatControls`), falling back to `MessageCircle` — the
-  same fallback `ChatHistoryPopover` rows use, so the inline preview and the
-  View-all match for legacy chats with no `backendId`. Projects rows stay
-  icon-less; the chat icon is informational (which backend ran it), not a repeat
-  of the section type.
+## Context materialization
 
-## Asset reuse decisions
+A project can attach **URL / YouTube** links and **in-vault binary files** (PDFs,
+Office docs, e-books, images — all materialized under the single `file` kind).
+Before a session
+opens, `projectContextMaterializer` captures them once per session
+(single-flight per project), converts each via brevilabs into a text snapshot,
+and builds a `<project_context>` block that is inlined into the session's first
+user prompt. The block lists absolute paths to the snapshots so the agent can
+read them directly; the composer shows a context status icon and queues sends
+while context is still materializing.
 
-PR1 reused existing code only where it was safe to, and rebuilt where the old
-asset carried legacy-Chat semantics. The rule of thumb: **a pure function,
-read-only selector, or side-effect-free hook is reused; a controller component
-or a hook that writes global state is not** — anything that depends on
-legacy-Chat concepts (`useChatInput` / `showChatUI` / `setCurrentProject` /
-chain type) cannot enter Agent Home directly. `ChatInput` is a shared hotspot
-(Agent + legacy Chat both render it), so it stays a black box — centering vs
-pinning is solved by the outer layout's CSS, never by editing `ChatInput`.
+Folders, notes, tags, and extensions are listed in the same block by path/pattern
+(they need no conversion); folders that live outside the session cwd are also
+reported as `additionalDirectories` to widen the agent's searchable roots.
 
-| Asset                                     | Decision                          | Why                                                                                                                          |
-| ----------------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `useProjects()`                           | reuse                             | Reactive read-only, stable ref; store is populated at `onLayoutReady`, so it has data even when only the Agent view is open. |
-| `sortByStrategy()`                        | reuse                             | Pure sort (reads `UsageTimestamps`, never touches it).                                                                       |
-| `filterProjects()`                        | reuse (search)                    | Pure filter.                                                                                                                 |
-| `ProjectConfig`                           | reuse                             | Plain type.                                                                                                                  |
-| `ChatInput`                               | reuse, black box (no edits)       | Controlled component; center/pin handled by outer CSS.                                                                       |
-| `AgentTabStrip`                           | reuse, untouched                  | Takes only `manager`; already global-scoped in the no-project world.                                                         |
-| `ChatHistoryPopover` / `ChatHistoryItem`  | reuse                             | Agent already uses them.                                                                                                     |
-| `ProjectList.tsx`                         | **rebuild** (`ProjectPickerList`) | Legacy-Chat controller (`useChatInput` / `showChatUI` / `setCurrentProject`); read-only picker is a clean rewrite.           |
-| `setCurrentProject` / `getCurrentProject` | **do not touch**                  | Generic name but carries legacy project-mode global semantics.                                                               |
-| `touchProjectLastUsed` / usage `touch`    | **do not touch**                  | Write semantics; PR1 is read-only.                                                                                           |
-| `AddProjectModal`                         | PR2 reuse                         | Callbacks are clean (no legacy semantics), but project creation is PR2.                                                      |
+**Contract (relied on by the session manager):** materialization **never
+rejects** — any failure degrades to a best-effort partial / empty result so
+session start is never blocked. It is cheap on unchanged context (snapshots
+cheap-skip by fingerprint, known-bad sources cheap-skip by failure marker), and a
+`contextSignature` over the source fields drives reactivity: a re-entered project
+re-materializes only when its sources changed, and the active project warms its
+cache in the background.
 
-## PR2 seam (not implemented in PR1)
+### The shared off-vault conversion cache
 
-Structural seams already in place:
+Snapshots are the supporting subsystem behind context materialization. Each
+source is converted **once per vault** and shared across every project that
+references it, instead of once per project.
 
-- The `AgentHome` shell is in place; PR2 adds a project-workspace state as a new
-  branch without disturbing the no-project skeleton.
-- The landing display components take only `items` / `projects` + callbacks, so
-  PR2 can swap in project-scoped history without touching them.
-- `ProjectPickerList.onSelect` / `onCreate` flip from coming-soon `Notice`s to
-  real project entry + creation; `GlobalRecentChatsSection` (global) sits beside
-  a future project-scoped "Project Chats" without a naming clash.
+**Off-vault, per-vault layout.** The cache lives outside the vault — single copy,
+not synced by Obsidian Sync / git, never indexed as note content — under the
+existing per-vault namespace that already hosts the recent-chats index:
 
-Deferred to PR2 (write operations / backend — must NOT leak into the **Projects**
-read-only list; chat management already shipped via the reused
-`ChatHistoryPopover`):
+```
+~/.obsidian-copilot/vaults/<vaultId>/context-cache/
+  remotes/   web-<md5(url)>.md · youtube-<md5(url)>.md          # shared by all projects
+  files/     file-<md5(vaultPath)>.md                           # shared by all projects
+  markers/   <md5(projectId)>/failed-<type>-<md5(source)>.json  # failure markers, per project
+```
 
-- **Project CRUD**: create / rename / delete / duplicate / archive, the per-row
-  `⋯` management menu, and the "name only" quick-create modal.
-- **`setCurrentProject` + project usage touch** — entering a project switches
-  context and records recency; PR1 writes neither.
-- **`projectId` on sessions, scope envelope / `scopeStatus` gating,
-  switch-project = switch-history, indexing card, drag-to-add context, Outputs.**
-- **Project-scoped chat history** — the chat management surface (rename / delete /
-  open-source / time-group headers / mobile always-visible actions) already ships
-  in PR1 for the global list via `ChatHistoryPopover`; PR2 only re-points it at a
-  project-filtered list.
-- **Sort-strategy switcher** writing `settings` (PR1's Projects list and the
-  Recent Chats inline preview pin `recent`; the chat View-all already follows the
-  read-only `chatHistorySortStrategy`).
-- **Background-session queue auto-flush** — sink the per-session compose queue
-  from the foreground composer down into the session layer
-  (`AgentSession` / `AgentChatUIState`) so a background turn drains its own
-  queued follow-ups when it finishes, instead of waiting for the user to return
-  to that tab. PR1's queue lives in `AgentChatInput` (UI), which by design only
-  observes the foreground session — see the DESIGN NOTE on the flush effect in
-  `AgentChatInput.tsx`. PR1 is already strictly better than legacy here (legacy
-  kept the queue in component `useState` and discarded it on tab-switch
-  remount); this is an additive enhancement, not a regression fix, and belongs
-  with the session-layer/backend work, not the read-only frontend.
+`vaultId = md5(adapter.getBasePath()).slice(0, 8)` (extracted as `getVaultId` in
+`utils/appPaths.ts`). Per-vault bucketing means the current vault's project
+registry is the cache's complete reference set, so garbage collection needs no
+cross-vault refs subsystem — at the cost of the same URL being converted once in
+each of two different vaults (rare). **All paths derive from one source of truth,
+`context/conversionsLocation.ts`** (`cacheRoot` / `remotesDir` / `filesDir` /
+`markersDir(projectId)`), shared by the writer and every reader.
+
+**Identity keys + internal freshness.** Snapshot filenames hash the **source
+identity** (`md5(url)` / `md5(vaultPath)`) — never content, never `projectId`.
+Freshness is a `fingerprint` stored in the snapshot's own metadata header, and it
+differs by kind: a **file** uses `mtime:size` (an edit changes the fingerprint, so
+the cheap-skip misses and the **same file is overwritten** — no orphans), while a
+**remote** uses its identity (`type:url`), so a successfully fetched URL is kept
+until its configured string changes. A URL's identity is the exact trimmed string
+the user configured — there is no semantic canonicalization (`x.com` ≠ `x.com/`).
+
+**Per-artifact lock.** A module-level lock (keyed by the snapshot filename, via
+`async-mutex`) wraps each source's whole read-decide-write. Because the key is
+identity-derived, the **same source across two projects maps to the same lock**:
+the first project to cold-convert acquires it, reads metadata (miss), fetches,
+atomically writes, releases; a second project waiting on the same source then
+acquires the lock, re-reads the now-present metadata, and **cheap-skips without
+re-fetching or overwriting**. Two projects cold-converting one URL converge to a
+single brevilabs call.
+
+**Failure markers (CAG-style negative cache).** A source that fails to
+fetch/parse with no usable snapshot writes a `failed-…json` marker in _its own
+project's_ marker bucket, carrying the error and (for files) the `mtime:size`
+fingerprint. A later automatic run cheap-skips that known-bad source — re-surfacing
+the stored error instead of re-hitting brevilabs every session — until the file
+changes or the user forces a retry (`forceRetryFailed`, the status popover's
+"Retry"). Markers are bucketed per project because a failure is meaningful only to
+the project that hit it; snapshots are shared, so they are **never reconciled
+against a single project's sources** (that would delete files other projects
+still use). Cross-project convergence is handled instead: when project B writes a
+shared snapshot for a source project A previously failed, A's next run cheap-skips
+the snapshot and best-effort clears its now-stale marker. A successful snapshot is
+kept indefinitely (no TTL) — the plugin can't observe an agent reading an absolute
+path, so a time-based or touch-on-read policy would either over-retain or delete
+context that is still in use.
+
+**Delivery to the three backends.** The shared cache lives outside every project
+cwd, so the only pointer all three backends can reach is an **absolute path**: the
+manifest lists each snapshot's absolute path (keyed by `type:source` so the same
+URL used as both a web and a YouTube source resolves to distinct snapshots), and
+agents read it with their native file tool. claude additionally accepts the cache
+root as an `additionalDirectories` entry; codex reads the whole disk; **opencode
+blocks reads outside the vault by default, so it is granted an
+`external_directory: { "<cacheRoot>/**": "allow" }`\*\* on its spawn agents.
+
+### The root-confined node:fs backend
+
+`ContextCacheFs` is a small injectable filesystem interface kept **node-free** (a
+pure type), so mobile-reachable code can import the type without pulling
+`node:fs` into the bundle. The single production implementation,
+`createNodeContextCacheFs`, is rooted at the absolute cache directory and loads
+`node:fs` / `node:path` **lazily via `require` inside the factory** — never at
+module top level — so the builtins are evaluated only behind the desktop Agent
+boundary. Three hard rules:
+
+- **Root-confined.** Internal paths are cache-root-relative (absolute paths are
+  resolved only in `conversionsLocation`); `resolveWithin` rejects `..` segments,
+  absolute inputs, and anything that resolves outside the root, and `clear` never
+  ascends to the parent `vaults/<id>/` (which holds `agent-chat-index.json`).
+  Symlink escape is documented as intentionally out of scope: every path is
+  plugin-derived md5 filenames, so no caller can inject one, and following a
+  pre-seeded symlink would require a local actor who already has write access to
+  this directory.
+- **Split best-effort policy.** `writeText` / `mkdirRecursive` **throw** — a
+  swallowed write would let the store report success while the snapshot is
+  missing (a manifest pointing at nothing). The store turns a write throw into a
+  per-source failure and a mkdir throw into a whole-run degradation. `list` /
+  `remove` / `clear` **tolerate** a missing target (`[]` / idempotent). `readText`
+  **passes the error through** — the store's `readMeta` / `readFailureMarker` and
+  the UI's tolerant helpers each `try/catch → null`, so read-as-miss tolerance
+  lives at the call sites, not the fs layer.
+- **Atomic writes.** `writeText` stages into a same-dir temp file then renames
+  over the target (with a short retry for transient Windows watcher/AV locks);
+  `list` ignores temp files. The cache is regenerable, so there is no `fsync`.
+
+### Mobile boundary
+
+The Agent-Mode context readers (status icon, content-conversion preview, the
+Clear command) are reachable from a shared modal that mobile also renders. They
+must never evaluate `node:fs` on mobile, so each reaches the node-touching modules
+(`conversionsLocation`, `contextCacheFs`) through a desktop-gated **dynamic
+`import`**, never a static top-level import. (Desktop-only paths that mobile can
+never reach — the materializer, the opencode descriptor — import the same modules
+statically, which is fine; only the mobile-reachable readers need the dynamic
+boundary.) On mobile the readers degrade to an empty state (there is no Agent Mode
+there anyway). A static-import smoke check (`scripts/mobile-load-smoke.cjs`) guards
+this boundary over the cache consumers.
+
+### Cleanup
+
+There is **no automatic garbage collection** in this version — the existing
+`Clear Copilot cache` command additionally wipes `context-cache/` (all three
+subdirectories) while leaving the sibling `agent-chat-index.json` intact. Marker
+cleanup happens incrementally (a stale marker is cleared when its source later
+succeeds, as above). The released CAG caches (`.copilot/*`) are a separate system
+and are left untouched. Source kinds are a single source of truth,
+`MATERIALIZED_SOURCE_TYPES` (`web` / `youtube` / `file`), so adding a kind updates
+the filename patterns and marker-pruning regex together.
+
+## Project instructions (`project.md` + `AGENTS.md` mirror)
+
+`project.md` is the single source of truth for a project's config and
+instructions. A **marker-gated `AGENTS.md` mirror** is generated alongside it by
+`ensureAgentsMirror`: codex and opencode auto-discover `AGENTS.md` from the
+session cwd, and claude receives the same composed instructions via
+`getProjectProfile`. A built-in project policy is layered into each project's
+instructions — for claude always; for codex/opencode through the generated
+mirror, which **yields to a user-authored, unmarked `AGENTS.md`** (the mirror only
+manages the file it owns, so it never clobbers a hand-written one).
+
+## History scope
+
+Agent chat history is scope-keyed: a project view lists only that project's
+chats, while `GLOBAL_SCOPE` is the flat all-chats view. A chat's scope is its
+frontmatter `projectId`; a legacy chat with no `projectId` resolves to
+`GLOBAL_SCOPE` (the hard contract is "absent/blank `projectId` → `GLOBAL_SCOPE`",
+never a filename-prefix guess). Native session history is scoped to projects too,
+and a resumed transcript hydrates from the session's scope cwd.
+
+Opening a saved chat from a different scope switches `activeProjectId` before
+resuming/creating its session. If the resume returns no session and the create
+then throws (e.g. a missing backend binary fails to spawn), the load would leave
+`activeProjectId` pointing at the new scope while `activeSessionId` still
+references the old one — breaking the active-session invariant.
+`rollbackHistoryLoadScope` restores the replaced scope on that failure, but only
+while still parked in the scope the load switched to (a concurrent switch during
+the awaited spawn means the user has moved on).
+
+## Hardening & cross-cutting
+
+- **`contextCacheFs` path guards** — `..`, absolute, and root-escaping paths are
+  rejected; symlink escape is a documented out-of-scope design note (above).
+- **Hard-disabled composer** — when the active project is orphaned (deleted out
+  from under the user), the composer blocks both keyboard sends and the
+  queued-message flush, not just pointer events, so a turn can't drain into a dead
+  project.
+- **Attachment envelope rename** — the per-message attachment envelope is
+  `<attached_context>` (renamed from `<copilot-context>`) to disambiguate it from
+  the project-wide `<project_context>` block.
+- **Unified todo / plan** — backend todo lists across claude / codex / opencode
+  are normalized into one plan model feeding the project info popover, with
+  per-session todo-id tracking and symmetric plan-clear on empty.
+
+## Verification
+
+The cache and scope behavior are covered by unit + integration suites, including
+a real-filesystem dedup integration test that drives the production
+`createNodeContextCacheFs` and the real per-artifact lock against a temp
+directory (two projects sharing a URL → one snapshot on disk, one fetch; the same
+for a shared PDF; a failed project's marker cleared once another project
+materializes the source). The opencode `external_directory` allow injection, the
+mobile static-import boundary, and the three-backend snapshot read were validated
+against a real vault.

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,8 @@ module.exports = {
     "^yaml$": "<rootDir>/node_modules/yaml/dist/index.js",
     "^@agentclientprotocol/sdk$": "<rootDir>/__mocks__/@agentclientprotocol/sdk.js",
     "^@anthropic-ai/claude-agent-sdk$": "<rootDir>/__mocks__/@anthropic-ai/claude-agent-sdk.js",
+    // react-resizable-panels is ESM-only with no CJS build to point at; stub it.
+    "^react-resizable-panels$": "<rootDir>/__mocks__/react-resizable-panels.js",
   },
   testRegex: ".*\\.test\\.(jsx?|tsx?)$",
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],

--- a/scripts/mobile-load-smoke.cjs
+++ b/scripts/mobile-load-smoke.cjs
@@ -17,6 +17,12 @@ const loadCriticalFiles = [
   "src/components/chat-components/plugins/slashMenuItems.ts",
 ];
 
+const contextCacheConsumerFiles = [
+  "src/commands/index.ts",
+  "src/components/project/agentProcessingAdapter.ts",
+  "src/utils/cacheFileOpener.ts",
+];
+
 const nodeModuleIds = new Set([
   "async_hooks",
   "buffer",
@@ -106,6 +112,24 @@ function checkAgentModeImportBoundaries() {
         `${relativePath}: dynamic Agent Mode import must be gated by isDesktopRuntime() ` +
           `— Platform.isDesktopApp is true under app.emulateMobile(true).`
       );
+    }
+  }
+}
+
+function checkContextCacheImportBoundaries() {
+  const desktopOnlyImports =
+    /import\s+(?:type\s+)?[^;]+?\s+from\s+["']@\/context\/(?:conversionsLocation|contextCacheFs)["']\s*;?/g;
+
+  for (const relativePath of contextCacheConsumerFiles) {
+    const source = readRepoFile(relativePath);
+    for (const match of source.matchAll(desktopOnlyImports)) {
+      const statement = match[0];
+      if (!isTypeOnlyImport(statement)) {
+        fail(
+          `${relativePath}: value import from ${statement.match(/["']([^"']+)["']/)?.[1]} ` +
+            "is on the mobile load path; use a desktop-gated dynamic import."
+        );
+      }
     }
   }
 }
@@ -357,6 +381,7 @@ function runBundleEvaluationSmoke() {
 }
 
 checkAgentModeImportBoundaries();
+checkContextCacheImportBoundaries();
 runBundleEvaluationSmoke();
 
 if (failures.length > 0) {

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -10,6 +10,44 @@ jest.mock("@/logger", () => ({
   logError: jest.fn(),
 }));
 
+// Controllable ACP SDK mock (richer than the shared `__mocks__` stub): lets a
+// test set the `initialize` response (to advertise capabilities) and capture
+// the `newSession` request. `mock`-prefixed names satisfy ts-jest's jest.mock
+// hoisting rules.
+let mockInitializeResult: unknown = { protocolVersion: 1 };
+const mockNewSession = jest.fn(async (..._args: unknown[]) => ({ sessionId: "test-session" }));
+const mockResumeSession = jest.fn(async (..._args: unknown[]) => ({}));
+const mockLoadSession = jest.fn(async (..._args: unknown[]) => ({}));
+
+jest.mock("@agentclientprotocol/sdk", () => {
+  class RequestError extends Error {
+    code: number;
+    constructor(code: number, message?: string) {
+      super(message);
+      this.code = code;
+      this.name = "RequestError";
+    }
+  }
+  class ClientSideConnection {
+    _client: unknown;
+    constructor(toClient: (c: unknown) => unknown) {
+      this._client = toClient(this);
+    }
+    initialize = jest.fn(async () => mockInitializeResult);
+    newSession = (...args: unknown[]) => mockNewSession(...args);
+    resumeSession = (...args: unknown[]) => mockResumeSession(...args);
+    loadSession = (...args: unknown[]) => mockLoadSession(...args);
+    prompt = jest.fn(async () => ({ stopReason: "end_turn" }));
+    cancel = jest.fn(async () => undefined);
+  }
+  return {
+    RequestError,
+    ClientSideConnection,
+    ndJsonStream: jest.fn(() => ({})),
+    PROTOCOL_VERSION: 1,
+  };
+});
+
 const exitListeners = new Set<() => void>();
 let mockProcessIsRunning = true;
 
@@ -67,6 +105,13 @@ describe("AcpBackendProcess", () => {
   beforeEach(() => {
     exitListeners.clear();
     mockProcessIsRunning = true;
+    mockInitializeResult = { protocolVersion: 1 };
+    mockNewSession.mockClear();
+    mockNewSession.mockResolvedValue({ sessionId: "test-session" });
+    mockResumeSession.mockClear();
+    mockResumeSession.mockResolvedValue({});
+    mockLoadSession.mockClear();
+    mockLoadSession.mockResolvedValue({});
   });
 
   it("routes session updates to the matching session handler and drops unknown ones", async () => {
@@ -99,6 +144,129 @@ describe("AcpBackendProcess", () => {
     } as unknown as Parameters<typeof client.sessionUpdate>[0];
     await expect(client.sessionUpdate(strayUpdate)).resolves.toBeUndefined();
     expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("scopes todowrite id tracking per session — a registered id does not bleed across sessions", async () => {
+    const backend = new AcpBackendProcess(
+      buildApp(),
+      buildStubBackend(),
+      "1.0.0",
+      buildStubDescriptor()
+    );
+    await backend.start();
+
+    const handlerA = jest.fn();
+    const handlerB = jest.fn();
+    backend.registerSessionHandler("sess-A", handlerA);
+    backend.registerSessionHandler("sess-B", handlerB);
+    const client = getVaultClient(backend);
+
+    // Session A registers "shared-id" as a todowrite call (synthesizes a plan).
+    await client.sessionUpdate({
+      sessionId: "sess-A",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "shared-id",
+        title: "todowrite",
+        rawInput: { todos: [{ content: "a", status: "pending", priority: "high" }] },
+      },
+    } as unknown as Parameters<typeof client.sessionUpdate>[0]);
+    expect(handlerA.mock.calls.some(([e]) => e.update.sessionUpdate === "plan")).toBe(true);
+
+    // Session B sends a titleless update reusing the SAME id with a todos
+    // payload. With a process-wide Set this would masquerade as a plan; scoped
+    // per session, B's tracker is empty so no plan is synthesized.
+    handlerB.mockClear();
+    await client.sessionUpdate({
+      sessionId: "sess-B",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "shared-id",
+        rawInput: { todos: [{ content: "leaked", status: "pending", priority: "low" }] },
+      },
+    } as unknown as Parameters<typeof client.sessionUpdate>[0]);
+    expect(handlerB.mock.calls.some(([e]) => e.update.sessionUpdate === "plan")).toBe(false);
+  });
+
+  it("keeps a session's todo tracker when re-registering the same sessionId (stale unsubscribe is a no-op)", async () => {
+    const backend = new AcpBackendProcess(
+      buildApp(),
+      buildStubBackend(),
+      "1.0.0",
+      buildStubDescriptor()
+    );
+    await backend.start();
+    const client = getVaultClient(backend);
+
+    // First handler registers "todo-1" as a todowrite call, then unsubscribes —
+    // but a SECOND handler for the same session is already registered, so the
+    // stale unsubscribe must not delete the live tracker.
+    const stale = backend.registerSessionHandler("sess-X", jest.fn());
+    await client.sessionUpdate({
+      sessionId: "sess-X",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "todo-1",
+        title: "todowrite",
+        rawInput: { todos: [{ content: "a", status: "pending", priority: "high" }] },
+      },
+    } as unknown as Parameters<typeof client.sessionUpdate>[0]);
+
+    const fresh = jest.fn();
+    backend.registerSessionHandler("sess-X", fresh); // replaces the handler
+    stale(); // stale unsubscribe — must NOT drop sess-X's tracker
+
+    // A titleless follow-up for the registered id must still synthesize a plan,
+    // proving the tracker survived the stale unsubscribe.
+    await client.sessionUpdate({
+      sessionId: "sess-X",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "todo-1",
+        rawInput: { todos: [{ content: "a", status: "in_progress", priority: "high" }] },
+      },
+    } as unknown as Parameters<typeof client.sessionUpdate>[0]);
+    expect(fresh.mock.calls.some(([e]) => e.update.sessionUpdate === "plan")).toBe(true);
+  });
+
+  it("drops todo trackers on subprocess exit so a restarted process starts clean", async () => {
+    const backend = new AcpBackendProcess(
+      buildApp(),
+      buildStubBackend(),
+      "1.0.0",
+      buildStubDescriptor()
+    );
+    await backend.start();
+    const client = getVaultClient(backend);
+
+    backend.registerSessionHandler("sess-E", jest.fn());
+    await client.sessionUpdate({
+      sessionId: "sess-E",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "todo-e",
+        title: "todowrite",
+        rawInput: { todos: [{ content: "a", status: "pending", priority: "high" }] },
+      },
+    } as unknown as Parameters<typeof client.sessionUpdate>[0]);
+
+    // Subprocess exits, then the process is restarted and the same sessionId +
+    // todo id reappear. With the onExit cleanup the tracker is gone, so a
+    // titleless update is NOT mistaken for the old todowrite call.
+    for (const fn of exitListeners) fn();
+    await backend.start();
+    const client2 = getVaultClient(backend);
+    const handler = jest.fn();
+    backend.registerSessionHandler("sess-E", handler);
+    await client2.sessionUpdate({
+      sessionId: "sess-E",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "todo-e",
+        rawInput: { todos: [{ content: "stale", status: "pending", priority: "low" }] },
+      },
+    } as unknown as Parameters<typeof client2.sessionUpdate>[0]);
+    expect(handler.mock.calls.some(([e]) => e.update.sessionUpdate === "plan")).toBe(false);
   });
 
   it("returns cancelled outcome when permission is requested but no prompter is registered", async () => {
@@ -178,5 +346,129 @@ describe("AcpBackendProcess", () => {
       buildStubDescriptor()
     );
     await expect(backend.prompt({ sessionId: "s1", prompt: [] })).rejects.toThrow(/start\(\)/);
+  });
+
+  describe("additionalDirectories (capability-gated)", () => {
+    async function startBackend(): Promise<AcpBackendProcess> {
+      const backend = new AcpBackendProcess(
+        buildApp(),
+        buildStubBackend(),
+        "1.0.0",
+        buildStubDescriptor()
+      );
+      await backend.start();
+      return backend;
+    }
+
+    it("reflects the probed capability — false when the agent does not advertise it", async () => {
+      // codex 0.135 / opencode 1.2.27 shape: no additionalDirectories advertised.
+      mockInitializeResult = {
+        protocolVersion: 1,
+        agentCapabilities: { sessionCapabilities: { list: {}, close: {} } },
+      };
+      const backend = await startBackend();
+      expect(backend.supportsAdditionalDirectories()).toBe(false);
+    });
+
+    it("reflects the probed capability — true when the agent advertises it", async () => {
+      mockInitializeResult = {
+        protocolVersion: 1,
+        agentCapabilities: { sessionCapabilities: { additionalDirectories: {} } },
+      };
+      const backend = await startBackend();
+      expect(backend.supportsAdditionalDirectories()).toBe(true);
+    });
+
+    it("does NOT forward additionalDirectories at session/new when uncapable", async () => {
+      mockInitializeResult = { protocolVersion: 1 };
+      const backend = await startBackend();
+      await backend.newSession({
+        cwd: "/vault",
+        mcpServers: [],
+        additionalDirectories: ["/abs/context"],
+      });
+      const req = mockNewSession.mock.calls[0][0] as { additionalDirectories?: string[] };
+      expect(req).not.toHaveProperty("additionalDirectories");
+    });
+
+    it("forwards additionalDirectories at session/new only when capable", async () => {
+      mockInitializeResult = {
+        protocolVersion: 1,
+        agentCapabilities: { sessionCapabilities: { additionalDirectories: {} } },
+      };
+      const backend = await startBackend();
+      await backend.newSession({
+        cwd: "/vault",
+        mcpServers: [],
+        additionalDirectories: ["/abs/context-a", "/abs/context-b"],
+      });
+      const req = mockNewSession.mock.calls[0][0] as { additionalDirectories?: string[] };
+      expect(req.additionalDirectories).toEqual(["/abs/context-a", "/abs/context-b"]);
+    });
+
+    it("omits the field for a capable agent when no extra roots are supplied", async () => {
+      mockInitializeResult = {
+        protocolVersion: 1,
+        agentCapabilities: { sessionCapabilities: { additionalDirectories: {} } },
+      };
+      const backend = await startBackend();
+      await backend.newSession({ cwd: "/vault", mcpServers: [] });
+      const req = mockNewSession.mock.calls[0][0] as { additionalDirectories?: string[] };
+      expect(req).not.toHaveProperty("additionalDirectories");
+    });
+
+    // Resume/load re-establish the roots the same way session/new does, so a
+    // restored project chat must re-send them — symmetry the wire adapter owns.
+    it("forwards additionalDirectories at session/resume when capable", async () => {
+      mockInitializeResult = {
+        protocolVersion: 1,
+        agentCapabilities: { sessionCapabilities: { resume: {}, additionalDirectories: {} } },
+      };
+      const backend = await startBackend();
+      await backend.resumeSession({
+        sessionId: "s1",
+        cwd: "/vault",
+        mcpServers: [],
+        additionalDirectories: ["/abs/context-a", "/abs/context-b"],
+      });
+      const req = mockResumeSession.mock.calls[0][0] as { additionalDirectories?: string[] };
+      expect(req.additionalDirectories).toEqual(["/abs/context-a", "/abs/context-b"]);
+    });
+
+    it("does NOT forward additionalDirectories at session/resume when uncapable", async () => {
+      // resume advertised, additionalDirectories NOT — the gate must still hold.
+      mockInitializeResult = {
+        protocolVersion: 1,
+        agentCapabilities: { sessionCapabilities: { resume: {} } },
+      };
+      const backend = await startBackend();
+      await backend.resumeSession({
+        sessionId: "s1",
+        cwd: "/vault",
+        mcpServers: [],
+        additionalDirectories: ["/abs/context"],
+      });
+      const req = mockResumeSession.mock.calls[0][0] as { additionalDirectories?: string[] };
+      expect(req).not.toHaveProperty("additionalDirectories");
+    });
+
+    it("forwards additionalDirectories at session/load when capable", async () => {
+      mockInitializeResult = {
+        protocolVersion: 1,
+        agentCapabilities: {
+          loadSession: true,
+          sessionCapabilities: { additionalDirectories: {} },
+        },
+      };
+      const backend = await startBackend();
+      await backend.loadSession({
+        sessionId: "s1",
+        cwd: "/vault",
+        mcpServers: [],
+        additionalDirectories: ["/abs/context-a", "/abs/context-b"],
+      });
+      const req = mockLoadSession.mock.calls[0][0] as { additionalDirectories?: string[] };
+      expect(req.additionalDirectories).toEqual(["/abs/context-a", "/abs/context-b"]);
+    });
   });
 });

--- a/src/agentMode/acp/AcpBackendProcess.ts
+++ b/src/agentMode/acp/AcpBackendProcess.ts
@@ -4,6 +4,7 @@ import {
   PROTOCOL_VERSION,
   RequestError,
   ndJsonStream,
+  type NewSessionRequest,
   type RequestPermissionRequest,
   type RequestPermissionResponse,
   type SessionConfigOption,
@@ -39,7 +40,7 @@ import type {
 import { wrapStreamsForDebug } from "./debugTap";
 import { AcpBackend } from "./types";
 import {
-  acpNotificationToEvent,
+  acpNotificationToEvents,
   acpPermissionRequestToPrompt,
   acpStateToBackendState,
   cancelInputToAcp,
@@ -64,6 +65,7 @@ export type AcpCapability =
   | "session/set_model"
   | "session/set_mode"
   | "session/set_config_option"
+  | "session/additional_directories"
   | "mcp/http"
   | "mcp/sse";
 
@@ -135,6 +137,14 @@ export class AcpBackendProcess implements BackendProcess {
   private exitListeners = new Set<() => void>();
   private capabilities = new Map<AcpCapability, boolean>();
   private readonly sessionWireState = new Map<SessionId, SessionWireState>();
+  // Tool-call ids first seen as a `todowrite`-titled call, so later
+  // tool_call_updates for the same id keep synthesizing a plan update even
+  // after opencode renames the title (e.g. "3 todos"). See wireTranslate's
+  // todoToolPlanFromAcp. Keyed by session like every other per-session map on
+  // this shared (per-backend) process — a single backend instance serves all
+  // its sessions, so a bare Set would leak ids across sessions and grow
+  // unbounded for the process lifetime. Pruned on session teardown + shutdown.
+  private readonly todoToolCallIdsBySession = new Map<SessionId, Set<string>>();
 
   constructor(
     private readonly app: App,
@@ -175,6 +185,7 @@ export class AcpBackendProcess implements BackendProcess {
       this.domainHandlers.clear();
       this.pendingUpdates.clear();
       this.sessionWireState.clear();
+      this.todoToolCallIdsBySession.clear();
       this.permissionPrompter = null;
       this.capabilities.clear();
       for (const fn of this.exitListeners) {
@@ -219,8 +230,15 @@ export class AcpBackendProcess implements BackendProcess {
       if (init.agentCapabilities?.mcpCapabilities?.sse === true) {
         this.capabilities.set("mcp/sse", true);
       }
+      // Experimental ACP capability: presence of the (possibly empty) object
+      // means the agent honors `additionalDirectories` on session lifecycle
+      // requests. codex 0.135 / opencode 1.2.27 don't advertise it, so they
+      // receive no field. Gating here auto-enables future versions that do.
+      if (init.agentCapabilities?.sessionCapabilities?.additionalDirectories != null) {
+        this.capabilities.set("session/additional_directories", true);
+      }
       logInfo(
-        `[AgentMode] initialized backend ${this.backend.id} (negotiated protocol v${init.protocolVersion}, listSessions=${this.hasCapability("session/list")}, resumeSession=${this.hasCapability("session/resume")}, loadSession=${this.hasCapability("session/load")}, mcp.http=${this.hasCapability("mcp/http")}, mcp.sse=${this.hasCapability("mcp/sse")})`
+        `[AgentMode] initialized backend ${this.backend.id} (negotiated protocol v${init.protocolVersion}, listSessions=${this.hasCapability("session/list")}, resumeSession=${this.hasCapability("session/resume")}, loadSession=${this.hasCapability("session/load")}, mcp.http=${this.hasCapability("mcp/http")}, mcp.sse=${this.hasCapability("mcp/sse")}, additionalDirectories=${this.hasCapability("session/additional_directories")})`
       );
     } catch (err) {
       logError(
@@ -258,24 +276,33 @@ export class AcpBackendProcess implements BackendProcess {
       this.pendingUpdates.delete(sessionId);
       for (const wire of buffered) {
         try {
-          handler(acpNotificationToEvent(wire));
+          for (const event of acpNotificationToEvents(wire, this.todoToolCallIdsFor(sessionId)))
+            handler(event);
         } catch (e) {
           logWarn(`[AgentMode] replay of buffered session/update threw for ${sessionId}`, e);
         }
       }
     }
     return () => {
+      // Only tear down if THIS handler is still the registered one — a later
+      // re-register for the same sessionId (resume/reconnect) must not have its
+      // live tracker deleted by the stale unsubscribe.
       if (this.domainHandlers.get(sessionId) === handler) {
         this.domainHandlers.delete(sessionId);
+        // Teardown (not per-turn): the handler is unregistered only when the
+        // AgentSession disposes, so drop this session's todo-id tracker too.
+        this.todoToolCallIdsBySession.delete(sessionId);
       }
     };
   }
 
   async newSession(params: OpenSessionInput): Promise<OpenSessionOutput> {
-    const wireResp = await this.requireConnection().newSession({
+    const req: NewSessionRequest = {
       cwd: params.cwd,
       mcpServers: params.mcpServers.map(mcpServerSpecToAcp),
-    });
+      ...this.additionalDirectoriesField(params.additionalDirectories),
+    };
+    const wireResp = await this.requireConnection().newSession(req);
     this.recordWireState(wireResp.sessionId, {
       models: wireResp.models ?? null,
       modes: wireResp.modes ?? null,
@@ -305,6 +332,25 @@ export class AcpBackendProcess implements BackendProcess {
 
   supportsMcpTransport(transport: "http" | "sse"): boolean {
     return this.hasCapability(transport === "http" ? "mcp/http" : "mcp/sse");
+  }
+
+  supportsAdditionalDirectories(): boolean {
+    return this.hasCapability("session/additional_directories");
+  }
+
+  // Extra searchable roots ride on every session-lifecycle request (new, resume,
+  // load), but only when the agent advertises the experimental
+  // `additionalDirectories` capability — resume/load re-establish the roots just
+  // like `session/new`, so they must carry them too or a restored project chat
+  // loses its off-vault context roots. Agents that don't advertise the capability
+  // get no field at all; sending one they'll silently ignore would be misleading.
+  // Empty/absent roots also send nothing, so non-project sessions stay untouched.
+  private additionalDirectoriesField(roots: string[] | undefined): {
+    additionalDirectories?: string[];
+  } {
+    return this.supportsAdditionalDirectories() && roots?.length
+      ? { additionalDirectories: roots }
+      : {};
   }
 
   async setSessionModel(params: { sessionId: SessionId; modelId: string }): Promise<BackendState> {
@@ -433,6 +479,7 @@ export class AcpBackendProcess implements BackendProcess {
           sessionId: sessionIdToAcp(params.sessionId),
           cwd: params.cwd,
           mcpServers: params.mcpServers.map(mcpServerSpecToAcp),
+          ...this.additionalDirectoriesField(params.additionalDirectories),
         }),
       { mustBeAdvertised: true }
     );
@@ -455,6 +502,7 @@ export class AcpBackendProcess implements BackendProcess {
           sessionId: sessionIdToAcp(params.sessionId),
           cwd: params.cwd,
           mcpServers: params.mcpServers.map(mcpServerSpecToAcp),
+          ...this.additionalDirectoriesField(params.additionalDirectories),
         }),
       { mustBeAdvertised: true }
     );
@@ -474,6 +522,7 @@ export class AcpBackendProcess implements BackendProcess {
     this.domainHandlers.clear();
     this.pendingUpdates.clear();
     this.sessionWireState.clear();
+    this.todoToolCallIdsBySession.clear();
     this.permissionPrompter = null;
     this.capabilities.clear();
     if (this.process) {
@@ -499,6 +548,20 @@ export class AcpBackendProcess implements BackendProcess {
 
   private recordWireState(sessionId: AcpSessionId, wire: SessionWireState): void {
     this.sessionWireState.set(sessionIdFromAcp(sessionId), wire);
+  }
+
+  /**
+   * The todo-tool id tracker for one session, created on first use. Scoping it
+   * per session keeps one session's `todowrite` ids from being honored for
+   * another on this shared backend process (see the field's declaration).
+   */
+  private todoToolCallIdsFor(sessionId: SessionId): Set<string> {
+    let ids = this.todoToolCallIdsBySession.get(sessionId);
+    if (!ids) {
+      ids = new Set<string>();
+      this.todoToolCallIdsBySession.set(sessionId, ids);
+    }
+    return ids;
   }
 
   private computeState(sessionId: AcpSessionId): BackendState {
@@ -555,7 +618,8 @@ export class AcpBackendProcess implements BackendProcess {
       return;
     }
 
-    handler(acpNotificationToEvent(update));
+    for (const event of acpNotificationToEvents(update, this.todoToolCallIdsFor(sessionId)))
+      handler(event);
   }
 
   private async handlePermission(

--- a/src/agentMode/acp/wireTranslate.test.ts
+++ b/src/agentMode/acp/wireTranslate.test.ts
@@ -1,0 +1,184 @@
+import type { SessionNotification } from "@agentclientprotocol/sdk";
+import { acpNotificationToEvents } from "./wireTranslate";
+
+const SESSION_ID = "sess-1";
+
+function notification(update: Record<string, unknown>): SessionNotification {
+  return { sessionId: SESSION_ID, update } as unknown as SessionNotification;
+}
+
+const VALID_TODOS = [
+  { content: "Brainstorm autumn imagery", status: "in_progress", priority: "high" },
+  { content: "Draft the haiku", status: "pending", priority: "high" },
+  { content: "Review and polish", status: "pending", priority: "medium" },
+];
+
+describe("acpNotificationToEvents — todowrite → synthesized plan", () => {
+  it("appends a plan event after a todowrite tool_call carrying rawInput.todos", () => {
+    const events = acpNotificationToEvents(
+      notification({
+        sessionUpdate: "tool_call",
+        toolCallId: "call-1",
+        title: "todowrite",
+        kind: "other",
+        status: "in_progress",
+        rawInput: { todos: VALID_TODOS },
+      })
+    );
+    expect(events).toHaveLength(2);
+    expect(events[0].update.sessionUpdate).toBe("tool_call");
+    expect(events[1].update).toEqual({
+      sessionUpdate: "plan",
+      entries: [
+        { content: "Brainstorm autumn imagery", status: "in_progress", priority: "high" },
+        { content: "Draft the haiku", status: "pending", priority: "high" },
+        { content: "Review and polish", status: "pending", priority: "medium" },
+      ],
+    });
+    expect(events.every((e) => e.sessionId === SESSION_ID)).toBe(true);
+  });
+
+  it("accepts a titleless tool_call_update once its id was registered as todowrite", () => {
+    const ids = new Set<string>();
+    acpNotificationToEvents(
+      notification({
+        sessionUpdate: "tool_call",
+        toolCallId: "call-1",
+        title: "todowrite",
+        rawInput: { todos: VALID_TODOS },
+      }),
+      ids
+    );
+    const events = acpNotificationToEvents(
+      notification({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call-1",
+        rawInput: { todos: VALID_TODOS },
+      }),
+      ids
+    );
+    expect(events).toHaveLength(2);
+    expect(events[1].update.sessionUpdate).toBe("plan");
+  });
+
+  it("rejects updates whose present title is not the native todowrite tool", () => {
+    // Without a tracker, a renamed/foreign title is skipped (its predecessor
+    // already delivered the same list).
+    for (const title of ["3 todos", "bash", "mcp__tracker__todowrite"]) {
+      const events = acpNotificationToEvents(
+        notification({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "call-1",
+          title,
+          rawInput: { todos: VALID_TODOS },
+        })
+      );
+      expect(events).toHaveLength(1);
+    }
+  });
+
+  it("continues synthesizing for a renamed/titleless update once the id is registered", () => {
+    const ids = new Set<string>();
+    // First sight: titled `todowrite` registers the id and synthesizes.
+    const first = acpNotificationToEvents(
+      notification({
+        sessionUpdate: "tool_call",
+        toolCallId: "call-7",
+        title: "todowrite",
+        rawInput: { todos: VALID_TODOS },
+      }),
+      ids
+    );
+    expect(first).toHaveLength(2);
+    // Follow-up renamed "3 todos" for the SAME id still synthesizes.
+    const renamed = acpNotificationToEvents(
+      notification({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call-7",
+        title: "3 todos",
+        rawInput: { todos: [{ content: "Brainstorm autumn imagery", status: "completed" }] },
+      }),
+      ids
+    );
+    expect(renamed).toHaveLength(2);
+    expect(renamed[1].update).toEqual({
+      sessionUpdate: "plan",
+      entries: [{ content: "Brainstorm autumn imagery", status: "completed", priority: "medium" }],
+    });
+  });
+
+  it("does not synthesize for an unregistered id carrying a todos-shaped payload", () => {
+    const ids = new Set<string>();
+    // A foreign tool's titleless update with a todos field must not masquerade.
+    const events = acpNotificationToEvents(
+      notification({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "other-tool",
+        rawInput: { todos: VALID_TODOS },
+      }),
+      ids
+    );
+    expect(events).toHaveLength(1);
+  });
+
+  it("ignores malformed todos and never appends for non-tool updates", () => {
+    expect(
+      acpNotificationToEvents(
+        notification({
+          sessionUpdate: "tool_call",
+          toolCallId: "call-1",
+          title: "todowrite",
+          rawInput: { todos: [{ content: "", status: "pending" }, { status: "in_progress" }, "x"] },
+        })
+      )
+    ).toHaveLength(1);
+    expect(
+      acpNotificationToEvents(
+        notification({
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "hello" },
+        })
+      )
+    ).toHaveLength(1);
+  });
+
+  it("emits an empty plan when a registered todo call reports todos: [] (a clear)", () => {
+    const ids = new Set<string>();
+    // First the list arrives, then the agent clears it with an empty array —
+    // the synth must emit an empty plan so the snapshot resets downstream.
+    acpNotificationToEvents(
+      notification({
+        sessionUpdate: "tool_call",
+        toolCallId: "call-9",
+        title: "todowrite",
+        rawInput: { todos: VALID_TODOS },
+      }),
+      ids
+    );
+    const cleared = acpNotificationToEvents(
+      notification({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "call-9",
+        title: "0 todos",
+        rawInput: { todos: [] },
+      }),
+      ids
+    );
+    expect(cleared).toHaveLength(2);
+    expect(cleared[1].update).toEqual({ sessionUpdate: "plan", entries: [] });
+  });
+
+  it("passes a real plan notification through unchanged as a single event", () => {
+    const events = acpNotificationToEvents(
+      notification({
+        sessionUpdate: "plan",
+        entries: [{ content: "step", status: "pending", priority: "medium" }],
+      })
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].update).toEqual({
+      sessionUpdate: "plan",
+      entries: [{ content: "step", status: "pending", priority: "medium" }],
+    });
+  });
+});

--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -27,6 +27,7 @@ import type {
   ToolKind as AcpToolKind,
 } from "@agentclientprotocol/sdk";
 import type {
+  AgentPlanEntry,
   AgentToolKind,
   AgentToolStatus,
   BackendConfigOption,
@@ -266,11 +267,96 @@ function toolCallDeltaFromAcp(
 
 // ---- Notification → SessionEvent --------------------------------------
 
-export function acpNotificationToEvent(n: SessionNotification): SessionEvent {
-  return {
-    sessionId: sessionIdFromAcp(n.sessionId),
-    update: acpUpdateToSessionUpdate(n.update),
-  };
+/**
+ * One wire notification can yield more than one session event: a `todowrite`
+ * tool call additionally synthesizes the standard `plan` update (see
+ * {@link todoToolPlanFromAcp}), so the trail's PlanPill and the todo snapshot
+ * stay backend-agnostic. The base translation always comes first.
+ *
+ * `todoToolCallIds` is one session's id set, owned by the caller
+ * (AcpBackendProcess keys it per session — see `todoToolCallIdsFor`): the first
+ * `todowrite`-titled tool call registers its id, so later `tool_call_update`s
+ * for the same call still synthesize even after opencode renames the title
+ * (e.g. "3 todos") or drops it. Omit it (tests, replay) to fall back to
+ * title-only recognition.
+ */
+export function acpNotificationToEvents(
+  n: SessionNotification,
+  todoToolCallIds?: Set<string>
+): SessionEvent[] {
+  const sessionId = sessionIdFromAcp(n.sessionId);
+  const events: SessionEvent[] = [{ sessionId, update: acpUpdateToSessionUpdate(n.update) }];
+  const todoPlan = todoToolPlanFromAcp(n.update, todoToolCallIds);
+  if (todoPlan) events.push({ sessionId, update: todoPlan });
+  return events;
+}
+
+/**
+ * opencode reports its execution todo list as a generic `todowrite` tool call
+ * whose `rawInput.todos` carries the full list — current releases (1.17.3)
+ * have NO plan-channel emission at all (verified: binary-string audit + live
+ * probes, designdocs/agent-projects/verify/README.md "Task-list channel").
+ * Synthesize the standard `plan` update from it. Builds that DO emit a real
+ * plan update coexist fine: identical entries dedupe downstream
+ * (`planEntriesEqual` for the message part, signature compare for the
+ * snapshot).
+ *
+ * Tool identity: the initial `tool_call` titles itself `todowrite`; opencode
+ * then mutates follow-up update titles (e.g. "3 todos"). We register the
+ * call's id on first sight (title === todowrite) so subsequent updates for the
+ * same id keep synthesizing regardless of title — and unknown ids are ignored,
+ * so a stray `{todos}` payload from another tool/backend can't masquerade.
+ */
+function todoToolPlanFromAcp(
+  update: SessionNotification["update"],
+  todoToolCallIds?: Set<string>
+): SessionUpdate | null {
+  if (update.sessionUpdate !== "tool_call" && update.sessionUpdate !== "tool_call_update") {
+    return null;
+  }
+  const toolCallId = (update as { toolCallId?: string }).toolCallId;
+  const title = (update as { title?: string | null }).title;
+  const isTodoTitle =
+    title != null &&
+    (() => {
+      const { tool, mcpServer } = resolveToolName(title);
+      return !mcpServer && tool.toLowerCase() === "todowrite";
+    })();
+
+  if (isTodoTitle && toolCallId) todoToolCallIds?.add(toolCallId);
+
+  // Recognized when the title says todowrite, or the id was registered from an
+  // earlier todowrite-titled call. Without a tracker (tests/replay), fall back
+  // to title-only — a renamed follow-up is then skipped, but its predecessor
+  // already delivered the same list.
+  const recognized =
+    isTodoTitle || (toolCallId != null && todoToolCallIds?.has(toolCallId) === true);
+  if (!recognized) return null;
+
+  const todos = (update.rawInput as { todos?: unknown } | undefined)?.todos;
+  if (!Array.isArray(todos)) return null;
+  const entries: AgentPlanEntry[] = [];
+  for (const todo of todos) {
+    if (typeof todo !== "object" || todo === null) continue;
+    const t = todo as { content?: unknown; status?: unknown; priority?: unknown };
+    if (typeof t.content !== "string" || t.content.length === 0) continue;
+    if (t.status !== "pending" && t.status !== "in_progress" && t.status !== "completed") continue;
+    entries.push({
+      content: t.content,
+      status: t.status,
+      priority:
+        t.priority === "high" || t.priority === "medium" || t.priority === "low"
+          ? t.priority
+          : "medium",
+    });
+  }
+  // A recognized todo tool reporting `todos: []` is a genuine clear — emit an
+  // empty plan so the snapshot resets (matching the claude path, which emits an
+  // empty plan when its last task is removed). But a NON-empty array that
+  // filtered down to nothing is malformed input, not a clear: don't wipe a good
+  // list on garbage. (`todos` is already array-guarded above.)
+  if (entries.length === 0 && todos.length > 0) return null;
+  return { sessionUpdate: "plan", entries };
 }
 
 function acpUpdateToSessionUpdate(update: SessionNotification["update"]): SessionUpdate {

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -248,12 +248,17 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
         (await getClaudeAuthStatus(claudePath, claudeChildEnv(getSettings()))).loggedIn,
       isPlanModePlanFilePath: isClaudePlanModePlanFilePath,
       getDefaultModelId: () => getSettings().agentMode?.backends?.claude?.defaultModel?.baseModelId,
-      // Forward the shared composed system prompt — the Copilot base framing
-      // (unless the user disabled it), the pill-syntax directive, and the
-      // user's custom prompt. The SDK appends it to its `claude_code` preset
-      // (see `ClaudeSdkBackendProcess`), so Claude keeps its tool/planning
-      // framing while gaining the Obsidian-vault identity. Re-read per
-      // `newSession()`, so a prompt change applies to the next session.
+      // Compose the shared system prompt — the Copilot base framing (unless the
+      // user disabled it), the pill-syntax directive, and the user's custom
+      // prompt — plus the owning project's instructions when the session is
+      // project-scoped. The SDK resolves the project instructions per session
+      // (via the manager-injected profile provider) and passes the opaque body
+      // here; `backends/shared` never imports the `projects/` layer. The
+      // result appends to Claude's `claude_code` preset (see
+      // `ClaudeSdkBackendProcess`), so Claude keeps its tool/planning framing
+      // while gaining the Obsidian-vault identity. Re-read per `newSession()`,
+      // so a prompt change applies to the next session. A global (no-project)
+      // session passes `undefined`, yielding the byte-identical global prompt.
       //
       // Claude discovers skills natively from `.claude/skills/`, so the payload
       // carries no SKILL.md authoring instructions. Claude has no
@@ -261,7 +266,7 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
       // symlink fanout already enforces visibility (no link = not seen). If the
       // Claude Agent SDK ever grows a per-skill deny hook, wire
       // `composeDenyList(getManagedSkills(), "claude")` in here.
-      getSystemPromptAppend: () => buildAgentSystemPrompt(),
+      getSystemPromptAppend: (opts) => buildAgentSystemPrompt(opts),
     });
   },
 

--- a/src/agentMode/backends/codex/CodexBackend.test.ts
+++ b/src/agentMode/backends/codex/CodexBackend.test.ts
@@ -53,6 +53,7 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
         mcpServers: [],
         activeBackend: "codex",
         debugFullFrames: false,
+        welcomeDismissed: false,
         skills: { folder: "copilot/skills" },
         backends: {
           codex: { binaryPath: "/usr/local/bin/codex-acp" },
@@ -114,6 +115,7 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
         mcpServers: [],
         activeBackend: "codex",
         debugFullFrames: false,
+        welcomeDismissed: false,
         skills: { folder: "team-skills" },
         backends: { codex: { binaryPath: "/usr/local/bin/codex-acp" } },
       },
@@ -179,6 +181,15 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
     );
   });
 
+  it("does not add a project.md fallback to the codex spawn args", async () => {
+    // Session-start ensureAgentsMirror supersedes the spawn-level fallback for project scopes;
+    // omitting it also prevents a GLOBAL session from treating a vault-root project.md note as
+    // codex instructions (the spawn descriptor has no scope to gate on).
+    const backend = new CodexBackend();
+    const desc = await backend.buildSpawnDescriptor({ vaultBasePath: "/vault" });
+    expect(desc.args).not.toContainEqual(expect.stringContaining("project_doc_fallback_filenames"));
+  });
+
   it("throws when the codex binary path is unset", async () => {
     setSettings({
       agentMode: {
@@ -186,6 +197,7 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
         mcpServers: [],
         activeBackend: "codex",
         debugFullFrames: false,
+        welcomeDismissed: false,
         skills: { folder: "copilot/skills" },
         backends: {},
       },

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -59,7 +59,6 @@ export class CodexBackend implements AcpBackend {
     // would also apply to GLOBAL sessions and let codex read a user's vault-root `project.md`
     // note as instructions. On the rare ensure failure a project session gets no instructions
     // (ensure never throws and re-runs next session) rather than the frontmatter-laden source.
-    // If a future review flags the missing fallback, point them here + at the session-start ensure.
     return descriptor;
   }
 }

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -51,6 +51,15 @@ export class CodexBackend implements AcpBackend {
       "-c",
       'sandbox_mode="workspace-write"',
     ];
+    // DESIGN NOTE: deliberately no `project_doc_fallback_filenames=["project.md"]`.
+    // Post-Phase-2 the session-start `ensureAgentsMirror` (AgentSessionManager, run before
+    // `resolveSessionCwd` for codex/opencode project sessions) guarantees the marker'd
+    // `AGENTS.md` mirror exists in the project cwd, so a `project.md` fallback is redundant.
+    // This descriptor only knows `vaultBasePath`, not the session scope: a spawn-level fallback
+    // would also apply to GLOBAL sessions and let codex read a user's vault-root `project.md`
+    // note as instructions. On the rare ensure failure a project session gets no instructions
+    // (ensure never throws and re-runs next session) rather than the frontmatter-laden source.
+    // If a future review flags the missing fallback, point them here + at the session-start ensure.
     return descriptor;
   }
 }

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -1,4 +1,5 @@
 import { ChatModelProviders } from "@/constants";
+import { logWarn } from "@/logger";
 import { getSettings, resetSettings, setSettings, updateSetting } from "@/settings/model";
 import type {
   BackendConfigRegistry,
@@ -555,6 +556,7 @@ describe("buildOpencodeConfig — agent/prompt/mode/skills blocks (preserved)", 
         mcpServers: [],
         activeBackend: "opencode",
         debugFullFrames: false,
+        welcomeDismissed: false,
         skills: { folder: "copilot/skills" },
         backends: {
           opencode: {
@@ -575,6 +577,7 @@ describe("buildOpencodeConfig — agent/prompt/mode/skills blocks (preserved)", 
         mcpServers: [],
         activeBackend: "opencode",
         debugFullFrames: false,
+        welcomeDismissed: false,
         skills: { folder: "copilot/skills" },
         backends: {
           opencode: {
@@ -595,6 +598,7 @@ describe("buildOpencodeConfig — agent/prompt/mode/skills blocks (preserved)", 
         mcpServers: [],
         activeBackend: "opencode",
         debugFullFrames: false,
+        welcomeDismissed: false,
         skills: { folder: "copilot/skills" },
         backends: {
           opencode: { binaryPath: "/x" },
@@ -670,6 +674,7 @@ describe("buildOpencodeConfig — agent/prompt/mode/skills blocks (preserved)", 
         mcpServers: [],
         activeBackend: "opencode",
         debugFullFrames: false,
+        welcomeDismissed: false,
         skills: { folder: "team-skills" },
         backends: {},
       },
@@ -740,11 +745,51 @@ describe("buildOpencodeConfig — agent/prompt/mode/skills blocks (preserved)", 
   });
 });
 
+describe("buildOpencodeConfig — context-cache external_directory allow", () => {
+  beforeEach(() => {
+    resetSettings();
+    seedSkills([]);
+    resetPromptState();
+  });
+
+  type AgentPerm = {
+    agent: Record<string, { permission?: Record<string, unknown> }>;
+  };
+
+  it("injects a cacheRoot-scoped external_directory allow on both spawn agents", async () => {
+    const cfg = (await buildOpencodeConfig(
+      getSettings(),
+      NO_MODELS_DEPS,
+      "/home/u/.obsidian-copilot/vaults/abc123/context-cache"
+    )) as AgentPerm;
+    const allow = {
+      external_directory: {
+        "/home/u/.obsidian-copilot/vaults/abc123/context-cache/**": "allow",
+      },
+    };
+    // build (auto) gets only the external_directory grant — no bash/edit asks.
+    expect(cfg.agent.build.permission).toEqual(allow);
+    // copilot-build (default) keeps its ask-before-write perms AND gains allow.
+    expect(cfg.agent["copilot-build"].permission).toEqual({
+      bash: "ask",
+      edit: "ask",
+      ...allow,
+    });
+  });
+
+  it("injects nothing when no cacheRoot is provided (feature dormant)", async () => {
+    const cfg = (await buildOpencodeConfig(getSettings(), NO_MODELS_DEPS)) as AgentPerm;
+    expect(cfg.agent.build.permission).toBeUndefined();
+    expect(cfg.agent["copilot-build"].permission).toEqual({ bash: "ask", edit: "ask" });
+  });
+});
+
 describe("OpencodeBackend.buildSpawnDescriptor", () => {
   beforeEach(() => {
     resetSettings();
     seedSkills([]);
     resetPromptState();
+    (logWarn as jest.Mock).mockClear();
   });
 
   it("throws if no binary is installed", async () => {
@@ -760,6 +805,7 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
       mcpServers: [],
       activeBackend: "opencode",
       debugFullFrames: false,
+      welcomeDismissed: false,
       skills: { folder: "copilot/skills" },
       backends: {
         opencode: {
@@ -785,6 +831,102 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
     const cfg = JSON.parse(desc.env.OPENCODE_CONFIG_CONTENT as string);
     expect(cfg.provider.anthropic.options).toEqual({ apiKey: "anth-xyz" });
     expect(cfg.provider.anthropic.models).toEqual({ "claude-sonnet-4-6": {} });
+  });
+
+  it("threads the injected getCacheRoot into the spawned external_directory allow", async () => {
+    updateSetting("agentMode", {
+      byok: {},
+      mcpServers: [],
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: { opencode: { binaryPath: "/path/to/opencode" } },
+    });
+    const deps: OpencodeModelDeps = {
+      ...NO_MODELS_DEPS,
+      getCacheRoot: () => "/cache/root",
+    };
+    const backend = new OpencodeBackend(deps);
+    const desc = await backend.buildSpawnDescriptor({ vaultBasePath: "/vault/abs" });
+    const cfg = JSON.parse(desc.env.OPENCODE_CONFIG_CONTENT as string);
+    expect(cfg.agent.build.permission).toEqual({
+      external_directory: { "/cache/root/**": "allow" },
+    });
+    expect(cfg.agent["copilot-build"].permission).toEqual({
+      bash: "ask",
+      edit: "ask",
+      external_directory: { "/cache/root/**": "allow" },
+    });
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("warns when an OPENCODE_CONFIG_CONTENT override would drop the cache allow rule", async () => {
+    updateSetting("agentMode", {
+      byok: {},
+      mcpServers: [],
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: {
+        opencode: {
+          binaryPath: "/path/to/opencode",
+          envOverrides: { OPENCODE_CONFIG_CONTENT: "{}" },
+        },
+      },
+    });
+    const deps: OpencodeModelDeps = {
+      ...NO_MODELS_DEPS,
+      getCacheRoot: () => "/cache/root",
+    };
+    const backend = new OpencodeBackend(deps);
+    await backend.buildSpawnDescriptor({ vaultBasePath: "/vault/abs" });
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("external_directory allow rule is dropped")
+    );
+  });
+
+  it("treats a blank getCacheRoot result as unavailable (no allow rule, no warn)", async () => {
+    updateSetting("agentMode", {
+      byok: {},
+      mcpServers: [],
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: { opencode: { binaryPath: "/path/to/opencode" } },
+    });
+    const deps: OpencodeModelDeps = {
+      ...NO_MODELS_DEPS,
+      getCacheRoot: () => "   ",
+    };
+    const backend = new OpencodeBackend(deps);
+    const desc = await backend.buildSpawnDescriptor({ vaultBasePath: "/vault/abs" });
+    const cfg = JSON.parse(desc.env.OPENCODE_CONFIG_CONTENT as string);
+    expect(cfg.agent.build.permission).toBeUndefined();
+    expect(cfg.agent["copilot-build"].permission).toEqual({ bash: "ask", edit: "ask" });
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn about the override when no cacheRoot is resolved", async () => {
+    updateSetting("agentMode", {
+      byok: {},
+      mcpServers: [],
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: {
+        opencode: {
+          binaryPath: "/path/to/opencode",
+          envOverrides: { OPENCODE_CONFIG_CONTENT: "{}" },
+        },
+      },
+    });
+    const backend = new OpencodeBackend(NO_MODELS_DEPS);
+    await backend.buildSpawnDescriptor({ vaultBasePath: "/vault/abs" });
+    expect(logWarn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -1,5 +1,5 @@
 import { ChatModelProviders } from "@/constants";
-import { logInfo } from "@/logger";
+import { logInfo, logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
 import type { CopilotSettings } from "@/settings/model";
 import { isSelfHostedProvider } from "@/modelManagement";
@@ -57,6 +57,14 @@ export const OPENCODE_CANONICAL_MODE_AGENT_IDS: Partial<Record<CopilotMode, stri
 export interface OpencodeModelDeps {
   providerRegistry: ProviderRegistry;
   backendConfigRegistry: BackendConfigRegistry;
+  /**
+   * Resolves the off-vault shared conversions cache root (absolute path) for
+   * this vault, or `undefined` when unavailable. Injected so this backend never
+   * reimplements vaultId/path derivation — that lives in
+   * `context/conversionsLocation.ts`. When omitted, the opencode
+   * `external_directory` allow rule is simply not injected (feature dormant).
+   */
+  getCacheRoot?: () => string | undefined;
 }
 
 /**
@@ -75,15 +83,47 @@ export class OpencodeBackend implements AcpBackend {
   }
 
   async buildSpawnDescriptor(ctx: { vaultBasePath: string }): Promise<AcpSpawnDescriptor> {
-    const binaryPath = getSettings().agentMode?.backends?.opencode?.binaryPath;
+    const settings = getSettings();
+    const binaryPath = settings.agentMode?.backends?.opencode?.binaryPath;
     if (!binaryPath) {
       throw new Error(
         "opencode binary not installed. Open Agent Mode settings and install it before starting a session."
       );
     }
 
-    const config = await buildOpencodeConfig(getSettings(), this.#deps);
-    const envOverrides = getSettings().agentMode?.backends?.opencode?.envOverrides ?? {};
+    // DESIGN NOTE: opencode only auto-discovers `AGENTS.md` from the session cwd and has no
+    // `project_doc_fallback_filenames` equivalent. The plugin guarantees the file exists by
+    // materializing the generated `AGENTS.md` mirror from the project's `project.md` at session
+    // start (see `ensureAgentsMirror`, called before cwd resolution in AgentSessionManager) —
+    // the same session-start ensure codex now relies on as its sole guarantee (codex's
+    // `project.md` fallback was removed; see the matching note in CodexBackend). Hence opencode
+    // needs no instruction-specific code in this spawn.
+    // The off-vault conversions cache lives outside opencode's `--cwd <vault>`
+    // boundary, so opencode prompts (`external_directory` ask) on every snapshot
+    // read unless we pre-allow it (see `buildOpencodeConfig`). cacheRoot is a
+    // static path with no first-launch window, so resolving it here at spawn is
+    // unconditional. The resolver is injected (from `conversionsLocation`) so
+    // this backend never derives the vault path itself.
+    // Normalize before use: the allow rule is a security boundary, so a blank /
+    // whitespace-only resolver result is treated as "unavailable" explicitly
+    // rather than leaning on downstream truthiness.
+    const cacheRoot = normalizeCacheRoot(this.#deps.getCacheRoot?.());
+    const config = await buildOpencodeConfig(settings, this.#deps, cacheRoot);
+    const envOverrides = settings.agentMode?.backends?.opencode?.envOverrides ?? {};
+    // Accepted degradation: a user `OPENCODE_CONFIG_CONTENT` override (spread
+    // last below) replaces the whole generated config, dropping the allow rule.
+    // opencode then prompts on every snapshot read; the sources still appear in
+    // the manifest. Warn so the lost approval-suppression is diagnosable.
+    if (
+      cacheRoot &&
+      Object.prototype.hasOwnProperty.call(envOverrides, "OPENCODE_CONFIG_CONTENT")
+    ) {
+      logWarn(
+        "[AgentMode] opencode envOverrides.OPENCODE_CONFIG_CONTENT replaces the generated config; " +
+          "the context-cache external_directory allow rule is dropped — opencode will prompt on every " +
+          "snapshot read. Remove that override to restore silent cache access."
+      );
+    }
     // Builtin Copilot Plus skill scripts read the license from the env.
     const plusEnv = await buildCopilotPlusEnv();
 
@@ -100,6 +140,18 @@ export class OpencodeBackend implements AcpBackend {
       },
     };
   }
+}
+
+/**
+ * Trim the injected cache root to a non-empty path, or `undefined`. The resolver
+ * contract (`conversionsLocation.cacheRoot`) is to return an ABSOLUTE
+ * context-cache root; absoluteness is the resolver's guarantee, but we refuse to
+ * emit an `external_directory` grant for a blank value so the security boundary
+ * never depends on bare truthiness of an empty string.
+ */
+function normalizeCacheRoot(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed ? trimmed : undefined;
 }
 
 /** Mutable opencode provider config entry built into `OPENCODE_CONFIG_CONTENT`. */
@@ -122,7 +174,8 @@ type ProviderConfig = {
  */
 export async function buildOpencodeConfig(
   s: CopilotSettings,
-  deps: OpencodeModelDeps
+  deps: OpencodeModelDeps,
+  cacheRoot?: string
 ): Promise<Record<string, unknown>> {
   const { providerRegistry, backendConfigRegistry } = deps;
 
@@ -249,13 +302,31 @@ export async function buildOpencodeConfig(
   // `restartOnSystemPromptChange`.
   const skillManagerReady = SkillManager.hasInstance();
   const prompt = buildAgentSystemPrompt();
+
+  // Pre-allow reads of the off-vault shared conversions cache so opencode
+  // doesn't fire an `external_directory` ask on every snapshot the manifest
+  // points at. The glob is matched against the requested absolute path;
+  // `/**` covers the nested `remotes/`, `files/`, and `markers/` subtrees.
+  // Scoped to cacheRoot only — never a broader grant. Injected on BOTH agents
+  // we ever spawn as (`copilot-build` = default, `build` = auto). For the
+  // native `build` agent this only adds the external_directory key — bash/edit
+  // stay at opencode's permissive defaults, so it does not start asking.
+  //
+  // NOTE (version-sensitive, pinned opencode 1.15.13): the `external_directory`
+  // permission key and the `{ "<glob>": "allow" }` shape are confirmed against
+  // 1.15.13; re-verify when the pinned opencode version changes.
+  const externalDirectoryPermission = cacheRoot
+    ? { external_directory: { [`${cacheRoot}/**`]: "allow" } }
+    : undefined;
+
   config.agent = {
     [OPENCODE_BUILTIN_BUILD_AGENT_ID]: {
+      ...(externalDirectoryPermission ? { permission: externalDirectoryPermission } : {}),
       prompt,
     },
     [OPENCODE_COPILOT_BUILD_AGENT_ID]: {
       mode: "primary",
-      permission: { bash: "ask", edit: "ask" },
+      permission: { bash: "ask", edit: "ask", ...externalDirectoryPermission },
       prompt,
     },
   };

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -26,6 +26,7 @@ import { OpencodeSettingsPanel } from "./OpencodeSettingsPanel";
 import { resolveOpencodeBinary } from "./opencodeBinaryResolver";
 import { mapNodeArch, mapNodePlatform } from "./platformResolver";
 import { detectBinary } from "@/utils/detectBinary";
+import { cacheRoot } from "@/context/conversionsLocation";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { simpleBinaryBackendProcess } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import type {
@@ -295,7 +296,14 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
     const { providerRegistry, backendConfigRegistry } = args.plugin.modelManagement;
     return simpleBinaryBackendProcess(
       args,
-      new OpencodeBackend({ providerRegistry, backendConfigRegistry })
+      new OpencodeBackend({
+        providerRegistry,
+        backendConfigRegistry,
+        // Activates the opencode external_directory allow rule for the off-vault
+        // shared conversions cache. vaultId/path derivation lives entirely in
+        // conversionsLocation — this backend never duplicates it.
+        getCacheRoot: () => cacheRoot(args.plugin.app),
+      })
     );
   },
 

--- a/src/agentMode/backends/shared/agentSystemPrompt.test.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.test.ts
@@ -146,6 +146,54 @@ describe("buildAgentSystemPrompt", () => {
     const prompt = buildAgentSystemPrompt();
     expect(prompt).not.toContain(COPILOT_MIYO_SEARCH_STEERING);
   });
+
+  describe("project instructions (global parity gate)", () => {
+    it("is byte-identical to the no-arg form when projectInstructions is absent/empty/blank", () => {
+      const baseline = buildAgentSystemPrompt();
+      // The global (no-project) parity guarantee: every "no instructions"
+      // spelling must produce the exact same payload as today's no-arg call.
+      expect(buildAgentSystemPrompt({})).toBe(baseline);
+      expect(buildAgentSystemPrompt({ projectInstructions: undefined })).toBe(baseline);
+      expect(buildAgentSystemPrompt({ projectInstructions: "" })).toBe(baseline);
+      expect(buildAgentSystemPrompt({ projectInstructions: "   \n\t " })).toBe(baseline);
+    });
+
+    it("wraps the trimmed project instructions in <project_instructions> as the final section", () => {
+      const baseline = buildAgentSystemPrompt();
+      const prompt = buildAgentSystemPrompt({
+        projectInstructions: "  Only cite notes tagged #verified.  ",
+      });
+      // Existing payload is untouched and stays the prefix; the project body is
+      // appended after a blank-line delimiter, wrapped like the user block.
+      expect(prompt).toBe(
+        `${baseline}\n\n<project_instructions>\nOnly cite notes tagged #verified.\n</project_instructions>`
+      );
+    });
+
+    it("appends project instructions even when the builtin prompt is disabled", () => {
+      setDisableBuiltinSystemPrompt(true);
+      const baseline = buildAgentSystemPrompt();
+      const prompt = buildAgentSystemPrompt({ projectInstructions: "project body" });
+      expect(prompt).toBe(
+        `${baseline}\n\n<project_instructions>\nproject body\n</project_instructions>`
+      );
+      expect(prompt.endsWith("</project_instructions>")).toBe(true);
+    });
+
+    it("places project instructions after the user custom prompt", () => {
+      updateCachedSystemPrompts([makePrompt("Haiku", "respond in haiku")]);
+      setSelectedPromptTitle("Haiku");
+      const prompt = buildAgentSystemPrompt({ projectInstructions: "PROJECT BODY" });
+      expect(prompt.indexOf("</user_custom_instructions>")).toBeLessThan(
+        prompt.indexOf("<project_instructions>")
+      );
+    });
+
+    it("never emits a <project_context> block in the system prompt (it rides the first user prompt now)", () => {
+      const prompt = buildAgentSystemPrompt({ projectInstructions: "PROJECT BODY" });
+      expect(prompt).not.toContain("<project_context>");
+    });
+  });
 });
 
 describe("COPILOT_PROMPT_BASE", () => {

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -124,8 +124,25 @@ export const COPILOT_PROMPT_BASE = `You are Obsidian Copilot, an AI assistant th
  * `getEffectiveUserPrompt`) at call time. Backends call this at their natural
  * prompt-injection point — spawn time for opencode/codex, `newSession()` for
  * the Claude SDK — so a settings change applies to the next session.
+ *
+ * `opts.projectInstructions` is the owning project's composed instruction
+ * body — the built-in project policy layered ahead of the user's `project.md`
+ * body (an opaque string the caller resolves via
+ * `getComposedProjectInstructions`; this module never touches the `projects/`
+ * layer). When absent or blank the output is byte-identical to the no-project
+ * prompt — the global (no-project) parity guarantee. When present it is
+ * wrapped in `<project_instructions>` (mirroring `<user_custom_instructions>`)
+ * as the final section, after the user's custom prompt. codex/opencode get the
+ * same composed body for free via native `AGENTS.md` discovery from the
+ * session cwd; this append is the Claude SDK's equivalent, since it has no
+ * cwd-discovery channel.
+ *
+ * Project *file context* (folders/notes/URLs) is NOT part of the system prompt:
+ * it is delivered as a `<project_context>` block inlined into the session's
+ * first user message (reachable by all three backends), built by the context
+ * materializer's `buildProjectContextBlock`.
  */
-export function buildAgentSystemPrompt(): string {
+export function buildAgentSystemPrompt(opts?: { projectInstructions?: string }): string {
   const parts: string[] = [];
 
   // The "Disable builtin system prompt" toggle suppresses only the Copilot
@@ -147,6 +164,15 @@ export function buildAgentSystemPrompt(): string {
     if (shouldUseMiyo(getSettings())) {
       parts.push(COPILOT_MIYO_SEARCH_STEERING);
     }
+    // Extensibility seam — todo/plan steering. Today `AGENT_TODO_PLANNING_STEERING`
+    // is injected ONLY in Project scope (via `composeProjectInstructions`), so this
+    // global prompt stays byte-identical for no-project sessions. To make todo
+    // planning global: push it here AND remove it from `composeProjectInstructions`
+    // — otherwise a Project session receives the section twice (once globally, once
+    // via `<project_instructions>` / AGENTS.md). Note the placement decision: pushing
+    // it INSIDE this `!getDisableBuiltinSystemPrompt()` branch ties it to the "Disable
+    // builtin system prompt" toggle (so those users lose Project todo steering too);
+    // push it OUTSIDE the branch if todo planning should survive that toggle.
   }
 
   parts.push(buildPillSyntaxDirective());
@@ -154,6 +180,15 @@ export function buildAgentSystemPrompt(): string {
   const userPrompt = getEffectiveUserPrompt().trim();
   if (userPrompt) {
     parts.push(`<user_custom_instructions>\n${userPrompt}\n</user_custom_instructions>`);
+  }
+
+  // Optional project-instructions block, last. Absent/blank → nothing pushed,
+  // so the global (no-project) prompt stays byte-identical. Wrapped in
+  // `<project_instructions>`, mirroring the `<user_custom_instructions>` block
+  // above — the plugin's convention for tagging opaque user content.
+  const projectInstructions = opts?.projectInstructions?.trim();
+  if (projectInstructions) {
+    parts.push(`<project_instructions>\n${projectInstructions}\n</project_instructions>`);
   }
 
   return parts.join("\n\n");

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -1,4 +1,4 @@
-import { type App, FileSystemAdapter, Platform } from "obsidian";
+import { type App, Platform } from "obsidian";
 import os from "node:os";
 import * as path from "node:path";
 import type CopilotPlugin from "@/main";
@@ -6,8 +6,7 @@ import { logError } from "@/logger";
 import { DEFAULT_SKILLS_FOLDER } from "@/constants";
 import { getSettings, subscribeToSettingsChange, type CopilotSettings } from "@/settings/model";
 import { subscribeToSystemPromptChange } from "@/system-prompts/state";
-import { copilotAppDataDir } from "@/utils/appPaths";
-import { md5 } from "@/utils/hash";
+import { copilotAppDataDir, getVaultId } from "@/utils/appPaths";
 import { buildAgentSystemPrompt } from "./backends/shared/agentSystemPrompt";
 import { backendRegistry, listBackendDescriptors } from "./backends/registry";
 import type { BackendId } from "./session/types";
@@ -165,9 +164,7 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   // entries and write conflicts across synced devices (iCloud/Syncthing/
   // Obsidian Sync). Scoped by a vault id (hash of the vault path) so vaults
   // don't share one file. Agent Mode is desktop-only, so Node fs is fine.
-  const vaultAdapter = app.vault.adapter;
-  const vaultBasePath = vaultAdapter instanceof FileSystemAdapter ? vaultAdapter.getBasePath() : "";
-  const vaultId = vaultBasePath ? md5(vaultBasePath).slice(0, 8) : "default";
+  const vaultId = getVaultId(app);
   const indexPath = path.join(
     copilotAppDataDir(os.homedir()),
     "vaults",

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -608,6 +608,178 @@ function errorResultMessage(errors: string[]): SDKMessage {
   };
 }
 
+describe("ClaudeSdkBackendProcess project profile provider", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    createSdkMcpServerMock.mockClear();
+  });
+
+  // Echoes the resolved project instructions so a test can read back exactly
+  // what the SDK passed to `getSystemPromptAppend` per session. Mirrors the
+  // descriptor's real `(opts) => buildAgentSystemPrompt(opts)`.
+  const echoAppend = (opts?: { projectInstructions?: string }): string => {
+    const parts = ["BASE"];
+    if (opts?.projectInstructions) parts.push(opts.projectInstructions);
+    return parts.join("\n\n");
+  };
+
+  function makeProc(getSystemPromptAppend: (opts?: { projectInstructions?: string }) => string) {
+    return new ClaudeSdkBackendProcess({
+      pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: { vault: {} } as any,
+      clientVersion: "1.2.3",
+      descriptor: fakeDescriptor(),
+      getSystemPromptAppend,
+    });
+  }
+
+  function appendOf(callIndex: number): unknown {
+    const opts = (getPromptQueryCalls()[callIndex][0] as { options: Record<string, unknown> })
+      .options;
+    return (opts.systemPrompt as { append?: unknown } | undefined)?.append;
+  }
+
+  it("global parity: an unset provider resolves the byte-identical no-project append", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const proc = makeProc(echoAppend);
+
+    // No provider wired, no projectId → same as today's global path.
+    const { sessionId } = await proc.newSession({ cwd: "/vault", mcpServers: [] });
+    proc.registerSessionHandler(sessionId, () => {});
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    expect(appendOf(0)).toBe("BASE");
+  });
+
+  it("global parity: GLOBAL_SCOPE / unknown project (provider returns undefined) yields the global append", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const proc = makeProc(echoAppend);
+    proc.setProjectProfileProvider(() => undefined);
+
+    const { sessionId } = await proc.newSession({
+      cwd: "/vault",
+      mcpServers: [],
+      projectId: "__global__",
+    });
+    proc.registerSessionHandler(sessionId, () => {});
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    expect(appendOf(0)).toBe("BASE");
+  });
+
+  it("appends the owning project's instructions when the provider resolves a profile", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const proc = makeProc(echoAppend);
+    proc.setProjectProfileProvider((id) =>
+      id === "proj-1" ? { id, systemPrompt: "Cite only #verified notes." } : undefined
+    );
+
+    const { sessionId } = await proc.newSession({
+      cwd: "/vault",
+      mcpServers: [],
+      projectId: "proj-1",
+    });
+    proc.registerSessionHandler(sessionId, () => {});
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    expect(appendOf(0)).toBe("BASE\n\nCite only #verified notes.");
+  });
+
+  it("resolves each session's own project on one process (per-session, not process-global)", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const proc = makeProc(echoAppend);
+    proc.setProjectProfileProvider((id) => {
+      if (id === "proj-A") return { id, systemPrompt: "A rules" };
+      if (id === "proj-B") return { id, systemPrompt: "B rules" };
+      return undefined;
+    });
+
+    const a = await proc.newSession({ cwd: "/vault", mcpServers: [], projectId: "proj-A" });
+    const b = await proc.newSession({ cwd: "/vault", mcpServers: [], projectId: "proj-B" });
+    proc.registerSessionHandler(a.sessionId, () => {});
+    proc.registerSessionHandler(b.sessionId, () => {});
+
+    await proc.prompt({ sessionId: a.sessionId, prompt: [{ type: "text", text: "hi" }] });
+    await proc.prompt({ sessionId: b.sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    // The two prompt calls carry each session's own project instructions.
+    expect(appendOf(0)).toBe("BASE\n\nA rules");
+    expect(appendOf(1)).toBe("BASE\n\nB rules");
+  });
+
+  it("captures project instructions at newSession, ignoring later provider swaps mid-session", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const proc = makeProc(echoAppend);
+    proc.setProjectProfileProvider((id) =>
+      id === "proj-1" ? { id, systemPrompt: "ORIGINAL" } : undefined
+    );
+
+    const { sessionId } = await proc.newSession({
+      cwd: "/vault",
+      mcpServers: [],
+      projectId: "proj-1",
+    });
+    proc.registerSessionHandler(sessionId, () => {});
+    // Swap the provider after the session exists; the captured append must win.
+    proc.setProjectProfileProvider((id) =>
+      id === "proj-1" ? { id, systemPrompt: "CHANGED" } : undefined
+    );
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    expect(appendOf(0)).toBe("BASE\n\nORIGINAL");
+  });
+});
+
+describe("ClaudeSdkBackendProcess additional directories", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    createSdkMcpServerMock.mockClear();
+  });
+
+  function makeProc() {
+    return new ClaudeSdkBackendProcess({
+      pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: { vault: {} } as any,
+      clientVersion: "1.2.3",
+      descriptor: fakeDescriptor(),
+    });
+  }
+
+  it("reports support for additionalDirectories (stable SDK option)", () => {
+    expect(makeProc().supportsAdditionalDirectories()).toBe(true);
+  });
+
+  it("forwards captured additionalDirectories into options on every turn", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const proc = makeProc();
+
+    const { sessionId } = await proc.newSession({
+      cwd: "/vault",
+      mcpServers: [],
+      additionalDirectories: ["/abs/context-a", "/abs/context-b"],
+    });
+    proc.registerSessionHandler(sessionId, () => {});
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    const call = getPromptQueryCalls()[0][0] as { options: { additionalDirectories?: string[] } };
+    expect(call.options.additionalDirectories).toEqual(["/abs/context-a", "/abs/context-b"]);
+  });
+
+  it("omits additionalDirectories from options when none were captured", async () => {
+    queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+    const proc = makeProc();
+
+    const { sessionId } = await proc.newSession({ cwd: "/vault", mcpServers: [] });
+    proc.registerSessionHandler(sessionId, () => {});
+    await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+    const call = getPromptQueryCalls()[0][0] as { options: { additionalDirectories?: string[] } };
+    expect(call.options.additionalDirectories).toBeUndefined();
+  });
+});
+
 describe("ClaudeSdkBackendProcess.prompt auth gate", () => {
   beforeEach(() => {
     queryMock.mockReset();

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -46,6 +46,7 @@ import type {
   OpenSessionOutput,
   PermissionDecision,
   PermissionPrompt,
+  ProjectProfile,
   PromptInput,
   PromptOutput,
   ResumeSessionInput,
@@ -55,7 +56,9 @@ import type {
   SessionUpdateHandler,
   StopReason,
 } from "@/agentMode/session/types";
+import type { ProjectScopeId } from "@/agentMode/session/scope";
 import { AuthRequiredError, MethodUnsupportedError } from "@/agentMode/session/errors";
+import { createClaudeTaskPlanState, type ClaudeTaskPlanState } from "./claudeTodoPlan";
 import { createTranslatorState, mapStopReason, translateSdkMessage } from "./sdkMessageTranslator";
 import { PermissionBridge, type AskUserQuestionPrompter } from "./permissionBridge";
 import {
@@ -76,6 +79,14 @@ import { guardSdkStreamStall } from "./sdkStreamStallGuard";
 interface SessionState {
   cwd: string | null;
   /**
+   * Scope this session belongs to, captured from the Open/Resume input so the
+   * SDK can resolve the owning project's instructions. One claude process can
+   * host many sessions across different projects; the projectId lives per
+   * session (not process-global) so each resolves its own instructions.
+   * `undefined` / `GLOBAL_SCOPE` means the implicit global workspace.
+   */
+  projectId?: ProjectScopeId;
+  /**
    * Drives whether the next `query()` passes `resume: <sessionId>` (continue
    * the persisted conversation) or `sessionId: <ourId>` (mint a new SDK-side
    * session with our pre-allocated id).
@@ -91,6 +102,18 @@ interface SessionState {
    */
   effort?: EffortLevel;
   mcpServers: Record<string, McpServerConfig>;
+  /**
+   * Absolute extra workspace roots captured from the Open/Resume input,
+   * forwarded into `options.additionalDirectories` on every `query()` for this
+   * session. The SDK option is stable (`sdk.d.ts`), so unlike the ACP backends
+   * this needs no capability gate. Absent / empty means cwd is the only root.
+   */
+  additionalDirectories?: string[];
+  /**
+   * Session-lived todo/Task accumulator shared across this session's queries
+   * (translator state is per-query; Task ids must survive turns).
+   */
+  claudeTaskPlan: ClaudeTaskPlanState;
   active?: Query;
   /**
    * Snapshot of the composed Copilot system prompt (base framing + pill-syntax
@@ -131,8 +154,14 @@ export interface ClaudeSdkBackendProcessOptions {
    * + user custom prompt). Read once per `newSession()` so a settings change
    * applies to the next session rather than mid-turn. Empty string / undefined
    * disables the append.
+   *
+   * `projectInstructions` is the owning project's resolved instruction body
+   * (from {@link setProjectProfileProvider}); the descriptor composes it into
+   * the append. An omitted object, or one whose `projectInstructions` is
+   * `undefined` (no project / GLOBAL_SCOPE / unset provider), yields the
+   * byte-identical global prompt.
    */
-  getSystemPromptAppend?: () => string | undefined;
+  getSystemPromptAppend?: (opts?: { projectInstructions?: string }) => string | undefined;
   /**
    * User-defined env vars merged onto `process.env` for the spawned `claude`
    * CLI. Read per `prompt()` so settings edits apply on the next turn.
@@ -176,6 +205,15 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     null;
   private askUserQuestionPrompter: AskUserQuestionPrompter | null = null;
   private isReadOnlySession: ((sessionId: SessionId) => boolean) | null = null;
+  /**
+   * Resolves a session's owning-project instructions by scope id. Injected by
+   * the manager via {@link setProjectProfileProvider} (mirrors the prompter
+   * setters). Null until wired, and returns `undefined` for `GLOBAL_SCOPE` /
+   * unknown projects — both paths fall back to the global prompt.
+   */
+  private projectProfileProvider:
+    | ((projectId: ProjectScopeId) => ProjectProfile | undefined)
+    | null = null;
   private exitListeners = new Set<() => void>();
   private shuttingDown = false;
   private readonly bridge: PermissionBridge;
@@ -225,6 +263,24 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     this.askUserQuestionPrompter = fn;
   }
 
+  setProjectProfileProvider(fn: (projectId: ProjectScopeId) => ProjectProfile | undefined): void {
+    this.projectProfileProvider = fn;
+  }
+
+  /**
+   * Compose this session's system-prompt append, resolving the owning
+   * project's instructions (if any). A defined non-global `projectId` consults
+   * the injected provider; `undefined` projectId, an unset provider, or a
+   * provider that returns `undefined` (GLOBAL_SCOPE / unknown project) all
+   * yield no project instructions → the append is byte-identical to the global
+   * (no-project) prompt. Captured at `newSession`/`resumeSession` time so a
+   * settings change applies to the next session, not mid-conversation.
+   */
+  private resolveSystemPromptAppend(projectId: ProjectScopeId | undefined): string {
+    const profile = projectId !== undefined ? this.projectProfileProvider?.(projectId) : undefined;
+    return this.opts.getSystemPromptAppend?.({ projectInstructions: profile?.systemPrompt }) ?? "";
+  }
+
   registerSessionHandler(sessionId: SessionId, handler: SessionUpdateHandler): () => void {
     this.sessionHandlers.set(sessionId, handler);
     const buffered = this.pendingUpdates.get(sessionId);
@@ -246,7 +302,11 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
   }
 
   async newSession(params: OpenSessionInput): Promise<OpenSessionOutput> {
-    logSdkOutbound("newSession", { cwd: params.cwd, mcpServers: params.mcpServers });
+    logSdkOutbound("newSession", {
+      cwd: params.cwd,
+      mcpServers: params.mcpServers,
+      projectId: params.projectId ?? null,
+    });
     const sessionId = uuidv4();
     const cwd = params.cwd ?? null;
     const mcp: Record<string, McpServerConfig> = {};
@@ -263,10 +323,13 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
 
     this.sessions.set(sessionId, {
       cwd,
+      projectId: params.projectId,
       firstPromptStarted: false,
       mcpServers: mcp,
       model: seedModelId,
-      systemPromptAppend: this.opts.getSystemPromptAppend?.() ?? "",
+      additionalDirectories: params.additionalDirectories,
+      systemPromptAppend: this.resolveSystemPromptAppend(params.projectId),
+      claudeTaskPlan: createClaudeTaskPlanState(),
     });
 
     const state = this.computeState(sessionId);
@@ -337,6 +400,12 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     if (session.model) options.model = session.model;
     if (session.permissionMode) options.permissionMode = session.permissionMode;
     if (session.effort) options.effort = session.effort;
+    // Widen the agent's searchable roots beyond cwd. The SDK option is stable,
+    // so this is forwarded unconditionally (no capability gate) whenever the
+    // session captured extra roots at open/resume.
+    if (session.additionalDirectories?.length) {
+      options.additionalDirectories = session.additionalDirectories;
+    }
     // Keep the toggle authoritative. Leaving `thinking` unset when off lets the
     // model's default take over — Sonnet 4.6 / Opus 4.6 default to adaptive
     // "summarized", so reasoning keeps streaming — so disable it explicitly.
@@ -390,7 +459,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
       onStall: (idleMs) => logSdkError("←", "stream:stalled", { idleMs }, params.sessionId),
     });
 
-    const translatorState = createTranslatorState();
+    const translatorState = createTranslatorState(session.claudeTaskPlan);
     let stopReason: StopReason = "end_turn";
     let resultErrorMessage: string | null = null;
     try {
@@ -635,7 +704,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
   async resumeSession(params: ResumeSessionInput): Promise<ResumeSessionOutput> {
     logSdkOutbound(
       "resumeSession",
-      { cwd: params.cwd, mcpServers: params.mcpServers },
+      { cwd: params.cwd, mcpServers: params.mcpServers, projectId: params.projectId ?? null },
       params.sessionId
     );
     const cwd = params.cwd ?? null;
@@ -650,10 +719,13 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
 
     this.sessions.set(params.sessionId, {
       cwd,
+      projectId: params.projectId,
       firstPromptStarted: true,
       mcpServers: mcp,
       model: seedModelId,
-      systemPromptAppend: this.opts.getSystemPromptAppend?.() ?? "",
+      additionalDirectories: params.additionalDirectories,
+      systemPromptAppend: this.resolveSystemPromptAppend(params.projectId),
+      claudeTaskPlan: createClaudeTaskPlanState(),
     });
 
     const state = this.computeState(params.sessionId);
@@ -673,6 +745,15 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
   }
 
   supportsMcpTransport(_transport: "http" | "sse"): boolean {
+    return true;
+  }
+
+  /**
+   * The SDK's `options.additionalDirectories` is a stable option (`sdk.d.ts`),
+   * so the Claude backend always honors widened roots — no capability probe is
+   * needed (unlike the ACP backends, which gate on an experimental wire field).
+   */
+  supportsAdditionalDirectories(): boolean {
     return true;
   }
 

--- a/src/agentMode/sdk/claudeSessionTranscript.ts
+++ b/src/agentMode/sdk/claudeSessionTranscript.ts
@@ -100,7 +100,7 @@ function joinTextBlocks(content: ContentBlock[]): string {
 
 /**
  * Unwrap the plugin's `<user-message>…</user-message>` envelope so the stored
- * prompt (which prepends a `<copilot-context>` block when notes are attached)
+ * prompt (which prepends an `<attached_context>` block when notes are attached)
  * displays as just what the user typed. Returns the input unchanged when no
  * wrapper is present (prompts sent without attached context aren't wrapped).
  */

--- a/src/agentMode/sdk/claudeSessionTranscript.ts
+++ b/src/agentMode/sdk/claudeSessionTranscript.ts
@@ -100,7 +100,7 @@ function joinTextBlocks(content: ContentBlock[]): string {
 
 /**
  * Unwrap the plugin's `<user-message>…</user-message>` envelope so the stored
- * prompt (which prepends an `<attached_context>` block when notes are attached)
+ * prompt (which prepends a `<copilot-context>` block when notes are attached)
  * displays as just what the user typed. Returns the input unchanged when no
  * wrapper is present (prompts sent without attached context aren't wrapped).
  */

--- a/src/agentMode/sdk/claudeTodoPlan.test.ts
+++ b/src/agentMode/sdk/claudeTodoPlan.test.ts
@@ -1,0 +1,284 @@
+import {
+  createClaudeTaskPlanState,
+  planUpdateFromClaudeToolResult,
+  planUpdateFromClaudeToolUse,
+} from "./claudeTodoPlan";
+
+function entriesOf(update: ReturnType<typeof planUpdateFromClaudeToolUse>) {
+  expect(update).not.toBeNull();
+  if (update?.sessionUpdate !== "plan") throw new Error("expected a plan update");
+  return update.entries;
+}
+
+describe("claudeTodoPlan — TodoWrite whole-list shape", () => {
+  it("converts input.todos into plan entries with stable content text", () => {
+    const state = createClaudeTaskPlanState();
+    const update = planUpdateFromClaudeToolUse(state, "tu1", "TodoWrite", {
+      todos: [
+        { content: "Brainstorm imagery", status: "in_progress", activeForm: "Brainstorming" },
+        { content: "Draft haiku", status: "pending", activeForm: "Drafting" },
+      ],
+    });
+    expect(entriesOf(update)).toEqual([
+      { content: "Brainstorm imagery", status: "in_progress", priority: "medium" },
+      { content: "Draft haiku", status: "pending", priority: "medium" },
+    ]);
+  });
+
+  it("filters malformed items and returns null when nothing valid remains", () => {
+    const state = createClaudeTaskPlanState();
+    expect(
+      planUpdateFromClaudeToolUse(state, "tu1", "TodoWrite", {
+        todos: [{ content: "", status: "pending" }, { content: "x", status: "bogus" }, "junk"],
+      })
+    ).toBeNull();
+    expect(planUpdateFromClaudeToolUse(state, "tu1", "TodoWrite", { todos: "nope" })).toBeNull();
+  });
+
+  it("suppresses re-emission of an identical list (streaming injection points)", () => {
+    const state = createClaudeTaskPlanState();
+    const input = { todos: [{ content: "a", status: "pending" }] };
+    expect(planUpdateFromClaudeToolUse(state, "tu1", "TodoWrite", input)).not.toBeNull();
+    expect(planUpdateFromClaudeToolUse(state, "tu1", "TodoWrite", input)).toBeNull();
+  });
+
+  it("clears the snapshot on a genuine empty list but not on all-malformed input", () => {
+    const state = createClaudeTaskPlanState();
+    planUpdateFromClaudeToolUse(state, "tu1", "TodoWrite", {
+      todos: [{ content: "a", status: "pending" }],
+    });
+    // A non-empty array that filters to nothing is garbage — keep the good list.
+    expect(
+      planUpdateFromClaudeToolUse(state, "tu2", "TodoWrite", {
+        todos: [{ content: "", status: "pending" }],
+      })
+    ).toBeNull();
+    // A real `todos: []` is a clear — emit empty entries to reset downstream.
+    expect(planUpdateFromClaudeToolUse(state, "tu3", "TodoWrite", { todos: [] })).toEqual({
+      sessionUpdate: "plan",
+      entries: [],
+    });
+  });
+});
+
+describe("claudeTodoPlan — Task tools split shape", () => {
+  it("accumulates TaskCreate → tool_result id binding → TaskUpdate status changes", () => {
+    const state = createClaudeTaskPlanState();
+    // Creates carry no id yet — nothing to show until the result binds one.
+    expect(
+      planUpdateFromClaudeToolUse(state, "tuA", "TaskCreate", {
+        subject: "Brainstorm imagery",
+        activeForm: "Brainstorming",
+      })
+    ).toBeNull();
+    const afterBind = planUpdateFromClaudeToolResult(state, "tuA", {
+      task: { id: "1", subject: "Brainstorm imagery" },
+    });
+    expect(entriesOf(afterBind)).toEqual([
+      { content: "Brainstorm imagery", status: "pending", priority: "medium" },
+    ]);
+
+    expect(
+      planUpdateFromClaudeToolUse(state, "tuB", "TaskCreate", { subject: "Draft" })
+    ).toBeNull();
+    planUpdateFromClaudeToolResult(state, "tuB", { task: { id: "2", subject: "Draft" } });
+
+    const afterUpdate = planUpdateFromClaudeToolUse(state, "tuC", "TaskUpdate", {
+      taskId: "1",
+      status: "in_progress",
+    });
+    expect(entriesOf(afterUpdate)).toEqual([
+      { content: "Brainstorm imagery", status: "in_progress", priority: "medium" },
+      { content: "Draft", status: "pending", priority: "medium" },
+    ]);
+  });
+
+  it("binds ids from every observed tool_result shape (incl. the real `Task #N` string)", () => {
+    for (const content of [
+      // The shape real claude CLIs (>= 2.1.142) actually emit.
+      "Task #1 created successfully: keep",
+      [{ type: "text", text: "Task #1 created successfully: keep" }],
+      // Object / JSON shapes kept for forward-compat with other CLI versions.
+      { task: { id: "k", subject: "keep" } },
+      JSON.stringify({ task: { id: "k", subject: "keep" } }),
+      [{ type: "text", text: JSON.stringify({ task: { id: "k", subject: "keep" } }) }],
+    ]) {
+      const state = createClaudeTaskPlanState();
+      planUpdateFromClaudeToolUse(state, "tu", "TaskCreate", { subject: "keep" });
+      const update = planUpdateFromClaudeToolResult(state, "tu", content);
+      expect(entriesOf(update)).toEqual([
+        { content: "keep", status: "pending", priority: "medium" },
+      ]);
+    }
+  });
+
+  it("binds the `#N` ordinal from the real string result and resolves TaskUpdate by it", () => {
+    const state = createClaudeTaskPlanState();
+    planUpdateFromClaudeToolUse(state, "tu1", "TaskCreate", { subject: "Choose theme" });
+    // Real CLI result is a human string; the id is the `#N` ordinal, and the
+    // echoed subject is ignored in favor of the authoritative pending subject.
+    const bound = planUpdateFromClaudeToolResult(
+      state,
+      "tu1",
+      "Task #1 created successfully: Choose theme (echoed copy)"
+    );
+    expect(entriesOf(bound)).toEqual([
+      { content: "Choose theme", status: "pending", priority: "medium" },
+    ]);
+    // TaskUpdate references that same ordinal `"1"` — the link that was broken
+    // when the string result couldn't be parsed into an id.
+    const updated = planUpdateFromClaudeToolUse(state, "tu2", "TaskUpdate", {
+      taskId: "1",
+      status: "completed",
+    });
+    expect(entriesOf(updated)).toEqual([
+      { content: "Choose theme", status: "completed", priority: "medium" },
+    ]);
+  });
+
+  it("TaskUpdate deleted removes the entry; unknown ids and unparseable results are ignored", () => {
+    const state = createClaudeTaskPlanState();
+    planUpdateFromClaudeToolUse(state, "a", "TaskCreate", { subject: "keep" });
+    planUpdateFromClaudeToolResult(state, "a", { task: { id: "k" } });
+    planUpdateFromClaudeToolUse(state, "b", "TaskCreate", { subject: "drop" });
+    planUpdateFromClaudeToolResult(state, "b", { task: { id: "d" } });
+
+    // Unknown id / unmatched result: no emission, no state change.
+    expect(
+      planUpdateFromClaudeToolUse(state, "x", "TaskUpdate", {
+        taskId: "ghost",
+        status: "completed",
+      })
+    ).toBeNull();
+    expect(
+      planUpdateFromClaudeToolResult(state, "never-created", { task: { id: "z" } })
+    ).toBeNull();
+
+    const afterDelete = planUpdateFromClaudeToolUse(state, "y", "TaskUpdate", {
+      taskId: "d",
+      status: "deleted",
+    });
+    expect(entriesOf(afterDelete)).toEqual([
+      { content: "keep", status: "pending", priority: "medium" },
+    ]);
+
+    // Deleting the last entry emits an EMPTY plan so downstream clears.
+    const afterLast = planUpdateFromClaudeToolUse(state, "z", "TaskUpdate", {
+      taskId: "k",
+      status: "deleted",
+    });
+    expect(entriesOf(afterLast)).toEqual([]);
+  });
+
+  it("consumes the pending TaskCreate even when its result is null/unparseable (no leak, no late bind)", () => {
+    const state = createClaudeTaskPlanState();
+    planUpdateFromClaudeToolUse(state, "tu", "TaskCreate", { subject: "ghost" });
+
+    // is_error result is passed as null content by the translator → the pending
+    // entry is consumed (spent) and nothing is emitted.
+    expect(planUpdateFromClaudeToolResult(state, "tu", null)).toBeNull();
+
+    // A second (stray re-delivered) result for the SAME id must NOT resurrect
+    // the entry — the pending was already consumed, so even a well-formed
+    // payload now no-ops instead of binding a phantom task.
+    expect(
+      planUpdateFromClaudeToolResult(state, "tu", { task: { id: "1", subject: "ghost" } })
+    ).toBeNull();
+  });
+
+  it("drops a fully-completed group when the next topic's first TaskCreate binds", () => {
+    // Official Todo lifecycle step 4: "Removed when all tasks in a group are
+    // completed." A new session topic (e.g. HK guide → Japan guide) must not
+    // stack its tasks onto the previous, already-finished group.
+    const state = createClaudeTaskPlanState();
+    for (const [tu, id, subject] of [
+      ["hk1", "1", "Plan HK transit"],
+      ["hk2", "2", "Plan HK food"],
+    ] as const) {
+      planUpdateFromClaudeToolUse(state, tu, "TaskCreate", { subject });
+      planUpdateFromClaudeToolResult(state, tu, `Task #${id} created successfully: ${subject}`);
+      planUpdateFromClaudeToolUse(state, `${tu}-done`, "TaskUpdate", {
+        taskId: id,
+        status: "completed",
+      });
+    }
+
+    // The new topic's FIRST create lands while every prior task is completed —
+    // the old group is dropped, leaving only the fresh task.
+    planUpdateFromClaudeToolUse(state, "jp1", "TaskCreate", { subject: "Plan Japan transit" });
+    const firstJapan = planUpdateFromClaudeToolResult(
+      state,
+      "jp1",
+      "Task #7 created successfully: Plan Japan transit"
+    );
+    expect(entriesOf(firstJapan)).toEqual([
+      { content: "Plan Japan transit", status: "pending", priority: "medium" },
+    ]);
+
+    // The SECOND create of the same batch sees a pending task → it appends,
+    // it does NOT wipe the just-started group.
+    planUpdateFromClaudeToolUse(state, "jp2", "TaskCreate", { subject: "Plan Japan food" });
+    const secondJapan = planUpdateFromClaudeToolResult(
+      state,
+      "jp2",
+      "Task #8 created successfully: Plan Japan food"
+    );
+    expect(entriesOf(secondJapan)).toEqual([
+      { content: "Plan Japan transit", status: "pending", priority: "medium" },
+      { content: "Plan Japan food", status: "pending", priority: "medium" },
+    ]);
+  });
+
+  it("keeps a still-active group intact when a mid-plan TaskCreate binds", () => {
+    // The clear only fires when EVERY task is completed. While a plan is still
+    // in flight (some done, some open) a freshly-added step must APPEND, not
+    // wipe — completed steps stay visible as progress within the live plan.
+    // (Real claude burst-creates a whole plan up front, so binds always land
+    // while tasks are pending; completion only happens afterwards. This guards
+    // that a genuine mid-plan addition is never mistaken for a new group.)
+    const state = createClaudeTaskPlanState();
+    for (const [tu, id, subject] of [
+      ["c1", "1", "Outline"],
+      ["c2", "2", "Draft"],
+    ] as const) {
+      planUpdateFromClaudeToolUse(state, tu, "TaskCreate", { subject });
+      planUpdateFromClaudeToolResult(state, tu, `Task #${id} created successfully: ${subject}`);
+    }
+    planUpdateFromClaudeToolUse(state, "c1-done", "TaskUpdate", {
+      taskId: "1",
+      status: "completed",
+    });
+    planUpdateFromClaudeToolUse(state, "c2-go", "TaskUpdate", {
+      taskId: "2",
+      status: "in_progress",
+    });
+
+    // #2 is still in_progress → the group is NOT fully completed → append.
+    planUpdateFromClaudeToolUse(state, "c3", "TaskCreate", { subject: "Polish" });
+    const update = planUpdateFromClaudeToolResult(
+      state,
+      "c3",
+      "Task #3 created successfully: Polish"
+    );
+    expect(entriesOf(update)).toEqual([
+      { content: "Outline", status: "completed", priority: "medium" },
+      { content: "Draft", status: "in_progress", priority: "medium" },
+      { content: "Polish", status: "pending", priority: "medium" },
+    ]);
+  });
+
+  it("survives across translator generations — the state is session-lived", () => {
+    // Simulates turn 1 creating the task and turn 2 (fresh translator, same
+    // shared state) updating it by id.
+    const state = createClaudeTaskPlanState();
+    planUpdateFromClaudeToolUse(state, "t1", "TaskCreate", { subject: "step" });
+    planUpdateFromClaudeToolResult(state, "t1", { task: { id: "42" } });
+    const turn2 = planUpdateFromClaudeToolUse(state, "t2", "TaskUpdate", {
+      taskId: "42",
+      status: "completed",
+    });
+    expect(entriesOf(turn2)).toEqual([
+      { content: "step", status: "completed", priority: "medium" },
+    ]);
+  });
+});

--- a/src/agentMode/sdk/claudeTodoPlan.ts
+++ b/src/agentMode/sdk/claudeTodoPlan.ts
@@ -1,0 +1,238 @@
+/**
+ * Normalizes Claude's execution todo list into the session-domain `plan`
+ * update — the same shape the ACP backends deliver — so the trail's PlanPill
+ * and the project-info Progress section stay backend- and version-agnostic.
+ *
+ * The Claude runtime ships TWO wire shapes, decided by the user's installed
+ * `claude` CLI (not by our pinned npm SDK):
+ *  - `TodoWrite` (CLI < 2.1.142, or `CLAUDE_CODE_ENABLE_TASKS=0`): one call
+ *    carrying the WHOLE list in `input.todos`.
+ *  - Task tools (CLI >= 2.1.142, the default): `TaskCreate` per item, the
+ *    task id arriving in the matching `tool_result`. The id is the `#N`
+ *    ordinal: real CLIs return the human-readable string
+ *    `"Task #N created successfully: <subject>"` (a `{task:{id,subject}}`
+ *    object/JSON is also accepted for forward-compat). Then
+ *    `TaskUpdate {taskId, status}` references that same `N`.
+ * Both converge here; display text is the stable title field (`content` /
+ * `subject`), deliberately NOT `activeForm` (per-status text would make the
+ * same entry's label jump between states and differ across shapes).
+ *
+ * State is held PER CLAUDE SESSION (not per query): Task ids created in turn
+ * 1 must still resolve when turn 2's `TaskUpdate` references them, and the
+ * translator's own state is rebuilt for every `query()` call.
+ */
+import type { AgentPlanEntry, SessionUpdate } from "@/agentMode/session/types";
+
+const TODO_STATUSES = ["pending", "in_progress", "completed"] as const;
+
+type TodoStatus = AgentPlanEntry["status"];
+
+function asTodoStatus(value: unknown): TodoStatus | null {
+  return TODO_STATUSES.includes(value as TodoStatus) ? (value as TodoStatus) : null;
+}
+
+export interface ClaudeTaskPlanState {
+  /** TaskCreate inputs waiting for their tool_result to deliver the task id. */
+  pendingCreatesByToolUseId: Map<string, { subject: string }>;
+  tasksById: Map<string, { subject: string; status: TodoStatus; order: number }>;
+  nextOrder: number;
+  /**
+   * Signature of the last emitted entries — suppresses re-emits when the
+   * multiple translator injection points (stream delta, block stop, assistant
+   * fallback) observe the same final input.
+   */
+  lastSignature: string | null;
+}
+
+export function createClaudeTaskPlanState(): ClaudeTaskPlanState {
+  return {
+    pendingCreatesByToolUseId: new Map(),
+    tasksById: new Map(),
+    nextOrder: 0,
+    lastSignature: null,
+  };
+}
+
+/**
+ * Feed one native, top-level tool_use (TodoWrite / TaskCreate / TaskUpdate).
+ * Callers are responsible for the native + top-level filter (no `mcpServer`,
+ * `parent_tool_use_id == null`) — subagent todos must not pollute the
+ * session-level list. Returns a `plan` update when the canonical list
+ * changed, else null.
+ */
+export function planUpdateFromClaudeToolUse(
+  state: ClaudeTaskPlanState,
+  toolUseId: string,
+  toolName: string,
+  rawInput: unknown
+): SessionUpdate | null {
+  const input = isRecord(rawInput) ? rawInput : null;
+  switch (toolName) {
+    case "TodoWrite": {
+      const todos = input?.todos;
+      if (!Array.isArray(todos)) return null;
+      const entries: AgentPlanEntry[] = [];
+      for (const todo of todos) {
+        if (!isRecord(todo)) continue;
+        const status = asTodoStatus(todo.status);
+        if (typeof todo.content !== "string" || todo.content.length === 0 || !status) continue;
+        entries.push({ content: todo.content, status, priority: "medium" });
+      }
+      // A genuinely empty list (`todos: []`) is a clear — emit it so the
+      // snapshot resets, matching the Task-tools path (deleting the last task
+      // emits an empty plan). But a NON-empty array that filtered down to
+      // nothing is malformed input, not a clear: don't wipe a good list on garbage.
+      if (entries.length === 0 && todos.length > 0) return null;
+      return emitIfChanged(state, entries);
+    }
+    case "TaskCreate": {
+      const subject = typeof input?.subject === "string" ? input.subject.trim() : "";
+      if (!subject) return null;
+      // No emission yet — the entry joins the list once the tool_result
+      // delivers its id (which also implicitly scopes results to top-level
+      // creates: subagent results never match this map).
+      state.pendingCreatesByToolUseId.set(toolUseId, { subject });
+      return null;
+    }
+    case "TaskUpdate": {
+      const taskId = typeof input?.taskId === "string" ? input.taskId : "";
+      if (!taskId) return null;
+      if (input?.status === "deleted") {
+        if (!state.tasksById.delete(taskId)) return null;
+        return emitIfChanged(state, snapshotEntries(state));
+      }
+      const status = asTodoStatus(input?.status);
+      const task = state.tasksById.get(taskId);
+      // Unknown id (e.g. created by a subagent, or a pre-resume task) is
+      // ignored rather than fabricated — we'd have no subject to show.
+      if (!task || !status || task.status === status) return null;
+      task.status = status;
+      return emitIfChanged(state, snapshotEntries(state));
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Feed one tool_result. Only results matching a pending TaskCreate bind an
+ * id; everything else is ignored. The result content arrives in several
+ * observed shapes: the plain string `"Task #N created successfully: ..."`
+ * (real CLI), a `{task:{id,subject}}` object, a JSON string of it, or a
+ * `[{type:"text", text:"..."}]` block list wrapping either form.
+ */
+export function planUpdateFromClaudeToolResult(
+  state: ClaudeTaskPlanState,
+  toolUseId: string,
+  content: unknown
+): SessionUpdate | null {
+  const pending = state.pendingCreatesByToolUseId.get(toolUseId);
+  if (!pending) return null;
+  // Consume the pending entry up front: a tool_use id's result arrives exactly
+  // once, so whether we can parse it or not, the pending record is spent —
+  // dropping it here stops failed/unparseable results from accumulating over a
+  // long session. Callers pass `null` content for an is_error result, which
+  // lands here as "consume but emit nothing".
+  state.pendingCreatesByToolUseId.delete(toolUseId);
+  const result = readTaskCreateResult(content);
+  if (!result) return null;
+  // Official Todo lifecycle step 4 ("Removed when all tasks in a group are
+  // completed"): a finished group must not linger once the next one starts.
+  // When this newly-bound create lands while every existing task is already
+  // completed, it is the first task of a NEW group (e.g. a second topic in the
+  // same claude session) — drop the old group so they don't stack. The check
+  // self-batches: once this pending task is in the map the group is no longer
+  // all-completed, so the rest of the batch appends instead of wiping.
+  if (isGroupFullyCompleted(state)) {
+    state.tasksById.clear();
+    state.nextOrder = 0;
+  }
+  state.tasksById.set(result.id, {
+    subject: result.subject ?? pending.subject,
+    status: "pending",
+    order: state.nextOrder++,
+  });
+  return emitIfChanged(state, snapshotEntries(state));
+}
+
+/** True only for a non-empty list whose every task has reached `completed`. */
+function isGroupFullyCompleted(state: ClaudeTaskPlanState): boolean {
+  if (state.tasksById.size === 0) return false;
+  for (const task of state.tasksById.values()) {
+    if (task.status !== "completed") return false;
+  }
+  return true;
+}
+
+function snapshotEntries(state: ClaudeTaskPlanState): AgentPlanEntry[] {
+  return Array.from(state.tasksById.values())
+    .sort((a, b) => a.order - b.order)
+    .map((task) => ({ content: task.subject, status: task.status, priority: "medium" as const }));
+}
+
+/**
+ * Layer 1 of 3 in the todo-plan dedup chain — the EMIT layer (claude only):
+ * the SDK translator feeds the same final tool input from several injection
+ * points (content_block stream delta, block stop, assistant fallback), so
+ * signature-compare here collapses them to one `plan` update. The downstream
+ * layers are NOT redundant: `AgentSession.applyCurrentTodoList` dedups the
+ * live snapshot's change notifications, and `planEntriesEqual`
+ * (AgentMessageStore) dedups the rendered plan message part.
+ */
+function emitIfChanged(
+  state: ClaudeTaskPlanState,
+  entries: AgentPlanEntry[]
+): SessionUpdate | null {
+  const signature = JSON.stringify(entries);
+  if (signature === state.lastSignature) return null;
+  state.lastSignature = signature;
+  return { sessionUpdate: "plan", entries };
+}
+
+function readTaskCreateResult(content: unknown): { id: string; subject?: string } | null {
+  const direct = readTaskShape(content);
+  if (direct) return direct;
+  if (typeof content === "string") {
+    return readTaskShape(tryParse(content)) ?? readTaskTextResult(content);
+  }
+  if (Array.isArray(content)) {
+    for (const block of content) {
+      if (!isRecord(block) || block.type !== "text" || typeof block.text !== "string") continue;
+      const parsed = readTaskShape(tryParse(block.text)) ?? readTaskTextResult(block.text);
+      if (parsed) return parsed;
+    }
+  }
+  return null;
+}
+
+// The task id is the `#N` ordinal — the same value TaskUpdate later sends as
+// `taskId`. We deliberately bind ONLY the id, not the echoed subject: the
+// authoritative subject is the tool_use's `input.subject` (already stashed in
+// the pending record), while this text is a localizable, possibly-truncated
+// echo. `readTaskCreateResult` falls back to the pending subject when this
+// returns no subject.
+const TASK_CREATED_RE = /^Task #(\d+) created successfully\b/;
+
+function readTaskTextResult(text: string): { id: string } | null {
+  const match = TASK_CREATED_RE.exec(text.trim());
+  return match ? { id: match[1] } : null;
+}
+
+function readTaskShape(value: unknown): { id: string; subject?: string } | null {
+  if (!isRecord(value) || !isRecord(value.task)) return null;
+  const { id, subject } = value.task;
+  if (typeof id !== "string" || id.length === 0) return null;
+  return { id, subject: typeof subject === "string" ? subject : undefined };
+}
+
+function tryParse(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -585,3 +585,202 @@ describe("mapStopReason", () => {
     expect(mapStopReason({ type: "result", subtype: "error_max_turns" } as any)).toBe("cancelled");
   });
 });
+
+describe("session todo-list normalization (TodoWrite / Task tools → plan)", () => {
+  function userMessage(content: unknown[], parent: string | null = null): SDKMessage {
+    return {
+      type: "user",
+      message: { content },
+      parent_tool_use_id: parent,
+      uuid: "uuid-u" as `${string}-${string}-${string}-${string}-${string}`,
+      session_id: SESSION_ID,
+    } as never;
+  }
+
+  it("emits a plan event alongside the tool events for a TodoWrite stream", () => {
+    const state = createTranslatorState();
+    translateSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "todo-1", name: "TodoWrite", input: {} },
+      }),
+      SESSION_ID,
+      state
+    );
+    const out = translateSdkMessage(
+      streamEvent({
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "input_json_delta",
+          partial_json:
+            '{"todos":[{"content":"step A","status":"in_progress","activeForm":"Doing A"}]}',
+        },
+      }),
+      SESSION_ID,
+      state
+    );
+    expect(out).toHaveLength(2);
+    expect(out[1].update).toEqual({
+      sessionUpdate: "plan",
+      entries: [{ content: "step A", status: "in_progress", priority: "medium" }],
+    });
+    // The block-stop re-observation of the same final input must not re-emit.
+    const stop = translateSdkMessage(
+      streamEvent({ type: "content_block_stop", index: 0 }),
+      SESSION_ID,
+      state
+    );
+    expect(stop.filter((e) => e.update.sessionUpdate === "plan")).toHaveLength(0);
+  });
+
+  it("accumulates Task tools across messages: create → result id → update", () => {
+    const state = createTranslatorState();
+    translateSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "task-create-1",
+          name: "TaskCreate",
+          input: { subject: "Brainstorm imagery" },
+        },
+      }),
+      SESSION_ID,
+      state
+    );
+    const bound = translateSdkMessage(
+      userMessage([
+        {
+          type: "tool_result",
+          tool_use_id: "task-create-1",
+          // The real claude CLI string shape — id is the `#N` ordinal.
+          content: "Task #1 created successfully: Brainstorm imagery",
+          is_error: false,
+        },
+      ]),
+      SESSION_ID,
+      state
+    );
+    const boundPlan = bound.find((e) => e.update.sessionUpdate === "plan");
+    expect(boundPlan?.update).toEqual({
+      sessionUpdate: "plan",
+      entries: [{ content: "Brainstorm imagery", status: "pending", priority: "medium" }],
+    });
+
+    const updated = translateSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 1,
+        content_block: {
+          type: "tool_use",
+          id: "task-upd-1",
+          name: "TaskUpdate",
+          input: { taskId: "1", status: "in_progress" },
+        },
+      }),
+      SESSION_ID,
+      state
+    );
+    const updatedPlan = updated.find((e) => e.update.sessionUpdate === "plan");
+    expect(updatedPlan?.update).toEqual({
+      sessionUpdate: "plan",
+      entries: [{ content: "Brainstorm imagery", status: "in_progress", priority: "medium" }],
+    });
+  });
+
+  it("ignores subagent calls (parent_tool_use_id set) and MCP tools sharing the name", () => {
+    const state = createTranslatorState();
+    const subagent = translateSdkMessage(
+      {
+        type: "stream_event",
+        event: {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "sub-1",
+            name: "TodoWrite",
+            input: { todos: [{ content: "sub task", status: "pending" }] },
+          },
+        },
+        parent_tool_use_id: "parent-1",
+        uuid: "uuid-s" as `${string}-${string}-${string}-${string}-${string}`,
+        session_id: SESSION_ID,
+      } as never,
+      SESSION_ID,
+      state
+    );
+    expect(subagent.filter((e) => e.update.sessionUpdate === "plan")).toHaveLength(0);
+
+    const mcp = translateSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 1,
+        content_block: {
+          type: "tool_use",
+          id: "mcp-1",
+          name: "mcp__tracker__TodoWrite",
+          input: { todos: [{ content: "mcp task", status: "pending" }] },
+        },
+      }),
+      SESSION_ID,
+      state
+    );
+    expect(mcp.filter((e) => e.update.sessionUpdate === "plan")).toHaveLength(0);
+  });
+
+  it("shares the accumulator across translator generations via createTranslatorState(shared)", () => {
+    const turn1 = createTranslatorState();
+    translateSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "c1",
+          name: "TaskCreate",
+          input: { subject: "persist me" },
+        },
+      }),
+      SESSION_ID,
+      turn1
+    );
+    translateSdkMessage(
+      userMessage([
+        {
+          type: "tool_result",
+          tool_use_id: "c1",
+          content: "Task #7 created successfully: persist me",
+          is_error: false,
+        },
+      ]),
+      SESSION_ID,
+      turn1
+    );
+
+    // Turn 2: fresh translator, same session-lived accumulator.
+    const turn2 = createTranslatorState(turn1.claudeTasks);
+    const out = translateSdkMessage(
+      streamEvent({
+        type: "content_block_start",
+        index: 0,
+        content_block: {
+          type: "tool_use",
+          id: "u1",
+          name: "TaskUpdate",
+          input: { taskId: "7", status: "completed" },
+        },
+      }),
+      SESSION_ID,
+      turn2
+    );
+    const plan = out.find((e) => e.update.sessionUpdate === "plan");
+    expect(plan?.update).toEqual({
+      sessionUpdate: "plan",
+      entries: [{ content: "persist me", status: "completed", priority: "medium" }],
+    });
+  });
+});

--- a/src/agentMode/sdk/sdkMessageTranslator.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.ts
@@ -14,11 +14,19 @@ import type {
   ToolCallContent,
 } from "@/agentMode/session/types";
 import { resolveToolName } from "@/agentMode/session/toolName";
+import {
+  createClaudeTaskPlanState,
+  planUpdateFromClaudeToolResult,
+  planUpdateFromClaudeToolUse,
+  type ClaudeTaskPlanState,
+} from "./claudeTodoPlan";
 import { deriveToolKind, deriveToolTitle, vendorMetaFields } from "./toolMeta";
 
 /**
  * Mutable per-query translator state. One instance lives for the duration of
- * a single `query()` call; reset whenever a new turn starts.
+ * a single `query()` call; reset whenever a new turn starts — EXCEPT
+ * `claudeTasks`, which the caller shares across a session's queries (Task ids
+ * created in one turn must resolve when a later turn updates them).
  */
 export interface TranslatorState {
   toolUseBlocks: Map<
@@ -34,10 +42,16 @@ export interface TranslatorState {
   >;
   /** Tool-use ids already emitted in this turn — used to dedupe in the assistant-message fallback path. */
   emittedToolUseIds: Set<string>;
+  /** Session-lived todo/Task accumulator (see claudeTodoPlan.ts). */
+  claudeTasks: ClaudeTaskPlanState;
 }
 
-export function createTranslatorState(): TranslatorState {
-  return { toolUseBlocks: new Map(), emittedToolUseIds: new Set() };
+export function createTranslatorState(claudeTasks?: ClaudeTaskPlanState): TranslatorState {
+  return {
+    toolUseBlocks: new Map(),
+    emittedToolUseIds: new Set(),
+    claudeTasks: claudeTasks ?? createClaudeTaskPlanState(),
+  };
 }
 
 function event(sessionId: SessionId, update: SessionUpdate): SessionEvent {
@@ -137,6 +151,17 @@ function translateStreamEvent(
             })
           );
         }
+        out.push(
+          ...todoPlanEvents(
+            sessionId,
+            state,
+            block.id,
+            name,
+            mcpServer,
+            parentToolUseId,
+            block.input ?? {}
+          )
+        );
         return out;
       }
       return [];
@@ -179,6 +204,15 @@ function translateStreamEvent(
             rawInput: parsed.value,
             ...vendorMetaFields(block.name, parentToolUseId, block.mcpServer),
           }),
+          ...todoPlanEvents(
+            sessionId,
+            state,
+            block.id,
+            block.name,
+            block.mcpServer,
+            parentToolUseId,
+            parsed.value
+          ),
         ];
       }
       return [];
@@ -197,6 +231,15 @@ function translateStreamEvent(
           status: "in_progress" as AgentToolStatus,
           ...vendorMetaFields(block.name, parentToolUseId, block.mcpServer),
         }),
+        ...todoPlanEvents(
+          sessionId,
+          state,
+          block.id,
+          block.name,
+          block.mcpServer,
+          parentToolUseId,
+          finalInput
+        ),
       ];
     }
     case "message_delta":
@@ -221,14 +264,39 @@ function translateAssistantMessage(
     if (state.emittedToolUseIds.has(b.id)) continue;
     state.emittedToolUseIds.add(b.id);
     out.push(event(sessionId, makeToolCallUpdate(b.id, b.name, b.input ?? {}, parentToolUseId)));
+    const { tool: name, mcpServer } = resolveToolName(b.name);
+    out.push(
+      ...todoPlanEvents(sessionId, state, b.id, name, mcpServer, parentToolUseId, b.input ?? {})
+    );
   }
   return out;
+}
+
+/**
+ * Session todo-list normalization (claudeTodoPlan.ts): feed native, TOP-LEVEL
+ * TodoWrite / TaskCreate / TaskUpdate calls into the session accumulator and
+ * surface the resulting `plan` update. MCP tools sharing a name and subagent
+ * calls (`parent_tool_use_id` set) are excluded — a subagent's todos must not
+ * pollute the session-level Progress.
+ */
+function todoPlanEvents(
+  sessionId: SessionId,
+  state: TranslatorState,
+  toolUseId: string,
+  name: string,
+  mcpServer: string | undefined,
+  parentToolUseId: string | undefined,
+  rawInput: unknown
+): SessionEvent[] {
+  if (mcpServer || parentToolUseId) return [];
+  const update = planUpdateFromClaudeToolUse(state.claudeTasks, toolUseId, name, rawInput);
+  return update ? [event(sessionId, update)] : [];
 }
 
 function translateUserMessage(
   msg: SDKUserMessage,
   sessionId: SessionId,
-  _state: TranslatorState
+  state: TranslatorState
 ): SessionEvent[] {
   const content = (msg.message as { content?: unknown }).content;
   if (!Array.isArray(content)) return [];
@@ -251,6 +319,16 @@ function translateUserMessage(
         content: outputs,
       })
     );
+    // A TaskCreate's result carries the task id; only ids pending in the
+    // accumulator match, so subagent results are inherently ignored. An
+    // is_error result still consumes its pending entry (passed as null content
+    // → no plan emitted) so failures can't accumulate over a long session.
+    const planUpdate = planUpdateFromClaudeToolResult(
+      state.claudeTasks,
+      b.tool_use_id,
+      b.is_error ? null : b.content
+    );
+    if (!b.is_error && planUpdate) out.push(event(sessionId, planUpdate));
   }
   return out;
 }

--- a/src/agentMode/session/AgentChatBackend.ts
+++ b/src/agentMode/session/AgentChatBackend.ts
@@ -2,6 +2,7 @@ import type { MessageContext } from "@/types/message";
 import type {
   AgentChatMessage,
   AgentQuestionAnswers,
+  AgentTodoListEntry,
   AskUserQuestionPrompt,
   BackendId,
   BackendState,
@@ -85,6 +86,14 @@ export interface AgentChatBackend {
    * surface. The floating plan card and the editor preview tab read this.
    */
   getCurrentPlan(): CurrentPlan | null;
+
+  /**
+   * The session's live execution todo list (normalized from every backend's
+   * todo channel), or `null` when there is none. Live-only: a resumed session
+   * starts at `null` until the agent's next todo update. The project-info
+   * Progress section reads this.
+   */
+  getCurrentTodoList(): AgentTodoListEntry[] | null;
 
   /**
    * True when an ExitPlanMode permission is currently pending. The chat input

--- a/src/agentMode/session/AgentChatPersistenceManager.test.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable obsidianmd/no-tfile-tfolder-cast -- test fixtures; not real TFiles */
 import { AI_SENDER, USER_SENDER } from "@/constants";
 import { AgentChatPersistenceManager } from "./AgentChatPersistenceManager";
+import { GLOBAL_SCOPE } from "./scope";
 import type { AgentChatMessage } from "./types";
 import type { App, TFile } from "obsidian";
 
@@ -205,5 +206,80 @@ describe("AgentChatPersistenceManager", () => {
     const result = await manager.saveSession([], "opencode");
     expect(result).toBeNull();
     expect(app.files.size).toBe(0);
+  });
+
+  describe("projectId scope round-trip", () => {
+    it("round-trips a real projectId for a project-scoped chat", async () => {
+      const messages = [makeMessage(USER_SENDER, "hi")];
+      const saved = await manager.saveSession(messages, "claude", { projectId: "proj-123" });
+      expect(saved).not.toBeNull();
+
+      const raw = app.files.get(saved!.path)!.contents!;
+      expect(raw).toContain('projectId: "proj-123"');
+
+      const loaded = await manager.loadFile(app.files.get(saved!.path) as unknown as TFile);
+      expect(loaded.projectId).toBe("proj-123");
+    });
+
+    it("defaults an unscoped chat to GLOBAL_SCOPE and writes no projectId (hard contract)", async () => {
+      const messages = [makeMessage(USER_SENDER, "hi")];
+      const saved = await manager.saveSession(messages, "claude");
+      const raw = app.files.get(saved!.path)!.contents!;
+      expect(raw).not.toContain("projectId:");
+
+      const loaded = await manager.loadFile(app.files.get(saved!.path) as unknown as TFile);
+      expect(loaded.projectId).toBe(GLOBAL_SCOPE);
+    });
+
+    it("treats an explicit GLOBAL_SCOPE like an unscoped chat (no projectId frontmatter)", async () => {
+      const messages = [makeMessage(USER_SENDER, "hi")];
+      const saved = await manager.saveSession(messages, "claude", { projectId: GLOBAL_SCOPE });
+      const raw = app.files.get(saved!.path)!.contents!;
+      expect(raw).not.toContain("projectId:");
+
+      const loaded = await manager.loadFile(app.files.get(saved!.path) as unknown as TFile);
+      expect(loaded.projectId).toBe(GLOBAL_SCOPE);
+    });
+
+    it("treats a blank projectId option like an unscoped chat", async () => {
+      const messages = [makeMessage(USER_SENDER, "hi")];
+      const saved = await manager.saveSession(messages, "claude", { projectId: "   " });
+      const raw = app.files.get(saved!.path)!.contents!;
+      expect(raw).not.toContain("projectId:");
+
+      const loaded = await manager.loadFile(app.files.get(saved!.path) as unknown as TFile);
+      expect(loaded.projectId).toBe(GLOBAL_SCOPE);
+    });
+
+    it("normalizes a padded projectId option before writing frontmatter", async () => {
+      const messages = [makeMessage(USER_SENDER, "hi")];
+      const saved = await manager.saveSession(messages, "claude", { projectId: " proj-123 " });
+      const raw = app.files.get(saved!.path)!.contents!;
+      expect(raw).toContain('projectId: "proj-123"');
+      expect(raw).not.toContain('projectId: " proj-123 "');
+
+      const loaded = await manager.loadFile(app.files.get(saved!.path) as unknown as TFile);
+      expect(loaded.projectId).toBe("proj-123");
+    });
+
+    it("maps a legacy agent__ chat with no projectId frontmatter to GLOBAL_SCOPE", async () => {
+      const path = "test-folder/agent__legacy.md";
+      await app.vault.adapter.write(
+        path,
+        [
+          "---",
+          "epoch: 1735732800000",
+          "mode: agent",
+          "backendId: claude",
+          "---",
+          "",
+          "**user**: hi",
+        ].join("\n")
+      );
+      // Reason: the stored file carries `contents`, so loadFile's vault.read
+      // path returns the frontmatter (a bare {path} fixture would read empty).
+      const loaded = await manager.loadFile(app.files.get(path) as unknown as TFile);
+      expect(loaded.projectId).toBe(GLOBAL_SCOPE);
+    });
   });
 });

--- a/src/agentMode/session/AgentChatPersistenceManager.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.ts
@@ -20,6 +20,8 @@ import {
 } from "@/utils/vaultAdapterUtils";
 import { TFile, type App } from "obsidian";
 import { Notice } from "obsidian";
+import { coerceProjectId, escapeYamlString, unescapeYamlString } from "./agentChatYaml";
+import { GLOBAL_SCOPE } from "./scope";
 import type { AgentChatMessage, BackendId } from "./types";
 
 const SAFE_FILENAME_BYTE_LIMIT = 100;
@@ -41,6 +43,14 @@ export interface LoadedAgentChat {
    * resume was wired up — those fall back to a fresh session.
    */
   sessionId?: string;
+  /**
+   * Scope this chat belongs to: a real project id, or {@link GLOBAL_SCOPE}.
+   * HARD CONTRACT: a chat with no `projectId` frontmatter (every legacy
+   * `agent__` chat) resolves to `GLOBAL_SCOPE`, so it keeps appearing in the
+   * global history. Never inferred from the filename — frontmatter is the only
+   * authority.
+   */
+  projectId: string;
 }
 
 interface ExistingMeta {
@@ -48,42 +58,7 @@ interface ExistingMeta {
   label?: string;
   lastAccessedAt?: number;
   sessionId?: string;
-}
-
-/**
- * Escape a string for safe YAML double-quoted string value. Strips control
- * chars (including newlines) up front — a stray `\n` in the user's topic
- * would otherwise terminate the line and corrupt the rest of the frontmatter.
- */
-function escapeYamlString(str: string): string {
-  return (
-    str
-      // eslint-disable-next-line no-control-regex
-      .replace(/[\x00-\x1F\x7F]/g, " ")
-      .replace(/\\/g, "\\\\")
-      .replace(/"/g, '\\"')
-  );
-}
-
-/**
- * Inverse of `escapeYamlString` for the values our hand-rolled frontmatter
- * parser extracts. Only handles the two escapes we emit (`\\` and `\"`).
- */
-function unescapeYamlString(str: string): string {
-  let out = "";
-  for (let i = 0; i < str.length; i++) {
-    const c = str[i];
-    if (c === "\\" && i + 1 < str.length) {
-      const next = str[i + 1];
-      if (next === "\\" || next === '"') {
-        out += next;
-        i++;
-        continue;
-      }
-    }
-    out += c;
-  }
-  return out;
+  projectId?: string;
 }
 
 /**
@@ -120,6 +95,13 @@ export class AgentChatPersistenceManager {
       modelKey?: string;
       existingPath?: string;
       sessionId?: string | null;
+      /**
+       * Scope to record in frontmatter. Pass a real project id to bind the
+       * chat to that project; omit (or pass `GLOBAL_SCOPE`) for a global chat,
+       * which writes no `projectId` so it stays indistinguishable from legacy
+       * global chats.
+       */
+      projectId?: string;
     }
   ): Promise<{ path: string } | null> {
     if (messages.length === 0) return null;
@@ -149,6 +131,11 @@ export class AgentChatPersistenceManager {
         modelKey: options?.modelKey,
         lastAccessedAt: existingMeta.lastAccessedAt,
         sessionId: options?.sessionId ?? existingMeta.sessionId,
+        // Reason: round-trip an existing chat's scope when the caller doesn't
+        // re-supply it (e.g. autosave updates), so a project chat never silently
+        // demotes itself to global on a later save. Coerce first so a blank
+        // option falls through to the existing scope instead of clobbering it.
+        projectId: coerceProjectId(options?.projectId) ?? existingMeta.projectId,
       });
 
       if (existingFile && isInVaultCache(this.app, existingFile.path)) {
@@ -215,12 +202,15 @@ export class AgentChatPersistenceManager {
     const topic = frontmatter.topic?.trim() || undefined;
     const label = frontmatter.agentLabel?.trim() || undefined;
     const sessionId = frontmatter.sessionId?.trim() || undefined;
+    // HARD CONTRACT: absent/blank projectId → GLOBAL_SCOPE, so legacy `agent__`
+    // chats stay in the global history. Never inferred from the filename.
+    const projectId = frontmatter.projectId?.trim() || GLOBAL_SCOPE;
     const messages = this.parseChatBody(body);
 
     logInfo(
-      `[AgentChatPersistenceManager] Loaded ${messages.length} messages from ${file.path} (backend=${backendId}, sessionId=${sessionId ?? "none"})`
+      `[AgentChatPersistenceManager] Loaded ${messages.length} messages from ${file.path} (backend=${backendId}, sessionId=${sessionId ?? "none"}, projectId=${projectId})`
     );
-    return { messages, backendId, topic, label, sessionId };
+    return { messages, backendId, topic, label, sessionId, projectId };
   }
 
   /**
@@ -268,6 +258,7 @@ export class AgentChatPersistenceManager {
         lastAccessedAt:
           typeof cached.lastAccessedAt === "number" ? cached.lastAccessedAt : undefined,
         sessionId: typeof cached.sessionId === "string" ? cached.sessionId : undefined,
+        projectId: coerceProjectId(cached.projectId),
       };
     }
     try {
@@ -279,6 +270,7 @@ export class AgentChatPersistenceManager {
         label: fm.agentLabel,
         lastAccessedAt: lastAccessed && Number.isFinite(lastAccessed) ? lastAccessed : undefined,
         sessionId: typeof fm.sessionId === "string" ? fm.sessionId : undefined,
+        projectId: coerceProjectId(fm.projectId),
       };
     } catch {
       return {};
@@ -459,6 +451,7 @@ export class AgentChatPersistenceManager {
     modelKey?: string;
     lastAccessedAt?: number;
     sessionId?: string | null;
+    projectId?: string;
   }): string {
     const settings = getSettings();
     const lines: string[] = [
@@ -467,6 +460,13 @@ export class AgentChatPersistenceManager {
       `mode: ${AGENT_CHAT_MODE}`,
       `backendId: ${args.backendId}`,
     ];
+    // Reason: global chats write no projectId, staying byte-identical to legacy
+    // `agent__` chats (which loadFile maps back to GLOBAL_SCOPE). Coerce so a
+    // blank/whitespace id never leaks a stray frontmatter line.
+    const projectId = coerceProjectId(args.projectId);
+    if (projectId && projectId !== GLOBAL_SCOPE) {
+      lines.push(`projectId: "${escapeYamlString(projectId)}"`);
+    }
     if (args.sessionId) lines.push(`sessionId: "${escapeYamlString(args.sessionId)}"`);
     if (args.topic) lines.push(`topic: "${escapeYamlString(args.topic)}"`);
     if (args.label) lines.push(`agentLabel: "${escapeYamlString(args.label)}"`);

--- a/src/agentMode/session/AgentChatUIState.ts
+++ b/src/agentMode/session/AgentChatUIState.ts
@@ -4,6 +4,7 @@ import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type {
   AgentChatMessage,
   AgentQuestionAnswers,
+  AgentTodoListEntry,
   AskUserQuestionPrompt,
   BackendId,
   BackendState,
@@ -34,6 +35,7 @@ export class AgentChatUIState implements AgentChatBackend {
       onStatusChanged: () => this.notifyListeners(),
       onModelChanged: () => this.notifyListeners(),
       onCurrentPlanChanged: () => this.notifyListeners(),
+      onCurrentTodoListChanged: () => this.notifyListeners(),
     });
   }
 
@@ -150,6 +152,10 @@ export class AgentChatUIState implements AgentChatBackend {
 
   getCurrentPlan(): CurrentPlan | null {
     return this.session.getCurrentPlan();
+  }
+
+  getCurrentTodoList(): AgentTodoListEntry[] | null {
+    return this.session.getCurrentTodoList();
   }
 
   async resolvePlanProposal(

--- a/src/agentMode/session/AgentMessageStore.ts
+++ b/src/agentMode/session/AgentMessageStore.ts
@@ -94,7 +94,19 @@ function partsEqual(a: AgentMessagePart, b: AgentMessagePart): boolean {
   }
 }
 
-/** Compare plan entries without stringifying the whole part object. */
+/**
+ * Compare plan entries without stringifying the whole part object.
+ *
+ * Layer 3 of 3 in the todo-plan dedup chain — the RENDER layer: stops an
+ * unchanged plan part from re-triggering a React notify on `upsertAgentPart`.
+ * The other two layers guard different things and are NOT redundant with this:
+ *  1. emit layer (`claudeTodoPlan.emitIfChanged`): collapses the SDK
+ *     translator's multiple injection points (stream delta / block stop /
+ *     assistant fallback) that observe the same final tool input.
+ *  2. snapshot layer (`AgentSession.applyCurrentTodoList`): suppresses
+ *     no-op `onCurrentTodoListChanged` ticks for the live Progress section.
+ * This layer is the only one that also dedups the plan MESSAGE part.
+ */
 function planEntriesEqual(
   a: Extract<AgentMessagePart, { kind: "plan" }>["entries"],
   b: Extract<AgentMessagePart, { kind: "plan" }>["entries"]

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -135,10 +135,10 @@ describe("buildPromptBlocks", () => {
     expect(blocks).toHaveLength(1);
     expect(blocks[0].type).toBe("text");
     const text = (blocks[0] as { type: "text"; text: string }).text;
-    expect(text).toContain("<attached_context>");
+    expect(text).toContain("<copilot-context>");
     expect(text).toContain("- daily/2026-04-28.md");
     expect(text).toContain("- projects/copilot.md");
-    expect(text).toContain("</attached_context>");
+    expect(text).toContain("</copilot-context>");
     expect(text).toContain("<user-message>\nsummarize them\n</user-message>");
   });
 
@@ -190,7 +190,7 @@ describe("buildPromptBlocks", () => {
     expect(blocks).toHaveLength(3);
     expect(blocks[0].type).toBe("text");
     const head = (blocks[0] as { type: "text"; text: string }).text;
-    expect(head).toContain("<attached_context>");
+    expect(head).toContain("<copilot-context>");
     expect(head).toContain("- a.md");
     expect(head).toContain("<user-message>\nlook at this\n</user-message>");
     expect(blocks[1]).toEqual({
@@ -255,7 +255,7 @@ describe("buildPromptBlocks", () => {
       webTabBlock
     );
     const text = (blocks[0] as { type: "text"; text: string }).text;
-    const envelopePos = text.indexOf("<attached_context>");
+    const envelopePos = text.indexOf("<copilot-context>");
     const selectionPos = text.indexOf("<web_selected_text>");
     const webTabPos = text.indexOf("<web_tab_context>");
     const messagePos = text.indexOf("<user-message>");
@@ -279,8 +279,8 @@ describe("buildPromptBlocks", () => {
     expect(text).toContain("<project_context>");
     expect(text).toContain("`/vault/Papers`");
     // Project context leads, then the per-message attached context, then the message.
-    expect(text.indexOf("<project_context>")).toBeLessThan(text.indexOf("<attached_context>"));
-    expect(text.indexOf("<attached_context>")).toBeLessThan(text.indexOf("<user-message>"));
+    expect(text.indexOf("<project_context>")).toBeLessThan(text.indexOf("<copilot-context>"));
+    expect(text.indexOf("<copilot-context>")).toBeLessThan(text.indexOf("<user-message>"));
   });
 
   it("omits the project-context block when none is provided (later turns)", () => {

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -8,6 +8,7 @@ import {
   withReadOnlyPreamble,
 } from "./AgentSession";
 import { ensureMultiAgentEntitlement, showMultiAgentUpgradePrompt } from "@/plusUtils";
+import { GLOBAL_SCOPE } from "./scope";
 import { AuthRequiredError, MethodUnsupportedError } from "./errors";
 import type { FanoutRunInput } from "./fanout/FanoutOrchestrator";
 import { FANOUT_READONLY_PREAMBLE, type FanoutTurn } from "./fanout/fanoutTypes";
@@ -134,10 +135,10 @@ describe("buildPromptBlocks", () => {
     expect(blocks).toHaveLength(1);
     expect(blocks[0].type).toBe("text");
     const text = (blocks[0] as { type: "text"; text: string }).text;
-    expect(text).toContain("<copilot-context>");
+    expect(text).toContain("<attached_context>");
     expect(text).toContain("- daily/2026-04-28.md");
     expect(text).toContain("- projects/copilot.md");
-    expect(text).toContain("</copilot-context>");
+    expect(text).toContain("</attached_context>");
     expect(text).toContain("<user-message>\nsummarize them\n</user-message>");
   });
 
@@ -189,7 +190,7 @@ describe("buildPromptBlocks", () => {
     expect(blocks).toHaveLength(3);
     expect(blocks[0].type).toBe("text");
     const head = (blocks[0] as { type: "text"; text: string }).text;
-    expect(head).toContain("<copilot-context>");
+    expect(head).toContain("<attached_context>");
     expect(head).toContain("- a.md");
     expect(head).toContain("<user-message>\nlook at this\n</user-message>");
     expect(blocks[1]).toEqual({
@@ -254,7 +255,7 @@ describe("buildPromptBlocks", () => {
       webTabBlock
     );
     const text = (blocks[0] as { type: "text"; text: string }).text;
-    const envelopePos = text.indexOf("<copilot-context>");
+    const envelopePos = text.indexOf("<attached_context>");
     const selectionPos = text.indexOf("<web_selected_text>");
     const webTabPos = text.indexOf("<web_tab_context>");
     const messagePos = text.indexOf("<user-message>");
@@ -262,6 +263,30 @@ describe("buildPromptBlocks", () => {
     expect(envelopePos).toBeLessThan(selectionPos);
     expect(selectionPos).toBeLessThan(webTabPos);
     expect(webTabPos).toBeLessThan(messagePos);
+  });
+
+  it("prepends the project-context block ahead of the attached context and message", () => {
+    const projectContextBlock =
+      "<project_context>\n## Included folders\n- `/vault/Papers`\n</project_context>";
+    const blocks = buildPromptBlocks(
+      "go",
+      { notes: [makeFile("a.md")], urls: [] },
+      undefined,
+      undefined,
+      projectContextBlock
+    );
+    const text = (blocks[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("<project_context>");
+    expect(text).toContain("`/vault/Papers`");
+    // Project context leads, then the per-message attached context, then the message.
+    expect(text.indexOf("<project_context>")).toBeLessThan(text.indexOf("<attached_context>"));
+    expect(text.indexOf("<attached_context>")).toBeLessThan(text.indexOf("<user-message>"));
+  });
+
+  it("omits the project-context block when none is provided (later turns)", () => {
+    const blocks = buildPromptBlocks("go", { notes: [makeFile("a.md")], urls: [] });
+    const text = (blocks[0] as { type: "text"; text: string }).text;
+    expect(text).not.toContain("<project_context>");
   });
 });
 
@@ -296,6 +321,31 @@ describe("AgentSession.loadDisplayMessages", () => {
       "earlier prompt",
       "earlier reply",
     ]);
+  });
+});
+
+describe("AgentSession.projectId", () => {
+  it("defaults to GLOBAL_SCOPE when no projectId option is given", () => {
+    const mock = makeMockBackend();
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+    expect(session.projectId).toBe(GLOBAL_SCOPE);
+  });
+
+  it("binds the provided projectId (immutable, like backendId)", () => {
+    const mock = makeMockBackend();
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+      projectId: "proj-42",
+    });
+    expect(session.projectId).toBe("proj-42");
   });
 });
 
@@ -1223,6 +1273,164 @@ describe("AgentSession.create (via start)", () => {
     });
     await session.ready;
     expect(session.getState()?.model).toBeNull();
+  });
+
+  it("passes the session's projectId into the newSession payload", async () => {
+    const mock = makeMockBackend();
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: emptyState() });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault/Projects/p",
+      internalId: "internal-1",
+      backendId: "opencode",
+      projectId: "proj-7",
+    });
+    await session.ready;
+    expect(mock.newSession).toHaveBeenCalledWith(
+      expect.objectContaining({ cwd: "/vault/Projects/p", projectId: "proj-7" })
+    );
+  });
+
+  it("defaults the newSession projectId to GLOBAL_SCOPE when no scope is given", async () => {
+    const mock = makeMockBackend();
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: emptyState() });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+    await session.ready;
+    expect(mock.newSession).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: GLOBAL_SCOPE })
+    );
+  });
+
+  it("awaits contextReady and forwards its roots into the newSession payload", async () => {
+    const mock = makeMockBackend();
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: emptyState() });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault/Projects/p",
+      internalId: "internal-1",
+      backendId: "opencode",
+      projectId: "proj-7",
+      contextReady: Promise.resolve({
+        additionalDirectories: ["/vault/SharedResearch"],
+      }),
+    });
+    await session.ready;
+    expect(mock.newSession).toHaveBeenCalledWith(
+      expect.objectContaining({ additionalDirectories: ["/vault/SharedResearch"] })
+    );
+  });
+
+  it("injects the <project_context> block into the first user prompt only", async () => {
+    const mock = makeMockBackend();
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: emptyState() });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault/Projects/p",
+      internalId: "internal-1",
+      backendId: "opencode",
+      projectId: "proj-7",
+      contextReady: Promise.resolve({
+        additionalDirectories: [],
+        projectContextBlock:
+          "<project_context>\n## Included folders\n- `/vault/Papers`\n</project_context>",
+      }),
+    });
+    await session.ready;
+
+    await session.sendPrompt("first").turn;
+    await session.sendPrompt("second").turn;
+
+    const promptText = (call: number): string => {
+      const input = mock.prompt.mock.calls[call][0] as {
+        prompt: Array<{ type: string; text?: string }>;
+      };
+      return input.prompt.map((b) => b.text ?? "").join("\n");
+    };
+    expect(promptText(0)).toContain("<project_context>");
+    expect(promptText(0)).toContain("`/vault/Papers`");
+    expect(promptText(0)).toContain("<user-message>\nfirst\n</user-message>");
+    // The block rides the first message only; the second turn is clean.
+    expect(promptText(1)).not.toContain("<project_context>");
+  });
+
+  it("re-injects the <project_context> block on retry when the first prompt fails", async () => {
+    const mock = makeMockBackend();
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: emptyState() });
+    // First delivery fails hard (transport) before the backend accepts the turn.
+    mock.prompt.mockRejectedValueOnce(new Error("transport down"));
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault/Projects/p",
+      internalId: "internal-1",
+      backendId: "opencode",
+      projectId: "proj-7",
+      contextReady: Promise.resolve({
+        additionalDirectories: [],
+        projectContextBlock:
+          "<project_context>\n## Included folders\n- `/vault/Papers`\n</project_context>",
+      }),
+    });
+    await session.ready;
+
+    await expect(session.sendPrompt("first").turn).rejects.toThrow("transport down");
+    await session.sendPrompt("retry").turn;
+
+    const promptText = (call: number): string => {
+      const input = mock.prompt.mock.calls[call][0] as {
+        prompt: Array<{ type: string; text?: string }>;
+      };
+      return input.prompt.map((b) => b.text ?? "").join("\n");
+    };
+    // The failed attempt carried it; since the backend never accepted the turn,
+    // the retry carries it again rather than dropping the context permanently.
+    expect(promptText(0)).toContain("<project_context>");
+    expect(promptText(1)).toContain("<project_context>");
+  });
+
+  it("forwards an empty roots array when no contextReady is supplied", async () => {
+    const mock = makeMockBackend();
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: emptyState() });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+    await session.ready;
+    expect(mock.newSession).toHaveBeenCalledWith(
+      expect.objectContaining({ additionalDirectories: [] })
+    );
+  });
+
+  it("does not call newSession until contextReady resolves (non-blocking visibility)", async () => {
+    const mock = makeMockBackend();
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: emptyState() });
+    let release!: (result: { additionalDirectories: string[] }) => void;
+    const contextReady = new Promise<{ additionalDirectories: string[] }>((resolve) => {
+      release = resolve;
+    });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault/Projects/p",
+      internalId: "internal-1",
+      backendId: "opencode",
+      projectId: "proj-7",
+      contextReady,
+    });
+    // Session exists immediately; newSession is gated on contextReady.
+    await Promise.resolve();
+    expect(mock.newSession).not.toHaveBeenCalled();
+    expect(session.getStatus()).toBe("starting");
+    release({ additionalDirectories: ["/vault/SharedResearch"] });
+    await session.ready;
+    expect(mock.newSession).toHaveBeenCalledWith(
+      expect.objectContaining({ additionalDirectories: ["/vault/SharedResearch"] })
+    );
   });
 
   it("attempts setModel when defaultModelSelection is set", async () => {
@@ -3222,5 +3430,76 @@ describe("AgentSession streamed-token notification coalescing", () => {
     const placeholder = session.store.getDisplayMessages().find((m) => m.sender === AI_SENDER);
     expect(placeholder?.message).toBe("partial");
     expect(placeholder?.turnStopReason).toBe("end_turn");
+  });
+});
+
+describe("AgentSession.getCurrentTodoList", () => {
+  function makeSession(mock: ReturnType<typeof makeMockBackend>) {
+    return new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+  }
+  const planUpdate = (entries: { content: string; status: string; priority?: string }[]) => ({
+    sessionId: "acp-1",
+    update: { sessionUpdate: "plan", entries } as never,
+  });
+
+  it("starts null, snapshots plan entries, and notifies the dedicated channel", () => {
+    const mock = makeMockBackend();
+    const session = makeSession(mock);
+    expect(session.getCurrentTodoList()).toBeNull();
+
+    let notified = 0;
+    session.subscribe({
+      onMessagesChanged: () => {},
+      onStatusChanged: () => {},
+      onCurrentTodoListChanged: () => notified++,
+    });
+    mock.emit(
+      planUpdate([
+        { content: "step A", status: "in_progress", priority: "medium" },
+        { content: "step B", status: "pending", priority: "medium" },
+      ])
+    );
+    expect(notified).toBe(1);
+    expect(session.getCurrentTodoList()).toEqual([
+      { content: "step A", status: "in_progress" },
+      { content: "step B", status: "pending" },
+    ]);
+  });
+
+  it("dedupes identical lists (synthesized + real plan channel) by content signature", () => {
+    const mock = makeMockBackend();
+    const session = makeSession(mock);
+    let notified = 0;
+    session.subscribe({
+      onMessagesChanged: () => {},
+      onStatusChanged: () => {},
+      onCurrentTodoListChanged: () => notified++,
+    });
+    const entries = [{ content: "same", status: "pending", priority: "high" }];
+    mock.emit(planUpdate(entries));
+    const snapshot = session.getCurrentTodoList();
+    mock.emit(planUpdate([{ content: "same", status: "pending", priority: "low" }]));
+    expect(notified).toBe(1);
+    // Held reference stays stable across the deduped update.
+    expect(session.getCurrentTodoList()).toBe(snapshot);
+  });
+
+  it("clears to null on an empty plan and on dispose", async () => {
+    const mock = makeMockBackend();
+    const session = makeSession(mock);
+    mock.emit(planUpdate([{ content: "only", status: "pending" }]));
+    expect(session.getCurrentTodoList()).not.toBeNull();
+
+    mock.emit(planUpdate([]));
+    expect(session.getCurrentTodoList()).toBeNull();
+
+    mock.emit(planUpdate([{ content: "again", status: "pending" }]));
+    await session.dispose();
+    expect(session.getCurrentTodoList()).toBeNull();
   });
 });

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -924,6 +924,46 @@ describe("AgentSession fan-out branching", () => {
     // The live turn rides on the message itself for the UI.
     expect(placeholder?.fanout?.summary.text).toBe("the narrative summary");
   });
+
+  it("does not let a first-turn fan-out consume the visible session's project context", async () => {
+    const mock = makeMockBackend();
+    const runFanoutTurn = jest.fn(async (input: FanoutRunInput): Promise<FanoutTurn> => {
+      const turn: FanoutTurn = {
+        answers: {
+          opencode: { backendId: "opencode", status: "done", text: "a" },
+          claude: { backendId: "claude", status: "done", text: "b" },
+        },
+        summary: { status: "done", text: "summary" },
+      };
+      input.onChange(turn);
+      return turn;
+    });
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+      runFanoutTurn,
+    });
+    // Stand in for the block the initializer captures for the first prompt.
+    (session as unknown as { projectContextBlock: string | null }).projectContextBlock =
+      "<project_context>\n## Included folders\n- `/vault/Papers`\n</project_context>";
+
+    // Turn 1 is a fan-out: only the ephemeral sub-sessions receive the block,
+    // and the visible backend is never prompted.
+    await session.sendPrompt("review", undefined, undefined, ["opencode", "claude"]).turn;
+    const fanoutPrompt = runFanoutTurn.mock.calls[0][0].prompt[0] as { type: "text"; text: string };
+    expect(fanoutPrompt.text).toContain("<project_context>");
+    expect(mock.prompt).not.toHaveBeenCalled();
+
+    // Turn 2 is a normal turn: the visible backend must finally receive the
+    // first-turn project context (regression — a fan-out turn used to burn it).
+    await session.sendPrompt("now you").turn;
+    expect(mock.prompt).toHaveBeenCalledTimes(1);
+    const req = mock.prompt.mock.calls[0][0] as { prompt: Array<{ type: string; text?: string }> };
+    const visibleText = (req.prompt[0] as { type: "text"; text: string }).text;
+    expect(visibleText).toContain("<project_context>");
+  });
 });
 
 describe("AgentSession fan-out paywall (send-boundary entitlement)", () => {

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1006,9 +1006,12 @@ export class AgentSession {
           projectContextBlock,
           historyBlock
         );
-        // The first-turn project-context block (if any) has now been delivered to
-        // the fan-out agents; mark it so the next visible turn doesn't re-inject it.
-        if (isFirstTurn) this.firstPromptSent = true;
+        // Deliberately do NOT mark `firstPromptSent` here. Fan-out delivers the
+        // first-turn project-context block only to the ephemeral sub-sessions; the
+        // visible backend never receives this prompt. Consuming the flag would make
+        // the next normal turn skip the block, permanently stripping the project
+        // manifest from the main chat. Leaving it unset lets that turn deliver it
+        // (and each ephemeral fan-out, being memoryless, re-receives it meanwhile).
         return await this.runFanoutPath(placeholderId, displayText, promptBlocks, turnStartedAt);
       }
 

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1,10 +1,13 @@
 import { AI_SENDER, USER_SENDER, WEB_SELECTED_TEXT_TAG } from "@/constants";
 import { logInfo, logWarn } from "@/logger";
 import { AgentMessageStore } from "@/agentMode/session/AgentMessageStore";
+import { GLOBAL_SCOPE, type ProjectScopeId } from "@/agentMode/session/scope";
 import {
   AgentChatMessage,
   AgentMessagePart,
+  AgentPlanEntry,
   AgentQuestionAnswers,
+  AgentTodoListEntry,
   AgentToolCallOutput,
   AskUserQuestionPrompt,
   BackendDescriptor,
@@ -42,6 +45,7 @@ import { resolveMcpServers } from "@/agentMode/session/mcpResolver";
 import { deriveChatTitleFromMessages } from "@/agentMode/session/chatHistoryMerge";
 import { getSettings } from "@/settings/model";
 import { ContextProcessor } from "@/contextProcessor";
+import type { ContextMaterializationResult } from "@/context/projectContextMaterializer";
 import { escapeXml } from "@/LLMProviders/chainRunner/utils/xmlParsing";
 import type { FanoutRunInput } from "@/agentMode/session/fanout/FanoutOrchestrator";
 import { isFanout } from "@/agentMode/session/fanout/answerers";
@@ -90,6 +94,9 @@ const EMPTY_QUESTIONS: AskUserQuestionPrompt[] = [];
 const EMPTY_ANSWERS: AgentQuestionAnswers = Object.freeze({});
 // Canonical "no fan-out" selection — referential stability on the single-agent path.
 const EMPTY_BACKEND_IDS: ReadonlyArray<BackendId> = Object.freeze([]);
+// Shared "no extra roots" array so a session created without project context
+// keeps a stable reference (no fresh `[]` allocation per construction).
+const EMPTY_ADDITIONAL_DIRECTORIES: string[] = Object.freeze([]) as unknown as string[];
 
 /**
  * Optimistically swap `state.model.current.baseModelId` for the persisted
@@ -160,6 +167,12 @@ export interface AgentSessionListener {
    */
   onCurrentPlanChanged?(): void;
   /**
+   * Optional: fired when the live execution todo list changes (a backend
+   * `plan` update with different content arrived, or the session reset).
+   * The project-info Progress section subscribes to this channel.
+   */
+  onCurrentTodoListChanged?(): void;
+  /**
    * Optional: fired when the "needs attention" flag flips. The tab strip
    * subscribes to render an accent dot on the brand icon for backgrounded
    * sessions that finished, errored, or paused for permission while the
@@ -173,6 +186,11 @@ export interface AgentSessionStartOptions {
   cwd: string;
   internalId: string;
   backendId: BackendId;
+  /**
+   * Scope this session belongs to. Immutable like `backendId`; defaults to
+   * {@link GLOBAL_SCOPE} (the implicit global workspace).
+   */
+  projectId?: ProjectScopeId;
   /**
    * Persisted user preference to apply after the backend's initial session
    * state. The session seeds it optimistically so the first picker paint
@@ -210,6 +228,19 @@ export interface AgentSessionStartOptions {
    * never reaches for the global `app`. Manager-supplied; tests omit it.
    */
   getApp?: () => App;
+  /**
+   * Resolves to the project's context-materialization result. Supplied by the
+   * manager and awaited in `initialize` right BEFORE `newSession`, so the
+   * session appears immediately (send-gated by the loading card) while prefetch
+   * runs in the background and the backend still gets the roots once they're
+   * ready. Absent for GLOBAL / context-free sessions — `initialize` then opens
+   * without delay.
+   *
+   * Carries both the extra searchable roots (forwarded to `newSession`) and the
+   * optional inline `<project_context>` block, captured for injection into this
+   * session's first user prompt.
+   */
+  contextReady?: Promise<ContextMaterializationResult>;
 }
 
 /**
@@ -221,6 +252,8 @@ export interface AgentSessionStateOptions {
   backendSessionId: SessionId;
   internalId: string;
   backendId: BackendId;
+  /** Scope this session belongs to. See {@link AgentSessionStartOptions.projectId}. */
+  projectId?: ProjectScopeId;
   initialState?: BackendState | null;
   /**
    * Optional persisted user preference applied to the warm/adopted session.
@@ -252,11 +285,24 @@ export class AgentSession {
   readonly store = new AgentMessageStore();
   readonly internalId: string;
   readonly backendId: BackendId;
+  /** Immutable scope binding ({@link GLOBAL_SCOPE} or a project id). */
+  readonly projectId: ProjectScopeId;
   /** Resolves when `newSession` succeeds; rejects when it fails. */
   readonly ready: Promise<void>;
   private backendSessionId: SessionId | null = null;
   private readonly backend: BackendProcess;
   private readonly cwd: string | null;
+  // Resolves to the project's context-materialization result; awaited before
+  // `newSession` (null for context-free / resumed sessions, which open without
+  // delay).
+  private readonly contextReady: Promise<ContextMaterializationResult> | null;
+  // The project's `<project_context>` block, captured from `contextReady` in
+  // `initialize`. Inlined into the FIRST user prompt only (see `runTurn` /
+  // `buildPromptBlocks`); null for GLOBAL / context-free / resumed sessions.
+  private projectContextBlock: string | null = null;
+  // Flips true once the first user prompt has been built, so the project-context
+  // block is injected exactly once at the head of the conversation.
+  private firstPromptSent = false;
   private readonly getDescriptor: (() => BackendDescriptor | undefined) | null;
   private readonly runFanoutTurn: RunFanoutTurn | null;
   private readonly getDisplayName: ((backendId: BackendId) => string) | null;
@@ -343,6 +389,15 @@ export class AgentSession {
   // while in canonical plan mode and a plan has been proposed; cleared on a
   // terminal user decision or when the canonical mode flips out of plan.
   private currentPlan: CurrentPlan | null = null;
+  // Live execution todo list — the latest `plan` update's entries, normalized
+  // for consumers (the trail's PlanPill reads the message part instead; this
+  // snapshot feeds surfaces outside the message flow). LIVE-ONLY by design:
+  // chat persistence drops plan parts, so a resumed/reloaded session starts
+  // at null and repopulates on the agent's next todo update.
+  private currentTodoList: AgentTodoListEntry[] | null = null;
+  // Signature of the last applied list — multiple equal plan updates (e.g.
+  // opencode's synthesized + occasional real plan channel) must not re-notify.
+  private currentTodoListSignature: string | null = null;
   // Monotonic counter for `currentPlan.id` so the React tree can detect a
   // *new* plan-mode review (vs. an in-place revision that bumps `revision`).
   private planSeq = 0;
@@ -366,11 +421,15 @@ export class AgentSession {
     this.backend = opts.backend;
     this.internalId = opts.internalId;
     this.backendId = opts.backendId;
+    this.projectId = opts.projectId ?? GLOBAL_SCOPE;
     this.cwd = opts.cwd ?? null;
     this.getDescriptor = opts.getDescriptor ?? null;
     this.runFanoutTurn = opts.runFanoutTurn ?? null;
     this.getDisplayName = opts.getDisplayName ?? null;
     this.getApp = opts.getApp ?? null;
+    // Only the start path (newSession) awaits context roots; adopted/resumed
+    // sessions had theirs forwarded by the manager's resume/load call already.
+    this.contextReady = "contextReady" in opts ? (opts.contextReady ?? null) : null;
     if ("backendSessionId" in opts) {
       this.backendSessionId = opts.backendSessionId;
       const originalState = opts.initialState ?? null;
@@ -419,9 +478,27 @@ export class AgentSession {
   private async initialize(opts: AgentSessionStartOptions): Promise<void> {
     const { backend, cwd, defaultModelSelection } = opts;
     try {
+      // Await the project's context roots (if any) BEFORE opening the session.
+      // The session is already visible and send-gated by the loading card; this
+      // delay only postpones the backend round-trip until prefetch settles. The
+      // promise never rejects (degrades to empty), so it can't strand startup.
+      const contextResult = this.contextReady ? await this.contextReady : null;
+      const additionalDirectories =
+        contextResult?.additionalDirectories ?? EMPTY_ADDITIONAL_DIRECTORIES;
+      // Capture the inline `<project_context>` block for this session's first
+      // prompt. The roots go to `newSession` below; the block rides the first
+      // user message (see `runTurn`).
+      this.projectContextBlock = contextResult?.projectContextBlock ?? null;
+      if (this.disposed) return;
       const resp = await backend.newSession({
         cwd,
         mcpServers: resolveMcpServers(backend, getSettings().agentMode?.mcpServers),
+        // Capture the owning scope alongside cwd so the backend can resolve
+        // this project's instructions; GLOBAL_SCOPE for the global workspace.
+        projectId: this.projectId,
+        // Extra searchable roots from the project's materialized context. The
+        // backend honors them only when it advertises the capability.
+        additionalDirectories,
       });
       if (this.disposed) return;
       const modelLog = resp.state.model
@@ -891,6 +968,10 @@ export class AgentSession {
       // synchronously within this turn (callers rely on that timing).
       const hasWebTabs = (context?.webTabs?.length ?? 0) > 0;
       const webTabBlock = hasWebTabs ? await serializeWebTabContext(context) : "";
+      // The project-context block rides the FIRST user prompt only; capture it
+      // up front so both the fan-out and single-agent paths can inject it.
+      const isFirstTurn = !this.firstPromptSent;
+      const projectContextBlock = isFirstTurn ? this.projectContextBlock : null;
 
       // Fan-out path: the `@`-mentioned answerers dispatch the identical prompt in
       // parallel ephemeral read-only sub-sessions and the main agent summarizes.
@@ -922,8 +1003,12 @@ export class AgentSession {
           context,
           promptContent,
           webTabBlock,
+          projectContextBlock,
           historyBlock
         );
+        // The first-turn project-context block (if any) has now been delivered to
+        // the fan-out agents; mark it so the next visible turn doesn't re-inject it.
+        if (isFirstTurn) this.firstPromptSent = true;
         return await this.runFanoutPath(placeholderId, displayText, promptBlocks, turnStartedAt);
       }
 
@@ -937,6 +1022,7 @@ export class AgentSession {
         context,
         promptContent,
         webTabBlock,
+        projectContextBlock,
         leadingContextBlock
       );
 
@@ -952,6 +1038,11 @@ export class AgentSession {
       if (leadingContextBlock !== null && resp.stopReason !== "cancelled") {
         this.pendingFanoutContext = [];
       }
+      // Mark the project-context block delivered only once the backend has accepted
+      // the turn, so a hard `prompt()` failure (transport/auth) leaves the flag
+      // unset and the user's retry re-delivers the context (a user cancel still
+      // resolves here, and the prompt did reach the backend, so it counts as delivered).
+      if (isFirstTurn) this.firstPromptSent = true;
       if (
         placeholderId &&
         resp.stopReason !== "cancelled" &&
@@ -1157,6 +1248,8 @@ export class AgentSession {
     this.flushQuestionResolvers();
     this.decidedPlanToolCallIds.clear();
     this.currentPlan = null;
+    this.currentTodoList = null;
+    this.currentTodoListSignature = null;
     this.settledStream = null;
     this.currentMessageIds = new Set();
     // Fire the `"closed"` transition before clearing listeners so
@@ -1215,6 +1308,16 @@ export class AgentSession {
   /** Snapshot of the singleton plan, or `null` if there's nothing to review. */
   getCurrentPlan(): CurrentPlan | null {
     return this.currentPlan;
+  }
+
+  /**
+   * The live execution todo list, or `null` when the session has none (no
+   * update yet, the agent cleared it, or the session was resumed — the
+   * snapshot is live-only; persistence never stores it). Returns the held
+   * array reference so React subscribers don't tear on unrelated ticks.
+   */
+  getCurrentTodoList(): AgentTodoListEntry[] | null {
+    return this.currentTodoList;
   }
 
   /**
@@ -1425,6 +1528,12 @@ export class AgentSession {
 
   private handleSessionEvent(event: SessionEvent): void {
     const update = event.update;
+
+    // Refresh the live todo snapshot before any placeholder gating — the
+    // snapshot is session-scoped state, not part of the message trail.
+    if (update.sessionUpdate === "plan" && this.applyCurrentTodoList(update.entries)) {
+      this.notifyCurrentTodoListChanged();
+    }
 
     // Session-scoped updates aren't tied to a turn placeholder.
     if (update.sessionUpdate === "session_info_update") {
@@ -1682,6 +1791,43 @@ export class AgentSession {
     }
   }
 
+  /**
+   * Apply a `plan` update's entries to the live todo snapshot. Returns true
+   * when the canonical content actually changed (signature compare) — equal
+   * lists from redundant updates (opencode's synthesized + real plan channel,
+   * Claude's multiple stream injection points) are dropped silently. An empty
+   * entries list clears the snapshot back to `null`.
+   *
+   * Layer 2 of 3 in the todo-plan dedup chain — the SNAPSHOT layer: suppresses
+   * no-op `onCurrentTodoListChanged` ticks for the Progress section. It is NOT
+   * redundant with the others: the emit layer (`claudeTodoPlan.emitIfChanged`)
+   * collapses one backend's repeated injections, and `planEntriesEqual`
+   * (AgentMessageStore) dedups the rendered plan message part — this layer is
+   * the only one guarding the live snapshot's listeners, and the only one that
+   * sees ALL backends' plan updates converged.
+   */
+  private applyCurrentTodoList(entries: AgentPlanEntry[]): boolean {
+    const next: AgentTodoListEntry[] = entries.map((e) => ({
+      content: e.content,
+      status: e.status,
+    }));
+    const signature = next.length > 0 ? JSON.stringify(next) : null;
+    if (signature === this.currentTodoListSignature) return false;
+    this.currentTodoList = next.length > 0 ? next : null;
+    this.currentTodoListSignature = signature;
+    return true;
+  }
+
+  private notifyCurrentTodoListChanged(): void {
+    for (const l of this.listeners) {
+      try {
+        l.onCurrentTodoListChanged?.();
+      } catch (e) {
+        logWarn(`[AgentMode] todo-list listener threw`, e);
+      }
+    }
+  }
+
   private notifyCurrentPlanChanged(): void {
     for (const l of this.listeners) {
       try {
@@ -1810,13 +1956,17 @@ export function buildPromptBlocks(
   context?: MessageContext,
   content?: PromptContent[],
   webTabBlock?: string,
+  projectContextBlock?: string | null,
   leadingContextBlock?: string | null
 ): PromptContent[] {
-  // Context sections precede the user message: an optional prior-turn block
-  // (buffered fan-out turns the backend never saw), the vault envelope, web-
-  // selection excerpts, then live web-tab content. Web blocks reuse the legacy
-  // `<web_*>` tags. `leadingContextBlock` is absent on the common path.
+  // Context sections precede the user message: the project-context block (first
+  // user prompt only — the project's folders/notes/URLs), then an optional
+  // prior-turn block (buffered fan-out turns the backend never saw), the vault
+  // envelope (attached notes + note excerpts), web-selection excerpts, then live
+  // web-tab content. Web tab/selection blocks reuse the legacy `<web_*>` tags so
+  // the model reads the same shapes it does in the non-agent chat.
   const sections = [
+    projectContextBlock?.trim() || null,
     leadingContextBlock?.trim() || null,
     buildContextEnvelope(context),
     buildWebSelectionBlocks(context),
@@ -1878,8 +2028,10 @@ function buildWebSelectionBlocks(context: MessageContext | undefined): string | 
 }
 
 /**
- * Build the `<copilot-context>` envelope listing attached vault paths and
- * inlining note excerpts. Returns `null` when there's nothing to attach.
+ * Build the `<attached_context>` envelope listing the vault items attached to
+ * THIS message (`@notes` + selected excerpts) and inlining note excerpts.
+ * Returns `null` when there's nothing to attach. Distinct from the project-wide
+ * `<project_context>` block, which lists the project's configured sources.
  */
 function buildContextEnvelope(context: MessageContext | undefined): string | null {
   if (!context) return null;
@@ -1888,7 +2040,7 @@ function buildContextEnvelope(context: MessageContext | undefined): string | nul
   if (notePaths.length === 0 && excerpts.length === 0) return null;
 
   const lines: string[] = [
-    "<copilot-context>",
+    "<attached_context>",
     "The user attached the following vault items. The vault is your current working directory; use the Read tool to inspect them when relevant.",
   ];
   if (notePaths.length > 0) {
@@ -1902,7 +2054,7 @@ function buildContextEnvelope(context: MessageContext | undefined): string | nul
       for (const l of e.content.split("\n")) lines.push(`  ${l}`);
     }
   }
-  lines.push("</copilot-context>");
+  lines.push("</attached_context>");
   return lines.join("\n");
 }
 

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -2031,7 +2031,7 @@ function buildWebSelectionBlocks(context: MessageContext | undefined): string | 
 }
 
 /**
- * Build the `<attached_context>` envelope listing the vault items attached to
+ * Build the `<copilot-context>` envelope listing the vault items attached to
  * THIS message (`@notes` + selected excerpts) and inlining note excerpts.
  * Returns `null` when there's nothing to attach. Distinct from the project-wide
  * `<project_context>` block, which lists the project's configured sources.
@@ -2043,7 +2043,7 @@ function buildContextEnvelope(context: MessageContext | undefined): string | nul
   if (notePaths.length === 0 && excerpts.length === 0) return null;
 
   const lines: string[] = [
-    "<attached_context>",
+    "<copilot-context>",
     "The user attached the following vault items. The vault is your current working directory; use the Read tool to inspect them when relevant.",
   ];
   if (notePaths.length > 0) {
@@ -2057,7 +2057,7 @@ function buildContextEnvelope(context: MessageContext | undefined): string | nul
       for (const l of e.content.split("\n")) lines.push(`  ${l}`);
     }
   }
-  lines.push("</attached_context>");
+  lines.push("</copilot-context>");
   return lines.join("\n");
 }
 

--- a/src/agentMode/session/AgentSessionIndex.test.ts
+++ b/src/agentMode/session/AgentSessionIndex.test.ts
@@ -155,6 +155,36 @@ describe("AgentSessionIndex", () => {
     expect((await second.getEntry("opencode", "s1"))?.title).toBe("My rename");
   });
 
+  it("scopes entries to a project; sweeps fill a missing scope but never strip a known one", async () => {
+    // Reason: project views filter native entries by the recorded projectId.
+    // Write-through (live sessions) is authoritative; a `listSessions` sweep
+    // re-discovering the same session arrives without (or with weaker)
+    // attribution and must not detach the chat from its project.
+    const index = new AgentSessionIndex(makeStorage(), INDEX_PATH);
+    await index.recordSession(entry({ projectId: "proj-1" }));
+    await index.mergeDiscoveredSessions([entry({ title: "Sweep title", lastAccessedAtMs: 9_000 })]);
+    expect((await index.getEntry("opencode", "s1"))?.projectId).toBe("proj-1");
+
+    // A sweep CAN attribute a session the index never saw live (CLI-created
+    // inside a project folder).
+    await index.mergeDiscoveredSessions([
+      entry({ sessionId: "s2", projectId: "proj-2", lastAccessedAtMs: 9_000 }),
+    ]);
+    expect((await index.getEntry("opencode", "s2"))?.projectId).toBe("proj-2");
+  });
+
+  it("the project scope round-trips through persistence", async () => {
+    const storage = makeStorage();
+    const first = new AgentSessionIndex(storage, INDEX_PATH);
+    await first.recordSession(entry({ projectId: "proj-1" }));
+    await first.recordSession(entry({ sessionId: "global-chat" }));
+    await first.flush();
+    const second = new AgentSessionIndex(storage, INDEX_PATH);
+    expect((await second.getEntry("opencode", "s1"))?.projectId).toBe("proj-1");
+    // Absent scope (a pre-projectId or global entry) stays absent ≙ global.
+    expect((await second.getEntry("opencode", "global-chat"))?.projectId).toBeUndefined();
+  });
+
   it("persists across instances via flush and ignores corrupt files", async () => {
     const storage = makeStorage();
     const first = new AgentSessionIndex(storage, INDEX_PATH);

--- a/src/agentMode/session/AgentSessionIndex.ts
+++ b/src/agentMode/session/AgentSessionIndex.ts
@@ -23,6 +23,15 @@ export interface AgentSessionIndexEntry {
   titleSource?: "user" | "agent";
   createdAtMs: number;
   lastAccessedAtMs: number;
+  /**
+   * Owning Agent Projects scope. Absent ≙ the global workspace — including
+   * every entry written before this field existed, so old index files keep
+   * working without a version bump. The project id (not the folder path) is
+   * stored because ids survive a project folder rename; live write-through is
+   * the authoritative source (each `AgentSession` is scope-immutable), with
+   * native sweeps falling back to cwd→project-folder attribution.
+   */
+  projectId?: string;
 }
 
 interface AgentSessionIndexFile {
@@ -76,6 +85,7 @@ function sanitizeEntry(raw: unknown): AgentSessionIndexEntry | null {
       title && (r.titleSource === "user" || r.titleSource === "agent") ? r.titleSource : undefined,
     createdAtMs: createdAtMs ?? lastAccessedAtMs!,
     lastAccessedAtMs: lastAccessedAtMs ?? createdAtMs!,
+    projectId: typeof r.projectId === "string" && r.projectId.trim() ? r.projectId : undefined,
   };
 }
 
@@ -134,6 +144,10 @@ export class AgentSessionIndex {
         entry.lastAccessedAtMs,
         existing?.lastAccessedAtMs ?? entry.lastAccessedAtMs
       ),
+      // A session's scope is immutable, so live and recorded values can only
+      // agree — keep whichever side knows it (an absent incoming value must
+      // not strip a previously recorded scope).
+      projectId: entry.projectId ?? existing?.projectId,
     });
     this.scheduleSave();
   }
@@ -163,12 +177,16 @@ export class AgentSessionIndex {
           entry.lastAccessedAtMs,
           existing?.lastAccessedAtMs ?? entry.lastAccessedAtMs
         ),
+        // Write-through knows the scope authoritatively; a sweep's cwd-derived
+        // attribution only fills gaps, never overrides.
+        projectId: existing?.projectId ?? entry.projectId,
       };
       if (
         !existing ||
         existing.title !== next.title ||
         existing.createdAtMs !== next.createdAtMs ||
-        existing.lastAccessedAtMs !== next.lastAccessedAtMs
+        existing.lastAccessedAtMs !== next.lastAccessedAtMs ||
+        existing.projectId !== next.projectId
       ) {
         this.entries.set(key, next);
         changed = true;

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -2487,6 +2487,35 @@ describe("AgentSessionManager.enterProject MRU touch", () => {
     expect(mgr.getActiveProjectId()).toBe(PROJECT_ID);
     expect(mgr.getActiveSession()).toBe(projectSession);
   });
+
+  it("rolls the entered scope back when its auto-spawn fails", async () => {
+    const OTHER_ID = "proj-other-fail";
+    recordSpy.mockImplementation((id: string) =>
+      id === PROJECT_ID || id === OTHER_ID
+        ? { filePath: `Projects/${id}/project.md`, project: { id } }
+        : undefined
+    );
+    const mgr = buildManager();
+    // Land in a project scope with a live session — the exact state a failed
+    // entry into a DIFFERENT project must restore.
+    await mgr.enterProject(PROJECT_ID);
+    const projectSession = mgr.getActiveSession();
+    expect(mgr.getActiveProjectId()).toBe(PROJECT_ID);
+
+    // Entering OTHER_ID switches the active scope and nulls the active session
+    // before awaiting the fresh spawn; the spawn then rejects. (Inject at
+    // AgentSession.start, which createSession always calls even on a warm proc —
+    // the prior enter left the backend running, so a cold-start reject wouldn't
+    // fire here.) The rollback must restore the prior scope + session rather than
+    // strand the manager in a chatless OTHER_ID scope (callers only show a Notice).
+    sessionCreateSpy.mockImplementationOnce(() => {
+      throw new Error("spawn boom");
+    });
+    await expect(mgr.enterProject(OTHER_ID)).rejects.toThrow();
+
+    expect(mgr.getActiveProjectId()).toBe(PROJECT_ID);
+    expect(mgr.getActiveSession()).toBe(projectSession);
+  });
 });
 
 describe("AgentSessionManager fresh-visit tab detach", () => {

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -2620,13 +2620,14 @@ describe("AgentSessionManager context-source dirty tracking", () => {
 
   function makeRecord(
     contextSource: ProjectConfig["contextSource"],
-    usageTimestamps = 0
+    usageTimestamps = 0,
+    systemPrompt = ""
   ): ProjectFileRecord {
     return {
       project: {
         id: PID,
         name: PID,
-        systemPrompt: "",
+        systemPrompt,
         projectModelKey: "",
         modelConfigs: {},
         contextSource,
@@ -2783,6 +2784,26 @@ describe("AgentSessionManager context-source dirty tracking", () => {
 
     expect(sessionCreateSpy).not.toHaveBeenCalled();
     expect(mgr.getActiveSession()).toBe(landing);
+  });
+
+  it("does not reuse an empty landing after a System-Prompt-only edit", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }, 0, "old instructions"));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    const landing = mgr.getActiveSession();
+    if (!landing) throw new Error("expected a landing session");
+    await mgr.exitProject();
+
+    // The materialization signature is unchanged (sources identical), so the
+    // project is NOT dirty — but the landing-capture signature changed, so the
+    // stale landing (which baked in the old instructions) must not be reused.
+    publish(makeRecord({ webUrls: "https://a.com" }, 0, "new instructions"));
+
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PID);
+
+    expect(sessionCreateSpy).toHaveBeenCalledTimes(1);
+    expect(mgr.getActiveSession()).not.toBe(landing);
   });
 
   it("rematerializeContext forces a retry of known-bad sources", async () => {

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -8,11 +8,27 @@ import { AgentSession } from "./AgentSession";
 import { buildNativeChatId } from "@/utils/nativeChatId";
 import { AgentSessionIndex } from "./AgentSessionIndex";
 import { AgentSessionManager } from "./AgentSessionManager";
+import { GLOBAL_SCOPE } from "./scope";
 import {
   getSettings as mockedGetSettings,
   setSettings as mockedSetSettings,
 } from "@/settings/model";
+import * as projectsState from "@/projects/state";
+import {
+  ensureProjectContextMaterialized,
+  type ContextMaterializeProgress,
+} from "@/context/projectContextMaterializer";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import {
+  agentProjectContextLoadAtom,
+  type AgentProjectContextLoadState,
+  type ProjectConfig,
+} from "@/aiParams";
+import type { ProjectFileRecord } from "@/projects/type";
+import { getProjectContextSignature } from "@/projects/projectContextSignature";
 import type { BackendDescriptor } from "./types";
+
+const mockEnsureMaterialized = ensureProjectContextMaterialized as jest.Mock;
 
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
@@ -26,6 +42,39 @@ const settingsChangeCallbacks = new Set<
   (prev: { agentMode: unknown }, next: { agentMode: unknown }) => void
 >();
 
+// Stub the project-folder mirror so a non-global spawn never touches the vault.
+jest.mock("@/projects/ensureAgentsMirror", () => ({
+  ensureAgentsMirror: jest.fn(async () => undefined),
+}));
+
+// MRU touch is fire-and-forget through the singleton; mock it so enterProject
+// tests assert the call without real frontmatter IO.
+const mockTouchProjectLastUsed = jest.fn(async () => undefined);
+jest.mock("@/projects/ProjectFileManager", () => ({
+  ProjectFileManager: {
+    getInstance: jest.fn(() => ({ touchProjectLastUsed: mockTouchProjectLastUsed })),
+  },
+}));
+
+// Stub context materialization so a non-global create / background warm never
+// hits brevilabs or the disk. The result faithfully carries the CAPTURED
+// signature of the live record (what the real materializer returns), so the
+// dirty-clear path behaves realistically; a spy so warm calls can be asserted.
+jest.mock("@/context/projectContextMaterializer", () => {
+  const { getProjectContextSignature } = jest.requireActual("@/projects/projectContextSignature");
+  const { getCachedProjectRecordById } = jest.requireActual("@/projects/state");
+  return {
+    ensureProjectContextMaterialized: jest.fn(async (_app: unknown, projectId: string) => {
+      const record = getCachedProjectRecordById(projectId);
+      return {
+        additionalDirectories: [],
+        contextSignature: record ? getProjectContextSignature(record) : undefined,
+      };
+    }),
+    EMPTY_CONTEXT_MATERIALIZATION_RESULT: { additionalDirectories: [] },
+  };
+});
+
 jest.mock("@/settings/model", () => ({
   getSettings: jest.fn(() => ({
     agentMode: { activeBackend: "opencode", backends: {} },
@@ -37,6 +86,10 @@ jest.mock("@/settings/model", () => ({
       return () => settingsChangeCallbacks.delete(cb);
     }
   ),
+  // Minimal jotai-store shim: a non-global spawn publishes context-load state
+  // through it (beginContextMaterialization). `get` returns an empty map so the
+  // first publish "owns" the flight; `set` is a no-op spy.
+  settingsStore: { get: jest.fn(() => ({})), set: jest.fn() },
 }));
 
 /** Fire the manager's settings subscription with a before/after pair. */
@@ -75,6 +128,10 @@ interface MockSessionTestHandle {
   setStatus(
     status: "starting" | "idle" | "running" | "awaiting_permission" | "error" | "closed"
   ): void;
+  /** Seed the display messages so a manual save writes a file (and a path). */
+  setMessages(messages: { message: string }[]): void;
+  /** Toggle whether the session reports user-visible messages (detach gating). */
+  setHasUserVisibleMessages(value: boolean): void;
 }
 
 const sessionTestHandles = new Map<string, MockSessionTestHandle>();
@@ -89,11 +146,14 @@ function makeMockSession(overrides: {
   internalId: string;
   backendSessionId?: string;
   backendId: string;
+  projectId?: string;
   ready?: Promise<void>;
 }): AgentSession {
   const sessionId = overrides.backendSessionId ?? `backend-${nextBackendSessionId++}`;
   let status: "starting" | "idle" | "running" | "awaiting_permission" | "error" | "closed" = "idle";
   let needsAttention = false;
+  let displayMessages: { message: string }[] = [];
+  let hasUserVisibleMessages = false;
   const listeners = new Set<{
     onStatusChanged?: (s: typeof status) => void;
     onNeedsAttentionChanged?: (v: boolean) => void;
@@ -101,9 +161,11 @@ function makeMockSession(overrides: {
   const session = {
     internalId: overrides.internalId,
     backendId: overrides.backendId,
+    projectId: overrides.projectId ?? GLOBAL_SCOPE,
     ready: overrides.ready ?? Promise.resolve(),
     getBackendSessionId: () => sessionId,
     getStatus: () => status,
+    store: { getDisplayMessages: () => displayMessages },
     cancel: mockSessionCancel,
     dispose: mockSessionDispose,
     setModel: jest.fn(),
@@ -115,7 +177,7 @@ function makeMockSession(overrides: {
       listeners.add(l);
       return () => listeners.delete(l);
     },
-    hasUserVisibleMessages: () => false,
+    hasUserVisibleMessages: () => hasUserVisibleMessages,
     getState: () => null,
     getRawSnapshot: () => ({ models: null, modes: null, configOptions: null }),
     getNeedsAttention: () => needsAttention,
@@ -136,15 +198,23 @@ function makeMockSession(overrides: {
       status = next;
       for (const l of listeners) l.onStatusChanged?.(next);
     },
+    setMessages: (messages) => {
+      displayMessages = messages;
+    },
+    setHasUserVisibleMessages: (value) => {
+      hasUserVisibleMessages = value;
+    },
   });
   return session;
 }
 
-const sessionCreateSpy = jest
-  .spyOn(AgentSession, "start")
-  .mockImplementation((opts) =>
-    makeMockSession({ internalId: opts.internalId, backendId: opts.backendId })
-  );
+const sessionCreateSpy = jest.spyOn(AgentSession, "start").mockImplementation((opts) =>
+  makeMockSession({
+    internalId: opts.internalId,
+    backendId: opts.backendId,
+    projectId: opts.projectId,
+  })
+);
 
 function buildApp(basePath = "/vault"): App {
   const adapter = new (FileSystemAdapter as unknown as new (basePath: string) => unknown)(basePath);
@@ -946,6 +1016,165 @@ describe("AgentSessionManager attention tracking", () => {
   });
 });
 
+describe("AgentSessionManager.getRunningChatIds", () => {
+  // A manager whose saveSession returns a stable on-disk path, so we can drive
+  // a session into the "saved" (markdown path) recent-list identity.
+  function buildManagerWithPersistence(): AgentSessionManager {
+    const descriptor = buildDescriptor();
+    const persistence = {
+      saveSession: jest.fn(async () => ({ path: "chats/agent__saved.md" })),
+    };
+    return new AgentSessionManager(
+      buildApp(),
+      buildPlugin() as unknown as ConstructorParameters<typeof AgentSessionManager>[1],
+      {
+        permissionPrompter: jest.fn(),
+        resolveDescriptor: (id) => (id === descriptor.id ? descriptor : undefined),
+        modelPreloader: {
+          getCachedBackendState: jest.fn(() => null),
+          preload: jest.fn(async () => undefined),
+          refresh: jest.fn(() => null),
+          subscribe: jest.fn(() => () => {}),
+          shutdown: jest.fn(),
+          setCached: jest.fn(),
+          clearCached: jest.fn(),
+          takeWarm: jest.fn(() => null),
+          getWarmProcs: jest.fn(() => []),
+        } as unknown as ConstructorParameters<typeof AgentSessionManager>[2]["modelPreloader"],
+        persistenceManager: persistence as unknown as ConstructorParameters<
+          typeof AgentSessionManager
+        >[2]["persistenceManager"],
+      }
+    );
+  }
+
+  it("returns the same frozen empty set when nothing is running", async () => {
+    const mgr = buildManager();
+    const a = await mgr.createSession();
+    getSessionTestHandle(a).setStatus("idle");
+    const first = mgr.getRunningChatIds();
+    expect(first.size).toBe(0);
+    // Referential stability: an empty result must reuse the module constant.
+    expect(mgr.getRunningChatIds()).toBe(first);
+  });
+
+  it("keys a running saved session by its markdown path", async () => {
+    const mgr = buildManagerWithPersistence();
+    const a = await mgr.createSession();
+    getSessionTestHandle(a).setMessages([{ message: "hi" }]);
+    await mgr.saveActiveSession();
+    getSessionTestHandle(a).setStatus("running");
+    expect(mgr.getRunningChatIds().has("chats/agent__saved.md")).toBe(true);
+  });
+
+  it("keys a running native session by its native chat id", async () => {
+    const mgr = buildManager();
+    const a = await mgr.createSession();
+    getSessionTestHandle(a).setStatus("running");
+    const expected = buildNativeChatId(a.backendId, a.getBackendSessionId()!);
+    expect(mgr.getRunningChatIds().has(expected)).toBe(true);
+  });
+
+  it("excludes idle / starting / closed sessions", async () => {
+    const mgr = buildManager();
+    const a = await mgr.createSession();
+    const b = await mgr.createSession();
+    getSessionTestHandle(a).setStatus("running");
+    getSessionTestHandle(b).setStatus("starting");
+    const ids = mgr.getRunningChatIds();
+    expect(ids.has(buildNativeChatId(a.backendId, a.getBackendSessionId()!))).toBe(true);
+    expect(ids.has(buildNativeChatId(b.backendId, b.getBackendSessionId()!))).toBe(false);
+  });
+
+  it("notifies subscribers when a session's running membership flips", async () => {
+    const mgr = buildManager();
+    const a = await mgr.createSession();
+    const listener = jest.fn();
+    mgr.subscribe(listener);
+    getSessionTestHandle(a).setStatus("running");
+    expect(listener).toHaveBeenCalledTimes(1);
+    listener.mockClear();
+    getSessionTestHandle(a).setStatus("idle");
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps both ids when a running session's first save re-keys it (dual-id)", async () => {
+    const mgr = buildManagerWithPersistence();
+    const a = await mgr.createSession();
+    getSessionTestHandle(a).setMessages([{ message: "hi" }]);
+    getSessionTestHandle(a).setStatus("running");
+    // Before the save the running session is keyed by its native id.
+    const nativeId = buildNativeChatId(a.backendId, a.getBackendSessionId()!);
+    expect(mgr.getRunningChatIds().has(nativeId)).toBe(true);
+
+    const listener = jest.fn();
+    mgr.subscribe(listener);
+    await mgr.saveActiveSession();
+
+    // The save itself must not notify (autosave stays decoupled from row
+    // visibility). Instead the set now carries BOTH ids, so whichever id the
+    // mounted list rendered the row under, `.has()` still hits.
+    expect(listener).not.toHaveBeenCalled();
+    const ids = mgr.getRunningChatIds();
+    expect(ids.has("chats/agent__saved.md")).toBe(true);
+    expect(ids.has(nativeId)).toBe(true);
+  });
+});
+
+describe("AgentSessionManager.getAttentionChatIds", () => {
+  it("returns the same frozen empty set when nothing needs attention", async () => {
+    const mgr = buildManager();
+    await mgr.createSession();
+    const first = mgr.getAttentionChatIds();
+    expect(first.size).toBe(0);
+    expect(mgr.getAttentionChatIds()).toBe(first);
+  });
+
+  it("hands a backgrounded finished session over from running to attention", async () => {
+    const mgr = buildManager();
+    const a = await mgr.createSession();
+    const b = await mgr.createSession();
+    // b is active by default; switch to a so b runs in the background.
+    mgr.setActiveSession(a.internalId);
+    const bHandle = getSessionTestHandle(b);
+    const nativeId = buildNativeChatId(b.backendId, b.getBackendSessionId()!);
+
+    bHandle.setStatus("running");
+    expect(mgr.getRunningChatIds().has(nativeId)).toBe(true);
+    expect(mgr.getAttentionChatIds().has(nativeId)).toBe(false);
+
+    // Finishing in the background: the id must leave the running set and
+    // enter the attention set in the same status flip — the row's spinner
+    // hands off to the live done-dot without a history reload.
+    bHandle.setStatus("idle");
+    expect(mgr.getRunningChatIds().has(nativeId)).toBe(false);
+    expect(mgr.getAttentionChatIds().has(nativeId)).toBe(true);
+  });
+
+  it("does not include the active session (it never flags attention)", async () => {
+    const mgr = buildManager();
+    const a = await mgr.createSession();
+    const aHandle = getSessionTestHandle(a);
+    aHandle.setStatus("running");
+    aHandle.setStatus("idle");
+    expect(mgr.getAttentionChatIds().size).toBe(0);
+  });
+
+  it("drops the id once the user activates the flagged tab", async () => {
+    const mgr = buildManager();
+    const a = await mgr.createSession();
+    const b = await mgr.createSession();
+    mgr.setActiveSession(a.internalId);
+    const bHandle = getSessionTestHandle(b);
+    bHandle.setStatus("running");
+    bHandle.setStatus("idle");
+    const nativeId = buildNativeChatId(b.backendId, b.getBackendSessionId()!);
+    expect(mgr.getAttentionChatIds().has(nativeId)).toBe(true);
+    mgr.setActiveSession(b.internalId);
+    expect(mgr.getAttentionChatIds().has(nativeId)).toBe(false);
+  });
+});
+
 describe("AgentSessionManager.replaceSessionInPlace", () => {
   // Drains the fire-and-forget `closeSession` chain that
   // replaceSessionInPlace kicks off, so assertions about pool removal
@@ -1562,6 +1791,7 @@ describe("AgentSessionManager chat history aggregation", () => {
     backendId?: string;
     sessionId?: string;
     lastAccessedAt?: number;
+    projectId?: string;
   }
 
   function makeIndexStorage() {
@@ -1750,6 +1980,34 @@ describe("AgentSessionManager chat history aggregation", () => {
     expect(items[0]?.id).toBe(buildNativeChatId("codex", "s9"));
   });
 
+  it("scopes a project view's native entries by the index's recorded projectId", async () => {
+    // Autosave-off project chats have no markdown frontmatter — the index's
+    // recorded scope is the only thing that can place them in a project list.
+    const { manager, index } = buildHistoryHarness();
+    await index.recordSession({
+      backendId: "codex",
+      sessionId: "in-project",
+      title: "Project chat",
+      createdAtMs: 1_000,
+      lastAccessedAtMs: 2_000,
+      projectId: "proj-1",
+    });
+    await index.recordSession({
+      backendId: "codex",
+      sessionId: "global-chat",
+      title: "Global chat",
+      createdAtMs: 1_000,
+      lastAccessedAtMs: 2_000,
+    });
+
+    const projectItems = await manager.getChatHistoryItems("proj-1");
+    expect(projectItems).toHaveLength(1);
+    expect(projectItems[0]?.id).toBe(buildNativeChatId("codex", "in-project"));
+
+    // The global view stays the flat all-scopes list.
+    expect(await manager.getChatHistoryItems()).toHaveLength(2);
+  });
+
   it("deleting a native entry tombstones it without touching persistence", async () => {
     const { manager, index, persistence } = buildHistoryHarness();
     await index.recordSession({
@@ -1863,6 +2121,137 @@ describe("AgentSessionManager chat history aggregation", () => {
     expect(titles).toContain("Made here");
     expect(titles).not.toContain("Made elsewhere");
     expect(sessionExistsLocally).toHaveBeenCalledWith({ sessionId: "foreign", cwd: "/vault" });
+  });
+
+  it("probes a project chat's resumability with its project cwd, not the vault root", async () => {
+    // Regression: a backend that keys its transcript store by cwd (Claude) stores
+    // a project chat's transcript under the PROJECT folder. Probing it with the
+    // vault root would report a perfectly resumable local project chat as absent
+    // and hide it. The locality probe must use the chat's own scope cwd.
+    projectsState.updateCachedProjectRecords([
+      {
+        project: { id: "proj-1" },
+        filePath: "Projects/proj-1/project.md",
+        folderName: "proj-1",
+      } as unknown as ProjectFileRecord,
+    ]);
+    try {
+      const sessionExistsLocally = jest.fn(
+        async ({ cwd }: { cwd: string }) => cwd === "/vault/Projects/proj-1"
+      );
+      const { manager } = buildHistoryHarness({
+        files: {
+          "chats/agent__p.md": {
+            epoch: 2_000,
+            topic: "Project chat",
+            backendId: "opencode",
+            sessionId: "proj-sess",
+            projectId: "proj-1",
+          },
+        },
+        warmSessionExistsLocally: sessionExistsLocally,
+      });
+
+      const titles = (await manager.getChatHistoryItems("proj-1")).map((i) => i.title);
+      expect(titles).toContain("Project chat");
+      expect(sessionExistsLocally).toHaveBeenCalledWith({
+        sessionId: "proj-sess",
+        cwd: "/vault/Projects/proj-1",
+      });
+    } finally {
+      projectsState.updateCachedProjectRecords([]);
+    }
+  });
+
+  it("probes each chat with its own scope cwd in the global flat view", async () => {
+    // The global Recent Chats view is a flat all-scopes list, so it must probe a
+    // global chat against the vault root AND a project chat against its project
+    // folder in the same pass — otherwise the project row gets wrongly hidden.
+    projectsState.updateCachedProjectRecords([
+      {
+        project: { id: "proj-1" },
+        filePath: "Projects/proj-1/project.md",
+        folderName: "proj-1",
+      } as unknown as ProjectFileRecord,
+    ]);
+    try {
+      const sessionExistsLocally = jest.fn(async () => true);
+      const { manager } = buildHistoryHarness({
+        files: {
+          "chats/agent__g.md": {
+            epoch: 2_000,
+            topic: "Global chat",
+            backendId: "opencode",
+            sessionId: "g-sess",
+          },
+          "chats/agent__p.md": {
+            epoch: 1_000,
+            topic: "Project chat",
+            backendId: "opencode",
+            sessionId: "p-sess",
+            projectId: "proj-1",
+          },
+        },
+        warmSessionExistsLocally: sessionExistsLocally,
+      });
+
+      const titles = (await manager.getChatHistoryItems()).map((i) => i.title);
+      expect(titles).toEqual(expect.arrayContaining(["Global chat", "Project chat"]));
+      expect(sessionExistsLocally).toHaveBeenCalledWith({ sessionId: "g-sess", cwd: "/vault" });
+      expect(sessionExistsLocally).toHaveBeenCalledWith({
+        sessionId: "p-sess",
+        cwd: "/vault/Projects/proj-1",
+      });
+    } finally {
+      projectsState.updateCachedProjectRecords([]);
+    }
+  });
+
+  it("still hides a genuinely non-resumable project chat (probed against its project cwd)", async () => {
+    // The fix must not over-correct: a project chat synced from another machine
+    // is absent under its OWN project cwd too, so it stays hidden + tombstoned —
+    // identical behavior to a non-resumable global chat, just with the right cwd.
+    projectsState.updateCachedProjectRecords([
+      {
+        project: { id: "proj-1" },
+        filePath: "Projects/proj-1/project.md",
+        folderName: "proj-1",
+      } as unknown as ProjectFileRecord,
+    ]);
+    try {
+      const sessionExistsLocally = jest.fn(async () => false);
+      const { manager, index } = buildHistoryHarness({
+        files: {
+          "chats/agent__p.md": {
+            epoch: 2_000,
+            topic: "Foreign project chat",
+            backendId: "opencode",
+            sessionId: "foreign-proj",
+            projectId: "proj-1",
+          },
+        },
+        warmSessionExistsLocally: sessionExistsLocally,
+      });
+      await index.recordSession({
+        backendId: "opencode",
+        sessionId: "foreign-proj",
+        title: "Twin",
+        createdAtMs: 1_000,
+        lastAccessedAtMs: 2_000,
+        projectId: "proj-1",
+      });
+
+      const titles = (await manager.getChatHistoryItems("proj-1")).map((i) => i.title);
+      expect(titles).not.toContain("Foreign project chat");
+      expect(sessionExistsLocally).toHaveBeenCalledWith({
+        sessionId: "foreign-proj",
+        cwd: "/vault/Projects/proj-1",
+      });
+      // The native twin is tombstoned, same as the global non-resumable path.
+      expect(await index.isTombstoned("opencode", "foreign-proj")).toBe(true);
+    } finally {
+      projectsState.updateCachedProjectRecords([]);
+    }
   });
 
   it("tombstones the native twin of a dropped non-local markdown chat", async () => {
@@ -1982,5 +2371,551 @@ describe("AgentSessionManager chat history aggregation", () => {
     const items = await manager.getChatHistoryItems();
     expect(listSessions).not.toHaveBeenCalled();
     expect(items.filter((i) => i.id.startsWith("copilot-agent-session://"))).toHaveLength(0);
+  });
+});
+
+describe("AgentSessionManager.enterProject MRU touch", () => {
+  const PROJECT_ID = "proj-mru";
+  let recordSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockTouchProjectLastUsed.mockClear();
+    (ProjectFileManager.getInstance as jest.Mock).mockClear();
+    // Make the scope resolvable: enterProject's orphan guard and resolveScopeCwd
+    // both read this, so a known id must return a record with a folder.
+    recordSpy = jest
+      .spyOn(projectsState, "getCachedProjectRecordById")
+      .mockImplementation((id: string) =>
+        id === PROJECT_ID
+          ? ({
+              filePath: "Projects/proj-mru/project.md",
+              project: { id: PROJECT_ID },
+            } as unknown as ReturnType<typeof projectsState.getCachedProjectRecordById>)
+          : undefined
+      );
+  });
+
+  afterEach(() => recordSpy.mockRestore());
+
+  it("touches last-used after a successful enter that spawns a session", async () => {
+    const mgr = buildManager();
+    await mgr.enterProject(PROJECT_ID);
+    expect(ProjectFileManager.getInstance).toHaveBeenCalled();
+    expect(mockTouchProjectLastUsed).toHaveBeenCalledWith(PROJECT_ID);
+  });
+
+  it("touches last-used on the restored-session path (no re-spawn)", async () => {
+    const mgr = buildManager();
+    // First enter spawns the scope's session; leaving and re-entering reuses it.
+    await mgr.enterProject(PROJECT_ID);
+    await mgr.exitProject();
+    mockTouchProjectLastUsed.mockClear();
+    sessionCreateSpy.mockClear();
+
+    await mgr.enterProject(PROJECT_ID);
+
+    expect(sessionCreateSpy).not.toHaveBeenCalled();
+    expect(mockTouchProjectLastUsed).toHaveBeenCalledWith(PROJECT_ID);
+  });
+
+  it("does not touch when returning to the global scope", async () => {
+    const mgr = buildManager();
+    await mgr.enterProject(PROJECT_ID);
+    mockTouchProjectLastUsed.mockClear();
+
+    await mgr.exitProject();
+
+    expect(mockTouchProjectLastUsed).not.toHaveBeenCalled();
+  });
+
+  it("does not touch a re-click of the already-active project", async () => {
+    const mgr = buildManager();
+    await mgr.enterProject(PROJECT_ID);
+    mockTouchProjectLastUsed.mockClear();
+
+    // Same scope, live session — the early return must not count as a new use.
+    await mgr.enterProject(PROJECT_ID);
+
+    expect(mockTouchProjectLastUsed).not.toHaveBeenCalled();
+  });
+
+  it("does not touch when the spawn fails", async () => {
+    const mgr = buildManager();
+    // A rejected backend start makes getOrCreateActiveSession throw before the
+    // touch runs — a failed enter must not bump MRU.
+    mockBackendStart.mockRejectedValueOnce(new Error("spawn boom"));
+
+    await expect(mgr.enterProject(PROJECT_ID)).rejects.toThrow();
+
+    expect(mockTouchProjectLastUsed).not.toHaveBeenCalled();
+  });
+
+  it("touches only the current scope when another enter wins the spawn race", async () => {
+    const OTHER_ID = "proj-other";
+    recordSpy.mockImplementation((id: string) =>
+      id === PROJECT_ID || id === OTHER_ID
+        ? { filePath: `Projects/${id}/project.md`, project: { id } }
+        : undefined
+    );
+    const mgr = buildManager();
+
+    // Both enters set `activeProjectId` synchronously in call order, so the
+    // second call wins the active scope before either spawn's post-await touch
+    // runs (a later microtask). The first enter's touch must observe the moved
+    // scope and skip, crediting only the winner.
+    const enterStale = mgr.enterProject(PROJECT_ID);
+    const enterWinner = mgr.enterProject(OTHER_ID);
+    await Promise.all([enterStale, enterWinner]);
+
+    expect(mockTouchProjectLastUsed).toHaveBeenCalledWith(OTHER_ID);
+    expect(mockTouchProjectLastUsed).not.toHaveBeenCalledWith(PROJECT_ID);
+  });
+
+  it("rolls the active scope back when a cross-scope history load fails to resume", async () => {
+    const mgr = buildManager();
+    // The active session lives in the project scope.
+    await mgr.enterProject(PROJECT_ID);
+    const projectSession = mgr.getActiveSession();
+    expect(mgr.getActiveProjectId()).toBe(PROJECT_ID);
+
+    // Opening a global native chat on an unresolvable backend switches the
+    // active scope to global first, then rejects because the resume can't
+    // start. The failure must restore the project scope — otherwise the active
+    // scope and the (unchanged) active session would disagree.
+    await expect(mgr.loadNativeSessionFromHistory("codex", "missing")).rejects.toThrow();
+
+    expect(mgr.getActiveProjectId()).toBe(PROJECT_ID);
+    expect(mgr.getActiveSession()).toBe(projectSession);
+  });
+});
+
+describe("AgentSessionManager fresh-visit tab detach", () => {
+  const PROJECT_ID = "proj-detach";
+  let recordSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    sessionCreateSpy.mockClear();
+    recordSpy = jest
+      .spyOn(projectsState, "getCachedProjectRecordById")
+      .mockImplementation((id: string) =>
+        id === PROJECT_ID
+          ? ({
+              filePath: "Projects/proj-detach/project.md",
+              project: { id: PROJECT_ID },
+            } as unknown as ReturnType<typeof projectsState.getCachedProjectRecordById>)
+          : undefined
+      );
+  });
+
+  afterEach(() => recordSpy.mockRestore());
+
+  /** Enter the project, mark its active session conversational, then leave. */
+  async function enterWithConversation(mgr: AgentSessionManager): Promise<AgentSession> {
+    await mgr.enterProject(PROJECT_ID);
+    const session = mgr.getActiveSession();
+    if (!session) throw new Error("expected an active session after enter");
+    getSessionTestHandle(session).setHasUserVisibleMessages(true);
+    await mgr.exitProject();
+    return session;
+  }
+
+  it("detaches a conversational session on re-entry and spawns a fresh one", async () => {
+    const mgr = buildManager();
+    const old = await enterWithConversation(mgr);
+
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PROJECT_ID);
+
+    // A fresh session was spawned and is the only tab shown for the scope.
+    expect(sessionCreateSpy).toHaveBeenCalledTimes(1);
+    const visible = mgr.getSessionsForScope(PROJECT_ID);
+    expect(visible).toHaveLength(1);
+    expect(visible[0].internalId).not.toBe(old.internalId);
+    // The old session is hidden from the strip but still alive in the pool.
+    expect(mgr.getSessionsForScope(PROJECT_ID)).not.toContain(old);
+    expect(mgr.getSessions()).toContain(old);
+  });
+
+  it("does not reuse an error-state landing; spawns a fresh session instead", async () => {
+    const mgr = buildManager();
+    await mgr.enterProject(PROJECT_ID);
+    const landing = mgr.getActiveSession();
+    if (!landing) throw new Error("expected a landing session");
+    // Its backend never opened — not a clean slate to adopt.
+    getSessionTestHandle(landing).setStatus("error");
+    await mgr.exitProject();
+
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PROJECT_ID);
+
+    expect(sessionCreateSpy).toHaveBeenCalledTimes(1);
+    expect(mgr.getActiveSession()).not.toBe(landing);
+  });
+
+  it("reuses an empty landing session instead of stacking a blank tab", async () => {
+    const mgr = buildManager();
+    await mgr.enterProject(PROJECT_ID);
+    const landing = mgr.getActiveSession();
+    await mgr.exitProject();
+
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PROJECT_ID);
+
+    expect(sessionCreateSpy).not.toHaveBeenCalled();
+    expect(mgr.getActiveSession()).toBe(landing);
+    expect(mgr.getSessionsForScope(PROJECT_ID)).toHaveLength(1);
+  });
+
+  it("keeps a detached running session in getRunningChatIds (history spinner)", async () => {
+    const mgr = buildManager();
+    const old = await enterWithConversation(mgr);
+    getSessionTestHandle(old).setStatus("running");
+
+    await mgr.enterProject(PROJECT_ID);
+
+    expect(mgr.getSessionsForScope(PROJECT_ID)).not.toContain(old);
+    expect(mgr.getRunningChatIds().size).toBeGreaterThan(0);
+  });
+
+  it("keeps a detached needs-attention session in getAttentionChatIds (history dot)", async () => {
+    const mgr = buildManager();
+    const old = await enterWithConversation(mgr);
+    old.markNeedsAttention();
+
+    await mgr.enterProject(PROJECT_ID);
+
+    expect(mgr.getSessionsForScope(PROJECT_ID)).not.toContain(old);
+    expect(mgr.getAttentionChatIds().size).toBeGreaterThan(0);
+  });
+
+  it("re-attaches a detached session when it is surfaced via setActiveSession", async () => {
+    const mgr = buildManager();
+    const old = await enterWithConversation(mgr);
+    await mgr.enterProject(PROJECT_ID);
+    expect(mgr.getSessionsForScope(PROJECT_ID)).not.toContain(old);
+
+    mgr.setActiveSession(old.internalId);
+
+    expect(mgr.getSessionsForScope(PROJECT_ID)).toContain(old);
+    expect(mgr.getActiveSession()).toBe(old);
+  });
+
+  it("closeSession picks a visible neighbor, never a detached session", async () => {
+    const mgr = buildManager();
+    const old = await enterWithConversation(mgr);
+    await mgr.enterProject(PROJECT_ID);
+    const fresh = mgr.getActiveSession();
+    if (!fresh) throw new Error("expected a fresh active session");
+
+    await mgr.closeSession(fresh.internalId);
+
+    // The only other in-scope session is detached, so there is no visible
+    // neighbor to fall back to — the active pointer must not resurrect `old`.
+    expect(mgr.getActiveSession()).not.toBe(old);
+  });
+});
+
+describe("AgentSessionManager context-source dirty tracking", () => {
+  const PID = "proj-dirty";
+
+  function makeRecord(
+    contextSource: ProjectConfig["contextSource"],
+    usageTimestamps = 0
+  ): ProjectFileRecord {
+    return {
+      project: {
+        id: PID,
+        name: PID,
+        systemPrompt: "",
+        projectModelKey: "",
+        modelConfigs: {},
+        contextSource,
+        created: 0,
+        UsageTimestamps: usageTimestamps,
+      },
+      filePath: `Projects/${PID}/project.md`,
+      folderName: PID,
+    };
+  }
+
+  /** Publish a record set to the real store (drives subscribeToProjectRecords). */
+  function publish(record: ProjectFileRecord): void {
+    projectsState.updateCachedProjectRecords([record]);
+  }
+
+  // Dirty-clearing is chained off the (resolved) contextReady promise, so let
+  // the microtask queue drain before asserting the dirty flag's effect.
+  const flushAsync = () => new Promise((resolve) => window.setTimeout(resolve, 0));
+
+  // Track managers so each is shut down (unsubscribed) after its test —
+  // otherwise a prior test's still-subscribed manager would react to the next
+  // test's `publish()` and warm again, contaminating the call counts.
+  const builtManagers: AgentSessionManager[] = [];
+  function buildTrackedManager(): AgentSessionManager {
+    const mgr = buildManager();
+    builtManagers.push(mgr);
+    return mgr;
+  }
+
+  beforeEach(() => {
+    mockEnsureMaterialized.mockClear();
+    sessionCreateSpy.mockClear();
+    projectsState.updateCachedProjectRecords([]);
+  });
+
+  afterEach(async () => {
+    await Promise.all(builtManagers.splice(0).map((mgr) => mgr.shutdown().catch(() => {})));
+    projectsState.updateCachedProjectRecords([]);
+  });
+
+  it("marks an inactive project dirty so re-entry detaches the stale empty landing and respawns", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+
+    await mgr.enterProject(PID);
+    const landing = mgr.getActiveSession();
+    if (!landing) throw new Error("expected a landing session");
+    await mgr.exitProject();
+
+    // Source edit for the (now inactive) project: marks it dirty.
+    publish(makeRecord({ webUrls: "https://a.com\nhttps://b.com" }));
+
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PID);
+
+    // The stale empty landing is gone from the strip; a fresh session took over.
+    expect(sessionCreateSpy).toHaveBeenCalledTimes(1);
+    const visible = mgr.getSessionsForScope(PID);
+    expect(visible).toHaveLength(1);
+    expect(visible[0]).not.toBe(landing);
+    expect(mgr.getSessionsForScope(PID)).not.toContain(landing);
+  });
+
+  it("clears dirty once a fresh session captured the new sources (later re-entry reuses)", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    await mgr.exitProject();
+
+    publish(makeRecord({ webUrls: "https://a.com\nhttps://b.com" }));
+    await mgr.enterProject(PID); // dirty → fresh spawn
+    await flushAsync(); // let the post-materialization dirty-clear run
+    const fresh = mgr.getActiveSession();
+    await mgr.exitProject();
+
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PID); // no longer dirty → reuse the empty landing
+
+    expect(sessionCreateSpy).not.toHaveBeenCalled();
+    expect(mgr.getActiveSession()).toBe(fresh);
+  });
+
+  it("keeps a project dirty when the fresh session fails to start (ready rejects)", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    await flushAsync();
+    await mgr.exitProject();
+
+    publish(makeRecord({ webUrls: "https://a.com\nhttps://b.com" })); // dirty = v2
+
+    // The dirty re-entry's fresh session fails to start: ready rejects, so the
+    // ready-success dirty-clear never runs.
+    sessionCreateSpy.mockImplementationOnce((opts) => {
+      const rejected = Promise.reject(new Error("startup boom"));
+      rejected.catch(() => {}); // swallow the unhandled-rejection warning
+      return makeMockSession({
+        internalId: opts.internalId,
+        backendId: opts.backendId,
+        projectId: opts.projectId,
+        ready: rejected,
+      });
+    });
+    await mgr.enterProject(PID);
+    await flushAsync();
+    await mgr.exitProject();
+
+    // dirty must SURVIVE (no session captured the new sources) → re-entry respawns.
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PID);
+    expect(sessionCreateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a project dirty when the create captured an older signature (single-flight race)", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    await mgr.exitProject();
+
+    // Source advances to v2 → dirty = signature(v2).
+    publish(makeRecord({ webUrls: "https://a.com\nhttps://b.com" }));
+
+    // Simulate the next create JOINING an in-flight run that materialized the
+    // OLDER v1 record: the result carries v1's signature, not the live v2.
+    const v1Signature = getProjectContextSignature(makeRecord({ webUrls: "https://a.com" }));
+    mockEnsureMaterialized.mockImplementationOnce(async () => ({
+      additionalDirectories: [],
+      contextSignature: v1Signature,
+    }));
+
+    await mgr.enterProject(PID); // dirty → fresh spawn capturing stale v1
+    await flushAsync();
+    await mgr.exitProject();
+
+    // v1 ≠ dirty(v2), so the flag must SURVIVE — the stale landing is not reused.
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PID);
+    expect(sessionCreateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a usage-timestamp-only touch (no dirty, empty landing still reused)", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    const landing = mgr.getActiveSession();
+    await mgr.exitProject();
+
+    // Same context source, only the MRU timestamp moved — must NOT dirty.
+    publish(makeRecord({ webUrls: "https://a.com" }, 12345));
+
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PID);
+
+    expect(sessionCreateSpy).not.toHaveBeenCalled();
+    expect(mgr.getActiveSession()).toBe(landing);
+  });
+
+  it("rematerializeContext forces a retry of known-bad sources", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    await flushAsync();
+    mockEnsureMaterialized.mockClear();
+
+    const started = mgr.rematerializeContext(PID);
+    await flushAsync();
+
+    expect(started).toBe(true);
+    expect(mockEnsureMaterialized).toHaveBeenCalledTimes(1);
+    // The 5th arg (forceRetryFailed) is forwarded as true so the materializer
+    // re-fetches sources whose failure markers the automatic path would honor.
+    expect(mockEnsureMaterialized.mock.calls[0][4]).toBe(true);
+  });
+
+  it("rematerializeContext early-exits while a run already owns the load atom", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    await flushAsync();
+    mockEnsureMaterialized.mockClear();
+
+    // A full run is blocking the atom: the forced retry would otherwise join it
+    // and have its force swallowed, so it must early-exit instead.
+    const getMock = jest.requireMock("@/settings/model").settingsStore.get as jest.Mock;
+    getMock.mockReturnValueOnce({ [PID]: { phase: "prefetch", blocking: true } });
+
+    const started = mgr.rematerializeContext(PID);
+
+    expect(started).toBe(false);
+    expect(mockEnsureMaterialized).not.toHaveBeenCalled();
+  });
+
+  it("warms the active project's cache on a source edit without gating the composer", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID); // active = PID
+    await flushAsync(); // let create-time materialization + atom writes settle
+
+    // Clear create-time materialization + atom writes, isolate the warm.
+    mockEnsureMaterialized.mockClear();
+    const settingsStoreSet = jest.requireMock("@/settings/model").settingsStore.set as jest.Mock;
+    settingsStoreSet.mockClear();
+
+    publish(makeRecord({ webUrls: "https://a.com\nhttps://b.com" }));
+
+    // Background warm ran (disk refresh) but never published a blocking load
+    // state — the composer of the session that won't consume it stays ungated.
+    expect(mockEnsureMaterialized).toHaveBeenCalledTimes(1);
+    expect(settingsStoreSet).not.toHaveBeenCalled();
+  });
+
+  it("stops reacting to record changes after shutdown", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    await mgr.shutdown();
+
+    mockEnsureMaterialized.mockClear();
+    // A post-shutdown edit must not warm or throw.
+    expect(() => publish(makeRecord({ webUrls: "https://a.com\nhttps://b.com" }))).not.toThrow();
+    expect(mockEnsureMaterialized).not.toHaveBeenCalled();
+  });
+
+  it("publishes processingSources + incremental failedSources during a run, clears at done", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    const setMock = jest.requireMock("@/settings/model").settingsStore.set as jest.Mock;
+    // Reconstruct the latest published load-state by replaying the most recent
+    // `settingsStore.set(agentProjectContextLoadAtom, updater)` call (the store is
+    // mocked, so there is no live atom to read back).
+    const latest = (): AgentProjectContextLoadState | undefined => {
+      for (let i = setMock.mock.calls.length - 1; i >= 0; i--) {
+        const [atom, updater] = setMock.mock.calls[i];
+        if (atom !== agentProjectContextLoadAtom || typeof updater !== "function") continue;
+        const next = updater({}) as Record<string, AgentProjectContextLoadState>;
+        if (next[PID]) return next[PID];
+      }
+      return undefined;
+    };
+
+    let drive!: (p: ContextMaterializeProgress) => void;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    mockEnsureMaterialized.mockImplementationOnce(
+      async (
+        _app: unknown,
+        _pid: string,
+        _cwd: string,
+        onProgress: (p: ContextMaterializeProgress) => void
+      ) => {
+        drive = onProgress;
+        onProgress({ phase: "prefetch", done: 0, total: 1 });
+        onProgress({ phase: "itemStart", item: { kind: "web", source: "https://a.com" } });
+        await gate;
+        return { additionalDirectories: [] };
+      }
+    );
+
+    const entering = mgr.enterProject(PID);
+    await flushAsync();
+
+    // Mid-flight: the source being fetched is published in `processingSources`.
+    expect(latest()).toMatchObject({
+      phase: "prefetch",
+      blocking: true,
+      processingSources: [{ kind: "web", source: "https://a.com" }],
+    });
+
+    // Settle as a failure: it leaves `processingSources` and lands in
+    // `failedSources` immediately — not deferred to the end of the run.
+    drive({
+      phase: "itemFailed",
+      item: { kind: "web", source: "https://a.com" },
+      failure: { kind: "web", source: "https://a.com", error: "boom", usedStaleSnapshot: false },
+    });
+    const afterFail = latest()!;
+    expect(afterFail.processingSources).toBeUndefined();
+    expect(afterFail.failedSources).toEqual([
+      { path: "https://a.com", type: "web", error: "boom", usedStaleSnapshot: false },
+    ]);
+
+    release();
+    await entering;
+    await flushAsync(); // let the materialize `.then()` publish the terminal "done"
+    // Done: nothing is processing.
+    expect(latest()).toMatchObject({ phase: "done", blocking: false });
+    expect(latest()!.processingSources).toBeUndefined();
   });
 });

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -2,21 +2,41 @@ import { logError, logInfo, logWarn } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { AgentChatUIState } from "@/agentMode/session/AgentChatUIState";
 import {
+  agentProjectContextLoadAtom,
+  type AgentInFlightSource,
+  type AgentProjectContextLoadState,
+  type ContextLoadStepCount,
+  type FailedItem,
+} from "@/aiParams";
+import {
   getSettings,
   setSettings,
+  settingsStore,
   subscribeToSettingsChange,
   type CopilotSettings,
 } from "@/settings/model";
+import {
+  ensureProjectContextMaterialized,
+  EMPTY_CONTEXT_MATERIALIZATION_RESULT,
+  materializeProjectContextSource,
+  type ContextMaterializationResult,
+  type ContextMaterializeProgress,
+} from "@/context/projectContextMaterializer";
+import type {
+  MaterializedSourceType,
+  MaterializeSourceIdentity,
+  SourceFailure,
+} from "@/context/contextCacheStore";
 import { err2String } from "@/utils";
 import type { ChatHistoryItem } from "@/components/chat-components/ChatHistoryPopover";
-import { fileToHistoryItem } from "@/utils/chatHistoryUtils";
+import { fileToHistoryItem, readChatPathProjectId } from "@/utils/chatHistoryUtils";
 import { readFrontmatterViaAdapter } from "@/utils/vaultAdapterUtils";
 import { App, FileSystemAdapter, Notice, Platform, TFile } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import { AgentSession, ATTENTION_TRIGGER_STATUSES, DEFAULT_TITLE_PREFIX } from "./AgentSession";
 import type { AgentChatPersistenceManager } from "./AgentChatPersistenceManager";
 import type { AgentModelPreloader, WarmBackend } from "./AgentModelPreloader";
-import { parseNativeChatId } from "@/utils/nativeChatId";
+import { buildNativeChatId, parseNativeChatId } from "@/utils/nativeChatId";
 import type { AgentSessionIndex } from "./AgentSessionIndex";
 import {
   deriveChatTitleFromMessages,
@@ -33,6 +53,23 @@ import {
 } from "./fanout/FanoutOrchestrator";
 import type { FanoutTurn } from "./fanout/fanoutTypes";
 import { backendStateSignature } from "./translateBackendState";
+import { GLOBAL_SCOPE, type ProjectScopeId } from "./scope";
+import {
+  OrphanedProjectError,
+  pickScopeNeighbor,
+  resolveProjectIdForCwd,
+  resolveScopeCwd,
+} from "./sessionScope";
+import {
+  getCachedProjectRecordById,
+  getCachedProjectRecords,
+  subscribeToProjectRecords,
+} from "@/projects/state";
+import type { ProjectFileRecord } from "@/projects/type";
+import { getProjectContextSignature } from "@/projects/projectContextSignature";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { ensureAgentsMirror } from "@/projects/ensureAgentsMirror";
+import { getComposedProjectInstructions } from "@/projects/projectSystemPrompt";
 import type {
   AgentQuestionAnswers,
   AskUserQuestionPrompt,
@@ -47,6 +84,7 @@ import type {
   ModelSelection,
   PermissionDecision,
   PermissionPrompt,
+  ProjectProfile,
   SessionId,
 } from "./types";
 
@@ -84,6 +122,72 @@ function withTimeout<T>(promise: Promise<T>, ms: number, fallback: T): Promise<T
 function isSameCwd(a: string, b: string): boolean {
   const norm = (p: string) => p.replace(/[/\\]+$/, "");
   return norm(a) === norm(b);
+}
+
+// Referential-stability constants for "empty" returns — never hand back a fresh
+// `[]` (would churn React consumers of these getters).
+const EMPTY_SESSIONS = Object.freeze([]) as unknown as AgentSession[];
+const EMPTY_HISTORY_ITEMS = Object.freeze([]) as unknown as ChatHistoryItem[];
+// DESIGN NOTE — intentionally NOT Object.freeze'd, unlike the array constants above.
+// (a) Goal is referential stability: an empty `getRunningChatIds()` /
+//     `getAttentionChatIds()` always hands back this same instance, so React
+//     consumers compare by identity (tests assert `toBe`).
+// (b) `Object.freeze` is a no-op for a Set's contents — `Object.freeze(new Set()).add(x)`
+//     still succeeds (freeze guards own properties, not the internal `[[SetData]]` slot),
+//     so wrapping it would buy nothing the array constants' freeze buys.
+// (c) Runtime immutability rests on the `ReadonlySet<string>` type (no `.add`/`.delete` in
+//     the surface) plus the convention that no caller mutates the result — consumers only
+//     `.has()`, read `.size`, and iterate.
+// If a future review flags this again, point them at this note.
+const EMPTY_RECENT_CHAT_IDS: ReadonlySet<string> = new Set();
+
+// Backends that discover project instructions from a physical `AGENTS.md` in the session cwd.
+// (claude instead has `project.md` parsed and injected in-process via setProjectProfileProvider,
+// so it needs no file.) Only these require the generated mirror to exist before cwd is read.
+const CWD_INSTRUCTION_BACKENDS: ReadonlySet<BackendId> = new Set(["codex", "opencode"]);
+
+/**
+ * Map a materializer {@link SourceFailure} to the atom's {@link FailedItem}. The
+ * cache layer's `"file"` kind becomes the UI's `"nonMd"` (markdown is never
+ * materialized, so an agent failure is only ever web/youtube/nonMd).
+ */
+function toFailedItem(failure: SourceFailure): FailedItem {
+  return {
+    path: failure.source,
+    type: failure.kind === "file" ? "nonMd" : failure.kind,
+    error: failure.error,
+    usedStaleSnapshot: failure.usedStaleSnapshot,
+  };
+}
+
+/** Whether a {@link FailedItem} refers to the same source as a lifecycle event
+ * (the cache layer's `"file"` kind is the atom's `"nonMd"`). */
+function failedItemIsSource(failed: FailedItem, item: MaterializeSourceIdentity): boolean {
+  if (failed.path !== item.source) return false;
+  return item.kind === "file" ? failed.type === "nonMd" : failed.type === item.kind;
+}
+
+/** Add a source to the live "processing" set (no-op if already present). Returns a
+ * NEW array on change so the atom publish is referentially distinct. */
+function addProcessingSource(
+  list: AgentInFlightSource[],
+  item: MaterializeSourceIdentity
+): AgentInFlightSource[] {
+  if (list.some((s) => s.kind === item.kind && s.source === item.source)) return list;
+  return [...list, { kind: item.kind, source: item.source }];
+}
+
+/** Remove a source from the live "processing" set. */
+function removeProcessingSource(
+  list: AgentInFlightSource[],
+  item: MaterializeSourceIdentity
+): AgentInFlightSource[] {
+  return list.filter((s) => !(s.kind === item.kind && s.source === item.source));
+}
+
+/** Append a freshly-settled failure, dropping any prior entry for the same source. */
+function upsertFailedItem(list: FailedItem[], failure: FailedItem): FailedItem[] {
+  return [...list.filter((f) => !(f.path === failure.path && f.type === failure.type)), failure];
 }
 
 export type PermissionPrompter = (req: PermissionPrompt) => Promise<PermissionDecision>;
@@ -144,9 +248,39 @@ export class AgentSessionManager {
   private sessions = new Map<string, AgentSession>();
   private chatUIStates = new Map<string, AgentChatUIState>();
   private activeSessionId: string | null = null;
-  // Dedupe only the auto-spawn path. Direct `createSession()` calls (e.g. `+`
-  // clicks) are independent — concurrent ones each spawn their own session.
-  private firstSessionPromise: Promise<AgentSession> | null = null;
+  // The scope the active session belongs to. Invariant:
+  // `activeSession.projectId === activeProjectId` (active always belongs to the
+  // current scope). `GLOBAL_SCOPE` is the implicit global workspace.
+  private activeProjectId: ProjectScopeId = GLOBAL_SCOPE;
+  // Per-scope most-recently-used session id, so re-entering a scope restores
+  // the tab the user last looked at there.
+  private readonly lastActiveByScope = new Map<ProjectScopeId, string>();
+  // Live sessions hidden from the current tab strip. Re-entering a project
+  // detaches its prior conversational sessions here so the strip shows only the
+  // fresh visit's workset — but they stay in `this.sessions` (and on disk), so
+  // chat history still lists them and their running/attention indicators stay
+  // live. Re-attached by `setActiveSession` (history open / tab click) and
+  // pruned whenever a session leaves the pool. Keyed by the globally-unique
+  // `internalId`, so no per-scope bucketing is needed.
+  private readonly detachedFromTabIds = new Set<string>();
+  // Projects whose context sources changed since their last materialization,
+  // keyed by id → the context signature AT THE TIME the change was observed.
+  // A dirty project must NOT reuse a pre-existing empty landing on re-entry (its
+  // captured `<project_context>` is stale) and must NOT keep a stale landing in
+  // the strip. Cleared once a freshly-created session captures the SAME
+  // signature — a newer edit's signature won't match, so its dirtiness survives
+  // (no lost update). Mirrors chat mode's `markdownNeedsReload`.
+  private readonly contextDirtySignatures = new Map<ProjectScopeId, string>();
+  // Snapshot of project records from the previous change notification, diffed
+  // against the next to detect context-source edits. Seeded in the constructor.
+  private previousProjectRecords: ProjectFileRecord[] = [];
+  private projectRecordsUnsubscriber?: () => void;
+  // Dedupe only the auto-spawn path, PER scope. Direct `createSession()` calls
+  // (e.g. `+` clicks) are independent — concurrent ones each spawn their own
+  // session. Keyed by scope so entering two scopes can't share one in-flight
+  // spawn; the key is cleared in `finally` so the next enter doesn't reuse a
+  // settled promise.
+  private readonly firstSessionPromiseByScope = new Map<ProjectScopeId, Promise<AgentSession>>();
   private pendingCreates = 0;
   private listeners = new Set<() => void>();
   private disposed = false;
@@ -172,7 +306,8 @@ export class AgentSessionManager {
   // - `unsub`: tear-down for the auto-save `session.subscribe()`
   // - `signature`: last serialized snapshot, for no-op skipping
   // - `modelCacheUnsub`: tear-down for the model-cache mirror subscription
-  // - `attentionUnsub`: tear-down for the needs-attention status watcher
+  // - `attentionUnsub`: tear-down for the per-session status watcher that both
+  //   flags needs-attention AND notifies on running-membership flips (spinner)
   private readonly sessionState = new Map<
     string,
     {
@@ -221,6 +356,7 @@ export class AgentSessionManager {
     this.settingsUnsub = subscribeToSettingsChange((prev, next) =>
       this.onDefaultSelectionsChanged(prev, next)
     );
+    this.setupProjectRecordChangeMonitor();
   }
 
   /**
@@ -317,6 +453,18 @@ export class AgentSessionManager {
       getDefaultSelection: (backendId) =>
         this.getDefaultSelection(backendId) ?? this.nativeDefaultSelection(backendId),
       getDisplayName: (backendId) => this.resolveDescriptor(backendId).displayName,
+      // DESIGN NOTE: fan-out sub-sessions intentionally run at the vault root,
+      // not the originating session's project folder, and aren't handed the
+      // project's `projectId` / `additionalDirectories`. This is the seam where
+      // multi-agent QA (which predates project workspaces) meets project scope.
+      // It's acceptable because the project's knowledge already reaches every
+      // answerer: `runTurn` injects the first-turn `<project_context>` block into
+      // the shared fan-out prompt. What a sub-session lacks is project-scoped
+      // tool *reach* (cwd + external roots) — tolerable for ephemeral read-only
+      // QA, whose answers are advisory and whose authoritative, fully-scoped reply
+      // comes from the main session. Threading project scope into the sub-sessions
+      // is a deliberate follow-up, not part of the project-workspace landing.
+      // If a future review flags this again, point them at this note.
       getCwd: () => {
         const adapter = this.app.vault.adapter;
         return adapter instanceof FileSystemAdapter ? adapter.getBasePath() : null;
@@ -334,6 +482,91 @@ export class AgentSessionManager {
   }
 
   /**
+   * Watch project config edits so a changed context source (URLs / inclusions /
+   * etc.) invalidates the project's materialized context — mirroring chat mode's
+   * {@link ProjectManager.setupProjectListChangeMonitor}. Seeds the prior-records
+   * snapshot up front so the first notification diffs against the real baseline.
+   */
+  private setupProjectRecordChangeMonitor(): void {
+    this.previousProjectRecords = getCachedProjectRecords();
+    this.projectRecordsUnsubscriber?.();
+    this.projectRecordsUnsubscriber = subscribeToProjectRecords((nextRecords) => {
+      this.handleProjectRecordsChanged(nextRecords);
+    });
+  }
+
+  /**
+   * Diff the new project records against the previous snapshot and mark any
+   * project whose context signature changed as dirty (its materialized context
+   * is stale). For the ACTIVE project we also warm its off-vault conversion
+   * cache in the background so the next chat there starts with sources already
+   * fetched — the
+   * warm never publishes to {@link agentProjectContextLoadAtom}, so it can never
+   * gate the composer of a session that won't even consume the new context.
+   */
+  private handleProjectRecordsChanged(nextRecords: ProjectFileRecord[]): void {
+    if (this.disposed) return;
+    const prevRecords = this.previousProjectRecords;
+    this.previousProjectRecords = nextRecords;
+
+    // Drop dirty flags for projects that no longer exist (deleted/renamed-away).
+    const nextIds = new Set(nextRecords.map((r) => r.project.id));
+    for (const id of this.contextDirtySignatures.keys()) {
+      if (!nextIds.has(id)) this.contextDirtySignatures.delete(id);
+    }
+
+    for (const nextRecord of nextRecords) {
+      const prevRecord = prevRecords.find((r) => r.project.id === nextRecord.project.id);
+      if (!prevRecord) continue; // brand-new project: nothing materialized yet
+      const nextSignature = getProjectContextSignature(nextRecord);
+      if (getProjectContextSignature(prevRecord) === nextSignature) continue;
+
+      const projectId = nextRecord.project.id;
+      this.contextDirtySignatures.set(projectId, nextSignature);
+      if (projectId === this.activeProjectId) this.warmProjectContext(projectId);
+    }
+  }
+
+  /**
+   * Fire-and-forget refresh of a project's off-vault conversion-cache snapshots. Unlike
+   * {@link rematerializeContext} this NEVER touches the context-load atom, so it
+   * silently warms the disk cache without gating any composer. The materializer
+   * single-flights and cheap-skips unchanged sources, so a newly-added URL is
+   * fetched while everything else is a no-op. Skipped off-desktop (no adapter).
+   */
+  private warmProjectContext(projectId: ProjectScopeId): void {
+    if (this.disposed || projectId === GLOBAL_SCOPE) return;
+    let cwd: string;
+    try {
+      cwd = this.resolveSessionCwd(projectId);
+    } catch {
+      return; // off-desktop: no FileSystemAdapter, nothing to warm
+    }
+    void ensureProjectContextMaterialized(this.app, projectId, cwd).catch((err) =>
+      logWarn(`[AgentMode] background context warm failed for ${projectId}`, err)
+    );
+  }
+
+  /** Whether a project's materialized context is known to be stale. */
+  private isProjectContextDirty(projectId: ProjectScopeId): boolean {
+    return this.contextDirtySignatures.has(projectId);
+  }
+
+  /**
+   * Clear a project's dirty flag once a freshly-created session has captured its
+   * context — but ONLY if the signature the session actually captured (passed in,
+   * read synchronously at materialization kickoff) still equals the dirty one. A
+   * newer edit that landed after this session started materializing bumps the
+   * dirty signature, so it won't match and the project stays dirty (this session
+   * captured the OLDER sources). The lost-update guard for edit/create races.
+   */
+  private clearContextDirtyIfCaptured(projectId: ProjectScopeId, capturedSignature: string): void {
+    if (this.contextDirtySignatures.get(projectId) === capturedSignature) {
+      this.contextDirtySignatures.delete(projectId);
+    }
+  }
+
+  /**
    * List every known Agent Mode chat as a `ChatHistoryItem`: markdown-saved
    * notes (ranked using the plugin's shared in-memory `lastAccessedAt`
    * tracker) merged with the session index's native-store entries, de-duped
@@ -343,14 +576,21 @@ export class AgentSessionManager {
    * by {@link LIST_SESSIONS_TIMEOUT_MS}) so chats created outside the plugin
    * surface too — a backend is never spawned just to enumerate history.
    */
-  async getChatHistoryItems(): Promise<ChatHistoryItem[]> {
+  async getChatHistoryItems(scope?: ProjectScopeId): Promise<ChatHistoryItem[]> {
     const persistence = this.opts.persistenceManager;
     const index = this.opts.sessionIndex;
-    if (!persistence && !index) return [];
+    if (!persistence && !index) return EMPTY_HISTORY_ITEMS;
 
+    // Paths of saved chats backed by a live session that is flagging for
+    // attention (finished / errored / paused while backgrounded). In-memory and
+    // app-lifetime only — purely-on-disk chats stay unflagged. Applied in the
+    // map below so both the global and project views carry the cue.
+    const liveAttentionPaths = this.collectLiveAttentionPaths();
+
+    let files: TFile[] = [];
     let markdownEntries: MarkdownChatEntry[] = [];
     if (persistence) {
-      const files = await persistence.getAgentChatHistoryFiles();
+      files = await persistence.getAgentChatHistoryFiles();
       const tracker = this.plugin.getChatHistoryLastAccessedAtManager();
       markdownEntries = await Promise.all(
         files.map(async (file) => {
@@ -359,20 +599,131 @@ export class AgentSessionManager {
           // cache-only read would leave those rows unmergeable and duplicate
           // their native twins.
           const ref = await this.readSessionRefFromFile(file.path);
+          const item = fileToHistoryItem(this.app, file, tracker);
           return {
-            item: fileToHistoryItem(this.app, file, tracker),
+            item: liveAttentionPaths.has(item.id) ? { ...item, needsAttention: true } : item,
             backendId: ref?.backendId,
             sessionId: ref?.sessionId,
           };
         })
       );
     }
+
+    // Project view: resolve the AUTHORITATIVE projectId per file and keep only
+    // this scope's chats. The sync `fileToHistoryItem` reads only metadataCache,
+    // which can lag right after a save or miss hidden-dir files — that would
+    // default such a chat to global and wrongly drop it from its project list.
+    // `readChatPathProjectId` hits the cache for indexed files (zero extra IO)
+    // and falls back to a one-shot adapter read only for unindexed ones.
+    if (scope && scope !== GLOBAL_SCOPE) {
+      const resolved = await Promise.all(
+        files.map(async (file, i) => {
+          const projectId =
+            (await readChatPathProjectId(this.app, file.path))?.trim() || GLOBAL_SCOPE;
+          return projectId === scope ? markdownEntries[i] : null;
+        })
+      );
+      // Drop cross-device-unresumable chats AFTER scope resolution: the resolver
+      // indexes `markdownEntries[i]` against `files`, so filtering the list before
+      // it would misalign those indices.
+      const scopedMarkdown = await this.dropNonLocalMarkdownEntries(
+        resolved.filter((entry): entry is MarkdownChatEntry => entry !== null)
+      );
+      if (!index) {
+        const items = scopedMarkdown.map((e) => e.item);
+        return items.length === 0 ? EMPTY_HISTORY_ITEMS : items;
+      }
+      // Native entries scope by the index's recorded projectId (written
+      // through from live sessions, or cwd-attributed by the sweep), so
+      // autosave-off project chats list here too — same dual-source merge as
+      // the global view, just filtered to this scope on both sides.
+      await this.refreshNativeSessionsFromBackends();
+      const scopedNative = (await index.getEntries()).filter((e) => e.projectId === scope);
+      const merged = mergeChatHistoryItems(scopedMarkdown, scopedNative);
+      return merged.length === 0 ? EMPTY_HISTORY_ITEMS : merged;
+    }
+
     markdownEntries = await this.dropNonLocalMarkdownEntries(markdownEntries);
     if (!index) return markdownEntries.map((e) => e.item);
 
     await this.refreshNativeSessionsFromBackends();
     const nativeEntries = await index.getEntries();
     return mergeChatHistoryItems(markdownEntries, nativeEntries);
+  }
+
+  /**
+   * Saved-file paths of live sessions currently flagging `needsAttention`. The
+   * path is keyed off the session's persisted file (set after its first save),
+   * matching `ChatHistoryItem.id`. Sessions that never saved (no path) or aren't
+   * flagging are skipped.
+   */
+  private collectLiveAttentionPaths(): Set<string> {
+    const paths = new Set<string>();
+    for (const [internalId, session] of this.sessions) {
+      if (!session.getNeedsAttention()) continue;
+      const path = this.sessionState.get(internalId)?.path;
+      if (path) paths.add(path);
+    }
+    return paths;
+  }
+
+  /**
+   * Every recent-list id this session may currently be rendered under. The ids
+   * match `ChatHistoryItem.id`: the persisted markdown path once saved, the
+   * `(backendId, sessionId)` native id before that. Deliberately BOTH when both
+   * exist: the mounted landing list is a snapshot, so right after the first
+   * autosave re-keys the chat from native id to path, the visible row may still
+   * carry the old native id — emitting both keeps `.has()` hitting whichever
+   * the row was rendered under, with no history reload. Harmless overshoot: a
+   * native id maps to the same chat and its native twin row is de-duped away.
+   *
+   * DESIGN NOTE — known limitation, deliberately deferred: a session that has
+   * neither saved nor reached the native index yet has NO row in the list at
+   * all, so its spinner/dot has nowhere to hang until the list next reloads.
+   * That's a missing row, not an id mismatch — dual ids can't help, and forcing
+   * a history reload from here would couple autosave to row visibility. If a
+   * future review flags this again, point them at this note.
+   */
+  private recentChatIdsForSession(internalId: string, session: AgentSession): string[] {
+    const ids: string[] = [];
+    const path = this.sessionState.get(internalId)?.path;
+    if (path) ids.push(path);
+    const backendSessionId = session.getBackendSessionId();
+    if (backendSessionId) ids.push(buildNativeChatId(session.backendId, backendSessionId));
+    return ids;
+  }
+
+  /**
+   * Recent-list ids of pool sessions whose backend turn is currently
+   * `"running"`, so the landing rows can swap their relative-time chip for a
+   * spinner. Only `"running"` counts — `awaiting_permission` is surfaced via
+   * the needs-attention dot. Returns a shared module constant when empty so
+   * React consumers don't churn on a fresh `Set`.
+   */
+  getRunningChatIds(): ReadonlySet<string> {
+    const ids = new Set<string>();
+    for (const [internalId, session] of this.sessions) {
+      if (session.getStatus() !== "running") continue;
+      for (const id of this.recentChatIdsForSession(internalId, session)) ids.add(id);
+    }
+    return ids.size === 0 ? EMPTY_RECENT_CHAT_IDS : ids;
+  }
+
+  /**
+   * Recent-list ids of pool sessions currently flagging needs-attention, so a
+   * row's done-dot can light up the moment its backgrounded turn finishes —
+   * the live complement to the `item.needsAttention` snapshot that
+   * `getChatHistoryItems` bakes in at load time (which goes stale the moment a
+   * session finishes after the list mounted, and never covers native-only
+   * rows). Same shape and constant-on-empty contract as `getRunningChatIds`.
+   */
+  getAttentionChatIds(): ReadonlySet<string> {
+    const ids = new Set<string>();
+    for (const [internalId, session] of this.sessions) {
+      if (!session.getNeedsAttention()) continue;
+      for (const id of this.recentChatIdsForSession(internalId, session)) ids.add(id);
+    }
+    return ids.size === 0 ? EMPTY_RECENT_CHAT_IDS : ids;
   }
 
   /**
@@ -524,7 +875,10 @@ export class AgentSessionManager {
    * Drop markdown chats whose backend session can't be resumed on this device
    * — a chat started on another machine syncs its note (with the session id)
    * but not the backend's local transcript store, so resuming it dead-ends.
-   * Only hides a row when a running backend can cheaply and definitively say
+   * Resumability is probed against each chat's own scope cwd (its project
+   * folder, or the vault root for global chats), since a backend may key its
+   * transcript store by cwd. Only hides a row when a running backend can
+   * cheaply and definitively say
    * the session is absent; an unknown answer (no such capability, backend not
    * running, or a probe error) keeps the row so we never hide a local chat.
    *
@@ -538,13 +892,28 @@ export class AgentSessionManager {
   ): Promise<MarkdownChatEntry[]> {
     const adapter = this.app.vault.adapter;
     if (!(adapter instanceof FileSystemAdapter)) return entries;
-    const cwd = adapter.getBasePath();
+    const vaultRoot = adapter.getBasePath();
     const procs = this.getRunningProcsByBackend();
     const keep = await Promise.all(
       entries.map(async (entry) => {
         if (!entry.backendId || !entry.sessionId) return true;
         const proc = procs.get(entry.backendId);
         if (!proc?.sessionExistsLocally) return true;
+        // Probe with the chat's OWN scope cwd, not the vault root: a project
+        // chat's transcript lives under its project folder (Claude keys the
+        // transcript path by cwd), so probing every row with the vault root
+        // would wrongly report a local project chat as non-resumable and hide
+        // it. Resolving per entry keeps both the flat global view and a project
+        // view correct. A scope that no longer resolves (deleted project) falls
+        // back to keeping the row — never hide a chat on an uncertain answer.
+        let cwd: string;
+        try {
+          const projectId =
+            (await readChatPathProjectId(this.app, entry.item.id))?.trim() || GLOBAL_SCOPE;
+          cwd = resolveScopeCwd(vaultRoot, projectId);
+        } catch {
+          return true;
+        }
         try {
           return await proc.sessionExistsLocally({ sessionId: entry.sessionId, cwd });
         } catch {
@@ -566,11 +935,12 @@ export class AgentSessionManager {
   }
 
   /**
-   * Merge one backend's `listSessions` result into the index. Filters to
-   * this vault's cwd (agent-side cwd filtering is not trusted — a stray
-   * session from another vault must never leak into this vault's history),
-   * skips the preloader's probe session, and requires a real title so the
-   * sweep can't surface empty placeholder sessions.
+   * Merge one backend's `listSessions` result into the index. Keeps sessions
+   * whose cwd is this vault's root (global scope) or a known project folder
+   * (attributed to that project) — agent-side cwd filtering is not trusted,
+   * and a stray session from another vault must never leak into this vault's
+   * history. Skips the preloader's probe session and requires a real title so
+   * the sweep can't surface empty placeholder sessions.
    */
   private async sweepNativeSessions(
     backendId: BackendId,
@@ -599,7 +969,12 @@ export class AgentSessionManager {
     const now = Date.now();
     const discovered = [];
     for (const s of sessions) {
-      if (!isSameCwd(s.cwd, vaultBasePath)) continue;
+      const inVaultRoot = isSameCwd(s.cwd, vaultBasePath);
+      // A session run inside a materialized project folder belongs to that
+      // project's history; anything matching neither the vault root nor a
+      // known project folder is another vault's session.
+      const projectId = inVaultRoot ? undefined : resolveProjectIdForCwd(vaultBasePath, s.cwd);
+      if (!inVaultRoot && !projectId) continue;
       if (probeSessionId && s.sessionId === probeSessionId) continue;
       // A live fan-out sub-session is ephemeral: skip it even before its
       // async tombstone lands, so a sweep racing the in-flight turn can't
@@ -615,6 +990,7 @@ export class AgentSessionManager {
         title,
         createdAtMs: timestamp,
         lastAccessedAtMs: timestamp,
+        projectId,
       });
     }
     if (discovered.length > 0) await index.mergeDiscoveredSessions(discovered);
@@ -630,24 +1006,35 @@ export class AgentSessionManager {
       throw new Error("AgentSessionManager has been shut down");
     }
     const active = this.getActiveSession();
-    if (active && active.getStatus() !== "closed") return active;
+    // Only reuse the active session when it belongs to the current scope —
+    // after `enterProject` the prior scope's session may still be pointed at by
+    // `activeSessionId` until this seeds a fresh one for the new scope.
+    if (active && active.projectId === this.activeProjectId && active.getStatus() !== "closed") {
+      return active;
+    }
     // Dedupe rapid auto-spawn callers (e.g. the router effect re-running
     // before the first create has populated the pool) so we don't seed two
-    // sessions when one was asked for.
-    if (this.firstSessionPromise) return this.firstSessionPromise;
-    this.firstSessionPromise = this.createSession();
+    // sessions when one was asked for. Keyed per scope so two scopes spawning
+    // at once don't collapse into one shared session.
+    const scope = this.activeProjectId;
+    const pending = this.firstSessionPromiseByScope.get(scope);
+    if (pending) return pending;
+    const promise = this.createSession(undefined, scope);
+    this.firstSessionPromiseByScope.set(scope, promise);
     try {
-      return await this.firstSessionPromise;
+      return await promise;
     } finally {
-      this.firstSessionPromise = null;
+      this.firstSessionPromiseByScope.delete(scope);
     }
   }
 
   /**
    * Spawn a fresh `AgentSession`. Lazily starts the requested backend on its
-   * first call. The new session becomes the active one. `backendId` defaults
-   * to `settings.agentMode.activeBackend` (the model-picker keeps that in
-   * sync with the user's most recently selected default model).
+   * first call. The new session becomes the active one *when its scope is the
+   * current one* (a background/restart create stays parked). `backendId`
+   * defaults to `settings.agentMode.activeBackend` (the model-picker keeps that
+   * in sync with the user's most recently selected default model). `projectId`
+   * defaults to the active scope and is bound immutably onto the session.
    *
    * The new session's initial (model, effort) defaults to the persisted
    * default for `backendId` via `getDefaultSelection`. Pass `seedSelection`
@@ -656,19 +1043,39 @@ export class AgentSessionManager {
    */
   async createSession(
     backendId?: BackendId,
+    projectId: ProjectScopeId = this.activeProjectId,
     seedSelection?: ModelSelection
   ): Promise<AgentSession> {
     if (this.disposed) {
       throw new Error("AgentSessionManager has been shut down");
     }
 
-    const adapter = this.app.vault.adapter;
-    if (!(adapter instanceof FileSystemAdapter)) {
-      throw new Error("Agent Mode requires desktop Obsidian (FileSystemAdapter).");
-    }
-    const vaultBasePath = adapter.getBasePath();
-
     const resolvedId = backendId ?? getSettings().agentMode?.activeBackend ?? "opencode";
+
+    // Materialize the project's AGENTS.md mirror from project.md BEFORE resolving cwd, so a
+    // cwd-instruction backend (codex/opencode) discovers the instruction file on its first
+    // session. This is the sole correctness guarantee for an old project.md-only project.
+    // Never throws (degrades gracefully); skipped for GLOBAL_SCOPE and for claude (which gets
+    // the instruction injected in-process, no file needed).
+    if (projectId !== GLOBAL_SCOPE && CWD_INSTRUCTION_BACKENDS.has(resolvedId)) {
+      const record = getCachedProjectRecordById(projectId);
+      if (record) await ensureAgentsMirror(this.app, record);
+    }
+
+    // Resolves the scope's cwd (vault root for global, project folder otherwise)
+    // and validates desktop/orphaned up front, before any pending-create state
+    // is mutated.
+    const cwd = this.resolveSessionCwd(projectId);
+
+    // Kick off context materialization WITHOUT blocking session creation: the
+    // session must become visible immediately so the composer's loading card +
+    // send-gate render while prefetch runs (§3.1.9). The returned promise is
+    // threaded into the session, which awaits it right before `newSession`.
+    // Skipped for GLOBAL_SCOPE — no promise, no atom write, byte-identical to a
+    // context-free create. Never rejects (degrades to empty roots).
+    const contextReady =
+      projectId === GLOBAL_SCOPE ? undefined : this.beginContextMaterialization(projectId, cwd);
+
     const descriptor = this.resolveDescriptor(resolvedId);
 
     this.pendingCreates++;
@@ -714,19 +1121,22 @@ export class AgentSessionManager {
     // disk on the next preload, so adopting that session as the chat would
     // replay the previous conversation's transcript and auto-title into a
     // supposedly fresh chat. `AgentSession.start` runs `newSession` on the
-    // (warm or cold) proc; the probe's state still seeds the picker so it
+    // (warm or cold) proc at the resolved scope cwd, threading the project
+    // scope + context roots; the probe's state still seeds the picker so it
     // doesn't blink while that round-trip is in flight.
     const session = AgentSession.start({
       backend,
-      cwd: vaultBasePath,
+      cwd,
       internalId: uuidv4(),
       backendId: resolvedId,
+      projectId,
       defaultModelSelection: resolvedSeed,
       initialCachedState: warm?.state ?? this.preloader.getCachedBackendState(resolvedId),
       getDescriptor: () => this.opts.resolveDescriptor(resolvedId),
       runFanoutTurn: (input) => this.runFanoutTurn(input),
       getDisplayName: (backendId) => this.resolveDescriptor(backendId).displayName,
       getApp: () => this.app,
+      contextReady,
     });
     if (warm) {
       logInfo(
@@ -735,7 +1145,18 @@ export class AgentSessionManager {
     }
     this.sessions.set(session.internalId, session);
     this.chatUIStates.set(session.internalId, new AgentChatUIState(session));
-    this.activeSessionId = session.internalId;
+    // A fresh id is never detached; clear defensively so a new session can't
+    // inherit a stale hidden-from-strip flag.
+    this.detachedFromTabIds.delete(session.internalId);
+    // Always the scope's newest MRU. But only steal the global active pointer
+    // when this session's scope is still the current one — a slow auto-spawn or
+    // a restart that replaces a *background* tab must not yank the user out of a
+    // scope they've since switched to (preserves `active.projectId ===
+    // activeProjectId`).
+    this.lastActiveByScope.set(projectId, session.internalId);
+    if (projectId === this.activeProjectId) {
+      this.activeSessionId = session.internalId;
+    }
     this.attachAutoSave(session);
     this.attachModelCacheSync(session);
     this.attachAttentionTracking(session);
@@ -749,6 +1170,22 @@ export class AgentSessionManager {
     // `ready` is already resolved, so the chain runs on the next microtask.
     void session.ready
       .then(async () => {
+        // Reaching here means the session is fully ready — it captured its context
+        // and opened its backend session (a failed startup rejects into `.catch`
+        // and never runs this). A fresh session's `ready` resolves only after
+        // `initialize()` has already awaited `contextReady`, so the await below is
+        // an already-settled microtask, not a fresh network wait — it can't stall
+        // `finishPendingCreate`. Clear the project's dirty flag FIRST, before any
+        // optional backend config that could hang and stall it. Clear only for the
+        // source revision the materializer actually captured (`contextSignature`):
+        // a newer edit mid-flight bumped the dirty signature, so it won't match and
+        // stays dirty (lost-update guard); a failed materialize carries no signature.
+        if (contextReady) {
+          const result = await contextReady;
+          if (!this.disposed && result.contextSignature !== undefined) {
+            this.clearContextDirtyIfCaptured(projectId, result.contextSignature);
+          }
+        }
         if (descriptor.applyInitialSessionConfig) {
           try {
             await descriptor.applyInitialSessionConfig(session, getSettings(), resolvedSeed);
@@ -789,6 +1226,504 @@ export class AgentSessionManager {
       throw new Error(`Unknown backend "${backendId}". Did you forget to register it?`);
     }
     return descriptor;
+  }
+
+  /**
+   * Absolute cwd for a session in `projectId`'s scope. Single source of truth
+   * for every session-construction site. Throws on a non-desktop adapter or an
+   * orphaned project (missing record) — the latter must never silently fall
+   * back to the vault root.
+   */
+  private resolveSessionCwd(projectId: ProjectScopeId): string {
+    const adapter = this.app.vault.adapter;
+    if (!(adapter instanceof FileSystemAdapter)) {
+      throw new Error("Agent Mode requires desktop Obsidian (FileSystemAdapter).");
+    }
+    return resolveScopeCwd(adapter.getBasePath(), projectId);
+  }
+
+  /**
+   * Start (but do NOT await) materializing a project's context, returning a
+   * promise of the extra searchable roots. Caller has already done config
+   * migration + cwd resolution, so the materializer sees the post-migration
+   * record and resolved cwd. Only ever invoked for a non-global scope.
+   *
+   * Publishes the blocking load state SYNCHRONOUSLY (before the session even
+   * appears) so the composer gates send the instant the tab renders, then flips
+   * to `done`/`error` and stores the result for {@link getProjectProfile} once
+   * the materializer settles. NEVER rejects — failure degrades to an empty
+   * result so the session's `newSession` (which awaits this) is never blocked.
+   *
+   * Resolves the full {@link ContextMaterializationResult} (searchable roots +
+   * the optional inline `<project_context>` block); the session captures both
+   * before opening. Progress/counts are NOT carried here — they publish
+   * separately via {@link agentProjectContextLoadAtom}.
+   */
+  private beginContextMaterialization(
+    projectId: ProjectScopeId,
+    cwd: string,
+    forceRetryFailed?: boolean
+  ): Promise<ContextMaterializationResult> {
+    // Accumulate counts so every publish carries the latest of all three steps
+    // (resolve / prefetch / parse), not just the one that fired last.
+    const counts: {
+      resolved?: number;
+      prefetch?: ContextLoadStepCount;
+      parsed?: ContextLoadStepCount;
+    } = {};
+    // Per-source state mirroring the legacy CAG tracker: `processingSources` is
+    // the live "in flight" set, `failedSources` accrues settled failures. Both
+    // publish incrementally so the popover renders a true queue; the materializer
+    // sends a final `failures` list that reconciles `failedSources` at the end.
+    let failedSources: FailedItem[] = [];
+    let processingSources: AgentInFlightSource[] = [];
+    // The latest step phase, so item-lifecycle publishes (which carry no phase of
+    // their own) keep the loading card on the current step.
+    let stepPhase: "resolve" | "prefetch" | "parse" = "resolve";
+
+    // Own the atom only when no concurrent run is already driving it. The
+    // materializer single-flights, so a second caller would otherwise (a) seed a
+    // count-less "resolve" over the owner's live counts and (b) publish a
+    // count-less terminal "done" during the owner's linger window. Letting only
+    // the flight owner publish keeps the projectId-keyed atom coherent.
+    const prior = settingsStore.get(agentProjectContextLoadAtom)[projectId];
+    const ownsPublish = !prior?.blocking;
+
+    // Seed the blocking state synchronously (before the session even appears) so
+    // the composer gates send the instant the tab renders.
+    if (ownsPublish) {
+      this.setContextLoadState(projectId, { phase: "resolve", blocking: true });
+    }
+
+    // Re-emit the running state with the current counts + per-source sets. Empty
+    // `processingSources` publishes as `undefined` (the adapter falls back to a
+    // frozen empty), matching the `retryingSources` referential-stability pattern.
+    const publishProgress = () => {
+      this.setContextLoadState(projectId, {
+        phase: stepPhase,
+        blocking: true,
+        ...counts,
+        failedSources,
+        processingSources: processingSources.length > 0 ? processingSources : undefined,
+      });
+    };
+
+    const onProgress = ownsPublish
+      ? (progress: ContextMaterializeProgress) => {
+          switch (progress.phase) {
+            case "failures":
+              // Final reconciliation of the run's failures (data-only; the
+              // terminal `done` publish carries the authoritative list).
+              failedSources = progress.failures.map(toFailedItem);
+              return;
+            case "itemStart":
+              processingSources = addProcessingSource(processingSources, progress.item);
+              failedSources = failedSources.filter((f) => !failedItemIsSource(f, progress.item));
+              publishProgress();
+              return;
+            case "itemFailed":
+              processingSources = removeProcessingSource(processingSources, progress.item);
+              failedSources = upsertFailedItem(failedSources, toFailedItem(progress.failure));
+              publishProgress();
+              return;
+            case "itemSettled":
+              processingSources = removeProcessingSource(processingSources, progress.item);
+              publishProgress();
+              return;
+            case "resolve":
+              counts.resolved = progress.resolved;
+              stepPhase = "resolve";
+              publishProgress();
+              return;
+            case "prefetch":
+              counts.prefetch = { done: progress.done, total: progress.total };
+              stepPhase = "prefetch";
+              publishProgress();
+              return;
+            case "parse":
+              counts.parsed = { done: progress.done, total: progress.total };
+              stepPhase = "parse";
+              publishProgress();
+              return;
+          }
+        }
+      : undefined;
+
+    return ensureProjectContextMaterialized(this.app, projectId, cwd, onProgress, forceRetryFailed)
+      .then((ctx) => {
+        if (ownsPublish) {
+          // Always carry `failedSources` (empty when clean) so a prior run's
+          // failures never linger; the run is done, so nothing is processing.
+          this.setContextLoadState(projectId, {
+            phase: "done",
+            blocking: false,
+            ...counts,
+            failedSources,
+          });
+        }
+        return ctx;
+      })
+      .catch((err) => {
+        // The materializer's contract is never-reject; this guards a contract
+        // breach. Publish as a completed run with a single synthetic failure
+        // (not a distinct error phase — there is no "whole context" failure state).
+        logWarn(`[AgentMode] project context materialize failed for ${projectId}; continuing`, err);
+        if (ownsPublish) {
+          this.setContextLoadState(projectId, {
+            phase: "done",
+            blocking: false,
+            failedSources: [{ path: "Project context", type: "nonMd", error: err2String(err) }],
+          });
+        }
+        return EMPTY_CONTEXT_MATERIALIZATION_RESULT;
+      });
+  }
+
+  /** Publish a project's context-load state to the projectId-keyed atom. */
+  private setContextLoadState(projectId: string, state: AgentProjectContextLoadState): void {
+    settingsStore.set(agentProjectContextLoadAtom, (prev) => ({ ...prev, [projectId]: state }));
+  }
+
+  /**
+   * Re-run a project's context materialization on demand — the status popover's
+   * "Retry" action. Fire-and-forget: progress/failures republish through
+   * {@link agentProjectContextLoadAtom} exactly like a session-create run. Passes
+   * `forceRetryFailed` so known-bad sources are re-fetched instead of honoring
+   * their persisted failure markers (the automatic path cheap-skips them). A
+   * no-op for the global scope (no per-project context).
+   *
+   * Early-exits while a run already owns the load atom (`blocking`), mirroring
+   * {@link rematerializeSource}: joining the in-flight session-create run would
+   * let its cheap-skip swallow the force, so the user's Retry would do nothing.
+   * Returns whether a real forced run started (so the caller can defer the
+   * post-retry landing refresh).
+   */
+  rematerializeContext(projectId: ProjectScopeId): boolean {
+    if (projectId === GLOBAL_SCOPE) return false;
+    // A session-create run owns the atom while blocking; don't fold the force in.
+    if (settingsStore.get(agentProjectContextLoadAtom)[projectId]?.blocking) return false;
+    let cwd: string;
+    try {
+      cwd = this.resolveSessionCwd(projectId);
+    } catch (err) {
+      // Off-desktop (no FileSystemAdapter): surface as a completed run with a
+      // single synthetic failure, mirroring the materializer's fatal path.
+      this.setContextLoadState(projectId, {
+        phase: "done",
+        blocking: false,
+        failedSources: [{ path: "Project context", type: "nonMd", error: err2String(err) }],
+      });
+      return false;
+    }
+    // Start the forced pass SYNCHRONOUSLY so it claims the materializer's
+    // single-flight slot before this returns: a background warm (a source edit)
+    // runs through that guard without owning the blocking atom, so the check
+    // above can't see it — but the forced run supersedes it (see
+    // {@link ensureProjectContextMaterialized}), and any landing refresh the
+    // returned `true` triggers then joins THIS forced run, not the stale warm.
+    void this.beginContextMaterialization(projectId, cwd, true);
+    // Reason: report whether a real run started so the caller can defer the
+    // post-retry landing refresh (skipped for the no-op scopes above).
+    return true;
+  }
+
+  /**
+   * Re-materialize a SINGLE source on demand — the per-row "Retry" in the
+   * Content Conversion panel. Ignored while a full run is in flight (the UI hides
+   * Retry then, and the running pass already re-attempts every source). On
+   * settle, drops this source's stale failure from the load atom — re-adding it
+   * only if the retry failed again — so the panel reflects the new outcome
+   * without a whole-project re-run. A no-op for the global scope.
+   *
+   * Returns whether a retry actually ran to completion — `false` when it was
+   * skipped (global scope, a full run owns the atom, or this source is already
+   * retrying), so the caller can avoid a premature post-retry refresh.
+   */
+  async rematerializeSource(
+    projectId: ProjectScopeId,
+    item: { kind: MaterializedSourceType; source: string }
+  ): Promise<boolean> {
+    if (projectId === GLOBAL_SCOPE) return false;
+    const before = settingsStore.get(agentProjectContextLoadAtom)[projectId];
+    // A full run owns the atom while blocking; don't race it.
+    if (before?.blocking) return false;
+
+    const matchesItem = (f: FailedItem) =>
+      f.path === item.source && (item.kind === "file" ? f.type === "nonMd" : f.type === item.kind);
+    const sameSource = (r: { kind: MaterializedSourceType; source: string }) =>
+      r.kind === item.kind && r.source === item.source;
+
+    // Single-flight per source: if this source's retry is already in flight, a
+    // second click would fire a duplicate materialize and let the first finisher
+    // clear the spinner early — so bail rather than re-fire.
+    const beforeRetrying = before?.retryingSources ?? [];
+    if (beforeRetrying.some(sameSource)) return false;
+
+    // Optimistically mark this source as retrying so its row flips to a spinner
+    // immediately — the click has visible feedback even if the retry fails again.
+    // Drop its stale failure now; re-add below only if the retry fails.
+    this.setContextLoadState(projectId, {
+      ...(before ?? { phase: "done" as const }),
+      blocking: false,
+      failedSources: (before?.failedSources ?? []).filter((f) => !matchesItem(f)),
+      retryingSources: [...beforeRetrying, item],
+    });
+
+    // The single-source retry serializes with any in-flight full run on the
+    // shared per-artifact lock (keyed by snapshot file name), and shared snapshots
+    // are never reconciled — so a concurrent warm can no longer reap the snapshot
+    // this Retry writes. No pre-join is needed.
+    const failures = await materializeProjectContextSource(this.app, projectId, item);
+
+    const prev = settingsStore.get(agentProjectContextLoadAtom)[projectId];
+    // A full run may have started during our await — it now owns the atom. Bail
+    // so we don't clobber its `blocking` send-gate / progress with a stale write.
+    if (prev?.blocking) return false;
+    const others = (prev?.failedSources ?? []).filter((f) => !matchesItem(f));
+    const remainingRetrying = (prev?.retryingSources ?? []).filter((r) => !sameSource(r));
+    this.setContextLoadState(projectId, {
+      ...(prev ?? { phase: "done" as const }),
+      blocking: false,
+      retryingSources: remainingRetrying.length > 0 ? remainingRetrying : undefined,
+      failedSources: [...others, ...failures.map(toFailedItem)],
+    });
+    return true;
+  }
+
+  /** The scope the active session belongs to ({@link GLOBAL_SCOPE} or a project id). */
+  getActiveProjectId(): ProjectScopeId {
+    return this.activeProjectId;
+  }
+
+  /**
+   * Sessions belonging to `projectId`, in tab order. Feeds the scoped tab strip.
+   * Distinct from {@link getSessions} (which stays full-set for draft-prune /
+   * auto-spawn). Returns a shared frozen empty array when the scope has none.
+   */
+  getSessionsForScope(projectId: ProjectScopeId): AgentSession[] {
+    const scoped: AgentSession[] = [];
+    for (const session of this.sessions.values()) {
+      if (session.projectId !== projectId) continue;
+      if (this.detachedFromTabIds.has(session.internalId)) continue;
+      scoped.push(session);
+    }
+    return scoped.length === 0 ? EMPTY_SESSIONS : scoped;
+  }
+
+  /** Session ids belonging to `projectId`, in tab order. */
+  private getSessionIdsForScope(projectId: ProjectScopeId): string[] {
+    const ids: string[] = [];
+    for (const session of this.sessions.values()) {
+      if (session.projectId !== projectId) continue;
+      if (this.detachedFromTabIds.has(session.internalId)) continue;
+      ids.push(session.internalId);
+    }
+    return ids;
+  }
+
+  /**
+   * Switch the active scope to `projectId` and surface one of its sessions:
+   * its MRU (if still alive) → any existing session in the scope → a freshly
+   * auto-spawned one. Orphaned ids (project deleted) show a Notice and are
+   * rejected without touching the active scope or cwd (no recovery UI yet).
+   * `exitProject` is just re-entering {@link GLOBAL_SCOPE}.
+   */
+  async enterProject(projectId: ProjectScopeId): Promise<void> {
+    if (this.disposed) return;
+    if (projectId !== GLOBAL_SCOPE && !getCachedProjectRecordById(projectId)) {
+      new Notice("This project no longer exists. Restore it to open its chats.");
+      return;
+    }
+    // Already here with a live in-scope session — nothing to restore.
+    const current = this.getActiveSession();
+    if (
+      projectId === this.activeProjectId &&
+      current &&
+      current.projectId === projectId &&
+      current.getStatus() !== "closed"
+    ) {
+      return;
+    }
+
+    this.parkActiveScope();
+    this.activeProjectId = projectId;
+
+    // A project scope opens as a FRESH visit: its prior conversational chats
+    // move to chat history (detached from the tab strip — not closed, so a
+    // backgrounded turn keeps running and stays visible via the history row's
+    // spinner/done-dot). A never-used empty landing tab is reused instead of
+    // stacking a new blank tab on every visit. The global workspace keeps its
+    // restore-the-last-tab behavior (it's the implicit scope `exitProject`
+    // returns to, not a project the user deliberately re-opens).
+    if (projectId !== GLOBAL_SCOPE) {
+      // A dirty project (its sources changed since last materialization) must
+      // start a genuinely fresh session — reusing an empty landing would carry
+      // the stale `<project_context>` it captured at creation — so detach even
+      // empty landings and force a spawn.
+      const dirty = this.isProjectContextDirty(projectId);
+      const reusable = dirty ? null : this.pickReusableLandingSession(projectId);
+      this.detachSessionsForProjectEntry(projectId, { includeEmpty: dirty });
+      if (reusable) {
+        this.detachedFromTabIds.delete(reusable.internalId);
+        this.activeSessionId = reusable.internalId;
+        this.lastActiveByScope.set(projectId, reusable.internalId);
+        reusable.clearNeedsAttention();
+        this.notify();
+        this.touchProjectUsage(projectId);
+        return;
+      }
+      this.activeSessionId = null;
+      this.notify();
+      await this.getOrCreateActiveSession();
+      this.touchProjectUsage(projectId);
+      return;
+    }
+
+    const restored = this.restoreScopeActiveSession(projectId);
+    if (restored) {
+      this.activeSessionId = restored.internalId;
+      this.lastActiveByScope.set(projectId, restored.internalId);
+      restored.clearNeedsAttention();
+      this.notify();
+      this.touchProjectUsage(projectId);
+      return;
+    }
+
+    // No reusable session in this scope — drop the stale cross-scope pointer
+    // (keeps the `active.projectId === activeProjectId` invariant) and spawn.
+    this.activeSessionId = null;
+    this.notify();
+    await this.getOrCreateActiveSession();
+    // Reason: count as a "use" only after the spawn resolves — a failed spawn
+    // (await throws) must not bump MRU.
+    this.touchProjectUsage(projectId);
+  }
+
+  /**
+   * Detach a project scope's prior tabs on re-entry — they stay live in the pool
+   * and listed in chat history. Conversational chats (with user-visible
+   * messages) always detach. Empty landing tabs detach only when
+   * `includeEmpty` is set (a dirty project, whose captured context is stale, must
+   * not leave a stale empty landing in the strip); otherwise they're left
+   * attached so a reusable one can become the fresh visit's tab (see
+   * {@link pickReusableLandingSession}).
+   */
+  private detachSessionsForProjectEntry(
+    projectId: ProjectScopeId,
+    opts: { includeEmpty: boolean }
+  ): void {
+    for (const session of this.sessions.values()) {
+      if (session.projectId !== projectId) continue;
+      if (session.getStatus() === "closed") continue;
+      if (!opts.includeEmpty && !session.hasUserVisibleMessages()) continue;
+      this.detachedFromTabIds.add(session.internalId);
+    }
+  }
+
+  /**
+   * The scope's reusable empty landing tab — a live, never-messaged session that
+   * a fresh visit can adopt instead of spawning a new blank one. Prefers the
+   * scope's MRU; falls back to the most recent matching session. `null` means
+   * the caller should spawn fresh.
+   */
+  private pickReusableLandingSession(projectId: ProjectScopeId): AgentSession | null {
+    // Only an idle/starting blank tab is safe to adopt as the fresh visit's tab.
+    // An "error" landing (its backend never opened) or one mid-turn
+    // ("running"/"awaiting_permission") is not a clean slate — spawn fresh instead.
+    const isReusable = (session: AgentSession): boolean =>
+      session.projectId === projectId &&
+      (session.getStatus() === "idle" || session.getStatus() === "starting") &&
+      !session.hasUserVisibleMessages();
+
+    const mruId = this.lastActiveByScope.get(projectId);
+    const mru = mruId ? this.sessions.get(mruId) : undefined;
+    if (mru && isReusable(mru)) return mru;
+
+    let fallback: AgentSession | null = null;
+    for (const session of this.sessions.values()) {
+      if (isReusable(session)) fallback = session;
+    }
+    return fallback;
+  }
+
+  /**
+   * Record a successful enter of `projectId` as its most-recent use, mirroring
+   * chat-mode {@link ProjectManager.switchProject}. Skips {@link GLOBAL_SCOPE}
+   * (the implicit workspace `exitProject` returns to) and any scope that is no
+   * longer current — the spawn-path caller touches after an `await`, so a
+   * concurrent `enterProject` may have moved the active scope on in the meantime.
+   */
+  private touchProjectUsage(projectId: ProjectScopeId): void {
+    // Reason: the spawn path touches after `await getOrCreateActiveSession()`;
+    // if the user switched scopes (or we were disposed) during that await, the
+    // project they LEFT must not be bumped to MRU top. Only credit the scope
+    // we're actually still in. The restored path passes trivially — there
+    // `activeProjectId` already equals `projectId` when this is called.
+    if (this.disposed || projectId === GLOBAL_SCOPE || this.activeProjectId !== projectId) return;
+    // Reason: MRU feedback only — fire-and-forget so the throttled frontmatter
+    // write never blocks the scope switch; touchProjectLastUsed logs+swallows
+    // its own failures.
+    void ProjectFileManager.getInstance(this.app).touchProjectLastUsed(projectId);
+  }
+
+  /** Leave the current project and return to the global workspace. */
+  async exitProject(): Promise<void> {
+    await this.enterProject(GLOBAL_SCOPE);
+  }
+
+  /** Record the current active session as its scope's MRU before a scope switch. */
+  private parkActiveScope(): void {
+    const active = this.getActiveSession();
+    if (active && active.getStatus() !== "closed") {
+      this.lastActiveByScope.set(active.projectId, active.internalId);
+    }
+  }
+
+  /**
+   * Pick the session to surface when entering `projectId`: its recorded MRU if
+   * still alive, else the last existing session in the scope. `null` means the
+   * scope is empty and the caller should auto-spawn.
+   */
+  private restoreScopeActiveSession(projectId: ProjectScopeId): AgentSession | null {
+    const mruId = this.lastActiveByScope.get(projectId);
+    if (mruId) {
+      const mru = this.sessions.get(mruId);
+      if (mru && mru.getStatus() !== "closed") return mru;
+    }
+    const scoped = this.getSessionsForScope(projectId);
+    return scoped.length > 0 ? scoped[scoped.length - 1] : null;
+  }
+
+  /**
+   * Park the current scope and point `activeProjectId` at `projectId` without
+   * restoring/spawning a session — used by history load, which creates the
+   * specific saved session itself right after.
+   */
+  private setActiveScope(projectId: ProjectScopeId): void {
+    if (projectId === this.activeProjectId) return;
+    this.parkActiveScope();
+    this.activeProjectId = projectId;
+  }
+
+  /**
+   * Undo the optimistic scope switch a history load performs before it has a
+   * session, when the resume/create that follows rejects. A history load calls
+   * `setActiveScope` to point `activeProjectId` at the chat's scope (so the new
+   * session activates there) while `activeSessionId` still references the
+   * previous scope's session; a failed load would otherwise strand the manager
+   * with `getActiveSession().projectId !== activeProjectId` until the user
+   * manually switches scopes. Only roll back if we're still parked in the scope
+   * we switched to — a concurrent scope switch during the awaited backend spawn
+   * means the user has moved on, and forcing them back would reintroduce the
+   * very race `createSession`'s activation guard already avoids.
+   */
+  private rollbackHistoryLoadScope(
+    attemptedProjectId: ProjectScopeId,
+    previousProjectId: ProjectScopeId
+  ): void {
+    if (this.activeProjectId === attemptedProjectId) {
+      this.activeProjectId = previousProjectId;
+    }
   }
 
   setDefaultBackend(backendId: BackendId): void {
@@ -1121,10 +2056,11 @@ export class AgentSessionManager {
   async closeSession(id: string): Promise<void> {
     const session = this.sessions.get(id);
     if (!session) return;
-    // Capture the closed tab's index BEFORE delete so we can pick the
-    // neighbor that currently sits to its right.
-    const idsBefore = Array.from(this.sessions.keys());
-    const closedIdx = idsBefore.indexOf(id);
+    const closedScope = session.projectId;
+    // Capture the closed tab's index WITHIN ITS SCOPE before delete so the
+    // neighbour pick stays in-scope (never jumps the user to another project).
+    const scopeIdsBefore = this.getSessionIdsForScope(closedScope);
+    const closedIdx = scopeIdsBefore.indexOf(id);
     try {
       await session.cancel();
     } catch (e) {
@@ -1141,20 +2077,47 @@ export class AgentSessionManager {
     this.detachAutoSave(id);
     this.sessions.delete(id);
     this.chatUIStates.delete(id);
+    this.detachedFromTabIds.delete(id);
+    // Drop the closed session from its scope's MRU so a later enter can't
+    // resurrect a dead id.
+    if (this.lastActiveByScope.get(closedScope) === id) {
+      this.lastActiveByScope.delete(closedScope);
+    }
     if (this.activeSessionId === id) {
-      const remaining = Array.from(this.sessions.keys());
-      this.activeSessionId =
-        remaining.length === 0 ? null : remaining[Math.min(closedIdx, remaining.length - 1)];
+      const scopeIdsAfter = this.getSessionIdsForScope(closedScope);
+      const nextId = pickScopeNeighbor(
+        scopeIdsAfter,
+        closedIdx,
+        this.lastActiveByScope.get(closedScope)
+      );
+      this.activeSessionId = nextId;
+      if (nextId) this.lastActiveByScope.set(closedScope, nextId);
+      // `activeProjectId` stays `closedScope` even when it's now empty — never
+      // silently jump the active scope on close.
     }
     this.notify();
   }
 
-  /** Move the active pointer to `id`. No-op if `id` is unknown. */
+  /**
+   * Move the active pointer to `id`. No-op if `id` is unknown. When the target
+   * lives in a different scope, the active scope follows it (cross-scope
+   * auto-switch) so the `active.projectId === activeProjectId` invariant holds.
+   * This is NOT a cancel path — the previously-active turn keeps running in the
+   * background (D6 auto-park).
+   */
   setActiveSession(id: string): void {
     const session = this.sessions.get(id);
     if (!session) return;
     if (this.activeSessionId === id) return;
+    if (session.projectId !== this.activeProjectId) {
+      this.parkActiveScope();
+      this.activeProjectId = session.projectId;
+    }
+    // Surfacing a session (history open / tab click) re-attaches it to its
+    // scope's tab strip if a prior project re-entry had detached it.
+    this.detachedFromTabIds.delete(id);
     this.activeSessionId = id;
+    this.lastActiveByScope.set(session.projectId, id);
     session.clearNeedsAttention();
     this.notify();
   }
@@ -1169,7 +2132,10 @@ export class AgentSessionManager {
    */
   async replaceSessionInPlace(oldId: string, backendId?: BackendId): Promise<AgentSession> {
     const oldIdx = Array.from(this.sessions.keys()).indexOf(oldId);
-    const created = await this.createSession(backendId);
+    // The replacement inherits the REPLACED session's scope, not the active
+    // scope (they can differ if the old tab wasn't the active one).
+    const replacedProjectId = this.sessions.get(oldId)?.projectId ?? this.activeProjectId;
+    const created = await this.createSession(backendId, replacedProjectId);
     if (oldIdx >= 0) {
       this.moveMapEntry(this.sessions, created.internalId, oldIdx);
       this.moveMapEntry(this.chatUIStates, created.internalId, oldIdx);
@@ -1269,8 +2235,9 @@ export class AgentSessionManager {
 
   /**
    * Subscribe to lifecycle changes (session created/closed/active changed/
-   * label changed, backend exit, isStarting/lastError flips). Returns an
-   * unsubscribe function. Listeners must not throw.
+   * label changed, backend exit, isStarting/lastError flips). Also fires when a
+   * session enters or leaves `running` (so the recent-list spinner can follow).
+   * Returns an unsubscribe function. Listeners must not throw.
    */
   subscribe(listener: () => void): () => void {
     this.listeners.add(listener);
@@ -1300,6 +2267,11 @@ export class AgentSessionManager {
     if (this.disposed) return;
     this.disposed = true;
     this.settingsUnsub();
+    // Unsubscribe SYNCHRONOUSLY up front: the teardown below awaits, and a
+    // project-record change landing in that window must not re-enter the handler
+    // on a half-disposed manager.
+    this.projectRecordsUnsubscriber?.();
+    this.projectRecordsUnsubscriber = undefined;
     logInfo(
       `[AgentMode] shutdown (pool size=${this.sessions.size}, backends=${this.backends.size})`
     );
@@ -1330,6 +2302,11 @@ export class AgentSessionManager {
     this.sessions.clear();
     this.chatUIStates.clear();
     this.activeSessionId = null;
+    this.activeProjectId = GLOBAL_SCOPE;
+    this.lastActiveByScope.clear();
+    this.detachedFromTabIds.clear();
+    this.contextDirtySignatures.clear();
+    this.firstSessionPromiseByScope.clear();
 
     const allBackends = Array.from(this.backends.values());
     await Promise.allSettled(
@@ -1383,13 +2360,38 @@ export class AgentSessionManager {
     const previousActiveId = this.activeSessionId;
 
     const loaded = await this.opts.persistenceManager.loadFile(file);
-
-    let session: AgentSession | null = null;
-    if (loaded.sessionId) {
-      session = await this.tryResumeSessionFromHistory(loaded.backendId, loaded.sessionId);
+    // `loaded.projectId` is authoritative (GLOBAL_SCOPE for legacy chats with no
+    // frontmatter). Read scope FIRST so the resumed session gets the right cwd;
+    // an orphaned project (deleted) shows a Notice and aborts rather than
+    // downgrading to the vault root (no recovery menu yet).
+    const projectId = loaded.projectId;
+    if (projectId !== GLOBAL_SCOPE && !getCachedProjectRecordById(projectId)) {
+      new Notice("This chat belongs to a project that no longer exists.");
+      throw new OrphanedProjectError(projectId);
     }
-    if (!session) {
-      session = await this.createSession(loaded.backendId);
+    // Point the active scope at the chat's scope before constructing its
+    // session (which then activates within that scope). No restore/spawn here —
+    // we create the specific saved session next. Snapshot the scope this call
+    // actually replaces right here, AFTER the awaits above — capturing earlier
+    // would let a scope switch raced in during `loadFile` make rollback restore
+    // a stale scope.
+    const previousActiveProjectId = this.activeProjectId;
+    this.setActiveScope(projectId);
+
+    // Resume or create the saved session. Either await can reject (e.g. a
+    // missing backend binary fails to spawn); on failure, undo the scope switch
+    // above so a failed open doesn't leave the active scope ahead of the active
+    // session. The throw points are all before a session activates, so no
+    // already-active session in the target scope can be wrongly rolled back.
+    let session: AgentSession;
+    try {
+      const resumed = loaded.sessionId
+        ? await this.tryResumeSessionFromHistory(loaded.backendId, loaded.sessionId, projectId)
+        : null;
+      session = resumed ?? (await this.createSession(loaded.backendId, projectId));
+    } catch (err) {
+      this.rollbackHistoryLoadScope(projectId, previousActiveProjectId);
+      throw err;
     }
 
     session.loadDisplayMessages(loaded.messages);
@@ -1400,6 +2402,7 @@ export class AgentSessionManager {
       // merged history ranks this chat correctly after a reopen.
       void this.opts.sessionIndex?.touch(loaded.backendId, loaded.sessionId);
     }
+    this.lastActiveByScope.set(projectId, session.internalId);
     this.absorbIntoEmptyActiveTab(session, previousActiveId);
     this.notify();
     return session;
@@ -1457,9 +2460,36 @@ export class AgentSessionManager {
     // Captured before the resumed session becomes active so we can replace an
     // empty landing tab in place rather than spawning a new one.
     const previousActiveId = this.activeSessionId;
-    const session = await this.tryResumeSessionFromHistory(backendId, sessionId);
-    if (!session) {
-      throw new Error(`Could not resume session ${sessionId} from the ${backendId} session store.`);
+    const index = this.opts.sessionIndex;
+    const entry = index ? await index.getEntry(backendId, sessionId) : null;
+    // Scope from the index entry (write-through / sweep attribution); absent ≙
+    // global. Mirrors loadSessionFromHistory's frontmatter handling: orphan
+    // guard first (never downgrade a project chat to the vault root), then
+    // point the active scope at the chat's scope before constructing it.
+    const projectId: ProjectScopeId = entry?.projectId ?? GLOBAL_SCOPE;
+    if (projectId !== GLOBAL_SCOPE && !getCachedProjectRecordById(projectId)) {
+      new Notice("This chat belongs to a project that no longer exists.");
+      throw new OrphanedProjectError(projectId);
+    }
+    // Snapshot the scope this call actually replaces right here, AFTER the
+    // `getEntry` await — capturing earlier would let a scope switch raced in
+    // during the await make rollback restore a stale scope.
+    const previousActiveProjectId = this.activeProjectId;
+    this.setActiveScope(projectId);
+    // Unlike markdown history there is no fresh-session fallback — a failed
+    // resume rejects, so undo the scope switch above before propagating it.
+    let session: AgentSession;
+    try {
+      const resumed = await this.tryResumeSessionFromHistory(backendId, sessionId, projectId);
+      if (!resumed) {
+        throw new Error(
+          `Could not resume session ${sessionId} from the ${backendId} session store.`
+        );
+      }
+      session = resumed;
+    } catch (err) {
+      this.rollbackHistoryLoadScope(projectId, previousActiveProjectId);
+      throw err;
     }
     // Rebuild the visible transcript for backends that resume without
     // replaying it (Claude SDK reads its on-disk session jsonl). ACP backends
@@ -1467,17 +2497,14 @@ export class AgentSessionManager {
     // session already has its messages. Best-effort: an empty result leaves
     // the resumed-but-blank session as-is rather than failing the open.
     await this.hydrateResumedTranscript(session, backendId, sessionId);
-    const index = this.opts.sessionIndex;
-    if (index) {
-      const entry = await index.getEntry(backendId, sessionId);
-      // Reapply with the recorded source: a user rename stays sticky, but an
-      // agent/derived title is agent-sourced so a resumed opencode/codex
-      // session can still refresh its title from later agent updates.
-      if (entry?.title) {
-        session.restoreLabel(entry.title, entry.titleSource === "user" ? "user" : "agent");
-      }
-      await index.touch(backendId, sessionId);
+    // Reapply with the recorded source: a user rename stays sticky, but an
+    // agent/derived title is agent-sourced so a resumed opencode/codex
+    // session can still refresh its title from later agent updates.
+    if (entry?.title) {
+      session.restoreLabel(entry.title, entry.titleSource === "user" ? "user" : "agent");
     }
+    if (index) await index.touch(backendId, sessionId);
+    this.lastActiveByScope.set(projectId, session.internalId);
     this.absorbIntoEmptyActiveTab(session, previousActiveId);
     this.notify();
     return session;
@@ -1497,12 +2524,15 @@ export class AgentSessionManager {
     const proc = this.backends.get(backendId);
     if (!proc?.readPersistedTranscript) return;
     if (session.store.getDisplayMessages().length > 0) return;
-    const adapter = this.app.vault.adapter;
-    if (!(adapter instanceof FileSystemAdapter)) return;
     try {
+      // The store is keyed by the cwd the session RAN in (Claude encodes the
+      // transcript path from it), so a project chat must hydrate from its
+      // project folder — the vault root would look in the wrong directory.
+      // Resolved inside the try: hydration is best-effort, and an orphaned
+      // scope just skips it like any other store miss.
       const transcript = await proc.readPersistedTranscript({
         sessionId,
-        cwd: adapter.getBasePath(),
+        cwd: this.resolveSessionCwd(session.projectId),
       });
       if (transcript.length > 0) session.loadDisplayMessages(transcript);
     } catch (e) {
@@ -1519,11 +2549,24 @@ export class AgentSessionManager {
    */
   private async tryResumeSessionFromHistory(
     backendId: BackendId,
-    sessionId: SessionId
+    sessionId: SessionId,
+    projectId: ProjectScopeId
   ): Promise<AgentSession | null> {
-    const adapter = this.app.vault.adapter;
-    if (!(adapter instanceof FileSystemAdapter)) return null;
-    const vaultBasePath = adapter.getBasePath();
+    // Same AGENTS.md mirror ensure as `createSession` — resume rehydrates an existing
+    // session, but its cwd still derives from the project record, so a cwd-instruction
+    // backend needs the mirror materialized before cwd is read. Never throws; skipped for
+    // GLOBAL_SCOPE and for claude.
+    if (projectId !== GLOBAL_SCOPE && CWD_INSTRUCTION_BACKENDS.has(backendId)) {
+      const record = getCachedProjectRecordById(projectId);
+      if (record) await ensureAgentsMirror(this.app, record);
+    }
+    const cwd = this.resolveSessionCwd(projectId);
+    // Kick off materialization in parallel (publishes the blocking load state up
+    // front), overlapping with `ensureBackend`. Unlike a fresh create, a resumed
+    // session can't appear before the backend rehydrates it, so we await the
+    // roots just before `loadSession`. Never rejects → resume is never blocked.
+    const contextReady =
+      projectId === GLOBAL_SCOPE ? undefined : this.beginContextMaterialization(projectId, cwd);
     const descriptor = this.resolveDescriptor(backendId);
 
     this.pendingCreates++;
@@ -1549,9 +2592,29 @@ export class AgentSessionManager {
 
     const mcpServers = resolveMcpServers(backend, getSettings().agentMode?.mcpServers);
 
+    // Await the roots now (materialize has been running alongside ensureBackend).
+    // GLOBAL has no contextReady → undefined, identical to a context-free resume.
+    // The inline `<project_context>` block is for fresh first prompts only, so a
+    // resumed session uses just the searchable roots here.
+    const additionalDirectories = contextReady
+      ? (await contextReady).additionalDirectories
+      : undefined;
+    // The await above is a new suspension point — re-check disposal before
+    // touching the (possibly tearing-down) backend, mirroring the fresh-create
+    // guard in AgentSession.initialize. Same cleanup as the path's other returns.
+    if (this.disposed) {
+      this.finishPendingCreate();
+      return null;
+    }
     let resumeResult: { sessionId: SessionId; state: BackendState } | null = null;
     try {
-      resumeResult = await backend.loadSession({ sessionId, cwd: vaultBasePath, mcpServers });
+      resumeResult = await backend.loadSession({
+        sessionId,
+        cwd,
+        mcpServers,
+        projectId,
+        additionalDirectories,
+      });
     } catch (err) {
       if (!(err instanceof MethodUnsupportedError)) {
         logWarn(`[AgentMode] loadSession failed for ${sessionId}`, err);
@@ -1564,8 +2627,10 @@ export class AgentSessionManager {
       try {
         resumeResult = await backend.resumeSession({
           sessionId,
-          cwd: vaultBasePath,
+          cwd,
           mcpServers,
+          projectId,
+          additionalDirectories,
         });
       } catch (err) {
         if (err instanceof MethodUnsupportedError) {
@@ -1590,8 +2655,9 @@ export class AgentSessionManager {
       backendSessionId: resumeResult.sessionId,
       internalId: uuidv4(),
       backendId,
+      projectId,
       initialState: resumeResult.state,
-      cwd: vaultBasePath,
+      cwd,
       getDescriptor: () => this.opts.resolveDescriptor(backendId),
       runFanoutTurn: (input) => this.runFanoutTurn(input),
       getDisplayName: (id) => this.resolveDescriptor(id).displayName,
@@ -1599,7 +2665,10 @@ export class AgentSessionManager {
     });
     this.sessions.set(session.internalId, session);
     this.chatUIStates.set(session.internalId, new AgentChatUIState(session));
+    this.detachedFromTabIds.delete(session.internalId);
     this.activeSessionId = session.internalId;
+    this.activeProjectId = projectId;
+    this.lastActiveByScope.set(projectId, session.internalId);
     this.attachAutoSave(session);
     this.attachModelCacheSync(session);
     this.attachAttentionTracking(session);
@@ -1688,6 +2757,10 @@ export class AgentSessionManager {
       titleSource,
       createdAtMs: messages[0]?.timestamp?.epoch ?? now,
       lastAccessedAtMs: now,
+      // Scope the native entry so project views can list it (markdown chats
+      // carry the scope in frontmatter; native-only chats have only this).
+      // GLOBAL_SCOPE maps to the field's "absent" encoding.
+      projectId: session.projectId === GLOBAL_SCOPE ? undefined : session.projectId,
     });
   }
 
@@ -1746,6 +2819,9 @@ export class AgentSessionManager {
       label,
       existingPath: state.path,
       sessionId,
+      // GLOBAL_SCOPE writes no frontmatter (byte-identical to legacy chats);
+      // a real project id binds the chat to that scope on disk.
+      projectId: session.projectId,
     });
     if (result) {
       state.path = result.path;
@@ -1827,12 +2903,21 @@ export class AgentSessionManager {
       onMessagesChanged: () => {},
       onStatusChanged: (next) => {
         const wasRunning = prev === "running";
+        const isRunning = next === "running";
         prev = next;
         void this.flushDeferredBackendRestartIfReady(session.backendId);
-        if (!wasRunning) return;
-        if (!ATTENTION_TRIGGER_STATUSES.has(next)) return;
-        if (this.activeSessionId === session.internalId) return;
-        session.markNeedsAttention();
+        // Existing attention marking — unchanged semantics: a backgrounded
+        // session that leaves `running` for a status that demands the user's eye.
+        if (
+          wasRunning &&
+          ATTENTION_TRIGGER_STATUSES.has(next) &&
+          this.activeSessionId !== session.internalId
+        ) {
+          session.markNeedsAttention();
+        }
+        // Re-render recent-list rows when this session's running membership
+        // flips, so the row's spinner appears/disappears in step.
+        if (wasRunning !== isRunning) this.notify();
       },
     });
     this.getSessionState(session.internalId).attentionUnsub = unsubscribe;
@@ -1868,6 +2953,29 @@ export class AgentSessionManager {
     // Lets a backend with its own permission gate (Claude SDK) hard-deny write/exec
     // tools for read-only fan-out sub-sessions — see `permissionBridge`.
     proc.setReadOnlySessionPredicate?.((sessionId) => this.isReadOnlyFanoutSession(sessionId));
+    // Inject the project-instruction resolver. Wiring here (the single
+    // warm-adopt + fresh choke point) covers both backend bring-up paths.
+    // Backends that discover instructions from cwd (codex/opencode) omit the
+    // setter and this is a no-op.
+    proc.setProjectProfileProvider?.((projectId) => this.getProjectProfile(projectId));
+  }
+
+  /**
+   * Map a scope id to the minimal {@link ProjectProfile} a backend needs to
+   * inject project instructions. Returns `undefined` for {@link GLOBAL_SCOPE}
+   * or an unknown project — keeping the `projects/` lookup here so
+   * `backends/` never imports the projects layer.
+   */
+  private getProjectProfile(projectId: ProjectScopeId): ProjectProfile | undefined {
+    if (projectId === GLOBAL_SCOPE) return undefined;
+    const record = getCachedProjectRecordById(projectId);
+    if (!record) return undefined;
+    return {
+      id: record.project.id,
+      // Layer the built-in project policy ahead of the user's own instruction body, so Claude's
+      // `<project_instructions>` carries the same composed body codex/opencode get via the mirror.
+      systemPrompt: getComposedProjectInstructions(record),
+    };
   }
 
   private async ensureBackend(
@@ -1934,12 +3042,32 @@ export class AgentSessionManager {
         this.detachAutoSave(s.internalId);
         this.sessions.delete(s.internalId);
         this.chatUIStates.delete(s.internalId);
+        this.detachedFromTabIds.delete(s.internalId);
+        // Drop the dead session from its scope's MRU so a later enter can't
+        // resurrect a dead id.
+        if (this.lastActiveByScope.get(s.projectId) === s.internalId) {
+          this.lastActiveByScope.delete(s.projectId);
+        }
         s.cancel().catch(() => {});
         s.dispose().catch(() => {});
       }
       if (this.activeSessionId && !this.sessions.has(this.activeSessionId)) {
-        const remaining = Array.from(this.sessions.keys());
-        this.activeSessionId = remaining[0] ?? null;
+        // Repoint at a STRIP-VISIBLE survivor only. A session detached on a prior
+        // project re-entry was deliberately parked to history; crash recovery must
+        // not silently resurrect it into the active tab. If none is visible, leave
+        // active null — the crash pill shows and the router (which bails on
+        // lastError) won't auto-respawn behind the user.
+        let next: AgentSession | undefined;
+        for (const s of this.sessions.values()) {
+          if (!this.detachedFromTabIds.has(s.internalId)) {
+            next = s;
+            break;
+          }
+        }
+        this.activeSessionId = next?.internalId ?? null;
+        // Crash repointing can cross scopes; keep `active.projectId ===
+        // activeProjectId` rather than leaving a stale scope behind.
+        if (next) this.activeProjectId = next.projectId;
       }
       // Surface the crash so the empty-state pill shows it and the
       // router's auto-spawn effect (which bails on lastError) doesn't
@@ -1997,10 +3125,12 @@ export class AgentSessionManager {
       // affected sessions are still closed; the tab falls back to its
       // needs-setup state. `restartBackendNow` is otherwise only reached for an
       // installed backend, so this is a no-op for the normal restart path.
+      const replacedSession = affected.find((s) => s.internalId === this.activeSessionId);
       const shouldCreateReplacement =
-        this.isBackendInstalled(backendId) &&
-        affected.length > 0 &&
-        affected.some((s) => s.internalId === this.activeSessionId);
+        this.isBackendInstalled(backendId) && affected.length > 0 && replacedSession !== undefined;
+      // The replacement must inherit the REPLACED session's scope, not the
+      // current active scope — captured before the close loop repoints `active`.
+      const replacementProjectId = replacedSession?.projectId ?? this.activeProjectId;
       for (const session of affected) {
         await this.closeSession(session.internalId);
       }
@@ -2023,7 +3153,9 @@ export class AgentSessionManager {
         this.registerPreload(backendId, probe);
         if (shouldCreateReplacement && !this.disposed) {
           await probe;
-          await this.createSession(backendId);
+          // The replacement inherits the REPLACED session's scope (captured
+          // above as `replacementProjectId`), not the current active scope.
+          await this.createSession(backendId, replacementProjectId);
         }
       }
       this.notify();

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -1571,6 +1571,10 @@ export class AgentSessionManager {
       return;
     }
 
+    // Snapshot the scope this entry replaces BEFORE the optimistic switch, so a
+    // rejected auto-spawn below can restore it (see `spawnEnteredScopeOrRollback`).
+    const previousActiveProjectId = this.activeProjectId;
+    const previousActiveSessionId = this.activeSessionId;
     this.parkActiveScope();
     this.activeProjectId = projectId;
 
@@ -1604,7 +1608,11 @@ export class AgentSessionManager {
       }
       this.activeSessionId = null;
       this.notify();
-      await this.getOrCreateActiveSession();
+      await this.spawnEnteredScopeOrRollback(
+        projectId,
+        previousActiveProjectId,
+        previousActiveSessionId
+      );
       this.touchProjectUsage(projectId);
       return;
     }
@@ -1774,6 +1782,41 @@ export class AgentSessionManager {
   ): void {
     if (this.activeProjectId === attemptedProjectId) {
       this.activeProjectId = previousProjectId;
+    }
+  }
+
+  /**
+   * Auto-spawn a just-entered project scope's first session, undoing the
+   * optimistic scope switch if the spawn rejects (e.g. a missing backend binary).
+   * By this point `enterProject` has parked the prior scope, pointed
+   * `activeProjectId` at the new scope, detached the new scope's tabs, and nulled
+   * `activeSessionId`. The callers only surface a Notice, so without this a
+   * rejected spawn would strand the manager in a project scope with no active
+   * chat. Restores the previous scope's `activeProjectId` + active-session pointer
+   * and re-notifies, then rethrows so the caller still reports the failure.
+   *
+   * Guarded on still being parked in the attempted scope: a concurrent
+   * `enterProject` during the awaited spawn means the user moved on, and forcing
+   * them back would clobber that newer switch (mirrors
+   * {@link rollbackHistoryLoadScope}). The detached tabs are intentionally left
+   * detached — they belong to the project we failed to enter, are invisible from
+   * the restored scope, and a later successful entry re-detaches them anyway as a
+   * fresh visit.
+   */
+  private async spawnEnteredScopeOrRollback(
+    attemptedProjectId: ProjectScopeId,
+    previousProjectId: ProjectScopeId,
+    previousActiveSessionId: string | null
+  ): Promise<void> {
+    try {
+      await this.getOrCreateActiveSession();
+    } catch (err) {
+      if (this.activeProjectId === attemptedProjectId) {
+        this.activeProjectId = previousProjectId;
+        this.activeSessionId = previousActiveSessionId;
+        this.notify();
+      }
+      throw err;
     }
   }
 

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -1645,6 +1645,17 @@ export class AgentSessionManager {
    * existing empty landing is stale/unusable and must not linger in the strip);
    * otherwise they're left attached so the reused one stays the visit's tab (see
    * {@link pickReusableLandingSession}).
+   *
+   * DESIGN NOTE — detached sessions are deliberately kept ALIVE (a backgrounded
+   * turn keeps running; the history row shows its spinner/done-dot) and are NOT
+   * evicted here, so repeated project re-entry accumulates idle detached sessions
+   * for the app's lifetime. Bounding the idle-detached class — an LRU cap that
+   * never evicts running/awaiting sessions — needs a per-session backend close
+   * primitive the backends don't expose yet, so it is out of scope for the
+   * project-workspace landing. Known limitation, deliberately deferred
+   * (obsidian-copilot-preview#164; the missing close primitive is
+   * obsidian-copilot-preview#178). If a future review flags this again, point
+   * them here.
    */
   private detachSessionsForProjectEntry(
     projectId: ProjectScopeId,

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -66,7 +66,10 @@ import {
   subscribeToProjectRecords,
 } from "@/projects/state";
 import type { ProjectFileRecord } from "@/projects/type";
-import { getProjectContextSignature } from "@/projects/projectContextSignature";
+import {
+  getProjectContextSignature,
+  getProjectLandingCaptureSignature,
+} from "@/projects/projectContextSignature";
 import { ProjectFileManager } from "@/projects/ProjectFileManager";
 import { ensureAgentsMirror } from "@/projects/ensureAgentsMirror";
 import { getComposedProjectInstructions } from "@/projects/projectSystemPrompt";
@@ -271,6 +274,15 @@ export class AgentSessionManager {
   // signature — a newer edit's signature won't match, so its dirtiness survives
   // (no lost update). Mirrors chat mode's `markdownNeedsReload`.
   private readonly contextDirtySignatures = new Map<ProjectScopeId, string>();
+  // A project landing session captures MORE than materialized context at
+  // creation: codex/opencode read the AGENTS.md mirror from cwd, and Claude
+  // captures its project-instructions append. The materialization dirty flag
+  // above deliberately ignores `systemPrompt`, so reuse decisions need their own
+  // fingerprint of what the session actually baked in (the landing-capture
+  // signature). Keyed by internal session id; every project session gets an
+  // entry, but only landing-shaped ones (idle/empty) are ever consulted for
+  // reuse. A missing entry means "not reusable as a project landing".
+  private readonly landingCaptureSignatures = new Map<string, string>();
   // Snapshot of project records from the previous change notification, diffed
   // against the next to detect context-source edits. Seeded in the constructor.
   private previousProjectRecords: ProjectFileRecord[] = [];
@@ -1052,14 +1064,22 @@ export class AgentSessionManager {
 
     const resolvedId = backendId ?? getSettings().agentMode?.activeBackend ?? "opencode";
 
+    // Read the live record once: it drives both the AGENTS.md mirror below and
+    // the landing-capture signature recorded after the session is built, so the
+    // two agree on the exact config this session bakes in.
+    const projectRecord =
+      projectId === GLOBAL_SCOPE ? undefined : getCachedProjectRecordById(projectId);
+    const landingCaptureSignature = projectRecord
+      ? getProjectLandingCaptureSignature(projectRecord)
+      : undefined;
+
     // Materialize the project's AGENTS.md mirror from project.md BEFORE resolving cwd, so a
     // cwd-instruction backend (codex/opencode) discovers the instruction file on its first
     // session. This is the sole correctness guarantee for an old project.md-only project.
     // Never throws (degrades gracefully); skipped for GLOBAL_SCOPE and for claude (which gets
     // the instruction injected in-process, no file needed).
-    if (projectId !== GLOBAL_SCOPE && CWD_INSTRUCTION_BACKENDS.has(resolvedId)) {
-      const record = getCachedProjectRecordById(projectId);
-      if (record) await ensureAgentsMirror(this.app, record);
+    if (projectRecord && CWD_INSTRUCTION_BACKENDS.has(resolvedId)) {
+      await ensureAgentsMirror(this.app, projectRecord);
     }
 
     // Resolves the scope's cwd (vault root for global, project folder otherwise)
@@ -1145,6 +1165,15 @@ export class AgentSessionManager {
     }
     this.sessions.set(session.internalId, session);
     this.chatUIStates.set(session.internalId, new AgentChatUIState(session));
+    // Record what this project landing captured so re-entry can tell a current
+    // landing from one that baked in stale config (incl. a System-Prompt-only
+    // edit the materialization dirty flag ignores). Global sessions capture no
+    // project config, so they get no entry (and are never reused as landings).
+    if (landingCaptureSignature) {
+      this.landingCaptureSignatures.set(session.internalId, landingCaptureSignature);
+    } else {
+      this.landingCaptureSignatures.delete(session.internalId);
+    }
     // A fresh id is never detached; clear defensively so a new session can't
     // inherit a stale hidden-from-strip flag.
     this.detachedFromTabIds.delete(session.internalId);
@@ -1556,13 +1585,17 @@ export class AgentSessionManager {
     // restore-the-last-tab behavior (it's the implicit scope `exitProject`
     // returns to, not a project the user deliberately re-opens).
     if (projectId !== GLOBAL_SCOPE) {
-      // A dirty project (its sources changed since last materialization) must
-      // start a genuinely fresh session — reusing an empty landing would carry
-      // the stale `<project_context>` it captured at creation — so detach even
-      // empty landings and force a spawn.
+      // Reuse an empty landing only when it's safe: not dirty (its
+      // `<project_context>` would be stale — materialization-only, see
+      // `contextDirtySignatures`) AND its creation-time capture still matches the
+      // live project config (`pickReusableLandingSession` checks the
+      // landing-capture signature, which also covers a System-Prompt-only edit the
+      // dirty flag ignores). When we instead spawn fresh, detach the project's
+      // empty landings too so a stale blank one can't linger in the strip; when we
+      // reuse, leave them so the adopted tab survives.
       const dirty = this.isProjectContextDirty(projectId);
       const reusable = dirty ? null : this.pickReusableLandingSession(projectId);
-      this.detachSessionsForProjectEntry(projectId, { includeEmpty: dirty });
+      this.detachSessionsForProjectEntry(projectId, { includeEmpty: !reusable });
       if (reusable) {
         this.detachedFromTabIds.delete(reusable.internalId);
         this.activeSessionId = reusable.internalId;
@@ -1603,9 +1636,9 @@ export class AgentSessionManager {
    * Detach a project scope's prior tabs on re-entry — they stay live in the pool
    * and listed in chat history. Conversational chats (with user-visible
    * messages) always detach. Empty landing tabs detach only when
-   * `includeEmpty` is set (a dirty project, whose captured context is stale, must
-   * not leave a stale empty landing in the strip); otherwise they're left
-   * attached so a reusable one can become the fresh visit's tab (see
+   * `includeEmpty` is set (the caller is spawning a fresh session, so any
+   * existing empty landing is stale/unusable and must not linger in the strip);
+   * otherwise they're left attached so the reused one stays the visit's tab (see
    * {@link pickReusableLandingSession}).
    */
   private detachSessionsForProjectEntry(
@@ -1622,18 +1655,18 @@ export class AgentSessionManager {
 
   /**
    * The scope's reusable empty landing tab — a live, never-messaged session that
-   * a fresh visit can adopt instead of spawning a new blank one. Prefers the
-   * scope's MRU; falls back to the most recent matching session. `null` means
-   * the caller should spawn fresh.
+   * a fresh visit can adopt instead of spawning a new blank one. A candidate must
+   * also have captured the CURRENT project config (matching landing-capture
+   * signature); one that baked in stale config is skipped. Prefers the scope's
+   * MRU; falls back to the most recent matching session. `null` means the caller
+   * should spawn fresh.
    */
   private pickReusableLandingSession(projectId: ProjectScopeId): AgentSession | null {
-    // Only an idle/starting blank tab is safe to adopt as the fresh visit's tab.
-    // An "error" landing (its backend never opened) or one mid-turn
-    // ("running"/"awaiting_permission") is not a clean slate — spawn fresh instead.
+    const expected = this.currentLandingCaptureSignature(projectId);
+    if (!expected) return null;
     const isReusable = (session: AgentSession): boolean =>
-      session.projectId === projectId &&
-      (session.getStatus() === "idle" || session.getStatus() === "starting") &&
-      !session.hasUserVisibleMessages();
+      this.isReusableLandingShell(session, projectId) &&
+      this.landingCaptureSignatures.get(session.internalId) === expected;
 
     const mruId = this.lastActiveByScope.get(projectId);
     const mru = mruId ? this.sessions.get(mruId) : undefined;
@@ -1644,6 +1677,27 @@ export class AgentSessionManager {
       if (isReusable(session)) fallback = session;
     }
     return fallback;
+  }
+
+  /**
+   * Whether a session is a clean slate to adopt as a landing — idle/starting and
+   * never messaged. An "error" landing (backend never opened) or one mid-turn
+   * ("running"/"awaiting_permission") is not, so the caller should spawn fresh.
+   * This is the shell check ONLY; capture-freshness is gated separately.
+   */
+  private isReusableLandingShell(session: AgentSession, projectId: ProjectScopeId): boolean {
+    return (
+      session.projectId === projectId &&
+      (session.getStatus() === "idle" || session.getStatus() === "starting") &&
+      !session.hasUserVisibleMessages()
+    );
+  }
+
+  /** The live project record's landing-capture signature, or null off-project. */
+  private currentLandingCaptureSignature(projectId: ProjectScopeId): string | null {
+    if (projectId === GLOBAL_SCOPE) return null;
+    const record = getCachedProjectRecordById(projectId);
+    return record ? getProjectLandingCaptureSignature(record) : null;
   }
 
   /**
@@ -2077,6 +2131,7 @@ export class AgentSessionManager {
     this.detachAutoSave(id);
     this.sessions.delete(id);
     this.chatUIStates.delete(id);
+    this.landingCaptureSignatures.delete(id);
     this.detachedFromTabIds.delete(id);
     // Drop the closed session from its scope's MRU so a later enter can't
     // resurrect a dead id.
@@ -2301,6 +2356,7 @@ export class AgentSessionManager {
     );
     this.sessions.clear();
     this.chatUIStates.clear();
+    this.landingCaptureSignatures.clear();
     this.activeSessionId = null;
     this.activeProjectId = GLOBAL_SCOPE;
     this.lastActiveByScope.clear();
@@ -3042,6 +3098,7 @@ export class AgentSessionManager {
         this.detachAutoSave(s.internalId);
         this.sessions.delete(s.internalId);
         this.chatUIStates.delete(s.internalId);
+        this.landingCaptureSignatures.delete(s.internalId);
         this.detachedFromTabIds.delete(s.internalId);
         // Drop the dead session from its scope's MRU so a later enter can't
         // resurrect a dead id.

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -141,7 +141,6 @@ const EMPTY_HISTORY_ITEMS = Object.freeze([]) as unknown as ChatHistoryItem[];
 // (c) Runtime immutability rests on the `ReadonlySet<string>` type (no `.add`/`.delete` in
 //     the surface) plus the convention that no caller mutates the result — consumers only
 //     `.has()`, read `.size`, and iterate.
-// If a future review flags this again, point them at this note.
 const EMPTY_RECENT_CHAT_IDS: ReadonlySet<string> = new Set();
 
 // Backends that discover project instructions from a physical `AGENTS.md` in the session cwd.
@@ -476,7 +475,6 @@ export class AgentSessionManager {
       // QA, whose answers are advisory and whose authoritative, fully-scoped reply
       // comes from the main session. Threading project scope into the sub-sessions
       // is a deliberate follow-up, not part of the project-workspace landing.
-      // If a future review flags this again, point them at this note.
       getCwd: () => {
         const adapter = this.app.vault.adapter;
         return adapter instanceof FileSystemAdapter ? adapter.getBasePath() : null;
@@ -693,8 +691,7 @@ export class AgentSessionManager {
    * neither saved nor reached the native index yet has NO row in the list at
    * all, so its spinner/dot has nowhere to hang until the list next reloads.
    * That's a missing row, not an id mismatch — dual ids can't help, and forcing
-   * a history reload from here would couple autosave to row visibility. If a
-   * future review flags this again, point them at this note.
+   * a history reload from here would couple autosave to row visibility.
    */
   private recentChatIdsForSession(internalId: string, session: AgentSession): string[] {
     const ids: string[] = [];

--- a/src/agentMode/session/agentChatYaml.ts
+++ b/src/agentMode/session/agentChatYaml.ts
@@ -1,0 +1,53 @@
+/**
+ * Tiny YAML-frontmatter helpers shared by `AgentChatPersistenceManager`. Kept
+ * in their own module so the manager stays focused on persistence flow and
+ * under the file-size budget. All functions are pure and side-effect free.
+ */
+
+/**
+ * Escape a string for a safe YAML double-quoted value. Strips control chars
+ * (including newlines) up front — a stray `\n` in the user's topic would
+ * otherwise terminate the line and corrupt the rest of the frontmatter.
+ */
+export function escapeYamlString(str: string): string {
+  return (
+    str
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x1F\x7F]/g, " ")
+      .replace(/\\/g, "\\\\")
+      .replace(/"/g, '\\"')
+  );
+}
+
+/**
+ * Inverse of {@link escapeYamlString} for the values our hand-rolled
+ * frontmatter parser extracts. Only handles the two escapes we emit (`\\` and
+ * `\"`).
+ */
+export function unescapeYamlString(str: string): string {
+  let out = "";
+  for (let i = 0; i < str.length; i++) {
+    const c = str[i];
+    if (c === "\\" && i + 1 < str.length) {
+      const next = str[i + 1];
+      if (next === "\\" || next === '"') {
+        out += next;
+        i++;
+        continue;
+      }
+    }
+    out += c;
+  }
+  return out;
+}
+
+/**
+ * Coerce a raw frontmatter `projectId` to a trimmed string, or `undefined`
+ * when absent/blank. Obsidian's YAML parser turns an unquoted numeric id into a
+ * number, so accept that too.
+ */
+export function coerceProjectId(value: unknown): string | undefined {
+  if (typeof value === "string") return value.trim() || undefined;
+  if (typeof value === "number") return String(value);
+  return undefined;
+}

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -152,7 +152,7 @@ export interface BackendDescriptor {
    *
    * When false (codex, Claude Code), the backend has no usable title source:
    * codex names a session after the raw first prompt, leaking the injected
-   * `<attached_context>` envelope, and the Claude SDK exposes no title API. For
+   * `<copilot-context>` envelope, and the Claude SDK exposes no title API. For
    * these the session derives the tab title client-side from the user's first
    * visible message and ignores any backend-provided title.
    *

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -152,7 +152,7 @@ export interface BackendDescriptor {
    *
    * When false (codex, Claude Code), the backend has no usable title source:
    * codex names a session after the raw first prompt, leaking the injected
-   * `<copilot-context>` envelope, and the Claude SDK exposes no title API. For
+   * `<attached_context>` envelope, and the Claude SDK exposes no title API. For
    * these the session derives the tab title client-side from the user's first
    * visible message and ignores any backend-provided title.
    *

--- a/src/agentMode/session/scope.ts
+++ b/src/agentMode/session/scope.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared scope identity for Agent Mode sessions and persisted chats.
+ *
+ * A session/chat is either bound to a real project (its `projectId`) or to the
+ * implicit global workspace. The sentinel below is the authoritative key for
+ * that global bucket so every layer (session manager, persistence, history)
+ * agrees on one value instead of juggling `undefined` vs empty string.
+ */
+/**
+ * DESIGN NOTE — `__global__` sentinel vs a hand-edited project id (deferred).
+ *
+ * (a) Trigger: a project's `AGENTS.md`/`project.md` frontmatter `id` is manually
+ *     edited (or corrupted by a sync conflict) to the literal string
+ *     `"__global__"`. Normal project ids are UUIDs minted by AddProjectModal, so
+ *     this is only reachable by hand-editing frontmatter, not through the UI.
+ * (b) Impact: that project collides with the global sentinel and is treated as
+ *     global — its session cwd falls back to the vault root, `enterProject`
+ *     validation is skipped, and saved chats write no `projectId` frontmatter.
+ * (c) Why it's not fixed here: the correct guard is a reserved-id check at
+ *     project creation/parse time (`createProject` / `parseProjectConfigFile`).
+ *     Enforcing it from this module would force `projects/` to reverse-import a
+ *     `session/` sentinel — a layering inversion not worth paying. Reserved-id
+ *     validation belongs in the project domain, where this guard should live.
+ * (d) If a future review flags this again, point them at this note.
+ */
+export const GLOBAL_SCOPE = "__global__" as const;
+
+/** A real project id, or {@link GLOBAL_SCOPE} for the global workspace. */
+export type ProjectScopeId = string;

--- a/src/agentMode/session/scope.ts
+++ b/src/agentMode/session/scope.ts
@@ -21,7 +21,6 @@
  *     Enforcing it from this module would force `projects/` to reverse-import a
  *     `session/` sentinel — a layering inversion not worth paying. Reserved-id
  *     validation belongs in the project domain, where this guard should live.
- * (d) If a future review flags this again, point them at this note.
  */
 export const GLOBAL_SCOPE = "__global__" as const;
 

--- a/src/agentMode/session/sessionScope.ts
+++ b/src/agentMode/session/sessionScope.ts
@@ -1,0 +1,79 @@
+import { dirname, join } from "node:path";
+import { getCachedProjectRecordById, getCachedProjectRecords } from "@/projects/state";
+import { GLOBAL_SCOPE, type ProjectScopeId } from "@/agentMode/session/scope";
+
+/**
+ * Raised when a project-scoped session points at a project whose registry
+ * record is gone (the project folder/config was deleted out from under it).
+ * Callers turn this into an "orphaned" experience (Notice + blocked send)
+ * instead of silently re-homing the session to the vault root.
+ */
+export class OrphanedProjectError extends Error {
+  constructor(readonly projectId: ProjectScopeId) {
+    super(`Project "${projectId}" is no longer available.`);
+    this.name = "OrphanedProjectError";
+  }
+}
+
+/**
+ * Absolute working directory for a session bound to `projectId`.
+ * - {@link GLOBAL_SCOPE} → the vault root.
+ * - a real project → that project's folder (the parent dir of its config file).
+ *
+ * A missing record is treated as orphaned and throws: never downgrade to the
+ * vault root, which would silently widen a "project" session to the whole vault.
+ */
+export function resolveScopeCwd(vaultBasePath: string, projectId: ProjectScopeId): string {
+  if (projectId === GLOBAL_SCOPE) return vaultBasePath;
+  const record = getCachedProjectRecordById(projectId);
+  if (!record) throw new OrphanedProjectError(projectId);
+  // Reason: project folders live at `dirname(config)`; a config sitting at the
+  // vault root yields ".", which join() collapses back to the vault root.
+  return join(vaultBasePath, dirname(record.filePath));
+}
+
+/** Whether `projectId` still resolves to a live scope (global is always live). */
+export function isLiveScope(projectId: ProjectScopeId): boolean {
+  return projectId === GLOBAL_SCOPE || getCachedProjectRecordById(projectId) !== undefined;
+}
+
+/**
+ * Reverse of {@link resolveScopeCwd}: attribute a working directory reported by
+ * a backend's native `listSessions` to the project whose folder it is. Lets the
+ * session-index sweep scope sessions started OUTSIDE the plugin (e.g. a CLI run
+ * inside a materialized project folder). Returns undefined for the vault root
+ * and for any path that matches no known project folder — exact folder match
+ * only, deliberately not "inside a project folder", mirroring the sweep's
+ * exact-cwd vault filter.
+ */
+export function resolveProjectIdForCwd(vaultBasePath: string, cwd: string): string | undefined {
+  const norm = (p: string) => p.replace(/[/\\]+$/, "");
+  const target = norm(cwd);
+  if (target === norm(vaultBasePath)) return undefined;
+  for (const record of getCachedProjectRecords()) {
+    if (target === norm(join(vaultBasePath, dirname(record.filePath)))) {
+      return record.project.id;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Pick the session that becomes active after closing one inside a scope, never
+ * leaving the scope: most-recently-used (if still alive) → the slot the closed
+ * session occupied (right neighbour, clamped to the new last) → `null` when the
+ * scope is now empty.
+ *
+ * @param scopeIdsAfterClose session ids remaining in the scope, in tab order.
+ * @param closedIdx index the closed session held within the scope before removal.
+ * @param mruCandidate the scope's recorded MRU id, if any.
+ */
+export function pickScopeNeighbor(
+  scopeIdsAfterClose: readonly string[],
+  closedIdx: number,
+  mruCandidate: string | undefined
+): string | null {
+  if (mruCandidate && scopeIdsAfterClose.includes(mruCandidate)) return mruCandidate;
+  if (scopeIdsAfterClose.length === 0) return null;
+  return scopeIdsAfterClose[Math.min(closedIdx, scopeIdsAfterClose.length - 1)];
+}

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -2,6 +2,7 @@ import type React from "react";
 import type { FormattedDateTime, MessageContext } from "@/types/message";
 // `import type` keeps the cycle with `fanoutTypes` compile-time only.
 import type { FanoutTurn } from "@/agentMode/session/fanout/fanoutTypes";
+import type { ProjectScopeId } from "./scope";
 
 export type {
   BackendAuth,
@@ -393,6 +394,16 @@ export interface AgentPlanEntry {
 }
 
 /**
+ * One entry of the session's live execution todo list — the consumer-facing
+ * projection of `plan` updates (priority dropped; no surface renders it).
+ * Read via `AgentChatBackend.getCurrentTodoList()`.
+ */
+export interface AgentTodoListEntry {
+  content: string;
+  status: AgentPlanEntry["status"];
+}
+
+/**
  * Initial / updated state for an in-flight tool call. Mirrors ACP `ToolCall`
  * (initial form) — emitted by backends in the `tool_call` `SessionUpdate`.
  */
@@ -588,11 +599,41 @@ export type McpServerSpec =
       headers: Array<{ name: string; value: string }>;
     };
 
+// ---- Project scope ------------------------------------------------------
+
+/**
+ * Minimal per-session view of a project's instruction payload. Deliberately
+ * decoupled from `aiParams.ProjectConfig` (which still carries legacy CAG
+ * fields like `projectModelKey`): a backend that injects project instructions
+ * needs only the scope id and the already-parsed, frontmatter-stripped system
+ * prompt. The manager maps `ProjectConfig → ProjectProfile` so `backends/`
+ * never imports the `projects/` layer.
+ */
+export interface ProjectProfile {
+  id: string;
+  systemPrompt: string;
+}
+
 // ---- Session-creation I/O shapes ---------------------------------------
 
 export interface OpenSessionInput {
   cwd: string;
   mcpServers: McpServerSpec[];
+  /**
+   * Scope this session belongs to ({@link ProjectScopeId}); captured like
+   * `cwd` so the backend can resolve the owning project's instructions.
+   * Absent / `GLOBAL_SCOPE` means the implicit global workspace.
+   */
+  projectId?: ProjectScopeId;
+  /**
+   * Absolute paths to widen the agent's searchable roots beyond `cwd` (the
+   * project's materialized context directories). Forwarded on every
+   * session-lifecycle request (new / resume / load) — resume and load
+   * re-establish the complete root list — and only by backends that report
+   * {@link BackendProcess.supportsAdditionalDirectories}. Absent / empty means
+   * no extra roots.
+   */
+  additionalDirectories?: string[];
 }
 
 export interface OpenSessionOutput {
@@ -604,6 +645,10 @@ export interface ResumeSessionInput {
   sessionId: SessionId;
   cwd: string;
   mcpServers: McpServerSpec[];
+  /** Scope this session belongs to. See {@link OpenSessionInput.projectId}. */
+  projectId?: ProjectScopeId;
+  /** Extra searchable roots. See {@link OpenSessionInput.additionalDirectories}. */
+  additionalDirectories?: string[];
 }
 
 export type ResumeSessionOutput = OpenSessionOutput;
@@ -612,6 +657,10 @@ export interface LoadSessionInput {
   sessionId: SessionId;
   cwd: string;
   mcpServers: McpServerSpec[];
+  /** Scope this session belongs to. See {@link OpenSessionInput.projectId}. */
+  projectId?: ProjectScopeId;
+  /** Extra searchable roots. See {@link OpenSessionInput.additionalDirectories}. */
+  additionalDirectories?: string[];
 }
 
 export type LoadSessionOutput = OpenSessionOutput;
@@ -685,6 +734,16 @@ export interface BackendProcess {
    * sessions; ACP backends governed by the shared prompter omit it.
    */
   setReadOnlySessionPredicate?(fn: (sessionId: SessionId) => boolean): void;
+  /**
+   * Optional: register the resolver a backend calls to look up a session's
+   * project instructions by scope id. Mirrors the prompter setters; the
+   * manager supplies a resolver that maps the cached project record to a
+   * minimal {@link ProjectProfile}. Returns `undefined` for `GLOBAL_SCOPE`
+   * or an unknown project. Only backends that inject project instructions
+   * implement it (Claude SDK in PR2b-1); codex/opencode discover AGENTS.md
+   * from the session cwd and omit it.
+   */
+  setProjectProfileProvider?(fn: (projectId: ProjectScopeId) => ProjectProfile | undefined): void;
   registerSessionHandler(sessionId: SessionId, handler: SessionUpdateHandler): () => void;
   newSession(params: OpenSessionInput): Promise<OpenSessionOutput>;
   prompt(params: PromptInput): Promise<PromptOutput>;
@@ -730,6 +789,16 @@ export interface BackendProcess {
    * Claude SDK adapter accepts http/sse natively.
    */
   supportsMcpTransport(transport: "http" | "sse"): boolean;
+  /**
+   * Whether the backend honors {@link OpenSessionInput.additionalDirectories}
+   * (widening the agent's searchable roots on every session-lifecycle request:
+   * new / resume / load). Optional like the
+   * other incrementally-added capability hooks (`setProjectProfileProvider`):
+   * the manager always forwards `additionalDirectories` and each backend gates
+   * internally on this before passing them to its wire/SDK. Backends that
+   * cannot widen roots omit it or return `false`.
+   */
+  supportsAdditionalDirectories?(): boolean;
   shutdown(): Promise<void>;
 }
 

--- a/src/agentMode/ui/AgentChatInput.test.tsx
+++ b/src/agentMode/ui/AgentChatInput.test.tsx
@@ -86,6 +86,7 @@ const makeDraft = (overrides: Partial<AgentInputDraftControls> = {}): AgentInput
   setIncludeActiveWebTab: jest.fn(),
   setLoading: jest.fn(),
   setQueue: jest.fn(),
+  migrateDraft: jest.fn(),
   resetCompose: jest.fn(),
   ...overrides,
 });

--- a/src/agentMode/ui/AgentChatInput.test.tsx
+++ b/src/agentMode/ui/AgentChatInput.test.tsx
@@ -1,12 +1,19 @@
 import { EMPTY_AGENT_MENTION_BRANDS } from "@/components/chat-components/hooks/useAtMentionCategories";
-import { render } from "@testing-library/react";
+import { AgentChatInput } from "@/agentMode/ui/AgentChatInput";
+import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
+import type { AgentInputDraftControls } from "@/agentMode/ui/hooks/useAgentInputDrafts";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { App } from "obsidian";
 import React from "react";
+
+// Mock factory names must match the real `use*` exports, so the no-hook `use`
+// prefix is expected on the mocked hooks below.
+/* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 
 // Entitlement gate — flipped per test.
 const mockUseCanUseMultiAgent = jest.fn<boolean, []>();
 const mockNavigateToPlusPage = jest.fn();
 jest.mock("@/plusUtils", () => ({
-  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real `useCanUseMultiAgent` hook; the name must match the export
   useCanUseMultiAgent: () => mockUseCanUseMultiAgent(),
   navigateToPlusPage: (...args: unknown[]) => mockNavigateToPlusPage(...args),
 }));
@@ -20,74 +27,93 @@ jest.mock("@/agentMode/ui/mentionedAgents", () => ({
   listInstalledAgentBrands: () => FAKE_BRANDS,
 }));
 
-// Capture the brands handed to the editor without rendering the heavy
-// Lexical-backed composer.
+// One ChatInput mock serves both suites: it captures the brands handed to the
+// editor (agent-mention gate) AND renders a clickable send button that routes
+// through `handleSendMessage` — the same entry the real Lexical editor's Enter
+// key hits (send-flow regression tests).
 let capturedAgentBrands: ReadonlyArray<unknown> | undefined;
 jest.mock("@/components/chat-components/ChatInput", () => ({
   __esModule: true,
-  default: (props: { agentBrands?: ReadonlyArray<unknown> }) => {
+  default: (props: {
+    agentBrands?: ReadonlyArray<unknown>;
+    handleSendMessage?: () => void;
+  }) => {
     capturedAgentBrands = props.agentBrands;
-    return null;
+    return (
+      <button type="button" onClick={() => props.handleSendMessage?.()}>
+        send
+      </button>
+    );
   },
 }));
 
-// Trim incidental module-level dependencies the composer pulls in.
 jest.mock("@/components/chat-components/hooks/useActiveWebTabState", () => ({
-  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real `useActiveWebTabState` hook; the name must match the export
   useActiveWebTabState: () => ({ activeWebTabForMentions: undefined }),
 }));
 jest.mock("@/aiParams", () => ({
   clearSelectedTextContexts: jest.fn(),
   removeSelectedTextContext: jest.fn(),
-  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real `useSelectedTextContexts` hook; the name must match the export
   useSelectedTextContexts: () => [[], jest.fn()],
 }));
 jest.mock("@/settings/model", () => ({
-  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real `useSettingsValue` hook; the name must match the export
   useSettingsValue: () => ({}),
 }));
+/* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
+
 jest.mock("@/commands/customCommandManager", () => ({
   CustomCommandManager: { getInstance: () => ({ recordUsage: jest.fn() }) },
 }));
 jest.mock("@/commands/state", () => ({ getCachedCustomCommands: () => [] }));
+jest.mock("@/agentMode/session/expandCustomCommandPrefix", () => ({
+  expandCustomCommandPrefix: async (text: string) => ({ text }),
+}));
+jest.mock("@/services/webViewerService/activeWebTabSnapshot", () => ({
+  buildWebTabsWithActiveSnapshot: () => [],
+}));
 
-import { AgentChatInput } from "@/agentMode/ui/AgentChatInput";
+const makeApp = (): App => ({ workspace: { getActiveFile: () => null } }) as unknown as App;
 
-function renderComposer() {
-  const draft = {
-    input: "",
-    images: [],
-    contextNotes: [],
-    includeActiveNote: false,
-    includeActiveWebTab: false,
-    loading: false,
-    queue: [],
-    setInput: jest.fn(),
-    setContextNotes: jest.fn(),
-    setSelectedImages: jest.fn(),
-    addImages: jest.fn(),
-    setIncludeActiveNote: jest.fn(),
-    setIncludeActiveWebTab: jest.fn(),
-    setLoading: jest.fn(),
-    setQueue: jest.fn(),
-    resetCompose: jest.fn(),
-  };
-  const app = { workspace: { getActiveFile: () => null } };
-  const props = {
-    backend: { sendMessage: jest.fn(), cancel: jest.fn() },
-    sessionId: "s1",
-    draft,
-    app,
-    mainAgentId: null,
-    updateUserMessageHistory: jest.fn(),
-    isStarting: false,
-    hasPendingPlanPermission: false,
-    modelPickerOverride: null,
-    modePickerOverride: null,
-    onCycleMode: jest.fn(),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any;
-  render(<AgentChatInput {...props} />);
+const makeDraft = (overrides: Partial<AgentInputDraftControls> = {}): AgentInputDraftControls => ({
+  input: "hello",
+  images: [],
+  contextNotes: [],
+  includeActiveNote: false,
+  includeActiveWebTab: false,
+  loading: false,
+  queue: [],
+  setInput: jest.fn(),
+  setContextNotes: jest.fn(),
+  setSelectedImages: jest.fn(),
+  addImages: jest.fn(),
+  setIncludeActiveNote: jest.fn(),
+  setIncludeActiveWebTab: jest.fn(),
+  setLoading: jest.fn(),
+  setQueue: jest.fn(),
+  resetCompose: jest.fn(),
+  ...overrides,
+});
+
+function renderInput(
+  backend: AgentChatBackend,
+  draft: AgentInputDraftControls,
+  extraProps: Partial<React.ComponentProps<typeof AgentChatInput>> = {}
+) {
+  return render(
+    <AgentChatInput
+      backend={backend}
+      sessionId="session-1"
+      draft={draft}
+      app={makeApp()}
+      mainAgentId={null}
+      updateUserMessageHistory={jest.fn()}
+      isStarting={false}
+      hasPendingPlanPermission={false}
+      modelPickerOverride={undefined}
+      modePickerOverride={undefined}
+      onCycleMode={jest.fn()}
+      {...extraProps}
+    />
+  );
 }
 
 describe("AgentChatInput agent-mention gate", () => {
@@ -98,13 +124,70 @@ describe("AgentChatInput agent-mention gate", () => {
 
   it("passes the real installed-agent list when entitled", () => {
     mockUseCanUseMultiAgent.mockReturnValue(true);
-    renderComposer();
+    renderInput({ sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend, makeDraft());
     expect(capturedAgentBrands).toBe(FAKE_BRANDS);
   });
 
   it("passes the frozen empty list (not a fresh []) when not entitled", () => {
     mockUseCanUseMultiAgent.mockReturnValue(false);
-    renderComposer();
+    renderInput({ sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend, makeDraft());
     expect(capturedAgentBrands).toBe(EMPTY_AGENT_MENTION_BRANDS);
+  });
+});
+
+describe("AgentChatInput turn-completion loading reset", () => {
+  it("regression: clears draft.loading when the turn resolves after the composer unmounted", async () => {
+    // First send from a landing: the user message lands, AgentHome flips
+    // landing→conversation, and the composer remounts mid-turn. The unmounting
+    // instance's runSend must still clear the shared draft's loading flag,
+    // or the Thinking spinner / stop button stick forever (#stuck-thinking).
+    let resolveTurn!: () => void;
+    const turn = new Promise<void>((resolve) => {
+      resolveTurn = resolve;
+    });
+    const backend = {
+      sendMessage: jest.fn(() => ({ turn })),
+      cancel: jest.fn(),
+    } as unknown as AgentChatBackend;
+    const draft = makeDraft();
+
+    const { unmount } = renderInput(backend, draft);
+    fireEvent.click(screen.getByText("send"));
+
+    await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(true));
+    expect(backend.sendMessage).toHaveBeenCalledTimes(1);
+
+    // The landing→conversation flip unmounts this composer instance while the
+    // turn is still in flight.
+    unmount();
+
+    await act(async () => {
+      resolveTurn();
+      await turn;
+    });
+
+    await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(false));
+  });
+});
+
+describe("AgentChatInput hard-disable", () => {
+  it("drops a send when the composer is disabled (orphaned project)", async () => {
+    // The mocked ChatInput's send button routes through handleSendMessage — the
+    // same entry the real Lexical editor's Enter key hits. A hard-disabled
+    // composer only dims + blocks pointer events in the DOM, so this keyboard
+    // path must be gated in the handler or a turn leaks into a dead project.
+    const backend = {
+      sendMessage: jest.fn(() => ({ turn: Promise.resolve() })),
+      cancel: jest.fn(),
+    } as unknown as AgentChatBackend;
+    const draft = makeDraft();
+
+    renderInput(backend, draft, { disabled: true });
+    fireEvent.click(screen.getByText("send"));
+    await act(async () => {});
+
+    expect(backend.sendMessage).not.toHaveBeenCalled();
+    expect(draft.setLoading).not.toHaveBeenCalledWith(true);
+    expect(draft.resetCompose).not.toHaveBeenCalled();
   });
 });

--- a/src/agentMode/ui/AgentChatInput.test.tsx
+++ b/src/agentMode/ui/AgentChatInput.test.tsx
@@ -34,10 +34,7 @@ jest.mock("@/agentMode/ui/mentionedAgents", () => ({
 let capturedAgentBrands: ReadonlyArray<unknown> | undefined;
 jest.mock("@/components/chat-components/ChatInput", () => ({
   __esModule: true,
-  default: (props: {
-    agentBrands?: ReadonlyArray<unknown>;
-    handleSendMessage?: () => void;
-  }) => {
+  default: (props: { agentBrands?: ReadonlyArray<unknown>; handleSendMessage?: () => void }) => {
     capturedAgentBrands = props.agentBrands;
     return (
       <button type="button" onClick={() => props.handleSendMessage?.()}>
@@ -124,13 +121,19 @@ describe("AgentChatInput agent-mention gate", () => {
 
   it("passes the real installed-agent list when entitled", () => {
     mockUseCanUseMultiAgent.mockReturnValue(true);
-    renderInput({ sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend, makeDraft());
+    renderInput(
+      { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend,
+      makeDraft()
+    );
     expect(capturedAgentBrands).toBe(FAKE_BRANDS);
   });
 
   it("passes the frozen empty list (not a fresh []) when not entitled", () => {
     mockUseCanUseMultiAgent.mockReturnValue(false);
-    renderInput({ sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend, makeDraft());
+    renderInput(
+      { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend,
+      makeDraft()
+    );
     expect(capturedAgentBrands).toBe(EMPTY_AGENT_MENTION_BRANDS);
   });
 });

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -1,4 +1,5 @@
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
+import { GLOBAL_SCOPE } from "@/agentMode/session/scope";
 import { expandCustomCommandPrefix } from "@/agentMode/session/expandCustomCommandPrefix";
 import { resolveActiveNoteToken } from "@/agentMode/session/resolveActiveNoteToken";
 import type { PromptContent } from "@/agentMode/session/types";
@@ -66,6 +67,26 @@ interface AgentChatInputProps {
   modelPickerOverride: ChatInputProps["modelPickerOverride"];
   modePickerOverride: ChatInputProps["modePickerOverride"];
   onCycleMode: () => void;
+  /**
+   * Active scope ({@link GLOBAL_SCOPE} or a project id). Gates the
+   * context-load hold below to real projects; `GLOBAL_SCOPE` never holds.
+   */
+  activeProjectId?: string;
+  /**
+   * The active project's context is still materializing (read by the parent from
+   * `agentProjectContextLoadAtom[projectId].blocking`). Send stays clickable but
+   * **queues** instead of firing, then auto-flushes when the load clears —
+   * queue-and-hold, never a hard-disabled button.
+   */
+  contextLoadBlocking?: boolean;
+  /**
+   * Hard-disable the whole composer (pointer-events + dim), e.g. the active
+   * project was deleted out from under the user. Distinct from
+   * {@link contextLoadBlocking}, which only defers sends.
+   */
+  disabled?: boolean;
+  /** Agent project-context status icon, rendered in the composer's badge row. */
+  contextStatusIndicator?: React.ReactNode;
 }
 
 // Stable no-op handlers for ChatInput props that don't apply to Agent Mode
@@ -160,9 +181,18 @@ export const AgentChatInput = memo(function AgentChatInput({
   modelPickerOverride,
   modePickerOverride,
   onCycleMode,
+  activeProjectId,
+  contextLoadBlocking = false,
+  disabled = false,
+  contextStatusIndicator,
 }: AgentChatInputProps) {
   const eventTarget = useContext(EventTargetContext);
   const settings = useSettingsValue();
+
+  // Hold sends only while a *real* project's context is materializing. Global
+  // scope never holds, so the global landing's send path is byte-identical.
+  const holdForContext =
+    contextLoadBlocking && !!activeProjectId && activeProjectId !== GLOBAL_SCOPE;
   const [selectedTextContexts] = useSelectedTextContexts();
   // SSoT for the Active Web Tab; `activeWebTabForMentions` matches the send
   // snapshot (preserved only when focusing the chat panel). Drives the
@@ -170,7 +200,6 @@ export const AgentChatInput = memo(function AgentChatInput({
   // webTabs at send time below.
   const { activeWebTabForMentions } = useActiveWebTabState();
 
-  const isMountedRef = useRef(false);
   const previousSessionIdRef = useRef(sessionId);
 
   // The `@agent` typeahead group + pills are paid-only. Reactive so a settings
@@ -216,13 +245,6 @@ export const AgentChatInput = memo(function AgentChatInput({
     resetCompose,
   } = draft;
 
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
-
   // Clear cross-session ephemeral state on a session switch: the global
   // selected-text atom and the mentioned-agent ref (neither is reset by the
   // editor remount), so a selection or `@agent` pill can't ride into the next session.
@@ -242,7 +264,7 @@ export const AgentChatInput = memo(function AgentChatInput({
     // Stop = user is bailing on the current turn; don't auto-flush queued
     // follow-ups they composed while the agent was running.
     setQueuedMessages([]);
-    if (isMountedRef.current) setLoading(false);
+    setLoading(false);
   }, [backend, setLoading, setQueuedMessages]);
 
   const runSend = useCallback(
@@ -261,7 +283,14 @@ export const AgentChatInput = memo(function AgentChatInput({
         logError("Error sending agent message:", error);
         new Notice("Failed to send message. Please try again.");
       } finally {
-        if (isMountedRef.current) setLoading(false);
+        // No mounted guard here: this composer remounts on the
+        // landing→conversation flip (AgentHome renders it at different tree
+        // positions), which happens DURING the first turn of every session —
+        // the unmounting instance must still clear the in-flight flag.
+        // `setLoading` writes AgentHome's per-session draft store (not local
+        // state), so calling it after unmount is safe, and the store itself
+        // drops updates for sessions that are no longer live.
+        setLoading(false);
       }
     },
     [backend, setLoading, updateUserMessageHistory]
@@ -269,6 +298,10 @@ export const AgentChatInput = memo(function AgentChatInput({
 
   const handleSendMessage = useCallback(
     async (webTabs?: WebTabContext[]) => {
+      // A hard-disabled composer (e.g. an orphaned project) must not send. The
+      // wrapper only blocks pointer events + dims, so a focused editor could
+      // otherwise submit a turn via the keyboard; bail before any prep work.
+      if (disabled) return;
       const text = inputMessage.trim();
       if (!text) return;
       const rawInput = inputMessage;
@@ -351,7 +384,10 @@ export const AgentChatInput = memo(function AgentChatInput({
       // again, point them here.
       clearSelectedTextContexts();
 
-      if (loading || isStarting) {
+      // Queue-and-hold: while a turn is in flight, starting, or the project's
+      // context is still materializing, park the message instead of sending.
+      // The flush effect below drains it once all three clear.
+      if (loading || isStarting || holdForContext) {
         setQueuedMessages((q) => [...q, item]);
         return;
       }
@@ -368,6 +404,8 @@ export const AgentChatInput = memo(function AgentChatInput({
       selectedTextContexts,
       loading,
       isStarting,
+      holdForContext,
+      disabled,
       resetCompose,
       runSend,
       setQueuedMessages,
@@ -397,11 +435,14 @@ export const AgentChatInput = memo(function AgentChatInput({
   // deferred to PR2; PR1 keeps execution in the foreground composer. If a
   // future review flags this again, point them at this note.
   useEffect(() => {
-    if (loading || isStarting || queuedMessages.length === 0) return;
+    // `disabled` guards the same hard-disable as the send path: a project
+    // orphaned while messages are queued must not drain its queue into a
+    // disabled composer.
+    if (disabled || loading || isStarting || holdForContext || queuedMessages.length === 0) return;
     const combined = combineQueuedMessages(queuedMessages);
     setQueuedMessages([]);
     void runSend(combined);
-  }, [loading, isStarting, queuedMessages, runSend, setQueuedMessages]);
+  }, [disabled, loading, isStarting, holdForContext, queuedMessages, runSend, setQueuedMessages]);
 
   const handleRemoveQueuedMessage = useCallback(
     (id: string) => {
@@ -429,8 +470,10 @@ export const AgentChatInput = memo(function AgentChatInput({
       )}
       {!canUseMultiAgent && <MultiAgentUpsellHint />}
       <div
-        className={hasPendingPlanPermission ? "tw-pointer-events-none tw-opacity-50" : undefined}
-        aria-disabled={hasPendingPlanPermission || undefined}
+        className={
+          hasPendingPlanPermission || disabled ? "tw-pointer-events-none tw-opacity-50" : undefined
+        }
+        aria-disabled={hasPendingPlanPermission || disabled || undefined}
       >
         {/* Key by session so ChatInput remounts on a tab/session switch. The
             per-session draft store (input/images/contextNotes/include flags)
@@ -472,6 +515,7 @@ export const AgentChatInput = memo(function AgentChatInput({
           onMentionedAgentsChange={handleMentionedAgentsChange}
           showProgressCard={NOOP}
           showIndexingCard={NOOP}
+          contextStatusIndicator={contextStatusIndicator}
         />
       </div>
     </>

--- a/src/agentMode/ui/AgentContextSection.test.tsx
+++ b/src/agentMode/ui/AgentContextSection.test.tsx
@@ -1,0 +1,119 @@
+// Mock the Manage modal so its transitive Obsidian-subclass imports
+// (FuzzySuggestModal, absent from the obsidian mock) don't crash module load.
+jest.mock("@/components/modals/project/context-manage-modal", () => ({
+  ContextManageModal: jest.fn().mockImplementation(() => ({ open: jest.fn() })),
+}));
+
+import AgentContextSection, { buildContextSummary } from "@/agentMode/ui/AgentContextSection";
+import type { ProjectConfig } from "@/aiParams";
+import { updateCachedProjectRecords } from "@/projects/state";
+import { createPatternSettingsValue } from "@/search/searchUtils";
+import { render, screen } from "@testing-library/react";
+import { App } from "obsidian";
+import React from "react";
+
+beforeAll(() => {
+  // Obsidian exposes `activeDocument` as a global; jsdom doesn't. The reused
+  // ProjectContextBadgeList → TruncatedText tooltip reads it on render.
+  window.activeDocument = window.document;
+});
+
+function makeProject(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    id: "p1",
+    name: "Halcyon Scope",
+    systemPrompt: "",
+    projectModelKey: "",
+    modelConfigs: {},
+    contextSource: {},
+    created: 0,
+    UsageTimestamps: 0,
+    ...overrides,
+  };
+}
+
+describe("buildContextSummary", () => {
+  it("returns an empty summary for an undefined project", () => {
+    const summary = buildContextSummary(undefined);
+    expect(summary.isEmpty).toBe(true);
+    expect(summary.totalItems).toBe(0);
+    expect(summary.urls).toBe(0);
+  });
+
+  it("returns an empty summary when the project has no context sources", () => {
+    expect(buildContextSummary(makeProject()).isEmpty).toBe(true);
+  });
+
+  it("counts inclusion badges by type + URLs", () => {
+    const inclusions = createPatternSettingsValue({
+      folderPatterns: ["notes/research"],
+      notePatterns: ["[[Intro]]"],
+      tagPatterns: ["#ml"],
+    });
+    const project = makeProject({
+      contextSource: {
+        inclusions,
+        webUrls: "https://arxiv.org/abs/2403",
+        youtubeUrls: "https://youtu.be/xyz",
+      },
+    });
+
+    const summary = buildContextSummary(project);
+    expect(summary.isEmpty).toBe(false);
+    expect(summary.totalItems).toBe(5);
+    // Counted with the same parsers the reused badge list renders with: a note
+    // pattern surfaces as a "file", plus the folder, the tag, and 2 URLs.
+    expect(summary.files).toBe(1);
+    expect(summary.folders).toBe(1);
+    expect(summary.tags).toBe(1);
+    expect(summary.urls).toBe(2);
+  });
+});
+
+describe("AgentContextSection", () => {
+  const app = {} as App;
+
+  it("renders nothing for an unknown (orphaned) project", () => {
+    updateCachedProjectRecords([]);
+    const { container } = render(<AgentContextSection app={app} projectId="missing" />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the drop hint + Manage with no header when context is empty", () => {
+    updateCachedProjectRecords([
+      { project: makeProject(), filePath: "Halcyon Scope/project.md", folderName: "Halcyon Scope" },
+    ]);
+
+    render(<AgentContextSection app={app} projectId="p1" />);
+
+    // The body is headerless (the placement — standalone or tab — supplies the
+    // header); it leads with the drop target and pins Manage in the footer. The
+    // empty state shows the drop hint both centered and in the persistent footer.
+    expect(screen.getAllByText("Drag files / folders here").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /Manage/ })).toBeTruthy();
+    expect(screen.queryByLabelText(/context/i)).toBeNull();
+  });
+
+  it("shows the badges + the combined drop box directly when populated", () => {
+    const inclusions = createPatternSettingsValue({
+      folderPatterns: ["notes/research"],
+      notePatterns: ["[[Intro]]"],
+    });
+    updateCachedProjectRecords([
+      {
+        project: makeProject({ contextSource: { inclusions } }),
+        filePath: "Halcyon Scope/project.md",
+        folderName: "Halcyon Scope",
+      },
+    ]);
+
+    render(<AgentContextSection app={app} projectId="p1" />);
+
+    // No collapse step anymore — the reused ProjectContextBadgeList renders the
+    // raw inclusion patterns immediately.
+    expect(screen.getByText(/notes\/research/)).toBeTruthy();
+    expect(screen.getByText(/Intro/)).toBeTruthy();
+    // The chips box doubles as the drop target — its hint row is persistent.
+    expect(screen.getByText("Drag files / folders here")).toBeTruthy();
+  });
+});

--- a/src/agentMode/ui/AgentContextSection.tsx
+++ b/src/agentMode/ui/AgentContextSection.tsx
@@ -1,0 +1,197 @@
+import { SHELF_BODY_FLOOR_CLASS } from "@/agentMode/ui/AgentHomeShelf";
+import type { ProjectConfig } from "@/aiParams";
+import { ContextManageModal } from "@/components/modals/project/context-manage-modal";
+import { buildBadgeItems } from "@/components/project/ProjectContextBadgeList";
+import { ProjectContextSourceEditor } from "@/components/project/ProjectContextSourceEditor";
+import { cn } from "@/lib/utils";
+import { logWarn } from "@/logger";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { getCachedProjectRecordById, useProjects } from "@/projects/state";
+import { parseProjectUrls } from "@/utils/urlTagUtils";
+import { App } from "obsidian";
+import * as React from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePersistentContextDrop } from "./hooks/usePersistentContextDrop";
+
+type ContextSource = NonNullable<ProjectConfig["contextSource"]>;
+
+interface AgentContextSectionProps {
+  app: App;
+  /** Project whose context (inclusions/URLs) this section summarizes + edits. */
+  projectId: string;
+  /** Portal target for the editor's +URL popover — the AgentHome root, so it
+   * resolves to the correct document in popout windows. */
+  popoverContainer?: HTMLElement | null;
+}
+
+interface ContextSummary {
+  totalItems: number;
+  isEmpty: boolean;
+  /** Per-type counts, matching the badge list's categorizer + the URL parser. */
+  files: number;
+  folders: number;
+  tags: number;
+  extensions: number;
+  urls: number;
+}
+
+const EMPTY_SUMMARY: ContextSummary = Object.freeze({
+  totalItems: 0,
+  isEmpty: true,
+  files: 0,
+  folders: 0,
+  tags: 0,
+  extensions: 0,
+  urls: 0,
+});
+
+/**
+ * Summarize a project's context for the section header + breakdown line. Counts
+ * inclusions via {@link buildBadgeItems} and URLs via {@link parseProjectUrls} —
+ * the SAME parsers the reused editor renders with — so the counts match the
+ * expanded editor exactly. Pure / testable.
+ */
+export function buildContextSummary(project: ProjectConfig | undefined): ContextSummary {
+  if (!project) return EMPTY_SUMMARY;
+
+  const badgeItems = buildBadgeItems(project.contextSource?.inclusions);
+  const counts = { files: 0, folders: 0, tags: 0, extensions: 0 };
+  for (const item of badgeItems) {
+    if (item.type === "note") counts.files++;
+    else if (item.type === "folder") counts.folders++;
+    else if (item.type === "tag") counts.tags++;
+    else counts.extensions++;
+  }
+
+  const urls = parseProjectUrls(
+    project.contextSource?.webUrls ?? "",
+    project.contextSource?.youtubeUrls ?? ""
+  ).length;
+
+  const totalItems = badgeItems.length + urls;
+  if (totalItems === 0) return EMPTY_SUMMARY;
+
+  return { totalItems, isEmpty: false, ...counts, urls };
+}
+
+/**
+ * The project Context body on the agent landing — a single
+ * {@link ProjectContextSourceEditor} (mixed file + URL chips, +URL, Manage)
+ * wired to immediate persistence. Edits/drops apply to NEW chats.
+ *
+ * Persistence is optimistic + serialized to fix the prior drop-write race:
+ * `onChange` updates a local `draft` (so the chip vanishes instantly) and queues
+ * a patch; a single in-flight `updateProject` drains the queue, each write
+ * rebased on the freshest persisted config (`getCachedProjectRecordById`) so
+ * rapid successive removals compose instead of clobbering each other. External
+ * record changes are adopted into the draft only while no write is pending.
+ *
+ * The root keeps the drop ref, the `data-copilot-drop-zone` marker, AND the
+ * height floor on the SAME element: that marker tells the chat container's
+ * draft-attach handler (useChatFileDrop) to yield while a drag hovers this body,
+ * so a taller wrapper would leave a dead strip where drops fall through to the
+ * draft. The floor is the shelf panel's SHELF_BODY_FLOOR_CLASS (imported, not
+ * hand-copied) and also covers this section's standalone (no-shelf) rendering;
+ * `tw-grow` on the editor fills that floor.
+ */
+export default function AgentContextSection({
+  app,
+  projectId,
+  popoverContainer,
+}: AgentContextSectionProps) {
+  const projects = useProjects();
+  const project = useMemo(() => projects.find((p) => p.id === projectId), [projects, projectId]);
+  const externalContext = project?.contextSource;
+
+  const [draft, setDraft] = useState<ContextSource | undefined>(externalContext);
+  const pendingRef = useRef<Partial<ContextSource> | null>(null);
+  const writingRef = useRef(false);
+
+  // Adopt external changes only when nothing optimistic is queued/in flight, so a
+  // background record refresh can't resurrect a chip the user just removed. This
+  // is the intended prop→optimistic-state sync; the lint rule's blanket warning
+  // about set-state-in-effect doesn't fit a guarded reconciliation like this.
+  useEffect(() => {
+    // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+    if (!pendingRef.current && !writingRef.current) setDraft(externalContext);
+  }, [externalContext]);
+
+  const flush = useCallback(() => {
+    if (writingRef.current) return;
+    const patch = pendingRef.current;
+    if (!patch) return;
+    pendingRef.current = null;
+    writingRef.current = true;
+    // Rebase each write on the freshest persisted config so queued patches
+    // compose rather than race on a stale closure-captured base.
+    const base = getCachedProjectRecordById(projectId)?.project;
+    if (!base) {
+      writingRef.current = false;
+      return;
+    }
+    ProjectFileManager.getInstance(app)
+      .updateProject(projectId, { ...base, contextSource: { ...base.contextSource, ...patch } })
+      .catch((err) => {
+        logWarn("[project-context] failed to save context changes", err);
+        // The optimistic draft assumed this write would land. With no further
+        // pending patch to reconcile it, resync the draft to the persisted config
+        // so the UI can't drift from disk (a removed chip reappearing, etc.).
+        if (!pendingRef.current) {
+          setDraft(getCachedProjectRecordById(projectId)?.project.contextSource);
+        }
+      })
+      .finally(() => {
+        writingRef.current = false;
+        if (pendingRef.current) flush();
+      });
+  }, [app, projectId]);
+
+  const handleChange = useCallback(
+    (patch: Partial<ContextSource>) => {
+      setDraft((prev) => ({ ...(prev ?? {}), ...patch }));
+      pendingRef.current = { ...(pendingRef.current ?? {}), ...patch };
+      flush();
+    },
+    [flush]
+  );
+
+  const sectionRef = useRef<HTMLDivElement>(null);
+  const { isDragging } = usePersistentContextDrop({ app, projectId, dropRef: sectionRef });
+
+  const handleManage = useCallback(() => {
+    if (!project) return;
+    const modal = new ContextManageModal(
+      app,
+      (updated) => {
+        ProjectFileManager.getInstance(app)
+          .updateProject(projectId, updated)
+          .catch((err) => logWarn("[project-context] failed to save context changes", err));
+      },
+      project,
+      { enableLinks: true }
+    );
+    modal.open();
+  }, [app, project, projectId]);
+
+  // Orphaned/unknown project: nothing to edit.
+  if (!project) return null;
+
+  return (
+    <div
+      ref={sectionRef}
+      data-copilot-drop-zone
+      className={cn(SHELF_BODY_FLOOR_CLASS, "tw-flex tw-grow tw-flex-col tw-p-2")}
+    >
+      <ProjectContextSourceEditor
+        contextSource={draft}
+        onChange={handleChange}
+        onManage={handleManage}
+        popoverContainer={popoverContainer}
+        isDragging={isDragging}
+        // Fill the shelf floor; the editor's own max-height caps it so a long
+        // context scrolls inside the box instead of taking over the whole tab.
+        className="tw-grow"
+      />
+    </div>
+  );
+}

--- a/src/agentMode/ui/AgentContextStatusIcon.test.tsx
+++ b/src/agentMode/ui/AgentContextStatusIcon.test.tsx
@@ -1,0 +1,252 @@
+import AgentContextStatusIcon, { buildStatusView } from "@/agentMode/ui/AgentContextStatusIcon";
+import {
+  agentProjectContextLoadAtom,
+  type AgentProjectContextLoadState,
+  type FailedItem,
+  type ProjectConfig,
+} from "@/aiParams";
+import { settingsStore } from "@/settings/model";
+import { act, render } from "@testing-library/react";
+import type { App } from "obsidian";
+import * as React from "react";
+
+// Radix Popover portals resolve Obsidian's `activeDocument` global at render;
+// jsdom doesn't define it. Point it at the test document.
+(window as unknown as { activeDocument: Document }).activeDocument = window.document;
+
+function entry(over: Partial<AgentProjectContextLoadState> = {}): AgentProjectContextLoadState {
+  return { phase: "done", blocking: false, ...over };
+}
+
+const webFailure: FailedItem = {
+  path: "https://a.com",
+  type: "web",
+  error: "boom",
+  usedStaleSnapshot: false,
+};
+const staleFailure: FailedItem = {
+  path: "https://b.com",
+  type: "web",
+  error: "network down",
+  usedStaleSnapshot: true,
+};
+
+describe("buildStatusView", () => {
+  it("rests on idle when there is no entry", () => {
+    const v = buildStatusView(undefined, true);
+    expect(v.kind).toBe("idle");
+    expect(v.headline).toBe("No context loaded");
+  });
+
+  it("rests on idle on the idle phase", () => {
+    expect(buildStatusView(entry({ phase: "idle" }), true).kind).toBe("idle");
+  });
+
+  it("rests on idle for a clean completion when the project has no configured context source", () => {
+    expect(buildStatusView(entry({ phase: "done" }), false).kind).toBe("idle");
+  });
+
+  it("is ready on a clean completion with a configured context source", () => {
+    const v = buildStatusView(entry({ phase: "done" }), true);
+    expect(v.kind).toBe("ready");
+    expect(v.headline).toBe("Context ready");
+  });
+
+  it("is working during a materialization phase", () => {
+    const v = buildStatusView(
+      entry({ phase: "prefetch", blocking: true, prefetch: { done: 2, total: 4 } }),
+      true
+    );
+    expect(v.kind).toBe("working");
+    expect(v.headline).toBe("Indexing context · 2/4");
+  });
+
+  it("is working when a retry is in flight even though the phase is still done", () => {
+    // A per-row retry sets `retryingSources` but leaves phase at "done" (and
+    // optimistically clears the failure) — the glyph must read working, not the
+    // green "ready" the bare phase check would give.
+    const v = buildStatusView(
+      entry({ phase: "done", retryingSources: [{ kind: "web", source: "https://a.com" }] }),
+      true
+    );
+    expect(v.kind).toBe("working");
+  });
+
+  it("is working when a source is processing even though the phase is still done", () => {
+    const v = buildStatusView(
+      entry({ phase: "done", processingSources: [{ kind: "web", source: "https://a.com" }] }),
+      true
+    );
+    expect(v.kind).toBe("working");
+  });
+
+  it("is failed from a persistent on-disk marker count when no entry exists yet", () => {
+    // A project whose failures live only as disk markers (Option D), with no run
+    // this session — the icon must read failed, not idle/ready.
+    const v = buildStatusView(undefined, true, 1);
+    expect(v.kind).toBe("failed");
+    expect(v.headline).toBe("1 source failed");
+  });
+
+  it("is failed from the persistent count on a clean-looking settled entry", () => {
+    const v = buildStatusView(entry({ phase: "done" }), true, 2);
+    expect(v.kind).toBe("failed");
+    expect(v.headline).toBe("2 sources failed");
+  });
+
+  it("prefers live missing failures over the persistent count", () => {
+    // A live missing failure is this run's truth; the disk count must not inflate
+    // the headline.
+    const v = buildStatusView(entry({ phase: "done", failedSources: [webFailure] }), true, 5);
+    expect(v.kind).toBe("failed");
+    expect(v.headline).toBe("1 source failed");
+  });
+
+  it("stays working over a persistent count while a retry is in flight", () => {
+    const v = buildStatusView(
+      entry({ phase: "done", retryingSources: [{ kind: "web", source: "https://a.com" }] }),
+      true,
+      3
+    );
+    expect(v.kind).toBe("working");
+  });
+
+  it("is failed when a source is missing (no stale fallback)", () => {
+    const v = buildStatusView(entry({ phase: "done", failedSources: [webFailure] }), true);
+    expect(v.kind).toBe("failed");
+    expect(v.headline).toBe("1 source failed");
+  });
+
+  it("stays ready (green) when failures are stale-but-usable only", () => {
+    const v = buildStatusView(entry({ phase: "done", failedSources: [staleFailure] }), true);
+    expect(v.kind).toBe("ready");
+    // The stale failure is still surfaced in the popover list.
+    expect(v.failures).toHaveLength(1);
+  });
+
+  it("counts only missing sources in the failed headline", () => {
+    const v = buildStatusView(
+      entry({ phase: "done", failedSources: [webFailure, staleFailure] }),
+      true
+    );
+    expect(v.kind).toBe("failed");
+    expect(v.headline).toBe("1 source failed");
+    expect(v.failures).toHaveLength(2); // both shown in detail
+  });
+
+  it("shows real-count step rows when present", () => {
+    const v = buildStatusView(
+      entry({ phase: "done", resolved: 243, prefetch: { done: 4, total: 4 } }),
+      true
+    );
+    const labels = v.steps.map((s) => s.label);
+    expect(labels).toContain("Resolve files (243)");
+    expect(labels).toContain("Prefetch 4 URLs · 4/4");
+    // No fabricated "Apply 100-cap" row — only real-count steps are shown.
+    expect(labels).not.toContain("Apply 100-cap");
+    expect(v.steps.every((s) => s.status === "done")).toBe(true);
+  });
+
+  it("treats a synthetic whole-context failure as failed", () => {
+    const v = buildStatusView(
+      entry({ phase: "done", failedSources: [{ path: "Project context", type: "nonMd", error: "fs" }] }), // prettier-ignore
+      true
+    );
+    expect(v.kind).toBe("failed");
+  });
+});
+
+describe("AgentContextStatusIcon anti-flash", () => {
+  const PROJECT = "proj-1";
+  const noop = () => {};
+
+  function setEntry(e: AgentProjectContextLoadState | undefined) {
+    settingsStore.set(agentProjectContextLoadAtom, e ? { [PROJECT]: e } : {});
+  }
+
+  // app/project only matter once the popover opens (the conversion body mounts);
+  // these anti-flash tests assert the trigger glyph only, so minimal stubs suffice.
+  const APP = {} as unknown as App;
+  const PROJECT_CONFIG = { id: PROJECT } as unknown as ProjectConfig;
+
+  function renderIcon() {
+    return render(
+      <AgentContextStatusIcon
+        app={APP}
+        activeProjectId={PROJECT}
+        project={PROJECT_CONFIG}
+        hasConfiguredContextSource
+        landing={false}
+        onReindex={() => false}
+        onRetryItem={() => Promise.resolve(false)}
+        onRefreshLanding={noop}
+        onEditContext={noop}
+      />
+    );
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    setEntry(undefined);
+  });
+  afterEach(() => {
+    // Real timers restored after RTL's auto-unmount (registered at import, so it
+    // runs after this inner hook) — the atom reset lives in beforeEach to avoid
+    // writing the store while a component from this test is still mounted.
+    jest.useRealTimers();
+  });
+
+  // The trigger button is always present now (the icon rests on the gray idle
+  // glyph), so anti-flash is asserted on the spinner glyph (`tw-animate-spin`),
+  // not on the button's presence.
+  const spinner = (c: HTMLElement) => c.querySelector(".tw-animate-spin");
+
+  it("shows the gray idle trigger with no entry (never hidden)", () => {
+    setEntry(undefined);
+    const { container } = renderIcon();
+    expect(container.querySelector('[aria-label="Project context status"]')).not.toBeNull();
+    expect(spinner(container)).toBeNull();
+  });
+
+  it("does not flash the working spinner if the run settles within 300ms (warm cache)", () => {
+    setEntry({ phase: "resolve", blocking: true });
+    const { container } = renderIcon();
+    // Within the reveal delay the trigger stays on the idle glyph — no spinner.
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(spinner(container)).toBeNull();
+    // The run completes cleanly before the timer elapses → straight to ready.
+    act(() => {
+      setEntry({ phase: "done", blocking: false, failedSources: [] });
+    });
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+    expect(spinner(container)).toBeNull();
+  });
+
+  it("shows the working spinner once the run exceeds 300ms (cold)", () => {
+    setEntry({ phase: "prefetch", blocking: true, prefetch: { done: 0, total: 4 } });
+    const { container } = renderIcon();
+    // Masked as idle until the reveal delay elapses.
+    expect(spinner(container)).toBeNull();
+    act(() => {
+      jest.advanceTimersByTime(350);
+    });
+    expect(spinner(container)).not.toBeNull();
+  });
+
+  it("shows the working spinner immediately for a user retry (no anti-flash idle blink)", () => {
+    // A per-row retry keeps phase `done` and sets `retryingSources`; the user just
+    // clicked, so the spinner must show at once — never blink the neutral idle
+    // glyph first.
+    setEntry({
+      phase: "done",
+      blocking: false,
+      retryingSources: [{ kind: "web", source: "https://a.com" }],
+    });
+    const { container } = renderIcon();
+    expect(spinner(container)).not.toBeNull();
+  });
+});

--- a/src/agentMode/ui/AgentContextStatusIcon.tsx
+++ b/src/agentMode/ui/AgentContextStatusIcon.tsx
@@ -1,0 +1,480 @@
+import { GLOBAL_SCOPE, type ProjectScopeId } from "@/agentMode/session/scope";
+import {
+  agentProjectContextLoadAtom,
+  type AgentProjectContextLoadState,
+  type FailedItem,
+  type ProjectConfig,
+} from "@/aiParams";
+import { AgentContextConversionModalContent } from "@/components/project/AgentContextConversionModalContent";
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import { useAgentPersistentFailureCount } from "@/components/project/useAgentPersistentFailureCount";
+import { useAgentProcessingItems } from "@/components/project/useAgentProcessingItems";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { settingsStore } from "@/settings/model";
+import { openAgentCachedItemPreview } from "@/utils/cacheFileOpener";
+import { useAtomValue } from "jotai";
+import { AlertCircle, CheckCircle, CircleDashed, Loader2 } from "lucide-react";
+import { App } from "obsidian";
+import * as React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface AgentContextStatusIconProps {
+  app: App;
+  /** Active workspace scope. {@link GLOBAL_SCOPE} never has a per-project entry. */
+  activeProjectId: ProjectScopeId;
+  /** The active project — drives the conversion popover's per-source list/preview. */
+  project: ProjectConfig;
+  /**
+   * Whether the project declares any context source (folder/note/tag/ext/URL/
+   * file). When false, a completed run with no failures rests on the neutral
+   * `idle` icon (nothing to report) rather than the green "ready" check. Computed
+   * by the parent from the project config.
+   */
+  hasConfiguredContextSource: boolean;
+  /**
+   * Whether the composer is in its landing layout (vertically centered, with
+   * content below it) rather than docked at the pane bottom. Drives the popover
+   * open direction: down from a centered composer (room below, would otherwise
+   * cover the hero above), up from a docked one. Radix still flips on collision
+   * if the chosen side lacks room.
+   */
+  landing: boolean;
+  /** Whole-run re-materialize (popover "Retry all/failed"): re-attempts failed
+   * sources (already-successful snapshots cheap-skip by fingerprint). Returns
+   * whether a run actually started (false for no-op scopes). */
+  onReindex: () => boolean;
+  /** Per-source retry (popover row "Retry") → `AgentSessionManager.rematerializeSource`.
+   * Resolves to whether the retry actually ran (false when deduped/skipped). */
+  onRetryItem: (item: ProcessingItem) => Promise<boolean>;
+  /** Re-capture context into an empty landing session. Deferred until the popover
+   * closes so a retry's completion can't yank the popover out from under the user
+   * (the session swap remounts the composer, see {@link handleOpenChange}). The
+   * return value (if any) is not awaited — callers fire-and-forget. */
+  onRefreshLanding: () => void | Promise<unknown>;
+  /** Open the project's context editor (popover "Edit context"). */
+  onEditContext: () => void;
+}
+
+/** Delay before the working spinner appears, so a warm (cache-hit) run that
+ * settles within the window keeps resting on the neutral `idle` icon instead of
+ * flashing the spinner (anti-flash). */
+const WORKING_REVEAL_MS = 300;
+
+/**
+ * The composer icon's resting/active glyphs — mirrors the legacy CAG chat-input
+ * status icon (`ChatContextMenu`): `idle` is its gray `CircleDashed`, the other
+ * three its spinner/check/alert. There is no "hidden": the icon is always shown
+ * for a project scope, resting on `idle` when there's nothing to report.
+ */
+type IconKind = "idle" | "working" | "ready" | "failed";
+
+interface StatusView {
+  kind: IconKind;
+  /** Collapsed headline shown in the popover header. */
+  headline: string;
+  /** Step rows (resolve/prefetch/parse), real counts only — never fabricated. */
+  steps: StatusStep[];
+  /** Per-source failures (already mapped to FailedItem by the manager). */
+  failures: FailedItem[];
+}
+
+interface StatusStep {
+  label: string;
+  status: "done" | "active" | "pending";
+}
+
+const PHASE_RANK: Record<AgentProjectContextLoadState["phase"], number> = {
+  idle: -1,
+  resolve: 0,
+  prefetch: 1,
+  parse: 2,
+  done: 3,
+};
+
+function stepStatus(
+  current: AgentProjectContextLoadState["phase"],
+  stepPhase: "resolve" | "prefetch" | "parse",
+  countComplete: boolean
+): StatusStep["status"] {
+  if (current === "done") return "done";
+  if (countComplete) return "done";
+  const rank = PHASE_RANK[current];
+  const stepRank = PHASE_RANK[stepPhase];
+  if (rank > stepRank) return "done";
+  if (rank === stepRank) return "active";
+  return "pending";
+}
+
+/**
+ * Derive the icon's view model from the raw load entry. Pure (no atom/timer), so
+ * it is unit-testable in isolation.
+ *
+ * - `idle`: no entry, idle phase, or a clean completion for a project that
+ *   declares no context source (nothing worth reporting — the neutral resting
+ *   state, mirroring the legacy CAG icon's `initial`).
+ * - `failed`: completed with at least one MISSING source (`usedStaleSnapshot`
+ *   false). Stale-but-usable failures alone stay `ready` (green) — context is
+ *   present, just old; the popover flags the staleness.
+ * - `ready`: completed, no missing sources, project has context configured.
+ * - `working`: a materialization phase is in flight.
+ */
+export function buildStatusView(
+  entry: AgentProjectContextLoadState | undefined,
+  hasConfiguredContextSource: boolean,
+  persistentMissingCount = 0
+): StatusView {
+  // Failures persist as on-disk markers (Option D), so a settled project can have
+  // failed sources the live atom no longer carries. `persistentMissingCount` (a
+  // disk read by the always-mounted icon — see useAgentPersistentFailureCount)
+  // surfaces them as failed even when no run is driving the atom. Only a NON-zero
+  // count matters; it never overrides an in-flight `working`.
+  const persistent = Math.max(0, persistentMissingCount);
+
+  if (!entry || entry.phase === "idle") {
+    // `persistent` is fed only here-via-`!entry`: a project that never ran a
+    // materialization this session (e.g. a reused landing) has NO atom entry, yet
+    // its prior failures live on disk. The `phase === "idle"` arm never receives a
+    // non-zero `persistent` because the hook gates its disk read to settled-done /
+    // no-entry (no producer writes a per-project `phase: "idle"` entry today); it
+    // shares this arm only to fall through to the same neutral idle glyph. If a
+    // future review flags the idle/persistent pairing as unreachable, point them
+    // at this note — it's intentional, the live path is the `!entry` one.
+    if (persistent > 0) {
+      return { kind: "failed", headline: failedHeadline(persistent), steps: [], failures: [] };
+    }
+    return { kind: "idle", headline: "No context loaded", steps: [], failures: [] };
+  }
+
+  const failures = entry.failedSources ?? [];
+  const missing = failures.filter((f) => !f.usedStaleSnapshot);
+  const done = entry.phase === "done";
+  // A per-source / per-row retry runs while the phase stays `done` (it only sets
+  // `retryingSources`), and a full run carries `processingSources` mid-flight.
+  // Either means work is in flight, so the glyph must read "working" — not the
+  // green "ready" the bare phase check would give after an optimistic retry
+  // clears the failure.
+  const inFlight =
+    (entry.retryingSources?.length ?? 0) > 0 || (entry.processingSources?.length ?? 0) > 0;
+
+  // Build the real-count step rows — never fabricated, so a row appears only for
+  // work that actually has a count (resolved files, prefetched URLs, parsed files).
+  const steps: StatusStep[] = [];
+  if (entry.resolved !== undefined && entry.resolved > 0) {
+    steps.push({
+      label: `Resolve files (${entry.resolved})`,
+      status: stepStatus(entry.phase, "resolve", true),
+    });
+  }
+  if (entry.prefetch) {
+    const { done: d, total } = entry.prefetch;
+    steps.push({
+      label: `Prefetch ${total} ${total === 1 ? "URL" : "URLs"} · ${d}/${total}`,
+      status: stepStatus(entry.phase, "prefetch", d >= total),
+    });
+  }
+  if (entry.parsed) {
+    const { done: d, total } = entry.parsed;
+    steps.push({
+      label: `Parse ${total} ${total === 1 ? "file" : "files"} · ${d}/${total}`,
+      status: stepStatus(entry.phase, "parse", d >= total),
+    });
+  }
+
+  if (!done || inFlight) {
+    const totalCount = (entry.prefetch?.total ?? 0) + (entry.parsed?.total ?? 0);
+    const doneCount = (entry.prefetch?.done ?? 0) + (entry.parsed?.done ?? 0);
+    const headline =
+      !done && totalCount > 0
+        ? `Indexing context · ${doneCount}/${totalCount}`
+        : "Indexing context";
+    return { kind: "working", headline, steps, failures };
+  }
+
+  // Completed.
+  // Live missing failures take precedence; otherwise fall back to the persisted
+  // on-disk markers (the settled-state truth the popover already shows).
+  const missingCount = missing.length > 0 ? missing.length : persistent;
+  if (missingCount > 0) {
+    return { kind: "failed", headline: failedHeadline(missingCount), steps, failures };
+  }
+  // Clean (or stale-only) completion. Rest on the neutral `idle` icon when the
+  // project has no configured context source — there is nothing to call "ready".
+  if (!hasConfiguredContextSource && failures.length === 0) {
+    return { kind: "idle", headline: "No context loaded", steps: [], failures: [] };
+  }
+  return { kind: "ready", headline: "Context ready", steps, failures };
+}
+
+/** "N source(s) failed" headline for the failed glyph. */
+function failedHeadline(count: number): string {
+  return count === 1 ? "1 source failed" : `${count} sources failed`;
+}
+
+interface ResolvedStatus {
+  /** The real status — drives the popover's headline, steps, failures, actions. */
+  view: StatusView;
+  /**
+   * The glyph the trigger button shows. Equals `view.kind` except during the
+   * anti-flash window, where a `working` run is masked as `idle` so a warm run
+   * doesn't flash the spinner. The popover still reflects the real `view`, so
+   * opening it mid-mask shows the true "indexing" state (never a false Retry).
+   */
+  triggerKind: IconKind;
+}
+
+/**
+ * Reads the projectId-keyed load atom and applies the anti-flash delay: while a
+ * run is `working`, the TRIGGER GLYPH stays on the neutral `idle` icon until
+ * {@link WORKING_REVEAL_MS} has elapsed. A warm run that completes within the
+ * window therefore never flashes the spinner — the glyph goes straight from
+ * `idle` to `ready`/`failed`. Terminal states render immediately. Reset per
+ * project so a peer's timer never leaks in. The masking is glyph-only: `view`
+ * always carries the real status for the popover.
+ */
+function useStatusView(
+  app: App,
+  activeProjectId: ProjectScopeId,
+  project: ProjectConfig,
+  hasConfiguredContextSource: boolean
+): ResolvedStatus {
+  const states = useAtomValue(agentProjectContextLoadAtom, { store: settingsStore });
+  const entry = activeProjectId === GLOBAL_SCOPE ? undefined : states[activeProjectId];
+  // Persisted on-disk failures the live atom may not carry once a run has settled
+  // (Option D). Only consulted for the active project; gated to settled states
+  // inside the hook so a live run pays no extra disk I/O.
+  const persistentMissingCount = useAgentPersistentFailureCount(
+    app,
+    project,
+    entry,
+    activeProjectId !== GLOBAL_SCOPE && project.id === activeProjectId
+  );
+  const view = buildStatusView(entry, hasConfiguredContextSource, persistentMissingCount);
+
+  // Anti-flash gate, keyed on project + phase + a retry-episode flag so a fresh
+  // working phase restarts the delay and a project switch resets it. The flag
+  // captures ONLY a retry that runs while the phase stays `done` (the one working
+  // episode the phase can't mark); a live run's per-item `processingSources`
+  // churn must NOT enter the key, or the spinner would re-mask to idle at every
+  // source boundary. The reset is done during render (React's "adjust state from
+  // props" pattern) so only the timer's async reveal touches state from the
+  // effect — keeping the effect side-effect-only.
+  const [revealWorking, setRevealWorking] = useState(false);
+  const retryWhileDone =
+    entry?.phase === "done" &&
+    ((entry.retryingSources?.length ?? 0) > 0 || (entry.processingSources?.length ?? 0) > 0);
+  const delayKey = `${activeProjectId}\0${entry?.phase ?? "none"}\0${retryWhileDone ? "retry" : ""}`;
+  const prevKeyRef = useRef(delayKey);
+  if (prevKeyRef.current !== delayKey) {
+    prevKeyRef.current = delayKey;
+    if (revealWorking) setRevealWorking(false);
+  }
+
+  useEffect(() => {
+    if (view.kind !== "working") return;
+    const timer = window.setTimeout(() => setRevealWorking(true), WORKING_REVEAL_MS);
+    return () => window.clearTimeout(timer);
+  }, [view.kind, delayKey]);
+
+  // Anti-flash masks a `working` glyph as `idle` for the first WORKING_REVEAL_MS
+  // so a warm AUTO run that settles fast never flashes the spinner. A
+  // user-initiated retry (the `retryWhileDone` working episode) is exempt: the
+  // user just clicked, so show the spinner immediately rather than blink the
+  // neutral "no context" glyph first.
+  const masked = view.kind === "working" && !revealWorking && !retryWhileDone;
+  return { view, triggerKind: masked ? "idle" : view.kind };
+}
+
+/** Leading trigger icon for the current kind — mirrors the legacy CAG project
+ * status icon (CircleDashed / Loader2 / CheckCircle / AlertCircle, same size +
+ * theme colors). `idle` is the gray resting glyph. */
+function TriggerIcon({ kind }: { kind: IconKind }) {
+  if (kind === "failed") return <AlertCircle className="tw-size-4 tw-text-error" />;
+  if (kind === "ready") return <CheckCircle className="tw-size-4 tw-text-success" />;
+  if (kind === "idle") return <CircleDashed className="tw-size-4 tw-text-faint" />;
+  return <Loader2 className="tw-size-4 tw-animate-spin tw-text-loading" />;
+}
+
+/**
+ * Composer status icon for a project's context materialization. Sits in the
+ * composer's top row (right of the context badges). The trigger glyph reflects
+ * idle/working/ready/failed (with an anti-flash delay); clicking opens the
+ * unified Content Conversion popover (design S) — the SAME surface the project
+ * header opens, so there's one place to see per-source status, retry a single
+ * source / the whole run, and jump to Edit context. Only mounted for a real
+ * (non-global, non-orphaned) project by the parent.
+ */
+export default function AgentContextStatusIcon({
+  app,
+  activeProjectId,
+  project,
+  hasConfiguredContextSource,
+  landing,
+  onReindex,
+  onRetryItem,
+  onRefreshLanding,
+  onEditContext,
+}: AgentContextStatusIconProps) {
+  const { triggerKind } = useStatusView(app, activeProjectId, project, hasConfiguredContextSource);
+  const [open, setOpen] = useState(false);
+
+  // A retry/reindex re-captures context by swapping the empty landing session,
+  // which remounts this whole composer subtree (ChatInput is `key={sessionId}`)
+  // and would close the popover. So we hold that refresh until the popover is
+  // dismissed. `openRef` lets a retry settling AFTER an early close still fire it.
+  const openRef = useRef(open);
+  // The scope a deferred refresh belongs to, captured when the retry/reindex was
+  // triggered (null = none pending). A retry can settle after the user switched
+  // projects on this same — never-remounted — composer icon; firing the landing
+  // refresh then would re-materialize the NEW project's session. So we only fire
+  // when the captured scope still matches the active one.
+  const pendingRefreshScopeRef = useRef<ProjectScopeId | null>(null);
+  const activeProjectIdRef = useRef(activeProjectId);
+  useEffect(() => {
+    activeProjectIdRef.current = activeProjectId;
+  }, [activeProjectId]);
+  // Always call the LATEST refresh. A slow retry can settle after the user closed
+  // the popover and started typing; the click-time closure would still see the
+  // old (empty) draft and wrongly replace the session, wiping that input. The
+  // current-render callback closes over the current draft, so its own empty-draft
+  // guard no-ops correctly.
+  const onRefreshLandingRef = useRef(onRefreshLanding);
+  useEffect(() => {
+    onRefreshLandingRef.current = onRefreshLanding;
+  }, [onRefreshLanding]);
+
+  // A per-source retry can settle after the user has switched scope and this icon
+  // unmounted; don't fire the landing refresh from a dead instance (it would act
+  // on whatever session is active by then).
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
+  // Fire the landing refresh only if the still-active scope matches the one the
+  // refresh was queued for (see {@link pendingRefreshScopeRef}).
+  const fireRefreshIfSameScope = useCallback((scope: ProjectScopeId) => {
+    if (scope === activeProjectIdRef.current) void onRefreshLandingRef.current();
+  }, []);
+
+  const deferRefreshUntilClosed = useCallback(
+    (scope: ProjectScopeId) => {
+      if (openRef.current) pendingRefreshScopeRef.current = scope;
+      else fireRefreshIfSameScope(scope);
+    },
+    [fireRefreshIfSameScope]
+  );
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      openRef.current = nextOpen;
+      setOpen(nextOpen);
+      if (!nextOpen && pendingRefreshScopeRef.current !== null) {
+        const scope = pendingRefreshScopeRef.current;
+        pendingRefreshScopeRef.current = null;
+        fireRefreshIfSameScope(scope);
+      }
+    },
+    [fireRefreshIfSameScope]
+  );
+
+  const handleRetryItem = useCallback(
+    async (item: ProcessingItem) => {
+      const scope = activeProjectIdRef.current;
+      if ((await onRetryItem(item)) && mountedRef.current) deferRefreshUntilClosed(scope);
+    },
+    [onRetryItem, deferRefreshUntilClosed]
+  );
+
+  const handleRetryAll = useCallback(() => {
+    const scope = activeProjectIdRef.current;
+    if (onReindex()) deferRefreshUntilClosed(scope);
+  }, [onReindex, deferRefreshUntilClosed]);
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost2"
+          size="fit"
+          className="tw-text-muted"
+          aria-label="Project context status"
+        >
+          <TriggerIcon kind={triggerKind} />
+        </Button>
+      </PopoverTrigger>
+      {/* 368px + p-0: the conversion content owns its own width/padding and a
+          single inner scroll layer (no nested popover scroll). Open direction
+          follows the composer: down on the landing (centered), up when docked. */}
+      <PopoverContent
+        align="end"
+        side={landing ? "bottom" : "top"}
+        className="tw-flex tw-max-h-[var(--radix-popover-content-available-height)] tw-w-[368px] tw-max-w-[calc(100vw-24px)] tw-flex-col tw-overflow-hidden tw-p-0"
+      >
+        {/* Mounted only while open, so the per-source read-model (disk + atom)
+            runs on demand rather than for every composer render. */}
+        {open && (
+          <ConversionPopoverBody
+            app={app}
+            project={project}
+            hasConfiguredContextSource={hasConfiguredContextSource}
+            onRetryItem={handleRetryItem}
+            onRetryAll={handleRetryAll}
+            onEditContext={() => {
+              handleOpenChange(false);
+              onEditContext();
+            }}
+          />
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * The popover's body: reads the per-source conversion model and renders the
+ * shared three-state {@link AgentContextConversionModalContent}. Split out so
+ * `useAgentProcessingItems` only runs while the popover is open.
+ */
+function ConversionPopoverBody({
+  app,
+  project,
+  hasConfiguredContextSource,
+  onRetryItem,
+  onRetryAll,
+  onEditContext,
+}: {
+  app: App;
+  project: ProjectConfig;
+  hasConfiguredContextSource: boolean;
+  onRetryItem: (item: ProcessingItem) => void;
+  onRetryAll: () => void;
+  onEditContext: () => void;
+}) {
+  const { items, skippedMarkdownCount } = useAgentProcessingItems(
+    app,
+    project,
+    project.contextSource
+  );
+
+  const handleOpenCachedItem = (item: ProcessingItem) => {
+    // Off-vault snapshots are keyed by source identity, so no project folder is
+    // needed — the item's kind + id locate the snapshot.
+    void openAgentCachedItemPreview(app, item);
+  };
+
+  return (
+    <AgentContextConversionModalContent
+      items={items}
+      hasConfiguredContextSource={hasConfiguredContextSource}
+      skippedMarkdownCount={skippedMarkdownCount}
+      onRetryItem={onRetryItem}
+      onRetryAll={onRetryAll}
+      onEditContext={onEditContext}
+      onOpenCachedItem={handleOpenCachedItem}
+    />
+  );
+}

--- a/src/agentMode/ui/AgentContextStatusIcon.tsx
+++ b/src/agentMode/ui/AgentContextStatusIcon.tsx
@@ -137,9 +137,8 @@ export function buildStatusView(
     // its prior failures live on disk. The `phase === "idle"` arm never receives a
     // non-zero `persistent` because the hook gates its disk read to settled-done /
     // no-entry (no producer writes a per-project `phase: "idle"` entry today); it
-    // shares this arm only to fall through to the same neutral idle glyph. If a
-    // future review flags the idle/persistent pairing as unreachable, point them
-    // at this note — it's intentional, the live path is the `!entry` one.
+    // shares this arm only to fall through to the same neutral idle glyph. The
+    // idle/persistent pairing is intentional — the live path is the `!entry` one.
     if (persistent > 0) {
       return { kind: "failed", headline: failedHeadline(persistent), steps: [], failures: [] };
     }

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -385,10 +385,11 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   // STALE inline block until a new chat. Replace it in place (the handleNewChat
   // pattern) so its fresh `initialize()` re-captures the new context — createSession
   // joins the just-started materialization (single-flight by project) on Retry, or
-  // re-materializes the updated config on Edit. Guarded on an EMPTY draft: a replace
-  // mints a new session id, which prunes the draft (input/images/notes/queue), so we
-  // never discard text the user has started typing — those edits then apply to the
-  // next new chat instead.
+  // re-materializes the updated config on Edit. Guarded on an EMPTY draft so a
+  // refresh never interrupts a draft already in progress. The replace mints a new
+  // session id and prunes the old draft, so to honor "never discard text the user
+  // has started typing" we also migrate any draft typed during the async startup
+  // window onto the new id (the pre-await check can't see those late keystrokes).
   // Returns whether a swap actually happened (false = guarded no-op), so the
   // context-source observer advances its baseline only on a real capture.
   const refreshContextForEmptyLanding = useCallback(async (): Promise<boolean> => {
@@ -401,7 +402,8 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
       draft.queue.length === 0;
     if (!draftEmpty) return false;
     try {
-      await manager.replaceSessionInPlace(active.internalId, active.backendId);
+      const replacement = await manager.replaceSessionInPlace(active.internalId, active.backendId);
+      draft.migrateDraft(active.internalId, replacement.internalId);
       return true;
     } catch (e) {
       logError("[AgentMode] refresh landing context failed", e);

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -40,7 +40,7 @@ import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { ProjectFileManager } from "@/projects/ProjectFileManager";
-import { getProjectContextSignature } from "@/projects/projectContextSignature";
+import { getProjectLandingCaptureSignature } from "@/projects/projectContextSignature";
 import { getCachedProjectRecordById, useProjects } from "@/projects/state";
 import { getSettings, settingsStore, updateSetting, useSettingsValue } from "@/settings/model";
 import { useAtomValue } from "jotai";
@@ -419,19 +419,22 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
     draft.images.length === 0 &&
     draft.contextNotes.length === 0 &&
     draft.queue.length === 0;
-  // Same signature the session manager dirty-tracks with (normalized sources +
-  // filePath), read from the live record. `projects` is a deliberate re-derive
-  // trigger — not read inside the factory, but a `useProjects()` change means the
-  // cached record (and thus its signature) may have changed.
-  const activeProjectContextSignature = useMemo(() => {
+  // Fingerprint of what an empty landing session captures at creation: the
+  // materialization signature PLUS the project instructions. Deliberately
+  // broader than the session manager's materialization dirty-tracking signature,
+  // because a landing also bakes in AGENTS.md / Claude's instruction append — so
+  // a System-Prompt-only edit must refresh it. Read from the live record;
+  // `projects` is a deliberate re-derive trigger — not read inside the factory,
+  // but a `useProjects()` change means the cached record may have changed.
+  const activeProjectLandingCaptureSignature = useMemo(() => {
     if (!isProjectScope) return null;
     const record = getCachedProjectRecordById(activeProjectId);
-    return record ? getProjectContextSignature(record) : null;
+    return record ? getProjectLandingCaptureSignature(record) : null;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isProjectScope, activeProjectId, projects]);
   useRefreshEmptyLandingOnContextSourceChange({
     activeProjectId,
-    signature: activeProjectContextSignature,
+    signature: activeProjectLandingCaptureSignature,
     isLanding,
     blocking: contextLoadBlocking,
     draftEmpty: draftIsEmpty,

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -1,8 +1,15 @@
 import AgentChatMessages from "@/agentMode/ui/AgentChatMessages";
 import { AgentChatControls } from "@/agentMode/ui/AgentChatControls";
 import { AgentChatInput } from "@/agentMode/ui/AgentChatInput";
+import AgentContextSection, { buildContextSummary } from "@/agentMode/ui/AgentContextSection";
+import AgentContextStatusIcon from "@/agentMode/ui/AgentContextStatusIcon";
+import { AgentLandingStack } from "@/agentMode/ui/AgentLandingStack";
+import { CreateProjectPanel } from "@/agentMode/ui/CreateProjectPanel";
 import { AgentModeStatus } from "@/agentMode/ui/AgentModeStatus";
+import { AgentProjectHeader } from "@/agentMode/ui/AgentProjectHeader";
+import { ProjectInfoPopover } from "@/agentMode/ui/ProjectInfoPopover";
 import { AgentTabStrip } from "@/agentMode/ui/AgentTabStrip";
+import { AgentWelcomeCard } from "@/agentMode/ui/AgentWelcomeCard";
 import { CopilotBrandIcon } from "@/agentMode/ui/CopilotBrandIcon";
 import { AgentHomeShelf, type AgentHomeShelfSection } from "@/agentMode/ui/AgentHomeShelf";
 import { GlobalRecentChatsSection } from "@/agentMode/ui/GlobalRecentChatsSection";
@@ -10,24 +17,36 @@ import { ProjectPickerList } from "@/agentMode/ui/ProjectPickerList";
 import { useAgentChatRuntimeState } from "@/agentMode/ui/hooks/useAgentChatRuntimeState";
 import { useAgentHistoryControls } from "@/agentMode/ui/hooks/useAgentHistoryControls";
 import { useAgentInputDrafts } from "@/agentMode/ui/hooks/useAgentInputDrafts";
+import { useAttentionChatIds } from "@/agentMode/ui/hooks/useAttentionChatIds";
+import { useRunningChatIds } from "@/agentMode/ui/hooks/useRunningChatIds";
 import { useChatInputAutoFocus } from "@/agentMode/ui/hooks/useChatInputAutoFocus";
+import { useRefreshEmptyLandingOnContextSourceChange } from "@/agentMode/ui/hooks/useRefreshEmptyLandingOnContextSourceChange";
 import { useAgentModelPicker } from "@/agentMode/ui/useAgentModelPicker";
 import { useAgentModePicker } from "@/agentMode/ui/useAgentModePicker";
 import { useSessionBackendDescriptor } from "@/agentMode/ui/useBackendDescriptor";
 import { pickRandomGreeting } from "@/agentMode/ui/landingGreetings";
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { GLOBAL_SCOPE } from "@/agentMode/session/scope";
+import { agentProjectContextLoadAtom, type ProjectConfig } from "@/aiParams";
+import { makeNewProjectConfig } from "@/agentMode/ui/AgentProjectCreateForm";
+import { ContextManageModal } from "@/components/modals/project/context-manage-modal";
+import { TruncatedText } from "@/components/TruncatedText";
 import { EVENT_NAMES } from "@/constants";
 import { AppContext, ChatViewEventTarget, EventTargetContext } from "@/context";
 import { ChatInputProvider, useChatInput } from "@/context/ChatInputContext";
 import { useChatFileDrop } from "@/hooks/useChatFileDrop";
+import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
 import type CopilotPlugin from "@/main";
-import { useProjects } from "@/projects/state";
-import { useSettingsValue } from "@/settings/model";
-import { Folder, MessageSquare } from "lucide-react";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { getProjectContextSignature } from "@/projects/projectContextSignature";
+import { getCachedProjectRecordById, useProjects } from "@/projects/state";
+import { getSettings, settingsStore, updateSetting, useSettingsValue } from "@/settings/model";
+import { useAtomValue } from "jotai";
+import { Files, Folder, MessageSquare } from "lucide-react";
 import { Notice } from "obsidian";
-import React, { useCallback, useContext, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 
 interface AgentHomeProps {
   backend: AgentChatBackend;
@@ -44,12 +63,14 @@ interface AgentHomeProps {
  * (the tab strip swaps `sessionId`/`backend` props), so input drafts live in
  * `AgentChatInput` keyed by session rather than being reset by a `key` remount.
  *
- * Derives a per-session view state: a session with no user-visible messages
- * shows the global landing (centered composer + read-only Projects / Recent
- * Chats); once it has messages it's the conversation. "Global" distinguishes
- * this no-project landing from the per-project landing PR2 adds. (The
- * no-session fallback is handled upstream in `AgentModeChat`.) The
- * `data-agent-landing` attribute marks the seam.
+ * Derives a per-session view state across three surfaces: a session with no
+ * user-visible messages is a landing — global (no project scope: top-anchored
+ * composer over Recent Chats / Projects) or per-project (the project's hero +
+ * scoped Recent Chats); once it has messages it's the conversation. The global
+ * and project landings share `AgentLandingStack`. The project header mounts over
+ * both the project landing and the in-project conversation. (The no-session
+ * fallback is handled upstream in `AgentModeChat`.) The `data-agent-landing`
+ * attribute ("global" | "project" | "conversation") marks the seam.
  */
 const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   backend,
@@ -95,10 +116,16 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
     isStarting,
     hasPendingPlanPermission,
     currentPlan,
+    currentTodoList,
     pendingToolPermissions,
     pendingAskUserQuestions,
   } = useAgentChatRuntimeState(backend);
 
+  // Whole-surface root — the portal container for header-anchored overlays
+  // (the project-info popover), which live OUTSIDE chatContainerRef. Held in
+  // state (not a plain ref) so the popover re-renders once the node mounts and
+  // actually receives the container instead of the first-render `null`.
+  const [rootEl, setRootEl] = useState<HTMLDivElement | null>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
 
   // External callers (CopilotPlugin.autosaveCurrentChat → CopilotAgentView.saveChat)
@@ -153,22 +180,154 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
     descriptor.openInstallUI(plugin);
   }, [descriptor, plugin]);
 
+  const projects = useProjects();
+
+  // Shared in-memory usage manager — the SAME instance `enterProject` touches. The
+  // picker blends it so entering a project reorders the landing list immediately,
+  // before the throttled disk persist catches up.
+  const projectUsageManager = useMemo(
+    () => ProjectFileManager.getInstance(app).getProjectUsageTimestampsManager(),
+    [app]
+  );
+
+  // Active scope drives the third (per-project) landing state and scopes the
+  // history list. `GLOBAL_SCOPE` is the implicit global workspace. Read fresh
+  // each render: the manager re-renders this tree on scope switch, and
+  // `useProjects()` re-renders it on project create/rename/delete — so the
+  // derived name and orphan flag stay live.
+  const activeProjectId = manager.getActiveProjectId();
+  const isProjectScope = activeProjectId !== GLOBAL_SCOPE;
+  const activeProject = isProjectScope ? projects.find((p) => p.id === activeProjectId) : undefined;
+  // The scope still points at a project whose record is gone (folder/`project.md`
+  // deleted while the user was inside it). Degrade rather than crash: the header
+  // keeps only the `‹` escape hatch, the composer hard-disables, and a one-time Notice fires.
+  const isOrphanedProject = isProjectScope && !activeProject;
+  const projectName = activeProject?.name ?? "";
+  // Latch the in-project header content so its exit collapse animates with the
+  // project it's leaving: `projectName`/`isOrphanedProject` flip to their global
+  // values the instant the scope changes, before the header's collapse finishes,
+  // which would otherwise flash an empty name mid-animation. The id rides along
+  // so the identity tile's color doesn't flash either. Writing the ref during
+  // render is the same derive-from-props pattern the context-load card uses.
+  // The global-scope initial id only ever lives in a collapsed, aria-hidden
+  // header; the first project entry latches a real project id.
+  const lastProjectHeaderRef = useRef({
+    id: activeProjectId,
+    name: projectName,
+    orphaned: isOrphanedProject,
+  });
+  if (isProjectScope) {
+    lastProjectHeaderRef.current = {
+      id: activeProjectId,
+      name: projectName,
+      orphaned: isOrphanedProject,
+    };
+  }
+  const headerProjectId = isProjectScope ? activeProjectId : lastProjectHeaderRef.current.id;
+  const headerName = isProjectScope ? projectName : lastProjectHeaderRef.current.name;
+  const headerOrphaned = isProjectScope ? isOrphanedProject : lastProjectHeaderRef.current.orphaned;
+
+  // Scope the history list to the active project (project id) or the flat
+  // all-chats view (`GLOBAL_SCOPE`). One wiring fixes both the landing's
+  // project Recent Chats shelf and the conversation-state History popover, which share
+  // this hook.
   const {
     chatHistoryItems,
+    chatHistorySettled,
     loadChatHistory: handleLoadChatHistory,
     loadChat: handleLoadChat,
     updateChatTitle: handleUpdateChatTitle,
     deleteChat: handleDeleteChat,
     openSourceFile: handleOpenSourceFile,
-  } = useAgentHistoryControls(manager, plugin);
+  } = useAgentHistoryControls(manager, plugin, activeProjectId);
 
-  const projects = useProjects();
+  // Recent-list rows show a spinner for any chat whose backend turn is still
+  // running in the background (the session keeps streaming when its tab is
+  // parked), and a live done-dot the moment that turn finishes. Shared by both
+  // the global and per-project landing shelves.
+  const runningChatIds = useRunningChatIds(manager);
+  const attentionChatIds = useAttentionChatIds(manager);
 
-  // Projects aren't shipped yet, so the Projects tab is disabled on the shelf
-  // (greyed, "Coming soon" on hover) and its list never mounts. This no-op
-  // stands in for ProjectPickerList's required handlers until selection lands;
-  // it's unreachable while the tab is disabled.
-  const handleProjectComingSoon = useCallback(() => {}, []);
+  // Blocking signal for the composer's send-gate: true while the active
+  // project's context is still materializing. Read-only here — the materializer
+  // owns writes to this atom.
+  const contextLoadStates = useAtomValue(agentProjectContextLoadAtom, { store: settingsStore });
+  const contextLoadBlocking =
+    isProjectScope && (contextLoadStates[activeProjectId]?.blocking ?? false);
+
+  // Leave the project scope, returning to the global workspace.
+  const handleExitProject = useCallback(() => {
+    manager.exitProject().catch((e) => {
+      logError("[AgentMode] exit project failed", e);
+      new Notice("Failed to leave project. Please try again.");
+    });
+  }, [manager]);
+
+  // A project was deleted via its `⋯` menu. If it was the active scope (deleted
+  // from the project header), drop back to the global workspace so we don't sit
+  // on a now-orphaned scope.
+  const handleProjectDeleted = useCallback(
+    (deletedId: string) => {
+      if (manager.getActiveProjectId() === deletedId) {
+        manager.exitProject().catch((e) => {
+          logError("[AgentMode] exit after delete failed", e);
+        });
+      }
+    },
+    [manager]
+  );
+
+  // Enter a project from the global shelf's Projects tab (P0 entry point).
+  const handleSelectProject = useCallback(
+    (project: ProjectConfig) => {
+      manager.enterProject(project.id).catch((e) => {
+        logError("[AgentMode] enter project failed", e);
+        new Notice("Failed to open project. Please try again.");
+      });
+    },
+    [manager]
+  );
+
+  // Name-only create: the modal assembles a full ProjectConfig; we persist it
+  // and drop straight into its landing. Rethrow on failure so the modal stays
+  // open instead of closing on a write that didn't land.
+  // Open the anchored name-only create panel next to whichever trigger was
+  // clicked (the "+ New project" row or the Welcome card button), so it appears
+  // beside the trigger instead of dead-center like the full edit modal.
+  const [createAnchor, setCreateAnchor] = useState<HTMLElement | null>(null);
+  const handleCreateProject = useCallback((anchorEl: HTMLElement) => {
+    setCreateAnchor(anchorEl);
+  }, []);
+
+  // Persist a name-only project then enter it. A reject (e.g. a duplicate name)
+  // bubbles to the panel's form, which shows a Notice and keeps the panel open.
+  const persistCreateProject = useCallback(
+    async ({ name }: { name: string }) => {
+      const project = makeNewProjectConfig(name);
+      try {
+        await ProjectFileManager.getInstance(app).createProject(project);
+        await manager.enterProject(project.id);
+      } catch (e) {
+        logError("[AgentMode] create project failed", e);
+        throw e;
+      }
+      setCreateAnchor(null);
+    },
+    [app, manager]
+  );
+
+  // Persist the global-landing Welcome card's dismissal. `updateSetting` replaces
+  // the whole `agentMode` object, so spread the freshest copy first.
+  const handleDismissWelcome = useCallback(() => {
+    updateSetting("agentMode", { ...getSettings().agentMode, welcomeDismissed: true });
+  }, []);
+
+  // Surface the orphaned-scope condition once when it appears (project deleted
+  // out from under the active session). The header + disabled composer let the
+  // user back out via the `‹` escape hatch.
+  useEffect(() => {
+    if (isOrphanedProject) new Notice("This project no longer exists.");
+  }, [isOrphanedProject]);
 
   const modelPickerOverride = useAgentModelPicker(manager);
   const modePickerOverride = useAgentModePicker(manager);
@@ -213,11 +372,104 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
     containerRef: chatContainerRef,
   });
 
-  // Global landing vs conversation. The runtime subscription re-renders this
-  // component as the stream updates, so reading the session's display-message
-  // count here re-derives in step: once the user's first message lands, the
-  // surface flips from the centered landing to the conversation layout.
-  const isGlobalLanding = !manager.getActiveSession()?.hasUserVisibleMessages();
+  // Three surfaces, derived per render (the runtime subscription re-renders as
+  // the stream updates, so the message-count read re-derives in step): a session
+  // with no user-visible messages is a landing — global (no project scope) or
+  // per-project — and once its first message lands it becomes the conversation.
+  const isLanding = !manager.getActiveSession()?.hasUserVisibleMessages();
+  const isProjectLanding = isLanding && isProjectScope;
+
+  // A session captures its `<project_context>` block + searchable roots once, at
+  // start (AgentSession.initialize awaiting `contextReady`). So after a Retry /
+  // Edit re-materializes, a still-empty landing session would otherwise keep the
+  // STALE inline block until a new chat. Replace it in place (the handleNewChat
+  // pattern) so its fresh `initialize()` re-captures the new context — createSession
+  // joins the just-started materialization (single-flight by project) on Retry, or
+  // re-materializes the updated config on Edit. Guarded on an EMPTY draft: a replace
+  // mints a new session id, which prunes the draft (input/images/notes/queue), so we
+  // never discard text the user has started typing — those edits then apply to the
+  // next new chat instead.
+  // Returns whether a swap actually happened (false = guarded no-op), so the
+  // context-source observer advances its baseline only on a real capture.
+  const refreshContextForEmptyLanding = useCallback(async (): Promise<boolean> => {
+    const active = manager.getActiveSession();
+    if (!active || active.hasUserVisibleMessages()) return false;
+    const draftEmpty =
+      draft.input.trim() === "" &&
+      draft.images.length === 0 &&
+      draft.contextNotes.length === 0 &&
+      draft.queue.length === 0;
+    if (!draftEmpty) return false;
+    try {
+      await manager.replaceSessionInPlace(active.internalId, active.backendId);
+      return true;
+    } catch (e) {
+      logError("[AgentMode] refresh landing context failed", e);
+      return false;
+    }
+  }, [manager, draft]);
+
+  // Reactively refresh the empty landing when the active project's context
+  // sources change underneath it (drag-drop / inline edit / +URL / chip removal
+  // / Manage modal all funnel through the project store, which re-renders here).
+  // The status icon's Retry keeps its own direct refresh — it re-captures from
+  // the cache WITHOUT a project-store write, so this observer never sees it.
+  const draftIsEmpty =
+    draft.input.trim() === "" &&
+    draft.images.length === 0 &&
+    draft.contextNotes.length === 0 &&
+    draft.queue.length === 0;
+  // Same signature the session manager dirty-tracks with (normalized sources +
+  // filePath), read from the live record. `projects` is a deliberate re-derive
+  // trigger — not read inside the factory, but a `useProjects()` change means the
+  // cached record (and thus its signature) may have changed.
+  const activeProjectContextSignature = useMemo(() => {
+    if (!isProjectScope) return null;
+    const record = getCachedProjectRecordById(activeProjectId);
+    return record ? getProjectContextSignature(record) : null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isProjectScope, activeProjectId, projects]);
+  useRefreshEmptyLandingOnContextSourceChange({
+    activeProjectId,
+    signature: activeProjectContextSignature,
+    isLanding,
+    blocking: contextLoadBlocking,
+    draftEmpty: draftIsEmpty,
+    refresh: refreshContextForEmptyLanding,
+  });
+
+  // Project landing lower-area placement: zero chats → the Context body renders
+  // standalone below the composer (no shelf); any chats → the tabbed shelf
+  // (Recent Chats / Context). Decided per landing VISIT (project + session) and
+  // latched, so in-visit churn can't swap the layout under the user:
+  //
+  // - Undecided until the scoped history load settles — rendering neither beats
+  //   flashing the wrong branch (e.g. mistaking "not loaded yet" for "no chats").
+  // - One-way upgrade standalone→shelf: the settle can be a stale list from the
+  //   previous visit (e.g. "New chat" right after a project's first
+  //   conversation), so a refresh that finds chats corrects the layout — that
+  //   flip lands within the visit's first moments, while the reverse
+  //   (shelf→standalone, e.g. deleting the last chat from the View-all popover
+  //   mid-visit) would yank the card out from under an open popover. The shelf
+  //   just shows the project empty copy until the next visit re-decides.
+  //
+  // Written during render — the same derive-from-props pattern as the header
+  // latch above.
+  const landingVisitKey = isProjectLanding ? `${activeProjectId}\0${sessionId}` : null;
+  const placementRef = useRef<{ key: string; standalone: boolean } | null>(null);
+  if (landingVisitKey === null) {
+    placementRef.current = null;
+  } else if (chatHistorySettled) {
+    const hasChats = chatHistoryItems.length > 0;
+    if (placementRef.current?.key !== landingVisitKey) {
+      placementRef.current = { key: landingVisitKey, standalone: !hasChats };
+    } else if (placementRef.current.standalone && hasChats) {
+      placementRef.current = { key: landingVisitKey, standalone: false };
+    }
+  } else if (placementRef.current?.key !== landingVisitKey) {
+    placementRef.current = null;
+  }
+  const projectPlacement = placementRef.current;
 
   // The session's main agent — the summarizer and the dedup anchor for
   // `@`-mentions. The composer belongs to the ACTIVE session, so anchor to its
@@ -236,11 +488,23 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const greeting = useMemo(() => pickRandomGreeting(), [sessionId]);
 
-  // Populate the Recent Chats list whenever the landing is shown (the
-  // conversation-state history popover loads on open via the same handler).
+  // Populate the chats list whenever a landing (global or per-project) is shown
+  // (the conversation-state history popover loads on open via the same handler).
+  // `handleLoadChatHistory` changes identity when the scope changes, so entering
+  // a project re-fetches its scoped chats here.
   useEffect(() => {
-    if (isGlobalLanding) void handleLoadChatHistory();
-  }, [isGlobalLanding, handleLoadChatHistory]);
+    if (isLanding) void handleLoadChatHistory();
+  }, [isLanding, handleLoadChatHistory]);
+
+  // Global shelf tab lives HERE (not in the shelf's own state) because the
+  // global shelf unmounts whenever the user leaves the global landing — into a
+  // project, or into a conversation and back via New Chat. This is deliberate
+  // instance-level UI memory: wherever the user left the global shelf, they
+  // return to it (entering a project from the Projects tab and backing out
+  // lands on Projects again instead of snapping to Recent Chats). AgentHome
+  // stays mounted across those switches, so the state survives. null = nothing
+  // picked yet → the shelf resolves to its first selectable tab.
+  const [globalShelfTab, setGlobalShelfTab] = useState<string | null>(null);
 
   // Chip-shelf sections for the landing. Each body renders lazily (only the open
   // section is mounted), so these render closures are cheap to recreate.
@@ -259,24 +523,24 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
             onDeleteChat={handleDeleteChat}
             onOpenSourceFile={handleOpenSourceFile}
             onLoadHistory={handleLoadChatHistory}
+            runningChatIds={runningChatIds}
+            attentionChatIds={attentionChatIds}
           />
         ),
       },
       {
-        // Projects isn't shipped yet: greyed on the right, "Coming soon" on
-        // hover, and its list never mounts (the shelf won't make a disabled
-        // tab active). Kept wired to ProjectPickerList for when selection lands.
         id: "projects",
         icon: <Folder className="tw-size-4" />,
         title: "Projects",
         count: projects.length,
-        disabled: true,
-        disabledTooltip: "Coming soon",
         renderBody: () => (
           <ProjectPickerList
             projects={projects}
-            onSelect={handleProjectComingSoon}
-            onCreate={handleProjectComingSoon}
+            onSelect={handleSelectProject}
+            onCreate={handleCreateProject}
+            app={app}
+            onProjectDeleted={handleProjectDeleted}
+            projectUsageTimestampsManager={projectUsageManager}
           />
         ),
       },
@@ -284,136 +548,362 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
     [
       projects,
       chatHistoryItems,
-      handleProjectComingSoon,
+      app,
+      projectUsageManager,
+      handleSelectProject,
+      handleCreateProject,
+      handleProjectDeleted,
       handleLoadChat,
       handleUpdateChatTitle,
       handleDeleteChat,
       handleOpenSourceFile,
       handleLoadChatHistory,
+      runningChatIds,
+      attentionChatIds,
     ]
   );
 
+  // Context tab count, computed here because the tab chip must show it while
+  // the tab body is unmounted (the shelf mounts only the active tab). Pure
+  // derivation from the cached record, so edits/drops keep it live.
+  const contextSummary = useMemo(() => buildContextSummary(activeProject), [activeProject]);
+
+  // Per-project landing shelf: the same tabbed card as the global landing, with
+  // scoped sections — Recent Chats first (default tab, identical to the global
+  // tab of the same name, just scoped; chat creation belongs to the tab strip's "+"
+  // on both landings), then the project Context body. Only rendered once the
+  // project has chats; a zero-chat project gets the standalone Context body
+  // instead (see projectPlacement above).
+  const projectLandingSections = useMemo<AgentHomeShelfSection[]>(
+    () => [
+      {
+        id: "project-chats",
+        icon: <MessageSquare className="tw-size-4" />,
+        title: "Recent Chats",
+        count: chatHistoryItems.length,
+        renderBody: () => (
+          <GlobalRecentChatsSection
+            items={chatHistoryItems}
+            variant="project"
+            onLoadChat={handleLoadChat}
+            onUpdateTitle={handleUpdateChatTitle}
+            onDeleteChat={handleDeleteChat}
+            onOpenSourceFile={handleOpenSourceFile}
+            onLoadHistory={handleLoadChatHistory}
+            runningChatIds={runningChatIds}
+            attentionChatIds={attentionChatIds}
+          />
+        ),
+      },
+      {
+        id: "project-context",
+        icon: <Files className="tw-size-4" />,
+        title: "Context",
+        count: contextSummary.totalItems,
+        renderBody: () => (
+          <AgentContextSection app={app} projectId={activeProjectId} popoverContainer={rootEl} />
+        ),
+      },
+    ],
+    [
+      chatHistoryItems,
+      contextSummary.totalItems,
+      app,
+      activeProjectId,
+      rootEl,
+      handleLoadChat,
+      handleUpdateChatTitle,
+      handleDeleteChat,
+      handleOpenSourceFile,
+      handleLoadChatHistory,
+      runningChatIds,
+      attentionChatIds,
+    ]
+  );
+
+  // One composer element, shared by all three surfaces. The project-scope props
+  // drive the send-gate: `activeProjectId` + `contextLoadBlocking` make a send
+  // queue-and-hold while context materializes; `disabled` hard-stops sends when
+  // the active project is orphaned.
+  // Project-context status icon for the composer's badge row. Only a real
+  // (non-orphaned) project scope has context to report; global + orphaned omit it.
+  // `onEditContext` opens the Manage Context modal (the same link/file/tag
+  // manager as the Context tab's Manage button), so the status popover edits
+  // context sources directly rather than detouring through the full Edit Project
+  // form. `onReindex` forces a re-materialization past the failure cache and
+  // calls `refreshContextForEmptyLanding` directly (it re-captures from the
+  // cache without a project-store write, so the source observer never sees it).
+  // `onEditContext`'s save, by contrast, writes the project store and lets the
+  // observer refresh the landing — so it must NOT also refresh directly.
+  const openProjectManageModal = () => {
+    if (!activeProject) return;
+    new ContextManageModal(
+      app,
+      (updated) => {
+        // The save writes through the project store, which the landing's
+        // context-source observer ({@link useRefreshEmptyLandingOnContextSourceChange})
+        // watches — so it refreshes the empty landing on its own. No direct
+        // refresh here, or the store update and this call would each fire a
+        // replaceSessionInPlace (double refresh).
+        void ProjectFileManager.getInstance(app)
+          .updateProject(activeProjectId, updated)
+          .catch((err) => logError("[AgentMode] save context changes failed", err));
+      },
+      activeProject,
+      { enableLinks: true }
+    ).open();
+  };
+
+  const contextStatusIndicator =
+    isProjectScope && !isOrphanedProject && activeProject ? (
+      <AgentContextStatusIcon
+        app={app}
+        activeProjectId={activeProjectId}
+        project={activeProject}
+        hasConfiguredContextSource={!contextSummary.isEmpty}
+        landing={isLanding}
+        onReindex={() => manager.rematerializeContext(activeProjectId)}
+        onRetryItem={(item) =>
+          manager
+            .rematerializeSource(activeProjectId, {
+              kind: item.cacheKind,
+              source: item.id,
+            })
+            .catch((e) => {
+              logError("[AgentMode] retry source failed", e);
+              return false;
+            })
+        }
+        // The status icon defers this to popover-close so a retry's completion
+        // can't swap the session and yank the popover shut mid-inspection.
+        onRefreshLanding={refreshContextForEmptyLanding}
+        onEditContext={openProjectManageModal}
+      />
+    ) : undefined;
+
+  const composerNode = (
+    <AgentChatInput
+      backend={backend}
+      sessionId={sessionId}
+      draft={draft}
+      app={app}
+      mainAgentId={mainAgentId}
+      updateUserMessageHistory={updateUserMessageHistory}
+      isStarting={isStarting}
+      hasPendingPlanPermission={hasPendingPlanPermission}
+      modelPickerOverride={modelPickerOverride ?? undefined}
+      modePickerOverride={modePickerOverride ?? undefined}
+      onCycleMode={handleCycleMode}
+      activeProjectId={activeProjectId}
+      contextLoadBlocking={contextLoadBlocking}
+      disabled={isOrphanedProject}
+      contextStatusIndicator={contextStatusIndicator}
+    />
+  );
+
+  // Hero: a single title line above the composer — the rotating greeting
+  // (global) or "Chat in <project>" (project landing). An orphaned scope falls
+  // back to the neutral greeting so no "Chat in" line renders against a blank
+  // name. The project landing carries no subtitle: just the title.
+  const showProjectHero = isProjectLanding && !isOrphanedProject;
+  const heroText = showProjectHero ? `Chat in ${projectName}` : greeting;
+  const hero = (
+    <div className="tw-flex tw-min-w-0 tw-items-center tw-justify-center tw-gap-3">
+      <CopilotBrandIcon className="tw-size-4 tw-shrink-0 tw-text-normal" />
+      {/* font-[330]: deliberate hero weight, a hair lighter than `font-normal`
+          (400) for the airy greeting. The project's named weight tokens have no
+          slot between light and normal, so this is an intentional one-off. (The
+          "no arbitrary values" rule targets font sizes, not weights.) Promote to
+          a named token if another weight like this appears.
+
+          TruncatedText (not flex-1) so a long project name ellipsizes with a
+          full-text tooltip while a short title keeps the icon+text pair
+          centered — flex-1 would stretch the text box and break the centering. */}
+      <TruncatedText
+        className="tw-min-w-0 tw-text-ui-title tw-font-[330] tw-text-normal"
+        tooltipContent={heroText}
+      >
+        {heroText}
+      </TruncatedText>
+    </div>
+  );
+
   return (
-    <div className="tw-flex tw-size-full tw-flex-col tw-overflow-hidden">
+    <div ref={setRootEl} className="tw-flex tw-size-full tw-flex-col tw-overflow-hidden">
+      {/* Project header sits ABOVE the tab strip: a project scope is just the
+          global layout (tab strip → landing/conversation) with the project
+          header prepended on top. It spans BOTH the project landing and the
+          in-project conversation so sending the first message never drops the
+          project scope from view.
+
+          It animates open/closed on scope change instead of popping: the grid
+          row transitions 1fr↔0fr over an overflow-hidden child, so the header's
+          auto height collapses smoothly and the tab strip + content below slide
+          with it. Kept mounted (not conditionally rendered) so BOTH enter and
+          exit animate; collapsed it's a 0-height, hidden, non-interactive row —
+          visually identical to absent, so the global layout is unchanged. */}
+      <div
+        className={cn(
+          "tw-grid tw-shrink-0 tw-transition-[grid-template-rows,opacity] tw-duration-200 tw-ease-out motion-reduce:tw-transition-none",
+          isProjectScope
+            ? "tw-grid-rows-[1fr] tw-opacity-100"
+            : "tw-pointer-events-none tw-grid-rows-[0fr] tw-opacity-0"
+        )}
+        aria-hidden={!isProjectScope}
+      >
+        <div className="tw-min-h-0 tw-overflow-hidden">
+          <AgentProjectHeader
+            projectId={headerProjectId}
+            projectName={headerName}
+            onExit={handleExitProject}
+            orphaned={headerOrphaned}
+            menu={
+              activeProject ? (
+                <ProjectInfoPopover
+                  app={app}
+                  project={activeProject}
+                  todoList={currentTodoList}
+                  // The header sits OUTSIDE chatContainerRef, so the popover
+                  // portals into the AgentHome root for popout correctness.
+                  container={rootEl}
+                />
+              ) : undefined
+            }
+          />
+        </div>
+      </div>
       <AgentTabStrip manager={manager} />
+      {createAnchor && (
+        <CreateProjectPanel
+          anchorEl={createAnchor}
+          onClose={() => setCreateAnchor(null)}
+          onSave={persistCreateProject}
+        />
+      )}
       <div className="tw-min-h-0 tw-flex-1">
         <div ref={chatContainerRef} className="tw-flex tw-size-full tw-flex-col tw-overflow-hidden">
           <div className="tw-h-full">
             <div className="tw-relative tw-flex tw-h-full tw-flex-col">
               {isDragActive && (
-                <div className="tw-absolute tw-inset-0 tw-z-modal tw-flex tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-dashed tw-bg-primary tw-opacity-80">
+                // pointer-events-none: this is visual feedback only — if the
+                // overlay caught events, every dragover after the first would
+                // target it and inner drop zones (the project context section)
+                // would become unreachable.
+                <div className="tw-pointer-events-none tw-absolute tw-inset-0 tw-z-modal tw-flex tw-items-center tw-justify-center tw-rounded-md tw-border tw-border-dashed tw-bg-primary tw-opacity-80">
                   <span>Drop files here...</span>
                 </div>
               )}
-              {/* Composer is a position-stable node at a fixed sibling index;
-                  the surrounding slots toggle so it slides from centered (global
-                  landing) to bottom (conversation) without remounting and losing
-                  the draft. On the landing the column scrolls as one unit and the
-                  flex spacers above/below the composer keep it centered (biased
-                  lower) while the section titles stay at their natural height
-                  (never compressed in a narrow sidebar); in the conversation
-                  state the transcript takes the flex space and the composer sits
-                  at the bottom. The landing column carries one shared horizontal
-                  padding (`tw-px-2`) so the composer's border and the section
-                  rows share the same left/right edge — inner elements add no
-                  extra horizontal padding of their own. */}
+              {/* Two surfaces share this padded, scrollable column: a landing
+                  (global or per-project, laid out by AgentLandingStack —
+                  top-anchored composer over a tabbed shelf) and the conversation
+                  (transcript + controls + bottom composer). The shared `tw-px-2`
+                  keeps the composer border and shelf rows on one left/right edge,
+                  so inner elements add no horizontal padding of their own.
+
+                  The composer (`composerNode`) is the same element in both
+                  branches but sits at different tree positions, so it remounts on
+                  the landing→conversation flip. That flip only fires right after
+                  a send (which already reset the draft) or on a chat load (which
+                  changes `sessionId` and remounts anyway); the per-session draft
+                  lives in AgentHome and survives. CAUTION: the flip happens
+                  DURING the first turn, so the unmounting composer instance still
+                  has an in-flight `runSend` — anything that turn must do on
+                  completion (clearing `draft.loading`) MUST NOT be gated on the
+                  composer still being mounted (see runSend's finally). */}
               <div
                 className={
-                  // Landing: overflow-y-auto, not hidden. With room, the flex
-                  // spacers fill the column exactly so no scrollbar shows; on a
-                  // pane too short to fit the status/title/composer stack the
-                  // column scrolls instead of clipping them out of reach (small
-                  // Obsidian splits / popouts). Conversation: the transcript owns
-                  // its own scroll, so this stays hidden.
-                  isGlobalLanding
+                  // Landing: overflow-y-auto, not hidden — the h-1/4 spacer +
+                  // flex-1 shelf fill the column exactly when there's room, and on
+                  // a pane too short to fit the stack the column scrolls instead of
+                  // clipping it out of reach. Conversation: the transcript owns its
+                  // own scroll, so this stays hidden.
+                  isLanding
                     ? "tw-flex tw-size-full tw-flex-col tw-overflow-y-auto tw-px-2"
                     : "tw-flex tw-size-full tw-flex-col tw-overflow-hidden"
                 }
-                data-agent-landing={isGlobalLanding ? "global" : "conversation"}
+                data-agent-landing={
+                  isProjectLanding ? "project" : isLanding ? "global" : "conversation"
+                }
               >
                 <AgentModeStatus manager={manager} plugin={plugin} onInstallClick={handleInstall} />
-                {isGlobalLanding ? (
-                  <>
-                    {/* Top spacer at a FIXED fraction of the column height
-                        (h-1/4), not a flex grow. This top-anchors the composer:
-                        the spacer is a percentage of the (constant) column
-                        height, so it stays put when the composer's own height
-                        changes — e.g. removing the active-note context chip. A
-                        flex spacer would instead re-divide the freed space and
-                        push the greeting + composer down (the "top drops" we want
-                        to avoid). The lower shelf region (flex-1) absorbs the
-                        change instead, so the composer's lower half and the shelf
-                        collapse upward while the greeting stays fixed. */}
-                    <div className="tw-h-1/4 tw-shrink-0" />
-                    <div className="tw-shrink-0 tw-pb-7">
-                      <div className="tw-flex tw-items-center tw-justify-center tw-gap-3">
-                        <CopilotBrandIcon className="tw-size-4 tw-text-normal" />
-                        {/* font-[330]: deliberate hero weight, a hair lighter than
-                            `font-normal` (400) for the airy greeting. The project's
-                            named weight tokens have no slot between light and normal,
-                            so this is an intentional one-off. (The "no arbitrary
-                            values" rule targets font sizes, not weights.) Promote to a
-                            named token if another weight like this appears. */}
-                        <span className="tw-text-ui-title tw-font-[330] tw-text-normal">
-                          {greeting}
-                        </span>
-                      </div>
-                    </div>
-                  </>
+                {isLanding ? (
+                  <AgentLandingStack
+                    hero={hero}
+                    composer={composerNode}
+                    floating={
+                      // Global landing with no projects yet → the dismissible
+                      // Welcome card. (Project context status now lives on the
+                      // composer's status icon, not a floating load card.)
+                      !isProjectLanding &&
+                      projects.length === 0 &&
+                      !settings.agentMode.welcomeDismissed ? (
+                        <AgentWelcomeCard
+                          onCreate={handleCreateProject}
+                          onDismiss={handleDismissWelcome}
+                        />
+                      ) : undefined
+                    }
+                    context={
+                      // Zero-chat project landing: the Context body standalone
+                      // below the composer (mutually exclusive with the shelf;
+                      // see projectPlacement). Skipped for an orphaned id — the
+                      // body renders null for an unknown project and the
+                      // wrapper would leave a stray padded gap.
+                      isProjectLanding && !isOrphanedProject && projectPlacement?.standalone ? (
+                        <div className="tw-px-2 tw-pb-1 tw-pt-3">
+                          <AgentContextSection
+                            app={app}
+                            projectId={activeProjectId}
+                            popoverContainer={rootEl}
+                          />
+                        </div>
+                      ) : undefined
+                    }
+                    shelf={
+                      isProjectLanding ? (
+                        // Tabbed Recent Chats / Context card, only once the
+                        // project has chats. Keyed by project so the selected
+                        // tab resets instead of leaking across scope switches
+                        // (the global and project shelves share this slot).
+                        // null while the placement is undecided (history not
+                        // settled) or standalone — the stack drops the shelf
+                        // wrapper entirely so no empty gap remains.
+                        projectPlacement && !projectPlacement.standalone ? (
+                          <AgentHomeShelf key={activeProjectId} sections={projectLandingSections} />
+                        ) : null
+                      ) : (
+                        <AgentHomeShelf
+                          sections={landingSections}
+                          activeSectionId={globalShelfTab}
+                          onSectionSelect={setGlobalShelfTab}
+                        />
+                      )
+                    }
+                  />
                 ) : (
-                  <AgentChatMessages
-                    messages={messages}
-                    app={app}
-                    currentPlan={currentPlan}
-                    pendingToolPermissions={pendingToolPermissions}
-                    pendingAskUserQuestions={pendingAskUserQuestions}
-                    chatBackend={backend}
-                    isLoading={draft.loading}
-                  />
+                  <>
+                    <AgentChatMessages
+                      messages={messages}
+                      app={app}
+                      currentPlan={currentPlan}
+                      pendingToolPermissions={pendingToolPermissions}
+                      pendingAskUserQuestions={pendingAskUserQuestions}
+                      chatBackend={backend}
+                      isLoading={draft.loading}
+                    />
+                    <AgentChatControls
+                      onNewChat={handleNewChat}
+                      onSaveAsNote={handleSaveAsNote}
+                      chatHistoryItems={chatHistoryItems}
+                      onLoadHistory={handleLoadChatHistory}
+                      onLoadChat={handleLoadChat}
+                      onUpdateChatTitle={handleUpdateChatTitle}
+                      onDeleteChat={handleDeleteChat}
+                      onOpenSourceFile={handleOpenSourceFile}
+                    />
+                    {composerNode}
+                  </>
                 )}
-                {isGlobalLanding ? null : (
-                  <AgentChatControls
-                    onNewChat={handleNewChat}
-                    onSaveAsNote={handleSaveAsNote}
-                    chatHistoryItems={chatHistoryItems}
-                    onLoadHistory={handleLoadChatHistory}
-                    onLoadChat={handleLoadChat}
-                    onUpdateChatTitle={handleUpdateChatTitle}
-                    onDeleteChat={handleDeleteChat}
-                    onOpenSourceFile={handleOpenSourceFile}
-                  />
-                )}
-                <div className={isGlobalLanding ? "tw-shrink-0" : undefined}>
-                  <AgentChatInput
-                    backend={backend}
-                    sessionId={sessionId}
-                    draft={draft}
-                    app={app}
-                    mainAgentId={mainAgentId}
-                    updateUserMessageHistory={updateUserMessageHistory}
-                    isStarting={isStarting}
-                    hasPendingPlanPermission={hasPendingPlanPermission}
-                    modelPickerOverride={modelPickerOverride ?? undefined}
-                    modePickerOverride={modePickerOverride ?? undefined}
-                    onCycleMode={handleCycleMode}
-                  />
-                </div>
-                {isGlobalLanding ? (
-                  /* Lower region below the composer holds the tabbed shelf
-                     (Projects / Recent Chats). flex-1 so it absorbs every change
-                     in the composer's height: when the composer shrinks (e.g. the
-                     context chip is removed) this region grows and its top-aligned
-                     card moves up — the composer above stays top-anchored. The
-                     shelf is a persistent card that sizes to its content and sits
-                     at the top of this region. This region owns no scroll of its
-                     own — on a pane too short to fit the card, the card caps to the
-                     region height (min-h-0 chain) and scrolls its list internally,
-                     keeping the tab bar in reach. No extra horizontal padding so
-                     the card lines up with the composer's border. */
-                  <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-pt-6">
-                    <AgentHomeShelf sections={landingSections} />
-                  </div>
-                ) : null}
               </div>
             </div>
           </div>

--- a/src/agentMode/ui/AgentHomeSection.tsx
+++ b/src/agentMode/ui/AgentHomeSection.tsx
@@ -24,8 +24,14 @@ import React, {
  * primitives.
  */
 
-/** Rows shown inline before the rest collapse behind the "View all" popover. */
-export const INLINE_LIMIT = 3;
+/**
+ * Rows shown inline before the rest collapse behind the "View all" popover.
+ * Shared by the Projects and Recent Chats shelf tabs so both preview the same
+ * number of rows — full tabs then land within ~10px of each other, which is
+ * what keeps switching tabs from jumping (the shelf floor only covers the
+ * short/empty end; see AgentHomeShelf.SHELF_BODY_FLOOR_CLASS).
+ */
+export const INLINE_LIMIT = 5;
 
 /**
  * Rows rendered per page in the View-all popover. The list grows by this much
@@ -36,7 +42,8 @@ const VIEW_ALL_PAGE_SIZE = 50;
 
 interface AgentHomeCreateRowProps {
   label: string;
-  onClick: () => void;
+  /** Receives the row's button element so a caller can anchor a popover to it. */
+  onClick: (anchor: HTMLElement) => void;
 }
 
 /**
@@ -53,7 +60,7 @@ export const AgentHomeCreateRow = memo(function AgentHomeCreateRow({
     <Button
       type="button"
       variant="ghost2"
-      onClick={onClick}
+      onClick={(e) => onClick(e.currentTarget)}
       aria-label={label}
       className="tw-h-auto tw-min-h-9 tw-w-full tw-justify-start tw-gap-2 tw-rounded-md tw-px-2 tw-py-1.5 hover:tw-bg-modifier-hover"
     >
@@ -87,6 +94,19 @@ interface AgentHomeListRowProps {
    * tile (tinted square + colored folder). Takes precedence over `icon`.
    */
   leading?: React.ReactNode;
+  /**
+   * Optional control that **replaces** the relative time on hover / keyboard
+   * focus — e.g. a project row's inline action cluster — mirroring the
+   * chat-history rows (the time is the resting right-edge element; the control
+   * takes its slot when the row is active). The row carries `tw-group`, so the
+   * swap is pure CSS: the time hides and this slot shows on `group-hover` /
+   * `group-focus-within`, plus `group-has-[[data-state=open]]` so any portaled
+   * popover a slot control opens stays visible after the pointer leaves.
+   * Pointer/keyboard events inside the
+   * slot are kept from bubbling to the row's `onClick`, so opening the menu never
+   * also fires the row action.
+   */
+  trailing?: React.ReactNode;
 }
 
 /**
@@ -103,13 +123,14 @@ export const AgentHomeListRow = memo(function AgentHomeListRow({
   indent = false,
   icon: Icon,
   leading,
+  trailing,
 }: AgentHomeListRowProps): React.ReactElement {
   return (
     <div
       role="button"
       tabIndex={0}
       className={cn(
-        "tw-flex tw-min-h-9 tw-w-full tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded-md tw-px-2 tw-py-1.5",
+        "tw-group tw-flex tw-min-h-9 tw-w-full tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded-md tw-px-2 tw-py-1.5",
         "tw-text-left tw-transition-colors hover:tw-bg-modifier-hover"
       )}
       onClick={onClick}
@@ -131,11 +152,31 @@ export const AgentHomeListRow = memo(function AgentHomeListRow({
         {label}
       </span>
       <span
-        className="tw-shrink-0 tw-whitespace-nowrap tw-text-xs tw-text-muted"
+        className={cn(
+          "tw-shrink-0 tw-whitespace-nowrap tw-text-xs tw-text-muted",
+          // Reason: only when a `trailing` control exists does it replace the
+          // time on hover/focus — a row without one keeps the time always shown.
+          trailing &&
+            "group-focus-within:tw-hidden group-hover:tw-hidden group-has-[[data-state=open]]:tw-hidden"
+        )}
         title={new Date(timeMs).toLocaleString()}
       >
         {formatCompactRelativeTime(timeMs)}
       </span>
+      {trailing && (
+        // Reason: the slot owns an independent control (e.g. an overflow menu),
+        // so stop pointer/keyboard events from bubbling to the row's onClick —
+        // otherwise opening the menu would also trigger the row action. Hidden at
+        // rest; takes the time's slot on hover/focus (or while its dropdown is
+        // open) so the row's right edge never shows both at once.
+        <span
+          className="tw-hidden tw-shrink-0 tw-items-center group-focus-within:tw-flex group-hover:tw-flex group-has-[[data-state=open]]:tw-flex"
+          onClick={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          {trailing}
+        </span>
+      )}
     </div>
   );
 });

--- a/src/agentMode/ui/AgentHomeShelf.test.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.test.tsx
@@ -9,13 +9,24 @@ beforeAll(() => {
   (window as unknown as { activeDocument: Document }).activeDocument = window.document;
 });
 
-function renderShelf(sections: AgentHomeShelfSection[]) {
+function renderShelf(
+  sections: AgentHomeShelfSection[],
+  controlled?: { activeSectionId: string | null; onSectionSelect?: (id: string) => void }
+) {
   return render(
     <TooltipProvider>
-      <AgentHomeShelf sections={sections} />
+      <AgentHomeShelf sections={sections} {...controlled} />
     </TooltipProvider>
   );
 }
+
+const projectsEnabled: AgentHomeShelfSection = {
+  id: "projects",
+  icon: <span />,
+  title: "Projects",
+  count: 5,
+  renderBody: () => <div>PROJECTS BODY</div>,
+};
 
 const chats: AgentHomeShelfSection = {
   id: "chats",
@@ -55,5 +66,28 @@ describe("AgentHomeShelf with a disabled section", () => {
     fireEvent.click(screen.getByRole("tab", { name: /Projects/ }));
     expect(screen.queryByText("PROJECTS BODY")).toBeNull();
     expect(screen.queryByText("CHATS BODY")).not.toBeNull();
+  });
+});
+
+describe("AgentHomeShelf controlled mode", () => {
+  it("renders the parent-selected section's body", () => {
+    renderShelf([chats, projectsEnabled], { activeSectionId: "projects" });
+    expect(screen.queryByText("PROJECTS BODY")).not.toBeNull();
+    expect(screen.queryByText("CHATS BODY")).toBeNull();
+  });
+
+  it("falls back to the first selectable section when nothing is picked yet (null)", () => {
+    renderShelf([chats, projectsEnabled], { activeSectionId: null });
+    expect(screen.queryByText("CHATS BODY")).not.toBeNull();
+  });
+
+  it("reports clicks via onSectionSelect instead of switching on its own", () => {
+    const onSectionSelect = jest.fn();
+    renderShelf([chats, projectsEnabled], { activeSectionId: "chats", onSectionSelect });
+    fireEvent.click(screen.getByRole("tab", { name: /Projects/ }));
+    expect(onSectionSelect).toHaveBeenCalledWith("projects");
+    // Controlled: the body only changes when the parent updates the prop.
+    expect(screen.queryByText("CHATS BODY")).not.toBeNull();
+    expect(screen.queryByText("PROJECTS BODY")).toBeNull();
   });
 });

--- a/src/agentMode/ui/AgentHomeShelf.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.tsx
@@ -46,8 +46,7 @@ interface AgentHomeShelfProps {
    * pairs elsewhere in this repo). Passing `activeSectionId` without
    * `onSectionSelect` yields a read-only tab bar, which is legal controlled
    * behavior, not a footgun worth a union type; the only controlled caller
-   * (AgentHome's global landing) passes both. If a future review flags the
-   * unpaired-props risk again, point them at this note.
+   * (AgentHome's global landing) passes both.
    */
   activeSectionId?: string | null;
   onSectionSelect?: (id: string) => void;

--- a/src/agentMode/ui/AgentHomeShelf.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.tsx
@@ -2,6 +2,16 @@ import { AgentHomeTab } from "@/agentMode/ui/AgentHomeTab";
 import { cn } from "@/lib/utils";
 import React, { useId, useState } from "react";
 
+/**
+ * Reserved floor for the shelf's panel body. Deliberately a *floor*, not an
+ * equal-height lock: full tabs (INLINE_LIMIT rows) all land within ~10px of
+ * each other naturally, and this floor just keeps short/empty lists from
+ * collapsing the card — the standard reserve-space-to-avoid-layout-shift
+ * pattern. AgentContextSection imports this for its standalone (no-shelf)
+ * rendering so the two surfaces can't drift.
+ */
+export const SHELF_BODY_FLOOR_CLASS = "tw-min-h-48";
+
 export interface AgentHomeShelfSection {
   /** Stable id used for tab selection. */
   id: string;
@@ -24,6 +34,23 @@ export interface AgentHomeShelfSection {
 interface AgentHomeShelfProps {
   sections: AgentHomeShelfSection[];
   className?: string;
+  /**
+   * Controlled selection: when provided (non-undefined), the parent owns the
+   * active tab and must update it via `onSectionSelect`. Used by the global
+   * landing so the selected tab survives this shelf unmounting while a project
+   * is open. Omit for the default uncontrolled behavior (project shelves,
+   * which deliberately reset per project via `key`).
+   *
+   * DESIGN NOTE: these are independent optionals, not a controlled/uncontrolled
+   * union — matching the Radix/standard React convention (and `value`/`onChange`
+   * pairs elsewhere in this repo). Passing `activeSectionId` without
+   * `onSectionSelect` yields a read-only tab bar, which is legal controlled
+   * behavior, not a footgun worth a union type; the only controlled caller
+   * (AgentHome's global landing) passes both. If a future review flags the
+   * unpaired-props risk again, point them at this note.
+   */
+  activeSectionId?: string | null;
+  onSectionSelect?: (id: string) => void;
 }
 
 /**
@@ -33,11 +60,26 @@ interface AgentHomeShelfProps {
  * section bodies are sized to lead with the same number of rows, so switching
  * tabs doesn't change the card height.
  */
-export function AgentHomeShelf({ sections, className }: AgentHomeShelfProps): React.ReactElement {
+export function AgentHomeShelf({
+  sections,
+  className,
+  activeSectionId,
+  onSectionSelect,
+}: AgentHomeShelfProps): React.ReactElement {
   // Default to (and only ever resolve to) the first selectable section — a
   // disabled tab can't be activated, so its body never mounts.
   const firstSelectable = sections.find((s) => !s.disabled) ?? null;
-  const [activeId, setActiveId] = useState<string | null>(firstSelectable?.id ?? null);
+  const [internalActiveId, setInternalActiveId] = useState<string | null>(
+    firstSelectable?.id ?? null
+  );
+  // Controlled when the parent passes `activeSectionId` (null counts as "parent
+  // owns it, nothing picked yet" and resolves to the first selectable below).
+  const isControlled = activeSectionId !== undefined;
+  const activeId = isControlled ? activeSectionId : internalActiveId;
+  const selectSection = (id: string) => {
+    if (!isControlled) setInternalActiveId(id);
+    onSectionSelect?.(id);
+  };
   const requested = sections.find((s) => s.id === activeId);
   const active = requested && !requested.disabled ? requested : firstSelectable;
   const panelId = useId();
@@ -79,14 +121,15 @@ export function AgentHomeShelf({ sections, className }: AgentHomeShelfProps): Re
             controlsId={panelId}
             disabled={section.disabled}
             disabledTooltip={section.disabledTooltip}
-            onClick={() => setActiveId(section.id)}
+            onClick={() => selectSection(section.id)}
           />
         ))}
       </div>
-      {/* The panel is the scroll container; the inner wrapper carries the fixed
-          min-height (create row + 3 item rows + "View all") so the card keeps the
-          same height across tabs and when a list is short/empty. With room the
-          card sizes to that content and sits at the top of the region; on a pane
+      {/* The panel is the scroll container; the inner wrapper carries the
+          min-height floor (SHELF_BODY_FLOOR_CLASS) so a short/empty list can't
+          collapse the card. It is also a flex column so a section can tw-grow
+          to fill the floor (centering its empty-state copy). With room the card
+          sizes to that content and sits at the top of the region; on a pane
           too short to fit it the card shrinks (min-h-0 on the card + min-h-0 here)
           and this panel scrolls its list internally while the tab bar stays
           pinned — instead of the card being clipped out of reach. The floor lives
@@ -98,7 +141,9 @@ export function AgentHomeShelf({ sections, className }: AgentHomeShelfProps): Re
         aria-labelledby={tabId(active.id)}
         className="tw-min-h-0 tw-overflow-y-auto"
       >
-        <div className="tw-min-h-48 tw-pb-1">{active.renderBody()}</div>
+        <div className={cn(SHELF_BODY_FLOOR_CLASS, "tw-flex tw-flex-col tw-pb-1")}>
+          {active.renderBody()}
+        </div>
       </div>
     </div>
   );

--- a/src/agentMode/ui/AgentLandingStack.tsx
+++ b/src/agentMode/ui/AgentLandingStack.tsx
@@ -1,0 +1,70 @@
+import React from "react";
+
+interface AgentLandingStackProps {
+  /** Brand icon + greeting (global) or "Chat in <project>" hero (project landing). */
+  hero: React.ReactNode;
+  /**
+   * The composer. Passed as a slot so the same `AgentChatInput` element the
+   * conversation state renders can sit at the frozen landing position.
+   */
+  composer: React.ReactNode;
+  /**
+   * Welcome card (global landing) OR context-load card (project landing) —
+   * mutually exclusive. Floats between the composer and the shelf.
+   */
+  floating?: React.ReactNode;
+  /**
+   * Standalone project Context body (the zero-chat project landing, where no
+   * shelf renders). Project landing only; sits below the floating slot.
+   */
+  context?: React.ReactNode;
+  /**
+   * Tabbed shelf (Recent Chats / Projects, or Project Chats / Context). Omitted
+   * on the zero-chat project landing, where the `context` slot renders instead —
+   * the wrapper (and its top padding) is skipped so no empty gap remains.
+   */
+  shelf?: React.ReactNode;
+}
+
+/**
+ * Pure layout for the Agent Home landing — both the global and per-project
+ * variants render through this so the mount order is frozen in one place:
+ * `hero → composer → [floating] → [context] → shelf`.
+ *
+ * The composer is **top-anchored**, not centered: a fixed-fraction (`h-1/4`)
+ * spacer pins it a quarter of the way down so its own height changes (e.g. a
+ * context chip appearing) don't shift it — the flex-1 shelf region below absorbs
+ * the slack instead. This matches the shipped global landing (decision #2550);
+ * the wireframe's vertically-centered hero is intentionally dropped.
+ *
+ * Presentational only: the parent owns the scrolling/padded column wrapper and
+ * feeds each slot.
+ */
+export function AgentLandingStack({
+  hero,
+  composer,
+  floating,
+  context,
+  shelf,
+}: AgentLandingStackProps): React.ReactElement {
+  return (
+    <>
+      <div className="tw-h-1/4 tw-shrink-0" />
+      <div className="tw-shrink-0 tw-pb-7">{hero}</div>
+      <div className="tw-shrink-0">{composer}</div>
+      {/* floating + context own their own padding (`tw-px-2 tw-pb-1`), so the
+          wrappers carry no padding of their own — when a slot's component
+          self-hides (e.g. the context-load card returning null once context is
+          ready) the `shrink-0` wrapper collapses to 0px instead of leaving a stray
+          gap above the shelf. Omitted entirely when the slot is empty, so the
+          global landing's DOM is unchanged. */}
+      {floating ? <div className="tw-shrink-0">{floating}</div> : null}
+      {context ? <div className="tw-shrink-0">{context}</div> : null}
+      {shelf ? (
+        <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-pt-6">{shelf}</div>
+      ) : null}
+    </>
+  );
+}
+
+export default AgentLandingStack;

--- a/src/agentMode/ui/AgentModeChat.test.tsx
+++ b/src/agentMode/ui/AgentModeChat.test.tsx
@@ -1,0 +1,98 @@
+import { AgentModeChat } from "@/agentMode/ui/AgentModeChat";
+import { GLOBAL_SCOPE } from "@/agentMode/session/scope";
+import type { AgentSession } from "@/agentMode/session/AgentSession";
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import type CopilotPlugin from "@/main";
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+
+// Stub the descriptor hooks so the effect's `preloadReady`/install gates are
+// satisfied without the real backend registry / jotai atoms. The mock factory
+// names must match the real `use*` exports, so the no-hook `use` prefix is
+// expected here.
+/* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
+jest.mock("@/agentMode/ui/useBackendDescriptor", () => ({
+  useActiveBackendDescriptor: () => ({ id: "claude", openInstallUI: jest.fn() }),
+  useBackendInstallState: () => ({ kind: "installed" }),
+}));
+/* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
+
+// Heavy children are irrelevant to the auto-spawn guard — render nothing.
+jest.mock("@/agentMode/ui/AgentHome", () => ({ AgentHome: () => null }));
+jest.mock("@/agentMode/ui/AgentModeStatus", () => ({ AgentModeStatus: () => null }));
+jest.mock("@/agentMode/ui/AgentChatControls", () => ({ AgentChatControls: () => null }));
+
+const session = (id: string): AgentSession => ({ internalId: id }) as unknown as AgentSession;
+
+interface ManagerStub {
+  activeProjectId: string;
+  scopeSessions: AgentSession[];
+  poolSessions: AgentSession[];
+}
+
+function makeManager({ activeProjectId, scopeSessions, poolSessions }: ManagerStub) {
+  const getOrCreateActiveSession = jest.fn(async () => session("spawned"));
+  const manager = {
+    subscribe: jest.fn(() => () => {}),
+    isPreloadReady: jest.fn(() => true),
+    getSessions: jest.fn(() => poolSessions),
+    getSessionsForScope: jest.fn(() => scopeSessions),
+    getActiveProjectId: jest.fn(() => activeProjectId),
+    getIsStarting: jest.fn(() => false),
+    getLastError: jest.fn(() => null),
+    getActiveSession: jest.fn(() => null),
+    getActiveChatUIState: jest.fn(() => null),
+    getOrCreateActiveSession,
+  } as unknown as AgentSessionManager & { getOrCreateActiveSession: jest.Mock };
+  return { manager, getOrCreateActiveSession };
+}
+
+function renderChat(manager: AgentSessionManager) {
+  const plugin = { app: {}, agentSessionManager: manager } as unknown as CopilotPlugin;
+  return render(
+    <AgentModeChat plugin={plugin} onSaveChat={() => {}} updateUserMessageHistory={() => {}} />
+  );
+}
+
+describe("AgentModeChat auto-spawn guard (scope-aware)", () => {
+  it("regression: spawns the current project scope's session even when another scope still has sessions", async () => {
+    // The closed scope (project-1) is empty, but the global pool still holds a
+    // session. A whole-pool guard would skip the spawn and strand the pane on
+    // the no-session fallback; the scope-aware guard must re-spawn project-1.
+    const { manager, getOrCreateActiveSession } = makeManager({
+      activeProjectId: "project-1",
+      scopeSessions: [],
+      poolSessions: [session("global-1")],
+    });
+
+    renderChat(manager);
+
+    await waitFor(() => expect(getOrCreateActiveSession).toHaveBeenCalledTimes(1));
+  });
+
+  it("spawns the global scope's session when global is empty but a project still has sessions", async () => {
+    const { manager, getOrCreateActiveSession } = makeManager({
+      activeProjectId: GLOBAL_SCOPE,
+      scopeSessions: [],
+      poolSessions: [session("project-1-s1")],
+    });
+
+    renderChat(manager);
+
+    await waitFor(() => expect(getOrCreateActiveSession).toHaveBeenCalledTimes(1));
+  });
+
+  it("does not spawn when the current scope already has a session (single-scope behavior unchanged)", async () => {
+    const { manager, getOrCreateActiveSession } = makeManager({
+      activeProjectId: GLOBAL_SCOPE,
+      scopeSessions: [session("global-1")],
+      poolSessions: [session("global-1")],
+    });
+
+    renderChat(manager);
+
+    // Flush effects, then assert the guard short-circuited.
+    await waitFor(() => expect(manager.getSessionsForScope).toHaveBeenCalled());
+    expect(getOrCreateActiveSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/agentMode/ui/AgentModeChat.tsx
+++ b/src/agentMode/ui/AgentModeChat.tsx
@@ -53,7 +53,14 @@ export const AgentModeChat: React.FC<Props> = ({
   React.useEffect(() => {
     if (!manager) return;
     if (!preloadReady) return;
-    if (manager.getSessions().length > 0) return;
+    // Gate on the *current scope's* sessions, not the whole pool: closing the
+    // last session in a scope (project or global) nulls the active session but
+    // keeps `activeProjectId` put, so we must re-spawn that scope's landing even
+    // when another scope still holds sessions. A whole-pool guard would leave the
+    // pane on the no-session fallback instead of the scope's landing.
+    // `getOrCreateActiveSession` is scope-aware and the manager de-dupes per
+    // scope, so this can't double-spawn.
+    if (manager.getSessionsForScope(manager.getActiveProjectId()).length > 0) return;
     if (manager.getIsStarting()) return;
     if (manager.getLastError()) return;
     if (installState.kind === "absent") return;

--- a/src/agentMode/ui/AgentProjectCreateForm.test.tsx
+++ b/src/agentMode/ui/AgentProjectCreateForm.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  AgentProjectCreateForm,
+  makeNewProjectConfig,
+} from "@/agentMode/ui/AgentProjectCreateForm";
+
+beforeAll(() => {
+  // jsdom's `crypto` has no `randomUUID`; `makeNewProjectConfig` needs it. Use a
+  // counter so each call is unique (the real runtime is Electron/Obsidian).
+  const cryptoObj = window.crypto as { randomUUID?: () => string };
+  if (typeof cryptoObj.randomUUID !== "function") {
+    let counter = 0;
+    cryptoObj.randomUUID = () => `00000000-0000-4000-8000-${String(++counter).padStart(12, "0")}`;
+  }
+});
+
+function renderForm(props: Partial<React.ComponentProps<typeof AgentProjectCreateForm>> = {}) {
+  const onSave = props.onSave ?? jest.fn().mockResolvedValue(undefined);
+  const onCancel = props.onCancel ?? jest.fn();
+  render(<AgentProjectCreateForm {...props} onSave={onSave} onCancel={onCancel} />);
+  return { onSave, onCancel };
+}
+
+describe("AgentProjectCreateForm", () => {
+  it("disables Create until a name is entered", () => {
+    renderForm();
+    const create = screen.getByText("Create").closest("button") as HTMLButtonElement;
+    expect(create.disabled).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText("Project name"), {
+      target: { value: "  Research  " },
+    });
+    expect(create.disabled).toBe(false);
+  });
+
+  it("saves the trimmed name", async () => {
+    const { onSave } = renderForm();
+    fireEvent.change(screen.getByPlaceholderText("Project name"), {
+      target: { value: "  Research  " },
+    });
+    fireEvent.click(screen.getByText("Create"));
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ name: "Research" }));
+  });
+
+  it("submits on Enter from the name field", async () => {
+    const { onSave } = renderForm();
+    const input = screen.getByPlaceholderText("Project name");
+    fireEvent.change(input, { target: { value: "Research" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(onSave).toHaveBeenCalledWith({ name: "Research" }));
+  });
+
+  it("cancels without saving", () => {
+    const { onCancel, onSave } = renderForm();
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});
+
+describe("makeNewProjectConfig", () => {
+  it("builds a name-only config with the Agent-Mode-empty defaults", () => {
+    const project = makeNewProjectConfig("Research");
+    expect(project.name).toBe("Research");
+    // Agent Mode never reads the CAG model selector → left empty, not defaulted.
+    expect(project.systemPrompt).toBe("");
+    expect(project.projectModelKey).toBe("");
+    expect(project.modelConfigs).toEqual({});
+    expect(project.contextSource).toEqual({
+      inclusions: "",
+      exclusions: "",
+      webUrls: "",
+      youtubeUrls: "",
+    });
+    expect(project.created).toBe(project.UsageTimestamps);
+    expect(typeof project.created).toBe("number");
+  });
+
+  it("assigns a unique id per call", () => {
+    expect(makeNewProjectConfig("A").id).not.toBe(makeNewProjectConfig("A").id);
+  });
+});

--- a/src/agentMode/ui/AgentProjectCreateForm.tsx
+++ b/src/agentMode/ui/AgentProjectCreateForm.tsx
@@ -1,0 +1,119 @@
+import { ProjectConfig } from "@/aiParams";
+import { Button } from "@/components/ui/button";
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { err2String, randomUUID } from "@/utils";
+import { Notice } from "obsidian";
+import React, { useState } from "react";
+
+interface AgentProjectCreateFormProps {
+  /**
+   * Optional card title + one-line subtitle. The anchored create panel renders
+   * the form as a titled card (design B.1); when `title` is set the name input
+   * drops its "Name" label, since the subtitle already prompts for it.
+   */
+  title?: string;
+  subtitle?: string;
+  /** Resolve to close the panel; reject to surface a Notice and stay open. */
+  onSave: (data: { name: string }) => Promise<void>;
+  onCancel: () => void;
+}
+
+/**
+ * Name-only "new project" form body, hosted by the anchored create panel
+ * ({@link CreateProjectPanel}). Full project editing lives in AddProjectModal
+ * (agent variant) — this form only creates. Exported for unit tests; the caller
+ * owns persistence (mapping the name onto a {@link ProjectConfig}).
+ */
+export function AgentProjectCreateForm({
+  title,
+  subtitle,
+  onSave,
+  onCancel,
+}: AgentProjectCreateFormProps): React.ReactElement {
+  const [name, setName] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const canSave = name.trim().length > 0 && !isSaving;
+
+  const handleSave = async () => {
+    if (name.trim().length === 0 || isSaving) return;
+    setIsSaving(true);
+    try {
+      await onSave({ name: name.trim() });
+    } catch (e) {
+      // Reason: createProject rejects on duplicate name etc. — keep the panel
+      // open so the user can correct the field instead of losing input.
+      new Notice(err2String(e));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const nameInput = (
+    <Input
+      type="text"
+      value={name}
+      onChange={(e) => setName(e.target.value)}
+      placeholder="Project name"
+      autoFocus
+      onKeyDown={(e) => {
+        // Enter submits straight from the single name field.
+        if (e.key === "Enter") {
+          e.preventDefault();
+          void handleSave();
+        }
+      }}
+      className="tw-w-full"
+    />
+  );
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-4">
+      {title && (
+        <div className="tw-flex tw-flex-col tw-gap-1">
+          <div className="tw-text-base tw-font-semibold tw-text-normal">{title}</div>
+          {subtitle && <div className="tw-text-sm tw-text-muted">{subtitle}</div>}
+        </div>
+      )}
+      {/* With a title card (create panel) the subtitle is the prompt, so the
+          input drops the redundant "Name" label; otherwise keep the field. */}
+      {title ? (
+        nameInput
+      ) : (
+        <FormField label="Name" required>
+          {nameInput}
+        </FormField>
+      )}
+
+      <div className="tw-flex tw-justify-end tw-gap-2">
+        <Button variant="secondary" onClick={onCancel} disabled={isSaving}>
+          Cancel
+        </Button>
+        <Button variant="default" onClick={() => void handleSave()} disabled={!canSave}>
+          {isSaving ? "Saving..." : "Create"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Build a fresh, valid {@link ProjectConfig} for a name-only create. Agent Mode
+ * ignores the CAG model selector, so it's left empty rather than forcing a
+ * meaningless choice at creation time. The single source of truth for the
+ * new-project shape, used by the anchored create panel (`CreateProjectPanel`).
+ */
+export function makeNewProjectConfig(name: string): ProjectConfig {
+  const now = Date.now();
+  return {
+    id: randomUUID(),
+    name,
+    systemPrompt: "",
+    projectModelKey: "",
+    modelConfigs: {},
+    contextSource: { inclusions: "", exclusions: "", webUrls: "", youtubeUrls: "" },
+    created: now,
+    UsageTimestamps: now,
+  };
+}

--- a/src/agentMode/ui/AgentProjectHeader.test.tsx
+++ b/src/agentMode/ui/AgentProjectHeader.test.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { AgentProjectHeader } from "@/agentMode/ui/AgentProjectHeader";
+
+// TruncatedText's Radix tooltip portals into Obsidian's `activeDocument` global,
+// which jsdom doesn't provide — alias it to the test document.
+beforeAll(() => {
+  (window as unknown as { activeDocument: Document }).activeDocument = window.document;
+});
+
+// TruncatedText renders a tooltip trigger, so wrap in the provider it expects.
+function renderHeader(props: Partial<React.ComponentProps<typeof AgentProjectHeader>> = {}) {
+  const onExit = props.onExit ?? jest.fn();
+  const menu = "menu" in props ? props.menu : <button type="button" aria-label="Project options" />;
+  render(
+    <TooltipProvider>
+      <AgentProjectHeader
+        projectId={props.projectId ?? "demo-project"}
+        projectName={props.projectName ?? "Demo"}
+        onExit={onExit}
+        menu={menu}
+        orphaned={props.orphaned}
+      />
+    </TooltipProvider>
+  );
+  return { onExit };
+}
+
+describe("AgentProjectHeader", () => {
+  it("shows the live project name", () => {
+    renderHeader({ projectName: "My Research" });
+    expect(screen.getByText("My Research")).toBeTruthy();
+  });
+
+  it("exits the project when the back affordance is clicked", () => {
+    const { onExit } = renderHeader();
+    fireEvent.click(screen.getByRole("button", { name: "Leave project" }));
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the provided options menu in the trailing slot", () => {
+    renderHeader({ menu: <button type="button" aria-label="Project options" /> });
+    expect(screen.getByLabelText("Project options")).toBeTruthy();
+  });
+
+  it("degrades to an escape hatch when the project is orphaned", () => {
+    const { onExit } = renderHeader({ projectName: "Gone", orphaned: true });
+    // No stale name or options menu pointing at a deleted project.
+    expect(screen.queryByText("Gone")).toBeNull();
+    expect(screen.queryByLabelText("Project options")).toBeNull();
+    expect(screen.getByText("This project no longer exists")).toBeTruthy();
+    // The back affordance still works so the user can leave the dead scope.
+    fireEvent.click(screen.getByRole("button", { name: "Leave project" }));
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agentMode/ui/AgentProjectHeader.tsx
+++ b/src/agentMode/ui/AgentProjectHeader.tsx
@@ -1,0 +1,77 @@
+import { ProjectIconTile } from "@/agentMode/ui/ProjectIconTile";
+import { TruncatedText } from "@/components/TruncatedText";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ChevronLeft } from "lucide-react";
+import React, { memo } from "react";
+
+interface AgentProjectHeaderProps {
+  /** Stable project id — drives the identity tile's color (same hue as the Projects tab). */
+  projectId: string;
+  /** Live project name (read from `useProjects` by the parent so renames reflect). */
+  projectName: string;
+  /** Leave the project workspace back to the global scope. */
+  onExit: () => void;
+  /**
+   * Per-project options control (the `⋯` overflow menu: Edit / Reveal / Delete),
+   * rendered in the trailing slot. Passed as a node so this stays presentational
+   * — the parent owns the menu component and its handlers. Omitted when orphaned.
+   */
+  menu?: React.ReactNode;
+  /**
+   * The active project's record is gone (folder/`project.md` deleted while the
+   * user was inside it). Degrades to just the `‹` escape hatch — no stale
+   * name, tile, or menu pointing at a project that no longer exists.
+   */
+  orphaned?: boolean;
+  className?: string;
+}
+
+/**
+ * Thin workspace header shown above the chat surface whenever a project scope is
+ * active (both the project landing and an in-project conversation). Presentational
+ * only: the parent owns scope state and feeds the live `projectName`.
+ */
+export const AgentProjectHeader = memo(
+  ({
+    projectId,
+    projectName,
+    onExit,
+    menu,
+    orphaned = false,
+    className,
+  }: AgentProjectHeaderProps): React.ReactElement => (
+    <div className={cn("tw-flex tw-w-full tw-items-center tw-gap-1 tw-px-2 tw-py-1.5", className)}>
+      <Button
+        variant="ghost2"
+        size="sm"
+        onClick={onExit}
+        aria-label="Leave project"
+        title="Leave project"
+        className="tw-flex tw-shrink-0 tw-items-center tw-px-1.5 tw-text-muted hover:tw-text-normal"
+      >
+        <ChevronLeft className="tw-size-4" />
+      </Button>
+
+      {orphaned ? (
+        <span className="tw-min-w-0 tw-flex-1 tw-text-ui-small tw-text-muted">
+          This project no longer exists
+        </span>
+      ) : (
+        <>
+          <ProjectIconTile id={projectId} />
+          <TruncatedText
+            className="tw-min-w-0 tw-flex-1 tw-text-ui-small tw-font-medium tw-text-normal"
+            tooltipContent={projectName}
+          >
+            {projectName}
+          </TruncatedText>
+
+          {menu}
+        </>
+      )}
+    </div>
+  )
+);
+
+AgentProjectHeader.displayName = "AgentProjectHeader";

--- a/src/agentMode/ui/AgentProjectRowActions.tsx
+++ b/src/agentMode/ui/AgentProjectRowActions.tsx
@@ -1,0 +1,160 @@
+import { ProjectConfig } from "@/aiParams";
+import { AddProjectModal } from "@/components/modals/project/AddProjectModal";
+import { ConfirmModal } from "@/components/modals/ConfirmModal";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { logError } from "@/logger";
+import { getProjectFolderPath } from "@/projects/projectPaths";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { getCachedProjectRecordById } from "@/projects/state";
+import { FolderSearch, Pencil, Trash2 } from "lucide-react";
+import { App, Notice, TFolder } from "obsidian";
+import React, { memo } from "react";
+
+/**
+ * Reveal a project's folder in Obsidian's file explorer via the internal
+ * file-explorer plugin (same approach as the projects migration flow). Hidden
+ * (dot-prefixed) folders aren't in the vault cache, so reveal silently no-ops —
+ * surface a Notice instead of failing quietly.
+ */
+export function revealProjectFolder(app: App, project: ProjectConfig): void {
+  const record = getCachedProjectRecordById(project.id);
+  const folderPath = record ? getProjectFolderPath(record.folderName) : null;
+  const folder = folderPath ? app.vault.getAbstractFileByPath(folderPath) : null;
+  if (folder instanceof TFolder) {
+    const fileExplorer = (
+      app as unknown as {
+        internalPlugins?: {
+          getPluginById?: (
+            id: string
+          ) =>
+            | { enabled?: boolean; instance?: { revealInFolder?: (folder: TFolder) => void } }
+            | undefined;
+        };
+      }
+    ).internalPlugins?.getPluginById?.("file-explorer");
+    if (fileExplorer?.enabled && fileExplorer.instance?.revealInFolder) {
+      fileExplorer.instance.revealInFolder(folder);
+      return;
+    }
+  }
+  new Notice(`Can't reveal "${project.name}" — its folder isn't visible in the file explorer.`);
+}
+
+interface AgentProjectRowActionsProps {
+  app: App;
+  project: ProjectConfig;
+  /** Fired after a successful edit (caller refreshes its project list/cache). */
+  onEdited?: (project: ProjectConfig) => void;
+  /** Fired after a successful delete (caller may exit the scope if it was active). */
+  onDeleted?: (projectId: string) => void;
+  className?: string;
+}
+
+/**
+ * Inline action cluster for a project row: Reveal in vault · Edit · Delete.
+ * Drop into {@link AgentHomeListRow}'s `trailing` slot — the row reveals it on
+ * hover / keyboard focus in the relative time's place, the same way the Recent
+ * Chats rows surface their open / rename / delete buttons, so the two shelf tabs
+ * read as one component family (this replaces the older `⋯` overflow dropdown).
+ *
+ * Edit and Delete deliberately stay modal-backed rather than inline: Edit is a
+ * multi-field form (the full {@link AddProjectModal}), and Delete keeps the
+ * {@link ConfirmModal} whose copy reassures that the notes survive — a destructive
+ * project op warrants the heavier confirm than a chat's inline two-step. The
+ * persistence ops (`updateProject` / `deleteProject`) run here; the caller wires
+ * `onEdited` / `onDeleted` for follow-up (refresh, exit an orphaned scope).
+ *
+ * Each button stops propagation so reveal / edit / delete never also fires the
+ * row's open-project action. The trailing slot already guards this, but keeping
+ * it on the buttons leaves the cluster self-contained for reuse outside the row.
+ */
+export const AgentProjectRowActions = memo(
+  ({
+    app,
+    project,
+    onEdited,
+    onDeleted,
+    className,
+  }: AgentProjectRowActionsProps): React.ReactElement => {
+    const handleEdit = () => {
+      // Agent edit reuses the full project modal MINUS the model card + CAG
+      // processing status (agentMode). No `plugin` → no CAG retry affordances.
+      new AddProjectModal(
+        app,
+        async (next) => {
+          const updated = await ProjectFileManager.getInstance(app).updateProject(project.id, next);
+          onEdited?.(updated.project);
+        },
+        project,
+        undefined,
+        true
+      ).open();
+    };
+
+    const handleDelete = () => {
+      new ConfirmModal(
+        app,
+        async () => {
+          try {
+            await ProjectFileManager.getInstance(app).deleteProject(project.id);
+            onDeleted?.(project.id);
+          } catch (e) {
+            logError("[AgentProjectRowActions] deleteProject failed", e);
+            new Notice(`Failed to delete project "${project.name}".`);
+          }
+        },
+        `Delete project "${project.name}"? This removes its configuration; your notes stay in the vault.`,
+        "Delete project",
+        "Delete",
+        "Cancel"
+      ).open();
+    };
+
+    return (
+      <div className={cn("tw-flex tw-items-center tw-gap-1.5", className)}>
+        <Button
+          size="sm"
+          variant="ghost"
+          aria-label={`Reveal ${project.name} in vault`}
+          title="Reveal in vault"
+          className="tw-size-5 tw-p-0"
+          onClick={(e) => {
+            e.stopPropagation();
+            revealProjectFolder(app, project);
+          }}
+        >
+          <FolderSearch className="tw-size-3.5" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          aria-label={`Edit project ${project.name}`}
+          title="Edit project"
+          className="tw-size-5 tw-p-0"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleEdit();
+          }}
+        >
+          <Pencil className="tw-size-3.5" />
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          aria-label={`Delete project ${project.name}`}
+          title="Delete"
+          className="tw-size-5 tw-p-0 tw-text-error hover:tw-text-error"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleDelete();
+          }}
+        >
+          <Trash2 className="tw-size-3.5" />
+        </Button>
+      </div>
+    );
+  }
+);
+
+AgentProjectRowActions.displayName = "AgentProjectRowActions";

--- a/src/agentMode/ui/AgentTabStrip.tsx
+++ b/src/agentMode/ui/AgentTabStrip.tsx
@@ -126,7 +126,10 @@ export const AgentTabStrip: React.FC<Props> = ({ manager }) => {
   const [, setTick] = React.useState(0);
   React.useEffect(() => manager.subscribe(() => setTick((v) => v + 1)), [manager]);
 
-  const sessions = manager.getSessions();
+  // Scope the strip to the active workspace: a project shows only its own
+  // sessions, the global workspace shows the global ones. `getSessions()` stays
+  // reserved for whole-pool consumers (draft prune / auto-spawn), per §2.4.
+  const sessions = manager.getSessionsForScope(manager.getActiveProjectId());
   const activeId = manager.getActiveSession()?.internalId ?? null;
   const isCreating = manager.getIsStarting();
   const [renamingId, setRenamingId] = React.useState<string | null>(null);

--- a/src/agentMode/ui/AgentTrailView.tsx
+++ b/src/agentMode/ui/AgentTrailView.tsx
@@ -208,20 +208,23 @@ interface PlanPillProps {
 }
 
 // Inline plan-checklist pill for `kind: "plan"` parts. Permission-gated
-// plan proposals are handled separately by `PlanProposalCard`.
-const PlanPill: React.FC<PlanPillProps> = ({ entries }) => (
-  <div className="tw-my-1 tw-rounded tw-border tw-border-border tw-bg-secondary tw-px-2 tw-py-1">
-    <p className="tw-mb-1 tw-text-xs tw-text-muted">Plan</p>
-    <ul className="tw-flex tw-flex-col tw-gap-0.5 tw-text-sm">
-      {entries.map((e, i) => (
-        // eslint-disable-next-line @eslint-react/no-array-index-key -- plan entries are positional and may share content
-        <li key={`plan-${i}`} className="tw-flex tw-items-start tw-gap-2">
-          <span aria-hidden="true">{planEntryIcon(e.status)}</span>
-          <span className={planEntryClass(e.status)}>{e.content}</span>
-        </li>
-      ))}
-    </ul>
-  </div>
-);
+// plan proposals are handled separately by `PlanProposalCard`. An empty
+// entries list (the agent deleted every task) renders nothing, not an
+// empty shell.
+const PlanPill: React.FC<PlanPillProps> = ({ entries }) =>
+  entries.length === 0 ? null : (
+    <div className="tw-my-1 tw-rounded tw-border tw-border-border tw-bg-secondary tw-px-2 tw-py-1">
+      <p className="tw-mb-1 tw-text-xs tw-text-muted">Plan</p>
+      <ul className="tw-flex tw-flex-col tw-gap-0.5 tw-text-sm">
+        {entries.map((e, i) => (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- plan entries are positional and may share content
+          <li key={`plan-${i}`} className="tw-flex tw-items-start tw-gap-2">
+            <span aria-hidden="true">{planEntryIcon(e.status)}</span>
+            <span className={planEntryClass(e.status)}>{e.content}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 
 export default AgentTrail;

--- a/src/agentMode/ui/AgentWelcomeCard.test.tsx
+++ b/src/agentMode/ui/AgentWelcomeCard.test.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { AgentWelcomeCard } from "@/agentMode/ui/AgentWelcomeCard";
+
+describe("AgentWelcomeCard", () => {
+  it("renders the project nudge copy and a create CTA", () => {
+    render(<AgentWelcomeCard onCreate={jest.fn()} onDismiss={jest.fn()} />);
+    expect(screen.getByText("Try a project")).toBeTruthy();
+    expect(screen.getByText("New project")).toBeTruthy();
+  });
+
+  it("invokes onCreate when the CTA is clicked", () => {
+    const onCreate = jest.fn();
+    render(<AgentWelcomeCard onCreate={onCreate} onDismiss={jest.fn()} />);
+    fireEvent.click(screen.getByText("New project"));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onDismiss from the × control", () => {
+    const onDismiss = jest.fn();
+    render(<AgentWelcomeCard onCreate={jest.fn()} onDismiss={onDismiss} />);
+    fireEvent.click(screen.getByLabelText("Dismiss"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agentMode/ui/AgentWelcomeCard.tsx
+++ b/src/agentMode/ui/AgentWelcomeCard.tsx
@@ -1,0 +1,70 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { FolderPlus, Sparkles, X } from "lucide-react";
+import React, { memo } from "react";
+
+interface AgentWelcomeCardProps {
+  /** Start the name-only project creation flow, anchored to the trigger button. */
+  onCreate: (anchor: HTMLElement) => void;
+  /**
+   * Dismiss the card. The parent persists this to `agentMode.welcomeDismissed`
+   * so the nudge never returns; the card itself holds no dismissed state.
+   */
+  onDismiss: () => void;
+  className?: string;
+}
+
+/**
+ * "Try a project" nudge for the global Agent Home landing. The parent floats it
+ * between the composer and the shelf and only mounts it when no projects exist
+ * and `welcomeDismissed` is false — this component is pure presentation, owning
+ * neither the visibility condition nor the persisted dismissal (it just signals
+ * intent via {@link AgentWelcomeCardProps.onDismiss}).
+ *
+ * Visual authority: design-handoff stage A.1. We take its copy/layout but not the
+ * sketch styling (no orange "NEW" badge, no handwriting) — Obsidian theme vars +
+ * existing `tw-` tokens only.
+ */
+export const AgentWelcomeCard = memo(
+  ({ onCreate, onDismiss, className }: AgentWelcomeCardProps): React.ReactElement => (
+    <div
+      className={cn(
+        "tw-relative tw-flex tw-flex-col tw-gap-2 tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-3",
+        className
+      )}
+    >
+      <Button
+        variant="ghost2"
+        size="icon"
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        // Pull into the padding so the × hugs the corner without crowding the title.
+        className="tw-absolute tw-right-1 tw-top-1 tw-size-6 tw-text-muted hover:tw-text-normal"
+      >
+        <X className="tw-size-4" />
+      </Button>
+
+      <div className="tw-flex tw-items-center tw-gap-1.5 tw-pr-6 tw-text-ui-small tw-font-semibold tw-text-normal">
+        <Sparkles className="tw-size-4 tw-shrink-0 tw-text-accent" />
+        <span>Try a project</span>
+      </div>
+
+      <p className="tw-m-0 tw-text-ui-smaller tw-text-muted">
+        Group notes, URLs, PDFs, and folders into a focused context. The agent answers only within
+        those materials, and each project keeps its own chat history.
+      </p>
+
+      <Button
+        variant="default"
+        size="sm"
+        onClick={(e) => onCreate(e.currentTarget)}
+        className="tw-mt-1 tw-w-full tw-gap-2"
+      >
+        <FolderPlus className="tw-size-4" />
+        New project
+      </Button>
+    </div>
+  )
+);
+
+AgentWelcomeCard.displayName = "AgentWelcomeCard";

--- a/src/agentMode/ui/CreateProjectPanel.tsx
+++ b/src/agentMode/ui/CreateProjectPanel.tsx
@@ -1,0 +1,137 @@
+import { AgentProjectCreateForm } from "@/agentMode/ui/AgentProjectCreateForm";
+import { computeVerticalPlacement } from "@/utils/panelPlacement";
+import * as React from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface CreateProjectPanelProps {
+  /** The clicked trigger ("+ New project" row or Welcome button) to anchor to. */
+  anchorEl: HTMLElement;
+  onClose: () => void;
+  /**
+   * Persist the new project. Resolve to close the panel; reject to keep it open
+   * with a Notice (e.g. a duplicate name).
+   */
+  onSave: (data: { name: string }) => Promise<void>;
+}
+
+/** Viewport-edge margin / anchor gap — matches Quick Command's placement inputs. */
+const MARGIN = 12;
+const GAP = 6;
+const PANEL_WIDTH = 260;
+/** First-paint height guess, replaced by a real measurement in useLayoutEffect. */
+const ESTIMATED_HEIGHT = 140;
+
+interface PanelPosition {
+  top: number;
+  left: number;
+}
+
+/**
+ * A lightweight, anchored "new project" popover. Unlike a screen-centered
+ * modal, it opens next to the trigger and flips below/above/center by available
+ * space — reusing Quick Command's placement
+ * brain ({@link computeVerticalPlacement}) and the name-only create form
+ * ({@link AgentProjectCreateForm}). Portaled into the trigger's own
+ * document so it lands in the right window when the view is popped out.
+ */
+export function CreateProjectPanel({
+  anchorEl,
+  onClose,
+  onSave,
+}: CreateProjectPanelProps): React.ReactPortal {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const doc = anchorEl.ownerDocument;
+  const win = doc.defaultView ?? window;
+
+  // Place from the trigger's rect. The same rect is fed as both the top and
+  // bottom anchor, so the helper reads "below" = under the trigger and "above"
+  // = over it; with neither fitting it falls back to viewport center.
+  const computePosition = useCallback(
+    (panelHeight: number): PanelPosition => {
+      const rect = anchorEl.getBoundingClientRect();
+      const { top } = computeVerticalPlacement({
+        scrollRect: { top: 0, bottom: win.innerHeight },
+        visibleBottom: rect,
+        visibleTop: rect,
+        panelHeight,
+        margin: MARGIN,
+        gap: GAP,
+        viewportHeight: win.innerHeight,
+      });
+      // Center the panel on the trigger's horizontal midpoint. The "+ New
+      // project" row and Welcome button span the project pane, so their midpoint
+      // is the pane's center — reads better than hugging the left edge.
+      const centeredLeft = rect.left + rect.width / 2 - PANEL_WIDTH / 2;
+      const left = Math.max(MARGIN, Math.min(centeredLeft, win.innerWidth - PANEL_WIDTH - MARGIN));
+      return { top, left };
+    },
+    [anchorEl, win]
+  );
+
+  const [position, setPosition] = useState<PanelPosition>(() => computePosition(ESTIMATED_HEIGHT));
+
+  // Re-place with the panel's REAL height once mounted (and on resize): a height
+  // estimate smaller than the real panel would put an "above" placement on top
+  // of the trigger. Mirrors QuickAskOverlay, which measures then finalizes.
+  //
+  // DESIGN NOTE: re-anchors on resize only, NOT on scroll — this is a transient
+  // name+Enter popover whose primary exits are submit / Esc / outside-click, so
+  // a mid-edit scroll of the landing is an edge case not worth a scroll listener
+  // or ResizeObserver. If a future review flags scroll-follow, prefer
+  // close-on-scroll over reposition. Point repeat reviews at this note.
+  useLayoutEffect(() => {
+    const reposition = () =>
+      setPosition(computePosition(panelRef.current?.offsetHeight ?? ESTIMATED_HEIGHT));
+    reposition();
+    win.addEventListener("resize", reposition);
+    return () => win.removeEventListener("resize", reposition);
+  }, [computePosition, win]);
+
+  // Escape + click-outside dismissal (no shared hook exists; mirrors
+  // QuickAskOverlay). `defaultPrevented` lets an inner control consume Escape
+  // first; a pointerdown on the trigger itself is ignored so it doesn't
+  // close-then-reopen.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !e.defaultPrevented) {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    const onPointerDown = (e: MouseEvent) => {
+      const target = e.target as Node | null;
+      if (target && !panelRef.current?.contains(target) && !anchorEl.contains(target)) {
+        onClose();
+      }
+    };
+    win.addEventListener("keydown", onKeyDown);
+    doc.addEventListener("mousedown", onPointerDown, true);
+    return () => {
+      win.removeEventListener("keydown", onKeyDown);
+      doc.removeEventListener("mousedown", onPointerDown, true);
+    };
+  }, [anchorEl, doc, win, onClose]);
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label="New project"
+      className="tw-fixed tw-z-popover tw-w-[260px] tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-primary tw-p-3 tw-shadow-lg"
+      // Dynamic pixel position (computed from the anchor) — inline style is the
+      // established pattern for this in `command-ui/draggable-modal.tsx`.
+      style={{ top: position.top, left: position.left }}
+    >
+      <AgentProjectCreateForm
+        title="New project"
+        subtitle="Create a new project in your vault"
+        onSave={onSave}
+        onCancel={onClose}
+      />
+    </div>,
+    doc.body
+  );
+}
+
+export default CreateProjectPanel;

--- a/src/agentMode/ui/CreateProjectPanel.tsx
+++ b/src/agentMode/ui/CreateProjectPanel.tsx
@@ -78,8 +78,8 @@ export function CreateProjectPanel({
   // DESIGN NOTE: re-anchors on resize only, NOT on scroll — this is a transient
   // name+Enter popover whose primary exits are submit / Esc / outside-click, so
   // a mid-edit scroll of the landing is an edge case not worth a scroll listener
-  // or ResizeObserver. If a future review flags scroll-follow, prefer
-  // close-on-scroll over reposition. Point repeat reviews at this note.
+  // or ResizeObserver. If scroll-follow is ever needed, prefer close-on-scroll
+  // over reposition.
   useLayoutEffect(() => {
     const reposition = () =>
       setPosition(computePosition(panelRef.current?.offsetHeight ?? ESTIMATED_HEIGHT));

--- a/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { GlobalRecentChatsSection } from "@/agentMode/ui/GlobalRecentChatsSection";
+
+// jsdom lacks Obsidian's `activeDocument`; the section's View-all popover portals
+// into it. The empty-state paths under test never open it, but alias defensively.
+beforeAll(() => {
+  (window as unknown as { activeDocument: Document }).activeDocument = window.document;
+});
+
+const noop = async () => {};
+
+function renderSection(props: Partial<React.ComponentProps<typeof GlobalRecentChatsSection>> = {}) {
+  return render(
+    <GlobalRecentChatsSection
+      items={props.items ?? []}
+      variant={props.variant}
+      title={props.title}
+      runningChatIds={props.runningChatIds}
+      attentionChatIds={props.attentionChatIds}
+      onLoadChat={noop}
+      onUpdateTitle={noop}
+      onDeleteChat={noop}
+      onOpenSourceFile={noop}
+    />
+  );
+}
+
+// The attention dot is `aria-hidden` (purely decorative overlay), so query it
+// by its accent class the way ChatIconWithAttention paints it.
+function queryAttentionDot(container: HTMLElement): Element | null {
+  return container.querySelector(".tw-bg-interactive-accent");
+}
+
+function makeItem(
+  id: string
+): React.ComponentProps<typeof GlobalRecentChatsSection>["items"][number] {
+  // `lastAccessedAt` set to "now" so the relative-time label renders the stable
+  // `now` bucket regardless of when the test runs.
+  return {
+    id,
+    title: `Chat ${id}`,
+    createdAt: new Date(),
+    lastAccessedAt: new Date(),
+  };
+}
+
+describe("GlobalRecentChatsSection", () => {
+  it("defaults to the global empty-state copy", () => {
+    renderSection();
+    expect(screen.getByText("No recent chats")).toBeTruthy();
+  });
+
+  it("uses project-scoped empty-state copy in the project variant", () => {
+    renderSection({ variant: "project" });
+    expect(screen.getByText("No chats in this project yet")).toBeTruthy();
+  });
+
+  it("applies the optional title as the section's accessible label", () => {
+    renderSection({ variant: "project", title: "Project Chats" });
+    expect(screen.getByLabelText("Project Chats")).toBeTruthy();
+  });
+
+  it("renders a running spinner instead of the time for a backgrounded session", () => {
+    const item = makeItem("running-1");
+    renderSection({ items: [item], runningChatIds: new Set([item.id]) });
+    expect(screen.getByLabelText("Running")).toBeTruthy();
+    expect(screen.queryByText("now")).toBeNull();
+  });
+
+  it("renders the relative time (no spinner) when the session is not running", () => {
+    const item = makeItem("idle-1");
+    renderSection({ items: [item], runningChatIds: new Set() });
+    expect(screen.queryByLabelText("Running")).toBeNull();
+    expect(screen.getByText("now")).toBeTruthy();
+  });
+
+  it("shows the attention dot from the live set even when the item snapshot lacks it", () => {
+    // The handoff case: a backgrounded session finished AFTER the history items
+    // were loaded — the stale snapshot says no attention, the live set says yes.
+    const item = makeItem("done-live");
+    expect(item.needsAttention).toBeUndefined();
+    const { container } = renderSection({
+      items: [item],
+      attentionChatIds: new Set([item.id]),
+    });
+    expect(queryAttentionDot(container)).not.toBeNull();
+  });
+
+  it("shows no attention dot when neither the snapshot nor the live set flags it", () => {
+    const item = makeItem("plain-1");
+    const { container } = renderSection({ items: [item], attentionChatIds: new Set() });
+    expect(queryAttentionDot(container)).toBeNull();
+  });
+
+  it("caps the inline preview at 5 chats and offers a View-all trigger on overflow", () => {
+    const items = Array.from({ length: 7 }, (_, i) => makeItem(`overflow-${i}`));
+    renderSection({ items });
+    expect(screen.getAllByText(/^Chat overflow-/)).toHaveLength(5);
+    expect(screen.getByText("View all chats")).toBeTruthy();
+  });
+
+  it("shows every match (no cap, no View-all) while searching", () => {
+    const items = Array.from({ length: 7 }, (_, i) => makeItem(`search-${i}`));
+    renderSection({ items });
+    fireEvent.change(screen.getByPlaceholderText("Search chats..."), {
+      target: { value: "Chat search" },
+    });
+    expect(screen.getAllByText(/^Chat search-/)).toHaveLength(7);
+    expect(screen.queryByText("View all chats")).toBeNull();
+  });
+});

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -1,19 +1,57 @@
 import { backendRegistry } from "@/agentMode/backends/registry";
+import { INLINE_LIMIT } from "@/agentMode/ui/AgentHomeSection";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { SearchBar } from "@/components/ui/SearchBar";
-import { ChatHistoryItem } from "@/components/chat-components/ChatHistoryPopover";
+import {
+  ChatHistoryItem,
+  ChatHistoryPopover,
+} from "@/components/chat-components/ChatHistoryPopover";
+import { ChatIconWithAttention } from "@/components/chat-components/ChatIconWithAttention";
 import { cn } from "@/lib/utils";
 import { isNativeChatId } from "@/utils/nativeChatId";
 import { formatCompactRelativeTime } from "@/utils/formatRelativeTime";
 import { sortByStrategy } from "@/utils/recentUsageManager";
-import { ArrowUpRight, Check, Edit2, MessageCircle, Trash2, X } from "lucide-react";
+import {
+  ArrowUpRight,
+  Check,
+  ChevronRight,
+  Edit2,
+  LoaderCircle,
+  MessageCircle,
+  Trash2,
+  X,
+} from "lucide-react";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 
+/** Stable noop for rows that aren't being renamed (they never invoke onSaveEdit). */
+const NOOP_SAVE = (): void => {};
+
+/**
+ * Which landing this section renders under. `global` is the original Agent Home
+ * "Recent Chats" tab (every chat, flat). `project` is the per-project landing's
+ * "Project Chats" tab — same component and identical row affordances, scoped
+ * data supplied by the caller; the variant only changes the empty-state copy.
+ * The section title/count live in the shelf chip above, so the variant never
+ * renders a visible heading.
+ */
+export type RecentChatsVariant = "global" | "project";
+
 interface GlobalRecentChatsSectionProps {
-  /** Recent chats supplied by core (global getChatHistoryItems). */
+  /** Recent chats supplied by core (global or project-scoped getChatHistoryItems). */
   items: ChatHistoryItem[];
+  /**
+   * Landing context — drives the empty-state copy only (the shelf owns the
+   * visible title). Defaults to `global`, preserving the original behavior.
+   */
+  variant?: RecentChatsVariant;
+  /**
+   * Human label for this section (e.g. "Recent Chats" / "Project Chats"). The
+   * shelf chip renders the visible title, so this is used only as the section's
+   * accessible label. Optional — omit to leave the group unlabeled.
+   */
+  title?: string;
   /** Open a chat by id (markdown path or native session id). */
   onLoadChat: (id: string) => Promise<void>;
   onUpdateTitle: (id: string, newTitle: string) => Promise<void>;
@@ -25,6 +63,18 @@ interface GlobalRecentChatsSectionProps {
   onOpenSourceFile: (id: string) => Promise<void>;
   /** Refresh the items (called once when the section mounts). */
   onLoadHistory?: () => void;
+  /**
+   * Recent-list ids whose backend turn is running in the background. Matching
+   * rows swap their relative-time chip for a spinner. Omitted means "none".
+   */
+  runningChatIds?: ReadonlySet<string>;
+  /**
+   * Recent-list ids whose live session is flagging needs-attention. OR'd with
+   * each item's baked-in `needsAttention` snapshot so the done-dot appears the
+   * moment a backgrounded turn finishes — the snapshot alone goes stale once
+   * the list is mounted. Omitted means "snapshot only".
+   */
+  attentionChatIds?: ReadonlySet<string>;
   className?: string;
 }
 
@@ -53,16 +103,31 @@ function sortChatsByRecent(items: ChatHistoryItem[]): ChatHistoryItem[] {
 /**
  * Neutral tile holding the chat's backend brand glyph (or the generic
  * fallback), sized to match the project tiles so the two shelf tabs share one
- * leading-slot width.
+ * leading-slot width. The attention dot mirrors the tab strip's cue for a
+ * backgrounded live session that finished / errored — without it the landing
+ * list would be the only chat surface hiding the signal (the conversation
+ * History popover renders it via the same wrapper).
  */
-const ChatIconTile = memo(({ Icon }: { Icon: React.ComponentType<{ className?: string }> }) => (
-  <span
-    aria-hidden="true"
-    className="tw-flex tw-size-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-md tw-bg-secondary tw-text-muted"
-  >
-    <Icon className="tw-size-4" />
-  </span>
-));
+const ChatIconTile = memo(
+  ({
+    Icon,
+    needsAttention,
+  }: {
+    Icon: React.ComponentType<{ className?: string }>;
+    needsAttention?: boolean;
+  }) => (
+    <span
+      aria-hidden="true"
+      className="tw-flex tw-size-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-md tw-bg-secondary tw-text-muted"
+    >
+      <ChatIconWithAttention
+        icon={Icon}
+        needsAttention={needsAttention}
+        iconClassName="tw-size-4"
+      />
+    </span>
+  )
+);
 ChatIconTile.displayName = "ChatIconTile";
 
 interface RecentChatRowProps {
@@ -81,6 +146,10 @@ interface RecentChatRowProps {
   /** Whether this chat has a source note to open (markdown-saved only). */
   canOpenSourceFile: boolean;
   onOpenSourceFile: (id: string) => void;
+  /** Whether this chat's backend turn is running in the background. */
+  isRunning: boolean;
+  /** Snapshot ∪ live needs-attention — drives the icon tile's done-dot. */
+  hasAttention: boolean;
 }
 
 /**
@@ -104,13 +173,15 @@ const RecentChatRow = memo(function RecentChatRow({
   onCancelDelete,
   canOpenSourceFile,
   onOpenSourceFile,
+  isRunning,
+  hasAttention,
 }: RecentChatRowProps): React.ReactElement {
   const Icon = resolveChatIcon(item) ?? MessageCircle;
 
   if (isEditing) {
     return (
       <div className="tw-flex tw-min-h-9 tw-items-center tw-gap-2 tw-rounded-md tw-px-2 tw-py-1.5">
-        <ChatIconTile Icon={Icon} />
+        <ChatIconTile Icon={Icon} needsAttention={hasAttention} />
         <Input
           value={editingTitle}
           onChange={(e) => onEditingTitleChange(e.target.value)}
@@ -152,7 +223,7 @@ const RecentChatRow = memo(function RecentChatRow({
         }
       }}
     >
-      <ChatIconTile Icon={Icon} />
+      <ChatIconTile Icon={Icon} needsAttention={hasAttention} />
       <span
         className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-ui-small tw-text-normal"
         title={item.title}
@@ -160,17 +231,28 @@ const RecentChatRow = memo(function RecentChatRow({
         {item.title}
       </span>
 
-      {/* Relative time by default; the action cluster replaces it on hover or
+      {/* Relative time by default; a backgrounded running session shows an accent
+          spinner in its place. The action cluster replaces either on hover or
           keyboard focus so a narrow sidebar doesn't have to fit both. The
           `group-focus-within` path keeps the actions reachable for keyboard
           users (focusing the row reveals them, so Tab can move into them) —
           on hover alone they'd stay `display:none` and out of the tab order. */}
-      <span
-        className="tw-shrink-0 tw-whitespace-nowrap tw-text-xs tw-text-muted group-focus-within:tw-hidden group-hover:tw-hidden"
-        title={new Date(item.lastAccessedAt).toLocaleString()}
-      >
-        {formatCompactRelativeTime(item.lastAccessedAt.getTime())}
-      </span>
+      {isRunning ? (
+        <LoaderCircle
+          className={cn(
+            "tw-size-3.5 tw-shrink-0 tw-animate-spin tw-text-accent",
+            "group-focus-within:tw-hidden group-hover:tw-hidden"
+          )}
+          aria-label="Running"
+        />
+      ) : (
+        <span
+          className="tw-shrink-0 tw-whitespace-nowrap tw-text-xs tw-text-muted group-focus-within:tw-hidden group-hover:tw-hidden"
+          title={new Date(item.lastAccessedAt).toLocaleString()}
+        >
+          {formatCompactRelativeTime(item.lastAccessedAt.getTime())}
+        </span>
+      )}
       <div className="tw-hidden tw-shrink-0 tw-items-center tw-gap-1.5 group-focus-within:tw-flex group-hover:tw-flex">
         {confirmingDelete ? (
           <>
@@ -247,19 +329,27 @@ const RecentChatRow = memo(function RecentChatRow({
 });
 
 /**
- * "Recent Chats" section for the Agent Home landing. A searchable, scrollable
- * list whose rows manage chats in place — open, rename, delete, and (for
- * markdown-saved chats only) open the source note — the same affordances as the
- * chat history popover, without a separate "view all" step. Native
- * (autosave-off) sessions appear here too; they just have no source note.
+ * "Recent Chats" section for the Agent Home landing. A searchable list whose
+ * rows manage chats in place — open, rename, delete, and (for markdown-saved
+ * chats only) open the source note — the same affordances as the chat history
+ * popover. The inline preview caps at {@link INLINE_LIMIT}; overflow lives
+ * behind a "View all chats" trigger that opens the full
+ * {@link ChatHistoryPopover}, while searching surfaces every match. Native
+ * (autosave-off) sessions appear here too; they just have no source note. The
+ * per-project landing reuses it (`variant="project"`) with scoped items and
+ * project empty copy — identical rows, no extra chrome.
  */
 export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
   items,
+  variant = "global",
+  title,
   onLoadChat,
   onUpdateTitle,
   onDeleteChat,
   onOpenSourceFile,
   onLoadHistory,
+  runningChatIds,
+  attentionChatIds,
   className,
 }: GlobalRecentChatsSectionProps): React.ReactElement {
   const [query, setQuery] = useState("");
@@ -273,12 +363,24 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
     onLoadHistory?.();
   }, [onLoadHistory]);
 
+  // Sort once for the inline preview (fixed recent-first, like the rest of the
+  // landing); the View-all popover re-sorts the full list by the user's
+  // configured chatHistorySortStrategy — the same management surface as the
+  // control bar's History button — so it reads raw `items` directly below.
   const sortedItems = useMemo(() => sortChatsByRecent(items), [items]);
+  const isSearching = query.trim().length > 0;
   const filteredItems = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return sortedItems;
     return sortedItems.filter((item) => item.title.toLowerCase().includes(q));
   }, [sortedItems, query]);
+  // Inline preview caps at INLINE_LIMIT; a search shows every match (the cap
+  // would hide exactly what the user is looking for).
+  const visibleItems = useMemo(
+    () => (isSearching ? filteredItems : filteredItems.slice(0, INLINE_LIMIT)),
+    [filteredItems, isSearching]
+  );
+  const hasOverflow = !isSearching && filteredItems.length > INLINE_LIMIT;
 
   const handleStartEdit = useCallback((id: string, title: string) => {
     setConfirmDeleteId(null);
@@ -309,41 +411,144 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
     [onOpenSourceFile]
   );
 
+  // Stable references so the memoized rows aren't all re-rendered on every
+  // section render (an inline arrow here would defeat RecentChatRow's memo).
+  const handleCancelEdit = useCallback(() => setEditingId(null), []);
+  const handleCancelDelete = useCallback(() => setConfirmDeleteId(null), []);
+
   return (
-    <div className={cn("tw-flex tw-flex-col tw-gap-2", className)}>
+    <div
+      role={title ? "group" : undefined}
+      aria-label={title}
+      // tw-grow fills the shelf panel's fixed floor (AgentHomeShelf) so the
+      // empty / no-match copy below can center inside the card instead of
+      // hugging the top of a mostly blank panel.
+      className={cn("tw-flex tw-grow tw-flex-col tw-gap-2", className)}
+    >
       {items.length > 0 && (
         <div className="tw-p-1">
-          <SearchBar value={query} onChange={setQuery} placeholder="Search chats..." />
+          {/* Compact height so the search row reads as a list utility, not a
+              full-size form field towering over the 36px rows below. */}
+          <SearchBar
+            value={query}
+            onChange={setQuery}
+            placeholder="Search chats..."
+            inputClassName="!tw-h-7"
+          />
         </div>
       )}
       {filteredItems.length === 0 ? (
-        <div className="tw-px-2 tw-py-1.5 tw-text-xs tw-text-muted">
-          {items.length === 0 ? "No recent chats" : "No matching chats"}
+        <div className="tw-flex tw-flex-1 tw-items-center tw-justify-center tw-px-2 tw-py-1.5 tw-text-xs tw-text-muted">
+          {items.length > 0
+            ? "No matching chats"
+            : variant === "project"
+              ? "No chats in this project yet"
+              : "No recent chats"}
         </div>
       ) : (
-        <ScrollArea className="tw-max-h-80 tw-overflow-y-auto">
-          <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
-            {filteredItems.map((item) => (
-              <RecentChatRow
-                key={item.id}
-                item={item}
-                isEditing={editingId === item.id}
-                editingTitle={editingTitle}
-                confirmingDelete={confirmDeleteId === item.id}
-                onOpen={onLoadChat}
-                onStartEdit={handleStartEdit}
-                onEditingTitleChange={setEditingTitle}
-                onSaveEdit={handleSaveEdit}
-                onCancelEdit={() => setEditingId(null)}
-                onStartDelete={setConfirmDeleteId}
-                onConfirmDelete={handleConfirmDelete}
-                onCancelDelete={() => setConfirmDeleteId(null)}
-                canOpenSourceFile={!isNativeChatId(item.id)}
-                onOpenSourceFile={handleOpenSourceFile}
-              />
-            ))}
-          </div>
-        </ScrollArea>
+        // Outer divide-y separates the scroll region from the "View all" row
+        // below with the same hairline the rows use between themselves — the
+        // exact look of the Projects tab, where the trigger sits in the list's
+        // divide-y container.
+        <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
+          {/* max-h-56 keeps a long search-result list scrolling INSIDE the card
+              near the inline preview's height, so searching doesn't balloon the
+              card. The inline (non-search) 5-row preview never reaches this cap,
+              and the "View all" row lives outside the scroll region so it can't
+              scroll out of reach. */}
+          <ScrollArea className="tw-max-h-56 tw-overflow-y-auto">
+            <div className="tw-flex tw-flex-col tw-divide-y tw-divide-border">
+              {visibleItems.map((item) => (
+                <RecentChatRow
+                  key={item.id}
+                  item={item}
+                  isEditing={editingId === item.id}
+                  // Only the row being renamed needs the live draft; passing a
+                  // stable "" to the rest keeps their memo from re-rendering on
+                  // every keystroke.
+                  editingTitle={editingId === item.id ? editingTitle : ""}
+                  confirmingDelete={confirmDeleteId === item.id}
+                  onOpen={onLoadChat}
+                  onStartEdit={handleStartEdit}
+                  onEditingTitleChange={setEditingTitle}
+                  // Only the editing row needs the live save handler (it changes
+                  // per keystroke via editingTitle); the rest get a stable noop so
+                  // their memo isn't defeated mid-rename.
+                  onSaveEdit={editingId === item.id ? handleSaveEdit : NOOP_SAVE}
+                  onCancelEdit={handleCancelEdit}
+                  onStartDelete={setConfirmDeleteId}
+                  onConfirmDelete={handleConfirmDelete}
+                  onCancelDelete={handleCancelDelete}
+                  canOpenSourceFile={!isNativeChatId(item.id)}
+                  onOpenSourceFile={handleOpenSourceFile}
+                  isRunning={runningChatIds?.has(item.id) ?? false}
+                  hasAttention={!!item.needsAttention || (attentionChatIds?.has(item.id) ?? false)}
+                />
+              ))}
+            </div>
+          </ScrollArea>
+          {hasOverflow && (
+            <ChatHistoryPopover
+              chatHistory={items}
+              onUpdateTitle={onUpdateTitle}
+              onDeleteChat={onDeleteChat}
+              onLoadChat={onLoadChat}
+              onOpenSourceFile={onOpenSourceFile}
+              getIcon={resolveChatIcon}
+              // Full-width row near the pane's lower half: open downward like
+              // an accordion. Radix flips to "top" if the area below is tight.
+              side="bottom"
+              align="start"
+            >
+              {/* Trigger styled identically to the Projects tab's "View all
+                  projects" row (AgentHomeViewAll) so the two shelf tabs read as
+                  one component family.
+
+                  DESIGN NOTE: unlike these inline rows, the popover's rows show
+                  the open-source-note action for native (autosave-off) chats
+                  too — pre-existing shared ChatHistoryPopover behavior (same
+                  exposure as the control bar's History button; the click
+                  degrades to a "no saved note" notice). Hiding it would mean a
+                  per-row visibility prop on the shared popover — tracked as
+                  shared-popover debt, not worth an entry-point hack here. If a
+                  future review flags this again, point them at this note.
+
+                  Radix merges its toggle onClick onto this child; Enter/Space
+                  dispatch a click so the popover opens for keyboard users
+                  without this row owning the popover's open state.
+
+                  DESIGN NOTE: onLoadHistory runs on every toggle (open *and*
+                  close), because Radix fires the merged onClick both ways and
+                  this row can't see the popover's open state. That's an
+                  intentional, harmless refresh — the same pattern the
+                  conversation control bar uses on its History button
+                  (AgentChatControls). loadChatHistory is mounted-guarded and
+                  self-correcting, so a fast open/close race only momentarily
+                  shows near-identical data. A "refresh only on open" fix would
+                  need ChatHistoryPopover to expose onOpenChange — not worth
+                  touching the shared base for this. If a future review flags
+                  this again, point them at this note. */}
+              <div
+                role="button"
+                tabIndex={0}
+                className={cn(
+                  "tw-flex tw-cursor-pointer tw-items-center tw-justify-between tw-rounded-md tw-px-2 tw-py-1.5",
+                  "tw-text-xs tw-text-accent tw-transition-colors hover:tw-bg-modifier-hover hover:tw-text-accent-hover"
+                )}
+                onClick={() => onLoadHistory?.()}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    e.currentTarget.click();
+                  }
+                }}
+              >
+                <span>View all chats</span>
+                <ChevronRight className="tw-size-3 tw-shrink-0" />
+              </div>
+            </ChatHistoryPopover>
+          )}
+        </div>
       )}
     </div>
   );

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -510,8 +510,7 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
                   exposure as the control bar's History button; the click
                   degrades to a "no saved note" notice). Hiding it would mean a
                   per-row visibility prop on the shared popover — tracked as
-                  shared-popover debt, not worth an entry-point hack here. If a
-                  future review flags this again, point them at this note.
+                  shared-popover debt, not worth an entry-point hack here.
 
                   Radix merges its toggle onClick onto this child; Enter/Space
                   dispatch a click so the popover opens for keyboard users
@@ -526,8 +525,7 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
                   self-correcting, so a fast open/close race only momentarily
                   shows near-identical data. A "refresh only on open" fix would
                   need ChatHistoryPopover to expose onOpenChange — not worth
-                  touching the shared base for this. If a future review flags
-                  this again, point them at this note. */}
+                  touching the shared base for this. */}
               <div
                 role="button"
                 tabIndex={0}

--- a/src/agentMode/ui/ProjectIconTile.tsx
+++ b/src/agentMode/ui/ProjectIconTile.tsx
@@ -1,0 +1,52 @@
+import { cn } from "@/lib/utils";
+import { Folder } from "lucide-react";
+import React, { memo } from "react";
+
+// Stable per-project accent: hash the id into one of six theme hues so a project
+// keeps the same color across renders and sessions (Math.random would reshuffle
+// every paint). Each entry pairs a solid `text` hue with its soft `bg` tint from
+// the `project` palette in tailwind.config — the folder glyph inherits the text
+// color, the tile shows the tint behind it.
+const PROJECT_ICON_PALETTE = [
+  "tw-text-project-red tw-bg-project-red",
+  "tw-text-project-orange tw-bg-project-orange",
+  "tw-text-project-yellow tw-bg-project-yellow",
+  "tw-text-project-green tw-bg-project-green",
+  "tw-text-project-blue tw-bg-project-blue",
+  "tw-text-project-purple tw-bg-project-purple",
+] as const;
+
+function projectIconClasses(id: string): string {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash << 5) - hash + id.charCodeAt(i);
+    hash |= 0; // clamp to 32-bit so long ids stay deterministic
+  }
+  return PROJECT_ICON_PALETTE[Math.abs(hash) % PROJECT_ICON_PALETTE.length];
+}
+
+interface ProjectIconTileProps {
+  /** Project id — the sole color input, so the accent survives renames. */
+  id: string;
+}
+
+/**
+ * Tinted square + colored folder, stable per project id. The project's visual
+ * identity primitive, shared by every surface that represents a project (the
+ * Projects-tab rows, the in-project workspace header) so one project always
+ * carries one color. Decorative: the adjacent project name is the readable text.
+ */
+export const ProjectIconTile = memo(
+  ({ id }: ProjectIconTileProps): React.ReactElement => (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "tw-flex tw-size-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-md",
+        projectIconClasses(id)
+      )}
+    >
+      <Folder className="tw-size-4" />
+    </span>
+  )
+);
+ProjectIconTile.displayName = "ProjectIconTile";

--- a/src/agentMode/ui/ProjectInfoPopover.test.tsx
+++ b/src/agentMode/ui/ProjectInfoPopover.test.tsx
@@ -1,0 +1,166 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+// activeDocument global (Radix popover portals into it).
+beforeAll(() => {
+  (window as unknown as { activeDocument: Document }).activeDocument = window.document;
+});
+
+const updateProject = jest.fn().mockResolvedValue({ project: {} });
+jest.mock("@/projects/ProjectFileManager", () => ({
+  ProjectFileManager: { getInstance: () => ({ updateProject }) },
+}));
+
+const getCachedProjectRecordById = jest.fn();
+jest.mock("@/projects/state", () => ({
+  getCachedProjectRecordById: (...args: unknown[]) => getCachedProjectRecordById(...args),
+}));
+
+jest.mock("@/projects/projectPaths", () => ({
+  getProjectFolderPath: (folderName: string) => `copilot/projects/${folderName}`,
+}));
+
+// Keep the edit/reveal collaborators inert — exercised elsewhere.
+jest.mock("@/components/modals/project/AddProjectModal", () => ({
+  AddProjectModal: jest.fn().mockImplementation(() => ({ open: jest.fn() })),
+}));
+const revealProjectFolder = jest.fn();
+jest.mock("@/agentMode/ui/AgentProjectRowActions", () => ({
+  revealProjectFolder: (...args: unknown[]) => revealProjectFolder(...args),
+}));
+const openSystemPromptModal = jest.fn();
+jest.mock("@/agentMode/ui/ProjectSystemPromptModal", () => ({
+  ProjectSystemPromptModal: jest.fn().mockImplementation((...args: unknown[]) => {
+    openSystemPromptModal(...args);
+    return { open: jest.fn() };
+  }),
+}));
+
+import { TFile, TFolder } from "obsidian";
+import { ProjectInfoPopover } from "@/agentMode/ui/ProjectInfoPopover";
+import type { AgentTodoListEntry } from "@/agentMode/session/types";
+import type { ProjectConfig } from "@/aiParams";
+
+const PROJECT = {
+  id: "proj-1",
+  name: "My Research",
+  systemPrompt: "be helpful",
+  contextSource: {},
+} as unknown as ProjectConfig;
+
+function makeFolder(names: string[]) {
+  const folder = new (TFolder as unknown as new (path: string) => TFolder)(
+    "copilot/projects/proj-1"
+  );
+  (folder as unknown as { children: unknown[] }).children = names.map(
+    (n) => new (TFile as unknown as new (path: string) => TFile)(`copilot/projects/proj-1/${n}`)
+  );
+  return folder;
+}
+
+// A marker line a generated AGENTS.md mirror carries (see ensureAgentsMirror.ts) — a read
+// returning this means "generated, hide it". Ownership keys off the stable
+// `MIRROR_MARKER_PREFIX`, not the exact wording, so this older-tail variant is still detected;
+// keeping it here doubles as a backward tail-compat check.
+const MIRROR_MARKER =
+  "<!-- copilot:generated-agents-mirror v1 — DO NOT EDIT. Mirror of this project's instructions " +
+  "(project.md); regenerated each session. Delete this line to take over the file. -->";
+
+function renderPopover(
+  todoList: AgentTodoListEntry[] | null,
+  folderNames: string[] = [],
+  fileContents: Record<string, string> = {}
+) {
+  getCachedProjectRecordById.mockReturnValue({ folderName: "proj-1" });
+  const openFile = jest.fn().mockResolvedValue(undefined);
+  const app = {
+    vault: {
+      getAbstractFileByPath: jest.fn().mockReturnValue(makeFolder(folderNames)),
+      read: jest.fn((file: TFile) => Promise.resolve(fileContents[file.name] ?? "")),
+    },
+    workspace: { getLeaf: jest.fn().mockReturnValue({ openFile }) },
+  } as unknown as Parameters<typeof ProjectInfoPopover>[0]["app"];
+  render(<ProjectInfoPopover app={app} project={PROJECT} todoList={todoList} />);
+  // Open the popover.
+  fireEvent.click(screen.getByLabelText("Project info for My Research"));
+  return { openFile };
+}
+
+describe("ProjectInfoPopover", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders the project name and the System Prompt row (never the backing file)", async () => {
+    renderPopover(null, ["project.md", "AGENTS.md", "notes.md"]);
+    expect(screen.getAllByText("My Research").length).toBeGreaterThan(0);
+    // Await the async file listing so its setState settles inside act().
+    expect(await screen.findByText("System Prompt")).toBeTruthy();
+  });
+
+  it("omits the Progress section when there is no todo list", async () => {
+    renderPopover(null);
+    expect(await screen.findByText("System Prompt")).toBeTruthy();
+    expect(screen.queryByText("Progress")).toBeNull();
+  });
+
+  it("renders the todo list with a completed/total count when present", async () => {
+    renderPopover([
+      { content: "step A", status: "completed" },
+      { content: "step B", status: "in_progress" },
+      { content: "step C", status: "pending" },
+    ]);
+    await screen.findByText("System Prompt");
+    expect(screen.getByText("Progress")).toBeTruthy();
+    expect(screen.getByText("1/3")).toBeTruthy();
+    expect(screen.getByText("step A")).toBeTruthy();
+    expect(screen.getByText("step C")).toBeTruthy();
+  });
+
+  it("lists folder files but excludes project.md and a GENERATED AGENTS.md mirror", async () => {
+    renderPopover(null, ["project.md", "AGENTS.md", "guide.pdf", "draft.md"], {
+      "AGENTS.md": `${MIRROR_MARKER}\n\nbe helpful`, // marker → generated mirror
+    });
+    expect(await screen.findByText("guide.pdf")).toBeTruthy();
+    expect(screen.getByText("draft.md")).toBeTruthy();
+    expect(screen.queryByText("project.md")).toBeNull();
+    expect(screen.queryByText("AGENTS.md")).toBeNull();
+  });
+
+  it("KEEPS a user-authored AGENTS.md (no marker) in the file list", async () => {
+    renderPopover(null, ["project.md", "AGENTS.md", "draft.md"], {
+      "AGENTS.md": "my own agent rules", // no marker → user-authored, must show
+    });
+    expect(await screen.findByText("AGENTS.md")).toBeTruthy();
+    expect(screen.getByText("draft.md")).toBeTruthy();
+    expect(screen.queryByText("project.md")).toBeNull();
+  });
+
+  it("keeps an AGENTS.md visible when its content cannot be read", async () => {
+    getCachedProjectRecordById.mockReturnValue({ folderName: "proj-1" });
+    const app = {
+      vault: {
+        getAbstractFileByPath: jest.fn().mockReturnValue(makeFolder(["AGENTS.md", "draft.md"])),
+        read: jest.fn().mockRejectedValue(new Error("read failed")),
+      },
+      workspace: { getLeaf: jest.fn().mockReturnValue({ openFile: jest.fn() }) },
+    } as unknown as Parameters<typeof ProjectInfoPopover>[0]["app"];
+    render(<ProjectInfoPopover app={app} project={PROJECT} todoList={null} />);
+    fireEvent.click(screen.getByLabelText("Project info for My Research"));
+    // Read failure must not hide a possibly-user file.
+    expect(await screen.findByText("AGENTS.md")).toBeTruthy();
+  });
+
+  it("opens the System Prompt editor when the row is clicked", async () => {
+    renderPopover(null);
+    fireEvent.click(await screen.findByText("System Prompt"));
+    expect(openSystemPromptModal).toHaveBeenCalledTimes(1);
+    // (app, initialPrompt, persistFn)
+    expect(openSystemPromptModal.mock.calls[0][1]).toBe("be helpful");
+  });
+
+  it("reveals the project folder from the header button", async () => {
+    renderPopover(null);
+    await screen.findByText("System Prompt");
+    fireEvent.click(screen.getByLabelText("Reveal project folder in vault"));
+    expect(revealProjectFolder).toHaveBeenCalledWith(expect.anything(), PROJECT);
+  });
+});

--- a/src/agentMode/ui/ProjectInfoPopover.tsx
+++ b/src/agentMode/ui/ProjectInfoPopover.tsx
@@ -1,0 +1,380 @@
+import { revealProjectFolder } from "@/agentMode/ui/AgentProjectRowActions";
+import { ProjectSystemPromptModal } from "@/agentMode/ui/ProjectSystemPromptModal";
+import type { AgentTodoListEntry } from "@/agentMode/session/types";
+import { ProjectConfig } from "@/aiParams";
+import { AddProjectModal } from "@/components/modals/project/AddProjectModal";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { logError } from "@/logger";
+import { isGeneratedAgentsMirrorContent } from "@/projects/ensureAgentsMirror";
+import { getProjectFolderPath } from "@/projects/projectPaths";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { getCachedProjectRecordById } from "@/projects/state";
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  FolderSearch,
+  List,
+  Settings,
+  SquarePen,
+} from "lucide-react";
+import { App, Notice, TFile, TFolder } from "obsidian";
+import React, { memo, useEffect, useState } from "react";
+
+/**
+ * The project's instruction config — always represented by the fixed "System
+ * Prompt" row, never listed as a plain file. `AGENTS.md` is NOT in here: it can
+ * be either the plugin's generated mirror (hidden) or a user-authored file
+ * (shown), distinguished by marker content, not by name — see the listing.
+ */
+const HIDDEN_BASENAME = "project.md";
+const AGENTS_BASENAME = "agents.md";
+
+/** Per-extension badge tints, the same project palette tokens rows use. */
+const BADGE_CLASSES: Record<string, string> = {
+  pdf: "tw-bg-project-red tw-text-project-red",
+  md: "tw-bg-project-blue tw-text-project-blue",
+  html: "tw-bg-project-orange tw-text-project-orange",
+  png: "tw-bg-project-green tw-text-project-green",
+};
+
+function FileBadge({ ext }: { ext: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "tw-flex tw-h-4 tw-w-7 tw-shrink-0 tw-items-center tw-justify-center tw-rounded tw-text-smallest tw-font-bold tw-uppercase",
+        BADGE_CLASSES[ext] ?? "tw-bg-secondary tw-text-muted"
+      )}
+    >
+      {ext.slice(0, 4) || "file"}
+    </span>
+  );
+}
+
+interface ProgressSectionProps {
+  todoList: AgentTodoListEntry[] | null;
+}
+
+/**
+ * The agent's live execution todo list (`getCurrentTodoList`). Per the design
+ * (and matching the backends' own behavior), NO active list renders nothing —
+ * the section never placeholder-pads the popover.
+ */
+function ProgressSection({ todoList }: ProgressSectionProps) {
+  if (!todoList || todoList.length === 0) return null;
+  const done = todoList.filter((t) => t.status === "completed").length;
+  return (
+    <div className="tw-px-3 tw-py-2.5">
+      <div className="tw-mb-1.5 tw-flex tw-items-baseline tw-justify-between">
+        <span className="tw-text-ui-smaller tw-font-semibold tw-text-faint">Progress</span>
+        <span className="tw-text-ui-smaller tw-text-faint">
+          {done}/{todoList.length}
+        </span>
+      </div>
+      <ul className="tw-m-0 tw-flex tw-list-none tw-flex-col tw-gap-1 tw-p-0">
+        {todoList.map((todo, i) => (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- entries are positional and may share content
+          <li key={`todo-${i}`} className="tw-flex tw-items-center tw-gap-2">
+            <span
+              aria-hidden="true"
+              className={cn(
+                "tw-flex tw-size-5 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-text-xs tw-font-semibold",
+                todo.status === "completed"
+                  ? "tw-bg-interactive-accent tw-text-on-accent"
+                  : todo.status === "in_progress"
+                    ? "tw-border-[1.5px] tw-border-solid tw-border-interactive-accent tw-text-accent"
+                    : "tw-border-[1.5px] tw-border-solid tw-border-border tw-text-faint"
+              )}
+            >
+              {todo.status === "completed" ? <Check className="tw-size-3" /> : i + 1}
+            </span>
+            <span
+              className={cn(
+                "tw-min-w-0 tw-truncate tw-text-ui-small",
+                // Done is de-emphasized (faint + strikethrough); everything not
+                // yet done — in_progress AND pending — stays full-strength so the
+                // contrast reads "completed vs remaining" at a glance.
+                todo.status === "completed" ? "tw-text-faint tw-line-through" : "tw-text-normal"
+              )}
+              title={todo.content}
+            >
+              {todo.content}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface ProjectFilesSectionProps {
+  app: App;
+  project: ProjectConfig;
+  onClose: () => void;
+  /** Fired after the System Prompt is saved, so the caller refreshes its cache. */
+  onEdited?: (project: ProjectConfig) => void;
+}
+
+function ProjectFilesSection({ app, project, onClose, onEdited }: ProjectFilesSectionProps) {
+  const [outputsOpen, setOutputsOpen] = useState(false);
+  const [files, setFiles] = useState<TFile[]>([]);
+
+  // Direct children of the project folder, minus: ALL dot-prefixed entries
+  // (user dot-files like `.env` — hiding dot-files is the conventional listing
+  // default, matching Finder/`ls`
+  // and Obsidian's own dot-folder handling), project.md (the System Prompt row
+  // represents it), and a GENERATED AGENTS.md mirror. A user-authored AGENTS.md
+  // (no marker) is kept — distinguishing the two needs the file CONTENT, not
+  // its name, so the listing is async. Runs when the popover body mounts (it
+  // only exists while open, so each open re-lists fresh without a vault
+  // subscription).
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const record = getCachedProjectRecordById(project.id);
+      const folderPath = record ? getProjectFolderPath(record.folderName) : null;
+      const folder = folderPath ? app.vault.getAbstractFileByPath(folderPath) : null;
+      if (!(folder instanceof TFolder)) {
+        if (!cancelled) setFiles([]);
+        return;
+      }
+      const candidates = folder.children.filter(
+        (child): child is TFile =>
+          child instanceof TFile &&
+          !child.name.startsWith(".") &&
+          child.name.toLowerCase() !== HIDDEN_BASENAME
+      );
+      const visible: TFile[] = [];
+      for (const child of candidates) {
+        if (child.name.toLowerCase() === AGENTS_BASENAME) {
+          // Hide only the generated mirror; on read failure keep the file
+          // visible rather than risk hiding a user's own AGENTS.md.
+          const isMirror = await app.vault
+            .read(child)
+            .then(isGeneratedAgentsMirrorContent)
+            .catch(() => false);
+          if (isMirror) continue;
+        }
+        visible.push(child);
+      }
+      visible.sort((a, b) => a.name.localeCompare(b.name));
+      if (!cancelled) setFiles(visible);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [app, project.id]);
+
+  const handleOpenFile = (file: TFile) => {
+    onClose();
+    void app.workspace
+      .getLeaf(false)
+      .openFile(file)
+      .catch((err) => logError("[ProjectInfoPopover] openFile failed", err));
+  };
+
+  const handleEditSystemPrompt = () => {
+    onClose();
+    new ProjectSystemPromptModal(app, project.systemPrompt ?? "", async (prompt) => {
+      const updated = await ProjectFileManager.getInstance(app).updateProject(project.id, {
+        ...project,
+        systemPrompt: prompt,
+      });
+      // Keep the caller's cached project in sync with the gear-edit path, so a
+      // reopen reads the new prompt instead of the pre-save value.
+      onEdited?.(updated.project);
+    }).open();
+  };
+
+  return (
+    <div className="tw-px-3 tw-py-2.5">
+      <div className="tw-mb-1 tw-flex tw-items-center tw-justify-between">
+        <span className="tw-text-ui-smaller tw-font-semibold tw-text-faint">Project files</span>
+        <Button
+          variant="ghost2"
+          size="icon"
+          aria-label="Reveal project files in vault"
+          className="tw-size-5 tw-text-faint hover:tw-text-normal"
+          onClick={() => {
+            onClose();
+            revealProjectFolder(app, project);
+          }}
+        >
+          <FolderSearch className="tw-size-3.5" />
+        </Button>
+      </div>
+
+      {/* Fixed first row: the project's instructions. Shows ONLY the label —
+          never the backing file name (project.md / the AGENTS.md mirror). */}
+      <div
+        role="button"
+        tabIndex={0}
+        className="tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded tw-p-1 hover:tw-bg-secondary"
+        onClick={handleEditSystemPrompt}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") handleEditSystemPrompt();
+        }}
+      >
+        <FileBadge ext="md" />
+        <span className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-ui-small">System Prompt</span>
+        <SquarePen aria-hidden="true" className="tw-size-3.5 tw-shrink-0 tw-text-faint" />
+      </div>
+
+      {files.map((file) => (
+        <div
+          key={file.path}
+          role="button"
+          tabIndex={0}
+          className="tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded tw-p-1 hover:tw-bg-secondary"
+          onClick={() => handleOpenFile(file)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") handleOpenFile(file);
+          }}
+        >
+          <FileBadge ext={file.extension.toLowerCase()} />
+          <span className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-ui-small" title={file.name}>
+            {file.name}
+          </span>
+        </div>
+      ))}
+
+      {/* Outputs: files generated during agent conversations. The producing
+          feature hasn't shipped yet, so this is the collapsed empty state the
+          design reserves — wired up once outputs land in the project folder. */}
+      <div
+        role="button"
+        tabIndex={0}
+        className="tw-flex tw-cursor-pointer tw-items-center tw-gap-1 tw-rounded tw-p-1 tw-text-muted hover:tw-bg-secondary"
+        onClick={() => setOutputsOpen((v) => !v)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") setOutputsOpen((v) => !v);
+        }}
+        aria-expanded={outputsOpen}
+      >
+        {outputsOpen ? (
+          <ChevronDown className="tw-size-3.5" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="tw-size-3.5" aria-hidden="true" />
+        )}
+        <span className="tw-text-ui-small tw-font-medium">Outputs</span>
+        <span className="tw-text-ui-smaller tw-text-faint">(0)</span>
+      </div>
+      {outputsOpen && (
+        <div className="tw-py-1 tw-pl-6 tw-text-ui-smaller tw-text-faint">No outputs yet</div>
+      )}
+    </div>
+  );
+}
+
+interface ProjectInfoPopoverProps {
+  app: App;
+  project: ProjectConfig;
+  /** Live execution todo list of the active session (null = no Progress section). */
+  todoList: AgentTodoListEntry[] | null;
+  /** Fired after a successful edit via the gear (caller refreshes its cache). */
+  onEdited?: (project: ProjectConfig) => void;
+  /** Portal container — the AgentHome ROOT (the header sits outside the chat container). */
+  container?: HTMLElement | null;
+  className?: string;
+}
+
+/**
+ * Project-info popover anchored to the project header's trailing button,
+ * replacing the old `⋯` overflow menu (design: PROJECT_INFO_POPOVER.md,
+ * project-info-panel-hifi.html F1–F3). Top card (name + Edit gear + reveal) →
+ * Progress (live todo list, hidden when none) → Project files (System Prompt
+ * row + folder files + Outputs placeholder). Deliberately NO Delete and no
+ * config chips — deletion stays on the project list rows' inline actions.
+ */
+export const ProjectInfoPopover = memo(
+  ({ app, project, todoList, onEdited, container, className }: ProjectInfoPopoverProps) => {
+    const [open, setOpen] = useState(false);
+
+    const handleEdit = () => {
+      setOpen(false);
+      // Same agent-flavored edit the old overflow menu opened: full project
+      // modal minus the model card + CAG processing status.
+      new AddProjectModal(
+        app,
+        async (next) => {
+          try {
+            const updated = await ProjectFileManager.getInstance(app).updateProject(
+              project.id,
+              next
+            );
+            onEdited?.(updated.project);
+          } catch (e) {
+            logError("[ProjectInfoPopover] updateProject failed", e);
+            new Notice(`Failed to update project "${project.name}".`);
+          }
+        },
+        project,
+        undefined,
+        true
+      ).open();
+    };
+
+    return (
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost2"
+            size="icon"
+            aria-label={`Project info for ${project.name}`}
+            className={cn("tw-size-7 tw-text-muted hover:tw-text-normal", className)}
+          >
+            <List className="tw-size-4" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="end"
+          container={container}
+          className="tw-w-72 tw-p-0"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+        >
+          <div className="tw-flex tw-items-center tw-gap-1 tw-px-3 tw-py-2.5">
+            <span
+              className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-ui-small tw-font-semibold"
+              title={project.name}
+            >
+              {project.name}
+            </span>
+            <Button
+              variant="ghost2"
+              size="icon"
+              aria-label={`Edit project ${project.name}`}
+              className="tw-size-6 tw-text-muted hover:tw-text-normal"
+              onClick={handleEdit}
+            >
+              <Settings className="tw-size-3.5" />
+            </Button>
+            <Button
+              variant="ghost2"
+              size="icon"
+              aria-label="Reveal project folder in vault"
+              className="tw-size-6 tw-text-muted hover:tw-text-normal"
+              onClick={() => {
+                setOpen(false);
+                revealProjectFolder(app, project);
+              }}
+            >
+              <FolderSearch className="tw-size-3.5" />
+            </Button>
+          </div>
+          <ProgressSection todoList={todoList} />
+          <ProjectFilesSection
+            app={app}
+            project={project}
+            onClose={() => setOpen(false)}
+            onEdited={onEdited}
+          />
+        </PopoverContent>
+      </Popover>
+    );
+  }
+);
+
+ProjectInfoPopover.displayName = "ProjectInfoPopover";

--- a/src/agentMode/ui/ProjectInfoPopover.tsx
+++ b/src/agentMode/ui/ProjectInfoPopover.tsx
@@ -20,7 +20,7 @@ import {
   Settings,
   SquarePen,
 } from "lucide-react";
-import { App, Notice, TFile, TFolder } from "obsidian";
+import { App, TFile, TFolder } from "obsidian";
 import React, { memo, useEffect, useState } from "react";
 
 /**
@@ -307,8 +307,13 @@ export const ProjectInfoPopover = memo(
             );
             onEdited?.(updated.project);
           } catch (e) {
+            // Reason: log for diagnostics, then rethrow so AddProjectModal keeps the
+            // form open and surfaces the failure (duplicate name / folder collision)
+            // instead of resolving onSave, closing, and discarding the user's edits.
+            // Mirrors the inline edit action in AgentProjectRowActions, which lets
+            // updateProject throw into the modal's own error handling.
             logError("[ProjectInfoPopover] updateProject failed", e);
-            new Notice(`Failed to update project "${project.name}".`);
+            throw e;
           }
         },
         project,

--- a/src/agentMode/ui/ProjectPickerList.test.tsx
+++ b/src/agentMode/ui/ProjectPickerList.test.tsx
@@ -1,0 +1,104 @@
+// Mock the Manage modal so its transitive Obsidian-subclass imports
+// (FuzzySuggestModal via the row Edit action's AddProjectModal) don't crash
+// module load under the obsidian mock.
+jest.mock("@/components/modals/project/context-manage-modal", () => ({
+  ContextManageModal: jest.fn().mockImplementation(() => ({ open: jest.fn() })),
+}));
+
+import { ProjectConfig } from "@/aiParams";
+import { ProjectPickerList } from "@/agentMode/ui/ProjectPickerList";
+import { RecentUsageManager } from "@/utils/recentUsageManager";
+import { act, render } from "@testing-library/react";
+import { App } from "obsidian";
+import React from "react";
+
+// jsdom lacks Obsidian's `activeDocument`; the View-all popover portals into it.
+// The tests below keep to the inline list (≤ INLINE_LIMIT projects) and never
+// open that surface, but alias defensively.
+beforeAll(() => {
+  (window as unknown as { activeDocument: Document }).activeDocument = window.document;
+});
+
+const app = {} as App;
+const noop = () => {};
+
+function makeProject(
+  id: string,
+  usageTimestamps: number,
+  created = usageTimestamps
+): ProjectConfig {
+  return {
+    id,
+    name: id,
+    systemPrompt: "",
+    projectModelKey: "",
+    modelConfigs: {},
+    contextSource: {},
+    created,
+    UsageTimestamps: usageTimestamps,
+  };
+}
+
+/** Project-name order as rendered, top-to-bottom (ignores icon-only action buttons). */
+function renderedOrder(container: HTMLElement, names: string[]): string[] {
+  const rows = Array.from(container.querySelectorAll<HTMLElement>('[role="button"]'));
+  return rows
+    .map((row) => names.find((name) => row.textContent?.includes(name)))
+    .filter((name): name is string => Boolean(name));
+}
+
+describe("ProjectPickerList", () => {
+  const projectA = makeProject("A", 1000);
+  const projectB = makeProject("B", 2000);
+  const projectC = makeProject("C", 3000);
+  const names = ["A", "B", "C"];
+
+  function renderPicker(manager?: RecentUsageManager<string>) {
+    return render(
+      <ProjectPickerList
+        projects={[projectA, projectB, projectC]}
+        onSelect={noop}
+        app={app}
+        projectUsageTimestampsManager={manager}
+      />
+    );
+  }
+
+  it("renders projects in most-recently-used order from persisted timestamps", () => {
+    const { container } = renderPicker();
+    expect(renderedOrder(container, names)).toEqual(["C", "B", "A"]);
+  });
+
+  it("falls back to persisted order when no usage manager is provided", () => {
+    const { container } = renderPicker(undefined);
+    // No crash, and the persisted MRU order still holds.
+    expect(renderedOrder(container, names)).toEqual(["C", "B", "A"]);
+  });
+
+  it("re-sorts to reflect an in-memory touch ahead of the throttled persist", () => {
+    const manager = new RecentUsageManager<string>();
+    const { container } = renderPicker(manager);
+    expect(renderedOrder(container, names)).toEqual(["C", "B", "A"]);
+
+    // Touch the oldest project in memory only (no persist). The revision
+    // subscription should re-sort it to the top even though its persisted
+    // UsageTimestamps is still the oldest.
+    act(() => {
+      manager.touch("A");
+    });
+
+    expect(renderedOrder(container, names)).toEqual(["A", "C", "B"]);
+  });
+
+  it("surfaces the inline Reveal / Edit / Delete actions on every row", () => {
+    const { getByLabelText } = renderPicker();
+    // The actions render inline per row (revealed on hover via CSS) instead of
+    // behind a single overflow trigger — getByLabelText throws if any is missing,
+    // so resolving all three per project is the assertion.
+    for (const name of names) {
+      expect(getByLabelText(`Reveal ${name} in vault`)).toBeTruthy();
+      expect(getByLabelText(`Edit project ${name}`)).toBeTruthy();
+      expect(getByLabelText(`Delete project ${name}`)).toBeTruthy();
+    }
+  });
+});

--- a/src/agentMode/ui/ProjectPickerList.tsx
+++ b/src/agentMode/ui/ProjectPickerList.tsx
@@ -4,138 +4,159 @@ import {
   AgentHomeViewAll,
   INLINE_LIMIT,
 } from "@/agentMode/ui/AgentHomeSection";
+import { AgentProjectRowActions } from "@/agentMode/ui/AgentProjectRowActions";
+import { ProjectIconTile } from "@/agentMode/ui/ProjectIconTile";
 import { ProjectConfig } from "@/aiParams";
+import { useRecentUsageManagerRevision } from "@/hooks/useRecentUsageManagerRevision";
 import { cn } from "@/lib/utils";
 import { filterProjects } from "@/utils/projectUtils";
-import { sortByStrategy, type SortStrategy } from "@/utils/recentUsageManager";
-import { Folder } from "lucide-react";
+import { RecentUsageManager, sortByStrategy, type SortStrategy } from "@/utils/recentUsageManager";
+import { App } from "obsidian";
 import React, { memo, useMemo, useState } from "react";
 
-// Reason: PR1 is strictly read-only — surface a fixed sort (most-recently-used first)
-// without exposing a switcher or writing the strategy back to settings.
-const READ_ONLY_SORT_STRATEGY: SortStrategy = "recent";
-
-// Stable per-project accent: hash the id into one of six theme hues so a project
-// keeps the same color across renders and sessions (Math.random would reshuffle
-// every paint). Each entry pairs a solid `text` hue with its soft `bg` tint from
-// the `project` palette in tailwind.config — the folder glyph inherits the text
-// color, the tile shows the tint behind it.
-const PROJECT_ICON_PALETTE = [
-  "tw-text-project-red tw-bg-project-red",
-  "tw-text-project-orange tw-bg-project-orange",
-  "tw-text-project-yellow tw-bg-project-yellow",
-  "tw-text-project-green tw-bg-project-green",
-  "tw-text-project-blue tw-bg-project-blue",
-  "tw-text-project-purple tw-bg-project-purple",
-] as const;
-
-function projectIconClasses(id: string): string {
-  let hash = 0;
-  for (let i = 0; i < id.length; i++) {
-    hash = (hash << 5) - hash + id.charCodeAt(i);
-    hash |= 0; // clamp to 32-bit so long ids stay deterministic
-  }
-  return PROJECT_ICON_PALETTE[Math.abs(hash) % PROJECT_ICON_PALETTE.length];
-}
-
-/** Tinted square + colored folder, stable per project id. */
-const ProjectIconTile = memo(({ id }: { id: string }) => (
-  <span
-    aria-hidden="true"
-    className={cn(
-      "tw-flex tw-size-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-md",
-      projectIconClasses(id)
-    )}
-  >
-    <Folder className="tw-size-4" />
-  </span>
-));
-ProjectIconTile.displayName = "ProjectIconTile";
+// Reason: the landing surfaces a fixed most-recently-used order with no switcher
+// and never writes the strategy back to settings.
+const LANDING_SORT_STRATEGY: SortStrategy = "recent";
 
 interface ProjectPickerListProps {
   /** Full project list (already reactive from useProjects upstream). */
   projects: ProjectConfig[];
-  /** Caller-owned selection handler. In PR1 core wires this to a coming-soon Notice. */
+  /** Caller-owned selection handler. PR2a wires this to `enterProject`. */
   onSelect: (project: ProjectConfig) => void;
   /**
-   * Optional header create action. When provided, a "+" button renders in the
-   * section header. PR1 wires this to a coming-soon Notice (no project CRUD).
+   * Optional create action, rendered as the leading "New project" row. Receives
+   * the row's button element so the caller can anchor the create popover to it.
    */
-  onCreate?: () => void;
+  onCreate?: (anchor: HTMLElement) => void;
+  /** Threaded to each row's inline actions (Reveal / Edit / Delete). */
+  app: App;
+  /** Forwarded to the row actions so the caller can exit a deleted active scope. */
+  onProjectDeleted?: (projectId: string) => void;
+  /**
+   * Shared in-memory usage manager. Blended into the sort + row time so entering a
+   * project reorders the list immediately, ahead of the throttled disk persist.
+   */
+  projectUsageTimestampsManager?: RecentUsageManager<string>;
   className?: string;
 }
 
 /**
- * Stable read-only ordering shared by the inline list and the View-all popover.
- *
- * DESIGN NOTE: sorts on the persisted `project.UsageTimestamps` only — it does
- * NOT blend in-memory touches via `RecentUsageManager.getEffectiveLastUsedAt`
- * the way the main chat-mode `ProjectList` does. This landing surface is
- * read-only: picking a project only fires a coming-soon Notice and never
- * touches usage, so the two lists diverge only in a narrow cross-surface race —
- * use a project in chat mode, then open Agent Home before the persisted
- * timestamp / file-backed project list catches up. Parity would mean threading
- * the project usage manager + a
- * `useSyncExternalStore` revision subscription into this deliberately minimal
- * read-only component; that cost outweighs the low-probability stale recency.
- * Accepted as consistency debt to resolve when the landing becomes interactive
- * (projects can be entered/touched here) by extracting a shared recency hook. If
- * a future review flags the divergence again, point them at this note.
+ * Effective last-used time for a project: the in-memory value (if more recent than
+ * the persisted one) so a just-entered project sorts/displays as most-recent before
+ * its timestamp persists, falling back to `created` when never used.
  */
-function useSortedProjects(projects: ProjectConfig[]): ProjectConfig[] {
+function effectiveLastUsedMs(
+  project: ProjectConfig,
+  manager: RecentUsageManager<string> | undefined
+): number {
+  return (
+    manager?.getEffectiveLastUsedAt(project.id, project.UsageTimestamps) ||
+    project.UsageTimestamps ||
+    project.created
+  );
+}
+
+/**
+ * Most-recently-used ordering shared by the inline list and the View-all popover.
+ *
+ * The landing is interactive — entering a project touches its usage — so this blends
+ * the in-memory {@link RecentUsageManager} via `getEffectiveLastUsedAt` exactly like
+ * the chat-mode `ProjectList`, and both read the SAME shared manager instance. The
+ * revision subscription drives a re-sort when memory changes between throttled
+ * persists, so a just-entered project jumps to the top before its timestamp lands on
+ * disk.
+ */
+function useSortedProjects(
+  projects: ProjectConfig[],
+  manager: RecentUsageManager<string> | undefined
+): ProjectConfig[] {
+  const revision = useRecentUsageManagerRevision(manager);
   return useMemo(
     () =>
-      sortByStrategy(projects, READ_ONLY_SORT_STRATEGY, {
+      sortByStrategy(projects, LANDING_SORT_STRATEGY, {
         getName: (project) => project.name,
         getCreatedAtMs: (project) => project.created,
-        getLastUsedAtMs: (project) => project.UsageTimestamps,
+        getLastUsedAtMs: (project) =>
+          manager?.getEffectiveLastUsedAt(project.id, project.UsageTimestamps) ??
+          project.UsageTimestamps,
       }),
-    [projects]
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- revision triggers re-sort when the manager's in-memory state changes
+    [projects, manager, revision]
   );
 }
 
 interface ProjectRowProps {
   project: ProjectConfig;
+  /**
+   * Effective last-used time, computed by the parent. Passed as a prop (not read
+   * from `project` here) so this `memo`'d row re-renders when only the in-memory
+   * time changes — the project reference itself stays stable across a touch.
+   */
+  timeMs: number;
   onSelect: (project: ProjectConfig) => void;
+  app: App;
+  onDeleted?: (projectId: string) => void;
 }
 
-const ProjectRow = memo(({ project, onSelect }: ProjectRowProps) => (
+const ProjectRow = memo(({ project, timeMs, onSelect, app, onDeleted }: ProjectRowProps) => (
   <AgentHomeListRow
     label={project.name}
-    timeMs={project.UsageTimestamps || project.created}
+    timeMs={timeMs}
     onClick={() => onSelect(project)}
     leading={<ProjectIconTile id={project.id} />}
+    trailing={<AgentProjectRowActions app={app} project={project} onDeleted={onDeleted} />}
   />
 ));
 ProjectRow.displayName = "ProjectRow";
 
 /**
- * Read-only project browser for the Agent Home landing (design A.2 + B.2).
+ * Project browser for the Agent Home landing (design A.2 + B.2).
  *
  * Shows the {@link INLINE_LIMIT} most-recent projects inline with a "View all
  * projects" affordance opening an in-pane search popover (not a fullscreen
  * modal). Selection and the optional create action are delegated to the caller;
- * this component never mutates project state, usage, or current-project.
+ * this component never mutates project state directly. Entering a project (via the
+ * caller) touches usage on the shared manager, which reorders this list live.
  */
 export const ProjectPickerList = memo(
-  ({ projects, onSelect, onCreate, className }: ProjectPickerListProps): React.ReactElement => {
+  ({
+    projects,
+    onSelect,
+    onCreate,
+    app,
+    onProjectDeleted,
+    projectUsageTimestampsManager,
+    className,
+  }: ProjectPickerListProps): React.ReactElement => {
     const [searchQuery, setSearchQuery] = useState("");
 
-    const sortedProjects = useSortedProjects(projects);
+    const sortedProjects = useSortedProjects(projects, projectUsageTimestampsManager);
     const inlineProjects = useMemo(() => sortedProjects.slice(0, INLINE_LIMIT), [sortedProjects]);
 
     const total = projects.length;
     const hasOverflow = total > INLINE_LIMIT;
 
     return (
-      <div className={cn("tw-flex tw-flex-col tw-divide-y tw-divide-border", className)}>
+      // tw-grow fills the shelf panel's fixed floor (AgentHomeShelf) so the
+      // empty-state copy below can center inside the card; the "New project"
+      // action row stays pinned at the top either way.
+      <div className={cn("tw-flex tw-grow tw-flex-col tw-divide-y tw-divide-border", className)}>
         {onCreate && <AgentHomeCreateRow label="New project" onClick={onCreate} />}
         {total === 0 ? (
-          <div className="tw-px-2 tw-py-1.5 tw-text-xs tw-text-muted">No projects available</div>
+          <div className="tw-flex tw-flex-1 tw-items-center tw-justify-center tw-px-2 tw-py-1.5 tw-text-xs tw-text-muted">
+            No projects available
+          </div>
         ) : (
           <>
             {inlineProjects.map((project) => (
-              <ProjectRow key={project.id} project={project} onSelect={onSelect} />
+              <ProjectRow
+                key={project.id}
+                project={project}
+                timeMs={effectiveLastUsedMs(project, projectUsageTimestampsManager)}
+                onSelect={onSelect}
+                app={app}
+                onDeleted={onProjectDeleted}
+              />
             ))}
             {hasOverflow && (
               <AgentHomeViewAll
@@ -152,10 +173,13 @@ export const ProjectPickerList = memo(
                   <ProjectRow
                     key={project.id}
                     project={project}
+                    timeMs={effectiveLastUsedMs(project, projectUsageTimestampsManager)}
                     onSelect={(selected) => {
                       onSelect(selected);
                       close();
                     }}
+                    app={app}
+                    onDeleted={onProjectDeleted}
                   />
                 )}
               />

--- a/src/agentMode/ui/ProjectSystemPromptModal.tsx
+++ b/src/agentMode/ui/ProjectSystemPromptModal.tsx
@@ -1,0 +1,106 @@
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { logError } from "@/logger";
+import { createPluginRoot } from "@/utils/react/createPluginRoot";
+import { App, Modal, Notice } from "obsidian";
+import React, { useState } from "react";
+import { Root } from "react-dom/client";
+
+interface ProjectSystemPromptModalContentProps {
+  initialPrompt: string;
+  onSave: (prompt: string) => Promise<void>;
+  onCancel: () => void;
+}
+
+function ProjectSystemPromptModalContent({
+  initialPrompt,
+  onSave,
+  onCancel,
+}: ProjectSystemPromptModalContentProps) {
+  const [prompt, setPrompt] = useState(initialPrompt);
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave(prompt);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-3">
+      <Textarea
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+        autoFocus
+        rows={6}
+        className="tw-min-h-24 tw-text-ui-small"
+        placeholder="Instructions the agent receives in every chat of this project…"
+      />
+      <div className="tw-flex tw-justify-end tw-gap-2">
+        <Button variant="secondary" onClick={onCancel} disabled={saving}>
+          Cancel
+        </Button>
+        <Button variant="default" onClick={handleSave} disabled={saving}>
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Lightweight editor for a project's system prompt (the "System Prompt" row
+ * in the project-info popover) — the F3 frame of the design handoff. A small
+ * native Modal (popout-correct, ESC handling) instead of the full Edit
+ * Project modal: a single textarea. No `{[[note]]}` template hints here —
+ * those variables are expanded by legacy chat's prompt processor only; agent
+ * backends receive the prompt verbatim.
+ *
+ * Saving persists via the caller; the prompt is captured per session at
+ * create/resume time on every backend, so edits apply to NEW chats only —
+ * the Notice says so explicitly.
+ */
+export class ProjectSystemPromptModal extends Modal {
+  private root: Root | null = null;
+
+  constructor(
+    app: App,
+    private readonly initialPrompt: string,
+    private readonly persist: (prompt: string) => Promise<void>
+  ) {
+    super(app);
+    // https://docs.obsidian.md/Reference/TypeScript+API/Modal/setTitle
+    // @ts-ignore
+    this.setTitle("Edit System Prompt");
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+    this.root = createPluginRoot(contentEl, this.app);
+    this.root.render(
+      <ProjectSystemPromptModalContent
+        initialPrompt={this.initialPrompt}
+        onCancel={() => this.close()}
+        onSave={async (prompt) => {
+          try {
+            await this.persist(prompt);
+            new Notice("System prompt saved. Applies to new chats.");
+            this.close();
+          } catch (e) {
+            logError("[ProjectSystemPromptModal] save failed", e);
+            new Notice("Failed to save the system prompt.");
+          }
+        }}
+      />
+    );
+  }
+
+  onClose() {
+    this.root?.unmount();
+    this.root = null;
+    this.contentEl.empty();
+  }
+}

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -631,7 +631,10 @@ describe("buildModelOnChange", () => {
     // Allow the IIFE to run.
     await new Promise((r) => window.setTimeout(r, 0));
     expect(persistDefaultSelection).not.toHaveBeenCalled();
-    expect(createSession).toHaveBeenCalledWith("claude", { baseModelId: "opus", effort: "low" });
+    expect(createSession).toHaveBeenCalledWith("claude", undefined, {
+      baseModelId: "opus",
+      effort: "low",
+    });
     expect(setDefaultBackend).toHaveBeenCalledWith("claude");
     expect(closeSession).toHaveBeenCalledWith("tab-1");
   });

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -365,7 +365,8 @@ function runCrossBackendPick(
 ): void {
   void (async () => {
     try {
-      await manager.createSession(targetBackendId, { baseModelId, effort });
+      // projectId left default (active scope); the transient pick only seeds the model.
+      await manager.createSession(targetBackendId, undefined, { baseModelId, effort });
       manager.setDefaultBackend(targetBackendId);
       if (oldSessionId) {
         void manager

--- a/src/agentMode/ui/hooks/useAgentChatRuntimeState.test.tsx
+++ b/src/agentMode/ui/hooks/useAgentChatRuntimeState.test.tsx
@@ -1,6 +1,7 @@
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type {
   AgentChatMessage,
+  AgentTodoListEntry,
   AskUserQuestionPrompt,
   CurrentPlan,
   PermissionPrompt,
@@ -13,6 +14,7 @@ interface FakeBackendState {
   isStarting: boolean;
   hasPendingPlanPermission: boolean;
   currentPlan: CurrentPlan | null;
+  currentTodoList?: AgentTodoListEntry[] | null;
   pendingToolPermissions: PermissionPrompt[];
   pendingAskUserQuestions: AskUserQuestionPrompt[];
 }
@@ -28,6 +30,7 @@ function makeFakeBackend(initial: Partial<FakeBackendState> = {}) {
     isStarting: initial.isStarting ?? false,
     hasPendingPlanPermission: initial.hasPendingPlanPermission ?? false,
     currentPlan: initial.currentPlan ?? null,
+    currentTodoList: initial.currentTodoList ?? null,
     pendingToolPermissions: initial.pendingToolPermissions ?? [],
     pendingAskUserQuestions: initial.pendingAskUserQuestions ?? [],
   };
@@ -42,6 +45,7 @@ function makeFakeBackend(initial: Partial<FakeBackendState> = {}) {
     isStarting: () => state.isStarting,
     hasPendingPlanPermission: () => state.hasPendingPlanPermission,
     getCurrentPlan: () => state.currentPlan,
+    getCurrentTodoList: () => state.currentTodoList ?? null,
     getPendingToolPermissions: () => state.pendingToolPermissions,
     getPendingAskUserQuestions: () => state.pendingAskUserQuestions,
   } as unknown as AgentChatBackend;

--- a/src/agentMode/ui/hooks/useAgentChatRuntimeState.ts
+++ b/src/agentMode/ui/hooks/useAgentChatRuntimeState.ts
@@ -1,6 +1,7 @@
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type {
   AgentChatMessage,
+  AgentTodoListEntry,
   AskUserQuestionPrompt,
   CurrentPlan,
   PermissionPrompt,
@@ -19,6 +20,7 @@ export interface AgentChatRuntimeState {
   isStarting: boolean;
   hasPendingPlanPermission: boolean;
   currentPlan: CurrentPlan | null;
+  currentTodoList: AgentTodoListEntry[] | null;
   pendingToolPermissions: PermissionPrompt[];
   pendingAskUserQuestions: AskUserQuestionPrompt[];
 }
@@ -31,6 +33,9 @@ export function useAgentChatRuntimeState(backend: AgentChatBackend): AgentChatRu
   );
   const [currentPlan, setCurrentPlan] = useState<CurrentPlan | null>(() =>
     backend.getCurrentPlan()
+  );
+  const [currentTodoList, setCurrentTodoList] = useState<AgentTodoListEntry[] | null>(() =>
+    backend.getCurrentTodoList()
   );
   const [pendingToolPermissions, setPendingToolPermissions] = useState<PermissionPrompt[]>(() =>
     backend.getPendingToolPermissions()
@@ -59,6 +64,7 @@ export function useAgentChatRuntimeState(backend: AgentChatBackend): AgentChatRu
       setIsStarting(backend.isStarting());
       setHasPendingPlanPermission(backend.hasPendingPlanPermission());
       setCurrentPlan(backend.getCurrentPlan());
+      setCurrentTodoList(backend.getCurrentTodoList());
       setPendingToolPermissions(backend.getPendingToolPermissions());
       setPendingAskUserQuestions(backend.getPendingAskUserQuestions());
     };
@@ -74,6 +80,7 @@ export function useAgentChatRuntimeState(backend: AgentChatBackend): AgentChatRu
     isStarting,
     hasPendingPlanPermission,
     currentPlan,
+    currentTodoList,
     pendingToolPermissions,
     pendingAskUserQuestions,
   };

--- a/src/agentMode/ui/hooks/useAgentHistoryControls.test.tsx
+++ b/src/agentMode/ui/hooks/useAgentHistoryControls.test.tsx
@@ -1,0 +1,192 @@
+import { useAgentHistoryControls } from "@/agentMode/ui/hooks/useAgentHistoryControls";
+import { GLOBAL_SCOPE } from "@/agentMode/session/scope";
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import type { ChatHistoryItem } from "@/components/chat-components/ChatHistoryPopover";
+import type CopilotPlugin from "@/main";
+import { act, renderHook } from "@testing-library/react";
+
+const item = (id: string): ChatHistoryItem => ({ id }) as unknown as ChatHistoryItem;
+
+function makeManager() {
+  return {
+    getChatHistoryItems: jest.fn(async () => [item("a"), item("b")]),
+    updateChatTitle: jest.fn(async () => {}),
+    deleteChatHistory: jest.fn(async () => {}),
+  } as unknown as AgentSessionManager & {
+    getChatHistoryItems: jest.Mock;
+    updateChatTitle: jest.Mock;
+    deleteChatHistory: jest.Mock;
+  };
+}
+
+const plugin = {} as unknown as CopilotPlugin;
+
+const renderControls = (manager: AgentSessionManager, scope?: string) =>
+  renderHook(({ s }: { s?: string }) => useAgentHistoryControls(manager, plugin, s), {
+    initialProps: { s: scope },
+  });
+
+describe("useAgentHistoryControls scope", () => {
+  it("regression: the global landing caller (no scope) loads ALL history", async () => {
+    // Reason: the highest-risk regression in PR2a is silently scoping the global
+    // Recent Chats list. Omitting `scope` must keep fetching every chat — the
+    // manager treats `undefined` as the flat all-chats view.
+    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+    const { result } = renderControls(manager);
+
+    await act(async () => {
+      await result.current.loadChatHistory();
+    });
+
+    expect(manager.getChatHistoryItems).toHaveBeenCalledWith(undefined);
+    expect(result.current.chatHistoryItems).toHaveLength(2);
+  });
+
+  it("loads only the active scope's chats when a project scope is passed", async () => {
+    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+    const { result } = renderControls(manager, "project-1");
+
+    await act(async () => {
+      await result.current.loadChatHistory();
+    });
+
+    expect(manager.getChatHistoryItems).toHaveBeenCalledWith("project-1");
+  });
+
+  it("GLOBAL_SCOPE behaves like the global all-chats view", async () => {
+    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+    const { result } = renderControls(manager, GLOBAL_SCOPE);
+
+    await act(async () => {
+      await result.current.loadChatHistory();
+    });
+
+    expect(manager.getChatHistoryItems).toHaveBeenCalledWith(GLOBAL_SCOPE);
+  });
+
+  it("hides the previous scope's items on a scope change until the refetch lands", async () => {
+    // Reason: AgentHome feeds one shared hook to both the project-landing Project
+    // Chats and the conversation History popover. The `scope` prop flips
+    // synchronously but the reload is async, so the stored items briefly belong to
+    // the old scope — they must not flash (e.g. another project's chats, or the
+    // global flat view) before the scoped refetch completes.
+    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+    const { result, rerender } = renderControls(manager, "project-1");
+
+    await act(async () => {
+      await result.current.loadChatHistory();
+    });
+    expect(result.current.chatHistoryItems).toHaveLength(2);
+
+    // Switch project before the new scope's items load → list clears, not stale.
+    rerender({ s: "project-2" });
+    expect(result.current.chatHistoryItems).toHaveLength(0);
+
+    await act(async () => {
+      await result.current.loadChatHistory();
+    });
+    expect(manager.getChatHistoryItems).toHaveBeenLastCalledWith("project-2");
+    expect(result.current.chatHistoryItems).toHaveLength(2);
+  });
+
+  it("drops a stale out-of-order load whose scope was superseded mid-flight", async () => {
+    // Reason: if the scope flips while an older fetch is still in flight and that
+    // older fetch resolves AFTER the newer one, it must not write its stale items
+    // back — otherwise the current scope's list is clobbered by the prior scope's
+    // and sticks (the visible-scope guard would then blank it permanently).
+    const resolvers: Record<string, (items: ChatHistoryItem[]) => void> = {};
+    const manager = {
+      getChatHistoryItems: jest.fn(
+        (s?: string) =>
+          new Promise<ChatHistoryItem[]>((resolve) => {
+            resolvers[s ?? GLOBAL_SCOPE] = resolve;
+          })
+      ),
+      updateChatTitle: jest.fn(async () => {}),
+      deleteChatHistory: jest.fn(async () => {}),
+    } as unknown as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+
+    const { result, rerender } = renderControls(manager, "project-1");
+
+    // Start project-1's load (call A) and leave it pending.
+    let loadA!: Promise<void>;
+    act(() => {
+      loadA = result.current.loadChatHistory();
+    });
+
+    // Scope flips to project-2; start its load (call B).
+    rerender({ s: "project-2" });
+    let loadB!: Promise<void>;
+    act(() => {
+      loadB = result.current.loadChatHistory();
+    });
+
+    // B lands first → project-2 items are shown.
+    await act(async () => {
+      resolvers["project-2"]([item("b1"), item("b2")]);
+      await loadB;
+    });
+    expect(result.current.chatHistoryItems).toHaveLength(2);
+
+    // A (stale project-1) resolves late → dropped, list stays on project-2's items.
+    await act(async () => {
+      resolvers["project-1"]([item("a1")]);
+      await loadA;
+    });
+    expect(result.current.chatHistoryItems).toHaveLength(2);
+  });
+
+  it("reports settled only after a load for the CURRENT scope completes", async () => {
+    // Reason: the project landing decides its layout (standalone Context vs the
+    // tabbed shelf) from the chat count, so it must be able to tell "not loaded
+    // yet" apart from "this project has no chats" — and a scope switch must
+    // reset the flag until the new scope's load lands.
+    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+    const { result, rerender } = renderControls(manager, "project-1");
+
+    expect(result.current.chatHistorySettled).toBe(false);
+    await act(async () => {
+      await result.current.loadChatHistory();
+    });
+    expect(result.current.chatHistorySettled).toBe(true);
+
+    rerender({ s: "project-2" });
+    expect(result.current.chatHistorySettled).toBe(false);
+    await act(async () => {
+      await result.current.loadChatHistory();
+    });
+    expect(result.current.chatHistorySettled).toBe(true);
+  });
+
+  it("settles even when the load fails, leaving the items empty", async () => {
+    // Reason: a failed first load must not leave the landing undecided forever
+    // (blank below the composer) — it settles with an empty list and the landing
+    // degrades to its zero-chat layout.
+    const manager = makeManager() as AgentSessionManager & { getChatHistoryItems: jest.Mock };
+    manager.getChatHistoryItems.mockRejectedValueOnce(new Error("vault read failed"));
+    const { result } = renderControls(manager, "project-1");
+
+    await act(async () => {
+      await result.current.loadChatHistory();
+    });
+
+    expect(result.current.chatHistorySettled).toBe(true);
+    expect(result.current.chatHistoryItems).toHaveLength(0);
+  });
+
+  it("refreshes within the same scope after a delete", async () => {
+    const manager = makeManager() as AgentSessionManager & {
+      getChatHistoryItems: jest.Mock;
+      deleteChatHistory: jest.Mock;
+    };
+    const { result } = renderControls(manager, "project-1");
+
+    await act(async () => {
+      await result.current.deleteChat("a");
+    });
+
+    expect(manager.deleteChatHistory).toHaveBeenCalledWith("a");
+    // The post-mutation reload must stay scoped, not fall back to global.
+    expect(manager.getChatHistoryItems).toHaveBeenCalledWith("project-1");
+  });
+});

--- a/src/agentMode/ui/hooks/useAgentHistoryControls.ts
+++ b/src/agentMode/ui/hooks/useAgentHistoryControls.ts
@@ -1,12 +1,26 @@
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { GLOBAL_SCOPE, type ProjectScopeId } from "@/agentMode/session/scope";
 import type { ChatHistoryItem } from "@/components/chat-components/ChatHistoryPopover";
 import { logError } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { Notice } from "obsidian";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+// Frozen empty slice returned while the loaded items belong to a different scope
+// than the one currently requested — a stable reference avoids a render churn.
+const EMPTY_CHAT_HISTORY_ITEMS = Object.freeze([]) as unknown as ChatHistoryItem[];
+
 export interface AgentHistoryControls {
   chatHistoryItems: ChatHistoryItem[];
+  /**
+   * True once a history load for the CURRENT scope has settled — success or
+   * failure. Lets the project landing wait for a real answer before deciding
+   * what to render below the composer (anti-flash), instead of mistaking the
+   * not-yet-loaded empty list for "this project has no chats". On failure the
+   * list stays empty and this still flips true: the landing degrades to its
+   * zero-chat layout rather than a permanent blank.
+   */
+  chatHistorySettled: boolean;
   loadChatHistory: () => Promise<void>;
   loadChat: (id: string) => Promise<void>;
   updateChatTitle: (id: string, newTitle: string) => Promise<void>;
@@ -18,12 +32,32 @@ export interface AgentHistoryControls {
  * History popover handlers (load list, open, rename, delete, open source) plus
  * the items state they refresh. Kept separate from chat-runtime state because
  * these are user-initiated one-shots, not backend-stream reactions.
+ *
+ * `scope` selects which chats the list loads (and reloads after rename/delete):
+ * a project id shows only that project's chats, the global workspace (default)
+ * shows the flat all-chats view. Changing `scope` re-fetches, so switching
+ * project re-scopes the section.
  */
 export function useAgentHistoryControls(
   manager: AgentSessionManager,
-  plugin: CopilotPlugin
+  plugin: CopilotPlugin,
+  scope?: ProjectScopeId
 ): AgentHistoryControls {
   const [chatHistoryItems, setChatHistoryItems] = useState<ChatHistoryItem[]>([]);
+  // Track which scope the loaded items belong to. On a scope change the prop
+  // updates synchronously but `loadChatHistory` is async, so the stored items
+  // briefly belong to the *previous* scope — hide them until the refetch lands
+  // rather than flash another project's (or the global flat) chats.
+  const effectiveScope = scope ?? GLOBAL_SCOPE;
+  const [loadedScope, setLoadedScope] = useState<ProjectScopeId>(effectiveScope);
+  const visibleChatHistoryItems =
+    loadedScope === effectiveScope ? chatHistoryItems : EMPTY_CHAT_HISTORY_ITEMS;
+  // Which scope has had a load SETTLE (success or failure). Deliberately a
+  // separate state from `loadedScope`: that one starts at `effectiveScope` (so
+  // the initial empty list is "visible"), which would misreport "already
+  // loaded" before the first fetch ever ran.
+  const [settledScope, setSettledScope] = useState<ProjectScopeId | null>(null);
+  const chatHistorySettled = settledScope === effectiveScope;
 
   const isMountedRef = useRef(false);
   useEffect(() => {
@@ -32,6 +66,15 @@ export function useAgentHistoryControls(
       isMountedRef.current = false;
     };
   }, []);
+
+  // Latest requested scope, for dropping out-of-order loads: if the scope flips
+  // while an older fetch is in flight, that fetch must NOT write back its (now
+  // stale) items/scope after the newer fetch has already landed — otherwise the
+  // current scope's list would be replaced by the previous scope's and stick.
+  const latestScopeRef = useRef(effectiveScope);
+  useEffect(() => {
+    latestScopeRef.current = effectiveScope;
+  }, [effectiveScope]);
 
   // Wrap an async action so a failure logs and surfaces a Notice consistently.
   // `rethrow` is on for callbacks the popover uses to revert inline edits
@@ -50,11 +93,21 @@ export function useAgentHistoryControls(
   );
 
   const loadChatHistory = useCallback(async () => {
+    const requestScope = scope ?? GLOBAL_SCOPE;
     await runWithNotice("load chat history", async () => {
-      const items = await manager.getChatHistoryItems();
-      if (isMountedRef.current) setChatHistoryItems(items);
+      const items = await manager.getChatHistoryItems(scope);
+      // Drop a stale result whose scope was superseded while it was in flight.
+      if (isMountedRef.current && latestScopeRef.current === requestScope) {
+        setLoadedScope(requestScope);
+        setChatHistoryItems(items);
+      }
     });
-  }, [manager, runWithNotice]);
+    // Mark settled even when the fetch failed (runWithNotice swallows the
+    // error): the items just stay as they were. Same staleness guard as above.
+    if (isMountedRef.current && latestScopeRef.current === requestScope) {
+      setSettledScope(requestScope);
+    }
+  }, [manager, runWithNotice, scope]);
 
   const loadChat = useCallback(
     async (id: string) => {
@@ -99,7 +152,8 @@ export function useAgentHistoryControls(
   );
 
   return {
-    chatHistoryItems,
+    chatHistoryItems: visibleChatHistoryItems,
+    chatHistorySettled,
     loadChatHistory,
     loadChat,
     updateChatTitle,

--- a/src/agentMode/ui/hooks/useAgentInputDrafts.test.tsx
+++ b/src/agentMode/ui/hooks/useAgentInputDrafts.test.tsx
@@ -134,4 +134,69 @@ describe("useAgentInputDrafts", () => {
     rerender({ activeSessionId: "a", liveSessionIds: ["b"], defaultIncludeActiveNote: false });
     expect(result.current.input).toBe("");
   });
+
+  it("migrates a draft typed during a session swap onto the replacement id", () => {
+    // Simulates the empty-landing refresh: the user types while the old session
+    // is still active (the new id isn't in liveSessionIds yet), then the swap
+    // migrates that draft onto the new session before the old one is pruned.
+    const { result, rerender } = renderDrafts({
+      activeSessionId: "old",
+      liveSessionIds: ["old"],
+      defaultIncludeActiveNote: false,
+    });
+
+    act(() => {
+      result.current.setInput("typed during startup");
+      result.current.setContextNotes([file("note.md")]);
+      result.current.addImages([new File([], "img.png")]);
+      result.current.setIncludeActiveWebTab(true);
+      result.current.setQueue([queued("q1")]);
+    });
+
+    act(() => result.current.migrateDraft("old", "new"));
+
+    // Once React observes the new session, its draft carries the typed content.
+    rerender({ activeSessionId: "new", liveSessionIds: ["new"], defaultIncludeActiveNote: false });
+    expect(result.current.input).toBe("typed during startup");
+    expect(result.current.contextNotes.map((n) => n.path)).toEqual(["note.md"]);
+    expect(result.current.images).toHaveLength(1);
+    expect(result.current.includeActiveWebTab).toBe(true);
+    expect(result.current.queue.map((q) => q.id)).toEqual(["q1"]);
+
+    // The old id no longer holds the migrated draft.
+    rerender({ activeSessionId: "old", liveSessionIds: ["new"], defaultIncludeActiveNote: false });
+    expect(result.current.input).toBe("");
+  });
+
+  it("does not migrate an empty source draft (clean swap stays clean)", () => {
+    const { result, rerender } = renderDrafts({
+      activeSessionId: "old",
+      liveSessionIds: ["old"],
+      defaultIncludeActiveNote: false,
+    });
+
+    act(() => result.current.migrateDraft("old", "new"));
+
+    rerender({ activeSessionId: "new", liveSessionIds: ["new"], defaultIncludeActiveNote: false });
+    expect(result.current.input).toBe("");
+  });
+
+  it("does not clobber input the user already started on the replacement", () => {
+    const { result, rerender } = renderDrafts({
+      activeSessionId: "old",
+      liveSessionIds: ["old", "new"],
+      defaultIncludeActiveNote: false,
+    });
+
+    act(() => result.current.setInput("old draft"));
+    rerender({
+      activeSessionId: "new",
+      liveSessionIds: ["old", "new"],
+      defaultIncludeActiveNote: false,
+    });
+    act(() => result.current.setInput("new draft"));
+
+    act(() => result.current.migrateDraft("old", "new"));
+    expect(result.current.input).toBe("new draft");
+  });
 });

--- a/src/agentMode/ui/hooks/useAgentInputDrafts.ts
+++ b/src/agentMode/ui/hooks/useAgentInputDrafts.ts
@@ -60,6 +60,13 @@ export interface AgentInputDraftControls extends AgentInputDraft {
   setIncludeActiveWebTab: (include: boolean) => void;
   setLoading: (loading: boolean) => void;
   setQueue: React.Dispatch<React.SetStateAction<QueuedAgentMessage[]>>;
+  /**
+   * Carry a compose draft from a replaced session onto its replacement, so text
+   * typed during an in-place session swap (e.g. the empty-landing context
+   * refresh) survives the old session's pruning. No-op when the source draft is
+   * empty or the target already holds user input. See {@link migrateDraft}.
+   */
+  migrateDraft: (fromSessionId: string, toSessionId: string) => void;
   /** Clear the compose fields after a send; leaves loading/queue untouched. */
   resetCompose: () => void;
 }
@@ -82,6 +89,19 @@ const createDraft = (includeActiveNote: boolean): AgentInputDraft => ({
 
 const applyArrayState = <T>(value: React.SetStateAction<T[]>, previous: T[]): T[] =>
   typeof value === "function" ? value(previous) : value;
+
+/**
+ * Whether a draft carries anything worth preserving across a session swap —
+ * any composed text/attachments/queue, or a toggle the user moved off its seed.
+ * An untouched draft migrates to nothing, so the swap stays a clean reset.
+ */
+const hasDraftPayload = (draft: AgentInputDraft, defaultIncludeActiveNote: boolean): boolean =>
+  draft.input.length > 0 ||
+  draft.images.length > 0 ||
+  draft.contextNotes.length > 0 ||
+  draft.queue.length > 0 ||
+  draft.includeActiveNote !== defaultIncludeActiveNote ||
+  draft.includeActiveWebTab;
 
 export function useAgentInputDrafts({
   activeSessionId,
@@ -177,6 +197,39 @@ export function useAgentInputDrafts({
     [updateActive]
   );
 
+  // Move a draft onto a replacement session id during an in-place swap. Writes
+  // `setDrafts` DIRECTLY (not via `updateDraft`) on purpose: the new id isn't in
+  // `liveSetRef` yet — React hasn't observed the manager's new session list when
+  // the swap resolves — so `updateDraft`'s live-guard would drop the write. The
+  // caller runs this synchronously the moment `replaceSessionInPlace` resolves,
+  // while the old session's `closeSession` is still suspended at `await cancel()`
+  // (it deletes the session only afterwards), so the source draft is still
+  // present here and the prune effect only fires later. `loading` resets — the
+  // replacement starts its own turn.
+  const migrateDraft = useCallback(
+    (fromSessionId: string, toSessionId: string) => {
+      if (fromSessionId === toSessionId) return;
+      setDrafts((prev) => {
+        const source = prev[fromSessionId];
+        if (!source || !hasDraftPayload(source, defaultIncludeActiveNote)) return prev;
+        // Never clobber input the user already started on the replacement.
+        const target = prev[toSessionId];
+        if (target && hasDraftPayload(target, defaultIncludeActiveNote)) return prev;
+        const next = { ...prev };
+        delete next[fromSessionId];
+        next[toSessionId] = {
+          ...source,
+          images: [...source.images],
+          contextNotes: [...source.contextNotes],
+          queue: [...source.queue],
+          loading: false,
+        };
+        return next;
+      });
+    },
+    [defaultIncludeActiveNote]
+  );
+
   // DESIGN NOTE: resetCompose hard-clears includeActiveNote to false after a
   // send, so within one session the active note auto-attaches only to the
   // FIRST message. Two scenarios, only one of which matches the legacy
@@ -241,6 +294,7 @@ export function useAgentInputDrafts({
       setIncludeActiveWebTab,
       setLoading,
       setQueue,
+      migrateDraft,
       resetCompose,
     }),
     [
@@ -253,6 +307,7 @@ export function useAgentInputDrafts({
       setIncludeActiveWebTab,
       setLoading,
       setQueue,
+      migrateDraft,
       resetCompose,
     ]
   );

--- a/src/agentMode/ui/hooks/useAttentionChatIds.ts
+++ b/src/agentMode/ui/hooks/useAttentionChatIds.ts
@@ -1,0 +1,15 @@
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { useManagerSetSnapshot } from "@/agentMode/ui/hooks/useManagerSetSnapshot";
+
+const getAttentionSnapshot = (manager: AgentSessionManager): ReadonlySet<string> =>
+  manager.getAttentionChatIds();
+
+/**
+ * Reactive set of recent-list ids currently flagging needs-attention — the
+ * live complement to the `item.needsAttention` snapshot, so a row's done-dot
+ * lights up the moment its backgrounded turn finishes (taking over from the
+ * running spinner) instead of waiting for the next history reload.
+ */
+export function useAttentionChatIds(manager: AgentSessionManager): ReadonlySet<string> {
+  return useManagerSetSnapshot(manager, getAttentionSnapshot);
+}

--- a/src/agentMode/ui/hooks/useManagerSetSnapshot.ts
+++ b/src/agentMode/ui/hooks/useManagerSetSnapshot.ts
@@ -1,0 +1,41 @@
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { useEffect, useRef, useState } from "react";
+
+/** True when both sets hold exactly the same ids — used to skip no-op renders. */
+function sameMembership(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a === b) return true;
+  if (a.size !== b.size) return false;
+  for (const id of a) {
+    if (!b.has(id)) return false;
+  }
+  return true;
+}
+
+/**
+ * Reactive snapshot of a manager-derived id set (running chats, attention
+ * chats, …), resynced on every manager notify. New snapshots are adopted only
+ * when the membership actually changes, so an unrelated notify (tab switch,
+ * label edit) doesn't churn the consumer's reference. `getSnapshot` is held in
+ * a ref so an inline arrow at the call site doesn't tear down the subscription
+ * each render.
+ */
+export function useManagerSetSnapshot(
+  manager: AgentSessionManager,
+  getSnapshot: (manager: AgentSessionManager) => ReadonlySet<string>
+): ReadonlySet<string> {
+  const getSnapshotRef = useRef(getSnapshot);
+  getSnapshotRef.current = getSnapshot;
+
+  const [ids, setIds] = useState<ReadonlySet<string>>(() => getSnapshot(manager));
+
+  useEffect(() => {
+    const sync = (): void => {
+      const next = getSnapshotRef.current(manager);
+      setIds((prev) => (sameMembership(prev, next) ? prev : next));
+    };
+    sync();
+    return manager.subscribe(sync);
+  }, [manager]);
+
+  return ids;
+}

--- a/src/agentMode/ui/hooks/usePersistentContextDrop.test.tsx
+++ b/src/agentMode/ui/hooks/usePersistentContextDrop.test.tsx
@@ -1,0 +1,151 @@
+import { usePersistentContextDrop } from "@/agentMode/ui/hooks/usePersistentContextDrop";
+import type { ProjectConfig } from "@/aiParams";
+import { updateCachedProjectRecords } from "@/projects/state";
+import { createPatternSettingsValue, getDecodedPatterns } from "@/search/searchUtils";
+import { createEvent, fireEvent, render, waitFor } from "@testing-library/react";
+import { App, Notice, TFile, TFolder } from "obsidian";
+import React, { useRef } from "react";
+
+const mockUpdateProject = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("@/projects/ProjectFileManager", () => ({
+  ProjectFileManager: {
+    getInstance: () => ({ updateProject: mockUpdateProject }),
+  },
+}));
+
+function makeProject(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    id: "p1",
+    name: "Halcyon Scope",
+    systemPrompt: "",
+    projectModelKey: "",
+    modelConfigs: {},
+    contextSource: {},
+    created: 0,
+    UsageTimestamps: 0,
+    ...overrides,
+  };
+}
+
+function seedProject(project: ProjectConfig) {
+  updateCachedProjectRecords([
+    { project, filePath: "Halcyon Scope/project.md", folderName: "Halcyon Scope" },
+  ]);
+}
+
+/** App whose vault resolves the given path-keyed abstract files. */
+function makeApp(byPath: Record<string, TFile | TFolder>): App {
+  return {
+    vault: {
+      getAbstractFileByPath: (path: string) => byPath[path] ?? null,
+    },
+  } as unknown as App;
+}
+
+function Harness({ app, projectId }: { app: App; projectId: string }) {
+  const ref = useRef<HTMLDivElement>(null);
+  usePersistentContextDrop({ app, projectId, dropRef: ref });
+  return <div ref={ref} data-testid="zone" />;
+}
+
+interface FakeItem {
+  kind: "string" | "file";
+  value?: string;
+}
+
+function dispatchDrop(zone: HTMLElement, items: FakeItem[]) {
+  const dataTransfer = {
+    types: [] as string[],
+    dropEffect: "",
+    items: items.map((it) => ({
+      kind: it.kind,
+      getAsString: (cb: (data: string) => void) => cb(it.value ?? ""),
+    })),
+  };
+  const event = createEvent.drop(zone);
+  Object.defineProperty(event, "dataTransfer", { value: dataTransfer });
+  fireEvent(zone, event);
+}
+
+describe("usePersistentContextDrop", () => {
+  beforeEach(() => {
+    mockUpdateProject.mockClear();
+    (Notice as unknown as jest.Mock).mockClear();
+  });
+  afterEach(() => updateCachedProjectRecords([]));
+
+  it("persists a dropped folder as a new inclusion via updateProject", async () => {
+    seedProject(makeProject());
+    const folder = new (TFolder as unknown as new (p: string) => TFolder)("notes/ideas");
+    const app = makeApp({ "notes/ideas": folder });
+
+    const { getByTestId } = render(<Harness app={app} projectId="p1" />);
+    dispatchDrop(getByTestId("zone"), [{ kind: "string", value: "notes/ideas" }]);
+
+    await waitFor(() => expect(mockUpdateProject).toHaveBeenCalledTimes(1));
+    const [, nextConfig] = mockUpdateProject.mock.calls[0];
+    expect(getDecodedPatterns(nextConfig.contextSource.inclusions)).toContain("notes/ideas");
+  });
+
+  it("persists a dropped note as a [[basename]] inclusion", async () => {
+    seedProject(makeProject());
+    const file = new (TFile as unknown as new (p: string) => TFile)("notes/Intro.md");
+    const app = makeApp({ "notes/Intro.md": file });
+
+    const { getByTestId } = render(<Harness app={app} projectId="p1" />);
+    dispatchDrop(getByTestId("zone"), [{ kind: "string", value: "notes/Intro.md" }]);
+
+    await waitFor(() => expect(mockUpdateProject).toHaveBeenCalledTimes(1));
+    const [, nextConfig] = mockUpdateProject.mock.calls[0];
+    expect(getDecodedPatterns(nextConfig.contextSource.inclusions)).toContain("[[Intro]]");
+  });
+
+  it("parses an obsidian:// URI with trailing params (file is not the last query key)", async () => {
+    seedProject(makeProject());
+    const file = new (TFile as unknown as new (p: string) => TFile)("notes/A.md");
+    const app = makeApp({ "notes/A.md": file });
+
+    const { getByTestId } = render(<Harness app={app} projectId="p1" />);
+    dispatchDrop(getByTestId("zone"), [
+      { kind: "string", value: "obsidian://open?vault=V&file=notes%2FA.md&line=3" },
+    ]);
+
+    await waitFor(() => expect(mockUpdateProject).toHaveBeenCalledTimes(1));
+    const [, nextConfig] = mockUpdateProject.mock.calls[0];
+    expect(getDecodedPatterns(nextConfig.contextSource.inclusions)).toContain("[[A]]");
+  });
+
+  it("is idempotent — a duplicate inclusion is not re-written", async () => {
+    seedProject(
+      makeProject({
+        contextSource: { inclusions: createPatternSettingsValue({ notePatterns: ["[[Intro]]"] }) },
+      })
+    );
+    const file = new (TFile as unknown as new (p: string) => TFile)("notes/Intro.md");
+    const app = makeApp({ "notes/Intro.md": file });
+
+    const { getByTestId } = render(<Harness app={app} projectId="p1" />);
+    dispatchDrop(getByTestId("zone"), [{ kind: "string", value: "notes/Intro.md" }]);
+
+    await waitFor(() =>
+      expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith("Already in project context")
+    );
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+  });
+
+  it("rejects external OS files (no vault item resolved)", async () => {
+    seedProject(makeProject());
+    const app = makeApp({});
+
+    const { getByTestId } = render(<Harness app={app} projectId="p1" />);
+    dispatchDrop(getByTestId("zone"), [{ kind: "file" }]);
+
+    await waitFor(() =>
+      expect(Notice as unknown as jest.Mock).toHaveBeenCalledWith(
+        "Only vault files or folders can be added to project context"
+      )
+    );
+    expect(mockUpdateProject).not.toHaveBeenCalled();
+  });
+});

--- a/src/agentMode/ui/hooks/usePersistentContextDrop.ts
+++ b/src/agentMode/ui/hooks/usePersistentContextDrop.ts
@@ -1,0 +1,244 @@
+import type { ProjectConfig } from "@/aiParams";
+import { logWarn } from "@/logger";
+import { ProjectFileManager } from "@/projects/ProjectFileManager";
+import { getCachedProjectRecordById } from "@/projects/state";
+import {
+  createPatternSettingsValue,
+  getFilePattern,
+  getMatchingPatterns,
+} from "@/search/searchUtils";
+import { App, Notice, TFile, TFolder, type TAbstractFile } from "obsidian";
+import { RefObject, useEffect, useState } from "react";
+
+/**
+ * Props for {@link usePersistentContextDrop}.
+ *
+ * Distinct from `useChatFileDrop` on purpose: that hook adds notes to the
+ * CURRENT message draft (transient), this one writes a PERSISTENT project
+ * inclusion that applies to future chats. The two live in different drop zones
+ * inside the same chat container, split by a two-sided contract: the container
+ * hook yields while a drag hovers an element marked `data-copilot-drop-zone`
+ * (its capture-phase check), and this hook `stopPropagation()`s only on DROP so
+ * the dropped item doesn't also land in the draft. dragover is left bubbling —
+ * Obsidian's drag manager repositions the drag ghost at the document level.
+ */
+export interface UsePersistentContextDropProps {
+  /** Obsidian app instance for vault lookups + project writes. */
+  app: App;
+  /** Project whose `contextSource.inclusions` receives the dropped item. */
+  projectId: string;
+  /** The drop-zone element; native drag listeners attach here. */
+  dropRef: RefObject<HTMLElement>;
+  /** When false, listeners are not attached (e.g. section collapsed). */
+  enabled?: boolean;
+}
+
+export interface UsePersistentContextDropReturn {
+  /** True while a droppable drag hovers the zone — drives the hover styling. */
+  isDragging: boolean;
+}
+
+/** Drag originating inside the plugin (e.g. relevant-note chips) — never a drop target. */
+const INTERNAL_DRAG_TYPE = "copilot/internal-drag";
+
+/**
+ * Extract the `file` param from an `obsidian://open?...` URI, or null when the
+ * input isn't such a URI. Parses by query key (not a greedy tail match) so extra
+ * params like `&line=12` don't get folded into the path.
+ */
+function obsidianOpenFileParam(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "obsidian:" || url.hostname !== "open") return null;
+    return url.searchParams.get("file");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve one dropped line to a vault file or folder. Accepts both the
+ * `obsidian://open?...&file=<path>` URI form (nav-bar / explorer drags) and a
+ * bare vault-relative path, and retries with a `.md` suffix for extensionless
+ * note links. Returns a {@link TFolder} as well as a {@link TFile} — folders are
+ * valid project inclusions (the materializer pulls the whole directory).
+ */
+function resolveDroppedAbstractFile(app: App, raw: string): TAbstractFile | null {
+  const line = raw.trim();
+  if (!line) return null;
+
+  const path = obsidianOpenFileParam(line) ?? line;
+  return (
+    app.vault.getAbstractFileByPath(path) ?? app.vault.getAbstractFileByPath(`${path}.md`) ?? null
+  );
+}
+
+/**
+ * Persist the dropped vault items as project inclusions. Idempotent: a
+ * folder becomes a bare folder pattern, a file becomes a `[[basename]]` note
+ * pattern; anything already present is skipped. Re-encodes via the canonical
+ * `createPatternSettingsValue` helper (never a raw append) and writes through
+ * `updateProject`. Returns the number of new patterns added.
+ */
+async function persistInclusions(
+  app: App,
+  projectId: string,
+  files: TAbstractFile[]
+): Promise<number> {
+  const record = getCachedProjectRecordById(projectId);
+  if (!record) {
+    new Notice("Project not found — could not add to context");
+    return 0;
+  }
+
+  const project = record.project;
+  const { inclusions: existing } = getMatchingPatterns({
+    inclusions: project.contextSource?.inclusions,
+    isProject: true,
+  });
+  const folderPatterns = new Set(existing?.folderPatterns ?? []);
+  const notePatterns = new Set(existing?.notePatterns ?? []);
+  const tagPatterns = new Set(existing?.tagPatterns ?? []);
+  const extensionPatterns = new Set(existing?.extensionPatterns ?? []);
+
+  let added = 0;
+  for (const file of files) {
+    if (file instanceof TFolder) {
+      // Skip the vault root (empty path): it would include everything.
+      if (file.path && !folderPatterns.has(file.path)) {
+        folderPatterns.add(file.path);
+        added++;
+      }
+    } else if (file instanceof TFile) {
+      const pattern = getFilePattern(file);
+      if (!notePatterns.has(pattern)) {
+        notePatterns.add(pattern);
+        added++;
+      }
+    }
+  }
+
+  if (added === 0) return 0;
+
+  const inclusions = createPatternSettingsValue({
+    tagPatterns: [...tagPatterns],
+    extensionPatterns: [...extensionPatterns],
+    folderPatterns: [...folderPatterns],
+    notePatterns: [...notePatterns],
+  });
+  const next: ProjectConfig = {
+    ...project,
+    contextSource: { ...project.contextSource, inclusions },
+  };
+  await ProjectFileManager.getInstance(app).updateProject(projectId, next);
+  return added;
+}
+
+/**
+ * Read every string item off a drop event (each `getAsString` is async, so
+ * collect the promises first to avoid races), then resolve them to vault
+ * files/folders. Multi-file nav-bar drags arrive as a single newline-joined
+ * string, so split each item by line.
+ */
+async function collectDroppedFiles(app: App, items: DataTransferItem[]): Promise<TAbstractFile[]> {
+  const strings = await Promise.all(
+    items.map(
+      (item) =>
+        new Promise<string>((resolve) => {
+          item.getAsString((data) => resolve(data));
+        })
+    )
+  );
+
+  const byPath = new Map<string, TAbstractFile>();
+  for (const raw of strings) {
+    for (const line of raw.split("\n")) {
+      const file = resolveDroppedAbstractFile(app, line);
+      if (file) byPath.set(file.path, file);
+    }
+  }
+  return [...byPath.values()];
+}
+
+/**
+ * Native drag-and-drop for the project Context section's drop zone. Writes a
+ * PERSISTENT inclusion (applies to new chats; no mid-session re-materialize) and
+ * rejects external OS files, which can't become vault inclusions.
+ */
+export function usePersistentContextDrop(
+  props: UsePersistentContextDropProps
+): UsePersistentContextDropReturn {
+  const { app, projectId, dropRef, enabled = true } = props;
+  const [isDragging, setIsDragging] = useState(false);
+
+  useEffect(() => {
+    const zone = dropRef.current;
+    if (!zone || !enabled) return;
+
+    const handleDragOver = (e: DragEvent) => {
+      if (!e.dataTransfer) return;
+      // NO stopPropagation here: the dragover must keep bubbling to the
+      // document, where Obsidian's drag manager repositions the drag ghost —
+      // swallowing it freezes the ghost at the zone's edge. The container's
+      // chat-file handler yields on its own (capture-phase
+      // `data-copilot-drop-zone` check in useChatFileDrop), so there's nothing
+      // to suppress.
+      e.preventDefault();
+      if (e.dataTransfer.types.includes(INTERNAL_DRAG_TYPE)) return;
+      e.dataTransfer.dropEffect = "copy";
+      setIsDragging(true);
+    };
+
+    const handleDragLeave = (e: DragEvent) => {
+      const rect = zone.getBoundingClientRect();
+      const { clientX: x, clientY: y } = e;
+      if (x < rect.left || x >= rect.right || y < rect.top || y >= rect.bottom) {
+        setIsDragging(false);
+      }
+    };
+
+    const handleDrop = async (e: DragEvent) => {
+      if (!e.dataTransfer) return;
+      e.preventDefault();
+      e.stopPropagation();
+      setIsDragging(false);
+      if (e.dataTransfer.types.includes(INTERNAL_DRAG_TYPE)) return;
+
+      const all = Array.from(e.dataTransfer.items);
+      const stringItems = all.filter((item) => item.kind === "string");
+      const hasExternalFiles = all.some((item) => item.kind === "file");
+
+      const files = stringItems.length > 0 ? await collectDroppedFiles(app, stringItems) : [];
+      if (files.length === 0) {
+        if (hasExternalFiles) {
+          new Notice("Only vault files or folders can be added to project context");
+        }
+        return;
+      }
+
+      try {
+        const added = await persistInclusions(app, projectId, files);
+        if (added > 0) {
+          new Notice("Added to project context");
+        } else {
+          new Notice("Already in project context");
+        }
+      } catch (err) {
+        logWarn("[project-context] failed to add dropped inclusion", err);
+        new Notice("Could not add to project context");
+      }
+    };
+
+    const onDrop = (e: DragEvent) => void handleDrop(e);
+    zone.addEventListener("dragover", handleDragOver);
+    zone.addEventListener("dragleave", handleDragLeave);
+    zone.addEventListener("drop", onDrop);
+    return () => {
+      zone.removeEventListener("dragover", handleDragOver);
+      zone.removeEventListener("dragleave", handleDragLeave);
+      zone.removeEventListener("drop", onDrop);
+    };
+  }, [app, projectId, dropRef, enabled]);
+
+  return { isDragging };
+}

--- a/src/agentMode/ui/hooks/useRefreshEmptyLandingOnContextSourceChange.test.tsx
+++ b/src/agentMode/ui/hooks/useRefreshEmptyLandingOnContextSourceChange.test.tsx
@@ -1,0 +1,176 @@
+import { useRefreshEmptyLandingOnContextSourceChange } from "@/agentMode/ui/hooks/useRefreshEmptyLandingOnContextSourceChange";
+import { GLOBAL_SCOPE } from "@/agentMode/session/scope";
+import { act, render } from "@testing-library/react";
+import React from "react";
+
+interface Props {
+  activeProjectId: string;
+  signature: string | null;
+  isLanding: boolean;
+  blocking: boolean;
+  draftEmpty: boolean;
+  refresh: () => Promise<boolean>;
+}
+
+/** Drives the hook through a real component so effects + ref updates run as in
+ * production. Each render passes the current props verbatim. */
+function Harness(props: Props) {
+  useRefreshEmptyLandingOnContextSourceChange(props);
+  return null;
+}
+
+const BASE: Props = {
+  activeProjectId: "p1",
+  signature: "sig-a",
+  isLanding: true,
+  blocking: false,
+  draftEmpty: true,
+  refresh: async () => true,
+};
+
+/** Flush the microtasks the hook's then/finally chain schedules. */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("useRefreshEmptyLandingOnContextSourceChange", () => {
+  it("seeds on first sight without refreshing", async () => {
+    const refresh = jest.fn(async () => true);
+    render(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("refreshes when the signature changes on an empty landing", async () => {
+    const refresh = jest.fn(async () => true);
+    const { rerender } = render(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    rerender(<Harness {...BASE} signature="sig-b" refresh={refresh} />);
+    await flush();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh on an unchanged signature (re-render churn)", async () => {
+    const refresh = jest.fn(async () => true);
+    const { rerender } = render(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    rerender(<Harness {...BASE} refresh={refresh} />);
+    rerender(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("defers while the draft is dirty, then refreshes once it empties", async () => {
+    const refresh = jest.fn(async () => true);
+    const { rerender } = render(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    // Source changes while the user is typing — no refresh yet.
+    rerender(<Harness {...BASE} signature="sig-b" draftEmpty={false} refresh={refresh} />);
+    await flush();
+    expect(refresh).not.toHaveBeenCalled();
+    // User clears the input — the deferred change is now picked up.
+    rerender(<Harness {...BASE} signature="sig-b" draftEmpty={true} refresh={refresh} />);
+    await flush();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("defers while blocking, then refreshes once it clears", async () => {
+    const refresh = jest.fn(async () => true);
+    const { rerender } = render(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    rerender(<Harness {...BASE} signature="sig-b" blocking={true} refresh={refresh} />);
+    await flush();
+    expect(refresh).not.toHaveBeenCalled();
+    rerender(<Harness {...BASE} signature="sig-b" blocking={false} refresh={refresh} />);
+    await flush();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts the new signature on a conversation without refreshing", async () => {
+    const refresh = jest.fn(async () => true);
+    const { rerender } = render(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    // Not a landing: accept silently (next New Chat reads fresh config)…
+    rerender(<Harness {...BASE} signature="sig-b" isLanding={false} refresh={refresh} />);
+    await flush();
+    expect(refresh).not.toHaveBeenCalled();
+    // …and because the baseline advanced, returning to a landing at the SAME
+    // signature must not retroactively refresh.
+    rerender(<Harness {...BASE} signature="sig-b" isLanding={true} refresh={refresh} />);
+    await flush();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("re-seeds on a project switch instead of diffing across projects", async () => {
+    const refresh = jest.fn(async () => true);
+    const { rerender } = render(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    // A different project with a different signature is a switch, not an edit.
+    rerender(<Harness {...BASE} activeProjectId="p2" signature="sig-z" refresh={refresh} />);
+    await flush();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op for the global scope", async () => {
+    const refresh = jest.fn(async () => true);
+    const { rerender } = render(
+      <Harness {...BASE} activeProjectId={GLOBAL_SCOPE} signature={null} refresh={refresh} />
+    );
+    await flush();
+    rerender(
+      <Harness {...BASE} activeProjectId={GLOBAL_SCOPE} signature={null} refresh={refresh} />
+    );
+    await flush();
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not tight-loop when a refresh keeps failing", async () => {
+    // A guarded no-op / failure resolves false; the baseline must stay put
+    // WITHOUT self-ticking, so it retries only on a real dependency change.
+    const refresh = jest.fn(async () => false);
+    const { rerender } = render(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    rerender(<Harness {...BASE} signature="sig-b" refresh={refresh} />);
+    await flush();
+    await flush();
+    // Exactly one attempt for the one signature change — no self-driven retries.
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("converges to the final signature when it changes again mid-flight", async () => {
+    // Hold the first refresh open so the single-flight guard is active while a
+    // newer edit lands; on settle the hook must catch up to the LATEST signature.
+    let releaseFirst!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let call = 0;
+    const refresh = jest.fn(async () => {
+      call += 1;
+      if (call === 1) await gate; // first replace stays in flight
+      return true;
+    });
+
+    const { rerender } = render(<Harness {...BASE} refresh={refresh} />);
+    await flush();
+    // sig-a → sig-b kicks off the first (held) refresh.
+    rerender(<Harness {...BASE} signature="sig-b" refresh={refresh} />);
+    await flush();
+    // While it's in flight, sig-b → sig-c arrives — gated, no second call yet.
+    rerender(<Harness {...BASE} signature="sig-c" refresh={refresh} />);
+    await flush();
+    expect(refresh).toHaveBeenCalledTimes(1);
+    // Release the first replace; the success tick re-evaluates and, since the
+    // live signature is now sig-c (≠ the captured sig-b baseline), refreshes again.
+    await act(async () => {
+      releaseFirst();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agentMode/ui/hooks/useRefreshEmptyLandingOnContextSourceChange.ts
+++ b/src/agentMode/ui/hooks/useRefreshEmptyLandingOnContextSourceChange.ts
@@ -1,0 +1,132 @@
+import { GLOBAL_SCOPE } from "@/agentMode/session/scope";
+import { useEffect, useRef, useState } from "react";
+
+interface UseRefreshEmptyLandingOnContextSourceChangeParams {
+  /** Active workspace scope; {@link GLOBAL_SCOPE} has no project context to track. */
+  activeProjectId: string;
+  /**
+   * The active project's context signature, or null for global/orphaned scope.
+   * MUST be the same {@link getProjectContextSignature} the session manager uses
+   * for dirty-tracking (normalized source fields + project filePath), so React
+   * and the manager agree on what counts as a real source change — computed by
+   * the caller from the live project record so it re-derives on every store
+   * change that re-renders the host.
+   */
+  signature: string | null;
+  /** Whether the active session is still an empty landing (no user messages). */
+  isLanding: boolean;
+  /** Context still materializing — replacing the session now would join a run
+   * that's about to be discarded, so we defer until it clears. */
+  blocking: boolean;
+  /** A replace prunes the draft, so we only refresh when there's nothing to lose. */
+  draftEmpty: boolean;
+  /** Replaces the empty landing session in place; resolves to whether a swap
+   * actually happened (false = guarded no-op, e.g. the draft filled in by the
+   * time it ran), so the baseline only advances on a real capture. */
+  refresh: () => Promise<boolean>;
+}
+
+/**
+ * Refresh the empty landing session when the active project's context SOURCES
+ * change underneath it.
+ *
+ * Every context mutation — drag-drop, inline edit, +URL, chip removal, the
+ * Manage modal — funnels through `updateProject` → the project store, which
+ * re-renders the host. Observing the active project's context signature here
+ * therefore covers every entry point (current and future) without each mutation
+ * site wiring its own callback.
+ *
+ * The signature is the only trigger. A single-flight ref serializes the
+ * (non-idempotent) session replacement. The baseline ref records the last
+ * signature we've RECONCILED and only advances when a change is truly settled —
+ * a successful refresh, or a deliberate accept (`!isLanding`). A change that's
+ * merely deferred (blocking, in-flight, or a dirty draft) leaves the baseline
+ * behind, so it's reconsidered the moment its gate clears: the draft emptying,
+ * blocking ending, or the in-flight replace settling each re-runs the
+ * evaluation. A FAILED refresh likewise leaves the baseline behind but does not
+ * self-retry — it waits for the next real dependency change rather than looping.
+ */
+export function useRefreshEmptyLandingOnContextSourceChange({
+  activeProjectId,
+  signature,
+  isLanding,
+  blocking,
+  draftEmpty,
+  refresh,
+}: UseRefreshEmptyLandingOnContextSourceChangeParams): void {
+  // The refresh closure depends on the draft, so it changes every keystroke;
+  // hold it in a ref so it never widens the evaluation effect's dependencies.
+  const refreshRef = useRef(refresh);
+  useEffect(() => {
+    refreshRef.current = refresh;
+  }, [refresh]);
+
+  const baselineRef = useRef<{ projectId: string; signature: string } | null>(null);
+  const inFlightRef = useRef(false);
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    []
+  );
+
+  // Bumped only after a SUCCESSFUL replace, to force one more evaluation that
+  // converges a source change which arrived mid-flight (its signature already
+  // changed during that render, so no dependency is left to re-trigger the
+  // effect). A guarded no-op or a failure deliberately does NOT tick — those
+  // wait for a real dependency change (draft emptying, signature/blocking
+  // change) instead, so a persistent failure can't tight-loop.
+  const [retryTick, setRetryTick] = useState(0);
+
+  useEffect(() => {
+    // Out of project scope: drop the baseline so re-entering a project re-seeds
+    // rather than diffing against a stale signature.
+    if (signature === null || activeProjectId === GLOBAL_SCOPE) {
+      baselineRef.current = null;
+      return;
+    }
+
+    const baseline = baselineRef.current;
+    // First sight of this project (open or scope switch): seed, never refresh —
+    // entering a project is not a source change.
+    if (!baseline || baseline.projectId !== activeProjectId) {
+      baselineRef.current = { projectId: activeProjectId, signature };
+      return;
+    }
+    if (baseline.signature === signature) return;
+
+    // Source changed on a surface that won't take a refresh: a conversation, not
+    // a landing. Accept the new signature — the next New Chat reads fresh config.
+    if (!isLanding) {
+      baselineRef.current = { projectId: activeProjectId, signature };
+      return;
+    }
+
+    // Deferred — DON'T advance the baseline, so the change is reconsidered once
+    // its gate clears: a dirty draft (emptying flips `draftEmpty`), an active
+    // materialization (`blocking` flips via its atom), or an in-flight replace
+    // (the retry tick below). Each is a dependency of this effect.
+    if (!draftEmpty || blocking || inFlightRef.current) return;
+
+    inFlightRef.current = true;
+    void refreshRef
+      .current()
+      .then((replaced) => {
+        // Advance the baseline only on a real capture; a guarded no-op or a
+        // failure leaves it behind so a later evaluation retries. Tick only on
+        // success — see {@link retryTick}.
+        if (replaced && mountedRef.current) {
+          baselineRef.current = { projectId: activeProjectId, signature };
+          setRetryTick((t) => t + 1);
+        }
+      })
+      .catch(() => {
+        // `refresh` swallows its own errors and resolves false; this is purely
+        // defensive so a rejection can't leave the single-flight latched.
+      })
+      .finally(() => {
+        inFlightRef.current = false;
+      });
+  }, [signature, activeProjectId, isLanding, blocking, draftEmpty, retryTick]);
+}

--- a/src/agentMode/ui/hooks/useRefreshEmptyLandingOnContextSourceChange.ts
+++ b/src/agentMode/ui/hooks/useRefreshEmptyLandingOnContextSourceChange.ts
@@ -5,12 +5,13 @@ interface UseRefreshEmptyLandingOnContextSourceChangeParams {
   /** Active workspace scope; {@link GLOBAL_SCOPE} has no project context to track. */
   activeProjectId: string;
   /**
-   * The active project's context signature, or null for global/orphaned scope.
-   * MUST be the same {@link getProjectContextSignature} the session manager uses
-   * for dirty-tracking (normalized source fields + project filePath), so React
-   * and the manager agree on what counts as a real source change — computed by
-   * the caller from the live project record so it re-derives on every store
-   * change that re-renders the host.
+   * The active project's landing-capture signature, or null for global/orphaned
+   * scope. Fingerprints the inputs an empty landing session bakes in at creation
+   * — the materialized context sources PLUS the project instruction body — so a
+   * System-Prompt-only edit triggers a refresh too. Broader than the session
+   * manager's materialization dirty signature on purpose. Computed by the caller
+   * from the live project record so it re-derives on every store change that
+   * re-renders the host.
    */
   signature: string | null;
   /** Whether the active session is still an empty landing (no user messages). */
@@ -27,14 +28,14 @@ interface UseRefreshEmptyLandingOnContextSourceChangeParams {
 }
 
 /**
- * Refresh the empty landing session when the active project's context SOURCES
+ * Refresh the empty landing session when the active project's captured inputs
  * change underneath it.
  *
- * Every context mutation — drag-drop, inline edit, +URL, chip removal, the
- * Manage modal — funnels through `updateProject` → the project store, which
- * re-renders the host. Observing the active project's context signature here
- * therefore covers every entry point (current and future) without each mutation
- * site wiring its own callback.
+ * Every project mutation — drag-drop, inline edit, +URL, chip removal, the
+ * Manage modal, a System-Prompt edit — funnels through `updateProject` → the
+ * project store, which re-renders the host. Observing the active project's
+ * landing-capture signature here therefore covers every entry point (current and
+ * future) without each mutation site wiring its own callback.
  *
  * The signature is the only trigger. A single-flight ref serializes the
  * (non-idempotent) session replacement. The baseline ref records the last
@@ -96,8 +97,9 @@ export function useRefreshEmptyLandingOnContextSourceChange({
     }
     if (baseline.signature === signature) return;
 
-    // Source changed on a surface that won't take a refresh: a conversation, not
-    // a landing. Accept the new signature — the next New Chat reads fresh config.
+    // Captured input changed on a surface that won't take a refresh: a
+    // conversation, not a landing. Accept the new signature — the next New Chat
+    // reads fresh config.
     if (!isLanding) {
       baselineRef.current = { projectId: activeProjectId, signature };
       return;

--- a/src/agentMode/ui/hooks/useRunningChatIds.test.tsx
+++ b/src/agentMode/ui/hooks/useRunningChatIds.test.tsx
@@ -1,0 +1,74 @@
+import { act, renderHook } from "@testing-library/react";
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { useAttentionChatIds } from "@/agentMode/ui/hooks/useAttentionChatIds";
+import { useRunningChatIds } from "@/agentMode/ui/hooks/useRunningChatIds";
+
+/**
+ * Minimal manager stand-in exposing only the surfaces the hooks read:
+ * `subscribe` (returns an unsubscribe) plus the two live id-set getters (both
+ * serve the same backing set — each test exercises one hook at a time). A
+ * handle lets the test swap the current set and fire the subscriber.
+ */
+function makeFakeManager(initial: ReadonlySet<string>) {
+  let current = initial;
+  const listeners = new Set<() => void>();
+  const manager = {
+    getRunningChatIds: () => current,
+    getAttentionChatIds: () => current,
+    subscribe: (l: () => void) => {
+      listeners.add(l);
+      return () => listeners.delete(l);
+    },
+  } as unknown as AgentSessionManager;
+  return {
+    manager,
+    emit: (next: ReadonlySet<string>) => {
+      current = next;
+      for (const l of listeners) l();
+    },
+    unsubscribed: () => listeners.size === 0,
+  };
+}
+
+describe("useRunningChatIds", () => {
+  it("returns the initial running set on mount", () => {
+    const { manager } = makeFakeManager(new Set(["a"]));
+    const { result } = renderHook(() => useRunningChatIds(manager));
+    expect(result.current.has("a")).toBe(true);
+  });
+
+  it("updates when the set's contents change", () => {
+    const fake = makeFakeManager(new Set(["a"]));
+    const { result } = renderHook(() => useRunningChatIds(fake.manager));
+    act(() => fake.emit(new Set(["a", "b"])));
+    expect(result.current.has("b")).toBe(true);
+  });
+
+  it("keeps the same reference when contents are unchanged", () => {
+    const fake = makeFakeManager(new Set(["a"]));
+    const { result } = renderHook(() => useRunningChatIds(fake.manager));
+    const before = result.current;
+    // Same membership in a freshly-allocated Set must not churn the snapshot.
+    act(() => fake.emit(new Set(["a"])));
+    expect(result.current).toBe(before);
+  });
+
+  it("unsubscribes on unmount", () => {
+    const fake = makeFakeManager(new Set());
+    const { unmount } = renderHook(() => useRunningChatIds(fake.manager));
+    unmount();
+    expect(fake.unsubscribed()).toBe(true);
+  });
+});
+
+describe("useAttentionChatIds", () => {
+  // The shared snapshot machinery is exercised above; this only pins that the
+  // attention wrapper reads the attention getter and stays subscribed.
+  it("tracks the manager's attention set", () => {
+    const fake = makeFakeManager(new Set(["done-1"]));
+    const { result } = renderHook(() => useAttentionChatIds(fake.manager));
+    expect(result.current.has("done-1")).toBe(true);
+    act(() => fake.emit(new Set(["done-1", "done-2"])));
+    expect(result.current.has("done-2")).toBe(true);
+  });
+});

--- a/src/agentMode/ui/hooks/useRunningChatIds.ts
+++ b/src/agentMode/ui/hooks/useRunningChatIds.ts
@@ -1,0 +1,14 @@
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { useManagerSetSnapshot } from "@/agentMode/ui/hooks/useManagerSetSnapshot";
+
+const getRunningSnapshot = (manager: AgentSessionManager): ReadonlySet<string> =>
+  manager.getRunningChatIds();
+
+/**
+ * Reactive set of recent-list ids whose backend turn is currently running.
+ * The manager re-notifies whenever a session's running membership flips, so
+ * the landing rows can show/hide their spinner without polling.
+ */
+export function useRunningChatIds(manager: AgentSessionManager): ReadonlySet<string> {
+  return useManagerSetSnapshot(manager, getRunningSnapshot);
+}

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -3,6 +3,7 @@ import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 
 import { ModelCapability, ReasoningEffort, Verbosity } from "@/constants";
+import type { MaterializedSourceType } from "@/context/contextCacheStore";
 import { settingsAtom, settingsStore } from "@/settings/model";
 import { SelectedTextContext } from "@/types/message";
 import { atom, useAtom } from "jotai";
@@ -41,6 +42,13 @@ export interface FailedItem {
   type: "md" | "web" | "youtube" | "nonMd";
   error?: string;
   timestamp?: number;
+  /**
+   * Agent project context only: the source's refresh failed but a previous
+   * snapshot is still in use, so it's stale-but-usable rather than missing.
+   * Lets the status icon stay "ready" (green) while the popover flags the
+   * staleness. Undefined for the legacy CAG failure tracker.
+   */
+  usedStaleSnapshot?: boolean;
 }
 
 interface ProjectContextLoadState {
@@ -56,6 +64,72 @@ export const projectContextLoadAtom = atom<ProjectContextLoadState>({
   processingFiles: [],
   total: [],
 });
+
+/** Done-of-total progress for one materialization step (prefetch / parse). */
+export interface ContextLoadStepCount {
+  done: number;
+  total: number;
+}
+
+export interface AgentProjectContextLoadState {
+  phase: "idle" | "resolve" | "prefetch" | "parse" | "done";
+  blocking: boolean; // true while send should be gated for this project
+  /**
+   * In-vault binary files queued for text materialization, known once the
+   * materializer resolves inclusions. Drives the card's "Resolve files (N)" row.
+   * Omitted until resolve completes (and stays omitted for a context with none).
+   */
+  resolved?: number;
+  /** Remote (web/YouTube) prefetch progress; omitted when there are no remotes. */
+  prefetch?: ContextLoadStepCount;
+  /** Binary-file parse progress; omitted when there are no files to parse. */
+  parsed?: ContextLoadStepCount;
+  /**
+   * Per-source fetch/parse failures from the last run. A run with failures still
+   * completes as `phase: "done"` (the session degrades gracefully); these drive
+   * the status icon's warning state and the popover's failed-source list. Always
+   * republished on `done` (empty array when everything succeeded) so a prior
+   * run's failures never linger.
+   */
+  failedSources?: FailedItem[];
+  /**
+   * Sources the full materialization run is fetching/parsing RIGHT NOW, mirroring
+   * the legacy CAG `processingFiles` set. Published incrementally as each source
+   * starts and settles, so the popover renders a true queue: URLs (fetched in
+   * parallel) appear together while files (parsed sequentially) appear one at a
+   * time, and each flips to its real outcome the instant it settles — never
+   * waiting for the whole run. Only the single-flight owner publishes it; cleared
+   * on `done`. `failedSources` is likewise published incrementally during a run.
+   */
+  processingSources?: AgentInFlightSource[];
+  /**
+   * Sources whose per-source retry is currently in flight (the popover row
+   * "Retry"). Drives an optimistic "processing" state on that row so a click has
+   * immediate feedback even when the retry ends up failing again. Never gates
+   * send (`blocking` stays false); cleared when each retry settles.
+   */
+  retryingSources?: AgentRetryingSource[];
+}
+
+/** A source whose per-source retry is currently in flight (popover row "Retry"). */
+export interface AgentRetryingSource {
+  kind: MaterializedSourceType;
+  source: string;
+}
+
+/** A source the full materialization run is currently fetching/parsing. */
+export interface AgentInFlightSource {
+  kind: MaterializedSourceType;
+  source: string;
+}
+
+/** Frozen empty list — referential stability for the "no retries in flight" case. */
+export const EMPTY_RETRYING_SOURCES: readonly AgentRetryingSource[] = Object.freeze([]);
+/** Frozen empty list — referential stability for the "nothing materializing" case. */
+export const EMPTY_PROCESSING_SOURCES: readonly AgentInFlightSource[] = Object.freeze([]);
+/** Per-project context-load state, keyed by projectId. Driven by AgentSessionManager's
+ *  materialize step; read by AgentContextStatusIcon / AgentChatInput to show progress + gate send. */
+export const agentProjectContextLoadAtom = atom<Record<string, AgentProjectContextLoadState>>({});
 
 interface IndexingProgressState {
   isActive: boolean;
@@ -84,6 +158,8 @@ export interface ProjectConfig {
   name: string;
   description?: string;
   systemPrompt: string;
+  // Old CAG Project Chain model selector. Agent Mode does NOT read this (it uses
+  // agentMode.activeBackend + the backend's default model); kept for CAG runtime + YAML compat.
   projectModelKey: string;
   modelConfigs: {
     temperature?: number;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -505,6 +505,17 @@ export function registerCommands(plugin: CopilotPlugin) {
       const fileCache = FileCache.getInstance<string>();
       await fileCache.clear(plugin.app.vault);
 
+      // Clear the off-vault shared conversion cache (Agent Mode snapshots +
+      // markers). Desktop-gated + dynamic import so node:fs / conversionsLocation
+      // never load on mobile (this command module is registered on all platforms).
+      // clear() is root-confined to `context-cache/` — it never ascends to the
+      // parent `vaults/<id>/`, so `agent-chat-index.json` is untouched.
+      if (isDesktopRuntime()) {
+        const { cacheRoot } = await import("@/context/conversionsLocation");
+        const { createNodeContextCacheFs } = await import("@/context/contextCacheFs");
+        await createNodeContextCacheFs(cacheRoot(plugin.app)).clear();
+      }
+
       new Notice("All Copilot caches cleared successfully");
     } catch (error) {
       logError("Error clearing Copilot caches:", error);

--- a/src/components/chat-components/ChatContextMenu.tsx
+++ b/src/components/chat-components/ChatContextMenu.tsx
@@ -44,6 +44,16 @@ interface ChatContextMenuProps {
   ) => void;
   lexicalEditorRef?: React.RefObject<{ focus: () => void }>;
   hideAddContextButton?: boolean;
+  /**
+   * Agent Mode passes its project-context status icon here; it renders at the
+   * right of the badge row. Legacy Chat leaves it undefined.
+   */
+  statusIndicator?: React.ReactNode;
+  /**
+   * True in Agent Mode. Suppresses the legacy CAG project-status icon (Agent Mode
+   * owns its own via {@link statusIndicator}); keeps the two from ever co-existing.
+   */
+  isAgentMode?: boolean;
 }
 
 export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
@@ -62,6 +72,8 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
   onTypeaheadSelect,
   lexicalEditorRef,
   hideAddContextButton = false,
+  statusIndicator,
+  isAgentMode = false,
 }) => {
   const app = useApp();
   const [currentChain] = useChainType();
@@ -216,7 +228,7 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
         ))}
       </div>
 
-      {currentChain === ChainType.PROJECT_CHAIN && (
+      {!isAgentMode && currentChain === ChainType.PROJECT_CHAIN && (
         <>
           <Separator orientation="vertical" />
           <div className="">
@@ -229,6 +241,13 @@ export const ChatContextMenu: React.FC<ChatContextMenuProps> = ({
               {getContextStatusIcon()}
             </Button>
           </div>
+        </>
+      )}
+
+      {statusIndicator && (
+        <>
+          <Separator orientation="vertical" />
+          {statusIndicator}
         </>
       )}
 

--- a/src/components/chat-components/ChatHistoryPopover.tsx
+++ b/src/components/chat-components/ChatHistoryPopover.tsx
@@ -6,6 +6,7 @@ import { SearchBar } from "@/components/ui/SearchBar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
+import { ChatIconWithAttention } from "@/components/chat-components/ChatIconWithAttention";
 import { logError } from "@/logger";
 import { useSettingsValue } from "@/settings/model";
 import { sortByStrategy } from "@/utils/recentUsageManager";
@@ -22,6 +23,15 @@ export interface ChatHistoryItem {
   /** Backend that produced this chat (Agent Mode only). Used to resolve a
    * brand icon in the popover via the caller-supplied `getIcon` resolver. */
   backendId?: string;
+  /** Raw `projectId` from frontmatter, or `undefined` when absent. The
+   * GLOBAL_SCOPE default is applied in the Agent Mode session layer, not here,
+   * to keep this generic helper free of cross-layer scope imports. */
+  projectId?: string;
+  /** A live in-memory session bound to this chat is flagging for attention
+   * (finished / errored / paused while backgrounded). In-memory only and valid
+   * for the app's lifetime — purely-on-disk chats never carry it. Populated by
+   * the Agent Mode session layer; absent on plain conversation history. */
+  needsAttention?: boolean;
 }
 
 type ChatHistoryIconResolver = (
@@ -402,7 +412,11 @@ function ChatHistoryItem({
   if (isEditing) {
     return (
       <div className="tw-flex tw-items-center tw-gap-2 tw-rounded-md tw-p-2">
-        <RowIcon className="tw-size-3 tw-shrink-0 tw-text-muted" />
+        <ChatIconWithAttention
+          icon={RowIcon}
+          needsAttention={chat.needsAttention}
+          iconClassName="tw-size-3 tw-text-muted"
+        />
         <Input
           value={editingTitle}
           onChange={(e) => onEditingTitleChange(e.target.value)}
@@ -433,7 +447,11 @@ function ChatHistoryItem({
       )}
       onClick={() => onLoadChat(chat.id)}
     >
-      <RowIcon className="tw-size-3 tw-shrink-0 tw-text-muted" />
+      <ChatIconWithAttention
+        icon={RowIcon}
+        needsAttention={chat.needsAttention}
+        iconClassName="tw-size-3 tw-text-muted"
+      />
 
       <div className="tw-min-w-0 tw-flex-1">
         <span className="tw-block tw-truncate tw-text-sm tw-font-medium tw-text-normal">

--- a/src/components/chat-components/ChatIconWithAttention.tsx
+++ b/src/components/chat-components/ChatIconWithAttention.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+interface ChatIconWithAttentionProps {
+  /** Leading glyph (a lucide icon or backend brand icon). */
+  icon: React.ComponentType<{ className?: string }>;
+  /** Overlay the accent dot — set when a live session for this chat needs attention. */
+  needsAttention?: boolean;
+  /** Class for the glyph itself (size + colour); the dot positions against it. */
+  iconClassName?: string;
+}
+
+/**
+ * Chat-row icon with the same "needs attention" accent dot the agent tab strip's
+ * `BrandIcon` paints, so a backgrounded session that finished / paused for
+ * permission reads identically in the history list and on its tab. Accent-only
+ * (the history list has no spinner / error-dot states). The wrapper owns
+ * positioning; callers size the glyph via `iconClassName` (rows differ: `tw-size-3`
+ * in the popover, `tw-size-4` inline).
+ */
+export const ChatIconWithAttention: React.FC<ChatIconWithAttentionProps> = ({
+  icon: Icon,
+  needsAttention,
+  iconClassName,
+}) => (
+  <span className="tw-relative tw-inline-flex tw-shrink-0 tw-items-center tw-justify-center">
+    <Icon className={iconClassName} />
+    {needsAttention && (
+      <span
+        aria-hidden
+        className={cn(
+          "tw-absolute -tw-right-0.5 -tw-top-0.5 tw-size-1.5 tw-rounded-full tw-ring-1 tw-ring-[var(--background-primary)]",
+          "tw-bg-interactive-accent"
+        )}
+      />
+    )}
+  </span>
+);

--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -129,6 +129,8 @@ export interface ChatInputProps {
   onRemoveSelectedText?: (id: string) => void;
   showProgressCard: () => void;
   showIndexingCard?: () => void;
+  /** Agent Mode project-context status icon, rendered in the context badge row. */
+  contextStatusIndicator?: React.ReactNode;
 
   /**
    * Render slot for the toggle row that sits next to the send button.
@@ -224,6 +226,7 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
     onRemoveSelectedText,
     showProgressCard,
     showIndexingCard,
+    contextStatusIndicator,
     toolControls,
     onToolPillsChange,
     onTagSelected,
@@ -795,6 +798,8 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
           onAddToContext={handleAddToContext}
           onRemoveFromContext={handleRemoveFromContext}
           hideAddContextButton={isAgentMode}
+          statusIndicator={contextStatusIndicator}
+          isAgentMode={isAgentMode}
         />
       )}
 

--- a/src/components/chat-components/ContextControl.tsx
+++ b/src/components/chat-components/ContextControl.tsx
@@ -23,6 +23,8 @@ interface ChatControlsProps {
   onRemoveFromContext: (category: string, data: string) => void;
 
   hideAddContextButton?: boolean;
+  statusIndicator?: React.ReactNode;
+  isAgentMode?: boolean;
 }
 
 export const ContextControl: React.FC<ChatControlsProps> = ({
@@ -41,6 +43,8 @@ export const ContextControl: React.FC<ChatControlsProps> = ({
   onAddToContext,
   onRemoveFromContext,
   hideAddContextButton,
+  statusIndicator,
+  isAgentMode,
 }) => {
   const handleRemoveContext = (category: string, data: string) => {
     // Delegate to unified handler
@@ -74,6 +78,8 @@ export const ContextControl: React.FC<ChatControlsProps> = ({
       onTypeaheadSelect={handleTypeaheadSelect}
       lexicalEditorRef={lexicalEditorRef}
       hideAddContextButton={hideAddContextButton}
+      statusIndicator={statusIndicator}
+      isAgentMode={isAgentMode}
     />
   );
 };

--- a/src/components/chat-components/ProjectList.tsx
+++ b/src/components/chat-components/ProjectList.tsx
@@ -19,7 +19,7 @@ import { cn } from "@/lib/utils";
 import { logError, logWarn } from "@/logger";
 import { ProjectFileManager } from "@/projects/ProjectFileManager";
 import { useSettingsValue } from "@/settings/model";
-import { RecentUsageManager, sortByStrategy } from "@/utils/recentUsageManager";
+import { sortByStrategy } from "@/utils/recentUsageManager";
 import {
   ArrowUpRight,
   ChevronDown,
@@ -34,32 +34,10 @@ import {
 } from "lucide-react";
 import { getCachedProjectRecordById } from "@/projects/state";
 import { App, Notice } from "obsidian";
-import React, {
-  memo,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  useSyncExternalStore,
-} from "react";
+import React, { memo, useEffect, useMemo, useState } from "react";
 import { filterProjects } from "@/utils/projectUtils";
+import { useRecentUsageManagerRevision } from "@/hooks/useRecentUsageManagerRevision";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-
-/**
- * Subscribe to a {@link RecentUsageManager} revision so in-memory touches can trigger
- * re-sorting even when the backing list reference stays unchanged (e.g. when persistence
- * is throttled).
- */
-function useRecentUsageManagerRevision<Key extends string>(
-  manager: RecentUsageManager<Key> | null | undefined
-): number {
-  const subscribe = useCallback(
-    (cb: () => void) => manager?.subscribe(cb) ?? (() => {}),
-    [manager]
-  );
-  const getSnapshot = useCallback(() => manager?.getRevision() ?? 0, [manager]);
-  return useSyncExternalStore(subscribe, getSnapshot);
-}
 
 function ProjectItem({
   project,

--- a/src/components/modals/CachePreviewModal.ts
+++ b/src/components/modals/CachePreviewModal.ts
@@ -1,16 +1,25 @@
-import { App, Component, MarkdownRenderer, Modal, Notice, setIcon } from "obsidian";
+import { logWarn } from "@/logger";
+import { renderMarkdown } from "@/utils/renderMarkdown";
+import { PREVIEW_RENDER_LIMIT, truncateForPreview } from "@/utils/truncateForPreview";
+import { App, Component, Modal, Notice, setIcon } from "obsidian";
 
 /**
  * Read-only modal for previewing cached parsed file content.
  *
  * Features:
  * - Wider layout (90vw / max 800px) for comfortable reading
- * - Markdown rendering via Obsidian's MarkdownRenderer
+ * - Markdown rendering via the project's `renderMarkdown` wrapper
+ * - Caps the rendered length (see `truncateForPreview`) so large snapshots
+ *   don't freeze the UI; Copy always hands over the full, untruncated content
  * - Copy icon button with visual feedback (copy → check → copy)
  * - Scrollable content area with theme-aware styling
  */
 export class CachePreviewModal extends Modal {
   private component: Component;
+  /** Pending deferred-render frame, cancelled if the modal closes first. */
+  private renderRafId?: number;
+  /** The window the frame was scheduled on, so onClose cancels on the same one. */
+  private renderRafWin?: Window;
 
   constructor(
     app: App,
@@ -31,6 +40,14 @@ export class CachePreviewModal extends Modal {
     contentEl.addClass("tw-flex", "tw-flex-col", "tw-p-0");
     this.component.load();
 
+    // Reason: cap the synchronous render so large snapshots don't freeze the UI.
+    // Copy still hands over the full content below.
+    const { text: previewText, truncated } = truncateForPreview(this.content);
+
+    // NOTE: `cls` strings here stay bare (no cn()) to match this file's existing
+    // createDiv convention; cn() is for merging conditional JSX classNames, which
+    // this imperative DOM construction doesn't need. If a future review flags
+    // this, point them here.
     // Header: file icon + title + copy button
     const header = contentEl.createDiv({
       cls: "tw-flex tw-items-center tw-justify-between tw-px-5 tw-py-3 tw-border-b tw-border-border",
@@ -53,39 +70,119 @@ export class CachePreviewModal extends Modal {
     });
     const copyIconEl = copyBtn.createSpan({ cls: "tw-flex tw-items-center" });
     setIcon(copyIconEl, "copy");
+    this.bindCopyFullContent(copyBtn, copyIconEl);
 
-    copyBtn.addEventListener("click", () => {
-      navigator.clipboard.writeText(this.content).then(
-        () => {
-          // Reason: visual feedback — icon changes to check mark for 2 seconds
-          setIcon(copyIconEl, "check");
-          copyBtn.addClass("tw-text-accent");
-          new Notice("Copied to clipboard");
-          window.setTimeout(() => {
-            setIcon(copyIconEl, "copy");
-            copyBtn.removeClass("tw-text-accent");
-          }, 2000);
-        },
-        () => new Notice("Failed to copy")
-      );
-    });
+    // Persistent banner when the preview was capped — keeps it visible above
+    // the scroll area instead of buried at the bottom of long content.
+    if (truncated) {
+      const limitKb = Math.round(PREVIEW_RENDER_LIMIT / 1000);
+      contentEl.createDiv({
+        text: `Preview shows the first ${limitKb} KB for performance. Use Copy to get the full content.`,
+        cls: "tw-px-5 tw-py-2 tw-text-sm tw-text-muted tw-border-b tw-border-border tw-bg-secondary",
+      });
+    }
 
-    // Content area: scrollable rendered markdown
+    // Content area: scrollable rendered markdown. Truncated content always
+    // fills the cap, so pin the height up front — the modal then opens at its
+    // final size and the deferred render fills it without growing the window.
+    // Small content keeps an auto height so the modal hugs its content.
     const scrollArea = contentEl.createDiv({
-      cls: "tw-overflow-auto tw-p-5",
-      attr: { style: "max-height: 50vh" },
+      cls: truncated
+        ? "tw-h-[50vh] tw-overflow-auto tw-p-5"
+        : "tw-max-h-[50vh] tw-overflow-auto tw-p-5",
     });
 
     const mdContainer = scrollArea.createDiv({
       cls: "markdown-rendered tw-p-4 tw-bg-primary-alt tw-rounded-lg tw-border tw-border-border",
     });
 
-    // Reason: pass empty sourcePath to prevent vault link resolution
-    void MarkdownRenderer.renderMarkdown(this.content, mdContainer, "", this.component);
+    // Explicit "cut here" marker at the end of the rendered slice so a capped
+    // preview reads as truncated, not as the natural end of the content. The
+    // flanking divider lines break the body text flow, and the centered pill is
+    // an actionable affordance (copy the full content without scrolling back up
+    // to the header) — the GitHub "Load diff" / Carbon overflow pattern.
+    if (truncated) {
+      const endMarker = scrollArea.createDiv({
+        cls: "tw-flex tw-items-center tw-gap-3 tw-pt-6 tw-pb-1",
+      });
+      endMarker.createDiv({ cls: "tw-flex-grow tw-border-t tw-border-border" });
+      const fullCopyBtn = endMarker.createEl("button", {
+        cls: "tw-flex tw-shrink-0 tw-items-center tw-gap-2 tw-px-4 tw-py-1.5 tw-rounded-full tw-bg-secondary tw-border tw-border-border tw-cursor-pointer tw-text-xs tw-font-medium tw-uppercase tw-tracking-wide tw-text-muted hover:tw-text-accent hover:tw-border-accent",
+        attr: { "aria-label": "Copy full content", title: "Copy full content" },
+      });
+      const fullCopyIconEl = fullCopyBtn.createSpan({ cls: "tw-flex tw-items-center" });
+      setIcon(fullCopyIconEl, "copy");
+      fullCopyBtn.createSpan({ text: "Copy full content" });
+      this.bindCopyFullContent(fullCopyBtn, fullCopyIconEl);
+      endMarker.createDiv({ cls: "tw-flex-grow tw-border-t tw-border-border" });
+    }
+
+    // Reason: pass empty sourcePath to prevent vault link resolution.
+    const renderContent = (): void => {
+      void renderMarkdown(this.app, previewText, mdContainer, "", this.component).catch(
+        (error: unknown) => {
+          logWarn("[CachePreviewModal] markdown render failed", error);
+        }
+      );
+    };
+
+    if (truncated) {
+      // Defer the heavy render so the (already full-size) shell paints first and
+      // the window opens instantly instead of blocking onOpen until the large
+      // snapshot is laid out. Two frames: paint the shell, then render.
+      //
+      // DESIGN NOTE — no "closed" guard around renderContent(): every caller does
+      // `new CachePreviewModal(...).open()` (see cacheFileOpener.ts), so an
+      // instance is never reused/reopened, and the heavy DOM work is effectively
+      // non-interruptible once it starts — the user can't close mid-render. The
+      // only residual case (async post-processors finishing after close) writes
+      // to a detached, GC-able container with no observable effect. A generation
+      // guard would defend a path no caller can reach.
+      // If a future review flags this again, point them at this note.
+      const win = this.contentEl.win ?? window;
+      this.renderRafWin = win;
+      this.renderRafId = win.requestAnimationFrame(() => {
+        this.renderRafId = win.requestAnimationFrame(() => {
+          this.renderRafId = undefined;
+          renderContent();
+        });
+      });
+    } else {
+      renderContent();
+    }
   }
 
   onClose(): void {
+    if (this.renderRafId !== undefined) {
+      (this.renderRafWin ?? window).cancelAnimationFrame(this.renderRafId);
+      this.renderRafId = undefined;
+    }
+    this.renderRafWin = undefined;
     this.component.unload();
     this.contentEl.empty();
+  }
+
+  /**
+   * Wire a copy-to-clipboard button that always copies the FULL content (never
+   * the truncated preview), with icon feedback (copy → check → copy). Shared by
+   * the header button and the truncation marker's "Copy full content" pill.
+   */
+  private bindCopyFullContent(button: HTMLElement, iconEl: HTMLElement): void {
+    button.addEventListener("click", () => {
+      navigator.clipboard.writeText(this.content).then(
+        () => {
+          // Reason: visual feedback — icon changes to a check mark for 2 seconds
+          setIcon(iconEl, "check");
+          button.addClass("tw-text-accent");
+          new Notice("Copied to clipboard");
+          // Use the button's own window so the reset fires correctly in popouts.
+          (button.win ?? window).setTimeout(() => {
+            setIcon(iconEl, "copy");
+            button.removeClass("tw-text-accent");
+          }, 2000);
+        },
+        () => new Notice("Failed to copy")
+      );
+    });
   }
 }

--- a/src/components/modals/CachePreviewModal.ts
+++ b/src/components/modals/CachePreviewModal.ts
@@ -46,8 +46,7 @@ export class CachePreviewModal extends Modal {
 
     // NOTE: `cls` strings here stay bare (no cn()) to match this file's existing
     // createDiv convention; cn() is for merging conditional JSX classNames, which
-    // this imperative DOM construction doesn't need. If a future review flags
-    // this, point them here.
+    // this imperative DOM construction doesn't need.
     // Header: file icon + title + copy button
     const header = contentEl.createDiv({
       cls: "tw-flex tw-items-center tw-justify-between tw-px-5 tw-py-3 tw-border-b tw-border-border",
@@ -138,7 +137,6 @@ export class CachePreviewModal extends Modal {
       // only residual case (async post-processors finishing after close) writes
       // to a detached, GC-able container with no observable effect. A generation
       // guard would defend a path no caller can reach.
-      // If a future review flags this again, point them at this note.
       const win = this.contentEl.win ?? window;
       this.renderRafWin = win;
       this.renderRafId = win.requestAnimationFrame(() => {

--- a/src/components/modals/project/AddProjectModal.tsx
+++ b/src/components/modals/project/AddProjectModal.tsx
@@ -17,6 +17,7 @@ import { UrlTagInput } from "@/components/ui/url-tag-input";
 import { SystemPromptSyntaxInstruction } from "@/components/SystemPromptSyntaxInstruction";
 import { DEFAULT_MODEL_SETTING } from "@/constants";
 import { ProjectContextBadgeList } from "@/components/project/ProjectContextBadgeList";
+import { ProjectContextSourceEditor } from "@/components/project/ProjectContextSourceEditor";
 import { err2String, randomUUID } from "@/utils";
 import { Settings } from "lucide-react";
 import { type UrlItem, parseProjectUrls, serializeProjectUrls } from "@/utils/urlTagUtils";
@@ -32,6 +33,27 @@ interface AddProjectModalContentProps {
   onSave: (project: ProjectConfig) => Promise<void>;
   onCancel: () => void;
   plugin?: CopilotPlugin;
+  /**
+   * Agent Mode variant: hides the Model Configuration card and the CAG
+   * processing/cache status (Agent projects have no model selector — see
+   * `ProjectConfig.projectModelKey` — and materialize context at session start
+   * rather than via the CAG vector pipeline), and drops the model from the
+   * required-field validation. Existing `projectModelKey`/`modelConfigs` values
+   * are preserved untouched for CAG compatibility.
+   *
+   * DESIGN NOTE — one flagged shell, not two modals. CAG and Agent share the
+   * same project shape (name, context source, URLs, save/validate flow); the
+   * only divergence is the model card and which status surface is shown. A
+   * dedicated Agent modal would duplicate the save/validate/context-editor
+   * plumbing to fork two render branches, so the shared shell is intentional.
+   * If Agent grows project fields CAG never has (forking the save/validate
+   * shape itself), split then. If a future review flags this again, point them
+   * at this note.
+   */
+  agentMode?: boolean;
+  /** Portal target for the context editor's +URL popover — the modal's own
+   * `contentEl`, so the popover (layer 30) stacks above this modal (layer 50). */
+  popoverContainer?: HTMLElement | null;
 }
 
 function AddProjectModalContent({
@@ -39,6 +61,8 @@ function AddProjectModalContent({
   onSave,
   onCancel,
   plugin,
+  agentMode = false,
+  popoverContainer,
 }: AddProjectModalContentProps) {
   const app = useApp();
   // Project model options come from the model-management "chat" backend
@@ -56,8 +80,11 @@ function AddProjectModalContent({
     initialProject
       ? {
           ...initialProject,
-          projectModelKey:
-            resolveSelectionId(initialProject.projectModelKey) || initialProject.projectModelKey,
+          // Agent Mode hides the model card, so don't resolve/migrate the
+          // (invisible) projectModelKey — preserve it verbatim. CAG still resolves.
+          projectModelKey: agentMode
+            ? initialProject.projectModelKey
+            : resolveSelectionId(initialProject.projectModelKey) || initialProject.projectModelKey,
         }
       : {
           id: randomUUID(),
@@ -92,35 +119,45 @@ function AddProjectModalContent({
 
   // Reason: Shared hook handles cache loading, file enumeration, and processingData construction.
   // contextSource draft is passed so newly added (unsaved) URLs appear as "Pending".
+  // Agent Mode hides the CAG processing/cache UI, so skip the cache read + vault
+  // file enumeration entirely (null cacheProject no-ops the expensive work).
   const { processingData, projectCache, isCurrentProject } = useProjectProcessingData({
-    cacheProject: initialProject ?? null,
-    contextSource: formData.contextSource,
+    cacheProject: agentMode ? null : (initialProject ?? null),
+    contextSource: agentMode ? undefined : formData.contextSource,
   });
 
   const handleEditProjectContext = (projectDraft: ProjectConfig) => {
     const modal = new ContextManageModal(
       app,
       (updatedProject: ProjectConfig) => {
-        // Reason: Only merge inclusions/exclusions (what ContextManageModal edits).
-        // Don't replace the entire contextSource — that would overwrite any
-        // webUrls/youtubeUrls changes the user made in AddProjectModal while
-        // the child modal was open.
+        // Merge back what the modal edited. CAG (enableLinks off) edits only
+        // inclusions/exclusions, so URLs are left to the parent's own editor and
+        // not clobbered. Agent Mode (enableLinks on) also edits URLs, so merge
+        // those too — otherwise the user's Manage URL changes would be dropped.
         setFormData((prev) => ({
           ...prev,
           contextSource: {
             ...prev.contextSource,
             inclusions: updatedProject.contextSource?.inclusions,
             exclusions: updatedProject.contextSource?.exclusions,
+            ...(agentMode
+              ? {
+                  webUrls: updatedProject.contextSource?.webUrls,
+                  youtubeUrls: updatedProject.contextSource?.youtubeUrls,
+                }
+              : {}),
           },
         }));
       },
-      projectDraft
+      projectDraft,
+      { enableLinks: agentMode }
     );
     modal.open();
   };
 
   const isFormValid = () => {
-    return formData.name && formData.projectModelKey;
+    // Agent projects have no model selector, so only the name is required.
+    return formData.name && (agentMode || formData.projectModelKey);
   };
 
   const handleInputChange = (
@@ -175,6 +212,16 @@ function AddProjectModalContent({
     handleInputChange("contextSource.youtubeUrls", youtubeUrls);
   };
 
+  /** Agent Mode: apply a context-source patch from the shared editor into the
+   * form draft. Persisted only on Save — the modal keeps draft (Cancel/Save)
+   * semantics, unlike the home section's immediate write. */
+  const handleContextChange = (patch: Partial<NonNullable<ProjectConfig["contextSource"]>>) => {
+    setFormData((prev) => ({
+      ...prev,
+      contextSource: { ...prev.contextSource, ...patch },
+    }));
+  };
+
   /** Handle inclusions pattern changes from badge list deletion */
   const handleInclusionsChange = (value: string) => {
     handleInputChange("contextSource.inclusions", value);
@@ -212,9 +259,19 @@ function AddProjectModalContent({
 
   const handleSave = async () => {
     const trimmedName = formData.name?.trim() ?? "";
-    const saveData = { ...formData, name: trimmedName };
+    // Agent Mode hides the model card; never let an Agent edit persist a changed
+    // projectModelKey/modelConfigs the user couldn't see — restore them verbatim.
+    const saveData =
+      agentMode && initialProject
+        ? {
+            ...formData,
+            name: trimmedName,
+            projectModelKey: initialProject.projectModelKey,
+            modelConfigs: initialProject.modelConfigs,
+          }
+        : { ...formData, name: trimmedName };
 
-    const requiredFields = ["name", "projectModelKey"];
+    const requiredFields = agentMode ? ["name"] : ["name", "projectModelKey"];
     const missingFields = requiredFields.filter((field) => !saveData[field as keyof ProjectConfig]);
 
     if (missingFields.length > 0) {
@@ -290,132 +347,158 @@ function AddProjectModalContent({
                 label="Project System Prompt"
                 description="Custom instructions for how the AI should behave in this project context"
               >
-                <SystemPromptSyntaxInstruction />
+                {/* Template variables ({activeNote}, {[[Note]]}, …) are expanded by
+                    legacy chat's prompt processor only; agent backends receive the
+                    prompt verbatim, so the hints would mislead in Agent Mode. */}
+                {!agentMode && <SystemPromptSyntaxInstruction />}
                 <Textarea
                   value={formData.systemPrompt}
                   onChange={(e) => handleInputChange("systemPrompt", e.target.value)}
                   onBlur={() => setTouched((prev) => ({ ...prev, systemPrompt: true }))}
-                  placeholder="Enter your project system prompt here... Use {[[Note Name]]} to include note contents."
+                  placeholder={
+                    agentMode
+                      ? "Enter your project system prompt here..."
+                      : "Enter your project system prompt here... Use {[[Note Name]]} to include note contents."
+                  }
                   className="tw-min-h-32"
                 />
               </FormField>
             </div>
           </div>
 
-          {/* Model Configuration Card */}
-          <div className="tw-rounded-lg tw-border tw-border-border tw-p-4 tw-bg-secondary/50">
-            <h3 className="tw-mb-3 tw-text-sm tw-font-medium tw-text-normal">
-              Model Configuration
-            </h3>
-            <div className="tw-flex tw-flex-col tw-gap-3">
-              <FormField
-                label="Default Model"
-                required
-                error={touched.projectModelKey && !formData.projectModelKey}
-                errorMessage="Default model is required"
-              >
-                <ObsidianNativeSelect
-                  value={formData.projectModelKey}
-                  onChange={(e) => handleInputChange("projectModelKey", e.target.value)}
-                  onBlur={() => setTouched((prev) => ({ ...prev, projectModelKey: true }))}
-                  placeholder="Select a model"
-                  options={chatModelOptions}
-                />
-              </FormField>
+          {/* Model Configuration Card — hidden in Agent Mode (no model selector). */}
+          {!agentMode && (
+            <div className="tw-rounded-lg tw-border tw-border-border tw-p-4 tw-bg-secondary/50">
+              <h3 className="tw-mb-3 tw-text-sm tw-font-medium tw-text-normal">
+                Model Configuration
+              </h3>
+              <div className="tw-flex tw-flex-col tw-gap-3">
+                <FormField
+                  label="Default Model"
+                  required
+                  error={touched.projectModelKey && !formData.projectModelKey}
+                  errorMessage="Default model is required"
+                >
+                  <ObsidianNativeSelect
+                    value={formData.projectModelKey}
+                    onChange={(e) => handleInputChange("projectModelKey", e.target.value)}
+                    onBlur={() => setTouched((prev) => ({ ...prev, projectModelKey: true }))}
+                    placeholder="Select a model"
+                    options={chatModelOptions}
+                  />
+                </FormField>
 
-              <FormField label="Temperature">
-                <SettingSlider
-                  value={formData.modelConfigs?.temperature ?? DEFAULT_MODEL_SETTING.TEMPERATURE}
-                  onChange={(value) => handleInputChange("modelConfigs.temperature", value)}
-                  min={0}
-                  max={2}
-                  step={0.01}
-                  className="tw-w-full"
-                />
-              </FormField>
+                <FormField label="Temperature">
+                  <SettingSlider
+                    value={formData.modelConfigs?.temperature ?? DEFAULT_MODEL_SETTING.TEMPERATURE}
+                    onChange={(value) => handleInputChange("modelConfigs.temperature", value)}
+                    min={0}
+                    max={2}
+                    step={0.01}
+                    className="tw-w-full"
+                  />
+                </FormField>
 
-              <FormField label="Token Limit">
-                <SettingSlider
-                  value={formData.modelConfigs?.maxTokens ?? DEFAULT_MODEL_SETTING.MAX_TOKENS}
-                  onChange={(value) => handleInputChange("modelConfigs.maxTokens", value)}
-                  min={1}
-                  max={65000}
-                  step={1}
-                  className="tw-w-full"
-                />
-              </FormField>
+                <FormField label="Token Limit">
+                  <SettingSlider
+                    value={formData.modelConfigs?.maxTokens ?? DEFAULT_MODEL_SETTING.MAX_TOKENS}
+                    onChange={(value) => handleInputChange("modelConfigs.maxTokens", value)}
+                    min={1}
+                    max={65000}
+                    step={1}
+                    className="tw-w-full"
+                  />
+                </FormField>
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Context Sources Card */}
           <div className="tw-rounded-lg tw-border tw-border-border tw-p-4 tw-bg-secondary/50">
             <h3 className="tw-mb-3 tw-text-sm tw-font-medium tw-text-normal">Context Sources</h3>
-            <div className="tw-flex tw-flex-col tw-gap-4">
-              {/* File Context Sub-card */}
-              <div className="tw-rounded-lg tw-border tw-border-border tw-p-4">
-                <FormField
-                  label={
-                    <div className="tw-flex tw-items-center tw-gap-2">
-                      <span>File Context</span>
-                      <HelpTooltip
-                        buttonClassName="tw-size-4 tw-text-muted"
-                        content={
-                          <div className="tw-max-w-80">
-                            <strong>Supported File Types:</strong>
-                            <br />
-                            <strong>• Documents:</strong> pdf, doc, docx, ppt, pptx, epub, txt, rtf
-                            and many more
-                            <br />
-                            <strong>• Images:</strong> jpg, png, svg, gif, bmp, webp, tiff
-                            <br />
-                            <strong>• Spreadsheets:</strong> xlsx, xls, csv, numbers
-                            <br />
-                            <br />
-                            Non-markdown files are converted to markdown in the background.
-                            <br />
-                            <strong>Rate limit:</strong> 50 files or 100MB per 3 hours, whichever is
-                            reached first.
-                          </div>
-                        }
-                      />
-                    </div>
-                  }
-                  description="Define patterns to include specific files, folders or tags (specified in the note property) in the project context."
-                >
-                  <ProjectContextBadgeList
-                    inclusions={formData.contextSource?.inclusions}
-                    exclusions={formData.contextSource?.exclusions}
-                    onInclusionsChange={handleInclusionsChange}
-                    onExclusionsChange={handleExclusionsChange}
-                    actionSlot={
-                      <Button
-                        size="lg"
-                        className="tw-h-9 tw-gap-1 tw-px-3 sm:tw-h-auto sm:tw-px-2"
-                        onClick={() => handleEditProjectContext(formData)}
-                      >
-                        <Settings className="tw-size-4 sm:tw-size-3.5" />
-                        Manage Context
-                      </Button>
+            {agentMode ? (
+              // Agent Mode: the same mixed file+URL editor as the project landing,
+              // wired to the form draft (Save commits). CAG keeps its split sub-cards.
+              <ProjectContextSourceEditor
+                contextSource={formData.contextSource}
+                onChange={handleContextChange}
+                onManage={() => handleEditProjectContext(formData)}
+                popoverContainer={popoverContainer}
+                droppable={false}
+                solidManageButton
+                showHelperText
+              />
+            ) : (
+              <div className="tw-flex tw-flex-col tw-gap-4">
+                {/* File Context Sub-card */}
+                <div className="tw-rounded-lg tw-border tw-border-border tw-p-4">
+                  <FormField
+                    label={
+                      <div className="tw-flex tw-items-center tw-gap-2">
+                        <span>File Context</span>
+                        <HelpTooltip
+                          buttonClassName="tw-size-4 tw-text-muted"
+                          content={
+                            <div className="tw-max-w-80">
+                              <strong>Supported File Types:</strong>
+                              <br />
+                              <strong>• Documents:</strong> pdf, doc, docx, ppt, pptx, epub, txt,
+                              rtf and many more
+                              <br />
+                              <strong>• Images:</strong> jpg, png, svg, gif, bmp, webp, tiff
+                              <br />
+                              <strong>• Spreadsheets:</strong> xlsx, xls, csv, numbers
+                              <br />
+                              <br />
+                              Non-markdown files are converted to markdown in the background.
+                              <br />
+                              <strong>Rate limit:</strong> 50 files or 100MB per 3 hours, whichever
+                              is reached first.
+                            </div>
+                          }
+                        />
+                      </div>
                     }
-                  />
-                </FormField>
-              </div>
-
-              {/* URLs Sub-card */}
-              <div className="tw-rounded-lg tw-border tw-border-border tw-p-4">
-                <div className="tw-mb-3">
-                  <span className="tw-text-sm tw-font-medium tw-text-normal">URLs</span>
-                  <p className="tw-mt-1 tw-text-ui-smaller tw-text-muted">
-                    Add web pages or YouTube videos as context sources
-                  </p>
+                    description="Define patterns to include specific files, folders or tags (specified in the note property) in the project context."
+                  >
+                    <ProjectContextBadgeList
+                      inclusions={formData.contextSource?.inclusions}
+                      exclusions={formData.contextSource?.exclusions}
+                      onInclusionsChange={handleInclusionsChange}
+                      onExclusionsChange={handleExclusionsChange}
+                      actionSlot={
+                        <Button
+                          size="lg"
+                          className="tw-h-9 tw-gap-1 tw-px-3 sm:tw-h-auto sm:tw-px-2"
+                          onClick={() => handleEditProjectContext(formData)}
+                        >
+                          <Settings className="tw-size-4 sm:tw-size-3.5" />
+                          Manage Context
+                        </Button>
+                      }
+                    />
+                  </FormField>
                 </div>
-                <UrlTagInput urls={urlItems} onAdd={handleUrlAdd} onRemove={handleUrlRemove} />
+
+                {/* URLs Sub-card */}
+                <div className="tw-rounded-lg tw-border tw-border-border tw-p-4">
+                  <div className="tw-mb-3">
+                    <span className="tw-text-sm tw-font-medium tw-text-normal">URLs</span>
+                    <p className="tw-mt-1 tw-text-ui-smaller tw-text-muted">
+                      Add web pages or YouTube videos as context sources
+                    </p>
+                  </div>
+                  <UrlTagInput urls={urlItems} onAdd={handleUrlAdd} onRemove={handleUrlRemove} />
+                </div>
               </div>
-            </div>
+            )}
           </div>
 
-          {/* Processing Status - show for any project in edit mode (active: live state; others: cache state) */}
-          {initialProject && processingData && (
+          {/* Processing Status — the CAG variant reads the CAG cache; the agent
+              variant reads the agent pipeline's own data (load atom + off-vault
+              conversion cache). Retry/open-cache stay CAG-only here: the agent
+              variant's retry lives in the composer's context status popover. */}
+          {!agentMode && initialProject && processingData && (
             <ProcessingStatus
               items={processingData.items}
               onRetry={isCurrentProject ? handleRetry : undefined}
@@ -450,7 +533,9 @@ export class AddProjectModal extends Modal {
     app: App,
     private onSave: (project: ProjectConfig) => Promise<void>,
     private initialProject?: ProjectConfig,
-    private plugin?: CopilotPlugin
+    private plugin?: CopilotPlugin,
+    /** Agent Mode variant — see {@link AddProjectModalContentProps.agentMode}. */
+    private agentMode: boolean = false
   ) {
     super(app);
   }
@@ -478,6 +563,8 @@ export class AddProjectModal extends Modal {
         onSave={handleSave}
         onCancel={handleCancel}
         plugin={this.plugin}
+        agentMode={this.agentMode}
+        popoverContainer={contentEl}
       />
     );
   }

--- a/src/components/modals/project/AddProjectModal.tsx
+++ b/src/components/modals/project/AddProjectModal.tsx
@@ -47,8 +47,7 @@ interface AddProjectModalContentProps {
    * dedicated Agent modal would duplicate the save/validate/context-editor
    * plumbing to fork two render branches, so the shared shell is intentional.
    * If Agent grows project fields CAG never has (forking the save/validate
-   * shape itself), split then. If a future review flags this again, point them
-   * at this note.
+   * shape itself), split then.
    */
   agentMode?: boolean;
   /** Portal target for the context editor's +URL popover — the modal's own

--- a/src/components/modals/project/ContextManageLinksPanel.tsx
+++ b/src/components/modals/project/ContextManageLinksPanel.tsx
@@ -1,0 +1,291 @@
+import type { ProjectConfig } from "@/aiParams";
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import { AddUrlPopover } from "@/components/project/AddUrlPopover";
+import { UrlTypeIcon } from "@/components/project/UrlTypeIcon";
+import { useAgentProcessingItems } from "@/components/project/useAgentProcessingItems";
+import { TruncatedText } from "@/components/TruncatedText";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { openAgentCachedItemPreview } from "@/utils/cacheFileOpener";
+import type { UrlItem, UrlKind } from "@/utils/urlTagUtils";
+import {
+  AlertCircle,
+  ArrowUpRight,
+  CheckCircle2,
+  Clock,
+  Globe,
+  Link,
+  Loader2,
+  PlusCircle,
+  X,
+  Youtube,
+} from "lucide-react";
+import { App } from "obsidian";
+import React, { useMemo } from "react";
+
+/** The three Links-related selections in the Manage sidebar. */
+export type LinksSection = "links" | "web" | "youtube";
+
+interface LinksSidebarSectionProps {
+  activeSection: string | null;
+  webCount: number;
+  youtubeCount: number;
+  onSelect: (section: LinksSection) => void;
+  /** Saved URLs so the +URL popover dedups re-adds. */
+  existingUrls: string[];
+  /** Parsed, deduped URLs from the +URL popover → merge into the draft. */
+  onAddUrls: (urls: UrlItem[]) => void;
+  /** Portal target for the +URL popover (the Manage modal's contentEl). */
+  popoverContainer?: HTMLElement | null;
+}
+
+/**
+ * Left-sidebar "Links" group (design M): a cyan parent "Links" + Web / YouTube
+ * children with counts. Clicking the parent lists both groups on the right;
+ * clicking a child filters to that one. Mirrors the existing file sections'
+ * look (hover + active highlight) without reaching into the modal's private
+ * SectionHeader.
+ */
+export function LinksSidebarSection({
+  activeSection,
+  webCount,
+  youtubeCount,
+  onSelect,
+  existingUrls,
+  onAddUrls,
+  popoverContainer,
+}: LinksSidebarSectionProps) {
+  return (
+    <div>
+      <div
+        className={cn(
+          "tw-mb-1 tw-flex tw-cursor-pointer tw-items-center tw-rounded-md tw-p-2 hover:tw-bg-secondary/50",
+          activeSection === "links" && "tw-bg-secondary"
+        )}
+        onClick={() => onSelect("links")}
+      >
+        <Link className="tw-mr-2 tw-size-4 tw-text-context-manager-cyan" />
+        <h3 className="tw-text-sm tw-font-semibold tw-text-context-manager-cyan">Links</h3>
+        <AddUrlPopover
+          existingUrls={existingUrls}
+          onAdd={onAddUrls}
+          container={popoverContainer}
+          trigger={
+            <Button
+              variant="ghost"
+              size="fit"
+              className="tw-ml-auto tw-text-muted hover:tw-bg-secondary"
+              title="Add link"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <PlusCircle className="tw-size-4 tw-text-context-manager-cyan" />
+            </Button>
+          }
+        />
+      </div>
+      <LinkSubItem
+        Icon={Globe}
+        label="Web"
+        count={webCount}
+        active={activeSection === "web"}
+        onClick={() => onSelect("web")}
+      />
+      <LinkSubItem
+        Icon={Youtube}
+        label="YouTube"
+        count={youtubeCount}
+        active={activeSection === "youtube"}
+        onClick={() => onSelect("youtube")}
+      />
+    </div>
+  );
+}
+
+function LinkSubItem({
+  Icon,
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  Icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-rounded-md tw-py-1.5 tw-pl-6 tw-pr-2 tw-text-sm hover:tw-bg-secondary/50",
+        active && "tw-bg-secondary tw-text-normal"
+      )}
+      onClick={onClick}
+    >
+      <Icon className="tw-size-4 tw-text-context-manager-cyan" />
+      <span className="tw-flex-1">{label}</span>
+      <span className="tw-text-xs tw-text-faint">{count}</span>
+    </div>
+  );
+}
+
+interface LinksContentPanelProps {
+  app: App;
+  /** Persisted project — drives the per-URL conversion status + preview path. */
+  project: ProjectConfig;
+  urlItems: UrlItem[];
+  filter: LinksSection;
+  onRemove: (id: string) => void;
+}
+
+/**
+ * Right-pane Links viewer: the saved URLs grouped under Web / YouTube labels.
+ * Each row shows its conversion status badge + a preview arrow (converted
+ * snapshot) + a hover delete. Adding is handled solely by the sidebar's "+"
+ * popover, matching every other context type (Tags / Folders / Files), whose
+ * right pane is a pure list with no inline add affordance.
+ *
+ * This panel renders ONLY when Links is selected (agent `enableLinks`), so
+ * reading the agent pipeline's status here never runs on the CAG path. Status
+ * reflects the SAVED config — a freshly added (unsaved) URL has no status yet.
+ */
+export function LinksContentPanel({
+  app,
+  project,
+  urlItems,
+  filter,
+  onRemove,
+}: LinksContentPanelProps) {
+  const { items } = useAgentProcessingItems(app, project, project.contextSource);
+  // Key by (cacheKind, url), not url alone: the same URL can be configured as
+  // BOTH a web and a youtube source, which the processing adapter emits as two
+  // distinct items sharing one `id` (see agentProcessingAdapter's same-URL pair
+  // contract). Keying on url alone would let one kind's status/snapshot clobber
+  // the other's — this matches how the canonical processing-status list keys its
+  // rows (`${cacheKind}:${id}`).
+  const statusByKey = useMemo(() => {
+    const map = new Map<string, ProcessingItem>();
+    for (const item of items) {
+      if (item.source === "url") map.set(`${item.cacheKind}:${item.id}`, item);
+    }
+    return map;
+  }, [items]);
+
+  const handlePreview = (item: ProcessingItem) => {
+    // Snapshots are off-vault and keyed by source identity, so the preview no
+    // longer needs the project folder — just the item's kind + id.
+    void openAgentCachedItemPreview(app, item);
+  };
+
+  const webItems = urlItems.filter((u) => u.type === "web");
+  const youtubeItems = urlItems.filter((u) => u.type === "youtube");
+  const showWeb = filter === "links" || filter === "web";
+  const showYoutube = filter === "links" || filter === "youtube";
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-2">
+      {showWeb && webItems.length > 0 && (
+        <UrlGroup
+          label="Web"
+          type="web"
+          items={webItems}
+          statusByKey={statusByKey}
+          onRemove={onRemove}
+          onPreview={handlePreview}
+        />
+      )}
+      {showYoutube && youtubeItems.length > 0 && (
+        <UrlGroup
+          label="YouTube"
+          type="youtube"
+          items={youtubeItems}
+          statusByKey={statusByKey}
+          onRemove={onRemove}
+          onPreview={handlePreview}
+        />
+      )}
+      {((showWeb && webItems.length > 0) || (showYoutube && youtubeItems.length > 0)) === false && (
+        <div className="tw-py-6 tw-text-center tw-text-sm tw-text-muted">
+          No links yet. Use the + next to Links in the sidebar to add one.
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Per-URL conversion status glyph (design M badges). `null` for unstarted /
+ * unsaved URLs (no row badge). */
+function UrlStatusIcon({ status }: { status: ProcessingItem["status"] }) {
+  switch (status) {
+    case "ready":
+      return <CheckCircle2 className="tw-size-3.5 tw-text-success" />;
+    case "processing":
+      return <Loader2 className="tw-size-3.5 tw-animate-spin tw-text-accent" />;
+    case "pending":
+      return <Clock className="tw-size-3.5 tw-text-faint" />;
+    case "failed":
+      return <AlertCircle className="tw-size-3.5 tw-text-error" />;
+    default:
+      return null;
+  }
+}
+
+function UrlGroup({
+  label,
+  type,
+  items,
+  statusByKey,
+  onRemove,
+  onPreview,
+}: {
+  label: string;
+  type: UrlKind;
+  items: UrlItem[];
+  statusByKey: ReadonlyMap<string, ProcessingItem>;
+  onRemove: (id: string) => void;
+  onPreview: (item: ProcessingItem) => void;
+}) {
+  return (
+    <div className="tw-mb-2">
+      <div className="tw-mb-1.5 tw-mt-2 tw-flex tw-items-center tw-gap-1.5 tw-text-xs tw-font-bold tw-text-faint">
+        <UrlTypeIcon type={type} className="tw-size-3.5" />
+        {label} <span className="tw-font-medium">({items.length})</span>
+      </div>
+      {items.map((item) => {
+        const status = statusByKey.get(`${type}:${item.url}`);
+        const isReady = status?.status === "ready";
+        return (
+          <div
+            key={item.id}
+            className="tw-group tw-mb-1.5 tw-flex tw-items-center tw-gap-2.5 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-px-3 tw-py-2"
+          >
+            <UrlTypeIcon type={item.type} className="tw-size-4 tw-shrink-0" />
+            <TruncatedText className="tw-min-w-0 tw-flex-1 tw-text-sm" tooltipContent={item.url}>
+              {item.url.replace(/^https?:\/\//, "")}
+            </TruncatedText>
+            {isReady && status && (
+              <ArrowUpRight
+                className="tw-size-4 tw-shrink-0 tw-cursor-pointer tw-text-faint tw-opacity-0 hover:tw-text-normal group-hover:tw-opacity-100"
+                onClick={() => onPreview(status)}
+                aria-label="View converted content"
+              />
+            )}
+            {status && (
+              // Success rests hidden (revealed on row hover); processing / queued /
+              // failed stay visible since they need attention.
+              <span
+                className={cn("tw-shrink-0", isReady && "tw-opacity-0 group-hover:tw-opacity-100")}
+              >
+                <UrlStatusIcon status={status.status} />
+              </span>
+            )}
+            <X
+              className="tw-size-4 tw-shrink-0 tw-cursor-pointer tw-text-faint tw-opacity-0 hover:tw-text-error group-hover:tw-opacity-100"
+              onClick={() => onRemove(item.id)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/modals/project/ContextManageLinksPanel.tsx
+++ b/src/components/modals/project/ContextManageLinksPanel.tsx
@@ -1,27 +1,18 @@
-import type { ProjectConfig } from "@/aiParams";
 import type { ProcessingItem } from "@/components/project/processingAdapter";
+import {
+  ProcessingStatusIcon,
+  processingSourceKey,
+} from "@/components/project/processingItemStatusView";
 import { AddUrlPopover } from "@/components/project/AddUrlPopover";
 import { UrlTypeIcon } from "@/components/project/UrlTypeIcon";
-import { useAgentProcessingItems } from "@/components/project/useAgentProcessingItems";
 import { TruncatedText } from "@/components/TruncatedText";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { openAgentCachedItemPreview } from "@/utils/cacheFileOpener";
 import type { UrlItem, UrlKind } from "@/utils/urlTagUtils";
-import {
-  AlertCircle,
-  ArrowUpRight,
-  CheckCircle2,
-  Clock,
-  Globe,
-  Link,
-  Loader2,
-  PlusCircle,
-  X,
-  Youtube,
-} from "lucide-react";
+import { ArrowUpRight, Globe, Link, PlusCircle, X, Youtube } from "lucide-react";
 import { App } from "obsidian";
-import React, { useMemo } from "react";
+import React from "react";
 
 /** The three Links-related selections in the Manage sidebar. */
 export type LinksSection = "links" | "web" | "youtube";
@@ -131,10 +122,11 @@ function LinkSubItem({
 
 interface LinksContentPanelProps {
   app: App;
-  /** Persisted project — drives the per-URL conversion status + preview path. */
-  project: ProjectConfig;
   urlItems: UrlItem[];
   filter: LinksSection;
+  /** Agent conversion status by {@link processingSourceKey}, supplied by the
+   * modal (one shared lookup across Links + File Context). */
+  agentProcessingByKey: ReadonlyMap<string, ProcessingItem>;
   onRemove: (id: string) => void;
 }
 
@@ -145,32 +137,17 @@ interface LinksContentPanelProps {
  * popover, matching every other context type (Tags / Folders / Files), whose
  * right pane is a pure list with no inline add affordance.
  *
- * This panel renders ONLY when Links is selected (agent `enableLinks`), so
- * reading the agent pipeline's status here never runs on the CAG path. Status
- * reflects the SAVED config — a freshly added (unsaved) URL has no status yet.
+ * Status reflects the SAVED config — a freshly added (unsaved) URL has no status
+ * yet. The status lookup is passed in (not derived here) so the URL rows and the
+ * File Context list share ONE {@link ProcessingStatusIcon} judgment.
  */
 export function LinksContentPanel({
   app,
-  project,
   urlItems,
   filter,
+  agentProcessingByKey,
   onRemove,
 }: LinksContentPanelProps) {
-  const { items } = useAgentProcessingItems(app, project, project.contextSource);
-  // Key by (cacheKind, url), not url alone: the same URL can be configured as
-  // BOTH a web and a youtube source, which the processing adapter emits as two
-  // distinct items sharing one `id` (see agentProcessingAdapter's same-URL pair
-  // contract). Keying on url alone would let one kind's status/snapshot clobber
-  // the other's — this matches how the canonical processing-status list keys its
-  // rows (`${cacheKind}:${id}`).
-  const statusByKey = useMemo(() => {
-    const map = new Map<string, ProcessingItem>();
-    for (const item of items) {
-      if (item.source === "url") map.set(`${item.cacheKind}:${item.id}`, item);
-    }
-    return map;
-  }, [items]);
-
   const handlePreview = (item: ProcessingItem) => {
     // Snapshots are off-vault and keyed by source identity, so the preview no
     // longer needs the project folder — just the item's kind + id.
@@ -189,7 +166,7 @@ export function LinksContentPanel({
           label="Web"
           type="web"
           items={webItems}
-          statusByKey={statusByKey}
+          agentProcessingByKey={agentProcessingByKey}
           onRemove={onRemove}
           onPreview={handlePreview}
         />
@@ -199,7 +176,7 @@ export function LinksContentPanel({
           label="YouTube"
           type="youtube"
           items={youtubeItems}
-          statusByKey={statusByKey}
+          agentProcessingByKey={agentProcessingByKey}
           onRemove={onRemove}
           onPreview={handlePreview}
         />
@@ -213,35 +190,18 @@ export function LinksContentPanel({
   );
 }
 
-/** Per-URL conversion status glyph (design M badges). `null` for unstarted /
- * unsaved URLs (no row badge). */
-function UrlStatusIcon({ status }: { status: ProcessingItem["status"] }) {
-  switch (status) {
-    case "ready":
-      return <CheckCircle2 className="tw-size-3.5 tw-text-success" />;
-    case "processing":
-      return <Loader2 className="tw-size-3.5 tw-animate-spin tw-text-accent" />;
-    case "pending":
-      return <Clock className="tw-size-3.5 tw-text-faint" />;
-    case "failed":
-      return <AlertCircle className="tw-size-3.5 tw-text-error" />;
-    default:
-      return null;
-  }
-}
-
 function UrlGroup({
   label,
   type,
   items,
-  statusByKey,
+  agentProcessingByKey,
   onRemove,
   onPreview,
 }: {
   label: string;
   type: UrlKind;
   items: UrlItem[];
-  statusByKey: ReadonlyMap<string, ProcessingItem>;
+  agentProcessingByKey: ReadonlyMap<string, ProcessingItem>;
   onRemove: (id: string) => void;
   onPreview: (item: ProcessingItem) => void;
 }) {
@@ -252,7 +212,7 @@ function UrlGroup({
         {label} <span className="tw-font-medium">({items.length})</span>
       </div>
       {items.map((item) => {
-        const status = statusByKey.get(`${type}:${item.url}`);
+        const status = agentProcessingByKey.get(processingSourceKey(type, item.url));
         const isReady = status?.status === "ready";
         return (
           <div
@@ -270,15 +230,7 @@ function UrlGroup({
                 aria-label="View converted content"
               />
             )}
-            {status && (
-              // Success rests hidden (revealed on row hover); processing / queued /
-              // failed stay visible since they need attention.
-              <span
-                className={cn("tw-shrink-0", isReady && "tw-opacity-0 group-hover:tw-opacity-100")}
-              >
-                <UrlStatusIcon status={status.status} />
-              </span>
-            )}
+            {status && <ProcessingStatusIcon item={status} revealReadyOnHover />}
             <X
               className="tw-size-4 tw-shrink-0 tw-cursor-pointer tw-text-faint tw-opacity-0 hover:tw-text-error group-hover:tw-opacity-100"
               onClick={() => onRemove(item.id)}

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -1,6 +1,13 @@
 import { FailedItem, ProjectConfig, useProjectContextLoad, getCurrentProject } from "@/aiParams";
 import { ContextCache, ProjectContextCache } from "@/cache/projectContextCache";
 import { FolderSearchModal } from "@/components/modals/FolderSearchModal";
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import {
+  buildProcessingItemLookup,
+  ProcessingStatusIcon,
+  processingSourceKey,
+} from "@/components/project/processingItemStatusView";
+import { useAgentProcessingItems } from "@/components/project/useAgentProcessingItems";
 import { openCachedProjectFile } from "@/utils/cacheFileOpener";
 import { ProjectFileSelectModal } from "@/components/modals/ProjectFileSelectModal";
 import { TagSearchModal } from "@/components/modals/TagSearchModal";
@@ -25,8 +32,6 @@ import {
   AlertCircle,
   ArrowUpRight,
   CheckCircle,
-  CheckCircle2,
-  Clock,
   FileAudio,
   FileImage,
   FileText,
@@ -294,46 +299,6 @@ const STATUS_COLOR: Record<ProjectContextItemStatus, string> = {
   notStarted: "tw-text-muted",
 };
 
-/** Agent (Links-style) compact status icons — keyed lookup instead of a condition
- * chain. `success` rests hidden (revealed on row hover) since it needs no
- * attention; `processing` spins. */
-const COMPACT_STATUS_ICON: Record<
-  ProjectContextItemStatus,
-  { Icon: React.ComponentType<{ className?: string }>; spin?: boolean; revealOnHover?: boolean }
-> = {
-  success: { Icon: CheckCircle2, revealOnHover: true },
-  failed: { Icon: AlertCircle },
-  processing: { Icon: Loader2, spin: true },
-  notStarted: { Icon: Clock },
-};
-
-/** The compact, icon-only status for the agent (Links) variant: a bare glyph whose
- * tooltip reveals the status label, or the failure error when failed. */
-function CompactStatusIcon({ loadStatus }: { loadStatus: ProjectContextItemStatusInfo }) {
-  const { Icon, spin, revealOnHover } = COMPACT_STATUS_ICON[loadStatus.status];
-  const tooltip =
-    loadStatus.status === "failed" && loadStatus.failedItem?.error
-      ? `Failed: ${loadStatus.failedItem.error}`
-      : STATUS_LABELS[loadStatus.status];
-  return (
-    <HelpTooltip
-      side="top"
-      contentClassName="tw-z-[60]"
-      content={<div className="tw-max-w-80">{tooltip}</div>}
-    >
-      <span
-        className={cn(
-          "tw-flex tw-size-5 tw-shrink-0 tw-items-center tw-justify-center",
-          STATUS_COLOR[loadStatus.status],
-          revealOnHover && "tw-opacity-0 group-hover:tw-opacity-100"
-        )}
-      >
-        <Icon className={cn("tw-size-3.5", spin && "tw-animate-spin")} />
-      </span>
-    </HelpTooltip>
-  );
-}
-
 // ============================================================================
 // ItemCard Component
 // ============================================================================
@@ -342,6 +307,9 @@ interface ItemCardProps {
   item: GroupItem;
   viewMode: "list";
   loadStatus?: ProjectContextItemStatusInfo;
+  /** Agent (Links) variant: per-file conversion status from the agent pipeline,
+   * rendered via the shared {@link ProcessingStatusIcon}. CAG uses `loadStatus`. */
+  agentProcessingItem?: ProcessingItem;
   onDelete: (e: React.MouseEvent, item: GroupItem) => void;
   /** Optional: callback to open the cached parsed content for this file. */
   onOpenCached?: () => void;
@@ -354,6 +322,7 @@ function ItemCard({
   item,
   viewMode,
   loadStatus,
+  agentProcessingItem,
   onDelete,
   onOpenCached,
   compactStatus,
@@ -401,7 +370,9 @@ function ItemCard({
           // bare icon (ready hidden until row hover), error revealed on hover.
           <>
             {previewButton}
-            {loadStatus && <CompactStatusIcon loadStatus={loadStatus} />}
+            {agentProcessingItem && (
+              <ProcessingStatusIcon item={agentProcessingItem} revealReadyOnHover />
+            )}
           </>
         ) : (
           // CAG (unchanged): icon + text Badge, then the preview arrow.
@@ -612,6 +583,21 @@ function ContextManage({
     cachedFiles,
     isCurrentProject,
   ]);
+
+  // Agent (Links) variant ONLY: one shared conversion-status lookup keyed by
+  // `processingSourceKey`, covering both URL rows and File Context rows so they
+  // render the same {@link ProcessingStatusIcon}. Gated to `enableLinks` so the
+  // CAG path never runs the agent read-model (off-vault cache / agent atom).
+  const { items: agentProcessingItems } = useAgentProcessingItems(
+    app,
+    initialProject,
+    initialProject.contextSource,
+    { enabled: enableLinks }
+  );
+  const agentProcessingByKey = useMemo(
+    () => buildProcessingItemLookup(agentProcessingItems),
+    [agentProcessingItems]
+  );
 
   const { inclusions: inclusionPatterns, exclusions: exclusionPatterns } = useMemo(() => {
     return getMatchingPatterns({
@@ -1528,9 +1514,9 @@ function ContextManage({
               {isLinksActive ? (
                 <LinksContentPanel
                   app={app}
-                  project={initialProject}
                   urlItems={contextUrls.urlItems}
                   filter={activeSection}
+                  agentProcessingByKey={agentProcessingByKey}
                   onRemove={contextUrls.removeUrl}
                 />
               ) : getDisplayItems.length === 0 ? (
@@ -1557,12 +1543,19 @@ function ContextManage({
                               item={item}
                               viewMode="list"
                               compactStatus={enableLinks}
+                              agentProcessingItem={
+                                // Agent file rows read the shared agent status lookup
+                                // (`file:<path>`); ignored rows never show status.
+                                enableLinks && activeSection !== "ignoreFiles" && !item.isIgnored
+                                  ? agentProcessingByKey.get(processingSourceKey("file", item.id))
+                                  : undefined
+                              }
                               loadStatus={
-                                // The Agent (Links) variant has no per-file status: agent context-load
-                                // state is aggregate (surfaced by AgentContextStatusIcon), and the CAG
-                                // ProjectContextCache / useProjectContextLoad atom this lookup reads is
-                                // never populated by the agent pipeline — feeding it here would render
-                                // stale or empty CAG state against agent files.
+                                // CAG-only per-file status. The agent variant uses
+                                // `agentProcessingItem` above — its status comes from the agent
+                                // pipeline (atom + off-vault cache), NOT the CAG
+                                // ProjectContextCache / useProjectContextLoad atom this lookup
+                                // reads, which the agent pipeline never populates.
                                 enableLinks || activeSection === "ignoreFiles" || item.isIgnored
                                   ? undefined
                                   : getProjectContextItemStatus(item.id, contextLoadLookup)

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -8,7 +8,7 @@ import {
   processingSourceKey,
 } from "@/components/project/processingItemStatusView";
 import { useAgentProcessingItems } from "@/components/project/useAgentProcessingItems";
-import { openCachedProjectFile } from "@/utils/cacheFileOpener";
+import { openAgentCachedItemPreview, openCachedProjectFile } from "@/utils/cacheFileOpener";
 import { ProjectFileSelectModal } from "@/components/modals/ProjectFileSelectModal";
 import { TagSearchModal } from "@/components/modals/TagSearchModal";
 import { TruncatedText } from "@/components/TruncatedText";
@@ -290,8 +290,8 @@ const STATUS_LABELS: Record<ProjectContextItemStatus, string> = {
   notStarted: "Not started",
 };
 
-/** Status → text color — shared by the CAG badge and the agent compact icon so the
- * two never drift. */
+/** Status → text color for the CAG badge. (The agent variant renders status via
+ * the shared {@link ProcessingStatusIcon}, which owns its own colors.) */
 const STATUS_COLOR: Record<ProjectContextItemStatus, string> = {
   success: "tw-text-success",
   failed: "tw-text-error",
@@ -333,8 +333,13 @@ function ItemCard({
   const IconComponent = item.isIgnored ? Plus : XIcon;
 
   // Shared "view parsed content" arrow (revealed on row hover for converted items).
+  // "Converted" is the agent item's `ready` state (Links variant) or the CAG
+  // `success` state — each surface feeds the matching status above.
+  const hasConvertedSnapshot = compactStatus
+    ? agentProcessingItem?.status === "ready"
+    : loadStatus?.status === "success";
   const previewButton =
-    onOpenCached && loadStatus?.status === "success" ? (
+    onOpenCached && hasConvertedSnapshot ? (
       <Button
         variant="ghost2"
         size="icon"
@@ -587,7 +592,9 @@ function ContextManage({
   // Agent (Links) variant ONLY: one shared conversion-status lookup keyed by
   // `processingSourceKey`, covering both URL rows and File Context rows so they
   // render the same {@link ProcessingStatusIcon}. Gated to `enableLinks` so the
-  // CAG path never runs the agent read-model (off-vault cache / agent atom).
+  // CAG path skips the off-vault/fs read and gets a stable empty result (the
+  // hook still subscribes to the agent atom, which is harmless — its value is
+  // unused when disabled).
   const { items: agentProcessingItems } = useAgentProcessingItems(
     app,
     initialProject,
@@ -727,6 +734,39 @@ function ContextManage({
   const [activeItem, setActiveItem] = useState<ActiveItem>(null);
   const isLinksActive =
     activeSection === "links" || activeSection === "web" || activeSection === "youtube";
+
+  // A file row's status + snapshot-preview, resolved in ONE place so the JSX
+  // doesn't branch on `enableLinks` per prop. Agent reads the shared agent
+  // pipeline (status icon + off-vault snapshot); CAG reads its ProjectContextCache
+  // (badge + in-vault parsed content). Ignored rows get neither.
+  const getFileRowStatusProps = useCallback(
+    (
+      item: GroupItem
+    ): Pick<ItemCardProps, "agentProcessingItem" | "loadStatus" | "onOpenCached"> => {
+      if (item.isIgnored || activeSection === "ignoreFiles") return {};
+      if (enableLinks) {
+        const agentItem = agentProcessingByKey.get(processingSourceKey("file", item.id));
+        return {
+          agentProcessingItem: agentItem,
+          onOpenCached: agentItem
+            ? () => void openAgentCachedItemPreview(app, agentItem)
+            : undefined,
+        };
+      }
+      const isMarkdown = item.id.split(".").pop()?.toLowerCase() === "md";
+      return {
+        loadStatus: getProjectContextItemStatus(item.id, contextLoadLookup),
+        // Markdown isn't converted, so it has no parsed snapshot to open.
+        onOpenCached: isMarkdown
+          ? undefined
+          : () => {
+              const name = item.name || item.id.split("/").pop() || item.id;
+              void openCachedProjectFile(app, projectCache, item.id, name);
+            },
+      };
+    },
+    [enableLinks, activeSection, agentProcessingByKey, contextLoadLookup, app, projectCache]
+  );
 
   //  groupList convert to inclusions format
   const convertGroupListToInclusions = useCallback(
@@ -1530,57 +1570,32 @@ function ContextManage({
                   {activeSection || searchTerm
                     ? // When a category is selected or a search is performed, display the normal item list.
                       sortItems(getDisplayItems)
-                        .map((item) =>
-                          showingCategoryItems && isCategoryItem(item) ? (
-                            <CategoryItemCard
-                              key={item.id}
-                              item={item}
-                              onClick={handleCategoryItemClick}
-                            />
-                          ) : !isCategoryItem(item) ? (
+                        .map((item) => {
+                          if (showingCategoryItems && isCategoryItem(item)) {
+                            return (
+                              <CategoryItemCard
+                                key={item.id}
+                                item={item}
+                                onClick={handleCategoryItemClick}
+                              />
+                            );
+                          }
+                          if (isCategoryItem(item)) return null;
+                          return (
                             <ItemCard
                               key={item.id}
                               item={item}
                               viewMode="list"
                               compactStatus={enableLinks}
-                              agentProcessingItem={
-                                // Agent file rows read the shared agent status lookup
-                                // (`file:<path>`); ignored rows never show status.
-                                enableLinks && activeSection !== "ignoreFiles" && !item.isIgnored
-                                  ? agentProcessingByKey.get(processingSourceKey("file", item.id))
-                                  : undefined
-                              }
-                              loadStatus={
-                                // CAG-only per-file status. The agent variant uses
-                                // `agentProcessingItem` above — its status comes from the agent
-                                // pipeline (atom + off-vault cache), NOT the CAG
-                                // ProjectContextCache / useProjectContextLoad atom this lookup
-                                // reads, which the agent pipeline never populates.
-                                enableLinks || activeSection === "ignoreFiles" || item.isIgnored
-                                  ? undefined
-                                  : getProjectContextItemStatus(item.id, contextLoadLookup)
-                              }
                               onDelete={
                                 activeSection === "ignoreFiles" || item.isIgnored
                                   ? handleDeleteIgnoreItem
                                   : handleDeleteItem
                               }
-                              onOpenCached={
-                                // Reason: only offer open for processed non-markdown files. CAG-only:
-                                // the parsed content lives in CAG's ProjectContextCache, which the agent
-                                // pipeline never writes (agent snapshots live in the off-vault conversion cache).
-                                !enableLinks &&
-                                !item.isIgnored &&
-                                item.id.split(".").pop()?.toLowerCase() !== "md"
-                                  ? () => {
-                                      const name = item.name || item.id.split("/").pop() || item.id;
-                                      void openCachedProjectFile(app, projectCache, item.id, name);
-                                    }
-                                  : undefined
-                              }
+                              {...getFileRowStatusProps(item)}
                             />
-                          ) : null
-                        )
+                          );
+                        })
                         .filter(Boolean)
                     : // When no category is selected and no search, display the grouped category list.
                       getDisplayItems

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -25,6 +25,8 @@ import {
   AlertCircle,
   ArrowUpRight,
   CheckCircle,
+  CheckCircle2,
+  Clock,
   FileAudio,
   FileImage,
   FileText,
@@ -41,6 +43,12 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Root } from "react-dom/client";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
+import {
+  LinksContentPanel,
+  LinksSidebarSection,
+} from "@/components/modals/project/ContextManageLinksPanel";
+import { useContextUrls } from "@/components/modals/project/useContextUrls";
+import { UrlTypeIcon } from "@/components/project/UrlTypeIcon";
 
 function FileIcon({ extension, size = "tw-size-4" }: { extension: string; size?: string }) {
   const ext = extension.toLowerCase().replace("*.", "");
@@ -61,7 +69,17 @@ interface ParsedQuery {
   extensions: string[];
 }
 
-type ActiveSection = "tags" | "folders" | "files" | "extensions" | "ignoreFiles" | "search" | null;
+type ActiveSection =
+  | "tags"
+  | "folders"
+  | "files"
+  | "extensions"
+  | "ignoreFiles"
+  | "search"
+  | "links"
+  | "web"
+  | "youtube"
+  | null;
 type ActiveItem = string | null;
 
 interface SectionHeaderProps {
@@ -70,6 +88,9 @@ interface SectionHeaderProps {
   iconColorClassName: string;
   onAddClick: () => void;
   tooltip?: string;
+  /** When provided, the title (icon + label) is clickable — lists the whole
+   * category on the right (agent Links variant). Omitted for CAG → not clickable. */
+  onTitleClick?: () => void;
 }
 
 const SectionHeader: React.FC<SectionHeaderProps> = ({
@@ -78,17 +99,28 @@ const SectionHeader: React.FC<SectionHeaderProps> = ({
   iconColorClassName,
   onAddClick,
   tooltip,
+  onTitleClick,
 }) => {
   return (
     <div className="tw-mb-3 tw-flex tw-items-center tw-justify-between">
-      <div className="tw-flex tw-items-center">
+      <div
+        className={cn(
+          "tw-flex tw-items-center",
+          onTitleClick &&
+            "tw-cursor-pointer tw-rounded-md tw-px-1 tw-py-0.5 hover:tw-bg-secondary/50"
+        )}
+        onClick={onTitleClick}
+      >
         <IconComponent className={`tw-mr-2 tw-size-4 ${iconColorClassName}`} />
         <h3 className={`tw-text-sm tw-font-semibold ${iconColorClassName}`}>{title}</h3>
         {tooltip && (
-          <HelpTooltip
-            buttonClassName="tw-ml-2 tw-size-4 tw-text-muted"
-            content={<div className="tw-max-w-80">{tooltip}</div>}
-          />
+          // Stop the tooltip click from bubbling to the (agent-clickable) title.
+          <span onClick={(e) => e.stopPropagation()}>
+            <HelpTooltip
+              buttonClassName="tw-ml-2 tw-size-4 tw-text-muted"
+              content={<div className="tw-max-w-80">{tooltip}</div>}
+            />
+          </span>
         )}
       </div>
 
@@ -124,6 +156,8 @@ interface SectionListProps {
   onAddClick: () => void;
   onDeleteItem: (e: React.MouseEvent, item: SectionItem) => void;
   tooltip?: string;
+  /** Forwarded to the header's title click (agent Links variant). */
+  onSectionClick?: () => void;
 }
 
 const SectionList: React.FC<SectionListProps> = ({
@@ -139,6 +173,7 @@ const SectionList: React.FC<SectionListProps> = ({
   onAddClick,
   onDeleteItem,
   tooltip,
+  onSectionClick,
 }) => {
   return (
     <div>
@@ -148,6 +183,7 @@ const SectionList: React.FC<SectionListProps> = ({
         iconColorClassName={iconColorClassName}
         onAddClick={onAddClick}
         tooltip={tooltip}
+        onTitleClick={onSectionClick}
       />
       <div className="tw-space-y-1">
         {items.map((item) => (
@@ -249,6 +285,55 @@ const STATUS_LABELS: Record<ProjectContextItemStatus, string> = {
   notStarted: "Not started",
 };
 
+/** Status → text color — shared by the CAG badge and the agent compact icon so the
+ * two never drift. */
+const STATUS_COLOR: Record<ProjectContextItemStatus, string> = {
+  success: "tw-text-success",
+  failed: "tw-text-error",
+  processing: "tw-text-accent",
+  notStarted: "tw-text-muted",
+};
+
+/** Agent (Links-style) compact status icons — keyed lookup instead of a condition
+ * chain. `success` rests hidden (revealed on row hover) since it needs no
+ * attention; `processing` spins. */
+const COMPACT_STATUS_ICON: Record<
+  ProjectContextItemStatus,
+  { Icon: React.ComponentType<{ className?: string }>; spin?: boolean; revealOnHover?: boolean }
+> = {
+  success: { Icon: CheckCircle2, revealOnHover: true },
+  failed: { Icon: AlertCircle },
+  processing: { Icon: Loader2, spin: true },
+  notStarted: { Icon: Clock },
+};
+
+/** The compact, icon-only status for the agent (Links) variant: a bare glyph whose
+ * tooltip reveals the status label, or the failure error when failed. */
+function CompactStatusIcon({ loadStatus }: { loadStatus: ProjectContextItemStatusInfo }) {
+  const { Icon, spin, revealOnHover } = COMPACT_STATUS_ICON[loadStatus.status];
+  const tooltip =
+    loadStatus.status === "failed" && loadStatus.failedItem?.error
+      ? `Failed: ${loadStatus.failedItem.error}`
+      : STATUS_LABELS[loadStatus.status];
+  return (
+    <HelpTooltip
+      side="top"
+      contentClassName="tw-z-[60]"
+      content={<div className="tw-max-w-80">{tooltip}</div>}
+    >
+      <span
+        className={cn(
+          "tw-flex tw-size-5 tw-shrink-0 tw-items-center tw-justify-center",
+          STATUS_COLOR[loadStatus.status],
+          revealOnHover && "tw-opacity-0 group-hover:tw-opacity-100"
+        )}
+      >
+        <Icon className={cn("tw-size-3.5", spin && "tw-animate-spin")} />
+      </span>
+    </HelpTooltip>
+  );
+}
+
 // ============================================================================
 // ItemCard Component
 // ============================================================================
@@ -260,13 +345,40 @@ interface ItemCardProps {
   onDelete: (e: React.MouseEvent, item: GroupItem) => void;
   /** Optional: callback to open the cached parsed content for this file. */
   onOpenCached?: () => void;
+  /** Agent (Links) variant: show status as a bare icon, no text label — matches
+   * the Links panel's icon-only status. CAG keeps icon + label. */
+  compactStatus?: boolean;
 }
 
-function ItemCard({ item, viewMode, loadStatus, onDelete, onOpenCached }: ItemCardProps) {
+function ItemCard({
+  item,
+  viewMode,
+  loadStatus,
+  onDelete,
+  onOpenCached,
+  compactStatus,
+}: ItemCardProps) {
   const extension = item.id.split(".").pop() || "";
 
   // add or remove
   const IconComponent = item.isIgnored ? Plus : XIcon;
+
+  // Shared "view parsed content" arrow (revealed on row hover for converted items).
+  const previewButton =
+    onOpenCached && loadStatus?.status === "success" ? (
+      <Button
+        variant="ghost2"
+        size="icon"
+        className="tw-hidden tw-size-5 group-hover:tw-block"
+        onClick={(e) => {
+          e.stopPropagation();
+          onOpenCached();
+        }}
+        title="View Parsed Content"
+      >
+        <ArrowUpRight className="tw-size-4" />
+      </Button>
+    ) : null;
 
   return (
     <div className="tw-group tw-flex tw-cursor-pointer tw-items-center tw-rounded-lg tw-border tw-border-solid tw-border-border tw-p-2 tw-transition-shadow hover:tw-shadow-md">
@@ -284,47 +396,43 @@ function ItemCard({ item, viewMode, loadStatus, onDelete, onOpenCached }: ItemCa
       </div>
 
       <div className="tw-ml-auto tw-flex tw-min-w-[24px] tw-items-center tw-justify-end tw-gap-2">
-        {loadStatus && (
-          <Badge
-            variant="outline"
-            className={cn(
-              "tw-flex tw-items-center tw-gap-1 tw-whitespace-nowrap",
-              loadStatus.status === "success" && "tw-text-success",
-              loadStatus.status === "failed" && "tw-text-error",
-              loadStatus.status === "processing" && "tw-text-accent",
-              loadStatus.status === "notStarted" && "tw-text-muted"
+        {compactStatus ? (
+          // Agent (Links-style): order is [preview][status][delete]; the status is a
+          // bare icon (ready hidden until row hover), error revealed on hover.
+          <>
+            {previewButton}
+            {loadStatus && <CompactStatusIcon loadStatus={loadStatus} />}
+          </>
+        ) : (
+          // CAG (unchanged): icon + text Badge, then the preview arrow.
+          <>
+            {loadStatus && (
+              <Badge
+                variant="outline"
+                className={cn(
+                  "tw-flex tw-items-center tw-gap-1 tw-whitespace-nowrap",
+                  STATUS_COLOR[loadStatus.status]
+                )}
+                title={
+                  loadStatus.status === "failed" && loadStatus.failedItem?.error
+                    ? `Failed: ${loadStatus.failedItem.error}`
+                    : STATUS_LABELS[loadStatus.status]
+                }
+              >
+                {loadStatus.status === "processing" ? (
+                  <Loader2 className="tw-size-3 tw-animate-spin" />
+                ) : loadStatus.status === "success" ? (
+                  <CheckCircle className="tw-size-3" />
+                ) : loadStatus.status === "failed" ? (
+                  <AlertCircle className="tw-size-3" />
+                ) : (
+                  <div className="tw-size-2 tw-rounded-full tw-border tw-border-solid tw-border-border" />
+                )}
+                <span className="tw-hidden md:tw-inline">{STATUS_LABELS[loadStatus.status]}</span>
+              </Badge>
             )}
-            title={
-              loadStatus.status === "failed" && loadStatus.failedItem?.error
-                ? `Failed: ${loadStatus.failedItem.error}`
-                : STATUS_LABELS[loadStatus.status]
-            }
-          >
-            {loadStatus.status === "processing" ? (
-              <Loader2 className="tw-size-3 tw-animate-spin" />
-            ) : loadStatus.status === "success" ? (
-              <CheckCircle className="tw-size-3" />
-            ) : loadStatus.status === "failed" ? (
-              <AlertCircle className="tw-size-3" />
-            ) : (
-              <div className="tw-size-2 tw-rounded-full tw-border tw-border-solid tw-border-border" />
-            )}
-            <span className="tw-hidden md:tw-inline">{STATUS_LABELS[loadStatus.status]}</span>
-          </Badge>
-        )}
-        {onOpenCached && loadStatus?.status === "success" && (
-          <Button
-            variant="ghost2"
-            size="icon"
-            className="tw-hidden tw-size-5 group-hover:tw-block"
-            onClick={(e) => {
-              e.stopPropagation();
-              onOpenCached();
-            }}
-            title="View Parsed Content"
-          >
-            <ArrowUpRight className="tw-size-4" />
-          </Button>
+            {previewButton}
+          </>
         )}
         <IconComponent
           className="tw-hidden tw-size-4 tw-shrink-0 tw-text-muted hover:tw-text-warning group-hover:tw-block group-hover:tw-flex-none"
@@ -370,7 +478,13 @@ function CategoryItemCard({
       onClick={() => onClick(item)}
     >
       <div className="tw-mr-2 tw-shrink-0">
-        <IconComponent className={`tw-size-6 ${iconColorClassName}`} />
+        {item.type === "web" || item.type === "youtube" ? (
+          // Reuse the canonical URL glyph so the card matches every other URL
+          // surface (Links sidebar, +URL popover, context chips).
+          <UrlTypeIcon type={item.type} className="tw-size-6" />
+        ) : (
+          IconComponent && <IconComponent className={`tw-size-6 ${iconColorClassName}`} />
+        )}
       </div>
       <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col">
         <TruncatedText className="tw-flex-1 tw-text-sm tw-font-medium">
@@ -390,6 +504,12 @@ interface ContextManageProps {
   onSave: (project: ProjectConfig) => void;
   onCancel: () => void;
   app: App;
+  /** Agent Mode: show the Links (Web/YouTube) section and persist URL edits.
+   * Off for CAG callers, leaving this modal's file-only behavior unchanged. */
+  enableLinks?: boolean;
+  /** Portal target for the Links +URL popover — the modal's own `contentEl`, so
+   * the popover (layer 30) stacks above this modal (layer 50). */
+  popoverContainer?: HTMLElement | null;
 }
 
 interface GroupItem {
@@ -412,7 +532,7 @@ interface IgnoreItems {
 interface CategoryItem {
   id: string;
   name: string;
-  type: "tag" | "folder" | "files" | "ignoreFiles";
+  type: "tag" | "folder" | "files" | "ignoreFiles" | "web" | "youtube";
   originalId?: string;
   count: number;
 }
@@ -423,13 +543,25 @@ function isCategoryItem(item: DisplayItem): item is CategoryItem {
   return "type" in item;
 }
 
-function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageProps) {
+function ContextManage({
+  initialProject,
+  onSave,
+  onCancel,
+  app,
+  enableLinks = false,
+  popoverContainer,
+}: ContextManageProps) {
   const isMobile = Platform.isMobile;
   const [contextLoadState] = useProjectContextLoad();
+  const contextUrls = useContextUrls(initialProject);
   const [projectCache, setProjectCache] = useState<ContextCache | null>(null);
 
-  // Load project cache on mount
+  // Load project cache on mount. Skipped for the Agent (Links) variant: the
+  // agent pipeline never writes the CAG ProjectContextCache, and its file rows
+  // no longer consume `projectCache` (see the ItemCard loadStatus/onOpenCached
+  // gating), so the read would only burn a disk hit and a re-render.
   useEffect(() => {
+    if (enableLinks) return;
     let isMounted = true;
     const loadCache = async () => {
       const cache = await ProjectContextCache.getInstance().get(initialProject);
@@ -441,7 +573,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
     return () => {
       isMounted = false;
     };
-  }, [initialProject]);
+  }, [initialProject, enableLinks]);
 
   // Check if viewing the currently loaded project
   const isCurrentProject = useMemo(() => {
@@ -607,6 +739,8 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
   const [searchTerm, setSearchTerm] = useState("");
   const [activeSection, setActiveSection] = useState<ActiveSection>(null);
   const [activeItem, setActiveItem] = useState<ActiveItem>(null);
+  const isLinksActive =
+    activeSection === "links" || activeSection === "web" || activeSection === "youtube";
 
   //  groupList convert to inclusions format
   const convertGroupListToInclusions = useCallback(
@@ -768,12 +902,39 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
       return [];
     }
 
+    // Clicking the Tags header (agent Links variant) lists every tag. CAG never
+    // reaches this state — its header isn't clickable — so behavior is unchanged.
+    if (activeSection === "tags") {
+      return sortItems(
+        Object.entries(groupList.tags).map(([tagId, files]) => ({
+          id: `tag:${tagId}`,
+          name: tagId.slice(1),
+          type: "tag",
+          originalId: tagId,
+          count: files.length,
+        }))
+      );
+    }
+
     if (activeSection === "folders" && activeItem) {
       const folderFiles = groupList.folders[activeItem];
       if (folderFiles) {
         return folderFiles;
       }
       return [];
+    }
+
+    // Clicking the Folders header (agent Links variant) lists every folder.
+    if (activeSection === "folders") {
+      return sortItems(
+        Object.entries(groupList.folders).map(([folderId, files]) => ({
+          id: `folder:${folderId}`,
+          name: folderId,
+          type: "folder",
+          originalId: folderId,
+          count: files.length,
+        }))
+      );
     }
 
     if (activeSection === "files") {
@@ -841,7 +1002,24 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
             ]
           : [];
 
-      return [...tagItems, ...folderItems, ...filesItem, ...ignoreFilesItem];
+      // Agent (Links) variant only: list Web and YouTube as their own cards so
+      // the overview surfaces every context type the same way (one card per
+      // non-empty group, exactly like folders). Leads the grid to mirror the
+      // sidebar, where Links sits first.
+      const webCount = enableLinks
+        ? contextUrls.urlItems.filter((u) => u.type === "web").length
+        : 0;
+      const youtubeCount = enableLinks
+        ? contextUrls.urlItems.filter((u) => u.type === "youtube").length
+        : 0;
+      const linkItems = [
+        ...(webCount > 0 ? [{ id: "web:all", name: "Web", type: "web", count: webCount }] : []),
+        ...(youtubeCount > 0
+          ? [{ id: "youtube:all", name: "YouTube", type: "youtube", count: youtubeCount }]
+          : []),
+      ];
+
+      return [...linkItems, ...tagItems, ...folderItems, ...filesItem, ...ignoreFilesItem];
     }
 
     return [];
@@ -858,6 +1036,8 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
     groupList.extensions,
     ignoreItems.files,
     sortItems,
+    enableLinks,
+    contextUrls.urlItems,
   ]);
 
   const makeSectionItem = useCallback(
@@ -1085,19 +1265,26 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
         groupHandlers.click.files();
       } else if (item.type === "ignoreFiles") {
         groupHandlers.click.ignoreFiles();
+      } else if (item.type === "web" || item.type === "youtube") {
+        setActiveState(item.type);
       }
     },
-    [groupHandlers]
+    [groupHandlers, setActiveState]
   );
 
   const getDisplayTitle = () => {
     if (searchTerm) return `Search Results for: "${searchTerm}"`;
+    if (activeSection === "links") return "Links";
+    if (activeSection === "web") return "Web";
+    if (activeSection === "youtube") return "YouTube";
     if (activeSection === "tags" && activeItem) {
       return `Tag: ${activeItem}`;
     }
+    if (activeSection === "tags") return "Tags";
     if (activeSection === "folders" && activeItem) {
       return `Folder: ${activeItem}`;
     }
+    if (activeSection === "folders") return "Folders";
     if (activeSection === "files") return "Files";
     if (activeSection === "extensions" && activeItem) {
       return `Extension: ${activeItem}`;
@@ -1105,6 +1292,12 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
     if (activeSection === "ignoreFiles") return "Ignore Files";
     return "All Categories";
   };
+
+  // Agent Links variant: clicking the Tags/Folders header lists that category's
+  // entries on the right. Those are CategoryItems, so the right pane must use the
+  // category-card branch (not the file ItemCard branch) for these states.
+  const showingCategoryItems =
+    !searchTerm && !activeItem && (activeSection === "tags" || activeSection === "folders");
 
   const handleDeleteItem = (e: React.MouseEvent, item: GroupItem) => {
     e.stopPropagation();
@@ -1167,6 +1360,11 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
         ...initialProject.contextSource,
         inclusions: include,
         exclusions: exclude,
+        // Agent Mode only: persist URL edits back. CAG callers don't enable
+        // Links, so their save payload is byte-for-byte unchanged.
+        ...(enableLinks
+          ? { webUrls: contextUrls.webUrls, youtubeUrls: contextUrls.youtubeUrls }
+          : {}),
       },
     });
   };
@@ -1184,6 +1382,25 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
 
             <ScrollArea className="tw-max-h-[500px] tw-flex-1">
               <div className="tw-space-y-6 tw-p-4">
+                {/* Links first: URLs are the most-used source in agent projects,
+                    so the section leads the navigation when links are enabled. */}
+                {enableLinks && (
+                  <>
+                    <LinksSidebarSection
+                      activeSection={activeSection}
+                      webCount={contextUrls.urlItems.filter((u) => u.type === "web").length}
+                      youtubeCount={contextUrls.urlItems.filter((u) => u.type === "youtube").length}
+                      onSelect={(s) => setActiveState(s)}
+                      existingUrls={contextUrls.urlItems.map((u) => u.url)}
+                      onAddUrls={(items) =>
+                        contextUrls.addFromText(items.map((i) => i.url).join("\n"))
+                      }
+                      popoverContainer={popoverContainer}
+                    />
+                    <Separator />
+                  </>
+                )}
+
                 {/* Tags Section */}
                 <SectionList
                   title="Tags"
@@ -1198,6 +1415,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
                   onAddClick={groupHandlers.add.tag}
                   onDeleteItem={(e, item) => groupHandlers.delete.tag(e, item)}
                   tooltip="must be in note property"
+                  onSectionClick={enableLinks ? () => setActiveState("tags", null) : undefined}
                 />
 
                 <Separator />
@@ -1214,6 +1432,7 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
                   onItemClick={groupHandlers.click.folder}
                   onAddClick={groupHandlers.add.folder}
                   onDeleteItem={(e, item) => groupHandlers.delete.folder(e, item)}
+                  onSectionClick={enableLinks ? () => setActiveState("folders", null) : undefined}
                 />
 
                 <Separator />
@@ -1306,7 +1525,15 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
 
             {/* Content Area */}
             <ScrollArea className="tw-max-h-[400px] tw-flex-1 tw-p-4 tw-pt-0">
-              {getDisplayItems.length === 0 ? (
+              {isLinksActive ? (
+                <LinksContentPanel
+                  app={app}
+                  project={initialProject}
+                  urlItems={contextUrls.urlItems}
+                  filter={activeSection}
+                  onRemove={contextUrls.removeUrl}
+                />
+              ) : getDisplayItems.length === 0 ? (
                 <div className="tw-mt-10 tw-text-center tw-text-muted">
                   {activeSection
                     ? "No items found."
@@ -1318,13 +1545,25 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
                     ? // When a category is selected or a search is performed, display the normal item list.
                       sortItems(getDisplayItems)
                         .map((item) =>
-                          !isCategoryItem(item) ? (
+                          showingCategoryItems && isCategoryItem(item) ? (
+                            <CategoryItemCard
+                              key={item.id}
+                              item={item}
+                              onClick={handleCategoryItemClick}
+                            />
+                          ) : !isCategoryItem(item) ? (
                             <ItemCard
                               key={item.id}
                               item={item}
                               viewMode="list"
+                              compactStatus={enableLinks}
                               loadStatus={
-                                activeSection === "ignoreFiles" || item.isIgnored
+                                // The Agent (Links) variant has no per-file status: agent context-load
+                                // state is aggregate (surfaced by AgentContextStatusIcon), and the CAG
+                                // ProjectContextCache / useProjectContextLoad atom this lookup reads is
+                                // never populated by the agent pipeline — feeding it here would render
+                                // stale or empty CAG state against agent files.
+                                enableLinks || activeSection === "ignoreFiles" || item.isIgnored
                                   ? undefined
                                   : getProjectContextItemStatus(item.id, contextLoadLookup)
                               }
@@ -1334,8 +1573,12 @@ function ContextManage({ initialProject, onSave, onCancel, app }: ContextManageP
                                   : handleDeleteItem
                               }
                               onOpenCached={
-                                // Reason: only offer open for non-markdown files that have been processed
-                                !item.isIgnored && item.id.split(".").pop()?.toLowerCase() !== "md"
+                                // Reason: only offer open for processed non-markdown files. CAG-only:
+                                // the parsed content lives in CAG's ProjectContextCache, which the agent
+                                // pipeline never writes (agent snapshots live in the off-vault conversion cache).
+                                !enableLinks &&
+                                !item.isIgnored &&
+                                item.id.split(".").pop()?.toLowerCase() !== "md"
                                   ? () => {
                                       const name = item.name || item.id.split("/").pop() || item.id;
                                       void openCachedProjectFile(app, projectCache, item.id, name);
@@ -1380,7 +1623,8 @@ export class ContextManageModal extends Modal {
   constructor(
     app: App,
     private onSave: (project: ProjectConfig) => void,
-    private initialProject: ProjectConfig
+    private initialProject: ProjectConfig,
+    private options: { enableLinks?: boolean } = {}
   ) {
     super(app);
   }
@@ -1406,6 +1650,8 @@ export class ContextManageModal extends Modal {
         onSave={handleSave}
         onCancel={handleCancel}
         app={this.app}
+        enableLinks={this.options.enableLinks}
+        popoverContainer={contentEl}
       />
     );
   }

--- a/src/components/modals/project/useContextUrls.ts
+++ b/src/components/modals/project/useContextUrls.ts
@@ -1,0 +1,57 @@
+import type { ProjectConfig } from "@/aiParams";
+import {
+  parseProjectUrls,
+  parseUrlsFromText,
+  serializeProjectUrls,
+  type UrlItem,
+} from "@/utils/urlTagUtils";
+import { useCallback, useMemo, useState } from "react";
+
+export interface ContextUrlsState {
+  webUrls: string;
+  youtubeUrls: string;
+  urlItems: UrlItem[];
+  /** Parse free text (single / batch paste), classify, dedup, and append. */
+  addFromText: (text: string) => void;
+  removeUrl: (id: string) => void;
+}
+
+/**
+ * Draft URL state for the Manage modal's Links panel: keeps the two
+ * newline-separated ProjectConfig strings, exposes them as parsed
+ * {@link UrlItem}s, and edits via the shared {@link parseUrlsFromText} /
+ * {@link serializeProjectUrls} so add/dedup/classify match UrlTagInput and the
+ * +URL modal exactly. Committed back into the project on the modal's Save.
+ */
+export function useContextUrls(initial: ProjectConfig): ContextUrlsState {
+  const [webUrls, setWebUrls] = useState(initial.contextSource?.webUrls ?? "");
+  const [youtubeUrls, setYoutubeUrls] = useState(initial.contextSource?.youtubeUrls ?? "");
+
+  const urlItems = useMemo(() => parseProjectUrls(webUrls, youtubeUrls), [webUrls, youtubeUrls]);
+
+  const commit = useCallback((items: UrlItem[]) => {
+    const serialized = serializeProjectUrls(items);
+    setWebUrls(serialized.webUrls);
+    setYoutubeUrls(serialized.youtubeUrls);
+  }, []);
+
+  const addFromText = useCallback(
+    (text: string) => {
+      const added = parseUrlsFromText(
+        text,
+        urlItems.map((u) => u.url)
+      );
+      if (added.length > 0) commit([...urlItems, ...added]);
+    },
+    [urlItems, commit]
+  );
+
+  const removeUrl = useCallback(
+    (id: string) => {
+      commit(urlItems.filter((u) => u.id !== id));
+    },
+    [urlItems, commit]
+  );
+
+  return { webUrls, youtubeUrls, urlItems, addFromText, removeUrl };
+}

--- a/src/components/project/AddUrlPopover.tsx
+++ b/src/components/project/AddUrlPopover.tsx
@@ -1,0 +1,193 @@
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { UrlInputRow } from "@/components/project/UrlInputRow";
+import { UrlTypeIcon } from "@/components/project/UrlTypeIcon";
+import { cn } from "@/lib/utils";
+import { createUrlItem, normalizeUrl, resolveInputUrls, type UrlItem } from "@/utils/urlTagUtils";
+import { Link, Plus, X } from "lucide-react";
+import React, { useMemo, useState } from "react";
+
+interface AddUrlPopoverProps {
+  /** Existing URLs (raw or normalized) so already-added entries flag as duplicates. */
+  existingUrls: string[];
+  /** The deduped, non-duplicate URLs the user confirmed. The caller merges them. */
+  onAdd: (urls: UrlItem[]) => void;
+  /** Portal target. Pass the host modal's `contentEl` so the popover stacks
+   * above it: the popover layer (30) sits below the modal layer (50), so a
+   * body-portaled popover would render behind the Edit-project modal. */
+  container?: HTMLElement | null;
+  /** Custom trigger (e.g. the Manage sidebar's PlusCircle). Defaults to the
+   * footer's cyan "+ URL" link. */
+  trigger?: React.ReactNode;
+}
+
+/** A URL staged for adding, tagged with whether it already lives in the project's
+ * context (a duplicate is shown but not committed). */
+interface PendingUrl {
+  item: UrlItem;
+  duplicate: boolean;
+}
+
+/**
+ * The "+ URL" control (design ⑤): a trigger opening a small popover that stages
+ * URLs in a **pending list** before committing. The input's right-side button is
+ * one control with two states — empty → paste from clipboard, non-empty → add
+ * the typed value (Enter does the same) — and a paste anywhere routes straight
+ * into the list. Each staged URL is auto-classified web/YouTube and deduped:
+ * within the list it collapses, against the project's existing URLs it flags as
+ * "Exists" and is excluded from the commit. "Add N" sends the valid items out
+ * through `onAdd`; the caller merges them into its context source.
+ *
+ * A Popover, NOT a Modal, so it never stacks a second modal over the Edit-project
+ * modal (see the agent layer rules' modal/dialog note). Parsing reuses the shared
+ * {@link resolveInputUrls} (scheme-anchored extraction + single-token fallback),
+ * so a pasted document can't smuggle bare-host prose tokens into the list.
+ */
+export function AddUrlPopover({ existingUrls, onAdd, container, trigger }: AddUrlPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const [pending, setPending] = useState<PendingUrl[]>([]);
+
+  const existingSet = useMemo(() => new Set(existingUrls.map(normalizeUrl)), [existingUrls]);
+
+  const validCount = pending.reduce((n, p) => (p.duplicate ? n : n + 1), 0);
+  const dupCount = pending.length - validCount;
+
+  // Stage every URL parsed from `text`, skipping ones already staged and tagging
+  // ones already in the project. The single source of truth for all three input
+  // paths (Add button, Enter, paste).
+  const stageFromText = (text: string) => {
+    const parsed = resolveInputUrls(text);
+    if (parsed.length === 0) return;
+    setPending((prev) => {
+      const staged = new Set(prev.map((p) => p.item.url));
+      const additions: PendingUrl[] = [];
+      for (const raw of parsed) {
+        const item = createUrlItem(raw);
+        if (staged.has(item.url)) continue;
+        staged.add(item.url);
+        additions.push({ item, duplicate: existingSet.has(item.url) });
+      }
+      return additions.length > 0 ? [...prev, ...additions] : prev;
+    });
+  };
+
+  const resetAndClose = () => {
+    setPending([]);
+    setOpen(false);
+  };
+
+  const commit = () => {
+    const valid = pending.filter((p) => !p.duplicate).map((p) => p.item);
+    if (valid.length === 0) return;
+    onAdd(valid);
+    resetAndClose();
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setPending([]);
+      }}
+    >
+      <PopoverTrigger asChild>
+        {trigger ?? (
+          <Button
+            variant="ghost2"
+            size="sm"
+            className="tw-h-auto tw-gap-1 tw-px-0 tw-text-context-manager-cyan hover:tw-text-context-manager-cyan"
+          >
+            <Plus className="tw-size-3.5" />
+            URL
+          </Button>
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="start" container={container} className="tw-w-80 tw-p-0">
+        <div className="tw-flex tw-items-center tw-gap-2 tw-border-x-[0px] tw-border-b tw-border-t-[0px] tw-border-solid tw-border-border tw-px-3.5 tw-pb-2.5 tw-pt-3 tw-text-sm tw-font-semibold tw-text-normal">
+          <Link className="tw-size-3.5" />
+          Add URLs
+          <Button
+            variant="ghost2"
+            size="icon"
+            aria-label="Close"
+            onClick={resetAndClose}
+            className="tw-ml-auto"
+          >
+            <X className="tw-size-3.5" />
+          </Button>
+        </div>
+
+        <div className="tw-flex tw-flex-col tw-gap-2 tw-px-3.5 tw-py-3">
+          <UrlInputRow autoFocus onSubmit={stageFromText} placeholder="Enter a URL…" />
+
+          {/* Fixed height (not max-height): the popover's total height stays
+              constant as items are staged, so Radix never re-flips it to dodge a
+              growing box — which read as a jarring jump when opened from the
+              Manage sidebar's tight top corner. */}
+          <div className="tw-flex tw-h-28 tw-flex-col tw-gap-1.5 tw-overflow-y-auto">
+            {pending.length === 0 ? (
+              <div className="tw-flex tw-flex-1 tw-flex-col tw-items-center tw-justify-center tw-gap-1 tw-text-center tw-text-xs tw-text-faint">
+                <Link className="tw-mb-1 tw-size-5" />
+                No URLs queued yet — type or paste above
+              </div>
+            ) : (
+              pending.map(({ item, duplicate }) => (
+                <div
+                  key={item.id}
+                  className={cn(
+                    "tw-flex tw-items-center tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-px-2.5 tw-py-1.5 tw-text-sm",
+                    duplicate ? "tw-border-error tw-bg-error/10" : "tw-border-border"
+                  )}
+                >
+                  <UrlTypeIcon type={item.type} className="tw-size-3.5 tw-shrink-0" />
+                  <span
+                    className={cn(
+                      "tw-min-w-0 tw-flex-1 tw-truncate",
+                      duplicate ? "tw-text-error" : "tw-text-normal"
+                    )}
+                    title={item.url}
+                  >
+                    {item.url.replace(/^https?:\/\//, "")}
+                  </span>
+                  {/* The leading icon already conveys web/YouTube, so only the
+                      duplicate case needs a label — "Exists" explains why it's
+                      excluded from the commit. */}
+                  {duplicate && (
+                    <span className="tw-shrink-0 tw-rounded tw-border tw-border-solid tw-border-error tw-px-1 tw-font-mono tw-text-ui-smaller tw-text-error">
+                      Exists
+                    </span>
+                  )}
+                  <Button
+                    variant="ghost2"
+                    size="icon"
+                    aria-label="Remove"
+                    className="tw-shrink-0"
+                    onClick={() => setPending((prev) => prev.filter((p) => p.item.id !== item.id))}
+                  >
+                    <X className="tw-size-3.5" />
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="tw-flex tw-items-center tw-gap-2 tw-border-x-[0px] tw-border-b-[0px] tw-border-t tw-border-solid tw-border-border tw-px-3.5 tw-py-2.5">
+          <span className="tw-text-xs tw-text-faint">
+            {validCount} to add
+            {dupCount > 0 && ` · ${dupCount} exist`}
+          </span>
+          <div className="tw-ml-auto tw-flex tw-gap-2">
+            <Button variant="ghost" size="sm" onClick={resetAndClose}>
+              Cancel
+            </Button>
+            <Button size="sm" disabled={validCount === 0} onClick={commit}>
+              Add{validCount > 0 ? ` ${validCount}` : ""}
+            </Button>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/project/AgentContextConversionModalContent.tsx
+++ b/src/components/project/AgentContextConversionModalContent.tsx
@@ -1,0 +1,253 @@
+import { ProcessingStatus } from "@/components/project/processing-status";
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { CheckCircle2, Inbox, Loader2, RotateCcw, SquarePen, XCircle } from "lucide-react";
+import React, { useMemo, useState } from "react";
+
+interface AgentContextConversionModalContentProps {
+  items: ProcessingItem[];
+  /** Whether the project declares any context source. Distinguishes a project
+   * with no sources at all from one whose sources are all conversion-free
+   * (markdown / native-readable), so the zero-item state isn't mislabeled
+   * "no context sources yet" when context is actually present. */
+  hasConfiguredContextSource: boolean;
+  skippedMarkdownCount: number;
+  /** Per-source retry (agent `rematerializeSource`). */
+  onRetryItem: (item: ProcessingItem) => void;
+  /** Whole-project re-materialize (failed-only when there are failures). */
+  onRetryAll: () => void;
+  onEditContext: () => void;
+  onOpenCachedItem?: (item: ProcessingItem) => void;
+}
+
+type Filter = "all" | "failed" | "processing";
+
+/**
+ * Content Conversion status surface (design S): header (icon + title + total) +
+ * progress bar + filter chips + the grouped list (reusing {@link ProcessingStatus}
+ * with its summary bar hidden) + footer (Retry all/failed · Edit context). Pure
+ * presentation — data + retry wiring are injected by the caller. Rendered inside
+ * an Obsidian modal (composer status popover) and embedded in the Edit modal.
+ */
+export function AgentContextConversionModalContent({
+  items,
+  hasConfiguredContextSource,
+  skippedMarkdownCount,
+  onRetryItem,
+  onRetryAll,
+  onEditContext,
+  onOpenCachedItem,
+}: AgentContextConversionModalContentProps) {
+  const total = items.length;
+  const failedCount = items.filter((i) => i.status === "failed").length;
+  // Pending counts as "in flight" (queued for the next/active run); unsupported
+  // counts as done (it won't convert, but it isn't a failure either).
+  const inFlightCount = items.filter(
+    (i) => i.status === "processing" || i.status === "pending"
+  ).length;
+  const doneCount = total - inFlightCount;
+  const successRatio =
+    total === 0 ? 0 : (items.filter((i) => i.status === "ready").length / total) * 100;
+  const failedRatio = total === 0 ? 0 : (failedCount / total) * 100;
+  const doneRatio = total === 0 ? 0 : (doneCount / total) * 100;
+
+  const overall: "success" | "processing" | "failed" =
+    inFlightCount > 0 ? "processing" : failedCount > 0 ? "failed" : "success";
+
+  // Default to the Failed filter when there are failures (design S3), but let the
+  // user switch afterward — lazy init avoids a set-state-in-effect reconciliation.
+  const [filter, setFilter] = useState<Filter>(() =>
+    items.some((i) => i.status === "failed") ? "failed" : "all"
+  );
+
+  // A retry can empty the active filter (e.g. the last failure clears while the
+  // Failed chip — and its filter — are still selected). Fall back to All so the
+  // body never shows an empty list against a chip that's no longer rendered.
+  const effectiveFilter: Filter =
+    (filter === "failed" && failedCount === 0) || (filter === "processing" && inFlightCount === 0)
+      ? "all"
+      : filter;
+
+  const filteredItems = useMemo(() => {
+    if (effectiveFilter === "failed") return items.filter((i) => i.status === "failed");
+    if (effectiveFilter === "processing")
+      return items.filter((i) => i.status === "processing" || i.status === "pending");
+    return items;
+  }, [items, effectiveFilter]);
+
+  // Zero-state: no items to CONVERT. Two distinct cases the UI must not conflate:
+  //  - conversion-free context (markdown / native-readable sources are present
+  //    but need no conversion) → a calm "nothing to convert" note, NOT an error.
+  //  - genuinely no sources → the neutral "add some" hint.
+  // Mislabeling the former as "no context sources yet" is the bug this guards.
+  if (total === 0) {
+    const hasConversionFreeContext = hasConfiguredContextSource || skippedMarkdownCount > 0;
+    return (
+      <div className="tw-flex tw-w-[368px] tw-max-w-full tw-flex-col">
+        <div className="tw-flex tw-items-center tw-gap-2 tw-border-x-[0px] tw-border-b tw-border-t-[0px] tw-border-solid tw-border-border tw-px-3.5 tw-py-3 tw-text-sm tw-font-semibold tw-text-normal">
+          {hasConversionFreeContext ? (
+            <CheckCircle2 className="tw-size-4 tw-text-success" />
+          ) : (
+            <Inbox className="tw-size-4 tw-text-muted" />
+          )}
+          {hasConversionFreeContext ? "No conversion needed" : "No context loaded"}
+        </div>
+        <div className="tw-px-3.5 tw-py-6 tw-text-center tw-text-sm tw-text-muted">
+          {hasConversionFreeContext ? (
+            <>
+              Context sources are configured and ready to use.
+              {skippedMarkdownCount > 0 && (
+                <div className="tw-mt-1 tw-text-xs tw-text-faint">
+                  {skippedMarkdownCount} markdown {skippedMarkdownCount === 1 ? "file" : "files"} —
+                  no conversion needed
+                </div>
+              )}
+            </>
+          ) : (
+            "This project has no context sources yet."
+          )}
+        </div>
+        <div className="tw-flex tw-justify-end tw-border-x-[0px] tw-border-b-[0px] tw-border-t tw-border-solid tw-border-border tw-px-3.5 tw-py-2.5">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="tw-gap-1.5 tw-text-muted"
+            onClick={onEditContext}
+          >
+            <SquarePen className="tw-size-3.5" />
+            Edit context
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-min-h-0 tw-w-[368px] tw-max-w-full tw-flex-col">
+      {/* Header */}
+      <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-2 tw-border-x-[0px] tw-border-b tw-border-t-[0px] tw-border-solid tw-border-border tw-px-3.5 tw-py-3 tw-text-sm tw-font-semibold tw-text-normal">
+        {overall === "success" && <CheckCircle2 className="tw-size-4 tw-text-success" />}
+        {overall === "processing" && (
+          <Loader2 className="tw-size-4 tw-animate-spin tw-text-accent" />
+        )}
+        {overall === "failed" && <XCircle className="tw-size-4 tw-text-error" />}
+        <span>
+          {overall === "success" && "Context ready"}
+          {overall === "processing" && "Processing…"}
+          {overall === "failed" && `${failedCount} failed`}
+        </span>
+        <span
+          className={cn(
+            "tw-ml-auto tw-font-mono tw-text-xs tw-font-medium",
+            overall === "processing" ? "tw-text-accent" : "tw-text-faint"
+          )}
+        >
+          {overall === "processing"
+            ? `${doneCount} / ${total}`
+            : `${total} ${overall === "failed" ? "total" : "items"}`}
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div className="tw-flex tw-h-1 tw-w-full tw-shrink-0 tw-overflow-hidden tw-bg-secondary">
+        {overall === "success" && <div className="tw-size-full tw-bg-success" />}
+        {overall === "processing" && (
+          <div
+            className="tw-h-full tw-bg-interactive-accent tw-transition-all"
+            style={{ width: `${doneRatio}%` }}
+          />
+        )}
+        {overall === "failed" && (
+          <>
+            <div className="tw-h-full tw-bg-success" style={{ width: `${successRatio}%` }} />
+            <div className="tw-h-full tw-bg-error" style={{ width: `${failedRatio}%` }} />
+          </>
+        )}
+      </div>
+
+      {/* Filter chips */}
+      <div className="tw-flex tw-shrink-0 tw-gap-1.5 tw-px-3.5 tw-pb-1 tw-pt-2">
+        <FilterChip
+          label="All"
+          active={effectiveFilter === "all"}
+          onClick={() => setFilter("all")}
+        />
+        {failedCount > 0 && (
+          <FilterChip
+            label={`Failed (${failedCount})`}
+            active={effectiveFilter === "failed"}
+            onClick={() => setFilter("failed")}
+          />
+        )}
+        {inFlightCount > 0 && (
+          <FilterChip
+            label="Processing"
+            active={effectiveFilter === "processing"}
+            onClick={() => setFilter("processing")}
+          />
+        )}
+      </div>
+
+      {/* List body — ONE scroll layer at the design's fixed `.pb` height (280px).
+          `maxHeight="none"` stops the per-group ScrollableLists from self-scrolling.
+          `min-h-0` (no flex-1) keeps the popover compact at the design size, yet lets
+          it shrink below 280 on a small window — PopoverContent is capped by Radix's
+          --radix-popover-content-available-height and the fixed header/footer are
+          shrink-0, so only this list gives way and the footer stays visible. */}
+      <div className="tw-max-h-[280px] tw-min-h-0 tw-overflow-y-auto tw-px-3.5 tw-pb-2 tw-pt-1">
+        <ProcessingStatus
+          items={filteredItems}
+          hideSummaryBar
+          showHeader={false}
+          onRetryItem={onRetryItem}
+          skippedMarkdownCount={skippedMarkdownCount}
+          maxHeight="none"
+          onOpenCachedItem={onOpenCachedItem}
+        />
+      </div>
+
+      {/* Footer */}
+      <div className="tw-flex tw-shrink-0 tw-gap-1.5 tw-border-x-[0px] tw-border-b-[0px] tw-border-t tw-border-solid tw-border-border tw-px-3.5 tw-py-2.5">
+        <Button variant="ghost" size="sm" className="tw-gap-1.5 tw-text-muted" onClick={onRetryAll}>
+          <RotateCcw className="tw-size-3.5" />
+          {failedCount > 0 ? "Retry failed" : "Retry all"}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="tw-gap-1.5 tw-text-muted"
+          onClick={onEditContext}
+        >
+          <SquarePen className="tw-size-3.5" />
+          Edit context
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function FilterChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Button
+      variant="ghost2"
+      size="sm"
+      className={cn(
+        "tw-h-auto tw-rounded-full tw-bg-secondary tw-px-2.5 tw-py-0.5 tw-text-xs tw-font-medium tw-text-muted hover:tw-bg-secondary hover:tw-text-normal",
+        active &&
+          "tw-text-accent tw-bg-interactive-accent/10 hover:tw-text-accent hover:tw-bg-interactive-accent/10"
+      )}
+      onClick={onClick}
+    >
+      {label}
+    </Button>
+  );
+}

--- a/src/components/project/ContextChip.tsx
+++ b/src/components/project/ContextChip.tsx
@@ -1,0 +1,50 @@
+import { TruncatedText } from "@/components/TruncatedText";
+import { cn } from "@/lib/utils";
+import { X } from "lucide-react";
+import React from "react";
+
+interface ContextChipProps {
+  /** Pre-sized lucide icon (e.g. `<Folder className="tw-size-3.5" />`). */
+  icon: React.ReactNode;
+  /** Theme color class for the icon, e.g. `tw-text-context-manager-yellow`. */
+  colorClass: string;
+  label: string;
+  /** Tooltip shown on the (truncated) label; defaults to the label text. */
+  tooltip?: string;
+  /** When provided, a hover-revealed X removes the chip. */
+  onRemove?: () => void;
+  /** Dim the chip (design's collapsed-overflow hint). */
+  dim?: boolean;
+}
+
+/**
+ * One context source rendered as the design's square 8px-radius bordered chip
+ * (NOT the pill `Badge` the CAG `ProjectContextBadgeList` uses — that component
+ * is shared with the legacy CAG modal and must keep its look). Folder / tag /
+ * file / web / youtube all share this atom, differing only by `icon`+`colorClass`,
+ * so the agent landing's mixed file+URL row reads as one consistent set.
+ */
+export function ContextChip({ icon, colorClass, label, tooltip, onRemove, dim }: ContextChipProps) {
+  return (
+    <span
+      className={cn(
+        "tw-inline-flex tw-max-w-[175px] tw-items-center tw-gap-1.5 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-primary tw-px-2 tw-py-1 tw-text-xs",
+        dim && "tw-opacity-45"
+      )}
+    >
+      <span className={cn("tw-flex tw-shrink-0 tw-items-center", colorClass)}>{icon}</span>
+      <TruncatedText className="tw-min-w-0" tooltipContent={tooltip ?? label}>
+        {label}
+      </TruncatedText>
+      {onRemove && (
+        <X
+          className="tw-size-3.5 tw-shrink-0 tw-cursor-pointer tw-text-faint hover:tw-text-normal"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+        />
+      )}
+    </span>
+  );
+}

--- a/src/components/project/ProjectContextBadgeList.tsx
+++ b/src/components/project/ProjectContextBadgeList.tsx
@@ -48,6 +48,11 @@ interface ProjectContextBadgeListProps {
   maxExpandedHeight?: number;
   /** Optional action element rendered on the right of the control bar (e.g. "Manage Context" button). */
   actionSlot?: React.ReactNode;
+  /**
+   * Drop the content container's own border/padding so the list can embed in a
+   * caller-owned box (e.g. the agent landing's combined chips-and-drop area).
+   */
+  borderless?: boolean;
 }
 
 /** Decode, deduplicate, and categorize a pattern string into badge items */
@@ -87,6 +92,7 @@ export const ProjectContextBadgeList: React.FC<ProjectContextBadgeListProps> = (
   maxCollapsedHeight = 84,
   maxExpandedHeight = 200,
   actionSlot,
+  borderless = false,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
@@ -183,7 +189,12 @@ export const ProjectContextBadgeList: React.FC<ProjectContextBadgeListProps> = (
   return (
     <div className="tw-flex tw-flex-col tw-gap-2">
       {/* Content container */}
-      <div className="tw-relative tw-rounded-md tw-border tw-border-solid tw-border-border tw-p-2">
+      <div
+        className={cn(
+          "tw-relative",
+          !borderless && "tw-rounded-md tw-border tw-border-solid tw-border-border tw-p-2"
+        )}
+      >
         <div
           ref={contentRef}
           className={cn(

--- a/src/components/project/ProjectContextSourceEditor.tsx
+++ b/src/components/project/ProjectContextSourceEditor.tsx
@@ -1,0 +1,333 @@
+import type { ProjectConfig } from "@/aiParams";
+import { AddUrlPopover } from "@/components/project/AddUrlPopover";
+import { ContextChip } from "@/components/project/ContextChip";
+import { buildBadgeItems, removePattern } from "@/components/project/ProjectContextBadgeList";
+import { UrlTypeIcon } from "@/components/project/UrlTypeIcon";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { parseProjectUrls, serializeProjectUrls, type UrlItem } from "@/utils/urlTagUtils";
+import { FileText, Folder, Hash, Inbox, Settings, Tag } from "lucide-react";
+import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
+
+type ContextSource = NonNullable<ProjectConfig["contextSource"]>;
+
+interface ProjectContextSourceEditorProps {
+  contextSource: ProjectConfig["contextSource"] | undefined;
+  /** Apply a partial context-source patch (a chip delete / URL add). The caller
+   * decides persistence: the home section persists immediately, the Edit modal
+   * folds it into its draft. */
+  onChange: (patch: Partial<ContextSource>) => void;
+  /** Open the full Manage modal. */
+  onManage: () => void;
+  /** Portal target for the footer +URL popover. Pass the host modal's `contentEl`
+   * (Edit project) so it stacks above the modal; omit on the home shelf (body). */
+  popoverContainer?: HTMLElement | null;
+  /** Drag is hovering this editor's drop zone (owned by the caller). */
+  isDragging?: boolean;
+  /** Whether this placement accepts drag-and-drop (the home shelf does; the Edit
+   * modal can't). When false the drag hints are hidden — only +URL / Manage show. */
+  droppable?: boolean;
+  /** Render Manage as the solid CTA button (Edit Project) rather than the home
+   * shelf's plain text link. Both open the same Manage modal. */
+  solidManageButton?: boolean;
+  /** Extra classes for the outer box (e.g. `tw-grow` to fill the home shelf floor). */
+  className?: string;
+  /** Render the two-line helper description above the box. On (Edit project) so
+   * the modal keeps the old sub-cards' guidance; off on the compact home tab,
+   * whose height is tuned to match its sibling tabs and shouldn't grow. */
+  showHelperText?: boolean;
+}
+
+const FILE_CHIP_CONFIG = {
+  folder: { Icon: Folder, colorClass: "tw-text-context-manager-yellow" },
+  tag: { Icon: Tag, colorClass: "tw-text-context-manager-orange" },
+  note: { Icon: FileText, colorClass: "tw-text-context-manager-blue" },
+  extension: { Icon: Hash, colorClass: "tw-text-context-manager-green" },
+} as const;
+
+/**
+ * The shared, controlled mixed file+URL context editor (design H / E). Renders
+ * inclusions (folder/tag/file/extension via {@link buildBadgeItems}) and URLs
+ * (via {@link parseProjectUrls}) as one wrapped {@link ContextChip} flow that
+ * fills the box and scrolls internally when it overflows, then a footer pinned at
+ * the box floor (drag hint · +URL · Manage). Pure / controlled: deletes and the
+ * +URL action go out through `onChange` as
+ * context-source patches, so the home placement can persist immediately while
+ * the Edit modal keeps them in a draft.
+ *
+ * Reuses the pattern pure-functions from ProjectContextBadgeList but NOT its
+ * pill rendering — the design's chips are square bordered tiles, and that
+ * component is shared with the legacy CAG modal whose look must not change.
+ */
+export function ProjectContextSourceEditor({
+  contextSource,
+  onChange,
+  onManage,
+  popoverContainer,
+  isDragging,
+  droppable = true,
+  solidManageButton = false,
+  className,
+  showHelperText = false,
+}: ProjectContextSourceEditorProps) {
+  const inclusions = contextSource?.inclusions;
+  const exclusions = contextSource?.exclusions;
+
+  const fileItems = useMemo(() => buildBadgeItems(inclusions), [inclusions]);
+  const exclusionItems = useMemo(() => buildBadgeItems(exclusions), [exclusions]);
+  const urlItems = useMemo(
+    () => parseProjectUrls(contextSource?.webUrls ?? "", contextSource?.youtubeUrls ?? ""),
+    [contextSource?.webUrls, contextSource?.youtubeUrls]
+  );
+
+  const totalCount = fileItems.length + urlItems.length + exclusionItems.length;
+  const isEmpty = totalCount === 0;
+
+  const handleRemoveFile = (pattern: string, type: (typeof fileItems)[number]["type"]) => {
+    onChange({ inclusions: removePattern(inclusions, pattern, type) });
+  };
+
+  const handleRemoveExclusion = (
+    pattern: string,
+    type: (typeof exclusionItems)[number]["type"]
+  ) => {
+    onChange({ exclusions: removePattern(exclusions, pattern, type) });
+  };
+
+  const handleRemoveUrl = (id: string) => {
+    const remaining: UrlItem[] = urlItems.filter((u) => u.id !== id);
+    const { webUrls, youtubeUrls } = serializeProjectUrls(remaining);
+    onChange({ webUrls, youtubeUrls });
+  };
+
+  const handleAddUrls = (added: UrlItem[]) => {
+    const { webUrls, youtubeUrls } = serializeProjectUrls([...urlItems, ...added]);
+    onChange({ webUrls, youtubeUrls });
+  };
+
+  // The chip flow fills the box and scrolls internally when it overflows; the box's
+  // own min/max-height (see the wrapper below) bounds it so the footer stays pinned
+  // at the box floor and a long context never grows the surrounding tab.
+  const [overflowing, setOverflowing] = useState(false);
+  // Whether the scroll container is at its bottom — drives the fade so "there's more
+  // below" stays signalled until you've scrolled to the end.
+  const [scrollAtBottom, setScrollAtBottom] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const check = () => {
+      setOverflowing(el.scrollHeight > el.clientHeight + 1);
+      setScrollAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < 2);
+    };
+    check();
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [fileItems, urlItems, exclusionItems]);
+
+  const showBottomFade = overflowing && !scrollAtBottom;
+
+  const chips = (
+    <>
+      {fileItems.map((item) => {
+        const { Icon, colorClass } = FILE_CHIP_CONFIG[item.type];
+        return (
+          <ContextChip
+            key={`file:${item.type}:${item.pattern}`}
+            icon={<Icon className="tw-size-3.5" />}
+            colorClass={colorClass}
+            label={item.pattern}
+            onRemove={() => handleRemoveFile(item.pattern, item.type)}
+          />
+        );
+      })}
+      {urlItems.map((item) => (
+        <ContextChip
+          key={item.id}
+          // UrlTypeIcon owns both glyph and color (the single source of truth for
+          // web=cyan / youtube=red), so the chip wrapper carries no colorClass.
+          icon={<UrlTypeIcon type={item.type} className="tw-size-3.5" />}
+          colorClass=""
+          label={item.url.replace(/^https?:\/\//, "")}
+          tooltip={item.url}
+          onRemove={() => handleRemoveUrl(item.id)}
+        />
+      ))}
+    </>
+  );
+
+  // Excluded patterns render dim, after a dashed separator + "Excluded:" label —
+  // mirroring the legacy ProjectContextBadgeList so the two read consistently.
+  const exclusionChips = exclusionItems.map((item) => {
+    const { Icon, colorClass } = FILE_CHIP_CONFIG[item.type];
+    return (
+      <ContextChip
+        key={`ex:${item.type}:${item.pattern}`}
+        icon={<Icon className="tw-size-3.5" />}
+        colorClass={colorClass}
+        label={item.pattern}
+        dim
+        onRemove={() => handleRemoveExclusion(item.pattern, item.type)}
+      />
+    );
+  });
+
+  const editorBox = (
+    <div
+      className={cn(
+        // min/max keep the box ≈ one shelf-tab tall (the home Recent Chats / project
+        // tabs land near the `SHELF_BODY_FLOOR_CLASS` floor at ~200px), so the
+        // Context tab matches its siblings instead of growing with the chip count;
+        // a long context scrolls inside the box. The caller's `tw-grow` fills up to
+        // this cap.
+        "tw-flex tw-max-h-60 tw-min-h-[200px] tw-flex-col tw-rounded-xl tw-border tw-p-3 tw-transition-colors",
+        isDragging
+          ? "tw-border-solid tw-border-interactive-accent"
+          : "tw-border-dashed tw-border-border",
+        className
+      )}
+    >
+      {/* Content region — flex-1 pushes the footer to the box floor in every state
+          (empty / sparse / full). The box's height bound comes from the caller.
+          tw-relative anchors the drag scrim below. */}
+      <div className="tw-relative tw-flex tw-min-h-0 tw-flex-1 tw-flex-col">
+        {isEmpty ? (
+          <div className="tw-flex tw-flex-1 tw-flex-col tw-items-center tw-justify-center tw-gap-1 tw-py-8 tw-text-center">
+            <Inbox
+              className={cn("tw-mb-1 tw-size-6", isDragging ? "tw-text-accent" : "tw-text-muted")}
+            />
+            <div
+              className={cn(
+                "tw-text-sm",
+                isDragging ? "tw-font-medium tw-text-accent" : "tw-text-normal"
+              )}
+            >
+              {droppable
+                ? isDragging
+                  ? "Drop to add to context"
+                  : "Drag files / folders here"
+                : "No context yet"}
+            </div>
+            <div className="tw-text-xs tw-text-muted">
+              {droppable ? "or use Manage to add inclusion / tag / URL" : "Add via + URL or Manage"}
+            </div>
+          </div>
+        ) : (
+          <div className="tw-relative tw-flex tw-min-h-0 tw-flex-1 tw-flex-col">
+            <div
+              ref={scrollRef}
+              onScroll={(e) => {
+                const el = e.currentTarget;
+                setScrollAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < 2);
+              }}
+              className="tw-min-h-0 tw-flex-1 tw-overflow-y-auto"
+            >
+              <div className="tw-flex tw-flex-wrap tw-gap-2">{chips}</div>
+              {exclusionItems.length > 0 && (
+                <>
+                  {(fileItems.length > 0 || urlItems.length > 0) && (
+                    <div className="tw-my-2 tw-border-t tw-border-dashed tw-border-border" />
+                  )}
+                  <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
+                    <span className="tw-mr-1 tw-text-xs tw-font-medium tw-text-muted">
+                      Excluded:
+                    </span>
+                    {exclusionChips}
+                  </div>
+                </>
+              )}
+            </div>
+            {showBottomFade && (
+              <div className="copilot-fade-mask-bottom tw-pointer-events-none tw-absolute tw-inset-x-0 tw-bottom-0 tw-h-8 tw-rounded-b-md" />
+            )}
+          </div>
+        )}
+        {/* Drag scrim: dims the populated chips in place (no layout jump) and
+            floats the drop prompt over them. As the content region's LAST
+            positioned child it paints above the chips with no z-index (matching
+            the legacy dropzone). pointer-events-none so the drag keeps hitting
+            the droppable box underneath; the empty state has its OWN "Drop"
+            affordance, so the scrim only covers a non-empty chip flow. */}
+        {droppable && !isEmpty && (
+          <div
+            aria-hidden={!isDragging}
+            className={cn(
+              "tw-pointer-events-none tw-absolute tw-inset-0 tw-flex tw-flex-col tw-items-center tw-justify-center tw-gap-1 tw-rounded-md tw-transition-opacity tw-duration-150 motion-reduce:tw-transition-none",
+              isDragging ? "tw-opacity-100" : "tw-opacity-0"
+            )}
+          >
+            {/* Two stacked fills: a translucent primary layer dims the chips, an
+                interactive-accent tint signals "active target". */}
+            <div className="tw-absolute tw-inset-0 tw-rounded-md tw-bg-primary tw-opacity-80" />
+            <div className="tw-absolute tw-inset-0 tw-rounded-md tw-bg-interactive-accent/10" />
+            <Inbox className="tw-relative tw-size-5 tw-text-accent" />
+            <div className="tw-relative tw-text-sm tw-font-medium tw-text-accent">
+              Drop to add to context
+            </div>
+            <div className="tw-relative tw-text-xs tw-text-muted">Added as an inclusion</div>
+          </div>
+        )}
+      </div>
+
+      {/* Footer (design `.ctxfoot`): left = drag hint + URL, right = Manage. Same
+          shape in every state so the box reads consistently empty or full. */}
+      <div className="tw-mt-3 tw-flex tw-flex-wrap tw-items-center tw-gap-3 tw-text-xs tw-text-faint">
+        <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-3">
+          {droppable ? (
+            <div
+              className={cn(
+                "tw-flex tw-min-w-0 tw-items-center tw-gap-1.5",
+                isDragging && "tw-font-medium tw-text-accent"
+              )}
+            >
+              <Inbox className="tw-size-3.5 tw-shrink-0" />
+              <span className="tw-truncate">
+                {isDragging ? "Drop to add to context" : "Drag files / folders here"}
+              </span>
+            </div>
+          ) : (
+            <span className="tw-truncate">Add a web / YouTube link</span>
+          )}
+          <AddUrlPopover
+            existingUrls={urlItems.map((u) => u.url)}
+            onAdd={handleAddUrls}
+            container={popoverContainer}
+          />
+        </div>
+        <div className="tw-ml-auto tw-flex tw-shrink-0 tw-items-center">
+          {solidManageButton ? (
+            <Button size="sm" className="tw-gap-1.5" onClick={onManage}>
+              <Settings className="tw-size-3.5" />
+              Manage Context
+            </Button>
+          ) : (
+            <Button
+              variant="ghost2"
+              size="sm"
+              className="tw-h-auto tw-gap-1.5 tw-px-0 tw-text-muted hover:tw-text-normal"
+              onClick={onManage}
+            >
+              <Settings className="tw-size-3.5" />
+              Manage
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (!showHelperText) return editorBox;
+  // Edit project: restore the old split sub-cards' guidance above the unified box.
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-2">
+      <div className="tw-text-sm tw-text-muted">
+        Define patterns to include specific files, folders or tags in the project context. You can
+        also add web pages or YouTube videos.
+      </div>
+      {editorBox}
+    </div>
+  );
+}

--- a/src/components/project/UrlInputRow.tsx
+++ b/src/components/project/UrlInputRow.tsx
@@ -1,0 +1,107 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { resolveInputUrls } from "@/utils/urlTagUtils";
+import { Clipboard, Plus } from "lucide-react";
+import * as React from "react";
+import { useState } from "react";
+
+interface UrlInputRowProps {
+  /**
+   * Receives the raw text the user submitted — by typing + Add/Enter, by the
+   * clipboard Paste button, or by pasting URLs into the field. The caller parses
+   * it and decides what "submit" means (stage to a pending list, add immediately).
+   */
+  onSubmit: (text: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+}
+
+/**
+ * The shared URL entry row (design ⑤): an {@link Input} plus ONE two-state button
+ * — empty → Paste (reads the clipboard), non-empty → Add (Enter does the same).
+ * A paste that contains URLs routes straight through `onSubmit` rather than
+ * landing in the field. Owns only its own draft text; everything past submit
+ * (parsing, dedup, staging vs immediate-add, the resulting list) is the caller's,
+ * so the +URL popover and the Manage Links panel share one input affordance
+ * without sharing their different list presentations.
+ */
+export function UrlInputRow({
+  onSubmit,
+  placeholder = "Enter a URL…",
+  autoFocus,
+}: UrlInputRowProps) {
+  const [value, setValue] = useState("");
+  const hasValue = value.trim().length > 0;
+
+  const submitText = (text: string) => {
+    onSubmit(text);
+    setValue("");
+  };
+
+  // Two-state action: type present → submit it; empty → import the clipboard.
+  const handleAction = async () => {
+    if (hasValue) {
+      submitText(value);
+      return;
+    }
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) submitText(text);
+    } catch {
+      // Clipboard unavailable / denied — typing still works.
+    }
+  };
+
+  // A paste that yields URLs is submitted directly (auto-split); other text
+  // (e.g. a fragment the user wants to finish typing) pastes into the field.
+  // Exception: a SINGLE URL pasted while the field already holds a draft lands in
+  // the input (browser default) instead of submitting — so it doesn't yank the
+  // URL away and wipe what the user was typing. An empty field or a multi-URL
+  // batch still routes straight through `onSubmit`.
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const text = e.clipboardData.getData("text");
+    const parsed = resolveInputUrls(text);
+    if (parsed.length === 0) return;
+    if (parsed.length === 1 && hasValue) return;
+    e.preventDefault();
+    submitText(text);
+  };
+
+  return (
+    <div className="tw-flex tw-gap-2">
+      <Input
+        autoFocus={autoFocus}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onPaste={handlePaste}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && hasValue) {
+            e.preventDefault();
+            void handleAction();
+          }
+        }}
+        placeholder={placeholder}
+        className="tw-min-w-0 tw-flex-1"
+      />
+      <Button
+        variant={hasValue ? "default" : "ghost2"}
+        size="sm"
+        className={cn(
+          // tw-h-9 (not size sm's h-6) keeps the button the same height as Input.
+          "tw-h-9 tw-shrink-0 tw-gap-1.5 tw-whitespace-nowrap tw-rounded-md tw-px-3 tw-font-semibold",
+          // No outline variant exists; force a plain-bg neutral outline over ghost2
+          // for the empty (Paste) state — `!` beats both ghost2's transparent bg
+          // and Obsidian's native button chrome.
+          !hasValue &&
+            "!tw-border !tw-border-solid !tw-border-border !tw-bg-primary !tw-text-muted !tw-shadow-none hover:!tw-bg-interactive-hover hover:!tw-text-normal"
+        )}
+        title={hasValue ? "Add to list" : "Paste from clipboard"}
+        onClick={() => void handleAction()}
+      >
+        {hasValue ? <Plus className="tw-size-3.5" /> : <Clipboard className="tw-size-3.5" />}
+        {hasValue ? "Add" : "Paste"}
+      </Button>
+    </div>
+  );
+}

--- a/src/components/project/UrlTypeIcon.tsx
+++ b/src/components/project/UrlTypeIcon.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/lib/utils";
+import type { UrlKind } from "@/utils/urlTagUtils";
+import { Globe, Youtube } from "lucide-react";
+import * as React from "react";
+
+/**
+ * Canonical glyph + theme color for a context URL's type, shared across every
+ * URL surface (the +URL popover, the Manage Links panel, the context chips) so
+ * they can't drift apart: web → cyan globe, YouTube → red play.
+ */
+export function UrlTypeIcon({ type, className }: { type: UrlKind; className?: string }) {
+  return type === "youtube" ? (
+    <Youtube className={cn("tw-text-error", className)} />
+  ) : (
+    <Globe className={cn("tw-text-context-manager-cyan", className)} />
+  );
+}

--- a/src/components/project/agentProcessingAdapter.test.ts
+++ b/src/components/project/agentProcessingAdapter.test.ts
@@ -1,0 +1,387 @@
+import type { AgentProjectContextLoadState } from "@/aiParams";
+import {
+  aggregateAgentCacheDirState,
+  buildAgentProcessingItems,
+  type AgentCacheDirReader,
+  type AgentCacheDirState,
+  type AgentProcessingSource,
+} from "@/components/project/agentProcessingAdapter";
+import {
+  CACHE_SCHEMA_VERSION,
+  cacheFileName,
+  failureMarkerName,
+} from "@/context/contextCacheStore";
+
+const URL_A = "https://a.example.com/page";
+const PDF = "docs/spec.pdf";
+
+const webSource: AgentProcessingSource = { kind: "web", source: URL_A };
+const fileSource: AgentProcessingSource = { kind: "file", source: PDF, fingerprint: "100:5" };
+
+function entry(over: Partial<AgentProjectContextLoadState> = {}): AgentProjectContextLoadState {
+  return { phase: "done", blocking: false, ...over };
+}
+
+function disk(over: Partial<AgentCacheDirState> = {}): AgentCacheDirState {
+  return {
+    snapshotNames: new Set(),
+    markersByName: new Map(),
+    fingerprintsByName: new Map(),
+    ...over,
+  };
+}
+
+const SAVED_ALL = new Set([`web:${URL_A}`, `file:${PDF}`]);
+
+describe("buildAgentProcessingItems", () => {
+  it("is Queued with no live entry, no disk state", () => {
+    const items = buildAgentProcessingItems(
+      [webSource, fileSource],
+      undefined,
+      undefined,
+      SAVED_ALL
+    );
+    expect(items.map((i) => i.status)).toEqual(["pending", "pending"]);
+  });
+
+  it("is Converted when the disk snapshot exists", () => {
+    const d = disk({ snapshotNames: new Set([cacheFileName("web", URL_A)]) });
+    const [web] = buildAgentProcessingItems([webSource], undefined, d, SAVED_ALL);
+    expect(web.status).toBe("ready");
+  });
+
+  it("downgrades a file snapshot to Queued when the file changed since conversion", () => {
+    const name = cacheFileName("file", PDF);
+    const d = disk({
+      snapshotNames: new Set([name]),
+      fingerprintsByName: new Map([[name, "100:5"]]),
+    });
+    const fresh = buildAgentProcessingItems([fileSource], undefined, d, SAVED_ALL)[0];
+    expect(fresh.status).toBe("ready");
+
+    const changed = buildAgentProcessingItems(
+      [{ ...fileSource, fingerprint: "200:9" }],
+      undefined,
+      d,
+      SAVED_ALL
+    )[0];
+    expect(changed.status).toBe("pending");
+  });
+
+  it("keeps a file snapshot Queued when its fingerprint is unknown (unreadable/old meta)", () => {
+    // Snapshot file present but no stored fingerprint → can't prove it's current.
+    const d = disk({ snapshotNames: new Set([cacheFileName("file", PDF)]) });
+    const [file] = buildAgentProcessingItems([fileSource], undefined, d, SAVED_ALL);
+    expect(file.status).toBe("pending");
+  });
+
+  it("is Failed with the persisted error when a disk failure marker exists", () => {
+    const d = disk({
+      markersByName: new Map([
+        [
+          failureMarkerName("web", URL_A),
+          { schemaVersion: CACHE_SCHEMA_VERSION, source: URL_A, kind: "web" as const, error: "fetch 404", failedAt: 1 }, // prettier-ignore
+        ],
+      ]),
+    });
+    const [web] = buildAgentProcessingItems([webSource], undefined, d, SAVED_ALL);
+    expect(web.status).toBe("failed");
+    expect(web.error).toBe("fetch 404");
+  });
+
+  it("prefers a live missing failure over a stale disk snapshot", () => {
+    const d = disk({ snapshotNames: new Set([cacheFileName("web", URL_A)]) });
+    const live = entry({
+      failedSources: [{ path: URL_A, type: "web", error: "boom", usedStaleSnapshot: false }],
+    });
+    const [web] = buildAgentProcessingItems([webSource], live, d, SAVED_ALL);
+    expect(web.status).toBe("failed");
+    expect(web.error).toBe("boom");
+  });
+
+  it("treats a live stale-but-usable failure as Converted even without disk state", () => {
+    const live = entry({
+      failedSources: [{ path: URL_A, type: "web", error: "net down", usedStaleSnapshot: true }],
+    });
+    const [web] = buildAgentProcessingItems([webSource], live, undefined, SAVED_ALL);
+    expect(web.status).toBe("ready");
+  });
+
+  it("matches live nonMd failures to file sources", () => {
+    const live = entry({
+      failedSources: [{ path: PDF, type: "nonMd", error: "parse", usedStaleSnapshot: false }],
+    });
+    const [file] = buildAgentProcessingItems([fileSource], live, undefined, SAVED_ALL);
+    expect(file.status).toBe("failed");
+  });
+
+  it("shows in-flight sources (processingSources) as Converting and queues the rest", () => {
+    // Mid-run: the URL is actively fetching (in processingSources) → processing;
+    // the file hasn't started yet → Queued. Both are saved.
+    const live = entry({
+      phase: "prefetch",
+      prefetch: { done: 0, total: 2 },
+      processingSources: [{ kind: "web", source: URL_A }],
+    });
+    const [web, file] = buildAgentProcessingItems([webSource, fileSource], live, disk(), SAVED_ALL);
+    expect(web.status).toBe("processing");
+    expect(file.status).toBe("pending"); // queued: hasn't started this run
+  });
+
+  it("never shows an unsaved draft as processing, even when a run is in flight", () => {
+    const live = entry({ phase: "prefetch", prefetch: { done: 0, total: 1 } });
+    const savedOnlyFile = new Set([`file:${PDF}`]);
+    const [web] = buildAgentProcessingItems([webSource], live, disk(), savedOnlyFile);
+    expect(web.status).toBe("pending"); // draft-only URL: no run knows about it
+  });
+
+  it("shows all parallel-fetched URLs as Converting together", () => {
+    // URLs fetch in parallel, so processingSources holds them all at once.
+    const URL_B = "https://b.example.com/x";
+    const live = entry({
+      phase: "prefetch",
+      prefetch: { done: 0, total: 2 },
+      processingSources: [
+        { kind: "web", source: URL_A },
+        { kind: "web", source: URL_B },
+      ],
+    });
+    const items = buildAgentProcessingItems(
+      [webSource, { kind: "web", source: URL_B }],
+      live,
+      disk(),
+      new Set([`web:${URL_A}`, `web:${URL_B}`])
+    );
+    expect(items.map((i) => i.status)).toEqual(["processing", "processing"]);
+  });
+
+  it("shows a saved failure marker as Failed during a run (Option D skips it), Converting only when retried", () => {
+    // Option D cheap-skips a known-bad source on the automatic run, so a valid
+    // marker reads as failed even mid-run — never Queued (nothing re-fetches it
+    // until a manual Retry). It flips to Converting only when the user forces a
+    // retry and the source enters processingSources.
+    const d = disk({
+      markersByName: new Map([
+        [
+          failureMarkerName("web", URL_A),
+          { schemaVersion: CACHE_SCHEMA_VERSION, source: URL_A, kind: "web" as const, error: "fetch 404", failedAt: 1 }, // prettier-ignore
+        ],
+      ]),
+    });
+    const duringRun = entry({ phase: "prefetch", prefetch: { done: 0, total: 1 } });
+    const [failed] = buildAgentProcessingItems([webSource], duringRun, d, SAVED_ALL);
+    expect(failed.status).toBe("failed");
+    expect(failed.error).toBe("fetch 404");
+
+    const active = entry({
+      phase: "prefetch",
+      prefetch: { done: 0, total: 1 },
+      processingSources: [{ kind: "web", source: URL_A }],
+    });
+    const [web] = buildAgentProcessingItems([webSource], active, d, SAVED_ALL);
+    expect(web.status).toBe("processing");
+    expect(web.error).toBeUndefined();
+
+    // The per-row "Retry" path drives `retryingSources` (not processingSources);
+    // it too must override the marker so the row spins immediately on click.
+    const retrying = entry({ phase: "done", retryingSources: [{ kind: "web", source: URL_A }] });
+    expect(buildAgentProcessingItems([webSource], retrying, d, SAVED_ALL)[0].status).toBe("processing"); // prettier-ignore
+  });
+
+  it("honors a file failure marker only while its fingerprint matches (changed/legacy → re-attempt)", () => {
+    const markerName = failureMarkerName("file", PDF);
+    const withMarker = (fingerprint?: string) =>
+      disk({
+        markersByName: new Map([
+          [
+            markerName,
+            {
+              schemaVersion: CACHE_SCHEMA_VERSION,
+              source: PDF,
+              kind: "file" as const,
+              error: "parse boom",
+              failedAt: 1,
+              ...(fingerprint !== undefined ? { fingerprint } : {}),
+            },
+          ],
+        ]),
+      });
+    const duringRun = entry({ phase: "parse", parsed: { done: 0, total: 1 } });
+
+    // fileSource's live fingerprint is "100:5".
+    // Marker fingerprint matches → cheap-skipped → failed, even mid-run.
+    const matched = buildAgentProcessingItems([fileSource], duringRun, withMarker("100:5"), SAVED_ALL)[0]; // prettier-ignore
+    expect(matched.status).toBe("failed");
+    expect(matched.error).toBe("parse boom");
+
+    // File changed since the failure (fingerprint mismatch) → marker not honored,
+    // the run re-attempts it → Queued, not a stale failure.
+    expect(buildAgentProcessingItems([fileSource], duringRun, withMarker("999:9"), SAVED_ALL)[0].status).toBe("pending"); // prettier-ignore
+
+    // Legacy marker without a fingerprint → untrustworthy → re-attempted, not failed.
+    expect(buildAgentProcessingItems([fileSource], duringRun, withMarker(undefined), SAVED_ALL)[0].status).toBe("pending"); // prettier-ignore
+  });
+
+  it("shows a stale file snapshot as Converting only while it's in processingSources", () => {
+    const name = cacheFileName("file", PDF);
+    const d = disk({
+      snapshotNames: new Set([name]),
+      fingerprintsByName: new Map([[name, "100:5"]]),
+    });
+    const changed = { ...fileSource, fingerprint: "200:9" };
+    // Run active, file not yet re-parsed → Queued.
+    const queued = entry({ phase: "parse", parsed: { done: 0, total: 1 } });
+    expect(buildAgentProcessingItems([changed], queued, d, SAVED_ALL)[0].status).toBe("pending");
+    // Being re-parsed → processing.
+    const active = entry({
+      phase: "parse",
+      parsed: { done: 0, total: 1 },
+      processingSources: [{ kind: "file", source: PDF }],
+    });
+    expect(buildAgentProcessingItems([changed], active, d, SAVED_ALL)[0].status).toBe("processing");
+  });
+
+  it("distinguishes a same-URL web and youtube pair by cacheKind (matches the CAG id contract)", () => {
+    // `id` is the raw URL (CAG parity → clean display + remove-by-(cacheKind,url)).
+    // The two rows are still distinct items; cacheKind is what tells them apart.
+    const dual: AgentProcessingSource[] = [
+      { kind: "web", source: URL_A },
+      { kind: "youtube", source: URL_A },
+    ];
+    const items = buildAgentProcessingItems(dual, undefined, undefined, new Set());
+    expect(items.map((i) => i.id)).toEqual([URL_A, URL_A]);
+    expect(items[0].cacheKind).toBe("web");
+    expect(items[1].cacheKind).toBe("youtube");
+  });
+
+  it("maps kinds onto the panel's source/fileType model", () => {
+    const items = buildAgentProcessingItems(
+      [webSource, fileSource],
+      undefined,
+      undefined,
+      SAVED_ALL
+    );
+    expect(items[0]).toMatchObject({ source: "url", fileType: "web", cacheKind: "web" });
+    expect(items[1]).toMatchObject({ source: "file", fileType: "pdf", cacheKind: "file" });
+  });
+});
+
+/** In-memory {@link AgentCacheDirReader} over a name→content map (missing → throws). */
+function fakeReader(files: Record<string, string>): AgentCacheDirReader {
+  return {
+    list: async () => Object.keys(files),
+    readText: async (name) => {
+      if (!(name in files)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return files[name];
+    },
+  };
+}
+
+/** A throwing reader, modeling a missing/unreadable directory. */
+const throwingReader: AgentCacheDirReader = {
+  list: async () => {
+    throw new Error("ENOENT: no such directory");
+  },
+  readText: async () => {
+    throw new Error("ENOENT");
+  },
+};
+
+/** A valid snapshot file body with the leading meta block parseSnapshotMeta reads. */
+function snapshotBody(over: {
+  sourceType: string;
+  fingerprint: string;
+  sourcePath?: string;
+}): string {
+  const meta = {
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    sourceType: over.sourceType,
+    ...(over.sourcePath ? { sourcePath: over.sourcePath } : { sourceUrl: "https://x" }),
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+    fingerprint: over.fingerprint,
+  };
+  return `<!-- copilot-context-cache\n${JSON.stringify(meta)}\n-->\n\nbody\n`;
+}
+
+function markerBody(source: string, kind: string, error: string, fingerprint?: string): string {
+  return JSON.stringify({
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    source,
+    kind,
+    error,
+    failedAt: 1,
+    ...(fingerprint !== undefined ? { fingerprint } : {}),
+  });
+}
+
+describe("aggregateAgentCacheDirState (off-vault dual-source)", () => {
+  const webName = cacheFileName("web", URL_A);
+  const fileName = cacheFileName("file", PDF);
+  const fileMarker = failureMarkerName("file", PDF);
+
+  it("unions snapshots from remotes + files and reads markers from the marker dir", async () => {
+    const state = await aggregateAgentCacheDirState(
+      {
+        remotes: fakeReader({
+          [webName]: snapshotBody({ sourceType: "web", fingerprint: "web:x" }),
+        }),
+        files: fakeReader({
+          [fileName]: snapshotBody({ sourceType: "file", sourcePath: PDF, fingerprint: "100:5" }),
+        }),
+        markers: fakeReader({ [fileMarker]: markerBody(PDF, "file", "parse boom", "100:5") }),
+      },
+      new Set([fileName])
+    );
+
+    // Snapshots come from BOTH buckets.
+    expect(state.snapshotNames.has(webName)).toBe(true);
+    expect(state.snapshotNames.has(fileName)).toBe(true);
+    // File fingerprint read only for the requested name.
+    expect(state.fingerprintsByName.get(fileName)).toBe("100:5");
+    // Marker parsed from the per-project marker dir.
+    expect(state.markersByName.get(fileMarker)?.error).toBe("parse boom");
+  });
+
+  it("does not read remote snapshot bodies (identity-fingerprinted)", async () => {
+    let remoteReads = 0;
+    const remotes: AgentCacheDirReader = {
+      list: async () => [webName],
+      readText: async () => {
+        remoteReads++;
+        return snapshotBody({ sourceType: "web", fingerprint: "web:x" });
+      },
+    };
+    const state = await aggregateAgentCacheDirState(
+      { remotes, files: fakeReader({}), markers: fakeReader({}) },
+      // Even if the URL snapshot name is "requested", remotes are never body-read.
+      new Set([webName])
+    );
+    expect(state.snapshotNames.has(webName)).toBe(true);
+    expect(remoteReads).toBe(0);
+  });
+
+  it("degrades to empty sets when a directory is missing/unreadable", async () => {
+    const state = await aggregateAgentCacheDirState(
+      { remotes: throwingReader, files: throwingReader, markers: throwingReader },
+      new Set()
+    );
+    expect(state.snapshotNames.size).toBe(0);
+    expect(state.markersByName.size).toBe(0);
+    expect(state.fingerprintsByName.size).toBe(0);
+  });
+
+  it("skips unparseable marker bodies and non-marker files in the marker dir", async () => {
+    const state = await aggregateAgentCacheDirState(
+      {
+        remotes: fakeReader({}),
+        files: fakeReader({}),
+        markers: fakeReader({
+          [fileMarker]: "{not json", // malformed → skipped
+          "stray.txt": "ignored", // not a failed-*.json → skipped
+        }),
+      },
+      new Set()
+    );
+    expect(state.markersByName.size).toBe(0);
+  });
+});

--- a/src/components/project/agentProcessingAdapter.ts
+++ b/src/components/project/agentProcessingAdapter.ts
@@ -38,6 +38,8 @@ import {
   type FailureMarker,
   type MaterializedSourceType,
 } from "@/context/contextCacheStore";
+import type { UrlItem } from "@/utils/urlTagUtils";
+import type { TFile } from "obsidian";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import type { App } from "obsidian";
 
@@ -48,6 +50,31 @@ export interface AgentProcessingSource {
   source: string;
   /** Live `mtime:size` for files — stale-snapshot detection. Unset for URLs. */
   fingerprint?: string;
+}
+
+/**
+ * Build the agent pipeline's configured-source list from already-resolved URL
+ * items and file candidates: URL sources first (no fingerprint), then file
+ * sources stamped with their live `mtime:size` fingerprint for stale-snapshot
+ * detection. Callers pass their own candidate set (draft vs saved context) so
+ * this stays a pure shape-builder — the single place the `AgentProcessingSource`
+ * shape is constructed, shared by the processing-items and persistent-failure
+ * read-models so the two can't drift.
+ */
+export function buildAgentProcessingSources(
+  urls: readonly UrlItem[],
+  fileCandidates: readonly TFile[]
+): AgentProcessingSource[] {
+  return [
+    ...urls.map((u): AgentProcessingSource => ({ kind: u.type, source: u.url })),
+    ...fileCandidates.map(
+      (f): AgentProcessingSource => ({
+        kind: "file",
+        source: f.path,
+        fingerprint: `${f.stat.mtime}:${f.stat.size}`,
+      })
+    ),
+  ];
 }
 
 /** Read-only view of the agent's off-vault conversion cache, keyed by file name. */
@@ -285,8 +312,7 @@ export function buildAgentProcessingItems(
       // do NOT keep a 4th live `succeededSources` set to erase it: that would
       // duplicate the whole processingSources machinery (atom field + publish +
       // clear + tests) to smooth a cosmetic blip that never touches the cache,
-      // the send gate, or captured session context. If a future review flags
-      // this again, point them at this note.
+      // the send gate, or captured session context.
       status = "pending";
     }
 

--- a/src/components/project/agentProcessingAdapter.ts
+++ b/src/components/project/agentProcessingAdapter.ts
@@ -1,0 +1,303 @@
+/**
+ * Adapter that synthesizes the agent pipeline's three data sources — the live
+ * `agentProjectContextLoadAtom` entry, the off-vault conversion-cache snapshots /
+ * failure markers, and the (possibly unsaved) form draft — into the
+ * ProcessingItem[] model rendered by the ProcessingStatus panel.
+ *
+ * Per-item status priority (highest first), mirroring the legacy CAG tracker's
+ * `processing > failed > success > queued` set membership (with the agent's disk
+ * snapshots/markers as the persistent success/failure truth between runs):
+ *  1. source being (re-)fetched right now — per-row Retry OR the full run's live
+ *     `processingSources` set → processing
+ *  2. live failure settled THIS run (missing → failed; stale → ready)
+ *  3. fresh disk snapshot present → Converted (for files, only when the stored
+ *     `mtime:size` fingerprint still matches — a changed file falls through)
+ *  4. valid disk failure marker → failed. Under Option D the next automatic run
+ *     cheap-skips a known-bad source (no re-fetch until a manual Retry), so it
+ *     reads as failed even mid-run, never "Queued". A file marker is honored only
+ *     while its fingerprint still matches the live file (a changed file falls
+ *     through to be re-attempted).
+ *  5. a run is in flight and the source has no valid marker and hasn't
+ *     started/settled yet → Queued (pending) — a genuinely new/changed source.
+ *  6. otherwise → pending (Queued: the next materialization handles it)
+ *
+ * The live atom drives processing/failed; ready/queued otherwise come from disk.
+ */
+
+import type { AgentProjectContextLoadState, FailedItem } from "@/aiParams";
+import { EMPTY_PROCESSING_SOURCES, EMPTY_RETRYING_SOURCES } from "@/aiParams";
+import {
+  processingItemEnvelope,
+  type ProcessingItem,
+} from "@/components/project/processingAdapter";
+import {
+  cacheFileName,
+  failureMarkerName,
+  parseFailureMarker,
+  parseSnapshotMeta,
+  type FailureMarker,
+  type MaterializedSourceType,
+} from "@/context/contextCacheStore";
+import { isDesktopRuntime } from "@/utils/desktopRuntime";
+import type { App } from "obsidian";
+
+/** One configured source the agent pipeline would materialize. */
+export interface AgentProcessingSource {
+  kind: MaterializedSourceType;
+  /** URL (web/youtube) or vault path (file). */
+  source: string;
+  /** Live `mtime:size` for files — stale-snapshot detection. Unset for URLs. */
+  fingerprint?: string;
+}
+
+/** Read-only view of the agent's off-vault conversion cache, keyed by file name. */
+export interface AgentCacheDirState {
+  snapshotNames: Set<string>;
+  markersByName: Map<string, FailureMarker>;
+  /** Stored fingerprints of file-kind snapshots (only those we were asked to read). */
+  fingerprintsByName: Map<string, string>;
+}
+
+/**
+ * Minimal read surface over ONE off-vault cache directory (the reader is rooted
+ * there, so names are basenames). Kept as an injectable interface so the pure
+ * {@link aggregateAgentCacheDirState} is unit-testable with an in-memory fake —
+ * the node:fs wiring lives only behind the desktop boundary in
+ * {@link readAgentCacheDirState}.
+ */
+export interface AgentCacheDirReader {
+  /** Entry basenames in the directory; resolves to `[]` when the dir is missing. */
+  list(): Promise<string[]>;
+  /** UTF-8 text of an entry by basename; rejects when missing/unreadable. */
+  readText(name: string): Promise<string>;
+}
+
+/**
+ * Aggregate the agent's cache status from its THREE off-vault sources: shared
+ * remote snapshots (`remotes/`), shared file snapshots (`files/`), and this
+ * project's failure markers (`markers/<projectHash>/`). Snapshots are shared
+ * vault-wide (keyed by source identity), markers are per-project — so a status
+ * read fans across both. Reads a snapshot's stored `mtime:size` only for the
+ * file names in `fileSnapshotNames` (URL snapshots are identity-fingerprinted —
+ * the name alone proves freshness, so their bodies are never read). Every
+ * directory/file read is tolerant: a missing dir lists empty, an unreadable file
+ * is skipped — a project that never materialized simply yields empty sets.
+ *
+ * Pure (fs injected) so it unit-tests without node:fs; the desktop wiring is in
+ * {@link readAgentCacheDirState}.
+ */
+export async function aggregateAgentCacheDirState(
+  readers: {
+    remotes: AgentCacheDirReader;
+    files: AgentCacheDirReader;
+    markers: AgentCacheDirReader;
+  },
+  fileSnapshotNames: ReadonlySet<string>
+): Promise<AgentCacheDirState> {
+  const snapshotNames = new Set<string>();
+  const markersByName = new Map<string, FailureMarker>();
+  const fingerprintsByName = new Map<string, string>();
+
+  const [remoteNames, fileNames, markerNames] = await Promise.all([
+    listTolerant(readers.remotes),
+    listTolerant(readers.files),
+    listTolerant(readers.markers),
+  ]);
+
+  // Remote snapshots: name alone proves freshness, so never read their bodies.
+  for (const name of remoteNames) {
+    if (name.endsWith(".md")) snapshotNames.add(name);
+  }
+  // File snapshots: read the stored fingerprint only for the requested names so a
+  // changed file can be detected as stale.
+  for (const name of fileNames) {
+    if (!name.endsWith(".md")) continue;
+    snapshotNames.add(name);
+    if (fileSnapshotNames.has(name)) {
+      const meta = await readMetaTolerant(readers.files, name);
+      if (meta) fingerprintsByName.set(name, meta.fingerprint);
+    }
+  }
+  // Per-project failure markers.
+  for (const name of markerNames) {
+    if (!name.startsWith("failed-") || !name.endsWith(".json")) continue;
+    const marker = await readJsonTolerant(readers.markers, name);
+    if (marker) markersByName.set(name, marker);
+  }
+
+  return { snapshotNames, markersByName, fingerprintsByName };
+}
+
+/**
+ * Desktop-gated wiring of {@link aggregateAgentCacheDirState} over the off-vault
+ * cache. Returns undefined on mobile or any failure — a project that never
+ * materialized (or a non-desktop runtime with no Agent Mode) is not an error.
+ *
+ * MOBILE BOUNDARY (design §3.4, invariant 4): this module is statically imported
+ * into the mobile bundle via the shared ContextManageModal, so it must NEVER
+ * statically import `conversionsLocation` (top-level `node:os`/`node:path`) or
+ * `contextCacheFs` (the node factory) — that would evaluate Node builtins at
+ * bundle load and crash mobile. Both are loaded ONLY here, behind the desktop
+ * gate, via dynamic import (esbuild splits them into a desktop-only chunk).
+ */
+export async function readAgentCacheDirState(
+  app: App,
+  projectId: string,
+  fileSnapshotNames: ReadonlySet<string>
+): Promise<AgentCacheDirState | undefined> {
+  if (!isDesktopRuntime()) return undefined;
+  try {
+    const { remotesDir, filesDir, markersDir } = await import("@/context/conversionsLocation");
+    const { createNodeContextCacheFs } = await import("@/context/contextCacheFs");
+    // A root-confined fs rooted AT each directory, so listing is `list("")` and a
+    // file read is `readText(name)` — no cache-root-relative path math, and the
+    // directory layout stays owned solely by conversionsLocation.
+    const dirReader = (dir: string): AgentCacheDirReader => {
+      const fs = createNodeContextCacheFs(dir);
+      return { list: () => fs.list(""), readText: (name) => fs.readText(name) };
+    };
+    return await aggregateAgentCacheDirState(
+      {
+        remotes: dirReader(remotesDir(app)),
+        files: dirReader(filesDir(app)),
+        markers: dirReader(markersDir(app, projectId)),
+      },
+      fileSnapshotNames
+    );
+  } catch {
+    return undefined;
+  }
+}
+
+async function listTolerant(reader: AgentCacheDirReader): Promise<string[]> {
+  try {
+    return await reader.list();
+  } catch {
+    return [];
+  }
+}
+
+async function readJsonTolerant(
+  reader: AgentCacheDirReader,
+  name: string
+): Promise<FailureMarker | null> {
+  try {
+    return parseFailureMarker(await reader.readText(name));
+  } catch {
+    return null;
+  }
+}
+
+async function readMetaTolerant(reader: AgentCacheDirReader, name: string) {
+  try {
+    return parseSnapshotMeta(await reader.readText(name));
+  } catch {
+    return null;
+  }
+}
+
+/** Live FailedItem kinds map onto materialized-source kinds ("nonMd" ↔ "file"). */
+function liveFailureMatches(failure: FailedItem, kind: MaterializedSourceType): boolean {
+  if (kind === "file") return failure.type === "nonMd";
+  return failure.type === kind;
+}
+
+const IN_FLIGHT_PHASES = new Set<AgentProjectContextLoadState["phase"]>([
+  "resolve",
+  "prefetch",
+  "parse",
+]);
+
+/**
+ * Build the panel's item list. `savedKeys` holds `${kind}:${source}` for every
+ * source in the PERSISTED project config — a draft-only addition can't be
+ * "processing" (no run knows about it yet), so it stays Queued until saved.
+ */
+export function buildAgentProcessingItems(
+  sources: AgentProcessingSource[],
+  liveEntry: AgentProjectContextLoadState | undefined,
+  disk: AgentCacheDirState | undefined,
+  savedKeys: ReadonlySet<string>
+): ProcessingItem[] {
+  const running = liveEntry !== undefined && IN_FLIGHT_PHASES.has(liveEntry.phase);
+  const liveFailures = liveEntry?.failedSources ?? [];
+  const retrying = liveEntry?.retryingSources ?? EMPTY_RETRYING_SOURCES;
+  const processing = liveEntry?.processingSources ?? EMPTY_PROCESSING_SOURCES;
+
+  return sources.map(({ kind, source, fingerprint }) => {
+    const key = `${kind}:${source}`;
+    let status: ProcessingItem["status"] = "pending";
+    let error: string | undefined;
+
+    const live = liveFailures.find((f) => f.path === source && liveFailureMatches(f, kind));
+    const snapshotName = cacheFileName(kind, source);
+    const hasSnapshot = disk?.snapshotNames.has(snapshotName) ?? false;
+    const marker = disk?.markersByName.get(failureMarkerName(kind, source));
+    const isRetrying = retrying.some((r) => r.kind === kind && r.source === source);
+    const isProcessing = processing.some((p) => p.kind === kind && p.source === source);
+    // A file snapshot is only trustworthy when its stored `mtime:size` still
+    // matches the live file; a missing/unparseable fingerprint can't prove the
+    // snapshot is current, so a changed file falls through to Queued/processing.
+    // URL snapshots are identity-fingerprinted (the name alone proves freshness).
+    const stored = disk?.fingerprintsByName.get(snapshotName);
+    const freshSnapshot =
+      hasSnapshot && (kind !== "file" || (stored !== undefined && stored === fingerprint));
+    // A persisted failure the next automatic run will honor (Option D cheap-skips
+    // a known-bad source until the user retries). Mirrors the materializer's skip
+    // condition: a remote marker is identity-keyed; a file marker is trustworthy
+    // only while its stored `mtime:size` still matches the live file — a changed
+    // file (or a legacy marker with no fingerprint) is NOT valid, so it falls
+    // through to be re-attempted rather than showing a stale failure.
+    const validMarker =
+      marker !== undefined && (kind !== "file" || marker.fingerprint === fingerprint)
+        ? marker
+        : undefined;
+
+    if ((isRetrying || isProcessing) && savedKeys.has(key)) {
+      // This source is being (re-)fetched right now — the per-row Retry, or the
+      // full run's live processing set. Show the spinner.
+      status = "processing";
+    } else if (live && !live.usedStaleSnapshot) {
+      status = "failed";
+      error = live.error;
+    } else if (live?.usedStaleSnapshot) {
+      // A stale-but-usable live failure counts as converted (context is present).
+      status = "ready";
+    } else if (freshSnapshot) {
+      status = "ready";
+    } else if (validMarker) {
+      // A known-bad source the next run will cheap-skip (Option D), so it reads as
+      // failed even mid-run — NOT "Queued", which would wrongly imply it's about
+      // to be processed when nothing will re-fetch it until a manual Retry.
+      status = "failed";
+      error = validMarker.error;
+    } else if (running && savedKeys.has(key)) {
+      // A run is active and this source has no valid failure marker and hasn't
+      // started/settled yet → Queued (a genuinely new/changed source the run will
+      // attempt).
+      //
+      // DESIGN NOTE — success is disk-truth, NOT a live atom set. When a source
+      // emits `itemSettled` it leaves `processingSources`, but its fresh snapshot
+      // isn't observed until `useAgentProcessingItems` re-reads the cache dir (it
+      // re-reads on every `liveEntry` change). So a just-settled source can read
+      // as Queued here for one async cache-dir read (~tens of ms) before flipping
+      // to Ready — a transient, self-correcting popover flicker. We deliberately
+      // do NOT keep a 4th live `succeededSources` set to erase it: that would
+      // duplicate the whole processingSources machinery (atom field + publish +
+      // clear + tests) to smooth a cosmetic blip that never touches the cache,
+      // the send gate, or captured session context. If a future review flags
+      // this again, point them at this note.
+      status = "pending";
+    }
+
+    return {
+      // Envelope (id/name/source/fileType) is shared with the CAG adapter so the
+      // two produce structurally identical items; `id` is the raw URL / vault
+      // path, which the shared ProcessingStatus row renders for URLs and the
+      // modal's remove handler matches by (cacheKind, id).
+      ...processingItemEnvelope(kind, source),
+      status,
+      ...(error !== undefined ? { error } : {}),
+    };
+  });
+}

--- a/src/components/project/processing-status.tsx
+++ b/src/components/project/processing-status.tsx
@@ -43,6 +43,14 @@ interface ProcessingStatusProps {
   maxHeight?: string;
   /** When false, hides the title and description. Use for embedding inside another panel. */
   showHeader?: boolean;
+  /** Optional: retry by full item — agent per-source retry needs `cacheKind`,
+   * which `onRetry(id)` can't carry. Takes precedence over `onRetry`. */
+  onRetryItem?: (item: ProcessingItem) => void;
+  /** Optional: "N markdown files — no conversion needed" note under From Files. */
+  skippedMarkdownCount?: number;
+  /** When true, render the grouped list directly without the collapsible summary
+   * bar — for a modal that supplies its own header / filter / footer chrome. */
+  hideSummaryBar?: boolean;
 }
 
 /**
@@ -149,12 +157,72 @@ export function ProcessingStatus({
   defaultExpanded = false,
   maxHeight,
   showHeader = true,
+  onRetryItem,
+  skippedMarkdownCount = 0,
+  hideSummaryBar = false,
 }: ProcessingStatusProps) {
   const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   const counts = getStatusCounts(items);
 
   const sortedFileItems = sortByStatusPriority(items.filter((i) => i.source === "file"));
   const sortedUrlItems = sortByStatusPriority(items.filter((i) => i.source === "url"));
+
+  // The grouped From Files / From URLs body, shared by the collapsible (CAG /
+  // embedded) and the bare (modal) layouts.
+  const groupsBody = (
+    <div className="tw-space-y-3 tw-p-3">
+      {sortedFileItems.length > 0 && (
+        <div className="tw-space-y-2">
+          <div className="tw-flex tw-items-center tw-gap-1.5 tw-px-1">
+            <FolderOpen className="tw-size-3.5 tw-text-accent" />
+            <span className="tw-text-ui-smaller tw-font-medium tw-text-muted">
+              From Files ({sortedFileItems.length})
+            </span>
+          </div>
+          <ScrollableList maxHeight={maxHeight || "200px"}>
+            {sortedFileItems.map((item) => (
+              <ProcessingItemRow
+                key={`${item.cacheKind}:${item.id}`}
+                item={item}
+                onRetry={onRetry}
+                onRetryItem={onRetryItem}
+                onOpenCached={onOpenCachedItem ? () => onOpenCachedItem(item) : undefined}
+              />
+            ))}
+          </ScrollableList>
+          {skippedMarkdownCount > 0 && (
+            <div className="tw-px-1 tw-text-ui-smaller tw-text-faint">
+              {skippedMarkdownCount} markdown {skippedMarkdownCount === 1 ? "file" : "files"} — no
+              conversion needed
+            </div>
+          )}
+        </div>
+      )}
+
+      {sortedUrlItems.length > 0 && (
+        <div className="tw-space-y-2">
+          <div className="tw-flex tw-items-center tw-gap-1.5 tw-px-1">
+            <Globe className="tw-size-3.5 tw-text-accent" />
+            <span className="tw-text-ui-smaller tw-font-medium tw-text-muted">
+              From URLs ({sortedUrlItems.length})
+            </span>
+          </div>
+          <ScrollableList maxHeight={maxHeight || "200px"}>
+            {sortedUrlItems.map((item) => (
+              <ProcessingItemRow
+                key={`${item.cacheKind}:${item.id}`}
+                item={item}
+                onRetry={onRetry}
+                onRetryItem={onRetryItem}
+                onOpenCached={onOpenCachedItem ? () => onOpenCachedItem(item) : undefined}
+                onRemove={onRemoveUrl ? () => onRemoveUrl(item) : undefined}
+              />
+            ))}
+          </ScrollableList>
+        </div>
+      )}
+    </div>
+  );
 
   return (
     <div className="tw-space-y-2">
@@ -180,127 +248,84 @@ export function ProcessingStatus({
       )}
 
       {/* Status Panel — only when there are items to show */}
-      {items.length > 0 && (
-        <div className="tw-rounded-lg tw-border tw-border-border">
-          <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
-            {/* Summary Bar */}
-            <CollapsibleTrigger asChild>
-              <Button
-                variant="secondary"
-                className=" tw-flex tw-h-auto tw-w-full tw-items-center tw-justify-between tw-rounded-lg tw-p-3 tw-text-left tw-transition-colors hover:tw-bg-modifier-hover"
-              >
-                <div className="tw-flex tw-items-center tw-gap-2">
-                  <div className="tw-flex tw-items-center tw-gap-1.5">
-                    {counts.ready > 0 && (
-                      <Badge
-                        variant="secondary"
-                        className="tw-h-5 tw-gap-1 tw-bg-success tw-px-1.5 tw-text-ui-smaller tw-text-success"
-                      >
-                        <CheckCircle2 className="tw-size-3" />
-                        {counts.ready}
-                      </Badge>
-                    )}
-                    {counts.processing > 0 && (
-                      <Badge
-                        variant="secondary"
-                        className="tw-h-5 tw-gap-1 tw-px-1.5 tw-text-ui-smaller"
-                      >
-                        <Loader2 className="tw-size-3 tw-animate-spin" />
-                        {counts.processing}
-                      </Badge>
-                    )}
-                    {counts.pending > 0 && (
-                      <Badge
-                        variant="secondary"
-                        className="tw-h-5 tw-gap-1 tw-px-1.5 tw-text-ui-smaller"
-                      >
-                        <Clock className="tw-size-3" />
-                        {counts.pending}
-                      </Badge>
-                    )}
-                    {counts.failed > 0 && (
-                      <Badge
-                        variant="secondary"
-                        className="tw-h-5 tw-gap-1 tw-bg-error tw-px-1.5 tw-text-ui-smaller tw-text-error"
-                      >
-                        <AlertCircle className="tw-size-3" />
-                        {counts.failed}
-                      </Badge>
-                    )}
-                    {/* Reason: unsupported items get a neutral gray badge to distinguish
+      {items.length > 0 &&
+        (hideSummaryBar ? (
+          <div className="tw-rounded-lg tw-border tw-border-border">{groupsBody}</div>
+        ) : (
+          <div className="tw-rounded-lg tw-border tw-border-border">
+            <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+              {/* Summary Bar */}
+              <CollapsibleTrigger asChild>
+                <Button
+                  variant="secondary"
+                  className=" tw-flex tw-h-auto tw-w-full tw-items-center tw-justify-between tw-rounded-lg tw-p-3 tw-text-left tw-transition-colors hover:tw-bg-modifier-hover"
+                >
+                  <div className="tw-flex tw-items-center tw-gap-2">
+                    <div className="tw-flex tw-items-center tw-gap-1.5">
+                      {counts.ready > 0 && (
+                        <Badge
+                          variant="secondary"
+                          className="tw-h-5 tw-gap-1 tw-bg-success tw-px-1.5 tw-text-ui-smaller tw-text-success"
+                        >
+                          <CheckCircle2 className="tw-size-3" />
+                          {counts.ready}
+                        </Badge>
+                      )}
+                      {counts.processing > 0 && (
+                        <Badge
+                          variant="secondary"
+                          className="tw-h-5 tw-gap-1 tw-px-1.5 tw-text-ui-smaller"
+                        >
+                          <Loader2 className="tw-size-3 tw-animate-spin" />
+                          {counts.processing}
+                        </Badge>
+                      )}
+                      {counts.pending > 0 && (
+                        <Badge
+                          variant="secondary"
+                          className="tw-h-5 tw-gap-1 tw-px-1.5 tw-text-ui-smaller"
+                        >
+                          <Clock className="tw-size-3" />
+                          {counts.pending}
+                        </Badge>
+                      )}
+                      {counts.failed > 0 && (
+                        <Badge
+                          variant="secondary"
+                          className="tw-h-5 tw-gap-1 tw-bg-error tw-px-1.5 tw-text-ui-smaller tw-text-error"
+                        >
+                          <AlertCircle className="tw-size-3" />
+                          {counts.failed}
+                        </Badge>
+                      )}
+                      {/* Reason: unsupported items get a neutral gray badge to distinguish
                         them from errors — they're not failures, just unprocessable file types. */}
-                    {counts.unsupported > 0 && (
-                      <Badge
-                        variant="secondary"
-                        className="tw-h-5 tw-gap-1 tw-px-1.5 tw-text-ui-smaller tw-text-muted"
-                      >
-                        <HelpCircle className="tw-size-3" />
-                        {counts.unsupported}
-                      </Badge>
-                    )}
-                  </div>
-                  <span className="tw-text-ui-smaller tw-text-muted">{counts.total} items</span>
-                </div>
-                {isExpanded ? (
-                  <ChevronDown className="tw-size-4 tw-text-muted" />
-                ) : (
-                  <ChevronRight className="tw-size-4 tw-text-muted" />
-                )}
-              </Button>
-            </CollapsibleTrigger>
-
-            <CollapsibleContent>
-              {/* Reason: each section scrolls independently so files don't push URLs out of view */}
-              <div className="tw-space-y-3 tw-border-t tw-border-border tw-p-3">
-                {/* From Files Section */}
-                {sortedFileItems.length > 0 && (
-                  <div className="tw-space-y-2">
-                    <div className="tw-flex tw-items-center tw-gap-1.5 tw-px-1">
-                      <FolderOpen className="tw-size-3.5 tw-text-accent" />
-                      <span className="tw-text-ui-smaller tw-font-medium tw-text-muted">
-                        From Files ({sortedFileItems.length})
-                      </span>
+                      {counts.unsupported > 0 && (
+                        <Badge
+                          variant="secondary"
+                          className="tw-h-5 tw-gap-1 tw-px-1.5 tw-text-ui-smaller tw-text-muted"
+                        >
+                          <HelpCircle className="tw-size-3" />
+                          {counts.unsupported}
+                        </Badge>
+                      )}
                     </div>
-                    <ScrollableList maxHeight={maxHeight || "200px"}>
-                      {sortedFileItems.map((item) => (
-                        <ProcessingItemRow
-                          key={item.id}
-                          item={item}
-                          onRetry={onRetry}
-                          onOpenCached={onOpenCachedItem ? () => onOpenCachedItem(item) : undefined}
-                        />
-                      ))}
-                    </ScrollableList>
+                    <span className="tw-text-ui-smaller tw-text-muted">{counts.total} items</span>
                   </div>
-                )}
+                  {isExpanded ? (
+                    <ChevronDown className="tw-size-4 tw-text-muted" />
+                  ) : (
+                    <ChevronRight className="tw-size-4 tw-text-muted" />
+                  )}
+                </Button>
+              </CollapsibleTrigger>
 
-                {/* From URLs Section */}
-                {sortedUrlItems.length > 0 && (
-                  <div className="tw-space-y-2">
-                    <div className="tw-flex tw-items-center tw-gap-1.5 tw-px-1">
-                      <Globe className="tw-size-3.5 tw-text-accent" />
-                      <span className="tw-text-ui-smaller tw-font-medium tw-text-muted">
-                        From URLs ({sortedUrlItems.length})
-                      </span>
-                    </div>
-                    <ScrollableList maxHeight={maxHeight || "200px"}>
-                      {sortedUrlItems.map((item) => (
-                        <ProcessingItemRow
-                          key={item.id}
-                          item={item}
-                          onRetry={onRetry}
-                          onOpenCached={onOpenCachedItem ? () => onOpenCachedItem(item) : undefined}
-                          onRemove={onRemoveUrl ? () => onRemoveUrl(item) : undefined}
-                        />
-                      ))}
-                    </ScrollableList>
-                  </div>
-                )}
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
-        </div>
-      )}
+              <CollapsibleContent>
+                <div className="tw-border-t tw-border-border">{groupsBody}</div>
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
+        ))}
     </div>
   );
 }
@@ -348,11 +373,14 @@ function ScrollableList({ maxHeight, children }: { maxHeight: string; children: 
 function ProcessingItemRow({
   item,
   onRetry,
+  onRetryItem,
   onOpenCached,
   onRemove,
 }: {
   item: ProcessingItem;
   onRetry?: (id: string) => void;
+  /** Full-item retry (agent per-source); takes precedence over `onRetry`. */
+  onRetryItem?: (item: ProcessingItem) => void;
   /** Callback to open the cached parsed content for this file item. */
   onOpenCached?: () => void;
   /** Callback to remove this URL from the project config. Only for URL items. */
@@ -420,12 +448,16 @@ function ProcessingItemRow({
             {item.error || "Conversion failed"}
           </TruncatedText>
           <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-1">
-            {onRetry && (
+            {(onRetry || onRetryItem) && (
               <Button
                 variant="ghost2"
                 size="icon"
                 aria-label="Retry"
-                onClick={() => onRetry(item.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (onRetryItem) onRetryItem(item);
+                  else onRetry?.(item.id);
+                }}
                 title="Retry"
                 className="tw-size-5 tw-text-muted hover:tw-text-accent"
               >

--- a/src/components/project/processing-status.tsx
+++ b/src/components/project/processing-status.tsx
@@ -13,12 +13,17 @@ import { Progress } from "@/components/ui/progress";
 import { TruncatedText } from "@/components/TruncatedText";
 import type { ProcessingItem } from "@/components/project/processingAdapter";
 import {
+  getProcessingStatusLabel,
+  processingItemKey,
+  ProcessingStatusIcon,
+} from "@/components/project/processingItemStatusView";
+import {
   AlertCircle,
+  ArrowUpRight,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
   Clock,
-  ArrowUpRight,
   FileImage,
   FileText,
   FileVideo,
@@ -53,36 +58,6 @@ interface ProcessingStatusProps {
   hideSummaryBar?: boolean;
 }
 
-/**
- * Renders the status icon for a ProcessingItem.
- * For ready+contentEmpty items, shows a warning HelpCircle instead of a green checkmark.
- */
-function StatusIcon({
-  status,
-  contentEmpty,
-}: {
-  status: ProcessingItem["status"];
-  contentEmpty?: boolean;
-}) {
-  // Reason: contentEmpty is a sub-state of "ready" — item was fetched but had no extractable content.
-  if (status === "ready" && contentEmpty) {
-    return <HelpCircle className="tw-size-3.5 tw-text-warning" />;
-  }
-
-  switch (status) {
-    case "ready":
-      return <CheckCircle2 className="tw-size-3.5 tw-text-success" />;
-    case "processing":
-      return <Loader2 className="tw-size-3.5 tw-animate-spin tw-text-loading" />;
-    case "failed":
-      return <AlertCircle className="tw-size-3.5 tw-text-error" />;
-    case "pending":
-      return <Clock className="tw-size-3.5 tw-text-muted" />;
-    case "unsupported":
-      return <HelpCircle className="tw-size-3.5 tw-text-muted" />;
-  }
-}
-
 function FileTypeIcon({ fileType }: { fileType: ProcessingItem["fileType"] }) {
   switch (fileType) {
     case "pdf":
@@ -109,28 +84,6 @@ function getStatusCounts(items: ProcessingItem[]) {
     unsupported: items.filter((i) => i.status === "unsupported").length,
     total: items.length,
   };
-}
-
-/**
- * Returns the human-readable label for a given status.
- * For ready+contentEmpty items the caller should override to "No content".
- */
-function getStatusLabel(status: ProcessingItem["status"], contentEmpty?: boolean): string {
-  // Reason: "No content" is a UI-only distinction within the "ready" status.
-  if (status === "ready" && contentEmpty) return "No content";
-
-  switch (status) {
-    case "ready":
-      return "Converted";
-    case "processing":
-      return "Converting...";
-    case "failed":
-      return "Failed";
-    case "pending":
-      return "Queued";
-    case "unsupported":
-      return "Unsupported";
-  }
 }
 
 /** Status priority for sorting: active/problematic items first, completed last. */
@@ -182,7 +135,7 @@ export function ProcessingStatus({
           <ScrollableList maxHeight={maxHeight || "200px"}>
             {sortedFileItems.map((item) => (
               <ProcessingItemRow
-                key={`${item.cacheKind}:${item.id}`}
+                key={processingItemKey(item)}
                 item={item}
                 onRetry={onRetry}
                 onRetryItem={onRetryItem}
@@ -210,7 +163,7 @@ export function ProcessingStatus({
           <ScrollableList maxHeight={maxHeight || "200px"}>
             {sortedUrlItems.map((item) => (
               <ProcessingItemRow
-                key={`${item.cacheKind}:${item.id}`}
+                key={processingItemKey(item)}
                 item={item}
                 onRetry={onRetry}
                 onRetryItem={onRetryItem}
@@ -421,10 +374,10 @@ function ProcessingItemRow({
                   Exception: contentEmpty items need a visible "No content" label. */}
               {(item.status !== "ready" || item.contentEmpty) && (
                 <span className="tw-text-ui-smaller tw-text-muted">
-                  {getStatusLabel(item.status, item.contentEmpty)}
+                  {getProcessingStatusLabel(item.status, item.contentEmpty)}
                 </span>
               )}
-              <StatusIcon status={item.status} contentEmpty={item.contentEmpty} />
+              <ProcessingStatusIcon item={item} tooltip={false} />
             </div>
           </div>
         </div>

--- a/src/components/project/processingAdapter.ts
+++ b/src/components/project/processingAdapter.ts
@@ -113,6 +113,35 @@ function inferUrlFileType(url: string): ProcessingItem["fileType"] {
   return detectUrlType(url);
 }
 
+/**
+ * Build the display envelope of a {@link ProcessingItem} — everything derivable
+ * from the source identity alone (`id`, `name`, `source`, `fileType`). Status,
+ * error, and contentEmpty are resolved separately by each pipeline and spread
+ * on top by the caller. Shared by the CAG adapter and the agent adapter so the
+ * two stay structurally identical; only their status resolution differs.
+ *
+ * `cacheKind` is the source's storage bucket; for a "web" kind the URL is still
+ * re-sniffed (a YouTube link pasted into the web list renders as a video).
+ */
+export function processingItemEnvelope(
+  cacheKind: ProcessingItem["cacheKind"],
+  key: string
+): Pick<ProcessingItem, "id" | "name" | "source" | "fileType" | "cacheKind"> {
+  const fileType =
+    cacheKind === "file"
+      ? inferFileType(key)
+      : cacheKind === "youtube"
+        ? "youtube"
+        : inferUrlFileType(key);
+  return {
+    id: key,
+    name: extractName(key),
+    source: cacheKind === "file" ? "file" : "url",
+    fileType,
+    cacheKind,
+  };
+}
+
 /** Extract a human-readable name from a file path or URL. */
 function extractName(key: string): string {
   // Reason: URLs should show domain + path + query; file paths should show just the filename.
@@ -289,12 +318,8 @@ export function buildProcessingItems(
     // which looks like a stalled queue to the user.
     if (!supportedExtensions.has(ext)) {
       items.push({
-        id: key,
-        name: extractName(key),
-        source: "file",
-        fileType: inferFileType(key),
+        ...processingItemEnvelope("file", key),
         status: "unsupported",
-        cacheKind: "file",
       });
       continue;
     }
@@ -314,13 +339,9 @@ export function buildProcessingItems(
     }
 
     items.push({
-      id: key,
-      name: extractName(key),
-      source: "file",
-      fileType: inferFileType(key),
+      ...processingItemEnvelope("file", key),
       status,
       error,
-      cacheKind: "file",
     });
   }
 
@@ -330,7 +351,6 @@ export function buildProcessingItems(
   for (const url of parseUrlConfig(project.contextSource?.webUrls)) {
     if (seenIds.has(url)) continue;
     seenIds.add(url);
-    const fileType = inferUrlFileType(url);
     let status: ProcessingItem["status"];
     let error: string | undefined;
     let contentEmpty: boolean | undefined;
@@ -351,14 +371,10 @@ export function buildProcessingItems(
     }
 
     items.push({
-      id: url,
-      name: extractName(url),
-      source: "url",
-      fileType,
+      ...processingItemEnvelope("web", url),
       status,
       error,
       contentEmpty,
-      cacheKind: "web",
     });
   }
 
@@ -368,7 +384,6 @@ export function buildProcessingItems(
   for (const url of parseUrlConfig(project.contextSource?.youtubeUrls)) {
     if (seenIds.has(url)) continue;
     seenIds.add(url);
-    const fileType: ProcessingItem["fileType"] = "youtube";
     let status: ProcessingItem["status"];
     let error: string | undefined;
     let contentEmpty: boolean | undefined;
@@ -388,14 +403,10 @@ export function buildProcessingItems(
     }
 
     items.push({
-      id: url,
-      name: extractName(url),
-      source: "url",
-      fileType,
+      ...processingItemEnvelope("youtube", url),
       status,
       error,
       contentEmpty,
-      cacheKind: "youtube",
     });
   }
 

--- a/src/components/project/processingItemStatusView.test.tsx
+++ b/src/components/project/processingItemStatusView.test.tsx
@@ -1,0 +1,65 @@
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import {
+  buildProcessingItemLookup,
+  getProcessingStatusLabel,
+  processingItemKey,
+  processingSourceKey,
+} from "@/components/project/processingItemStatusView";
+
+function makeItem(overrides: Partial<ProcessingItem>): ProcessingItem {
+  return {
+    id: "x",
+    name: "x",
+    source: "url",
+    fileType: "web",
+    status: "ready",
+    cacheKind: "web",
+    ...overrides,
+  };
+}
+
+describe("processing item keys", () => {
+  it("keys files by path and URLs by url under their cache bucket", () => {
+    expect(processingSourceKey("file", "data/x.xlsx")).toBe("file:data/x.xlsx");
+    expect(processingSourceKey("web", "https://a.com")).toBe("web:https://a.com");
+  });
+
+  it("does NOT let the same URL configured as both web and youtube collide", () => {
+    const web = makeItem({ id: "https://v", cacheKind: "web", status: "ready" });
+    const youtube = makeItem({ id: "https://v", cacheKind: "youtube", status: "failed" });
+    const lookup = buildProcessingItemLookup([web, youtube]);
+
+    expect(lookup.get(processingSourceKey("web", "https://v"))?.status).toBe("ready");
+    expect(lookup.get(processingSourceKey("youtube", "https://v"))?.status).toBe("failed");
+    expect(lookup.size).toBe(2);
+  });
+
+  it("indexes file and url items in one lookup", () => {
+    const file = makeItem({
+      id: "notes/a.pdf",
+      source: "file",
+      cacheKind: "file",
+      fileType: "pdf",
+    });
+    const url = makeItem({ id: "https://a.com", source: "url", cacheKind: "web" });
+    const lookup = buildProcessingItemLookup([file, url]);
+
+    expect(lookup.get(processingItemKey(file))).toBe(file);
+    expect(lookup.get(processingSourceKey("file", "notes/a.pdf"))).toBe(file);
+    expect(lookup.get(processingSourceKey("web", "https://a.com"))).toBe(url);
+  });
+});
+
+describe("getProcessingStatusLabel", () => {
+  it("surfaces a fetched-but-empty ready item as 'No content'", () => {
+    expect(getProcessingStatusLabel("ready", true)).toBe("No content");
+    expect(getProcessingStatusLabel("ready", false)).toBe("Converted");
+  });
+
+  it("labels each status", () => {
+    expect(getProcessingStatusLabel("processing")).toBe("Converting...");
+    expect(getProcessingStatusLabel("failed")).toBe("Failed");
+    expect(getProcessingStatusLabel("pending")).toBe("Queued");
+    expect(getProcessingStatusLabel("unsupported")).toBe("Unsupported");
+  });
+});

--- a/src/components/project/processingItemStatusView.tsx
+++ b/src/components/project/processingItemStatusView.tsx
@@ -1,0 +1,125 @@
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import { HelpTooltip } from "@/components/ui/help-tooltip";
+import { cn } from "@/lib/utils";
+import { AlertCircle, CheckCircle2, Clock, HelpCircle, Loader2 } from "lucide-react";
+import React from "react";
+
+/**
+ * Single source of truth for rendering an agent {@link ProcessingItem}'s
+ * conversion status — the key it's looked up by, its status glyph, and its label.
+ *
+ * Every agent surface (the composer status popover, the Manage modal's Links
+ * panel, and its File Context list) routes through here so the status semantics
+ * never drift across them. The legacy CAG status (`ProjectContextItemStatus` in
+ * the Manage modal) is deliberately NOT folded in: it reads a different cache
+ * (`ProjectContextCache`) with different semantics, so it stays separate.
+ */
+
+/** Canonical lookup key for a processing item: `<cacheKind>:<id>`. Keying on the
+ * cache bucket (not just the id) keeps a URL configured as BOTH web and youtube
+ * — two items sharing one id — from clobbering each other. */
+export function processingSourceKey(kind: ProcessingItem["cacheKind"], id: string): string {
+  return `${kind}:${id}`;
+}
+
+export function processingItemKey(item: ProcessingItem): string {
+  return processingSourceKey(item.cacheKind, item.id);
+}
+
+/** Index a processing-item list by {@link processingItemKey} for O(1) per-row lookup. */
+export function buildProcessingItemLookup(
+  items: readonly ProcessingItem[]
+): ReadonlyMap<string, ProcessingItem> {
+  const map = new Map<string, ProcessingItem>();
+  for (const item of items) map.set(processingItemKey(item), item);
+  return map;
+}
+
+/** Human-readable status label. `contentEmpty` is a sub-state of `ready` (fetched
+ * but no extractable content), surfaced as "No content". */
+export function getProcessingStatusLabel(
+  status: ProcessingItem["status"],
+  contentEmpty?: boolean
+): string {
+  if (status === "ready" && contentEmpty) return "No content";
+  switch (status) {
+    case "ready":
+      return "Converted";
+    case "processing":
+      return "Converting...";
+    case "failed":
+      return "Failed";
+    case "pending":
+      return "Queued";
+    case "unsupported":
+      return "Unsupported";
+  }
+}
+
+function ProcessingStatusGlyph({ item, className }: { item: ProcessingItem; className?: string }) {
+  // contentEmpty rides on "ready": fetched OK but empty, so it warns rather than
+  // resting on the green check.
+  if (item.status === "ready" && item.contentEmpty) {
+    return <HelpCircle className={cn("tw-size-3.5 tw-text-warning", className)} />;
+  }
+  switch (item.status) {
+    case "ready":
+      return <CheckCircle2 className={cn("tw-size-3.5 tw-text-success", className)} />;
+    case "processing":
+      return <Loader2 className={cn("tw-size-3.5 tw-animate-spin tw-text-loading", className)} />;
+    case "failed":
+      return <AlertCircle className={cn("tw-size-3.5 tw-text-error", className)} />;
+    case "pending":
+      return <Clock className={cn("tw-size-3.5 tw-text-muted", className)} />;
+    case "unsupported":
+      return <HelpCircle className={cn("tw-size-3.5 tw-text-muted", className)} />;
+  }
+}
+
+interface ProcessingStatusIconProps {
+  item: ProcessingItem;
+  className?: string;
+  /** Dense rows: a settled `ready` item rests hidden until the row is hovered
+   * (it needs no attention), while processing/failed/queued stay visible. The
+   * parent row must carry `tw-group`. */
+  revealReadyOnHover?: boolean;
+  /** Wrap the glyph in a tooltip showing the label (or the error when failed).
+   * Off for surfaces that already render the label as adjacent text. */
+  tooltip?: boolean;
+}
+
+/** The shared per-item status glyph. */
+export function ProcessingStatusIcon({
+  item,
+  className,
+  revealReadyOnHover = false,
+  tooltip = true,
+}: ProcessingStatusIconProps) {
+  const restsHidden = revealReadyOnHover && item.status === "ready" && !item.contentEmpty;
+  const glyph = (
+    <span
+      className={cn(
+        "tw-flex tw-size-5 tw-shrink-0 tw-items-center tw-justify-center",
+        restsHidden && "tw-opacity-0 group-hover:tw-opacity-100",
+        className
+      )}
+    >
+      <ProcessingStatusGlyph item={item} />
+    </span>
+  );
+  if (!tooltip) return glyph;
+
+  const label =
+    item.status === "failed" && item.error
+      ? `Failed: ${item.error}`
+      : getProcessingStatusLabel(item.status, item.contentEmpty);
+  return (
+    <HelpTooltip
+      side="top"
+      contentClassName="tw-z-[60]"
+      content={<div className="tw-max-w-80">{label}</div>}
+    >
+      {glyph}
+    </HelpTooltip>
+  );
+}

--- a/src/components/project/useAgentPersistentFailureCount.test.ts
+++ b/src/components/project/useAgentPersistentFailureCount.test.ts
@@ -1,0 +1,165 @@
+import type { AgentProjectContextLoadState, ProjectConfig } from "@/aiParams";
+import * as adapter from "@/components/project/agentProcessingAdapter";
+import { useAgentPersistentFailureCount } from "@/components/project/useAgentPersistentFailureCount";
+import {
+  CACHE_SCHEMA_VERSION,
+  cacheFileName,
+  failureMarkerName,
+} from "@/context/contextCacheStore";
+import { listMaterializeCandidates } from "@/context/materializeCandidates";
+import * as projectState from "@/projects/state";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { App } from "obsidian";
+
+jest.mock("@/context/materializeCandidates", () => ({
+  listMaterializeCandidates: jest.fn(() => []),
+}));
+
+const readSpy = jest.spyOn(adapter, "readAgentCacheDirState");
+const listCandidatesMock = listMaterializeCandidates as jest.MockedFunction<
+  typeof listMaterializeCandidates
+>;
+jest
+  .spyOn(projectState, "getCachedProjectRecordById")
+  .mockReturnValue({ filePath: "Projects/p1/project.md" } as never);
+
+const app = { vault: { adapter: {} } } as unknown as App;
+const project = {
+  id: "p1",
+  contextSource: { webUrls: "https://a.com", youtubeUrls: "" },
+} as unknown as ProjectConfig;
+
+function entry(over: Partial<AgentProjectContextLoadState> = {}): AgentProjectContextLoadState {
+  return { phase: "done", blocking: false, ...over };
+}
+
+const webMarkerDisk = {
+  snapshotNames: new Set<string>(),
+  markersByName: new Map([
+    [
+      failureMarkerName("web", "https://a.com"),
+      { schemaVersion: CACHE_SCHEMA_VERSION, source: "https://a.com", kind: "web" as const, error: "boom", failedAt: 1 }, // prettier-ignore
+    ],
+  ]),
+  fingerprintsByName: new Map<string, string>(),
+};
+
+describe("useAgentPersistentFailureCount", () => {
+  beforeEach(() => {
+    readSpy.mockReset();
+    // The module mock factory returns [] by default, but mockReset() above would
+    // clear it for any test that overrides it — restore the no-file-sources default.
+    listCandidatesMock.mockReset();
+    listCandidatesMock.mockReturnValue([]);
+  });
+
+  it("does not read disk while a run is in flight (live atom is authoritative)", () => {
+    readSpy.mockResolvedValue(webMarkerDisk);
+    const running = entry({ phase: "prefetch" });
+    const { result } = renderHook(() =>
+      useAgentPersistentFailureCount(app, project, running, true)
+    );
+    expect(result.current).toBe(0);
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not read disk while a retry is in flight even at phase done", () => {
+    readSpy.mockResolvedValue(webMarkerDisk);
+    const retrying = entry({ retryingSources: [{ kind: "web", source: "https://a.com" }] });
+    renderHook(() => useAgentPersistentFailureCount(app, project, retrying, true));
+    expect(readSpy).not.toHaveBeenCalled();
+  });
+
+  it("counts a persisted failure marker once settled", async () => {
+    readSpy.mockResolvedValue(webMarkerDisk);
+    const settled = entry();
+    const { result } = renderHook(() =>
+      useAgentPersistentFailureCount(app, project, settled, true)
+    );
+    await waitFor(() => expect(result.current).toBe(1));
+    expect(readSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not count a stale file marker when a SHARED snapshot is fresh", async () => {
+    // Regression (shared off-vault cache): project A's parse failed and left a
+    // marker whose fingerprint still matches the unchanged file; project B then
+    // wrote the shared snapshot. The resting icon must read the file snapshot's
+    // fingerprint and let that fresh shared snapshot override A's stale marker —
+    // counting 0, not a phantom failure. (With the old EMPTY set it read 1.)
+    const filePath = "Docs/source.pdf";
+    const fingerprint = "10:20";
+    const snapshotName = cacheFileName("file", filePath);
+    listCandidatesMock.mockReturnValue([
+      { path: filePath, extension: "pdf", stat: { mtime: 10, size: 20 } } as never,
+    ]);
+    readSpy.mockResolvedValue({
+      snapshotNames: new Set([snapshotName]),
+      markersByName: new Map([
+        [
+          failureMarkerName("file", filePath),
+          { schemaVersion: CACHE_SCHEMA_VERSION, source: filePath, kind: "file" as const, error: "stale parse failure", failedAt: 1, fingerprint }, // prettier-ignore
+        ],
+      ]),
+      fingerprintsByName: new Map([[snapshotName, fingerprint]]),
+    });
+
+    const fileProject = {
+      id: "p1",
+      contextSource: { webUrls: "", youtubeUrls: "" },
+    } as unknown as ProjectConfig;
+    const { result } = renderHook(() =>
+      useAgentPersistentFailureCount(app, fileProject, entry(), true)
+    );
+
+    await waitFor(() => expect(readSpy).toHaveBeenCalledTimes(1));
+    // The fix: the hook now asks the reader for THIS file's snapshot fingerprint.
+    expect(readSpy.mock.calls[0][2]).toEqual(new Set([snapshotName]));
+    expect(result.current).toBe(0);
+  });
+
+  it("does not surface a slow read's count after the live entry changed under it", async () => {
+    // staleness guard: a disk read in flight for entry A must not paint its count
+    // once the hook re-renders with a different liveEntry (B) whose own read is
+    // still pending — the count is keyed to the entry it was computed for.
+    let resolveA!: (d: typeof webMarkerDisk) => void;
+    const readA = new Promise<typeof webMarkerDisk>((r) => (resolveA = r));
+    const readB = new Promise<typeof webMarkerDisk>(() => {}); // entryB's read never settles
+    readSpy.mockReturnValueOnce(readA).mockReturnValueOnce(readB);
+
+    const entryA = entry();
+    const { result, rerender } = renderHook(
+      ({ e }) => useAgentPersistentFailureCount(app, project, e, true),
+      { initialProps: { e: entryA } }
+    );
+
+    const entryB = entry();
+    rerender({ e: entryB }); // now keyed to entryB; entryB's read (readB) is pending
+    await act(async () => {
+      resolveA(webMarkerDisk); // the stale entryA read resolves late
+    });
+    // entryA's count is discarded (keyed to a now-stale entry); entryB's read is
+    // still pending, so nothing is surfaced.
+    expect(result.current).toBe(0);
+  });
+
+  it("invalidates an already-painted count the instant the live entry changes", async () => {
+    // Directly covers the return-value freshness guard (cached count is keyed to
+    // the liveEntry it was computed for): entryA paints count=1, then a rerender
+    // to entryB (whose own read is still pending) must drop back to 0 immediately
+    // — not keep showing entryA's stale 1.
+    readSpy.mockResolvedValueOnce(webMarkerDisk); // entryA read → count 1
+    const readB = new Promise<typeof webMarkerDisk>(() => {}); // entryB read pending
+    const entryA = entry();
+    const { result, rerender } = renderHook(
+      ({ e }) => useAgentPersistentFailureCount(app, project, e, true),
+      { initialProps: { e: entryA } }
+    );
+    await waitFor(() => expect(result.current).toBe(1));
+
+    readSpy.mockReturnValueOnce(readB);
+    const entryB = entry();
+    rerender({ e: entryB });
+    // entryA's cached count no longer matches the current entry → 0 at once.
+    expect(result.current).toBe(0);
+  });
+});

--- a/src/components/project/useAgentPersistentFailureCount.ts
+++ b/src/components/project/useAgentPersistentFailureCount.ts
@@ -1,6 +1,7 @@
 import { type AgentProjectContextLoadState, type ProjectConfig } from "@/aiParams";
 import {
   buildAgentProcessingItems,
+  buildAgentProcessingSources,
   readAgentCacheDirState,
   type AgentProcessingSource,
 } from "@/components/project/agentProcessingAdapter";
@@ -53,16 +54,7 @@ export function useAgentPersistentFailureCount(
     if (!settled) return EMPTY_SOURCES;
     const contextSource = project.contextSource;
     const urls = parseProjectUrls(contextSource?.webUrls || "", contextSource?.youtubeUrls || "");
-    return [
-      ...urls.map((u): AgentProcessingSource => ({ kind: u.type, source: u.url })),
-      ...listMaterializeCandidates(app, contextSource).map(
-        (f): AgentProcessingSource => ({
-          kind: "file",
-          source: f.path,
-          fingerprint: `${f.stat.mtime}:${f.stat.size}`,
-        })
-      ),
-    ];
+    return buildAgentProcessingSources(urls, listMaterializeCandidates(app, contextSource));
   }, [app, project.contextSource, settled]);
 
   // Snapshot names of the FILE sources, so the read fetches their stored

--- a/src/components/project/useAgentPersistentFailureCount.ts
+++ b/src/components/project/useAgentPersistentFailureCount.ts
@@ -1,0 +1,135 @@
+import { type AgentProjectContextLoadState, type ProjectConfig } from "@/aiParams";
+import {
+  buildAgentProcessingItems,
+  readAgentCacheDirState,
+  type AgentProcessingSource,
+} from "@/components/project/agentProcessingAdapter";
+import { cacheFileName } from "@/context/contextCacheStore";
+import { listMaterializeCandidates } from "@/context/materializeCandidates";
+import { parseProjectUrls } from "@/utils/urlTagUtils";
+import type { App } from "obsidian";
+import { useEffect, useMemo, useState } from "react";
+
+/**
+ * Lightweight persistent-failure read-model for the ALWAYS-MOUNTED context
+ * status icon. The popover's per-source list reads disk markers via
+ * {@link useAgentProcessingItems}, but that hook only runs while the popover is
+ * open — so the resting icon would otherwise rely solely on the live atom and
+ * show green "ready" for a project whose failures live only as on-disk markers
+ * (Option D: a failed source persists a marker and is cheap-skipped until a
+ * manual retry, so no live run repopulates `failedSources`).
+ *
+ * This hook closes that gap with the minimum work:
+ *  - It reads the cache dir ONLY when materialization is settled (no run in
+ *    flight). During a run the live atom is authoritative — the icon already
+ *    derives failed/working from it — so we never add disk I/O on a per-progress
+ *    tick to an always-mounted component.
+ *  - It asks `readAgentCacheDirState` to read snapshot meta for the configured
+ *    FILE sources (not just markers). Remote snapshots prove freshness by name
+ *    alone, but file snapshots need their stored `mtime:size` fingerprint:
+ *    snapshots are now SHARED across projects, so a fresh snapshot written by
+ *    another project must be able to override THIS project's stale-but-still-
+ *    fingerprint-matching failure marker — otherwise the resting icon keeps
+ *    flagging a failure another project already resolved.
+ *  - It reuses `buildAgentProcessingItems`' marker rules rather than reimplement
+ *    them, so the icon and the popover never diverge on what counts as failed.
+ */
+export function useAgentPersistentFailureCount(
+  app: App,
+  project: ProjectConfig,
+  liveEntry: AgentProjectContextLoadState | undefined,
+  enabled: boolean
+): number {
+  // Settled = no run is driving the atom: either no entry, or a completed phase
+  // with nothing retrying/processing. Only then is the disk the authoritative
+  // failure source the icon must consult.
+  const settled =
+    enabled &&
+    (liveEntry === undefined || liveEntry.phase === "done") &&
+    (liveEntry?.retryingSources?.length ?? 0) === 0 &&
+    (liveEntry?.processingSources?.length ?? 0) === 0;
+
+  const sources = useMemo<AgentProcessingSource[]>(() => {
+    if (!settled) return EMPTY_SOURCES;
+    const contextSource = project.contextSource;
+    const urls = parseProjectUrls(contextSource?.webUrls || "", contextSource?.youtubeUrls || "");
+    return [
+      ...urls.map((u): AgentProcessingSource => ({ kind: u.type, source: u.url })),
+      ...listMaterializeCandidates(app, contextSource).map(
+        (f): AgentProcessingSource => ({
+          kind: "file",
+          source: f.path,
+          fingerprint: `${f.stat.mtime}:${f.stat.size}`,
+        })
+      ),
+    ];
+  }, [app, project.contextSource, settled]);
+
+  // Snapshot names of the FILE sources, so the read fetches their stored
+  // fingerprints (a shared fresh snapshot can then override this project's stale
+  // marker). Remotes are omitted — their name alone proves freshness, so reading
+  // their bodies would be wasted I/O on an always-mounted component.
+  const fileSnapshotNames = useMemo<ReadonlySet<string>>(() => {
+    let names: Set<string> | undefined;
+    for (const source of sources) {
+      if (source.kind !== "file") continue;
+      (names ??= new Set<string>()).add(cacheFileName("file", source.source));
+    }
+    return names ?? EMPTY_FILE_SNAPSHOT_NAMES;
+  }, [sources]);
+
+  const savedKeys = useMemo<ReadonlySet<string>>(
+    () =>
+      sources.length === 0 ? EMPTY_KEYS : new Set(sources.map((s) => `${s.kind}:${s.source}`)),
+    [sources]
+  );
+  // A content signature of the source set, so a project/source switch invalidates
+  // a previously-read count (which belonged to a different project).
+  const sourceKey = useMemo(
+    () => sources.map((s) => `${s.kind}:${s.source}:${s.fingerprint ?? ""}`).join("\n"),
+    [sources]
+  );
+
+  const [result, setResult] = useState<FailureCountResult | undefined>(undefined);
+
+  useEffect(() => {
+    if (!settled || sources.length === 0) return;
+    let cancelled = false;
+    void readAgentCacheDirState(app, project.id, fileSnapshotNames).then((disk) => {
+      if (cancelled) return;
+      const count = disk
+        ? buildAgentProcessingItems(sources, undefined, disk, savedKeys).filter(
+            (item) => item.status === "failed"
+          ).length
+        : 0;
+      setResult({ projectId: project.id, sourceKey, liveEntry, count });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [app, project.id, sources, savedKeys, sourceKey, liveEntry, settled, fileSnapshotNames]);
+
+  // Return the cached count only when it was computed for the CURRENT project,
+  // source set, and live entry — otherwise 0 (a project/source/entry change
+  // invalidates it until the next read lands, mirroring the popover's disk lag).
+  const fresh =
+    settled &&
+    sources.length > 0 &&
+    result?.projectId === project.id &&
+    result.sourceKey === sourceKey &&
+    result.liveEntry === liveEntry;
+  return fresh ? result.count : 0;
+}
+
+interface FailureCountResult {
+  projectId: string;
+  sourceKey: string;
+  liveEntry: AgentProjectContextLoadState | undefined;
+  count: number;
+}
+
+// Referential stability: frozen/shared empties so a "no sources" render never
+// allocates a fresh collection (keeps the memo deps stable).
+const EMPTY_SOURCES = Object.freeze([] as AgentProcessingSource[]) as AgentProcessingSource[];
+const EMPTY_KEYS: ReadonlySet<string> = new Set<string>();
+const EMPTY_FILE_SNAPSHOT_NAMES: ReadonlySet<string> = new Set<string>();

--- a/src/components/project/useAgentProcessingItems.ts
+++ b/src/components/project/useAgentProcessingItems.ts
@@ -45,10 +45,12 @@ export function useAgentProcessingItems(
   contextSource: ProjectConfig["contextSource"],
   options?: { enabled?: boolean }
 ): AgentProcessingItemsState {
-  // Disabled for CAG callers: the agent read-model touches the off-vault cache
-  // (node fs, desktop-only) and the agent load atom, neither of which a CAG/chat
-  // project has. A caller that always mounts this hook (React rule) passes
-  // `enabled: false` to short-circuit it to empty without that work.
+  // Disabled for CAG callers: the agent read-model enumerates context sources and
+  // reads the off-vault cache (node fs, desktop-only), which a CAG/chat project
+  // has no use for. A caller that always mounts this hook (React rule) passes
+  // `enabled: false` to short-circuit it to a stable empty result, skipping that
+  // work. (The atom is still subscribed — hooks run unconditionally — but its
+  // value is unused when disabled, so it only costs a harmless re-render.)
   const enabled = options?.enabled ?? true;
   const loadStates = useAtomValue(agentProjectContextLoadAtom, { store: settingsStore });
   const liveEntry = enabled ? loadStates[project.id] : undefined;

--- a/src/components/project/useAgentProcessingItems.ts
+++ b/src/components/project/useAgentProcessingItems.ts
@@ -1,0 +1,109 @@
+import { agentProjectContextLoadAtom, type ProjectConfig } from "@/aiParams";
+import {
+  buildAgentProcessingItems,
+  readAgentCacheDirState,
+  type AgentCacheDirState,
+  type AgentProcessingSource,
+} from "@/components/project/agentProcessingAdapter";
+import type { ProcessingItem } from "@/components/project/processingAdapter";
+import { cacheFileName } from "@/context/contextCacheStore";
+import {
+  listMaterializeCandidates,
+  listMaterializeContextFileSummary,
+} from "@/context/materializeCandidates";
+import { settingsStore } from "@/settings/model";
+import { parseProjectUrls } from "@/utils/urlTagUtils";
+import { useAtomValue } from "jotai";
+import type { App } from "obsidian";
+import { useEffect, useMemo, useState } from "react";
+
+export interface AgentProcessingItemsState {
+  items: ProcessingItem[];
+  /** Matched `.md` files (no conversion needed) — for the "N skipped" note. */
+  skippedMarkdownCount: number;
+}
+
+/**
+ * The agent pipeline's Content Conversion read-model: synthesizes the live load
+ * atom + the off-vault conversion cache + the (possibly draft) context source into the
+ * ProcessingItem[] the status UI renders, plus the skipped-markdown count.
+ *
+ * Extracted from AgentProcessingStatusPanel so the Edit-modal panel and the
+ * standalone conversion modal share ONE data path. Reactive: a retry that
+ * updates the load atom (or rewrites a snapshot) re-renders both surfaces.
+ *
+ * `contextSource` is passed separately from `project` so the Edit modal can feed
+ * its unsaved DRAFT (newly added sources show as Queued); `project.contextSource`
+ * is the saved set used to decide which sources a run can actually see.
+ */
+export function useAgentProcessingItems(
+  app: App,
+  project: ProjectConfig,
+  contextSource: ProjectConfig["contextSource"]
+): AgentProcessingItemsState {
+  const loadStates = useAtomValue(agentProjectContextLoadAtom, { store: settingsStore });
+  const liveEntry = loadStates[project.id];
+
+  const inclusions = contextSource?.inclusions;
+  const exclusions = contextSource?.exclusions;
+  const summary = useMemo(
+    () => listMaterializeContextFileSummary(app, { inclusions, exclusions }),
+    [app, inclusions, exclusions]
+  );
+  const candidates = summary.candidates;
+
+  const sources = useMemo<AgentProcessingSource[]>(() => {
+    const urls = parseProjectUrls(contextSource?.webUrls || "", contextSource?.youtubeUrls || "");
+    return [
+      ...urls.map((u): AgentProcessingSource => ({ kind: u.type, source: u.url })),
+      ...candidates.map(
+        (f): AgentProcessingSource => ({
+          kind: "file",
+          source: f.path,
+          fingerprint: `${f.stat.mtime}:${f.stat.size}`,
+        })
+      ),
+    ];
+  }, [contextSource?.webUrls, contextSource?.youtubeUrls, candidates]);
+
+  // Sources a materialization run can actually see — i.e. the persisted config.
+  // Draft-only additions are excluded so they can't show as "processing".
+  const savedContextSource = project.contextSource;
+  const savedKeys = useMemo(() => {
+    const keys = new Set<string>();
+    const urls = parseProjectUrls(
+      savedContextSource?.webUrls || "",
+      savedContextSource?.youtubeUrls || ""
+    );
+    for (const u of urls) keys.add(u.id);
+    for (const f of listMaterializeCandidates(app, savedContextSource)) keys.add(`file:${f.path}`);
+    return keys;
+  }, [app, savedContextSource]);
+
+  const fileSnapshotNames = useMemo(
+    () => new Set(candidates.map((f) => cacheFileName("file", f.path))),
+    [candidates]
+  );
+
+  const [disk, setDisk] = useState<AgentCacheDirState | undefined>(undefined);
+  useEffect(() => {
+    // Re-read the off-vault cache whenever the live atom entry changes — not just
+    // on `phase`. A single-source retry rewrites snapshots / deletes a failure
+    // marker while leaving phase at "done", so keying on the whole entry is what
+    // lets the panel drop a now-fixed failure. The cancelled flag drops a stale read.
+    let cancelled = false;
+    void readAgentCacheDirState(app, project.id, fileSnapshotNames).then((state) => {
+      if (!cancelled) setDisk(state);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [app, project.id, fileSnapshotNames, liveEntry]);
+
+  const items = useMemo(
+    () => buildAgentProcessingItems(sources, liveEntry, disk, savedKeys),
+    [sources, liveEntry, disk, savedKeys]
+  );
+
+  return { items, skippedMarkdownCount: summary.skippedMarkdownCount };
+}

--- a/src/components/project/useAgentProcessingItems.ts
+++ b/src/components/project/useAgentProcessingItems.ts
@@ -1,6 +1,7 @@
 import { agentProjectContextLoadAtom, type ProjectConfig } from "@/aiParams";
 import {
   buildAgentProcessingItems,
+  buildAgentProcessingSources,
   readAgentCacheDirState,
   type AgentCacheDirState,
   type AgentProcessingSource,
@@ -69,16 +70,7 @@ export function useAgentProcessingItems(
   const sources = useMemo<AgentProcessingSource[]>(() => {
     if (!enabled) return [];
     const urls = parseProjectUrls(contextSource?.webUrls || "", contextSource?.youtubeUrls || "");
-    return [
-      ...urls.map((u): AgentProcessingSource => ({ kind: u.type, source: u.url })),
-      ...candidates.map(
-        (f): AgentProcessingSource => ({
-          kind: "file",
-          source: f.path,
-          fingerprint: `${f.stat.mtime}:${f.stat.size}`,
-        })
-      ),
-    ];
+    return buildAgentProcessingSources(urls, candidates);
   }, [enabled, contextSource?.webUrls, contextSource?.youtubeUrls, candidates]);
 
   // Sources a materialization run can actually see — i.e. the persisted config.

--- a/src/components/project/useAgentProcessingItems.ts
+++ b/src/components/project/useAgentProcessingItems.ts
@@ -23,6 +23,9 @@ export interface AgentProcessingItemsState {
   skippedMarkdownCount: number;
 }
 
+// Referentially stable empty so a disabled call never feeds callers a fresh [].
+const EMPTY_PROCESSING_ITEMS: ProcessingItem[] = Object.freeze([]) as unknown as ProcessingItem[];
+
 /**
  * The agent pipeline's Content Conversion read-model: synthesizes the live load
  * atom + the off-vault conversion cache + the (possibly draft) context source into the
@@ -39,20 +42,30 @@ export interface AgentProcessingItemsState {
 export function useAgentProcessingItems(
   app: App,
   project: ProjectConfig,
-  contextSource: ProjectConfig["contextSource"]
+  contextSource: ProjectConfig["contextSource"],
+  options?: { enabled?: boolean }
 ): AgentProcessingItemsState {
+  // Disabled for CAG callers: the agent read-model touches the off-vault cache
+  // (node fs, desktop-only) and the agent load atom, neither of which a CAG/chat
+  // project has. A caller that always mounts this hook (React rule) passes
+  // `enabled: false` to short-circuit it to empty without that work.
+  const enabled = options?.enabled ?? true;
   const loadStates = useAtomValue(agentProjectContextLoadAtom, { store: settingsStore });
-  const liveEntry = loadStates[project.id];
+  const liveEntry = enabled ? loadStates[project.id] : undefined;
 
-  const inclusions = contextSource?.inclusions;
-  const exclusions = contextSource?.exclusions;
+  const inclusions = enabled ? contextSource?.inclusions : undefined;
+  const exclusions = enabled ? contextSource?.exclusions : undefined;
   const summary = useMemo(
-    () => listMaterializeContextFileSummary(app, { inclusions, exclusions }),
-    [app, inclusions, exclusions]
+    () =>
+      enabled
+        ? listMaterializeContextFileSummary(app, { inclusions, exclusions })
+        : { candidates: [], skippedMarkdownCount: 0 },
+    [app, enabled, inclusions, exclusions]
   );
   const candidates = summary.candidates;
 
   const sources = useMemo<AgentProcessingSource[]>(() => {
+    if (!enabled) return [];
     const urls = parseProjectUrls(contextSource?.webUrls || "", contextSource?.youtubeUrls || "");
     return [
       ...urls.map((u): AgentProcessingSource => ({ kind: u.type, source: u.url })),
@@ -64,13 +77,14 @@ export function useAgentProcessingItems(
         })
       ),
     ];
-  }, [contextSource?.webUrls, contextSource?.youtubeUrls, candidates]);
+  }, [enabled, contextSource?.webUrls, contextSource?.youtubeUrls, candidates]);
 
   // Sources a materialization run can actually see — i.e. the persisted config.
   // Draft-only additions are excluded so they can't show as "processing".
   const savedContextSource = project.contextSource;
   const savedKeys = useMemo(() => {
     const keys = new Set<string>();
+    if (!enabled) return keys;
     const urls = parseProjectUrls(
       savedContextSource?.webUrls || "",
       savedContextSource?.youtubeUrls || ""
@@ -78,7 +92,7 @@ export function useAgentProcessingItems(
     for (const u of urls) keys.add(u.id);
     for (const f of listMaterializeCandidates(app, savedContextSource)) keys.add(`file:${f.path}`);
     return keys;
-  }, [app, savedContextSource]);
+  }, [app, enabled, savedContextSource]);
 
   const fileSnapshotNames = useMemo(
     () => new Set(candidates.map((f) => cacheFileName("file", f.path))),
@@ -87,6 +101,10 @@ export function useAgentProcessingItems(
 
   const [disk, setDisk] = useState<AgentCacheDirState | undefined>(undefined);
   useEffect(() => {
+    if (!enabled) {
+      setDisk(undefined);
+      return;
+    }
     // Re-read the off-vault cache whenever the live atom entry changes — not just
     // on `phase`. A single-source retry rewrites snapshots / deletes a failure
     // marker while leaving phase at "done", so keying on the whole entry is what
@@ -98,11 +116,14 @@ export function useAgentProcessingItems(
     return () => {
       cancelled = true;
     };
-  }, [app, project.id, fileSnapshotNames, liveEntry]);
+  }, [app, enabled, project.id, fileSnapshotNames, liveEntry]);
 
   const items = useMemo(
-    () => buildAgentProcessingItems(sources, liveEntry, disk, savedKeys),
-    [sources, liveEntry, disk, savedKeys]
+    () =>
+      enabled
+        ? buildAgentProcessingItems(sources, liveEntry, disk, savedKeys)
+        : EMPTY_PROCESSING_ITEMS,
+    [enabled, sources, liveEntry, disk, savedKeys]
   );
 
   return { items, skippedMarkdownCount: summary.skippedMarkdownCount };

--- a/src/components/ui/SearchBar.tsx
+++ b/src/components/ui/SearchBar.tsx
@@ -1,18 +1,26 @@
 import React from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { XCircle, Search } from "lucide-react";
 
 interface SearchBarProps {
   value: string;
   onChange: (value: string) => void;
   placeholder?: string;
+  /**
+   * Extra classes for the inner Input — e.g. a height override (`!tw-h-7`) for
+   * compact list contexts. The Input's base height is `!`-important, so an
+   * override must be `!`-important too (cn/tailwind-merge resolves the conflict).
+   */
+  inputClassName?: string;
 }
 
 export const SearchBar: React.FC<SearchBarProps> = ({
   value,
   onChange,
   placeholder = "Search...",
+  inputClassName,
 }) => {
   return (
     <div className="tw-relative">
@@ -21,7 +29,8 @@ export const SearchBar: React.FC<SearchBarProps> = ({
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="tw-pr-10" // Add padding to prevent text overlap with icons
+        // tw-pr-10 prevents text overlap with the trailing icons
+        className={cn("tw-pr-10", inputClassName)}
       />
       {value && (
         <Button

--- a/src/components/ui/url-tag-input.tsx
+++ b/src/components/ui/url-tag-input.tsx
@@ -38,8 +38,7 @@ export function UrlTagInput({ urls, onAdd, onRemove }: UrlTagInputProps) {
   // ("foo.com bar.com") no longer batch-adds. This is an INTENTIONAL, user-approved
   // change (chose "scheme lock"), unifying all three URL entry points to stop prose
   // tokens (`1.`, `(context.urls)`, CJK sentences) from being stored as real URLs.
-  // It is a deliberate exception to "CAG zero behavior change". If a future review
-  // flags this as a CAG regression, point them at this note.
+  // It is a deliberate exception to "CAG zero behavior change".
   const parseAndAddUrls = (text: string) => {
     // Reason: shared parser normalizes, classifies web/youtube, and dedups against
     // the current list (stable ids) — same behavior as the +URL modal / Manage panel.

--- a/src/components/ui/url-tag-input.tsx
+++ b/src/components/ui/url-tag-input.tsx
@@ -10,7 +10,7 @@
  */
 
 import { Button } from "@/components/ui/button";
-import { type UrlItem, detectUrlType, isValidUrl } from "@/utils/urlTagUtils";
+import { type UrlItem, parseUrlsFromText } from "@/utils/urlTagUtils";
 import { TruncatedText } from "@/components/TruncatedText";
 import { ClipboardPaste, Globe, Link, X } from "lucide-react";
 import React, {
@@ -27,35 +27,26 @@ interface UrlTagInputProps {
   onRemove: (id: string) => void;
 }
 
-/** Generate a short random ID */
-function generateId(): string {
-  return Math.random().toString(36).substring(2, 9);
-}
-
 export function UrlTagInput({ urls, onAdd, onRemove }: UrlTagInputProps) {
   const [inputValue, setInputValue] = useState("");
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Reason: Existing URL set for dedup — prevents duplicate entries on add
-  const existingUrls = new Set(urls.map((u) => u.url.trim()));
-
+  // DESIGN NOTE: this CAG-shared input now routes through the same scheme-anchored
+  // `parseUrlsFromText` as the agent surfaces. That tightens CAG parsing — a single
+  // bare host (example.com) still adds, but a multi-token bare-host blob
+  // ("foo.com bar.com") no longer batch-adds. This is an INTENTIONAL, user-approved
+  // change (chose "scheme lock"), unifying all three URL entry points to stop prose
+  // tokens (`1.`, `(context.urls)`, CJK sentences) from being stored as real URLs.
+  // It is a deliberate exception to "CAG zero behavior change". If a future review
+  // flags this as a CAG regression, point them at this note.
   const parseAndAddUrls = (text: string) => {
-    const urlStrings = text
-      .split(/[\n\s]+/)
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0 && isValidUrl(s));
-
-    if (urlStrings.length === 0) return;
-
-    const newUrls: UrlItem[] = [];
-    for (const raw of urlStrings) {
-      const url = raw.startsWith("http") ? raw : `https://${raw}`;
-      if (existingUrls.has(url)) continue;
-      existingUrls.add(url);
-      newUrls.push({ id: generateId(), url, type: detectUrlType(raw) });
-    }
-
+    // Reason: shared parser normalizes, classifies web/youtube, and dedups against
+    // the current list (stable ids) — same behavior as the +URL modal / Manage panel.
+    const newUrls = parseUrlsFromText(
+      text,
+      urls.map((u) => u.url)
+    );
     if (newUrls.length > 0) {
       onAdd(newUrls);
     }
@@ -74,11 +65,18 @@ export function UrlTagInput({ urls, onAdd, onRemove }: UrlTagInputProps) {
 
   const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
     const pastedText = e.clipboardData.getData("text");
-    // Reason: If paste contains multiple URLs, intercept and batch-process
-    if (pastedText.includes("\n") || pastedText.split(/\s+/).filter(isValidUrl).length > 1) {
-      e.preventDefault();
-      parseAndAddUrls(pastedText);
-    }
+    // Only intercept a multi-URL batch paste. A single URL (or text that yields
+    // none — a prose/bare-host blob, or a fragment completing a typed URL) falls
+    // through to the input so it's visible/editable, never silently swallowed and
+    // never clobbering what the user already typed.
+    const parsed = parseUrlsFromText(
+      pastedText,
+      urls.map((u) => u.url)
+    );
+    if (parsed.length <= 1) return;
+    e.preventDefault();
+    onAdd(parsed);
+    setInputValue("");
   };
 
   const handlePasteFromClipboard = async () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1067,6 +1067,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
     // disclosure lives in the Report-issue modal, shown only when the user
     // chooses to share the log.
     debugFullFrames: true,
+    welcomeDismissed: false,
     skills: {
       folder: DEFAULT_SKILLS_FOLDER,
     },

--- a/src/context/contextCacheFs.test.ts
+++ b/src/context/contextCacheFs.test.ts
@@ -1,0 +1,111 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createNodeContextCacheFs } from "./contextCacheFs";
+
+describe("createNodeContextCacheFs", () => {
+  let parent: string;
+  let root: string;
+
+  beforeEach(async () => {
+    // `parent` stands in for `vaults/<id>/`; `root` is the cache dir inside it.
+    parent = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ctx-cache-fs-"));
+    root = path.join(parent, "context-cache");
+    await fs.promises.mkdir(root, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(parent, { recursive: true, force: true });
+  });
+
+  it("writes atomically and reads back the content (no temp left behind)", async () => {
+    const cache = createNodeContextCacheFs(root);
+    await cache.mkdirRecursive("remotes");
+    await cache.writeText("remotes/web-1.md", "hello");
+
+    expect(await cache.readText("remotes/web-1.md")).toBe("hello");
+    // Only the final file — the staging temp must have been renamed away.
+    expect(await fs.promises.readdir(path.join(root, "remotes"))).toEqual(["web-1.md"]);
+  });
+
+  it("list returns basenames and ignores in-progress temp files", async () => {
+    const cache = createNodeContextCacheFs(root);
+    await cache.mkdirRecursive("remotes");
+    await cache.writeText("remotes/web-1.md", "a");
+    // Simulate a temp left by a crashed/concurrent write.
+    await fs.promises.writeFile(path.join(root, "remotes", ".copilot-cache-tmp-web-2.md-7"), "x");
+
+    expect(await cache.list("remotes")).toEqual(["web-1.md"]);
+  });
+
+  it("list returns [] for a missing directory", async () => {
+    const cache = createNodeContextCacheFs(root);
+    expect(await cache.list("does-not-exist")).toEqual([]);
+  });
+
+  it("remove is idempotent on a missing file", async () => {
+    const cache = createNodeContextCacheFs(root);
+    await expect(cache.remove("remotes/gone.md")).resolves.toBeUndefined();
+  });
+
+  it("rejects a `..` segment before touching the filesystem (root-confined)", async () => {
+    const cache = createNodeContextCacheFs(root);
+    await expect(cache.writeText("../escape.md", "x")).rejects.toThrow('".." segment');
+    // The escape target must not have been created in the parent.
+    await expect(fs.promises.readdir(parent)).resolves.not.toContain("escape.md");
+  });
+
+  it("rejects an absolute path", async () => {
+    const cache = createNodeContextCacheFs(root);
+    await expect(cache.writeText(path.join(parent, "abs.md"), "x")).rejects.toThrow("absolute");
+  });
+
+  it("refuses to write the cache root itself (no temp leaks into the parent)", async () => {
+    const cache = createNodeContextCacheFs(root);
+    await expect(cache.writeText("", "x")).rejects.toThrow("cache root");
+    // Nothing staged into the parent `vaults/<id>/` stand-in.
+    expect(await fs.promises.readdir(parent)).toEqual(["context-cache"]);
+  });
+
+  it("exists returns false for a missing entry and true for a written one", async () => {
+    const cache = createNodeContextCacheFs(root);
+    expect(await cache.exists("remotes/web-1.md")).toBe(false);
+    await cache.mkdirRecursive("remotes");
+    await cache.writeText("remotes/web-1.md", "a");
+    expect(await cache.exists("remotes/web-1.md")).toBe(true);
+  });
+
+  it("readText surfaces a missing-file error (symmetric with the vault adapter)", async () => {
+    const cache = createNodeContextCacheFs(root);
+    await expect(cache.readText("remotes/missing.md")).rejects.toBeDefined();
+  });
+
+  it("write throws (does not swallow) when the target directory is missing", async () => {
+    const cache = createNodeContextCacheFs(root);
+    // No mkdir for `remotes` → staging the temp fails. The error must surface
+    // so the caller records a per-source failure instead of a silent success.
+    await expect(cache.writeText("remotes/web-1.md", "x")).rejects.toBeDefined();
+    // And no half-written temp is left lingering at the root.
+    expect(await fs.promises.readdir(root)).toEqual([]);
+  });
+
+  it("clear wipes the cache root but never ascends to the parent vault dir", async () => {
+    const cache = createNodeContextCacheFs(root);
+    await cache.mkdirRecursive("remotes");
+    await cache.writeText("remotes/web-1.md", "a");
+    // A sibling of `root` standing in for `agent-chat-index.json`.
+    const sibling = path.join(parent, "agent-chat-index.json");
+    await fs.promises.writeFile(sibling, "{}");
+
+    await cache.clear();
+
+    expect(fs.existsSync(root)).toBe(false);
+    expect(fs.existsSync(sibling)).toBe(true);
+  });
+
+  it("clear on an already-missing root is a no-op", async () => {
+    const cache = createNodeContextCacheFs(root);
+    await fs.promises.rm(root, { recursive: true, force: true });
+    await expect(cache.clear()).resolves.toBeUndefined();
+  });
+});

--- a/src/context/contextCacheFs.ts
+++ b/src/context/contextCacheFs.ts
@@ -1,0 +1,197 @@
+/**
+ * Minimal filesystem surface the project-context materializer needs. Kept as an
+ * injectable interface so the cache logic stays pure and unit-testable with an
+ * in-memory fake — the only production implementation,
+ * {@link createNodeContextCacheFs}, loads `node:fs` lazily at the desktop edge.
+ *
+ * All paths are **cache-root-relative**, POSIX-separated (the node backend
+ * resolves them under the off-vault cache root). Keeping the interface itself
+ * free of Node builtins lets node-free, mobile-reachable code import the TYPE
+ * without pulling `node:fs` into the bundle.
+ */
+export interface ContextCacheFs {
+  exists(path: string): Promise<boolean>;
+  mkdirRecursive(path: string): Promise<void>;
+  /** Shallow directory listing (entry names only). Returns `[]` when missing. */
+  list(path: string): Promise<string[]>;
+  readText(path: string): Promise<string>;
+  writeText(path: string, content: string): Promise<void>;
+  /** Idempotent delete — a missing path is not an error. */
+  remove(path: string): Promise<void>;
+}
+
+/**
+ * {@link ContextCacheFs} plus the destructive `clear` the off-vault node
+ * backend needs. Kept separate from the base interface so the vault adapter
+ * (which must never wipe a whole tree) is not forced to implement it.
+ */
+export interface NodeContextCacheFs extends ContextCacheFs {
+  /**
+   * Recursively delete the entire cache root. Root-confined by construction:
+   * it targets `root` itself and never ascends to the parent `vaults/<id>/`,
+   * which also hosts `agent-chat-index.json`. Best-effort: a missing root is a
+   * no-op.
+   */
+  clear(): Promise<void>;
+}
+
+/**
+ * Hidden filename prefix marking an in-progress atomic write. {@link list}
+ * filters these out so a half-written snapshot never appears as a real entry.
+ */
+const ATOMIC_TEMP_PREFIX = ".copilot-cache-tmp-";
+
+/** Monotonic suffix making concurrent temp filenames in one directory unique. */
+let atomicTempSeq = 0;
+
+/**
+ * Production {@link ContextCacheFs} backed by `node:fs`, rooted at the absolute
+ * off-vault cache directory (see {@link import("./conversionsLocation")}).
+ * Unlike the vault adapter, all paths are **cache-root-relative** — absolute
+ * paths are resolved only in `conversionsLocation` — and every operation is
+ * confined under `root`.
+ *
+ * `node:fs` / `node:path` are loaded lazily (via `require`) inside the factory,
+ * not at module top-level. Reason: this file also exports the node-free
+ * {@link ContextCacheFs} interface; a top-level `import "node:fs"` would
+ * evaluate Node builtins for *any* importer of this module — including
+ * mobile-reachable code that only needs the type — and crash Obsidian mobile at
+ * bundle load. The factory is invoked only behind the desktop Agent boundary,
+ * so the `require` runs desktop-only.
+ *
+ * Best-effort policy (deliberately split, per the cache design):
+ *  - `writeText` / `mkdirRecursive` **throw** on failure. A swallowed write
+ *    would let the store report success while the file is missing, leaving a
+ *    manifest entry that points at an empty snapshot. The materializer turns
+ *    these throws into a per-source failure (write) or a whole-round cache
+ *    degradation (mkdir) — the fs layer must not fake success.
+ *  - `list` / `remove` / `clear` tolerate a missing target (`[]` / idempotent).
+ */
+export function createNodeContextCacheFs(root: string): NodeContextCacheFs {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
+  const fs = require("node:fs") as typeof import("node:fs");
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
+  const nodePath = require("node:path") as typeof import("node:path");
+
+  const rootAbs = nodePath.resolve(root);
+
+  /**
+   * Atomic rename with a short retry. Inlined rather than imported from
+   * `@/agentMode/skills/renameWithRetry` because the module-boundary rules
+   * forbid `src/context` (host layer) from depending on `src/agentMode/skills`.
+   * The rationale is identical: a Windows vault watcher / AV can briefly hold
+   * the destination handle, and a short wait usually clears it.
+   */
+  const renameWithRetry = async (from: string, to: string, attempts = 3): Promise<void> => {
+    let lastErr: unknown;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        await fs.promises.rename(from, to);
+        return;
+      } catch (e) {
+        lastErr = e;
+        await new Promise((resolve) => window.setTimeout(resolve, 200));
+      }
+    }
+    throw lastErr;
+  };
+
+  /**
+   * Resolve a cache-root-relative path to an absolute path, failing loud if it
+   * would escape `root`: a `..`, an absolute input, or a resolved path outside
+   * `root` is rejected rather than allowed to land somewhere unexpected (e.g.
+   * the parent `vaults/<id>/`).
+   *
+   * Symlink escape is intentionally out of scope: every `cachePath` is
+   * plugin-derived (fixed bucket names + md5 snapshot/marker filenames; user
+   * input is hashed before it becomes a path segment), so no caller can inject
+   * one. Following a pre-seeded symlink would require a local actor with write
+   * access to this plugin-owned off-vault directory — already outside this
+   * layer's threat model — so we skip the per-op `realpath`/`lstat` cost on the
+   * cache hot path. If a future review flags this again, point them here.
+   */
+  const resolveWithin = (cachePath: string): string => {
+    if (cachePath.split(/[\\/]+/).includes("..")) {
+      throw new Error(`unsafe context-cache path (".." segment): ${cachePath}`);
+    }
+    if (nodePath.isAbsolute(cachePath)) {
+      throw new Error(`unsafe context-cache path (absolute): ${cachePath}`);
+    }
+    const resolved = nodePath.resolve(rootAbs, cachePath);
+    const rel = nodePath.relative(rootAbs, resolved);
+    if (rel === "" || (!rel.startsWith("..") && !nodePath.isAbsolute(rel))) {
+      return resolved;
+    }
+    throw new Error(`unsafe context-cache path (escapes root): ${cachePath}`);
+  };
+
+  const removeBestEffort = async (target: string, recursive: boolean): Promise<void> => {
+    try {
+      await fs.promises.rm(target, { recursive, force: true });
+    } catch {
+      // Best-effort: the cache is regenerable and deletes are idempotent.
+    }
+  };
+
+  return {
+    async exists(cachePath) {
+      const resolved = resolveWithin(cachePath);
+      try {
+        await fs.promises.stat(resolved);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async mkdirRecursive(cachePath) {
+      await fs.promises.mkdir(resolveWithin(cachePath), { recursive: true });
+    },
+    async list(cachePath) {
+      const resolved = resolveWithin(cachePath);
+      try {
+        const entries = await fs.promises.readdir(resolved);
+        return entries.filter((entry) => !entry.startsWith(ATOMIC_TEMP_PREFIX));
+      } catch {
+        return [];
+      }
+    },
+    async readText(cachePath) {
+      return fs.promises.readFile(resolveWithin(cachePath), "utf-8");
+    },
+    async writeText(cachePath, content) {
+      // Atomic write: stage into a same-dir temp then rename over the target,
+      // so a concurrent reader never sees a partial snapshot. The rename is
+      // retried (renameWithRetry) because Windows watchers/AV can briefly hold
+      // a handle. We do NOT fsync — the cache is regenerable.
+      const target = resolveWithin(cachePath);
+      if (target === rootAbs) {
+        // A write target must be a *file under* root. Refusing the root itself
+        // keeps the staging temp — created in the target's parent dir — from
+        // ever landing in the parent `vaults/<id>/`.
+        throw new Error(`refusing to write the cache root itself: ${cachePath}`);
+      }
+      // Temp name carries a timestamp + random suffix (not just an in-process
+      // counter) so two Obsidian instances staging the same target on one vault
+      // don't collide on the temp file and corrupt each other's atomic write.
+      const temp = nodePath.join(
+        nodePath.dirname(target),
+        `${ATOMIC_TEMP_PREFIX}${nodePath.basename(target)}-${Date.now()}-${(atomicTempSeq++).toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+      );
+      try {
+        await fs.promises.writeFile(temp, content, "utf-8");
+        await renameWithRetry(temp, target);
+      } catch (error) {
+        // Never leave a half-written temp behind, then propagate so the caller
+        // records a per-source failure.
+        await removeBestEffort(temp, false);
+        throw error;
+      }
+    },
+    async remove(cachePath) {
+      await removeBestEffort(resolveWithin(cachePath), false);
+    },
+    async clear() {
+      await removeBestEffort(rootAbs, true);
+    },
+  };
+}

--- a/src/context/contextCacheFs.ts
+++ b/src/context/contextCacheFs.ts
@@ -108,7 +108,7 @@ export function createNodeContextCacheFs(root: string): NodeContextCacheFs {
    * one. Following a pre-seeded symlink would require a local actor with write
    * access to this plugin-owned off-vault directory — already outside this
    * layer's threat model — so we skip the per-op `realpath`/`lstat` cost on the
-   * cache hot path. If a future review flags this again, point them here.
+   * cache hot path.
    */
   const resolveWithin = (cachePath: string): string => {
     if (cachePath.split(/[\\/]+/).includes("..")) {

--- a/src/context/contextCacheStore.test.ts
+++ b/src/context/contextCacheStore.test.ts
@@ -1,0 +1,697 @@
+import { Mutex } from "async-mutex";
+import { join } from "node:path";
+import type { ContextCacheFs } from "./contextCacheFs";
+import {
+  materializeSources,
+  reconcileMarkers,
+  type ContextConverters,
+  type FileSource,
+  type MaterializeProgress,
+  type RemoteSource,
+} from "./contextCacheStore";
+
+/** Minimal in-memory {@link ContextCacheFs} for deterministic, network-free tests. */
+function memFs(seed: Record<string, string> = {}): ContextCacheFs & { files: Map<string, string> } {
+  const files = new Map<string, string>(Object.entries(seed));
+  return {
+    files,
+    async exists(p) {
+      return files.has(p);
+    },
+    async mkdirRecursive() {
+      // no-op: the flat map needs no directories
+    },
+    async list(dir) {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      return [...files.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .map((k) => k.slice(prefix.length))
+        .filter((name) => !name.includes("/"));
+    },
+    async readText(p) {
+      if (!files.has(p)) throw new Error(`ENOENT: ${p}`);
+      return files.get(p)!;
+    },
+    async writeText(p, content) {
+      files.set(p, content);
+    },
+    async remove(p) {
+      files.delete(p);
+    },
+  };
+}
+
+// Snapshots are shared vault-wide (remotes/files); markers are bucketed per
+// project. Keep three distinct dirs so a misrouted write surfaces immediately.
+const REMOTES_DIR = "/cache/remotes";
+const FILES_DIR = "/cache/files";
+const MARKER_DIR = "/cache/markers/projA";
+const MARKER_DIR_B = "/cache/markers/projB";
+const DIRS = { remotesDir: REMOTES_DIR, filesDir: FILES_DIR, markerDir: MARKER_DIR };
+const T0 = 1_700_000_000_000;
+const DAY = 24 * 60 * 60 * 1000;
+
+/** A real per-artifact lock (mirrors the materializer's global injection). */
+function sharedLock(): <T>(key: string, run: () => Promise<T>) => Promise<T> {
+  const mutexes = new Map<string, Mutex>();
+  return (key, run) => {
+    let mutex = mutexes.get(key);
+    if (!mutex) {
+      mutex = new Mutex();
+      mutexes.set(key, mutex);
+    }
+    return mutex.runExclusive(run);
+  };
+}
+
+function converters(overrides: Partial<ContextConverters> = {}): ContextConverters {
+  return {
+    fetchRemote: jest.fn(async (s: RemoteSource) => `content for ${s.url}`),
+    parseFile: jest.fn(async (_bytes: ArrayBuffer, ext: string) => `parsed ${ext}`),
+    ...overrides,
+  };
+}
+
+function fileSource(over: Partial<FileSource> = {}): FileSource {
+  return {
+    vaultPath: "Proj/doc.pdf",
+    ext: "pdf",
+    mtime: 1000,
+    size: 50,
+    read: jest.fn(async () => new ArrayBuffer(8)),
+    ...over,
+  };
+}
+
+const flushMicrotasks = () => new Promise((resolve) => window.setTimeout(resolve, 0));
+
+describe("materializeSources", () => {
+  it("writes remote snapshots to remotesDir and file snapshots to filesDir", async () => {
+    const fs = memFs();
+    const remotes: RemoteSource[] = [
+      { type: "web", url: "https://a.com" },
+      { type: "youtube", url: "https://youtu.be/x" },
+    ];
+    const { entries } = await materializeSources({
+      ...DIRS,
+      fs,
+      converters: converters(),
+      remotes,
+      files: [fileSource()],
+      nowMs: T0,
+    });
+
+    expect(entries).toHaveLength(3);
+    // Remote snapshots live under remotesDir, the file snapshot under filesDir.
+    const written = [...fs.files.keys()];
+    expect(written.filter((p) => p.startsWith(`${REMOTES_DIR}/`))).toHaveLength(2);
+    expect(written.filter((p) => p.startsWith(`${FILES_DIR}/`))).toHaveLength(1);
+
+    const webEntry = entries.find((e) => e.type === "web")!;
+    const body = fs.files.get(join(REMOTES_DIR, webEntry.cacheFileName))!;
+    expect(body).toContain("copilot-context-cache");
+    expect(body).toContain('"sourceUrl":"https://a.com"');
+    expect(body).toContain("content for https://a.com");
+  });
+
+  it("names snapshots by md5 of the source (lowercase 32-hex)", async () => {
+    const fs = memFs();
+    const { entries } = await materializeSources({
+      ...DIRS,
+      fs,
+      converters: converters(),
+      remotes: [{ type: "web", url: "https://a.com" }],
+      files: [],
+      nowMs: T0,
+    });
+    // md5 hex is 32 lowercase chars — distinct from the old cyrb53 14-char hash.
+    expect(entries[0].cacheFileName).toMatch(/^web-[0-9a-f]{32}\.md$/);
+  });
+
+  it("cheap-skips an unchanged successful source indefinitely (no re-fetch / re-parse)", async () => {
+    const fs = memFs();
+    const conv = converters();
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://a.com" }];
+    const file = fileSource();
+
+    await materializeSources({ ...DIRS, fs, converters: conv, remotes, files: [file], nowMs: T0 }); // prettier-ignore
+    // Second pass far in the future: a successful snapshot has no TTL, so its
+    // identity / fingerprint match still cheap-skips both the fetch and parse.
+    await materializeSources({ ...DIRS, fs, converters: conv, remotes, files: [file], nowMs: T0 + 365 * DAY }); // prettier-ignore
+
+    expect(conv.fetchRemote).toHaveBeenCalledTimes(1);
+    expect(conv.parseFile).toHaveBeenCalledTimes(1);
+  });
+
+  it("stamps the cache schema version into written snapshots", async () => {
+    const fs = memFs();
+    const { entries } = await materializeSources({
+      ...DIRS,
+      fs,
+      converters: converters(),
+      remotes: [{ type: "web", url: "https://a.com" }],
+      files: [],
+      nowMs: T0,
+    });
+    expect(fs.files.get(join(REMOTES_DIR, entries[0].cacheFileName))!).toContain('"schemaVersion":1'); // prettier-ignore
+  });
+
+  it("re-materializes a snapshot whose schema version no longer matches (not cheap-skipped)", async () => {
+    const fs = memFs();
+    const conv = converters();
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://a.com" }];
+
+    const { entries } = await materializeSources({ ...DIRS, fs, converters: conv, remotes, files: [], nowMs: T0 }); // prettier-ignore
+    // Simulate a future format change: an on-disk snapshot from a different
+    // schema version. The version gate must treat it as a miss, not cheap-skip.
+    const key = join(REMOTES_DIR, entries[0].cacheFileName);
+    fs.files.set(key, fs.files.get(key)!.replace('"schemaVersion":1', '"schemaVersion":999'));
+
+    await materializeSources({ ...DIRS, fs, converters: conv, remotes, files: [], nowMs: T0 + DAY }); // prettier-ignore
+
+    expect(conv.fetchRemote).toHaveBeenCalledTimes(2); // re-fetched, not skipped
+  });
+
+  it("re-parses a file when its mtime/size fingerprint changes", async () => {
+    const fs = memFs();
+    const conv = converters();
+
+    await materializeSources({ ...DIRS, fs, converters: conv, remotes: [], files: [fileSource({ mtime: 1000, size: 50 })], nowMs: T0 }); // prettier-ignore
+    await materializeSources({ ...DIRS, fs, converters: conv, remotes: [], files: [fileSource({ mtime: 2000, size: 50 })], nowMs: T0 }); // prettier-ignore
+
+    expect(conv.parseFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a stale file snapshot when a re-parse fails", async () => {
+    const fs = memFs();
+    const good = converters();
+    await materializeSources({ ...DIRS, fs, converters: good, remotes: [], files: [fileSource({ mtime: 1000, size: 50 })], nowMs: T0 }); // prettier-ignore
+    const fileName = [...fs.files.keys()].find((k) => k.includes("file-"))!;
+    const staleBody = fs.files.get(fileName)!;
+
+    const failing = converters({
+      parseFile: jest.fn(async () => {
+        throw new Error("bad parse");
+      }),
+    });
+    const { entries, failures } = await materializeSources({
+      ...DIRS,
+      fs,
+      converters: failing,
+      remotes: [],
+      files: [fileSource({ mtime: 2000, size: 99 })], // edited → re-parse attempted
+      nowMs: T0 + 1,
+    });
+
+    expect(failing.parseFile).toHaveBeenCalledTimes(1);
+    expect(entries).toHaveLength(1); // stale entry still counts as present
+    expect(fs.files.get(fileName)).toBe(staleBody); // content untouched
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({ source: "Proj/doc.pdf", kind: "file", usedStaleSnapshot: true }); // prettier-ignore
+    expect(failures[0].error).toContain("bad parse");
+    // No failure marker is written when a stale snapshot remains usable.
+    expect([...fs.files.keys()].some((k) => k.includes("failed-"))).toBe(false);
+  });
+
+  it("skips a brand-new source whose fetch fails (no file written) and writes a marker in markerDir", async () => {
+    const fs = memFs();
+    const failing = converters({
+      fetchRemote: jest.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const { entries, failures, wantedMarkerNames } = await materializeSources({
+      ...DIRS,
+      fs,
+      converters: failing,
+      remotes: [{ type: "web", url: "https://a.com" }],
+      files: [],
+      nowMs: T0,
+    });
+
+    expect(entries).toHaveLength(0);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({ source: "https://a.com", kind: "web", usedStaleSnapshot: false }); // prettier-ignore
+    expect(failures[0].error).toContain("boom");
+    // The marker lives under the per-project markerDir, and it is wanted so a
+    // same-run reconcile keeps it (the status panel reads it to surface the error).
+    const marker = [...fs.files.keys()].find((k) => k.includes("failed-web-"))!;
+    expect(marker.startsWith(`${MARKER_DIR}/`)).toBe(true);
+    expect(wantedMarkerNames.has(marker.slice(`${MARKER_DIR}/`.length))).toBe(true);
+  });
+
+  it("cheap-skips a known-bad remote on the next automatic run (no re-fetch) but still surfaces it", async () => {
+    const fs = memFs();
+    const failing = converters({
+      fetchRemote: jest.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://a.com" }];
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes, files: [], nowMs: T0 }); // prettier-ignore
+    const { failures, wantedMarkerNames } = await materializeSources({
+      ...DIRS,
+      fs,
+      converters: failing,
+      remotes,
+      files: [],
+      nowMs: T0 + 1,
+    });
+
+    expect(failing.fetchRemote).toHaveBeenCalledTimes(1);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({ source: "https://a.com", kind: "web", usedStaleSnapshot: false }); // prettier-ignore
+    expect(failures[0].error).toContain("boom");
+    const markerKey = [...fs.files.keys()].find((k) => k.includes("failed-web-"))!;
+    expect(wantedMarkerNames.has(markerKey.slice(`${MARKER_DIR}/`.length))).toBe(true);
+  });
+
+  it("emits no itemStart/itemFailed for a cheap-skipped failed source", async () => {
+    const fs = memFs();
+    const failing = converters({
+      fetchRemote: jest.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://a.com" }];
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes, files: [], nowMs: T0 }); // prettier-ignore
+    const events: MaterializeProgress[] = [];
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes, files: [], nowMs: T0 + 1, onProgress: (p) => events.push(p) }); // prettier-ignore
+    expect(events.some((p) => p.phase.startsWith("item"))).toBe(false);
+  });
+
+  it("re-fetches a known-bad remote when forceRetryFailed is set", async () => {
+    const fs = memFs();
+    const failing = converters({
+      fetchRemote: jest.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://a.com" }];
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes, files: [], nowMs: T0 }); // prettier-ignore
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes, files: [], nowMs: T0 + 1, forceRetryFailed: true }); // prettier-ignore
+
+    expect(failing.fetchRemote).toHaveBeenCalledTimes(2);
+  });
+
+  it("cheap-skips a known-bad file on the next automatic run while unchanged", async () => {
+    const fs = memFs();
+    const failing = converters({
+      parseFile: jest.fn(async () => {
+        throw new Error("bad parse");
+      }),
+    });
+    const file = fileSource({ mtime: 1000, size: 50 });
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes: [], files: [file], nowMs: T0 }); // prettier-ignore
+    const { failures } = await materializeSources({ ...DIRS, fs, converters: failing, remotes: [], files: [file], nowMs: T0 + 1 }); // prettier-ignore
+
+    expect(failing.parseFile).toHaveBeenCalledTimes(1); // marker honored, no re-parse
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({ source: "Proj/doc.pdf", kind: "file", usedStaleSnapshot: false }); // prettier-ignore
+  });
+
+  it("re-parses a known-bad file when its mtime/size fingerprint changes (marker stale)", async () => {
+    const fs = memFs();
+    const failing = converters({
+      parseFile: jest.fn(async () => {
+        throw new Error("bad parse");
+      }),
+    });
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes: [], files: [fileSource({ mtime: 1000, size: 50 })], nowMs: T0 }); // prettier-ignore
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes: [], files: [fileSource({ mtime: 2000, size: 99 })], nowMs: T0 + 1 }); // prettier-ignore
+
+    expect(failing.parseFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-parses a known-bad file when its marker predates the fingerprint field", async () => {
+    const fs = memFs();
+    const failing = converters({
+      parseFile: jest.fn(async () => {
+        throw new Error("bad parse");
+      }),
+    });
+    const file = fileSource({ mtime: 1000, size: 50 });
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes: [], files: [file], nowMs: T0 }); // prettier-ignore
+    // Simulate a legacy marker written before the fingerprint field: strip it.
+    const markerKey = [...fs.files.keys()].find((k) => k.includes("failed-file-"))!;
+    const legacy = JSON.parse(fs.files.get(markerKey)!) as Record<string, unknown>;
+    delete legacy.fingerprint;
+    fs.files.set(markerKey, JSON.stringify(legacy));
+
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes: [], files: [file], nowMs: T0 + 1 }); // prettier-ignore
+    expect(failing.parseFile).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not honor a failure marker while a stale snapshot still exists (existing !== null wins)", async () => {
+    const fs = memFs();
+    await materializeSources({ ...DIRS, fs, converters: converters(), remotes: [], files: [fileSource({ mtime: 1000, size: 50 })], nowMs: T0 }); // prettier-ignore
+    const failing = converters({
+      parseFile: jest.fn(async () => {
+        throw new Error("bad parse");
+      }),
+    });
+    const { entries, failures } = await materializeSources({ ...DIRS, fs, converters: failing, remotes: [], files: [fileSource({ mtime: 2000, size: 99 })], nowMs: T0 + 1 }); // prettier-ignore
+
+    expect(failing.parseFile).toHaveBeenCalledTimes(1); // re-attempted, not marker-skipped
+    expect(entries).toHaveLength(1); // stale snapshot still present
+    expect(failures[0]).toMatchObject({ usedStaleSnapshot: true });
+    expect([...fs.files.keys()].some((k) => k.includes("failed-"))).toBe(false);
+  });
+
+  it("keeps a newly-written failure marker wanted so a same-run reconcile can't delete it", async () => {
+    const fs = memFs();
+    const failing = converters({
+      fetchRemote: jest.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://a.com" }];
+    const { wantedMarkerNames } = await materializeSources({
+      ...DIRS,
+      fs,
+      converters: failing,
+      remotes,
+      files: [],
+      nowMs: T0,
+    });
+    const markerKey = [...fs.files.keys()].find((k) => k.includes("failed-web-"))!;
+    expect(markerKey).toBeDefined();
+    expect(wantedMarkerNames.has(markerKey.slice(`${MARKER_DIR}/`.length))).toBe(true);
+    await reconcileMarkers(fs, MARKER_DIR, wantedMarkerNames);
+    expect(fs.files.has(markerKey)).toBe(true); // survived the reconcile
+  });
+
+  it("clears the failure marker once a previously-failed source succeeds", async () => {
+    const fs = memFs();
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://a.com" }];
+    const failing = converters({
+      fetchRemote: jest.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes, files: [], nowMs: T0 }); // prettier-ignore
+    expect([...fs.files.keys()].some((k) => k.includes("failed-web-"))).toBe(true);
+
+    const { entries, failures } = await materializeSources({
+      ...DIRS,
+      fs,
+      converters: converters(),
+      remotes,
+      files: [],
+      nowMs: T0 + 1,
+      forceRetryFailed: true,
+    });
+    expect(entries).toHaveLength(1);
+    expect(failures).toHaveLength(0);
+    expect([...fs.files.keys()].some((k) => k.includes("failed-web-"))).toBe(false);
+  });
+
+  it("deduplicates repeated sources to a single cache file", async () => {
+    const fs = memFs();
+    const conv = converters();
+    await materializeSources({
+      ...DIRS,
+      fs,
+      converters: conv,
+      remotes: [
+        { type: "web", url: "https://a.com" },
+        { type: "web", url: "https://a.com" },
+      ],
+      files: [],
+      nowMs: T0,
+    });
+    expect(conv.fetchRemote).toHaveBeenCalledTimes(1);
+    expect([...fs.files.keys()]).toHaveLength(1);
+  });
+
+  it("emits per-item onProgress for each loop with deduped totals", async () => {
+    const fs = memFs();
+    const progress: MaterializeProgress[] = [];
+    await materializeSources({
+      ...DIRS,
+      fs,
+      converters: converters(),
+      remotes: [
+        { type: "web", url: "https://a.com" },
+        { type: "web", url: "https://a.com" }, // duplicate → deduped to total 1
+        { type: "youtube", url: "https://youtu.be/x" },
+      ],
+      files: [fileSource()],
+      nowMs: T0,
+      onProgress: (p) => progress.push(p),
+    });
+
+    expect(progress.filter((p) => p.phase === "prefetch")).toEqual([
+      { phase: "prefetch", done: 0, total: 2 },
+      { phase: "prefetch", done: 1, total: 2 },
+      { phase: "prefetch", done: 2, total: 2 },
+    ]);
+    expect(progress.filter((p) => p.phase === "parse")).toEqual([
+      { phase: "parse", done: 0, total: 1 },
+      { phase: "parse", done: 1, total: 1 },
+    ]);
+  });
+
+  it("emits itemStart/itemSettled only for sources that do work (cheap-skips stay silent)", async () => {
+    const fs = memFs();
+    const conv = converters();
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://a.com" }];
+    const first: MaterializeProgress[] = [];
+    await materializeSources({ ...DIRS, fs, converters: conv, remotes, files: [], nowMs: T0, onProgress: (p) => first.push(p) }); // prettier-ignore
+    expect(first.filter((p) => p.phase === "itemStart")).toEqual([
+      { phase: "itemStart", item: { kind: "web", source: "https://a.com" } },
+    ]);
+    expect(first.some((p) => p.phase === "itemSettled")).toBe(true);
+
+    const second: MaterializeProgress[] = [];
+    await materializeSources({ ...DIRS, fs, converters: conv, remotes, files: [], nowMs: T0 + 1, onProgress: (p) => second.push(p) }); // prettier-ignore
+    expect(second.some((p) => p.phase.startsWith("item"))).toBe(false);
+  });
+
+  it("emits itemFailed (carrying the error) for a failed source, never itemSettled", async () => {
+    const fs = memFs();
+    const failing = converters({
+      fetchRemote: jest.fn(async () => {
+        throw new Error("boom");
+      }),
+    });
+    const events: MaterializeProgress[] = [];
+    await materializeSources({ ...DIRS, fs, converters: failing, remotes: [{ type: "web", url: "https://a.com" }], files: [], nowMs: T0, onProgress: (p) => events.push(p) }); // prettier-ignore
+    expect(events.filter((p) => p.phase.startsWith("item")).map((p) => p.phase)).toEqual([
+      "itemStart",
+      "itemFailed",
+    ]);
+    const failed = events.find((p) => p.phase === "itemFailed");
+    expect(failed?.phase).toBe("itemFailed");
+    if (failed?.phase === "itemFailed") {
+      expect(failed.item).toEqual({ kind: "web", source: "https://a.com" });
+      expect(failed.failure.error).toContain("boom");
+    }
+  });
+
+  it("fetches URLs in parallel — both are in flight before either settles", async () => {
+    const fs = memFs();
+    const gates: Record<string, () => void> = {};
+    const inFlight: string[] = [];
+    const conv = converters({
+      fetchRemote: jest.fn(async (s: RemoteSource) => {
+        inFlight.push(s.url);
+        await new Promise<void>((resolve) => {
+          gates[s.url] = resolve;
+        });
+        return `content ${s.url}`;
+      }),
+    });
+    const done = materializeSources({ ...DIRS, fs, converters: conv, remotes: [{ type: "web", url: "https://a.com" }, { type: "web", url: "https://b.com" }], files: [], nowMs: T0 }); // prettier-ignore
+    await flushMicrotasks();
+    expect(new Set(inFlight)).toEqual(new Set(["https://a.com", "https://b.com"]));
+    gates["https://a.com"]();
+    gates["https://b.com"]();
+    await done;
+  });
+
+  it("isolates a marker-write failure to its own source — the parallel run still resolves", async () => {
+    const fs = memFs();
+    const writeText = fs.writeText;
+    fs.writeText = async (p: string, content: string) => {
+      if (p.includes("failed-")) throw new Error("disk full");
+      await writeText(p, content);
+    };
+    let releaseB!: () => void;
+    const bGate = new Promise<void>((resolve) => {
+      releaseB = resolve;
+    });
+    const conv = converters({
+      fetchRemote: jest.fn(async (s: RemoteSource) => {
+        if (s.url === "https://a.com") throw new Error("net down");
+        await bGate; // keep B in flight until A has already failed its marker write
+        return `content ${s.url}`;
+      }),
+    });
+    const events: MaterializeProgress[] = [];
+    const done = materializeSources({ ...DIRS, fs, converters: conv, remotes: [{ type: "web", url: "https://a.com" }, { type: "web", url: "https://b.com" }], files: [], nowMs: T0, onProgress: (p) => events.push(p) }); // prettier-ignore
+    await flushMicrotasks();
+    releaseB();
+    const result = await done;
+
+    expect(result.failures.map((f) => f.source)).toEqual(["https://a.com"]);
+    expect(result.entries.map((e) => e.source)).toEqual(["https://b.com"]);
+
+    const itemPhasesFor = (url: string) =>
+      events.filter((p) => "item" in p && p.item.source === url).map((p) => p.phase);
+    expect(itemPhasesFor("https://a.com")).toEqual(["itemStart", "itemFailed"]);
+    expect(itemPhasesFor("https://b.com")).toEqual(["itemStart", "itemSettled"]);
+    const prefetch = events.filter((p) => p.phase === "prefetch");
+    expect(prefetch[prefetch.length - 1]).toEqual({ phase: "prefetch", done: 2, total: 2 });
+  });
+
+  it("omits onProgress for an empty loop", async () => {
+    const fs = memFs();
+    const progress: MaterializeProgress[] = [];
+    await materializeSources({
+      ...DIRS,
+      fs,
+      converters: converters(),
+      remotes: [{ type: "web", url: "https://a.com" }],
+      files: [],
+      nowMs: T0,
+      onProgress: (p) => progress.push(p),
+    });
+    expect(progress.some((p) => p.phase === "parse")).toBe(false);
+  });
+});
+
+describe("materializeSources — per-artifact lock (cross-project dedup)", () => {
+  it("merges two projects cold-converting the same URL into one fetch; the second does not overwrite", async () => {
+    // Two projects share the same fs + remotesDir but have distinct markerDirs.
+    // The injected lock (keyed by snapshot file name) serializes their upserts.
+    const fs = memFs();
+    const withSourceLock = sharedLock();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let fetchCount = 0;
+    const conv = converters({
+      fetchRemote: jest.fn(async (s: RemoteSource) => {
+        fetchCount += 1;
+        await gate; // hold the lock so the second project is forced to wait
+        return `content #${fetchCount} for ${s.url}`;
+      }),
+    });
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://shared.com" }];
+
+    const runA = materializeSources({ remotesDir: REMOTES_DIR, filesDir: FILES_DIR, markerDir: MARKER_DIR, fs, converters: conv, remotes, files: [], nowMs: T0, withSourceLock }); // prettier-ignore
+    await flushMicrotasks(); // A acquires the lock and reaches the gated fetch
+    const runB = materializeSources({ remotesDir: REMOTES_DIR, filesDir: FILES_DIR, markerDir: MARKER_DIR_B, fs, converters: conv, remotes, files: [], nowMs: T0 + 1, withSourceLock }); // prettier-ignore
+    await flushMicrotasks(); // B is now waiting on the same per-artifact lock
+    release();
+    const [resA, resB] = await Promise.all([runA, runB]);
+
+    // One fetch total; B re-read the meta inside the lock and cheap-skipped.
+    expect(conv.fetchRemote).toHaveBeenCalledTimes(1);
+    // Both projects see a present entry pointing at the one shared snapshot.
+    expect(resA.entries).toHaveLength(1);
+    expect(resB.entries).toHaveLength(1);
+    const snapshots = [...fs.files.keys()].filter((k) => k.startsWith(`${REMOTES_DIR}/`));
+    expect(snapshots).toHaveLength(1);
+    // A's content was NOT overwritten by B.
+    expect(fs.files.get(snapshots[0])).toContain("content #1 for https://shared.com");
+  });
+});
+
+describe("materializeSources — stale marker cleanup on shared cheap-skip", () => {
+  it("clears project A's marker once project B writes the shared snapshot (A cheap-skip hit)", async () => {
+    const fs = memFs();
+    const remotes: RemoteSource[] = [{ type: "web", url: "https://shared.com" }];
+
+    // 1. Project A fails → marker in A's bucket, no snapshot.
+    const failing = converters({
+      fetchRemote: jest.fn(async () => {
+        throw new Error("down");
+      }),
+    });
+    await materializeSources({ remotesDir: REMOTES_DIR, filesDir: FILES_DIR, markerDir: MARKER_DIR, fs, converters: failing, remotes, files: [], nowMs: T0 }); // prettier-ignore
+    const markerKey = [...fs.files.keys()].find((k) => k.startsWith(`${MARKER_DIR}/`))!;
+    expect(markerKey).toBeDefined();
+
+    // 2. Project B succeeds → shared snapshot written (B never had a marker).
+    await materializeSources({ remotesDir: REMOTES_DIR, filesDir: FILES_DIR, markerDir: MARKER_DIR_B, fs, converters: converters(), remotes, files: [], nowMs: T0 + 1 }); // prettier-ignore
+    expect([...fs.files.keys()].some((k) => k.startsWith(`${REMOTES_DIR}/`))).toBe(true);
+
+    // 3. Project A re-runs: the shared snapshot now cheap-skips, and A's stale
+    //    marker is cleared so its status panel stops reporting a failure.
+    const conv = converters();
+    const { failures } = await materializeSources({ remotesDir: REMOTES_DIR, filesDir: FILES_DIR, markerDir: MARKER_DIR, fs, converters: conv, remotes, files: [], nowMs: T0 + 2 }); // prettier-ignore
+
+    expect(conv.fetchRemote).not.toHaveBeenCalled(); // cheap-skipped the shared snapshot
+    expect(failures).toHaveLength(0);
+    expect(fs.files.has(markerKey)).toBe(false); // A's stale marker was cleared
+  });
+
+  it("clears project A's marker when a re-parse fails but a usable (stale) snapshot exists", async () => {
+    const fs = memFs();
+
+    // 1. Project A fails to parse the file at fingerprint F1 → marker, no snapshot.
+    const failingF1 = converters({
+      parseFile: jest.fn(async () => {
+        throw new Error("bad parse F1");
+      }),
+    });
+    await materializeSources({ remotesDir: REMOTES_DIR, filesDir: FILES_DIR, markerDir: MARKER_DIR, fs, converters: failingF1, remotes: [], files: [fileSource({ mtime: 1000, size: 50 })], nowMs: T0 }); // prettier-ignore
+    const markerKey = [...fs.files.keys()].find((k) => k.startsWith(`${MARKER_DIR}/`))!;
+    expect(markerKey).toBeDefined();
+
+    // 2. Project B parses the same file at F1 → shared snapshot (B's own bucket).
+    await materializeSources({ remotesDir: REMOTES_DIR, filesDir: FILES_DIR, markerDir: MARKER_DIR_B, fs, converters: converters(), remotes: [], files: [fileSource({ mtime: 1000, size: 50 })], nowMs: T0 + 1 }); // prettier-ignore
+    expect([...fs.files.keys()].some((k) => k.startsWith(`${FILES_DIR}/`))).toBe(true);
+
+    // 3. The file changes to F2 and project A re-parses: the F1 snapshot is now
+    //    stale (fingerprint mismatch) so it re-attempts, fails again, but keeps the
+    //    usable stale snapshot. A's marker is no longer a "missing source" and must
+    //    be cleared here — the single-source retry path skips the marker reconcile.
+    const failingF2 = converters({
+      parseFile: jest.fn(async () => {
+        throw new Error("bad parse F2");
+      }),
+    });
+    const { failures } = await materializeSources({ remotesDir: REMOTES_DIR, filesDir: FILES_DIR, markerDir: MARKER_DIR, fs, converters: failingF2, remotes: [], files: [fileSource({ mtime: 2000, size: 99 })], nowMs: T0 + 2 }); // prettier-ignore
+
+    expect(failingF2.parseFile).toHaveBeenCalledTimes(1); // re-attempted, not marker-skipped
+    expect(failures[0]).toMatchObject({ usedStaleSnapshot: true }); // stale snapshot still usable
+    expect(fs.files.has(markerKey)).toBe(false); // A's now-wrong missing-source marker was cleared
+  });
+});
+
+describe("reconcileMarkers", () => {
+  it("deletes obsolete owned markers in markerDir but preserves unknown files", async () => {
+    const fs = memFs({
+      [join(MARKER_DIR, "failed-web-deadbeef01.json")]: "{}",
+      [join(MARKER_DIR, "failed-file-cafe02.json")]: "{}", // wanted
+      [join(MARKER_DIR, "user-notes.md")]: "not ours",
+    });
+    const wanted = new Set(["failed-file-cafe02.json"]);
+
+    await reconcileMarkers(fs, MARKER_DIR, wanted);
+
+    expect(fs.files.has(join(MARKER_DIR, "failed-web-deadbeef01.json"))).toBe(false);
+    expect(fs.files.has(join(MARKER_DIR, "failed-file-cafe02.json"))).toBe(true);
+    expect(fs.files.has(join(MARKER_DIR, "user-notes.md"))).toBe(true);
+  });
+
+  it("never touches shared snapshots — it only lists and prunes the marker dir", async () => {
+    // Snapshots live in remotesDir/filesDir, never in markerDir, so a marker
+    // reconcile can't reach them even with an empty wanted set.
+    const fs = memFs({
+      [join(REMOTES_DIR, "web-abc01.md")]: "shared snapshot",
+      [join(FILES_DIR, "file-abc02.md")]: "shared snapshot",
+      [join(MARKER_DIR, "failed-youtube-abc03.json")]: "{}",
+    });
+
+    await reconcileMarkers(fs, MARKER_DIR, new Set());
+
+    expect(fs.files.has(join(REMOTES_DIR, "web-abc01.md"))).toBe(true);
+    expect(fs.files.has(join(FILES_DIR, "file-abc02.md"))).toBe(true);
+    expect(fs.files.has(join(MARKER_DIR, "failed-youtube-abc03.json"))).toBe(false);
+  });
+});

--- a/src/context/contextCacheStore.test.ts
+++ b/src/context/contextCacheStore.test.ts
@@ -2,8 +2,11 @@ import { Mutex } from "async-mutex";
 import { join } from "node:path";
 import type { ContextCacheFs } from "./contextCacheFs";
 import {
+  CACHE_SCHEMA_VERSION,
   materializeSources,
+  parseSnapshotMeta,
   reconcileMarkers,
+  type CacheEntryMeta,
   type ContextConverters,
   type FileSource,
   type MaterializeProgress,
@@ -693,5 +696,32 @@ describe("reconcileMarkers", () => {
     expect(fs.files.has(join(REMOTES_DIR, "web-abc01.md"))).toBe(true);
     expect(fs.files.has(join(FILES_DIR, "file-abc02.md"))).toBe(true);
     expect(fs.files.has(join(MARKER_DIR, "failed-youtube-abc03.json"))).toBe(false);
+  });
+});
+
+describe("parseSnapshotMeta", () => {
+  // Mirror the writer's exact framing (META_OPEN / META_CLOSE are module-private).
+  const buildSnapshot = (meta: CacheEntryMeta): string =>
+    `<!-- copilot-context-cache\n${JSON.stringify(meta)}\n-->\n\n# File: x\n\ncontent\n`;
+
+  const fileMeta = (sourcePath: string): CacheEntryMeta => ({
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    sourceType: "file",
+    sourcePath,
+    fetchedAt: "2026-01-01T00:00:00.000Z",
+    fingerprint: "123:456",
+  });
+
+  it("parses a well-formed meta block", () => {
+    const meta = fileMeta("Notes/foo.md");
+    expect(parseSnapshotMeta(buildSnapshot(meta))).toEqual(meta);
+  });
+
+  it("does not truncate the JSON on a '-->' inside the source path", () => {
+    // Regression: indexOf("-->") matched the marker embedded in the JSON value,
+    // cutting the JSON short -> JSON.parse threw -> permanent cache miss. The
+    // close marker is now anchored to a line boundary.
+    const meta = fileMeta("Notes/a-->b.md");
+    expect(parseSnapshotMeta(buildSnapshot(meta))).toEqual(meta);
   });
 });

--- a/src/context/contextCacheStore.ts
+++ b/src/context/contextCacheStore.ts
@@ -708,7 +708,11 @@ async function readMeta(fs: ContextCacheFs, filePath: string): Promise<CacheEntr
  */
 export function parseSnapshotMeta(raw: string): CacheEntryMeta | null {
   if (!raw.startsWith(META_OPEN)) return null;
-  const close = raw.indexOf(META_CLOSE);
+  // Match the close marker only at a line start (the writer always emits it as
+  // `\n${META_CLOSE}\n`). A bare `indexOf(META_CLOSE)` would match a `-->`
+  // embedded in the JSON's sourcePath/sourceUrl, truncating the JSON and forcing
+  // a permanent cache miss for any source whose path legitimately contains `-->`.
+  const close = raw.indexOf(`\n${META_CLOSE}`, META_OPEN.length);
   if (close < 0) return null;
   const json = raw.slice(META_OPEN.length, close).trim();
   try {

--- a/src/context/contextCacheStore.ts
+++ b/src/context/contextCacheStore.ts
@@ -1,0 +1,741 @@
+import { err2String } from "@/errorFormat";
+import { logWarn } from "@/logger";
+import { md5 } from "@/utils/hash";
+import type { UrlKind } from "@/utils/urlTagUtils";
+import type { ContextCacheFs } from "./contextCacheFs";
+
+/** Source kinds that get materialized into the conversion cache as text
+ * snapshots. The single source of truth — file-name patterns (see
+ * {@link OWNED_MARKER_RE}) and other modules' source-kind unions derive from
+ * this, so adding a kind here updates them all. */
+export const MATERIALIZED_SOURCE_TYPES = ["web", "youtube", "file"] as const;
+export type MaterializedSourceType = (typeof MATERIALIZED_SOURCE_TYPES)[number];
+
+/** A URL or YouTube link to fetch via brevilabs primitives. */
+export interface RemoteSource {
+  type: UrlKind;
+  /** The configured URL — also the cache key and fingerprint basis. */
+  url: string;
+}
+
+/** An in-vault binary file (PDF/image/doc) to parse into searchable text. */
+export interface FileSource {
+  /** Vault-relative path (the user-facing source identity). */
+  vaultPath: string;
+  /** Lowercased extension passed to the parser. */
+  ext: string;
+  /** Cheap change signal — no read required to compute. */
+  mtime: number;
+  size: number;
+  /** Lazily reads the file's bytes (only invoked when a (re)parse is needed). */
+  read: () => Promise<ArrayBuffer>;
+}
+
+/** Brevilabs-backed converters, injected so the core stays network-free in tests. */
+export interface ContextConverters {
+  fetchRemote: (source: RemoteSource) => Promise<string>;
+  parseFile: (bytes: ArrayBuffer, ext: string) => Promise<string>;
+}
+
+/** One successfully-present cache file (fresh or kept-stale), for the manifest. */
+export interface MaterializedEntry {
+  type: MaterializedSourceType;
+  /** Original source (URL or vault path). */
+  source: string;
+  /** Snapshot file basename within its source-kind bucket (`<type>-<md5>.md`). */
+  cacheFileName: string;
+  /**
+   * Absolute, OS-native path of the snapshot file, for the manifest's snapshot
+   * pointer (the agent reads it directly). Filled by the DESKTOP materializer
+   * from {@link import("./conversionsLocation")}; this node-free store never sets
+   * it, so every reader must tolerate its absence (degrade to no pointer).
+   */
+  snapshotAbsPath?: string;
+}
+
+/**
+ * A source that failed to fetch/parse during materialization. The run still
+ * completes (the session degrades gracefully); these are surfaced to the status
+ * icon + popover so the failure is diagnosable. `usedStaleSnapshot` distinguishes
+ * "refresh failed but a previous snapshot is still in use" (context available,
+ * just stale) from "no snapshot at all, source is missing".
+ */
+export interface SourceFailure {
+  source: string;
+  kind: MaterializedSourceType;
+  error: string;
+  usedStaleSnapshot: boolean;
+}
+
+/** Identity of one source as it moves through the materialization lifecycle. */
+export interface MaterializeSourceIdentity {
+  kind: MaterializedSourceType;
+  source: string;
+}
+
+/**
+ * Progress for the materialization loops, emitted as work lands. The step counts
+ * (`prefetch`/`parse`, `done`/`total`) drive the loading card's progress rows;
+ * the per-source lifecycle events drive the popover's live queue — `itemStart`
+ * when a source actually begins fetching/parsing (a cheap-skip never starts),
+ * then `itemFailed`/`itemSettled` when it lands. All are carried OUT-OF-BAND from
+ * the materialization RESULT.
+ */
+export type MaterializeProgress =
+  | { phase: "prefetch" | "parse"; done: number; total: number }
+  | { phase: "itemStart"; item: MaterializeSourceIdentity }
+  | { phase: "itemFailed"; item: MaterializeSourceIdentity; failure: SourceFailure }
+  | { phase: "itemSettled"; item: MaterializeSourceIdentity };
+
+export interface MaterializeSourcesInput {
+  /**
+   * Directory for shared remote snapshots (web pages, YouTube transcripts).
+   * Vault-wide — keyed by source identity, never by project — so the SAME source
+   * referenced by N projects resolves to ONE snapshot here.
+   */
+  remotesDir: string;
+  /** Directory for shared in-vault file snapshots (PDFs/images), keyed by vault path. */
+  filesDir: string;
+  /**
+   * Directory for THIS project's failure markers. Bucketed per project (snapshots
+   * are shared, but a failure is meaningful only to the project that hit it), so
+   * it is the one directory safe to reconcile against a single project's sources.
+   */
+  markerDir: string;
+  fs: ContextCacheFs;
+  converters: ContextConverters;
+  remotes: RemoteSource[];
+  files: FileSource[];
+  /** Current wall-clock (ms) — injected for deterministic snapshot timestamps. */
+  nowMs: number;
+  /**
+   * Re-attempt every failed source even if a persisted failure marker would
+   * otherwise cheap-skip it. Default `false` (the automatic path skips known-bad
+   * sources); set `true` only by the user-driven "Retry" actions so a manual
+   * retry always forces a fresh fetch/parse.
+   */
+  forceRetryFailed?: boolean;
+  /** Optional progress sink, fired per item as each loop advances. */
+  onProgress?: (progress: MaterializeProgress) => void;
+  /**
+   * Optional critical section wrapping each source's ENTIRE read-decide-write,
+   * keyed by its snapshot file name. The materializer injects a global
+   * per-artifact lock so two projects cold-converting the same shared source
+   * converge to one fetch: the first writes the snapshot, the second re-reads the
+   * meta inside the lock and cheap-skips. Defaults to a pass-through — the store
+   * stays pure and single-project unit tests need no lock. Keyed by file name
+   * (identity-derived, so the same source across projects shares one lock).
+   */
+  withSourceLock?: <T>(key: string, run: () => Promise<T>) => Promise<T>;
+}
+
+export interface MaterializeSourcesResult {
+  entries: MaterializedEntry[];
+  /**
+   * Failure-marker names this project still references (a fresh or honored
+   * marker). Only the per-project marker directory is reconciled against these;
+   * shared snapshots are never reconciled (cross-project deletion).
+   */
+  wantedMarkerNames: Set<string>;
+  /** Sources that failed to fetch/parse this run (empty when all succeeded). */
+  failures: SourceFailure[];
+}
+
+/** Metadata block persisted at the top of every cache file. */
+export interface CacheEntryMeta {
+  /** Cache format version — readers discard a mismatch as a miss (see {@link CACHE_SCHEMA_VERSION}). */
+  schemaVersion: number;
+  sourceType: MaterializedSourceType;
+  /** Origin URL for web/youtube snapshots. */
+  sourceUrl?: string;
+  /** Vault path for in-vault file snapshots. */
+  sourcePath?: string;
+  fetchedAt: string;
+  /** Cheap-skip key: identity for remotes, `mtime:size` for files. */
+  fingerprint: string;
+}
+
+const META_OPEN = "<!-- copilot-context-cache";
+const META_CLOSE = "-->";
+/**
+ * Persisted cache-format version. Bump ONLY when an EXISTING field's semantics
+ * change (e.g. the `fingerprint` `mtime:size` format) — readers then treat a
+ * mismatch as a cache miss and re-materialize, instead of misreading an old file
+ * as fresh. Additive/removed fields are tolerant-parsed and need no bump. The
+ * cache is regenerable, so this discards-and-rebuilds rather than migrating
+ * (unlike `settingsVersion`, which migrates non-regenerable settings).
+ *
+ * Exported so tests can stamp a current-version fixture without hardcoding the
+ * number (which would silently break them on the next bump).
+ */
+export const CACHE_SCHEMA_VERSION = 1;
+
+/**
+ * Persisted failure marker: a source that failed to fetch/parse with NO usable
+ * snapshot. Negative cache — a later automatic run cheap-skips a known-bad
+ * source (reading the stored error) instead of re-hitting brevilabs on every new
+ * session, until the user forces a retry. A `.json` file — never `.md` — so the
+ * agent never greps a failure marker as if it were materialized context. Cleared
+ * when the source later succeeds.
+ */
+export interface FailureMarker {
+  /** Cache format version — readers discard a mismatch as a miss (see {@link CACHE_SCHEMA_VERSION}). */
+  schemaVersion: number;
+  source: string;
+  kind: MaterializedSourceType;
+  error: string;
+  failedAt: number;
+  /**
+   * The file's `mtime:size` fingerprint at failure time (file kind only). The
+   * cheap-skip is honored only while this still matches the live file, so
+   * editing/replacing a failed file re-attempts it immediately — mirroring the
+   * snapshot path's fingerprint check. Absent for remotes (identity-keyed); a
+   * marker written before this field existed is treated as untrustworthy and
+   * re-attempted once rather than skipped on stale information.
+   */
+  fingerprint?: string;
+}
+
+/**
+ * Materialize every configured source: remote snapshots into `remotesDir`, file
+ * snapshots into `filesDir`, failure markers into the per-project `markerDir`,
+ * skipping any whose fingerprint is unchanged (a successful snapshot is kept
+ * indefinitely). A fetch/parse failure never throws: an existing stale file is
+ * kept, otherwise the source is skipped and a failure marker is written. A later
+ * automatic run cheap-skips that known-bad source (re-surfacing the stored error)
+ * until the file changes or `forceRetryFailed` forces a fresh attempt. Returns
+ * the present entries, the live failure-marker names (so the per-project marker
+ * reconcile keeps them), and the per-source failures for this run.
+ */
+export async function materializeSources(
+  input: MaterializeSourcesInput
+): Promise<MaterializeSourcesResult> {
+  const { remotesDir, filesDir, markerDir, fs, converters, nowMs, onProgress } = input;
+  const forceRetryFailed = input.forceRetryFailed ?? false;
+  // Default to a pass-through so the store stays lock-agnostic; the materializer
+  // injects the real global per-artifact lock.
+  const withSourceLock =
+    input.withSourceLock ?? (<T>(_key: string, run: () => Promise<T>) => run());
+  // Ensure every target dir exists before any write. A mkdir failure is NOT
+  // swallowed here: it throws so the materializer's whole-run catch degrades the
+  // session to the empty result (a per-source failure would wrongly imply the
+  // rest of the cache is writable).
+  await fs.mkdirRecursive(remotesDir);
+  await fs.mkdirRecursive(filesDir);
+  await fs.mkdirRecursive(markerDir);
+
+  const entries: MaterializedEntry[] = [];
+  const failures: SourceFailure[] = [];
+  // Only failure markers are reconciled (per-project, safe to prune); shared
+  // snapshots are never reconciled, so they are never added to a wanted set.
+  const wantedMarkerNames = new Set<string>();
+
+  // Dedupe up front so the emitted totals match the actual work performed.
+  const remotes = dedupeBy(input.remotes, (r) => `${r.type}:${r.url}`);
+  const files = dedupeBy(input.files, (f) => f.vaultPath);
+
+  // URLs are fetched in PARALLEL (matching the legacy CAG cache — `url4llm`
+  // calls are independent and each failure is isolated per source); binary files
+  // are parsed SEQUENTIALLY (heavier, also matching CAG). Each source emits
+  // `itemStart` only when it truly begins work (a cheap-skip stays silent) and
+  // `itemFailed`/`itemSettled` when it lands, so the popover renders a live queue.
+  if (remotes.length > 0) onProgress?.({ phase: "prefetch", done: 0, total: remotes.length });
+  let prefetchDone = 0;
+  const remoteResults = await Promise.all(
+    remotes.map(async (remote) => {
+      const item: MaterializeSourceIdentity = { kind: remote.type, source: remote.url };
+      const fileName = cacheFileName(remote.type, remote.url);
+      const markerName = failureMarkerName(remote.type, remote.url);
+      // The lock wraps the whole upsert (read meta → decide → fetch → write), so
+      // a second project waiting on the same source re-reads the now-present meta
+      // inside the lock and cheap-skips instead of re-fetching/overwriting.
+      const result = await runWithLifecycle(item, onProgress, (onStart) =>
+        withSourceLock(fileName, () =>
+          upsertRemote(
+            remotesDir,
+            markerDir,
+            fileName,
+            markerName,
+            remote,
+            converters,
+            fs,
+            nowMs,
+            forceRetryFailed,
+            onStart
+          )
+        )
+      );
+      prefetchDone += 1;
+      onProgress?.({ phase: "prefetch", done: prefetchDone, total: remotes.length });
+      return { remote, result };
+    })
+  );
+  // Fold results in the ORIGINAL order — the parallel tasks above must not race
+  // on these shared collections, so the mutation happens here, sequentially.
+  for (const { remote, result } of remoteResults) {
+    const fileName = cacheFileName(remote.type, remote.url);
+    const markerName = failureMarkerName(remote.type, remote.url);
+    if (result.present) {
+      entries.push({ type: remote.type, source: remote.url, cacheFileName: fileName });
+    }
+    if (result.failure) {
+      failures.push(result.failure);
+      // The marker belongs to a still-configured source: keep it (reconcile
+      // would otherwise delete it the same run we wrote/honored it).
+      if (result.markerWanted) wantedMarkerNames.add(markerName);
+    }
+  }
+
+  if (files.length > 0) onProgress?.({ phase: "parse", done: 0, total: files.length });
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+    const item: MaterializeSourceIdentity = { kind: "file", source: file.vaultPath };
+    const fileName = cacheFileName("file", file.vaultPath);
+    const markerName = failureMarkerName("file", file.vaultPath);
+    const result = await runWithLifecycle(item, onProgress, (onStart) =>
+      withSourceLock(fileName, () =>
+        upsertFile(
+          filesDir,
+          markerDir,
+          fileName,
+          markerName,
+          file,
+          converters,
+          fs,
+          nowMs,
+          forceRetryFailed,
+          onStart
+        )
+      )
+    );
+    if (result.present) {
+      entries.push({ type: "file", source: file.vaultPath, cacheFileName: fileName });
+    }
+    if (result.failure) {
+      failures.push(result.failure);
+      if (result.markerWanted) wantedMarkerNames.add(markerName);
+    }
+    onProgress?.({ phase: "parse", done: i + 1, total: files.length });
+  }
+
+  return { entries, wantedMarkerNames, failures };
+}
+
+/**
+ * Run one source's upsert and emit its lifecycle events. `itemStart` fires only
+ * if the upsert actually began work (its `onStart` callback ran — a cheap-skip
+ * never calls it, so a cached source stays silent and renders straight to Ready).
+ * On settle, a failure emits `itemFailed` (carrying the error), success emits
+ * `itemSettled`; both remove the source from the popover's "processing" set.
+ *
+ * This is the lifecycle OWNER: an upsert that throws (e.g. the failure-marker
+ * write itself fails on a full/locked disk) is isolated into a per-source
+ * failure rather than propagating. Reason: the remote upserts run under one
+ * `Promise.all`, so a single rejection would (a) cancel nothing — sibling
+ * sources keep running and their late `onProgress` would re-publish a `blocking`
+ * state after the run already settled to `done`, stranding the loading card —
+ * and (b) collapse the whole run into the materializer's whole-run catch. A
+ * conservative per-source failure keeps the run resolvable and matches the
+ * legacy CAG tracker's per-source isolation.
+ */
+async function runWithLifecycle(
+  item: MaterializeSourceIdentity,
+  onProgress: ((progress: MaterializeProgress) => void) | undefined,
+  run: (onStart: () => void) => Promise<UpsertResult>
+): Promise<UpsertResult> {
+  let started = false;
+  let result: UpsertResult;
+  try {
+    result = await run(() => {
+      started = true;
+      onProgress?.({ phase: "itemStart", item });
+    });
+  } catch (err) {
+    // The only path that throws past the upsert's own catch today is the
+    // failure-marker write, which runs only when there's no usable snapshot — so
+    // `usedStaleSnapshot` is false here. A future throw site that DOES hold a
+    // usable stale snapshot should convert its error inside the upsert (with
+    // `usedStaleSnapshot: true`) rather than fall through to this default.
+    result = {
+      present: false,
+      failure: {
+        source: item.source,
+        kind: item.kind,
+        error: err2String(err),
+        usedStaleSnapshot: false,
+      },
+    };
+  }
+  // Only emit a settle event when the source was shown as processing (started);
+  // a throw before `onStart` leaves nothing to clear — the final `failures`
+  // reconciliation carries it instead.
+  if (started) {
+    if (result.failure) onProgress?.({ phase: "itemFailed", item, failure: result.failure });
+    else onProgress?.({ phase: "itemSettled", item });
+  }
+  return result;
+}
+
+/** Outcome of an upsert: whether a usable snapshot is present, and any failure. */
+interface UpsertResult {
+  present: boolean;
+  failure?: SourceFailure;
+  /**
+   * True when a failure marker for this source was written this run. The caller
+   * adds it to `wantedMarkerNames` so the same-run marker reconcile doesn't delete
+   * the marker it just wrote (which the status panel reads to surface the error).
+   */
+  markerWanted?: boolean;
+}
+
+async function upsertRemote(
+  snapshotDir: string,
+  markerDir: string,
+  fileName: string,
+  markerName: string,
+  remote: RemoteSource,
+  converters: ContextConverters,
+  fs: ContextCacheFs,
+  nowMs: number,
+  forceRetryFailed: boolean,
+  onStart?: () => void
+): Promise<UpsertResult> {
+  const filePath = joinCachePath(snapshotDir, fileName);
+  const markerPath = joinCachePath(markerDir, markerName);
+  const existing = await readMeta(fs, filePath);
+  const fingerprint = `${remote.type}:${remote.url}`;
+  // A successful snapshot is kept indefinitely (identity fingerprint), mirroring
+  // the legacy project-context cache: re-fetch only when the source is added or
+  // its config changes, never on a timer.
+  if (existing !== null && existing.fingerprint === fingerprint) {
+    // The shared snapshot is present — possibly written by another project after
+    // THIS project recorded a failure. Best-effort clear our own stale marker so
+    // the status panel stops surfacing a failure the shared snapshot resolved.
+    await removeMarkerBestEffort(fs, markerPath);
+    return { present: true };
+  }
+
+  // Negative cheap-skip: a prior failure with no usable snapshot. Skip the
+  // re-fetch (don't re-pay the latency on every new session) and re-surface the
+  // stored error, unless the user forced a retry. The `existing === null` guard
+  // keeps the success path above authoritative — a kept-stale snapshot is never
+  // treated as a failure to skip. No `onStart` fires, so the source stays out of
+  // the live "processing" queue and is carried purely by the failures list.
+  if (!forceRetryFailed && existing === null) {
+    const marker = await readFailureMarker(fs, markerPath);
+    if (marker !== null) {
+      return {
+        present: false,
+        failure: { source: remote.url, kind: remote.type, error: marker.error, usedStaleSnapshot: false }, // prettier-ignore
+        markerWanted: true, // honor the existing marker so reconcile keeps it
+      };
+    }
+  }
+
+  try {
+    onStart?.(); // about to fetch — surfaces this source as "processing"
+    const content = await converters.fetchRemote(remote);
+    await writeEntry(fs, filePath, remote.type, remote.url, fingerprint, content, nowMs);
+    // Best-effort marker clear: the snapshot is already written, so a delete
+    // error must NOT downgrade this success to a failure.
+    await removeMarkerBestEffort(fs, markerPath);
+    return { present: true };
+  } catch (err) {
+    const error = err2String(err);
+    logWarn(`[project-context] fetch failed for ${remote.url}: ${error}`);
+    const usedStaleSnapshot = existing !== null;
+    // Only write a failure marker when there is NO snapshot to fall back on;
+    // a stale snapshot is still usable, so its source is not "missing". When a
+    // stale snapshot IS usable, best-effort clear any pre-existing marker: a
+    // "missing source" marker is now semantically wrong, and the single-source
+    // retry path skips the marker reconcile that would otherwise drop it.
+    let markerWanted = false;
+    if (!usedStaleSnapshot) {
+      await writeFailureMarker(fs, markerPath, remote.url, remote.type, error, nowMs);
+      markerWanted = true;
+    } else {
+      await removeMarkerBestEffort(fs, markerPath);
+    }
+    return {
+      present: usedStaleSnapshot,
+      failure: { source: remote.url, kind: remote.type, error, usedStaleSnapshot },
+      markerWanted,
+    };
+  }
+}
+
+async function upsertFile(
+  snapshotDir: string,
+  markerDir: string,
+  fileName: string,
+  markerName: string,
+  file: FileSource,
+  converters: ContextConverters,
+  fs: ContextCacheFs,
+  nowMs: number,
+  forceRetryFailed: boolean,
+  onStart?: () => void
+): Promise<UpsertResult> {
+  const filePath = joinCachePath(snapshotDir, fileName);
+  const markerPath = joinCachePath(markerDir, markerName);
+  const existing = await readMeta(fs, filePath);
+  const fingerprint = `${file.mtime}:${file.size}`;
+  // A parsed snapshot is kept while the file is unchanged; a different
+  // `mtime:size` re-parses.
+  if (existing !== null && existing.fingerprint === fingerprint) {
+    // See upsertRemote: clear our own stale marker now that the shared snapshot
+    // is present (another project may have produced it).
+    await removeMarkerBestEffort(fs, markerPath);
+    return { present: true };
+  }
+
+  // Negative cheap-skip: a prior parse failure with no snapshot — honored only
+  // while the file is byte-for-byte unchanged (marker fingerprint matches the
+  // live `mtime:size`), so an edited/replaced file re-attempts immediately. A
+  // marker without a fingerprint predates this field: treat it as untrustworthy
+  // and re-attempt once rather than skip on stale information.
+  if (!forceRetryFailed && existing === null) {
+    const marker = await readFailureMarker(fs, markerPath);
+    if (marker !== null && marker.fingerprint === fingerprint) {
+      return {
+        present: false,
+        failure: { source: file.vaultPath, kind: "file", error: marker.error, usedStaleSnapshot: false }, // prettier-ignore
+        markerWanted: true, // honor the existing marker so reconcile keeps it
+      };
+    }
+  }
+
+  try {
+    onStart?.(); // about to parse — surfaces this source as "processing"
+    const content = await converters.parseFile(await file.read(), file.ext);
+    await writeEntry(fs, filePath, "file", file.vaultPath, fingerprint, content, nowMs);
+    // Best-effort (see upsertRemote): a marker-delete error must not fail a
+    // snapshot that is already written.
+    await removeMarkerBestEffort(fs, markerPath);
+    return { present: true };
+  } catch (err) {
+    const error = err2String(err);
+    logWarn(`[project-context] parse failed for ${file.vaultPath}: ${error}`);
+    const usedStaleSnapshot = existing !== null;
+    // See upsertRemote: write a marker only when no snapshot exists; when a stale
+    // snapshot is usable, best-effort clear any pre-existing marker so a single-
+    // source retry (which skips the marker reconcile) can't leave a stale failure.
+    let markerWanted = false;
+    if (!usedStaleSnapshot) {
+      await writeFailureMarker(fs, markerPath, file.vaultPath, "file", error, nowMs, fingerprint);
+      markerWanted = true;
+    } else {
+      await removeMarkerBestEffort(fs, markerPath);
+    }
+    return {
+      present: usedStaleSnapshot,
+      failure: { source: file.vaultPath, kind: "file", error, usedStaleSnapshot },
+      markerWanted,
+    };
+  }
+}
+
+/**
+ * Delete this project's failure markers that the current config no longer
+ * references. Only the per-project marker directory is reconciled: snapshots are
+ * shared vault-wide, so pruning them against a single project's wanted set would
+ * delete files other projects still reference (the legacy `clearForProject`
+ * cross-project deletion bug). Unrecognized files are always preserved.
+ */
+export async function reconcileMarkers(
+  fs: ContextCacheFs,
+  markerDir: string,
+  wantedMarkerNames: Set<string>
+): Promise<void> {
+  const present = await fs.list(markerDir);
+  for (const name of present) {
+    if (wantedMarkerNames.has(name)) continue;
+    if (!OWNED_MARKER_RE.test(name)) continue;
+    await fs.remove(joinCachePath(markerDir, name));
+  }
+}
+
+/**
+ * Join a cache-relative file name onto the cache dir. Cache paths are always
+ * vault-relative and POSIX-separated, so a plain "/" join (no `node:path`) is
+ * correct on every platform and keeps this module Node-builtin-free.
+ */
+function joinCachePath(dir: string, name: string): string {
+  const left = dir.replace(/\/+$/, "");
+  const right = name.replace(/^\/+/, "");
+  return left ? `${left}/${right}` : right;
+}
+
+/**
+ * A `failed-<type>-<hash>.json` failure marker this module owns and may prune in
+ * {@link reconcileMarkers}. Built from MATERIALIZED_SOURCE_TYPES so a new source
+ * kind is covered automatically; the values are plain identifiers, so a bare
+ * alternation needs no regex escaping. `md5` emits lowercase hex, so the
+ * `[0-9a-f]+` class matches the hash.
+ */
+const SOURCE_TYPE_ALTERNATION = MATERIALIZED_SOURCE_TYPES.join("|");
+const OWNED_MARKER_RE = new RegExp(`^failed-(${SOURCE_TYPE_ALTERNATION})-[0-9a-f]+\\.json$`);
+
+/**
+ * Deterministic snapshot file name for a source. Exported (with
+ * {@link failureMarkerName}) so read-only consumers — the edit modal's Content
+ * Conversion panel — can probe a cache dir for a source's persisted state by
+ * name alone, without parsing file contents.
+ */
+export function cacheFileName(type: MaterializedSourceType, source: string): string {
+  return `${type}-${md5(source)}.md`;
+}
+
+/** Failure marker name for a source (parallel to {@link cacheFileName}). */
+export function failureMarkerName(type: MaterializedSourceType, source: string): string {
+  return `failed-${type}-${md5(source)}.json`;
+}
+
+/**
+ * Remove a failure marker without ever failing the caller. The marker is a pure
+ * status hint, so a delete error (e.g. a transient EACCES) must not turn a
+ * present, usable snapshot into a reported failure — unlike a snapshot WRITE,
+ * which must surface (see {@link createNodeContextCacheFs}). Missing markers are
+ * already a no-op via the fs contract; this only guards a hard delete error.
+ */
+async function removeMarkerBestEffort(fs: ContextCacheFs, markerPath: string): Promise<void> {
+  try {
+    await fs.remove(markerPath);
+  } catch (err) {
+    logWarn(`[project-context] could not clear stale failure marker ${markerPath}: ${err2String(err)}`); // prettier-ignore
+  }
+}
+
+async function writeFailureMarker(
+  fs: ContextCacheFs,
+  markerPath: string,
+  source: string,
+  kind: MaterializedSourceType,
+  error: string,
+  nowMs: number,
+  fingerprint?: string
+): Promise<void> {
+  const marker: FailureMarker = { schemaVersion: CACHE_SCHEMA_VERSION, source, kind, error, failedAt: nowMs, ...(fingerprint !== undefined ? { fingerprint } : {}) }; // prettier-ignore
+  await fs.writeText(markerPath, JSON.stringify(marker));
+}
+
+/** Read and tolerantly parse a source's failure marker (null when absent/malformed). */
+async function readFailureMarker(
+  fs: ContextCacheFs,
+  markerPath: string
+): Promise<FailureMarker | null> {
+  let raw: string;
+  try {
+    raw = await fs.readText(markerPath);
+  } catch {
+    return null;
+  }
+  return parseFailureMarker(raw);
+}
+
+/**
+ * Tolerant parse of a failure marker's JSON content (null on any malformation).
+ * Exported for read-only consumers that fetch the bytes themselves rather than
+ * through a {@link ContextCacheFs}.
+ *
+ * DESIGN NOTE: `kind` is type-checked as a string but NOT validated against the
+ * `FailureMarker["kind"]` union. These markers are written only by this module
+ * (never user-authored), so a value outside the union can't arise on the real
+ * path; the downstream panel renders an unknown kind harmlessly as a generic
+ * failure. Tightening to a union whitelist would only guard a hand-corrupted
+ * cache file, which has no real caller. If a future review flags this again,
+ * point them at this note.
+ */
+export function parseFailureMarker(raw: string): FailureMarker | null {
+  try {
+    const parsed = JSON.parse(raw) as Partial<FailureMarker>;
+    // Version mismatch -> treat as no marker, so the source is re-attempted.
+    if (parsed.schemaVersion !== CACHE_SCHEMA_VERSION) return null;
+    if (
+      typeof parsed.source !== "string" ||
+      typeof parsed.kind !== "string" ||
+      typeof parsed.error !== "string" ||
+      typeof parsed.failedAt !== "number"
+    ) {
+      return null;
+    }
+    return parsed as FailureMarker;
+  } catch {
+    return null;
+  }
+}
+
+async function writeEntry(
+  fs: ContextCacheFs,
+  filePath: string,
+  sourceType: MaterializedSourceType,
+  source: string,
+  fingerprint: string,
+  content: string,
+  nowMs: number
+): Promise<void> {
+  const fetchedAt = new Date(nowMs).toISOString();
+  const meta: CacheEntryMeta = {
+    schemaVersion: CACHE_SCHEMA_VERSION,
+    sourceType,
+    ...(sourceType === "file" ? { sourcePath: source } : { sourceUrl: source }),
+    fetchedAt,
+    fingerprint,
+  };
+  const body = content.trim();
+  const text =
+    `${META_OPEN}\n${JSON.stringify(meta)}\n${META_CLOSE}\n\n` +
+    `# ${sourceType === "file" ? "File" : sourceType === "youtube" ? "YouTube" : "URL"}: ${source}\n` +
+    `_Materialized ${fetchedAt} — snapshot; refresh if the source changed._\n\n` +
+    `${body}\n`;
+  await fs.writeText(filePath, text);
+}
+
+async function readMeta(fs: ContextCacheFs, filePath: string): Promise<CacheEntryMeta | null> {
+  let raw: string;
+  try {
+    raw = await fs.readText(filePath);
+  } catch {
+    return null;
+  }
+  return parseSnapshotMeta(raw);
+}
+
+/**
+ * Tolerant parse of a snapshot file's leading meta block (null on any
+ * malformation). Exported for read-only consumers that fetch the bytes
+ * themselves — the edit modal compares a file snapshot's stored `fingerprint`
+ * against the live `mtime:size` to detect a stale conversion.
+ */
+export function parseSnapshotMeta(raw: string): CacheEntryMeta | null {
+  if (!raw.startsWith(META_OPEN)) return null;
+  const close = raw.indexOf(META_CLOSE);
+  if (close < 0) return null;
+  const json = raw.slice(META_OPEN.length, close).trim();
+  try {
+    const parsed = JSON.parse(json) as Partial<CacheEntryMeta>;
+    // Version mismatch -> treat as a miss so the source re-materializes. Note the
+    // old snapshot is then NOT used as a stale fallback if the re-fetch fails; on
+    // an unreleased format that one-time rebuild is acceptable.
+    if (parsed.schemaVersion !== CACHE_SCHEMA_VERSION) return null;
+    const hasSource = Boolean(parsed.sourceUrl ?? parsed.sourcePath);
+    if (!parsed.sourceType || !hasSource || !parsed.fetchedAt || !parsed.fingerprint) {
+      return null;
+    }
+    return parsed as CacheEntryMeta;
+  } catch {
+    return null;
+  }
+}
+
+function dedupeBy<T>(items: T[], keyOf: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const item of items) {
+    const key = keyOf(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
+  }
+  return out;
+}

--- a/src/context/contextCacheStore.ts
+++ b/src/context/contextCacheStore.ts
@@ -643,8 +643,7 @@ async function readFailureMarker(
  * (never user-authored), so a value outside the union can't arise on the real
  * path; the downstream panel renders an unknown kind harmlessly as a generic
  * failure. Tightening to a union whitelist would only guard a hand-corrupted
- * cache file, which has no real caller. If a future review flags this again,
- * point them at this note.
+ * cache file, which has no real caller.
  */
 export function parseFailureMarker(raw: string): FailureMarker | null {
   try {

--- a/src/context/conversionsLocation.test.ts
+++ b/src/context/conversionsLocation.test.ts
@@ -1,0 +1,37 @@
+import type { App } from "obsidian";
+import { FileSystemAdapter } from "obsidian";
+import * as path from "node:path";
+import { getVaultId } from "@/utils/appPaths";
+import { md5 } from "@/utils/hash";
+import { cacheRoot, filesDir, markersDir, remotesDir } from "./conversionsLocation";
+
+// The jsdom mock's FileSystemAdapter takes a base path; the real obsidian type
+// declares a 0-arg constructor, so cast to build a hashable instance.
+const FsAdapter = FileSystemAdapter as unknown as new (basePath: string) => FileSystemAdapter;
+const appWith = (basePath: string): App =>
+  ({ vault: { adapter: new FsAdapter(basePath) } }) as unknown as App;
+
+describe("conversionsLocation", () => {
+  const app = appWith("/Users/me/My Vault");
+
+  it("roots the cache at ~/.obsidian-copilot/vaults/<vaultId>/context-cache", () => {
+    const root = cacheRoot(app);
+    // The vaultId comes from the shared helper, so the two always agree.
+    expect(
+      root.endsWith(path.join(".obsidian-copilot", "vaults", getVaultId(app), "context-cache"))
+    ).toBe(true);
+  });
+
+  it("derives every subdirectory from the single cacheRoot (layout §2)", () => {
+    const root = cacheRoot(app);
+    expect(remotesDir(app)).toBe(path.join(root, "remotes"));
+    expect(filesDir(app)).toBe(path.join(root, "files"));
+    expect(markersDir(app, "proj-1")).toBe(path.join(root, "markers", md5("proj-1")));
+  });
+
+  it("buckets failure markers by md5(projectId), not the raw id", () => {
+    const dir = markersDir(app, "proj-1");
+    expect(path.basename(dir)).toBe(md5("proj-1"));
+    expect(dir).not.toContain("proj-1");
+  });
+});

--- a/src/context/conversionsLocation.ts
+++ b/src/context/conversionsLocation.ts
@@ -1,0 +1,82 @@
+import type { App } from "obsidian";
+// These builders produce absolute, OS-native paths for the desktop-only
+// off-vault cache; mobile never reaches them (Agent Mode is desktop-gated).
+// eslint-disable-next-line import/no-nodejs-modules
+import os from "node:os";
+// eslint-disable-next-line import/no-nodejs-modules
+import * as path from "node:path";
+import { copilotAppDataDir, getVaultId } from "@/utils/appPaths";
+import { md5 } from "@/utils/hash";
+import type { MaterializedSourceType } from "./contextCacheStore";
+
+/**
+ * Single source of truth for where this vault's shared, off-vault conversion
+ * cache lives on disk. Both the writer (materializer) and every reader (UI
+ * status, preview, Clear command) derive their paths from here, so the layout
+ * is defined exactly once.
+ *
+ * Layout under {@link copilotAppDataDir} (reusing the existing per-vault
+ * namespace that already hosts the recent-chats index):
+ *
+ * ```
+ * ~/.obsidian-copilot/vaults/<vaultId>/context-cache/
+ *   remotes/   web-<md5(url)>.md · youtube-<md5(url)>.md     (shared across all projects)
+ *   files/     file-<md5(vaultPath)>.md                       (vaultId already scopes the parent)
+ *   markers/   <md5(projectId)>/failed-<type>-<md5(source)>.json   (failure markers, bucketed per project)
+ * ```
+ *
+ * Off-vault (device-local, not synced) so a source is converted once per vault
+ * rather than once per project, and the cache never enters Obsidian Sync / git
+ * or pollutes vault-wide agent search. These builders return absolute,
+ * OS-native paths and are therefore desktop-only — Agent Mode (their only
+ * consumer) is gated behind the desktop runtime boundary.
+ *
+ * ### Why this is a separate stack from CAG's `ProjectContextCache`
+ *
+ * The two solve different problems and cannot share storage:
+ * - CAG's cache is **in-vault** (`.copilot/project-context-cache`, via the
+ *   vault adapter), synced, and exists to inline converted text back into the
+ *   chat model's prompt as RAG context.
+ * - This cache is **off-vault** and exists to hand **absolute file paths** to
+ *   three external agent subprocesses (claude/codex/opencode) that read the
+ *   files themselves — so it must live somewhere they can reach, dedupe by
+ *   source identity across projects, and survive without vault sync.
+ *
+ * What the two genuinely could share is not the store but three lower layers:
+ * source-identity keying, acquisition (the brevilabs conversion call), and
+ * staleness. Folding those into one reusable layer is the right future move;
+ * sharing the `ProjectContextCache` singleton is not (its in-vault, RAG-shaped
+ * storage doesn't fit the absolute-path/off-vault/cross-project-dedup needs here).
+ */
+export function cacheRoot(app: App): string {
+  return path.join(copilotAppDataDir(os.homedir()), "vaults", getVaultId(app), "context-cache");
+}
+
+/** Shared snapshots for remote sources (web pages, YouTube transcripts). */
+export function remotesDir(app: App): string {
+  return path.join(cacheRoot(app), "remotes");
+}
+
+/** Shared snapshots for converted vault binaries (PDF, image, …), keyed by vault path. */
+export function filesDir(app: App): string {
+  return path.join(cacheRoot(app), "files");
+}
+
+/**
+ * Per-project failure markers. Bucketed by `md5(projectId)` because snapshots
+ * are shared but a failure is meaningful only to the project that hit it.
+ */
+export function markersDir(app: App, projectId: string): string {
+  return path.join(cacheRoot(app), "markers", md5(projectId));
+}
+
+/**
+ * Absolute, OS-native path of a snapshot file, derived from its source kind and
+ * basename: remote kinds (web/youtube) live under {@link remotesDir}, converted
+ * vault files under {@link filesDir}. The manifest lists this so the agent reads
+ * the snapshot directly (the shared cache is outside every project's cwd, so an
+ * absolute path is the only pointer reachable across all three backends).
+ */
+export function snapshotAbsPath(app: App, type: MaterializedSourceType, fileName: string): string {
+  return path.join(type === "file" ? filesDir(app) : remotesDir(app), fileName);
+}

--- a/src/context/manifestBuilder.test.ts
+++ b/src/context/manifestBuilder.test.ts
@@ -1,0 +1,124 @@
+import type { MaterializedEntry } from "./contextCacheStore";
+import {
+  buildProjectContextBlock,
+  MAX_MANIFEST_ENTRIES,
+  type ManifestPathEntry,
+  type ManifestSources,
+} from "./manifestBuilder";
+
+function abs(vaultPath: string, absPath?: string): ManifestPathEntry {
+  return absPath ? { vaultPath, absPath } : { vaultPath };
+}
+
+function sources(over: Partial<ManifestSources> = {}): ManifestSources {
+  return {
+    folders: [],
+    notes: [],
+    extensions: [],
+    tags: [],
+    webUrls: [],
+    youtubeUrls: [],
+    materialized: [],
+    ...over,
+  };
+}
+
+describe("buildProjectContextBlock", () => {
+  it("wraps the listing in a <project_context> block", () => {
+    const md = buildProjectContextBlock(sources({ tags: ["#research"] }));
+    expect(md.startsWith("<project_context>")).toBe(true);
+    expect(md.endsWith("</project_context>")).toBe(true);
+  });
+
+  it("lists folders and notes by absolute path without expanding members", () => {
+    const materialized: MaterializedEntry[] = [
+      {
+        type: "web",
+        source: "https://a.com",
+        cacheFileName: "web-1.md",
+        snapshotAbsPath: "/cache/remotes/web-1.md",
+      },
+    ];
+    const md = buildProjectContextBlock(
+      sources({
+        folders: [abs("Papers", "/vault/Papers")],
+        tags: ["#research"],
+        extensions: ["*.pdf"],
+        notes: [abs("Notes/Spec.md", "/vault/Notes/Spec.md")],
+        webUrls: ["https://a.com"],
+        materialized,
+      })
+    );
+
+    expect(md).toContain("## Included folders");
+    expect(md).toContain("`/vault/Papers`");
+    expect(md).toContain("## Included notes");
+    expect(md).toContain("`/vault/Notes/Spec.md`");
+    expect(md).toContain("## Included tags");
+    expect(md).toContain("#research");
+    expect(md).toContain("`*.pdf`");
+    expect(md).toContain("https://a.com → `/cache/remotes/web-1.md`");
+    // No member-file expansion of the folder.
+    expect(md).not.toMatch(/Papers\/\S+\.md/);
+  });
+
+  it("lists a materialized source without a pointer when it has no absolute path", () => {
+    // A snapshot entry that never got an absolute path (e.g. a non-desktop build)
+    // degrades to no pointer — the source stays listed, just unlinked.
+    const materialized: MaterializedEntry[] = [
+      { type: "web", source: "https://a.com", cacheFileName: "web-1.md" },
+    ];
+    const md = buildProjectContextBlock(sources({ webUrls: ["https://a.com"], materialized }));
+    expect(md).toContain("https://a.com");
+    expect(md).not.toContain("https://a.com → ");
+  });
+
+  it("falls back to the vault path when a source has no absolute path", () => {
+    const md = buildProjectContextBlock(
+      sources({ folders: [abs("Missing/")], notes: [abs("[[Ghost]]")] })
+    );
+    expect(md).toContain("`Missing/`");
+    expect(md).toContain("`[[Ghost]]`");
+  });
+
+  it("lists a declared URL even when it has no materialized snapshot (fetch failed)", () => {
+    const md = buildProjectContextBlock(
+      sources({ webUrls: ["https://broken.com"], materialized: [] })
+    );
+    expect(md).toContain("## Included URLs");
+    expect(md).toContain("https://broken.com");
+    // No snapshot pointer when materialization failed.
+    expect(md).not.toContain("https://broken.com → ");
+  });
+
+  it("points web and youtube rows at their own snapshots when the same URL is in both", () => {
+    // parseProjectUrls keeps the same URL as both a web and a youtube source; each
+    // gets its own type-keyed snapshot. The pointer lookup must be type-aware or
+    // one row would resolve to the other's snapshot.
+    const url = "https://youtu.be/abc";
+    const materialized: MaterializedEntry[] = [
+      { type: "web", source: url, cacheFileName: "web-1.md", snapshotAbsPath: "/cache/remotes/web-1.md" }, // prettier-ignore
+      { type: "youtube", source: url, cacheFileName: "youtube-1.md", snapshotAbsPath: "/cache/remotes/youtube-1.md" }, // prettier-ignore
+    ];
+    const md = buildProjectContextBlock(
+      sources({ webUrls: [url], youtubeUrls: [url], materialized })
+    );
+
+    expect(md).toContain(`${url} → \`/cache/remotes/web-1.md\``);
+    expect(md).toContain(`${url} → \`/cache/remotes/youtube-1.md\``);
+  });
+
+  it("states omitted count honestly past the entry cap", () => {
+    const folders = Array.from({ length: MAX_MANIFEST_ENTRIES + 25 }, (_, i) => abs(`Folder${i}`));
+    const md = buildProjectContextBlock(sources({ folders }));
+
+    expect(md).toContain(`Only the first ${MAX_MANIFEST_ENTRIES} of ${folders.length} sources`);
+    expect(md).toContain("25 more are omitted");
+    expect(md).toContain("Use folder/tag search");
+  });
+
+  it("omits the truncation note when under the cap", () => {
+    const md = buildProjectContextBlock(sources({ folders: [abs("A"), abs("B")] }));
+    expect(md).not.toContain("omitted");
+  });
+});

--- a/src/context/manifestBuilder.ts
+++ b/src/context/manifestBuilder.ts
@@ -1,0 +1,123 @@
+import { type MaterializedEntry, type MaterializedSourceType } from "./contextCacheStore";
+
+/**
+ * Hard cap on listed context entries. Past this, the block states how many were
+ * omitted and how to find them — never silently truncating (design §4.4.1).
+ */
+export const MAX_MANIFEST_ENTRIES = 100;
+
+/**
+ * A folder/note source resolved for the context block. `absPath` lets the agent
+ * reach sources that live OUTSIDE the session cwd (the whole reason the block
+ * lists absolute paths); it is absent when the pattern resolves to no on-disk
+ * file/folder (e.g. a not-yet-created note, or a glob), in which case the
+ * user-facing `vaultPath` is listed so the source is never dropped.
+ */
+export interface ManifestPathEntry {
+  vaultPath: string;
+  absPath?: string;
+}
+
+/**
+ * The user's declared context *sources* — never the files a folder/tag expands
+ * to (design §4.1). URLs/YouTube links are always listed even when their fetch
+ * failed (the source is still part of the project); a materialized snapshot
+ * pointer is appended only when one exists.
+ */
+export interface ManifestSources {
+  folders: ManifestPathEntry[];
+  notes: ManifestPathEntry[];
+  extensions: string[];
+  tags: string[];
+  webUrls: string[];
+  youtubeUrls: string[];
+  /** Present cache files, used to resolve snapshot pointers + list file snapshots. */
+  materialized: MaterializedEntry[];
+}
+
+interface ManifestLine {
+  /** Section heading the line belongs under. */
+  section: string;
+  text: string;
+}
+
+/**
+ * Render the `<project_context>` block inlined into a session's first user
+ * prompt: a short, honest map of the project's context sources with absolute
+ * folder/note paths so every backend can reach them (the manifest is inlined
+ * into the prompt, not written as a sidecar cache file the ACP backends would
+ * never discover). Lists at most {@link MAX_MANIFEST_ENTRIES} entries and, when more
+ * exist, says exactly how many were omitted so the agent never mistakes a
+ * partial list for a complete one.
+ */
+export function buildProjectContextBlock(sources: ManifestSources): string {
+  // Pointer = the snapshot's ABSOLUTE path (the shared cache is off-vault, outside
+  // every project cwd, so a relative pointer wouldn't resolve for any backend). An
+  // entry without an absolute path (e.g. a non-desktop build that never filled it)
+  // degrades to no pointer — the source is still listed, just unlinked.
+  // Keyed by `${type}:${source}`, not source alone: the same URL can be configured
+  // as BOTH a web link and a YouTube link (parseProjectUrls keeps both), and each
+  // gets its own type-keyed snapshot — a source-only key would collide and point
+  // one row at the other's snapshot.
+  const snapshotBySource = new Map(
+    sources.materialized
+      .filter((e): e is typeof e & { snapshotAbsPath: string } => Boolean(e.snapshotAbsPath))
+      .map((e) => [`${e.type}:${e.source}`, e.snapshotAbsPath])
+  );
+  const withPointer = (type: MaterializedSourceType, source: string): string => {
+    const absPath = snapshotBySource.get(`${type}:${source}`);
+    return absPath ? `${source} → \`${absPath}\`` : source;
+  };
+  // Prefer the absolute path (reachable from anywhere); fall back to the vault
+  // pattern when the source didn't resolve to a real on-disk path.
+  const pathText = (entry: ManifestPathEntry): string => `\`${entry.absPath ?? entry.vaultPath}\``;
+
+  const lines: ManifestLine[] = [
+    ...sources.folders.map((e) => line("Included folders", pathText(e))),
+    ...sources.notes.map((e) => line("Included notes", pathText(e))),
+    ...sources.extensions.map((p) => line("Included file types", `\`${p}\``)),
+    ...sources.tags.map((t) => line("Included tags", t)),
+    ...sources.webUrls.map((u) => line("Included URLs", withPointer("web", u))),
+    ...sources.youtubeUrls.map((u) => line("Included YouTube", withPointer("youtube", u))),
+    ...sources.materialized
+      .filter((e) => e.type === "file")
+      .map((e) => line("Materialized files", withPointer(e.type, e.source))),
+  ];
+
+  const total = lines.length;
+  const shown = lines.slice(0, MAX_MANIFEST_ENTRIES);
+  const omitted = total - shown.length;
+
+  const out: string[] = [
+    "<project_context>",
+    "Context sources for this project, with absolute paths. Folders and tags are",
+    "listed as sources, not expanded into member files — use your own search",
+    "(grep/glob/read) to enumerate them. Materialized snapshots of URLs, YouTube",
+    "transcripts, and PDFs/images are shown inline as an absolute path after the",
+    "source, formatted `<source> → <absolute path>` — read that path directly. A source",
+    "with no path isn't cached (not yet converted or conversion failed); use the source itself.",
+  ];
+
+  let currentSection = "";
+  for (const item of shown) {
+    if (item.section !== currentSection) {
+      currentSection = item.section;
+      out.push("", `## ${currentSection}`);
+    }
+    out.push(`- ${item.text}`);
+  }
+
+  if (omitted > 0) {
+    out.push(
+      "",
+      `> Only the first ${shown.length} of ${total} sources are listed; ${omitted} more are omitted. ` +
+        `Use folder/tag search (grep/find) to find the rest.`
+    );
+  }
+  out.push("</project_context>");
+  return out.join("\n");
+}
+
+function line(section: string, text: string): ManifestLine {
+  return { section, text };
+}

--- a/src/context/materializeCandidates.ts
+++ b/src/context/materializeCandidates.ts
@@ -1,0 +1,108 @@
+import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
+import { App, TFile } from "obsidian";
+
+/**
+ * Binary/non-text extensions whose content the agent cannot read natively across
+ * backends — parsed to text via brevilabs. Markdown and plain-text files are
+ * already grep-able in the project folder, so they are never materialized.
+ *
+ * Lives in this UI-safe module (no converter / Node-fs / session imports) so the
+ * edit modal's Content Conversion panel can enumerate candidates without pulling
+ * in the materializer's heavyweight dependency graph.
+ */
+export const MATERIALIZE_EXTENSIONS = new Set([
+  "pdf",
+  "doc",
+  "docx",
+  "ppt",
+  "pptx",
+  "epub",
+  "rtf",
+  "xls",
+  "xlsx",
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "bmp",
+  "tiff",
+  "webp",
+]);
+
+// Referential stability: one frozen empty array for every "no candidates" exit.
+const EMPTY_FILES: TFile[] = Object.freeze([] as TFile[]) as TFile[];
+
+// Reason: `app.vault.getFiles()` order is not guaranteed stable across reloads,
+// renames, or index changes. Sorting candidates by path gives both the
+// materializer and the conversion UI a deterministic order, so the manifest's
+// "first N of M" listing and the on-disk conversion cache stay stable run to run.
+const byPath = (a: TFile, b: TFile): number => a.path.localeCompare(b.path);
+
+/**
+ * The vault files the materializer would queue for text conversion, given a
+ * project's context source — the same extension + pattern filter as the
+ * materializer's resolve step. Shared by the materializer itself and the edit
+ * modal's Content Conversion panel, so the panel's file list always matches
+ * what a session start actually materializes. Sorted by path for stable order.
+ */
+export function listMaterializeCandidates(
+  app: App,
+  contextSource: { inclusions?: string; exclusions?: string } | undefined
+): TFile[] {
+  const { inclusions, exclusions } = getMatchingPatterns({
+    inclusions: contextSource?.inclusions,
+    exclusions: contextSource?.exclusions,
+    isProject: true,
+  });
+  if (!inclusions) return EMPTY_FILES;
+  return app.vault
+    .getFiles()
+    .filter((file) => MATERIALIZE_EXTENSIONS.has(file.extension.toLowerCase()))
+    .filter((file) => shouldIndexFile(app, file, inclusions, exclusions, true))
+    .sort(byPath);
+}
+
+export interface MaterializeContextFileSummary {
+  /** Binary/non-text files queued for conversion (same set as {@link listMaterializeCandidates}). */
+  candidates: TFile[];
+  /** Count of matched `.md` files — already grep-able, so listed only as "N skipped". */
+  skippedMarkdownCount: number;
+}
+
+const EMPTY_SUMMARY: MaterializeContextFileSummary = Object.freeze({
+  candidates: EMPTY_FILES,
+  skippedMarkdownCount: 0,
+});
+
+/**
+ * One-pass variant for the Content Conversion panel: returns the conversion
+ * candidates AND how many matched files are plain markdown (no conversion
+ * needed). Computed together so the panel doesn't enumerate the vault twice.
+ */
+export function listMaterializeContextFileSummary(
+  app: App,
+  contextSource: { inclusions?: string; exclusions?: string } | undefined
+): MaterializeContextFileSummary {
+  const { inclusions, exclusions } = getMatchingPatterns({
+    inclusions: contextSource?.inclusions,
+    exclusions: contextSource?.exclusions,
+    isProject: true,
+  });
+  if (!inclusions) return EMPTY_SUMMARY;
+
+  const matched = app.vault
+    .getFiles()
+    .filter((file) => shouldIndexFile(app, file, inclusions, exclusions, true))
+    .sort(byPath);
+  const candidates = matched.filter((file) =>
+    MATERIALIZE_EXTENSIONS.has(file.extension.toLowerCase())
+  );
+  const skippedMarkdownCount = matched.filter(
+    (file) => file.extension.toLowerCase() === "md"
+  ).length;
+
+  return {
+    candidates: candidates.length > 0 ? candidates : EMPTY_FILES,
+    skippedMarkdownCount,
+  };
+}

--- a/src/context/materializeSources.realfs.test.ts
+++ b/src/context/materializeSources.realfs.test.ts
@@ -1,0 +1,220 @@
+import { Mutex } from "async-mutex";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createNodeContextCacheFs } from "./contextCacheFs";
+import {
+  cacheFileName,
+  failureMarkerName,
+  materializeSources,
+  type ContextConverters,
+  type FileSource,
+  type RemoteSource,
+} from "./contextCacheStore";
+
+/**
+ * End-to-end integration of {@link materializeSources} over the PRODUCTION
+ * {@link createNodeContextCacheFs} (real `node:fs`, atomic temp+rename,
+ * root-confined resolve) and a real per-artifact {@link Mutex} lock — the exact
+ * stack the desktop materializer runs. The store's own suite proves the same
+ * decisions against an in-memory fake; this proves the integration seam none of
+ * them touch: the on-disk `remotes/`/`files/`/`markers/<proj>/` layout, the
+ * `<type>-<md5>.md` snapshot names, and that cross-project dedup actually lands a
+ * SINGLE file on disk with a SINGLE fetch. It is the automated stand-in for the
+ * manual `test:vault` checks (items 1, 3, 6) that need a real filesystem.
+ */
+describe("materializeSources × createNodeContextCacheFs (real fs)", () => {
+  let parent: string;
+  let root: string;
+
+  // Cache-root-RELATIVE dirs, mirroring what `cacheRootRelativeDir` hands the
+  // root-confined node fs in production (conversionsLocation's absolute
+  // <root>/remotes, <root>/files, <root>/markers/<md5(projectId)>).
+  const REMOTES = "remotes";
+  const FILES = "files";
+  const MARKERS_A = "markers/projA";
+  const MARKERS_B = "markers/projB";
+  const T0 = 1_700_000_000_000;
+
+  beforeEach(async () => {
+    // `parent` stands in for `vaults/<id>/`; `root` is the cache dir inside it.
+    parent = await fs.promises.mkdtemp(path.join(os.tmpdir(), "ctx-cache-e2e-"));
+    root = path.join(parent, "context-cache");
+    await fs.promises.mkdir(root, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(parent, { recursive: true, force: true });
+  });
+
+  /** A real global per-artifact lock keyed by snapshot file name (the materializer's injection). */
+  function sharedLock(): <T>(key: string, run: () => Promise<T>) => Promise<T> {
+    const mutexes = new Map<string, Mutex>();
+    return (key, run) => {
+      let mutex = mutexes.get(key);
+      if (!mutex) {
+        mutex = new Mutex();
+        mutexes.set(key, mutex);
+      }
+      return mutex.runExclusive(run);
+    };
+  }
+
+  const onDisk = (rel: string): string[] => {
+    try {
+      return fs.readdirSync(path.join(root, rel)).sort();
+    } catch {
+      return [];
+    }
+  };
+
+  // item 1 — same URL across two projects converges to ONE snapshot + ONE fetch.
+  it("dedupes a shared URL to one remotes/web-<md5>.md with a single fetch", async () => {
+    const url = "https://shared.example.com/page";
+    const remotes: RemoteSource[] = [{ type: "web", url }];
+    const fetchRemote = jest.fn(async (s: RemoteSource) => `content for ${s.url}`);
+    const converters: ContextConverters = { fetchRemote, parseFile: jest.fn() };
+    const withSourceLock = sharedLock();
+
+    // Project A (cold) fetches and writes the shared snapshot.
+    const cacheA = createNodeContextCacheFs(root);
+    const resA = await materializeSources({
+      remotesDir: REMOTES, filesDir: FILES, markerDir: MARKERS_A,
+      fs: cacheA, converters, remotes, files: [], nowMs: T0, withSourceLock,
+    }); // prettier-ignore
+
+    const expectedName = cacheFileName("web", url);
+    expect(onDisk(REMOTES)).toEqual([expectedName]);
+    expect(expectedName).toMatch(/^web-[0-9a-f]{32}\.md$/);
+    expect(resA.entries).toHaveLength(1);
+
+    // Project B (distinct marker bucket, same URL) re-reads the present snapshot
+    // inside the lock and cheap-skips — no second fetch, no second file.
+    const cacheB = createNodeContextCacheFs(root);
+    const resB = await materializeSources({
+      remotesDir: REMOTES, filesDir: FILES, markerDir: MARKERS_B,
+      fs: cacheB, converters, remotes, files: [], nowMs: T0 + 1, withSourceLock,
+    }); // prettier-ignore
+
+    expect(fetchRemote).toHaveBeenCalledTimes(1);
+    expect(onDisk(REMOTES)).toEqual([expectedName]);
+    expect(resB.entries).toHaveLength(1);
+    // The snapshot on disk is a real materialized file, not an empty placeholder.
+    expect(fs.readFileSync(path.join(root, REMOTES, expectedName), "utf-8")).toContain(
+      `content for ${url}`
+    );
+  });
+
+  // item 1 (concurrency) — two projects cold-converting the SAME url at once
+  // still fetch once: the per-artifact lock serializes their read-decide-write.
+  it("serializes two concurrent cold converts of one URL to a single fetch (real lock)", async () => {
+    const url = "https://race.example.com";
+    const remotes: RemoteSource[] = [{ type: "web", url }];
+    const withSourceLock = sharedLock();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let fetchCount = 0;
+    const fetchRemote = jest.fn(async (s: RemoteSource) => {
+      fetchCount += 1;
+      await gate; // hold the lock so the second caller is forced to wait
+      return `content #${fetchCount} for ${s.url}`;
+    });
+    const converters: ContextConverters = { fetchRemote, parseFile: jest.fn() };
+
+    const runA = materializeSources({
+      remotesDir: REMOTES, filesDir: FILES, markerDir: MARKERS_A,
+      fs: createNodeContextCacheFs(root), converters, remotes, files: [], nowMs: T0, withSourceLock,
+    }); // prettier-ignore
+    // Let A acquire the lock and reach the gated fetch before B starts.
+    await new Promise((r) => window.setTimeout(r, 0));
+    const runB = materializeSources({
+      remotesDir: REMOTES, filesDir: FILES, markerDir: MARKERS_B,
+      fs: createNodeContextCacheFs(root), converters, remotes, files: [], nowMs: T0 + 1, withSourceLock,
+    }); // prettier-ignore
+    await new Promise((r) => window.setTimeout(r, 0));
+    release();
+    await Promise.all([runA, runB]);
+
+    expect(fetchRemote).toHaveBeenCalledTimes(1);
+    expect(onDisk(REMOTES)).toEqual([cacheFileName("web", url)]);
+  });
+
+  // item 3 — same in-vault PDF across two projects converges to ONE files/ snapshot.
+  it("dedupes a shared PDF to one files/file-<md5>.md with a single parse", async () => {
+    const vaultPath = "Shared/report.pdf";
+    const parseFile = jest.fn(async (_bytes: ArrayBuffer, ext: string) => `parsed ${ext}`);
+    const converters: ContextConverters = { fetchRemote: jest.fn(), parseFile };
+    const withSourceLock = sharedLock();
+    const makeFile = (): FileSource => ({
+      vaultPath,
+      ext: "pdf",
+      mtime: 1000,
+      size: 2048,
+      read: async () => new ArrayBuffer(8),
+    });
+
+    await materializeSources({
+      remotesDir: REMOTES, filesDir: FILES, markerDir: MARKERS_A,
+      fs: createNodeContextCacheFs(root), converters, remotes: [], files: [makeFile()], nowMs: T0, withSourceLock,
+    }); // prettier-ignore
+    const expectedName = cacheFileName("file", vaultPath);
+    expect(onDisk(FILES)).toEqual([expectedName]);
+
+    await materializeSources({
+      remotesDir: REMOTES, filesDir: FILES, markerDir: MARKERS_B,
+      fs: createNodeContextCacheFs(root), converters, remotes: [], files: [makeFile()], nowMs: T0 + 1, withSourceLock,
+    }); // prettier-ignore
+
+    expect(parseFile).toHaveBeenCalledTimes(1);
+    expect(onDisk(FILES)).toEqual([expectedName]);
+  });
+
+  // item 6 (P2) — A fails (marker on disk), B later succeeds (shared snapshot on
+  // disk); A's automatic re-run cheap-skips the shared snapshot AND clears its now
+  // semantically-wrong marker, so the status icon stops reporting a stale failure.
+  it("clears project A's on-disk failure marker once project B materializes the shared source", async () => {
+    const url = "https://flaky.example.com";
+    const remotes: RemoteSource[] = [{ type: "web", url }];
+    const markerName = failureMarkerName("web", url);
+
+    // 1. A fails → marker lands in A's bucket, no snapshot.
+    await materializeSources({
+      remotesDir: REMOTES, filesDir: FILES, markerDir: MARKERS_A,
+      fs: createNodeContextCacheFs(root),
+      converters: {
+        fetchRemote: jest.fn(async () => {
+          throw new Error("network down");
+        }),
+        parseFile: jest.fn(),
+      },
+      remotes, files: [], nowMs: T0,
+    }); // prettier-ignore
+    expect(onDisk(MARKERS_A)).toEqual([markerName]);
+    expect(onDisk(REMOTES)).toEqual([]);
+
+    // 2. B succeeds → shared snapshot written (B never had a marker).
+    await materializeSources({
+      remotesDir: REMOTES, filesDir: FILES, markerDir: MARKERS_B,
+      fs: createNodeContextCacheFs(root),
+      converters: { fetchRemote: jest.fn(async () => "recovered content"), parseFile: jest.fn() },
+      remotes, files: [], nowMs: T0 + 1,
+    }); // prettier-ignore
+    expect(onDisk(REMOTES)).toEqual([cacheFileName("web", url)]);
+
+    // 3. A's next automatic run: cheap-skips the shared snapshot and drops its
+    //    stale marker — no fetch, no reported failure, marker gone from disk.
+    const fetchRemote = jest.fn(async () => "should not run");
+    const { failures } = await materializeSources({
+      remotesDir: REMOTES, filesDir: FILES, markerDir: MARKERS_A,
+      fs: createNodeContextCacheFs(root),
+      converters: { fetchRemote, parseFile: jest.fn() },
+      remotes, files: [], nowMs: T0 + 2,
+    }); // prettier-ignore
+
+    expect(fetchRemote).not.toHaveBeenCalled();
+    expect(failures).toHaveLength(0);
+    expect(onDisk(MARKERS_A)).toEqual([]);
+  });
+});

--- a/src/context/projectContextMaterializer.test.ts
+++ b/src/context/projectContextMaterializer.test.ts
@@ -313,6 +313,37 @@ describe("ensureProjectContextMaterialized — single-flight", () => {
     expect(client.url4llm).toHaveBeenCalledWith("https://b.com");
     expect(client.url4llm).toHaveBeenCalledTimes(2);
   });
+
+  it("supersedes an in-flight run whose source set was edited (a later caller must not join the stale run)", async () => {
+    const app = fakeApp();
+    // Run A materializes source A; gate its fetch so it stays in flight.
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com" }));
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const url4llm = jest.fn(async (url: string) => {
+      if (url === "https://a.com") await gate; // hold run A in flight
+      return { response: url === "https://a.com" ? "A text" : "B text" };
+    });
+    getClient.mockReturnValue({ url4llm, youtube4llm: jest.fn(), docs4llm: jest.fn() });
+
+    const a = ensureProjectContextMaterialized(app, "p1", CWD); // non-force, signature S1
+    await flushMicrotasks(); // A reaches the gated fetch, still in flight
+
+    // The project's context is edited mid-flight → new source set → new signature.
+    getRecord.mockReturnValue(record({ webUrls: "https://b.com" }));
+    const b = ensureProjectContextMaterialized(app, "p1", CWD); // non-force, signature S2
+
+    release(); // let A settle; B's deferred run then materializes the NEW source
+    const [aRes, bRes] = await Promise.all([a, b]);
+
+    // B did NOT join the stale run — it superseded and captured the edited sources.
+    // (Pre-fix, the unconditional non-force join returned A's pre-edit result and
+    // never fetched b.com.)
+    expect(bRes).not.toBe(aRes);
+    expect(url4llm).toHaveBeenCalledWith("https://b.com");
+  });
 });
 
 describe("Option D — failure markers, forced retry, single-source reconcile", () => {

--- a/src/context/projectContextMaterializer.test.ts
+++ b/src/context/projectContextMaterializer.test.ts
@@ -1,0 +1,457 @@
+import { FileSystemAdapter, TFolder, type App } from "obsidian";
+import type { ContextCacheFs } from "./contextCacheFs";
+
+// In-memory fs injected in place of the node cache fs.
+let mockFs: ContextCacheFs & { files: Map<string, string> };
+
+jest.mock("./contextCacheFs", () => ({
+  createNodeContextCacheFs: () => mockFs,
+}));
+
+jest.mock("@/projects/state", () => ({
+  getCachedProjectRecordById: jest.fn(),
+}));
+jest.mock("@/search/searchUtils", () => ({
+  getMatchingPatterns: jest.fn(),
+  shouldIndexFile: jest.fn(() => true),
+}));
+jest.mock("@/LLMProviders/brevilabsClient", () => ({
+  BrevilabsClient: { getInstance: jest.fn() },
+}));
+
+import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
+import { getCachedProjectRecordById } from "@/projects/state";
+import { getMatchingPatterns } from "@/search/searchUtils";
+import {
+  ensureProjectContextMaterialized,
+  materializeProjectContextSource,
+  type ContextMaterializeProgress,
+} from "./projectContextMaterializer";
+
+const getRecord = getCachedProjectRecordById as jest.Mock;
+const getPatterns = getMatchingPatterns as jest.Mock;
+const getClient = BrevilabsClient.getInstance as jest.Mock;
+
+const CWD = "/vault/Proj";
+// Cache writes go to the SHARED off-vault cache now (node-fs backed, mocked here
+// by the in-memory `mockFs`). The store receives cache-root-relative dirs
+// derived by the materializer: `remotes/`, `files/`, and a per-project
+// `markers/<md5(projectId)>/`. The agent-facing absolute folder/note paths still
+// come from `getFullPath` and are asserted as `/vault/...` below — unchanged.
+
+function memFs(): ContextCacheFs & { files: Map<string, string> } {
+  const files = new Map<string, string>();
+  return {
+    files,
+    exists: async (p) => files.has(p),
+    mkdirRecursive: async () => undefined,
+    list: async (dir) => {
+      const prefix = dir.endsWith("/") ? dir : `${dir}/`;
+      return [...files.keys()]
+        .filter((k) => k.startsWith(prefix))
+        .map((k) => k.slice(prefix.length))
+        .filter((n) => !n.includes("/"));
+    },
+    readText: async (p) => {
+      if (!files.has(p)) throw new Error(`ENOENT: ${p}`);
+      return files.get(p)!;
+    },
+    writeText: async (p, c) => void files.set(p, c),
+    remove: async (p) => void files.delete(p),
+  };
+}
+
+function record(contextSource: Record<string, string | undefined>, id = "p1") {
+  return { project: { id, contextSource }, filePath: "Proj/AGENTS.md", folderName: "Proj" };
+}
+
+const flushMicrotasks = () => new Promise((resolve) => window.setTimeout(resolve, 0));
+
+function patterns(over: Record<string, string[]> = {}) {
+  return {
+    inclusions: { folderPatterns: [], notePatterns: [], extensionPatterns: [], tagPatterns: [], ...over }, // prettier-ignore
+    exclusions: null,
+  };
+}
+
+function fakeApp(files: Array<{ path: string; ext: string }> = [], folders: string[] = []): App {
+  const tfiles = files.map((f) => ({
+    path: f.path,
+    extension: f.ext,
+    basename: f.path
+      .split("/")
+      .pop()!
+      .replace(/\.[^.]+$/, ""),
+    stat: { mtime: 1000, size: 10 },
+  }));
+  const folderSet = new Set(folders);
+  const FsAdapter = FileSystemAdapter as unknown as new (basePath: string) => FileSystemAdapter;
+  const Folder = TFolder as unknown as new (path: string) => TFolder;
+  return {
+    vault: {
+      adapter: new FsAdapter("/vault"),
+      getFiles: () => tfiles,
+      getAbstractFileByPath: (p: string) => (folderSet.has(p) ? new Folder(p) : null),
+      readBinary: jest.fn(async () => new ArrayBuffer(4)),
+    },
+  } as unknown as App;
+}
+
+beforeEach(() => {
+  mockFs = memFs();
+  jest.clearAllMocks();
+  getPatterns.mockReturnValue(patterns());
+  getClient.mockReturnValue({
+    url4llm: jest.fn(async () => ({ response: "url text" })),
+    youtube4llm: jest.fn(async () => ({ response: { transcript: "yt text" } })),
+    docs4llm: jest.fn(async () => ({ response: "pdf text" })),
+  });
+});
+
+describe("ensureProjectContextMaterialized", () => {
+  it("returns the frozen empty result when the project is unknown", async () => {
+    getRecord.mockReturnValue(undefined);
+    const result = await ensureProjectContextMaterialized(fakeApp(), "missing", CWD);
+    expect(result.additionalDirectories).toEqual([]);
+    expect(result.projectContextBlock).toBeUndefined();
+  });
+
+  it("returns empty when the project has no context sources", async () => {
+    getRecord.mockReturnValue(record({}));
+    const result = await ensureProjectContextMaterialized(fakeApp(), "p1", CWD);
+    expect(result.additionalDirectories).toEqual([]);
+    expect(result.projectContextBlock).toBeUndefined();
+    expect(mockFs.files.size).toBe(0);
+  });
+
+  it("materializes a web URL into the shared remotes dir and inlines it in the context block", async () => {
+    getRecord.mockReturnValue(record({ webUrls: "https://example.com" }));
+    const result = await ensureProjectContextMaterialized(fakeApp(), "p1", CWD);
+
+    expect(result.projectContextBlock).toContain("<project_context>");
+    expect(result.projectContextBlock).toContain("https://example.com");
+    // No manifest file is written anywhere — context is inline in the prompt.
+    expect([...mockFs.files.keys()].some((k) => k.endsWith("CONTEXT.md"))).toBe(false);
+    // The snapshot lands under the shared `remotes/` dir, not a project dir.
+    const cacheFile = [...mockFs.files.keys()].find((k) => k.startsWith("remotes/web-"));
+    expect(cacheFile).toBeDefined();
+    expect(mockFs.files.get(cacheFile!)).toContain("url text");
+  });
+
+  it("reports only out-of-cwd folder inclusions as additional directories", async () => {
+    getRecord.mockReturnValue(record({ inclusions: "External,Proj/Sub" }));
+    getPatterns.mockReturnValue(patterns({ folderPatterns: ["External", "Proj/Sub"] }));
+    const app = fakeApp([], ["External", "Proj/Sub"]);
+
+    const result = await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    expect(result.additionalDirectories).toEqual(["/vault/External"]);
+    // Both folders are listed in the block with absolute paths (add-dir is only
+    // for the out-of-cwd one).
+    expect(result.projectContextBlock).toContain("`/vault/External`");
+    expect(result.projectContextBlock).toContain("`/vault/Proj/Sub`");
+  });
+
+  it("lists included notes by absolute path in the context block", async () => {
+    getRecord.mockReturnValue(record({ inclusions: "[[Spec]]" }));
+    getPatterns.mockReturnValue(patterns({ notePatterns: ["[[Spec]]"] }));
+    const app = fakeApp([{ path: "Notes/Spec.md", ext: "md" }]);
+
+    const result = await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    expect(result.projectContextBlock).toContain("## Included notes");
+    expect(result.projectContextBlock).toContain("`/vault/Notes/Spec.md`");
+  });
+
+  it("lists every note that shares an inclusion title (basename collision)", async () => {
+    getRecord.mockReturnValue(record({ inclusions: "[[Spec]]" }));
+    getPatterns.mockReturnValue(patterns({ notePatterns: ["[[Spec]]"] }));
+    const app = fakeApp([
+      { path: "A/Spec.md", ext: "md" },
+      { path: "B/Spec.md", ext: "md" },
+    ]);
+
+    const result = await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    expect(result.projectContextBlock).toContain("`/vault/A/Spec.md`");
+    expect(result.projectContextBlock).toContain("`/vault/B/Spec.md`");
+  });
+
+  it("materializes in-vault PDFs but ignores markdown files", async () => {
+    getRecord.mockReturnValue(record({ inclusions: "Proj" }));
+    getPatterns.mockReturnValue(patterns({ folderPatterns: ["Proj"] }));
+    const app = fakeApp([
+      { path: "Proj/a.pdf", ext: "pdf" },
+      { path: "Proj/note.md", ext: "md" },
+    ]);
+
+    await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    const client = getClient.mock.results[0].value as { docs4llm: jest.Mock };
+    expect(client.docs4llm).toHaveBeenCalledTimes(1); // pdf only, never the .md
+    expect([...mockFs.files.keys()].some((k) => k.includes("/file-"))).toBe(true);
+  });
+
+  it("reports resolve + per-loop progress through onProgress", async () => {
+    getRecord.mockReturnValue(record({ inclusions: "Proj", webUrls: "https://example.com" }));
+    getPatterns.mockReturnValue(patterns({ folderPatterns: ["Proj"] }));
+    const app = fakeApp([{ path: "Proj/a.pdf", ext: "pdf" }]);
+
+    const progress: ContextMaterializeProgress[] = [];
+    await ensureProjectContextMaterialized(app, "p1", CWD, (p) => progress.push(p));
+
+    // Resolve fires first, counting the one materialize-eligible binary file.
+    expect(progress[0]).toEqual({ phase: "resolve", resolved: 1 });
+    expect(progress).toContainEqual({ phase: "prefetch", done: 1, total: 1 });
+    expect(progress).toContainEqual({ phase: "parse", done: 1, total: 1 });
+  });
+
+  it("never rejects when a brevilabs fetch fails", async () => {
+    getRecord.mockReturnValue(record({ webUrls: "https://broken.com" }));
+    getClient.mockReturnValue({
+      url4llm: jest.fn(async () => {
+        throw new Error("network down");
+      }),
+      youtube4llm: jest.fn(),
+      docs4llm: jest.fn(),
+    });
+
+    const result = await ensureProjectContextMaterialized(fakeApp(), "p1", CWD);
+    // Degrades gracefully: block still built, no snapshot written, never throws.
+    expect(result.projectContextBlock).toContain("https://broken.com");
+    expect([...mockFs.files.keys()].some((k) => k.startsWith("remotes/web-"))).toBe(false);
+    // No manifest file is written.
+    expect([...mockFs.files.keys()].some((k) => k.endsWith("CONTEXT.md"))).toBe(false);
+  });
+
+  it("returns the frozen empty result if a filesystem write throws", async () => {
+    getRecord.mockReturnValue(record({ webUrls: "https://example.com" }));
+    // mkdir is awaited outside the per-source try/catch, so a hard fs failure
+    // propagates to the never-reject guard and degrades to the empty result.
+    mockFs.mkdirRecursive = jest.fn(async () => {
+      throw new Error("EACCES");
+    });
+
+    const result = await ensureProjectContextMaterialized(fakeApp(), "p1", CWD);
+    expect(result.additionalDirectories).toEqual([]);
+    expect(result.projectContextBlock).toBeUndefined();
+  });
+});
+
+describe("ensureProjectContextMaterialized — single-flight", () => {
+  it("dedupes concurrent calls for the same project to one run", async () => {
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com" }));
+    const app = fakeApp();
+
+    const [r1, r2] = await Promise.all([
+      ensureProjectContextMaterialized(app, "p1", CWD),
+      ensureProjectContextMaterialized(app, "p1", CWD),
+    ]);
+
+    const client = getClient.mock.results[0].value as { url4llm: jest.Mock };
+    expect(client.url4llm).toHaveBeenCalledTimes(1); // fetched once, not twice
+    expect(r1).toBe(r2); // both awaited the same in-flight promise
+  });
+
+  it("does not serialize different projects with DIFFERENT sources", async () => {
+    // Distinct URLs per project: the per-project single-flight doesn't block them
+    // and they don't collide on the global per-artifact lock (different keys).
+    getRecord.mockImplementation((id: string) =>
+      record({ webUrls: id === "p1" ? "https://p1.com" : "https://p2.com" }, id)
+    );
+
+    await Promise.all([
+      ensureProjectContextMaterialized(fakeApp(), "p1", "/vault/P1"),
+      ensureProjectContextMaterialized(fakeApp(), "p2", "/vault/P2"),
+    ]);
+
+    const client = getClient.mock.results[0].value as { url4llm: jest.Mock };
+    expect(client.url4llm).toHaveBeenCalledTimes(2); // one per project, ran in parallel
+  });
+
+  it("dedupes two projects converting the SAME url to a single fetch (global per-artifact lock)", async () => {
+    // Same URL across two distinct projects → same snapshot file name → same
+    // global mutex. The first fetches and writes; the second re-reads the meta
+    // inside the lock and cheap-skips. (The OLD behavior fetched twice.)
+    getRecord.mockImplementation((id: string) => record({ webUrls: "https://shared.com" }, id));
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let calls = 0;
+    const url4llm = jest.fn(async () => {
+      calls += 1;
+      await gate; // hold the lock so the second project is forced to wait
+      return { response: `content #${calls}` };
+    });
+    getClient.mockReturnValue({ url4llm, youtube4llm: jest.fn(), docs4llm: jest.fn() });
+
+    const a = ensureProjectContextMaterialized(fakeApp(), "pA", "/vault/PA");
+    await flushMicrotasks(); // A acquires the lock and reaches the gated fetch
+    const b = ensureProjectContextMaterialized(fakeApp(), "pB", "/vault/PB");
+    await flushMicrotasks(); // B is waiting on the same per-artifact lock
+    release();
+    await Promise.all([a, b]);
+
+    expect(url4llm).toHaveBeenCalledTimes(1); // merged to a single fetch
+    const snapshots = [...mockFs.files.keys()].filter((k) => k.startsWith("remotes/web-"));
+    expect(snapshots).toHaveLength(1);
+    expect(mockFs.files.get(snapshots[0])).toContain("content #1"); // not overwritten by B
+  });
+
+  it("clears the in-flight entry so a later call re-evaluates fresh state", async () => {
+    const app = fakeApp();
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com" }));
+    await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    // After the first run settled, the source changed — a fresh call must run
+    // again (not return the prior settled promise) and fetch the new URL.
+    getRecord.mockReturnValue(record({ webUrls: "https://b.com" }));
+    await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    const client = getClient.mock.results[0].value as { url4llm: jest.Mock };
+    expect(client.url4llm).toHaveBeenCalledWith("https://b.com");
+    expect(client.url4llm).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("Option D — failure markers, forced retry, single-source reconcile", () => {
+  it("cheap-skips a known-bad source on the next automatic run (no re-fetch)", async () => {
+    const app = fakeApp();
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com" }));
+    const url4llm = jest.fn(async () => {
+      throw new Error("network down");
+    });
+    getClient.mockReturnValue({ url4llm, youtube4llm: jest.fn(), docs4llm: jest.fn() });
+
+    await ensureProjectContextMaterialized(app, "p1", CWD);
+    expect([...mockFs.files.keys()].some((k) => k.includes("failed-web-"))).toBe(true);
+
+    // Second automatic pass: the failure marker is honored — the URL is not
+    // re-fetched — yet the failure is still surfaced through onProgress.
+    const progress: ContextMaterializeProgress[] = [];
+    await ensureProjectContextMaterialized(app, "p1", CWD, (p) => progress.push(p));
+
+    expect(url4llm).toHaveBeenCalledTimes(1); // not re-fetched
+    const failures = progress.find((p) => p.phase === "failures");
+    expect(failures?.phase === "failures" && failures.failures).toHaveLength(1);
+  });
+
+  it("materializeProjectContextSource forces a retry past the failure marker", async () => {
+    const app = fakeApp();
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com" }));
+    const url4llm = jest.fn(async (): Promise<{ response: string }> => {
+      throw new Error("network down");
+    });
+    getClient.mockReturnValue({ url4llm, youtube4llm: jest.fn(), docs4llm: jest.fn() });
+    await ensureProjectContextMaterialized(app, "p1", CWD);
+    expect(url4llm).toHaveBeenCalledTimes(1);
+
+    // The single-source Retry forces a fresh fetch even though the marker is on
+    // disk (the automatic path above would have cheap-skipped it).
+    url4llm.mockResolvedValueOnce({ response: "recovered" });
+    const failures = await materializeProjectContextSource(app, "p1", {
+      kind: "web",
+      source: "https://a.com",
+    });
+
+    expect(url4llm).toHaveBeenCalledTimes(2);
+    expect(failures).toHaveLength(0);
+    const snapshot = [...mockFs.files.keys()].find((k) => k.includes("/web-"));
+    expect(mockFs.files.get(snapshot!)).toContain("recovered");
+    expect([...mockFs.files.keys()].some((k) => k.includes("failed-web-"))).toBe(false);
+  });
+
+  it("a forced retry supersedes an in-flight non-force warm; later joiners get the forced result", async () => {
+    const app = fakeApp();
+
+    // Phase 1: source A fails on the automatic path → marker, no snapshot.
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com" }));
+    getClient.mockReturnValue({
+      url4llm: jest.fn(async () => {
+        throw new Error("down");
+      }),
+      youtube4llm: jest.fn(),
+      docs4llm: jest.fn(),
+    });
+    await ensureProjectContextMaterialized(app, "p1", CWD);
+    expect([...mockFs.files.keys()].some((k) => k.includes("failed-web-"))).toBe(true);
+
+    // Phase 2: the source set now also has B (e.g. a source edit kicked off a
+    // warm). The warm is non-force, so it cheap-skips A's marker and only fetches
+    // B; a forced "Retry" arrives while it is in flight.
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com\nhttps://b.com" }));
+    const url4llm = jest.fn(async (url: string) => ({ response: url === "https://a.com" ? "A recovered" : "B text" })); // prettier-ignore
+    getClient.mockReturnValue({ url4llm, youtube4llm: jest.fn(), docs4llm: jest.fn() });
+
+    const warm = ensureProjectContextMaterialized(app, "p1", CWD); // non-force
+    const forced = ensureProjectContextMaterialized(app, "p1", CWD, undefined, true);
+    const joiner = ensureProjectContextMaterialized(app, "p1", CWD); // non-force, lands after the force
+
+    // Resolved-value identity (the fn is async, so promise refs always differ):
+    // a later non-force caller joins the FORCED run, not the stale warm — so a
+    // session-create / landing-refresh after Retry captures the forced result.
+    const [warmRes, forcedRes, joinerRes] = await Promise.all([warm, forced, joiner]);
+    expect(joinerRes).toBe(forcedRes);
+    expect(joinerRes).not.toBe(warmRes);
+
+    // The forced pass re-fetched A past its marker and cleared it (a non-force
+    // warm would have cheap-skipped it); B (written by the warm) cheap-skipped on
+    // its identity fingerprint.
+    expect(url4llm).toHaveBeenCalledWith("https://a.com");
+    const snapshotA = [...mockFs.files.keys()].find(
+      (k) => k.includes("/web-") && mockFs.files.get(k)!.includes("A recovered")
+    );
+    expect(snapshotA).toBeDefined();
+    expect([...mockFs.files.keys()].some((k) => k.includes("failed-web-"))).toBe(false);
+  });
+
+  it("a concurrent full run does not duplicate or clobber a single-source retry (per-artifact lock)", async () => {
+    // Replaces the old reconcile-coordination test. Shared snapshots are never
+    // reconciled, and the retry + full run serialize on the per-artifact lock for
+    // the same URL — so the retry's snapshot survives and is not re-fetched.
+    const app = fakeApp();
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com" }));
+
+    // 1. First automatic run fails → marker on disk, no snapshot.
+    getClient.mockReturnValue({
+      url4llm: jest.fn(async () => {
+        throw new Error("down");
+      }),
+      youtube4llm: jest.fn(),
+      docs4llm: jest.fn(),
+    });
+    await ensureProjectContextMaterialized(app, "p1", CWD);
+    expect([...mockFs.files.keys()].some((k) => k.includes("failed-web-"))).toBe(true);
+
+    // 2. Gate the single-source retry's fetch so it holds the per-artifact lock.
+    let releaseFetch!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    const url4llm = jest.fn(async () => {
+      await gate;
+      return { response: "recovered" };
+    });
+    getClient.mockReturnValue({ url4llm, youtube4llm: jest.fn(), docs4llm: jest.fn() });
+
+    const retry = materializeProjectContextSource(app, "p1", { kind: "web", source: "https://a.com" }); // prettier-ignore
+    await flushMicrotasks(); // the retry acquires the lock and reaches its gated fetch
+
+    // 3. A full run starts during the retry's write window. Its upsert for the
+    //    same URL waits on the same per-artifact lock rather than re-fetching.
+    const full = ensureProjectContextMaterialized(app, "p1", CWD);
+    await flushMicrotasks();
+
+    // 4. Release the retry; both settle.
+    releaseFetch();
+    await Promise.all([retry, full]);
+
+    // 5. One fetch total (the retry's); its snapshot survived, marker cleared.
+    const snapshot = [...mockFs.files.keys()].find((k) => k.startsWith("remotes/web-"));
+    expect(snapshot).toBeDefined();
+    expect(mockFs.files.get(snapshot!)).toContain("recovered");
+    expect([...mockFs.files.keys()].some((k) => k.includes("failed-web-"))).toBe(false);
+    expect(url4llm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/context/projectContextMaterializer.ts
+++ b/src/context/projectContextMaterializer.ts
@@ -262,6 +262,15 @@ async function runMaterialize(
       ...youtubeUrls.map((url): RemoteSource => ({ type: "youtube", url })),
     ];
 
+    // DESIGN NOTE — exclusions are parsed (they gate `listMaterializeCandidates`
+    // below, so excluded binaries aren't converted) but deliberately NOT carried
+    // into the manifest/search guidance. PR2 exclusion is Tier 1 (soft,
+    // best-effort = "don't materialize / don't feed" + ignore files); it does NOT
+    // stop the agent's native grep from reading an excluded file inside an
+    // included folder. That "粒度错配的洞" is explicitly acknowledged-and-unblocked
+    // — hard enforcement needs a backend/OS sandbox (Tier 2/3), deferred past PR2.
+    // See designdocs/agent-projects/PR2_DESIGN.md §4.1.1. If a future review flags
+    // this again, point them at this note.
     const { inclusions } = getMatchingPatterns({
       inclusions: contextSource.inclusions,
       exclusions: contextSource.exclusions,
@@ -269,6 +278,15 @@ async function runMaterialize(
     });
     const folders = inclusions?.folderPatterns ?? [];
     const notes = inclusions?.notePatterns ?? [];
+    // DESIGN NOTE — tag/extension inclusions are forwarded to the manifest as
+    // SOURCE LABELS, not resolved to absolute paths or `additionalDirectories`
+    // (unlike folders/notes, which are concrete locations). PR2 routes tags/
+    // extensions through the agent's NATIVE search (grep/find + a resident
+    // instruction on counting Obsidian tags); precise/efficient resolution
+    // (MCP `tag_search`) is deferred to PR3. So a tag whose matches live outside
+    // the project cwd is reachable only via that native search, by design.
+    // See designdocs/agent-projects/PR2_DESIGN.md §4.1. If a future review flags
+    // this again, point them at this note.
     const extensions = inclusions?.extensionPatterns ?? [];
     const tags = inclusions?.tagPatterns ?? [];
 

--- a/src/context/projectContextMaterializer.ts
+++ b/src/context/projectContextMaterializer.ts
@@ -104,8 +104,7 @@ const EMPTY_RESULT = EMPTY_CONTEXT_MATERIALIZATION_RESULT;
  * the joined caller would write to the pre-rename dir. That window is effectively
  * unreachable, the next session (in-flight entry cleared on settle) self-heals to
  * the new cwd, and keying by cwd would weaken the single-flight (the whole point
- * is to dedupe per project). Not worth the extra key. If a future review flags
- * this again, point them at this note.
+ * is to dedupe per project). Not worth the extra key.
  *
  * The entry carries whether its run is a FORCED retry so the single-flight can
  * tell a background warm apart from a user "Retry": a forced call supersedes an
@@ -269,8 +268,7 @@ async function runMaterialize(
     // stop the agent's native grep from reading an excluded file inside an
     // included folder. That "粒度错配的洞" is explicitly acknowledged-and-unblocked
     // — hard enforcement needs a backend/OS sandbox (Tier 2/3), deferred past PR2.
-    // See designdocs/agent-projects/PR2_DESIGN.md §4.1.1. If a future review flags
-    // this again, point them at this note.
+    // See designdocs/agent-projects/PR2_DESIGN.md §4.1.1.
     const { inclusions } = getMatchingPatterns({
       inclusions: contextSource.inclusions,
       exclusions: contextSource.exclusions,
@@ -285,8 +283,7 @@ async function runMaterialize(
     // instruction on counting Obsidian tags); precise/efficient resolution
     // (MCP `tag_search`) is deferred to PR3. So a tag whose matches live outside
     // the project cwd is reachable only via that native search, by design.
-    // See designdocs/agent-projects/PR2_DESIGN.md §4.1. If a future review flags
-    // this again, point them at this note.
+    // See designdocs/agent-projects/PR2_DESIGN.md §4.1.
     const extensions = inclusions?.extensionPatterns ?? [];
     const tags = inclusions?.tagPatterns ?? [];
 
@@ -575,8 +572,7 @@ function resolveFolderPaths(
  * explicit-path read (verified — `designdocs/agent-projects/verify/ADDDIR_FINDINGS.md`).
  * add-dir is a claude-only autonomous-search enhancement codex/opencode ignore;
  * granting one note's whole parent folder would over-grant — the exact thing
- * `obsidian-copilot-preview#165` aims to curb. If a future review flags this
- * again, point them at this note.
+ * `obsidian-copilot-preview#165` aims to curb.
  */
 function resolveNotePaths(
   app: App,

--- a/src/context/projectContextMaterializer.ts
+++ b/src/context/projectContextMaterializer.ts
@@ -108,12 +108,23 @@ const EMPTY_RESULT = EMPTY_CONTEXT_MATERIALIZATION_RESULT;
  *
  * The entry carries whether its run is a FORCED retry so the single-flight can
  * tell a background warm apart from a user "Retry": a forced call supersedes an
- * in-flight non-force run (see {@link ensureProjectContextMaterialized}).
+ * in-flight non-force run (see {@link ensureProjectContextMaterialized}). It also
+ * carries the context signature the run is materializing, so a caller wanting a
+ * NEWER source set (the project's context was edited mid-flight) supersedes the
+ * stale run instead of joining it.
  */
 interface InFlightMaterialization {
   promise: Promise<ContextMaterializationResult>;
   /** True when this run bypasses failure markers (a user-initiated retry). */
   forceRetryFailed: boolean;
+  /**
+   * Context signature ({@link getProjectContextSignature}) of the project record
+   * this run is materializing, captured when the run was queued. A later caller
+   * whose record signature differs supersedes rather than joins — otherwise it
+   * would receive the pre-edit `<project_context>` / `additionalDirectories`.
+   * `undefined` when no record was cached at queue time.
+   */
+  contextSignature: string | undefined;
 }
 
 const inFlightMaterializations = new Map<string, InFlightMaterialization>();
@@ -201,17 +212,34 @@ export async function ensureProjectContextMaterialized(
   forceRetryFailed?: boolean
 ): Promise<ContextMaterializationResult> {
   const force = forceRetryFailed ?? false;
+  // Captured synchronously so an incoming caller can tell whether the in-flight
+  // run is materializing the source revision it actually wants.
+  const record = getCachedProjectRecordById(projectId);
+  const currentSignature = record ? getProjectContextSignature(record) : undefined;
   const existing = inFlightMaterializations.get(projectId);
   // Single-flight: a second concurrent caller joins the in-flight run and its
   // `onProgress` is intentionally dropped — the flight owner's sink already
   // drives the shared progress atom, so every reader still sees live counts.
   //
-  // A non-force caller always joins; a forced retry joins only an already-forced
-  // run. A forced retry that finds a NON-force run in flight (e.g. a background
-  // warm, which never owns the blocking atom and so is invisible to the manager's
-  // early-exit check) must NOT join it — that would cheap-skip the known-bad
-  // sources the user explicitly asked to re-fetch. Instead it SUPERSEDES below.
-  if (existing && (!force || existing.forceRetryFailed)) return existing.promise;
+  // A caller joins ONLY when the in-flight run is materializing the SAME source
+  // set it wants (matching signature). If the project's context was edited while
+  // a run is in flight, that run's signature is now stale — joining it would hand
+  // the caller the pre-edit `<project_context>` / `additionalDirectories` (and the
+  // queued first send would flush with the old sources), so it SUPERSEDES below
+  // to capture the new sources instead.
+  //
+  // Among same-signature runs: a non-force caller joins; a forced retry joins only
+  // an already-forced run. A forced retry that finds a NON-force run in flight
+  // (e.g. a background warm, invisible to the manager's early-exit check) must NOT
+  // join it — that would cheap-skip the known-bad sources the user explicitly
+  // asked to re-fetch. Instead it SUPERSEDES below.
+  if (
+    existing &&
+    existing.contextSignature === currentSignature &&
+    (!force || existing.forceRetryFailed)
+  ) {
+    return existing.promise;
+  }
 
   // Take over the slot SYNCHRONOUSLY so a concurrent session-create joins this
   // forced run rather than the run it replaces — but defer the forced run's own
@@ -229,7 +257,11 @@ export async function ensureProjectContextMaterialized(
       inFlightMaterializations.delete(projectId);
     }
   });
-  inFlightMaterializations.set(projectId, { promise, forceRetryFailed: force });
+  inFlightMaterializations.set(projectId, {
+    promise,
+    forceRetryFailed: force,
+    contextSignature: currentSignature,
+  });
   return promise;
 }
 

--- a/src/context/projectContextMaterializer.ts
+++ b/src/context/projectContextMaterializer.ts
@@ -1,0 +1,603 @@
+import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
+import { err2String } from "@/errorFormat";
+import { logInfo, logWarn } from "@/logger";
+import { getCachedProjectRecordById } from "@/projects/state";
+import { getProjectContextSignature } from "@/projects/projectContextSignature";
+import { getMatchingPatterns } from "@/search/searchUtils";
+import { listMaterializeCandidates } from "@/context/materializeCandidates";
+import { Mutex } from "async-mutex";
+import { App, FileSystemAdapter, TFile, TFolder } from "obsidian";
+import { createNodeContextCacheFs } from "./contextCacheFs";
+import {
+  cacheRoot,
+  filesDir,
+  markersDir,
+  remotesDir,
+  snapshotAbsPath,
+} from "./conversionsLocation";
+import {
+  materializeSources,
+  reconcileMarkers,
+  type ContextConverters,
+  type FileSource,
+  type MaterializedSourceType,
+  type MaterializeSourceIdentity,
+  type RemoteSource,
+  type SourceFailure,
+} from "./contextCacheStore";
+import { buildProjectContextBlock, type ManifestPathEntry } from "./manifestBuilder";
+
+/**
+ * Plain-data result of materializing a project's context before a session opens.
+ *
+ * This is the shared contract resolved by a session's `contextReady`. Keep it
+ * minimal: searchable roots plus the optional inline context block — nothing
+ * else. Reason: progress counts for the UI loading card live in a SEPARATE
+ * `agentProjectContextLoadAtom`, never here, so this stays a clean dirs+block
+ * value that any backend / the UI can consume without folding in load state.
+ */
+export interface ContextMaterializationResult {
+  /** Absolute paths to widen the agent's searchable roots (add-dir). Empty if none. */
+  additionalDirectories: string[];
+  /**
+   * The `<project_context>` block to inline into the session's FIRST user
+   * prompt (absolute folder/note paths, snapshot pointers, tag/ext/URL guides).
+   * Undefined when the project declares no context sources.
+   */
+  projectContextBlock?: string;
+  /**
+   * The context signature of the project record THIS run actually read (see
+   * {@link getProjectContextSignature}). Lets a caller tell which source revision
+   * was captured — critical because the single-flight guard can hand a joined
+   * caller a result materialized from an EARLIER record than the one live now.
+   * Undefined only when no record was found, or the whole run threw.
+   */
+  contextSignature?: string;
+}
+
+/**
+ * Live progress for the materialization steps, surfaced to the UI loading card.
+ * Carried OUT-OF-BAND from {@link ContextMaterializationResult} (counts never
+ * fold into the result) so the result stays a clean dirs+block value. The
+ * session manager is the sole subscriber and republishes these to the
+ * projectId-keyed `agentProjectContextLoadAtom`.
+ */
+export type ContextMaterializeProgress =
+  | { phase: "resolve"; resolved: number }
+  | { phase: "prefetch"; done: number; total: number }
+  | { phase: "parse"; done: number; total: number }
+  | { phase: "itemStart"; item: MaterializeSourceIdentity }
+  | { phase: "itemFailed"; item: MaterializeSourceIdentity; failure: SourceFailure }
+  | { phase: "itemSettled"; item: MaterializeSourceIdentity }
+  | { phase: "failures"; failures: SourceFailure[] };
+
+export type ContextMaterializeProgressFn = (progress: ContextMaterializeProgress) => void;
+
+// Referential stability: a single frozen empty array for every "no context" exit.
+const EMPTY_DIRECTORIES: string[] = Object.freeze([] as string[]) as string[];
+/**
+ * Frozen fallback result for the "no usable record / whole-run failure" exits —
+ * NO `contextSignature`, so it never clears a caller's dirty flag (nothing was
+ * captured). A project that resolves to no sources returns a DISTINCT result
+ * carrying its signature (so its dirty flag can clear); only the record-absent
+ * and catch paths use this shared frozen reference. Exported so the session
+ * manager's materialize-failure path hands back the same reference.
+ */
+export const EMPTY_CONTEXT_MATERIALIZATION_RESULT: ContextMaterializationResult = Object.freeze({
+  additionalDirectories: EMPTY_DIRECTORIES,
+});
+const EMPTY_RESULT = EMPTY_CONTEXT_MATERIALIZATION_RESULT;
+
+/**
+ * Per-project single-flight guard. Concurrent cold-start sessions for the same
+ * project (e.g. the user opens a second chat / a history-load races the first)
+ * would otherwise each miss the disk cheap-skip before the first write lands and
+ * redundantly hit brevilabs + race on the same hash-named cache files. The map
+ * entry is cleared once the promise settles, so a later call re-evaluates fresh
+ * on-disk fingerprints (idempotent). Mirrors `inFlightMigrations`.
+ *
+ * DESIGN NOTE — keyed by `projectId` ALONE, not `projectId+cwd`. `cwd` is a pure
+ * function of `projectId` (`resolveScopeCwd` → `dirname(record.filePath)`), so
+ * two concurrent calls for the same project resolve the same cwd. They could
+ * diverge only if the project folder is renamed in the sub-second window between
+ * two cold-start session opens while a materialize is mid-flight — at which point
+ * the joined caller would write to the pre-rename dir. That window is effectively
+ * unreachable, the next session (in-flight entry cleared on settle) self-heals to
+ * the new cwd, and keying by cwd would weaken the single-flight (the whole point
+ * is to dedupe per project). Not worth the extra key. If a future review flags
+ * this again, point them at this note.
+ *
+ * The entry carries whether its run is a FORCED retry so the single-flight can
+ * tell a background warm apart from a user "Retry": a forced call supersedes an
+ * in-flight non-force run (see {@link ensureProjectContextMaterialized}).
+ */
+interface InFlightMaterialization {
+  promise: Promise<ContextMaterializationResult>;
+  /** True when this run bypasses failure markers (a user-initiated retry). */
+  forceRetryFailed: boolean;
+}
+
+const inFlightMaterializations = new Map<string, InFlightMaterialization>();
+
+/**
+ * Global per-artifact locks keyed by snapshot file name. Because the file name is
+ * derived from the source IDENTITY (never the project), the SAME source across
+ * two projects maps to the SAME mutex — so two projects cold-converting one URL
+ * converge to a single fetch: the first acquires the lock, reads meta (miss),
+ * fetches, atomically writes, releases; the second waits, acquires, re-reads the
+ * now-present meta, and cheap-skips without re-fetching or overwriting. Mirrors
+ * CAG's `ProjectContextCache.getOrCreateProjectMutex`.
+ *
+ * The map is bounded by the count of distinct cached sources in a vault (small),
+ * so it is never pruned — matching CAG, which likewise retains its mutexes.
+ */
+const sourceArtifactMutexes = new Map<string, Mutex>();
+
+/**
+ * Get-or-create the mutex for a snapshot file name. No creation lock is needed
+ * (unlike CAG's belt-and-suspenders `mutexCreationMutex`): there is no `await`
+ * between the `get` and the `set`, so in JS's single-threaded model two
+ * concurrent callers run this synchronously to completion and observe the same
+ * instance. # Reason: a creation mutex would only matter if creation could yield.
+ */
+function getSourceArtifactMutex(key: string): Mutex {
+  let mutex = sourceArtifactMutexes.get(key);
+  if (!mutex) {
+    mutex = new Mutex();
+    sourceArtifactMutexes.set(key, mutex);
+  }
+  return mutex;
+}
+
+/** Run a source's read-decide-write under its global per-artifact lock. */
+function withSourceLock<T>(key: string, run: () => Promise<T>): Promise<T> {
+  return getSourceArtifactMutex(key).runExclusive(run);
+}
+
+/**
+ * Cache-root-RELATIVE form of a conversionsLocation absolute directory, for the
+ * root-confined node fs (which rejects absolute paths). conversionsLocation
+ * builds every directory under `root`, so the relative part is the suffix after
+ * the root prefix; normalized to POSIX so the node fs resolves it identically on
+ * every OS. Fails loud if the path is not actually under root (it always is —
+ * this guards a future layout drift rather than a live case).
+ */
+function cacheRootRelativeDir(root: string, absoluteDir: string): string {
+  const normRoot = toPosix(root).replace(/\/+$/, "");
+  const normDir = toPosix(absoluteDir).replace(/\/+$/, "");
+  if (normDir === normRoot) return "";
+  const prefix = `${normRoot}/`;
+  if (!normDir.startsWith(prefix)) {
+    throw new Error(`context-cache directory escapes root: ${absoluteDir}`);
+  }
+  return normDir.slice(prefix.length);
+}
+
+/** Normalize OS-native separators to POSIX for the root-confined node fs. */
+function toPosix(p: string): string {
+  return p.replace(/\\/g, "/");
+}
+
+/**
+ * Materialize a project's external context (URLs/YouTube/PDFs/images) into the
+ * vault's shared off-vault conversion cache, build a source manifest, and report
+ * any out-of-cwd folder inclusions as extra searchable roots. Called by the
+ * session manager at its cwd choke points, after config migration + cwd
+ * resolution.
+ *
+ * Contract (relied on by the manager): NEVER rejects — any failure degrades to a
+ * best-effort partial / empty result so session start is never blocked. Cheap on
+ * unchanged context (successful snapshots cheap-skip by fingerprint, known-bad
+ * sources cheap-skip by failure marker). Concurrent calls for the same project
+ * dedupe to one in-flight run; concurrent runs across projects converging on one
+ * shared source dedupe to a single fetch via the per-artifact lock.
+ * `forceRetryFailed` (the status popover's "Retry") re-attempts known-bad sources
+ * instead of honoring their markers. Writes only under the off-vault cache root.
+ */
+export async function ensureProjectContextMaterialized(
+  app: App,
+  projectId: string,
+  cwd: string,
+  onProgress?: ContextMaterializeProgressFn,
+  forceRetryFailed?: boolean
+): Promise<ContextMaterializationResult> {
+  const force = forceRetryFailed ?? false;
+  const existing = inFlightMaterializations.get(projectId);
+  // Single-flight: a second concurrent caller joins the in-flight run and its
+  // `onProgress` is intentionally dropped — the flight owner's sink already
+  // drives the shared progress atom, so every reader still sees live counts.
+  //
+  // A non-force caller always joins; a forced retry joins only an already-forced
+  // run. A forced retry that finds a NON-force run in flight (e.g. a background
+  // warm, which never owns the blocking atom and so is invisible to the manager's
+  // early-exit check) must NOT join it — that would cheap-skip the known-bad
+  // sources the user explicitly asked to re-fetch. Instead it SUPERSEDES below.
+  if (existing && (!force || existing.forceRetryFailed)) return existing.promise;
+
+  // Take over the slot SYNCHRONOUSLY so a concurrent session-create joins this
+  // forced run rather than the run it replaces — but defer the forced run's own
+  // disk work until the prior run settles, so the two never race-write the same
+  // hash-named cache files (the prior keeps the never-reject contract, so its
+  // rejection can't happen, but guard defensively).
+  const prior = existing?.promise;
+  const promise = (async () => {
+    if (prior) await prior.catch(() => undefined);
+    return runMaterialize(app, projectId, cwd, onProgress, force);
+  })().finally(() => {
+    // Guarded clear: a superseded prior run's own `finally` may fire after we've
+    // claimed the slot, so only delete when it still points at THIS promise.
+    if (inFlightMaterializations.get(projectId)?.promise === promise) {
+      inFlightMaterializations.delete(projectId);
+    }
+  });
+  inFlightMaterializations.set(projectId, { promise, forceRetryFailed: force });
+  return promise;
+}
+
+/**
+ * The materialization body, wrapped so it always resolves with a result —
+ * `ensureProjectContextMaterialized` adds the single-flight guard on top.
+ */
+async function runMaterialize(
+  app: App,
+  projectId: string,
+  cwd: string,
+  onProgress?: ContextMaterializeProgressFn,
+  forceRetryFailed?: boolean
+): Promise<ContextMaterializationResult> {
+  try {
+    const record = getCachedProjectRecordById(projectId);
+    if (!record) return EMPTY_RESULT;
+    // Captured up front from the record THIS run reads, so the result reports the
+    // exact source revision it materialized (the dirty-tracking caller relies on
+    // this to avoid clearing a flag a newer edit raised — see the result field).
+    const contextSignature = getProjectContextSignature(record);
+    const contextSource = record.project.contextSource;
+    if (!contextSource) return { additionalDirectories: EMPTY_DIRECTORIES, contextSignature };
+
+    const webUrls = splitLines(contextSource.webUrls);
+    const youtubeUrls = splitLines(contextSource.youtubeUrls);
+    const remotes: RemoteSource[] = [
+      ...webUrls.map((url): RemoteSource => ({ type: "web", url })),
+      ...youtubeUrls.map((url): RemoteSource => ({ type: "youtube", url })),
+    ];
+
+    const { inclusions } = getMatchingPatterns({
+      inclusions: contextSource.inclusions,
+      exclusions: contextSource.exclusions,
+      isProject: true,
+    });
+    const folders = inclusions?.folderPatterns ?? [];
+    const notes = inclusions?.notePatterns ?? [];
+    const extensions = inclusions?.extensionPatterns ?? [];
+    const tags = inclusions?.tagPatterns ?? [];
+
+    const adapter = getVaultFileSystemAdapter(app);
+    const { entries: folderEntries, additionalDirectories } = resolveFolderPaths(
+      app,
+      folders,
+      cwd,
+      adapter
+    );
+    const noteEntries = resolveNotePaths(app, notes, adapter);
+
+    const files: FileSource[] = inclusions
+      ? listMaterializeCandidates(app, contextSource).map((file) => ({
+          vaultPath: file.path,
+          ext: file.extension.toLowerCase(),
+          mtime: file.stat.mtime,
+          size: file.stat.size,
+          read: () => app.vault.readBinary(file),
+        }))
+      : [];
+
+    const hasAnySource =
+      remotes.length > 0 ||
+      files.length > 0 ||
+      folders.length > 0 ||
+      notes.length > 0 ||
+      extensions.length > 0 ||
+      tags.length > 0 ||
+      additionalDirectories.length > 0;
+    if (!hasAnySource) return { additionalDirectories: EMPTY_DIRECTORIES, contextSignature };
+
+    // Inclusions are resolved; report the count of binary files queued for
+    // materialization so the loading card can show "Resolve files (N)".
+    onProgress?.({ phase: "resolve", resolved: files.length });
+
+    // The cache is OFF-VAULT and SHARED across projects: remote/file snapshots
+    // are keyed by source identity (one copy per vault), only failure markers are
+    // per-project. The node fs is root-confined at `cacheRoot`, so the store gets
+    // cache-root-relative dirs (it rejects absolute paths). These node builtins
+    // run desktop-only — the materializer is reachable solely through the dynamic
+    // Agent Mode chunk (see main.ts desktop gate).
+    const root = cacheRoot(app);
+    const fs = createNodeContextCacheFs(root);
+    const remotesRel = cacheRootRelativeDir(root, remotesDir(app));
+    const filesRel = cacheRootRelativeDir(root, filesDir(app));
+    const markersRel = cacheRootRelativeDir(root, markersDir(app, projectId));
+
+    const { entries, wantedMarkerNames, failures } = await materializeSources({
+      remotesDir: remotesRel,
+      filesDir: filesRel,
+      markerDir: markersRel,
+      fs,
+      converters: createConverters(),
+      remotes,
+      files,
+      nowMs: Date.now(),
+      forceRetryFailed,
+      onProgress,
+      withSourceLock,
+    });
+
+    // Surface per-source failures out-of-band (never folded into the result, which
+    // stays a clean dirs+block value). Always emitted — an empty array clears any
+    // prior run's failures in the subscriber.
+    onProgress?.({ phase: "failures", failures });
+
+    // Resolve each present snapshot to its absolute, off-vault path so the
+    // manifest can point the agent straight at it (the shared cache lives outside
+    // every project cwd; an absolute path is the only pointer all three backends
+    // can reach). conversionsLocation owns the layout, so the type→bucket mapping
+    // is not duplicated here. Desktop-only, like the rest of this function.
+    const manifestEntries = entries.map((entry) => ({
+      ...entry,
+      snapshotAbsPath: snapshotAbsPath(app, entry.type, entry.cacheFileName),
+    }));
+
+    const projectContextBlock = buildProjectContextBlock({
+      folders: folderEntries,
+      notes: noteEntries,
+      extensions,
+      tags,
+      webUrls,
+      youtubeUrls,
+      materialized: manifestEntries,
+    });
+    // No manifest file is written: the block above is inlined into the session's
+    // first user prompt. Only the per-project failure markers are reconciled —
+    // shared snapshots are never pruned against one project's sources (that would
+    // delete files other projects still reference).
+    await reconcileMarkers(fs, markersRel, wantedMarkerNames);
+
+    logInfo(
+      `[project-context] materialized ${entries.length} source(s) for ${projectId}; ` +
+        `add-dir=${additionalDirectories.length}, failures=${failures.length}`
+    );
+
+    return {
+      additionalDirectories:
+        additionalDirectories.length > 0 ? additionalDirectories : EMPTY_DIRECTORIES,
+      projectContextBlock,
+      contextSignature,
+    };
+  } catch (err) {
+    // A failure HERE (not a per-source fetch/parse error, which never throws) is a
+    // whole-materialization breakdown: cache fs, reconcile, or block builder. Keep
+    // the never-reject contract, but surface it as a single synthetic failure so
+    // the status icon can still flag "context unavailable" with a readable cause.
+    const error = err2String(err);
+    logWarn(`[project-context] materialize failed for ${projectId}; continuing`, err);
+    onProgress?.({
+      phase: "failures",
+      failures: [{ source: "Project context", kind: "file", error, usedStaleSnapshot: false }],
+    });
+    return EMPTY_RESULT;
+  }
+}
+
+/** Brevilabs-backed converters. Empty results throw so no useless cache file is written. */
+function createConverters(): ContextConverters {
+  return {
+    fetchRemote: async (source) => {
+      const client = BrevilabsClient.getInstance();
+      const content =
+        source.type === "youtube"
+          ? ((await client.youtube4llm(source.url)).response?.transcript ?? "")
+          : ((await client.url4llm(source.url)).response ?? "");
+      if (!content.trim()) throw new Error(`empty content for ${source.url}`);
+      return content;
+    },
+    parseFile: async (bytes, ext) => {
+      const { response } = await BrevilabsClient.getInstance().docs4llm(bytes, ext);
+      const content = docs4llmToText(response);
+      if (!content.trim()) throw new Error(`empty parse result for .${ext}`);
+      return content;
+    },
+  };
+}
+
+/**
+ * Re-materialize a SINGLE context source — the per-row "Retry" in the Content
+ * Conversion panel. Reuses the same off-vault cache dirs / converters as the full
+ * run but skips reconcile: it only (re)writes this one source's snapshot or
+ * failure marker (materializeSources clears the marker on success), leaving every
+ * other source untouched. Forces a retry past the failure marker (this IS the
+ * user's explicit retry). The per-artifact lock makes this safe against a
+ * concurrent full run on the same source — they serialize on the snapshot key, so
+ * neither overwrites the other and shared snapshots (never reconciled) can't be
+ * reaped. Returns this source's failures (empty on success). Never throws,
+ * mirroring the full run's contract.
+ */
+export async function materializeProjectContextSource(
+  app: App,
+  projectId: string,
+  item: { kind: MaterializedSourceType; source: string }
+): Promise<SourceFailure[]> {
+  const record = getCachedProjectRecordById(projectId);
+  if (!record) {
+    return [
+      {
+        source: item.source,
+        kind: item.kind,
+        error: "Project not found",
+        usedStaleSnapshot: false,
+      },
+    ];
+  }
+
+  let remotes: RemoteSource[] = [];
+  let files: FileSource[] = [];
+  if (item.kind === "file") {
+    const file = app.vault.getAbstractFileByPath(item.source);
+    if (!(file instanceof TFile)) {
+      return [
+        {
+          source: item.source,
+          kind: "file",
+          error: "File not found in vault",
+          usedStaleSnapshot: false,
+        },
+      ];
+    }
+    files = [
+      {
+        vaultPath: file.path,
+        ext: file.extension.toLowerCase(),
+        mtime: file.stat.mtime,
+        size: file.stat.size,
+        read: () => app.vault.readBinary(file),
+      },
+    ];
+  } else {
+    remotes = [{ type: item.kind, url: item.source }];
+  }
+
+  try {
+    const root = cacheRoot(app);
+    const fs = createNodeContextCacheFs(root);
+    const { failures } = await materializeSources({
+      remotesDir: cacheRootRelativeDir(root, remotesDir(app)),
+      filesDir: cacheRootRelativeDir(root, filesDir(app)),
+      markerDir: cacheRootRelativeDir(root, markersDir(app, projectId)),
+      fs,
+      converters: createConverters(),
+      remotes,
+      files,
+      nowMs: Date.now(),
+      forceRetryFailed: true,
+      withSourceLock,
+    });
+    return failures;
+  } catch (err) {
+    return [
+      { source: item.source, kind: item.kind, error: err2String(err), usedStaleSnapshot: false },
+    ];
+  }
+}
+
+/** docs4llm's `response` is `unknown` — normalize to text for the cache file. */
+function docs4llmToText(response: unknown): string {
+  if (typeof response === "string") return response;
+  try {
+    return JSON.stringify(response, null, 2);
+  } catch (err) {
+    logWarn(`[project-context] could not stringify docs4llm response: ${err2String(err)}`);
+    return "";
+  }
+}
+
+/**
+ * The desktop disk-backed adapter, or null otherwise. Used to turn vault paths
+ * into absolute OS paths (`getFullPath`) for the agent backend's searchable
+ * roots; a non-disk adapter (mobile / in-memory) degrades to vault-path-only
+ * manifest entries with no add-dir.
+ */
+function getVaultFileSystemAdapter(app: App): FileSystemAdapter | null {
+  const adapter = app.vault.adapter;
+  return adapter instanceof FileSystemAdapter ? adapter : null;
+}
+
+/**
+ * Resolve folder inclusions to absolute `ManifestPathEntry`s for the context
+ * block, and collect the subset that lives OUTSIDE the project cwd as add-dir
+ * roots. In-cwd folders need no add-dir (already searchable); a pattern that
+ * doesn't resolve to a real folder (e.g. a glob) is still listed in the block by
+ * its vault path, just without an absolute path / add-dir entry.
+ */
+function resolveFolderPaths(
+  app: App,
+  folderPatterns: string[],
+  cwd: string,
+  adapter: FileSystemAdapter | null
+): { entries: ManifestPathEntry[]; additionalDirectories: string[] } {
+  const entries: ManifestPathEntry[] = [];
+  const external = new Set<string>();
+  for (const pattern of folderPatterns) {
+    const vaultPath = pattern.replace(/\/+$/, "");
+    const folder = app.vault.getAbstractFileByPath(vaultPath);
+    if (adapter && folder instanceof TFolder) {
+      const abs = adapter.getFullPath(folder.path);
+      entries.push({ vaultPath, absPath: abs });
+      if (!isUnderCwd(cwd, abs)) external.add(abs);
+    } else {
+      entries.push({ vaultPath });
+    }
+  }
+  return {
+    entries,
+    additionalDirectories: external.size > 0 ? [...external] : EMPTY_DIRECTORIES,
+  };
+}
+
+/**
+ * Resolve `[[Title]]` note inclusions to absolute `ManifestPathEntry`s. The
+ * title is matched against file basenames, mirroring how `searchUtils`'
+ * `matchFilePathWithNotes` pairs a note pattern to a vault file — so a title
+ * shared by several notes lists EVERY match (matching the inclusion semantics),
+ * not just the first. A pattern with no matching file is still listed by its raw
+ * `[[Title]]` form so the source is never dropped.
+ *
+ * DESIGN NOTE — notes deliberately do NOT contribute to `additionalDirectories`
+ * (folders do; see {@link resolveFolderPaths}). Trigger: a note included from
+ * OUTSIDE the project cwd. Assessment: NOT a defect (P-low, no live trigger).
+ * Under the soft-scope model the note's absolute path listed in the
+ * `<project_context>` block is readable on all three backends today via
+ * explicit-path read (verified — `designdocs/agent-projects/verify/ADDDIR_FINDINGS.md`).
+ * add-dir is a claude-only autonomous-search enhancement codex/opencode ignore;
+ * granting one note's whole parent folder would over-grant — the exact thing
+ * `obsidian-copilot-preview#165` aims to curb. If a future review flags this
+ * again, point them at this note.
+ */
+function resolveNotePaths(
+  app: App,
+  notePatterns: string[],
+  adapter: FileSystemAdapter | null
+): ManifestPathEntry[] {
+  if (notePatterns.length === 0) return [];
+  const files = adapter ? app.vault.getFiles() : [];
+  return notePatterns.flatMap((pattern) => {
+    // categorizePatterns guarantees the `[[ ... ]]` shape, so slicing is safe.
+    const title = pattern.slice(2, -2);
+    if (!adapter) return [{ vaultPath: pattern }];
+    const matches = files.filter((file) => file.basename === title);
+    if (matches.length === 0) return [{ vaultPath: pattern }];
+    return matches.map((file) => ({
+      vaultPath: file.path,
+      absPath: adapter.getFullPath(file.path),
+    }));
+  });
+}
+
+/**
+ * Whether an absolute path lives at or under the session cwd. Compared on
+ * forward-slash-normalized strings (not `node:path`) so it holds regardless of
+ * the OS separator `getFullPath`/cwd report — folders already inside the cwd
+ * need no add-dir root; only the rest become searchable-root entries.
+ */
+function isUnderCwd(cwd: string, abs: string): boolean {
+  const norm = (p: string) => p.replace(/\\/g, "/").replace(/\/+$/, "");
+  const base = norm(cwd);
+  const target = norm(abs);
+  return target === base || target.startsWith(`${base}/`);
+}
+
+/** Split a newline-joined config string into trimmed, non-empty entries. */
+function splitLines(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}

--- a/src/context/projectMarkerCleanup.test.ts
+++ b/src/context/projectMarkerCleanup.test.ts
@@ -1,0 +1,47 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { App } from "obsidian";
+import { clearProjectMarkers } from "./projectMarkerCleanup";
+import { markersDir } from "./conversionsLocation";
+
+jest.mock("./conversionsLocation", () => ({ markersDir: jest.fn() }));
+
+const mockedMarkersDir = markersDir as jest.MockedFunction<typeof markersDir>;
+const app = {} as App;
+
+describe("clearProjectMarkers", () => {
+  let root: string;
+
+  beforeEach(async () => {
+    // A stand-in cache root with two project marker buckets and a shared snapshot.
+    root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "marker-cleanup-"));
+    await fs.promises.mkdir(path.join(root, "markers", "projA"), { recursive: true });
+    await fs.promises.mkdir(path.join(root, "markers", "projB"), { recursive: true });
+    await fs.promises.mkdir(path.join(root, "remotes"), { recursive: true });
+    await fs.promises.writeFile(path.join(root, "markers", "projA", "failed-web-1.json"), "{}");
+    await fs.promises.writeFile(path.join(root, "markers", "projB", "failed-web-2.json"), "{}");
+    await fs.promises.writeFile(path.join(root, "remotes", "web-1.md"), "snapshot");
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(root, { recursive: true, force: true });
+    mockedMarkersDir.mockReset();
+  });
+
+  it("removes only the target project's bucket, leaving siblings and snapshots", async () => {
+    mockedMarkersDir.mockReturnValue(path.join(root, "markers", "projA"));
+
+    await clearProjectMarkers(app, "project-a");
+
+    expect(fs.existsSync(path.join(root, "markers", "projA"))).toBe(false);
+    // A sibling project's markers and the shared snapshot cache must survive.
+    expect(fs.existsSync(path.join(root, "markers", "projB", "failed-web-2.json"))).toBe(true);
+    expect(fs.existsSync(path.join(root, "remotes", "web-1.md"))).toBe(true);
+  });
+
+  it("is a no-op for a blank project id (never resolves a bucket path)", async () => {
+    await clearProjectMarkers(app, "   ");
+    expect(mockedMarkersDir).not.toHaveBeenCalled();
+  });
+});

--- a/src/context/projectMarkerCleanup.ts
+++ b/src/context/projectMarkerCleanup.ts
@@ -1,0 +1,28 @@
+import { createNodeContextCacheFs } from "@/context/contextCacheFs";
+import { markersDir } from "@/context/conversionsLocation";
+import type { App } from "obsidian";
+
+/**
+ * Delete one project's failure-marker bucket from the off-vault conversion cache.
+ *
+ * Materialized snapshots (`remotes/`, `files/`) are shared vault-wide and must
+ * survive deleting any single project; only the per-project `markers/<hash>/`
+ * bucket is project-scoped, so that is all this removes. Recreating a project
+ * under the same id would otherwise inherit stale negative-cache entries.
+ *
+ * Confinement: we root a {@link createNodeContextCacheFs} AT the bucket directory
+ * and call its recursive `clear()`, so the wipe targets exactly that bucket and
+ * cannot reach shared snapshots or sibling projects' markers. This reuses the
+ * existing recursive-clear path rather than widening `remove()` (which is
+ * intentionally non-recursive) to delete a non-empty directory.
+ *
+ * Desktop-only: it pulls in node-backed cache modules, so callers must gate on
+ * the desktop runtime and dynamically import this module (mirroring the global
+ * "Clear Copilot cache" command). Best-effort by construction — `clear()`
+ * tolerates a missing bucket.
+ */
+export async function clearProjectMarkers(app: App, projectId: string): Promise<void> {
+  const normalizedId = (projectId || "").trim();
+  if (!normalizedId) return;
+  await createNodeContextCacheFs(markersDir(app, normalizedId)).clear();
+}

--- a/src/hooks/useChatFileDrop.test.tsx
+++ b/src/hooks/useChatFileDrop.test.tsx
@@ -1,0 +1,80 @@
+import { useChatFileDrop } from "@/hooks/useChatFileDrop";
+import { createEvent, fireEvent, render } from "@testing-library/react";
+import type { App } from "obsidian";
+import React, { useEffect, useRef } from "react";
+
+/**
+ * Regression guard for the stuck drag-overlay bug: a drop that lands in an inner
+ * `data-copilot-drop-zone` stops propagating in the BUBBLE phase (the zone owns
+ * its own persistence), so the outer chat container's bubble `handleDrop` never
+ * runs to clear `isDragActive`. The fix is a CAPTURE-phase cleanup listener that
+ * fires before the inner zone's stopPropagation — this test pins that contract.
+ */
+
+interface FakeItem {
+  kind: "string" | "file";
+}
+
+/** Minimal DataTransfer carrying only the fields the hook reads. */
+function makeDataTransfer(items: FakeItem[]) {
+  return {
+    types: [] as string[],
+    dropEffect: "",
+    items: items.map((item) => ({ kind: item.kind })),
+  };
+}
+
+function dispatchDrag(type: "dragOver" | "drop", target: HTMLElement, items: FakeItem[]): void {
+  const event = createEvent[type](target, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "dataTransfer", { value: makeDataTransfer(items) });
+  fireEvent(target, event);
+}
+
+/**
+ * Outer container wired to the hook, with an inner drop zone that mimics
+ * `usePersistentContextDrop`: a native bubble-phase `drop` listener that stops
+ * propagation, so the outer bubble handler is bypassed exactly as in production.
+ */
+function Harness({ app }: { app: App }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const innerZoneRef = useRef<HTMLDivElement>(null);
+  const { isDragActive } = useChatFileDrop({
+    app,
+    contextNotes: [],
+    setContextNotes: jest.fn(),
+    selectedImages: [],
+    onAddImage: jest.fn(),
+    containerRef,
+  });
+
+  useEffect(() => {
+    const innerZone = innerZoneRef.current;
+    if (!innerZone) return;
+    const stopBubble = (event: Event) => event.stopPropagation();
+    innerZone.addEventListener("drop", stopBubble);
+    return () => innerZone.removeEventListener("drop", stopBubble);
+  }, []);
+
+  return (
+    <div ref={containerRef}>
+      <div data-testid="overlay">{isDragActive ? "active" : "idle"}</div>
+      <div ref={innerZoneRef} data-copilot-drop-zone="" data-testid="inner-zone" />
+    </div>
+  );
+}
+
+describe("useChatFileDrop", () => {
+  it("clears the overlay when a drop lands in an inner zone that stops bubbling", () => {
+    const { getByTestId } = render(<Harness app={{} as App} />);
+    const overlay = getByTestId("overlay");
+
+    // Dragging over the outer container raises the overlay.
+    dispatchDrag("dragOver", getByTestId("overlay"), [{ kind: "file" }]);
+    expect(overlay.textContent).toBe("active");
+
+    // Dropping into the inner zone (which stops bubble propagation) must still
+    // clear the overlay via the capture-phase listener.
+    dispatchDrag("drop", getByTestId("inner-zone"), [{ kind: "file" }]);
+    expect(overlay.textContent).toBe("idle");
+  });
+});

--- a/src/hooks/useChatFileDrop.ts
+++ b/src/hooks/useChatFileDrop.ts
@@ -109,6 +109,16 @@ export function useChatFileDrop(props: UseChatFileDropProps): UseChatFileDropRet
      * Handle dragover event to show visual feedback
      */
     const handleDragOver = (e: DragEvent) => {
+      // An inner element can own its own drop semantics (e.g. the project
+      // context section persists an inclusion instead of attaching to the
+      // draft). Yield there: clear our overlay and let the zone's handlers
+      // run. Registered in the CAPTURE phase below, since such zones
+      // stopPropagation() in the bubble phase and we'd never see the event.
+      const target = e.target instanceof HTMLElement ? e.target : null;
+      if (target?.closest("[data-copilot-drop-zone]")) {
+        setIsDragActive(false);
+        return;
+      }
       e.preventDefault();
       if (e.dataTransfer) {
         e.dataTransfer.dropEffect = "copy";
@@ -150,6 +160,11 @@ export function useChatFileDrop(props: UseChatFileDropProps): UseChatFileDropRet
      */
     const handleDrop = async (e: DragEvent) => {
       if (!e.dataTransfer) return;
+      // Symmetric with the dragover yield: a drop inside a marked inner zone
+      // belongs to that zone — never also attach it to the draft, even if the
+      // zone's own handler forgot to stopPropagation().
+      const target = e.target instanceof HTMLElement ? e.target : null;
+      if (target?.closest("[data-copilot-drop-zone]")) return;
       e.preventDefault();
 
       // Clear drag state
@@ -254,16 +269,30 @@ export function useChatFileDrop(props: UseChatFileDropProps): UseChatFileDropRet
       void handleDrop(e);
     };
 
-    // Attach event listeners
-    container.addEventListener("dragover", handleDragOver);
+    // Always clear our overlay on ANY drop, even one that lands in an inner
+    // drop zone. Such a zone stops propagation in the BUBBLE phase, so the
+    // bubble-phase handleDrop above never runs to clear `isDragActive` — leaving
+    // a stuck overlay after a drop that grazed the outer area first. This
+    // capture-phase listener fires before the zone's stopPropagation, so the
+    // overlay always clears. State cleanup only — it never preventDefaults or
+    // handles the drop, so the bubble handler still owns draft injection.
+    const handleDropCaptureCleanup = () => setIsDragActive(false);
+
+    // Attach event listeners. dragover uses the capture phase so the
+    // inner-zone yield above runs even when a nested drop zone stops
+    // propagation in the bubble phase; drop stays on bubble so a zone's
+    // stopPropagation() keeps its drop from also landing in the draft.
+    container.addEventListener("dragover", handleDragOver, true);
     container.addEventListener("dragleave", handleDragLeave);
     container.addEventListener("drop", handleDropEvent);
+    container.addEventListener("drop", handleDropCaptureCleanup, true);
 
     // Cleanup
     return () => {
-      container.removeEventListener("dragover", handleDragOver);
+      container.removeEventListener("dragover", handleDragOver, true);
       container.removeEventListener("dragleave", handleDragLeave);
       container.removeEventListener("drop", handleDropEvent);
+      container.removeEventListener("drop", handleDropCaptureCleanup, true);
     };
   }, [app, contextNotes, selectedImages, onAddImage, setContextNotes, containerRef]);
 

--- a/src/hooks/useRecentUsageManagerRevision.ts
+++ b/src/hooks/useRecentUsageManagerRevision.ts
@@ -1,0 +1,25 @@
+import { RecentUsageManager } from "@/utils/recentUsageManager";
+import { useCallback, useSyncExternalStore } from "react";
+
+/**
+ * Subscribe to a {@link RecentUsageManager}'s revision so the UI can re-sort when
+ * in-memory usage changes — even when the backing list reference is unchanged.
+ *
+ * Reason: the manager updates its in-memory "last used" timestamps immediately on
+ * `touch()` but only throttle-persists to disk (~30s). Sorting purely on the
+ * persisted timestamp would show a stale order within the throttle window. Reading
+ * this revision as a render dependency forces a re-sort the moment memory changes.
+ *
+ * Handles a missing manager safely: a stable no-op subscribe and a constant `0`
+ * snapshot, so callers can pass `null`/`undefined` without conditional hooks.
+ */
+export function useRecentUsageManagerRevision<Key extends string>(
+  manager: RecentUsageManager<Key> | null | undefined
+): number {
+  const subscribe = useCallback(
+    (onChange: () => void) => manager?.subscribe(onChange) ?? (() => {}),
+    [manager]
+  );
+  const getSnapshot = useCallback(() => manager?.getRevision() ?? 0, [manager]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/src/mentions/Mention.ts
+++ b/src/mentions/Mention.ts
@@ -10,6 +10,7 @@ import { err2String, isTwitterUrl, isYoutubeUrl } from "@/utils";
 import { logError } from "@/logger";
 import { isSelfHostModeValid } from "@/plusUtils";
 import { getSettings } from "@/settings/model";
+import { extractUrlsFromText } from "@/utils/urlTagUtils";
 
 export interface MentionData {
   type: string;
@@ -36,18 +37,11 @@ export class Mention {
   }
 
   extractAllUrls(text: string): string[] {
-    // Match URLs and trim any trailing commas
-    const urlRegex = /https?:\/\/[^\s"'<>]+/g;
-    return (text.match(urlRegex) || [])
-      .map((url) => url.replace(/,+$/, "")) // Remove trailing commas
-      .filter((url, index, self) => self.indexOf(url) === index); // Remove duplicates
+    return extractUrlsFromText(text);
   }
 
   extractUrls(text: string): string[] {
-    const urlRegex = /https?:\/\/[^\s"'<>]+/g;
-    return (text.match(urlRegex) || [])
-      .map((url) => url.replace(/,+$/, ""))
-      .filter((url, index, self) => self.indexOf(url) === index);
+    return extractUrlsFromText(text);
   }
 
   async processUrl(url: string): Promise<Url4llmResponse & { error?: string }> {

--- a/src/projects/ProjectFileManager.test.ts
+++ b/src/projects/ProjectFileManager.test.ts
@@ -40,6 +40,11 @@ jest.mock("@/projects/projectUtils", () => ({
   getProjectConfigFilePath: jest.fn((name: string) => `copilot-projects/${name}/project.md`),
 }));
 
+jest.mock("@/projects/ensureAgentsMirror", () => ({
+  ensureAgentsMirror: jest.fn(async () => {}),
+  removeAgentsMirror: jest.fn(async () => {}),
+}));
+
 jest.mock("@/utils", () => ({
   ensureFolderExists: jest.fn(async () => {}),
 }));

--- a/src/projects/ProjectFileManager.ts
+++ b/src/projects/ProjectFileManager.ts
@@ -38,6 +38,7 @@ import {
   upsertCachedProjectRecord,
 } from "@/projects/state";
 import { ensureFolderExists } from "@/utils";
+import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { RecentUsageManager } from "@/utils/recentUsageManager";
 import {
   isInVaultCache,
@@ -612,6 +613,18 @@ export class ProjectFileManager {
       await ProjectContextCache.getInstance()
         .clearForProject(existing.project)
         .catch((err) => logError("[Projects] Failed to clear context cache on delete", err));
+
+      // Reason: the vault-level cache above leaves the off-vault failure-marker
+      // bucket (markers/<md5(projectId)>) behind. Clearing it stops a project
+      // recreated under the same id from inheriting stale negative-cache state.
+      // Desktop-gated + dynamically imported so node-backed cache modules never
+      // load on mobile; best-effort so a cleanup failure can't strand the delete.
+      if (isDesktopRuntime()) {
+        const { clearProjectMarkers } = await import("@/context/projectMarkerCleanup");
+        await clearProjectMarkers(this.app, normalizedId).catch((err) =>
+          logError(`[Projects] Failed to clear off-vault failure markers on delete`, err)
+        );
+      }
 
       logInfo(`[Projects] Deleted project: ${normalizedId} -> ${folderPath}`);
 

--- a/src/projects/ProjectFileManager.ts
+++ b/src/projects/ProjectFileManager.ts
@@ -17,6 +17,7 @@ import {
   PROJECTS_UNSUPPORTED_FOLDER_NAME,
 } from "@/projects/constants";
 import { ProjectFileRecord } from "@/projects/type";
+import { ensureAgentsMirror, removeAgentsMirror } from "@/projects/ensureAgentsMirror";
 import {
   fetchAllProjects,
   getProjectConfigFilePath,
@@ -88,7 +89,16 @@ export class ProjectFileManager {
   public async initialize(): Promise<void> {
     logInfo("[Projects] Initializing ProjectFileManager");
     await ensureProjectsMigratedIfNeeded(this.app);
-    await loadAllProjects(this.app);
+    const records = await loadAllProjects(this.app);
+    // Best-effort UX: pre-generate the AGENTS.md mirror for already-loaded projects so
+    // codex/opencode discover instructions even before a per-project session-start ensure.
+    // Runs here (after load), NOT in the settings-migration layer. Never blocks startup.
+    await this.ensureAgentsMirrorsForAll(records);
+  }
+
+  /** Generate/refresh the AGENTS.md mirror for every loaded project (best-effort batch). */
+  private async ensureAgentsMirrorsForAll(records: ProjectFileRecord[]): Promise<void> {
+    await Promise.all(records.map((record) => ensureAgentsMirror(this.app, record)));
   }
 
   /**
@@ -225,7 +235,8 @@ export class ProjectFileManager {
   }
 
   /**
-   * Create a new project file (\<projectsFolder\>/\<id\>/project.md).
+   * Create a new project file at \<projectsFolder\>/\<folderName\>/project.md (the single
+   * source of truth), then generate its one-way AGENTS.md mirror for codex/opencode.
    * @param project - ProjectConfig to create
    * @returns Newly created ProjectFileRecord
    */
@@ -316,6 +327,8 @@ export class ProjectFileManager {
 
       upsertCachedProjectRecord(record);
       logInfo(`[Projects] Created project: ${projectId} -> ${filePath}`);
+      // Best-effort: generate the one-way AGENTS.md mirror from the new instruction body.
+      await ensureAgentsMirror(this.app, record);
       return record;
     } finally {
       removePendingFileWrite(filePath);
@@ -363,6 +376,8 @@ export class ProjectFileManager {
 
     if (nextFolderName !== existing.folderName) {
       const newFolderPath = getProjectFolderPath(nextFolderName);
+      // Reason: a folder rename keeps the config basename (`project.md`), so the new config
+      // path is just `project.md` under the renamed folder.
       const newFilePath = getProjectConfigFilePath(nextFolderName);
 
       // Check collision: cache (case-insensitive) + filesystem
@@ -495,6 +510,10 @@ export class ProjectFileManager {
 
       upsertCachedProjectRecord(updated);
 
+      // Best-effort: refresh the one-way AGENTS.md mirror. When only context/url/last-used
+      // changed (instruction body unchanged), ensureAgentsMirror cheap-skips the write.
+      await ensureAgentsMirror(this.app, updated);
+
       logInfo(`[Projects] Updated project: ${normalizedId} -> ${filePath}`);
       return updated;
     } catch (writeError) {
@@ -533,8 +552,9 @@ export class ProjectFileManager {
   }
 
   /**
-   * Delete a project by id. Deletes only the managed project.md file, then removes
-   * the folder if it is empty (to avoid deleting user-created files).
+   * Delete a project by id. Deletes the managed project.md file and its generated AGENTS.md
+   * mirror (only when the mirror carries the marker — a user's own AGENTS.md is left alone),
+   * then removes the folder if it is empty (to avoid deleting user-created files).
    * @param projectId - Project id to delete
    */
   public async deleteProject(projectId: string): Promise<void> {
@@ -565,6 +585,10 @@ export class ProjectFileManager {
       // Reason: clear cache immediately after file deletion to prevent phantom project
       // state if the subsequent folder cleanup fails.
       deleteCachedProjectRecordById(normalizedId);
+
+      // Reason: drop the generated mirror (marker-gated) so the folder can be emptied and a
+      // stale AGENTS.md doesn't linger. A user-authored AGENTS.md is preserved (no marker).
+      await removeAgentsMirror(this.app, existing);
 
       // Cleanup: remove the folder only if it is empty after deleting project.md.
       // Best-effort: the project file is already gone, so cleanup failure

--- a/src/projects/constants.ts
+++ b/src/projects/constants.ts
@@ -30,5 +30,24 @@ export const COPILOT_PROJECT_WEB_URLS = "copilot-project-web-urls";
 export const COPILOT_PROJECT_YOUTUBE_URLS = "copilot-project-youtube-urls";
 
 // File structure conventions
+//
+// `project.md` is the single source of truth for a project: frontmatter config plus the
+// markdown instruction body. It is the only file the scanner/register recognize, and it is
+// never renamed. `AGENTS.md` is a one-way, plugin-generated mirror of the composed project
+// instructions — the built-in project policy layered ahead of the `project.md` body (see
+// {@link ensureAgentsMirror}) — that codex/opencode auto-discover from the session cwd. It is
+// derived output, never a config source, and is excluded from recognition here.
 export const PROJECT_CONFIG_FILE_NAME = "project.md";
+
+/** Bare file name of the generated, one-way instruction mirror read by codex/opencode from cwd. */
+export const AGENTS_MIRROR_FILE = "AGENTS.md";
+
+/**
+ * Folder, relative to a project's directory (the session cwd), where the agent is steered to
+ * write generated/intermediate files. A name, not a path: the built-in project system prompt
+ * (`projectSystemPrompt.ts`) and any future Outputs UI both reference this single constant
+ * instead of re-hardcoding the string.
+ */
+export const PROJECT_OUTPUTS_DIRNAME = "outputs";
+
 export const PROJECTS_UNSUPPORTED_FOLDER_NAME = "unsupported";

--- a/src/projects/ensureAgentsMirror.test.ts
+++ b/src/projects/ensureAgentsMirror.test.ts
@@ -1,0 +1,238 @@
+import { App } from "obsidian";
+import {
+  ensureAgentsMirror,
+  isGeneratedAgentsMirrorContent,
+  MIRROR_MARKER_PREFIX,
+  removeAgentsMirror,
+} from "@/projects/ensureAgentsMirror";
+import {
+  BUILTIN_PROJECT_SYSTEM_PROMPT,
+  composeProjectInstructions,
+} from "@/projects/projectSystemPrompt";
+import { ProjectFileRecord } from "@/projects/type";
+import { mockTFile, mockTFolder } from "@/__tests__/mockObsidian";
+
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({ projectsFolder: "copilot-projects" })),
+}));
+
+jest.mock("@/projects/state", () => ({
+  addPendingFileWrite: jest.fn(),
+  removePendingFileWrite: jest.fn(),
+}));
+
+jest.mock("@/logger", () => ({
+  logError: jest.fn(),
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+}));
+
+const FOLDER = "copilot-projects/Foo";
+const MIRROR_PATH = `${FOLDER}/AGENTS.md`;
+
+/**
+ * Minimal in-memory vault: tracks on-disk content per path plus which paths the vault has
+ * indexed as TFiles (vs. hidden-folder files only visible through the adapter).
+ */
+class FakeVault {
+  files = new Map<string, string>();
+  cached = new Set<string>();
+  folders = new Set<string>([FOLDER]);
+
+  // Spy hooks
+  modify = jest.fn(async (file: { path: string }, content: string) => {
+    this.files.set(file.path, content);
+  });
+  create = jest.fn(async (path: string, content: string) => {
+    this.files.set(path, content);
+    this.cached.add(path);
+    return mockTFile({ path, name: path.split("/").pop(), extension: "md" });
+  });
+  trash = jest.fn(async (file: { path: string }) => {
+    this.files.delete(file.path);
+    this.cached.delete(file.path);
+  });
+
+  getAbstractFileByPath = (path: string) => {
+    if (this.folders.has(path)) return mockTFolder({ name: path.split("/").pop(), children: [] });
+    if (this.cached.has(path) && this.files.has(path)) {
+      return mockTFile({ path, name: path.split("/").pop(), extension: "md" });
+    }
+    return null;
+  };
+  read = (file: { path: string }) => Promise.resolve(this.files.get(file.path) ?? "");
+
+  adapter = {
+    exists: jest.fn((path: string) => Promise.resolve(this.files.has(path))),
+    read: jest.fn((path: string) => Promise.resolve(this.files.get(path) ?? "")),
+    write: jest.fn(async (path: string, content: string) => {
+      this.files.set(path, content);
+    }),
+    remove: jest.fn(async (path: string) => {
+      this.files.delete(path);
+    }),
+  };
+
+  /** Seed a file as already on disk and indexed by the vault cache. */
+  seedCached(path: string, content: string) {
+    this.files.set(path, content);
+    this.cached.add(path);
+  }
+}
+
+function makeApp(vault: FakeVault): App {
+  return {
+    vault,
+    fileManager: { trashFile: (file: { path: string }) => vault.trash(file) },
+  } as unknown as App;
+}
+
+function makeRecord(systemPrompt: string, extra?: Record<string, unknown>): ProjectFileRecord {
+  return {
+    project: {
+      id: "p1",
+      name: "Foo",
+      systemPrompt,
+      contextSource: {},
+      ...extra,
+    } as unknown as ProjectFileRecord["project"],
+    filePath: `${FOLDER}/project.md`,
+    folderName: "Foo",
+  };
+}
+
+describe("ensureAgentsMirror", () => {
+  it("generates a marker'd mirror whose payload is exactly the composed instructions", async () => {
+    const vault = new FakeVault();
+    await ensureAgentsMirror(makeApp(vault), makeRecord("Be concise."));
+
+    const written = vault.files.get(MIRROR_PATH)!;
+    expect(written).toBeDefined();
+    // The whole file is one marker line + one blank line + the composed body, byte-exact.
+    const [markerLine] = written.split("\n", 1);
+    expect(markerLine.startsWith(MIRROR_MARKER_PREFIX)).toBe(true);
+    expect(written).toBe(`${markerLine}\n\n${composeProjectInstructions("Be concise.")}`);
+  });
+
+  it("cheap-skips when the instruction body is unchanged (even if other config fields change)", async () => {
+    const vault = new FakeVault();
+    const app = makeApp(vault);
+    await ensureAgentsMirror(app, makeRecord("Body A", { contextSource: { inclusions: "a/" } }));
+    vault.modify.mockClear();
+    vault.create.mockClear();
+    vault.adapter.write.mockClear();
+
+    // Same body, different context → must NOT rewrite the mirror.
+    await ensureAgentsMirror(app, makeRecord("Body A", { contextSource: { inclusions: "b/" } }));
+    expect(vault.modify).not.toHaveBeenCalled();
+    expect(vault.create).not.toHaveBeenCalled();
+    expect(vault.adapter.write).not.toHaveBeenCalled();
+  });
+
+  it("rewrites the mirror when the instruction body changes", async () => {
+    const vault = new FakeVault();
+    const app = makeApp(vault);
+    await ensureAgentsMirror(app, makeRecord("Body A"));
+    await ensureAgentsMirror(app, makeRecord("Body B"));
+    expect(vault.files.get(MIRROR_PATH)!.endsWith("Body B")).toBe(true);
+  });
+
+  it("NEVER overwrites a user-authored AGENTS.md with no marker", async () => {
+    const vault = new FakeVault();
+    const userContent = "# My own agents file\nHand written, no marker.";
+    vault.seedCached(MIRROR_PATH, userContent);
+
+    await ensureAgentsMirror(makeApp(vault), makeRecord("Plugin instructions"));
+
+    expect(vault.files.get(MIRROR_PATH)).toBe(userContent);
+    expect(vault.modify).not.toHaveBeenCalled();
+  });
+
+  it("keeps a marker'd mirror carrying the built-in policy when the user body becomes empty", async () => {
+    const vault = new FakeVault();
+    const app = makeApp(vault);
+    await ensureAgentsMirror(app, makeRecord("Something"));
+    expect(vault.files.get(MIRROR_PATH)).toContain("Something");
+
+    // Emptying the user's project.md body no longer deletes the mirror: the composed body still
+    // carries the built-in project policy, so the file is rewritten to that policy alone.
+    await ensureAgentsMirror(app, makeRecord(""));
+    const written = vault.files.get(MIRROR_PATH);
+    expect(written).toContain(BUILTIN_PROJECT_SYSTEM_PROMPT);
+    expect(written).not.toContain("Something");
+  });
+
+  it("leaves a no-marker user file untouched — so codex/opencode get no built-in layer there (known exception)", async () => {
+    const vault = new FakeVault();
+    vault.seedCached(MIRROR_PATH, "user file, no marker");
+    // A user who removed the marker owns the file; we never overwrite it. The trade-off is that
+    // this project's codex/opencode sessions don't receive the built-in policy via the mirror
+    // (Claude still does, via getProjectProfile). Intentional — it matches AGENTS.md precedence,
+    // where user/local content wins. If a future review flags this, point them here.
+    await ensureAgentsMirror(makeApp(vault), makeRecord("anything"));
+    expect(vault.files.get(MIRROR_PATH)).toBe("user file, no marker");
+  });
+});
+
+describe("removeAgentsMirror", () => {
+  it("deletes only a marker'd mirror", async () => {
+    const vault = new FakeVault();
+    const app = makeApp(vault);
+    await ensureAgentsMirror(app, makeRecord("body"));
+    expect(vault.files.has(MIRROR_PATH)).toBe(true);
+
+    await removeAgentsMirror(app, makeRecord("body"));
+    expect(vault.files.has(MIRROR_PATH)).toBe(false);
+  });
+
+  it("leaves a user-authored AGENTS.md (no marker) untouched", async () => {
+    const vault = new FakeVault();
+    vault.seedCached(MIRROR_PATH, "user content");
+    await removeAgentsMirror(makeApp(vault), makeRecord("body"));
+    expect(vault.files.get(MIRROR_PATH)).toBe("user content");
+  });
+});
+
+describe("isGeneratedAgentsMirrorContent", () => {
+  it("is true for content carrying the generated marker envelope", async () => {
+    // Build a real mirror via ensureAgentsMirror so the marker matches exactly.
+    const vault = new FakeVault();
+    await ensureAgentsMirror(makeApp(vault), makeRecord("Be concise."));
+    const generated = vault.files.get(MIRROR_PATH)!;
+    expect(isGeneratedAgentsMirrorContent(generated)).toBe(true);
+  });
+
+  it("is false for a user-authored file and for empty content", () => {
+    expect(isGeneratedAgentsMirrorContent("# My own agents file\nno marker")).toBe(false);
+    expect(isGeneratedAgentsMirrorContent("")).toBe(false);
+  });
+});
+
+describe("marker prefix recognition", () => {
+  // An older/alternate marker wording that still shares the stable machine prefix and a
+  // well-formed envelope — recognition must accept it (the whole point of keying off the prefix
+  // rather than the full line, so the human-facing tail can evolve without orphaning files).
+  const oldTail = `${MIRROR_MARKER_PREFIX} v1 — DO NOT EDIT. Older wording. -->`;
+
+  const BOM = String.fromCharCode(0xfeff); // U+FEFF byte-order mark
+
+  it("recognizes an older marker wording sharing the stable prefix (LF, CRLF, BOM)", () => {
+    expect(isGeneratedAgentsMirrorContent(`${oldTail}\n\nbody`)).toBe(true);
+    expect(isGeneratedAgentsMirrorContent(`${oldTail}\r\n\r\nbody`)).toBe(true);
+    expect(isGeneratedAgentsMirrorContent(`${BOM}${oldTail}\n\nbody`)).toBe(true);
+  });
+
+  it("rejects malformed or look-alike first lines (treated as user files)", () => {
+    // No blank line between marker and body.
+    expect(isGeneratedAgentsMirrorContent(`${oldTail}\nbody`)).toBe(false);
+    // Mixed newline styles across the envelope (only consistent `\n\n` / `\r\n\r\n` is ours).
+    expect(isGeneratedAgentsMirrorContent(`${oldTail}\r\n\nbody`)).toBe(false);
+    expect(isGeneratedAgentsMirrorContent(`${oldTail}\n\r\nbody`)).toBe(false);
+    // First line never closes the HTML comment.
+    expect(isGeneratedAgentsMirrorContent(`${MIRROR_MARKER_PREFIX} v1 unterminated\n\nbody`)).toBe(
+      false
+    );
+    // Prefix with no space boundary (e.g. `…generated-agents-mirrorish`).
+    expect(isGeneratedAgentsMirrorContent(`${MIRROR_MARKER_PREFIX}ish v1 -->\n\nbody`)).toBe(false);
+  });
+});

--- a/src/projects/ensureAgentsMirror.test.ts
+++ b/src/projects/ensureAgentsMirror.test.ts
@@ -168,7 +168,7 @@ describe("ensureAgentsMirror", () => {
     // A user who removed the marker owns the file; we never overwrite it. The trade-off is that
     // this project's codex/opencode sessions don't receive the built-in policy via the mirror
     // (Claude still does, via getProjectProfile). Intentional — it matches AGENTS.md precedence,
-    // where user/local content wins. If a future review flags this, point them here.
+    // where user/local content wins.
     await ensureAgentsMirror(makeApp(vault), makeRecord("anything"));
     expect(vault.files.get(MIRROR_PATH)).toBe("user file, no marker");
   });

--- a/src/projects/ensureAgentsMirror.ts
+++ b/src/projects/ensureAgentsMirror.ts
@@ -1,0 +1,255 @@
+import { logError } from "@/logger";
+import { AGENTS_MIRROR_FILE } from "@/projects/constants";
+import { getProjectFolderPath } from "@/projects/projectPaths";
+import { getComposedProjectInstructions } from "@/projects/projectSystemPrompt";
+import { addPendingFileWrite, removePendingFileWrite } from "@/projects/state";
+import { ProjectFileRecord } from "@/projects/type";
+import { trashFile } from "@/utils/vaultAdapterUtils";
+import { App, normalizePath, TFile, TFolder } from "obsidian";
+
+// Reason: a project's instruction body is the built-in project policy layered ahead of the
+// user's own `project.md` body (see {@link getComposedProjectInstructions}). codex/opencode
+// only auto-discover instructions from a physical file in the session cwd, so the plugin
+// generates `AGENTS.md` as a ONE-WAY mirror of that composed body. The mirror is derived
+// output: it is never read back, never a config source, and only ever touched when it carries
+// the marker below — a user's own AGENTS.md (no marker) is left strictly alone.
+
+/**
+ * Stable, machine-readable prefix that marks a generated mirror as plugin-owned. Ownership keys
+ * off THIS prefix alone, so the rest of {@link MARKER_LINE} (version + the human-facing hint)
+ * can evolve without orphaning files already on disk — a later marker reword still recognizes,
+ * and rewrites, an earlier one. Exported so tests can build sample markers without re-hardcoding
+ * the full line.
+ */
+export const MIRROR_MARKER_PREFIX = "<!-- copilot:generated-agents-mirror";
+
+/**
+ * First (and only) marker line stamped on a generated mirror. Keep it on a SINGLE physical line
+ * closing with ` -->`: the envelope is `${MARKER_LINE}\n\n${body}`, and {@link stripMarkerEnvelope}
+ * relies on that shape to recover the body byte-for-byte. The prose past the prefix is purely
+ * human-facing — it points the user at the real edit surface (the project in Copilot / its
+ * `project.md`), since hand-editing this mirror is overwritten on the next session.
+ */
+const MARKER_LINE =
+  `${MIRROR_MARKER_PREFIX} v1 — Auto-generated; do not edit here. To change these instructions, ` +
+  "edit this project in Copilot (its project.md); regenerated each session. " +
+  "Delete this line to take over the file. -->";
+
+const BOM = "\uFEFF";
+
+/**
+ * Per-path operation queue. Serializes ensure/remove calls for the same mirror path so an
+ * overlapping create + update (or two session starts) can't race into a double-create; each
+ * op re-reads disk state when it runs, so the later op still applies its newer body.
+ */
+const mirrorOperationQueues = new Map<string, Promise<void>>();
+
+interface MirrorSnapshot {
+  exists: boolean;
+  /** The cached TFile when the mirror is indexed by the vault (vs. a hidden-folder file). */
+  file?: TFile;
+  /**
+   * The mirrored body when the file carries the generated marker, else `null`. A `null`
+   * payload means "not ours" — either the file is absent or it is a user-authored AGENTS.md
+   * we must never overwrite or delete.
+   */
+  managedPayload: string | null;
+}
+
+/**
+ * Generate or refresh the project's `AGENTS.md` mirror from its composed instruction body
+ * (built-in project policy + the user's `project.md` body — see
+ * {@link getComposedProjectInstructions}).
+ *
+ * Guarantees (never throws — failures are logged so they can't block session start):
+ * - Marker gating: only a marker'd mirror is ever overwritten; a user's AGENTS.md is untouched.
+ * - Cheap-skip: compares the BODY payload only, so a context/url/last-used change to the
+ *   project (which leaves the instruction body unchanged) does not churn the mirror.
+ * - The composed body is always non-empty (the built-in policy is always present), so the
+ *   empty-body delete path below is effectively unreachable for a real project; it is kept as a
+ *   defensive guard and still never touches a user's own (unmarked) file.
+ */
+export async function ensureAgentsMirror(app: App, record: ProjectFileRecord): Promise<void> {
+  try {
+    const mirrorPath = getMirrorPath(record);
+    await runQueued(mirrorPath, () =>
+      ensureMirrorInternal(app, mirrorPath, getComposedProjectInstructions(record))
+    );
+  } catch (error) {
+    logError(
+      `[Projects] Failed to ensure AGENTS.md mirror for project "${record.project.id}"`,
+      error
+    );
+  }
+}
+
+/**
+ * Delete the generated `AGENTS.md` mirror for a project being removed — but only when it
+ * carries the generated marker. A user-authored AGENTS.md is left in place.
+ */
+export async function removeAgentsMirror(app: App, record: ProjectFileRecord): Promise<void> {
+  try {
+    const mirrorPath = getMirrorPath(record);
+    await runQueued(mirrorPath, () => removeMirrorInternal(app, mirrorPath));
+  } catch (error) {
+    logError(
+      `[Projects] Failed to remove AGENTS.md mirror for project "${record.project.id}"`,
+      error
+    );
+  }
+}
+
+async function ensureMirrorInternal(app: App, mirrorPath: string, body: string): Promise<void> {
+  // Empty instruction → no mirror at all; drop a stale generated one (never a user file).
+  if (body.length === 0) {
+    await removeMirrorInternal(app, mirrorPath);
+    return;
+  }
+
+  const snapshot = await readMirror(app, mirrorPath);
+
+  // User-authored AGENTS.md (no marker) → escape hatch, never touch it.
+  if (snapshot.exists && snapshot.managedPayload === null) return;
+
+  // Body unchanged → skip (compares the body payload only, not the whole config).
+  if (snapshot.managedPayload === body) return;
+
+  addPendingFileWrite(mirrorPath);
+  try {
+    // Re-read inside the guard to absorb a file that appeared during the first read.
+    const latest = await readMirror(app, mirrorPath);
+    if (latest.exists && latest.managedPayload === null) return;
+    if (latest.managedPayload === body) return;
+    await writeMirror(app, latest, mirrorPath, buildMirrorContent(body));
+  } finally {
+    removePendingFileWrite(mirrorPath);
+  }
+}
+
+async function removeMirrorInternal(app: App, mirrorPath: string): Promise<void> {
+  const snapshot = await readMirror(app, mirrorPath);
+  if (!snapshot.exists || snapshot.managedPayload === null) return;
+
+  addPendingFileWrite(mirrorPath);
+  try {
+    const latest = await readMirror(app, mirrorPath);
+    if (!latest.exists || latest.managedPayload === null) return;
+    if (latest.file) {
+      await trashFile(app, latest.file);
+    } else {
+      await app.vault.adapter.remove(mirrorPath);
+    }
+  } finally {
+    removePendingFileWrite(mirrorPath);
+  }
+}
+
+function getMirrorPath(record: ProjectFileRecord): string {
+  return normalizePath(`${getProjectFolderPath(record.folderName)}/${AGENTS_MIRROR_FILE}`);
+}
+
+function buildMirrorContent(body: string): string {
+  return `${MARKER_LINE}\n\n${body}`;
+}
+
+/**
+ * Recover the mirrored body from on-disk content, or `null` when the file is not a generated
+ * mirror. Ownership is recognized by the stable {@link MIRROR_MARKER_PREFIX} rather than the full
+ * line, so an older marker wording is still recovered (and rewritten) — but the first line must
+ * be a well-formed single-line HTML comment (prefix, then a space boundary, closing with ` -->`)
+ * followed by exactly one blank line, else we treat it as a user file and don't manage it. The
+ * body is sliced past that envelope so it round-trips byte-for-byte, even when it starts with
+ * newlines.
+ */
+function stripMarkerEnvelope(content: string): string | null {
+  const offset = content.startsWith(BOM) ? BOM.length : 0;
+  if (!content.startsWith(MIRROR_MARKER_PREFIX, offset)) return null;
+  // Require a space after the prefix so a user line like `…generated-agents-mirrorish` is not
+  // mistaken for ours.
+  if (content[offset + MIRROR_MARKER_PREFIX.length] !== " ") return null;
+
+  const lf = content.indexOf("\n", offset);
+  if (lf === -1) return null;
+
+  // The marker must occupy the whole first line and close the HTML comment. Trim a CRLF `\r`
+  // before testing so both line endings are accepted.
+  const isCrlf = lf > offset && content[lf - 1] === "\r";
+  const lineEnd = isCrlf ? lf - 1 : lf;
+  if (!content.slice(offset, lineEnd).endsWith(" -->")) return null;
+
+  // The marker line is followed by exactly one blank line, in the SAME newline style; the body
+  // starts after it. Anything else (`marker\nbody`, or a mixed `\r\n`/`\n` separator) is a
+  // malformed/hand-edited envelope → treat as a user file we don't manage.
+  const afterLineBreak = lf + 1;
+  const blankLine = isCrlf ? "\r\n" : "\n";
+  if (content.startsWith(blankLine, afterLineBreak)) {
+    return content.slice(afterLineBreak + blankLine.length);
+  }
+  return null;
+}
+
+/**
+ * Whether `content` is a plugin-generated `AGENTS.md` mirror (carries the marker
+ * envelope) rather than a user-authored file. The marker is the project's sole
+ * ownership signal — basename/path can't distinguish the two, since a generated
+ * mirror and a user's own `AGENTS.md` occupy the same path. Callers that only
+ * need the yes/no (e.g. deciding whether to surface the file in a listing) use
+ * this instead of reaching for the marker constant.
+ */
+export function isGeneratedAgentsMirrorContent(content: string): boolean {
+  return stripMarkerEnvelope(content) !== null;
+}
+
+async function readMirror(app: App, mirrorPath: string): Promise<MirrorSnapshot> {
+  const abstractFile = app.vault.getAbstractFileByPath(mirrorPath);
+  if (abstractFile) {
+    if (!(abstractFile instanceof TFile)) {
+      // A folder occupies the path — not ours; never touch.
+      return { exists: true, managedPayload: null };
+    }
+    const content = await app.vault.read(abstractFile);
+    return { exists: true, file: abstractFile, managedPayload: stripMarkerEnvelope(content) };
+  }
+
+  if (!(await app.vault.adapter.exists(mirrorPath))) {
+    return { exists: false, managedPayload: null };
+  }
+  const content = await app.vault.adapter.read(mirrorPath);
+  return { exists: true, managedPayload: stripMarkerEnvelope(content) };
+}
+
+async function writeMirror(
+  app: App,
+  snapshot: MirrorSnapshot,
+  mirrorPath: string,
+  content: string
+): Promise<void> {
+  if (snapshot.file) {
+    await app.vault.modify(snapshot.file, content);
+    return;
+  }
+
+  // No cached TFile: create through the vault when the parent folder is indexed (keeps the
+  // vault cache consistent), else fall back to the adapter for hidden-folder projects.
+  const folderPath = normalizePath(mirrorPath.split("/").slice(0, -1).join("/"));
+  const folder = app.vault.getAbstractFileByPath(folderPath);
+  if (folder instanceof TFolder && !snapshot.exists) {
+    await app.vault.create(mirrorPath, content);
+    return;
+  }
+  await app.vault.adapter.write(mirrorPath, content);
+}
+
+async function runQueued(mirrorPath: string, operation: () => Promise<void>): Promise<void> {
+  const previous = mirrorOperationQueues.get(mirrorPath) ?? Promise.resolve();
+  const next = previous.catch(() => undefined).then(operation);
+  mirrorOperationQueues.set(mirrorPath, next);
+  try {
+    await next;
+  } finally {
+    // Reason: only clear when still the tail, so a later-enqueued op isn't orphaned.
+    if (mirrorOperationQueues.get(mirrorPath) === next) {
+      mirrorOperationQueues.delete(mirrorPath);
+    }
+  }
+}

--- a/src/projects/legacyAgentsResidue.ts
+++ b/src/projects/legacyAgentsResidue.ts
@@ -1,0 +1,128 @@
+import { logError, logInfo } from "@/logger";
+import {
+  AGENTS_MIRROR_FILE,
+  COPILOT_PROJECT_ID,
+  PROJECT_CONFIG_FILE_NAME,
+  PROJECTS_UNSUPPORTED_FOLDER_NAME,
+} from "@/projects/constants";
+import { getProjectsFolder } from "@/projects/projectPaths";
+import { addPendingFileWrite, removePendingFileWrite } from "@/projects/state";
+import { trashFile } from "@/utils/vaultAdapterUtils";
+import { App, normalizePath, parseYaml, TFile, TFolder } from "obsidian";
+
+/**
+ * One-time, dev-only cleanup of the unreleased PR2b-1 rename residue.
+ *
+ * PR2b-1 (never released) renamed a project's config to `AGENTS.md` (frontmatter + body).
+ * The released model — restored in Phase 2 — keeps `project.md` as the single source of truth
+ * and treats `AGENTS.md` as a generated, body-only mirror. Without this reconcile, a dev vault
+ * whose config lives in `AGENTS.md` (and has no `project.md`) would stop being recognized.
+ *
+ * For each such folder we copy the `AGENTS.md` content into `project.md` FIRST (zero data loss —
+ * the source is never removed before the new copy exists), then drop the config-laden
+ * `AGENTS.md`. The post-load mirror batch regenerates a clean, marker'd body-only mirror from
+ * the new `project.md`. Real users never hit this state, so it is best-effort and silent.
+ */
+export async function reconcileLegacyAgentsResidue(app: App): Promise<void> {
+  const projectsFolder = getProjectsFolder();
+  let folderPaths: string[];
+  try {
+    folderPaths = await listProjectSubfolders(app, projectsFolder);
+  } catch (error) {
+    logError("[Projects] Failed to scan for PR2b-1 AGENTS.md residue", error);
+    return;
+  }
+
+  for (const folderPath of folderPaths) {
+    const folderName = folderPath.split("/").pop() ?? "";
+    if (folderName === PROJECTS_UNSUPPORTED_FOLDER_NAME) continue;
+
+    const agentsPath = normalizePath(`${folderPath}/${AGENTS_MIRROR_FILE}`);
+    const projectMdPath = normalizePath(`${folderPath}/${PROJECT_CONFIG_FILE_NAME}`);
+
+    try {
+      if (!(await fileExists(app, agentsPath))) continue;
+      // project.md already present → not residue; AGENTS.md is (or will become) a mirror.
+      if (await fileExists(app, projectMdPath)) continue;
+
+      const content = await readFile(app, agentsPath);
+      // Only adopt a PR2b-1 config (has copilot-project-id); leave a user's AGENTS.md alone.
+      if (content === null || !hasCopilotProjectId(content)) continue;
+
+      addPendingFileWrite(projectMdPath);
+      try {
+        await createFile(app, projectMdPath, content);
+      } finally {
+        removePendingFileWrite(projectMdPath);
+      }
+
+      addPendingFileWrite(agentsPath);
+      try {
+        await deleteFile(app, agentsPath);
+      } finally {
+        removePendingFileWrite(agentsPath);
+      }
+
+      logInfo(`[Projects] Reconciled PR2b-1 AGENTS.md residue → project.md in ${folderPath}`);
+    } catch (error) {
+      logError(`[Projects] Failed to reconcile AGENTS.md residue in ${folderPath}`, error);
+    }
+  }
+}
+
+/** True when the file's frontmatter carries a non-empty `copilot-project-id`. */
+function hasCopilotProjectId(content: string): boolean {
+  const fmMatch = content.replace(/^\uFEFF/, "").match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!fmMatch) return false;
+  try {
+    const parsed = parseYaml(fmMatch[1]);
+    if (!parsed || typeof parsed !== "object") return false;
+    const id = (parsed as Record<string, unknown>)[COPILOT_PROJECT_ID];
+    return typeof id === "string" ? id.trim().length > 0 : typeof id === "number";
+  } catch {
+    return false;
+  }
+}
+
+/** List immediate sub-folder paths of `projectsFolder` (vault cache, adapter fallback). */
+async function listProjectSubfolders(app: App, projectsFolder: string): Promise<string[]> {
+  const root = app.vault.getAbstractFileByPath(projectsFolder);
+  if (root instanceof TFolder) {
+    return root.children.filter((c): c is TFolder => c instanceof TFolder).map((c) => c.path);
+  }
+  if (await app.vault.adapter.exists(projectsFolder)) {
+    const listing = await app.vault.adapter.list(projectsFolder);
+    return listing.folders;
+  }
+  return [];
+}
+
+async function fileExists(app: App, path: string): Promise<boolean> {
+  if (app.vault.getAbstractFileByPath(path) instanceof TFile) return true;
+  return app.vault.adapter.exists(path);
+}
+
+async function readFile(app: App, path: string): Promise<string | null> {
+  const file = app.vault.getAbstractFileByPath(path);
+  if (file instanceof TFile) return app.vault.read(file);
+  if (await app.vault.adapter.exists(path)) return app.vault.adapter.read(path);
+  return null;
+}
+
+async function createFile(app: App, path: string, content: string): Promise<void> {
+  const folderPath = normalizePath(path.split("/").slice(0, -1).join("/"));
+  if (app.vault.getAbstractFileByPath(folderPath) instanceof TFolder) {
+    await app.vault.create(path, content);
+  } else {
+    await app.vault.adapter.write(path, content);
+  }
+}
+
+async function deleteFile(app: App, path: string): Promise<void> {
+  const file = app.vault.getAbstractFileByPath(path);
+  if (file instanceof TFile) {
+    await trashFile(app, file);
+  } else if (await app.vault.adapter.exists(path)) {
+    await app.vault.adapter.remove(path);
+  }
+}

--- a/src/projects/projectContextSignature.test.ts
+++ b/src/projects/projectContextSignature.test.ts
@@ -1,0 +1,80 @@
+import type { ProjectConfig } from "@/aiParams";
+import type { ProjectFileRecord } from "@/projects/type";
+import {
+  getProjectContextSignature,
+  normalizeProjectContextSource,
+} from "./projectContextSignature";
+
+function makeProject(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    id: "p1",
+    name: "Project One",
+    systemPrompt: "",
+    projectModelKey: "",
+    modelConfigs: {},
+    contextSource: {},
+    created: 0,
+    UsageTimestamps: 0,
+    ...overrides,
+  };
+}
+
+function makeRecord(
+  project: ProjectConfig,
+  filePath = "Projects/One/project.md"
+): ProjectFileRecord {
+  return { project, filePath, folderName: "One" };
+}
+
+describe("normalizeProjectContextSource", () => {
+  it("trims lines, drops blanks, and rejoins", () => {
+    const project = makeProject({
+      contextSource: { webUrls: "  https://a.com \n\n  https://b.com  \n" },
+    });
+    expect(normalizeProjectContextSource(project).webUrls).toBe("https://a.com\nhttps://b.com");
+  });
+
+  it("treats undefined source fields as empty strings", () => {
+    expect(normalizeProjectContextSource(makeProject())).toEqual({
+      inclusions: "",
+      exclusions: "",
+      webUrls: "",
+      youtubeUrls: "",
+    });
+  });
+
+  it("ignores fields outside the context source (systemPrompt etc.)", () => {
+    const a = makeProject({ systemPrompt: "old" });
+    const b = makeProject({ systemPrompt: "new" });
+    expect(normalizeProjectContextSource(a)).toEqual(normalizeProjectContextSource(b));
+  });
+});
+
+describe("getProjectContextSignature", () => {
+  it("is stable across cosmetic whitespace edits", () => {
+    const a = makeRecord(makeProject({ contextSource: { webUrls: "https://a.com" } }));
+    const b = makeRecord(makeProject({ contextSource: { webUrls: "  https://a.com  \n" } }));
+    expect(getProjectContextSignature(a)).toBe(getProjectContextSignature(b));
+  });
+
+  it("changes when a web URL is added", () => {
+    const before = makeRecord(makeProject({ contextSource: { webUrls: "https://a.com" } }));
+    const after = makeRecord(
+      makeProject({ contextSource: { webUrls: "https://a.com\nhttps://b.com" } })
+    );
+    expect(getProjectContextSignature(before)).not.toBe(getProjectContextSignature(after));
+  });
+
+  it("does NOT change on a usage-timestamp-only touch", () => {
+    const before = makeRecord(makeProject({ UsageTimestamps: 1 }));
+    const after = makeRecord(makeProject({ UsageTimestamps: 999 }));
+    expect(getProjectContextSignature(before)).toBe(getProjectContextSignature(after));
+  });
+
+  it("changes when the project file is relocated (cache dir / cwd moves)", () => {
+    const project = makeProject({ contextSource: { webUrls: "https://a.com" } });
+    const before = makeRecord(project, "Projects/One/project.md");
+    const after = makeRecord(project, "Projects/Renamed/project.md");
+    expect(getProjectContextSignature(before)).not.toBe(getProjectContextSignature(after));
+  });
+});

--- a/src/projects/projectContextSignature.test.ts
+++ b/src/projects/projectContextSignature.test.ts
@@ -2,6 +2,7 @@ import type { ProjectConfig } from "@/aiParams";
 import type { ProjectFileRecord } from "@/projects/type";
 import {
   getProjectContextSignature,
+  getProjectLandingCaptureSignature,
   normalizeProjectContextSource,
 } from "./projectContextSignature";
 
@@ -76,5 +77,36 @@ describe("getProjectContextSignature", () => {
     const before = makeRecord(project, "Projects/One/project.md");
     const after = makeRecord(project, "Projects/Renamed/project.md");
     expect(getProjectContextSignature(before)).not.toBe(getProjectContextSignature(after));
+  });
+});
+
+describe("getProjectLandingCaptureSignature", () => {
+  it("changes on a System-Prompt-only edit (which the materialization signature ignores)", () => {
+    const before = makeRecord(makeProject({ systemPrompt: "old" }));
+    const after = makeRecord(makeProject({ systemPrompt: "new" }));
+    // The materialization signature is intentionally blind to systemPrompt...
+    expect(getProjectContextSignature(before)).toBe(getProjectContextSignature(after));
+    // ...but the landing-capture signature must see it, so the empty landing refreshes.
+    expect(getProjectLandingCaptureSignature(before)).not.toBe(
+      getProjectLandingCaptureSignature(after)
+    );
+  });
+
+  it("still changes on a context-source edit (folds in the materialization signature)", () => {
+    const before = makeRecord(makeProject({ contextSource: { webUrls: "https://a.com" } }));
+    const after = makeRecord(
+      makeProject({ contextSource: { webUrls: "https://a.com\nhttps://b.com" } })
+    );
+    expect(getProjectLandingCaptureSignature(before)).not.toBe(
+      getProjectLandingCaptureSignature(after)
+    );
+  });
+
+  it("does NOT change on a usage-timestamp-only touch", () => {
+    const before = makeRecord(makeProject({ systemPrompt: "same", UsageTimestamps: 1 }));
+    const after = makeRecord(makeProject({ systemPrompt: "same", UsageTimestamps: 999 }));
+    expect(getProjectLandingCaptureSignature(before)).toBe(
+      getProjectLandingCaptureSignature(after)
+    );
   });
 });

--- a/src/projects/projectContextSignature.ts
+++ b/src/projects/projectContextSignature.ts
@@ -65,3 +65,26 @@ export function getProjectContextSignature(record: ProjectFileRecord): string {
     filePath: record.filePath,
   });
 }
+
+/**
+ * Fingerprint of everything an EMPTY project landing session bakes in at
+ * creation: the materialization signature PLUS the project's instruction body.
+ * A landing session captures its instructions once at start — Claude via
+ * `systemPromptAppend`, codex/opencode via the AGENTS.md mirror read from cwd —
+ * so a System-Prompt-only edit must replace the still-empty session for the
+ * first message to use the new instructions, even though it changes no
+ * materialized source.
+ *
+ * Kept SEPARATE from {@link getProjectContextSignature} on purpose: that one
+ * drives re-materialization (glob/URL/PDF conversion) and must stay insensitive
+ * to `systemPrompt` (see its DESIGN NOTE) — folding the prompt in there would
+ * re-materialize on every prompt edit. `systemPrompt` is compared verbatim
+ * (no `normalizeMultiline`): `project.md` preserves the body's whitespace, so a
+ * whitespace-only edit is still a real change to what the session captures.
+ */
+export function getProjectLandingCaptureSignature(record: ProjectFileRecord): string {
+  return JSON.stringify({
+    context: getProjectContextSignature(record),
+    systemPrompt: record.project.systemPrompt ?? "",
+  });
+}

--- a/src/projects/projectContextSignature.ts
+++ b/src/projects/projectContextSignature.ts
@@ -26,7 +26,6 @@ interface NormalizedContextSource {
  * project-records publish (a hot path), and the worst case of an over-eager
  * signature is benign: one extra materialization that single-flights and
  * cheap-skips unchanged sources — the same cost as the feature's happy path.
- * If a future review flags this again, point them at this note.
  */
 function normalizeMultiline(value: string | undefined): string {
   if (!value) return "";

--- a/src/projects/projectContextSignature.ts
+++ b/src/projects/projectContextSignature.ts
@@ -1,0 +1,67 @@
+import type { ProjectConfig } from "@/aiParams";
+import type { ProjectFileRecord } from "@/projects/type";
+
+/**
+ * The context-source fields whose change should invalidate a project's
+ * materialized context. Deliberately excludes `systemPrompt`, `modelConfigs`,
+ * `UsageTimestamps`, etc. — those affect a session's behavior but not which
+ * external sources get materialized into the off-vault conversion cache.
+ */
+interface NormalizedContextSource {
+  inclusions: string;
+  exclusions: string;
+  webUrls: string;
+  youtubeUrls: string;
+}
+
+/**
+ * Collapse a multiline config value to a canonical form so cosmetic edits
+ * (trailing spaces, blank lines, reordering-free whitespace) don't read as a
+ * real change. Returns lines trimmed, blanks dropped, rejoined with `\n`.
+ *
+ * DESIGN NOTE: this is a deliberately CHEAP textual normalization, not a
+ * resolved-glob comparison. A reviewer may suggest deriving the signature from
+ * `getMatchingPatterns()` so two patterns that match the same files read as
+ * equal — don't. That would resolve globs against the live vault on every
+ * project-records publish (a hot path), and the worst case of an over-eager
+ * signature is benign: one extra materialization that single-flights and
+ * cheap-skips unchanged sources — the same cost as the feature's happy path.
+ * If a future review flags this again, point them at this note.
+ */
+function normalizeMultiline(value: string | undefined): string {
+  if (!value) return "";
+  return value
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .join("\n");
+}
+
+/**
+ * Canonical view of the fields that drive context materialization. Used to
+ * decide whether a project edit actually changed its external sources (vs. a
+ * usage-timestamp touch or an unrelated config tweak).
+ */
+export function normalizeProjectContextSource(project: ProjectConfig): NormalizedContextSource {
+  const source = project.contextSource;
+  return {
+    inclusions: normalizeMultiline(source?.inclusions),
+    exclusions: normalizeMultiline(source?.exclusions),
+    webUrls: normalizeMultiline(source?.webUrls),
+    youtubeUrls: normalizeMultiline(source?.youtubeUrls),
+  };
+}
+
+/**
+ * A stable fingerprint of everything that determines a project's materialized
+ * context: its normalized source fields PLUS its `filePath` (the project folder
+ * — and therefore the resolved cwd and the manifest's absolute paths — moves
+ * when the file is renamed/relocated even if the config is byte-identical). Two
+ * records with the same signature need no re-materialization.
+ */
+export function getProjectContextSignature(record: ProjectFileRecord): string {
+  return JSON.stringify({
+    source: normalizeProjectContextSource(record.project),
+    filePath: record.filePath,
+  });
+}

--- a/src/projects/projectMigration.ts
+++ b/src/projects/projectMigration.ts
@@ -2,6 +2,7 @@ import { ProjectConfig } from "@/aiParams";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { logError, logInfo, logWarn } from "@/logger";
 import { COPILOT_PROJECT_ID, PROJECTS_UNSUPPORTED_FOLDER_NAME } from "@/projects/constants";
+import { reconcileLegacyAgentsResidue } from "@/projects/legacyAgentsResidue";
 import { deriveProjectFolderName, sanitizeVaultPathSegment } from "@/projects/projectPaths";
 import {
   ensureProjectFrontmatter,
@@ -542,6 +543,8 @@ async function migrateProjectFolderNames(app: App): Promise<void> {
     const newFolderPath = `${projectsFolder}/${safeFolderName}`;
     const oldFolderPath = getProjectFolderPath(record.folderName);
     const oldFilePath = record.filePath;
+    // Reason: a folder rename preserves the config basename (`project.md`), so the new path
+    // is just the same config name under the renamed folder.
     const newFilePath = getProjectConfigFilePath(safeFolderName);
 
     // Reason: case-insensitive collision guard — skip if another project already
@@ -610,6 +613,10 @@ export async function ensureProjectsMigratedIfNeeded(app: App): Promise<void> {
   if (legacyProjects.length > 0) {
     await migrateProjectsFromSettingsToVault(app);
   }
+
+  // Reason: dev-only — restore `project.md` from any unreleased PR2b-1 `AGENTS.md`-only config
+  // before scanning/renaming, so those projects are recognized again. No-op for real users.
+  await reconcileLegacyAgentsResidue(app);
 
   // Reason: run naming migration after data.json migration to rename id-based folders
   // to name-based folders. This also handles pre-existing projects from before the

--- a/src/projects/projectPaths.test.ts
+++ b/src/projects/projectPaths.test.ts
@@ -1,0 +1,86 @@
+import {
+  getProjectConfigFilePath,
+  getProjectFolderNameFromConfigPath,
+  isProjectConfigFile,
+} from "@/projects/projectPaths";
+import { mockTFile } from "@/__tests__/mockObsidian";
+
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({ projectsFolder: "copilot-projects" })),
+}));
+
+describe("getProjectConfigFilePath — single source of truth", () => {
+  it("returns the project.md path under the project folder", () => {
+    expect(getProjectConfigFilePath("MyProject")).toBe("copilot-projects/MyProject/project.md");
+  });
+
+  it("honors a root override", () => {
+    expect(getProjectConfigFilePath("MyProject", "custom/root")).toBe(
+      "custom/root/MyProject/project.md"
+    );
+  });
+});
+
+describe("isProjectConfigFile — project.md only (AGENTS.md is not a config)", () => {
+  it("recognizes project.md", () => {
+    expect(
+      isProjectConfigFile(
+        mockTFile({ path: "copilot-projects/Foo/project.md", name: "project.md", extension: "md" })
+      )
+    ).toBe(true);
+  });
+
+  it("does NOT recognize the generated AGENTS.md mirror as a config file", () => {
+    expect(
+      isProjectConfigFile(
+        mockTFile({ path: "copilot-projects/Foo/AGENTS.md", name: "AGENTS.md", extension: "md" })
+      )
+    ).toBe(false);
+  });
+
+  it("rejects files under the unsupported/ backup folder", () => {
+    expect(
+      isProjectConfigFile(
+        mockTFile({
+          path: "copilot-projects/unsupported/project.md",
+          name: "project.md",
+          extension: "md",
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("rejects an unrecognized config file name at the right depth", () => {
+    expect(
+      isProjectConfigFile(
+        mockTFile({ path: "copilot-projects/Foo/notes.md", name: "notes.md", extension: "md" })
+      )
+    ).toBe(false);
+  });
+
+  it("rejects files nested too deep", () => {
+    expect(
+      isProjectConfigFile(
+        mockTFile({
+          path: "copilot-projects/Foo/sub/project.md",
+          name: "project.md",
+          extension: "md",
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("getProjectFolderNameFromConfigPath", () => {
+  it("extracts the folder from a project.md path", () => {
+    expect(getProjectFolderNameFromConfigPath("copilot-projects/Foo/project.md")).toBe("Foo");
+  });
+
+  it("returns null for the AGENTS.md mirror (not a config path)", () => {
+    expect(getProjectFolderNameFromConfigPath("copilot-projects/Foo/AGENTS.md")).toBeNull();
+  });
+
+  it("returns null for a non-config path", () => {
+    expect(getProjectFolderNameFromConfigPath("copilot-projects/Foo/other.md")).toBeNull();
+  });
+});

--- a/src/projects/projectPaths.ts
+++ b/src/projects/projectPaths.ts
@@ -28,7 +28,12 @@ export function getProjectFolderPath(folderName: string): string {
 }
 
 /**
- * Get a project's config file (project.md) path.
+ * Get a project's config file (`project.md`) path for read/write/create operations.
+ *
+ * `project.md` is the single recognized config name; a folder rename keeps this same
+ * basename, so this path is correct for both new projects and rebasing onto a renamed
+ * folder (the generated `AGENTS.md` mirror is handled separately and never moved here).
+ *
  * @param folderName - Project folder name
  * @param folderOverride - Optional root folder override
  * @returns Normalized vault path
@@ -39,12 +44,15 @@ export function getProjectConfigFilePath(folderName: string, folderOverride?: st
 }
 
 /**
- * Check if a file is a project config file (project.md).
+ * Check if a file is a project config file (`project.md`).
  *
  * Rules:
  * - Must be under projectsFolder
  * - Path must be: \<projectsFolder\>/\<folderName\>/project.md (exactly 2 levels deep)
  * - Excludes unsupported/ directory
+ *
+ * The generated `AGENTS.md` mirror is intentionally NOT recognized here, so the register
+ * never reacts to its create/modify/delete events (no watcher regeneration loop).
  *
  * @param file - Vault abstract file
  * @returns Type guard: true if file is a valid project config TFile
@@ -67,8 +75,8 @@ export function isProjectConfigFile(file: TAbstractFile): file is TFile {
 }
 
 /**
- * Extract the project folder name from a project.md path.
- * @param filePath - Vault path of project.md
+ * Extract the project folder name from a `project.md` path.
+ * @param filePath - Vault path of a recognized project config file
  * @returns Folder name, or null if path is invalid
  */
 export function getProjectFolderNameFromConfigPath(filePath: string): string | null {

--- a/src/projects/projectRegister.ts
+++ b/src/projects/projectRegister.ts
@@ -29,9 +29,12 @@ import { App, Notice, TAbstractFile, Vault } from "obsidian";
  * Aligned with system-prompts Register pattern.
  *
  * Responsibilities:
- * - Auto-sync project.md create/modify/delete/rename to in-memory cache
+ * - Auto-sync project config (project.md) create/modify/delete/rename to cache
  * - Listen for projectsFolder setting changes with latest-wins reload
  * - Avoid event loops from pending file writes
+ *
+ * The generated AGENTS.md mirror is not a recognized config file, so none of these
+ * handlers react to it (no watcher regeneration loop).
  */
 export class ProjectRegister {
   private app: App;

--- a/src/projects/projectSystemPrompt.test.ts
+++ b/src/projects/projectSystemPrompt.test.ts
@@ -1,0 +1,81 @@
+import { PROJECT_OUTPUTS_DIRNAME } from "@/projects/constants";
+import {
+  BUILTIN_PROJECT_SYSTEM_PROMPT,
+  composeProjectInstructions,
+  getComposedProjectInstructions,
+  PROJECT_CUSTOM_SYSTEM_PROMPT_HEADING,
+} from "@/projects/projectSystemPrompt";
+import { ProjectFileRecord } from "@/projects/type";
+import { AGENT_TODO_PLANNING_STEERING } from "@/system-prompts/agentTodoPlanningSteering";
+
+// The program-authored built-in prefix every composition carries: workspace policy followed by
+// the todo-planning steering, joined by the same blank line the user body uses.
+const BUILTIN_PREFIX = `${BUILTIN_PROJECT_SYSTEM_PROMPT}\n\n${AGENT_TODO_PLANNING_STEERING}`;
+
+function recordWith(systemPrompt: unknown): ProjectFileRecord {
+  return {
+    project: { id: "p1", name: "Foo", systemPrompt },
+    filePath: "copilot-projects/Foo/project.md",
+    folderName: "Foo",
+  } as unknown as ProjectFileRecord;
+}
+
+describe("BUILTIN_PROJECT_SYSTEM_PROMPT", () => {
+  it("names the configured outputs folder and carries its own heading", () => {
+    expect(BUILTIN_PROJECT_SYSTEM_PROMPT).toContain(`${PROJECT_OUTPUTS_DIRNAME}/`);
+    expect(BUILTIN_PROJECT_SYSTEM_PROMPT.startsWith("## ")).toBe(true);
+    // The default-only-cwd rule must surface the opt-in exceptions, not a blanket ban — else a
+    // project's configured context sources (handed to backends as additionalDirectories) look
+    // forbidden.
+    expect(BUILTIN_PROJECT_SYSTEM_PROMPT).toContain("configured context sources");
+  });
+
+  it("has no leading/trailing whitespace", () => {
+    expect(BUILTIN_PROJECT_SYSTEM_PROMPT).toBe(BUILTIN_PROJECT_SYSTEM_PROMPT.trim());
+  });
+});
+
+describe("composeProjectInstructions", () => {
+  it("returns the built-in prefix alone when there is no user body", () => {
+    expect(composeProjectInstructions("")).toBe(BUILTIN_PREFIX);
+  });
+
+  it("treats a whitespace-only user body as empty", () => {
+    expect(composeProjectInstructions("   \n\t ")).toBe(BUILTIN_PREFIX);
+  });
+
+  it("carries the todo-planning steering as its own ## section after the workspace policy", () => {
+    // Project-scoped on purpose: the section lives here, never in the global prompt, so the
+    // no-project prompt stays byte-identical. Its own `## ` heading keeps it a distinct section.
+    expect(AGENT_TODO_PLANNING_STEERING.startsWith("## ")).toBe(true);
+    expect(composeProjectInstructions("")).toBe(
+      `${BUILTIN_PROJECT_SYSTEM_PROMPT}\n\n${AGENT_TODO_PLANNING_STEERING}`
+    );
+  });
+
+  it("partitions built-ins and user body into parallel ## sections, byte-exact", () => {
+    const out = composeProjectInstructions("Be concise.");
+    expect(out).toBe(`${BUILTIN_PREFIX}\n\n${PROJECT_CUSTOM_SYSTEM_PROMPT_HEADING}\n\nBe concise.`);
+  });
+
+  it("preserves a non-blank user body untouched (no trimming)", () => {
+    // project.md parsing keeps the body's leading whitespace (trimStart: false); composing must
+    // not strip it — e.g. an indented code block at the very start of the instructions.
+    const body = "    indented code block\nplain line  ";
+    expect(composeProjectInstructions(body)).toBe(
+      `${BUILTIN_PREFIX}\n\n${PROJECT_CUSTOM_SYSTEM_PROMPT_HEADING}\n\n${body}`
+    );
+  });
+});
+
+describe("getComposedProjectInstructions", () => {
+  it("composes from a record's systemPrompt", () => {
+    expect(getComposedProjectInstructions(recordWith("Cite sources."))).toBe(
+      `${BUILTIN_PREFIX}\n\n${PROJECT_CUSTOM_SYSTEM_PROMPT_HEADING}\n\nCite sources.`
+    );
+  });
+
+  it("falls back to the built-in prefix when systemPrompt is missing", () => {
+    expect(getComposedProjectInstructions(recordWith(undefined))).toBe(BUILTIN_PREFIX);
+  });
+});

--- a/src/projects/projectSystemPrompt.test.ts
+++ b/src/projects/projectSystemPrompt.test.ts
@@ -1,3 +1,4 @@
+import { buildProjectContextBlock } from "@/context/manifestBuilder";
 import { PROJECT_OUTPUTS_DIRNAME } from "@/projects/constants";
 import {
   BUILTIN_PROJECT_SYSTEM_PROMPT,
@@ -32,6 +33,25 @@ describe("BUILTIN_PROJECT_SYSTEM_PROMPT", () => {
 
   it("has no leading/trailing whitespace", () => {
     expect(BUILTIN_PROJECT_SYSTEM_PROMPT).toBe(BUILTIN_PROJECT_SYSTEM_PROMPT.trim());
+  });
+
+  it("points the read carve-out at the same tag the manifest actually emits", () => {
+    // The read carve-out tells the agent to read paths listed in the `<project_context>` block.
+    // That tag is hardcoded in both this prompt and the manifest builder; if the builder ever
+    // renames it, the opt-in instruction silently dangles and the off-vault-cache regression
+    // returns (the agent stops reading materialized snapshots). Pin both to one literal.
+    const tag = "<project_context>";
+    const block = buildProjectContextBlock({
+      folders: [],
+      notes: [],
+      extensions: [],
+      tags: [],
+      webUrls: [],
+      youtubeUrls: [],
+      materialized: [],
+    });
+    expect(block).toContain(tag);
+    expect(BUILTIN_PROJECT_SYSTEM_PROMPT).toContain(tag);
   });
 });
 

--- a/src/projects/projectSystemPrompt.ts
+++ b/src/projects/projectSystemPrompt.ts
@@ -13,17 +13,21 @@ import { AGENT_TODO_PLANNING_STEERING } from "@/system-prompts/agentTodoPlanning
  * the project folder (`resolveScopeCwd`), so "this project's folder" and "outputs/" stay
  * portable — no vault-absolute paths, no hardcoded folder branches.
  *
- * The default-only-cwd rule deliberately carves out the paths the user already opted into:
- * the project's configured context sources are handed to backends as out-of-cwd
- * `additionalDirectories`, so reading them is expected, not a violation. Carrying its own
+ * The default-only-cwd rule deliberately carves out the paths the user already opted into,
+ * which reach the backend two ways: out-of-cwd context FOLDERS as `additionalDirectories`,
+ * and materialized snapshots (PDFs/spreadsheets/images, web/YouTube captures) as inline
+ * absolute paths in the `<project_context>` block. Both are expected reads, not violations —
+ * so the rule names the block itself, not just the vague "configured context sources", to keep
+ * an off-vault cache path (`~/.obsidian-copilot/.../context-cache/...`) from reading as
+ * forbidden. Carrying its own
  * `## ` heading keeps this layer visually distinct from the user's custom prompt once the two
  * are concatenated. "Built-in" (vs the user's "Custom") matches the plugin's existing
  * vocabulary — the global "Disable builtin system prompt" toggle.
  */
 export const BUILTIN_PROJECT_SYSTEM_PROMPT = `## Built-in system prompt
-- This project's folder is your working directory. Treat it as the project workspace and keep your work inside it by default.
-- Write generated files, drafts, and intermediate artifacts under an \`${PROJECT_OUTPUTS_DIRNAME}/\` folder inside the working directory, creating it if needed — unless the user names a different destination.
-- By default, only read and search files inside the working directory. Don't reach for files outside it unless these instructions, the project's configured context sources, or the user explicitly point you to a specific file or location.`;
+- This project's folder is your working directory and workspace. Write generated files, drafts, and intermediate artifacts under an \`${PROJECT_OUTPUTS_DIRNAME}/\` folder inside it, creating it if needed — unless the user names a different destination.
+- Read and search inside the working directory by default. On top of that, the project's configured context sources listed in the \`<project_context>\` block are opted-in even when they live outside it — notably the off-vault materialized snapshots (converted PDFs/spreadsheets/images, web/YouTube captures) under the device-local context cache — so reading and searching those paths is expected, not a violation. When a source shows a \`→ <absolute path>\` snapshot pointer, read that path directly, without hesitation or asking.
+- Don't reach for unrelated files outside the working directory or those context sources unless these instructions or the user point you to a specific file or location.`;
 
 /**
  * Heading that opens the user's own system-prompt section. Markdown has no section terminator —

--- a/src/projects/projectSystemPrompt.ts
+++ b/src/projects/projectSystemPrompt.ts
@@ -1,0 +1,67 @@
+import { PROJECT_OUTPUTS_DIRNAME } from "@/projects/constants";
+import { ProjectFileRecord } from "@/projects/type";
+import { AGENT_TODO_PLANNING_STEERING } from "@/system-prompts/agentTodoPlanningSteering";
+
+/**
+ * The program-authored project policy layer — the project-scope analogue of the global
+ * built-in prompt (`COPILOT_PROMPT_BASE` / `DEFAULT_SYSTEM_PROMPT`). It is composed ahead of
+ * a project's own instruction body (the user's `project.md`) and delivered, per scope, to
+ * every backend: inlined into Claude's `<project_instructions>` and mirrored into the
+ * `AGENTS.md` codex/opencode read from the session cwd.
+ *
+ * Why these rules are phrased relative to the working directory: a project session's cwd IS
+ * the project folder (`resolveScopeCwd`), so "this project's folder" and "outputs/" stay
+ * portable — no vault-absolute paths, no hardcoded folder branches.
+ *
+ * The default-only-cwd rule deliberately carves out the paths the user already opted into:
+ * the project's configured context sources are handed to backends as out-of-cwd
+ * `additionalDirectories`, so reading them is expected, not a violation. Carrying its own
+ * `## ` heading keeps this layer visually distinct from the user's custom prompt once the two
+ * are concatenated. "Built-in" (vs the user's "Custom") matches the plugin's existing
+ * vocabulary — the global "Disable builtin system prompt" toggle.
+ */
+export const BUILTIN_PROJECT_SYSTEM_PROMPT = `## Built-in system prompt
+- This project's folder is your working directory. Treat it as the project workspace and keep your work inside it by default.
+- Write generated files, drafts, and intermediate artifacts under an \`${PROJECT_OUTPUTS_DIRNAME}/\` folder inside the working directory, creating it if needed — unless the user names a different destination.
+- By default, only read and search files inside the working directory. Don't reach for files outside it unless these instructions, the project's configured context sources, or the user explicitly point you to a specific file or location.`;
+
+/**
+ * Heading that opens the user's own system-prompt section. Markdown has no section terminator —
+ * without this, the user body would structurally belong to the `## Built-in system prompt`
+ * section above it (AGENTS.md-consuming agents treat `## ` headings as section boundaries). A
+ * parallel heading keeps the built-in and custom prompts cleanly partitioned.
+ */
+export const PROJECT_CUSTOM_SYSTEM_PROMPT_HEADING = "## Custom system prompt";
+
+/**
+ * Layer the program-authored policy ahead of a project's own (custom) system prompt. The result
+ * is never empty (the built-in sections are always present), so a project with a blank
+ * `systemPrompt` still carries the policy. Each part is its own `## ` section, in order:
+ *   1. {@link BUILTIN_PROJECT_SYSTEM_PROMPT} — the project workspace policy (cwd/outputs/search).
+ *   2. {@link AGENT_TODO_PLANNING_STEERING} — when to create a todo/plan list. Project-scoped on
+ *      purpose: injecting it here (not in the global `buildAgentSystemPrompt`) keeps the global
+ *      no-project prompt byte-identical. The same constant can be promoted to global later — see
+ *      the seam comment in `agentMode/backends/shared/agentSystemPrompt.ts`.
+ *   3. The user's body under {@link PROJECT_CUSTOM_SYSTEM_PROMPT_HEADING}, last so it can override
+ *      the built-ins on conflict (the AGENTS.md convention that more-specific, later guidance wins).
+ *
+ * Blankness is detected with `trim()`, but a non-blank body is concatenated UNTOUCHED:
+ * `project.md` parsing deliberately preserves the body's leading whitespace
+ * (`stripFrontmatter(..., { trimStart: false })`), and trimming here would e.g. break an
+ * indented code block sitting at the very start of the user's instructions.
+ */
+export function composeProjectInstructions(userBody: string): string {
+  const parts = [BUILTIN_PROJECT_SYSTEM_PROMPT, AGENT_TODO_PLANNING_STEERING];
+  if (userBody.trim()) {
+    parts.push(`${PROJECT_CUSTOM_SYSTEM_PROMPT_HEADING}\n\n${userBody}`);
+  }
+  return parts.join("\n\n");
+}
+
+/**
+ * Single entry point both delivery paths (`getProjectProfile` for Claude, `ensureAgentsMirror`
+ * for codex/opencode) call, so the nullish-handling rule for an absent body lives in one place.
+ */
+export function getComposedProjectInstructions(record: ProjectFileRecord): string {
+  return composeProjectInstructions(record.project.systemPrompt ?? "");
+}

--- a/src/projects/projectUtils.test.ts
+++ b/src/projects/projectUtils.test.ts
@@ -1,6 +1,11 @@
-import { App, TFile } from "obsidian";
-import { parseProjectConfigFile, sanitizeVaultPathSegment } from "@/projects/projectUtils";
-import { mockTFile } from "@/__tests__/mockObsidian";
+import { App, TFile, TFolder } from "obsidian";
+import {
+  parseProjectConfigFile,
+  sanitizeVaultPathSegment,
+  scanAllProjectConfigFiles,
+} from "@/projects/projectUtils";
+import { getProjectFolderNameFromConfigPath, isProjectConfigFile } from "@/projects/projectPaths";
+import { mockTFile, mockTFolder } from "@/__tests__/mockObsidian";
 
 // Mock deep dependencies to avoid transitive import chains
 jest.mock("@/settings/model", () => ({
@@ -228,5 +233,120 @@ describe("sanitizeVaultPathSegment", () => {
     // Reason: "." and ".." have trailing dots stripped first, then become empty → fallback "_"
     expect(sanitizeVaultPathSegment(".")).toBe("_");
     expect(sanitizeVaultPathSegment("..")).toBe("_");
+  });
+});
+
+// Helper: build a project config TFile mock under the mocked projects folder.
+function makeConfigFile(folderName: string, fileName: string): TFile {
+  const path = `copilot-projects/${folderName}/${fileName}`;
+  return mockTFile({
+    path,
+    name: fileName,
+    basename: fileName.replace(/\.md$/, ""),
+    extension: "md",
+  });
+}
+
+describe("isProjectConfigFile (project.md only)", () => {
+  it("recognizes project.md but not the generated AGENTS.md mirror", () => {
+    expect(isProjectConfigFile(makeConfigFile("my-project", "project.md"))).toBe(true);
+    expect(isProjectConfigFile(makeConfigFile("my-project", "AGENTS.md"))).toBe(false);
+  });
+
+  it("rejects other markdown names in a project folder", () => {
+    expect(isProjectConfigFile(makeConfigFile("my-project", "notes.md"))).toBe(false);
+    expect(isProjectConfigFile(makeConfigFile("my-project", "readme.md"))).toBe(false);
+  });
+
+  it("rejects config files inside the unsupported/ backup folder", () => {
+    expect(isProjectConfigFile(makeConfigFile("unsupported", "project.md"))).toBe(false);
+  });
+
+  it("rejects files that are not exactly two levels deep", () => {
+    expect(isProjectConfigFile(makeConfigFile("nested/deeper", "project.md"))).toBe(false);
+    const shallow = mockTFile({
+      path: "copilot-projects/project.md",
+      name: "project.md",
+      basename: "project",
+      extension: "md",
+    });
+    expect(isProjectConfigFile(shallow)).toBe(false);
+  });
+});
+
+describe("getProjectFolderNameFromConfigPath (project.md only)", () => {
+  it("extracts the folder name from a project.md path", () => {
+    expect(getProjectFolderNameFromConfigPath("copilot-projects/foo/project.md")).toBe("foo");
+  });
+
+  it("returns null for unrecognized names (incl. AGENTS.md) or wrong depth", () => {
+    expect(getProjectFolderNameFromConfigPath("copilot-projects/foo/AGENTS.md")).toBeNull();
+    expect(getProjectFolderNameFromConfigPath("copilot-projects/foo/notes.md")).toBeNull();
+    expect(getProjectFolderNameFromConfigPath("copilot-projects/project.md")).toBeNull();
+    expect(getProjectFolderNameFromConfigPath("other/foo/project.md")).toBeNull();
+  });
+});
+
+describe("scanAllProjectConfigFiles (project.md only)", () => {
+  const PROJECTS_FOLDER = "copilot-projects";
+
+  // Build an app whose projects folder contains the given folders, each mapping a config
+  // file name to its raw content. metadataCache is empty so the YAML fallback parser runs.
+  function setupScanApp(folders: Record<string, Record<string, string>>): App {
+    const contentByPath = new Map<string, string>();
+    const children: TFolder[] = [];
+
+    for (const [folderName, configs] of Object.entries(folders)) {
+      const files: TFile[] = [];
+      for (const [fileName, content] of Object.entries(configs)) {
+        const file = makeConfigFile(folderName, fileName);
+        contentByPath.set(file.path, content);
+        files.push(file);
+      }
+      children.push(mockTFolder({ name: folderName, children: files }));
+    }
+
+    const rootFolder = mockTFolder({ name: PROJECTS_FOLDER, children });
+
+    return {
+      vault: {
+        getAbstractFileByPath: jest.fn((path: string) => {
+          if (path === PROJECTS_FOLDER) return rootFolder;
+          if (contentByPath.has(path)) {
+            return makeConfigFile(path.split("/")[1], path.split("/").pop() ?? "");
+          }
+          return null;
+        }),
+        read: jest.fn((file: TFile) => Promise.resolve(contentByPath.get(file.path) ?? "")),
+        adapter: { exists: jest.fn().mockResolvedValue(false), list: jest.fn() },
+      },
+      metadataCache: { getFileCache: jest.fn().mockReturnValue(null) },
+    } as unknown as App;
+  }
+
+  const validConfig = (id: string): string =>
+    ["---", `copilot-project-id: ${id}`, `copilot-project-name: ${id}`, "---", "body"].join("\n");
+
+  it("recognizes a project.md project", async () => {
+    const app = setupScanApp({ beta: { "project.md": validConfig("beta") } });
+    const { records } = await scanAllProjectConfigFiles(app);
+    expect(records).toHaveLength(1);
+    expect(records[0].project.id).toBe("beta");
+    expect(records[0].filePath).toBe("copilot-projects/beta/project.md");
+  });
+
+  it("does NOT recognize an AGENTS.md-only folder (mirror is not a config)", async () => {
+    const app = setupScanApp({ alpha: { "AGENTS.md": validConfig("alpha") } });
+    const { records } = await scanAllProjectConfigFiles(app);
+    expect(records).toHaveLength(0);
+  });
+
+  it("recognizes project.md and ignores a sibling AGENTS.md mirror in the same folder", async () => {
+    const app = setupScanApp({
+      gamma: { "AGENTS.md": validConfig("gamma"), "project.md": validConfig("gamma") },
+    });
+    const { records } = await scanAllProjectConfigFiles(app);
+    expect(records).toHaveLength(1);
+    expect(records[0].filePath).toBe("copilot-projects/gamma/project.md");
   });
 });

--- a/src/projects/projectUtils.ts
+++ b/src/projects/projectUtils.ts
@@ -151,7 +151,9 @@ function joinUrlsArrayToString(urls: string[]): string {
 }
 
 /**
- * Parse a project.md file into a ProjectFileRecord.
+ * Parse a project config file (`project.md`) into a ProjectFileRecord. The `systemPrompt`
+ * is the file body (instruction text); config comes from frontmatter. The generated
+ * `AGENTS.md` mirror is never read here — `project.md` is the single source of truth.
  *
  * Key constraints:
  * - id: frontmatter is authoritative, folder name is fallback
@@ -159,7 +161,7 @@ function joinUrlsArrayToString(urls: string[]): string {
  * - inclusions/exclusions: kept as encoded strings with YAML folding stripped
  * - webUrls/youtubeUrls: stored as YAML arrays, converted to newline strings for runtime
  *
- * @param file - project.md TFile
+ * @param file - recognized project config TFile
  * @returns ProjectFileRecord, or null if parse fails
  */
 export async function parseProjectConfigFile(
@@ -286,14 +288,14 @@ export async function parseProjectConfigFile(
 }
 
 /**
- * Scan all project config files with duplicate id detection.
+ * Scan all project config files (`project.md`) with per-id deduplication.
  *
  * Performance: only traverses the projectsFolder subtree, not the entire vault.
  * Looks for \<projectsFolder\>/\<folderName\>/project.md (one level deep).
  *
- * Duplicate rules:
- * - Build id -> path[] index during scan
- * - On duplicate: logWarn, keep first by path alphabetical order (stable)
+ * Dedup rule:
+ * - Per id (across folders): build id -> path[] index; on duplicate logWarn and keep the
+ *   first by folder/path order (stable).
  *
  * @returns Records and diagnostics
  */
@@ -334,6 +336,7 @@ export async function scanAllProjectConfigFiles(app: App): Promise<{
     }
   }
 
+  // Reason: stable ordering by path keeps duplicate-id "keep first" deterministic across folders.
   files.sort((a, b) => a.path.localeCompare(b.path));
 
   const duplicateIdIndex: Record<string, string[]> = {};

--- a/src/projects/state.ts
+++ b/src/projects/state.ts
@@ -51,7 +51,7 @@ export function getCachedProjectRecordById(projectId: string): ProjectFileRecord
 
 /**
  * Non-reactive: find a cached record by file path.
- * @param filePath - Vault path of project.md
+ * @param filePath - Vault path of the project config file (AGENTS.md / legacy project.md)
  * @returns Matching record or undefined
  */
 export function getCachedProjectRecordByFilePath(filePath: string): ProjectFileRecord | undefined {
@@ -71,7 +71,7 @@ export function updateCachedProjectRecords(records: ProjectFileRecord[]): void {
  * Avoids transient "disappear/reappear" gaps for subscribers during modify events,
  * while still cleaning up stale entries when the frontmatter id changes.
  *
- * @param filePath - Vault path of project.md being modified
+ * @param filePath - Vault path of the project config file (AGENTS.md / legacy project.md) being modified
  * @param record - Parsed record to store for that file
  */
 export function replaceCachedProjectRecordByFilePath(
@@ -131,7 +131,7 @@ export function deleteCachedProjectRecordById(projectId: string): void {
 
 /**
  * Remove a project record by file path (used for delete/rename events).
- * @param filePath - Vault path of project.md
+ * @param filePath - Vault path of the project config file (AGENTS.md / legacy project.md)
  */
 export function deleteCachedProjectRecordByFilePath(filePath: string): void {
   const records = projectsStore.get(projectRecordsAtom);

--- a/src/projects/state.ts
+++ b/src/projects/state.ts
@@ -51,7 +51,7 @@ export function getCachedProjectRecordById(projectId: string): ProjectFileRecord
 
 /**
  * Non-reactive: find a cached record by file path.
- * @param filePath - Vault path of the project config file (AGENTS.md / legacy project.md)
+ * @param filePath - Vault path of the project config file (project.md, the SSOT; AGENTS.md is its generated mirror)
  * @returns Matching record or undefined
  */
 export function getCachedProjectRecordByFilePath(filePath: string): ProjectFileRecord | undefined {
@@ -71,7 +71,7 @@ export function updateCachedProjectRecords(records: ProjectFileRecord[]): void {
  * Avoids transient "disappear/reappear" gaps for subscribers during modify events,
  * while still cleaning up stale entries when the frontmatter id changes.
  *
- * @param filePath - Vault path of the project config file (AGENTS.md / legacy project.md) being modified
+ * @param filePath - Vault path of the project config file (project.md, the SSOT; AGENTS.md is its generated mirror) being modified
  * @param record - Parsed record to store for that file
  */
 export function replaceCachedProjectRecordByFilePath(
@@ -131,7 +131,7 @@ export function deleteCachedProjectRecordById(projectId: string): void {
 
 /**
  * Remove a project record by file path (used for delete/rename events).
- * @param filePath - Vault path of the project config file (AGENTS.md / legacy project.md)
+ * @param filePath - Vault path of the project config file (project.md, the SSOT; AGENTS.md is its generated mirror)
  */
 export function deleteCachedProjectRecordByFilePath(filePath: string): void {
   const records = projectsStore.get(projectRecordsAtom);

--- a/src/projects/type.ts
+++ b/src/projects/type.ts
@@ -1,7 +1,7 @@
 import { ProjectConfig } from "@/aiParams";
 
 /**
- * A parsed project file record (project.md).
+ * A parsed project config record (`project.md`, the single source of truth).
  *
  * - `project.id`: authoritative value from frontmatter; folder name as fallback
  * - `filePath`: vault path for write-back operations (e.g. last-used throttled persist)
@@ -10,7 +10,7 @@ export interface ProjectFileRecord {
   /** Runtime-compatible ProjectConfig. */
   project: ProjectConfig;
 
-  /** Vault path of the project.md file. */
+  /** Vault path of the project config file (`project.md`). */
   filePath: string;
 
   /** Parent folder name (used as id fallback). */

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -1,4 +1,5 @@
 import { CustomError } from "@/error";
+import { AGENTS_MIRROR_FILE, PROJECT_CONFIG_FILE_NAME } from "@/projects/constants";
 import EmbeddingsManager from "@/LLMProviders/embeddingManager";
 import { logError, logInfo, logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
@@ -448,8 +449,14 @@ function isInternalExcludedPath(filePath: string): boolean {
     if (!filePath.startsWith(prefix)) continue;
     const relativePath = filePath.slice(prefix.length);
     const parts = relativePath.split("/");
-    // Exact match: <folderName>/project.md (2 segments, second is "project.md")
-    if (parts.length === 2 && parts[1] === "project.md") return true;
+    // Exact match: <folderName>/<config> (2 segments). Exclude both the `project.md`
+    // config and its generated `AGENTS.md` mirror by name (path-level mechanism — the
+    // mirror's marker isn't visible here) so neither instruction file leaks into the index.
+    if (
+      parts.length === 2 &&
+      (parts[1] === PROJECT_CONFIG_FILE_NAME || parts[1] === AGENTS_MIRROR_FILE)
+    )
+      return true;
     if (relativePath.startsWith("unsupported/") || relativePath === "unsupported") return true;
   }
   return false;

--- a/src/settings/deviceProfiles.test.ts
+++ b/src/settings/deviceProfiles.test.ts
@@ -10,6 +10,7 @@ function makeAgentMode(partial: Partial<AgentMode> = {}): AgentMode {
     activeBackend: "opencode",
     backends: {},
     debugFullFrames: false,
+    welcomeDismissed: false,
     skills: { folder: "copilot/skills" },
     ...partial,
   };

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -192,6 +192,7 @@ describe("sanitizeSettings - agentMode shape migration", () => {
       activeBackend: "opencode",
       backends: {},
       debugFullFrames: true,
+      welcomeDismissed: false,
       skills: { folder: "copilot/skills" },
     });
   });

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -266,6 +266,13 @@ export interface CopilotSettings {
      */
     debugFullFrames: boolean;
     /**
+     * One-shot dismissal of the Agent Home "Try a project" welcome card. The card
+     * only shows on the global landing while no projects exist; once dismissed it
+     * stays hidden regardless of project count. Persisted so the nudge doesn't
+     * reappear across reloads. Defaults to `false`.
+     */
+    welcomeDismissed: boolean;
+    /**
      * Skills management — canonical-store discovery, symlink lifecycle,
      * reconciliation. See `designdocs/SKILLS_MANAGEMENT.md` and
      * `designdocs/SKILLS_DISCOVERY_REDESIGN.md`.
@@ -909,6 +916,11 @@ function sanitizeAgentMode(raw: unknown): CopilotSettings["agentMode"] {
       ? r.debugFullFrames
       : DEFAULT_SETTINGS.agentMode.debugFullFrames;
 
+  const welcomeDismissed =
+    typeof r.welcomeDismissed === "boolean"
+      ? r.welcomeDismissed
+      : DEFAULT_SETTINGS.agentMode.welcomeDismissed;
+
   const claudeCliRaw =
     r.claudeCli && typeof r.claudeCli === "object"
       ? (r.claudeCli as Record<string, unknown>)
@@ -941,6 +953,7 @@ function sanitizeAgentMode(raw: unknown): CopilotSettings["agentMode"] {
     activeBackend,
     backends,
     debugFullFrames,
+    welcomeDismissed,
     skills,
     ...(claudeCli ? { claudeCli } : {}),
     ...(deviceProfiles ? { deviceProfiles } : {}),

--- a/src/settings/welcomeDismissed.test.ts
+++ b/src/settings/welcomeDismissed.test.ts
@@ -1,0 +1,40 @@
+import { DEFAULT_SETTINGS } from "@/constants";
+import { sanitizeSettings, type CopilotSettings } from "@/settings/model";
+
+describe("sanitizeSettings - agentMode.welcomeDismissed", () => {
+  it("defaults to false when absent", () => {
+    const sanitized = sanitizeSettings({
+      ...DEFAULT_SETTINGS,
+      agentMode: { byok: {}, mcpServers: [] } as unknown as CopilotSettings["agentMode"],
+    });
+    expect(sanitized.agentMode.welcomeDismissed).toBe(false);
+  });
+
+  it("carries a persisted true through sanitize", () => {
+    const sanitized = sanitizeSettings({
+      ...DEFAULT_SETTINGS,
+      agentMode: {
+        byok: {},
+        mcpServers: [],
+        welcomeDismissed: true,
+      } as unknown as CopilotSettings["agentMode"],
+    });
+    expect(sanitized.agentMode.welcomeDismissed).toBe(true);
+  });
+
+  it("ignores non-boolean values, falling back to the default", () => {
+    const sanitized = sanitizeSettings({
+      ...DEFAULT_SETTINGS,
+      agentMode: {
+        byok: {},
+        mcpServers: [],
+        welcomeDismissed: "yes",
+      } as unknown as CopilotSettings["agentMode"],
+    });
+    expect(sanitized.agentMode.welcomeDismissed).toBe(false);
+  });
+
+  it("ships a false default in DEFAULT_SETTINGS", () => {
+    expect(DEFAULT_SETTINGS.agentMode.welcomeDismissed).toBe(false);
+  });
+});

--- a/src/system-prompts/agentTodoPlanningSteering.test.ts
+++ b/src/system-prompts/agentTodoPlanningSteering.test.ts
@@ -1,0 +1,28 @@
+import { AGENT_TODO_PLANNING_STEERING } from "@/system-prompts/agentTodoPlanningSteering";
+
+describe("AGENT_TODO_PLANNING_STEERING", () => {
+  it("is a self-contained ## section with no leading/trailing whitespace", () => {
+    // Composed as its own section (joined by blank lines); stray edge whitespace would
+    // double-space the seams in `composeProjectInstructions`.
+    expect(AGENT_TODO_PLANNING_STEERING.startsWith("## ")).toBe(true);
+    expect(AGENT_TODO_PLANNING_STEERING).toBe(AGENT_TODO_PLANNING_STEERING.trim());
+  });
+
+  // The wording below is load-bearing — see the module header. These assertions keep a
+  // well-meaning future edit from re-introducing the exact failure modes it was written to
+  // avoid, since the text reaches three backends and there is no other guard on it.
+  it("names no vendor-specific planning tool", () => {
+    // A concrete tool name makes one backend try to mimic another's API.
+    expect(AGENT_TODO_PLANNING_STEERING).not.toMatch(/TodoWrite|update_plan|TaskCreate|TaskUpdate/);
+  });
+
+  it("stays threshold-style — says when to skip, never mandates a plan", () => {
+    expect(AGENT_TODO_PLANNING_STEERING).toContain("**When to skip:**");
+    expect(AGENT_TODO_PLANNING_STEERING.toLowerCase()).not.toContain("always");
+  });
+
+  it("keeps the user's-language and single-in-progress guardrails", () => {
+    expect(AGENT_TODO_PLANNING_STEERING).toContain("user's language");
+    expect(AGENT_TODO_PLANNING_STEERING).toContain("exactly one item in progress");
+  });
+});

--- a/src/system-prompts/agentTodoPlanningSteering.ts
+++ b/src/system-prompts/agentTodoPlanningSteering.ts
@@ -1,0 +1,30 @@
+/**
+ * Agent task-planning steering — a backend-agnostic prompt section that tells the
+ * agent WHEN to create a todo/plan list (and, just as importantly, when not to).
+ *
+ * It lives here, in the neutral `system-prompts` domain, so BOTH prompt builders
+ * can consume the SAME text without a circular dependency:
+ *  - `projects/projectSystemPrompt.ts` injects it today — Project scope only, so
+ *    the global (no-project) prompt stays byte-identical.
+ *  - `agentMode/backends/shared/agentSystemPrompt.ts` could push it globally later
+ *    (see the seam comment there); single source, no duplicated wording.
+ *
+ * The wording rules are deliberate and load-bearing:
+ *  - Threshold-style, never "always": trivial Q&A and single-step tasks must NOT
+ *    trigger a plan, or the agent spams noise into the popover Progress section.
+ *  - Generalized ("built-in todo/plan tool"), never a vendor tool name like
+ *    TodoWrite / update_plan / TaskCreate — naming one backend's tool makes the
+ *    others try to mimic an API they don't have.
+ *  - "in the user's language" — a non-English request must not yield English todo
+ *    items, since the same text renders in the live Progress section.
+ */
+export const AGENT_TODO_PLANNING_STEERING = `## Task planning
+Use your built-in todo/plan tool for complex work so the user can follow your progress.
+
+**When to plan:** the task takes roughly 3+ meaningful steps, spans multiple notes or files, or the user explicitly asks for a plan or checklist.
+**When to skip:** simple questions, single-step tasks, or anything you can answer directly — an unnecessary plan is just noise.
+
+When you plan:
+- Write each item in the user's language.
+- Keep exactly one item in progress at a time: mark it in progress before you start that step, and completed as soon as the work is actually done.
+- Update the plan as scope changes — add steps you discover and drop ones that no longer apply.`;

--- a/src/utils/appPaths.test.ts
+++ b/src/utils/appPaths.test.ts
@@ -1,5 +1,8 @@
+import type { App } from "obsidian";
+import { FileSystemAdapter } from "obsidian";
 import * as path from "node:path";
-import { COPILOT_APP_DIR_NAME, copilotAppDataDir } from "./appPaths";
+import { md5 } from "@/utils/hash";
+import { COPILOT_APP_DIR_NAME, copilotAppDataDir, getVaultId } from "./appPaths";
 
 describe("copilotAppDataDir", () => {
   it("is ~/.obsidian-copilot under the given home dir", () => {
@@ -10,5 +13,32 @@ describe("copilotAppDataDir", () => {
     expect(COPILOT_APP_DIR_NAME).toBe(".obsidian-copilot");
     // Guard against a regression to the GitHub-Copilot-CLI-colliding name.
     expect(COPILOT_APP_DIR_NAME).not.toBe(".copilot");
+  });
+});
+
+describe("getVaultId", () => {
+  const appWith = (adapter: unknown): App => ({ vault: { adapter } }) as unknown as App;
+  // The jsdom mock's FileSystemAdapter takes a base path; the real obsidian
+  // type declares a 0-arg constructor, so cast to build a hashable instance.
+  const FsAdapter = FileSystemAdapter as unknown as new (basePath: string) => FileSystemAdapter;
+
+  it("is the first 8 hex chars of md5(vaultBasePath) for a desktop adapter", () => {
+    const app = appWith(new FsAdapter("/Users/me/My Vault"));
+    expect(getVaultId(app)).toBe(md5("/Users/me/My Vault").slice(0, 8));
+    expect(getVaultId(app)).toHaveLength(8);
+  });
+
+  it("stays equivalent to the legacy inline computation it replaced", () => {
+    const basePath = "/vault";
+    const app = appWith(new FsAdapter(basePath));
+    // The exact expression previously inlined in agentMode/index.ts.
+    const legacy = basePath ? md5(basePath).slice(0, 8) : "default";
+    expect(getVaultId(app)).toBe(legacy);
+  });
+
+  it('falls back to "default" when the adapter is not a FileSystemAdapter', () => {
+    // e.g. mobile / in-memory adapters expose no stable absolute base path.
+    const app = appWith({ getBasePath: () => "/unused" });
+    expect(getVaultId(app)).toBe("default");
   });
 });

--- a/src/utils/appPaths.ts
+++ b/src/utils/appPaths.ts
@@ -1,4 +1,6 @@
+import { type App, FileSystemAdapter } from "obsidian";
 import * as path from "node:path";
+import { md5 } from "@/utils/hash";
 
 /**
  * Name of Copilot's per-user, OS-level data directory: `~/.obsidian-copilot`.
@@ -24,4 +26,23 @@ export const COPILOT_APP_DIR_NAME = ".obsidian-copilot";
  */
 export function copilotAppDataDir(homeDir: string): string {
   return path.join(homeDir, COPILOT_APP_DIR_NAME);
+}
+
+/**
+ * Stable per-vault identifier used to bucket this vault's off-vault data under
+ * {@link copilotAppDataDir} (e.g. `vaults/<vaultId>/`). It is the first 8 hex
+ * chars of `md5(vaultBasePath)` — short enough for a readable directory name,
+ * wide enough to avoid collisions across a user's handful of vaults.
+ *
+ * Reason: only the desktop {@link FileSystemAdapter} exposes an absolute base
+ * path. On other adapters (mobile, in-memory) there is no stable path to hash,
+ * so we fall back to `"default"`. Off-vault data is desktop-only anyway, so the
+ * fallback is never the live path in practice — it just keeps the function
+ * total. Identical input path → identical id, so every consumer that derives a
+ * path from this id (recent-chats index, conversion cache) agrees.
+ */
+export function getVaultId(app: App): string {
+  const adapter = app.vault.adapter;
+  const vaultBasePath = adapter instanceof FileSystemAdapter ? adapter.getBasePath() : "";
+  return vaultBasePath ? md5(vaultBasePath).slice(0, 8) : "default";
 }

--- a/src/utils/cacheFileOpener.ts
+++ b/src/utils/cacheFileOpener.ts
@@ -1,7 +1,10 @@
 import { type ContextCache, getFileCacheRef } from "@/cache/projectContextCache";
 import { CachePreviewModal } from "@/components/modals/CachePreviewModal";
 import type { ProcessingItem } from "@/components/project/processingAdapter";
+import { cacheFileName } from "@/context/contextCacheStore";
 import { logError } from "@/logger";
+import { isDesktopRuntime } from "@/utils/desktopRuntime";
+import { isMissingFileError } from "@/utils/isMissingFileError";
 import { App, Notice } from "obsidian";
 
 /**
@@ -95,4 +98,52 @@ export async function openCachedItemPreview(
   }
 
   new CachePreviewModal(app, item.name, content).open();
+}
+
+/**
+ * Open a preview for an AGENT project's converted snapshot — the agent-mode
+ * counterpart to {@link openCachedItemPreview}. The agent pipeline stores each
+ * source's materialized text in the shared OFF-VAULT conversion cache: remote
+ * snapshots under `remotes/`, converted vault files under `files/` (keyed by
+ * source identity, not project). Read the file, hand it to {@link CachePreviewModal}.
+ * The snapshot's leading `<!-- copilot-context-cache … -->` block is an HTML
+ * comment, so the markdown preview hides it and its `# File/URL:` header renders
+ * as a heading — no special stripping needed.
+ *
+ * MOBILE BOUNDARY (design §3.4, invariant 4): this util is statically imported
+ * into the mobile bundle (via the shared ContextManageModal), so it must not
+ * statically import `conversionsLocation`/`contextCacheFs` (which evaluate Node
+ * builtins). They are loaded only behind the desktop gate via dynamic import;
+ * mobile has no Agent Mode, so the preview is desktop-only.
+ */
+export async function openAgentCachedItemPreview(
+  app: App,
+  item: Pick<ProcessingItem, "id" | "name" | "cacheKind">
+): Promise<void> {
+  if (!isDesktopRuntime()) {
+    new Notice("Converted previews are available on desktop only.");
+    return;
+  }
+  const fileName = cacheFileName(item.cacheKind, item.id);
+  // Read directly instead of an exists()+read() round-trip: a missing snapshot
+  // throws, and we map that back to the "not converted yet" message below.
+  try {
+    const { remotesDir, filesDir } = await import("@/context/conversionsLocation");
+    const { createNodeContextCacheFs } = await import("@/context/contextCacheFs");
+    const dir = item.cacheKind === "file" ? filesDir(app) : remotesDir(app);
+    // The fs is rooted AT the snapshot's bucket, so the read is `readText(name)`.
+    const content = await createNodeContextCacheFs(dir).readText(fileName);
+    if (!content.trim()) {
+      new Notice("No content available for this item.");
+      return;
+    }
+    new CachePreviewModal(app, item.name, content).open();
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      new Notice("No converted content yet for this item.");
+      return;
+    }
+    logError(`Failed to read agent cached snapshot: ${fileName}`, error);
+    new Notice("Failed to read converted content.");
+  }
 }

--- a/src/utils/chatHistoryUtils.test.ts
+++ b/src/utils/chatHistoryUtils.test.ts
@@ -1,0 +1,69 @@
+/* eslint-disable obsidianmd/no-tfile-tfolder-cast -- test fixtures; not real TFiles */
+import { fileToHistoryItem } from "@/utils/chatHistoryUtils";
+import type { RecentUsageManager } from "@/utils/recentUsageManager";
+import type { App, TFile } from "obsidian";
+
+jest.mock("obsidian", () => ({ App: jest.fn(), TFile: jest.fn() }));
+jest.mock("@/utils", () => ({
+  formatDateTime: jest.fn(() => ({ display: "2026/01/01 12:00:00", fileName: "20260101_120000" })),
+}));
+jest.mock("@/projects/projectPaths", () => ({
+  sanitizeVaultPathSegment: jest.fn((s: string) => s),
+}));
+jest.mock("@/projects/state", () => ({
+  getCachedProjectRecords: jest.fn(() => []),
+}));
+jest.mock("@/utils/vaultAdapterUtils", () => ({
+  readFrontmatterViaAdapter: jest.fn().mockResolvedValue(null),
+}));
+
+/** A RecentUsageManager stub that echoes the persisted timestamp back. */
+const lastAccessedStub = {
+  getEffectiveLastUsedAt: (_path: string, persisted?: number | null) => persisted ?? 0,
+} as unknown as RecentUsageManager<string>;
+
+/**
+ * Build an `app` whose metadataCache returns the given frontmatter for any
+ * file, so we can assert how `fileToHistoryItem` reads scope metadata.
+ */
+function makeApp(frontmatter: Record<string, unknown>) {
+  return {
+    metadataCache: {
+      getFileCache: jest.fn(() => ({ frontmatter })),
+    },
+  } as unknown as App;
+}
+
+function makeFile(): TFile {
+  return {
+    path: "test-folder/agent__chat.md",
+    basename: "agent__chat",
+    stat: { ctime: 1735732800000, mtime: 1735732800000 },
+  } as unknown as TFile;
+}
+
+describe("fileToHistoryItem projectId extraction", () => {
+  it("extracts a string projectId from frontmatter", () => {
+    const app = makeApp({ epoch: 1735732800000, projectId: "proj-123" });
+    const item = fileToHistoryItem(app, makeFile(), lastAccessedStub);
+    expect(item.projectId).toBe("proj-123");
+  });
+
+  it("coerces a numeric projectId (unquoted YAML) to a string", () => {
+    const app = makeApp({ epoch: 1735732800000, projectId: 123 });
+    const item = fileToHistoryItem(app, makeFile(), lastAccessedStub);
+    expect(item.projectId).toBe("123");
+  });
+
+  it("leaves projectId undefined when absent (no GLOBAL_SCOPE default in this layer)", () => {
+    const app = makeApp({ epoch: 1735732800000 });
+    const item = fileToHistoryItem(app, makeFile(), lastAccessedStub);
+    expect(item.projectId).toBeUndefined();
+  });
+
+  it("treats a blank projectId as undefined", () => {
+    const app = makeApp({ epoch: 1735732800000, projectId: "   " });
+    const item = fileToHistoryItem(app, makeFile(), lastAccessedStub);
+    expect(item.projectId).toBeUndefined();
+  });
+});

--- a/src/utils/chatHistoryUtils.ts
+++ b/src/utils/chatHistoryUtils.ts
@@ -237,15 +237,21 @@ export function fileToHistoryItem(
     file.path,
     persistedLastAccessedAtMs ?? createdAt.getTime()
   );
-  const rawBackendId = app.metadataCache.getFileCache(file)?.frontmatter?.backendId;
+  const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+  const rawBackendId = frontmatter?.backendId;
   const backendId =
     typeof rawBackendId === "string" && rawBackendId.trim() ? rawBackendId.trim() : undefined;
+  // Reason: expose the raw frontmatter projectId (undefined when absent). The
+  // GLOBAL_SCOPE default for unscoped chats is applied by the Agent Mode session
+  // layer, keeping this util free of a cross-layer scope import.
+  const projectId = coerceProjectId(frontmatter?.projectId);
   return {
     id: file.path,
     title: extractChatTitle(app, file),
     createdAt,
     lastAccessedAt: new Date(effectiveLastAccessedAtMs),
     backendId,
+    projectId,
   };
 }
 

--- a/src/utils/isMissingFileError.test.ts
+++ b/src/utils/isMissingFileError.test.ts
@@ -1,0 +1,32 @@
+import { isMissingFileError } from "@/utils/isMissingFileError";
+
+describe("isMissingFileError", () => {
+  it("matches a Node ENOENT error code", () => {
+    const error = Object.assign(new Error("whatever"), { code: "ENOENT" });
+    expect(isMissingFileError(error)).toBe(true);
+  });
+
+  it("matches an ENOENT message without a code", () => {
+    expect(isMissingFileError(new Error("ENOENT: no such file or directory"))).toBe(true);
+  });
+
+  it("matches a NotFoundError name", () => {
+    const error = new Error("missing");
+    error.name = "NotFoundError";
+    expect(isMissingFileError(error)).toBe(true);
+  });
+
+  it("matches 'not found' / 'does not exist' messages from other adapters", () => {
+    expect(isMissingFileError(new Error("File not found"))).toBe(true);
+    expect(isMissingFileError(new Error("The path does not exist"))).toBe(true);
+  });
+
+  it("matches a plain string error", () => {
+    expect(isMissingFileError("ENOENT")).toBe(true);
+  });
+
+  it("does not match a generic read failure", () => {
+    expect(isMissingFileError(new Error("permission denied"))).toBe(false);
+    expect(isMissingFileError(new Error("EACCES"))).toBe(false);
+  });
+});

--- a/src/utils/isMissingFileError.ts
+++ b/src/utils/isMissingFileError.ts
@@ -1,0 +1,17 @@
+import { errCode } from "@/utils/errorUtils";
+
+/**
+ * True when an error thrown by a vault adapter read means the file is absent,
+ * as opposed to a genuine read failure. Obsidian surfaces this differently per
+ * platform: Node's desktop `FileSystemAdapter` throws an `ENOENT` Error, while
+ * other adapters use a `NotFoundError` name or "not found" / "does not exist"
+ * messages — so match the common shapes rather than a single string.
+ */
+export function isMissingFileError(error: unknown): boolean {
+  if (errCode(error) === "ENOENT") return true;
+
+  if (error instanceof Error && error.name === "NotFoundError") return true;
+
+  const message = error instanceof Error ? error.message : String(error);
+  return /ENOENT|no such file|not found|does not exist/i.test(message);
+}

--- a/src/utils/truncateForPreview.test.ts
+++ b/src/utils/truncateForPreview.test.ts
@@ -1,0 +1,51 @@
+import { PREVIEW_RENDER_LIMIT, truncateForPreview } from "@/utils/truncateForPreview";
+
+describe("truncateForPreview", () => {
+  it("returns short content unchanged", () => {
+    const content = "# Title\n\nsome body text";
+    expect(truncateForPreview(content)).toEqual({ text: content, truncated: false });
+  });
+
+  it("returns content at exactly the limit unchanged", () => {
+    const content = "a".repeat(PREVIEW_RENDER_LIMIT);
+    expect(truncateForPreview(content)).toEqual({ text: content, truncated: false });
+  });
+
+  it("truncates oversized content and flags it", () => {
+    const content = "a".repeat(PREVIEW_RENDER_LIMIT + 500);
+    const result = truncateForPreview(content);
+    expect(result.truncated).toBe(true);
+    expect(result.text.length).toBeLessThanOrEqual(PREVIEW_RENDER_LIMIT);
+  });
+
+  it("backs the cut up to the last newline at or before the limit", () => {
+    // Newline sits 5 chars before the limit; the cut should land on it so the
+    // rendered slice ends on a clean line boundary.
+    const head = "x".repeat(PREVIEW_RENDER_LIMIT - 5);
+    const content = `${head}\n${"y".repeat(100)}`;
+    const result = truncateForPreview(content);
+    expect(result.truncated).toBe(true);
+    expect(result.text).toBe(head);
+  });
+
+  it("hard-cuts at the limit when no newline is in range", () => {
+    const content = "z".repeat(PREVIEW_RENDER_LIMIT + 200);
+    const result = truncateForPreview(content, 50);
+    expect(result.text).toBe("z".repeat(50));
+    expect(result.truncated).toBe(true);
+  });
+
+  it("keeps the full budget when the only newline is far before the limit (one giant line)", () => {
+    // Mirrors a one-line JSON/spreadsheet dump: a short header line, then a
+    // huge unbroken line. Snapping back to the header newline would collapse
+    // the preview, so we must hard-cut at the limit instead.
+    const content = `head\n${"x".repeat(PREVIEW_RENDER_LIMIT * 2)}`;
+    const result = truncateForPreview(content);
+    expect(result.truncated).toBe(true);
+    expect(result.text.length).toBe(PREVIEW_RENDER_LIMIT);
+  });
+
+  it("handles an empty string", () => {
+    expect(truncateForPreview("")).toEqual({ text: "", truncated: false });
+  });
+});

--- a/src/utils/truncateForPreview.ts
+++ b/src/utils/truncateForPreview.ts
@@ -1,0 +1,50 @@
+/**
+ * Maximum number of characters fed to the markdown renderer in a single
+ * synchronous pass. `MarkdownRenderer.render` builds the whole DOM tree on the
+ * main thread with no lazy/section rendering, so an unbounded parsed snapshot
+ * (PDF/URL text can reach several MB) freezes the UI until it finishes. Render
+ * cost scales with this cap, so it is kept modest to keep open latency low —
+ * dense single-line payloads (e.g. a spreadsheet dumped as one JSON line) are
+ * especially expensive to lay out. ~30 KB still shows plenty to confirm a parse;
+ * the full content is always available via Copy.
+ */
+export const PREVIEW_RENDER_LIMIT = 30_000;
+
+/**
+ * How far back from the limit we'll hunt for a line break to cut on. Kept small
+ * so a single very long line (e.g. minified JSON / a one-line spreadsheet dump)
+ * can't snap the cut back near the start and collapse the preview to a handful
+ * of characters — past this window we just hard-cut and keep the full budget.
+ */
+const SNAP_BACK_WINDOW = 1_024;
+
+export interface TruncatedPreview {
+  /** The slice safe to render (whole content when not truncated). */
+  text: string;
+  /** True when the content exceeded the limit and `text` is a prefix of it. */
+  truncated: boolean;
+}
+
+/**
+ * Bound the cost of a one-shot markdown render by capping the input length.
+ *
+ * When truncation is needed we back the cut up to the last newline at or before
+ * `limit` so the visible content ends on a clean line boundary instead of
+ * mid-word; if there is no newline in range we hard-cut at `limit`.
+ */
+export function truncateForPreview(
+  content: string,
+  limit = PREVIEW_RENDER_LIMIT
+): TruncatedPreview {
+  if (content.length <= limit) {
+    return { text: content, truncated: false };
+  }
+
+  // Snap to a line break only when one sits within SNAP_BACK_WINDOW of the
+  // limit, so normal multi-line text cuts cleanly; a long unbroken line has no
+  // nearby newline and gets hard-cut at the limit to preserve the budget.
+  const newlineIndex = content.lastIndexOf("\n", limit);
+  const endIndex =
+    newlineIndex >= limit - SNAP_BACK_WINDOW && newlineIndex > 0 ? newlineIndex : limit;
+  return { text: content.slice(0, endIndex), truncated: true };
+}

--- a/src/utils/urlTagUtils.test.ts
+++ b/src/utils/urlTagUtils.test.ts
@@ -119,6 +119,16 @@ describe("extractUrlsFromText", () => {
     expect(extractUrlsFromText("(see https://example.com.)")).toEqual(["https://example.com"]);
   });
 
+  it("handles a long unbalanced trailing bracket run without quadratic blowup", () => {
+    // Perf tripwire: trimming used to re-split the whole string per stripped char
+    // (O(n²)), freezing the main thread on a pathological paste. The linear
+    // rewrite resolves this 100k-')' run instantly; reintroducing the quadratic
+    // form would blow the test timeout. (Correctness of the rewrite itself is
+    // covered by the small balanced/unbalanced cases above.)
+    const url = "https://example.com";
+    expect(extractUrlsFromText(`${url}${")".repeat(100_000)}`)).toEqual([url]);
+  });
+
   it("strips markdown image/link wrappers down to the url", () => {
     expect(extractUrlsFromText('![alt](https://cdn.example.com/a.png "title")')).toEqual([
       "https://cdn.example.com/a.png",

--- a/src/utils/urlTagUtils.test.ts
+++ b/src/utils/urlTagUtils.test.ts
@@ -1,0 +1,145 @@
+import {
+  createUrlItem,
+  extractUrlsFromText,
+  normalizeUrl,
+  parseProjectUrls,
+  parseUrlsFromText,
+  resolveInputUrls,
+  serializeProjectUrls,
+} from "@/utils/urlTagUtils";
+
+describe("normalizeUrl", () => {
+  it("prepends https:// to a bare host", () => {
+    expect(normalizeUrl("example.com")).toBe("https://example.com");
+  });
+
+  it("leaves an explicit scheme untouched and trims", () => {
+    expect(normalizeUrl("  http://example.com  ")).toBe("http://example.com");
+    expect(normalizeUrl("https://example.com")).toBe("https://example.com");
+  });
+});
+
+describe("createUrlItem", () => {
+  it("normalizes the url and classifies a plain web page", () => {
+    const item = createUrlItem("example.com/page");
+    expect(item).toEqual({
+      id: "web:https://example.com/page",
+      url: "https://example.com/page",
+      type: "web",
+    });
+  });
+
+  it("classifies a YouTube video as youtube", () => {
+    const item = createUrlItem("https://www.youtube.com/watch?v=dQw4w9WgXcQ");
+    expect(item.type).toBe("youtube");
+  });
+
+  it("produces a stable id for the same input", () => {
+    expect(createUrlItem("example.com").id).toBe(createUrlItem("example.com").id);
+  });
+});
+
+describe("parseUrlsFromText", () => {
+  it("parses a single url", () => {
+    const items = parseUrlsFromText("https://example.com");
+    expect(items).toHaveLength(1);
+    expect(items[0].url).toBe("https://example.com");
+  });
+
+  it("extracts every scheme-anchored url from a batch", () => {
+    const items = parseUrlsFromText("https://example.com\nhttps://foo.org https://bar.net");
+    expect(items.map((i) => i.url)).toEqual([
+      "https://example.com",
+      "https://foo.org",
+      "https://bar.net",
+    ]);
+  });
+
+  it("accepts a single bare host typed without a scheme", () => {
+    const items = parseUrlsFromText("example.com");
+    expect(items.map((i) => i.url)).toEqual(["https://example.com"]);
+  });
+
+  it("does NOT harvest bare-host tokens from a multi-token blob", () => {
+    // The single biggest fix: prose tokens that look like hosts (`1.`,
+    // `(context.urls)`, `Mention.mentions:`, a CJK sentence whose 。 folds to a
+    // dot) must not become URLs when a document is pasted. Only the explicit
+    // https:// link survives.
+    const blob = [
+      "1. first point",
+      "see (context.urls) and Mention.mentions: for details",
+      "这是现有架构的统一设计。",
+      "real link https://anthropic.com/news",
+    ].join("\n");
+    expect(parseUrlsFromText(blob).map((i) => i.url)).toEqual(["https://anthropic.com/news"]);
+  });
+
+  it("dedups within the input and against existing urls (by normalized url)", () => {
+    const items = parseUrlsFromText("https://example.com\nhttps://example.com\nhttps://foo.org", [
+      "https://foo.org",
+    ]);
+    expect(items.map((i) => i.url)).toEqual(["https://example.com"]);
+  });
+
+  it("classifies web and youtube items", () => {
+    const items = parseUrlsFromText("https://example.com\nhttps://youtu.be/dQw4w9WgXcQ");
+    expect(items.find((i) => i.url.includes("example"))?.type).toBe("web");
+    expect(items.find((i) => i.url.includes("youtu.be"))?.type).toBe("youtube");
+  });
+
+  it("round-trips through serialize/parseProjectUrls without loss", () => {
+    const items = parseUrlsFromText(
+      "https://example.com\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    );
+    const { webUrls, youtubeUrls } = serializeProjectUrls(items);
+    const reparsed = parseProjectUrls(webUrls, youtubeUrls);
+    expect(reparsed.map((i) => i.url).sort()).toEqual(items.map((i) => i.url).sort());
+  });
+});
+
+describe("extractUrlsFromText", () => {
+  it("only matches scheme-anchored urls, ignoring bare-host prose", () => {
+    expect(extractUrlsFromText("ping example.com or 1. or (context.urls)")).toEqual([]);
+    expect(extractUrlsFromText("go to https://example.com now")).toEqual(["https://example.com"]);
+  });
+
+  it("trims trailing sentence and CJK punctuation", () => {
+    expect(extractUrlsFromText("see https://example.com.")).toEqual(["https://example.com"]);
+    expect(extractUrlsFromText("链接 https://example.com，谢谢")).toEqual(["https://example.com"]);
+  });
+
+  it("drops an unbalanced trailing bracket but keeps balanced ones", () => {
+    expect(extractUrlsFromText("(https://example.com)")).toEqual(["https://example.com"]);
+    expect(extractUrlsFromText("https://en.wikipedia.org/wiki/Foo_(bar)")).toEqual([
+      "https://en.wikipedia.org/wiki/Foo_(bar)",
+    ]);
+  });
+
+  it("re-trims punctuation a stripped bracket was hiding", () => {
+    expect(extractUrlsFromText("(see https://example.com.)")).toEqual(["https://example.com"]);
+  });
+
+  it("strips markdown image/link wrappers down to the url", () => {
+    expect(extractUrlsFromText('![alt](https://cdn.example.com/a.png "title")')).toEqual([
+      "https://cdn.example.com/a.png",
+    ]);
+  });
+
+  it("de-duplicates repeated urls", () => {
+    expect(extractUrlsFromText("https://x.com https://x.com")).toEqual(["https://x.com"]);
+  });
+});
+
+describe("resolveInputUrls", () => {
+  it("returns scheme-anchored urls when present", () => {
+    expect(resolveInputUrls("https://a.com bare.com")).toEqual(["https://a.com"]);
+  });
+
+  it("falls back to a single bare host with no scheme", () => {
+    expect(resolveInputUrls("youtube.com/watch?v=x")).toEqual(["youtube.com/watch?v=x"]);
+  });
+
+  it("does not fall back for a multi-token bare-host blob", () => {
+    expect(resolveInputUrls("foo.com bar.com")).toEqual([]);
+  });
+});

--- a/src/utils/urlTagUtils.ts
+++ b/src/utils/urlTagUtils.ts
@@ -11,10 +11,17 @@
 
 import { getYouTubeVideoId } from "@/utils/youtubeUrl";
 
+/**
+ * The two kinds a context URL can be classified as. Single source of truth —
+ * every URL surface (input, icon, status, cache remote) derives from this so a
+ * new kind is added in one place.
+ */
+export type UrlKind = "web" | "youtube";
+
 export interface UrlItem {
   id: string;
   url: string;
-  type: "web" | "youtube";
+  type: UrlKind;
 }
 
 /**
@@ -23,7 +30,7 @@ export interface UrlItem {
  * re-parsed from strings on every render. A deterministic ID based on
  * the URL content ensures stable keys and prevents unnecessary re-mounts.
  */
-function stableId(type: "web" | "youtube", url: string): string {
+function stableId(type: UrlKind, url: string): string {
   return `${type}:${url}`;
 }
 
@@ -35,11 +42,119 @@ function stableId(type: "web" | "youtube", url: string): string {
  * "youtube". Non-video YouTube pages (channels, playlists, homepage) correctly
  * fall through to "web", matching the downstream transcript pipeline expectation.
  */
-export function detectUrlType(url: string): "web" | "youtube" {
+export function detectUrlType(url: string): UrlKind {
   // Reason: User input may omit the protocol (e.g. "youtube.com/watch?v=...").
   // getYouTubeVideoId requires a full URL for `new URL()` parsing.
   const normalized = url.startsWith("http") ? url : `https://${url}`;
   return getYouTubeVideoId(normalized) !== null ? "youtube" : "web";
+}
+
+/**
+ * Add the `https://` scheme when the user typed a bare host (e.g. "example.com").
+ * Reason: callers store and dedup URLs in normalized form so the same address
+ * typed with/without a scheme collapses to one entry.
+ */
+export function normalizeUrl(raw: string): string {
+  const trimmed = raw.trim();
+  return trimmed.startsWith("http") ? trimmed : `https://${trimmed}`;
+}
+
+/**
+ * Build a {@link UrlItem} from a raw (possibly scheme-less) URL string, using the
+ * same stable id scheme as {@link parseProjectUrls} so a value keeps one identity
+ * whether it was just typed or re-parsed from the persisted strings.
+ */
+export function createUrlItem(raw: string): UrlItem {
+  const url = normalizeUrl(raw);
+  const type = detectUrlType(raw);
+  return { id: stableId(type, url), url, type };
+}
+
+const CLOSING_TO_OPENING: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
+
+/**
+ * Trim trailing punctuation a URL accretes from the prose around it — sentence
+ * enders and CJK punctuation — plus an UNBALANCED closing bracket, so
+ * "(see https://x.com)" yields "https://x.com" while a path that legitimately
+ * ends in a balanced bracket (e.g. Wikipedia ".../Foo_(disambiguation)") keeps it.
+ */
+function trimSentencePunctuation(url: string): string {
+  return url.replace(/[.,;:!?，。！？；：、]+$/u, "");
+}
+
+function trimUrlTrailingPunctuation(url: string): string {
+  let next = trimSentencePunctuation(url);
+  while (next.length > 0) {
+    const last = next[next.length - 1];
+    const opener = CLOSING_TO_OPENING[last];
+    if (!opener) break;
+    const opens = next.split(opener).length - 1;
+    const closes = next.split(last).length - 1;
+    if (closes <= opens) break;
+    // Re-trim sentence punctuation that the bracket was hiding ("example.com.)").
+    next = trimSentencePunctuation(next.slice(0, -1));
+  }
+  return next;
+}
+
+/**
+ * Extract http(s) URLs from free-form text. Scheme-anchored on purpose: a bare
+ * dotted token in prose ("1.", "(context.urls)", or a CJK sentence whose `。`
+ * IDNA-folds to a dot) is NOT a URL — and since a legit bare host like
+ * "example.com" is structurally indistinguishable from those, requiring an
+ * explicit http(s):// scheme is the only robust lever against false positives
+ * when a whole document is pasted. Trailing prose punctuation is trimmed and the
+ * result de-duplicated. This is the canonical extractor — `Mention.extractUrls`
+ * (the @-mention pipeline) and {@link parseUrlsFromText} both route through it.
+ */
+export function extractUrlsFromText(text: string): string[] {
+  // Stop the match at whitespace, quotes, angle brackets, and CJK/full-width
+  // punctuation — the last so a URL written flush against Chinese prose
+  // ("链接https://x.com，谢谢") doesn't swallow the trailing sentence.
+  const urlRegex = /https?:\/\/[^\s"'<>，。、！？；：）（【】「」『』《》]+/g;
+  const seen = new Set<string>();
+  const urls: string[] = [];
+  for (const raw of text.match(urlRegex) ?? []) {
+    const url = trimUrlTrailingPunctuation(raw);
+    if (!url || seen.has(url)) continue;
+    seen.add(url);
+    urls.push(url);
+  }
+  return urls;
+}
+
+/**
+ * Resolve free-form text to the URL strings a user meant to add: every
+ * scheme-anchored URL via {@link extractUrlsFromText}, OR — when the text is a
+ * single bare token with no scheme (e.g. "youtube.com/watch?v=x") — that one
+ * host. The single-token fallback keeps the convenience of typing one URL
+ * without a scheme, while a pasted blob (which has whitespace) never triggers it,
+ * so prose can't smuggle bare-host garbage in.
+ */
+export function resolveInputUrls(text: string): string[] {
+  const extracted = extractUrlsFromText(text);
+  if (extracted.length > 0) return extracted;
+  const single = text.trim();
+  return single && !/\s/.test(single) && isValidUrl(single) ? [single] : [];
+}
+
+/**
+ * Parse free-form text (single URL, or batch paste) into deduplicated
+ * {@link UrlItem}s. `existingUrls` (raw or normalized) are excluded so re-adding
+ * a URL already in the list is a no-op. Dedup is by normalized URL. Shared by
+ * {@link UrlTagInput}, the home/Manage `+URL` flows, and the project URL field,
+ * so all classify and normalize input identically.
+ */
+export function parseUrlsFromText(text: string, existingUrls: string[] = []): UrlItem[] {
+  const seen = new Set(existingUrls.map(normalizeUrl));
+  const items: UrlItem[] = [];
+  for (const raw of resolveInputUrls(text)) {
+    const item = createUrlItem(raw);
+    if (seen.has(item.url)) continue;
+    seen.add(item.url);
+    items.push(item);
+  }
+  return items;
 }
 
 /**
@@ -54,7 +169,7 @@ export function parseProjectUrls(webUrls: string, youtubeUrls: string): UrlItem[
   const seen = new Set<string>();
   const items: UrlItem[] = [];
 
-  const parseField = (raw: string, type: "web" | "youtube") => {
+  const parseField = (raw: string, type: UrlKind) => {
     if (!raw) return;
     const lines = raw.split("\n");
     for (const line of lines) {

--- a/src/utils/urlTagUtils.ts
+++ b/src/utils/urlTagUtils.ts
@@ -72,29 +72,44 @@ export function createUrlItem(raw: string): UrlItem {
 
 const CLOSING_TO_OPENING: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
 
+const SENTENCE_PUNCTUATION_RE = /[.,;:!?，。！？；：、]/u;
+
+/** Walk back over trailing sentence/CJK punctuation in `url[0, end)`, returning the new end. */
+function trimSentencePunctuationEnd(url: string, end: number): number {
+  while (end > 0 && SENTENCE_PUNCTUATION_RE.test(url[end - 1])) end--;
+  return end;
+}
+
 /**
  * Trim trailing punctuation a URL accretes from the prose around it — sentence
  * enders and CJK punctuation — plus an UNBALANCED closing bracket, so
  * "(see https://x.com)" yields "https://x.com" while a path that legitimately
  * ends in a balanced bracket (e.g. Wikipedia ".../Foo_(disambiguation)") keeps it.
  */
-function trimSentencePunctuation(url: string): string {
-  return url.replace(/[.,;:!?，。！？；：、]+$/u, "");
-}
-
 function trimUrlTrailingPunctuation(url: string): string {
-  let next = trimSentencePunctuation(url);
-  while (next.length > 0) {
-    const last = next[next.length - 1];
+  let end = trimSentencePunctuationEnd(url, url.length);
+  // Count brackets once so the trailing-strip loop stays O(n). Re-splitting the
+  // whole string per stripped char is O(n²) and freezes the main thread on a
+  // pathological trailing-bracket run (e.g. a corrupted paste). Only closers and
+  // sentence punctuation are ever stripped — never openers — so these opener
+  // totals stay valid as `end` walks left.
+  const openCounts: Record<string, number> = { "(": 0, "[": 0, "{": 0 };
+  const closeCounts: Record<string, number> = { ")": 0, "]": 0, "}": 0 };
+  for (let i = 0; i < end; i++) {
+    const ch = url[i];
+    if (ch === "(" || ch === "[" || ch === "{") openCounts[ch]++;
+    else if (ch === ")" || ch === "]" || ch === "}") closeCounts[ch]++;
+  }
+  while (end > 0) {
+    const last = url[end - 1];
     const opener = CLOSING_TO_OPENING[last];
     if (!opener) break;
-    const opens = next.split(opener).length - 1;
-    const closes = next.split(last).length - 1;
-    if (closes <= opens) break;
-    // Re-trim sentence punctuation that the bracket was hiding ("example.com.)").
-    next = trimSentencePunctuation(next.slice(0, -1));
+    if (closeCounts[last] <= openCounts[opener]) break; // balanced — keep it
+    closeCounts[last]--;
+    // Re-trim sentence punctuation the bracket was hiding ("example.com.)").
+    end = trimSentencePunctuationEnd(url, end - 1);
   }
-  return next;
+  return url.slice(0, end);
 }
 
 /**

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,6 +48,7 @@ module.exports = {
         yellow: "var(--color-yellow)",
         orange: "var(--color-orange)",
         purple: "var(--color-purple)",
+        cyan: "var(--color-cyan)",
       },
       // Per-project accent hues (Agent Home project tiles). Theme-aware via
       // Obsidian's named color vars; paired with the matching `bg.project` tints.
@@ -122,6 +123,7 @@ module.exports = {
       "border-hover": "var(--background-modifier-border-hover)",
       "border-focus": "var(--background-modifier-border-focus)",
       "interactive-accent": "var(--interactive-accent)",
+      error: "var(--text-error)",
     },
     ringColor: {
       ring: "var(--interactive-accent)",


### PR DESCRIPTION
## Summary

Turns Agent Mode "projects" into Claude-Projects-style **scoped workspaces**. Entering a project gives it its own sessions, chat history, landing, and materialized context; the global workspace becomes one special scope (`GLOBAL_SCOPE`) sharing the exact same code path.

### Session & scope model

- `AgentSessionManager` keys every session by an immutable `projectId`, with per-scope MRU, scope-aware cwd resolution, and `enterProject` / `exitProject`. The active-session invariant (`active.projectId === activeProjectId`) keeps existing UI helpers untouched.
- Backend restarts / in-place replacements inherit the replaced session's `projectId`. Re-entering a project opens as a fresh visit — conversational chats detach from the tab strip (kept live, listed in chat history with a running spinner / done-dot) and an unused empty landing is reused rather than stacked. The global workspace keeps its restore-the-last-tab behavior.

### Project instructions & context pipeline

- `project.md` stays the single source of truth, with a marker-gated `AGENTS.md` mirror (`ensureAgentsMirror`): codex/opencode auto-discover it from the session cwd, claude gets the same composed instructions. A built-in project policy is layered into every project's instructions.
- New `projectContextMaterializer` + `contextCacheStore` + `manifestBuilder` capture a project's context once per session, single-flight per project, into a **shared off-vault cache** (`~/.obsidian-copilot/vaults/<vaultId>/context-cache/`, single source of truth `conversionsLocation.ts`) so each source is converted **once per vault** and reused across every project that references it. Disk access goes through a root-confined `contextCacheFs` that loads `node:fs` / `node:path` **lazily behind the desktop Agent boundary**; mobile-reachable readers reach it via a desktop-gated dynamic import (guarded by `scripts/mobile-load-smoke.cjs`).
- The first prompt inlines a `<project_context>` block with absolute paths; the composer shows a context status icon and queues sends while context materializes. Staleness is tracked by a signature over the source fields, so a re-entered project re-materializes only when its sources changed.
- Binary materialize candidates are enumerated in a stable, path-sorted order, so the cache and the manifest's honest "first N of M" listing stay deterministic across runs.

### Landing & project UI

- `AgentLandingStack` spine (hero + composer + shelf), project landing tabs (Project Chats / Context) aligned with the global landing, a collapsible project header above the tab strip, and project CRUD (anchored create popover, edit modal, overflow menu); shelf lists cap at 5 behind a View-all popover.

### Unified context management

- One shared context editor / Manage modal serves both CAG projects and Agent projects. The Agent (Links) variant adds a Links section + URL popover and is fully scoped to the agent pipeline: load state is surfaced as aggregate progress on the composer status icon, and the modal does **not** read the CAG per-file load status or `ProjectContextCache` (which the agent pipeline never writes).
- The Manage modal's **All Categories** overview lists every context type as its own card — **Web** and **YouTube** (each with their item count, using the canonical URL glyph) sit alongside Tags, Folders, and Files, and open straight to their filtered URL list.
- Scheme-anchored URL extraction is shared across every URL surface so prose tokens can't be stored as real URLs. Truncated content-conversion previews mark the cut with a labelled divider and a one-click "Copy full content" pill.

### Unified todo lists

- One backend-agnostic todo pipeline across claude/codex/opencode feeding the project info popover, with per-session todo-id tracking and plan-clear symmetry.

### Recent chats & composer

- Running spinner on backgrounded rows, live done-dot handoff with dual-id row matching, MRU-sorted project list, and memo-stable row callbacks (rename/cancel/save scoped to the editing row).
- Project-context loading moved off the floating card onto a composer status icon, with queue-and-hold sends while context materializes.
- **Fix:** clear the in-flight loading flag when the composer remounts on the landing→conversation flip — previously the Thinking spinner / stop button stuck forever after a session's first message and follow-up sends were parked in the queue (regression test included).

## Architecture

The change spans three concerns — the **backend agent layers**, the **frontend chat surface**, and the **off-vault context cache** that feeds both — tied together by a **project/session data model**. Diagrams render natively on GitHub; each is collapsed so the section stays scannable.

<details open>
<summary><b>1 · Backend layering</b> — <code>src/agentMode</code> import boundaries (eslint-plugin-boundaries)</summary>

Six element types with strict, lint-enforced imports (source of truth: `boundaries/elements` + `boundaries/dependencies` in `eslint.config.mjs`; mirrored in `src/agentMode/AGENTS.md`). `session/` is the backend-agnostic **contract layer**; `acp/` and `sdk/` are **siblings that never import each other** (ACP wire vs in-process SDK, both emitting the same `SessionEvent` stream); only `acp/` may touch `@agentclientprotocol/sdk`.

```mermaid
flowchart TB
    host["host app (src/**)"]
    mm["modelManagement<br/>self-contained module"]

    subgraph AM ["src/agentMode — internal deps (arrow = imports)"]
        direction TB
        barrel["index.ts · barrel<br/><i>the only entry; re-exports all of AM</i>"]
        ui["ui/"]
        registry["registry.ts"]
        backend["backends/&lt;id&gt;<br/>+ backends/shared"]
        skills["skills/"]
        acp["acp/<br/><i>only importer of @agentclientprotocol/sdk</i>"]
        sdk["sdk/"]
        session["session/ · contract layer<br/><i>everything bottoms out here</i>"]

        ui --> registry
        ui --> skills
        ui --> session
        registry --> backend
        backend --> acp
        backend --> sdk
        backend --> session
        backend --> skills
        skills --> registry
        acp --> session
        sdk --> session
    end

    host -->|"only via barrel"| barrel
    host --> mm
    backend --> mm

    classDef island fill:#fff4e6,stroke:#d4a72c;
    class mm island
```

> **There is a real dependency cycle** — `backend → skills → registry → backend`, all three are actual imports — which is why this graph can't collapse into a clean layered stack. The back-edge `skills → registry` comes from the `SkillsSettings` panel listing the available backends: a benign settings dependency, not deep coupling.

| from | allowed imports (`→ host` omitted — **every** module has it) |
| --- | --- |
| `session/` | — |
| `acp/` | session · _only module allowed to touch `@agentclientprotocol/sdk`_ |
| `sdk/` | session |
| `backends/<id>` | acp · sdk · session · skills · modelManagement · same-name backend · `backends/shared` |
| `registry.ts` | backend · session |
| `skills/` | registry · session |
| `ui/` | registry · skills · session |
| `index.ts` (barrel) | acp · sdk · backend · registry · ui · skills · session (re-export only) |
| `modelManagement` | — |
| `host (src/**)` | barrel · modelManagement |

Every module additionally may import `host` (shared types); those ~8 edges are dropped from the graph to keep it legible. `acp/` and `sdk/` never import each other — both emit the same `SessionEvent` stream into `session/`. A new backend is one folder under `backends/<id>/` exporting a `BackendDescriptor`; subprocess agents (codex/opencode) wrap `simpleBinaryBackendProcess`, in-process agents (claude) construct an `sdk/` driver directly. `registry.ts` is the single place that names them.

</details>

<details>
<summary><b>2 · Frontend architecture</b> — persistent shell + per-session draft store</summary>

`AgentHome` is a **persistent shell** (no `key`-remount on tab switch): the tab strip swaps `sessionId`/`backend` props, and per-session compose drafts live in a store owned by `AgentHome`, so switching tabs swaps the active draft instead of discarding unsent input. All project/scope state is **derived through `manager.subscribe()`**, never cached independently, so a backend restart can't strand it.

```mermaid
flowchart TD
    CV[CopilotAgentView] --> AMC["AgentModeChat<br/>preload gate · auto-spawn"]
    AMC -->|"manager.subscribe() → derived state"| AH["AgentHome<br/><b>persistent shell · no key, no remount</b>"]
    AH --> CIP[ChatInputProvider]

    CIP --> TS["AgentTabStrip<br/>per-scope tabs"]
    CIP --> ST[AgentModeStatus]
    CIP --> MSG["AgentChatMessages<br/><i>per-token memo boundary</i>"]
    CIP --> IN["AgentChatInput<br/><i>controlled by draft prop</i>"]
    CIP --> CTL["AgentChatControls<br/>new · save · history"]
    CIP --> LSx["landing — Projects · Recent Chats"]

    subgraph H["hooks (all owned by AgentHome)"]
        RS[useAgentChatRuntimeState]
        DR[useAgentInputDrafts]
        HC[useAgentHistoryControls]
    end

    RS -. messages / plan / permission / ask-user .-> MSG
    DR -. per-session draft / queue / loading .-> IN
    HC -. load / open / rename / delete .-> CTL
```

| hook | state it owns | feeds |
| --- | --- | --- |
| `useAgentChatRuntimeState(backend)` | messages · isStarting · plan/permission · ask-user | AgentChatMessages |
| `useAgentInputDrafts` | per-session: input · images · context · queue · loading | AgentChatInput |
| `useAgentHistoryControls` | load · open · rename · delete | AgentChatControls |

Solid edges are React parent/child; dashed edges are the hook → leaf data flow.

**Status rendering is a single source of truth.** Every agent surface (composer status popover, the Manage modal's Links panel, its File Context list) routes through `processingItemStatusView` (key → glyph → label), so status semantics never drift across panels. The legacy CAG per-file status is deliberately *not* folded in — it reads a different cache with different semantics.

</details>

<details>
<summary><b>3 · Cache design</b> — shared, off-vault, deduped per source identity</summary>

Each source is converted **once per vault** and shared across every project that references it. The cache lives **outside the vault** (not synced, not indexed as note content), under the per-vault namespace that already hosts the recent-chats index. All paths derive from one SSOT, `context/conversionsLocation.ts`.

```mermaid
flowchart TD
    root["~/.obsidian-copilot/vaults/&lt;vaultId&gt;/<br/>vaultId = md5(getBasePath()).slice(0,8)"]
    root --> idx["agent-chat-index.json — sibling, untouched by the cache"]
    root --> cc["context-cache/ — SSOT: conversionsLocation.ts"]
    cc --> rem["remotes/<br/>web-&lt;md5(url)&gt;.md · youtube-&lt;md5(url)&gt;.md<br/><b>shared by all projects</b>"]
    cc --> files["files/<br/>file-&lt;md5(vaultPath)&gt;.md<br/><b>shared by all projects</b>"]
    cc --> mk["markers/&lt;md5(projectId)&gt;/<br/>failed-&lt;type&gt;-&lt;md5(source)&gt;.json<br/><b>per-project negative cache</b>"]
```

- **Identity keys, not content/project.** Filenames hash source identity (`md5(url)` / `md5(vaultPath)`). Freshness is a `fingerprint` in the snapshot header: a **file** uses `mtime:size` (edit → overwrite in place, no orphans); a **remote** uses `type:url` (kept until the configured string changes — no canonicalization).
- **Root-confined `node:fs`.** `contextCacheFs` rejects `..`/absolute/root-escaping paths, writes atomically (temp + rename), and loads `node:fs`/`node:path` **lazily behind the desktop Agent boundary**. Mobile-reachable readers reach it through a **desktop-gated dynamic import**; `scripts/mobile-load-smoke.cjs` guards the boundary.
- **No automatic GC.** `Clear Copilot cache` wipes `context-cache/` (all three subdirs) while leaving the sibling index intact; stale failure markers self-clear when a source later succeeds.

**Single-flight dedup** — two projects cold-converting one URL converge to a single brevilabs call via a per-artifact lock keyed by the (identity-derived) snapshot filename:

```mermaid
sequenceDiagram
    participant A as Project A run
    participant B as Project B run
    participant L as per-artifact lock (key = snapshot filename)
    participant FS as contextCacheFs (off-vault)
    participant BL as brevilabs

    A->>L: acquire(web-md5(url).md)
    B->>L: acquire(web-md5(url).md) — waits
    A->>FS: readMeta → miss
    A->>BL: fetch + convert
    BL-->>A: text
    A->>FS: atomic write snapshot
    A-->>L: release
    L-->>B: granted
    B->>FS: readMeta → HIT (fingerprint matches)
    Note over B,FS: cheap-skip — no fetch, no overwrite
    B-->>L: release
```

</details>

<details>
<summary><b>4 · Project data model</b> — <code>project.md</code> SSOT + session scope</summary>

`project.md` is the single source of truth for a project's config and instructions; a **marker-gated `AGENTS.md` mirror** (`ensureAgentsMirror`) yields to a user-authored, unmarked `AGENTS.md`. `AgentSessionManager` keys sessions by an internal id but **binds each to an immutable `projectId`**; all scope behavior keys off that `projectId`, and the global workspace is one special scope (`GLOBAL_SCOPE`) on the same code path.

```mermaid
flowchart TB
    pm["project.md<br/><b>single source of truth</b> — config + instructions"]

    subgraph INSTR ["instructions fan out to 3 backends"]
        mirror["AGENTS.md mirror<br/>ensureAgentsMirror (marker-gated)"]
        profile["getProjectProfile<br/>→ claude composed instructions"]
        policy["built-in project policy"]
    end

    subgraph MGR ["AgentSessionManager — scoped by projectId"]
        direction TB
        map["Map&lt;internalId, AgentSession&gt;<br/>each bound to an immutable projectId"]
        mru["per-scope MRU · getSessionsForScope"]
        cwd["resolveScopeCwd<br/>project folder | vault root (GLOBAL_SCOPE)"]
        hist["history scope-keyed by frontmatter projectId"]
        map --> mru
        map --> cwd
        map --> hist
    end

    pm --> mirror
    pm --> profile
    pm --> policy
    pm -. defines scope .-> map
```

| concept | detail |
| --- | --- |
| invariant | `active.projectId === activeProjectId` (keeps existing UI helpers untouched) |
| AGENTS.md mirror | marker-gated; yields to a user-authored, unmarked `AGENTS.md`. codex/opencode auto-discover it from the session cwd |
| GLOBAL_SCOPE | the global workspace is one special scope on the same code path; history with an absent/blank `projectId` → GLOBAL_SCOPE |

</details>

<details>
<summary><b>5 · End-to-end</b> — context materialization → first prompt</summary>

Materialization runs **single-flight per project** and **never rejects** (any failure degrades to a best-effort partial so session start is never blocked). A `contextSignature` over the source fields drives reactivity: a re-entered project re-materializes only when its sources changed.

```mermaid
sequenceDiagram
    participant U as User
    participant M as AgentSessionManager
    participant CM as projectContextMaterializer (single-flight)
    participant CS as contextCacheStore + per-artifact lock
    participant MF as manifestBuilder
    participant S as session (backend)

    U->>M: enterProject / send first message
    M->>CM: materialize(contextSource) — never rejects
    Note over CM: contextSignature unchanged? → reuse warm cache
    CM->>CS: per-source convert (web / youtube / file)<br/>cheap-skip by fingerprint or failure marker
    CS-->>CM: snapshot absolute paths (+ markers on failure)
    CM->>MF: build manifest (type:source → abs path)
    MF-->>M: <project_context> block
    M->>S: inline block into first user prompt<br/>+ additionalDirectories (claude) / external_directory allow (opencode)
    Note over U,S: composer queues sends + shows status icon while materializing
```

The shared cache lives outside every project cwd, so the only pointer all three backends can reach is an **absolute path** in the manifest. claude additionally gets the cache root as an `additionalDirectories` entry; opencode (which blocks reads outside the vault) is granted an `external_directory` allow for the cache root; codex reads the whole disk.

</details>

<details>
<summary><b>6 · Project re-entry lifecycle</b> — why the landing/session fix commits exist</summary>

Re-entering a project opens as a **fresh visit**, not a replay of every prior tab. Several of this PR's commits harden this seam (stale-capture guard, refresh-on-system-prompt-edit, draft preservation, context preservation after first-turn fan-out).

```mermaid
flowchart TD
    enter([re-enter project]) --> conv["in-progress conversational chats<br/>detach from the tab strip<br/>→ kept live, listed in history with a running dot"]
    enter --> q{"an unused empty landing exists<br/>AND its captured context + systemPrompt<br/>signature still matches?"}
    q -->|yes| reuse["reuse that empty landing"]
    q -->|no / stale| fresh["open a fresh landing"]
```

The global workspace is the exception: it keeps its restore-the-last-tab behavior.

</details>

## Test plan

- [x] `npx jest src/agentMode src/context src/components/project src/components/modals/project` — 101 suites / 1412 tests pass
- [x] `eslint .` + `tsc --noEmit` + `prettier --check` clean across the whole project
- [x] Mobile boundary: cache consumers never statically import `node:fs` (guarded by `scripts/mobile-load-smoke.cjs`); the off-vault `contextCacheFs` loads node builtins lazily behind the desktop Agent boundary
- [ ] Manual: send first message from global landing and a project landing — Thinking spinner and stop button clear when the turn ends
- [ ] Manual: project create / enter / exit round-trip keeps the global shelf tab and MRU order
- [ ] Manual: Manage modal "All Categories" shows Web / YouTube cards that open the filtered URL list
- [ ] Manual: todo popover reflects backend todo updates across claude/codex/opencode

## Actual Effect

https://github.com/user-attachments/assets/48bc6297-f6f2-4d88-a6ea-c9da08d8dd64



https://github.com/user-attachments/assets/241f1f44-76bd-486f-ba60-1e3cae8cc36c

