### PR TITLE
fix(agent-mode): label Codex file edits by target

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -204,6 +204,8 @@ When the agent uses **Write to File** or **Replace in File**, it shows a preview
 - **Split view**: Before/after shown side by side
 - **Side-by-side view**: Changes highlighted inline
 
+In Agent Mode, the activity trail names the target of a single-file edit and shows a file count when one action changes multiple files.
+
 You can choose your preferred diff view in **Settings → Copilot → Plus → Diff View Mode**.
 
 Review the proposed change and click:

--- a/src/agentMode/ui/toolSummaries.test.ts
+++ b/src/agentMode/ui/toolSummaries.test.ts
@@ -138,7 +138,7 @@ describe("lookupToolSummary", () => {
   it("falls back to ACP toolKind when vendor is missing", () => {
     const t = tool({ toolKind: "edit", title: "wrote thing" });
     const s = lookupToolSummary(t);
-    expect(s.collapsedLine(t, CTX)).toMatch(/^Edited /);
+    expect(s.collapsedLine(t, CTX)).toBe("Edited files");
   });
 
   it("falls back to generic when both vendor and toolKind are unknown", () => {
@@ -313,6 +313,60 @@ describe("lookupToolSummary", () => {
     expect(lookupToolSummary(inflight).collapsedLine(inflight, CTX)).toBe("Editing draft.md");
     const done = tool({ ...inflight, status: "completed" });
     expect(lookupToolSummary(done).collapsedLine(done, CTX)).toBe("Edited draft.md");
+  });
+
+  it("uses a single Codex diff path as the edit target", () => {
+    const t = tool({
+      toolKind: "edit",
+      title: "Editing files",
+      output: [
+        {
+          type: "diff",
+          path: "/Users/me/vault/src/agentMode/ui/toolSummaries.ts",
+          oldText: "before",
+          newText: "after",
+        },
+      ],
+    });
+    const summary = lookupToolSummary(t);
+
+    expect(summary.collapsedLine(t, CTX)).toBe("Edited src/agentMode/ui/toolSummaries.ts");
+    expect(summary.targetPath?.(t, CTX)).toBe("src/agentMode/ui/toolSummaries.ts");
+
+    const outsideVault = {
+      ...t,
+      output: [{ ...t.output![0], path: "/Users/me/private/draft.md" }],
+    };
+    expect(summary.collapsedLine(outsideVault, CTX)).toBe("Edited …/draft.md");
+  });
+
+  it("counts unique Codex diff paths for multi-file edits", () => {
+    const inflight = tool({
+      toolKind: "edit",
+      title: "Editing files",
+      status: "in_progress",
+      output: [
+        { type: "diff", path: "src/a.ts", oldText: "a", newText: "A" },
+        { type: "diff", path: "src/a.ts", oldText: "A", newText: "AA" },
+        { type: "diff", path: "src/b.ts", oldText: null, newText: "B" },
+      ],
+    });
+    const summary = lookupToolSummary(inflight);
+
+    expect(summary.collapsedLine(inflight, CTX)).toBe("Editing 2 files");
+    const done = { ...inflight, status: "completed" as const };
+    expect(summary.collapsedLine(done, CTX)).toBe("Edited 2 files");
+    expect(summary.targetPath?.(done, CTX)).toBeNull();
+  });
+
+  it("preserves OpenCode filePath edit targets", () => {
+    const t = tool({
+      toolKind: "edit",
+      title: "draft.md",
+      input: { filePath: "/Users/me/vault/draft.md" },
+    });
+
+    expect(lookupToolSummary(t).collapsedLine(t, CTX)).toBe("Edited draft.md");
   });
 
   it("uses Fetching while WebFetch is in flight and Fetched when it completes", () => {

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -190,6 +190,14 @@ function verb(part: ToolCallPart, progressive: string, past: string): string {
   return part.status === "completed" || part.status === "failed" ? past : progressive;
 }
 
+function diffTargetPaths(part: ToolCallPart): string[] {
+  const paths = new Set<string>();
+  for (const output of part.output ?? []) {
+    if (output.type === "diff" && output.path.length > 0) paths.add(output.path);
+  }
+  return [...paths];
+}
+
 function targetFromPath(part: ToolCallPart, vaultBase: string | null): string | null {
   const loc = part.locations?.[0]?.path;
   if (typeof loc === "string" && loc.length > 0) return toVaultRelative(loc, vaultBase);
@@ -200,6 +208,8 @@ function targetFromPath(part: ToolCallPart, vaultBase: string | null): string | 
   if (typeof input?.file_path === "string") return toVaultRelative(input.file_path, vaultBase);
   if (typeof input?.filePath === "string") return toVaultRelative(input.filePath, vaultBase);
   if (typeof input?.path === "string") return toVaultRelative(input.path, vaultBase);
+  const diffPaths = diffTargetPaths(part);
+  if (diffPaths.length === 1) return toVaultRelative(diffPaths[0], vaultBase);
   return null;
 }
 
@@ -292,8 +302,14 @@ const LIST_SUMMARY: ToolSummary = {
 
 const EDIT_SUMMARY: ToolSummary = {
   icon: pickToolIcon({ vendorToolName: "Edit" }),
-  collapsedLine: (p, ctx) =>
-    `${verb(p, "Editing", "Edited")} ${displayTargetFromPath(p, ctx?.vaultBase ?? null) ?? targetFromTitle(p)}`,
+  collapsedLine: (p, ctx) => {
+    const diffPathCount = diffTargetPaths(p).length;
+    return `${verb(p, "Editing", "Edited")} ${
+      diffPathCount > 1
+        ? pluralize(diffPathCount, "file")
+        : (displayTargetFromPath(p, ctx?.vaultBase ?? null) ?? "files")
+    }`;
+  },
   outcome: (p) => {
     const { added, removed } = diffStats(p);
     if (added === 0 && removed === 0) return null;
@@ -312,7 +328,8 @@ const EDIT_SUMMARY: ToolSummary = {
       outcome: added + removed > 0 ? `+${added} / −${removed} lines` : "",
     };
   },
-  targetPath: (p, ctx) => targetFromPath(p, ctx?.vaultBase ?? null),
+  targetPath: (p, ctx) =>
+    diffTargetPaths(p).length > 1 ? null : targetFromPath(p, ctx?.vaultBase ?? null),
 };
 
 const BASH_SUMMARY: ToolSummary = {


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#230

> GitHub did not register the cross-repo closing reference; close preview issue #230 manually when this PR merges.

## Problem

Codex ACP emits edit tool calls titled `Editing files` with changed paths only in structured diff content. `EDIT_SUMMARY` treated that activity title as the target after adding its own status verb, so completed cards read `Edited Editing files` and repeated edits were indistinguishable.

## Fix

Use unique structured diff paths as the fallback source for edit targets. A single file follows the existing minimized, clickable path flow; multiple files show an accurate count without a misleading single-file link; and calls without a usable path fall back to `files` instead of the backend activity title. Existing OpenCode `filePath` and Claude `file_path` targets keep their current behavior.

## Scope

3 files, +77/−4. This is the smallest shape that fixes the mismatch: one diff-path extractor extends the existing target resolver, with focused backend and boundary coverage plus the corresponding user documentation.

## Changes

- Update `toolSummaries.ts` to derive single-file edit targets and multi-file counts from diff output.
- Cover Codex single/multi-file payloads, outside-vault path minimization, and OpenCode/Claude regressions.
- Document how Agent Mode labels single- and multi-file edit activity.

## Verification

- `npm test -- --runInBand src/agentMode/ui/toolSummaries.test.ts` — 47 tests passed.
- `npm test -- --runInBand` — 334 suites and 4,778 tests passed.
- `npm run format` — passed.
- `npm run lint` — passed.
- `npm run build` — passed.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)