### PR TITLE
fix(agent-mode): clear composer after sending text with images

### DIFF
--- a/src/agentMode/ui/AgentChatInput.test.tsx
+++ b/src/agentMode/ui/AgentChatInput.test.tsx
@@ -274,6 +274,52 @@ describe("AgentChatInput status-icon boundary", () => {
   });
 });
 
+describe("AgentChatInput compose reset ordering", () => {
+  beforeEach(() => {
+    mockUseCanUseMultiAgent.mockReturnValue(true);
+  });
+
+  it("regression: clears the composer before awaiting attached-image conversion (#211)", async () => {
+    // Hold the image read open so ordering is observable. The composer must
+    // clear the instant the user sends, not after every File.arrayBuffer()
+    // resolves — leaving the draft populated across those awaits let the
+    // Lexical editor race resetCompose and strand the just-sent text in the
+    // input when text was sent alongside images.
+    let resolveRead!: (buf: ArrayBuffer) => void;
+    const image = {
+      type: "image/png",
+      arrayBuffer: () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          resolveRead = resolve;
+        }),
+    } as unknown as File;
+
+    const backend = {
+      sendMessage: jest.fn(() => ({ turn: Promise.resolve() })),
+      cancel: jest.fn(),
+    } as unknown as AgentChatBackend;
+    const draft = makeDraft({ images: [image] });
+
+    renderInput(backend, draft);
+    fireEvent.click(screen.getByText("send"));
+
+    // Composer is cleared while the image read is still pending, before the
+    // turn is dispatched.
+    await waitFor(() => expect(draft.resetCompose).toHaveBeenCalledTimes(1));
+    expect(backend.sendMessage).not.toHaveBeenCalled();
+
+    // Finishing the read lets the turn fire with the converted image attached.
+    await act(async () => {
+      resolveRead(new ArrayBuffer(1));
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(backend.sendMessage).toHaveBeenCalledTimes(1));
+    const promptContent = (backend.sendMessage as jest.Mock).mock.calls[0][2];
+    expect(promptContent).toHaveLength(1);
+    expect(promptContent[0].type).toBe("image");
+  });
+});
+
 describe("AgentChatInput hard-disable", () => {
   it("drops a send when the composer is disabled (orphaned project)", async () => {
     // The mocked ChatInput's send button routes through handleSendMessage — the

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -373,17 +373,10 @@ export const AgentChatInput = memo(function AgentChatInput({
         }
       }
 
-      const content: PromptContent[] = [];
-
-      // Convert attached images to base64 image content blocks.
-      for (const image of selectedImages) {
-        const block = await fileToImageBlock(image);
-        if (block) content.push(block);
-      }
-
       // Resolve the `@`-mentions into the ANSWERER set (installed, deduped). Only
       // carried when it actually fans out; the single-agent path sends no
-      // `mentionedAgents` and stays byte-for-byte the existing behavior.
+      // `mentionedAgents` and stays byte-for-byte the existing behavior. Read the
+      // mention ref before resetCompose clears it below.
       let mentionedAgents: ReadonlyArray<BackendId> | undefined;
       if (mainAgentId) {
         const answerers = resolveAnswerers({
@@ -391,6 +384,31 @@ export const AgentChatInput = memo(function AgentChatInput({
           installedAgentIds,
         });
         if (isFanout(answerers, mainAgentId)) mentionedAgents = answerers;
+      }
+
+      // Clear the composer NOW, before the async image reads below, so it empties
+      // the instant the user sends instead of after every attached image finishes
+      // decoding. `selectedImages` is already captured in this closure, so the
+      // conversion still runs on the snapshot. (The stale-text-left-behind race in
+      // #211 is closed at its source by `ignoreSelectionChange` on the editor's
+      // OnChangePlugin; clearing before the awaits additionally shrinks the window
+      // the draft stays populated, but is not what fixes the race.)
+      mentionedAgentIdsRef.current = [];
+      resetCompose();
+      // The message context is built below from this render's captured
+      // `selectedTextContexts` (a closure value the atom clear doesn't touch), so
+      // clearing the global atom here is safe for this send. The narrow window where
+      // the awaits below let the user switch sessions and start a new selection
+      // before this clear fires is accepted as-is (carried over verbatim from the
+      // pre-split AgentChat, and a cleared selection is trivially recoverable). If a
+      // future review flags this again, point them here.
+      clearSelectedTextContexts();
+
+      // Convert the attached images to base64 image content blocks.
+      const content: PromptContent[] = [];
+      for (const image of selectedImages) {
+        const block = await fileToImageBlock(image);
+        if (block) content.push(block);
       }
 
       const item: QueuedAgentMessage = {
@@ -401,17 +419,6 @@ export const AgentChatInput = memo(function AgentChatInput({
         promptContent: content.length > 0 ? content : undefined,
         mentionedAgents,
       };
-
-      mentionedAgentIdsRef.current = [];
-      resetCompose();
-      // The message context was already snapshotted above from this render's
-      // captured `selectedTextContexts`, so clearing the global atom here is safe
-      // for this send. The narrow window where the awaits above let the user
-      // switch sessions and start a new selection before this clear fires is
-      // accepted as-is (carried over verbatim from the pre-split AgentChat, and a
-      // cleared selection is trivially recoverable). If a future review flags this
-      // again, point them here.
-      clearSelectedTextContexts();
 
       // Queue-and-hold: while a turn is in flight, starting, or the project's
       // context is still materializing, park the message instead of sending.

--- a/src/components/chat-components/LexicalEditor.tsx
+++ b/src/components/chat-components/LexicalEditor.tsx
@@ -195,7 +195,11 @@ const LexicalEditor: React.FC<LexicalEditorProps> = ({
             }
             ErrorBoundary={LexicalErrorBoundary}
           />
-          <OnChangePlugin onChange={handleEditorChange} />
+          {/* ignoreSelectionChange: only text edits should push into `value`.
+              Selection/focus-only changes carry the same text, and firing
+              onChange for them lets stale editor text race a just-issued
+              external clear back into the controlled value (#211). */}
+          <OnChangePlugin onChange={handleEditorChange} ignoreSelectionChange />
           <HistoryPlugin />
           <KeyboardPlugin
             onSubmit={onSubmit}


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#211

## Problem

In Agent Chat, sending a message that has **text plus attached images** posts the turn correctly (the user message includes both text and images), but the text is left stranded in the composer. Only the image previews clear.

The Lexical editor in `LexicalEditor.tsx` is a controlled component: the parent compose value flows in through `ValueSyncPlugin`, and editor edits flow back out through `OnChangePlugin` → `handleEditorChange` → `onChange(textContent)`. On send, `handleSendMessage` (`AgentChatInput.tsx`) calls `resetCompose()`, which sets the compose value to `""`. But `OnChangePlugin` fires on selection- and focus-only changes too (its `ignoreSelectionChange` defaults to `false`), and such a change re-runs `handleEditorChange` with the still-present editor text, pushing the stale text back into the controlled value before `ValueSyncPlugin` has synced the editor to empty. The value ends up back at the old text, so the editor is never cleared.

The image path made it reproducible: the send handler awaited `File.arrayBuffer()` for every attached image *before* calling `resetCompose()`, widening the window; and on the first turn of a session the landing to conversation remount fires a focus/selection change right in that window.

## Fix

Two changes, one of which is the root cause and one a supporting improvement:

- **Close the race at its source.** Add `ignoreSelectionChange` to the shared editor's `OnChangePlugin`. `handleEditorChange` only reads `root.getTextContent()`, so selection/focus-only changes never carried new information; firing `onChange` for them was always redundant work, and it was the only vector that re-injected stale text over a just-issued clear. This is the fix that actually resolves #211, and it applies to every consumer of the shared editor as a strict reduction in redundant `onChange` calls.
- **Clear the composer before awaiting image conversion.** Reorder `handleSendMessage` so `resetCompose()` / `clearSelectedTextContexts()` run right after the send is validated and snapshotted, before the async image reads. The composer now empties the instant the user sends instead of after every image decodes, and the draft no longer stays populated across the `arrayBuffer()` awaits.

Rejected alternative: fixing only in `AgentChatInput` (e.g. re-clearing after the awaits) would have left the underlying controlled-component race in the shared editor for the non-agent chat to hit later. Putting `ignoreSelectionChange` on the shared editor fixes the class of bug rather than one instance.

## Scope

`/simplify` gate: **PASS** — 3 files changed, +78 / -21. Clean on reuse, simplification, and efficiency; one altitude note applied (the reorder comment now leads with its UX rationale and marks `ignoreSelectionChange` as the actual race fix). This is the smallest shape that solves the issue: one flag on the shared editor removes the mechanism, and the send-handler reorder is pure code motion of existing calls.

## Changes

- `src/components/chat-components/LexicalEditor.tsx` — add `ignoreSelectionChange` to `OnChangePlugin` so selection/focus-only edits no longer push unchanged text back into the controlled value.
- `src/agentMode/ui/AgentChatInput.tsx` — move the compose clear (`resetCompose`, `clearSelectedTextContexts`, mention-ref reset) ahead of the image-conversion loop; resolve `@`-mentions before the ref is cleared. Pure reordering of existing calls.
- `src/agentMode/ui/AgentChatInput.test.tsx` — regression test locking the clear-before-image-conversion order: with a held-open image read, the composer clears while conversion is still pending and the turn dispatches afterward with the image attached.

## Verification

- `npx jest src/agentMode/ui/AgentChatInput.test.tsx` — 10 passed (incl. the new regression test, which fails on the pre-reorder ordering).
- `npx jest src/components/chat-components src/agentMode/ui` — 386 tests passed. Three suites that transitively import `ClaudeSdkBackendProcess.ts` fail to *compile* on a pre-existing `StopHookInput.background_tasks` type mismatch from the local SDK version; that file is outside this diff and CI resolves the pinned SDK, so it is unrelated.
- `npx eslint` on all three files — clean. `prettier --write` — no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Note: the issue lives in the `obsidian-copilot-preview` repo. GitHub does not auto-close issues across repositories, so **preview#211 must be closed manually on merge.**_
