### PR TITLE
fix(dev): identify test-vault builds exactly

### DIFF
--- a/designdocs/agents/TESTING_GUIDE.md
+++ b/designdocs/agents/TESTING_GUIDE.md
@@ -44,7 +44,7 @@ plugin loaded into a real vault. The CLI lives at
 npm run test:vault
 ```
 
-macOS only. Installs deps, builds, symlinks `main.js` / `manifest.json` /
+macOS only. Installs deps, builds, and copies `main.js` / `manifest.json` /
 `styles.css` from the current worktree into
 `$COPILOT_TEST_VAULT_PATH/.obsidian/plugins/copilot/`, then reloads the plugin
 via the Obsidian CLI. Requires `$COPILOT_TEST_VAULT_PATH` (user-level env var)
@@ -53,6 +53,10 @@ pointing at a vault that has been opened in Obsidian at least once.
 This is the canonical "get my changes running" step — don't hand-roll `npm run
 build && cp main.js …`. If the user has multiple Conductor worktrees, whichever
 one ran `test:vault` last wins; verify with the preflight in the next section.
+The copied manifest carries a development-only version suffix and visible tag
+with the commit, clean/dirty state, and bundle hash. A later build in the
+worktree does not mutate the deployed plugin; run `test:vault` again to deploy
+and reload the new build.
 
 ## Reset the test vault's settings
 
@@ -131,6 +135,7 @@ $OBS vault=$VAULT eval code='JSON.stringify({
   path:  app.vault.adapter.basePath,
   copilotLoaded: !!app.plugins.plugins.copilot,
   copilotVersion: app.plugins.manifests.copilot?.version,
+  buildTag: app.plugins.manifests.copilot?.description?.match(/dev build: ([^ |]+)/)?.[1],
   buildBranch: app.plugins.manifests.copilot?.description?.match(/branch: ([^ |]+)/)?.[1]
 })'
 ```
@@ -142,6 +147,8 @@ Check that:
   vault as a fresh renderer — silently. The plugin may not be ready yet; if
   `copilotLoaded` is `false`, call `app.plugins.loadPlugin("copilot")` via
   `eval` and re-probe.)
+- `buildTag` starts with the current worktree's short commit, reports the
+  expected clean/dirty state, and stays unchanged until the next deployment
 - `buildBranch` matches the worktree branch you actually built from. Multiple
   Conductor workspaces sharing one test vault means whichever ran
   `npm run test:vault` last wins — _verify_, don't assume.

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prepare": "husky",
     "prompt:debug": "node scripts/printPromptDebug.js",
     "test:vault": "bash scripts/test-vault.sh",
+    "test:vault:script": "bash scripts/test-vault.test.sh",
     "test:reset-data": "bash scripts/test-reset-data.sh"
   },
   "keywords": [],

--- a/scripts/test-vault.sh
+++ b/scripts/test-vault.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-OBSIDIAN_BIN="/Applications/Obsidian.app/Contents/MacOS/obsidian"
+OBSIDIAN_BIN="${OBSIDIAN_BIN:-/Applications/Obsidian.app/Contents/MacOS/obsidian}"
 
 if [[ -z "${COPILOT_TEST_VAULT_PATH:-}" ]]; then
   cat >&2 <<'EOF'
@@ -52,22 +52,15 @@ EOF
     ;;
 esac
 
-# Deployment mode: symlinks by default (macOS / native Linux). Switch to file
-# copy on WSL when the vault lives on a Windows-mounted filesystem — Obsidian
-# on Windows can't resolve WSL-flavored POSIX symlinks stored on DrvFs/9p.
-DEPLOY_MODE="link"
-if [[ "$(uname -r 2>/dev/null)" == *[Mm]icrosoft* ]] && [[ "$VAULT_REAL" == /mnt/* ]]; then
-  DEPLOY_MODE="copy"
-fi
-# iCloud-synced vaults (Obsidian on iOS/iPadOS) can't use symlinks: iCloud
-# uploads file contents, not link targets, so a symlinked main.js never reaches
-# the phone. Copy real files so the mobile device receives the build.
-if [[ "$VAULT_REAL" == *"/Mobile Documents/"* ]]; then
-  DEPLOY_MODE="copy"
-fi
-
 echo "==> Installing dependencies"
 npm install --prefer-offline --no-audit --no-fund
+
+BRANCH="$(git -C "$WORKTREE_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+BUILD_COMMIT="$(git -C "$WORKTREE_ROOT" rev-parse --short=8 HEAD 2>/dev/null || echo unknown)"
+BUILD_STATE="clean"
+if [[ -n "$(git -C "$WORKTREE_ROOT" status --porcelain --untracked-files=normal 2>/dev/null)" ]]; then
+  BUILD_STATE="dirty"
+fi
 
 echo "==> Building plugin"
 npm run build
@@ -81,38 +74,62 @@ fi
 PLUGIN_DIR="$VAULT_PATH/.obsidian/plugins/$PLUGIN_ID"
 mkdir -p "$PLUGIN_DIR"
 
-echo "==> Deploying artifacts into $PLUGIN_DIR (mode: $DEPLOY_MODE)"
+echo "==> Copying artifacts into $PLUGIN_DIR"
 for f in main.js styles.css; do
   if [[ ! -f "$WORKTREE_ROOT/$f" ]]; then
     echo "error: expected build artifact missing: $WORKTREE_ROOT/$f" >&2
     exit 1
   fi
   rm -f "$PLUGIN_DIR/$f"
-  if [[ "$DEPLOY_MODE" == "copy" ]]; then
-    cp -f "$WORKTREE_ROOT/$f" "$PLUGIN_DIR/$f"
-  else
-    ln -sfn "$WORKTREE_ROOT/$f" "$PLUGIN_DIR/$f"
-  fi
+  cp -f "$WORKTREE_ROOT/$f" "$PLUGIN_DIR/$f"
 done
 
-# Write a timestamp-tagged manifest.json (real file, not a symlink). The plugin
-# NAME (shown in Obsidian's Community plugins list / sidebar) carries the build
-# timestamp ONLY — never the branch/worktree name, which is not a reliable signal
-# of what code is actually loaded. The DESCRIPTION still carries `branch: <name>`
-# because the `npm run test:vault` preflight in TESTING_GUIDE.md greps it
-# (`/branch: ([^ |]+)/`) to catch deploying from the wrong worktree when several
-# worktrees share one vault.
-BRANCH="$(git -C "$WORKTREE_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
 BUILD_TS="$(date +%Y%m%d-%H%M%S)"
-echo "==> Writing timestamp-tagged manifest.json (name build: $BUILD_TS, branch: $BRANCH)"
 rm -f "$PLUGIN_DIR/manifest.json"
-SRC="$WORKTREE_ROOT/manifest.json" DEST="$PLUGIN_DIR/manifest.json" BRANCH="$BRANCH" BUILD_TS="$BUILD_TS" node -e '
-  const fs = require("fs");
-  const m = JSON.parse(fs.readFileSync(process.env.SRC, "utf8"));
-  m.name = m.name + " [" + process.env.BUILD_TS + "]";
-  m.description = "[branch: " + process.env.BRANCH + " | build: " + process.env.BUILD_TS + "] " + m.description;
-  fs.writeFileSync(process.env.DEST, JSON.stringify(m, null, 2) + "\n");
-'
+BUILD_TAG="$(
+  SRC="$WORKTREE_ROOT/manifest.json" \
+    DEST="$PLUGIN_DIR/manifest.json" \
+    ARTIFACT_DIR="$PLUGIN_DIR" \
+    BRANCH="$BRANCH" \
+    BUILD_COMMIT="$BUILD_COMMIT" \
+    BUILD_STATE="$BUILD_STATE" \
+    BUILD_TS="$BUILD_TS" \
+    node -e '
+    const crypto = require("node:crypto");
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const hash = crypto.createHash("sha256");
+    for (const file of ["main.js", "styles.css"]) {
+      hash.update(file);
+      hash.update("\0");
+      hash.update(fs.readFileSync(path.join(process.env.ARTIFACT_DIR, file)));
+      hash.update("\0");
+    }
+    const bundleSha = hash.digest("hex").slice(0, 12);
+    const buildTag = [
+      process.env.BUILD_COMMIT,
+      process.env.BUILD_STATE,
+      bundleSha,
+    ].join("-");
+    const manifest = JSON.parse(fs.readFileSync(process.env.SRC, "utf8"));
+    const versionSeparator = manifest.version.includes("+") ? "." : "+";
+    manifest.version += versionSeparator + [
+      "dev",
+      process.env.BUILD_COMMIT,
+      process.env.BUILD_STATE,
+      bundleSha,
+    ].join(".");
+    manifest.name += " [" + buildTag + "]";
+    manifest.description = [
+      "[dev build: " + buildTag,
+      "branch: " + process.env.BRANCH,
+      "built: " + process.env.BUILD_TS + "]",
+    ].join(" | ") + " " + manifest.description;
+    fs.writeFileSync(process.env.DEST, JSON.stringify(manifest, null, 2) + "\n");
+    process.stdout.write(buildTag);
+  '
+)"
+echo "==> Wrote development manifest (build: $BUILD_TAG, branch: $BRANCH)"
 
 # Reload by toggling disable -> enable, NOT `plugin:reload`. On this setup
 # `plugin:reload` returns success but does NOT re-run the plugin's onload, so the
@@ -141,6 +158,7 @@ echo
 echo "Done."
 echo "  worktree: $WORKTREE_ROOT"
 echo "  branch:   $BRANCH"
-echo "  build:    $BUILD_TS"
+echo "  build:    $BUILD_TAG"
+echo "  built:    $BUILD_TS"
 echo "  vault:    $VAULT_PATH"
 echo "  plugin:   $PLUGIN_ID"

--- a/scripts/test-vault.test.sh
+++ b/scripts/test-vault.test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+FIXTURE_ROOT="$TEST_ROOT/repo"
+VAULT_ROOT="$TEST_ROOT/vault"
+FAKE_BIN="$TEST_ROOT/bin"
+mkdir -p "$FIXTURE_ROOT/scripts" "$VAULT_ROOT/.obsidian" "$FAKE_BIN"
+cp "$REPO_ROOT/scripts/test-vault.sh" "$FIXTURE_ROOT/scripts/test-vault.sh"
+
+cat >"$FIXTURE_ROOT/manifest.json" <<'EOF'
+{
+  "id": "copilot",
+  "name": "Copilot",
+  "version": "4.0.0-preview-260629",
+  "description": "Test fixture"
+}
+EOF
+printf 'clean bundle\n' >"$FIXTURE_ROOT/main.js"
+printf 'clean styles\n' >"$FIXTURE_ROOT/styles.css"
+printf 'tracked\n' >"$FIXTURE_ROOT/source.txt"
+printf 'main.js\nstyles.css\n' >"$FIXTURE_ROOT/.gitignore"
+
+cat >"$FAKE_BIN/npm" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cp "$FAKE_BIN/npm" "$FAKE_BIN/obsidian"
+chmod +x "$FAKE_BIN/npm" "$FAKE_BIN/obsidian"
+
+git -C "$FIXTURE_ROOT" init -q
+git -C "$FIXTURE_ROOT" config user.email "test@example.com"
+git -C "$FIXTURE_ROOT" config user.name "Test"
+git -C "$FIXTURE_ROOT" config commit.gpgsign false
+git -C "$FIXTURE_ROOT" add .gitignore manifest.json scripts/test-vault.sh source.txt
+git -C "$FIXTURE_ROOT" commit -qm "fixture"
+
+run_deploy() {
+  PATH="$FAKE_BIN:$PATH" \
+    COPILOT_TEST_VAULT_PATH="$VAULT_ROOT" \
+    OBSIDIAN_BIN="$FAKE_BIN/obsidian" \
+    bash "$FIXTURE_ROOT/scripts/test-vault.sh" >/dev/null
+}
+
+assert_manifest() {
+  local state="$1"
+  ARTIFACT_DIR="$VAULT_ROOT/.obsidian/plugins/copilot" \
+    BUILD_COMMIT="$COMMIT" \
+    BUILD_STATE="$state" \
+    node -e '
+    const crypto = require("node:crypto");
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const hash = crypto.createHash("sha256");
+    for (const file of ["main.js", "styles.css"]) {
+      hash.update(file);
+      hash.update("\0");
+      hash.update(fs.readFileSync(path.join(process.env.ARTIFACT_DIR, file)));
+      hash.update("\0");
+    }
+    const bundleSha = hash.digest("hex").slice(0, 12);
+    const buildTag = [
+      process.env.BUILD_COMMIT,
+      process.env.BUILD_STATE,
+      bundleSha,
+    ].join("-");
+    const manifest = require(path.join(process.env.ARTIFACT_DIR, "manifest.json"));
+    const expectedVersion =
+      `4.0.0-preview-260629+dev.${process.env.BUILD_COMMIT}.${process.env.BUILD_STATE}.${bundleSha}`;
+    if (manifest.version !== expectedVersion) {
+      throw new Error(`expected ${expectedVersion}, received ${manifest.version}`);
+    }
+    if (manifest.name !== `Copilot [${buildTag}]`) {
+      throw new Error(`unexpected build name: ${manifest.name}`);
+    }
+    if (!manifest.description.includes(`dev build: ${buildTag}`)) {
+      throw new Error(`build tag missing from description: ${manifest.description}`);
+    }
+  '
+}
+
+COMMIT="$(git -C "$FIXTURE_ROOT" rev-parse --short=8 HEAD)"
+mkdir -p "$VAULT_ROOT/.obsidian/plugins/copilot"
+ln -s "$FIXTURE_ROOT/main.js" "$VAULT_ROOT/.obsidian/plugins/copilot/main.js"
+ln -s "$FIXTURE_ROOT/styles.css" "$VAULT_ROOT/.obsidian/plugins/copilot/styles.css"
+run_deploy
+assert_manifest clean
+
+for artifact in main.js styles.css; do
+  if [[ -L "$VAULT_ROOT/.obsidian/plugins/copilot/$artifact" ]]; then
+    echo "expected $artifact to be copied, not symlinked" >&2
+    exit 1
+  fi
+done
+DEPLOYED_MAIN="$VAULT_ROOT/.obsidian/plugins/copilot/main.js"
+printf 'changed after deployment\n' >"$FIXTURE_ROOT/main.js"
+if [[ "$(cat "$DEPLOYED_MAIN")" != "clean bundle" ]]; then
+  echo "deployed main.js changed when the worktree artifact changed" >&2
+  exit 1
+fi
+if [[ "$(node -p "require('$FIXTURE_ROOT/manifest.json').version")" != "4.0.0-preview-260629" ]]; then
+  echo "test-vault changed the source manifest version" >&2
+  exit 1
+fi
+
+printf 'dirty\n' >>"$FIXTURE_ROOT/source.txt"
+printf 'dirty bundle\n' >"$FIXTURE_ROOT/main.js"
+run_deploy
+assert_manifest dirty
+
+echo "test-vault deployment tests passed"


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#229

## Problem

`npm run test:vault` symlinked the built bundle into the vault but wrote the development manifest only once. A later local build could therefore change the loaded `main.js` while Obsidian still displayed an older release/version tag.

## Fix

- Copy the bundle into the test vault so a deployment stays immutable until the next explicit `test:vault` run. A symlink is intentionally live: after `test:vault` writes the manifest, any later `npm run build` overwrites the worktree artifacts and immediately changes the bundle seen by the vault while the deployed manifest remains unchanged. A copy makes the bundle and manifest one deployment snapshot, so their identity advances together only when `test:vault` runs.
- Give the deployed manifest a development-only SemVer suffix and visible tag containing the source commit, clean/dirty state, and a hash of the copied bundle.
- Exercise the real deployment script in a temporary fixture, including replacement of old symlinks and clean/dirty builds.
- Document the build tag and preflight check for development.

Keeping symlinks and teaching individual build commands to refresh the deployed manifest was rejected: builds have multiple entry points, and a build should not implicitly mutate a vault deployment. The copy model makes deployment explicit and keeps ordinary local builds isolated.

Release manifests and user-facing release metadata are unchanged.

The tracked issue lives in the preview repository and must be closed manually when this PR merges.

## Scope

4 files, +179/−39. Most additions are the end-to-end shell fixture that covers the deployment boundary; the production change removes the platform-specific symlink branches and adds only the identity generation needed by the workflow.

## Verification

- `bash -n scripts/test-vault.sh scripts/test-vault.test.sh`
- `npm run test:vault:script`
- `npm run format && npm run lint`
- `npm run test -- --runInBand --silent` — 333 suites and 4,764 tests passed
- `npm run build`
- `git diff --check FETCH_HEAD...HEAD`

🤖 Generated with [Codex](https://openai.com/codex/)
