### PR TITLE
fix(agent-mode): surface Claude usage errors

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -166,6 +166,8 @@ Claude can delegate independent work to background subagents. Agent Mode keeps t
 
 This requires Claude Code 2.1.206 or newer. Copilot checks the installed version when it starts and whenever you apply or auto-detect a Claude binary. An older binary is marked **Incompatible version** in Settings → Copilot → Agents → Claude and cannot start a session. If you select Claude in chat, Copilot shows the required version and a **Configure Claude** button that opens the same setup dialog; installation guidance stays in that dialog.
 
+If Claude's usage is exhausted, Copilot shows Claude's own error in chat, including the reset time when Claude provides one. You can wait until the limit resets or switch to another agent.
+
 ---
 
 ## File Editing: Preview and Diff

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -132,6 +132,46 @@ function resultMessage(): SDKMessage {
   };
 }
 
+const USAGE_LIMIT_MESSAGE = "You've hit your session limit · resets 6:30pm (America/New_York)";
+
+function usageLimitMessages(): SDKMessage[] {
+  return [
+    {
+      type: "rate_limit_event",
+      rate_limit_info: {
+        status: "rejected",
+        resetsAt: 1_784_154_600,
+        rateLimitType: "five_hour",
+        overageStatus: "rejected",
+        overageDisabledReason: "org_level_disabled",
+        isUsingOverage: false,
+      },
+      uuid: "uuid-limit" as `${string}-${string}-${string}-${string}-${string}`,
+      session_id: "irrelevant",
+    },
+    {
+      type: "assistant",
+      error: "rate_limit",
+      message: {
+        model: "<synthetic>",
+        role: "assistant",
+        stop_reason: "stop_sequence",
+        content: [{ type: "text", text: USAGE_LIMIT_MESSAGE }],
+      },
+      parent_tool_use_id: null,
+      uuid: "uuid-assistant" as `${string}-${string}-${string}-${string}-${string}`,
+      session_id: "irrelevant",
+    },
+    {
+      ...resultMessage(),
+      is_error: true,
+      api_error_status: 429,
+      result: USAGE_LIMIT_MESSAGE,
+      stop_reason: "stop_sequence",
+    },
+  ] as SDKMessage[];
+}
+
 function getPromptQueryCalls(): unknown[][] {
   return queryMock.mock.calls.filter((c) => {
     const opts = (c[0] as { options?: { cwd?: unknown } } | undefined)?.options;
@@ -281,6 +321,25 @@ describe("ClaudeSdkBackendProcess", () => {
       expect(call.options.resume).toBeUndefined();
       // No skill-creation directive opt passed → no systemPrompt override.
       expect(call.options.systemPrompt).toBeUndefined();
+    });
+
+    it("rejects with Claude's reset message when a success-shaped result reports usage exhaustion", async () => {
+      queryMock.mockImplementation(() => makeQuery(usageLimitMessages()));
+
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+
+      const { sessionId } = await proc.newSession({ cwd: "/vault", mcpServers: [] });
+      proc.registerSessionHandler(sessionId, () => {});
+
+      await expect(
+        proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] })
+      ).rejects.toThrow(new Error(USAGE_LIMIT_MESSAGE));
     });
 
     it("forwards the composed system prompt via systemPrompt append on the claude_code preset", async () => {

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -478,7 +478,9 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
         for (const e of events) this.dispatchEvent(e);
         if (sdkMsg.type === "result") {
           stopReason = mapStopReason(sdkMsg);
-          if (stopReason !== "end_turn" && sdkMsg.subtype !== "success") {
+          if (sdkMsg.subtype === "success" && sdkMsg.is_error && sdkMsg.result.trim()) {
+            resultErrorMessage = sdkMsg.result;
+          } else if (stopReason !== "end_turn" && sdkMsg.subtype !== "success") {
             const errs = "errors" in sdkMsg ? sdkMsg.errors : undefined;
             if (errs && errs.length > 0) {
               resultErrorMessage = errs.join("; ");


### PR DESCRIPTION
## Summary
<img width="567" height="641" alt="Screenshot 2026-07-15 at 5 19 20 PM" src="https://github.com/user-attachments/assets/1918f5c0-9e01-45ff-b3db-0d62f652c7cc" />

| SDK evidence | Before | After |
| --- | --- | --- |
| `result.is_error=true`, HTTP 429, exact reset text | mapped to `end_turn` | rejected with Claude provider text |
| no streamed text or tool activity | generic empty-turn fallback | visible provider error |

**Why:** Claude can report exhausted subscription usage as a success-shaped terminal SDK result. Copilot discarded the synthetic assistant error and treated that result as a normal empty turn, hiding the actionable reset message.

**What:** The Claude SDK adapter now rejects success-shaped terminal errors with the exact non-empty provider result, so the existing session error path shows the reset message in chat.

## Decisions

- Preserve the exact human-readable Claude usage message, including the reset time when provided.
- Detect failure from the terminal `result.is_error` contract; `rate_limit_event` remains diagnostic because it also carries allowed warnings.
- Keep the change provider-local and reuse the existing prompt-error rendering rather than expanding the shared session protocol.

## Changes

- `709dfb8e` — recognize success-shaped Claude terminal errors, replay the captured rate-limit SDK sequence in the `prompt()` suite, and document the visible reset-message behavior. Verify by confirming exhausted usage rejects with the provider message while ordinary success still returns `end_turn`.

## Notes / follow-ups

- Pre-limit warning UX is intentionally out of scope; this change handles terminal provider failures.