### PR TITLE
feat(agent-context): refresh Agent Mode project context when included folder contents change

### DIFF
--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -288,6 +288,32 @@ describe("buildPromptBlocks", () => {
     const text = (blocks[0] as { type: "text"; text: string }).text;
     expect(text).not.toContain("<project_context>");
   });
+
+  it("injects the project-context-updates note after the manifest, before the message", () => {
+    const updatesBlock =
+      "<project_context_updates>\nsources may have changed\n</project_context_updates>";
+    const blocks = buildPromptBlocks(
+      "go",
+      { notes: [makeFile("a.md")], urls: [] },
+      undefined,
+      undefined,
+      "<project_context>\nmanifest\n</project_context>",
+      undefined,
+      updatesBlock
+    );
+    const text = (blocks[0] as { type: "text"; text: string }).text;
+    expect(text).toContain("<project_context_updates>");
+    expect(text.indexOf("<project_context>")).toBeLessThan(
+      text.indexOf("<project_context_updates>")
+    );
+    expect(text.indexOf("<project_context_updates>")).toBeLessThan(text.indexOf("<user-message>"));
+  });
+
+  it("omits the updates note when none is provided", () => {
+    const blocks = buildPromptBlocks("go", { notes: [makeFile("a.md")], urls: [] });
+    const text = (blocks[0] as { type: "text"; text: string }).text;
+    expect(text).not.toContain("<project_context_updates>");
+  });
 });
 
 describe("AgentSession.loadDisplayMessages", () => {
@@ -621,6 +647,51 @@ describe("AgentSession.sendPrompt", () => {
     });
     session.sendPrompt("first");
     expect(() => session.sendPrompt("second")).toThrow(/in flight/);
+  });
+
+  it("injects the project-context-updates note and acks its epoch after acceptance", async () => {
+    const mock = makeMockBackend();
+    const markDelivered = jest.fn();
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+      projectId: "proj-1",
+      getProjectContextUpdates: () => ({
+        epoch: 5,
+        block: "<project_context_updates>changed</project_context_updates>",
+      }),
+      markProjectContextUpdatesDelivered: markDelivered,
+    });
+
+    await session.sendPrompt("hi").turn;
+
+    const promptArg = mock.prompt.mock.calls[0][0] as { prompt: Array<{ text?: string }> };
+    expect(promptArg.prompt[0].text).toContain(
+      "<project_context_updates>changed</project_context_updates>"
+    );
+    expect(markDelivered).toHaveBeenCalledWith(5);
+  });
+
+  it("does not ack when the updates getter returns null", async () => {
+    const mock = makeMockBackend();
+    const markDelivered = jest.fn();
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+      projectId: "proj-1",
+      getProjectContextUpdates: () => null,
+      markProjectContextUpdatesDelivered: markDelivered,
+    });
+
+    await session.sendPrompt("hi").turn;
+
+    const promptArg = mock.prompt.mock.calls[0][0] as { prompt: Array<{ text?: string }> };
+    expect(promptArg.prompt[0].text).not.toContain("<project_context_updates>");
+    expect(markDelivered).not.toHaveBeenCalled();
   });
 
   it("marks an empty completed turn as a visible error message", async () => {

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -182,7 +182,39 @@ export interface AgentSessionListener {
   onNeedsAttentionChanged?(needsAttention: boolean): void;
 }
 
-export interface AgentSessionStartOptions {
+/**
+ * A pending project-context-updates note for a session: the coarse "sources may
+ * have changed" nudge (`block`) plus the content `epoch` it covers. The epoch is
+ * echoed back via {@link ProjectContextUpdatesHooks.markProjectContextUpdatesDelivered}
+ * once the turn is accepted, so the manager can advance the session's cursor.
+ */
+export interface ProjectContextUpdates {
+  epoch: number;
+  block: string;
+}
+
+/**
+ * Optional per-turn freshness hooks the manager wires into a PROJECT session (a
+ * conditional spread leaves them absent for GLOBAL / context-free sessions, so
+ * their turn path stays byte-identical to before this feature).
+ */
+export interface ProjectContextUpdatesHooks {
+  /**
+   * Sync accessor for a pending updates note for THIS session, or null when the
+   * session has already seen the latest content epoch. Called each turn just
+   * before the prompt is assembled (the manager flushes pending vault events
+   * inside it, so a change made moments before send is seen).
+   */
+  getProjectContextUpdates?: () => ProjectContextUpdates | null;
+  /**
+   * Acknowledge that the note for `epoch` rode an ACCEPTED turn so it isn't
+   * re-injected next turn. Called only after the backend accepts the prompt
+   * (mirrors `firstPromptSent`); the fan-out path never calls it.
+   */
+  markProjectContextUpdatesDelivered?: (epoch: number) => void;
+}
+
+export interface AgentSessionStartOptions extends ProjectContextUpdatesHooks {
   backend: BackendProcess;
   cwd: string;
   internalId: string;
@@ -248,7 +280,7 @@ export interface AgentSessionStartOptions {
  * Pre-resolved state used by tests and by `loadSessionFromHistory` to
  * construct a session that bypasses the async backend startup.
  */
-export interface AgentSessionStateOptions {
+export interface AgentSessionStateOptions extends ProjectContextUpdatesHooks {
   backend: BackendProcess;
   backendSessionId: SessionId;
   internalId: string;
@@ -308,6 +340,10 @@ export class AgentSession {
   private readonly runFanoutTurn: RunFanoutTurn | null;
   private readonly getDisplayName: ((backendId: BackendId) => string) | null;
   private readonly getApp: (() => App) | null;
+  // Per-turn project-context freshness hooks (see `ProjectContextUpdatesHooks`).
+  // Null for GLOBAL / context-free sessions, so their turn path is unchanged.
+  private readonly getProjectContextUpdatesFn: (() => ProjectContextUpdates | null) | null;
+  private readonly markProjectContextUpdatesDeliveredFn: ((epoch: number) => void) | null;
   // `status` is derived from the primitives below — see `getStatus()`.
   // `cachedStatus` is a memo of the last value we fired through
   // `onStatusChanged`, used purely for change detection. It is not the
@@ -432,6 +468,8 @@ export class AgentSession {
     this.runFanoutTurn = opts.runFanoutTurn ?? null;
     this.getDisplayName = opts.getDisplayName ?? null;
     this.getApp = opts.getApp ?? null;
+    this.getProjectContextUpdatesFn = opts.getProjectContextUpdates ?? null;
+    this.markProjectContextUpdatesDeliveredFn = opts.markProjectContextUpdatesDelivered ?? null;
     // Only the start path (newSession) awaits context roots; adopted/resumed
     // sessions had theirs forwarded by the manager's resume/load call already.
     this.contextReady = "contextReady" in opts ? (opts.contextReady ?? null) : null;
@@ -976,6 +1014,12 @@ export class AgentSession {
       // up front so both the fan-out and single-agent paths can inject it.
       const isFirstTurn = !this.firstPromptSent;
       const projectContextBlock = isFirstTurn ? this.projectContextBlock : null;
+      // The coarse "sources may have changed" note for an ongoing/resumed project
+      // session. Read once here (the manager flushes pending vault events inside
+      // the getter) so both paths inject the same value; acked only after the
+      // single-agent backend accepts the turn. Null for GLOBAL / current sessions.
+      const projectContextUpdates = this.getProjectContextUpdatesFn?.() ?? null;
+      const projectContextUpdatesBlock = projectContextUpdates?.block ?? null;
 
       // Fan-out path: the `@`-mentioned answerers dispatch the identical prompt in
       // parallel ephemeral read-only sub-sessions and the main agent summarizes.
@@ -1008,7 +1052,8 @@ export class AgentSession {
           promptContent,
           webTabBlock,
           projectContextBlock,
-          historyBlock
+          historyBlock,
+          projectContextUpdatesBlock
         );
         // Deliberately do NOT mark `firstPromptSent` here. Fan-out delivers the
         // first-turn project-context block only to the ephemeral sub-sessions; the
@@ -1030,7 +1075,8 @@ export class AgentSession {
         promptContent,
         webTabBlock,
         projectContextBlock,
-        leadingContextBlock
+        leadingContextBlock,
+        projectContextUpdatesBlock
       );
 
       const req: PromptInput = {
@@ -1050,6 +1096,14 @@ export class AgentSession {
       // unset and the user's retry re-delivers the context (a user cancel still
       // resolves here, and the prompt did reach the backend, so it counts as delivered).
       if (isFirstTurn) this.firstPromptSent = true;
+      // Same delivery contract as `firstPromptSent`: the note reached the backend
+      // in this accepted (possibly cancelled) prompt, so advance the session's
+      // cursor. A hard `prompt()` failure throws before here, leaving the cursor
+      // unmoved so the retry re-delivers the note. Fan-out returns earlier and
+      // never reaches this ack.
+      if (projectContextUpdates) {
+        this.markProjectContextUpdatesDeliveredFn?.(projectContextUpdates.epoch);
+      }
       if (
         placeholderId &&
         resp.stopReason !== "cancelled" &&
@@ -1996,16 +2050,19 @@ export function buildPromptBlocks(
   content?: PromptContent[],
   webTabBlock?: string,
   projectContextBlock?: string | null,
-  leadingContextBlock?: string | null
+  leadingContextBlock?: string | null,
+  projectContextUpdatesBlock?: string | null
 ): PromptContent[] {
   // Context sections precede the user message: the project-context block (first
-  // user prompt only — the project's folders/notes/URLs), then an optional
-  // prior-turn block (buffered fan-out turns the backend never saw), the vault
-  // envelope (attached notes + note excerpts), web-selection excerpts, then live
-  // web-tab content. Web tab/selection blocks reuse the legacy `<web_*>` tags so
-  // the model reads the same shapes it does in the non-agent chat.
+  // user prompt only — the project's folders/notes/URLs), then the coarse
+  // "sources may have changed" updates note (ongoing/resumed turns), then an
+  // optional prior-turn block (buffered fan-out turns the backend never saw), the
+  // vault envelope (attached notes + note excerpts), web-selection excerpts, then
+  // live web-tab content. Web tab/selection blocks reuse the legacy `<web_*>` tags
+  // so the model reads the same shapes it does in the non-agent chat.
   const sections = [
     projectContextBlock?.trim() || null,
+    projectContextUpdatesBlock?.trim() || null,
     leadingContextBlock?.trim() || null,
     buildContextEnvelope(context),
     buildWebSelectionBlocks(context),

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -8,6 +8,7 @@ import { AgentSession } from "./AgentSession";
 import { buildNativeChatId } from "@/utils/nativeChatId";
 import { AgentSessionIndex } from "./AgentSessionIndex";
 import { AgentSessionManager } from "./AgentSessionManager";
+import { ProjectContentTracker } from "@/context/projectContentTracker";
 import { GLOBAL_SCOPE } from "./scope";
 import {
   getSettings as mockedGetSettings,
@@ -219,7 +220,13 @@ const sessionCreateSpy = jest.spyOn(AgentSession, "start").mockImplementation((o
 
 function buildApp(basePath = "/vault"): App {
   const adapter = new (FileSystemAdapter as unknown as new (basePath: string) => unknown)(basePath);
-  return { vault: { adapter } } as unknown as App;
+  // The ProjectContentTracker registers vault event listeners at construction;
+  // provide no-op `on`/`offref` so a manager can be built in tests.
+  const vaultEvents = {
+    on: jest.fn(() => ({}) as never),
+    offref: jest.fn(),
+  };
+  return { vault: { adapter, ...vaultEvents } } as unknown as App;
 }
 
 function buildPlugin(): { manifest: { version: string } } {
@@ -1843,6 +1850,9 @@ describe("AgentSessionManager chat history aggregation", () => {
         adapter,
         getAbstractFileByPath: (p: string) =>
           tfiles.find((f: { path: string }) => f.path === p) ?? null,
+        // ProjectContentTracker registers vault listeners at construction.
+        on: jest.fn(() => ({}) as never),
+        offref: jest.fn(),
       },
       metadataCache: {
         getFileCache: (file: { path: string }) => {
@@ -2968,5 +2978,71 @@ describe("AgentSessionManager context-source dirty tracking", () => {
     // Done: nothing is processing.
     expect(latest()).toMatchObject({ phase: "done", blocking: false });
     expect(latest()!.processingSources).toBeUndefined();
+  });
+
+  it("a content change marks the project dirty and blocks empty-landing reuse", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    const landing = mgr.getActiveSession();
+    if (!landing) throw new Error("expected a landing session");
+    await flushAsync(); // let the create-time dirty-clear settle
+    await mgr.exitProject();
+
+    // Simulate the content tracker's callback firing for an in-scope file edit
+    // (the tracker itself is unit-tested; here we assert the manager wiring).
+    (mgr as unknown as { markProjectContextDirty: (id: string) => void }).markProjectContextDirty(
+      PID
+    );
+
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PID);
+
+    expect(sessionCreateSpy).toHaveBeenCalledTimes(1);
+    expect(mgr.getActiveSession()).not.toBe(landing);
+  });
+
+  it("wires the update hooks into a PROJECT session but not a GLOBAL one", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+
+    sessionCreateSpy.mockClear();
+    await mgr.enterProject(PID);
+    const projectOpts = sessionCreateSpy.mock.calls[0][0];
+    expect(typeof projectOpts.getProjectContextUpdates).toBe("function");
+    expect(typeof projectOpts.markProjectContextUpdatesDelivered).toBe("function");
+
+    // Back to the global scope (createSession defaults to the active scope).
+    await mgr.exitProject();
+    sessionCreateSpy.mockClear();
+    await mgr.createSession();
+    const globalOpts = sessionCreateSpy.mock.calls[0][0];
+    expect(globalOpts.getProjectContextUpdates).toBeUndefined();
+    expect(globalOpts.markProjectContextUpdatesDelivered).toBeUndefined();
+  });
+
+  it("getProjectContextUpdates flushes, returns the note when behind, then null once acked", () => {
+    const mgr = buildTrackedManager();
+    const tracker = (mgr as unknown as { contentTracker: ProjectContentTracker }).contentTracker;
+    const flushSpy = jest.spyOn(tracker, "flushNow");
+    jest.spyOn(tracker, "getEpoch").mockReturnValue(3);
+    const m = mgr as unknown as {
+      getProjectContextUpdates: (
+        id: string,
+        pid: string
+      ) => { epoch: number; block: string } | null;
+      markProjectContextUpdatesDelivered: (id: string, epoch: number) => void;
+    };
+
+    const first = m.getProjectContextUpdates("s1", PID);
+    expect(flushSpy).toHaveBeenCalled(); // send-time flush of pending vault events
+    expect(first?.epoch).toBe(3);
+    expect(first?.block).toContain("<project_context_updates>");
+
+    m.markProjectContextUpdatesDelivered("s1", 3);
+    expect(m.getProjectContextUpdates("s1", PID)).toBeNull();
+
+    // A GLOBAL session never gets a note, regardless of epoch.
+    expect(m.getProjectContextUpdates("s2", GLOBAL_SCOPE)).toBeNull();
   });
 });

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -3045,4 +3045,30 @@ describe("AgentSessionManager context-source dirty tracking", () => {
     // A GLOBAL session never gets a note, regardless of epoch.
     expect(m.getProjectContextUpdates("s2", GLOBAL_SCOPE)).toBeNull();
   });
+
+  it("advances the epoch on a config-source change so an ongoing session gets the note", async () => {
+    publish(makeRecord({ webUrls: "https://a.com" }));
+    const mgr = buildTrackedManager();
+    await mgr.enterProject(PID);
+    const session = mgr.getActiveSession();
+    if (!session) throw new Error("expected a landing session");
+    await flushAsync(); // let the create-time cursor seed settle
+
+    const m = mgr as unknown as {
+      getProjectContextUpdates: (
+        id: string,
+        pid: string
+      ) => { epoch: number; block: string } | null;
+    };
+    // Caught up right after creation.
+    expect(m.getProjectContextUpdates(session.internalId, PID)).toBeNull();
+
+    // A config edit adds a source the ongoing session can't otherwise see → the
+    // epoch advances → its next send carries the coarse note.
+    publish(makeRecord({ webUrls: "https://a.com\nhttps://b.com" }));
+
+    expect(m.getProjectContextUpdates(session.internalId, PID)?.block).toContain(
+      "<project_context_updates>"
+    );
+  });
 });

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -557,9 +557,13 @@ export class AgentSessionManager {
       if (getProjectContextSignature(prevRecord) === nextSignature) continue;
 
       const projectId = nextRecord.project.id;
-      // Same epoch-salted dirty key shape as a content change, so the clear guard
-      // treats both uniformly. A config edit keeps the baseline warm of the active
-      // project (its sources may have genuinely changed — a new URL/PDF).
+      // Advance the SAME content epoch a file change uses, so an ongoing session
+      // gets the coarse note when a config edit adds a source it can't otherwise
+      // see (a new URL/PDF/folder). Bump BEFORE marking dirty so the dirty key
+      // carries the new epoch; same key shape as a content change, so the clear
+      // guard treats both uniformly. A config edit also keeps the baseline warm of
+      // the active project (its sources may have genuinely changed).
+      this.contentTracker.bumpEpoch(projectId);
       this.markProjectContextDirty(projectId, nextRecord);
       if (projectId === this.activeProjectId) this.warmProjectContext(projectId);
     }
@@ -1191,6 +1195,10 @@ export class AgentSessionManager {
     // threaded into the session, which awaits it right before `newSession`.
     // Skipped for GLOBAL_SCOPE — no promise, no atom write, byte-identical to a
     // context-free create. Never rejects (degrades to empty roots).
+    // Settle queued vault events first so a just-edited source is reflected in the
+    // epoch/dirty snapshot below (a `+`-click create doesn't go through
+    // `enterProject`'s flush). No-op when nothing is pending.
+    if (projectId !== GLOBAL_SCOPE) this.contentTracker.flushNow();
     // Snapshot the content epoch + dirty key BEFORE kicking materialization, so
     // the delivery-cursor seed and the dirty-clear guard both reference the exact
     // revision this session is about to capture. A content change that lands while
@@ -1346,7 +1354,13 @@ export class AgentSessionManager {
                 capturedDirtyKey,
                 result.contextSignature
               );
-              this.lastSeenProjectContentEpochBySession.set(internalId, capturedContentEpoch);
+              // Seed the cursor to the captured epoch, but NEVER regress it: if a
+              // turn already acked a newer epoch before this settled, keep the
+              // higher value so the note isn't re-emitted.
+              const seen = this.lastSeenProjectContentEpochBySession.get(internalId);
+              if (seen === undefined || capturedContentEpoch > seen) {
+                this.lastSeenProjectContentEpochBySession.set(internalId, capturedContentEpoch);
+              }
             }
           }
         }
@@ -1737,6 +1751,11 @@ export class AgentSessionManager {
     // restore-the-last-tab behavior (it's the implicit scope `exitProject`
     // returns to, not a project the user deliberately re-opens).
     if (projectId !== GLOBAL_SCOPE) {
+      // Settle any queued vault events NOW so the reuse decision below sees a file
+      // the user edited moments ago (within the tracker's debounce window). Without
+      // this, an edit-then-immediately-reopen would read `dirty=false` and reuse the
+      // stale empty landing — violating "don't reuse a stale empty landing".
+      this.contentTracker.flushNow();
       // Reuse an empty landing only when it's safe: not dirty (its
       // `<project_context>` would be stale — materialization-only, see
       // `contextDirtySignatures`) AND its creation-time capture still matches the

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -662,6 +662,18 @@ export class AgentSessionManager {
    * flush pending vault events so this send sees a just-made edit, then return the
    * coarse note iff the project's content epoch has advanced past what this session
    * last saw. GLOBAL sessions never get the hook, so this is a project-only path.
+   *
+   * DESIGN NOTE — this hook only emits a coarse "sources may have changed" note; it
+   * deliberately does NOT rebuild the live session's `projectContextBlock` or remount
+   * its `additionalDirectories` (both captured at session init). So a source added or
+   * edited while an empty landing sits open surfaces as the note on the first in-place
+   * send, but the manifest/roots stay as captured: already-mounted or in-cwd sources
+   * are re-read by the agent when the note prompts it, whereas a newly-declared
+   * external root or a materialized snapshot (e.g. a PDF conversion) is only recovered
+   * by a fresh or re-entered session — the empty-landing reuse gate forces that on
+   * leave/re-enter. This keeps a pure content change from triggering any in-place
+   * re-materialization; full in-place source re-delivery is a separate concern.
+   * If a future review flags the in-place stale manifest again, point them here.
    */
   private getProjectContextUpdates(
     internalId: string,

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -67,9 +67,13 @@ import {
 } from "@/projects/state";
 import type { ProjectFileRecord } from "@/projects/type";
 import {
+  composeContextDirtyKey,
+  contextDirtyKeyMatchesConfig,
   getProjectContextSignature,
   getProjectLandingCaptureSignature,
 } from "@/projects/projectContextSignature";
+import { ProjectContentTracker } from "@/context/projectContentTracker";
+import { buildProjectContextUpdatesBlock } from "@/context/contextUpdatesBlockBuilder";
 import { ProjectFileManager } from "@/projects/ProjectFileManager";
 import { ensureAgentsMirror } from "@/projects/ensureAgentsMirror";
 import { getComposedProjectInstructions } from "@/projects/projectSystemPrompt";
@@ -147,6 +151,11 @@ const EMPTY_RECENT_CHAT_IDS: ReadonlySet<string> = new Set();
 // (claude instead has `project.md` parsed and injected in-process via setProjectProfileProvider,
 // so it needs no file.) Only these require the generated mirror to exist before cwd is read.
 const CWD_INSTRUCTION_BACKENDS: ReadonlySet<BackendId> = new Set(["codex", "opencode"]);
+
+// Delivery-cursor seed for a resumed session: BEHIND any real content epoch
+// (which starts at 0), so its first send always emits the coarse freshness note
+// regardless of whether a change was observed this plugin session.
+const RESUMED_SESSION_BEHIND_EPOCH = -1;
 
 /**
  * Map a materializer {@link SourceFailure} to the atom's {@link FailedItem}. The
@@ -282,6 +291,18 @@ export class AgentSessionManager {
   // entry, but only landing-shaped ones (idle/empty) are ever consulted for
   // reuse. A missing entry means "not reusable as a project landing".
   private readonly landingCaptureSignatures = new Map<string, string>();
+  // Watches the vault for changes to files a project's declared sources point at
+  // and bumps a per-project content epoch; a bump marks the project dirty (via
+  // `markProjectContextDirty`) and lets ongoing/resumed sessions surface a coarse
+  // "sources may have changed" note. Constructed/subscribed in the constructor,
+  // disposed in `dispose`.
+  private readonly contentTracker: ProjectContentTracker;
+  private contentTrackerUnsubscribe?: () => void;
+  // The content epoch each session has already been shown (via the coarse note or
+  // its fresh first-turn manifest). A session whose project's epoch has advanced
+  // past this value gets the note on its next send. Keyed by internal session id;
+  // a resumed session seeds a "behind" sentinel so its first send always notes.
+  private readonly lastSeenProjectContentEpochBySession = new Map<string, number>();
   // Snapshot of project records from the previous change notification, diffed
   // against the next to detect context-source edits. Seeded in the constructor.
   private previousProjectRecords: ProjectFileRecord[] = [];
@@ -366,6 +387,10 @@ export class AgentSessionManager {
     this.fanoutOrchestrator = new FanoutOrchestrator(this.createFanoutHost());
     this.settingsUnsub = subscribeToSettingsChange((prev, next) =>
       this.onDefaultSelectionsChanged(prev, next)
+    );
+    this.contentTracker = new ProjectContentTracker(this.app);
+    this.contentTrackerUnsubscribe = this.contentTracker.onContentChanged((projectId) =>
+      this.markProjectContextDirty(projectId)
     );
     this.setupProjectRecordChangeMonitor();
   }
@@ -532,9 +557,32 @@ export class AgentSessionManager {
       if (getProjectContextSignature(prevRecord) === nextSignature) continue;
 
       const projectId = nextRecord.project.id;
-      this.contextDirtySignatures.set(projectId, nextSignature);
+      // Same epoch-salted dirty key shape as a content change, so the clear guard
+      // treats both uniformly. A config edit keeps the baseline warm of the active
+      // project (its sources may have genuinely changed — a new URL/PDF).
+      this.markProjectContextDirty(projectId, nextRecord);
       if (projectId === this.activeProjectId) this.warmProjectContext(projectId);
     }
+  }
+
+  /**
+   * Flag a project's materialized context as stale under an epoch-salted dirty
+   * key (config signature + the tracker's current content epoch). A pure content
+   * edit doesn't move the config signature, so the epoch salt is what lets it read
+   * as a distinct dirty revision and gate empty-landing reuse. Unlike a config
+   * change this does NOT warm — freshness is recovered lazily when the next
+   * session for the project materializes (the empty-landing gate forces that).
+   */
+  private markProjectContextDirty(
+    projectId: ProjectScopeId,
+    record = getCachedProjectRecordById(projectId)
+  ): void {
+    if (this.disposed || projectId === GLOBAL_SCOPE || !record) return;
+    const key = composeContextDirtyKey(
+      getProjectContextSignature(record),
+      this.contentTracker.getEpoch(projectId)
+    );
+    this.contextDirtySignatures.set(projectId, key);
   }
 
   /**
@@ -552,8 +600,29 @@ export class AgentSessionManager {
     } catch {
       return; // off-desktop: no FileSystemAdapter, nothing to warm
     }
-    void ensureProjectContextMaterialized(this.app, projectId, cwd).catch((err) =>
-      logWarn(`[AgentMode] background context warm failed for ${projectId}`, err)
+    void ensureProjectContextMaterialized(
+      this.app,
+      projectId,
+      cwd,
+      undefined,
+      undefined,
+      this.currentContextRevisionKey(projectId)
+    ).catch((err) => logWarn(`[AgentMode] background context warm failed for ${projectId}`, err));
+  }
+
+  /**
+   * The epoch-salted revision key for a project's CURRENT config + content epoch,
+   * passed to the materializer's single-flight so a run reading stale content is
+   * superseded rather than joined once the content epoch advances. `undefined`
+   * when no record is cached (the materializer then falls back to the config
+   * signature, its prior behavior).
+   */
+  private currentContextRevisionKey(projectId: ProjectScopeId): string | undefined {
+    const record = getCachedProjectRecordById(projectId);
+    if (!record) return undefined;
+    return composeContextDirtyKey(
+      getProjectContextSignature(record),
+      this.contentTracker.getEpoch(projectId)
     );
   }
 
@@ -564,16 +633,48 @@ export class AgentSessionManager {
 
   /**
    * Clear a project's dirty flag once a freshly-created session has captured its
-   * context — but ONLY if the signature the session actually captured (passed in,
-   * read synchronously at materialization kickoff) still equals the dirty one. A
-   * newer edit that landed after this session started materializing bumps the
-   * dirty signature, so it won't match and the project stays dirty (this session
-   * captured the OLDER sources). The lost-update guard for edit/create races.
+   * context — but ONLY if the dirty key still EXACTLY equals the one captured at
+   * this session's materialization kickoff (a newer config edit or content bump
+   * replaces the key, so it won't match and the project stays dirty — the
+   * lost-update guard), AND the materializer result's config signature belongs to
+   * that captured key's config. The exact-key check is what makes the epoch-salted
+   * content revision safe: paired with the materializer's `revisionKey`, the run
+   * that resolved actually read the captured epoch's content.
    */
-  private clearContextDirtyIfCaptured(projectId: ProjectScopeId, capturedSignature: string): void {
-    if (this.contextDirtySignatures.get(projectId) === capturedSignature) {
+  private clearContextDirtyIfCaptured(
+    projectId: ProjectScopeId,
+    capturedKey: string | undefined,
+    resultContextSignature: string | undefined
+  ): void {
+    if (capturedKey === undefined || resultContextSignature === undefined) return;
+    if (this.contextDirtySignatures.get(projectId) !== capturedKey) return;
+    if (contextDirtyKeyMatchesConfig(capturedKey, resultContextSignature)) {
       this.contextDirtySignatures.delete(projectId);
     }
+  }
+
+  /**
+   * Sync accessor wired into a project session (see `ProjectContextUpdatesHooks`):
+   * flush pending vault events so this send sees a just-made edit, then return the
+   * coarse note iff the project's content epoch has advanced past what this session
+   * last saw. GLOBAL sessions never get the hook, so this is a project-only path.
+   */
+  private getProjectContextUpdates(
+    internalId: string,
+    projectId: ProjectScopeId
+  ): { epoch: number; block: string } | null {
+    if (projectId === GLOBAL_SCOPE) return null;
+    this.contentTracker.flushNow();
+    const epoch = this.contentTracker.getEpoch(projectId);
+    const lastSeen = this.lastSeenProjectContentEpochBySession.get(internalId) ?? 0;
+    if (epoch <= lastSeen) return null;
+    return { epoch, block: buildProjectContextUpdatesBlock() };
+  }
+
+  /** Advance a session's content-epoch cursor once its note rode an accepted turn. */
+  private markProjectContextUpdatesDelivered(internalId: string, epoch: number): void {
+    const lastSeen = this.lastSeenProjectContentEpochBySession.get(internalId) ?? 0;
+    if (epoch > lastSeen) this.lastSeenProjectContentEpochBySession.set(internalId, epoch);
   }
 
   /**
@@ -1090,8 +1191,25 @@ export class AgentSessionManager {
     // threaded into the session, which awaits it right before `newSession`.
     // Skipped for GLOBAL_SCOPE — no promise, no atom write, byte-identical to a
     // context-free create. Never rejects (degrades to empty roots).
+    // Snapshot the content epoch + dirty key BEFORE kicking materialization, so
+    // the delivery-cursor seed and the dirty-clear guard both reference the exact
+    // revision this session is about to capture. A content change that lands while
+    // materialization is in flight bumps the epoch past `capturedContentEpoch`, so
+    // it still surfaces as a note on a later send (and supersedes the run via the
+    // revision key rather than being silently absorbed).
+    const capturedContentEpoch =
+      projectId === GLOBAL_SCOPE ? 0 : this.contentTracker.getEpoch(projectId);
+    const capturedDirtyKey =
+      projectId === GLOBAL_SCOPE ? undefined : this.contextDirtySignatures.get(projectId);
     const contextReady =
-      projectId === GLOBAL_SCOPE ? undefined : this.beginContextMaterialization(projectId, cwd);
+      projectId === GLOBAL_SCOPE
+        ? undefined
+        : this.beginContextMaterialization(
+            projectId,
+            cwd,
+            undefined,
+            this.currentContextRevisionKey(projectId)
+          );
 
     const descriptor = this.resolveDescriptor(resolvedId);
 
@@ -1141,10 +1259,11 @@ export class AgentSessionManager {
     // (warm or cold) proc at the resolved scope cwd, threading the project
     // scope + context roots; the probe's state still seeds the picker so it
     // doesn't blink while that round-trip is in flight.
+    const internalId = uuidv4();
     const session = AgentSession.start({
       backend,
       cwd,
-      internalId: uuidv4(),
+      internalId,
       backendId: resolvedId,
       projectId,
       defaultModelSelection: resolvedSeed,
@@ -1154,6 +1273,15 @@ export class AgentSessionManager {
       getDisplayName: (backendId) => this.resolveDescriptor(backendId).displayName,
       getApp: () => this.app,
       contextReady,
+      // Project sessions only — leaving these absent keeps a GLOBAL session's
+      // turn path byte-identical to before this feature (no hook, no note).
+      ...(projectId !== GLOBAL_SCOPE
+        ? {
+            getProjectContextUpdates: () => this.getProjectContextUpdates(internalId, projectId),
+            markProjectContextUpdatesDelivered: (epoch: number) =>
+              this.markProjectContextUpdatesDelivered(internalId, epoch),
+          }
+        : {}),
     });
     if (warm) {
       logInfo(
@@ -1202,14 +1330,24 @@ export class AgentSessionManager {
         // `initialize()` has already awaited `contextReady`, so the await below is
         // an already-settled microtask, not a fresh network wait — it can't stall
         // `finishPendingCreate`. Clear the project's dirty flag FIRST, before any
-        // optional backend config that could hang and stall it. Clear only for the
-        // source revision the materializer actually captured (`contextSignature`):
-        // a newer edit mid-flight bumped the dirty signature, so it won't match and
-        // stays dirty (lost-update guard); a failed materialize carries no signature.
+        // optional backend config that could hang and stall it. Clear only when the
+        // captured dirty key still matches (a newer edit/content bump superseded it,
+        // so it stays dirty — lost-update guard) and the materializer captured a
+        // signature (a failed materialize carries none). The same success path seeds
+        // the session's delivery cursor to the epoch it captured, so its FRESH
+        // first-turn manifest isn't immediately followed by a redundant note; a
+        // change during materialization bumped the epoch past this and still notes.
         if (contextReady) {
           const result = await contextReady;
-          if (!this.disposed && result.contextSignature !== undefined) {
-            this.clearContextDirtyIfCaptured(projectId, result.contextSignature);
+          if (!this.disposed && this.sessions.get(internalId) === session) {
+            if (result.contextSignature !== undefined) {
+              this.clearContextDirtyIfCaptured(
+                projectId,
+                capturedDirtyKey,
+                result.contextSignature
+              );
+              this.lastSeenProjectContentEpochBySession.set(internalId, capturedContentEpoch);
+            }
           }
         }
         if (descriptor.applyInitialSessionConfig) {
@@ -1288,7 +1426,8 @@ export class AgentSessionManager {
   private beginContextMaterialization(
     projectId: ProjectScopeId,
     cwd: string,
-    forceRetryFailed?: boolean
+    forceRetryFailed?: boolean,
+    revisionKey?: string
   ): Promise<ContextMaterializationResult> {
     // Accumulate counts so every publish carries the latest of all three steps
     // (resolve / prefetch / parse), not just the one that fired last.
@@ -1375,7 +1514,14 @@ export class AgentSessionManager {
         }
       : undefined;
 
-    return ensureProjectContextMaterialized(this.app, projectId, cwd, onProgress, forceRetryFailed)
+    return ensureProjectContextMaterialized(
+      this.app,
+      projectId,
+      cwd,
+      onProgress,
+      forceRetryFailed,
+      revisionKey
+    )
       .then((ctx) => {
         if (ownsPublish) {
           // Always carry `failedSources` (empty when clean) so a prior run's
@@ -1447,7 +1593,12 @@ export class AgentSessionManager {
     // above can't see it — but the forced run supersedes it (see
     // {@link ensureProjectContextMaterialized}), and any landing refresh the
     // returned `true` triggers then joins THIS forced run, not the stale warm.
-    void this.beginContextMaterialization(projectId, cwd, true);
+    void this.beginContextMaterialization(
+      projectId,
+      cwd,
+      true,
+      this.currentContextRevisionKey(projectId)
+    );
     // Reason: report whether a real run started so the caller can defer the
     // post-retry landing refresh (skipped for the no-op scopes above).
     return true;
@@ -1676,12 +1827,19 @@ export class AgentSessionManager {
    * signature); one that baked in stale config is skipped. Prefers the scope's
    * MRU; falls back to the most recent matching session. `null` means the caller
    * should spawn fresh.
+   *
+   * A DETACHED landing is never reusable: it was pushed out of the strip because a
+   * fresh visit spawned past it (e.g. it was content-dirty at the time), so its
+   * captured `<project_context>` may predate a change the landing-capture signature
+   * — which tracks config, not file contents — cannot see. Re-adopting it would
+   * violate "don't reuse a stale empty landing"; spawn fresh instead.
    */
   private pickReusableLandingSession(projectId: ProjectScopeId): AgentSession | null {
     const expected = this.currentLandingCaptureSignature(projectId);
     if (!expected) return null;
     const isReusable = (session: AgentSession): boolean =>
       this.isReusableLandingShell(session, projectId) &&
+      !this.detachedFromTabIds.has(session.internalId) &&
       this.landingCaptureSignatures.get(session.internalId) === expected;
 
     const mruId = this.lastActiveByScope.get(projectId);
@@ -2183,6 +2341,7 @@ export class AgentSessionManager {
     this.sessions.delete(id);
     this.chatUIStates.delete(id);
     this.landingCaptureSignatures.delete(id);
+    this.lastSeenProjectContentEpochBySession.delete(id);
     this.detachedFromTabIds.delete(id);
     // Drop the closed session from its scope's MRU so a later enter can't
     // resurrect a dead id.
@@ -2378,6 +2537,11 @@ export class AgentSessionManager {
     // on a half-disposed manager.
     this.projectRecordsUnsubscriber?.();
     this.projectRecordsUnsubscriber = undefined;
+    // Stop the vault watcher and drop its listener before the awaited teardown so
+    // a late vault event can't bump an epoch on a half-disposed manager.
+    this.contentTrackerUnsubscribe?.();
+    this.contentTrackerUnsubscribe = undefined;
+    this.contentTracker.dispose();
     logInfo(
       `[AgentMode] shutdown (pool size=${this.sessions.size}, backends=${this.backends.size})`
     );
@@ -2408,6 +2572,7 @@ export class AgentSessionManager {
     this.sessions.clear();
     this.chatUIStates.clear();
     this.landingCaptureSignatures.clear();
+    this.lastSeenProjectContentEpochBySession.clear();
     this.activeSessionId = null;
     this.activeProjectId = GLOBAL_SCOPE;
     this.lastActiveByScope.clear();
@@ -2674,7 +2839,14 @@ export class AgentSessionManager {
     // session can't appear before the backend rehydrates it, so we await the
     // roots just before `loadSession`. Never rejects → resume is never blocked.
     const contextReady =
-      projectId === GLOBAL_SCOPE ? undefined : this.beginContextMaterialization(projectId, cwd);
+      projectId === GLOBAL_SCOPE
+        ? undefined
+        : this.beginContextMaterialization(
+            projectId,
+            cwd,
+            undefined,
+            this.currentContextRevisionKey(projectId)
+          );
     const descriptor = this.resolveDescriptor(backendId);
 
     this.pendingCreates++;
@@ -2758,10 +2930,11 @@ export class AgentSessionManager {
       return null;
     }
 
+    const internalId = uuidv4();
     const session = new AgentSession({
       backend,
       backendSessionId: resumeResult.sessionId,
-      internalId: uuidv4(),
+      internalId,
       backendId,
       projectId,
       initialState: resumeResult.state,
@@ -2770,7 +2943,22 @@ export class AgentSessionManager {
       runFanoutTurn: (input) => this.runFanoutTurn(input),
       getDisplayName: (id) => this.resolveDescriptor(id).displayName,
       getApp: () => this.app,
+      // Project sessions only. A resumed conversation was closed for a while, so
+      // its sources may well have changed — seed the cursor BEHIND the current
+      // epoch so its first send always emits the coarse note (the maintainer's
+      // "resumed-session note"), independent of whether a change was observed this
+      // plugin session. Deferred fresh-manifest re-delivery is a separate feature.
+      ...(projectId !== GLOBAL_SCOPE
+        ? {
+            getProjectContextUpdates: () => this.getProjectContextUpdates(internalId, projectId),
+            markProjectContextUpdatesDelivered: (epoch: number) =>
+              this.markProjectContextUpdatesDelivered(internalId, epoch),
+          }
+        : {}),
     });
+    if (projectId !== GLOBAL_SCOPE) {
+      this.lastSeenProjectContentEpochBySession.set(internalId, RESUMED_SESSION_BEHIND_EPOCH);
+    }
     this.sessions.set(session.internalId, session);
     this.chatUIStates.set(session.internalId, new AgentChatUIState(session));
     this.detachedFromTabIds.delete(session.internalId);
@@ -3155,6 +3343,7 @@ export class AgentSessionManager {
         this.sessions.delete(s.internalId);
         this.chatUIStates.delete(s.internalId);
         this.landingCaptureSignatures.delete(s.internalId);
+        this.lastSeenProjectContentEpochBySession.delete(s.internalId);
         this.detachedFromTabIds.delete(s.internalId);
         // Drop the dead session from its scope's MRU so a later enter can't
         // resurrect a dead id.

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -1324,6 +1324,27 @@ export class AgentSessionManager {
     this.attachAttentionTracking(session);
     this.notify();
 
+    // Seed the delivery cursor as soon as the project's context is MATERIALIZED —
+    // before the session becomes sendable (which only happens once `initialize`
+    // opens the backend session, after `contextReady` resolves). Piggybacking on
+    // `session.ready` instead would leave a window during the post-`newSession`
+    // `confirmSeededSelection` await where a first send could emit a redundant note.
+    // Only acts while this exact session is still pooled, and never regresses a
+    // higher already-acked epoch. (The dirty CLEAR stays on `session.ready` below —
+    // a failed backend startup must leave the project dirty so a re-entry re-spawns.)
+    if (contextReady) {
+      void contextReady
+        .then((result) => {
+          if (this.disposed || this.sessions.get(internalId) !== session) return;
+          if (result.contextSignature === undefined) return;
+          const seen = this.lastSeenProjectContentEpochBySession.get(internalId);
+          if (seen === undefined || capturedContentEpoch > seen) {
+            this.lastSeenProjectContentEpochBySession.set(internalId, capturedContentEpoch);
+          }
+        })
+        .catch(() => {});
+    }
+
     // Once the ACP session is ready, apply backend-specific persisted state
     // (claude's effort, future config-option preferences) and clear the
     // "starting" pill. On failure, capture into `lastError` so the status
@@ -1333,35 +1354,21 @@ export class AgentSessionManager {
     void session.ready
       .then(async () => {
         // Reaching here means the session is fully ready — it captured its context
-        // and opened its backend session (a failed startup rejects into `.catch`
-        // and never runs this). A fresh session's `ready` resolves only after
-        // `initialize()` has already awaited `contextReady`, so the await below is
-        // an already-settled microtask, not a fresh network wait — it can't stall
-        // `finishPendingCreate`. Clear the project's dirty flag FIRST, before any
-        // optional backend config that could hang and stall it. Clear only when the
-        // captured dirty key still matches (a newer edit/content bump superseded it,
-        // so it stays dirty — lost-update guard) and the materializer captured a
-        // signature (a failed materialize carries none). The same success path seeds
-        // the session's delivery cursor to the epoch it captured, so its FRESH
-        // first-turn manifest isn't immediately followed by a redundant note; a
-        // change during materialization bumped the epoch past this and still notes.
+        // and opened its backend session (a failed startup rejects into `.catch` and
+        // never runs this, so the project stays dirty and a re-entry re-spawns).
+        // Clear the dirty flag FIRST, before any optional backend config that could
+        // hang and stall `finishPendingCreate`. Clear only when the captured dirty
+        // key still matches (a newer edit/content bump superseded it — lost-update
+        // guard) and the materializer captured a signature (a failed materialize
+        // carries none). The cursor SEED already ran off `contextReady` above.
         if (contextReady) {
           const result = await contextReady;
-          if (!this.disposed && this.sessions.get(internalId) === session) {
-            if (result.contextSignature !== undefined) {
-              this.clearContextDirtyIfCaptured(
-                projectId,
-                capturedDirtyKey,
-                result.contextSignature
-              );
-              // Seed the cursor to the captured epoch, but NEVER regress it: if a
-              // turn already acked a newer epoch before this settled, keep the
-              // higher value so the note isn't re-emitted.
-              const seen = this.lastSeenProjectContentEpochBySession.get(internalId);
-              if (seen === undefined || capturedContentEpoch > seen) {
-                this.lastSeenProjectContentEpochBySession.set(internalId, capturedContentEpoch);
-              }
-            }
+          if (
+            !this.disposed &&
+            this.sessions.get(internalId) === session &&
+            result.contextSignature !== undefined
+          ) {
+            this.clearContextDirtyIfCaptured(projectId, capturedDirtyKey, result.contextSignature);
           }
         }
         if (descriptor.applyInitialSessionConfig) {
@@ -2853,6 +2860,11 @@ export class AgentSessionManager {
       if (record) await ensureAgentsMirror(this.app, record);
     }
     const cwd = this.resolveSessionCwd(projectId);
+    // Settle queued vault events so the revision key below reflects a just-edited
+    // source — otherwise resume could join an in-flight run reading the old content
+    // and rehydrate the backend with stale searchable roots (the forced coarse note
+    // can't add a root the backend never mounted).
+    if (projectId !== GLOBAL_SCOPE) this.contentTracker.flushNow();
     // Kick off materialization in parallel (publishes the blocking load state up
     // front), overlapping with `ensureBackend`. Unlike a fresh create, a resumed
     // session can't appear before the backend rehydrates it, so we await the

--- a/src/context/contextUpdatesBlockBuilder.test.ts
+++ b/src/context/contextUpdatesBlockBuilder.test.ts
@@ -1,0 +1,14 @@
+import { buildProjectContextUpdatesBlock } from "./contextUpdatesBlockBuilder";
+
+describe("buildProjectContextUpdatesBlock", () => {
+  it("returns the fixed coarse note wrapped in a project_context_updates tag", () => {
+    const block = buildProjectContextUpdatesBlock();
+    expect(block).toContain("<project_context_updates>");
+    expect(block).toContain("</project_context_updates>");
+    expect(block).toContain("re-check declared folders/tags/files before answering");
+  });
+
+  it("is a stable, source-agnostic constant (no per-path detail)", () => {
+    expect(buildProjectContextUpdatesBlock()).toBe(buildProjectContextUpdatesBlock());
+  });
+});

--- a/src/context/contextUpdatesBlockBuilder.ts
+++ b/src/context/contextUpdatesBlockBuilder.ts
@@ -1,0 +1,20 @@
+/**
+ * Builds the coarse "project sources may have changed" note injected into an
+ * ongoing or resumed project session when the tracker has observed a content
+ * change the session hasn't seen yet.
+ *
+ * This is deliberately a single fixed, source-agnostic nudge — NOT a per-path
+ * or per-source delta. The agent re-checks the project's declared scope itself;
+ * exact per-path / binary deltas are a separate feature. Keeping it a pure
+ * function (no params) makes the exact wording unit-testable and keeps the
+ * manager decoupled from prompt phrasing.
+ */
+const PROJECT_CONTEXT_UPDATES_BLOCK = [
+  "<project_context_updates>",
+  "Project sources may have changed, re-check declared folders/tags/files before answering.",
+  "</project_context_updates>",
+].join("\n");
+
+export function buildProjectContextUpdatesBlock(): string {
+  return PROJECT_CONTEXT_UPDATES_BLOCK;
+}

--- a/src/context/projectContentTracker.test.ts
+++ b/src/context/projectContentTracker.test.ts
@@ -176,6 +176,44 @@ describe("ProjectContentTracker", () => {
     tracker.dispose();
   });
 
+  it("dirties a tag-declaring project on a FOLDER delete (tagged notes may be inside)", () => {
+    mockRecords(record("a", { inclusions: "#important" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("delete", folder("SomeFolder"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
+    tracker.dispose();
+  });
+
+  it("dirties a tag-declaring project when a note LEAVES markdown scope (.md → .txt)", () => {
+    mockRecords(record("a", { inclusions: "#important" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    // New file is .txt (not markdown), but the old path was .md — it left tag scope.
+    fire("rename", file("Notes/note.txt"), "Notes/note.md");
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
+    tracker.dispose();
+  });
+
+  it("does NOT let an internal markdown file dirty a tag-declaring project", () => {
+    mockRecords(record("a", { inclusions: "#important" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    // Editing the internal log (a markdown file) must not spray tag-project notes.
+    fire("modify", file("copilot/copilot-log.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(0);
+    tracker.dispose();
+  });
+
   it("flushNow drains synchronously and does not double-bump on a later timer", () => {
     jest.useFakeTimers();
     mockRecords(record("a", { inclusions: "Notes" }));

--- a/src/context/projectContentTracker.test.ts
+++ b/src/context/projectContentTracker.test.ts
@@ -214,7 +214,9 @@ describe("ProjectContentTracker", () => {
     tracker.dispose();
   });
 
-  it("does NOT dirty on a folder CREATE (an empty new folder has no members)", () => {
+  it("does NOT dirty on a folder CREATE that is a DESCENDANT of a declared folder", () => {
+    // The declared root `Notes` already exists, so a child folder appearing under
+    // it doesn't change how the root resolves — no manifest change, no dirty.
     mockRecords(
       record("tag", { inclusions: "#important" }),
       record("folder", { inclusions: "Notes" })
@@ -227,6 +229,21 @@ describe("ProjectContentTracker", () => {
 
     expect(tracker.getEpoch("tag")).toBe(0);
     expect(tracker.getEpoch("folder")).toBe(0);
+    tracker.dispose();
+  });
+
+  it("dirties when a folder CREATE IS an exactly-declared folder pattern", () => {
+    // A project declares `External` (out of its folder), which didn't exist. Once
+    // created, resolveFolderPaths turns it into a real manifest entry + search root,
+    // so a stale empty landing must not be reused.
+    mockRecords(record("a", { inclusions: "External" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("create", folder("External"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
     tracker.dispose();
   });
 

--- a/src/context/projectContentTracker.test.ts
+++ b/src/context/projectContentTracker.test.ts
@@ -1,0 +1,231 @@
+import { App, TFile, TFolder } from "obsidian";
+import { ProjectContentTracker } from "./projectContentTracker";
+import * as projectState from "@/projects/state";
+import type { ProjectFileRecord } from "@/projects/type";
+
+jest.mock("@/logger", () => ({
+  logWarn: jest.fn(),
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+}));
+
+jest.mock("@/logFileManager", () => ({
+  logFileManager: { getLogPath: () => "copilot/copilot-log.md" },
+}));
+
+jest.mock(
+  "@/settings/model",
+  (): Record<string, unknown> => ({
+    ...jest.requireActual("@/settings/model"),
+    getSettings: jest
+      .fn()
+      .mockReturnValue({ projectsFolder: "", qaInclusions: "", qaExclusions: "" }),
+  })
+);
+
+jest.mock("@/projects/state", () => ({
+  getCachedProjectRecords: jest.fn().mockReturnValue([]),
+}));
+
+type Handler = (file: unknown, oldPath?: string) => void;
+
+/** A fake vault that records event handlers so a test can fire them by hand. */
+function makeApp(): { app: App; fire: (event: string, file: unknown, oldPath?: string) => void } {
+  const handlers = new Map<string, Handler[]>();
+  const app = {
+    vault: {
+      on: (event: string, handler: Handler) => {
+        const list = handlers.get(event) ?? [];
+        list.push(handler);
+        handlers.set(event, list);
+        return { event };
+      },
+      offref: jest.fn(),
+    },
+  } as unknown as App;
+  const fire = (event: string, file: unknown, oldPath?: string) => {
+    for (const handler of handlers.get(event) ?? []) handler(file, oldPath);
+  };
+  return { app, fire };
+}
+
+function record(id: string, contextSource: Record<string, string>): ProjectFileRecord {
+  return {
+    project: { id, contextSource } as ProjectFileRecord["project"],
+    filePath: `Projects/${id}/project.md`,
+    folderName: id,
+  };
+}
+
+function mockRecords(...records: ProjectFileRecord[]): void {
+  (projectState.getCachedProjectRecords as jest.Mock).mockReturnValue(records);
+}
+
+function file(path: string): TFile {
+  return new (TFile as unknown as new (p: string) => TFile)(path);
+}
+
+function folder(path: string): TFolder {
+  return new (TFolder as unknown as new (p: string) => TFolder)(path);
+}
+
+describe("ProjectContentTracker", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("bumps the epoch only for the project whose folder scope a file change touches", () => {
+    mockRecords(record("a", { inclusions: "Notes" }), record("b", { inclusions: "Other" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("Notes/topic.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
+    expect(tracker.getEpoch("b")).toBe(0);
+    tracker.dispose();
+  });
+
+  it("notifies subscribers with the affected project id", () => {
+    mockRecords(record("a", { inclusions: "Notes" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+    const seen: string[] = [];
+    tracker.onContentChanged((id) => seen.push(id));
+
+    fire("create", file("Notes/new.md"));
+    tracker.flushNow();
+
+    expect(seen).toEqual(["a"]);
+    tracker.dispose();
+  });
+
+  it("matches a deleted file by its (dead) path", () => {
+    mockRecords(record("a", { inclusions: "Notes" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("delete", file("Notes/gone.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
+    tracker.dispose();
+  });
+
+  it("matches a rename on BOTH the old and the new path", () => {
+    mockRecords(record("in", { inclusions: "Notes" }), record("out", { inclusions: "Archive" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    // Moved from Archive (out's scope) into Notes (in's scope): both dirty.
+    fire("rename", file("Notes/moved.md"), "Archive/moved.md");
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("in")).toBe(1);
+    expect(tracker.getEpoch("out")).toBe(1);
+    tracker.dispose();
+  });
+
+  it("dirties a folder-inclusion project on an ANCESTOR folder rename", () => {
+    mockRecords(record("a", { inclusions: "Notes/Sub" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    // Renaming the ancestor `Notes` moves the included `Notes/Sub` subtree.
+    fire("rename", folder("Renamed"), "Notes");
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
+    tracker.dispose();
+  });
+
+  it("conservatively dirties a tag-declaring project on ANY markdown change", () => {
+    // The changed file isn't under any folder pattern, but the project declares a
+    // tag, and tags can't be resolved from a path — so it dirties conservatively.
+    mockRecords(record("a", { inclusions: "#important" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("Anywhere/note.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
+    tracker.dispose();
+  });
+
+  it("does NOT dirty a tag-declaring project on a non-markdown change out of scope", () => {
+    mockRecords(record("a", { inclusions: "#important" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("Anywhere/image.png"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(0);
+    tracker.dispose();
+  });
+
+  it("ignores an internal Copilot file caught by a broad *.md pattern", () => {
+    mockRecords(record("a", { inclusions: "*.md" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("copilot/copilot-log.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(0);
+    tracker.dispose();
+  });
+
+  it("flushNow drains synchronously and does not double-bump on a later timer", () => {
+    jest.useFakeTimers();
+    mockRecords(record("a", { inclusions: "Notes" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("Notes/topic.md"));
+    tracker.flushNow();
+    expect(tracker.getEpoch("a")).toBe(1);
+
+    // The debounce timer must have been cleared by flush — no second bump.
+    jest.runOnlyPendingTimers();
+    expect(tracker.getEpoch("a")).toBe(1);
+
+    tracker.dispose();
+    jest.useRealTimers();
+  });
+
+  it("a matcher throw for one project doesn't stop the sweep for others", () => {
+    // First record has a getter that throws when its contextSource is read.
+    const boom = {
+      project: {
+        id: "boom",
+        get contextSource() {
+          throw new Error("bad pattern");
+        },
+      },
+      filePath: "Projects/boom/project.md",
+      folderName: "boom",
+    } as unknown as ProjectFileRecord;
+    mockRecords(boom, record("ok", { inclusions: "Notes" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("Notes/topic.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("ok")).toBe(1);
+    tracker.dispose();
+  });
+
+  it("stops bumping after dispose", () => {
+    mockRecords(record("a", { inclusions: "Notes" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+    tracker.dispose();
+
+    fire("modify", file("Notes/topic.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(0);
+  });
+});

--- a/src/context/projectContentTracker.test.ts
+++ b/src/context/projectContentTracker.test.ts
@@ -214,6 +214,22 @@ describe("ProjectContentTracker", () => {
     tracker.dispose();
   });
 
+  it("does NOT dirty on a folder CREATE (an empty new folder has no members)", () => {
+    mockRecords(
+      record("tag", { inclusions: "#important" }),
+      record("folder", { inclusions: "Notes" })
+    );
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("create", folder("Notes/NewEmpty"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("tag")).toBe(0);
+    expect(tracker.getEpoch("folder")).toBe(0);
+    tracker.dispose();
+  });
+
   it("flushNow drains synchronously and does not double-bump on a later timer", () => {
     jest.useFakeTimers();
     mockRecords(record("a", { inclusions: "Notes" }));

--- a/src/context/projectContentTracker.ts
+++ b/src/context/projectContentTracker.ts
@@ -188,6 +188,14 @@ function changeAffectsProject(change: PendingChange, record: ProjectFileRecord):
   }
 
   if (change.isFolder) {
+    // DESIGN NOTE — a folder CREATE/MODIFY is a deliberate no-op, INCLUDING when the
+    // created folder exactly equals a declared `folderPattern` (e.g. a project
+    // includes `External`, which didn't exist, and the user creates it). An empty
+    // folder has nothing to materialize, so the manifest is unchanged; an ongoing
+    // session doesn't re-mount searchable roots mid-conversation in v1 regardless;
+    // and an empty landing's captured (empty) manifest equals a fresh one's, so
+    // reuse is harmless. The moment any FILE lands inside it, the file event dirties
+    // and self-heals. If a future review flags this again, point them here.
     if (!folderMembershipEvent) return false;
     // Obsidian doesn't guarantee child events on a folder op, so match the folder
     // path against folder patterns in BOTH directions (the event path may be an

--- a/src/context/projectContentTracker.ts
+++ b/src/context/projectContentTracker.ts
@@ -1,0 +1,226 @@
+import { logWarn } from "@/logger";
+import { getCachedProjectRecords } from "@/projects/state";
+import type { ProjectFileRecord } from "@/projects/type";
+import {
+  getMatchingPatterns,
+  isInternalExcludedPath,
+  type PatternCategory,
+} from "@/search/searchUtils";
+import { debounce, type DebouncedFunction } from "@/utils/debounce";
+import { App, EventRef, normalizePath, TAbstractFile, TFile, TFolder } from "obsidian";
+
+const DEBOUNCE_MS = 2000;
+
+/**
+ * An immutable snapshot of one vault event. We deliberately do NOT keep the
+ * `TAbstractFile` reference: Obsidian mutates `TFile.path` in place on rename,
+ * so a live reference read at drain time would report the post-rename path for
+ * a queued pre-rename event. Snapshotting the strings at enqueue time keeps the
+ * old/new paths correct.
+ */
+interface PendingChange {
+  isFolder: boolean;
+  isMarkdown: boolean;
+  path: string;
+  oldPath?: string;
+}
+
+/**
+ * Watches the vault for changes to files a project's declared context sources
+ * point at, and bumps a per-project "content epoch" when it sees one. This is
+ * the freshness signal behind Agent Mode's project-context staleness fix: a
+ * bumped epoch marks the project dirty (so a stale empty landing isn't reused)
+ * and lets ongoing/resumed sessions surface a coarse "sources may have changed"
+ * note.
+ *
+ * Deliberately COARSE (over-dirty is the safe direction for a freshness hint):
+ * it never emits per-path deltas, never classifies binaries, and keeps no
+ * change log — it only answers "did anything in this project's declared scope
+ * change since epoch N?". Exact per-path/binary deltas are a separate feature.
+ */
+export class ProjectContentTracker {
+  private readonly vaultRefs: EventRef[] = [];
+  private readonly pending: PendingChange[] = [];
+  private readonly epochs = new Map<string, number>();
+  private readonly listeners = new Set<(projectId: string) => void>();
+  private readonly debouncedDrain: DebouncedFunction<() => void>;
+  private disposed = false;
+
+  constructor(
+    private readonly app: App,
+    debounceMs: number = DEBOUNCE_MS
+  ) {
+    this.debouncedDrain = debounce(() => this.drain(), debounceMs, { trailing: true });
+    const onEvent = (file: TAbstractFile) => this.enqueue(file);
+    this.vaultRefs.push(this.app.vault.on("create", onEvent));
+    this.vaultRefs.push(this.app.vault.on("modify", onEvent));
+    this.vaultRefs.push(this.app.vault.on("delete", onEvent));
+    // Rename carries the previous path; snapshot both sides so a move out of or
+    // into a project's scope is detected.
+    this.vaultRefs.push(
+      this.app.vault.on("rename", (file: TAbstractFile, oldPath: string) =>
+        this.enqueue(file, oldPath)
+      )
+    );
+  }
+
+  /** The current content epoch for a project (0 if nothing has changed yet). */
+  getEpoch(projectId: string): number {
+    return this.epochs.get(projectId) ?? 0;
+  }
+
+  /** Subscribe to per-project content-change notifications; returns an unsubscribe. */
+  onContentChanged(callback: (projectId: string) => void): () => void {
+    this.listeners.add(callback);
+    return () => this.listeners.delete(callback);
+  }
+
+  /**
+   * Settle any queued events synchronously — used at send time so the turn sees
+   * a change the user made moments before sending (the debounce would otherwise
+   * still be pending). `flush()` invokes the trailing drain and clears the timer,
+   * so there is no later double-fire.
+   */
+  flushNow(): void {
+    this.debouncedDrain.flush();
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.debouncedDrain.cancel();
+    for (const ref of this.vaultRefs) this.app.vault.offref(ref);
+    this.vaultRefs.length = 0;
+    this.pending.length = 0;
+    this.listeners.clear();
+    this.epochs.clear();
+  }
+
+  private enqueue(file: TAbstractFile, oldPath?: string): void {
+    // Guard against an event delivered after teardown (offref should prevent this,
+    // but a queued microtask could still arrive) so a disposed tracker stays inert.
+    if (this.disposed) return;
+    this.pending.push({
+      isFolder: file instanceof TFolder,
+      isMarkdown: file instanceof TFile && file.extension === "md",
+      path: normalizeVaultPath(file.path),
+      oldPath: oldPath ? normalizeVaultPath(oldPath) : undefined,
+    });
+    this.debouncedDrain();
+  }
+
+  private drain(): void {
+    const changes = this.pending.splice(0);
+    if (changes.length === 0) return;
+
+    const affected = new Set<string>();
+    for (const record of getCachedProjectRecords()) {
+      try {
+        if (changes.some((change) => changeAffectsProject(change, record))) {
+          affected.add(record.project.id);
+        }
+      } catch (err) {
+        // A malformed pattern in one project must not stop the sweep for others,
+        // nor break the watcher.
+        logWarn(`[project-content] scope match failed for project ${record.project.id}`, err);
+      }
+    }
+
+    for (const projectId of affected) {
+      this.epochs.set(projectId, this.getEpoch(projectId) + 1);
+      for (const listener of this.listeners) {
+        try {
+          listener(projectId);
+        } catch (err) {
+          logWarn(`[project-content] content-change listener failed for ${projectId}`, err);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Whether a single vault change touches a project's declared context scope.
+ * Conservative by design: inclusion-only matching (exclusions only ever shrink
+ * the set, so ignoring them just yields an occasional harmless extra note), plus
+ * a broad tag rule and broad folder rule since neither can be resolved precisely
+ * from a path string alone.
+ */
+function changeAffectsProject(change: PendingChange, record: ProjectFileRecord): boolean {
+  const { inclusions, exclusions } = getMatchingPatterns({
+    inclusions: record.project.contextSource?.inclusions,
+    exclusions: record.project.contextSource?.exclusions,
+    isProject: true,
+  });
+  // A project with no inclusions materializes nothing, so nothing can dirty it.
+  if (!inclusions) return false;
+
+  // Tag membership can't be recovered from a path (and the metadata cache may
+  // not have parsed a just-edited file yet), so ANY markdown change conservatively
+  // dirties a project that declares a tag pattern on either side.
+  if (change.isMarkdown && declaresTagPattern(inclusions, exclusions)) return true;
+
+  const paths = change.oldPath ? [change.path, change.oldPath] : [change.path];
+
+  if (change.isFolder) {
+    // Obsidian doesn't guarantee child events on a folder op, so match the folder
+    // path against folder patterns in BOTH directions (the event path may be an
+    // ancestor OR a descendant of a pattern), and conservatively dirty projects
+    // whose note/extension members a folder move could have relocated.
+    if (
+      (inclusions.folderPatterns ?? []).some((p) => paths.some((path) => foldersIntersect(path, p)))
+    ) {
+      return true;
+    }
+    return (
+      (inclusions.notePatterns?.length ?? 0) > 0 || (inclusions.extensionPatterns?.length ?? 0) > 0
+    );
+  }
+
+  return paths.some((path) => fileMatchesInclusions(path, inclusions));
+}
+
+function declaresTagPattern(
+  inclusions: PatternCategory,
+  exclusions: PatternCategory | null
+): boolean {
+  return (inclusions.tagPatterns?.length ?? 0) > 0 || (exclusions?.tagPatterns?.length ?? 0) > 0;
+}
+
+function fileMatchesInclusions(path: string, inclusions: PatternCategory): boolean {
+  // Internal Copilot files (project.md, the AGENTS.md mirror, the log) can be
+  // caught by a `*.md` or projects-folder pattern but must never count as a
+  // context source — mirror shouldIndexFile's exclusion for the dead-path case.
+  if (isInternalExcludedPath(path)) return false;
+
+  const lower = path.toLowerCase();
+  if ((inclusions.extensionPatterns ?? []).some((p) => lower.endsWith(p.slice(1).toLowerCase()))) {
+    return true;
+  }
+  if ((inclusions.folderPatterns ?? []).some((p) => isSameOrUnder(path, normalizeVaultPath(p)))) {
+    return true;
+  }
+  const base = basenameWithoutExtension(path);
+  return (inclusions.notePatterns ?? []).some((p) => p.slice(2, -2) === base);
+}
+
+/** True when either folder path is the same as, or nested under, the other. */
+function foldersIntersect(a: string, b: string): boolean {
+  const left = normalizeVaultPath(a);
+  const right = normalizeVaultPath(b);
+  return isSameOrUnder(left, right) || isSameOrUnder(right, left);
+}
+
+/** True when `path` equals `ancestor` or sits directly under it. */
+function isSameOrUnder(path: string, ancestor: string): boolean {
+  if (ancestor.length === 0) return false;
+  return path === ancestor || path.startsWith(`${ancestor}/`);
+}
+
+function basenameWithoutExtension(path: string): string {
+  const base = path.split("/").pop() ?? path;
+  return base.replace(/\.[^/.]+$/, "");
+}
+
+function normalizeVaultPath(path: string): string {
+  return normalizePath(path).replace(/^\/+/, "").replace(/\/+$/, "");
+}

--- a/src/context/projectContentTracker.ts
+++ b/src/context/projectContentTracker.ts
@@ -18,7 +18,10 @@ const DEBOUNCE_MS = 2000;
  * a queued pre-rename event. Snapshotting the strings at enqueue time keeps the
  * old/new paths correct.
  */
+type VaultEventKind = "create" | "modify" | "delete" | "rename";
+
 interface PendingChange {
+  kind: VaultEventKind;
   isFolder: boolean;
   isMarkdown: boolean;
   path: string;
@@ -51,15 +54,14 @@ export class ProjectContentTracker {
     debounceMs: number = DEBOUNCE_MS
   ) {
     this.debouncedDrain = debounce(() => this.drain(), debounceMs, { trailing: true });
-    const onEvent = (file: TAbstractFile) => this.enqueue(file);
-    this.vaultRefs.push(this.app.vault.on("create", onEvent));
-    this.vaultRefs.push(this.app.vault.on("modify", onEvent));
-    this.vaultRefs.push(this.app.vault.on("delete", onEvent));
+    this.vaultRefs.push(this.app.vault.on("create", (file) => this.enqueue("create", file)));
+    this.vaultRefs.push(this.app.vault.on("modify", (file) => this.enqueue("modify", file)));
+    this.vaultRefs.push(this.app.vault.on("delete", (file) => this.enqueue("delete", file)));
     // Rename carries the previous path; snapshot both sides so a move out of or
     // into a project's scope is detected.
     this.vaultRefs.push(
       this.app.vault.on("rename", (file: TAbstractFile, oldPath: string) =>
-        this.enqueue(file, oldPath)
+        this.enqueue("rename", file, oldPath)
       )
     );
   }
@@ -107,11 +109,12 @@ export class ProjectContentTracker {
     this.epochs.clear();
   }
 
-  private enqueue(file: TAbstractFile, oldPath?: string): void {
+  private enqueue(kind: VaultEventKind, file: TAbstractFile, oldPath?: string): void {
     // Guard against an event delivered after teardown (offref should prevent this,
     // but a queued microtask could still arrive) so a disposed tracker stays inert.
     if (this.disposed) return;
     this.pending.push({
+      kind,
       isFolder: file instanceof TFolder,
       isMarkdown: file instanceof TFile && file.extension === "md",
       path: normalizeVaultPath(file.path),
@@ -167,20 +170,25 @@ function changeAffectsProject(change: PendingChange, record: ProjectFileRecord):
   if (!inclusions) return false;
 
   const paths = change.oldPath ? [change.path, change.oldPath] : [change.path];
+  // Only a folder RENAME or DELETE can change which files exist under a scope; a
+  // folder CREATE is an empty directory with no members, so it can't dirty anything.
+  const folderMembershipEvent =
+    change.isFolder && (change.kind === "rename" || change.kind === "delete");
 
   // Tag membership can't be recovered from a path (and the metadata cache may not
   // have parsed a just-edited file yet), so conservatively dirty a tag-declaring
   // project on ANY event that could change which files carry a tag: a markdown
   // change (checked on BOTH rename sides — a `.md → .txt` rename leaves tag scope)
-  // or a folder op that could move tagged notes. Skip when every side is an
-  // internal Copilot file (a `project.md` edit must not spray notes) — but keep it
-  // when one side is a user path (an internal ↔ user rename still counts).
+  // or a folder rename/delete that could move tagged notes. Skip when every side is
+  // an internal Copilot file (a `project.md` edit must not spray notes) — but keep
+  // it when one side is a user path (an internal ↔ user rename still counts).
   if (declaresTagPattern(inclusions, exclusions) && paths.some((p) => !isInternalExcludedPath(p))) {
     const touchesMarkdown = change.isMarkdown || paths.some((p) => p.toLowerCase().endsWith(".md"));
-    if (touchesMarkdown || change.isFolder) return true;
+    if (touchesMarkdown || folderMembershipEvent) return true;
   }
 
   if (change.isFolder) {
+    if (!folderMembershipEvent) return false;
     // Obsidian doesn't guarantee child events on a folder op, so match the folder
     // path against folder patterns in BOTH directions (the event path may be an
     // ancestor OR a descendant of a pattern), and conservatively dirty projects

--- a/src/context/projectContentTracker.ts
+++ b/src/context/projectContentTracker.ts
@@ -69,6 +69,18 @@ export class ProjectContentTracker {
     return this.epochs.get(projectId) ?? 0;
   }
 
+  /**
+   * Advance a project's content epoch by one and return the new value. Used both
+   * internally (a matched vault change) and by the session manager for a config
+   * source edit, so a config change and a content change advance the SAME epoch —
+   * an ongoing session then gets the coarse note in either case.
+   */
+  bumpEpoch(projectId: string): number {
+    const next = this.getEpoch(projectId) + 1;
+    this.epochs.set(projectId, next);
+    return next;
+  }
+
   /** Subscribe to per-project content-change notifications; returns an unsubscribe. */
   onContentChanged(callback: (projectId: string) => void): () => void {
     this.listeners.add(callback);
@@ -126,7 +138,7 @@ export class ProjectContentTracker {
     }
 
     for (const projectId of affected) {
-      this.epochs.set(projectId, this.getEpoch(projectId) + 1);
+      this.bumpEpoch(projectId);
       for (const listener of this.listeners) {
         try {
           listener(projectId);
@@ -154,12 +166,19 @@ function changeAffectsProject(change: PendingChange, record: ProjectFileRecord):
   // A project with no inclusions materializes nothing, so nothing can dirty it.
   if (!inclusions) return false;
 
-  // Tag membership can't be recovered from a path (and the metadata cache may
-  // not have parsed a just-edited file yet), so ANY markdown change conservatively
-  // dirties a project that declares a tag pattern on either side.
-  if (change.isMarkdown && declaresTagPattern(inclusions, exclusions)) return true;
-
   const paths = change.oldPath ? [change.path, change.oldPath] : [change.path];
+
+  // Tag membership can't be recovered from a path (and the metadata cache may not
+  // have parsed a just-edited file yet), so conservatively dirty a tag-declaring
+  // project on ANY event that could change which files carry a tag: a markdown
+  // change (checked on BOTH rename sides — a `.md → .txt` rename leaves tag scope)
+  // or a folder op that could move tagged notes. Skip when every side is an
+  // internal Copilot file (a `project.md` edit must not spray notes) — but keep it
+  // when one side is a user path (an internal ↔ user rename still counts).
+  if (declaresTagPattern(inclusions, exclusions) && paths.some((p) => !isInternalExcludedPath(p))) {
+    const touchesMarkdown = change.isMarkdown || paths.some((p) => p.toLowerCase().endsWith(".md"));
+    if (touchesMarkdown || change.isFolder) return true;
+  }
 
   if (change.isFolder) {
     // Obsidian doesn't guarantee child events on a folder op, so match the folder

--- a/src/context/projectContentTracker.ts
+++ b/src/context/projectContentTracker.ts
@@ -188,14 +188,18 @@ function changeAffectsProject(change: PendingChange, record: ProjectFileRecord):
   }
 
   if (change.isFolder) {
-    // DESIGN NOTE — a folder CREATE/MODIFY is a deliberate no-op, INCLUDING when the
-    // created folder exactly equals a declared `folderPattern` (e.g. a project
-    // includes `External`, which didn't exist, and the user creates it). An empty
-    // folder has nothing to materialize, so the manifest is unchanged; an ongoing
-    // session doesn't re-mount searchable roots mid-conversation in v1 regardless;
-    // and an empty landing's captured (empty) manifest equals a fresh one's, so
-    // reuse is harmless. The moment any FILE lands inside it, the file event dirties
-    // and self-heals. If a future review flags this again, point them here.
+    // A folder CREATE matters ONLY when the created folder IS an exactly-declared
+    // folder pattern: `resolveFolderPaths` (projectContextMaterializer) then turns
+    // that previously-unresolved source into a real manifest entry (absPath) and,
+    // when it's out-of-cwd, a mounted `additionalDirectories` search root — so a
+    // stale empty landing must not be reused. A parent/child create resolves no
+    // DIFFERENT pattern (an unrelated declared subfolder stays unresolved; an
+    // already-existing declared root is unaffected) and changes no tag/note/
+    // extension membership, so the broad fallbacks stay OFF for CREATE.
+    if (change.kind === "create") {
+      return (inclusions.folderPatterns ?? []).some((p) => normalizeVaultPath(p) === change.path);
+    }
+    // A folder MODIFY changes nothing; only RENAME/DELETE move existing members.
     if (!folderMembershipEvent) return false;
     // Obsidian doesn't guarantee child events on a folder op, so match the folder
     // path against folder patterns in BOTH directions (the event path may be an

--- a/src/context/projectContextMaterializer.test.ts
+++ b/src/context/projectContextMaterializer.test.ts
@@ -344,6 +344,51 @@ describe("ensureProjectContextMaterialized — single-flight", () => {
     expect(bRes).not.toBe(aRes);
     expect(url4llm).toHaveBeenCalledWith("https://b.com");
   });
+
+  it("supersedes an in-flight run when a caller passes a NEWER revisionKey (same config signature)", async () => {
+    const app = fakeApp();
+    // The config signature never changes here (same sources); only the content
+    // revision key differs — the case a pure file edit produces.
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com" }));
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const url4llm = jest.fn(async (url: string) => {
+      await gate;
+      return { response: `${url} text` };
+    });
+    getClient.mockReturnValue({ url4llm, youtube4llm: jest.fn(), docs4llm: jest.fn() });
+
+    // A runs at revision epoch 0; hold it in flight.
+    const a = ensureProjectContextMaterialized(app, "p1", CWD, undefined, undefined, "sig#0");
+    await flushMicrotasks();
+    // A content edit bumped the epoch → B wants revision epoch 1 and must NOT join A.
+    const b = ensureProjectContextMaterialized(app, "p1", CWD, undefined, undefined, "sig#1");
+
+    release();
+    const [aRes, bRes] = await Promise.all([a, b]);
+
+    // Distinct result objects prove B ran its OWN materialization (superseded)
+    // rather than joining A's in-flight promise, which would return the same
+    // object. (The URL's snapshot is fingerprint cheap-skipped, so the count of
+    // fetches isn't the signal here — the separate run is.)
+    expect(bRes).not.toBe(aRes);
+  });
+
+  it("still dedupes concurrent callers that share the same revisionKey", async () => {
+    getRecord.mockReturnValue(record({ webUrls: "https://a.com" }));
+    const app = fakeApp();
+
+    const [r1, r2] = await Promise.all([
+      ensureProjectContextMaterialized(app, "p1", CWD, undefined, undefined, "sig#7"),
+      ensureProjectContextMaterialized(app, "p1", CWD, undefined, undefined, "sig#7"),
+    ]);
+
+    const client = getClient.mock.results[0].value as { url4llm: jest.Mock };
+    expect(client.url4llm).toHaveBeenCalledTimes(1); // one run, joined
+    expect(r1).toBe(r2);
+  });
 });
 
 describe("Option D — failure markers, forced retry, single-source reconcile", () => {

--- a/src/context/projectContextMaterializer.ts
+++ b/src/context/projectContextMaterializer.ts
@@ -118,13 +118,15 @@ interface InFlightMaterialization {
   /** True when this run bypasses failure markers (a user-initiated retry). */
   forceRetryFailed: boolean;
   /**
-   * Context signature ({@link getProjectContextSignature}) of the project record
-   * this run is materializing, captured when the run was queued. A later caller
-   * whose record signature differs supersedes rather than joins — otherwise it
-   * would receive the pre-edit `<project_context>` / `additionalDirectories`.
-   * `undefined` when no record was cached at queue time.
+   * The source REVISION this run is materializing, captured when queued. Defaults
+   * to the config signature ({@link getProjectContextSignature}), but a caller may
+   * pass an epoch-salted key ({@link composeContextDirtyKey}) so that a pure
+   * CONTENT edit — which does not move the config signature — still reads as a
+   * newer revision and SUPERSEDES a run holding the old content, instead of
+   * joining it and receiving a stale `<project_context>` / `additionalDirectories`.
+   * `undefined` when no record was cached at queue time and no key was passed.
    */
-  contextSignature: string | undefined;
+  revision: string | undefined;
 }
 
 const inFlightMaterializations = new Map<string, InFlightMaterialization>();
@@ -209,13 +211,19 @@ export async function ensureProjectContextMaterialized(
   projectId: string,
   cwd: string,
   onProgress?: ContextMaterializeProgressFn,
-  forceRetryFailed?: boolean
+  forceRetryFailed?: boolean,
+  revisionKey?: string
 ): Promise<ContextMaterializationResult> {
   const force = forceRetryFailed ?? false;
   // Captured synchronously so an incoming caller can tell whether the in-flight
   // run is materializing the source revision it actually wants.
   const record = getCachedProjectRecordById(projectId);
   const currentSignature = record ? getProjectContextSignature(record) : undefined;
+  // The revision this caller wants. Defaults to the config signature so callers
+  // that don't track content epochs behave exactly as before; the session manager
+  // passes an epoch-salted key so a mid-flight content edit supersedes a run that
+  // read the pre-edit content (see {@link InFlightMaterialization.revision}).
+  const currentRevision = revisionKey ?? currentSignature;
   const existing = inFlightMaterializations.get(projectId);
   // Single-flight: a second concurrent caller joins the in-flight run and its
   // `onProgress` is intentionally dropped — the flight owner's sink already
@@ -233,11 +241,7 @@ export async function ensureProjectContextMaterialized(
   // (e.g. a background warm, invisible to the manager's early-exit check) must NOT
   // join it — that would cheap-skip the known-bad sources the user explicitly
   // asked to re-fetch. Instead it SUPERSEDES below.
-  if (
-    existing &&
-    existing.contextSignature === currentSignature &&
-    (!force || existing.forceRetryFailed)
-  ) {
+  if (existing && existing.revision === currentRevision && (!force || existing.forceRetryFailed)) {
     return existing.promise;
   }
 
@@ -260,7 +264,7 @@ export async function ensureProjectContextMaterialized(
   inFlightMaterializations.set(projectId, {
     promise,
     forceRetryFailed: force,
-    contextSignature: currentSignature,
+    revision: currentRevision,
   });
   return promise;
 }

--- a/src/projects/projectContextSignature.test.ts
+++ b/src/projects/projectContextSignature.test.ts
@@ -1,6 +1,8 @@
 import type { ProjectConfig } from "@/aiParams";
 import type { ProjectFileRecord } from "@/projects/type";
 import {
+  composeContextDirtyKey,
+  contextDirtyKeyMatchesConfig,
   getProjectContextSignature,
   getProjectLandingCaptureSignature,
   normalizeProjectContextSource,
@@ -108,5 +110,29 @@ describe("getProjectLandingCaptureSignature", () => {
     expect(getProjectLandingCaptureSignature(before)).toBe(
       getProjectLandingCaptureSignature(after)
     );
+  });
+});
+
+describe("composeContextDirtyKey / contextDirtyKeyMatchesConfig", () => {
+  const sig = getProjectContextSignature(makeRecord(makeProject()));
+
+  it("salts a config signature with an epoch", () => {
+    expect(composeContextDirtyKey(sig, 3)).toBe(`${sig}#3`);
+  });
+
+  it("matches the bare signature and any epoch-salted form of it", () => {
+    expect(contextDirtyKeyMatchesConfig(sig, sig)).toBe(true);
+    expect(contextDirtyKeyMatchesConfig(composeContextDirtyKey(sig, 0), sig)).toBe(true);
+    expect(contextDirtyKeyMatchesConfig(composeContextDirtyKey(sig, 42), sig)).toBe(true);
+  });
+
+  it("does NOT match a different config signature", () => {
+    const other = getProjectContextSignature(makeRecord(makeProject({ id: "p2" }), "Other/p.md"));
+    expect(contextDirtyKeyMatchesConfig(composeContextDirtyKey(sig, 1), other)).toBe(false);
+  });
+
+  it("is undefined-safe and rejects a non-numeric suffix", () => {
+    expect(contextDirtyKeyMatchesConfig(undefined, sig)).toBe(false);
+    expect(contextDirtyKeyMatchesConfig(`${sig}#abc`, sig)).toBe(false);
   });
 });

--- a/src/projects/projectContextSignature.ts
+++ b/src/projects/projectContextSignature.ts
@@ -87,3 +87,37 @@ export function getProjectLandingCaptureSignature(record: ProjectFileRecord): st
     systemPrompt: record.project.systemPrompt ?? "",
   });
 }
+
+/**
+ * Compose a content-aware dirty key from a config signature and a content
+ * revision epoch. The config signature (see {@link getProjectContextSignature})
+ * only moves when the project's declared sources change; edits to the FILES
+ * those sources point at do not touch it. Salting it with the tracker's
+ * per-project epoch lets a pure content change still read as a distinct dirty
+ * revision, so it can gate empty-landing reuse and drive re-materialization
+ * through the same machinery a config edit uses.
+ */
+export function composeContextDirtyKey(configSignature: string, epoch: number): string {
+  return `${configSignature}#${epoch}`;
+}
+
+/**
+ * Whether a dirty key (possibly epoch-salted by {@link composeContextDirtyKey})
+ * belongs to the given config signature. True when the key is the bare config
+ * signature, or the config signature followed by `#<digits>`. The dirty-clear
+ * guard uses this to confirm a materialization result (which carries only the
+ * config signature) corresponds to the captured dirty key's config — the exact
+ * epoch is enforced separately by comparing the whole captured key.
+ */
+export function contextDirtyKeyMatchesConfig(
+  key: string | undefined,
+  configSignature: string
+): boolean {
+  if (key === undefined) return false;
+  if (key === configSignature) return true;
+  // Reason: the salt is appended as `#<epoch>`; split on the LAST `#` so a `#`
+  // inside the JSON signature itself can't cause a false prefix match.
+  const lastHash = key.lastIndexOf("#");
+  if (lastHash < 0) return false;
+  return key.slice(0, lastHash) === configSignature && /^\d+$/.test(key.slice(lastHash + 1));
+}

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -434,9 +434,11 @@ function getInternalExcludeFolderPrefixes(): string[] {
 /**
  * Check whether a file path is an internal Copilot file that should be excluded from searches.
  * Checks both exact path matches (log file) and folder prefix matches (projects folder).
+ * Exported so callers that only have a vault path (e.g. a delete/rename event whose `TFile`
+ * no longer resolves) can apply the same internal-file exclusion as {@link isInternalExcludedFile}.
  * @param filePath - Full path to the file in the vault
  */
-function isInternalExcludedPath(filePath: string): boolean {
+export function isInternalExcludedPath(filePath: string): boolean {
   const excludes = new Set(getInternalExcludePaths());
   if (excludes.has(filePath)) return true;
 


### PR DESCRIPTION
Closes logancyang/obsidian-copilot-preview#208 (both confirmed repros).

## Problem

Agent Mode captured a project's context once per session: the manifest rode only the first prompt, and dirty tracking hashed config fields only. A file added to an included folder stayed invisible to ongoing conversations (Repro A, `.md`) and to re-entered projects reusing the pre-created empty landing (Repro B, PDF — no snapshot in the manifest). Both repros confirmed via frame logs.

## What this does

**Detection foundation**

- `ProjectContentTracker` (host layer): vault watcher with a batch debounce (Set semantics — bulk bursts keep every path; same-path delete→re-create resolves as a replace, not a delete), per-project monotonic content epoch + capped change log, metadataCache tag source with conservative dirtying. Live create/modify match via the shared `resolveAffectedProjects` (extracted to `searchUtils`; Chat mode's watcher routes through it, behavior identical); delete/rename/folder-rename match path-based (rename-out invalidates via `oldPath`; markdown/folder deletes conservatively dirty tag-pattern projects).
- Composite dirty key (`configSignature + "#" + epoch`) with a guarded clear (stored key must equal the kickoff-captured key AND its config part must match what the run actually read) — a second event landing mid-materialization can never be wiped.
- Revision-aware materializer single-flight: a content-dirty caller supersedes (never joins) a run that started before the file existed.

**Delivery, three cases**

- **Case 1 — ongoing conversations (non-blocking):** each send flushes the debounce, compares the session's `lastDeliveredEpoch` (advanced only after the backend accepts; fan-out never advances), and injects a wire-only `<project_context_updates>` block — changed PATHS only, never contents. Text changes carry a re-enumerate nudge; binaries ride a probe-classified status (pending → raw path now + background warm, snapshot pointer on a later turn; failed → announced once; deleted/renamed-out → "old snapshot is invalid"). Binary tracking-set mutations are staged and applied only on backend accept, so a thrown prompt re-announces.
- **Case 2 — in-place first send on a stale empty landing (blocking):** the composer's send handler consults `holdActiveSessionForFreshContext` (flushes the debounce first, so "add a file, send immediately" holds), which re-materializes via the existing queue-and-hold and refreshes the landing's manifest before the queued send flushes. A failed materialization keeps the stale-but-usable manifest, leaves the delivery cursor behind, and arms the hold at most once per dirty revision (no flush→re-hold loop).
- **Case 3 — re-enter:** content events now reach `isProjectContextDirty`, so a stale landing is not reused — a fresh session's first manifest includes the new sources.
- **Resumed sessions** keep the `projectContextBlock` their resume path already materializes (previously discarded) and deliver it on the first send with a re-check preamble.

## Testing

- ~4,460 unit tests green (+~100 new across tracker/matcher/builder/probe/manager/session/composer), `npm run format` / `npm run lint` clean.
- Validated end-to-end in a live vault with frame-log evidence: natural-question `.md` discovery, natural-question PDF via snapshot, rename-out (no repeated announcements), forced-failure raw-PDF fallback.

## Known limitations / follow-ups

Recorded in `designdocs/agent-projects/AGENT_PROJECT_CONTEXT_STALENESS.md` (ships with this PR), notably: change-log compaction renders a generic re-enumerate nudge; ongoing config-change deltas are a generic re-check nudge; Case 2 covers content staleness only (config-root / system-prompt capture mismatches are a designed landing-replacement follow-up); remote same-URL content changes stay stale by design; tag-pattern projects are conservatively dirtied on any markdown re-index — precision follow-up filed as logancyang/obsidian-copilot-preview#210 (which also fixes Chat mode's existing tag-removal cache miss).
