### PR TITLE
fix(agent-mode): restore inline code background when reloading a chat

### DIFF
--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -334,4 +334,23 @@ describe("ChatSingleMessage", () => {
     expect(messageSegment?.querySelector(".content-hr")).not.toBeNull();
     expect(messageSegment?.querySelector('a[href="#fn-2"]')?.textContent).toBe("2");
   });
+
+  it("marks rendered text segments with markdown-rendered for native reading-view styling", async () => {
+    const { container } = render(
+      <TooltipProvider>
+        <ChatSingleMessage
+          message={baseMessage}
+          app={createAppStub()}
+          isStreaming={false}
+          onDelete={() => {}}
+        />
+      </TooltipProvider>
+    );
+
+    await waitFor(() => expect(renderMarkdownMock).toHaveBeenCalled());
+
+    const messageSegment = container.querySelector(".message-segment");
+    expect(messageSegment).toBeTruthy();
+    expect(messageSegment?.classList.contains("markdown-rendered")).toBe(true);
+  });
 });

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -687,7 +687,11 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
             const insertBefore = contentRef.current!.children[currentIndex];
 
             const textDiv = doc.createElement("div");
-            textDiv.className = "message-segment";
+            // `markdown-rendered` opts the container into Obsidian's native
+            // reading-view stylesheet so reloaded messages match the live
+            // render path (AgentMarkdownText). Most visibly, it restores the
+            // gray background pill on inline `<code>` spans.
+            textDiv.className = "message-segment markdown-rendered";
 
             if (insertBefore) {
               contentRef.current!.insertBefore(textDiv, insertBefore);


### PR DESCRIPTION
## Summary

Fixes logancyang/obsidian-copilot-preview#188 (issue lives in the preview repo).

Inline code spans (single backticks) lost their gray background pill when an Agent Mode chat was reopened from Recent Chats.

### Root cause

- **Live messages** render via `AgentMarkdownText.tsx`, which calls `target.classList.add("markdown-rendered")`. That class opts the container into Obsidian's native reading-view stylesheet, which styles inline `<code>` with the background pill.
- **Reloaded messages** render via `ChatSingleMessage.tsx`. It builds `.message-segment` text divs and runs `renderMarkdown` into them, but never added `markdown-rendered`. It relied on the plugin's own `.message-content code` rule, which does not reproduce the native pill in the user's theme.

### Fix

Add `markdown-rendered` to each rendered `.message-segment` text div, mirroring exactly how the live path (`AgentMarkdownText`) applies it. The class is scoped to the segment divs (not `.message-content`) to avoid regressing the existing `.message-content` table/code-block/paragraph rules.

### Before / after

- **Before:** reloaded inline code had no (or theme-incorrect) background.
- **After:** reloaded inline code shows the same gray pill as the live render.

## Testing

- `npm run build` passes (TypeScript check clean).
- Added a unit test in `ChatSingleMessage.test.tsx` asserting the rendered text segment carries `markdown-rendered`; the `ChatSingleMessage` suite passes (7/7).
- `npm run format` and `npm run lint` clean.
- No CSS changes; `styles.css` (generated) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)