### PR TITLE
fix(ui): rebuild SettingSwitch on Obsidian native toggle variables

### DIFF
--- a/src/components/ui/setting-switch.test.tsx
+++ b/src/components/ui/setting-switch.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { SettingSwitch } from "./setting-switch";
+
+describe("SettingSwitch", () => {
+  it("renders an element with role=switch", () => {
+    render(<SettingSwitch />);
+    expect(screen.getByRole("switch")).not.toBeNull();
+  });
+
+  it("reflects the checked state via aria-checked and data-state", () => {
+    const { rerender } = render(<SettingSwitch checked />);
+    const on = screen.getByRole("switch");
+    expect(on.getAttribute("aria-checked")).toBe("true");
+    expect(on.getAttribute("data-state")).toBe("checked");
+
+    rerender(<SettingSwitch checked={false} />);
+    const off = screen.getByRole("switch");
+    expect(off.getAttribute("aria-checked")).toBe("false");
+    expect(off.getAttribute("data-state")).toBe("unchecked");
+  });
+
+  it("calls onCheckedChange with the negation of checked when clicked", () => {
+    const onCheckedChange = jest.fn();
+
+    const { rerender } = render(
+      <SettingSwitch checked={false} onCheckedChange={onCheckedChange} />
+    );
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onCheckedChange).toHaveBeenLastCalledWith(true);
+
+    rerender(<SettingSwitch checked onCheckedChange={onCheckedChange} />);
+    fireEvent.click(screen.getByRole("switch"));
+    expect(onCheckedChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("toggles on Enter and on Space", () => {
+    const onCheckedChange = jest.fn();
+    render(<SettingSwitch checked={false} onCheckedChange={onCheckedChange} />);
+    const sw = screen.getByRole("switch");
+
+    fireEvent.keyDown(sw, { key: "Enter" });
+    expect(onCheckedChange).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(sw, { key: " " });
+    expect(onCheckedChange).toHaveBeenCalledTimes(2);
+    expect(onCheckedChange).toHaveBeenNthCalledWith(1, true);
+    expect(onCheckedChange).toHaveBeenNthCalledWith(2, true);
+
+    fireEvent.keyDown(sw, { key: "a" });
+    expect(onCheckedChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not toggle and is not focusable when disabled", () => {
+    const onCheckedChange = jest.fn();
+    render(<SettingSwitch checked={false} disabled onCheckedChange={onCheckedChange} />);
+    const sw = screen.getByRole("switch");
+
+    fireEvent.click(sw);
+    fireEvent.keyDown(sw, { key: "Enter" });
+    fireEvent.keyDown(sw, { key: " " });
+    expect(onCheckedChange).not.toHaveBeenCalled();
+
+    expect(sw.getAttribute("aria-disabled")).toBe("true");
+    expect(sw.tabIndex).toBe(-1);
+  });
+});

--- a/src/components/ui/setting-switch.tsx
+++ b/src/components/ui/setting-switch.tsx
@@ -33,7 +33,7 @@ const SettingSwitch = React.forwardRef<HTMLDivElement, SettingSwitchProps>(
         ref={ref}
         tabIndex={disabled ? -1 : 0}
         className={cn(
-          "tw-relative tw-inline-flex tw-h-5.5 tw-w-10 tw-shrink-0 tw-cursor-pointer tw-items-center tw-rounded-full tw-transition-colors",
+          "tw-relative tw-inline-flex tw-h-[calc(var(--toggle-s-thumb-height)_+_var(--toggle-s-border-width)*2)] tw-w-[var(--toggle-s-width)] tw-shrink-0 tw-cursor-pointer tw-items-center tw-rounded-[var(--toggle-radius)] tw-transition-colors",
           "focus-visible:tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-ring focus-visible:tw-ring-offset-2",
           checked ? "tw-bg-interactive-accent" : "tw-bg-[--background-modifier-border-hover]",
           disabled && "tw-cursor-not-allowed tw-opacity-50",
@@ -45,8 +45,10 @@ const SettingSwitch = React.forwardRef<HTMLDivElement, SettingSwitchProps>(
       >
         <div
           className={cn(
-            "tw-pointer-events-none tw-block tw-size-4 tw-rounded-full tw-bg-toggle-thumb tw-shadow-lg tw-ring-0 tw-transition-transform",
-            checked ? "tw-translate-x-5.5" : "tw-translate-x-0.5"
+            "tw-pointer-events-none tw-block tw-h-[var(--toggle-s-thumb-height)] tw-w-[var(--toggle-s-thumb-width)] tw-rounded-[var(--toggle-thumb-radius)] tw-bg-toggle-thumb tw-shadow-sm tw-ring-0 tw-transition-transform",
+            checked
+              ? "tw-translate-x-[calc(var(--toggle-s-width)_-_var(--toggle-s-thumb-width)_-_var(--toggle-s-border-width))]"
+              : "tw-translate-x-[var(--toggle-s-border-width)]"
           )}
         />
       </div>


### PR DESCRIPTION
## Problem

The chat-controls toggles looked broken when Obsidian's font size was changed (thumb no longer reached the edge). Root cause: **`SettingSwitch` mixed CSS units.** Every dimension was fixed px via Obsidian's `--size-4-*` tokens **except** the track width, which used Tailwind's default `tw-w-10` (`2.5rem`). In Obsidian, `rem` is relative to the root font size, which the interface **Font size** setting drives (`baseFontSize`) — so that setting stretched the width alone while the px thumb/height/travel stayed put.

## Fix
<img width="464" height="227" alt="Screenshot 2026-07-02 at 10 56 27 PM" src="https://github.com/user-attachments/assets/f6cb7f27-b6ce-49d6-a5c2-f28dc583bab0" />
<img width="183" height="170" alt="Screenshot 2026-07-02 at 10 56 49 PM" src="https://github.com/user-attachments/assets/2e91344b-3f3f-4bd7-a54d-38f91e20b0d6" />

Source **all** of the switch's geometry from Obsidian's native small-toggle variables so it is 100% px and pixel-matches Obsidian's own toggles:

| Piece | Before | After |
| --- | --- | --- |
| track width | `tw-w-10` (2.5rem, font-relative) | `var(--toggle-s-width)` (36px) |
| track height | `tw-h-5.5` (22px) | `calc(--toggle-s-thumb-height + 2·--toggle-s-border-width)` (16px) |
| thumb | `tw-size-4` (16px circle) | `--toggle-s-thumb-width/height` (20×12 pill) |
| travel | hardcoded `translate-x-5.5` | `calc(width − thumb − border)` — derived from the sizes (2→14px) |
| radius | `rounded-full` | `--toggle-radius` / `--toggle-thumb-radius` (24px) |

Public API, ARIA (`role="switch"`), keyboard, and `onCheckedChange` semantics are unchanged. No caller edits — all 6 usages pass only `checked`/`onCheckedChange`/`disabled`.

### Why fixed-px (not rem)

Researched how mature libraries handle this. The bug class is always **unit mixing** (cf. [mui#40795](https://github.com/mui/material-ui/issues/40795), [shadcn-svelte#1146](https://github.com/huntabyte/shadcn-svelte/issues/1146)). Two consistent fixes exist: scale-with-font (rem/em — shadcn, Bootstrap, Chakra) or fixed (px — MUI, Ant, **Obsidian's native toggle**). Since this switch lives inside Obsidian and should match Obsidian's own controls (which are fixed px), we adopt the native px vars — and we take shadcn's real lesson (derive the thumb travel from the sizes rather than hardcoding a mismatched distance, which is what originally broke).

## Verification

**Phase 1 — unit + gates.** `format` / `lint` / `build` / `test` all green. Adds a React Testing Library behavior test (`role="switch"`, `aria-checked`/`data-state` per state, click + Enter/Space fire `onCheckedChange`, `disabled` blocks). Independent code-review pass, no correctness findings.

**Phase 2 — live Obsidian.** Measured the rebuilt geometry in a real renderer: track **36×16**, thumb **20×12**, 2px insets, 14px on-travel — exactly Obsidian's native small toggle. Critically, rendering the same geometry inside a **32px-font** container produced **identical pixel values** (`fontInvariant: true`) — the reported font-size break is gone. No uncaught errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
