### PR TITLE
feat(model-management): add DeepInfra Copilot Plus models, default off

### DIFF
--- a/src/LLMProviders/chainRunner/BaseChainRunner.ts
+++ b/src/LLMProviders/chainRunner/BaseChainRunner.ts
@@ -2,6 +2,7 @@ import { ABORT_REASON, AI_SENDER } from "@/constants";
 import { logError, logInfo } from "@/logger";
 import { ChatMessage, ResponseMetadata } from "@/types/message";
 import { err2String, formatDateTime } from "@/utils";
+import { formatUsageCapError } from "@/utils/usageCapError";
 import ChainManager from "@/LLMProviders/chainManager";
 
 export interface ChainRunner {
@@ -150,6 +151,15 @@ export abstract class BaseChainRunner implements ChainRunner {
   protected async handleError(error: unknown, processErrorChunk: (message: string) => void) {
     const msg = err2String(error);
     logError("Error during LLM invocation:", msg);
+    // Usage-cap (plan limit) errors get the friendly purchase-credits message with
+    // the dashboard link — on the main streaming path too, not just the planning
+    // catch (which routes through getApiErrorMessage). This is the common cap path:
+    // the relay returns token_limit_error mid-invocation after planning succeeds.
+    const capMessage = formatUsageCapError(error);
+    if (capMessage) {
+      processErrorChunk(capMessage);
+      return;
+    }
     const errorData =
       (error as { response?: { data?: { error?: unknown } } })?.response?.data?.error || msg;
     const errorCode = (errorData as { code?: string })?.code || msg;

--- a/src/LLMProviders/chatModelManager.bridge.test.ts
+++ b/src/LLMProviders/chatModelManager.bridge.test.ts
@@ -1,5 +1,5 @@
 import type { CustomModel } from "@/aiParams";
-import { ChatModelProviders } from "@/constants";
+import { ChatModelProviders, ModelCapability } from "@/constants";
 import { MissingApiKeyError } from "@/error";
 import { getSettings, setSettings } from "@/settings/model";
 
@@ -49,6 +49,32 @@ describe("ChatModelManager bridged models", () => {
     await expect(
       ChatModelManager.getInstance().createModelInstanceFromBridged(bridgedModel())
     ).rejects.toBeInstanceOf(MissingApiKeyError);
+  });
+
+  it("findModelByName falls back to the active bridged model so its capabilities resolve", async () => {
+    const manager = ChatModelManager.getInstance();
+    // A vision-capable Plus model that exists only as a bridged ConfiguredModel
+    // (not in legacy activeModels) — e.g. kimi-k2.7-code.
+    const model = bridgedModel({
+      name: "kimi-k2.7-code",
+      provider: ChatModelProviders.COPILOT_PLUS,
+      apiKey: "bridge-key",
+      capabilities: [ModelCapability.VISION],
+    });
+
+    // Not findable before it's the active bridged model...
+    expect(manager.findModelByName("kimi-k2.7-code")).toBeUndefined();
+
+    await manager.setChatModelFromBridged(model);
+
+    // ...now resolvable by name, carrying its VISION capability so
+    // isMultimodalModel/hasCapability route images instead of dropping them.
+    const found = manager.findModelByName("kimi-k2.7-code");
+    expect(found).toBe(model);
+    expect(found?.capabilities).toContain(ModelCapability.VISION);
+
+    // A different name never resolves to the active bridged model.
+    expect(manager.findModelByName("some-other-model")).toBeUndefined();
   });
 
   it("retains the active bridged model for temperature overrides", async () => {

--- a/src/LLMProviders/chatModelManager.bridge.test.ts
+++ b/src/LLMProviders/chatModelManager.bridge.test.ts
@@ -77,6 +77,37 @@ describe("ChatModelManager bridged models", () => {
     expect(manager.findModelByName("some-other-model")).toBeUndefined();
   });
 
+  it("prefers the active bridged model over a legacy duplicate of the same id", async () => {
+    const manager = ChatModelManager.getInstance();
+    // copilot-plus-flash exists in legacy activeModels (built-in) advertising only
+    // VISION, AND as a bridged model now also carrying REASONING. The bridged one
+    // is what's running, so it must win — otherwise hasCapability(REASONING) reads
+    // the legacy entry and reasoning content is dropped.
+    const legacyFlash = {
+      name: "copilot-plus-flash",
+      provider: ChatModelProviders.COPILOT_PLUS,
+      enabled: true,
+      capabilities: [ModelCapability.VISION],
+    };
+    setSettings({ activeModels: [legacyFlash] });
+
+    const bridged = bridgedModel({
+      name: "copilot-plus-flash",
+      provider: ChatModelProviders.COPILOT_PLUS,
+      apiKey: "bridge-key",
+      capabilities: [ModelCapability.VISION, ModelCapability.REASONING],
+    });
+    await manager.setChatModelFromBridged(bridged);
+
+    const found = manager.findModelByName("copilot-plus-flash");
+    expect(found).toBe(bridged);
+    expect(found?.capabilities).toEqual(
+      expect.arrayContaining([ModelCapability.VISION, ModelCapability.REASONING])
+    );
+
+    setSettings({ activeModels: [] });
+  });
+
   it("retains the active bridged model for temperature overrides", async () => {
     const manager = ChatModelManager.getInstance();
     const model = bridgedModel({ apiKey: "bridge-key" });

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -467,11 +467,15 @@ export default class ChatModelManager {
           baseURL: BREVILABS_MODELS_BASE_URL,
           fetch: safeFetch,
         },
-        // Reasoning is opt-in: the relay's reasoning models only reason when an
-        // effort is sent, so flash stays fast by default. Forward the user's
-        // per-model effort pick (the relay reads reasoning_effort) only for models
-        // with the REASONING capability.
-        enableReasoning: customModel.capabilities?.includes(ModelCapability.REASONING) ?? false,
+        // Reasoning is opt-in: forward the user's per-model effort pick only for
+        // REASONING-capable models, and gate enableReasoning on an EXPLICIT effort.
+        // Without an effort, ChatOpenRouter.invocationParams falls back to
+        // `reasoning: { max_tokens: 1024 }`, which would make the default-on
+        // copilot-plus-flash spend reasoning budget/latency despite being the fast
+        // default. So flash stays fast until the user picks an effort.
+        enableReasoning:
+          (customModel.capabilities?.includes(ModelCapability.REASONING) ?? false) &&
+          !!customModel.reasoningEffort,
         reasoningEffort:
           customModel.capabilities?.includes(ModelCapability.REASONING) &&
           customModel.reasoningEffort
@@ -1126,23 +1130,23 @@ export default class ChatModelManager {
   }
 
   findModelByName(modelName: string): CustomModel | undefined {
-    const settings = getSettings();
-    const legacy = settings.activeModels.find((model) => model.name === modelName);
-    if (legacy) return legacy;
-    // Chat-backend (bridged) models live in the Provider/ConfiguredModel
-    // registries, not in `activeModels`, so a name lookup misses them and any
-    // capability check (e.g. CopilotPlusChainRunner.isMultimodalModel) would
-    // read `false`. Fall back to the active bridged model when its name
-    // matches: it carries the capabilities derived from its modalities via
-    // `configuredModelToCustomModel`, so image-capable Plus models that exist
-    // only as ConfiguredModels (e.g. kimi-k2.7-code) are correctly treated as
-    // multimodal instead of silently dropping attached images.
+    // Prefer the active bridged model on an exact name match, BEFORE the legacy
+    // lookup. Chat-backend (bridged) models live in the Provider/ConfiguredModel
+    // registries and carry the full capability set derived from their
+    // modalities/reasoning (`configuredModelToCustomModel`). A model whose wire id
+    // ALSO exists in legacy `settings.activeModels` — notably `copilot-plus-flash`,
+    // whose built-in entry advertises only VISION — would otherwise mask the
+    // bridged REASONING/VISION capabilities, so a capability check
+    // (CopilotPlusChainRunner.hasCapability / isMultimodalModel) reads `false` and
+    // reasoning/image content is dropped. The bridged model is the one actually
+    // running, so it wins.
     if (
       ChatModelManager.activeModelSource === "bridged" &&
       ChatModelManager.activeModel?.name === modelName
     ) {
       return ChatModelManager.activeModel;
     }
-    return undefined;
+    const settings = getSettings();
+    return settings.activeModels.find((model) => model.name === modelName);
   }
 }

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -467,6 +467,16 @@ export default class ChatModelManager {
           baseURL: BREVILABS_MODELS_BASE_URL,
           fetch: safeFetch,
         },
+        // Reasoning is opt-in: the relay's reasoning models only reason when an
+        // effort is sent, so flash stays fast by default. Forward the user's
+        // per-model effort pick (the relay reads reasoning_effort) only for models
+        // with the REASONING capability.
+        enableReasoning: customModel.capabilities?.includes(ModelCapability.REASONING) ?? false,
+        reasoningEffort:
+          customModel.capabilities?.includes(ModelCapability.REASONING) &&
+          customModel.reasoningEffort
+            ? customModel.reasoningEffort
+            : undefined,
       },
       [ChatModelProviders.MISTRAL]: {
         modelName,

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -1117,6 +1117,22 @@ export default class ChatModelManager {
 
   findModelByName(modelName: string): CustomModel | undefined {
     const settings = getSettings();
-    return settings.activeModels.find((model) => model.name === modelName);
+    const legacy = settings.activeModels.find((model) => model.name === modelName);
+    if (legacy) return legacy;
+    // Chat-backend (bridged) models live in the Provider/ConfiguredModel
+    // registries, not in `activeModels`, so a name lookup misses them and any
+    // capability check (e.g. CopilotPlusChainRunner.isMultimodalModel) would
+    // read `false`. Fall back to the active bridged model when its name
+    // matches: it carries the capabilities derived from its modalities via
+    // `configuredModelToCustomModel`, so image-capable Plus models that exist
+    // only as ConfiguredModels (e.g. kimi-k2.7-code) are correctly treated as
+    // multimodal instead of silently dropping attached images.
+    if (
+      ChatModelManager.activeModelSource === "bridged" &&
+      ChatModelManager.activeModel?.name === modelName
+    ) {
+      return ChatModelManager.activeModel;
+    }
+    return undefined;
   }
 }

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -246,6 +246,29 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     });
   });
 
+  it("injects reasoning:true so opencode offers an effort option for reasoning models", async () => {
+    const provider = makeProvider("p-anthropic", {
+      kind: "byok",
+      catalogProviderId: "anthropic",
+    });
+    const model = makeModel("p-anthropic", "deepseek-v4-flash");
+    model.info.modalities = { input: ["text"], output: ["text"] };
+    model.info.reasoning = true;
+    const deps = makeDeps({
+      resolved: [okEntry(provider, model)],
+      keys: { "p-anthropic": "anth-123" },
+    });
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { models?: Record<string, unknown> }>;
+    };
+    expect(cfg.provider.anthropic.models).toEqual({
+      "deepseek-v4-flash": {
+        modalities: { input: ["text"], output: ["text"] },
+        reasoning: true,
+      },
+    });
+  });
+
   it("injects an empty config for a model with no modalities metadata", async () => {
     const provider = makeProvider("p-anthropic", {
       kind: "byok",

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -267,6 +267,11 @@ export async function buildOpencodeConfig(
       modelConfig.modalities = info.modalities;
       if (info.modalities.input?.includes("image")) modelConfig.attachment = true;
     }
+    // Declare reasoning support so opencode offers a thought-level (effort) option
+    // for the model. opencode has no catalog entry for Copilot Plus / self-hosted
+    // OpenAI-compatible providers, so without this it defaults to non-reasoning and
+    // the effort picker shows "na". Mirrors the modalities injection above.
+    if (info.reasoning) modelConfig.reasoning = true;
     providerConfig.models[info.id] = modelConfig;
     injected.push(`${mapping.id}/${info.id}`);
   }

--- a/src/agentMode/ui/ModelEnableList.tsx
+++ b/src/agentMode/ui/ModelEnableList.tsx
@@ -1,12 +1,13 @@
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FreeModelWarningIcon } from "@/components/ui/FreeModelWarningIcon";
+import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { ModelCapabilityIcons, hasCapabilityIcons } from "@/components/ui/model-display";
 import { SearchBar } from "@/components/ui/SearchBar";
 import { SettingSwitch } from "@/components/ui/setting-switch";
 import type { ModelCapability } from "@/constants";
 import { cn } from "@/lib/utils";
-import { ChevronRight } from "lucide-react";
+import { ChevronRight, KeyRound } from "lucide-react";
 import React from "react";
 
 /** A single toggleable model row. */
@@ -39,11 +40,17 @@ export interface ModelEnableGroup {
   /** Group heading — a provider display name (no glyphs/avatars). */
   label: string;
   /**
-   * Origin badge (e.g. "BYOK", "Agent Provided"). Set only when the list spans
-   * multiple origins, so it actually disambiguates. Copilot Plus carries no
-   * badge — its label already reads "Copilot Plus".
+   * Short badge shown after the label. For most origins it's an origin tag
+   * (e.g. "BYOK", "Agent Provided") set only when the list spans multiple
+   * origins, so it actually disambiguates. Copilot Plus instead carries a
+   * "privacy" badge.
    */
   badge?: string;
+  /**
+   * Optional hover hint rendered as a small icon after the badge (e.g.
+   * "Copilot license required" for the Copilot Plus group).
+   */
+  tooltip?: string;
   /**
    * Visually emphasize the group header (accent color). Set for Copilot Plus,
    * which the caller also floats to the top of the list.
@@ -126,7 +133,7 @@ export const ModelEnableList: React.FC<ModelEnableListProps> = ({
     <div className="tw-flex tw-flex-col tw-gap-2">
       <SearchBar value={query} onChange={onQueryChange} placeholder={searchPlaceholder} />
 
-      <div className="tw-max-h-80 tw-overflow-y-auto tw-pr-1">
+      <div className="tw-max-h-[36rem] tw-overflow-y-auto tw-pr-1">
         {!hasRows ? (
           <div className="tw-py-6 tw-text-center tw-text-sm tw-text-muted">
             {emptyState ?? (searching ? `No models match “${query.trim()}”.` : "No models.")}
@@ -161,6 +168,11 @@ export const ModelEnableList: React.FC<ModelEnableListProps> = ({
                         <Badge variant="secondary" className="tw-shrink-0 tw-font-normal">
                           {group.badge}
                         </Badge>
+                      )}
+                      {group.tooltip && (
+                        <HelpTooltip content={group.tooltip} side="top" buttonClassName="tw-size-4">
+                          <KeyRound className="tw-size-3.5 tw-shrink-0 tw-text-muted" />
+                        </HelpTooltip>
                       )}
                     </div>
                   </CollapsibleTrigger>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,10 @@ import { v4 as uuidv4 } from "uuid";
 import { ChainType } from "./chainType";
 import { PromptSortStrategy } from "./types";
 
+// Copilot website usage dashboard (view usage, purchase credits). Used as the
+// fallback link when a usage-cap error doesn't carry its own dashboard_url.
+export const USAGE_DASHBOARD_URL = "https://www.obsidiancopilot.com/en/dashboard/token-usage";
+
 export const BREVILABS_API_BASE_URL = "https://api.brevilabs.com/v1";
 export const BREVILABS_MODELS_BASE_URL = "https://models.brevilabs.com/v1";
 export const CHAT_VIEWTYPE = "copilot-chat-view";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -198,6 +198,13 @@ export const DEFAULT_OLLAMA_NUM_CTX = 131072;
 
 export enum ChatModels {
   COPILOT_PLUS_FLASH = "copilot-plus-flash",
+  // Additional Copilot Plus relay models (served via the brevilabs proxy).
+  COPILOT_PLUS_KIMI_K2_6 = "kimi-k2.6",
+  COPILOT_PLUS_GLM_5_2 = "glm-5.2",
+  COPILOT_PLUS_KIMI_K2_7_CODE = "kimi-k2.7-code",
+  COPILOT_PLUS_DEEPSEEK_V4_PRO = "deepseek-v4-pro",
+  COPILOT_PLUS_MIMO_V2_5 = "mimo-v2.5",
+  COPILOT_PLUS_MINIMAX_M2_7 = "minimax-m2.7",
   GPT_5_5 = "gpt-5.5",
   GPT_5_4_mini = "gpt-5.4-mini",
   GPT_41 = "gpt-4.1",

--- a/src/modelManagement/setup/CopilotPlusSetupApi.test.ts
+++ b/src/modelManagement/setup/CopilotPlusSetupApi.test.ts
@@ -172,6 +172,11 @@ const EMBEDDING: ModelInfo = {
   displayName: "Copilot Plus Small",
   isEmbedding: true,
 };
+const EXTRA: ModelInfo = {
+  id: "glm-5.2",
+  displayName: "GLM-5.2",
+  toolCall: true,
+};
 
 interface Harness {
   api: CopilotPlusSetupApi;
@@ -251,6 +256,68 @@ describe("CopilotPlusSetupApi.registerPlusProvider", () => {
     expect(h.backends.enabledFor("chat")).toEqual([flashId]);
     expect(h.backends.enabledFor("opencode")).toEqual([flashId]);
     expect(h.backends.enabledFor("chat")).not.toContain(embeddingId);
+  });
+
+  it("with autoEnrollModelIds, enrolls only the listed models; the rest are created but off", async () => {
+    const h = makeHarness();
+    const result = await h.api.registerPlusProvider({
+      providerType: "openai-compatible",
+      displayName: "Copilot Plus",
+      baseUrl: "https://models.brevilabs.com/v1",
+      apiKey: "lic-key",
+      models: [FLASH, EXTRA],
+      autoEnrollModelIds: [FLASH.id],
+    });
+
+    // Both models exist as ConfiguredModels...
+    expect(result.configuredModelIds).toHaveLength(2);
+    const flashId = h.models.getByWireId(result.providerId, FLASH.id)!.configuredModelId;
+    const extraId = h.models.getByWireId(result.providerId, EXTRA.id)!.configuredModelId;
+    expect(extraId).toBeDefined();
+
+    // ...but only the listed flash model is enrolled into the pickers.
+    expect(h.backends.enabledFor("chat")).toEqual([flashId]);
+    expect(h.backends.enabledFor("opencode")).toEqual([flashId]);
+    expect(h.backends.enabledFor("chat")).not.toContain(extraId);
+    expect(h.backends.enabledFor("opencode")).not.toContain(extraId);
+  });
+
+  it("with autoEnrollModelIds, a newly-added model on re-sync stays off (existing curation preserved)", async () => {
+    const h = makeHarness();
+    // First sync: only flash exists and is enrolled.
+    const first = await h.api.registerPlusProvider({
+      providerType: "openai-compatible",
+      displayName: "Copilot Plus",
+      baseUrl: "https://models.brevilabs.com/v1",
+      apiKey: "lic-key",
+      models: [FLASH],
+      autoEnrollModelIds: [FLASH.id],
+    });
+    const flashId = first.configuredModelIds[0];
+
+    // Second sync introduces EXTRA, still not in the default-enabled set.
+    await h.api.registerPlusProvider({
+      providerType: "openai-compatible",
+      displayName: "Copilot Plus",
+      baseUrl: "https://models.brevilabs.com/v1",
+      apiKey: "lic-key",
+      models: [FLASH, EXTRA],
+      autoEnrollModelIds: [FLASH.id],
+    });
+
+    const extraId = h.models.getByWireId(first.providerId, EXTRA.id)!.configuredModelId;
+    expect(h.backends.enabledFor("opencode")).toEqual([flashId]);
+    expect(h.backends.enabledFor("opencode")).not.toContain(extraId);
+  });
+
+  it("without autoEnrollModelIds, every non-embedding model auto-enrolls (prior behavior)", async () => {
+    const h = makeHarness();
+    const result = await register(h, [FLASH, EXTRA]);
+
+    const flashId = h.models.getByWireId(result.providerId, FLASH.id)!.configuredModelId;
+    const extraId = h.models.getByWireId(result.providerId, EXTRA.id)!.configuredModelId;
+    expect(h.backends.enabledFor("opencode")).toEqual([flashId, extraId]);
+    expect(h.backends.enabledFor("chat")).toEqual([flashId, extraId]);
   });
 
   it("does not call setApiKey when no key is supplied", async () => {

--- a/src/modelManagement/setup/CopilotPlusSetupApi.test.ts
+++ b/src/modelManagement/setup/CopilotPlusSetupApi.test.ts
@@ -390,6 +390,31 @@ describe("CopilotPlusSetupApi.registerPlusProvider", () => {
     expect(row.configuredModelId).toBe(idBefore);
     expect(row.info.displayName).toBe("Copilot Plus Flash 2");
   });
+
+  it("refreshes drifted capability fields (reasoning/modalities/toolCall) in place", async () => {
+    const h = makeHarness();
+    // Existing model registered WITHOUT reasoning/modalities (an older snapshot).
+    const first = await register(h, [{ id: "glm-5.2", displayName: "GLM-5.2", toolCall: false }]);
+    const idBefore = first.configuredModelIds[0];
+    expect(h.models.getByWireId(first.providerId, "glm-5.2")!.info.reasoning).toBeUndefined();
+
+    // Re-register the same id with new capabilities — e.g. reasoning effort support.
+    await register(h, [
+      {
+        id: "glm-5.2",
+        displayName: "GLM-5.2",
+        toolCall: true,
+        reasoning: true,
+        modalities: { input: ["text"], output: ["text"] },
+      },
+    ]);
+
+    const row = h.models.getByWireId(first.providerId, "glm-5.2")!;
+    expect(row.configuredModelId).toBe(idBefore); // no churn
+    expect(row.info.reasoning).toBe(true);
+    expect(row.info.toolCall).toBe(true);
+    expect(row.info.modalities).toEqual({ input: ["text"], output: ["text"] });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/modelManagement/setup/CopilotPlusSetupApi.ts
+++ b/src/modelManagement/setup/CopilotPlusSetupApi.ts
@@ -11,9 +11,11 @@
  * `unregisterPlusProvider`, which cascade-removes through
  * `ModelManagementCoordinator`.
  *
- * Default auto-enrollment mirrors BYOK: Plus models surface in both
- * Simple Chat and the OpenCode agent picker
- * (`BYOK_DEFAULT_AUTO_ENROLL`).
+ * Auto-enrollment targets the BYOK backends (`BYOK_DEFAULT_AUTO_ENROLL`:
+ * Simple Chat + the OpenCode agent picker). `autoEnrollModelIds` narrows
+ * *which* models enroll on first add: Plus passes just the default-on
+ * subset (the flash model), so the rest of the lineup is created and shown
+ * in the pickers but left off for the user to toggle on.
  */
 
 import type { ModelManagementCoordinator } from "@/modelManagement/createModelManagement";
@@ -40,6 +42,13 @@ export interface RegisterPlusProviderInput {
   models: readonly ModelInfo[];
   /** Defaults to `BYOK_DEFAULT_AUTO_ENROLL` (= chat + opencode). */
   autoEnrollIn?: readonly BackendType[];
+  /** Wire ids (`ModelInfo.id`) eligible for default auto-enrollment. When
+   *  provided, only newly-added models whose id is in this set get enrolled
+   *  into `autoEnrollIn`; the rest are added available-but-off. When omitted,
+   *  every newly-added (non-embedding) model is enrolled — the prior behavior.
+   *  Lets Plus curate a default-on subset (just the flash model today) while
+   *  still surfacing the full lineup in the pickers. */
+  autoEnrollModelIds?: readonly string[];
 }
 
 export interface PlusSetupResult {
@@ -117,7 +126,8 @@ export class CopilotPlusSetupApi {
     const configuredModelIds = await this.#reconcileModels(
       providerId,
       input.models,
-      input.autoEnrollIn ?? BYOK_DEFAULT_AUTO_ENROLL
+      input.autoEnrollIn ?? BYOK_DEFAULT_AUTO_ENROLL,
+      input.autoEnrollModelIds
     );
 
     return { providerId, configuredModelIds };
@@ -151,20 +161,27 @@ export class CopilotPlusSetupApi {
 
   /**
    * Diff-reconcile the Plus provider's ConfiguredModel set against `models`:
-   * add new wire ids (auto-enrolling each non-embedding model), refresh drifted
-   * display strings in place (no configuredModelId churn), and cascade-remove
-   * vanished ones. Returns the resulting ids in input order. Mirrors
-   * `AgentSetupApi.#reconcileModels`; only real deltas write, so re-syncing an
-   * unchanged list never resets user curation.
+   * add new wire ids (auto-enrolling each eligible non-embedding model), refresh
+   * drifted display strings in place (no configuredModelId churn), and
+   * cascade-remove vanished ones. Returns the resulting ids in input order.
+   * Mirrors `AgentSetupApi.#reconcileModels`; only real deltas write, so
+   * re-syncing an unchanged list never resets user curation.
+   *
+   * `autoEnrollModelIds`, when provided, restricts auto-enrollment to that set
+   * of wire ids — newly-added models outside it are still created (so they
+   * appear in the pickers) but left off. `undefined` means enroll every
+   * newly-added non-embedding model (the prior, unrestricted behavior).
    */
   async #reconcileModels(
     providerId: string,
     models: readonly ModelInfo[],
-    autoEnrollIn: readonly BackendType[]
+    autoEnrollIn: readonly BackendType[],
+    autoEnrollModelIds?: readonly string[]
   ): Promise<string[]> {
     const existing = this.#models.listByProvider(providerId);
     const existingByWireId = new Map(existing.map((m) => [m.info.id, m]));
     const desiredWireIds = new Set(models.map((info) => info.id));
+    const autoEnrollFilter = autoEnrollModelIds ? new Set(autoEnrollModelIds) : null;
 
     for (const info of models) {
       const current = existingByWireId.get(info.id);
@@ -172,7 +189,8 @@ export class CopilotPlusSetupApi {
         const configuredModelId = await this.#models.add({ providerId, info });
         // Embedding models aren't chat models — enrolling them into chat/agent
         // backends would surface them in completion pickers where they fail.
-        if (!info.isEmbedding) {
+        // A wire id outside `autoEnrollFilter` (when set) ships available-but-off.
+        if (!info.isEmbedding && (!autoEnrollFilter || autoEnrollFilter.has(info.id))) {
           for (const backend of autoEnrollIn) {
             await this.#backends.enableModel(backend, configuredModelId);
           }

--- a/src/modelManagement/setup/CopilotPlusSetupApi.ts
+++ b/src/modelManagement/setup/CopilotPlusSetupApi.ts
@@ -162,7 +162,7 @@ export class CopilotPlusSetupApi {
   /**
    * Diff-reconcile the Plus provider's ConfiguredModel set against `models`:
    * add new wire ids (auto-enrolling each eligible non-embedding model), refresh
-   * drifted display strings in place (no configuredModelId churn), and
+   * drifted display + capability fields in place (no configuredModelId churn), and
    * cascade-remove vanished ones. Returns the resulting ids in input order.
    * Mirrors `AgentSetupApi.#reconcileModels`; only real deltas write, so
    * re-syncing an unchanged list never resets user curation.
@@ -197,12 +197,26 @@ export class CopilotPlusSetupApi {
         }
         continue;
       }
+      // Refresh the curated snapshot in place when any field drifted — not just the
+      // display strings. Capability fields (modalities, reasoning, toolCall) must be
+      // re-synced too, otherwise an existing user keeps a stale snapshot and never
+      // picks up newly-advertised capabilities (e.g. reasoning effort) on re-sign-in.
+      // Plus models are server-curated, so there are no user overrides to clobber.
       if (
         current.info.displayName !== info.displayName ||
-        current.info.description !== info.description
+        current.info.description !== info.description ||
+        current.info.toolCall !== info.toolCall ||
+        current.info.reasoning !== info.reasoning ||
+        JSON.stringify(current.info.modalities) !== JSON.stringify(info.modalities)
       ) {
         await this.#models.update(current.configuredModelId, {
-          info: { displayName: info.displayName, description: info.description },
+          info: {
+            displayName: info.displayName,
+            description: info.description,
+            toolCall: info.toolCall,
+            reasoning: info.reasoning,
+            modalities: info.modalities,
+          },
         });
       }
     }

--- a/src/modelManagement/setup/copilotPlusSync.test.ts
+++ b/src/modelManagement/setup/copilotPlusSync.test.ts
@@ -77,6 +77,21 @@ describe("syncCopilotPlusProvider", () => {
     expect(COPILOT_PLUS_DEFAULT_ENABLED_MODELS).toEqual(["copilot-plus-flash"]);
   });
 
+  it("flags every reasoning-capable model except kimi-k2.6 so the effort picker shows", () => {
+    const reasoningById = Object.fromEntries(
+      COPILOT_PLUS_MODELS.map((m) => [m.id, m.reasoning === true])
+    );
+    expect(reasoningById).toEqual({
+      "copilot-plus-flash": true,
+      "kimi-k2.6": false, // Azure model without effort support (matches backend)
+      "glm-5.2": true,
+      "kimi-k2.7-code": true,
+      "deepseek-v4-pro": true,
+      "mimo-v2.5": true,
+      "minimax-m2.7": true,
+    });
+  });
+
   it("still registers (never tears down) when the stored key fails to decrypt, leaving the token untouched", async () => {
     // Decrypt failure: getDecryptedKey returns "" but the raw key is present
     // and the user is still a Plus user.

--- a/src/modelManagement/setup/copilotPlusSync.test.ts
+++ b/src/modelManagement/setup/copilotPlusSync.test.ts
@@ -9,7 +9,11 @@
  * provider + user curation. These tests pin that down.
  */
 
-import { syncCopilotPlusProvider } from "./copilotPlusSync";
+import {
+  COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
+  COPILOT_PLUS_MODELS,
+  syncCopilotPlusProvider,
+} from "./copilotPlusSync";
 
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
 import type { RegisterPlusProviderInput } from "@/modelManagement/setup/CopilotPlusSetupApi";
@@ -51,7 +55,26 @@ describe("syncCopilotPlusProvider", () => {
     expect(getDecryptedKey).toHaveBeenCalledWith("enc_desk_raw");
     expect(unregisterPlusProvider).not.toHaveBeenCalled();
     expect(registerPlusProvider).toHaveBeenCalledTimes(1);
-    expect(registerPlusProvider.mock.calls[0][0]).toMatchObject({ apiKey: "decrypted-token" });
+    expect(registerPlusProvider.mock.calls[0][0]).toMatchObject({
+      apiKey: "decrypted-token",
+      models: COPILOT_PLUS_MODELS,
+      // Only the default-on subset (flash) auto-enrolls; the rest ship off.
+      autoEnrollModelIds: COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
+    });
+  });
+
+  it("curated list ships the full lineup but defaults only copilot-plus-flash to on", () => {
+    const ids = COPILOT_PLUS_MODELS.map((m) => m.id);
+    expect(ids).toEqual([
+      "copilot-plus-flash",
+      "kimi-k2.6",
+      "glm-5.2",
+      "kimi-k2.7-code",
+      "deepseek-v4-pro",
+      "mimo-v2.5",
+      "minimax-m2.7",
+    ]);
+    expect(COPILOT_PLUS_DEFAULT_ENABLED_MODELS).toEqual(["copilot-plus-flash"]);
   });
 
   it("still registers (never tears down) when the stored key fails to decrypt, leaving the token untouched", async () => {

--- a/src/modelManagement/setup/copilotPlusSync.ts
+++ b/src/modelManagement/setup/copilotPlusSync.ts
@@ -51,7 +51,7 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
   {
     id: ChatModels.COPILOT_PLUS_GLM_5_2,
     displayName: "GLM-5.2",
-    description: "A frontier open-weight model.",
+    description: "A long-horizon frontier open model that beats some of the best closed models.",
     toolCall: true,
     reasoning: true,
     modalities: { input: ["text"], output: ["text"] },

--- a/src/modelManagement/setup/copilotPlusSync.ts
+++ b/src/modelManagement/setup/copilotPlusSync.ts
@@ -24,6 +24,13 @@ import type { ModelInfo } from "@/modelManagement/types/catalog";
  * Only `copilot-plus-flash` is enabled by default (see
  * `COPILOT_PLUS_DEFAULT_ENABLED_MODELS`); the rest ship available-but-off in the
  * chat + opencode pickers for the user to toggle on.
+ *
+ * `reasoning: true` marks the models the relay accepts an effort level for (it
+ * matches the models service's `supports_reasoning`). The chat + agent pickers
+ * read this (via `configuredModelToCustomModel` → `ModelCapability.REASONING`)
+ * to surface the effort selector. These models do NOT reason unless the user
+ * picks an effort, so flash stays fast by default. Kimi K2.6 (Azure) is the one
+ * model without effort support, so it's left unflagged.
  */
 export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
   {
@@ -31,6 +38,7 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
     displayName: "Copilot Plus Flash",
     description: "The default model: fastest responses and the most quota.",
     toolCall: true,
+    reasoning: true,
     modalities: { input: ["text", "image"], output: ["text"] },
   },
   {
@@ -45,6 +53,7 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
     displayName: "GLM-5.2",
     description: "A frontier open-weight model.",
     toolCall: true,
+    reasoning: true,
     modalities: { input: ["text"], output: ["text"] },
   },
   {
@@ -52,6 +61,7 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
     displayName: "Kimi K2.7 Code",
     description: "Optimized for coding tasks.",
     toolCall: true,
+    reasoning: true,
     modalities: { input: ["text", "image"], output: ["text"] },
   },
   {
@@ -59,6 +69,7 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
     displayName: "DeepSeek V4 Pro",
     description: "A top-tier model for the hardest reasoning and agentic tasks.",
     toolCall: true,
+    reasoning: true,
     modalities: { input: ["text"], output: ["text"] },
   },
   {
@@ -66,6 +77,7 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
     displayName: "MiMo V2.5",
     description: "Cost-effective and capable for everyday use.",
     toolCall: true,
+    reasoning: true,
     modalities: { input: ["text"], output: ["text"] },
   },
   {
@@ -73,6 +85,7 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
     displayName: "MiniMax M2.7",
     description: "A compact, efficient model for lightweight tasks.",
     toolCall: true,
+    reasoning: true,
     modalities: { input: ["text"], output: ["text"] },
   },
 ]);

--- a/src/modelManagement/setup/copilotPlusSync.ts
+++ b/src/modelManagement/setup/copilotPlusSync.ts
@@ -16,18 +16,75 @@ import type { ModelManagementApi } from "@/modelManagement/createModelManagement
 import type { ModelInfo } from "@/modelManagement/types/catalog";
 
 /**
- * The Copilot Plus models the brevilabs relay exposes. Hardcoded — Plus offers
- * a single curated chat model today and there's no relay catalog to fetch. Wire
- * ids must match what the relay accepts; opencode routes them as
- * `copilot-plus/<id>` (see `mapProviderToOpencodeId`).
+ * The Copilot Plus models the brevilabs relay exposes. Hardcoded — there's no
+ * relay catalog to fetch, so this mirrors the curated public lineup served by
+ * `models.brevilabs.com/v1/models`. Wire ids must match what the relay accepts;
+ * opencode routes them as `copilot-plus/<id>` (see `mapProviderToOpencodeId`).
+ *
+ * Only `copilot-plus-flash` is enabled by default (see
+ * `COPILOT_PLUS_DEFAULT_ENABLED_MODELS`); the rest ship available-but-off in the
+ * chat + opencode pickers for the user to toggle on.
  */
 export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
   {
     id: ChatModels.COPILOT_PLUS_FLASH,
     displayName: "Copilot Plus Flash",
+    description: "The default model: fastest responses and the most quota.",
     toolCall: true,
     modalities: { input: ["text", "image"], output: ["text"] },
   },
+  {
+    id: ChatModels.COPILOT_PLUS_KIMI_K2_6,
+    displayName: "Kimi K2.6",
+    description: "Good for long-running reasoning tasks.",
+    toolCall: true,
+    modalities: { input: ["text"], output: ["text"] },
+  },
+  {
+    id: ChatModels.COPILOT_PLUS_GLM_5_2,
+    displayName: "GLM-5.2",
+    description: "A frontier open-weight model.",
+    toolCall: true,
+    modalities: { input: ["text"], output: ["text"] },
+  },
+  {
+    id: ChatModels.COPILOT_PLUS_KIMI_K2_7_CODE,
+    displayName: "Kimi K2.7 Code",
+    description: "Optimized for coding tasks.",
+    toolCall: true,
+    modalities: { input: ["text", "image"], output: ["text"] },
+  },
+  {
+    id: ChatModels.COPILOT_PLUS_DEEPSEEK_V4_PRO,
+    displayName: "DeepSeek V4 Pro",
+    description: "A top-tier model for the hardest reasoning and agentic tasks.",
+    toolCall: true,
+    modalities: { input: ["text"], output: ["text"] },
+  },
+  {
+    id: ChatModels.COPILOT_PLUS_MIMO_V2_5,
+    displayName: "MiMo V2.5",
+    description: "Cost-effective and capable for everyday use.",
+    toolCall: true,
+    modalities: { input: ["text"], output: ["text"] },
+  },
+  {
+    id: ChatModels.COPILOT_PLUS_MINIMAX_M2_7,
+    displayName: "MiniMax M2.7",
+    description: "A compact, efficient model for lightweight tasks.",
+    toolCall: true,
+    modalities: { input: ["text"], output: ["text"] },
+  },
+]);
+
+/**
+ * Wire ids auto-enrolled (toggled on) by default when the Plus provider is
+ * registered. Everything else in `COPILOT_PLUS_MODELS` is added but left
+ * unenrolled, so users opt into the extra models themselves. Passed to
+ * `registerPlusProvider` as `autoEnrollModelIds`.
+ */
+export const COPILOT_PLUS_DEFAULT_ENABLED_MODELS: readonly string[] = Object.freeze([
+  ChatModels.COPILOT_PLUS_FLASH,
 ]);
 
 /**
@@ -61,6 +118,7 @@ export async function syncCopilotPlusProvider(
         // `registerPlusProvider` leave the existing token in place.
         apiKey: token || undefined,
         models: COPILOT_PLUS_MODELS,
+        autoEnrollModelIds: COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
       });
     } else {
       await api.setup.copilotPlus.unregisterPlusProvider();

--- a/src/settings/v2/components/configuredModelGrouping.test.ts
+++ b/src/settings/v2/components/configuredModelGrouping.test.ts
@@ -439,7 +439,7 @@ describe("buildModelEnableGroups", () => {
     expect(groups.find((g) => g.label === "opencode")?.badge).toBe("Agent Provided");
   });
 
-  it("floats Copilot Plus to the top, highlights it, and gives it no redundant badge", () => {
+  it("floats Copilot Plus to the top, highlights it, and gives it the privacy badge + license tooltip", () => {
     const plusProvider: Provider = {
       providerId: "plus-1",
       providerType: "anthropic",
@@ -472,7 +472,8 @@ describe("buildModelEnableGroups", () => {
     // Copilot Plus is first regardless of candidate order.
     expect(groups[0].key).toBe("byok:plus-1");
     expect(groups[0].highlight).toBe(true);
-    expect(groups[0].badge).toBeUndefined();
+    expect(groups[0].badge).toBe("privacy");
+    expect(groups[0].tooltip).toBe("Copilot license required");
     // Non-Plus groups are not highlighted.
     expect(groups.find((g) => g.key === "byok:byok-1")?.highlight).toBeUndefined();
   });

--- a/src/settings/v2/components/configuredModelGrouping.ts
+++ b/src/settings/v2/components/configuredModelGrouping.ts
@@ -214,12 +214,15 @@ export function buildModelEnableGroups(
   }
 
   // Copilot Plus is highlighted and floated to the top; its provider name
-  // already reads "Copilot Plus", so it carries no disambiguating badge. Every
-  // other origin gets a badge only when the list actually mixes origins.
+  // already reads "Copilot Plus", so instead of a disambiguating origin badge
+  // it carries a "privacy" badge plus a license-required hover hint. Every
+  // other origin gets an origin badge only when the list mixes origins.
   const mixed = new Set(out.map((o) => o.kind)).size > 1;
   for (const o of out) {
     if (o.kind === "copilot-plus") {
       o.group.highlight = true;
+      o.group.badge = "privacy";
+      o.group.tooltip = "Copilot license required";
     } else if (mixed) {
       o.group.badge = originBadgeLabel(o.kind);
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,7 @@ import { DateTime } from "luxon";
 import { App, MarkdownView, Notice, TFile, Vault, normalizePath, requestUrl } from "obsidian";
 import { CustomModel } from "./aiParams";
 import { getApiKeyForProvider } from "@/utils/modelUtils";
+import { formatUsageCapError } from "@/utils/usageCapError";
 export { err2String } from "@/errorFormat";
 
 /**
@@ -91,10 +92,16 @@ function isLicenseKeyError(error: unknown): boolean {
 }
 
 export function getApiErrorMessage(error: unknown): string {
-  const errorDetail = extractErrorDetail(error);
   if (isLicenseKeyError(error)) {
     return ERROR_MESSAGES.INVALID_LICENSE_KEY_USER;
   }
+  // Usage-cap (plan limit) errors get a friendly, actionable message with a link to
+  // the usage dashboard to purchase credits, instead of the raw relay error text.
+  const capMessage = formatUsageCapError(error);
+  if (capMessage) {
+    return capMessage;
+  }
+  const errorDetail = extractErrorDetail(error);
   return (
     errorDetail.message ||
     (errorDetail.reason ? `Error: ${errorDetail.reason}` : ERROR_MESSAGES.UNKNOWN_ERROR)

--- a/src/utils/usageCapError.test.ts
+++ b/src/utils/usageCapError.test.ts
@@ -25,7 +25,8 @@ describe("formatUsageCapError", () => {
     const msg = formatUsageCapError(err);
     expect(msg).toContain("usage cap");
     expect(msg).toContain("purchase credits");
-    expect(msg).toContain(`(${DASH})`); // markdown link target
+    expect(msg).toContain(DASH); // bare URL (plain text, renders in ErrorBlock)
+    expect(msg).not.toContain("]("); // not Markdown link syntax
   });
 
   it("detects a cap error nested under other transport wrappers", () => {

--- a/src/utils/usageCapError.test.ts
+++ b/src/utils/usageCapError.test.ts
@@ -1,0 +1,47 @@
+import { formatUsageCapError } from "@/utils/usageCapError";
+
+describe("formatUsageCapError", () => {
+  const DASH = "https://www.obsidiancopilot.com/en/dashboard/token-usage";
+
+  it("returns null for non-cap errors", () => {
+    expect(formatUsageCapError(null)).toBeNull();
+    expect(formatUsageCapError(new Error("boom"))).toBeNull();
+    expect(formatUsageCapError({ detail: { error: { type: "rate_limit_error" } } })).toBeNull();
+    expect(formatUsageCapError("just a string")).toBeNull();
+  });
+
+  it("detects the relay 429 shape (detail.error.type) and links the dashboard", () => {
+    const err = {
+      status: 429,
+      detail: {
+        error: {
+          type: "token_limit_error",
+          message: "5-hour usage cap reached. ...",
+          dashboard_url: DASH,
+          credits_hint: "purchase credits ...",
+        },
+      },
+    };
+    const msg = formatUsageCapError(err);
+    expect(msg).toContain("usage cap");
+    expect(msg).toContain("purchase credits");
+    expect(msg).toContain(`(${DASH})`); // markdown link target
+  });
+
+  it("detects a cap error nested under other transport wrappers", () => {
+    const err = { error: { error: { error: { dashboard_url: DASH } } } };
+    expect(formatUsageCapError(err)).toContain(DASH);
+  });
+
+  it("detects via credits_hint alone and falls back to the default dashboard URL", () => {
+    const err = { response: { data: { error: { credits_hint: "Enable credits ..." } } } };
+    const msg = formatUsageCapError(err);
+    expect(msg).toContain(DASH); // fallback when no dashboard_url present
+  });
+
+  it("is cycle-safe (does not infinitely recurse on circular errors)", () => {
+    const a: Record<string, unknown> = { type: "other" };
+    a.self = a;
+    expect(formatUsageCapError(a)).toBeNull();
+  });
+});

--- a/src/utils/usageCapError.ts
+++ b/src/utils/usageCapError.ts
@@ -66,8 +66,12 @@ export function formatUsageCapError(error: unknown): string | null {
   const fields = findCapFields(error);
   if (!fields) return null;
   const url = fields.dashboard_url || USAGE_DASHBOARD_URL;
+  // Plain text with a bare URL (no Markdown). The main streaming error path renders
+  // this via ErrorBlock as plain text (whitespace-pre-wrap), so Markdown link syntax
+  // would show literally; a bare URL stays readable there and still auto-links in any
+  // Markdown-rendered context.
   return (
-    `**You've reached your usage cap.** To keep going beyond your plan's limit, ` +
-    `[purchase credits on your usage dashboard](${url}).`
+    `You've reached your usage cap. To keep going beyond your plan's limit, ` +
+    `purchase credits on your usage dashboard: ${url}`
   );
 }

--- a/src/utils/usageCapError.ts
+++ b/src/utils/usageCapError.ts
@@ -1,0 +1,73 @@
+/**
+ * Detects a Copilot Plus usage-cap error and formats a user-facing message that
+ * points to the website usage dashboard and invites purchasing credits.
+ *
+ * The models relay returns a 429 whose body is
+ *   { detail: { error: { type: "token_limit_error", dashboard_url, credits_hint, message, ... } } }
+ * but the error object the plugin catches varies by transport (LangChain wraps the
+ * body under different keys), so the detector deep-searches the thrown value for the
+ * cap signal rather than assuming one shape.
+ */
+import { USAGE_DASHBOARD_URL } from "@/constants";
+
+/** The cap fields we look for, wherever they end up nested on the error. */
+interface CapErrorFields {
+  type?: string;
+  dashboard_url?: string;
+  credits_hint?: string;
+  message?: string;
+}
+
+const CAP_TYPE = "token_limit_error";
+const MAX_SEARCH_DEPTH = 6;
+
+/**
+ * Walk the error value (bounded depth, cycle-safe) and return the first object that
+ * carries a usage-cap signal: `type === "token_limit_error"`, or a `dashboard_url` /
+ * `credits_hint` field. Returns null when no cap signal is present.
+ */
+function findCapFields(
+  value: unknown,
+  depth = 0,
+  seen = new Set<unknown>()
+): CapErrorFields | null {
+  if (!value || typeof value !== "object" || depth > MAX_SEARCH_DEPTH || seen.has(value)) {
+    return null;
+  }
+  seen.add(value);
+
+  const obj = value as Record<string, unknown>;
+  const isCap =
+    obj.type === CAP_TYPE ||
+    typeof obj.dashboard_url === "string" ||
+    typeof obj.credits_hint === "string";
+  if (isCap) {
+    return {
+      type: typeof obj.type === "string" ? obj.type : undefined,
+      dashboard_url: typeof obj.dashboard_url === "string" ? obj.dashboard_url : undefined,
+      credits_hint: typeof obj.credits_hint === "string" ? obj.credits_hint : undefined,
+      message: typeof obj.message === "string" ? obj.message : undefined,
+    };
+  }
+
+  for (const child of Object.values(obj)) {
+    const found = findCapFields(child, depth + 1, seen);
+    if (found) return found;
+  }
+  return null;
+}
+
+/**
+ * If `error` is a usage-cap error, return a Markdown message inviting the user to
+ * purchase credits on the usage dashboard (a clickable link). Otherwise null, so
+ * callers fall through to their generic error handling.
+ */
+export function formatUsageCapError(error: unknown): string | null {
+  const fields = findCapFields(error);
+  if (!fields) return null;
+  const url = fields.dashboard_url || USAGE_DASHBOARD_URL;
+  return (
+    `**You've reached your usage cap.** To keep going beyond your plan's limit, ` +
+    `[purchase credits on your usage dashboard](${url}).`
+  );
+}


### PR DESCRIPTION
Related: logancyang/obsidian-copilot-preview#199

## What

Adds the full curated Copilot Plus model lineup to the plugin, matching the public set now served by `models.brevilabs.com/v1/models`. Previously the plugin only knew about `copilot-plus-flash`; this brings the other six public models in:

- `kimi-k2.6`, `glm-5.2`, `kimi-k2.7-code`, `deepseek-v4-pro`, `mimo-v2.5`, `minimax-m2.7`

They surface in the chat + opencode pickers (the **Copilot Plus** section under OpenCode) for the user to toggle on. **Only `copilot-plus-flash` is enabled by default** — the six new ones ship available-but-off.

## How

- `src/modelManagement/setup/copilotPlusSync.ts` — `COPILOT_PLUS_MODELS` expanded to the 7-model lineup with canonical one-line descriptions and per-model modalities (image input only for `copilot-plus-flash` and `kimi-k2.7-code`, matching how the relay actually serves them). New `COPILOT_PLUS_DEFAULT_ENABLED_MODELS = [copilot-plus-flash]`, passed to `registerPlusProvider` as `autoEnrollModelIds`.
- `src/modelManagement/setup/CopilotPlusSetupApi.ts` — new optional `autoEnrollModelIds` on `registerPlusProvider` / `#reconcileModels`. When set, only newly-added models in that set auto-enroll into `autoEnrollIn` (chat + opencode); the rest are created (so they appear in the pickers) but left unenrolled. `undefined` keeps the prior enroll-everything behavior, so **BYOK is unaffected**.
- `src/constants.ts` — the six new wire ids added to the `ChatModels` enum.

### Why the auto-enroll gate matters

New Plus models normally auto-enroll into both pickers. Without this gate, the six new models would turn themselves **on** for every existing Plus user on their next sign-in sync. The gate keeps them off and preserves existing user curation — `flash` stays enrolled, the new ones arrive off.

## Tests

- New unit tests: new models off-by-default, off-on-resync preserves existing curation, prior enroll-all behavior when `autoEnrollModelIds` is omitted, curated-list shape + default-enabled set.
- `tsc -noEmit` clean, `eslint` clean, `npm test` for `src/modelManagement/` + `src/agentMode/backends/opencode/` (487 tests) pass.

## Dependency

The relay must serve these ids for them to work at runtime — see Brevilabs/brevilabs-models#56 (the `/v1/models` endpoint + DeepInfra model serving). This PR is the plugin-side list; it degrades gracefully (models just appear in the picker) and doesn't require the relay to be deployed to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
