### PR TITLE
feat(embeddings): support configurable dimensions

### DIFF
--- a/docs/models-and-parameters.md
+++ b/docs/models-and-parameters.md
@@ -92,7 +92,9 @@ Embedding models convert text into numerical vectors, which powers semantic (mea
 
 Go to **Settings → Copilot → QA** → **Embedding Model**.
 
-If you change embedding models, you must rebuild the vault index because the old vectors are incompatible with the new model. Copilot will prompt you to confirm before rebuilding.
+For custom OpenAI-compatible embedding models, you can configure **Embedding dimensions**. Leave it empty to use the provider's default. A value such as `512` is only an example, not a Copilot default; your provider and model must support the dimensions you choose.
+
+If you change the embedding model or its dimensions, you must fully rebuild the vault index because the old vectors are incompatible. Copilot will prompt you to confirm before rebuilding.
 
 ### What Embeddings Affect
 

--- a/src/LLMProviders/embeddingManager.test.ts
+++ b/src/LLMProviders/embeddingManager.test.ts
@@ -1,0 +1,227 @@
+import { CustomModel } from "@/aiParams";
+import { EmbeddingModelProviders } from "@/constants";
+import { getEmbeddingModelIdentity } from "@/utils/embeddingDimensions";
+import type { Embeddings } from "@langchain/core/embeddings";
+
+const settings = {
+  activeEmbeddingModels: [] as CustomModel[],
+  embeddingBatchSize: 16,
+  embeddingModelKey: "",
+};
+
+const openAIEmbeddingsInstances: Array<{ config: Record<string, unknown>; embedQuery: jest.Mock }> =
+  [];
+let nextEmbeddingVector: number[] = [0];
+
+jest.mock("@langchain/openai", () => ({
+  OpenAIEmbeddings: class {
+    config: Record<string, unknown>;
+    embedQuery = jest.fn(async () => nextEmbeddingVector);
+
+    constructor(config: Record<string, unknown>) {
+      this.config = config;
+      openAIEmbeddingsInstances.push(this);
+    }
+  },
+  AzureOpenAIEmbeddings: class {},
+}));
+
+jest.mock("@langchain/google-genai", () => ({ GoogleGenerativeAIEmbeddings: class {} }));
+jest.mock("@langchain/ollama", () => ({ OllamaEmbeddings: class {} }));
+jest.mock("./CustomJinaEmbeddings", () => ({ CustomJinaEmbeddings: class {} }));
+jest.mock("./CustomOpenAIEmbeddings", () => ({ CustomOpenAIEmbeddings: class {} }));
+jest.mock("./brevilabsClient", () => ({
+  BrevilabsClient: { getInstance: jest.fn() },
+}));
+jest.mock("@/settings/model", () => ({
+  getSettings: () => settings,
+  getModelKeyFromModel: (model: CustomModel) => `${model.name}|${model.provider}`,
+  subscribeToSettingsChange: jest.fn(),
+}));
+jest.mock("@/encryptionService", () => ({ getDecryptedKey: async (key: string) => key }));
+jest.mock("@/utils", () => ({
+  err2String: (error: unknown) => String(error),
+  safeFetch: jest.fn(),
+}));
+jest.mock("@/logger", () => ({ logInfo: jest.fn() }));
+jest.mock("obsidian", () => ({ Notice: jest.fn() }));
+
+import EmbeddingManager from "./embeddingManager";
+
+interface EmbeddingManagerInternals {
+  activeEmbeddingModels: CustomModel[];
+  getEmbeddingConfig(model: CustomModel): Promise<Record<string, unknown>>;
+}
+
+/** Creates an isolated manager without singleton settings subscriptions. */
+function createManager(models: CustomModel[] = []): EmbeddingManager {
+  const manager = Object.create(EmbeddingManager.prototype) as EmbeddingManager;
+  (manager as unknown as EmbeddingManagerInternals).activeEmbeddingModels = models;
+  return manager;
+}
+
+/** Creates the smallest valid custom embedding model for the test under consideration. */
+function createModel(
+  provider: EmbeddingModelProviders,
+  dimensions?: number,
+  name = "test-embedding-model"
+): CustomModel {
+  return {
+    name,
+    provider,
+    enabled: true,
+    isEmbeddingModel: true,
+    apiKey: "test-api-key",
+    dimensions,
+  };
+}
+
+/** Obtains the private configuration method to assert the provider constructor input. */
+function getEmbeddingConfig(manager: EmbeddingManager, model: CustomModel) {
+  // The configuration is intentionally private; this assertion verifies its externally observable
+  // constructor input without adding a production-only test API.
+  return (manager as unknown as EmbeddingManagerInternals).getEmbeddingConfig(model);
+}
+
+describe("EmbeddingManager OpenAI-compatible dimensions", () => {
+  beforeEach(() => {
+    settings.activeEmbeddingModels = [];
+    settings.embeddingModelKey = "";
+    nextEmbeddingVector = [0];
+    openAIEmbeddingsInstances.length = 0;
+    jest.clearAllMocks();
+  });
+
+  it.each([512, 1024])(
+    "passes valid dimensions %d to the OpenAI-compatible embedding constructor",
+    async (dimensions) => {
+      const config = await getEmbeddingConfig(
+        createManager(),
+        createModel(EmbeddingModelProviders.OPENAI_FORMAT, dimensions)
+      );
+
+      expect(config).toEqual(expect.objectContaining({ dimensions }));
+    }
+  );
+
+  it.each([undefined, 0, -1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "omits invalid OpenAI-compatible dimensions: %p",
+    async (dimensions) => {
+      const config = await getEmbeddingConfig(
+        createManager(),
+        createModel(EmbeddingModelProviders.OPENAI_FORMAT, dimensions)
+      );
+
+      expect(config).not.toHaveProperty("dimensions");
+    }
+  );
+
+  it.each([
+    EmbeddingModelProviders.OPENAI,
+    EmbeddingModelProviders.OLLAMA,
+    EmbeddingModelProviders.LM_STUDIO,
+    EmbeddingModelProviders.AZURE_OPENAI,
+    EmbeddingModelProviders.SILICONFLOW,
+    EmbeddingModelProviders.OPENROUTERAI,
+  ])("does not pass dimensions to %s", async (provider) => {
+    const config = await getEmbeddingConfig(createManager(), createModel(provider, 512));
+
+    expect(config).not.toHaveProperty("dimensions");
+  });
+
+  it("preserves dimensions for the existing Copilot Plus Jina provider", async () => {
+    const config = await getEmbeddingConfig(
+      createManager(),
+      createModel(EmbeddingModelProviders.COPILOT_PLUS_JINA, 512)
+    );
+
+    expect(config).toEqual(expect.objectContaining({ dimensions: 512 }));
+  });
+
+  it("accepts a matching vector length when pinging a dimensioned OpenAI-compatible model", async () => {
+    const model = createModel(EmbeddingModelProviders.OPENAI_FORMAT, 512);
+    nextEmbeddingVector = Array.from({ length: 512 }, () => 0);
+
+    await expect(createManager().ping(model)).resolves.toBe(true);
+    expect(openAIEmbeddingsInstances[0].config).toEqual(
+      expect.objectContaining({ dimensions: 512 })
+    );
+    expect(openAIEmbeddingsInstances[0].embedQuery).toHaveBeenCalledWith("test");
+  });
+
+  it("reports the configured and returned dimensions when ping receives a mismatched vector", async () => {
+    const model = createModel(EmbeddingModelProviders.OPENAI_FORMAT, 512);
+    nextEmbeddingVector = Array.from({ length: 1024 }, () => 0);
+
+    await expect(createManager().ping(model)).rejects.toThrow(
+      "Embedding dimension mismatch: configured 512, but the provider returned 1024."
+    );
+    expect(openAIEmbeddingsInstances).toHaveLength(1);
+  });
+
+  it("does not enforce a vector length when OpenAI-compatible dimensions are not configured", async () => {
+    const model = createModel(EmbeddingModelProviders.OPENAI_FORMAT);
+    nextEmbeddingVector = Array.from({ length: 1024 }, () => 0);
+
+    await expect(createManager().ping(model)).resolves.toBe(true);
+  });
+
+  it("does not enforce a vector length when OpenAI-compatible dimensions are invalid", async () => {
+    const model = createModel(EmbeddingModelProviders.OPENAI_FORMAT, 0);
+    nextEmbeddingVector = Array.from({ length: 1024 }, () => 0);
+
+    await expect(createManager().ping(model)).resolves.toBe(true);
+  });
+
+  it("uses dimensions in the current embedding identity without changing legacy identities", () => {
+    const embeddingsInstance = { modelName: "test-embedding-model" } as unknown as Embeddings;
+    const legacyModel = createModel(EmbeddingModelProviders.OPENAI_FORMAT);
+    const model512 = createModel(EmbeddingModelProviders.OPENAI_FORMAT, 512);
+    const model1024 = createModel(EmbeddingModelProviders.OPENAI_FORMAT, 1024);
+
+    settings.embeddingModelKey = "test-embedding-model|3rd party (openai-format)";
+
+    const legacyIdentity = createManager([legacyModel]).getEmbeddingModelIdentity(
+      embeddingsInstance
+    );
+    const identity512 = createManager([model512]).getEmbeddingModelIdentity(embeddingsInstance);
+    const identity1024 = createManager([model1024]).getEmbeddingModelIdentity(embeddingsInstance);
+
+    expect(legacyIdentity).toBe("test-embedding-model");
+    expect(identity512).toBe(getEmbeddingModelIdentity("test-embedding-model", 512));
+    expect(identity1024).toBe(getEmbeddingModelIdentity("test-embedding-model", 1024));
+    expect(identity512).not.toBe(legacyIdentity);
+    expect(identity1024).not.toBe(identity512);
+  });
+
+  it("keeps the legacy identity for providers that do not support configurable dimensions", () => {
+    const model = createModel(EmbeddingModelProviders.COPILOT_PLUS_JINA, 512);
+    settings.embeddingModelKey = `test-embedding-model|${EmbeddingModelProviders.COPILOT_PLUS_JINA}`;
+
+    const identity = createManager([model]).getEmbeddingModelIdentity({
+      model: "test-embedding-model",
+    } as unknown as Embeddings);
+
+    expect(identity).toBe("test-embedding-model");
+  });
+
+  it("uses encoded shared identities for selected model names containing dimensions delimiters", () => {
+    const firstModelName = "test|dimensions=512";
+    const secondModelName = "test|dimensions=1024";
+    const firstModel = createModel(EmbeddingModelProviders.OPENAI_FORMAT, 512, firstModelName);
+    const secondModel = createModel(EmbeddingModelProviders.OPENAI_FORMAT, 512, secondModelName);
+
+    settings.embeddingModelKey = `${firstModelName}|${EmbeddingModelProviders.OPENAI_FORMAT}`;
+    const firstIdentity = createManager([firstModel]).getEmbeddingModelIdentity({
+      modelName: firstModelName,
+    } as unknown as Embeddings);
+    settings.embeddingModelKey = `${secondModelName}|${EmbeddingModelProviders.OPENAI_FORMAT}`;
+    const secondIdentity = createManager([secondModel]).getEmbeddingModelIdentity({
+      modelName: secondModelName,
+    } as unknown as Embeddings);
+
+    expect(firstIdentity).toBe(getEmbeddingModelIdentity(firstModelName, 512));
+    expect(firstIdentity).toBe("embedding-config:test%7Cdimensions%3D512|dimensions=512");
+    expect(firstIdentity).not.toBe(secondIdentity);
+  });
+});

--- a/src/LLMProviders/embeddingManager.ts
+++ b/src/LLMProviders/embeddingManager.ts
@@ -5,6 +5,10 @@ import { CustomError } from "@/error";
 import { logInfo } from "@/logger";
 import { getModelKeyFromModel, getSettings, subscribeToSettingsChange } from "@/settings/model";
 import { err2String, safeFetch } from "@/utils";
+import {
+  getEmbeddingModelIdentity,
+  getValidEmbeddingDimensions,
+} from "@/utils/embeddingDimensions";
 import { Embeddings } from "@langchain/core/embeddings";
 import { GoogleGenerativeAIEmbeddings } from "@langchain/google-genai";
 import { OllamaEmbeddings } from "@langchain/ollama";
@@ -31,6 +35,13 @@ const EMBEDDING_PROVIDER_CONSTRUCTORS = {
 } as const;
 
 type EmbeddingProviderConstructorMap = typeof EMBEDDING_PROVIDER_CONSTRUCTORS;
+
+/** Returns whether an error was raised by the local embedding dimension validation. */
+function isEmbeddingDimensionMismatchError(error: unknown): error is Error {
+  return (
+    error instanceof Error && error.message.startsWith("Embedding dimension mismatch: configured ")
+  );
+}
 
 export default class EmbeddingManager {
   private activeEmbeddingModels: CustomModel[];
@@ -128,6 +139,27 @@ export default class EmbeddingManager {
     }
   }
 
+  /**
+   * Returns the internal identity for an embeddings instance and the selected model configuration.
+   *
+   * @param embeddingsInstance - The instantiated embeddings provider.
+   * @returns A dimension-aware identity for configured OpenAI-compatible models.
+   */
+  getEmbeddingModelIdentity(embeddingsInstance: Embeddings): string {
+    const modelName = EmbeddingManager.getModelName(embeddingsInstance);
+    const embeddingModelKey = getSettings().embeddingModelKey;
+    const currentModel = this.activeEmbeddingModels.find(
+      (model) => getModelKeyFromModel(model) === embeddingModelKey
+    );
+    const dimensions =
+      currentModel &&
+      (currentModel.provider as EmbeddingModelProviders) === EmbeddingModelProviders.OPENAI_FORMAT
+        ? currentModel.dimensions
+        : undefined;
+
+    return getEmbeddingModelIdentity(modelName, dimensions);
+  }
+
   // Get the custom model that matches the name and provider from the model key
   private getCustomModel(modelKey: string): CustomModel {
     return this.activeEmbeddingModels.filter((model) => {
@@ -183,6 +215,7 @@ export default class EmbeddingManager {
   private async getEmbeddingConfig(customModel: CustomModel): Promise<Record<string, unknown>> {
     const settings = getSettings();
     const modelName = customModel.name;
+    const validDimensions = getValidEmbeddingDimensions(customModel.dimensions);
 
     const baseConfig = {
       maxRetries: 3,
@@ -282,6 +315,7 @@ export default class EmbeddingManager {
         modelName,
         openAIApiKey: await getDecryptedKey(customModel.apiKey || ""),
         batchSize: getSettings().embeddingBatchSize,
+        ...(validDimensions === undefined ? {} : { dimensions: validDimensions }),
         configuration: {
           baseURL: customModel.baseUrl,
           fetch: customModel.enableCors ? safeFetch : undefined,
@@ -319,7 +353,19 @@ export default class EmbeddingManager {
       const modelToTest = { ...model, enableCors };
       const config = await this.getEmbeddingConfig(modelToTest);
       const testModel = new (this.getProviderConstructor(modelToTest))(config);
-      await testModel.embedQuery("test");
+      const embedding = await testModel.embedQuery("test");
+      const validDimensions = getValidEmbeddingDimensions(modelToTest.dimensions);
+
+      if (
+        (modelToTest.provider as EmbeddingModelProviders) ===
+          EmbeddingModelProviders.OPENAI_FORMAT &&
+        validDimensions !== undefined &&
+        embedding.length !== validDimensions
+      ) {
+        throw new Error(
+          `Embedding dimension mismatch: configured ${validDimensions}, but the provider returned ${embedding.length}.`
+        );
+      }
     };
 
     try {
@@ -327,6 +373,10 @@ export default class EmbeddingManager {
       await tryPing(false);
       return true;
     } catch (firstError) {
+      if (isEmbeddingDimensionMismatchError(firstError)) {
+        throw firstError;
+      }
+
       logInfo("First ping attempt failed, trying with CORS...");
       try {
         // Second try with CORS
@@ -336,6 +386,10 @@ export default class EmbeddingManager {
         );
         return true;
       } catch (error) {
+        if (isEmbeddingDimensionMismatchError(error)) {
+          throw error;
+        }
+
         const msg =
           "\nwithout CORS Error: " +
           err2String(firstError) +

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -166,7 +166,7 @@ export interface CustomModel {
   capabilities?: ModelCapability[];
   displayName?: string;
 
-  // Embedding models only (Jina at the moment)
+  // Embedding models only
   dimensions?: number;
   // OpenAI specific fields
   openAIOrgId?: string;

--- a/src/search/dbOperations.identityIntegration.test.ts
+++ b/src/search/dbOperations.identityIntegration.test.ts
@@ -1,0 +1,77 @@
+const getEmbeddingModelIdentity = jest.fn(
+  () => "embedding-config:nomic-embed-text-v1.5|dimensions=1024"
+);
+const search = jest.fn().mockResolvedValue({
+  hits: [
+    {
+      document: {
+        embeddingModel: "embedding-config:nomic-embed-text-v1.5|dimensions=512",
+      },
+    },
+  ],
+});
+
+jest.mock("@/LLMProviders/embeddingManager", () => ({
+  __esModule: true,
+  default: Object.assign(jest.fn(), {
+    getInstance: jest.fn(() => ({ getEmbeddingModelIdentity })),
+  }),
+}));
+jest.mock("@/error", () => ({ CustomError: Error }));
+jest.mock("@/logger", () => ({ logError: jest.fn(), logInfo: jest.fn() }));
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(),
+  subscribeToSettingsChange: jest.fn(),
+}));
+jest.mock("@/utils/hash", () => ({ md5: jest.fn() }));
+jest.mock("@/search/searchUtils", () => ({
+  getMatchingPatterns: jest.fn(),
+  getVectorLength: jest.fn(),
+  shouldIndexFile: jest.fn(),
+}));
+jest.mock("@/search/chunkedStorage", () => ({ ChunkedStorage: jest.fn() }));
+jest.mock("@orama/orama", () => ({
+  create: jest.fn(),
+  insert: jest.fn(),
+  remove: jest.fn(),
+  removeMultiple: jest.fn(),
+  search,
+}));
+jest.mock("obsidian", () => ({
+  App: jest.fn(),
+  MarkdownView: jest.fn(),
+  Notice: jest.fn(),
+  Platform: {},
+  TFile: jest.fn(),
+  Vault: jest.fn(),
+  normalizePath: jest.fn(),
+  requestUrl: jest.fn(),
+}));
+
+import { DBOperations } from "./dbOperations";
+
+describe("DBOperations configured embedding identity changes", () => {
+  it("rebuilds when the persisted 512-dimensional identity differs from the current 1024-dimensional identity", async () => {
+    const embeddingInstance = { modelName: "nomic-embed-text-v1.5" };
+    const replacementDb = {};
+    const dbOperations = Object.create(DBOperations.prototype) as {
+      oramaDb: object;
+      createNewDb: jest.Mock;
+      saveDB: jest.Mock;
+    };
+    dbOperations.oramaDb = {};
+    dbOperations.createNewDb = jest.fn().mockResolvedValue(replacementDb);
+    dbOperations.saveDB = jest.fn().mockResolvedValue(undefined);
+
+    const changed = (await DBOperations.prototype.checkAndHandleEmbeddingModelChange.call(
+      dbOperations,
+      embeddingInstance
+    )) as boolean;
+
+    expect(getEmbeddingModelIdentity).toHaveBeenCalledWith(embeddingInstance);
+    expect(search).toHaveBeenCalledWith(dbOperations.oramaDb, { term: "", limit: 1 });
+    expect(dbOperations.createNewDb).toHaveBeenCalledWith(embeddingInstance);
+    expect(dbOperations.saveDB).toHaveBeenCalledTimes(1);
+    expect(changed).toBe(true);
+  });
+});

--- a/src/search/dbOperations.ts
+++ b/src/search/dbOperations.ts
@@ -515,7 +515,8 @@ export class DBOperations {
     }
 
     if (prevEmbeddingModel) {
-      const currEmbeddingModel = EmbeddingsManager.getModelName(embeddingInstance);
+      const currEmbeddingModel =
+        EmbeddingsManager.getInstance().getEmbeddingModelIdentity(embeddingInstance);
 
       if (!areEmbeddingModelsSame(prevEmbeddingModel, currEmbeddingModel)) {
         // Model has changed, notify user and rebuild DB

--- a/src/search/indexOperations.test.ts
+++ b/src/search/indexOperations.test.ts
@@ -1,0 +1,107 @@
+jest.mock("@/aiParams", () => ({
+  flushIndexingCount: jest.fn(),
+  getIndexingProgressState: jest.fn(() => ({ isCancelled: false, isPaused: false })),
+  resetIndexingProgressState: jest.fn(),
+  setIndexingProgressState: jest.fn(),
+  throttledUpdateIndexingCount: jest.fn(),
+  updateIndexingProgressState: jest.fn(),
+}));
+
+jest.mock("@/LLMProviders/embeddingManager", () => ({
+  __esModule: true,
+  default: Object.assign(jest.fn(), {
+    getModelName: jest.fn(() => "nomic-embed-text-v1.5"),
+  }),
+}));
+
+jest.mock("@/logger", () => ({ logError: jest.fn(), logInfo: jest.fn(), logWarn: jest.fn() }));
+jest.mock("@/rateLimiter", () => ({ RateLimiter: jest.fn() }));
+jest.mock("@/search/v3/chunks", () => ({ getSharedChunkManager: jest.fn() }));
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({
+    enableSemanticSearchV3: true,
+    embeddingRequestsPerMin: 60,
+    embeddingBatchSize: 1,
+  })),
+  subscribeToSettingsChange: jest.fn(),
+}));
+jest.mock("@/utils", () => ({ formatDateTime: jest.fn() }));
+jest.mock("@/utils/hash", () => ({ md5: jest.fn(() => "doc-id") }));
+jest.mock("@/search/searchUtils", () => ({
+  getMatchingPatterns: jest.fn(),
+  shouldIndexFile: jest.fn(),
+}));
+jest.mock("obsidian", () => ({ Notice: jest.fn(), TFile: jest.fn() }));
+
+import { IndexOperations } from "./indexOperations";
+
+describe("IndexOperations embedding model identity", () => {
+  it("writes the manager identity into prepared local index documents", async () => {
+    const embeddingInstance = { modelName: "nomic-embed-text-v1.5" };
+    const identity = "embedding-config:nomic-embed-text-v1.5|dimensions=1024";
+    const embeddingsManager = {
+      getEmbeddingsAPI: jest.fn().mockResolvedValue(embeddingInstance),
+      getEmbeddingModelIdentity: jest.fn().mockReturnValue(identity),
+    };
+    const operation = Object.create(IndexOperations.prototype) as {
+      embeddingsManager: typeof embeddingsManager;
+      indexBackend: Record<string, jest.Mock>;
+      getFilesToIndex: jest.Mock;
+      prepareAllChunks: jest.Mock;
+    };
+
+    operation.embeddingsManager = embeddingsManager;
+    operation.indexBackend = {
+      requiresEmbeddings: jest.fn(() => true),
+      checkAndHandleEmbeddingModelChange: jest.fn().mockResolvedValue(false),
+      garbageCollect: jest.fn().mockResolvedValue(undefined),
+      clearFilesMissingEmbeddings: jest.fn(),
+    };
+    operation.getFilesToIndex = jest.fn().mockResolvedValue([{}]);
+    operation.prepareAllChunks = jest.fn().mockResolvedValue([]);
+
+    await IndexOperations.prototype.indexVaultToVectorStore.call(operation);
+
+    expect(embeddingsManager.getEmbeddingModelIdentity).toHaveBeenCalledWith(embeddingInstance);
+    expect(operation.prepareAllChunks).toHaveBeenCalledWith([{}], identity);
+  });
+
+  it("clears only the local index and forces a full rebuild when dimensions change", async () => {
+    const embeddingInstance = { modelName: "nomic-embed-text-v1.5" };
+    const embeddingsManager = {
+      getEmbeddingsAPI: jest.fn().mockResolvedValue(embeddingInstance),
+      getEmbeddingModelIdentity: jest
+        .fn()
+        .mockReturnValue("embedding-config:nomic-embed-text-v1.5|dimensions=1024"),
+    };
+    const vault = {
+      delete: jest.fn(),
+      adapter: { remove: jest.fn() },
+    };
+    const operation = Object.create(IndexOperations.prototype) as {
+      app: { vault: typeof vault };
+      embeddingsManager: typeof embeddingsManager;
+      indexBackend: Record<string, jest.Mock>;
+      getFilesToIndex: jest.Mock;
+      prepareAllChunks: jest.Mock;
+    };
+
+    operation.app = { vault };
+    operation.embeddingsManager = embeddingsManager;
+    operation.indexBackend = {
+      requiresEmbeddings: jest.fn(() => true),
+      checkAndHandleEmbeddingModelChange: jest.fn().mockResolvedValue(true),
+      clearIndex: jest.fn().mockResolvedValue(undefined),
+      clearFilesMissingEmbeddings: jest.fn(),
+    };
+    operation.getFilesToIndex = jest.fn().mockResolvedValue([{}]);
+    operation.prepareAllChunks = jest.fn().mockResolvedValue([]);
+
+    await IndexOperations.prototype.indexVaultToVectorStore.call(operation);
+
+    expect(operation.indexBackend.clearIndex).toHaveBeenCalledWith(embeddingInstance);
+    expect(operation.getFilesToIndex).toHaveBeenCalledWith(true);
+    expect(vault.delete).not.toHaveBeenCalled();
+    expect(vault.adapter.remove).not.toHaveBeenCalled();
+  });
+});

--- a/src/search/indexOperations.ts
+++ b/src/search/indexOperations.ts
@@ -137,7 +137,7 @@ export class IndexOperations {
       // New: Prepare all chunks first
       const embeddingModel =
         requiresEmbeddings && embeddingInstance
-          ? EmbeddingsManager.getModelName(embeddingInstance)
+          ? this.embeddingsManager.getEmbeddingModelIdentity(embeddingInstance)
           : "";
       const allChunks = await this.prepareAllChunks(files, embeddingModel);
       if (allChunks.length === 0) {
@@ -607,7 +607,7 @@ export class IndexOperations {
       // Reuse prepareAllChunks with a single file
       const embeddingModel =
         requiresEmbeddings && embeddingInstance
-          ? EmbeddingsManager.getModelName(embeddingInstance)
+          ? this.embeddingsManager.getEmbeddingModelIdentity(embeddingInstance)
           : "";
       const chunks = await this.prepareAllChunks([file], embeddingModel);
       if (chunks.length === 0) return;

--- a/src/settings/v2/components/EmbeddingDimensionsField.test.tsx
+++ b/src/settings/v2/components/EmbeddingDimensionsField.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+import { EmbeddingDimensionsField } from "./EmbeddingDimensionsField";
+
+describe("EmbeddingDimensionsField", () => {
+  it("publishes a valid positive integer", () => {
+    const onChange = jest.fn();
+
+    render(<EmbeddingDimensionsField onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText("Embedding dimensions"), {
+      target: { value: "512" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith(512);
+  });
+
+  it("publishes undefined when cleared", () => {
+    const onChange = jest.fn();
+
+    render(<EmbeddingDimensionsField dimensions={512} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText("Embedding dimensions"), {
+      target: { value: "" },
+    });
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("keeps a decimal input invalid without publishing it", () => {
+    const onChange = jest.fn();
+    const onValidityChange = jest.fn();
+
+    render(<EmbeddingDimensionsField onChange={onChange} onValidityChange={onValidityChange} />);
+
+    fireEvent.change(screen.getByLabelText("Embedding dimensions"), {
+      target: { value: "1.5" },
+    });
+
+    expect(screen.getByText("Embedding dimensions must be a positive integer")).not.toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(onValidityChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("shows the existing dimensions", () => {
+    render(<EmbeddingDimensionsField dimensions={512} onChange={jest.fn()} />);
+
+    expect(screen.getByLabelText("Embedding dimensions")).toHaveProperty("value", "512");
+  });
+});

--- a/src/settings/v2/components/EmbeddingDimensionsField.tsx
+++ b/src/settings/v2/components/EmbeddingDimensionsField.tsx
@@ -1,0 +1,74 @@
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import { getValidEmbeddingDimensions } from "@/utils/embeddingDimensions";
+import React, { useEffect, useMemo, useState } from "react";
+
+interface EmbeddingDimensionsFieldProps {
+  dimensions?: number;
+  onChange: (dimensions: number | undefined) => void;
+  onValidityChange?: (isValid: boolean) => void;
+}
+
+/**
+ * Collects an optional provider-supported embedding output dimension.
+ *
+ * Invalid text remains local so model settings are never updated with an
+ * unsupported value while the user corrects the field.
+ */
+export const EmbeddingDimensionsField: React.FC<EmbeddingDimensionsFieldProps> = ({
+  dimensions,
+  onChange,
+  onValidityChange,
+}) => {
+  const [inputValue, setInputValue] = useState(() => dimensions?.toString() ?? "");
+  const validDimensions = useMemo(
+    () => getValidEmbeddingDimensions(Number(inputValue)),
+    [inputValue]
+  );
+  const isValid = inputValue === "" || validDimensions !== undefined;
+
+  useEffect(() => {
+    // Keep the local invalid-input buffer in sync when the parent loads a different model.
+    // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+    setInputValue(dimensions?.toString() ?? "");
+  }, [dimensions]);
+
+  useEffect(() => {
+    onValidityChange?.(isValid);
+  }, [isValid, onValidityChange]);
+
+  /** Publishes only a valid dimension or an explicit provider-default reset. */
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    setInputValue(value);
+
+    if (value === "") {
+      onChange(undefined);
+      return;
+    }
+
+    const nextDimensions = getValidEmbeddingDimensions(Number(value));
+    if (nextDimensions !== undefined) {
+      onChange(nextDimensions);
+    }
+  };
+
+  return (
+    <FormField
+      label="Embedding dimensions"
+      description="Optional output vector dimensions. Leave empty to use the provider default. Changing the model or dimensions requires rebuilding the vault index."
+      error={!isValid}
+      errorMessage="Embedding dimensions must be a positive integer"
+    >
+      <Input
+        type="number"
+        aria-label="Embedding dimensions"
+        min={1}
+        step={1}
+        placeholder="Provider default, e.g. 512"
+        value={inputValue}
+        onChange={handleChange}
+      />
+    </FormField>
+  );
+};

--- a/src/settings/v2/components/ModelAddDialog.tsx
+++ b/src/settings/v2/components/ModelAddDialog.tsx
@@ -37,6 +37,7 @@ import { err2String, getProviderInfo, getProviderLabel, omit } from "@/utils";
 import { buildCurlCommandForModel } from "@/utils/curlCommand";
 import { CheckCircle2, ChevronDown, Loader2, XCircle } from "lucide-react";
 import { getApiKeyForProvider } from "@/utils/modelUtils";
+import { EmbeddingDimensionsField } from "./EmbeddingDimensionsField";
 import { Notice } from "obsidian";
 import React, { useState } from "react";
 
@@ -79,6 +80,7 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
   const [dialogElement, setDialogElement] = useState<HTMLDivElement | null>(null);
   const [isOpen, setIsOpen] = useState(() => hasRequiredExtraSettings(defaultProvider));
   const [isVerifying, setIsVerifying] = useState(false);
+  const [isEmbeddingDimensionsValid, setIsEmbeddingDimensionsValid] = useState(true);
   const [verifyStatus, setVerifyStatus] = useState<"idle" | "success" | "failed">("idle");
   const [errors, setErrors] = useState<FormErrors>({
     name: false,
@@ -218,7 +220,13 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
 
   // Check if buttons should be disabled
   const isButtonDisabled = (): boolean => {
-    return isVerifying || !isFormValid();
+    const showEmbeddingDimensions =
+      isEmbeddingModel &&
+      (model.provider as EmbeddingModelProviders) === EmbeddingModelProviders.OPENAI_FORMAT;
+
+    return (
+      isVerifying || !isFormValid() || (showEmbeddingDimensions && !isEmbeddingDimensionsValid)
+    );
   };
 
   const handleAdd = () => {
@@ -239,6 +247,7 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
   const handleProviderChange = (provider: ChatModelProviders) => {
     setProviderInfo(getProviderInfo(provider));
     setVerifyStatus("idle");
+    setIsEmbeddingDimensionsValid(true);
     setModel({
       ...model,
       provider,
@@ -633,6 +642,16 @@ export const ModelAddDialog: React.FC<ModelAddDialogProps> = ({
               </p>
             )}
           </FormField>
+
+          {isEmbeddingModel &&
+            (model.provider as EmbeddingModelProviders) ===
+              EmbeddingModelProviders.OPENAI_FORMAT && (
+              <EmbeddingDimensionsField
+                dimensions={model.dimensions}
+                onChange={(dimensions) => updateModelWithReset({ dimensions })}
+                onValidityChange={setIsEmbeddingDimensionsValid}
+              />
+            )}
 
           {!isEmbeddingModel && (
             <FormField

--- a/src/settings/v2/components/ModelEditDialog.test.tsx
+++ b/src/settings/v2/components/ModelEditDialog.test.tsx
@@ -1,0 +1,96 @@
+import type { CustomModel } from "@/aiParams";
+import { EmbeddingModelProviders } from "@/constants";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const pluginRoot = {
+  render: jest.fn<void, [React.ReactElement]>(),
+  unmount: jest.fn(),
+};
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+jest.mock("@/components/ui/checkbox", () => ({ Checkbox: () => null }));
+jest.mock("@/components/ui/form-field", () => ({
+  FormField: ({ label, children }: { label: React.ReactNode; children: React.ReactNode }) => (
+    <div>
+      {label}
+      {children}
+    </div>
+  ),
+}));
+jest.mock("@/components/ui/help-tooltip", () => ({ HelpTooltip: () => null }));
+jest.mock("@/components/ui/input", () => ({
+  Input: React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+    (props, ref) => <input ref={ref} {...props} />
+  ),
+}));
+jest.mock("@/components/ui/label", () => ({ Label: () => null }));
+jest.mock("@/components/ui/password-input", () => ({ PasswordInput: () => null }));
+jest.mock("@/components/ui/ModelParametersEditor", () => ({ ModelParametersEditor: () => null }));
+jest.mock("@/settings/model", () => ({ getSettings: jest.fn(() => ({})) }));
+jest.mock("@/utils", () => ({
+  debounce: <T extends (...args: never[]) => unknown>(callback: T) => callback,
+  getProviderInfo: jest.fn(() => ({})),
+  getProviderLabel: jest.fn((provider: string) => provider),
+}));
+jest.mock("@/utils/modelUtils", () => ({
+  getApiKeyForProvider: jest.fn(() => ""),
+}));
+jest.mock("@/utils/react/createPluginRoot", () => ({
+  createPluginRoot: jest.fn(() => pluginRoot),
+}));
+jest.mock("obsidian", () => ({
+  Modal: class {
+    contentEl = window.document.createElement("div");
+    modalEl = { addClass: jest.fn() };
+
+    constructor(protected app: unknown) {}
+
+    setTitle(): void {}
+    close(): void {}
+  },
+  Platform: { isMobile: false },
+}));
+
+import { ModelEditModal } from "./ModelEditDialog";
+
+describe("ModelEditModal embedding dimensions", () => {
+  it("sends edited and cleared dimensions through the model update callback", () => {
+    const originalModel: CustomModel = {
+      name: "nomic-embed-text-v1.5",
+      provider: EmbeddingModelProviders.OPENAI_FORMAT,
+      enabled: true,
+      isEmbeddingModel: true,
+      dimensions: 512,
+    };
+    const onUpdate = jest.fn();
+    const modal = new ModelEditModal({} as never, originalModel, true, onUpdate);
+
+    modal.onOpen();
+    render(pluginRoot.render.mock.calls[0][0]);
+
+    fireEvent.change(screen.getByLabelText("Embedding dimensions"), {
+      target: { value: "1024" },
+    });
+    expect(onUpdate).toHaveBeenLastCalledWith(
+      true,
+      originalModel,
+      expect.objectContaining({ dimensions: 1024 })
+    );
+
+    fireEvent.change(screen.getByLabelText("Embedding dimensions"), {
+      target: { value: "" },
+    });
+    expect(onUpdate).toHaveBeenLastCalledWith(
+      true,
+      originalModel,
+      expect.objectContaining({ dimensions: undefined })
+    );
+  });
+});

--- a/src/settings/v2/components/ModelEditDialog.tsx
+++ b/src/settings/v2/components/ModelEditDialog.tsx
@@ -1,6 +1,7 @@
 import { CustomModel } from "@/aiParams";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { EmbeddingDimensionsField } from "./EmbeddingDimensionsField";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -208,6 +209,15 @@ const ModelEditModalContent: React.FC<ModelEditModalContentProps> = ({
             </p>
           )}
         </FormField>
+
+        {isEmbeddingModel &&
+          (localModel.provider as EmbeddingModelProviders) ===
+            EmbeddingModelProviders.OPENAI_FORMAT && (
+            <EmbeddingDimensionsField
+              dimensions={localModel.dimensions}
+              onChange={(dimensions) => handleLocalUpdate("dimensions", dimensions)}
+            />
+          )}
 
         {/* Prompt Caching Toggle for OpenRouter */}
         {(localModel.provider as ChatModelProviders) === ChatModelProviders.OPENROUTERAI && (

--- a/src/settings/v2/components/ModelSettings.test.tsx
+++ b/src/settings/v2/components/ModelSettings.test.tsx
@@ -1,0 +1,150 @@
+import { CustomModel } from "@/aiParams";
+import { EmbeddingModelProviders } from "@/constants";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const mockUpdateSetting = jest.fn();
+const mockSetSettings = jest.fn();
+const mockIndexVaultToVectorStore = jest.fn();
+const mockEditModalOpen = jest.fn();
+const mockRebuildModalOpen = jest.fn();
+let mockModelUpdate:
+  | ((isEmbeddingModel: boolean, originalModel: CustomModel, updatedModel: CustomModel) => void)
+  | undefined;
+let mockConfirmRebuild: (() => void | Promise<void>) | undefined;
+
+const selectedEmbeddingModel: CustomModel = {
+  name: "custom-embedding",
+  provider: EmbeddingModelProviders.OPENAI_FORMAT,
+  enabled: true,
+  isEmbeddingModel: true,
+  dimensions: 512,
+};
+
+const mockSettings = {
+  activeModels: [] as CustomModel[],
+  activeEmbeddingModels: [selectedEmbeddingModel],
+  embeddingModelKey: `${selectedEmbeddingModel.name}|${selectedEmbeddingModel.provider}`,
+  enableSemanticSearchV3: true,
+  contextTurns: 15,
+  autoCompactThreshold: 128000,
+};
+
+jest.mock("@/components/ui/setting-item", () => ({ SettingItem: () => null }));
+jest.mock("@/context", () => ({
+  // This mock must retain the production hook name even though it does not need React state.
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix
+  useApp: () => ({}),
+}));
+jest.mock("@/LLMProviders/embeddingManager", () => ({
+  __esModule: true,
+  default: { getInstance: jest.fn(() => ({ ping: jest.fn() })) },
+}));
+jest.mock("@/LLMProviders/projectManager", () => ({
+  __esModule: true,
+  default: { instance: { getCurrentChainManager: jest.fn() } },
+}));
+jest.mock("@/settings/model", () => ({
+  getModelKeyFromModel: (model: CustomModel) => `${model.name}|${model.provider}`,
+  setSettings: mockSetSettings,
+  updateSetting: mockUpdateSetting,
+  // This mock must retain the production hook name even though it returns fixed test data.
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix
+  useSettingsValue: () => mockSettings,
+}));
+jest.mock("@/settings/v2/components/ModelAddDialog", () => ({
+  ModelAddDialog: () => null,
+}));
+jest.mock("@/settings/v2/components/ModelEditDialog", () => ({
+  ModelEditModal: class {
+    constructor(
+      _app: unknown,
+      _model: CustomModel,
+      _isEmbeddingModel: boolean,
+      onUpdate: typeof mockModelUpdate
+    ) {
+      mockModelUpdate = onUpdate;
+    }
+
+    open(): void {
+      mockEditModalOpen();
+    }
+  },
+}));
+jest.mock("@/settings/v2/components/ModelTable", () => ({
+  ModelTable: ({
+    models,
+    onEdit,
+    title,
+  }: {
+    models: CustomModel[];
+    onEdit?: (model: CustomModel) => void;
+    title: string;
+  }) =>
+    models[0] ? (
+      <button type="button" onClick={() => onEdit?.(models[0])}>
+        Edit {title}
+      </button>
+    ) : null,
+}));
+jest.mock("@/components/modals/RebuildIndexConfirmModal", () => ({
+  RebuildIndexConfirmModal: class {
+    constructor(_app: unknown, onConfirm: typeof mockConfirmRebuild) {
+      mockConfirmRebuild = onConfirm;
+    }
+
+    open(): void {
+      mockRebuildModalOpen();
+    }
+  },
+}));
+jest.mock("@/search/vectorStoreManager", () => ({
+  __esModule: true,
+  default: {
+    getInstance: jest.fn(() => ({
+      indexVaultToVectorStore: mockIndexVaultToVectorStore,
+    })),
+  },
+}));
+jest.mock("obsidian", () => ({ Notice: jest.fn() }));
+
+import { ModelSettings } from "./ModelSettings";
+
+describe("ModelSettings embedding dimension updates", () => {
+  beforeEach(() => {
+    mockModelUpdate = undefined;
+    mockConfirmRebuild = undefined;
+    jest.clearAllMocks();
+  });
+
+  it("confirms before saving and rebuilding changed dimensions for the selected model", async () => {
+    render(<ModelSettings />);
+    fireEvent.click(screen.getByRole("button", { name: "Edit Embedding Models" }));
+
+    const updatedModel = { ...selectedEmbeddingModel, dimensions: 1024 };
+    act(() => {
+      mockModelUpdate?.(true, selectedEmbeddingModel, updatedModel);
+    });
+
+    expect(mockRebuildModalOpen).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSetting).not.toHaveBeenCalled();
+    expect(mockIndexVaultToVectorStore).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await mockConfirmRebuild?.();
+    });
+
+    expect(mockUpdateSetting).toHaveBeenCalledWith("activeEmbeddingModels", [updatedModel]);
+    expect(mockIndexVaultToVectorStore).toHaveBeenCalledWith(false, {
+      userInitiated: true,
+    });
+
+    act(() => {
+      mockModelUpdate?.(true, selectedEmbeddingModel, updatedModel);
+    });
+
+    expect(mockRebuildModalOpen).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSetting).toHaveBeenCalledTimes(2);
+    expect(mockIndexVaultToVectorStore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/settings/v2/components/ModelSettings.tsx
+++ b/src/settings/v2/components/ModelSettings.tsx
@@ -1,21 +1,31 @@
 import { CustomModel } from "@/aiParams";
+import { RebuildIndexConfirmModal } from "@/components/modals/RebuildIndexConfirmModal";
 import { SettingItem } from "@/components/ui/setting-item";
 import { useApp } from "@/context";
 import { BUILTIN_CHAT_MODELS, BUILTIN_EMBEDDING_MODELS } from "@/constants";
 import EmbeddingManager from "@/LLMProviders/embeddingManager";
 import ProjectManager from "@/LLMProviders/projectManager";
 import { logError } from "@/logger";
-import { CopilotSettings, setSettings, updateSetting, useSettingsValue } from "@/settings/model";
+import {
+  CopilotSettings,
+  getModelKeyFromModel,
+  setSettings,
+  updateSetting,
+  useSettingsValue,
+} from "@/settings/model";
 import { ModelAddDialog } from "@/settings/v2/components/ModelAddDialog";
 import { ModelEditModal } from "@/settings/v2/components/ModelEditDialog";
 import { ModelTable } from "@/settings/v2/components/ModelTable";
+import { applyEmbeddingModelUpdate } from "@/settings/v2/utils/embeddingModelUpdate";
 import { omit } from "@/utils";
 import { Notice } from "obsidian";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 
 export const ModelSettings: React.FC = () => {
   const app = useApp();
   const settings = useSettingsValue();
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
   const [showAddDialog, setShowAddDialog] = useState(false);
   const [showAddEmbeddingDialog, setShowAddEmbeddingDialog] = useState(false);
 
@@ -68,7 +78,8 @@ export const ModelSettings: React.FC = () => {
     });
   };
 
-  const handleModelUpdate = (
+  /** Persists an edited model in the matching settings collection. */
+  const persistModelUpdate = (
     isEmbeddingModel: boolean,
     originalModel: CustomModel,
     updatedModel: CustomModel
@@ -76,18 +87,49 @@ export const ModelSettings: React.FC = () => {
     const settingField: keyof CopilotSettings = isEmbeddingModel
       ? "activeEmbeddingModels"
       : "activeModels";
+    const currentSettings = settingsRef.current;
 
-    const modelIndex = settings[settingField].findIndex(
+    const modelIndex = currentSettings[settingField].findIndex(
       (m) => m.name === originalModel.name && m.provider === originalModel.provider
     );
     if (modelIndex !== -1) {
-      const updatedModels = [...settings[settingField]];
+      const updatedModels = [...currentSettings[settingField]];
       updatedModels[modelIndex] = updatedModel;
+      settingsRef.current = { ...currentSettings, [settingField]: updatedModels };
       updateSetting(settingField, updatedModels);
     } else {
       new Notice("Could not find model to update");
       logError("Could not find model to update:", originalModel);
     }
+  };
+
+  /** Saves model edits and confirms an index rebuild before changing active dimensions. */
+  const handleModelUpdate = (
+    isEmbeddingModel: boolean,
+    originalModel: CustomModel,
+    updatedModel: CustomModel
+  ) => {
+    const currentSettings = settingsRef.current;
+    const currentModel = currentSettings.activeEmbeddingModels.find(
+      (model) => getModelKeyFromModel(model) === getModelKeyFromModel(originalModel)
+    );
+    applyEmbeddingModelUpdate({
+      isEmbeddingModel,
+      isSelectedModel: getModelKeyFromModel(originalModel) === currentSettings.embeddingModelKey,
+      currentDimensions: currentModel?.dimensions,
+      updatedDimensions: updatedModel.dimensions,
+      semanticSearchEnabled: currentSettings.enableSemanticSearchV3,
+      persist: () => persistModelUpdate(isEmbeddingModel, originalModel, updatedModel),
+      confirmRebuild: (onConfirm) => new RebuildIndexConfirmModal(app, onConfirm).open(),
+      rebuildIndex: async () => {
+        const VectorStoreManager = (await import("@/search/vectorStoreManager")).default;
+        await VectorStoreManager.getInstance().indexVaultToVectorStore(false, {
+          userInitiated: true,
+        });
+      },
+      notifySearchDisabled: () =>
+        new Notice("Embedding dimensions saved. Enable Semantic Search to build the index."),
+    });
   };
 
   // Handler for updates originating from the ModelTable itself (e.g., checkbox toggles)

--- a/src/settings/v2/utils/embeddingModelUpdate.test.ts
+++ b/src/settings/v2/utils/embeddingModelUpdate.test.ts
@@ -1,0 +1,88 @@
+import { applyEmbeddingModelUpdate } from "./embeddingModelUpdate";
+
+interface TestHarness {
+  persist: jest.Mock;
+  confirmRebuild: jest.Mock;
+  rebuildIndex: jest.Mock;
+  notifySearchDisabled: jest.Mock;
+  confirmCallback?: () => Promise<void>;
+}
+
+/** Creates plain callback dependencies for exercising the model-update orchestration. */
+function createHarness(): TestHarness {
+  const harness: TestHarness = {
+    persist: jest.fn(),
+    confirmRebuild: jest.fn(),
+    rebuildIndex: jest.fn().mockResolvedValue(undefined),
+    notifySearchDisabled: jest.fn(),
+  };
+  harness.confirmRebuild.mockImplementation((callback: () => Promise<void>) => {
+    harness.confirmCallback = callback;
+  });
+  return harness;
+}
+
+/** Runs the update flow with the selected model changing from 512 to 1024 dimensions. */
+function applySelectedDimensionChange(
+  harness: TestHarness,
+  overrides: Partial<Parameters<typeof applyEmbeddingModelUpdate>[0]> = {}
+): void {
+  applyEmbeddingModelUpdate({
+    isEmbeddingModel: true,
+    isSelectedModel: true,
+    currentDimensions: 512,
+    updatedDimensions: 1024,
+    semanticSearchEnabled: true,
+    persist: harness.persist,
+    confirmRebuild: harness.confirmRebuild,
+    rebuildIndex: harness.rebuildIndex,
+    notifySearchDisabled: harness.notifySearchDisabled,
+    ...overrides,
+  });
+}
+
+describe("applyEmbeddingModelUpdate", () => {
+  it("waits for confirmation before saving selected-model dimension changes", () => {
+    const harness = createHarness();
+
+    applySelectedDimensionChange(harness);
+
+    expect(harness.confirmRebuild).toHaveBeenCalledTimes(1);
+    expect(harness.persist).not.toHaveBeenCalled();
+    expect(harness.rebuildIndex).not.toHaveBeenCalled();
+  });
+
+  it("saves and rebuilds after confirmation", async () => {
+    const harness = createHarness();
+    applySelectedDimensionChange(harness);
+
+    await harness.confirmCallback?.();
+
+    expect(harness.persist).toHaveBeenCalledTimes(1);
+    expect(harness.rebuildIndex).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves without rebuilding when semantic search is disabled", () => {
+    const harness = createHarness();
+
+    applySelectedDimensionChange(harness, { semanticSearchEnabled: false });
+
+    expect(harness.persist).toHaveBeenCalledTimes(1);
+    expect(harness.notifySearchDisabled).toHaveBeenCalledTimes(1);
+    expect(harness.confirmRebuild).not.toHaveBeenCalled();
+    expect(harness.rebuildIndex).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "a non-selected model", isSelectedModel: false },
+    { name: "a non-embedding model", isEmbeddingModel: false },
+    { name: "unchanged dimensions", updatedDimensions: 512 },
+  ])("saves $name immediately", (overrides) => {
+    const harness = createHarness();
+
+    applySelectedDimensionChange(harness, overrides);
+
+    expect(harness.persist).toHaveBeenCalledTimes(1);
+    expect(harness.confirmRebuild).not.toHaveBeenCalled();
+  });
+});

--- a/src/settings/v2/utils/embeddingModelUpdate.ts
+++ b/src/settings/v2/utils/embeddingModelUpdate.ts
@@ -1,0 +1,39 @@
+export interface EmbeddingModelUpdateOptions {
+  isEmbeddingModel: boolean;
+  isSelectedModel: boolean;
+  currentDimensions?: number;
+  updatedDimensions?: number;
+  semanticSearchEnabled: boolean;
+  persist: () => void;
+  confirmRebuild: (onConfirm: () => Promise<void>) => void;
+  rebuildIndex: () => Promise<void>;
+  notifySearchDisabled: () => void;
+}
+
+/**
+ * Applies an edited model immediately or behind a confirmed semantic-index rebuild.
+ *
+ * @param options - Current model state and UI-independent update callbacks.
+ */
+export function applyEmbeddingModelUpdate(options: EmbeddingModelUpdateOptions): void {
+  const dimensionsChanged =
+    options.isEmbeddingModel &&
+    options.isSelectedModel &&
+    options.currentDimensions !== options.updatedDimensions;
+
+  if (!dimensionsChanged) {
+    options.persist();
+    return;
+  }
+
+  if (!options.semanticSearchEnabled) {
+    options.persist();
+    options.notifySearchDisabled();
+    return;
+  }
+
+  options.confirmRebuild(async () => {
+    options.persist();
+    await options.rebuildIndex();
+  });
+}

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -4,6 +4,7 @@ import {
   extractNoteFiles,
   extractTemplateNoteFiles,
   formatDateTime,
+  areEmbeddingModelsSame,
   getModelInfo,
   getNotesFromPath,
   getNotesFromTags,
@@ -19,6 +20,21 @@ import {
 } from "./utils";
 import { TimeoutError } from "./error";
 import { ChatModelProviders } from "./constants";
+import { EMBEDDING_MODEL_IDENTITY_PREFIX } from "./utils/embeddingDimensions";
+
+describe("areEmbeddingModelsSame", () => {
+  it("does not apply legacy Nomic aliases to configured dimension identities", () => {
+    const model512 = `${EMBEDDING_MODEL_IDENTITY_PREFIX}nomic-embed-text-v1.5|dimensions=512`;
+    const model1024 = `${EMBEDDING_MODEL_IDENTITY_PREFIX}nomic-embed-text-v1.5|dimensions=1024`;
+
+    expect(areEmbeddingModelsSame(model512, model1024)).toBe(false);
+  });
+
+  it("keeps legacy embedding aliases compatible when neither model has an identity prefix", () => {
+    expect(areEmbeddingModelsSame("nomic-embed-text-v1", "nomic-embed-text-v1.5")).toBe(true);
+    expect(areEmbeddingModelsSame("small", "cohereai")).toBe(true);
+  });
+});
 
 // Mock Obsidian's TFile class
 jest.mock("obsidian", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,7 @@ import { MemoryVariables } from "@langchain/core/memory";
 import { DateTime } from "luxon";
 import { MarkdownView, Notice, TFile, Vault, normalizePath, requestUrl } from "obsidian";
 import { CustomModel } from "./aiParams";
+import { EMBEDDING_MODEL_IDENTITY_PREFIX } from "./utils/embeddingDimensions";
 import { getApiKeyForProvider } from "@/utils/modelUtils";
 export { err2String } from "@/errorFormat";
 
@@ -380,6 +381,12 @@ export function areEmbeddingModelsSame(
   model2: string | undefined
 ): boolean {
   if (!model1 || !model2) return false;
+  if (
+    model1.startsWith(EMBEDDING_MODEL_IDENTITY_PREFIX) ||
+    model2.startsWith(EMBEDDING_MODEL_IDENTITY_PREFIX)
+  ) {
+    return model1 === model2;
+  }
   // TODO: Hacks to handle different embedding model names for the same model. Need better handling.
   if (model1.includes(NOMIC_EMBED_TEXT) && model2.includes(NOMIC_EMBED_TEXT)) {
     return true;

--- a/src/utils/embeddingDimensions.test.ts
+++ b/src/utils/embeddingDimensions.test.ts
@@ -1,0 +1,60 @@
+import {
+  EMBEDDING_MODEL_IDENTITY_PREFIX,
+  getEmbeddingModelIdentity,
+  getValidEmbeddingDimensions,
+} from "./embeddingDimensions";
+
+describe("getValidEmbeddingDimensions", () => {
+  it.each([512, 1024])("accepts the positive integer %d", (dimensions) => {
+    expect(getValidEmbeddingDimensions(dimensions)).toBe(dimensions);
+  });
+
+  it.each([
+    undefined,
+    "",
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+    "512",
+  ])("rejects an invalid dimensions value: %p", (dimensions) => {
+    expect(getValidEmbeddingDimensions(dimensions)).toBeUndefined();
+  });
+});
+
+describe("getEmbeddingModelIdentity", () => {
+  it("keeps the legacy model name when dimensions are not configured", () => {
+    expect(getEmbeddingModelIdentity("text-embedding-3-small", undefined)).toBe(
+      "text-embedding-3-small"
+    );
+  });
+
+  it("includes valid dimensions in a stable internal identity", () => {
+    const identity = getEmbeddingModelIdentity("text-embedding-3-small", 512);
+
+    expect(identity).toBe(
+      `${EMBEDDING_MODEL_IDENTITY_PREFIX}${encodeURIComponent("text-embedding-3-small")}|dimensions=512`
+    );
+    expect(getEmbeddingModelIdentity("text-embedding-3-small", 512)).toBe(identity);
+  });
+
+  it("uses different identities for different valid dimensions", () => {
+    expect(getEmbeddingModelIdentity("text-embedding-3-small", 512)).not.toBe(
+      getEmbeddingModelIdentity("text-embedding-3-small", 1024)
+    );
+  });
+
+  it("encodes model names containing the dimensions delimiter into distinct configured identities", () => {
+    const firstModelName = "test|dimensions=512";
+    const secondModelName = "test|dimensions=1024";
+    const firstIdentity = getEmbeddingModelIdentity(firstModelName, 512);
+    const secondIdentity = getEmbeddingModelIdentity(secondModelName, 512);
+
+    expect(firstIdentity).toBe(
+      `${EMBEDDING_MODEL_IDENTITY_PREFIX}test%7Cdimensions%3D512|dimensions=512`
+    );
+    expect(firstIdentity).not.toBe(secondIdentity);
+  });
+});

--- a/src/utils/embeddingDimensions.ts
+++ b/src/utils/embeddingDimensions.ts
@@ -1,0 +1,30 @@
+/** Prefix used to distinguish dimension-specific embedding model identities. */
+export const EMBEDDING_MODEL_IDENTITY_PREFIX = "embedding-config:";
+
+/**
+ * Returns dimensions only when the value is a finite positive integer.
+ *
+ * @param value - The candidate embedding dimensions value.
+ * @returns The validated dimensions, or undefined when the value is invalid.
+ */
+export function getValidEmbeddingDimensions(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 && Number.isInteger(value)
+    ? value
+    : undefined;
+}
+
+/**
+ * Builds an internal model identity that includes valid embedding dimensions.
+ *
+ * @param modelName - The configured embedding model name.
+ * @param dimensions - The candidate embedding dimensions value.
+ * @returns The original model name when dimensions are invalid, otherwise a dimension-specific identity.
+ */
+export function getEmbeddingModelIdentity(modelName: string, dimensions: unknown): string {
+  const validDimensions = getValidEmbeddingDimensions(dimensions);
+  if (validDimensions === undefined) {
+    return modelName;
+  }
+
+  return `${EMBEDDING_MODEL_IDENTITY_PREFIX}${encodeURIComponent(modelName)}|dimensions=${validDimensions}`;
+}


### PR DESCRIPTION
## Summary

- add an optional positive-integer dimensions field for custom OpenAI-compatible embedding models
- pass supported dimensions to embedding requests and validate the returned vector length during connection testing
- include configured dimensions in the local index identity so dimension changes trigger a rebuild
- confirm before saving and rebuilding when the selected model's dimensions change; save with guidance when Semantic Search is disabled
- preserve legacy behavior and index identities when dimensions are empty, including existing Copilot Plus/Jina providers
- document the new setting and its rebuild requirement

Related to #2131.

## Test plan

- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run test -- --runInBand` (124 suites, 2177 tests)
- [x] `npm run build`
- [x] pre-commit `nano-staged` hook
- [x] independent code review of the follow-up fix

## Compatibility

The setting is intentionally limited to custom OpenAI-compatible embedding models, whose API accepts the `dimensions` parameter. Leaving the field empty preserves the provider default and existing behavior.