### PR TITLE
feat(settings): unify Copilot data under one configurable root folder (v4, part 2)

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -45,6 +45,11 @@ module.exports = {
     isDesktop: true,
     isDesktopApp: true,
     isMobile: false,
+    // Filesystem case sensitivity is behaviour some code branches on; default to
+    // the case-sensitive branch so a test must opt in to folding explicitly.
+    isWin: false,
+    isMacOS: false,
+    isIosApp: false,
   },
   FileSystemAdapter: class FileSystemAdapter {
     constructor(basePath = "/vault") {

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -71,7 +71,7 @@ Each AI response has action buttons:
 
 ### Autosave
 
-By default, Copilot automatically saves your conversations as markdown files in your vault. Each saved chat appears in the `copilot/copilot-conversations/` folder.
+By default, Copilot automatically saves your conversations as markdown files in your vault. Each saved chat appears in the `copilot-conversations/` sub-folder of your Copilot folder (by default `copilot/copilot-conversations/`).
 
 You can turn off autosave in Settings → Basic. When you start a new chat, any unsaved conversation is saved automatically.
 
@@ -145,7 +145,7 @@ On Agent Home, Relevant Notes appears as a shelf tab when the dedicated pane is 
 
 ## Saving a Chat Manually
 
-If autosave is off, or you want to save mid-conversation, click the **Save Chat as Note** button above the chat input box. This saves the current conversation to your configured save folder.
+If autosave is off, or you want to save mid-conversation, click the **Save Chat as Note** button above the chat input box. This saves the current conversation to your Copilot conversations folder (`copilot-conversations/` under your Copilot folder).
 
 ---
 

--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -64,7 +64,7 @@ You can ask Copilot to explicitly remember specific facts about you:
 Copilot saves this to a memory file in your vault and references it in future conversations.
 
 - **Enable**: **Settings → Copilot → Plus → Reference Saved Memories** (on by default)
-- **Memory folder**: **Settings → Copilot → Plus → Memory Folder Name** — default: `copilot/memory`
+- **Memory folder**: memories are stored in the `memory/` sub-folder of your Copilot folder — default `copilot/memory`. It follows the Copilot folder location (**Settings → Copilot → Basic → Copilot folder location**).
 - **Update memory tool**: The AI can add, update, or remove memories when you ask
 
 ---

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -121,7 +121,7 @@ Go to **Settings → Copilot → Command** to manage all your custom commands:
 
 ### Custom Prompts Folder
 
-Commands are stored as markdown files in your vault. The default folder is `copilot/copilot-custom-prompts/`. You can change this in **Settings → Copilot → Basic → Custom prompts folder**.
+Commands are stored as markdown files in your vault, in the `copilot-custom-prompts/` sub-folder of your Copilot folder (by default `copilot/copilot-custom-prompts/`). This location is derived from your Copilot folder — change the root in **Settings → Copilot → Basic → Copilot folder location** to change where new commands are saved. There is no separate custom-prompts folder setting anymore.
 
 ---
 

--- a/docs/system-prompts.md
+++ b/docs/system-prompts.md
@@ -38,12 +38,12 @@ Custom system prompts let you add your own instructions on top of the built-in p
 
 ### Where They're Stored
 
-Custom system prompts are stored as markdown files in your vault, in the folder:
+Custom system prompts are stored as markdown files in your vault, in the `system-prompts/` sub-folder of your Copilot folder:
 ```
 copilot/system-prompts/
 ```
 
-You can change this folder in **Settings → Copilot → Advanced → System Prompts Folder Name**.
+This location is derived from your Copilot folder. To move it, change the root in **Settings → Copilot → Basic → Copilot folder location** — every Copilot sub-folder follows that root, so it is no longer configured on its own. Changing the root affects only where new prompts are saved; existing prompt files stay where they are unless you move them yourself.
 
 ### Creating a System Prompt
 

--- a/docs/troubleshooting-and-faq.md
+++ b/docs/troubleshooting-and-faq.md
@@ -259,7 +259,7 @@ Yes. You can have API keys configured for multiple providers simultaneously and 
 
 ### Where are my saved chats stored?
 
-Chat conversations are saved as markdown files in your vault, in the folder `copilot/copilot-conversations/` by default. You can change this folder in **Settings → Copilot → Basic → Default save folder**.
+Chat conversations are saved as markdown files in your vault, in the `copilot-conversations/` sub-folder of your Copilot folder (by default `copilot/copilot-conversations/`). To change where new chats are saved, change the root in **Settings → Copilot → Basic → Copilot folder location** — every Copilot sub-folder derives from it. Changing the root affects only new chats; conversations you have already saved stay in the old folder unless you move them yourself.
 
 ### How do I clear the Copilot cache?
 
@@ -267,13 +267,15 @@ Use **Command palette → Clear Copilot cache**. This clears cached responses an
 
 ### What is the `copilot/` folder in my vault?
 
-The `copilot/` folder is created by the plugin and stores:
+The `copilot/` folder is your Copilot folder — the default root the plugin uses to store its own files:
 - `copilot-conversations/` — Saved chat histories
 - `copilot-custom-prompts/` — Your custom commands
 - `system-prompts/` — Your custom system prompts
 - `memory/` — Saved AI memories (if enabled)
+- `skills/` — Agent skills
+- `projects/` — Project files
 
-This folder is automatically excluded from vault search to avoid cluttering results.
+You can rename this root in **Settings → Copilot → Basic → Copilot folder location**; all of the sub-folders above derive from it. The Copilot folder is automatically excluded from vault search to avoid cluttering results. If you change the root, the old folder is not moved for you and stays excluded from search permanently — any folder that has ever been your Copilot folder is kept out of search results even after you switch away from it.
 
 ### How do I switch modes?
 

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -114,7 +114,7 @@ Example: `private, Work/Confidential, #private` excludes the private folder, a s
 
 > **Note**: Tag matching works with tags in the note's **properties (frontmatter)**, not inline tags within the note body.
 
-The `copilot` folder is always excluded automatically (it contains the plugin's own files).
+Your Copilot folder is always excluded automatically (it holds the plugin's own files — conversations, prompts, memory, skills, and projects). This covers the default `copilot` folder, your current Copilot folder if you changed it in **Settings → Copilot → Basic → Copilot folder location**, and every folder that has previously been your Copilot folder. Past Copilot folders stay excluded permanently, so any files the plugin left behind after a folder change never leak into search results.
 
 ### Inclusions
 

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import * as path from "node:path";
 import type CopilotPlugin from "@/main";
 import { logError } from "@/logger";
-import { DEFAULT_SKILLS_FOLDER } from "@/constants";
 import { getSettings, subscribeToSettingsChange, type CopilotSettings } from "@/settings/model";
+import { deriveSkillsFolder, getEffectiveSkillsFolder } from "@/settings/copilotFolder";
 import { subscribeToSystemPromptChange } from "@/system-prompts/state";
 import { copilotAppDataDir, getVaultId } from "@/utils/appPaths";
 import { buildAgentSystemPrompt } from "./backends/shared/agentSystemPrompt";
@@ -362,8 +362,10 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
     // appear in the new folder without a reload) or when Miyo availability
     // flips (so each gated Miyo skill is seeded/pruned to match). Both run the
     // same gate-aware seed pass against the current folder.
-    const prevFolder = prev.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
-    const nextFolder = next.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
+    // Reason: the skills folder is derived from the configurable copilotFolder
+    // root; compare derived paths rather than the retired agentMode.skills.folder.
+    const prevFolder = deriveSkillsFolder(prev);
+    const nextFolder = deriveSkillsFolder(next);
     // `enableMiyoSearchSkill` and `docProcessorBackend` are the two gates
     // `planManagedBuiltins` reads, and each also selects prompt steering that
     // codex/opencode bake at spawn. `enableMiyo` / `miyoServerUrl` are still
@@ -428,11 +430,9 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   // Seed plugin-shipped builtin skills into the canonical folder, THEN run
   // discovery so the first pass picks them up and fans them out to the agent
   // dirs. Non-blocking for plugin load.
-  void seedManagedBuiltins(getSettings().agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER).catch(
-    (error) => {
-      logError("[Skills] Initial discovery pass failed", error);
-    }
-  );
+  void seedManagedBuiltins(getEffectiveSkillsFolder()).catch((error) => {
+    logError("[Skills] Initial discovery pass failed", error);
+  });
   // Non-blocking — plugin load should not wait on disk reconcile.
   for (const descriptor of listBackendDescriptors()) {
     descriptor

--- a/src/agentMode/session/AgentChatPersistenceManager.test.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.test.ts
@@ -7,6 +7,7 @@ import type { AgentChatMessage } from "./types";
 import { TFile } from "obsidian";
 import type { App } from "obsidian";
 import { getSettings } from "@/settings/model";
+import { getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 
 jest.mock("obsidian", () => ({
   Notice: jest.fn(),
@@ -131,6 +132,25 @@ describe("AgentChatPersistenceManager", () => {
     expect(loaded.messages[0].message).toBe("hello world");
     expect(loaded.messages[1].sender).toBe(AI_SENDER);
     expect(loaded.messages[1].message).toBe("hi back");
+  });
+
+  it("writes under the folder captured at entry, not one a mid-save root change swaps in", async () => {
+    // Captured once at entry and threaded through ensure, filename generation,
+    // and the fallback path. Simulate a Copilot-root change landing after the
+    // save starts: the entry read returns the old folder, every later read the
+    // new one. The written path must stay under the old folder so ensure/create
+    // can't straddle two directories.
+    // Only override the entry read; later reads fall back to the default mock
+    // ("test-folder"). The written path must stay under the entry-captured
+    // "old-folder" so ensure/create can't straddle two directories.
+    const folderMock = jest.mocked(getEffectiveConversationsFolder);
+    folderMock.mockReturnValueOnce("old-folder");
+
+    const saved = await manager.saveSession([makeMessage(USER_SENDER, "hi")], "claude", {});
+
+    expect(saved).not.toBeNull();
+    expect(saved!.path.startsWith("old-folder/")).toBe(true);
+    expect(saved!.path).not.toContain("test-folder");
   });
 
   it("writes the built-in conversation tag independent of the persisted setting", async () => {

--- a/src/agentMode/session/AgentChatPersistenceManager.test.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.test.ts
@@ -6,6 +6,7 @@ import { GLOBAL_SCOPE } from "./scope";
 import type { AgentChatMessage } from "./types";
 import { TFile } from "obsidian";
 import type { App } from "obsidian";
+import { getSettings } from "@/settings/model";
 
 jest.mock("obsidian", () => ({
   Notice: jest.fn(),
@@ -18,6 +19,9 @@ jest.mock("@/settings/model", () => ({
     defaultConversationTag: "copilot-conversation",
     defaultConversationNoteName: "{$date}_{$time}__{$topic}",
   }),
+}));
+jest.mock("@/settings/copilotFolder", () => ({
+  getEffectiveConversationsFolder: jest.fn(() => "test-folder"),
 }));
 jest.mock("@/utils", () => ({
   ensureFolderExists: jest.fn(async () => {}),
@@ -127,6 +131,19 @@ describe("AgentChatPersistenceManager", () => {
     expect(loaded.messages[0].message).toBe("hello world");
     expect(loaded.messages[1].sender).toBe(AI_SENDER);
     expect(loaded.messages[1].message).toBe("hi back");
+  });
+
+  it("writes the built-in conversation tag independent of the persisted setting", async () => {
+    // Freeze check: a custom/stale defaultConversationTag must not reach new notes.
+    (getSettings as jest.Mock).mockReturnValueOnce({
+      defaultSaveFolder: "test-folder",
+      defaultConversationTag: "user-custom-tag",
+      defaultConversationNoteName: "{$date}_{$time}__{$topic}",
+    });
+    const saved = await manager.saveSession([makeMessage(USER_SENDER, "hi")], "claude", {});
+    const contents = app.files.get(saved!.path)!.contents!;
+    expect(contents).toContain("tags:\n  - copilot-conversation");
+    expect(contents).not.toContain("user-custom-tag");
   });
 
   it("serializes a mid-stream fan-out turn so an interrupted autosave isn't blank", async () => {

--- a/src/agentMode/session/AgentChatPersistenceManager.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.ts
@@ -19,6 +19,7 @@ import {
   readFrontmatterViaAdapter,
   trashFile,
 } from "@/utils/vaultAdapterUtils";
+import { joinPosix } from "@/utils/pathUtils";
 import { TFile, type App } from "obsidian";
 import { Notice } from "obsidian";
 import { coerceProjectId, escapeYamlString, unescapeYamlString } from "./agentChatYaml";
@@ -143,7 +144,12 @@ export class AgentChatPersistenceManager {
       const chatContent = this.formatChatContent(messages);
       const firstMessageEpoch = messages[0].timestamp?.epoch ?? Date.now();
 
-      await ensureFolderExists(this.app.vault, getEffectiveConversationsFolder());
+      // Capture the conversations folder once so a concurrent Copilot-root
+      // change can't make this save ensure one directory and then write a path
+      // under another. The fallback path below reads the same snapshot.
+      const conversationsFolder = getEffectiveConversationsFolder();
+
+      await ensureFolderExists(this.app.vault, conversationsFolder);
 
       const existingFile = options?.existingPath
         ? this.resolveExistingFile(options.existingPath)
@@ -152,7 +158,12 @@ export class AgentChatPersistenceManager {
 
       const preferredFileName = existingFile
         ? existingFile.path
-        : this.generateFileName(messages, firstMessageEpoch, existingMeta.topic);
+        : this.generateFileName(
+            messages,
+            firstMessageEpoch,
+            conversationsFolder,
+            existingMeta.topic
+          );
 
       const noteContent = this.generateNoteContent({
         chatContent,
@@ -196,7 +207,7 @@ export class AgentChatPersistenceManager {
         }
         if (isNameTooLongError(err)) {
           logWarn("[AgentChatPersistenceManager] Filename too long, falling back to minimal name");
-          const fallback = `${getEffectiveConversationsFolder()}/${AGENT_FILENAME_PREFIX}chat-${firstMessageEpoch}.md`;
+          const fallback = `${conversationsFolder}/${AGENT_FILENAME_PREFIX}chat-${firstMessageEpoch}.md`;
           try {
             const created = await this.app.vault.create(fallback, noteContent);
             return { path: created.path };
@@ -414,6 +425,7 @@ export class AgentChatPersistenceManager {
   private generateFileName(
     messages: AgentChatMessage[],
     firstMessageEpoch: number,
+    folder: string,
     topic?: string
   ): string {
     const settings = getSettings();
@@ -473,10 +485,10 @@ export class AgentChatPersistenceManager {
     if (getUtf8ByteLength(baseNameWithPrefix) > SAFE_FILENAME_BYTE_LIMIT) {
       const availableForBasename = SAFE_FILENAME_BYTE_LIMIT - extensionBytes - filePrefixBytes;
       const truncatedBasename = truncateToByteLimit(sanitizedFileName, availableForBasename);
-      return `${getEffectiveConversationsFolder()}/${filePrefix}${truncatedBasename}.md`;
+      return joinPosix(folder, `${filePrefix}${truncatedBasename}.md`);
     }
 
-    return `${getEffectiveConversationsFolder()}/${baseNameWithPrefix}`;
+    return joinPosix(folder, baseNameWithPrefix);
   }
 
   private generateNoteContent(args: {

--- a/src/agentMode/session/AgentChatPersistenceManager.ts
+++ b/src/agentMode/session/AgentChatPersistenceManager.ts
@@ -1,7 +1,8 @@
 import { serializeFanoutComposite } from "@/agentMode/session/fanout/fanoutTypes";
-import { AGENT_CHAT_MODE, AI_SENDER, USER_SENDER } from "@/constants";
+import { AGENT_CHAT_MODE, AI_SENDER, COPILOT_CONVERSATION_TAG, USER_SENDER } from "@/constants";
 import { logError, logInfo, logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
+import { getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 import { FormattedDateTime } from "@/types/message";
 import {
   ensureFolderExists,
@@ -139,11 +140,10 @@ export class AgentChatPersistenceManager {
     if (messages.length === 0) return null;
 
     try {
-      const settings = getSettings();
       const chatContent = this.formatChatContent(messages);
       const firstMessageEpoch = messages[0].timestamp?.epoch ?? Date.now();
 
-      await ensureFolderExists(this.app.vault, settings.defaultSaveFolder);
+      await ensureFolderExists(this.app.vault, getEffectiveConversationsFolder());
 
       const existingFile = options?.existingPath
         ? this.resolveExistingFile(options.existingPath)
@@ -196,7 +196,7 @@ export class AgentChatPersistenceManager {
         }
         if (isNameTooLongError(err)) {
           logWarn("[AgentChatPersistenceManager] Filename too long, falling back to minimal name");
-          const fallback = `${settings.defaultSaveFolder}/${AGENT_FILENAME_PREFIX}chat-${firstMessageEpoch}.md`;
+          const fallback = `${getEffectiveConversationsFolder()}/${AGENT_FILENAME_PREFIX}chat-${firstMessageEpoch}.md`;
           try {
             const created = await this.app.vault.create(fallback, noteContent);
             return { path: created.path };
@@ -255,8 +255,7 @@ export class AgentChatPersistenceManager {
    * never collides with legacy or project chats.
    */
   async getAgentChatHistoryFiles(): Promise<TFile[]> {
-    const settings = getSettings();
-    const files = await listMarkdownFiles(this.app, settings.defaultSaveFolder);
+    const files = await listMarkdownFiles(this.app, getEffectiveConversationsFolder());
     return files.filter((file) => file.basename.startsWith(AGENT_FILENAME_PREFIX));
   }
 
@@ -474,10 +473,10 @@ export class AgentChatPersistenceManager {
     if (getUtf8ByteLength(baseNameWithPrefix) > SAFE_FILENAME_BYTE_LIMIT) {
       const availableForBasename = SAFE_FILENAME_BYTE_LIMIT - extensionBytes - filePrefixBytes;
       const truncatedBasename = truncateToByteLimit(sanitizedFileName, availableForBasename);
-      return `${settings.defaultSaveFolder}/${filePrefix}${truncatedBasename}.md`;
+      return `${getEffectiveConversationsFolder()}/${filePrefix}${truncatedBasename}.md`;
     }
 
-    return `${settings.defaultSaveFolder}/${baseNameWithPrefix}`;
+    return `${getEffectiveConversationsFolder()}/${baseNameWithPrefix}`;
   }
 
   private generateNoteContent(args: {
@@ -492,7 +491,6 @@ export class AgentChatPersistenceManager {
     projectId?: string;
     usage?: SessionUsage;
   }): string {
-    const settings = getSettings();
     const lines: string[] = [
       "---",
       `epoch: ${args.firstMessageEpoch}`,
@@ -516,7 +514,7 @@ export class AgentChatPersistenceManager {
     // parser (and our hand-rolled splitFrontmatter) verbatim.
     if (args.usage) lines.push(`usage: '${JSON.stringify(args.usage)}'`);
     lines.push("tags:");
-    lines.push(`  - ${settings.defaultConversationTag}`);
+    lines.push(`  - ${COPILOT_CONVERSATION_TAG}`);
     lines.push("---");
     lines.push("");
     lines.push(args.chatContent);

--- a/src/agentMode/skills/SkillManager.test.ts
+++ b/src/agentMode/skills/SkillManager.test.ts
@@ -30,6 +30,10 @@ jest.mock("@/settings/model", () => ({
   updateSetting: jest.fn(),
 }));
 
+jest.mock("@/settings/copilotFolder", () => ({
+  getEffectiveSkillsFolder: () => skillsFolder,
+}));
+
 jest.mock("./discoverManagedSkills", () => ({
   discoverManagedSkills: jest.fn(),
 }));

--- a/src/agentMode/skills/SkillManager.ts
+++ b/src/agentMode/skills/SkillManager.ts
@@ -1,5 +1,6 @@
 import { logError, logInfo, logWarn } from "@/logger";
 import { getSettings, updateSetting } from "@/settings/model";
+import { getEffectiveSkillsFolder } from "@/settings/copilotFolder";
 import { atom, createStore, useAtomValue } from "jotai";
 import { FileSystemAdapter, type App, type EventRef, type TAbstractFile } from "obsidian";
 import { normalizeAbsPath, parentDir } from "@/utils/pathUtils";
@@ -1211,16 +1212,13 @@ function stableHash(value: string): string {
 }
 
 /**
- * Resolve `agentMode.skills.folder` defensively. Settings validation
- * normally guarantees a well-formed value, but the UI may render before
- * settings hydration finishes; fall back to the default in that window.
+ * Resolve the effective skills folder, derived from the configurable copilotFolder
+ * root. Settings validation normally guarantees a well-formed root, but the UI may
+ * render before settings hydration finishes; the derivation falls back to the
+ * default in that window.
  */
 function resolveSkillsFolder(): string {
-  const raw = getSettings().agentMode?.skills?.folder;
-  if (typeof raw !== "string" || raw.trim().length === 0) {
-    return DEFAULT_SKILLS_FOLDER;
-  }
-  return raw;
+  return getEffectiveSkillsFolder();
 }
 
 /**

--- a/src/agentMode/skills/ui/SkillRow.test.tsx
+++ b/src/agentMode/skills/ui/SkillRow.test.tsx
@@ -5,6 +5,40 @@ import type { App } from "obsidian";
 import React from "react";
 import { SkillRow } from "./SkillRow";
 
+// The migration/consolidate paths resolve the destination from the derived
+// skills folder. Mock the accessor so a test can assert the confirm dialog
+// shows the derived path (and not the retired agentMode.skills.folder).
+const getEffectiveSkillsFolder = jest.fn(() => "copilot/skills");
+jest.mock("@/settings/copilotFolder", () => ({
+  getEffectiveSkillsFolder: () => getEffectiveSkillsFolder(),
+}));
+
+// Narrow SkillManager mock: only the members the consolidate path reads before
+// opening the confirm dialog. No disk, no real migration.
+const resolveCanonicalNameForMigration = jest.fn((name: string) => name);
+const getSuppressMigrationConfirm = jest.fn(() => false);
+jest.mock("@/agentMode/skills/SkillManager", () => ({
+  SkillManager: {
+    getInstance: () => ({
+      resolveCanonicalNameForMigration: (name: string) => resolveCanonicalNameForMigration(name),
+      getSuppressMigrationConfirm: () => getSuppressMigrationConfirm(),
+      consolidateMirroredSkill: jest.fn(),
+    }),
+  },
+}));
+
+// Capture the options the consolidate flow passes to the confirm modal so the
+// test can inspect the action lines without opening a real Obsidian modal.
+let lastMigrateModalOptions: { actionLines: { verb: string; detail: string }[] } | null = null;
+jest.mock("./MigrateSkillConfirmModal", () => ({
+  MigrateSkillConfirmModal: class {
+    constructor(_app: unknown, options: { actionLines: { verb: string; detail: string }[] }) {
+      lastMigrateModalOptions = options;
+    }
+    open = jest.fn();
+  },
+}));
+
 // Radix DropdownMenu portals resolve `activeDocument` at render time, and its
 // trigger relies on Pointer Capture + PointerEvent, neither of which jsdom
 // implements. Polyfill the minimum so the menu can actually open in the test.
@@ -56,34 +90,82 @@ function renderRow(onRevealInVault: () => void) {
   return { ...utils, containerRef };
 }
 
-describe("SkillRow overflow menu", () => {
-  afterEach(() => {
-    activeDocument.body.removeAttribute(SCROLL_LOCK_ATTR);
+describe("SkillRow", () => {
+  describe("overflow menu", () => {
+    afterEach(() => {
+      activeDocument.body.removeAttribute(SCROLL_LOCK_ATTR);
+    });
+
+    // Regression guard for issue #118: a modal dropdown engages
+    // react-remove-scroll's document-level wheel listener. "Reveal in vault"
+    // moves focus into the file-explorer leaf, which can interrupt the menu's
+    // close/unmount and strand that listener, killing wheel scrolling vault-wide
+    // until restart. Keeping the menu non-modal means the lock is never engaged.
+    it("does not engage a body scroll lock when the menu opens", () => {
+      renderRow(() => {});
+
+      openMenu();
+
+      // The menu is open (its items are mounted)…
+      expect(screen.getByText("Reveal in vault")).not.toBeNull();
+      // …but the body must not be scroll-locked.
+      expect(activeDocument.body.hasAttribute(SCROLL_LOCK_ATTR)).toBe(false);
+    });
+
+    it("invokes the reveal handler when Reveal in vault is selected", () => {
+      const onRevealInVault = jest.fn();
+      renderRow(onRevealInVault);
+
+      openMenu();
+      fireEvent.click(screen.getByText("Reveal in vault"));
+
+      expect(onRevealInVault).toHaveBeenCalledTimes(1);
+    });
   });
 
-  // Regression guard for issue #118: a modal dropdown engages
-  // react-remove-scroll's document-level wheel listener. "Reveal in vault"
-  // moves focus into the file-explorer leaf, which can interrupt the menu's
-  // close/unmount and strand that listener, killing wheel scrolling vault-wide
-  // until restart. Keeping the menu non-modal means the lock is never engaged.
-  it("does not engage a body scroll lock when the menu opens", () => {
-    renderRow(() => {});
+  describe("migrate-to-shared-folder confirmation", () => {
+    const mirroredSkill: Skill = {
+      name: "writing-helper",
+      description: "Helps with writing.",
+      filePath: "/vault/.claude/skills/writing-helper/SKILL.md",
+      dirPath: "/vault/.claude/skills/writing-helper",
+      body: "",
+      enabledAgents: [],
+      location: { kind: "project", agentDirs: ["claude", "codex"] },
+    };
 
-    openMenu();
+    function renderMirroredRow() {
+      const containerRef: React.RefObject<HTMLDivElement> = { current: null };
+      return render(
+        <AppContext.Provider value={{} as App}>
+          <div ref={containerRef} />
+          <SkillRow
+            skill={mirroredSkill}
+            agents={[]}
+            agentDirsProjectRel={{ claude: ".claude/skills", codex: ".codex/skills" }}
+            onRevealInVault={() => {}}
+            containerRef={containerRef}
+          />
+        </AppContext.Provider>
+      );
+    }
 
-    // The menu is open (its items are mounted)…
-    expect(screen.getByText("Reveal in vault")).not.toBeNull();
-    // …but the body must not be scroll-locked.
-    expect(activeDocument.body.hasAttribute(SCROLL_LOCK_ATTR)).toBe(false);
-  });
+    afterEach(() => {
+      lastMigrateModalOptions = null;
+    });
 
-  it("invokes the reveal handler when Reveal in vault is selected", () => {
-    const onRevealInVault = jest.fn();
-    renderRow(onRevealInVault);
+    it("targets the folder derived from the Copilot root, not the retired skills field", () => {
+      // Regression: the confirm dialog's Move line must point at the derived
+      // skills folder. A non-default root exposed the bug — the old resolver read
+      // agentMode.skills.folder, which no longer tracks the root.
+      getEffectiveSkillsFolder.mockReturnValue("team/copilot/skills");
+      renderMirroredRow();
 
-    openMenu();
-    fireEvent.click(screen.getByText("Reveal in vault"));
+      openMenu();
+      fireEvent.click(screen.getByText("Migrate to shared folder"));
 
-    expect(onRevealInVault).toHaveBeenCalledTimes(1);
+      const moveLine = lastMigrateModalOptions?.actionLines.find((line) => line.verb === "Move");
+      expect(moveLine?.detail).toContain("<vault>/team/copilot/skills/writing-helper/");
+    });
   });
 });

--- a/src/agentMode/skills/ui/SkillRow.tsx
+++ b/src/agentMode/skills/ui/SkillRow.tsx
@@ -13,8 +13,7 @@ import type { AgentBrand, BackendId } from "@/agentMode/session/types";
 import { Button } from "@/components/ui/button";
 import { useApp } from "@/context";
 import { logError } from "@/logger";
-import { getSettings } from "@/settings/model";
-import { DEFAULT_SKILLS_FOLDER } from "@/agentMode/skills/agentPaths";
+import { getEffectiveSkillsFolder } from "@/settings/copilotFolder";
 import { SkillManager } from "@/agentMode/skills/SkillManager";
 import { decideToggleAction } from "@/agentMode/skills/toggleDecision";
 import { formatSkillDisplayName } from "@/agentMode/skills/mergeDiscovery";
@@ -708,7 +707,5 @@ function buildConsolidateActionLines(args: BuildConsolidateLinesArgs): MigrateAc
  * falling back to the spec default when settings are missing.
  */
 function resolveCanonicalSkillsFolderRel(): string {
-  const folder = getSettings().agentMode?.skills?.folder;
-  if (typeof folder === "string" && folder.length > 0) return folder;
-  return DEFAULT_SKILLS_FOLDER;
+  return getEffectiveSkillsFolder();
 }

--- a/src/agentMode/skills/ui/SkillsSettings.test.tsx
+++ b/src/agentMode/skills/ui/SkillsSettings.test.tsx
@@ -1,0 +1,73 @@
+import { AppContext } from "@/context";
+import { DEFAULT_SETTINGS } from "@/constants";
+import { settingsAtom, settingsStore, updateSetting } from "@/settings/model";
+import { act, render, screen } from "@testing-library/react";
+import type { App } from "obsidian";
+import React from "react";
+import { SkillsSettings } from "./SkillsSettings";
+
+// The manager owns filesystem discovery and a live subscription store; stub the
+// singleton so the component renders in isolation while letting us observe the
+// refresh triggered by a derived-path change.
+const refresh = jest.fn().mockResolvedValue(undefined);
+const getAgentDirsProjectRel = jest.fn().mockReturnValue({});
+jest.mock("@/agentMode/skills/SkillManager", () => ({
+  SkillManager: { getInstance: () => ({ refresh, getAgentDirsProjectRel }) },
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
+  useManagedSkills: () => [],
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
+  useEpermSeen: () => false,
+  dismissEpermBanner: jest.fn(),
+}));
+
+// The registry pulls in every backend's icon/adapter chain; the row list is
+// empty in these tests, so an empty descriptor set keeps the surface minimal.
+jest.mock("@/agentMode/backends/registry", () => ({
+  listBackendDescriptors: () => [],
+}));
+
+function renderSettings() {
+  return render(
+    <AppContext.Provider value={{ vault: { adapter: {} } } as unknown as App}>
+      <SkillsSettings />
+    </AppContext.Provider>
+  );
+}
+
+describe("SkillsSettings", () => {
+  describe("SkillsSettings()", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, copilotFolder: "copilot" });
+    });
+
+    it("does not surface a Skills folder settings control (folder is root-derived, not user-editable)", () => {
+      renderSettings();
+      // The dedicated "Skills folder" setting row was removed: no editable input
+      // bound to the retired agentMode.skills.folder field, and no setting row.
+      expect(screen.queryByLabelText("Skills folder")).toBeNull();
+      expect(screen.queryByText("Skills folder")).toBeNull();
+    });
+
+    it("re-derives the discovered folder and re-scans when the Copilot root changes", () => {
+      renderSettings();
+      // Mount runs one discovery pass; the derived path surfaces in the
+      // empty-state hint (there is no folder-setting row).
+      expect(screen.getByText(/copilot\/skills/)).not.toBeNull();
+      expect(refresh).toHaveBeenCalledTimes(1);
+
+      // No manual rerender: useSettingsValue is a live jotai subscription, so
+      // the store update alone must re-render and re-scan. Asserting that here
+      // is what locks the reactive contract (a snapshot-only regression fails).
+      act(() => {
+        updateSetting("copilotFolder", "vault-tools");
+      });
+
+      expect(screen.getByText(/vault-tools\/skills/)).not.toBeNull();
+      expect(screen.queryByText(/copilot\/skills/)).toBeNull();
+      // The discovery pass re-runs so the list reflects the new derived folder;
+      // guards against the effect regressing to a stale/retired dependency.
+      expect(refresh).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/agentMode/skills/ui/SkillsSettings.tsx
+++ b/src/agentMode/skills/ui/SkillsSettings.tsx
@@ -1,4 +1,3 @@
-import { DEFAULT_SKILLS_FOLDER } from "@/agentMode/skills/agentPaths";
 import { formatSkillDisplayName } from "@/agentMode/skills/mergeDiscovery";
 import { listBackendDescriptors } from "@/agentMode/backends/registry";
 import type { AgentBrand } from "@/agentMode/session/types";
@@ -17,16 +16,14 @@ import {
 } from "@/agentMode/skills/SkillManager";
 import { SkillRow } from "./SkillRow";
 import { type Skill } from "@/agentMode/skills/types";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { SettingItem } from "@/components/ui/setting-item";
-import { SettingSection } from "@/components/ui/setting-section";
 import { cn } from "@/lib/utils";
-import { logError, logWarn } from "@/logger";
+import { logWarn } from "@/logger";
+import { deriveSkillsFolder } from "@/settings/copilotFolder";
 import { openWithSystemDefault } from "@/utils/openWithSystemDefault";
 import { getVaultBase, toVaultRelative } from "@/utils/vaultPath";
-import { updateSetting, useSettingsValue, validateSkillsFolder } from "@/settings/model";
-import { AlertTriangle, Folder, Search } from "lucide-react";
+import { useSettingsValue } from "@/settings/model";
+import { AlertTriangle, Search } from "lucide-react";
 import { App, FileSystemAdapter, Notice, TFile, TFolder } from "obsidian";
 import { useApp } from "@/context";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -45,9 +42,10 @@ const SYNC_BRANDS: ReadonlyArray<{ substr: string; brand: string }> = [
 /**
  * Skills tab.
  *
- * Renders the header copy, the Skills-folder setting row, the toolbar
- * (search + count), and either the empty placeholder or the Tidy list of
- * {@link SkillRow}s sourced from {@link SkillManager}.
+ * Renders the header copy, the toolbar (search + count), and either the
+ * empty placeholder or the Tidy list of {@link SkillRow}s sourced from
+ * {@link SkillManager}. The skills folder is root-derived and not editable
+ * here, so there is no folder-setting row.
  *
  * Discovery is fully automatic — the unified walker (canonical folder plus
  * every registered agent's project-skills directory) runs on every mount
@@ -62,6 +60,10 @@ const SYNC_BRANDS: ReadonlyArray<{ substr: string; brand: string }> = [
 export const SkillsSettings: React.FC = () => {
   const app = useApp();
   const settings = useSettingsValue();
+  // Skills live under the single configurable Copilot root. The derived path
+  // drives discovery (the effect below) and the empty-state hint; it is not
+  // user-editable here, so there is no folder-setting row.
+  const skillsFolder = deriveSkillsFolder(settings);
   // Brand projection of every registered backend. Sourced from the public
   // registry — descriptors are module-level constants so the list is stable
   // per session; the `useMemo` keeps the reference identity stable across
@@ -75,12 +77,9 @@ export const SkillsSettings: React.FC = () => {
       })),
     []
   );
-  const persistedFolder = settings.agentMode.skills.folder;
   const skills = useManagedSkills();
   const epermSeen = useEpermSeen();
 
-  const [draft, setDraft] = useState(persistedFolder);
-  const [validationError, setValidationError] = useState<string | null>(null);
   const [searchValue, setSearchValue] = useState("");
 
   // Anchor for Radix portals on this tab (e.g. SkillRow's overflow menu).
@@ -93,58 +92,13 @@ export const SkillsSettings: React.FC = () => {
   // EPERM banner. Neither persists across plugin reloads — by design.
   const [syncBannerDismissed, setSyncBannerDismissed] = useState(false);
 
-  // Keep the local draft in sync if persisted settings change underneath us
-  // (e.g. via Reset Settings). We don't want to clobber the user's in-flight
-  // typing, so only sync when the persisted value changes.
-  useEffect(() => {
-    /* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- resync the local draft when persisted settings change underneath us (e.g. Reset Settings); see comment above */
-    setDraft(persistedFolder);
-    setValidationError(null);
-    /* eslint-enable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
-  }, [persistedFolder]);
-
-  // Trigger a discovery pass on mount and on persisted-folder change so
-  // the list reflects whatever lives at the currently configured path.
-  // The unified walker pulls in canonical + every agent's project-skills
-  // dir in one pass.
+  // Trigger a discovery pass on mount and whenever the derived folder changes
+  // (e.g. the user moves the Copilot root) so the list reflects whatever lives
+  // at the currently configured path. The unified walker pulls in canonical +
+  // every agent's project-skills dir in one pass.
   useEffect(() => {
     void SkillManager.getInstance().refresh();
-  }, [persistedFolder]);
-
-  /** Validate the draft against `validateSkillsFolder`; updates inline error state. */
-  const validate = useCallback((value: string) => {
-    const result = validateSkillsFolder(value);
-    if (!result.ok) {
-      setValidationError(result.reason);
-      return null;
-    }
-    setValidationError(null);
-    return result.folder;
-  }, []);
-
-  /** Persist the draft when it is valid; called on blur and on Enter. */
-  const commit = useCallback(
-    (value: string) => {
-      const folder = validate(value);
-      if (folder === null) return;
-      if (folder === persistedFolder) return;
-      try {
-        updateSetting("agentMode", {
-          ...settings.agentMode,
-          skills: { ...settings.agentMode.skills, folder },
-        });
-      } catch (err) {
-        logError("Failed to persist skills folder", err);
-        new Notice("Failed to save skills folder. See console for details.");
-      }
-    },
-    [persistedFolder, settings.agentMode, validate]
-  );
-
-  /** Folder-picker icon button. Not wired yet — opens a notice telling the user to type the path. */
-  const handlePickFolder = useCallback(() => {
-    new Notice("Folder picker is not available yet — type the vault-relative path for now.");
-  }, []);
+  }, [skillsFolder]);
 
   /**
    * Open a SKILL.md (absolute path) for editing. Managed skills live inside
@@ -189,7 +143,7 @@ export const SkillsSettings: React.FC = () => {
 
   const filteredSkills = useMemo(() => filterSkills(skills, searchValue), [skills, searchValue]);
 
-  const displayFolder = persistedFolder.length > 0 ? persistedFolder : DEFAULT_SKILLS_FOLDER;
+  const displayFolder = skillsFolder;
 
   /**
    * Open the per-skill Properties modal. The modal owns its own save and
@@ -263,56 +217,6 @@ export const SkillsSettings: React.FC = () => {
             automatically.
           </div>
         </div>
-
-        <SettingSection>
-          <SettingItem
-            type="custom"
-            title="Skills folder"
-            description={
-              <div className="tw-flex tw-flex-col tw-gap-1">
-                <span>
-                  Where Copilot keeps the shared copy of every skill. Agent shortcuts point here.
-                  Changing this moves the folder and rewrites all shortcuts.
-                </span>
-                {validationError !== null && (
-                  <span className="tw-text-error">{validationError}</span>
-                )}
-              </div>
-            }
-          >
-            <div className="tw-flex tw-items-center tw-gap-2">
-              <Input
-                value={draft}
-                onChange={(e) => {
-                  const next = e.target.value;
-                  setDraft(next);
-                  validate(next);
-                }}
-                onBlur={(e) => commit(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    commit(draft);
-                    (e.target as HTMLInputElement).blur();
-                  }
-                }}
-                placeholder="copilot/skills"
-                className="!tw-w-56"
-                aria-label="Skills folder"
-                aria-invalid={validationError !== null}
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handlePickFolder}
-                title="Pick folder"
-                aria-label="Pick folder"
-              >
-                <Folder className="tw-size-4" />
-              </Button>
-            </div>
-          </SettingItem>
-        </SettingSection>
 
         {/* Durable banners — stack at the top of the tab body, above the toolbar. */}
         {(epermSeen || (syncBrand !== null && !syncBannerDismissed)) && (

--- a/src/commands/customCommandRegister.test.ts
+++ b/src/commands/customCommandRegister.test.ts
@@ -108,9 +108,7 @@ describe("customCommandRegister", () => {
         fetchAllCustomCommands.mockResolvedValue([command("New")]);
 
         settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("team/ai"));
-        jest.advanceTimersByTime(1000);
-        await Promise.resolve();
-        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(0);
 
         // Stale "Old" registration removed, "New" registered, cache replaced.
         expect(removeCommand).toHaveBeenCalledWith("copilot-command-Old");
@@ -120,9 +118,19 @@ describe("customCommandRegister", () => {
         expect(updateCachedCommands).toHaveBeenCalledWith([command("New")]);
       });
 
-      it("does not reload when the root — and thus the derived folder — is unchanged", () => {
+      it("starts the reload without waiting, so no timer delay keeps old commands live", () => {
+        // Any delay before the swap is a window in which a caller holding a
+        // command from the old folder writes it through the new live root.
+        fetchAllCustomCommands.mockResolvedValue([]);
+
+        settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("team/ai"));
+
+        expect(fetchAllCustomCommands).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not reload when the root — and thus the derived folder — is unchanged", async () => {
         settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("copilot"));
-        jest.advanceTimersByTime(1000);
+        await jest.advanceTimersByTimeAsync(1000);
 
         expect(fetchAllCustomCommands).not.toHaveBeenCalled();
       });
@@ -138,14 +146,11 @@ describe("customCommandRegister", () => {
 
         // Request A: folder change copilot -> a
         settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("a"));
-        jest.advanceTimersByTime(1000);
-        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(0);
 
         // Request B: folder change a -> b, resolves before A
         settingsChangeHandler(settingsWithRoot("a"), settingsWithRoot("b"));
-        jest.advanceTimersByTime(1000);
-        await Promise.resolve();
-        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(0);
 
         expect(updateCachedCommands).toHaveBeenCalledWith([command("Fresh")]);
         updateCachedCommands.mockClear();
@@ -222,8 +227,7 @@ describe("customCommandRegister", () => {
 
           // Kick off a reload; its fetch stays pending across teardown.
           settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("team/ai"));
-          jest.advanceTimersByTime(1000);
-          await Promise.resolve();
+          await jest.advanceTimersByTimeAsync(0);
 
           register.cleanup();
 

--- a/src/commands/customCommandRegister.test.ts
+++ b/src/commands/customCommandRegister.test.ts
@@ -1,0 +1,243 @@
+import { App, Plugin, Vault } from "obsidian";
+import { CustomCommandRegister } from "@/commands/customCommandRegister";
+import type { CustomCommand } from "@/commands/type";
+import type { CopilotSettings } from "@/settings/model";
+
+jest.mock("obsidian", () => ({
+  Plugin: jest.fn(),
+  Vault: jest.fn(),
+  TFile: jest.fn(),
+  normalizePath: (path: string) => path.replace(/\/+/g, "/").replace(/^\/|\/$/g, ""),
+}));
+
+jest.mock("@/logger", () => ({
+  logError: jest.fn(),
+}));
+
+jest.mock("@/commands/CustomCommandChatModal", () => ({
+  CustomCommandChatModal: jest.fn().mockImplementation(() => ({ open: jest.fn() })),
+}));
+
+jest.mock("@/commands/customCommandManager", () => ({
+  CustomCommandManager: {
+    getInstance: jest.fn(() => ({ recordUsage: jest.fn().mockResolvedValue(undefined) })),
+  },
+}));
+
+jest.mock("@/commands/customCommandUtils", () => ({
+  getCommandId: (title: string) => `copilot-command-${title}`,
+  isCustomCommandFile: jest.fn(() => true),
+  loadAllCustomCommands: jest.fn().mockResolvedValue([]),
+  fetchAllCustomCommands: jest.fn(),
+  parseCustomCommandFile: jest.fn(),
+  getNextCustomCommandOrder: jest.fn(() => 0),
+  ensureCommandFrontmatter: jest.fn(),
+  hasOrderFrontmatter: jest.fn(() => true),
+}));
+
+jest.mock("@/commands/state", () => ({
+  deleteCachedCommand: jest.fn(),
+  getCachedCustomCommands: jest.fn(() => []),
+  isFileWritePending: jest.fn(() => false),
+  updateCachedCommand: jest.fn(),
+  updateCachedCommands: jest.fn(),
+}));
+
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({ copilotFolder: "copilot" })),
+  subscribeToSettingsChange: jest.fn().mockReturnValue(() => {}),
+}));
+
+function command(title: string): CustomCommand {
+  return {
+    title,
+    content: "",
+    modelKey: "",
+    showInContextMenu: false,
+    showInSlashMenu: false,
+    order: 0,
+    lastUsedMs: 0,
+  };
+}
+
+function settingsWithRoot(copilotFolder: string): CopilotSettings {
+  return { copilotFolder } as CopilotSettings;
+}
+
+describe("customCommandRegister", () => {
+  describe("CustomCommandRegister", () => {
+    describe("handleSettingsChange()", () => {
+      let settingsChangeHandler: (prev: CopilotSettings, next: CopilotSettings) => void;
+      let unsubscribe: jest.Mock;
+      let addCommand: jest.Mock;
+      let removeCommand: jest.Mock;
+      let fetchAllCustomCommands: jest.Mock;
+      let getCachedCustomCommands: jest.Mock;
+      let updateCachedCommands: jest.Mock;
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+
+        ({ fetchAllCustomCommands } = jest.requireMock("@/commands/customCommandUtils"));
+        ({ getCachedCustomCommands, updateCachedCommands } = jest.requireMock("@/commands/state"));
+
+        unsubscribe = jest.fn();
+        const { subscribeToSettingsChange } = jest.requireMock<{
+          subscribeToSettingsChange: jest.Mock;
+        }>("@/settings/model");
+        subscribeToSettingsChange.mockReturnValue(unsubscribe);
+
+        addCommand = jest.fn();
+        removeCommand = jest.fn();
+        const mockPlugin = { addCommand, removeCommand, app: {} } as unknown as Plugin;
+        const mockVault = { on: jest.fn(), off: jest.fn() } as unknown as Vault;
+
+        new CustomCommandRegister(mockPlugin, { vault: mockVault } as unknown as App);
+
+        settingsChangeHandler = subscribeToSettingsChange.mock
+          .calls[0][0] as typeof settingsChangeHandler;
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it("reloads registrations when the derived folder changes because the root changed", async () => {
+        getCachedCustomCommands.mockReturnValue([command("Old")]);
+        fetchAllCustomCommands.mockResolvedValue([command("New")]);
+
+        settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("team/ai"));
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Stale "Old" registration removed, "New" registered, cache replaced.
+        expect(removeCommand).toHaveBeenCalledWith("copilot-command-Old");
+        expect(addCommand).toHaveBeenCalledWith(
+          expect.objectContaining({ id: "copilot-command-New", name: "New" })
+        );
+        expect(updateCachedCommands).toHaveBeenCalledWith([command("New")]);
+      });
+
+      it("does not reload when the root — and thus the derived folder — is unchanged", () => {
+        settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("copilot"));
+        jest.advanceTimersByTime(1000);
+
+        expect(fetchAllCustomCommands).not.toHaveBeenCalled();
+      });
+
+      it("discards a superseded reload so its stale commands never reach the cache", async () => {
+        let resolveStale: (value: CustomCommand[]) => void = () => {};
+        const stalePromise = new Promise<CustomCommand[]>((r) => {
+          resolveStale = r;
+        });
+        fetchAllCustomCommands
+          .mockReturnValueOnce(stalePromise) // request A (stale)
+          .mockResolvedValueOnce([command("Fresh")]); // request B (latest)
+
+        // Request A: folder change copilot -> a
+        settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("a"));
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+
+        // Request B: folder change a -> b, resolves before A
+        settingsChangeHandler(settingsWithRoot("a"), settingsWithRoot("b"));
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(updateCachedCommands).toHaveBeenCalledWith([command("Fresh")]);
+        updateCachedCommands.mockClear();
+
+        // Now the stale request A resolves — it must be discarded.
+        resolveStale([command("Stale")]);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(updateCachedCommands).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("cleanup()", () => {
+      it("unsubscribes from settings changes on teardown", () => {
+        const unsubscribe = jest.fn();
+        const { subscribeToSettingsChange } = jest.requireMock<{
+          subscribeToSettingsChange: jest.Mock;
+        }>("@/settings/model");
+        subscribeToSettingsChange.mockReturnValue(unsubscribe);
+
+        const mockPlugin = {
+          addCommand: jest.fn(),
+          removeCommand: jest.fn(),
+          app: {},
+        } as unknown as Plugin;
+        const mockVault = { on: jest.fn(), off: jest.fn() } as unknown as Vault;
+        const register = new CustomCommandRegister(mockPlugin, {
+          vault: mockVault,
+        } as unknown as App);
+
+        register.cleanup();
+
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+      });
+
+      it("discards an in-flight reload that resolves after teardown so it never registers commands or writes the cache", async () => {
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+        try {
+          const { fetchAllCustomCommands } = jest.requireMock<{
+            fetchAllCustomCommands: jest.Mock;
+          }>("@/commands/customCommandUtils");
+          const { getCachedCustomCommands, updateCachedCommands } = jest.requireMock<{
+            getCachedCustomCommands: jest.Mock;
+            updateCachedCommands: jest.Mock;
+          }>("@/commands/state");
+          getCachedCustomCommands.mockReturnValue([]);
+
+          let resolveFetch: (value: CustomCommand[]) => void = () => {};
+          fetchAllCustomCommands.mockReturnValue(
+            new Promise<CustomCommand[]>((r) => {
+              resolveFetch = r;
+            })
+          );
+
+          const { subscribeToSettingsChange } = jest.requireMock<{
+            subscribeToSettingsChange: jest.Mock;
+          }>("@/settings/model");
+          subscribeToSettingsChange.mockReturnValue(() => {});
+
+          const addCommand = jest.fn();
+          const removeCommand = jest.fn();
+          const mockPlugin = { addCommand, removeCommand, app: {} } as unknown as Plugin;
+          const mockVault = { on: jest.fn(), off: jest.fn() } as unknown as Vault;
+          const register = new CustomCommandRegister(mockPlugin, {
+            vault: mockVault,
+          } as unknown as App);
+
+          const settingsChangeHandler = subscribeToSettingsChange.mock.calls[0][0] as (
+            prev: CopilotSettings,
+            next: CopilotSettings
+          ) => void;
+
+          // Kick off a reload; its fetch stays pending across teardown.
+          settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("team/ai"));
+          jest.advanceTimersByTime(1000);
+          await Promise.resolve();
+
+          register.cleanup();
+
+          // The fetch resolves only after teardown; the disposed guard must drop it.
+          resolveFetch([command("Late")]);
+          await Promise.resolve();
+          await Promise.resolve();
+
+          expect(addCommand).not.toHaveBeenCalled();
+          expect(updateCachedCommands).not.toHaveBeenCalled();
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+    });
+  });
+});

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -67,7 +67,6 @@ export class CustomCommandRegister {
     // cache after teardown.
     this.disposed = true;
     ++this.folderChangeRequestId;
-    this.debouncedFolderChange.cancel();
     this.settingsUnsubscriber?.();
     this.vault.off("create", this.handleFileCreation);
     this.vault.off("delete", this.handleFileDeletion);
@@ -94,18 +93,13 @@ export class CustomCommandRegister {
   ): void => {
     // Reason: the folder is derived from copilotFolder; compare derived paths.
     if (deriveCustomPromptsFolder(prev) !== deriveCustomPromptsFolder(next)) {
-      this.debouncedFolderChange();
+      // Started immediately, not debounced: the root is committed through an
+      // explicit Apply + Confirm, so there is no keystroke burst to absorb, and
+      // every millisecond of delay is a millisecond in which a caller holding a
+      // command from the old folder can write it through the new one.
+      void this.handleFolderChange();
     }
   };
-
-  /** Debounced folder-change reload (avoid rapid-fire while the root is edited). */
-  private debouncedFolderChange = debounce(
-    () => {
-      void this.handleFolderChange();
-    },
-    1000,
-    { leading: false, trailing: true }
-  );
 
   /**
    * Reload command registrations after the folder changes, using a pure fetch
@@ -122,8 +116,8 @@ export class CustomCommandRegister {
    * snapshot predates that command, so the atomic-swap phase treats it as stale,
    * removes its registration, and `updateCachedCommands` overwrites it out of the
    * cache.
-   * (a) Trigger: a command file created concurrently inside the change-root
-   *     debounce + fetch window.
+   * (a) Trigger: a command file created concurrently inside the root-change
+   *     fetch window.
    * (b) Consequence: that command is briefly cleared by this swap; the next vault
    *     event targeting the same file (modify/create/delete) re-registers it, so
    *     the state self-heals.

--- a/src/commands/customCommandRegister.ts
+++ b/src/commands/customCommandRegister.ts
@@ -2,6 +2,7 @@ import {
   getCommandId,
   isCustomCommandFile,
   loadAllCustomCommands,
+  fetchAllCustomCommands,
   parseCustomCommandFile,
   getNextCustomCommandOrder,
   ensureCommandFrontmatter,
@@ -16,8 +17,11 @@ import {
   getCachedCustomCommands,
   isFileWritePending,
   updateCachedCommand,
+  updateCachedCommands,
 } from "@/commands/state";
 import { CustomCommandManager } from "@/commands/customCommandManager";
+import { getSettings, subscribeToSettingsChange } from "@/settings/model";
+import { deriveCustomPromptsFolder } from "@/settings/copilotFolder";
 import { logError } from "@/logger";
 
 /** This manager is used to register custom commands as obsidian commands */
@@ -25,6 +29,11 @@ export class CustomCommandRegister {
   private plugin: Plugin;
   private app: App;
   private vault: Vault;
+  private settingsUnsubscriber?: () => void;
+  /** Monotonic request id for latest-wins semantics on folder change. */
+  private folderChangeRequestId = 0;
+  /** Set once {@link cleanup} runs so an in-flight reload cannot touch a torn-down instance. */
+  private disposed = false;
 
   constructor(plugin: Plugin, app: App) {
     this.plugin = plugin;
@@ -53,6 +62,13 @@ export class CustomCommandRegister {
    * Clean up resources used by the cache
    */
   cleanup() {
+    // Reason: mark disposed and bump the request id so any reload awaiting a
+    // fetch bails out before it can register commands or write the module-level
+    // cache after teardown.
+    this.disposed = true;
+    ++this.folderChangeRequestId;
+    this.debouncedFolderChange.cancel();
+    this.settingsUnsubscriber?.();
     this.vault.off("create", this.handleFileCreation);
     this.vault.off("delete", this.handleFileDeletion);
     this.vault.off("rename", this.handleFileRename);
@@ -64,6 +80,92 @@ export class CustomCommandRegister {
     this.vault.on("delete", this.handleFileDeletion);
     this.vault.on("rename", this.handleFileRename);
     this.vault.on("modify", this.handleFileModify);
+    this.settingsUnsubscriber = subscribeToSettingsChange(this.handleSettingsChange);
+  }
+
+  /**
+   * React to a change in the derived custom-commands folder (driven by the
+   * configurable copilotFolder root). Reloads command registrations from the
+   * new folder while old files stay in place.
+   */
+  private handleSettingsChange = (
+    prev: ReturnType<typeof getSettings>,
+    next: ReturnType<typeof getSettings>
+  ): void => {
+    // Reason: the folder is derived from copilotFolder; compare derived paths.
+    if (deriveCustomPromptsFolder(prev) !== deriveCustomPromptsFolder(next)) {
+      this.debouncedFolderChange();
+    }
+  };
+
+  /** Debounced folder-change reload (avoid rapid-fire while the root is edited). */
+  private debouncedFolderChange = debounce(
+    () => {
+      void this.handleFolderChange();
+    },
+    1000,
+    { leading: false, trailing: true }
+  );
+
+  /**
+   * Reload command registrations after the folder changes, using a pure fetch
+   * followed by an atomic swap so a superseded reload cannot register commands
+   * from a stale folder or clobber a newer cache.
+   *
+   * Reason: `loadAllCustomCommands` writes the global cache before returning, so
+   * an in-flight stale reload would pollute the cache even behind a request-id
+   * guard. Fetching without touching the cache, then checking the generation
+   * before mutating registrations, keeps only the latest reload's effect.
+   *
+   * DESIGN NOTE (scan-race, accepted): if a `handleFileCreation` registers a new
+   * command file and writes the cache while this fetch is in flight, the fetch
+   * snapshot predates that command, so the atomic-swap phase treats it as stale,
+   * removes its registration, and `updateCachedCommands` overwrites it out of the
+   * cache.
+   * (a) Trigger: a command file created concurrently inside the change-root
+   *     debounce + fetch window.
+   * (b) Consequence: that command is briefly cleared by this swap; the next vault
+   *     event targeting the same file (modify/create/delete) re-registers it, so
+   *     the state self-heals.
+   * (c) Why not fixed: a real fix needs a vault-mutation generation counter; that
+   *     machinery is disproportionate to a window that is both narrow (root change
+   *     overlapping a concurrent command-file create) and self-healing.
+   * (d) If a future review flags this again, point them at this note.
+   */
+  private async handleFolderChange(): Promise<void> {
+    const currentRequestId = ++this.folderChangeRequestId;
+
+    try {
+      const nextCommands = await fetchAllCustomCommands(this.app);
+
+      // Bail out if the instance was torn down while this fetch was in flight;
+      // registering commands or writing the cache post-teardown would leak state.
+      if (this.disposed) return;
+
+      // Latest-wins: a newer folder change started while this fetch was in flight.
+      if (currentRequestId !== this.folderChangeRequestId) return;
+
+      // Atomically swap registrations: drop commands no longer present, then
+      // (re)register the current set, then replace the cache in one step.
+      const nextTitles = new Set(nextCommands.map((command) => command.title));
+      for (const stale of getCachedCustomCommands()) {
+        if (!nextTitles.has(stale.title)) {
+          this.removeRegisteredCommand(stale.title);
+        }
+      }
+      nextCommands.forEach((command) => this.registerCommand(command));
+      updateCachedCommands(nextCommands);
+    } catch (error) {
+      // Latest-wins guard: ignore a stale failure resolved after a newer reload.
+      if (currentRequestId !== this.folderChangeRequestId) return;
+      logError("Error reloading custom commands after folder change", error);
+    }
+  }
+
+  /** Remove a registered obsidian command by its command title. */
+  private removeRegisteredCommand(title: string): void {
+    const commandId = getCommandId(title);
+    (this.plugin as unknown as { removeCommand: (id: string) => void }).removeCommand(commandId);
   }
 
   private handleFileModify = debounce(

--- a/src/commands/customCommandUtils.ts
+++ b/src/commands/customCommandUtils.ts
@@ -9,8 +9,9 @@ import {
 } from "@/commands/constants";
 import { CustomCommand } from "@/commands/type";
 import { logWarn } from "@/logger";
-import { App, normalizePath, Notice, TAbstractFile, TFile, Vault } from "obsidian";
+import { App, Notice, TAbstractFile, TFile, Vault } from "obsidian";
 import { getSettings } from "@/settings/model";
+import { getEffectiveCustomPromptsFolder } from "@/settings/copilotFolder";
 import {
   updateCachedCommands,
   getCachedCustomCommands,
@@ -76,7 +77,7 @@ export function getCommandId(commandName: string) {
 }
 
 export function getCustomCommandsFolder(): string {
-  return normalizePath(getSettings().customPromptsFolder);
+  return getEffectiveCustomPromptsFolder();
 }
 
 export function getCommandFilePath(title: string): string {
@@ -129,11 +130,18 @@ export async function parseCustomCommandFile(app: App, file: TFile): Promise<Cus
   };
 }
 
-export async function loadAllCustomCommands(app: App): Promise<CustomCommand[]> {
+/**
+ * Fetch all custom commands from the vault WITHOUT writing the global cache.
+ * Use this when the caller must coordinate cache writes itself (e.g. latest-wins
+ * folder reloads) so a superseded async reload cannot clobber a newer result.
+ */
+export async function fetchAllCustomCommands(app: App): Promise<CustomCommand[]> {
   const files = app.vault.getFiles().filter((file) => isCustomCommandFile(file));
-  const commands: CustomCommand[] = await Promise.all(
-    files.map((file) => parseCustomCommandFile(app, file))
-  );
+  return await Promise.all(files.map((file) => parseCustomCommandFile(app, file)));
+}
+
+export async function loadAllCustomCommands(app: App): Promise<CustomCommand[]> {
+  const commands = await fetchAllCustomCommands(app);
   updateCachedCommands(commands);
   return commands;
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -27,6 +27,7 @@ import { getSearchBackend } from "@/miyo/miyoUtils";
 import { getAllQAMarkdownContent } from "@/search/searchUtils";
 import { NoteSelectedTextContext, WebSelectedTextContext } from "@/types/message";
 import { ensureFolderExists, isSourceModeOn } from "@/utils";
+import { getEffectiveCopilotFolder } from "@/settings/copilotFolder";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { Editor, MarkdownView, Notice, TFile } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
@@ -409,7 +410,7 @@ export function registerCommands(plugin: CopilotPlugin, publish: PublishFile) {
 
       // Create or update the file in the vault
       const fileName = `Copilot-Indexed-Files-${new Date().toLocaleDateString().replace(/\//g, "-")}.md`;
-      const folderPath = "copilot";
+      const folderPath = getEffectiveCopilotFolder();
       const filePath = `${folderPath}/${fileName}`;
 
       // Ensure destination folder exists (supports mobile and nested)
@@ -484,7 +485,7 @@ export function registerCommands(plugin: CopilotPlugin, publish: PublishFile) {
 
       // Create the debug file
       const fileName = `Copilot-Embedding-Debug-${activeFile.basename.replace(/[\\/:*?"<>|]/g, "_")}.md`;
-      const folderPath = "copilot";
+      const folderPath = getEffectiveCopilotFolder();
       const filePath = `${folderPath}/${fileName}`;
 
       await ensureFolderExists(plugin.app.vault, folderPath);

--- a/src/components/chat-components/hooks/useAtMentionSearch.ts
+++ b/src/components/chat-components/hooks/useAtMentionSearch.ts
@@ -16,7 +16,7 @@ import {
   CategoryOption,
   EMPTY_AGENT_MENTION_BRANDS,
 } from "./useAtMentionCategories";
-import { getSettings } from "@/settings/model";
+import { getEffectiveCustomPromptsFolder } from "@/settings/copilotFolder";
 import { SelfHostCloudWarningIcon } from "@/components/ui/SelfHostCloudWarningIcon";
 
 // Maximum number of results to show in @ mention search
@@ -273,7 +273,7 @@ export function useAtMentionSearch(
       if (!query) {
         // For notes category with no query, rank custom command notes lower
         if (selectedCategory === "notes") {
-          const customPromptsFolder = getSettings().customPromptsFolder;
+          const customPromptsFolder = getEffectiveCustomPromptsFolder();
           const regularNotes = items.filter(
             (item) =>
               !(

--- a/src/components/chat-components/hooks/useNoteSearch.ts
+++ b/src/components/chat-components/hooks/useNoteSearch.ts
@@ -4,7 +4,7 @@ import { FileText, FileClock } from "lucide-react";
 import fuzzysort from "fuzzysort";
 import { useAllNotes } from "./useAllNotes";
 import { TypeaheadOption } from "@/components/chat-components/TypeaheadMenuContent";
-import { getSettings } from "@/settings/model";
+import { getEffectiveCustomPromptsFolder } from "@/settings/copilotFolder";
 
 export interface NoteSearchOption extends TypeaheadOption {
   file: TFile;
@@ -61,7 +61,7 @@ export function useNoteSearch(
   // Filter and search notes based on query (name only)
   const searchResults = useMemo(() => {
     const mergedConfig = { ...DEFAULT_CONFIG, ...config };
-    const customPromptsFolder = getSettings().customPromptsFolder;
+    const customPromptsFolder = getEffectiveCustomPromptsFolder();
 
     // If no query, return first N notes with custom command notes ranked lower
     if (!query.trim()) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,6 +46,9 @@ export const AI_SENDER = "ai";
 
 // Default folder names
 export const COPILOT_FOLDER_ROOT = "copilot";
+// Configurable root all Copilot sub-folders derive from (PR-乙). Defaults to
+// the historical hardcoded root so existing vaults keep their layout.
+export const DEFAULT_COPILOT_FOLDER = COPILOT_FOLDER_ROOT;
 const DEFAULT_CHAT_HISTORY_FOLDER = `${COPILOT_FOLDER_ROOT}/copilot-conversations`;
 const DEFAULT_CUSTOM_PROMPTS_FOLDER = `${COPILOT_FOLDER_ROOT}/copilot-custom-prompts`;
 const DEFAULT_MEMORY_FOLDER = `${COPILOT_FOLDER_ROOT}/memory`;
@@ -53,6 +56,12 @@ const DEFAULT_SYSTEM_PROMPTS_FOLDER = `${COPILOT_FOLDER_ROOT}/system-prompts`;
 const DEFAULT_PROJECTS_FOLDER = `${COPILOT_FOLDER_ROOT}/projects`;
 export const DEFAULT_SKILLS_FOLDER = `${COPILOT_FOLDER_ROOT}/skills`;
 const DEFAULT_CONVERTED_DOC_OUTPUT_FOLDER = "";
+// Built-in tag written into every saved conversation's frontmatter. Frozen as a
+// constant (no longer user-configurable): no code reads the tag to identify
+// conversations — they are keyed by folder + epoch — so it only serves as a
+// stable, filterable marker. The legacy `defaultConversationTag` setting is kept
+// as a dead field for schema compatibility but is no longer read.
+export const COPILOT_CONVERSATION_TAG = "copilot-conversation";
 export const DEFAULT_QA_EXCLUSIONS_SETTING = COPILOT_FOLDER_ROOT;
 export const DEFAULT_SYSTEM_PROMPT = `You are Obsidian Copilot, a helpful assistant that integrates AI to Obsidian note-taking.
   1. Never mention that you do not have access to something. Always rely on the user provided context.
@@ -996,6 +1005,14 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   openAIProxyBaseUrl: "",
   openAIEmbeddingProxyBaseUrl: "",
   stream: true,
+  copilotFolder: DEFAULT_COPILOT_FOLDER,
+  // Every folder ever activated as the Copilot root (seeded with the legacy
+  // root in the v8 migration). Kept append-only so each historical root stays
+  // permanently excluded from QA indexing even after the root is changed.
+  copilotRootHistory: [],
+  // True only when a legacy (v1-v7) vault was migrated to v8; WS-D reads it to
+  // decide whether to show the one-time folder-relocation prompt, then clears it.
+  upgradedToV8FromLegacy: false,
   defaultSaveFolder: DEFAULT_CHAT_HISTORY_FOLDER,
   defaultConversationTag: "copilot-conversation",
   autosaveChat: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,10 +57,18 @@ const DEFAULT_PROJECTS_FOLDER = `${COPILOT_FOLDER_ROOT}/projects`;
 export const DEFAULT_SKILLS_FOLDER = `${COPILOT_FOLDER_ROOT}/skills`;
 const DEFAULT_CONVERTED_DOC_OUTPUT_FOLDER = "";
 // Built-in tag written into every saved conversation's frontmatter. Frozen as a
-// constant (no longer user-configurable): no code reads the tag to identify
-// conversations — they are keyed by folder + epoch — so it only serves as a
-// stable, filterable marker. The legacy `defaultConversationTag` setting is kept
-// as a dead field for schema compatibility but is no longer read.
+// constant: no code reads the tag to identify conversations — they are keyed by
+// folder + epoch — so built-in history is unaffected by the freeze.
+//
+// DESIGN NOTE (accepted compatibility break): a vault that had customized the
+// old `defaultConversationTag` keeps that value in data.json, but it is no
+// longer read, and existing notes are never rewritten. Such a vault therefore
+// ends up with two markers, and the user's own tag-based queries, searches and
+// automations see only the older half. That cost was accepted deliberately to
+// converge on one built-in marker; grandfathering the persisted value was
+// rejected because a hidden setting would then steer output forever. Batch
+// remediation is tracked in obsidian-copilot-preview#224.
+// If a future review flags this again, point them at this note.
 export const COPILOT_CONVERSATION_TAG = "copilot-conversation";
 export const DEFAULT_QA_EXCLUSIONS_SETTING = COPILOT_FOLDER_ROOT;
 export const DEFAULT_SYSTEM_PROMPT = `You are Obsidian Copilot, a helpful assistant that integrates AI to Obsidian note-taking.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1059,6 +1059,7 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   selfHostUrl: "",
   selfHostApiKey: "",
   miyoServerUrl: "",
+  miyoSyncedExclusions: "",
   selfHostSearchProvider: "firecrawl",
   firecrawlApiKey: "",
   perplexityApiKey: "",

--- a/src/core/ChatPersistenceManager.test.ts
+++ b/src/core/ChatPersistenceManager.test.ts
@@ -4,6 +4,7 @@ import { App, Notice, TFile } from "obsidian";
 import type { MessageRepository } from "./MessageRepository";
 import { ChatPersistenceManager } from "./ChatPersistenceManager";
 import { mockTFile } from "@/__tests__/mockObsidian";
+import { getSettings } from "@/settings/model";
 
 const USER_SENDER = "user";
 const AI_SENDER = "ai";
@@ -28,6 +29,9 @@ jest.mock("@/settings/model", () => ({
     defaultConversationTag: "copilot-conversation",
     defaultConversationNoteName: "{$topic}@{$date}_{$time}",
   }),
+}));
+jest.mock("@/settings/copilotFolder", () => ({
+  getEffectiveConversationsFolder: jest.fn(() => "test-folder"),
 }));
 jest.mock("@/aiParams", () => ({
   getCurrentProject: jest.fn().mockReturnValue(null),
@@ -1586,6 +1590,35 @@ tags:
       const lines = noteContent.split("\n");
       const modelKeyLine = lines.find((line: string) => line.startsWith("modelKey:"));
       expect(modelKeyLine).toBe('modelKey: "model\\\\with\\\\backslash|provider"');
+    });
+  });
+
+  describe("frozen conversation tag", () => {
+    it("writes the built-in tag independent of the persisted defaultConversationTag", () => {
+      // The tag is frozen to a constant. Feed a custom setting value: if a
+      // regression made generateNoteContent read the setting again, the custom
+      // value would leak into the note and fail the assertion below.
+      const gs = getSettings as jest.Mock;
+      gs.mockReturnValue({
+        defaultSaveFolder: "test-folder",
+        defaultConversationTag: "user-custom-tag",
+        defaultConversationNoteName: "{$topic}@{$date}_{$time}",
+      });
+      try {
+        const noteContent = asInternal(persistenceManager).generateNoteContent(
+          "**user**: hi",
+          1695513480000,
+          "gpt-4"
+        );
+        expect(noteContent).toContain("tags:\n  - copilot-conversation");
+        expect(noteContent).not.toContain("user-custom-tag");
+      } finally {
+        gs.mockReturnValue({
+          defaultSaveFolder: "test-folder",
+          defaultConversationTag: "copilot-conversation",
+          defaultConversationNoteName: "{$topic}@{$date}_{$time}",
+        });
+      }
     });
   });
 

--- a/src/core/ChatPersistenceManager.test.ts
+++ b/src/core/ChatPersistenceManager.test.ts
@@ -5,6 +5,8 @@ import type { MessageRepository } from "./MessageRepository";
 import { ChatPersistenceManager } from "./ChatPersistenceManager";
 import { mockTFile } from "@/__tests__/mockObsidian";
 import { getSettings } from "@/settings/model";
+import { getEffectiveConversationsFolder } from "@/settings/copilotFolder";
+import { ensureFolderExists } from "@/utils";
 
 const USER_SENDER = "user";
 const AI_SENDER = "ai";
@@ -112,7 +114,7 @@ type MockApp = {
     };
   };
   metadataCache: { getFileCache: jest.Mock };
-  fileManager: { processFrontMatter: jest.Mock };
+  fileManager: { processFrontMatter: jest.Mock; renameFile: jest.Mock };
 };
 
 type MockMessageRepo = { getDisplayMessages: jest.Mock };
@@ -148,6 +150,7 @@ describe("ChatPersistenceManager", () => {
       },
       fileManager: {
         processFrontMatter: jest.fn(),
+        renameFile: jest.fn(),
       },
     };
 
@@ -376,6 +379,48 @@ Nature's quiet song`);
       );
       const savedContent = mockApp.vault.create.mock.calls[0][1] as string;
       expect(savedContent).not.toContain("topic:");
+    });
+
+    it("writes under the folder captured at entry, not one a mid-save root change swaps in", async () => {
+      // The folder is captured once at entry and threaded through ensure, the
+      // existing-file lookup, filename generation, and the conflict/fallback
+      // paths. Simulate a Copilot-root change landing after the save starts:
+      // the entry read returns the old folder, every later read the new one.
+      // The created path must stay under the old folder — the save must not
+      // ensure one directory and then create the file under another.
+      // Only override the entry read; later reads fall back to the default
+      // mock ("test-folder"), so this can't leak a permanent return value into
+      // sibling tests. The created path must stay under the entry-captured
+      // "old-folder", proving the save doesn't re-resolve mid-operation.
+      const folderMock = jest.mocked(getEffectiveConversationsFolder);
+      folderMock.mockReturnValueOnce("old-folder");
+
+      const messages: ChatMessage[] = [
+        {
+          id: "1",
+          message: "Hello",
+          sender: USER_SENDER,
+          timestamp: {
+            epoch: 1695513480000,
+            display: "2024/09/23 22:18:00",
+            fileName: "2024_09_23_221800",
+          },
+          isVisible: true,
+        },
+      ];
+      mockMessageRepo.getDisplayMessages.mockReturnValue(messages);
+      // No existing file, folder empty, target path free → single clean create.
+      mockApp.vault.getMarkdownFiles.mockReturnValue([]);
+      mockApp.vault.getAbstractFileByPath.mockReturnValue(null);
+      mockApp.vault.adapter.exists.mockResolvedValue(false);
+
+      await persistenceManager.saveChat("gpt-4");
+
+      const createdPath = mockApp.vault.create.mock.calls[0][0] as string;
+      expect(createdPath.startsWith("old-folder/")).toBe(true);
+      expect(createdPath).not.toContain("test-folder");
+      // ensureFolderExists must target the same captured folder.
+      expect(ensureFolderExists).toHaveBeenCalledWith(expect.anything(), "old-folder");
     });
 
     it("should use AI topic text from structured responses without object artifacts", async () => {
@@ -1746,6 +1791,42 @@ tags:
       );
 
       getFilesSpy.mockRestore();
+    });
+  });
+
+  describe("renameFileToMatchTopic", () => {
+    beforeEach(() => {
+      // A fixed topic → deterministic target basename; the folder comes from the
+      // file's own path, which is what these tests exercise.
+      mockMessageRepo.getDisplayMessages.mockReturnValue([]);
+      jest
+        .mocked(getEffectiveConversationsFolder)
+        .mockReturnValue("live-root/copilot-conversations");
+    });
+
+    it("keeps a nested chat in its own folder, ignoring the live root", async () => {
+      const file = mockTFile({ path: "old-root/copilot-conversations/chat.md" });
+      mockApp.metadataCache.getFileCache.mockReturnValue({ frontmatter: { epoch: 1695513480000 } });
+
+      await persistenceManager.renameFileToMatchTopic(null, file, "New Topic");
+
+      const newPath = mockApp.fileManager.renameFile.mock.calls[0][1] as string;
+      expect(newPath.startsWith("old-root/copilot-conversations/")).toBe(true);
+      // Must not follow the (changed) live root.
+      expect(newPath).not.toContain("live-root");
+    });
+
+    it("does not produce a leading slash when renaming a vault-root file", async () => {
+      // Hidden-directory chats use synthetic TFiles with parent === null; a
+      // top-level path has no slash, so the parent folder is empty. The result
+      // must be a bare vault-root name, never "/name.md".
+      const file = mockTFile({ path: "chat.md" });
+      mockApp.metadataCache.getFileCache.mockReturnValue({ frontmatter: { epoch: 1695513480000 } });
+
+      await persistenceManager.renameFileToMatchTopic(null, file, "New Topic");
+
+      const newPath = mockApp.fileManager.renameFile.mock.calls[0][1] as string;
+      expect(newPath.startsWith("/")).toBe(false);
     });
   });
 });

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -23,6 +23,7 @@ import {
   patchFrontmatter,
   readFrontmatterViaAdapter,
 } from "@/utils/vaultAdapterUtils";
+import { joinPosix } from "@/utils/pathUtils";
 import { App, Notice, TFile } from "obsidian";
 import { MessageRepository } from "./MessageRepository";
 
@@ -66,11 +67,18 @@ export class ChatPersistenceManager {
       const chatContent = this.formatChatContent(messages);
       const firstMessageEpoch = messages[0].timestamp?.epoch || Date.now();
 
+      // Capture the conversations folder once at the start of the save so a
+      // concurrent Copilot-root change can't make this operation ensure one
+      // directory and then generate a path under another. Every folder-derived
+      // path below (existing-file lookup, filename, conflict and fallback
+      // paths) reads this snapshot instead of re-resolving the live setting.
+      const conversationsFolder = getEffectiveConversationsFolder();
+
       // Ensure the save folder exists (supports nested paths) using utility helper.
-      await ensureFolderExists(this.app.vault, getEffectiveConversationsFolder());
+      await ensureFolderExists(this.app.vault, conversationsFolder);
 
       // Check if a file with this epoch already exists
-      const existingFile = await this.findFileByEpoch(firstMessageEpoch);
+      const existingFile = await this.findFileByEpoch(firstMessageEpoch, conversationsFolder);
       const existingFrontmatter = existingFile
         ? this.app.metadataCache.getFileCache(existingFile)?.frontmatter
         : undefined;
@@ -95,7 +103,13 @@ export class ChatPersistenceManager {
 
       const preferredFileName = existingFile
         ? existingFile.path
-        : this.generateFileName(currentProject, messages, firstMessageEpoch, existingTopic);
+        : this.generateFileName(
+            currentProject,
+            messages,
+            firstMessageEpoch,
+            conversationsFolder,
+            existingTopic
+          );
 
       const noteContent = this.generateNoteContent(
         chatContent,
@@ -153,7 +167,7 @@ export class ChatPersistenceManager {
               const currentProjectId = currentProject?.id;
               if (currentProjectId && conflictProjectId !== currentProjectId) {
                 // Different project owns this file — generate a unique name instead
-                const rawUniqueName = `${getEffectiveConversationsFolder()}/${sanitizeVaultPathSegment(currentProjectId)}__chat-${firstMessageEpoch}.md`;
+                const rawUniqueName = `${conversationsFolder}/${sanitizeVaultPathSegment(currentProjectId)}__chat-${firstMessageEpoch}.md`;
                 const uniqueName = await this.resolveChatSavePath(rawUniqueName, currentProject);
                 targetFile = await this.app.vault.create(uniqueName, noteContent);
                 new Notice(`Chat saved as note: ${uniqueName}`);
@@ -204,7 +218,7 @@ export class ChatPersistenceManager {
             const filePrefix = fallbackProject
               ? `${sanitizeVaultPathSegment(fallbackProject.id)}__`
               : "";
-            const rawFallbackName = `${getEffectiveConversationsFolder()}/${filePrefix}chat-${firstMessageEpoch}.md`;
+            const rawFallbackName = `${conversationsFolder}/${filePrefix}chat-${firstMessageEpoch}.md`;
             // Reason: check ownership to prevent cross-project collision on fallback path
             const fallbackName = await this.resolveChatSavePath(rawFallbackName, currentProject);
 
@@ -322,10 +336,13 @@ export class ChatPersistenceManager {
   }
 
   /**
-   * Get all chat history files from the vault
+   * Get all chat history files from the vault.
+   * @param folder - Conversations folder to list; defaults to the live effective
+   *   folder. A save operation passes the folder it captured at entry so its
+   *   existing-file lookup stays consistent with where it will write.
    */
-  async getChatHistoryFiles(): Promise<TFile[]> {
-    const folderFiles = await listMarkdownFiles(this.app, getEffectiveConversationsFolder());
+  async getChatHistoryFiles(folder: string = getEffectiveConversationsFolder()): Promise<TFile[]> {
+    const folderFiles = await listMarkdownFiles(this.app, folder);
     if (folderFiles.length === 0) return [];
 
     const currentProject = getCurrentProject();
@@ -594,9 +611,12 @@ export class ChatPersistenceManager {
 
   /**
    * Find a file by its epoch in the frontmatter.
+   * @param epoch - Frontmatter epoch to match.
+   * @param folder - Conversations folder to search; the caller passes the folder
+   *   it captured at save entry so the lookup matches where it will write.
    */
-  private async findFileByEpoch(epoch: number): Promise<TFile | null> {
-    const files = await this.getChatHistoryFiles();
+  private async findFileByEpoch(epoch: number, folder?: string): Promise<TFile | null> {
+    const files = await this.getChatHistoryFiles(folder);
 
     for (const file of files) {
       // Try metadata cache first (works for non-hidden directories)
@@ -688,12 +708,16 @@ ${conversationSummary}`;
    * @param project - The project context for the filename prefix.
    * @param messages - The conversation messages used to derive the topic.
    * @param firstMessageEpoch - Epoch timestamp of the first message in the chat.
+   * @param folder - Destination conversations folder; passed in (rather than
+   *   re-resolved) so it stays consistent with the rest of a single save even
+   *   if the Copilot root changes concurrently.
    * @param topic - Optional pre-computed topic to use for the filename.
    */
   private generateFileName(
     project: ProjectConfig | null,
     messages: ChatMessage[],
     firstMessageEpoch: number,
+    folder: string,
     topic?: string
   ): string {
     const settings = getSettings();
@@ -775,10 +799,10 @@ ${conversationSummary}`;
       // If still too long, truncate the entire filename more aggressively
       const availableForBasename = SAFE_FILENAME_BYTE_LIMIT - extensionBytes - filePrefixBytes;
       const truncatedBasename = truncateToByteLimit(sanitizedFileName, availableForBasename);
-      return `${getEffectiveConversationsFolder()}/${filePrefix}${truncatedBasename}.md`;
+      return joinPosix(folder, `${filePrefix}${truncatedBasename}.md`);
     }
 
-    return `${getEffectiveConversationsFolder()}/${baseNameWithPrefix}`;
+    return joinPosix(folder, baseNameWithPrefix);
   }
 
   /**
@@ -913,7 +937,15 @@ ${chatContent}`;
     }
 
     const messages = this.messageRepo.getDisplayMessages();
-    const newPath = this.generateFileName(project, messages, epoch, topic);
+    // Rename within the file's own folder. This runs after async topic
+    // generation, so re-resolving the effective folder here could move an
+    // already-saved chat from the old root into a newly-changed one. Derive the
+    // parent from the file's own path rather than `file.parent`, which is null
+    // for the synthetic TFiles used for hidden-directory chats — falling back to
+    // the live setting there would reopen the same cross-root move.
+    const slashIndex = file.path.lastIndexOf("/");
+    const parentFolder = slashIndex === -1 ? "" : file.path.slice(0, slashIndex);
+    const newPath = this.generateFileName(project, messages, epoch, parentFolder, topic);
 
     if (file.path === newPath) {
       return;

--- a/src/core/ChatPersistenceManager.ts
+++ b/src/core/ChatPersistenceManager.ts
@@ -1,11 +1,12 @@
 import { getCurrentProject, ProjectConfig } from "@/aiParams";
-import { AI_SENDER, USER_SENDER } from "@/constants";
+import { AI_SENDER, COPILOT_CONVERSATION_TAG, USER_SENDER } from "@/constants";
 import ChainManager from "@/LLMProviders/chainManager";
 import { parseReasoningBlock } from "@/LLMProviders/chainRunner/utils/AgentReasoningState";
 import { logError, logInfo, logWarn } from "@/logger";
 import { sanitizeVaultPathSegment } from "@/projects/projectUtils";
 import { filterChatHistoryFiles, readChatPathProjectId } from "@/utils/chatHistoryUtils";
 import { getSettings } from "@/settings/model";
+import { getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 import { ChatMessage, MessageContext } from "@/types/message";
 import {
   ensureFolderExists,
@@ -62,12 +63,11 @@ export class ChatPersistenceManager {
         return;
       }
 
-      const settings = getSettings();
       const chatContent = this.formatChatContent(messages);
       const firstMessageEpoch = messages[0].timestamp?.epoch || Date.now();
 
       // Ensure the save folder exists (supports nested paths) using utility helper.
-      await ensureFolderExists(this.app.vault, settings.defaultSaveFolder);
+      await ensureFolderExists(this.app.vault, getEffectiveConversationsFolder());
 
       // Check if a file with this epoch already exists
       const existingFile = await this.findFileByEpoch(firstMessageEpoch);
@@ -153,7 +153,7 @@ export class ChatPersistenceManager {
               const currentProjectId = currentProject?.id;
               if (currentProjectId && conflictProjectId !== currentProjectId) {
                 // Different project owns this file — generate a unique name instead
-                const rawUniqueName = `${settings.defaultSaveFolder}/${sanitizeVaultPathSegment(currentProjectId)}__chat-${firstMessageEpoch}.md`;
+                const rawUniqueName = `${getEffectiveConversationsFolder()}/${sanitizeVaultPathSegment(currentProjectId)}__chat-${firstMessageEpoch}.md`;
                 const uniqueName = await this.resolveChatSavePath(rawUniqueName, currentProject);
                 targetFile = await this.app.vault.create(uniqueName, noteContent);
                 new Notice(`Chat saved as note: ${uniqueName}`);
@@ -204,7 +204,7 @@ export class ChatPersistenceManager {
             const filePrefix = fallbackProject
               ? `${sanitizeVaultPathSegment(fallbackProject.id)}__`
               : "";
-            const rawFallbackName = `${settings.defaultSaveFolder}/${filePrefix}chat-${firstMessageEpoch}.md`;
+            const rawFallbackName = `${getEffectiveConversationsFolder()}/${filePrefix}chat-${firstMessageEpoch}.md`;
             // Reason: check ownership to prevent cross-project collision on fallback path
             const fallbackName = await this.resolveChatSavePath(rawFallbackName, currentProject);
 
@@ -325,8 +325,7 @@ export class ChatPersistenceManager {
    * Get all chat history files from the vault
    */
   async getChatHistoryFiles(): Promise<TFile[]> {
-    const settings = getSettings();
-    const folderFiles = await listMarkdownFiles(this.app, settings.defaultSaveFolder);
+    const folderFiles = await listMarkdownFiles(this.app, getEffectiveConversationsFolder());
     if (folderFiles.length === 0) return [];
 
     const currentProject = getCurrentProject();
@@ -776,10 +775,10 @@ ${conversationSummary}`;
       // If still too long, truncate the entire filename more aggressively
       const availableForBasename = SAFE_FILENAME_BYTE_LIMIT - extensionBytes - filePrefixBytes;
       const truncatedBasename = truncateToByteLimit(sanitizedFileName, availableForBasename);
-      return `${settings.defaultSaveFolder}/${filePrefix}${truncatedBasename}.md`;
+      return `${getEffectiveConversationsFolder()}/${filePrefix}${truncatedBasename}.md`;
     }
 
-    return `${settings.defaultSaveFolder}/${baseNameWithPrefix}`;
+    return `${getEffectiveConversationsFolder()}/${baseNameWithPrefix}`;
   }
 
   /**
@@ -792,7 +791,6 @@ ${conversationSummary}`;
     topic?: string,
     lastAccessedAt?: number
   ): string {
-    const settings = getSettings();
     const currentProject = getCurrentProject();
 
     return `---
@@ -803,7 +801,7 @@ ${lastAccessedAt ? `lastAccessedAt: ${lastAccessedAt}` : ""}
 ${currentProject ? `projectId: "${escapeYamlString(currentProject.id)}"` : ""}
 ${currentProject ? `projectName: "${escapeYamlString(currentProject.name)}"` : ""}
 tags:
-  - ${settings.defaultConversationTag}
+  - ${COPILOT_CONVERSATION_TAG}
 ---
 
 ${chatContent}`;

--- a/src/logFileManager.ts
+++ b/src/logFileManager.ts
@@ -2,13 +2,14 @@ import { err2String } from "@/errorFormat";
 import { App, TFile } from "obsidian";
 import { ensureFolderExists } from "@/utils";
 import { getSettings } from "@/settings/model";
+import { getEffectiveCopilotFolder } from "@/settings/copilotFolder";
 import { isSensitiveKey } from "@/encryptionService";
 
 type LogLevel = "INFO" | "WARN" | "ERROR";
 
 /**
  * Manages a rolling log file that keeps the last N entries and works on desktop and mobile.
- * - Writes to <vault>/copilot/copilot-log.md
+ * - Writes to <vault>/<copilotFolder>/copilot-log.md
  * - Maintains an in-memory ring buffer of the last 500 entries
  * - Debounced flush to reduce I/O; single-line entries to preserve accurate line limits
  */
@@ -39,7 +40,8 @@ class LogFileManager {
   }
 
   getLogPath(): string {
-    return "copilot/copilot-log.md"; // under copilot/
+    // Under the configurable copilot root folder.
+    return `${getEffectiveCopilotFolder()}/copilot-log.md`;
   }
 
   /** Ensure the log manager is initialized. Always starts with an empty buffer. */

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,6 +76,7 @@ import {
   updateSetting,
 } from "@/settings/model";
 import { didMiyoSyncedRootsChange, shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
+import { resetMiyoMutations } from "@/miyo/miyoResync";
 import { ensureCopilotSubfolders, getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 import { buildUpgradeRelocationEntries } from "@/settings/upgradeNotice";
 import { UpgradeRelocationNotice } from "@/settings/UpgradeRelocationNotice";
@@ -175,6 +176,12 @@ export default class CopilotPlugin extends Plugin {
     // AFTER the next onload has already initialized — and would then null
     // out the new instance, breaking saves until another full reload.
     resetPersistenceState();
+    // Same lifecycle hazard, same placement: abandon Miyo mutations queued by a
+    // previous lifecycle so a hung request can't block this one, and invalidate
+    // in-flight ones so their receipts can't land in this vault's settings.
+    // Must precede `loadSettings()` — after the token moves, a late write is
+    // discarded; before it, the write still belongs to the outgoing vault.
+    resetMiyoMutations();
     KeychainService.resetInstance();
     KeychainService.getInstance(this.app);
     await this.loadSettings();

--- a/src/main.ts
+++ b/src/main.ts
@@ -176,11 +176,9 @@ export default class CopilotPlugin extends Plugin {
     // AFTER the next onload has already initialized — and would then null
     // out the new instance, breaking saves until another full reload.
     resetPersistenceState();
-    // Same lifecycle hazard, same placement: abandon Miyo mutations queued by a
-    // previous lifecycle so a hung request can't block this one, and invalidate
-    // in-flight ones so their receipts can't land in this vault's settings.
-    // Must precede `loadSettings()` — after the token moves, a late write is
-    // discarded; before it, the write still belongs to the outgoing vault.
+    // Also reset here, not only in `onunload`: a crash or a hard kill never runs
+    // unload at all, and the module would then start this lifecycle holding the
+    // previous one's queue. Bumping twice is harmless — no task exists yet.
     resetMiyoMutations();
     KeychainService.resetInstance();
     KeychainService.getInstance(this.app);
@@ -509,12 +507,21 @@ export default class CopilotPlugin extends Plugin {
   }
 
   async onunload() {
+    // End the Miyo mutation lifecycle HERE, as the first statement: everything
+    // above the first `await` runs before the next `onload()` can possibly
+    // start, so this carries none of the late-continuation risk that keeps
+    // `resetPersistenceState()` at load time. Doing it at unload is what makes
+    // the boundary real — waiting for the next load would leave a task from
+    // this vault free to write settings and issue DELETE/POST during an unload
+    // that is never followed by a re-enable, or while another vault is opening.
+    resetMiyoMutations();
+
     // Best-effort flush of pending keychain/data.json writes.
     // Reason: onunload() is void in Obsidian's type system, but awaiting here
     // is no worse than fire-and-forget, and consistent with the log flush below.
-    // (Module-level state + KeychainService singleton reset happen at the
-    // START of the next onload, not here — see comment in onload above for
-    // the late-write race that motivated the move.)
+    // (The KeychainService singleton and the persistence module's own state
+    // reset at the START of the next onload — see the comment there for the
+    // late-write race that motivated it.)
     await flushPersistence();
 
     // Clear all persistent selection highlights before unload

--- a/src/main.ts
+++ b/src/main.ts
@@ -435,14 +435,14 @@ export default class CopilotPlugin extends Plugin {
 
       void this.notifyLegacyUpgradeRelocation();
 
-      // A Copilot root change can arrive via settings sync without passing
-      // through the settings UI (whose confirm chain runs the auto-resync), so
-      // Miyo's server-side exclusions may be silently stale at startup. Only a
-      // REAL roots change prompts — a receipt from another device with equal
-      // roots stays quiet; the Miyo tab's on-load verification self-heals it.
-      // No `enableMiyo` gate: shouldSurfaceMiyoResync already treats a non-empty
-      // receipt as evidence of a past registration, and a user who disconnected
-      // in Copilot can still be exposed through Miyo's Relay.
+      // A Copilot root change can leave Miyo's server-side exclusions stale
+      // without anything prompting at the time: one arriving via settings sync
+      // never passes through the settings UI at all, and the UI itself only
+      // points at the Miyo tab. Only a REAL roots change prompts — a receipt
+      // from another device with equal roots stays quiet; the Miyo tab's on-load
+      // verification self-heals it. No `enableMiyo` gate: shouldSurfaceMiyoResync
+      // already treats a non-empty receipt as evidence of a past registration,
+      // and a user who disconnected in Copilot can still be exposed via Relay.
       const startupSettings = getSettings();
       if (
         didMiyoSyncedRootsChange(startupSettings) &&

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,7 @@ import {
   subscribeToSettingsChange,
   updateSetting,
 } from "@/settings/model";
+import { didMiyoSyncedRootsChange, shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
 import { ensureCopilotSubfolders, getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 import { buildUpgradeRelocationEntries } from "@/settings/upgradeNotice";
 import { UpgradeRelocationNotice } from "@/settings/UpgradeRelocationNotice";
@@ -426,6 +427,22 @@ export default class CopilotPlugin extends Plugin {
         .then(() => migrateSystemPromptsFromSettings(this.app));
 
       void this.notifyLegacyUpgradeRelocation();
+
+      // A Copilot root change can arrive via settings sync without passing
+      // through the settings UI (whose confirm chain runs the auto-resync), so
+      // Miyo's server-side exclusions may be silently stale at startup. Only a
+      // REAL roots change prompts — a receipt from another device with equal
+      // roots stays quiet; the Miyo tab's on-load verification self-heals it.
+      // No `enableMiyo` gate: shouldSurfaceMiyoResync already treats a non-empty
+      // receipt as evidence of a past registration, and a user who disconnected
+      // in Copilot can still be exposed through Miyo's Relay.
+      const startupSettings = getSettings();
+      if (
+        didMiyoSyncedRootsChange(startupSettings) &&
+        shouldSurfaceMiyoResync(this.app, startupSettings)
+      ) {
+        new Notice("Miyo search needs a resync — open the Miyo settings tab.", 8000);
+      }
     });
 
     // Initialize automatic selection handler

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,7 @@ import {
   updateSetting,
 } from "@/settings/model";
 import { didMiyoSyncedRootsChange, shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
-import { resetMiyoMutations } from "@/miyo/miyoResync";
+import { type MiyoMutationSession, resetMiyoMutations } from "@/miyo/miyoResync";
 import { ensureCopilotSubfolders, getEffectiveConversationsFolder } from "@/settings/copilotFolder";
 import { buildUpgradeRelocationEntries } from "@/settings/upgradeNotice";
 import { UpgradeRelocationNotice } from "@/settings/UpgradeRelocationNotice";
@@ -146,6 +146,18 @@ export default class CopilotPlugin extends Plugin {
   private planPreviewViewType?: typeof import("@/agentMode").PLAN_PREVIEW_VIEW_TYPE;
   private agentModelDiscoveryUnsubscriber?: () => void;
   modelManagement!: ModelManagementApi;
+  // Proof of THIS lifecycle for anything that enqueues a Miyo folder mutation.
+  // Assigned in `onload` right after the queue reset, and read by the settings
+  // UI rather than captured there: settings tabs mount lazily (`TabContent`
+  // renders nothing until selected), so a tab first opened after a reload would
+  // capture the incoming lifecycle while still holding the outgoing vault's
+  // `app`. The plugin instance is one-per-lifecycle by construction, so it is
+  // the honest place for this.
+  //
+  // Assign it exactly once and never recompute it per read: the Miyo tab uses it
+  // as an effect dependency, so a getter that captured on every access would
+  // hand React a new object each render and spin that effect forever.
+  miyoMutationSession!: MiyoMutationSession;
   private ribbonIconEl?: HTMLElement;
   userMemoryManager: UserMemoryManager;
   quickAskController: QuickAskController;
@@ -179,7 +191,10 @@ export default class CopilotPlugin extends Plugin {
     // Also reset here, not only in `onunload`: a crash or a hard kill never runs
     // unload at all, and the module would then start this lifecycle holding the
     // previous one's queue. Bumping twice is harmless — no task exists yet.
-    resetMiyoMutations();
+    // The reset hands back this lifecycle's session; producers read it off the
+    // plugin rather than obtaining one themselves, which is what keeps a stale
+    // settings tree from vouching for the lifecycle it outlived.
+    this.miyoMutationSession = resetMiyoMutations();
     KeychainService.resetInstance();
     KeychainService.getInstance(this.app);
     await this.loadSettings();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import type { AgentSessionManager } from "@/agentMode";
+import React from "react";
 // Deep import (not the barrel): these run on the load path for every
 // platform, and the barrel pulls Node-only modules that crash mobile.
 import { isNativeChatId, parseNativeChatId } from "@/utils/nativeChatId";
@@ -15,6 +16,7 @@ import { registerCommands } from "@/commands";
 import CopilotView from "@/components/CopilotView";
 import RelevantNotesView from "@/components/RelevantNotesView";
 import { APPLY_VIEW_TYPE, ApplyView } from "@/components/composer/ApplyView";
+import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { LoadChatHistoryModal } from "@/components/modals/LoadChatHistoryModal";
 
 import { registerContextMenu, registerSymposiumFileMenu } from "@/commands/contextMenu";
@@ -71,7 +73,11 @@ import {
   getSettings,
   setSettings,
   subscribeToSettingsChange,
+  updateSetting,
 } from "@/settings/model";
+import { ensureCopilotSubfolders, getEffectiveConversationsFolder } from "@/settings/copilotFolder";
+import { buildUpgradeRelocationEntries } from "@/settings/upgradeNotice";
+import { UpgradeRelocationNotice } from "@/settings/UpgradeRelocationNotice";
 import { dehydrateDeviceProfile, hydrateDeviceProfile } from "@/settings/deviceProfiles";
 import { getDeviceId } from "@/utils/deviceId";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
@@ -418,6 +424,8 @@ export default class CopilotPlugin extends Plugin {
       void this.systemPromptRegister
         .initialize()
         .then(() => migrateSystemPromptsFromSettings(this.app));
+
+      void this.notifyLegacyUpgradeRelocation();
     });
 
     // Initialize automatic selection handler
@@ -425,6 +433,38 @@ export default class CopilotPlugin extends Plugin {
 
     // Initialize web selection watcher (Desktop only)
     this.initWebSelectionWatcher();
+  }
+
+  /**
+   * One-time guidance for users upgrading a legacy (v1-v7) vault whose Copilot
+   * data needs relocating (a sub-folder was customized, or the root itself
+   * moved). v4 consolidated every data folder under a single derived root, so
+   * Copilot now reads and writes the derived locations while their old files
+   * stay put. This shows them the old→new paths
+   * and asks them to move files manually; per the maintainer decision it never
+   * moves files itself. The flag is cleared afterwards (whether or not the notice
+   * is shown) so the check runs once. A failed clear-write only repeats the
+   * one-time check on the next restart, which is idempotent.
+   */
+  private async notifyLegacyUpgradeRelocation(): Promise<void> {
+    if (!getSettings().upgradedToV8FromLegacy) return;
+
+    const entries = buildUpgradeRelocationEntries(getSettings());
+    if (entries.length > 0) {
+      // Pre-create the derived sub-folders so the destinations the notice points
+      // at already exist when the user goes to move their files there.
+      await ensureCopilotSubfolders(this.app.vault, getSettings());
+      new ConfirmModal(
+        this.app,
+        () => {},
+        React.createElement(UpgradeRelocationNotice, { entries }),
+        "",
+        "OK",
+        ""
+      ).open();
+    }
+
+    updateSetting("upgradedToV8FromLegacy", false);
   }
 
   /**
@@ -1056,7 +1096,7 @@ export default class CopilotPlugin extends Plugin {
   }
 
   async getChatHistoryFiles(): Promise<TFile[]> {
-    const folderFiles = await listMarkdownFiles(this.app, getSettings().defaultSaveFolder);
+    const folderFiles = await listMarkdownFiles(this.app, getEffectiveConversationsFolder());
     if (folderFiles.length === 0) return [];
 
     const currentProject = getCurrentProject();

--- a/src/memory/UserMemoryManager.test.ts
+++ b/src/memory/UserMemoryManager.test.ts
@@ -20,6 +20,10 @@ import { logError, logWarn } from "@/logger";
 jest.mock("@/settings/copilotFolder", () => ({
   getEffectiveMemoryFolder: jest.fn(() => "copilot/memory"),
 }));
+import { getEffectiveMemoryFolder } from "@/settings/copilotFolder";
+const mockedMemoryFolder = getEffectiveMemoryFolder as jest.MockedFunction<
+  typeof getEffectiveMemoryFolder
+>;
 
 import { CopilotSettings, getSettings } from "@/settings/model";
 import { ensureFolderExists } from "@/utils";
@@ -88,6 +92,9 @@ describe("UserMemoryManager", () => {
       invoke: jest.fn(),
     } as unknown as jest.Mocked<BaseChatModel>;
 
+    // Reset explicitly: `clearAllMocks` drops calls but keeps a mockReturnValue,
+    // and a test that moves the root mid-operation would otherwise leak it.
+    mockedMemoryFolder.mockReturnValue("copilot/memory");
     userMemoryManager = new UserMemoryManager(mockApp);
   });
 
@@ -227,6 +234,37 @@ describe("UserMemoryManager", () => {
       expect(logError).toHaveBeenCalledWith(
         "[UserMemoryManager] Failed to parse LLM response as JSON:",
         expect.any(Error)
+      );
+    });
+  });
+
+  describe("updateMemory", () => {
+    it("writes the summary to the root that is current when the model returns", async () => {
+      // The memory folder derives from the Copilot root, and the model call is an
+      // unbounded network await. A root change during it must not leave the
+      // operation ensuring one directory and writing into another — the summary
+      // does not depend on the old location, so the current root is correct and
+      // the folder it ensures must be the one it writes.
+      mockedMemoryFolder.mockReturnValue("copilot/memory");
+      const model = {
+        invoke: jest.fn(async () => {
+          mockedMemoryFolder.mockReturnValue("moved/memory");
+          return new AIMessageChunk({ content: '{"summary":"s","topics":[],"insights":[]}' });
+        }),
+      } as unknown as BaseChatModel;
+      (mockVault.getAbstractFileByPath as jest.Mock).mockReturnValue(null);
+
+      await asInternal(userMemoryManager).updateMemory(
+        [
+          { id: "1", message: "hi", sender: "user", isVisible: true, timestamp: null },
+        ] as ChatMessage[],
+        model
+      );
+
+      expect(ensureFolderExists).toHaveBeenCalledWith(mockVault, "moved/memory");
+      expect(mockVault.create).toHaveBeenCalledWith(
+        "moved/memory/Recent Conversations.md",
+        expect.any(String)
       );
     });
   });

--- a/src/memory/UserMemoryManager.test.ts
+++ b/src/memory/UserMemoryManager.test.ts
@@ -17,6 +17,10 @@ import { UserMemoryManager } from "./UserMemoryManager";
 import { App, TFile, Vault } from "obsidian";
 import { ChatMessage } from "@/types/message";
 import { logError, logWarn } from "@/logger";
+jest.mock("@/settings/copilotFolder", () => ({
+  getEffectiveMemoryFolder: jest.fn(() => "copilot/memory"),
+}));
+
 import { CopilotSettings, getSettings } from "@/settings/model";
 import { ensureFolderExists } from "@/utils";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";

--- a/src/memory/UserMemoryManager.test.ts
+++ b/src/memory/UserMemoryManager.test.ts
@@ -269,6 +269,30 @@ describe("UserMemoryManager", () => {
     });
   });
 
+  describe("updateSavedMemory", () => {
+    it("reports the path it wrote, not one re-resolved after the root moved", async () => {
+      // The write intentionally stays in the folder captured before the model
+      // call, so a caller re-resolving afterwards would name a file this save
+      // never touched — and the memory would look missing.
+      mockedMemoryFolder.mockReturnValue("copilot/memory");
+      (mockVault.getAbstractFileByPath as jest.Mock).mockReturnValue(null);
+      const model = {
+        invoke: jest.fn(async () => {
+          mockedMemoryFolder.mockReturnValue("moved/memory");
+          return new AIMessageChunk({ content: "- remembered" });
+        }),
+      } as unknown as BaseChatModel;
+
+      const result = await userMemoryManager.updateSavedMemory("remember this", model);
+
+      expect(result.filePath).toBe("copilot/memory/Saved Memories.md");
+      expect(mockVault.create).toHaveBeenCalledWith(
+        "copilot/memory/Saved Memories.md",
+        expect.any(String)
+      );
+    });
+  });
+
   describe("extractJsonFromResponse", () => {
     it("should extract JSON from markdown code blocks with json language tag", () => {
       const content = `Here's the response:
@@ -566,7 +590,10 @@ The conversation covered advanced features and included code examples.`,
       const createdContent = mockVault.create.mock.calls[0][1];
       expect(createdContent).not.toContain("**");
 
-      expect(result).toEqual({ content: llmMergedContent });
+      expect(result).toEqual({
+        content: llmMergedContent,
+        filePath: "copilot/memory/Saved Memories.md",
+      });
     });
 
     it("should append to existing Saved Memories file", async () => {
@@ -609,7 +636,10 @@ The conversation covered advanced features and included code examples.`,
       const modifiedContent = mockVault.modify.mock.calls[0][1];
       expect(modifiedContent).not.toContain("**");
 
-      expect(result).toEqual({ content: mergedContent });
+      expect(result).toEqual({
+        content: mergedContent,
+        filePath: "copilot/memory/Saved Memories.md",
+      });
     });
 
     it("should handle errors during save operation", async () => {

--- a/src/memory/UserMemoryManager.ts
+++ b/src/memory/UserMemoryManager.ts
@@ -2,6 +2,7 @@ import { App, TFile } from "obsidian";
 import { ChatMessage } from "@/types/message";
 import { logInfo, logError, logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
+import { getEffectiveMemoryFolder } from "@/settings/copilotFolder";
 import { ensureFolderExists } from "@/utils";
 import { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
@@ -225,20 +226,15 @@ export class UserMemoryManager {
    * Ensure the user memory folder exists
    */
   private async ensureMemoryFolderExists(): Promise<void> {
-    const settings = getSettings();
-    const memoryFolderPath = settings.memoryFolderName;
-
-    await ensureFolderExists(this.app.vault, memoryFolderPath);
+    await ensureFolderExists(this.app.vault, getEffectiveMemoryFolder());
   }
 
   private getRecentConversationFilePath(): string {
-    const settings = getSettings();
-    return `${settings.memoryFolderName}/Recent Conversations.md`;
+    return `${getEffectiveMemoryFolder()}/Recent Conversations.md`;
   }
 
   public getSavedMemoriesFilePath(): string {
-    const settings = getSettings();
-    return `${settings.memoryFolderName}/Saved Memories.md`;
+    return `${getEffectiveMemoryFolder()}/Saved Memories.md`;
   }
 
   /**

--- a/src/memory/UserMemoryManager.ts
+++ b/src/memory/UserMemoryManager.ts
@@ -88,7 +88,7 @@ export class UserMemoryManager {
   async updateSavedMemory(
     query: string,
     chatModel: BaseChatModel
-  ): Promise<{ content?: string; error?: string }> {
+  ): Promise<{ content?: string; error?: string; filePath?: string }> {
     const settings = getSettings();
 
     // Only proceed if saved memory is enabled
@@ -112,12 +112,12 @@ export class UserMemoryManager {
       const memoryFolder = getEffectiveMemoryFolder();
       await this.ensureMemoryFolderExists(memoryFolder);
       // Add to saved memories file
-      const result = await this.updateSavedMemoryFile(
-        this.getSavedMemoriesFilePath(memoryFolder),
-        query,
-        chatModel
-      );
-      return result;
+      const filePath = this.getSavedMemoriesFilePath(memoryFolder);
+      const result = await this.updateSavedMemoryFile(filePath, query, chatModel);
+      // Report the path actually written, not a re-resolved one: the root can
+      // move during the model call, and a caller resolving it afterwards would
+      // name a file this write never touched.
+      return { ...result, filePath };
     } catch (error) {
       return {
         error: "Error saving memory: " + (error instanceof Error ? error.message : String(error)),

--- a/src/memory/UserMemoryManager.ts
+++ b/src/memory/UserMemoryManager.ts
@@ -27,9 +27,13 @@ export class UserMemoryManager {
    */
   private async loadMemory(): Promise<void> {
     try {
+      // One folder for both reads: resolving twice could pair a recent-history
+      // file from one root with saved memories from another if the root moves
+      // between them.
+      const memoryFolder = getEffectiveMemoryFolder();
       // Load recent conversations
       const recentConversationsFile = this.app.vault.getAbstractFileByPath(
-        this.getRecentConversationFilePath()
+        this.getRecentConversationFilePath(memoryFolder)
       );
       if (recentConversationsFile instanceof TFile) {
         this.recentConversationsContent = await this.app.vault.read(recentConversationsFile);
@@ -40,7 +44,7 @@ export class UserMemoryManager {
 
       // Load saved memories
       const savedMemoriesFile = this.app.vault.getAbstractFileByPath(
-        this.getSavedMemoriesFilePath()
+        this.getSavedMemoriesFilePath(memoryFolder)
       );
       if (savedMemoriesFile instanceof TFile) {
         this.savedMemoriesContent = await this.app.vault.read(savedMemoriesFile);
@@ -101,11 +105,15 @@ export class UserMemoryManager {
     }
 
     try {
-      // Ensure user memory folder exists
-      await this.ensureMemoryFolderExists();
+      // Captured BEFORE the model call, unlike the recent-conversation path:
+      // this is a read-modify-write whose model output is derived from THIS
+      // file's existing content, so redirecting the write to a root that
+      // changed meanwhile would overwrite that file with a foreign snapshot.
+      const memoryFolder = getEffectiveMemoryFolder();
+      await this.ensureMemoryFolderExists(memoryFolder);
       // Add to saved memories file
       const result = await this.updateSavedMemoryFile(
-        this.getSavedMemoriesFilePath(),
+        this.getSavedMemoriesFilePath(memoryFolder),
         query,
         chatModel
       );
@@ -196,9 +204,6 @@ export class UserMemoryManager {
 
     this.isUpdatingMemory = true;
     try {
-      // Ensure user memory folder exists
-      await this.ensureMemoryFolderExists();
-
       if (!chatModel) {
         logError("[UserMemoryManager] No chat model available, skipping memory update");
         return;
@@ -211,8 +216,14 @@ export class UserMemoryManager {
 
       // Extract and save conversation summary to recent conversations
       const conversationSection = await this.createConversationSection(messages, chatModel);
+      // Resolve the folder AFTER the model call, not before: a Copilot root
+      // change during it moves the memory folder, and the summary does not
+      // depend on the old location — so the current root is where the user
+      // expects it, and ensuring the same value we write guarantees it exists.
+      const memoryFolder = getEffectiveMemoryFolder();
+      await this.ensureMemoryFolderExists(memoryFolder);
       await this.addToRecentConversationsFile(
-        this.getRecentConversationFilePath(),
+        this.getRecentConversationFilePath(memoryFolder),
         conversationSection
       );
     } catch (error) {
@@ -223,18 +234,25 @@ export class UserMemoryManager {
   }
 
   /**
-   * Ensure the user memory folder exists
+   * Ensure the memory folder an operation has committed to exists.
+   *
+   * Takes the folder rather than resolving it so an operation cannot ensure one
+   * directory and then write into another: the memory folder derives from the
+   * Copilot root, which the user can move mid-operation. Mirrors the snapshot
+   * discipline the chat-save paths already use.
+   *
+   * @param memoryFolder - Folder this operation resolved once and will write to.
    */
-  private async ensureMemoryFolderExists(): Promise<void> {
-    await ensureFolderExists(this.app.vault, getEffectiveMemoryFolder());
+  private async ensureMemoryFolderExists(memoryFolder: string): Promise<void> {
+    await ensureFolderExists(this.app.vault, memoryFolder);
   }
 
-  private getRecentConversationFilePath(): string {
-    return `${getEffectiveMemoryFolder()}/Recent Conversations.md`;
+  private getRecentConversationFilePath(memoryFolder = getEffectiveMemoryFolder()): string {
+    return `${memoryFolder}/Recent Conversations.md`;
   }
 
-  public getSavedMemoriesFilePath(): string {
-    return `${getEffectiveMemoryFolder()}/Saved Memories.md`;
+  public getSavedMemoriesFilePath(memoryFolder = getEffectiveMemoryFolder()): string {
+    return `${memoryFolder}/Saved Memories.md`;
   }
 
   /**

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -372,6 +372,63 @@ describe("MiyoClient", () => {
     });
   });
 
+  describe("beforeRequest hook", () => {
+    it("refuses addFolder after the URL and credentials resolve, so nothing is sent", async () => {
+      // The caller's own check runs before this method; resolution and
+      // decryption are awaits, so only a hook here can stop a request whose
+      // caller went stale in between.
+      mockedRequestUrl.mockResolvedValue({
+        status: 201,
+        json: { path: "/Users/me/vault" },
+        text: "",
+      } as RequestUrlResponse);
+      const client = new MiyoClient();
+
+      await expect(
+        client.addFolder({ path: "/Users/me/vault" }, undefined, () => {
+          throw new Error("lifecycle expired");
+        })
+      ).rejects.toThrow("lifecycle expired");
+
+      expect(mockResolveBaseUrl).toHaveBeenCalled();
+      expect(mockedGetDecryptedKey).toHaveBeenCalled();
+      expect(mockedRequestUrl).not.toHaveBeenCalled();
+    });
+
+    it("refuses deleteFolder after the URL and credentials resolve, so nothing is sent", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: { deleted: true },
+        text: "",
+      } as RequestUrlResponse);
+      const client = new MiyoClient();
+
+      await expect(
+        client.deleteFolder("my-vault", undefined, () => {
+          throw new Error("lifecycle expired");
+        })
+      ).rejects.toThrow("lifecycle expired");
+
+      expect(mockResolveBaseUrl).toHaveBeenCalled();
+      expect(mockedRequestUrl).not.toHaveBeenCalled();
+    });
+
+    it("sends the request when the hook is absent or returns", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: { deleted: true },
+        text: "",
+      } as RequestUrlResponse);
+      const client = new MiyoClient();
+      const hook = jest.fn();
+
+      await client.deleteFolder("my-vault", undefined, hook);
+
+      expect(hook).toHaveBeenCalledTimes(1);
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("deleteFolder", () => {
     it("DELETEs /v0/folder with the folder name in the JSON body", async () => {
       mockedRequestUrl.mockResolvedValue({

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -370,9 +370,7 @@ describe("MiyoClient", () => {
 
       expect(mockResolveBaseUrl).toHaveBeenCalledWith({ overrideUrl: "http://127.0.0.1:9999" });
     });
-  });
 
-  describe("beforeRequest hook", () => {
     it("refuses addFolder after the URL and credentials resolve, so nothing is sent", async () => {
       // The caller's own check runs before this method; resolution and
       // decryption are awaits, so only a hook here can stop a request whose
@@ -393,39 +391,6 @@ describe("MiyoClient", () => {
       expect(mockResolveBaseUrl).toHaveBeenCalled();
       expect(mockedGetDecryptedKey).toHaveBeenCalled();
       expect(mockedRequestUrl).not.toHaveBeenCalled();
-    });
-
-    it("refuses deleteFolder after the URL and credentials resolve, so nothing is sent", async () => {
-      mockedRequestUrl.mockResolvedValue({
-        status: 200,
-        json: { deleted: true },
-        text: "",
-      } as RequestUrlResponse);
-      const client = new MiyoClient();
-
-      await expect(
-        client.deleteFolder("my-vault", undefined, () => {
-          throw new Error("lifecycle expired");
-        })
-      ).rejects.toThrow("lifecycle expired");
-
-      expect(mockResolveBaseUrl).toHaveBeenCalled();
-      expect(mockedRequestUrl).not.toHaveBeenCalled();
-    });
-
-    it("sends the request when the hook is absent or returns", async () => {
-      mockedRequestUrl.mockResolvedValue({
-        status: 200,
-        json: { deleted: true },
-        text: "",
-      } as RequestUrlResponse);
-      const client = new MiyoClient();
-      const hook = jest.fn();
-
-      await client.deleteFolder("my-vault", undefined, hook);
-
-      expect(hook).toHaveBeenCalledTimes(1);
-      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -475,6 +440,39 @@ describe("MiyoClient", () => {
       await expect(client.deleteFolder("my-vault")).rejects.toThrow(
         "Miyo delete-folder failed with status 500: boom"
       );
+    });
+
+    it("refuses deleteFolder after the URL and credentials resolve, so nothing is sent", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: { deleted: true },
+        text: "",
+      } as RequestUrlResponse);
+      const client = new MiyoClient();
+
+      await expect(
+        client.deleteFolder("my-vault", undefined, () => {
+          throw new Error("lifecycle expired");
+        })
+      ).rejects.toThrow("lifecycle expired");
+
+      expect(mockResolveBaseUrl).toHaveBeenCalled();
+      expect(mockedRequestUrl).not.toHaveBeenCalled();
+    });
+
+    it("sends the request when the hook is absent or returns", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: { deleted: true },
+        text: "",
+      } as RequestUrlResponse);
+      const client = new MiyoClient();
+      const hook = jest.fn();
+
+      await client.deleteFolder("my-vault", undefined, hook);
+
+      expect(hook).toHaveBeenCalledTimes(1);
+      expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -253,6 +253,53 @@ describe("MiyoClient", () => {
     });
   });
 
+  describe("constructor", () => {
+    it("authenticates with the snapshot it was given, not whatever settings hold later", async () => {
+      // A queued Miyo mutation can outlive the vault that started it. Reading
+      // the key per request would then send the newly-opened vault's credential
+      // to the outgoing vault's endpoint, so callers whose work spans that
+      // boundary capture the key up front.
+      mockedRequestUrl.mockResolvedValue({
+        status: 201,
+        json: { path: "/Users/me/vault" },
+        text: "",
+      } as RequestUrlResponse);
+      const client = new MiyoClient({ plusLicenseKey: "key-of-the-vault-that-asked" });
+
+      // The vault switches while the mutation is queued.
+      mockedGetSettings.mockReturnValue({
+        plusLicenseKey: "key-of-a-different-vault",
+        debug: false,
+      } as CopilotSettings);
+      mockedGetDecryptedKey.mockImplementation(async (value: string) => value);
+
+      await client.addFolder({ path: "/Users/me/vault" });
+
+      expect(mockedRequestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: { Authorization: "Bearer key-of-the-vault-that-asked" },
+        })
+      );
+    });
+
+    it("reads the live key when given no snapshot, as short-lived callers expect", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 201,
+        json: { path: "/Users/me/vault" },
+        text: "",
+      } as RequestUrlResponse);
+      mockedGetDecryptedKey.mockImplementation(async (value: string) => value);
+
+      await new MiyoClient().addFolder({ path: "/Users/me/vault" });
+
+      expect(mockedRequestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: { Authorization: "Bearer plus-test-license" },
+        })
+      );
+    });
+  });
+
   describe("addFolder", () => {
     it("POSTs the request to /v0/folder and returns the created record on 201", async () => {
       const folderRecord = { path: "/Users/me/vault", exclude_folders: ["copilot"] };

--- a/src/miyo/MiyoClient.test.ts
+++ b/src/miyo/MiyoClient.test.ts
@@ -325,6 +325,55 @@ describe("MiyoClient", () => {
     });
   });
 
+  describe("deleteFolder", () => {
+    it("DELETEs /v0/folder with the folder name in the JSON body", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 200,
+        json: { deleted: true },
+        text: "",
+      } as RequestUrlResponse);
+
+      const client = new MiyoClient();
+      await client.deleteFolder("my-vault");
+
+      expect(mockedRequestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: "http://127.0.0.1:8742/v0/folder",
+          method: "DELETE",
+          contentType: "application/json",
+          body: JSON.stringify({ path: "my-vault" }),
+          throw: false,
+        })
+      );
+    });
+
+    it("treats 404 not-registered as success", async () => {
+      // The caller's goal — no registration under that name — already holds
+      // (e.g. a prior resync deleted it but never got to re-add).
+      mockedRequestUrl.mockResolvedValue({
+        status: 404,
+        json: { detail: "Folder not registered: my-vault" },
+        text: "",
+      } as RequestUrlResponse);
+
+      const client = new MiyoClient();
+      await expect(client.deleteFolder("my-vault")).resolves.toBeUndefined();
+    });
+
+    it("throws a detailed error on other failures", async () => {
+      mockedRequestUrl.mockResolvedValue({
+        status: 500,
+        json: { detail: "boom" },
+        text: "",
+      } as RequestUrlResponse);
+
+      const client = new MiyoClient();
+      await expect(client.deleteFolder("my-vault")).rejects.toThrow(
+        "Miyo delete-folder failed with status 500: boom"
+      );
+    });
+  });
+
   describe("fetchHealth()", () => {
     it("resolves null once the probe timeout elapses when the request never responds", async () => {
       jest.useFakeTimers();

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -2,7 +2,7 @@ import { getDecryptedKey } from "@/encryptionService";
 import { logError, logInfo, logWarn } from "@/logger";
 import type { MiyoHealthResponse } from "@/miyo/miyoHealth";
 import { MiyoServiceDiscovery } from "@/miyo/MiyoServiceDiscovery";
-import { getSettings } from "@/settings/model";
+import { type CopilotSettings, getSettings } from "@/settings/model";
 import { err2String, withTimeout } from "@/utils";
 import { requestUrl } from "obsidian";
 
@@ -184,10 +184,20 @@ export class MiyoClient {
 
   private discovery: MiyoServiceDiscovery;
 
+  private readonly authSnapshot?: Pick<CopilotSettings, "plusLicenseKey">;
+
   /**
    * Create a new Miyo client instance.
+   *
+   * @param authSnapshot - Credentials captured when the caller's work began.
+   *   Callers whose requests can outlive the settings they started under —
+   *   a multi-request mutation that straddles a vault switch — pass their own
+   *   snapshot so every request carries the credential of the vault that asked
+   *   for it. Omitted, each request reads the live settings, which is what
+   *   short-lived callers want.
    */
-  constructor() {
+  constructor(authSnapshot?: Pick<CopilotSettings, "plusLicenseKey">) {
+    this.authSnapshot = authSnapshot;
     this.discovery = MiyoServiceDiscovery.getInstance();
   }
 
@@ -605,7 +615,7 @@ export class MiyoClient {
    * @returns Headers object for requestUrl.
    */
   private async buildHeaders(): Promise<Record<string, string>> {
-    const settings = getSettings();
+    const settings = this.authSnapshot ?? getSettings();
     const headers: Record<string, string> = {};
 
     const licenseKey = settings.plusLicenseKey

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -346,6 +346,54 @@ export class MiyoClient {
   }
 
   /**
+   * Remove a folder registration (`DELETE /v0/folder`), which also purges the
+   * folder's indexed documents (verified empirically: a post-delete global
+   * search returns no leftovers).
+   *
+   * 404 is a success: the caller's goal — no registration under that name —
+   * already holds (e.g. a prior resync deleted it but never got to re-add).
+   * The identifier is the record's canonical `path`, which is the folder NAME,
+   * not the absolute path (also verified against a live registration).
+   *
+   * @param folderName - Registered folder name (see getMiyoFolderName).
+   * @param overrideUrl - Explicit base URL (from settings) or empty for discovery.
+   */
+  public async deleteFolder(folderName: string, overrideUrl?: string): Promise<void> {
+    const baseUrl = await this.resolveBaseUrl(overrideUrl);
+    const headers = await this.buildHeaders();
+    const url = new URL("/v0/folder", baseUrl);
+    logInfo("Miyo request:", {
+      method: "DELETE",
+      url: url.toString(),
+      hasBody: true,
+      hasAuthorizationHeader: Boolean(headers.Authorization),
+    });
+    const response = await requestUrl({
+      url: url.toString(),
+      method: "DELETE",
+      headers,
+      contentType: "application/json",
+      body: JSON.stringify({ path: folderName }),
+      throw: false,
+    });
+    if (response.status === 404) {
+      logInfo("Miyo folder already unregistered; delete is a no-op");
+      return;
+    }
+    if (response.status >= 400) {
+      const detail =
+        this.parseResponseJson<{ detail?: string }>(response.json, response.text)?.detail ||
+        response.text ||
+        "";
+      throw new Error(
+        detail
+          ? `Miyo delete-folder failed with status ${response.status}: ${detail}`
+          : `Miyo delete-folder failed with status ${response.status}`
+      );
+    }
+  }
+
+  /**
    * Determine whether a vault folder is registered with Miyo.
    *
    * Unlike {@link getFolder} (which throws on any non-2xx), this reads the raw

--- a/src/miyo/MiyoClient.ts
+++ b/src/miyo/MiyoClient.ts
@@ -287,11 +287,16 @@ export class MiyoClient {
    *
    * @param request - Folder registration body; `path` must be absolute.
    * @param overrideUrl - Explicit base URL (from settings) or empty for discovery.
+   * @param beforeRequest - Invoked once the URL and credentials are resolved and
+   *   immediately before the request goes out; throw from it to call the
+   *   registration off. Exists because resolution and decryption are awaits, so
+   *   a caller's earlier check can go stale before anything is sent.
    * @returns The created folder record on 201, or `null` when already registered.
    */
   public async addFolder(
     request: MiyoAddFolderRequest,
-    overrideUrl?: string
+    overrideUrl?: string,
+    beforeRequest?: () => void
   ): Promise<MiyoFolderEntry | null> {
     let response: Awaited<ReturnType<typeof requestUrl>>;
     try {
@@ -299,6 +304,9 @@ export class MiyoClient {
       const url = new URL("/v0/folder", baseUrl);
       const headers = await this.buildHeaders();
       const body = JSON.stringify(request);
+      // Last point at which this registration can still be called off: once
+      // `requestUrl` has it, Obsidian offers no way to abort.
+      beforeRequest?.();
       logInfo("Miyo request:", {
         method: "POST",
         url: url.toString(),
@@ -367,11 +375,22 @@ export class MiyoClient {
    *
    * @param folderName - Registered folder name (see getMiyoFolderName).
    * @param overrideUrl - Explicit base URL (from settings) or empty for discovery.
+   * @param beforeRequest - Invoked once the URL and credentials are resolved and
+   *   immediately before the request goes out; throw from it to call the deletion
+   *   off. Exists because resolution and decryption are awaits, so a caller's
+   *   earlier check can go stale before anything is sent.
    */
-  public async deleteFolder(folderName: string, overrideUrl?: string): Promise<void> {
+  public async deleteFolder(
+    folderName: string,
+    overrideUrl?: string,
+    beforeRequest?: () => void
+  ): Promise<void> {
     const baseUrl = await this.resolveBaseUrl(overrideUrl);
     const headers = await this.buildHeaders();
     const url = new URL("/v0/folder", baseUrl);
+    // Last point at which this deletion can still be called off: once
+    // `requestUrl` has it, Obsidian offers no way to abort.
+    beforeRequest?.();
     logInfo("Miyo request:", {
       method: "DELETE",
       url: url.toString(),

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -228,7 +228,26 @@ describe("miyoResync", () => {
       expect(updateSetting).not.toHaveBeenCalled(); // empty receipt: nothing to clear
     });
 
-    it("rebuilds its own vanished registration, failing closed on the Miyo-side grants", async () => {
+    it("retries the re-add once so a transient failure keeps the record's grants", async () => {
+      // The grants are only knowable in the run that deleted the record. One
+      // more attempt here is the difference between preserving the user's Relay
+      // setting and resetting it on the next Resync.
+      rootMovedSettings();
+      currentSettings.miyoSyncedExclusions = receiptFor();
+      getFolder.mockResolvedValue(record({ allow_remote_read: true, allow_writes: false }));
+      addFolder.mockRejectedValueOnce(new Error("connection reset"));
+      addFolder.mockResolvedValue(record());
+
+      await expect(resyncMiyoFolder(app)).resolves.toBe("resynced");
+
+      expect(addFolder).toHaveBeenCalledTimes(2);
+      expect(addFolder).toHaveBeenLastCalledWith(
+        expect.objectContaining({ allow_remote_read: true, allow_writes: false }),
+        undefined
+      );
+    });
+
+    it("rebuilds its own vanished registration, and reports the grants it had to reset", async () => {
       // The receipt proves this vault WAS registered here; the server says it
       // isn't now. Refusing to re-add used to strand a rebuild that died between
       // its DELETE and its POST — every retry saw the same 404 and refused too.
@@ -238,10 +257,10 @@ describe("miyoResync", () => {
 
       const outcome = await resyncMiyoFolder(app);
 
-      expect(outcome).toBe("resynced");
-      // The vanished record's toggles are unknowable, so they are not guessed:
-      // re-granting Relay read to a vault whose owner turned it off is the one
-      // outcome that cannot be undone by noticing later.
+      // A distinct outcome, because the caller has to tell the user: the record
+      // that carried the grants is gone, and guessing `true` would re-grant
+      // Relay read to a vault whose owner had turned it off.
+      expect(outcome).toBe("resynced-grants-reset");
       expect(addFolder).toHaveBeenCalledWith(
         expect.objectContaining({ allow_remote_read: false, allow_writes: false }),
         undefined
@@ -250,12 +269,13 @@ describe("miyoResync", () => {
     });
 
     it("recovers on a second Resync after the re-add failed mid-rebuild", async () => {
-      // DELETE lands, POST throws: the registration and its index are gone while
-      // the receipt still names this vault. The next Resync must be able to
-      // repair that, since the same action caused it.
+      // DELETE lands, both POST attempts throw: the registration and its index
+      // are gone while the receipt still names this vault. The next Resync must
+      // be able to repair that, since the same action caused it.
       rootMovedSettings();
       currentSettings.miyoSyncedExclusions = receiptFor();
       getFolder.mockResolvedValueOnce(record());
+      addFolder.mockRejectedValueOnce(new Error("connection reset"));
       addFolder.mockRejectedValueOnce(new Error("connection reset"));
 
       await expect(resyncMiyoFolder(app)).resolves.toBe("failed");
@@ -266,8 +286,7 @@ describe("miyoResync", () => {
       checkFolderRegistration.mockResolvedValue("unregistered");
       addFolder.mockResolvedValue(record());
 
-      await expect(resyncMiyoFolder(app)).resolves.toBe("resynced");
-      expect(addFolder).toHaveBeenCalledTimes(2);
+      await expect(resyncMiyoFolder(app)).resolves.toBe("resynced-grants-reset");
       // No second DELETE — there was nothing left to delete.
       expect(deleteFolder).toHaveBeenCalledTimes(1);
     });
@@ -635,6 +654,27 @@ describe("miyoResync", () => {
 
     it("resolves with the task's value when the lifecycle is still current", async () => {
       await expect(enqueueMiyoFolderMutation(async () => "value")).resolves.toBe("value");
+    });
+    it("stops an in-flight mutation before it can delete on a closed vault's behalf", async () => {
+      // The previous coverage let the stale task's lookup return a covering
+      // record, so it only ever tried to write a receipt. Park it on a lookup
+      // that comes back STALE instead: without a guard before the DELETE, the
+      // task would go on to rebuild a registration for a vault that is gone.
+      rootMovedSettings();
+      currentSettings.miyoSyncedExclusions = receiptFor();
+      const lookup = deferred<MiyoFolderEntry>();
+      getFolder.mockReturnValueOnce(lookup.promise);
+
+      const stranded = resyncMiyoFolder(app);
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+      resetMiyoMutations();
+      lookup.resolve(record());
+
+      await expect(stranded).resolves.toBe("failed");
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(addFolder).not.toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -474,6 +474,28 @@ describe("miyoResync", () => {
       expect(updateSetting).not.toHaveBeenCalled();
     });
 
+    it("still re-registers when the lifecycle ends after its DELETE went out", async () => {
+      // The compensating POST deliberately carries no lifecycle hook: abandoning
+      // it once the DELETE succeeded would leave the vault unregistered. So the
+      // POST runs even though the lifecycle is gone — and the receipt, which is
+      // guarded, is not written. This is the trade-off the reset note records.
+      rootMovedSettings();
+      getFolder.mockResolvedValue(record());
+      const deleteLanded = deferred<void>();
+      deleteFolder.mockReturnValueOnce(deleteLanded.promise);
+
+      const pending = resyncMiyoFolder(app, session);
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+      expect(deleteFolder).toHaveBeenCalledTimes(1);
+
+      resetMiyoMutations();
+      deleteLanded.resolve();
+
+      await expect(pending).resolves.toBe("failed");
+      expect(addFolder).toHaveBeenCalledTimes(1);
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
     it("reports failed without touching Miyo when the caller's session has expired", async () => {
       // The Resync button lives in a tree that is never unmounted, so a click
       // handler bound under the outgoing vault stays callable. Its stale session

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -43,7 +43,8 @@ jest.mock("@/utils/vaultPath", () => ({ getVaultBase: jest.fn(() => "/abs/vault"
 
 import type { App } from "obsidian";
 import type { MiyoAddFolderRequest, MiyoFolderEntry } from "@/miyo/MiyoClient";
-import { miyoRecordCoversScope, resyncMiyoFolder, verifyMiyoScope } from "@/miyo/miyoResync";
+import { miyoRecordCoversSystemRoots, resyncMiyoFolder, verifyMiyoScope } from "@/miyo/miyoResync";
+import type { CopilotSettings } from "@/settings/model";
 
 const app = { vault: { getName: () => "my-vault" } } as unknown as App;
 
@@ -101,32 +102,44 @@ function rootMovedSettings(): void {
 }
 
 describe("miyoResync", () => {
-  describe("miyoRecordCoversScope()", () => {
-    const desired: MiyoAddFolderRequest = {
-      path: "/abs/vault",
-      exclude_folders: ["copilot", "team/ai"],
-    };
+  describe("miyoRecordCoversSystemRoots()", () => {
+    const movedRootSettings = () =>
+      ({
+        ...currentSettings,
+        copilotFolder: "team/ai",
+        copilotRootHistory: ["copilot", "team/ai"],
+      }) as CopilotSettings;
 
-    it("accepts a record whose exclusions are a superset of the desired ones", () => {
+    it("accepts a record whose exclusions are a superset of the system roots", () => {
       expect(
-        miyoRecordCoversScope(
+        miyoRecordCoversSystemRoots(
           record({ exclude_folders: ["copilot", "team/ai", "user-extra"] }),
-          desired
+          movedRootSettings()
         )
       ).toBe(true);
     });
 
-    it("rejects a record missing a desired exclusion", () => {
-      expect(miyoRecordCoversScope(record({ exclude_folders: ["copilot"] }), desired)).toBe(false);
+    it("rejects a record missing a system root", () => {
+      expect(
+        miyoRecordCoversSystemRoots(record({ exclude_folders: ["copilot"] }), movedRootSettings())
+      ).toBe(false);
     });
 
-    it("rejects a record whose inclusions differ (a different scope, not a superset)", () => {
+    it("ignores qa* and inclusion drift — the staleness signal is roots-only", () => {
+      // The user edited qaExclusions/qaInclusions since registration but never
+      // moved the root: that snapshot drift is the documented pre-existing gap,
+      // not grounds for a destructive rebuild.
+      const settings = {
+        ...currentSettings,
+        qaExclusions: "copilot,drifted-folder",
+        qaInclusions: "notes",
+      } as CopilotSettings;
       expect(
-        miyoRecordCoversScope(
-          record({ exclude_folders: ["copilot", "team/ai"], include_folders: ["notes"] }),
-          desired
+        miyoRecordCoversSystemRoots(
+          record({ exclude_folders: ["copilot"], include_folders: ["stale-whitelist"] }),
+          settings
         )
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -43,10 +43,24 @@ jest.mock("@/utils/vaultPath", () => ({ getVaultBase: jest.fn(() => "/abs/vault"
 
 import type { App } from "obsidian";
 import type { MiyoAddFolderRequest, MiyoFolderEntry } from "@/miyo/MiyoClient";
-import { miyoRecordCoversSystemRoots, resyncMiyoFolder, verifyMiyoScope } from "@/miyo/miyoResync";
+import {
+  miyoRecordCoversSystemRoots,
+  resetMiyoMutations,
+  resyncMiyoFolder,
+  verifyMiyoScope,
+} from "@/miyo/miyoResync";
 import type { CopilotSettings } from "@/settings/model";
 
 const app = { vault: { getName: () => "my-vault" } } as unknown as App;
+
+/** A promise whose settlement the test controls, to hold a mutation mid-flight. */
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
 
 /** Stored sync receipt; defaults to this device/endpoint/folder identity. */
 function receiptFor(
@@ -78,6 +92,9 @@ function record(over: Record<string, unknown> = {}): MiyoFolderEntry {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // The mutation queue is module state that outlives a single test just as it
+  // outlives a plugin lifecycle; start each test on a fresh chain and token.
+  resetMiyoMutations();
   currentSettings = {
     copilotFolder: "copilot",
     copilotRootHistory: ["copilot"],
@@ -277,6 +294,31 @@ describe("miyoResync", () => {
       await expect(first).resolves.toBe("verified");
       await expect(second).resolves.toBe("verified");
       expect(getFolder).toHaveBeenCalledTimes(2);
+    });
+
+    it("finishes the server-side rebuild but discards the receipt when the lifecycle ends mid-flight", async () => {
+      // A resync that got past DELETE must still complete its POST — abandoning
+      // it between the two is exactly what strands a vault unregistered. What
+      // must not survive is the receipt: this vault's settings store is gone.
+      rootMovedSettings();
+      currentSettings.miyoSyncedExclusions = receiptFor();
+      getFolder.mockResolvedValue(record());
+      const post = deferred<MiyoFolderEntry>();
+      addFolder.mockReturnValueOnce(post.promise);
+
+      const pending = resyncMiyoFolder(app);
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+      expect(deleteFolder).toHaveBeenCalledTimes(1);
+
+      // The vault closes while the POST is outstanding.
+      resetMiyoMutations();
+      post.resolve(record({ exclude_folders: ["copilot", "team/ai"] }));
+
+      // Server-side work completes; the local receipt does not follow it, and
+      // the caller sees a failure rather than a success it can act on.
+      await expect(pending).resolves.toBe("failed");
+      expect(addFolder).toHaveBeenCalledTimes(1);
+      expect(updateSetting).not.toHaveBeenCalled();
     });
 
     it("reports a conflict without deleting when the previous-name registration still exists", async () => {
@@ -490,6 +532,51 @@ describe("miyoResync", () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+  });
+
+  describe("resetMiyoMutations()", () => {
+    it("lets a new lifecycle run while a previous mutation is still hung", async () => {
+      // The failure this exists to fix: mutations are deliberately untimed, so
+      // without a fresh chain a request that never returns would block every
+      // Miyo operation for the newly opened vault.
+      const hung = deferred<MiyoFolderEntry>();
+      getFolder.mockReturnValueOnce(hung.promise);
+      getFolder.mockResolvedValue(record());
+
+      const stranded = resyncMiyoFolder(app);
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+      expect(getFolder).toHaveBeenCalledTimes(1);
+
+      resetMiyoMutations();
+
+      // Runs to completion with the first request still outstanding.
+      await expect(resyncMiyoFolder(app)).resolves.toBe("verified");
+
+      hung.resolve(record());
+      await expect(stranded).resolves.toBe("failed");
+    });
+
+    it("keeps a mutation queued behind the old chain from ever starting", async () => {
+      // A task that had not begun when the vault closed must not issue requests
+      // at all — unlike a started one, nothing is half-done that needs finishing.
+      const hung = deferred<MiyoFolderEntry>();
+      getFolder.mockReturnValueOnce(hung.promise);
+      getFolder.mockResolvedValue(record());
+
+      const running = resyncMiyoFolder(app);
+      const queued = resyncMiyoFolder(app);
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+      expect(getFolder).toHaveBeenCalledTimes(1);
+
+      resetMiyoMutations();
+      hung.resolve(record());
+
+      await expect(running).resolves.toBe("failed");
+      await expect(queued).resolves.toBe("failed");
+      // The queued run never reached its own lookup.
+      expect(getFolder).toHaveBeenCalledTimes(1);
+      expect(updateSetting).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -44,6 +44,7 @@ jest.mock("@/utils/vaultPath", () => ({ getVaultBase: jest.fn(() => "/abs/vault"
 import type { App } from "obsidian";
 import type { MiyoAddFolderRequest, MiyoFolderEntry } from "@/miyo/MiyoClient";
 import {
+  enqueueMiyoFolderMutation,
   miyoRecordCoversSystemRoots,
   resetMiyoMutations,
   resyncMiyoFolder,
@@ -227,16 +228,48 @@ describe("miyoResync", () => {
       expect(updateSetting).not.toHaveBeenCalled(); // empty receipt: nothing to clear
     });
 
-    it("clears this device's receipt when its registration is confirmed gone", async () => {
+    it("rebuilds its own vanished registration, failing closed on the Miyo-side grants", async () => {
+      // The receipt proves this vault WAS registered here; the server says it
+      // isn't now. Refusing to re-add used to strand a rebuild that died between
+      // its DELETE and its POST — every retry saw the same 404 and refused too.
       currentSettings.miyoSyncedExclusions = receiptFor();
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
       const outcome = await resyncMiyoFolder(app);
 
-      expect(outcome).toBe("unregistered");
-      expect(addFolder).not.toHaveBeenCalled();
-      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", "");
+      expect(outcome).toBe("resynced");
+      // The vanished record's toggles are unknowable, so they are not guessed:
+      // re-granting Relay read to a vault whose owner turned it off is the one
+      // outcome that cannot be undone by noticing later.
+      expect(addFolder).toHaveBeenCalledWith(
+        expect.objectContaining({ allow_remote_read: false, allow_writes: false }),
+        undefined
+      );
+      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", expect.any(String));
+    });
+
+    it("recovers on a second Resync after the re-add failed mid-rebuild", async () => {
+      // DELETE lands, POST throws: the registration and its index are gone while
+      // the receipt still names this vault. The next Resync must be able to
+      // repair that, since the same action caused it.
+      rootMovedSettings();
+      currentSettings.miyoSyncedExclusions = receiptFor();
+      getFolder.mockResolvedValueOnce(record());
+      addFolder.mockRejectedValueOnce(new Error("connection reset"));
+
+      await expect(resyncMiyoFolder(app)).resolves.toBe("failed");
+      expect(deleteFolder).toHaveBeenCalledTimes(1);
+
+      // Second click: the folder now 404s, and the receipt still vouches for it.
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockResolvedValue("unregistered");
+      addFolder.mockResolvedValue(record());
+
+      await expect(resyncMiyoFolder(app)).resolves.toBe("resynced");
+      expect(addFolder).toHaveBeenCalledTimes(2);
+      // No second DELETE — there was nothing left to delete.
+      expect(deleteFolder).toHaveBeenCalledTimes(1);
     });
 
     it("reports a conflict and keeps the stale receipt when re-add hits 409", async () => {
@@ -577,6 +610,31 @@ describe("miyoResync", () => {
       // The queued run never reached its own lookup.
       expect(getFolder).toHaveBeenCalledTimes(1);
       expect(updateSetting).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("enqueueMiyoFolderMutation()", () => {
+    it("rejects a task that completed after its lifecycle ended", async () => {
+      // The register flow writes its receipt in the caller's continuation, after
+      // the awaited call returns — outside anything this module can guard. Only
+      // rejecting the promise keeps that continuation from running, so this is
+      // the contract that stops one vault's registration from landing in another.
+      const started = deferred<void>();
+      const finish = deferred<string>();
+      const pending = enqueueMiyoFolderMutation(() => {
+        started.resolve();
+        return finish.promise;
+      });
+      await started.promise;
+
+      resetMiyoMutations();
+      finish.resolve("would-have-been-returned");
+
+      await expect(pending).rejects.toThrow();
+    });
+
+    it("resolves with the task's value when the lifecycle is still current", async () => {
+      await expect(enqueueMiyoFolderMutation(async () => "value")).resolves.toBe("value");
     });
   });
 });

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -212,11 +212,11 @@ describe("miyoResync", () => {
       expect(body.allow_remote_read).toBe(false);
     });
 
-    it("never re-registers an unregistered vault — registration needs explicit consent", async () => {
-      // At the 404, "a prior rebuild was interrupted" and "the user removed
-      // the registration in Miyo" are indistinguishable, so the resync must
-      // not re-register (it would silently reverse a deliberate removal and
-      // re-grant Relay). Recovery goes through the register flow.
+    it("does not re-register on a 404 it has no receipt to vouch for", async () => {
+      // Without a receipt naming this device/endpoint/folder there is no evidence
+      // this vault was ever registered here, so a 404 says "never used Miyo" —
+      // not "our own rebuild was interrupted". Registering would be inventing
+      // consent; the vouched-for case is covered by the next test.
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -474,6 +474,55 @@ describe("miyoResync", () => {
       expect(updateSetting).not.toHaveBeenCalled();
     });
 
+    it("keeps the record's own exclusions instead of narrowing to the Copilot scope", async () => {
+      // `PATCH /v0/folder` lets any client tighten a registration, so the record
+      // is not ours alone. Replacing its filters with only the Copilot-derived
+      // scope would re-index what its owner excluded — and with Relay on, expose
+      // it. Excludes always win server-side, so the union is the safe direction.
+      rootMovedSettings();
+      getFolder.mockResolvedValue(
+        record({
+          exclude_folders: ["copilot", "Private"],
+          exclude_patterns: ["**/secret/**"],
+        })
+      );
+
+      await expect(resyncMiyoFolder(app, session)).resolves.toBe("resynced");
+
+      const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
+      expect(body.exclude_folders).toEqual(
+        expect.arrayContaining(["copilot", "team/ai", "Private"])
+      );
+      expect(body.exclude_patterns).toEqual(expect.arrayContaining(["**/secret/**"]));
+    });
+
+    it("keeps the record's include whitelist rather than widening it with ours", async () => {
+      // Include filters are an OR whitelist, so unioning would ADD everything
+      // our side lists to what the record permitted. Preserving the record's is
+      // the only direction that cannot end up broader than the server enforced.
+      rootMovedSettings();
+      currentSettings.qaInclusions = "Notes";
+      getFolder.mockResolvedValue(record({ include_folders: ["OnlyThis"] }));
+
+      await resyncMiyoFolder(app, session);
+
+      const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
+      expect(body.include_folders).toEqual(["OnlyThis"]);
+    });
+
+    it("applies our include whitelist when the record carries none", async () => {
+      // No whitelist on the record means nothing is narrowed today; applying
+      // ours narrows, which is the safe direction.
+      rootMovedSettings();
+      currentSettings.qaInclusions = "Notes";
+      getFolder.mockResolvedValue(record());
+
+      await resyncMiyoFolder(app, session);
+
+      const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
+      expect(body.include_folders).toEqual(expect.arrayContaining(["Notes"]));
+    });
+
     it("still re-registers when the lifecycle ends after its DELETE went out", async () => {
       // The compensating POST deliberately carries no lifecycle hook: abandoning
       // it once the DELETE succeeded would leave the vault unregistered. So the

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -1,0 +1,383 @@
+jest.mock("@/logger");
+
+// miyoUtils (real) pulls these at module load; stub so importing here is inert.
+jest.mock("@/plusUtils", () => ({ isSelfHostModeValidFor: jest.fn() }));
+jest.mock("@/miyo/miyoStatusStore", () => ({
+  isMiyoAvailableForCapability: jest.fn(),
+  getMiyoStatusSnapshot: jest.fn(),
+  refreshMiyoStatus: jest.fn(),
+}));
+jest.mock("@/utils/deviceId", () => ({ getDeviceId: jest.fn(() => "device-A") }));
+
+// Controllable Miyo client; the class type is erased (type-only imports).
+const resolveBaseUrl = jest.fn<Promise<string>, unknown[]>();
+const getFolder = jest.fn<Promise<unknown>, unknown[]>();
+const checkFolderRegistration = jest.fn<Promise<string>, unknown[]>();
+const deleteFolder = jest.fn<Promise<void>, unknown[]>();
+const addFolder = jest.fn<Promise<unknown>, unknown[]>();
+const scanFolder = jest.fn<Promise<unknown>, unknown[]>();
+jest.mock("@/miyo/MiyoClient", () => ({
+  MiyoClient: class {
+    resolveBaseUrl = (...a: unknown[]) => resolveBaseUrl(...a);
+    getFolder = (...a: unknown[]) => getFolder(...a);
+    checkFolderRegistration = (...a: unknown[]) => checkFolderRegistration(...a);
+    deleteFolder = (...a: unknown[]) => deleteFolder(...a);
+    addFolder = (...a: unknown[]) => addFolder(...a);
+    scanFolder = (...a: unknown[]) => scanFolder(...a);
+  },
+}));
+
+const updateSetting = jest.fn<void, unknown[]>();
+let currentSettings: Record<string, unknown>;
+// Keep the real module (searchUtils needs its normalizeRootFolders); override
+// only the settings accessors the resync reads/writes.
+jest.mock("@/settings/model", () => ({
+  ...jest.requireActual<object>("@/settings/model"),
+  getSettings: jest.fn(() => currentSettings),
+  updateSetting: (...a: unknown[]) => {
+    updateSetting(...a);
+  },
+}));
+
+jest.mock("@/utils/vaultPath", () => ({ getVaultBase: jest.fn(() => "/abs/vault") }));
+
+import type { App } from "obsidian";
+import type { MiyoAddFolderRequest, MiyoFolderEntry } from "@/miyo/MiyoClient";
+import { miyoRecordCoversScope, resyncMiyoFolder, verifyMiyoScope } from "@/miyo/miyoResync";
+
+const app = { vault: { getName: () => "my-vault" } } as unknown as App;
+
+/** Stored sync receipt; defaults to this device/endpoint/folder identity. */
+function receiptFor(
+  over: Partial<{ device: string; url: string; folder: string; roots: string[] }> = {}
+): string {
+  return JSON.stringify({
+    device: "device-A",
+    url: "",
+    folder: "my-vault",
+    roots: ["copilot"],
+    ...over,
+  });
+}
+
+/** Folder record as Miyo returns it; loose shape like the real entry type. */
+function record(over: Record<string, unknown> = {}): MiyoFolderEntry {
+  return {
+    path: "my-vault",
+    exclude_folders: ["copilot"],
+    exclude_patterns: [],
+    include_folders: [],
+    include_patterns: [],
+    include_extensions: [],
+    allow_remote_read: true,
+    allow_writes: true,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  currentSettings = {
+    copilotFolder: "copilot",
+    copilotRootHistory: ["copilot"],
+    miyoServerUrl: "",
+    qaInclusions: "",
+    qaExclusions: "copilot",
+    miyoSyncedExclusions: "",
+  };
+  resolveBaseUrl.mockResolvedValue("http://miyo");
+  deleteFolder.mockResolvedValue(undefined);
+  addFolder.mockResolvedValue(record());
+  scanFolder.mockResolvedValue({});
+});
+
+/** Settings for a vault whose root moved to team/ai (record above is stale). */
+function rootMovedSettings(): void {
+  currentSettings = {
+    ...currentSettings,
+    copilotFolder: "team/ai",
+    copilotRootHistory: ["copilot", "team/ai"],
+  };
+}
+
+describe("miyoResync", () => {
+  describe("miyoRecordCoversScope()", () => {
+    const desired: MiyoAddFolderRequest = {
+      path: "/abs/vault",
+      exclude_folders: ["copilot", "team/ai"],
+    };
+
+    it("accepts a record whose exclusions are a superset of the desired ones", () => {
+      expect(
+        miyoRecordCoversScope(
+          record({ exclude_folders: ["copilot", "team/ai", "user-extra"] }),
+          desired
+        )
+      ).toBe(true);
+    });
+
+    it("rejects a record missing a desired exclusion", () => {
+      expect(miyoRecordCoversScope(record({ exclude_folders: ["copilot"] }), desired)).toBe(false);
+    });
+
+    it("rejects a record whose inclusions differ (a different scope, not a superset)", () => {
+      expect(
+        miyoRecordCoversScope(
+          record({ exclude_folders: ["copilot", "team/ai"], include_folders: ["notes"] }),
+          desired
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("resyncMiyoFolder()", () => {
+    it("verifies without rebuilding when the record already covers the scope", async () => {
+      getFolder.mockResolvedValue(record());
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("verified");
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(addFolder).not.toHaveBeenCalled();
+      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", expect.any(String));
+    });
+
+    it("deletes and re-registers with the fresh scope when the record is stale", async () => {
+      rootMovedSettings();
+      getFolder.mockResolvedValue(record()); // still only excludes "copilot"
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("resynced");
+      expect(deleteFolder).toHaveBeenCalledWith("my-vault", undefined);
+      const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
+      expect(body.path).toBe("/abs/vault");
+      expect(body.exclude_folders).toEqual(expect.arrayContaining(["copilot", "team/ai"]));
+      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", expect.any(String));
+      expect(scanFolder).toHaveBeenCalled();
+    });
+
+    it("carries the record's Relay opt-out into the re-registration", async () => {
+      rootMovedSettings();
+      getFolder.mockResolvedValue(record({ allow_remote_read: false }));
+
+      await resyncMiyoFolder(app);
+
+      const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
+      expect(body.allow_remote_read).toBe(false);
+    });
+
+    it("fails closed on Relay when the record omits the field", async () => {
+      // Omitting allow_remote_read makes the server default it to TRUE —
+      // silently re-enabling Relay for a user who opted out in Miyo.
+      rootMovedSettings();
+      const stale = record({ allow_remote_read: undefined });
+      delete (stale as Record<string, unknown>).allow_remote_read;
+      getFolder.mockResolvedValue(stale);
+
+      await resyncMiyoFolder(app);
+
+      const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
+      expect(body.allow_remote_read).toBe(false);
+    });
+
+    it("recovers an unregistered vault by registering directly (no delete)", async () => {
+      // A prior run deleted but never re-added, or the user removed the folder
+      // in Miyo: GET 404 → POST straight away.
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockResolvedValue("unregistered");
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("resynced");
+      expect(deleteFolder).not.toHaveBeenCalled();
+      const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
+      expect(body.allow_remote_read).toBe(true); // register-flow default
+    });
+
+    it("reports a conflict and keeps the stale receipt when re-add hits 409", async () => {
+      rootMovedSettings();
+      getFolder.mockResolvedValue(record());
+      addFolder.mockResolvedValue(null); // 409 → null per addFolder contract
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("conflict");
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("fails without writing anything when the record can't be read", async () => {
+      getFolder.mockRejectedValue(new Error("boom"));
+      checkFolderRegistration.mockResolvedValue("error");
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("failed");
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("still writes the receipt when only the re-scan trigger fails", async () => {
+      // The scope is committed; Miyo re-scans on its own. Staying dirty would
+      // provoke another destructive delete/re-add for a self-healing lag.
+      rootMovedSettings();
+      getFolder.mockResolvedValue(record());
+      scanFolder.mockRejectedValue(new Error("scan down"));
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("resynced-scan-failed");
+      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", expect.any(String));
+    });
+
+    it("serializes concurrent runs instead of interleaving them", async () => {
+      let releaseFirst!: (value: MiyoFolderEntry) => void;
+      getFolder.mockImplementationOnce(
+        () => new Promise<unknown>((resolve) => (releaseFirst = resolve))
+      );
+      getFolder.mockResolvedValue(record());
+
+      const first = resyncMiyoFolder(app);
+      const second = resyncMiyoFolder(app);
+      // Flush pending microtasks so the first run reaches its blocked getFolder.
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+      // The second run must not start (no second getFolder) while the first
+      // still holds the mutation chain.
+      expect(getFolder).toHaveBeenCalledTimes(1);
+
+      releaseFirst(record());
+      await expect(first).resolves.toBe("verified");
+      await expect(second).resolves.toBe("verified");
+      expect(getFolder).toHaveBeenCalledTimes(2);
+    });
+
+    it("cleans up the old registration when the vault was renamed on this device", async () => {
+      // GET by the new name 404s, but the receipt shows THIS device+endpoint
+      // registered under the old name — that stale registration is deleted
+      // before registering the new name.
+      currentSettings.miyoSyncedExclusions = receiptFor({ folder: "old-vault-name" });
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockResolvedValue("unregistered");
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("resynced");
+      expect(deleteFolder).toHaveBeenCalledWith("old-vault-name", undefined);
+    });
+
+    it("never deletes based on a foreign device's receipt", async () => {
+      currentSettings.miyoSyncedExclusions = receiptFor({
+        device: "device-B",
+        folder: "old-vault-name",
+      });
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockResolvedValue("unregistered");
+
+      await resyncMiyoFolder(app);
+
+      expect(deleteFolder).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("verifyMiyoScope()", () => {
+    it("reports covered and self-heals the receipt when the record enforces the scope", async () => {
+      getFolder.mockResolvedValue(record());
+      currentSettings.miyoSyncedExclusions = receiptFor({ device: "device-B" }); // foreign, mismatch
+
+      const verdict = await verifyMiyoScope(app);
+
+      expect(verdict).toBe("covered");
+      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", expect.any(String));
+    });
+
+    it("reports stale without touching the receipt when the record misses the scope", async () => {
+      rootMovedSettings();
+      getFolder.mockResolvedValue(record()); // only excludes "copilot"
+
+      const verdict = await verifyMiyoScope(app);
+
+      expect(verdict).toBe("stale");
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("clears the receipt on 404 only when it names exactly this device/endpoint/folder", async () => {
+      currentSettings.miyoSyncedExclusions = receiptFor();
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockResolvedValue("unregistered");
+
+      const verdict = await verifyMiyoScope(app);
+
+      expect(verdict).toBe("unregistered");
+      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", "");
+    });
+
+    it("keeps the receipt and reports stale on 404 after a same-device rename", async () => {
+      // The old registration may still exist under the old name; the receipt is
+      // the only cleanup lead and must survive.
+      currentSettings.miyoSyncedExclusions = receiptFor({ folder: "old-vault-name" });
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockResolvedValue("unregistered");
+
+      const verdict = await verifyMiyoScope(app);
+
+      expect(verdict).toBe("stale");
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("never clears a non-empty receipt it cannot parse", async () => {
+      // An unparseable value can't be attributed to any identity; wiping it
+      // would sync out and destroy whatever evidence it holds elsewhere.
+      currentSettings.miyoSyncedExclusions = "not-json";
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockResolvedValue("unregistered");
+
+      const verdict = await verifyMiyoScope(app);
+
+      expect(verdict).toBe("unregistered");
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("leaves a foreign device's receipt untouched on 404", async () => {
+      // Clearing it would clobber the other device's evidence via settings sync.
+      currentSettings.miyoSyncedExclusions = receiptFor({ device: "device-B" });
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockResolvedValue("unregistered");
+
+      const verdict = await verifyMiyoScope(app);
+
+      expect(verdict).toBe("unregistered");
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("reports unknown when the registration state can't be determined", async () => {
+      getFolder.mockRejectedValue(new Error("boom"));
+      checkFolderRegistration.mockResolvedValue("error");
+
+      const verdict = await verifyMiyoScope(app);
+
+      expect(verdict).toBe("unknown");
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("times out a hung lookup so the mutation chain keeps moving", async () => {
+      jest.useFakeTimers();
+      try {
+        // A Miyo that accepts the connection but never responds must not hold
+        // the chain forever: the lookup timeout fails this verify, and a
+        // queued resync still gets its turn.
+        getFolder.mockImplementationOnce(() => new Promise<never>(() => {}));
+        checkFolderRegistration.mockResolvedValue("error");
+
+        const verify = verifyMiyoScope(app);
+        await jest.advanceTimersByTimeAsync(10_001);
+        await expect(verify).resolves.toBe("unknown");
+
+        getFolder.mockResolvedValue(record());
+        await expect(verifyMiyoScope(app)).resolves.toBe("covered");
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+});

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -21,8 +21,18 @@ jest.mock("@/miyo/MiyoClient", () => ({
     resolveBaseUrl = (...a: unknown[]) => resolveBaseUrl(...a);
     getFolder = (...a: unknown[]) => getFolder(...a);
     checkFolderRegistration = (...a: unknown[]) => checkFolderRegistration(...a);
-    deleteFolder = (...a: unknown[]) => deleteFolder(...a);
-    addFolder = (...a: unknown[]) => addFolder(...a);
+    // The destructive calls run their `beforeRequest` hook before delegating,
+    // exactly where the real client runs it: after URL/credential resolution and
+    // before `requestUrl`. A hook that throws must therefore leave the spy
+    // untouched, which is what "no request went out" means at this boundary.
+    deleteFolder = (folderName: unknown, url: unknown, beforeRequest?: () => void) => {
+      beforeRequest?.();
+      return deleteFolder(folderName, url, beforeRequest);
+    };
+    addFolder = (request: unknown, url: unknown, beforeRequest?: () => void) => {
+      beforeRequest?.();
+      return addFolder(request, url, beforeRequest);
+    };
     scanFolder = (...a: unknown[]) => scanFolder(...a);
   },
 }));
@@ -50,6 +60,7 @@ import {
   resyncMiyoFolder,
   verifyMiyoScope,
 } from "@/miyo/miyoResync";
+import type { MiyoMutationSession } from "@/miyo/miyoResync";
 import type { CopilotSettings } from "@/settings/model";
 
 const app = { vault: { getName: () => "my-vault" } } as unknown as App;
@@ -91,11 +102,15 @@ function record(over: Record<string, unknown> = {}): MiyoFolderEntry {
   };
 }
 
+// Session for the lifecycle `beforeEach` established. Tests that reset mid-way
+// keep a reference to this one to act as the outgoing lifecycle's producer.
+let session: MiyoMutationSession;
+
 beforeEach(() => {
   jest.clearAllMocks();
   // The mutation queue is module state that outlives a single test just as it
   // outlives a plugin lifecycle; start each test on a fresh chain and token.
-  resetMiyoMutations();
+  session = resetMiyoMutations();
   currentSettings = {
     copilotFolder: "copilot",
     copilotRootHistory: ["copilot"],
@@ -165,7 +180,7 @@ describe("miyoResync", () => {
     it("verifies without rebuilding when the record already covers the scope", async () => {
       getFolder.mockResolvedValue(record());
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("verified");
       expect(deleteFolder).not.toHaveBeenCalled();
@@ -177,10 +192,10 @@ describe("miyoResync", () => {
       rootMovedSettings();
       getFolder.mockResolvedValue(record()); // still only excludes "copilot"
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("resynced");
-      expect(deleteFolder).toHaveBeenCalledWith("my-vault", undefined);
+      expect(deleteFolder).toHaveBeenCalledWith("my-vault", undefined, expect.any(Function));
       const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
       expect(body.path).toBe("/abs/vault");
       expect(body.exclude_folders).toEqual(expect.arrayContaining(["copilot", "team/ai"]));
@@ -192,7 +207,7 @@ describe("miyoResync", () => {
       rootMovedSettings();
       getFolder.mockResolvedValue(record({ allow_remote_read: false }));
 
-      await resyncMiyoFolder(app);
+      await resyncMiyoFolder(app, session);
 
       const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
       expect(body.allow_remote_read).toBe(false);
@@ -206,7 +221,7 @@ describe("miyoResync", () => {
       delete (stale as Record<string, unknown>).allow_remote_read;
       getFolder.mockResolvedValue(stale);
 
-      await resyncMiyoFolder(app);
+      await resyncMiyoFolder(app, session);
 
       const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
       expect(body.allow_remote_read).toBe(false);
@@ -220,7 +235,7 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("unregistered");
       expect(deleteFolder).not.toHaveBeenCalled();
@@ -238,11 +253,14 @@ describe("miyoResync", () => {
       addFolder.mockRejectedValueOnce(new Error("connection reset"));
       addFolder.mockResolvedValue(record());
 
-      await expect(resyncMiyoFolder(app)).resolves.toBe("resynced");
+      await expect(resyncMiyoFolder(app, session)).resolves.toBe("resynced");
 
       expect(addFolder).toHaveBeenCalledTimes(2);
+      // No `beforeRequest` on this one, deliberately: once the DELETE is out the
+      // POST has to follow or the vault is left unregistered.
       expect(addFolder).toHaveBeenLastCalledWith(
         expect.objectContaining({ allow_remote_read: true, allow_writes: false }),
+        undefined,
         undefined
       );
     });
@@ -255,7 +273,7 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       // A distinct outcome, because the caller has to tell the user: the record
       // that carried the grants is gone, and guessing `true` would re-grant
@@ -263,7 +281,8 @@ describe("miyoResync", () => {
       expect(outcome).toBe("resynced-grants-reset");
       expect(addFolder).toHaveBeenCalledWith(
         expect.objectContaining({ allow_remote_read: false, allow_writes: false }),
-        undefined
+        undefined,
+        expect.any(Function)
       );
       expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", expect.any(String));
     });
@@ -278,7 +297,7 @@ describe("miyoResync", () => {
       addFolder.mockRejectedValueOnce(new Error("connection reset"));
       addFolder.mockRejectedValueOnce(new Error("connection reset"));
 
-      await expect(resyncMiyoFolder(app)).resolves.toBe("failed");
+      await expect(resyncMiyoFolder(app, session)).resolves.toBe("failed");
       expect(deleteFolder).toHaveBeenCalledTimes(1);
 
       // Second click: the folder now 404s, and the receipt still vouches for it.
@@ -286,7 +305,7 @@ describe("miyoResync", () => {
       checkFolderRegistration.mockResolvedValue("unregistered");
       addFolder.mockResolvedValue(record());
 
-      await expect(resyncMiyoFolder(app)).resolves.toBe("resynced-grants-reset");
+      await expect(resyncMiyoFolder(app, session)).resolves.toBe("resynced-grants-reset");
       // No second DELETE — there was nothing left to delete.
       expect(deleteFolder).toHaveBeenCalledTimes(1);
     });
@@ -296,7 +315,7 @@ describe("miyoResync", () => {
       getFolder.mockResolvedValue(record());
       addFolder.mockResolvedValue(null); // 409 → null per addFolder contract
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("conflict");
       expect(updateSetting).not.toHaveBeenCalled();
@@ -306,7 +325,7 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("boom"));
       checkFolderRegistration.mockResolvedValue("error");
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("failed");
       expect(deleteFolder).not.toHaveBeenCalled();
@@ -320,7 +339,7 @@ describe("miyoResync", () => {
       getFolder.mockResolvedValue(record());
       scanFolder.mockRejectedValue(new Error("scan down"));
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("resynced-scan-failed");
       expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", expect.any(String));
@@ -333,8 +352,8 @@ describe("miyoResync", () => {
       );
       getFolder.mockResolvedValue(record());
 
-      const first = resyncMiyoFolder(app);
-      const second = resyncMiyoFolder(app);
+      const first = resyncMiyoFolder(app, session);
+      const second = resyncMiyoFolder(app, session);
       // Flush pending microtasks so the first run reaches its blocked getFolder.
       await new Promise((resolve) => window.setTimeout(resolve, 0));
 
@@ -358,7 +377,7 @@ describe("miyoResync", () => {
       const post = deferred<MiyoFolderEntry>();
       addFolder.mockReturnValueOnce(post.promise);
 
-      const pending = resyncMiyoFolder(app);
+      const pending = resyncMiyoFolder(app, session);
       await new Promise((resolve) => window.setTimeout(resolve, 0));
       expect(deleteFolder).toHaveBeenCalledTimes(1);
 
@@ -385,7 +404,7 @@ describe("miyoResync", () => {
         Promise.resolve(name === "old-vault-name" ? "registered" : "unregistered")
       );
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("conflict");
       expect(deleteFolder).not.toHaveBeenCalled();
@@ -402,7 +421,7 @@ describe("miyoResync", () => {
         Promise.resolve(name === "old-vault-name" ? "error" : "unregistered")
       );
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("failed");
       expect(deleteFolder).not.toHaveBeenCalled();
@@ -417,7 +436,7 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("unregistered");
       expect(deleteFolder).not.toHaveBeenCalled();
@@ -431,7 +450,7 @@ describe("miyoResync", () => {
       // a remote registration.
       currentSettings.miyoServerUrl = "https://miyo.example.com";
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("failed");
       expect(getFolder).not.toHaveBeenCalled();
@@ -448,10 +467,28 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, session);
 
       expect(outcome).toBe("unregistered");
       expect(deleteFolder).not.toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("reports failed without touching Miyo when the caller's session has expired", async () => {
+      // The Resync button lives in a tree that is never unmounted, so a click
+      // handler bound under the outgoing vault stays callable. Its stale session
+      // must stop the DELETE/POST rather than rebuild the outgoing vault's
+      // registration from inside the incoming one.
+      rootMovedSettings();
+      const staleSession = session;
+      getFolder.mockResolvedValue(record());
+
+      resetMiyoMutations();
+
+      await expect(resyncMiyoFolder(app, staleSession)).resolves.toBe("failed");
+      expect(getFolder).not.toHaveBeenCalled();
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(addFolder).not.toHaveBeenCalled();
       expect(updateSetting).not.toHaveBeenCalled();
     });
   });
@@ -461,7 +498,7 @@ describe("miyoResync", () => {
       getFolder.mockResolvedValue(record());
       currentSettings.miyoSyncedExclusions = receiptFor({ device: "device-B" }); // foreign, mismatch
 
-      const verdict = await verifyMiyoScope(app);
+      const verdict = await verifyMiyoScope(app, session);
 
       expect(verdict).toBe("covered");
       expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", expect.any(String));
@@ -471,7 +508,7 @@ describe("miyoResync", () => {
       rootMovedSettings();
       getFolder.mockResolvedValue(record()); // only excludes "copilot"
 
-      const verdict = await verifyMiyoScope(app);
+      const verdict = await verifyMiyoScope(app, session);
 
       expect(verdict).toBe("stale");
       expect(updateSetting).not.toHaveBeenCalled();
@@ -482,7 +519,7 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
-      const verdict = await verifyMiyoScope(app);
+      const verdict = await verifyMiyoScope(app, session);
 
       expect(verdict).toBe("unregistered");
       expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", "");
@@ -497,7 +534,7 @@ describe("miyoResync", () => {
         Promise.resolve(name === "old-vault-name" ? "registered" : "unregistered")
       );
 
-      const verdict = await verifyMiyoScope(app);
+      const verdict = await verifyMiyoScope(app, session);
 
       expect(verdict).toBe("stale");
       expect(updateSetting).not.toHaveBeenCalled();
@@ -512,7 +549,7 @@ describe("miyoResync", () => {
         Promise.resolve(name === "old-vault-name" ? "error" : "unregistered")
       );
 
-      const verdict = await verifyMiyoScope(app);
+      const verdict = await verifyMiyoScope(app, session);
 
       expect(verdict).toBe("unknown");
       expect(updateSetting).not.toHaveBeenCalled();
@@ -525,7 +562,7 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
-      const verdict = await verifyMiyoScope(app);
+      const verdict = await verifyMiyoScope(app, session);
 
       expect(verdict).toBe("unregistered");
       expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", "");
@@ -538,7 +575,7 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
-      const verdict = await verifyMiyoScope(app);
+      const verdict = await verifyMiyoScope(app, session);
 
       expect(verdict).toBe("unregistered");
       expect(updateSetting).not.toHaveBeenCalled();
@@ -550,7 +587,7 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
-      const verdict = await verifyMiyoScope(app);
+      const verdict = await verifyMiyoScope(app, session);
 
       expect(verdict).toBe("unregistered");
       expect(updateSetting).not.toHaveBeenCalled();
@@ -560,7 +597,7 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("boom"));
       checkFolderRegistration.mockResolvedValue("error");
 
-      const verdict = await verifyMiyoScope(app);
+      const verdict = await verifyMiyoScope(app, session);
 
       expect(verdict).toBe("unknown");
       expect(updateSetting).not.toHaveBeenCalled();
@@ -575,15 +612,29 @@ describe("miyoResync", () => {
         getFolder.mockImplementationOnce(() => new Promise<never>(() => {}));
         checkFolderRegistration.mockResolvedValue("error");
 
-        const verify = verifyMiyoScope(app);
+        const verify = verifyMiyoScope(app, session);
         await jest.advanceTimersByTimeAsync(10_001);
         await expect(verify).resolves.toBe("unknown");
 
         getFolder.mockResolvedValue(record());
-        await expect(verifyMiyoScope(app)).resolves.toBe("covered");
+        await expect(verifyMiyoScope(app, session)).resolves.toBe("covered");
       } finally {
         jest.useRealTimers();
       }
+    });
+
+    it("reports unknown without writing a receipt when the caller's session has expired", async () => {
+      // The root-change probe fires from an async tail that can outlive its
+      // vault. A covering record would otherwise self-heal the receipt — into
+      // whichever vault is open by then, describing a scope that is not its own.
+      const staleSession = session;
+      getFolder.mockResolvedValue(record());
+
+      resetMiyoMutations();
+
+      await expect(verifyMiyoScope(app, staleSession)).resolves.toBe("unknown");
+      expect(getFolder).not.toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled();
     });
   });
 
@@ -596,14 +647,15 @@ describe("miyoResync", () => {
       getFolder.mockReturnValueOnce(hung.promise);
       getFolder.mockResolvedValue(record());
 
-      const stranded = resyncMiyoFolder(app);
+      const stranded = resyncMiyoFolder(app, session);
       await new Promise((resolve) => window.setTimeout(resolve, 0));
       expect(getFolder).toHaveBeenCalledTimes(1);
 
-      resetMiyoMutations();
+      const nextLifecycle = resetMiyoMutations();
 
-      // Runs to completion with the first request still outstanding.
-      await expect(resyncMiyoFolder(app)).resolves.toBe("verified");
+      // Runs to completion with the first request still outstanding. Uses the
+      // session the reset handed back — the incoming lifecycle's own proof.
+      await expect(resyncMiyoFolder(app, nextLifecycle)).resolves.toBe("verified");
 
       hung.resolve(record());
       await expect(stranded).resolves.toBe("failed");
@@ -616,8 +668,8 @@ describe("miyoResync", () => {
       getFolder.mockReturnValueOnce(hung.promise);
       getFolder.mockResolvedValue(record());
 
-      const running = resyncMiyoFolder(app);
-      const queued = resyncMiyoFolder(app);
+      const running = resyncMiyoFolder(app, session);
+      const queued = resyncMiyoFolder(app, session);
       await new Promise((resolve) => window.setTimeout(resolve, 0));
       expect(getFolder).toHaveBeenCalledTimes(1);
 
@@ -643,7 +695,7 @@ describe("miyoResync", () => {
       const pending = enqueueMiyoFolderMutation(() => {
         started.resolve();
         return finish.promise;
-      });
+      }, session);
       await started.promise;
 
       resetMiyoMutations();
@@ -653,8 +705,24 @@ describe("miyoResync", () => {
     });
 
     it("resolves with the task's value when the lifecycle is still current", async () => {
-      await expect(enqueueMiyoFolderMutation(async () => "value")).resolves.toBe("value");
+      await expect(enqueueMiyoFolderMutation(async () => "value", session)).resolves.toBe("value");
     });
+
+    it("refuses a producer whose session predates the current lifecycle", async () => {
+      // The producers that can reach here after a vault switch — the settings
+      // tab's never-unmounted React tree, an open MiyoConnectModal, the
+      // root-change async tail — hold a session taken when they were created.
+      // Reading the token at enqueue time instead would hand them the incoming
+      // vault's token and let them act on it.
+      const staleSession = session;
+      const task = jest.fn(async () => "ran");
+
+      resetMiyoMutations();
+
+      await expect(enqueueMiyoFolderMutation(task, staleSession)).rejects.toThrow();
+      expect(task).not.toHaveBeenCalled();
+    });
+
     it("stops an in-flight mutation before it can delete on a closed vault's behalf", async () => {
       // The previous coverage let the stale task's lookup return a covering
       // record, so it only ever tried to write a receipt. Park it on a lookup
@@ -665,7 +733,7 @@ describe("miyoResync", () => {
       const lookup = deferred<MiyoFolderEntry>();
       getFolder.mockReturnValueOnce(lookup.promise);
 
-      const stranded = resyncMiyoFolder(app);
+      const stranded = resyncMiyoFolder(app, session);
       await new Promise((resolve) => window.setTimeout(resolve, 0));
 
       resetMiyoMutations();

--- a/src/miyo/miyoResync.test.ts
+++ b/src/miyo/miyoResync.test.ts
@@ -194,18 +194,32 @@ describe("miyoResync", () => {
       expect(body.allow_remote_read).toBe(false);
     });
 
-    it("recovers an unregistered vault by registering directly (no delete)", async () => {
-      // A prior run deleted but never re-added, or the user removed the folder
-      // in Miyo: GET 404 → POST straight away.
+    it("never re-registers an unregistered vault — registration needs explicit consent", async () => {
+      // At the 404, "a prior rebuild was interrupted" and "the user removed
+      // the registration in Miyo" are indistinguishable, so the resync must
+      // not re-register (it would silently reverse a deliberate removal and
+      // re-grant Relay). Recovery goes through the register flow.
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
       const outcome = await resyncMiyoFolder(app);
 
-      expect(outcome).toBe("resynced");
+      expect(outcome).toBe("unregistered");
       expect(deleteFolder).not.toHaveBeenCalled();
-      const body = addFolder.mock.calls[0][0] as MiyoAddFolderRequest;
-      expect(body.allow_remote_read).toBe(true); // register-flow default
+      expect(addFolder).not.toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled(); // empty receipt: nothing to clear
+    });
+
+    it("clears this device's receipt when its registration is confirmed gone", async () => {
+      currentSettings.miyoSyncedExclusions = receiptFor();
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockResolvedValue("unregistered");
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("unregistered");
+      expect(addFolder).not.toHaveBeenCalled();
+      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", "");
     });
 
     it("reports a conflict and keeps the stale receipt when re-add hits 409", async () => {
@@ -265,21 +279,74 @@ describe("miyoResync", () => {
       expect(getFolder).toHaveBeenCalledTimes(2);
     });
 
-    it("cleans up the old registration when the vault was renamed on this device", async () => {
-      // GET by the new name 404s, but the receipt shows THIS device+endpoint
-      // registered under the old name — that stale registration is deleted
-      // before registering the new name.
+    it("reports a conflict without deleting when the previous-name registration still exists", async () => {
+      // GET by the current name 404s and the receipt shows THIS device+endpoint
+      // under a different, still-registered name. That name may belong to
+      // ANOTHER vault by now (folder names are just vault names), so nothing is
+      // deleted or cleared — the user cleans up in Miyo, and the kept receipt
+      // keeps verify reporting the exposure.
+      currentSettings.miyoSyncedExclusions = receiptFor({ folder: "old-vault-name" });
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockImplementation((name) =>
+        Promise.resolve(name === "old-vault-name" ? "registered" : "unregistered")
+      );
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("conflict");
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(addFolder).not.toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("fails without accusing when the previous-name probe can't determine the state", async () => {
+      // A transient error must not instruct the user to delete a registration
+      // whose existence is unconfirmed; the receipt survives for the retry.
+      currentSettings.miyoSyncedExclusions = receiptFor({ folder: "old-vault-name" });
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockImplementation((name) =>
+        Promise.resolve(name === "old-vault-name" ? "error" : "unregistered")
+      );
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("failed");
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("consumes the rename receipt when the previous-name registration is confirmed gone", async () => {
+      // The user already removed the old registration in Miyo: the probe
+      // confirms it, so the receipt clears instead of reporting a conflict
+      // forever after the user followed the cleanup instruction.
       currentSettings.miyoSyncedExclusions = receiptFor({ folder: "old-vault-name" });
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
       const outcome = await resyncMiyoFolder(app);
 
-      expect(outcome).toBe("resynced");
-      expect(deleteFolder).toHaveBeenCalledWith("old-vault-name", undefined);
+      expect(outcome).toBe("unregistered");
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(addFolder).not.toHaveBeenCalled();
+      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", "");
     });
 
-    it("never deletes based on a foreign device's receipt", async () => {
+    it("refuses to run when the endpoint flipped to a remote target while queued", async () => {
+      // Callers gate on a local endpoint before enqueueing; the queued task
+      // re-checks at execution so a mid-queue URL switch can't make it mutate
+      // a remote registration.
+      currentSettings.miyoServerUrl = "https://miyo.example.com";
+
+      const outcome = await resyncMiyoFolder(app);
+
+      expect(outcome).toBe("failed");
+      expect(getFolder).not.toHaveBeenCalled();
+      expect(deleteFolder).not.toHaveBeenCalled();
+      expect(addFolder).not.toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("never deletes or clears based on a foreign device's receipt", async () => {
       currentSettings.miyoSyncedExclusions = receiptFor({
         device: "device-B",
         folder: "old-vault-name",
@@ -287,9 +354,11 @@ describe("miyoResync", () => {
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
-      await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app);
 
+      expect(outcome).toBe("unregistered");
       expect(deleteFolder).not.toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled();
     });
   });
 
@@ -326,16 +395,46 @@ describe("miyoResync", () => {
     });
 
     it("keeps the receipt and reports stale on 404 after a same-device rename", async () => {
-      // The old registration may still exist under the old name; the receipt is
+      // The old registration still exists under the old name; the receipt is
       // the only cleanup lead and must survive.
+      currentSettings.miyoSyncedExclusions = receiptFor({ folder: "old-vault-name" });
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockImplementation((name) =>
+        Promise.resolve(name === "old-vault-name" ? "registered" : "unregistered")
+      );
+
+      const verdict = await verifyMiyoScope(app);
+
+      expect(verdict).toBe("stale");
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("reports unknown when the previous-name probe can't determine the state", async () => {
+      // Same three-state rule as the resync path: only a confirmed
+      // "registered" may drive the stale banner and its cleanup instruction.
+      currentSettings.miyoSyncedExclusions = receiptFor({ folder: "old-vault-name" });
+      getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
+      checkFolderRegistration.mockImplementation((name) =>
+        Promise.resolve(name === "old-vault-name" ? "error" : "unregistered")
+      );
+
+      const verdict = await verifyMiyoScope(app);
+
+      expect(verdict).toBe("unknown");
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("consumes the rename receipt once the old-name registration is confirmed gone", async () => {
+      // The user followed the cleanup prompt and removed the old registration
+      // in Miyo: the probe confirms it, the receipt clears, the banner ends.
       currentSettings.miyoSyncedExclusions = receiptFor({ folder: "old-vault-name" });
       getFolder.mockRejectedValue(new Error("Miyo request failed with status 404"));
       checkFolderRegistration.mockResolvedValue("unregistered");
 
       const verdict = await verifyMiyoScope(app);
 
-      expect(verdict).toBe("stale");
-      expect(updateSetting).not.toHaveBeenCalled();
+      expect(verdict).toBe("unregistered");
+      expect(updateSetting).toHaveBeenCalledWith("miyoSyncedExclusions", "");
     });
 
     it("never clears a non-empty receipt it cannot parse", async () => {

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -52,6 +52,25 @@ export type MiyoResyncOutcome =
   /** Transport/setup failure (Miyo unreachable, no vault base, …); still stale. */
   | "failed";
 
+/**
+ * DESIGN NOTE — the queue below is module state that a token makes behave like
+ * instance state. A coordinator the plugin owns and disposes
+ * (`plugin.miyoMutations.dispose()`) is the honest shape: object identity is
+ * unique per instance, so it would genuinely remove `mutationLifecycle`, the
+ * monotonic-collision reasoning, `MiyoMutationSession`, and the numeric token
+ * threaded through five call sites — this is a change of state ownership, not a
+ * rename.
+ *
+ * Deferred anyway, and the reason is cost of timing, not size: every guard point
+ * still has to survive the move, including the enqueue EXIT check, because the
+ * register flow writes its receipt after the awaited call returns
+ * (`MiyoSettings.tsx`, the `submission.created` branch) — outside anything the
+ * queue can wrap. Doing that now re-opens the review surface of an area that has
+ * taken five rounds to settle, on a PR whose blocking review is already answered.
+ * No issue is filed yet, so treat this as deferred rather than tracked.
+ * If a future review flags the module-level state, point them here — for the
+ * shape, not as an argument that it is not worth doing.
+ */
 // Serializes every Miyo folder mutation. Reason: the settings-tab Resync button
 // and the register flow can otherwise interleave DELETE/POST against the same
 // registration. The chain mirrors the agent-skills seedChain: each task reads
@@ -70,17 +89,6 @@ let mutationLifecycle = 0;
 
 /**
  * A producer's proof of which plugin lifecycle it belongs to.
- *
- * DESIGN NOTE — the queue below is module state that a token makes behave like
- * instance state. The honest shape is a coordinator the plugin OWNS and disposes
- * (`plugin.miyoMutations.dispose()`), since a new plugin instance would then get
- * a new queue for free and a stale settings tree would hold the disposed one.
- * Deliberately not done here: it still needs an explicit `disposed` flag (that
- * is this token under another name), every guard point below stays — including
- * the enqueue EXIT check, because the register flow writes its receipt after the
- * awaited call returns, outside anything the queue can wrap — and it would reset
- * the review surface of this whole area for a rename. Tracked as follow-up.
- * If a future review flags the module-level state again, point them here.
  *
  * Held instead of a bare number so it can only be obtained from
  * {@link resetMiyoMutations} — i.e. by the lifecycle owner, at the moment the

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -71,6 +71,17 @@ let mutationLifecycle = 0;
 /**
  * A producer's proof of which plugin lifecycle it belongs to.
  *
+ * DESIGN NOTE — the queue below is module state that a token makes behave like
+ * instance state. The honest shape is a coordinator the plugin OWNS and disposes
+ * (`plugin.miyoMutations.dispose()`), since a new plugin instance would then get
+ * a new queue for free and a stale settings tree would hold the disposed one.
+ * Deliberately not done here: it still needs an explicit `disposed` flag (that
+ * is this token under another name), every guard point below stays — including
+ * the enqueue EXIT check, because the register flow writes its receipt after the
+ * awaited call returns, outside anything the queue can wrap — and it would reset
+ * the review surface of this whole area for a rename. Tracked as follow-up.
+ * If a future review flags the module-level state again, point them here.
+ *
  * Held instead of a bare number so it can only be obtained from
  * {@link resetMiyoMutations} — i.e. by the lifecycle owner, at the moment the
  * previous lifecycle's queue is abandoned. There is deliberately no way to ask

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -1,0 +1,377 @@
+import { logInfo, logWarn } from "@/logger";
+import { MiyoClient, type MiyoAddFolderRequest, type MiyoFolderEntry } from "@/miyo/MiyoClient";
+import {
+  buildMiyoSyncReceipt,
+  getMiyoCustomUrl,
+  getMiyoFolderExclusions,
+  getMiyoFolderInclusions,
+  getMiyoFolderName,
+  parseMiyoSyncReceipt,
+  type MiyoSyncReceipt,
+} from "@/miyo/miyoUtils";
+import { extractAppIgnoreSettings, getSystemExcludedFolders } from "@/search/searchUtils";
+import { getSettings, updateSetting } from "@/settings/model";
+import { err2String } from "@/utils";
+import { getDeviceId } from "@/utils/deviceId";
+import { getVaultBase } from "@/utils/vaultPath";
+import type { App } from "obsidian";
+
+/**
+ * Resynchronize the vault's Miyo registration with the current Copilot scope.
+ *
+ * Miyo only receives exclusions as a registration-time snapshot, so a Copilot
+ * root change leaves the server indexing content that should be excluded (and
+ * readable via Relay). This module owns the reconcile: verify the live record,
+ * and only when it genuinely diverges, delete + re-register with the fresh
+ * scope (deletion also purges the folder's index, verified empirically).
+ *
+ * All Miyo folder mutations — resync runs AND the register flow — must pass
+ * through {@link enqueueMiyoFolderMutation} so a resync can never interleave
+ * its DELETE/POST with a concurrent registration.
+ */
+
+/** Result of one resync run, for the caller to map onto user-facing messages. */
+export type MiyoResyncOutcome =
+  /** Server record already covered the scope; receipt written, nothing rebuilt. */
+  | "verified"
+  /** Deleted + re-registered with the fresh scope; re-scan kicked off. */
+  | "resynced"
+  /** Re-registered, but the re-scan trigger failed; Miyo re-scans on its own. */
+  | "resynced-scan-failed"
+  /** Re-add hit 409 right after a delete — server state contested; still stale. */
+  | "conflict"
+  /** Transport/setup failure (Miyo unreachable, no vault base, …); still stale. */
+  | "failed";
+
+// Serializes every Miyo folder mutation. Reason: the auto-resync after a root
+// change, the settings-tab Resync button, and the register flow can otherwise
+// interleave DELETE/POST against the same registration. The chain mirrors the
+// agent-skills seedChain: each task reads fresh state when IT runs (so a root
+// change mid-run simply enqueues a later run that sees the newer root), and the
+// chain itself never rejects so one failure can't strand later mutations.
+let mutationChain: Promise<unknown> = Promise.resolve();
+
+/**
+ * Run `task` behind every previously enqueued Miyo folder mutation. Returns the
+ * task's own promise (rejections reach the caller; the chain stays resolved).
+ *
+ * @param task - Mutation to serialize; invoked once its turn arrives.
+ */
+export function enqueueMiyoFolderMutation<T>(task: () => Promise<T>): Promise<T> {
+  const run = mutationChain.then(task);
+  mutationChain = run.catch(() => {
+    /* keep the chain alive for the next mutation */
+  });
+  return run;
+}
+
+/** How long a read-only Miyo lookup may hold the mutation chain. */
+const LOOKUP_TIMEOUT_MS = 10_000;
+
+/**
+ * Bound a READ-ONLY lookup so a Miyo that accepts the connection but never
+ * responds can't hold the mutation chain forever (Obsidian's `requestUrl` has
+ * no timeout of its own — see `fetchHealth`'s probe timeout for the precedent).
+ *
+ * DESIGN NOTE — mutations (DELETE/POST/scan) are deliberately NOT wrapped.
+ * `requestUrl` is uncancellable: racing a mutation against a timer would let
+ * the chain advance while the request may still land later, which is exactly
+ * the interleaving the chain exists to prevent. A hung mutation therefore still
+ * blocks the queue; the read-only bound covers the common mount-verify path.
+ * If a future review flags this again, point them here.
+ */
+function withLookupTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = window.setTimeout(
+      () => reject(new Error(`Miyo ${label} timed out after ${LOOKUP_TIMEOUT_MS}ms`)),
+      LOOKUP_TIMEOUT_MS
+    );
+    promise.then(
+      (value) => {
+        window.clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        window.clearTimeout(timer);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    );
+  });
+}
+
+/**
+ * Whether the stored receipt vouches for the registration currently being
+ * queried — same device, same Miyo endpoint, same folder name. Only then may a
+ * 404 be read as "our registration is gone"; a foreign or renamed identity says
+ * nothing about the record the receipt actually describes.
+ */
+function receiptMatchesIdentity(
+  receipt: MiyoSyncReceipt,
+  settings: { miyoServerUrl?: string },
+  folderName: string
+): boolean {
+  return (
+    receipt.device === getDeviceId() &&
+    receipt.url === (settings.miyoServerUrl || "").trim() &&
+    receipt.folder === folderName
+  );
+}
+
+/** String-array field of a folder record, read defensively (loose entry type). */
+function recordArray(record: MiyoFolderEntry, key: string): string[] {
+  const value = record[key];
+  return Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+}
+
+function isSuperset(container: readonly string[], required: readonly string[]): boolean {
+  const set = new Set(container);
+  return required.every((entry) => set.has(entry));
+}
+
+function sameSet(a: readonly string[], b: readonly string[]): boolean {
+  return isSuperset(a, b) && isSuperset(b, a);
+}
+
+/**
+ * Whether the live folder record already enforces the desired scope, making a
+ * destructive delete + re-register (and the full re-index it implies)
+ * unnecessary. Exclusions may be a superset (extra, user-added Miyo-side
+ * exclusions are privacy-safe and not ours to fight); inclusions must match
+ * exactly, since a different whitelist is a genuinely different scope.
+ *
+ * DESIGN NOTE — the superset rule cannot tell a Miyo-side user exclusion from
+ * a Copilot-pushed exclusion the user has since REMOVED from `qaExclusions`.
+ * After such a removal the server keeps excluding that folder, this check still
+ * reads "covered", and the content stays unindexed until a manual
+ * re-registration — a search-miss, not a privacy leak (the leak direction is
+ * always caught, since a MISSING desired exclusion fails the superset).
+ * Distinguishing the two would require the receipt to carry the full pushed
+ * exclusion list and a three-way compare; exact equality instead would make
+ * resync destroy genuine Miyo-side privacy exclusions, which is strictly
+ * worse. If a future review flags this again, point them here.
+ *
+ * @param record - Live folder entry fetched from Miyo.
+ * @param desired - Freshly-built registration body for the current scope.
+ */
+export function miyoRecordCoversScope(
+  record: MiyoFolderEntry,
+  desired: MiyoAddFolderRequest
+): boolean {
+  return (
+    isSuperset(recordArray(record, "exclude_folders"), desired.exclude_folders ?? []) &&
+    isSuperset(recordArray(record, "exclude_patterns"), desired.exclude_patterns ?? []) &&
+    sameSet(recordArray(record, "include_folders"), desired.include_folders ?? []) &&
+    sameSet(recordArray(record, "include_patterns"), desired.include_patterns ?? []) &&
+    sameSet(recordArray(record, "include_extensions"), desired.include_extensions ?? [])
+  );
+}
+
+/** Registration body for the current scope (shared by resync and verify). */
+function buildDesiredScope(app: App, settings = getSettings()): MiyoAddFolderRequest {
+  return {
+    path: getVaultBase(app) ?? "",
+    ...getMiyoFolderInclusions(settings.qaInclusions),
+    ...getMiyoFolderExclusions(settings.qaExclusions, [
+      ...getSystemExcludedFolders(settings),
+      ...extractAppIgnoreSettings(app),
+    ]),
+  };
+}
+
+/**
+ * Resync the vault's Miyo registration to the current scope. Never throws —
+ * every failure maps to an outcome so fire-and-forget callers stay safe.
+ *
+ * Serialized via {@link enqueueMiyoFolderMutation}; reads settings fresh when
+ * its turn arrives, so a queued run always reconciles toward the latest scope.
+ *
+ * @param app - Active Obsidian app (vault name/base for the registration).
+ */
+export function resyncMiyoFolder(app: App): Promise<MiyoResyncOutcome> {
+  return enqueueMiyoFolderMutation(() => runResync(app));
+}
+
+/** Result of a read-only scope verification against the live Miyo record. */
+export type MiyoScopeVerification = "covered" | "stale" | "unregistered" | "unknown";
+
+/**
+ * Verify the live Miyo record against the current scope WITHOUT rebuilding,
+ * self-healing the local receipt where the server is the better witness:
+ *
+ * - record covers the scope but the local receipt mismatches (another device's
+ *   receipt arrived via sync, a sync merge reordered history, …) → write the
+ *   current receipt silently; no banner, no destructive rebuild.
+ * - vault not registered AND the stored receipt names exactly this
+ *   device/endpoint/folder → the registration it vouched for is truly gone
+ *   (user removed it in Miyo); clear the receipt. A 404 with a DIFFERENT
+ *   receipt identity proves nothing about the record the receipt describes:
+ *   a renamed vault (same device+endpoint, old folder name) reports "stale" so
+ *   the old registration gets surfaced and cleaned up; a foreign-device or
+ *   other-endpoint receipt is left untouched and reads "unregistered" (nothing
+ *   is exposed on THIS server).
+ * - record does NOT cover the scope → "stale": the caller must surface the
+ *   resync prompt even if local state looks clean (Reset Settings wiped the
+ *   receipt, or the user registered before receipts existed) — the live record
+ *   outranks local signals in both directions.
+ *
+ * Never throws; unreachable Miyo reports "unknown" so callers fall back to the
+ * local mismatch signal.
+ *
+ * @param app - Active Obsidian app (vault name for the registration lookup).
+ */
+export function verifyMiyoScope(app: App): Promise<MiyoScopeVerification> {
+  return enqueueMiyoFolderMutation(() => runVerify(app));
+}
+
+async function runVerify(app: App): Promise<MiyoScopeVerification> {
+  try {
+    const settings = getSettings();
+    const folderName = getMiyoFolderName(app);
+    const customUrl = getMiyoCustomUrl(settings) || undefined;
+    const client = new MiyoClient();
+    const baseUrl = await client.resolveBaseUrl(customUrl);
+
+    let record: MiyoFolderEntry;
+    try {
+      record = await withLookupTimeout(client.getFolder(baseUrl, folderName), "folder lookup");
+    } catch {
+      const registration = await withLookupTimeout(
+        client.checkFolderRegistration(folderName, customUrl),
+        "registration check"
+      );
+      if (registration !== "unregistered") {
+        return "unknown";
+      }
+      const receipt = parseMiyoSyncReceipt(settings.miyoSyncedExclusions);
+      if (!receipt) {
+        // Empty — nothing to clear — or non-empty but unparseable. The latter
+        // cannot be attributed to any identity, so it is never cleared: wiping
+        // it would sync out and destroy whatever evidence it holds elsewhere.
+        return "unregistered";
+      }
+      if (receiptMatchesIdentity(receipt, settings, folderName)) {
+        updateSetting("miyoSyncedExclusions", "");
+        return "unregistered";
+      }
+      // Same device + endpoint but a different folder name: the vault was
+      // renamed and the OLD registration may still exist (and expose content).
+      // Keep the receipt as the cleanup lead and surface the prompt.
+      if (receipt.device === getDeviceId() && receipt.url === getMiyoCustomUrl(settings)) {
+        return "stale";
+      }
+      // Foreign device / other endpoint: says nothing about this server, and
+      // clearing it would clobber the other device's evidence via sync.
+      return "unregistered";
+    }
+
+    if (!miyoRecordCoversScope(record, buildDesiredScope(app, settings))) {
+      return "stale";
+    }
+    const receipt = buildMiyoSyncReceipt(app, settings);
+    if (settings.miyoSyncedExclusions !== receipt) {
+      updateSetting("miyoSyncedExclusions", receipt);
+    }
+    return "covered";
+  } catch (error) {
+    logWarn(`Miyo scope verification failed: ${err2String(error)}`);
+    return "unknown";
+  }
+}
+
+async function runResync(app: App): Promise<MiyoResyncOutcome> {
+  try {
+    const settings = getSettings();
+    const vaultBase = getVaultBase(app);
+    if (!vaultBase) {
+      logWarn("Miyo resync: no vault base path (mobile/remote?); cannot resync.");
+      return "failed";
+    }
+    const folderName = getMiyoFolderName(app);
+    const customUrl = getMiyoCustomUrl(settings) || undefined;
+    const client = new MiyoClient();
+    const baseUrl = await client.resolveBaseUrl(customUrl);
+
+    // Capture the receipt for the scope we are about to commit. Written only
+    // after that exact commit succeeds — never recomputed afterwards, so a root
+    // change landing mid-run can't get marked as synced by this run (its own
+    // queued run will reconcile it).
+    const receipt = buildMiyoSyncReceipt(app, settings);
+    const desired = buildDesiredScope(app, settings);
+
+    // Verify first: a record that already enforces the scope needs no rebuild.
+    let record: MiyoFolderEntry | null = null;
+    try {
+      record = await withLookupTimeout(client.getFolder(baseUrl, folderName), "folder lookup");
+    } catch (error) {
+      const registration = await withLookupTimeout(
+        client.checkFolderRegistration(folderName, customUrl),
+        "registration check"
+      );
+      if (registration !== "unregistered") {
+        logWarn(`Miyo resync: could not read folder record: ${err2String(error)}`);
+        return "failed";
+      }
+      // Unregistered: recovery path — a prior run deleted but never re-added
+      // (or the user removed it in Miyo). Register directly with the fresh scope.
+      // If the receipt shows THIS device+endpoint registered under a different
+      // folder name, the vault was renamed and the old registration still
+      // exists — delete it so it can't keep serving stale content. Never act on
+      // a foreign-device or other-endpoint receipt: it is not ours to delete.
+      const staleReceipt = parseMiyoSyncReceipt(settings.miyoSyncedExclusions);
+      if (
+        staleReceipt &&
+        staleReceipt.device === getDeviceId() &&
+        staleReceipt.url === getMiyoCustomUrl(settings) &&
+        staleReceipt.folder !== folderName
+      ) {
+        await client.deleteFolder(staleReceipt.folder, customUrl);
+      }
+    }
+
+    if (record) {
+      if (miyoRecordCoversScope(record, desired)) {
+        updateSetting("miyoSyncedExclusions", receipt);
+        logInfo("Miyo resync: server record already covers the scope; receipt updated.");
+        return "verified";
+      }
+      // Carry the user's Miyo-side toggles into the re-registration. Fail
+      // closed when a field is absent: omitting allow_remote_read makes the
+      // server default it to TRUE, silently re-enabling Relay for a user who
+      // opted out in Miyo — the exact privacy hole this resync exists to close.
+      desired.allow_remote_read = record.allow_remote_read === true;
+      desired.allow_writes = record.allow_writes === true;
+
+      await client.deleteFolder(folderName, customUrl);
+    } else {
+      // Fresh registration (recovery): match the register flow's defaults.
+      desired.allow_remote_read = true;
+    }
+
+    const created = await client.addFolder(desired, customUrl);
+    if (created === null) {
+      // 409 right after a delete (or on the recovery path): the server still
+      // holds a registration we couldn't replace. Do NOT write the receipt —
+      // its exclusions are unknown and possibly stale.
+      logWarn("Miyo resync: re-add returned 409; server registration contested.");
+      return "conflict";
+    }
+
+    updateSetting("miyoSyncedExclusions", receipt);
+
+    try {
+      await client.scanFolder(baseUrl, folderName, false);
+      return "resynced";
+    } catch (error) {
+      // The scope is committed and the receipt is correct; only the re-index
+      // kick failed. Miyo re-scans registered folders on its own (verified on a
+      // live instance: last_scan advances days after registration), so surface
+      // a warning instead of staying dirty — staying dirty would provoke
+      // another destructive delete/re-add for a self-healing lag.
+      logWarn(`Miyo resync: re-scan trigger failed: ${err2String(error)}`);
+      return "resynced-scan-failed";
+    }
+  } catch (error) {
+    logWarn(`Miyo resync failed: ${err2String(error)}`);
+    return "failed";
+  }
+}

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -6,6 +6,7 @@ import {
   getMiyoFolderExclusions,
   getMiyoFolderInclusions,
   getMiyoFolderName,
+  isLocalMiyoUrl,
   parseMiyoSyncReceipt,
   type MiyoSyncReceipt,
 } from "@/miyo/miyoUtils";
@@ -38,8 +39,13 @@ export type MiyoResyncOutcome =
   | "resynced"
   /** Re-registered, but the re-scan trigger failed; Miyo re-scans on its own. */
   | "resynced-scan-failed"
-  /** Re-add hit 409 right after a delete — server state contested; still stale. */
+  /** Server holds a registration this flow can't safely replace (409 right
+   *  after a delete, or one left under this vault's previous name) — manual
+   *  cleanup in Miyo; still stale. */
   | "conflict"
+  /** Vault not registered with Miyo; nothing rebuilt — registering is the
+   *  register flow's job (it carries explicit user consent). */
+  | "unregistered"
   /** Transport/setup failure (Miyo unreachable, no vault base, …); still stale. */
   | "failed";
 
@@ -248,8 +254,23 @@ async function runVerify(app: App): Promise<MiyoScopeVerification> {
       }
       // Same device + endpoint but a different folder name: the vault was
       // renamed and the OLD registration may still exist (and expose content).
-      // Keep the receipt as the cleanup lead and surface the prompt.
+      // A read-only probe settles it: still registered → keep the receipt as
+      // the cleanup lead and surface the prompt; confirmed gone (the user
+      // cleaned it up in Miyo) → consume the receipt so the banner can end.
       if (receipt.device === getDeviceId() && receipt.url === getMiyoCustomUrl(settings)) {
+        const oldName = await withLookupTimeout(
+          client.checkFolderRegistration(receipt.folder, customUrl),
+          "previous-name check"
+        );
+        if (oldName === "unregistered") {
+          updateSetting("miyoSyncedExclusions", "");
+          return "unregistered";
+        }
+        if (oldName !== "registered") {
+          // Transient failure: the old registration's existence is unknown —
+          // neither accuse nor clear; report like any other failed lookup.
+          return "unknown";
+        }
         return "stale";
       }
       // Foreign device / other endpoint: says nothing about this server, and
@@ -280,7 +301,18 @@ async function runResync(app: App): Promise<MiyoResyncOutcome> {
       return "failed";
     }
     const folderName = getMiyoFolderName(app);
-    const customUrl = getMiyoCustomUrl(settings) || undefined;
+    const miyoUrl = getMiyoCustomUrl(settings);
+    // Reason: callers gate on a LOCAL endpoint before enqueueing, but this
+    // task reads settings fresh when its turn arrives — the endpoint may have
+    // been switched to a remote target while queued. A remote registration is
+    // not this flow's to DELETE/POST (and the body would leak this machine's
+    // vault path), so refuse and stay retryable — mirroring registerVault's
+    // execution-time re-check.
+    if (!isLocalMiyoUrl(miyoUrl)) {
+      logWarn("Miyo resync: endpoint switched to a remote target while queued; not resyncing.");
+      return "failed";
+    }
+    const customUrl = miyoUrl || undefined;
     const client = new MiyoClient();
     const baseUrl = await client.resolveBaseUrl(customUrl);
 
@@ -292,7 +324,7 @@ async function runResync(app: App): Promise<MiyoResyncOutcome> {
     const desired = buildDesiredScope(app, settings);
 
     // Verify first: a record that already enforces the scope needs no rebuild.
-    let record: MiyoFolderEntry | null = null;
+    let record: MiyoFolderEntry;
     try {
       record = await withLookupTimeout(client.getFolder(baseUrl, folderName), "folder lookup");
     } catch (error) {
@@ -304,47 +336,82 @@ async function runResync(app: App): Promise<MiyoResyncOutcome> {
         logWarn(`Miyo resync: could not read folder record: ${err2String(error)}`);
         return "failed";
       }
-      // Unregistered: recovery path — a prior run deleted but never re-added
-      // (or the user removed it in Miyo). Register directly with the fresh scope.
-      // If the receipt shows THIS device+endpoint registered under a different
-      // folder name, the vault was renamed and the old registration still
-      // exists — delete it so it can't keep serving stale content. Never act on
-      // a foreign-device or other-endpoint receipt: it is not ours to delete.
+      // DESIGN NOTE — an unregistered vault triggers NO server mutation here.
+      // (a) It is NOT re-registered: "a prior rebuild was interrupted between
+      //     DELETE and POST" and "the user removed the registration in Miyo"
+      //     are indistinguishable, and every registration in this product is
+      //     an explicit user action (Connect / Add this vault).
+      //     Auto-registering would silently reverse a deliberate removal —
+      //     and the toggles the stale-record path carries (Relay opt-out)
+      //     have no source here, so it would also re-grant allow_remote_read.
+      // (b) A receipt naming a DIFFERENT folder on this device+endpoint is
+      //     NOT auto-deleted either: folder names are just vault names, so
+      //     the receipt cannot prove that name still belongs to this vault —
+      //     another vault may have registered the same name since, and
+      //     deleting on receipt evidence alone could destroy that vault's
+      //     registration and index. Manual cleanup is surfaced instead.
+      // If a future review flags this again, point them here.
       const staleReceipt = parseMiyoSyncReceipt(settings.miyoSyncedExclusions);
       if (
         staleReceipt &&
         staleReceipt.device === getDeviceId() &&
-        staleReceipt.url === getMiyoCustomUrl(settings) &&
-        staleReceipt.folder !== folderName
+        staleReceipt.url === getMiyoCustomUrl(settings)
       ) {
-        await client.deleteFolder(staleReceipt.folder, customUrl);
+        if (staleReceipt.folder !== folderName) {
+          // Read-only probe: once the old-name registration is confirmed gone
+          // (the user cleaned it up in Miyo), the receipt is consumed —
+          // without this, following our own "remove it in Miyo, then retry"
+          // instruction would keep reporting a conflict forever.
+          const oldName = await withLookupTimeout(
+            client.checkFolderRegistration(staleReceipt.folder, customUrl),
+            "previous-name check"
+          );
+          if (oldName === "unregistered") {
+            updateSetting("miyoSyncedExclusions", "");
+            return "unregistered";
+          }
+          if (oldName !== "registered") {
+            // Transient failure: don't tell the user to delete a registration
+            // whose existence is unconfirmed — keep the receipt and retry.
+            logWarn("Miyo resync: could not determine the previous-name registration's state.");
+            return "failed";
+          }
+          // Still registered: keep the receipt — it is the only evidence that
+          // keeps verify reporting the exposure until the user cleans up.
+          logWarn(
+            "Miyo resync: a registration under this vault's previous name still exists; " +
+              "remove it in the Miyo app."
+          );
+          return "conflict";
+        }
+        // The registration the receipt vouched for is confirmed gone: clear
+        // it so verify stops reporting a stale registration that no longer
+        // exists. Foreign-device / other-endpoint receipts are never touched
+        // — they are not ours to clear.
+        updateSetting("miyoSyncedExclusions", "");
       }
+      return "unregistered";
     }
 
-    if (record) {
-      if (miyoRecordCoversSystemRoots(record, settings)) {
-        updateSetting("miyoSyncedExclusions", receipt);
-        logInfo("Miyo resync: server record already covers the scope; receipt updated.");
-        return "verified";
-      }
-      // Carry the user's Miyo-side toggles into the re-registration. Fail
-      // closed when a field is absent: omitting allow_remote_read makes the
-      // server default it to TRUE, silently re-enabling Relay for a user who
-      // opted out in Miyo — the exact privacy hole this resync exists to close.
-      desired.allow_remote_read = record.allow_remote_read === true;
-      desired.allow_writes = record.allow_writes === true;
-
-      await client.deleteFolder(folderName, customUrl);
-    } else {
-      // Fresh registration (recovery): match the register flow's defaults.
-      desired.allow_remote_read = true;
+    if (miyoRecordCoversSystemRoots(record, settings)) {
+      updateSetting("miyoSyncedExclusions", receipt);
+      logInfo("Miyo resync: server record already covers the scope; receipt updated.");
+      return "verified";
     }
+    // Carry the user's Miyo-side toggles into the re-registration. Fail
+    // closed when a field is absent: omitting allow_remote_read makes the
+    // server default it to TRUE, silently re-enabling Relay for a user who
+    // opted out in Miyo — the exact privacy hole this resync exists to close.
+    desired.allow_remote_read = record.allow_remote_read === true;
+    desired.allow_writes = record.allow_writes === true;
+
+    await client.deleteFolder(folderName, customUrl);
 
     const created = await client.addFolder(desired, customUrl);
     if (created === null) {
-      // 409 right after a delete (or on the recovery path): the server still
-      // holds a registration we couldn't replace. Do NOT write the receipt —
-      // its exclusions are unknown and possibly stale.
+      // 409 right after a delete: the server still holds a registration we
+      // couldn't replace. Do NOT write the receipt — its exclusions are
+      // unknown and possibly stale.
       logWarn("Miyo resync: re-add returned 409; server registration contested.");
       return "conflict";
     }

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -138,10 +138,17 @@ export interface MiyoMutationSession {
  * chain instead would restore ordering, but only by blocking the new lifecycle
  * behind the hung request — the failure this function exists to fix, and the one
  * the maintainer named. `requestUrl` cannot be aborted, so no third option
- * exists for a request already sent. Recovery is the Resync button: the
- * lifecycle guard stops the outgoing POST that would have followed, so the
- * incoming vault is left unregistered rather than holding a wrong scope, and its
- * own banner reports that.
+ * exists for a request already sent.
+ *
+ * The worst case is worth stating plainly rather than softened: the outgoing
+ * lifecycle's compensating POST deliberately carries no lifecycle hook (see
+ * {@link addFolderPreservingGrants} — abandoning it after its DELETE succeeded
+ * would leave a vault unregistered), so when both lifecycles share an endpoint
+ * and a folder name, the late DELETE can remove the incoming registration and
+ * the POST then re-create it under the OUTGOING vault's path and scope. The
+ * incoming vault's own receipt no longer matches that record, which is what its
+ * banner keys on; Resync repairs it. Ordering this correctly would need either a
+ * blocking chain (rejected above) or an abortable transport (Obsidian has none).
  * If a future review flags any of these, point them at these notes.
  */
 export function resetMiyoMutations(): MiyoMutationSession {

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -57,14 +57,93 @@ export type MiyoResyncOutcome =
 // chain itself never rejects so one failure can't strand later mutations.
 let mutationChain: Promise<unknown> = Promise.resolve();
 
+// Identifies the plugin lifecycle a mutation was enqueued under. Node's require
+// cache keeps this module alive across disable→enable and "Open another vault",
+// so without it a task started under vault A can finish after vault B loaded and
+// write A's receipt into B's settings. Monotonic on purpose — never reset to 0
+// (unlike `transactionEpoch`), or a task holding a stale value could match a
+// later lifecycle by coincidence.
+let mutationLifecycle = 0;
+
+/**
+ * Abandon queued Miyo mutations and invalidate in-flight ones, so a new plugin
+ * lifecycle starts with a clean queue and no stale task can write into it.
+ *
+ * Call at the START of `onload()`, alongside `resetPersistenceState()` — NOT
+ * from `onunload()`. Obsidian treats unload as fire-and-forget, so a reset there
+ * can land after the next `onload()` has already initialized and would clear the
+ * new lifecycle's state (see the comment at that call site).
+ *
+ * Replacing the chain matters independently of the token: mutations are
+ * deliberately untimed (see {@link withLookupTimeout}), so a hung request from
+ * the previous lifecycle would otherwise block every Miyo operation in the new
+ * one.
+ *
+ * DESIGN NOTE — this deliberately trades serialization for liveness. A task
+ * already running under the old chain keeps running, so its late DELETE/POST
+ * can now interleave with a new lifecycle's mutation against the same Miyo
+ * folder (same vault re-enabled, or two vaults sharing a folder identity).
+ * Both properties are unattainable at once while `requestUrl` is
+ * uncancellable — a request that cannot be aborted will land whatever we do,
+ * and blocking the new lifecycle behind it is the failure this exists to fix.
+ * The token below keeps the stale task from writing settings; the server-side
+ * race is accepted and self-heals on the next verify.
+ * If a future review flags this again, point them at this note.
+ */
+export function resetMiyoMutations(): void {
+  mutationLifecycle += 1;
+  mutationChain = Promise.resolve();
+}
+
+/**
+ * Persist the Miyo sync receipt on behalf of a queued mutation, unless that
+ * mutation belongs to a plugin lifecycle that has since ended.
+ *
+ * Every receipt write inside a mutation goes through here rather than calling
+ * `updateSetting` directly: the settings store is module-global too, so after a
+ * vault switch a late write would land in whichever vault is now open.
+ *
+ * @param lifecycle - Token the mutation captured when it was enqueued.
+ * @param receipt - Receipt to store, or `""` to clear it.
+ */
+function commitReceipt(lifecycle: number, receipt: string): void {
+  if (lifecycle !== mutationLifecycle) {
+    logWarn("Miyo: discarded a receipt write from an expired plugin lifecycle.");
+    return;
+  }
+  updateSetting("miyoSyncedExclusions", receipt);
+}
+
 /**
  * Run `task` behind every previously enqueued Miyo folder mutation. Returns the
  * task's own promise (rejections reach the caller; the chain stays resolved).
  *
- * @param task - Mutation to serialize; invoked once its turn arrives.
+ * Rejects instead of resolving when the plugin lifecycle ended while the task
+ * was queued or running. Rejecting rather than returning a value is what stops
+ * a caller's `await` continuation from running — the register flow writes its
+ * receipt *outside* this module, after the awaited call returns, so a check
+ * confined to the task body would not cover it.
+ *
+ * @param task - Mutation to serialize; invoked once its turn arrives, receiving
+ *   the lifecycle token it must pass to {@link commitReceipt} for any write.
  */
-export function enqueueMiyoFolderMutation<T>(task: () => Promise<T>): Promise<T> {
-  const run = mutationChain.then(task);
+export function enqueueMiyoFolderMutation<T>(task: (lifecycle: number) => Promise<T>): Promise<T> {
+  const lifecycle = mutationLifecycle;
+  const run = mutationChain.then(async () => {
+    // Queued but not yet started when the lifecycle ended: never run it at all,
+    // so it cannot issue requests on behalf of a vault that is no longer open.
+    if (lifecycle !== mutationLifecycle) {
+      throw new Error("Miyo mutation belongs to an expired plugin lifecycle");
+    }
+    const result = await task(lifecycle);
+    // Ran to completion, but the lifecycle ended while it did. The server-side
+    // work stands (it was this vault's own registration); only the result must
+    // not travel onward into a lifecycle that never asked for it.
+    if (lifecycle !== mutationLifecycle) {
+      throw new Error("Miyo mutation completed after its plugin lifecycle expired");
+    }
+    return result;
+  });
   mutationChain = run.catch(() => {
     /* keep the chain alive for the next mutation */
   });
@@ -187,7 +266,13 @@ function buildDesiredScope(app: App, settings = getSettings()): MiyoAddFolderReq
  * @param app - Active Obsidian app (vault name/base for the registration).
  */
 export function resyncMiyoFolder(app: App): Promise<MiyoResyncOutcome> {
-  return enqueueMiyoFolderMutation(() => runResync(app));
+  return enqueueMiyoFolderMutation((lifecycle) => runResync(app, lifecycle)).catch((error) => {
+    // Preserves the never-throws contract: the only rejection the queue itself
+    // raises is an expired lifecycle, which for a caller in the current one
+    // reads the same as any other unfinished mutation.
+    logWarn(`Miyo resync abandoned: ${err2String(error)}`);
+    return "failed";
+  });
 }
 
 /** Result of a read-only scope verification against the live Miyo record. */
@@ -219,10 +304,15 @@ export type MiyoScopeVerification = "covered" | "stale" | "unregistered" | "unkn
  * @param app - Active Obsidian app (vault name for the registration lookup).
  */
 export function verifyMiyoScope(app: App): Promise<MiyoScopeVerification> {
-  return enqueueMiyoFolderMutation(() => runVerify(app));
+  return enqueueMiyoFolderMutation((lifecycle) => runVerify(app, lifecycle)).catch((error) => {
+    // Same never-throws contract as the resync entry point; an abandoned verify
+    // is indistinguishable from an unreachable one to the banner.
+    logWarn(`Miyo scope verification abandoned: ${err2String(error)}`);
+    return "unknown";
+  });
 }
 
-async function runVerify(app: App): Promise<MiyoScopeVerification> {
+async function runVerify(app: App, lifecycle: number): Promise<MiyoScopeVerification> {
   try {
     const settings = getSettings();
     const folderName = getMiyoFolderName(app);
@@ -249,7 +339,7 @@ async function runVerify(app: App): Promise<MiyoScopeVerification> {
         return "unregistered";
       }
       if (receiptMatchesIdentity(receipt, settings, folderName)) {
-        updateSetting("miyoSyncedExclusions", "");
+        commitReceipt(lifecycle, "");
         return "unregistered";
       }
       // Same device + endpoint but a different folder name: the vault was
@@ -263,7 +353,7 @@ async function runVerify(app: App): Promise<MiyoScopeVerification> {
           "previous-name check"
         );
         if (oldName === "unregistered") {
-          updateSetting("miyoSyncedExclusions", "");
+          commitReceipt(lifecycle, "");
           return "unregistered";
         }
         if (oldName !== "registered") {
@@ -283,7 +373,7 @@ async function runVerify(app: App): Promise<MiyoScopeVerification> {
     }
     const receipt = buildMiyoSyncReceipt(app, settings);
     if (settings.miyoSyncedExclusions !== receipt) {
-      updateSetting("miyoSyncedExclusions", receipt);
+      commitReceipt(lifecycle, receipt);
     }
     return "covered";
   } catch (error) {
@@ -292,7 +382,7 @@ async function runVerify(app: App): Promise<MiyoScopeVerification> {
   }
 }
 
-async function runResync(app: App): Promise<MiyoResyncOutcome> {
+async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome> {
   try {
     const settings = getSettings();
     const vaultBase = getVaultBase(app);
@@ -367,7 +457,7 @@ async function runResync(app: App): Promise<MiyoResyncOutcome> {
             "previous-name check"
           );
           if (oldName === "unregistered") {
-            updateSetting("miyoSyncedExclusions", "");
+            commitReceipt(lifecycle, "");
             return "unregistered";
           }
           if (oldName !== "registered") {
@@ -388,13 +478,13 @@ async function runResync(app: App): Promise<MiyoResyncOutcome> {
         // it so verify stops reporting a stale registration that no longer
         // exists. Foreign-device / other-endpoint receipts are never touched
         // — they are not ours to clear.
-        updateSetting("miyoSyncedExclusions", "");
+        commitReceipt(lifecycle, "");
       }
       return "unregistered";
     }
 
     if (miyoRecordCoversSystemRoots(record, settings)) {
-      updateSetting("miyoSyncedExclusions", receipt);
+      commitReceipt(lifecycle, receipt);
       logInfo("Miyo resync: server record already covers the scope; receipt updated.");
       return "verified";
     }
@@ -416,7 +506,7 @@ async function runResync(app: App): Promise<MiyoResyncOutcome> {
       return "conflict";
     }
 
-    updateSetting("miyoSyncedExclusions", receipt);
+    commitReceipt(lifecycle, receipt);
 
     try {
       await client.scanFolder(baseUrl, folderName, false);

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -49,12 +49,12 @@ export type MiyoResyncOutcome =
   /** Transport/setup failure (Miyo unreachable, no vault base, …); still stale. */
   | "failed";
 
-// Serializes every Miyo folder mutation. Reason: the auto-resync after a root
-// change, the settings-tab Resync button, and the register flow can otherwise
-// interleave DELETE/POST against the same registration. The chain mirrors the
-// agent-skills seedChain: each task reads fresh state when IT runs (so a root
-// change mid-run simply enqueues a later run that sees the newer root), and the
-// chain itself never rejects so one failure can't strand later mutations.
+// Serializes every Miyo folder mutation. Reason: the settings-tab Resync button
+// and the register flow can otherwise interleave DELETE/POST against the same
+// registration. The chain mirrors the agent-skills seedChain: each task reads
+// fresh state when IT runs (so a root change mid-run simply enqueues a later run
+// that sees the newer root), and the chain itself never rejects so one failure
+// can't strand later mutations.
 let mutationChain: Promise<unknown> = Promise.resolve();
 
 // Identifies the plugin lifecycle a mutation was enqueued under. Node's require
@@ -87,7 +87,9 @@ let mutationLifecycle = 0;
  * uncancellable — a request that cannot be aborted will land whatever we do,
  * and blocking the new lifecycle behind it is the failure this exists to fix.
  * The token below keeps the stale task from writing settings; the server-side
- * race is accepted and self-heals on the next verify.
+ * race is accepted. Note that nothing repairs it automatically — a later verify
+ * only DETECTS the drift and surfaces the banner, whose Resync button the user
+ * must press.
  * If a future review flags this again, point them at this note.
  */
 export function resetMiyoMutations(): void {
@@ -317,7 +319,11 @@ async function runVerify(app: App, lifecycle: number): Promise<MiyoScopeVerifica
     const settings = getSettings();
     const folderName = getMiyoFolderName(app);
     const customUrl = getMiyoCustomUrl(settings) || undefined;
-    const client = new MiyoClient();
+    // Snapshot the credential with the rest of the request identity: this task
+    // may outlive the vault it started under, and the header is otherwise read
+    // live per request — which would send the incoming vault's key to this
+    // vault's endpoint.
+    const client = new MiyoClient({ plusLicenseKey: settings.plusLicenseKey });
     const baseUrl = await client.resolveBaseUrl(customUrl);
 
     let record: MiyoFolderEntry;
@@ -403,7 +409,11 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
       return "failed";
     }
     const customUrl = miyoUrl || undefined;
-    const client = new MiyoClient();
+    // Snapshot the credential with the rest of the request identity: this task
+    // may outlive the vault it started under, and the header is otherwise read
+    // live per request — which would send the incoming vault's key to this
+    // vault's endpoint.
+    const client = new MiyoClient({ plusLicenseKey: settings.plusLicenseKey });
     const baseUrl = await client.resolveBaseUrl(customUrl);
 
     // Capture the receipt for the scope we are about to commit. Written only
@@ -426,20 +436,28 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
         logWarn(`Miyo resync: could not read folder record: ${err2String(error)}`);
         return "failed";
       }
-      // DESIGN NOTE — an unregistered vault triggers NO server mutation here.
-      // (a) It is NOT re-registered: "a prior rebuild was interrupted between
-      //     DELETE and POST" and "the user removed the registration in Miyo"
-      //     are indistinguishable, and every registration in this product is
-      //     an explicit user action (Connect / Add this vault).
-      //     Auto-registering would silently reverse a deliberate removal —
-      //     and the toggles the stale-record path carries (Relay opt-out)
-      //     have no source here, so it would also re-grant allow_remote_read.
-      // (b) A receipt naming a DIFFERENT folder on this device+endpoint is
-      //     NOT auto-deleted either: folder names are just vault names, so
-      //     the receipt cannot prove that name still belongs to this vault —
-      //     another vault may have registered the same name since, and
-      //     deleting on receipt evidence alone could destroy that vault's
-      //     registration and index. Manual cleanup is surfaced instead.
+      // DESIGN NOTE — what an unregistered vault means here, and what Resync
+      // may do about it.
+      // (a) A receipt naming THIS device+endpoint+folder is only written after a
+      //     successful registration, so its subject is gone: either the user
+      //     removed it in Miyo, or a previous rebuild died between its DELETE
+      //     and its POST. Those are indistinguishable, and the second one is a
+      //     hole this flow can dig itself — refusing to re-add left the user
+      //     with no registration and no way back, since every later Resync saw
+      //     the same 404 and refused again. The explicit Resync click is the
+      //     consent to re-add: it is a user action, on a banner that says the
+      //     scope is out of sync, and re-adding is what "resync" means.
+      //     Re-registration FAILS CLOSED on the Miyo-side toggles — the record
+      //     that carried them is gone, so they are unknowable here, and
+      //     guessing `true` would silently re-grant Relay read access to a
+      //     vault whose owner had turned it off. A downgrade the user can undo
+      //     in Miyo beats a re-grant they never see.
+      // (b) A receipt naming a DIFFERENT folder on this device+endpoint is NOT
+      //     auto-deleted: folder names are just vault names, so the receipt
+      //     cannot prove that name still belongs to this vault — another vault
+      //     may have registered the same name since, and deleting on receipt
+      //     evidence alone could destroy that vault's registration and index.
+      //     Manual cleanup is surfaced instead.
       // If a future review flags this again, point them here.
       const staleReceipt = parseMiyoSyncReceipt(settings.miyoSyncedExclusions);
       if (
@@ -474,18 +492,34 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
           );
           return "conflict";
         }
-        // The registration the receipt vouched for is confirmed gone: clear
-        // it so verify stops reporting a stale registration that no longer
-        // exists. Foreign-device / other-endpoint receipts are never touched
-        // — they are not ours to clear.
-        commitReceipt(lifecycle, "");
+        // The registration this receipt vouched for is gone. Rebuild it with
+        // the current scope, but without the Relay/write grants it may have
+        // carried — see (a) above.
+        desired.allow_remote_read = false;
+        desired.allow_writes = false;
+        const rebuilt = await client.addFolder(desired, customUrl);
+        if (rebuilt === null) {
+          // 409: something registered this folder between the two lookups.
+          // Its scope is unknown, so the receipt stays unwritten and the
+          // banner stays up.
+          logWarn("Miyo resync: re-add of a vanished registration returned 409.");
+          return "conflict";
+        }
+        commitReceipt(lifecycle, receipt);
+        try {
+          await client.scanFolder(baseUrl, folderName, false);
+          return "resynced";
+        } catch (scanError) {
+          logWarn(`Miyo resync: re-scan trigger failed: ${err2String(scanError)}`);
+          return "resynced-scan-failed";
+        }
       }
       return "unregistered";
     }
 
     if (miyoRecordCoversSystemRoots(record, settings)) {
       commitReceipt(lifecycle, receipt);
-      logInfo("Miyo resync: server record already covers the scope; receipt updated.");
+      logInfo("Miyo resync: server record already covers the scope.");
       return "verified";
     }
     // Carry the user's Miyo-side toggles into the re-registration. Fail

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -69,8 +69,33 @@ let mutationChain: Promise<unknown> = Promise.resolve();
 let mutationLifecycle = 0;
 
 /**
+ * A producer's proof of which plugin lifecycle it belongs to.
+ *
+ * Held instead of a bare number so it can only be obtained from
+ * {@link resetMiyoMutations} — i.e. by the lifecycle owner, at the moment the
+ * previous lifecycle's queue is abandoned. There is deliberately no way to ask
+ * for "whatever lifecycle is current right now": handing that to the queue is
+ * precisely what let stale producers pass every guard.
+ */
+export interface MiyoMutationSession {
+  readonly lifecycle: number;
+}
+
+/**
  * Abandon queued Miyo mutations and invalidate in-flight ones, so no task can
- * outlive the plugin lifecycle that started it.
+ * outlive the plugin lifecycle that started it, and return the incoming
+ * lifecycle's session.
+ *
+ * The plugin stores that session on itself (`CopilotPlugin.miyoMutationSession`)
+ * and producers read it from there; they must never obtain one themselves.
+ * Nothing guarantees a producer dies with its lifecycle — the settings React
+ * root is never unmounted (`SettingsPage.display()` drops it into a local), an
+ * open `Modal` outlives `onunload()`, and settings tabs mount lazily, so a tab
+ * first opened after a reload would otherwise vouch for the INCOMING lifecycle
+ * while still holding the outgoing vault's `app`. Returning the session from the
+ * reset rather than exposing a separate capture makes that misuse unavailable:
+ * the only way to get one is to end the previous lifecycle, and only the plugin
+ * does that. `onunload` ignores the return value.
  *
  * Called from `onunload()` as its first statement — everything there runs
  * before the first `await`, hence before the next `onload()` could begin, so it
@@ -84,23 +109,28 @@ let mutationLifecycle = 0;
  * one.
  *
  * A task that is mid-flight keeps running, but {@link assertCurrentLifecycle}
- * refuses it before each request it has NOT yet sent. What that does and does
- * not reach is written down below rather than assumed.
+ * refuses it before each request it has NOT yet sent — including inside
+ * `MiyoClient`, immediately before `requestUrl`. What that does and does not
+ * reach is written down below rather than assumed.
  *
- * KNOWN GAP — the guards sit at the call sites, so `addFolder`/`deleteFolder`
- * still await service discovery and credential decryption after their check;
- * a lifecycle ending inside those awaits lets the request through. Moving the
- * check next to `requestUrl` would close that, and is worth doing — it needs an
- * optional per-request hook on two client methods, not the wholesale change an
- * earlier version of this note claimed. Tracked as follow-up.
+ * DESIGN NOTE — the only requests that can still act for a closed lifecycle are
+ * ones already handed to `requestUrl`, which Obsidian cannot abort. Everything
+ * earlier is refused, including during service discovery and credential
+ * decryption (the `beforeRequest` hook the destructive client calls take). The
+ * damage a sent request can still do: an explicit `customUrl` bypasses
+ * `MiyoServiceDiscovery`'s cache, so it cannot be redirected at the incoming
+ * vault, but discovery is a process-wide singleton and an empty URL resolves to
+ * a machine-level endpoint (`service.json`, else `127.0.0.1:8742`). When both
+ * lifecycles end up on the same endpoint AND share a folder name (folder name
+ * is the vault name), an outgoing DELETE can land on the incoming
+ * registration — a same-vault re-enable being one common instance.
  *
- * KNOWN GAP — a task enqueued by an outgoing lifecycle's UI *after* the next
- * `onload()` captures the NEW token and passes every guard while carrying the
- * old vault's `app`. Closing it requires the producer to hold a session taken at
- * mount rather than being handed the current token at enqueue time. Tracked as
- * follow-up; the trigger needs an async chain still resolving across a vault
- * switch, and the damage is a receipt landing in the wrong vault, which that
- * vault's own banner then reports.
+ * DESIGN NOTE — a producer that outlives its lifecycle can no longer smuggle
+ * work in: the lifecycle is proved by a {@link MiyoMutationSession} the plugin
+ * received at load, not read at enqueue time. That covers the producers which
+ * really do survive `onunload()` — the never-unmounted settings React tree, an
+ * open `MiyoConnectModal`, and the root-change async tail — including the case
+ * where the stale tree mounts a tab for the FIRST time after the reload.
  *
  * DESIGN NOTE — replacing the chain lets the incoming lifecycle proceed while an
  * uncancellable DELETE from the outgoing one is still in flight, so that DELETE
@@ -108,14 +138,16 @@ let mutationLifecycle = 0;
  * chain instead would restore ordering, but only by blocking the new lifecycle
  * behind the hung request — the failure this function exists to fix, and the one
  * the maintainer named. `requestUrl` cannot be aborted, so no third option
- * exists for a request already sent. Both vaults must share a folder name for
- * the scopes to disagree; a same-vault re-enable rebuilds an equivalent scope
- * and costs an index rebuild.
+ * exists for a request already sent. Recovery is the Resync button: the
+ * lifecycle guard stops the outgoing POST that would have followed, so the
+ * incoming vault is left unregistered rather than holding a wrong scope, and its
+ * own banner reports that.
  * If a future review flags any of these, point them at these notes.
  */
-export function resetMiyoMutations(): void {
+export function resetMiyoMutations(): MiyoMutationSession {
   mutationLifecycle += 1;
   mutationChain = Promise.resolve();
+  return Object.freeze({ lifecycle: mutationLifecycle });
 }
 
 /**
@@ -164,9 +196,16 @@ function commitReceipt(lifecycle: number, receipt: string): void {
  *
  * @param task - Mutation to serialize; invoked once its turn arrives, receiving
  *   the lifecycle token it must pass to {@link commitReceipt} for any write.
+ * @param session - The lifecycle's session, obtained by the plugin from
+ *   {@link resetMiyoMutations} at load and read off it by the caller. Required
+ *   rather than defaulted to the live lifecycle: a default would silently
+ *   re-admit any producer that outlived its vault.
  */
-export function enqueueMiyoFolderMutation<T>(task: (lifecycle: number) => Promise<T>): Promise<T> {
-  const lifecycle = mutationLifecycle;
+export function enqueueMiyoFolderMutation<T>(
+  task: (lifecycle: number) => Promise<T>,
+  session: MiyoMutationSession
+): Promise<T> {
+  const { lifecycle } = session;
   const run = mutationChain.then(async () => {
     // Queued but not yet started when the lifecycle ended: never run it at all,
     // so it cannot issue requests on behalf of a vault that is no longer open.
@@ -298,15 +337,22 @@ function buildDesiredScope(app: App, settings = getSettings()): MiyoAddFolderReq
  * its turn arrives, so a queued run always reconciles toward the latest scope.
  *
  * @param app - Active Obsidian app (vault name/base for the registration).
+ * @param session - The lifecycle's session, read off the plugin
+ *   (`CopilotPlugin.miyoMutationSession`); never obtained by the caller itself.
  */
-export function resyncMiyoFolder(app: App): Promise<MiyoResyncOutcome> {
-  return enqueueMiyoFolderMutation((lifecycle) => runResync(app, lifecycle)).catch((error) => {
-    // Preserves the never-throws contract: the only rejection the queue itself
-    // raises is an expired lifecycle, which for a caller in the current one
-    // reads the same as any other unfinished mutation.
-    logWarn(`Miyo resync abandoned: ${err2String(error)}`);
-    return "failed";
-  });
+export function resyncMiyoFolder(
+  app: App,
+  session: MiyoMutationSession
+): Promise<MiyoResyncOutcome> {
+  return enqueueMiyoFolderMutation((lifecycle) => runResync(app, lifecycle), session).catch(
+    (error) => {
+      // Preserves the never-throws contract: the only rejection the queue itself
+      // raises is an expired lifecycle, which for a caller in the current one
+      // reads the same as any other unfinished mutation.
+      logWarn(`Miyo resync abandoned: ${err2String(error)}`);
+      return "failed";
+    }
+  );
 }
 
 /** Result of a read-only scope verification against the live Miyo record. */
@@ -336,14 +382,21 @@ export type MiyoScopeVerification = "covered" | "stale" | "unregistered" | "unkn
  * local mismatch signal.
  *
  * @param app - Active Obsidian app (vault name for the registration lookup).
+ * @param session - The lifecycle's session, read off the plugin
+ *   (`CopilotPlugin.miyoMutationSession`); never obtained by the caller itself.
  */
-export function verifyMiyoScope(app: App): Promise<MiyoScopeVerification> {
-  return enqueueMiyoFolderMutation((lifecycle) => runVerify(app, lifecycle)).catch((error) => {
-    // Same never-throws contract as the resync entry point; an abandoned verify
-    // is indistinguishable from an unreachable one to the banner.
-    logWarn(`Miyo scope verification abandoned: ${err2String(error)}`);
-    return "unknown";
-  });
+export function verifyMiyoScope(
+  app: App,
+  session: MiyoMutationSession
+): Promise<MiyoScopeVerification> {
+  return enqueueMiyoFolderMutation((lifecycle) => runVerify(app, lifecycle), session).catch(
+    (error) => {
+      // Same never-throws contract as the resync entry point; an abandoned verify
+      // is indistinguishable from an unreachable one to the banner.
+      logWarn(`Miyo scope verification abandoned: ${err2String(error)}`);
+      return "unknown";
+    }
+  );
 }
 
 async function runVerify(app: App, lifecycle: number): Promise<MiyoScopeVerification> {
@@ -561,8 +614,9 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
         // carried — see (a) above.
         desired.allow_remote_read = false;
         desired.allow_writes = false;
-        assertCurrentLifecycle(lifecycle);
-        const rebuilt = await client.addFolder(desired, customUrl);
+        const rebuilt = await client.addFolder(desired, customUrl, () =>
+          assertCurrentLifecycle(lifecycle)
+        );
         if (rebuilt === null) {
           // 409: something registered this folder between the two lookups.
           // Its scope is unknown, so the receipt stays unwritten and the
@@ -598,8 +652,7 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
 
     // Last point at which abandoning is still safe: once the DELETE is out, the
     // POST must follow or the vault is left unregistered.
-    assertCurrentLifecycle(lifecycle);
-    await client.deleteFolder(folderName, customUrl);
+    await client.deleteFolder(folderName, customUrl, () => assertCurrentLifecycle(lifecycle));
 
     const created = await addFolderPreservingGrants(client, desired, customUrl);
     if (created === null) {

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -37,6 +37,9 @@ export type MiyoResyncOutcome =
   | "verified"
   /** Deleted + re-registered with the fresh scope; re-scan kicked off. */
   | "resynced"
+  /** Rebuilt a registration that had vanished, but its Miyo-side Relay/write
+   *  grants were unknowable and had to be reset — the user must be told. */
+  | "resynced-grants-reset"
   /** Re-registered, but the re-scan trigger failed; Miyo re-scans on its own. */
   | "resynced-scan-failed"
   /** Server holds a registration this flow can't safely replace (409 right
@@ -66,35 +69,42 @@ let mutationChain: Promise<unknown> = Promise.resolve();
 let mutationLifecycle = 0;
 
 /**
- * Abandon queued Miyo mutations and invalidate in-flight ones, so a new plugin
- * lifecycle starts with a clean queue and no stale task can write into it.
+ * Abandon queued Miyo mutations and invalidate in-flight ones, so no task can
+ * outlive the plugin lifecycle that started it.
  *
- * Call at the START of `onload()`, alongside `resetPersistenceState()` — NOT
- * from `onunload()`. Obsidian treats unload as fire-and-forget, so a reset there
- * can land after the next `onload()` has already initialized and would clear the
- * new lifecycle's state (see the comment at that call site).
+ * Called from `onunload()` as its first statement — everything there runs
+ * before the first `await`, hence before the next `onload()` could begin, so it
+ * carries none of the late-continuation risk that keeps `resetPersistenceState`
+ * at load time. Also called at the start of `onload()`, because a crash never
+ * runs unload at all.
  *
  * Replacing the chain matters independently of the token: mutations are
  * deliberately untimed (see {@link withLookupTimeout}), so a hung request from
  * the previous lifecycle would otherwise block every Miyo operation in the new
  * one.
  *
- * DESIGN NOTE — this deliberately trades serialization for liveness. A task
- * already running under the old chain keeps running, so its late DELETE/POST
- * can now interleave with a new lifecycle's mutation against the same Miyo
- * folder (same vault re-enabled, or two vaults sharing a folder identity).
- * Both properties are unattainable at once while `requestUrl` is
- * uncancellable — a request that cannot be aborted will land whatever we do,
- * and blocking the new lifecycle behind it is the failure this exists to fix.
- * The token below keeps the stale task from writing settings; the server-side
- * race is accepted. Note that nothing repairs it automatically — a later verify
- * only DETECTS the drift and surfaces the banner, whose Resync button the user
- * must press.
- * If a future review flags this again, point them at this note.
+ * A task that is mid-flight keeps running, but {@link assertCurrentLifecycle}
+ * stops it before it can issue anything destructive, so what survives a reset
+ * is only the read it was already waiting on. The one sequence deliberately
+ * allowed to finish is a DELETE that has already gone out: its POST must
+ * follow, or the vault is left unregistered with no record to rebuild from.
  */
 export function resetMiyoMutations(): void {
   mutationLifecycle += 1;
   mutationChain = Promise.resolve();
+}
+
+/**
+ * Abort the current mutation unless it still belongs to the live plugin
+ * lifecycle. Called before every request that changes server state, so a task
+ * whose vault closed mid-flight cannot act on the registration afterwards.
+ *
+ * @param lifecycle - Token the mutation captured when it was enqueued.
+ */
+function assertCurrentLifecycle(lifecycle: number): void {
+  if (lifecycle !== mutationLifecycle) {
+    throw new Error("Miyo mutation belongs to an expired plugin lifecycle");
+  }
 }
 
 /**
@@ -134,16 +144,12 @@ export function enqueueMiyoFolderMutation<T>(task: (lifecycle: number) => Promis
   const run = mutationChain.then(async () => {
     // Queued but not yet started when the lifecycle ended: never run it at all,
     // so it cannot issue requests on behalf of a vault that is no longer open.
-    if (lifecycle !== mutationLifecycle) {
-      throw new Error("Miyo mutation belongs to an expired plugin lifecycle");
-    }
+    assertCurrentLifecycle(lifecycle);
     const result = await task(lifecycle);
     // Ran to completion, but the lifecycle ended while it did. The server-side
     // work stands (it was this vault's own registration); only the result must
     // not travel onward into a lifecycle that never asked for it.
-    if (lifecycle !== mutationLifecycle) {
-      throw new Error("Miyo mutation completed after its plugin lifecycle expired");
-    }
+    assertCurrentLifecycle(lifecycle);
     return result;
   });
   mutationChain = run.catch(() => {
@@ -388,6 +394,35 @@ async function runVerify(app: App, lifecycle: number): Promise<MiyoScopeVerifica
   }
 }
 
+/**
+ * Re-register a folder whose record was just deleted, retrying once.
+ *
+ * The retry exists because the grants being restored are only knowable inside
+ * this run: they were read off the record moments before the DELETE removed it.
+ * A later Resync has no source for them and must fail closed, so one more
+ * attempt here is the difference between preserving a user's Relay setting and
+ * silently turning it off.
+ *
+ * @param client - Client already bound to this run's endpoint and credential.
+ * @param desired - Registration body carrying the grants read before the DELETE.
+ * @param customUrl - Endpoint override captured for this run, if any.
+ * @returns The created record, or `null` when the server reports a conflict.
+ */
+async function addFolderPreservingGrants(
+  client: MiyoClient,
+  desired: MiyoAddFolderRequest,
+  customUrl: string | undefined
+): Promise<MiyoFolderEntry | null> {
+  try {
+    return await client.addFolder(desired, customUrl);
+  } catch (error) {
+    logWarn(`Miyo resync: re-add failed, retrying once: ${err2String(error)}`);
+    // A first POST that landed but lost its response surfaces as 409 here,
+    // which the caller already treats as a contested registration.
+    return await client.addFolder(desired, customUrl);
+  }
+}
+
 async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome> {
   try {
     const settings = getSettings();
@@ -447,11 +482,14 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
       //     the same 404 and refused again. The explicit Resync click is the
       //     consent to re-add: it is a user action, on a banner that says the
       //     scope is out of sync, and re-adding is what "resync" means.
-      //     Re-registration FAILS CLOSED on the Miyo-side toggles — the record
-      //     that carried them is gone, so they are unknowable here, and
-      //     guessing `true` would silently re-grant Relay read access to a
-      //     vault whose owner had turned it off. A downgrade the user can undo
-      //     in Miyo beats a re-grant they never see.
+      //     Re-registration FAILS CLOSED on the Miyo-side toggles. They were
+      //     knowable in the run that deleted the record — which is why that run
+      //     retries its own POST rather than leaving them to this path — but by
+      //     the time a separate Resync arrives their only source is gone.
+      //     Guessing `true` would silently re-grant Relay read access to a
+      //     vault whose owner had turned it off; guessing `false` downgrades,
+      //     which is why this returns its own outcome so the user is told
+      //     rather than left thinking Relay is still on.
       // (b) A receipt naming a DIFFERENT folder on this device+endpoint is NOT
       //     auto-deleted: folder names are just vault names, so the receipt
       //     cannot prove that name still belongs to this vault — another vault
@@ -497,6 +535,7 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
         // carried — see (a) above.
         desired.allow_remote_read = false;
         desired.allow_writes = false;
+        assertCurrentLifecycle(lifecycle);
         const rebuilt = await client.addFolder(desired, customUrl);
         if (rebuilt === null) {
           // 409: something registered this folder between the two lookups.
@@ -508,11 +547,13 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
         commitReceipt(lifecycle, receipt);
         try {
           await client.scanFolder(baseUrl, folderName, false);
-          return "resynced";
         } catch (scanError) {
           logWarn(`Miyo resync: re-scan trigger failed: ${err2String(scanError)}`);
-          return "resynced-scan-failed";
         }
+        // Reported separately from a normal resync: the caller has to say the
+        // grants were reset, or the downgrade is as silent as the re-grant this
+        // avoids.
+        return "resynced-grants-reset";
       }
       return "unregistered";
     }
@@ -529,9 +570,12 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
     desired.allow_remote_read = record.allow_remote_read === true;
     desired.allow_writes = record.allow_writes === true;
 
+    // Last point at which abandoning is still safe: once the DELETE is out, the
+    // POST must follow or the vault is left unregistered.
+    assertCurrentLifecycle(lifecycle);
     await client.deleteFolder(folderName, customUrl);
 
-    const created = await client.addFolder(desired, customUrl);
+    const created = await addFolderPreservingGrants(client, desired, customUrl);
     if (created === null) {
       // 409 right after a delete: the server still holds a registration we
       // couldn't replace. Do NOT write the receipt — its exclusions are

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -84,10 +84,27 @@ let mutationLifecycle = 0;
  * one.
  *
  * A task that is mid-flight keeps running, but {@link assertCurrentLifecycle}
- * stops it before it can issue anything destructive, so what survives a reset
- * is only the read it was already waiting on. The one sequence deliberately
- * allowed to finish is a DELETE that has already gone out: its POST must
- * follow, or the vault is left unregistered with no record to rebuild from.
+ * refuses it before each request it has NOT yet sent. Two things are outside
+ * that reach, deliberately:
+ *
+ * DESIGN NOTE — a request already on the wire cannot be recalled: Obsidian's
+ * `requestUrl` takes no abort signal, and the guards sit at the call sites, so a
+ * lifecycle that ends between the check and the socket write still lets that one
+ * request through. Narrowing the window further (a callback fired inside the
+ * client, just before the write) was considered and rejected: it would thread a
+ * parameter through a client shared by seven call sites to shave milliseconds
+ * off a window it cannot close.
+ *
+ * DESIGN NOTE — replacing the chain lets the incoming lifecycle proceed while an
+ * uncancellable DELETE from the outgoing one is still in flight, so that DELETE
+ * can land on a registration the new lifecycle just created. Keeping the old
+ * chain instead would restore ordering, but only by blocking the new lifecycle
+ * behind the hung request — the failure this function exists to fix, and the one
+ * the maintainer named. Reads are bounded (see {@link withLookupTimeout}); the
+ * untimed requests are exactly the destructive ones, so the two properties
+ * cannot both hold. Same-vault re-enable rebuilds the same scope, costing an
+ * index rebuild; the harmful shape needs two vaults sharing a folder name.
+ * If a future review flags either of these, point them at these notes.
  */
 export function resetMiyoMutations(): void {
   mutationLifecycle += 1;
@@ -96,12 +113,14 @@ export function resetMiyoMutations(): void {
 
 /**
  * Abort the current mutation unless it still belongs to the live plugin
- * lifecycle. Called before every request that changes server state, so a task
- * whose vault closed mid-flight cannot act on the registration afterwards.
+ * lifecycle. Called before each request that changes server state — including
+ * the register flow's, which reaches its POST several awaits after its task
+ * started — so a task whose vault closed mid-flight stops rather than acting on
+ * a registration nobody is watching.
  *
  * @param lifecycle - Token the mutation captured when it was enqueued.
  */
-function assertCurrentLifecycle(lifecycle: number): void {
+export function assertCurrentLifecycle(lifecycle: number): void {
   if (lifecycle !== mutationLifecycle) {
     throw new Error("Miyo mutation belongs to an expired plugin lifecycle");
   }

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -10,7 +10,7 @@ import {
   type MiyoSyncReceipt,
 } from "@/miyo/miyoUtils";
 import { extractAppIgnoreSettings, getSystemExcludedFolders } from "@/search/searchUtils";
-import { getSettings, updateSetting } from "@/settings/model";
+import { type CopilotSettings, getSettings, updateSetting } from "@/settings/model";
 import { err2String } from "@/utils";
 import { getDeviceId } from "@/utils/deviceId";
 import { getVaultBase } from "@/utils/vaultPath";
@@ -128,42 +128,35 @@ function isSuperset(container: readonly string[], required: readonly string[]): 
   return required.every((entry) => set.has(entry));
 }
 
-function sameSet(a: readonly string[], b: readonly string[]): boolean {
-  return isSuperset(a, b) && isSuperset(b, a);
-}
-
 /**
- * Whether the live folder record already enforces the desired scope, making a
- * destructive delete + re-register (and the full re-index it implies)
- * unnecessary. Exclusions may be a superset (extra, user-added Miyo-side
- * exclusions are privacy-safe and not ours to fight); inclusions must match
- * exactly, since a different whitelist is a genuinely different scope.
+ * Whether the live folder record already excludes every CURRENT system root
+ * (active + historical Copilot roots), making a destructive delete +
+ * re-register (and the full re-index it implies) unnecessary.
  *
- * DESIGN NOTE — the superset rule cannot tell a Miyo-side user exclusion from
- * a Copilot-pushed exclusion the user has since REMOVED from `qaExclusions`.
- * After such a removal the server keeps excluding that folder, this check still
- * reads "covered", and the content stays unindexed until a manual
- * re-registration — a search-miss, not a privacy leak (the leak direction is
- * always caught, since a MISSING desired exclusion fails the superset).
- * Distinguishing the two would require the receipt to carry the full pushed
- * exclusion list and a three-way compare; exact equality instead would make
- * resync destroy genuine Miyo-side privacy exclusions, which is strictly
- * worse. If a future review flags this again, point them here.
+ * DESIGN NOTE — the staleness signal is deliberately ROOTS-ONLY. Drift in the
+ * qa* patterns or Obsidian's own ignore list is the pre-existing
+ * registration-snapshot gap documented at the registration site (qa* scope is
+ * re-applied live at query time; the ignore-list gap predates this PR), and
+ * comparing the full desired body here would flag — and destructively
+ * rebuild for — users who never changed their root. Only the resync BODY uses
+ * the full current scope, so once a roots-driven rebuild does happen it
+ * carries everything current along. Exclusions may be a superset: extra,
+ * user-added Miyo-side exclusions are privacy-safe and not ours to fight,
+ * while the leak direction (a system root MISSING from the server's
+ * exclusions) always fails the superset and triggers the rebuild.
+ * If a future review flags this again, point them here.
  *
  * @param record - Live folder entry fetched from Miyo.
- * @param desired - Freshly-built registration body for the current scope.
+ * @param settings - Settings snapshot the current system roots derive from.
  */
-export function miyoRecordCoversScope(
+export function miyoRecordCoversSystemRoots(
   record: MiyoFolderEntry,
-  desired: MiyoAddFolderRequest
+  settings: CopilotSettings
 ): boolean {
-  return (
-    isSuperset(recordArray(record, "exclude_folders"), desired.exclude_folders ?? []) &&
-    isSuperset(recordArray(record, "exclude_patterns"), desired.exclude_patterns ?? []) &&
-    sameSet(recordArray(record, "include_folders"), desired.include_folders ?? []) &&
-    sameSet(recordArray(record, "include_patterns"), desired.include_patterns ?? []) &&
-    sameSet(recordArray(record, "include_extensions"), desired.include_extensions ?? [])
-  );
+  // Reuse the registration-body builder (with no qa patterns) so the roots are
+  // normalized exactly as they were when pushed into `exclude_folders`.
+  const desired = getMiyoFolderExclusions("", getSystemExcludedFolders(settings));
+  return isSuperset(recordArray(record, "exclude_folders"), desired.exclude_folders ?? []);
 }
 
 /** Registration body for the current scope (shared by resync and verify). */
@@ -264,7 +257,7 @@ async function runVerify(app: App): Promise<MiyoScopeVerification> {
       return "unregistered";
     }
 
-    if (!miyoRecordCoversScope(record, buildDesiredScope(app, settings))) {
+    if (!miyoRecordCoversSystemRoots(record, settings)) {
       return "stale";
     }
     const receipt = buildMiyoSyncReceipt(app, settings);
@@ -329,7 +322,7 @@ async function runResync(app: App): Promise<MiyoResyncOutcome> {
     }
 
     if (record) {
-      if (miyoRecordCoversScope(record, desired)) {
+      if (miyoRecordCoversSystemRoots(record, settings)) {
         updateSetting("miyoSyncedExclusions", receipt);
         logInfo("Miyo resync: server record already covers the scope; receipt updated.");
         return "verified";

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -294,6 +294,50 @@ function isSuperset(container: readonly string[], required: readonly string[]): 
 }
 
 /**
+ * Fold the live record's own scope into a replacement body, so a rebuild never
+ * comes back broader than what the server already enforced.
+ *
+ * Needed because the record is not ours alone: `PATCH /v0/folder` (docs/miyo-api.md)
+ * lets any client narrow a registration's filters, and a rebuild that POSTs only
+ * the Copilot-derived scope would silently drop those — re-indexing content the
+ * owner had excluded and, with Relay on, exposing it to remote AI.
+ *
+ * Exclusions union: excludes always win server-side, so adding is always safe.
+ * Include filters do NOT union — they are an OR whitelist (see
+ * {@link getMiyoFolderInclusions}), so unioning would WIDEN scope. When the
+ * record carries one, it is kept verbatim and ours is dropped; the cost is that
+ * a `qaInclusions` edit stops propagating through a rebuild, which changes
+ * nothing in practice since staleness detection is roots-only and never fires on
+ * qa* drift anyway. When the record carries none, ours applies — a narrowing.
+ *
+ * @param desired - Replacement body built from the current Copilot scope; mutated.
+ * @param record - Live folder entry the rebuild is replacing.
+ */
+function preserveRecordScope(desired: MiyoAddFolderRequest, record: MiyoFolderEntry): void {
+  const union = (ours: string[] | undefined, theirs: string[]): string[] | undefined => {
+    const merged = [...new Set([...(ours ?? []), ...theirs])];
+    return merged.length > 0 ? merged : undefined;
+  };
+  desired.exclude_folders = union(desired.exclude_folders, recordArray(record, "exclude_folders"));
+  desired.exclude_patterns = union(
+    desired.exclude_patterns,
+    recordArray(record, "exclude_patterns")
+  );
+
+  const recordIncludeFolders = recordArray(record, "include_folders");
+  const recordIncludePatterns = recordArray(record, "include_patterns");
+  const recordIncludeExtensions = recordArray(record, "include_extensions");
+  const recordWhitelists =
+    recordIncludeFolders.length + recordIncludePatterns.length + recordIncludeExtensions.length > 0;
+  if (recordWhitelists) {
+    desired.include_folders = recordIncludeFolders.length > 0 ? recordIncludeFolders : undefined;
+    desired.include_patterns = recordIncludePatterns.length > 0 ? recordIncludePatterns : undefined;
+    desired.include_extensions =
+      recordIncludeExtensions.length > 0 ? recordIncludeExtensions : undefined;
+  }
+}
+
+/**
  * Whether the live folder record already excludes every CURRENT system root
  * (active + historical Copilot roots), making a destructive delete +
  * re-register (and the full re-index it implies) unnecessary.
@@ -303,12 +347,13 @@ function isSuperset(container: readonly string[], required: readonly string[]): 
  * registration-snapshot gap documented at the registration site (qa* scope is
  * re-applied live at query time; the ignore-list gap predates this PR), and
  * comparing the full desired body here would flag — and destructively
- * rebuild for — users who never changed their root. Only the resync BODY uses
- * the full current scope, so once a roots-driven rebuild does happen it
- * carries everything current along. Exclusions may be a superset: extra,
- * user-added Miyo-side exclusions are privacy-safe and not ours to fight,
- * while the leak direction (a system root MISSING from the server's
- * exclusions) always fails the superset and triggers the rebuild.
+ * rebuild for — users who never changed their root. Exclusions may be a
+ * superset: extra exclusions on the record are privacy-safe and not ours to
+ * fight, while the leak direction (a system root MISSING from the server's
+ * exclusions) always fails the superset and triggers the rebuild. A rebuild
+ * then keeps those extras rather than replacing them — see
+ * {@link preserveRecordScope}, without which this tolerance would only hold
+ * until the next resync.
  * If a future review flags this again, point them here.
  *
  * @param record - Live folder entry fetched from Miyo.
@@ -656,6 +701,9 @@ async function runResync(app: App, lifecycle: number): Promise<MiyoResyncOutcome
     // opted out in Miyo — the exact privacy hole this resync exists to close.
     desired.allow_remote_read = record.allow_remote_read === true;
     desired.allow_writes = record.allow_writes === true;
+    // Same reasoning one level up: the record's own filters are part of the
+    // boundary it enforces, and a rebuild must not come back broader.
+    preserveRecordScope(desired, record);
 
     // Last point at which abandoning is still safe: once the DELETE is out, the
     // POST must follow or the vault is left unregistered.

--- a/src/miyo/miyoResync.ts
+++ b/src/miyo/miyoResync.ts
@@ -84,27 +84,34 @@ let mutationLifecycle = 0;
  * one.
  *
  * A task that is mid-flight keeps running, but {@link assertCurrentLifecycle}
- * refuses it before each request it has NOT yet sent. Two things are outside
- * that reach, deliberately:
+ * refuses it before each request it has NOT yet sent. What that does and does
+ * not reach is written down below rather than assumed.
  *
- * DESIGN NOTE — a request already on the wire cannot be recalled: Obsidian's
- * `requestUrl` takes no abort signal, and the guards sit at the call sites, so a
- * lifecycle that ends between the check and the socket write still lets that one
- * request through. Narrowing the window further (a callback fired inside the
- * client, just before the write) was considered and rejected: it would thread a
- * parameter through a client shared by seven call sites to shave milliseconds
- * off a window it cannot close.
+ * KNOWN GAP — the guards sit at the call sites, so `addFolder`/`deleteFolder`
+ * still await service discovery and credential decryption after their check;
+ * a lifecycle ending inside those awaits lets the request through. Moving the
+ * check next to `requestUrl` would close that, and is worth doing — it needs an
+ * optional per-request hook on two client methods, not the wholesale change an
+ * earlier version of this note claimed. Tracked as follow-up.
+ *
+ * KNOWN GAP — a task enqueued by an outgoing lifecycle's UI *after* the next
+ * `onload()` captures the NEW token and passes every guard while carrying the
+ * old vault's `app`. Closing it requires the producer to hold a session taken at
+ * mount rather than being handed the current token at enqueue time. Tracked as
+ * follow-up; the trigger needs an async chain still resolving across a vault
+ * switch, and the damage is a receipt landing in the wrong vault, which that
+ * vault's own banner then reports.
  *
  * DESIGN NOTE — replacing the chain lets the incoming lifecycle proceed while an
  * uncancellable DELETE from the outgoing one is still in flight, so that DELETE
  * can land on a registration the new lifecycle just created. Keeping the old
  * chain instead would restore ordering, but only by blocking the new lifecycle
  * behind the hung request — the failure this function exists to fix, and the one
- * the maintainer named. Reads are bounded (see {@link withLookupTimeout}); the
- * untimed requests are exactly the destructive ones, so the two properties
- * cannot both hold. Same-vault re-enable rebuilds the same scope, costing an
- * index rebuild; the harmful shape needs two vaults sharing a folder name.
- * If a future review flags either of these, point them at these notes.
+ * the maintainer named. `requestUrl` cannot be aborted, so no third option
+ * exists for a request already sent. Both vaults must share a folder name for
+ * the scopes to disagree; a same-vault re-enable rebuilds an equivalent scope
+ * and costs an index rebuild.
+ * If a future review flags any of these, point them at these notes.
  */
 export function resetMiyoMutations(): void {
   mutationLifecycle += 1;

--- a/src/miyo/miyoUtils.test.ts
+++ b/src/miyo/miyoUtils.test.ts
@@ -24,6 +24,7 @@ import {
   getSearchBackend,
   getVaultRelativeMiyoPath,
   hasUserQaPatterns,
+  isCurrentVaultMiyoPath,
   isLocalMiyoUrl,
   isMiyoScopeMismatch,
   seedDocProcessorBackend,
@@ -87,6 +88,29 @@ describe("getVaultRelativeMiyoPath", () => {
 
   it("returns the normalized path when the vault folder name is empty", () => {
     expect(getVaultRelativeMiyoPath(buildApp(""), "notes\\foo.md")).toBe("notes/foo.md");
+  });
+});
+
+describe("isCurrentVaultMiyoPath", () => {
+  const buildApp = (vaultName: string): App =>
+    ({
+      vault: {
+        getName: () => vaultName,
+      },
+    }) as unknown as App;
+
+  it("owns a raw path prefixed with the current vault's folder name", () => {
+    expect(isCurrentVaultMiyoPath(buildApp("MyVault"), "MyVault/copilot/x.md")).toBe(true);
+  });
+
+  it("disowns a raw path prefixed with another folder's name, even one matching a system root", () => {
+    // "copilot" is the default Copilot root NAME — but as a raw prefix it is
+    // another Miyo folder's namespace, not this vault's content.
+    expect(isCurrentVaultMiyoPath(buildApp("MyVault"), "copilot/notes/foo.md")).toBe(false);
+  });
+
+  it("claims ownership when no folder name is resolvable (conservative: filters still apply)", () => {
+    expect(isCurrentVaultMiyoPath(buildApp(""), "notes/foo.md")).toBe(true);
   });
 });
 

--- a/src/miyo/miyoUtils.test.ts
+++ b/src/miyo/miyoUtils.test.ts
@@ -7,17 +7,27 @@ jest.mock("@/miyo/miyoStatusStore", () => ({
   refreshMiyoStatus: jest.fn(),
 }));
 
+// Pin the device id so receipts built in different test runs stay comparable.
+jest.mock("@/utils/deviceId", () => ({
+  getDeviceId: jest.fn(() => "device-A"),
+}));
+
 import { Platform, type App } from "obsidian";
 import type { CopilotSettings } from "@/settings/model";
 import {
+  buildMiyoSyncReceipt,
+  didMiyoSyncedRootsChange,
   getMiyoFilePath,
   getMiyoFolderExclusions,
   getMiyoFolderInclusions,
   getMiyoFolderName,
   getSearchBackend,
   getVaultRelativeMiyoPath,
+  hasUserQaPatterns,
   isLocalMiyoUrl,
+  isMiyoScopeMismatch,
   seedDocProcessorBackend,
+  shouldSurfaceMiyoResync,
 } from "@/miyo/miyoUtils";
 
 /** Minimal settings stub; the accessors only read the fields set per-test. */
@@ -307,5 +317,177 @@ describe("getMiyoFolderInclusions", () => {
   it("drops root/parent pointers from include_folders", () => {
     expect(getMiyoFolderInclusions("./")).toEqual({});
     expect(getMiyoFolderInclusions("projects, .")).toEqual({ include_folders: ["projects"] });
+  });
+});
+
+/** App whose vault reports the given name; enough for the receipt helpers. */
+const appNamed = (name: string): App => ({ vault: { getName: () => name } }) as unknown as App;
+
+/** Settings stub for the sync-receipt helpers. */
+const receiptSettings = (over: Partial<CopilotSettings> = {}): CopilotSettings =>
+  ({
+    copilotFolder: "copilot",
+    copilotRootHistory: ["copilot"],
+    miyoServerUrl: "",
+    qaInclusions: "",
+    qaExclusions: "copilot",
+    enableMiyo: false,
+    miyoSyncedExclusions: "",
+    ...over,
+  }) as unknown as CopilotSettings;
+
+describe("buildMiyoSyncReceipt", () => {
+  it("binds device, url, folder, and the sorted system roots", () => {
+    const receipt = JSON.parse(
+      buildMiyoSyncReceipt(
+        appNamed("my-vault"),
+        receiptSettings({ copilotFolder: "team/ai", copilotRootHistory: ["zeta", "alpha"] })
+      )
+    ) as { device: string; url: string; folder: string; roots: string[] };
+    expect(receipt.device).toBe("device-A");
+    expect(receipt.url).toBe("");
+    expect(receipt.folder).toBe("my-vault");
+    expect(receipt.roots).toEqual([...receipt.roots].sort());
+    expect(receipt.roots).toContain("team/ai");
+  });
+
+  it("yields the same receipt regardless of history order", () => {
+    // Obsidian Sync can reorder copilotRootHistory on merge; content-equal
+    // histories must not fake a mismatch.
+    const a = buildMiyoSyncReceipt(
+      appNamed("v"),
+      receiptSettings({ copilotRootHistory: ["one", "two"] })
+    );
+    const b = buildMiyoSyncReceipt(
+      appNamed("v"),
+      receiptSettings({ copilotRootHistory: ["two", "one"] })
+    );
+    expect(a).toBe(b);
+  });
+});
+
+describe("isMiyoScopeMismatch", () => {
+  it("matches when the stored receipt equals the current expected receipt", () => {
+    const app = appNamed("v");
+    const settings = receiptSettings();
+    const synced = receiptSettings({ miyoSyncedExclusions: buildMiyoSyncReceipt(app, settings) });
+    expect(isMiyoScopeMismatch(app, synced)).toBe(false);
+  });
+
+  it("mismatches after the root changes", () => {
+    const app = appNamed("v");
+    const before = buildMiyoSyncReceipt(app, receiptSettings());
+    const after = receiptSettings({
+      copilotFolder: "team/ai",
+      copilotRootHistory: ["copilot", "team/ai"],
+      miyoSyncedExclusions: before,
+    });
+    expect(isMiyoScopeMismatch(app, after)).toBe(true);
+  });
+
+  it("mismatches when the receipt was written by another device", () => {
+    const app = appNamed("v");
+    const settings = receiptSettings();
+    const foreign = buildMiyoSyncReceipt(app, settings).replace("device-A", "device-B");
+    expect(isMiyoScopeMismatch(app, receiptSettings({ miyoSyncedExclusions: foreign }))).toBe(true);
+  });
+
+  it("treats a missing receipt field as mismatch", () => {
+    const settings = receiptSettings();
+    delete (settings as unknown as Record<string, unknown>).miyoSyncedExclusions;
+    expect(isMiyoScopeMismatch(appNamed("v"), settings)).toBe(true);
+  });
+});
+
+describe("shouldSurfaceMiyoResync", () => {
+  it("surfaces for a mismatch while Miyo is enabled", () => {
+    expect(shouldSurfaceMiyoResync(appNamed("v"), receiptSettings({ enableMiyo: true }))).toBe(
+      true
+    );
+  });
+
+  it("surfaces for a mismatch with a past registration even when Miyo is disabled", () => {
+    // Disconnected in Copilot but still registered server-side: Relay can still
+    // read, so the prompt must not disappear.
+    const app = appNamed("v");
+    const stale = buildMiyoSyncReceipt(app, receiptSettings()).replace("device-A", "device-B");
+    expect(shouldSurfaceMiyoResync(app, receiptSettings({ miyoSyncedExclusions: stale }))).toBe(
+      true
+    );
+  });
+
+  it("stays quiet for a never-registered user", () => {
+    expect(shouldSurfaceMiyoResync(appNamed("v"), receiptSettings())).toBe(false);
+  });
+
+  it("stays quiet when the receipt is current", () => {
+    const app = appNamed("v");
+    const settings = receiptSettings({ enableMiyo: true });
+    const synced = receiptSettings({
+      enableMiyo: true,
+      miyoSyncedExclusions: buildMiyoSyncReceipt(app, settings),
+    });
+    expect(shouldSurfaceMiyoResync(app, synced)).toBe(false);
+  });
+});
+
+describe("didMiyoSyncedRootsChange", () => {
+  it("returns false with no receipt", () => {
+    expect(didMiyoSyncedRootsChange(receiptSettings())).toBe(false);
+  });
+
+  it("returns true after the roots actually change", () => {
+    const receipt = buildMiyoSyncReceipt(appNamed("v"), receiptSettings());
+    const changed = receiptSettings({
+      copilotFolder: "team/ai",
+      copilotRootHistory: ["copilot", "team/ai"],
+      miyoSyncedExclusions: receipt,
+    });
+    expect(didMiyoSyncedRootsChange(changed)).toBe(true);
+  });
+
+  it("returns false for a device-only mismatch (roots unchanged)", () => {
+    // Another device's receipt with identical roots: the settings tab's on-load
+    // verification self-heals this silently; no startup nag.
+    const foreign = buildMiyoSyncReceipt(appNamed("v"), receiptSettings()).replace(
+      "device-A",
+      "device-B"
+    );
+    expect(didMiyoSyncedRootsChange(receiptSettings({ miyoSyncedExclusions: foreign }))).toBe(
+      false
+    );
+  });
+
+  it("returns false for a malformed receipt", () => {
+    expect(didMiyoSyncedRootsChange(receiptSettings({ miyoSyncedExclusions: "not-json" }))).toBe(
+      false
+    );
+  });
+});
+
+describe("hasUserQaPatterns", () => {
+  it("returns false for the default exclusions (system root only)", () => {
+    expect(hasUserQaPatterns(receiptSettings())).toBe(false);
+  });
+
+  it("returns false when exclusions hold only system roots, even with trailing slashes", () => {
+    const settings = receiptSettings({
+      copilotFolder: "team/ai",
+      copilotRootHistory: ["copilot", "team/ai"],
+      qaExclusions: encodeURIComponent("copilot/") + "," + encodeURIComponent("team/ai"),
+    });
+    expect(hasUserQaPatterns(settings)).toBe(false);
+  });
+
+  it("returns true when the user added their own exclusion", () => {
+    expect(hasUserQaPatterns(receiptSettings({ qaExclusions: "copilot,journal" }))).toBe(true);
+  });
+
+  it("returns true when any inclusion is set", () => {
+    expect(hasUserQaPatterns(receiptSettings({ qaInclusions: "projects" }))).toBe(true);
+  });
+
+  it("returns false when exclusions were cleared entirely", () => {
+    expect(hasUserQaPatterns(receiptSettings({ qaExclusions: "" }))).toBe(false);
   });
 });

--- a/src/miyo/miyoUtils.ts
+++ b/src/miyo/miyoUtils.ts
@@ -430,6 +430,16 @@ export interface MiyoSyncReceipt {
  * device-only mismatches to avoid nagging when this device's server is in
  * fact fine. The Miyo tab's on-load `verifyMiyoScope` is the self-heal entry
  * point — and the exposure window lasts until the user opens that tab.
+ * An EMPTY receipt is the same shape of unknown: a registration made before
+ * receipts existed leaves no local evidence, and a migration cannot
+ * synthesize a truthful one (the server's scope is unknowable offline;
+ * fabricating a receipt would falsely mark it synced). Empty stays the
+ * conservative state — mismatch holds, the retriever over-fetches, the Miyo
+ * tab's on-load verify self-heals or forces the banner, and the root-change
+ * trigger runs a read-only live probe for the disconnected-with-empty-receipt
+ * case. The startup roots-change notice still needs a parseable receipt:
+ * noticing on every empty receipt would nag the entire pre-receipt user base
+ * whose scopes are in fact fine.
  * Follow-up (out of scope here): a timeout-bounded startup live-verify for
  * foreign receipts. If a future review flags this again, point them here.
  *

--- a/src/miyo/miyoUtils.ts
+++ b/src/miyo/miyoUtils.ts
@@ -382,6 +382,28 @@ export function getVaultRelativeMiyoPath(app: App, miyoPath: string): string {
 }
 
 /**
+ * Whether a RAW Miyo result path belongs to the current vault's registered
+ * folder. Ownership must be decided before {@link getVaultRelativeMiyoPath}
+ * strips the prefix: raw paths are unambiguous (this vault's results carry the
+ * vault's folder name, other folders carry theirs), but once stripped, an
+ * external folder that happens to share a name with a vault-relative folder
+ * (e.g. a Miyo folder literally named "copilot") becomes indistinguishable
+ * from in-vault content.
+ *
+ * @param app - Obsidian application instance.
+ * @param miyoPath - Raw path as returned by Miyo, before prefix-stripping.
+ */
+export function isCurrentVaultMiyoPath(app: App, miyoPath: string): boolean {
+  const folderName = getMiyoFolderName(app);
+  if (!folderName) {
+    // No resolvable folder name (mobile/remote): claim ownership so the
+    // privacy filters still apply — the conservative direction.
+    return true;
+  }
+  return normalizeFilesystemPath(miyoPath).startsWith(`${folderName}/`);
+}
+
+/**
  * Build the sync receipt recorded after the system root exclusions were
  * successfully pushed to the registered Miyo folder. The receipt self-identifies
  * its target — device, Miyo endpoint, folder name — alongside the sorted roots:

--- a/src/miyo/miyoUtils.ts
+++ b/src/miyo/miyoUtils.ts
@@ -4,9 +4,14 @@ import {
   isMiyoAvailableForCapability,
   refreshMiyoStatus,
 } from "@/miyo/miyoStatusStore";
-import { shouldUseMiyo } from "@/miyo/miyoRuntimePolicy";
-import { categorizePatterns, getDecodedPatterns } from "@/search/searchUtils";
+import { getMiyoCustomUrl, shouldUseMiyo } from "@/miyo/miyoRuntimePolicy";
+import {
+  categorizePatterns,
+  getDecodedPatterns,
+  getSystemExcludedFolders,
+} from "@/search/searchUtils";
 import { CopilotSettings, getSettings } from "@/settings/model";
+import { getDeviceId } from "@/utils/deviceId";
 import { App } from "obsidian";
 
 // Re-exported from miyoRuntimePolicy so callers keep importing these from
@@ -374,4 +379,136 @@ export function getVaultRelativeMiyoPath(app: App, miyoPath: string): string {
   }
 
   return normalizedMiyoPath;
+}
+
+/**
+ * Build the sync receipt recorded after the system root exclusions were
+ * successfully pushed to the registered Miyo folder. The receipt self-identifies
+ * its target — device, Miyo endpoint, folder name — alongside the sorted roots:
+ *
+ * - `device`: `data.json` syncs across devices but each device talks to its own
+ *   Miyo, so a receipt written on device A must read as stale on device B.
+ *   Embedding the device id makes that automatic without a device-local store.
+ * - `url` / `folder`: switching the Miyo server or renaming the vault targets a
+ *   different registration, which the old receipt must not vouch for.
+ * - `roots` are sorted so an Obsidian Sync merge that reorders
+ *   `copilotRootHistory` (content unchanged) cannot fake a mismatch and trigger
+ *   a pointless destructive re-registration.
+ *
+ * @param app - Active Obsidian app; names the registered folder.
+ * @param settings - Settings snapshot to derive the current scope from.
+ */
+export function buildMiyoSyncReceipt(app: App, settings: CopilotSettings): string {
+  return JSON.stringify({
+    device: getDeviceId(),
+    url: getMiyoCustomUrl(settings),
+    folder: getMiyoFolderName(app),
+    roots: [...getSystemExcludedFolders(settings)].sort(),
+  });
+}
+
+/** Parsed shape of a stored sync receipt. */
+export interface MiyoSyncReceipt {
+  device: string;
+  url: string;
+  folder: string;
+  roots: string[];
+}
+
+/**
+ * Parse a stored sync receipt, or null when absent/malformed. Callers use the
+ * identity fields to decide whether the receipt vouches for the registration
+ * they are looking at (same device, endpoint, and folder name).
+ *
+ * DESIGN NOTE — a foreign receipt proves NOTHING about this device's Miyo.
+ * `miyoSyncedExclusions` syncs via data.json, but each device talks to its own
+ * Miyo server. After device B resyncs, its receipt arrives here with current
+ * roots — yet THIS device's Miyo may still hold the old scope, and its Relay
+ * can keep exposing new-root content. The receipt's `device` field makes that
+ * detectable (mismatch → banner, and #4 keeps over-fetching conservatively),
+ * but the startup roots-change notice deliberately stays quiet for
+ * device-only mismatches to avoid nagging when this device's server is in
+ * fact fine. The Miyo tab's on-load `verifyMiyoScope` is the self-heal entry
+ * point — and the exposure window lasts until the user opens that tab.
+ * Follow-up (out of scope here): a timeout-bounded startup live-verify for
+ * foreign receipts. If a future review flags this again, point them here.
+ *
+ * @param stored - Raw `miyoSyncedExclusions` value.
+ */
+export function parseMiyoSyncReceipt(stored: unknown): MiyoSyncReceipt | null {
+  if (typeof stored !== "string" || stored.length === 0) return null;
+  try {
+    const parsed = JSON.parse(stored) as Partial<MiyoSyncReceipt>;
+    if (
+      typeof parsed.device !== "string" ||
+      typeof parsed.url !== "string" ||
+      typeof parsed.folder !== "string" ||
+      !Array.isArray(parsed.roots)
+    ) {
+      return null;
+    }
+    return parsed as MiyoSyncReceipt;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Whether the recorded sync receipt no longer matches the current expected
+ * scope — i.e. Miyo's server-side exclusions may be stale. Errors and missing
+ * fields read as mismatch: the consequences of a false positive are a benign
+ * over-fetch and a verify-first resync, while a false negative leaks.
+ */
+export function isMiyoScopeMismatch(app: App, settings: CopilotSettings): boolean {
+  try {
+    const stored =
+      typeof settings.miyoSyncedExclusions === "string" ? settings.miyoSyncedExclusions : "";
+    return stored !== buildMiyoSyncReceipt(app, settings);
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Whether the resync prompt (banner / post-root-change notice) should surface.
+ * Requires a mismatch plus evidence Miyo is in play: `enableMiyo`, or a
+ * non-empty receipt proving a past registration — a user who disconnected in
+ * Copilot but left Miyo + Relay running is still exposed and must not lose the
+ * prompt.
+ */
+export function shouldSurfaceMiyoResync(app: App, settings: CopilotSettings): boolean {
+  const stored =
+    typeof settings.miyoSyncedExclusions === "string" ? settings.miyoSyncedExclusions : "";
+  return isMiyoScopeMismatch(app, settings) && (settings.enableMiyo === true || stored !== "");
+}
+
+/**
+ * Whether the system roots differ from those in the recorded receipt — the
+ * signal for the one-time startup notice when a root change arrived via
+ * settings sync without passing through the settings UI. A mismatch caused only
+ * by another device's receipt (roots equal, device differs) stays silent; the
+ * Miyo tab's on-load verification self-heals that case without nagging.
+ */
+export function didMiyoSyncedRootsChange(settings: CopilotSettings): boolean {
+  const receipt = parseMiyoSyncReceipt(settings.miyoSyncedExclusions);
+  if (!receipt) return false;
+  const current = [...getSystemExcludedFolders(settings)].sort();
+  return JSON.stringify(receipt.roots) !== JSON.stringify(current);
+}
+
+/**
+ * Whether the user has QA patterns of their own — beyond the system root
+ * exclusions — that the Miyo retriever's local filter can act on. Drives the
+ * over-fetch decision: with no user patterns and a synced scope, the server
+ * already omits everything the local filter would drop.
+ *
+ * `qaExclusions` defaults to the Copilot root, so raw non-emptiness is not a
+ * signal; system-root entries are subtracted before judging.
+ */
+export function hasUserQaPatterns(settings: CopilotSettings): boolean {
+  if ((settings.qaInclusions || "").trim().length > 0) return true;
+  const raw = (settings.qaExclusions || "").trim();
+  if (raw.length === 0) return false;
+  const system = new Set(getSystemExcludedFolders(settings));
+  return getDecodedPatterns(raw).some((pattern) => !system.has(pattern.replace(/\/+$/, "")));
 }

--- a/src/projects/ProjectFileManager.ts
+++ b/src/projects/ProjectFileManager.ts
@@ -487,8 +487,7 @@ export class ProjectFileManager {
             lastUsedMs,
           });
         } catch (fmError) {
-          if (materialized)
-            await this.rollbackCreatedFile(filePath, getProjectFolderPath(folderName));
+          if (materialized) await this.rollbackCreatedFile(filePath, projectFolderIn(folderName));
           throw fmError;
         }
 
@@ -575,7 +574,10 @@ export class ProjectFileManager {
       return;
     }
 
-    const folderPath = getProjectFolderPath(existing.folderName);
+    // From the record's own config path: deleting via the live root would target
+    // a same-named project in a different tree during the window after a root
+    // change but before ProjectRegister reloads its cache.
+    const { projectFolderPath: folderPath } = getProjectAnchorFromConfigPath(existing.filePath);
 
     try {
       addPendingFileWrite(existing.filePath);

--- a/src/projects/ProjectFileManager.ts
+++ b/src/projects/ProjectFileManager.ts
@@ -20,6 +20,7 @@ import { ProjectFileRecord } from "@/projects/type";
 import { ensureAgentsMirror, removeAgentsMirror } from "@/projects/ensureAgentsMirror";
 import {
   fetchAllProjects,
+  getProjectAnchorFromConfigPath,
   getProjectConfigFilePath,
   getProjectFolderPath,
   getProjectsFolder,
@@ -369,6 +370,14 @@ export class ProjectFileManager {
 
     let filePath = existing.filePath;
     let folderName = existing.folderName;
+    // Every path below derives from the record's OWN location, never the live
+    // projects root. A Copilot root change activates immediately while
+    // ProjectRegister reloads its cache on a 1s trailing debounce, so an update
+    // started in that window would otherwise rename and write inside a
+    // different tree — destructively when the new root is a previously-used one
+    // that already holds a project of this name.
+    const { projectsRoot } = getProjectAnchorFromConfigPath(existing.filePath);
+    const projectFolderIn = (name: string) => normalizePath(`${projectsRoot}/${name}`);
 
     // Reason: when the project name changes, the folder should be renamed to match.
     // This keeps vault browsing intuitive (folder = project name).
@@ -376,10 +385,10 @@ export class ProjectFileManager {
     let oldFilePathForPending: string | null = null;
 
     if (nextFolderName !== existing.folderName) {
-      const newFolderPath = getProjectFolderPath(nextFolderName);
+      const newFolderPath = projectFolderIn(nextFolderName);
       // Reason: a folder rename keeps the config basename (`project.md`), so the new config
       // path is just `project.md` under the renamed folder.
-      const newFilePath = getProjectConfigFilePath(nextFolderName);
+      const newFilePath = getProjectConfigFilePath(nextFolderName, projectsRoot);
 
       // Check collision: cache (case-insensitive) + filesystem
       const folderKey = nextFolderName.toLowerCase();
@@ -395,7 +404,7 @@ export class ProjectFileManager {
       // (e.g. "foo" → "Foo") reports the old folder as "already existing". Skip the
       // disk-conflict check when the paths differ only in case.
       const isCaseOnlyRename =
-        newFolderPath.toLowerCase() === getProjectFolderPath(existing.folderName).toLowerCase();
+        newFolderPath.toLowerCase() === projectFolderIn(existing.folderName).toLowerCase();
       if (!isCaseOnlyRename && (await this.vault.adapter.exists(newFolderPath))) {
         throw new Error(`Cannot rename project folder: "${newFolderPath}" already exists on disk`);
       }
@@ -406,7 +415,7 @@ export class ProjectFileManager {
       addPendingFileWrite(newFilePath);
 
       try {
-        const oldFolderPath = getProjectFolderPath(existing.folderName);
+        const oldFolderPath = projectFolderIn(existing.folderName);
         // Reason: use vault-cache-aware rename when possible, adapter fallback for hidden folders
         const folderObj = this.vault.getAbstractFileByPath(oldFolderPath);
         if (folderObj instanceof TFolder) {
@@ -446,8 +455,8 @@ export class ProjectFileManager {
       // migration completed), materialize it now so the update can proceed.
       if (!file) {
         logInfo(`[Projects] Materializing missing vault file for project: ${normalizedId}`);
-        const folderPath = getProjectFolderPath(folderName);
-        await ensureFolderExists(this.vault, getProjectsFolder());
+        const folderPath = projectFolderIn(folderName);
+        await ensureFolderExists(this.vault, projectsRoot);
         await ensureFolderExists(this.vault, folderPath);
         file = await this.vault.create(filePath, nextProject.systemPrompt || "");
         materialized = true;
@@ -522,8 +531,8 @@ export class ProjectFileManager {
       // to prevent leaving the project in an inconsistent location.
       if (oldFilePathForPending && folderName !== existing.folderName) {
         try {
-          const oldFolderPath = getProjectFolderPath(existing.folderName);
-          const newFolderPath = getProjectFolderPath(folderName);
+          const oldFolderPath = projectFolderIn(existing.folderName);
+          const newFolderPath = projectFolderIn(folderName);
           // Reason: use vault.rename() for cached folders (same as forward rename) so
           // the vault cache stays consistent. Fall back to adapter for hidden folders.
           const renamedFolder = this.vault.getAbstractFileByPath(newFolderPath);

--- a/src/projects/ensureAgentsMirror.test.ts
+++ b/src/projects/ensureAgentsMirror.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@/projects/projectSystemPrompt";
 import { ProjectFileRecord } from "@/projects/type";
 import { mockTFile, mockTFolder } from "@/__tests__/mockObsidian";
+import { getSettings } from "@/settings/model";
 
 jest.mock("@/settings/model", () => ({
   getSettings: jest.fn(() => ({ projectsFolder: "copilot-projects" })),
@@ -119,6 +120,25 @@ describe("ensureAgentsMirror", () => {
     const [markerLine] = written.split("\n", 1);
     expect(markerLine.startsWith(MIRROR_MARKER_PREFIX)).toBe(true);
     expect(written).toBe(`${markerLine}\n\n${composeProjectInstructions("Be concise.")}`);
+  });
+
+  it("writes beside the record's own project.md even after the configured root moved", async () => {
+    // A Copilot root change activates before ProjectRegister reloads its cache,
+    // so for at least a second the record still points at the old tree. Deriving
+    // the mirror from the live root there would write it next to a DIFFERENT
+    // project — overwriting that one's generated mirror.
+    const vault = new FakeVault();
+    const mockedSettings = getSettings as jest.Mock;
+    mockedSettings.mockReturnValue({ projectsFolder: "moved-root/projects" });
+    try {
+      await ensureAgentsMirror(makeApp(vault), makeRecord("Be concise."));
+
+      expect(vault.files.has(MIRROR_PATH)).toBe(true);
+      expect([...vault.files.keys()].some((k) => k.startsWith("moved-root/"))).toBe(false);
+    } finally {
+      // Restore: the mock is module-level and later suites read it.
+      mockedSettings.mockReturnValue({ projectsFolder: "copilot-projects" });
+    }
   });
 
   it("cheap-skips when the instruction body is unchanged (even if other config fields change)", async () => {

--- a/src/projects/ensureAgentsMirror.test.ts
+++ b/src/projects/ensureAgentsMirror.test.ts
@@ -16,6 +16,13 @@ jest.mock("@/settings/model", () => ({
   getSettings: jest.fn(() => ({ projectsFolder: "copilot-projects" })),
 }));
 
+// getProjectsFolder derives from copilotFolder in production; shim the derived
+// accessor to the folder these tests configure via getSettings().projectsFolder.
+jest.mock("@/settings/copilotFolder", () => {
+  const { getSettings } = jest.requireMock<typeof import("@/settings/model")>("@/settings/model");
+  return { getEffectiveProjectsFolder: jest.fn(() => getSettings().projectsFolder) };
+});
+
 jest.mock("@/projects/state", () => ({
   addPendingFileWrite: jest.fn(),
   removePendingFileWrite: jest.fn(),

--- a/src/projects/ensureAgentsMirror.ts
+++ b/src/projects/ensureAgentsMirror.ts
@@ -1,6 +1,6 @@
 import { logError } from "@/logger";
 import { AGENTS_MIRROR_FILE } from "@/projects/constants";
-import { getProjectFolderPath } from "@/projects/projectPaths";
+import { getProjectAnchorFromConfigPath } from "@/projects/projectPaths";
 import { getComposedProjectInstructions } from "@/projects/projectSystemPrompt";
 import { addPendingFileWrite, removePendingFileWrite } from "@/projects/state";
 import { ProjectFileRecord } from "@/projects/type";
@@ -144,8 +144,17 @@ async function removeMirrorInternal(app: App, mirrorPath: string): Promise<void>
   }
 }
 
+/**
+ * The mirror always sits beside the `project.md` it mirrors.
+ *
+ * Derived from `record.filePath` rather than the live projects root: a Copilot
+ * root change activates before `ProjectRegister` reloads its cache, so a mirror
+ * written from the live root in that window lands in a different tree — and
+ * overwrites the generated mirror of whatever project occupies that name there.
+ */
 function getMirrorPath(record: ProjectFileRecord): string {
-  return normalizePath(`${getProjectFolderPath(record.folderName)}/${AGENTS_MIRROR_FILE}`);
+  const { projectFolderPath } = getProjectAnchorFromConfigPath(record.filePath);
+  return normalizePath(`${projectFolderPath}/${AGENTS_MIRROR_FILE}`);
 }
 
 function buildMirrorContent(body: string): string {

--- a/src/projects/projectMigration.ts
+++ b/src/projects/projectMigration.ts
@@ -20,7 +20,7 @@ import {
 import { addPendingFileWrite, removePendingFileWrite } from "@/projects/state";
 import { getSettings, updateSetting } from "@/settings/model";
 import { ensureFolderExists, stripFrontmatter } from "@/utils";
-import { App, Notice, parseYaml, TFile, TFolder, Vault } from "obsidian";
+import { App, Notice, normalizePath, parseYaml, TFile, TFolder, Vault } from "obsidian";
 import { trashFile } from "@/utils/vaultAdapterUtils";
 
 /**
@@ -43,10 +43,13 @@ function normalizeLineEndings(content: string): string {
 async function saveFailedProjectToUnsupported(
   vault: Vault,
   project: ProjectConfig,
-  reason: string
+  reason: string,
+  projectsFolder: string
 ): Promise<boolean> {
   try {
-    const unsupportedFolder = getProjectsUnsupportedFolder();
+    const unsupportedFolder = normalizePath(
+      `${projectsFolder}/${PROJECTS_UNSUPPORTED_FOLDER_NAME}`
+    );
     await ensureFolderExists(vault, unsupportedFolder);
 
     const safeId = sanitizeVaultPathSegment(project.id || "unknown") || "unknown";
@@ -147,10 +150,10 @@ async function rollbackCreatedFile(app: App, filePath: string, folderPath: strin
 async function writeProjectToVaultFile(
   app: App,
   project: ProjectConfig,
-  folderName: string
+  folderName: string,
+  projectsFolder: string
 ): Promise<TFile> {
   const vault = app.vault;
-  const projectsFolder = getProjectsFolder();
   await ensureFolderExists(vault, projectsFolder);
   await ensureFolderExists(vault, `${projectsFolder}/${folderName}`);
 
@@ -275,14 +278,19 @@ export async function migrateProjectsFromSettingsToVault(app: App): Promise<void
     // Dirty data defense: skip empty ids
     if (!id) {
       logWarn("[Projects] Skip migrating project with empty id");
-      await saveFailedProjectToUnsupported(vault, project, "empty project id");
+      await saveFailedProjectToUnsupported(vault, project, "empty project id", passProjectsFolder);
       continue;
     }
 
     // Dirty data defense: skip duplicate ids
     if (seenIds.has(id)) {
       logWarn(`[Projects] Skip migrating duplicate project id: ${id}`);
-      await saveFailedProjectToUnsupported(vault, project, `duplicate project id: ${id}`);
+      await saveFailedProjectToUnsupported(
+        vault,
+        project,
+        `duplicate project id: ${id}`,
+        passProjectsFolder
+      );
       continue;
     }
     seenIds.add(id);
@@ -300,7 +308,8 @@ export async function migrateProjectsFromSettingsToVault(app: App): Promise<void
       await saveFailedProjectToUnsupported(
         vault,
         project,
-        `folder name collision: "${folderName}" already used by id="${firstIdForFolder}"`
+        `folder name collision: "${folderName}" already used by id="${firstIdForFolder}"`,
+        passProjectsFolder
       );
       continue;
     }
@@ -387,7 +396,8 @@ export async function migrateProjectsFromSettingsToVault(app: App): Promise<void
         await saveFailedProjectToUnsupported(
           vault,
           project,
-          `existing file content mismatch at ${filePath} (delete/rename the file and re-run migration)`
+          `existing file content mismatch at ${filePath} (delete/rename the file and re-run migration)`,
+          passProjectsFolder
         );
         continue;
       }
@@ -399,13 +409,14 @@ export async function migrateProjectsFromSettingsToVault(app: App): Promise<void
       await saveFailedProjectToUnsupported(
         vault,
         project,
-        `target file exists at ${filePath} with mismatched id="${existingId}"`
+        `target file exists at ${filePath} with mismatched id="${existingId}"`,
+        passProjectsFolder
       );
       continue;
     }
 
     try {
-      const file = await writeProjectToVaultFile(app, project, folderName);
+      const file = await writeProjectToVaultFile(app, project, folderName, passProjectsFolder);
 
       const verified = await verifyMigratedContent(vault, file, project.systemPrompt || "");
       if (!verified) {
@@ -414,14 +425,19 @@ export async function migrateProjectsFromSettingsToVault(app: App): Promise<void
         // and fails again indefinitely.
         const folderPath = `${passProjectsFolder}/${folderName}`;
         await rollbackCreatedFile(app, file.path, folderPath);
-        await saveFailedProjectToUnsupported(vault, project, "content verification mismatch");
+        await saveFailedProjectToUnsupported(
+          vault,
+          project,
+          "content verification mismatch",
+          passProjectsFolder
+        );
       } else {
         migratedEntries.push(project);
       }
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       logError(`[Projects] Failed to migrate project id=${id}`, error);
-      await saveFailedProjectToUnsupported(vault, project, msg);
+      await saveFailedProjectToUnsupported(vault, project, msg, passProjectsFolder);
     }
   }
 

--- a/src/projects/projectMigration.ts
+++ b/src/projects/projectMigration.ts
@@ -3,11 +3,14 @@ import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { logError, logInfo, logWarn } from "@/logger";
 import { COPILOT_PROJECT_ID, PROJECTS_UNSUPPORTED_FOLDER_NAME } from "@/projects/constants";
 import { reconcileLegacyAgentsResidue } from "@/projects/legacyAgentsResidue";
-import { deriveProjectFolderName, sanitizeVaultPathSegment } from "@/projects/projectPaths";
+import {
+  deriveProjectFolderName,
+  getProjectAnchorFromConfigPath,
+  sanitizeVaultPathSegment,
+} from "@/projects/projectPaths";
 import {
   ensureProjectFrontmatter,
   getProjectConfigFilePath,
-  getProjectFolderPath,
   getProjectsFolder,
   getProjectsUnsupportedFolder,
   readFrontmatterFieldFromFile,
@@ -151,7 +154,10 @@ async function writeProjectToVaultFile(
   await ensureFolderExists(vault, projectsFolder);
   await ensureFolderExists(vault, `${projectsFolder}/${folderName}`);
 
-  const filePath = getProjectConfigFilePath(folderName);
+  // Reuse the root this call already ensured rather than re-reading the live
+  // one: a Copilot root change between the ensure and here would write outside
+  // the directory that was just created.
+  const filePath = getProjectConfigFilePath(folderName, projectsFolder);
 
   const folderPath = `${projectsFolder}/${folderName}`;
 
@@ -241,6 +247,10 @@ function getMigrationFolderName(projectId: string, projectName?: string): string
  * @param app - Obsidian App instance
  */
 export async function migrateProjectsFromSettingsToVault(app: App): Promise<void> {
+  // One root for the whole pass. This runs on layout-ready and loops with awaits
+  // per project, so re-reading the live root mid-pass could plan against one
+  // tree and write into another.
+  const passProjectsFolder = getProjectsFolder();
   const vault = app.vault;
   const settings = getSettings();
   const legacyProjects = settings.projectList || [];
@@ -295,7 +305,7 @@ export async function migrateProjectsFromSettingsToVault(app: App): Promise<void
       continue;
     }
     seenFolderNames.set(folderKey, id);
-    const filePath = getProjectConfigFilePath(folderName);
+    const filePath = getProjectConfigFilePath(folderName, passProjectsFolder);
 
     // Retry-safety: if target file already exists from a prior partial migration, skip it
     // but only if the frontmatter id matches (to avoid treating conflict files as successful)
@@ -402,7 +412,7 @@ export async function migrateProjectsFromSettingsToVault(app: App): Promise<void
         // Reason: rollback the just-created file to prevent a permanent retry-failure loop.
         // Without this, the existing-file branch on next restart re-detects, re-verifies,
         // and fails again indefinitely.
-        const folderPath = `${getProjectsFolder()}/${folderName}`;
+        const folderPath = `${passProjectsFolder}/${folderName}`;
         await rollbackCreatedFile(app, file.path, folderPath);
         await saveFailedProjectToUnsupported(vault, project, "content verification mismatch");
       } else {
@@ -518,7 +528,6 @@ async function migrateProjectFolderNames(app: App): Promise<void> {
   if (records.length === 0) return;
 
   let renamed = 0;
-  const projectsFolder = getProjectsFolder();
   // Reason: track reserved lowercase folder names to prevent case-insensitive collisions
   // (e.g. "Foo" and "foo" both targeting the same path on macOS/Windows).
   // Matches the same guard used in createProject() and updateProject().
@@ -540,12 +549,16 @@ async function migrateProjectFolderNames(app: App): Promise<void> {
 
     if (safeFolderName === record.folderName) continue; // Already correct
 
-    const newFolderPath = `${projectsFolder}/${safeFolderName}`;
-    const oldFolderPath = getProjectFolderPath(record.folderName);
+    // Anchored on the record's own config path, not the live root: this loop
+    // awaits a rename per project, and a Copilot root change mid-loop would
+    // otherwise pair a source in one tree with a destination in another.
+    const { projectsRoot: recordProjectsRoot, projectFolderPath: oldFolderPath } =
+      getProjectAnchorFromConfigPath(record.filePath);
+    const newFolderPath = `${recordProjectsRoot}/${safeFolderName}`;
     const oldFilePath = record.filePath;
     // Reason: a folder rename preserves the config basename (`project.md`), so the new path
     // is just the same config name under the renamed folder.
-    const newFilePath = getProjectConfigFilePath(safeFolderName);
+    const newFilePath = getProjectConfigFilePath(safeFolderName, recordProjectsRoot);
 
     // Reason: case-insensitive collision guard — skip if another project already
     // occupies or is targeting this lowercase folder name (cross-platform safety).

--- a/src/projects/projectPaths.test.ts
+++ b/src/projects/projectPaths.test.ts
@@ -5,8 +5,8 @@ import {
 } from "@/projects/projectPaths";
 import { mockTFile } from "@/__tests__/mockObsidian";
 
-jest.mock("@/settings/model", () => ({
-  getSettings: jest.fn(() => ({ projectsFolder: "copilot-projects" })),
+jest.mock("@/settings/copilotFolder", () => ({
+  getEffectiveProjectsFolder: jest.fn(() => "copilot-projects"),
 }));
 
 describe("getProjectConfigFilePath — single source of truth", () => {

--- a/src/projects/projectPaths.test.ts
+++ b/src/projects/projectPaths.test.ts
@@ -10,116 +10,122 @@ import { mockTFile } from "@/__tests__/mockObsidian";
 jest.mock("@/settings/copilotFolder", () => ({
   getEffectiveProjectsFolder: jest.fn(() => "copilot-projects"),
 }));
+describe("projectPaths", () => {
+  describe("getProjectConfigFilePath()", () => {
+    it("returns the project.md path under the project folder", () => {
+      expect(getProjectConfigFilePath("MyProject")).toBe("copilot-projects/MyProject/project.md");
+    });
 
-describe("getProjectConfigFilePath — single source of truth", () => {
-  it("returns the project.md path under the project folder", () => {
-    expect(getProjectConfigFilePath("MyProject")).toBe("copilot-projects/MyProject/project.md");
+    it("honors a root override", () => {
+      expect(getProjectConfigFilePath("MyProject", "custom/root")).toBe(
+        "custom/root/MyProject/project.md"
+      );
+    });
   });
 
-  it("honors a root override", () => {
-    expect(getProjectConfigFilePath("MyProject", "custom/root")).toBe(
-      "custom/root/MyProject/project.md"
-    );
-  });
-});
+  describe("getProjectAnchorFromConfigPath()", () => {
+    it("resolves a project's tree from its own config path, ignoring the live root", () => {
+      // The two disagree for at least a second after a Copilot root change: the
+      // root activates immediately while ProjectRegister reloads its cache on a
+      // 1s trailing debounce. An operation holding a record from the old tree must
+      // keep acting on that tree.
+      const anchor = getProjectAnchorFromConfigPath("old-root/projects/My Project/project.md");
 
-describe("getProjectAnchorFromConfigPath", () => {
-  it("resolves a project's tree from its own config path, ignoring the live root", () => {
-    // The two disagree for at least a second after a Copilot root change: the
-    // root activates immediately while ProjectRegister reloads its cache on a
-    // 1s trailing debounce. An operation holding a record from the old tree must
-    // keep acting on that tree.
-    const anchor = getProjectAnchorFromConfigPath("old-root/projects/My Project/project.md");
-
-    expect(anchor.projectFolderPath).toBe("old-root/projects/My Project");
-    expect(anchor.projectsRoot).toBe("old-root/projects");
-  });
-
-  it("throws on a path too shallow to name a tree instead of inventing one", () => {
-    // Unreachable from a real record (isProjectConfigFile enforces the shape).
-    // Throwing beats both alternatives: a naive slice truncates ("project.md" to
-    // "project."), and defaulting to the live root reintroduces the dependency
-    // this helper removes. Either hands the caller a path pointing nowhere.
-    expect(() => getProjectAnchorFromConfigPath("project.md")).toThrow(
-      'Not a project config path: "project.md"'
-    );
-  });
-
-  it("is unaffected by the configured root moving", () => {
-    const mockedRoot = getEffectiveProjectsFolder as jest.Mock;
-    mockedRoot.mockReturnValue("new-root/projects");
-    try {
-      const anchor = getProjectAnchorFromConfigPath("old-root/projects/Alpha/project.md");
-
+      expect(anchor.projectFolderPath).toBe("old-root/projects/My Project");
       expect(anchor.projectsRoot).toBe("old-root/projects");
-    } finally {
-      // Restore: this mock is module-level, and the suites below derive paths
-      // from it.
-      mockedRoot.mockReturnValue("copilot-projects");
-    }
-  });
-});
+    });
 
-describe("isProjectConfigFile — project.md only (AGENTS.md is not a config)", () => {
-  it("recognizes project.md", () => {
-    expect(
-      isProjectConfigFile(
-        mockTFile({ path: "copilot-projects/Foo/project.md", name: "project.md", extension: "md" })
-      )
-    ).toBe(true);
-  });
+    it("throws on a path too shallow to name a tree instead of inventing one", () => {
+      // Unreachable from a real record (isProjectConfigFile enforces the shape).
+      // Throwing beats both alternatives: a naive slice truncates ("project.md" to
+      // "project."), and defaulting to the live root reintroduces the dependency
+      // this helper removes. Either hands the caller a path pointing nowhere.
+      expect(() => getProjectAnchorFromConfigPath("project.md")).toThrow(
+        'Not a project config path: "project.md"'
+      );
+    });
 
-  it("does NOT recognize the generated AGENTS.md mirror as a config file", () => {
-    expect(
-      isProjectConfigFile(
-        mockTFile({ path: "copilot-projects/Foo/AGENTS.md", name: "AGENTS.md", extension: "md" })
-      )
-    ).toBe(false);
-  });
+    it("is unaffected by the configured root moving", () => {
+      const mockedRoot = getEffectiveProjectsFolder as jest.Mock;
+      mockedRoot.mockReturnValue("new-root/projects");
+      try {
+        const anchor = getProjectAnchorFromConfigPath("old-root/projects/Alpha/project.md");
 
-  it("rejects files under the unsupported/ backup folder", () => {
-    expect(
-      isProjectConfigFile(
-        mockTFile({
-          path: "copilot-projects/unsupported/project.md",
-          name: "project.md",
-          extension: "md",
-        })
-      )
-    ).toBe(false);
+        expect(anchor.projectsRoot).toBe("old-root/projects");
+      } finally {
+        // Restore: this mock is module-level, and the suites below derive paths
+        // from it.
+        mockedRoot.mockReturnValue("copilot-projects");
+      }
+    });
   });
 
-  it("rejects an unrecognized config file name at the right depth", () => {
-    expect(
-      isProjectConfigFile(
-        mockTFile({ path: "copilot-projects/Foo/notes.md", name: "notes.md", extension: "md" })
-      )
-    ).toBe(false);
+  // AGENTS.md is deliberately not a config file — see the guard's own note.
+  describe("isProjectConfigFile()", () => {
+    it("recognizes project.md", () => {
+      expect(
+        isProjectConfigFile(
+          mockTFile({
+            path: "copilot-projects/Foo/project.md",
+            name: "project.md",
+            extension: "md",
+          })
+        )
+      ).toBe(true);
+    });
+
+    it("does NOT recognize the generated AGENTS.md mirror as a config file", () => {
+      expect(
+        isProjectConfigFile(
+          mockTFile({ path: "copilot-projects/Foo/AGENTS.md", name: "AGENTS.md", extension: "md" })
+        )
+      ).toBe(false);
+    });
+
+    it("rejects files under the unsupported/ backup folder", () => {
+      expect(
+        isProjectConfigFile(
+          mockTFile({
+            path: "copilot-projects/unsupported/project.md",
+            name: "project.md",
+            extension: "md",
+          })
+        )
+      ).toBe(false);
+    });
+
+    it("rejects an unrecognized config file name at the right depth", () => {
+      expect(
+        isProjectConfigFile(
+          mockTFile({ path: "copilot-projects/Foo/notes.md", name: "notes.md", extension: "md" })
+        )
+      ).toBe(false);
+    });
+
+    it("rejects files nested too deep", () => {
+      expect(
+        isProjectConfigFile(
+          mockTFile({
+            path: "copilot-projects/Foo/sub/project.md",
+            name: "project.md",
+            extension: "md",
+          })
+        )
+      ).toBe(false);
+    });
   });
 
-  it("rejects files nested too deep", () => {
-    expect(
-      isProjectConfigFile(
-        mockTFile({
-          path: "copilot-projects/Foo/sub/project.md",
-          name: "project.md",
-          extension: "md",
-        })
-      )
-    ).toBe(false);
-  });
-});
+  describe("getProjectFolderNameFromConfigPath()", () => {
+    it("extracts the folder from a project.md path", () => {
+      expect(getProjectFolderNameFromConfigPath("copilot-projects/Foo/project.md")).toBe("Foo");
+    });
 
-describe("getProjectFolderNameFromConfigPath", () => {
-  it("extracts the folder from a project.md path", () => {
-    expect(getProjectFolderNameFromConfigPath("copilot-projects/Foo/project.md")).toBe("Foo");
-  });
+    it("returns null for the AGENTS.md mirror (not a config path)", () => {
+      expect(getProjectFolderNameFromConfigPath("copilot-projects/Foo/AGENTS.md")).toBeNull();
+    });
 
-  it("returns null for the AGENTS.md mirror (not a config path)", () => {
-    expect(getProjectFolderNameFromConfigPath("copilot-projects/Foo/AGENTS.md")).toBeNull();
-  });
-
-  it("returns null for a non-config path", () => {
-    expect(getProjectFolderNameFromConfigPath("copilot-projects/Foo/other.md")).toBeNull();
+    it("returns null for a non-config path", () => {
+      expect(getProjectFolderNameFromConfigPath("copilot-projects/Foo/other.md")).toBeNull();
+    });
   });
 });

--- a/src/projects/projectPaths.test.ts
+++ b/src/projects/projectPaths.test.ts
@@ -1,8 +1,10 @@
 import {
+  getProjectAnchorFromConfigPath,
   getProjectConfigFilePath,
   getProjectFolderNameFromConfigPath,
   isProjectConfigFile,
 } from "@/projects/projectPaths";
+import { getEffectiveProjectsFolder } from "@/settings/copilotFolder";
 import { mockTFile } from "@/__tests__/mockObsidian";
 
 jest.mock("@/settings/copilotFolder", () => ({
@@ -18,6 +20,33 @@ describe("getProjectConfigFilePath — single source of truth", () => {
     expect(getProjectConfigFilePath("MyProject", "custom/root")).toBe(
       "custom/root/MyProject/project.md"
     );
+  });
+});
+
+describe("getProjectAnchorFromConfigPath", () => {
+  it("resolves a project's tree from its own config path, ignoring the live root", () => {
+    // The two disagree for at least a second after a Copilot root change: the
+    // root activates immediately while ProjectRegister reloads its cache on a
+    // 1s trailing debounce. An operation holding a record from the old tree must
+    // keep acting on that tree.
+    const anchor = getProjectAnchorFromConfigPath("old-root/projects/My Project/project.md");
+
+    expect(anchor.projectFolderPath).toBe("old-root/projects/My Project");
+    expect(anchor.projectsRoot).toBe("old-root/projects");
+  });
+
+  it("is unaffected by the configured root moving", () => {
+    const mockedRoot = getEffectiveProjectsFolder as jest.Mock;
+    mockedRoot.mockReturnValue("new-root/projects");
+    try {
+      const anchor = getProjectAnchorFromConfigPath("old-root/projects/Alpha/project.md");
+
+      expect(anchor.projectsRoot).toBe("old-root/projects");
+    } finally {
+      // Restore: this mock is module-level, and the suites below derive paths
+      // from it.
+      mockedRoot.mockReturnValue("copilot-projects");
+    }
   });
 });
 

--- a/src/projects/projectPaths.test.ts
+++ b/src/projects/projectPaths.test.ts
@@ -35,6 +35,16 @@ describe("getProjectAnchorFromConfigPath", () => {
     expect(anchor.projectsRoot).toBe("old-root/projects");
   });
 
+  it("throws on a path too shallow to name a tree instead of inventing one", () => {
+    // Unreachable from a real record (isProjectConfigFile enforces the shape).
+    // Throwing beats both alternatives: a naive slice truncates ("project.md" to
+    // "project."), and defaulting to the live root reintroduces the dependency
+    // this helper removes. Either hands the caller a path pointing nowhere.
+    expect(() => getProjectAnchorFromConfigPath("project.md")).toThrow(
+      'Not a project config path: "project.md"'
+    );
+  });
+
   it("is unaffected by the configured root moving", () => {
     const mockedRoot = getEffectiveProjectsFolder as jest.Mock;
     mockedRoot.mockReturnValue("new-root/projects");

--- a/src/projects/projectPaths.ts
+++ b/src/projects/projectPaths.ts
@@ -11,6 +11,32 @@ export function getProjectsFolder(): string {
 }
 
 /**
+ * Locate an existing project from its own config path instead of the live root.
+ *
+ * For a project that is already on disk, `record.filePath` is the authority —
+ * not whatever root is configured right now. The two disagree for at least a
+ * second after a Copilot root change: the root activates immediately while
+ * `ProjectRegister` reloads its cache on a 1s trailing debounce, so an operation
+ * started in that window holds a record from the old tree. Deriving paths from
+ * the live root there would rename, write, or mirror into a DIFFERENT tree —
+ * destructively so when the new root is a previously-used Copilot root that
+ * already holds a project of the same name (re-activating one is supported, and
+ * the note-content guard exempts it).
+ *
+ * @param configFilePath - A record's `filePath` (`\<root\>/\<folder\>/project.md`).
+ * @returns The project's own folder and the projects root that contains it.
+ */
+export function getProjectAnchorFromConfigPath(configFilePath: string): {
+  projectFolderPath: string;
+  projectsRoot: string;
+} {
+  const normalized = normalizePath(configFilePath);
+  const projectFolderPath = normalized.slice(0, normalized.lastIndexOf("/"));
+  const projectsRoot = projectFolderPath.slice(0, projectFolderPath.lastIndexOf("/"));
+  return { projectFolderPath, projectsRoot };
+}
+
+/**
  * Get the unsupported backup folder path for failed migrations.
  * @returns Normalized vault path
  */

--- a/src/projects/projectPaths.ts
+++ b/src/projects/projectPaths.ts
@@ -1,13 +1,13 @@
 import { PROJECT_CONFIG_FILE_NAME, PROJECTS_UNSUPPORTED_FOLDER_NAME } from "@/projects/constants";
-import { getSettings } from "@/settings/model";
+import { getEffectiveProjectsFolder } from "@/settings/copilotFolder";
 import { normalizePath, TAbstractFile, TFile, Vault } from "obsidian";
 
 /**
- * Get the projects root folder path from settings.
+ * Get the projects root folder path, derived from the configurable copilotFolder root.
  * @returns Normalized vault path
  */
 export function getProjectsFolder(): string {
-  return normalizePath(getSettings().projectsFolder);
+  return getEffectiveProjectsFolder();
 }
 
 /**

--- a/src/projects/projectPaths.ts
+++ b/src/projects/projectPaths.ts
@@ -30,10 +30,19 @@ export function getProjectAnchorFromConfigPath(configFilePath: string): {
   projectFolderPath: string;
   projectsRoot: string;
 } {
-  const normalized = normalizePath(configFilePath);
-  const projectFolderPath = normalized.slice(0, normalized.lastIndexOf("/"));
-  const projectsRoot = projectFolderPath.slice(0, projectFolderPath.lastIndexOf("/"));
-  return { projectFolderPath, projectsRoot };
+  const segments = normalizePath(configFilePath).split("/");
+  // Records only ever come from a path `isProjectConfigFile` accepted, which is
+  // exactly `<root>/<folder>/project.md`. Anything shorter cannot name a tree,
+  // so throw rather than invent one: a naive slice would silently truncate
+  // ("project.md" -> "project."), and falling back to the live root would
+  // reintroduce the very dependency this function exists to remove.
+  if (segments.length < 3) {
+    throw new Error(`Not a project config path: "${configFilePath}"`);
+  }
+  return {
+    projectFolderPath: segments.slice(0, -1).join("/"),
+    projectsRoot: segments.slice(0, -2).join("/"),
+  };
 }
 
 /**

--- a/src/projects/projectRegister.test.ts
+++ b/src/projects/projectRegister.test.ts
@@ -1,0 +1,117 @@
+import { App, Vault } from "obsidian";
+import { ProjectRegister } from "@/projects/projectRegister";
+import type { CopilotSettings } from "@/settings/model";
+
+jest.mock("obsidian", () => ({
+  Notice: jest.fn(),
+  Vault: jest.fn(),
+  normalizePath: (path: string) => path.replace(/\/+/g, "/").replace(/^\/|\/$/g, ""),
+}));
+
+jest.mock("@/logger", () => ({
+  logInfo: jest.fn(),
+  logError: jest.fn(),
+  logWarn: jest.fn(),
+}));
+
+jest.mock("@/projects/ProjectFileManager", () => {
+  const instance = { fetchProjects: jest.fn().mockResolvedValue([]), initialize: jest.fn() };
+  return { ProjectFileManager: { getInstance: jest.fn(() => instance) } };
+});
+
+jest.mock("@/projects/projectUtils", () => ({
+  ensureProjectFrontmatter: jest.fn(),
+  getProjectsFolder: jest.fn(() => "copilot/projects"),
+  isProjectConfigFile: jest.fn(() => false),
+  parseProjectConfigFile: jest.fn(),
+  loadAllProjects: jest.fn(),
+}));
+
+jest.mock("@/projects/state", () => ({
+  deleteCachedProjectRecordByFilePath: jest.fn(),
+  getCachedProjectRecordByFilePath: jest.fn(),
+  getCachedProjectRecordById: jest.fn(),
+  getCachedProjectRecords: jest.fn(() => []),
+  isPendingFileWrite: jest.fn(() => false),
+  replaceCachedProjectRecordByFilePath: jest.fn(),
+  updateCachedProjectRecords: jest.fn(),
+  upsertCachedProjectRecord: jest.fn(),
+}));
+
+jest.mock("@/aiParams", () => ({
+  getCurrentProject: jest.fn(() => null),
+}));
+
+jest.mock("@/cache/projectContextCache", () => ({
+  ProjectContextCache: {
+    getInstance: jest.fn(() => ({ clearForProject: jest.fn().mockResolvedValue(undefined) })),
+  },
+}));
+
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({ copilotFolder: "copilot" })),
+  subscribeToSettingsChange: jest.fn().mockReturnValue(() => {}),
+}));
+
+/** Build a settings object carrying only the root the watcher reads. */
+function settingsWithRoot(copilotFolder: string): CopilotSettings {
+  return { copilotFolder } as CopilotSettings;
+}
+
+describe("projectRegister", () => {
+  describe("ProjectRegister", () => {
+    describe("handleSettingsChange()", () => {
+      let settingsChangeHandler: (prev: CopilotSettings, next: CopilotSettings) => void;
+      let fetchProjects: jest.Mock;
+      let updateCachedProjectRecords: jest.Mock;
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+        jest.useFakeTimers();
+
+        const { ProjectFileManager } = jest.requireMock<{
+          ProjectFileManager: { getInstance: () => { fetchProjects: jest.Mock } };
+        }>("@/projects/ProjectFileManager");
+        fetchProjects = ProjectFileManager.getInstance().fetchProjects;
+        fetchProjects.mockResolvedValue([]);
+
+        ({ updateCachedProjectRecords } = jest.requireMock<{
+          updateCachedProjectRecords: jest.Mock;
+        }>("@/projects/state"));
+
+        const mockVault = { on: jest.fn(), off: jest.fn() } as unknown as Vault;
+        const register = new ProjectRegister({ vault: mockVault } as unknown as App);
+        void register.initialize();
+
+        const { subscribeToSettingsChange } = jest.requireMock<{
+          subscribeToSettingsChange: jest.Mock;
+        }>("@/settings/model");
+        settingsChangeHandler = subscribeToSettingsChange.mock
+          .calls[0][0] as typeof settingsChangeHandler;
+      });
+
+      afterEach(() => {
+        jest.useRealTimers();
+      });
+
+      it("reloads projects when the derived folder changes because the root changed", async () => {
+        settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("team/ai"));
+
+        jest.advanceTimersByTime(1000);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(fetchProjects).toHaveBeenCalledTimes(1);
+        expect(updateCachedProjectRecords).toHaveBeenCalledWith([]);
+      });
+
+      it("does not reload when the root — and thus the derived folder — is unchanged", () => {
+        settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("copilot"));
+
+        jest.advanceTimersByTime(1000);
+
+        expect(fetchProjects).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/projects/projectRegister.test.ts
+++ b/src/projects/projectRegister.test.ts
@@ -42,9 +42,11 @@ jest.mock("@/aiParams", () => ({
   getCurrentProject: jest.fn(() => null),
 }));
 
+const mockClearForProject = jest.fn().mockResolvedValue(undefined);
+
 jest.mock("@/cache/projectContextCache", () => ({
   ProjectContextCache: {
-    getInstance: jest.fn(() => ({ clearForProject: jest.fn().mockResolvedValue(undefined) })),
+    getInstance: jest.fn(() => ({ clearForProject: mockClearForProject })),
   },
 }));
 
@@ -60,40 +62,68 @@ function settingsWithRoot(copilotFolder: string): CopilotSettings {
 
 describe("projectRegister", () => {
   describe("ProjectRegister", () => {
+    let settingsChangeHandler: (prev: CopilotSettings, next: CopilotSettings) => void;
+    let fetchProjects: jest.Mock;
+    let updateCachedProjectRecords: jest.Mock;
+    let getCachedProjectRecords: jest.Mock;
+    let register: ProjectRegister;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      jest.useFakeTimers();
+
+      // Reason: mockReset drops any queued *Once implementations from a prior
+      // test; mockClear alone would leak them into the next one.
+      mockClearForProject.mockReset().mockResolvedValue(undefined);
+
+      const { ProjectFileManager } = jest.requireMock<{
+        ProjectFileManager: { getInstance: () => { fetchProjects: jest.Mock } };
+      }>("@/projects/ProjectFileManager");
+      fetchProjects = ProjectFileManager.getInstance().fetchProjects;
+      fetchProjects.mockReset().mockResolvedValue([]);
+
+      ({ updateCachedProjectRecords, getCachedProjectRecords } = jest.requireMock<{
+        updateCachedProjectRecords: jest.Mock;
+        getCachedProjectRecords: jest.Mock;
+      }>("@/projects/state"));
+      getCachedProjectRecords.mockReturnValue([]);
+
+      const mockVault = { on: jest.fn(), off: jest.fn() } as unknown as Vault;
+      register = new ProjectRegister({ vault: mockVault } as unknown as App);
+      void register.initialize();
+
+      const { subscribeToSettingsChange } = jest.requireMock<{
+        subscribeToSettingsChange: jest.Mock;
+      }>("@/settings/model");
+      settingsChangeHandler = subscribeToSettingsChange.mock
+        .calls[0][0] as typeof settingsChangeHandler;
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    /**
+     * Start a reload and park it inside the per-project context-cache clears,
+     * mirroring a slow vault: the handler has passed its post-fetch check but
+     * has not yet committed. Returns the release for that clear.
+     */
+    function startReloadStalledInCacheClear(from: string, to: string): () => void {
+      getCachedProjectRecords.mockReturnValue([{ project: { id: "stale" } }]);
+      let release!: () => void;
+      mockClearForProject.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            release = resolve;
+          })
+      );
+      settingsChangeHandler(settingsWithRoot(from), settingsWithRoot(to));
+      // Reason: `release` is only assigned once the debounce fires and the
+      // handler actually reaches the clear, which is after this returns.
+      return () => release();
+    }
+
     describe("handleSettingsChange()", () => {
-      let settingsChangeHandler: (prev: CopilotSettings, next: CopilotSettings) => void;
-      let fetchProjects: jest.Mock;
-      let updateCachedProjectRecords: jest.Mock;
-
-      beforeEach(() => {
-        jest.clearAllMocks();
-        jest.useFakeTimers();
-
-        const { ProjectFileManager } = jest.requireMock<{
-          ProjectFileManager: { getInstance: () => { fetchProjects: jest.Mock } };
-        }>("@/projects/ProjectFileManager");
-        fetchProjects = ProjectFileManager.getInstance().fetchProjects;
-        fetchProjects.mockResolvedValue([]);
-
-        ({ updateCachedProjectRecords } = jest.requireMock<{
-          updateCachedProjectRecords: jest.Mock;
-        }>("@/projects/state"));
-
-        const mockVault = { on: jest.fn(), off: jest.fn() } as unknown as Vault;
-        const register = new ProjectRegister({ vault: mockVault } as unknown as App);
-        void register.initialize();
-
-        const { subscribeToSettingsChange } = jest.requireMock<{
-          subscribeToSettingsChange: jest.Mock;
-        }>("@/settings/model");
-        settingsChangeHandler = subscribeToSettingsChange.mock
-          .calls[0][0] as typeof settingsChangeHandler;
-      });
-
-      afterEach(() => {
-        jest.useRealTimers();
-      });
-
       it("reloads projects when the derived folder changes because the root changed", async () => {
         settingsChangeHandler(settingsWithRoot("copilot"), settingsWithRoot("team/ai"));
 
@@ -111,6 +141,67 @@ describe("projectRegister", () => {
         jest.advanceTimersByTime(1000);
 
         expect(fetchProjects).not.toHaveBeenCalled();
+      });
+
+      it("discards a reload that resumes from its cache clears after a newer one committed", async () => {
+        const staleRecords = [{ project: { id: "intermediate" } }];
+        const freshRecords = [{ project: { id: "final" } }];
+        fetchProjects.mockResolvedValueOnce(staleRecords).mockResolvedValueOnce(freshRecords);
+
+        const releaseStaleClear = startReloadStalledInCacheClear("a", "b");
+        await jest.advanceTimersByTimeAsync(1000);
+
+        settingsChangeHandler(settingsWithRoot("b"), settingsWithRoot("c"));
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(updateCachedProjectRecords).toHaveBeenCalledTimes(1);
+        expect(updateCachedProjectRecords).toHaveBeenCalledWith(freshRecords);
+
+        releaseStaleClear();
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(updateCachedProjectRecords).toHaveBeenCalledTimes(1);
+      });
+
+      it("keeps the newer records when an earlier failed reload resumes from its cache clears", async () => {
+        const freshRecords = [{ project: { id: "final" } }];
+        fetchProjects
+          .mockRejectedValueOnce(new Error("fetch failed"))
+          .mockResolvedValueOnce(freshRecords);
+
+        const releaseFailedClear = startReloadStalledInCacheClear("a", "b");
+        await jest.advanceTimersByTimeAsync(1000);
+
+        settingsChangeHandler(settingsWithRoot("b"), settingsWithRoot("c"));
+        await jest.advanceTimersByTimeAsync(1000);
+        expect(updateCachedProjectRecords).toHaveBeenCalledWith(freshRecords);
+
+        releaseFailedClear();
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(updateCachedProjectRecords).not.toHaveBeenCalledWith([]);
+      });
+    });
+
+    describe("cleanup()", () => {
+      it("stops an in-flight reload from committing after teardown", async () => {
+        // Cancelling the debounce only stops a reload that has not started. A
+        // torn-down instance must not write into the records store a freshly
+        // created one now owns.
+        let releaseFetch!: (records: unknown[]) => void;
+        fetchProjects.mockReturnValueOnce(
+          new Promise<unknown[]>((resolve) => {
+            releaseFetch = resolve;
+          })
+        );
+
+        settingsChangeHandler(settingsWithRoot("a"), settingsWithRoot("b"));
+        await jest.advanceTimersByTimeAsync(1000);
+
+        register.cleanup();
+        releaseFetch([{ project: { id: "late" } }]);
+        await jest.advanceTimersByTimeAsync(0);
+
+        expect(updateCachedProjectRecords).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/projects/projectRegister.ts
+++ b/src/projects/projectRegister.ts
@@ -75,6 +75,10 @@ export class ProjectRegister {
     for (const d of this.fileModifyDebouncers.values()) d.cancel();
     this.fileModifyDebouncers.clear();
     this.debouncedFolderChange.cancel();
+    // Cancelling only stops a reload that has not started. Bumping the
+    // generation also retires one already in flight, so a torn-down instance
+    // cannot commit records into the store a new instance now owns.
+    this.folderChangeRequestId++;
     this.settingsUnsubscriber?.();
 
     this.vault.off("create", this.handleFileCreation);
@@ -150,6 +154,10 @@ export class ProjectRegister {
         )
       );
 
+      // Clearing the caches is per-file disk I/O, so a newer reload can start
+      // and finish inside it; without this second check whichever handler
+      // resumes last would install its own records over the newer ones.
+      if (currentRequestId !== this.folderChangeRequestId) return;
       updateCachedProjectRecords(nextRecords);
 
       // Reason: don't call setCurrentProject(null) here — ProjectManager's
@@ -189,6 +197,9 @@ export class ProjectRegister {
         )
       );
 
+      // A newer reload may have committed while these clears were awaited;
+      // wiping the records now would discard its results.
+      if (currentRequestId !== this.folderChangeRequestId) return;
       updateCachedProjectRecords([]);
 
       logError(`[Projects] Failed to reload after folder change: ${nextFolder}`, error);

--- a/src/projects/projectRegister.ts
+++ b/src/projects/projectRegister.ts
@@ -21,6 +21,7 @@ import {
 import { loadAllProjects } from "@/projects/projectUtils";
 import { PROJECT_CONFIG_FILE_NAME, PROJECTS_UNSUPPORTED_FOLDER_NAME } from "@/projects/constants";
 import { getSettings, subscribeToSettingsChange } from "@/settings/model";
+import { deriveProjectsFolder } from "@/settings/copilotFolder";
 import { debounce } from "@/utils/debounce";
 import { App, Notice, TAbstractFile, Vault } from "obsidian";
 
@@ -100,8 +101,11 @@ export class ProjectRegister {
     prev: ReturnType<typeof getSettings>,
     next: ReturnType<typeof getSettings>
   ): void => {
-    if (prev.projectsFolder !== next.projectsFolder) {
-      this.debouncedFolderChange(next.projectsFolder);
+    // Reason: the folder is derived from the configurable copilotFolder root, so
+    // compare the derived paths rather than the retired projectsFolder field.
+    const nextFolder = deriveProjectsFolder(next);
+    if (deriveProjectsFolder(prev) !== nextFolder) {
+      this.debouncedFolderChange(nextFolder);
     }
   };
 

--- a/src/projects/projectUtils.test.ts
+++ b/src/projects/projectUtils.test.ts
@@ -12,6 +12,13 @@ jest.mock("@/settings/model", () => ({
   getSettings: jest.fn(() => ({ projectsFolder: "copilot-projects" })),
 }));
 
+// getProjectsFolder derives from copilotFolder in production; shim the derived
+// accessor to the folder these tests configure via getSettings().projectsFolder.
+jest.mock("@/settings/copilotFolder", () => {
+  const { getSettings } = jest.requireMock<typeof import("@/settings/model")>("@/settings/model");
+  return { getEffectiveProjectsFolder: jest.fn(() => getSettings().projectsFolder) };
+});
+
 jest.mock("@/projects/state", () => ({
   addPendingFileWrite: jest.fn(),
   removePendingFileWrite: jest.fn(),

--- a/src/projects/projectUtils.ts
+++ b/src/projects/projectUtils.ts
@@ -34,6 +34,7 @@ import {
 
 // Re-export path utilities so existing consumers don't need to change imports
 export {
+  getProjectAnchorFromConfigPath,
   getProjectsFolder,
   getProjectsUnsupportedFolder,
   getProjectFolderPath,

--- a/src/search/miyo/MiyoSemanticRetriever.test.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.test.ts
@@ -19,6 +19,8 @@ jest.mock("@/settings/model", () => ({
 jest.mock("@/miyo/miyoUtils", () => ({
   getMiyoFolderName: jest.fn(),
   getVaultRelativeMiyoPath: jest.fn((_: unknown, path: string) => path.replace("/vault/", "")),
+  // Mirrors the real ownership rule against the mocked "/vault" folder name.
+  isCurrentVaultMiyoPath: jest.fn((_: unknown, path: string) => path.startsWith("/vault/")),
   getMiyoCustomUrl: jest.fn().mockReturnValue(""),
   // Default: synced scope, no user patterns — the narrow-limit branch. Tests
   // that exercise the over-fetch branches flip these explicitly.
@@ -266,5 +268,77 @@ describe("MiyoSemanticRetriever", () => {
 
     expect(documents).toHaveLength(1);
     expect(documents[0].metadata.path).toBe("notes/keep.md");
+  });
+
+  it("keeps search-all results from an external folder that shares a system root's name", async () => {
+    // Ownership is judged on the RAW path: this vault's results carry the
+    // "/vault/" prefix, an external folder carries its own name — even when
+    // that name equals the default Copilot root ("copilot"). The external
+    // chunk must survive while the vault's own former-root chunk is dropped.
+    (getSettings as jest.Mock).mockReturnValue({
+      miyoServerUrl: "http://miyo.local",
+      debug: false,
+      miyoSearchAll: true,
+      copilotFolder: "copilot",
+    });
+    // clearAllMocks does not reset mockReturnValue implementations pinned by
+    // earlier tests; re-pin the narrow-limit branch explicitly.
+    (hasUserQaPatterns as jest.Mock).mockReturnValue(false);
+    (isMiyoScopeMismatch as jest.Mock).mockReturnValue(false);
+
+    mockSearch.mockResolvedValue({
+      results: [
+        {
+          id: "own-old-root",
+          score: 0.9,
+          path: "/vault/copilot/old-chat.md",
+          chunk_index: 0,
+          chunk_text: "this vault's excluded copilot data",
+        },
+        {
+          id: "external",
+          score: 0.85,
+          path: "copilot/notes/foo.md",
+          chunk_index: 0,
+          chunk_text: "another folder that happens to be named copilot",
+        },
+      ],
+    });
+
+    const retriever = createRetriever();
+    const documents = await retriever.getRelevantDocuments("query");
+
+    expect(mockSearch).toHaveBeenCalledWith("http://miyo.local", undefined, "query", 20, undefined);
+    expect(documents).toHaveLength(1);
+    expect(documents[0].metadata.path).toBe("copilot/notes/foo.md");
+    expect(documents[0].metadata.fromCurrentVault).toBe(false);
+  });
+
+  it("still applies the system-root filter to unprefixed paths on a folder-scoped query", async () => {
+    // A folder-scoped query only returns this vault's content, so ownership is
+    // asserted regardless of the raw prefix — a result arriving without the
+    // folder prefix must not dodge the privacy filter by looking external.
+    (getSettings as jest.Mock).mockReturnValue({
+      miyoServerUrl: "http://miyo.local",
+      debug: false,
+      copilotFolder: "copilot",
+    });
+
+    mockSearch.mockResolvedValue({
+      results: [
+        {
+          id: "unprefixed",
+          score: 0.9,
+          path: "copilot/old-chat.md",
+          chunk_index: 0,
+          chunk_text: "unprefixed former-root content",
+        },
+      ],
+    });
+
+    const retriever = createRetriever();
+    const documents = await retriever.getRelevantDocuments("query");
+
+    expect(documents).toHaveLength(0);
   });
 });

--- a/src/search/miyo/MiyoSemanticRetriever.test.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.test.ts
@@ -1,5 +1,5 @@
 import { type App, TFile } from "obsidian";
-import { getMiyoFolderName } from "@/miyo/miyoUtils";
+import { getMiyoFolderName, hasUserQaPatterns, isMiyoScopeMismatch } from "@/miyo/miyoUtils";
 import { MiyoSemanticRetriever } from "@/search/miyo/MiyoSemanticRetriever";
 import { getSettings } from "@/settings/model";
 import { RETURN_ALL_LIMIT } from "@/search/v3/SearchCore";
@@ -20,6 +20,10 @@ jest.mock("@/miyo/miyoUtils", () => ({
   getMiyoFolderName: jest.fn(),
   getVaultRelativeMiyoPath: jest.fn((_: unknown, path: string) => path.replace("/vault/", "")),
   getMiyoCustomUrl: jest.fn().mockReturnValue(""),
+  // Default: synced scope, no user patterns — the narrow-limit branch. Tests
+  // that exercise the over-fetch branches flip these explicitly.
+  hasUserQaPatterns: jest.fn(() => false),
+  isMiyoScopeMismatch: jest.fn(() => false),
 }));
 jest.mock("@/miyo/MiyoClient", () => ({
   MiyoClient: jest.fn().mockImplementation(() => ({
@@ -94,14 +98,14 @@ describe("MiyoSemanticRetriever", () => {
     const retriever = createRetriever();
     const documents = await retriever.getRelevantDocuments("query with [[notes/a]] mention");
 
-    // Over-fetch is always on now: the system root exclusion is always active
-    // (hasActiveCopilotPatterns is unconditionally true), so the request uses
-    // RETURN_ALL_LIMIT so post-filtering still leaves enough to fill finalK.
+    // Synced scope + no user patterns: the server already omits everything the
+    // local filter would drop, so the request narrows to finalK×2 (dedup
+    // margin) instead of the full RETURN_ALL_LIMIT pool.
     expect(mockSearch).toHaveBeenCalledWith(
       "http://miyo.local",
       "/vault",
       "query with [[notes/a]] mention",
-      RETURN_ALL_LIMIT,
+      20,
       undefined
     );
     expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
@@ -157,8 +161,9 @@ describe("MiyoSemanticRetriever", () => {
   });
 
   it("over-fetches but caps returned chunks to the requested limit when a filter is active", async () => {
-    // An active inclusion/exclusion pattern can drop results, so the retriever
-    // over-fetches candidates to still fill the requested cap.
+    // A user-authored inclusion/exclusion pattern can drop results, so the
+    // retriever over-fetches candidates to still fill the requested cap.
+    (hasUserQaPatterns as jest.Mock).mockReturnValue(true);
     (getSettings as jest.Mock).mockReturnValue({
       miyoServerUrl: "http://miyo.local",
       debug: false,
@@ -201,11 +206,11 @@ describe("MiyoSemanticRetriever", () => {
     ]);
   });
 
-  it("over-fetches even with no user patterns because the system root exclusion is always active", async () => {
-    // The always-on system root exclusion (copilot + active + historical roots)
-    // can always drop a chunk, so the retriever must over-fetch to RETURN_ALL_LIMIT
-    // regardless of the user's QA patterns — otherwise post-filtering could leave
-    // fewer than finalK results.
+  it("over-fetches while the Miyo scope is stale", async () => {
+    // A stale server-side scope can return system-root content the local filter
+    // must drop, so the retriever keeps the expanded pool until the resync
+    // receipt is current again.
+    (isMiyoScopeMismatch as jest.Mock).mockReturnValue(true);
     mockSearch.mockResolvedValue({ results: [] });
 
     const retriever = createRetriever({ maxK: 3 });

--- a/src/search/miyo/MiyoSemanticRetriever.test.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.test.ts
@@ -11,6 +11,10 @@ const mockGetDocumentsByPath = jest.fn();
 jest.mock("@/logger");
 jest.mock("@/settings/model", () => ({
   getSettings: jest.fn(),
+  // searchUtils' getSystemExcludedFolders normalizes root paths through the real
+  // helper; keep it faithful so the pattern filter behaves as in production.
+  normalizeRootFolders:
+    jest.requireActual<typeof import("@/settings/model")>("@/settings/model").normalizeRootFolders,
 }));
 jest.mock("@/miyo/miyoUtils", () => ({
   getMiyoFolderName: jest.fn(),
@@ -90,11 +94,14 @@ describe("MiyoSemanticRetriever", () => {
     const retriever = createRetriever();
     const documents = await retriever.getRelevantDocuments("query with [[notes/a]] mention");
 
+    // Over-fetch is always on now: the system root exclusion is always active
+    // (hasActiveCopilotPatterns is unconditionally true), so the request uses
+    // RETURN_ALL_LIMIT so post-filtering still leaves enough to fill finalK.
     expect(mockSearch).toHaveBeenCalledWith(
       "http://miyo.local",
       "/vault",
       "query with [[notes/a]] mention",
-      10,
+      RETURN_ALL_LIMIT,
       undefined
     );
     expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
@@ -194,15 +201,23 @@ describe("MiyoSemanticRetriever", () => {
     ]);
   });
 
-  it("bounds the request to the requested limit when no filter is active", async () => {
-    // With no inclusion/exclusion pattern and returnAll off, over-fetching only
-    // wastes transfer/processing, so the request is bounded to the cap.
+  it("over-fetches even with no user patterns because the system root exclusion is always active", async () => {
+    // The always-on system root exclusion (copilot + active + historical roots)
+    // can always drop a chunk, so the retriever must over-fetch to RETURN_ALL_LIMIT
+    // regardless of the user's QA patterns — otherwise post-filtering could leave
+    // fewer than finalK results.
     mockSearch.mockResolvedValue({ results: [] });
 
     const retriever = createRetriever({ maxK: 3 });
     await retriever.getRelevantDocuments("query");
 
-    expect(mockSearch).toHaveBeenCalledWith("http://miyo.local", "/vault", "query", 3, undefined);
+    expect(mockSearch).toHaveBeenCalledWith(
+      "http://miyo.local",
+      "/vault",
+      "query",
+      RETURN_ALL_LIMIT,
+      undefined
+    );
   });
 
   it("filters chunks by Copilot inclusion/exclusion rules", async () => {

--- a/src/search/miyo/MiyoSemanticRetriever.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.ts
@@ -4,8 +4,14 @@ import { BaseRetriever } from "@langchain/core/retrievers";
 import { App } from "obsidian";
 import { logInfo, logWarn } from "@/logger";
 import { MiyoClient, MiyoSearchFilter, MiyoSearchResult } from "@/miyo/MiyoClient";
-import { getMiyoCustomUrl, getMiyoFolderName, getVaultRelativeMiyoPath } from "@/miyo/miyoUtils";
-import { createCopilotPatternFilter, hasActiveCopilotPatterns } from "@/search/searchUtils";
+import {
+  getMiyoCustomUrl,
+  getMiyoFolderName,
+  getVaultRelativeMiyoPath,
+  hasUserQaPatterns,
+  isMiyoScopeMismatch,
+} from "@/miyo/miyoUtils";
+import { createCopilotPatternFilter } from "@/search/searchUtils";
 import { getSettings } from "@/settings/model";
 import { RETURN_ALL_LIMIT } from "@/search/v3/SearchCore";
 
@@ -115,12 +121,23 @@ export class MiyoSemanticRetriever extends BaseRetriever {
   private async searchMiyo(query: string): Promise<Document[]> {
     try {
       const baseUrl = await this.client.resolveBaseUrl(getMiyoCustomUrl(getSettings()));
-      // Over-fetch candidates only when inclusion/exclusion filtering can drop
-      // results (or the caller wants everything), so filtering still leaves
-      // enough chunks to fill finalK and the set is capped afterwards. Without
-      // an active filter, bound the request to finalK so default searches don't
-      // transfer up to RETURN_ALL_LIMIT chunks for no filtering benefit.
-      const limit = this.returnAll || hasActiveCopilotPatterns() ? RETURN_ALL_LIMIT : this.finalK;
+      // Over-fetch candidates only when the local filter can actually drop
+      // results: user-authored qa patterns (the server never sees tag/note
+      // patterns, and edited patterns lag its registration snapshot), or a
+      // stale Miyo scope (the server may return system-root content the filter
+      // must remove). With a synced scope and no user patterns, the server
+      // already omits everything the filter would drop, so a small 2× margin —
+      // covering post-fetch chunk dedup, which Miyo does not guarantee against —
+      // replaces the former always-RETURN_ALL_LIMIT fetch. The margin is
+      // best-effort by design: finalK is an upper bound, not a fill guarantee
+      // (the similarity threshold already returns fewer), and a retry-on-
+      // shortfall second request would add tail latency for a duplicate
+      // density no real payload has shown.
+      const settings = getSettings();
+      const limit =
+        this.returnAll || hasUserQaPatterns(settings) || isMiyoScopeMismatch(this.app, settings)
+          ? RETURN_ALL_LIMIT
+          : Math.min(this.finalK * 2, RETURN_ALL_LIMIT);
       const filters = this.buildSearchFilters();
       if (getSettings().debug) {
         logInfo("MiyoSemanticRetriever: search params:", {

--- a/src/search/miyo/MiyoSemanticRetriever.ts
+++ b/src/search/miyo/MiyoSemanticRetriever.ts
@@ -9,6 +9,7 @@ import {
   getMiyoFolderName,
   getVaultRelativeMiyoPath,
   hasUserQaPatterns,
+  isCurrentVaultMiyoPath,
   isMiyoScopeMismatch,
 } from "@/miyo/miyoUtils";
 import { createCopilotPatternFilter } from "@/search/searchUtils";
@@ -94,6 +95,15 @@ export class MiyoSemanticRetriever extends BaseRetriever {
     const excludedPaths: string[] = [];
     for (const chunk of chunks) {
       const path = chunk.metadata.path as string;
+      // Another vault's results (search-all) never go through Copilot's QA
+      // rules: those rules — including the system-root exclusion — are defined
+      // over THIS vault's namespace, and an external folder that merely shares
+      // a root's name (e.g. "copilot") must not be swallowed by them. Absent
+      // flag (fail-closed) means "ours" and gets filtered.
+      if (chunk.metadata.fromCurrentVault === false) {
+        allowed.push(chunk);
+        continue;
+      }
       if (isAllowed(path)) {
         allowed.push(chunk);
       } else {
@@ -149,7 +159,8 @@ export class MiyoSemanticRetriever extends BaseRetriever {
           filters,
         });
       }
-      const folderName = getSettings().miyoSearchAll ? undefined : getMiyoFolderName(this.app);
+      const searchAll = settings.miyoSearchAll;
+      const folderName = searchAll ? undefined : getMiyoFolderName(this.app);
       const response = await this.client.search(baseUrl, folderName, query, limit, filters);
 
       const rawResults = response.results || [];
@@ -161,7 +172,7 @@ export class MiyoSemanticRetriever extends BaseRetriever {
         );
       }
 
-      return filteredResults.map((result) => this.toDocument(result));
+      return filteredResults.map((result) => this.toDocument(result, searchAll));
     } catch (error) {
       logWarn(`MiyoSemanticRetriever: search failed: ${error}`);
       return [];
@@ -192,10 +203,17 @@ export class MiyoSemanticRetriever extends BaseRetriever {
    * Convert Miyo search results to LangChain Documents.
    *
    * @param result - Miyo search result item.
+   * @param searchAll - Whether the originating query spanned all Miyo folders
+   *   (snapshotted at request time so a mid-request settings flip can't change
+   *   how this batch's ownership is judged).
    * @returns LangChain Document instance.
    */
-  private toDocument(result: MiyoSearchResult): Document {
+  private toDocument(result: MiyoSearchResult, searchAll: boolean): Document {
     const relativePath = getVaultRelativeMiyoPath(this.app, result.path);
+    // A folder-scoped query only ever returns this vault's content, so it is
+    // always ours — even if a result arrives without the folder prefix. Only
+    // an unrestricted (search-all) query needs the raw-path ownership check.
+    const fromCurrentVault = !searchAll || isCurrentVaultMiyoPath(this.app, result.path);
     const metadata = result.metadata ?? {};
     const chunkId =
       metadata.chunkId ||
@@ -219,6 +237,9 @@ export class MiyoSemanticRetriever extends BaseRetriever {
         created_at: result.created_at,
         nchars: result.nchars,
         chunkId,
+        // After ...metadata so a server-supplied field can never override the
+        // locally-computed ownership verdict.
+        fromCurrentVault,
       },
     });
   }

--- a/src/search/searchUtils.test.ts
+++ b/src/search/searchUtils.test.ts
@@ -1,3 +1,4 @@
+import * as obsidian from "obsidian";
 import * as settingsModel from "@/settings/model";
 import * as utils from "@/utils";
 import { TFile } from "obsidian";
@@ -16,6 +17,9 @@ import {
 // Mock Obsidian's TFile and Modal classes
 jest.mock("obsidian", () => ({
   normalizePath: (path: string) => path.replace(/\/+/g, "/").replace(/^\/|\/$/g, ""),
+  // Mutable so a test can assert the case-sensitive and case-insensitive
+  // behaviours of system-root matching on one platform.
+  Platform: { isWin: false, isMacOS: true, isIosApp: false },
   TFile: class TFile {
     path: string;
   },
@@ -563,7 +567,7 @@ describe("searchUtils", () => {
       expect(mockGetAbstractFileByPath).not.toHaveBeenCalledWith("ai/memory/note.md");
     });
 
-    it("does not over-match sibling or differently-cased folders", () => {
+    it("does not over-match a sibling folder that merely shares the root's prefix", () => {
       (settingsModel.getSettings as jest.Mock).mockReturnValue({
         qaInclusions: "",
         qaExclusions: "",
@@ -571,10 +575,43 @@ describe("searchUtils", () => {
         copilotRootHistory: ["copilot"],
       });
       const filter = createCopilotPatternFilter(window.app);
-      // Case-sensitive: "Copilot/" is a different folder and is kept.
-      expect(filter("Copilot/note.md")).toBe(true);
       // Segment boundary: "mycopilot/" is not the "copilot" root.
       expect(filter("mycopilot/note.md")).toBe(true);
+    });
+
+    it("excludes a differently-cased root where the filesystem is case-insensitive", () => {
+      // On macOS/Windows, "Copilot/" and "copilot/" are the same folder. Nothing
+      // reconciles the stored spelling against the real one, so comparing
+      // exact-case here would fail OPEN and let chats reach QA indexing.
+      (obsidian.Platform as { isMacOS: boolean }).isMacOS = true;
+      (settingsModel.getSettings as jest.Mock).mockReturnValue({
+        qaInclusions: "",
+        qaExclusions: "",
+        copilotFolder: "copilot",
+        copilotRootHistory: ["copilot"],
+      });
+
+      expect(createCopilotPatternFilter(window.app)("Copilot/note.md")).toBe(false);
+    });
+
+    it("keeps a differently-cased folder where the filesystem is case-sensitive", () => {
+      // On Linux the two really are separate folders, so folding would exclude
+      // notes the user never put under a Copilot root.
+      const platform = obsidian.Platform as { isWin: boolean; isMacOS: boolean; isIosApp: boolean };
+      const restore = { ...platform };
+      Object.assign(platform, { isWin: false, isMacOS: false, isIosApp: false });
+      try {
+        (settingsModel.getSettings as jest.Mock).mockReturnValue({
+          qaInclusions: "",
+          qaExclusions: "",
+          copilotFolder: "copilot",
+          copilotRootHistory: ["copilot"],
+        });
+
+        expect(createCopilotPatternFilter(window.app)("Copilot/note.md")).toBe(true);
+      } finally {
+        Object.assign(platform, restore);
+      }
     });
   });
 });

--- a/src/search/searchUtils.test.ts
+++ b/src/search/searchUtils.test.ts
@@ -8,7 +8,6 @@ import {
   getDecodedPatterns,
   getMatchingPatterns,
   getSystemExcludedFolders,
-  hasActiveCopilotPatterns,
   isInternalExcludedPath,
   previewPatternValue,
   shouldIndexFile,
@@ -545,16 +544,6 @@ describe("searchUtils", () => {
         copilotFolder: "team-ai",
       });
       expect(isInternalExcludedPath("team-ai/projects/my-project/notes.md")).toBe(false);
-    });
-  });
-
-  describe("hasActiveCopilotPatterns", () => {
-    it("is always true because the system root exclusion is always active", () => {
-      (settingsModel.getSettings as jest.Mock).mockReturnValue({
-        qaInclusions: "",
-        qaExclusions: "",
-      });
-      expect(hasActiveCopilotPatterns()).toBe(true);
     });
   });
 

--- a/src/search/searchUtils.test.ts
+++ b/src/search/searchUtils.test.ts
@@ -3,15 +3,20 @@ import * as utils from "@/utils";
 import { TFile } from "obsidian";
 import {
   categorizePatterns,
+  createCopilotPatternFilter,
   createPatternSettingsValue,
   getDecodedPatterns,
   getMatchingPatterns,
+  getSystemExcludedFolders,
+  hasActiveCopilotPatterns,
+  isInternalExcludedPath,
   previewPatternValue,
   shouldIndexFile,
 } from "./searchUtils";
 
 // Mock Obsidian's TFile and Modal classes
 jest.mock("obsidian", () => ({
+  normalizePath: (path: string) => path.replace(/\/+/g, "/").replace(/^\/|\/$/g, ""),
   TFile: class TFile {
     path: string;
   },
@@ -479,6 +484,108 @@ describe("searchUtils", () => {
         extensionPatterns: [],
         notePatterns: [],
       });
+    });
+  });
+
+  describe("getSystemExcludedFolders", () => {
+    it("always includes the historical copilot root", () => {
+      const folders = getSystemExcludedFolders({
+        copilotFolder: "copilot",
+        copilotRootHistory: [],
+      } as unknown as Parameters<typeof getSystemExcludedFolders>[0]);
+      expect(folders).toContain("copilot");
+    });
+
+    it("includes the active root and every historical root", () => {
+      const folders = getSystemExcludedFolders({
+        copilotFolder: "team-ai",
+        copilotRootHistory: ["copilot", "ai"],
+      } as unknown as Parameters<typeof getSystemExcludedFolders>[0]);
+      expect(new Set(folders)).toEqual(new Set(["copilot", "ai", "team-ai"]));
+    });
+
+    it("normalizes and dedupes without lowercasing (matcher is case-sensitive)", () => {
+      const folders = getSystemExcludedFolders({
+        copilotFolder: "Copilot/",
+        copilotRootHistory: ["copilot", "Copilot"],
+      } as unknown as Parameters<typeof getSystemExcludedFolders>[0]);
+      // "Copilot" (trailing slash stripped) and "copilot" stay distinct entries.
+      expect(new Set(folders)).toEqual(new Set(["copilot", "Copilot"]));
+    });
+  });
+
+  describe("isInternalExcludedPath", () => {
+    it("excludes project-config files under the projects folder derived from the default root", () => {
+      (settingsModel.getSettings as jest.Mock).mockReturnValue({
+        qaInclusions: "",
+        qaExclusions: "",
+        copilotFolder: "copilot",
+      });
+      expect(isInternalExcludedPath("copilot/projects/my-project/project.md")).toBe(true);
+    });
+
+    it("derives the projects folder from a custom root, not the retired projectsFolder field", () => {
+      (settingsModel.getSettings as jest.Mock).mockReturnValue({
+        qaInclusions: "",
+        qaExclusions: "",
+        copilotFolder: "team-ai",
+        // Retired field left pointing at the stale default path; derivation must ignore it.
+        projectsFolder: "copilot/projects",
+      });
+      // Excluded under the derived custom-root path.
+      expect(isInternalExcludedPath("team-ai/projects/my-project/project.md")).toBe(true);
+      // NOT excluded under the stale retired path, proving derivation from the root.
+      expect(isInternalExcludedPath("copilot/projects/my-project/project.md")).toBe(false);
+    });
+
+    it("does not exclude ordinary user files that merely live under the projects folder", () => {
+      (settingsModel.getSettings as jest.Mock).mockReturnValue({
+        qaInclusions: "",
+        qaExclusions: "",
+        copilotFolder: "team-ai",
+      });
+      expect(isInternalExcludedPath("team-ai/projects/my-project/notes.md")).toBe(false);
+    });
+  });
+
+  describe("hasActiveCopilotPatterns", () => {
+    it("is always true because the system root exclusion is always active", () => {
+      (settingsModel.getSettings as jest.Mock).mockReturnValue({
+        qaInclusions: "",
+        qaExclusions: "",
+      });
+      expect(hasActiveCopilotPatterns()).toBe(true);
+    });
+  });
+
+  describe("createCopilotPatternFilter", () => {
+    it("excludes the active and historical roots even with no user patterns", () => {
+      (settingsModel.getSettings as jest.Mock).mockReturnValue({
+        qaInclusions: "",
+        qaExclusions: "",
+        copilotFolder: "ai",
+        copilotRootHistory: ["copilot", "ai"],
+      });
+      const filter = createCopilotPatternFilter(window.app);
+      // System roots dropped on the raw path — no TFile resolution required.
+      expect(filter("ai/memory/note.md")).toBe(false);
+      expect(filter("copilot/copilot-conversations/chat.md")).toBe(false);
+      expect(filter("notes/idea.md")).toBe(true);
+      expect(mockGetAbstractFileByPath).not.toHaveBeenCalledWith("ai/memory/note.md");
+    });
+
+    it("does not over-match sibling or differently-cased folders", () => {
+      (settingsModel.getSettings as jest.Mock).mockReturnValue({
+        qaInclusions: "",
+        qaExclusions: "",
+        copilotFolder: "copilot",
+        copilotRootHistory: ["copilot"],
+      });
+      const filter = createCopilotPatternFilter(window.app);
+      // Case-sensitive: "Copilot/" is a different folder and is kept.
+      expect(filter("Copilot/note.md")).toBe(true);
+      // Segment boundary: "mycopilot/" is not the "copilot" root.
+      expect(filter("mycopilot/note.md")).toBe(true);
     });
   });
 });

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -182,9 +182,16 @@ function hasCaseInsensitiveFilesystem(): boolean {
  * Separate from {@link matchFilePathWithFolders} so the case-folding stays off
  * the user-pattern path — see {@link isSystemExcludedPath} for why.
  *
- * Exported because anything DECIDING which paths a root covers has to agree with
- * this: a guard that compares exact-case would clear a candidate root this
- * matcher then treats as covering the user's real notes.
+ * Exported for COVERAGE questions only — "does this root cover that path" — so a
+ * guard deciding whether a candidate root would swallow the user's notes agrees
+ * with the boundary that later enforces it.
+ *
+ * Deliberately NOT for IDENTITY questions such as "is this candidate the root I
+ * used before" (see `isKnownCopilotRoot`). The platform check here is a
+ * heuristic that treats every macOS volume as case-insensitive, which is safe
+ * while it only ever over-excludes. Reused to grant an exemption it inverts:
+ * on a case-sensitive volume it would accept a genuinely different folder as
+ * "already known" and skip the content guard entirely.
  *
  * @param filePath - Vault-relative path, as the vault or Miyo reported it.
  * @param systemRoots - Roots from {@link getSystemExcludedFolders}, or a

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -167,7 +167,7 @@ export function getSystemExcludedFolders(settings: CopilotSettings): string[] {
  * gates on the platform, accepting that a case-sensitive APFS volume may
  * over-exclude, which fails closed.
  */
-function isSystemExcludedPath(filePath: string): boolean {
+export function isSystemExcludedPath(filePath: string): boolean {
   return matchSystemRoots(filePath, getSystemExcludedFolders(getSettings()));
 }
 

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -8,7 +8,7 @@ import { getEffectiveProjectsFolder } from "@/settings/copilotFolder";
 import { logFileManager } from "@/logFileManager";
 import { getTagsFromNote, stripHash } from "@/utils";
 import { Embeddings } from "@langchain/core/embeddings";
-import { App, TFile } from "obsidian";
+import { App, Platform, TFile } from "obsidian";
 
 export interface PatternCategory {
   tagPatterns?: string[];
@@ -153,9 +153,46 @@ export function getSystemExcludedFolders(settings: CopilotSettings): string[] {
   return normalizeRootFolders([COPILOT_FOLDER_ROOT, settings.copilotFolder, ...history]);
 }
 
-/** Whether a vault-relative path falls under any live system-excluded Copilot root. */
+/**
+ * Whether a vault-relative path falls under any live system-excluded Copilot root.
+ *
+ * Case-folded on case-insensitive filesystems, unlike the user's own qa*
+ * patterns. A stored root keeps whatever spelling it was configured with —
+ * nothing reconciles it against the real path, and an external sync, an OS-level
+ * case-only rename, or simply typing `TeamAI` when the disk holds `teamai/` is
+ * enough to make them differ. Comparing exact-case there fails OPEN, letting
+ * chats under a Copilot root reach QA indexing and Miyo results. Folding is
+ * confined to these roots: `qaExclusions` is the user's own literal, and on a
+ * case-sensitive volume `Notes/` and `notes/` really are two folders — so this
+ * gates on the platform, accepting that a case-sensitive APFS volume may
+ * over-exclude, which fails closed.
+ */
 function isSystemExcludedPath(filePath: string): boolean {
-  return matchFilePathWithFolders(filePath, getSystemExcludedFolders(getSettings()));
+  return matchSystemRoots(filePath, getSystemExcludedFolders(getSettings()));
+}
+
+/** Whether the host filesystem treats paths case-insensitively. */
+function hasCaseInsensitiveFilesystem(): boolean {
+  return Platform.isWin || Platform.isMacOS || Platform.isIosApp;
+}
+
+/**
+ * Match a raw path against the system-excluded Copilot roots.
+ *
+ * Separate from {@link matchFilePathWithFolders} so the case-folding stays off
+ * the user-pattern path — see {@link isSystemExcludedPath} for why.
+ *
+ * @param filePath - Vault-relative path, as the vault or Miyo reported it.
+ * @param systemRoots - Roots from {@link getSystemExcludedFolders}.
+ */
+function matchSystemRoots(filePath: string, systemRoots: string[]): boolean {
+  if (!hasCaseInsensitiveFilesystem()) {
+    return matchFilePathWithFolders(filePath, systemRoots);
+  }
+  return matchFilePathWithFolders(
+    filePath.toLowerCase(),
+    systemRoots.map((root) => root.toLowerCase())
+  );
 }
 
 /**
@@ -210,8 +247,9 @@ export function createCopilotPatternFilter(app: App): (path: string) => boolean 
   const { inclusions, exclusions } = getMatchingPatterns();
   return (path: string) => {
     // System root exclusion runs first on the raw path (no TFile), holding even
-    // in the no-user-pattern fast path below.
-    if (matchFilePathWithFolders(path, systemExcludedFolders)) {
+    // in the no-user-pattern fast path below. Case-folded where the filesystem
+    // is — see isSystemExcludedPath.
+    if (matchSystemRoots(path, systemExcludedFolders)) {
       return false;
     }
     if (!inclusions && !exclusions) {

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -177,15 +177,20 @@ function hasCaseInsensitiveFilesystem(): boolean {
 }
 
 /**
- * Match a raw path against the system-excluded Copilot roots.
+ * Match a raw path against Copilot roots the way the exclusion boundary does.
  *
  * Separate from {@link matchFilePathWithFolders} so the case-folding stays off
  * the user-pattern path — see {@link isSystemExcludedPath} for why.
  *
+ * Exported because anything DECIDING which paths a root covers has to agree with
+ * this: a guard that compares exact-case would clear a candidate root this
+ * matcher then treats as covering the user's real notes.
+ *
  * @param filePath - Vault-relative path, as the vault or Miyo reported it.
- * @param systemRoots - Roots from {@link getSystemExcludedFolders}.
+ * @param systemRoots - Roots from {@link getSystemExcludedFolders}, or a
+ *   candidate root being evaluated before it is committed.
  */
-function matchSystemRoots(filePath: string, systemRoots: string[]): boolean {
+export function matchSystemRoots(filePath: string, systemRoots: string[]): boolean {
   if (!hasCaseInsensitiveFilesystem()) {
     return matchFilePathWithFolders(filePath, systemRoots);
   }

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -226,15 +226,6 @@ export function createCopilotPatternFilter(app: App): (path: string) => boolean 
 }
 
 /**
- * Whether {@link createCopilotPatternFilter} can remove results, so callers know
- * whether to over-fetch to compensate. Always true: the system root exclusion is
- * always active, so a candidate can be dropped even with no user patterns.
- */
-export function hasActiveCopilotPatterns(): boolean {
-  return true;
-}
-
-/**
  * Break down the patterns into their respective categories.
  * @param patterns - The patterns to categorize.
  * @returns An object containing the categorized patterns.

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -1,8 +1,10 @@
+import { COPILOT_FOLDER_ROOT } from "@/constants";
 import { CustomError } from "@/error";
 import { AGENTS_MIRROR_FILE, PROJECT_CONFIG_FILE_NAME } from "@/projects/constants";
 import EmbeddingsManager from "@/LLMProviders/embeddingManager";
 import { logError, logInfo, logWarn } from "@/logger";
-import { getSettings } from "@/settings/model";
+import { getSettings, normalizeRootFolders, type CopilotSettings } from "@/settings/model";
+import { getEffectiveProjectsFolder } from "@/settings/copilotFolder";
 import { logFileManager } from "@/logFileManager";
 import { getTagsFromNote, stripHash } from "@/utils";
 import { Embeddings } from "@langchain/core/embeddings";
@@ -138,6 +140,25 @@ export function getMatchingPatterns(options?: {
 }
 
 /**
+ * The Copilot root folders excluded from QA indexing independent of the user's
+ * patterns: `copilot`, the active root, and every root ever activated
+ * ({@link CopilotSettings.copilotRootHistory}). Always-on privacy invariant so
+ * content under any current OR former root never enters the index.
+ *
+ * @param settings - Current Copilot settings.
+ * @returns Normalized, deduped root folders to exclude (never empty).
+ */
+export function getSystemExcludedFolders(settings: CopilotSettings): string[] {
+  const history = Array.isArray(settings.copilotRootHistory) ? settings.copilotRootHistory : [];
+  return normalizeRootFolders([COPILOT_FOLDER_ROOT, settings.copilotFolder, ...history]);
+}
+
+/** Whether a vault-relative path falls under any live system-excluded Copilot root. */
+function isSystemExcludedPath(filePath: string): boolean {
+  return matchFilePathWithFolders(filePath, getSystemExcludedFolders(getSettings()));
+}
+
+/**
  * Should index the file based on the inclusions and exclusions patterns.
  * @param file - The file to check.
  * @param inclusions - The inclusions patterns.
@@ -156,6 +177,10 @@ export function shouldIndexFile(
   if (isInternalExcludedFile(file)) {
     return false;
   }
+  // Exclude the system Copilot roots (active + historical) before user patterns.
+  if (isSystemExcludedPath(file.path)) {
+    return false;
+  }
   if (exclusions && matchFilePathWithPatterns(app, file, exclusions)) {
     return false;
   }
@@ -172,20 +197,26 @@ export function shouldIndexFile(
 }
 
 /**
- * Build a predicate that decides whether a vault-relative path passes Copilot's
- * QA inclusion/exclusion rules. The active patterns are resolved once so the
- * predicate can be reused across many results. Paths that don't resolve to a
- * vault {@link TFile} are kept, since the rules can't be evaluated for them.
+ * Build a predicate deciding whether a vault-relative path passes Copilot's QA
+ * rules (resolved once for reuse). Unresolvable paths are kept, but the system
+ * root exclusion is applied to the raw path first, so a former root's content is
+ * dropped even with no user QA patterns configured.
  *
  * @param app - The Obsidian app instance.
  * @returns Predicate returning true when the path should be kept.
  */
 export function createCopilotPatternFilter(app: App): (path: string) => boolean {
+  const systemExcludedFolders = getSystemExcludedFolders(getSettings());
   const { inclusions, exclusions } = getMatchingPatterns();
-  if (!inclusions && !exclusions) {
-    return () => true;
-  }
   return (path: string) => {
+    // System root exclusion runs first on the raw path (no TFile), holding even
+    // in the no-user-pattern fast path below.
+    if (matchFilePathWithFolders(path, systemExcludedFolders)) {
+      return false;
+    }
+    if (!inclusions && !exclusions) {
+      return true;
+    }
     const file = app.vault.getAbstractFileByPath(path);
     if (!(file instanceof TFile)) {
       return true;
@@ -195,16 +226,12 @@ export function createCopilotPatternFilter(app: App): (path: string) => boolean 
 }
 
 /**
- * Whether any QA inclusion/exclusion pattern is currently configured. Callers
- * use this to decide whether {@link createCopilotPatternFilter} can actually
- * remove results — when nothing is configured the filter is a no-op, so there
- * is no point over-fetching candidates to compensate for it.
- *
- * @returns True when at least one inclusion or exclusion pattern is active.
+ * Whether {@link createCopilotPatternFilter} can remove results, so callers know
+ * whether to over-fetch to compensate. Always true: the system root exclusion is
+ * always active, so a candidate can be dropped even with no user patterns.
  */
 export function hasActiveCopilotPatterns(): boolean {
-  const { inclusions, exclusions } = getMatchingPatterns();
-  return Boolean(inclusions || exclusions);
+  return true;
 }
 
 /**
@@ -419,8 +446,10 @@ function getInternalExcludePaths(): string[] {
  * Any file whose path starts with one of these prefixes is considered internal.
  */
 function getInternalExcludeFolderPrefixes(): string[] {
-  const settings = getSettings();
-  const projectsFolder = (settings.projectsFolder || "").trim();
+  // Reason: derive the projects folder from the configurable root instead of the
+  // retired `settings.projectsFolder`, so a custom root excludes its own
+  // project-config files rather than the stale default path.
+  const projectsFolder = getEffectiveProjectsFolder().trim();
   if (projectsFolder) {
     // Reason: normalize to forward slashes, collapse duplicates, strip trailing slash,
     // then append exactly one "/" for prefix matching. Mirrors normalizePath behavior

--- a/src/search/v3/FilterRetriever.test.ts
+++ b/src/search/v3/FilterRetriever.test.ts
@@ -23,6 +23,7 @@ jest.mock("@/utils", () => ({
 }));
 jest.mock("@/search/searchUtils", () => ({
   isInternalExcludedFile: jest.fn().mockReturnValue(false),
+  isSystemExcludedPath: jest.fn().mockReturnValue(false),
   shouldIndexFile: jest.fn().mockReturnValue(true),
   getMatchingPatterns: jest.fn().mockReturnValue({ inclusions: null, exclusions: null }),
 }));
@@ -77,6 +78,35 @@ describe("FilterRetriever", () => {
       expect(results[0].metadata.score).toBe(1.0);
       expect(results[0].metadata.source).toBe("title-match");
       expect(results[0].pageContent).toBe("Note content here");
+    });
+
+    it("drops an explicitly linked note that lives under a Copilot root", async () => {
+      // Copilot roots are excluded unconditionally, so naming a chat note with
+      // [[...]] must not reach past that: these documents carry
+      // includeInContext: true and nothing downstream drops them.
+      const extractNoteFiles = jest.requireMock("@/utils").extractNoteFiles as jest.Mock;
+      const isSystemExcludedPath = jest.requireMock("@/search/searchUtils")
+        .isSystemExcludedPath as jest.Mock;
+      const chatNote = createTFile("team-ai/copilot-conversations/Topic.md", {
+        mtime: 1000,
+        ctime: 500,
+      });
+      extractNoteFiles.mockReturnValueOnce([chatNote]);
+      isSystemExcludedPath.mockImplementation((path: string) => path.startsWith("team-ai/"));
+
+      const retriever = new FilterRetriever(mockApp as unknown as App, {
+        salientTerms: [],
+        maxK: 30,
+      });
+
+      try {
+        const results = await retriever.getRelevantDocuments("summarise [[Topic]]");
+
+        expect(results.length).toBe(0);
+        expect(mockApp.vault.cachedRead).not.toHaveBeenCalled();
+      } finally {
+        isSystemExcludedPath.mockReturnValue(false);
+      }
     });
 
     it("should return empty when no [[note]] mentions in query", async () => {

--- a/src/search/v3/FilterRetriever.ts
+++ b/src/search/v3/FilterRetriever.ts
@@ -1,6 +1,11 @@
 import { logInfo, logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
-import { isInternalExcludedFile, shouldIndexFile, getMatchingPatterns } from "@/search/searchUtils";
+import {
+  getMatchingPatterns,
+  isInternalExcludedFile,
+  isSystemExcludedPath,
+  shouldIndexFile,
+} from "@/search/searchUtils";
 import { extractNoteFiles } from "@/utils";
 import { Document } from "@langchain/core/documents";
 import { App, TFile, getAllTags } from "obsidian";
@@ -276,7 +281,14 @@ export class FilterRetriever {
     const chunks: Document[] = [];
 
     for (const file of noteFiles) {
-      if (isInternalExcludedFile(file)) {
+      // A Copilot root is excluded unconditionally, so an explicit [[link]] must
+      // not reach past it either: these documents are returned with
+      // `includeInContext: true` and nothing downstream drops them, so a linked
+      // chat note would otherwise be handed to the model verbatim. Deliberately
+      // NOT the full `shouldIndexFile` — that would also subject explicit links
+      // to the user's own qaInclusions/qaExclusions, which they have always been
+      // able to override by naming a file directly.
+      if (isInternalExcludedFile(file) || isSystemExcludedPath(file.path)) {
         continue;
       }
       try {

--- a/src/services/settingsPersistence.test.ts
+++ b/src/services/settingsPersistence.test.ts
@@ -460,6 +460,46 @@ describe("persistSettings", () => {
 });
 
 // ---------------------------------------------------------------------------
+// persistSettingsWithinTransaction
+// ---------------------------------------------------------------------------
+
+describe("persistSettingsWithinTransaction", () => {
+  it("dispatches straight to saveData for a disk-mode snapshot", async () => {
+    const { mod } = await loadModule();
+    const saveData = jest.fn().mockResolvedValue(undefined);
+
+    const current = makeSettings({ openAIApiKey: "sk-in-txn" });
+    await mod.persistSettingsWithinTransaction(current, saveData, current);
+
+    expect(saveData).toHaveBeenCalledWith(expect.objectContaining({ openAIApiKey: "sk-in-txn" }));
+  });
+
+  it("ignores the one-shot suppression flag so an in-transaction save always lands", async () => {
+    // suppressNextPersistOnce() is meant to swallow the subscriber-driven
+    // persist that follows setSettings — it must NOT suppress the transaction's
+    // own durable write, or the root change would never reach disk.
+    const { mod } = await loadModule();
+    const saveData = jest.fn().mockResolvedValue(undefined);
+
+    mod.suppressNextPersistOnce();
+    const current = makeSettings({ openAIApiKey: "sk-not-suppressed" });
+    await mod.persistSettingsWithinTransaction(current, saveData, current);
+
+    expect(saveData).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates a save failure so the caller can abort activation", async () => {
+    const { mod } = await loadModule();
+    const saveData = jest.fn().mockRejectedValue(new Error("disk full"));
+
+    const current = makeSettings({ openAIApiKey: "sk-x" });
+    await expect(mod.persistSettingsWithinTransaction(current, saveData, current)).rejects.toThrow(
+      "disk full"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // migrateDiskSecretsToKeychain
 // ---------------------------------------------------------------------------
 

--- a/src/services/settingsPersistence.ts
+++ b/src/services/settingsPersistence.ts
@@ -124,7 +124,9 @@ export function refreshDiskHasSecrets(data: CopilotSettings): void {
  * Electron's require cache keeps the module instance alive across plugin
  * disable→enable. After a mid-migration disable, stale state would poison
  * the next session. Similarly, switching vaults via "Open another vault"
- * carries stale state across vaults. Call this from `onunload`.
+ * carries stale state across vaults. Call this at the START of `onload`, not
+ * from `onunload` — unload is fire-and-forget, so a reset there can land after
+ * the next `onload` initialized and would clear the incoming lifecycle's state.
  */
 export function resetPersistenceState(): void {
   writeQueue = Promise.resolve();

--- a/src/services/settingsPersistence.ts
+++ b/src/services/settingsPersistence.ts
@@ -124,9 +124,7 @@ export function refreshDiskHasSecrets(data: CopilotSettings): void {
  * Electron's require cache keeps the module instance alive across plugin
  * disable→enable. After a mid-migration disable, stale state would poison
  * the next session. Similarly, switching vaults via "Open another vault"
- * carries stale state across vaults. Call this at the START of `onload`, not
- * from `onunload` — unload is fire-and-forget, so a reset there can land after
- * the next `onload` initialized and would clear the incoming lifecycle's state.
+ * carries stale state across vaults. Call this from `onunload`.
  */
 export function resetPersistenceState(): void {
   writeQueue = Promise.resolve();

--- a/src/services/settingsPersistence.ts
+++ b/src/services/settingsPersistence.ts
@@ -841,6 +841,30 @@ export const clearDiskSecrets = migrateDiskSecretsToKeychain;
 // ---------------------------------------------------------------------------
 
 /**
+ * Persist a settings snapshot from *inside* an already-running
+ * {@link runPersistenceTransaction} task, dispatching straight to disk/keychain
+ * without re-entering the write queue.
+ *
+ * Reason: a transaction task already executes inside `writeQueue`. Routing its
+ * own save through the public {@link persistSettings} would enqueue it behind
+ * the very transaction that is awaiting it — a self-deadlock. This entry point
+ * bypasses the queue (and the one-shot suppression flag, which is reserved for
+ * the subscriber-driven duplicate the caller intentionally follows with) so the
+ * transaction can make its snapshot durable before mutating in-memory state.
+ *
+ * @param settings - Complete settings snapshot to make durable.
+ * @param saveData - Plugin-bound writer for `data.json`.
+ * @param prevSettings - Previous snapshot, used as the keychain rollback baseline.
+ */
+export async function persistSettingsWithinTransaction(
+  settings: CopilotSettings,
+  saveData: (data: CopilotSettings) => Promise<void>,
+  prevSettings?: CopilotSettings
+): Promise<void> {
+  await doPersist(settings, saveData, prevSettings);
+}
+
+/**
  * Public entry point — queues a save behind the write queue and any pending
  * dedicated transactions, then dispatches to disk or keychain mode.
  */

--- a/src/settings/UpgradeRelocationNotice.test.tsx
+++ b/src/settings/UpgradeRelocationNotice.test.tsx
@@ -1,0 +1,33 @@
+import { UpgradeRelocationNotice } from "@/settings/UpgradeRelocationNotice";
+import type { FolderRelocationEntry } from "@/settings/upgradeNotice";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("UpgradeRelocationNotice", () => {
+  describe("UpgradeRelocationNotice()", () => {
+    it("renders the heading and states that files were not moved", () => {
+      render(<UpgradeRelocationNotice entries={[]} />);
+      expect(screen.getByRole("heading", { name: "Copilot folders have moved" })).not.toBeNull();
+      expect(screen.getByText(/weren.t moved/)).not.toBeNull();
+    });
+
+    it("lists each entry as an old-to-new path pair", () => {
+      const entries: FolderRelocationEntry[] = [
+        {
+          label: "Chat conversations",
+          oldPath: "old/chats",
+          newPath: "copilot/copilot-conversations",
+        },
+        { label: "Agent skills", oldPath: "old/skills", newPath: "copilot/skills" },
+      ];
+      render(<UpgradeRelocationNotice entries={entries} />);
+      // Each entry contributes a list item carrying its old and new paths.
+      const items = screen.getAllByRole("listitem");
+      expect(items).toHaveLength(2);
+      expect(items[0].textContent).toBe(
+        "Chat conversations: old/chats → copilot/copilot-conversations"
+      );
+      expect(items[1].textContent).toBe("Agent skills: old/skills → copilot/skills");
+    });
+  });
+});

--- a/src/settings/UpgradeRelocationNotice.tsx
+++ b/src/settings/UpgradeRelocationNotice.tsx
@@ -1,0 +1,35 @@
+import { FolderRelocationEntry } from "@/settings/upgradeNotice";
+import { FolderSync } from "lucide-react";
+import React from "react";
+
+/**
+ * Body of the one-time "Copilot folders have moved" modal shown after a v3→v4
+ * upgrade to a user whose data needs relocating (a folder was customized, or the
+ * root itself moved). Leads with a folder-sync icon header, states that files
+ * were not moved, then lists each folder that needs relocating as `old → new`.
+ */
+export function UpgradeRelocationNotice({
+  entries,
+}: {
+  entries: readonly FolderRelocationEntry[];
+}) {
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-4">
+      <div className="tw-flex tw-items-center tw-gap-3 tw-text-normal">
+        <FolderSync className="tw-size-6 tw-shrink-0 tw-text-accent" />
+        <h2 className="tw-m-0 tw-text-xl tw-font-bold">Copilot folders have moved</h2>
+      </div>
+      <p className="tw-m-0 tw-text-muted">
+        Copilot now keeps everything under one folder. Your files weren&apos;t moved — move them
+        over if you want Copilot to keep using them (Obsidian updates the links automatically).
+      </p>
+      <ul className="tw-m-0 tw-flex tw-flex-col tw-gap-1.5 tw-pl-4 tw-text-muted">
+        {entries.map((entry) => (
+          <li key={entry.label}>
+            {entry.label}: <code>{entry.oldPath}</code> → <code>{entry.newPath}</code>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/settings/copilotFolder.test.ts
+++ b/src/settings/copilotFolder.test.ts
@@ -1,0 +1,217 @@
+import {
+  COPILOT_SUBFOLDER,
+  deriveConversationsFolder,
+  deriveCustomPromptsFolder,
+  deriveMemoryFolder,
+  deriveProjectsFolder,
+  deriveSkillsFolder,
+  deriveSystemPromptsFolder,
+  ensureCopilotSubfolders,
+  getEffectiveConversationsFolder,
+  getEffectiveCopilotFolder,
+  getEffectiveCustomPromptsFolder,
+  getEffectiveMemoryFolder,
+  getEffectiveProjectsFolder,
+  getEffectiveSkillsFolder,
+  getEffectiveSystemPromptsFolder,
+} from "@/settings/copilotFolder";
+import type { CopilotSettings } from "@/settings/model";
+import { getSettings } from "@/settings/model";
+import { DEFAULT_SETTINGS } from "@/constants";
+
+jest.mock("obsidian", () => ({
+  // Collapse duplicate separators and trim edges the way Obsidian's helper does,
+  // enough for the derived-path assertions here.
+  normalizePath: (path: string) => path.replace(/\/+/g, "/").replace(/^\/|\/$/g, ""),
+}));
+
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(),
+}));
+
+jest.mock("@/utils", () => ({
+  ensureFolderExists: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("@/logger", () => ({
+  logWarn: jest.fn(),
+}));
+
+const mockedGetSettings = getSettings as jest.MockedFunction<typeof getSettings>;
+
+/** Build the minimal settings slice the derivation helpers read. */
+function settingsWithRoot(copilotFolder: string): CopilotSettings {
+  return { copilotFolder } as CopilotSettings;
+}
+
+describe("copilotFolder", () => {
+  describe("deriveConversationsFolder()", () => {
+    it("derives the historical default conversations path for the default root", () => {
+      expect(deriveConversationsFolder(settingsWithRoot("copilot"))).toBe(
+        "copilot/copilot-conversations"
+      );
+    });
+
+    it("re-roots the conversations folder under a custom root", () => {
+      expect(deriveConversationsFolder(settingsWithRoot("team/ai"))).toBe(
+        "team/ai/copilot-conversations"
+      );
+    });
+
+    it("falls back to the default root when the configured root is blank", () => {
+      expect(deriveConversationsFolder(settingsWithRoot("  "))).toBe(
+        "copilot/copilot-conversations"
+      );
+    });
+  });
+
+  describe("deriveCustomPromptsFolder()", () => {
+    it("derives the historical default custom-prompts path for the default root", () => {
+      expect(deriveCustomPromptsFolder(settingsWithRoot("copilot"))).toBe(
+        "copilot/copilot-custom-prompts"
+      );
+    });
+
+    it("re-roots the custom-prompts folder under a custom root", () => {
+      expect(deriveCustomPromptsFolder(settingsWithRoot("notes/copilot"))).toBe(
+        "notes/copilot/copilot-custom-prompts"
+      );
+    });
+  });
+
+  describe("deriveSystemPromptsFolder()", () => {
+    it("derives the historical default system-prompts path for the default root", () => {
+      expect(deriveSystemPromptsFolder(settingsWithRoot("copilot"))).toBe("copilot/system-prompts");
+    });
+
+    it("re-roots the system-prompts folder under a custom root", () => {
+      expect(deriveSystemPromptsFolder(settingsWithRoot("team/ai"))).toBe("team/ai/system-prompts");
+    });
+  });
+
+  describe("deriveSkillsFolder()", () => {
+    it("derives the historical default skills path for the default root", () => {
+      expect(deriveSkillsFolder(settingsWithRoot("copilot"))).toBe("copilot/skills");
+    });
+
+    it("re-roots the skills folder under a custom root", () => {
+      expect(deriveSkillsFolder(settingsWithRoot("team/ai"))).toBe("team/ai/skills");
+    });
+  });
+
+  describe("deriveMemoryFolder()", () => {
+    it("derives the historical default memory path for the default root", () => {
+      expect(deriveMemoryFolder(settingsWithRoot("copilot"))).toBe("copilot/memory");
+    });
+
+    it("re-roots the memory folder under a custom root", () => {
+      expect(deriveMemoryFolder(settingsWithRoot("team/ai"))).toBe("team/ai/memory");
+    });
+  });
+
+  describe("deriveProjectsFolder()", () => {
+    it("derives the historical default projects path for the default root", () => {
+      expect(deriveProjectsFolder(settingsWithRoot("copilot"))).toBe("copilot/projects");
+    });
+
+    it("re-roots the projects folder under a custom root", () => {
+      expect(deriveProjectsFolder(settingsWithRoot("team/ai"))).toBe("team/ai/projects");
+    });
+  });
+
+  describe("COPILOT_SUBFOLDER", () => {
+    it("pins the sub-folder names to the historical hardcoded defaults", () => {
+      expect(COPILOT_SUBFOLDER).toEqual({
+        conversations: "copilot-conversations",
+        customPrompts: "copilot-custom-prompts",
+        systemPrompts: "system-prompts",
+        skills: "skills",
+        memory: "memory",
+        projects: "projects",
+      });
+    });
+  });
+
+  describe("getEffectiveCopilotFolder()", () => {
+    it("returns the configured root read from global settings", () => {
+      mockedGetSettings.mockReturnValue(settingsWithRoot("team/ai"));
+      expect(getEffectiveCopilotFolder()).toBe("team/ai");
+    });
+  });
+
+  describe("effective accessors read the live global root", () => {
+    it("derive every sub-folder from the current global copilotFolder", () => {
+      mockedGetSettings.mockReturnValue(settingsWithRoot("team/ai"));
+      expect(getEffectiveConversationsFolder()).toBe("team/ai/copilot-conversations");
+      expect(getEffectiveCustomPromptsFolder()).toBe("team/ai/copilot-custom-prompts");
+      expect(getEffectiveSystemPromptsFolder()).toBe("team/ai/system-prompts");
+      expect(getEffectiveSkillsFolder()).toBe("team/ai/skills");
+      expect(getEffectiveMemoryFolder()).toBe("team/ai/memory");
+      expect(getEffectiveProjectsFolder()).toBe("team/ai/projects");
+    });
+  });
+
+  describe("ensureCopilotSubfolders()", () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { ensureFolderExists } = require("@/utils") as {
+      ensureFolderExists: jest.MockedFunction<(vault: unknown, folder: string) => Promise<void>>;
+    };
+    const fakeVault = {} as import("obsidian").Vault;
+
+    beforeEach(() => ensureFolderExists.mockClear());
+
+    it("creates all six derived sub-folders under the given root", async () => {
+      await ensureCopilotSubfolders(fakeVault, settingsWithRoot("team/ai"));
+      const created = ensureFolderExists.mock.calls.map((call) => call[1]);
+      expect(created).toEqual([
+        "team/ai/copilot-conversations",
+        "team/ai/copilot-custom-prompts",
+        "team/ai/system-prompts",
+        "team/ai/skills",
+        "team/ai/memory",
+        "team/ai/projects",
+      ]);
+    });
+
+    it("continues past a folder that fails so one bad path cannot block the rest", async () => {
+      ensureFolderExists
+        .mockRejectedValueOnce(new Error("path conflict"))
+        .mockResolvedValue(undefined);
+      await expect(
+        ensureCopilotSubfolders(fakeVault, settingsWithRoot("copilot"))
+      ).resolves.toBeUndefined();
+      // All six are still attempted even though the first threw.
+      expect(ensureFolderExists).toHaveBeenCalledTimes(6);
+    });
+  });
+
+  describe("byte-for-byte parity with the retired default sub-folders", () => {
+    // Reason: a default vault (copilotFolder === "copilot") must resolve to the
+    // exact paths the retired per-folder defaults used, so upgrades are a no-op.
+    const settings = DEFAULT_SETTINGS;
+
+    it("matches the default conversations folder", () => {
+      expect(deriveConversationsFolder(settings)).toBe(DEFAULT_SETTINGS.defaultSaveFolder);
+    });
+
+    it("matches the default custom-prompts folder", () => {
+      expect(deriveCustomPromptsFolder(settings)).toBe(DEFAULT_SETTINGS.customPromptsFolder);
+    });
+
+    it("matches the default system-prompts folder", () => {
+      expect(deriveSystemPromptsFolder(settings)).toBe(DEFAULT_SETTINGS.userSystemPromptsFolder);
+    });
+
+    it("matches the default skills folder", () => {
+      expect(deriveSkillsFolder(settings)).toBe(DEFAULT_SETTINGS.agentMode.skills.folder);
+    });
+
+    it("matches the default memory folder", () => {
+      expect(deriveMemoryFolder(settings)).toBe(DEFAULT_SETTINGS.memoryFolderName);
+    });
+
+    it("matches the default projects folder", () => {
+      expect(deriveProjectsFolder(settings)).toBe(DEFAULT_SETTINGS.projectsFolder);
+    });
+  });
+});

--- a/src/settings/copilotFolder.ts
+++ b/src/settings/copilotFolder.ts
@@ -1,0 +1,147 @@
+import { DEFAULT_COPILOT_FOLDER } from "@/constants";
+import { logWarn } from "@/logger";
+import { getSettings, type CopilotSettings } from "@/settings/model";
+import { ensureFolderExists } from "@/utils";
+import { normalizePath, type Vault } from "obsidian";
+
+/**
+ * Fixed sub-folder names every Copilot data folder derives from the single
+ * configurable `copilotFolder` root. These names are the historical hardcoded
+ * defaults (byte-for-byte), so a default vault (`copilotFolder === "copilot"`)
+ * resolves to exactly the same paths it used before the root became configurable.
+ */
+export const COPILOT_SUBFOLDER = Object.freeze({
+  conversations: "copilot-conversations",
+  customPrompts: "copilot-custom-prompts",
+  systemPrompts: "system-prompts",
+  skills: "skills",
+  memory: "memory",
+  projects: "projects",
+} as const);
+
+/** Settings shape the derivation helpers depend on. */
+type FolderSettings = Pick<CopilotSettings, "copilotFolder">;
+
+/**
+ * Resolve the configurable root all sub-folders derive from.
+ *
+ * Reason: the loader's `sanitizeSettings` guarantees a non-empty, traversal-free
+ * root, but the UI can render before settings hydration completes. Falling back
+ * to the default in that window keeps derived paths well-formed rather than
+ * producing a leading-slash path. Mirrors `SkillManager.resolveSkillsFolder`.
+ */
+function copilotRoot(settings: FolderSettings): string {
+  return (settings.copilotFolder || "").trim() || DEFAULT_COPILOT_FOLDER;
+}
+
+/** Join the resolved root with a fixed sub-folder name into a normalized path. */
+function deriveSubfolder(settings: FolderSettings, subfolder: string): string {
+  return normalizePath(`${copilotRoot(settings)}/${subfolder}`);
+}
+
+/**
+ * Derive the chat-conversations folder from a settings snapshot.
+ * Pure: callers (e.g. watchers comparing prev/next) pass the snapshot they hold
+ * instead of reading the global store mid-operation.
+ */
+export function deriveConversationsFolder(settings: FolderSettings): string {
+  return deriveSubfolder(settings, COPILOT_SUBFOLDER.conversations);
+}
+
+/** Derive the custom-commands folder from a settings snapshot. */
+export function deriveCustomPromptsFolder(settings: FolderSettings): string {
+  return deriveSubfolder(settings, COPILOT_SUBFOLDER.customPrompts);
+}
+
+/** Derive the user system-prompts folder from a settings snapshot. */
+export function deriveSystemPromptsFolder(settings: FolderSettings): string {
+  return deriveSubfolder(settings, COPILOT_SUBFOLDER.systemPrompts);
+}
+
+/** Derive the agent skills folder from a settings snapshot. */
+export function deriveSkillsFolder(settings: FolderSettings): string {
+  return deriveSubfolder(settings, COPILOT_SUBFOLDER.skills);
+}
+
+/** Derive the user-memory folder from a settings snapshot. */
+export function deriveMemoryFolder(settings: FolderSettings): string {
+  return deriveSubfolder(settings, COPILOT_SUBFOLDER.memory);
+}
+
+/** Derive the projects folder from a settings snapshot. */
+export function deriveProjectsFolder(settings: FolderSettings): string {
+  return deriveSubfolder(settings, COPILOT_SUBFOLDER.projects);
+}
+
+/**
+ * Effective root folder for artifacts written directly under it (e.g. the log
+ * file and index-inspection notes), not into one of the derived sub-folders.
+ */
+export function getEffectiveCopilotFolder(): string {
+  return normalizePath(copilotRoot(getSettings()));
+}
+
+/** Effective chat-conversations folder derived from the current global settings. */
+export function getEffectiveConversationsFolder(): string {
+  return deriveConversationsFolder(getSettings());
+}
+
+/** Effective custom-commands folder derived from the current global settings. */
+export function getEffectiveCustomPromptsFolder(): string {
+  return deriveCustomPromptsFolder(getSettings());
+}
+
+/** Effective user system-prompts folder derived from the current global settings. */
+export function getEffectiveSystemPromptsFolder(): string {
+  return deriveSystemPromptsFolder(getSettings());
+}
+
+/** Effective agent skills folder derived from the current global settings. */
+export function getEffectiveSkillsFolder(): string {
+  return deriveSkillsFolder(getSettings());
+}
+
+/** Effective user-memory folder derived from the current global settings. */
+export function getEffectiveMemoryFolder(): string {
+  return deriveMemoryFolder(getSettings());
+}
+
+/** Effective projects folder derived from the current global settings. */
+export function getEffectiveProjectsFolder(): string {
+  return deriveProjectsFolder(getSettings());
+}
+
+/**
+ * Pre-create every derived Copilot sub-folder under the current root so the
+ * locations the relocation/change-root notices point at already exist when the
+ * user goes to move files into them (Obsidian's own move dialog creates missing
+ * targets, but a user moving files from the OS file manager needs them present).
+ *
+ * Best-effort and idempotent: {@link ensureFolderExists} skips folders that
+ * already exist, and a per-folder failure (e.g. a file already occupies the
+ * path) is logged and skipped rather than aborting the rest.
+ *
+ * @param vault - Active vault, threaded in (never the global `app`).
+ * @param settings - Settings snapshot whose `copilotFolder` roots the derivation.
+ */
+export async function ensureCopilotSubfolders(
+  vault: Vault,
+  settings: FolderSettings
+): Promise<void> {
+  const derivers = [
+    deriveConversationsFolder,
+    deriveCustomPromptsFolder,
+    deriveSystemPromptsFolder,
+    deriveSkillsFolder,
+    deriveMemoryFolder,
+    deriveProjectsFolder,
+  ];
+  for (const derive of derivers) {
+    const folder = derive(settings);
+    try {
+      await ensureFolderExists(vault, folder);
+    } catch (error) {
+      logWarn(`Could not pre-create Copilot sub-folder "${folder}".`, error);
+    }
+  }
+}

--- a/src/settings/copilotFolder.ts
+++ b/src/settings/copilotFolder.ts
@@ -74,6 +74,38 @@ export function deriveProjectsFolder(settings: FolderSettings): string {
 }
 
 /**
+ * DESIGN NOTE — every `getEffective*Folder()` below reads the LIVE global
+ * settings, so calling one twice inside a single operation can return two
+ * different folders: the root activates the moment it is persisted, and the
+ * caches keyed off it reload asynchronously (`ProjectRegister` on a 1s trailing
+ * debounce, the command/prompt registers likewise).
+ *
+ * The rule for callers is therefore: an operation resolves its folder ONCE and
+ * uses that value for every `ensureFolderExists` and write it performs.
+ * Which moment to resolve at is not uniform, and cannot be — the two directions
+ * are opposites:
+ *   - Work whose content does not depend on the old location (a fresh create, a
+ *     summary produced by a model call) resolves LATE, just before writing, so
+ *     it lands where the user now expects it.
+ *   - Work anchored to something already on disk (a read-modify-write, or any
+ *     CRUD on an existing record) resolves from that thing's own path — see
+ *     `getProjectAnchorFromConfigPath` — because redirecting it would overwrite
+ *     a different file with a snapshot of this one.
+ *
+ * Enforcing this by construction would mean these accessors becoming
+ * unavailable except through an operation-scoped layout snapshot, the way
+ * `MiyoMutationSession` makes a stale lifecycle token unrepresentable. That is
+ * the right long-term shape and is deliberately NOT done here: it would touch
+ * every writer and consumer across ~14 modules, and the correctness of each one
+ * depends on which of the two directions above it needs — a mechanical
+ * conversion would silently pick the wrong one. Tracked as a follow-up.
+ *
+ * If a future review flags a new instance, the fix is to give that operation a
+ * single folder value, and to point them at this note for why there is no
+ * blanket rule.
+ */
+
+/**
  * Effective root folder for artifacts written directly under it (e.g. the log
  * file and index-inspection notes), not into one of the derived sub-folders.
  */

--- a/src/settings/copilotRootChange.test.ts
+++ b/src/settings/copilotRootChange.test.ts
@@ -75,21 +75,6 @@ describe("copilotRootChange", () => {
       expect(copilotRootContainsNotes(app, "ai")).toBe(false);
     });
 
-    it("does not treat a differently-cased folder as a recorded root", () => {
-      // Identity stays exact-case even on filesystems where coverage folds: this
-      // gates the EXEMPTION from the note-content guard, so folding here would
-      // accept a genuinely different `notes/` as the `Notes` root once used and
-      // activate Copilot over the user's own notes. See the note on the function.
-      const platform = obsidian.Platform as { isMacOS: boolean };
-      const previous = platform.isMacOS;
-      platform.isMacOS = true;
-      try {
-        expect(isKnownCopilotRoot("TeamAI", ["teamai"])).toBe(false);
-      } finally {
-        platform.isMacOS = previous;
-      }
-    });
-
     it("returns false for an empty candidate root", () => {
       const app = appWithMarkdown(["a.md"]);
       expect(copilotRootContainsNotes(app, "")).toBe(false);
@@ -167,6 +152,21 @@ describe("copilotRootChange", () => {
 
     it("matches a root against the history in canonical form despite trailing slashes", () => {
       expect(isKnownCopilotRoot("ai/", ["copilot", "ai"])).toBe(true);
+    });
+
+    it("does not treat a differently-cased folder as a recorded root", () => {
+      // Identity stays exact-case even on filesystems where coverage folds: this
+      // gates the EXEMPTION from the note-content guard, so folding here would
+      // accept a genuinely different `notes/` as the `Notes` root once used and
+      // activate Copilot over the user's own notes. See the note on the function.
+      const platform = obsidian.Platform as { isMacOS: boolean };
+      const previous = platform.isMacOS;
+      platform.isMacOS = true;
+      try {
+        expect(isKnownCopilotRoot("TeamAI", ["teamai"])).toBe(false);
+      } finally {
+        platform.isMacOS = previous;
+      }
     });
 
     it("returns false for a root absent from the history", () => {

--- a/src/settings/copilotRootChange.test.ts
+++ b/src/settings/copilotRootChange.test.ts
@@ -104,6 +104,41 @@ describe("copilotRootChange", () => {
     });
   });
 
+  // The Apply guard is `!isKnownCopilotRoot(...) && copilotRootContainsNotes(...)`,
+  // and the two use different comparisons on purpose. BasicSettings mocks both,
+  // so the composed rule is only observable here.
+  describe("the exemption/coverage pair the Apply guard composes", () => {
+    const applyWouldBlock = (app: App, folder: string, history: string[]) =>
+      !isKnownCopilotRoot(folder, history) && copilotRootContainsNotes(app, folder);
+
+    it("blocks a differently-cased historical root rather than exempting it", () => {
+      // Fails closed: identity is exact-case, so this is refused by the content
+      // guard instead of exempted. The user's original spelling still works.
+      const platform = obsidian.Platform as { isMacOS: boolean };
+      const previous = platform.isMacOS;
+      platform.isMacOS = true;
+      try {
+        const app = appWithMarkdown(["teamai/copilot-conversations/chat.md"]);
+        expect(applyWouldBlock(app, "TeamAI", ["teamai"])).toBe(true);
+      } finally {
+        platform.isMacOS = previous;
+      }
+    });
+
+    it("does not exempt a real folder that merely differs in case from a historical root", () => {
+      // The reason identity must NOT fold: on a case-sensitive volume `notes/`
+      // is a different folder holding the user's own notes. Folding identity
+      // would exempt it and activate a Copilot root over them.
+      const app = appWithMarkdown(["notes/user-note.md"]);
+      expect(applyWouldBlock(app, "notes", ["Notes"])).toBe(true);
+    });
+
+    it("exempts a historical root spelled exactly as recorded", () => {
+      const app = appWithMarkdown(["teamai/copilot-conversations/chat.md"]);
+      expect(applyWouldBlock(app, "teamai", ["teamai"])).toBe(false);
+    });
+  });
+
   describe("findCopilotRootFileConflict()", () => {
     /** Minimal App whose vault cache holds the given file/folder entries. */
     function appWithEntries(entries: Record<string, "file" | "folder">): App {

--- a/src/settings/copilotRootChange.test.ts
+++ b/src/settings/copilotRootChange.test.ts
@@ -75,6 +75,21 @@ describe("copilotRootChange", () => {
       expect(copilotRootContainsNotes(app, "ai")).toBe(false);
     });
 
+    it("does not treat a differently-cased folder as a recorded root", () => {
+      // Identity stays exact-case even on filesystems where coverage folds: this
+      // gates the EXEMPTION from the note-content guard, so folding here would
+      // accept a genuinely different `notes/` as the `Notes` root once used and
+      // activate Copilot over the user's own notes. See the note on the function.
+      const platform = obsidian.Platform as { isMacOS: boolean };
+      const previous = platform.isMacOS;
+      platform.isMacOS = true;
+      try {
+        expect(isKnownCopilotRoot("TeamAI", ["teamai"])).toBe(false);
+      } finally {
+        platform.isMacOS = previous;
+      }
+    });
+
     it("returns false for an empty candidate root", () => {
       const app = appWithMarkdown(["a.md"]);
       expect(copilotRootContainsNotes(app, "")).toBe(false);
@@ -101,41 +116,6 @@ describe("copilotRootChange", () => {
       // holds no notes and must be accepted.
       const app = appWithMarkdown(["notes/private.md"]);
       expect(copilotRootContainsNotes(app, "Notes")).toBe(false);
-    });
-  });
-
-  // The Apply guard is `!isKnownCopilotRoot(...) && copilotRootContainsNotes(...)`,
-  // and the two use different comparisons on purpose. BasicSettings mocks both,
-  // so the composed rule is only observable here.
-  describe("the exemption/coverage pair the Apply guard composes", () => {
-    const applyWouldBlock = (app: App, folder: string, history: string[]) =>
-      !isKnownCopilotRoot(folder, history) && copilotRootContainsNotes(app, folder);
-
-    it("blocks a differently-cased historical root rather than exempting it", () => {
-      // Fails closed: identity is exact-case, so this is refused by the content
-      // guard instead of exempted. The user's original spelling still works.
-      const platform = obsidian.Platform as { isMacOS: boolean };
-      const previous = platform.isMacOS;
-      platform.isMacOS = true;
-      try {
-        const app = appWithMarkdown(["teamai/copilot-conversations/chat.md"]);
-        expect(applyWouldBlock(app, "TeamAI", ["teamai"])).toBe(true);
-      } finally {
-        platform.isMacOS = previous;
-      }
-    });
-
-    it("does not exempt a real folder that merely differs in case from a historical root", () => {
-      // The reason identity must NOT fold: on a case-sensitive volume `notes/`
-      // is a different folder holding the user's own notes. Folding identity
-      // would exempt it and activate a Copilot root over them.
-      const app = appWithMarkdown(["notes/user-note.md"]);
-      expect(applyWouldBlock(app, "notes", ["Notes"])).toBe(true);
-    });
-
-    it("exempts a historical root spelled exactly as recorded", () => {
-      const app = appWithMarkdown(["teamai/copilot-conversations/chat.md"]);
-      expect(applyWouldBlock(app, "teamai", ["teamai"])).toBe(false);
     });
   });
 

--- a/src/settings/copilotRootChange.test.ts
+++ b/src/settings/copilotRootChange.test.ts
@@ -1,0 +1,115 @@
+import { DEFAULT_SETTINGS } from "@/constants";
+import {
+  applyCopilotRootChange,
+  copilotRootContainsNotes,
+  isKnownCopilotRoot,
+} from "@/settings/copilotRootChange";
+import { getSettings, settingsAtom, settingsStore, type CopilotSettings } from "@/settings/model";
+import type { App } from "obsidian";
+
+const garbageCollectVectorStore = jest.fn<Promise<number>, []>();
+jest.mock("@/search/vectorStoreManager", () => ({
+  __esModule: true,
+  default: { getInstance: () => ({ garbageCollectVectorStore }) },
+}));
+
+/** Minimal App whose vault reports the given Markdown file paths. */
+function appWithMarkdown(paths: string[]): App {
+  return {
+    vault: { getMarkdownFiles: () => paths.map((path) => ({ path })) },
+  } as unknown as App;
+}
+
+function seedSettings(partial: Partial<CopilotSettings>): void {
+  settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, ...partial });
+}
+
+describe("copilotRootChange", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    garbageCollectVectorStore.mockResolvedValue(0);
+    settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS });
+  });
+
+  describe("copilotRootContainsNotes()", () => {
+    it("returns true when a Markdown file lives directly under the target root", () => {
+      const app = appWithMarkdown(["ai/note.md", "other/x.md"]);
+      expect(copilotRootContainsNotes(app, "ai")).toBe(true);
+    });
+
+    it("returns true for a nested Markdown file under the target root", () => {
+      const app = appWithMarkdown(["ai/sub/deep.md"]);
+      expect(copilotRootContainsNotes(app, "ai")).toBe(true);
+    });
+
+    it("returns false when no Markdown file is at or under the target root", () => {
+      const app = appWithMarkdown(["notes/a.md", "ai-adjacent/b.md"]);
+      // "ai-adjacent" must not match the "ai" prefix at a segment boundary.
+      expect(copilotRootContainsNotes(app, "ai")).toBe(false);
+    });
+
+    it("returns false for an empty candidate root", () => {
+      const app = appWithMarkdown(["a.md"]);
+      expect(copilotRootContainsNotes(app, "")).toBe(false);
+    });
+  });
+
+  describe("isKnownCopilotRoot()", () => {
+    it("returns true for a root recorded in the history", () => {
+      expect(isKnownCopilotRoot("ai", ["copilot", "ai"])).toBe(true);
+    });
+
+    it("matches a root against the history in canonical form despite trailing slashes", () => {
+      expect(isKnownCopilotRoot("ai/", ["copilot", "ai"])).toBe(true);
+    });
+
+    it("returns false for a root absent from the history", () => {
+      expect(isKnownCopilotRoot("new-root", ["copilot", "ai"])).toBe(false);
+    });
+
+    it("returns false for an empty candidate root", () => {
+      expect(isKnownCopilotRoot("", ["copilot", "ai"])).toBe(false);
+    });
+
+    it("returns false against an empty history", () => {
+      expect(isKnownCopilotRoot("ai", [])).toBe(false);
+    });
+  });
+
+  describe("applyCopilotRootChange()", () => {
+    it("commits the new root and its protection history in one settings snapshot", async () => {
+      seedSettings({ copilotFolder: "ai", copilotRootHistory: ["copilot", "ai"] });
+
+      await applyCopilotRootChange("team-ai");
+
+      const after = getSettings();
+      expect(after.copilotFolder).toBe("team-ai");
+      // Old + new + legacy roots all survive in the append-only history.
+      expect(new Set(after.copilotRootHistory)).toEqual(new Set(["copilot", "ai", "team-ai"]));
+    });
+
+    it("triggers a best-effort garbage-collection pass after activating", async () => {
+      seedSettings({ copilotFolder: "copilot" });
+      await applyCopilotRootChange("ai");
+      expect(garbageCollectVectorStore).toHaveBeenCalledTimes(1);
+    });
+
+    it("still activates the new root when garbage collection fails", async () => {
+      seedSettings({ copilotFolder: "copilot" });
+      garbageCollectVectorStore.mockRejectedValueOnce(new Error("index offline"));
+
+      await expect(applyCopilotRootChange("ai")).resolves.toBeUndefined();
+      expect(getSettings().copilotFolder).toBe("ai");
+    });
+
+    it("does not activate an invalid root or run garbage collection", async () => {
+      seedSettings({ copilotFolder: "copilot", copilotRootHistory: ["copilot"] });
+
+      await applyCopilotRootChange("../escape");
+
+      expect(getSettings().copilotFolder).toBe("copilot");
+      expect(getSettings().copilotRootHistory).toEqual(["copilot"]);
+      expect(garbageCollectVectorStore).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/settings/copilotRootChange.test.ts
+++ b/src/settings/copilotRootChange.test.ts
@@ -8,6 +8,7 @@ import {
 import { mockTFile, mockTFolder } from "@/__tests__/mockObsidian";
 import { getSettings, settingsAtom, settingsStore, type CopilotSettings } from "@/settings/model";
 import type { App } from "obsidian";
+import * as obsidian from "obsidian";
 
 const garbageCollectVectorStore = jest.fn<Promise<number>, []>();
 jest.mock("@/search/vectorStoreManager", () => ({
@@ -77,6 +78,29 @@ describe("copilotRootChange", () => {
     it("returns false for an empty candidate root", () => {
       const app = appWithMarkdown(["a.md"]);
       expect(copilotRootContainsNotes(app, "")).toBe(false);
+    });
+
+    it("catches a differently-cased folder where the filesystem is case-insensitive", () => {
+      // This guard has to agree with the exclusion matcher, which folds case on
+      // these platforms. Comparing exact-case would clear `Notes`, and the real
+      // `notes/` — the user's own notes — would then be excluded from search:
+      // exactly what the guard exists to prevent.
+      const platform = obsidian.Platform as { isMacOS: boolean };
+      const previous = platform.isMacOS;
+      platform.isMacOS = true;
+      try {
+        const app = appWithMarkdown(["notes/private.md"]);
+        expect(copilotRootContainsNotes(app, "Notes")).toBe(true);
+      } finally {
+        platform.isMacOS = previous;
+      }
+    });
+
+    it("treats a differently-cased folder as distinct where the filesystem is case-sensitive", () => {
+      // On Linux `Notes/` and `notes/` really are two folders, so the candidate
+      // holds no notes and must be accepted.
+      const app = appWithMarkdown(["notes/private.md"]);
+      expect(copilotRootContainsNotes(app, "Notes")).toBe(false);
     });
   });
 

--- a/src/settings/copilotRootChange.test.ts
+++ b/src/settings/copilotRootChange.test.ts
@@ -2,8 +2,10 @@ import { DEFAULT_SETTINGS } from "@/constants";
 import {
   applyCopilotRootChange,
   copilotRootContainsNotes,
+  findCopilotRootFileConflict,
   isKnownCopilotRoot,
 } from "@/settings/copilotRootChange";
+import { mockTFile, mockTFolder } from "@/__tests__/mockObsidian";
 import { getSettings, settingsAtom, settingsStore, type CopilotSettings } from "@/settings/model";
 import type { App } from "obsidian";
 
@@ -75,6 +77,47 @@ describe("copilotRootChange", () => {
     it("returns false for an empty candidate root", () => {
       const app = appWithMarkdown(["a.md"]);
       expect(copilotRootContainsNotes(app, "")).toBe(false);
+    });
+  });
+
+  describe("findCopilotRootFileConflict()", () => {
+    /** Minimal App whose vault cache holds the given file/folder entries. */
+    function appWithEntries(entries: Record<string, "file" | "folder">): App {
+      return {
+        vault: {
+          getAbstractFileByPath: (path: string) => {
+            const kind = entries[path];
+            if (kind === "file") return mockTFile({ path });
+            if (kind === "folder") return mockTFolder({ path });
+            return null;
+          },
+        },
+      } as unknown as App;
+    }
+
+    it("returns the root itself when it exists as a file", () => {
+      const app = appWithEntries({ "ai.txt": "file" });
+      expect(findCopilotRootFileConflict(app, "ai.txt")).toBe("ai.txt");
+    });
+
+    it("returns the first ancestor that exists as a file", () => {
+      const app = appWithEntries({ team: "file" });
+      expect(findCopilotRootFileConflict(app, "team/ai")).toBe("team");
+    });
+
+    it("returns null when every existing prefix is a folder", () => {
+      const app = appWithEntries({ team: "folder", "team/ai": "folder" });
+      expect(findCopilotRootFileConflict(app, "team/ai")).toBeNull();
+    });
+
+    it("returns null when nothing exists at any prefix yet", () => {
+      const app = appWithEntries({});
+      expect(findCopilotRootFileConflict(app, "brand/new/root")).toBeNull();
+    });
+
+    it("returns null for an empty candidate root", () => {
+      const app = appWithEntries({});
+      expect(findCopilotRootFileConflict(app, "")).toBeNull();
     });
   });
 

--- a/src/settings/copilotRootChange.test.ts
+++ b/src/settings/copilotRootChange.test.ts
@@ -13,6 +13,28 @@ jest.mock("@/search/vectorStoreManager", () => ({
   default: { getInstance: () => ({ garbageCollectVectorStore }) },
 }));
 
+// Persistence transaction surface. The transaction runner executes its task
+// inline so the persist→activate ordering under test is preserved; the durable
+// write and suppression are captured so tests can assert order and simulate a
+// save failure.
+const persistSettingsWithinTransaction = jest.fn<Promise<void>, unknown[]>();
+const suppressNextPersistOnce = jest.fn<void, []>();
+jest.mock("@/services/settingsPersistence", () => ({
+  runPersistenceTransaction: (task: () => Promise<void>) => task(),
+  persistSettingsWithinTransaction: async (...args: unknown[]) => {
+    await persistSettingsWithinTransaction(...args);
+  },
+  suppressNextPersistOnce: () => suppressNextPersistOnce(),
+}));
+
+const saveData = jest.fn<Promise<void>, unknown[]>();
+jest.mock("@/settings/copilotSaveData", () => ({
+  getCopilotSaveData: () => saveData,
+}));
+
+/** Minimal App; the plugin lookup is mocked away via getCopilotSaveData. */
+const app = {} as App;
+
 /** Minimal App whose vault reports the given Markdown file paths. */
 function appWithMarkdown(paths: string[]): App {
   return {
@@ -28,6 +50,8 @@ describe("copilotRootChange", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     garbageCollectVectorStore.mockResolvedValue(0);
+    persistSettingsWithinTransaction.mockResolvedValue(undefined);
+    saveData.mockResolvedValue(undefined);
     settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS });
   });
 
@@ -80,7 +104,7 @@ describe("copilotRootChange", () => {
     it("commits the new root and its protection history in one settings snapshot", async () => {
       seedSettings({ copilotFolder: "ai", copilotRootHistory: ["copilot", "ai"] });
 
-      await applyCopilotRootChange("team-ai");
+      await applyCopilotRootChange(app, "team-ai");
 
       const after = getSettings();
       expect(after.copilotFolder).toBe("team-ai");
@@ -88,9 +112,99 @@ describe("copilotRootChange", () => {
       expect(new Set(after.copilotRootHistory)).toEqual(new Set(["copilot", "ai", "team-ai"]));
     });
 
+    it("durably persists the new root before activating it in memory", async () => {
+      seedSettings({ copilotFolder: "copilot", copilotRootHistory: ["copilot"] });
+      // Capture the in-memory root as seen at persist time to prove the durable
+      // write happens BEFORE the memory flip.
+      let rootWhenPersisted: string | undefined;
+      const persistedSnapshots: string[] = [];
+      persistSettingsWithinTransaction.mockImplementation((next: unknown) => {
+        rootWhenPersisted = getSettings().copilotFolder;
+        persistedSnapshots.push((next as CopilotSettings).copilotFolder);
+        return Promise.resolve();
+      });
+
+      await applyCopilotRootChange(app, "ai");
+
+      expect(rootWhenPersisted).toBe("copilot"); // memory still old at persist time
+      expect(persistedSnapshots).toEqual(["ai"]); // durable snapshot carries the new root
+      expect(getSettings().copilotFolder).toBe("ai"); // memory flipped only after
+      expect(suppressNextPersistOnce).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves a concurrent settings edit in memory across the reconcile", async () => {
+      // Reproduces the two-window race: a non-root edit lands during the first
+      // persist (triggering reconcile), and another during the second persist.
+      // The functional activation update must keep both in memory rather than
+      // reverting them to the snapshot captured before they arrived.
+      seedSettings({ copilotFolder: "copilot", copilotRootHistory: ["copilot"] });
+      persistSettingsWithinTransaction
+        .mockImplementationOnce(() => {
+          // Edit A during the first persist → makes `fresh` differ → reconcile.
+          settingsStore.set(settingsAtom, {
+            ...getSettings(),
+            userSystemPromptsFolder: "edit-A",
+          });
+          return Promise.resolve();
+        })
+        .mockImplementationOnce(() => {
+          // Edit B during the second (reconcile) persist.
+          settingsStore.set(settingsAtom, {
+            ...getSettings(),
+            defaultSaveFolder: "edit-B",
+          });
+          return Promise.resolve();
+        });
+
+      await applyCopilotRootChange(app, "ai");
+
+      const after = getSettings();
+      expect(after.copilotFolder).toBe("ai"); // root change landed
+      expect(after.userSystemPromptsFolder).toBe("edit-A"); // first-window edit kept
+      expect(after.defaultSaveFolder).toBe("edit-B"); // second-window edit not clobbered
+    });
+
+    it("completes the root change even when the reconcile save fails", async () => {
+      // The first persist made the root durable — the user-visible operation
+      // succeeded. A failing reconcile (which only carries a concurrent edit to
+      // disk) must not fail the whole change; the edit stays in memory and
+      // lands with the next save.
+      seedSettings({ copilotFolder: "copilot", copilotRootHistory: ["copilot"] });
+      persistSettingsWithinTransaction
+        .mockImplementationOnce(() => {
+          // Concurrent edit during the first persist → reconcile triggers.
+          settingsStore.set(settingsAtom, {
+            ...getSettings(),
+            userSystemPromptsFolder: "edit-A",
+          });
+          return Promise.resolve();
+        })
+        .mockRejectedValueOnce(new Error("reconcile disk full"));
+
+      await expect(applyCopilotRootChange(app, "ai")).resolves.toBeUndefined();
+
+      expect(getSettings().copilotFolder).toBe("ai"); // change completed
+      expect(getSettings().userSystemPromptsFolder).toBe("edit-A"); // edit kept in memory
+      expect(garbageCollectVectorStore).toHaveBeenCalledTimes(1); // follow-ups ran
+    });
+
+    it("keeps the old root and skips GC when the durable save fails", async () => {
+      seedSettings({ copilotFolder: "copilot", copilotRootHistory: ["copilot"] });
+      persistSettingsWithinTransaction.mockRejectedValueOnce(new Error("disk full"));
+
+      await expect(applyCopilotRootChange(app, "ai")).rejects.toThrow("disk full");
+
+      // Save failed before activation, so the in-memory root is untouched and no
+      // GC ran — the session keeps writing under the protected old root.
+      expect(getSettings().copilotFolder).toBe("copilot");
+      expect(getSettings().copilotRootHistory).toEqual(["copilot"]);
+      expect(suppressNextPersistOnce).not.toHaveBeenCalled();
+      expect(garbageCollectVectorStore).not.toHaveBeenCalled();
+    });
+
     it("triggers a best-effort garbage-collection pass after activating", async () => {
       seedSettings({ copilotFolder: "copilot" });
-      await applyCopilotRootChange("ai");
+      await applyCopilotRootChange(app, "ai");
       expect(garbageCollectVectorStore).toHaveBeenCalledTimes(1);
     });
 
@@ -98,17 +212,18 @@ describe("copilotRootChange", () => {
       seedSettings({ copilotFolder: "copilot" });
       garbageCollectVectorStore.mockRejectedValueOnce(new Error("index offline"));
 
-      await expect(applyCopilotRootChange("ai")).resolves.toBeUndefined();
+      await expect(applyCopilotRootChange(app, "ai")).resolves.toBeUndefined();
       expect(getSettings().copilotFolder).toBe("ai");
     });
 
     it("does not activate an invalid root or run garbage collection", async () => {
       seedSettings({ copilotFolder: "copilot", copilotRootHistory: ["copilot"] });
 
-      await applyCopilotRootChange("../escape");
+      await applyCopilotRootChange(app, "../escape");
 
       expect(getSettings().copilotFolder).toBe("copilot");
       expect(getSettings().copilotRootHistory).toEqual(["copilot"]);
+      expect(persistSettingsWithinTransaction).not.toHaveBeenCalled();
       expect(garbageCollectVectorStore).not.toHaveBeenCalled();
     });
   });

--- a/src/settings/copilotRootChange.ts
+++ b/src/settings/copilotRootChange.ts
@@ -1,7 +1,42 @@
 import { logInfo, logWarn } from "@/logger";
-import { normalizeRootFolders, setSettings, validateCopilotFolder } from "@/settings/model";
+import { getCopilotSaveData } from "@/settings/copilotSaveData";
+import {
+  type CopilotSettings,
+  getSettings,
+  normalizeRootFolders,
+  setSettings,
+  validateCopilotFolder,
+} from "@/settings/model";
+import {
+  persistSettingsWithinTransaction,
+  runPersistenceTransaction,
+  suppressNextPersistOnce,
+} from "@/services/settingsPersistence";
 import type { App } from "obsidian";
 import { normalizePath } from "obsidian";
+
+/**
+ * Build the root-change patch: the new root plus its exclusion history (existing
+ * history ∪ the root being left ∪ the new root), normalized. Applied over a
+ * settings snapshot to produce both the durable write and the in-memory update
+ * from that same snapshot, so the two stay consistent.
+ *
+ * @param current - Settings snapshot the patch is derived against.
+ * @param folder - Validated new root.
+ */
+function buildRootPatch(
+  current: Pick<CopilotSettings, "copilotFolder" | "copilotRootHistory">,
+  folder: string
+): Pick<CopilotSettings, "copilotFolder" | "copilotRootHistory"> {
+  return {
+    copilotRootHistory: normalizeRootFolders([
+      ...current.copilotRootHistory,
+      current.copilotFolder,
+      folder,
+    ]),
+    copilotFolder: folder,
+  };
+}
 
 /**
  * Whether `folder` is a root Copilot has used before, per the recorded history.
@@ -58,74 +93,123 @@ export function copilotRootContainsNotes(app: App, folder: string): boolean {
 }
 
 /**
- * Activate a new Copilot root, persisting the QA protection set and the active
- * root together and then garbage-collecting orphaned index docs.
+ * Activate a new Copilot root: durably persist the new root together with its QA
+ * protection history BEFORE it becomes visible to runtime folder resolvers, then
+ * garbage-collect orphaned index docs.
  *
- * The protection set (legacy root + previous root + full history + new root)
- * and the new `copilotFolder` are written in a single atomic settings update,
- * so a persisted snapshot can never show the new root without a history entry
- * that keeps the previous root excluded from QA — there is no half-committed
- * window to activate a root whose history has not landed. Callers must have
- * already run {@link validateCopilotFolder} and the content check; the guard
- * here is defensive and simply refuses to activate an invalid value.
+ * The protection set (legacy root + previous root + full history + new root) and
+ * the new `copilotFolder` are written as one snapshot, so a persisted snapshot
+ * can never show the new root without a history entry that keeps the previous
+ * root excluded from QA. Callers must have already run
+ * {@link validateCopilotFolder} and the content check; the guard here is
+ * defensive and simply refuses to activate an invalid value.
  *
- * DESIGN NOTE — activation is memory-first, not persist-before-activate.
- * `setSettings` only updates the in-memory atom; the disk write is the
- * fire-and-forget `persistSettings` in the settings subscriber (see `main.ts`).
- * (a) The residual risk: if that persist fails AND the user creates new
- *     conversations under the new root during this same session AND then
- *     restarts, the reloaded snapshot still carries the old root/history, so the
- *     leftover new-root content is no longer system-excluded and can leak into
- *     QA search.
- * (b) We deliberately do NOT `await persistSettings` before activating (no GC /
- *     no "success" until disk lands). The persistence architecture is locked to
- *     memory-first, no-rollback-on-failure (see the subscriber comment in
- *     `main.ts`): memory is the source of truth and disk reconciles on the next
- *     successful write. An awaited persist here could not roll the in-memory
- *     root back on failure without violating that invariant, so it would only
- *     relabel the same unavoidable window — not close it — while adding a
- *     module-level `suppressNextPersistOnce` race against the subscriber.
- * (c) Existing mitigations bound the damage: the subscriber surfaces a Notice on
- *     persist failure so the user knows the save did not land; the next
- *     successful persist reconciles disk with memory; and `sanitizeSettings`
- *     idempotently unions the current root back into the protection set on every
- *     load, so a persisted (even if lagging) snapshot never activates a root
- *     whose own path is unprotected.
+ * DESIGN NOTE — activation is persist-before-activate.
+ * The new root must not reach runtime folder resolvers (`getEffective*Folder`)
+ * until the same snapshot is durably on disk.
+ * (a) Closed leak: previously the in-memory root flipped first and the disk
+ *     write was a fire-and-forget subscriber persist. If that write failed and
+ *     the user then wrote chats under the new root and restarted, the reloaded
+ *     old snapshot no longer system-excluded the new root, so those chats leaked
+ *     into QA search. Persisting first removes that window.
+ * (b) Mechanism: the explicit write runs inside {@link runPersistenceTransaction}
+ *     via {@link persistSettingsWithinTransaction} (the in-queue path — the
+ *     public `persistSettings` would deadlock behind the active transaction).
+ *     Only after it resolves do we {@link suppressNextPersistOnce} and
+ *     `setSettings`, so the subscriber's duplicate persist for this same state
+ *     is swallowed. suppression is consumed synchronously by the subscriber in
+ *     the same call stack, so there is no race — the same invariant the keychain
+ *     transactions already rely on.
+ * (c) Failure path: if the write throws, the transaction rejects before
+ *     `setSettings` runs, so the in-memory root is never touched — no rollback
+ *     needed, and the caller keeps the old root and surfaces the failure.
  * (d) If a future review flags this again, point them at this note.
  *
  * DESIGN NOTE — content-check TOCTOU (accepted, not fixed here).
  * The vault-content guard ({@link copilotRootContainsNotes}) runs in the UI
  * before the confirm modal; this Apply layer deliberately does NOT re-run it
- * before `setSettings`.
+ * before activating.
  * (a) Trigger: within the few-second window between the UI content check passing
  *     and the user confirming, Obsidian Sync or another plugin creates notes
  *     under the target root.
  * (b) Consequence: those newly-arrived notes get excluded from QA wholesale when
  *     the root activates. It is fully reversible — pointing the root elsewhere
  *     restores them; no data is lost.
- * (c) Why not fixed: re-validating at the Apply layer means threading `App` +
- *     `Vault` into this function purely to re-scan for a few-second, reversible
- *     window — a cost that does not match the exposure.
+ * (c) Why not fixed: `app` is now in scope, but a re-scan would only narrow, not
+ *     close, the window — vault contents can still change during the async
+ *     persist. Fully closing it would require coordinating with every vault
+ *     writer, which is not justified for this reversible outcome.
  * (d) If a future review flags this again, point them at this note.
  *
+ * @param app - Active Obsidian app; used to resolve the plugin's `saveData`.
  * @param newRoot - The user-entered root; re-validated defensively.
  */
-export async function applyCopilotRootChange(newRoot: string): Promise<void> {
+export async function applyCopilotRootChange(app: App, newRoot: string): Promise<void> {
   const validation = validateCopilotFolder(newRoot);
   if (!validation.ok) {
     logWarn("Copilot root change rejected an invalid folder value.", validation.reason);
     return;
   }
   const folder = validation.folder;
+  const saveData = getCopilotSaveData(app);
 
-  setSettings((current) => ({
-    copilotRootHistory: normalizeRootFolders([
-      ...current.copilotRootHistory,
-      current.copilotFolder,
-      folder,
-    ]),
-    copilotFolder: folder,
-  }));
+  // Persist the new root + history durably before flipping the in-memory root,
+  // so a failed save (which rejects the transaction) leaves the old root active
+  // rather than a session that writes under an unsaved, unprotected root.
+  await runPersistenceTransaction(async () => {
+    const previous = getSettings();
+    const target: CopilotSettings = { ...previous, ...buildRootPatch(previous, folder) };
+    await persistSettingsWithinTransaction(target, saveData, previous);
+
+    // Reconcile with any concurrent settings edits that landed during the
+    // await. The transaction captured `previous` up front; an unrelated
+    // `setSettings()` (theme, prompts, …) during the persist advances in-memory
+    // state, and its queued subscriber persist is dropped by the
+    // `transactionEpoch` guard. Without this step those edits would be lost from
+    // disk if the user quit before the next save. Re-derive from the latest
+    // snapshot and, if it differs from what we just wrote, persist once more so
+    // disk reflects the merged final state.
+    //
+    // DESIGN NOTE — single-round reconcile with a functional activation update.
+    // The reconcile persists once more so concurrent edits reach disk; it does
+    // NOT loop "re-read → persist" until stable, because a stream of edits (e.g.
+    // a slider drag) could keep it from terminating — a livelock risk on the
+    // settings write queue that is not worth closing a millisecond-scale gap.
+    // The residual window: an edit landing during this second persist has its
+    // own queued persist dropped by the `transactionEpoch` guard, so it may not
+    // reach disk until the next settings save. It is NOT lost from memory —
+    // both activation points below apply the root patch with a functional
+    // updater `(current) => buildRootPatch(current, folder)`, which only
+    // overwrites the root-owned fields and preserves whatever else `current`
+    // holds. So the worst case is a disk-lag that the next save reconciles, not
+    // a vanished setting. (Passing the whole `merged` snapshot to `setSettings`
+    // instead would clobber that concurrent edit from memory too — the bug this
+    // note guards against.)
+    // If a future review flags this again, point them at this note.
+    const fresh = getSettings();
+    const merged: CopilotSettings = { ...fresh, ...buildRootPatch(fresh, folder) };
+    if (JSON.stringify(merged) !== JSON.stringify(target)) {
+      try {
+        await persistSettingsWithinTransaction(merged, saveData, target);
+      } catch (reconcileError) {
+        // The first persist already made the root change durable, so the
+        // user-visible operation SUCCEEDED — throwing here would make the
+        // caller report failure (and skip its follow-ups) over a change that
+        // did happen. The only casualty is the concurrent edit's disk copy;
+        // it stays in memory (the functional updater below preserves it) and
+        // the next successful save reconciles it — the same accepted disk-lag
+        // as the second-window note above.
+        logWarn(
+          "Copilot root change: reconcile save for a concurrent edit failed; " +
+            "it stays in memory and lands with the next save.",
+          reconcileError
+        );
+      }
+    }
+
+    suppressNextPersistOnce();
+    setSettings((current) => buildRootPatch(current, folder));
+  });
 
   // Best-effort: drop index docs that the old/new root now excludes. GC is
   // idempotent and the next full index re-runs it, so failures are logged and

--- a/src/settings/copilotRootChange.ts
+++ b/src/settings/copilotRootChange.ts
@@ -53,6 +53,24 @@ function buildRootPatch(
  * @param folder - Candidate root, vault-root-relative.
  * @param history - Recorded `copilotRootHistory` from settings.
  */
+/**
+ * DESIGN NOTE — this comparison is exact-case while
+ * {@link copilotRootContainsNotes} folds case on Windows/macOS. The asymmetry is
+ * deliberate: that one answers COVERAGE (fail-closed — over-excluding is safe),
+ * this one answers IDENTITY and gates an EXEMPTION from the note-content guard,
+ * where the same heuristic inverts. On a case-sensitive macOS volume, folding
+ * here would accept a genuinely different `notes/` as "the `Notes` root I used
+ * before" and skip the guard, activating a Copilot root over the user's real
+ * notes.
+ * Cost of leaving it exact-case: re-activating a historical root under a
+ * different spelling (history holds `teamai`, the user types `TeamAI`) is
+ * refused by the content guard instead of exempted. Recoverable — the original
+ * spelling works — and it fails closed.
+ * The real fix is a filesystem-aware root identity (resolve the candidate to the
+ * actual directory and compare that), which this repo has no facility for and
+ * which touches already-persisted history. Deferred.
+ * If a future review flags the mismatch, point them at this note.
+ */
 export function isKnownCopilotRoot(folder: string, history: readonly string[]): boolean {
   const [normalizedFolder] = normalizeRootFolders([folder]);
   if (!normalizedFolder) return false;

--- a/src/settings/copilotRootChange.ts
+++ b/src/settings/copilotRootChange.ts
@@ -1,4 +1,5 @@
 import { logInfo, logWarn } from "@/logger";
+import { matchSystemRoots } from "@/search/searchUtils";
 import { getCopilotSaveData } from "@/settings/copilotSaveData";
 import {
   type CopilotSettings,
@@ -86,10 +87,11 @@ export function isKnownCopilotRoot(folder: string, history: readonly string[]): 
 export function copilotRootContainsNotes(app: App, folder: string): boolean {
   const root = normalizePath(folder).replace(/\/+$/, "");
   if (root.length === 0) return false;
-  const prefix = `${root}/`;
-  return app.vault
-    .getMarkdownFiles()
-    .some((file) => file.path === root || file.path.startsWith(prefix));
+  // Compared exactly as the exclusion boundary will compare it: that matcher
+  // folds case on case-insensitive filesystems, so an exact-case check here
+  // would clear `Notes` while the vault holds `notes/` — and the very notes this
+  // guard exists to protect would then be excluded from search.
+  return app.vault.getMarkdownFiles().some((file) => matchSystemRoots(file.path, [root]));
 }
 
 /**

--- a/src/settings/copilotRootChange.ts
+++ b/src/settings/copilotRootChange.ts
@@ -13,7 +13,7 @@ import {
   suppressNextPersistOnce,
 } from "@/services/settingsPersistence";
 import type { App } from "obsidian";
-import { normalizePath } from "obsidian";
+import { normalizePath, TFile } from "obsidian";
 
 /**
  * Build the root-change patch: the new root plus its exclusion history (existing
@@ -90,6 +90,38 @@ export function copilotRootContainsNotes(app: App, folder: string): boolean {
   return app.vault
     .getMarkdownFiles()
     .some((file) => file.path === root || file.path.startsWith(prefix));
+}
+
+/**
+ * Find the first prefix of `folder` that already exists as a FILE in the vault,
+ * or null when every existing prefix is a folder (or nothing exists yet).
+ *
+ * Reason: a root like `ai.txt`, or `team/ai` where `team` is a file, passes the
+ * syntax and Markdown-content checks, persists successfully, and then every
+ * folder creation under it fails forever (the sub-folder pre-create only logs,
+ * so the first visible failure is a chat save much later). The Apply layer's
+ * caller uses this to reject the change up front with the conflicting path.
+ *
+ * Residual gaps, accepted: the vault cache doesn't index hidden paths, so a
+ * conflict inside a hidden directory surfaces at adapter write time instead;
+ * and a file inside an existing root that happens to carry a fixed sub-folder
+ * name (e.g. a non-Markdown file literally named `chats`) is not prechecked —
+ * both are rare and fail visibly at the write site.
+ *
+ * @param app - Active Obsidian app, threaded in (never the global `app`).
+ * @param folder - Candidate root, vault-root-relative.
+ */
+export function findCopilotRootFileConflict(app: App, folder: string): string | null {
+  const root = normalizePath(folder).replace(/\/+$/, "");
+  if (root.length === 0) return null;
+  let prefix = "";
+  for (const segment of root.split("/")) {
+    prefix = prefix ? `${prefix}/${segment}` : segment;
+    if (app.vault.getAbstractFileByPath(prefix) instanceof TFile) {
+      return prefix;
+    }
+  }
+  return null;
 }
 
 /**

--- a/src/settings/copilotRootChange.ts
+++ b/src/settings/copilotRootChange.ts
@@ -1,0 +1,141 @@
+import { logInfo, logWarn } from "@/logger";
+import { normalizeRootFolders, setSettings, validateCopilotFolder } from "@/settings/model";
+import type { App } from "obsidian";
+import { normalizePath } from "obsidian";
+
+/**
+ * Whether `folder` is a root Copilot has used before, per the recorded history.
+ *
+ * Reason: a previously-active root still holds the Copilot Markdown it wrote
+ * (chats, memory, prompts) because a root switch never moves files, and that
+ * root stays permanently QA-excluded via `copilotRootHistory`. Re-activating it
+ * therefore introduces no new "ordinary notes silently hidden" risk, so the
+ * caller uses this to skip the {@link copilotRootContainsNotes} guard that would
+ * otherwise reject the switch on its own leftover data. Comparison is done on
+ * the same canonical form the history and QA matcher use.
+ *
+ * @param folder - Candidate root, vault-root-relative.
+ * @param history - Recorded `copilotRootHistory` from settings.
+ */
+export function isKnownCopilotRoot(folder: string, history: readonly string[]): boolean {
+  const [normalizedFolder] = normalizeRootFolders([folder]);
+  if (!normalizedFolder) return false;
+  return normalizeRootFolders(history).includes(normalizedFolder);
+}
+
+/**
+ * App-aware helpers for changing the single configurable Copilot root folder.
+ *
+ * Syntax validation lives in {@link validateCopilotFolder} (pure, in `model`).
+ * This module adds the two pieces that need runtime state:
+ *   1. vault-content validation — reject a root that already holds ordinary
+ *      notes, because activating it would permanently exclude those notes from
+ *      QA search (the root and its history are always system-excluded);
+ *   2. the atomic root switch plus an immediate best-effort garbage-collection
+ *      pass so index docs newly excluded by the change are dropped without
+ *      waiting for the next full index.
+ */
+
+/**
+ * Whether the target root already contains ordinary Markdown notes.
+ *
+ * Reason: once a folder becomes the Copilot root it is system-excluded from QA
+ * indexing wholesale, so pointing the root at a folder that already holds the
+ * user's notes would silently drop them from search. The Apply layer calls this
+ * to reject that case before committing.
+ *
+ * @param app - Active Obsidian app, threaded in (never the global `app`).
+ * @param folder - Candidate root, vault-root-relative.
+ * @returns True when at least one Markdown file lives at or under `folder`.
+ */
+export function copilotRootContainsNotes(app: App, folder: string): boolean {
+  const root = normalizePath(folder).replace(/\/+$/, "");
+  if (root.length === 0) return false;
+  const prefix = `${root}/`;
+  return app.vault
+    .getMarkdownFiles()
+    .some((file) => file.path === root || file.path.startsWith(prefix));
+}
+
+/**
+ * Activate a new Copilot root, persisting the QA protection set and the active
+ * root together and then garbage-collecting orphaned index docs.
+ *
+ * The protection set (legacy root + previous root + full history + new root)
+ * and the new `copilotFolder` are written in a single atomic settings update,
+ * so a persisted snapshot can never show the new root without a history entry
+ * that keeps the previous root excluded from QA — there is no half-committed
+ * window to activate a root whose history has not landed. Callers must have
+ * already run {@link validateCopilotFolder} and the content check; the guard
+ * here is defensive and simply refuses to activate an invalid value.
+ *
+ * DESIGN NOTE — activation is memory-first, not persist-before-activate.
+ * `setSettings` only updates the in-memory atom; the disk write is the
+ * fire-and-forget `persistSettings` in the settings subscriber (see `main.ts`).
+ * (a) The residual risk: if that persist fails AND the user creates new
+ *     conversations under the new root during this same session AND then
+ *     restarts, the reloaded snapshot still carries the old root/history, so the
+ *     leftover new-root content is no longer system-excluded and can leak into
+ *     QA search.
+ * (b) We deliberately do NOT `await persistSettings` before activating (no GC /
+ *     no "success" until disk lands). The persistence architecture is locked to
+ *     memory-first, no-rollback-on-failure (see the subscriber comment in
+ *     `main.ts`): memory is the source of truth and disk reconciles on the next
+ *     successful write. An awaited persist here could not roll the in-memory
+ *     root back on failure without violating that invariant, so it would only
+ *     relabel the same unavoidable window — not close it — while adding a
+ *     module-level `suppressNextPersistOnce` race against the subscriber.
+ * (c) Existing mitigations bound the damage: the subscriber surfaces a Notice on
+ *     persist failure so the user knows the save did not land; the next
+ *     successful persist reconciles disk with memory; and `sanitizeSettings`
+ *     idempotently unions the current root back into the protection set on every
+ *     load, so a persisted (even if lagging) snapshot never activates a root
+ *     whose own path is unprotected.
+ * (d) If a future review flags this again, point them at this note.
+ *
+ * DESIGN NOTE — content-check TOCTOU (accepted, not fixed here).
+ * The vault-content guard ({@link copilotRootContainsNotes}) runs in the UI
+ * before the confirm modal; this Apply layer deliberately does NOT re-run it
+ * before `setSettings`.
+ * (a) Trigger: within the few-second window between the UI content check passing
+ *     and the user confirming, Obsidian Sync or another plugin creates notes
+ *     under the target root.
+ * (b) Consequence: those newly-arrived notes get excluded from QA wholesale when
+ *     the root activates. It is fully reversible — pointing the root elsewhere
+ *     restores them; no data is lost.
+ * (c) Why not fixed: re-validating at the Apply layer means threading `App` +
+ *     `Vault` into this function purely to re-scan for a few-second, reversible
+ *     window — a cost that does not match the exposure.
+ * (d) If a future review flags this again, point them at this note.
+ *
+ * @param newRoot - The user-entered root; re-validated defensively.
+ */
+export async function applyCopilotRootChange(newRoot: string): Promise<void> {
+  const validation = validateCopilotFolder(newRoot);
+  if (!validation.ok) {
+    logWarn("Copilot root change rejected an invalid folder value.", validation.reason);
+    return;
+  }
+  const folder = validation.folder;
+
+  setSettings((current) => ({
+    copilotRootHistory: normalizeRootFolders([
+      ...current.copilotRootHistory,
+      current.copilotFolder,
+      folder,
+    ]),
+    copilotFolder: folder,
+  }));
+
+  // Best-effort: drop index docs that the old/new root now excludes. GC is
+  // idempotent and the next full index re-runs it, so failures are logged and
+  // swallowed rather than retried. Dynamically imported to keep the search
+  // stack out of the settings bundle's eager graph.
+  try {
+    const { default: VectorStoreManager } = await import("@/search/vectorStoreManager");
+    const removed = await VectorStoreManager.getInstance().garbageCollectVectorStore();
+    logInfo(`Copilot root change: garbage collection removed ${removed} stale index docs.`);
+  } catch (error) {
+    logWarn("Copilot root change: garbage collection failed (will retry on next index).", error);
+  }
+}

--- a/src/settings/copilotSaveData.test.ts
+++ b/src/settings/copilotSaveData.test.ts
@@ -1,0 +1,32 @@
+import { getCopilotSaveData } from "@/settings/copilotSaveData";
+import type { CopilotSettings } from "@/settings/model";
+import type { App } from "obsidian";
+
+/** Build an App whose plugin registry returns (or omits) a Copilot plugin. */
+function appWithPlugin(saveData?: (data: CopilotSettings) => Promise<void>): App {
+  return {
+    plugins: {
+      getPlugin: (id: string) => (id === "copilot" && saveData ? { saveData } : null),
+    },
+  } as unknown as App;
+}
+
+describe("copilotSaveData", () => {
+  describe("getCopilotSaveData()", () => {
+    it("returns a writer that delegates to the loaded plugin's saveData", async () => {
+      const pluginSave = jest.fn<Promise<void>, [CopilotSettings]>().mockResolvedValue(undefined);
+      const write = getCopilotSaveData(appWithPlugin(pluginSave));
+      const data = { copilotFolder: "team/copilot" } as CopilotSettings;
+
+      await write(data);
+
+      expect(pluginSave).toHaveBeenCalledWith(data);
+    });
+
+    it("throws when the Copilot plugin is not loaded", async () => {
+      const write = getCopilotSaveData(appWithPlugin(undefined));
+
+      await expect(write({} as CopilotSettings)).rejects.toThrow("Copilot plugin not found");
+    });
+  });
+});

--- a/src/settings/copilotSaveData.ts
+++ b/src/settings/copilotSaveData.ts
@@ -1,0 +1,27 @@
+import type { CopilotSettings } from "@/settings/model";
+import type { App } from "obsidian";
+
+/**
+ * Returns a `saveData` callback bound to the loaded Copilot plugin instance.
+ *
+ * Reason: settings code (React components, the root-change apply layer) doesn't
+ * hold the plugin directly, so persistence transactions look it up via the
+ * Obsidian `App`. The plugin's own `saveData` override must stay the boundary
+ * because it dehydrates device-specific settings before delegating to Obsidian.
+ * Centralising the `app.plugins` cast (untyped in the Obsidian API) and the
+ * "plugin not found" guard here keeps every call site consistent.
+ *
+ * @param app - Active Obsidian app used to locate the loaded plugin.
+ */
+export function getCopilotSaveData(app: App): (data: CopilotSettings) => Promise<void> {
+  return async (data: CopilotSettings) => {
+    const { plugins } = app as unknown as {
+      plugins: {
+        getPlugin: (id: string) => { saveData: (data: CopilotSettings) => Promise<void> } | null;
+      };
+    };
+    const copilotPlugin = plugins.getPlugin("copilot");
+    if (!copilotPlugin) throw new Error("Copilot plugin not found");
+    await copilotPlugin.saveData(data);
+  };
+}

--- a/src/settings/migrations/index.ts
+++ b/src/settings/migrations/index.ts
@@ -10,10 +10,11 @@
  * for a v4 vault picking up the v5 backfill).
  */
 
+import { DEFAULT_COPILOT_FOLDER } from "@/constants";
 import { logInfo } from "@/logger";
 import { seedDocProcessorBackend } from "@/miyo/miyoUtils";
 import type { ModelManagementApi } from "@/modelManagement";
-import { getSettings, setSettings } from "@/settings/model";
+import { getSettings, normalizeRootFolders, setSettings } from "@/settings/model";
 
 import { executeByokMigration } from "./byokMigration";
 import { planRequiresApiKeyBackfill } from "./requiresApiKeyMigration";
@@ -62,6 +63,31 @@ export async function runSettingsMigrations(api: ModelManagementApi): Promise<vo
   // and Sync it to desktop before desktop ever migrates).
   if (fromVersion < 7 && getSettings().enableMiyo === true) {
     setSettings({ enableMiyoSearchSkill: true });
+  }
+
+  // v8: seed the configurable `copilotFolder` root so the derived sub-folder
+  // accessors have a concrete base to resolve against. Old vaults get the
+  // historical hardcoded root, preserving their on-disk layout.
+  if (fromVersion < 8) {
+    setSettings({ copilotFolder: DEFAULT_COPILOT_FOLDER });
+
+    // Seed the root-exclusion history with the legacy + current roots so both
+    // stay permanently excluded from QA indexing after any future root change.
+    const currentRoot = getSettings().copilotFolder;
+    setSettings({
+      copilotRootHistory: normalizeRootFolders([DEFAULT_COPILOT_FOLDER, currentRoot]),
+    });
+
+    // Capture, BEFORE the version bump below drops `fromVersion`, that this
+    // vault predates v8 so WS-D can show the one-time folder-relocation prompt.
+    // Every vault reaching this block is a pre-existing one: fresh installs are
+    // stamped to the current version at bootstrap (settingsPersistence) and
+    // never enter migration. That includes pre-versioned installs (real users
+    // whose data.json predates the `settingsVersion` field → `fromVersion === 0`),
+    // which are the oldest users and the most likely to have customized folders,
+    // so they must get the flag too. WS-D still only prompts users who actually
+    // customized a folder, so a default user is never shown the modal.
+    setSettings({ upgradedToV8FromLegacy: true });
   }
 
   // Bump unconditionally after the migrations so a per-provider failure can't

--- a/src/settings/migrations/runSettingsMigrations.test.ts
+++ b/src/settings/migrations/runSettingsMigrations.test.ts
@@ -5,7 +5,7 @@
  */
 
 import type { CustomModel } from "@/aiParams";
-import { ChatModelProviders, DEFAULT_SETTINGS } from "@/constants";
+import { ChatModelProviders, DEFAULT_COPILOT_FOLDER, DEFAULT_SETTINGS } from "@/constants";
 import type { ModelManagementApi } from "@/modelManagement";
 import { getSettings, setSettings, type CopilotSettings } from "@/settings/model";
 import { Platform } from "obsidian";
@@ -246,4 +246,87 @@ it("v7: keys off persisted enableMiyo, not the mobile-sensitive search backend",
   } finally {
     (Platform as { isMobile: boolean }).isMobile = false;
   }
+});
+
+describe("runSettingsMigrations()", () => {
+  it("v8: seeds copilotFolder for a v7 vault", async () => {
+    // A v7 vault predates the configurable root and must be stamped with the
+    // historical default so the derived sub-folder accessors have a base.
+    mockGetSettings.mockReturnValue(settings({ settingsVersion: 7 }));
+    const { api } = makeApi();
+
+    await runSettingsMigrations(api);
+
+    expect(mockSetSettings).toHaveBeenCalledWith({ copilotFolder: DEFAULT_COPILOT_FOLDER });
+    expect(mockSetSettings).toHaveBeenCalledWith({ settingsVersion: CURRENT_SETTINGS_VERSION });
+  });
+
+  it("v8: seeds copilotFolder for a pre-versioned install", async () => {
+    mockGetSettings.mockReturnValue(settings({ settingsVersion: undefined }));
+    const { api } = makeApi();
+
+    await runSettingsMigrations(api);
+
+    expect(mockSetSettings).toHaveBeenCalledWith({ copilotFolder: DEFAULT_COPILOT_FOLDER });
+  });
+
+  it("v8: does not re-seed copilotFolder for a vault already at the current version", async () => {
+    mockGetSettings.mockReturnValue(settings({ settingsVersion: CURRENT_SETTINGS_VERSION }));
+    const { api } = makeApi();
+
+    await runSettingsMigrations(api);
+
+    const copilotFolderWrite = mockSetSettings.mock.calls.find(
+      (call) => "copilotFolder" in call[0]
+    );
+    expect(copilotFolderWrite).toBeUndefined();
+  });
+
+  it("v8: seeds copilotRootHistory with the legacy and current roots", async () => {
+    mockGetSettings.mockReturnValue(settings({ settingsVersion: 7 }));
+    const { api } = makeApi();
+
+    await runSettingsMigrations(api);
+
+    const historyWrite = mockSetSettings.mock.calls.find(
+      (call) => typeof call[0] === "object" && "copilotRootHistory" in call[0]
+    );
+    const seededHistory = (historyWrite?.[0] as Partial<CopilotSettings> | undefined)
+      ?.copilotRootHistory;
+    expect(seededHistory).toEqual([DEFAULT_COPILOT_FOLDER]);
+  });
+
+  it("v8: flags a legacy vault (v7) as upgraded so WS-D can prompt", async () => {
+    mockGetSettings.mockReturnValue(settings({ settingsVersion: 7 }));
+    const { api } = makeApi();
+
+    await runSettingsMigrations(api);
+
+    expect(mockSetSettings).toHaveBeenCalledWith({ upgradedToV8FromLegacy: true });
+  });
+
+  it("v8: flags a pre-versioned install (version 0) as upgraded so WS-D can prompt", async () => {
+    // A pre-versioned install (settingsVersion absent → `fromVersion === 0`) is a
+    // real user whose data.json predates the version field, not a fresh install:
+    // fresh installs are stamped to the current version at bootstrap and never
+    // reach this migration. So a `0` here IS a legacy vault and must be flagged.
+    mockGetSettings.mockReturnValue(settings({ settingsVersion: undefined }));
+    const { api } = makeApi();
+
+    await runSettingsMigrations(api);
+
+    expect(mockSetSettings).toHaveBeenCalledWith({ upgradedToV8FromLegacy: true });
+  });
+
+  it("v8: does not flag a vault already at the current version", async () => {
+    mockGetSettings.mockReturnValue(settings({ settingsVersion: CURRENT_SETTINGS_VERSION }));
+    const { api } = makeApi();
+
+    await runSettingsMigrations(api);
+
+    const flagWrite = mockSetSettings.mock.calls.find(
+      (call) => "upgradedToV8FromLegacy" in call[0]
+    );
+    expect(flagWrite).toBeUndefined();
+  });
 });

--- a/src/settings/migrations/version.ts
+++ b/src/settings/migrations/version.ts
@@ -15,5 +15,6 @@
  *   5   → backfill `Provider.requiresApiKey` on flagless rows.
  *   6   → seed `docProcessorBackend` from effective Miyo state.
  *   7   → seed `enableMiyoSearchSkill` from persisted `enableMiyo` intent.
+ *   8   → seed `copilotFolder` root so derived sub-folder accessors resolve.
  */
-export const CURRENT_SETTINGS_VERSION = 7;
+export const CURRENT_SETTINGS_VERSION = 8;

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -425,6 +425,26 @@ describe("sanitizeSettings - legacy Miyo settings cleanup", () => {
     expect("enableMiyoSearch" in sanitizedRecord).toBe(false);
   });
 
+  it("defaults a missing or malformed miyoSyncedExclusions to an empty receipt", () => {
+    const withoutReceipt = {
+      ...DEFAULT_SETTINGS,
+      miyoSyncedExclusions: undefined,
+    } as unknown as CopilotSettings;
+    expect(sanitizeSettings(withoutReceipt).miyoSyncedExclusions).toBe("");
+
+    const malformed = {
+      ...DEFAULT_SETTINGS,
+      miyoSyncedExclusions: 42,
+    } as unknown as CopilotSettings;
+    expect(sanitizeSettings(malformed).miyoSyncedExclusions).toBe("");
+
+    const preserved = {
+      ...DEFAULT_SETTINGS,
+      miyoSyncedExclusions: '{"device":"d","roots":[]}',
+    };
+    expect(sanitizeSettings(preserved).miyoSyncedExclusions).toBe('{"device":"d","roots":[]}');
+  });
+
   it("preserves embedding provider migrations while stripping obsolete Miyo keys", () => {
     const legacySettings = {
       ...DEFAULT_SETTINGS,

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -824,10 +824,26 @@ describe("model", () => {
       expect(validateCopilotFolder("a/b|c").ok).toBe(false);
     });
 
+    it("rejects Windows-reserved device names in any segment, any case, with or without extension", () => {
+      expect(validateCopilotFolder("NUL").ok).toBe(false);
+      expect(validateCopilotFolder("team/CON").ok).toBe(false);
+      expect(validateCopilotFolder("con.md").ok).toBe(false);
+      expect(validateCopilotFolder("Com1").ok).toBe(false);
+      // Names that merely CONTAIN a reserved word stay valid.
+      expect(validateCopilotFolder("console").ok).toBe(true);
+      expect(validateCopilotFolder("nul-notes").ok).toBe(true);
+    });
+
+    it("rejects segments ending with a dot or space on every platform", () => {
+      expect(validateCopilotFolder("copilot.").ok).toBe(false);
+      expect(validateCopilotFolder("team /ai").ok).toBe(false);
+      expect(validateCopilotFolder("team./ai").ok).toBe(false);
+    });
+
     it("agrees with sanitizeSettings on the copilotFolder fallback contract", () => {
       // sanitizeSettings must coerce every value validateCopilotFolder rejects to
       // the default; a value it accepts must survive verbatim.
-      for (const value of ["../escape", "/etc/passwd", "C:/x", ""]) {
+      for (const value of ["../escape", "/etc/passwd", "C:/x", "", "NUL", "copilot."]) {
         const out = sanitizeSettings({ ...DEFAULT_SETTINGS, copilotFolder: value });
         expect(out.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
       }

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -6,9 +6,14 @@ import {
   SEND_SHORTCUT,
 } from "@/constants";
 import {
+  normalizeRootFolders,
+  resetSettings,
   sanitizeEnvOverrides,
   sanitizeQaExclusions,
   sanitizeSettings,
+  settingsAtom,
+  settingsStore,
+  validateCopilotFolder,
   CopilotSettings,
 } from "@/settings/model";
 import { getEffectiveUserPrompt, getSystemPrompt } from "@/system-prompts/systemPromptBuilder";
@@ -51,10 +56,15 @@ describe("sanitizeQaExclusions", () => {
 
     const sanitized = sanitizeQaExclusions(rawValue);
 
-    expect(sanitized.split(",")).toEqual([
-      encodeURIComponent("folder/"),
-      encodeURIComponent(COPILOT_FOLDER_ROOT),
-    ]);
+    expect(sanitized.split(",")).toEqual([encodeURIComponent("folder/")]);
+  });
+
+  it("no longer force-injects the copilot root (system exclusion covers it)", () => {
+    const rawValue = encodeURIComponent("folder");
+
+    const sanitized = sanitizeQaExclusions(rawValue);
+
+    expect(sanitized.split(",")).toEqual([encodeURIComponent("folder")]);
   });
 });
 
@@ -661,5 +671,210 @@ describe("sanitizeSettings - docProcessorBackend (v6 field)", () => {
       docProcessorBackend: "miyo",
     });
     expect(out.docProcessorBackend).toBe("miyo");
+  });
+});
+
+describe("model", () => {
+  describe("sanitizeSettings()", () => {
+    it("defaults to the historical root when empty", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        copilotFolder: "",
+      });
+      expect(out.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
+    });
+
+    it("defaults to the historical root when whitespace-only", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        copilotFolder: "   ",
+      });
+      expect(out.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
+    });
+
+    it("trims surrounding whitespace from a custom value", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        copilotFolder: "  my-ai  ",
+      });
+      expect(out.copilotFolder).toBe("my-ai");
+    });
+
+    it("preserves a nested custom value", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        copilotFolder: "notes/ai",
+      });
+      expect(out.copilotFolder).toBe("notes/ai");
+    });
+
+    it("rejects a parent-traversal path", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        copilotFolder: "../escape",
+      });
+      expect(out.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
+    });
+
+    it("rejects a Windows drive-absolute path", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        copilotFolder: "C:/Users/evil",
+      });
+      expect(out.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
+    });
+
+    it("rejects a Unix-absolute path", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        copilotFolder: "/etc/passwd",
+      });
+      expect(out.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
+    });
+    it("unions the active root into a normalized, deduped history", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        copilotFolder: "team-ai",
+        copilotRootHistory: ["copilot", "ai", "copilot"],
+      });
+      expect(new Set(out.copilotRootHistory)).toEqual(new Set(["copilot", "ai", "team-ai"]));
+    });
+
+    it("guarantees the active root is present even when history is missing", () => {
+      const raw = { ...DEFAULT_SETTINGS, copilotFolder: "ai" } as unknown as Record<
+        string,
+        unknown
+      >;
+      delete raw.copilotRootHistory;
+      const out = sanitizeSettings(raw as unknown as CopilotSettings);
+      expect(out.copilotRootHistory).toContain("ai");
+    });
+
+    it("coerces a non-boolean upgrade flag to the default", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        upgradedToV8FromLegacy: undefined,
+      } as unknown as CopilotSettings);
+      expect(out.upgradedToV8FromLegacy).toBe(false);
+    });
+
+    it("preserves a true upgrade flag", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        upgradedToV8FromLegacy: true,
+      });
+      expect(out.upgradedToV8FromLegacy).toBe(true);
+    });
+  });
+
+  describe("validateCopilotFolder()", () => {
+    it("rejects empty and whitespace-only values", () => {
+      expect(validateCopilotFolder("").ok).toBe(false);
+      expect(validateCopilotFolder("   ").ok).toBe(false);
+    });
+
+    it("accepts a simple relative folder and trims it", () => {
+      expect(validateCopilotFolder("  my-ai  ")).toEqual({ ok: true, folder: "my-ai" });
+    });
+
+    it("accepts a nested relative folder and strips a trailing slash", () => {
+      expect(validateCopilotFolder("notes/ai/")).toEqual({ ok: true, folder: "notes/ai" });
+    });
+
+    it("rejects parent-traversal, absolute, and drive-letter paths", () => {
+      expect(validateCopilotFolder("../escape").ok).toBe(false);
+      expect(validateCopilotFolder("a/../b").ok).toBe(false);
+      expect(validateCopilotFolder("/etc/passwd").ok).toBe(false);
+      expect(validateCopilotFolder("C:/Users/evil").ok).toBe(false);
+    });
+
+    it("rejects a lone dot segment", () => {
+      expect(validateCopilotFolder("a/./b").ok).toBe(false);
+    });
+
+    it("rejects the Obsidian config folder case-insensitively", () => {
+      // eslint-disable-next-line obsidianmd/hardcoded-config-path -- the test asserts rejection of the conventional config dir literal
+      expect(validateCopilotFolder(".obsidian").ok).toBe(false);
+      expect(validateCopilotFolder(".Obsidian/plugins").ok).toBe(false);
+    });
+
+    it("rejects Windows-illegal characters in any segment", () => {
+      expect(validateCopilotFolder("a/b<c").ok).toBe(false);
+      expect(validateCopilotFolder('a/b"c').ok).toBe(false);
+      expect(validateCopilotFolder("a/b|c").ok).toBe(false);
+    });
+
+    it("agrees with sanitizeSettings on the copilotFolder fallback contract", () => {
+      // sanitizeSettings must coerce every value validateCopilotFolder rejects to
+      // the default; a value it accepts must survive verbatim.
+      for (const value of ["../escape", "/etc/passwd", "C:/x", ""]) {
+        const out = sanitizeSettings({ ...DEFAULT_SETTINGS, copilotFolder: value });
+        expect(out.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
+      }
+      const kept = sanitizeSettings({ ...DEFAULT_SETTINGS, copilotFolder: "team/ai" });
+      expect(kept.copilotFolder).toBe("team/ai");
+    });
+  });
+
+  describe("normalizeRootFolders()", () => {
+    it("preserves case and strips trailing slashes without lowercasing", () => {
+      expect(normalizeRootFolders(["Copilot/", "ai//"])).toEqual(["Copilot", "ai"]);
+    });
+
+    it("dedupes case-sensitively, preserving first-seen order", () => {
+      expect(normalizeRootFolders(["copilot", "ai", "copilot", "Copilot"])).toEqual([
+        "copilot",
+        "ai",
+        "Copilot",
+      ]);
+    });
+
+    it("drops empty, non-string, and vault-escaping entries", () => {
+      expect(
+        normalizeRootFolders([
+          "",
+          "   ",
+          undefined,
+          "../escape",
+          "a/../b",
+          "/etc",
+          "C:\\Users\\Josh",
+          "notes/ai",
+        ])
+      ).toEqual(["notes/ai"]);
+    });
+
+    it("collapses interior duplicate slashes into the matcher's canonical form", () => {
+      expect(normalizeRootFolders(["a//b"])).toEqual(["a/b"]);
+    });
+
+    it("strips interior single-dot segments into the matcher's canonical form", () => {
+      expect(normalizeRootFolders(["a/./b"])).toEqual(["a/b"]);
+    });
+
+    it("leaves an already-canonical legitimate root unchanged", () => {
+      expect(normalizeRootFolders(["a/b"])).toEqual(["a/b"]);
+    });
+
+    it("canonicalizes before deduping and traversal filtering", () => {
+      expect(normalizeRootFolders(["a//b", "a/./b", "x/../y", "a/b"])).toEqual(["a/b"]);
+    });
+  });
+
+  describe("resetSettings()", () => {
+    it("preserves historical roots and folds in the pre-reset active root", () => {
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        copilotFolder: "team-ai",
+        copilotRootHistory: ["copilot", "ai"],
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      expect(after.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
+      // Legacy + historical + pre-reset active root all survive the reset.
+      expect(new Set(after.copilotRootHistory)).toEqual(new Set(["copilot", "ai", "team-ai"]));
+    });
   });
 });

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -1136,6 +1136,10 @@ function sanitizeAgentMode(raw: unknown): CopilotSettings["agentMode"] {
  * embedded literal control bytes, which made the source file binary and
  * missed DEL.
  */
+// Names Windows reserves at any path depth, with or without an extension —
+// creating `NUL` or `con.md` fails or misbehaves at the filesystem layer.
+const WINDOWS_RESERVED_NAME_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
+
 // eslint-disable-next-line no-control-regex
 const CONTROL_CHAR_RE = /[\u0000-\u001f\u007f]/;
 
@@ -1286,6 +1290,16 @@ export function validateCopilotFolder(
         ok: false,
         reason: 'Folder path contains characters not allowed in folder names (< > : " | ? *).',
       };
+    }
+    // Rejected on every platform, not just Windows: vaults sync across
+    // machines, so a root that persists fine on macOS would then fail every
+    // folder creation on a Windows device — the same silent, persistent
+    // write-failure mode as pointing the root at an existing file.
+    if (/[. ]$/.test(segment)) {
+      return { ok: false, reason: "Folder names cannot end with a dot or space." };
+    }
+    if (WINDOWS_RESERVED_NAME_RE.test(segment)) {
+      return { ok: false, reason: `"${segment}" is a name reserved by Windows.` };
     }
   }
   return { ok: true, folder: cleaned };

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -1265,16 +1265,23 @@ export function validateCopilotFolder(
       return { ok: false, reason: 'Folder path cannot contain "." segments.' };
     }
     // DESIGN NOTE — leading-dot (hidden) folder names are deliberately
-    // ACCEPTED. Hidden chat folders are a supported upstream capability
-    // (#2188/#2204 added adapter-based save/history precisely because
-    // Obsidian's Vault cache does not track hidden paths), and the chat,
-    // project, and skill stores all carry adapter fallbacks. Custom-command
-    // and system-prompt discovery still enumerate via `vault.getFiles()`, so
-    // those two features cannot see content under a hidden root — a
-    // pre-existing Vault-cache limitation that the single-root design now
-    // couples to the same folder choice. Rejecting dot segments here would
-    // regress the supported hidden-chat capability; porting command/prompt
-    // discovery to adapter scans is a follow-up outside this PR's scope.
+    // ACCEPTED.
+    // Trigger: a root such as `.copilot` places every derived store under a
+    // path Obsidian omits from the Vault cache.
+    // Assessment: chat, projects, and skills carry adapter-backed hidden-path
+    // support. Custom commands and system prompts do not — and the gap is wider
+    // than discovery: `loadAllCustomCommands` / `loadAllSystemPrompts` enumerate
+    // `vault.getFiles()`, while their create/update/delete paths also rely on
+    // cached `TFile`s, metadataCache, and `processFrontMatter`. Under a hidden
+    // root both can therefore read as empty AND fail to edit reliably.
+    // Scope: the Vault-cache limitation predates this PR — the old
+    // `customPromptsFolder` / `userSystemPromptsFolder` settings accepted hidden
+    // paths too. What the single-root design adds is the coupling: a root chosen
+    // for the supported hidden-chat capability now drags these two along.
+    // Why not fixed here: rejecting dot segments would regress supported hidden
+    // chats, and a scanner-only patch would leave them listable but not
+    // editable — real support needs adapter-backed CRUD plus frontmatter
+    // handling. Deferred as a follow-up.
     // If a future review flags this again, point them at this note.
     if (segment.toLowerCase() === CONVENTIONAL_OBSIDIAN_CONFIG_DIR) {
       return {

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -1260,6 +1260,18 @@ export function validateCopilotFolder(
     if (segment === ".") {
       return { ok: false, reason: 'Folder path cannot contain "." segments.' };
     }
+    // DESIGN NOTE — leading-dot (hidden) folder names are deliberately
+    // ACCEPTED. Hidden chat folders are a supported upstream capability
+    // (#2188/#2204 added adapter-based save/history precisely because
+    // Obsidian's Vault cache does not track hidden paths), and the chat,
+    // project, and skill stores all carry adapter fallbacks. Custom-command
+    // and system-prompt discovery still enumerate via `vault.getFiles()`, so
+    // those two features cannot see content under a hidden root — a
+    // pre-existing Vault-cache limitation that the single-root design now
+    // couples to the same folder choice. Rejecting dot segments here would
+    // regress the supported hidden-chat capability; porting command/prompt
+    // discovery to adapter scans is a follow-up outside this PR's scope.
+    // If a future review flags this again, point them at this note.
     if (segment.toLowerCase() === CONVENTIONAL_OBSIDIAN_CONFIG_DIR) {
       return {
         ok: false,

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -182,6 +182,13 @@ export interface CopilotSettings {
   selfHostApiKey: string;
   /** Custom Miyo server URL, e.g. "http://192.168.1.10:8742" (empty = use local service discovery) */
   miyoServerUrl: string;
+  /**
+   * Fingerprint of the system root exclusions last successfully synced to the
+   * registered Miyo folder (empty = never synced). Compared against the current
+   * fingerprint to detect that Miyo's server-side exclusions went stale after a
+   * Copilot root change; see `getMiyoExclusionsFingerprint` in miyoUtils.
+   */
+  miyoSyncedExclusions: string;
   /** Which provider to use for self-host web search */
   selfHostSearchProvider: "firecrawl" | "perplexity";
   /** Firecrawl API key for self-host web search */
@@ -804,6 +811,11 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
   // Ensure miyoServerUrl has a default value
   if (typeof sanitizedSettings.miyoServerUrl !== "string") {
     sanitizedSettings.miyoServerUrl = DEFAULT_SETTINGS.miyoServerUrl;
+  }
+
+  // Ensure miyoSyncedExclusions has a default value
+  if (typeof sanitizedSettings.miyoSyncedExclusions !== "string") {
+    sanitizedSettings.miyoSyncedExclusions = DEFAULT_SETTINGS.miyoSyncedExclusions;
   }
 
   // Ensure selfHostSearchProvider is a valid value

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -10,7 +10,6 @@ import {
   AGENT_MAX_ITERATIONS_LIMIT,
   BUILTIN_CHAT_MODELS,
   BUILTIN_EMBEDDING_MODELS,
-  COPILOT_FOLDER_ROOT,
   DEFAULT_OPEN_AREA,
   DEFAULT_QA_EXCLUSIONS_SETTING,
   DEFAULT_SETTINGS,
@@ -85,6 +84,33 @@ export interface CopilotSettings {
   openAIProxyBaseUrl: string;
   openAIEmbeddingProxyBaseUrl: string;
   stream: boolean;
+  /** Configurable root folder all Copilot sub-folders derive from (default: "copilot"). */
+  copilotFolder: string;
+  /**
+   * Every folder that has ever been the Copilot root (seeded with the legacy
+   * `copilot` root in the v8 migration). Append-only: once a folder has held
+   * Copilot data it stays here so it remains permanently excluded from QA
+   * indexing, even after the root is changed away from it.
+   *
+   * DESIGN NOTE — this list is best-effort under multi-device Sync. Two offline
+   * devices that each change to a different root can have one branch's history
+   * overwritten by a covering Sync merge; the startup union in
+   * {@link sanitizeSettings} only re-adds THIS device's current root, so a root
+   * that only ever existed on the overwritten device can't be recovered.
+   * Accepted as a residual because changing the root at all is rare, and two
+   * devices concurrently changing to different roots rarer still.
+   *
+   * A second residual — a local persist failure activating a new root in memory
+   * before its history lands on disk — is documented at the activation site in
+   * {@link applyCopilotRootChange}; see that note before re-litigating whether
+   * the switch should persist before activating.
+   */
+  copilotRootHistory: string[];
+  /**
+   * True only when a legacy (v1-v7) vault was migrated to v8. Consumed once by
+   * the v3->v4 upgrade prompt (WS-D), which clears it back to false.
+   */
+  upgradedToV8FromLegacy: boolean;
   defaultSaveFolder: string;
   defaultConversationTag: string;
   autosaveChat: boolean;
@@ -423,6 +449,56 @@ const EMPTY_PROVIDERS = Object.freeze({}) as unknown as Record<string, Provider>
 const EMPTY_CONFIGURED_MODELS = Object.freeze([]) as unknown as ConfiguredModel[];
 const EMPTY_BACKENDS = Object.freeze({}) as unknown as Partial<Record<BackendType, BackendConfig>>;
 
+/** Frozen fallback for an empty {@link CopilotSettings.copilotRootHistory}. */
+const EMPTY_COPILOT_ROOT_HISTORY = Object.freeze([]) as unknown as string[];
+
+/**
+ * Canonicalize Copilot root-folder paths into the form the QA folder matcher
+ * (`matchFilePathWithFolders`) compares against: forward slashes, collapsed
+ * duplicate separators, no `.` segments, no trailing slash, and case preserved
+ * (the matcher is case-sensitive, so lowercasing here would break exact-root
+ * matching). Collapsing `//` and dropping `.` segments matters because history
+ * entries can arrive from Obsidian Sync merges or hand-edited `data.json` in a
+ * non-`normalizePath` form (e.g. `a//b`, `a/./b`); real file paths are compared
+ * post-`normalizePath`, so an un-collapsed root would fail the prefix match and
+ * silently leak that root's notes into QA. Legitimate roots already pass through
+ * `validateCopilotFolder` free of `//`/`.` segments, so this is a no-op for them
+ * and only repairs anomalous entries. Entries that are empty or escape the vault
+ * root (parent traversal, drive-absolute, or root-absolute paths) are dropped
+ * rather than coerced to a default, and duplicates are removed preserving
+ * first-seen order.
+ *
+ * @param input - Raw root paths; non-string, empty, and unsafe entries are skipped.
+ * @returns A deduped, normalized list, or a frozen empty constant when none survive.
+ */
+export function normalizeRootFolders(input: readonly (string | undefined)[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== "string") continue;
+    // Reason: collapse `//` and strip `.` segments so anomalous history entries
+    // land in the same canonical form the QA matcher compares real paths against.
+    const normalized = raw
+      .trim()
+      .replace(/\\/g, "/")
+      .replace(/\/+/g, "/")
+      .split("/")
+      .filter((segment) => segment !== ".")
+      .join("/")
+      .replace(/\/+$/, "");
+    if (normalized.length === 0) continue;
+    const escapesVault =
+      /(^|\/)\.\.(\/|$)/.test(normalized) ||
+      /^[a-zA-Z]:/.test(normalized) ||
+      normalized.startsWith("/");
+    if (escapesVault) continue;
+    if (seen.has(normalized)) continue;
+    seen.add(normalized);
+    result.push(normalized);
+  }
+  return result.length > 0 ? result : EMPTY_COPILOT_ROOT_HISTORY;
+}
+
 /**
  * Resolve a valid embedding model key for the current settings.
  *
@@ -460,7 +536,15 @@ export function setSettings(
 }
 
 /**
- * Normalize QA exclusion patterns and guarantee the Copilot folder root is excluded.
+ * Normalize the user's QA exclusion patterns (dedupe by canonical path key,
+ * preserving a single trailing slash when the user wrote one).
+ *
+ * The Copilot root itself is NOT forced in here anymore: the always-on system
+ * exclusion ({@link getSystemExcludedFolders} in `searchUtils`) permanently
+ * excludes the `copilot` root plus the active and historical roots, so this
+ * function only has to canonicalize what the user typed. A user-supplied
+ * `copilot` entry is kept as-is and simply overlaps the system exclusion.
+ *
  * @param rawValue - Persisted QA exclusion setting value.
  * @returns Encoded QA exclusion patterns string.
  */
@@ -477,18 +561,12 @@ export function sanitizeQaExclusions(rawValue: unknown): string {
   decodedPatterns.forEach((pattern) => {
     const canonical = pattern.replace(/\/+$/, "");
     const canonicalKey = canonical.length > 0 ? canonical : pattern;
-    if (canonicalKey === COPILOT_FOLDER_ROOT) {
-      canonicalToOriginalPattern.set(COPILOT_FOLDER_ROOT, COPILOT_FOLDER_ROOT);
-      return;
-    }
     if (!canonicalToOriginalPattern.has(canonicalKey)) {
       const normalizedValue =
         canonical.length > 0 && pattern.endsWith("/") ? `${canonical}/` : pattern;
       canonicalToOriginalPattern.set(canonicalKey, normalizedValue);
     }
   });
-
-  canonicalToOriginalPattern.set(COPILOT_FOLDER_ROOT, COPILOT_FOLDER_ROOT);
 
   return Array.from(canonicalToOriginalPattern.values())
     .map((pattern) => encodeURIComponent(pattern))
@@ -541,10 +619,20 @@ export function getSettings(): Readonly<CopilotSettings> {
  * If a future review flags this again, point them at this note.
  */
 export function resetSettings(): void {
+  const current = getSettings();
+  // Reset is a deterministic path, not best-effort: preserve the root-exclusion
+  // history and fold in the pre-reset active root before it is replaced by the
+  // default. Otherwise a reset would drop every historical root and leave that
+  // still-on-disk content exposed to QA indexing.
+  const preservedRootHistory = normalizeRootFolders([
+    ...(Array.isArray(current.copilotRootHistory) ? current.copilotRootHistory : []),
+    current.copilotFolder,
+  ]);
   const defaultSettingsWithBuiltIns = {
     ...DEFAULT_SETTINGS,
     activeModels: BUILTIN_CHAT_MODELS.map((model) => ({ ...model, enabled: true })),
     activeEmbeddingModels: BUILTIN_EMBEDDING_MODELS.map((model) => ({ ...model, enabled: true })),
+    copilotRootHistory: preservedRootHistory,
   };
   setSettings(defaultSettingsWithBuiltIns);
 }
@@ -850,6 +938,34 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
     sanitizedSettings.defaultSendShortcut = DEFAULT_SETTINGS.defaultSendShortcut;
   }
 
+  // Coerce copilotFolder to a valid vault-relative path. validateCopilotFolder
+  // is the single source of truth for root syntax (empty, traversal, absolute,
+  // .obsidian, control/Windows-illegal chars) shared with the settings UI; an
+  // invalid persisted value falls back to the default rather than being trusted.
+  const copilotFolderValidation = validateCopilotFolder(
+    typeof settingsToSanitize.copilotFolder === "string" ? settingsToSanitize.copilotFolder : ""
+  );
+  sanitizedSettings.copilotFolder = copilotFolderValidation.ok
+    ? copilotFolderValidation.folder
+    : DEFAULT_SETTINGS.copilotFolder;
+
+  // Normalize the append-only root history and idempotently union in the
+  // active root, so this device's current root is always present in its own
+  // history (the load-time self-heal referenced in the field's DESIGN NOTE).
+  // These roots are excluded from QA indexing permanently — see
+  // getSystemExcludedFolders in searchUtils.
+  const rawRootHistory = Array.isArray(settingsToSanitize.copilotRootHistory)
+    ? settingsToSanitize.copilotRootHistory
+    : [];
+  sanitizedSettings.copilotRootHistory = normalizeRootFolders([
+    ...rawRootHistory,
+    sanitizedSettings.copilotFolder,
+  ]);
+
+  if (typeof sanitizedSettings.upgradedToV8FromLegacy !== "boolean") {
+    sanitizedSettings.upgradedToV8FromLegacy = DEFAULT_SETTINGS.upgradedToV8FromLegacy;
+  }
+
   // Ensure folder settings fall back to defaults when empty/whitespace
   const saveFolder = (settingsToSanitize.defaultSaveFolder || "").trim();
   sanitizedSettings.defaultSaveFolder =
@@ -1012,6 +1128,15 @@ function sanitizeAgentMode(raw: unknown): CopilotSettings["agentMode"] {
 const CONTROL_CHAR_RE = /[\u0000-\u001f\u007f]/;
 
 /**
+ * The conventional Obsidian config-folder name, rejected as a Copilot root so a
+ * misconfigured root can't collide with Obsidian's own config. This is a pure,
+ * Vault-less syntax check, so it can only guard the near-universal default —
+ * users who relocated their config dir get no false positive here.
+ */
+// eslint-disable-next-line obsidianmd/hardcoded-config-path -- pure validator has no Vault to read configDir; guard the conventional default
+const CONVENTIONAL_OBSIDIAN_CONFIG_DIR = ".obsidian";
+
+/**
  * Validate a user-entered "Skills folder" value against the rules in
  * `designdocs/SKILLS_MANAGEMENT.md` §Skills folder setting.
  *
@@ -1076,6 +1201,69 @@ export function validateSkillsFolder(
     }
   }
 
+  return { ok: true, folder: cleaned };
+}
+
+/**
+ * Validate a user-entered Copilot root folder (`copilotFolder`) for syntax
+ * only — the reusable check shared by `sanitizeSettings` (every load / Sync /
+ * hand-edited data.json passes through it) and the settings UI for early
+ * feedback before Apply. Vault-content checks that need App/Vault access
+ * (rejecting a root that already holds ordinary notes) live in
+ * `copilotRootChange`, not here.
+ *
+ * Unlike {@link validateSkillsFolder}, absolute and drive-letter paths are
+ * rejected rather than stripped: the root is the trust boundary every derived
+ * sub-folder inherits, so a leading-slash value is treated as a mistake to
+ * surface, not silently rewritten. The `.obsidian` config folder is rejected
+ * to keep Copilot data from colliding with Obsidian's own config.
+ *
+ * @param value Raw user input.
+ * @returns `{ ok: true, folder }` with the trimmed, trailing-slash-stripped
+ *   value, or `{ ok: false, reason }` carrying a UI-ready message.
+ */
+export function validateCopilotFolder(
+  value: string
+): { ok: true; folder: string } | { ok: false; reason: string } {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return { ok: false, reason: "Folder name cannot be empty." };
+  }
+  const trimmed = value.trim();
+  // Reject (do not strip) absolute and drive-letter paths so a root can never
+  // escape the vault; a stray leading slash is surfaced as an error instead.
+  if (/^[/\\]/.test(trimmed) || /^[a-zA-Z]:/.test(trimmed)) {
+    return { ok: false, reason: "Folder path must be relative to the vault root." };
+  }
+  const cleaned = trimmed.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (cleaned.length === 0) {
+    return { ok: false, reason: "Folder name cannot be empty." };
+  }
+  for (const segment of cleaned.split("/")) {
+    if (segment.length === 0) {
+      return { ok: false, reason: "Folder path cannot contain empty segments (//)." };
+    }
+    if (segment === "..") {
+      return { ok: false, reason: 'Folder path cannot contain ".." segments.' };
+    }
+    if (segment === ".") {
+      return { ok: false, reason: 'Folder path cannot contain "." segments.' };
+    }
+    if (segment.toLowerCase() === CONVENTIONAL_OBSIDIAN_CONFIG_DIR) {
+      return {
+        ok: false,
+        reason: "Folder path cannot use the Obsidian config folder.",
+      };
+    }
+    if (CONTROL_CHAR_RE.test(segment)) {
+      return { ok: false, reason: "Folder path contains illegal control characters." };
+    }
+    if (/[<>:"|?*]/.test(segment)) {
+      return {
+        ok: false,
+        reason: 'Folder path contains characters not allowed in folder names (< > : " | ? *).',
+      };
+    }
+  }
   return { ok: true, folder: cleaned };
 }
 

--- a/src/settings/upgradeNotice.test.ts
+++ b/src/settings/upgradeNotice.test.ts
@@ -1,0 +1,187 @@
+import type { CopilotSettings } from "@/settings/model";
+import { buildUpgradeRelocationEntries } from "@/settings/upgradeNotice";
+
+jest.mock("obsidian", () => ({
+  // Collapse duplicate separators and trim edges the way Obsidian's helper does,
+  // enough for the derived-path assertions here.
+  normalizePath: (path: string) => path.replace(/\/+/g, "/").replace(/^\/|\/$/g, ""),
+}));
+
+// The pure helpers never read the global store, but copilotFolder.ts imports it.
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(),
+}));
+
+/**
+ * Build the settings slice the upgrade notice reads. Defaults every folder to
+ * its historical legacy default under the seeded "copilot" root, so a test only
+ * overrides the fields it wants to treat as customized.
+ */
+function buildSettings(
+  overrides: Partial<{
+    copilotFolder: string;
+    defaultSaveFolder: string;
+    customPromptsFolder: string;
+    userSystemPromptsFolder: string;
+    skillsFolder: string;
+    memoryFolderName: string;
+  }> = {}
+): CopilotSettings {
+  const {
+    copilotFolder = "copilot",
+    defaultSaveFolder = "copilot/copilot-conversations",
+    customPromptsFolder = "copilot/copilot-custom-prompts",
+    userSystemPromptsFolder = "copilot/system-prompts",
+    skillsFolder = "copilot/skills",
+    memoryFolderName = "copilot/memory",
+  } = overrides;
+  return {
+    copilotFolder,
+    defaultSaveFolder,
+    customPromptsFolder,
+    userSystemPromptsFolder,
+    memoryFolderName,
+    agentMode: { skills: { folder: skillsFolder } },
+  } as unknown as CopilotSettings;
+}
+
+describe("upgradeNotice", () => {
+  describe("buildUpgradeRelocationEntries()", () => {
+    it("returns no entries when every folder is at its legacy default", () => {
+      expect(buildUpgradeRelocationEntries(buildSettings())).toEqual([]);
+    });
+
+    it("reports a single customized folder with its old value and derived new path", () => {
+      const entries = buildUpgradeRelocationEntries(
+        buildSettings({ defaultSaveFolder: "my-notes/chats" })
+      );
+      expect(entries).toEqual([
+        {
+          label: "Chat conversations",
+          oldPath: "my-notes/chats",
+          newPath: "copilot/copilot-conversations",
+        },
+      ]);
+    });
+
+    it("reports every customized folder while omitting the untouched ones", () => {
+      const entries = buildUpgradeRelocationEntries(
+        buildSettings({
+          customPromptsFolder: "prompts",
+          userSystemPromptsFolder: "sys",
+          skillsFolder: "my-skills",
+        })
+      );
+      expect(entries).toEqual([
+        { label: "Custom prompts", oldPath: "prompts", newPath: "copilot/copilot-custom-prompts" },
+        { label: "System prompts", oldPath: "sys", newPath: "copilot/system-prompts" },
+        { label: "Agent skills", oldPath: "my-skills", newPath: "copilot/skills" },
+      ]);
+    });
+
+    it("lists every sub-folder when the root moves, since they all relocate", () => {
+      // Re-rooting to team/ai moves all sub-folders: each old copilot/<name>
+      // no longer equals the new team/ai/<name>, so all five are surfaced. The
+      // conversations entry additionally reflects the separately-customized old
+      // value.
+      const entries = buildUpgradeRelocationEntries(
+        buildSettings({ copilotFolder: "team/ai", defaultSaveFolder: "old/chats" })
+      );
+      expect(entries).toEqual([
+        {
+          label: "Chat conversations",
+          oldPath: "old/chats",
+          newPath: "team/ai/copilot-conversations",
+        },
+        {
+          label: "Custom prompts",
+          oldPath: "copilot/copilot-custom-prompts",
+          newPath: "team/ai/copilot-custom-prompts",
+        },
+        {
+          label: "System prompts",
+          oldPath: "copilot/system-prompts",
+          newPath: "team/ai/system-prompts",
+        },
+        { label: "Agent skills", oldPath: "copilot/skills", newPath: "team/ai/skills" },
+        { label: "Memory", oldPath: "copilot/memory", newPath: "team/ai/memory" },
+      ]);
+    });
+
+    it("surfaces a customized memory folder, since the new manager reads the derived path", () => {
+      // A vault upgraded from a release whose Plus settings exposed "Memory
+      // Folder Name" can carry a non-default memoryFolderName; the new manager
+      // reads copilot/memory instead, so the old data must be flagged to move.
+      const entries = buildUpgradeRelocationEntries(
+        buildSettings({ memoryFolderName: "my-memory" })
+      );
+      expect(entries).toEqual([
+        { label: "Memory", oldPath: "my-memory", newPath: "copilot/memory" },
+      ]);
+    });
+
+    it("omits memory when its stored value is the legacy default", () => {
+      expect(
+        buildUpgradeRelocationEntries(buildSettings({ memoryFolderName: "copilot/memory" }))
+      ).toEqual([]);
+    });
+
+    it("omits folders whose old value already equals the derived new path", () => {
+      // The user re-rooted to team/ai and their stored sub-folder values already
+      // equal the paths that root now derives to — nothing to move, so the
+      // notice lists nothing.
+      const entries = buildUpgradeRelocationEntries(
+        buildSettings({
+          copilotFolder: "team/ai",
+          defaultSaveFolder: "team/ai/copilot-conversations",
+          customPromptsFolder: "team/ai/copilot-custom-prompts",
+          userSystemPromptsFolder: "team/ai/system-prompts",
+          skillsFolder: "team/ai/skills",
+          memoryFolderName: "team/ai/memory",
+        })
+      );
+      expect(entries).toEqual([]);
+    });
+
+    it("does not flag a default folder that differs only by a trailing slash", () => {
+      expect(
+        buildUpgradeRelocationEntries(
+          buildSettings({ defaultSaveFolder: "copilot/copilot-conversations/" })
+        )
+      ).toEqual([]);
+    });
+
+    it("does not flag a default folder that differs only by a trailing slash then whitespace", () => {
+      expect(
+        buildUpgradeRelocationEntries(
+          buildSettings({ defaultSaveFolder: "copilot/copilot-conversations/ " })
+        )
+      ).toEqual([]);
+    });
+
+    it("flags a folder that differs from its default only by letter case as customized", () => {
+      // Reason: comparison is case-sensitive to match the QA folder matcher, so on
+      // a case-sensitive filesystem `Copilot/...` is a genuinely different directory
+      // whose migration notice must still fire.
+      expect(
+        buildUpgradeRelocationEntries(
+          buildSettings({ defaultSaveFolder: "Copilot/copilot-conversations" })
+        )
+      ).toEqual([
+        {
+          label: "Chat conversations",
+          oldPath: "Copilot/copilot-conversations",
+          newPath: "copilot/copilot-conversations",
+        },
+      ]);
+    });
+
+    it("does not flag a default folder that differs only by path separator", () => {
+      expect(
+        buildUpgradeRelocationEntries(
+          buildSettings({ userSystemPromptsFolder: "copilot\\system-prompts" })
+        )
+      ).toEqual([]);
+    });
+  });
+});

--- a/src/settings/upgradeNotice.ts
+++ b/src/settings/upgradeNotice.ts
@@ -1,0 +1,141 @@
+import {
+  deriveConversationsFolder,
+  deriveCustomPromptsFolder,
+  deriveMemoryFolder,
+  deriveSkillsFolder,
+  deriveSystemPromptsFolder,
+} from "@/settings/copilotFolder";
+import type { CopilotSettings } from "@/settings/model";
+
+/**
+ * One legacy sub-folder whose data needs relocating after the v3→v4 folder
+ * consolidation — its stored old path differs from the path Copilot now derives
+ * to (because the folder was customized, or the root itself moved). `oldPath` is
+ * where the data physically still lives; `newPath` is where Copilot reads and
+ * writes now.
+ */
+export interface FolderRelocationEntry {
+  /** Human-readable name of the data class (e.g. "Chat conversations"). */
+  label: string;
+  /** Stored path Copilot used before the upgrade; the files remain here. */
+  oldPath: string;
+  /** Derived path Copilot reads and writes after the upgrade. */
+  newPath: string;
+}
+
+/** Settings slice the upgrade notice inspects. */
+type UpgradeNoticeSettings = Pick<
+  CopilotSettings,
+  | "copilotFolder"
+  | "defaultSaveFolder"
+  | "customPromptsFolder"
+  | "userSystemPromptsFolder"
+  | "memoryFolderName"
+  | "agentMode"
+>;
+
+/** Settings slice the pure derivation helpers depend on. */
+type RootSettings = Pick<CopilotSettings, "copilotFolder">;
+
+interface SubFolderSpec {
+  /** Display name for the relocation entry. */
+  label: string;
+  /** Stored legacy field value, shown verbatim as the old path. */
+  legacyValue: (settings: UpgradeNoticeSettings) => string;
+  /** Derive the effective sub-folder path from a settings snapshot. */
+  derive: (settings: RootSettings) => string;
+}
+
+/**
+ * The legacy sub-folders whose stored path is compared against the derived new
+ * path to build the relocation list. Each had a real writer before v4 — either a
+ * user-facing path input or, for memory, a "Memory Folder Name" field that
+ * shipped in the Copilot Plus settings from 3.1.0 through 3.3.3 and wrote
+ * `memoryFolderName` via `updateSetting`. A vault upgraded from any of those
+ * releases can therefore carry a non-default `memoryFolderName` in `data.json`,
+ * and the new `UserMemoryManager` reads the derived `<root>/memory` instead, so
+ * memory must be surfaced when the two differ.
+ *
+ * Projects (`projectsFolder`) is deliberately absent: although it is a persisted
+ * field, a full history search found no product write path (no `updateSetting`
+ * call, no input control) — only the default seed, sanitize fallback, and read
+ * sites. Its stored value is therefore always the default, so it can never
+ * differ from the derived path at upgrade. If a future review flags projects as
+ * missing here, point them at this note and re-check for a real writer before
+ * adding it.
+ */
+const SUBFOLDER_SPECS: readonly SubFolderSpec[] = [
+  {
+    label: "Chat conversations",
+    legacyValue: (s) => s.defaultSaveFolder,
+    derive: deriveConversationsFolder,
+  },
+  {
+    label: "Custom prompts",
+    legacyValue: (s) => s.customPromptsFolder,
+    derive: deriveCustomPromptsFolder,
+  },
+  {
+    label: "System prompts",
+    legacyValue: (s) => s.userSystemPromptsFolder,
+    derive: deriveSystemPromptsFolder,
+  },
+  {
+    label: "Agent skills",
+    legacyValue: (s) => s.agentMode.skills.folder,
+    derive: deriveSkillsFolder,
+  },
+  {
+    label: "Memory",
+    legacyValue: (s) => s.memoryFolderName,
+    derive: deriveMemoryFolder,
+  },
+];
+
+/**
+ * Canonicalize a vault-relative folder path for equality comparison only.
+ * Normalizes backslashes, duplicate and surrounding slashes so a user who never
+ * customized a folder (but whose stored value differs by a trailing slash) is
+ * not mistaken for a customizer. Comparison is case-sensitive to match the QA
+ * folder matcher and the rest of the codebase's path handling: on a
+ * case-sensitive filesystem (Linux) `Copilot/...` and `copilot/...` are
+ * genuinely different directories, so lowercasing here would misjudge a real
+ * customizer as a default user and skip their migration notice, silently
+ * orphaning their old conversations. The trade-off is that on a case-insensitive
+ * filesystem (macOS/Windows) a stored value differing only by case yields one
+ * benign no-op prompt — an acceptable, low-risk cost for not under-detecting
+ * real customizers on case-sensitive filesystems.
+ */
+function canonicalizePath(path: string): string {
+  return path
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/\/+/g, "/")
+    .replace(/^\/+|\/+$/g, "");
+}
+
+/**
+ * Build the list of legacy sub-folders whose data needs relocating after the
+ * v3→v4 folder consolidation: every folder whose stored old path differs from
+ * the path it now derives to (covers both individually-customized folders and,
+ * when the root itself moved, folders that only shifted because of the new
+ * root). Pure — the caller passes the settings snapshot so the decision is
+ * unit-testable without the global store. Returns an empty array when nothing
+ * needs to move (e.g. default users), which the caller treats as "do not prompt".
+ */
+export function buildUpgradeRelocationEntries(
+  settings: UpgradeNoticeSettings
+): FolderRelocationEntry[] {
+  return SUBFOLDER_SPECS.flatMap((spec) => {
+    const oldPath = spec.legacyValue(settings);
+    const newPath = spec.derive(settings);
+    // Only surface a folder whose data actually needs to move: if the old
+    // location already resolves to the new derived path there is nothing to
+    // relocate. This also covers default (never-customized) users, whose old
+    // value equals the derived default.
+    if (canonicalizePath(oldPath) === canonicalizePath(newPath)) {
+      return [];
+    }
+    return [{ label: spec.label, oldPath, newPath }];
+  });
+}

--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -6,6 +6,7 @@ import { ObsidianNativeSelect } from "@/components/ui/obsidian-native-select";
 import { useApp } from "@/context";
 import { logFileManager } from "@/logFileManager";
 import { flushRecordedPromptPayloadToLog } from "@/LLMProviders/chainRunner/utils/promptPayloadRecorder";
+import { getCopilotSaveData } from "@/settings/copilotSaveData";
 import { KeychainService } from "@/services/keychainService";
 import {
   canClearDiskSecrets,
@@ -27,34 +28,13 @@ import {
 import { ArrowUpRight, Info, Plus, ShieldCheck, Trash2, Unlock } from "lucide-react";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { MigrateConfirmModal } from "@/components/modals/MigrateConfirmModal";
-import { type App, Notice } from "obsidian";
+import { Notice } from "obsidian";
 import React, { useCallback, useEffect, useState } from "react";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { getPromptFilePath, SystemPromptAddModal } from "@/system-prompts";
 import { useSystemPrompts } from "@/system-prompts/state";
 
 const DESKTOP_UNAVAILABLE_FRAME_LOG_PATH = "(Agent Mode frame logs are desktop-only)";
-
-/**
- * Returns a `saveData` callback bound to the loaded Copilot plugin instance.
- *
- * Reason: settings React components don't have direct access to the plugin,
- * so persistence transactions look it up via the Obsidian `App`. Kept as a
- * single helper to centralise the `app.plugins` cast (untyped in the Obsidian
- * API) and the "plugin not found" guard at every call site.
- */
-function getCopilotSaveData(app: App): (data: CopilotSettings) => Promise<void> {
-  return async (data: CopilotSettings) => {
-    const { plugins } = app as unknown as {
-      plugins: {
-        getPlugin: (id: string) => { saveData: (data: CopilotSettings) => Promise<void> } | null;
-      };
-    };
-    const copilotPlugin = plugins.getPlugin("copilot");
-    if (!copilotPlugin) throw new Error("Copilot plugin not found");
-    await copilotPlugin.saveData(data);
-  };
-}
 
 export const AdvancedSettings: React.FC = () => {
   const app = useApp();

--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -354,15 +354,6 @@ export const AdvancedSettings: React.FC = () => {
             </Button>
           </div>
         </SettingItem>
-
-        <SettingItem
-          type="text"
-          title="System Prompts Folder Name"
-          description="Folder where system prompts are stored."
-          value={settings.userSystemPromptsFolder}
-          onChange={(value) => updateSetting("userSystemPromptsFolder", value)}
-          placeholder="copilot/system-prompts"
-        />
       </SettingSection>
 
       {/* Others Section */}

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -97,7 +97,7 @@ describe("BasicSettings", () => {
     expect(applyCopilotRootChange).not.toHaveBeenCalled();
 
     capturedOnConfirm?.();
-    expect(applyCopilotRootChange).toHaveBeenCalledWith("ai");
+    expect(applyCopilotRootChange).toHaveBeenCalledWith(expect.anything(), "ai");
   });
 
   it("does nothing when Apply is pressed with the current root unchanged", () => {

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -1,0 +1,109 @@
+import { DEFAULT_SETTINGS } from "@/constants";
+import { settingsAtom, settingsStore } from "@/settings/model";
+import { BasicSettings } from "@/settings/v2/components/BasicSettings";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Notice } from "obsidian";
+import React from "react";
+
+// Stub the Plus banner to keep its dependency chain out of the test.
+jest.mock("@/settings/v2/components/PlusSettings", () => ({ PlusSettings: () => null }));
+
+// App is threaded via useApp; the root-change orchestration is unit-tested in
+// copilotRootChange.test, so mock it here to observe the UI's decisions.
+jest.mock("@/context", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
+  useApp: () => ({ vault: { getMarkdownFiles: () => [] } }),
+}));
+
+const applyCopilotRootChange = jest.fn<Promise<void>, unknown[]>().mockResolvedValue(undefined);
+const copilotRootContainsNotes = jest.fn<boolean, unknown[]>().mockReturnValue(false);
+const isKnownCopilotRoot = jest.fn<boolean, unknown[]>().mockReturnValue(false);
+jest.mock("@/settings/copilotRootChange", () => ({
+  applyCopilotRootChange: (...a: unknown[]) => applyCopilotRootChange(...a),
+  copilotRootContainsNotes: (...a: unknown[]) => copilotRootContainsNotes(...a),
+  isKnownCopilotRoot: (...a: unknown[]) => isKnownCopilotRoot(...a),
+}));
+
+// Capture ConfirmModal construction so a test can fire its confirm callback.
+let capturedOnConfirm: (() => void) | null = null;
+const modalCtor = jest.fn((onConfirm: () => void) => {
+  capturedOnConfirm = onConfirm;
+});
+jest.mock("@/components/modals/ConfirmModal", () => ({
+  ConfirmModal: class {
+    open = jest.fn();
+    constructor(_app: unknown, onConfirm: () => void) {
+      modalCtor(onConfirm);
+    }
+  },
+}));
+
+describe("BasicSettings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    capturedOnConfirm = null;
+    settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, copilotFolder: "copilot" });
+    copilotRootContainsNotes.mockReturnValue(false);
+    isKnownCopilotRoot.mockReturnValue(false);
+  });
+
+  it("binds the Copilot folder input to the persisted root", () => {
+    render(<BasicSettings />);
+    expect(screen.getByLabelText<HTMLInputElement>("Copilot folder").value).toBe("copilot");
+  });
+
+  it("no longer renders the retired conversation folder and tag inputs", () => {
+    render(<BasicSettings />);
+    expect(screen.queryByText("Default Conversation Folder Name")).toBeNull();
+    expect(screen.queryByText("Default Conversation Tag")).toBeNull();
+  });
+
+  it("rejects an invalid root on Apply without opening the confirm modal", () => {
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "../escape" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+    expect(Notice).toHaveBeenCalledTimes(1);
+    expect(modalCtor).not.toHaveBeenCalled();
+    expect(applyCopilotRootChange).not.toHaveBeenCalled();
+  });
+
+  it("rejects a root that already contains notes without opening the confirm modal", () => {
+    copilotRootContainsNotes.mockReturnValue(true);
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "existing" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+    expect(Notice).toHaveBeenCalledTimes(1);
+    expect(modalCtor).not.toHaveBeenCalled();
+    expect(applyCopilotRootChange).not.toHaveBeenCalled();
+  });
+
+  it("opens the confirm modal for a previously-used root even though it holds Copilot notes", () => {
+    // Re-activating a known Copilot root: its Markdown is Copilot's own leftover
+    // data and stays QA-excluded via history, so the note guard is skipped and
+    // the user reaches the confirmation instead of being blocked.
+    copilotRootContainsNotes.mockReturnValue(true);
+    isKnownCopilotRoot.mockReturnValue(true);
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "old-root" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+    expect(modalCtor).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the confirm modal for a valid new root and applies the change on confirm", () => {
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+    expect(modalCtor).toHaveBeenCalledTimes(1);
+    expect(applyCopilotRootChange).not.toHaveBeenCalled();
+
+    capturedOnConfirm?.();
+    expect(applyCopilotRootChange).toHaveBeenCalledWith("ai");
+  });
+
+  it("does nothing when Apply is pressed with the current root unchanged", () => {
+    render(<BasicSettings />);
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+    expect(modalCtor).not.toHaveBeenCalled();
+    expect(applyCopilotRootChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -17,10 +17,12 @@ jest.mock("@/context", () => ({
 
 const applyCopilotRootChange = jest.fn<Promise<void>, unknown[]>().mockResolvedValue(undefined);
 const copilotRootContainsNotes = jest.fn<boolean, unknown[]>().mockReturnValue(false);
+const findCopilotRootFileConflict = jest.fn<string | null, unknown[]>().mockReturnValue(null);
 const isKnownCopilotRoot = jest.fn<boolean, unknown[]>().mockReturnValue(false);
 jest.mock("@/settings/copilotRootChange", () => ({
   applyCopilotRootChange: (...a: unknown[]) => applyCopilotRootChange(...a),
   copilotRootContainsNotes: (...a: unknown[]) => copilotRootContainsNotes(...a),
+  findCopilotRootFileConflict: (...a: unknown[]) => findCopilotRootFileConflict(...a),
   isKnownCopilotRoot: (...a: unknown[]) => isKnownCopilotRoot(...a),
 }));
 
@@ -59,6 +61,7 @@ describe("BasicSettings", () => {
     capturedOnConfirm = null;
     settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, copilotFolder: "copilot" });
     copilotRootContainsNotes.mockReturnValue(false);
+    findCopilotRootFileConflict.mockReturnValue(null);
     isKnownCopilotRoot.mockReturnValue(false);
     shouldSurfaceMiyoResync.mockReturnValue(false);
     resyncMiyoFolder.mockResolvedValue("resynced");
@@ -79,6 +82,16 @@ describe("BasicSettings", () => {
   it("rejects an invalid root on Apply without opening the confirm modal", () => {
     render(<BasicSettings />);
     fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "../escape" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+    expect(Notice).toHaveBeenCalledTimes(1);
+    expect(modalCtor).not.toHaveBeenCalled();
+    expect(applyCopilotRootChange).not.toHaveBeenCalled();
+  });
+
+  it("rejects a root whose path is occupied by an existing file without opening the confirm modal", () => {
+    findCopilotRootFileConflict.mockReturnValue("ai.txt");
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai.txt" } });
     fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
     expect(Notice).toHaveBeenCalledTimes(1);
     expect(modalCtor).not.toHaveBeenCalled();

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -1,7 +1,7 @@
 import { DEFAULT_SETTINGS } from "@/constants";
 import { settingsAtom, settingsStore } from "@/settings/model";
 import { BasicSettings } from "@/settings/v2/components/BasicSettings";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Notice } from "obsidian";
 import React from "react";
 
@@ -24,6 +24,19 @@ jest.mock("@/settings/copilotRootChange", () => ({
   isKnownCopilotRoot: (...a: unknown[]) => isKnownCopilotRoot(...a),
 }));
 
+// The post-change hybrid trigger: observe whether the auto-resync fires.
+const resyncMiyoFolder = jest.fn<Promise<string>, unknown[]>().mockResolvedValue("resynced");
+jest.mock("@/miyo/miyoResync", () => ({
+  resyncMiyoFolder: (...a: unknown[]) => resyncMiyoFolder(...a),
+}));
+const shouldSurfaceMiyoResync = jest.fn<boolean, unknown[]>().mockReturnValue(false);
+jest.mock("@/miyo/miyoUtils", () => ({
+  shouldSurfaceMiyoResync: (...a: unknown[]) => shouldSurfaceMiyoResync(...a),
+  isLocalMiyoUrl: () => true,
+  getMiyoCustomUrl: () => "",
+}));
+jest.mock("@/utils/vaultPath", () => ({ getVaultBase: () => "/abs/vault" }));
+
 // Capture ConfirmModal construction so a test can fire its confirm callback.
 let capturedOnConfirm: (() => void) | null = null;
 const modalCtor = jest.fn((onConfirm: () => void) => {
@@ -45,6 +58,8 @@ describe("BasicSettings", () => {
     settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, copilotFolder: "copilot" });
     copilotRootContainsNotes.mockReturnValue(false);
     isKnownCopilotRoot.mockReturnValue(false);
+    shouldSurfaceMiyoResync.mockReturnValue(false);
+    resyncMiyoFolder.mockResolvedValue("resynced");
   });
 
   it("binds the Copilot folder input to the persisted root", () => {
@@ -98,6 +113,28 @@ describe("BasicSettings", () => {
 
     capturedOnConfirm?.();
     expect(applyCopilotRootChange).toHaveBeenCalledWith(expect.anything(), "ai");
+  });
+
+  it("auto-resyncs Miyo after a confirmed root change when its scope went stale", async () => {
+    shouldSurfaceMiyoResync.mockReturnValue(true);
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+
+    capturedOnConfirm?.();
+
+    await waitFor(() => expect(resyncMiyoFolder).toHaveBeenCalledTimes(1));
+  });
+
+  it("leaves Miyo alone after a root change when nothing needs resyncing", async () => {
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+
+    capturedOnConfirm?.();
+
+    await waitFor(() => expect(applyCopilotRootChange).toHaveBeenCalled());
+    expect(resyncMiyoFolder).not.toHaveBeenCalled();
   });
 
   it("does nothing when Apply is pressed with the current root unchanged", () => {

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -26,11 +26,10 @@ jest.mock("@/settings/copilotRootChange", () => ({
   isKnownCopilotRoot: (...a: unknown[]) => isKnownCopilotRoot(...a),
 }));
 
-// The post-change hybrid trigger: observe whether the auto-resync fires.
-const resyncMiyoFolder = jest.fn<Promise<string>, unknown[]>().mockResolvedValue("resynced");
+// The root-change trigger's read-only probe: the only way a registration that
+// predates receipts (or whose receipt a reset wiped) can be reported at all.
 const verifyMiyoScope = jest.fn<Promise<string>, unknown[]>().mockResolvedValue("unregistered");
 jest.mock("@/miyo/miyoResync", () => ({
-  resyncMiyoFolder: (...a: unknown[]) => resyncMiyoFolder(...a),
   verifyMiyoScope: (...a: unknown[]) => verifyMiyoScope(...a),
 }));
 const shouldSurfaceMiyoResync = jest.fn<boolean, unknown[]>().mockReturnValue(false);
@@ -64,7 +63,6 @@ describe("BasicSettings", () => {
     findCopilotRootFileConflict.mockReturnValue(null);
     isKnownCopilotRoot.mockReturnValue(false);
     shouldSurfaceMiyoResync.mockReturnValue(false);
-    resyncMiyoFolder.mockResolvedValue("resynced");
     verifyMiyoScope.mockResolvedValue("unregistered");
   });
 
@@ -131,10 +129,8 @@ describe("BasicSettings", () => {
     expect(applyCopilotRootChange).toHaveBeenCalledWith(expect.anything(), "ai");
   });
 
-  it("points at the Miyo tab without mutating the registration when the scope went stale", async () => {
-    // Changing a local folder setting must never delete/recreate a remote
-    // registration on its own; the Miyo tab's banner carries the explicit
-    // Resync. The unused mocks below are the regression guard for that.
+  it("points at the Miyo tab without probing when local state already signals a resync", async () => {
+    // Local evidence is enough; asking the server would add nothing.
     shouldSurfaceMiyoResync.mockReturnValue(true);
     render(<BasicSettings />);
     fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
@@ -148,22 +144,38 @@ describe("BasicSettings", () => {
         6000
       )
     );
-    expect(resyncMiyoFolder).not.toHaveBeenCalled();
     expect(verifyMiyoScope).not.toHaveBeenCalled();
   });
 
-  it("stays silent about Miyo after a root change when nothing locally signals a resync", async () => {
+  it("reports a registration only the server knows about when the receipt is empty", async () => {
+    // A registration made before receipts existed — or one whose receipt a Reset
+    // Settings wiped — leaves no local trace, and the startup notice is gated on
+    // the same empty receipt. Without this probe the user is never told.
+    verifyMiyoScope.mockResolvedValue("stale");
     render(<BasicSettings />);
     fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
     fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
 
     capturedOnConfirm?.();
 
-    await waitFor(() => expect(applyCopilotRootChange).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(Notice).toHaveBeenCalledWith(
+        expect.stringContaining("Miyo search needs a resync"),
+        6000
+      )
+    );
+  });
+
+  it("stays silent when the probe finds no registration exposing the new root", async () => {
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+
+    capturedOnConfirm?.();
+
+    await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(1));
     const noticeTexts = (Notice as unknown as jest.Mock).mock.calls.map((call) => String(call[0]));
     expect(noticeTexts.some((text) => text.includes("Miyo"))).toBe(false);
-    expect(resyncMiyoFolder).not.toHaveBeenCalled();
-    expect(verifyMiyoScope).not.toHaveBeenCalled();
   });
 
   it("does nothing when Apply is pressed with the current root unchanged", () => {

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -26,8 +26,10 @@ jest.mock("@/settings/copilotRootChange", () => ({
 
 // The post-change hybrid trigger: observe whether the auto-resync fires.
 const resyncMiyoFolder = jest.fn<Promise<string>, unknown[]>().mockResolvedValue("resynced");
+const verifyMiyoScope = jest.fn<Promise<string>, unknown[]>().mockResolvedValue("unregistered");
 jest.mock("@/miyo/miyoResync", () => ({
   resyncMiyoFolder: (...a: unknown[]) => resyncMiyoFolder(...a),
+  verifyMiyoScope: (...a: unknown[]) => verifyMiyoScope(...a),
 }));
 const shouldSurfaceMiyoResync = jest.fn<boolean, unknown[]>().mockReturnValue(false);
 jest.mock("@/miyo/miyoUtils", () => ({
@@ -60,6 +62,7 @@ describe("BasicSettings", () => {
     isKnownCopilotRoot.mockReturnValue(false);
     shouldSurfaceMiyoResync.mockReturnValue(false);
     resyncMiyoFolder.mockResolvedValue("resynced");
+    verifyMiyoScope.mockResolvedValue("unregistered");
   });
 
   it("binds the Copilot folder input to the persisted root", () => {
@@ -135,6 +138,38 @@ describe("BasicSettings", () => {
 
     await waitFor(() => expect(applyCopilotRootChange).toHaveBeenCalled());
     expect(resyncMiyoFolder).not.toHaveBeenCalled();
+  });
+
+  it("notices after a root change when a live probe finds a stale pre-receipt registration", async () => {
+    // Empty receipt + nothing locally surfacing a resync: the only evidence of
+    // a pre-receipt-era registration is the server itself, so the trigger
+    // probes read-only and points at the Miyo tab instead of mutating.
+    verifyMiyoScope.mockResolvedValue("stale");
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+
+    capturedOnConfirm?.();
+
+    await waitFor(() =>
+      expect(Notice).toHaveBeenCalledWith(
+        expect.stringContaining("Miyo search needs a resync"),
+        6000
+      )
+    );
+    expect(resyncMiyoFolder).not.toHaveBeenCalled();
+  });
+
+  it("stays silent after a root change when the live probe finds no Miyo registration", async () => {
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+
+    capturedOnConfirm?.();
+
+    await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(1));
+    const noticeTexts = (Notice as unknown as jest.Mock).mock.calls.map((call) => String(call[0]));
+    expect(noticeTexts.some((text) => text.includes("Miyo"))).toBe(false);
   });
 
   it("does nothing when Apply is pressed with the current root unchanged", () => {

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -15,6 +15,16 @@ jest.mock("@/context", () => ({
   useApp: () => ({ vault: { getMarkdownFiles: () => [] } }),
 }));
 
+// The Miyo mutation session is owned by the plugin (one per lifecycle) rather
+// than captured by this tab, which mounts lazily. Hoisted so the stand-in keeps
+// production's referential stability: the session is an effect dependency, and a
+// fresh object per render would loop the verify effect forever.
+const mockPluginInstance = { miyoMutationSession: Object.freeze({ lifecycle: 0 }) };
+jest.mock("@/contexts/PluginContext", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
+  usePlugin: () => mockPluginInstance,
+}));
+
 const applyCopilotRootChange = jest.fn<Promise<void>, unknown[]>().mockResolvedValue(undefined);
 const copilotRootContainsNotes = jest.fn<boolean, unknown[]>().mockReturnValue(false);
 const findCopilotRootFileConflict = jest.fn<string | null, unknown[]>().mockReturnValue(null);
@@ -163,6 +173,24 @@ describe("BasicSettings", () => {
         expect.stringContaining("Miyo search needs a resync"),
         6000
       )
+    );
+  });
+
+  it("probes with the plugin's session, so a tree that outlived its lifecycle is refused", async () => {
+    // The session must come from the plugin (one per lifecycle), not from this
+    // tab: tabs mount lazily, so a tab first opened after a reload would
+    // otherwise vouch for the incoming lifecycle while holding the old app.
+    verifyMiyoScope.mockResolvedValue("covered");
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+
+    capturedOnConfirm?.();
+
+    await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(1));
+    expect(verifyMiyoScope).toHaveBeenCalledWith(
+      expect.anything(),
+      mockPluginInstance.miyoMutationSession
     );
   });
 

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -131,33 +131,11 @@ describe("BasicSettings", () => {
     expect(applyCopilotRootChange).toHaveBeenCalledWith(expect.anything(), "ai");
   });
 
-  it("auto-resyncs Miyo after a confirmed root change when its scope went stale", async () => {
+  it("points at the Miyo tab without mutating the registration when the scope went stale", async () => {
+    // Changing a local folder setting must never delete/recreate a remote
+    // registration on its own; the Miyo tab's banner carries the explicit
+    // Resync. The unused mocks below are the regression guard for that.
     shouldSurfaceMiyoResync.mockReturnValue(true);
-    render(<BasicSettings />);
-    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
-    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
-
-    capturedOnConfirm?.();
-
-    await waitFor(() => expect(resyncMiyoFolder).toHaveBeenCalledTimes(1));
-  });
-
-  it("leaves Miyo alone after a root change when nothing needs resyncing", async () => {
-    render(<BasicSettings />);
-    fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
-    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
-
-    capturedOnConfirm?.();
-
-    await waitFor(() => expect(applyCopilotRootChange).toHaveBeenCalled());
-    expect(resyncMiyoFolder).not.toHaveBeenCalled();
-  });
-
-  it("notices after a root change when a live probe finds a stale pre-receipt registration", async () => {
-    // Empty receipt + nothing locally surfacing a resync: the only evidence of
-    // a pre-receipt-era registration is the server itself, so the trigger
-    // probes read-only and points at the Miyo tab instead of mutating.
-    verifyMiyoScope.mockResolvedValue("stale");
     render(<BasicSettings />);
     fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
     fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
@@ -171,18 +149,21 @@ describe("BasicSettings", () => {
       )
     );
     expect(resyncMiyoFolder).not.toHaveBeenCalled();
+    expect(verifyMiyoScope).not.toHaveBeenCalled();
   });
 
-  it("stays silent after a root change when the live probe finds no Miyo registration", async () => {
+  it("stays silent about Miyo after a root change when nothing locally signals a resync", async () => {
     render(<BasicSettings />);
     fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "ai" } });
     fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
 
     capturedOnConfirm?.();
 
-    await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(applyCopilotRootChange).toHaveBeenCalled());
     const noticeTexts = (Notice as unknown as jest.Mock).mock.calls.map((call) => String(call[0]));
     expect(noticeTexts.some((text) => text.includes("Miyo"))).toBe(false);
+    expect(resyncMiyoFolder).not.toHaveBeenCalled();
+    expect(verifyMiyoScope).not.toHaveBeenCalled();
   });
 
   it("does nothing when Apply is pressed with the current root unchanged", () => {

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -1,28 +1,110 @@
+import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { Button } from "@/components/ui/button";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { Input } from "@/components/ui/input";
 import { SettingItem } from "@/components/ui/setting-item";
 import { SettingSection } from "@/components/ui/setting-section";
 import { DEFAULT_OPEN_AREA, SEND_SHORTCUT } from "@/constants";
+import { useApp } from "@/context";
 import { cn } from "@/lib/utils";
-import { updateSetting, useSettingsValue } from "@/settings/model";
+import { ensureCopilotSubfolders } from "@/settings/copilotFolder";
+import {
+  applyCopilotRootChange,
+  copilotRootContainsNotes,
+  isKnownCopilotRoot,
+} from "@/settings/copilotRootChange";
+import { updateSetting, useSettingsValue, validateCopilotFolder } from "@/settings/model";
 import { PlusSettings } from "@/settings/v2/components/PlusSettings";
 import { formatDateTime } from "@/utils";
-import { Loader2 } from "lucide-react";
+import { revealFolderInExplorer } from "@/utils/revealFolderInExplorer";
+import { Folder, FolderSync, Loader2 } from "lucide-react";
 import { Notice } from "obsidian";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
-// Read-only preview of the unified Copilot folder (PR-3 makes it editable and
-// wires the real setting). Sub-folders derive from this root. The row is hidden
-// until PR-3 lands — see the commented block in the render below.
-// const COPILOT_FOLDER_PLACEHOLDER = "copilot";
+/**
+ * Body of the "Change Copilot folder" confirmation modal. Leads with a
+ * folder-sync icon header, then states the two things the user must know before
+ * committing: files are not moved, and the old root stays permanently excluded
+ * from search.
+ */
+function CopilotFolderChangeNotice({ oldRoot, newRoot }: { oldRoot: string; newRoot: string }) {
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-4">
+      <div className="tw-flex tw-items-center tw-gap-3 tw-text-normal">
+        <FolderSync className="tw-size-6 tw-shrink-0 tw-text-accent" />
+        <h2 className="tw-m-0 tw-text-xl tw-font-bold">Change Copilot folder</h2>
+      </div>
+      <p className="tw-m-0 tw-text-muted">
+        Copilot will keep new chats and data under <code>{newRoot}/</code>. Your files aren&apos;t
+        moved — your old data stays in <strong className="tw-text-normal">{oldRoot}/</strong>, which
+        stays permanently excluded from search. Move it over if you want; Obsidian updates the
+        links.
+      </p>
+    </div>
+  );
+}
 
 export const BasicSettings: React.FC = () => {
+  const app = useApp();
   const settings = useSettingsValue();
   const [isChecking, setIsChecking] = useState(false);
   const [conversationNoteName, setConversationNoteName] = useState(
     settings.defaultConversationNoteName || "{$date}_{$time}__{$topic}"
   );
+
+  // Draft + explicit Apply for the Copilot root. Reason: persisting on every
+  // keystroke would re-point every derived sub-folder and trigger reload
+  // watchers per character; a root change also needs an up-front confirmation.
+  const persistedRoot = settings.copilotFolder;
+  const [folderDraft, setFolderDraft] = useState(persistedRoot);
+
+  useEffect(() => {
+    /* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- resync the draft when the persisted root changes underneath us (e.g. Reset Settings or a completed change) */
+    setFolderDraft(persistedRoot);
+    /* eslint-enable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
+  }, [persistedRoot]);
+
+  const applyFolderChange = () => {
+    const validation = validateCopilotFolder(folderDraft);
+    if (!validation.ok) {
+      new Notice(`Invalid Copilot folder: ${validation.reason}`, 5000);
+      return;
+    }
+    const folder = validation.folder;
+    if (folder === persistedRoot) {
+      new Notice("That's already the Copilot folder.", 3000);
+      return;
+    }
+    // Reason: a root that already holds ordinary notes would be excluded from
+    // search wholesale once activated, silently hiding those notes. A root
+    // Copilot used before is exempt — its only Markdown is Copilot's own
+    // leftover data (chats/memory/prompts), and it stays QA-excluded via
+    // history, so re-activating it hides nothing new.
+    if (
+      !isKnownCopilotRoot(folder, settings.copilotRootHistory) &&
+      copilotRootContainsNotes(app, folder)
+    ) {
+      new Notice(
+        `"${folder}" already contains notes. Choose a folder that isn't used for regular notes, otherwise those notes would be excluded from search.`,
+        8000
+      );
+      return;
+    }
+    new ConfirmModal(
+      app,
+      () => {
+        void applyCopilotRootChange(folder)
+          .then(() => ensureCopilotSubfolders(app.vault, { copilotFolder: folder }))
+          .then(() => new Notice(`Copilot folder changed to "${folder}".`, 4000))
+          .catch(() => new Notice("Failed to change the Copilot folder. Check the logs.", 5000));
+      },
+      <CopilotFolderChangeNotice oldRoot={persistedRoot} newRoot={folder} />,
+      "",
+      "Change folder",
+      "Cancel",
+      () => setFolderDraft(persistedRoot)
+    ).open();
+  };
 
   const applyCustomNoteFormat = () => {
     setIsChecking(true);
@@ -92,38 +174,6 @@ export const BasicSettings: React.FC = () => {
           ]}
         />
 
-        {/* Copilot folder location — hidden until the next phase (PR-3) makes it
-            editable and wires the real `copilotFolder` setting + migration.
-            Shipping a disabled read-only preview now would just confuse users, so
-            keep it out of the UI until it does something. Restore this block when
-            PR-3 lands. */}
-        {/*
-        <SettingItem
-          type="custom"
-          title="Copilot folder location"
-          description="Where Copilot keeps conversations, prompts, memory and more. All sub-folders derive from this."
-        >
-          <div className="tw-flex tw-items-center tw-gap-2">
-            <Input
-              type="text"
-              value={COPILOT_FOLDER_PLACEHOLDER}
-              disabled
-              readOnly
-              className="tw-w-full sm:tw-w-[160px]"
-            />
-            <Button
-              variant="secondary"
-              size="icon"
-              disabled
-              aria-label="Open Copilot folder"
-              title="Open Copilot folder"
-            >
-              <Folder className="tw-size-4" />
-            </Button>
-          </div>
-        </SettingItem>
-        */}
-
         <SettingItem
           type="select"
           title="Send Shortcut"
@@ -150,6 +200,45 @@ export const BasicSettings: React.FC = () => {
             { label: "Shift + Enter", value: SEND_SHORTCUT.SHIFT_ENTER },
           ]}
         />
+
+        <SettingItem
+          type="custom"
+          title="Copilot folder location"
+          description="Where Copilot keeps conversations, prompts, memory and more. All sub-folders derive from this."
+        >
+          <div className="tw-flex tw-items-center tw-gap-2">
+            <Input
+              type="text"
+              value={folderDraft}
+              onChange={(e) => setFolderDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  applyFolderChange();
+                }
+              }}
+              placeholder="copilot"
+              className="tw-w-full sm:tw-w-[160px]"
+              aria-label="Copilot folder"
+            />
+            <Button
+              variant="secondary"
+              onClick={applyFolderChange}
+              aria-label="Apply Copilot folder"
+            >
+              Apply
+            </Button>
+            <Button
+              variant="secondary"
+              size="icon"
+              onClick={() => revealFolderInExplorer(app, settings.copilotFolder)}
+              aria-label="Open Copilot folder"
+              title="Open Copilot folder"
+            >
+              <Folder className="tw-size-4" />
+            </Button>
+          </div>
+        </SettingItem>
       </SettingSection>
 
       {/* Saving Conversations Section */}
@@ -160,24 +249,6 @@ export const BasicSettings: React.FC = () => {
           description="Writes each chat to a Markdown note in your vault after every user message and AI response. With this off, agent chats still appear in Recent Chats from session history; only the Markdown note is skipped."
           checked={settings.autosaveChat}
           onCheckedChange={(checked) => updateSetting("autosaveChat", checked)}
-        />
-
-        <SettingItem
-          type="text"
-          title="Default Conversation Folder Name"
-          description="The default folder name where chat conversations will be saved. Default is 'copilot/copilot-conversations'"
-          value={settings.defaultSaveFolder}
-          onChange={(value) => updateSetting("defaultSaveFolder", value)}
-          placeholder="copilot/copilot-conversations"
-        />
-
-        <SettingItem
-          type="text"
-          title="Default Conversation Tag"
-          description="The default tag to be used when saving a conversation. Default is 'ai-conversations'"
-          value={settings.defaultConversationTag}
-          onChange={(value) => updateSetting("defaultConversationTag", value)}
-          placeholder="ai-conversations"
         />
 
         <SettingItem

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -93,7 +93,7 @@ export const BasicSettings: React.FC = () => {
     new ConfirmModal(
       app,
       () => {
-        void applyCopilotRootChange(folder)
+        void applyCopilotRootChange(app, folder)
           .then(() => ensureCopilotSubfolders(app.vault, { copilotFolder: folder }))
           .then(() => new Notice(`Copilot folder changed to "${folder}".`, 4000))
           .catch(() => new Notice("Failed to change the Copilot folder. Check the logs.", 5000));

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -7,8 +7,7 @@ import { SettingSection } from "@/components/ui/setting-section";
 import { DEFAULT_OPEN_AREA, SEND_SHORTCUT } from "@/constants";
 import { useApp } from "@/context";
 import { cn } from "@/lib/utils";
-import { resyncMiyoFolder, verifyMiyoScope } from "@/miyo/miyoResync";
-import { getMiyoCustomUrl, isLocalMiyoUrl, shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
+import { shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
 import { ensureCopilotSubfolders } from "@/settings/copilotFolder";
 import {
   applyCopilotRootChange,
@@ -22,7 +21,6 @@ import {
   useSettingsValue,
   validateCopilotFolder,
 } from "@/settings/model";
-import { getVaultBase } from "@/utils/vaultPath";
 import { PlusSettings } from "@/settings/v2/components/PlusSettings";
 import { formatDateTime } from "@/utils";
 import { revealFolderInExplorer } from "@/utils/revealFolderInExplorer";
@@ -115,39 +113,13 @@ export const BasicSettings: React.FC = () => {
       () => {
         void applyCopilotRootChange(app, folder)
           .then(() => {
-            // The root moved, so Miyo's server-side exclusions are stale.
-            // Reconcile automatically (silent on success); when that can't run
-            // or fails, point at the Miyo tab where the banner offers a retry.
-            // Reads fresh settings — the React `settings` closure predates the
-            // root change. Fire-and-forget: a Miyo hiccup must not break the
-            // rest of the root-change chain.
-            const fresh = getSettings();
-            const notice = () =>
+            // The root moved, so Miyo's server-side exclusions no longer match.
+            // Point at the Miyo tab and stop there: changing a local folder
+            // setting must not mutate a remote registration on its own, and the
+            // banner there carries the explicit Resync action. Reads fresh
+            // settings — the React `settings` closure predates the root change.
+            if (shouldSurfaceMiyoResync(app, getSettings())) {
               new Notice("Miyo search needs a resync — open the Miyo settings tab.", 6000);
-            if (!shouldSurfaceMiyoResync(app, fresh)) {
-              // No local evidence of a registration — but a pre-receipt-era
-              // registration leaves none: a user who registered before receipts
-              // existed and later disconnected (enableMiyo off, receipt empty)
-              // still has a live server-side scope whose Relay can read the new
-              // root. Only a read-only live probe can tell that apart from
-              // "never used Miyo"; on a confirmed stale registration point at
-              // the Miyo tab, and never mutate a disconnected user's Miyo.
-              if (fresh.miyoSyncedExclusions === "") {
-                void verifyMiyoScope(app).then((scope) => {
-                  if (scope === "stale") notice();
-                });
-              }
-              return;
-            }
-            if (getVaultBase(app) && isLocalMiyoUrl(getMiyoCustomUrl(fresh))) {
-              void resyncMiyoFolder(app).then((outcome) => {
-                // "unregistered" stays silent: nothing on the server exposes
-                // the new root, and nagging would second-guess a user who
-                // deliberately removed the registration in Miyo.
-                if (outcome === "conflict" || outcome === "failed") notice();
-              });
-            } else {
-              notice();
             }
           })
           .then(() => ensureCopilotSubfolders(app.vault, { copilotFolder: folder }))

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -6,6 +6,7 @@ import { SettingItem } from "@/components/ui/setting-item";
 import { SettingSection } from "@/components/ui/setting-section";
 import { DEFAULT_OPEN_AREA, SEND_SHORTCUT } from "@/constants";
 import { useApp } from "@/context";
+import { usePlugin } from "@/contexts/PluginContext";
 import { cn } from "@/lib/utils";
 import { verifyMiyoScope } from "@/miyo/miyoResync";
 import { shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
@@ -55,6 +56,10 @@ function CopilotFolderChangeNotice({ oldRoot, newRoot }: { oldRoot: string; newR
 export const BasicSettings: React.FC = () => {
   const app = useApp();
   const settings = useSettingsValue();
+  // From the plugin, not captured here: this tab mounts the first time the user
+  // selects it, so a tab first opened after a reload would vouch for the
+  // incoming lifecycle while still holding the outgoing vault's `app`.
+  const { miyoMutationSession } = usePlugin();
   const [isChecking, setIsChecking] = useState(false);
   const [conversationNoteName, setConversationNoteName] = useState(
     settings.defaultConversationNoteName || "{$date}_{$time}__{$topic}"
@@ -133,7 +138,7 @@ export const BasicSettings: React.FC = () => {
               // receipt. Only asking the server can tell that apart from
               // "never used Miyo". Read-only — it never mutates the
               // registration; a covering record just self-heals the receipt.
-              void verifyMiyoScope(app).then((scope) => {
+              void verifyMiyoScope(app, miyoMutationSession).then((scope) => {
                 if (scope === "stale") notice();
               });
             }

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -13,6 +13,7 @@ import { ensureCopilotSubfolders } from "@/settings/copilotFolder";
 import {
   applyCopilotRootChange,
   copilotRootContainsNotes,
+  findCopilotRootFileConflict,
   isKnownCopilotRoot,
 } from "@/settings/copilotRootChange";
 import {
@@ -83,6 +84,17 @@ export const BasicSettings: React.FC = () => {
       new Notice("That's already the Copilot folder.", 3000);
       return;
     }
+    // Reason: a path (or ancestor) occupied by an existing FILE would accept
+    // and persist fine, but every folder creation under it fails from then on
+    // — the first visible symptom being a failed chat save much later.
+    const conflict = findCopilotRootFileConflict(app, folder);
+    if (conflict) {
+      new Notice(
+        `"${conflict}" is an existing file, so "${folder}" can't be used as a folder. Choose another location.`,
+        8000
+      );
+      return;
+    }
     // Reason: a root that already holds ordinary notes would be excluded from
     // search wholesale once activated, silently hiding those notes. A root
     // Copilot used before is exempt — its only Markdown is Copilot's own
@@ -129,6 +141,9 @@ export const BasicSettings: React.FC = () => {
             }
             if (getVaultBase(app) && isLocalMiyoUrl(getMiyoCustomUrl(fresh))) {
               void resyncMiyoFolder(app).then((outcome) => {
+                // "unregistered" stays silent: nothing on the server exposes
+                // the new root, and nagging would second-guess a user who
+                // deliberately removed the registration in Miyo.
                 if (outcome === "conflict" || outcome === "failed") notice();
               });
             } else {

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -7,7 +7,7 @@ import { SettingSection } from "@/components/ui/setting-section";
 import { DEFAULT_OPEN_AREA, SEND_SHORTCUT } from "@/constants";
 import { useApp } from "@/context";
 import { cn } from "@/lib/utils";
-import { resyncMiyoFolder } from "@/miyo/miyoResync";
+import { resyncMiyoFolder, verifyMiyoScope } from "@/miyo/miyoResync";
 import { getMiyoCustomUrl, isLocalMiyoUrl, shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
 import { ensureCopilotSubfolders } from "@/settings/copilotFolder";
 import {
@@ -110,9 +110,23 @@ export const BasicSettings: React.FC = () => {
             // root change. Fire-and-forget: a Miyo hiccup must not break the
             // rest of the root-change chain.
             const fresh = getSettings();
-            if (!shouldSurfaceMiyoResync(app, fresh)) return;
             const notice = () =>
               new Notice("Miyo search needs a resync — open the Miyo settings tab.", 6000);
+            if (!shouldSurfaceMiyoResync(app, fresh)) {
+              // No local evidence of a registration — but a pre-receipt-era
+              // registration leaves none: a user who registered before receipts
+              // existed and later disconnected (enableMiyo off, receipt empty)
+              // still has a live server-side scope whose Relay can read the new
+              // root. Only a read-only live probe can tell that apart from
+              // "never used Miyo"; on a confirmed stale registration point at
+              // the Miyo tab, and never mutate a disconnected user's Miyo.
+              if (fresh.miyoSyncedExclusions === "") {
+                void verifyMiyoScope(app).then((scope) => {
+                  if (scope === "stale") notice();
+                });
+              }
+              return;
+            }
             if (getVaultBase(app) && isLocalMiyoUrl(getMiyoCustomUrl(fresh))) {
               void resyncMiyoFolder(app).then((outcome) => {
                 if (outcome === "conflict" || outcome === "failed") notice();

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -7,13 +7,21 @@ import { SettingSection } from "@/components/ui/setting-section";
 import { DEFAULT_OPEN_AREA, SEND_SHORTCUT } from "@/constants";
 import { useApp } from "@/context";
 import { cn } from "@/lib/utils";
+import { resyncMiyoFolder } from "@/miyo/miyoResync";
+import { getMiyoCustomUrl, isLocalMiyoUrl, shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
 import { ensureCopilotSubfolders } from "@/settings/copilotFolder";
 import {
   applyCopilotRootChange,
   copilotRootContainsNotes,
   isKnownCopilotRoot,
 } from "@/settings/copilotRootChange";
-import { updateSetting, useSettingsValue, validateCopilotFolder } from "@/settings/model";
+import {
+  getSettings,
+  updateSetting,
+  useSettingsValue,
+  validateCopilotFolder,
+} from "@/settings/model";
+import { getVaultBase } from "@/utils/vaultPath";
 import { PlusSettings } from "@/settings/v2/components/PlusSettings";
 import { formatDateTime } from "@/utils";
 import { revealFolderInExplorer } from "@/utils/revealFolderInExplorer";
@@ -94,6 +102,25 @@ export const BasicSettings: React.FC = () => {
       app,
       () => {
         void applyCopilotRootChange(app, folder)
+          .then(() => {
+            // The root moved, so Miyo's server-side exclusions are stale.
+            // Reconcile automatically (silent on success); when that can't run
+            // or fails, point at the Miyo tab where the banner offers a retry.
+            // Reads fresh settings — the React `settings` closure predates the
+            // root change. Fire-and-forget: a Miyo hiccup must not break the
+            // rest of the root-change chain.
+            const fresh = getSettings();
+            if (!shouldSurfaceMiyoResync(app, fresh)) return;
+            const notice = () =>
+              new Notice("Miyo search needs a resync — open the Miyo settings tab.", 6000);
+            if (getVaultBase(app) && isLocalMiyoUrl(getMiyoCustomUrl(fresh))) {
+              void resyncMiyoFolder(app).then((outcome) => {
+                if (outcome === "conflict" || outcome === "failed") notice();
+              });
+            } else {
+              notice();
+            }
+          })
           .then(() => ensureCopilotSubfolders(app.vault, { copilotFolder: folder }))
           .then(() => new Notice(`Copilot folder changed to "${folder}".`, 4000))
           .catch(() => new Notice("Failed to change the Copilot folder. Check the logs.", 5000));

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -7,6 +7,7 @@ import { SettingSection } from "@/components/ui/setting-section";
 import { DEFAULT_OPEN_AREA, SEND_SHORTCUT } from "@/constants";
 import { useApp } from "@/context";
 import { cn } from "@/lib/utils";
+import { verifyMiyoScope } from "@/miyo/miyoResync";
 import { shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
 import { ensureCopilotSubfolders } from "@/settings/copilotFolder";
 import {
@@ -114,12 +115,27 @@ export const BasicSettings: React.FC = () => {
         void applyCopilotRootChange(app, folder)
           .then(() => {
             // The root moved, so Miyo's server-side exclusions no longer match.
-            // Point at the Miyo tab and stop there: changing a local folder
-            // setting must not mutate a remote registration on its own, and the
-            // banner there carries the explicit Resync action. Reads fresh
-            // settings — the React `settings` closure predates the root change.
-            if (shouldSurfaceMiyoResync(app, getSettings())) {
+            // Surface it and stop there: changing a local folder setting must
+            // not mutate a remote registration on its own, and the Miyo tab's
+            // banner carries the explicit Resync. Reads fresh settings — the
+            // React `settings` closure predates the root change.
+            const fresh = getSettings();
+            const notice = () =>
               new Notice("Miyo search needs a resync — open the Miyo settings tab.", 6000);
+            if (shouldSurfaceMiyoResync(app, fresh)) {
+              notice();
+            } else if (fresh.miyoSyncedExclusions === "") {
+              // No local evidence — but a registration made before receipts
+              // existed leaves none, and neither does one whose receipt a
+              // Reset Settings wiped. Such a vault is still indexed, and its
+              // Relay can read the new root, while nothing local would ever
+              // report it: the startup notice is gated on the same empty
+              // receipt. Only asking the server can tell that apart from
+              // "never used Miyo". Read-only — it never mutates the
+              // registration; a covering record just self-heals the receipt.
+              void verifyMiyoScope(app).then((scope) => {
+                if (scope === "stale") notice();
+              });
             }
           })
           .then(() => ensureCopilotSubfolders(app.vault, { copilotFolder: folder }))

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { useCustomCommands } from "@/commands/state";
 import { MobileCard, MobileCardDropdownAction } from "@/components/ui/mobile-card";
-import { CopyPlus, Folder, GripVertical, Info, PenLine, Plus, Trash2 } from "lucide-react";
+import { CopyPlus, GripVertical, Info, PenLine, Plus, Trash2 } from "lucide-react";
 
 import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
 import {
   Table,
   TableBody,
@@ -39,15 +38,11 @@ import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { EMPTY_COMMAND } from "@/commands/constants";
 import { CustomCommandManager } from "@/commands/customCommandManager";
 import { CustomCommandSettingsModal } from "@/commands/CustomCommandSettingsModal";
-import {
-  generateCopyCommandName,
-  loadAllCustomCommands,
-  sortCommandsByOrder,
-} from "@/commands/customCommandUtils";
+import { generateCopyCommandName, sortCommandsByOrder } from "@/commands/customCommandUtils";
 import { generateDefaultCommands } from "@/commands/migrator";
 import { CustomCommand } from "@/commands/type";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
-import { FolderSearchModal } from "@/components/modals/FolderSearchModal";
+import { deriveCustomPromptsFolder } from "@/settings/copilotFolder";
 import { useApp } from "@/context";
 import { SettingItem } from "@/components/ui/setting-item";
 import { SettingSection } from "@/components/ui/setting-section";
@@ -298,6 +293,9 @@ export const CommandSettings: React.FC = () => {
   }, [rawCommands]);
 
   const settings = useSettingsValue();
+  // Derived from the single Copilot root; the folder is no longer separately
+  // editable, so the banner shows where commands are actually loaded from.
+  const customPromptsFolder = deriveCustomPromptsFolder(settings);
   const containerRef = useRef<HTMLDivElement>(null);
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -312,33 +310,6 @@ export const CommandSettings: React.FC = () => {
 
   const handleUpdate = async (newCommand: CustomCommand, prevCommandTitle: string) => {
     await CustomCommandManager.getInstance().updateCommand(newCommand, prevCommandTitle);
-  };
-
-  // Draft + blur-commit for the custom-prompts folder field. Reason: persisting
-  // on every keystroke would fire updateSetting + a full command reload per
-  // character. Mirrors the draft/blur pattern used by other folder inputs.
-  const persistedPromptsFolder = settings.customPromptsFolder;
-  const [promptsFolderDraft, setPromptsFolderDraft] = useState(persistedPromptsFolder);
-
-  useEffect(() => {
-    /* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- resync the local draft when the persisted folder changes underneath us (e.g. Reset Settings) */
-    setPromptsFolderDraft(persistedPromptsFolder);
-    /* eslint-enable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
-  }, [persistedPromptsFolder]);
-
-  // Persist the custom-prompts folder and reload commands from the new location.
-  // Shared by the blur-commit on the text input and the folder-picker button.
-  const commitPromptsFolder = (value: string) => {
-    if (value === persistedPromptsFolder) return;
-    updateSetting("customPromptsFolder", value);
-    void loadAllCustomCommands(app).catch((err) => logError("loadAllCustomCommands failed", err));
-  };
-
-  const handlePickPromptsFolder = () => {
-    new FolderSearchModal(app, (folder) => {
-      setPromptsFolderDraft(folder);
-      commitPromptsFolder(folder);
-    }).open();
   };
 
   const handleCreate = async (newCommand: CustomCommand) => {
@@ -436,8 +407,8 @@ export const CommandSettings: React.FC = () => {
 
   return (
     <div className="tw-space-y-4" ref={containerRef}>
-      <section>
-        <div className="tw-mb-4 tw-flex tw-flex-col tw-gap-2">
+      <section className={cn("tw-flex tw-flex-col tw-gap-4")}>
+        <div className="tw-flex tw-flex-col tw-gap-2">
           <div className="tw-text-xl tw-font-bold">Custom Commands</div>
           <div className="tw-text-sm tw-text-muted">
             Preset prompts you trigger from the editor right-click menu or with a <code>/</code>{" "}
@@ -449,44 +420,12 @@ export const CommandSettings: React.FC = () => {
           <Info className="tw-size-5 tw-shrink-0 tw-text-accent" />{" "}
           <div>
             Commands are automatically loaded from .md files in your custom prompts folder{" "}
-            <strong>{settings.customPromptsFolder}</strong>. Modifying the files will also update
-            the command settings.
+            <strong>{customPromptsFolder}</strong>. Modifying the files will also update the command
+            settings.
           </div>
         </div>
 
         <SettingSection>
-          <SettingItem
-            type="custom"
-            title="Custom Prompts Folder Name"
-            description="Folder where custom prompts are stored"
-          >
-            <div className="tw-flex tw-items-center tw-gap-2">
-              <Input
-                value={promptsFolderDraft}
-                onChange={(e) => setPromptsFolderDraft(e.target.value)}
-                onBlur={(e) => commitPromptsFolder(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    e.preventDefault();
-                    commitPromptsFolder(promptsFolderDraft);
-                    (e.target as HTMLInputElement).blur();
-                  }
-                }}
-                placeholder="copilot/copilot-custom-prompts"
-                className="!tw-w-56"
-                aria-label="Custom prompts folder"
-              />
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handlePickPromptsFolder}
-                title="Pick folder"
-                aria-label="Pick folder"
-              >
-                <Folder className="tw-size-4" />
-              </Button>
-            </div>
-          </SettingItem>
           <SettingItem
             type="switch"
             title="Custom Prompt Templating"

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -25,6 +25,7 @@ const updateSetting = jest.fn<void, unknown[]>();
 let currentSettings = { ...DEFAULT_SETTINGS };
 jest.mock("@/settings/model", () => ({
   updateSetting: (...a: unknown[]) => updateSetting(...a),
+  getSettings: () => currentSettings,
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
   useSettingsValue: () => currentSettings,
 }));
@@ -65,13 +66,26 @@ jest.mock("@/miyo/MiyoClient", () => ({
     checkFolderRegistration = async () => mockRegistration;
   },
 }));
+// Quiet by default so the resync banner doesn't render into unrelated tests;
+// the banner tests flip this on.
+const shouldSurfaceMiyoResync = jest.fn<boolean, unknown[]>(() => false);
 jest.mock("@/miyo/miyoUtils", () => ({
   getMiyoCustomUrl: () => "",
   getMiyoFolderExclusions: () => ({}),
+  getMiyoFolderInclusions: () => ({}),
   getMiyoFolderName: () => "vault",
   isLocalMiyoUrl: () => true,
+  buildMiyoSyncReceipt: () => "receipt",
+  shouldSurfaceMiyoResync: (...a: unknown[]) => shouldSurfaceMiyoResync(...a),
   MIYO_ADD_FOLDER_DEEPLINK_URL: "miyo://add",
   MIYO_DEEPLINK_URL: "miyo://",
+}));
+// The scope-resync module talks to a live Miyo; keep it inert here.
+const resyncMiyoFolder = jest.fn<Promise<string>, unknown[]>(async () => "verified");
+jest.mock("@/miyo/miyoResync", () => ({
+  enqueueMiyoFolderMutation: (task: () => Promise<unknown>) => task(),
+  resyncMiyoFolder: (...a: unknown[]) => resyncMiyoFolder(...a),
+  verifyMiyoScope: jest.fn(async () => "unknown"),
 }));
 // Capture the options the component passes to the modal so a test can invoke the
 // modal's callbacks (onRetry/onAddVault) directly — the Retry button has no
@@ -449,5 +463,22 @@ describe("Connect — two-phase commit rolls back on a failed health check", () 
     // Without the ownership token, A's superseded revert would write false here.
     expect(updateSetting).not.toHaveBeenCalledWith("enableMiyo", false);
     expect(enableTrueCount()).toBe(2);
+  });
+});
+
+describe("scope resync banner", () => {
+  it("stays hidden when the local receipt matches", () => {
+    render(<MiyoSettings />);
+    expect(screen.queryByRole("button", { name: /Resync Miyo/ })).toBeNull();
+  });
+
+  it("shows and runs the resync when the scope went stale", async () => {
+    shouldSurfaceMiyoResync.mockReturnValue(true);
+    render(<MiyoSettings />);
+
+    const button = screen.getByRole("button", { name: /Resync Miyo/ });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(resyncMiyoFolder).toHaveBeenCalledTimes(1));
   });
 });

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -68,6 +68,7 @@ jest.mock("@/miyo/MiyoClient", () => ({
   MiyoClient: class {
     isBackendAvailable = async () => mockReachable;
     checkFolderRegistration = async () => mockRegistration;
+    addFolder = async () => ({ path: "/vault" });
   },
 }));
 // Quiet by default so the resync banner doesn't render into unrelated tests;
@@ -88,20 +89,37 @@ jest.mock("@/miyo/miyoUtils", () => ({
 // verdict defaults to "unknown" (the component then falls back to the local
 // signal); the banner tests pin it to a definite verdict.
 const resyncMiyoFolder = jest.fn<Promise<string>, unknown[]>(async () => "verified");
+// Sessions the register flow presented to the queue, so a test can prove the
+// producer forwarded the plugin's rather than one of its own.
+const enqueuedSessions: unknown[] = [];
 const verifyMiyoScope = jest.fn<Promise<string>, unknown[]>(async () => "unknown");
 jest.mock("@/miyo/miyoResync", () => ({
   assertCurrentLifecycle: () => undefined,
-  enqueueMiyoFolderMutation: (task: (lifecycle: number) => Promise<unknown>) => task(0),
+  enqueueMiyoFolderMutation: (task: (lifecycle: number) => Promise<unknown>, session: unknown) => {
+    enqueuedSessions.push(session);
+    return task(0);
+  },
   resyncMiyoFolder: (...a: unknown[]) => resyncMiyoFolder(...a),
   verifyMiyoScope: (...a: unknown[]) => verifyMiyoScope(...a),
 }));
 // Capture the options the component passes to the modal so a test can invoke the
 // modal's callbacks (onRetry/onAddVault) directly — the Retry button has no
 // busy-guard, which is the real path that fires concurrent enable attempts.
-let lastModalOptions: { onRetry: () => Promise<unknown>; onClose: () => void } | null = null;
+let lastModalOptions: {
+  onRetry: () => Promise<unknown>;
+  onClose: () => void;
+  onAddVault?: () => Promise<unknown>;
+} | null = null;
 jest.mock("@/settings/v2/components/MiyoConnectModal", () => ({
   MiyoConnectModal: class {
-    constructor(_app: unknown, options: { onRetry: () => Promise<unknown>; onClose: () => void }) {
+    constructor(
+      _app: unknown,
+      options: {
+        onRetry: () => Promise<unknown>;
+        onClose: () => void;
+        onAddVault?: () => Promise<unknown>;
+      }
+    ) {
       lastModalOptions = options;
     }
     open = jest.fn();
@@ -160,6 +178,23 @@ beforeEach(() => {
   mockReachable = true;
   mockRegistration = "registered";
   lastModalOptions = null;
+  enqueuedSessions.length = 0;
+});
+
+it("registers through the queue with the plugin's session", async () => {
+  // The Connect modal is a standalone Obsidian Modal that outlives onunload, so
+  // its Add-this-vault callback is the producer most able to act for a closed
+  // lifecycle. It must hand the queue the plugin's session, not a fresh one.
+  mockRegistration = "unregistered";
+  render(<MiyoSettings />);
+
+  fireEvent.click(await screen.findByText("Connect"));
+  await waitFor(() => expect(lastModalOptions).not.toBeNull());
+  expect(lastModalOptions?.onAddVault).toBeDefined();
+
+  await lastModalOptions?.onAddVault?.();
+
+  expect(enqueuedSessions).toEqual([mockPluginInstance.miyoMutationSession]);
 });
 
 it("verifies scope with the plugin's session, not one this tab obtained itself", async () => {
@@ -520,6 +555,13 @@ describe("scope resync banner", () => {
     fireEvent.click(button);
 
     await waitFor(() => expect(resyncMiyoFolder).toHaveBeenCalledTimes(1));
+    // Same requirement as the verify probe: the Resync click must present the
+    // plugin's session, or a settings tree that outlived its lifecycle could
+    // delete and re-register on the incoming vault's queue.
+    expect(resyncMiyoFolder).toHaveBeenCalledWith(
+      expect.anything(),
+      mockPluginInstance.miyoMutationSession
+    );
   });
 
   it("re-verifies when the Copilot root changes while the tab stays mounted", async () => {

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -28,6 +28,10 @@ jest.mock("@/settings/model", () => ({
   getSettings: () => currentSettings,
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
   useSettingsValue: () => currentSettings,
+  // The scope-verify key derives the system roots through the real normalizer,
+  // so a test that moves the Copilot root gets the production root set.
+  normalizeRootFolders:
+    jest.requireActual<typeof import("@/settings/model")>("@/settings/model").normalizeRootFolders,
 }));
 
 // Miyo connection status. Defaults to connected; individual tests flip
@@ -80,12 +84,15 @@ jest.mock("@/miyo/miyoUtils", () => ({
   MIYO_ADD_FOLDER_DEEPLINK_URL: "miyo://add",
   MIYO_DEEPLINK_URL: "miyo://",
 }));
-// The scope-resync module talks to a live Miyo; keep it inert here.
+// The scope-resync module talks to a live Miyo; keep it inert here. The verify
+// verdict defaults to "unknown" (the component then falls back to the local
+// signal); the banner tests pin it to a definite verdict.
 const resyncMiyoFolder = jest.fn<Promise<string>, unknown[]>(async () => "verified");
+const verifyMiyoScope = jest.fn<Promise<string>, unknown[]>(async () => "unknown");
 jest.mock("@/miyo/miyoResync", () => ({
   enqueueMiyoFolderMutation: (task: () => Promise<unknown>) => task(),
   resyncMiyoFolder: (...a: unknown[]) => resyncMiyoFolder(...a),
-  verifyMiyoScope: jest.fn(async () => "unknown"),
+  verifyMiyoScope: (...a: unknown[]) => verifyMiyoScope(...a),
 }));
 // Capture the options the component passes to the modal so a test can invoke the
 // modal's callbacks (onRetry/onAddVault) directly — the Retry button has no
@@ -100,9 +107,13 @@ jest.mock("@/settings/v2/components/MiyoConnectModal", () => ({
     close = jest.fn();
   },
 }));
+// Stable identity, matching production: useApp() reads a context value, so the
+// app reference does not change between renders. A fresh object per call would
+// re-fire every app-keyed effect on each render.
+const mockAppInstance = {};
 jest.mock("@/context", () => ({
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
-  useApp: () => ({}),
+  useApp: () => mockAppInstance,
 }));
 jest.mock("@/plusUtils", () => ({ createPlusPageUrl: () => "https://example.com" }));
 jest.mock("@/utils/vaultPath", () => ({ getVaultBase: () => "/vault" }));
@@ -467,6 +478,12 @@ describe("Connect — two-phase commit rolls back on a failed health check", () 
 });
 
 describe("scope resync banner", () => {
+  // The verdict is pinned per test; restore the indefinite default so a pinned
+  // verdict can't leak forward.
+  beforeEach(() => {
+    verifyMiyoScope.mockResolvedValue("unknown");
+  });
+
   it("stays hidden when the local receipt matches", () => {
     render(<MiyoSettings />);
     expect(screen.queryByRole("button", { name: /Resync Miyo/ })).toBeNull();
@@ -480,5 +497,43 @@ describe("scope resync banner", () => {
     fireEvent.click(button);
 
     await waitFor(() => expect(resyncMiyoFolder).toHaveBeenCalledTimes(1));
+  });
+
+  it("re-verifies when the Copilot root changes while the tab stays mounted", async () => {
+    // A "covered" verdict vetoes the local mismatch signal outright, so the
+    // banner is hidden despite shouldSurfaceMiyoResync saying otherwise.
+    shouldSurfaceMiyoResync.mockReturnValue(true);
+    verifyMiyoScope.mockResolvedValue("covered");
+    const { rerender } = render(<MiyoSettings />);
+    await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("button", { name: /Resync Miyo/ })).toBeNull();
+
+    // A root change reaches the shared settings atom without unmounting this
+    // tab: its Apply persists to disk before flipping the in-memory root, and
+    // the user can be back here by then. A verdict about roots that no longer
+    // apply must stop answering for the ones that do.
+    currentSettings = { ...currentSettings, copilotFolder: "notes/copilot" };
+    verifyMiyoScope.mockResolvedValue("unknown");
+    rerender(<MiyoSettings />);
+
+    await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole("button", { name: /Resync Miyo/ })).toBeTruthy();
+  });
+
+  it("re-verifies when Connect adopts a registration this tab did not create", async () => {
+    // Nothing was registered at load, so the verdict reads "no exposure".
+    verifyMiyoScope.mockResolvedValue("unregistered");
+    mockMiyoBackend = "unavailable";
+    currentSettings = { ...DEFAULT_SETTINGS, enableMiyo: false };
+    render(<MiyoSettings />);
+    await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(1));
+
+    // The user registered the vault in the Miyo app and Connect finds it
+    // already there. That record's exclusions are unknown and no local input
+    // moved, so only an explicit re-verify can tell whether it exposes the
+    // Copilot roots.
+    fireEvent.click(await screen.findByText("Connect"));
+
+    await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalledTimes(2));
   });
 });

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -12,6 +12,14 @@ jest.mock("@/agentMode", () => ({
   removeMiyoSearchSkill: (...a: unknown[]) => removeMiyoSearchSkill(...a),
 }));
 
+// Skills folder derives from the configurable Copilot root. Mock the pure
+// deriver so a test can point the root anywhere and assert the toggle installs
+// to the derived path, without pulling in the real obsidian normalizePath.
+jest.mock("@/settings/copilotFolder", () => ({
+  deriveSkillsFolder: (s: { copilotFolder?: string }) =>
+    `${(s.copilotFolder || "copilot").replace(/\/+$/, "")}/skills`,
+}));
+
 // Persisted-settings surface: capture writes and feed a controllable snapshot.
 const updateSetting = jest.fn<void, unknown[]>();
 let currentSettings = { ...DEFAULT_SETTINGS };
@@ -128,6 +136,29 @@ it("installs the skill, commits the flag, and confirms with a Notice on enable",
   await waitFor(() => expect(installMiyoSearchSkill).toHaveBeenCalledTimes(1));
   expect(updateSetting).toHaveBeenCalledWith("enableMiyoSearchSkill", true);
   expect(NoticeMock).toHaveBeenCalledWith("Miyo search skill installed");
+});
+
+it("installs to the folder derived from a non-default Copilot root, not the retired field", async () => {
+  // Regression: a customized root must reach the derived skills folder. The
+  // retired agentMode.skills.folder no longer tracks the root, so installing
+  // against it would write to the wrong directory (and collide with the path
+  // the background seeder uses).
+  currentSettings = {
+    ...DEFAULT_SETTINGS,
+    enableMiyoSearchSkill: false,
+    copilotFolder: "team/copilot",
+    agentMode: {
+      ...DEFAULT_SETTINGS.agentMode,
+      skills: { ...DEFAULT_SETTINGS.agentMode.skills, folder: "copilot/skills" },
+    },
+  };
+  installMiyoSearchSkill.mockResolvedValue("installed");
+  render(<MiyoSettings />);
+
+  fireEvent.click(toggle());
+
+  await waitFor(() => expect(installMiyoSearchSkill).toHaveBeenCalledTimes(1));
+  expect(installMiyoSearchSkill).toHaveBeenCalledWith(expect.anything(), "team/copilot/skills");
 });
 
 it("does NOT commit the flag on a collision, and explains why", async () => {

--- a/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
+++ b/src/settings/v2/components/MiyoSettings.searchSkill.test.tsx
@@ -90,7 +90,8 @@ jest.mock("@/miyo/miyoUtils", () => ({
 const resyncMiyoFolder = jest.fn<Promise<string>, unknown[]>(async () => "verified");
 const verifyMiyoScope = jest.fn<Promise<string>, unknown[]>(async () => "unknown");
 jest.mock("@/miyo/miyoResync", () => ({
-  enqueueMiyoFolderMutation: (task: () => Promise<unknown>) => task(),
+  assertCurrentLifecycle: () => undefined,
+  enqueueMiyoFolderMutation: (task: (lifecycle: number) => Promise<unknown>) => task(0),
   resyncMiyoFolder: (...a: unknown[]) => resyncMiyoFolder(...a),
   verifyMiyoScope: (...a: unknown[]) => verifyMiyoScope(...a),
 }));
@@ -114,6 +115,15 @@ const mockAppInstance = {};
 jest.mock("@/context", () => ({
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
   useApp: () => mockAppInstance,
+}));
+// The Miyo mutation session is owned by the plugin (one per lifecycle) rather
+// than captured by this tab, which mounts lazily. Hoisted so the stand-in keeps
+// production's referential stability: the session is an effect dependency, and a
+// fresh object per render would loop the verify effect forever.
+const mockPluginInstance = { miyoMutationSession: Object.freeze({ lifecycle: 0 }) };
+jest.mock("@/contexts/PluginContext", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
+  usePlugin: () => mockPluginInstance,
 }));
 jest.mock("@/plusUtils", () => ({ createPlusPageUrl: () => "https://example.com" }));
 jest.mock("@/utils/vaultPath", () => ({ getVaultBase: () => "/vault" }));
@@ -150,6 +160,19 @@ beforeEach(() => {
   mockReachable = true;
   mockRegistration = "registered";
   lastModalOptions = null;
+});
+
+it("verifies scope with the plugin's session, not one this tab obtained itself", async () => {
+  // Tabs mount lazily, so a tab first opened after a plugin reload would
+  // otherwise vouch for the incoming lifecycle while holding the outgoing
+  // vault's app. The session has to come from the plugin instance.
+  render(<MiyoSettings />);
+
+  await waitFor(() => expect(verifyMiyoScope).toHaveBeenCalled());
+  expect(verifyMiyoScope).toHaveBeenCalledWith(
+    expect.anything(),
+    mockPluginInstance.miyoMutationSession
+  );
 });
 
 it("installs the skill, commits the flag, and confirms with a Notice on enable", async () => {

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -10,7 +10,12 @@ import { cn } from "@/lib/utils";
 import { logWarn } from "@/logger";
 import { MiyoClient } from "@/miyo/MiyoClient";
 import { type CapabilityStatus, refreshMiyoStatus } from "@/miyo/miyoStatusStore";
-import { enqueueMiyoFolderMutation, resyncMiyoFolder, verifyMiyoScope } from "@/miyo/miyoResync";
+import {
+  assertCurrentLifecycle,
+  enqueueMiyoFolderMutation,
+  resyncMiyoFolder,
+  verifyMiyoScope,
+} from "@/miyo/miyoResync";
 import {
   buildMiyoSyncReceipt,
   getMiyoCustomUrl,
@@ -439,13 +444,13 @@ export const MiyoSettings: React.FC = () => {
       //     If a review flags this again, point them at this note.
       // Serialized with resync runs: the Resync button's DELETE/POST must never
       // interleave with this registration. The task reads settings when it RUNS,
-      // settings when it RUNS, not when it is queued — it can sit behind an
+      // not when it is queued — it can sit behind an
       // in-flight mutation, and a root/endpoint change landing in that window
       // would otherwise be submitted as an already-stale scope (with a receipt
       // vouching for it). Mirrors resyncMiyoFolder's execution-time fresh read;
       // the receipt is built from the same snapshot as the submitted body so it
       // always describes what the server actually holds.
-      const submission = await enqueueMiyoFolderMutation(async () => {
+      const submission = await enqueueMiyoFolderMutation(async (lifecycle) => {
         const fresh = getSettings();
         const freshUrl = getMiyoCustomUrl(fresh);
         // DESIGN NOTE — a remote flip mid-queue surfaces as the retryable
@@ -466,7 +471,10 @@ export const MiyoSettings: React.FC = () => {
         }
         // Snapshot the credential alongside the endpoint: this registration is
         // queued and can outlive the vault that asked for it, while the auth
-        // header is otherwise read live per request.
+        // header is otherwise read live per request. The lifecycle re-check is
+        // separate from `superseded()` above — that one tracks the UI's own
+        // attempt generation, this one whether the vault is still open at all.
+        assertCurrentLifecycle(lifecycle);
         const created = await new MiyoClient({ plusLicenseKey: fresh.plusLicenseKey }).addFolder(
           {
             path: vaultBase,

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -223,18 +223,36 @@ export const MiyoSettings: React.FC = () => {
   // unreachable → the banner falls back to the local receipt-mismatch signal.
   const [serverScopeStale, setServerScopeStale] = useState<boolean | null>(null);
   const [resyncPending, setResyncPending] = useState(false);
+  const [scopeVerifyNonce, setScopeVerifyNonce] = useState(0);
 
-  // Verify the live record on mount AND whenever the Miyo endpoint changes —
-  // a verdict for the old endpoint says nothing about the new one, so it is
-  // reset before re-verifying (the `cancelled` flag drops results from a
-  // superseded run). The live record outranks local signals in both directions:
-  // a covering record silently self-heals a mismatched receipt (e.g. another
-  // device's receipt arrived via sync), and a stale record forces the banner
-  // even when local state looks clean (Reset Settings wiped the receipt, or
-  // the registration predates receipts).
+  // Forces the verify below to run again when the live record may have changed
+  // without any local input moving — see the call sites for the two cases.
+  const invalidateScopeVerdict = useCallback(() => setScopeVerifyNonce((n) => n + 1), []);
+
+  // Verify the live record on mount AND whenever an input the verdict was
+  // derived from moves underneath it: the Miyo endpoint, the system roots the
+  // record is checked against, or an explicit invalidation. The verdict is a
+  // sticky veto — a `false` suppresses the local mismatch banner outright — so
+  // a verdict formed against inputs that no longer hold must not answer for the
+  // current ones; it is reset before re-verifying (the `cancelled` flag drops
+  // results from a superseded run). Keying on the roots also covers the async
+  // tail of a root change: `applyCopilotRootChange` persists to disk before it
+  // flips the in-memory root, and the user can open this tab inside that window,
+  // so the new root can land while this component stays mounted.
+  //
+  // The live record outranks local signals in both directions: a covering
+  // record silently self-heals a mismatched receipt (e.g. another device's
+  // receipt arrived via sync), and a stale record forces the banner even when
+  // local state looks clean (Reset Settings wiped the receipt, or the
+  // registration predates receipts).
   const miyoEndpointUrl = getMiyoCustomUrl(settings);
+  // Only the system roots: they are what the record is checked against
+  // (`miyoRecordCoversSystemRoots`). The receipt is deliberately NOT part of
+  // this key — a "covered" verdict writes the receipt itself, which would
+  // re-trigger the effect forever.
+  const verifiedRootsKey = [...getSystemExcludedFolders(settings)].sort().join("\n");
   useEffect(() => {
-    /* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- reset the stale verdict when the endpoint changes underneath us */
+    /* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- reset the stale verdict when the inputs it was derived from change underneath us */
     setServerScopeStale(null);
     /* eslint-enable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
     // No local-only gate: the verify is a read-only lookup that works against a
@@ -251,7 +269,7 @@ export const MiyoSettings: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [app, miyoEndpointUrl]);
+  }, [app, miyoEndpointUrl, verifiedRootsKey, scopeVerifyNonce]);
 
   const handleResync = useCallback(async () => {
     setResyncPending(true);
@@ -480,10 +498,15 @@ export const MiyoSettings: React.FC = () => {
     // confirm reachability is "unreachable" (guide the user to start Miyo), never
     // "error" (which reads as "couldn't register" and contradicts the server).
     if (superseded()) return "unreachable";
+    // The record just changed (201) or turned out to pre-exist with unknown
+    // exclusions (409, which deliberately leaves the receipt empty above). The
+    // standing verdict was formed against the record as it was before either,
+    // so it must not keep vetoing the banner.
+    invalidateScopeVerdict();
     const available = await enableMiyoBackend(superseded);
     if (superseded()) return "unreachable";
     return available ? "added" : "unreachable";
-  }, [app, settings, enableMiyoBackend]);
+  }, [app, settings, enableMiyoBackend, invalidateScopeVerdict]);
 
   // One connection attempt: probe reachability, then (if reachable) check whether
   // this vault is registered with Miyo. An unregistered vault is NOT auto-added —
@@ -514,6 +537,11 @@ export const MiyoSettings: React.FC = () => {
     // Registered → enable. Re-check the guard right before the settings write so a
     // cancel/unmount that landed during the check can't flip enableMiyo on.
     if (superseded()) return "superseded";
+    // This tab never registered the vault, so the record is one the user created
+    // in the Miyo app — its exclusions are unknown and no local input moved to
+    // signal that. Re-verify instead of trusting a verdict formed when the
+    // record was absent (or was a different record entirely).
+    invalidateScopeVerdict();
     const available = await enableMiyoBackend(superseded);
     // A newer attempt may have started during the enable refresh — don't let this
     // stale result drive the UI (close the modal / bounce a step). enableMiyoBackend
@@ -522,7 +550,7 @@ export const MiyoSettings: React.FC = () => {
     // Miyo may have dropped between registration and this refresh; only claim
     // "connected" when the backend is actually available now.
     return available ? "connected" : "unreachable";
-  }, [app, settings, probeReachable, enableMiyoBackend]);
+  }, [app, settings, probeReachable, enableMiyoBackend, invalidateScopeVerdict]);
 
   // Wraps attemptConnection with the shared error affordance so both entry points
   // (Connect button, modal Retry) surface the same Notice on an indeterminate

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -426,8 +426,8 @@ export const MiyoSettings: React.FC = () => {
       //     needs either a query-time userIgnoreFilters filter in the retriever or
       //     an idempotent folder-filter re-sync; both are out of this PR's scope.
       //     If a review flags this again, point them at this note.
-      // Serialized with resync runs: an auto-resync after a root change must
-      // never interleave its DELETE/POST with this registration. The task reads
+      // Serialized with resync runs: the Resync button's DELETE/POST must never
+      // interleave with this registration. The task reads settings when it RUNS,
       // settings when it RUNS, not when it is queued — it can sit behind an
       // in-flight mutation, and a root/endpoint change landing in that window
       // would otherwise be submitted as an already-stale scope (with a receipt
@@ -453,7 +453,10 @@ export const MiyoSettings: React.FC = () => {
             "Miyo endpoint switched to a remote target while registration was queued"
           );
         }
-        const created = await new MiyoClient().addFolder(
+        // Snapshot the credential alongside the endpoint: this registration is
+        // queued and can outlive the vault that asked for it, while the auth
+        // header is otherwise read live per request.
+        const created = await new MiyoClient({ plusLicenseKey: fresh.plusLicenseKey }).addFolder(
           {
             path: vaultBase,
             // Remote read (Relay) is enabled by default so a user who turns on

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -4,7 +4,7 @@ import { SegmentedControl } from "@/components/ui/segmented-control";
 import { SettingItem } from "@/components/ui/setting-item";
 import { SettingSection } from "@/components/ui/setting-section";
 import { SettingSwitch } from "@/components/ui/setting-switch";
-import { DEFAULT_SKILLS_FOLDER, MIYO_HOMEPAGE_URL } from "@/constants";
+import { MIYO_HOMEPAGE_URL } from "@/constants";
 import { useApp } from "@/context";
 import { cn } from "@/lib/utils";
 import { logWarn } from "@/logger";
@@ -20,6 +20,7 @@ import {
   MIYO_CONNECT_DEEPLINK_URL,
 } from "@/miyo/miyoUtils";
 import { useMiyoStatus } from "@/miyo/useMiyoStatus";
+import { deriveSkillsFolder } from "@/settings/copilotFolder";
 import { updateSetting, useSettingsValue } from "@/settings/model";
 import {
   type ConnectOutcome,
@@ -488,6 +489,11 @@ export const MiyoSettings: React.FC = () => {
   // `miyo-search` folder, or a write failure, must leave the toggle off rather
   // than claim success. A generation token drops a superseded flip (rapid
   // on/off, or unmount) so it can't commit stale state or fire a late Notice.
+  // Derive the skills folder from the configurable Copilot root rather than the
+  // retired `agentMode.skills.folder`, which no longer tracks the root: a
+  // non-default root would otherwise install/remove the skill in the wrong
+  // directory (and collide with the derived path the background seeder uses).
+  const skillsFolder = deriveSkillsFolder(settings);
   const handleToggleSearchSkill = useCallback(
     async (next: boolean) => {
       const attempt = (skillAttemptRef.current += 1);
@@ -498,7 +504,6 @@ export const MiyoSettings: React.FC = () => {
       const superseded = () => skillAttemptRef.current !== attempt;
       const unmounted = () => !mountedRef.current;
       setPendingSkillEnabled(next);
-      const folder = settings.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
       try {
         // Import the agent-mode barrel lazily: it pulls in Node-only modules and
         // must never be evaluated on mobile (see main.ts). This handler only runs
@@ -508,7 +513,7 @@ export const MiyoSettings: React.FC = () => {
         // Nothing has touched disk yet, so bailing here can't diverge disk from flag.
         if (superseded() || unmounted()) return;
         if (next) {
-          const result = await installMiyoSearchSkill(app, folder);
+          const result = await installMiyoSearchSkill(app, skillsFolder);
           if (superseded()) return;
           if (result === "installed") {
             // Persist regardless of unmount: the files ARE on disk now.
@@ -524,7 +529,7 @@ export const MiyoSettings: React.FC = () => {
             new Notice("Couldn't install the Miyo search skill. Please try again.");
           }
         } else {
-          const result = await removeMiyoSearchSkill(app, folder);
+          const result = await removeMiyoSearchSkill(app, skillsFolder);
           if (superseded()) return;
           if (result === "failed") {
             // The skill is still on disk — keep the flag on so UI and disk agree,
@@ -552,7 +557,7 @@ export const MiyoSettings: React.FC = () => {
         if (!superseded() && !unmounted()) setPendingSkillEnabled(null);
       }
     },
-    [app, settings.agentMode?.skills?.folder]
+    [app, skillsFolder]
   );
 
   const commitUrl = useCallback(() => {

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -29,7 +29,7 @@ import {
 import { MiyoStatusRow } from "@/settings/v2/components/MiyoStatusRow";
 import { err2String } from "@/utils";
 import { getVaultBase } from "@/utils/vaultPath";
-import { extractAppIgnoreSettings } from "@/search/searchUtils";
+import { extractAppIgnoreSettings, getSystemExcludedFolders } from "@/search/searchUtils";
 import { ArrowUpRight, ChevronRight, CornerDownRight, TriangleAlert } from "lucide-react";
 import { Notice, Platform } from "obsidian";
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -342,7 +342,16 @@ export const MiyoSettings: React.FC = () => {
           // vault kept out of Relay can flip allow_remote_read off per folder in Miyo.
           allow_remote_read: true,
           ...getMiyoFolderInclusions(settings.qaInclusions),
-          ...getMiyoFolderExclusions(settings.qaExclusions, extractAppIgnoreSettings(app)),
+          // Project the always-on system root exclusions (active + historical
+          // Copilot roots) alongside Obsidian's own ignore folders, so a former
+          // root's content isn't uploaded for indexing. This is a registration-
+          // time snapshot; MiyoSemanticRetriever re-applies the LIVE scope
+          // (createCopilotPatternFilter, which also enforces these roots) at
+          // query time, so correctness never depends on the snapshot.
+          ...getMiyoFolderExclusions(settings.qaExclusions, [
+            ...getSystemExcludedFolders(settings),
+            ...extractAppIgnoreSettings(app),
+          ]),
         },
         customUrl || undefined
       );

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -289,6 +289,17 @@ export const MiyoSettings: React.FC = () => {
           new Notice("Miyo resynced; indexing will catch up on Miyo's next scan.");
           setServerScopeStale(false);
           break;
+        case "resynced-grants-reset":
+          // The rebuild could not recover this folder's Miyo-side permissions,
+          // so they were reset to off. Say so plainly: a user who had remote
+          // read enabled would otherwise keep believing it still is.
+          new Notice(
+            "Miyo resynced. This folder's registration had to be rebuilt, so its " +
+              "remote read and write access were turned off — re-enable them in the Miyo app if you want them.",
+            10000
+          );
+          setServerScopeStale(false);
+          break;
         case "conflict":
           new Notice(
             "Miyo reports a conflicting registration (possibly under this vault's previous name). " +

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -10,7 +10,9 @@ import { cn } from "@/lib/utils";
 import { logWarn } from "@/logger";
 import { MiyoClient } from "@/miyo/MiyoClient";
 import { type CapabilityStatus, refreshMiyoStatus } from "@/miyo/miyoStatusStore";
+import { enqueueMiyoFolderMutation, resyncMiyoFolder, verifyMiyoScope } from "@/miyo/miyoResync";
 import {
+  buildMiyoSyncReceipt,
   getMiyoCustomUrl,
   getMiyoFolderExclusions,
   getMiyoFolderInclusions,
@@ -18,6 +20,7 @@ import {
   isLocalMiyoUrl,
   MIYO_CHATS_DEEPLINK_URL,
   MIYO_CONNECT_DEEPLINK_URL,
+  shouldSurfaceMiyoResync,
 } from "@/miyo/miyoUtils";
 import { useMiyoStatus } from "@/miyo/useMiyoStatus";
 import { deriveSkillsFolder } from "@/settings/copilotFolder";
@@ -215,6 +218,73 @@ export const MiyoSettings: React.FC = () => {
     void refresh(false);
   }, [refresh]);
 
+  // ── Miyo scope resync ──
+  // Server-verified staleness from the on-mount check; null = unverified /
+  // unreachable → the banner falls back to the local receipt-mismatch signal.
+  const [serverScopeStale, setServerScopeStale] = useState<boolean | null>(null);
+  const [resyncPending, setResyncPending] = useState(false);
+
+  // Verify the live record on mount AND whenever the Miyo endpoint changes —
+  // a verdict for the old endpoint says nothing about the new one, so it is
+  // reset before re-verifying (the `cancelled` flag drops results from a
+  // superseded run). The live record outranks local signals in both directions:
+  // a covering record silently self-heals a mismatched receipt (e.g. another
+  // device's receipt arrived via sync), and a stale record forces the banner
+  // even when local state looks clean (Reset Settings wiped the receipt, or
+  // the registration predates receipts).
+  const miyoEndpointUrl = getMiyoCustomUrl(settings);
+  useEffect(() => {
+    /* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- reset the stale verdict when the endpoint changes underneath us */
+    setServerScopeStale(null);
+    /* eslint-enable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
+    // No local-only gate: the verify is a read-only lookup that works against a
+    // remote Miyo too, and it's the only way a remote user's banner can ever
+    // clear (they have no local register flow to write a receipt). Unreachable
+    // endpoints resolve to "unknown" and fall back to the local signal. Only
+    // the Resync button's delete/re-add stays gated on canAutoAddVault.
+    let cancelled = false;
+    void verifyMiyoScope(app).then((verdict) => {
+      if (cancelled || !mountedRef.current) return;
+      if (verdict === "stale") setServerScopeStale(true);
+      else if (verdict === "covered" || verdict === "unregistered") setServerScopeStale(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [app, miyoEndpointUrl]);
+
+  const handleResync = useCallback(async () => {
+    setResyncPending(true);
+    try {
+      const outcome = await resyncMiyoFolder(app);
+      if (!mountedRef.current) return;
+      switch (outcome) {
+        case "verified":
+          new Notice("Miyo is already in sync with your Copilot folders.");
+          setServerScopeStale(false);
+          break;
+        case "resynced":
+          new Notice("Miyo resynced — excluded folders updated, re-index started.");
+          setServerScopeStale(false);
+          break;
+        case "resynced-scan-failed":
+          new Notice("Miyo resynced; indexing will catch up on Miyo's next scan.");
+          setServerScopeStale(false);
+          break;
+        case "conflict":
+          new Notice(
+            "Miyo still reports a conflicting registration. Retry, or remove this folder in the Miyo app."
+          );
+          break;
+        case "failed":
+          new Notice("Couldn't resync Miyo. Make sure Miyo is running, then retry.");
+          break;
+      }
+    } finally {
+      if (mountedRef.current) setResyncPending(false);
+    }
+  }, [app]);
+
   // Direct reachability probe that BYPASSES the shouldUseMiyo gate. The status
   // store only probes once Miyo is enabled (its snapshot reflects the *effective*
   // backend), but Connect must check reachability *before* enabling — the same
@@ -331,31 +401,44 @@ export const MiyoSettings: React.FC = () => {
       //     needs either a query-time userIgnoreFilters filter in the retriever or
       //     an idempotent folder-filter re-sync; both are out of this PR's scope.
       //     If a review flags this again, point them at this note.
-      await new MiyoClient().addFolder(
-        {
-          path: vaultBase,
-          // Remote read (Relay) is enabled by default so a user who turns on
-          // Miyo's Relay connector — itself an explicit, paid, signed-in opt-in
-          // (ChatGPT/Claude linked once) — gets cloud access to this vault without
-          // re-configuring it per folder. It's inert until Relay is actually on, so
-          // it doesn't expose anything on its own; the register modal states this
-          // plainly rather than promising absolute privacy. A user who wants this
-          // vault kept out of Relay can flip allow_remote_read off per folder in Miyo.
-          allow_remote_read: true,
-          ...getMiyoFolderInclusions(settings.qaInclusions),
-          // Project the always-on system root exclusions (active + historical
-          // Copilot roots) alongside Obsidian's own ignore folders, so a former
-          // root's content isn't uploaded for indexing. This is a registration-
-          // time snapshot; MiyoSemanticRetriever re-applies the LIVE scope
-          // (createCopilotPatternFilter, which also enforces these roots) at
-          // query time, so correctness never depends on the snapshot.
-          ...getMiyoFolderExclusions(settings.qaExclusions, [
-            ...getSystemExcludedFolders(settings),
-            ...extractAppIgnoreSettings(app),
-          ]),
-        },
-        customUrl || undefined
+      // Serialized with resync runs: an auto-resync after a root change must
+      // never interleave its DELETE/POST with this registration.
+      const created = await enqueueMiyoFolderMutation(() =>
+        new MiyoClient().addFolder(
+          {
+            path: vaultBase,
+            // Remote read (Relay) is enabled by default so a user who turns on
+            // Miyo's Relay connector — itself an explicit, paid, signed-in opt-in
+            // (ChatGPT/Claude linked once) — gets cloud access to this vault without
+            // re-configuring it per folder. It's inert until Relay is actually on, so
+            // it doesn't expose anything on its own; the register modal states this
+            // plainly rather than promising absolute privacy. A user who wants this
+            // vault kept out of Relay can flip allow_remote_read off per folder in Miyo.
+            allow_remote_read: true,
+            ...getMiyoFolderInclusions(settings.qaInclusions),
+            // Project the always-on system root exclusions (active + historical
+            // Copilot roots) alongside Obsidian's own ignore folders, so a former
+            // root's content isn't uploaded for indexing. This is a registration-
+            // time snapshot; MiyoSemanticRetriever re-applies the LIVE scope
+            // (createCopilotPatternFilter, which also enforces these roots) at
+            // query time, so correctness never depends on the snapshot.
+            ...getMiyoFolderExclusions(settings.qaExclusions, [
+              ...getSystemExcludedFolders(settings),
+              ...extractAppIgnoreSettings(app),
+            ]),
+          },
+          customUrl || undefined
+        )
       );
+      // Record the sync receipt only for a fresh 201 — a 409 (already
+      // registered) means the server holds an EARLIER snapshot whose exclusions
+      // are unknown and possibly stale; marking it synced would silence the
+      // resync prompt over a stale scope. Written before the enable step and
+      // regardless of `superseded()`: the server-side registration DID happen
+      // with this exact body, whatever the UI does afterwards.
+      if (created !== null) {
+        updateSetting("miyoSyncedExclusions", buildMiyoSyncReceipt(app, settings));
+      }
     } catch (error) {
       logWarn(`Miyo add-folder failed: ${err2String(error)}`);
       return "error";
@@ -594,6 +677,29 @@ export const MiyoSettings: React.FC = () => {
       <div className="tw-text-sm tw-text-muted">
         Local, private context that stays on your machine — unlimited, no credits.
       </div>
+
+      {(serverScopeStale === true ||
+        (serverScopeStale === null && shouldSurfaceMiyoResync(app, settings))) && (
+        <div className="tw-flex tw-items-center tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-px-3 tw-py-2.5 tw-text-xs tw-text-warning tw-bg-warning/10 tw-border-warning/30">
+          <TriangleAlert className="tw-size-4 tw-shrink-0" />
+          <span className="tw-flex-1">
+            Miyo&apos;s excluded folders don&apos;t match your Copilot folder — chats could be
+            indexed and exposed. Resync to update them.
+          </span>
+          {canAutoAddVault() ? (
+            <Button
+              size="sm"
+              variant="secondary"
+              disabled={resyncPending}
+              onClick={() => void handleResync()}
+            >
+              {resyncPending ? "Resyncing…" : "Resync Miyo"}
+            </Button>
+          ) : (
+            <span className="tw-shrink-0">Remove and re-add this folder in the Miyo app.</span>
+          )}
+        </div>
+      )}
 
       {/* Connection */}
       <SettingSection label="Connection">

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -6,6 +6,7 @@ import { SettingSection } from "@/components/ui/setting-section";
 import { SettingSwitch } from "@/components/ui/setting-switch";
 import { MIYO_HOMEPAGE_URL } from "@/constants";
 import { useApp } from "@/context";
+import { usePlugin } from "@/contexts/PluginContext";
 import { cn } from "@/lib/utils";
 import { logWarn } from "@/logger";
 import { MiyoClient } from "@/miyo/MiyoClient";
@@ -132,6 +133,11 @@ export const MiyoSettings: React.FC = () => {
   const app = useApp();
   const settings = useSettingsValue();
   const status = useMiyoStatus();
+
+  // From the plugin, not captured here: this tab mounts the first time the user
+  // selects it, which in a settings tree that outlived a reload is a different
+  // lifecycle than the one this tree belongs to.
+  const { miyoMutationSession } = usePlugin();
 
   // Draft + blur commit so we persist once on blur, not on every keystroke.
   const [urlDraft, setUrlDraft] = useState(settings.miyoServerUrl || "");
@@ -266,7 +272,7 @@ export const MiyoSettings: React.FC = () => {
     // endpoints resolve to "unknown" and fall back to the local signal. Only
     // the Resync button's delete/re-add stays gated on canAutoAddVault.
     let cancelled = false;
-    void verifyMiyoScope(app).then((verdict) => {
+    void verifyMiyoScope(app, miyoMutationSession).then((verdict) => {
       if (cancelled || !mountedRef.current) return;
       if (verdict === "stale") setServerScopeStale(true);
       else if (verdict === "covered" || verdict === "unregistered") setServerScopeStale(false);
@@ -274,12 +280,12 @@ export const MiyoSettings: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [app, miyoEndpointUrl, verifiedRootsKey, scopeVerifyNonce]);
+  }, [app, miyoEndpointUrl, miyoMutationSession, verifiedRootsKey, scopeVerifyNonce]);
 
   const handleResync = useCallback(async () => {
     setResyncPending(true);
     try {
-      const outcome = await resyncMiyoFolder(app);
+      const outcome = await resyncMiyoFolder(app, miyoMutationSession);
       if (!mountedRef.current) return;
       switch (outcome) {
         case "verified":
@@ -324,7 +330,7 @@ export const MiyoSettings: React.FC = () => {
     } finally {
       if (mountedRef.current) setResyncPending(false);
     }
-  }, [app]);
+  }, [app, miyoMutationSession]);
 
   // Direct reachability probe that BYPASSES the shouldUseMiyo gate. The status
   // store only probes once Miyo is enabled (its snapshot reflects the *effective*
@@ -471,10 +477,11 @@ export const MiyoSettings: React.FC = () => {
         }
         // Snapshot the credential alongside the endpoint: this registration is
         // queued and can outlive the vault that asked for it, while the auth
-        // header is otherwise read live per request. The lifecycle re-check is
-        // separate from `superseded()` above — that one tracks the UI's own
-        // attempt generation, this one whether the vault is still open at all.
-        assertCurrentLifecycle(lifecycle);
+        // header is otherwise read live per request. The lifecycle check rides
+        // on `addFolder`'s `beforeRequest` below — it fires after URL resolution
+        // and decryption, so unlike a check here it cannot go stale before the
+        // POST leaves. It is separate from `superseded()` above: that tracks the
+        // UI's own attempt generation, this one whether the vault is still open.
         const created = await new MiyoClient({ plusLicenseKey: fresh.plusLicenseKey }).addFolder(
           {
             path: vaultBase,
@@ -498,10 +505,11 @@ export const MiyoSettings: React.FC = () => {
               ...extractAppIgnoreSettings(app),
             ]),
           },
-          freshUrl || undefined
+          freshUrl || undefined,
+          () => assertCurrentLifecycle(lifecycle)
         );
         return { created, receipt: buildMiyoSyncReceipt(app, fresh) };
-      });
+      }, miyoMutationSession);
       // Record the sync receipt only for a fresh 201 — a 409 (already
       // registered) means the server holds an EARLIER snapshot whose exclusions
       // are unknown and possibly stale; marking it synced would silence the
@@ -528,7 +536,7 @@ export const MiyoSettings: React.FC = () => {
     const available = await enableMiyoBackend(superseded);
     if (superseded()) return "unreachable";
     return available ? "added" : "unreachable";
-  }, [app, settings, enableMiyoBackend, invalidateScopeVerdict]);
+  }, [app, settings, enableMiyoBackend, invalidateScopeVerdict, miyoMutationSession]);
 
   // One connection attempt: probe reachability, then (if reachable) check whether
   // this vault is registered with Miyo. An unregistered vault is NOT auto-added —

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/miyo/miyoUtils";
 import { useMiyoStatus } from "@/miyo/useMiyoStatus";
 import { deriveSkillsFolder } from "@/settings/copilotFolder";
-import { updateSetting, useSettingsValue } from "@/settings/model";
+import { getSettings, updateSetting, useSettingsValue } from "@/settings/model";
 import {
   type ConnectOutcome,
   type ConnectStep,
@@ -402,9 +402,33 @@ export const MiyoSettings: React.FC = () => {
       //     an idempotent folder-filter re-sync; both are out of this PR's scope.
       //     If a review flags this again, point them at this note.
       // Serialized with resync runs: an auto-resync after a root change must
-      // never interleave its DELETE/POST with this registration.
-      const created = await enqueueMiyoFolderMutation(() =>
-        new MiyoClient().addFolder(
+      // never interleave its DELETE/POST with this registration. The task reads
+      // settings when it RUNS, not when it is queued — it can sit behind an
+      // in-flight mutation, and a root/endpoint change landing in that window
+      // would otherwise be submitted as an already-stale scope (with a receipt
+      // vouching for it). Mirrors resyncMiyoFolder's execution-time fresh read;
+      // the receipt is built from the same snapshot as the submitted body so it
+      // always describes what the server actually holds.
+      const submission = await enqueueMiyoFolderMutation(async () => {
+        const fresh = getSettings();
+        const freshUrl = getMiyoCustomUrl(fresh);
+        // DESIGN NOTE — a remote flip mid-queue surfaces as the retryable
+        // "error" outcome, NOT as a "manual" modal transition. Reaching this
+        // throw needs a double race: the modal blocks local edits, so only a
+        // synced-in endpoint change can land here, and only while the mutation
+        // chain is already busy. Recovery is close-and-reopen (canAutoAdd
+        // re-derives to false → manual deeplink guidance); nothing was
+        // submitted to the wrong target. Extending MiyoConnectModal's outcome
+        // routing with a mid-flight canAutoAdd downgrade for this corner is
+        // deliberately rejected — and a direct deeplink open after the queued
+        // await would have lost user activation anyway.
+        // If a future review flags this again, point them at this note.
+        if (!isLocalMiyoUrl(freshUrl)) {
+          throw new Error(
+            "Miyo endpoint switched to a remote target while registration was queued"
+          );
+        }
+        const created = await new MiyoClient().addFolder(
           {
             path: vaultBase,
             // Remote read (Relay) is enabled by default so a user who turns on
@@ -415,29 +439,30 @@ export const MiyoSettings: React.FC = () => {
             // plainly rather than promising absolute privacy. A user who wants this
             // vault kept out of Relay can flip allow_remote_read off per folder in Miyo.
             allow_remote_read: true,
-            ...getMiyoFolderInclusions(settings.qaInclusions),
+            ...getMiyoFolderInclusions(fresh.qaInclusions),
             // Project the always-on system root exclusions (active + historical
             // Copilot roots) alongside Obsidian's own ignore folders, so a former
             // root's content isn't uploaded for indexing. This is a registration-
             // time snapshot; MiyoSemanticRetriever re-applies the LIVE scope
             // (createCopilotPatternFilter, which also enforces these roots) at
             // query time, so correctness never depends on the snapshot.
-            ...getMiyoFolderExclusions(settings.qaExclusions, [
-              ...getSystemExcludedFolders(settings),
+            ...getMiyoFolderExclusions(fresh.qaExclusions, [
+              ...getSystemExcludedFolders(fresh),
               ...extractAppIgnoreSettings(app),
             ]),
           },
-          customUrl || undefined
-        )
-      );
+          freshUrl || undefined
+        );
+        return { created, receipt: buildMiyoSyncReceipt(app, fresh) };
+      });
       // Record the sync receipt only for a fresh 201 — a 409 (already
       // registered) means the server holds an EARLIER snapshot whose exclusions
       // are unknown and possibly stale; marking it synced would silence the
       // resync prompt over a stale scope. Written before the enable step and
       // regardless of `superseded()`: the server-side registration DID happen
       // with this exact body, whatever the UI does afterwards.
-      if (created !== null) {
-        updateSetting("miyoSyncedExclusions", buildMiyoSyncReceipt(app, settings));
+      if (submission.created !== null) {
+        updateSetting("miyoSyncedExclusions", submission.receipt);
       }
     } catch (error) {
       logWarn(`Miyo add-folder failed: ${err2String(error)}`);

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -273,8 +273,15 @@ export const MiyoSettings: React.FC = () => {
           break;
         case "conflict":
           new Notice(
-            "Miyo still reports a conflicting registration. Retry, or remove this folder in the Miyo app."
+            "Miyo reports a conflicting registration (possibly under this vault's previous name). " +
+              "Remove it in the Miyo app, then retry."
           );
+          break;
+        case "unregistered":
+          // Nothing on the server exposes this vault, so the stale banner can
+          // clear; re-registering is the register flow's job (explicit consent).
+          new Notice("This vault isn't registered with Miyo. Reconnect to register it.");
+          setServerScopeStale(false);
           break;
         case "failed":
           new Notice("Couldn't resync Miyo. Make sure Miyo is running, then retry.");

--- a/src/settings/v2/components/SelfHostSettings.tsx
+++ b/src/settings/v2/components/SelfHostSettings.tsx
@@ -72,7 +72,11 @@ export const SelfHostSettings: React.FC = () => {
           disabled={isEligible !== true && !selfHostOn}
         />
 
-        <div className="tw-flex tw-items-start tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-px-3 tw-py-2.5 tw-text-xs tw-text-normal tw-bg-interactive-accent/10 tw-border-interactive-accent/30">
+        <div
+          className={cn(
+            "tw-flex tw-items-start tw-gap-2 tw-py-3 tw-text-xs tw-text-normal tw-bg-interactive-accent/10"
+          )}
+        >
           <ShieldCheck className="tw-mt-0.5 tw-size-4 tw-shrink-0 tw-text-accent" />
           <div className="tw-leading-relaxed">
             <span className="tw-font-semibold">Privacy-first.</span> While Self-Host is on, cloud

--- a/src/system-prompts/SystemPromptAddModal.test.tsx
+++ b/src/system-prompts/SystemPromptAddModal.test.tsx
@@ -1,0 +1,40 @@
+import { DEFAULT_SETTINGS } from "@/constants";
+import { settingsAtom, settingsStore } from "@/settings/model";
+import { SystemPromptAddModalContent } from "@/system-prompts/SystemPromptAddModal";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("SystemPromptAddModal", () => {
+  // The banner under test never touches `contentEl` (only the disabled template
+  // popover would), so a bare stub keeps the render free of DOM-global lint.
+  const contentEl = {} as unknown as HTMLElement;
+  const renderContent = () =>
+    render(
+      <SystemPromptAddModalContent
+        prompts={[]}
+        onConfirm={jest.fn()}
+        onCancel={jest.fn()}
+        contentEl={contentEl}
+      />
+    );
+
+  describe("SystemPromptAddModalContent", () => {
+    beforeEach(() => {
+      settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS });
+    });
+
+    it("shows the system-prompts folder derived from the default root", () => {
+      settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, copilotFolder: "copilot" });
+      renderContent();
+      expect(screen.getByText("copilot/system-prompts")).toBeTruthy();
+    });
+
+    it("shows the system-prompts folder derived from a custom root after a root change", () => {
+      settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, copilotFolder: "team-ai" });
+      renderContent();
+      expect(screen.getByText("team-ai/system-prompts")).toBeTruthy();
+      // Guards the F4 fix: the banner must not fall back to the retired flat field.
+      expect(screen.queryByText("copilot/system-prompts")).toBeNull();
+    });
+  });
+});

--- a/src/system-prompts/SystemPromptAddModal.tsx
+++ b/src/system-prompts/SystemPromptAddModal.tsx
@@ -12,6 +12,7 @@ import { validatePromptName } from "@/system-prompts/systemPromptUtils";
 import { SystemPromptManager } from "@/system-prompts/systemPromptManager";
 import { EMPTY_SYSTEM_PROMPT } from "@/system-prompts/constants";
 import { useSettingsValue } from "@/settings/model";
+import { deriveSystemPromptsFolder } from "@/settings/copilotFolder";
 import { SystemPromptSyntaxInstruction } from "@/components/SystemPromptSyntaxInstruction";
 import { logError } from "@/logger";
 
@@ -69,7 +70,9 @@ interface SystemPromptAddModalContentProps {
   contentEl: HTMLElement;
 }
 
-function SystemPromptAddModalContent({
+/** Exported for testing: the modal's React body, so the derived-path banner can
+ * be asserted without mounting the Obsidian `Modal` shell. */
+export function SystemPromptAddModalContent({
   prompts,
   onConfirm,
   onCancel,
@@ -124,8 +127,8 @@ function SystemPromptAddModalContent({
         <Lightbulb className="tw-size-5 tw-shrink-0" />
         <div className="tw-flex-1">
           System prompts are automatically loaded from .md files in your system prompts folder{" "}
-          <strong>{settings.userSystemPromptsFolder}</strong>. Modifying the files will also update
-          the system prompt settings.
+          <strong>{deriveSystemPromptsFolder(settings)}</strong>. Modifying the files will also
+          update the system prompt settings.
         </div>
       </div>
 

--- a/src/system-prompts/migration.test.ts
+++ b/src/system-prompts/migration.test.ts
@@ -30,6 +30,9 @@ jest.mock("@/logger", () => ({
 jest.mock("@/system-prompts/systemPromptUtils", () => ({
   getSystemPromptsFolder: jest.fn(() => "SystemPrompts"),
   getPromptFilePath: jest.fn((title: string) => `SystemPrompts/${title}.md`),
+  getPromptFilePathInFolder: jest.fn(
+    (title: string, folder?: string) => `${folder ?? "SystemPrompts"}/${title}.md`
+  ),
   ensurePromptFrontmatter: jest.fn(),
   loadAllSystemPrompts: jest.fn(),
 }));

--- a/src/system-prompts/migration.ts
+++ b/src/system-prompts/migration.ts
@@ -2,6 +2,7 @@ import { App, TFile, Vault } from "obsidian";
 import {
   ensurePromptFrontmatter,
   getPromptFilePath,
+  getPromptFilePathInFolder,
   getSystemPromptsFolder,
   loadAllSystemPrompts,
 } from "@/system-prompts/systemPromptUtils";
@@ -154,7 +155,8 @@ export async function migrateSystemPromptsFromSettings(app: App): Promise<void> 
     // Generate a unique name if default name already exists
     // Reason: Prevents data loss when file exists with different content
     const promptName = generateUniquePromptName(MIGRATED_PROMPT_NAME, vault);
-    const filePath = getPromptFilePath(promptName);
+    // Same folder that was just ensured, not a fresh lookup.
+    const filePath = getPromptFilePathInFolder(promptName, folder);
 
     if (promptName !== MIGRATED_PROMPT_NAME) {
       logInfo(`Default name already exists, using unique name: "${promptName}"`);

--- a/src/system-prompts/systemPromptManager.test.ts
+++ b/src/system-prompts/systemPromptManager.test.ts
@@ -28,6 +28,11 @@ jest.mock("@/utils", () => ({
 jest.mock("@/system-prompts/systemPromptUtils", () => ({
   validatePromptName: jest.fn(),
   getPromptFilePath: jest.fn(),
+  // createPrompt pins one folder and derives the path from it; the other paths
+  // still use the bare accessor.
+  getPromptFilePathInFolder: jest.fn((title: string, folder?: string) =>
+    folder ? `${folder}/${title}.md` : `SystemPrompts/${title}.md`
+  ),
   getSystemPromptsFolder: jest.fn(() => "SystemPrompts"),
   loadAllSystemPrompts: jest.fn(),
   ensurePromptFrontmatter: jest.fn(),
@@ -127,6 +132,24 @@ describe("SystemPromptManager", () => {
         "SystemPrompts/New Prompt.md"
       );
       (state.getCachedSystemPrompts as jest.Mock).mockReturnValue([]);
+    });
+
+    it("creates the file in the same folder it ensured, even if the root then moves", async () => {
+      // The prompts folder derives from the Copilot root. Resolving it once for
+      // the ensure and again for the file path would create the prompt outside
+      // the directory just created if the root changed in between.
+      const mockedFolder = systemPromptUtils.getSystemPromptsFolder as jest.Mock;
+      mockedFolder.mockReturnValueOnce("SystemPrompts");
+      mockedFolder.mockReturnValue("moved/SystemPrompts");
+      const mockFile = mockTFile({ path: "SystemPrompts/New Prompt.md" });
+      Object.setPrototypeOf(mockFile, TFile.prototype);
+      (mockVault.getAbstractFileByPath as jest.Mock).mockReturnValue(mockFile);
+
+      await manager.createPrompt(newPrompt);
+
+      expect(utils.ensureFolderExists).toHaveBeenCalledWith(mockVault, "SystemPrompts");
+      expect(mockVault.create).toHaveBeenCalledWith("SystemPrompts/New Prompt.md", "Test content");
+      mockedFolder.mockReturnValue("SystemPrompts");
     });
 
     it("creates a new prompt file", async () => {

--- a/src/system-prompts/systemPromptManager.ts
+++ b/src/system-prompts/systemPromptManager.ts
@@ -5,6 +5,7 @@ import {
   fetchAllSystemPrompts,
   generateCopyPromptName,
   getPromptFilePath,
+  getPromptFilePathInFolder,
   getSystemPromptsFolder,
   loadAllSystemPrompts,
   validatePromptName,
@@ -76,8 +77,11 @@ export class SystemPromptManager {
       throw new Error(error);
     }
 
-    const filePath = getPromptFilePath(prompt.title);
+    // One folder for the whole create: resolving it again for the file path
+    // could ensure one directory and create the prompt in another if the
+    // Copilot root moves in between.
     const folderPath = getSystemPromptsFolder();
+    const filePath = getPromptFilePathInFolder(prompt.title, folderPath);
 
     try {
       addPendingFileWrite(filePath);

--- a/src/system-prompts/systemPromptRegister.test.ts
+++ b/src/system-prompts/systemPromptRegister.test.ts
@@ -10,6 +10,7 @@ jest.mock("obsidian", () => ({
   Plugin: jest.fn(),
   TFile: jest.fn(),
   Vault: jest.fn(),
+  normalizePath: (path: string) => path,
 }));
 
 // Mock logger
@@ -41,6 +42,7 @@ jest.mock("@/system-prompts/systemPromptUtils", () => ({
     lastUsedMs: 0,
   }),
   ensurePromptFrontmatter: jest.fn().mockResolvedValue(undefined),
+  updatePromptDefaultFlag: jest.fn().mockResolvedValue(undefined),
 }));
 
 // Mock settings
@@ -267,10 +269,7 @@ describe("SystemPromptRegister", () => {
       ]);
 
       // Trigger folder change
-      settingsChangeHandler(
-        { userSystemPromptsFolder: "OldFolder" },
-        { userSystemPromptsFolder: "NewFolder" }
-      );
+      settingsChangeHandler({ copilotFolder: "OldFolder" }, { copilotFolder: "NewFolder" });
 
       // Fast-forward debounce timer
       jest.advanceTimersByTime(300);
@@ -303,10 +302,7 @@ describe("SystemPromptRegister", () => {
       ]);
 
       // Trigger folder change
-      settingsChangeHandler(
-        { userSystemPromptsFolder: "OldFolder" },
-        { userSystemPromptsFolder: "NewFolder" }
-      );
+      settingsChangeHandler({ copilotFolder: "OldFolder" }, { copilotFolder: "NewFolder" });
 
       // Fast-forward debounce timer
       jest.advanceTimersByTime(300);
@@ -339,10 +335,7 @@ describe("SystemPromptRegister", () => {
       ]);
 
       // Trigger folder change
-      settingsChangeHandler(
-        { userSystemPromptsFolder: "OldFolder" },
-        { userSystemPromptsFolder: "NewFolder" }
-      );
+      settingsChangeHandler({ copilotFolder: "OldFolder" }, { copilotFolder: "NewFolder" });
 
       // Fast-forward debounce timer
       jest.advanceTimersByTime(300);
@@ -357,20 +350,41 @@ describe("SystemPromptRegister", () => {
       expect(Notice).not.toHaveBeenCalled();
     });
 
+    it("passes the OLD derived folder to the default flag update when the root also changes", async () => {
+      const { updatePromptDefaultFlag } = jest.requireMock<{
+        updatePromptDefaultFlag: jest.Mock;
+      }>("@/system-prompts/systemPromptUtils");
+      const { getSettings } = jest.requireMock<{ getSettings: jest.Mock }>("@/settings/model");
+      getSettings.mockReturnValue({
+        defaultSystemPromptTitle: "NewDefault",
+        copilotFolder: "team/ai",
+      });
+
+      // Root changes copilot -> team/ai AND the default title changes in the same tick.
+      settingsChangeHandler(
+        { copilotFolder: "copilot", defaultSystemPromptTitle: "OldDefault" },
+        { copilotFolder: "team/ai", defaultSystemPromptTitle: "NewDefault" }
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Old flag cleared using the OLD derived folder (copilot/system-prompts),
+      // new flag set in the current (new) folder.
+      expect(updatePromptDefaultFlag).toHaveBeenCalledWith(
+        expect.anything(),
+        "OldDefault",
+        false,
+        "copilot/system-prompts"
+      );
+      expect(updatePromptDefaultFlag).toHaveBeenCalledWith(expect.anything(), "NewDefault", true);
+    });
+
     it("debounces rapid folder changes", async () => {
       // Trigger multiple rapid folder changes
-      settingsChangeHandler(
-        { userSystemPromptsFolder: "Folder1" },
-        { userSystemPromptsFolder: "Folder2" }
-      );
-      settingsChangeHandler(
-        { userSystemPromptsFolder: "Folder2" },
-        { userSystemPromptsFolder: "Folder3" }
-      );
-      settingsChangeHandler(
-        { userSystemPromptsFolder: "Folder3" },
-        { userSystemPromptsFolder: "Folder4" }
-      );
+      settingsChangeHandler({ copilotFolder: "Folder1" }, { copilotFolder: "Folder2" });
+      settingsChangeHandler({ copilotFolder: "Folder2" }, { copilotFolder: "Folder3" });
+      settingsChangeHandler({ copilotFolder: "Folder3" }, { copilotFolder: "Folder4" });
 
       // Fast-forward debounce timer
       jest.advanceTimersByTime(300);
@@ -388,10 +402,7 @@ describe("SystemPromptRegister", () => {
       mockManager.fetchPrompts.mockRejectedValueOnce(new Error("Network error"));
 
       // Trigger folder change
-      settingsChangeHandler(
-        { userSystemPromptsFolder: "OldFolder" },
-        { userSystemPromptsFolder: "NewFolder" }
-      );
+      settingsChangeHandler({ copilotFolder: "OldFolder" }, { copilotFolder: "NewFolder" });
 
       // Fast-forward debounce timer
       jest.advanceTimersByTime(300);
@@ -435,18 +446,12 @@ describe("SystemPromptRegister", () => {
         .mockReturnValueOnce(promiseB); // Second call (request B)
 
       // Trigger first folder change (request A)
-      settingsChangeHandler(
-        { userSystemPromptsFolder: "Original" },
-        { userSystemPromptsFolder: "FolderA" }
-      );
+      settingsChangeHandler({ copilotFolder: "Original" }, { copilotFolder: "FolderA" });
       jest.advanceTimersByTime(300);
       await Promise.resolve();
 
       // Trigger second folder change (request B) before A completes
-      settingsChangeHandler(
-        { userSystemPromptsFolder: "FolderA" },
-        { userSystemPromptsFolder: "FolderB" }
-      );
+      settingsChangeHandler({ copilotFolder: "FolderA" }, { copilotFolder: "FolderB" });
       jest.advanceTimersByTime(300);
       await Promise.resolve();
 

--- a/src/system-prompts/systemPromptRegister.ts
+++ b/src/system-prompts/systemPromptRegister.ts
@@ -16,6 +16,7 @@ import {
   setSelectedPromptTitle,
 } from "@/system-prompts/state";
 import { getSettings, subscribeToSettingsChange, updateSetting } from "@/settings/model";
+import { deriveSystemPromptsFolder } from "@/settings/copilotFolder";
 import { SystemPromptManager } from "@/system-prompts/systemPromptManager";
 import { debounce } from "@/utils/debounce";
 import { logError, logInfo } from "@/logger";
@@ -83,13 +84,17 @@ export class SystemPromptRegister {
     prev: ReturnType<typeof getSettings>,
     next: ReturnType<typeof getSettings>
   ): void => {
-    const folderChanged = prev.userSystemPromptsFolder !== next.userSystemPromptsFolder;
+    // Reason: the folder is derived from the configurable copilotFolder root, so
+    // compare the derived paths rather than the retired userSystemPromptsFolder field.
+    const prevFolder = deriveSystemPromptsFolder(prev);
+    const nextFolder = deriveSystemPromptsFolder(next);
+    const folderChanged = prevFolder !== nextFolder;
     const defaultChanged = prev.defaultSystemPromptTitle !== next.defaultSystemPromptTitle;
 
     // Handle default change first, using the old folder path if folder also changed
     // This ensures we can find the old default file before the folder changes
     if (defaultChanged) {
-      const oldFolder = folderChanged ? prev.userSystemPromptsFolder : undefined;
+      const oldFolder = folderChanged ? prevFolder : undefined;
       void this.handleDefaultPromptChange(
         prev.defaultSystemPromptTitle,
         next.defaultSystemPromptTitle,
@@ -98,7 +103,7 @@ export class SystemPromptRegister {
     }
 
     if (folderChanged) {
-      this.debouncedFolderChange(next.userSystemPromptsFolder);
+      this.debouncedFolderChange(nextFolder);
     }
   };
 

--- a/src/system-prompts/systemPromptUtils.test.ts
+++ b/src/system-prompts/systemPromptUtils.test.ts
@@ -7,7 +7,7 @@ import {
   generateCopyPromptName,
 } from "@/system-prompts/systemPromptUtils";
 import { UserSystemPrompt } from "@/system-prompts/type";
-import { TFile, TAbstractFile, normalizePath } from "obsidian";
+import { TFile, TAbstractFile } from "obsidian";
 import * as settingsModel from "@/settings/model";
 import type { CopilotSettings } from "@/settings/model";
 import { mockTFile } from "@/__tests__/mockObsidian";
@@ -25,6 +25,16 @@ jest.mock("@/settings/model", () => ({
     userSystemPromptsFolder: "SystemPrompts",
   })),
 }));
+
+// The folder read point derives from copilotFolder in production; these tests
+// exercise path-composition/file-matching, so the derived accessor is shimmed
+// to the folder each test configures via getSettings().userSystemPromptsFolder.
+jest.mock("@/settings/copilotFolder", () => {
+  const { getSettings } = jest.requireMock<typeof import("@/settings/model")>("@/settings/model");
+  return {
+    getEffectiveSystemPromptsFolder: jest.fn(() => getSettings().userSystemPromptsFolder),
+  };
+});
 
 // Mock state management
 jest.mock("@/system-prompts/state", () => ({
@@ -116,23 +126,13 @@ describe("validatePromptName", () => {
 });
 
 describe("getSystemPromptsFolder", () => {
-  it("returns the system prompts folder path from settings", () => {
+  it("returns the effective (copilotFolder-derived) system prompts folder", () => {
     jest.spyOn(settingsModel, "getSettings").mockReturnValue({
       userSystemPromptsFolder: "CustomFolder/SystemPrompts",
     } as CopilotSettings);
 
     const result = getSystemPromptsFolder();
     expect(result).toBe("CustomFolder/SystemPrompts");
-  });
-
-  it("normalizes the path", () => {
-    jest.spyOn(settingsModel, "getSettings").mockReturnValue({
-      userSystemPromptsFolder: "SystemPrompts",
-    } as CopilotSettings);
-
-    const result = getSystemPromptsFolder();
-    expect(normalizePath).toHaveBeenCalled();
-    expect(result).toBe("SystemPrompts");
   });
 });
 

--- a/src/system-prompts/systemPromptUtils.ts
+++ b/src/system-prompts/systemPromptUtils.ts
@@ -67,11 +67,17 @@ export function getPromptFilePath(title: string): string {
 }
 
 /**
- * Get the file path for a system prompt by title in a specific folder
+ * Get the file path for a system prompt by title in a specific folder.
+ *
+ * Callers that create or move a prompt should pass `folder` explicitly and use
+ * the same value they ensured: the prompts folder derives from the Copilot root,
+ * so resolving it twice around an `await` can ensure one directory and write
+ * into another.
+ *
  * @param title - The title of the prompt
  * @param folder - Optional folder path (defaults to current settings folder)
  */
-function getPromptFilePathInFolder(title: string, folder?: string): string {
+export function getPromptFilePathInFolder(title: string, folder?: string): string {
   const folderPath = folder ? normalizePath(folder) : getSystemPromptsFolder();
   return normalizePath(`${folderPath}/${title}.md`);
 }

--- a/src/system-prompts/systemPromptUtils.ts
+++ b/src/system-prompts/systemPromptUtils.ts
@@ -7,7 +7,7 @@ import {
 } from "@/system-prompts/constants";
 import { UserSystemPrompt } from "@/system-prompts/type";
 import { App, normalizePath, TAbstractFile, TFile } from "obsidian";
-import { getSettings } from "@/settings/model";
+import { getEffectiveSystemPromptsFolder } from "@/settings/copilotFolder";
 import { stripFrontmatter } from "@/utils";
 import {
   updateCachedSystemPrompts,
@@ -53,10 +53,10 @@ export function validatePromptName(
 }
 
 /**
- * Get the system prompts folder path from settings
+ * Get the system prompts folder path, derived from the configurable copilotFolder root.
  */
 export function getSystemPromptsFolder(): string {
-  return normalizePath(getSettings().userSystemPromptsFolder);
+  return getEffectiveSystemPromptsFolder();
 }
 
 /**

--- a/src/tools/memoryTools.ts
+++ b/src/tools/memoryTools.ts
@@ -34,10 +34,9 @@ export const createUpdateMemoryTool = (app: App) =>
           };
         }
 
-        const memoryFilePath = memoryManager.getSavedMemoriesFilePath();
         return {
           success: true,
-          message: `Memory updated successfully into ${memoryFilePath}: ${result.content}`,
+          message: `Memory updated successfully into ${result.filePath}: ${result.content}`,
         };
       } catch (error: unknown) {
         logError("[updateMemoryTool] Error updating memory:", error);

--- a/src/utils/revealFolderInExplorer.test.ts
+++ b/src/utils/revealFolderInExplorer.test.ts
@@ -1,0 +1,56 @@
+import { revealFolderInExplorer } from "@/utils/revealFolderInExplorer";
+import { Notice, TFolder, type App } from "obsidian";
+
+/** Build an App whose vault resolves `relPath` to `resolved` and exposes an
+ *  optionally-enabled File Explorer with a spyable `revealInFolder`. */
+function makeApp(options: {
+  resolved: unknown;
+  explorerEnabled?: boolean;
+  hasReveal?: boolean;
+  revealInFolder?: jest.Mock;
+}): App {
+  const instance = options.hasReveal ? { revealInFolder: options.revealInFolder } : {};
+  return {
+    vault: { getAbstractFileByPath: () => options.resolved },
+    internalPlugins: {
+      getPluginById: (id: string) =>
+        id === "file-explorer" ? { enabled: options.explorerEnabled ?? true, instance } : undefined,
+    },
+  } as unknown as App;
+}
+
+describe("revealFolderInExplorer", () => {
+  describe("revealFolderInExplorer()", () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it("reveals the folder when it resolves to a TFolder and the explorer is enabled", () => {
+      const revealInFolder = jest.fn();
+      const folder = new (TFolder as unknown as new (p: string) => TFolder)("copilot");
+      revealFolderInExplorer(
+        makeApp({ resolved: folder, explorerEnabled: true, hasReveal: true, revealInFolder }),
+        "copilot"
+      );
+      expect(revealInFolder).toHaveBeenCalledWith(folder);
+      expect(Notice).not.toHaveBeenCalled();
+    });
+
+    it("shows a Notice when the folder is not in the vault cache", () => {
+      revealFolderInExplorer(makeApp({ resolved: null }), "copilot");
+      expect(Notice).toHaveBeenCalledTimes(1);
+    });
+
+    it("shows a Notice when the File Explorer plugin is disabled", () => {
+      const folder = new (TFolder as unknown as new (p: string) => TFolder)("copilot");
+      revealFolderInExplorer(
+        makeApp({
+          resolved: folder,
+          explorerEnabled: false,
+          hasReveal: true,
+          revealInFolder: jest.fn(),
+        }),
+        "copilot"
+      );
+      expect(Notice).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/utils/revealFolderInExplorer.ts
+++ b/src/utils/revealFolderInExplorer.ts
@@ -1,0 +1,37 @@
+import { logWarn } from "@/logger";
+import { App, Notice, TFolder } from "obsidian";
+
+/**
+ * Reveal a vault-root-relative folder in Obsidian's built-in File Explorer.
+ *
+ * Surfaces a Notice instead of failing silently when the folder isn't in the
+ * vault cache yet (e.g. it hasn't been created — Copilot creates its folders
+ * lazily on first write) or the File Explorer core plugin is disabled.
+ *
+ * @param app - Active Obsidian app, threaded in rather than read from global.
+ * @param relPath - Vault-root-relative folder path to reveal.
+ */
+export function revealFolderInExplorer(app: App, relPath: string): void {
+  const folder = app.vault.getAbstractFileByPath(relPath);
+  if (!(folder instanceof TFolder)) {
+    new Notice(`Folder "${relPath}" doesn't exist yet — it's created on first use.`, 5000);
+    return;
+  }
+  const fileExplorer = (
+    app as unknown as {
+      internalPlugins?: {
+        getPluginById?: (
+          id: string
+        ) =>
+          | { enabled?: boolean; instance?: { revealInFolder?: (folder: TFolder) => void } }
+          | undefined;
+      };
+    }
+  ).internalPlugins?.getPluginById?.("file-explorer");
+  if (fileExplorer?.enabled && fileExplorer.instance?.revealInFolder) {
+    fileExplorer.instance.revealInFolder(folder);
+    return;
+  }
+  logWarn("[settings] File Explorer plugin unavailable; cannot reveal folder.");
+  new Notice("File Explorer isn't enabled; can't reveal the folder.", 5000);
+}


### PR DESCRIPTION
Part of logancyang/obsidian-copilot-preview#195 (the folder-migration piece
deferred from #2692; the umbrella issue stays open for the remaining parts).

## Problem

After the v4 settings redesign (#2692), Copilot still scattered its data across
four independently-configurable sub-folder settings (conversations, custom
prompts, system prompts, skills) plus separate memory/projects paths. Users had
no single "where does Copilot keep its stuff" control, the settings surface
carried four folder inputs, and the QA privacy exclusion was hardcoded to the
literal `copilot` folder — so any user who moved their data left private
conversations exposed to vault search. #2692 hid a placeholder folder-location
row pending exactly this PR.

## Fix

Introduce one configurable `copilotFolder` root (default `copilot`); all six
sub-folders derive from it (`${root}/copilot-conversations`, `/system-prompts`,
`/skills`, `/memory`, `/projects`, `/copilot-custom-prompts`). The plugin never
moves files — changing the root reloads consumers to the derived location via
the existing subscribe/debounce/reload watcher pattern (watchers now compare
derived paths), leaves old data in place, and prompts once about old→new paths.
Default users (root = `copilot`) get byte-identical paths, so upgrade is a
no-op.

Chosen over physically migrating files (rejected: no atomic folder-move API,
`renameFile` has a known duplication bug, and it serves ~1% of users) — the
maintainer confirmed "don't move, just prompt."

## Scope

59 files changed, +2690 / −402. Large because it spans the field + migration,
the derived-accessor layer, the QA exclusion rework, the settings UI, and the
upgrade prompt as one coherent unit; the tag-migration follow-up is
deliberately **not** bundled (see Deferred).

## Changes

- **Root field + migration** — `copilotFolder` + v8 migration seeding the root
  and a legacy-upgrade flag (fires for pre-versioned installs too).
- **Derived accessors** — pure `derive*Folder`/`getEffective*Folder`; three
  folder watchers compare derived paths; custom-command watcher added with
  pure-fetch → generation-check → atomic swap.
- **QA privacy** — whole-root exclusion expanded from `copilot` to
  `copilot` + active root + all historical roots, across every consumer entry
  point; reset/hydrate preserve root history; change-root triggers a
  best-effort GC.
- **Settings UI** — editable root row (draft + explicit Apply), change-root
  ConfirmModal (discloses permanent old-root search exclusion), root
  validation; the three sub-folder inputs are retired; the skills folder is
  root-derived (no settings row).
- **Conversation tag** — frozen to a constant `#copilot-conversation` (session
  identity is folder+epoch, never the tag → zero note migration).
- **Upgrade prompt** — one-time v3→v4 notice listing old→new paths for users
  who had customized a sub-folder.
- **Docs** — six user-facing docs updated to the unified-folder behavior.

Retired settings fields are kept as dead (no schema break).

## Verification

- `tsc --noEmit` OK · `eslint .` OK · `prettier --check` OK
- Full suite: **335 suites / 4789 tests pass** (2 suites / 7 skipped).
- Reviewed via a structural + two line-level codex passes; findings triaged and
  fixed (QA matcher canonicalization, case-sensitive upgrade compare,
  custom-command teardown invalidation, retired-field read points).

## Deferred (tracked, not in this PR)

- **Conversation-tag split (intentional, no migration here)** — customized-tag
  users get a split: old notes keep their custom tag, new notes use the frozen
  `#copilot-conversation`. This affects only user-defined Dataview/tag filters,
  **not** chat-history usage — the chat-history UI keys off the folder (a fixed
  location), never the tag. Per maintainer decision this PR does not migrate
  existing notes; a general-purpose batch-frontmatter tool that would let users
  self-serve such cleanups is tracked separately in
  logancyang/obsidian-copilot-preview#224.
- **Change-root persistence window** — activation is memory-first (matches the
  codebase's locked no-rollback settings architecture); documented via DESIGN
  NOTE, bounded by Notice-on-failure + next-persist reconcile + hydrate union.

