### PR TITLE
fix(agent-mode): switch to the picked model on the first click, not the second

### DIFF
--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -22,6 +22,7 @@ import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemP
 import { buildBuiltinSkillEnv } from "@/agentMode/backends/shared/builtinSkillEnv";
 import type {
   BackendConfigOption,
+  BackendState,
   EnabledModelEntry,
   ModeMapping,
   ModelSelection,
@@ -268,12 +269,19 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
     return isClaudePlanModePlanFilePath(absolutePath);
   },
 
-  async applySelection(session: AgentSession, selection: ModelSelection): Promise<void> {
+  async applySelection(
+    session: AgentSession,
+    selection: ModelSelection,
+    reportedState?: BackendState | null
+  ): Promise<void> {
     // Claude's wire id is just the baseModelId — effort travels through
     // `setConfigOption`, not the model id. Skip the model round-trip when
     // the base hasn't changed, otherwise effort-only ticks would fire a
-    // pointless `setSessionModel` on every slider drag.
-    const currentBase = session.getState()?.model?.current.baseModelId;
+    // pointless `setSessionModel` on every slider drag. The guard compares
+    // against the reported state when given — during startup seeding the
+    // session state optimistically shows the target already.
+    const guardState = reportedState ?? session.getState();
+    const currentBase = guardState?.model?.current.baseModelId;
     if (currentBase !== selection.baseModelId) {
       await session.applyModelWireId(claudeWire.encode(selection));
     }
@@ -281,7 +289,7 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
     const cfgOpt = claudeWire.effortConfigFor?.(selection.baseModelId);
     if (!cfgOpt) return;
     try {
-      await session.setConfigOption(cfgOpt.id, selection.effort, "confirmed");
+      await session.setConfigOption(cfgOpt.id, selection.effort, "reported");
     } catch (e) {
       if (!(e instanceof MethodUnsupportedError)) throw e;
     }
@@ -391,7 +399,7 @@ async function replayPersistedEffort(
     const cfgOpt = ClaudeBackendDescriptor.wire.effortConfigFor?.(current.baseModelId);
     if (!cfgOpt) return true;
     try {
-      await session.setConfigOption(cfgOpt.id, persistedEffort, "confirmed");
+      await session.setConfigOption(cfgOpt.id, persistedEffort, "reported");
     } catch (e) {
       if (e instanceof MethodUnsupportedError) return true;
       logWarn(`[AgentMode] could not apply default effort ${persistedEffort}`, e);

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -281,7 +281,7 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
     const cfgOpt = claudeWire.effortConfigFor?.(selection.baseModelId);
     if (!cfgOpt) return;
     try {
-      await session.setConfigOption(cfgOpt.id, selection.effort);
+      await session.applyConfigOption(cfgOpt.id, selection.effort, "confirmed");
     } catch (e) {
       if (!(e instanceof MethodUnsupportedError)) throw e;
     }
@@ -391,7 +391,7 @@ async function replayPersistedEffort(
     const cfgOpt = ClaudeBackendDescriptor.wire.effortConfigFor?.(current.baseModelId);
     if (!cfgOpt) return true;
     try {
-      await session.setConfigOption(cfgOpt.id, persistedEffort);
+      await session.applyConfigOption(cfgOpt.id, persistedEffort, "confirmed");
     } catch (e) {
       if (e instanceof MethodUnsupportedError) return true;
       logWarn(`[AgentMode] could not apply default effort ${persistedEffort}`, e);

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -281,7 +281,7 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
     const cfgOpt = claudeWire.effortConfigFor?.(selection.baseModelId);
     if (!cfgOpt) return;
     try {
-      await session.applyConfigOption(cfgOpt.id, selection.effort, "confirmed");
+      await session.setConfigOption(cfgOpt.id, selection.effort, "confirmed");
     } catch (e) {
       if (!(e instanceof MethodUnsupportedError)) throw e;
     }
@@ -391,7 +391,7 @@ async function replayPersistedEffort(
     const cfgOpt = ClaudeBackendDescriptor.wire.effortConfigFor?.(current.baseModelId);
     if (!cfgOpt) return true;
     try {
-      await session.applyConfigOption(cfgOpt.id, persistedEffort, "confirmed");
+      await session.setConfigOption(cfgOpt.id, persistedEffort, "confirmed");
     } catch (e) {
       if (e instanceof MethodUnsupportedError) return true;
       logWarn(`[AgentMode] could not apply default effort ${persistedEffort}`, e);

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -210,7 +210,7 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
       effort: "high",
     });
     expect(applyModelWireId).not.toHaveBeenCalled();
-    expect(setConfigOption).toHaveBeenCalledWith("effort", "high", "confirmed");
+    expect(setConfigOption).toHaveBeenCalledWith("effort", "high", "reported");
   });
 
   it("switches the base model before applying its config-option-backed effort", async () => {
@@ -227,7 +227,7 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
       effort: "high",
     });
     expect(applyModelWireId).toHaveBeenCalledWith("openai/gpt-5");
-    expect(setConfigOption).toHaveBeenCalledWith("effort", "high", "confirmed");
+    expect(setConfigOption).toHaveBeenCalledWith("effort", "high", "reported");
     expect(applyModelWireId.mock.invocationCallOrder[0]).toBeLessThan(
       setConfigOption.mock.invocationCallOrder[0]
     );

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -165,7 +165,7 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
   function makeSession(state: BackendState): {
     session: AgentSession;
     applyModelWireId: jest.Mock;
-    applyConfigOption: jest.Mock;
+    setConfigOption: jest.Mock;
   } {
     let currentState = state;
     const applyModelWireId = jest.fn(async () => {
@@ -184,20 +184,20 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
           : null,
       };
     });
-    const applyConfigOption = jest.fn(async () => undefined);
+    const setConfigOption = jest.fn(async () => undefined);
     return {
       session: {
         getState: () => currentState,
         applyModelWireId,
-        applyConfigOption,
+        setConfigOption,
       } as unknown as AgentSession,
       applyModelWireId,
-      applyConfigOption,
+      setConfigOption,
     };
   }
 
   it("routes config-option-backed effort through the thought-level option", async () => {
-    const { session, applyModelWireId, applyConfigOption } = makeSession({
+    const { session, applyModelWireId, setConfigOption } = makeSession({
       model: {
         current: { baseModelId: "openai/gpt-5", effort: "low" },
         availableModels: [],
@@ -210,11 +210,11 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
       effort: "high",
     });
     expect(applyModelWireId).not.toHaveBeenCalled();
-    expect(applyConfigOption).toHaveBeenCalledWith("effort", "high", "confirmed");
+    expect(setConfigOption).toHaveBeenCalledWith("effort", "high", "confirmed");
   });
 
   it("switches the base model before applying its config-option-backed effort", async () => {
-    const { session, applyModelWireId, applyConfigOption } = makeSession({
+    const { session, applyModelWireId, setConfigOption } = makeSession({
       model: {
         current: { baseModelId: "anthropic/claude-sonnet", effort: "low" },
         availableModels: [],
@@ -227,9 +227,9 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
       effort: "high",
     });
     expect(applyModelWireId).toHaveBeenCalledWith("openai/gpt-5");
-    expect(applyConfigOption).toHaveBeenCalledWith("effort", "high", "confirmed");
+    expect(setConfigOption).toHaveBeenCalledWith("effort", "high", "confirmed");
     expect(applyModelWireId.mock.invocationCallOrder[0]).toBeLessThan(
-      applyConfigOption.mock.invocationCallOrder[0]
+      setConfigOption.mock.invocationCallOrder[0]
     );
   });
 });

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -165,7 +165,7 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
   function makeSession(state: BackendState): {
     session: AgentSession;
     applyModelWireId: jest.Mock;
-    setConfigOption: jest.Mock;
+    applyConfigOption: jest.Mock;
   } {
     let currentState = state;
     const applyModelWireId = jest.fn(async () => {
@@ -184,20 +184,20 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
           : null,
       };
     });
-    const setConfigOption = jest.fn(async () => undefined);
+    const applyConfigOption = jest.fn(async () => undefined);
     return {
       session: {
         getState: () => currentState,
         applyModelWireId,
-        setConfigOption,
+        applyConfigOption,
       } as unknown as AgentSession,
       applyModelWireId,
-      setConfigOption,
+      applyConfigOption,
     };
   }
 
   it("routes config-option-backed effort through the thought-level option", async () => {
-    const { session, applyModelWireId, setConfigOption } = makeSession({
+    const { session, applyModelWireId, applyConfigOption } = makeSession({
       model: {
         current: { baseModelId: "openai/gpt-5", effort: "low" },
         availableModels: [],
@@ -210,11 +210,11 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
       effort: "high",
     });
     expect(applyModelWireId).not.toHaveBeenCalled();
-    expect(setConfigOption).toHaveBeenCalledWith("effort", "high");
+    expect(applyConfigOption).toHaveBeenCalledWith("effort", "high", "confirmed");
   });
 
   it("switches the base model before applying its config-option-backed effort", async () => {
-    const { session, applyModelWireId, setConfigOption } = makeSession({
+    const { session, applyModelWireId, applyConfigOption } = makeSession({
       model: {
         current: { baseModelId: "anthropic/claude-sonnet", effort: "low" },
         availableModels: [],
@@ -227,9 +227,9 @@ describe("OpencodeBackendDescriptor.applySelection", () => {
       effort: "high",
     });
     expect(applyModelWireId).toHaveBeenCalledWith("openai/gpt-5");
-    expect(setConfigOption).toHaveBeenCalledWith("effort", "high");
+    expect(applyConfigOption).toHaveBeenCalledWith("effort", "high", "confirmed");
     expect(applyModelWireId.mock.invocationCallOrder[0]).toBeLessThan(
-      setConfigOption.mock.invocationCallOrder[0]
+      applyConfigOption.mock.invocationCallOrder[0]
     );
   });
 });

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -212,7 +212,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
         const effortConfigId =
           refreshedApply?.kind === "setConfigOption" ? refreshedApply.effortConfigId : undefined;
         if (effortConfigId) {
-          await session.applyConfigOption(effortConfigId, selection.effort, "confirmed");
+          await session.setConfigOption(effortConfigId, selection.effort, "confirmed");
         }
       }
       return;

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -212,7 +212,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
         const effortConfigId =
           refreshedApply?.kind === "setConfigOption" ? refreshedApply.effortConfigId : undefined;
         if (effortConfigId) {
-          await session.setConfigOption(effortConfigId, selection.effort);
+          await session.applyConfigOption(effortConfigId, selection.effort, "confirmed");
         }
       }
       return;

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -29,6 +29,7 @@ import { cacheRoot } from "@/context/conversionsLocation";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { simpleBinaryBackendProcess } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import type {
+  BackendState,
   EffortOption,
   EnabledModelEntry,
   ModeMapping,
@@ -196,12 +197,19 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
     }
   },
 
-  async applySelection(session: AgentSession, selection: ModelSelection): Promise<void> {
-    const apply = session.getState()?.model?.apply;
+  async applySelection(
+    session: AgentSession,
+    selection: ModelSelection,
+    reportedState?: BackendState | null
+  ): Promise<void> {
+    // Guard reads use the reported state when given — during startup seeding
+    // the session state optimistically shows the target already.
+    const guardState = reportedState ?? session.getState();
+    const apply = guardState?.model?.apply;
     if (apply?.kind === "setConfigOption" && apply.effortConfigId) {
       // The effort option is model-specific, so activate the bare model first
       // and use the option id from the refreshed state.
-      const currentBase = session.getState()?.model?.current.baseModelId;
+      const currentBase = guardState?.model?.current.baseModelId;
       if (currentBase !== selection.baseModelId) {
         await session.applyModelWireId(
           opencodeWire.encode({ baseModelId: selection.baseModelId, effort: null })
@@ -212,7 +220,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
         const effortConfigId =
           refreshedApply?.kind === "setConfigOption" ? refreshedApply.effortConfigId : undefined;
         if (effortConfigId) {
-          await session.setConfigOption(effortConfigId, selection.effort, "confirmed");
+          await session.setConfigOption(effortConfigId, selection.effort, "reported");
         }
       }
       return;

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -3018,6 +3018,109 @@ describe("AgentSession.create (via start)", () => {
     expect(mock.prompt).toHaveBeenCalled();
   });
 
+  it("holds a queued first prompt until a model re-pick made during startup lands", async () => {
+    // Regression (P1): the session reports "idle" during the seeded
+    // confirmation, so the user can pick another model; that apply queues on
+    // the serialization chain behind the seeded one, but `ready` only covers
+    // confirmSeededSelection — the first prompt must also drain the chain or
+    // it runs on the seed instead of the latest pick.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "opus", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "opus", name: "Opus", provider: "anthropic", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+          { baseModelId: "haiku", name: "Haiku", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    let resolveSeeded!: (s: BackendState) => void;
+    let resolveRepick!: (s: BackendState) => void;
+    mock.setSessionModel
+      .mockImplementationOnce(() => new Promise<BackendState>((r) => (resolveSeeded = r)))
+      .mockImplementationOnce(() => new Promise<BackendState>((r) => (resolveRepick = r)));
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "claude",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeDescriptorWireWithoutEffort(),
+    });
+    await new Promise((r) => window.setTimeout(r, 0));
+    // The user re-picks while the seeded switch is still in flight…
+    const repick = session.setModel("haiku");
+    // …and immediately submits.
+    const { turn } = session.sendPrompt("hi");
+    resolveSeeded({
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    });
+    await new Promise((r) => window.setTimeout(r, 0));
+    // ready has resolved, but the re-pick is still in flight — no prompt yet.
+    expect(mock.prompt).not.toHaveBeenCalled();
+    resolveRepick({
+      model: { ...reported.model!, current: { baseModelId: "haiku", effort: null } },
+      mode: null,
+    });
+    await repick;
+    await turn;
+    expect(mock.prompt).toHaveBeenCalled();
+    expect(session.getState()?.model?.current.baseModelId).toBe("haiku");
+  });
+
+  it("a cancel whose backend round-trip is slow still stops a queued first prompt", async () => {
+    // Regression: cancel() previously aborted the local controller only after
+    // `backend.cancel` resolved; a queued turn whose wait completed inside
+    // that window saw an unaborted signal and dispatched the prompt anyway.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "opus", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "opus", name: "Opus", provider: "anthropic", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    let resolveSetModel!: (s: BackendState) => void;
+    mock.setSessionModel.mockImplementationOnce(
+      () => new Promise<BackendState>((resolve) => (resolveSetModel = resolve))
+    );
+    let resolveCancel!: () => void;
+    mock.cancel.mockImplementationOnce(
+      () => new Promise<undefined>((resolve) => (resolveCancel = () => resolve(undefined)))
+    );
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "claude",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeDescriptorWireWithoutEffort(),
+    });
+    await new Promise((r) => window.setTimeout(r, 0));
+    const { turn } = session.sendPrompt("hi");
+    const cancelled = session.cancel();
+    // The backend cancel round-trip is still in flight when the model
+    // confirmation lands — the queued turn must still see the abort.
+    resolveSetModel({
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    });
+    await expect(turn).resolves.toBe("cancelled");
+    expect(mock.prompt).not.toHaveBeenCalled();
+    resolveCancel();
+    await cancelled;
+  });
+
   it("seeds config-option opencode effort via the effort option, not the model id", async () => {
     // Regression: a cross-backend pick to config-option opencode (≥1.15.13)
     // must set the bare model on the model config option and the effort on the

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2434,6 +2434,47 @@ describe("AgentSession.create (via start)", () => {
     expect(session.getState()?.model?.current.effort).toBe("high");
   });
 
+  it("keeps the user-applied model when a setMode response carries a stale model", async () => {
+    // A mode-switch response is a full BackendState snapshot; if it was computed
+    // against pre-switch state it must not clobber the applied model. Only the
+    // model dimension is pinned — the mode change itself lands.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: "openai", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    const switched: BackendState = {
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce(switched);
+    mock.setSessionMode.mockResolvedValueOnce({
+      model: reported.model,
+      mode: { current: "plan", options: [{ value: "plan", label: "Plan" }], apply: {} },
+    });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeWireOnlyDescriptor(),
+    });
+    await session.ready;
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+    await session.setMode("plan");
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+    expect(session.getState()?.mode?.current).toBe("plan");
+  });
+
   it("seeds config-option opencode effort via the effort option, not the model id", async () => {
     // Regression: a cross-backend pick to config-option opencode (≥1.15.13)
     // must set the bare model on the model config option and the effort on the

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2237,11 +2237,11 @@ describe("AgentSession.create (via start)", () => {
   });
 
   it("cross-backend seed to a guard-on-current setModel backend still issues the real switch", async () => {
-    // Regression: Claude-style backends guard their setModel on getState().current.
-    // The optimistic display seed already shows the target, so without dropping it
-    // confirmSeededSelection would fool the guard into skipping the real switch,
-    // stranding the backend on its startup default. The seed must be dropped so the
-    // guard sees the true reported model and fires setSessionModel.
+    // Regression: Claude-style backends guard their setModel write on the current
+    // model. The optimistic display seed already shows the target, so a guard
+    // reading the seeded session state would skip the real switch, stranding the
+    // backend on its startup default. confirmSeededSelection passes the reported
+    // state to applySelection so the guard compares truth and fires setSessionModel.
     const mock = makeMockBackend();
     const reported: BackendState = {
       model: {
@@ -2565,6 +2565,153 @@ describe("AgentSession.create (via start)", () => {
     expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
   });
 
+  it("keeps the optimistic seed visible while the confirming switch is in flight", async () => {
+    // Regression: initialize() notifies before confirmSeededSelection runs, so
+    // React reads whatever state is current when it renders. Resetting the
+    // seed to make descriptor guards work would flash the backend default
+    // until the confirming setModel lands; instead the seed stays and the
+    // guard compares against the reported state passed to applySelection.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "opus", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "opus", name: "Opus", provider: "anthropic", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    let resolveSetModel!: (s: BackendState) => void;
+    mock.setSessionModel.mockImplementationOnce(
+      () => new Promise<BackendState>((resolve) => (resolveSetModel = resolve))
+    );
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "claude",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeDescriptorWireWithoutEffort(),
+    });
+    // Let initialize reach the in-flight setSessionModel.
+    await new Promise((r) => window.setTimeout(r, 0));
+    expect(mock.setSessionModel).toHaveBeenCalledWith({ sessionId: "acp-1", modelId: "sonnet" });
+    // A render during the round-trip sees the pick, not the backend default.
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+    resolveSetModel({
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    });
+    await session.ready;
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+  });
+
+  it("preserves a trusted same-model effort change when rejecting a later stale revert", async () => {
+    // Regression: a same-model push is trusted verbatim, so the effort it
+    // carries is the latest trusted selection. The pin must follow it —
+    // otherwise a later stale different-model snapshot is "reconciled" back
+    // to the pin's obsolete effort, silently undoing the accepted change.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: "openai", effortOptions: [] },
+          {
+            baseModelId: "sonnet",
+            name: "Sonnet",
+            provider: "anthropic",
+            effortOptions: [{ value: "high", label: "High" }],
+          },
+        ],
+      },
+      mode: null,
+    };
+    const switched: BackendState = {
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce(switched);
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeWireOnlyDescriptor(),
+    });
+    await session.ready;
+    const withEffort: BackendState = {
+      model: { ...switched.model!, current: { baseModelId: "sonnet", effort: "high" } },
+      mode: null,
+    };
+    mock.emit({
+      sessionId: "acp-1",
+      update: { sessionUpdate: "state_changed", state: withEffort },
+    });
+    expect(session.getState()?.model?.current).toEqual({ baseModelId: "sonnet", effort: "high" });
+    // A stale pre-switch snapshot must restore the latest trusted selection,
+    // including the effort accepted above — not the effort pinned at apply time.
+    mock.emit({ sessionId: "acp-1", update: { sessionUpdate: "state_changed", state: reported } });
+    expect(session.getState()?.model?.current).toEqual({ baseModelId: "sonnet", effort: "high" });
+  });
+
+  it("keeps the applied model when an effort apply's response carries a stale model", async () => {
+    // Regression: effort writes are not model confirmations. When an effort
+    // response snapshot carries a stale pre-switch model, it must neither
+    // clobber the just-applied model nor re-pin lastAppliedModel to the stale
+    // value — otherwise a later truthful push is "reconciled" back to it.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "opus", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "opus", name: "Opus", provider: "anthropic", effortOptions: [] },
+          {
+            baseModelId: "sonnet",
+            name: "Sonnet",
+            provider: "anthropic",
+            effortOptions: [{ value: "high", label: "High" }],
+          },
+        ],
+      },
+      mode: null,
+    };
+    const switched: BackendState = {
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce(switched);
+    // The effort write's response was computed against pre-switch state.
+    mock.setSessionConfigOption.mockResolvedValueOnce(reported);
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "claude",
+      defaultModelSelection: { baseModelId: "sonnet", effort: "high" },
+      getDescriptor: () => makeDescriptorWireWithoutEffort(),
+    });
+    await session.ready;
+    // The stale effort response did not revert the applied model.
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+    // Pin uncorrupted: a truthful push carrying the pick (with its effort
+    // landed backend-side) is honored as-is.
+    const confirmed: BackendState = {
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: "high" } },
+      mode: null,
+    };
+    mock.emit({ sessionId: "acp-1", update: { sessionUpdate: "state_changed", state: confirmed } });
+    expect(session.getState()?.model?.current).toEqual({ baseModelId: "sonnet", effort: "high" });
+  });
+
   it("seeds config-option opencode effort via the effort option, not the model id", async () => {
     // Regression: a cross-backend pick to config-option opencode (≥1.15.13)
     // must set the bare model on the model config option and the effort on the
@@ -2732,11 +2879,13 @@ function makeConfigOptionDescriptor(): BackendDescriptor {
     wire,
     applySelection: async (
       session: AgentSession,
-      selection: { baseModelId: string; effort: string | null }
+      selection: { baseModelId: string; effort: string | null },
+      reportedState?: BackendState | null
     ) => {
-      const apply = session.getState()?.model?.apply;
+      const guardState = reportedState ?? session.getState();
+      const apply = guardState?.model?.apply;
       if (apply?.kind === "setConfigOption" && apply.effortConfigId) {
-        const currentBase = session.getState()?.model?.current.baseModelId;
+        const currentBase = guardState?.model?.current.baseModelId;
         if (currentBase !== selection.baseModelId) {
           await session.applyModelWireId(
             wire.encode({ baseModelId: selection.baseModelId, effort: null })
@@ -2747,7 +2896,7 @@ function makeConfigOptionDescriptor(): BackendDescriptor {
           const effortConfigId =
             refreshed?.kind === "setConfigOption" ? refreshed.effortConfigId : undefined;
           if (effortConfigId)
-            await session.setConfigOption(effortConfigId, selection.effort, "confirmed");
+            await session.setConfigOption(effortConfigId, selection.effort, "reported");
         }
         return;
       }
@@ -2845,16 +2994,19 @@ function makeDescriptorWireWithoutEffort(): BackendDescriptor {
   return {
     wire,
     // Claude-style: effort lives outside the wire id, so the model channel
-    // carries only the base id and effort goes through setConfigOption.
+    // carries only the base id and effort goes through setConfigOption. The
+    // guard compares against the reported state when given, mirroring the
+    // real descriptor.
     applySelection: async (
       session: AgentSession,
-      selection: { baseModelId: string; effort: string | null }
+      selection: { baseModelId: string; effort: string | null },
+      reportedState?: BackendState | null
     ) => {
-      const currentBase = session.getState()?.model?.current.baseModelId;
+      const currentBase = (reportedState ?? session.getState())?.model?.current.baseModelId;
       if (currentBase !== selection.baseModelId)
         await session.applyModelWireId(wire.encode(selection));
       if (selection.effort !== null)
-        await session.setConfigOption("effort", selection.effort, "confirmed");
+        await session.setConfigOption("effort", selection.effort, "reported");
     },
   } as unknown as BackendDescriptor;
 }

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2705,7 +2705,8 @@ function makeConfigOptionDescriptor(): BackendDescriptor {
           const refreshed = session.getState()?.model?.apply;
           const effortConfigId =
             refreshed?.kind === "setConfigOption" ? refreshed.effortConfigId : undefined;
-          if (effortConfigId) await session.setConfigOption(effortConfigId, selection.effort);
+          if (effortConfigId)
+            await session.applyConfigOption(effortConfigId, selection.effort, "confirmed");
         }
         return;
       }
@@ -2811,7 +2812,8 @@ function makeDescriptorWireWithoutEffort(): BackendDescriptor {
       const currentBase = session.getState()?.model?.current.baseModelId;
       if (currentBase !== selection.baseModelId)
         await session.applyModelWireId(wire.encode(selection));
-      if (selection.effort !== null) await session.setConfigOption("effort", selection.effort);
+      if (selection.effort !== null)
+        await session.applyConfigOption("effort", selection.effort, "confirmed");
     },
   } as unknown as BackendDescriptor;
 }
@@ -2881,7 +2883,7 @@ describe("AgentSession.setConfigOption", () => {
       internalId: "internal-1",
       backendId: "claude",
     });
-    await session.setConfigOption("effort", "high");
+    await session.applyConfigOption("effort", "high", "confirmed");
     expect(mock.setSessionConfigOption).toHaveBeenCalledWith({
       sessionId: "acp-1",
       configId: "effort",
@@ -2903,7 +2905,7 @@ describe("AgentSession.setConfigOption", () => {
       onStatusChanged: jest.fn(),
       onModelChanged,
     });
-    await session.setConfigOption("effort", "low");
+    await session.applyConfigOption("effort", "low", "confirmed");
     expect(onModelChanged).toHaveBeenCalledTimes(1);
   });
 
@@ -2924,7 +2926,7 @@ describe("AgentSession.setConfigOption", () => {
       onStatusChanged: jest.fn(),
       onModelChanged,
     });
-    await expect(session.setConfigOption("effort", "high")).rejects.toBeInstanceOf(
+    await expect(session.applyConfigOption("effort", "high", "confirmed")).rejects.toBeInstanceOf(
       MethodUnsupportedError
     );
     expect(onModelChanged).not.toHaveBeenCalled();

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2475,6 +2475,55 @@ describe("AgentSession.create (via start)", () => {
     expect(session.getState()?.mode?.current).toBe("plan");
   });
 
+  it("keeps the user-applied model when a config-option mode apply carries a stale model", async () => {
+    // opencode routes mode switches through setSessionConfigOption; the response
+    // is a whole-state snapshot that can be stale. It must not clobber the
+    // applied model, and it must not re-pin lastAppliedModelBaseId to the stale
+    // value — otherwise a later truthful state_changed would be "reconciled"
+    // back to the stale model.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: "openai", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    const switched: BackendState = {
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce(switched);
+    mock.setSessionConfigOption.mockResolvedValueOnce({
+      model: reported.model,
+      mode: { current: "plan", options: [{ value: "plan", label: "Plan" }], apply: {} },
+    });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeWireOnlyDescriptor(),
+    });
+    await session.ready;
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+    await session.setModeConfigOption("mode", "plan");
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+    expect(session.getState()?.mode?.current).toBe("plan");
+    // Pin uncorrupted: a truthful push carrying the pick is honored as-is.
+    mock.emit({
+      sessionId: "acp-1",
+      update: { sessionUpdate: "state_changed", state: switched },
+    });
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+  });
+
   it("seeds config-option opencode effort via the effort option, not the model id", async () => {
     // Regression: a cross-backend pick to config-option opencode (≥1.15.13)
     // must set the bare model on the model config option and the effort on the

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2236,6 +2236,42 @@ describe("AgentSession.create (via start)", () => {
     expect(session.getState()?.model?.current.baseModelId).toBe("anthropic/sonnet");
   });
 
+  it("cross-backend seed to a guard-on-current setModel backend still issues the real switch", async () => {
+    // Regression: Claude-style backends guard their setModel on getState().current.
+    // The optimistic display seed already shows the target, so without dropping it
+    // confirmSeededSelection would fool the guard into skipping the real switch,
+    // stranding the backend on its startup default. The seed must be dropped so the
+    // guard sees the true reported model and fires setSessionModel.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "opus", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "opus", name: "Opus", provider: "anthropic", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce({
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "claude",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeDescriptorWireWithoutEffort(),
+    });
+    await session.ready;
+    expect(mock.setSessionModel).toHaveBeenCalledWith({ sessionId: "acp-1", modelId: "sonnet" });
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+  });
+
   it("seeds config-option opencode effort via the effort option, not the model id", async () => {
     // Regression: a cross-backend pick to config-option opencode (≥1.15.13)
     // must set the bare model on the model config option and the effort on the

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2852,6 +2852,106 @@ describe("AgentSession.create (via start)", () => {
     ]);
   });
 
+  it("a superseded model apply response cannot re-pin over the user's newer pick", async () => {
+    // Regression: rapid picks start unserialized applies; if the older
+    // request's response resolves after the newer one, treating it as a
+    // confirmation would re-pin the older model and make the guard rewrite
+    // later truthful pushes. A superseded response is demoted to a reported
+    // snapshot and reconciled against the newest pick instead.
+    const mock = makeMockBackend();
+    const base: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: "openai", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+          { baseModelId: "haiku", name: "Haiku", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    let resolveFirst!: (s: BackendState) => void;
+    mock.setSessionModel
+      .mockImplementationOnce(() => new Promise<BackendState>((r) => (resolveFirst = r)))
+      .mockResolvedValueOnce({
+        model: { ...base.model!, current: { baseModelId: "haiku", effort: null } },
+        mode: null,
+      });
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+      initialState: base,
+    });
+    const first = session.setModel("sonnet");
+    await session.setModel("haiku");
+    expect(session.getState()?.model?.current.baseModelId).toBe("haiku");
+    // The older apply's response arrives late, carrying its own (now stale) model.
+    resolveFirst({
+      model: { ...base.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    });
+    await first;
+    expect(session.getState()?.model?.current.baseModelId).toBe("haiku");
+    // Pin uncorrupted: a stale push reverting the newest pick is still rejected.
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "state_changed",
+        state: {
+          model: { ...base.model!, current: { baseModelId: "gpt-5", effort: null } },
+          mode: null,
+        },
+      },
+    });
+    expect(session.getState()?.model?.current.baseModelId).toBe("haiku");
+  });
+
+  it("queues a first prompt fired during the seeded-switch round-trip behind the confirmation", async () => {
+    // Regression: the status gate opens ("idle") before confirmSeededSelection
+    // finishes, so a fast first submit could race the model switch and run on
+    // the backend default. The turn must wait for `ready` before prompting.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "opus", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "opus", name: "Opus", provider: "anthropic", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    let resolveSetModel!: (s: BackendState) => void;
+    mock.setSessionModel.mockImplementationOnce(
+      () => new Promise<BackendState>((resolve) => (resolveSetModel = resolve))
+    );
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "claude",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeDescriptorWireWithoutEffort(),
+    });
+    await new Promise((r) => window.setTimeout(r, 0));
+    expect(session.getStatus()).toBe("idle");
+    const { turn } = session.sendPrompt("hi");
+    await new Promise((r) => window.setTimeout(r, 0));
+    // The prompt is queued behind the in-flight model confirmation.
+    expect(mock.prompt).not.toHaveBeenCalled();
+    resolveSetModel({
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    });
+    await turn;
+    expect(mock.prompt).toHaveBeenCalled();
+  });
+
   it("seeds config-option opencode effort via the effort option, not the model id", async () => {
     // Regression: a cross-backend pick to config-option opencode (≥1.15.13)
     // must set the bare model on the model config option and the effort on the

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2272,6 +2272,87 @@ describe("AgentSession.create (via start)", () => {
     expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
   });
 
+  it("keeps the user-applied model when a late state_changed would revert it", async () => {
+    // Regression: opencode's config_option_update broadcasts (synthesized into
+    // state_changed) can race a switch and carry the pre-switch default; the old
+    // unconditional overwrite clobbered the user's pick back to the default.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: "openai", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    const switched: BackendState = {
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce(switched);
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeWireOnlyDescriptor(),
+    });
+    await session.ready;
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+    mock.emit({ sessionId: "acp-1", update: { sessionUpdate: "state_changed", state: reported } });
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+  });
+
+  it("honors a state_changed that keeps the applied model but changes effort", async () => {
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: "openai", effortOptions: [] },
+          {
+            baseModelId: "sonnet",
+            name: "Sonnet",
+            provider: "anthropic",
+            effortOptions: [{ value: "high", label: "High" }],
+          },
+        ],
+      },
+      mode: null,
+    };
+    const switched: BackendState = {
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce(switched);
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeWireOnlyDescriptor(),
+    });
+    await session.ready;
+    const withEffort: BackendState = {
+      model: { ...switched.model!, current: { baseModelId: "sonnet", effort: "high" } },
+      mode: null,
+    };
+    mock.emit({
+      sessionId: "acp-1",
+      update: { sessionUpdate: "state_changed", state: withEffort },
+    });
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+    expect(session.getState()?.model?.current.effort).toBe("high");
+  });
+
   it("seeds config-option opencode effort via the effort option, not the model id", async () => {
     // Regression: a cross-backend pick to config-option opencode (≥1.15.13)
     // must set the bare model on the model config option and the effort on the

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2272,6 +2272,87 @@ describe("AgentSession.create (via start)", () => {
     expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
   });
 
+  it("cross-backend seed to Claude lands both the picked model and its effort", async () => {
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "opus", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "opus", name: "Opus", provider: "anthropic", effortOptions: [] },
+          {
+            baseModelId: "sonnet",
+            name: "Sonnet",
+            provider: "anthropic",
+            effortOptions: [{ value: "high", label: "High" }],
+          },
+        ],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce({
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    });
+    mock.setSessionConfigOption.mockResolvedValueOnce({
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: "high" } },
+      mode: null,
+    });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "claude",
+      defaultModelSelection: { baseModelId: "sonnet", effort: "high" },
+      getDescriptor: () => makeDescriptorWireWithoutEffort(),
+    });
+    await session.ready;
+    expect(mock.setSessionModel).toHaveBeenCalledWith({ sessionId: "acp-1", modelId: "sonnet" });
+    expect(mock.setSessionConfigOption).toHaveBeenCalledWith({
+      sessionId: "acp-1",
+      configId: "effort",
+      value: "high",
+    });
+    expect(session.getState()?.model?.current).toEqual({ baseModelId: "sonnet", effort: "high" });
+  });
+
+  it("cross-backend seed to a guard-less setModel backend issues the switch", async () => {
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5-codex", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          {
+            baseModelId: "gpt-5-codex",
+            name: "GPT-5 Codex",
+            provider: "openai",
+            effortOptions: [],
+          },
+          { baseModelId: "o3", name: "o3", provider: "openai", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce({
+      model: { ...reported.model!, current: { baseModelId: "o3", effort: null } },
+      mode: null,
+    });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "codex",
+      defaultModelSelection: { baseModelId: "o3", effort: null },
+      getDescriptor: () => makeWireOnlyDescriptor(),
+    });
+    await session.ready;
+    expect(mock.setSessionModel).toHaveBeenCalledWith({ sessionId: "acp-1", modelId: "o3" });
+    expect(session.getState()?.model?.current.baseModelId).toBe("o3");
+  });
+
   it("keeps the user-applied model when a late state_changed would revert it", async () => {
     // Regression: opencode's config_option_update broadcasts (synthesized into
     // state_changed) can race a switch and carry the pre-switch default; the old

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2712,6 +2712,146 @@ describe("AgentSession.create (via start)", () => {
     expect(session.getState()?.model?.current).toEqual({ baseModelId: "sonnet", effort: "high" });
   });
 
+  it("clears the pin when the backend drops the applied model", async () => {
+    // Regression: a snapshot accepted because the applied model vanished from
+    // the catalog ends the pin's authority. If the catalog later re-offers
+    // the model while the backend stays on its fallback, the old pin must not
+    // be grafted back — the picker would disagree with the model in use.
+    const mock = makeMockBackend();
+    const catalogWithBoth = [
+      { baseModelId: "gpt-5", name: "GPT-5", provider: "openai", effortOptions: [] },
+      { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+    ];
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+      initialState: {
+        model: {
+          current: { baseModelId: "gpt-5", effort: null },
+          apply: { kind: "setModel" },
+          availableModels: catalogWithBoth,
+        },
+        mode: null,
+      },
+    });
+    mock.setSessionModel.mockResolvedValueOnce({
+      model: {
+        current: { baseModelId: "sonnet", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: catalogWithBoth,
+      },
+      mode: null,
+    });
+    await session.setModel("sonnet");
+    // The backend drops sonnet from the catalog and falls back.
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "state_changed",
+        state: {
+          model: {
+            current: { baseModelId: "gpt-5", effort: null },
+            apply: { kind: "setModel" },
+            availableModels: [catalogWithBoth[0]],
+          },
+          mode: null,
+        },
+      },
+    });
+    expect(session.getState()?.model?.current.baseModelId).toBe("gpt-5");
+    // Sonnet returns to the catalog while the backend still reports the
+    // fallback — that is not a stale echo of the old switch; it stands.
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "state_changed",
+        state: {
+          model: {
+            current: { baseModelId: "gpt-5", effort: null },
+            apply: { kind: "setModel" },
+            availableModels: catalogWithBoth,
+          },
+          mode: null,
+        },
+      },
+    });
+    expect(session.getState()?.model?.current.baseModelId).toBe("gpt-5");
+  });
+
+  it("carries the pinned model's effort metadata through a rejected stale revert", async () => {
+    // Regression: the translator attaches thought-level effortOptions and the
+    // apply spec's effortConfigId to a snapshot's *own* active model. Keeping
+    // the stale snapshot's catalog verbatim while grafting the pinned current
+    // would hide the pinned model's effort selector (empty effortOptions) and
+    // dispatch effort through the stale model's option id.
+    const mock = makeMockBackend();
+    const confirmedState: BackendState = {
+      model: {
+        current: { baseModelId: "sonnet", effort: "high" },
+        apply: { kind: "setConfigOption", configId: "model", effortConfigId: "thought-sonnet" },
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: "openai", effortOptions: [] },
+          {
+            baseModelId: "sonnet",
+            name: "Sonnet",
+            provider: "anthropic",
+            effortOptions: [{ value: "high", label: "High" }],
+          },
+        ],
+      },
+      mode: null,
+    };
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+      initialState: emptyState(),
+    });
+    mock.setSessionConfigOption.mockResolvedValueOnce(confirmedState);
+    await session.setConfigOption("model", "sonnet", "confirmed");
+    // Stale pre-switch snapshot: gpt-5 active, so its entry carries the
+    // thought-level options and the apply spec points at gpt-5's option.
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "state_changed",
+        state: {
+          model: {
+            current: { baseModelId: "gpt-5", effort: "low" },
+            apply: { kind: "setConfigOption", configId: "model", effortConfigId: "thought-gpt5" },
+            availableModels: [
+              {
+                baseModelId: "gpt-5",
+                name: "GPT-5",
+                provider: "openai",
+                effortOptions: [{ value: "low", label: "Low" }],
+              },
+              { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+            ],
+          },
+          mode: null,
+        },
+      },
+    });
+    const model = session.getState()?.model;
+    expect(model?.current).toEqual({ baseModelId: "sonnet", effort: "high" });
+    expect(model?.availableModels.find((m) => m.baseModelId === "sonnet")?.effortOptions).toEqual([
+      { value: "high", label: "High" },
+    ]);
+    expect(model?.apply).toEqual({
+      kind: "setConfigOption",
+      configId: "model",
+      effortConfigId: "thought-sonnet",
+    });
+    // The stale model's own catalog entry stays authoritative.
+    expect(model?.availableModels.find((m) => m.baseModelId === "gpt-5")?.effortOptions).toEqual([
+      { value: "low", label: "Low" },
+    ]);
+  });
+
   it("seeds config-option opencode effort via the effort option, not the model id", async () => {
     // Regression: a cross-backend pick to config-option opencode (≥1.15.13)
     // must set the bare model on the model config option and the effort on the

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2389,6 +2389,47 @@ describe("AgentSession.create (via start)", () => {
     expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
   });
 
+  it("restores the applied effort along with the model when rejecting a stale revert", async () => {
+    // A stale push carries the pre-switch selection wholesale. Rejecting only
+    // its model would graft the stale effort onto the applied base (e.g.
+    // sonnet + gpt-5's "high"), a selection the backend never confirmed.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5", effort: "high" },
+        apply: { kind: "setModel" },
+        availableModels: [
+          {
+            baseModelId: "gpt-5",
+            name: "GPT-5",
+            provider: "openai",
+            effortOptions: [{ value: "high", label: "High" }],
+          },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    const switched: BackendState = {
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    mock.setSessionModel.mockResolvedValueOnce(switched);
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeWireOnlyDescriptor(),
+    });
+    await session.ready;
+    expect(session.getState()?.model?.current).toEqual({ baseModelId: "sonnet", effort: null });
+    mock.emit({ sessionId: "acp-1", update: { sessionUpdate: "state_changed", state: reported } });
+    expect(session.getState()?.model?.current).toEqual({ baseModelId: "sonnet", effort: null });
+  });
+
   it("honors a state_changed that keeps the applied model but changes effort", async () => {
     const mock = makeMockBackend();
     const reported: BackendState = {
@@ -2478,7 +2519,7 @@ describe("AgentSession.create (via start)", () => {
   it("keeps the user-applied model when a config-option mode apply carries a stale model", async () => {
     // opencode routes mode switches through setSessionConfigOption; the response
     // is a whole-state snapshot that can be stale. It must not clobber the
-    // applied model, and it must not re-pin lastAppliedModelBaseId to the stale
+    // applied model, and it must not re-pin lastAppliedModel to the stale
     // value — otherwise a later truthful state_changed would be "reconciled"
     // back to the stale model.
     const mock = makeMockBackend();

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2873,7 +2873,7 @@ describe("AgentSession.setModel", () => {
   });
 });
 
-describe("AgentSession.setConfigOption", () => {
+describe("AgentSession.applyConfigOption", () => {
   it("forwards to backend and replaces state from response", async () => {
     const mock = makeMockBackend();
     mock.setSessionConfigOption.mockResolvedValueOnce(emptyState());

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2513,7 +2513,7 @@ describe("AgentSession.create (via start)", () => {
     });
     await session.ready;
     expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
-    await session.setModeConfigOption("mode", "plan");
+    await session.applyConfigOption("mode", "plan", "reported");
     expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
     expect(session.getState()?.mode?.current).toBe("plan");
     // Pin uncorrupted: a truthful push carrying the pick is honored as-is.

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2513,7 +2513,7 @@ describe("AgentSession.create (via start)", () => {
     });
     await session.ready;
     expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
-    await session.applyConfigOption("mode", "plan", "reported");
+    await session.setConfigOption("mode", "plan", "reported");
     expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
     expect(session.getState()?.mode?.current).toBe("plan");
     // Pin uncorrupted: a truthful push carrying the pick is honored as-is.
@@ -2706,7 +2706,7 @@ function makeConfigOptionDescriptor(): BackendDescriptor {
           const effortConfigId =
             refreshed?.kind === "setConfigOption" ? refreshed.effortConfigId : undefined;
           if (effortConfigId)
-            await session.applyConfigOption(effortConfigId, selection.effort, "confirmed");
+            await session.setConfigOption(effortConfigId, selection.effort, "confirmed");
         }
         return;
       }
@@ -2813,7 +2813,7 @@ function makeDescriptorWireWithoutEffort(): BackendDescriptor {
       if (currentBase !== selection.baseModelId)
         await session.applyModelWireId(wire.encode(selection));
       if (selection.effort !== null)
-        await session.applyConfigOption("effort", selection.effort, "confirmed");
+        await session.setConfigOption("effort", selection.effort, "confirmed");
     },
   } as unknown as BackendDescriptor;
 }
@@ -2873,7 +2873,7 @@ describe("AgentSession.setModel", () => {
   });
 });
 
-describe("AgentSession.applyConfigOption", () => {
+describe("AgentSession.setConfigOption", () => {
   it("forwards to backend and replaces state from response", async () => {
     const mock = makeMockBackend();
     mock.setSessionConfigOption.mockResolvedValueOnce(emptyState());
@@ -2883,7 +2883,7 @@ describe("AgentSession.applyConfigOption", () => {
       internalId: "internal-1",
       backendId: "claude",
     });
-    await session.applyConfigOption("effort", "high", "confirmed");
+    await session.setConfigOption("effort", "high", "confirmed");
     expect(mock.setSessionConfigOption).toHaveBeenCalledWith({
       sessionId: "acp-1",
       configId: "effort",
@@ -2905,7 +2905,7 @@ describe("AgentSession.applyConfigOption", () => {
       onStatusChanged: jest.fn(),
       onModelChanged,
     });
-    await session.applyConfigOption("effort", "low", "confirmed");
+    await session.setConfigOption("effort", "low", "confirmed");
     expect(onModelChanged).toHaveBeenCalledTimes(1);
   });
 
@@ -2926,7 +2926,7 @@ describe("AgentSession.applyConfigOption", () => {
       onStatusChanged: jest.fn(),
       onModelChanged,
     });
-    await expect(session.applyConfigOption("effort", "high", "confirmed")).rejects.toBeInstanceOf(
+    await expect(session.setConfigOption("effort", "high", "confirmed")).rejects.toBeInstanceOf(
       MethodUnsupportedError
     );
     expect(onModelChanged).not.toHaveBeenCalled();

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -2852,12 +2852,13 @@ describe("AgentSession.create (via start)", () => {
     ]);
   });
 
-  it("a superseded model apply response cannot re-pin over the user's newer pick", async () => {
-    // Regression: rapid picks start unserialized applies; if the older
-    // request's response resolves after the newer one, treating it as a
-    // confirmation would re-pin the older model and make the guard rewrite
-    // later truthful pushes. A superseded response is demoted to a reported
-    // snapshot and reconciled against the newest pick instead.
+  it("serializes rapid model applies so the last pick is the last write", async () => {
+    // Regression: rapid picks dispatched concurrent requests whose responses
+    // could complete out of order — the ACP wire cache is overwritten by each
+    // completion, and a backend processing them out of order could genuinely
+    // end on the older pick while the display showed the newer one. Dispatch
+    // is now sequenced: the next request is sent only after the previous
+    // response lands, so the last pick is the last write everywhere.
     const mock = makeMockBackend();
     const base: BackendState = {
       model: {
@@ -2886,27 +2887,92 @@ describe("AgentSession.create (via start)", () => {
       initialState: base,
     });
     const first = session.setModel("sonnet");
-    await session.setModel("haiku");
-    expect(session.getState()?.model?.current.baseModelId).toBe("haiku");
-    // The older apply's response arrives late, carrying its own (now stale) model.
+    const second = session.setModel("haiku");
+    await new Promise((r) => window.setTimeout(r, 0));
+    // The second dispatch is held until the first response lands.
+    expect(mock.setSessionModel).toHaveBeenCalledTimes(1);
     resolveFirst({
       model: { ...base.model!, current: { baseModelId: "sonnet", effort: null } },
       mode: null,
     });
     await first;
-    expect(session.getState()?.model?.current.baseModelId).toBe("haiku");
-    // Pin uncorrupted: a stale push reverting the newest pick is still rejected.
-    mock.emit({
+    await second;
+    expect(mock.setSessionModel).toHaveBeenCalledTimes(2);
+    expect(mock.setSessionModel).toHaveBeenLastCalledWith({
       sessionId: "acp-1",
-      update: {
-        sessionUpdate: "state_changed",
-        state: {
-          model: { ...base.model!, current: { baseModelId: "gpt-5", effort: null } },
-          mode: null,
-        },
-      },
+      modelId: "haiku",
     });
     expect(session.getState()?.model?.current.baseModelId).toBe("haiku");
+  });
+
+  it("a failed model apply does not wedge the serialization chain", async () => {
+    const mock = makeMockBackend();
+    const base: BackendState = {
+      model: {
+        current: { baseModelId: "gpt-5", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: "openai", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    mock.setSessionModel.mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce({
+      model: { ...base.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    });
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "opencode",
+      initialState: base,
+    });
+    await expect(session.setModel("sonnet")).rejects.toThrow("boom");
+    await session.setModel("sonnet");
+    expect(session.getState()?.model?.current.baseModelId).toBe("sonnet");
+  });
+
+  it("does not dispatch a prompt whose turn was cancelled while queued behind startup", async () => {
+    // Regression: a turn queued behind the seeded-model confirmation must not
+    // start a backend turn if the user cancelled while it waited — the prompt
+    // would run with no one watching.
+    const mock = makeMockBackend();
+    const reported: BackendState = {
+      model: {
+        current: { baseModelId: "opus", effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [
+          { baseModelId: "opus", name: "Opus", provider: "anthropic", effortOptions: [] },
+          { baseModelId: "sonnet", name: "Sonnet", provider: "anthropic", effortOptions: [] },
+        ],
+      },
+      mode: null,
+    };
+    mock.newSession.mockResolvedValueOnce({ sessionId: "acp-1", state: reported });
+    let resolveSetModel!: (s: BackendState) => void;
+    mock.setSessionModel.mockImplementationOnce(
+      () => new Promise<BackendState>((resolve) => (resolveSetModel = resolve))
+    );
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "claude",
+      defaultModelSelection: { baseModelId: "sonnet", effort: null },
+      getDescriptor: () => makeDescriptorWireWithoutEffort(),
+    });
+    await new Promise((r) => window.setTimeout(r, 0));
+    const { turn } = session.sendPrompt("hi");
+    await new Promise((r) => window.setTimeout(r, 0));
+    await session.cancel();
+    resolveSetModel({
+      model: { ...reported.model!, current: { baseModelId: "sonnet", effort: null } },
+      mode: null,
+    });
+    await expect(turn).resolves.toBe("cancelled");
+    expect(mock.prompt).not.toHaveBeenCalled();
   });
 
   it("queues a first prompt fired during the seeded-switch round-trip behind the confirmation", async () => {

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1211,6 +1211,17 @@ export class AgentSession {
       // already surfaced elsewhere — the prompt proceeds and fails as today.
       if (!this.startupConfirmed) {
         await this.ready.then(undefined, () => undefined);
+        // The session reports "idle" during the confirmation round-trip, so
+        // the user may have picked another model meanwhile; that apply rides
+        // `modelApplyChain` behind the seeded one, and `ready` doesn't cover
+        // it. Drain the chain (it never rejects) so the first prompt runs on
+        // the latest pick, re-checking in case a new apply landed while
+        // awaiting the previous tail.
+        let applies: Promise<unknown>;
+        do {
+          applies = this.modelApplyChain;
+          await applies;
+        } while (applies !== this.modelApplyChain);
         // The user may have cancelled or closed the chat while this turn was
         // queued — dispatching the prompt now would start a backend turn
         // nobody is watching.
@@ -1545,6 +1556,12 @@ export class AgentSession {
       this.flushQuestionResolvers();
       this.notifyMessages();
     }
+    // Abort locally before the backend round-trip so a turn queued behind the
+    // startup confirmation observes the cancellation synchronously — deferring
+    // it until `backend.cancel` resolves leaves a window where the queued
+    // turn's abort check passes and it dispatches a prompt that the earlier
+    // cancel notification doesn't cover.
+    this.abortController?.abort();
     try {
       await this.backend.cancel({ sessionId: this.backendSessionId });
     } catch (e) {

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -110,7 +110,7 @@ const EMPTY_ADDITIONAL_DIRECTORIES: string[] = Object.freeze([]) as unknown as s
  *
  * Only `baseModelId` is seeded — `effort` is left as the backend reported.
  * For descriptor-style backends (Claude) effort lives out-of-band and is
- * applied via `applyInitialSessionConfig` → `setConfigOption`; seeding it
+ * applied via `applyInitialSessionConfig` → `applyConfigOption`; seeding it
  * here would make that step see a matching value and silently skip the
  * real config write. For wire-effort backends (opencode-style) the
  * subsequent `setModel` call carries the user's effort through the
@@ -233,7 +233,7 @@ export interface AgentSessionStartOptions extends ProjectContextUpdatesHooks {
    * Persisted user preference to apply after the backend's initial session
    * state. The session seeds it optimistically so the first picker paint
    * shows the user's pick, then confirms with the backend via setModel
-   * (and, for descriptor-style backends, setConfigOption — handled by the
+   * (and, for descriptor-style backends, applyConfigOption — handled by the
    * manager's `applyInitialSessionConfig` hook).
    */
   defaultModelSelection?: ModelSelection;
@@ -316,7 +316,7 @@ export interface AgentSessionStateOptions extends ProjectContextUpdatesHooks {
 export type StateProvenance =
   /** Optimistic display seed, or a revert to the last reported state. */
   | "seed"
-  /** Response to a user model apply (`setModel` / `setConfigOption`). */
+  /** Response to a user model apply (`setModel` / a confirmed config option). */
   | "confirmed"
   /** Any other backend snapshot (`setMode` response, `state_changed` push). */
   | "reported";
@@ -415,8 +415,8 @@ export class AgentSession {
    */
   private currentState: BackendState | null = null;
   /**
-   * The model base id the user/seed last explicitly applied via setModel /
-   * setConfigOption. Used to reject a stale "reported" snapshot (state_changed
+   * The model base id the user/seed last explicitly applied via setModel or
+   * a confirmed applyConfigOption. Used to reject a stale "reported" snapshot (state_changed
    * push, setMode response) that would silently revert it (these backends
    * never self-switch the model).
    */
@@ -692,7 +692,7 @@ export class AgentSession {
   async applyModelWireId(wireId: string): Promise<void> {
     const apply = this.currentState?.model?.apply;
     if (apply?.kind === "setConfigOption") {
-      await this.setConfigOption(apply.configId, wireId);
+      await this.applyConfigOption(apply.configId, wireId, "confirmed");
       return;
     }
     await this.setModel(wireId);
@@ -759,22 +759,15 @@ export class AgentSession {
   }
 
   /**
-   * Set a session configuration option carrying a user model/effort apply
-   * (effort, or the model option on config-option-backed catalogs). The
-   * response is a model confirmation, so it re-pins the applied model. Mode
-   * changes routed through a config option must call `applyConfigOption`
-   * with `"reported"` instead — their response snapshots are not model
-   * confirmations, and a stale one must neither clobber the applied model
-   * nor re-pin `lastAppliedModelBaseId` to the stale value.
-   */
-  async setConfigOption(configId: string, value: string): Promise<void> {
-    return this.applyConfigOption(configId, value, "confirmed");
-  }
-
-  /**
-   * Config-option round-trip; `provenance` carries the caller's intent.
-   * Reuses `notifyModelChanged` because the picker treats model and
-   * configOption changes as one channel.
+   * Config-option round-trip; `provenance` carries the caller's intent. A
+   * user model/effort apply (effort, or the model option on config-option-
+   * backed catalogs) passes `"confirmed"` — the response is a model
+   * confirmation and re-pins the applied model. A mode change routed through
+   * a config option passes `"reported"` — its response snapshot is not a
+   * model confirmation, and a stale one must neither clobber the applied
+   * model nor re-pin `lastAppliedModelBaseId` to the stale value. Reuses
+   * `notifyModelChanged` because the picker treats model and configOption
+   * changes as one channel.
    */
   async applyConfigOption(
     configId: string,

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -415,12 +415,14 @@ export class AgentSession {
    */
   private currentState: BackendState | null = null;
   /**
-   * The model base id the user/seed last explicitly applied via setModel or
-   * a confirmed setConfigOption. Used to reject a stale "reported" snapshot (state_changed
-   * push, setMode response) that would silently revert it (these backends
-   * never self-switch the model).
+   * The model selection the user/seed last explicitly applied via setModel or
+   * a confirmed setConfigOption. Used to reject a stale "reported" snapshot
+   * (state_changed push, setMode response) that would silently revert it
+   * (these backends never self-switch the model). Effort rides along so a
+   * rejected revert restores the whole selection instead of grafting the
+   * stale model's effort onto the applied base.
    */
-  private lastAppliedModelBaseId: string | null = null;
+  private lastAppliedModel: ModelSelection | null = null;
   private label: string | null = null;
   // Tracks who set the current label so an agent-pushed `session_info_update`
   // can't clobber a label the user explicitly chose via Rename.
@@ -653,10 +655,12 @@ export class AgentSession {
     this.currentState = next && provenance === "reported" ? this.reconcileAppliedModel(next) : next;
   }
 
-  /** Record the model just applied so a stale backend push can't revert it. */
+  /** Record the selection just applied so a stale backend push can't revert it. */
   private rememberAppliedModel(state: BackendState): void {
-    const base = state.model?.current.baseModelId;
-    if (base) this.lastAppliedModelBaseId = base;
+    const current = state.model?.current;
+    if (current?.baseModelId) {
+      this.lastAppliedModel = { baseModelId: current.baseModelId, effort: current.effort ?? null };
+    }
   }
 
   /**
@@ -665,19 +669,25 @@ export class AgentSession {
    * into state_changed by the ACP layer) that can race a model switch and carry
    * the pre-switch default. These backends never self-switch the model, so when
    * an incoming state regresses the model away from the last applied selection —
-   * and the backend still offers that model — keep it. Every other dimension
-   * (effort, mode, availableModels) stays authoritative.
+   * and the backend still offers that model — keep the whole applied selection:
+   * restoring only the base would graft the stale model's effort onto it (e.g.
+   * `sonnet` + a leftover `gpt-5` "high"), a selection the backend never
+   * confirmed. When the incoming model agrees with the applied one, the push is
+   * trusted verbatim — effort changes riding it are honored — and mode and
+   * availableModels stay authoritative either way.
    */
   private reconcileAppliedModel(incoming: BackendState): BackendState {
-    const applied = this.lastAppliedModelBaseId;
+    const applied = this.lastAppliedModel;
     if (applied === null || !incoming.model) return incoming;
-    if (incoming.model.current.baseModelId === applied) return incoming;
-    if (!incoming.model.availableModels.some((m) => m.baseModelId === applied)) return incoming;
+    if (incoming.model.current.baseModelId === applied.baseModelId) return incoming;
+    if (!incoming.model.availableModels.some((m) => m.baseModelId === applied.baseModelId)) {
+      return incoming;
+    }
     return {
       ...incoming,
       model: {
         ...incoming.model,
-        current: { ...incoming.model.current, baseModelId: applied },
+        current: { ...incoming.model.current, ...applied },
       },
     };
   }
@@ -765,7 +775,7 @@ export class AgentSession {
    * confirmation and re-pins the applied model. A mode change routed through
    * a config option passes `"reported"` — its response snapshot is not a
    * model confirmation, and a stale one must neither clobber the applied
-   * model nor re-pin `lastAppliedModelBaseId` to the stale value. Reuses
+   * model nor re-pin `lastAppliedModel` to the stale value. Reuses
    * `notifyModelChanged` because the picker treats model and configOption
    * changes as one channel.
    */

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -313,7 +313,7 @@ export interface AgentSessionStateOptions extends ProjectContextUpdatesHooks {
  * self-switch it — so only a `"confirmed"` write may move the pinned model,
  * and `"reported"` snapshots are reconciled against it.
  */
-export type StateProvenance =
+type StateProvenance =
   /** Optimistic display seed, or a revert to the last reported state. */
   | "seed"
   /** Response to a user model apply (`setModel` / a confirmed config option). */

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -759,11 +759,36 @@ export class AgentSession {
   }
 
   /**
-   * Set a session configuration option (e.g. effort). Reuses
-   * `notifyModelChanged` because the picker treats model and configOption
-   * changes as one channel.
+   * Set a session configuration option carrying a user model/effort apply
+   * (effort, or the model option on config-option-backed catalogs). The
+   * response is a model confirmation, so it re-pins the applied model. Mode
+   * changes routed through a config option must use `setModeConfigOption`
+   * instead — their response snapshots are not model confirmations.
    */
   async setConfigOption(configId: string, value: string): Promise<void> {
+    return this.applyConfigOption(configId, value, "confirmed");
+  }
+
+  /**
+   * Apply a config-option-backed mode change (opencode). The response is a
+   * whole-state snapshot, not a user model apply, so it lands as `"reported"`:
+   * a stale model in it can neither clobber the applied model nor re-pin
+   * `lastAppliedModelBaseId` to the stale value.
+   */
+  async setModeConfigOption(configId: string, value: string): Promise<void> {
+    return this.applyConfigOption(configId, value, "reported");
+  }
+
+  /**
+   * Shared config-option round-trip; `provenance` carries the caller's intent.
+   * Reuses `notifyModelChanged` because the picker treats model and
+   * configOption changes as one channel.
+   */
+  private async applyConfigOption(
+    configId: string,
+    value: string,
+    provenance: StateProvenance
+  ): Promise<void> {
     if (this.getStatus() === "closed") throw new Error("Session is closed");
     if (!this.backendSessionId) throw new Error("Session is still starting");
     const next = await this.backend.setSessionConfigOption({
@@ -771,7 +796,7 @@ export class AgentSession {
       configId,
       value,
     });
-    this.applyState(next, "confirmed");
+    this.applyState(next, provenance);
     this.notifyModelChanged();
     this.clearCurrentPlanIfModeLeft();
   }

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -313,7 +313,7 @@ export interface AgentSessionStateOptions extends ProjectContextUpdatesHooks {
  * self-switch it — so only a `"confirmed"` write may move the pinned model,
  * and `"reported"` snapshots are reconciled against it.
  */
-type StateProvenance =
+export type StateProvenance =
   /** Optimistic display seed, or a revert to the last reported state. */
   | "seed"
   /** Response to a user model apply (`setModel` / `setConfigOption`). */
@@ -762,29 +762,21 @@ export class AgentSession {
    * Set a session configuration option carrying a user model/effort apply
    * (effort, or the model option on config-option-backed catalogs). The
    * response is a model confirmation, so it re-pins the applied model. Mode
-   * changes routed through a config option must use `setModeConfigOption`
-   * instead — their response snapshots are not model confirmations.
+   * changes routed through a config option must call `applyConfigOption`
+   * with `"reported"` instead — their response snapshots are not model
+   * confirmations, and a stale one must neither clobber the applied model
+   * nor re-pin `lastAppliedModelBaseId` to the stale value.
    */
   async setConfigOption(configId: string, value: string): Promise<void> {
     return this.applyConfigOption(configId, value, "confirmed");
   }
 
   /**
-   * Apply a config-option-backed mode change (opencode). The response is a
-   * whole-state snapshot, not a user model apply, so it lands as `"reported"`:
-   * a stale model in it can neither clobber the applied model nor re-pin
-   * `lastAppliedModelBaseId` to the stale value.
-   */
-  async setModeConfigOption(configId: string, value: string): Promise<void> {
-    return this.applyConfigOption(configId, value, "reported");
-  }
-
-  /**
-   * Shared config-option round-trip; `provenance` carries the caller's intent.
+   * Config-option round-trip; `provenance` carries the caller's intent.
    * Reuses `notifyModelChanged` because the picker treats model and
    * configOption changes as one channel.
    */
-  private async applyConfigOption(
+  async applyConfigOption(
     configId: string,
     value: string,
     provenance: StateProvenance

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -667,17 +667,17 @@ export class AgentSession {
       : null;
     const originalEffort = originalState.model?.current.effort ?? null;
     if (encoded === originalEncoded && selection.effort === originalEffort) return;
-    // Config-option backends (opencode ≥1.15.13) guard their model switch on
-    // the *current* state, and the optimistic baseModelId seed already shows
-    // the target — which would skip the real switch and strand the backend on
-    // its originally-reported model. Drop the seed first so `applySelection`
-    // sees the true state and issues the switch. setModel-style backends always
-    // issue the round-trip regardless of current, so their optimistic seed can
-    // stand and the picker doesn't blink.
     const configOptionBacked = originalState.model?.apply?.kind === "setConfigOption";
-    if (configOptionBacked) {
-      this.currentState = originalState;
-    }
+    // Drop the optimistic baseModelId seed before delegating to applySelection.
+    // Descriptor applySelection impls may guard their model write on the session's
+    // *current* model (Claude via setModel guards on getState().current; config-
+    // option opencode guards on the current option value). The seed already shows
+    // the target, so without this they'd see "already there" and skip the real
+    // switch, stranding the backend on its startup default. Restoring the true
+    // reported state makes the guard fire; no blink results because no notify
+    // fires between this reset and the confirming setModel below. Guard-less
+    // setModel backends round-trip regardless, so they're unaffected.
+    this.currentState = originalState;
     try {
       // Clearing effort to the agent default on a config-option backend whose
       // process baked a concrete effort: the base already matches, so

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -673,13 +673,21 @@ export class AgentSession {
    * restoring only the base would graft the stale model's effort onto it (e.g.
    * `sonnet` + a leftover `gpt-5` "high"), a selection the backend never
    * confirmed. When the incoming model agrees with the applied one, the push is
-   * trusted verbatim — effort changes riding it are honored — and mode and
+   * trusted verbatim — effort changes riding it are honored, and the pin's
+   * effort is refreshed to match so a later stale-model snapshot restores this
+   * latest trusted selection rather than an obsolete effort. Mode and
    * availableModels stay authoritative either way.
    */
   private reconcileAppliedModel(incoming: BackendState): BackendState {
     const applied = this.lastAppliedModel;
     if (applied === null || !incoming.model) return incoming;
-    if (incoming.model.current.baseModelId === applied.baseModelId) return incoming;
+    if (incoming.model.current.baseModelId === applied.baseModelId) {
+      this.lastAppliedModel = {
+        baseModelId: applied.baseModelId,
+        effort: incoming.model.current.effort ?? null,
+      };
+      return incoming;
+    }
     if (!incoming.model.availableModels.some((m) => m.baseModelId === applied.baseModelId)) {
       return incoming;
     }
@@ -740,16 +748,14 @@ export class AgentSession {
     const originalEffort = originalState.model?.current.effort ?? null;
     if (encoded === originalEncoded && selection.effort === originalEffort) return;
     const configOptionBacked = originalState.model?.apply?.kind === "setConfigOption";
-    // Drop the optimistic baseModelId seed before delegating to applySelection.
-    // Descriptor applySelection impls may guard their model write on the session's
-    // *current* model (Claude via setModel guards on getState().current; config-
-    // option opencode guards on the current option value). The seed already shows
-    // the target, so without this they'd see "already there" and skip the real
-    // switch, stranding the backend on its startup default. Restoring the true
-    // reported state makes the guard fire; no blink results because no notify
-    // fires between this reset and the confirming setModel below. Guard-less
-    // setModel backends round-trip regardless, so they're unaffected.
-    this.applyState(originalState, "seed");
+    // The session state keeps the optimistic seed while the switch is in
+    // flight: initialize() has already flipped the status and notified, so any
+    // render during the round-trip reads whatever state is current — resetting
+    // it here would flash the backend default until the confirmation lands.
+    // Descriptor guards that skip redundant model writes must therefore not
+    // read the seeded session state (it already shows the target, so they'd
+    // see "already there" and skip the real switch); `originalState` is passed
+    // to applySelection below as the reported truth to compare against.
     try {
       // Clearing effort to the agent default on a config-option backend whose
       // process baked a concrete effort: the base already matches, so
@@ -760,7 +766,7 @@ export class AgentSession {
         await this.applyModelWireId(descriptor.wire.encode(selection));
         return;
       }
-      await descriptor.applySelection(this, selection);
+      await descriptor.applySelection(this, selection, originalState);
     } catch (e) {
       logWarn(`[AgentMode] could not apply seeded selection ${encoded}; reverting seed`, e);
       this.applyState(originalState, "seed");
@@ -769,15 +775,16 @@ export class AgentSession {
   }
 
   /**
-   * Config-option round-trip; `provenance` carries the caller's intent. A
-   * user model/effort apply (effort, or the model option on config-option-
-   * backed catalogs) passes `"confirmed"` — the response is a model
-   * confirmation and re-pins the applied model. A mode change routed through
-   * a config option passes `"reported"` — its response snapshot is not a
-   * model confirmation, and a stale one must neither clobber the applied
-   * model nor re-pin `lastAppliedModel` to the stale value. Reuses
-   * `notifyModelChanged` because the picker treats model and configOption
-   * changes as one channel.
+   * Config-option round-trip; `provenance` carries the caller's intent. Only
+   * a user *model* apply (the model option on config-option-backed catalogs)
+   * passes `"confirmed"` — its response is a model confirmation and re-pins
+   * the applied model. Effort and mode writes pass `"reported"`: their
+   * response snapshots are not model confirmations, and a stale one must
+   * neither clobber the applied model nor re-pin `lastAppliedModel` to the
+   * stale value. An effort response that agrees on the pinned base still
+   * lands verbatim and refreshes the pin's effort via `reconcileAppliedModel`.
+   * Reuses `notifyModelChanged` because the picker treats model and
+   * configOption changes as one channel.
    */
   async setConfigOption(
     configId: string,

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -110,7 +110,7 @@ const EMPTY_ADDITIONAL_DIRECTORIES: string[] = Object.freeze([]) as unknown as s
  *
  * Only `baseModelId` is seeded — `effort` is left as the backend reported.
  * For descriptor-style backends (Claude) effort lives out-of-band and is
- * applied via `applyInitialSessionConfig` → `applyConfigOption`; seeding it
+ * applied via `applyInitialSessionConfig` → `setConfigOption`; seeding it
  * here would make that step see a matching value and silently skip the
  * real config write. For wire-effort backends (opencode-style) the
  * subsequent `setModel` call carries the user's effort through the
@@ -233,7 +233,7 @@ export interface AgentSessionStartOptions extends ProjectContextUpdatesHooks {
    * Persisted user preference to apply after the backend's initial session
    * state. The session seeds it optimistically so the first picker paint
    * shows the user's pick, then confirms with the backend via setModel
-   * (and, for descriptor-style backends, applyConfigOption — handled by the
+   * (and, for descriptor-style backends, setConfigOption — handled by the
    * manager's `applyInitialSessionConfig` hook).
    */
   defaultModelSelection?: ModelSelection;
@@ -416,7 +416,7 @@ export class AgentSession {
   private currentState: BackendState | null = null;
   /**
    * The model base id the user/seed last explicitly applied via setModel or
-   * a confirmed applyConfigOption. Used to reject a stale "reported" snapshot (state_changed
+   * a confirmed setConfigOption. Used to reject a stale "reported" snapshot (state_changed
    * push, setMode response) that would silently revert it (these backends
    * never self-switch the model).
    */
@@ -692,7 +692,7 @@ export class AgentSession {
   async applyModelWireId(wireId: string): Promise<void> {
     const apply = this.currentState?.model?.apply;
     if (apply?.kind === "setConfigOption") {
-      await this.applyConfigOption(apply.configId, wireId, "confirmed");
+      await this.setConfigOption(apply.configId, wireId, "confirmed");
       return;
     }
     await this.setModel(wireId);
@@ -769,7 +769,7 @@ export class AgentSession {
    * `notifyModelChanged` because the picker treats model and configOption
    * changes as one channel.
    */
-  async applyConfigOption(
+  async setConfigOption(
     configId: string,
     value: string,
     provenance: StateProvenance

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -416,8 +416,9 @@ export class AgentSession {
   private currentState: BackendState | null = null;
   /**
    * The model base id the user/seed last explicitly applied via setModel /
-   * setConfigOption. Used to reject a stale `state_changed` push that would
-   * silently revert it (these backends never self-switch the model).
+   * setConfigOption. Used to reject a stale "reported" snapshot (state_changed
+   * push, setMode response) that would silently revert it (these backends
+   * never self-switch the model).
    */
   private lastAppliedModelBaseId: string | null = null;
   private label: string | null = null;

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -308,6 +308,20 @@ export interface AgentSessionStateOptions extends ProjectContextUpdatesHooks {
 }
 
 /**
+ * Where a `BackendState` write originates; `applyState` derives its merge
+ * policy from this. The model dimension is user-owned — backends never
+ * self-switch it — so only a `"confirmed"` write may move the pinned model,
+ * and `"reported"` snapshots are reconciled against it.
+ */
+type StateProvenance =
+  /** Optimistic display seed, or a revert to the last reported state. */
+  | "seed"
+  /** Response to a user model apply (`setModel` / `setConfigOption`). */
+  | "confirmed"
+  /** Any other backend snapshot (`setMode` response, `state_changed` push). */
+  | "reported";
+
+/**
  * Per-chat Agent Mode session. Owns its `AgentMessageStore`, the lifecycle
  * of one backend session id, and the `AbortController` that cancels in-flight
  * turns.
@@ -497,7 +511,7 @@ export class AgentSession {
     if ("backendSessionId" in opts) {
       this.backendSessionId = opts.backendSessionId;
       const originalState = opts.initialState ?? null;
-      this.currentState = seedSelectionIntoState(originalState, opts.defaultModelSelection);
+      this.applyState(seedSelectionIntoState(originalState, opts.defaultModelSelection), "seed");
       this.unregisterSessionHandler = this.backend.registerSessionHandler(
         opts.backendSessionId,
         (event) => this.handleSessionEvent(event)
@@ -516,9 +530,9 @@ export class AgentSession {
       // Eagerly seed from the preloader cache so the picker doesn't fall
       // back to the prior session's `current` while `backend.newSession` is
       // in flight. `initialize()` replaces this with the agent's response.
-      this.currentState = seedSelectionIntoState(
-        opts.initialCachedState ?? null,
-        opts.defaultModelSelection
+      this.applyState(
+        seedSelectionIntoState(opts.initialCachedState ?? null, opts.defaultModelSelection),
+        "seed"
       );
       this.ready = this.initialize(opts);
     }
@@ -572,7 +586,7 @@ export class AgentSession {
         : "agent did not report model state";
       logInfo(`[AgentMode] session ${resp.sessionId} ${modelLog}`);
       this.backendSessionId = resp.sessionId;
-      this.currentState = seedSelectionIntoState(resp.state, defaultModelSelection);
+      this.applyState(seedSelectionIntoState(resp.state, defaultModelSelection), "seed");
       this.unregisterSessionHandler = this.backend.registerSessionHandler(resp.sessionId, (event) =>
         this.handleSessionEvent(event)
       );
@@ -622,9 +636,20 @@ export class AgentSession {
       sessionId: this.backendSessionId,
       modelId,
     });
-    this.currentState = next;
-    this.rememberAppliedModel(next);
+    this.applyState(next, "confirmed");
     this.notifyModelChanged();
+  }
+
+  /**
+   * Sole write path for `currentState`. Centralizes the per-dimension
+   * ownership policy so no call site can bypass it: a `"confirmed"` response
+   * re-pins the user-applied model, a `"reported"` snapshot has its model
+   * dimension reconciled against that pin (see `reconcileAppliedModel`), and
+   * a `"seed"` is trusted verbatim as transient display state.
+   */
+  private applyState(next: BackendState | null, provenance: StateProvenance): void {
+    if (next && provenance === "confirmed") this.rememberAppliedModel(next);
+    this.currentState = next && provenance === "reported" ? this.reconcileAppliedModel(next) : next;
   }
 
   /** Record the model just applied so a stale backend push can't revert it. */
@@ -713,7 +738,7 @@ export class AgentSession {
     // reported state makes the guard fire; no blink results because no notify
     // fires between this reset and the confirming setModel below. Guard-less
     // setModel backends round-trip regardless, so they're unaffected.
-    this.currentState = originalState;
+    this.applyState(originalState, "seed");
     try {
       // Clearing effort to the agent default on a config-option backend whose
       // process baked a concrete effort: the base already matches, so
@@ -727,7 +752,7 @@ export class AgentSession {
       await descriptor.applySelection(this, selection);
     } catch (e) {
       logWarn(`[AgentMode] could not apply seeded selection ${encoded}; reverting seed`, e);
-      this.currentState = originalState;
+      this.applyState(originalState, "seed");
       this.notifyModelChanged();
     }
   }
@@ -745,8 +770,7 @@ export class AgentSession {
       configId,
       value,
     });
-    this.currentState = next;
-    this.rememberAppliedModel(next);
+    this.applyState(next, "confirmed");
     this.notifyModelChanged();
     this.clearCurrentPlanIfModeLeft();
   }
@@ -766,7 +790,7 @@ export class AgentSession {
       sessionId: this.backendSessionId,
       modeId,
     });
-    this.currentState = next;
+    this.applyState(next, "reported");
     this.notifyModelChanged();
     this.clearCurrentPlanIfModeLeft();
   }
@@ -1776,7 +1800,7 @@ export class AgentSession {
       return;
     }
     if (update.sessionUpdate === "state_changed") {
-      this.currentState = this.reconcileAppliedModel(update.state);
+      this.applyState(update.state, "reported");
       this.notifyModelChanged();
       this.clearCurrentPlanIfModeLeft();
       return;

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -424,13 +424,15 @@ export class AgentSession {
    */
   private lastAppliedModel: ModelSelection | null = null;
   /**
-   * Monotonic id of the newest in-flight user model apply. Concurrent applies
-   * are not serialized, so an older request's response can resolve after a
-   * newer one; only the newest generation's response is a model confirmation —
-   * a superseded response is demoted to a "reported" snapshot and reconciled,
-   * so it can't re-pin the older model over the user's latest pick.
+   * Serializes user model applies. Rapid picks previously dispatched
+   * concurrent requests whose responses could complete out of order — the
+   * ACP layer's wire cache is overwritten by each completion with its own
+   * modelId, and a backend processing them out of order could genuinely end
+   * on the older pick, so display, cache, and backend could all disagree.
+   * Sequencing dispatch (the next request is sent only after the previous
+   * response lands) makes the last pick the last write everywhere.
    */
-  private modelApplyGeneration = 0;
+  private modelApplyChain: Promise<unknown> = Promise.resolve();
   /**
    * Flips true once `ready` settles. Lets `runTurn` gate only turns fired
    * during the startup window on the seeded-model confirmation while keeping
@@ -658,13 +660,26 @@ export class AgentSession {
   async setModel(modelId: string): Promise<void> {
     if (this.getStatus() === "closed") throw new Error("Session is closed");
     if (!this.backendSessionId) throw new Error("Session is still starting");
-    const generation = ++this.modelApplyGeneration;
-    const next = await this.backend.setSessionModel({
-      sessionId: this.backendSessionId,
-      modelId,
+    const sessionId = this.backendSessionId;
+    await this.enqueueModelApply(async () => {
+      const next = await this.backend.setSessionModel({ sessionId, modelId });
+      this.applyState(next, "confirmed");
+      this.notifyModelChanged();
     });
-    this.applyState(next, generation === this.modelApplyGeneration ? "confirmed" : "reported");
-    this.notifyModelChanged();
+  }
+
+  /**
+   * Append a model apply to the serialization chain. The chain never rejects
+   * (each caller receives its own failure; the next apply runs regardless),
+   * so a failed switch can't wedge every later one.
+   */
+  private enqueueModelApply<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.modelApplyChain.then(fn, fn);
+    this.modelApplyChain = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
   }
 
   /**
@@ -854,16 +869,21 @@ export class AgentSession {
   ): Promise<void> {
     if (this.getStatus() === "closed") throw new Error("Session is closed");
     if (!this.backendSessionId) throw new Error("Session is still starting");
-    const generation = provenance === "confirmed" ? ++this.modelApplyGeneration : null;
-    const next = await this.backend.setSessionConfigOption({
-      sessionId: this.backendSessionId,
-      configId,
-      value,
-    });
-    const superseded = generation !== null && generation !== this.modelApplyGeneration;
-    this.applyState(next, superseded ? "reported" : provenance);
-    this.notifyModelChanged();
-    this.clearCurrentPlanIfModeLeft();
+    const sessionId = this.backendSessionId;
+    const dispatch = async () => {
+      const next = await this.backend.setSessionConfigOption({ sessionId, configId, value });
+      this.applyState(next, provenance);
+      this.notifyModelChanged();
+      this.clearCurrentPlanIfModeLeft();
+    };
+    // Model applies ("confirmed") ride the serialization chain — see
+    // `modelApplyChain`. Effort/mode writes ("reported") stay unserialized;
+    // their responses are reconciled snapshots either way.
+    if (provenance === "confirmed") {
+      await this.enqueueModelApply(dispatch);
+      return;
+    }
+    await dispatch();
   }
 
   /**
@@ -1189,7 +1209,21 @@ export class AgentSession {
       // (a settled promise still costs a microtask, and callers rely on
       // `backend.prompt` being invoked synchronously). A failed startup is
       // already surfaced elsewhere — the prompt proceeds and fails as today.
-      if (!this.startupConfirmed) await this.ready.then(undefined, () => undefined);
+      if (!this.startupConfirmed) {
+        await this.ready.then(undefined, () => undefined);
+        // The user may have cancelled or closed the chat while this turn was
+        // queued — dispatching the prompt now would start a backend turn
+        // nobody is watching.
+        if (this.disposed || this.abortController?.signal.aborted) {
+          if (placeholderId && this.store.markTurnComplete(placeholderId, "cancelled")) {
+            this.notifyMessages();
+          }
+          this.settledStream = null;
+          this.currentMessageIds = new Set();
+          if (this.placeholderId === placeholderId) this.placeholderId = null;
+          return "cancelled";
+        }
+      }
       // Extract live Web Viewer content (reader-mode markdown, YouTube
       // transcripts) just before the prompt is built so it reflects the page
       // at send/flush time, not at compose time. Only take the async hop when

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -423,6 +423,21 @@ export class AgentSession {
    * stale model's effort onto the applied base.
    */
   private lastAppliedModel: ModelSelection | null = null;
+  /**
+   * Monotonic id of the newest in-flight user model apply. Concurrent applies
+   * are not serialized, so an older request's response can resolve after a
+   * newer one; only the newest generation's response is a model confirmation —
+   * a superseded response is demoted to a "reported" snapshot and reconciled,
+   * so it can't re-pin the older model over the user's latest pick.
+   */
+  private modelApplyGeneration = 0;
+  /**
+   * Flips true once `ready` settles. Lets `runTurn` gate only turns fired
+   * during the startup window on the seeded-model confirmation while keeping
+   * `backend.prompt` synchronously invoked for every later turn (callers rely
+   * on that timing).
+   */
+  private startupConfirmed = false;
   private label: string | null = null;
   // Tracks who set the current label so an agent-pushed `session_info_update`
   // can't clobber a label the user explicitly chose via Rename.
@@ -525,10 +540,14 @@ export class AgentSession {
       // Gate `ready` on the model confirmation round-trip so `sendPrompt`
       // can't fire on the probe's model before the user's persisted
       // selection is applied to the backend.
-      this.ready =
-        opts.defaultModelSelection && originalState
-          ? this.confirmSeededSelection(opts.defaultModelSelection, originalState)
-          : Promise.resolve();
+      if (opts.defaultModelSelection && originalState) {
+        this.ready = this.confirmSeededSelection(opts.defaultModelSelection, originalState);
+      } else {
+        this.ready = Promise.resolve();
+        // Already settled — flip synchronously so the first turn doesn't take
+        // the queued path (its callers rely on a synchronous prompt dispatch).
+        this.startupConfirmed = true;
+      }
     } else {
       // Eagerly seed from the preloader cache so the picker doesn't fall
       // back to the prior session's `current` while `backend.newSession` is
@@ -539,6 +558,10 @@ export class AgentSession {
       );
       this.ready = this.initialize(opts);
     }
+    const confirm = () => {
+      this.startupConfirmed = true;
+    };
+    void this.ready.then(confirm, confirm);
   }
 
   /**
@@ -635,11 +658,12 @@ export class AgentSession {
   async setModel(modelId: string): Promise<void> {
     if (this.getStatus() === "closed") throw new Error("Session is closed");
     if (!this.backendSessionId) throw new Error("Session is still starting");
+    const generation = ++this.modelApplyGeneration;
     const next = await this.backend.setSessionModel({
       sessionId: this.backendSessionId,
       modelId,
     });
-    this.applyState(next, "confirmed");
+    this.applyState(next, generation === this.modelApplyGeneration ? "confirmed" : "reported");
     this.notifyModelChanged();
   }
 
@@ -830,12 +854,14 @@ export class AgentSession {
   ): Promise<void> {
     if (this.getStatus() === "closed") throw new Error("Session is closed");
     if (!this.backendSessionId) throw new Error("Session is still starting");
+    const generation = provenance === "confirmed" ? ++this.modelApplyGeneration : null;
     const next = await this.backend.setSessionConfigOption({
       sessionId: this.backendSessionId,
       configId,
       value,
     });
-    this.applyState(next, provenance);
+    const superseded = generation !== null && generation !== this.modelApplyGeneration;
+    this.applyState(next, superseded ? "reported" : provenance);
     this.notifyModelChanged();
     this.clearCurrentPlanIfModeLeft();
   }
@@ -1156,6 +1182,14 @@ export class AgentSession {
         ]);
       }
 
+      // The status gate opens ("idle") before the seeded-model confirmation
+      // round-trip completes, so a fast first submit could otherwise race the
+      // switch and run on the backend default. Queue such a turn behind
+      // `ready`; the flag keeps every later turn on the synchronous path
+      // (a settled promise still costs a microtask, and callers rely on
+      // `backend.prompt` being invoked synchronously). A failed startup is
+      // already surfaced elsewhere — the prompt proceeds and fails as today.
+      if (!this.startupConfirmed) await this.ready.then(undefined, () => undefined);
       // Extract live Web Viewer content (reader-mode markdown, YouTube
       // transcripts) just before the prompt is built so it reflects the page
       // at send/flush time, not at compose time. Only take the async hop when

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -400,6 +400,12 @@ export class AgentSession {
    * `setSession*` responses.
    */
   private currentState: BackendState | null = null;
+  /**
+   * The model base id the user/seed last explicitly applied via setModel /
+   * setConfigOption. Used to reject a stale `state_changed` push that would
+   * silently revert it (these backends never self-switch the model).
+   */
+  private lastAppliedModelBaseId: string | null = null;
   private label: string | null = null;
   // Tracks who set the current label so an agent-pushed `session_info_update`
   // can't clobber a label the user explicitly chose via Rename.
@@ -617,7 +623,37 @@ export class AgentSession {
       modelId,
     });
     this.currentState = next;
+    this.rememberAppliedModel(next);
     this.notifyModelChanged();
+  }
+
+  /** Record the model just applied so a stale backend push can't revert it. */
+  private rememberAppliedModel(state: BackendState): void {
+    const base = state.model?.current.baseModelId;
+    if (base) this.lastAppliedModelBaseId = base;
+  }
+
+  /**
+   * A `state_changed` push must not silently revert the user's just-applied
+   * model. opencode broadcasts config_option_update notifications (synthesized
+   * into state_changed by the ACP layer) that can race a model switch and carry
+   * the pre-switch default. These backends never self-switch the model, so when
+   * an incoming state regresses the model away from the last applied selection —
+   * and the backend still offers that model — keep it. Every other dimension
+   * (effort, mode, availableModels) stays authoritative.
+   */
+  private reconcileAppliedModel(incoming: BackendState): BackendState {
+    const applied = this.lastAppliedModelBaseId;
+    if (applied === null || !incoming.model) return incoming;
+    if (incoming.model.current.baseModelId === applied) return incoming;
+    if (!incoming.model.availableModels.some((m) => m.baseModelId === applied)) return incoming;
+    return {
+      ...incoming,
+      model: {
+        ...incoming.model,
+        current: { ...incoming.model.current, baseModelId: applied },
+      },
+    };
   }
 
   /**
@@ -710,6 +746,7 @@ export class AgentSession {
       value,
     });
     this.currentState = next;
+    this.rememberAppliedModel(next);
     this.notifyModelChanged();
     this.clearCurrentPlanIfModeLeft();
   }
@@ -1739,7 +1776,7 @@ export class AgentSession {
       return;
     }
     if (update.sessionUpdate === "state_changed") {
-      this.currentState = update.state;
+      this.currentState = this.reconcileAppliedModel(update.state);
       this.notifyModelChanged();
       this.clearCurrentPlanIfModeLeft();
       return;

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -677,6 +677,16 @@ export class AgentSession {
    * effort is refreshed to match so a later stale-model snapshot restores this
    * latest trusted selection rather than an obsolete effort. Mode and
    * availableModels stay authoritative either way.
+   *
+   * Two boundary rules keep the merged state honest. A snapshot accepted
+   * because the applied model vanished from the catalog also clears the pin —
+   * the backend abandoned that model, so re-offering it later must not graft
+   * it back over the fallback actually in use. And when a stale revert is
+   * rejected, the active-model-specific metadata (the pinned entry's
+   * effortOptions and the apply spec's effortConfigId, which the translator
+   * derives from the snapshot's *own* active model) is carried over from the
+   * previous state, so the picker's effort selector and dispatch target keep
+   * describing the model actually shown.
    */
   private reconcileAppliedModel(incoming: BackendState): BackendState {
     const applied = this.lastAppliedModel;
@@ -689,12 +699,39 @@ export class AgentSession {
       return incoming;
     }
     if (!incoming.model.availableModels.some((m) => m.baseModelId === applied.baseModelId)) {
+      this.lastAppliedModel = null;
       return incoming;
     }
+    const prevModel = this.currentState?.model;
+    const prevCoherent = prevModel?.current.baseModelId === applied.baseModelId ? prevModel : null;
+    const prevEntry = prevCoherent?.availableModels.find(
+      (m) => m.baseModelId === applied.baseModelId
+    );
+    const availableModels = incoming.model.availableModels.map((m) =>
+      m.baseModelId === applied.baseModelId &&
+      m.effortOptions.length === 0 &&
+      prevEntry &&
+      prevEntry.effortOptions.length > 0
+        ? { ...m, effortOptions: prevEntry.effortOptions }
+        : m
+    );
+    const apply =
+      incoming.model.apply.kind === "setConfigOption" &&
+      prevCoherent?.apply.kind === "setConfigOption"
+        ? {
+            kind: "setConfigOption" as const,
+            configId: incoming.model.apply.configId,
+            ...(prevCoherent.apply.effortConfigId
+              ? { effortConfigId: prevCoherent.apply.effortConfigId }
+              : {}),
+          }
+        : incoming.model.apply;
     return {
       ...incoming,
       model: {
         ...incoming.model,
+        apply,
+        availableModels,
         current: { ...incoming.model.current, ...applied },
       },
     };

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -171,7 +171,7 @@ function makeMockSession(overrides: {
     dispose: mockSessionDispose,
     setModel: jest.fn(),
     setMode: jest.fn(),
-    setConfigOption: jest.fn(),
+    applyConfigOption: jest.fn(),
     getLabel: () => null,
     setLabel: jest.fn(),
     getSessionUsage: () => null,

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -1559,7 +1559,7 @@ describe("AgentSessionManager default-model settings subscription", () => {
       resolveReady = resolve;
     });
     // A session that is still starting (no backend session id yet) would throw
-    // from setModel/setConfigOption, so the re-apply must wait on `ready`.
+    // from setModel/applyConfigOption, so the re-apply must wait on `ready`.
     sessionCreateSpy.mockImplementationOnce((opts) => {
       const session = makeMockSession({ internalId: opts.internalId, backendId: opts.backendId });
       Object.defineProperty(session, "ready", { value: ready });

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -171,7 +171,7 @@ function makeMockSession(overrides: {
     dispose: mockSessionDispose,
     setModel: jest.fn(),
     setMode: jest.fn(),
-    applyConfigOption: jest.fn(),
+    setConfigOption: jest.fn(),
     getLabel: () => null,
     setLabel: jest.fn(),
     getSessionUsage: () => null,
@@ -1559,7 +1559,7 @@ describe("AgentSessionManager default-model settings subscription", () => {
       resolveReady = resolve;
     });
     // A session that is still starting (no backend session id yet) would throw
-    // from setModel/applyConfigOption, so the re-apply must wait on `ready`.
+    // from setModel/setConfigOption, so the re-apply must wait on `ready`.
     sessionCreateSpy.mockImplementationOnce((opts) => {
       const session = makeMockSession({ internalId: opts.internalId, backendId: opts.backendId });
       Object.defineProperty(session, "ready", { value: ready });

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -2119,7 +2119,7 @@ export class AgentSessionManager {
     if (spec.kind === "setMode") {
       await session.setMode(spec.nativeId);
     } else {
-      await session.setModeConfigOption(spec.configId, spec.value);
+      await session.applyConfigOption(spec.configId, spec.value, "reported");
     }
     await this.persistDefaultMode(backendId, mode);
   }

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -2119,7 +2119,7 @@ export class AgentSessionManager {
     if (spec.kind === "setMode") {
       await session.setMode(spec.nativeId);
     } else {
-      await session.setConfigOption(spec.configId, spec.value);
+      await session.setModeConfigOption(spec.configId, spec.value);
     }
     await this.persistDefaultMode(backendId, mode);
   }

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -357,7 +357,7 @@ export class AgentSessionManager {
   // prompter consults this to hard-deny write/exec tools for them.
   private readonly readOnlyFanoutSessions = new Set<SessionId>();
   // Serializes per-session default-model re-applies so two rapid settings
-  // changes can't race their setModel/setConfigOption round-trips and leave
+  // changes can't race their setModel/applyConfigOption round-trips and leave
   // the session on a stale model. Each link re-reads the latest default, so
   // the final settings value always wins.
   private readonly defaultApplyChains = new Map<string, Promise<void>>();

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -357,7 +357,7 @@ export class AgentSessionManager {
   // prompter consults this to hard-deny write/exec tools for them.
   private readonly readOnlyFanoutSessions = new Set<SessionId>();
   // Serializes per-session default-model re-applies so two rapid settings
-  // changes can't race their setModel/applyConfigOption round-trips and leave
+  // changes can't race their setModel/setConfigOption round-trips and leave
   // the session on a stale model. Each link re-reads the latest default, so
   // the final settings value always wins.
   private readonly defaultApplyChains = new Map<string, Promise<void>>();
@@ -2119,7 +2119,7 @@ export class AgentSessionManager {
     if (spec.kind === "setMode") {
       await session.setMode(spec.nativeId);
     } else {
-      await session.applyConfigOption(spec.configId, spec.value, "reported");
+      await session.setConfigOption(spec.configId, spec.value, "reported");
     }
     await this.persistDefaultMode(backendId, mode);
   }

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -270,7 +270,7 @@ export interface BackendDescriptor {
    * model id.
    *
    * Implementations are expected to swallow `MethodUnsupportedError` from
-   * the underlying `session.applyConfigOption` call (the backend may simply
+   * the underlying `session.setConfigOption` call (the backend may simply
    * lack the capability) and propagate everything else.
    */
   applySelection(session: AgentSession, selection: ModelSelection): Promise<void>;

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -7,6 +7,7 @@ import type {
   BackendConfigOption,
   BackendId,
   BackendProcess,
+  BackendState,
   EffortOption,
   EnabledModelEntry,
   ModelSelection,
@@ -272,8 +273,19 @@ export interface BackendDescriptor {
    * Implementations are expected to swallow `MethodUnsupportedError` from
    * the underlying `session.setConfigOption` call (the backend may simply
    * lack the capability) and propagate everything else.
+   *
+   * `reportedState`, when supplied, is the backend's true reported state and
+   * must be what any "skip the redundant model write" guard compares against.
+   * During startup seeding the session's cached state is an optimistic display
+   * seed that already shows the target model, so a guard reading
+   * `session.getState()` would conclude "already there" and skip the real
+   * switch. When absent, the session state is the reported truth.
    */
-  applySelection(session: AgentSession, selection: ModelSelection): Promise<void>;
+  applySelection(
+    session: AgentSession,
+    selection: ModelSelection,
+    reportedState?: BackendState | null
+  ): Promise<void>;
 
   /**
    * Optional: return the canonical → native mode mapping for this backend

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -270,7 +270,7 @@ export interface BackendDescriptor {
    * model id.
    *
    * Implementations are expected to swallow `MethodUnsupportedError` from
-   * the underlying `session.setConfigOption` call (the backend may simply
+   * the underlying `session.applyConfigOption` call (the backend may simply
    * lack the capability) and propagate everything else.
    */
   applySelection(session: AgentSession, selection: ModelSelection): Promise<void>;

--- a/src/agentMode/session/replayPersistedMode.test.ts
+++ b/src/agentMode/session/replayPersistedMode.test.ts
@@ -8,22 +8,22 @@ type ModeState = NonNullable<BackendState["mode"]>;
 interface MockSessionParts {
   mode: ModeState | null;
   setMode?: jest.Mock;
-  setConfigOption?: jest.Mock;
+  setModeConfigOption?: jest.Mock;
 }
 
-function makeSession({ mode, setMode, setConfigOption }: MockSessionParts): {
+function makeSession({ mode, setMode, setModeConfigOption }: MockSessionParts): {
   session: AgentSession;
   setMode: jest.Mock;
-  setConfigOption: jest.Mock;
+  setModeConfigOption: jest.Mock;
 } {
   const setModeMock = setMode ?? jest.fn().mockResolvedValue(undefined);
-  const setConfigOptionMock = setConfigOption ?? jest.fn().mockResolvedValue(undefined);
+  const setModeConfigOptionMock = setModeConfigOption ?? jest.fn().mockResolvedValue(undefined);
   const session = {
     getState: (): BackendState => ({ model: null, mode }),
     setMode: setModeMock,
-    setConfigOption: setConfigOptionMock,
+    setModeConfigOption: setModeConfigOptionMock,
   } as unknown as AgentSession;
-  return { session, setMode: setModeMock, setConfigOption: setConfigOptionMock };
+  return { session, setMode: setModeMock, setModeConfigOption: setModeConfigOptionMock };
 }
 
 const modeState = (current: CopilotMode | null, apply: ModeState["apply"]): ModeState => ({
@@ -45,14 +45,14 @@ describe("replayPersistedMode", () => {
     expect(setMode).toHaveBeenCalledWith("bypassPermissions");
   });
 
-  it("applies the persisted mode via setConfigOption for configOption-style backends", async () => {
-    const { session, setConfigOption } = makeSession({
+  it("applies the persisted mode via setModeConfigOption for configOption-style backends", async () => {
+    const { session, setModeConfigOption } = makeSession({
       mode: modeState("default", {
         plan: { kind: "setConfigOption", configId: "approval", value: "plan" },
       }),
     });
     await replayPersistedMode(session, "plan");
-    expect(setConfigOption).toHaveBeenCalledWith("approval", "plan");
+    expect(setModeConfigOption).toHaveBeenCalledWith("approval", "plan");
   });
 
   it("is a no-op when no mode is persisted", async () => {
@@ -79,14 +79,14 @@ describe("replayPersistedMode", () => {
 
   it("falls back to a no-op when the backend doesn't offer the persisted mode", async () => {
     // Persisted "auto" but this backend only advertises an apply spec for "plan".
-    const { session, setMode, setConfigOption } = makeSession({
+    const { session, setMode, setModeConfigOption } = makeSession({
       mode: modeState("default", {
         plan: { kind: "setConfigOption", configId: "approval", value: "plan" },
       }),
     });
     await replayPersistedMode(session, "auto");
     expect(setMode).not.toHaveBeenCalled();
-    expect(setConfigOption).not.toHaveBeenCalled();
+    expect(setModeConfigOption).not.toHaveBeenCalled();
   });
 
   it("swallows MethodUnsupportedError without throwing", async () => {

--- a/src/agentMode/session/replayPersistedMode.test.ts
+++ b/src/agentMode/session/replayPersistedMode.test.ts
@@ -8,22 +8,22 @@ type ModeState = NonNullable<BackendState["mode"]>;
 interface MockSessionParts {
   mode: ModeState | null;
   setMode?: jest.Mock;
-  setModeConfigOption?: jest.Mock;
+  applyConfigOption?: jest.Mock;
 }
 
-function makeSession({ mode, setMode, setModeConfigOption }: MockSessionParts): {
+function makeSession({ mode, setMode, applyConfigOption }: MockSessionParts): {
   session: AgentSession;
   setMode: jest.Mock;
-  setModeConfigOption: jest.Mock;
+  applyConfigOption: jest.Mock;
 } {
   const setModeMock = setMode ?? jest.fn().mockResolvedValue(undefined);
-  const setModeConfigOptionMock = setModeConfigOption ?? jest.fn().mockResolvedValue(undefined);
+  const applyConfigOptionMock = applyConfigOption ?? jest.fn().mockResolvedValue(undefined);
   const session = {
     getState: (): BackendState => ({ model: null, mode }),
     setMode: setModeMock,
-    setModeConfigOption: setModeConfigOptionMock,
+    applyConfigOption: applyConfigOptionMock,
   } as unknown as AgentSession;
-  return { session, setMode: setModeMock, setModeConfigOption: setModeConfigOptionMock };
+  return { session, setMode: setModeMock, applyConfigOption: applyConfigOptionMock };
 }
 
 const modeState = (current: CopilotMode | null, apply: ModeState["apply"]): ModeState => ({
@@ -45,14 +45,14 @@ describe("replayPersistedMode", () => {
     expect(setMode).toHaveBeenCalledWith("bypassPermissions");
   });
 
-  it("applies the persisted mode via setModeConfigOption for configOption-style backends", async () => {
-    const { session, setModeConfigOption } = makeSession({
+  it("applies the persisted mode as a reported config-option apply for configOption-style backends", async () => {
+    const { session, applyConfigOption } = makeSession({
       mode: modeState("default", {
         plan: { kind: "setConfigOption", configId: "approval", value: "plan" },
       }),
     });
     await replayPersistedMode(session, "plan");
-    expect(setModeConfigOption).toHaveBeenCalledWith("approval", "plan");
+    expect(applyConfigOption).toHaveBeenCalledWith("approval", "plan", "reported");
   });
 
   it("is a no-op when no mode is persisted", async () => {
@@ -79,14 +79,14 @@ describe("replayPersistedMode", () => {
 
   it("falls back to a no-op when the backend doesn't offer the persisted mode", async () => {
     // Persisted "auto" but this backend only advertises an apply spec for "plan".
-    const { session, setMode, setModeConfigOption } = makeSession({
+    const { session, setMode, applyConfigOption } = makeSession({
       mode: modeState("default", {
         plan: { kind: "setConfigOption", configId: "approval", value: "plan" },
       }),
     });
     await replayPersistedMode(session, "auto");
     expect(setMode).not.toHaveBeenCalled();
-    expect(setModeConfigOption).not.toHaveBeenCalled();
+    expect(applyConfigOption).not.toHaveBeenCalled();
   });
 
   it("swallows MethodUnsupportedError without throwing", async () => {

--- a/src/agentMode/session/replayPersistedMode.test.ts
+++ b/src/agentMode/session/replayPersistedMode.test.ts
@@ -8,22 +8,22 @@ type ModeState = NonNullable<BackendState["mode"]>;
 interface MockSessionParts {
   mode: ModeState | null;
   setMode?: jest.Mock;
-  applyConfigOption?: jest.Mock;
+  setConfigOption?: jest.Mock;
 }
 
-function makeSession({ mode, setMode, applyConfigOption }: MockSessionParts): {
+function makeSession({ mode, setMode, setConfigOption }: MockSessionParts): {
   session: AgentSession;
   setMode: jest.Mock;
-  applyConfigOption: jest.Mock;
+  setConfigOption: jest.Mock;
 } {
   const setModeMock = setMode ?? jest.fn().mockResolvedValue(undefined);
-  const applyConfigOptionMock = applyConfigOption ?? jest.fn().mockResolvedValue(undefined);
+  const setConfigOptionMock = setConfigOption ?? jest.fn().mockResolvedValue(undefined);
   const session = {
     getState: (): BackendState => ({ model: null, mode }),
     setMode: setModeMock,
-    applyConfigOption: applyConfigOptionMock,
+    setConfigOption: setConfigOptionMock,
   } as unknown as AgentSession;
-  return { session, setMode: setModeMock, applyConfigOption: applyConfigOptionMock };
+  return { session, setMode: setModeMock, setConfigOption: setConfigOptionMock };
 }
 
 const modeState = (current: CopilotMode | null, apply: ModeState["apply"]): ModeState => ({
@@ -46,13 +46,13 @@ describe("replayPersistedMode", () => {
   });
 
   it("applies the persisted mode as a reported config-option apply for configOption-style backends", async () => {
-    const { session, applyConfigOption } = makeSession({
+    const { session, setConfigOption } = makeSession({
       mode: modeState("default", {
         plan: { kind: "setConfigOption", configId: "approval", value: "plan" },
       }),
     });
     await replayPersistedMode(session, "plan");
-    expect(applyConfigOption).toHaveBeenCalledWith("approval", "plan", "reported");
+    expect(setConfigOption).toHaveBeenCalledWith("approval", "plan", "reported");
   });
 
   it("is a no-op when no mode is persisted", async () => {
@@ -79,14 +79,14 @@ describe("replayPersistedMode", () => {
 
   it("falls back to a no-op when the backend doesn't offer the persisted mode", async () => {
     // Persisted "auto" but this backend only advertises an apply spec for "plan".
-    const { session, setMode, applyConfigOption } = makeSession({
+    const { session, setMode, setConfigOption } = makeSession({
       mode: modeState("default", {
         plan: { kind: "setConfigOption", configId: "approval", value: "plan" },
       }),
     });
     await replayPersistedMode(session, "auto");
     expect(setMode).not.toHaveBeenCalled();
-    expect(applyConfigOption).not.toHaveBeenCalled();
+    expect(setConfigOption).not.toHaveBeenCalled();
   });
 
   it("swallows MethodUnsupportedError without throwing", async () => {

--- a/src/agentMode/session/replayPersistedMode.ts
+++ b/src/agentMode/session/replayPersistedMode.ts
@@ -32,7 +32,7 @@ export async function replayPersistedMode(
     if (spec.kind === "setMode") {
       await session.setMode(spec.nativeId);
     } else {
-      await session.setModeConfigOption(spec.configId, spec.value);
+      await session.applyConfigOption(spec.configId, spec.value, "reported");
     }
   } catch (e) {
     if (e instanceof MethodUnsupportedError) return;

--- a/src/agentMode/session/replayPersistedMode.ts
+++ b/src/agentMode/session/replayPersistedMode.ts
@@ -32,7 +32,7 @@ export async function replayPersistedMode(
     if (spec.kind === "setMode") {
       await session.setMode(spec.nativeId);
     } else {
-      await session.applyConfigOption(spec.configId, spec.value, "reported");
+      await session.setConfigOption(spec.configId, spec.value, "reported");
     }
   } catch (e) {
     if (e instanceof MethodUnsupportedError) return;

--- a/src/agentMode/session/replayPersistedMode.ts
+++ b/src/agentMode/session/replayPersistedMode.ts
@@ -32,7 +32,7 @@ export async function replayPersistedMode(
     if (spec.kind === "setMode") {
       await session.setMode(spec.nativeId);
     } else {
-      await session.setConfigOption(spec.configId, spec.value);
+      await session.setModeConfigOption(spec.configId, spec.value);
     }
   } catch (e) {
     if (e instanceof MethodUnsupportedError) return;


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#227

> Note: GitHub's cross-repo auto-close did not register this reference (`closingIssuesReferences` is empty) — close logancyang/obsidian-copilot-preview#227 manually on merge.

## Problem

Switching models at the start of an agent session — e.g. OpenCode → Claude Sonnet — didn't take on the first click: it ran the backend **default** model instead, and a second click was needed to actually reach the pick. The model itself was wrong, not just the picker label.

Investigation (reproduced against the real `AgentSession` before fixing) found **two independent mechanisms**, both leaving the session on the default:

| Backend | Symptom | Mechanism |
| --- | --- | --- |
| **Claude** | always the default | `confirmSeededSelection` optimistically seeds the display to the pick, then delegates the real switch to `descriptor.applySelection`. Claude's `applySelection` guards `setSessionModel` on the session's *current* model — which the optimistic seed already set to the pick — so it saw "already there" and **skipped the switch**. The seed was dropped before `applySelection` only for config-option backends, on a false assumption that setModel-style backends always round-trip. |
| **Opencode** | intermittently reverts | opencode broadcasts `config_option_update` notifications that the ACP layer synthesizes into `state_changed`; one can race the switch and carry the pre-switch default. `handleSessionEvent` applied `state_changed` **unconditionally**, so the late push clobbered the just-applied model back to the default. |

## Fix

- **Claude (guard vs. seed):** thread the backend's reported startup state into `descriptor.applySelection` as an explicit `reportedState` argument; the Claude/opencode "skip the redundant model write" guards compare against it instead of the seeded session state, so the guard fires the real switch. The optimistic seed stays visible during the confirmation round-trip — an earlier revision dropped the seed instead, but `initialize()` has already notified by then, so React's next render would flash the backend default until the switch confirmed (Codex review catch).
- **Opencode (stale reverts):** track the last user/seed-applied selection and, when a stale snapshot would revert its model (and the backend still offers it), restore the whole selection — restoring only the base would graft the stale effort onto it (Codex review catch). These backends never self-switch the model, so a revert is a stale echo. Pushes that agree on the model are trusted verbatim, so effort changes riding them land — and the pin's effort is refreshed to match, so a later stale revert restores the latest trusted selection rather than the apply-time effort (Codex review catch). Two boundary rules keep the merged state honest (Codex review catches): a snapshot accepted because the applied model vanished from the catalog clears the pin (the backend abandoned it — a later catalog update must not graft it back over the fallback in use), and a rejected revert carries over the pinned model's active-model metadata (its `effortOptions` entry and `apply.effortConfigId`, which the translator derives from a snapshot's *own* active model) so the effort selector and dispatch target keep describing the model shown.
- **Hardening (review request):** funnel every `currentState` write through a single `applyState(next, provenance)` choke point encoding the ownership policy — `"confirmed"` model-apply responses re-pin the user's model, `"reported"` snapshots (`state_changed` push, `setMode` response) are reconciled against the pin, `"seed"` writes are trusted as transient display state. This closes the previously-unguarded `setMode` response path by construction; the alternative (leaving remember/reconcile calls scattered at the nine write sites) was rejected in review because each new write site would re-open the bypass class.
- **Apply races (review findings):** rapid picks start unserialized model applies, and the status gate opens before the seeded confirmation completes. Model applies are serialized on a per-session chain — the next request dispatches only after the previous response lands, so the last pick is the last write on the backend, the ACP wire cache, and the display alike (a demotion-only fix was rejected in review: it healed the display but left the wire cache and backend on the older pick). And `runTurn` queues a turn fired during the startup window behind `ready` so the first prompt can't race the seeded switch onto the backend default (later turns keep their synchronous dispatch path); a turn cancelled or disposed while queued finalizes as `"cancelled"` without dispatching the prompt; the gate also drains the apply chain (a re-pick made during the window must win over the seed) and `cancel()` aborts locally before its backend round-trip so a queued turn can't slip through mid-cancellation.
- **Non-model writes follow intent, not wire method (review findings):** opencode routes mode switches through `setSessionConfigOption`, and Claude/opencode route effort through it too, so those responses previously landed as model confirmations — a stale response could clobber the applied model *and* re-pin it to the stale value, making the guard rewrite later truthful pushes. `setConfigOption(configId, value, provenance)` requires the caller's intent, and `"confirmed"` is reserved for genuine model applies (`applyModelWireId`'s config-option channel); effort applies and mode applies (`applyMode`, `replayPersistedMode`, effort descriptors) pass `"reported"`. A provenance-less entry point was rejected because it let a caller land a snapshot as a model confirmation without saying so.

## Scope

Budget gate: PASS — 9 files, +1199/−69; two root-cause fixes plus one provenance-typed write path, a single config-option entry point, and an explicit reported-state argument on `applySelection`; the files beyond the core two are exactly the call sites made intent-explicit, and every regression test pins a distinct mechanism.

## Changes

- `src/agentMode/session/AgentSession.ts` — `StateProvenance` type, `applyState` sole write path, `rememberAppliedModel` pin, and `reconcileAppliedModel` guard (which also refreshes the pin's effort on trusted same-model snapshots); all `currentState` writes routed through `applyState`; `setConfigOption` requires the caller's provenance; `confirmSeededSelection` keeps the seed visible and passes the reported state to `applySelection`.
- `src/agentMode/session/descriptor.ts` — `applySelection` accepts an optional `reportedState` the guards must compare against.
- `src/agentMode/session/AgentSessionManager.ts` — `applyMode`'s config-option path passes `"reported"`.
- `src/agentMode/session/replayPersistedMode.ts` — persisted-mode replay passes `"reported"`.
- `src/agentMode/backends/claude/descriptor.ts`, `src/agentMode/backends/opencode/descriptor.ts` — guards compare against `reportedState`; effort applies pass `"reported"`.
- `src/agentMode/session/AgentSession.test.ts` — nineteen regression tests: Claude guard-vs-seed repro, Claude model+effort landing, guard-less (codex) switch, stale `state_changed` clobber repro, stale revert restores the applied effort too (no stale-effort graft), same-model `state_changed` effort change honored, stale `setMode` response model preserved, stale config-option mode-apply response model preserved with pin left uncorrupted, seed stays visible while the confirming switch is in flight, trusted same-model effort survives a later stale revert, stale-modeled effort response can't clobber the applied model or corrupt the pin, pin cleared when the backend drops the applied model, pinned model's effort metadata carried through a rejected stale revert, rapid model applies serialized (last pick is last write, failures don't wedge the chain), first prompt queued behind the seeded confirmation, queued turn cancelled mid-wait never dispatches its prompt, queued prompt held for a startup-window re-pick, slow cancel round-trip still stops a queued prompt.
- `src/agentMode/session/replayPersistedMode.test.ts`, `src/agentMode/backends/opencode/descriptor.test.ts` — expectations and mocks updated to the provenance-carrying call.

## Verification

- New regression tests reproduce the bugs (red) and pass after the fix (green), including effort landing on the pick, a same-model `state_changed` still being honored, stale `setMode` / config-option mode-apply / effort-apply responses no longer clobbering the pick or corrupting it via re-pin, and the optimistic seed staying visible during the confirmation round-trip.
- Full gates green: **304 suites / 4393 tests**, `npm run lint`, `npm run format`, `npm run build` (tsc + esbuild) all pass.

Planned via otacon (session `otc_izxy2k`); reviewed and hardened via otacon review (issue filed as logancyang/obsidian-copilot-preview#227); six Codex review rounds addressed (seed visibility, effort provenance, pin freshness/lifetime, reconcile metadata coherence, apply-generation and startup-prompt races).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
