### PR TITLE
feat(models): flag non-vision models, guard image sends

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -22,3 +22,15 @@ if (typeof Node !== "undefined" && !Object.prototype.hasOwnProperty.call(Node.pr
     configurable: true,
   });
 }
+
+// Obsidian exposes `activeDocument` / `activeWindow` globals pointing at the
+// focused popout's document/window. Under jsdom there's only one document, so
+// alias them onto `window` (the jsdom global object) — plugin code that portals
+// into `activeDocument.body` (e.g. the Radix tooltip) would otherwise throw
+// `activeDocument is not defined`.
+if (typeof window.activeDocument === "undefined") {
+  window.activeDocument = window.document;
+}
+if (typeof window.activeWindow === "undefined") {
+  window.activeWindow = window;
+}

--- a/src/agentMode/backends/opencode/opencodeModelResolve.ts
+++ b/src/agentMode/backends/opencode/opencodeModelResolve.ts
@@ -1,6 +1,6 @@
 import type { CopilotSettings } from "@/settings/model";
 import type { ConfiguredModel, Provider } from "@/modelManagement";
-import { providerRequiresApiKey } from "@/modelManagement";
+import { capabilitiesFromConfiguredInfo, providerRequiresApiKey } from "@/modelManagement";
 import type { EnabledModelCredentialState, EnabledModelEntry } from "@/agentMode/session/types";
 
 export interface OpencodeProviderMapping {
@@ -124,6 +124,7 @@ export function opencodeEnabledModelEntries(
       description: configuredModel.info.description,
       credentialState: credentialStateFor(provider, mapping.native),
       isFree: isOpencodeZenWireId(baseModelId),
+      capabilities: capabilitiesFromConfiguredInfo(configuredModel.info),
     });
   }
   return out.length === 0 ? EMPTY_ENABLED_ENTRIES : out;

--- a/src/agentMode/backends/shared/agentEnabledModels.test.ts
+++ b/src/agentMode/backends/shared/agentEnabledModels.test.ts
@@ -1,6 +1,7 @@
 import { agentOriginEnabledModelEntries } from "./agentEnabledModels";
 import type { CopilotSettings } from "@/settings/model";
 import type { ConfiguredModel } from "@/modelManagement";
+import { ModelCapability } from "@/constants";
 
 /** Bare descriptor-style decode (claude): the wire id IS the baseModelId. */
 const bareDecode = (wireId: string): { selection: { baseModelId: string } } => ({
@@ -72,6 +73,27 @@ describe("agentOriginEnabledModelEntries", () => {
     const settings = settingsWith("claude", ["cm1", "ghost"], [model("cm1", "claude-sonnet-4-5")]);
     const entries = agentOriginEnabledModelEntries(settings, "claude", bareDecode);
     expect(entries.map((e) => e.baseModelId)).toEqual(["claude-sonnet-4-5"]);
+  });
+
+  it("derives capabilities from info.modalities, and leaves them undefined when unknown", () => {
+    const visionModel: ConfiguredModel = {
+      configuredModelId: "cm1",
+      providerId: "p1",
+      info: {
+        id: "claude-sonnet-4-5",
+        displayName: "claude-sonnet-4-5",
+        modalities: { input: ["text", "image"] },
+      },
+      configuredAt: 0,
+    };
+    const settings = settingsWith("claude", ["cm1", "cm2"], [visionModel, model("cm2", "legacy")]);
+    const entries = agentOriginEnabledModelEntries(settings, "claude", bareDecode);
+    const vision = entries.find((e) => e.baseModelId === "claude-sonnet-4-5");
+    const unknown = entries.find((e) => e.baseModelId === "legacy");
+    expect(vision?.capabilities).toContain(ModelCapability.VISION);
+    // `model()` builds info without `modalities` → "unknown", so the picker can
+    // fall back to the catalog rather than asserting no vision.
+    expect(unknown?.capabilities).toBeUndefined();
   });
 
   it("only reads the requested agentType's enabledModels", () => {

--- a/src/agentMode/backends/shared/agentEnabledModels.ts
+++ b/src/agentMode/backends/shared/agentEnabledModels.ts
@@ -1,5 +1,5 @@
 import type { CopilotSettings } from "@/settings/model";
-import type { ConfiguredModel } from "@/modelManagement";
+import { type ConfiguredModel, capabilitiesFromConfiguredInfo } from "@/modelManagement";
 import type { EnabledModelEntry } from "@/agentMode/session/types";
 
 /** See AGENTS.md → "Referential stability". */
@@ -41,6 +41,7 @@ export function agentOriginEnabledModelEntries(
       name: configuredModel.info.displayName || configuredModel.info.id,
       description: configuredModel.info.description,
       credentialState: "ok",
+      capabilities: capabilitiesFromConfiguredInfo(configuredModel.info),
     });
   }
 

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -1,4 +1,5 @@
 import type React from "react";
+import type { ModelCapability } from "@/constants";
 import type { FormattedDateTime, MessageContext } from "@/types/message";
 // `import type` keeps the cycle with `fanoutTypes` compile-time only.
 import type { FanoutTurn } from "@/agentMode/session/fanout/fanoutTypes";
@@ -140,6 +141,14 @@ export interface EnabledModelEntry {
   name: string;
   description?: string;
   credentialState: EnabledModelCredentialState;
+  /**
+   * Capabilities derived from the model's persisted `ConfiguredModel.info`
+   * (the modality snapshot taken at setup) — the reliable source the picker
+   * prefers over a live catalog lookup. `undefined` means "unknown" (the
+   * stored info carried no modality data), letting the picker fall back to the
+   * catalog rather than asserting a model has no vision.
+   */
+  capabilities?: ModelCapability[];
   /**
    * `true` for an opencode Zen model (opencode's self-hosted free tier). The
    * opencode backend computes this; the UI just renders a privacy warning, so

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -36,6 +36,8 @@ import {
   type SelectedTextContext,
   type WebTabContext,
 } from "@/types/message";
+import { getModelKeyFromModel } from "@/settings/model";
+import { modelSupportsVision } from "@/utils";
 import { arrayBufferToBase64 } from "@/utils/base64";
 import { mergeWebTabContexts } from "@/utils/urlNormalization";
 import { Clock, Sparkles, X } from "lucide-react";
@@ -311,6 +313,25 @@ export const AgentChatInput = memo(function AgentChatInput({
         shouldIncludeActiveWebTab
       );
 
+      // Hard-block sending images to a model that is KNOWN to lack vision. We
+      // only block when the active entry's capabilities are populated (an empty
+      // array still means "known"); undefined means "unknown" and must not
+      // block. An undefined `modelPickerOverride` (model switching disabled) can't
+      // resolve an active entry, so it's also treated as unknown. Inputs are left
+      // intact (guard precedes resetCompose) so the user can switch models.
+      if (selectedImages.length > 0) {
+        const activeEntry = modelPickerOverride?.models.find(
+          (m) => getModelKeyFromModel(m) === modelPickerOverride.value
+        );
+        if (Array.isArray(activeEntry?.capabilities) && !modelSupportsVision(activeEntry)) {
+          const modelLabel = activeEntry.displayName || activeEntry.name;
+          new Notice(
+            `${modelLabel} doesn't support images. Switch to a vision-capable model to send images.`
+          );
+          return;
+        }
+      }
+
       const content: PromptContent[] = [];
 
       // Convert attached images to base64 image content blocks.
@@ -368,6 +389,7 @@ export const AgentChatInput = memo(function AgentChatInput({
       selectedTextContexts,
       loading,
       isStarting,
+      modelPickerOverride,
       resetCompose,
       runSend,
       setQueuedMessages,

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -170,7 +170,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   // it's unreachable while the tab is disabled.
   const handleProjectComingSoon = useCallback(() => {}, []);
 
-  const modelPickerOverride = useAgentModelPicker(manager);
+  const modelPickerOverride = useAgentModelPicker(manager, plugin.modelManagement.catalogService);
   const modePickerOverride = useAgentModePicker(manager);
 
   const handleCycleMode = useCallback(() => {

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -170,7 +170,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   // it's unreachable while the tab is disabled.
   const handleProjectComingSoon = useCallback(() => {}, []);
 
-  const modelPickerOverride = useAgentModelPicker(manager, plugin.modelManagement.catalogService);
+  const modelPickerOverride = useAgentModelPicker(manager);
   const modePickerOverride = useAgentModePicker(manager);
 
   const handleCycleMode = useCallback(() => {

--- a/src/agentMode/ui/ModelEnableList.tsx
+++ b/src/agentMode/ui/ModelEnableList.tsx
@@ -1,7 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FreeModelWarningIcon } from "@/components/ui/FreeModelWarningIcon";
-import { ModelCapabilityIcons } from "@/components/ui/model-display";
+import { ModelCapabilityIcons, hasCapabilityIcons } from "@/components/ui/model-display";
 import { SearchBar } from "@/components/ui/SearchBar";
 import { SettingSwitch } from "@/components/ui/setting-switch";
 import type { ModelCapability } from "@/constants";
@@ -104,7 +104,7 @@ export const ModelEnableList: React.FC<ModelEnableListProps> = ({
             <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1">
               <span className="tw-truncate">{row.label}</span>
               {row.isFree && <FreeModelWarningIcon />}
-              {row.capabilities && row.capabilities.length > 0 && (
+              {hasCapabilityIcons(row.capabilities) && (
                 <span className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
                   <ModelCapabilityIcons capabilities={row.capabilities} iconSize={14} />
                 </span>

--- a/src/agentMode/ui/ModelEnableList.tsx
+++ b/src/agentMode/ui/ModelEnableList.tsx
@@ -1,8 +1,10 @@
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FreeModelWarningIcon } from "@/components/ui/FreeModelWarningIcon";
+import { ModelCapabilityIcons } from "@/components/ui/model-display";
 import { SearchBar } from "@/components/ui/SearchBar";
 import { SettingSwitch } from "@/components/ui/setting-switch";
+import type { ModelCapability } from "@/constants";
 import { cn } from "@/lib/utils";
 import { ChevronRight } from "lucide-react";
 import React from "react";
@@ -19,6 +21,8 @@ export interface ModelEnableRow {
   wireId?: string;
   /** Whether the model is currently enabled. */
   enabled: boolean;
+  /** Modality icons (vision/websearch) shown beside the label; reasoning is not rendered. */
+  capabilities?: ModelCapability[];
   /**
    * `true` for a free model (zero catalog cost) routed through a third party.
    * Renders a privacy-warning icon + tooltip beside the label, since such
@@ -100,6 +104,11 @@ export const ModelEnableList: React.FC<ModelEnableListProps> = ({
             <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1">
               <span className="tw-truncate">{row.label}</span>
               {row.isFree && <FreeModelWarningIcon />}
+              {row.capabilities && row.capabilities.length > 0 && (
+                <span className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
+                  <ModelCapabilityIcons capabilities={row.capabilities} iconSize={14} />
+                </span>
+              )}
             </div>
             {row.description && (
               <div className="tw-truncate tw-text-xs tw-text-muted">{row.description}</div>

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -4,11 +4,8 @@ import {
   buildEffortSibling,
   buildModelOnChange,
   buildPickerEntries,
-  capabilitiesFromModelInfo,
   resolveActiveDisplayState,
   synthesizeAgentEntry,
-  type CatalogLookup,
-  type CatalogModelInfo,
 } from "./agentModelPickerHelpers";
 import { ModelCapability } from "@/constants";
 import { getModelKeyFromModel } from "@/settings/model";
@@ -193,7 +190,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("gpt-5", [codexEntry]),
       activeCurrentEntry: codexEntry,
     };
-    const { entries } = buildPickerEntries(manager, [codex, claude], ctx, emptySettings, null);
+    const { entries } = buildPickerEntries(manager, [codex, claude], ctx, emptySettings);
     const ids = entries.map((e) => e._backendId);
     expect(ids).toEqual(["codex"]);
   });
@@ -218,7 +215,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("ghost-model", [stranded]),
       activeCurrentEntry: stranded,
     };
-    const { entries, valueKey } = buildPickerEntries(manager, [codex], ctx, emptySettings, null);
+    const { entries, valueKey } = buildPickerEntries(manager, [codex], ctx, emptySettings);
     expect(entries[0].name).toBe("ghost-model");
     expect(entries[0]._backendId).toBe("codex");
     expect(valueKey).toBe("codex:ghost-model|agent");
@@ -241,7 +238,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("gpt-5", [entry]),
       activeCurrentEntry: entry,
     };
-    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings, null);
+    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings);
     expect(entries).toHaveLength(1);
     expect(entries[0].name).toBe("gpt-5");
   });
@@ -278,7 +275,7 @@ describe("buildPickerEntries", () => {
       activeModelState: null,
       activeCurrentEntry: undefined,
     };
-    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings, null);
+    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings);
     expect(entries.map((e) => e.name)).toEqual(["anthropic/claude-sonnet-4-6"]);
   });
 
@@ -305,7 +302,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("kept-model", [kept, dropped]),
       activeCurrentEntry: kept,
     };
-    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings, null);
+    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings);
     expect(entries.map((e) => e.name)).toEqual(["kept-model"]);
   });
 
@@ -337,7 +334,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("gpt-5", [entry]),
       activeCurrentEntry: entry,
     };
-    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings, null);
+    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings);
     expect(entries[0]._subtitle).toBe("Frontier model for complex coding");
   });
 
@@ -365,7 +362,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("ghost", [stranded]),
       activeCurrentEntry: stranded,
     };
-    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings, null);
+    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings);
     expect(entries[0]._subtitle).toBe("Opus 4.7 with 1M context");
   });
 
@@ -393,7 +390,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("anthropic/claude-haiku", [sticky]),
       activeCurrentEntry: sticky,
     };
-    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings, null);
+    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings);
     expect(entries.map((e) => e.name)).toEqual(["anthropic/claude-haiku"]);
   });
 });
@@ -420,7 +417,6 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
       backendModels: [makeModelEntry("openrouter/c", "Reported C")],
       keepBaseModelId: null,
       settings: emptySettings,
-      catalog: null,
     });
     const byId = Object.fromEntries(entries.map((e) => [e.name, e]));
     expect(byId["openrouter/a"]._disabledReason).toBe("Add API key");
@@ -453,7 +449,6 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
       ],
       keepBaseModelId: null,
       settings: emptySettings,
-      catalog: null,
     });
     const byId = Object.fromEntries(entries.map((e) => [e.name, e]));
     expect(byId["opencode/big-pickle"]._isFree).toBe(true);
@@ -475,7 +470,6 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
       backendModels: [makeModelEntry("opus-4-5", "Opus 4.5")],
       keepBaseModelId: null,
       settings: emptySettings,
-      catalog: null,
     });
     const byId = Object.fromEntries(entries.map((e) => [e.name, e]));
     expect(byId["opus-4-5"]._disabledReason).toBeUndefined();
@@ -491,7 +485,6 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
         backendModels: [makeModelEntry("openrouter/a"), makeModelEntry("sticky")],
         keepBaseModelId: "sticky",
         settings: emptySettings,
-        catalog: null,
       }
     );
     const names = entries.map((e) => e.name);
@@ -504,7 +497,7 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
     appendBackendSection(
       entries,
       opencodeWithEntries([{ baseModelId: "openrouter/a", name: "A", credentialState: "ok" }]),
-      { backendModels: null, keepBaseModelId: null, settings: emptySettings, catalog: null }
+      { backendModels: null, keepBaseModelId: null, settings: emptySettings }
     );
     // No flags before the catalog loads — buildPickerEntries shows "Loading…".
     expect(entries).toHaveLength(0);
@@ -729,39 +722,9 @@ describe("buildEffortOptionsByModelKey", () => {
   });
 });
 
-// ---- capability enrichment ---------------------------------------------
+// ---- capability propagation --------------------------------------------
 
-describe("capabilitiesFromModelInfo", () => {
-  function info(partial: CatalogModelInfo): CatalogModelInfo {
-    return { ...partial };
-  }
-
-  it("maps image input to VISION and reasoning to REASONING", () => {
-    expect(
-      capabilitiesFromModelInfo(info({ modalities: { input: ["text", "image"] }, reasoning: true }))
-    ).toEqual([ModelCapability.VISION, ModelCapability.REASONING]);
-  });
-
-  it("returns an empty array for a known model with neither capability", () => {
-    expect(capabilitiesFromModelInfo(info({ modalities: { input: ["text"] } }))).toEqual([]);
-  });
-
-  it("omits VISION when modalities are absent", () => {
-    expect(capabilitiesFromModelInfo(info({ reasoning: true }))).toEqual([
-      ModelCapability.REASONING,
-    ]);
-  });
-});
-
-describe("buildPickerEntries — catalog capability enrichment", () => {
-  function makeCatalog(
-    providerId: string,
-    models: Record<string, CatalogModelInfo>
-  ): CatalogLookup {
-    const provider = { models };
-    return { getProvider: (id) => (id === providerId ? provider : undefined) };
-  }
-
+describe("buildPickerEntries — persisted capability propagation", () => {
   function reported(baseModelId: string, provider: string | null): ModelEntry {
     return { baseModelId, name: baseModelId, provider, effortOptions: [] };
   }
@@ -778,11 +741,16 @@ describe("buildPickerEntries — catalog capability enrichment", () => {
     };
   }
 
-  it("sets capabilities on a catalog hit (bare base id, provider == catalog id)", () => {
+  it("surfaces an enabled model's persisted capabilities on its picker entry", () => {
     const claude = {
       ...makeDescriptor("claude"),
       getEnabledModelEntries: () => [
-        { baseModelId: "claude-sonnet-4-5", name: "Sonnet", credentialState: "ok" as const },
+        {
+          baseModelId: "claude-sonnet-4-5",
+          name: "Sonnet",
+          credentialState: "ok" as const,
+          capabilities: [ModelCapability.VISION, ModelCapability.REASONING],
+        },
       ],
     } as unknown as BackendDescriptor;
     const manager = makeManager({
@@ -793,56 +761,12 @@ describe("buildPickerEntries — catalog capability enrichment", () => {
         },
       },
     });
-    const catalog = makeCatalog("anthropic", {
-      "claude-sonnet-4-5": { modalities: { input: ["text", "image"] }, reasoning: true },
-    });
-    const { entries } = buildPickerEntries(
-      manager,
-      [claude],
-      ctxFor("claude"),
-      emptySettings,
-      catalog
-    );
+    const { entries } = buildPickerEntries(manager, [claude], ctxFor("claude"), emptySettings);
     const entry = entries.find((e) => e.name === "claude-sonnet-4-5");
     expect(entry?.capabilities).toEqual([ModelCapability.VISION, ModelCapability.REASONING]);
   });
 
-  it("strips a leading provider segment from a suffix-style base id before lookup", () => {
-    const opencode = {
-      ...makeDescriptor("opencode"),
-      getEnabledModelEntries: () => [
-        {
-          baseModelId: "anthropic/claude-sonnet-4-5",
-          name: "Sonnet",
-          credentialState: "ok" as const,
-        },
-      ],
-    } as unknown as BackendDescriptor;
-    const manager = makeManager({
-      cachedStateById: {
-        opencode: {
-          model: makeModelState("anthropic/claude-sonnet-4-5", [
-            reported("anthropic/claude-sonnet-4-5", "anthropic"),
-          ]),
-          mode: null,
-        },
-      },
-    });
-    const catalog = makeCatalog("anthropic", {
-      "claude-sonnet-4-5": { modalities: { input: ["text", "image"] } },
-    });
-    const { entries } = buildPickerEntries(
-      manager,
-      [opencode],
-      ctxFor("opencode"),
-      emptySettings,
-      catalog
-    );
-    const entry = entries.find((e) => e.name === "anthropic/claude-sonnet-4-5");
-    expect(entry?.capabilities).toEqual([ModelCapability.VISION]);
-  });
-
-  it("leaves capabilities undefined on a catalog miss (provider not in catalog)", () => {
+  it("leaves capabilities undefined when the enabled entry carries none", () => {
     const claude = {
       ...makeDescriptor("claude"),
       getEnabledModelEntries: () => [
@@ -857,67 +781,7 @@ describe("buildPickerEntries — catalog capability enrichment", () => {
         },
       },
     });
-    // Catalog only knows "openai" — the "anthropic" lookup misses.
-    const catalog = makeCatalog("openai", { "gpt-5": {} });
-    const { entries } = buildPickerEntries(
-      manager,
-      [claude],
-      ctxFor("claude"),
-      emptySettings,
-      catalog
-    );
-    const entry = entries.find((e) => e.name === "claude-sonnet-4-5");
-    expect(entry?.capabilities).toBeUndefined();
-  });
-
-  it("leaves capabilities undefined when the model has no provider attribution", () => {
-    const codex = {
-      ...makeDescriptor("codex"),
-      getEnabledModelEntries: () => [
-        { baseModelId: "gpt-5", name: "GPT-5", credentialState: "ok" as const },
-      ],
-    } as unknown as BackendDescriptor;
-    const manager = makeManager({
-      cachedStateById: {
-        codex: { model: makeModelState("gpt-5", [reported("gpt-5", null)]), mode: null },
-      },
-    });
-    const catalog = makeCatalog("openai", {
-      "gpt-5": { modalities: { input: ["text", "image"] } },
-    });
-    const { entries } = buildPickerEntries(
-      manager,
-      [codex],
-      ctxFor("codex"),
-      emptySettings,
-      catalog
-    );
-    const entry = entries.find((e) => e.name === "gpt-5");
-    expect(entry?.capabilities).toBeUndefined();
-  });
-
-  it("leaves capabilities undefined when no catalog is provided", () => {
-    const claude = {
-      ...makeDescriptor("claude"),
-      getEnabledModelEntries: () => [
-        { baseModelId: "claude-sonnet-4-5", name: "Sonnet", credentialState: "ok" as const },
-      ],
-    } as unknown as BackendDescriptor;
-    const manager = makeManager({
-      cachedStateById: {
-        claude: {
-          model: makeModelState("claude-sonnet-4-5", [reported("claude-sonnet-4-5", "anthropic")]),
-          mode: null,
-        },
-      },
-    });
-    const { entries } = buildPickerEntries(
-      manager,
-      [claude],
-      ctxFor("claude"),
-      emptySettings,
-      null
-    );
+    const { entries } = buildPickerEntries(manager, [claude], ctxFor("claude"), emptySettings);
     const entry = entries.find((e) => e.name === "claude-sonnet-4-5");
     expect(entry?.capabilities).toBeUndefined();
   });

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -4,9 +4,13 @@ import {
   buildEffortSibling,
   buildModelOnChange,
   buildPickerEntries,
+  capabilitiesFromModelInfo,
   resolveActiveDisplayState,
   synthesizeAgentEntry,
+  type CatalogLookup,
+  type CatalogModelInfo,
 } from "./agentModelPickerHelpers";
+import { ModelCapability } from "@/constants";
 import { getModelKeyFromModel } from "@/settings/model";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import type {
@@ -189,7 +193,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("gpt-5", [codexEntry]),
       activeCurrentEntry: codexEntry,
     };
-    const { entries } = buildPickerEntries(manager, [codex, claude], ctx, emptySettings);
+    const { entries } = buildPickerEntries(manager, [codex, claude], ctx, emptySettings, null);
     const ids = entries.map((e) => e._backendId);
     expect(ids).toEqual(["codex"]);
   });
@@ -214,7 +218,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("ghost-model", [stranded]),
       activeCurrentEntry: stranded,
     };
-    const { entries, valueKey } = buildPickerEntries(manager, [codex], ctx, emptySettings);
+    const { entries, valueKey } = buildPickerEntries(manager, [codex], ctx, emptySettings, null);
     expect(entries[0].name).toBe("ghost-model");
     expect(entries[0]._backendId).toBe("codex");
     expect(valueKey).toBe("codex:ghost-model|agent");
@@ -237,7 +241,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("gpt-5", [entry]),
       activeCurrentEntry: entry,
     };
-    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings);
+    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings, null);
     expect(entries).toHaveLength(1);
     expect(entries[0].name).toBe("gpt-5");
   });
@@ -274,7 +278,7 @@ describe("buildPickerEntries", () => {
       activeModelState: null,
       activeCurrentEntry: undefined,
     };
-    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings);
+    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings, null);
     expect(entries.map((e) => e.name)).toEqual(["anthropic/claude-sonnet-4-6"]);
   });
 
@@ -301,7 +305,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("kept-model", [kept, dropped]),
       activeCurrentEntry: kept,
     };
-    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings);
+    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings, null);
     expect(entries.map((e) => e.name)).toEqual(["kept-model"]);
   });
 
@@ -333,7 +337,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("gpt-5", [entry]),
       activeCurrentEntry: entry,
     };
-    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings);
+    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings, null);
     expect(entries[0]._subtitle).toBe("Frontier model for complex coding");
   });
 
@@ -361,7 +365,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("ghost", [stranded]),
       activeCurrentEntry: stranded,
     };
-    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings);
+    const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings, null);
     expect(entries[0]._subtitle).toBe("Opus 4.7 with 1M context");
   });
 
@@ -389,7 +393,7 @@ describe("buildPickerEntries", () => {
       activeModelState: makeModelState("anthropic/claude-haiku", [sticky]),
       activeCurrentEntry: sticky,
     };
-    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings);
+    const { entries } = buildPickerEntries(manager, [opencode], ctx, emptySettings, null);
     expect(entries.map((e) => e.name)).toEqual(["anthropic/claude-haiku"]);
   });
 });
@@ -416,6 +420,7 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
       backendModels: [makeModelEntry("openrouter/c", "Reported C")],
       keepBaseModelId: null,
       settings: emptySettings,
+      catalog: null,
     });
     const byId = Object.fromEntries(entries.map((e) => [e.name, e]));
     expect(byId["openrouter/a"]._disabledReason).toBe("Add API key");
@@ -448,6 +453,7 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
       ],
       keepBaseModelId: null,
       settings: emptySettings,
+      catalog: null,
     });
     const byId = Object.fromEntries(entries.map((e) => [e.name, e]));
     expect(byId["opencode/big-pickle"]._isFree).toBe(true);
@@ -469,6 +475,7 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
       backendModels: [makeModelEntry("opus-4-5", "Opus 4.5")],
       keepBaseModelId: null,
       settings: emptySettings,
+      catalog: null,
     });
     const byId = Object.fromEntries(entries.map((e) => [e.name, e]));
     expect(byId["opus-4-5"]._disabledReason).toBeUndefined();
@@ -484,6 +491,7 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
         backendModels: [makeModelEntry("openrouter/a"), makeModelEntry("sticky")],
         keepBaseModelId: "sticky",
         settings: emptySettings,
+        catalog: null,
       }
     );
     const names = entries.map((e) => e.name);
@@ -496,7 +504,7 @@ describe("appendBackendSection — getEnabledModelEntries path", () => {
     appendBackendSection(
       entries,
       opencodeWithEntries([{ baseModelId: "openrouter/a", name: "A", credentialState: "ok" }]),
-      { backendModels: null, keepBaseModelId: null, settings: emptySettings }
+      { backendModels: null, keepBaseModelId: null, settings: emptySettings, catalog: null }
     );
     // No flags before the catalog loads — buildPickerEntries shows "Loading…".
     expect(entries).toHaveLength(0);
@@ -718,5 +726,199 @@ describe("buildEffortOptionsByModelKey", () => {
     const entries = [synthesizeAgentEntry(OTHER, OTHER, opencode)];
     const out = buildEffortOptionsByModelKey(manager, entries);
     expect(out[getModelKeyFromModel(entries[0])]).toEqual([]);
+  });
+});
+
+// ---- capability enrichment ---------------------------------------------
+
+describe("capabilitiesFromModelInfo", () => {
+  function info(partial: CatalogModelInfo): CatalogModelInfo {
+    return { ...partial };
+  }
+
+  it("maps image input to VISION and reasoning to REASONING", () => {
+    expect(
+      capabilitiesFromModelInfo(info({ modalities: { input: ["text", "image"] }, reasoning: true }))
+    ).toEqual([ModelCapability.VISION, ModelCapability.REASONING]);
+  });
+
+  it("returns an empty array for a known model with neither capability", () => {
+    expect(capabilitiesFromModelInfo(info({ modalities: { input: ["text"] } }))).toEqual([]);
+  });
+
+  it("omits VISION when modalities are absent", () => {
+    expect(capabilitiesFromModelInfo(info({ reasoning: true }))).toEqual([
+      ModelCapability.REASONING,
+    ]);
+  });
+});
+
+describe("buildPickerEntries — catalog capability enrichment", () => {
+  function makeCatalog(
+    providerId: string,
+    models: Record<string, CatalogModelInfo>
+  ): CatalogLookup {
+    const provider = { models };
+    return { getProvider: (id) => (id === providerId ? provider : undefined) };
+  }
+
+  function reported(baseModelId: string, provider: string | null): ModelEntry {
+    return { baseModelId, name: baseModelId, provider, effortOptions: [] };
+  }
+
+  function ctxFor(backendId: "codex" | "claude" | "opencode"): ModelActiveContext {
+    return {
+      activeSession: { backendId } as unknown as AgentSession,
+      activeChatUIState: null,
+      activeBackendId: backendId,
+      activeDescriptor: makeDescriptor(backendId),
+      activeSessionHasHistory: false,
+      activeModelState: null,
+      activeCurrentEntry: undefined,
+    };
+  }
+
+  it("sets capabilities on a catalog hit (bare base id, provider == catalog id)", () => {
+    const claude = {
+      ...makeDescriptor("claude"),
+      getEnabledModelEntries: () => [
+        { baseModelId: "claude-sonnet-4-5", name: "Sonnet", credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = makeManager({
+      cachedStateById: {
+        claude: {
+          model: makeModelState("claude-sonnet-4-5", [reported("claude-sonnet-4-5", "anthropic")]),
+          mode: null,
+        },
+      },
+    });
+    const catalog = makeCatalog("anthropic", {
+      "claude-sonnet-4-5": { modalities: { input: ["text", "image"] }, reasoning: true },
+    });
+    const { entries } = buildPickerEntries(
+      manager,
+      [claude],
+      ctxFor("claude"),
+      emptySettings,
+      catalog
+    );
+    const entry = entries.find((e) => e.name === "claude-sonnet-4-5");
+    expect(entry?.capabilities).toEqual([ModelCapability.VISION, ModelCapability.REASONING]);
+  });
+
+  it("strips a leading provider segment from a suffix-style base id before lookup", () => {
+    const opencode = {
+      ...makeDescriptor("opencode"),
+      getEnabledModelEntries: () => [
+        {
+          baseModelId: "anthropic/claude-sonnet-4-5",
+          name: "Sonnet",
+          credentialState: "ok" as const,
+        },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = makeManager({
+      cachedStateById: {
+        opencode: {
+          model: makeModelState("anthropic/claude-sonnet-4-5", [
+            reported("anthropic/claude-sonnet-4-5", "anthropic"),
+          ]),
+          mode: null,
+        },
+      },
+    });
+    const catalog = makeCatalog("anthropic", {
+      "claude-sonnet-4-5": { modalities: { input: ["text", "image"] } },
+    });
+    const { entries } = buildPickerEntries(
+      manager,
+      [opencode],
+      ctxFor("opencode"),
+      emptySettings,
+      catalog
+    );
+    const entry = entries.find((e) => e.name === "anthropic/claude-sonnet-4-5");
+    expect(entry?.capabilities).toEqual([ModelCapability.VISION]);
+  });
+
+  it("leaves capabilities undefined on a catalog miss (provider not in catalog)", () => {
+    const claude = {
+      ...makeDescriptor("claude"),
+      getEnabledModelEntries: () => [
+        { baseModelId: "claude-sonnet-4-5", name: "Sonnet", credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = makeManager({
+      cachedStateById: {
+        claude: {
+          model: makeModelState("claude-sonnet-4-5", [reported("claude-sonnet-4-5", "anthropic")]),
+          mode: null,
+        },
+      },
+    });
+    // Catalog only knows "openai" — the "anthropic" lookup misses.
+    const catalog = makeCatalog("openai", { "gpt-5": {} });
+    const { entries } = buildPickerEntries(
+      manager,
+      [claude],
+      ctxFor("claude"),
+      emptySettings,
+      catalog
+    );
+    const entry = entries.find((e) => e.name === "claude-sonnet-4-5");
+    expect(entry?.capabilities).toBeUndefined();
+  });
+
+  it("leaves capabilities undefined when the model has no provider attribution", () => {
+    const codex = {
+      ...makeDescriptor("codex"),
+      getEnabledModelEntries: () => [
+        { baseModelId: "gpt-5", name: "GPT-5", credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = makeManager({
+      cachedStateById: {
+        codex: { model: makeModelState("gpt-5", [reported("gpt-5", null)]), mode: null },
+      },
+    });
+    const catalog = makeCatalog("openai", {
+      "gpt-5": { modalities: { input: ["text", "image"] } },
+    });
+    const { entries } = buildPickerEntries(
+      manager,
+      [codex],
+      ctxFor("codex"),
+      emptySettings,
+      catalog
+    );
+    const entry = entries.find((e) => e.name === "gpt-5");
+    expect(entry?.capabilities).toBeUndefined();
+  });
+
+  it("leaves capabilities undefined when no catalog is provided", () => {
+    const claude = {
+      ...makeDescriptor("claude"),
+      getEnabledModelEntries: () => [
+        { baseModelId: "claude-sonnet-4-5", name: "Sonnet", credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = makeManager({
+      cachedStateById: {
+        claude: {
+          model: makeModelState("claude-sonnet-4-5", [reported("claude-sonnet-4-5", "anthropic")]),
+          mode: null,
+        },
+      },
+    });
+    const { entries } = buildPickerEntries(
+      manager,
+      [claude],
+      ctxFor("claude"),
+      emptySettings,
+      null
+    );
+    const entry = entries.find((e) => e.name === "claude-sonnet-4-5");
+    expect(entry?.capabilities).toBeUndefined();
   });
 });

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -84,6 +84,16 @@ export interface CatalogModelInfo {
  */
 export interface CatalogLookup {
   getProvider(id: string): { models: Record<string, CatalogModelInfo> } | undefined;
+  /**
+   * Lazily download/populate the catalog. Optional so test stubs and any
+   * synchronous-only lookup stay assignable. The picker calls it once on mount
+   * because nothing else in the agent path warms the catalog — without it
+   * `getProvider` always misses and no capability icons render.
+   */
+  ensureLoaded?(): Promise<void>;
+  /** Subscribe to catalog (re)population so the picker re-derives capabilities
+   *  once data lands. Returns an unsubscribe fn. Optional for the same reason. */
+  onChange?(listener: () => void): () => void;
 }
 
 /**

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -1,6 +1,6 @@
 import { Notice } from "obsidian";
 import { logError } from "@/logger";
-import { ModelCapability } from "@/constants";
+import type { ModelCapability } from "@/constants";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type { AgentChatUIState } from "@/agentMode/session/AgentChatUIState";
@@ -66,90 +66,6 @@ export function handlePickerSwitchError(err: unknown, action: "model" | "effort"
 export const AGENT_PROVIDER = "agent";
 
 /**
- * Minimal structural view of a catalog `ModelInfo` — only the fields capability
- * derivation reads. Declared locally (not imported from `@/modelManagement`)
- * because the agent-mode `ui` layer must not depend on that module; the real
- * `ModelInfo` is structurally assignable to this.
- */
-export interface CatalogModelInfo {
-  modalities?: { input?: string[] };
-  reasoning?: boolean;
-}
-
-/**
- * Narrow read-only view of the catalog the picker needs — just the synchronous
- * in-memory provider lookup. Declared structurally (no `@/modelManagement`
- * import) so the build path stays inside the `ui` boundary; the real
- * `CatalogDownloadService` is assignable to it. Trivially stubbable in tests.
- */
-export interface CatalogLookup {
-  getProvider(id: string): { models: Record<string, CatalogModelInfo> } | undefined;
-  /**
-   * Lazily download/populate the catalog. Optional so test stubs and any
-   * synchronous-only lookup stay assignable. The picker calls it once on mount
-   * because nothing else in the agent path warms the catalog — without it
-   * `getProvider` always misses and no capability icons render.
-   */
-  ensureLoaded?(): Promise<void>;
-  /** Subscribe to catalog (re)population so the picker re-derives capabilities
-   *  once data lands. Returns an unsubscribe fn. Optional for the same reason. */
-  onChange?(listener: () => void): () => void;
-}
-
-/**
- * Derive picker capabilities from a catalog `ModelInfo`. The agent-side analog
- * of `configuredModelToCustomModel`'s derivation — kept identical so a model
- * surfaces the same capabilities whether configured for chat or reached via an
- * agent backend. A model is vision-capable when it lists `"image"` input;
- * reasoning when `reasoning === true`.
- */
-export function capabilitiesFromModelInfo(info: CatalogModelInfo): ModelCapability[] {
-  const capabilities: ModelCapability[] = [];
-  if (info.modalities?.input?.includes("image")) capabilities.push(ModelCapability.VISION);
-  if (info.reasoning) capabilities.push(ModelCapability.REASONING);
-  return capabilities;
-}
-
-/**
- * Resolve the catalog `ModelInfo` for an agent model, or `undefined` on any
- * miss (no provider attribution, provider not in catalog, id not found). The
- * catalog keys models by bare wire id; `provider` is the normalized Copilot
- * provider id, which coincides with the models.dev catalog provider id for the
- * frontier providers (`anthropic`, `openai`, `google`, …). Suffix-style
- * backends (opencode) carry a `<provider>/` prefix on `baseModelId`, so we also
- * try the id with its leading provider segment stripped.
- */
-function lookupCatalogModelInfo(
-  catalog: CatalogLookup | null,
-  provider: string | null,
-  baseModelId: string
-): CatalogModelInfo | undefined {
-  if (!catalog || !provider) return undefined;
-  const models = catalog.getProvider(provider)?.models;
-  if (!models) return undefined;
-  const direct = models[baseModelId];
-  if (direct) return direct;
-  const slash = baseModelId.indexOf("/");
-  if (slash >= 0) return models[baseModelId.slice(slash + 1)];
-  return undefined;
-}
-
-/**
- * Capabilities for an agent model, derived from the catalog. Returns
- * `undefined` (NOT `[]`) on a catalog miss so the image-send guard treats the
- * model as "unknown" and never blocks it. A hit returns the derived array
- * (possibly empty — a known model that genuinely lacks vision/reasoning).
- */
-function capabilitiesFromCatalog(
-  catalog: CatalogLookup | null,
-  provider: string | null,
-  baseModelId: string
-): ModelCapability[] | undefined {
-  const info = lookupCatalogModelInfo(catalog, provider, baseModelId);
-  return info ? capabilitiesFromModelInfo(info) : undefined;
-}
-
-/**
  * Append one backend's section to the picker.
  *
  * One policy for every backend, via `getEnabledModelEntries`: iterate the
@@ -177,8 +93,6 @@ export function appendBackendSection(
     keepBaseModelId: string | null;
     /** Current settings — read by `getEnabledModelEntries`. */
     settings: CopilotSettings;
-    /** Catalog for capability enrichment; `null` when not yet loaded. */
-    catalog: CatalogLookup | null;
   }
 ): void {
   const enabledEntries = descriptor.getEnabledModelEntries?.(ctx.settings) ?? null;
@@ -191,8 +105,7 @@ export function appendBackendSection(
     descriptor,
     enabledEntries,
     ctx.backendModels,
-    ctx.keepBaseModelId,
-    ctx.catalog
+    ctx.keepBaseModelId
   );
 }
 
@@ -210,8 +123,7 @@ function appendFromEnabledEntries(
   descriptor: BackendDescriptor,
   enabledEntries: ReadonlyArray<EnabledModelEntry>,
   backendModels: ReadonlyArray<ModelEntry>,
-  keepBaseModelId: string | null,
-  catalog: CatalogLookup | null
+  keepBaseModelId: string | null
 ): void {
   const reportedById = new Map(backendModels.map((m) => [m.baseModelId, m]));
   const emitted = new Set<string>();
@@ -219,13 +131,10 @@ function appendFromEnabledEntries(
     const reported = reportedById.get(enabled.baseModelId);
     const name = reported?.name || enabled.name || enabled.baseModelId;
     const subtitle = reported?.description ?? enabled.description;
-    // Prefer the model's own persisted capabilities (derived from its
-    // `ConfiguredModel.info` modality snapshot) — reliable without the live
-    // catalog. Fall back to the catalog only when the stored info was silent
-    // (`undefined`) on modalities, so a known no-vision model isn't re-guessed.
-    const capabilities =
-      enabled.capabilities ??
-      capabilitiesFromCatalog(catalog, reported?.provider ?? null, enabled.baseModelId);
+    // Capabilities come from the model's persisted `ConfiguredModel.info`
+    // modality snapshot. `undefined` (no snapshot) means "unknown" — no icon,
+    // and the image-send guard leaves the model unblocked.
+    const capabilities = enabled.capabilities;
     const entry = synthesizeAgentEntry(
       enabled.baseModelId,
       name,
@@ -243,11 +152,6 @@ function appendFromEnabledEntries(
   if (keepBaseModelId && !emitted.has(keepBaseModelId)) {
     const reported = reportedById.get(keepBaseModelId);
     if (reported) {
-      const capabilities = capabilitiesFromCatalog(
-        catalog,
-        reported.provider,
-        reported.baseModelId
-      );
       entries.push(
         synthesizeAgentEntry(
           reported.baseModelId,
@@ -255,7 +159,7 @@ function appendFromEnabledEntries(
           descriptor,
           reported.description,
           undefined,
-          capabilities
+          undefined
         )
       );
     }
@@ -284,9 +188,10 @@ export function synthesizeAgentEntry(
   subtitle?: string,
   isFree?: boolean,
   /**
-   * Catalog-derived capabilities, or `undefined` when unknown (catalog miss).
-   * Left off the entry entirely when undefined so the image-send guard treats
-   * the model as "unknown" — never blocked.
+   * Capabilities from the model's persisted `ConfiguredModel.info` snapshot, or
+   * `undefined` when unknown (no snapshot). Left off the entry entirely when
+   * undefined so the image-send guard treats the model as "unknown" — never
+   * blocked.
    */
   capabilities?: ModelCapability[]
 ): ModelSelectorEntry {
@@ -381,8 +286,7 @@ export function buildPickerEntries(
   manager: AgentSessionManager,
   descriptors: BackendDescriptor[],
   ctx: ModelActiveContext,
-  settings: CopilotSettings,
-  catalog: CatalogLookup | null
+  settings: CopilotSettings
 ): { entries: ModelSelectorEntry[]; valueKey: string } {
   const entries: ModelSelectorEntry[] = [];
   for (const descriptor of descriptors) {
@@ -397,7 +301,6 @@ export function buildPickerEntries(
       backendModels,
       keepBaseModelId,
       settings,
-      catalog,
     });
     // No catalog cached yet (and not because the agent intentionally
     // omitted a model state). Show a per-backend loading / failure row so
@@ -432,7 +335,7 @@ export function buildPickerEntries(
         ctx.activeDescriptor,
         ctx.activeCurrentEntry.description,
         undefined,
-        capabilitiesFromCatalog(catalog, ctx.activeCurrentEntry.provider, baseId)
+        undefined
       );
       entries.unshift(synth);
       valueKey = getModelKeyFromModel(synth);
@@ -652,13 +555,11 @@ export function buildAgentModelPicker(args: {
   manager: AgentSessionManager | null;
   descriptors: BackendDescriptor[];
   settings: CopilotSettings;
-  /** Catalog for capability enrichment; `null` until it has loaded. */
-  catalog: CatalogLookup | null;
 }): AgentModelPickerOverride | null {
-  const { manager, descriptors, settings, catalog } = args;
+  const { manager, descriptors, settings } = args;
   if (!manager) return null;
   const ctx = collectModelActiveContext(manager);
-  const { entries, valueKey } = buildPickerEntries(manager, descriptors, ctx, settings, catalog);
+  const { entries, valueKey } = buildPickerEntries(manager, descriptors, ctx, settings);
   const onChange = buildModelOnChange(manager, ctx, entries);
   return {
     models: entries,

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -219,11 +219,13 @@ function appendFromEnabledEntries(
     const reported = reportedById.get(enabled.baseModelId);
     const name = reported?.name || enabled.name || enabled.baseModelId;
     const subtitle = reported?.description ?? enabled.description;
-    const capabilities = capabilitiesFromCatalog(
-      catalog,
-      reported?.provider ?? null,
-      enabled.baseModelId
-    );
+    // Prefer the model's own persisted capabilities (derived from its
+    // `ConfiguredModel.info` modality snapshot) — reliable without the live
+    // catalog. Fall back to the catalog only when the stored info was silent
+    // (`undefined`) on modalities, so a known no-vision model isn't re-guessed.
+    const capabilities =
+      enabled.capabilities ??
+      capabilitiesFromCatalog(catalog, reported?.provider ?? null, enabled.baseModelId);
     const entry = synthesizeAgentEntry(
       enabled.baseModelId,
       name,

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -1,5 +1,6 @@
 import { Notice } from "obsidian";
 import { logError } from "@/logger";
+import { ModelCapability } from "@/constants";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type { AgentChatUIState } from "@/agentMode/session/AgentChatUIState";
@@ -65,6 +66,80 @@ export function handlePickerSwitchError(err: unknown, action: "model" | "effort"
 export const AGENT_PROVIDER = "agent";
 
 /**
+ * Minimal structural view of a catalog `ModelInfo` — only the fields capability
+ * derivation reads. Declared locally (not imported from `@/modelManagement`)
+ * because the agent-mode `ui` layer must not depend on that module; the real
+ * `ModelInfo` is structurally assignable to this.
+ */
+export interface CatalogModelInfo {
+  modalities?: { input?: string[] };
+  reasoning?: boolean;
+}
+
+/**
+ * Narrow read-only view of the catalog the picker needs — just the synchronous
+ * in-memory provider lookup. Declared structurally (no `@/modelManagement`
+ * import) so the build path stays inside the `ui` boundary; the real
+ * `CatalogDownloadService` is assignable to it. Trivially stubbable in tests.
+ */
+export interface CatalogLookup {
+  getProvider(id: string): { models: Record<string, CatalogModelInfo> } | undefined;
+}
+
+/**
+ * Derive picker capabilities from a catalog `ModelInfo`. The agent-side analog
+ * of `configuredModelToCustomModel`'s derivation — kept identical so a model
+ * surfaces the same capabilities whether configured for chat or reached via an
+ * agent backend. A model is vision-capable when it lists `"image"` input;
+ * reasoning when `reasoning === true`.
+ */
+export function capabilitiesFromModelInfo(info: CatalogModelInfo): ModelCapability[] {
+  const capabilities: ModelCapability[] = [];
+  if (info.modalities?.input?.includes("image")) capabilities.push(ModelCapability.VISION);
+  if (info.reasoning) capabilities.push(ModelCapability.REASONING);
+  return capabilities;
+}
+
+/**
+ * Resolve the catalog `ModelInfo` for an agent model, or `undefined` on any
+ * miss (no provider attribution, provider not in catalog, id not found). The
+ * catalog keys models by bare wire id; `provider` is the normalized Copilot
+ * provider id, which coincides with the models.dev catalog provider id for the
+ * frontier providers (`anthropic`, `openai`, `google`, …). Suffix-style
+ * backends (opencode) carry a `<provider>/` prefix on `baseModelId`, so we also
+ * try the id with its leading provider segment stripped.
+ */
+function lookupCatalogModelInfo(
+  catalog: CatalogLookup | null,
+  provider: string | null,
+  baseModelId: string
+): CatalogModelInfo | undefined {
+  if (!catalog || !provider) return undefined;
+  const models = catalog.getProvider(provider)?.models;
+  if (!models) return undefined;
+  const direct = models[baseModelId];
+  if (direct) return direct;
+  const slash = baseModelId.indexOf("/");
+  if (slash >= 0) return models[baseModelId.slice(slash + 1)];
+  return undefined;
+}
+
+/**
+ * Capabilities for an agent model, derived from the catalog. Returns
+ * `undefined` (NOT `[]`) on a catalog miss so the image-send guard treats the
+ * model as "unknown" and never blocks it. A hit returns the derived array
+ * (possibly empty — a known model that genuinely lacks vision/reasoning).
+ */
+function capabilitiesFromCatalog(
+  catalog: CatalogLookup | null,
+  provider: string | null,
+  baseModelId: string
+): ModelCapability[] | undefined {
+  const info = lookupCatalogModelInfo(catalog, provider, baseModelId);
+  return info ? capabilitiesFromModelInfo(info) : undefined;
+}
+
+/**
  * Append one backend's section to the picker.
  *
  * One policy for every backend, via `getEnabledModelEntries`: iterate the
@@ -92,6 +167,8 @@ export function appendBackendSection(
     keepBaseModelId: string | null;
     /** Current settings — read by `getEnabledModelEntries`. */
     settings: CopilotSettings;
+    /** Catalog for capability enrichment; `null` when not yet loaded. */
+    catalog: CatalogLookup | null;
   }
 ): void {
   const enabledEntries = descriptor.getEnabledModelEntries?.(ctx.settings) ?? null;
@@ -104,7 +181,8 @@ export function appendBackendSection(
     descriptor,
     enabledEntries,
     ctx.backendModels,
-    ctx.keepBaseModelId
+    ctx.keepBaseModelId,
+    ctx.catalog
   );
 }
 
@@ -122,7 +200,8 @@ function appendFromEnabledEntries(
   descriptor: BackendDescriptor,
   enabledEntries: ReadonlyArray<EnabledModelEntry>,
   backendModels: ReadonlyArray<ModelEntry>,
-  keepBaseModelId: string | null
+  keepBaseModelId: string | null,
+  catalog: CatalogLookup | null
 ): void {
   const reportedById = new Map(backendModels.map((m) => [m.baseModelId, m]));
   const emitted = new Set<string>();
@@ -130,12 +209,18 @@ function appendFromEnabledEntries(
     const reported = reportedById.get(enabled.baseModelId);
     const name = reported?.name || enabled.name || enabled.baseModelId;
     const subtitle = reported?.description ?? enabled.description;
+    const capabilities = capabilitiesFromCatalog(
+      catalog,
+      reported?.provider ?? null,
+      enabled.baseModelId
+    );
     const entry = synthesizeAgentEntry(
       enabled.baseModelId,
       name,
       descriptor,
       subtitle,
-      enabled.isFree
+      enabled.isFree,
+      capabilities
     );
     const reason = credentialDisabledReason(enabled.credentialState, !!reported);
     if (reason) entry._disabledReason = reason;
@@ -146,8 +231,20 @@ function appendFromEnabledEntries(
   if (keepBaseModelId && !emitted.has(keepBaseModelId)) {
     const reported = reportedById.get(keepBaseModelId);
     if (reported) {
+      const capabilities = capabilitiesFromCatalog(
+        catalog,
+        reported.provider,
+        reported.baseModelId
+      );
       entries.push(
-        synthesizeAgentEntry(reported.baseModelId, reported.name, descriptor, reported.description)
+        synthesizeAgentEntry(
+          reported.baseModelId,
+          reported.name,
+          descriptor,
+          reported.description,
+          undefined,
+          capabilities
+        )
       );
     }
   }
@@ -173,7 +270,13 @@ export function synthesizeAgentEntry(
   humanName: string,
   descriptor: BackendDescriptor,
   subtitle?: string,
-  isFree?: boolean
+  isFree?: boolean,
+  /**
+   * Catalog-derived capabilities, or `undefined` when unknown (catalog miss).
+   * Left off the entry entirely when undefined so the image-send guard treats
+   * the model as "unknown" — never blocked.
+   */
+  capabilities?: ModelCapability[]
 ): ModelSelectorEntry {
   return {
     name: baseModelId,
@@ -181,6 +284,7 @@ export function synthesizeAgentEntry(
     enabled: true,
     isBuiltIn: false,
     displayName: humanName || baseModelId,
+    capabilities,
     _group: descriptor.displayName,
     _backendId: descriptor.id,
     _subtitle: subtitle,
@@ -265,7 +369,8 @@ export function buildPickerEntries(
   manager: AgentSessionManager,
   descriptors: BackendDescriptor[],
   ctx: ModelActiveContext,
-  settings: CopilotSettings
+  settings: CopilotSettings,
+  catalog: CatalogLookup | null
 ): { entries: ModelSelectorEntry[]; valueKey: string } {
   const entries: ModelSelectorEntry[] = [];
   for (const descriptor of descriptors) {
@@ -280,6 +385,7 @@ export function buildPickerEntries(
       backendModels,
       keepBaseModelId,
       settings,
+      catalog,
     });
     // No catalog cached yet (and not because the agent intentionally
     // omitted a model state). Show a per-backend loading / failure row so
@@ -312,7 +418,9 @@ export function buildPickerEntries(
         baseId,
         ctx.activeCurrentEntry.name,
         ctx.activeDescriptor,
-        ctx.activeCurrentEntry.description
+        ctx.activeCurrentEntry.description,
+        undefined,
+        capabilitiesFromCatalog(catalog, ctx.activeCurrentEntry.provider, baseId)
       );
       entries.unshift(synth);
       valueKey = getModelKeyFromModel(synth);
@@ -532,11 +640,13 @@ export function buildAgentModelPicker(args: {
   manager: AgentSessionManager | null;
   descriptors: BackendDescriptor[];
   settings: CopilotSettings;
+  /** Catalog for capability enrichment; `null` until it has loaded. */
+  catalog: CatalogLookup | null;
 }): AgentModelPickerOverride | null {
-  const { manager, descriptors, settings } = args;
+  const { manager, descriptors, settings, catalog } = args;
   if (!manager) return null;
   const ctx = collectModelActiveContext(manager);
-  const { entries, valueKey } = buildPickerEntries(manager, descriptors, ctx, settings);
+  const { entries, valueKey } = buildPickerEntries(manager, descriptors, ctx, settings, catalog);
   const onChange = buildModelOnChange(manager, ctx, entries);
   return {
     models: entries,

--- a/src/agentMode/ui/useAgentModelPicker.ts
+++ b/src/agentMode/ui/useAgentModelPicker.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import { useSettingsValue } from "@/settings/model";
 import { listBackendDescriptors } from "@/agentMode/backends/registry";
@@ -86,6 +86,38 @@ function useAgentModelSignal(
 }
 
 /**
+ * Warm the catalog once and re-render when it (re)populates, so the picker
+ * derives capability icons as soon as `models.dev` data lands. Nothing else in
+ * the agent path calls `ensureLoaded`, so without this `getProvider` always
+ * misses and capabilities never show. Returns a version counter that mutates on
+ * every `onChange` — fed into the picker memo so it recomputes.
+ */
+function useCatalogVersion(catalog: CatalogLookup | null): number {
+  const ensuredRef = useRef(false);
+  useEffect(() => {
+    if (ensuredRef.current) return;
+    ensuredRef.current = true;
+    void catalog?.ensureLoaded?.();
+  }, [catalog]);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => catalog?.onChange?.(onStoreChange) ?? (() => {}),
+    [catalog]
+  );
+  const versionRef = useRef(0);
+  const getSnapshot = useCallback(() => versionRef.current, []);
+  return useSyncExternalStore(
+    (onStoreChange) =>
+      subscribe(() => {
+        versionRef.current += 1;
+        onStoreChange();
+      }),
+    getSnapshot,
+    getSnapshot
+  );
+}
+
+/**
  * Build the `modelPickerOverride` for `ChatInput` — one grouped section per
  * registered backend, plus an optional effort sibling for the active model.
  * Once the active session has any user-visible messages, non-active backend
@@ -101,10 +133,12 @@ export function useAgentModelPicker(
   const settings = useSettingsValue();
   const descriptors = useMemo(() => listBackendDescriptors(), []);
   const signal = useAgentModelSignal(manager, descriptors);
+  const catalogVersion = useCatalogVersion(catalog);
   return useMemo(() => {
-    // `signal` is the memo invalidator — referenced here so
-    // react-hooks/exhaustive-deps accepts it in the dep array.
+    // `signal` / `catalogVersion` are memo invalidators — referenced here so
+    // react-hooks/exhaustive-deps accepts them in the dep array.
     void signal;
+    void catalogVersion;
     return buildAgentModelPicker({ manager, descriptors, settings, catalog });
-  }, [manager, descriptors, settings, catalog, signal]);
+  }, [manager, descriptors, settings, catalog, signal, catalogVersion]);
 }

--- a/src/agentMode/ui/useAgentModelPicker.ts
+++ b/src/agentMode/ui/useAgentModelPicker.ts
@@ -5,6 +5,7 @@ import { listBackendDescriptors } from "@/agentMode/backends/registry";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import { modelStateSignature } from "@/agentMode/session/translateBackendState";
 import type { BackendDescriptor } from "@/agentMode/session/types";
+import type { CatalogLookup } from "./agentModelPickerHelpers";
 import { buildAgentModelPicker } from "./agentModelPickerHelpers";
 import { useManagerSubscribe } from "./useManagerSubscribe";
 
@@ -94,7 +95,8 @@ function useAgentModelSignal(
  * Mode is *not* part of this override — see `useAgentModePicker` for that.
  */
 export function useAgentModelPicker(
-  manager: AgentSessionManager | null
+  manager: AgentSessionManager | null,
+  catalog: CatalogLookup | null
 ): AgentModelPickerOverride | null {
   const settings = useSettingsValue();
   const descriptors = useMemo(() => listBackendDescriptors(), []);
@@ -103,6 +105,6 @@ export function useAgentModelPicker(
     // `signal` is the memo invalidator — referenced here so
     // react-hooks/exhaustive-deps accepts it in the dep array.
     void signal;
-    return buildAgentModelPicker({ manager, descriptors, settings });
-  }, [manager, descriptors, settings, signal]);
+    return buildAgentModelPicker({ manager, descriptors, settings, catalog });
+  }, [manager, descriptors, settings, catalog, signal]);
 }

--- a/src/agentMode/ui/useAgentModelPicker.ts
+++ b/src/agentMode/ui/useAgentModelPicker.ts
@@ -1,11 +1,10 @@
-import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import { useSettingsValue } from "@/settings/model";
 import { listBackendDescriptors } from "@/agentMode/backends/registry";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import { modelStateSignature } from "@/agentMode/session/translateBackendState";
 import type { BackendDescriptor } from "@/agentMode/session/types";
-import type { CatalogLookup } from "./agentModelPickerHelpers";
 import { buildAgentModelPicker } from "./agentModelPickerHelpers";
 import { useManagerSubscribe } from "./useManagerSubscribe";
 
@@ -86,38 +85,6 @@ function useAgentModelSignal(
 }
 
 /**
- * Warm the catalog once and re-render when it (re)populates, so the picker
- * derives capability icons as soon as `models.dev` data lands. Nothing else in
- * the agent path calls `ensureLoaded`, so without this `getProvider` always
- * misses and capabilities never show. Returns a version counter that mutates on
- * every `onChange` — fed into the picker memo so it recomputes.
- */
-function useCatalogVersion(catalog: CatalogLookup | null): number {
-  const ensuredRef = useRef(false);
-  useEffect(() => {
-    if (ensuredRef.current) return;
-    ensuredRef.current = true;
-    void catalog?.ensureLoaded?.();
-  }, [catalog]);
-
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => catalog?.onChange?.(onStoreChange) ?? (() => {}),
-    [catalog]
-  );
-  const versionRef = useRef(0);
-  const getSnapshot = useCallback(() => versionRef.current, []);
-  return useSyncExternalStore(
-    (onStoreChange) =>
-      subscribe(() => {
-        versionRef.current += 1;
-        onStoreChange();
-      }),
-    getSnapshot,
-    getSnapshot
-  );
-}
-
-/**
  * Build the `modelPickerOverride` for `ChatInput` — one grouped section per
  * registered backend, plus an optional effort sibling for the active model.
  * Once the active session has any user-visible messages, non-active backend
@@ -127,18 +94,15 @@ function useCatalogVersion(catalog: CatalogLookup | null): number {
  * Mode is *not* part of this override — see `useAgentModePicker` for that.
  */
 export function useAgentModelPicker(
-  manager: AgentSessionManager | null,
-  catalog: CatalogLookup | null
+  manager: AgentSessionManager | null
 ): AgentModelPickerOverride | null {
   const settings = useSettingsValue();
   const descriptors = useMemo(() => listBackendDescriptors(), []);
   const signal = useAgentModelSignal(manager, descriptors);
-  const catalogVersion = useCatalogVersion(catalog);
   return useMemo(() => {
-    // `signal` / `catalogVersion` are memo invalidators — referenced here so
-    // react-hooks/exhaustive-deps accepts them in the dep array.
+    // `signal` is a memo invalidator — referenced here so
+    // react-hooks/exhaustive-deps accepts it in the dep array.
     void signal;
-    void catalogVersion;
-    return buildAgentModelPicker({ manager, descriptors, settings, catalog });
-  }, [manager, descriptors, settings, catalog, signal, catalogVersion]);
+    return buildAgentModelPicker({ manager, descriptors, settings });
+  }, [manager, descriptors, settings, signal]);
 }

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -323,7 +323,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
       if (Array.isArray(activeModel?.capabilities) && !modelSupportsVision(activeModel)) {
         const modelLabel = activeModel.displayName || activeModel.name;
         new Notice(
-          `${modelLabel} doesn't support images. Switch to a vision-capable model, or enable Vision for this model in its provider settings.`
+          `${modelLabel} doesn't support images. Switch to a vision-capable model to send images.`
         );
         return;
       }

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -45,11 +45,11 @@ import CopilotPlugin from "@/main";
 import { useIsPlusUser } from "@/plusUtils";
 import { ProjectFileManager } from "@/projects/ProjectFileManager";
 import { useProjects } from "@/projects/state";
-import { useSettingsValue } from "@/settings/model";
+import { getModelKeyFromModel, useSettingsValue } from "@/settings/model";
 import { ChatManagerChatUIState } from "@/state/ChatUIState";
 import { FileParserManager } from "@/tools/FileParserManager";
 import { ChatMessage } from "@/types/message";
-import { err2String, isPlusChain } from "@/utils";
+import { err2String, isPlusChain, modelSupportsVision } from "@/utils";
 import { arrayBufferToBase64 } from "@/utils/base64";
 import { appendUniqueFiles } from "@/utils/fileListUtils";
 import { Notice, TFile } from "obsidian";
@@ -310,6 +310,23 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
     if (hasUrlsInContext && !isPlusChain(currentChain)) {
       // Show notice but continue processing the message without URL context
       new Notice(RESTRICTION_MESSAGES.URL_PROCESSING_RESTRICTED);
+    }
+
+    // Hard-block sending images to a model that is KNOWN to lack vision. We only
+    // block when capabilities are populated (an empty array still means "known");
+    // undefined capabilities mean "unknown" and must not block. Inputs are left
+    // intact so the user can switch models without retyping.
+    if (selectedImages.length > 0) {
+      const activeModel = chatModelPicker.models.find(
+        (m) => getModelKeyFromModel(m) === chatModelPicker.value
+      );
+      if (Array.isArray(activeModel?.capabilities) && !modelSupportsVision(activeModel)) {
+        const modelLabel = activeModel.displayName || activeModel.name;
+        new Notice(
+          `${modelLabel} doesn't support images. Switch to a vision-capable model, or enable Vision for this model in its provider settings.`
+        );
+        return;
+      }
     }
 
     try {

--- a/src/components/chat-components/useChatModelPicker.ts
+++ b/src/components/chat-components/useChatModelPicker.ts
@@ -1,6 +1,6 @@
-import { ModelCapability } from "@/constants";
 import {
   backendPickerAtomFamily,
+  capabilitiesFromConfiguredInfo,
   mapProviderTypeToChatModelProvider,
   providerRequiresApiKey,
   resolveChatModelSelectionId,
@@ -62,11 +62,10 @@ export function useChatModelPicker(params: {
     for (const entry of entries) {
       if (entry.state !== "ok") continue;
       const { configuredModel, provider, configuredModelId } = entry;
-      const capabilities: ModelCapability[] = [];
-      if (configuredModel.info.reasoning) capabilities.push(ModelCapability.REASONING);
-      if (configuredModel.info.modalities?.input?.includes("image")) {
-        capabilities.push(ModelCapability.VISION);
-      }
+      // Leave capabilities `undefined` when the snapshot carries no modality
+      // data so unknown models stay unblocked; only a populated array (which may
+      // be empty) asserts "known". See the image guard in `Chat.tsx`.
+      const capabilities = capabilitiesFromConfiguredInfo(configuredModel.info);
       const needsKey = providerRequiresApiKey(provider) && !provider.apiKeyKeychainId;
       const modelEntry: ModelSelectorEntry = {
         name: configuredModelId,

--- a/src/components/ui/model-display.test.tsx
+++ b/src/components/ui/model-display.test.tsx
@@ -1,0 +1,43 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { ModelCapabilityIcons, getModelDisplayWithIcons } from "./model-display";
+import type { CustomModel } from "@/aiParams";
+import { ModelCapability } from "@/constants";
+
+describe("ModelCapabilityIcons", () => {
+  it("renders an icon for vision and websearch but never for reasoning", () => {
+    const { container } = render(
+      <ModelCapabilityIcons
+        capabilities={[
+          ModelCapability.VISION,
+          ModelCapability.REASONING,
+          ModelCapability.WEB_SEARCH,
+        ]}
+      />
+    );
+    // Reasoning is intentionally not rendered (ubiquitous; kept runtime-only),
+    // so only the vision + websearch icons appear.
+    expect(container.querySelectorAll("svg").length).toBe(2);
+  });
+
+  it("renders nothing when the only capability is reasoning", () => {
+    const { container } = render(
+      <ModelCapabilityIcons capabilities={[ModelCapability.REASONING]} />
+    );
+    expect(container.querySelectorAll("svg").length).toBe(0);
+  });
+});
+
+describe("getModelDisplayWithIcons", () => {
+  it("omits the Reasoning label while keeping Vision", () => {
+    const model: CustomModel = {
+      name: "omni",
+      provider: "openai",
+      enabled: true,
+      capabilities: [ModelCapability.VISION, ModelCapability.REASONING],
+    };
+    const text = getModelDisplayWithIcons(model);
+    expect(text).toContain("Vision");
+    expect(text).not.toContain("Reasoning");
+  });
+});

--- a/src/components/ui/model-display.test.tsx
+++ b/src/components/ui/model-display.test.tsx
@@ -1,43 +1,90 @@
 import { render } from "@testing-library/react";
 import React from "react";
-import { ModelCapabilityIcons, getModelDisplayWithIcons } from "./model-display";
+import {
+  ModelCapabilityIcons,
+  getModelDisplayWithIcons,
+  hasCapabilityIcons,
+} from "./model-display";
 import type { CustomModel } from "@/aiParams";
 import { ModelCapability } from "@/constants";
 
+const NO_VISION = "model-cap-no-vision";
+
 describe("ModelCapabilityIcons", () => {
-  it("renders an icon for vision and websearch but never for reasoning", () => {
-    const { container } = render(
-      <ModelCapabilityIcons
-        capabilities={[
-          ModelCapability.VISION,
-          ModelCapability.REASONING,
-          ModelCapability.WEB_SEARCH,
-        ]}
-      />
-    );
-    // Reasoning is intentionally not rendered (ubiquitous; kept runtime-only),
-    // so only the vision + websearch icons appear.
-    expect(container.querySelectorAll("svg").length).toBe(2);
+  it("renders nothing for unknown capabilities (undefined)", () => {
+    // `undefined` = no modality snapshot. We must NOT assert a missing
+    // capability — render nothing, distinct from the eye-off below.
+    const { container, queryByTestId } = render(<ModelCapabilityIcons capabilities={undefined} />);
+    expect(container.querySelectorAll("svg").length).toBe(0);
+    expect(queryByTestId(NO_VISION)).toBeNull();
   });
 
-  it("renders nothing when the only capability is reasoning", () => {
-    const { container } = render(
-      <ModelCapabilityIcons capabilities={[ModelCapability.REASONING]} />
+  it("renders the eye-off for a known model that lacks vision (empty array)", () => {
+    const { container, queryByTestId } = render(<ModelCapabilityIcons capabilities={[]} />);
+    expect(queryByTestId(NO_VISION)).not.toBeNull();
+    expect(container.querySelectorAll("svg").length).toBe(1);
+  });
+
+  it("renders no icon for a vision-capable model", () => {
+    // Vision is the norm — we don't badge it (mirrors the hidden reasoning icon).
+    const { container, queryByTestId } = render(
+      <ModelCapabilityIcons capabilities={[ModelCapability.VISION]} />
     );
     expect(container.querySelectorAll("svg").length).toBe(0);
+    expect(queryByTestId(NO_VISION)).toBeNull();
+  });
+
+  it("renders the globe only for a vision + web-search model", () => {
+    const { container, queryByTestId } = render(
+      <ModelCapabilityIcons capabilities={[ModelCapability.VISION, ModelCapability.WEB_SEARCH]} />
+    );
+    expect(container.querySelectorAll("svg").length).toBe(1);
+    expect(queryByTestId(NO_VISION)).toBeNull();
+  });
+
+  it("renders the globe and the eye-off for a web-search-only model", () => {
+    const { container, queryByTestId } = render(
+      <ModelCapabilityIcons capabilities={[ModelCapability.WEB_SEARCH]} />
+    );
+    expect(container.querySelectorAll("svg").length).toBe(2);
+    expect(queryByTestId(NO_VISION)).not.toBeNull();
+  });
+
+  it("renders the eye-off when the only capability is reasoning (no vision)", () => {
+    const { container, queryByTestId } = render(
+      <ModelCapabilityIcons capabilities={[ModelCapability.REASONING]} />
+    );
+    expect(container.querySelectorAll("svg").length).toBe(1);
+    expect(queryByTestId(NO_VISION)).not.toBeNull();
+  });
+});
+
+describe("hasCapabilityIcons", () => {
+  it("is false for unknown (undefined) and vision-only models", () => {
+    expect(hasCapabilityIcons(undefined)).toBe(false);
+    expect(hasCapabilityIcons([ModelCapability.VISION])).toBe(false);
+    expect(hasCapabilityIcons([ModelCapability.VISION, ModelCapability.REASONING])).toBe(false);
+  });
+
+  it("is true when an icon would render (no-vision or web search)", () => {
+    expect(hasCapabilityIcons([])).toBe(true);
+    expect(hasCapabilityIcons([ModelCapability.REASONING])).toBe(true);
+    expect(hasCapabilityIcons([ModelCapability.WEB_SEARCH])).toBe(true);
+    expect(hasCapabilityIcons([ModelCapability.VISION, ModelCapability.WEB_SEARCH])).toBe(true);
   });
 });
 
 describe("getModelDisplayWithIcons", () => {
-  it("omits the Reasoning label while keeping Vision", () => {
+  it("surfaces Websearch but never Vision or Reasoning", () => {
     const model: CustomModel = {
       name: "omni",
       provider: "openai",
       enabled: true,
-      capabilities: [ModelCapability.VISION, ModelCapability.REASONING],
+      capabilities: [ModelCapability.VISION, ModelCapability.REASONING, ModelCapability.WEB_SEARCH],
     };
     const text = getModelDisplayWithIcons(model);
-    expect(text).toContain("Vision");
+    expect(text).toContain("Websearch");
+    expect(text).not.toContain("Vision");
     expect(text).not.toContain("Reasoning");
   });
 });

--- a/src/components/ui/model-display.test.tsx
+++ b/src/components/ui/model-display.test.tsx
@@ -34,19 +34,19 @@ describe("ModelCapabilityIcons", () => {
     expect(queryByTestId(NO_VISION)).toBeNull();
   });
 
-  it("renders the globe only for a vision + web-search model", () => {
+  it("renders no icon for a vision + web-search model (web search is not badged)", () => {
     const { container, queryByTestId } = render(
       <ModelCapabilityIcons capabilities={[ModelCapability.VISION, ModelCapability.WEB_SEARCH]} />
     );
-    expect(container.querySelectorAll("svg").length).toBe(1);
+    expect(container.querySelectorAll("svg").length).toBe(0);
     expect(queryByTestId(NO_VISION)).toBeNull();
   });
 
-  it("renders the globe and the eye-off for a web-search-only model", () => {
+  it("renders only the eye-off for a web-search-only model (no vision)", () => {
     const { container, queryByTestId } = render(
       <ModelCapabilityIcons capabilities={[ModelCapability.WEB_SEARCH]} />
     );
-    expect(container.querySelectorAll("svg").length).toBe(2);
+    expect(container.querySelectorAll("svg").length).toBe(1);
     expect(queryByTestId(NO_VISION)).not.toBeNull();
   });
 
@@ -60,22 +60,22 @@ describe("ModelCapabilityIcons", () => {
 });
 
 describe("hasCapabilityIcons", () => {
-  it("is false for unknown (undefined) and vision-only models", () => {
+  it("is false for unknown (undefined) and any vision-capable model", () => {
     expect(hasCapabilityIcons(undefined)).toBe(false);
     expect(hasCapabilityIcons([ModelCapability.VISION])).toBe(false);
     expect(hasCapabilityIcons([ModelCapability.VISION, ModelCapability.REASONING])).toBe(false);
+    expect(hasCapabilityIcons([ModelCapability.VISION, ModelCapability.WEB_SEARCH])).toBe(false);
   });
 
-  it("is true when an icon would render (no-vision or web search)", () => {
+  it("is true when the model is known to lack vision", () => {
     expect(hasCapabilityIcons([])).toBe(true);
     expect(hasCapabilityIcons([ModelCapability.REASONING])).toBe(true);
     expect(hasCapabilityIcons([ModelCapability.WEB_SEARCH])).toBe(true);
-    expect(hasCapabilityIcons([ModelCapability.VISION, ModelCapability.WEB_SEARCH])).toBe(true);
   });
 });
 
 describe("getModelDisplayWithIcons", () => {
-  it("surfaces Websearch but never Vision or Reasoning", () => {
+  it("shows name and provider, never a modality label", () => {
     const model: CustomModel = {
       name: "omni",
       provider: "openai",
@@ -83,7 +83,9 @@ describe("getModelDisplayWithIcons", () => {
       capabilities: [ModelCapability.VISION, ModelCapability.REASONING, ModelCapability.WEB_SEARCH],
     };
     const text = getModelDisplayWithIcons(model);
-    expect(text).toContain("Websearch");
+    expect(text).toContain("omni");
+    expect(text).toContain("OpenAI");
+    expect(text).not.toContain("Websearch");
     expect(text).not.toContain("Vision");
     expect(text).not.toContain("Reasoning");
   });

--- a/src/components/ui/model-display.tsx
+++ b/src/components/ui/model-display.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { CustomModel } from "@/aiParams";
 import { getProviderLabel } from "@/utils";
-import { Eye, Globe } from "lucide-react";
+import { EyeOff, Globe } from "lucide-react";
 import { ModelCapability } from "@/constants";
+import { HelpTooltip } from "@/components/ui/help-tooltip";
 
 interface ModelDisplayProps {
   model: CustomModel;
@@ -14,38 +15,53 @@ interface ModelCapabilityIconsProps {
   iconSize?: number;
 }
 
-const EMPTY_CAPABILITIES: ModelCapability[] = [];
+const NO_VISION_LABEL = "This model does not support image inputs.";
 
+/**
+ * Whether {@link ModelCapabilityIcons} would render at least one icon. Drives the
+ * surrounding wrapper so it never renders empty (a vision-capable model shows no
+ * icon) and never hides the eye-off for a model known to lack vision (`[]`).
+ */
+export function hasCapabilityIcons(capabilities: ModelCapability[] | undefined): boolean {
+  if (capabilities === undefined) return false;
+  return (
+    capabilities.includes(ModelCapability.WEB_SEARCH) ||
+    !capabilities.includes(ModelCapability.VISION)
+  );
+}
+
+/**
+ * We badge only the exception, not the norm. `undefined` means "unknown" (no
+ * modality snapshot — e.g. an agent-provided model) and renders nothing; we never
+ * assert a missing capability we don't actually know about. A defined array is
+ * "known": flag the absence of vision with a muted eye-off. Vision and reasoning
+ * themselves render nothing — they're ubiquitous on modern models, so the only
+ * vision signal we surface is the warning that a model can't take images.
+ */
 export const ModelCapabilityIcons: React.FC<ModelCapabilityIconsProps> = ({
-  capabilities = EMPTY_CAPABILITIES,
+  capabilities,
   iconSize = 16,
 }) => {
+  if (capabilities === undefined) return null;
+  const showGlobe = capabilities.includes(ModelCapability.WEB_SEARCH);
+  const showNoVision = !capabilities.includes(ModelCapability.VISION);
   return (
     <>
-      {capabilities
-        .sort((a, b) => a.localeCompare(b))
-        .map((cap) => {
-          switch (cap) {
-            case ModelCapability.VISION:
-              return (
-                <Eye
-                  key={cap}
-                  className="tw-text-model-capabilities-green"
-                  style={{ width: iconSize, height: iconSize }}
-                />
-              );
-            case ModelCapability.WEB_SEARCH:
-              return (
-                <Globe
-                  key={cap}
-                  className="tw-text-model-capabilities-blue"
-                  style={{ width: iconSize, height: iconSize }}
-                />
-              );
-            default:
-              return null;
-          }
-        })}
+      {showGlobe && (
+        <Globe
+          className="tw-text-model-capabilities-blue"
+          style={{ width: iconSize, height: iconSize }}
+        />
+      )}
+      {showNoVision && (
+        <HelpTooltip content={NO_VISION_LABEL} side="top">
+          <EyeOff
+            className="tw-text-muted"
+            style={{ width: iconSize, height: iconSize }}
+            data-testid="model-cap-no-vision"
+          />
+        </HelpTooltip>
+      )}
     </>
   );
 };
@@ -55,7 +71,7 @@ export const ModelDisplay: React.FC<ModelDisplayProps> = ({ model, iconSize = 14
   return (
     <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1">
       <span className="tw-truncate tw-text-sm hover:tw-text-normal">{displayName}</span>
-      {model.capabilities && model.capabilities.length > 0 && (
+      {hasCapabilityIcons(model.capabilities) && (
         <div className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
           <ModelCapabilityIcons capabilities={model.capabilities} iconSize={iconSize} />
         </div>
@@ -73,18 +89,9 @@ export const getModelDisplayText = (model: CustomModel): string => {
 export const getModelDisplayWithIcons = (model: CustomModel): string => {
   const displayName = model.displayName || model.name;
   const provider = `(${getProviderLabel(model.provider, model)})`;
-  const icons =
-    model.capabilities
-      ?.map((cap) => {
-        switch (cap) {
-          case ModelCapability.VISION:
-            return "Vision";
-          case ModelCapability.WEB_SEARCH:
-            return "Websearch";
-          default:
-            return "";
-        }
-      })
-      .join("|") || "";
+  const icons = (model.capabilities ?? [])
+    .map((cap) => (cap === ModelCapability.WEB_SEARCH ? "Websearch" : ""))
+    .filter(Boolean)
+    .join("|");
   return `${displayName} ${provider} ${icons}`;
 };

--- a/src/components/ui/model-display.tsx
+++ b/src/components/ui/model-display.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { CustomModel } from "@/aiParams";
 import { getProviderLabel } from "@/utils";
-import { Lightbulb, Eye, Globe } from "lucide-react";
+import { Eye, Globe } from "lucide-react";
 import { ModelCapability } from "@/constants";
 
 interface ModelDisplayProps {
@@ -26,14 +26,6 @@ export const ModelCapabilityIcons: React.FC<ModelCapabilityIconsProps> = ({
         .sort((a, b) => a.localeCompare(b))
         .map((cap) => {
           switch (cap) {
-            case ModelCapability.REASONING:
-              return (
-                <Lightbulb
-                  key={cap}
-                  className="tw-text-model-capabilities-blue"
-                  style={{ width: iconSize, height: iconSize }}
-                />
-              );
             case ModelCapability.VISION:
               return (
                 <Eye
@@ -85,8 +77,6 @@ export const getModelDisplayWithIcons = (model: CustomModel): string => {
     model.capabilities
       ?.map((cap) => {
         switch (cap) {
-          case ModelCapability.REASONING:
-            return "Reasoning";
           case ModelCapability.VISION:
             return "Vision";
           case ModelCapability.WEB_SEARCH:

--- a/src/components/ui/model-display.tsx
+++ b/src/components/ui/model-display.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { CustomModel } from "@/aiParams";
 import { getProviderLabel } from "@/utils";
-import { EyeOff, Globe } from "lucide-react";
+import { EyeOff } from "lucide-react";
 import { ModelCapability } from "@/constants";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 
@@ -18,16 +18,13 @@ interface ModelCapabilityIconsProps {
 const NO_VISION_LABEL = "This model does not support image inputs.";
 
 /**
- * Whether {@link ModelCapabilityIcons} would render at least one icon. Drives the
+ * Whether {@link ModelCapabilityIcons} would render the eye-off. Drives the
  * surrounding wrapper so it never renders empty (a vision-capable model shows no
  * icon) and never hides the eye-off for a model known to lack vision (`[]`).
  */
 export function hasCapabilityIcons(capabilities: ModelCapability[] | undefined): boolean {
   if (capabilities === undefined) return false;
-  return (
-    capabilities.includes(ModelCapability.WEB_SEARCH) ||
-    !capabilities.includes(ModelCapability.VISION)
-  );
+  return !capabilities.includes(ModelCapability.VISION);
 }
 
 /**
@@ -36,33 +33,22 @@ export function hasCapabilityIcons(capabilities: ModelCapability[] | undefined):
  * assert a missing capability we don't actually know about. A defined array is
  * "known": flag the absence of vision with a muted eye-off. Vision and reasoning
  * themselves render nothing — they're ubiquitous on modern models, so the only
- * vision signal we surface is the warning that a model can't take images.
+ * signal we surface is the warning that a model can't take images.
  */
 export const ModelCapabilityIcons: React.FC<ModelCapabilityIconsProps> = ({
   capabilities,
   iconSize = 16,
 }) => {
   if (capabilities === undefined) return null;
-  const showGlobe = capabilities.includes(ModelCapability.WEB_SEARCH);
-  const showNoVision = !capabilities.includes(ModelCapability.VISION);
+  if (capabilities.includes(ModelCapability.VISION)) return null;
   return (
-    <>
-      {showGlobe && (
-        <Globe
-          className="tw-text-model-capabilities-blue"
-          style={{ width: iconSize, height: iconSize }}
-        />
-      )}
-      {showNoVision && (
-        <HelpTooltip content={NO_VISION_LABEL} side="top">
-          <EyeOff
-            className="tw-text-muted"
-            style={{ width: iconSize, height: iconSize }}
-            data-testid="model-cap-no-vision"
-          />
-        </HelpTooltip>
-      )}
-    </>
+    <HelpTooltip content={NO_VISION_LABEL} side="top">
+      <EyeOff
+        className="tw-text-muted"
+        style={{ width: iconSize, height: iconSize }}
+        data-testid="model-cap-no-vision"
+      />
+    </HelpTooltip>
   );
 };
 
@@ -89,9 +75,5 @@ export const getModelDisplayText = (model: CustomModel): string => {
 export const getModelDisplayWithIcons = (model: CustomModel): string => {
   const displayName = model.displayName || model.name;
   const provider = `(${getProviderLabel(model.provider, model)})`;
-  const icons = (model.capabilities ?? [])
-    .map((cap) => (cap === ModelCapability.WEB_SEARCH ? "Websearch" : ""))
-    .filter(Boolean)
-    .join("|");
-  return `${displayName} ${provider} ${icons}`;
+  return `${displayName} ${provider}`;
 };

--- a/src/modelManagement/chatModel/modelCapabilityFlags.test.ts
+++ b/src/modelManagement/chatModel/modelCapabilityFlags.test.ts
@@ -1,0 +1,123 @@
+import { ModelCapability } from "@/constants";
+import type { ModelInfo } from "@/modelManagement/types/catalog";
+import {
+  applyCapsToModelInfo,
+  capabilityListFromModelInfo,
+  capsFromModelInfo,
+} from "./modelCapabilityFlags";
+
+describe("capsFromModelInfo", () => {
+  it("reads vision from an image input modality and reasoning from the flag", () => {
+    const info: ModelInfo = {
+      id: "m",
+      displayName: "M",
+      modalities: { input: ["text", "image"] },
+      reasoning: true,
+    };
+    expect(capsFromModelInfo(info)).toEqual({ vision: true, reasoning: true });
+  });
+
+  it("defaults both to false when metadata is absent", () => {
+    expect(capsFromModelInfo({ id: "m", displayName: "M" })).toEqual({
+      vision: false,
+      reasoning: false,
+    });
+  });
+
+  it("is false for vision when input has no image", () => {
+    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["text"] } };
+    expect(capsFromModelInfo(info).vision).toBe(false);
+  });
+});
+
+describe("capabilityListFromModelInfo", () => {
+  it("maps reasoning + vision to the capability enum values", () => {
+    const info: ModelInfo = {
+      id: "m",
+      displayName: "M",
+      modalities: { input: ["text", "image"] },
+      reasoning: true,
+    };
+    expect(capabilityListFromModelInfo(info)).toEqual([
+      ModelCapability.REASONING,
+      ModelCapability.VISION,
+    ]);
+  });
+
+  it("returns an empty list for a plain model", () => {
+    expect(capabilityListFromModelInfo({ id: "m", displayName: "M" })).toEqual([]);
+  });
+});
+
+describe("applyCapsToModelInfo", () => {
+  it("adds image while preserving other input modalities and output", () => {
+    const info: ModelInfo = {
+      id: "m",
+      displayName: "M",
+      modalities: { input: ["text", "audio"], output: ["text"] },
+    };
+    const next = applyCapsToModelInfo(info, { vision: true, reasoning: false });
+    expect(next.modalities?.input).toEqual(["text", "audio", "image"]);
+    expect(next.modalities?.output).toEqual(["text"]);
+    expect(next.reasoning).toBe(false);
+  });
+
+  it("removes image while preserving other input modalities", () => {
+    const info: ModelInfo = {
+      id: "m",
+      displayName: "M",
+      modalities: { input: ["text", "image"], output: ["text"] },
+    };
+    const next = applyCapsToModelInfo(info, { vision: false, reasoning: false });
+    expect(next.modalities?.input).toEqual(["text"]);
+    expect(next.modalities?.output).toEqual(["text"]);
+  });
+
+  it("does not duplicate image when already present", () => {
+    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["image"] } };
+    const next = applyCapsToModelInfo(info, { vision: true, reasoning: false });
+    expect(next.modalities?.input).toEqual(["image"]);
+  });
+
+  it("toggles reasoning independently", () => {
+    const info: ModelInfo = { id: "m", displayName: "M" };
+    expect(applyCapsToModelInfo(info, { vision: false, reasoning: true }).reasoning).toBe(true);
+    expect(applyCapsToModelInfo(info, { vision: false, reasoning: false }).reasoning).toBe(false);
+  });
+
+  it("adds image to a plain model that had no modalities at all", () => {
+    const info: ModelInfo = { id: "m", displayName: "M" };
+    const next = applyCapsToModelInfo(info, { vision: true, reasoning: false });
+    expect(next.modalities?.input).toEqual(["image"]);
+  });
+
+  it("omits modalities when input becomes empty and there is no output", () => {
+    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["image"] } };
+    const next = applyCapsToModelInfo(info, { vision: false, reasoning: false });
+    expect(next.modalities).toBeUndefined();
+  });
+
+  it("keeps an output-only modalities object when input clears", () => {
+    const info: ModelInfo = {
+      id: "m",
+      displayName: "M",
+      modalities: { input: ["image"], output: ["text"] },
+    };
+    const next = applyCapsToModelInfo(info, { vision: false, reasoning: false });
+    expect(next.modalities).toEqual({ output: ["text"] });
+  });
+
+  it("does not mutate the input object", () => {
+    const input = ["text"];
+    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input } };
+    applyCapsToModelInfo(info, { vision: true, reasoning: true });
+    expect(input).toEqual(["text"]);
+    expect(info.reasoning).toBeUndefined();
+  });
+
+  it("round-trips through capsFromModelInfo", () => {
+    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["text"] } };
+    const caps = { vision: true, reasoning: true };
+    expect(capsFromModelInfo(applyCapsToModelInfo(info, caps))).toEqual(caps);
+  });
+});

--- a/src/modelManagement/chatModel/modelCapabilityFlags.test.ts
+++ b/src/modelManagement/chatModel/modelCapabilityFlags.test.ts
@@ -1,34 +1,6 @@
 import { ModelCapability } from "@/constants";
 import type { ModelInfo } from "@/modelManagement/types/catalog";
-import {
-  applyCapsToModelInfo,
-  capabilityListFromModelInfo,
-  capsFromModelInfo,
-} from "./modelCapabilityFlags";
-
-describe("capsFromModelInfo", () => {
-  it("reads vision from an image input modality and reasoning from the flag", () => {
-    const info: ModelInfo = {
-      id: "m",
-      displayName: "M",
-      modalities: { input: ["text", "image"] },
-      reasoning: true,
-    };
-    expect(capsFromModelInfo(info)).toEqual({ vision: true, reasoning: true });
-  });
-
-  it("defaults both to false when metadata is absent", () => {
-    expect(capsFromModelInfo({ id: "m", displayName: "M" })).toEqual({
-      vision: false,
-      reasoning: false,
-    });
-  });
-
-  it("is false for vision when input has no image", () => {
-    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["text"] } };
-    expect(capsFromModelInfo(info).vision).toBe(false);
-  });
-});
+import { capabilityListFromModelInfo } from "./modelCapabilityFlags";
 
 describe("capabilityListFromModelInfo", () => {
   it("maps reasoning + vision to the capability enum values", () => {
@@ -44,80 +16,17 @@ describe("capabilityListFromModelInfo", () => {
     ]);
   });
 
+  it("reads vision from an image input modality only", () => {
+    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["text", "image"] } };
+    expect(capabilityListFromModelInfo(info)).toEqual([ModelCapability.VISION]);
+  });
+
+  it("is empty for an input without image", () => {
+    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["text"] } };
+    expect(capabilityListFromModelInfo(info)).toEqual([]);
+  });
+
   it("returns an empty list for a plain model", () => {
     expect(capabilityListFromModelInfo({ id: "m", displayName: "M" })).toEqual([]);
-  });
-});
-
-describe("applyCapsToModelInfo", () => {
-  it("adds image while preserving other input modalities and output", () => {
-    const info: ModelInfo = {
-      id: "m",
-      displayName: "M",
-      modalities: { input: ["text", "audio"], output: ["text"] },
-    };
-    const next = applyCapsToModelInfo(info, { vision: true, reasoning: false });
-    expect(next.modalities?.input).toEqual(["text", "audio", "image"]);
-    expect(next.modalities?.output).toEqual(["text"]);
-    expect(next.reasoning).toBe(false);
-  });
-
-  it("removes image while preserving other input modalities", () => {
-    const info: ModelInfo = {
-      id: "m",
-      displayName: "M",
-      modalities: { input: ["text", "image"], output: ["text"] },
-    };
-    const next = applyCapsToModelInfo(info, { vision: false, reasoning: false });
-    expect(next.modalities?.input).toEqual(["text"]);
-    expect(next.modalities?.output).toEqual(["text"]);
-  });
-
-  it("does not duplicate image when already present", () => {
-    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["image"] } };
-    const next = applyCapsToModelInfo(info, { vision: true, reasoning: false });
-    expect(next.modalities?.input).toEqual(["image"]);
-  });
-
-  it("toggles reasoning independently", () => {
-    const info: ModelInfo = { id: "m", displayName: "M" };
-    expect(applyCapsToModelInfo(info, { vision: false, reasoning: true }).reasoning).toBe(true);
-    expect(applyCapsToModelInfo(info, { vision: false, reasoning: false }).reasoning).toBe(false);
-  });
-
-  it("adds image to a plain model that had no modalities at all", () => {
-    const info: ModelInfo = { id: "m", displayName: "M" };
-    const next = applyCapsToModelInfo(info, { vision: true, reasoning: false });
-    expect(next.modalities?.input).toEqual(["image"]);
-  });
-
-  it("omits modalities when input becomes empty and there is no output", () => {
-    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["image"] } };
-    const next = applyCapsToModelInfo(info, { vision: false, reasoning: false });
-    expect(next.modalities).toBeUndefined();
-  });
-
-  it("keeps an output-only modalities object when input clears", () => {
-    const info: ModelInfo = {
-      id: "m",
-      displayName: "M",
-      modalities: { input: ["image"], output: ["text"] },
-    };
-    const next = applyCapsToModelInfo(info, { vision: false, reasoning: false });
-    expect(next.modalities).toEqual({ output: ["text"] });
-  });
-
-  it("does not mutate the input object", () => {
-    const input = ["text"];
-    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input } };
-    applyCapsToModelInfo(info, { vision: true, reasoning: true });
-    expect(input).toEqual(["text"]);
-    expect(info.reasoning).toBeUndefined();
-  });
-
-  it("round-trips through capsFromModelInfo", () => {
-    const info: ModelInfo = { id: "m", displayName: "M", modalities: { input: ["text"] } };
-    const caps = { vision: true, reasoning: true };
-    expect(capsFromModelInfo(applyCapsToModelInfo(info, caps))).toEqual(caps);
   });
 });

--- a/src/modelManagement/chatModel/modelCapabilityFlags.ts
+++ b/src/modelManagement/chatModel/modelCapabilityFlags.ts
@@ -1,0 +1,67 @@
+/**
+ * Pure helpers bridging a `ModelInfo`'s modality/reasoning metadata and the
+ * editable capability toggles surfaced in the BYOK "Advanced" panel.
+ *
+ * Single source of truth is `ModelInfo` itself: a user override is persisted by
+ * overlaying it back onto `modalities.input` / `reasoning` (no new field). The
+ * derivation here MUST match `configuredModelToCustomModel` so what the panel
+ * shows equals what the chat bridge derives into `CustomModel.capabilities`.
+ */
+import { ModelCapability } from "@/constants";
+import type { ModelInfo } from "@/modelManagement/types/catalog";
+
+export interface CapFlags {
+  vision: boolean;
+  reasoning: boolean;
+}
+
+const IMAGE_MODALITY = "image";
+
+const EMPTY_CAPABILITY_LIST: ModelCapability[] = Object.freeze([]) as unknown as ModelCapability[];
+
+export function capsFromModelInfo(info: ModelInfo): CapFlags {
+  return {
+    vision: !!info.modalities?.input?.includes(IMAGE_MODALITY),
+    reasoning: !!info.reasoning,
+  };
+}
+
+export function capabilityListFromModelInfo(info: ModelInfo): ModelCapability[] {
+  const caps = capsFromModelInfo(info);
+  if (!caps.reasoning && !caps.vision) return EMPTY_CAPABILITY_LIST;
+  const list: ModelCapability[] = [];
+  if (caps.reasoning) list.push(ModelCapability.REASONING);
+  if (caps.vision) list.push(ModelCapability.VISION);
+  return list;
+}
+
+/**
+ * Return a NEW `ModelInfo` with `reasoning` and `modalities.input` adjusted to
+ * reflect `caps`. Other input modalities (e.g. "text", "audio") and the
+ * existing `output` array are preserved; the input object is never mutated.
+ */
+export function applyCapsToModelInfo(info: ModelInfo, caps: CapFlags): ModelInfo {
+  const prevInput = info.modalities?.input ?? [];
+  const withoutImage = prevInput.filter((m) => m !== IMAGE_MODALITY);
+  const nextInput = caps.vision ? [...withoutImage, IMAGE_MODALITY] : withoutImage;
+
+  const prevOutput = info.modalities?.output;
+  // Only attach `modalities` when there's something to carry, so a plain model
+  // doesn't grow an empty `{ input: [] }` that the bridge would treat as no-op
+  // anyway — keeps the persisted snapshot minimal.
+  const nextModalities =
+    nextInput.length > 0 || prevOutput !== undefined
+      ? {
+          ...(nextInput.length > 0 ? { input: nextInput } : {}),
+          ...(prevOutput !== undefined ? { output: prevOutput } : {}),
+        }
+      : undefined;
+
+  const next: ModelInfo = { ...info, reasoning: caps.reasoning };
+  if (nextModalities) {
+    next.modalities = nextModalities;
+  } else {
+    delete next.modalities;
+  }
+  return next;
+}

--- a/src/modelManagement/chatModel/modelCapabilityFlags.ts
+++ b/src/modelManagement/chatModel/modelCapabilityFlags.ts
@@ -36,6 +36,18 @@ export function capabilityListFromModelInfo(info: ModelInfo): ModelCapability[] 
 }
 
 /**
+ * Capabilities for a persisted/configured model, or `undefined` when the
+ * snapshot carries no modality data at all. The presence of `modalities`
+ * is what distinguishes "known to lack vision" (returns a list without
+ * `VISION`) from "unknown" (`undefined`) — the latter lets a caller fall
+ * back to the live catalog instead of asserting no vision. Used by the agent
+ * pickers so a model's vision icon comes from its own `info` first.
+ */
+export function capabilitiesFromConfiguredInfo(info: ModelInfo): ModelCapability[] | undefined {
+  return info.modalities ? capabilityListFromModelInfo(info) : undefined;
+}
+
+/**
  * Return a NEW `ModelInfo` with `reasoning` and `modalities.input` adjusted to
  * reflect `caps`. Other input modalities (e.g. "text", "audio") and the
  * existing `output` array are preserved; the input object is never mutated.

--- a/src/modelManagement/chatModel/modelCapabilityFlags.ts
+++ b/src/modelManagement/chatModel/modelCapabilityFlags.ts
@@ -1,37 +1,25 @@
 /**
- * Pure helpers bridging a `ModelInfo`'s modality/reasoning metadata and the
- * editable capability toggles surfaced in the BYOK "Advanced" panel.
- *
- * Single source of truth is `ModelInfo` itself: a user override is persisted by
- * overlaying it back onto `modalities.input` / `reasoning` (no new field). The
- * derivation here MUST match `configuredModelToCustomModel` so what the panel
- * shows equals what the chat bridge derives into `CustomModel.capabilities`.
+ * Pure helpers deriving a model's capabilities from its `ModelInfo`
+ * modality/reasoning metadata. `ModelInfo` is the single source of truth:
+ * vision is `modalities.input` containing `"image"`, reasoning is the
+ * `reasoning` flag. The derivation here MUST match `configuredModelToCustomModel`
+ * so what the pickers show equals what the chat bridge derives into
+ * `CustomModel.capabilities`.
  */
 import { ModelCapability } from "@/constants";
 import type { ModelInfo } from "@/modelManagement/types/catalog";
-
-export interface CapFlags {
-  vision: boolean;
-  reasoning: boolean;
-}
 
 const IMAGE_MODALITY = "image";
 
 const EMPTY_CAPABILITY_LIST: ModelCapability[] = Object.freeze([]) as unknown as ModelCapability[];
 
-export function capsFromModelInfo(info: ModelInfo): CapFlags {
-  return {
-    vision: !!info.modalities?.input?.includes(IMAGE_MODALITY),
-    reasoning: !!info.reasoning,
-  };
-}
-
 export function capabilityListFromModelInfo(info: ModelInfo): ModelCapability[] {
-  const caps = capsFromModelInfo(info);
-  if (!caps.reasoning && !caps.vision) return EMPTY_CAPABILITY_LIST;
+  const reasoning = !!info.reasoning;
+  const vision = !!info.modalities?.input?.includes(IMAGE_MODALITY);
+  if (!reasoning && !vision) return EMPTY_CAPABILITY_LIST;
   const list: ModelCapability[] = [];
-  if (caps.reasoning) list.push(ModelCapability.REASONING);
-  if (caps.vision) list.push(ModelCapability.VISION);
+  if (reasoning) list.push(ModelCapability.REASONING);
+  if (vision) list.push(ModelCapability.VISION);
   return list;
 }
 
@@ -45,35 +33,4 @@ export function capabilityListFromModelInfo(info: ModelInfo): ModelCapability[] 
  */
 export function capabilitiesFromConfiguredInfo(info: ModelInfo): ModelCapability[] | undefined {
   return info.modalities ? capabilityListFromModelInfo(info) : undefined;
-}
-
-/**
- * Return a NEW `ModelInfo` with `reasoning` and `modalities.input` adjusted to
- * reflect `caps`. Other input modalities (e.g. "text", "audio") and the
- * existing `output` array are preserved; the input object is never mutated.
- */
-export function applyCapsToModelInfo(info: ModelInfo, caps: CapFlags): ModelInfo {
-  const prevInput = info.modalities?.input ?? [];
-  const withoutImage = prevInput.filter((m) => m !== IMAGE_MODALITY);
-  const nextInput = caps.vision ? [...withoutImage, IMAGE_MODALITY] : withoutImage;
-
-  const prevOutput = info.modalities?.output;
-  // Only attach `modalities` when there's something to carry, so a plain model
-  // doesn't grow an empty `{ input: [] }` that the bridge would treat as no-op
-  // anyway — keeps the persisted snapshot minimal.
-  const nextModalities =
-    nextInput.length > 0 || prevOutput !== undefined
-      ? {
-          ...(nextInput.length > 0 ? { input: nextInput } : {}),
-          ...(prevOutput !== undefined ? { output: prevOutput } : {}),
-        }
-      : undefined;
-
-  const next: ModelInfo = { ...info, reasoning: caps.reasoning };
-  if (nextModalities) {
-    next.modalities = nextModalities;
-  } else {
-    delete next.modalities;
-  }
-  return next;
 }

--- a/src/modelManagement/index.ts
+++ b/src/modelManagement/index.ts
@@ -49,6 +49,10 @@ export {
 export type { ResolvedChatBackendEntry } from "./chatModel/chatModelSelection";
 export { resolveChatBackendModel } from "./chatModel/resolveChatBackendModel";
 export type { ChatBackendResolution } from "./chatModel/resolveChatBackendModel";
+export {
+  capabilityListFromModelInfo,
+  capabilitiesFromConfiguredInfo,
+} from "./chatModel/modelCapabilityFlags";
 
 // ---------------------------------------------------------------------------
 // Provider adapter contract

--- a/src/modelManagement/ui/components/ByokGlobalTable.test.tsx
+++ b/src/modelManagement/ui/components/ByokGlobalTable.test.tsx
@@ -73,6 +73,47 @@ describe("ByokGlobalTable", () => {
     expect(screen.getByText("Embedding")).toBeTruthy();
   });
 
+  it("badges the no-vision exception on text-only rows but not vision rows", () => {
+    const withModalities: ByokTableGroup = {
+      ...group,
+      models: [
+        {
+          configuredModelId: "text-only",
+          providerId: "p1",
+          info: {
+            id: "text-only",
+            displayName: "Text Only",
+            modalities: { input: ["text"] },
+          },
+          configuredAt: 0,
+        },
+        {
+          configuredModelId: "vision",
+          providerId: "p1",
+          info: {
+            id: "vision",
+            displayName: "Vision Model",
+            modalities: { input: ["text", "image"] },
+          },
+          configuredAt: 0,
+        },
+      ],
+    };
+    render(
+      <ByokGlobalTable groups={[withModalities]} onConfigure={jest.fn()} onRemove={jest.fn()} />
+    );
+    // A model KNOWN to lack image input shows the muted eye-off.
+    expect(
+      screen
+        .getByTestId("byok-model-text-only")
+        .querySelector('[data-testid="model-cap-no-vision"]')
+    ).not.toBeNull();
+    // A vision-capable model is the norm and shows no capability icon.
+    expect(
+      screen.getByTestId("byok-model-vision").querySelector('[data-testid="model-cap-no-vision"]')
+    ).toBeNull();
+  });
+
   it("collapses the model rows when the section header is clicked", () => {
     render(<ByokGlobalTable groups={[group]} onConfigure={jest.fn()} onRemove={jest.fn()} />);
     expect(screen.getByText("Claude Sonnet 4.5")).toBeTruthy();

--- a/src/modelManagement/ui/components/ByokGlobalTable.tsx
+++ b/src/modelManagement/ui/components/ByokGlobalTable.tsx
@@ -15,7 +15,9 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { ModelCapabilityIcons, hasCapabilityIcons } from "@/components/ui/model-display";
 import { cn } from "@/lib/utils";
+import { capabilitiesFromConfiguredInfo } from "@/modelManagement/chatModel/modelCapabilityFlags";
 import type { ConfiguredModel, Provider } from "@/modelManagement/types/persisted";
 import {
   formatContextWindow,
@@ -193,6 +195,7 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
 const ModelRow: React.FC<{ model: ConfiguredModel }> = ({ model }) => {
   const contextLabel = formatContextWindow(model.info.limits?.context);
   const releaseLabel = formatReleaseDate(model.info.releaseDate);
+  const capabilities = capabilitiesFromConfiguredInfo(model.info);
   return (
     <div
       role="row"
@@ -208,6 +211,11 @@ const ModelRow: React.FC<{ model: ConfiguredModel }> = ({ model }) => {
           <Badge variant="secondary" className="tw-shrink-0 tw-text-ui-smaller">
             Embedding
           </Badge>
+        )}
+        {hasCapabilityIcons(capabilities) && (
+          <span className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
+            <ModelCapabilityIcons capabilities={capabilities} iconSize={14} />
+          </span>
         )}
       </div>
       <span className="tw-shrink-0 tw-text-xs tw-text-muted">{contextLabel}</span>

--- a/src/modelManagement/ui/components/ModelChecklist.test.tsx
+++ b/src/modelManagement/ui/components/ModelChecklist.test.tsx
@@ -47,7 +47,7 @@ describe("ModelChecklist", () => {
     expect(screen.getByText("Embedding")).toBeTruthy();
   });
 
-  it("renders read-only capability icons derived from ModelInfo", () => {
+  it("renders read-only vision icon, but never a reasoning icon", () => {
     const VISION_REASON: ModelInfo = {
       id: "omni",
       displayName: "Omni",
@@ -63,8 +63,9 @@ describe("ModelChecklist", () => {
       />
     );
     const omniRow = screen.getByTestId("model-row-omni");
-    // Lightbulb (reasoning) + Eye (vision) render as two SVG icons.
-    expect(omniRow.querySelectorAll("svg").length).toBe(2);
+    // Only the Eye (vision) icon renders — reasoning is ubiquitous and is
+    // intentionally not shown, even though it's still derived for runtime.
+    expect(omniRow.querySelectorAll("svg").length).toBe(1);
     // A plain model shows no capability icons.
     expect(screen.getByTestId("model-row-gpt-5").querySelectorAll("svg").length).toBe(0);
     expect(container).toBeTruthy();

--- a/src/modelManagement/ui/components/ModelChecklist.test.tsx
+++ b/src/modelManagement/ui/components/ModelChecklist.test.tsx
@@ -47,6 +47,29 @@ describe("ModelChecklist", () => {
     expect(screen.getByText("Embedding")).toBeTruthy();
   });
 
+  it("renders read-only capability icons derived from ModelInfo", () => {
+    const VISION_REASON: ModelInfo = {
+      id: "omni",
+      displayName: "Omni",
+      modalities: { input: ["text", "image"] },
+      reasoning: true,
+    };
+    const { container } = render(
+      <ModelChecklist
+        availableModels={[VISION_REASON, PLAIN]}
+        selected={new Set<string>()}
+        onToggle={jest.fn()}
+        onAddId={jest.fn()}
+      />
+    );
+    const omniRow = screen.getByTestId("model-row-omni");
+    // Lightbulb (reasoning) + Eye (vision) render as two SVG icons.
+    expect(omniRow.querySelectorAll("svg").length).toBe(2);
+    // A plain model shows no capability icons.
+    expect(screen.getByTestId("model-row-gpt-5").querySelectorAll("svg").length).toBe(0);
+    expect(container).toBeTruthy();
+  });
+
   it("emits onToggle with the wire id when a checkbox is clicked", () => {
     const onToggle = jest.fn();
     renderList({ availableModels: [PLAIN], onToggle });

--- a/src/modelManagement/ui/components/ModelChecklist.test.tsx
+++ b/src/modelManagement/ui/components/ModelChecklist.test.tsx
@@ -47,28 +47,36 @@ describe("ModelChecklist", () => {
     expect(screen.getByText("Embedding")).toBeTruthy();
   });
 
-  it("renders read-only vision icon, but never a reasoning icon", () => {
+  it("badges only the no-vision exception: nothing for vision or unknown, an eye-off for known text-only", () => {
     const VISION_REASON: ModelInfo = {
       id: "omni",
       displayName: "Omni",
       modalities: { input: ["text", "image"] },
       reasoning: true,
     };
-    const { container } = render(
+    const TEXT_ONLY: ModelInfo = {
+      id: "text-only",
+      displayName: "Text Only",
+      modalities: { input: ["text"] },
+    };
+    render(
       <ModelChecklist
-        availableModels={[VISION_REASON, PLAIN]}
+        availableModels={[VISION_REASON, TEXT_ONLY, PLAIN]}
         selected={new Set<string>()}
         onToggle={jest.fn()}
         onAddId={jest.fn()}
       />
     );
-    const omniRow = screen.getByTestId("model-row-omni");
-    // Only the Eye (vision) icon renders — reasoning is ubiquitous and is
-    // intentionally not shown, even though it's still derived for runtime.
-    expect(omniRow.querySelectorAll("svg").length).toBe(1);
-    // A plain model shows no capability icons.
+    // Vision is the norm (not badged) and reasoning is hidden — a vision-capable
+    // model shows no capability icon.
+    expect(screen.getByTestId("model-row-omni").querySelectorAll("svg").length).toBe(0);
+    // A model KNOWN to lack image input shows the muted eye-off.
+    expect(
+      screen.getByTestId("model-row-text-only").querySelector('[data-testid="model-cap-no-vision"]')
+    ).not.toBeNull();
+    // A model whose snapshot has no modality data is "unknown" — render nothing,
+    // never assert a missing capability.
     expect(screen.getByTestId("model-row-gpt-5").querySelectorAll("svg").length).toBe(0);
-    expect(container).toBeTruthy();
   });
 
   it("emits onToggle with the wire id when a checkbox is clicked", () => {

--- a/src/modelManagement/ui/components/ModelChecklist.tsx
+++ b/src/modelManagement/ui/components/ModelChecklist.tsx
@@ -15,7 +15,9 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { ModelCapabilityIcons } from "@/components/ui/model-display";
 import { cn } from "@/lib/utils";
+import { capabilityListFromModelInfo } from "@/modelManagement/chatModel/modelCapabilityFlags";
 import type { ModelInfo } from "@/modelManagement/types/catalog";
 import {
   formatContextWindow,
@@ -117,6 +119,7 @@ export const ModelChecklist: React.FC<ModelChecklistProps> = ({
             const releaseLabel = formatReleaseDate(model.releaseDate);
             const isLastChecked = index === checkedCount - 1 && checkedCount < filtered.length;
             const removable = onRemoveId !== undefined && customIds?.has(model.id) === true;
+            const capabilities = capabilityListFromModelInfo(model);
             return (
               <label
                 key={model.id}
@@ -141,6 +144,11 @@ export const ModelChecklist: React.FC<ModelChecklistProps> = ({
                     <Badge variant="secondary" className="tw-shrink-0 tw-text-ui-smaller">
                       Embedding
                     </Badge>
+                  )}
+                  {capabilities.length > 0 && (
+                    <span className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
+                      <ModelCapabilityIcons capabilities={capabilities} iconSize={14} />
+                    </span>
                   )}
                 </span>
                 <span className="tw-shrink-0 tw-text-xs tw-text-muted">{contextLabel}</span>

--- a/src/modelManagement/ui/components/ModelChecklist.tsx
+++ b/src/modelManagement/ui/components/ModelChecklist.tsx
@@ -15,9 +15,9 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-import { ModelCapabilityIcons } from "@/components/ui/model-display";
+import { ModelCapabilityIcons, hasCapabilityIcons } from "@/components/ui/model-display";
 import { cn } from "@/lib/utils";
-import { capabilityListFromModelInfo } from "@/modelManagement/chatModel/modelCapabilityFlags";
+import { capabilitiesFromConfiguredInfo } from "@/modelManagement/chatModel/modelCapabilityFlags";
 import type { ModelInfo } from "@/modelManagement/types/catalog";
 import {
   formatContextWindow,
@@ -119,7 +119,7 @@ export const ModelChecklist: React.FC<ModelChecklistProps> = ({
             const releaseLabel = formatReleaseDate(model.releaseDate);
             const isLastChecked = index === checkedCount - 1 && checkedCount < filtered.length;
             const removable = onRemoveId !== undefined && customIds?.has(model.id) === true;
-            const capabilities = capabilityListFromModelInfo(model);
+            const capabilities = capabilitiesFromConfiguredInfo(model);
             return (
               <label
                 key={model.id}
@@ -145,7 +145,7 @@ export const ModelChecklist: React.FC<ModelChecklistProps> = ({
                       Embedding
                     </Badge>
                   )}
-                  {capabilities.length > 0 && (
+                  {hasCapabilityIcons(capabilities) && (
                     <span className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
                       <ModelCapabilityIcons capabilities={capabilities} iconSize={14} />
                     </span>

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
@@ -60,16 +60,6 @@ jest.mock("@/modelManagement/state/atoms", () => {
         origin: { kind: "byok" },
         addedAt: 0,
       },
-      {
-        // Risk R1 fixture: a saved model carries a vision override the catalog
-        // metadata disagrees with. Re-saving must preserve the saved caps.
-        providerId: "p-vision",
-        providerType: "anthropic",
-        displayName: "Vision Provider",
-        baseUrl: "https://api.anthropic.com",
-        origin: { kind: "byok", catalogProviderId: "vision" },
-        addedAt: 0,
-      },
     ]),
     configuredModelsAtom: jotai.atom([
       {
@@ -86,18 +76,6 @@ jest.mock("@/modelManagement/state/atoms", () => {
         configuredModelId: "cm2",
         providerId: "p1",
         info: { id: "claude-opus", displayName: "Claude Opus 4.5" },
-        configuredAt: 0,
-      },
-      {
-        // Risk R1: saved snapshot has vision (image input) — the catalog
-        // metadata for the same id lacks it (see visionCatalogMetadata).
-        configuredModelId: "cm-vision",
-        providerId: "p-vision",
-        info: {
-          id: "seer",
-          displayName: "Seer",
-          modalities: { input: ["text", "image"], output: ["text"] },
-        },
         configuredAt: 0,
       },
     ]),
@@ -176,18 +154,6 @@ const anthropicCatalogMetadata = {
     "claude-opus": { id: "claude-opus", displayName: "Claude Opus 4.5" },
     "claude-haiku": { id: "claude-haiku", displayName: "Claude Haiku 4.5" },
     "voyage-embed": { id: "voyage-embed", displayName: "Voyage Embed", isEmbedding: true },
-  },
-};
-
-// R1: the catalog masks the saved vision (no image input) for the same id, so
-// the catalog-first resolver would drop a prior override absent the overlay fix.
-const visionCatalogMetadata = {
-  id: "vision",
-  displayName: "Vision Provider",
-  providerType: "anthropic" as const,
-  defaultBaseUrl: "https://api.anthropic.com",
-  models: {
-    seer: { id: "seer", displayName: "Seer", modalities: { input: ["text"], output: ["text"] } },
   },
 };
 
@@ -530,105 +496,6 @@ describe("ConfigureProviderForm (edit mode)", () => {
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true)
     );
-  });
-});
-
-describe("ConfigureProviderForm (Advanced capability overrides)", () => {
-  function expandAdvanced(): void {
-    fireEvent.click(screen.getByTestId("advanced-toggle"));
-  }
-
-  it("lists each selected non-embedding model with a vision toggle", async () => {
-    mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
-    expandAdvanced();
-    expect(screen.getByTestId("advanced-row-claude-sonnet")).toBeTruthy();
-    expect(screen.getByTestId("advanced-vision-claude-sonnet")).toBeTruthy();
-    // Reasoning is no longer surfaced as a toggle (ubiquitous; kept runtime-only).
-    expect(screen.queryByTestId("advanced-reasoning-claude-sonnet")).toBeNull();
-  });
-
-  it("shows an empty hint when no models are selected", async () => {
-    mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["llama3.2"] });
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(screen.getByTestId("model-row-llama3.2")).toBeTruthy());
-    expandAdvanced();
-    expect(screen.getByTestId("advanced-empty")).toBeTruthy();
-  });
-
-  it("excludes embedding models from the panel", async () => {
-    mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
-    mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["voyage-embed"] });
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(screen.getByTestId("model-row-voyage-embed")).toBeTruthy());
-    fireEvent.click(rowCheckbox("voyage-embed"));
-    expandAdvanced();
-    expect(screen.queryByTestId("advanced-row-voyage-embed")).toBeNull();
-  });
-
-  it("persists a vision override onto a catalog model that lacked it", async () => {
-    mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
-    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
-    const onClose = jest.fn();
-    render(
-      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={onClose} />
-    );
-    fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-ant" } });
-    manualAddId("claude-sonnet");
-    expandAdvanced();
-    // claude-sonnet has no vision in the catalog — turn it on.
-    fireEvent.click(screen.getByTestId("advanced-vision-claude-sonnet"));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(mockSetupProvider).toHaveBeenCalled());
-    const saved = mockSetupProvider.mock.calls[0][0] as { models: Array<{ id: string }> };
-    const seer = saved.models.find((m) => m.id === "claude-sonnet") as {
-      modalities?: { input?: string[] };
-    };
-    expect(seer.modalities?.input).toContain("image");
-  });
-
-  it("R1: re-saving an untouched model preserves a saved vision override against catalog precedence", async () => {
-    // p-vision's saved model has image input; its catalog metadata (resolved
-    // via getProvider) does not. The user never opens Advanced — the overlay
-    // must still re-assert the saved caps.
-    mockGetProvider.mockReturnValue(visionCatalogMetadata);
-    mockBulkSet.mockResolvedValue(["cm-vision"]);
-    const onClose = jest.fn();
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p-vision" }} onClose={onClose} />
-    );
-    await waitFor(() => expect(rowCheckbox("seer").getAttribute("aria-checked")).toBe("true"));
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(mockBulkSet).toHaveBeenCalled());
-    const [, infos] = mockBulkSet.mock.calls[0] as [string, Array<{ id: string }>];
-    const seer = infos.find((m) => m.id === "seer") as { modalities?: { input?: string[] } };
-    expect(seer.modalities?.input).toContain("image");
-  });
-
-  it("R1: toggling vision off on a saved-vision model drops image on re-save", async () => {
-    mockGetProvider.mockReturnValue(visionCatalogMetadata);
-    mockBulkSet.mockResolvedValue(["cm-vision"]);
-    render(
-      <ConfigureProviderForm state={{ mode: "edit", providerId: "p-vision" }} onClose={jest.fn()} />
-    );
-    await waitFor(() => expect(screen.getByTestId("model-row-seer")).toBeTruthy());
-    expandAdvanced();
-    // The toggle seeds from the SAVED caps (vision on), so a click turns it off.
-    const visionToggle = screen.getByTestId("advanced-vision-seer");
-    expect(visionToggle.getAttribute("aria-checked")).toBe("true");
-    fireEvent.click(visionToggle);
-    fireEvent.click(screen.getByRole("button", { name: "Save" }));
-    await waitFor(() => expect(mockBulkSet).toHaveBeenCalled());
-    const [, infos] = mockBulkSet.mock.calls[0] as [string, Array<{ id: string }>];
-    const seer = infos.find((m) => m.id === "seer") as { modalities?: { input?: string[] } };
-    expect(seer.modalities?.input ?? []).not.toContain("image");
   });
 });
 

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
@@ -29,7 +29,11 @@ jest.mock("@/modelManagement/ui/ModelManagementContext", () => ({
     configuredModelRegistry: { bulkSet: mockBulkSet },
     backendConfigRegistry: { enableModel: mockEnableModel, removeRefs: mockRemoveRefs },
     coordinator: { removeProvider: jest.fn() },
-    catalogService: { getProvider: mockGetProvider },
+    catalogService: {
+      getProvider: mockGetProvider,
+      ensureLoaded: jest.fn().mockResolvedValue(undefined),
+      onChange: jest.fn().mockReturnValue(() => {}),
+    },
   }),
 }));
 // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real `useApp` hook; the name must match the export
@@ -534,7 +538,7 @@ describe("ConfigureProviderForm (Advanced capability overrides)", () => {
     fireEvent.click(screen.getByTestId("advanced-toggle"));
   }
 
-  it("lists each selected non-embedding model with vision + reasoning toggles", async () => {
+  it("lists each selected non-embedding model with a vision toggle", async () => {
     mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
     render(
       <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
@@ -543,7 +547,8 @@ describe("ConfigureProviderForm (Advanced capability overrides)", () => {
     expandAdvanced();
     expect(screen.getByTestId("advanced-row-claude-sonnet")).toBeTruthy();
     expect(screen.getByTestId("advanced-vision-claude-sonnet")).toBeTruthy();
-    expect(screen.getByTestId("advanced-reasoning-claude-sonnet")).toBeTruthy();
+    // Reasoning is no longer surfaced as a toggle (ubiquitous; kept runtime-only).
+    expect(screen.queryByTestId("advanced-reasoning-claude-sonnet")).toBeNull();
   });
 
   it("shows an empty hint when no models are selected", async () => {

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
@@ -56,6 +56,16 @@ jest.mock("@/modelManagement/state/atoms", () => {
         origin: { kind: "byok" },
         addedAt: 0,
       },
+      {
+        // Risk R1 fixture: a saved model carries a vision override the catalog
+        // metadata disagrees with. Re-saving must preserve the saved caps.
+        providerId: "p-vision",
+        providerType: "anthropic",
+        displayName: "Vision Provider",
+        baseUrl: "https://api.anthropic.com",
+        origin: { kind: "byok", catalogProviderId: "vision" },
+        addedAt: 0,
+      },
     ]),
     configuredModelsAtom: jotai.atom([
       {
@@ -72,6 +82,18 @@ jest.mock("@/modelManagement/state/atoms", () => {
         configuredModelId: "cm2",
         providerId: "p1",
         info: { id: "claude-opus", displayName: "Claude Opus 4.5" },
+        configuredAt: 0,
+      },
+      {
+        // Risk R1: saved snapshot has vision (image input) — the catalog
+        // metadata for the same id lacks it (see visionCatalogMetadata).
+        configuredModelId: "cm-vision",
+        providerId: "p-vision",
+        info: {
+          id: "seer",
+          displayName: "Seer",
+          modalities: { input: ["text", "image"], output: ["text"] },
+        },
         configuredAt: 0,
       },
     ]),
@@ -150,6 +172,18 @@ const anthropicCatalogMetadata = {
     "claude-opus": { id: "claude-opus", displayName: "Claude Opus 4.5" },
     "claude-haiku": { id: "claude-haiku", displayName: "Claude Haiku 4.5" },
     "voyage-embed": { id: "voyage-embed", displayName: "Voyage Embed", isEmbedding: true },
+  },
+};
+
+// R1: the catalog masks the saved vision (no image input) for the same id, so
+// the catalog-first resolver would drop a prior override absent the overlay fix.
+const visionCatalogMetadata = {
+  id: "vision",
+  displayName: "Vision Provider",
+  providerType: "anthropic" as const,
+  defaultBaseUrl: "https://api.anthropic.com",
+  models: {
+    seer: { id: "seer", displayName: "Seer", modalities: { input: ["text"], output: ["text"] } },
   },
 };
 
@@ -492,6 +526,104 @@ describe("ConfigureProviderForm (edit mode)", () => {
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true)
     );
+  });
+});
+
+describe("ConfigureProviderForm (Advanced capability overrides)", () => {
+  function expandAdvanced(): void {
+    fireEvent.click(screen.getByTestId("advanced-toggle"));
+  }
+
+  it("lists each selected non-embedding model with vision + reasoning toggles", async () => {
+    mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
+    render(
+      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
+    );
+    await waitFor(() => expect(screen.getByTestId("model-row-claude-sonnet")).toBeTruthy());
+    expandAdvanced();
+    expect(screen.getByTestId("advanced-row-claude-sonnet")).toBeTruthy();
+    expect(screen.getByTestId("advanced-vision-claude-sonnet")).toBeTruthy();
+    expect(screen.getByTestId("advanced-reasoning-claude-sonnet")).toBeTruthy();
+  });
+
+  it("shows an empty hint when no models are selected", async () => {
+    mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["llama3.2"] });
+    render(
+      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
+    );
+    await waitFor(() => expect(screen.getByTestId("model-row-llama3.2")).toBeTruthy());
+    expandAdvanced();
+    expect(screen.getByTestId("advanced-empty")).toBeTruthy();
+  });
+
+  it("excludes embedding models from the panel", async () => {
+    mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
+    mockListProviderModels.mockResolvedValue({ ok: true, modelIds: ["voyage-embed"] });
+    render(
+      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
+    );
+    await waitFor(() => expect(screen.getByTestId("model-row-voyage-embed")).toBeTruthy());
+    fireEvent.click(rowCheckbox("voyage-embed"));
+    expandAdvanced();
+    expect(screen.queryByTestId("advanced-row-voyage-embed")).toBeNull();
+  });
+
+  it("persists a vision override onto a catalog model that lacked it", async () => {
+    mockGetProvider.mockReturnValue(anthropicCatalogMetadata);
+    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+    const onClose = jest.fn();
+    render(
+      <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={onClose} />
+    );
+    fireEvent.change(screen.getByTestId("api-key"), { target: { value: "sk-ant" } });
+    manualAddId("claude-sonnet");
+    expandAdvanced();
+    // claude-sonnet has no vision in the catalog — turn it on.
+    fireEvent.click(screen.getByTestId("advanced-vision-claude-sonnet"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockSetupProvider).toHaveBeenCalled());
+    const saved = mockSetupProvider.mock.calls[0][0] as { models: Array<{ id: string }> };
+    const seer = saved.models.find((m) => m.id === "claude-sonnet") as {
+      modalities?: { input?: string[] };
+    };
+    expect(seer.modalities?.input).toContain("image");
+  });
+
+  it("R1: re-saving an untouched model preserves a saved vision override against catalog precedence", async () => {
+    // p-vision's saved model has image input; its catalog metadata (resolved
+    // via getProvider) does not. The user never opens Advanced — the overlay
+    // must still re-assert the saved caps.
+    mockGetProvider.mockReturnValue(visionCatalogMetadata);
+    mockBulkSet.mockResolvedValue(["cm-vision"]);
+    const onClose = jest.fn();
+    render(
+      <ConfigureProviderForm state={{ mode: "edit", providerId: "p-vision" }} onClose={onClose} />
+    );
+    await waitFor(() => expect(rowCheckbox("seer").getAttribute("aria-checked")).toBe("true"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockBulkSet).toHaveBeenCalled());
+    const [, infos] = mockBulkSet.mock.calls[0] as [string, Array<{ id: string }>];
+    const seer = infos.find((m) => m.id === "seer") as { modalities?: { input?: string[] } };
+    expect(seer.modalities?.input).toContain("image");
+  });
+
+  it("R1: toggling vision off on a saved-vision model drops image on re-save", async () => {
+    mockGetProvider.mockReturnValue(visionCatalogMetadata);
+    mockBulkSet.mockResolvedValue(["cm-vision"]);
+    render(
+      <ConfigureProviderForm state={{ mode: "edit", providerId: "p-vision" }} onClose={jest.fn()} />
+    );
+    await waitFor(() => expect(screen.getByTestId("model-row-seer")).toBeTruthy());
+    expandAdvanced();
+    // The toggle seeds from the SAVED caps (vision on), so a click turns it off.
+    const visionToggle = screen.getByTestId("advanced-vision-seer");
+    expect(visionToggle.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(visionToggle);
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() => expect(mockBulkSet).toHaveBeenCalled());
+    const [, infos] = mockBulkSet.mock.calls[0] as [string, Array<{ id: string }>];
+    const seer = infos.find((m) => m.id === "seer") as { modalities?: { input?: string[] } };
+    expect(seer.modalities?.input ?? []).not.toContain("image");
   });
 });
 

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -24,12 +24,16 @@ import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { ReactModal } from "@/components/modals/ReactModal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { SearchBar } from "@/components/ui/SearchBar";
+import { SettingSwitch } from "@/components/ui/setting-switch";
 import { useApp } from "@/context";
+import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
+import { capsFromModelInfo, type CapFlags } from "@/modelManagement/chatModel/modelCapabilityFlags";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
 import { BYOK_DEFAULT_AUTO_ENROLL } from "@/modelManagement/setup/ByokSetupApi";
 import { providerRequiresApiKey } from "@/modelManagement/providers/providerRequiresApiKey";
@@ -44,9 +48,9 @@ import {
 } from "@/modelManagement/ui/ModelManagementContext";
 import { settingsStore } from "@/settings/model";
 import { useAtomValue } from "jotai";
-import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { CheckCircle2, ChevronDown, Loader2, XCircle } from "lucide-react";
 import { App, Notice } from "obsidian";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useModelCandidatePool } from "./useModelCandidatePool";
 
 /**
@@ -206,6 +210,11 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [modelQuery, setModelQuery] = useState("");
+  // User-edited capability overrides from the Advanced panel, keyed by wire id.
+  // Only ids the user actually toggled live here; untouched selected models
+  // fall through to their effective (catalog/saved) caps in the pool's overlay.
+  const [capOverrides, setCapOverrides] = useState<Record<string, CapFlags>>({});
+  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   // Whether this provider needs a key. New mode reads the picked definition;
   // edit mode reads the explicit persisted flag — never inferred from the
@@ -232,8 +241,46 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
     extras,
     requiresApiKey,
     providerHydrated: state.mode === "edit" ? !!provider : true,
+    capOverrides,
     api,
   });
+
+  // Saved snapshots by wire id. In edit mode the user's previously-saved caps
+  // live here; the catalog-first `resolveModelInfo` would otherwise mask a
+  // prior override (Risk R1), so the Advanced panel seeds from the saved
+  // snapshot when present and falls back to the catalog/synth resolution.
+  const savedInfoByWireId = useMemo(
+    () => new Map(existingModels.map((m) => [m.info.id, m.info])),
+    [existingModels]
+  );
+
+  const effectiveCapsForId = useCallback(
+    (wireId: string): CapFlags =>
+      capsFromModelInfo(savedInfoByWireId.get(wireId) ?? pool.resolveModelInfo(wireId)),
+    [savedInfoByWireId, pool]
+  );
+
+  // Selected, non-embedding models for the Advanced panel — each row shows the
+  // user override if set, else the effective (saved-then-catalog) caps, so the
+  // toggles reflect exactly what would be saved.
+  const advancedModels = useMemo(
+    () =>
+      [...pool.selectedWireIds]
+        .map((id) => pool.resolveModelInfo(id))
+        .filter((info) => !info.isEmbedding)
+        .map((info) => ({
+          info,
+          caps: capOverrides[info.id] ?? effectiveCapsForId(info.id),
+        })),
+    [pool, capOverrides, effectiveCapsForId]
+  );
+
+  const setCapFlag = (wireId: string, key: keyof CapFlags, value: boolean): void => {
+    setCapOverrides((prev) => {
+      const base = prev[wireId] ?? effectiveCapsForId(wireId);
+      return { ...prev, [wireId]: { ...base, [key]: value } };
+    });
+  };
 
   // Single verification path shared by Test and save-time auto-verify. In new
   // mode the synthetic provider carries `catalogProviderId` so the adapter's
@@ -514,6 +561,71 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
             fetchError={pool.fetchError}
           />
         </div>
+
+        <Collapsible
+          open={advancedOpen}
+          onOpenChange={setAdvancedOpen}
+          className="tw-flex tw-flex-col tw-gap-2"
+        >
+          <CollapsibleTrigger
+            className={cn(
+              "tw-flex tw-items-center tw-gap-1.5 tw-bg-transparent tw-p-0 tw-text-left",
+              "tw-text-sm tw-font-medium tw-text-normal tw-shadow-none"
+            )}
+            data-testid="advanced-toggle"
+          >
+            <ChevronDown
+              className={cn(
+                "tw-size-4 tw-shrink-0 tw-transition-transform",
+                advancedOpen && "tw-rotate-180"
+              )}
+            />
+            Advanced
+          </CollapsibleTrigger>
+          <CollapsibleContent className="tw-flex tw-flex-col tw-gap-2">
+            {advancedModels.length > 0 ? (
+              <div
+                className={cn(
+                  "tw-flex tw-flex-col tw-divide-y tw-divide-border tw-rounded-md",
+                  "tw-border tw-border-solid tw-border-border"
+                )}
+                data-testid="advanced-capabilities"
+              >
+                {advancedModels.map(({ info, caps }) => (
+                  <div
+                    key={info.id}
+                    data-testid={`advanced-row-${info.id}`}
+                    className="tw-flex tw-items-center tw-gap-4 tw-px-3 tw-py-2 tw-text-sm"
+                  >
+                    <span className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-normal">
+                      {info.displayName}
+                    </span>
+                    <label className="tw-flex tw-shrink-0 tw-items-center tw-gap-2 tw-text-xs tw-text-muted">
+                      Vision
+                      <SettingSwitch
+                        checked={caps.vision}
+                        onCheckedChange={(next) => setCapFlag(info.id, "vision", next)}
+                        data-testid={`advanced-vision-${info.id}`}
+                      />
+                    </label>
+                    <label className="tw-flex tw-shrink-0 tw-items-center tw-gap-2 tw-text-xs tw-text-muted">
+                      Reasoning
+                      <SettingSwitch
+                        checked={caps.reasoning}
+                        onCheckedChange={(next) => setCapFlag(info.id, "reasoning", next)}
+                        data-testid={`advanced-reasoning-${info.id}`}
+                      />
+                    </label>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="tw-text-xs tw-text-muted" data-testid="advanced-empty">
+                Select at least one non-embedding model to adjust its capabilities.
+              </div>
+            )}
+          </CollapsibleContent>
+        </Collapsible>
       </div>
 
       {state.mode === "new" ? (

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -186,13 +186,36 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
         ? provider.origin.catalogProviderId
         : undefined;
 
+  // Warm the catalog and re-render when it (re)populates, so a cold first open
+  // enriches rows the moment `models.dev` lands instead of capturing an empty
+  // snapshot forever (the memo below would otherwise never recompute). Mirrors
+  // the load/subscribe pattern in `ByokPanel`.
+  const [catalogVersion, setCatalogVersion] = useState(0);
+  useEffect(() => {
+    let cancelled = false;
+    const bump = (): void => {
+      if (!cancelled) setCatalogVersion((v) => v + 1);
+    };
+    const unsub = api.catalogService.onChange(bump);
+    api.catalogService
+      .ensureLoaded()
+      .then(bump)
+      .catch((err) => logError("[ConfigureProviderDialog] catalog ensureLoaded failed", err));
+    return () => {
+      cancelled = true;
+      unsub();
+    };
+  }, [api]);
+
   // Catalog metadata for row enrichment only — never seeds the candidate
   // pool. Live catalog wins; on miss (offline, legacy id) we fall back to
   // an empty record and rows render id-only until metadata loads.
   const catalogMetadata = useMemo<Record<string, ModelInfo>>(() => {
     if (!catalogProviderId) return EMPTY_METADATA;
     return api.catalogService.getProvider(catalogProviderId)?.models ?? EMPTY_METADATA;
-  }, [catalogProviderId, api]);
+    // `catalogVersion` re-runs this once the catalog lands.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogProviderId, api, catalogVersion]);
 
   const [displayName, setDisplayName] = useState(() =>
     state.mode === "new" ? state.source.displayName : (provider?.displayName ?? "")
@@ -606,14 +629,6 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
                         checked={caps.vision}
                         onCheckedChange={(next) => setCapFlag(info.id, "vision", next)}
                         data-testid={`advanced-vision-${info.id}`}
-                      />
-                    </label>
-                    <label className="tw-flex tw-shrink-0 tw-items-center tw-gap-2 tw-text-xs tw-text-muted">
-                      Reasoning
-                      <SettingSwitch
-                        checked={caps.reasoning}
-                        onCheckedChange={(next) => setCapFlag(info.id, "reasoning", next)}
-                        data-testid={`advanced-reasoning-${info.id}`}
                       />
                     </label>
                   </div>

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -24,16 +24,12 @@ import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { ReactModal } from "@/components/modals/ReactModal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { SearchBar } from "@/components/ui/SearchBar";
-import { SettingSwitch } from "@/components/ui/setting-switch";
 import { useApp } from "@/context";
-import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
-import { capsFromModelInfo, type CapFlags } from "@/modelManagement/chatModel/modelCapabilityFlags";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
 import { BYOK_DEFAULT_AUTO_ENROLL } from "@/modelManagement/setup/ByokSetupApi";
 import { providerRequiresApiKey } from "@/modelManagement/providers/providerRequiresApiKey";
@@ -48,9 +44,9 @@ import {
 } from "@/modelManagement/ui/ModelManagementContext";
 import { settingsStore } from "@/settings/model";
 import { useAtomValue } from "jotai";
-import { CheckCircle2, ChevronDown, Loader2, XCircle } from "lucide-react";
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
 import { App, Notice } from "obsidian";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useModelCandidatePool } from "./useModelCandidatePool";
 
 /**
@@ -233,11 +229,6 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [modelQuery, setModelQuery] = useState("");
-  // User-edited capability overrides from the Advanced panel, keyed by wire id.
-  // Only ids the user actually toggled live here; untouched selected models
-  // fall through to their effective (catalog/saved) caps in the pool's overlay.
-  const [capOverrides, setCapOverrides] = useState<Record<string, CapFlags>>({});
-  const [advancedOpen, setAdvancedOpen] = useState(false);
 
   // Whether this provider needs a key. New mode reads the picked definition;
   // edit mode reads the explicit persisted flag — never inferred from the
@@ -264,46 +255,8 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
     extras,
     requiresApiKey,
     providerHydrated: state.mode === "edit" ? !!provider : true,
-    capOverrides,
     api,
   });
-
-  // Saved snapshots by wire id. In edit mode the user's previously-saved caps
-  // live here; the catalog-first `resolveModelInfo` would otherwise mask a
-  // prior override (Risk R1), so the Advanced panel seeds from the saved
-  // snapshot when present and falls back to the catalog/synth resolution.
-  const savedInfoByWireId = useMemo(
-    () => new Map(existingModels.map((m) => [m.info.id, m.info])),
-    [existingModels]
-  );
-
-  const effectiveCapsForId = useCallback(
-    (wireId: string): CapFlags =>
-      capsFromModelInfo(savedInfoByWireId.get(wireId) ?? pool.resolveModelInfo(wireId)),
-    [savedInfoByWireId, pool]
-  );
-
-  // Selected, non-embedding models for the Advanced panel — each row shows the
-  // user override if set, else the effective (saved-then-catalog) caps, so the
-  // toggles reflect exactly what would be saved.
-  const advancedModels = useMemo(
-    () =>
-      [...pool.selectedWireIds]
-        .map((id) => pool.resolveModelInfo(id))
-        .filter((info) => !info.isEmbedding)
-        .map((info) => ({
-          info,
-          caps: capOverrides[info.id] ?? effectiveCapsForId(info.id),
-        })),
-    [pool, capOverrides, effectiveCapsForId]
-  );
-
-  const setCapFlag = (wireId: string, key: keyof CapFlags, value: boolean): void => {
-    setCapOverrides((prev) => {
-      const base = prev[wireId] ?? effectiveCapsForId(wireId);
-      return { ...prev, [wireId]: { ...base, [key]: value } };
-    });
-  };
 
   // Single verification path shared by Test and save-time auto-verify. In new
   // mode the synthetic provider carries `catalogProviderId` so the adapter's
@@ -584,63 +537,6 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
             fetchError={pool.fetchError}
           />
         </div>
-
-        <Collapsible
-          open={advancedOpen}
-          onOpenChange={setAdvancedOpen}
-          className="tw-flex tw-flex-col tw-gap-2"
-        >
-          <CollapsibleTrigger
-            className={cn(
-              "tw-flex tw-items-center tw-gap-1.5 tw-bg-transparent tw-p-0 tw-text-left",
-              "tw-text-sm tw-font-medium tw-text-normal tw-shadow-none"
-            )}
-            data-testid="advanced-toggle"
-          >
-            <ChevronDown
-              className={cn(
-                "tw-size-4 tw-shrink-0 tw-transition-transform",
-                advancedOpen && "tw-rotate-180"
-              )}
-            />
-            Advanced
-          </CollapsibleTrigger>
-          <CollapsibleContent className="tw-flex tw-flex-col tw-gap-2">
-            {advancedModels.length > 0 ? (
-              <div
-                className={cn(
-                  "tw-flex tw-flex-col tw-divide-y tw-divide-border tw-rounded-md",
-                  "tw-border tw-border-solid tw-border-border"
-                )}
-                data-testid="advanced-capabilities"
-              >
-                {advancedModels.map(({ info, caps }) => (
-                  <div
-                    key={info.id}
-                    data-testid={`advanced-row-${info.id}`}
-                    className="tw-flex tw-items-center tw-gap-4 tw-px-3 tw-py-2 tw-text-sm"
-                  >
-                    <span className="tw-min-w-0 tw-flex-1 tw-truncate tw-text-normal">
-                      {info.displayName}
-                    </span>
-                    <label className="tw-flex tw-shrink-0 tw-items-center tw-gap-2 tw-text-xs tw-text-muted">
-                      Vision
-                      <SettingSwitch
-                        checked={caps.vision}
-                        onCheckedChange={(next) => setCapFlag(info.id, "vision", next)}
-                        data-testid={`advanced-vision-${info.id}`}
-                      />
-                    </label>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="tw-text-xs tw-text-muted" data-testid="advanced-empty">
-                Select at least one non-embedding model to adjust its capabilities.
-              </div>
-            )}
-          </CollapsibleContent>
-        </Collapsible>
       </div>
 
       {state.mode === "new" ? (

--- a/src/modelManagement/ui/dialogs/useModelCandidatePool.ts
+++ b/src/modelManagement/ui/dialogs/useModelCandidatePool.ts
@@ -12,18 +12,11 @@
  * endpoint, or manual entry. Catalog hits only enrich row labels/limits.
  */
 import { looksLikeEmbeddingModel } from "@/modelManagement/catalog/catalogTransform";
-import {
-  applyCapsToModelInfo,
-  capsFromModelInfo,
-  type CapFlags,
-} from "@/modelManagement/chatModel/modelCapabilityFlags";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
 import { listProviderModels } from "@/modelManagement/providers/adapters/listProviderModels";
 import type { ModelInfo, ProviderType } from "@/modelManagement/types/catalog";
 import type { ConfiguredModel } from "@/modelManagement/types/persisted";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-
-const EMPTY_CAP_OVERRIDES: Readonly<Record<string, CapFlags>> = Object.freeze({});
 
 export interface UseModelCandidatePoolArgs {
   mode: "new" | "edit";
@@ -41,13 +34,6 @@ export interface UseModelCandidatePoolArgs {
   requiresApiKey: boolean;
   /** Edit mode: gate the mount fetch on the provider row having hydrated. */
   providerHydrated: boolean;
-  /**
-   * Per-wire-id capability overrides from the Advanced panel. `buildSelectedModelInfos`
-   * overlays these onto each selected non-embedding model so the user's vision/reasoning
-   * choices survive catalog-wins precedence on re-save (Risk R1). Embedding models are
-   * never overlaid.
-   */
-  capOverrides?: Readonly<Record<string, CapFlags>>;
   api: ModelManagementApi;
 }
 
@@ -79,7 +65,6 @@ export function useModelCandidatePool({
   extras,
   requiresApiKey,
   providerHydrated,
-  capOverrides = EMPTY_CAP_OVERRIDES,
   api,
 }: UseModelCandidatePoolArgs): ModelCandidatePool {
   const [selectedWireIds, setSelectedWireIds] = useState<Set<string>>(() =>
@@ -254,26 +239,13 @@ export function useModelCandidatePool({
     [existingByWireId]
   );
 
-  // Resolved `ModelInfo`s for the selected ids — same precedence the picker
-  // rendered, so what gets persisted matches what the user saw. For every
-  // selected non-embedding model we overlay an effective `CapFlags`:
-  //   user override (Advanced panel)  ??  the saved snapshot's caps  ??  resolved caps.
-  // The saved-snapshot fallback is the Risk R1 fix: `resolveModelInfo` is
-  // catalog-first, so without re-asserting the saved caps a re-save would
-  // silently discard a prior vision/reasoning override the catalog disagrees
-  // with — even when the user never opened the Advanced panel. Embedding
-  // models are never overlaid.
+  // Resolved `ModelInfo`s for the selected ids — same catalog → snapshot →
+  // synthesize precedence the picker rendered, so what gets persisted matches
+  // what the user saw. Capabilities ride along on each `ModelInfo` (its
+  // `modalities` / `reasoning`); there's no separate overlay.
   const buildSelectedModelInfos = useCallback(
-    (): ModelInfo[] =>
-      [...selectedWireIds].map((id) => {
-        const info = resolveModelInfo(id);
-        if (info.isEmbedding) return info;
-        const savedInfo = existingByWireId.get(id);
-        const effective = capsFromModelInfo(savedInfo ?? info);
-        const caps = capOverrides[id] ?? effective;
-        return applyCapsToModelInfo(info, caps);
-      }),
-    [selectedWireIds, resolveModelInfo, capOverrides, existingByWireId]
+    (): ModelInfo[] => [...selectedWireIds].map((id) => resolveModelInfo(id)),
+    [selectedWireIds, resolveModelInfo]
   );
 
   return {

--- a/src/modelManagement/ui/dialogs/useModelCandidatePool.ts
+++ b/src/modelManagement/ui/dialogs/useModelCandidatePool.ts
@@ -12,11 +12,18 @@
  * endpoint, or manual entry. Catalog hits only enrich row labels/limits.
  */
 import { looksLikeEmbeddingModel } from "@/modelManagement/catalog/catalogTransform";
+import {
+  applyCapsToModelInfo,
+  capsFromModelInfo,
+  type CapFlags,
+} from "@/modelManagement/chatModel/modelCapabilityFlags";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
 import { listProviderModels } from "@/modelManagement/providers/adapters/listProviderModels";
 import type { ModelInfo, ProviderType } from "@/modelManagement/types/catalog";
 import type { ConfiguredModel } from "@/modelManagement/types/persisted";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+const EMPTY_CAP_OVERRIDES: Readonly<Record<string, CapFlags>> = Object.freeze({});
 
 export interface UseModelCandidatePoolArgs {
   mode: "new" | "edit";
@@ -34,6 +41,13 @@ export interface UseModelCandidatePoolArgs {
   requiresApiKey: boolean;
   /** Edit mode: gate the mount fetch on the provider row having hydrated. */
   providerHydrated: boolean;
+  /**
+   * Per-wire-id capability overrides from the Advanced panel. `buildSelectedModelInfos`
+   * overlays these onto each selected non-embedding model so the user's vision/reasoning
+   * choices survive catalog-wins precedence on re-save (Risk R1). Embedding models are
+   * never overlaid.
+   */
+  capOverrides?: Readonly<Record<string, CapFlags>>;
   api: ModelManagementApi;
 }
 
@@ -65,6 +79,7 @@ export function useModelCandidatePool({
   extras,
   requiresApiKey,
   providerHydrated,
+  capOverrides = EMPTY_CAP_OVERRIDES,
   api,
 }: UseModelCandidatePoolArgs): ModelCandidatePool {
   const [selectedWireIds, setSelectedWireIds] = useState<Set<string>>(() =>
@@ -240,10 +255,25 @@ export function useModelCandidatePool({
   );
 
   // Resolved `ModelInfo`s for the selected ids — same precedence the picker
-  // rendered, so what gets persisted matches what the user saw.
+  // rendered, so what gets persisted matches what the user saw. For every
+  // selected non-embedding model we overlay an effective `CapFlags`:
+  //   user override (Advanced panel)  ??  the saved snapshot's caps  ??  resolved caps.
+  // The saved-snapshot fallback is the Risk R1 fix: `resolveModelInfo` is
+  // catalog-first, so without re-asserting the saved caps a re-save would
+  // silently discard a prior vision/reasoning override the catalog disagrees
+  // with — even when the user never opened the Advanced panel. Embedding
+  // models are never overlaid.
   const buildSelectedModelInfos = useCallback(
-    (): ModelInfo[] => [...selectedWireIds].map(resolveModelInfo),
-    [selectedWireIds, resolveModelInfo]
+    (): ModelInfo[] =>
+      [...selectedWireIds].map((id) => {
+        const info = resolveModelInfo(id);
+        if (info.isEmbedding) return info;
+        const savedInfo = existingByWireId.get(id);
+        const effective = capsFromModelInfo(savedInfo ?? info);
+        const caps = capOverrides[id] ?? effective;
+        return applyCapsToModelInfo(info, caps);
+      }),
+    [selectedWireIds, resolveModelInfo, capOverrides, existingByWireId]
   );
 
   return {

--- a/src/settings/v2/components/configuredModelGrouping.test.ts
+++ b/src/settings/v2/components/configuredModelGrouping.test.ts
@@ -7,6 +7,7 @@ import {
   type Candidate,
 } from "./configuredModelGrouping";
 import type { ConfiguredModel, Provider } from "@/modelManagement";
+import { ModelCapability } from "@/constants";
 
 function byokProvider(id: string, displayName: string): Provider {
   return {
@@ -223,6 +224,38 @@ describe("toRow", () => {
     const row = toRow(candidate);
     expect(row.label).toBe("Default (recommended)");
     expect(row.description).toBe("Opus 4.7 with 1M context · Most capable for complex work");
+  });
+
+  it("derives the vision capability from info.modalities (for the row's icon)", () => {
+    const provider = agentProvider("claude", "claude", "Claude");
+    const visionRow = toRow({
+      configuredModel: {
+        configuredModelId: "cm",
+        providerId: "claude",
+        info: {
+          id: "claude-sonnet-4-5",
+          displayName: "Claude Sonnet 4.5",
+          modalities: { input: ["text", "image"] },
+        },
+        configuredAt: 0,
+      },
+      provider,
+      enabled: true,
+    });
+    expect(visionRow.capabilities).toContain(ModelCapability.VISION);
+
+    // A model whose snapshot lacks image input carries no vision icon.
+    const noVisionRow = toRow({
+      configuredModel: {
+        configuredModelId: "cm2",
+        providerId: "claude",
+        info: { id: "text-only", displayName: "Text Only", modalities: { input: ["text"] } },
+        configuredAt: 0,
+      },
+      provider,
+      enabled: true,
+    });
+    expect(noVisionRow.capabilities ?? []).not.toContain(ModelCapability.VISION);
   });
 
   it("flags opencode Zen models (opencode/ wire id) as free, others not", () => {

--- a/src/settings/v2/components/configuredModelGrouping.test.ts
+++ b/src/settings/v2/components/configuredModelGrouping.test.ts
@@ -258,6 +258,38 @@ describe("toRow", () => {
     expect(noVisionRow.capabilities ?? []).not.toContain(ModelCapability.VISION);
   });
 
+  it("leaves capabilities undefined for an unknown snapshot, defined for a known one", () => {
+    const provider = agentProvider("claude", "claude", "Claude");
+    // No `modalities` at all — we don't know, so the row stays "unknown"
+    // (undefined). The picker renders nothing rather than asserting no vision.
+    const unknownRow = toRow({
+      configuredModel: {
+        configuredModelId: "cm",
+        providerId: "claude",
+        info: { id: "claude-sonnet-4-5", displayName: "Claude Sonnet 4.5" },
+        configuredAt: 0,
+      },
+      provider,
+      enabled: true,
+    });
+    expect(unknownRow.capabilities).toBeUndefined();
+
+    // A snapshot WITH modalities but no image input is "known to lack vision" —
+    // a defined array, so the picker renders the eye-off rather than nothing.
+    const knownNoVisionRow = toRow({
+      configuredModel: {
+        configuredModelId: "cm2",
+        providerId: "claude",
+        info: { id: "text-only", displayName: "Text Only", modalities: { input: ["text"] } },
+        configuredAt: 0,
+      },
+      provider,
+      enabled: true,
+    });
+    expect(knownNoVisionRow.capabilities).toBeDefined();
+    expect(knownNoVisionRow.capabilities).not.toContain(ModelCapability.VISION);
+  });
+
   it("flags opencode Zen models (opencode/ wire id) as free, others not", () => {
     const provider = agentProvider("oc", "opencode", "opencode");
     const zen = toRow({

--- a/src/settings/v2/components/configuredModelGrouping.ts
+++ b/src/settings/v2/components/configuredModelGrouping.ts
@@ -2,7 +2,7 @@
 
 import { isOpencodeZenWireId, type ModelEnableGroup, type ModelEnableRow } from "@/agentMode";
 import {
-  capabilityListFromModelInfo,
+  capabilitiesFromConfiguredInfo,
   type ConfiguredModel,
   type Provider,
 } from "@/modelManagement";
@@ -123,7 +123,7 @@ export function toRow(candidate: Candidate): ModelEnableRow {
     wireId: id,
     enabled,
     isFree: isOpencodeZenWireId(id),
-    capabilities: capabilityListFromModelInfo(configuredModel.info),
+    capabilities: capabilitiesFromConfiguredInfo(configuredModel.info),
   };
 }
 

--- a/src/settings/v2/components/configuredModelGrouping.ts
+++ b/src/settings/v2/components/configuredModelGrouping.ts
@@ -1,7 +1,11 @@
 /** Pure grouping logic for `ConfiguredModelEnableList`, split from the React container so it's testable with plain data. */
 
 import { isOpencodeZenWireId, type ModelEnableGroup, type ModelEnableRow } from "@/agentMode";
-import type { ConfiguredModel, Provider } from "@/modelManagement";
+import {
+  capabilityListFromModelInfo,
+  type ConfiguredModel,
+  type Provider,
+} from "@/modelManagement";
 
 /** One candidate model joined to its provider, plus current enabled state. */
 export interface Candidate {
@@ -119,6 +123,7 @@ export function toRow(candidate: Candidate): ModelEnableRow {
     wireId: id,
     enabled,
     isFree: isOpencodeZenWireId(id),
+    capabilities: capabilityListFromModelInfo(configuredModel.info),
   };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
   ALLOWED_NOTE_CONTEXT_EXTENSIONS,
   ChatModelProviders,
   EmbeddingModelProviders,
+  ModelCapability,
   NOMIC_EMBED_TEXT,
   Provider,
   ProviderInfo,
@@ -820,6 +821,12 @@ export function findCustomModel(modelKey: string, activeModels: CustomModel[]): 
     throw new Error(`No model configuration found for: ${modelKey}`);
   }
   return model;
+}
+
+// Capabilities can be undefined when a model's vision support is simply unknown;
+// callers that hard-block on missing vision must treat undefined as "unknown", not "no".
+export function modelSupportsVision(model: CustomModel): boolean {
+  return !!model.capabilities?.includes(ModelCapability.VISION);
 }
 
 export function getProviderInfo(provider: string): ProviderMetadata {


### PR DESCRIPTION
## Summary

Two gaps, one root cause: models with missing/wrong capability metadata get no `vision`/`reasoning`, and nothing stopped a user sending images to a non-vision model — it failed silently (and frustrated users). This PR **flags the exception instead of the norm**: the model UI now surfaces a single indicator *only* on models that **don't** support vision, hard-blocks image sends to those models on **both** the chat and Agent Mode paths

<img width="556" height="436" alt="Screenshot 2026-06-21 at 8 38 51 PM" src="https://github.com/user-attachments/assets/9e48860c-97b4-4a9b-a969-17f975fc896c" />
<img width="569" height="521" alt="Screenshot 2026-06-21 at 8 39 08 PM" src="https://github.com/user-attachments/assets/68933650-9eac-4403-aa67-6189892353ef" />


## Modality indicator — only flag models without vision

Vision is ubiquitous on modern models, so badging it is noise. We invert it:

- **Known to lack vision** → a single muted **eye-off** icon (with a "This model does not support image inputs." tooltip). This is the only vision signal we surface.
- **Vision-capable** → no icon. Vision is the norm; we don't badge it (mirrors the already-hidden reasoning icon).
- **Unknown** (no modality snapshot — e.g. an agent-provided model not in the catalog) → no icon. We never assert a missing capability we don't actually know about.
- **Web search** keeps its blue globe; **reasoning** stays hidden.

The distinction is encoded in `capabilitiesFromConfiguredInfo()`: a snapshot **with** modalities but no image input returns a defined array without `VISION` ("known text-only" → eye-off); a snapshot with **no** modalities returns `undefined` ("unknown" → render nothing). `hasCapabilityIcons()` drives the surrounding wrapper so a vision-capable/unknown row never renders an empty icon slot. This applies consistently across the BYOK Configure dialog, the model checklist, and the agent model pickers.

## Guard image sends to non-vision models

The guard fires **only when a model's capabilities are known and exclude vision**; unclassifiable models keep `capabilities: undefined` and are never falsely blocked.

- `Chat.handleSendMessage` (chat path) and `AgentChatInput.handleSendMessage` (Agent Mode) both block the send when images are attached and the active model is known to lack vision. The `Notice` names the model; the typed text + images are preserved (no silent failure, nothing cleared).
- Agent picker entries are enriched with capabilities derived from the models.dev catalog by `(provider, baseModelId)`, threaded as a structural type to respect the agent-mode `ui` import boundary (no `@/modelManagement` import); catalog misses stay `undefined`.
