### PR TITLE
feat(agent-mode): project background task lifecycle onto launch cards

### DIFF
--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -360,6 +360,75 @@ describe("ClaudeSdkBackendProcess", () => {
       ).rejects.toThrow(new Error(USAGE_LIMIT_MESSAGE));
     });
 
+    it("preserves background task identity across prompt queries", async () => {
+      queryMock
+        .mockImplementationOnce(() =>
+          makeQuery([
+            streamEvent({
+              type: "content_block_start",
+              index: 0,
+              content_block: { type: "tool_use", id: "tu-launch", name: "Agent", input: {} },
+            }),
+            {
+              type: "user",
+              tool_use_result: {
+                isAsync: true,
+                status: "async_launched",
+                agentId: "task-a",
+              },
+              message: {
+                content: [
+                  {
+                    type: "tool_result",
+                    tool_use_id: "tu-launch",
+                    content: "Async agent launched successfully.",
+                  },
+                ],
+              },
+              parent_tool_use_id: null,
+              session_id: "irrelevant",
+            } as unknown as SDKMessage,
+            resultMessage(),
+          ])
+        )
+        .mockImplementationOnce(() =>
+          makeQuery([
+            {
+              type: "system",
+              subtype: "task_notification",
+              task_id: "task-a",
+              status: "completed",
+              summary: "late report",
+            } as unknown as SDKMessage,
+            resultMessage(),
+          ])
+        );
+
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+      const { sessionId } = await proc.newSession({ cwd: "/vault", mcpServers: [] });
+      const events: SessionEvent[] = [];
+      proc.registerSessionHandler(sessionId, (event) => events.push(event));
+
+      await proc.prompt({ sessionId, prompt: [{ type: "text", text: "start" }] });
+      await proc.prompt({ sessionId, prompt: [{ type: "text", text: "continue" }] });
+
+      expect(events).toContainEqual({
+        sessionId,
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tu-launch",
+          status: "completed",
+          content: [{ type: "content", content: { type: "text", text: "late report" } }],
+        },
+      });
+    });
+
     it("forwards the composed system prompt via systemPrompt append on the claude_code preset", async () => {
       queryMock.mockImplementation(() =>
         makeQuery([streamEvent({ type: "message_start", message: {} }), resultMessage()])

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -61,6 +61,7 @@ import type {
 import type { ProjectScopeId } from "@/agentMode/session/scope";
 import { AuthRequiredError, MethodUnsupportedError } from "@/agentMode/session/errors";
 import { createClaudeTaskPlanState, type ClaudeTaskPlanState } from "./claudeTodoPlan";
+import { ClaudeBackgroundTaskStateMachine } from "./claudeTaskProtocol";
 import { createTranslatorState, mapStopReason, translateSdkMessage } from "./sdkMessageTranslator";
 import { PermissionBridge, type AskUserQuestionPrompter } from "./permissionBridge";
 import {
@@ -116,6 +117,8 @@ interface SessionState {
    * (translator state is per-query; Task ids must survive turns).
    */
   claudeTaskPlan: ClaudeTaskPlanState;
+  /** Session-lived correlation for background launches that outlast one query. */
+  backgroundTasks: ClaudeBackgroundTaskStateMachine;
   active?: Query;
   /**
    * Snapshot of the composed Copilot system prompt (base framing + pill-syntax
@@ -366,6 +369,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
       additionalDirectories: params.additionalDirectories,
       systemPromptAppend: this.resolveSystemPromptAppend(params.projectId),
       claudeTaskPlan: createClaudeTaskPlanState(),
+      backgroundTasks: new ClaudeBackgroundTaskStateMachine(),
     });
 
     const state = this.computeState(sessionId);
@@ -504,7 +508,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
       onStall: (idleMs) => logSdkError("←", "stream:stalled", { idleMs }, params.sessionId),
     });
 
-    const translatorState = createTranslatorState(session.claudeTaskPlan);
+    const translatorState = createTranslatorState(session.claudeTaskPlan, session.backgroundTasks);
     let stopReason: StopReason = "end_turn";
     let resultErrorMessage: string | null = null;
     try {
@@ -774,6 +778,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
       additionalDirectories: params.additionalDirectories,
       systemPromptAppend: this.resolveSystemPromptAppend(params.projectId),
       claudeTaskPlan: createClaudeTaskPlanState(),
+      backgroundTasks: new ClaudeBackgroundTaskStateMachine(),
     });
 
     const state = this.computeState(params.sessionId);

--- a/src/agentMode/sdk/claudeTaskProtocol.test.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.test.ts
@@ -43,10 +43,9 @@ function systemMessage(frame: Record<string, unknown>): SDKMessage {
 function observeTool(
   protocol: ClaudeBackgroundTaskStateMachine,
   toolCallId: string,
-  nativeToolName: string,
-  input: unknown = {}
+  nativeToolName: string
 ): void {
-  protocol.accept({ kind: "tool_snapshot", toolCallId, nativeToolName, input });
+  protocol.accept({ kind: "tool_snapshot", toolCallId, nativeToolName });
 }
 
 function acceptMessage(protocol: ClaudeBackgroundTaskStateMachine, message: SDKMessage) {
@@ -63,12 +62,10 @@ describe("claudeTaskProtocol", () => {
           kind: "tool_snapshot",
           toolCallId: "read-a",
           nativeToolName: "Read",
-          input: {},
         });
         const second = protocol.accept({
           kind: "tool_snapshot",
           toolCallId: "mcp-task",
-          input: {},
         });
 
         expect(first).toEqual({ updates: [], resultActions: new Map() });
@@ -356,16 +353,10 @@ describe("claudeTaskProtocol", () => {
         expect(acknowledged.resultActions.get("launch")).toEqual({ kind: "omit" });
       });
 
-      it("uses structured launch metadata when acknowledgement text changes", () => {
+      it("does not infer task identity from prompt or description", () => {
         const protocol = new ClaudeBackgroundTaskStateMachine();
-        observeTool(protocol, "other", "Agent", {
-          prompt: "foreground prompt",
-          description: "Foreground task",
-        });
-        observeTool(protocol, "background", "Task", {
-          prompt: "background prompt",
-          description: "Background task",
-        });
+        observeTool(protocol, "other", "Agent");
+        observeTool(protocol, "background", "Task");
 
         const acknowledged = acceptMessage(
           protocol,
@@ -383,14 +374,41 @@ describe("claudeTaskProtocol", () => {
             }
           )
         );
+        const taskOnlyProgress = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_progress",
+            task_id: "task-a",
+            description: "working",
+          })
+        );
+        const started = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "background",
+          })
+        );
 
-        expect(acknowledged.resultActions).toEqual(new Map([["background", { kind: "omit" }]]));
+        expect(acknowledged.resultActions).toEqual(new Map());
+        expect(taskOnlyProgress.updates).toEqual([]);
+        expect(started.updates).toEqual([{ toolCallId: "background", status: "in_progress" }]);
       });
 
-      it("keeps duplicate structured launch metadata ambiguous until an explicit frame binds it", () => {
+      it("uses an explicit task binding to select an acknowledgement from multiple launches", () => {
         const protocol = new ClaudeBackgroundTaskStateMachine();
-        observeTool(protocol, "launch-a", "Agent", { prompt: "same prompt" });
-        observeTool(protocol, "launch-b", "Task", { prompt: "same prompt" });
+        observeTool(protocol, "launch-a", "Agent");
+        observeTool(protocol, "launch-b", "Task");
+
+        const started = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "launch-b",
+          })
+        );
 
         const acknowledged = acceptMessage(
           protocol,
@@ -403,21 +421,12 @@ describe("claudeTaskProtocol", () => {
               isAsync: true,
               status: "async_launched",
               agentId: "task-a",
-              prompt: "same prompt",
             }
           )
         );
-        const started = acceptMessage(
-          protocol,
-          systemMessage({
-            subtype: "task_started",
-            task_id: "task-a",
-            tool_use_id: "launch-b",
-          })
-        );
 
-        expect(acknowledged.resultActions).toEqual(new Map());
         expect(started.updates).toEqual([{ toolCallId: "launch-b", status: "in_progress" }]);
+        expect(acknowledged.resultActions).toEqual(new Map([["launch-b", { kind: "omit" }]]));
       });
 
       it("preserves an earlier pending terminal report when a later patch has no output", () => {

--- a/src/agentMode/sdk/claudeTaskProtocol.test.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.test.ts
@@ -29,7 +29,7 @@ function userMessage(
 
 function launchAck(agentId: string, ...toolCallIds: string[]): SDKMessage {
   return userMessage(
-    toolCallIds.map((id) => ({ id })),
+    toolCallIds.map((id) => ({ id, content: "Async agent launched successfully." })),
     { isAsync: true, status: "async_launched", agentId }
   );
 }
@@ -128,6 +128,35 @@ describe("claudeTaskProtocol", () => {
             content: [{ type: "content", content: { type: "text", text: "done" } }],
           },
         ]);
+      });
+
+      it("retires foreground task identity after its ordinary result", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+        acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "launch",
+          })
+        );
+
+        const result = acceptMessage(
+          protocol,
+          userMessage([{ id: "launch", content: "foreground report" }])
+        );
+        const lateProgress = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_progress",
+            task_id: "task-a",
+            description: "too late",
+          })
+        );
+
+        expect(result).toEqual({ updates: [], resultActions: new Map() });
+        expect(lateProgress.updates).toEqual([]);
       });
 
       it("ignores task-only frames without an unambiguous launch binding", () => {
@@ -257,41 +286,51 @@ describe("claudeTaskProtocol", () => {
         expect(conflictingFailure.updates).toEqual([]);
       });
 
-      it("retains ambiguous launch candidates until an explicit task frame selects the owner", () => {
-        const unique = new ClaudeBackgroundTaskStateMachine();
-        observeTool(unique, "launch", "Agent");
-        const uniqueDecision = acceptMessage(unique, launchAck("task-a", "launch"));
+      it("binds the exact asynchronous acknowledgement in a batched Agent result", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "foreground", "Agent");
+        observeTool(protocol, "background", "Task");
 
-        const ambiguous = new ClaudeBackgroundTaskStateMachine();
-        observeTool(ambiguous, "launch-a", "Agent");
-        observeTool(ambiguous, "launch-b", "Task");
-        const ambiguousDecision = acceptMessage(
-          ambiguous,
-          launchAck("task-a", "launch-a", "launch-b")
+        const acknowledged = acceptMessage(
+          protocol,
+          userMessage(
+            [
+              { id: "foreground", content: "foreground report" },
+              {
+                id: "background",
+                content: [{ type: "text", text: "Async agent launched successfully." }],
+              },
+            ],
+            { isAsync: true, status: "async_launched", agentId: "task-a" }
+          )
         );
-
-        expect(uniqueDecision.resultActions.get("launch")).toEqual({ kind: "omit" });
-        expect(ambiguousDecision.resultActions.size).toBe(0);
-
-        const lateFrame = acceptMessage(
-          ambiguous,
+        const progress = acceptMessage(
+          protocol,
           systemMessage({
-            subtype: "task_started",
+            subtype: "task_progress",
             task_id: "task-a",
-            tool_use_id: "launch-a",
-          })
-        );
-        const rejectedSibling = acceptMessage(
-          ambiguous,
-          systemMessage({
-            subtype: "task_started",
-            task_id: "task-a",
-            tool_use_id: "launch-b",
+            description: "Count notes",
           })
         );
 
-        expect(lateFrame.updates).toEqual([{ toolCallId: "launch-a", status: "in_progress" }]);
-        expect(rejectedSibling.updates).toEqual([]);
+        expect(acknowledged.resultActions).toEqual(new Map([["background", { kind: "omit" }]]));
+        expect(progress.updates).toEqual([
+          {
+            toolCallId: "background",
+            status: "in_progress",
+            progress: { description: "Count notes" },
+          },
+        ]);
+        expect(
+          acceptMessage(
+            protocol,
+            systemMessage({
+              subtype: "task_started",
+              task_id: "task-a",
+              tool_use_id: "foreground",
+            })
+          ).updates
+        ).toEqual([]);
       });
 
       it("retains terminal identity until a delayed output frame completes the card", () => {

--- a/src/agentMode/sdk/claudeTaskProtocol.test.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.test.ts
@@ -356,36 +356,101 @@ describe("claudeTaskProtocol", () => {
         expect(acknowledged.resultActions.get("launch")).toEqual({ kind: "omit" });
       });
 
-      it("recognizes the verbose asynchronous acknowledgement text of newer CLIs", () => {
+      it("uses structured launch metadata when acknowledgement text changes", () => {
         const protocol = new ClaudeBackgroundTaskStateMachine();
-        observeTool(protocol, "other", "Agent");
-        observeTool(protocol, "background", "Task");
+        observeTool(protocol, "other", "Agent", {
+          prompt: "foreground prompt",
+          description: "Foreground task",
+        });
+        observeTool(protocol, "background", "Task", {
+          prompt: "background prompt",
+          description: "Background task",
+        });
 
         const acknowledged = acceptMessage(
           protocol,
           userMessage(
             [
               { id: "other", content: "foreground report" },
-              {
-                id: "background",
-                content: [
-                  {
-                    type: "text",
-                    text:
-                      "Async agent launched successfully. (This tool result is internal " +
-                      "metadata — never quote or paste any part of it, including the agentId " +
-                      "below, into a user-facing reply.)\n" +
-                      "agentId: task-a (internal ID - do not mention to user. Use SendMessage " +
-                      "with to: 'task-a', summary: '<5-10 word recap>' to continue this agent.)",
-                  },
-                ],
-              },
+              { id: "background", content: "opaque internal acknowledgement" },
             ],
-            { isAsync: true, status: "async_launched", agentId: "task-a" }
+            {
+              isAsync: true,
+              status: "async_launched",
+              agentId: "task-a",
+              prompt: "background prompt",
+              description: "Background task",
+            }
           )
         );
 
         expect(acknowledged.resultActions).toEqual(new Map([["background", { kind: "omit" }]]));
+      });
+
+      it("keeps duplicate structured launch metadata ambiguous until an explicit frame binds it", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch-a", "Agent", { prompt: "same prompt" });
+        observeTool(protocol, "launch-b", "Task", { prompt: "same prompt" });
+
+        const acknowledged = acceptMessage(
+          protocol,
+          userMessage(
+            [
+              { id: "launch-a", content: "first result" },
+              { id: "launch-b", content: "second result" },
+            ],
+            {
+              isAsync: true,
+              status: "async_launched",
+              agentId: "task-a",
+              prompt: "same prompt",
+            }
+          )
+        );
+        const started = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "launch-b",
+          })
+        );
+
+        expect(acknowledged.resultActions).toEqual(new Map());
+        expect(started.updates).toEqual([{ toolCallId: "launch-b", status: "in_progress" }]);
+      });
+
+      it("preserves an earlier pending terminal report when a later patch has no output", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+
+        acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "task-a",
+            status: "completed",
+            summary: "done",
+          })
+        );
+        acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_updated",
+            task_id: "task-a",
+            patch: { status: "completed" },
+          })
+        );
+
+        const acknowledged = acceptMessage(protocol, launchAck("task-a", "launch"));
+
+        expect(acknowledged.updates).toEqual([
+          {
+            toolCallId: "launch",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "done" } }],
+          },
+        ]);
       });
 
       it("normalizes progress and never regresses a terminal launch", () => {
@@ -459,20 +524,25 @@ describe("claudeTaskProtocol", () => {
         expect(conflictingFailure.updates).toEqual([]);
       });
 
-      it("binds the exact asynchronous acknowledgement in a batched Agent result", () => {
+      it("uses a prior task binding to suppress a batched asynchronous acknowledgement", () => {
         const protocol = new ClaudeBackgroundTaskStateMachine();
         observeTool(protocol, "foreground", "Agent");
         observeTool(protocol, "background", "Task");
+        acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "background",
+          })
+        );
 
         const acknowledged = acceptMessage(
           protocol,
           userMessage(
             [
               { id: "foreground", content: "foreground report" },
-              {
-                id: "background",
-                content: [{ type: "text", text: "Async agent launched successfully." }],
-              },
+              { id: "background", content: "opaque internal acknowledgement" },
             ],
             { isAsync: true, status: "async_launched", agentId: "task-a" }
           )

--- a/src/agentMode/sdk/claudeTaskProtocol.test.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.test.ts
@@ -248,7 +248,7 @@ describe("claudeTaskProtocol", () => {
         const unsupported = acceptMessage(
           protocol,
           systemMessage({
-            subtype: "task_updated",
+            subtype: "task_checkpoint",
             task_id: "task-a",
             tool_use_id: "launch",
           })
@@ -264,6 +264,128 @@ describe("claudeTaskProtocol", () => {
 
         expect(unsupported.updates).toEqual([]);
         expect(laterStart.updates).toEqual([{ toolCallId: "launch", status: "in_progress" }]);
+      });
+
+      it("settles a bound launch from a terminal task_updated patch", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+        acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "launch",
+          })
+        );
+
+        const updated = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_updated",
+            task_id: "task-a",
+            patch: { status: "completed" },
+          })
+        );
+
+        expect(updated.updates).toEqual([{ toolCallId: "launch", status: "completed" }]);
+      });
+
+      it("fails a bound launch from a killed task_updated patch and surfaces its error", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+        acceptMessage(protocol, launchAck("task-a", "launch"));
+
+        const killed = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_updated",
+            task_id: "task-a",
+            patch: { status: "killed", error: "killed by user" },
+          })
+        );
+
+        expect(killed.updates).toEqual([
+          {
+            toolCallId: "launch",
+            status: "failed",
+            content: [{ type: "content", content: { type: "text", text: "killed by user" } }],
+          },
+        ]);
+      });
+
+      it("ignores non-terminal task_updated patches", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+        acceptMessage(protocol, launchAck("task-a", "launch"));
+
+        const running = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_updated",
+            task_id: "task-a",
+            patch: { status: "running", description: "still going" },
+          })
+        );
+
+        expect(running.updates).toEqual([]);
+      });
+
+      it("replays a task-only terminal frame once the launch acknowledgement binds", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+
+        const early = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "task-a",
+            status: "completed",
+            summary: "done",
+          })
+        );
+        const acknowledged = acceptMessage(protocol, launchAck("task-a", "launch"));
+
+        expect(early.updates).toEqual([]);
+        expect(acknowledged.updates).toEqual([
+          {
+            toolCallId: "launch",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "done" } }],
+          },
+        ]);
+        expect(acknowledged.resultActions.get("launch")).toEqual({ kind: "omit" });
+      });
+
+      it("recognizes the verbose asynchronous acknowledgement text of newer CLIs", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "other", "Agent");
+        observeTool(protocol, "background", "Task");
+
+        const acknowledged = acceptMessage(
+          protocol,
+          userMessage(
+            [
+              { id: "other", content: "foreground report" },
+              {
+                id: "background",
+                content: [
+                  {
+                    type: "text",
+                    text:
+                      "Async agent launched successfully. (This tool result is internal " +
+                      "metadata — never quote or paste any part of it, including the agentId " +
+                      "below, into a user-facing reply.)\n" +
+                      "agentId: task-a (internal ID - do not mention to user. Use SendMessage " +
+                      "with to: 'task-a', summary: '<5-10 word recap>' to continue this agent.)",
+                  },
+                ],
+              },
+            ],
+            { isAsync: true, status: "async_launched", agentId: "task-a" }
+          )
+        );
+
+        expect(acknowledged.resultActions).toEqual(new Map([["background", { kind: "omit" }]]));
       });
 
       it("normalizes progress and never regresses a terminal launch", () => {

--- a/src/agentMode/sdk/claudeTaskProtocol.test.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.test.ts
@@ -6,6 +6,7 @@ import { ClaudeBackgroundTaskStateMachine } from "./claudeTaskProtocol";
 interface ToolResultFixture {
   id: string;
   content?: unknown;
+  isError?: boolean;
 }
 
 function userMessage(
@@ -20,6 +21,7 @@ function userMessage(
         type: "tool_result",
         tool_use_id: result.id,
         content: result.content ?? "done",
+        ...(result.isError ? { is_error: true } : {}),
       })),
     },
     parent_tool_use_id: null,
@@ -130,7 +132,7 @@ describe("claudeTaskProtocol", () => {
         ]);
       });
 
-      it("retires foreground task identity after its ordinary result", () => {
+      it("keeps identified foreground task identity terminal after its ordinary result", () => {
         const protocol = new ClaudeBackgroundTaskStateMachine();
         observeTool(protocol, "launch", "Agent");
         acceptMessage(
@@ -154,9 +156,58 @@ describe("claudeTaskProtocol", () => {
             description: "too late",
           })
         );
+        observeTool(protocol, "replacement", "Agent");
+        const duplicateIdentity = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "replacement",
+          })
+        );
 
         expect(result).toEqual({ updates: [], resultActions: new Map() });
         expect(lateProgress.updates).toEqual([]);
+        expect(duplicateIdentity.updates).toEqual([]);
+      });
+
+      it("binds late foreground task identity without reopening a terminal launch", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+        acceptMessage(
+          protocol,
+          userMessage([{ id: "launch", content: "foreground report", isError: true }])
+        );
+
+        const lateStart = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "launch",
+          })
+        );
+        const lateProgress = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_progress",
+            task_id: "task-a",
+            description: "too late",
+          })
+        );
+        observeTool(protocol, "replacement", "Task");
+        const duplicateIdentity = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "replacement",
+          })
+        );
+
+        expect(lateStart.updates).toEqual([]);
+        expect(lateProgress.updates).toEqual([]);
+        expect(duplicateIdentity.updates).toEqual([]);
       });
 
       it("ignores task-only frames without an unambiguous launch binding", () => {
@@ -370,6 +421,15 @@ describe("claudeTaskProtocol", () => {
             description: "too late",
           })
         );
+        observeTool(protocol, "replacement", "Task");
+        const duplicateIdentity = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "replacement",
+          })
+        );
 
         expect(terminalStatus.updates).toEqual([{ toolCallId: "launch", status: "completed" }]);
         expect(terminalOutput.updates).toEqual([
@@ -380,6 +440,31 @@ describe("claudeTaskProtocol", () => {
           },
         ]);
         expect(afterCompletion.updates).toEqual([]);
+        expect(duplicateIdentity.updates).toEqual([]);
+      });
+
+      it("preserves the first terminal status when an ordinary result supplies late output", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+        acceptMessage(protocol, launchAck("task-a", "launch"));
+        acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "task-a",
+            status: "completed",
+          })
+        );
+
+        const lateOutput = acceptMessage(
+          protocol,
+          userMessage([{ id: "launch", content: "late output", isError: true }])
+        );
+
+        expect(lateOutput.resultActions.get("launch")).toEqual({
+          kind: "preserve_status",
+          status: "completed",
+        });
       });
     });
   });

--- a/src/agentMode/sdk/claudeTaskProtocol.test.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.test.ts
@@ -1,0 +1,314 @@
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { ClaudeBackgroundTaskStateMachine } from "./claudeTaskProtocol";
+
+// These fixtures mirror carriers captured from Claude Code 2.1.206. Keeping
+// the carrier shapes visible makes each test read as one protocol transcript.
+interface ToolResultFixture {
+  id: string;
+  content?: unknown;
+}
+
+function userMessage(
+  toolResults: ToolResultFixture[],
+  toolUseResult?: Record<string, unknown>
+): SDKMessage {
+  return {
+    type: "user",
+    ...(toolUseResult ? { tool_use_result: toolUseResult } : {}),
+    message: {
+      content: toolResults.map((result) => ({
+        type: "tool_result",
+        tool_use_id: result.id,
+        content: result.content ?? "done",
+      })),
+    },
+    parent_tool_use_id: null,
+    session_id: "test-session",
+  } as unknown as SDKMessage;
+}
+
+function launchAck(agentId: string, ...toolCallIds: string[]): SDKMessage {
+  return userMessage(
+    toolCallIds.map((id) => ({ id })),
+    { isAsync: true, status: "async_launched", agentId }
+  );
+}
+
+function systemMessage(frame: Record<string, unknown>): SDKMessage {
+  return { type: "system", ...frame } as unknown as SDKMessage;
+}
+
+function observeTool(
+  protocol: ClaudeBackgroundTaskStateMachine,
+  toolCallId: string,
+  nativeToolName: string,
+  input: unknown = {}
+): void {
+  protocol.accept({ kind: "tool_snapshot", toolCallId, nativeToolName, input });
+}
+
+function acceptMessage(protocol: ClaudeBackgroundTaskStateMachine, message: SDKMessage) {
+  return protocol.accept({ kind: "sdk_message", message });
+}
+
+describe("claudeTaskProtocol", () => {
+  describe("ClaudeBackgroundTaskStateMachine", () => {
+    describe("accept()", () => {
+      it("returns one stable empty decision for unrelated carriers", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+
+        const first = protocol.accept({
+          kind: "tool_snapshot",
+          toolCallId: "read-a",
+          nativeToolName: "Read",
+          input: {},
+        });
+        const second = protocol.accept({
+          kind: "tool_snapshot",
+          toolCallId: "mcp-task",
+          input: {},
+        });
+
+        expect(first).toEqual({ updates: [], resultActions: new Map() });
+        expect(second).toBe(first);
+      });
+
+      it("binds a launch from task_started before its asynchronous acknowledgement", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+
+        const started = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "launch",
+          })
+        );
+        const acknowledged = acceptMessage(protocol, launchAck("task-a", "launch"));
+
+        expect(started.updates).toEqual([{ toolCallId: "launch", status: "in_progress" }]);
+        expect(acknowledged.resultActions.get("launch")).toEqual({ kind: "omit" });
+      });
+
+      it("correlates task-only progress and terminal frames after the launch acknowledgement", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+        acceptMessage(protocol, launchAck("task-a", "launch"));
+
+        const progress = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_progress",
+            task_id: "task-a",
+            description: "Count notes",
+          })
+        );
+        const completed = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "task-a",
+            status: "completed",
+            summary: "done",
+          })
+        );
+
+        expect(progress.updates).toEqual([
+          {
+            toolCallId: "launch",
+            status: "in_progress",
+            progress: { description: "Count notes" },
+          },
+        ]);
+        expect(completed.updates).toEqual([
+          {
+            toolCallId: "launch",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "done" } }],
+          },
+        ]);
+      });
+
+      it("ignores task-only frames without an unambiguous launch binding", () => {
+        const unknown = new ClaudeBackgroundTaskStateMachine();
+        expect(
+          acceptMessage(
+            unknown,
+            systemMessage({
+              subtype: "task_progress",
+              task_id: "unknown-task",
+              description: "working",
+            })
+          ).updates
+        ).toEqual([]);
+
+        const ambiguous = new ClaudeBackgroundTaskStateMachine();
+        observeTool(ambiguous, "launch-a", "Agent");
+        observeTool(ambiguous, "launch-b", "Task");
+        acceptMessage(ambiguous, launchAck("task-a", "launch-a", "launch-b"));
+
+        expect(
+          acceptMessage(
+            ambiguous,
+            systemMessage({
+              subtype: "task_notification",
+              task_id: "task-a",
+              status: "completed",
+              summary: "done",
+            })
+          ).updates
+        ).toEqual([]);
+      });
+
+      it("does not let an unsupported system subtype establish task identity", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+
+        const unsupported = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_updated",
+            task_id: "task-a",
+            tool_use_id: "launch",
+          })
+        );
+        const laterStart = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-b",
+            tool_use_id: "launch",
+          })
+        );
+
+        expect(unsupported.updates).toEqual([]);
+        expect(laterStart.updates).toEqual([{ toolCallId: "launch", status: "in_progress" }]);
+      });
+
+      it("normalizes progress and never regresses a terminal launch", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+
+        const progress = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_progress",
+            task_id: "task-a",
+            tool_use_id: "launch",
+            description: "Count notes",
+            last_tool_name: "Glob",
+            usage: {
+              tool_uses: 3,
+              duration_ms: 9851,
+              total_tokens: Number.POSITIVE_INFINITY,
+            },
+          })
+        );
+        const completed = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "task-a",
+            tool_use_id: "launch",
+            status: "completed",
+            summary: "done",
+          })
+        );
+        const lateProgress = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_progress",
+            task_id: "task-a",
+            tool_use_id: "launch",
+          })
+        );
+        const conflictingFailure = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "task-a",
+            tool_use_id: "launch",
+            status: "failed",
+            summary: "late failure",
+          })
+        );
+
+        expect(progress.updates).toEqual([
+          {
+            toolCallId: "launch",
+            status: "in_progress",
+            progress: {
+              description: "Count notes",
+              toolName: "Glob",
+              toolUses: 3,
+              durationMs: 9851,
+            },
+          },
+        ]);
+        expect(completed.updates).toEqual([
+          {
+            toolCallId: "launch",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "done" } }],
+          },
+        ]);
+        expect(lateProgress.updates).toEqual([]);
+        expect(conflictingFailure.updates).toEqual([]);
+      });
+
+      it("omits only a uniquely attributable asynchronous launch acknowledgement", () => {
+        const unique = new ClaudeBackgroundTaskStateMachine();
+        observeTool(unique, "launch", "Agent");
+        const uniqueDecision = acceptMessage(unique, launchAck("task-a", "launch"));
+
+        const ambiguous = new ClaudeBackgroundTaskStateMachine();
+        observeTool(ambiguous, "launch-a", "Agent");
+        observeTool(ambiguous, "launch-b", "Task");
+        const ambiguousDecision = acceptMessage(
+          ambiguous,
+          launchAck("task-a", "launch-a", "launch-b")
+        );
+
+        expect(uniqueDecision.resultActions.get("launch")).toEqual({ kind: "omit" });
+        expect(ambiguousDecision.resultActions.size).toBe(0);
+
+        const lateFrame = acceptMessage(
+          ambiguous,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "launch-a",
+          })
+        );
+        expect(lateFrame.updates).toEqual([]);
+      });
+
+      it("clears query-owned identity when the query finishes", () => {
+        const protocol = new ClaudeBackgroundTaskStateMachine();
+        observeTool(protocol, "launch", "Agent");
+        acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "launch",
+          })
+        );
+        protocol.accept({ kind: "query_finished" });
+
+        const lateTerminal = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "task-a",
+            tool_use_id: "launch",
+            status: "completed",
+            summary: "late",
+          })
+        );
+        expect(lateTerminal.updates).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/agentMode/sdk/claudeTaskProtocol.test.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.test.ts
@@ -257,7 +257,7 @@ describe("claudeTaskProtocol", () => {
         expect(conflictingFailure.updates).toEqual([]);
       });
 
-      it("omits only a uniquely attributable asynchronous launch acknowledgement", () => {
+      it("retains ambiguous launch candidates until an explicit task frame selects the owner", () => {
         const unique = new ClaudeBackgroundTaskStateMachine();
         observeTool(unique, "launch", "Agent");
         const uniqueDecision = acceptMessage(unique, launchAck("task-a", "launch"));
@@ -281,10 +281,20 @@ describe("claudeTaskProtocol", () => {
             tool_use_id: "launch-a",
           })
         );
-        expect(lateFrame.updates).toEqual([]);
+        const rejectedSibling = acceptMessage(
+          ambiguous,
+          systemMessage({
+            subtype: "task_started",
+            task_id: "task-a",
+            tool_use_id: "launch-b",
+          })
+        );
+
+        expect(lateFrame.updates).toEqual([{ toolCallId: "launch-a", status: "in_progress" }]);
+        expect(rejectedSibling.updates).toEqual([]);
       });
 
-      it("clears query-owned identity when the query finishes", () => {
+      it("retains terminal identity until a delayed output frame completes the card", () => {
         const protocol = new ClaudeBackgroundTaskStateMachine();
         observeTool(protocol, "launch", "Agent");
         acceptMessage(
@@ -295,19 +305,42 @@ describe("claudeTaskProtocol", () => {
             tool_use_id: "launch",
           })
         );
-        protocol.accept({ kind: "query_finished" });
-
-        const lateTerminal = acceptMessage(
+        const terminalStatus = acceptMessage(
           protocol,
           systemMessage({
             subtype: "task_notification",
             task_id: "task-a",
-            tool_use_id: "launch",
+            status: "completed",
+          })
+        );
+
+        const terminalOutput = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "task-a",
             status: "completed",
             summary: "late",
           })
         );
-        expect(lateTerminal.updates).toEqual([]);
+        const afterCompletion = acceptMessage(
+          protocol,
+          systemMessage({
+            subtype: "task_progress",
+            task_id: "task-a",
+            description: "too late",
+          })
+        );
+
+        expect(terminalStatus.updates).toEqual([{ toolCallId: "launch", status: "completed" }]);
+        expect(terminalOutput.updates).toEqual([
+          {
+            toolCallId: "launch",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "late" } }],
+          },
+        ]);
+        expect(afterCompletion.updates).toEqual([]);
       });
     });
   });

--- a/src/agentMode/sdk/claudeTaskProtocol.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.ts
@@ -19,8 +19,6 @@ import type {
 interface AwaitingTaskIdentity {
   phase: "awaiting_identity";
   toolCallId: string;
-  prompt?: string;
-  description?: string;
   candidateTaskId?: string;
 }
 
@@ -47,7 +45,6 @@ export type ClaudeTaskCarrier =
       kind: "tool_snapshot";
       toolCallId: string;
       nativeToolName?: string;
-      input: unknown;
     }
   | { kind: "sdk_message"; message: SDKMessage };
 
@@ -74,12 +71,6 @@ interface ClaudeToolResultBlock {
   status: TerminalTaskStatus;
 }
 
-interface AsyncLaunchMetadata {
-  taskId: string;
-  prompt?: string;
-  description?: string;
-}
-
 interface PendingTerminalFrame {
   status: TerminalTaskStatus;
   output?: string;
@@ -90,8 +81,6 @@ type ClaudeTaskProtocolEvent =
   | {
       kind: "launch_observed";
       toolCallId: string;
-      prompt?: string;
-      description?: string;
     }
   | {
       kind: "task_active";
@@ -110,7 +99,7 @@ type ClaudeTaskProtocolEvent =
   | {
       kind: "result_batch";
       results: readonly ClaudeToolResultBlock[];
-      asyncLaunch?: AsyncLaunchMetadata;
+      asyncLaunchTaskId?: string;
     };
 
 const EMPTY_TASK_UPDATES: readonly ClaudeTaskToolUpdate[] = Object.freeze([]);
@@ -161,8 +150,6 @@ export class ClaudeBackgroundTaskStateMachine {
           this.launchesByToolCallId.set(protocolEvent.toolCallId, {
             phase: "awaiting_identity",
             toolCallId: protocolEvent.toolCallId,
-            prompt: protocolEvent.prompt,
-            description: protocolEvent.description,
           });
         }
         return NO_TASK_DECISION;
@@ -222,19 +209,19 @@ export class ClaudeBackgroundTaskStateMachine {
     protocolEvent: Extract<ClaudeTaskProtocolEvent, { kind: "result_batch" }>
   ): ClaudeTaskDecision {
     const resultActions = new Map<string, ClaudeTaskResultAction>();
-    const launchAckToolCallId = protocolEvent.asyncLaunch
-      ? this.launchAckOwner(protocolEvent.asyncLaunch, protocolEvent.results)
+    const launchAckToolCallId = protocolEvent.asyncLaunchTaskId
+      ? this.launchAckOwner(protocolEvent.asyncLaunchTaskId, protocolEvent.results)
       : undefined;
     if (launchAckToolCallId) resultActions.set(launchAckToolCallId, { kind: "omit" });
 
     const ambiguousTaskId =
-      protocolEvent.asyncLaunch &&
+      protocolEvent.asyncLaunchTaskId &&
       !launchAckToolCallId &&
-      !this.launchToolCallIdByTaskId.has(protocolEvent.asyncLaunch.taskId) &&
+      !this.launchToolCallIdByTaskId.has(protocolEvent.asyncLaunchTaskId) &&
       protocolEvent.results.filter(
         ({ toolCallId }) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
       ).length > 1
-        ? protocolEvent.asyncLaunch.taskId
+        ? protocolEvent.asyncLaunchTaskId
         : undefined;
 
     // Async acknowledgements stay active; every unambiguous ordinary result is
@@ -304,30 +291,20 @@ export class ClaudeBackgroundTaskStateMachine {
   }
 
   private launchAckOwner(
-    asyncLaunch: AsyncLaunchMetadata,
+    taskId: string,
     results: readonly ClaudeToolResultBlock[]
   ): string | undefined {
-    const known = this.launchToolCallIdByTaskId.get(asyncLaunch.taskId);
+    const known = this.launchToolCallIdByTaskId.get(taskId);
     if (known) {
       return results.some(({ toolCallId }) => toolCallId === known) ? known : undefined;
     }
+    // Prompt and description describe work rather than identity. An explicit
+    // task binding or one pending launch is required before ownership is safe.
     const candidates = results.filter(
       ({ toolCallId }) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
     );
-    const metadataMatches = candidates.filter(({ toolCallId }) => {
-      const launch = this.launchesByToolCallId.get(toolCallId);
-      if (!launch || launch.phase !== "awaiting_identity") return false;
-      const hasMetadata = asyncLaunch.prompt !== undefined || asyncLaunch.description !== undefined;
-      return (
-        hasMetadata &&
-        (asyncLaunch.prompt === undefined || launch.prompt === asyncLaunch.prompt) &&
-        (asyncLaunch.description === undefined || launch.description === asyncLaunch.description)
-      );
-    });
-    if (metadataMatches.length > 1) return undefined;
-    const owner = metadataMatches[0] ?? (candidates.length === 1 ? candidates[0] : undefined);
-    if (!owner) return undefined;
-    return this.bindLaunch(owner.toolCallId, asyncLaunch.taskId)?.toolCallId;
+    if (candidates.length !== 1) return undefined;
+    return this.bindLaunch(candidates[0].toolCallId, taskId)?.toolCallId;
   }
 
   private pruneAmbiguousCandidates(taskId: string, ownerToolCallId: string): void {
@@ -400,12 +377,9 @@ export class ClaudeBackgroundTaskStateMachine {
 function protocolEventFromCarrier(carrier: ClaudeTaskCarrier): ClaudeTaskProtocolEvent | undefined {
   if (carrier.kind === "tool_snapshot") {
     if (carrier.nativeToolName === "Agent" || carrier.nativeToolName === "Task") {
-      const input = asRecord(carrier.input);
       return {
         kind: "launch_observed",
         toolCallId: carrier.toolCallId,
-        prompt: nonEmptyString(input?.prompt),
-        description: nonEmptyString(input?.description),
       };
     }
     return undefined;
@@ -416,7 +390,7 @@ function protocolEventFromCarrier(carrier: ClaudeTaskCarrier): ClaudeTaskProtoco
     return {
       kind: "result_batch",
       results: toolResultBlocks(message),
-      asyncLaunch: readAsyncLaunchMetadata(message),
+      asyncLaunchTaskId: readAsyncLaunchTaskId(message),
     };
   }
   if (message.type !== "system") return undefined;
@@ -555,18 +529,12 @@ function textContent(text: string): ToolCallContent[] {
   return [{ type: "content", content: { type: "text", text } }];
 }
 
-function readAsyncLaunchMetadata(msg: SDKMessage): AsyncLaunchMetadata | undefined {
+function readAsyncLaunchTaskId(msg: SDKMessage): string | undefined {
   const result = asRecord((msg as { tool_use_result?: unknown }).tool_use_result);
   if (!result) return undefined;
   const isAsync = result.isAsync === true || nonEmptyString(result.status) === "async_launched";
   if (!isAsync) return undefined;
-  const taskId = nonEmptyString(result.agentId);
-  if (!taskId) return undefined;
-  return {
-    taskId,
-    prompt: nonEmptyString(result.prompt),
-    description: nonEmptyString(result.description),
-  };
+  return nonEmptyString(result.agentId);
 }
 
 function mapTerminalTaskStatus(status: unknown): TerminalTaskStatus | undefined {

--- a/src/agentMode/sdk/claudeTaskProtocol.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.ts
@@ -19,6 +19,8 @@ import type {
 interface AwaitingTaskIdentity {
   phase: "awaiting_identity";
   toolCallId: string;
+  prompt?: string;
+  description?: string;
   candidateTaskId?: string;
 }
 
@@ -69,8 +71,13 @@ export interface ClaudeTaskDecision {
 
 interface ClaudeToolResultBlock {
   toolCallId: string;
-  content: unknown;
   status: TerminalTaskStatus;
+}
+
+interface AsyncLaunchMetadata {
+  taskId: string;
+  prompt?: string;
+  description?: string;
 }
 
 interface PendingTerminalFrame {
@@ -80,7 +87,12 @@ interface PendingTerminalFrame {
 }
 
 type ClaudeTaskProtocolEvent =
-  | { kind: "launch_observed"; toolCallId: string }
+  | {
+      kind: "launch_observed";
+      toolCallId: string;
+      prompt?: string;
+      description?: string;
+    }
   | {
       kind: "task_active";
       toolCallId?: string;
@@ -98,7 +110,7 @@ type ClaudeTaskProtocolEvent =
   | {
       kind: "result_batch";
       results: readonly ClaudeToolResultBlock[];
-      launchTaskId?: string;
+      asyncLaunch?: AsyncLaunchMetadata;
     };
 
 const EMPTY_TASK_UPDATES: readonly ClaudeTaskToolUpdate[] = Object.freeze([]);
@@ -149,6 +161,8 @@ export class ClaudeBackgroundTaskStateMachine {
           this.launchesByToolCallId.set(protocolEvent.toolCallId, {
             phase: "awaiting_identity",
             toolCallId: protocolEvent.toolCallId,
+            prompt: protocolEvent.prompt,
+            description: protocolEvent.description,
           });
         }
         return NO_TASK_DECISION;
@@ -183,10 +197,14 @@ export class ClaudeBackgroundTaskStateMachine {
       // observed (or a conflicting identity), and replaying it later would
       // fabricate a card.
       if (protocolEvent.toolCallId === undefined) {
+        const pending = this.pendingTerminalsByTaskId.get(protocolEvent.taskId);
         this.pendingTerminalsByTaskId.set(protocolEvent.taskId, {
-          status: protocolEvent.status,
-          output: protocolEvent.output,
-          progress: protocolEvent.progress,
+          status: pending?.status ?? protocolEvent.status,
+          output: pending?.output ?? protocolEvent.output,
+          progress:
+            pending?.progress && protocolEvent.progress
+              ? { ...pending.progress, ...protocolEvent.progress }
+              : (pending?.progress ?? protocolEvent.progress),
         });
       }
       return NO_TASK_DECISION;
@@ -204,19 +222,19 @@ export class ClaudeBackgroundTaskStateMachine {
     protocolEvent: Extract<ClaudeTaskProtocolEvent, { kind: "result_batch" }>
   ): ClaudeTaskDecision {
     const resultActions = new Map<string, ClaudeTaskResultAction>();
-    const launchAckToolCallId = protocolEvent.launchTaskId
-      ? this.launchAckOwner(protocolEvent.launchTaskId, protocolEvent.results)
+    const launchAckToolCallId = protocolEvent.asyncLaunch
+      ? this.launchAckOwner(protocolEvent.asyncLaunch, protocolEvent.results)
       : undefined;
     if (launchAckToolCallId) resultActions.set(launchAckToolCallId, { kind: "omit" });
 
     const ambiguousTaskId =
-      protocolEvent.launchTaskId &&
+      protocolEvent.asyncLaunch &&
       !launchAckToolCallId &&
-      !this.launchToolCallIdByTaskId.has(protocolEvent.launchTaskId) &&
+      !this.launchToolCallIdByTaskId.has(protocolEvent.asyncLaunch.taskId) &&
       protocolEvent.results.filter(
         ({ toolCallId }) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
       ).length > 1
-        ? protocolEvent.launchTaskId
+        ? protocolEvent.asyncLaunch.taskId
         : undefined;
 
     // Async acknowledgements stay active; every unambiguous ordinary result is
@@ -286,27 +304,30 @@ export class ClaudeBackgroundTaskStateMachine {
   }
 
   private launchAckOwner(
-    agentId: string,
+    asyncLaunch: AsyncLaunchMetadata,
     results: readonly ClaudeToolResultBlock[]
   ): string | undefined {
-    const known = this.launchToolCallIdByTaskId.get(agentId);
+    const known = this.launchToolCallIdByTaskId.get(asyncLaunch.taskId);
     if (known) {
       return results.some(({ toolCallId }) => toolCallId === known) ? known : undefined;
-    }
-    const acknowledgementCandidates = results.filter(
-      ({ toolCallId, content }) =>
-        this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity" &&
-        isAsyncLaunchAcknowledgement(content)
-    );
-    if (acknowledgementCandidates.length === 1) {
-      const [{ toolCallId }] = acknowledgementCandidates;
-      return this.bindLaunch(toolCallId, agentId)?.toolCallId;
     }
     const candidates = results.filter(
       ({ toolCallId }) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
     );
-    if (candidates.length !== 1) return undefined;
-    return this.bindLaunch(candidates[0].toolCallId, agentId)?.toolCallId;
+    const metadataMatches = candidates.filter(({ toolCallId }) => {
+      const launch = this.launchesByToolCallId.get(toolCallId);
+      if (!launch || launch.phase !== "awaiting_identity") return false;
+      const hasMetadata = asyncLaunch.prompt !== undefined || asyncLaunch.description !== undefined;
+      return (
+        hasMetadata &&
+        (asyncLaunch.prompt === undefined || launch.prompt === asyncLaunch.prompt) &&
+        (asyncLaunch.description === undefined || launch.description === asyncLaunch.description)
+      );
+    });
+    if (metadataMatches.length > 1) return undefined;
+    const owner = metadataMatches[0] ?? (candidates.length === 1 ? candidates[0] : undefined);
+    if (!owner) return undefined;
+    return this.bindLaunch(owner.toolCallId, asyncLaunch.taskId)?.toolCallId;
   }
 
   private pruneAmbiguousCandidates(taskId: string, ownerToolCallId: string): void {
@@ -379,7 +400,13 @@ export class ClaudeBackgroundTaskStateMachine {
 function protocolEventFromCarrier(carrier: ClaudeTaskCarrier): ClaudeTaskProtocolEvent | undefined {
   if (carrier.kind === "tool_snapshot") {
     if (carrier.nativeToolName === "Agent" || carrier.nativeToolName === "Task") {
-      return { kind: "launch_observed", toolCallId: carrier.toolCallId };
+      const input = asRecord(carrier.input);
+      return {
+        kind: "launch_observed",
+        toolCallId: carrier.toolCallId,
+        prompt: nonEmptyString(input?.prompt),
+        description: nonEmptyString(input?.description),
+      };
     }
     return undefined;
   }
@@ -389,7 +416,7 @@ function protocolEventFromCarrier(carrier: ClaudeTaskCarrier): ClaudeTaskProtoco
     return {
       kind: "result_batch",
       results: toolResultBlocks(message),
-      launchTaskId: readAsyncLaunchAgentId(message),
+      asyncLaunch: readAsyncLaunchMetadata(message),
     };
   }
   if (message.type !== "system") return undefined;
@@ -488,26 +515,11 @@ function toolResultBlocks(msg: SDKMessage): ClaudeToolResultBlock[] {
     if (toolCallId) {
       results.push({
         toolCallId,
-        content: record.content,
         status: record.is_error === true ? "failed" : "completed",
       });
     }
   }
   return results;
-}
-
-function isAsyncLaunchAcknowledgement(content: unknown): boolean {
-  // Only the leading sentence is stable across CLI versions — the trailing
-  // metadata warning and agentId instructions vary — so match the prefix.
-  const text = toolResultText(content)?.trimStart();
-  return text !== undefined && text.startsWith("Async agent launched successfully.");
-}
-
-function toolResultText(content: unknown): string | undefined {
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content) || content.length !== 1) return undefined;
-  const block = asRecord(content[0]);
-  return block?.type === "text" ? nonEmptyString(block.text) : undefined;
 }
 
 function readTaskProgress(msg: {
@@ -543,12 +555,18 @@ function textContent(text: string): ToolCallContent[] {
   return [{ type: "content", content: { type: "text", text } }];
 }
 
-function readAsyncLaunchAgentId(msg: SDKMessage): string | undefined {
+function readAsyncLaunchMetadata(msg: SDKMessage): AsyncLaunchMetadata | undefined {
   const result = asRecord((msg as { tool_use_result?: unknown }).tool_use_result);
   if (!result) return undefined;
   const isAsync = result.isAsync === true || nonEmptyString(result.status) === "async_launched";
   if (!isAsync) return undefined;
-  return nonEmptyString(result.agentId);
+  const taskId = nonEmptyString(result.agentId);
+  if (!taskId) return undefined;
+  return {
+    taskId,
+    prompt: nonEmptyString(result.prompt),
+    description: nonEmptyString(result.description),
+  };
 }
 
 function mapTerminalTaskStatus(status: unknown): TerminalTaskStatus | undefined {

--- a/src/agentMode/sdk/claudeTaskProtocol.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.ts
@@ -73,6 +73,12 @@ interface ClaudeToolResultBlock {
   status: TerminalTaskStatus;
 }
 
+interface PendingTerminalFrame {
+  status: TerminalTaskStatus;
+  output?: string;
+  progress?: AgentToolProgress;
+}
+
 type ClaudeTaskProtocolEvent =
   | { kind: "launch_observed"; toolCallId: string }
   | {
@@ -113,6 +119,11 @@ const NO_TASK_DECISION: ClaudeTaskDecision = Object.freeze({
 export class ClaudeBackgroundTaskStateMachine {
   private readonly launchesByToolCallId = new Map<string, TaskLaunch>();
   private readonly launchToolCallIdByTaskId = new Map<string, string>();
+  // A fast task can settle with only its task id before the launch
+  // acknowledgement supplies the binding; the frame is parked here and
+  // replayed by `bindLaunch` the moment the identity arrives.
+  private readonly pendingTerminalsByTaskId = new Map<string, PendingTerminalFrame>();
+  private readonly replayedUpdates: ClaudeTaskToolUpdate[] = [];
 
   /**
    * Applies one carrier atomically and returns every resulting protocol decision.
@@ -121,7 +132,14 @@ export class ClaudeBackgroundTaskStateMachine {
    */
   accept(carrier: ClaudeTaskCarrier): ClaudeTaskDecision {
     const protocolEvent = protocolEventFromCarrier(carrier);
-    return protocolEvent ? this.transition(protocolEvent) : NO_TASK_DECISION;
+    if (!protocolEvent) return NO_TASK_DECISION;
+    const decision = this.transition(protocolEvent);
+    if (this.replayedUpdates.length === 0) return decision;
+    const replays = this.replayedUpdates.splice(0);
+    return {
+      updates: [...replays, ...decision.updates],
+      resultActions: decision.resultActions,
+    };
   }
 
   private transition(protocolEvent: ClaudeTaskProtocolEvent): ClaudeTaskDecision {
@@ -159,7 +177,20 @@ export class ClaudeBackgroundTaskStateMachine {
     protocolEvent: Extract<ClaudeTaskProtocolEvent, { kind: "task_terminal" }>
   ): ClaudeTaskDecision {
     const launch = this.resolveLaunch(protocolEvent.toolCallId, protocolEvent.taskId);
-    if (!launch) return NO_TASK_DECISION;
+    if (!launch) {
+      // Park only task-only frames: a frame carrying an explicit tool_use_id
+      // that still fails to resolve refers to a launch this session never
+      // observed (or a conflicting identity), and replaying it later would
+      // fabricate a card.
+      if (protocolEvent.toolCallId === undefined) {
+        this.pendingTerminalsByTaskId.set(protocolEvent.taskId, {
+          status: protocolEvent.status,
+          output: protocolEvent.output,
+          progress: protocolEvent.progress,
+        });
+      }
+      return NO_TASK_DECISION;
+    }
     const update = this.mergeTerminal(
       launch,
       protocolEvent.status,
@@ -236,7 +267,14 @@ export class ClaudeBackgroundTaskStateMachine {
     }
     this.launchesByToolCallId.set(toolCallId, identified);
     this.launchToolCallIdByTaskId.set(taskId, toolCallId);
-    return identified;
+    const pending = this.pendingTerminalsByTaskId.get(taskId);
+    if (!pending) return identified;
+    this.pendingTerminalsByTaskId.delete(taskId);
+    const replay = this.mergeTerminal(identified, pending.status, pending.output, pending.progress);
+    if (replay) this.replayedUpdates.push(replay);
+    // mergeTerminal advanced the stored launch; return the settled record so
+    // the caller's phase checks see the terminal state.
+    return this.launchesByToolCallId.get(toolCallId) as IdentifiedTaskLaunch;
   }
 
   private resolveLaunch(
@@ -365,7 +403,24 @@ function protocolEventFromCarrier(carrier: ClaudeTaskCarrier): ClaudeTaskProtoco
     description?: unknown;
     last_tool_name?: unknown;
     usage?: unknown;
+    patch?: unknown;
   };
+  if (frame.subtype === "task_updated") {
+    // `task_updated` carries a partial TaskState patch and no tool_use_id. A
+    // subagent may report its terminal transition only here, so map terminal
+    // patch statuses through the state machine; non-terminal patches carry
+    // nothing the launch card renders.
+    const taskId = nonEmptyString(frame.task_id);
+    const patch = asRecord(frame.patch);
+    const status = mapTerminalTaskStatus(patch?.status);
+    if (!taskId || !status) return undefined;
+    return {
+      kind: "task_terminal",
+      taskId,
+      status,
+      output: nonEmptyString(patch?.error),
+    };
+  }
   if (
     frame.subtype !== "task_started" &&
     frame.subtype !== "task_progress" &&
@@ -442,11 +497,10 @@ function toolResultBlocks(msg: SDKMessage): ClaudeToolResultBlock[] {
 }
 
 function isAsyncLaunchAcknowledgement(content: unknown): boolean {
-  const text = toolResultText(content)?.trim();
-  return (
-    text !== undefined &&
-    /^Async agent launched successfully\.(?:\r?\nagentId: [^\r\n]+ \(internal ID\))?$/.test(text)
-  );
+  // Only the leading sentence is stable across CLI versions — the trailing
+  // metadata warning and agentId instructions vary — so match the prefix.
+  const text = toolResultText(content)?.trimStart();
+  return text !== undefined && text.startsWith("Async agent launched successfully.");
 }
 
 function toolResultText(content: unknown): string | undefined {
@@ -503,6 +557,7 @@ function mapTerminalTaskStatus(status: unknown): TerminalTaskStatus | undefined 
       return "completed";
     case "failed":
     case "stopped":
+    case "killed":
       return "failed";
     default:
       return undefined;

--- a/src/agentMode/sdk/claudeTaskProtocol.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.ts
@@ -1,11 +1,11 @@
 /**
- * @fileoverview Owns Claude background-task identity, correlation, and terminal merging.
+ * @fileoverview Owns Claude Agent/Task identity, lifecycle, and terminal output merging.
  *
  * One logical task has two identities whose carriers may arrive out of order:
  * `L`, the Agent/Task launch tool-call ID, and `T`, Claude's task ID. The launch
- * moves through awaiting identity, active, and terminal without output; a
- * launch is pruned after its final output arrives. Identity remains one-to-one
- * and terminal status never regresses.
+ * moves through awaiting identity, active, and terminal. Execution state and
+ * output availability remain separate, identified correlation lasts for the
+ * SDK session, and terminal status never regresses.
  * Keeping those rules behind one session-owned interface prevents the translator
  * from coordinating maps whose invariants can drift apart.
  */
@@ -16,30 +16,29 @@ import type {
   ToolCallContent,
 } from "@/agentMode/session/types";
 
-interface AwaitingBackgroundTaskIdentity {
+interface AwaitingTaskIdentity {
   phase: "awaiting_identity";
   toolCallId: string;
   candidateTaskId?: string;
 }
 
-interface ActiveBackgroundTaskLaunch {
+interface ActiveTaskLaunch {
   phase: "active";
   toolCallId: string;
   taskId: string;
 }
 
-interface TerminalBackgroundTaskWithoutOutput {
-  phase: "terminal_without_output";
+interface TerminalTaskLaunch {
+  phase: "terminal";
   toolCallId: string;
-  taskId: string;
+  taskId?: string;
   terminalStatus: TerminalTaskStatus;
+  outputAvailable: boolean;
 }
 
-type IdentifiedBackgroundTaskLaunch =
-  | ActiveBackgroundTaskLaunch
-  | TerminalBackgroundTaskWithoutOutput;
+type IdentifiedTaskLaunch = ActiveTaskLaunch | (TerminalTaskLaunch & { taskId: string });
 
-type BackgroundTaskLaunch = AwaitingBackgroundTaskIdentity | IdentifiedBackgroundTaskLaunch;
+type TaskLaunch = AwaitingTaskIdentity | ActiveTaskLaunch | TerminalTaskLaunch;
 
 export type ClaudeTaskCarrier =
   | {
@@ -57,18 +56,21 @@ export interface ClaudeTaskToolUpdate {
   progress?: AgentToolProgress;
 }
 
-export type ClaudeTaskResultAction = { kind: "omit" };
+type TerminalTaskStatus = "completed" | "failed";
+
+export type ClaudeTaskResultAction =
+  | { kind: "omit" }
+  | { kind: "preserve_status"; status: TerminalTaskStatus };
 
 export interface ClaudeTaskDecision {
   updates: readonly ClaudeTaskToolUpdate[];
   resultActions: ReadonlyMap<string, ClaudeTaskResultAction>;
 }
 
-type TerminalTaskStatus = "completed" | "failed";
-
 interface ClaudeToolResultBlock {
   toolCallId: string;
   content: unknown;
+  status: TerminalTaskStatus;
 }
 
 type ClaudeTaskProtocolEvent =
@@ -101,14 +103,15 @@ const NO_TASK_DECISION: ClaudeTaskDecision = Object.freeze({
 });
 
 /**
- * Reconciles Claude's background-task carriers for one SDK session.
+ * Reconciles Claude Agent/Task carriers for one SDK session.
  *
  * Callers submit carrier snapshots without coordinating their order. The
- * protocol owns identity correlation across query boundaries and monotonic
- * transitions; callers only project its decisions to session events.
+ * protocol owns foreground and background identity correlation across query
+ * boundaries plus monotonic execution state; callers only project its decisions
+ * to session events.
  */
 export class ClaudeBackgroundTaskStateMachine {
-  private readonly launchesByToolCallId = new Map<string, BackgroundTaskLaunch>();
+  private readonly launchesByToolCallId = new Map<string, TaskLaunch>();
   private readonly launchToolCallIdByTaskId = new Map<string, string>();
 
   /**
@@ -185,8 +188,9 @@ export class ClaudeBackgroundTaskStateMachine {
         ? protocolEvent.launchTaskId
         : undefined;
 
-    // Foreground Agent/Task results cannot receive future background frames.
-    for (const { toolCallId } of protocolEvent.results) {
+    // Async acknowledgements stay active; every unambiguous ordinary result is
+    // terminal because the normal result pipeline already owns its final output.
+    for (const { toolCallId, status } of protocolEvent.results) {
       const launch = this.launchesByToolCallId.get(toolCallId);
       if (launch && toolCallId !== launchAckToolCallId) {
         if (launch.phase === "awaiting_identity" && ambiguousTaskId) {
@@ -195,7 +199,13 @@ export class ClaudeBackgroundTaskStateMachine {
             candidateTaskId: ambiguousTaskId,
           });
         } else {
-          this.forgetLaunch(launch);
+          if (launch.phase === "terminal") {
+            resultActions.set(toolCallId, {
+              kind: "preserve_status",
+              status: launch.terminalStatus,
+            });
+          }
+          this.markForegroundResult(launch, status);
         }
       }
     }
@@ -205,23 +215,25 @@ export class ClaudeBackgroundTaskStateMachine {
       : { updates: EMPTY_TASK_UPDATES, resultActions };
   }
 
-  private bindLaunch(
-    toolCallId: string,
-    taskId: string
-  ): IdentifiedBackgroundTaskLaunch | undefined {
+  private bindLaunch(toolCallId: string, taskId: string): IdentifiedTaskLaunch | undefined {
     const launch = this.launchesByToolCallId.get(toolCallId);
     if (!launch) return undefined;
-    if (launch.phase !== "awaiting_identity" && launch.taskId !== taskId) return undefined;
+    if (launch.phase === "active" && launch.taskId !== taskId) return undefined;
+    if (launch.phase === "terminal" && launch.taskId && launch.taskId !== taskId) return undefined;
     const existing = this.launchToolCallIdByTaskId.get(taskId);
     if (existing && existing !== toolCallId) return undefined;
     if (launch.phase === "awaiting_identity" && launch.candidateTaskId !== undefined) {
       if (launch.candidateTaskId !== taskId) return undefined;
       this.pruneAmbiguousCandidates(taskId, toolCallId);
     }
-    const identified =
-      launch.phase === "awaiting_identity"
-        ? ({ phase: "active", toolCallId, taskId } satisfies ActiveBackgroundTaskLaunch)
-        : launch;
+    let identified: IdentifiedTaskLaunch;
+    if (launch.phase === "awaiting_identity") {
+      identified = { phase: "active", toolCallId, taskId };
+    } else if (launch.phase === "terminal") {
+      identified = { ...launch, taskId };
+    } else {
+      identified = launch;
+    }
     this.launchesByToolCallId.set(toolCallId, identified);
     this.launchToolCallIdByTaskId.set(taskId, toolCallId);
     return identified;
@@ -230,7 +242,7 @@ export class ClaudeBackgroundTaskStateMachine {
   private resolveLaunch(
     toolCallId: string | undefined,
     taskId: string
-  ): IdentifiedBackgroundTaskLaunch | undefined {
+  ): IdentifiedTaskLaunch | undefined {
     const resolvedToolCallId = toolCallId ?? this.launchToolCallIdByTaskId.get(taskId);
     return resolvedToolCallId ? this.bindLaunch(resolvedToolCallId, taskId) : undefined;
   }
@@ -271,22 +283,37 @@ export class ClaudeBackgroundTaskStateMachine {
     }
   }
 
-  private forgetLaunch(launch: BackgroundTaskLaunch): void {
-    this.launchesByToolCallId.delete(launch.toolCallId);
-    if (launch.phase !== "awaiting_identity") {
-      this.launchToolCallIdByTaskId.delete(launch.taskId);
+  private markForegroundResult(launch: TaskLaunch, status: TerminalTaskStatus): void {
+    if (launch.phase === "terminal") {
+      if (!launch.outputAvailable) {
+        this.launchesByToolCallId.set(launch.toolCallId, {
+          ...launch,
+          outputAvailable: true,
+        });
+      }
+      return;
     }
+    this.launchesByToolCallId.set(launch.toolCallId, {
+      phase: "terminal",
+      toolCallId: launch.toolCallId,
+      ...(launch.phase === "active" ? { taskId: launch.taskId } : {}),
+      terminalStatus: status,
+      outputAvailable: true,
+    });
   }
 
   private mergeTerminal(
-    launch: IdentifiedBackgroundTaskLaunch,
+    launch: IdentifiedTaskLaunch,
     status: TerminalTaskStatus,
     output?: string,
     progress?: AgentToolProgress
   ): ClaudeTaskToolUpdate | undefined {
-    if (launch.phase === "terminal_without_output") {
-      if (!output) return undefined;
-      this.forgetLaunch(launch);
+    if (launch.phase === "terminal") {
+      if (!output || launch.outputAvailable) return undefined;
+      this.launchesByToolCallId.set(launch.toolCallId, {
+        ...launch,
+        outputAvailable: true,
+      });
       return {
         toolCallId: launch.toolCallId,
         status: launch.terminalStatus,
@@ -295,15 +322,13 @@ export class ClaudeBackgroundTaskStateMachine {
       };
     }
 
-    if (output) {
-      this.forgetLaunch(launch);
-    } else {
-      this.launchesByToolCallId.set(launch.toolCallId, {
-        ...launch,
-        phase: "terminal_without_output",
-        terminalStatus: status,
-      });
-    }
+    this.launchesByToolCallId.set(launch.toolCallId, {
+      phase: "terminal",
+      toolCallId: launch.toolCallId,
+      taskId: launch.taskId,
+      terminalStatus: status,
+      outputAvailable: output !== undefined,
+    });
     return {
       toolCallId: launch.toolCallId,
       status,
@@ -377,10 +402,10 @@ function taskDecision(update: ClaudeTaskToolUpdate): ClaudeTaskDecision {
   return { updates: [update], resultActions: EMPTY_RESULT_ACTIONS };
 }
 
-function isTerminalLaunch(
-  launch: IdentifiedBackgroundTaskLaunch
-): launch is TerminalBackgroundTaskWithoutOutput {
-  return launch.phase === "terminal_without_output";
+function isTerminalLaunch(launch: IdentifiedTaskLaunch): launch is TerminalTaskLaunch & {
+  taskId: string;
+} {
+  return launch.phase === "terminal";
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -405,7 +430,13 @@ function toolResultBlocks(msg: SDKMessage): ClaudeToolResultBlock[] {
     const record = asRecord(block);
     if (record?.type !== "tool_result") continue;
     const toolCallId = nonEmptyString(record.tool_use_id);
-    if (toolCallId) results.push({ toolCallId, content: record.content });
+    if (toolCallId) {
+      results.push({
+        toolCallId,
+        content: record.content,
+        status: record.is_error === true ? "failed" : "completed",
+      });
+    }
   }
   return results;
 }

--- a/src/agentMode/sdk/claudeTaskProtocol.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.ts
@@ -66,6 +66,11 @@ export interface ClaudeTaskDecision {
 
 type TerminalTaskStatus = "completed" | "failed";
 
+interface ClaudeToolResultBlock {
+  toolCallId: string;
+  content: unknown;
+}
+
 type ClaudeTaskProtocolEvent =
   | { kind: "launch_observed"; toolCallId: string }
   | {
@@ -84,7 +89,7 @@ type ClaudeTaskProtocolEvent =
     }
   | {
       kind: "result_batch";
-      resultIds: readonly string[];
+      results: readonly ClaudeToolResultBlock[];
       launchTaskId?: string;
     };
 
@@ -166,7 +171,7 @@ export class ClaudeBackgroundTaskStateMachine {
   ): ClaudeTaskDecision {
     const resultActions = new Map<string, ClaudeTaskResultAction>();
     const launchAckToolCallId = protocolEvent.launchTaskId
-      ? this.launchAckOwner(protocolEvent.launchTaskId, protocolEvent.resultIds)
+      ? this.launchAckOwner(protocolEvent.launchTaskId, protocolEvent.results)
       : undefined;
     if (launchAckToolCallId) resultActions.set(launchAckToolCallId, { kind: "omit" });
 
@@ -174,23 +179,23 @@ export class ClaudeBackgroundTaskStateMachine {
       protocolEvent.launchTaskId &&
       !launchAckToolCallId &&
       !this.launchToolCallIdByTaskId.has(protocolEvent.launchTaskId) &&
-      protocolEvent.resultIds.filter(
-        (toolCallId) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
+      protocolEvent.results.filter(
+        ({ toolCallId }) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
       ).length > 1
         ? protocolEvent.launchTaskId
         : undefined;
 
     // Foreground Agent/Task results cannot receive future background frames.
-    for (const toolCallId of protocolEvent.resultIds) {
+    for (const { toolCallId } of protocolEvent.results) {
       const launch = this.launchesByToolCallId.get(toolCallId);
-      if (launch?.phase === "awaiting_identity" && toolCallId !== launchAckToolCallId) {
-        if (ambiguousTaskId) {
+      if (launch && toolCallId !== launchAckToolCallId) {
+        if (launch.phase === "awaiting_identity" && ambiguousTaskId) {
           this.launchesByToolCallId.set(toolCallId, {
             ...launch,
             candidateTaskId: ambiguousTaskId,
           });
         } else {
-          this.launchesByToolCallId.delete(toolCallId);
+          this.forgetLaunch(launch);
         }
       }
     }
@@ -230,14 +235,28 @@ export class ClaudeBackgroundTaskStateMachine {
     return resolvedToolCallId ? this.bindLaunch(resolvedToolCallId, taskId) : undefined;
   }
 
-  private launchAckOwner(agentId: string, resultIds: readonly string[]): string | undefined {
+  private launchAckOwner(
+    agentId: string,
+    results: readonly ClaudeToolResultBlock[]
+  ): string | undefined {
     const known = this.launchToolCallIdByTaskId.get(agentId);
-    if (known) return resultIds.includes(known) ? known : undefined;
-    const candidates = resultIds.filter(
-      (toolCallId) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
+    if (known) {
+      return results.some(({ toolCallId }) => toolCallId === known) ? known : undefined;
+    }
+    const acknowledgementCandidates = results.filter(
+      ({ toolCallId, content }) =>
+        this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity" &&
+        isAsyncLaunchAcknowledgement(content)
+    );
+    if (acknowledgementCandidates.length === 1) {
+      const [{ toolCallId }] = acknowledgementCandidates;
+      return this.bindLaunch(toolCallId, agentId)?.toolCallId;
+    }
+    const candidates = results.filter(
+      ({ toolCallId }) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
     );
     if (candidates.length !== 1) return undefined;
-    return this.bindLaunch(candidates[0], agentId)?.toolCallId;
+    return this.bindLaunch(candidates[0].toolCallId, agentId)?.toolCallId;
   }
 
   private pruneAmbiguousCandidates(taskId: string, ownerToolCallId: string): void {
@@ -252,9 +271,11 @@ export class ClaudeBackgroundTaskStateMachine {
     }
   }
 
-  private forgetLaunch(launch: IdentifiedBackgroundTaskLaunch): void {
+  private forgetLaunch(launch: BackgroundTaskLaunch): void {
     this.launchesByToolCallId.delete(launch.toolCallId);
-    this.launchToolCallIdByTaskId.delete(launch.taskId);
+    if (launch.phase !== "awaiting_identity") {
+      this.launchToolCallIdByTaskId.delete(launch.taskId);
+    }
   }
 
   private mergeTerminal(
@@ -304,7 +325,7 @@ function protocolEventFromCarrier(carrier: ClaudeTaskCarrier): ClaudeTaskProtoco
   if (message.type === "user") {
     return {
       kind: "result_batch",
-      resultIds: toolResultIds(message),
+      results: toolResultBlocks(message),
       launchTaskId: readAsyncLaunchAgentId(message),
     };
   }
@@ -376,17 +397,32 @@ function finiteNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function toolResultIds(msg: SDKMessage): string[] {
+function toolResultBlocks(msg: SDKMessage): ClaudeToolResultBlock[] {
   const content = asRecord((msg as { message?: unknown }).message)?.content;
   if (!Array.isArray(content)) return [];
-  const ids: string[] = [];
+  const results: ClaudeToolResultBlock[] = [];
   for (const block of content) {
     const record = asRecord(block);
     if (record?.type !== "tool_result") continue;
-    const id = nonEmptyString(record.tool_use_id);
-    if (id) ids.push(id);
+    const toolCallId = nonEmptyString(record.tool_use_id);
+    if (toolCallId) results.push({ toolCallId, content: record.content });
   }
-  return ids;
+  return results;
+}
+
+function isAsyncLaunchAcknowledgement(content: unknown): boolean {
+  const text = toolResultText(content)?.trim();
+  return (
+    text !== undefined &&
+    /^Async agent launched successfully\.(?:\r?\nagentId: [^\r\n]+ \(internal ID\))?$/.test(text)
+  );
+}
+
+function toolResultText(content: unknown): string | undefined {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content) || content.length !== 1) return undefined;
+  const block = asRecord(content[0]);
+  return block?.type === "text" ? nonEmptyString(block.text) : undefined;
 }
 
 function readTaskProgress(msg: {

--- a/src/agentMode/sdk/claudeTaskProtocol.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.ts
@@ -1,0 +1,419 @@
+/**
+ * @fileoverview Owns Claude background-task identity, correlation, and terminal merging.
+ *
+ * One logical task has two identities whose carriers may arrive out of order:
+ * `L`, the Agent/Task launch tool-call ID, and `T`, Claude's task ID. The launch
+ * moves through awaiting identity, active, terminal without output, and terminal
+ * with output. Identity remains one-to-one and terminal status never regresses.
+ * Keeping those rules behind one query-owned interface prevents the translator
+ * from coordinating maps whose invariants can drift apart.
+ */
+import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  AgentToolProgress,
+  AgentToolStatus,
+  ToolCallContent,
+} from "@/agentMode/session/types";
+
+interface AwaitingBackgroundTaskIdentity {
+  phase: "awaiting_identity";
+  toolCallId: string;
+}
+
+interface ActiveBackgroundTaskLaunch {
+  phase: "active";
+  toolCallId: string;
+  taskId: string;
+}
+
+interface TerminalBackgroundTaskWithoutOutput {
+  phase: "terminal_without_output";
+  toolCallId: string;
+  taskId: string;
+  terminalStatus: TerminalTaskStatus;
+}
+
+interface TerminalBackgroundTaskWithOutput {
+  phase: "terminal_with_output";
+  toolCallId: string;
+  taskId: string;
+  terminalStatus: TerminalTaskStatus;
+  output: string;
+}
+
+type IdentifiedBackgroundTaskLaunch =
+  | ActiveBackgroundTaskLaunch
+  | TerminalBackgroundTaskWithoutOutput
+  | TerminalBackgroundTaskWithOutput;
+
+type BackgroundTaskLaunch = AwaitingBackgroundTaskIdentity | IdentifiedBackgroundTaskLaunch;
+
+export type ClaudeTaskCarrier =
+  | {
+      kind: "tool_snapshot";
+      toolCallId: string;
+      nativeToolName?: string;
+      input: unknown;
+    }
+  | { kind: "sdk_message"; message: SDKMessage }
+  | { kind: "query_finished" };
+
+export interface ClaudeTaskToolUpdate {
+  toolCallId: string;
+  status?: AgentToolStatus;
+  content?: ToolCallContent[];
+  progress?: AgentToolProgress;
+}
+
+export type ClaudeTaskResultAction = { kind: "omit" };
+
+export interface ClaudeTaskDecision {
+  updates: readonly ClaudeTaskToolUpdate[];
+  resultActions: ReadonlyMap<string, ClaudeTaskResultAction>;
+}
+
+type TerminalTaskStatus = "completed" | "failed";
+
+type ClaudeTaskProtocolEvent =
+  | { kind: "launch_observed"; toolCallId: string }
+  | {
+      kind: "task_active";
+      toolCallId?: string;
+      taskId: string;
+      progress?: AgentToolProgress;
+    }
+  | {
+      kind: "task_terminal";
+      toolCallId?: string;
+      taskId: string;
+      status: TerminalTaskStatus;
+      output?: string;
+      progress?: AgentToolProgress;
+    }
+  | {
+      kind: "result_batch";
+      resultIds: readonly string[];
+      launchTaskId?: string;
+    }
+  | { kind: "query_finished" };
+
+const EMPTY_TASK_UPDATES: readonly ClaudeTaskToolUpdate[] = Object.freeze([]);
+const EMPTY_RESULT_ACTIONS: ReadonlyMap<string, ClaudeTaskResultAction> = new Map();
+const NO_TASK_DECISION: ClaudeTaskDecision = Object.freeze({
+  updates: EMPTY_TASK_UPDATES,
+  resultActions: EMPTY_RESULT_ACTIONS,
+});
+
+/**
+ * Reconciles Claude's background-task carriers into decisions for one SDK query.
+ *
+ * Callers submit carrier snapshots without coordinating their order. The
+ * protocol owns identity correlation and monotonic transitions; callers only
+ * project its decisions to session events.
+ */
+export class ClaudeBackgroundTaskStateMachine {
+  private readonly launchesByToolCallId = new Map<string, BackgroundTaskLaunch>();
+  private readonly launchToolCallIdByTaskId = new Map<string, string>();
+
+  /**
+   * Applies one carrier atomically and returns every resulting protocol decision.
+   *
+   * @param carrier A tool snapshot, SDK message, or query-lifecycle signal.
+   */
+  accept(carrier: ClaudeTaskCarrier): ClaudeTaskDecision {
+    const protocolEvent = protocolEventFromCarrier(carrier);
+    return protocolEvent ? this.transition(protocolEvent) : NO_TASK_DECISION;
+  }
+
+  private transition(protocolEvent: ClaudeTaskProtocolEvent): ClaudeTaskDecision {
+    switch (protocolEvent.kind) {
+      case "launch_observed":
+        if (!this.launchesByToolCallId.has(protocolEvent.toolCallId)) {
+          this.launchesByToolCallId.set(protocolEvent.toolCallId, {
+            phase: "awaiting_identity",
+            toolCallId: protocolEvent.toolCallId,
+          });
+        }
+        return NO_TASK_DECISION;
+      case "task_active":
+        return this.transitionActiveTask(protocolEvent);
+      case "task_terminal":
+        return this.transitionTerminalTask(protocolEvent);
+      case "result_batch":
+        return this.transitionResultBatch(protocolEvent);
+      case "query_finished":
+        this.launchesByToolCallId.clear();
+        this.launchToolCallIdByTaskId.clear();
+        return NO_TASK_DECISION;
+    }
+  }
+
+  private transitionActiveTask(
+    protocolEvent: Extract<ClaudeTaskProtocolEvent, { kind: "task_active" }>
+  ): ClaudeTaskDecision {
+    const launch = this.resolveLaunch(protocolEvent.toolCallId, protocolEvent.taskId);
+    if (!launch || isTerminalLaunch(launch)) return NO_TASK_DECISION;
+    return taskDecision({
+      toolCallId: launch.toolCallId,
+      status: "in_progress",
+      ...(protocolEvent.progress ? { progress: protocolEvent.progress } : {}),
+    });
+  }
+
+  private transitionTerminalTask(
+    protocolEvent: Extract<ClaudeTaskProtocolEvent, { kind: "task_terminal" }>
+  ): ClaudeTaskDecision {
+    const launch = this.resolveLaunch(protocolEvent.toolCallId, protocolEvent.taskId);
+    if (!launch) return NO_TASK_DECISION;
+    const update = this.mergeTerminal(
+      launch,
+      protocolEvent.status,
+      protocolEvent.output,
+      protocolEvent.progress
+    );
+    return update ? taskDecision(update) : NO_TASK_DECISION;
+  }
+
+  private transitionResultBatch(
+    protocolEvent: Extract<ClaudeTaskProtocolEvent, { kind: "result_batch" }>
+  ): ClaudeTaskDecision {
+    const resultActions = new Map<string, ClaudeTaskResultAction>();
+    const launchAckToolCallId = protocolEvent.launchTaskId
+      ? this.launchAckOwner(protocolEvent.launchTaskId, protocolEvent.resultIds)
+      : undefined;
+    if (launchAckToolCallId) resultActions.set(launchAckToolCallId, { kind: "omit" });
+
+    // Foreground Agent/Task results cannot receive future background frames.
+    for (const toolCallId of protocolEvent.resultIds) {
+      const launch = this.launchesByToolCallId.get(toolCallId);
+      if (launch?.phase === "awaiting_identity" && toolCallId !== launchAckToolCallId) {
+        this.launchesByToolCallId.delete(toolCallId);
+      }
+    }
+
+    return resultActions.size === 0
+      ? NO_TASK_DECISION
+      : { updates: EMPTY_TASK_UPDATES, resultActions };
+  }
+
+  private bindLaunch(
+    toolCallId: string,
+    taskId: string
+  ): IdentifiedBackgroundTaskLaunch | undefined {
+    const launch = this.launchesByToolCallId.get(toolCallId);
+    if (!launch) return undefined;
+    if (launch.phase !== "awaiting_identity" && launch.taskId !== taskId) return undefined;
+    const existing = this.launchToolCallIdByTaskId.get(taskId);
+    if (existing && existing !== toolCallId) return undefined;
+    const identified =
+      launch.phase === "awaiting_identity"
+        ? ({ phase: "active", toolCallId, taskId } satisfies ActiveBackgroundTaskLaunch)
+        : launch;
+    this.launchesByToolCallId.set(toolCallId, identified);
+    this.launchToolCallIdByTaskId.set(taskId, toolCallId);
+    return identified;
+  }
+
+  private resolveLaunch(
+    toolCallId: string | undefined,
+    taskId: string
+  ): IdentifiedBackgroundTaskLaunch | undefined {
+    const resolvedToolCallId = toolCallId ?? this.launchToolCallIdByTaskId.get(taskId);
+    return resolvedToolCallId ? this.bindLaunch(resolvedToolCallId, taskId) : undefined;
+  }
+
+  private launchAckOwner(agentId: string, resultIds: readonly string[]): string | undefined {
+    const known = this.launchToolCallIdByTaskId.get(agentId);
+    if (known) return resultIds.includes(known) ? known : undefined;
+    const candidates = resultIds.filter((toolCallId) => this.launchesByToolCallId.has(toolCallId));
+    if (candidates.length !== 1) return undefined;
+    return this.bindLaunch(candidates[0], agentId)?.toolCallId;
+  }
+
+  private mergeTerminal(
+    launch: IdentifiedBackgroundTaskLaunch,
+    status: TerminalTaskStatus,
+    output?: string,
+    progress?: AgentToolProgress
+  ): ClaudeTaskToolUpdate | undefined {
+    if (launch.phase === "terminal_with_output") return undefined;
+    if (launch.phase === "terminal_without_output") {
+      if (!output) return undefined;
+      this.launchesByToolCallId.set(launch.toolCallId, {
+        ...launch,
+        phase: "terminal_with_output",
+        output,
+      });
+      return {
+        toolCallId: launch.toolCallId,
+        status: launch.terminalStatus,
+        content: textContent(output),
+        ...(progress ? { progress } : {}),
+      };
+    }
+
+    const terminalLaunch: TerminalBackgroundTaskWithoutOutput | TerminalBackgroundTaskWithOutput =
+      output
+        ? { ...launch, phase: "terminal_with_output", terminalStatus: status, output }
+        : { ...launch, phase: "terminal_without_output", terminalStatus: status };
+    this.launchesByToolCallId.set(launch.toolCallId, terminalLaunch);
+    return {
+      toolCallId: launch.toolCallId,
+      status,
+      ...(output ? { content: textContent(output) } : {}),
+      ...(progress ? { progress } : {}),
+    };
+  }
+}
+
+function protocolEventFromCarrier(carrier: ClaudeTaskCarrier): ClaudeTaskProtocolEvent | undefined {
+  if (carrier.kind === "query_finished") return carrier;
+
+  if (carrier.kind === "tool_snapshot") {
+    if (carrier.nativeToolName === "Agent" || carrier.nativeToolName === "Task") {
+      return { kind: "launch_observed", toolCallId: carrier.toolCallId };
+    }
+    return undefined;
+  }
+
+  const message = carrier.message;
+  if (message.type === "user") {
+    return {
+      kind: "result_batch",
+      resultIds: toolResultIds(message),
+      launchTaskId: readAsyncLaunchAgentId(message),
+    };
+  }
+  if (message.type !== "system") return undefined;
+
+  const frame = message as {
+    subtype?: string;
+    task_id?: string;
+    tool_use_id?: string;
+    status?: unknown;
+    summary?: unknown;
+    description?: unknown;
+    last_tool_name?: unknown;
+    usage?: unknown;
+  };
+  if (
+    frame.subtype !== "task_started" &&
+    frame.subtype !== "task_progress" &&
+    frame.subtype !== "task_notification"
+  ) {
+    return undefined;
+  }
+  const taskId = nonEmptyString(frame.task_id);
+  const toolCallId = nonEmptyString(frame.tool_use_id);
+  if (!taskId || (frame.tool_use_id !== undefined && !toolCallId)) return undefined;
+  const progress = readTaskProgress(frame);
+  if (frame.subtype !== "task_notification") {
+    return {
+      kind: "task_active",
+      toolCallId,
+      taskId,
+      ...(frame.subtype === "task_progress" && progress ? { progress } : {}),
+    };
+  }
+  const status = mapTerminalTaskStatus(frame.status);
+  return status
+    ? {
+        kind: "task_terminal",
+        toolCallId,
+        taskId,
+        status,
+        output: nonEmptyString(frame.summary),
+        ...(progress ? { progress } : {}),
+      }
+    : { kind: "task_active", toolCallId, taskId, ...(progress ? { progress } : {}) };
+}
+
+function taskDecision(update: ClaudeTaskToolUpdate): ClaudeTaskDecision {
+  return { updates: [update], resultActions: EMPTY_RESULT_ACTIONS };
+}
+
+function isTerminalLaunch(
+  launch: IdentifiedBackgroundTaskLaunch
+): launch is TerminalBackgroundTaskWithoutOutput | TerminalBackgroundTaskWithOutput {
+  return launch.phase === "terminal_without_output" || launch.phase === "terminal_with_output";
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value : undefined;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function toolResultIds(msg: SDKMessage): string[] {
+  const content = asRecord((msg as { message?: unknown }).message)?.content;
+  if (!Array.isArray(content)) return [];
+  const ids: string[] = [];
+  for (const block of content) {
+    const record = asRecord(block);
+    if (record?.type !== "tool_result") continue;
+    const id = nonEmptyString(record.tool_use_id);
+    if (id) ids.push(id);
+  }
+  return ids;
+}
+
+function readTaskProgress(msg: {
+  description?: unknown;
+  last_tool_name?: unknown;
+  usage?: unknown;
+}): AgentToolProgress | undefined {
+  const usage = asRecord(msg.usage);
+  const description = nonEmptyString(msg.description);
+  const toolName = nonEmptyString(msg.last_tool_name);
+  const toolUses = finiteNumber(usage?.tool_uses);
+  const durationMs = finiteNumber(usage?.duration_ms);
+  const totalTokens = finiteNumber(usage?.total_tokens);
+  if (
+    description === undefined &&
+    toolName === undefined &&
+    toolUses === undefined &&
+    durationMs === undefined &&
+    totalTokens === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    ...(description ? { description } : {}),
+    ...(toolName ? { toolName } : {}),
+    ...(toolUses !== undefined ? { toolUses } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(totalTokens !== undefined ? { totalTokens } : {}),
+  };
+}
+
+function textContent(text: string): ToolCallContent[] {
+  return [{ type: "content", content: { type: "text", text } }];
+}
+
+function readAsyncLaunchAgentId(msg: SDKMessage): string | undefined {
+  const result = asRecord((msg as { tool_use_result?: unknown }).tool_use_result);
+  if (!result) return undefined;
+  const isAsync = result.isAsync === true || nonEmptyString(result.status) === "async_launched";
+  if (!isAsync) return undefined;
+  return nonEmptyString(result.agentId);
+}
+
+function mapTerminalTaskStatus(status: unknown): TerminalTaskStatus | undefined {
+  switch (status) {
+    case "completed":
+      return "completed";
+    case "failed":
+    case "stopped":
+      return "failed";
+    default:
+      return undefined;
+  }
+}

--- a/src/agentMode/sdk/claudeTaskProtocol.ts
+++ b/src/agentMode/sdk/claudeTaskProtocol.ts
@@ -3,9 +3,10 @@
  *
  * One logical task has two identities whose carriers may arrive out of order:
  * `L`, the Agent/Task launch tool-call ID, and `T`, Claude's task ID. The launch
- * moves through awaiting identity, active, terminal without output, and terminal
- * with output. Identity remains one-to-one and terminal status never regresses.
- * Keeping those rules behind one query-owned interface prevents the translator
+ * moves through awaiting identity, active, and terminal without output; a
+ * launch is pruned after its final output arrives. Identity remains one-to-one
+ * and terminal status never regresses.
+ * Keeping those rules behind one session-owned interface prevents the translator
  * from coordinating maps whose invariants can drift apart.
  */
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
@@ -18,6 +19,7 @@ import type {
 interface AwaitingBackgroundTaskIdentity {
   phase: "awaiting_identity";
   toolCallId: string;
+  candidateTaskId?: string;
 }
 
 interface ActiveBackgroundTaskLaunch {
@@ -33,18 +35,9 @@ interface TerminalBackgroundTaskWithoutOutput {
   terminalStatus: TerminalTaskStatus;
 }
 
-interface TerminalBackgroundTaskWithOutput {
-  phase: "terminal_with_output";
-  toolCallId: string;
-  taskId: string;
-  terminalStatus: TerminalTaskStatus;
-  output: string;
-}
-
 type IdentifiedBackgroundTaskLaunch =
   | ActiveBackgroundTaskLaunch
-  | TerminalBackgroundTaskWithoutOutput
-  | TerminalBackgroundTaskWithOutput;
+  | TerminalBackgroundTaskWithoutOutput;
 
 type BackgroundTaskLaunch = AwaitingBackgroundTaskIdentity | IdentifiedBackgroundTaskLaunch;
 
@@ -55,8 +48,7 @@ export type ClaudeTaskCarrier =
       nativeToolName?: string;
       input: unknown;
     }
-  | { kind: "sdk_message"; message: SDKMessage }
-  | { kind: "query_finished" };
+  | { kind: "sdk_message"; message: SDKMessage };
 
 export interface ClaudeTaskToolUpdate {
   toolCallId: string;
@@ -94,8 +86,7 @@ type ClaudeTaskProtocolEvent =
       kind: "result_batch";
       resultIds: readonly string[];
       launchTaskId?: string;
-    }
-  | { kind: "query_finished" };
+    };
 
 const EMPTY_TASK_UPDATES: readonly ClaudeTaskToolUpdate[] = Object.freeze([]);
 const EMPTY_RESULT_ACTIONS: ReadonlyMap<string, ClaudeTaskResultAction> = new Map();
@@ -105,11 +96,11 @@ const NO_TASK_DECISION: ClaudeTaskDecision = Object.freeze({
 });
 
 /**
- * Reconciles Claude's background-task carriers into decisions for one SDK query.
+ * Reconciles Claude's background-task carriers for one SDK session.
  *
  * Callers submit carrier snapshots without coordinating their order. The
- * protocol owns identity correlation and monotonic transitions; callers only
- * project its decisions to session events.
+ * protocol owns identity correlation across query boundaries and monotonic
+ * transitions; callers only project its decisions to session events.
  */
 export class ClaudeBackgroundTaskStateMachine {
   private readonly launchesByToolCallId = new Map<string, BackgroundTaskLaunch>();
@@ -118,7 +109,7 @@ export class ClaudeBackgroundTaskStateMachine {
   /**
    * Applies one carrier atomically and returns every resulting protocol decision.
    *
-   * @param carrier A tool snapshot, SDK message, or query-lifecycle signal.
+   * @param carrier A tool snapshot or SDK message from the owning session.
    */
   accept(carrier: ClaudeTaskCarrier): ClaudeTaskDecision {
     const protocolEvent = protocolEventFromCarrier(carrier);
@@ -141,10 +132,6 @@ export class ClaudeBackgroundTaskStateMachine {
         return this.transitionTerminalTask(protocolEvent);
       case "result_batch":
         return this.transitionResultBatch(protocolEvent);
-      case "query_finished":
-        this.launchesByToolCallId.clear();
-        this.launchToolCallIdByTaskId.clear();
-        return NO_TASK_DECISION;
     }
   }
 
@@ -183,11 +170,28 @@ export class ClaudeBackgroundTaskStateMachine {
       : undefined;
     if (launchAckToolCallId) resultActions.set(launchAckToolCallId, { kind: "omit" });
 
+    const ambiguousTaskId =
+      protocolEvent.launchTaskId &&
+      !launchAckToolCallId &&
+      !this.launchToolCallIdByTaskId.has(protocolEvent.launchTaskId) &&
+      protocolEvent.resultIds.filter(
+        (toolCallId) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
+      ).length > 1
+        ? protocolEvent.launchTaskId
+        : undefined;
+
     // Foreground Agent/Task results cannot receive future background frames.
     for (const toolCallId of protocolEvent.resultIds) {
       const launch = this.launchesByToolCallId.get(toolCallId);
       if (launch?.phase === "awaiting_identity" && toolCallId !== launchAckToolCallId) {
-        this.launchesByToolCallId.delete(toolCallId);
+        if (ambiguousTaskId) {
+          this.launchesByToolCallId.set(toolCallId, {
+            ...launch,
+            candidateTaskId: ambiguousTaskId,
+          });
+        } else {
+          this.launchesByToolCallId.delete(toolCallId);
+        }
       }
     }
 
@@ -205,6 +209,10 @@ export class ClaudeBackgroundTaskStateMachine {
     if (launch.phase !== "awaiting_identity" && launch.taskId !== taskId) return undefined;
     const existing = this.launchToolCallIdByTaskId.get(taskId);
     if (existing && existing !== toolCallId) return undefined;
+    if (launch.phase === "awaiting_identity" && launch.candidateTaskId !== undefined) {
+      if (launch.candidateTaskId !== taskId) return undefined;
+      this.pruneAmbiguousCandidates(taskId, toolCallId);
+    }
     const identified =
       launch.phase === "awaiting_identity"
         ? ({ phase: "active", toolCallId, taskId } satisfies ActiveBackgroundTaskLaunch)
@@ -225,9 +233,28 @@ export class ClaudeBackgroundTaskStateMachine {
   private launchAckOwner(agentId: string, resultIds: readonly string[]): string | undefined {
     const known = this.launchToolCallIdByTaskId.get(agentId);
     if (known) return resultIds.includes(known) ? known : undefined;
-    const candidates = resultIds.filter((toolCallId) => this.launchesByToolCallId.has(toolCallId));
+    const candidates = resultIds.filter(
+      (toolCallId) => this.launchesByToolCallId.get(toolCallId)?.phase === "awaiting_identity"
+    );
     if (candidates.length !== 1) return undefined;
     return this.bindLaunch(candidates[0], agentId)?.toolCallId;
+  }
+
+  private pruneAmbiguousCandidates(taskId: string, ownerToolCallId: string): void {
+    for (const [toolCallId, launch] of this.launchesByToolCallId) {
+      if (
+        toolCallId !== ownerToolCallId &&
+        launch.phase === "awaiting_identity" &&
+        launch.candidateTaskId === taskId
+      ) {
+        this.launchesByToolCallId.delete(toolCallId);
+      }
+    }
+  }
+
+  private forgetLaunch(launch: IdentifiedBackgroundTaskLaunch): void {
+    this.launchesByToolCallId.delete(launch.toolCallId);
+    this.launchToolCallIdByTaskId.delete(launch.taskId);
   }
 
   private mergeTerminal(
@@ -236,14 +263,9 @@ export class ClaudeBackgroundTaskStateMachine {
     output?: string,
     progress?: AgentToolProgress
   ): ClaudeTaskToolUpdate | undefined {
-    if (launch.phase === "terminal_with_output") return undefined;
     if (launch.phase === "terminal_without_output") {
       if (!output) return undefined;
-      this.launchesByToolCallId.set(launch.toolCallId, {
-        ...launch,
-        phase: "terminal_with_output",
-        output,
-      });
+      this.forgetLaunch(launch);
       return {
         toolCallId: launch.toolCallId,
         status: launch.terminalStatus,
@@ -252,11 +274,15 @@ export class ClaudeBackgroundTaskStateMachine {
       };
     }
 
-    const terminalLaunch: TerminalBackgroundTaskWithoutOutput | TerminalBackgroundTaskWithOutput =
-      output
-        ? { ...launch, phase: "terminal_with_output", terminalStatus: status, output }
-        : { ...launch, phase: "terminal_without_output", terminalStatus: status };
-    this.launchesByToolCallId.set(launch.toolCallId, terminalLaunch);
+    if (output) {
+      this.forgetLaunch(launch);
+    } else {
+      this.launchesByToolCallId.set(launch.toolCallId, {
+        ...launch,
+        phase: "terminal_without_output",
+        terminalStatus: status,
+      });
+    }
     return {
       toolCallId: launch.toolCallId,
       status,
@@ -267,8 +293,6 @@ export class ClaudeBackgroundTaskStateMachine {
 }
 
 function protocolEventFromCarrier(carrier: ClaudeTaskCarrier): ClaudeTaskProtocolEvent | undefined {
-  if (carrier.kind === "query_finished") return carrier;
-
   if (carrier.kind === "tool_snapshot") {
     if (carrier.nativeToolName === "Agent" || carrier.nativeToolName === "Task") {
       return { kind: "launch_observed", toolCallId: carrier.toolCallId };
@@ -334,8 +358,8 @@ function taskDecision(update: ClaudeTaskToolUpdate): ClaudeTaskDecision {
 
 function isTerminalLaunch(
   launch: IdentifiedBackgroundTaskLaunch
-): launch is TerminalBackgroundTaskWithoutOutput | TerminalBackgroundTaskWithOutput {
-  return launch.phase === "terminal_without_output" || launch.phase === "terminal_with_output";
+): launch is TerminalBackgroundTaskWithoutOutput {
+  return launch.phase === "terminal_without_output";
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -724,410 +724,474 @@ describe("translateSdkMessage", () => {
     );
     expect(out).toEqual([]);
   });
-});
+  describe("background subagent system frames", () => {
+    const UUID = "uuid-1" as `${string}-${string}-${string}-${string}-${string}`;
 
-describe("sdkMessageTranslator", () => {
-  describe("translateSdkMessage()", () => {
-    describe("background subagent system frames", () => {
-      const UUID = "uuid-1" as `${string}-${string}-${string}-${string}-${string}`;
+    function systemMessage(fields: Record<string, unknown>): SDKMessage {
+      return {
+        type: "system",
+        uuid: UUID,
+        session_id: SESSION_ID,
+        ...fields,
+      } as unknown as SDKMessage;
+    }
 
-      function systemMessage(fields: Record<string, unknown>): SDKMessage {
-        return {
-          type: "system",
-          uuid: UUID,
-          session_id: SESSION_ID,
-          ...fields,
-        } as unknown as SDKMessage;
-      }
+    function launchAckResult(toolUseId: string, agentId = "abc123"): SDKMessage {
+      return {
+        type: "user",
+        tool_use_result: { isAsync: true, status: "async_launched", agentId },
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: toolUseId,
+              is_error: false,
+              content: [{ type: "text", text: "Async agent launched successfully." }],
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+        session_id: SESSION_ID,
+      } as unknown as SDKMessage;
+    }
 
-      function launchAckResult(toolUseId: string, agentId = "abc123"): SDKMessage {
-        return {
-          type: "user",
-          tool_use_result: { isAsync: true, status: "async_launched", agentId },
-          message: {
+    function trackToolUse(
+      state: ReturnType<typeof createTranslatorState>,
+      id: string,
+      name: string,
+      input: Record<string, unknown> = {}
+    ): void {
+      translateSdkMessage(
+        streamEvent({
+          type: "content_block_start",
+          index: state.emittedToolUseIds.size,
+          content_block: { type: "tool_use", id, name, input },
+        }),
+        SESSION_ID,
+        state
+      );
+    }
+
+    // Task frames only apply once we've tracked the launch (agentId "abc123" →
+    // card "tu-launch"); seed that so the gate lets them through.
+    function seedLaunch(state: ReturnType<typeof createTranslatorState>): void {
+      trackToolUse(state, "tu-launch", "Agent");
+      translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state);
+    }
+
+    it("binds task_started before the async acknowledgement arrives", () => {
+      const state = createTranslatorState();
+      trackToolUse(state, "tu-launch", "Agent");
+
+      const started = translateSdkMessage(
+        systemMessage({
+          subtype: "task_started",
+          task_id: "abc123",
+          tool_use_id: "tu-launch",
+          description: "Analyze vault",
+        }),
+        SESSION_ID,
+        state
+      );
+
+      expect(started[0].update).toMatchObject({
+        toolCallId: "tu-launch",
+        status: "in_progress",
+      });
+      expect(translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state)).toEqual([]);
+    });
+
+    it("folds task_notification onto the launch card as its output + terminal status", () => {
+      const state = createTranslatorState();
+      seedLaunch(state);
+      const out = translateSdkMessage(
+        systemMessage({
+          subtype: "task_notification",
+          task_id: "abc123",
+          tool_use_id: "tu-launch",
+          status: "completed",
+          summary: "Most prominent category: AI/agents (16 notes).",
+        }),
+        SESSION_ID,
+        state
+      );
+      expect(out).toEqual([
+        {
+          sessionId: SESSION_ID,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tu-launch",
+            status: "completed",
             content: [
               {
-                type: "tool_result",
-                tool_use_id: toolUseId,
-                is_error: false,
-                content: [{ type: "text", text: "Async agent launched successfully." }],
+                type: "content",
+                content: { type: "text", text: "Most prominent category: AI/agents (16 notes)." },
               },
             ],
           },
-          parent_tool_use_id: null,
-          session_id: SESSION_ID,
-        } as unknown as SDKMessage;
-      }
+        },
+      ]);
+    });
 
-      function trackToolUse(
-        state: ReturnType<typeof createTranslatorState>,
-        id: string,
-        name: string,
-        input: Record<string, unknown> = {}
-      ): void {
+    it("maps a non-completed task_notification status to failed", () => {
+      const state = createTranslatorState();
+      seedLaunch(state);
+      const out = translateSdkMessage(
+        systemMessage({
+          subtype: "task_notification",
+          task_id: "abc123",
+          tool_use_id: "tu-launch",
+          status: "stopped",
+          summary: "",
+        }),
+        SESSION_ID,
+        state
+      );
+      expect(out).toHaveLength(1);
+      expect(out[0].update).toMatchObject({ toolCallId: "tu-launch", status: "failed" });
+      // Empty summary contributes no content field (nothing to render).
+      expect((out[0].update as { content?: unknown }).content).toBeUndefined();
+    });
+
+    it.each([
+      ["completed", "completed"],
+      ["stopped", "failed"],
+    ])("uses the shared terminal mapping for task_notification status %s", (status, expected) => {
+      const state = createTranslatorState();
+      seedLaunch(state);
+      const out = translateSdkMessage(
+        systemMessage({
+          subtype: "task_notification",
+          task_id: "abc123",
+          tool_use_id: "tu-launch",
+          status,
+        }),
+        SESSION_ID,
+        state
+      );
+      expect(out[0].update).toMatchObject({ toolCallId: "tu-launch", status: expected });
+    });
+
+    it("keeps task_started in progress and normalizes meaningful task_progress", () => {
+      const state = createTranslatorState();
+      seedLaunch(state);
+      expect(
         translateSdkMessage(
-          streamEvent({
-            type: "content_block_start",
-            index: state.emittedToolUseIds.size,
-            content_block: { type: "tool_use", id, name, input },
-          }),
-          SESSION_ID,
-          state
-        );
-      }
-
-      // Task frames only apply once we've tracked the launch (agentId "abc123" →
-      // card "tu-launch"); seed that so the gate lets them through.
-      function seedLaunch(state: ReturnType<typeof createTranslatorState>): void {
-        trackToolUse(state, "tu-launch", "Agent");
-        translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state);
-      }
-
-      it("binds task_started before the async acknowledgement arrives", () => {
-        const state = createTranslatorState();
-        trackToolUse(state, "tu-launch", "Agent");
-
-        const started = translateSdkMessage(
           systemMessage({
             subtype: "task_started",
             task_id: "abc123",
             tool_use_id: "tu-launch",
-            description: "Analyze vault",
+            description: "started",
           }),
           SESSION_ID,
           state
-        );
-
-        expect(started[0].update).toMatchObject({
-          toolCallId: "tu-launch",
-          status: "in_progress",
-        });
-        expect(translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state)).toEqual([]);
+        )[0].update
+      ).toEqual({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tu-launch",
+        status: "in_progress",
       });
-
-      it("folds task_notification onto the launch card as its output + terminal status", () => {
-        const state = createTranslatorState();
-        seedLaunch(state);
-        const out = translateSdkMessage(
+      expect(
+        translateSdkMessage(
           systemMessage({
-            subtype: "task_notification",
+            subtype: "task_progress",
             task_id: "abc123",
             tool_use_id: "tu-launch",
-            status: "completed",
-            summary: "Most prominent category: AI/agents (16 notes).",
-          }),
-          SESSION_ID,
-          state
-        );
-        expect(out).toEqual([
-          {
-            sessionId: SESSION_ID,
-            update: {
-              sessionUpdate: "tool_call_update",
-              toolCallId: "tu-launch",
-              status: "completed",
-              content: [
-                {
-                  type: "content",
-                  content: { type: "text", text: "Most prominent category: AI/agents (16 notes)." },
-                },
-              ],
-            },
-          },
-        ]);
-      });
-
-      it("maps a non-completed task_notification status to failed", () => {
-        const state = createTranslatorState();
-        seedLaunch(state);
-        const out = translateSdkMessage(
-          systemMessage({
-            subtype: "task_notification",
-            task_id: "abc123",
-            tool_use_id: "tu-launch",
-            status: "stopped",
-            summary: "",
-          }),
-          SESSION_ID,
-          state
-        );
-        expect(out).toHaveLength(1);
-        expect(out[0].update).toMatchObject({ toolCallId: "tu-launch", status: "failed" });
-        // Empty summary contributes no content field (nothing to render).
-        expect((out[0].update as { content?: unknown }).content).toBeUndefined();
-      });
-
-      it.each([
-        ["completed", "completed"],
-        ["stopped", "failed"],
-      ])("uses the shared terminal mapping for task_notification status %s", (status, expected) => {
-        const state = createTranslatorState();
-        seedLaunch(state);
-        const out = translateSdkMessage(
-          systemMessage({
-            subtype: "task_notification",
-            task_id: "abc123",
-            tool_use_id: "tu-launch",
-            status,
-          }),
-          SESSION_ID,
-          state
-        );
-        expect(out[0].update).toMatchObject({ toolCallId: "tu-launch", status: expected });
-      });
-
-      it("keeps task_started in progress and normalizes meaningful task_progress", () => {
-        const state = createTranslatorState();
-        seedLaunch(state);
-        expect(
-          translateSdkMessage(
-            systemMessage({
-              subtype: "task_started",
-              task_id: "abc123",
-              tool_use_id: "tu-launch",
-              description: "started",
-            }),
-            SESSION_ID,
-            state
-          )[0].update
-        ).toEqual({
-          sessionUpdate: "tool_call_update",
-          toolCallId: "tu-launch",
-          status: "in_progress",
-        });
-        expect(
-          translateSdkMessage(
-            systemMessage({
-              subtype: "task_progress",
-              task_id: "abc123",
-              tool_use_id: "tu-launch",
-              description: "Count markdown files",
-              last_tool_name: "Read",
-              usage: { tool_uses: 3, duration_ms: 9851, total_tokens: 4210 },
-            }),
-            SESSION_ID,
-            state
-          )[0].update
-        ).toEqual({
-          sessionUpdate: "tool_call_update",
-          toolCallId: "tu-launch",
-          status: "in_progress",
-          progress: {
             description: "Count markdown files",
-            toolName: "Read",
-            toolUses: 3,
-            durationMs: 9851,
-            totalTokens: 4210,
-          },
-        });
+            last_tool_name: "Read",
+            usage: { tool_uses: 3, duration_ms: 9851, total_tokens: 4210 },
+          }),
+          SESSION_ID,
+          state
+        )[0].update
+      ).toEqual({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tu-launch",
+        status: "in_progress",
+        progress: {
+          description: "Count markdown files",
+          toolName: "Read",
+          toolUses: 3,
+          durationMs: 9851,
+          totalTokens: 4210,
+        },
       });
+    });
 
-      it("ignores a straggling task_progress after the notification settled the card", () => {
-        const state = createTranslatorState();
-        seedLaunch(state);
+    it("ignores a straggling task_progress after the notification settled the card", () => {
+      const state = createTranslatorState();
+      seedLaunch(state);
+      translateSdkMessage(
+        systemMessage({
+          subtype: "task_notification",
+          task_id: "abc123",
+          tool_use_id: "tu-launch",
+          status: "completed",
+          summary: "done",
+        }),
+        SESSION_ID,
+        state
+      );
+      const out = translateSdkMessage(
+        systemMessage({
+          subtype: "task_progress",
+          task_id: "abc123",
+          tool_use_id: "tu-launch",
+          description: "…",
+        }),
+        SESSION_ID,
+        state
+      );
+      expect(out).toEqual([]);
+    });
+
+    it("ignores a task_notification that is not a tracked subagent launch (background Bash/Monitor)", () => {
+      const state = createTranslatorState();
+      seedLaunch(state); // tracks agentId "abc123" → "tu-launch"
+      // A background Bash finishing: task_id/tool_use_id don't match the tracked
+      // launch, so it must NOT clobber that (or any) card.
+      expect(
+        translateSdkMessage(
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "bash-task",
+            tool_use_id: "tu-bash",
+            status: "completed",
+            summary: "done",
+          }),
+          SESSION_ID,
+          state
+        )
+      ).toEqual([]);
+      // Right task_id but a different tool_use_id (stale/other card) is also ignored.
+      expect(
         translateSdkMessage(
           systemMessage({
             subtype: "task_notification",
             task_id: "abc123",
-            tool_use_id: "tu-launch",
+            tool_use_id: "tu-other",
             status: "completed",
             summary: "done",
           }),
           SESSION_ID,
           state
-        );
-        const out = translateSdkMessage(
-          systemMessage({
-            subtype: "task_progress",
-            task_id: "abc123",
-            tool_use_id: "tu-launch",
-            description: "…",
-          }),
-          SESSION_ID,
-          state
-        );
-        expect(out).toEqual([]);
-      });
+        )
+      ).toEqual([]);
+    });
 
-      it("ignores a task_notification that is not a tracked subagent launch (background Bash/Monitor)", () => {
-        const state = createTranslatorState();
-        seedLaunch(state); // tracks agentId "abc123" → "tu-launch"
-        // A background Bash finishing: task_id/tool_use_id don't match the tracked
-        // launch, so it must NOT clobber that (or any) card.
-        expect(
-          translateSdkMessage(
-            systemMessage({
-              subtype: "task_notification",
-              task_id: "bash-task",
-              tool_use_id: "tu-bash",
-              status: "completed",
-              summary: "done",
-            }),
-            SESSION_ID,
-            state
-          )
-        ).toEqual([]);
-        // Right task_id but a different tool_use_id (stale/other card) is also ignored.
-        expect(
-          translateSdkMessage(
-            systemMessage({
-              subtype: "task_notification",
-              task_id: "abc123",
-              tool_use_id: "tu-other",
-              status: "completed",
-              summary: "done",
-            }),
-            SESSION_ID,
-            state
-          )
-        ).toEqual([]);
-      });
+    it("correlates task frames with no tool_use_id after acknowledgement", () => {
+      const state = createTranslatorState();
+      seedLaunch(state);
 
-      it("correlates task frames with no tool_use_id after acknowledgement", () => {
-        const state = createTranslatorState();
-        seedLaunch(state);
-
-        const progress = translateSdkMessage(
-          systemMessage({
-            subtype: "task_progress",
-            task_id: "abc123",
-            description: "Count notes",
-          }),
-          SESSION_ID,
-          state
-        );
-        const completed = translateSdkMessage(
-          systemMessage({
-            subtype: "task_notification",
-            task_id: "abc123",
-            status: "completed",
-            summary: "done",
-          }),
-          SESSION_ID,
-          state
-        );
-
-        expect(progress[0].update).toMatchObject({
-          toolCallId: "tu-launch",
-          status: "in_progress",
-          progress: { description: "Count notes" },
-        });
-        expect(completed[0].update).toMatchObject({
-          toolCallId: "tu-launch",
+      const progress = translateSdkMessage(
+        systemMessage({
+          subtype: "task_progress",
+          task_id: "abc123",
+          description: "Count notes",
+        }),
+        SESSION_ID,
+        state
+      );
+      const completed = translateSdkMessage(
+        systemMessage({
+          subtype: "task_notification",
+          task_id: "abc123",
           status: "completed",
-        });
+          summary: "done",
+        }),
+        SESSION_ID,
+        state
+      );
+
+      expect(progress[0].update).toMatchObject({
+        toolCallId: "tu-launch",
+        status: "in_progress",
+        progress: { description: "Count notes" },
       });
-
-      it("ignores task_updated frames", () => {
-        const state = createTranslatorState();
-        seedLaunch(state);
-
-        expect(
-          translateSdkMessage(
-            systemMessage({
-              subtype: "task_updated",
-              task_id: "abc123",
-              patch: { status: "completed" },
-            }),
-            SESSION_ID,
-            state
-          )
-        ).toEqual([]);
-      });
-
-      it("suppresses the async-launch ack tool_result so the launch stays in_progress", () => {
-        const state = createTranslatorState();
-        trackToolUse(state, "tu-launch", "Agent");
-        expect(translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state)).toEqual([]);
-      });
-
-      it("suppresses only the launch-ack block, still translating a batched sibling result", () => {
-        const state = createTranslatorState();
-        trackToolUse(state, "tu-launch", "Agent");
-        trackToolUse(state, "tu-read", "Read");
-        const batched = {
-          type: "user",
-          tool_use_result: { isAsync: true, status: "async_launched", agentId: "abc123" },
-          message: {
-            content: [
-              {
-                type: "tool_result",
-                tool_use_id: "tu-launch",
-                content: [{ type: "text", text: "Async agent launched successfully." }],
-              },
-              { type: "tool_result", tool_use_id: "tu-read", content: "file contents" },
-            ],
-          },
-          parent_tool_use_id: null,
-          session_id: SESSION_ID,
-        } as unknown as SDKMessage;
-        const out = translateSdkMessage(batched, SESSION_ID, state);
-        // Only the sibling Read is translated; the launch ack is suppressed.
-        expect(out).toHaveLength(1);
-        expect(out[0].update).toMatchObject({ toolCallId: "tu-read", status: "completed" });
-      });
-
-      it("matches a batched launch ack to the Agent result when it is not the first block", () => {
-        const state = createTranslatorState();
-        trackToolUse(state, "tu-read", "Read");
-        trackToolUse(state, "tu-launch", "Agent");
-        const batched = {
-          type: "user",
-          tool_use_result: { isAsync: true, status: "async_launched", agentId: "abc123" },
-          message: {
-            content: [
-              { type: "tool_result", tool_use_id: "tu-read", content: "file contents" },
-              {
-                type: "tool_result",
-                tool_use_id: "tu-launch",
-                content: [{ type: "text", text: "Async agent launched successfully." }],
-              },
-            ],
-          },
-          parent_tool_use_id: null,
-          session_id: SESSION_ID,
-        } as unknown as SDKMessage;
-
-        const out = translateSdkMessage(batched, SESSION_ID, state);
-
-        expect(out).toHaveLength(1);
-        expect(out[0].update).toMatchObject({ toolCallId: "tu-read", status: "completed" });
-      });
-
-      it("still completes a genuine (non-launch) tool_result", () => {
-        const state = createTranslatorState();
-        const out = translateSdkMessage(
-          {
-            type: "user",
-            message: {
-              content: [
-                { type: "tool_result", tool_use_id: "tu-real", content: "done", is_error: false },
-              ],
-            },
-            parent_tool_use_id: null,
-            session_id: SESSION_ID,
-          } as unknown as SDKMessage,
-          SESSION_ID,
-          state
-        );
-        expect(out[0].update).toMatchObject({ toolCallId: "tu-real", status: "completed" });
+      expect(completed[0].update).toMatchObject({
+        toolCallId: "tu-launch",
+        status: "completed",
       });
     });
-  });
-});
 
-describe("mapStopReason", () => {
-  it("maps success → end_turn", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(mapStopReason({ type: "result", subtype: "success" } as any)).toBe("end_turn");
-  });
-  it("maps error variants → cancelled", () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(mapStopReason({ type: "result", subtype: "error_during_execution" } as any)).toBe(
-      "cancelled"
-    );
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(mapStopReason({ type: "result", subtype: "error_max_turns" } as any)).toBe("cancelled");
+    it("keeps task identity across translator generations until terminal output arrives", () => {
+      const firstQuery = createTranslatorState();
+      seedLaunch(firstQuery);
+      translateSdkMessage(resultMsg({}), SESSION_ID, firstQuery);
+      const nextQuery = createTranslatorState(firstQuery.claudeTasks, firstQuery.backgroundTasks);
+
+      const completed = translateSdkMessage(
+        systemMessage({
+          subtype: "task_notification",
+          task_id: "abc123",
+          status: "completed",
+          summary: "finished after the first query",
+        }),
+        SESSION_ID,
+        nextQuery
+      );
+      const lateProgress = translateSdkMessage(
+        systemMessage({
+          subtype: "task_progress",
+          task_id: "abc123",
+          description: "too late",
+        }),
+        SESSION_ID,
+        nextQuery
+      );
+
+      expect(completed[0].update).toMatchObject({
+        toolCallId: "tu-launch",
+        status: "completed",
+      });
+      expect(lateProgress).toEqual([]);
+    });
+
+    it("ignores task_updated frames", () => {
+      const state = createTranslatorState();
+      seedLaunch(state);
+
+      expect(
+        translateSdkMessage(
+          systemMessage({
+            subtype: "task_updated",
+            task_id: "abc123",
+            patch: { status: "completed" },
+          }),
+          SESSION_ID,
+          state
+        )
+      ).toEqual([]);
+    });
+
+    it("suppresses the async-launch ack tool_result so the launch stays in_progress", () => {
+      const state = createTranslatorState();
+      trackToolUse(state, "tu-launch", "Agent");
+      expect(translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state)).toEqual([]);
+    });
+
+    it("suppresses only the launch-ack block, still translating a batched sibling result", () => {
+      const state = createTranslatorState();
+      trackToolUse(state, "tu-launch", "Agent");
+      trackToolUse(state, "tu-read", "Read");
+      const batched = {
+        type: "user",
+        tool_use_result: { isAsync: true, status: "async_launched", agentId: "abc123" },
+        message: {
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tu-launch",
+              content: [{ type: "text", text: "Async agent launched successfully." }],
+            },
+            { type: "tool_result", tool_use_id: "tu-read", content: "file contents" },
+          ],
+        },
+        parent_tool_use_id: null,
+        session_id: SESSION_ID,
+      } as unknown as SDKMessage;
+      const out = translateSdkMessage(batched, SESSION_ID, state);
+      // Only the sibling Read is translated; the launch ack is suppressed.
+      expect(out).toHaveLength(1);
+      expect(out[0].update).toMatchObject({ toolCallId: "tu-read", status: "completed" });
+    });
+
+    it("matches a batched launch ack to the Agent result when it is not the first block", () => {
+      const state = createTranslatorState();
+      trackToolUse(state, "tu-read", "Read");
+      trackToolUse(state, "tu-launch", "Agent");
+      const batched = {
+        type: "user",
+        tool_use_result: { isAsync: true, status: "async_launched", agentId: "abc123" },
+        message: {
+          content: [
+            { type: "tool_result", tool_use_id: "tu-read", content: "file contents" },
+            {
+              type: "tool_result",
+              tool_use_id: "tu-launch",
+              content: [{ type: "text", text: "Async agent launched successfully." }],
+            },
+          ],
+        },
+        parent_tool_use_id: null,
+        session_id: SESSION_ID,
+      } as unknown as SDKMessage;
+
+      const out = translateSdkMessage(batched, SESSION_ID, state);
+
+      expect(out).toHaveLength(1);
+      expect(out[0].update).toMatchObject({ toolCallId: "tu-read", status: "completed" });
+    });
+
+    it("keeps batched Agent candidates until task_started identifies the async launch", () => {
+      const state = createTranslatorState();
+      trackToolUse(state, "tu-foreground", "Agent");
+      trackToolUse(state, "tu-background", "Task");
+      translateSdkMessage(
+        {
+          type: "user",
+          tool_use_result: { isAsync: true, status: "async_launched", agentId: "abc123" },
+          message: {
+            content: [
+              { type: "tool_result", tool_use_id: "tu-foreground", content: "done" },
+              {
+                type: "tool_result",
+                tool_use_id: "tu-background",
+                content: "Async agent launched successfully.",
+              },
+            ],
+          },
+          parent_tool_use_id: null,
+          session_id: SESSION_ID,
+        } as unknown as SDKMessage,
+        SESSION_ID,
+        state
+      );
+
+      const selected = translateSdkMessage(
+        systemMessage({
+          subtype: "task_started",
+          task_id: "abc123",
+          tool_use_id: "tu-background",
+        }),
+        SESSION_ID,
+        state
+      );
+      const rejected = translateSdkMessage(
+        systemMessage({
+          subtype: "task_started",
+          task_id: "abc123",
+          tool_use_id: "tu-foreground",
+        }),
+        SESSION_ID,
+        state
+      );
+
+      expect(selected[0].update).toMatchObject({
+        toolCallId: "tu-background",
+        status: "in_progress",
+      });
+      expect(rejected).toEqual([]);
+    });
+
+    it("still completes a genuine (non-launch) tool_result", () => {
+      const state = createTranslatorState();
+      const out = translateSdkMessage(
+        {
+          type: "user",
+          message: {
+            content: [
+              { type: "tool_result", tool_use_id: "tu-real", content: "done", is_error: false },
+            ],
+          },
+          parent_tool_use_id: null,
+          session_id: SESSION_ID,
+        } as unknown as SDKMessage,
+        SESSION_ID,
+        state
+      );
+      expect(out[0].update).toMatchObject({ toolCallId: "tu-real", status: "completed" });
+    });
   });
 });
 
@@ -1436,5 +1500,20 @@ describe("translateSdkMessage — result → usage_update", () => {
     expect(update.sessionUpdate).toBe("usage_update");
     expect(update.usage.usedTokens).toBe(12);
     expect(update.usage.contextWindow).toBeUndefined();
+  });
+});
+
+describe("mapStopReason()", () => {
+  it("maps success → end_turn", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(mapStopReason({ type: "result", subtype: "success" } as any)).toBe("end_turn");
+  });
+  it("maps error variants → cancelled", () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(mapStopReason({ type: "result", subtype: "error_during_execution" } as any)).toBe(
+      "cancelled"
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(mapStopReason({ type: "result", subtype: "error_max_turns" } as any)).toBe("cancelled");
   });
 });

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -1123,11 +1123,11 @@ describe("translateSdkMessage", () => {
       expect(out[0].update).toMatchObject({ toolCallId: "tu-read", status: "completed" });
     });
 
-    it("keeps batched Agent candidates until task_started identifies the async launch", () => {
+    it("suppresses the exact batched launch acknowledgement and binds task-only frames", () => {
       const state = createTranslatorState();
       trackToolUse(state, "tu-foreground", "Agent");
       trackToolUse(state, "tu-background", "Task");
-      translateSdkMessage(
+      const acknowledged = translateSdkMessage(
         {
           type: "user",
           tool_use_result: { isAsync: true, status: "async_launched", agentId: "abc123" },
@@ -1148,30 +1148,32 @@ describe("translateSdkMessage", () => {
         state
       );
 
-      const selected = translateSdkMessage(
+      const progress = translateSdkMessage(
         systemMessage({
-          subtype: "task_started",
+          subtype: "task_progress",
           task_id: "abc123",
-          tool_use_id: "tu-background",
-        }),
-        SESSION_ID,
-        state
-      );
-      const rejected = translateSdkMessage(
-        systemMessage({
-          subtype: "task_started",
-          task_id: "abc123",
-          tool_use_id: "tu-foreground",
+          description: "Count notes",
         }),
         SESSION_ID,
         state
       );
 
-      expect(selected[0].update).toMatchObject({
+      expect(acknowledged).toEqual([
+        {
+          sessionId: SESSION_ID,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tu-foreground",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "done" } }],
+          },
+        },
+      ]);
+      expect(progress[0].update).toMatchObject({
         toolCallId: "tu-background",
         status: "in_progress",
+        progress: { description: "Count notes" },
       });
-      expect(rejected).toEqual([]);
     });
 
     it("still completes a genuine (non-launch) tool_result", () => {

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -172,7 +172,6 @@ describe("translateSdkMessage", () => {
       name: "Tool",
       inputJsonAcc: "",
       lastParsedInput: {},
-      emittedToolCall: false,
     });
     translateSdkMessage(streamEvent({ type: "message_start", message: {} }), SESSION_ID, state);
     expect(state.toolUseBlocks.size).toBe(0);
@@ -724,6 +723,396 @@ describe("translateSdkMessage", () => {
       state
     );
     expect(out).toEqual([]);
+  });
+});
+
+describe("sdkMessageTranslator", () => {
+  describe("translateSdkMessage()", () => {
+    describe("background subagent system frames", () => {
+      const UUID = "uuid-1" as `${string}-${string}-${string}-${string}-${string}`;
+
+      function systemMessage(fields: Record<string, unknown>): SDKMessage {
+        return {
+          type: "system",
+          uuid: UUID,
+          session_id: SESSION_ID,
+          ...fields,
+        } as unknown as SDKMessage;
+      }
+
+      function launchAckResult(toolUseId: string, agentId = "abc123"): SDKMessage {
+        return {
+          type: "user",
+          tool_use_result: { isAsync: true, status: "async_launched", agentId },
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: toolUseId,
+                is_error: false,
+                content: [{ type: "text", text: "Async agent launched successfully." }],
+              },
+            ],
+          },
+          parent_tool_use_id: null,
+          session_id: SESSION_ID,
+        } as unknown as SDKMessage;
+      }
+
+      function trackToolUse(
+        state: ReturnType<typeof createTranslatorState>,
+        id: string,
+        name: string,
+        input: Record<string, unknown> = {}
+      ): void {
+        translateSdkMessage(
+          streamEvent({
+            type: "content_block_start",
+            index: state.emittedToolUseIds.size,
+            content_block: { type: "tool_use", id, name, input },
+          }),
+          SESSION_ID,
+          state
+        );
+      }
+
+      // Task frames only apply once we've tracked the launch (agentId "abc123" →
+      // card "tu-launch"); seed that so the gate lets them through.
+      function seedLaunch(state: ReturnType<typeof createTranslatorState>): void {
+        trackToolUse(state, "tu-launch", "Agent");
+        translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state);
+      }
+
+      it("binds task_started before the async acknowledgement arrives", () => {
+        const state = createTranslatorState();
+        trackToolUse(state, "tu-launch", "Agent");
+
+        const started = translateSdkMessage(
+          systemMessage({
+            subtype: "task_started",
+            task_id: "abc123",
+            tool_use_id: "tu-launch",
+            description: "Analyze vault",
+          }),
+          SESSION_ID,
+          state
+        );
+
+        expect(started[0].update).toMatchObject({
+          toolCallId: "tu-launch",
+          status: "in_progress",
+        });
+        expect(translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state)).toEqual([]);
+      });
+
+      it("folds task_notification onto the launch card as its output + terminal status", () => {
+        const state = createTranslatorState();
+        seedLaunch(state);
+        const out = translateSdkMessage(
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "abc123",
+            tool_use_id: "tu-launch",
+            status: "completed",
+            summary: "Most prominent category: AI/agents (16 notes).",
+          }),
+          SESSION_ID,
+          state
+        );
+        expect(out).toEqual([
+          {
+            sessionId: SESSION_ID,
+            update: {
+              sessionUpdate: "tool_call_update",
+              toolCallId: "tu-launch",
+              status: "completed",
+              content: [
+                {
+                  type: "content",
+                  content: { type: "text", text: "Most prominent category: AI/agents (16 notes)." },
+                },
+              ],
+            },
+          },
+        ]);
+      });
+
+      it("maps a non-completed task_notification status to failed", () => {
+        const state = createTranslatorState();
+        seedLaunch(state);
+        const out = translateSdkMessage(
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "abc123",
+            tool_use_id: "tu-launch",
+            status: "stopped",
+            summary: "",
+          }),
+          SESSION_ID,
+          state
+        );
+        expect(out).toHaveLength(1);
+        expect(out[0].update).toMatchObject({ toolCallId: "tu-launch", status: "failed" });
+        // Empty summary contributes no content field (nothing to render).
+        expect((out[0].update as { content?: unknown }).content).toBeUndefined();
+      });
+
+      it.each([
+        ["completed", "completed"],
+        ["stopped", "failed"],
+      ])("uses the shared terminal mapping for task_notification status %s", (status, expected) => {
+        const state = createTranslatorState();
+        seedLaunch(state);
+        const out = translateSdkMessage(
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "abc123",
+            tool_use_id: "tu-launch",
+            status,
+          }),
+          SESSION_ID,
+          state
+        );
+        expect(out[0].update).toMatchObject({ toolCallId: "tu-launch", status: expected });
+      });
+
+      it("keeps task_started in progress and normalizes meaningful task_progress", () => {
+        const state = createTranslatorState();
+        seedLaunch(state);
+        expect(
+          translateSdkMessage(
+            systemMessage({
+              subtype: "task_started",
+              task_id: "abc123",
+              tool_use_id: "tu-launch",
+              description: "started",
+            }),
+            SESSION_ID,
+            state
+          )[0].update
+        ).toEqual({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tu-launch",
+          status: "in_progress",
+        });
+        expect(
+          translateSdkMessage(
+            systemMessage({
+              subtype: "task_progress",
+              task_id: "abc123",
+              tool_use_id: "tu-launch",
+              description: "Count markdown files",
+              last_tool_name: "Read",
+              usage: { tool_uses: 3, duration_ms: 9851, total_tokens: 4210 },
+            }),
+            SESSION_ID,
+            state
+          )[0].update
+        ).toEqual({
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tu-launch",
+          status: "in_progress",
+          progress: {
+            description: "Count markdown files",
+            toolName: "Read",
+            toolUses: 3,
+            durationMs: 9851,
+            totalTokens: 4210,
+          },
+        });
+      });
+
+      it("ignores a straggling task_progress after the notification settled the card", () => {
+        const state = createTranslatorState();
+        seedLaunch(state);
+        translateSdkMessage(
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "abc123",
+            tool_use_id: "tu-launch",
+            status: "completed",
+            summary: "done",
+          }),
+          SESSION_ID,
+          state
+        );
+        const out = translateSdkMessage(
+          systemMessage({
+            subtype: "task_progress",
+            task_id: "abc123",
+            tool_use_id: "tu-launch",
+            description: "…",
+          }),
+          SESSION_ID,
+          state
+        );
+        expect(out).toEqual([]);
+      });
+
+      it("ignores a task_notification that is not a tracked subagent launch (background Bash/Monitor)", () => {
+        const state = createTranslatorState();
+        seedLaunch(state); // tracks agentId "abc123" → "tu-launch"
+        // A background Bash finishing: task_id/tool_use_id don't match the tracked
+        // launch, so it must NOT clobber that (or any) card.
+        expect(
+          translateSdkMessage(
+            systemMessage({
+              subtype: "task_notification",
+              task_id: "bash-task",
+              tool_use_id: "tu-bash",
+              status: "completed",
+              summary: "done",
+            }),
+            SESSION_ID,
+            state
+          )
+        ).toEqual([]);
+        // Right task_id but a different tool_use_id (stale/other card) is also ignored.
+        expect(
+          translateSdkMessage(
+            systemMessage({
+              subtype: "task_notification",
+              task_id: "abc123",
+              tool_use_id: "tu-other",
+              status: "completed",
+              summary: "done",
+            }),
+            SESSION_ID,
+            state
+          )
+        ).toEqual([]);
+      });
+
+      it("correlates task frames with no tool_use_id after acknowledgement", () => {
+        const state = createTranslatorState();
+        seedLaunch(state);
+
+        const progress = translateSdkMessage(
+          systemMessage({
+            subtype: "task_progress",
+            task_id: "abc123",
+            description: "Count notes",
+          }),
+          SESSION_ID,
+          state
+        );
+        const completed = translateSdkMessage(
+          systemMessage({
+            subtype: "task_notification",
+            task_id: "abc123",
+            status: "completed",
+            summary: "done",
+          }),
+          SESSION_ID,
+          state
+        );
+
+        expect(progress[0].update).toMatchObject({
+          toolCallId: "tu-launch",
+          status: "in_progress",
+          progress: { description: "Count notes" },
+        });
+        expect(completed[0].update).toMatchObject({
+          toolCallId: "tu-launch",
+          status: "completed",
+        });
+      });
+
+      it("ignores task_updated frames", () => {
+        const state = createTranslatorState();
+        seedLaunch(state);
+
+        expect(
+          translateSdkMessage(
+            systemMessage({
+              subtype: "task_updated",
+              task_id: "abc123",
+              patch: { status: "completed" },
+            }),
+            SESSION_ID,
+            state
+          )
+        ).toEqual([]);
+      });
+
+      it("suppresses the async-launch ack tool_result so the launch stays in_progress", () => {
+        const state = createTranslatorState();
+        trackToolUse(state, "tu-launch", "Agent");
+        expect(translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state)).toEqual([]);
+      });
+
+      it("suppresses only the launch-ack block, still translating a batched sibling result", () => {
+        const state = createTranslatorState();
+        trackToolUse(state, "tu-launch", "Agent");
+        trackToolUse(state, "tu-read", "Read");
+        const batched = {
+          type: "user",
+          tool_use_result: { isAsync: true, status: "async_launched", agentId: "abc123" },
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tu-launch",
+                content: [{ type: "text", text: "Async agent launched successfully." }],
+              },
+              { type: "tool_result", tool_use_id: "tu-read", content: "file contents" },
+            ],
+          },
+          parent_tool_use_id: null,
+          session_id: SESSION_ID,
+        } as unknown as SDKMessage;
+        const out = translateSdkMessage(batched, SESSION_ID, state);
+        // Only the sibling Read is translated; the launch ack is suppressed.
+        expect(out).toHaveLength(1);
+        expect(out[0].update).toMatchObject({ toolCallId: "tu-read", status: "completed" });
+      });
+
+      it("matches a batched launch ack to the Agent result when it is not the first block", () => {
+        const state = createTranslatorState();
+        trackToolUse(state, "tu-read", "Read");
+        trackToolUse(state, "tu-launch", "Agent");
+        const batched = {
+          type: "user",
+          tool_use_result: { isAsync: true, status: "async_launched", agentId: "abc123" },
+          message: {
+            content: [
+              { type: "tool_result", tool_use_id: "tu-read", content: "file contents" },
+              {
+                type: "tool_result",
+                tool_use_id: "tu-launch",
+                content: [{ type: "text", text: "Async agent launched successfully." }],
+              },
+            ],
+          },
+          parent_tool_use_id: null,
+          session_id: SESSION_ID,
+        } as unknown as SDKMessage;
+
+        const out = translateSdkMessage(batched, SESSION_ID, state);
+
+        expect(out).toHaveLength(1);
+        expect(out[0].update).toMatchObject({ toolCallId: "tu-read", status: "completed" });
+      });
+
+      it("still completes a genuine (non-launch) tool_result", () => {
+        const state = createTranslatorState();
+        const out = translateSdkMessage(
+          {
+            type: "user",
+            message: {
+              content: [
+                { type: "tool_result", tool_use_id: "tu-real", content: "done", is_error: false },
+              ],
+            },
+            parent_tool_use_id: null,
+            session_id: SESSION_ID,
+          } as unknown as SDKMessage,
+          SESSION_ID,
+          state
+        );
+        expect(out[0].update).toMatchObject({ toolCallId: "tu-real", status: "completed" });
+      });
+    });
   });
 });
 

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -772,6 +772,34 @@ describe("translateSdkMessage", () => {
       );
     }
 
+    function trackStreamedToolUse(
+      state: ReturnType<typeof createTranslatorState>,
+      index: number,
+      id: string,
+      name: string,
+      input: Record<string, unknown>
+    ): void {
+      translateSdkMessage(
+        streamEvent({
+          type: "content_block_start",
+          index,
+          content_block: { type: "tool_use", id, name, input: {} },
+        }),
+        SESSION_ID,
+        state
+      );
+      translateSdkMessage(
+        streamEvent({
+          type: "content_block_delta",
+          index,
+          delta: { type: "input_json_delta", partial_json: JSON.stringify(input) },
+        }),
+        SESSION_ID,
+        state
+      );
+      translateSdkMessage(streamEvent({ type: "content_block_stop", index }), SESSION_ID, state);
+    }
+
     // Task frames only apply once we've tracked the launch (agentId "abc123" →
     // card "tu-launch"); seed that so the gate lets them through.
     function seedLaunch(state: ReturnType<typeof createTranslatorState>): void {
@@ -1144,10 +1172,24 @@ describe("translateSdkMessage", () => {
       expect(out[0].update).toMatchObject({ toolCallId: "tu-read", status: "completed" });
     });
 
-    it("uses structured launch metadata to suppress a batched acknowledgement", () => {
+    it("uses explicit task identity when launch inputs stream from empty snapshots", () => {
       const state = createTranslatorState();
-      trackToolUse(state, "tu-foreground", "Agent", { prompt: "foreground prompt" });
-      trackToolUse(state, "tu-background", "Task", { prompt: "background prompt" });
+      trackStreamedToolUse(state, 0, "tu-foreground", "Agent", {
+        prompt: "foreground prompt",
+      });
+      trackStreamedToolUse(state, 1, "tu-background", "Task", {
+        prompt: "background prompt",
+      });
+      translateSdkMessage(
+        systemMessage({
+          subtype: "task_started",
+          task_id: "abc123",
+          tool_use_id: "tu-background",
+          description: "Background task",
+        }),
+        SESSION_ID,
+        state
+      );
       const acknowledged = translateSdkMessage(
         {
           type: "user",
@@ -1155,7 +1197,7 @@ describe("translateSdkMessage", () => {
             isAsync: true,
             status: "async_launched",
             agentId: "abc123",
-            prompt: "background prompt",
+            prompt: "metadata is not an identity key",
           },
           message: {
             content: [

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -1047,7 +1047,28 @@ describe("translateSdkMessage", () => {
       expect(lateProgress).toEqual([]);
     });
 
-    it("ignores task_updated frames", () => {
+    it("settles the launch when task_updated carries a terminal patch status", () => {
+      const state = createTranslatorState();
+      seedLaunch(state);
+
+      const settled = translateSdkMessage(
+        systemMessage({
+          subtype: "task_updated",
+          task_id: "abc123",
+          patch: { status: "completed" },
+        }),
+        SESSION_ID,
+        state
+      );
+
+      expect(settled[0].update).toMatchObject({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tu-launch",
+        status: "completed",
+      });
+    });
+
+    it("ignores task_updated frames whose patch is not terminal", () => {
       const state = createTranslatorState();
       seedLaunch(state);
 
@@ -1056,7 +1077,7 @@ describe("translateSdkMessage", () => {
           systemMessage({
             subtype: "task_updated",
             task_id: "abc123",
-            patch: { status: "completed" },
+            patch: { status: "running" },
           }),
           SESSION_ID,
           state

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -1176,6 +1176,53 @@ describe("translateSdkMessage", () => {
       });
     });
 
+    it("keeps the first terminal status when an ordinary result supplies late output", () => {
+      const state = createTranslatorState();
+      trackToolUse(state, "tu-launch", "Agent");
+      translateSdkMessage(launchAckResult("tu-launch"), SESSION_ID, state);
+      translateSdkMessage(
+        systemMessage({
+          subtype: "task_notification",
+          task_id: "abc123",
+          status: "completed",
+        }),
+        SESSION_ID,
+        state
+      );
+
+      const lateOutput = translateSdkMessage(
+        {
+          type: "user",
+          message: {
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tu-launch",
+                content: "late output",
+                is_error: true,
+              },
+            ],
+          },
+          parent_tool_use_id: null,
+          session_id: SESSION_ID,
+        } as unknown as SDKMessage,
+        SESSION_ID,
+        state
+      );
+
+      expect(lateOutput).toEqual([
+        {
+          sessionId: SESSION_ID,
+          update: {
+            sessionUpdate: "tool_call_update",
+            toolCallId: "tu-launch",
+            status: "completed",
+            content: [{ type: "content", content: { type: "text", text: "late output" } }],
+          },
+        },
+      ]);
+    });
+
     it("still completes a genuine (non-launch) tool_result", () => {
       const state = createTranslatorState();
       const out = translateSdkMessage(

--- a/src/agentMode/sdk/sdkMessageTranslator.test.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.test.ts
@@ -1144,21 +1144,26 @@ describe("translateSdkMessage", () => {
       expect(out[0].update).toMatchObject({ toolCallId: "tu-read", status: "completed" });
     });
 
-    it("suppresses the exact batched launch acknowledgement and binds task-only frames", () => {
+    it("uses structured launch metadata to suppress a batched acknowledgement", () => {
       const state = createTranslatorState();
-      trackToolUse(state, "tu-foreground", "Agent");
-      trackToolUse(state, "tu-background", "Task");
+      trackToolUse(state, "tu-foreground", "Agent", { prompt: "foreground prompt" });
+      trackToolUse(state, "tu-background", "Task", { prompt: "background prompt" });
       const acknowledged = translateSdkMessage(
         {
           type: "user",
-          tool_use_result: { isAsync: true, status: "async_launched", agentId: "abc123" },
+          tool_use_result: {
+            isAsync: true,
+            status: "async_launched",
+            agentId: "abc123",
+            prompt: "background prompt",
+          },
           message: {
             content: [
               { type: "tool_result", tool_use_id: "tu-foreground", content: "done" },
               {
                 type: "tool_result",
                 tool_use_id: "tu-background",
-                content: "Async agent launched successfully.",
+                content: "opaque internal acknowledgement",
               },
             ],
           },

--- a/src/agentMode/sdk/sdkMessageTranslator.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.ts
@@ -22,12 +22,15 @@ import {
   type ClaudeTaskPlanState,
 } from "./claudeTodoPlan";
 import { deriveToolKind, deriveToolTitle, vendorMetaFields } from "./toolMeta";
+import { ClaudeBackgroundTaskStateMachine, type ClaudeTaskToolUpdate } from "./claudeTaskProtocol";
+
+/** Every SDK `system` frame — the `type: "system"` slice of the message union. */
+type SDKSystemLike = Extract<SDKMessage, { type: "system" }>;
 
 /**
  * Mutable per-query translator state. One instance lives for the duration of
- * a single `query()` call; reset whenever a new turn starts — EXCEPT
- * `claudeTasks`, which the caller shares across a session's queries (Task ids
- * created in one turn must resolve when a later turn updates them).
+ * a single `query()` call; reset whenever a new turn starts. Only
+ * `claudeTasks` is deliberately shared across queries.
  */
 export interface TranslatorState {
   toolUseBlocks: Map<
@@ -38,11 +41,12 @@ export interface TranslatorState {
       mcpServer?: string;
       inputJsonAcc: string;
       lastParsedInput: unknown;
-      emittedToolCall: boolean;
     }
   >;
   /** Tool-use ids already emitted in this turn — used to dedupe in the assistant-message fallback path. */
   emittedToolUseIds: Set<string>;
+  /** Opaque owner of Claude launch/push/pull correlation for this query. */
+  backgroundTasks: ClaudeBackgroundTaskStateMachine;
   /** Session-lived todo/Task accumulator (see claudeTodoPlan.ts). */
   claudeTasks: ClaudeTaskPlanState;
   /**
@@ -66,10 +70,15 @@ interface AssistantUsageSample {
   model: string;
 }
 
+/**
+ * Creates isolated correlation state so SDK messages can be translated without leaking task or tool identity across sessions.
+ * @param claudeTasks - The task-plan state to preserve when translator generations share one conversation.
+ */
 export function createTranslatorState(claudeTasks?: ClaudeTaskPlanState): TranslatorState {
   return {
     toolUseBlocks: new Map(),
     emittedToolUseIds: new Set(),
+    backgroundTasks: new ClaudeBackgroundTaskStateMachine(),
     claudeTasks: claudeTasks ?? createClaudeTaskPlanState(),
   };
 }
@@ -79,10 +88,10 @@ function event(sessionId: SessionId, update: SessionUpdate): SessionEvent {
 }
 
 /**
- * Translate one SDK message to zero or more session-domain events. Returning
- * an array (rather than firing a callback) keeps the function pure and
- * trivially testable; the caller decides what to do with the events and when
- * to terminate the prompt promise.
+ * Preserves the SDK boundary by turning vendor messages into session-domain events for backend-independent consumers.
+ * @param msg - The vendor message to translate.
+ * @param sessionId - The session that should receive the translated events.
+ * @param state - The cross-message correlation state for the active translation stream.
  */
 export function translateSdkMessage(
   msg: SDKMessage,
@@ -96,6 +105,8 @@ export function translateSdkMessage(
       return translateAssistantMessage(msg, sessionId, state);
     case "user":
       return translateUserMessage(msg, sessionId, state);
+    case "system":
+      return translateSystemMessage(msg, sessionId, state);
     case "result":
       return translateResultMessage(msg, sessionId, state);
     default:
@@ -117,6 +128,7 @@ function translateResultMessage(
   sessionId: SessionId,
   state: TranslatorState
 ): SessionEvent[] {
+  state.backgroundTasks.accept({ kind: "query_finished" });
   const sample = state.lastAssistantUsage;
   // No main-model turn to measure (e.g. an errored/empty result): leave the
   // meter on its prior occupancy rather than invent a cumulative number.
@@ -164,6 +176,19 @@ function modelTokens(m: SDKResultMessage["modelUsage"][string]): number {
   return m.inputTokens + m.outputTokens + m.cacheReadInputTokens + m.cacheCreationInputTokens;
 }
 
+/**
+ * Delegates Claude's out-of-order task protocol to the background-task state machine and
+ * converts its normalized decision into the session event vocabulary.
+ */
+function translateSystemMessage(
+  msg: SDKSystemLike,
+  sessionId: SessionId,
+  state: TranslatorState
+): SessionEvent[] {
+  const decision = state.backgroundTasks.accept({ kind: "sdk_message", message: msg });
+  return taskUpdateEvents(sessionId, decision.updates);
+}
+
 export function mapStopReason(msg: SDKResultMessage): "end_turn" | "cancelled" | "refusal" {
   if (msg.subtype === "success") return "end_turn";
   return "cancelled";
@@ -208,13 +233,13 @@ function translateStreamEvent(
       const block = sdkEvent.content_block;
       if (block.type === "tool_use") {
         const { tool: name, mcpServer } = resolveToolName(block.name);
+        acceptBackgroundTaskToolSnapshot(state, block.id, name, mcpServer, block.input);
         state.toolUseBlocks.set(sdkEvent.index, {
           id: block.id,
           name,
           mcpServer,
           inputJsonAcc: "",
           lastParsedInput: block.input ?? {},
-          emittedToolCall: true,
         });
         state.emittedToolUseIds.add(block.id);
         const out: SessionEvent[] = [
@@ -305,6 +330,7 @@ function translateStreamEvent(
       const parsed = tryParseJson(block.inputJsonAcc);
       const finalInput = parsed.ok ? parsed.value : block.lastParsedInput;
       block.lastParsedInput = finalInput;
+      acceptBackgroundTaskToolSnapshot(state, block.id, block.name, block.mcpServer, finalInput);
       return [
         event(sessionId, {
           sessionUpdate: "tool_call_update",
@@ -358,10 +384,11 @@ function translateAssistantMessage(
   for (const block of content) {
     const b = block as { type?: string; id?: string; name?: string; input?: unknown };
     if (b.type !== "tool_use" || !b.id || !b.name) continue;
+    const { tool: name, mcpServer } = resolveToolName(b.name);
+    acceptBackgroundTaskToolSnapshot(state, b.id, name, mcpServer, b.input);
     if (state.emittedToolUseIds.has(b.id)) continue;
     state.emittedToolUseIds.add(b.id);
     out.push(event(sessionId, makeToolCallUpdate(b.id, b.name, b.input ?? {}, parentToolUseId)));
-    const { tool: name, mcpServer } = resolveToolName(b.name);
     out.push(
       ...todoPlanEvents(sessionId, state, b.id, name, mcpServer, parentToolUseId, b.input ?? {})
     );
@@ -427,6 +454,8 @@ function translateUserMessage(
 ): SessionEvent[] {
   const content = (msg.message as { content?: unknown }).content;
   if (!Array.isArray(content)) return [];
+  const decision = state.backgroundTasks.accept({ kind: "sdk_message", message: msg });
+
   const out: SessionEvent[] = [];
   for (const block of content) {
     const b = block as {
@@ -436,6 +465,10 @@ function translateUserMessage(
       is_error?: boolean;
     };
     if (b.type !== "tool_result" || !b.tool_use_id) continue;
+
+    const resultAction = decision.resultActions.get(b.tool_use_id);
+    if (resultAction?.kind === "omit") continue;
+
     const status: AgentToolStatus = b.is_error ? "failed" : "completed";
     const outputs = toolResultContent(b.content);
     out.push(
@@ -457,6 +490,7 @@ function translateUserMessage(
     );
     if (!b.is_error && planUpdate) out.push(event(sessionId, planUpdate));
   }
+  out.push(...taskUpdateEvents(sessionId, decision.updates));
   return out;
 }
 
@@ -477,6 +511,30 @@ function makeToolCallUpdate(
     mcpServer,
     ...vendorMetaFields(name, parentToolUseId, mcpServer),
   };
+}
+
+function acceptBackgroundTaskToolSnapshot(
+  state: TranslatorState,
+  toolUseId: string,
+  name: string,
+  mcpServer: string | undefined,
+  rawInput: unknown
+): void {
+  state.backgroundTasks.accept({
+    kind: "tool_snapshot",
+    toolCallId: toolUseId,
+    nativeToolName: mcpServer ? undefined : name,
+    input: rawInput,
+  });
+}
+
+function taskUpdateEvents(
+  sessionId: SessionId,
+  updates: readonly ClaudeTaskToolUpdate[]
+): SessionEvent[] {
+  return updates.map((update) =>
+    event(sessionId, { sessionUpdate: "tool_call_update", ...update })
+  );
 }
 
 function toolResultContent(content: unknown): ToolCallContent[] | undefined {

--- a/src/agentMode/sdk/sdkMessageTranslator.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.ts
@@ -28,9 +28,9 @@ import { ClaudeBackgroundTaskStateMachine, type ClaudeTaskToolUpdate } from "./c
 type SDKSystemLike = Extract<SDKMessage, { type: "system" }>;
 
 /**
- * Mutable per-query translator state. One instance lives for the duration of
- * a single `query()` call; reset whenever a new turn starts. Only
- * `claudeTasks` is deliberately shared across queries.
+ * Mutable translator state. One instance lives for a single `query()` call;
+ * stream parsing fields reset with each turn, while the Claude task owners are
+ * deliberately shared across queries in the same session.
  */
 export interface TranslatorState {
   toolUseBlocks: Map<
@@ -45,7 +45,7 @@ export interface TranslatorState {
   >;
   /** Tool-use ids already emitted in this turn — used to dedupe in the assistant-message fallback path. */
   emittedToolUseIds: Set<string>;
-  /** Opaque owner of Claude launch/push/pull correlation for this query. */
+  /** Session-lived owner of Claude background-task identity and lifecycle. */
   backgroundTasks: ClaudeBackgroundTaskStateMachine;
   /** Session-lived todo/Task accumulator (see claudeTodoPlan.ts). */
   claudeTasks: ClaudeTaskPlanState;
@@ -71,14 +71,18 @@ interface AssistantUsageSample {
 }
 
 /**
- * Creates isolated correlation state so SDK messages can be translated without leaking task or tool identity across sessions.
+ * Creates query-local parsing state backed by the owning session's Claude task state.
  * @param claudeTasks - The task-plan state to preserve when translator generations share one conversation.
+ * @param backgroundTasks - The background-task state to preserve across queries in one session.
  */
-export function createTranslatorState(claudeTasks?: ClaudeTaskPlanState): TranslatorState {
+export function createTranslatorState(
+  claudeTasks?: ClaudeTaskPlanState,
+  backgroundTasks?: ClaudeBackgroundTaskStateMachine
+): TranslatorState {
   return {
     toolUseBlocks: new Map(),
     emittedToolUseIds: new Set(),
-    backgroundTasks: new ClaudeBackgroundTaskStateMachine(),
+    backgroundTasks: backgroundTasks ?? new ClaudeBackgroundTaskStateMachine(),
     claudeTasks: claudeTasks ?? createClaudeTaskPlanState(),
   };
 }
@@ -128,7 +132,6 @@ function translateResultMessage(
   sessionId: SessionId,
   state: TranslatorState
 ): SessionEvent[] {
-  state.backgroundTasks.accept({ kind: "query_finished" });
   const sample = state.lastAssistantUsage;
   // No main-model turn to measure (e.g. an errored/empty result): leave the
   // meter on its prior occupancy rather than invent a cumulative number.

--- a/src/agentMode/sdk/sdkMessageTranslator.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.ts
@@ -472,7 +472,12 @@ function translateUserMessage(
     const resultAction = decision.resultActions.get(b.tool_use_id);
     if (resultAction?.kind === "omit") continue;
 
-    const status: AgentToolStatus = b.is_error ? "failed" : "completed";
+    let status: AgentToolStatus;
+    if (resultAction?.kind === "preserve_status") {
+      status = resultAction.status;
+    } else {
+      status = b.is_error ? "failed" : "completed";
+    }
     const outputs = toolResultContent(b.content);
     out.push(
       event(sessionId, {

--- a/src/agentMode/sdk/sdkMessageTranslator.ts
+++ b/src/agentMode/sdk/sdkMessageTranslator.ts
@@ -236,7 +236,7 @@ function translateStreamEvent(
       const block = sdkEvent.content_block;
       if (block.type === "tool_use") {
         const { tool: name, mcpServer } = resolveToolName(block.name);
-        acceptBackgroundTaskToolSnapshot(state, block.id, name, mcpServer, block.input);
+        observeBackgroundTaskLaunch(state, block.id, name, mcpServer);
         state.toolUseBlocks.set(sdkEvent.index, {
           id: block.id,
           name,
@@ -333,7 +333,6 @@ function translateStreamEvent(
       const parsed = tryParseJson(block.inputJsonAcc);
       const finalInput = parsed.ok ? parsed.value : block.lastParsedInput;
       block.lastParsedInput = finalInput;
-      acceptBackgroundTaskToolSnapshot(state, block.id, block.name, block.mcpServer, finalInput);
       return [
         event(sessionId, {
           sessionUpdate: "tool_call_update",
@@ -388,7 +387,7 @@ function translateAssistantMessage(
     const b = block as { type?: string; id?: string; name?: string; input?: unknown };
     if (b.type !== "tool_use" || !b.id || !b.name) continue;
     const { tool: name, mcpServer } = resolveToolName(b.name);
-    acceptBackgroundTaskToolSnapshot(state, b.id, name, mcpServer, b.input);
+    observeBackgroundTaskLaunch(state, b.id, name, mcpServer);
     if (state.emittedToolUseIds.has(b.id)) continue;
     state.emittedToolUseIds.add(b.id);
     out.push(event(sessionId, makeToolCallUpdate(b.id, b.name, b.input ?? {}, parentToolUseId)));
@@ -521,18 +520,16 @@ function makeToolCallUpdate(
   };
 }
 
-function acceptBackgroundTaskToolSnapshot(
+function observeBackgroundTaskLaunch(
   state: TranslatorState,
   toolUseId: string,
   name: string,
-  mcpServer: string | undefined,
-  rawInput: unknown
+  mcpServer: string | undefined
 ): void {
   state.backgroundTasks.accept({
     kind: "tool_snapshot",
     toolCallId: toolUseId,
     nativeToolName: mcpServer ? undefined : name,
-    input: rawInput,
   });
 }
 

--- a/src/agentMode/session/AgentMessageStore.test.ts
+++ b/src/agentMode/session/AgentMessageStore.test.ts
@@ -209,6 +209,28 @@ describe("AgentMessageStore", () => {
     expect(msg?.parts).toHaveLength(1);
   });
 
+  it("findMessageIdWithToolCall returns the message owning a tool call, or undefined", () => {
+    const store = new AgentMessageStore();
+    const first = store.addMessage(placeholder());
+    const second = store.addMessage(placeholder());
+    store.upsertAgentPart(first, {
+      kind: "tool_call",
+      id: "tc-old",
+      title: "Agent",
+      status: "in_progress",
+    });
+    store.upsertAgentPart(second, {
+      kind: "tool_call",
+      id: "tc-new",
+      title: "Read README",
+      status: "completed",
+    });
+
+    expect(store.findMessageIdWithToolCall("tc-old")).toBe(first);
+    expect(store.findMessageIdWithToolCall("tc-new")).toBe(second);
+    expect(store.findMessageIdWithToolCall("tc-missing")).toBeUndefined();
+  });
+
   it("markMessageError flags the message and appends formatted error text", () => {
     const store = new AgentMessageStore();
     const id = store.addMessage({

--- a/src/agentMode/session/AgentMessageStore.test.ts
+++ b/src/agentMode/session/AgentMessageStore.test.ts
@@ -130,6 +130,27 @@ describe("AgentMessageStore", () => {
     expect(store.upsertAgentPart(id, { ...part })).toBe(false);
   });
 
+  it("notifies for progress changes but skips identical progress", () => {
+    const store = new AgentMessageStore();
+    const id = store.addMessage(placeholder());
+    const part: AgentMessagePart = {
+      kind: "tool_call",
+      id: "tc1",
+      title: "Agent",
+      status: "in_progress",
+      progress: { description: "Inspect vault", toolUses: 1, durationMs: 1000 },
+    };
+
+    expect(store.upsertAgentPart(id, part)).toBe(true);
+    expect(store.upsertAgentPart(id, { ...part, progress: { ...part.progress } })).toBe(false);
+    expect(
+      store.upsertAgentPart(id, {
+        ...part,
+        progress: { ...part.progress, toolUses: 2 },
+      })
+    ).toBe(true);
+  });
+
   it("upsertAgentPart compares large repeated tool outputs without duplicating", () => {
     const store = new AgentMessageStore();
     const id = store.addMessage(placeholder());

--- a/src/agentMode/session/AgentMessageStore.ts
+++ b/src/agentMode/session/AgentMessageStore.ts
@@ -364,6 +364,20 @@ export class AgentMessageStore {
   }
 
   /**
+   * Locate the message that already renders a tool call, searching newest
+   * first. Lets a late update for a long-running tool (e.g. a background
+   * subagent settling during a later turn) land on its original card instead
+   * of the current placeholder. Returns undefined when no message has it.
+   */
+  findMessageIdWithToolCall(toolCallId: string): string | undefined {
+    for (let i = this.messages.length - 1; i >= 0; i--) {
+      const msg = this.messages[i];
+      if (msg.parts?.some((p) => p.kind === "tool_call" && p.id === toolCallId)) return msg.id;
+    }
+    return undefined;
+  }
+
+  /**
    * Mark a message as an error and append the error text to its display body.
    * Used when a turn rejects mid-stream so the partial placeholder gets a
    * visible error instead of looking like a normal truncated reply.

--- a/src/agentMode/session/AgentMessageStore.ts
+++ b/src/agentMode/session/AgentMessageStore.ts
@@ -86,11 +86,28 @@ function partsEqual(a: AgentMessagePart, b: AgentMessagePart): boolean {
         a.status === b.status &&
         a.vendorToolName === b.vendorToolName &&
         a.parentToolCallId === b.parentToolCallId &&
+        toolProgressEqual(a.progress, b.progress) &&
         boundedValueEqual(a.input, b.input) &&
         locationsEqual(a.locations, b.locations) &&
         toolOutputsEqual(a.output, b.output)
       );
   }
+}
+
+/** Compare normalized progress without serializing the surrounding tool input/output. */
+function toolProgressEqual(
+  a: Extract<AgentMessagePart, { kind: "tool_call" }>["progress"],
+  b: Extract<AgentMessagePart, { kind: "tool_call" }>["progress"]
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return a === b;
+  return (
+    a.description === b.description &&
+    a.toolName === b.toolName &&
+    a.toolUses === b.toolUses &&
+    a.durationMs === b.durationMs &&
+    a.totalTokens === b.totalTokens
+  );
 }
 
 /**

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -967,6 +967,58 @@ describe("AgentSession.sendPrompt", () => {
     await turn;
   });
 
+  it("routes a tool_call_update for a prior turn's tool call to its original message", async () => {
+    const mock = makeMockBackend();
+    let resolvePrompt: ((v: { stopReason: "end_turn" }) => void) | null = null;
+    mock.prompt.mockImplementation(
+      () => new Promise((resolve) => (resolvePrompt = resolve as typeof resolvePrompt))
+    );
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "claude-code",
+    });
+
+    const first = session.sendPrompt("launch a background agent");
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-agent",
+        title: "Agent",
+        status: "in_progress",
+      },
+    });
+    resolvePrompt!({ stopReason: "end_turn" });
+    await first.turn;
+
+    const second = session.sendPrompt("meanwhile");
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc-agent",
+        status: "completed",
+        content: [{ type: "content", content: { type: "text", text: "agent report" } }],
+      },
+    });
+
+    const ai = session.store.getDisplayMessages().filter((m) => m.sender === AI_SENDER);
+    // The first turn's launch card settles in place…
+    expect(ai[0]?.parts?.[0]).toMatchObject({
+      kind: "tool_call",
+      id: "tc-agent",
+      status: "completed",
+      output: [{ type: "text", text: "agent report" }],
+    });
+    // …and no duplicate card appears on the new turn's placeholder.
+    expect(ai[1]?.parts ?? []).toHaveLength(0);
+
+    resolvePrompt!({ stopReason: "end_turn" });
+    await second.turn;
+  });
+
   it("merges partial tool progress", async () => {
     const mock = makeMockBackend();
     let resolvePrompt: ((v: { stopReason: "end_turn" }) => void) | null = null;

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -1023,6 +1023,90 @@ describe("AgentSession.sendPrompt", () => {
     expect(laterTurn?.isErrorMessage).not.toBe(true);
   });
 
+  it("routes a prior turn's tool update after the current turn is cancelled", async () => {
+    jest.useFakeTimers();
+    try {
+      const mock = makeMockBackend();
+      const resolvePrompts: Array<(value: { stopReason: "end_turn" | "cancelled" }) => void> = [];
+      mock.prompt.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolvePrompts.push(resolve);
+          })
+      );
+      const session = new AgentSession({
+        backend: mock.asBackend,
+        backendSessionId: "acp-1",
+        internalId: "internal-1",
+        backendId: "claude-code",
+      });
+
+      const first = session.sendPrompt("launch a background agent");
+      mock.emit({
+        sessionId: "acp-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-agent",
+          title: "Agent",
+          status: "in_progress",
+        },
+      });
+      resolvePrompts[0]({ stopReason: "end_turn" });
+      await first.turn;
+
+      const second = session.sendPrompt("do something else");
+      mock.emit({
+        sessionId: "acp-1",
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "tc-cancelled",
+          title: "Current turn tool",
+          status: "in_progress",
+        },
+      });
+      await session.cancel();
+      await expect(second.turn).resolves.toBe("cancelled");
+
+      mock.emit({
+        sessionId: "acp-1",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tc-agent",
+          status: "completed",
+          content: [{ type: "content", content: { type: "text", text: "agent report" } }],
+        },
+      });
+      mock.emit({
+        sessionId: "acp-1",
+        update: {
+          sessionUpdate: "tool_call_update",
+          toolCallId: "tc-cancelled",
+          status: "completed",
+        },
+      });
+
+      const ai = session.store
+        .getDisplayMessages()
+        .filter((message) => message.sender === AI_SENDER);
+      expect(ai[0]?.parts?.[0]).toMatchObject({
+        kind: "tool_call",
+        id: "tc-agent",
+        status: "completed",
+        output: [{ type: "text", text: "agent report" }],
+      });
+      expect(ai[1]?.parts?.[0]).toMatchObject({
+        kind: "tool_call",
+        id: "tc-cancelled",
+        status: "in_progress",
+      });
+
+      resolvePrompts[1]({ stopReason: "cancelled" });
+      await jest.advanceTimersByTimeAsync(500);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it("merges partial tool progress", async () => {
     const mock = makeMockBackend();
     let resolvePrompt: ((v: { stopReason: "end_turn" }) => void) | null = null;

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -1017,6 +1017,10 @@ describe("AgentSession.sendPrompt", () => {
 
     resolvePrompt!({ stopReason: "end_turn" });
     await second.turn;
+
+    const laterTurn = session.store.getDisplayMessages().filter((m) => m.sender === AI_SENDER)[1];
+    expect(laterTurn).toMatchObject({ message: "", turnStopReason: "end_turn" });
+    expect(laterTurn?.isErrorMessage).not.toBe(true);
   });
 
   it("merges partial tool progress", async () => {

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -967,6 +967,50 @@ describe("AgentSession.sendPrompt", () => {
     await turn;
   });
 
+  it("merges partial tool progress", async () => {
+    const mock = makeMockBackend();
+    let resolvePrompt: ((v: { stopReason: "end_turn" }) => void) | null = null;
+    mock.prompt.mockImplementation(
+      () => new Promise((resolve) => (resolvePrompt = resolve as typeof resolvePrompt))
+    );
+    const session = new AgentSession({
+      backend: mock.asBackend,
+      backendSessionId: "acp-1",
+      internalId: "internal-1",
+      backendId: "claude-code",
+    });
+    const { turn } = session.sendPrompt("hi");
+
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId: "tc1",
+        title: "Agent",
+        status: "in_progress",
+        progress: { description: "Inspect vault", toolUses: 1 },
+      },
+    });
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "tool_call_update",
+        toolCallId: "tc1",
+        progress: { toolUses: 3, durationMs: 9851 },
+      },
+    });
+
+    const part = session.store.getDisplayMessages().find((message) => message.sender === AI_SENDER)
+      ?.parts?.[0];
+    expect(part).toMatchObject({
+      kind: "tool_call",
+      progress: { description: "Inspect vault", toolUses: 3, durationMs: 9851 },
+    });
+
+    resolvePrompt!({ stopReason: "end_turn" });
+    await turn;
+  });
+
   // Emit one completed tool call with `text` output and return the stored output.
   const storedToolOutput = async (text: string): Promise<AgentToolCallOutput | undefined> => {
     const mock = makeMockBackend();

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1781,7 +1781,12 @@ export class AgentSession {
         return;
       }
       case "tool_call_update": {
-        const existing = this.findToolCallPart(placeholderId, update.toolCallId);
+        // A background launch can settle during a later prompt; route the
+        // update to the message that owns the tool call so the original card
+        // settles instead of a duplicate appearing on the current turn.
+        const owningMessageId =
+          this.store.findMessageIdWithToolCall(update.toolCallId) ?? placeholderId;
+        const existing = this.findToolCallPart(owningMessageId, update.toolCallId);
         const merged = mergeToolCallUpdate(existing, update);
         if (merged.kind === "tool_call") {
           const exitPlan = tryReadExitPlanModeCall({
@@ -1793,7 +1798,7 @@ export class AgentSession {
             this.publishGatedPlan(merged.id, exitPlan);
           }
         }
-        if (this.store.upsertAgentPart(placeholderId, merged)) {
+        if (this.store.upsertAgentPart(owningMessageId, merged)) {
           this.scheduleNotifyMessages();
         }
         return;

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -371,6 +371,10 @@ export class AgentSession {
   // keep the QA context. LIVE-ONLY — never persisted.
   private pendingFanoutContext: PendingFanoutContext[] = [];
   private placeholderId: string | null = null;
+  // A task update routed to an earlier turn still counts as activity consumed
+  // by the current backend prompt, even though it adds nothing to this turn's
+  // placeholder.
+  private currentTurnHadRoutedToolActivity = false;
   // ACP `messageId`s seen on this turn's content chunks. Used to re-route
   // trailing chunks that a backend flushes *after* the `session/prompt` result
   // (observed with opencode + fast DeepSeek models) to the right message.
@@ -976,6 +980,7 @@ export class AgentSession {
     };
     this.placeholderId = this.store.addMessage(placeholder);
     this.currentMessageIds = new Set();
+    this.currentTurnHadRoutedToolActivity = false;
     this.notifyMessages();
 
     // Backends without a title summarizer (codex, Claude Code) have no usable
@@ -1161,6 +1166,7 @@ export class AgentSession {
       if (
         placeholderId &&
         resp.stopReason !== "cancelled" &&
+        !this.currentTurnHadRoutedToolActivity &&
         !this.store.hasAssistantActivity(placeholderId)
       ) {
         const message = buildEmptyTurnMessage(this.backendId, resp.stopReason);
@@ -1786,6 +1792,7 @@ export class AgentSession {
         // settles instead of a duplicate appearing on the current turn.
         const owningMessageId =
           this.store.findMessageIdWithToolCall(update.toolCallId) ?? placeholderId;
+        if (owningMessageId !== placeholderId) this.currentTurnHadRoutedToolActivity = true;
         const existing = this.findToolCallPart(owningMessageId, update.toolCallId);
         const merged = mergeToolCallUpdate(existing, update);
         if (merged.kind === "tool_call") {

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1682,6 +1682,21 @@ export class AgentSession {
 
   private handleSessionEvent(event: SessionEvent): void {
     const update = event.update;
+    const toolOwnerMessageId =
+      update.sessionUpdate === "tool_call_update"
+        ? this.store.findMessageIdWithToolCall(update.toolCallId)
+        : undefined;
+    const toolOwnerStopReason = toolOwnerMessageId
+      ? this.store.getMessage(toolOwnerMessageId)?.turnStopReason
+      : undefined;
+    // A completed non-cancelled message belongs to an earlier turn. Its
+    // background task may settle while a later prompt is being cancelled, so
+    // preserve that update while continuing to suppress the cancelled turn's
+    // own tool activity.
+    const isPriorToolUpdate =
+      toolOwnerMessageId !== undefined &&
+      toolOwnerStopReason !== undefined &&
+      toolOwnerStopReason !== "cancelled";
 
     if (this.cancelledPromptDrain || this.abortController?.signal.aborted) {
       switch (update.sessionUpdate) {
@@ -1694,8 +1709,14 @@ export class AgentSession {
           );
           return;
         case "tool_call":
-        case "tool_call_update":
         case "plan":
+          this.cancelledTurnActivity += 1;
+          logWarn(
+            `[AgentMode] dropping ${update.sessionUpdate} from cancelled turn ${this.internalId}`
+          );
+          return;
+        case "tool_call_update":
+          if (isPriorToolUpdate) break;
           this.cancelledTurnActivity += 1;
           logWarn(
             `[AgentMode] dropping ${update.sessionUpdate} from cancelled turn ${this.internalId}`
@@ -1762,7 +1783,8 @@ export class AgentSession {
     }
 
     const placeholderId = this.placeholderId;
-    if (!placeholderId) {
+    const targetMessageId = isPriorToolUpdate ? toolOwnerMessageId : placeholderId;
+    if (!targetMessageId) {
       logWarn(`[AgentMode] dropping session/update — no placeholder for ${this.internalId}`);
       return;
     }
@@ -1776,12 +1798,12 @@ export class AgentSession {
         });
         if (exitPlan) {
           this.publishGatedPlan(update.toolCallId, exitPlan);
-          if (this.store.upsertAgentPart(placeholderId, toolCallToPart(update))) {
+          if (this.store.upsertAgentPart(targetMessageId, toolCallToPart(update))) {
             this.scheduleNotifyMessages();
           }
           return;
         }
-        if (this.store.upsertAgentPart(placeholderId, toolCallToPart(update))) {
+        if (this.store.upsertAgentPart(targetMessageId, toolCallToPart(update))) {
           this.scheduleNotifyMessages();
         }
         return;
@@ -1790,10 +1812,8 @@ export class AgentSession {
         // A background launch can settle during a later prompt; route the
         // update to the message that owns the tool call so the original card
         // settles instead of a duplicate appearing on the current turn.
-        const owningMessageId =
-          this.store.findMessageIdWithToolCall(update.toolCallId) ?? placeholderId;
-        if (owningMessageId !== placeholderId) this.currentTurnHadRoutedToolActivity = true;
-        const existing = this.findToolCallPart(owningMessageId, update.toolCallId);
+        if (targetMessageId !== placeholderId) this.currentTurnHadRoutedToolActivity = true;
+        const existing = this.findToolCallPart(targetMessageId, update.toolCallId);
         const merged = mergeToolCallUpdate(existing, update);
         if (merged.kind === "tool_call") {
           const exitPlan = tryReadExitPlanModeCall({
@@ -1805,13 +1825,13 @@ export class AgentSession {
             this.publishGatedPlan(merged.id, exitPlan);
           }
         }
-        if (this.store.upsertAgentPart(owningMessageId, merged)) {
+        if (this.store.upsertAgentPart(targetMessageId, merged)) {
           this.scheduleNotifyMessages();
         }
         return;
       }
       case "plan": {
-        if (this.store.upsertAgentPart(placeholderId, planToPart(update))) {
+        if (this.store.upsertAgentPart(targetMessageId, planToPart(update))) {
           this.scheduleNotifyMessages();
         }
         return;

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -2261,6 +2261,7 @@ function toolCallToPart(
     vendorToolName: call.vendorToolName,
     mcpServer: call.mcpServer,
     parentToolCallId: call.parentToolCallId,
+    progress: call.progress,
   };
 }
 
@@ -2322,6 +2323,7 @@ function mergeToolCallUpdate(
     vendorToolName: upd.vendorToolName ?? base.vendorToolName,
     mcpServer: upd.mcpServer ?? base.mcpServer,
     parentToolCallId: upd.parentToolCallId ?? base.parentToolCallId,
+    progress: upd.progress === undefined ? base.progress : { ...base.progress, ...upd.progress },
   };
 }
 

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -424,6 +424,15 @@ export interface AgentTodoListEntry {
   status: AgentPlanEntry["status"];
 }
 
+/** Backend-neutral progress reported by a long-running tool call. */
+export interface AgentToolProgress {
+  description?: string;
+  toolName?: string;
+  toolUses?: number;
+  durationMs?: number;
+  totalTokens?: number;
+}
+
 /**
  * Initial / updated state for an in-flight tool call. Mirrors ACP `ToolCall`
  * (initial form) — emitted by backends in the `tool_call` `SessionUpdate`.
@@ -446,6 +455,8 @@ export interface ToolCallSnapshot {
   mcpServer?: string;
   /** Parent tool-call id, for nested tools (e.g. Claude's Task subagents). */
   parentToolCallId?: string;
+  /** Latest backend-neutral progress for a long-running tool call. */
+  progress?: AgentToolProgress;
   /** True iff this tool call is the agent's plan-finalization signal. */
   isPlanProposal?: boolean;
 }
@@ -465,6 +476,7 @@ export interface ToolCallDelta {
   /** MCP server name; see `ToolCallSnapshot.mcpServer`. */
   mcpServer?: string;
   parentToolCallId?: string;
+  progress?: AgentToolProgress;
   isPlanProposal?: boolean;
 }
 
@@ -877,6 +889,8 @@ export type AgentMessagePart =
        * top-level.
        */
       parentToolCallId?: string;
+      /** Latest normalized progress for this tool call. */
+      progress?: AgentToolProgress;
     }
   | {
       kind: "thought";

--- a/src/agentMode/ui/AgentTrailView.test.tsx
+++ b/src/agentMode/ui/AgentTrailView.test.tsx
@@ -131,4 +131,28 @@ describe("AgentTrail inline trail (no collapse)", () => {
     // The research tool card renders inline (not folded behind a toggle).
     expect(screen.getByText("Search vault")).toBeTruthy();
   });
+
+  it("shows progress on a childless background subagent card", () => {
+    renderTrail({
+      parts: [
+        {
+          kind: "tool_call",
+          id: "launch",
+          title: "Agent",
+          vendorToolName: "Agent",
+          status: "in_progress",
+          input: { subagent_type: "Explore", description: "Analyze notes" },
+          progress: {
+            description: "Count markdown files",
+            toolUses: 3,
+            durationMs: 9851,
+          },
+        },
+      ],
+      isStreaming: true,
+      turnStopReason: undefined,
+    });
+
+    expect(screen.getByText("Running Count markdown files · 3 tools · 9s")).toBeTruthy();
+  });
 });

--- a/src/agentMode/ui/AgentTrailView.test.tsx
+++ b/src/agentMode/ui/AgentTrailView.test.tsx
@@ -143,7 +143,7 @@ describe("AgentTrail inline trail (no collapse)", () => {
           status: "in_progress",
           input: { subagent_type: "Explore", description: "Analyze notes" },
           progress: {
-            description: "Count markdown files",
+            description: "Running Count markdown files",
             toolUses: 3,
             durationMs: 9851,
           },

--- a/src/agentMode/ui/SubAgentCard.tsx
+++ b/src/agentMode/ui/SubAgentCard.tsx
@@ -20,6 +20,14 @@ interface SubAgentCardProps {
   renderNode: (node: RenderNode, key: string | number) => React.ReactNode;
 }
 
+/**
+ * Keeps delegated work attached to its launch so the prompt, progress, and report remain one traceable unit.
+ * @param parent - The tool call that launched the delegated work.
+ * @param childNodes - The nested activity produced by the delegated work.
+ * @param truncated - Whether omitted activity should be disclosed to the user.
+ * @param app - The Obsidian application used to render note-aware content.
+ * @param renderNode - The renderer for nested agent-trail nodes.
+ */
 export const SubAgentCard: React.FC<SubAgentCardProps> = ({
   parent,
   childNodes,
@@ -32,6 +40,7 @@ export const SubAgentCard: React.FC<SubAgentCardProps> = ({
   const summary = lookupToolSummary(parent);
   const Icon = summary.icon;
   const line = summary.collapsedLine(parent);
+  const outcome = summary.outcome(parent);
   const childCounts = countChildren(childNodes);
   const inputPrompt = extractSubAgentInputPrompt(parent);
   const returnText = extractSubAgentReturnText(parent);
@@ -52,9 +61,12 @@ export const SubAgentCard: React.FC<SubAgentCardProps> = ({
           <ChevronRight className="tw-size-3 tw-text-muted" />
         )}
       </div>
+      {outcome ? <div className="tw-pl-5 tw-text-xs tw-text-muted">{outcome}</div> : null}
       {open ? (
         <div className="tw-mt-2 tw-flex tw-flex-col tw-gap-1 tw-border-l tw-border-border tw-pl-3">
-          <div className="tw-text-xs tw-text-muted">{describeCounts(childCounts, truncated)}</div>
+          {childCounts.tools > 0 || childCounts.reasoning > 0 || truncated ? (
+            <div className="tw-text-xs tw-text-muted">{describeCounts(childCounts, truncated)}</div>
+          ) : null}
           {inputPrompt ? (
             <div className="tw-my-1">
               <div

--- a/src/agentMode/ui/agentTrail.test.ts
+++ b/src/agentMode/ui/agentTrail.test.ts
@@ -183,6 +183,20 @@ describe("buildAgentTrail", () => {
     expect(tree[0].type).toBe("subagent");
   });
 
+  it.each([
+    ["a named vendor tool", { vendorToolName: "RunAnalysis" }],
+    ["an anonymous MCP tool", { mcpServer: "analysis-server", toolKind: "other" }],
+    ["a typed native tool", { toolKind: "execute" }],
+  ] as const)(
+    "does not classify %s with a subagent_type parameter as a subagent",
+    (_label, identity) => {
+      const tree = buildAgentTrail([
+        tool("ordinary", { ...identity, input: { subagent_type: "worker" } }),
+      ]);
+      expect(tree[0].type).toBe("action");
+    }
+  );
+
   it("a sub-agent breaks the run; same-tool peers around it compact independently", () => {
     const parts = [
       tool("e1", { vendorToolName: "Edit" }),

--- a/src/agentMode/ui/agentTrail.test.ts
+++ b/src/agentMode/ui/agentTrail.test.ts
@@ -177,6 +177,16 @@ describe("buildAgentTrail", () => {
     }
   });
 
+  it.each(["Agent", "Task"])(
+    "renders an MCP tool named %s as an action rather than a subagent",
+    (vendorToolName) => {
+      const tree = buildAgentTrail([
+        tool("mcp-tool", { vendorToolName, mcpServer: "srv", toolKind: "think" }),
+      ]);
+      expect(tree[0].type).toBe("action");
+    }
+  );
+
   it("recognizes an opencode task tool (subagent_type input) as a subagent group", () => {
     const parts = [tool("t", { input: { subagent_type: "general" } })];
     const tree = buildAgentTrail(parts);

--- a/src/agentMode/ui/agentTrail.test.ts
+++ b/src/agentMode/ui/agentTrail.test.ts
@@ -158,6 +158,31 @@ describe("buildAgentTrail", () => {
     }
   });
 
+  it("groups a background (childless) sub-agent launch as a subagent node", () => {
+    // A launch can still be childless when no complete nested frame arrived;
+    // the card remains a group so the final report has a home.
+    const parts = [
+      tool("launch", {
+        vendorToolName: "Agent",
+        input: { subagent_type: "Explore", description: "Analyze notes" },
+        output: [{ type: "text", text: "Most prominent: AI/agents (16)." }],
+      }),
+    ];
+    const tree = buildAgentTrail(parts);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].type).toBe("subagent");
+    if (tree[0].type === "subagent") {
+      expect(tree[0].parent.id).toBe("launch");
+      expect(tree[0].children).toHaveLength(0);
+    }
+  });
+
+  it("recognizes an opencode task tool (subagent_type input) as a subagent group", () => {
+    const parts = [tool("t", { input: { subagent_type: "general" } })];
+    const tree = buildAgentTrail(parts);
+    expect(tree[0].type).toBe("subagent");
+  });
+
   it("a sub-agent breaks the run; same-tool peers around it compact independently", () => {
     const parts = [
       tool("e1", { vendorToolName: "Edit" }),

--- a/src/agentMode/ui/agentTrail.ts
+++ b/src/agentMode/ui/agentTrail.ts
@@ -61,13 +61,22 @@ export function toolKeyFor(part: ToolCallPart): string {
   return part.mcpServer ? `mcp:${part.mcpServer}:${base}` : base;
 }
 
-/**
- * `ToolSearch` is Claude Code's deferred-tool schema loader — invoked
- * before every `ExitPlanMode` to fetch its schema. Hiding it removes
- * meaningless "tool calls" cards at the end of plan mode.
- */
+/** Claude Code's deferred-tool schema loader has no standalone user meaning. */
 function isHiddenTool(part: AgentMessagePart): boolean {
   return part.kind === "tool_call" && part.vendorToolName === "ToolSearch";
+}
+
+/**
+ * A sub-agent invocation (Claude's `Agent`/`Task`, or opencode's `task` tool,
+ * which surfaces no vendor name but carries a `subagent_type` input). Background
+ * Claude background subagents do not emit partial stream events, but current
+ * SDK versions do forward their complete nested assistant/user frames. A
+ * childless launch still renders as a group so its final report has a home.
+ */
+function isSubAgentLaunch(part: ToolCallPart): boolean {
+  if (part.vendorToolName === "Agent" || part.vendorToolName === "Task") return true;
+  const input = part.input as { subagent_type?: unknown } | null | undefined;
+  return typeof input?.subagent_type === "string";
 }
 
 /**
@@ -155,11 +164,14 @@ function foldNodes(
     }
     // tool_call
     const children = childrenByParent.get(p.id);
-    if (children && children.length > 0) {
+    if ((children && children.length > 0) || isSubAgentLaunch(p)) {
       // Sub-agent: flush any pending compaction first (sub-agent boundary
-      // breaks compaction), then emit the subagent node.
+      // breaks compaction), then emit the subagent node. A background launch
+      // has no streamed children but still groups so its report renders inside.
       const childNodes =
-        depth + 1 >= maxDepth ? [] : foldNodes(children, childrenByParent, maxDepth, depth + 1);
+        depth + 1 >= maxDepth
+          ? []
+          : foldNodes(children ?? [], childrenByParent, maxDepth, depth + 1);
       out.push({
         type: "subagent",
         parent: p,

--- a/src/agentMode/ui/agentTrail.ts
+++ b/src/agentMode/ui/agentTrail.ts
@@ -75,7 +75,9 @@ function isHiddenTool(part: AgentMessagePart): boolean {
  * its final report has a home.
  */
 function isSubAgentLaunch(part: ToolCallPart): boolean {
-  if (part.vendorToolName === "Agent" || part.vendorToolName === "Task") return true;
+  if (!part.mcpServer && (part.vendorToolName === "Agent" || part.vendorToolName === "Task")) {
+    return true;
+  }
   if (part.vendorToolName || part.mcpServer) return false;
   if (part.toolKind && part.toolKind !== "other") return false;
   const input = part.input as { subagent_type?: unknown } | null | undefined;

--- a/src/agentMode/ui/agentTrail.ts
+++ b/src/agentMode/ui/agentTrail.ts
@@ -67,14 +67,17 @@ function isHiddenTool(part: AgentMessagePart): boolean {
 }
 
 /**
- * A sub-agent invocation (Claude's `Agent`/`Task`, or opencode's `task` tool,
- * which surfaces no vendor name but carries a `subagent_type` input). Background
- * Claude background subagents do not emit partial stream events, but current
- * SDK versions do forward their complete nested assistant/user frames. A
- * childless launch still renders as a group so its final report has a home.
+ * A sub-agent invocation (Claude's `Agent`/`Task`, or opencode's anonymous
+ * `task` tool, which has no vendor/MCP provenance, maps to missing/other kind,
+ * and carries a `subagent_type` input). Background Claude subagents do not emit
+ * partial stream events, but current SDK versions do forward their complete
+ * nested assistant/user frames. A childless launch still renders as a group so
+ * its final report has a home.
  */
 function isSubAgentLaunch(part: ToolCallPart): boolean {
   if (part.vendorToolName === "Agent" || part.vendorToolName === "Task") return true;
+  if (part.vendorToolName || part.mcpServer) return false;
+  if (part.toolKind && part.toolKind !== "other") return false;
   const input = part.input as { subagent_type?: unknown } | null | undefined;
   return typeof input?.subagent_type === "string";
 }

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -419,24 +419,6 @@ describe("extractSubAgentReturnText", () => {
     });
     expect(extractSubAgentReturnText(t)).toBe("Here is what I found: …");
   });
-
-  it("never surfaces a background subagent's launch ack as the return value", () => {
-    // Internal metadata explicitly marked "never quote to the user" — a resumed
-    // transcript could reconstruct it as the launch card's output.
-    const t = tool({
-      input: { prompt: "analyze notes" },
-      output: [
-        { type: "text", text: "Async agent launched successfully.\nagentId: abc123 (internal ID)" },
-      ],
-    });
-    expect(extractSubAgentReturnText(t)).toBeNull();
-  });
-
-  it("keeps a legitimate report that begins with the launch acknowledgment wording", () => {
-    const report = "Async agent launched successfully after the retry, then completed the audit.";
-    const t = tool({ output: [{ type: "text", text: report }] });
-    expect(extractSubAgentReturnText(t)).toBe(report);
-  });
 });
 
 describe("extractSubAgentInputPrompt", () => {

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -201,7 +201,7 @@ describe("lookupToolSummary", () => {
       vendorToolName: "Agent",
       status: "in_progress",
       progress: {
-        description: "Count markdown files and subfolders",
+        description: "Running Count markdown files and subfolders",
         toolUses: 3,
         durationMs: 9851,
       },

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -196,6 +196,28 @@ describe("lookupToolSummary", () => {
     expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Tool call");
   });
 
+  it("summarizes live subagent progress and omits stale descriptions after completion", () => {
+    const running = tool({
+      vendorToolName: "Agent",
+      status: "in_progress",
+      progress: {
+        description: "Count markdown files and subfolders",
+        toolUses: 3,
+        durationMs: 9851,
+      },
+    });
+    const done = tool({
+      ...running,
+      status: "completed",
+      progress: { ...running.progress, toolUses: 19, durationMs: 66_000 },
+    });
+
+    expect(lookupToolSummary(running).outcome(running)).toBe(
+      "Running Count markdown files and subfolders · 3 tools · 9s"
+    );
+    expect(lookupToolSummary(done).outcome(done)).toBe("19 tools · 1m 6s");
+  });
+
   it("summarizes AskUserQuestion with the question header", () => {
     const t = tool({
       vendorToolName: "AskUserQuestion",
@@ -396,6 +418,18 @@ describe("extractSubAgentReturnText", () => {
       output: [{ type: "text", text: "Here is what I found: …" }],
     });
     expect(extractSubAgentReturnText(t)).toBe("Here is what I found: …");
+  });
+
+  it("never surfaces a background subagent's launch ack as the return value", () => {
+    // Internal metadata explicitly marked "never quote to the user" — a resumed
+    // transcript could reconstruct it as the launch card's output.
+    const t = tool({
+      input: { prompt: "analyze notes" },
+      output: [
+        { type: "text", text: "Async agent launched successfully.\nagentId: abc123 (internal ID)" },
+      ],
+    });
+    expect(extractSubAgentReturnText(t)).toBeNull();
   });
 });
 

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -431,6 +431,12 @@ describe("extractSubAgentReturnText", () => {
     });
     expect(extractSubAgentReturnText(t)).toBeNull();
   });
+
+  it("keeps a legitimate report that begins with the launch acknowledgment wording", () => {
+    const report = "Async agent launched successfully after the retry, then completed the audit.";
+    const t = tool({ output: [{ type: "text", text: report }] });
+    expect(extractSubAgentReturnText(t)).toBe(report);
+  });
 });
 
 describe("extractSubAgentInputPrompt", () => {

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -600,7 +600,7 @@ export function extractSubAgentInputPrompt(part: ToolCallPart): string | null {
 }
 
 /**
- * Selects the user-visible delegated-work report so internal acknowledgments and echoed prompts are not mistaken for results.
+ * Selects the user-visible delegated-work report without repeating an echoed prompt.
  * @param part - The subagent tool call whose displayable report is needed.
  */
 export function extractSubAgentReturnText(part: ToolCallPart): string | null {
@@ -611,15 +611,6 @@ export function extractSubAgentReturnText(part: ToolCallPart): string | null {
   const m = joined.match(/<task_result>([\s\S]*?)<\/task_result>/);
   const result = m ? m[1].trim() : joined.trim();
   if (!result) return null;
-  // A background subagent's launch ack is internal
-  // metadata explicitly marked "never quote to the user" — never render it as
-  // the return value. The live path suppresses it upstream (SDK translator);
-  // this also covers a resumed transcript that reconstructs the ack as output.
-  if (
-    /^Async agent launched successfully\.(?:\r?\nagentId: [^\r\n]+ \(internal ID\))?$/.test(result)
-  ) {
-    return null;
-  }
   const prompt = extractSubAgentInputPrompt(part);
   if (prompt && prompt === result) return null;
   return result;

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -609,11 +609,15 @@ export function extractSubAgentReturnText(part: ToolCallPart): string | null {
   const m = joined.match(/<task_result>([\s\S]*?)<\/task_result>/);
   const result = m ? m[1].trim() : joined.trim();
   if (!result) return null;
-  // A background subagent's launch ack ("Async agent launched…") is internal
+  // A background subagent's launch ack is internal
   // metadata explicitly marked "never quote to the user" — never render it as
   // the return value. The live path suppresses it upstream (SDK translator);
   // this also covers a resumed transcript that reconstructs the ack as output.
-  if (result.startsWith("Async agent launched")) return null;
+  if (
+    /^Async agent launched successfully\.(?:\r?\nagentId: [^\r\n]+ \(internal ID\))?$/.test(result)
+  ) {
+    return null;
+  }
   const prompt = extractSubAgentInputPrompt(part);
   if (prompt && prompt === result) return null;
   return result;

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -407,8 +407,10 @@ const TASK_SUMMARY: ToolSummary = {
     const progress = p.progress;
     if (!progress) return null;
     const bits: string[] = [];
+    // The SDK's task_progress descriptions are already verb-prefixed status
+    // lines ("Running X", "Reading Y") — don't stack another verb on top.
     if ((p.status === "pending" || p.status === "in_progress") && progress.description?.trim()) {
-      bits.push(`Running ${progress.description.trim()}`);
+      bits.push(progress.description.trim());
     }
     if (progress.toolUses !== undefined) {
       bits.push(pluralize(progress.toolUses, "tool"));

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -2,6 +2,7 @@ import type { LucideIcon } from "lucide-react";
 import { Bot, MessageCircleQuestion } from "lucide-react";
 import { pickToolIcon } from "@/agentMode/ui/toolIcons";
 import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
+import { formatDuration } from "@/lib/duration";
 import { isAbsolutePath, toVaultRelative } from "@/utils/vaultPath";
 
 /**
@@ -402,7 +403,19 @@ const TASK_SUMMARY: ToolSummary = {
           : targetFromTitle(p);
     return agent ? `${agent} · "${desc}"` : `Sub-agent · "${desc}"`;
   },
-  outcome: () => null,
+  outcome: (p) => {
+    const progress = p.progress;
+    if (!progress) return null;
+    const bits: string[] = [];
+    if ((p.status === "pending" || p.status === "in_progress") && progress.description?.trim()) {
+      bits.push(`Running ${progress.description.trim()}`);
+    }
+    if (progress.toolUses !== undefined) {
+      bits.push(pluralize(progress.toolUses, "tool"));
+    }
+    if (progress.durationMs !== undefined) bits.push(formatDuration(progress.durationMs));
+    return bits.length > 0 ? bits.join(" · ") : null;
+  },
   aggregate: (parts) => ({
     line: `Ran ${pluralize(parts.length, "sub-agent")}${statusSuffix(parts)}`,
     outcome: "",
@@ -585,13 +598,8 @@ export function extractSubAgentInputPrompt(part: ToolCallPart): string | null {
 }
 
 /**
- * Extract the sub-agent return value from a Task / sub-agent tool call's
- * output. Strips `<task_result>…</task_result>` markers (opencode wraps
- * the result this way) and returns the inner text. Returns null when
- * the part has no text output, or when the output is identical to the
- * input prompt — Claude Code initially echoes the prompt as the Agent
- * tool's `content` before the sub-agent has produced anything, and that
- * echoed prompt would otherwise render in the "response" slot.
+ * Selects the user-visible delegated-work report so internal acknowledgments and echoed prompts are not mistaken for results.
+ * @param part - The subagent tool call whose displayable report is needed.
  */
 export function extractSubAgentReturnText(part: ToolCallPart): string | null {
   if (!part.output) return null;
@@ -601,6 +609,11 @@ export function extractSubAgentReturnText(part: ToolCallPart): string | null {
   const m = joined.match(/<task_result>([\s\S]*?)<\/task_result>/);
   const result = m ? m[1].trim() : joined.trim();
   if (!result) return null;
+  // A background subagent's launch ack ("Async agent launched…") is internal
+  // metadata explicitly marked "never quote to the user" — never render it as
+  // the return value. The live path suppresses it upstream (SDK translator);
+  // this also covers a resumed transcript that reconstructs the ack as output.
+  if (result.startsWith("Async agent launched")) return null;
   const prompt = extractSubAgentInputPrompt(part);
   if (prompt && prompt === result) return null;
   return result;

--- a/src/components/chat-components/RelevantNotes.test.tsx
+++ b/src/components/chat-components/RelevantNotes.test.tsx
@@ -39,6 +39,7 @@ jest.mock("@/hooks/useNoteDrag", () => ({
 }));
 
 jest.mock("@/miyo/miyoUtils", () => ({
+  getSearchBackend: () => "keyword",
   shouldUseMiyo: () => false,
 }));
 


### PR DESCRIPTION
## Stack position

2 of 3, based on #2688.

Stack:
1. #2688 — keep background task turns alive
2. #2686 — project task lifecycle onto launch cards
3. #2661 — fold TaskOutput into the launch card

## What

- Adds a session-scoped Claude task state machine that correlates launch tool calls with Claude task IDs across query boundaries.
- Projects started, progress, terminal status, and terminal output onto the original Agent or Task launch card.
- Suppresses the asynchronous launch acknowledgement and renders childless background launches as subagent cards with progress.

## User impact

Users see the launch card advance from running to completed or failed, with progress and the terminal report when Claude sends it. TaskOutput remains a separate visible card at this stack point; the top PR folds it safely.

## Verification

- Protocol, translator, session, and trail UI: 7 suites and 298 tests passed
- npm run lint

The complete top-of-stack tree also passes the full test suite and production build.