### PR TITLE
fix(agent-mode): preserve composer input when switching agents mid-compose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,5 +48,6 @@ Read the matching guide when your task touches that area — they aren't loaded 
 - Local model support via Ollama / LM Studio.
 - Rate limiting is implemented for all API calls.
 - Message & chat architecture (Repository → Manager → UIState → UI; single `MessageRepository`; per-project isolation) → [`designdocs/MESSAGE_ARCHITECTURE.md`](./designdocs/MESSAGE_ARCHITECTURE.md).
+- A tab's compose lane (`AgentSession.composeLaneId`) is stable across in-place session swaps; the Agent Mode composer keys by lane, while the transcript/token-meter/persistence key by session.
 - Tech debt and known issues → [`designdocs/todo/TECHDEBT.md`](./designdocs/todo/TECHDEBT.md). Current session plan → [`TODO.md`](./TODO.md).
 - Available Tailwind tokens/classes → [`tailwind.config.js`](./tailwind.config.js).

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -1317,6 +1317,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
     });
     await session.ready;
@@ -1331,6 +1332,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
     });
     await session.ready;
@@ -1344,6 +1346,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault/Projects/p",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       projectId: "proj-7",
     });
@@ -1360,6 +1363,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
     });
     await session.ready;
@@ -1375,6 +1379,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault/Projects/p",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       projectId: "proj-7",
       contextReady: Promise.resolve({
@@ -1394,6 +1399,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault/Projects/p",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       projectId: "proj-7",
       contextReady: Promise.resolve({
@@ -1429,6 +1435,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault/Projects/p",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       projectId: "proj-7",
       contextReady: Promise.resolve({
@@ -1461,6 +1468,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
     });
     await session.ready;
@@ -1480,6 +1488,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault/Projects/p",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       projectId: "proj-7",
       contextReady,
@@ -1518,6 +1527,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       defaultModelSelection: { baseModelId: "openai/gpt-5", effort: null },
       getDescriptor: () => makeWireOnlyDescriptor(),
@@ -1544,6 +1554,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
     });
     await session.ready;
@@ -1573,6 +1584,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "codex",
     });
     await session.ready;
@@ -1610,6 +1622,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       defaultModelSelection: { baseModelId: "openai/gpt-5", effort: null },
       getDescriptor: () => makeWireOnlyDescriptor(),
@@ -1661,6 +1674,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       defaultModelSelection: { baseModelId: "big-pickle", effort: null },
       initialCachedState: cachedState,
@@ -1711,6 +1725,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "claude",
       defaultModelSelection: { baseModelId: "anthropic/sonnet", effort: "high" },
       // Descriptor whose wire encoding ignores effort (Claude-style).
@@ -1752,6 +1767,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       defaultModelSelection: { baseModelId: "openai/gpt-5", effort: null },
       getDescriptor: () => makeWireOnlyDescriptor(),
@@ -1815,6 +1831,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       defaultModelSelection: { baseModelId: "openai/gpt-5", effort: "high" },
       getDescriptor: () => makeConfigOptionDescriptor(),
@@ -1871,6 +1888,7 @@ describe("AgentSession.create (via start)", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "opencode",
       // Cleared effort → agent default (null), same model as the stale report.
       defaultModelSelection: { baseModelId: "openai/gpt-5", effort: null },
@@ -2397,6 +2415,7 @@ describe("AgentSession intent capabilities", () => {
       backend: mock.asBackend,
       cwd: "/vault",
       internalId: "internal-1",
+      composeLaneId: "lane-1",
       backendId: "test-backend",
       getDescriptor: () => undefined,
     });

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -185,6 +185,13 @@ export interface AgentSessionStartOptions {
   backend: BackendProcess;
   cwd: string;
   internalId: string;
+  /**
+   * Stable identity of the composer lane this session occupies. A replacement
+   * session created by an in-place swap INHERITS the old session's lane id so
+   * the composer keyed by lane survives a cross-backend model pick. Passed in
+   * by the caller (like `internalId`); the session never generates it.
+   */
+  composeLaneId: string;
   backendId: BackendId;
   /**
    * Scope this session belongs to. Immutable like `backendId`; defaults to
@@ -284,6 +291,9 @@ export interface AgentSessionStateOptions {
 export class AgentSession {
   readonly store = new AgentMessageStore();
   readonly internalId: string;
+  // Stable composer-lane identity; inherited across an in-place backend swap so
+  // the lane-keyed composer is preserved (see `AgentSessionStartOptions`).
+  readonly composeLaneId: string;
   readonly backendId: BackendId;
   /** Immutable scope binding ({@link GLOBAL_SCOPE} or a project id). */
   readonly projectId: ProjectScopeId;
@@ -420,6 +430,10 @@ export class AgentSession {
   constructor(opts: AgentSessionStateOptions | AgentSessionStartOptions) {
     this.backend = opts.backend;
     this.internalId = opts.internalId;
+    // Only the start path carries a lane id (a new/replacement composer lane);
+    // adopted/resumed sessions (state options) reuse `internalId` as the lane
+    // since they aren't spawned by an in-place swap.
+    this.composeLaneId = "composeLaneId" in opts ? opts.composeLaneId : opts.internalId;
     this.backendId = opts.backendId;
     this.projectId = opts.projectId ?? GLOBAL_SCOPE;
     this.cwd = opts.cwd ?? null;

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -1053,7 +1053,8 @@ export class AgentSessionManager {
   async createSession(
     backendId?: BackendId,
     projectId: ProjectScopeId = this.activeProjectId,
-    seedSelection?: ModelSelection
+    seedSelection?: ModelSelection,
+    opts?: { inheritLaneId?: string }
   ): Promise<AgentSession> {
     if (this.disposed) {
       throw new Error("AgentSessionManager has been shut down");
@@ -1141,10 +1142,15 @@ export class AgentSessionManager {
     // (warm or cold) proc at the resolved scope cwd, threading the project
     // scope + context roots; the probe's state still seeds the picker so it
     // doesn't blink while that round-trip is in flight.
+    // A replacement session from an in-place backend swap inherits the old
+    // session's composer lane so the lane-keyed composer survives; a plain
+    // create mints a fresh lane.
+    const composeLaneId = opts?.inheritLaneId ?? uuidv4();
     const session = AgentSession.start({
       backend,
       cwd,
       internalId: uuidv4(),
+      composeLaneId,
       backendId: resolvedId,
       projectId,
       defaultModelSelection: resolvedSeed,
@@ -2236,12 +2242,21 @@ export class AgentSessionManager {
    * jumped to a sibling tab). `backendId` defaults to the same fallback as
    * `createSession`.
    */
-  async replaceSessionInPlace(oldId: string, backendId?: BackendId): Promise<AgentSession> {
+  async replaceSessionInPlace(
+    oldId: string,
+    backendId?: BackendId,
+    opts?: { inheritLane?: boolean; seedSelection?: ModelSelection }
+  ): Promise<AgentSession> {
     const oldIdx = Array.from(this.sessions.keys()).indexOf(oldId);
     // The replacement inherits the REPLACED session's scope, not the active
     // scope (they can differ if the old tab wasn't the active one).
     const replacedProjectId = this.sessions.get(oldId)?.projectId ?? this.activeProjectId;
-    const created = await this.createSession(backendId, replacedProjectId);
+    // A cross-backend model pick hands the replacement the old session's
+    // composer lane so the composer keyed by lane survives the swap.
+    const inheritLaneId = opts?.inheritLane ? this.sessions.get(oldId)?.composeLaneId : undefined;
+    const created = await this.createSession(backendId, replacedProjectId, opts?.seedSelection, {
+      inheritLaneId,
+    });
     if (oldIdx >= 0) {
       this.moveMapEntry(this.sessions, created.internalId, oldIdx);
       this.moveMapEntry(this.chatUIStates, created.internalId, oldIdx);

--- a/src/agentMode/ui/AgentChatInput.test.tsx
+++ b/src/agentMode/ui/AgentChatInput.test.tsx
@@ -86,7 +86,6 @@ const makeDraft = (overrides: Partial<AgentInputDraftControls> = {}): AgentInput
   setIncludeActiveWebTab: jest.fn(),
   setLoading: jest.fn(),
   setQueue: jest.fn(),
-  migrateDraft: jest.fn(),
   resetCompose: jest.fn(),
   ...overrides,
 });
@@ -99,7 +98,7 @@ function renderInput(
   return render(
     <AgentChatInput
       backend={backend}
-      sessionId="session-1"
+      composeLaneId="lane-1"
       draft={draft}
       app={makeApp()}
       mainAgentId={null}

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -48,8 +48,13 @@ import { v4 as uuidv4 } from "uuid";
 
 interface AgentChatInputProps {
   backend: AgentChatBackend;
-  /** Active session's internal id; selects which per-session draft is shown. */
-  sessionId: string;
+  /**
+   * The active tab's compose-lane id. Stable across an in-place session swap
+   * (the replacement inherits the lane), so the editor keys on this rather than
+   * the session id: a swap keeps the same lane and does NOT remount/clear, while
+   * a real tab switch (a different lane) still remounts for per-tab isolation.
+   */
+  composeLaneId: string;
   /**
    * Per-session draft controls, owned by AgentHome (the common owner of the
    * transcript spinner and drop overlay that also read this draft's `loading`
@@ -173,7 +178,7 @@ async function fileToImageBlock(file: File): Promise<PromptContent | null> {
  */
 export const AgentChatInput = memo(function AgentChatInput({
   backend,
-  sessionId,
+  composeLaneId,
   draft,
   app,
   mainAgentId,
@@ -202,7 +207,7 @@ export const AgentChatInput = memo(function AgentChatInput({
   // webTabs at send time below.
   const { activeWebTabForMentions } = useActiveWebTabState();
 
-  const previousSessionIdRef = useRef(sessionId);
+  const previousLaneIdRef = useRef(composeLaneId);
 
   // The `@agent` typeahead group + pills are paid-only. Reactive so a settings
   // change flips the gate live; the authoritative send-time check is separate.
@@ -247,15 +252,17 @@ export const AgentChatInput = memo(function AgentChatInput({
     resetCompose,
   } = draft;
 
-  // Clear cross-session ephemeral state on a session switch: the global
-  // selected-text atom and the mentioned-agent ref (neither is reset by the
-  // editor remount), so a selection or `@agent` pill can't ride into the next session.
+  // Clear cross-tab ephemeral state on a real tab switch (a different compose
+  // lane): the global selected-text atom and the mentioned-agent ref (neither is
+  // reset by the editor remount), so a selection or `@agent` pill can't ride into
+  // the next tab. Keyed on the lane, not the session id, so an in-place swap
+  // (same lane, new session) does NOT clear — the user's selection/pills survive.
   useEffect(() => {
-    if (previousSessionIdRef.current === sessionId) return;
-    previousSessionIdRef.current = sessionId;
+    if (previousLaneIdRef.current === composeLaneId) return;
+    previousLaneIdRef.current = composeLaneId;
     clearSelectedTextContexts();
     mentionedAgentIdsRef.current = [];
-  }, [sessionId]);
+  }, [composeLaneId]);
 
   const handleStopGenerating = useCallback(async () => {
     try {
@@ -497,18 +504,19 @@ export const AgentChatInput = memo(function AgentChatInput({
         }
         aria-disabled={hasPendingPlanPermission || disabled || undefined}
       >
-        {/* Key by session so ChatInput remounts on a tab/session switch. The
-            per-session draft store (input/images/contextNotes/include flags)
-            lives up in AgentHome and is threaded back as controlled props, so
-            those survive the remount — but ChatInput's own internal-only state
-            (contextUrls/contextFolders/contextWebTabs, the @-mention pills, the
-            Lexical editor) is NOT in the draft, and would otherwise bleed from
-            the previous session into a fresh one. The remount restores the
-            per-session isolation the old `key={internalId}` AgentChat gave us.
-            sessionId is stable across the landing→conversation flip (same
-            session), so this never remounts during that transition. */}
+        {/* Key by compose lane so ChatInput remounts on a real tab switch (a
+            different lane). The per-lane draft store (input/images/contextNotes/
+            include flags) lives up in AgentHome and is threaded back as
+            controlled props, so those survive the remount — but ChatInput's own
+            internal-only state (contextUrls/contextFolders/contextWebTabs, the
+            @-mention pills, the Lexical editor) is NOT in the draft, and would
+            otherwise bleed from the previous tab into a fresh one. The remount
+            restores per-tab isolation. An in-place session swap (same lane, new
+            session id) does NOT remount, so those live pills/URLs/folders survive
+            the swap. The lane is also stable across the landing→conversation flip
+            (same session), so that transition never remounts either. */}
         <ChatInput
-          key={sessionId}
+          key={composeLaneId}
           isAgentMode
           inputMessage={inputMessage}
           setInputMessage={setInputMessage}

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -341,23 +341,36 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
     if (next.value !== value) onChange(next.value);
   }, [modePickerOverride]);
 
-  // Stable list of live session ids so the draft store's pruning and memo
+  // Stable list of live compose-lane ids so the draft store's pruning and memo
   // don't churn on every manager notify (getSessions() returns a fresh array).
   // The "\0" delimiter (matching useAgentInputDrafts' own signature key) can't
-  // appear in a session id, so distinct id sets always produce distinct keys.
+  // appear in a lane id, so distinct lane sets always produce distinct keys.
+  // Deduped: during an in-place swap the old + new session momentarily share a
+  // lane (the replacement inherits it), and the draft store keys by lane.
   const sessions = manager.getSessions();
-  const liveKey = sessions.map((s) => s.internalId).join("\0");
-  const liveSessionIds = useMemo(() => sessions.map((s) => s.internalId), [liveKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  const laneKey = sessions.map((s) => s.composeLaneId).join("\0");
+  const liveLaneIds = useMemo(
+    () => Array.from(new Set(sessions.map((s) => s.composeLaneId))),
+    // sessions is re-derived each render; gate on its stable join key instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [laneKey]
+  );
 
-  // Per-session compose drafts live in the shell (the common owner) so the
+  // The active tab's compose lane — the draft store's selection key. Stable
+  // across an in-place swap (the replacement inherits the lane), so a swap
+  // preserves the typed input/pills/queue natively. Falls back to the sessionId
+  // prop before any active session exists (mirrors today's null handling).
+  const activeLaneId = manager.getActiveSession()?.composeLaneId ?? sessionId;
+
+  // Per-lane compose drafts live in the shell (the common owner) so the
   // active turn's `loading` (transcript spinner) and the drop overlay's drag
   // state can be read directly here, instead of being mirrored up from the
   // composer via effect callbacks. The hook returns a referentially stable
   // controls object, so passing it down to the memoized AgentChatInput doesn't
   // re-render the composer on per-token stream updates.
   const draft = useAgentInputDrafts({
-    activeSessionId: sessionId,
-    liveSessionIds,
+    activeLaneId,
+    liveLaneIds,
     defaultIncludeActiveNote: settings.autoAddActiveContentToContext === true,
   });
 
@@ -386,12 +399,12 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   // pattern) so its fresh `initialize()` re-captures the new context — createSession
   // joins the just-started materialization (single-flight by project) on Retry, or
   // re-materializes the updated config on Edit. Guarded on an EMPTY draft so a
-  // refresh never interrupts a draft already in progress. The replace mints a new
-  // session id and prunes the old draft, so to honor "never discard text the user
-  // has started typing" we also migrate any draft typed during the async startup
-  // window onto the new id (the pre-await check can't see those late keystrokes).
-  // Returns whether a swap actually happened (false = guarded no-op), so the
-  // context-source observer advances its baseline only on a real capture.
+  // refresh never interrupts a draft already in progress. The replacement INHERITS
+  // the compose lane, so any draft typed during the async startup window (which the
+  // pre-await check can't see) persists natively — the draft store keys by lane,
+  // not session id, so there's nothing to migrate. Returns whether a swap actually
+  // happened (false = guarded no-op), so the context-source observer advances its
+  // baseline only on a real capture.
   const refreshContextForEmptyLanding = useCallback(async (): Promise<boolean> => {
     const active = manager.getActiveSession();
     if (!active || active.hasUserVisibleMessages()) return false;
@@ -402,8 +415,9 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
       draft.queue.length === 0;
     if (!draftEmpty) return false;
     try {
-      const replacement = await manager.replaceSessionInPlace(active.internalId, active.backendId);
-      draft.migrateDraft(active.internalId, replacement.internalId);
+      await manager.replaceSessionInPlace(active.internalId, active.backendId, {
+        inheritLane: true,
+      });
       return true;
     } catch (e) {
       logError("[AgentMode] refresh landing context failed", e);
@@ -489,7 +503,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   // landing open gets a new line) but stable across the stream re-renders within
   // a session, so it doesn't flicker as tokens arrive. sessionId is the
   // intentional re-roll trigger — not read inside the factory, so exhaustive-deps
-  // flags it; the dep is deliberate (same as the liveSessionIds memo above).
+  // flags it; the dep is deliberate (same as the liveLaneIds memo above).
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const greeting = useMemo(() => pickRandomGreeting(), [sessionId]);
 
@@ -689,7 +703,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   const composerNode = (
     <AgentChatInput
       backend={backend}
-      sessionId={sessionId}
+      composeLaneId={activeLaneId}
       draft={draft}
       app={app}
       mainAgentId={mainAgentId}

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -152,6 +152,7 @@ function makeManager(opts: {
   persistDefaultSelection?: jest.Mock;
   createSession?: jest.Mock;
   closeSession?: jest.Mock;
+  replaceSessionInPlace?: jest.Mock;
 }): AgentSessionManager {
   return {
     getCachedBackendState: (id: string) => opts.cachedStateById?.[id] ?? null,
@@ -162,6 +163,7 @@ function makeManager(opts: {
     persistDefaultSelection: opts.persistDefaultSelection ?? jest.fn().mockResolvedValue(undefined),
     createSession: opts.createSession ?? jest.fn().mockResolvedValue(undefined),
     closeSession: opts.closeSession ?? jest.fn().mockResolvedValue(undefined),
+    replaceSessionInPlace: opts.replaceSessionInPlace ?? jest.fn().mockResolvedValue(undefined),
   } as unknown as AgentSessionManager;
 }
 
@@ -612,14 +614,14 @@ describe("buildModelOnChange", () => {
     expect(applySelection).not.toHaveBeenCalled();
   });
 
-  it("cross-backend pick seeds the new session transiently without persisting the default", async () => {
+  it("cross-backend pick swaps the tab in place, seeding transiently without persisting the default", async () => {
     const persistDefaultSelection = jest.fn().mockResolvedValue(undefined);
-    const createSession = jest.fn().mockResolvedValue(undefined);
+    const replaceSessionInPlace = jest.fn().mockResolvedValue(undefined);
     const setDefaultBackend = jest.fn();
     const closeSession = jest.fn().mockResolvedValue(undefined);
     const manager = makeManager({
       persistDefaultSelection,
-      createSession,
+      replaceSessionInPlace,
       setDefaultBackend,
       closeSession,
       // The legacy single-arg path seeds effort from the target's persisted
@@ -632,12 +634,14 @@ describe("buildModelOnChange", () => {
     // Allow the IIFE to run.
     await new Promise((r) => window.setTimeout(r, 0));
     expect(persistDefaultSelection).not.toHaveBeenCalled();
-    expect(createSession).toHaveBeenCalledWith("claude", undefined, {
-      baseModelId: "opus",
-      effort: "low",
+    // With an existing tab the pick swaps in place, inheriting the old session's
+    // composer lane and seeding the model — it does NOT mint+close a new tab.
+    expect(replaceSessionInPlace).toHaveBeenCalledWith("tab-1", "claude", {
+      inheritLane: true,
+      seedSelection: { baseModelId: "opus", effort: "low" },
     });
     expect(setDefaultBackend).toHaveBeenCalledWith("claude");
-    expect(closeSession).toHaveBeenCalledWith("tab-1");
+    expect(closeSession).not.toHaveBeenCalled();
   });
 
   it("ignores entries with no _backendId or unresolvable baseModelId", () => {

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -388,14 +388,23 @@ function runCrossBackendPick(
 ): void {
   void (async () => {
     try {
-      // projectId left default (active scope); the transient pick only seeds the model.
-      await manager.createSession(targetBackendId, undefined, { baseModelId, effort });
-      manager.setDefaultBackend(targetBackendId);
+      const seedSelection = { baseModelId, effort };
+      // With an existing tab, swap in place so the replacement inherits the old
+      // session's composer lane (preserving the composer) and takes the same tab
+      // slot; replaceSessionInPlace closes the old session itself. With no old
+      // session (e.g. the empty landing) fall back to a plain seeded create.
       if (oldSessionId) {
-        void manager
-          .closeSession(oldSessionId)
-          .catch((e) => logError("[AgentMode] closeSession of empty tab failed", e));
+        await manager.replaceSessionInPlace(oldSessionId, targetBackendId, {
+          inheritLane: true,
+          seedSelection,
+        });
+      } else {
+        // projectId left default (active scope); the transient pick only seeds the model.
+        await manager.createSession(targetBackendId, undefined, seedSelection);
       }
+      // Keep the default backend in sync so backend-scoped UI (the "/" skill
+      // menu) follows the swap.
+      manager.setDefaultBackend(targetBackendId);
     } catch (err) {
       logError("[AgentMode] cross-backend pick failed", err);
       new Notice(`Failed to start ${targetDescriptor.displayName}. See console for details.`);

--- a/src/agentMode/ui/hooks/useAgentInputDrafts.test.tsx
+++ b/src/agentMode/ui/hooks/useAgentInputDrafts.test.tsx
@@ -14,8 +14,8 @@ const queued = (id: string): QueuedAgentMessage => ({
 });
 
 interface Props {
-  activeSessionId: string;
-  liveSessionIds: string[];
+  activeLaneId: string;
+  liveLaneIds: string[];
   defaultIncludeActiveNote: boolean;
 }
 
@@ -25,8 +25,8 @@ const renderDrafts = (initialProps: Props) =>
 describe("useAgentInputDrafts", () => {
   it("seeds a fresh draft from the defaults with frozen empties", () => {
     const { result } = renderDrafts({
-      activeSessionId: "a",
-      liveSessionIds: ["a"],
+      activeLaneId: "a",
+      liveLaneIds: ["a"],
       defaultIncludeActiveNote: true,
     });
 
@@ -39,47 +39,47 @@ describe("useAgentInputDrafts", () => {
     expect(result.current.queue).toEqual([]);
   });
 
-  it("keeps each session's compose draft isolated across switches", () => {
+  it("keeps each lane's compose draft isolated across switches", () => {
     const { result, rerender } = renderDrafts({
-      activeSessionId: "a",
-      liveSessionIds: ["a", "b"],
+      activeLaneId: "a",
+      liveLaneIds: ["a", "b"],
       defaultIncludeActiveNote: false,
     });
 
     act(() => result.current.setInput("draft for a"));
     expect(result.current.input).toBe("draft for a");
 
-    // Switch to b: its draft is fresh.
-    rerender({ activeSessionId: "b", liveSessionIds: ["a", "b"], defaultIncludeActiveNote: false });
+    // Switch to lane b: its draft is fresh.
+    rerender({ activeLaneId: "b", liveLaneIds: ["a", "b"], defaultIncludeActiveNote: false });
     expect(result.current.input).toBe("");
     act(() => result.current.setInput("draft for b"));
 
     // Back to a: the unsent text survived the round-trip.
-    rerender({ activeSessionId: "a", liveSessionIds: ["a", "b"], defaultIncludeActiveNote: false });
+    rerender({ activeLaneId: "a", liveLaneIds: ["a", "b"], defaultIncludeActiveNote: false });
     expect(result.current.input).toBe("draft for a");
   });
 
-  it("tracks loading per session so a background turn doesn't bleed", () => {
+  it("tracks loading per lane so a background turn doesn't bleed", () => {
     const { result, rerender } = renderDrafts({
-      activeSessionId: "a",
-      liveSessionIds: ["a", "b"],
+      activeLaneId: "a",
+      liveLaneIds: ["a", "b"],
       defaultIncludeActiveNote: false,
     });
 
     act(() => result.current.setLoading(true));
     expect(result.current.loading).toBe(true);
 
-    rerender({ activeSessionId: "b", liveSessionIds: ["a", "b"], defaultIncludeActiveNote: false });
+    rerender({ activeLaneId: "b", liveLaneIds: ["a", "b"], defaultIncludeActiveNote: false });
     expect(result.current.loading).toBe(false);
 
-    rerender({ activeSessionId: "a", liveSessionIds: ["a", "b"], defaultIncludeActiveNote: false });
+    rerender({ activeLaneId: "a", liveLaneIds: ["a", "b"], defaultIncludeActiveNote: false });
     expect(result.current.loading).toBe(true);
   });
 
   it("applies functional updates to attachments and queue", () => {
     const { result } = renderDrafts({
-      activeSessionId: "a",
-      liveSessionIds: ["a"],
+      activeLaneId: "a",
+      liveLaneIds: ["a"],
       defaultIncludeActiveNote: false,
     });
 
@@ -94,8 +94,8 @@ describe("useAgentInputDrafts", () => {
 
   it("resetCompose clears compose fields but leaves loading and queue", () => {
     const { result } = renderDrafts({
-      activeSessionId: "a",
-      liveSessionIds: ["a"],
+      activeLaneId: "a",
+      liveLaneIds: ["a"],
       defaultIncludeActiveNote: true,
     });
 
@@ -118,30 +118,32 @@ describe("useAgentInputDrafts", () => {
     expect(result.current.queue.map((q) => q.id)).toEqual(["q1"]);
   });
 
-  it("prunes a draft once its session is no longer live", () => {
+  it("prunes a draft once its lane is no longer live", () => {
     const { result, rerender } = renderDrafts({
-      activeSessionId: "a",
-      liveSessionIds: ["a", "b"],
+      activeLaneId: "a",
+      liveLaneIds: ["a", "b"],
       defaultIncludeActiveNote: false,
     });
 
     act(() => result.current.setInput("a text"));
 
-    // Close session a (e.g. tab closed / replaced); only b remains live.
-    rerender({ activeSessionId: "b", liveSessionIds: ["b"], defaultIncludeActiveNote: false });
+    // Close lane a (its tab was closed with no replacement); only b remains live.
+    rerender({ activeLaneId: "b", liveLaneIds: ["b"], defaultIncludeActiveNote: false });
 
     // Revisiting a (were it ever reselected) yields a fresh draft, not the old.
-    rerender({ activeSessionId: "a", liveSessionIds: ["b"], defaultIncludeActiveNote: false });
+    rerender({ activeLaneId: "a", liveLaneIds: ["b"], defaultIncludeActiveNote: false });
     expect(result.current.input).toBe("");
   });
 
-  it("migrates a draft typed during a session swap onto the replacement id", () => {
-    // Simulates the empty-landing refresh: the user types while the old session
-    // is still active (the new id isn't in liveSessionIds yet), then the swap
-    // migrates that draft onto the new session before the old one is pruned.
+  it("keeps a lane's draft across an in-place swap (old + new share the lane)", () => {
+    // Simulates the empty-landing context refresh: the session is replaced in
+    // place but INHERITS its compose lane, so the old and new session ids
+    // momentarily both map to the same lane (a transient duplicate in
+    // liveLaneIds). The draft is keyed by lane, so it survives natively — no
+    // migration needed.
     const { result, rerender } = renderDrafts({
-      activeSessionId: "old",
-      liveSessionIds: ["old"],
+      activeLaneId: "lane",
+      liveLaneIds: ["lane"],
       defaultIncludeActiveNote: false,
     });
 
@@ -153,50 +155,19 @@ describe("useAgentInputDrafts", () => {
       result.current.setQueue([queued("q1")]);
     });
 
-    act(() => result.current.migrateDraft("old", "new"));
+    // The swap overlap: old + new session both report the same lane.
+    rerender({
+      activeLaneId: "lane",
+      liveLaneIds: ["lane", "lane"],
+      defaultIncludeActiveNote: false,
+    });
+    // Once the old session is pruned, only the single lane remains.
+    rerender({ activeLaneId: "lane", liveLaneIds: ["lane"], defaultIncludeActiveNote: false });
 
-    // Once React observes the new session, its draft carries the typed content.
-    rerender({ activeSessionId: "new", liveSessionIds: ["new"], defaultIncludeActiveNote: false });
     expect(result.current.input).toBe("typed during startup");
     expect(result.current.contextNotes.map((n) => n.path)).toEqual(["note.md"]);
     expect(result.current.images).toHaveLength(1);
     expect(result.current.includeActiveWebTab).toBe(true);
     expect(result.current.queue.map((q) => q.id)).toEqual(["q1"]);
-
-    // The old id no longer holds the migrated draft.
-    rerender({ activeSessionId: "old", liveSessionIds: ["new"], defaultIncludeActiveNote: false });
-    expect(result.current.input).toBe("");
-  });
-
-  it("does not migrate an empty source draft (clean swap stays clean)", () => {
-    const { result, rerender } = renderDrafts({
-      activeSessionId: "old",
-      liveSessionIds: ["old"],
-      defaultIncludeActiveNote: false,
-    });
-
-    act(() => result.current.migrateDraft("old", "new"));
-
-    rerender({ activeSessionId: "new", liveSessionIds: ["new"], defaultIncludeActiveNote: false });
-    expect(result.current.input).toBe("");
-  });
-
-  it("does not clobber input the user already started on the replacement", () => {
-    const { result, rerender } = renderDrafts({
-      activeSessionId: "old",
-      liveSessionIds: ["old", "new"],
-      defaultIncludeActiveNote: false,
-    });
-
-    act(() => result.current.setInput("old draft"));
-    rerender({
-      activeSessionId: "new",
-      liveSessionIds: ["old", "new"],
-      defaultIncludeActiveNote: false,
-    });
-    act(() => result.current.setInput("new draft"));
-
-    act(() => result.current.migrateDraft("old", "new"));
-    expect(result.current.input).toBe("new draft");
   });
 });

--- a/src/agentMode/ui/hooks/useAgentInputDrafts.ts
+++ b/src/agentMode/ui/hooks/useAgentInputDrafts.ts
@@ -44,9 +44,9 @@ export interface AgentInputDraft {
 }
 
 interface UseAgentInputDraftsArgs {
-  activeSessionId: string;
-  /** Internal ids of all live sessions; drafts for ids not here are pruned. */
-  liveSessionIds: readonly string[];
+  activeLaneId: string;
+  /** Compose-lane ids of all live sessions; drafts for lanes not here are pruned. */
+  liveLaneIds: readonly string[];
   /** Seed for a fresh draft's include-active-note toggle (the user setting). */
   defaultIncludeActiveNote: boolean;
 }
@@ -60,13 +60,6 @@ export interface AgentInputDraftControls extends AgentInputDraft {
   setIncludeActiveWebTab: (include: boolean) => void;
   setLoading: (loading: boolean) => void;
   setQueue: React.Dispatch<React.SetStateAction<QueuedAgentMessage[]>>;
-  /**
-   * Carry a compose draft from a replaced session onto its replacement, so text
-   * typed during an in-place session swap (e.g. the empty-landing context
-   * refresh) survives the old session's pruning. No-op when the source draft is
-   * empty or the target already holds user input. See {@link migrateDraft}.
-   */
-  migrateDraft: (fromSessionId: string, toSessionId: string) => void;
   /** Clear the compose fields after a send; leaves loading/queue untouched. */
   resetCompose: () => void;
 }
@@ -90,66 +83,56 @@ const createDraft = (includeActiveNote: boolean): AgentInputDraft => ({
 const applyArrayState = <T>(value: React.SetStateAction<T[]>, previous: T[]): T[] =>
   typeof value === "function" ? value(previous) : value;
 
-/**
- * Whether a draft carries anything worth preserving across a session swap —
- * any composed text/attachments/queue, or a toggle the user moved off its seed.
- * An untouched draft migrates to nothing, so the swap stays a clean reset.
- */
-const hasDraftPayload = (draft: AgentInputDraft, defaultIncludeActiveNote: boolean): boolean =>
-  draft.input.length > 0 ||
-  draft.images.length > 0 ||
-  draft.contextNotes.length > 0 ||
-  draft.queue.length > 0 ||
-  draft.includeActiveNote !== defaultIncludeActiveNote ||
-  draft.includeActiveWebTab;
-
 export function useAgentInputDrafts({
-  activeSessionId,
-  liveSessionIds,
+  activeLaneId,
+  liveLaneIds,
   defaultIncludeActiveNote,
 }: UseAgentInputDraftsArgs): AgentInputDraftControls {
   const [drafts, setDrafts] = useState<Record<string, AgentInputDraft>>({});
 
-  // Stable key so the prune effect only fires when the set of live sessions
+  // Stable key so the prune effect only fires when the set of live lanes
   // actually changes, not on every parent re-render (the array prop is a
-  // fresh reference each render).
-  const liveKey = liveSessionIds.join("\0");
-  const liveSetRef = useRef<Set<string>>(new Set(liveSessionIds));
+  // fresh reference each render). `liveLaneIds` may briefly contain DUPLICATES
+  // during an in-place swap (old + new session momentarily share one lane);
+  // `new Set(...)` collapses them, so the prune below is duplicate-safe and
+  // order-independent — it only ever tests membership, never uniqueness.
+  const liveKey = liveLaneIds.join("\0");
+  const liveSetRef = useRef<Set<string>>(new Set(liveLaneIds));
 
   useEffect(() => {
-    const live = new Set(liveSessionIds);
+    const live = new Set(liveLaneIds);
     liveSetRef.current = live;
     setDrafts((prev) => {
       let changed = false;
       const next: Record<string, AgentInputDraft> = {};
-      for (const [sessionId, draft] of Object.entries(prev)) {
-        if (live.has(sessionId)) next[sessionId] = draft;
+      for (const [laneId, draft] of Object.entries(prev)) {
+        if (live.has(laneId)) next[laneId] = draft;
         else changed = true;
       }
       return changed ? next : prev;
     });
-    // liveSessionIds is re-derived each render; gate on its stable join key.
+    // liveLaneIds is re-derived each render; gate on its stable join key.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [liveKey]);
 
   const updateDraft = useCallback(
-    (sessionId: string, updater: (draft: AgentInputDraft) => AgentInputDraft) => {
+    (laneId: string, updater: (draft: AgentInputDraft) => AgentInputDraft) => {
       setDrafts((prev) => {
-        // A turn can resolve after its session was closed/replaced; don't let
-        // that late update resurrect a pruned draft.
-        if (!liveSetRef.current.has(sessionId)) return prev;
-        const current = prev[sessionId] ?? createDraft(defaultIncludeActiveNote);
+        // A turn can resolve after its lane went away (session closed with no
+        // replacement); don't let that late update resurrect a pruned draft.
+        if (!liveSetRef.current.has(laneId)) return prev;
+        const current = prev[laneId] ?? createDraft(defaultIncludeActiveNote);
         const next = updater(current);
         if (next === current) return prev;
-        return { ...prev, [sessionId]: next };
+        return { ...prev, [laneId]: next };
       });
     },
     [defaultIncludeActiveNote]
   );
 
   const updateActive = useCallback(
-    (updater: (draft: AgentInputDraft) => AgentInputDraft) => updateDraft(activeSessionId, updater),
-    [activeSessionId, updateDraft]
+    (updater: (draft: AgentInputDraft) => AgentInputDraft) => updateDraft(activeLaneId, updater),
+    [activeLaneId, updateDraft]
   );
 
   const setInput = useCallback(
@@ -197,39 +180,6 @@ export function useAgentInputDrafts({
     [updateActive]
   );
 
-  // Move a draft onto a replacement session id during an in-place swap. Writes
-  // `setDrafts` DIRECTLY (not via `updateDraft`) on purpose: the new id isn't in
-  // `liveSetRef` yet — React hasn't observed the manager's new session list when
-  // the swap resolves — so `updateDraft`'s live-guard would drop the write. The
-  // caller runs this synchronously the moment `replaceSessionInPlace` resolves,
-  // while the old session's `closeSession` is still suspended at `await cancel()`
-  // (it deletes the session only afterwards), so the source draft is still
-  // present here and the prune effect only fires later. `loading` resets — the
-  // replacement starts its own turn.
-  const migrateDraft = useCallback(
-    (fromSessionId: string, toSessionId: string) => {
-      if (fromSessionId === toSessionId) return;
-      setDrafts((prev) => {
-        const source = prev[fromSessionId];
-        if (!source || !hasDraftPayload(source, defaultIncludeActiveNote)) return prev;
-        // Never clobber input the user already started on the replacement.
-        const target = prev[toSessionId];
-        if (target && hasDraftPayload(target, defaultIncludeActiveNote)) return prev;
-        const next = { ...prev };
-        delete next[fromSessionId];
-        next[toSessionId] = {
-          ...source,
-          images: [...source.images],
-          contextNotes: [...source.contextNotes],
-          queue: [...source.queue],
-          loading: false,
-        };
-        return next;
-      });
-    },
-    [defaultIncludeActiveNote]
-  );
-
   // DESIGN NOTE: resetCompose hard-clears includeActiveNote to false after a
   // send, so within one session the active note auto-attaches only to the
   // FIRST message. Two scenarios, only one of which matches the legacy
@@ -263,7 +213,7 @@ export function useAgentInputDrafts({
     [updateActive]
   );
 
-  const active = drafts[activeSessionId];
+  const active = drafts[activeLaneId];
   const fields = useMemo<AgentInputDraft>(
     () =>
       active ?? {
@@ -294,7 +244,6 @@ export function useAgentInputDrafts({
       setIncludeActiveWebTab,
       setLoading,
       setQueue,
-      migrateDraft,
       resetCompose,
     }),
     [
@@ -307,7 +256,6 @@ export function useAgentInputDrafts({
       setIncludeActiveWebTab,
       setLoading,
       setQueue,
-      migrateDraft,
       resetCompose,
     ]
   );


### PR DESCRIPTION
## What & why

Switching coding agents at the start of a session by picking a model on a
*different backend* (e.g. opencode → claude) is a **cross-backend pick**: it
mints a brand-new session in the same tab. The Agent Mode composer was keyed by
session `internalId`, so the new session's key wiped everything the user had
already typed — prompt text, attached notes, images, selected-text context,
`@agent` mentions, and queued follow-ups.

## Fix — a stable compose lane

Introduce `AgentSession.composeLaneId`: a stable id a replacement session
**inherits** on an in-place swap. The composer (draft store, `<ChatInput>`
remount, and the selected-text/mention clear) now keys by lane instead of
session id. On a cross-backend swap the lane is unchanged, so the editor never
remounts and the draft never re-keys — all input is preserved natively, no
migration and no reconstruction.

| Transition | Session | Compose lane | Composer |
| --- | --- | --- | --- |
| swap agent (opencode→claude) | new | **inherited** | untouched — all input preserved |
| New Chat | new | fresh | reset (unchanged) |
| switch tab | other | that tab's | isolated (unchanged) |
| new tab · load · resume | new | fresh | reset (unchanged) |

Because the editor stays mounted across a swap, live pills (notes, URLs,
folders, `@agent`) survive as-is — no serialization or reparsing needed. This
also let the old `migrateDraft` handoff be removed.

## Phases
- **Phase 1** — `composeLaneId` on `AgentSession`; `createSession({ inheritLaneId })`; `replaceSessionInPlace({ inheritLane, seedSelection })`; cross-backend picks route through it (also fixes the tab jumping to the strip's end).
- **Phase 2** — key the composer (draft store + `ChatInput` remount + selected-text/mention clear) by lane; remove the now-dead `migrateDraft` / `hasDraftPayload`.
- **Phase 3** — one-line architecture note + full gates.

## Verification
- Full suite: **4355/4355** tests (301 suites).
- `npm run lint` and `npm run build` (tsc + esbuild): clean.

Plan grilled, reviewed, and approved via otacon (session `otc_w8zqpk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)