### PR TITLE
feat(agent-home): surface Relevant Notes as a home-shelf tab

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,10 @@ module.exports = {
     // jsdom; Jest can't parse ESM without extra config, so point at the CJS
     // build it ships under dist/.
     "^yaml$": "<rootDir>/node_modules/yaml/dist/index.js",
+    // @orama/orama resolves to its ESM "browser" entry under jsdom, which Jest
+    // can't parse; point at the CJS build it ships under dist/commonjs/ (same
+    // reason as yaml above).
+    "^@orama/orama$": "<rootDir>/node_modules/@orama/orama/dist/commonjs/index.js",
     "^@agentclientprotocol/sdk$": "<rootDir>/__mocks__/@agentclientprotocol/sdk.js",
     "^@anthropic-ai/claude-agent-sdk$": "<rootDir>/__mocks__/@anthropic-ai/claude-agent-sdk.js",
     // react-resizable-panels is ESM-only with no CJS build to point at; stub it.

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -6,7 +6,10 @@ import { AgentTabStrip } from "@/agentMode/ui/AgentTabStrip";
 import { CopilotBrandIcon } from "@/agentMode/ui/CopilotBrandIcon";
 import { AgentHomeShelf, type AgentHomeShelfSection } from "@/agentMode/ui/AgentHomeShelf";
 import { GlobalRecentChatsSection } from "@/agentMode/ui/GlobalRecentChatsSection";
+import { HOME_SHELF_TAB_STORAGE_KEY } from "@/agentMode/ui/homeShelfPrefs";
 import { ProjectPickerList } from "@/agentMode/ui/ProjectPickerList";
+import { RelevantNotesShelfPanel } from "@/agentMode/ui/RelevantNotesShelfPanel";
+import { useRelevantNotesPaneOpen } from "@/agentMode/ui/useRelevantNotesPaneOpen";
 import { useAgentChatRuntimeState } from "@/agentMode/ui/hooks/useAgentChatRuntimeState";
 import { useAgentHistoryControls } from "@/agentMode/ui/hooks/useAgentHistoryControls";
 import { useAgentInputDrafts } from "@/agentMode/ui/hooks/useAgentInputDrafts";
@@ -25,7 +28,7 @@ import { logError } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { useProjects } from "@/projects/state";
 import { useSettingsValue } from "@/settings/model";
-import { Folder, MessageSquare } from "lucide-react";
+import { FileSearch, Folder, MessageSquare } from "lucide-react";
 import { Notice } from "obsidian";
 import React, { useCallback, useContext, useEffect, useMemo, useRef } from "react";
 
@@ -64,6 +67,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   const settings = useSettingsValue();
   const eventTarget = useContext(EventTargetContext);
   const chatInput = useChatInput();
+  const isRelevantNotesPaneOpen = useRelevantNotesPaneOpen(app);
 
   // Place the caret in the composer when the agent view opens so the user can
   // type immediately. AgentHome only mounts once preload settles and a session
@@ -262,6 +266,23 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
           />
         ),
       },
+      // Hidden while the dedicated Relevant Notes pane is open, so the shelf
+      // doesn't duplicate a surface the user already has pinned alongside chat.
+      ...(isRelevantNotesPaneOpen
+        ? []
+        : [
+            {
+              id: "relevant-notes",
+              icon: <FileSearch className="tw-size-4" />,
+              title: "Relevant Notes",
+              renderBody: () => (
+                <RelevantNotesShelfPanel
+                  onPopOut={() => void plugin.activateRelevantNotesView()}
+                  onAddToChat={(text) => void plugin.insertTextIntoActiveChat(text)}
+                />
+              ),
+            },
+          ]),
       {
         // Projects isn't shipped yet: greyed on the right, "Coming soon" on
         // hover, and its list never mounts (the shelf won't make a disabled
@@ -290,6 +311,8 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
       handleDeleteChat,
       handleOpenSourceFile,
       handleLoadChatHistory,
+      isRelevantNotesPaneOpen,
+      plugin,
     ]
   );
 
@@ -411,7 +434,10 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
                      keeping the tab bar in reach. No extra horizontal padding so
                      the card lines up with the composer's border. */
                   <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-pt-6">
-                    <AgentHomeShelf sections={landingSections} />
+                    <AgentHomeShelf
+                      sections={landingSections}
+                      storageKey={HOME_SHELF_TAB_STORAGE_KEY}
+                    />
                   </div>
                 ) : null}
               </div>

--- a/src/agentMode/ui/AgentHomeShelf.test.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.test.tsx
@@ -3,16 +3,19 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
+// Shared test key for storageKey tests.
+const TEST_STORAGE_KEY = "test:shelf-tab";
+
 // The tooltip portal targets Obsidian's `activeDocument` global (popout-safe);
 // jsdom has no such global, so point it at the test document.
 beforeAll(() => {
   (window as unknown as { activeDocument: Document }).activeDocument = window.document;
 });
 
-function renderShelf(sections: AgentHomeShelfSection[]) {
+function renderShelf(sections: AgentHomeShelfSection[], storageKey?: string) {
   return render(
     <TooltipProvider>
-      <AgentHomeShelf sections={sections} />
+      <AgentHomeShelf sections={sections} storageKey={storageKey} />
     </TooltipProvider>
   );
 }
@@ -55,5 +58,74 @@ describe("AgentHomeShelf with a disabled section", () => {
     fireEvent.click(screen.getByRole("tab", { name: /Projects/ }));
     expect(screen.queryByText("PROJECTS BODY")).toBeNull();
     expect(screen.queryByText("CHATS BODY")).not.toBeNull();
+  });
+});
+
+describe("AgentHomeTab count badge", () => {
+  const noCount: AgentHomeShelfSection = {
+    id: "nocnt",
+    icon: <span />,
+    title: "No Count",
+    renderBody: () => <div>NO COUNT BODY</div>,
+  };
+  const zeroCount: AgentHomeShelfSection = {
+    id: "zerocnt",
+    icon: <span />,
+    title: "Zero Count",
+    count: 0,
+    renderBody: () => <div>ZERO COUNT BODY</div>,
+  };
+
+  it("shows no badge when count is undefined", () => {
+    renderShelf([noCount]);
+    const tab = screen.getByRole("tab", { name: /No Count/ });
+    // Only the icon + title text — no numeric suffix.
+    expect(tab.textContent?.trim()).toBe("No Count");
+  });
+
+  it("shows no badge when count is 0", () => {
+    renderShelf([zeroCount]);
+    const tab = screen.getByRole("tab", { name: /Zero Count/ });
+    expect(tab.textContent?.trim()).toBe("Zero Count");
+  });
+
+  it("shows the badge when count is positive", () => {
+    renderShelf([chats]);
+    const tab = screen.getByRole("tab", { name: /Recent Chats/ });
+    expect(tab.textContent).toContain("2");
+  });
+});
+
+describe("AgentHomeShelf storageKey persistence and fallback", () => {
+  const notes: AgentHomeShelfSection = {
+    id: "notes",
+    icon: <span />,
+    title: "Notes",
+    renderBody: () => <div>NOTES BODY</div>,
+  };
+
+  beforeEach(() => {
+    window.localStorage.removeItem(TEST_STORAGE_KEY);
+  });
+
+  it("persists the selected tab id to localStorage on click", () => {
+    renderShelf([chats, notes], TEST_STORAGE_KEY);
+    fireEvent.click(screen.getByRole("tab", { name: /Notes/ }));
+    expect(window.localStorage.getItem(TEST_STORAGE_KEY)).toBe("notes");
+  });
+
+  it("restores the persisted tab on mount", () => {
+    window.localStorage.setItem(TEST_STORAGE_KEY, "notes");
+    renderShelf([chats, notes], TEST_STORAGE_KEY);
+    expect(screen.queryByText("NOTES BODY")).not.toBeNull();
+    expect(screen.queryByText("CHATS BODY")).toBeNull();
+  });
+
+  it("falls back to the first selectable tab when the persisted id is absent", () => {
+    // "relevant-notes" was persisted but that section is no longer in the list.
+    window.localStorage.setItem(TEST_STORAGE_KEY, "relevant-notes");
+    renderShelf([chats, notes], TEST_STORAGE_KEY);
+    expect(screen.queryByText("CHATS BODY")).not.toBeNull();
+    expect(screen.queryByText("NOTES BODY")).toBeNull();
   });
 });

--- a/src/agentMode/ui/AgentHomeShelf.tsx
+++ b/src/agentMode/ui/AgentHomeShelf.tsx
@@ -1,6 +1,7 @@
 import { AgentHomeTab } from "@/agentMode/ui/AgentHomeTab";
+import { getHomeShelfTab, setHomeShelfTab } from "@/agentMode/ui/homeShelfPrefs";
 import { cn } from "@/lib/utils";
-import React, { useId, useState } from "react";
+import React, { useCallback, useId, useState } from "react";
 
 export interface AgentHomeShelfSection {
   /** Stable id used for tab selection. */
@@ -8,7 +9,7 @@ export interface AgentHomeShelfSection {
   /** Leading type icon for the tab. */
   icon: React.ReactNode;
   title: string;
-  count: number;
+  count?: number;
   /** Rendered into the panel while this tab is the selected one. */
   renderBody: () => React.ReactNode;
   /**
@@ -24,6 +25,7 @@ export interface AgentHomeShelfSection {
 interface AgentHomeShelfProps {
   sections: AgentHomeShelfSection[];
   className?: string;
+  storageKey?: string;
 }
 
 /**
@@ -33,11 +35,25 @@ interface AgentHomeShelfProps {
  * section bodies are sized to lead with the same number of rows, so switching
  * tabs doesn't change the card height.
  */
-export function AgentHomeShelf({ sections, className }: AgentHomeShelfProps): React.ReactElement {
+export function AgentHomeShelf({
+  sections,
+  className,
+  storageKey,
+}: AgentHomeShelfProps): React.ReactElement {
   // Default to (and only ever resolve to) the first selectable section — a
   // disabled tab can't be activated, so its body never mounts.
   const firstSelectable = sections.find((s) => !s.disabled) ?? null;
-  const [activeId, setActiveId] = useState<string | null>(firstSelectable?.id ?? null);
+  const [activeId, setActiveIdState] = useState<string | null>(() => {
+    const stored = storageKey ? getHomeShelfTab(storageKey) : null;
+    return stored ?? firstSelectable?.id ?? null;
+  });
+  const selectTab = useCallback(
+    (id: string) => {
+      setActiveIdState(id);
+      if (storageKey) setHomeShelfTab(storageKey, id);
+    },
+    [storageKey]
+  );
   const requested = sections.find((s) => s.id === activeId);
   const active = requested && !requested.disabled ? requested : firstSelectable;
   const panelId = useId();
@@ -79,7 +95,7 @@ export function AgentHomeShelf({ sections, className }: AgentHomeShelfProps): Re
             controlsId={panelId}
             disabled={section.disabled}
             disabledTooltip={section.disabledTooltip}
-            onClick={() => setActiveId(section.id)}
+            onClick={() => selectTab(section.id)}
           />
         ))}
       </div>

--- a/src/agentMode/ui/AgentHomeTab.tsx
+++ b/src/agentMode/ui/AgentHomeTab.tsx
@@ -9,7 +9,7 @@ interface AgentHomeTabProps {
   /** Leading type icon (sized by the caller, typically `tw-size-4`). */
   icon: React.ReactNode;
   title: string;
-  count: number;
+  count?: number;
   /** Whether this tab is the selected one. */
   active: boolean;
   onClick: () => void;
@@ -68,7 +68,7 @@ export const AgentHomeTab = memo(function AgentHomeTab({
     >
       <span className="tw-flex tw-shrink-0 tw-items-center tw-text-muted">{icon}</span>
       <span>{title}</span>
-      {!disabled && (
+      {!disabled && typeof count === "number" && count > 0 && (
         <span className={cn("tw-text-ui-smaller", active ? "tw-text-muted" : "tw-text-faint")}>
           {count}
         </span>

--- a/src/agentMode/ui/CopilotAgentView.tsx
+++ b/src/agentMode/ui/CopilotAgentView.tsx
@@ -3,6 +3,7 @@ import { attachChatViewLayoutObservers } from "@/components/chat-components/atta
 import { CHAT_AGENT_VIEWTYPE, COPILOT_AGENT_ICON_ID } from "@/constants";
 import { ChatViewEventTarget, EventTargetContext } from "@/context";
 import CopilotPlugin from "@/main";
+import { registerActiveLeafChangeBridge } from "@/utils/registerActiveLeafChangeBridge";
 import { mountPluginViewRoot, type PluginViewRootHandle } from "@/utils/react/mountPluginViewRoot";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { ItemView, WorkspaceLeaf } from "obsidian";
@@ -45,6 +46,8 @@ export default class CopilotAgentView extends ItemView {
 
     const observers = attachChatViewLayoutObservers(this.containerEl);
     this.disposeLayoutObservers = observers.dispose;
+
+    registerActiveLeafChangeBridge(this, this.eventTarget);
 
     this.registerEvent(
       this.app.workspace.on("layout-change", () => {

--- a/src/agentMode/ui/RelevantNotesShelfPanel.tsx
+++ b/src/agentMode/ui/RelevantNotesShelfPanel.tsx
@@ -1,0 +1,66 @@
+import { dismissPopOutHint, isPopOutHintDismissed } from "@/agentMode/ui/homeShelfPrefs";
+import { RelevantNotes } from "@/components/chat-components/RelevantNotes";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ExternalLink, X } from "lucide-react";
+import React, { useState } from "react";
+
+interface RelevantNotesShelfPanelProps {
+  /** Open the dedicated Relevant Notes pane (the shelf is transient). */
+  onPopOut: () => void;
+  /** Insert text (a `[[wikilink]]`) into the target chat input. */
+  onAddToChat: (text: string) => void;
+}
+
+/**
+ * Relevant Notes rendered inside the Agent Home shelf. The shelf is transient
+ * (it collapses as you chat), so a one-time, dismissible hint nudges the user
+ * toward the dedicated pane that persists alongside the conversation. Assumes
+ * the surrounding agent view already provides AppContext + EventTargetContext.
+ */
+export function RelevantNotesShelfPanel({ onPopOut, onAddToChat }: RelevantNotesShelfPanelProps) {
+  const [hintDismissed, setHintDismissed] = useState(() => isPopOutHintDismissed());
+
+  const handleDismiss = () => {
+    dismissPopOutHint();
+    setHintDismissed(true);
+  };
+
+  return (
+    <div className={cn("tw-flex tw-size-full tw-flex-col tw-overflow-hidden")}>
+      {!hintDismissed && (
+        <div
+          className={cn(
+            "tw-flex tw-shrink-0 tw-items-center tw-gap-2 tw-rounded-md tw-border tw-border-solid",
+            "tw-border-border tw-bg-secondary tw-px-2 tw-py-1.5 tw-text-ui-smaller tw-text-muted"
+          )}
+        >
+          <span className="tw-min-w-0 tw-flex-1">
+            Open Relevant Notes in its own pane to keep it while you chat.
+          </span>
+          <Button
+            variant="ghost2"
+            size="fit"
+            className={cn("tw-shrink-0 tw-text-muted", "hover:tw-text-normal")}
+            onClick={onPopOut}
+          >
+            <ExternalLink className="tw-size-3" />
+            Open pane
+          </Button>
+          <Button
+            variant="ghost2"
+            size="fit"
+            className={cn("tw-shrink-0 tw-text-muted", "hover:tw-text-normal")}
+            onClick={handleDismiss}
+            aria-label="Dismiss hint"
+          >
+            <X className="tw-size-3" />
+          </Button>
+        </div>
+      )}
+      <div className={cn("tw-min-h-0 tw-flex-1")}>
+        <RelevantNotes onAddToChat={onAddToChat} />
+      </div>
+    </div>
+  );
+}

--- a/src/agentMode/ui/homeShelfPrefs.ts
+++ b/src/agentMode/ui/homeShelfPrefs.ts
@@ -1,0 +1,53 @@
+/**
+ * Device-local UI preferences for the Agent Home shelf, persisted in
+ * `window.localStorage` (which Obsidian never syncs). Mirrors the storage idiom
+ * in `deviceId.ts`: every access is wrapped in try/catch, reads return a safe
+ * default on failure, and writes swallow errors so a broken-storage device
+ * (disabled / restricted) never crashes the UI — it just loses persistence.
+ *
+ * These are intentionally device-local: which shelf tab you last viewed and
+ * whether you dismissed the pop-out hint are per-device UI state, not content
+ * that should ride a synced `data.json` to your other devices.
+ */
+
+import { logWarn } from "@/logger";
+
+const HOME_SHELF_TAB_KEY = "copilot:home-shelf-tab:v1";
+const POPOUT_HINT_DISMISSED_KEY = "copilot:relevant-notes-popout-hint-dismissed:v1";
+
+/** Read the last-selected shelf tab id, or `null` when unset or storage is unusable. */
+export function getHomeShelfTab(): string | null {
+  try {
+    const value = window.localStorage.getItem(HOME_SHELF_TAB_KEY);
+    return value && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the selected shelf tab id; no-op if storage is unusable. */
+export function setHomeShelfTab(id: string): void {
+  try {
+    window.localStorage.setItem(HOME_SHELF_TAB_KEY, id);
+  } catch (e) {
+    logWarn("Failed to persist home shelf tab", e);
+  }
+}
+
+/** Whether the user dismissed the Relevant Notes pop-out hint; defaults to false. */
+export function isPopOutHintDismissed(): boolean {
+  try {
+    return window.localStorage.getItem(POPOUT_HINT_DISMISSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+/** Mark the Relevant Notes pop-out hint dismissed; no-op if storage is unusable. */
+export function dismissPopOutHint(): void {
+  try {
+    window.localStorage.setItem(POPOUT_HINT_DISMISSED_KEY, "true");
+  } catch (e) {
+    logWarn("Failed to persist pop-out hint dismissal", e);
+  }
+}

--- a/src/agentMode/ui/homeShelfPrefs.ts
+++ b/src/agentMode/ui/homeShelfPrefs.ts
@@ -12,13 +12,13 @@
 
 import { logWarn } from "@/logger";
 
-const HOME_SHELF_TAB_KEY = "copilot:home-shelf-tab:v1";
+export const HOME_SHELF_TAB_STORAGE_KEY = "copilot:home-shelf-tab:v1";
 const POPOUT_HINT_DISMISSED_KEY = "copilot:relevant-notes-popout-hint-dismissed:v1";
 
 /** Read the last-selected shelf tab id, or `null` when unset or storage is unusable. */
-export function getHomeShelfTab(): string | null {
+export function getHomeShelfTab(storageKey: string): string | null {
   try {
-    const value = window.localStorage.getItem(HOME_SHELF_TAB_KEY);
+    const value = window.localStorage.getItem(storageKey);
     return value && value.length > 0 ? value : null;
   } catch {
     return null;
@@ -26,9 +26,9 @@ export function getHomeShelfTab(): string | null {
 }
 
 /** Persist the selected shelf tab id; no-op if storage is unusable. */
-export function setHomeShelfTab(id: string): void {
+export function setHomeShelfTab(storageKey: string, id: string): void {
   try {
-    window.localStorage.setItem(HOME_SHELF_TAB_KEY, id);
+    window.localStorage.setItem(storageKey, id);
   } catch (e) {
     logWarn("Failed to persist home shelf tab", e);
   }

--- a/src/agentMode/ui/useRelevantNotesPaneOpen.ts
+++ b/src/agentMode/ui/useRelevantNotesPaneOpen.ts
@@ -1,0 +1,19 @@
+import { RELEVANT_NOTES_VIEWTYPE } from "@/constants";
+import type { App } from "obsidian";
+import { useEffect, useState } from "react";
+
+/** True while a dedicated Relevant Notes pane leaf is open; updates on layout-change. */
+export function useRelevantNotesPaneOpen(app: App): boolean {
+  const [open, setOpen] = useState(
+    () => app.workspace.getLeavesOfType(RELEVANT_NOTES_VIEWTYPE).length > 0
+  );
+  useEffect(() => {
+    // Re-sync on mount in case the workspace changed between the lazy-init read
+    // and this effect running (e.g. a layout restored in the same tick).
+    const update = () => setOpen(app.workspace.getLeavesOfType(RELEVANT_NOTES_VIEWTYPE).length > 0);
+    update();
+    const ref = app.workspace.on("layout-change", update);
+    return () => app.workspace.offref(ref);
+  }, [app]);
+  return open;
+}

--- a/src/components/CopilotView.tsx
+++ b/src/components/CopilotView.tsx
@@ -4,6 +4,7 @@ import { CHAT_VIEWTYPE } from "@/constants";
 import { ChatViewEventTarget, EventTargetContext } from "@/context";
 import CopilotPlugin from "@/main";
 import { FileParserManager } from "@/tools/FileParserManager";
+import { registerActiveLeafChangeBridge } from "@/utils/registerActiveLeafChangeBridge";
 import { mountPluginViewRoot, type PluginViewRootHandle } from "@/utils/react/mountPluginViewRoot";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { ItemView, Platform, WorkspaceLeaf } from "obsidian";
@@ -55,6 +56,8 @@ export default class CopilotView extends ItemView {
     this.viewRoot = mountPluginViewRoot(this.containerEl, this.app, () => this.renderTree());
     this.setupMobileKeyboardObserver();
     this.setupDrawerHideObserver();
+
+    registerActiveLeafChangeBridge(this, this.eventTarget);
 
     // Reason: The view can move between containers (e.g. editor tab → drawer)
     // without onOpen firing again. Re-bind the drawer observer on layout changes

--- a/src/components/RelevantNotesView.tsx
+++ b/src/components/RelevantNotesView.tsx
@@ -1,9 +1,10 @@
 import { RelevantNotes } from "@/components/chat-components/RelevantNotes";
-import { EVENT_NAMES, RELEVANT_NOTES_VIEWTYPE } from "@/constants";
+import { RELEVANT_NOTES_VIEWTYPE } from "@/constants";
 import { EventTargetContext } from "@/context";
 import CopilotPlugin from "@/main";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
-import { ItemView, MarkdownView, WorkspaceLeaf } from "obsidian";
+import { registerActiveLeafChangeBridge } from "@/utils/registerActiveLeafChangeBridge";
+import { ItemView, WorkspaceLeaf } from "obsidian";
 import * as React from "react";
 import { Root } from "react-dom/client";
 
@@ -12,9 +13,9 @@ import { Root } from "react-dom/client";
  *
  * `RelevantNotes` reads the active file via `useActiveFile`, which seeds from
  * the current active file on mount and then updates on the `ACTIVE_LEAF_CHANGE`
- * event on this view's own `eventTarget`. The plugin's global handler dispatches
- * that event only to the legacy chat view, so this view feeds its own
- * `eventTarget` (mirroring that handler's condition) on subsequent leaf changes.
+ * event on this view's own `eventTarget`. This view bridges that event itself
+ * via `registerActiveLeafChangeBridge` since no other component feeds its
+ * `eventTarget`.
  */
 export default class RelevantNotesView extends ItemView {
   private root: Root | null = null;
@@ -49,13 +50,7 @@ export default class RelevantNotesView extends ItemView {
     this.root = createPluginRoot(this.containerEl.children[1], this.app);
     this.renderView();
 
-    this.registerEvent(
-      this.app.workspace.on("active-leaf-change", (leaf) => {
-        if (leaf?.view instanceof MarkdownView && leaf.view.file) {
-          this.eventTarget.dispatchEvent(new CustomEvent(EVENT_NAMES.ACTIVE_LEAF_CHANGE));
-        }
-      })
-    );
+    registerActiveLeafChangeBridge(this, this.eventTarget);
   }
 
   private renderView(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -373,22 +373,6 @@ export default class CopilotPlugin extends Plugin {
         if (activeViewType === CHAT_VIEWTYPE || activeViewType === CHAT_AGENT_VIEWTYPE) {
           this.lastActiveChatViewType = activeViewType;
         }
-
-        if (leaf && leaf.view instanceof MarkdownView) {
-          const file = leaf.view.file;
-          if (file) {
-            // Note: File tracking and real-time reindexing removed for simplicity
-            // Semantic search indexes are rebuilt manually or on startup as needed
-            const activeCopilotView = this.app.workspace
-              .getLeavesOfType(CHAT_VIEWTYPE)
-              .find((leaf) => leaf.view instanceof CopilotView)?.view as CopilotView;
-
-            if (activeCopilotView) {
-              const event = new CustomEvent(EVENT_NAMES.ACTIVE_LEAF_CHANGE);
-              activeCopilotView.eventTarget.dispatchEvent(event);
-            }
-          }
-        }
       })
     );
 

--- a/src/utils/registerActiveLeafChangeBridge.ts
+++ b/src/utils/registerActiveLeafChangeBridge.ts
@@ -1,0 +1,23 @@
+import { EVENT_NAMES } from "@/constants";
+import { ItemView, MarkdownView } from "obsidian";
+
+/**
+ * Bridge Obsidian's workspace `active-leaf-change` onto a view-local
+ * `eventTarget` so React consumers (via `useActiveFile`) re-read the active
+ * file when the user switches notes.
+ *
+ * Each chat-ish view self-owns this bridge rather than relying on a single
+ * plugin-level dispatch: `useActiveFile` listens on the view's own
+ * `eventTarget`, so a view that never feeds its target stays frozen at its
+ * mount seed. Registering through the view's `registerEvent` ties the listener
+ * to the view lifecycle (auto-unregistered on close).
+ */
+export function registerActiveLeafChangeBridge(view: ItemView, eventTarget: EventTarget): void {
+  view.registerEvent(
+    view.app.workspace.on("active-leaf-change", (leaf) => {
+      if (leaf?.view instanceof MarkdownView && leaf.view.file) {
+        eventTarget.dispatchEvent(new CustomEvent(EVENT_NAMES.ACTIVE_LEAF_CHANGE));
+      }
+    })
+  );
+}


### PR DESCRIPTION
## Why

Relevant Notes has been palette-only since #2559 (moved out of the chat into a dedicated pane). Discoverability dropped to ~zero. This resurfaces it where users already are — the agent home — without re-cluttering the chat.

Planned via an otacon socratic session; the final design diverged from the initial "add a ribbon icon" idea after reasoning through Smart Connections' model and our chat-first priority.

## What

- **New "Relevant Notes" tab** on the agent home shelf (order: Recent Chats · Relevant Notes · Projects), reusing the existing `RelevantNotes` component. Rendered **unconditionally** — embeddings-off users hit the existing "enable semantic search" CTA, turning the tab into an in-context funnel.
- **Dismissible pop-out hint** inside the tab opens the existing dedicated pane — the persistent / during-chat path the landing-only shelf can't provide.
- **Tab hidden while the dedicated pane is open** (`useRelevantNotesPaneOpen`, reactive to `layout-change`) so the two surfaces never duplicate; it returns when the pane closes.
- **Selected tab persisted** in device-local `localStorage` (no settings-schema change); fallback-to-first-selectable is preserved so an absent persisted id never breaks.
- **Count badge made optional** on the shelf tab (renders only when `count > 0`), so Relevant Notes shows no badge and does no eager semantic compute.
- **No ribbon.** The dedicated `RelevantNotesView` pane + "Open Relevant Notes" command are unchanged and serve as the pop-out target.

## Phases

1. `RelevantNotesShelfPanel` (tab body + dismissible pop-out hint) and `homeShelfPrefs` localStorage helpers.
2. Shelf wiring: the tab section, `useRelevantNotesPaneOpen` mutual-exclusion, optional-count badge, and tab persistence — plus focused `AgentHomeShelf` tests.

## Verification

- `npm run build` passes (tsc + esbuild + tailwind); `styles.css` unchanged.
- `eslint .` + `prettier --check` clean.
- `AgentHomeShelf.test.tsx`: 9/9 (3 existing + 6 new — count suppression, persistence, restore, fallback).
- Manual QA via `npm run test:vault` recommended: confirm the tab lists notes for the active file, Add-to-Chat works from the landing, and the tab toggles correctly as the dedicated pane opens/closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)