### PR TITLE
fix(agent-mode): restore user message text when a recent chat has image attachments

### DIFF
--- a/src/agentMode/sdk/claudeSessionTranscript.test.ts
+++ b/src/agentMode/sdk/claudeSessionTranscript.test.ts
@@ -52,6 +52,48 @@ describe("parseClaudeTranscript", () => {
     ]);
   });
 
+  it("keeps the text of a multimodal user prompt and drops its image blocks", () => {
+    const jsonl = [
+      line({
+        type: "user",
+        timestamp: TS,
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "what is in this picture?" },
+            { type: "image", source: { type: "base64", media_type: "image/png", data: "iVBOR" } },
+          ],
+        },
+      }),
+      line({
+        type: "assistant",
+        timestamp: TS,
+        message: { role: "assistant", content: [{ type: "text", text: "a cat" }] },
+      }),
+    ].join("\n");
+
+    expect(parseClaudeTranscript(jsonl).map((m) => [m.sender, m.message])).toEqual([
+      [USER_SENDER, "what is in this picture?"],
+      [AI_SENDER, "a cat"],
+    ]);
+  });
+
+  it("unwraps the <user-message> envelope on a multimodal prompt", () => {
+    const wrapped =
+      "<copilot-context>\nNotes:\n- a.md\n</copilot-context>\n\n<user-message>\ndescribe the image\n</user-message>";
+    const jsonl = line({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "text", text: wrapped },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "iVBOR" } },
+        ],
+      },
+    });
+    expect(parseClaudeTranscript(jsonl)[0].message).toBe("describe the image");
+  });
+
   it("unwraps the <user-message> envelope, dropping the context block", () => {
     const wrapped =
       "<copilot-context>\nNotes:\n- a.md\n</copilot-context>\n\n<user-message>\nsummarize a.md\n</user-message>";

--- a/src/agentMode/sdk/claudeSessionTranscript.ts
+++ b/src/agentMode/sdk/claudeSessionTranscript.ts
@@ -15,8 +15,11 @@ import type { AgentChatMessage } from "@/agentMode/session/types";
  *
  * Each line is one JSON record. We keep only genuine user prompts and assistant
  * prose, skipping everything else the CLI logs:
- *  - `type: "user"` with a **string** content → a typed prompt. (Array content
- *    on a user record is a `tool_result`, not user input — skipped.)
+ *  - `type: "user"` with a **string** content → a typed prompt.
+ *  - `type: "user"` with **array** content → either a multimodal prompt (text +
+ *    image blocks, e.g. an attached image) or a `tool_result`. We keep the text
+ *    blocks (images are dropped from the display) and skip the record only when
+ *    it carries a `tool_result` block, which is agent output rather than input.
  *  - `type: "assistant"` → concatenated `text` blocks (tool_use / thinking
  *    blocks dropped); skipped entirely when the turn was pure tool use.
  *  - `isMeta` / `isSidechain` records, summaries, attachments, queue ops,
@@ -43,16 +46,17 @@ export function parseClaudeTranscript(jsonlText: string): AgentChatMessage[] {
     if (entry.type === "user" && typeof content === "string") {
       sender = USER_SENDER;
       text = stripUserMessageWrapper(content).trim();
+    } else if (entry.type === "user" && Array.isArray(content)) {
+      // A tool_result is agent output the CLI logs as a user record — skip it.
+      // Anything else (text + image blocks) is a genuine multimodal prompt;
+      // keep its text and drop the images from the display.
+      if (!content.some((b) => b?.type === "tool_result")) {
+        sender = USER_SENDER;
+        text = stripUserMessageWrapper(joinTextBlocks(content)).trim();
+      }
     } else if (entry.type === "assistant" && Array.isArray(content)) {
       sender = AI_SENDER;
-      text = content
-        .filter(
-          (b): b is { type: "text"; text: string } =>
-            b?.type === "text" && typeof b.text === "string"
-        )
-        .map((b) => b.text)
-        .join("\n\n")
-        .trim();
+      text = joinTextBlocks(content);
     }
     if (!sender || !text) continue;
 
@@ -74,8 +78,24 @@ interface ClaudeTranscriptEntry {
   timestamp?: unknown;
   message?: {
     role?: string;
-    content?: string | Array<{ type?: string; text?: string }>;
+    content?: string | ContentBlock[];
   };
+}
+
+interface ContentBlock {
+  type?: string;
+  text?: string;
+}
+
+/** Concatenate the `text` blocks of a content array, ignoring tool_use, image, etc. */
+function joinTextBlocks(content: ContentBlock[]): string {
+  return content
+    .filter(
+      (b): b is { type: "text"; text: string } => b?.type === "text" && typeof b.text === "string"
+    )
+    .map((b) => b.text)
+    .join("\n\n")
+    .trim();
 }
 
 /**


### PR DESCRIPTION
## Problem

After #2609, reopening a recent **Claude** Agent Mode chat that contains a user message with an attached image dropped the **entire user turn** from the restored view — only the AI response loaded, leaving an orphaned reply.

## Root cause

A native (autosave-off) Claude chat rebuilds its visible transcript from the on-disk CLI `.jsonl` via `parseClaudeTranscript` (`src/agentMode/sdk/claudeSessionTranscript.ts`). That parser only accepted user records whose `content` was a **string**, treating *all* array content as a `tool_result` and skipping it.

A user message with an attached image is logged by the CLI with **array** content (a `text` block + `image` block), so the whole record — including the typed text — was silently skipped.

## Fix

User records with array content are now kept unless they carry a `tool_result` block (genuine agent output). For a multimodal prompt we restore the `text` blocks and omit the images from the display, matching the markdown loader's "sender + text only" behavior. Images are intentionally not rebuilt into the restored bubble (the CLI transcript stores them as base64; re-inflating bloats the view and the live-session display path is unaffected).

## Tests

- New: multimodal user prompt (text + image) restores its text and drops the image.
- New: `<user-message>` envelope unwrapping still works on a multimodal prompt.
- Existing `tool_result`-is-skipped and string-prompt cases unchanged and still pass.

`npm run format && npm run lint` clean; `claudeSessionTranscript` suite green (6/6).

Fixes the regression reported against logancyang/obsidian-copilot-preview after #2609.

🤖 Generated with [Claude Code](https://claude.com/claude-code)