### PR TITLE
fix(agent-mode): allow exec/skill tools in read-only fan-out QA turns

### DIFF
--- a/src/agentMode/sdk/permissionBridge.test.ts
+++ b/src/agentMode/sdk/permissionBridge.test.ts
@@ -336,7 +336,7 @@ describe("PermissionBridge.canUseTool", () => {
       expect(prompter).not.toHaveBeenCalled();
     });
 
-    it("still allows reads in a read-only session (only write/exec are denied)", async () => {
+    it("still allows reads in a read-only session (only vault writes are denied)", async () => {
       const prompter = jest.fn(async () => ({
         outcome: { outcome: "selected" as const, optionId: "allow_once" as const },
       }));

--- a/src/agentMode/sdk/permissionBridge.ts
+++ b/src/agentMode/sdk/permissionBridge.ts
@@ -23,7 +23,7 @@ import type {
 } from "@/agentMode/session/types";
 import { PERMISSION_OPTION_KINDS } from "@/agentMode/session/types";
 import { resolveToolName } from "@/agentMode/session/toolName";
-import { isWriteOrExecToolKind } from "@/agentMode/session/fanout/fanoutTypes";
+import { isVaultWriteToolKind } from "@/agentMode/session/fanout/fanoutTypes";
 import { err2String } from "@/utils";
 import { logSdkInbound, logSdkOutbound } from "./sdkDebugTap";
 import { deriveToolKind, deriveToolTitle, vendorMetaFields } from "./toolMeta";
@@ -116,10 +116,10 @@ export class PermissionBridge {
       // unknown MCP tools in a read-only QA turn; known-classified MCP reads
       // (read/search/fetch) still fall through.
       const isUnverifiableMcpTool = Boolean(mcpServer) && kind === "other";
-      if (isWriteOrExecToolKind(kind) || isUnverifiableMcpTool) {
+      if (isVaultWriteToolKind(kind) || isUnverifiableMcpTool) {
         return this.deny(
           "canUseTool:response",
-          "Read-only QA turn: write and exec tools are disabled.",
+          "Read-only QA turn: vault-write tools are disabled.",
           sessionId
         );
       }

--- a/src/agentMode/sdk/toolMeta.test.ts
+++ b/src/agentMode/sdk/toolMeta.test.ts
@@ -1,4 +1,4 @@
-import { isWriteOrExecToolKind } from "@/agentMode/session/fanout/fanoutTypes";
+import { isVaultWriteToolKind } from "@/agentMode/session/fanout/fanoutTypes";
 import { deriveToolKind } from "./toolMeta";
 
 describe("deriveToolKind", () => {
@@ -15,17 +15,25 @@ describe("deriveToolKind", () => {
   });
 
   // Read-only fan-out leans on `deriveToolKind` to label every native Claude
-  // file-mutation / shell tool as a write/exec kind so the shared permission
-  // prompter denies it. A tool that falls through to `"other"` would be ALLOWED
-  // in a read-only sub-session — that is the gap this guard catches. NotebookEdit
+  // file-mutation tool as a vault-write kind so the shared permission prompter
+  // denies it. A tool that falls through to `"other"` would be ALLOWED in a
+  // read-only sub-session — that is the gap this guard catches. NotebookEdit
   // (.ipynb writes) regressed here once: it was not in any branch and slipped
   // through as `"other"`.
-  it("classifies every native Claude write/exec tool so read-only fan-out denies it", () => {
-    const writeOrExecTools = ["Write", "Edit", "MultiEdit", "NotebookEdit", "Bash"];
-    for (const name of writeOrExecTools) {
+  it("classifies every native Claude file-mutation tool so read-only fan-out denies it", () => {
+    const writeTools = ["Write", "Edit", "MultiEdit", "NotebookEdit"];
+    for (const name of writeTools) {
       const kind = deriveToolKind(name);
-      expect(isWriteOrExecToolKind(kind)).toBe(true);
+      expect(isVaultWriteToolKind(kind)).toBe(true);
     }
+  });
+
+  // Bash is `execute`, intentionally ALLOWED in a read-only fan-out turn so
+  // Copilot's skill-script relay tools (web search/fetch) run; the read-only
+  // prompt + native sandbox keep shell from writing the vault.
+  it("classifies Bash as execute (allowed in read-only fan-out)", () => {
+    expect(deriveToolKind("Bash")).toBe("execute");
+    expect(isVaultWriteToolKind("execute")).toBe(false);
   });
 
   it("routes native plan tools to switch_mode (not an MCP tool of the same name)", () => {

--- a/src/agentMode/session/fanout/fanoutTypes.test.ts
+++ b/src/agentMode/session/fanout/fanoutTypes.test.ts
@@ -7,7 +7,7 @@ import {
   buildSummaryUserPrompt,
   EMPTY_PENDING_FANOUT_CONTEXT,
   FANOUT_HISTORY_MAX_CHARS,
-  isWriteOrExecToolKind,
+  isVaultWriteToolKind,
   parseFanoutComposite,
   renderFanoutComposite,
   selectSummaryInputs,
@@ -25,23 +25,33 @@ const histMsg = (sender: string, message: string): AgentChatMessage => ({
 
 const upper = (id: string) => id.toUpperCase();
 
-describe("isWriteOrExecToolKind", () => {
-  it("denies write/exec tool kinds", () => {
-    const denied: AgentToolKind[] = ["edit", "delete", "move", "execute"];
+describe("isVaultWriteToolKind", () => {
+  it("denies vault-mutating tool kinds", () => {
+    const denied: AgentToolKind[] = ["edit", "delete", "move"];
     for (const kind of denied) {
-      expect(isWriteOrExecToolKind(kind)).toBe(true);
+      expect(isVaultWriteToolKind(kind)).toBe(true);
     }
   });
 
-  it("allows read/search/fetch/think/switch_mode/other tool kinds", () => {
-    const allowed: AgentToolKind[] = ["read", "search", "fetch", "think", "switch_mode", "other"];
+  it("allows read/search/fetch/think/switch_mode/other/execute tool kinds", () => {
+    // `execute` passes so Copilot's skill-script relay tools (web search/fetch)
+    // run in a read-only QA turn; the prompt + sandbox keep shell from writing.
+    const allowed: AgentToolKind[] = [
+      "read",
+      "search",
+      "fetch",
+      "think",
+      "switch_mode",
+      "other",
+      "execute",
+    ];
     for (const kind of allowed) {
-      expect(isWriteOrExecToolKind(kind)).toBe(false);
+      expect(isVaultWriteToolKind(kind)).toBe(false);
     }
   });
 
   it("fails safe (denies) when the kind is unknown", () => {
-    expect(isWriteOrExecToolKind(undefined)).toBe(true);
+    expect(isVaultWriteToolKind(undefined)).toBe(true);
   });
 });
 

--- a/src/agentMode/session/fanout/fanoutTypes.ts
+++ b/src/agentMode/session/fanout/fanoutTypes.ts
@@ -103,25 +103,28 @@ export interface FanoutSummary {
 }
 
 /**
- * Tool kinds that mutate the vault or execute commands, hard-denied in a
- * read-only fan-out sub-session. `other` is intentionally NOT here: denying it
- * would block legitimate read-only MCP tools, and the prompt + sandbox already
- * steer the agent away from mutations.
+ * Tool kinds that mutate the vault, hard-denied in a read-only fan-out
+ * sub-session. `execute` is intentionally NOT here: Copilot's relay
+ * capabilities (web search/fetch, PDF, YouTube) ship as skill scripts the
+ * backend runs via shell, so a blanket exec deny silently kills web search for
+ * backends with no native equivalent (opencode). The read-only prompt preamble
+ * plus each backend's native read-only sandbox keep exec from writing. `other`
+ * is also not here: denying it would block legitimate read-only MCP tools.
  */
-const WRITE_OR_EXEC_KINDS: ReadonlySet<AgentToolKind> = new Set<AgentToolKind>([
+const VAULT_WRITE_KINDS: ReadonlySet<AgentToolKind> = new Set<AgentToolKind>([
   "edit",
   "delete",
   "move",
-  "execute",
 ]);
 
 /**
- * Whether a tool kind must be denied in a read-only fan-out sub-session.
- * `undefined` (kind not reported) is treated as a write to fail safe.
+ * Whether a tool kind mutates the vault and must be denied in a read-only
+ * fan-out sub-session. `undefined` (kind not reported) is treated as a write to
+ * fail safe.
  */
-export function isWriteOrExecToolKind(kind: AgentToolKind | undefined): boolean {
+export function isVaultWriteToolKind(kind: AgentToolKind | undefined): boolean {
   if (kind === undefined) return true;
-  return WRITE_OR_EXEC_KINDS.has(kind);
+  return VAULT_WRITE_KINDS.has(kind);
 }
 
 /**

--- a/src/agentMode/ui/permissionPrompter.test.ts
+++ b/src/agentMode/ui/permissionPrompter.test.ts
@@ -23,7 +23,8 @@ describe("createDefaultPermissionPrompter — read-only fan-out policy", () => {
       (id) => id === "ro-session"
     );
 
-    for (const kind of ["read", "search", "fetch"] as AgentToolKind[]) {
+    // `execute` is allowed so skill-script relay tools (web search) run.
+    for (const kind of ["read", "search", "fetch", "execute"] as AgentToolKind[]) {
       const decision = await prompter(promptFor("ro-session", kind));
       expect(decision.outcome).toEqual({ outcome: "selected", optionId: "allow_once" });
     }
@@ -31,14 +32,14 @@ describe("createDefaultPermissionPrompter — read-only fan-out policy", () => {
     expect(handleToolPermission).not.toHaveBeenCalled();
   });
 
-  it("denies write/exec tools for a read-only fan-out sub-session", async () => {
+  it("denies vault-write tools for a read-only fan-out sub-session", async () => {
     const prompter = createDefaultPermissionPrompter(
       () => null,
       () => true
     );
     // `other` is an unknown/MCP tool that can't be verified read-only, so it
-    // is denied too (fail-safe), alongside the write/exec kinds.
-    for (const kind of ["edit", "delete", "move", "execute", "other"] as AgentToolKind[]) {
+    // is denied too (fail-safe), alongside the vault-mutating kinds.
+    for (const kind of ["edit", "delete", "move", "other"] as AgentToolKind[]) {
       const decision = await prompter(promptFor("ro-session", kind));
       expect(decision.outcome).toEqual({ outcome: "selected", optionId: "reject_once" });
       expect(decision.denyMessage).toContain("Read-only");

--- a/src/agentMode/ui/permissionPrompter.ts
+++ b/src/agentMode/ui/permissionPrompter.ts
@@ -3,7 +3,7 @@ import type {
   AskUserQuestionPrompter,
   PermissionPrompter,
 } from "@/agentMode/session/AgentSessionManager";
-import { isWriteOrExecToolKind } from "@/agentMode/session/fanout/fanoutTypes";
+import { isVaultWriteToolKind } from "@/agentMode/session/fanout/fanoutTypes";
 import {
   PERMISSION_ALLOW_KINDS,
   PERMISSION_REJECT_KINDS,
@@ -19,17 +19,20 @@ import {
  * enforcement layer behind the orchestrator's read-only guarantee.
  */
 function decideReadOnly(req: PermissionPrompt): PermissionDecision {
-  // `other` is an unknown/MCP tool we can't verify is read-only, so fail safe
-  // and deny it here too (mirrors the Claude SDK bridge's unknown-MCP denial);
+  // Only vault mutation (edit/delete/move) is hard-denied. `execute` passes so
+  // Copilot's skill-script relay tools (web search/fetch, etc.) run; the
+  // read-only prompt + native sandbox keep shell from writing. `other` is an
+  // unknown/MCP tool we can't verify is read-only, so fail safe and deny it
+  // here too (mirrors the Claude SDK bridge's unknown-MCP denial);
   // read/search/fetch/think/switch_mode still pass.
   const kind = req.toolCall.kind;
-  const deny = isWriteOrExecToolKind(kind) || kind === "other";
+  const deny = isVaultWriteToolKind(kind) || kind === "other";
   const kinds = deny ? PERMISSION_REJECT_KINDS : PERMISSION_ALLOW_KINDS;
   const opt = req.options.find((o) => kinds.includes(o.kind));
   if (!opt) return { outcome: { outcome: "cancelled" } };
   const decision: PermissionDecision = { outcome: { outcome: "selected", optionId: opt.optionId } };
   return deny
-    ? { ...decision, denyMessage: "Read-only QA turn: write and exec tools are disabled." }
+    ? { ...decision, denyMessage: "Read-only QA turn: vault-write tools are disabled." }
     : decision;
 }
 


### PR DESCRIPTION
## Problem

In a multi-agent (fan-out) QA turn, the read-only gate hard-denied the `execute` tool kind. That silently killed web search for any backend whose only web path is a shell-run skill script.

Diagnosed from the ACP frame logs: an opencode fan-out agent loaded the `copilot-web-search` skill and tried to run it via `bash`, which the read-only gate rejected ("Read-only QA turn: write and exec tools are disabled."). With no native web-search fallback, opencode emitted zero assistant text and the turn rendered "This agent did not answer." Claude and Codex answered the same question because each has a native web-search tool that never routes through a shell exec.

## Fix

Narrow the read-only fan-out gate to deny only genuine vault mutation (`edit` / `delete` / `move`). Allow `execute` so Copilot's skill-script relay tools (web search/fetch, PDF, YouTube, X) run. The read-only prompt preamble (already instructs "do NOT modify any files / run write/shell tools") plus each backend's native read-only sandbox keep shell from writing the vault. `other` (unverifiable third-party MCP) stays denied as before.

- Rename `isWriteOrExecToolKind` -> `isVaultWriteToolKind` to match the new semantics.
- Update both enforcement sites: the UI permission prompter (`permissionPrompter.ts`) and the Claude SDK bridge (`permissionBridge.ts`).
- Reword the deny message to "vault-write tools are disabled."

## Test plan

- `npm run test`: full suite green (261 suites / 3873 tests), including updated unit tests in `fanoutTypes.test.ts`, `permissionPrompter.test.ts`, `permissionBridge.test.ts`, and `toolMeta.test.ts` (exec now allowed, file-mutation still denied, `Bash` -> `execute` -> allowed).
- `npm run format`: clean.
- Manual: run a multi-agent turn including opencode with a web-dependent question (e.g. "how many goals did Messi score today") and confirm opencode now answers via copilot web search.

## Follow-up

Observability gap tracked separately in logancyang/obsidian-copilot-preview#189: a fan-out slot that ends empty because a tool was denied/failed still shows the generic "did not answer" with no reason and no live progress. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
