### PR TITLE
fix(agent-mode): ship Windows cmd/ps1 runtime for builtin relay skills

### DIFF
--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -60,7 +60,7 @@ For these requests, prefer the bundled Copilot skill over any built-in tool of y
 - Getting a YouTube video's transcript → the \`copilot-youtube-transcript\` skill
 - Fetching an X (Twitter) post → the \`copilot-fetch-x\` skill
 
-Each skill ships both a \`.sh\` and a \`.mjs\` script. Run the \`.sh\` with \`sh\` first; if the platform can't run \`sh\` (for example, Windows without Git Bash), run the matching \`.mjs\` with \`node\` instead. If neither \`sh\` nor \`node\` is available, tell the user to install Node.js from https://nodejs.org and try again.
+Each skill ships a runnable script per OS — a \`.sh\` for macOS/Linux and a \`.cmd\` for Windows. Follow the skill's own "How to run" instructions for the right command; both runtimes are always present, so nothing needs to be installed.
 
 If a skill is missing, disabled, reports that Copilot Plus is not active, or fails for this particular request (for example a page it can't fetch or any other relay error), silently fall back to your own equivalent tool (or, if you have none for that task, tell the user it's unavailable) and complete the request — never refuse and never block the user on upgrading. Only pass along an upgrade or renewal note when the skill's own message explicitly invites it, and keep any such mention brief and occasional.`;
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -77,6 +77,11 @@ describe("builtin Copilot Plus skills", () => {
       // Same license guard as the shell script.
       expect(ps1).toContain("if (-not $KEY -or -not $BASE) { NoLicense }");
       expect(ps1).toContain("Copilot Plus");
+      // The body is sent as explicit UTF-8 bytes — Windows PowerShell 5.1 would
+      // otherwise ASCII-encode a string body and corrupt non-ASCII input.
+      expect(ps1).toContain("[System.Text.Encoding]::UTF8.GetBytes($json)");
+      expect(ps1).toContain("application/json; charset=utf-8");
+      expect(ps1).toContain("-Body $bytes");
     }
   });
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,7 +1,7 @@
 import { BUILTIN_SKILLS, managedBuiltinSkills, MIYO_SEARCH_SKILL, PLUS_ENV } from "./builtinSkills";
 
-/** A script file shipped by a skill, matched by extension (".sh" or ".mjs"). */
-function scriptOf(name: string, ext: ".sh" | ".mjs" = ".sh"): string {
+/** A script file shipped by a skill, matched by extension (".sh", ".cmd", ".ps1"). */
+function scriptOf(name: string, ext: ".sh" | ".cmd" | ".ps1" = ".sh"): string {
   const skill = BUILTIN_SKILLS.find((s) => s.name === name);
   if (!skill) throw new Error(`no builtin skill ${name}`);
   const file = skill.files.find((f) => f.path.endsWith(ext));
@@ -29,19 +29,30 @@ describe("builtin Copilot Plus skills", () => {
     }
   });
 
-  it("ships both an sh and a node script, and documents the sh → node fallback", () => {
+  it("ships one runnable script per OS — POSIX sh + Windows cmd/ps1, no Node", () => {
     for (const skill of BUILTIN_SKILLS) {
       const sh = skill.files.find((f) => f.path.endsWith(".sh"));
-      const mjs = skill.files.find((f) => f.path.endsWith(".mjs"));
+      const cmd = skill.files.find((f) => f.path.endsWith(".cmd"));
+      const ps1 = skill.files.find((f) => f.path.endsWith(".ps1"));
       expect(sh).toBeDefined();
-      expect(mjs).toBeDefined();
-      // The two scripts share a base name (web-search.sh ↔ web-search.mjs).
-      expect(mjs!.path).toBe(sh!.path.replace(/\.sh$/, ".mjs"));
-      // SKILL.md tells the agent to prefer sh, fall back to node, then prompt
-      // for a Node install if neither runtime is available.
+      expect(cmd).toBeDefined();
+      expect(ps1).toBeDefined();
+      // The three scripts share a base name (web-search.sh ↔ .cmd ↔ .ps1).
+      expect(cmd!.path).toBe(sh!.path.replace(/\.sh$/, ".cmd"));
+      expect(ps1!.path).toBe(sh!.path.replace(/\.sh$/, ".ps1"));
+      // SKILL.md routes macOS/Linux at sh and Windows at the cmd wrapper (run
+      // with PowerShell's `&` call operator), with no Node anywhere.
       expect(skill.skillMd).toContain(`sh "/absolute/path/to/this/skill/directory/${sh!.path}"`);
-      expect(skill.skillMd).toContain(`node "/absolute/path/to/this/skill/directory/${mjs!.path}"`);
-      expect(skill.skillMd).toContain("install Node.js");
+      expect(skill.skillMd).toContain(`& "/absolute/path/to/this/skill/directory/${cmd!.path}"`);
+      expect(skill.skillMd).not.toContain("install Node.js");
+      expect(skill.skillMd).not.toContain("node ");
+      // No Node runtime ships anymore.
+      expect(skill.files.some((f) => f.path.endsWith(".mjs"))).toBe(false);
+      // The cmd launcher drives the sibling ps1 via Windows PowerShell with the
+      // execution policy relaxed, locating it relative to its own folder.
+      expect(cmd!.content).toContain("WindowsPowerShell\\v1.0\\powershell.exe");
+      expect(cmd!.content).toContain("-ExecutionPolicy Bypass");
+      expect(cmd!.content).toContain(`-File "%~dp0${ps1!.path}"`);
     }
   });
 
@@ -58,15 +69,14 @@ describe("builtin Copilot Plus skills", () => {
       expect(sh).toContain('[ -n "$KEY" ] && [ -n "$BASE" ] || no_license');
       expect(sh).toContain("Copilot Plus");
 
-      const mjs = scriptOf(skill.name, ".mjs");
-      expect(mjs).toContain(`#!/usr/bin/env node`);
-      expect(mjs).toContain(`process.env.${PLUS_ENV.licenseKey}`);
-      expect(mjs).toContain(`process.env.${PLUS_ENV.baseUrl}`);
-      expect(mjs).toContain('Authorization: "Bearer " + KEY');
-      expect(mjs).toContain('"X-Client-Version": CLIENT_VERSION');
+      const ps1 = scriptOf(skill.name, ".ps1");
+      expect(ps1).toContain(`[Environment]::GetEnvironmentVariable('${PLUS_ENV.licenseKey}')`);
+      expect(ps1).toContain(`[Environment]::GetEnvironmentVariable('${PLUS_ENV.baseUrl}')`);
+      expect(ps1).toContain('Authorization = "Bearer $KEY"');
+      expect(ps1).toContain("'X-Client-Version' = $CLIENT_VERSION");
       // Same license guard as the shell script.
-      expect(mjs).toContain("if (!KEY || !BASE) noLicense();");
-      expect(mjs).toContain("Copilot Plus");
+      expect(ps1).toContain("if (-not $KEY -or -not $BASE) { NoLicense }");
+      expect(ps1).toContain("Copilot Plus");
     }
   });
 
@@ -96,20 +106,20 @@ describe("builtin Copilot Plus skills", () => {
       expect(sh).toContain("$RELAY_FAILED_FALLBACK");
       expect(sh).toContain("your own equivalent built-in tool for this");
 
-      const mjs = scriptOf(skill.name, ".mjs");
-      expect(mjs).toContain("your own equivalent built-in tools");
-      expect(mjs).not.toContain("web tools");
-      expect(mjs).toContain("process.pid % 4 === 0");
-      expect(mjs).toContain("die(LICENSE_INVALID)");
-      expect(mjs).toContain("RELAY_FAILED_FALLBACK");
+      const ps1 = scriptOf(skill.name, ".ps1");
+      expect(ps1).toContain("your own equivalent built-in tools");
+      expect(ps1).not.toContain("web tools");
+      expect(ps1).toContain("($PID % 4) -eq 0");
+      expect(ps1).toContain("Die $LICENSE_INVALID");
+      expect(ps1).toContain("RELAY_FAILED_FALLBACK");
     }
   });
 
   it("includes the firecrawl-backed web-fetch skill targeting /url4llm", () => {
     expect(scriptOf("copilot-web-fetch", ".sh")).toContain('relay "/url4llm"');
     expect(scriptOf("copilot-web-fetch", ".sh")).toContain('\\"url\\"');
-    expect(scriptOf("copilot-web-fetch", ".mjs")).toContain('await relay("/url4llm"');
-    expect(scriptOf("copilot-web-fetch", ".mjs")).toContain("url: ARG, user_id: USER_ID");
+    expect(scriptOf("copilot-web-fetch", ".ps1")).toContain('Invoke-Relay "/url4llm"');
+    expect(scriptOf("copilot-web-fetch", ".ps1")).toContain("@{ url = $ARG; user_id = $USER_ID }");
   });
 
   it("maps each relay tool to its endpoint and request body (both scripts)", () => {
@@ -120,11 +130,13 @@ describe("builtin Copilot Plus skills", () => {
     // Single-arg tools JSON-escape the argument they pass.
     expect(scriptOf("copilot-web-search", ".sh")).toContain('$(json_escape "$ARG")');
 
-    // The node fallback hits the same endpoints with a structured body.
-    expect(scriptOf("copilot-web-search", ".mjs")).toContain('await relay("/websearch"');
-    expect(scriptOf("copilot-web-search", ".mjs")).toContain("query: ARG, user_id: USER_ID");
-    expect(scriptOf("copilot-youtube-transcript", ".mjs")).toContain('await relay("/youtube4llm"');
-    expect(scriptOf("copilot-fetch-x", ".mjs")).toContain('await relay("/twitter4llm"');
+    // The PowerShell sibling hits the same endpoints with a structured body.
+    expect(scriptOf("copilot-web-search", ".ps1")).toContain('Invoke-Relay "/websearch"');
+    expect(scriptOf("copilot-web-search", ".ps1")).toContain(
+      "@{ query = $ARG; user_id = $USER_ID }"
+    );
+    expect(scriptOf("copilot-youtube-transcript", ".ps1")).toContain('Invoke-Relay "/youtube4llm"');
+    expect(scriptOf("copilot-fetch-x", ".ps1")).toContain('Invoke-Relay "/twitter4llm"');
   });
 
   it("read-pdf base64-encodes the file into the pdf field (both scripts)", () => {
@@ -133,10 +145,12 @@ describe("builtin Copilot Plus skills", () => {
     expect(sh).toContain("base64");
     expect(sh).toContain('\\"pdf\\"');
 
-    const mjs = scriptOf("copilot-read-pdf", ".mjs");
-    expect(mjs).toContain('await relay("/pdf4llm"');
-    expect(mjs).toContain('toString("base64")');
-    expect(mjs).toContain("pdf: PDF, user_id: USER_ID");
+    const ps1 = scriptOf("copilot-read-pdf", ".ps1");
+    expect(ps1).toContain('Invoke-Relay "/pdf4llm"');
+    expect(ps1).toContain(
+      "[System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes($FILE))"
+    );
+    expect(ps1).toContain("@{ pdf = $PDF; user_id = $USER_ID }");
   });
 });
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -82,6 +82,10 @@ describe("builtin Copilot Plus skills", () => {
       expect(ps1).toContain("[System.Text.Encoding]::UTF8.GetBytes($json)");
       expect(ps1).toContain("application/json; charset=utf-8");
       expect(ps1).toContain("-Body $bytes");
+      // Output side: force UTF-8 so non-ASCII relay output isn't mojibaked by
+      // Windows PowerShell 5.1's default code-page console encoding.
+      expect(ps1).toContain("[Console]::OutputEncoding = [System.Text.Encoding]::UTF8");
+      expect(ps1).toContain("$OutputEncoding = [System.Text.Encoding]::UTF8");
     }
   });
 

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -212,10 +212,14 @@ if (-not $KEY -or -not $BASE) { NoLicense }
 # Invoke-Relay endpoint body -> prints the response body, mapping HTTP status.
 function Invoke-Relay($endpoint, $body) {
   $json = $body | ConvertTo-Json -Compress -Depth 5
+  # Send UTF-8 bytes explicitly: Windows PowerShell 5.1 encodes a string body as
+  # ASCII by default (UTF-8 only became the default in 7.4), which would corrupt
+  # non-ASCII queries/URLs. A byte[] body is sent verbatim, matching curl.
+  $bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
   try {
-    $resp = Invoke-WebRequest -Uri "$BASE$endpoint" -Method Post -ContentType 'application/json' \`
+    $resp = Invoke-WebRequest -Uri "$BASE$endpoint" -Method Post -ContentType 'application/json; charset=utf-8' \`
       -Headers @{ Authorization = "Bearer $KEY"; 'X-Client-Version' = $CLIENT_VERSION } \`
-      -Body $json -UseBasicParsing
+      -Body $bytes -UseBasicParsing
     $code = [int]$resp.StatusCode
     $out = $resp.Content
   } catch {

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -182,6 +182,12 @@ function powershellPreamble(): string {
 # stdout. Reads its config from env the plugin injects at agent spawn; embeds no
 # key. Targets Windows PowerShell 5.1 (.NET BCL only) so it needs no Node.
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+# Emit stdout/stderr as UTF-8: Windows PowerShell 5.1 defaults Console.OutputEncoding
+# to the system code page, which mojibakes non-ASCII relay output (e.g. Japanese
+# results, fetched pages, transcripts) before the agent reads it. The removed Node
+# fallback wrote UTF-8; match that. $OutputEncoding governs the pipeline too.
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
 $BASE = [Environment]::GetEnvironmentVariable('${PLUS_ENV.baseUrl}')
 $KEY = [Environment]::GetEnvironmentVariable('${PLUS_ENV.licenseKey}')
 $USER_ID = [Environment]::GetEnvironmentVariable('${PLUS_ENV.userId}')

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -6,25 +6,25 @@ import type { BackendId } from "@/agentMode/session/types";
  * skills, these are seeded into the canonical skills folder by the plugin (see
  * `seedBuiltinSkills`) and refreshed when `version` bumps.
  *
- * Each skill ships a `SKILL.md` (instructions the agent reads) plus two
- * runnable scripts: a POSIX `sh` script (run with `curl`) and an equivalent
- * Node `.mjs` script. Both read the Copilot Plus license + relay base URL from
- * env vars the plugin injects at spawn time (see `buildCopilotPlusEnv`) and call
- * the Brevilabs relay directly — no key is embedded in the skill files. When no
- * license is configured (free user) or the relay rejects it, the script exits
- * non-zero with a message that tells the agent to fall back to its own
- * equivalent built-in capability — never to block the user — with only an
- * occasional, gentle upsell.
+ * Each skill ships a `SKILL.md` (instructions the agent reads) plus one
+ * runnable script per OS: a POSIX `sh` script for macOS/Linux and a Windows
+ * `.cmd` wrapper that drives an adjacent PowerShell `.ps1`. All read the Copilot
+ * Plus license + relay base URL from env vars the plugin injects at spawn time
+ * (see `buildCopilotPlusEnv`) and call the Brevilabs relay directly — no key is
+ * embedded in the skill files. When no license is configured (free user) or the
+ * relay rejects it, the script exits non-zero with a message that tells the
+ * agent to fall back to its own equivalent built-in capability — never to block
+ * the user — with only an occasional, gentle upsell.
  *
- * Why ship both an `sh` and a Node script: `sh` + `curl` is preferred because
- * the script runs in the *agent's* shell, where `sh`, `curl`, `sed`, and
- * `base64` live in `/usr/bin` and are reachable regardless of the user's node
- * setup (Obsidian launches with a minimal PATH that usually excludes nvm/Volta/
- * Homebrew node). But Windows has no `sh` unless Git Bash is installed, so each
- * skill also ships a Node fallback. SKILL.md tells the agent to try `sh` first,
- * fall back to `node <script>.mjs`, and — if neither runtime exists — prompt the
- * user to install Node.js. Scripts need neither extra imports nor an executable
- * bit.
+ * Why one script per OS (and no Node): every runtime here is guaranteed present
+ * without any install. On macOS/Linux the agent's shell has `sh`, `curl`, `sed`,
+ * and `base64` in `/usr/bin`. On Windows, `cmd` and Windows PowerShell 5.1 ship
+ * with the OS, so the `.cmd` → `.ps1` pair runs in a bare PowerShell with no Git
+ * Bash and no Node. This matters because Obsidian launches with a reduced PATH
+ * that usually excludes nvm/Volta/Homebrew node — a managed-opencode Windows
+ * session frequently has neither `sh` nor `node`, which is why the earlier
+ * `sh` → `node` fallback dead-ended (see the PDF report in #2634). Scripts need
+ * no extra imports and no executable bit.
  */
 export interface BuiltinSkill {
   /** Folder name + SKILL.md `name`. Kebab-case, Copilot-branded. */
@@ -159,113 +159,135 @@ relay() {
 `;
 }
 
+/** Wrap a string as a single-quoted PowerShell literal (`'` doubled to escape). */
+function psSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
 /**
- * Node equivalent of {@link scriptPreamble}, shipped alongside each `.sh` so
- * Windows users (no `sh` unless Git Bash is installed) still have a runnable
- * script. Uses Node's global `fetch` (Node 18+) and the built-in `node:` core
- * modules only — no npm deps, so it runs from a bare vault folder. The `.mjs`
- * extension forces ESM regardless of any ambient `package.json`, which lets the
- * per-skill tail use top-level `await`.
+ * Windows (PowerShell) equivalent of {@link scriptPreamble}, run by the `.cmd`
+ * launcher each skill ships. Targets Windows PowerShell 5.1 — which ships with
+ * the OS, so it needs no Git Bash and no Node, the two runtimes a reduced-PATH
+ * managed-opencode session often lacks. Uses only the .NET BCL + built-in
+ * cmdlets (`Invoke-WebRequest`, `[System.Convert]`), so it runs from a bare
+ * vault folder.
  *
  * Behaviour mirrors the shell script exactly: same env vars, same relay call,
  * same no-license / 401/403 → fall-back-to-your-own-tools mapping, same
- * non-zero exits. If the runtime is older than Node 18 (`fetch` undefined) it
- * exits with a "update Node" message rather than failing obscurely.
+ * non-zero exits.
  */
-function nodeScriptPreamble(): string {
-  return `#!/usr/bin/env node
-// Node fallback for the matching .sh script — for platforms that can't run sh
-// (e.g. Windows without Git Bash). Calls the Brevilabs relay and prints the
-// JSON result to stdout. Reads its config from env the plugin injects at agent
-// spawn; embeds no key.
-const BASE = process.env.${PLUS_ENV.baseUrl} || "";
-const KEY = process.env.${PLUS_ENV.licenseKey} || "";
-const USER_ID = process.env.${PLUS_ENV.userId} || "";
-const CLIENT_VERSION = process.env.${PLUS_ENV.clientVersion} || "";
-const NO_LICENSE = ${JSON.stringify(NO_LICENSE_MESSAGE)};
-const NO_LICENSE_UPSELL = ${JSON.stringify(NO_LICENSE_UPSELL)};
-const LICENSE_INVALID = ${JSON.stringify(LICENSE_INVALID_MESSAGE)};
-const RELAY_FAILED_FALLBACK = ${JSON.stringify(RELAY_FAILED_FALLBACK)};
+function powershellPreamble(): string {
+  return `# Windows (PowerShell) sibling of the matching .sh script, launched by the .cmd
+# wrapper next to it. Calls the Brevilabs relay and prints the JSON result to
+# stdout. Reads its config from env the plugin injects at agent spawn; embeds no
+# key. Targets Windows PowerShell 5.1 (.NET BCL only) so it needs no Node.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$BASE = [Environment]::GetEnvironmentVariable('${PLUS_ENV.baseUrl}')
+$KEY = [Environment]::GetEnvironmentVariable('${PLUS_ENV.licenseKey}')
+$USER_ID = [Environment]::GetEnvironmentVariable('${PLUS_ENV.userId}')
+$CLIENT_VERSION = [Environment]::GetEnvironmentVariable('${PLUS_ENV.clientVersion}')
+if ($null -eq $USER_ID) { $USER_ID = '' }
+if ($null -eq $CLIENT_VERSION) { $CLIENT_VERSION = '' }
+$NO_LICENSE = ${psSingleQuote(NO_LICENSE_MESSAGE)}
+$NO_LICENSE_UPSELL = ${psSingleQuote(NO_LICENSE_UPSELL)}
+$LICENSE_INVALID = ${psSingleQuote(LICENSE_INVALID_MESSAGE)}
+$RELAY_FAILED_FALLBACK = ${psSingleQuote(RELAY_FAILED_FALLBACK)}
 
-function die(message, code = 2) {
-  process.stderr.write(String(message) + "\\n");
-  process.exit(code);
+function Die($message, $code = 2) {
+  [Console]::Error.WriteLine([string]$message)
+  exit $code
 }
 
-// No Copilot Plus license configured (free user). Don't block them: tell the
-// agent to use its own equivalent tools, appending the upsell only ~1 in 4 runs (keyed
-// off the process id) so the nudge stays occasional instead of firing every call.
-function noLicense() {
-  let msg = NO_LICENSE;
-  if (process.pid % 4 === 0) msg += " " + NO_LICENSE_UPSELL;
-  die(msg);
+# No Copilot Plus license configured (free user). Don't block them: tell the
+# agent to use its own equivalent tools, appending the upsell only ~1 in 4 runs
+# (keyed off the process id) so the nudge stays occasional instead of every call.
+function NoLicense {
+  $msg = $NO_LICENSE
+  if (($PID % 4) -eq 0) { $msg = "$msg $NO_LICENSE_UPSELL" }
+  Die $msg
 }
 
-if (!KEY || !BASE) noLicense();
+if (-not $KEY -or -not $BASE) { NoLicense }
 
-// relay(endpoint, body) -> prints the response body, mapping HTTP status.
-async function relay(endpoint, body) {
-  if (typeof fetch !== "function") {
-    die("This fallback needs Node 18 or newer (global fetch). Ask the user to update Node.js.", 1);
-  }
-  let resp;
+# Invoke-Relay endpoint body -> prints the response body, mapping HTTP status.
+function Invoke-Relay($endpoint, $body) {
+  $json = $body | ConvertTo-Json -Compress -Depth 5
   try {
-    resp = await fetch(BASE + endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer " + KEY,
-        "X-Client-Version": CLIENT_VERSION,
-      },
-      body: JSON.stringify(body),
-    });
+    $resp = Invoke-WebRequest -Uri "$BASE$endpoint" -Method Post -ContentType 'application/json' \`
+      -Headers @{ Authorization = "Bearer $KEY"; 'X-Client-Version' = $CLIENT_VERSION } \`
+      -Body $json -UseBasicParsing
+    $code = [int]$resp.StatusCode
+    $out = $resp.Content
   } catch {
-    die("Could not reach the Copilot relay. " + RELAY_FAILED_FALLBACK, 1);
+    # A non-2xx makes Invoke-WebRequest throw; recover the response to map status.
+    $r = $null
+    try { $r = $_.Exception.Response } catch {}
+    if (-not $r) { Die "Could not reach the Copilot relay. $RELAY_FAILED_FALLBACK" 1 }
+    $code = [int]$r.StatusCode
+    $reader = New-Object System.IO.StreamReader($r.GetResponseStream())
+    $out = $reader.ReadToEnd()
   }
-  const out = await resp.text();
-  if (resp.status === 401 || resp.status === 403) die(LICENSE_INVALID);
-  if (resp.status >= 200 && resp.status < 300) {
-    process.stdout.write(out + "\\n");
-  } else {
-    die("Request failed (HTTP " + resp.status + "): " + out + ". " + RELAY_FAILED_FALLBACK, 1);
-  }
+  if ($code -eq 401 -or $code -eq 403) { Die $LICENSE_INVALID }
+  elseif ($code -ge 200 -and $code -lt 300) { [Console]::Out.WriteLine($out) }
+  else { Die "Request failed (HTTP $code): $out. $RELAY_FAILED_FALLBACK" 1 }
 }
 `;
 }
 
 /**
- * The SKILL.md "How to run" section shared by every builtin skill. Documents
- * the `sh` → `node` → install-Node fallback chain so the agent never dead-ends
- * on a platform that lacks one runtime. `extraNote` appends a skill-specific
- * sentence (e.g. PDF's "pass an absolute path") before the trailing line.
+ * The Windows `.cmd` entry point each relay skill ships. A bare quoted path is a
+ * string (not a command) in PowerShell, so the agent runs this `.cmd`, which in
+ * turn launches the adjacent `.ps1` with an absolute `powershell.exe` path
+ * (System32 stays on PATH even in the reduced shells where `node` is missing)
+ * and `-ExecutionPolicy Bypass` so an unsigned script still runs. `%~dp0`
+ * resolves the script's own folder, so the `.ps1` is found wherever the skill
+ * dir is symlinked. `%*` forwards every argument verbatim.
+ */
+function cmdLauncher(ps1File: string): string {
+  return `@echo off
+setlocal
+set "PS=%SystemRoot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+if not exist "%PS%" set "PS=powershell"
+"%PS%" -NoProfile -ExecutionPolicy Bypass -File "%~dp0${ps1File}" %*
+exit /b %errorlevel%
+`;
+}
+
+/**
+ * The SKILL.md "How to run" section shared by every builtin skill. Ships one
+ * runnable script per OS — `sh` for macOS/Linux, a `.cmd` wrapper for Windows —
+ * each backed by a runtime that is always present (no Git Bash, no Node), so the
+ * agent never dead-ends on a missing runtime. `extraNote` appends a
+ * skill-specific sentence (e.g. PDF's "pass an absolute path") at the end.
  */
 function howToRunSection(opts: {
   shFile: string;
-  nodeFile: string;
+  cmdFile: string;
   argPlaceholder: string;
   extraNote?: string;
 }): string {
   const dir = "/absolute/path/to/this/skill/directory";
   return `## How to run
 
-Find the absolute path to this SKILL.md file on disk, then run the script that
-sits next to it. Prefer the POSIX shell version:
+Find the absolute path to this SKILL.md file on disk, then run the script next
+to it that matches the operating system. No extra runtime is needed — \`sh\`
+(macOS/Linux) and \`cmd\`/PowerShell (Windows) are always present.
+
+On macOS or Linux:
 
 \`\`\`bash
 sh "${dir}/${opts.shFile}" "${opts.argPlaceholder}"
 \`\`\`
 
-If your platform can't run \`sh\` (for example, Windows without Git Bash), run
-the Node version that sits in the same folder instead:
+On Windows, run the \`.cmd\` wrapper. In PowerShell you must prefix it with the
+call operator \`&\` (PowerShell treats a quoted path on its own as a string and
+won't run it); from cmd, run the quoted path without the \`&\`:
 
-\`\`\`bash
-node "${dir}/${opts.nodeFile}" "${opts.argPlaceholder}"
+\`\`\`powershell
+& "${dir}/${opts.cmdFile}" "${opts.argPlaceholder}"
 \`\`\`
-
-If neither \`sh\` nor \`node\` is available, tell the user to install Node.js
-from https://nodejs.org and run the command again.${opts.extraNote ? ` ${opts.extraNote}` : ""}
-
-Both scripts print the result to stdout.`;
+${opts.extraNote ? `\n${opts.extraNote}\n` : ""}
+Both print the result to stdout.`;
 }
 
 /**
@@ -302,8 +324,9 @@ function relaySkill(opts: {
   scriptFile: string;
 }): BuiltinSkill {
   const [argKey, argPlaceholder] = opts.arg;
-  const nodeScriptFile = opts.scriptFile.replace(/\.sh$/, ".mjs");
-  const version = 4;
+  const cmdFile = opts.scriptFile.replace(/\.sh$/, ".cmd");
+  const ps1File = opts.scriptFile.replace(/\.sh$/, ".ps1");
+  const version = 5;
   return {
     name: opts.name,
     version,
@@ -321,7 +344,7 @@ metadata:
 
 ${opts.intro}
 
-${howToRunSection({ shFile: opts.scriptFile, nodeFile: nodeScriptFile, argPlaceholder })}
+${howToRunSection({ shFile: opts.scriptFile, cmdFile, argPlaceholder })}
 
 ${LICENSE_PROBLEM_SECTION}
 `,
@@ -335,11 +358,15 @@ relay "${opts.endpoint}" "{\\"${argKey}\\":\\"$(json_escape "$ARG")\\",\\"user_i
 `,
       },
       {
-        path: nodeScriptFile,
-        content: `${nodeScriptPreamble()}
-const ARG = process.argv.slice(2).join(" ");
-if (!ARG) die("Usage: node ${nodeScriptFile} <${argKey}>", 1);
-await relay("${opts.endpoint}", { ${argKey}: ARG, user_id: USER_ID });
+        path: cmdFile,
+        content: cmdLauncher(ps1File),
+      },
+      {
+        path: ps1File,
+        content: `${powershellPreamble()}
+$ARG = ($args -join ' ')
+if (-not $ARG) { Die "Usage: ${ps1File} <${argKey}>" 1 }
+Invoke-Relay "${opts.endpoint}" @{ ${argKey} = $ARG; user_id = $USER_ID }
 `,
       },
     ],
@@ -368,7 +395,7 @@ const WEB_FETCH = relaySkill({
   scriptFile: "web-fetch.sh",
 });
 
-const READ_PDF_VERSION = 5;
+const READ_PDF_VERSION = 6;
 const READ_PDF: BuiltinSkill = {
   name: "copilot-read-pdf",
   version: READ_PDF_VERSION,
@@ -389,7 +416,7 @@ summarize, or quote it.
 
 ${howToRunSection({
   shFile: "read-pdf.sh",
-  nodeFile: "read-pdf.mjs",
+  cmdFile: "read-pdf.cmd",
   argPlaceholder: "<path-to-file.pdf>",
   extraNote: "Pass an absolute path to the PDF file.",
 })}
@@ -410,19 +437,22 @@ relay "/pdf4llm" "{\\"pdf\\":\\"$PDF\\",\\"user_id\\":\\"$(json_escape "$USER_ID
 `,
     },
     {
-      path: "read-pdf.mjs",
-      content: `${nodeScriptPreamble()}
-const FILE = process.argv[2] || "";
-if (!FILE) die("Usage: node read-pdf.mjs <path-to-file.pdf>", 1);
-let PDF;
+      path: "read-pdf.cmd",
+      content: cmdLauncher("read-pdf.ps1"),
+    },
+    {
+      path: "read-pdf.ps1",
+      content: `${powershellPreamble()}
+$FILE = if ($args.Count -ge 1) { $args[0] } else { '' }
+if (-not $FILE) { Die "Usage: read-pdf.ps1 <path-to-file.pdf>" 1 }
+if (-not (Test-Path -LiteralPath $FILE -PathType Leaf)) { Die "Could not read file: $FILE" 1 }
 try {
-  // Mirror brevilabsClient.ts pdf4llm: JSON body with base64-encoded pdf field.
-  const { readFileSync } = await import("node:fs");
-  PDF = readFileSync(FILE).toString("base64");
+  # Mirror brevilabsClient.ts pdf4llm: JSON body with base64-encoded pdf field.
+  $PDF = [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes($FILE))
 } catch {
-  die("Could not read file: " + FILE, 1);
+  Die "Could not read file: $FILE" 1
 }
-await relay("/pdf4llm", { pdf: PDF, user_id: USER_ID });
+Invoke-Relay "/pdf4llm" @{ pdf = $PDF; user_id = $USER_ID }
 `,
     },
   ],


### PR DESCRIPTION
## What

The builtin Copilot Plus relay skills (`copilot-read-pdf`, `copilot-web-search`, `copilot-web-fetch`, `copilot-youtube-transcript`, `copilot-fetch-x`) shipped a POSIX `.sh` plus a Node `.mjs` fallback. On Windows, a managed-opencode session launches in PowerShell with **neither** `sh` (no Git Bash) **nor** `node` on PATH — Obsidian's reduced PATH excludes nvm/Volta/Homebrew node — so the skill dead-ended.

A user hit exactly this in logancyang/obsidian-copilot-preview#194 / the PDF report in #2634: the agent ran `node ...\read-pdf.mjs`, got `node : The term 'node' is not recognized`, and told the user it couldn't read PDFs without Node.js.

## Change

Replace the Node fallback with a native Windows runtime, mirroring how `miyo-search` already solved this. Each relay skill now ships **one runnable script per OS**:

- `.sh` for macOS/Linux (unchanged behavior)
- a `.cmd` wrapper that launches an adjacent PowerShell `.ps1` via the absolute `WindowsPowerShell\v1.0\powershell.exe` (System32 stays on PATH even in reduced shells) with `-ExecutionPolicy Bypass`, resolving the `.ps1` through `%~dp0`

The `.ps1` mirrors the `.sh` exactly: TLS1.2, same env-driven config (no embedded key), base64 + HTTP POST to the relay, and the same no-license / 401-403 / relay-failure → fall-back-to-your-own-tools mapping and exit codes. Windows PowerShell 5.1 ships with the OS, so this runs with **zero install** — no Git Bash, no Node.

SKILL.md "How to run" and the `COPILOT_PLUS_TOOLS_STEERING` system prompt now route per OS, removing the "install Node.js" dead-end. Skill versions bumped (relay 4 → 5, read-pdf 5 → 6) so seeded copies refresh.

## Test

- Rewrote `builtinSkills.test.ts` to assert the per-OS `.sh` + `.cmd` + `.ps1` trio, the cmd→ps1 launcher wiring, and the PowerShell relay/endpoint/body for every skill; no `.mjs` ships.
- `builtinSkills`, `seedBuiltinSkills`, `agentSystemPrompt` suites green (47 tests). `format` + `lint` clean.

Note: an already-seeded vault may keep an inert orphan `read-pdf.mjs` (the seeder rewrites listed files but doesn't prune removed ones); it is unreferenced by SKILL.md and harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011T4qVU9iszFGZ1q5ro8m2X