### PR TITLE
fix(agent-mode): surface incompatible agent installs

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -160,6 +160,12 @@ While the agent is working, the chat shows status indicators for each tool call:
 
 This lets you see what the agent is doing as it works.
 
+### Parallel Subagents
+
+Claude can delegate independent work to background subagents. Agent Mode keeps the turn active while those subagents run, shows the current step, tool count, and elapsed time on each subagent card, then keeps the final report under the card that launched it. Internal result-collection calls stay out of the trail once their report is attached; if Copilot cannot safely match one to its launch, it leaves that result visible instead of risking lost output. Background shell commands and other non-agent tasks do not delay the turn.
+
+This requires Claude Code 2.1.206 or newer. Copilot checks the installed version when it starts and whenever you apply or auto-detect a Claude binary. An older binary is marked **Incompatible version** in Settings → Copilot → Agents → Claude and cannot start a session. If you select Claude in chat, Copilot shows the required version and a **Configure Claude** button that opens the same setup dialog; installation guidance stays in that dialog.
+
 ---
 
 ## File Editing: Preview and Diff

--- a/src/agentMode/backends/claude/ClaudeInstallModal.tsx
+++ b/src/agentMode/backends/claude/ClaudeInstallModal.tsx
@@ -2,9 +2,8 @@ import { BinaryPathSetting } from "@/agentMode/backends/shared/BinaryPathSetting
 import { ConfigDialogShell, ConfigSection } from "@/agentMode/backends/shared/ConfigDialogShell";
 import { InstallCommandRow } from "@/agentMode/backends/shared/InstallCommandRow";
 import { InstallStatusLine } from "@/agentMode/backends/shared/installStatus";
-import type { InstallState } from "@/agentMode/session/types";
 import { ReactModal } from "@/components/modals/ReactModal";
-import { setSettings, useSettingsValue } from "@/settings/model";
+import { getSettings, setSettings, useSettingsValue } from "@/settings/model";
 import { validateExecutableFile } from "@/utils/detectBinary";
 import { App, Notice } from "obsidian";
 import React from "react";
@@ -12,7 +11,9 @@ import {
   CLAUDE_INSTALL_COMMAND,
   claudeCliDetectionSearchDirs,
   detectClaudeCliPath,
-  resolveClaudeCliPath,
+  getClaudeInstallState,
+  refreshClaudeInstallState,
+  subscribeClaudeInstallState,
 } from "./descriptor";
 
 /**
@@ -23,19 +24,26 @@ import {
  */
 const ClaudeConfigBody: React.FC<{ onClose: () => void }> = ({ onClose }) => {
   const settings = useSettingsValue();
+  const getInstallStateSnapshot = React.useCallback(
+    () => getClaudeInstallState(settings),
+    [settings]
+  );
+  const sessionState = React.useSyncExternalStore(
+    subscribeClaudeInstallState,
+    getInstallStateSnapshot
+  );
+
+  React.useEffect(() => {
+    void refreshClaudeInstallState(getSettings(), true);
+  }, []);
 
   const overridePath = settings.agentMode?.claudeCli?.path ?? "";
-  const resolvedPath = resolveClaudeCliPath(settings);
-  const isCustom = Boolean(overridePath);
-
-  const sessionState: InstallState = resolvedPath
-    ? { kind: "ready", source: isCustom ? "custom" : "managed" }
-    : { kind: "absent" };
 
   const onSaveCustomPath = React.useCallback(async (path: string): Promise<string | null> => {
     const err = await validateExecutableFile(path);
     if (err) return err;
     setSettings((cur) => ({ agentMode: { ...cur.agentMode, claudeCli: { path } } }));
+    await refreshClaudeInstallState(getSettings(), true);
     new Notice("Claude CLI path saved.");
     return null;
   }, []);

--- a/src/agentMode/backends/claude/claudeCompatibilityStore.test.ts
+++ b/src/agentMode/backends/claude/claudeCompatibilityStore.test.ts
@@ -1,0 +1,85 @@
+import {
+  ClaudeCompatibilityStore,
+  type ClaudeCompatibilityInput,
+} from "./claudeCompatibilityStore";
+
+function input(cacheKey = "claude-a"): ClaudeCompatibilityInput {
+  return {
+    cacheKey,
+    path: "/usr/local/bin/claude",
+    source: "custom",
+    env: process.env,
+  };
+}
+
+describe("claudeCompatibilityStore", () => {
+  describe("ClaudeCompatibilityStore.get()", () => {
+    it("returns a stable checking snapshot until the runtime publishes state", () => {
+      const store = new ClaudeCompatibilityStore();
+      const first = store.get(input());
+
+      expect(first).toEqual({ kind: "checking", source: "custom" });
+      expect(store.get(input())).toBe(first);
+    });
+  });
+
+  describe("ClaudeCompatibilityStore.refresh()", () => {
+    it("publishes an incompatible result and notifies subscribers", async () => {
+      const store = new ClaudeCompatibilityStore();
+      const listener = jest.fn();
+      store.subscribe(listener);
+      const run = jest.fn().mockResolvedValue({ stdout: "2.1.205 (Claude Code)" });
+
+      expect(store.get(input())).toEqual({ kind: "checking", source: "custom" });
+      await expect(store.refresh(input(), { run })).resolves.toEqual({
+        kind: "incompatible",
+        source: "custom",
+        currentVersion: "2.1.205",
+        minVersion: "2.1.206",
+        message:
+          "Claude Code 2.1.205 is not supported. Copilot requires Claude Code 2.1.206 or newer.",
+      });
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it("deduplicates concurrent probes for the same runtime", async () => {
+      const store = new ClaudeCompatibilityStore();
+      let resolveRun!: (value: { stdout: string }) => void;
+      const run = jest.fn(
+        () => new Promise<{ stdout: string }>((resolve) => (resolveRun = resolve))
+      );
+
+      const first = store.refresh(input(), { run });
+      const second = store.refresh(input(), { run });
+      expect(first).toBe(second);
+      expect(run).toHaveBeenCalledTimes(1);
+
+      resolveRun({ stdout: "2.1.206 (Claude Code)" });
+      await expect(first).resolves.toEqual({ kind: "ready", source: "custom" });
+    });
+
+    it("keeps states independent across runtime cache keys", async () => {
+      const store = new ClaudeCompatibilityStore();
+      const oldRun = jest.fn().mockResolvedValue({ stdout: "2.1.205 (Claude Code)" });
+      const newRun = jest.fn().mockResolvedValue({ stdout: "2.1.206 (Claude Code)" });
+
+      await store.refresh(input("old-path"), { run: oldRun });
+      await store.refresh(input("new-path-or-env"), { run: newRun });
+
+      expect(store.get(input("old-path")).kind).toBe("incompatible");
+      expect(store.get(input("new-path-or-env"))).toEqual({ kind: "ready", source: "custom" });
+    });
+
+    it("returns a readable error when the version cannot be checked", async () => {
+      const store = new ClaudeCompatibilityStore();
+      const run = jest.fn().mockRejectedValue(new Error("spawn failed"));
+
+      const state = await store.refresh(input(), { run });
+
+      expect(state.kind).toBe("error");
+      expect(state.kind === "error" && state.message).toContain(
+        "Could not verify the installed Claude Code version"
+      );
+    });
+  });
+});

--- a/src/agentMode/backends/claude/claudeCompatibilityStore.ts
+++ b/src/agentMode/backends/claude/claudeCompatibilityStore.ts
@@ -1,0 +1,99 @@
+import type { InstallState } from "@/agentMode/session/types";
+import {
+  probeClaudeVersion,
+  type ClaudeVersionRunner,
+} from "@/agentMode/backends/claude/claudeVersion";
+
+export interface ClaudeCompatibilityInput {
+  cacheKey: string;
+  path: string;
+  source: "managed" | "custom";
+  env: NodeJS.ProcessEnv;
+}
+
+interface RefreshOptions {
+  force?: boolean;
+  run?: ClaudeVersionRunner;
+}
+
+type Listener = () => void;
+
+const CHECKING_STATES = Object.freeze({
+  managed: Object.freeze({ kind: "checking", source: "managed" }),
+  custom: Object.freeze({ kind: "checking", source: "custom" }),
+}) satisfies Readonly<Record<ClaudeCompatibilityInput["source"], InstallState>>;
+
+/**
+ * Owns transient, device-local compatibility state for selected Claude Code runtimes.
+ *
+ * It coordinates readiness checks and change notifications by runtime identity
+ * so UI and session startup share one current answer. Executable selection,
+ * persistence, and user-facing recovery remain the responsibility of callers.
+ */
+export class ClaudeCompatibilityStore {
+  private readonly states = new Map<string, InstallState>();
+  private readonly inflight = new Map<string, Promise<InstallState>>();
+  private readonly listeners = new Set<Listener>();
+
+  /**
+   * Gives synchronous consumers the latest readiness answer without starting a
+   * compatibility check.
+   * @param input - The runtime identity and installation source whose readiness should be read.
+   */
+  get(input: ClaudeCompatibilityInput): InstallState {
+    return this.states.get(input.cacheKey) ?? CHECKING_STATES[input.source];
+  }
+
+  /**
+   * Brings one runtime's readiness up to date after installation or configuration changes.
+   * @param input - The runtime identity, executable, and environment that should be checked.
+   * @param options - The cache policy and command runner that should govern the check.
+   */
+  refresh(input: ClaudeCompatibilityInput, options: RefreshOptions = {}): Promise<InstallState> {
+    const running = this.inflight.get(input.cacheKey);
+    if (running) return running;
+
+    const cached = this.states.get(input.cacheKey);
+    if (!options.force && cached && cached.kind !== "checking") return Promise.resolve(cached);
+
+    this.set(input.cacheKey, CHECKING_STATES[input.source]);
+    const promise = probeClaudeVersion(input.path, input.env, options.run)
+      .then((compatibility): InstallState => {
+        if (compatibility.kind === "supported") {
+          return { kind: "ready", source: input.source };
+        }
+        return { ...compatibility, source: input.source };
+      })
+      .catch(
+        (error): InstallState => ({
+          kind: "error",
+          message: error instanceof Error ? error.message : String(error),
+        })
+      )
+      .then((state) => {
+        this.set(input.cacheKey, state);
+        return state;
+      })
+      .finally(() => this.inflight.delete(input.cacheKey));
+
+    this.inflight.set(input.cacheKey, promise);
+    return promise;
+  }
+
+  /**
+   * Keeps readiness consumers synchronized with compatibility transitions
+   * without exposing probe lifecycle details.
+   * @param listener - The consumer to notify whenever a runtime's readiness changes.
+   */
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private set(key: string, state: InstallState): void {
+    this.states.set(key, state);
+    for (const listener of this.listeners) listener();
+  }
+}
+
+export const claudeCompatibilityStore = new ClaudeCompatibilityStore();

--- a/src/agentMode/backends/claude/claudeVersion.test.ts
+++ b/src/agentMode/backends/claude/claudeVersion.test.ts
@@ -14,6 +14,33 @@ describe("claudeVersion", () => {
   });
 
   describe("probeClaudeVersion()", () => {
+    it.each([
+      "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js",
+      "C:\\nvm\\node_modules\\@anthropic-ai\\claude-code\\cli-wrapper.cjs",
+    ])("runs script fallback %s through Node instead of executing it directly", async (script) => {
+      const run = jest.fn().mockResolvedValue({ stdout: `${CLAUDE_MIN_VERSION} (Claude Code)` });
+
+      await expect(probeClaudeVersion(script, process.env, run)).resolves.toEqual({
+        kind: "supported",
+        version: CLAUDE_MIN_VERSION,
+      });
+      expect(run).toHaveBeenCalledWith(process.execPath, [script, "--version"], {
+        env: expect.objectContaining({ ELECTRON_RUN_AS_NODE: "1" }),
+        timeout: 10_000,
+      });
+    });
+
+    it("executes native binaries directly without the Node launcher", async () => {
+      const run = jest.fn().mockResolvedValue({ stdout: `${CLAUDE_MIN_VERSION} (Claude Code)` });
+
+      await probeClaudeVersion("/usr/local/bin/claude", process.env, run);
+
+      expect(run).toHaveBeenCalledWith("/usr/local/bin/claude", ["--version"], {
+        env: process.env,
+        timeout: 10_000,
+      });
+    });
+
     it("returns incompatible metadata for an older Claude Code version", async () => {
       const run = jest.fn().mockResolvedValue({ stdout: "2.1.205 (Claude Code)" });
 

--- a/src/agentMode/backends/claude/claudeVersion.test.ts
+++ b/src/agentMode/backends/claude/claudeVersion.test.ts
@@ -1,0 +1,66 @@
+import {
+  assertClaudeVersionSupported,
+  CLAUDE_MIN_VERSION,
+  parseClaudeVersionOutput,
+  probeClaudeVersion,
+  type ClaudeVersionRunner,
+} from "./claudeVersion";
+
+describe("claudeVersion", () => {
+  describe("parseClaudeVersionOutput()", () => {
+    it("returns the semantic version from Claude Code output", () => {
+      expect(parseClaudeVersionOutput("2.1.206 (Claude Code)\n")).toBe("2.1.206");
+    });
+  });
+
+  describe("probeClaudeVersion()", () => {
+    it("returns incompatible metadata for an older Claude Code version", async () => {
+      const run = jest.fn().mockResolvedValue({ stdout: "2.1.205 (Claude Code)" });
+
+      await expect(probeClaudeVersion("/usr/local/bin/claude", process.env, run)).resolves.toEqual({
+        kind: "incompatible",
+        currentVersion: "2.1.205",
+        minVersion: CLAUDE_MIN_VERSION,
+        message:
+          "Claude Code 2.1.205 is not supported. Copilot requires Claude Code 2.1.206 or newer.",
+      });
+    });
+  });
+
+  describe("assertClaudeVersionSupported()", () => {
+    it("accepts the minimum supported version", async () => {
+      const run = jest.fn().mockResolvedValue({ stdout: `${CLAUDE_MIN_VERSION} (Claude Code)` });
+
+      await expect(
+        assertClaudeVersionSupported("/usr/local/bin/claude", process.env, run)
+      ).resolves.toBeUndefined();
+      expect(run).toHaveBeenCalledWith("/usr/local/bin/claude", ["--version"], {
+        env: process.env,
+        timeout: 10_000,
+      });
+    });
+
+    it("throws for an older version without embedding install instructions", async () => {
+      const run = jest.fn().mockResolvedValue({ stdout: "2.1.205 (Claude Code)" });
+
+      await expect(
+        assertClaudeVersionSupported("/usr/local/bin/claude", process.env, run)
+      ).rejects.toThrow(
+        "Claude Code 2.1.205 is not supported. Copilot requires Claude Code 2.1.206 or newer."
+      );
+      await expect(
+        assertClaudeVersionSupported("/usr/local/bin/claude", process.env, run)
+      ).rejects.not.toThrow("npm install");
+    });
+
+    it("throws when the output does not contain a version", async () => {
+      const run: ClaudeVersionRunner = jest
+        .fn()
+        .mockResolvedValue({ stdout: "Claude Code unknown" });
+
+      await expect(
+        assertClaudeVersionSupported("/usr/local/bin/claude", process.env, run)
+      ).rejects.toThrow("Could not read the installed Claude Code version");
+    });
+  });
+});

--- a/src/agentMode/backends/claude/claudeVersion.ts
+++ b/src/agentMode/backends/claude/claudeVersion.ts
@@ -1,0 +1,82 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { compareSemver } from "@/utils/semver";
+
+const execFileAsync = promisify(execFile);
+const VERSION_TIMEOUT_MS = 10_000;
+
+export const CLAUDE_MIN_VERSION = "2.1.206";
+
+export type ClaudeVersionRunner = (
+  claudePath: string,
+  args: string[],
+  options: { env: NodeJS.ProcessEnv; timeout: number }
+) => Promise<{ stdout: string }>;
+
+export function parseClaudeVersionOutput(stdout: string): string | null {
+  return stdout.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null;
+}
+
+export type ClaudeVersionCompatibility =
+  | { kind: "supported"; version: string }
+  | {
+      kind: "incompatible";
+      currentVersion: string;
+      minVersion: string;
+      message: string;
+    };
+
+/**
+ * Establishes whether the selected Claude Code runtime satisfies the protocol contract the plugin depends on.
+ * @param claudePath - The selected Claude Code executable to inspect.
+ * @param env - The runtime environment that should govern the compatibility check.
+ * @param run - The command runner used to obtain version information.
+ */
+export async function probeClaudeVersion(
+  claudePath: string,
+  env: NodeJS.ProcessEnv,
+  run: ClaudeVersionRunner = execFileAsync
+): Promise<ClaudeVersionCompatibility> {
+  let stdout: string;
+  try {
+    ({ stdout } = await run(claudePath, ["--version"], {
+      env,
+      timeout: VERSION_TIMEOUT_MS,
+    }));
+  } catch {
+    throw new Error(
+      `Could not verify the installed Claude Code version. Copilot requires Claude Code ${CLAUDE_MIN_VERSION} or newer.`
+    );
+  }
+
+  const version = parseClaudeVersionOutput(stdout);
+  if (!version) {
+    throw new Error(
+      `Could not read the installed Claude Code version. Copilot requires Claude Code ${CLAUDE_MIN_VERSION} or newer.`
+    );
+  }
+  if (compareSemver(version, CLAUDE_MIN_VERSION) < 0) {
+    return {
+      kind: "incompatible",
+      currentVersion: version,
+      minVersion: CLAUDE_MIN_VERSION,
+      message: `Claude Code ${version} is not supported. Copilot requires Claude Code ${CLAUDE_MIN_VERSION} or newer.`,
+    };
+  }
+  return { kind: "supported", version };
+}
+
+/**
+ * Enforces compatibility at the session boundary so unsupported runtimes fail with an actionable error.
+ * @param claudePath - The selected Claude Code executable that will back the session.
+ * @param env - The runtime environment the session will inherit.
+ * @param run - The command runner used to verify the selected runtime.
+ */
+export async function assertClaudeVersionSupported(
+  claudePath: string,
+  env: NodeJS.ProcessEnv,
+  run: ClaudeVersionRunner = execFileAsync
+): Promise<void> {
+  const compatibility = await probeClaudeVersion(claudePath, env, run);
+  if (compatibility.kind === "incompatible") throw new Error(compatibility.message);
+}

--- a/src/agentMode/backends/claude/claudeVersion.ts
+++ b/src/agentMode/backends/claude/claudeVersion.ts
@@ -13,6 +13,28 @@ export type ClaudeVersionRunner = (
   options: { env: NodeJS.ProcessEnv; timeout: number }
 ) => Promise<{ stdout: string }>;
 
+/**
+ * The resolver's npm-package fallbacks (`cli.js` / `cli-wrapper.cjs`) are Node
+ * scripts, not native executables — invoking them directly fails outright on
+ * Windows and on Unix depends on a `node` shebang resolvable from Obsidian's
+ * minimal PATH. Launch them through Electron's own binary running as Node
+ * (`ELECTRON_RUN_AS_NODE`), which always exists, so a resolver-supported
+ * install can't get misclassified as broken.
+ */
+function buildVersionInvocation(
+  claudePath: string,
+  env: NodeJS.ProcessEnv
+): { command: string; args: string[]; env: NodeJS.ProcessEnv } {
+  if (!/\.[cm]?js$/i.test(claudePath)) {
+    return { command: claudePath, args: ["--version"], env };
+  }
+  return {
+    command: process.execPath,
+    args: [claudePath, "--version"],
+    env: { ...env, ELECTRON_RUN_AS_NODE: "1" },
+  };
+}
+
 export function parseClaudeVersionOutput(stdout: string): string | null {
   return stdout.match(/\b(\d+\.\d+\.\d+)\b/)?.[1] ?? null;
 }
@@ -37,10 +59,11 @@ export async function probeClaudeVersion(
   env: NodeJS.ProcessEnv,
   run: ClaudeVersionRunner = execFileAsync
 ): Promise<ClaudeVersionCompatibility> {
+  const invocation = buildVersionInvocation(claudePath, env);
   let stdout: string;
   try {
-    ({ stdout } = await run(claudePath, ["--version"], {
-      env,
+    ({ stdout } = await run(invocation.command, invocation.args, {
+      env: invocation.env,
       timeout: VERSION_TIMEOUT_MS,
     }));
   } catch {

--- a/src/agentMode/backends/claude/descriptor.test.ts
+++ b/src/agentMode/backends/claude/descriptor.test.ts
@@ -1,0 +1,133 @@
+import type { InstallState } from "@/agentMode/session/types";
+import type { CopilotSettings } from "@/settings/model";
+import { resolveClaudeBinary } from "./claudeBinaryResolver";
+import { claudeCompatibilityStore } from "./claudeCompatibilityStore";
+import {
+  getClaudeInstallState,
+  refreshClaudeInstallState,
+  subscribeClaudeInstallState,
+} from "./descriptor";
+
+jest.mock("./claudeBinaryResolver", () => ({
+  claudeBinarySearchDirs: jest.fn(() => []),
+  resolveClaudeBinary: jest.fn(),
+}));
+
+jest.mock("./claudeCompatibilityStore", () => ({
+  claudeCompatibilityStore: {
+    get: jest.fn(),
+    refresh: jest.fn(),
+    subscribe: jest.fn(),
+  },
+}));
+
+const mockResolveClaudeBinary = resolveClaudeBinary as jest.MockedFunction<
+  typeof resolveClaudeBinary
+>;
+const mockGetCompatibility = claudeCompatibilityStore.get as jest.MockedFunction<
+  typeof claudeCompatibilityStore.get
+>;
+const mockRefreshCompatibility = claudeCompatibilityStore.refresh as jest.MockedFunction<
+  typeof claudeCompatibilityStore.refresh
+>;
+const mockSubscribeCompatibility = claudeCompatibilityStore.subscribe as jest.MockedFunction<
+  typeof claudeCompatibilityStore.subscribe
+>;
+
+function settingsWithClaudeRuntime(options: {
+  path?: string;
+  envOverrides?: Record<string, string>;
+}): CopilotSettings {
+  return {
+    agentMode: {
+      claudeCli: options.path ? { path: options.path } : undefined,
+      backends: {
+        claude: {
+          envOverrides: options.envOverrides,
+        },
+      },
+    },
+  } as unknown as CopilotSettings;
+}
+
+describe("claude descriptor", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("getClaudeInstallState()", () => {
+    it("returns absent without consulting compatibility state when no executable resolves", () => {
+      mockResolveClaudeBinary.mockReturnValue(null);
+
+      const first = getClaudeInstallState(settingsWithClaudeRuntime({}));
+
+      expect(first).toEqual({ kind: "absent" });
+      expect(getClaudeInstallState(settingsWithClaudeRuntime({}))).toBe(first);
+      expect(mockGetCompatibility).not.toHaveBeenCalled();
+    });
+
+    it("reads compatibility state using the custom executable and sorted environment identity", () => {
+      const readyState: InstallState = { kind: "ready", source: "custom" };
+      mockResolveClaudeBinary.mockReturnValue("/custom/bin/claude");
+      mockGetCompatibility.mockReturnValue(readyState);
+
+      const result = getClaudeInstallState(
+        settingsWithClaudeRuntime({
+          path: "/custom/bin/claude",
+          envOverrides: { ZED: "last", ALPHA: "first" },
+        })
+      );
+
+      expect(result).toBe(readyState);
+      expect(mockGetCompatibility).toHaveBeenCalledWith({
+        cacheKey: 'custom\u0000/custom/bin/claude\u0000[["ALPHA","first"],["ZED","last"]]',
+        path: "/custom/bin/claude",
+        source: "custom",
+        env: expect.objectContaining({ ALPHA: "first", ZED: "last" }),
+      });
+    });
+  });
+
+  describe("refreshClaudeInstallState()", () => {
+    it("does not refresh compatibility state when no executable resolves", async () => {
+      mockResolveClaudeBinary.mockReturnValue(null);
+
+      await expect(refreshClaudeInstallState(settingsWithClaudeRuntime({}), true)).resolves.toEqual(
+        {
+          kind: "absent",
+        }
+      );
+      expect(mockRefreshCompatibility).not.toHaveBeenCalled();
+    });
+
+    it("forces a refresh for the managed executable and returns its new state", async () => {
+      const readyState: InstallState = { kind: "ready", source: "managed" };
+      mockResolveClaudeBinary.mockReturnValue("/managed/bin/claude");
+      mockRefreshCompatibility.mockResolvedValue(readyState);
+
+      const result = await refreshClaudeInstallState(settingsWithClaudeRuntime({}), true);
+
+      expect(result).toBe(readyState);
+      expect(mockRefreshCompatibility).toHaveBeenCalledWith(
+        {
+          cacheKey: "managed\u0000/managed/bin/claude\u0000[]",
+          path: "/managed/bin/claude",
+          source: "managed",
+          env: process.env,
+        },
+        { force: true }
+      );
+    });
+  });
+
+  describe("subscribeClaudeInstallState()", () => {
+    it("subscribes to compatibility changes and returns the matching unsubscribe function", () => {
+      const listener = jest.fn();
+      const unsubscribe = jest.fn();
+      mockSubscribeCompatibility.mockReturnValue(unsubscribe);
+
+      expect(subscribeClaudeInstallState(listener)).toBe(unsubscribe);
+      expect(mockSubscribeCompatibility).toHaveBeenCalledWith(listener);
+    });
+  });
+});

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -14,6 +14,7 @@ import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { MethodUnsupportedError } from "@/agentMode/session/errors";
 import { claudeBinarySearchDirs, resolveClaudeBinary } from "./claudeBinaryResolver";
 import { getClaudeAuthStatus, signInToClaude } from "./claudeAuth";
+import { assertClaudeVersionSupported } from "./claudeVersion";
 import { agentOriginEnabledModelEntries } from "@/agentMode/backends/shared/agentEnabledModels";
 import { ClaudeSdkBackendProcess } from "@/agentMode/sdk/ClaudeSdkBackendProcess";
 import { getCachedSdkCatalog, synthesizeEffortConfigOption } from "@/agentMode/sdk/effortOption";
@@ -30,11 +31,17 @@ import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMod
 import { ClaudeInstallModal } from "./ClaudeInstallModal";
 import ClaudeLogo from "./logo.svg";
 import { ClaudeSettingsPanel } from "./ClaudeSettingsPanel";
+import {
+  claudeCompatibilityStore,
+  type ClaudeCompatibilityInput,
+} from "./claudeCompatibilityStore";
 
 export const CLAUDE_INSTALL_COMMAND =
   process.platform === "win32"
     ? "irm https://gist.githubusercontent.com/logancyang/7a87eb38d91015eac567521f8cc9c729/raw/install-claude-agent-mode-windows.ps1 | iex"
     : "npm install -g @anthropic-ai/claude-code";
+
+const ABSENT_INSTALL_STATE: InstallState = Object.freeze({ kind: "absent" });
 
 export function updateClaudeFields(partial: Partial<ClaudeBackendSettings>): void {
   updateAgentModeBackendFields("claude", partial);
@@ -91,6 +98,23 @@ function claudeChildEnv(settings: CopilotSettings): NodeJS.ProcessEnv {
     : process.env;
 }
 
+function claudeCompatibilityInput(
+  settings: CopilotSettings,
+  claudePath: string
+): ClaudeCompatibilityInput {
+  const overrides = settings.agentMode?.backends?.claude?.envOverrides;
+  const environmentKey = JSON.stringify(
+    Object.entries(overrides ?? {}).sort(([a], [b]) => a.localeCompare(b))
+  );
+  const source = settings.agentMode?.claudeCli?.path ? "custom" : "managed";
+  return {
+    cacheKey: `${source}\u0000${claudePath}\u0000${environmentKey}`,
+    path: claudePath,
+    source,
+    env: claudeChildEnv(settings),
+  };
+}
+
 /**
  * Resolve the `claude` CLI path from settings + auto-detection. Mirrors the
  * `getInstallState` logic: explicit override wins, otherwise the resolver
@@ -115,6 +139,32 @@ export function detectClaudeCliPath(): string | null {
 
 export function claudeCliDetectionSearchDirs(): string[] {
   return claudeBinarySearchDirs({ override: undefined, ...claudeResolverEnv() });
+}
+
+export function getClaudeInstallState(settings: CopilotSettings): InstallState {
+  const claudePath = resolveClaudeCliPath(settings);
+  if (!claudePath) return ABSENT_INSTALL_STATE;
+  return claudeCompatibilityStore.get(claudeCompatibilityInput(settings, claudePath));
+}
+
+/**
+ * Refreshes compatibility knowledge after runtime configuration changes so readiness does not remain stale.
+ * @param settings - The settings that select the executable and its runtime environment.
+ * @param force - Whether an already-settled compatibility result should be checked again.
+ */
+export async function refreshClaudeInstallState(
+  settings: CopilotSettings,
+  force = false
+): Promise<InstallState> {
+  const claudePath = resolveClaudeCliPath(settings);
+  if (!claudePath) return ABSENT_INSTALL_STATE;
+  return claudeCompatibilityStore.refresh(claudeCompatibilityInput(settings, claudePath), {
+    force,
+  });
+}
+
+export function subscribeClaudeInstallState(listener: () => void): () => void {
+  return claudeCompatibilityStore.subscribe(listener);
 }
 
 /**
@@ -164,12 +214,7 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
   },
 
   getInstallState(settings: CopilotSettings): InstallState {
-    const path = resolveClaudeCliPath(settings);
-    if (!path) return { kind: "absent" };
-    return {
-      kind: "ready",
-      source: settings.agentMode?.claudeCli?.path ? "custom" : "managed",
-    };
+    return getClaudeInstallState(settings);
   },
 
   getResolvedBinaryPath(settings: CopilotSettings): string | null {
@@ -177,11 +222,25 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
   },
 
   subscribeInstallState(_plugin: CopilotPlugin, cb: () => void): () => void {
-    return subscribeToSettingsChange((prev, next) => {
-      if (prev.agentMode?.claudeCli?.path !== next.agentMode?.claudeCli?.path) {
+    const unsubscribeSettings = subscribeToSettingsChange((prev, next) => {
+      if (
+        prev.agentMode?.claudeCli?.path !== next.agentMode?.claudeCli?.path ||
+        prev.agentMode?.backends?.claude?.envOverrides !==
+          next.agentMode?.backends?.claude?.envOverrides
+      ) {
         cb();
+        void refreshClaudeInstallState(next, true);
       }
     });
+    const unsubscribeCompatibility = subscribeClaudeInstallState(cb);
+    return () => {
+      unsubscribeSettings();
+      unsubscribeCompatibility();
+    };
+  },
+
+  async onPluginLoad(): Promise<void> {
+    await refreshClaudeInstallState(getSettings(), true);
   },
 
   openInstallUI(plugin: CopilotPlugin): void {
@@ -246,6 +305,8 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
       getManagedEnv: () => buildCopilotPlusEnv(args.clientVersion),
       checkAuth: async () =>
         (await getClaudeAuthStatus(claudePath, claudeChildEnv(getSettings()))).loggedIn,
+      checkCompatibility: () =>
+        assertClaudeVersionSupported(claudePath, claudeChildEnv(getSettings())),
       isPlanModePlanFilePath: isClaudePlanModePlanFilePath,
       getDefaultModelId: () => getSettings().agentMode?.backends?.claude?.defaultModel?.baseModelId,
       // Compose the shared system prompt — the Copilot base framing (unless the

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -61,6 +61,7 @@ import {
   OpencodeBinaryManager,
   parseVersionFromStdout,
   pickMatchingAsset,
+  toOpencodeInstallState,
   verifyOpencodeBinary,
 } from "./OpencodeBinaryManager";
 
@@ -209,6 +210,39 @@ describe("computeInstallState", () => {
     // vault synced from another device where opencode was installed (#123).
     expect(computeInstallState({ binaryPath: "/p", binaryVersion: "1.2.3" }, () => false)).toEqual({
       kind: "absent",
+    });
+  });
+});
+
+describe("OpencodeBinaryManager", () => {
+  describe("toOpencodeInstallState()", () => {
+    it("maps absent and supported installs to backend readiness", () => {
+      expect(toOpencodeInstallState({ kind: "absent" })).toEqual({ kind: "absent" });
+      expect(
+        toOpencodeInstallState({
+          kind: "installed",
+          version: OPENCODE_MIN_ACP_VERSION,
+          path: "/p",
+          source: "managed",
+        })
+      ).toEqual({ kind: "ready", source: "managed" });
+    });
+
+    it("returns the shared incompatible state for an outdated install", () => {
+      expect(
+        toOpencodeInstallState({
+          kind: "installed",
+          version: "1.15.12",
+          path: "/p",
+          source: "custom",
+        })
+      ).toEqual({
+        kind: "incompatible",
+        source: "custom",
+        currentVersion: "1.15.12",
+        minVersion: OPENCODE_MIN_ACP_VERSION,
+        message: `opencode v1.15.12 is not supported. Copilot requires opencode v${OPENCODE_MIN_ACP_VERSION} or newer.`,
+      });
     });
   });
 });

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -19,6 +19,7 @@ import { promisify } from "node:util";
 import { renameWithRetry } from "@/agentMode/skills/renameWithRetry";
 import { copilotAppDataDir } from "@/utils/appPaths";
 import { expectedBinaryName, resolveOpencodeTarget } from "./platformResolver";
+import type { InstallState as BackendInstallState } from "@/agentMode/session/types";
 
 const execFileAsync = promisify(execFile);
 const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000;
@@ -135,6 +136,24 @@ export function readOpencodeSettings(): OpencodeBackendSettings {
 export function isOpencodeVersionOutdated(version: string | undefined): boolean {
   if (!version) return false;
   return compareSemver(version, OPENCODE_MIN_ACP_VERSION) < 0;
+}
+
+/**
+ * Gives every OpenCode entry point one readiness policy so outdated installs are handled consistently.
+ * @param state - The detected OpenCode installation state to interpret for backend use.
+ */
+export function toOpencodeInstallState(state: InstallState): BackendInstallState {
+  if (state.kind === "absent") return state;
+  if (!isOpencodeVersionOutdated(state.version)) {
+    return { kind: "ready", source: state.source };
+  }
+  return {
+    kind: "incompatible",
+    source: state.source,
+    currentVersion: state.version,
+    minVersion: OPENCODE_MIN_ACP_VERSION,
+    message: `opencode v${state.version} is not supported. Copilot requires opencode v${OPENCODE_MIN_ACP_VERSION} or newer.`,
+  };
 }
 
 function updateOpencodeFields(partial: Partial<OpencodeBackendSettings>): void {

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -7,16 +7,16 @@ import {
   InstallOptions,
   isOpencodeVersionOutdated,
   ProgressEvent,
+  toOpencodeInstallState,
 } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
 import type { OpencodeBinaryManager } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
 import { detectOpencodeCliPath } from "@/agentMode/backends/opencode/descriptor";
-import type { InstallState } from "@/agentMode/session/types";
 import { ReactModal } from "@/components/modals/ReactModal";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { formatBinaryPathForDisplay } from "@/utils/binaryPath";
-import { OPENCODE_MIN_ACP_VERSION, OPENCODE_PINNED_VERSION } from "@/constants";
+import { OPENCODE_PINNED_VERSION } from "@/constants";
 import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
 import { useSettingsValue } from "@/settings/model";
@@ -207,8 +207,7 @@ const OpencodeConfigBody: React.FC<{
   const isCustom = customInstall !== null;
   const customPath = customInstall?.path ?? "";
 
-  const sessionState: InstallState =
-    local.kind === "installed" ? { kind: "ready", source: local.source } : { kind: "absent" };
+  const sessionState = toOpencodeInstallState(local);
   const detail = local.kind === "installed" ? `opencode v${local.version}` : undefined;
 
   const installedVersion = local.kind === "installed" ? local.version : null;
@@ -263,10 +262,6 @@ const OpencodeConfigBody: React.FC<{
           )}
           role="alert"
         >
-          <span>
-            opencode v{installedVersion} is out of date. Update to v{OPENCODE_MIN_ACP_VERSION}+ —
-            older versions can&apos;t report their models to the picker.
-          </span>
           {upgradeRun.kind === "running" ? (
             <>
               <p className="tw-my-0 tw-text-xs">{phaseLabel(upgradeRun.progress)}</p>

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -3,7 +3,6 @@ import * as os from "node:os";
 import { OpencodeInstallModal } from "@/agentMode/backends/opencode/OpencodeInstallModal";
 import OpencodeLogo from "@/agentMode/backends/opencode/logo.svg";
 import type CopilotPlugin from "@/main";
-import { OPENCODE_MIN_ACP_VERSION } from "@/constants";
 import { logWarn } from "@/logger";
 import {
   getSettings,
@@ -18,8 +17,8 @@ import {
 } from "./OpencodeBackend";
 import {
   computeInstallState,
-  isOpencodeVersionOutdated,
   OpencodeBinaryManager,
+  toOpencodeInstallState,
 } from "./OpencodeBinaryManager";
 import { opencodeEnabledModelEntries } from "./opencodeModelResolve";
 import { OpencodeSettingsPanel } from "./OpencodeSettingsPanel";
@@ -38,12 +37,7 @@ import type {
   ModelWireCodec,
   SessionId,
 } from "@/agentMode/session/types";
-import type {
-  BackendDescriptor,
-  BackendProcess,
-  BackendUpgradeInfo,
-  InstallState,
-} from "@/agentMode/session/types";
+import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
 
 /** Config option id OpenCode uses to switch the active agent at runtime. */
 const OPENCODE_MODE_CONFIG_OPTION_ID = "mode";
@@ -158,9 +152,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
   },
 
   getInstallState(settings: CopilotSettings): InstallState {
-    const raw = computeInstallState(settings.agentMode?.backends?.opencode);
-    if (raw.kind === "absent") return { kind: "absent" };
-    return { kind: "ready", source: raw.source };
+    return toOpencodeInstallState(computeInstallState(settings.agentMode?.backends?.opencode));
   },
 
   getResolvedBinaryPath(settings: CopilotSettings): string | null {
@@ -188,16 +180,6 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
       platform: mapNodePlatform(process.platform) ?? process.platform,
       arch: mapNodeArch(process.arch) ?? process.arch,
     }).open();
-  },
-
-  getUpgradeInfo(settings: CopilotSettings): BackendUpgradeInfo | null {
-    const state = computeInstallState(settings.agentMode?.backends?.opencode);
-    if (state.kind !== "installed" || !isOpencodeVersionOutdated(state.version)) return null;
-    return {
-      currentVersion: state.version,
-      minVersion: OPENCODE_MIN_ACP_VERSION,
-      source: state.source,
-    };
   },
 
   async upgrade(plugin: CopilotPlugin): Promise<void> {

--- a/src/agentMode/backends/shared/installStatus.test.ts
+++ b/src/agentMode/backends/shared/installStatus.test.ts
@@ -1,32 +1,56 @@
 import type { InstallState } from "@/agentMode/session/types";
 import { installBadge } from "./installStatus";
 
-describe("installBadge", () => {
-  it("returns a green 'Ready' badge with a check for ready state", () => {
-    const spec = installBadge({ kind: "ready", source: "managed" });
-    expect(spec).toEqual({
-      label: "Ready",
-      variant: "outline",
-      className: "tw-text-success",
-      showCheck: true,
+describe("installStatus", () => {
+  describe("installBadge()", () => {
+    it("returns a green 'Ready' badge with a check for ready state", () => {
+      const spec = installBadge({ kind: "ready", source: "managed" });
+      expect(spec).toEqual({
+        label: "Ready",
+        variant: "outline",
+        className: "tw-text-success",
+        showCheck: true,
+      });
     });
-  });
 
-  it("ignores source — custom and managed both read 'Ready' (no path/source on the card)", () => {
-    expect(installBadge({ kind: "ready", source: "custom" })?.label).toBe("Ready");
-    expect(installBadge({ kind: "ready", source: "managed" })?.label).toBe("Ready");
-  });
+    it("ignores source — custom and managed both read 'Ready' (no path/source on the card)", () => {
+      expect(installBadge({ kind: "ready", source: "custom" })?.label).toBe("Ready");
+      expect(installBadge({ kind: "ready", source: "managed" })?.label).toBe("Ready");
+    });
 
-  it("returns null for absent state — the missing badge is the 'not configured' signal", () => {
-    expect(installBadge({ kind: "absent" })).toBeNull();
-  });
+    it("returns null for absent state — the missing badge is the 'not configured' signal", () => {
+      expect(installBadge({ kind: "absent" })).toBeNull();
+    });
 
-  it("returns a destructive 'Error' badge carrying the message as a tooltip", () => {
-    const state: InstallState = { kind: "error", message: "boom" };
-    expect(installBadge(state)).toEqual({
-      label: "Error",
-      variant: "destructive",
-      title: "boom",
+    it("returns a destructive 'Error' badge carrying the message as a tooltip", () => {
+      const state: InstallState = { kind: "error", message: "boom" };
+      expect(installBadge(state)).toEqual({
+        label: "Error",
+        variant: "destructive",
+        title: "boom",
+      });
+    });
+
+    it("returns a shared incompatible-version badge with the requirement as a tooltip", () => {
+      const state: InstallState = {
+        kind: "incompatible",
+        source: "custom",
+        currentVersion: "2.1.205",
+        minVersion: "2.1.206",
+        message: "Claude Code 2.1.205 is not supported.",
+      };
+      expect(installBadge(state)).toEqual({
+        label: "Incompatible version",
+        variant: "destructive",
+        title: state.message,
+      });
+    });
+
+    it("returns a neutral checking badge while compatibility is being probed", () => {
+      expect(installBadge({ kind: "checking", source: "managed" })).toEqual({
+        label: "Checking…",
+        variant: "outline",
+      });
     });
   });
 });

--- a/src/agentMode/backends/shared/installStatus.tsx
+++ b/src/agentMode/backends/shared/installStatus.tsx
@@ -16,15 +16,18 @@ interface InstallBadgeSpec {
 }
 
 /**
- * Derive the card status badge from an {@link InstallState}.
- *
- * Returns `null` when the agent is not configured — the *absence* of a badge
- * is the "not configured" signal; the CTA-styled Configure button carries the
- * call to action, so no "Setup required" pill is shown on the card.
+ * Gives agent cards one status vocabulary while leaving the configure action as the missing-install signal.
+ * @param state - The backend readiness state the card needs to communicate.
  */
 export function installBadge(state: InstallState): InstallBadgeSpec | null {
   if (state.kind === "ready") {
     return { label: "Ready", variant: "outline", className: "tw-text-success", showCheck: true };
+  }
+  if (state.kind === "checking") {
+    return { label: "Checking…", variant: "outline" };
+  }
+  if (state.kind === "incompatible") {
+    return { label: "Incompatible version", variant: "destructive", title: state.message };
   }
   if (state.kind === "error") {
     return { label: "Error", variant: "destructive", title: state.message };
@@ -48,11 +51,9 @@ export const InstallBadge: React.FC<{ state: InstallState }> = ({ state }) => {
 };
 
 /**
- * Status line shown at the top of a Configure dialog: the badge plus an
- * optional verbose detail line (resolved path / version) the caller supplies,
- * since {@link InstallState} does not carry the path. Unlike the card, the
- * unconfigured state reads explicitly here ("Not configured") because the
- * dialog is where setup happens.
+ * Gives configuration dialogs a shared readiness summary so users can understand whether setup action is required.
+ * @param state - The backend readiness state the dialog needs to explain.
+ * @param detail - Optional runtime context that helps the user identify the configured installation.
  */
 export const InstallStatusLine: React.FC<{
   state: InstallState;
@@ -65,5 +66,8 @@ export const InstallStatusLine: React.FC<{
       <InstallBadge state={state} />
     )}
     {detail && <div className="tw-break-all tw-font-mono tw-text-xs tw-text-muted">{detail}</div>}
+    {(state.kind === "incompatible" || state.kind === "error") && (
+      <div className="tw-text-sm tw-text-error">{state.message}</div>
+    )}
   </div>
 );

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -549,6 +549,65 @@ describe("ClaudeSdkBackendProcess.newSession dynamic catalog", () => {
     const call = getPromptQueryCalls()[0][0] as { options: { thinking?: unknown } };
     expect(call.options.thinking).toEqual({ type: "adaptive", display: "summarized" });
   });
+
+  it("does not open a session when Claude Code is unsupported", async () => {
+    const checkCompatibility = jest
+      .fn()
+      .mockRejectedValue(new Error("Claude Code 2.1.205 is not supported"));
+    const proc = new ClaudeSdkBackendProcess({
+      pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: { vault: {} } as any,
+      clientVersion: "1.2.3",
+      descriptor: fakeDescriptor(),
+      checkCompatibility,
+    });
+
+    await expect(proc.newSession({ cwd: "/vault", mcpServers: [] })).rejects.toThrow(
+      "Claude Code 2.1.205 is not supported"
+    );
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it("shares a successful compatibility check across sessions", async () => {
+    const checkCompatibility = jest.fn().mockResolvedValue(undefined);
+    const proc = new ClaudeSdkBackendProcess({
+      pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: { vault: {} } as any,
+      clientVersion: "1.2.3",
+      descriptor: fakeDescriptor(),
+      checkCompatibility,
+    });
+
+    await Promise.all([
+      proc.newSession({ cwd: "/vault-a", mcpServers: [] }),
+      proc.newSession({ cwd: "/vault-b", mcpServers: [] }),
+    ]);
+
+    expect(checkCompatibility).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries compatibility after a failed check", async () => {
+    const checkCompatibility = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("upgrade required"))
+      .mockResolvedValueOnce(undefined);
+    const proc = new ClaudeSdkBackendProcess({
+      pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      app: { vault: {} } as any,
+      clientVersion: "1.2.3",
+      descriptor: fakeDescriptor(),
+      checkCompatibility,
+    });
+
+    await expect(proc.newSession({ cwd: "/vault", mcpServers: [] })).rejects.toThrow(
+      "upgrade required"
+    );
+    await expect(proc.newSession({ cwd: "/vault", mcpServers: [] })).resolves.toBeDefined();
+    expect(checkCompatibility).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("ANTHROPIC_MODEL env override reaches the catalog probe", () => {

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -181,6 +181,11 @@ export interface ClaudeSdkBackendProcessOptions {
    * ends without output, which forces a re-check (covers mid-session expiry).
    */
   checkAuth?: () => Promise<boolean>;
+  /**
+   * Rejects when the external Claude Code CLI cannot provide the protocol
+   * guarantees this adapter relies on. Checked before opening any session.
+   */
+  checkCompatibility?: () => Promise<void>;
 }
 
 /**
@@ -229,6 +234,8 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
    * sign-in state; set true once `checkAuth` confirms the CLI is signed in.
    */
   private authConfirmed = false;
+  private compatibilityConfirmed = false;
+  private compatibilityProbe: Promise<void> | null = null;
 
   constructor(private readonly opts: ClaudeSdkBackendProcessOptions) {
     this.bridge = new PermissionBridge({
@@ -307,6 +314,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
       mcpServers: params.mcpServers,
       projectId: params.projectId ?? null,
     });
+    await this.ensureCompatible();
     const sessionId = uuidv4();
     const cwd = params.cwd ?? null;
     const mcp: Record<string, McpServerConfig> = {};
@@ -707,6 +715,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
       { cwd: params.cwd, mcpServers: params.mcpServers, projectId: params.projectId ?? null },
       params.sessionId
     );
+    await this.ensureCompatible();
     const cwd = params.cwd ?? null;
     const mcp: Record<string, McpServerConfig> = {};
     for (const server of params.mcpServers ?? []) {
@@ -806,6 +815,23 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     });
     this.cachedModelsProbe = probePromise;
     return probePromise;
+  }
+
+  private ensureCompatible(): Promise<void> {
+    if (this.compatibilityConfirmed || !this.opts.checkCompatibility) return Promise.resolve();
+    if (this.compatibilityProbe) return this.compatibilityProbe;
+    const probe = this.opts.checkCompatibility().then(
+      () => {
+        this.compatibilityConfirmed = true;
+        this.compatibilityProbe = null;
+      },
+      (error: unknown) => {
+        this.compatibilityProbe = null;
+        throw error;
+      }
+    );
+    this.compatibilityProbe = probe;
+    return probe;
   }
 
   private computeState(sessionId: SessionId): BackendState {

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -27,7 +27,7 @@ import {
 } from "@/aiParams";
 import type { ProjectFileRecord } from "@/projects/type";
 import { getProjectContextSignature } from "@/projects/projectContextSignature";
-import type { BackendDescriptor } from "./types";
+import type { BackendDescriptor, InstallState } from "./types";
 
 const mockEnsureMaterialized = ensureProjectContextMaterialized as jest.Mock;
 
@@ -1669,11 +1669,11 @@ describe("AgentSessionManager.onInstallStateChanged", () => {
   // Builds a manager whose install state is mutable mid-test (mirrors a user
   // applying/clearing a binary path) and exposes the preloader spies.
   function buildInstallStateManager(opts: {
-    installed: boolean;
+    installState: InstallState;
     cachedState?: unknown;
     refreshResult?: Promise<void> | null;
   }) {
-    let installed = opts.installed;
+    let installState = opts.installState;
     const preloader = {
       getCachedBackendState: jest.fn(() => opts.cachedState ?? null),
       preload: jest.fn(async () => undefined),
@@ -1687,7 +1687,7 @@ describe("AgentSessionManager.onInstallStateChanged", () => {
     };
     const descriptor = {
       ...buildDescriptor(),
-      getInstallState: jest.fn(() => ({ kind: installed ? "ready" : "absent" })),
+      getInstallState: jest.fn(() => installState),
     } as unknown as BackendDescriptor;
     const mgr = new AgentSessionManager(
       buildApp(),
@@ -1700,14 +1700,16 @@ describe("AgentSessionManager.onInstallStateChanged", () => {
         >[2]["modelPreloader"],
       }
     );
-    return { mgr, preloader, setInstalled: (v: boolean) => (installed = v) };
+    return { mgr, preloader, setInstallState: (state: InstallState) => (installState = state) };
   }
 
   it("preloads a freshly-installed backend that was never probed", async () => {
     // Newly installed: nothing warm, nothing live. `restartBackend` returns
     // false, so the manager must kick a first preload — without it the picker
     // would stay empty until a plugin reload.
-    const { mgr, preloader } = buildInstallStateManager({ installed: true });
+    const { mgr, preloader } = buildInstallStateManager({
+      installState: { kind: "ready", source: "custom" },
+    });
 
     await mgr.onInstallStateChanged("opencode");
 
@@ -1720,7 +1722,7 @@ describe("AgentSessionManager.onInstallStateChanged", () => {
     // A warm probe (from load-time preload) carries the old binary; re-probe
     // it rather than spinning up a second one.
     const { mgr, preloader } = buildInstallStateManager({
-      installed: true,
+      installState: { kind: "ready", source: "custom" },
       cachedState: { model: null, mode: null },
       refreshResult: Promise.resolve(),
     });
@@ -1732,7 +1734,9 @@ describe("AgentSessionManager.onInstallStateChanged", () => {
   });
 
   it("restarts a live backend against the new binary", async () => {
-    const { mgr, preloader } = buildInstallStateManager({ installed: true });
+    const { mgr, preloader } = buildInstallStateManager({
+      installState: { kind: "ready", source: "custom" },
+    });
     await mgr.createSession();
     mockBackendShutdown.mockClear();
     preloader.preload.mockClear();
@@ -1747,19 +1751,37 @@ describe("AgentSessionManager.onInstallStateChanged", () => {
   });
 
   it("tears down and drops the warm probe when the binary is no longer available", async () => {
-    const { mgr, preloader, setInstalled } = buildInstallStateManager({ installed: true });
+    const { mgr, preloader, setInstallState } = buildInstallStateManager({
+      installState: { kind: "ready", source: "custom" },
+    });
     await mgr.createSession();
     mockBackendShutdown.mockClear();
     sessionCreateSpy.mockClear();
 
     // Path cleared / binary removed.
-    setInstalled(false);
+    setInstallState({ kind: "absent" });
     await mgr.onInstallStateChanged("opencode");
 
     expect(mockBackendShutdown).toHaveBeenCalled();
     // No replacement session is spawned for an uninstalled backend.
     expect(sessionCreateSpy).not.toHaveBeenCalled();
     expect(preloader.clearCached).toHaveBeenCalledWith("opencode");
+    expect(preloader.preload).not.toHaveBeenCalled();
+  });
+
+  it("keeps live and warm backend state while a compatibility check is in flight", async () => {
+    const { mgr, preloader } = buildInstallStateManager({
+      installState: { kind: "checking", source: "custom" },
+      cachedState: { model: null, mode: null },
+    });
+    await mgr.createSession();
+    mockBackendShutdown.mockClear();
+
+    await mgr.onInstallStateChanged("opencode");
+
+    expect(mockBackendShutdown).not.toHaveBeenCalled();
+    expect(preloader.clearCached).not.toHaveBeenCalled();
+    expect(preloader.refresh).not.toHaveBeenCalled();
     expect(preloader.preload).not.toHaveBeenCalled();
   });
 });

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -1769,6 +1769,44 @@ describe("AgentSessionManager.onInstallStateChanged", () => {
     expect(preloader.preload).not.toHaveBeenCalled();
   });
 
+  it("clears a settled preload status when the backend becomes absent", async () => {
+    const { mgr, setInstallState } = buildInstallStateManager({
+      installState: { kind: "ready", source: "custom" },
+    });
+    mgr.registerPreload("opencode", Promise.resolve());
+    await Promise.resolve();
+    expect(mgr.getPreloadStatus("opencode")).toBe("ready");
+
+    setInstallState({ kind: "absent" });
+    await mgr.onInstallStateChanged("opencode");
+
+    // "absent" is the picker's silent-omit contract — without this, the stale
+    // "ready" status keeps synthesizing selectable rows for an uninstalled
+    // backend.
+    expect(mgr.getPreloadStatus("opencode")).toBe("absent");
+  });
+
+  it("keeps the preload status when the backend becomes incompatible", async () => {
+    const { mgr, setInstallState } = buildInstallStateManager({
+      installState: { kind: "ready", source: "custom" },
+    });
+    mgr.registerPreload("opencode", Promise.resolve());
+    await Promise.resolve();
+
+    setInstallState({
+      kind: "incompatible",
+      source: "custom",
+      currentVersion: "1.0.0",
+      minVersion: "2.0.0",
+      message: "too old",
+    });
+    await mgr.onInstallStateChanged("opencode");
+
+    // Incompatible installs stay visible in the picker so a pick routes the
+    // user to the Upgrade/Configure pill.
+    expect(mgr.getPreloadStatus("opencode")).toBe("ready");
+  });
+
   it("keeps live and warm backend state while a compatibility check is in flight", async () => {
     const { mgr, preloader } = buildInstallStateManager({
       installState: { kind: "checking", source: "custom" },

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -2212,6 +2212,13 @@ export class AgentSessionManager {
       // it from respawning); `clearCached` then drops any warm probe.
       await this.restartBackend(backendId, "binary no longer available");
       this.preloader.clearCached(backendId);
+      // An uninstalled backend must vanish from the picker, so its settled
+      // preload status can't keep vouching for enabled-model fallback rows.
+      // Incompatible/error installs keep their status: their rows stay
+      // visible so a pick routes the user to the Upgrade/Configure pill.
+      if (!installState || installState.kind === "absent") {
+        if (this.preloadStatus.delete(backendId)) this.notify();
+      }
       return;
     }
     const refreshed = await this.restartBackend(backendId, "binary path changed");

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -2202,7 +2202,12 @@ export class AgentSessionManager {
    */
   async onInstallStateChanged(backendId: BackendId): Promise<void> {
     if (this.disposed) return;
-    if (!this.isBackendInstalled(backendId)) {
+    const installState = this.opts.resolveDescriptor(backendId)?.getInstallState(getSettings());
+    // Compatibility probes publish a transient checking state before their
+    // authoritative result. Keep live and warm processes intact until that
+    // result says whether the configured runtime is actually usable.
+    if (installState?.kind === "checking") return;
+    if (installState?.kind !== "ready") {
       // Tears down a live proc (the install guard in `restartBackendNow` keeps
       // it from respawning); `clearCached` then drops any warm probe.
       await this.restartBackend(backendId, "binary no longer available");

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -20,20 +20,16 @@ import type {
 /** UI-facing install/setup state for a backend. */
 export type InstallState =
   | { kind: "absent" }
+  | { kind: "checking"; source: "managed" | "custom" }
   | { kind: "ready"; source: "managed" | "custom" }
+  | {
+      kind: "incompatible";
+      source: "managed" | "custom";
+      currentVersion: string;
+      minVersion: string;
+      message: string;
+    }
   | { kind: "error"; message: string };
-
-/**
- * Reported by `getUpgradeInfo` when the installed binary is too old for the
- * plugin to drive (e.g. opencode < 1.15.13 lacks the config-option model API).
- * Generic UI renders an upgrade CTA from this; `source` selects the mechanism
- * (`upgrade` reinstalls managed binaries, runs `<cli> upgrade` for custom ones).
- */
-export interface BackendUpgradeInfo {
-  currentVersion: string;
-  minVersion: string;
-  source: "managed" | "custom";
-}
 
 /** Sign-in state for backends that authenticate via a CLI / external account. */
 export interface BackendAuthStatus {
@@ -175,13 +171,6 @@ export interface BackendDescriptor {
 
   /** Open backend-specific install/setup modal. */
   openInstallUI(plugin: CopilotPlugin): void;
-
-  /**
-   * Optional: report that the installed binary is too old for the plugin, so
-   * generic UI can surface an upgrade CTA. Returns `null` when current,
-   * unknown, not installed, or not applicable (claude/codex don't implement it).
-   */
-  getUpgradeInfo?(settings: CopilotSettings): BackendUpgradeInfo | null;
 
   /**
    * Optional: upgrade the installed binary in place (managed reinstall, or the

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -10,7 +10,6 @@ export type {
   BackendAuthStatus,
   BackendDescriptor,
   BackendSignInHandlers,
-  BackendUpgradeInfo,
   InstallState,
 } from "./descriptor";
 export type { CurrentPlan, PlanDecisionAction, PlanProposalDecision } from "./plan";

--- a/src/agentMode/ui/AgentChatInput.test.tsx
+++ b/src/agentMode/ui/AgentChatInput.test.tsx
@@ -24,7 +24,7 @@ jest.mock("@/agentMode/ui/mentionedAgents", () => ({
   EMPTY_ANSWERERS: Object.freeze([]),
   isFanout: () => false,
   resolveAnswerers: () => [],
-  listInstalledAgentBrands: () => FAKE_BRANDS,
+  useInstalledAgentBrands: () => FAKE_BRANDS,
 }));
 
 // One ChatInput mock serves both suites: it captures the brands handed to the
@@ -108,6 +108,7 @@ function renderInput(
   return render(
     <AgentChatInput
       backend={backend}
+      plugin={{} as never}
       sessionId="session-1"
       draft={draft}
       app={makeApp()}

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -25,11 +25,11 @@ import { EventTargetContext } from "@/context";
 import { logError, logWarn } from "@/logger";
 import {
   isFanout,
-  listInstalledAgentBrands,
   resolveAnswerers,
+  useInstalledAgentBrands,
 } from "@/agentMode/ui/mentionedAgents";
 import type { BackendId } from "@/agentMode/session/types";
-import { useSettingsValue } from "@/settings/model";
+import type CopilotPlugin from "@/main";
 import { buildWebTabsWithActiveSnapshot } from "@/services/webViewerService/activeWebTabSnapshot";
 import {
   isNoteSelectedTextContext,
@@ -48,6 +48,8 @@ import { v4 as uuidv4 } from "uuid";
 
 interface AgentChatInputProps {
   backend: AgentChatBackend;
+  /** Plugin instance — descriptors need it to observe backend readiness changes. */
+  plugin: CopilotPlugin;
   /** Active session's internal id; selects which per-session draft is shown. */
   sessionId: string;
   /**
@@ -178,6 +180,7 @@ async function fileToImageBlock(file: File): Promise<PromptContent | null> {
  */
 export const AgentChatInput = memo(function AgentChatInput({
   backend,
+  plugin,
   sessionId,
   draft,
   app,
@@ -194,7 +197,6 @@ export const AgentChatInput = memo(function AgentChatInput({
   contextStatusIndicator,
 }: AgentChatInputProps) {
   const eventTarget = useContext(EventTargetContext);
-  const settings = useSettingsValue();
 
   // Hold sends only while a *real* project's context is materializing. Global
   // scope never holds, so the global landing's send path is byte-identical.
@@ -213,8 +215,9 @@ export const AgentChatInput = memo(function AgentChatInput({
   // change flips the gate live; the authoritative send-time check is separate.
   const canUseMultiAgent = useCanUseMultiAgent();
 
-  // Installed agents the user can `@`-mention, recomputed only on settings change.
-  const installedAgentBrands = useMemo(() => listInstalledAgentBrands(settings), [settings]);
+  // Installed agents the user can `@`-mention; tracks settings *and* async
+  // readiness (compatibility probes settle without a settings write).
+  const installedAgentBrands = useInstalledAgentBrands(plugin);
   // Entitlement-gated typeahead list: free users get the frozen empty list so the
   // "Agents" group never renders. Both operands are stable refs (no memo needed).
   const agentBrands = canUseMultiAgent ? installedAgentBrands : EMPTY_AGENT_MENTION_BRANDS;

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -690,6 +690,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   const composerNode = (
     <AgentChatInput
       backend={backend}
+      plugin={plugin}
       sessionId={sessionId}
       draft={draft}
       app={app}

--- a/src/agentMode/ui/AgentModeChat.test.tsx
+++ b/src/agentMode/ui/AgentModeChat.test.tsx
@@ -13,7 +13,7 @@ import React from "react";
 /* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 jest.mock("@/agentMode/ui/useBackendDescriptor", () => ({
   useActiveBackendDescriptor: () => ({ id: "claude", openInstallUI: jest.fn() }),
-  useBackendInstallState: () => ({ kind: "installed" }),
+  useBackendInstallState: () => ({ kind: "ready", source: "custom" }),
 }));
 /* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 

--- a/src/agentMode/ui/AgentModeChat.tsx
+++ b/src/agentMode/ui/AgentModeChat.tsx
@@ -16,10 +16,10 @@ interface Props {
 }
 
 /**
- * Agent Mode chat surface. Owns session-manager subscription, auto-spawn of the
- * first session on mount, and the no-session fallback (status pill + minimal
- * controls). Mounted by `CopilotAgentView` (the dedicated agent pane), so this
- * component is only rendered when the agent view is open.
+ * Keeps the dedicated Agent Mode pane synchronized with the active scope and backend throughout session startup.
+ * @param plugin - The plugin instance that owns Agent Mode runtime services.
+ * @param onSaveChat - The callback that exposes the current conversation's save action.
+ * @param updateUserMessageHistory - The callback that records submitted messages for input history.
  */
 export const AgentModeChat: React.FC<Props> = ({
   plugin,
@@ -28,7 +28,7 @@ export const AgentModeChat: React.FC<Props> = ({
 }) => {
   const manager = plugin.agentSessionManager;
   const descriptor = useActiveBackendDescriptor();
-  const installState = useBackendInstallState(descriptor);
+  const installState = useBackendInstallState(descriptor, plugin);
   const [tick, setTick] = React.useState(0);
 
   React.useEffect(() => {
@@ -63,7 +63,7 @@ export const AgentModeChat: React.FC<Props> = ({
     if (manager.getSessionsForScope(manager.getActiveProjectId()).length > 0) return;
     if (manager.getIsStarting()) return;
     if (manager.getLastError()) return;
-    if (installState.kind === "absent") return;
+    if (installState.kind !== "ready") return;
     manager.getOrCreateActiveSession().catch((e) => {
       logError("[AgentMode] auto-start failed", e);
     });

--- a/src/agentMode/ui/AgentModeStatus.test.tsx
+++ b/src/agentMode/ui/AgentModeStatus.test.tsx
@@ -1,0 +1,83 @@
+import { AgentModeStatus } from "@/agentMode/ui/AgentModeStatus";
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import type { BackendDescriptor } from "@/agentMode/session/types";
+import type CopilotPlugin from "@/main";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const descriptor = {
+  id: "claude",
+  displayName: "Claude",
+  openInstallUI: jest.fn(),
+} as unknown as BackendDescriptor;
+
+let installState: ReturnType<BackendDescriptor["getInstallState"]> = {
+  kind: "ready",
+  source: "custom",
+};
+
+jest.mock("@/agentMode/ui/useBackendDescriptor", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks real hook exports
+  useSessionBackendDescriptor: () => descriptor,
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks real hook exports
+  useBackendInstallState: () => installState,
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks real hook exports
+  useBackendAuthState: () => ({ status: null, signingIn: false, url: null, signIn: jest.fn() }),
+}));
+
+jest.mock("@/settings/model", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook export
+  useSettingsValue: () => ({}),
+}));
+
+describe("AgentModeStatus", () => {
+  describe("AgentModeStatus()", () => {
+    beforeEach(() => {
+      installState = { kind: "ready", source: "custom" };
+      jest.clearAllMocks();
+    });
+
+    it("renders the actionable backend boot error instead of a generic retry label", () => {
+      const error =
+        "Claude Code 2.1.205 is not supported. Copilot requires Claude Code 2.1.206 or newer. Update Claude Code with: npm install -g @anthropic-ai/claude-code";
+      const manager = {
+        subscribe: jest.fn(() => () => {}),
+        getLastError: jest.fn(() => error),
+        getOrCreateActiveSession: jest.fn(),
+      } as unknown as AgentSessionManager;
+      const plugin = { app: {} } as unknown as CopilotPlugin;
+
+      render(<AgentModeStatus manager={manager} plugin={plugin} onInstallClick={jest.fn()} />);
+
+      expect(screen.getByRole("alert")).toBeTruthy();
+      expect(screen.getByText(error)).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+      expect(screen.queryByText("Error — click Retry")).toBeNull();
+    });
+
+    it("opens Claude configuration instead of retrying an incompatible version", () => {
+      const message =
+        "Claude Code 2.1.205 is not supported. Copilot requires Claude Code 2.1.206 or newer.";
+      installState = {
+        kind: "incompatible",
+        source: "custom",
+        currentVersion: "2.1.205",
+        minVersion: "2.1.206",
+        message,
+      };
+      const manager = {
+        subscribe: jest.fn(() => () => {}),
+        getLastError: jest.fn(() => `${message} Update with npm install`),
+        getOrCreateActiveSession: jest.fn(),
+      } as unknown as AgentSessionManager;
+      const plugin = { app: {} } as unknown as CopilotPlugin;
+
+      render(<AgentModeStatus manager={manager} plugin={plugin} onInstallClick={jest.fn()} />);
+
+      expect(screen.getByText(message)).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Configure Claude" }));
+      expect(descriptor.openInstallUI).toHaveBeenCalledWith(plugin);
+    });
+  });
+});

--- a/src/agentMode/ui/AgentModeStatus.tsx
+++ b/src/agentMode/ui/AgentModeStatus.tsx
@@ -8,7 +8,6 @@ import { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
 import type CopilotPlugin from "@/main";
-import { useSettingsValue } from "@/settings/model";
 import { Notice } from "obsidian";
 import React from "react";
 
@@ -22,17 +21,15 @@ interface Props {
 }
 
 /**
- * Inline status pill rendered above the chat input in Agent Mode. Only
- * surfaces actionable states: install gap (binary missing) and boot error
- * (Retry). Every healthy state renders nothing — the chat input already
- * conveys readiness.
+ * Leads users from Agent Mode failures to the relevant recovery action without adding noise to healthy sessions.
+ * @param manager - The session manager that exposes startup failures and retry behavior.
+ * @param plugin - The plugin instance needed to run backend recovery actions.
+ * @param onInstallClick - The action to start setup when the selected backend is absent.
  */
 export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallClick }) => {
   const descriptor = useSessionBackendDescriptor(manager);
-  const installState = useBackendInstallState(descriptor);
+  const installState = useBackendInstallState(descriptor, plugin);
   const auth = useBackendAuthState(descriptor);
-  const settings = useSettingsValue();
-  const upgradeInfo = descriptor.getUpgradeInfo?.(settings) ?? null;
   const [upgrading, setUpgrading] = React.useState(false);
 
   // Re-render on manager notify so `lastError` flips are picked up.
@@ -67,9 +64,21 @@ export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallCli
     );
   }
 
-  // An outdated binary can't drive the model picker (opencode < 1.15.13 lost the
-  // model API), so prompt an upgrade before auth or anything else.
-  if (upgradeInfo) {
+  if (installState.kind === "checking") {
+    return (
+      <div
+        className={cn(
+          "tw-flex tw-items-center tw-justify-between tw-gap-2 tw-rounded",
+          "tw-bg-secondary tw-px-3 tw-py-2 tw-text-xs tw-text-muted"
+        )}
+      >
+        <span>Checking {descriptor.displayName} version…</span>
+      </div>
+    );
+  }
+
+  if (installState.kind === "incompatible") {
+    const canUpgrade = descriptor.upgrade !== undefined;
     return (
       <div
         className={cn(
@@ -78,12 +87,40 @@ export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallCli
         )}
         role="alert"
       >
-        <span>
-          {descriptor.displayName} {upgradeInfo.currentVersion} is out of date — update to{" "}
-          {upgradeInfo.minVersion}+ to choose models.
+        <span>{installState.message}</span>
+        <Button
+          className="tw-shrink-0"
+          variant="default"
+          size="sm"
+          disabled={canUpgrade && upgrading}
+          onClick={canUpgrade ? handleUpgrade : () => descriptor.openInstallUI(plugin)}
+        >
+          {canUpgrade
+            ? upgrading
+              ? "Upgrading…"
+              : "Upgrade"
+            : `Configure ${descriptor.displayName}`}
+        </Button>
+      </div>
+    );
+  }
+
+  if (installState.kind === "error") {
+    return (
+      <div
+        className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-rounded tw-bg-secondary tw-px-3 tw-py-2 tw-text-xs"
+        role="alert"
+      >
+        <span className="tw-min-w-0 tw-flex-1 tw-break-words tw-text-error">
+          {installState.message}
         </span>
-        <Button variant="default" size="sm" disabled={upgrading} onClick={handleUpgrade}>
-          {upgrading ? "Upgrading…" : "Upgrade"}
+        <Button
+          className="tw-shrink-0"
+          variant="ghost"
+          size="sm"
+          onClick={() => descriptor.openInstallUI(plugin)}
+        >
+          Configure {descriptor.displayName}
         </Button>
       </div>
     );
@@ -132,9 +169,12 @@ export const AgentModeStatus: React.FC<Props> = ({ manager, plugin, onInstallCli
   };
 
   return (
-    <div className="tw-flex tw-items-center tw-justify-between tw-rounded tw-bg-secondary tw-px-3 tw-py-2 tw-text-xs">
-      <span className="tw-text-error">Error — click Retry</span>
-      <Button variant="ghost" size="sm" onClick={handleRetry}>
+    <div
+      className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-rounded tw-bg-secondary tw-px-3 tw-py-2 tw-text-xs"
+      role="alert"
+    >
+      <span className="tw-min-w-0 tw-flex-1 tw-break-words tw-text-error">{bootError}</span>
+      <Button className="tw-shrink-0" variant="ghost" size="sm" onClick={handleRetry}>
         Retry
       </Button>
     </div>

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -145,6 +145,7 @@ function makeUIState(opts: {
 
 function makeManager(opts: {
   cachedStateById?: Record<string, BackendState | null>;
+  preloadStatusById?: Record<string, "pending" | "ready" | "error" | "absent">;
   effortCatalogById?: Record<string, Record<string, EffortOption[]>>;
   defaultSelectionById?: Record<string, { baseModelId: string; effort: string | null } | null>;
   setDefaultBackend?: jest.Mock;
@@ -155,6 +156,7 @@ function makeManager(opts: {
 }): AgentSessionManager {
   return {
     getCachedBackendState: (id: string) => opts.cachedStateById?.[id] ?? null,
+    getPreloadStatus: (id: string) => opts.preloadStatusById?.[id] ?? "absent",
     getEffortCatalog: (id: string) => opts.effortCatalogById?.[id] ?? null,
     getDefaultSelection: (id: string) => opts.defaultSelectionById?.[id] ?? null,
     setDefaultBackend: opts.setDefaultBackend ?? jest.fn(),
@@ -170,6 +172,65 @@ const emptySettings = {} as CopilotSettings;
 // ---- buildPickerEntries ----
 
 describe("buildPickerEntries", () => {
+  it("keeps enabled models selectable when a settled preload has no live catalog", () => {
+    const claude = {
+      ...makeDescriptor("claude"),
+      getEnabledModelEntries: () => [
+        { baseModelId: "default", name: "Default", credentialState: "ok" as const },
+        { baseModelId: "sonnet", name: "Sonnet", credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = makeManager({
+      cachedStateById: { claude: null },
+      preloadStatusById: { claude: "ready" },
+    });
+    const ctx: ModelActiveContext = {
+      activeSession: null,
+      activeChatUIState: null,
+      activeBackendId: null,
+      activeDescriptor: undefined,
+      activeSessionHasHistory: false,
+      activeModelState: null,
+      activeCurrentEntry: undefined,
+    };
+
+    const { entries } = buildPickerEntries(manager, [claude], ctx, emptySettings);
+
+    expect(entries.map((entry) => entry.name)).toEqual(["default", "sonnet"]);
+    expect(entries.every((entry) => entry._disabledReason === undefined)).toBe(true);
+  });
+
+  it("does not invent model rows when the backend intentionally reports mode-only state", () => {
+    const descriptor = {
+      ...makeDescriptor("claude"),
+      getEnabledModelEntries: () => [
+        { baseModelId: "stale", name: "Stale", credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = makeManager({
+      cachedStateById: {
+        claude: {
+          model: null,
+          mode: { current: null, options: [], apply: {} },
+        },
+      },
+      preloadStatusById: { claude: "ready" },
+    });
+    const ctx: ModelActiveContext = {
+      activeSession: null,
+      activeChatUIState: null,
+      activeBackendId: null,
+      activeDescriptor: undefined,
+      activeSessionHasHistory: false,
+      activeModelState: null,
+      activeCurrentEntry: undefined,
+    };
+
+    const { entries } = buildPickerEntries(manager, [descriptor], ctx, emptySettings);
+
+    expect(entries).toHaveLength(0);
+  });
+
   it("hides non-active backend sections once the active session has history", () => {
     const codex = makeDescriptor("codex");
     const claude = makeDescriptor("claude");

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -66,22 +66,10 @@ export function handlePickerSwitchError(err: unknown, action: "model" | "effort"
 export const AGENT_PROVIDER = "agent";
 
 /**
- * Append one backend's section to the picker.
- *
- * One policy for every backend, via `getEnabledModelEntries`: iterate the
- * backend's *enabled* models, enriched by the reported catalog when present.
- * Every enabled model appears — one the agent dropped for a missing key, or
- * no longer reports at all, is shown non-selectable with a flag
- * (`"Add API key"`, `"Not offered by agent"`, …) rather than silently hidden.
- * Agent-native backends (claude, codex) report `credentialState: "ok"`, so
- * their only flag is `"Not offered by agent"` for a stale enabled id.
- *
- * The active session's selection (and an inactive backend's persisted default)
- * is always kept via `keepBaseModelId`. A descriptor that implements no
- * `getEnabledModelEntries` opts out entirely; `buildPickerEntries` still re-adds
- * the active selection if curation stranded it. During preload (no reported
- * catalog yet) we defer to the "Loading…" placeholder `buildPickerEntries`
- * adds, so we don't flag "Not offered by agent" before the catalog loads.
+ * Preserves usable and stranded choices for one backend so credential or catalog drift never hides recovery paths.
+ * @param entries - The picker entries being assembled across backends.
+ * @param descriptor - The backend whose model choices and selection policy should be represented.
+ * @param ctx - The catalog, settings, and active-selection context for this backend.
  */
 export function appendBackendSection(
   entries: ModelSelectorEntry[],
@@ -93,13 +81,17 @@ export function appendBackendSection(
     keepBaseModelId: string | null;
     /** Current settings — read by `getEnabledModelEntries`. */
     settings: CopilotSettings;
+    /** Preload settled without a catalog, so persisted enabled models are the only recovery path. */
+    useEnabledFallback?: boolean;
   }
 ): void {
   const enabledEntries = descriptor.getEnabledModelEntries?.(ctx.settings) ?? null;
   if (!enabledEntries) return;
-  // Preload still pending → no reported catalog yet; let buildPickerEntries
-  // render the Loading placeholder instead of flagging prematurely.
-  if (!ctx.backendModels) return;
+  if (!ctx.backendModels) {
+    if (!ctx.useEnabledFallback) return;
+    appendEnabledFallbackEntries(entries, descriptor, enabledEntries);
+    return;
+  }
   appendFromEnabledEntries(
     entries,
     descriptor,
@@ -107,6 +99,25 @@ export function appendBackendSection(
     ctx.backendModels,
     ctx.keepBaseModelId
   );
+}
+
+function appendEnabledFallbackEntries(
+  entries: ModelSelectorEntry[],
+  descriptor: BackendDescriptor,
+  enabledEntries: ReadonlyArray<EnabledModelEntry>
+): void {
+  for (const enabled of enabledEntries) {
+    const entry = synthesizeAgentEntry(
+      enabled.baseModelId,
+      enabled.name || enabled.baseModelId,
+      descriptor,
+      enabled.description,
+      enabled.isFree,
+      enabled.capabilities
+    );
+    if (enabled.credentialState === "missing_key") entry._disabledReason = MISSING_KEY_LABEL;
+    entries.push(entry);
+  }
 }
 
 /**
@@ -276,11 +287,11 @@ export function collectModelActiveContext(manager: AgentSessionManager): ModelAc
 }
 
 /**
- * Build one entry per registered backend (filtered by overrides and
- * sticky-selection preservation), then locate the active selection. If
- * curation stranded the user's current model, prepend a synthesized entry
- * so it remains visible. Returns the entries array and the resolved
- * `valueKey`.
+ * Builds a cross-backend picker that keeps the active choice visible through preload gaps and catalog changes.
+ * @param manager - The session manager that owns live and cached backend selection state.
+ * @param descriptors - The registered backends that may contribute picker choices.
+ * @param ctx - The active session and model context that must remain stable in the picker.
+ * @param settings - The persisted configuration used to determine enabled choices.
  */
 export function buildPickerEntries(
   manager: AgentSessionManager,
@@ -297,20 +308,26 @@ export function buildPickerEntries(
       ? (ctx.activeModelState?.current.baseModelId ?? null)
       : (manager.getDefaultSelection(descriptor.id)?.baseModelId ?? null);
     const backendModels = cached?.model?.availableModels ?? null;
+    const hasNoCachedState = cached === null;
+    const preloadStatus = manager.getPreloadStatus(descriptor.id);
+    const sectionStart = entries.length;
     appendBackendSection(entries, descriptor, {
       backendModels,
       keepBaseModelId,
       settings,
+      useEnabledFallback:
+        hasNoCachedState && (preloadStatus === "ready" || preloadStatus === "error"),
     });
     // No catalog cached yet (and not because the agent intentionally
     // omitted a model state). Show a per-backend loading / failure row so
     // the user can see every installed backend immediately — important
     // because the chat now unblocks on just the *active* backend's
     // preload, not the global preload.
-    if (!backendModels) {
-      const status = manager.getPreloadStatus(descriptor.id);
-      if (status === "pending" || status === "error") {
-        entries.push(synthesizePreloadPlaceholder(descriptor, status));
+    if (hasNoCachedState && entries.length === sectionStart) {
+      if (preloadStatus === "pending") {
+        entries.push(synthesizePreloadPlaceholder(descriptor, "pending"));
+      } else if (preloadStatus === "ready" || preloadStatus === "error") {
+        entries.push(synthesizePreloadPlaceholder(descriptor, "error"));
       }
     }
   }

--- a/src/agentMode/ui/mentionedAgents.test.ts
+++ b/src/agentMode/ui/mentionedAgents.test.ts
@@ -4,14 +4,21 @@ import {
   isFanout,
   listInstalledAgentBrands,
   resolveAnswerers,
+  useInstalledAgentBrands,
 } from "@/agentMode/ui/mentionedAgents";
 import type { BackendDescriptor, InstallState } from "@/agentMode/session/types";
+import type CopilotPlugin from "@/main";
 import type { CopilotSettings } from "@/settings/model";
+import { act, renderHook } from "@testing-library/react";
 
 const Icon = () => null;
 
 jest.mock("@/agentMode/backends/registry", () => ({
   listBackendDescriptors: jest.fn(),
+}));
+
+jest.mock("@/settings/model", () => ({
+  useSettingsValue: () => ({}),
 }));
 
 import { listBackendDescriptors } from "@/agentMode/backends/registry";
@@ -53,6 +60,38 @@ describe("listInstalledAgentBrands", () => {
   it("returns the frozen empty constant when nothing is installed", () => {
     mockedList.mockReturnValue([descriptor("opencode", { kind: "absent" })]);
     expect(listInstalledAgentBrands(settings)).toBe(EMPTY_AGENT_BRANDS);
+  });
+});
+
+describe("useInstalledAgentBrands", () => {
+  it("re-lists a backend whose readiness settles without a settings write", () => {
+    let install: InstallState = { kind: "checking", source: "managed" };
+    const listeners = new Set<() => void>();
+    mockedList.mockReturnValue([
+      {
+        id: "claude",
+        displayName: "Claude",
+        Icon,
+        getInstallState: () => install,
+        subscribeInstallState: (_plugin: CopilotPlugin, cb: () => void) => {
+          listeners.add(cb);
+          return () => listeners.delete(cb);
+        },
+      } as unknown as BackendDescriptor,
+    ]);
+
+    const { result, unmount } = renderHook(() => useInstalledAgentBrands({} as CopilotPlugin));
+    expect(result.current).toBe(EMPTY_AGENT_BRANDS);
+
+    // The compatibility probe settles ready — no settings write involved.
+    act(() => {
+      install = { kind: "ready", source: "managed" };
+      listeners.forEach((cb) => cb());
+    });
+    expect(result.current.map((b) => b.id)).toEqual(["claude"]);
+
+    unmount();
+    expect(listeners.size).toBe(0);
   });
 });
 

--- a/src/agentMode/ui/mentionedAgents.test.ts
+++ b/src/agentMode/ui/mentionedAgents.test.ts
@@ -30,11 +30,19 @@ function descriptor(id: string, install: InstallState): BackendDescriptor {
 const settings = {} as CopilotSettings;
 
 describe("listInstalledAgentBrands", () => {
-  it("offers only installed (ready) backends projected to brands; excludes absent/errored", () => {
+  it("offers only ready backends; excludes absent, checking, incompatible, and errored", () => {
     mockedList.mockReturnValue([
       descriptor("opencode", { kind: "ready", source: "managed" }),
       descriptor("claude", { kind: "absent" }),
       descriptor("codex", { kind: "error", message: "boom" }),
+      descriptor("checking", { kind: "checking", source: "custom" }),
+      descriptor("old", {
+        kind: "incompatible",
+        source: "custom",
+        currentVersion: "1.0.0",
+        minVersion: "2.0.0",
+        message: "too old",
+      }),
     ]);
 
     const brands = listInstalledAgentBrands(settings);

--- a/src/agentMode/ui/mentionedAgents.ts
+++ b/src/agentMode/ui/mentionedAgents.ts
@@ -1,6 +1,8 @@
+import React from "react";
 import { listBackendDescriptors } from "@/agentMode/backends/registry";
 import type { AgentBrand } from "@/agentMode/session/types";
-import type { CopilotSettings } from "@/settings/model";
+import type CopilotPlugin from "@/main";
+import { useSettingsValue, type CopilotSettings } from "@/settings/model";
 
 // Fan-out routing lives in session/fanout so the session layer can share it
 // without depending on the UI. Re-exported here for the composer.
@@ -18,4 +20,40 @@ export function listInstalledAgentBrands(settings: CopilotSettings): ReadonlyArr
     .filter((descriptor) => descriptor.getInstallState(settings).kind === "ready")
     .map(({ id, displayName, Icon }) => ({ id, displayName, Icon }) satisfies AgentBrand);
   return brands.length > 0 ? brands : EMPTY_AGENT_BRANDS;
+}
+
+/**
+ * Keeps the composer's mentionable-agent set current as backend readiness
+ * settles. Readiness can change without a settings write (compatibility
+ * probes publish asynchronously), so a settings-keyed memo alone would leave
+ * a just-verified backend missing from `@agent` suggestions and the send-time
+ * allowlist until an unrelated settings edit.
+ * @param plugin - The plugin instance descriptors need to observe readiness changes.
+ */
+export function useInstalledAgentBrands(plugin: CopilotPlugin): ReadonlyArray<AgentBrand> {
+  const settings = useSettingsValue();
+  const subscribe = React.useCallback(
+    (listener: () => void) => {
+      const unsubs = listBackendDescriptors().map((descriptor) =>
+        descriptor.subscribeInstallState(plugin, listener)
+      );
+      return () => unsubs.forEach((unsub) => unsub());
+    },
+    [plugin]
+  );
+  // Snapshot exactly what the brand list consumes — ready-backend membership —
+  // so probe-settled transitions re-render and everything else is ignored.
+  const getSnapshot = React.useCallback(
+    () =>
+      listBackendDescriptors()
+        .filter((descriptor) => descriptor.getInstallState(settings).kind === "ready")
+        .map((descriptor) => descriptor.id)
+        .join(","),
+    [settings]
+  );
+  const readyIds = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return React.useMemo(() => {
+    void readyIds;
+    return listInstalledAgentBrands(settings);
+  }, [settings, readyIds]);
 }

--- a/src/agentMode/ui/useBackendDescriptor.test.tsx
+++ b/src/agentMode/ui/useBackendDescriptor.test.tsx
@@ -1,0 +1,168 @@
+import { act, renderHook } from "@testing-library/react";
+import { backendRegistry, getActiveBackendDescriptor } from "@/agentMode/backends/registry";
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import type { BackendDescriptor, InstallState } from "@/agentMode/session/types";
+import type CopilotPlugin from "@/main";
+import type { CopilotSettings } from "@/settings/model";
+import React from "react";
+import { useBackendInstallState, useSessionBackendDescriptor } from "./useBackendDescriptor";
+
+let mockSettings = {} as CopilotSettings;
+
+jest.mock("@/settings/model", () => ({
+  useSettingsValue: () => React.useMemo(() => mockSettings, []),
+}));
+
+jest.mock("@/agentMode/backends/registry", () => ({
+  backendRegistry: {},
+  getActiveBackendDescriptor: jest.fn(),
+}));
+
+const mockGetActiveBackendDescriptor = getActiveBackendDescriptor as jest.MockedFunction<
+  typeof getActiveBackendDescriptor
+>;
+const registry = backendRegistry;
+
+function descriptor(id: string): BackendDescriptor {
+  return { id } as BackendDescriptor;
+}
+
+function makeManager() {
+  let startingBackendId: string | null = null;
+  let activeBackendId: string | null = null;
+  const listeners = new Set<() => void>();
+  const manager = {
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getStartingBackendId: () => startingBackendId,
+    getActiveSession: () => (activeBackendId ? { backendId: activeBackendId } : null),
+  } as unknown as AgentSessionManager;
+
+  return {
+    manager,
+    emit: (next: { starting?: string | null; active?: string | null }) => {
+      if (next.starting !== undefined) startingBackendId = next.starting;
+      if (next.active !== undefined) activeBackendId = next.active;
+      for (const listener of listeners) listener();
+    },
+    unsubscribed: () => listeners.size === 0,
+  };
+}
+
+function makeInstallDescriptor(initial: InstallState) {
+  let state = initial;
+  const listeners = new Set<() => void>();
+  const backend = {
+    id: "claude",
+    getInstallState: () => ({ ...state }),
+    subscribeInstallState: (_plugin: CopilotPlugin, listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  } as unknown as BackendDescriptor;
+
+  return {
+    backend,
+    emit: (next: InstallState) => {
+      state = next;
+      for (const listener of listeners) listener();
+    },
+    unsubscribed: () => listeners.size === 0,
+  };
+}
+
+describe("useBackendDescriptor", () => {
+  beforeEach(() => {
+    mockSettings = {} as CopilotSettings;
+    mockGetActiveBackendDescriptor.mockReset();
+    for (const id of Object.keys(registry)) delete registry[id];
+  });
+
+  describe("useSessionBackendDescriptor()", () => {
+    it("tracks starting and active session backend changes", () => {
+      const fallback = descriptor("fallback");
+      const claude = descriptor("claude");
+      const codex = descriptor("codex");
+      registry.claude = claude;
+      registry.codex = codex;
+      mockGetActiveBackendDescriptor.mockReturnValue(fallback);
+      const fake = makeManager();
+      const { result } = renderHook(() => useSessionBackendDescriptor(fake.manager));
+
+      expect(result.current).toBe(fallback);
+      act(() => fake.emit({ active: "codex" }));
+      expect(result.current).toBe(codex);
+      act(() => fake.emit({ starting: "claude" }));
+      expect(result.current).toBe(claude);
+      act(() => fake.emit({ starting: null }));
+      expect(result.current).toBe(codex);
+    });
+
+    it("unsubscribes from manager changes on unmount", () => {
+      mockGetActiveBackendDescriptor.mockReturnValue(descriptor("fallback"));
+      const fake = makeManager();
+      const { unmount } = renderHook(() => useSessionBackendDescriptor(fake.manager));
+
+      unmount();
+
+      expect(fake.unsubscribed()).toBe(true);
+    });
+  });
+
+  describe("useBackendInstallState()", () => {
+    it("updates when the install-state value changes despite fresh descriptor objects", () => {
+      const fake = makeInstallDescriptor({ kind: "checking", source: "custom" });
+      const plugin = {} as CopilotPlugin;
+      const { result } = renderHook(() => useBackendInstallState(fake.backend, plugin));
+
+      expect(result.current).toEqual({ kind: "checking", source: "custom" });
+      act(() =>
+        fake.emit({
+          kind: "incompatible",
+          source: "custom",
+          currentVersion: "2.1.205",
+          minVersion: "2.1.206",
+          message: "Update Claude Code.",
+        })
+      );
+      expect(result.current).toEqual({
+        kind: "incompatible",
+        source: "custom",
+        currentVersion: "2.1.205",
+        minVersion: "2.1.206",
+        message: "Update Claude Code.",
+      });
+    });
+
+    it("skips rerenders when a notification does not change install state", () => {
+      const ready: InstallState = { kind: "ready", source: "custom" };
+      const fake = makeInstallDescriptor(ready);
+      const plugin = {} as CopilotPlugin;
+      let renderCount = 0;
+      const { result } = renderHook(() => {
+        renderCount += 1;
+        return useBackendInstallState(fake.backend, plugin);
+      });
+      const before = result.current;
+      const rendersBeforeNotification = renderCount;
+
+      act(() => fake.emit(ready));
+
+      expect(renderCount).toBe(rendersBeforeNotification);
+      expect(result.current).toBe(before);
+    });
+
+    it("unsubscribes from install-state changes on unmount", () => {
+      const fake = makeInstallDescriptor({ kind: "absent" });
+      const { unmount } = renderHook(() =>
+        useBackendInstallState(fake.backend, {} as CopilotPlugin)
+      );
+
+      unmount();
+
+      expect(fake.unsubscribed()).toBe(true);
+    });
+  });
+});

--- a/src/agentMode/ui/useBackendDescriptor.ts
+++ b/src/agentMode/ui/useBackendDescriptor.ts
@@ -5,6 +5,27 @@ import { logError } from "@/logger";
 import { useSettingsValue } from "@/settings/model";
 import { Notice } from "obsidian";
 import React from "react";
+import type CopilotPlugin from "@/main";
+
+function installStateSignature(state: InstallState): string {
+  switch (state.kind) {
+    case "absent":
+      return "absent";
+    case "checking":
+    case "ready":
+      return `${state.kind}:${state.source}`;
+    case "incompatible":
+      return JSON.stringify([
+        state.kind,
+        state.source,
+        state.currentVersion,
+        state.minVersion,
+        state.message,
+      ]);
+    case "error":
+      return JSON.stringify([state.kind, state.message]);
+  }
+}
 
 /** Resolve the active (default) backend descriptor from settings. */
 export function useActiveBackendDescriptor(): BackendDescriptor {
@@ -25,13 +46,15 @@ export function useSessionBackendDescriptor(
   manager: AgentSessionManager | null | undefined
 ): BackendDescriptor {
   const settings = useSettingsValue();
-  const [, forceRender] = React.useState(0);
-  React.useEffect(() => {
-    if (!manager) return;
-    return manager.subscribe(() => forceRender((n) => n + 1));
-  }, [manager]);
-  const sessionBackendId =
-    manager?.getStartingBackendId() ?? manager?.getActiveSession()?.backendId;
+  const subscribe = React.useCallback(
+    (listener: () => void) => manager?.subscribe(listener) ?? (() => {}),
+    [manager]
+  );
+  const getSnapshot = React.useCallback(
+    () => manager?.getStartingBackendId() ?? manager?.getActiveSession()?.backendId ?? null,
+    [manager]
+  );
+  const sessionBackendId = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   if (sessionBackendId) {
     const desc = backendRegistry[sessionBackendId];
     if (desc) return desc;
@@ -39,9 +62,31 @@ export function useSessionBackendDescriptor(
   return getActiveBackendDescriptor(settings);
 }
 
-/** Compute the descriptor's current install state. Recomputes each render. */
-export function useBackendInstallState(descriptor: BackendDescriptor): InstallState {
-  return descriptor.getInstallState(useSettingsValue());
+/**
+ * Keeps backend readiness UI synchronized with settings and asynchronous runtime checks.
+ * A semantic signature is the external-store snapshot because some descriptors allocate
+ * a new state object on every read even when its value has not changed.
+ * @param descriptor - The backend whose readiness should be observed.
+ * @param plugin - The plugin instance used to subscribe to backend-specific readiness changes.
+ */
+export function useBackendInstallState(
+  descriptor: BackendDescriptor,
+  plugin: CopilotPlugin
+): InstallState {
+  const settings = useSettingsValue();
+  const subscribe = React.useCallback(
+    (listener: () => void) => descriptor.subscribeInstallState(plugin, listener),
+    [descriptor, plugin]
+  );
+  const getSnapshot = React.useCallback(
+    () => installStateSignature(descriptor.getInstallState(settings)),
+    [descriptor, settings]
+  );
+  const signature = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return React.useMemo(() => {
+    void signature;
+    return descriptor.getInstallState(settings);
+  }, [descriptor, settings, signature]);
 }
 
 export interface BackendAuthUiState {

--- a/src/settings/v2/components/AgentSettings.test.tsx
+++ b/src/settings/v2/components/AgentSettings.test.tsx
@@ -22,12 +22,18 @@ jest.mock("@/hooks/useChatBackendModelOptions", () => ({
 
 const Icon: React.FC<{ className?: string }> = () => <svg data-testid="icon" />;
 
+const installStates: Record<string, { kind: string; [key: string]: unknown }> = {
+  opencode: { kind: "ready", source: "managed" },
+  claude: { kind: "ready", source: "custom" },
+  codex: { kind: "ready", source: "custom" },
+};
+
 function makeDescriptor(id: string, displayName: string) {
   return {
     id,
     displayName,
     Icon,
-    getInstallState: () => ({ kind: "ready" as const }),
+    getInstallState: () => installStates[id],
     getResolvedBinaryPath: () => null,
     openInstallUI: jest.fn(),
     SettingsPanel: () => <div data-testid={`panel-${id}`}>settings panel</div>,
@@ -43,6 +49,9 @@ const DESCRIPTORS = [
 jest.mock("@/agentMode", () => ({
   listBackendDescriptors: () => DESCRIPTORS,
   InstallBadge: () => <span data-testid="install-badge" />,
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook export
+  useBackendInstallState: (descriptor: { getInstallState: () => unknown }) =>
+    descriptor.getInstallState(),
   McpServersPanel: () => <div data-testid="mcp-panel">mcp</div>,
   AgentDefaultModelSetting: ({ descriptor }: { descriptor: { id: string } }) => (
     <div data-testid={`default-model-${descriptor.id}`}>default model</div>
@@ -71,6 +80,12 @@ jest.mock("./ConfiguredModelEnableList", () => ({
 }));
 
 describe("AgentSettings", () => {
+  beforeEach(() => {
+    installStates.opencode = { kind: "ready", source: "managed" };
+    installStates.claude = { kind: "ready", source: "custom" };
+    installStates.codex = { kind: "ready", source: "custom" };
+  });
+
   it("renders the four sub-tabs in order: OpenCode, Claude, Codex, Quick Chat", () => {
     render(<AgentSettings />);
     const tabs = screen.getAllByRole("tab").map((t) => t.textContent);
@@ -111,5 +126,24 @@ describe("AgentSettings", () => {
     expect(screen.queryByTestId("chat-model-list")).toBeNull();
     fireEvent.click(screen.getByText("Quick Chat"));
     expect(screen.getByTestId("chat-model-list")).not.toBeNull();
+  });
+
+  it("shows an incompatible-version message and hides ready-only model controls", () => {
+    const message =
+      "Claude Code 2.1.205 is not supported. Copilot requires Claude Code 2.1.206 or newer.";
+    installStates.claude = {
+      kind: "incompatible",
+      source: "custom",
+      currentVersion: "2.1.205",
+      minVersion: "2.1.206",
+      message,
+    };
+
+    render(<AgentSettings />);
+    fireEvent.click(screen.getByRole("tab", { name: "Claude" }));
+
+    expect(screen.getByText(message)).toBeTruthy();
+    expect(screen.queryByTestId("default-model-claude")).toBeNull();
+    expect(screen.queryByTestId("model-list-claude")).toBeNull();
   });
 });

--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -3,6 +3,7 @@ import {
   InstallBadge,
   listBackendDescriptors,
   McpServersPanel,
+  useBackendInstallState,
   type BackendDescriptor,
   type BackendId,
 } from "@/agentMode";
@@ -204,7 +205,7 @@ const BackendPanel: React.FC<{
   const Panel = descriptor.SettingsPanel;
   const manager = plugin.agentSessionManager;
 
-  const installState = descriptor.getInstallState(settings);
+  const installState = useBackendInstallState(descriptor, plugin);
   const resolvedPath = descriptor.getResolvedBinaryPath?.(settings) ?? null;
 
   // Probe when ready but uncached — the load-time preload may have skipped this
@@ -234,6 +235,9 @@ const BackendPanel: React.FC<{
               <TruncatedText className="tw-max-w-[90%] tw-font-mono tw-text-xs tw-text-muted">
                 {formatBinaryPathForDisplay(resolvedPath)}
               </TruncatedText>
+            )}
+            {(installState.kind === "incompatible" || installState.kind === "error") && (
+              <span className="tw-text-xs tw-text-error">{installState.message}</span>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Problem

Backend readiness treated an executable path as sufficient even when the installed CLI could not satisfy the runtime contract. Unsupported Claude Code versions could appear ready in Settings and chat, then fail only when a session started. OpenCode exposed a separate upgrade path, so install-state behavior was inconsistent across backends.

## Fix
<img width="584" height="564" alt="Screenshot 2026-07-14 at 9 50 54 PM" src="https://github.com/user-attachments/assets/1503025c-d4dd-48a2-90b7-3b958a479370" />
<img width="568" height="125" alt="Screenshot 2026-07-14 at 9 51 07 PM" src="https://github.com/user-attachments/assets/6ef1530d-d8bd-44d3-90fb-8bcfbeaae181" />
<img width="563" height="615" alt="Screenshot 2026-07-14 at 9 57 02 PM" src="https://github.com/user-attachments/assets/77bf1d83-9d77-4217-b4e8-e27feb5c0b38" />
<img width="570" height="721" alt="Screenshot 2026-07-14 at 9 59 22 PM" src="https://github.com/user-attachments/assets/f17324b6-3c29-481f-aae1-db53d8cd93ac" />



- Model backend installation as absent, checking, ready, incompatible, or error.
- Probe Claude Code versions without a shell, cache settled results, deduplicate concurrent probes, and refresh after Apply or Auto-detect.
- Reject unsupported Claude Code before opening or resuming an SDK session.
- Keep incompatible configured backends visible in the picker and surface actionable Configure or Upgrade controls in chat and Settings.
- Reuse the same install-state policy for OpenCode readiness and upgrades.
- Subscribe React surfaces to semantic install-state snapshots.

## Scope and merge order

This PR is based directly on `v4-preview` and can be reviewed and tested independently. It contains no background-task lifecycle, Stop hook, TaskOutput, task-correlation, or subagent-card changes.

PR #2661 is stacked on this PR because its background-task protocol requires the supported Claude Code installation contract established here. Merge this PR first, then #2661.

## Testing

- `npm run format`
- `npm run lint`
- `npm run test -- --runInBand`: 313 suites, 4,467 tests passed
- `npm run build`
- `git diff --check origin/v4-preview...HEAD`
