### PR TITLE
fix(agent-mode): highlight active multi-agent tab + readable summary

### DIFF
--- a/src/agentMode/session/fanout/fanoutTypes.ts
+++ b/src/agentMode/session/fanout/fanoutTypes.ts
@@ -154,7 +154,13 @@ export const FANOUT_SUMMARY_INSTRUCTION =
   'the request were made of you; no sentence may begin with "I".\n' +
   "- Use ONLY the outputs shown; ignore any environment scaffolding (tool lists, " +
   "available skills/agents, boilerplate). Do not mention how many agents there " +
-  "were, who did not respond, or anything missing. Be concise.\n\n" +
+  "were, who did not respond, or anything missing.\n\n" +
+  "FORMAT (always): clean, scannable Markdown, and be concise. Lead with the " +
+  "bottom line in one or two sentences, THEN the sections below as `###` " +
+  "subheadings — each on its own line, preceded by a blank line, with one or two " +
+  "short paragraphs under it. Do NOT pack points into dense bullet lists; prefer " +
+  "short paragraphs and whitespace, and use a bullet list only for 3+ genuinely " +
+  "parallel items, one line each, never nested.\n\n" +
   "FIRST pick the MODE from the request and the outputs:\n" +
   "- ANSWER mode — the agents answered a question or analyzed something (facts, " +
   "explanation, a recommendation, identity); there is a best answer to converge " +
@@ -164,20 +170,25 @@ export const FANOUT_SUMMARY_INSTRUCTION =
   "design); these are options, not competing claims.\n\n" +
   "If only ONE agent responded (either mode): one to three sentences on its " +
   "answer or approach, attributed, no headings.\n\n" +
-  "TWO OR MORE in ANSWER mode — markdown sections, omitting any that is empty:\n" +
-  '  "**Each agent**" — one concise bullet per agent.\n' +
-  '  "**Agreements**" — the points the agents share.\n' +
-  '  "**Disagreements**" — where they differ, naming the sides.\n\n' +
-  "TWO OR MORE in DELIVERABLE mode — help the user CHOOSE or MERGE, NOT " +
-  "agreements/disagreements:\n" +
-  '  "**Options**" — one bullet per agent on what is DISTINCTIVE about its take ' +
-  "(the angle, tone, structure, or tradeoff that would make someone pick it, and " +
-  "who it suits).\n" +
-  '  "**Recommendation**" — name the best option for the likely goal and why in a ' +
-  "sentence or two; if a combination is clearly better, say which parts of which " +
-  "to merge.\n" +
+  "TWO OR MORE in ANSWER mode — lead with the bottom line, then these `###` " +
+  "sections, omitting any that would be empty:\n" +
+  "  ### Each agent\n" +
+  "  A short attributed paragraph for each agent's take.\n" +
+  "  ### Agreements\n" +
+  "  The points the agents share.\n" +
+  "  ### Disagreements\n" +
+  "  Where they differ, naming the sides.\n\n" +
+  "TWO OR MORE in DELIVERABLE mode — lead with the bottom line, then help the " +
+  "user CHOOSE or MERGE (NOT agreements/disagreements), as `###` sections:\n" +
+  "  ### Options\n" +
+  "  A short attributed paragraph per agent on what is DISTINCTIVE about its " +
+  "take — the angle, tone, structure, or tradeoff that would make someone pick " +
+  "it, and who it suits.\n" +
+  "  ### Recommendation\n" +
+  "  Name the best option for the likely goal and why; if a combination is " +
+  "clearly better, say which parts of which to merge.\n" +
   "  Do NOT reproduce the artifacts (the user already has each in its own tab); " +
-  "summarize the approach only.\n\n" +
+  "describe the approach only.\n\n" +
   "Do NOT modify any files or run write/shell tools.";
 
 /** The text persisted when every fan-out agent failed. */

--- a/src/agentMode/ui/FanoutTurnView.test.tsx
+++ b/src/agentMode/ui/FanoutTurnView.test.tsx
@@ -80,4 +80,14 @@ describe("FanoutTurnView", () => {
     fireEvent.click(screen.getByRole("tab", { name: /opencode/ }));
     expect(screen.getByTestId("agent-md").textContent).toBe("OPENCODE_BODY");
   });
+
+  it("shows 'did not answer' (not 'Thinking…') for a finished slot with no text", () => {
+    // Regression: a done-but-empty slot was showing a green check + "Thinking…",
+    // reading as both finished and still working at once.
+    const t = turn([answer("opencode", "done", "")], "the narrative summary");
+    renderView(t);
+    fireEvent.click(screen.getByRole("tab", { name: /opencode/ }));
+    expect(screen.getByText(/did not answer/i)).toBeTruthy();
+    expect(screen.queryByText(/Thinking/i)).toBeNull();
+  });
 });

--- a/src/agentMode/ui/FanoutTurnView.tsx
+++ b/src/agentMode/ui/FanoutTurnView.tsx
@@ -49,9 +49,12 @@ const FanoutTab: React.FC<FanoutTabProps> = ({ option, selected, onSelect }) => 
       onClick={handleClick}
       className={cn(
         "tw-flex tw-items-center tw-gap-1.5 tw-rounded-md tw-border tw-border-solid tw-border-transparent tw-px-2 tw-py-1 tw-text-sm tw-transition-colors",
+        // Active tab: accent border + faint accent tint + normal-weight text,
+        // matching AgentTabStrip's active-tab treatment. The accent border is the
+        // reliable highlight; a background-only swap reads as "no active tab".
         selected
-          ? "tw-bg-interactive-accent tw-text-on-accent"
-          : "tw-text-muted hover:tw-bg-interactive-hover"
+          ? "tw-border-interactive-accent tw-font-medium tw-text-normal tw-bg-interactive-accent/10"
+          : "tw-text-muted hover:tw-bg-interactive-hover hover:tw-text-normal"
       )}
     >
       {Icon ? <Icon className="tw-size-4 tw-shrink-0" /> : null}

--- a/src/agentMode/ui/FanoutTurnView.tsx
+++ b/src/agentMode/ui/FanoutTurnView.tsx
@@ -80,7 +80,7 @@ const FanoutStatusDot: React.FC<FanoutStatusDotProps> = ({ state }) => {
   if (state === "error") {
     return <AlertTriangle className="tw-size-3 tw-shrink-0 tw-text-error" />;
   }
-  if (state === "cancelled") {
+  if (state === "cancelled" || state === "empty") {
     return <CircleSlash className="tw-size-3 tw-shrink-0 tw-text-muted" />;
   }
   return null;
@@ -185,6 +185,17 @@ const FanoutTurnBody: React.FC<FanoutTurnBodyProps> = ({ turn, value, app }) => 
           <FanoutStatusLine icon={<ThinkingSpinner />} text="Streaming…" shimmer />
         ) : null}
       </div>
+    );
+  }
+
+  // Finished with no text — terminal "did not answer", NOT a spinner (a `done`
+  // slot must never read as still thinking).
+  if (answer.status === "done") {
+    return (
+      <FanoutStatusLine
+        icon={<CircleSlash className="tw-size-4 tw-text-muted" />}
+        text="This agent did not answer."
+      />
     );
   }
 

--- a/src/agentMode/ui/fanoutDropdown.test.ts
+++ b/src/agentMode/ui/fanoutDropdown.test.ts
@@ -16,6 +16,7 @@ jest.mock("@/agentMode/backends/registry", () => {
 
 import type { FanoutSummaryStatus } from "@/agentMode/session/fanout/fanoutTypes";
 import {
+  agentStateForAnswer,
   agentStateForStatus,
   buildFanoutOptions,
   defaultFanoutOption,
@@ -49,6 +50,18 @@ describe("agentStateForStatus", () => {
     expect(agentStateForStatus("done")).toBe("answer");
     expect(agentStateForStatus("error")).toBe("error");
     expect(agentStateForStatus("cancelled")).toBe("cancelled");
+  });
+});
+
+describe("agentStateForAnswer", () => {
+  it("maps a done slot with text to answer, but a done slot with no text to empty", () => {
+    expect(agentStateForAnswer(answer("opencode", "done", "hi"))).toBe("answer");
+    // The bug: a finished-but-empty slot must NOT read as a success check.
+    expect(agentStateForAnswer(answer("opencode", "done", "   "))).toBe("empty");
+  });
+  it("defers to the raw status for non-done slots", () => {
+    expect(agentStateForAnswer(answer("opencode", "running", ""))).toBe("streaming");
+    expect(agentStateForAnswer(answer("opencode", "error", "", "x"))).toBe("error");
   });
 });
 

--- a/src/agentMode/ui/fanoutDropdown.ts
+++ b/src/agentMode/ui/fanoutDropdown.ts
@@ -15,8 +15,10 @@ export type FanoutOptionValue = BackendId;
 /**
  * Presentational state of one agent's slot, derived from its live status.
  * Decoupled from {@link AgentAnswerStatus} so the renderer switches on intent.
+ * `empty` is a slot that finished but produced no text (the agent did not
+ * answer) — terminal, so it must not show a spinner or a success check.
  */
-export type FanoutAgentState = "streaming" | "answer" | "error" | "cancelled";
+export type FanoutAgentState = "streaming" | "answer" | "error" | "cancelled" | "empty";
 
 /** Map an agent answer's live status to its presentational state. */
 export function agentStateForStatus(status: AgentAnswerStatus): FanoutAgentState {
@@ -30,6 +32,16 @@ export function agentStateForStatus(status: AgentAnswerStatus): FanoutAgentState
     case "done":
       return "answer";
   }
+}
+
+/**
+ * Like {@link agentStateForStatus} but resolves a `done` slot with no text to
+ * `empty` — so it renders as "did not answer" instead of a misleading success
+ * check (the slot finished without producing an answer).
+ */
+export function agentStateForAnswer(answer: AgentAnswer): FanoutAgentState {
+  if (answer.status === "done" && answer.text.trim().length === 0) return "empty";
+  return agentStateForStatus(answer.status);
 }
 
 /**
@@ -94,7 +106,7 @@ export function buildFanoutOptions(turn: FanoutTurn): FanoutOption[] {
       value: backendId,
       label: displayName,
       Icon,
-      state: agentStateForStatus(answer.status),
+      state: agentStateForAnswer(answer),
     });
   }
   return options;


### PR DESCRIPTION
Two small polish changes to the multi-agent (fan-out) response.

### 1. Highlight the active response tab
The selected tab only swapped its background fill, which didn't read as "active" (tabs looked the same unless hovered). Now matches `AgentTabStrip`'s proven active-tab treatment: **accent border + faint accent tint + normal-weight medium text**. No `!important` — the `border-transparent` → `border-interactive-accent` conflict resolves through `cn()`/`twMerge`.

### 2. Readable summary (headings, not dense bullets)
The summary used bold inline labels (`**Each agent**`) and one dense bullet per agent. The instruction now leads with the bottom line, then uses proper `###` subheadings (Each agent / Agreements / Disagreements, or Options / Recommendation) with short paragraphs and whitespace; bullets only for 3+ genuinely parallel one-line items.

### Gates
`format` / `lint` clean (incl. tailwind class-order), `tsc --noEmit` clean, `npm run test` 3,843 green, production `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)