### PR TITLE
fix(agent-mode): show attached images in the posted user message

### DIFF
--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -1,6 +1,11 @@
 import { AI_SENDER, USER_SENDER } from "@/constants";
 import type { TFile } from "obsidian";
-import { AgentSession, buildPromptBlocks, tryReadExitPlanModeCall } from "./AgentSession";
+import {
+  AgentSession,
+  buildPromptBlocks,
+  buildUserDisplayContent,
+  tryReadExitPlanModeCall,
+} from "./AgentSession";
 import { AuthRequiredError, MethodUnsupportedError } from "./errors";
 import type {
   AgentToolCallOutput,
@@ -318,6 +323,30 @@ describe("AgentSession.restoreLabel", () => {
   });
 });
 
+describe("buildUserDisplayContent", () => {
+  it("returns undefined when there is no prompt content", () => {
+    expect(buildUserDisplayContent()).toBeUndefined();
+    expect(buildUserDisplayContent([])).toBeUndefined();
+  });
+
+  it("returns undefined when prompt content has no images", () => {
+    expect(buildUserDisplayContent([{ type: "text", text: "hi" }])).toBeUndefined();
+  });
+
+  it("projects each image block into an image_url data-URL entry, ignoring non-images", () => {
+    expect(
+      buildUserDisplayContent([
+        { type: "text", text: "describe these" },
+        { type: "image", mimeType: "image/png", data: "AAA=" },
+        { type: "image", mimeType: "image/jpeg", data: "BBB=" },
+      ])
+    ).toEqual([
+      { type: "image_url", image_url: { url: "data:image/png;base64,AAA=" } },
+      { type: "image_url", image_url: { url: "data:image/jpeg;base64,BBB=" } },
+    ]);
+  });
+});
+
 describe("AgentSession.sendPrompt", () => {
   it("appends user + placeholder synchronously and resolves on stopReason", async () => {
     const mock = makeMockBackend();
@@ -361,7 +390,11 @@ describe("AgentSession.sendPrompt", () => {
     ]).turn;
     const messages = session.store.getDisplayMessages();
     expect(messages[0].message).toBe("describe");
-    expect(messages[0].content).toBeUndefined();
+    // The posted user bubble carries the image as a renderable data-URL entry,
+    // while the backend still receives the original base64 image block.
+    expect(messages[0].content).toEqual([
+      { type: "image_url", image_url: { url: "data:image/png;base64,aGVsbG8=" } },
+    ]);
     expect(mock.prompt).toHaveBeenCalledWith({
       sessionId: "acp-1",
       prompt: [
@@ -369,6 +402,18 @@ describe("AgentSession.sendPrompt", () => {
         { type: "image", mimeType: "image/png", data: "aGVsbG8=" },
       ],
     });
+  });
+
+  it("leaves the user message content unset when no images are attached", () => {
+    const mock = makeMockBackend();
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+    session.sendPrompt("just text");
+    expect(session.store.getDisplayMessages()[0].content).toBeUndefined();
   });
 
   it("rejects if a turn is already in flight", () => {

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -324,26 +324,29 @@ describe("AgentSession.restoreLabel", () => {
 });
 
 describe("buildUserDisplayContent", () => {
-  it("returns undefined when there is no prompt content", () => {
-    expect(buildUserDisplayContent()).toBeUndefined();
-    expect(buildUserDisplayContent([])).toBeUndefined();
+  it("returns undefined when there are no images", () => {
+    expect(buildUserDisplayContent("hi")).toBeUndefined();
+    expect(buildUserDisplayContent("hi", [])).toBeUndefined();
+    expect(buildUserDisplayContent("hi", [{ type: "text", text: "x" }])).toBeUndefined();
   });
 
-  it("returns undefined when prompt content has no images", () => {
-    expect(buildUserDisplayContent([{ type: "text", text: "hi" }])).toBeUndefined();
-  });
-
-  it("projects each image block into an image_url data-URL entry, ignoring non-images", () => {
+  it("puts the prompt text first, then an image_url entry per image", () => {
     expect(
-      buildUserDisplayContent([
-        { type: "text", text: "describe these" },
+      buildUserDisplayContent("describe these", [
         { type: "image", mimeType: "image/png", data: "AAA=" },
         { type: "image", mimeType: "image/jpeg", data: "BBB=" },
       ])
     ).toEqual([
+      { type: "text", text: "describe these" },
       { type: "image_url", image_url: { url: "data:image/png;base64,AAA=" } },
       { type: "image_url", image_url: { url: "data:image/jpeg;base64,BBB=" } },
     ]);
+  });
+
+  it("omits the text entry for an image-only message", () => {
+    expect(
+      buildUserDisplayContent("   ", [{ type: "image", mimeType: "image/png", data: "AAA=" }])
+    ).toEqual([{ type: "image_url", image_url: { url: "data:image/png;base64,AAA=" } }]);
   });
 });
 
@@ -390,9 +393,11 @@ describe("AgentSession.sendPrompt", () => {
     ]).turn;
     const messages = session.store.getDisplayMessages();
     expect(messages[0].message).toBe("describe");
-    // The posted user bubble carries the image as a renderable data-URL entry,
-    // while the backend still receives the original base64 image block.
+    // The posted user bubble carries the prompt text plus the image as a
+    // renderable data-URL entry, while the backend still receives the original
+    // base64 image block.
     expect(messages[0].content).toEqual([
+      { type: "text", text: "describe" },
       { type: "image_url", image_url: { url: "data:image/png;base64,aGVsbG8=" } },
     ]);
     expect(mock.prompt).toHaveBeenCalledWith({

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -750,6 +750,9 @@ export class AgentSession {
       timestamp: formatDateTime(new Date()),
       isVisible: true,
       context,
+      // Surface attached images in the posted bubble. The backend consumes the
+      // original `promptContent` image blocks; this is a display-only projection.
+      content: buildUserDisplayContent(promptContent),
     };
     const userMessageId = this.store.addMessage(userMessage);
 
@@ -1504,6 +1507,26 @@ function tryParseJsonObject(s: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
+}
+
+/**
+ * Project outgoing image prompt blocks into the display `content` shape the
+ * chat renderer understands: `ChatSingleMessage` renders `image_url` entries as
+ * `<img>`. The backend still consumes the original `PromptContent` image blocks
+ * (base64); this is a display-only projection so attached images show in the
+ * posted user bubble. Returns undefined when there are no images.
+ */
+export function buildUserDisplayContent(
+  promptContent?: PromptContent[]
+): Array<{ type: "image_url"; image_url: { url: string } }> | undefined {
+  const images = (promptContent ?? []).filter(
+    (p): p is Extract<PromptContent, { type: "image" }> => p.type === "image"
+  );
+  if (images.length === 0) return undefined;
+  return images.map((img) => ({
+    type: "image_url",
+    image_url: { url: `data:${img.mimeType};base64,${img.data}` },
+  }));
 }
 
 export function buildPromptBlocks(

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -752,7 +752,7 @@ export class AgentSession {
       context,
       // Surface attached images in the posted bubble. The backend consumes the
       // original `promptContent` image blocks; this is a display-only projection.
-      content: buildUserDisplayContent(promptContent),
+      content: buildUserDisplayContent(displayText, promptContent),
     };
     const userMessageId = this.store.addMessage(userMessage);
 
@@ -1509,24 +1509,40 @@ function tryParseJsonObject(s: string): Record<string, unknown> | null {
   }
 }
 
+type DisplayContentItem =
+  | { type: "text"; text: string }
+  | { type: "image_url"; image_url: { url: string } };
+
 /**
- * Project outgoing image prompt blocks into the display `content` shape the
- * chat renderer understands: `ChatSingleMessage` renders `image_url` entries as
- * `<img>`. The backend still consumes the original `PromptContent` image blocks
- * (base64); this is a display-only projection so attached images show in the
- * posted user bubble. Returns undefined when there are no images.
+ * Project a user prompt's text + outgoing image blocks into the display
+ * `content` shape the chat renderer understands: `ChatSingleMessage` renders a
+ * `content` array of `text` and `image_url` entries (text first, then images,
+ * mirroring the legacy chat composer). The backend still consumes the original
+ * `PromptContent` image blocks (base64); this is a display-only projection so
+ * attached images show in the posted user bubble.
+ *
+ * Returns undefined when there are no images — text-only messages render via the
+ * renderer's plain `message` fallback and don't need a `content` array. When
+ * images are present, the text entry is included only if there is prompt text,
+ * so an image-only message doesn't render an empty text line.
  */
 export function buildUserDisplayContent(
+  displayText: string,
   promptContent?: PromptContent[]
-): Array<{ type: "image_url"; image_url: { url: string } }> | undefined {
+): DisplayContentItem[] | undefined {
   const images = (promptContent ?? []).filter(
     (p): p is Extract<PromptContent, { type: "image" }> => p.type === "image"
   );
   if (images.length === 0) return undefined;
-  return images.map((img) => ({
-    type: "image_url",
-    image_url: { url: `data:${img.mimeType};base64,${img.data}` },
-  }));
+  const content: DisplayContentItem[] = [];
+  if (displayText.trim()) content.push({ type: "text", text: displayText });
+  for (const img of images) {
+    content.push({
+      type: "image_url",
+      image_url: { url: `data:${img.mimeType};base64,${img.data}` },
+    });
+  }
+  return content;
 }
 
 export function buildPromptBlocks(


### PR DESCRIPTION
## Summary

Attached images in Agent Mode were delivered to the model but never appeared in the posted user message bubble.

Closes logancyang/obsidian-copilot-preview#157

## Root cause

`AgentSession.sendPrompt` stored the user message without a `content` field and forwarded the image `promptContent` blocks only to the backend prompt. The renderer (`ChatSingleMessage`) shows images only from `content` entries shaped `{ type: "image_url", image_url: { url } }`, so with `content` undefined the bubble drew nothing. There was also a shape mismatch: the composer emits `{ type: "image", mimeType, data }` (base64) while the renderer expects `image_url`.

## Change

- New `buildUserDisplayContent(promptContent)` projects outgoing image blocks into the renderer's `image_url` shape (`data:<mimeType>;base64,<data>`).
- `sendPrompt` stores that projection as the user message's `content`. The backend `promptContent` path is untouched, so the model still receives the original base64 image blocks.
- Backend-agnostic: applies to codex, Claude Code, and opencode.

## Tests

- `buildUserDisplayContent` unit tests: no content / no images → undefined; non-image blocks ignored; multiple images projected to data-URL entries.
- `sendPrompt` integration: an image attachment now records `content` with an `image_url` data URL while still forwarding the base64 block to the backend; a text-only message records no `content`.
- All 1012 agent-mode tests pass; `tsc` and `eslint` clean.

## Notes / scope

- Markdown autosave serializes only message text (`AgentChatPersistenceManager`, `**sender**: message`), so saved notes are **not** bloated with base64 and persistence is unchanged.
- Consequence: a chat restored from saved markdown won't re-show images (base64 isn't persisted to the note). That's the deliberate tradeoff flagged in the issue's open questions; the reported bug (live posted message) is fully fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)