### PR TITLE
fix(agent-mode): bundle the frame log as .txt so GitHub accepts it

### DIFF
--- a/src/utils/issueReport.test.ts
+++ b/src/utils/issueReport.test.ts
@@ -51,7 +51,8 @@ describe("assembleReportBundle", () => {
     expect(result.files).toEqual([
       "report.md",
       "screenshot.png",
-      "acp-frames.ndjson",
+      // Bundled with a `.txt` suffix so GitHub accepts the upload (it rejects `.ndjson`).
+      "acp-frames.ndjson.txt",
       "opencode.log",
     ]);
 
@@ -62,7 +63,7 @@ describe("assembleReportBundle", () => {
     expect(copies).toEqual([
       {
         src: "/tmp/acp-frames.ndjson",
-        dest: "/tmp/reports/report-20260615-101500/acp-frames.ndjson",
+        dest: "/tmp/reports/report-20260615-101500/acp-frames.ndjson.txt",
       },
       {
         src: "/tmp/opencode/log/session.log",
@@ -100,7 +101,7 @@ describe("assembleReportBundle", () => {
     const result = await assembleReportBundle(baseInput, runtime);
 
     expect(result.files).toContain("report.md");
-    expect(result.files).not.toContain("acp-frames.ndjson");
+    expect(result.files).not.toContain("acp-frames.ndjson.txt");
     expect(result.files).toContain("opencode.log");
   });
 

--- a/src/utils/issueReport.ts
+++ b/src/utils/issueReport.ts
@@ -16,7 +16,10 @@
  */
 const REPORT_REPO = "logancyang/obsidian-copilot";
 const SCREENSHOT_NAME = "screenshot.png";
-const FRAME_LOG_NAME = "acp-frames.ndjson";
+// GitHub's issue attachment allowlist rejects `.ndjson`, so the bundled frame
+// log gets a trailing `.txt` (an allowed type) while keeping `.ndjson` in the
+// name as a format hint. Content is unchanged: one JSON object per line.
+const FRAME_LOG_NAME = "acp-frames.ndjson.txt";
 const OPENCODE_LOG_NAME = "opencode.log";
 const REPORT_NOTE_NAME = "report.md";
 


### PR DESCRIPTION
## Problem

The Agent Mode "Report an issue" flow (#2614) saves the prepped files loose for the user to drag into a GitHub issue. But GitHub's attachment allowlist rejects `.ndjson`, so the diagnostic frame log (`acp-frames.ndjson`) — the most useful artifact — could not actually be attached.

Fixes https://github.com/logancyang/obsidian-copilot-preview/issues/155.

## Change

Save the bundled frame-log copy with a GitHub-allowed extension instead of zipping: `acp-frames.ndjson.txt` (`.txt` is on GitHub's allowlist; the `.ndjson` stays in the name as a format hint). The on-disk content is unchanged (one JSON object per line), and the source log keeps its real `.ndjson` name.

This is a one-line behavior change. It's simpler than packaging a zip, and it keeps the privacy story honest: the loose files in the opened folder are exactly what the user drags in, so reviewing/editing them before attaching works as the modal warning already states (no separate pre-built archive that could ship un-redacted content).

## Testing

- `npm run test -- src/utils/issueReport.test.ts` — passes; the bundle/copy assertions now expect `acp-frames.ndjson.txt`.
- `npx tsc --noEmit`, Prettier, and ESLint clean on changed files.
- Manual: open Agent Mode → Report an issue → submit; drag `acp-frames.ndjson.txt` into the prefilled issue and confirm GitHub accepts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)