### PR TITLE
Stop the Copilot Plus license hint click from toggling the group

### DIFF
--- a/src/agentMode/ui/ModelEnableList.tsx
+++ b/src/agentMode/ui/ModelEnableList.tsx
@@ -170,9 +170,22 @@ export const ModelEnableList: React.FC<ModelEnableListProps> = ({
                         </Badge>
                       )}
                       {group.tooltip && (
-                        <HelpTooltip content={group.tooltip} side="top" buttonClassName="tw-size-4">
-                          <KeyRound className="tw-size-3.5 tw-shrink-0 tw-text-muted" />
-                        </HelpTooltip>
+                        // Stop pointer/click from bubbling to the CollapsibleTrigger so
+                        // tapping the hint (which opens the tooltip on mobile) doesn't
+                        // also collapse/expand the group.
+                        <span
+                          className="tw-flex tw-shrink-0 tw-items-center"
+                          onClick={(e) => e.stopPropagation()}
+                          onPointerDown={(e) => e.stopPropagation()}
+                        >
+                          <HelpTooltip
+                            content={group.tooltip}
+                            side="top"
+                            buttonClassName="tw-size-4"
+                          >
+                            <KeyRound className="tw-size-3.5 tw-shrink-0 tw-text-muted" />
+                          </HelpTooltip>
+                        </span>
                       )}
                     </div>
                   </CollapsibleTrigger>


### PR DESCRIPTION
Follow-up to #2645 (which merged at head `47d3f1e4`). The Copilot Plus "Copilot license required" hint fix was committed moments after that merge, so it never made it into `v4-preview` — this brings it in.

## What
On mobile, `HelpTooltip` opens via its own click handler, but the license hint is rendered inside the `CollapsibleTrigger` in `src/agentMode/ui/ModelEnableList.tsx`. Tapping the key icon to read the tooltip bubbled to the group trigger and collapsed/expanded the whole model group, making the hint hard to use.

## Fix
Wrap the hint in a span that stops `onClick`/`onPointerDown` propagation, so tapping the key icon opens the tooltip without toggling the group.

Addresses the Codex P3 from #2645.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
