### PR TITLE
feat(symposium): publish notes from Obsidian

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,7 +99,7 @@ Run **Publish file to Symposium** from the command palette, a Markdown note's Fi
 
 After publishing, Copilot stores the Symposium document ID in the note's `symposium` property. Run the same action again to update the existing page or withdraw its public link. Symposium deletes its stored copy, but it cannot recall copies that readers or caches already fetched. Withdrawing the page also removes the property from the note.
 
-If the page is published but its document ID cannot be saved, reopening the dialog resumes the local save without publishing again. If the initial publish response is lost, Copilot blocks another attempt until the plugin reloads to avoid creating a duplicate page.
+If Publish or Delete succeeds but the note's property cannot be updated, reopening the dialog resumes that local change without contacting Symposium again. If the initial publish response is lost, Copilot blocks another attempt until the plugin reloads to avoid creating a duplicate page.
 
 Copilot stops before publishing when a note's frontmatter is malformed or is not a YAML property map.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,6 +99,8 @@ Run **Publish file to Symposium** from the command palette, a Markdown note's Fi
 
 After publishing, Copilot stores the Symposium document ID in the note's `symposium` property. Run the same action again to update the existing page or withdraw its public link. Symposium deletes its stored copy, but it cannot recall copies that readers or caches already fetched. Withdrawing the page also removes the property from the note.
 
+If the page is published but its document ID cannot be saved, reopening the dialog resumes the local save without publishing again. If the initial publish response is lost, Copilot blocks another attempt until the plugin reloads to avoid creating a duplicate page.
+
 ---
 
 ## Keyboard Shortcuts

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,7 +97,7 @@ The AI will automatically include your currently open note as context, so you ca
 
 Run **Publish file to Symposium** from the command palette, a Markdown note's File explorer menu, its note menu, or the editor's **Copilot** submenu. Copilot asks for confirmation because anyone with the resulting link can read the published page.
 
-After publishing, Copilot stores the Symposium document ID in the note's `symposium` property. Run the same action again to update the existing page or permanently delete it. Deleting the page also removes the property from the note.
+After publishing, Copilot stores the Symposium document ID in the note's `symposium` property. Run the same action again to update the existing page or withdraw its public link. Symposium deletes its stored copy, but it cannot recall copies that readers or caches already fetched. Withdrawing the page also removes the property from the note.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,6 +9,7 @@ Copilot for Obsidian is an AI-powered plugin that brings large language models (
 - **Note editing**: Ask the AI to write or update your notes for you
 - **Semantic search**: Find notes by meaning, not just keywords
 - **Custom commands**: Run AI-powered prompts on selected text
+- **Public sharing**: Publish Markdown notes to Symposium with a shareable link
 - **Web search**: Fetch and summarize information from the internet
 - **Memory**: Have the AI remember facts about you across conversations
 
@@ -89,6 +90,14 @@ By default, Copilot opens as a **view** (sidebar panel). You can change this in 
 5. Continue the conversation naturally
 
 The AI will automatically include your currently open note as context, so you can say things like "summarize this note" or "what are the action items in this note?"
+
+---
+
+## Publish a Note to Symposium
+
+Run **Publish file to Symposium** from the command palette, a Markdown note's File explorer menu, its note menu, or the editor's **Copilot** submenu. Copilot asks for confirmation because anyone with the resulting link can read the published page.
+
+After publishing, Copilot stores the Symposium document ID in the note's `symposium` property. Run the same action again to update the existing page or permanently delete it. Deleting the page also removes the property from the note.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -101,6 +101,8 @@ After publishing, Copilot stores the Symposium document ID in the note's `sympos
 
 If the page is published but its document ID cannot be saved, reopening the dialog resumes the local save without publishing again. If the initial publish response is lost, Copilot blocks another attempt until the plugin reloads to avoid creating a duplicate page.
 
+Copilot stops before publishing when a note's frontmatter is malformed or is not a YAML property map.
+
 ---
 
 ## Keyboard Shortcuts

--- a/src/commands/contextMenu.test.ts
+++ b/src/commands/contextMenu.test.ts
@@ -1,0 +1,170 @@
+import { registerContextMenu, registerSymposiumFileMenu } from "@/commands/contextMenu";
+import { COMMAND_IDS, COMMAND_ICONS, COMMAND_NAMES } from "@/constants";
+import { TFile, TFolder, type App, type EventRef, type Menu } from "obsidian";
+
+jest.mock("@/commands/state", () => ({
+  getCachedCustomCommands: jest.fn(() => []),
+}));
+
+class TestMenuItem {
+  title = "";
+  icon = "";
+  submenu: TestMenu | null = null;
+  click: (() => void) | null = null;
+
+  setTitle(title: string): TestMenuItem {
+    this.title = title;
+    return this;
+  }
+
+  setIcon(icon: string): TestMenuItem {
+    this.icon = icon;
+    return this;
+  }
+
+  setSubmenu(): TestMenuItem {
+    this.submenu = new TestMenu();
+    return this;
+  }
+
+  onClick(callback: () => void): TestMenuItem {
+    this.click = callback;
+    return this;
+  }
+}
+
+class TestMenu {
+  readonly items: TestMenuItem[] = [];
+
+  addItem(configure: (item: TestMenuItem) => void): TestMenu {
+    const item = new TestMenuItem();
+    configure(item);
+    this.items.push(item);
+    return this;
+  }
+
+  addSeparator(): TestMenu {
+    return this;
+  }
+}
+
+function markdownFile(path: string): TFile {
+  const TFileConstructor = TFile as unknown as new (path: string) => TFile;
+  return new TFileConstructor(path);
+}
+
+function folder(path: string): TFolder {
+  const TFolderConstructor = TFolder as unknown as new (path: string) => TFolder;
+  return new TFolderConstructor(path);
+}
+
+function findItem(menu: TestMenu, title: string): TestMenuItem | undefined {
+  return menu.items.find((item) => item.title === title);
+}
+
+describe("contextMenu", () => {
+  describe("registerContextMenu()", () => {
+    it("publishes the active Markdown file directly from the editor Copilot submenu", () => {
+      const activeFile = markdownFile("Notes/Active.md");
+      const publish = jest.fn().mockResolvedValue(undefined);
+      const menu = new TestMenu();
+      const app = {
+        commands: { executeCommandById: jest.fn() },
+        workspace: { getActiveFile: jest.fn(() => activeFile) },
+      } as unknown as App;
+
+      registerContextMenu(menu as unknown as Menu, app, publish);
+
+      const copilotMenu = findItem(menu, "Copilot")?.submenu;
+      const publishItem = findItem(
+        copilotMenu!,
+        COMMAND_NAMES[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM]
+      );
+      expect(publishItem?.icon).toBe(COMMAND_ICONS[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM]);
+
+      publishItem?.click?.();
+
+      expect(publish).toHaveBeenCalledWith(activeFile);
+    });
+
+    it.each([
+      ["no active file", null],
+      ["a non-Markdown file", markdownFile("Notes/Diagram.canvas")],
+    ])("omits the editor action for %s", (_case, activeFile) => {
+      const menu = new TestMenu();
+      const app = {
+        commands: { executeCommandById: jest.fn() },
+        workspace: { getActiveFile: jest.fn(() => activeFile) },
+      } as unknown as App;
+
+      registerContextMenu(menu as unknown as Menu, app, jest.fn());
+
+      const copilotMenu = findItem(menu, "Copilot")?.submenu;
+      expect(
+        findItem(copilotMenu!, COMMAND_NAMES[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM])
+      ).toBeUndefined();
+    });
+  });
+
+  describe("registerSymposiumFileMenu()", () => {
+    it("registers one file-menu handler that publishes the exact clicked Markdown file", () => {
+      const activeFile = markdownFile("Notes/Active.md");
+      const clickedFile = markdownFile("Notes/Clicked.md");
+      const eventRef = {} as EventRef;
+      const publish = jest.fn().mockResolvedValue(undefined);
+      let fileMenuHandler: ((menu: Menu, file: TFile) => void) | undefined;
+      const on = jest.fn((eventName: string, handler: typeof fileMenuHandler) => {
+        expect(eventName).toBe("file-menu");
+        fileMenuHandler = handler;
+        return eventRef;
+      });
+      const registerEvent = jest.fn();
+      const host = {
+        app: {
+          workspace: {
+            getActiveFile: jest.fn(() => activeFile),
+            on,
+          },
+        } as unknown as App,
+        registerEvent,
+      };
+
+      registerSymposiumFileMenu(host, publish);
+
+      expect(on).toHaveBeenCalledTimes(1);
+      expect(registerEvent).toHaveBeenCalledWith(eventRef);
+
+      const menu = new TestMenu();
+      fileMenuHandler?.(menu as unknown as Menu, clickedFile);
+      const publishItem = findItem(menu, COMMAND_NAMES[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM]);
+      publishItem?.click?.();
+
+      expect(publish).toHaveBeenCalledWith(clickedFile);
+      expect(publish).not.toHaveBeenCalledWith(activeFile);
+    });
+
+    it.each([
+      ["a folder", folder("Notes")],
+      ["a non-Markdown file", markdownFile("Notes/Diagram.canvas")],
+    ])("omits the file-menu action for %s", (_case, file) => {
+      let fileMenuHandler: ((menu: Menu, file: TFile | TFolder) => void) | undefined;
+      const host = {
+        app: {
+          workspace: {
+            on: jest.fn((_eventName: string, handler: typeof fileMenuHandler) => {
+              fileMenuHandler = handler;
+              return {};
+            }),
+          },
+        } as unknown as App,
+        registerEvent: jest.fn(),
+      };
+      const menu = new TestMenu();
+
+      registerSymposiumFileMenu(host, jest.fn());
+      fileMenuHandler?.(menu as unknown as Menu, file);
+
+      expect(menu.items).toHaveLength(0);
+    });
+  });
+});

--- a/src/commands/contextMenu.test.ts
+++ b/src/commands/contextMenu.test.ts
@@ -64,8 +64,9 @@ function findItem(menu: TestMenu, title: string): TestMenuItem | undefined {
 
 describe("contextMenu", () => {
   describe("registerContextMenu()", () => {
-    it("publishes the active Markdown file directly from the editor Copilot submenu", () => {
+    it("publishes the editor event's Markdown file instead of the workspace active file", () => {
       const activeFile = markdownFile("Notes/Active.md");
+      const editorFile = markdownFile("Notes/Editor.md");
       const publish = jest.fn().mockResolvedValue(undefined);
       const menu = new TestMenu();
       const app = {
@@ -73,7 +74,7 @@ describe("contextMenu", () => {
         workspace: { getActiveFile: jest.fn(() => activeFile) },
       } as unknown as App;
 
-      registerContextMenu(menu as unknown as Menu, app, publish);
+      registerContextMenu(menu as unknown as Menu, app, editorFile, publish);
 
       const copilotMenu = findItem(menu, "Copilot")?.submenu;
       const publishItem = findItem(
@@ -84,7 +85,8 @@ describe("contextMenu", () => {
 
       publishItem?.click?.();
 
-      expect(publish).toHaveBeenCalledWith(activeFile);
+      expect(publish).toHaveBeenCalledWith(editorFile);
+      expect(publish).not.toHaveBeenCalledWith(activeFile);
     });
 
     it.each([
@@ -97,7 +99,7 @@ describe("contextMenu", () => {
         workspace: { getActiveFile: jest.fn(() => activeFile) },
       } as unknown as App;
 
-      registerContextMenu(menu as unknown as Menu, app, jest.fn());
+      registerContextMenu(menu as unknown as Menu, app, activeFile, jest.fn());
 
       const copilotMenu = findItem(menu, "Copilot")?.submenu;
       expect(

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -1,8 +1,10 @@
 import { getCommandId, sortCommandsByOrder } from "@/commands/customCommandUtils";
 import { getCachedCustomCommands } from "@/commands/state";
-import { COMMAND_IDS } from "@/constants";
-import type { App, Menu } from "obsidian";
+import { COMMAND_ICONS, COMMAND_IDS, COMMAND_NAMES } from "@/constants";
+import { TFile, type App, type EventRef, type Menu, type TAbstractFile } from "obsidian";
 import type { CustomCommand } from "./type";
+
+type PublishFile = (file: TFile) => void;
 
 interface CommandManager {
   executeCommandById: (commandId: string) => boolean;
@@ -19,12 +21,17 @@ function hasCommandManager(app: App): app is AppWithCommands {
   return typeof (app as Partial<AppWithCommands>).commands?.executeCommandById === "function";
 }
 
+function isMarkdownFile(file: TAbstractFile | null): file is TFile {
+  return file instanceof TFile && file.extension === "md";
+}
+
 /**
  * Registers the Copilot submenu entries in Obsidian's editor context menu.
  */
-export function registerContextMenu(menu: Menu, obsidianApp: App): void {
+export function registerContextMenu(menu: Menu, obsidianApp: App, publish: PublishFile): void {
   if (!hasCommandManager(obsidianApp)) return;
 
+  const activeFile = obsidianApp.workspace.getActiveFile();
   const execute = (commandId: string): void => {
     obsidianApp.commands.executeCommandById(commandId);
   };
@@ -56,6 +63,15 @@ export function registerContextMenu(menu: Menu, obsidianApp: App): void {
       });
     });
 
+    if (isMarkdownFile(activeFile)) {
+      submenu.addItem((subItem) => {
+        subItem
+          .setTitle(COMMAND_NAMES[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM])
+          .setIcon(COMMAND_ICONS[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM]!)
+          .onClick(() => publish(activeFile));
+      });
+    }
+
     // Get custom commands
     const commands = getCachedCustomCommands();
     const visibleCustomCommands = commands.filter(
@@ -76,4 +92,29 @@ export function registerContextMenu(menu: Menu, obsidianApp: App): void {
       });
     });
   });
+}
+
+interface SymposiumFileMenuHost {
+  app: App;
+  registerEvent(eventRef: EventRef): void;
+}
+
+/**
+ * Registers the shared explorer and note-menu action while preserving the exact clicked file.
+ */
+export function registerSymposiumFileMenu(host: SymposiumFileMenuHost, publish: PublishFile): void {
+  host.registerEvent(
+    host.app.workspace.on("file-menu", (menu, file) => {
+      if (!isMarkdownFile(file)) {
+        return;
+      }
+
+      menu.addItem((item) => {
+        item
+          .setTitle(COMMAND_NAMES[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM])
+          .setIcon(COMMAND_ICONS[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM]!)
+          .onClick(() => publish(file));
+      });
+    })
+  );
 }

--- a/src/commands/contextMenu.ts
+++ b/src/commands/contextMenu.ts
@@ -28,10 +28,14 @@ function isMarkdownFile(file: TAbstractFile | null): file is TFile {
 /**
  * Registers the Copilot submenu entries in Obsidian's editor context menu.
  */
-export function registerContextMenu(menu: Menu, obsidianApp: App, publish: PublishFile): void {
+export function registerContextMenu(
+  menu: Menu,
+  obsidianApp: App,
+  file: TFile | null,
+  publish: PublishFile
+): void {
   if (!hasCommandManager(obsidianApp)) return;
 
-  const activeFile = obsidianApp.workspace.getActiveFile();
   const execute = (commandId: string): void => {
     obsidianApp.commands.executeCommandById(commandId);
   };
@@ -63,12 +67,12 @@ export function registerContextMenu(menu: Menu, obsidianApp: App, publish: Publi
       });
     });
 
-    if (isMarkdownFile(activeFile)) {
+    if (isMarkdownFile(file)) {
       submenu.addItem((subItem) => {
         subItem
           .setTitle(COMMAND_NAMES[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM])
           .setIcon(COMMAND_ICONS[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM]!)
-          .onClick(() => publish(activeFile));
+          .onClick(() => publish(file));
       });
     }
 

--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -1,0 +1,70 @@
+import { registerCommands } from "@/commands";
+import { COMMAND_ICONS, COMMAND_IDS, COMMAND_NAMES } from "@/constants";
+import type CopilotPlugin from "@/main";
+import { TFile, type Command } from "obsidian";
+
+jest.mock("@/commands/CustomCommandChatModal", () => ({
+  CustomCommandChatModal: jest.fn(),
+}));
+jest.mock("@/utils/desktopRuntime", () => ({
+  isDesktopRuntime: jest.fn(() => false),
+}));
+
+function markdownFile(path: string): TFile {
+  const TFileConstructor = TFile as unknown as new (path: string) => TFile;
+  return new TFileConstructor(path);
+}
+
+describe("commands", () => {
+  describe("registerCommands()", () => {
+    it("registers the Symposium palette command and publishes the active Markdown file", () => {
+      const activeFile = markdownFile("Notes/Active.md");
+      const commands: Command[] = [];
+      const plugin = {
+        addCommand: jest.fn((command: Command) => commands.push(command)),
+        app: {
+          workspace: {
+            getActiveFile: jest.fn(() => activeFile),
+          },
+        },
+      } as unknown as CopilotPlugin;
+      const publish = jest.fn().mockResolvedValue(undefined);
+
+      registerCommands(plugin, publish);
+
+      const command = commands.find(({ id }) => id === COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM);
+      expect(command).toMatchObject({
+        name: COMMAND_NAMES[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM],
+        icon: COMMAND_ICONS[COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM],
+      });
+      expect(command?.checkCallback?.(true)).toBe(true);
+      expect(publish).not.toHaveBeenCalled();
+
+      expect(command?.checkCallback?.(false)).toBe(true);
+      expect(publish).toHaveBeenCalledWith(activeFile);
+    });
+
+    it.each([
+      ["no active file", null],
+      ["a non-Markdown active file", markdownFile("Notes/Diagram.canvas")],
+    ])("hides the Symposium palette command for %s", (_case, activeFile) => {
+      const commands: Command[] = [];
+      const plugin = {
+        addCommand: jest.fn((command: Command) => commands.push(command)),
+        app: {
+          workspace: {
+            getActiveFile: jest.fn(() => activeFile),
+          },
+        },
+      } as unknown as CopilotPlugin;
+      const publish = jest.fn().mockResolvedValue(undefined);
+
+      registerCommands(plugin, publish);
+
+      const command = commands.find(({ id }) => id === COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM);
+      expect(command?.checkCallback?.(true)).toBe(false);
+      expect(command?.checkCallback?.(false)).toBe(false);
+      expect(publish).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,7 +22,7 @@ import { ApplyCustomCommandModal } from "@/components/modals/ApplyCustomCommandM
 import { YoutubeTranscriptModal } from "@/components/modals/YoutubeTranscriptModal";
 import { checkIsPaidUser } from "@/plusUtils";
 // Debug modals removed with search v3
-import CopilotPlugin from "@/main";
+import type CopilotPlugin from "@/main";
 import { getSearchBackend } from "@/miyo/miyoUtils";
 import { getAllQAMarkdownContent } from "@/search/searchUtils";
 import { NoteSelectedTextContext, WebSelectedTextContext } from "@/types/message";
@@ -32,6 +32,8 @@ import { Editor, MarkdownView, Notice, TFile } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import { COMMAND_IDS, COMMAND_ICONS, COMMAND_NAMES, CommandId } from "@/constants";
 import { setSelectedTextContexts } from "@/aiParams";
+
+type PublishFile = (file: TFile) => void;
 
 /**
  * Add a command to the plugin. Supports async callbacks; errors are logged.
@@ -87,7 +89,19 @@ function addCheckCommand(
   });
 }
 
-export function registerCommands(plugin: CopilotPlugin) {
+export function registerCommands(plugin: CopilotPlugin, publish: PublishFile) {
+  addCheckCommand(plugin, COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM, (checking) => {
+    const activeFile = plugin.app.workspace.getActiveFile();
+    if (!(activeFile instanceof TFile) || activeFile.extension !== "md") {
+      return false;
+    }
+
+    if (!checking) {
+      publish(activeFile);
+    }
+    return true;
+  });
+
   addEditorCommand(plugin, COMMAND_IDS.COUNT_WORD_AND_TOKENS_SELECTION, async (editor: Editor) => {
     const selectedText = editor.getSelection();
     const wordCount = selectedText.split(" ").length;

--- a/src/components/modals/SymposiumModal.test.tsx
+++ b/src/components/modals/SymposiumModal.test.tsx
@@ -226,6 +226,25 @@ describe("SymposiumModal", () => {
         expect(await screen.findByText("Publish complete")).toBeTruthy();
       });
 
+      it("shows an update receipt as partial success when the note identity is not verified", async () => {
+        const onConfirm = createConfirmMock().mockResolvedValue({
+          kind: "persistence",
+          action: "update",
+          message: "The original page was updated, but this note's identity changed.",
+          receipt: RECEIPT,
+        });
+        renderModal(onConfirm, DOC_ID);
+
+        await clickButton("Yes, update");
+
+        expect(await screen.findByText("Page updated; note identity not verified")).toBeTruthy();
+        expect(
+          screen.getByText("The original page was updated, but this note's identity changed.")
+        ).toBeTruthy();
+        expect(screen.getByText(RECEIPT.url)).toBeTruthy();
+        expect(screen.queryByRole("button", { name: "Retry save" })).toBeNull();
+      });
+
       it("copies and opens the API-returned URL from the success view", async () => {
         const writeText = jest.fn().mockResolvedValue(undefined);
         Object.defineProperty(window.navigator, "clipboard", {

--- a/src/components/modals/SymposiumModal.test.tsx
+++ b/src/components/modals/SymposiumModal.test.tsx
@@ -319,6 +319,10 @@ describe("SymposiumModal", () => {
         fireEvent.click(screen.getByRole("button", { name: "Update" }));
         await clickButton("Yes, update");
         expectButtonsInSameRow("Close", "Copy", "Open");
+        const link = screen.getByRole("link", { name: RECEIPT.url });
+        expect(link.getAttribute("href")).toBe(RECEIPT.url);
+        expect(link.getAttribute("target")).toBe("_blank");
+        expect(link.getAttribute("rel")).toBe("noopener noreferrer");
         await clickButton("Copy");
         fireEvent.click(screen.getByRole("button", { name: "Open" }));
 

--- a/src/components/modals/SymposiumModal.test.tsx
+++ b/src/components/modals/SymposiumModal.test.tsx
@@ -11,6 +11,7 @@ jest.mock("obsidian", () => ({
     app: unknown;
     baseClose = jest.fn();
     contentEl = activeDocument.createElement("div");
+    modalEl = activeDocument.createElement("div");
     titleEl = activeDocument.createElement("div");
 
     constructor(app: unknown) {
@@ -95,7 +96,7 @@ describe("SymposiumModal", () => {
 
   describe("SymposiumModal", () => {
     describe("onOpen()", () => {
-      it("shows a compact publish confirmation with the note name and warning", async () => {
+      it("shows a compact explicit publish confirmation with the note name and warning", async () => {
         const onConfirm = createConfirmMock().mockResolvedValue({
           kind: "success",
           action: "publish",
@@ -109,12 +110,15 @@ describe("SymposiumModal", () => {
         expect(screen.queryByText(/theme/i)).toBeNull();
         expect(screen.queryByText(/preview/i)).toBeNull();
 
-        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        expect(modal.modalEl.classList.contains("copilot-symposium-modal")).toBe(true);
+        expectButtonsInSameRow("No, cancel", "Yes, publish");
+
+        fireEvent.click(screen.getByRole("button", { name: "No, cancel" }));
         expect(baseClose).toHaveBeenCalledTimes(1);
         expect(onConfirm).not.toHaveBeenCalled();
 
         const publishModal = renderModal(onConfirm);
-        await clickButton("Publish");
+        await clickButton("Yes, publish");
         expect(onConfirm).toHaveBeenCalledWith("publish", activeDocument);
         expect(publishModal.contentEl.childElementCount).toBeGreaterThan(0);
       });
@@ -131,7 +135,7 @@ describe("SymposiumModal", () => {
         const modal = renderModal(onConfirm, null, onClosed);
         const baseClose = (modal as unknown as { baseClose: jest.Mock }).baseClose;
 
-        fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+        fireEvent.click(screen.getByRole("button", { name: "Yes, publish" }));
         expect(screen.getByRole("button", { name: "Publishing…" })).toBeTruthy();
 
         act(() => {
@@ -153,7 +157,7 @@ describe("SymposiumModal", () => {
         expect(baseClose).toHaveBeenCalledTimes(1);
       });
 
-      it("offers update and delete as direct confirmed actions for a published note", async () => {
+      it("replaces the manage actions with delete confirmation before deleting", async () => {
         const onConfirm = createConfirmMock().mockResolvedValue({
           kind: "success",
           action: "delete",
@@ -162,11 +166,18 @@ describe("SymposiumModal", () => {
 
         expect(screen.getByText("Manage “Architecture”")).toBeTruthy();
         expectButtonsInSameRow("Cancel", "Update", "Delete");
+
+        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+        expect(screen.getByText("Delete “Architecture”?")).toBeTruthy();
         expect(
           screen.getByText(/previously fetched or cached copies cannot be recalled/i)
         ).toBeTruthy();
+        expectButtonsInSameRow("No, cancel", "Yes, delete");
+        expect(screen.queryByRole("button", { name: "Update" })).toBeNull();
+        expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+        expect(onConfirm).not.toHaveBeenCalled();
 
-        await clickButton("Delete");
+        await clickButton("Yes, delete");
         expect(onConfirm).toHaveBeenCalledWith("delete", activeDocument);
         expect(await screen.findByText("Removed from Symposium")).toBeTruthy();
       });
@@ -181,7 +192,7 @@ describe("SymposiumModal", () => {
         });
         renderModal(onConfirm);
 
-        await clickButton("Publish");
+        await clickButton("Yes, publish");
 
         expect(await screen.findByText("Symposium access required")).toBeTruthy();
         expect(
@@ -206,7 +217,7 @@ describe("SymposiumModal", () => {
           });
         renderModal(onConfirm);
 
-        await clickButton("Publish");
+        await clickButton("Yes, publish");
         expect(await screen.findByText("Publish failed")).toBeTruthy();
 
         await clickButton("Retry");
@@ -230,7 +241,7 @@ describe("SymposiumModal", () => {
         });
         renderModal(onConfirm);
 
-        await clickButton("Publish");
+        await clickButton("Yes, publish");
         expect(await screen.findByText("Published, but not saved to the note")).toBeTruthy();
         expect(screen.getByText(RECEIPT.url)).toBeTruthy();
         expectButtonsInSameRow("Close", "Retry save", "Copy", "Open");
@@ -275,7 +286,13 @@ describe("SymposiumModal", () => {
         });
         renderModal(onConfirm, DOC_ID);
 
-        await clickButton("Update");
+        fireEvent.click(screen.getByRole("button", { name: "Update" }));
+        expect(screen.getByText("Update “Architecture”?")).toBeTruthy();
+        expectButtonsInSameRow("No, cancel", "Yes, update");
+        expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+        expect(onConfirm).not.toHaveBeenCalled();
+
+        await clickButton("Yes, update");
 
         expect(await screen.findByText("Page updated; note identity not verified")).toBeTruthy();
         expect(
@@ -299,7 +316,8 @@ describe("SymposiumModal", () => {
         });
         renderModal(onConfirm, DOC_ID);
 
-        await clickButton("Update");
+        fireEvent.click(screen.getByRole("button", { name: "Update" }));
+        await clickButton("Yes, update");
         expectButtonsInSameRow("Close", "Copy", "Open");
         await clickButton("Copy");
         fireEvent.click(screen.getByRole("button", { name: "Open" }));

--- a/src/components/modals/SymposiumModal.test.tsx
+++ b/src/components/modals/SymposiumModal.test.tsx
@@ -110,7 +110,7 @@ describe("SymposiumModal", () => {
         expect(publishModal.contentEl.childElementCount).toBeGreaterThan(0);
       });
 
-      it("blocks native close while a confirmed action is pending", async () => {
+      it("allows native close while a confirmed action is pending", async () => {
         let resolveConfirm: ((result: SymposiumModalResult) => void) | undefined;
         const onConfirm = createConfirmMock().mockImplementation(
           () =>
@@ -118,23 +118,27 @@ describe("SymposiumModal", () => {
               resolveConfirm = resolve;
             })
         );
-        const modal = renderModal(onConfirm);
+        const onClosed = jest.fn();
+        const modal = renderModal(onConfirm, null, onClosed);
         const baseClose = (modal as unknown as { baseClose: jest.Mock }).baseClose;
 
         fireEvent.click(screen.getByRole("button", { name: "Yes, publish" }));
-        modal.close();
-
-        expect(baseClose).not.toHaveBeenCalled();
         expect(screen.getByRole("button", { name: "Working…" })).toBeTruthy();
 
-        resolveConfirm?.({
-          kind: "success",
-          action: "publish",
-          receipt: RECEIPT,
-        });
-        await screen.findByText("Publish complete");
         act(() => {
           modal.close();
+        });
+
+        expect(baseClose).toHaveBeenCalledTimes(1);
+        expect(modal.contentEl.childElementCount).toBe(0);
+        expect(onClosed).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+          resolveConfirm?.({
+            kind: "success",
+            action: "publish",
+            receipt: RECEIPT,
+          });
         });
 
         expect(baseClose).toHaveBeenCalledTimes(1);
@@ -306,40 +310,6 @@ describe("SymposiumModal", () => {
         });
 
         expect(modal.contentEl.childElementCount).toBe(0);
-      });
-    });
-
-    describe("dispose()", () => {
-      it("force-closes and unmounts while a confirmed action is pending", async () => {
-        let resolveConfirm: ((result: SymposiumModalResult) => void) | undefined;
-        const onConfirm = createConfirmMock().mockImplementation(
-          () =>
-            new Promise((resolve) => {
-              resolveConfirm = resolve;
-            })
-        );
-        const onClosed = jest.fn();
-        const modal = renderModal(onConfirm, null, onClosed);
-        const baseClose = (modal as unknown as { baseClose: jest.Mock }).baseClose;
-
-        fireEvent.click(screen.getByRole("button", { name: "Yes, publish" }));
-        expect(screen.getByRole("button", { name: "Working…" })).toBeTruthy();
-
-        act(() => {
-          modal.dispose();
-        });
-
-        expect(baseClose).toHaveBeenCalledTimes(1);
-        expect(modal.contentEl.childElementCount).toBe(0);
-        expect(onClosed).toHaveBeenCalledTimes(1);
-
-        await act(async () => {
-          resolveConfirm?.({
-            kind: "success",
-            action: "publish",
-            receipt: RECEIPT,
-          });
-        });
       });
     });
   });

--- a/src/components/modals/SymposiumModal.test.tsx
+++ b/src/components/modals/SymposiumModal.test.tsx
@@ -25,6 +25,7 @@ jest.mock("obsidian", () => ({
 
     close(): void {
       this.baseClose();
+      (this as unknown as { onClose?: () => void }).onClose?.();
     }
   },
 }));
@@ -47,12 +48,14 @@ function createConfirmMock(): jest.MockedFunction<SymposiumModalOptions["onConfi
 
 function renderModal(
   onConfirm: jest.MockedFunction<SymposiumModalOptions["onConfirm"]>,
-  docId: string | null = null
+  docId: string | null = null,
+  onClosed?: () => void
 ): SymposiumModal {
   const modal = new SymposiumModal({} as App, {
     fileName: "Architecture",
     docId,
     onConfirm,
+    onClosed,
   });
   activeDocument.body.appendChild(modal.contentEl);
   act(() => {
@@ -99,8 +102,10 @@ describe("SymposiumModal", () => {
         expect(baseClose).toHaveBeenCalledTimes(1);
         expect(onConfirm).not.toHaveBeenCalled();
 
+        const publishModal = renderModal(onConfirm);
         await clickButton("Yes, publish");
         expect(onConfirm).toHaveBeenCalledWith("publish", activeDocument);
+        expect(publishModal.contentEl.childElementCount).toBeGreaterThan(0);
       });
 
       it("blocks native close while a confirmed action is pending", async () => {
@@ -126,7 +131,9 @@ describe("SymposiumModal", () => {
           receipt: RECEIPT,
         });
         await screen.findByText("Publish complete");
-        modal.close();
+        act(() => {
+          modal.close();
+        });
 
         expect(baseClose).toHaveBeenCalledTimes(1);
       });
@@ -253,6 +260,40 @@ describe("SymposiumModal", () => {
         });
 
         expect(modal.contentEl.childElementCount).toBe(0);
+      });
+    });
+
+    describe("dispose()", () => {
+      it("force-closes and unmounts while a confirmed action is pending", async () => {
+        let resolveConfirm: ((result: SymposiumModalResult) => void) | undefined;
+        const onConfirm = createConfirmMock().mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              resolveConfirm = resolve;
+            })
+        );
+        const onClosed = jest.fn();
+        const modal = renderModal(onConfirm, null, onClosed);
+        const baseClose = (modal as unknown as { baseClose: jest.Mock }).baseClose;
+
+        fireEvent.click(screen.getByRole("button", { name: "Yes, publish" }));
+        expect(screen.getByRole("button", { name: "Working…" })).toBeTruthy();
+
+        act(() => {
+          modal.dispose();
+        });
+
+        expect(baseClose).toHaveBeenCalledTimes(1);
+        expect(modal.contentEl.childElementCount).toBe(0);
+        expect(onClosed).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+          resolveConfirm?.({
+            kind: "success",
+            action: "publish",
+            receipt: RECEIPT,
+          });
+        });
       });
     });
   });

--- a/src/components/modals/SymposiumModal.test.tsx
+++ b/src/components/modals/SymposiumModal.test.tsx
@@ -49,11 +49,13 @@ function createConfirmMock(): jest.MockedFunction<SymposiumModalOptions["onConfi
 function renderModal(
   onConfirm: jest.MockedFunction<SymposiumModalOptions["onConfirm"]>,
   docId: string | null = null,
-  onClosed?: () => void
+  onClosed?: () => void,
+  initialResult?: SymposiumModalResult
 ): SymposiumModal {
   const modal = new SymposiumModal({} as App, {
     fileName: "Architecture",
     docId,
+    initialResult,
     onConfirm,
     onClosed,
   });
@@ -223,6 +225,31 @@ describe("SymposiumModal", () => {
         await clickButton("Retry save");
         expect(retrySave).toHaveBeenCalledTimes(1);
         expect(onConfirm).toHaveBeenCalledTimes(1);
+        expect(await screen.findByText("Publish complete")).toBeTruthy();
+      });
+
+      it("resumes an initial partial-success save without confirming another publish", async () => {
+        const retrySave = jest.fn().mockResolvedValue({
+          kind: "success",
+          action: "publish",
+          receipt: RECEIPT,
+        });
+        const onConfirm = createConfirmMock();
+        renderModal(onConfirm, null, undefined, {
+          kind: "persistence",
+          action: "publish",
+          message: "The page is already public. Retry saving its document id.",
+          receipt: RECEIPT,
+          retrySave,
+        });
+
+        expect(screen.getByText("Published, but not saved to the note")).toBeTruthy();
+        expect(screen.getByText(RECEIPT.url)).toBeTruthy();
+
+        await clickButton("Retry save");
+
+        expect(retrySave).toHaveBeenCalledTimes(1);
+        expect(onConfirm).not.toHaveBeenCalled();
         expect(await screen.findByText("Publish complete")).toBeTruthy();
       });
 

--- a/src/components/modals/SymposiumModal.test.tsx
+++ b/src/components/modals/SymposiumModal.test.tsx
@@ -73,6 +73,15 @@ async function clickButton(name: string | RegExp): Promise<void> {
   });
 }
 
+function expectButtonsInSameRow(...names: string[]): void {
+  const buttons = names.map((name) => screen.getByRole("button", { name }));
+  const row = buttons[0].parentElement;
+  expect(row).not.toBeNull();
+  for (const button of buttons) {
+    expect(button.parentElement).toBe(row);
+  }
+}
+
 describe("SymposiumModal", () => {
   afterEach(() => {
     for (const modal of mountedModals.splice(0)) {
@@ -86,7 +95,7 @@ describe("SymposiumModal", () => {
 
   describe("SymposiumModal", () => {
     describe("onOpen()", () => {
-      it("shows a compact explicit yes/no publish confirmation with the note name and warning", async () => {
+      it("shows a compact publish confirmation with the note name and warning", async () => {
         const onConfirm = createConfirmMock().mockResolvedValue({
           kind: "success",
           action: "publish",
@@ -100,12 +109,12 @@ describe("SymposiumModal", () => {
         expect(screen.queryByText(/theme/i)).toBeNull();
         expect(screen.queryByText(/preview/i)).toBeNull();
 
-        fireEvent.click(screen.getByRole("button", { name: "No, cancel" }));
+        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
         expect(baseClose).toHaveBeenCalledTimes(1);
         expect(onConfirm).not.toHaveBeenCalled();
 
         const publishModal = renderModal(onConfirm);
-        await clickButton("Yes, publish");
+        await clickButton("Publish");
         expect(onConfirm).toHaveBeenCalledWith("publish", activeDocument);
         expect(publishModal.contentEl.childElementCount).toBeGreaterThan(0);
       });
@@ -122,8 +131,8 @@ describe("SymposiumModal", () => {
         const modal = renderModal(onConfirm, null, onClosed);
         const baseClose = (modal as unknown as { baseClose: jest.Mock }).baseClose;
 
-        fireEvent.click(screen.getByRole("button", { name: "Yes, publish" }));
-        expect(screen.getByRole("button", { name: "Working…" })).toBeTruthy();
+        fireEvent.click(screen.getByRole("button", { name: "Publish" }));
+        expect(screen.getByRole("button", { name: "Publishing…" })).toBeTruthy();
 
         act(() => {
           modal.close();
@@ -144,21 +153,20 @@ describe("SymposiumModal", () => {
         expect(baseClose).toHaveBeenCalledTimes(1);
       });
 
-      it("lets a published note explicitly confirm update or delete", async () => {
+      it("offers update and delete as direct confirmed actions for a published note", async () => {
         const onConfirm = createConfirmMock().mockResolvedValue({
           kind: "success",
           action: "delete",
         });
         renderModal(onConfirm, DOC_ID);
 
-        expect(screen.getByText("Update “Architecture”?")).toBeTruthy();
-        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
-        expect(screen.getByText("Delete “Architecture”?")).toBeTruthy();
+        expect(screen.getByText("Manage “Architecture”")).toBeTruthy();
+        expectButtonsInSameRow("Cancel", "Update", "Delete");
         expect(
           screen.getByText(/previously fetched or cached copies cannot be recalled/i)
         ).toBeTruthy();
 
-        await clickButton("Yes, delete");
+        await clickButton("Delete");
         expect(onConfirm).toHaveBeenCalledWith("delete", activeDocument);
         expect(await screen.findByText("Removed from Symposium")).toBeTruthy();
       });
@@ -173,7 +181,7 @@ describe("SymposiumModal", () => {
         });
         renderModal(onConfirm);
 
-        await clickButton("Yes, publish");
+        await clickButton("Publish");
 
         expect(await screen.findByText("Symposium access required")).toBeTruthy();
         expect(
@@ -198,7 +206,7 @@ describe("SymposiumModal", () => {
           });
         renderModal(onConfirm);
 
-        await clickButton("Yes, publish");
+        await clickButton("Publish");
         expect(await screen.findByText("Publish failed")).toBeTruthy();
 
         await clickButton("Retry");
@@ -222,9 +230,10 @@ describe("SymposiumModal", () => {
         });
         renderModal(onConfirm);
 
-        await clickButton("Yes, publish");
+        await clickButton("Publish");
         expect(await screen.findByText("Published, but not saved to the note")).toBeTruthy();
         expect(screen.getByText(RECEIPT.url)).toBeTruthy();
+        expectButtonsInSameRow("Close", "Retry save", "Copy", "Open");
 
         await clickButton("Retry save");
         expect(retrySave).toHaveBeenCalledTimes(1);
@@ -266,7 +275,7 @@ describe("SymposiumModal", () => {
         });
         renderModal(onConfirm, DOC_ID);
 
-        await clickButton("Yes, update");
+        await clickButton("Update");
 
         expect(await screen.findByText("Page updated; note identity not verified")).toBeTruthy();
         expect(
@@ -290,7 +299,8 @@ describe("SymposiumModal", () => {
         });
         renderModal(onConfirm, DOC_ID);
 
-        await clickButton("Yes, update");
+        await clickButton("Update");
+        expectButtonsInSameRow("Close", "Copy", "Open");
         await clickButton("Copy");
         fireEvent.click(screen.getByRole("button", { name: "Open" }));
 

--- a/src/components/modals/SymposiumModal.test.tsx
+++ b/src/components/modals/SymposiumModal.test.tsx
@@ -1,4 +1,7 @@
-import type { SymposiumModalOptions } from "@/components/modals/SymposiumModal";
+import type {
+  SymposiumModalOptions,
+  SymposiumModalResult,
+} from "@/components/modals/SymposiumModal";
 import type { SymposiumReceipt } from "@/symposium/types";
 import { act, fireEvent, screen } from "@testing-library/react";
 
@@ -6,7 +9,7 @@ jest.mock("obsidian", () => ({
   App: class App {},
   Modal: class Modal {
     app: unknown;
-    close = jest.fn();
+    baseClose = jest.fn();
     contentEl = activeDocument.createElement("div");
     titleEl = activeDocument.createElement("div");
 
@@ -18,6 +21,10 @@ jest.mock("obsidian", () => ({
       this.titleEl.setText = (text: string) => {
         this.titleEl.textContent = text;
       };
+    }
+
+    close(): void {
+      this.baseClose();
     }
   },
 }));
@@ -81,6 +88,7 @@ describe("SymposiumModal", () => {
           receipt: RECEIPT,
         });
         const modal = renderModal(onConfirm);
+        const baseClose = (modal as unknown as { baseClose: jest.Mock }).baseClose;
 
         expect(screen.getByText("Publish “Architecture”?")).toBeTruthy();
         expect(screen.getByText(/anyone with the public link/i)).toBeTruthy();
@@ -88,11 +96,39 @@ describe("SymposiumModal", () => {
         expect(screen.queryByText(/preview/i)).toBeNull();
 
         fireEvent.click(screen.getByRole("button", { name: "No, cancel" }));
-        expect(modal.close).toHaveBeenCalledTimes(1);
+        expect(baseClose).toHaveBeenCalledTimes(1);
         expect(onConfirm).not.toHaveBeenCalled();
 
         await clickButton("Yes, publish");
         expect(onConfirm).toHaveBeenCalledWith("publish", activeDocument);
+      });
+
+      it("blocks native close while a confirmed action is pending", async () => {
+        let resolveConfirm: ((result: SymposiumModalResult) => void) | undefined;
+        const onConfirm = createConfirmMock().mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              resolveConfirm = resolve;
+            })
+        );
+        const modal = renderModal(onConfirm);
+        const baseClose = (modal as unknown as { baseClose: jest.Mock }).baseClose;
+
+        fireEvent.click(screen.getByRole("button", { name: "Yes, publish" }));
+        modal.close();
+
+        expect(baseClose).not.toHaveBeenCalled();
+        expect(screen.getByRole("button", { name: "Working…" })).toBeTruthy();
+
+        resolveConfirm?.({
+          kind: "success",
+          action: "publish",
+          receipt: RECEIPT,
+        });
+        await screen.findByText("Publish complete");
+        modal.close();
+
+        expect(baseClose).toHaveBeenCalledTimes(1);
       });
 
       it("lets a published note explicitly confirm update or delete", async () => {
@@ -105,7 +141,9 @@ describe("SymposiumModal", () => {
         expect(screen.getByText("Update “Architecture”?")).toBeTruthy();
         fireEvent.click(screen.getByRole("button", { name: "Delete" }));
         expect(screen.getByText("Delete “Architecture”?")).toBeTruthy();
-        expect(screen.getByText(/permanently removes every public version/i)).toBeTruthy();
+        expect(
+          screen.getByText(/previously fetched or cached copies cannot be recalled/i)
+        ).toBeTruthy();
 
         await clickButton("Yes, delete");
         expect(onConfirm).toHaveBeenCalledWith("delete", activeDocument);

--- a/src/components/modals/SymposiumModal.test.tsx
+++ b/src/components/modals/SymposiumModal.test.tsx
@@ -1,0 +1,221 @@
+import type { SymposiumModalOptions } from "@/components/modals/SymposiumModal";
+import type { SymposiumReceipt } from "@/symposium/types";
+import { act, fireEvent, screen } from "@testing-library/react";
+
+jest.mock("obsidian", () => ({
+  App: class App {},
+  Modal: class Modal {
+    app: unknown;
+    close = jest.fn();
+    contentEl = activeDocument.createElement("div");
+    titleEl = activeDocument.createElement("div");
+
+    constructor(app: unknown) {
+      this.app = app;
+      this.contentEl.empty = () => {
+        this.contentEl.replaceChildren();
+      };
+      this.titleEl.setText = (text: string) => {
+        this.titleEl.textContent = text;
+      };
+    }
+  },
+}));
+
+import { SymposiumModal } from "@/components/modals/SymposiumModal";
+import type { App } from "obsidian";
+
+const DOC_ID = "9f2k4mvq7t0xbz3n";
+const RECEIPT: SymposiumReceipt = {
+  docId: DOC_ID,
+  url: `https://symposium.md/d/${DOC_ID}?server=exact`,
+  version: 2,
+};
+
+const mountedModals: SymposiumModal[] = [];
+
+function createConfirmMock(): jest.MockedFunction<SymposiumModalOptions["onConfirm"]> {
+  return jest.fn();
+}
+
+function renderModal(
+  onConfirm: jest.MockedFunction<SymposiumModalOptions["onConfirm"]>,
+  docId: string | null = null
+): SymposiumModal {
+  const modal = new SymposiumModal({} as App, {
+    fileName: "Architecture",
+    docId,
+    onConfirm,
+  });
+  activeDocument.body.appendChild(modal.contentEl);
+  act(() => {
+    modal.onOpen();
+  });
+  mountedModals.push(modal);
+  return modal;
+}
+
+async function clickButton(name: string | RegExp): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name }));
+  });
+}
+
+describe("SymposiumModal", () => {
+  afterEach(() => {
+    for (const modal of mountedModals.splice(0)) {
+      act(() => {
+        modal.onClose();
+      });
+    }
+    activeDocument.body.innerHTML = "";
+    jest.restoreAllMocks();
+  });
+
+  describe("SymposiumModal", () => {
+    describe("onOpen()", () => {
+      it("shows a compact explicit yes/no publish confirmation with the note name and warning", async () => {
+        const onConfirm = createConfirmMock().mockResolvedValue({
+          kind: "success",
+          action: "publish",
+          receipt: RECEIPT,
+        });
+        const modal = renderModal(onConfirm);
+
+        expect(screen.getByText("Publish “Architecture”?")).toBeTruthy();
+        expect(screen.getByText(/anyone with the public link/i)).toBeTruthy();
+        expect(screen.queryByText(/theme/i)).toBeNull();
+        expect(screen.queryByText(/preview/i)).toBeNull();
+
+        fireEvent.click(screen.getByRole("button", { name: "No, cancel" }));
+        expect(modal.close).toHaveBeenCalledTimes(1);
+        expect(onConfirm).not.toHaveBeenCalled();
+
+        await clickButton("Yes, publish");
+        expect(onConfirm).toHaveBeenCalledWith("publish", activeDocument);
+      });
+
+      it("lets a published note explicitly confirm update or delete", async () => {
+        const onConfirm = createConfirmMock().mockResolvedValue({
+          kind: "success",
+          action: "delete",
+        });
+        renderModal(onConfirm, DOC_ID);
+
+        expect(screen.getByText("Update “Architecture”?")).toBeTruthy();
+        fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+        expect(screen.getByText("Delete “Architecture”?")).toBeTruthy();
+        expect(screen.getByText(/permanently removes every public version/i)).toBeTruthy();
+
+        await clickButton("Yes, delete");
+        expect(onConfirm).toHaveBeenCalledWith("delete", activeDocument);
+        expect(await screen.findByText("Removed from Symposium")).toBeTruthy();
+      });
+
+      it("shows the server's unauthorized message as a non-retryable access notice", async () => {
+        const onConfirm = createConfirmMock().mockResolvedValue({
+          kind: "failure",
+          action: "publish",
+          message: "Publishing is currently limited to lifetime license holders.",
+          accessNotice: true,
+          retryable: false,
+        });
+        renderModal(onConfirm);
+
+        await clickButton("Yes, publish");
+
+        expect(await screen.findByText("Symposium access required")).toBeTruthy();
+        expect(
+          screen.getByText("Publishing is currently limited to lifetime license holders.")
+        ).toBeTruthy();
+        expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+      });
+
+      it("offers retry for an internal failure and then shows the returned receipt", async () => {
+        const onConfirm = createConfirmMock()
+          .mockResolvedValueOnce({
+            kind: "failure",
+            action: "publish",
+            message: "License validation is temporarily unavailable.",
+            accessNotice: false,
+            retryable: true,
+          })
+          .mockResolvedValueOnce({
+            kind: "success",
+            action: "publish",
+            receipt: RECEIPT,
+          });
+        renderModal(onConfirm);
+
+        await clickButton("Yes, publish");
+        expect(await screen.findByText("Publish failed")).toBeTruthy();
+
+        await clickButton("Retry");
+        expect(await screen.findByText(RECEIPT.url)).toBeTruthy();
+        expect(screen.getByText(`Document ${DOC_ID} · Version 2`)).toBeTruthy();
+        expect(onConfirm).toHaveBeenCalledTimes(2);
+      });
+
+      it("retries a partial-success save without repeating the confirmed network action", async () => {
+        const retrySave = jest.fn().mockResolvedValue({
+          kind: "success",
+          action: "publish",
+          receipt: RECEIPT,
+        });
+        const onConfirm = createConfirmMock().mockResolvedValue({
+          kind: "persistence",
+          action: "publish",
+          message: "The page is already public. Retry saving its document id.",
+          receipt: RECEIPT,
+          retrySave,
+        });
+        renderModal(onConfirm);
+
+        await clickButton("Yes, publish");
+        expect(await screen.findByText("Published, but not saved to the note")).toBeTruthy();
+        expect(screen.getByText(RECEIPT.url)).toBeTruthy();
+
+        await clickButton("Retry save");
+        expect(retrySave).toHaveBeenCalledTimes(1);
+        expect(onConfirm).toHaveBeenCalledTimes(1);
+        expect(await screen.findByText("Publish complete")).toBeTruthy();
+      });
+
+      it("copies and opens the API-returned URL from the success view", async () => {
+        const writeText = jest.fn().mockResolvedValue(undefined);
+        Object.defineProperty(window.navigator, "clipboard", {
+          configurable: true,
+          value: { writeText },
+        });
+        const open = jest.spyOn(window, "open").mockImplementation(() => null);
+        const onConfirm = createConfirmMock().mockResolvedValue({
+          kind: "success",
+          action: "update",
+          receipt: RECEIPT,
+        });
+        renderModal(onConfirm, DOC_ID);
+
+        await clickButton("Yes, update");
+        await clickButton("Copy");
+        fireEvent.click(screen.getByRole("button", { name: "Open" }));
+
+        expect(writeText).toHaveBeenCalledWith(RECEIPT.url);
+        expect(open).toHaveBeenCalledWith(RECEIPT.url, "_blank", "noopener,noreferrer");
+      });
+    });
+
+    describe("onClose()", () => {
+      it("unmounts and clears the modal content", () => {
+        const onConfirm = createConfirmMock();
+        const modal = renderModal(onConfirm);
+        expect(modal.contentEl.childElementCount).toBeGreaterThan(0);
+
+        act(() => {
+          modal.onClose();
+        });
+
+        expect(modal.contentEl.childElementCount).toBe(0);
+      });
+    });
+  });
+});

--- a/src/components/modals/SymposiumModal.tsx
+++ b/src/components/modals/SymposiumModal.tsx
@@ -35,6 +35,7 @@ export type SymposiumModalResult =
 export interface SymposiumModalOptions {
   fileName: string;
   docId: string | null;
+  initialResult?: SymposiumModalResult;
   onConfirm: (action: SymposiumAction, ownerDocument: Document) => Promise<SymposiumModalResult>;
   onClosed?: () => void;
 }
@@ -86,12 +87,13 @@ function SymposiumReceiptView({ receipt }: { receipt: SymposiumReceipt }) {
 function SymposiumModalContent({
   fileName,
   docId,
+  initialResult,
   onConfirm,
   onClose,
   onWorkingChange,
 }: SymposiumModalContentProps) {
   const [action, setAction] = useState<SymposiumAction>(docId ? "update" : "publish");
-  const [result, setResult] = useState<SymposiumModalResult | null>(null);
+  const [result, setResult] = useState<SymposiumModalResult | null>(initialResult ?? null);
   const [working, setWorking] = useState(false);
 
   const runAction = async (nextAction: SymposiumAction, ownerDocument: Document) => {

--- a/src/components/modals/SymposiumModal.tsx
+++ b/src/components/modals/SymposiumModal.tsx
@@ -48,7 +48,12 @@ function actionLabel(action: SymposiumAction): string {
   return `${action[0].toUpperCase()}${action.slice(1)}`;
 }
 
-function SymposiumReceiptView({ receipt }: { receipt: SymposiumReceipt }) {
+interface SymposiumReceiptViewProps {
+  receipt: SymposiumReceipt;
+  actions?: React.ReactNode;
+}
+
+function SymposiumReceiptView({ receipt, actions }: SymposiumReceiptViewProps) {
   const [copyMessage, setCopyMessage] = useState("");
 
   const copyUrl = async (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -74,6 +79,7 @@ function SymposiumReceiptView({ receipt }: { receipt: SymposiumReceipt }) {
       </div>
       <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
         {copyMessage && <span className="tw-text-small tw-text-muted">{copyMessage}</span>}
+        {actions}
         <Button variant="secondary" onClick={copyUrl}>
           Copy
         </Button>
@@ -90,40 +96,43 @@ function SymposiumModalContent({
   onConfirm,
   onClose,
 }: SymposiumModalContentProps) {
-  const [action, setAction] = useState<SymposiumAction>(docId ? "update" : "publish");
   const [result, setResult] = useState<SymposiumModalResult | null>(initialResult ?? null);
-  const [working, setWorking] = useState(false);
+  const [workingAction, setWorkingAction] = useState<SymposiumAction | null>(null);
+  const working = workingAction !== null;
 
   const runAction = async (nextAction: SymposiumAction, ownerDocument: Document) => {
-    setWorking(true);
+    setWorkingAction(nextAction);
     try {
       setResult(await onConfirm(nextAction, ownerDocument));
     } finally {
-      setWorking(false);
+      setWorkingAction(null);
     }
   };
 
-  const confirm = (event: React.MouseEvent<HTMLButtonElement>) => {
-    void runAction(action, event.currentTarget.doc);
-  };
-
   const retry = (event: React.MouseEvent<HTMLButtonElement>) => {
-    void runAction(result?.action ?? action, event.currentTarget.doc);
+    if (result?.kind === "failure") {
+      void runAction(result.action, event.currentTarget.doc);
+    }
   };
 
   const retrySave = async () => {
     if (result?.kind !== "persistence" || !result.retrySave) {
       return;
     }
-    setWorking(true);
+    setWorkingAction(result.action);
     try {
       setResult(await result.retrySave());
     } finally {
-      setWorking(false);
+      setWorkingAction(null);
     }
   };
 
   if (result?.kind === "success") {
+    const closeButton = (
+      <Button variant="secondary" onClick={onClose}>
+        Close
+      </Button>
+    );
     return (
       <div className="tw-flex tw-flex-col tw-gap-4">
         <div className="tw-font-semibold tw-text-normal">
@@ -131,12 +140,11 @@ function SymposiumModalContent({
             ? "Removed from Symposium"
             : `${actionLabel(result.action)} complete`}
         </div>
-        {result.receipt && <SymposiumReceiptView receipt={result.receipt} />}
-        <div className="tw-flex tw-justify-end">
-          <Button variant="secondary" onClick={onClose}>
-            Close
-          </Button>
-        </div>
+        {result.receipt ? (
+          <SymposiumReceiptView receipt={result.receipt} actions={closeButton} />
+        ) : (
+          <div className="tw-flex tw-justify-end">{closeButton}</div>
+        )}
       </div>
     );
   }
@@ -165,6 +173,18 @@ function SymposiumModalContent({
   }
 
   if (result?.kind === "persistence") {
+    const actions = (
+      <>
+        <Button variant="secondary" onClick={onClose}>
+          Close
+        </Button>
+        {result.retrySave && (
+          <Button onClick={() => void retrySave()} disabled={working}>
+            {working ? "Saving…" : "Retry save"}
+          </Button>
+        )}
+      </>
+    );
     return (
       <div className="tw-flex tw-flex-col tw-gap-4" role="alert">
         <div className="tw-font-semibold tw-text-normal">
@@ -175,17 +195,11 @@ function SymposiumModalContent({
               : "Page withdrawn; note unchanged"}
         </div>
         <p className="tw-m-0 tw-text-muted">{result.message}</p>
-        {result.receipt && <SymposiumReceiptView receipt={result.receipt} />}
-        <div className="tw-flex tw-justify-end tw-gap-2">
-          <Button variant="secondary" onClick={onClose}>
-            Close
-          </Button>
-          {result.retrySave && (
-            <Button onClick={() => void retrySave()} disabled={working}>
-              {working ? "Saving…" : "Retry save"}
-            </Button>
-          )}
-        </div>
+        {result.receipt ? (
+          <SymposiumReceiptView receipt={result.receipt} actions={actions} />
+        ) : (
+          <div className="tw-flex tw-justify-end tw-gap-2">{actions}</div>
+        )}
       </div>
     );
   }
@@ -194,45 +208,43 @@ function SymposiumModalContent({
     <div className="tw-flex tw-flex-col tw-gap-4">
       <div>
         <div className="tw-font-semibold tw-text-normal">
-          {actionLabel(action)} “{fileName}”?
+          {docId ? `Manage “${fileName}”` : `Publish “${fileName}”?`}
         </div>
         <p className="tw-mb-0 tw-mt-2 tw-text-muted">
-          {action === "delete"
-            ? "Yes withdraws the link and deletes Symposium’s stored copy. Previously fetched or cached copies cannot be recalled."
-            : "Yes makes this note available to anyone with the public link."}
+          {docId
+            ? "Update replaces the current public page. Delete withdraws the link and removes Symposium’s stored copy; previously fetched or cached copies cannot be recalled."
+            : "This makes the note available to anyone with the public link."}
         </p>
       </div>
 
-      {docId && (
-        <div className="tw-flex tw-gap-2" aria-label="Symposium action">
+      <div className="tw-flex tw-justify-end tw-gap-2" aria-label="Symposium actions">
+        <Button variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        {docId ? (
+          <>
+            <Button
+              onClick={(event) => void runAction("update", event.currentTarget.doc)}
+              disabled={working}
+            >
+              {workingAction === "update" ? "Updating…" : "Update"}
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={(event) => void runAction("delete", event.currentTarget.doc)}
+              disabled={working}
+            >
+              {workingAction === "delete" ? "Deleting…" : "Delete"}
+            </Button>
+          </>
+        ) : (
           <Button
-            variant={action === "update" ? "default" : "secondary"}
-            onClick={() => setAction("update")}
+            onClick={(event) => void runAction("publish", event.currentTarget.doc)}
             disabled={working}
           >
-            Update
+            {workingAction === "publish" ? "Publishing…" : "Publish"}
           </Button>
-          <Button
-            variant={action === "delete" ? "destructive" : "secondary"}
-            onClick={() => setAction("delete")}
-            disabled={working}
-          >
-            Delete
-          </Button>
-        </div>
-      )}
-
-      <div className="tw-flex tw-justify-end tw-gap-2">
-        <Button variant="secondary" onClick={onClose} disabled={working}>
-          No, cancel
-        </Button>
-        <Button
-          variant={action === "delete" ? "destructive" : "default"}
-          onClick={confirm}
-          disabled={working}
-        >
-          {working ? "Working…" : `Yes, ${action}`}
-        </Button>
+        )}
       </div>
     </div>
   );

--- a/src/components/modals/SymposiumModal.tsx
+++ b/src/components/modals/SymposiumModal.tsx
@@ -48,6 +48,12 @@ function actionLabel(action: SymposiumAction): string {
   return `${action[0].toUpperCase()}${action.slice(1)}`;
 }
 
+const WORKING_LABELS: Record<SymposiumAction, string> = {
+  publish: "Publishing…",
+  update: "Updating…",
+  delete: "Deleting…",
+};
+
 interface SymposiumReceiptViewProps {
   receipt: SymposiumReceipt;
   actions?: React.ReactNode;
@@ -96,6 +102,9 @@ function SymposiumModalContent({
   onConfirm,
   onClose,
 }: SymposiumModalContentProps) {
+  const [confirmationAction, setConfirmationAction] = useState<SymposiumAction | null>(
+    docId ? null : "publish"
+  );
   const [result, setResult] = useState<SymposiumModalResult | null>(initialResult ?? null);
   const [workingAction, setWorkingAction] = useState<SymposiumAction | null>(null);
   const working = workingAction !== null;
@@ -204,46 +213,49 @@ function SymposiumModalContent({
     );
   }
 
+  const heading = confirmationAction
+    ? `${actionLabel(confirmationAction)} “${fileName}”?`
+    : `Manage “${fileName}”`;
+  const description =
+    confirmationAction === "delete"
+      ? "Yes withdraws the link and deletes Symposium’s stored copy. Previously fetched or cached copies cannot be recalled."
+      : confirmationAction === "update"
+        ? "Yes replaces the current public page with this note’s latest content."
+        : confirmationAction === "publish"
+          ? "Yes makes this note available to anyone with the public link."
+          : "Choose whether to replace the current public page or withdraw it.";
+
   return (
     <div className="tw-flex tw-flex-col tw-gap-4">
       <div>
-        <div className="tw-font-semibold tw-text-normal">
-          {docId ? `Manage “${fileName}”` : `Publish “${fileName}”?`}
-        </div>
-        <p className="tw-mb-0 tw-mt-2 tw-text-muted">
-          {docId
-            ? "Update replaces the current public page. Delete withdraws the link and removes Symposium’s stored copy; previously fetched or cached copies cannot be recalled."
-            : "This makes the note available to anyone with the public link."}
-        </p>
+        <div className="tw-font-semibold tw-text-normal">{heading}</div>
+        <p className="tw-mb-0 tw-mt-2 tw-text-muted">{description}</p>
       </div>
 
       <div className="tw-flex tw-justify-end tw-gap-2" aria-label="Symposium actions">
-        <Button variant="secondary" onClick={onClose}>
-          Cancel
-        </Button>
-        {docId ? (
+        {confirmationAction ? (
           <>
-            <Button
-              onClick={(event) => void runAction("update", event.currentTarget.doc)}
-              disabled={working}
-            >
-              {workingAction === "update" ? "Updating…" : "Update"}
+            <Button variant="secondary" onClick={onClose} disabled={working}>
+              No, cancel
             </Button>
             <Button
-              variant="destructive"
-              onClick={(event) => void runAction("delete", event.currentTarget.doc)}
+              variant={confirmationAction === "delete" ? "destructive" : "default"}
+              onClick={(event) => void runAction(confirmationAction, event.currentTarget.doc)}
               disabled={working}
             >
-              {workingAction === "delete" ? "Deleting…" : "Delete"}
+              {working ? WORKING_LABELS[confirmationAction] : `Yes, ${confirmationAction}`}
             </Button>
           </>
         ) : (
-          <Button
-            onClick={(event) => void runAction("publish", event.currentTarget.doc)}
-            disabled={working}
-          >
-            {workingAction === "publish" ? "Publishing…" : "Publish"}
-          </Button>
+          <>
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button onClick={() => setConfirmationAction("update")}>Update</Button>
+            <Button variant="destructive" onClick={() => setConfirmationAction("delete")}>
+              Delete
+            </Button>
+          </>
         )}
       </div>
     </div>
@@ -261,6 +273,7 @@ export class SymposiumModal extends Modal {
     private readonly options: SymposiumModalOptions
   ) {
     super(app);
+    this.modalEl.classList.add("copilot-symposium-modal");
     this.titleEl.setText("Share with Symposium");
   }
 

--- a/src/components/modals/SymposiumModal.tsx
+++ b/src/components/modals/SymposiumModal.tsx
@@ -1,0 +1,259 @@
+import { Button } from "@/components/ui/button";
+import { createPluginRoot } from "@/utils/react/createPluginRoot";
+import type { SymposiumAction, SymposiumReceipt } from "@/symposium/types";
+import { App, Modal } from "obsidian";
+import React, { useState } from "react";
+import type { Root } from "react-dom/client";
+
+export interface SymposiumSuccessResult {
+  kind: "success";
+  action: SymposiumAction;
+  receipt?: SymposiumReceipt;
+}
+
+export interface SymposiumFailureResult {
+  kind: "failure";
+  action: SymposiumAction;
+  message: string;
+  accessNotice: boolean;
+  retryable: boolean;
+}
+
+export interface SymposiumPersistenceResult {
+  kind: "persistence";
+  action: "publish" | "delete";
+  message: string;
+  receipt?: SymposiumReceipt;
+  retrySave: () => Promise<SymposiumModalResult>;
+}
+
+export type SymposiumModalResult =
+  | SymposiumSuccessResult
+  | SymposiumFailureResult
+  | SymposiumPersistenceResult;
+
+export interface SymposiumModalOptions {
+  fileName: string;
+  docId: string | null;
+  onConfirm: (action: SymposiumAction, ownerDocument: Document) => Promise<SymposiumModalResult>;
+}
+
+interface SymposiumModalContentProps extends SymposiumModalOptions {
+  onClose: () => void;
+}
+
+function actionLabel(action: SymposiumAction): string {
+  return `${action[0].toUpperCase()}${action.slice(1)}`;
+}
+
+function SymposiumReceiptView({ receipt }: { receipt: SymposiumReceipt }) {
+  const [copyMessage, setCopyMessage] = useState("");
+
+  const copyUrl = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    try {
+      await event.currentTarget.win.navigator.clipboard.writeText(receipt.url);
+      setCopyMessage("Copied");
+    } catch {
+      setCopyMessage("Could not copy the link");
+    }
+  };
+
+  const openUrl = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.currentTarget.win.open(receipt.url, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-3">
+      <code className="tw-break-all tw-rounded-md tw-bg-secondary tw-p-2 tw-text-small">
+        {receipt.url}
+      </code>
+      <div className="tw-text-small tw-text-muted">
+        Document {receipt.docId} · Version {receipt.version}
+      </div>
+      <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
+        {copyMessage && <span className="tw-text-small tw-text-muted">{copyMessage}</span>}
+        <Button variant="secondary" onClick={copyUrl}>
+          Copy
+        </Button>
+        <Button onClick={openUrl}>Open</Button>
+      </div>
+    </div>
+  );
+}
+
+function SymposiumModalContent({
+  fileName,
+  docId,
+  onConfirm,
+  onClose,
+}: SymposiumModalContentProps) {
+  const [action, setAction] = useState<SymposiumAction>(docId ? "update" : "publish");
+  const [result, setResult] = useState<SymposiumModalResult | null>(null);
+  const [working, setWorking] = useState(false);
+
+  const runAction = async (nextAction: SymposiumAction, ownerDocument: Document) => {
+    setWorking(true);
+    try {
+      setResult(await onConfirm(nextAction, ownerDocument));
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  const confirm = (event: React.MouseEvent<HTMLButtonElement>) => {
+    void runAction(action, event.currentTarget.doc);
+  };
+
+  const retry = (event: React.MouseEvent<HTMLButtonElement>) => {
+    void runAction(result?.action ?? action, event.currentTarget.doc);
+  };
+
+  const retrySave = async () => {
+    if (result?.kind !== "persistence") {
+      return;
+    }
+    setWorking(true);
+    try {
+      setResult(await result.retrySave());
+    } finally {
+      setWorking(false);
+    }
+  };
+
+  if (result?.kind === "success") {
+    return (
+      <div className="tw-flex tw-flex-col tw-gap-4">
+        <div className="tw-font-semibold tw-text-normal">
+          {result.action === "delete"
+            ? "Removed from Symposium"
+            : `${actionLabel(result.action)} complete`}
+        </div>
+        {result.receipt && <SymposiumReceiptView receipt={result.receipt} />}
+        <div className="tw-flex tw-justify-end">
+          <Button variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (result?.kind === "failure") {
+    return (
+      <div className="tw-flex tw-flex-col tw-gap-4" role="alert">
+        <div className="tw-font-semibold tw-text-normal">
+          {result.accessNotice
+            ? "Symposium access required"
+            : `${actionLabel(result.action)} failed`}
+        </div>
+        <p className="tw-m-0 tw-text-muted">{result.message}</p>
+        <div className="tw-flex tw-justify-end tw-gap-2">
+          <Button variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+          {result.retryable && (
+            <Button onClick={retry} disabled={working}>
+              {working ? "Retrying…" : "Retry"}
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (result?.kind === "persistence") {
+    return (
+      <div className="tw-flex tw-flex-col tw-gap-4" role="alert">
+        <div className="tw-font-semibold tw-text-normal">
+          {result.action === "publish"
+            ? "Published, but not saved to the note"
+            : "Deleted, but the note still has its old link"}
+        </div>
+        <p className="tw-m-0 tw-text-muted">{result.message}</p>
+        {result.receipt && <SymposiumReceiptView receipt={result.receipt} />}
+        <div className="tw-flex tw-justify-end tw-gap-2">
+          <Button variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+          <Button onClick={() => void retrySave()} disabled={working}>
+            {working ? "Saving…" : "Retry save"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-4">
+      <div>
+        <div className="tw-font-semibold tw-text-normal">
+          {actionLabel(action)} “{fileName}”?
+        </div>
+        <p className="tw-mb-0 tw-mt-2 tw-text-muted">
+          {action === "delete"
+            ? "Yes permanently removes every public version at this link."
+            : "Yes makes this note available to anyone with the public link."}
+        </p>
+      </div>
+
+      {docId && (
+        <div className="tw-flex tw-gap-2" aria-label="Symposium action">
+          <Button
+            variant={action === "update" ? "default" : "secondary"}
+            onClick={() => setAction("update")}
+            disabled={working}
+          >
+            Update
+          </Button>
+          <Button
+            variant={action === "delete" ? "destructive" : "secondary"}
+            onClick={() => setAction("delete")}
+            disabled={working}
+          >
+            Delete
+          </Button>
+        </div>
+      )}
+
+      <div className="tw-flex tw-justify-end tw-gap-2">
+        <Button variant="secondary" onClick={onClose} disabled={working}>
+          No, cancel
+        </Button>
+        <Button
+          variant={action === "delete" ? "destructive" : "default"}
+          onClick={confirm}
+          disabled={working}
+        >
+          {working ? "Working…" : `Yes, ${action}`}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Hosts the complete state-aware Symposium confirmation and result flow for one note.
+ */
+export class SymposiumModal extends Modal {
+  private root: Root | null = null;
+
+  constructor(
+    app: App,
+    private readonly options: SymposiumModalOptions
+  ) {
+    super(app);
+    this.titleEl.setText("Share with Symposium");
+  }
+
+  onOpen(): void {
+    this.contentEl.empty();
+    this.root = createPluginRoot(this.contentEl, this.app);
+    this.root.render(<SymposiumModalContent {...this.options} onClose={() => this.close()} />);
+  }
+
+  onClose(): void {
+    this.root?.unmount();
+    this.root = null;
+    this.contentEl.empty();
+  }
+}

--- a/src/components/modals/SymposiumModal.tsx
+++ b/src/components/modals/SymposiumModal.tsx
@@ -78,7 +78,14 @@ function SymposiumReceiptView({ receipt, actions }: SymposiumReceiptViewProps) {
   return (
     <div className="tw-flex tw-flex-col tw-gap-3">
       <code className="tw-break-all tw-rounded-md tw-bg-secondary tw-p-2 tw-text-small">
-        {receipt.url}
+        <a
+          href={receipt.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="tw-text-accent tw-underline"
+        >
+          {receipt.url}
+        </a>
       </code>
       <div className="tw-text-small tw-text-muted">
         Document {receipt.docId} · Version {receipt.version}

--- a/src/components/modals/SymposiumModal.tsx
+++ b/src/components/modals/SymposiumModal.tsx
@@ -21,7 +21,7 @@ export interface SymposiumFailureResult {
 
 export interface SymposiumPersistenceResult {
   kind: "persistence";
-  action: "publish" | "delete";
+  action: SymposiumAction;
   message: string;
   receipt?: SymposiumReceipt;
   retrySave?: () => Promise<SymposiumModalResult>;
@@ -174,7 +174,9 @@ function SymposiumModalContent({
         <div className="tw-font-semibold tw-text-normal">
           {result.action === "publish"
             ? "Published, but not saved to the note"
-            : "Page withdrawn; note unchanged"}
+            : result.action === "update"
+              ? "Page updated; note identity not verified"
+              : "Page withdrawn; note unchanged"}
         </div>
         <p className="tw-m-0 tw-text-muted">{result.message}</p>
         {result.receipt && <SymposiumReceiptView receipt={result.receipt} />}

--- a/src/components/modals/SymposiumModal.tsx
+++ b/src/components/modals/SymposiumModal.tsx
@@ -24,7 +24,7 @@ export interface SymposiumPersistenceResult {
   action: "publish" | "delete";
   message: string;
   receipt?: SymposiumReceipt;
-  retrySave: () => Promise<SymposiumModalResult>;
+  retrySave?: () => Promise<SymposiumModalResult>;
 }
 
 export type SymposiumModalResult =
@@ -36,10 +36,12 @@ export interface SymposiumModalOptions {
   fileName: string;
   docId: string | null;
   onConfirm: (action: SymposiumAction, ownerDocument: Document) => Promise<SymposiumModalResult>;
+  onClosed?: () => void;
 }
 
 interface SymposiumModalContentProps extends SymposiumModalOptions {
   onClose: () => void;
+  onWorkingChange: (working: boolean) => void;
 }
 
 function actionLabel(action: SymposiumAction): string {
@@ -86,6 +88,7 @@ function SymposiumModalContent({
   docId,
   onConfirm,
   onClose,
+  onWorkingChange,
 }: SymposiumModalContentProps) {
   const [action, setAction] = useState<SymposiumAction>(docId ? "update" : "publish");
   const [result, setResult] = useState<SymposiumModalResult | null>(null);
@@ -93,10 +96,12 @@ function SymposiumModalContent({
 
   const runAction = async (nextAction: SymposiumAction, ownerDocument: Document) => {
     setWorking(true);
+    onWorkingChange(true);
     try {
       setResult(await onConfirm(nextAction, ownerDocument));
     } finally {
       setWorking(false);
+      onWorkingChange(false);
     }
   };
 
@@ -109,14 +114,16 @@ function SymposiumModalContent({
   };
 
   const retrySave = async () => {
-    if (result?.kind !== "persistence") {
+    if (result?.kind !== "persistence" || !result.retrySave) {
       return;
     }
     setWorking(true);
+    onWorkingChange(true);
     try {
       setResult(await result.retrySave());
     } finally {
       setWorking(false);
+      onWorkingChange(false);
     }
   };
 
@@ -167,7 +174,7 @@ function SymposiumModalContent({
         <div className="tw-font-semibold tw-text-normal">
           {result.action === "publish"
             ? "Published, but not saved to the note"
-            : "Deleted, but the note still has its old link"}
+            : "Page withdrawn; note unchanged"}
         </div>
         <p className="tw-m-0 tw-text-muted">{result.message}</p>
         {result.receipt && <SymposiumReceiptView receipt={result.receipt} />}
@@ -175,9 +182,11 @@ function SymposiumModalContent({
           <Button variant="secondary" onClick={onClose}>
             Close
           </Button>
-          <Button onClick={() => void retrySave()} disabled={working}>
-            {working ? "Saving…" : "Retry save"}
-          </Button>
+          {result.retrySave && (
+            <Button onClick={() => void retrySave()} disabled={working}>
+              {working ? "Saving…" : "Retry save"}
+            </Button>
+          )}
         </div>
       </div>
     );
@@ -191,7 +200,7 @@ function SymposiumModalContent({
         </div>
         <p className="tw-mb-0 tw-mt-2 tw-text-muted">
           {action === "delete"
-            ? "Yes permanently removes every public version at this link."
+            ? "Yes withdraws the link and deletes Symposium’s stored copy. Previously fetched or cached copies cannot be recalled."
             : "Yes makes this note available to anyone with the public link."}
         </p>
       </div>
@@ -236,6 +245,8 @@ function SymposiumModalContent({
  */
 export class SymposiumModal extends Modal {
   private root: Root | null = null;
+  private working = false;
+  private forceClose = false;
 
   constructor(
     app: App,
@@ -248,12 +259,35 @@ export class SymposiumModal extends Modal {
   onOpen(): void {
     this.contentEl.empty();
     this.root = createPluginRoot(this.contentEl, this.app);
-    this.root.render(<SymposiumModalContent {...this.options} onClose={() => this.close()} />);
+    this.root.render(
+      <SymposiumModalContent
+        {...this.options}
+        onClose={() => this.close()}
+        onWorkingChange={(working) => {
+          this.working = working;
+        }}
+      />
+    );
+  }
+
+  close(): void {
+    if (!this.working || this.forceClose) {
+      super.close();
+    }
+  }
+
+  /**
+   * Closes the modal during plugin teardown even if a confirmed request is still settling.
+   */
+  dispose(): void {
+    this.forceClose = true;
+    this.close();
   }
 
   onClose(): void {
     this.root?.unmount();
     this.root = null;
     this.contentEl.empty();
+    this.options.onClosed?.();
   }
 }

--- a/src/components/modals/SymposiumModal.tsx
+++ b/src/components/modals/SymposiumModal.tsx
@@ -42,7 +42,6 @@ export interface SymposiumModalOptions {
 
 interface SymposiumModalContentProps extends SymposiumModalOptions {
   onClose: () => void;
-  onWorkingChange: (working: boolean) => void;
 }
 
 function actionLabel(action: SymposiumAction): string {
@@ -90,7 +89,6 @@ function SymposiumModalContent({
   initialResult,
   onConfirm,
   onClose,
-  onWorkingChange,
 }: SymposiumModalContentProps) {
   const [action, setAction] = useState<SymposiumAction>(docId ? "update" : "publish");
   const [result, setResult] = useState<SymposiumModalResult | null>(initialResult ?? null);
@@ -98,12 +96,10 @@ function SymposiumModalContent({
 
   const runAction = async (nextAction: SymposiumAction, ownerDocument: Document) => {
     setWorking(true);
-    onWorkingChange(true);
     try {
       setResult(await onConfirm(nextAction, ownerDocument));
     } finally {
       setWorking(false);
-      onWorkingChange(false);
     }
   };
 
@@ -120,12 +116,10 @@ function SymposiumModalContent({
       return;
     }
     setWorking(true);
-    onWorkingChange(true);
     try {
       setResult(await result.retrySave());
     } finally {
       setWorking(false);
-      onWorkingChange(false);
     }
   };
 
@@ -249,8 +243,6 @@ function SymposiumModalContent({
  */
 export class SymposiumModal extends Modal {
   private root: Root | null = null;
-  private working = false;
-  private forceClose = false;
 
   constructor(
     app: App,
@@ -263,29 +255,7 @@ export class SymposiumModal extends Modal {
   onOpen(): void {
     this.contentEl.empty();
     this.root = createPluginRoot(this.contentEl, this.app);
-    this.root.render(
-      <SymposiumModalContent
-        {...this.options}
-        onClose={() => this.close()}
-        onWorkingChange={(working) => {
-          this.working = working;
-        }}
-      />
-    );
-  }
-
-  close(): void {
-    if (!this.working || this.forceClose) {
-      super.close();
-    }
-  }
-
-  /**
-   * Closes the modal during plugin teardown even if a confirmed request is still settling.
-   */
-  dispose(): void {
-    this.forceClose = true;
-    this.close();
+    this.root.render(<SymposiumModalContent {...this.options} onClose={() => this.close()} />);
   }
 
   onClose(): void {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -849,6 +849,7 @@ export const COMMAND_IDS = {
   OPEN_LOG_FILE: "open-log-file",
   CLEAR_LOG_FILE: "clear-log-file",
   DOWNLOAD_YOUTUBE_SCRIPT: "download-youtube-script",
+  PUBLISH_FILE_TO_SYMPOSIUM: "publish-file-to-symposium",
   TRIGGER_QUICK_ASK: "trigger-quick-ask",
 } as const;
 
@@ -881,6 +882,7 @@ export const COMMAND_NAMES: Record<CommandId, string> = {
   [COMMAND_IDS.OPEN_LOG_FILE]: "Create log file",
   [COMMAND_IDS.CLEAR_LOG_FILE]: "Clear log file",
   [COMMAND_IDS.DOWNLOAD_YOUTUBE_SCRIPT]: "Download YouTube Script (plus)",
+  [COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM]: "Publish file to Symposium",
   [COMMAND_IDS.TRIGGER_QUICK_ASK]: "Quick Ask",
 };
 
@@ -915,6 +917,7 @@ export const COMMAND_ICONS: Partial<Record<CommandId, string>> = {
   [COMMAND_IDS.OPEN_LOG_FILE]: "file-text",
   [COMMAND_IDS.CLEAR_LOG_FILE]: "file-x",
   [COMMAND_IDS.DOWNLOAD_YOUTUBE_SCRIPT]: "youtube",
+  [COMMAND_IDS.PUBLISH_FILE_TO_SYMPOSIUM]: "share-2",
 };
 
 /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ import RelevantNotesView from "@/components/RelevantNotesView";
 import { APPLY_VIEW_TYPE, ApplyView } from "@/components/composer/ApplyView";
 import { LoadChatHistoryModal } from "@/components/modals/LoadChatHistoryModal";
 
-import { registerContextMenu } from "@/commands/contextMenu";
+import { registerContextMenu, registerSymposiumFileMenu } from "@/commands/contextMenu";
 import { CustomCommandRegister } from "@/commands/customCommandRegister";
 import { migrateCommands, suggestDefaultCommands } from "@/commands/migrator";
 import { migrateSystemPromptsFromSettings } from "@/system-prompts/migration";
@@ -116,6 +116,7 @@ import {
   trashFile,
 } from "@/utils/vaultAdapterUtils";
 import { v4 as uuidv4 } from "uuid";
+import { SymposiumPublisher } from "@/symposium/SymposiumPublisher";
 
 // Removed unused FileTrackingState interface
 
@@ -354,13 +355,20 @@ export default class CopilotPlugin extends Plugin {
       () => (this.canUseAgentView() ? this.activateAgentView() : this.activateView())
     );
 
-    registerCommands(this);
+    const symposiumPublisher = new SymposiumPublisher(this.app);
+    const publishFile = (file: TFile): void => {
+      void symposiumPublisher
+        .open(file)
+        .catch((error) => logError("Failed to open Symposium publishing.", error));
+    };
+    registerCommands(this, publishFile);
+    registerSymposiumFileMenu(this, publishFile);
 
     // Tool initialization is now handled automatically in CopilotPlusChainRunner and AutonomousAgentChainRunner
 
     this.registerEvent(
       this.app.workspace.on("editor-menu", (menu: Menu) => {
-        registerContextMenu(menu, this.app);
+        registerContextMenu(menu, this.app, publishFile);
       })
     );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -361,14 +361,15 @@ export default class CopilotPlugin extends Plugin {
         .open(file)
         .catch((error) => logError("Failed to open Symposium publishing.", error));
     };
+    this.register(() => symposiumPublisher.dispose());
     registerCommands(this, publishFile);
     registerSymposiumFileMenu(this, publishFile);
 
     // Tool initialization is now handled automatically in CopilotPlusChainRunner and AutonomousAgentChainRunner
 
     this.registerEvent(
-      this.app.workspace.on("editor-menu", (menu: Menu) => {
-        registerContextMenu(menu, this.app, publishFile);
+      this.app.workspace.on("editor-menu", (menu: Menu, _editor, info) => {
+        registerContextMenu(menu, this.app, info.file, publishFile);
       })
     );
 

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -20,6 +20,12 @@ If your plugin does not need CSS, delete this file.
   z-index: 9999 !important;
 }
 
+.copilot-symposium-modal {
+  width: min(32rem, calc(100vw - 2rem));
+  min-width: 0;
+  max-width: calc(100vw - 2rem);
+}
+
 /* Single-side dividers. Preflight is off, so `tw-border-b tw-border-solid`
    leaks `border-style: solid` to all sides and renders all four borders. */
 .copilot-divider-b {

--- a/src/symposium/SymposiumClient.test.ts
+++ b/src/symposium/SymposiumClient.test.ts
@@ -103,13 +103,7 @@ describe("SymposiumClient", () => {
           false,
         ],
         ["an oversized document", 413, "too_large", "That push is too large to accept.", false],
-        [
-          "a quota limit",
-          429,
-          "quota_exceeded",
-          "You have used all of today's pushes.",
-          false,
-        ],
+        ["a quota limit", 429, "quota_exceeded", "You have used all of today's pushes.", false],
         [
           "a license validation outage",
           500,

--- a/src/symposium/SymposiumClient.test.ts
+++ b/src/symposium/SymposiumClient.test.ts
@@ -140,13 +140,26 @@ describe("SymposiumClient", () => {
         ["invalid doc id", { docId: "UPPERCASE", url: "https://symposium.site/d/x", version: 1 }],
         ["non-HTTPS URL", { docId: DOC_ID, url: "http://symposium.site/d/x", version: 1 }],
         ["non-integer version", { docId: DOC_ID, url: "https://symposium.site/d/x", version: 1.5 }],
-      ])("rejects a successful receipt with %s", async (_case, receipt) => {
+      ])("treats a successful POST with %s as ambiguous", async (_case, receipt) => {
         mockedRequestUrl.mockResolvedValue(response(201, receipt));
 
         await expectClientError(new SymposiumClient().publish(DOCUMENT, "decrypted-license"), {
-          message: "Symposium returned an invalid response (HTTP 201).",
-          code: "malformed_response",
+          message:
+            "Symposium may have published this note, but Copilot did not receive a valid receipt. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.",
+          code: "ambiguous_publish",
           status: 201,
+          retryable: false,
+        });
+      });
+
+      it("treats an unexpected successful POST status as ambiguous", async () => {
+        mockedRequestUrl.mockResolvedValue(response(200));
+
+        await expectClientError(new SymposiumClient().publish(DOCUMENT, "decrypted-license"), {
+          message:
+            "Symposium may have published this note, but Copilot did not receive a valid receipt. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.",
+          code: "ambiguous_publish",
+          status: 200,
           retryable: false,
         });
       });
@@ -156,7 +169,7 @@ describe("SymposiumClient", () => {
 
         await expectClientError(new SymposiumClient().publish(DOCUMENT, "decrypted-license"), {
           message:
-            "Symposium may have published this note, but Copilot did not receive its document id. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.",
+            "Symposium may have published this note, but Copilot did not receive a valid receipt. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.",
           code: "ambiguous_publish",
           status: null,
           retryable: false,
@@ -211,6 +224,26 @@ describe("SymposiumClient", () => {
           response(200, {
             docId: "0123456789abcdef",
             url: "https://symposium.site/d/0123456789abcdef",
+            version: 2,
+          })
+        );
+
+        await expectClientError(
+          new SymposiumClient().update(DOC_ID, DOCUMENT, "decrypted-license"),
+          {
+            message: "Symposium returned an invalid response (HTTP 200).",
+            code: "malformed_response",
+            status: 200,
+            retryable: false,
+          }
+        );
+      });
+
+      it("keeps a malformed PUT receipt distinct from ambiguous creation", async () => {
+        mockedRequestUrl.mockResolvedValue(
+          response(200, {
+            docId: DOC_ID,
+            url: "http://symposium.site/d/x",
             version: 2,
           })
         );

--- a/src/symposium/SymposiumClient.test.ts
+++ b/src/symposium/SymposiumClient.test.ts
@@ -1,0 +1,306 @@
+import { SymposiumClient, SymposiumClientError } from "@/symposium/SymposiumClient";
+import { SYMPOSIUM_API_ORIGIN } from "@/symposium/constants";
+import type { SymposiumDocument } from "@/symposium/types";
+import { requestUrl, type RequestUrlResponse } from "obsidian";
+
+jest.mock("obsidian", () => ({
+  requestUrl: jest.fn(),
+}));
+
+const DOC_ID = "9f2k4mvq7t0xbz3n";
+const DOCUMENT: SymposiumDocument = {
+  title: "Architecture",
+  html: "<!doctype html><html><body>Review</body></html>",
+  byteLength: 52,
+};
+
+function response(status: number, json?: unknown): RequestUrlResponse {
+  return {
+    status,
+    headers: {},
+    arrayBuffer: new ArrayBuffer(0),
+    json,
+    text: json === undefined ? "" : JSON.stringify(json),
+  };
+}
+
+async function expectClientError(
+  promise: Promise<unknown>,
+  expected: {
+    message: string;
+    code: string;
+    status: number | null;
+    retryable: boolean;
+  }
+): Promise<void> {
+  try {
+    await promise;
+    throw new Error("Expected SymposiumClientError");
+  } catch (error) {
+    expect(error).toBeInstanceOf(SymposiumClientError);
+    expect(error).toMatchObject(expected);
+  }
+}
+
+describe("SymposiumClient", () => {
+  const mockedRequestUrl = requestUrl as jest.MockedFunction<typeof requestUrl>;
+
+  beforeEach(() => {
+    mockedRequestUrl.mockReset();
+  });
+
+  describe("SymposiumClientError", () => {
+    describe("constructor()", () => {
+      it("retains the server-facing fields needed by the UI", () => {
+        const error = new SymposiumClientError("Try again.", "internal", 500, true);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error).toMatchObject({
+          name: "SymposiumClientError",
+          message: "Try again.",
+          code: "internal",
+          status: 500,
+          retryable: true,
+        });
+      });
+    });
+  });
+
+  describe("SymposiumClient", () => {
+    describe("publish()", () => {
+      it("posts only title and HTML to the fixed endpoint and returns the server URL verbatim", async () => {
+        const returnedUrl = `https://symposium.site/d/${DOC_ID}?from=server#exact`;
+        mockedRequestUrl.mockResolvedValue(
+          response(201, { docId: DOC_ID, url: returnedUrl, version: 1 })
+        );
+
+        const receipt = await new SymposiumClient().publish(DOCUMENT, "decrypted-license");
+
+        expect(receipt).toEqual({ docId: DOC_ID, url: returnedUrl, version: 1 });
+        expect(mockedRequestUrl).toHaveBeenCalledWith({
+          url: `${SYMPOSIUM_API_ORIGIN}/api/v1/docs`,
+          method: "POST",
+          headers: { Authorization: "Bearer decrypted-license" },
+          contentType: "application/json",
+          body: JSON.stringify({ title: DOCUMENT.title, html: DOCUMENT.html }),
+          throw: false,
+        });
+      });
+
+      it.each([
+        [
+          "an invalid license",
+          401,
+          "unauthorized",
+          "That license key is not valid for publishing.",
+          false,
+        ],
+        [
+          "an ineligible plan",
+          401,
+          "unauthorized",
+          "Publishing is currently limited to lifetime license holders.",
+          false,
+        ],
+        ["an oversized document", 413, "too_large", "That push is too large to accept.", false],
+        [
+          "a quota limit",
+          429,
+          "quota_exceeded",
+          "You have used all of today's pushes.",
+          false,
+        ],
+        [
+          "a license validation outage",
+          500,
+          "internal",
+          "License validation is temporarily unavailable.",
+          true,
+        ],
+      ])(
+        "preserves the structured error for %s",
+        async (_case, status, code, message, retryable) => {
+          mockedRequestUrl.mockResolvedValue(response(status, { error: { code, message } }));
+
+          await expectClientError(new SymposiumClient().publish(DOCUMENT, "decrypted-license"), {
+            message,
+            code,
+            status,
+            retryable,
+          });
+        }
+      );
+
+      it("rejects malformed error envelopes without exposing their raw body", async () => {
+        mockedRequestUrl.mockResolvedValue(response(401, { message: "no envelope" }));
+
+        await expectClientError(new SymposiumClient().publish(DOCUMENT, "decrypted-license"), {
+          message: "Symposium returned an invalid response (HTTP 401).",
+          code: "malformed_response",
+          status: 401,
+          retryable: false,
+        });
+      });
+
+      it.each([
+        ["invalid doc id", { docId: "UPPERCASE", url: "https://symposium.site/d/x", version: 1 }],
+        ["non-HTTPS URL", { docId: DOC_ID, url: "http://symposium.site/d/x", version: 1 }],
+        ["non-integer version", { docId: DOC_ID, url: "https://symposium.site/d/x", version: 1.5 }],
+      ])("rejects a successful receipt with %s", async (_case, receipt) => {
+        mockedRequestUrl.mockResolvedValue(response(201, receipt));
+
+        await expectClientError(new SymposiumClient().publish(DOCUMENT, "decrypted-license"), {
+          message: "Symposium returned an invalid response (HTTP 201).",
+          code: "malformed_response",
+          status: 201,
+          retryable: false,
+        });
+      });
+
+      it("maps a request failure to a retryable network error", async () => {
+        mockedRequestUrl.mockRejectedValue(new Error("socket failed"));
+
+        await expectClientError(new SymposiumClient().publish(DOCUMENT, "decrypted-license"), {
+          message: "Could not reach Symposium. Please try again.",
+          code: "network",
+          status: null,
+          retryable: true,
+        });
+      });
+    });
+
+    describe("update()", () => {
+      it("puts the next version at the existing document route", async () => {
+        const receipt = {
+          docId: DOC_ID,
+          url: `https://symposium.site/d/${DOC_ID}`,
+          version: 2,
+        };
+        mockedRequestUrl.mockResolvedValue(response(200, receipt));
+
+        await expect(
+          new SymposiumClient().update(DOC_ID, DOCUMENT, "decrypted-license")
+        ).resolves.toEqual(receipt);
+        expect(mockedRequestUrl).toHaveBeenCalledWith({
+          url: `${SYMPOSIUM_API_ORIGIN}/api/v1/docs/${DOC_ID}`,
+          method: "PUT",
+          headers: { Authorization: "Bearer decrypted-license" },
+          contentType: "application/json",
+          body: JSON.stringify({ title: DOCUMENT.title, html: DOCUMENT.html }),
+          throw: false,
+        });
+      });
+
+      it("returns not_found without an implicit POST fallback", async () => {
+        mockedRequestUrl.mockResolvedValue(
+          response(404, {
+            error: { code: "not_found", message: `No doc with id ${DOC_ID}.` },
+          })
+        );
+
+        await expectClientError(
+          new SymposiumClient().update(DOC_ID, DOCUMENT, "decrypted-license"),
+          {
+            message: `No doc with id ${DOC_ID}.`,
+            code: "not_found",
+            status: 404,
+            retryable: false,
+          }
+        );
+        expect(mockedRequestUrl).toHaveBeenCalledTimes(1);
+        expect(mockedRequestUrl).toHaveBeenCalledWith(expect.objectContaining({ method: "PUT" }));
+      });
+
+      it("rejects a receipt for a different document identity", async () => {
+        mockedRequestUrl.mockResolvedValue(
+          response(200, {
+            docId: "0123456789abcdef",
+            url: "https://symposium.site/d/0123456789abcdef",
+            version: 2,
+          })
+        );
+
+        await expectClientError(
+          new SymposiumClient().update(DOC_ID, DOCUMENT, "decrypted-license"),
+          {
+            message: "Symposium returned an invalid response (HTTP 200).",
+            code: "malformed_response",
+            status: 200,
+            retryable: false,
+          }
+        );
+      });
+    });
+
+    describe("delete()", () => {
+      it("deletes the existing document without sending a body", async () => {
+        mockedRequestUrl.mockResolvedValue(response(204));
+
+        await expect(
+          new SymposiumClient().delete(DOC_ID, "decrypted-license")
+        ).resolves.toBeUndefined();
+        expect(mockedRequestUrl).toHaveBeenCalledWith({
+          url: `${SYMPOSIUM_API_ORIGIN}/api/v1/docs/${DOC_ID}`,
+          method: "DELETE",
+          headers: { Authorization: "Bearer decrypted-license" },
+          throw: false,
+        });
+      });
+
+      it("treats structured 404 not_found as an idempotent success", async () => {
+        mockedRequestUrl.mockResolvedValue(
+          response(404, {
+            error: { code: "not_found", message: `No doc with id ${DOC_ID}.` },
+          })
+        );
+
+        await expect(
+          new SymposiumClient().delete(DOC_ID, "decrypted-license")
+        ).resolves.toBeUndefined();
+      });
+
+      it.each([
+        [
+          "a different 404 code",
+          response(404, { error: { code: "unauthorized", message: "Invalid key." } }),
+          {
+            message: "Invalid key.",
+            code: "unauthorized",
+            status: 404,
+            retryable: false,
+          },
+        ],
+        [
+          "an unstructured 404",
+          response(404, { message: "missing" }),
+          {
+            message: "Symposium returned an invalid response (HTTP 404).",
+            code: "malformed_response",
+            status: 404,
+            retryable: false,
+          },
+        ],
+        [
+          "an unexpected 200",
+          response(200),
+          {
+            message: "Symposium returned an invalid response (HTTP 200).",
+            code: "malformed_response",
+            status: 200,
+            retryable: false,
+          },
+        ],
+      ])(
+        "rejects %s instead of treating it as deleted",
+        async (_case, serverResponse, expected) => {
+          mockedRequestUrl.mockResolvedValue(serverResponse);
+
+          await expectClientError(
+            new SymposiumClient().delete(DOC_ID, "decrypted-license"),
+            expected
+          );
+        }
+      );
+    });
+  });
+});

--- a/src/symposium/SymposiumClient.test.ts
+++ b/src/symposium/SymposiumClient.test.ts
@@ -151,14 +151,15 @@ describe("SymposiumClient", () => {
         });
       });
 
-      it("maps a request failure to a retryable network error", async () => {
+      it("marks a request failure as ambiguous and non-retryable", async () => {
         mockedRequestUrl.mockRejectedValue(new Error("socket failed"));
 
         await expectClientError(new SymposiumClient().publish(DOCUMENT, "decrypted-license"), {
-          message: "Could not reach Symposium. Please try again.",
-          code: "network",
+          message:
+            "Symposium may have published this note, but Copilot did not receive its document id. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.",
+          code: "ambiguous_publish",
           status: null,
-          retryable: true,
+          retryable: false,
         });
       });
     });
@@ -221,6 +222,20 @@ describe("SymposiumClient", () => {
             code: "malformed_response",
             status: 200,
             retryable: false,
+          }
+        );
+      });
+
+      it("keeps a PUT transport failure retryable because the document id is stable", async () => {
+        mockedRequestUrl.mockRejectedValue(new Error("socket failed"));
+
+        await expectClientError(
+          new SymposiumClient().update(DOC_ID, DOCUMENT, "decrypted-license"),
+          {
+            message: "Could not reach Symposium. Please try again.",
+            code: "network",
+            status: null,
+            retryable: true,
           }
         );
       });

--- a/src/symposium/SymposiumClient.ts
+++ b/src/symposium/SymposiumClient.ts
@@ -9,7 +9,7 @@ import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from "obsid
 const DOCS_ENDPOINT = `${SYMPOSIUM_API_ORIGIN}/api/v1/docs`;
 const NETWORK_ERROR_MESSAGE = "Could not reach Symposium. Please try again.";
 const AMBIGUOUS_PUBLISH_MESSAGE =
-  "Symposium may have published this note, but Copilot did not receive its document id. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.";
+  "Symposium may have published this note, but Copilot did not receive a valid receipt. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.";
 
 /**
  * Carries a Symposium failure to the UI without interpreting server-side authorization policy.
@@ -106,7 +106,7 @@ export class SymposiumClient {
       });
     } catch (error) {
       if (method === "POST" && error instanceof SymposiumClientError && error.code === "network") {
-        throw new SymposiumClientError(AMBIGUOUS_PUBLISH_MESSAGE, "ambiguous_publish", null, false);
+        throw ambiguousPublishError(null);
       }
       throw error;
     }
@@ -115,10 +115,24 @@ export class SymposiumClient {
       if (response.status < 200 || response.status >= 300) {
         throw errorFromResponse(response);
       }
+      if (method === "POST") {
+        throw ambiguousPublishError(response.status);
+      }
       throw malformedResponse(response.status);
     }
 
-    return parseReceipt(response, expectedDocId);
+    try {
+      return parseReceipt(response, expectedDocId);
+    } catch (error) {
+      if (
+        method === "POST" &&
+        error instanceof SymposiumClientError &&
+        error.code === "malformed_response"
+      ) {
+        throw ambiguousPublishError(response.status);
+      }
+      throw error;
+    }
   }
 
   private async request(options: RequestUrlParam): Promise<RequestUrlResponse> {
@@ -211,4 +225,8 @@ function malformedResponse(status: number): SymposiumClientError {
     status,
     status >= 500
   );
+}
+
+function ambiguousPublishError(status: number | null): SymposiumClientError {
+  return new SymposiumClientError(AMBIGUOUS_PUBLISH_MESSAGE, "ambiguous_publish", status, false);
 }

--- a/src/symposium/SymposiumClient.ts
+++ b/src/symposium/SymposiumClient.ts
@@ -8,6 +8,8 @@ import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from "obsid
 
 const DOCS_ENDPOINT = `${SYMPOSIUM_API_ORIGIN}/api/v1/docs`;
 const NETWORK_ERROR_MESSAGE = "Could not reach Symposium. Please try again.";
+const AMBIGUOUS_PUBLISH_MESSAGE =
+  "Symposium may have published this note, but Copilot did not receive its document id. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.";
 
 /**
  * Carries a Symposium failure to the UI without interpreting server-side authorization policy.
@@ -92,14 +94,22 @@ export class SymposiumClient {
     licenseKey: string,
     expectedDocId?: string
   ): Promise<SymposiumReceipt> {
-    const response = await this.request({
-      url,
-      method,
-      headers: authorizationHeaders(licenseKey),
-      contentType: "application/json",
-      body: JSON.stringify({ title: document.title, html: document.html }),
-      throw: false,
-    });
+    let response: RequestUrlResponse;
+    try {
+      response = await this.request({
+        url,
+        method,
+        headers: authorizationHeaders(licenseKey),
+        contentType: "application/json",
+        body: JSON.stringify({ title: document.title, html: document.html }),
+        throw: false,
+      });
+    } catch (error) {
+      if (method === "POST" && error instanceof SymposiumClientError && error.code === "network") {
+        throw new SymposiumClientError(AMBIGUOUS_PUBLISH_MESSAGE, "ambiguous_publish", null, false);
+      }
+      throw error;
+    }
     const expectedStatus = method === "POST" ? 201 : 200;
     if (response.status !== expectedStatus) {
       if (response.status < 200 || response.status >= 300) {

--- a/src/symposium/SymposiumClient.ts
+++ b/src/symposium/SymposiumClient.ts
@@ -1,0 +1,204 @@
+import { SYMPOSIUM_API_ORIGIN, SYMPOSIUM_DOC_ID_PATTERN } from "@/symposium/constants";
+import type {
+  SymposiumDocument,
+  SymposiumErrorResponse,
+  SymposiumReceipt,
+} from "@/symposium/types";
+import { requestUrl, type RequestUrlParam, type RequestUrlResponse } from "obsidian";
+
+const DOCS_ENDPOINT = `${SYMPOSIUM_API_ORIGIN}/api/v1/docs`;
+const NETWORK_ERROR_MESSAGE = "Could not reach Symposium. Please try again.";
+
+/**
+ * Carries a Symposium failure to the UI without interpreting server-side authorization policy.
+ */
+export class SymposiumClientError extends Error {
+  /**
+   * @param message The human-readable server message or a transport-safe fallback.
+   * @param code The stable server error code or a client transport/validation code.
+   * @param status The HTTP status, or null when no response was received.
+   * @param retryable Whether retrying the same operation can resolve the failure.
+   */
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly status: number | null,
+    public readonly retryable: boolean
+  ) {
+    super(message);
+    this.name = "SymposiumClientError";
+    Object.setPrototypeOf(this, SymposiumClientError.prototype);
+  }
+}
+
+/**
+ * Owns the fixed Symposium HTTP wire contract without managing credentials or note identity.
+ */
+export class SymposiumClient {
+  /**
+   * @param document The complete HTML document to publish.
+   * @param licenseKey The decrypted license key used only for this request.
+   */
+  async publish(document: SymposiumDocument, licenseKey: string): Promise<SymposiumReceipt> {
+    return this.push("POST", DOCS_ENDPOINT, document, licenseKey);
+  }
+
+  /**
+   * @param docId The existing Symposium document identity.
+   * @param document The complete HTML document for the new version.
+   * @param licenseKey The decrypted license key used only for this request.
+   */
+  async update(
+    docId: string,
+    document: SymposiumDocument,
+    licenseKey: string
+  ): Promise<SymposiumReceipt> {
+    return this.push(
+      "PUT",
+      `${DOCS_ENDPOINT}/${encodeURIComponent(docId)}`,
+      document,
+      licenseKey,
+      docId
+    );
+  }
+
+  /**
+   * @param docId The Symposium document identity to withdraw.
+   * @param licenseKey The decrypted license key used only for this request.
+   */
+  async delete(docId: string, licenseKey: string): Promise<void> {
+    const response = await this.request({
+      url: `${DOCS_ENDPOINT}/${encodeURIComponent(docId)}`,
+      method: "DELETE",
+      headers: authorizationHeaders(licenseKey),
+      throw: false,
+    });
+
+    if (response.status === 204) {
+      return;
+    }
+
+    const error = errorFromResponse(response);
+    if (response.status === 404 && error.code === "not_found") {
+      return;
+    }
+    throw error;
+  }
+
+  private async push(
+    method: "POST" | "PUT",
+    url: string,
+    document: SymposiumDocument,
+    licenseKey: string,
+    expectedDocId?: string
+  ): Promise<SymposiumReceipt> {
+    const response = await this.request({
+      url,
+      method,
+      headers: authorizationHeaders(licenseKey),
+      contentType: "application/json",
+      body: JSON.stringify({ title: document.title, html: document.html }),
+      throw: false,
+    });
+    const expectedStatus = method === "POST" ? 201 : 200;
+    if (response.status !== expectedStatus) {
+      if (response.status < 200 || response.status >= 300) {
+        throw errorFromResponse(response);
+      }
+      throw malformedResponse(response.status);
+    }
+
+    return parseReceipt(response, expectedDocId);
+  }
+
+  private async request(options: RequestUrlParam): Promise<RequestUrlResponse> {
+    try {
+      return await requestUrl(options);
+    } catch {
+      throw new SymposiumClientError(NETWORK_ERROR_MESSAGE, "network", null, true);
+    }
+  }
+}
+
+function authorizationHeaders(licenseKey: string): Record<string, string> {
+  return { Authorization: `Bearer ${licenseKey}` };
+}
+
+function parseReceipt(response: RequestUrlResponse, expectedDocId?: string): SymposiumReceipt {
+  const value = responseJson(response);
+  if (!isRecord(value)) {
+    throw malformedResponse(response.status);
+  }
+
+  const { docId, url, version } = value;
+  if (
+    typeof docId !== "string" ||
+    !SYMPOSIUM_DOC_ID_PATTERN.test(docId) ||
+    (expectedDocId !== undefined && docId !== expectedDocId) ||
+    typeof url !== "string" ||
+    !isHttpsUrl(url) ||
+    typeof version !== "number" ||
+    !Number.isSafeInteger(version) ||
+    version < 1
+  ) {
+    throw malformedResponse(response.status);
+  }
+
+  return { docId, url, version };
+}
+
+function errorFromResponse(response: RequestUrlResponse): SymposiumClientError {
+  const value = responseJson(response);
+  if (!isErrorResponse(value)) {
+    return malformedResponse(response.status);
+  }
+
+  const { code, message } = value.error;
+  return new SymposiumClientError(
+    message,
+    code,
+    response.status,
+    code === "internal" || response.status >= 500
+  );
+}
+
+function responseJson(response: RequestUrlResponse): unknown {
+  try {
+    return response.json;
+  } catch {
+    return undefined;
+  }
+}
+
+function isErrorResponse(value: unknown): value is SymposiumErrorResponse {
+  if (!isRecord(value) || !isRecord(value.error)) {
+    return false;
+  }
+  return (
+    typeof value.error.code === "string" &&
+    value.error.code.length > 0 &&
+    typeof value.error.message === "string" &&
+    value.error.message.length > 0
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function malformedResponse(status: number): SymposiumClientError {
+  return new SymposiumClientError(
+    `Symposium returned an invalid response (HTTP ${status}).`,
+    "malformed_response",
+    status,
+    status >= 500
+  );
+}

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -4,6 +4,7 @@ import type {
 } from "@/components/modals/SymposiumModal";
 import { SymposiumClientError } from "@/symposium/SymposiumClient";
 import { SymposiumPublisher } from "@/symposium/SymposiumPublisher";
+import { SymposiumDocumentTooLargeError } from "@/symposium/symposiumDocument";
 import type { SymposiumDocument, SymposiumReceipt } from "@/symposium/types";
 import type { App, TFile } from "obsidian";
 
@@ -32,6 +33,7 @@ interface Harness {
   frontmatter: Record<string, unknown>;
   loadLicenseKey: jest.Mock;
   modalOptions: SymposiumModalOptions[];
+  disposeModal: jest.Mock;
   openModal: jest.Mock;
   processFrontMatter: jest.Mock;
   publisher: SymposiumPublisher;
@@ -48,8 +50,13 @@ function createHarness(frontmatter: Record<string, unknown> = {}): Harness {
     }
   );
   const app = {
-    metadataCache: {
-      getFileCache: jest.fn(() => ({ frontmatter })),
+    vault: {
+      read: jest.fn(async () => {
+        const yaml = Object.entries(frontmatter)
+          .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+          .join("\n");
+        return yaml ? `---\n${yaml}\n---\n` : "";
+      }),
     },
     fileManager: { processFrontMatter },
   } as unknown as App;
@@ -62,13 +69,14 @@ function createHarness(frontmatter: Record<string, unknown> = {}): Harness {
   const buildDocument = jest.fn().mockResolvedValue(DOCUMENT);
   const modalOptions: SymposiumModalOptions[] = [];
   const openModal = jest.fn();
+  const disposeModal = jest.fn();
   const publisher = new SymposiumPublisher(app, {
     client,
     loadLicenseKey,
     buildDocument,
     createModal: (options) => {
       modalOptions.push(options);
-      return { open: openModal };
+      return { open: openModal, dispose: disposeModal };
     },
   });
 
@@ -80,6 +88,7 @@ function createHarness(frontmatter: Record<string, unknown> = {}): Harness {
     frontmatter,
     loadLicenseKey,
     modalOptions,
+    disposeModal,
     openModal,
     processFrontMatter,
     publisher,
@@ -164,6 +173,24 @@ describe("SymposiumPublisher", () => {
         expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
       });
 
+      it("does not POST a fallback when the identity changes during the failed update", async () => {
+        const harness = createHarness({ symposium: DOC_ID });
+        harness.client.update.mockImplementation(async () => {
+          harness.frontmatter.symposium = NEW_DOC_ID;
+          throw new SymposiumClientError("Document is gone.", "not_found", 404, false);
+        });
+
+        const result = await openAndConfirm(harness, "update");
+
+        expect(result).toMatchObject({
+          kind: "failure",
+          action: "update",
+          retryable: false,
+        });
+        expect(harness.client.publish).not.toHaveBeenCalled();
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+      });
+
       it("does not POST after any update failure other than structured 404 not_found", async () => {
         const harness = createHarness({ symposium: DOC_ID });
         harness.client.update.mockRejectedValue(
@@ -209,6 +236,41 @@ describe("SymposiumPublisher", () => {
         });
       });
 
+      it("reports an oversized rendered document without offering a futile retry", async () => {
+        const harness = createHarness();
+        harness.buildDocument.mockRejectedValue(
+          new SymposiumDocumentTooLargeError(10 * 1024 * 1024 + 1)
+        );
+
+        const result = await openAndConfirm(harness, "publish");
+
+        expect(result).toEqual({
+          kind: "failure",
+          action: "publish",
+          message: "Symposium HTML is 10485761 bytes; the limit is 10485760 bytes.",
+          accessNotice: false,
+          retryable: false,
+        });
+        expect(harness.client.publish).not.toHaveBeenCalled();
+      });
+
+      it("keeps a frontmatter read failure retryable without sending a request", async () => {
+        const harness = createHarness();
+        await harness.publisher.open(harness.file);
+        (harness.app.vault.read as jest.Mock).mockRejectedValueOnce(new Error("vault unavailable"));
+
+        const result = await harness.modalOptions[0].onConfirm("publish", activeDocument);
+
+        expect(result).toEqual({
+          kind: "failure",
+          action: "publish",
+          message: "Copilot could not complete this Symposium action.",
+          accessNotice: false,
+          retryable: true,
+        });
+        expect(harness.client.publish).not.toHaveBeenCalled();
+      });
+
       it("preserves a successful POST receipt and retries only the local save", async () => {
         const harness = createHarness();
         harness.processFrontMatter
@@ -228,13 +290,32 @@ describe("SymposiumPublisher", () => {
         });
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
 
-        const saved = await (
-          partial as Extract<SymposiumModalResult, { kind: "persistence" }>
-        ).retrySave();
+        const saved = await (partial as Extract<SymposiumModalResult, { kind: "persistence" }>)
+          .retrySave!();
 
         expect(saved).toEqual({ kind: "success", action: "publish", receipt: RECEIPT });
         expect(harness.frontmatter.symposium).toBe(DOC_ID);
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not overwrite a newer identity after a publish completes", async () => {
+        const harness = createHarness();
+        harness.client.publish.mockImplementation(async () => {
+          harness.frontmatter.symposium = NEW_DOC_ID;
+          return RECEIPT;
+        });
+
+        const result = await openAndConfirm(harness, "publish");
+
+        expect(result).toMatchObject({
+          kind: "persistence",
+          action: "publish",
+          receipt: RECEIPT,
+        });
+        expect(
+          (result as Extract<SymposiumModalResult, { kind: "persistence" }>).retrySave
+        ).toBeUndefined();
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
       });
 
       it("rejects a stale unpublished confirmation before it can orphan another page", async () => {
@@ -256,6 +337,24 @@ describe("SymposiumPublisher", () => {
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
       });
 
+      it("does not publish when the identity changes while the document is rendering", async () => {
+        const harness = createHarness();
+        harness.buildDocument.mockImplementation(async () => {
+          harness.frontmatter.symposium = NEW_DOC_ID;
+          return DOCUMENT;
+        });
+
+        const result = await openAndConfirm(harness, "publish");
+
+        expect(result).toMatchObject({
+          kind: "failure",
+          action: "publish",
+          retryable: false,
+        });
+        expect(harness.client.publish).not.toHaveBeenCalled();
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+      });
+
       it("deletes remotely before clearing identity and retries a failed local removal only", async () => {
         const harness = createHarness({ symposium: DOC_ID, tags: ["shared"] });
         harness.processFrontMatter
@@ -272,13 +371,27 @@ describe("SymposiumPublisher", () => {
         expect(harness.buildDocument).not.toHaveBeenCalled();
         expect(partial).toMatchObject({ kind: "persistence", action: "delete" });
 
-        const removed = await (
-          partial as Extract<SymposiumModalResult, { kind: "persistence" }>
-        ).retrySave();
+        const removed = await (partial as Extract<SymposiumModalResult, { kind: "persistence" }>)
+          .retrySave!();
 
         expect(removed).toEqual({ kind: "success", action: "delete" });
         expect(harness.frontmatter).toEqual({ tags: ["shared"] });
         expect(harness.client.delete).toHaveBeenCalledTimes(1);
+      });
+
+      it("does not remove a newer identity after a remote deletion completes", async () => {
+        const harness = createHarness({ symposium: DOC_ID });
+        harness.client.delete.mockImplementation(async () => {
+          harness.frontmatter.symposium = NEW_DOC_ID;
+        });
+
+        const result = await openAndConfirm(harness, "delete");
+
+        expect(result).toMatchObject({ kind: "persistence", action: "delete" });
+        expect(
+          (result as Extract<SymposiumModalResult, { kind: "persistence" }>).retrySave
+        ).toBeUndefined();
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
       });
 
       it("requires a decryptable configured key without locally checking a plan", async () => {
@@ -311,7 +424,10 @@ describe("SymposiumPublisher", () => {
         await harness.publisher.open(harness.file);
 
         const first = harness.modalOptions[0].onConfirm("publish", activeDocument);
-        await Promise.resolve();
+        for (let turn = 0; turn < 20 && !resolvePublish; turn += 1) {
+          await Promise.resolve();
+        }
+        expect(resolvePublish).toBeDefined();
         harness.file.path = "Notes/Renamed Architecture.md";
         const second = await harness.modalOptions[1].onConfirm("publish", activeDocument);
 
@@ -338,6 +454,45 @@ describe("SymposiumPublisher", () => {
           receipt: { ...RECEIPT, version: 2 },
         });
         expect(harness.client.update).toHaveBeenCalledTimes(1);
+      });
+
+      it("disposes open modals and prevents stale callbacks after plugin teardown", async () => {
+        const harness = createHarness();
+        await harness.publisher.open(harness.file);
+
+        harness.publisher.dispose();
+        const result = await harness.modalOptions[0].onConfirm("publish", activeDocument);
+        await harness.publisher.open(harness.file);
+
+        expect(harness.disposeModal).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+          kind: "failure",
+          action: "publish",
+          message: "Symposium publishing is no longer available.",
+          accessNotice: false,
+          retryable: false,
+        });
+        expect(harness.openModal).toHaveBeenCalledTimes(1);
+        expect(harness.client.publish).not.toHaveBeenCalled();
+      });
+
+      it("does not open a modal when plugin teardown occurs during the identity read", async () => {
+        const harness = createHarness();
+        let resolveRead: ((markdown: string) => void) | undefined;
+        jest.mocked(harness.app.vault.read).mockImplementationOnce(
+          () =>
+            new Promise<string>((resolve) => {
+              resolveRead = resolve;
+            })
+        );
+
+        const opening = harness.publisher.open(harness.file);
+        harness.publisher.dispose();
+        resolveRead?.("");
+        await opening;
+
+        expect(harness.openModal).not.toHaveBeenCalled();
+        expect(harness.modalOptions).toHaveLength(0);
       });
     });
   });

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -322,7 +322,7 @@ describe("SymposiumPublisher", () => {
 
       it("blocks another POST after a publish response is lost", async () => {
         const message =
-          "Symposium may have published this note, but Copilot did not receive its document id. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.";
+          "Symposium may have published this note, but Copilot did not receive a valid receipt. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.";
         const harness = createHarness();
         harness.client.publish.mockRejectedValue(
           new SymposiumClientError(message, "ambiguous_publish", null, false)

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -503,6 +503,32 @@ describe("SymposiumPublisher", () => {
         expect(harness.modalOptions[2].initialResult).toBeUndefined();
       });
 
+      it("retains a successful POST receipt when frontmatter becomes a sequence", async () => {
+        const harness = createHarness();
+        harness.processFrontMatter.mockImplementationOnce(
+          async (_file: TFile, update: (value: Record<string, unknown>) => void) => {
+            update(["shared"] as unknown as Record<string, unknown>);
+          }
+        );
+
+        const result = await openAndConfirm(harness, "publish");
+
+        expect(result).toMatchObject({
+          kind: "persistence",
+          action: "publish",
+          receipt: RECEIPT,
+        });
+        expect(
+          (result as Extract<SymposiumModalResult, { kind: "persistence" }>).retrySave
+        ).toBeInstanceOf(Function);
+
+        harness.modalOptions[0].onClosed?.();
+        await harness.publisher.open(harness.file);
+
+        expect(harness.modalOptions[1].initialResult).toEqual(result);
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
+      });
+
       it.each([
         ["newer identity", NEW_DOC_ID],
         ["unrecognized property", { url: "https://example.com/symposium" }],
@@ -579,12 +605,25 @@ describe("SymposiumPublisher", () => {
         expect(harness.buildDocument).not.toHaveBeenCalled();
         expect(partial).toMatchObject({ kind: "persistence", action: "delete" });
 
-        const removed = await (partial as Extract<SymposiumModalResult, { kind: "persistence" }>)
+        harness.modalOptions[0].onClosed?.();
+        await harness.publisher.open(harness.file);
+
+        const resumed = harness.modalOptions[1].initialResult;
+        expect(resumed).toMatchObject({ kind: "persistence", action: "delete" });
+        expect(harness.client.update).not.toHaveBeenCalled();
+        expect(harness.client.publish).not.toHaveBeenCalled();
+
+        const removed = await (resumed as Extract<SymposiumModalResult, { kind: "persistence" }>)
           .retrySave!();
 
         expect(removed).toEqual({ kind: "success", action: "delete" });
         expect(harness.frontmatter).toEqual({ tags: ["shared"] });
         expect(harness.client.delete).toHaveBeenCalledTimes(1);
+
+        harness.modalOptions[1].onClosed?.();
+        await harness.publisher.open(harness.file);
+        expect(harness.modalOptions[2]).toMatchObject({ docId: null });
+        expect(harness.modalOptions[2].initialResult).toBeUndefined();
       });
 
       it("does not remove a newer identity after a remote deletion completes", async () => {

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -216,6 +216,12 @@ describe("SymposiumPublisher", () => {
         });
         expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
         expect(harness.processFrontMatter).not.toHaveBeenCalled();
+
+        await harness.publisher.open(harness.file);
+        expect(harness.modalOptions[1]).toMatchObject({
+          docId: NEW_DOC_ID,
+          initialResult: undefined,
+        });
       });
 
       it("reports partial success when the identity cannot be read after update completes", async () => {
@@ -239,6 +245,38 @@ describe("SymposiumPublisher", () => {
         });
         expect(harness.frontmatter.symposium).toBe(DOC_ID);
         expect(harness.processFrontMatter).not.toHaveBeenCalled();
+
+        await harness.publisher.open(harness.file);
+        expect(harness.modalOptions[1].initialResult).toEqual(result);
+      });
+
+      it("retains an updated receipt when the note identity disappears", async () => {
+        const receipt = { ...RECEIPT, version: 2 };
+        const harness = createHarness({ symposium: DOC_ID });
+        harness.client.update.mockImplementation(async () => {
+          delete harness.frontmatter.symposium;
+          return receipt;
+        });
+
+        const result = await openAndConfirm(harness, "update");
+
+        expect(result).toEqual({
+          kind: "persistence",
+          action: "update",
+          message:
+            "The original page was updated, but this note’s Symposium identity changed or could not be verified. Its current identity was left unchanged.",
+          receipt,
+        });
+
+        harness.modalOptions[0].onClosed?.();
+        await harness.publisher.open(harness.file);
+
+        expect(harness.modalOptions[1].initialResult).toEqual(result);
+        await expect(harness.modalOptions[1].onConfirm("publish", activeDocument)).resolves.toEqual(
+          result
+        );
+        expect(harness.client.update).toHaveBeenCalledTimes(1);
+        expect(harness.client.publish).not.toHaveBeenCalled();
       });
 
       it("falls back once from exact PUT not_found to POST and replaces the stale id", async () => {

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -401,8 +401,10 @@ describe("SymposiumPublisher", () => {
         harness.client.publish.mockRejectedValue(
           new SymposiumClientError(message, "ambiguous_publish", null, false)
         );
+        await harness.publisher.open(harness.file);
+        await harness.publisher.open(harness.file);
 
-        const first = await openAndConfirm(harness, "publish");
+        const first = await harness.modalOptions[0].onConfirm("publish", activeDocument);
 
         expect(first).toEqual({
           kind: "failure",
@@ -412,12 +414,17 @@ describe("SymposiumPublisher", () => {
           retryable: false,
         });
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
+        await expect(harness.modalOptions[1].onConfirm("publish", activeDocument)).resolves.toEqual(
+          first
+        );
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
 
         harness.modalOptions[0].onClosed?.();
+        harness.modalOptions[1].onClosed?.();
         await harness.publisher.open(harness.file);
 
-        expect(harness.modalOptions[1].initialResult).toEqual(first);
-        await expect(harness.modalOptions[1].onConfirm("publish", activeDocument)).resolves.toEqual(
+        expect(harness.modalOptions[2].initialResult).toEqual(first);
+        await expect(harness.modalOptions[2].onConfirm("publish", activeDocument)).resolves.toEqual(
           first
         );
         expect(harness.buildDocument).toHaveBeenCalledTimes(1);

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -148,9 +148,12 @@ describe("SymposiumPublisher", () => {
         expect(harness.client.publish).not.toHaveBeenCalled();
       });
 
-      it("rejects malformed YAML before rendering or publishing", async () => {
+      it.each([
+        ["malformed YAML", "---\nsymposium: [\n---\n"],
+        ["a YAML sequence", "---\n- shared\n---\n"],
+      ])("rejects %s before rendering or publishing", async (_case, markdown) => {
         const harness = createHarness();
-        jest.mocked(harness.app.vault.read).mockResolvedValue("---\nsymposium: [\n---\n");
+        jest.mocked(harness.app.vault.read).mockResolvedValue(markdown);
 
         await harness.publisher.open(harness.file);
         const result = harness.modalOptions[0].initialResult;
@@ -159,7 +162,7 @@ describe("SymposiumPublisher", () => {
           kind: "failure",
           action: "publish",
           message:
-            "This note's frontmatter is not valid YAML. Fix it before publishing to Symposium.",
+            "This note's frontmatter must be a YAML property map. Fix it before publishing to Symposium.",
           accessNotice: false,
           retryable: false,
         });
@@ -293,6 +296,39 @@ describe("SymposiumPublisher", () => {
         expect(harness.client.update).toHaveBeenCalledTimes(1);
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
         expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+      });
+
+      it("retains a fallback POST receipt when the stale identity disappears", async () => {
+        const replacement = { ...RECEIPT, docId: NEW_DOC_ID, version: 1 };
+        const harness = createHarness({ symposium: DOC_ID });
+        harness.client.update.mockRejectedValue(
+          new SymposiumClientError("Document is gone.", "not_found", 404, false)
+        );
+        harness.client.publish.mockImplementation(async () => {
+          delete harness.frontmatter.symposium;
+          return replacement;
+        });
+
+        const result = await openAndConfirm(harness, "update");
+
+        expect(result).toMatchObject({
+          kind: "persistence",
+          action: "publish",
+          receipt: replacement,
+        });
+        expect(
+          (result as Extract<SymposiumModalResult, { kind: "persistence" }>).retrySave
+        ).toBeUndefined();
+
+        harness.modalOptions[0].onClosed?.();
+        await harness.publisher.open(harness.file);
+
+        expect(harness.modalOptions[1].initialResult).toEqual(result);
+        await expect(harness.modalOptions[1].onConfirm("publish", activeDocument)).resolves.toEqual(
+          result
+        );
+        expect(harness.client.update).toHaveBeenCalledTimes(1);
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
       });
 
       it("does not POST a fallback when the identity changes during the failed update", async () => {

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -1,0 +1,344 @@
+import type {
+  SymposiumModalOptions,
+  SymposiumModalResult,
+} from "@/components/modals/SymposiumModal";
+import { SymposiumClientError } from "@/symposium/SymposiumClient";
+import { SymposiumPublisher } from "@/symposium/SymposiumPublisher";
+import type { SymposiumDocument, SymposiumReceipt } from "@/symposium/types";
+import type { App, TFile } from "obsidian";
+
+const DOC_ID = "9f2k4mvq7t0xbz3n";
+const NEW_DOC_ID = "0123456789abcdef";
+const DOCUMENT: SymposiumDocument = {
+  title: "Architecture",
+  html: "<!doctype html><html><body>Review</body></html>",
+  byteLength: 52,
+};
+const RECEIPT: SymposiumReceipt = {
+  docId: DOC_ID,
+  url: `https://symposium.md/d/${DOC_ID}?server=exact`,
+  version: 1,
+};
+
+interface Harness {
+  app: App;
+  buildDocument: jest.Mock;
+  client: {
+    publish: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+  };
+  file: TFile;
+  frontmatter: Record<string, unknown>;
+  loadLicenseKey: jest.Mock;
+  modalOptions: SymposiumModalOptions[];
+  openModal: jest.Mock;
+  processFrontMatter: jest.Mock;
+  publisher: SymposiumPublisher;
+}
+
+function createHarness(frontmatter: Record<string, unknown> = {}): Harness {
+  const file = {
+    path: "Notes/Architecture.md",
+    basename: "Architecture",
+  } as TFile; // eslint-disable-line obsidianmd/no-tfile-tfolder-cast -- focused controller test fixture
+  const processFrontMatter = jest.fn(
+    async (_file: TFile, update: (value: Record<string, unknown>) => void) => {
+      update(frontmatter);
+    }
+  );
+  const app = {
+    metadataCache: {
+      getFileCache: jest.fn(() => ({ frontmatter })),
+    },
+    fileManager: { processFrontMatter },
+  } as unknown as App;
+  const client = {
+    publish: jest.fn().mockResolvedValue(RECEIPT),
+    update: jest.fn().mockResolvedValue({ ...RECEIPT, version: 2 }),
+    delete: jest.fn().mockResolvedValue(undefined),
+  };
+  const loadLicenseKey = jest.fn().mockResolvedValue("decrypted-license");
+  const buildDocument = jest.fn().mockResolvedValue(DOCUMENT);
+  const modalOptions: SymposiumModalOptions[] = [];
+  const openModal = jest.fn();
+  const publisher = new SymposiumPublisher(app, {
+    client,
+    loadLicenseKey,
+    buildDocument,
+    createModal: (options) => {
+      modalOptions.push(options);
+      return { open: openModal };
+    },
+  });
+
+  return {
+    app,
+    buildDocument,
+    client,
+    file,
+    frontmatter,
+    loadLicenseKey,
+    modalOptions,
+    openModal,
+    processFrontMatter,
+    publisher,
+  };
+}
+
+async function openAndConfirm(
+  harness: Harness,
+  action: "publish" | "update" | "delete"
+): Promise<SymposiumModalResult> {
+  await harness.publisher.open(harness.file);
+  return harness.modalOptions.at(-1)!.onConfirm(action, activeDocument);
+}
+
+describe("SymposiumPublisher", () => {
+  describe("SymposiumPublisher", () => {
+    describe("open()", () => {
+      it.each([
+        ["missing", {}],
+        ["non-string", { symposium: { docId: DOC_ID } }],
+        ["malformed", { symposium: "UPPERCASE1234567" }],
+      ])("opens an unpublished confirmation and posts for a %s property", async (_case, value) => {
+        const harness = createHarness(value);
+
+        await harness.publisher.open(harness.file);
+
+        expect(harness.openModal).toHaveBeenCalledTimes(1);
+        expect(harness.modalOptions[0]).toMatchObject({
+          fileName: "Architecture",
+          docId: null,
+        });
+
+        const result = await harness.modalOptions[0].onConfirm("publish", activeDocument);
+
+        expect(result).toEqual({ kind: "success", action: "publish", receipt: RECEIPT });
+        expect(harness.loadLicenseKey).toHaveBeenCalledTimes(1);
+        expect(harness.buildDocument).toHaveBeenCalledWith(harness.file, activeDocument);
+        expect(harness.client.publish).toHaveBeenCalledWith(DOCUMENT, "decrypted-license");
+        expect(harness.frontmatter.symposium).toBe(DOC_ID);
+      });
+
+      it("updates the current valid id without rewriting frontmatter", async () => {
+        const harness = createHarness({ symposium: DOC_ID });
+
+        const result = await openAndConfirm(harness, "update");
+
+        expect(harness.modalOptions[0].docId).toBe(DOC_ID);
+        expect(result).toEqual({
+          kind: "success",
+          action: "update",
+          receipt: { ...RECEIPT, version: 2 },
+        });
+        expect(harness.client.update).toHaveBeenCalledWith(DOC_ID, DOCUMENT, "decrypted-license");
+        expect(harness.client.publish).not.toHaveBeenCalled();
+        expect(harness.processFrontMatter).not.toHaveBeenCalled();
+      });
+
+      it("lets copied notes intentionally update the same remote id", async () => {
+        const first = createHarness({ symposium: DOC_ID });
+        const second = createHarness({ symposium: DOC_ID });
+
+        await openAndConfirm(first, "update");
+        await openAndConfirm(second, "update");
+
+        expect(first.client.update).toHaveBeenCalledWith(DOC_ID, DOCUMENT, "decrypted-license");
+        expect(second.client.update).toHaveBeenCalledWith(DOC_ID, DOCUMENT, "decrypted-license");
+      });
+
+      it("falls back once from exact PUT not_found to POST and replaces the stale id", async () => {
+        const replacement = { ...RECEIPT, docId: NEW_DOC_ID, version: 1 };
+        const harness = createHarness({ symposium: DOC_ID });
+        harness.client.update.mockRejectedValue(
+          new SymposiumClientError("Document is gone.", "not_found", 404, false)
+        );
+        harness.client.publish.mockResolvedValue(replacement);
+
+        const result = await openAndConfirm(harness, "update");
+
+        expect(result).toEqual({ kind: "success", action: "publish", receipt: replacement });
+        expect(harness.client.update).toHaveBeenCalledTimes(1);
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+      });
+
+      it("does not POST after any update failure other than structured 404 not_found", async () => {
+        const harness = createHarness({ symposium: DOC_ID });
+        harness.client.update.mockRejectedValue(
+          new SymposiumClientError(
+            "Publishing is currently limited to lifetime license holders.",
+            "unauthorized",
+            401,
+            false
+          )
+        );
+
+        const result = await openAndConfirm(harness, "update");
+
+        expect(result).toEqual({
+          kind: "failure",
+          action: "update",
+          message: "Publishing is currently limited to lifetime license holders.",
+          accessNotice: true,
+          retryable: false,
+        });
+        expect(harness.client.publish).not.toHaveBeenCalled();
+      });
+
+      it("keeps structured internal server failures retryable", async () => {
+        const harness = createHarness();
+        harness.client.publish.mockRejectedValue(
+          new SymposiumClientError(
+            "License validation is temporarily unavailable.",
+            "internal",
+            500,
+            true
+          )
+        );
+
+        const result = await openAndConfirm(harness, "publish");
+
+        expect(result).toEqual({
+          kind: "failure",
+          action: "publish",
+          message: "License validation is temporarily unavailable.",
+          accessNotice: false,
+          retryable: true,
+        });
+      });
+
+      it("preserves a successful POST receipt and retries only the local save", async () => {
+        const harness = createHarness();
+        harness.processFrontMatter
+          .mockRejectedValueOnce(new Error("vault is read-only"))
+          .mockImplementationOnce(
+            async (_file: TFile, update: (value: Record<string, unknown>) => void) => {
+              update(harness.frontmatter);
+            }
+          );
+
+        const partial = await openAndConfirm(harness, "publish");
+
+        expect(partial).toMatchObject({
+          kind: "persistence",
+          action: "publish",
+          receipt: RECEIPT,
+        });
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
+
+        const saved = await (
+          partial as Extract<SymposiumModalResult, { kind: "persistence" }>
+        ).retrySave();
+
+        expect(saved).toEqual({ kind: "success", action: "publish", receipt: RECEIPT });
+        expect(harness.frontmatter.symposium).toBe(DOC_ID);
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
+      });
+
+      it("rejects a stale unpublished confirmation before it can orphan another page", async () => {
+        const harness = createHarness();
+        await harness.publisher.open(harness.file);
+        await harness.publisher.open(harness.file);
+
+        await harness.modalOptions[0].onConfirm("publish", activeDocument);
+        const stale = await harness.modalOptions[1].onConfirm("publish", activeDocument);
+
+        expect(stale).toEqual({
+          kind: "failure",
+          action: "publish",
+          message:
+            "This note's Symposium identity changed. Close and reopen this dialog before trying again.",
+          accessNotice: false,
+          retryable: false,
+        });
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
+      });
+
+      it("deletes remotely before clearing identity and retries a failed local removal only", async () => {
+        const harness = createHarness({ symposium: DOC_ID, tags: ["shared"] });
+        harness.processFrontMatter
+          .mockRejectedValueOnce(new Error("vault is read-only"))
+          .mockImplementationOnce(
+            async (_file: TFile, update: (value: Record<string, unknown>) => void) => {
+              update(harness.frontmatter);
+            }
+          );
+
+        const partial = await openAndConfirm(harness, "delete");
+
+        expect(harness.client.delete).toHaveBeenCalledWith(DOC_ID, "decrypted-license");
+        expect(harness.buildDocument).not.toHaveBeenCalled();
+        expect(partial).toMatchObject({ kind: "persistence", action: "delete" });
+
+        const removed = await (
+          partial as Extract<SymposiumModalResult, { kind: "persistence" }>
+        ).retrySave();
+
+        expect(removed).toEqual({ kind: "success", action: "delete" });
+        expect(harness.frontmatter).toEqual({ tags: ["shared"] });
+        expect(harness.client.delete).toHaveBeenCalledTimes(1);
+      });
+
+      it("requires a decryptable configured key without locally checking a plan", async () => {
+        const harness = createHarness();
+        harness.loadLicenseKey.mockResolvedValue("");
+
+        const result = await openAndConfirm(harness, "publish");
+
+        expect(result).toEqual({
+          kind: "failure",
+          action: "publish",
+          message: "Add a Copilot Plus license key in Settings before publishing with Symposium.",
+          accessNotice: true,
+          retryable: false,
+        });
+        expect(harness.buildDocument).not.toHaveBeenCalled();
+        expect(harness.client.publish).not.toHaveBeenCalled();
+      });
+
+      it("keeps one in-flight operation per file across renames and releases it afterward", async () => {
+        const harness = createHarness();
+        let resolvePublish: ((receipt: SymposiumReceipt) => void) | undefined;
+        harness.client.publish.mockImplementationOnce(
+          () =>
+            new Promise<SymposiumReceipt>((resolve) => {
+              resolvePublish = resolve;
+            })
+        );
+        await harness.publisher.open(harness.file);
+        await harness.publisher.open(harness.file);
+
+        const first = harness.modalOptions[0].onConfirm("publish", activeDocument);
+        await Promise.resolve();
+        harness.file.path = "Notes/Renamed Architecture.md";
+        const second = await harness.modalOptions[1].onConfirm("publish", activeDocument);
+
+        expect(second).toEqual({
+          kind: "failure",
+          action: "publish",
+          message: "A Symposium action is already in progress for this note.",
+          accessNotice: false,
+          retryable: false,
+        });
+
+        resolvePublish?.(RECEIPT);
+        await expect(first).resolves.toEqual({
+          kind: "success",
+          action: "publish",
+          receipt: RECEIPT,
+        });
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
+
+        const third = await openAndConfirm(harness, "update");
+        expect(third).toEqual({
+          kind: "success",
+          action: "update",
+          receipt: { ...RECEIPT, version: 2 },
+        });
+        expect(harness.client.update).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+});

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -148,6 +148,28 @@ describe("SymposiumPublisher", () => {
         expect(harness.client.publish).not.toHaveBeenCalled();
       });
 
+      it("rejects malformed YAML before rendering or publishing", async () => {
+        const harness = createHarness();
+        jest.mocked(harness.app.vault.read).mockResolvedValue("---\nsymposium: [\n---\n");
+
+        await harness.publisher.open(harness.file);
+        const result = harness.modalOptions[0].initialResult;
+
+        expect(result).toEqual({
+          kind: "failure",
+          action: "publish",
+          message:
+            "This note's frontmatter is not valid YAML. Fix it before publishing to Symposium.",
+          accessNotice: false,
+          retryable: false,
+        });
+        await expect(harness.modalOptions[0].onConfirm("publish", activeDocument)).resolves.toEqual(
+          result
+        );
+        expect(harness.buildDocument).not.toHaveBeenCalled();
+        expect(harness.client.publish).not.toHaveBeenCalled();
+      });
+
       it("updates the current valid id without rewriting frontmatter", async () => {
         const harness = createHarness({ symposium: DOC_ID });
 
@@ -298,6 +320,36 @@ describe("SymposiumPublisher", () => {
         });
       });
 
+      it("blocks another POST after a publish response is lost", async () => {
+        const message =
+          "Symposium may have published this note, but Copilot did not receive its document id. To avoid creating a duplicate page, this publish cannot be retried until the plugin reloads.";
+        const harness = createHarness();
+        harness.client.publish.mockRejectedValue(
+          new SymposiumClientError(message, "ambiguous_publish", null, false)
+        );
+
+        const first = await openAndConfirm(harness, "publish");
+
+        expect(first).toEqual({
+          kind: "failure",
+          action: "publish",
+          message,
+          accessNotice: false,
+          retryable: false,
+        });
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
+
+        harness.modalOptions[0].onClosed?.();
+        await harness.publisher.open(harness.file);
+
+        expect(harness.modalOptions[1].initialResult).toEqual(first);
+        await expect(harness.modalOptions[1].onConfirm("publish", activeDocument)).resolves.toEqual(
+          first
+        );
+        expect(harness.buildDocument).toHaveBeenCalledTimes(1);
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
+      });
+
       it("reports an oversized rendered document without offering a futile retry", async () => {
         const harness = createHarness();
         harness.buildDocument.mockRejectedValue(
@@ -352,12 +404,29 @@ describe("SymposiumPublisher", () => {
         });
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
 
-        const saved = await (partial as Extract<SymposiumModalResult, { kind: "persistence" }>)
+        harness.modalOptions[0].onClosed?.();
+        await harness.publisher.open(harness.file);
+
+        const resumed = harness.modalOptions[1].initialResult;
+        expect(resumed).toMatchObject({
+          kind: "persistence",
+          action: "publish",
+          receipt: RECEIPT,
+        });
+        expect(harness.buildDocument).toHaveBeenCalledTimes(1);
+        expect(harness.client.publish).toHaveBeenCalledTimes(1);
+
+        const saved = await (resumed as Extract<SymposiumModalResult, { kind: "persistence" }>)
           .retrySave!();
 
         expect(saved).toEqual({ kind: "success", action: "publish", receipt: RECEIPT });
         expect(harness.frontmatter.symposium).toBe(DOC_ID);
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
+
+        harness.modalOptions[1].onClosed?.();
+        await harness.publisher.open(harness.file);
+        expect(harness.modalOptions[2]).toMatchObject({ docId: DOC_ID });
+        expect(harness.modalOptions[2].initialResult).toBeUndefined();
       });
 
       it.each([

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -33,7 +33,7 @@ interface Harness {
   frontmatter: Record<string, unknown>;
   loadLicenseKey: jest.Mock;
   modalOptions: SymposiumModalOptions[];
-  disposeModal: jest.Mock;
+  closeModal: jest.Mock;
   openModal: jest.Mock;
   processFrontMatter: jest.Mock;
   publisher: SymposiumPublisher;
@@ -69,14 +69,14 @@ function createHarness(frontmatter: Record<string, unknown> = {}): Harness {
   const buildDocument = jest.fn().mockResolvedValue(DOCUMENT);
   const modalOptions: SymposiumModalOptions[] = [];
   const openModal = jest.fn();
-  const disposeModal = jest.fn();
+  const closeModal = jest.fn();
   const publisher = new SymposiumPublisher(app, {
     client,
     loadLicenseKey,
     buildDocument,
     createModal: (options) => {
       modalOptions.push(options);
-      return { open: openModal, dispose: disposeModal };
+      return { open: openModal, close: closeModal };
     },
   });
 
@@ -88,7 +88,7 @@ function createHarness(frontmatter: Record<string, unknown> = {}): Harness {
     frontmatter,
     loadLicenseKey,
     modalOptions,
-    disposeModal,
+    closeModal,
     openModal,
     processFrontMatter,
     publisher,
@@ -711,7 +711,7 @@ describe("SymposiumPublisher", () => {
         const result = await harness.modalOptions[0].onConfirm("publish", activeDocument);
         await harness.publisher.open(harness.file);
 
-        expect(harness.disposeModal).toHaveBeenCalledTimes(1);
+        expect(harness.closeModal).toHaveBeenCalledTimes(1);
         expect(result).toEqual({
           kind: "failure",
           action: "publish",

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -106,11 +106,8 @@ async function openAndConfirm(
 describe("SymposiumPublisher", () => {
   describe("SymposiumPublisher", () => {
     describe("open()", () => {
-      it.each([
-        ["missing", {}],
-        ["non-string", { symposium: { docId: DOC_ID } }],
-        ["malformed", { symposium: "UPPERCASE1234567" }],
-      ])("opens an unpublished confirmation and posts for a %s property", async (_case, value) => {
+      it("opens an unpublished confirmation and posts when the property is missing", async () => {
+        const value = {};
         const harness = createHarness(value);
 
         await harness.publisher.open(harness.file);
@@ -128,6 +125,27 @@ describe("SymposiumPublisher", () => {
         expect(harness.buildDocument).toHaveBeenCalledWith(harness.file, activeDocument);
         expect(harness.client.publish).toHaveBeenCalledWith(DOCUMENT, "decrypted-license");
         expect(harness.frontmatter.symposium).toBe(DOC_ID);
+      });
+
+      it.each([
+        ["non-string", { docId: DOC_ID }],
+        ["malformed", "UPPERCASE1234567"],
+      ])("refuses to overwrite an occupied %s property", async (_case, value) => {
+        const harness = createHarness({ symposium: value });
+
+        const result = await openAndConfirm(harness, "publish");
+
+        expect(result).toEqual({
+          kind: "failure",
+          action: "publish",
+          message:
+            "This note already uses the symposium property for an unrecognized value. Rename or remove that property before publishing.",
+          accessNotice: false,
+          retryable: false,
+        });
+        expect(harness.frontmatter.symposium).toBe(value);
+        expect(harness.buildDocument).not.toHaveBeenCalled();
+        expect(harness.client.publish).not.toHaveBeenCalled();
       });
 
       it("updates the current valid id without rewriting frontmatter", async () => {
@@ -342,10 +360,13 @@ describe("SymposiumPublisher", () => {
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
       });
 
-      it("does not overwrite a newer identity after a publish completes", async () => {
+      it.each([
+        ["newer identity", NEW_DOC_ID],
+        ["unrecognized property", { url: "https://example.com/symposium" }],
+      ])("does not overwrite a %s after a publish completes", async (_case, newerValue) => {
         const harness = createHarness();
         harness.client.publish.mockImplementation(async () => {
-          harness.frontmatter.symposium = NEW_DOC_ID;
+          harness.frontmatter.symposium = newerValue;
           return RECEIPT;
         });
 
@@ -359,7 +380,7 @@ describe("SymposiumPublisher", () => {
         expect(
           (result as Extract<SymposiumModalResult, { kind: "persistence" }>).retrySave
         ).toBeUndefined();
-        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(newerValue);
       });
 
       it("rejects a stale unpublished confirmation before it can orphan another page", async () => {

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -157,6 +157,50 @@ describe("SymposiumPublisher", () => {
         expect(second.client.update).toHaveBeenCalledWith(DOC_ID, DOCUMENT, "decrypted-license");
       });
 
+      it("reports partial success without replacing a newer identity after update completes", async () => {
+        const receipt = { ...RECEIPT, version: 2 };
+        const harness = createHarness({ symposium: DOC_ID });
+        harness.client.update.mockImplementation(async () => {
+          harness.frontmatter.symposium = NEW_DOC_ID;
+          return receipt;
+        });
+
+        const result = await openAndConfirm(harness, "update");
+
+        expect(result).toEqual({
+          kind: "persistence",
+          action: "update",
+          message:
+            "The original page was updated, but this note’s Symposium identity changed or could not be verified. Its current identity was left unchanged.",
+          receipt,
+        });
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+        expect(harness.processFrontMatter).not.toHaveBeenCalled();
+      });
+
+      it("reports partial success when the identity cannot be read after update completes", async () => {
+        const receipt = { ...RECEIPT, version: 2 };
+        const harness = createHarness({ symposium: DOC_ID });
+        harness.client.update.mockImplementation(async () => {
+          (harness.app.vault.read as jest.Mock).mockRejectedValueOnce(
+            new Error("vault unavailable")
+          );
+          return receipt;
+        });
+
+        const result = await openAndConfirm(harness, "update");
+
+        expect(result).toEqual({
+          kind: "persistence",
+          action: "update",
+          message:
+            "The original page was updated, but this note’s Symposium identity changed or could not be verified. Its current identity was left unchanged.",
+          receipt,
+        });
+        expect(harness.frontmatter.symposium).toBe(DOC_ID);
+        expect(harness.processFrontMatter).not.toHaveBeenCalled();
+      });
+
       it("falls back once from exact PUT not_found to POST and replaces the stale id", async () => {
         const replacement = { ...RECEIPT, docId: NEW_DOC_ID, version: 1 };
         const harness = createHarness({ symposium: DOC_ID });

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -389,6 +389,7 @@ export class SymposiumPublisher {
     try {
       const removed = await removeSymposiumDocId(this.app, file, expectedDocId);
       if (!removed) {
+        this.blockedPublishResults.delete(file);
         return {
           kind: "persistence",
           action: "delete",
@@ -396,6 +397,7 @@ export class SymposiumPublisher {
             "The original page was withdrawn, but this note now points to a different Symposium document. Its newer identity was left unchanged.",
         };
       }
+      this.blockedPublishResults.delete(file);
       return { kind: "success", action: "delete" };
     } catch {
       return this.deletePersistenceFailure(file, expectedDocId);
@@ -403,7 +405,7 @@ export class SymposiumPublisher {
   }
 
   private deletePersistenceFailure(file: TFile, expectedDocId: string): SymposiumPersistenceResult {
-    return {
+    const result: SymposiumPersistenceResult = {
       kind: "persistence",
       action: "delete",
       message:
@@ -413,6 +415,8 @@ export class SymposiumPublisher {
           this.removeLocalIdentity(file, expectedDocId)
         ),
     };
+    this.blockedPublishResults.set(file, result);
+    return result;
   }
 
   private async withFileLock(

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -1,0 +1,270 @@
+import {
+  SymposiumModal,
+  type SymposiumFailureResult,
+  type SymposiumModalOptions,
+  type SymposiumModalResult,
+  type SymposiumPersistenceResult,
+} from "@/components/modals/SymposiumModal";
+import { getDecryptedKey } from "@/encryptionService";
+import { getSettings } from "@/settings/model";
+import { SymposiumClient, SymposiumClientError } from "@/symposium/SymposiumClient";
+import {
+  getSymposiumDocId,
+  removeSymposiumDocId,
+  saveSymposiumDocId,
+} from "@/symposium/symposiumFrontmatter";
+import { buildSymposiumDocument } from "@/symposium/symposiumDocument";
+import type { SymposiumAction, SymposiumDocument, SymposiumReceipt } from "@/symposium/types";
+import { App, Component, TFile } from "obsidian";
+
+interface SymposiumClientPort {
+  publish(document: SymposiumDocument, licenseKey: string): Promise<SymposiumReceipt>;
+  update(docId: string, document: SymposiumDocument, licenseKey: string): Promise<SymposiumReceipt>;
+  delete(docId: string, licenseKey: string): Promise<void>;
+}
+
+interface SymposiumModalPort {
+  open(): void;
+}
+
+interface SymposiumPublisherDependencies {
+  client?: SymposiumClientPort;
+  loadLicenseKey?: () => Promise<string>;
+  buildDocument?: (file: TFile, ownerDocument: Document) => Promise<SymposiumDocument>;
+  createModal?: (options: SymposiumModalOptions) => SymposiumModalPort;
+}
+
+const MISSING_LICENSE_MESSAGE =
+  "Add a Copilot Plus license key in Settings before publishing with Symposium.";
+const BUSY_MESSAGE = "A Symposium action is already in progress for this note.";
+
+async function loadConfiguredLicenseKey(): Promise<string> {
+  const configuredKey = getSettings().plusLicenseKey;
+  return configuredKey ? (await getDecryptedKey(configuredKey)).trim() : "";
+}
+
+async function buildDocumentWithComponent(
+  app: App,
+  file: TFile,
+  ownerDocument: Document
+): Promise<SymposiumDocument> {
+  const component = new Component();
+  component.load();
+  try {
+    return await buildSymposiumDocument(app, file, component, ownerDocument);
+  } finally {
+    component.unload();
+  }
+}
+
+function operationFailure(action: SymposiumAction, error: unknown): SymposiumFailureResult {
+  if (error instanceof SymposiumClientError) {
+    return {
+      kind: "failure",
+      action,
+      message: error.message,
+      accessNotice: error.status === 401 && error.code === "unauthorized",
+      retryable: error.retryable,
+    };
+  }
+
+  return {
+    kind: "failure",
+    action,
+    message: "Copilot could not complete this Symposium action.",
+    accessNotice: false,
+    retryable: true,
+  };
+}
+
+/**
+ * Coordinates one note's confirmed Symposium action, remote request, and local identity update.
+ *
+ * The publisher owns per-file concurrency and partial-success recovery. It does not decide
+ * Symposium entitlement or retain decrypted credentials beyond an individual request.
+ */
+export class SymposiumPublisher {
+  private readonly client: SymposiumClientPort;
+  private readonly loadLicenseKey: () => Promise<string>;
+  private readonly buildDocument: (
+    file: TFile,
+    ownerDocument: Document
+  ) => Promise<SymposiumDocument>;
+  private readonly createModal: (options: SymposiumModalOptions) => SymposiumModalPort;
+  private readonly inFlightFiles = new Set<TFile>();
+
+  constructor(
+    private readonly app: App,
+    dependencies: SymposiumPublisherDependencies = {}
+  ) {
+    this.client = dependencies.client ?? new SymposiumClient();
+    this.loadLicenseKey = dependencies.loadLicenseKey ?? loadConfiguredLicenseKey;
+    this.buildDocument =
+      dependencies.buildDocument ??
+      ((file, ownerDocument) => buildDocumentWithComponent(this.app, file, ownerDocument));
+    this.createModal =
+      dependencies.createModal ?? ((options) => new SymposiumModal(this.app, options));
+  }
+
+  /**
+   * Opens the state-aware confirmation flow for the exact file supplied by the caller.
+   *
+   * @param file The Markdown note selected by the invoking command or menu.
+   */
+  async open(file: TFile): Promise<void> {
+    const docId = getSymposiumDocId(this.app, file);
+    this.createModal({
+      fileName: file.basename,
+      docId,
+      onConfirm: (action, ownerDocument) => this.execute(file, docId, action, ownerDocument),
+    }).open();
+  }
+
+  private async execute(
+    file: TFile,
+    expectedDocId: string | null,
+    action: SymposiumAction,
+    ownerDocument: Document
+  ): Promise<SymposiumModalResult> {
+    return this.withFileLock(file, action, async () => {
+      const docId = getSymposiumDocId(this.app, file);
+      if (docId !== expectedDocId) {
+        return {
+          kind: "failure",
+          action,
+          message:
+            "This note's Symposium identity changed. Close and reopen this dialog before trying again.",
+          accessNotice: false,
+          retryable: false,
+        };
+      }
+
+      let licenseKey: string;
+      try {
+        licenseKey = await this.loadLicenseKey();
+      } catch {
+        licenseKey = "";
+      }
+      if (!licenseKey) {
+        return {
+          kind: "failure",
+          action,
+          message: MISSING_LICENSE_MESSAGE,
+          accessNotice: true,
+          retryable: false,
+        };
+      }
+
+      if (action !== "publish" && !docId) {
+        return {
+          kind: "failure",
+          action,
+          message: "This note no longer has a valid Symposium document id.",
+          accessNotice: false,
+          retryable: false,
+        };
+      }
+
+      try {
+        if (action === "delete") {
+          await this.client.delete(docId!, licenseKey);
+          return await this.removeLocalIdentity(file);
+        }
+
+        const document = await this.buildDocument(file, ownerDocument);
+        if (action === "publish") {
+          const receipt = await this.client.publish(document, licenseKey);
+          return await this.savePublishedIdentity(file, receipt);
+        }
+
+        try {
+          const receipt = await this.client.update(docId!, document, licenseKey);
+          return { kind: "success", action: "update", receipt };
+        } catch (error) {
+          if (
+            !(error instanceof SymposiumClientError) ||
+            error.status !== 404 ||
+            error.code !== "not_found"
+          ) {
+            throw error;
+          }
+        }
+
+        const receipt = await this.client.publish(document, licenseKey);
+        return await this.savePublishedIdentity(file, receipt);
+      } catch (error) {
+        return operationFailure(action, error);
+      }
+    });
+  }
+
+  private async savePublishedIdentity(
+    file: TFile,
+    receipt: SymposiumReceipt
+  ): Promise<SymposiumModalResult> {
+    try {
+      await saveSymposiumDocId(this.app, file, receipt.docId);
+      return { kind: "success", action: "publish", receipt };
+    } catch {
+      return this.publishPersistenceFailure(file, receipt);
+    }
+  }
+
+  private publishPersistenceFailure(
+    file: TFile,
+    receipt: SymposiumReceipt
+  ): SymposiumPersistenceResult {
+    return {
+      kind: "persistence",
+      action: "publish",
+      message:
+        "The page is already public. Retry saving its document id to this note; this will not publish again.",
+      receipt,
+      retrySave: () =>
+        this.withFileLock(file, "publish", async () => this.savePublishedIdentity(file, receipt)),
+    };
+  }
+
+  private async removeLocalIdentity(file: TFile): Promise<SymposiumModalResult> {
+    try {
+      await removeSymposiumDocId(this.app, file);
+      return { kind: "success", action: "delete" };
+    } catch {
+      return this.deletePersistenceFailure(file);
+    }
+  }
+
+  private deletePersistenceFailure(file: TFile): SymposiumPersistenceResult {
+    return {
+      kind: "persistence",
+      action: "delete",
+      message:
+        "The public page is already deleted. Retry removing its document id from this note; this will not contact Symposium again.",
+      retrySave: () =>
+        this.withFileLock(file, "delete", async () => this.removeLocalIdentity(file)),
+    };
+  }
+
+  private async withFileLock(
+    file: TFile,
+    action: SymposiumAction,
+    operation: () => Promise<SymposiumModalResult>
+  ): Promise<SymposiumModalResult> {
+    if (this.inFlightFiles.has(file)) {
+      return {
+        kind: "failure",
+        action,
+        message: BUSY_MESSAGE,
+        accessNotice: false,
+        retryable: false,
+      };
+    }
+
+    this.inFlightFiles.add(file);
+    try {
+      return await operation();
+    } finally {
+      this.inFlightFiles.delete(file);
+    }
+  }
+}

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -30,7 +30,7 @@ interface SymposiumClientPort {
 
 interface SymposiumModalPort {
   open(): void;
-  dispose(): void;
+  close(): void;
 }
 
 interface SymposiumPublisherDependencies {
@@ -204,7 +204,7 @@ export class SymposiumPublisher {
   dispose(): void {
     this.disposed = true;
     for (const modal of [...this.modals]) {
-      modal.dispose();
+      modal.close();
     }
     this.modals.clear();
     this.blockedPublishResults.clear();

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -13,7 +13,10 @@ import {
   removeSymposiumDocId,
   saveSymposiumDocId,
 } from "@/symposium/symposiumFrontmatter";
-import { buildSymposiumDocument } from "@/symposium/symposiumDocument";
+import {
+  buildSymposiumDocument,
+  SymposiumDocumentTooLargeError,
+} from "@/symposium/symposiumDocument";
 import type { SymposiumAction, SymposiumDocument, SymposiumReceipt } from "@/symposium/types";
 import { App, Component, TFile } from "obsidian";
 
@@ -25,6 +28,7 @@ interface SymposiumClientPort {
 
 interface SymposiumModalPort {
   open(): void;
+  dispose(): void;
 }
 
 interface SymposiumPublisherDependencies {
@@ -58,6 +62,15 @@ async function buildDocumentWithComponent(
 }
 
 function operationFailure(action: SymposiumAction, error: unknown): SymposiumFailureResult {
+  if (error instanceof SymposiumDocumentTooLargeError) {
+    return {
+      kind: "failure",
+      action,
+      message: error.message,
+      accessNotice: false,
+      retryable: false,
+    };
+  }
   if (error instanceof SymposiumClientError) {
     return {
       kind: "failure",
@@ -77,6 +90,17 @@ function operationFailure(action: SymposiumAction, error: unknown): SymposiumFai
   };
 }
 
+function identityChangedFailure(action: SymposiumAction): SymposiumFailureResult {
+  return {
+    kind: "failure",
+    action,
+    message:
+      "This note's Symposium identity changed. Close and reopen this dialog before trying again.",
+    accessNotice: false,
+    retryable: false,
+  };
+}
+
 /**
  * Coordinates one note's confirmed Symposium action, remote request, and local identity update.
  *
@@ -92,6 +116,8 @@ export class SymposiumPublisher {
   ) => Promise<SymposiumDocument>;
   private readonly createModal: (options: SymposiumModalOptions) => SymposiumModalPort;
   private readonly inFlightFiles = new Set<TFile>();
+  private readonly modals = new Set<SymposiumModalPort>();
+  private disposed = false;
 
   constructor(
     private readonly app: App,
@@ -112,12 +138,38 @@ export class SymposiumPublisher {
    * @param file The Markdown note selected by the invoking command or menu.
    */
   async open(file: TFile): Promise<void> {
-    const docId = getSymposiumDocId(this.app, file);
-    this.createModal({
+    if (this.disposed) {
+      return;
+    }
+    const docId = await getSymposiumDocId(this.app, file);
+    if (this.disposed) {
+      return;
+    }
+    let modal: SymposiumModalPort;
+    modal = this.createModal({
       fileName: file.basename,
       docId,
       onConfirm: (action, ownerDocument) => this.execute(file, docId, action, ownerDocument),
-    }).open();
+      onClosed: () => this.modals.delete(modal),
+    });
+    this.modals.add(modal);
+    try {
+      modal.open();
+    } catch (error) {
+      this.modals.delete(modal);
+      throw error;
+    }
+  }
+
+  /**
+   * Disables stale modal callbacks and closes this publisher's UI during plugin teardown.
+   */
+  dispose(): void {
+    this.disposed = true;
+    for (const modal of [...this.modals]) {
+      modal.dispose();
+    }
+    this.modals.clear();
   }
 
   private async execute(
@@ -127,16 +179,23 @@ export class SymposiumPublisher {
     ownerDocument: Document
   ): Promise<SymposiumModalResult> {
     return this.withFileLock(file, action, async () => {
-      const docId = getSymposiumDocId(this.app, file);
-      if (docId !== expectedDocId) {
+      if (this.disposed) {
         return {
           kind: "failure",
           action,
-          message:
-            "This note's Symposium identity changed. Close and reopen this dialog before trying again.",
+          message: "Symposium publishing is no longer available.",
           accessNotice: false,
           retryable: false,
         };
+      }
+      let docId: string | null;
+      try {
+        docId = await getSymposiumDocId(this.app, file);
+      } catch (error) {
+        return operationFailure(action, error);
+      }
+      if (docId !== expectedDocId) {
+        return identityChangedFailure(action);
       }
 
       let licenseKey: string;
@@ -167,14 +226,20 @@ export class SymposiumPublisher {
 
       try {
         if (action === "delete") {
+          if ((await getSymposiumDocId(this.app, file)) !== docId) {
+            return identityChangedFailure(action);
+          }
           await this.client.delete(docId!, licenseKey);
-          return await this.removeLocalIdentity(file);
+          return await this.removeLocalIdentity(file, docId!);
         }
 
         const document = await this.buildDocument(file, ownerDocument);
+        if ((await getSymposiumDocId(this.app, file)) !== docId) {
+          return identityChangedFailure(action);
+        }
         if (action === "publish") {
           const receipt = await this.client.publish(document, licenseKey);
-          return await this.savePublishedIdentity(file, receipt);
+          return await this.savePublishedIdentity(file, receipt, null);
         }
 
         try {
@@ -190,8 +255,11 @@ export class SymposiumPublisher {
           }
         }
 
+        if ((await getSymposiumDocId(this.app, file)) !== docId) {
+          return identityChangedFailure(action);
+        }
         const receipt = await this.client.publish(document, licenseKey);
-        return await this.savePublishedIdentity(file, receipt);
+        return await this.savePublishedIdentity(file, receipt, docId);
       } catch (error) {
         return operationFailure(action, error);
       }
@@ -200,19 +268,30 @@ export class SymposiumPublisher {
 
   private async savePublishedIdentity(
     file: TFile,
-    receipt: SymposiumReceipt
+    receipt: SymposiumReceipt,
+    expectedDocId: string | null
   ): Promise<SymposiumModalResult> {
     try {
-      await saveSymposiumDocId(this.app, file, receipt.docId);
+      const saved = await saveSymposiumDocId(this.app, file, receipt.docId, expectedDocId);
+      if (!saved) {
+        return {
+          kind: "persistence",
+          action: "publish",
+          message:
+            "The page is public, but this note’s Symposium identity changed while publishing. Its newer identity was left unchanged.",
+          receipt,
+        };
+      }
       return { kind: "success", action: "publish", receipt };
     } catch {
-      return this.publishPersistenceFailure(file, receipt);
+      return this.publishPersistenceFailure(file, receipt, expectedDocId);
     }
   }
 
   private publishPersistenceFailure(
     file: TFile,
-    receipt: SymposiumReceipt
+    receipt: SymposiumReceipt,
+    expectedDocId: string | null
   ): SymposiumPersistenceResult {
     return {
       kind: "persistence",
@@ -221,27 +300,42 @@ export class SymposiumPublisher {
         "The page is already public. Retry saving its document id to this note; this will not publish again.",
       receipt,
       retrySave: () =>
-        this.withFileLock(file, "publish", async () => this.savePublishedIdentity(file, receipt)),
+        this.withFileLock(file, "publish", async () =>
+          this.savePublishedIdentity(file, receipt, expectedDocId)
+        ),
     };
   }
 
-  private async removeLocalIdentity(file: TFile): Promise<SymposiumModalResult> {
+  private async removeLocalIdentity(
+    file: TFile,
+    expectedDocId: string
+  ): Promise<SymposiumModalResult> {
     try {
-      await removeSymposiumDocId(this.app, file);
+      const removed = await removeSymposiumDocId(this.app, file, expectedDocId);
+      if (!removed) {
+        return {
+          kind: "persistence",
+          action: "delete",
+          message:
+            "The original page was withdrawn, but this note now points to a different Symposium document. Its newer identity was left unchanged.",
+        };
+      }
       return { kind: "success", action: "delete" };
     } catch {
-      return this.deletePersistenceFailure(file);
+      return this.deletePersistenceFailure(file, expectedDocId);
     }
   }
 
-  private deletePersistenceFailure(file: TFile): SymposiumPersistenceResult {
+  private deletePersistenceFailure(file: TFile, expectedDocId: string): SymposiumPersistenceResult {
     return {
       kind: "persistence",
       action: "delete",
       message:
         "The public page is already deleted. Retry removing its document id from this note; this will not contact Symposium again.",
       retrySave: () =>
-        this.withFileLock(file, "delete", async () => this.removeLocalIdentity(file)),
+        this.withFileLock(file, "delete", async () =>
+          this.removeLocalIdentity(file, expectedDocId)
+        ),
     };
   }
 

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -244,6 +244,21 @@ export class SymposiumPublisher {
 
         try {
           const receipt = await this.client.update(docId!, document, licenseKey);
+          let identityUnchanged = false;
+          try {
+            identityUnchanged = (await getSymposiumDocId(this.app, file)) === docId;
+          } catch {
+            // Remote success is still partial success when the local identity cannot be verified.
+          }
+          if (!identityUnchanged) {
+            return {
+              kind: "persistence",
+              action: "update",
+              message:
+                "The original page was updated, but this note’s Symposium identity changed or could not be verified. Its current identity was left unchanged.",
+              receipt,
+            };
+          }
           return { kind: "success", action: "update", receipt };
         } catch (error) {
           if (

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -9,6 +9,7 @@ import { getDecryptedKey } from "@/encryptionService";
 import { getSettings } from "@/settings/model";
 import { SymposiumClient, SymposiumClientError } from "@/symposium/SymposiumClient";
 import {
+  SymposiumFrontmatterParseError,
   getSymposiumDocId,
   removeSymposiumDocId,
   saveSymposiumDocId,
@@ -63,7 +64,10 @@ async function buildDocumentWithComponent(
 }
 
 function operationFailure(action: SymposiumAction, error: unknown): SymposiumFailureResult {
-  if (error instanceof SymposiumPropertyConflictError) {
+  if (
+    error instanceof SymposiumFrontmatterParseError ||
+    error instanceof SymposiumPropertyConflictError
+  ) {
     return {
       kind: "failure",
       action,
@@ -126,6 +130,10 @@ export class SymposiumPublisher {
   ) => Promise<SymposiumDocument>;
   private readonly createModal: (options: SymposiumModalOptions) => SymposiumModalPort;
   private readonly inFlightFiles = new Set<TFile>();
+  private readonly blockedPublishResults = new Map<
+    TFile,
+    SymposiumFailureResult | SymposiumPersistenceResult
+  >();
   private readonly modals = new Set<SymposiumModalPort>();
   private disposed = false;
 
@@ -152,26 +160,33 @@ export class SymposiumPublisher {
       return;
     }
     let docId: string | null = null;
-    let propertyConflict: SymposiumPropertyConflictError | null = null;
-    try {
-      docId = await getSymposiumDocId(this.app, file);
-    } catch (error) {
-      if (!(error instanceof SymposiumPropertyConflictError)) {
-        throw error;
+    let initialResult: SymposiumFailureResult | SymposiumPersistenceResult | undefined =
+      this.blockedPublishResults.get(file);
+    if (!initialResult) {
+      try {
+        docId = await getSymposiumDocId(this.app, file);
+      } catch (error) {
+        if (
+          !(error instanceof SymposiumFrontmatterParseError) &&
+          !(error instanceof SymposiumPropertyConflictError)
+        ) {
+          throw error;
+        }
+        initialResult = operationFailure("publish", error);
       }
-      propertyConflict = error;
     }
     if (this.disposed) {
       return;
     }
+    const openingResult = initialResult;
     let modal: SymposiumModalPort;
     modal = this.createModal({
       fileName: file.basename,
       docId,
-      onConfirm: (action, ownerDocument) =>
-        propertyConflict
-          ? Promise.resolve(operationFailure(action, propertyConflict))
-          : this.execute(file, docId, action, ownerDocument),
+      initialResult: openingResult,
+      onConfirm: openingResult
+        ? () => Promise.resolve(openingResult)
+        : (action, ownerDocument) => this.execute(file, docId, action, ownerDocument),
       onClosed: () => this.modals.delete(modal),
     });
     this.modals.add(modal);
@@ -192,6 +207,7 @@ export class SymposiumPublisher {
       modal.dispose();
     }
     this.modals.clear();
+    this.blockedPublishResults.clear();
   }
 
   private async execute(
@@ -298,7 +314,11 @@ export class SymposiumPublisher {
         const receipt = await this.client.publish(document, licenseKey);
         return await this.savePublishedIdentity(file, receipt, docId);
       } catch (error) {
-        return operationFailure(action, error);
+        const failure = operationFailure(action, error);
+        if (error instanceof SymposiumClientError && error.code === "ambiguous_publish") {
+          this.blockedPublishResults.set(file, failure);
+        }
+        return failure;
       }
     });
   }
@@ -311,6 +331,7 @@ export class SymposiumPublisher {
     try {
       const saved = await saveSymposiumDocId(this.app, file, receipt.docId, expectedDocId);
       if (!saved) {
+        this.blockedPublishResults.delete(file);
         return {
           kind: "persistence",
           action: "publish",
@@ -319,6 +340,7 @@ export class SymposiumPublisher {
           receipt,
         };
       }
+      this.blockedPublishResults.delete(file);
       return { kind: "success", action: "publish", receipt };
     } catch {
       return this.publishPersistenceFailure(file, receipt, expectedDocId);
@@ -330,7 +352,7 @@ export class SymposiumPublisher {
     receipt: SymposiumReceipt,
     expectedDocId: string | null
   ): SymposiumPersistenceResult {
-    return {
+    const result: SymposiumPersistenceResult = {
       kind: "persistence",
       action: "publish",
       message:
@@ -341,6 +363,8 @@ export class SymposiumPublisher {
           this.savePublishedIdentity(file, receipt, expectedDocId)
         ),
     };
+    this.blockedPublishResults.set(file, result);
+    return result;
   }
 
   private async removeLocalIdentity(

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -282,20 +282,24 @@ export class SymposiumPublisher {
 
         try {
           const receipt = await this.client.update(docId!, document, licenseKey);
-          let identityUnchanged = false;
+          let currentDocId: string | null | undefined;
           try {
-            identityUnchanged = (await getSymposiumDocId(this.app, file)) === docId;
+            currentDocId = await getSymposiumDocId(this.app, file);
           } catch {
             // Remote success is still partial success when the local identity cannot be verified.
           }
-          if (!identityUnchanged) {
-            return {
+          if (currentDocId !== docId) {
+            const result: SymposiumPersistenceResult = {
               kind: "persistence",
               action: "update",
               message:
                 "The original page was updated, but this note’s Symposium identity changed or could not be verified. Its current identity was left unchanged.",
               receipt,
             };
+            if (!currentDocId) {
+              this.blockedPublishResults.set(file, result);
+            }
+            return result;
           }
           return { kind: "success", action: "update", receipt };
         } catch (error) {

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -12,6 +12,7 @@ import {
   getSymposiumDocId,
   removeSymposiumDocId,
   saveSymposiumDocId,
+  SymposiumPropertyConflictError,
 } from "@/symposium/symposiumFrontmatter";
 import {
   buildSymposiumDocument,
@@ -62,6 +63,15 @@ async function buildDocumentWithComponent(
 }
 
 function operationFailure(action: SymposiumAction, error: unknown): SymposiumFailureResult {
+  if (error instanceof SymposiumPropertyConflictError) {
+    return {
+      kind: "failure",
+      action,
+      message: error.message,
+      accessNotice: false,
+      retryable: false,
+    };
+  }
   if (error instanceof SymposiumDocumentTooLargeError) {
     return {
       kind: "failure",
@@ -141,7 +151,16 @@ export class SymposiumPublisher {
     if (this.disposed) {
       return;
     }
-    const docId = await getSymposiumDocId(this.app, file);
+    let docId: string | null = null;
+    let propertyConflict: SymposiumPropertyConflictError | null = null;
+    try {
+      docId = await getSymposiumDocId(this.app, file);
+    } catch (error) {
+      if (!(error instanceof SymposiumPropertyConflictError)) {
+        throw error;
+      }
+      propertyConflict = error;
+    }
     if (this.disposed) {
       return;
     }
@@ -149,7 +168,10 @@ export class SymposiumPublisher {
     modal = this.createModal({
       fileName: file.basename,
       docId,
-      onConfirm: (action, ownerDocument) => this.execute(file, docId, action, ownerDocument),
+      onConfirm: (action, ownerDocument) =>
+        propertyConflict
+          ? Promise.resolve(operationFailure(action, propertyConflict))
+          : this.execute(file, docId, action, ownerDocument),
       onClosed: () => this.modals.delete(modal),
     });
     this.modals.add(modal);

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -335,14 +335,25 @@ export class SymposiumPublisher {
     try {
       const saved = await saveSymposiumDocId(this.app, file, receipt.docId, expectedDocId);
       if (!saved) {
-        this.blockedPublishResults.delete(file);
-        return {
+        const result: SymposiumPersistenceResult = {
           kind: "persistence",
           action: "publish",
           message:
-            "The page is public, but this note’s Symposium identity changed while publishing. Its newer identity was left unchanged.",
+            "The page is public, but this note’s Symposium identity changed or could not be verified. Its current frontmatter was left unchanged.",
           receipt,
         };
+        let currentDocId: string | null | undefined;
+        try {
+          currentDocId = await getSymposiumDocId(this.app, file);
+        } catch {
+          // A successful POST must stay blocked when no valid identity can route reopen to Update.
+        }
+        if (currentDocId) {
+          this.blockedPublishResults.delete(file);
+        } else {
+          this.blockedPublishResults.set(file, result);
+        }
+        return result;
       }
       this.blockedPublishResults.delete(file);
       return { kind: "success", action: "publish", receipt };

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -226,6 +226,10 @@ export class SymposiumPublisher {
           retryable: false,
         };
       }
+      const blockedResult = this.blockedPublishResults.get(file);
+      if (blockedResult) {
+        return blockedResult;
+      }
       let docId: string | null;
       try {
         docId = await getSymposiumDocId(this.app, file);

--- a/src/symposium/constants.ts
+++ b/src/symposium/constants.ts
@@ -1,0 +1,3 @@
+export const SYMPOSIUM_API_ORIGIN = "https://api.symposium.md";
+export const SYMPOSIUM_DOC_ID_PATTERN = /^[0123456789abcdefghjkmnpqrstvwxyz]{16}$/;
+export const SYMPOSIUM_MAX_HTML_BYTES = 10 * 1024 * 1024;

--- a/src/symposium/obsidianPublishBaseline.test.ts
+++ b/src/symposium/obsidianPublishBaseline.test.ts
@@ -1,0 +1,21 @@
+import { OBSIDIAN_PUBLISH_BASELINE } from "@/symposium/obsidianPublishBaseline";
+
+describe("obsidianPublishBaseline", () => {
+  describe("OBSIDIAN_PUBLISH_BASELINE", () => {
+    it("styles the core reading-view structures used by published notes", () => {
+      expect(OBSIDIAN_PUBLISH_BASELINE).toContain(".markdown-rendered h1");
+      expect(OBSIDIAN_PUBLISH_BASELINE).toContain(".markdown-rendered table");
+      expect(OBSIDIAN_PUBLISH_BASELINE).toContain(".markdown-rendered pre");
+      expect(OBSIDIAN_PUBLISH_BASELINE).toContain(".markdown-rendered .callout");
+      expect(OBSIDIAN_PUBLISH_BASELINE).toContain(".markdown-rendered .markdown-embed");
+      expect(OBSIDIAN_PUBLISH_BASELINE).toContain(".symposium-missing-asset");
+    });
+
+    it("defines a responsive neutral page without depending on Obsidian theme styles", () => {
+      expect(OBSIDIAN_PUBLISH_BASELINE).toContain("--background-primary: #ffffff");
+      expect(OBSIDIAN_PUBLISH_BASELINE).toContain(".publish-renderer");
+      expect(OBSIDIAN_PUBLISH_BASELINE).toContain("@media (max-width: 40rem)");
+      expect(OBSIDIAN_PUBLISH_BASELINE).not.toContain("body.theme-");
+    });
+  });
+});

--- a/src/symposium/obsidianPublishBaseline.ts
+++ b/src/symposium/obsidianPublishBaseline.ts
@@ -1,0 +1,189 @@
+export const OBSIDIAN_PUBLISH_BASELINE = `
+:root {
+  color-scheme: light;
+  --background-primary: #ffffff;
+  --background-secondary: #f6f7f8;
+  --text-normal: #242424;
+  --text-muted: #666666;
+  --text-accent: #5b5fc7;
+  --interactive-accent: #5b5fc7;
+  --background-modifier-border: #d8d8d8;
+  --code-background: #f3f3f3;
+  --callout-color: 91, 95, 199;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--background-primary);
+  color: var(--text-normal);
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 16px;
+  line-height: 1.65;
+}
+
+.publish-renderer {
+  width: min(100% - 2rem, 46rem);
+  margin: 0 auto;
+  padding: 3rem 0 5rem;
+}
+
+.markdown-rendered h1,
+.markdown-rendered h2,
+.markdown-rendered h3,
+.markdown-rendered h4,
+.markdown-rendered h5,
+.markdown-rendered h6 {
+  margin: 1.8em 0 0.6em;
+  line-height: 1.25;
+}
+
+.markdown-rendered h1 {
+  font-size: 2rem;
+}
+
+.markdown-rendered h2 {
+  padding-bottom: 0.2em;
+  border-bottom: 1px solid var(--background-modifier-border);
+  font-size: 1.5rem;
+}
+
+.markdown-rendered h3 {
+  font-size: 1.25rem;
+}
+
+.markdown-rendered p,
+.markdown-rendered ul,
+.markdown-rendered ol,
+.markdown-rendered blockquote,
+.markdown-rendered pre,
+.markdown-rendered table {
+  margin: 1em 0;
+}
+
+.markdown-rendered a {
+  color: var(--text-accent);
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.15em;
+}
+
+.markdown-rendered .internal-link {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--background-modifier-border);
+  text-underline-offset: 0.15em;
+}
+
+.markdown-rendered blockquote {
+  margin-left: 0;
+  padding: 0.1em 1em;
+  border-left: 3px solid var(--background-modifier-border);
+  color: var(--text-muted);
+}
+
+.markdown-rendered code {
+  padding: 0.15em 0.35em;
+  border-radius: 0.25rem;
+  background: var(--code-background);
+  font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  font-size: 0.9em;
+}
+
+.markdown-rendered pre {
+  overflow-x: auto;
+  padding: 1rem;
+  border-radius: 0.4rem;
+  background: var(--code-background);
+}
+
+.markdown-rendered pre code {
+  padding: 0;
+  background: transparent;
+}
+
+.markdown-rendered table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.markdown-rendered th,
+.markdown-rendered td {
+  padding: 0.5rem 0.7rem;
+  border: 1px solid var(--background-modifier-border);
+  text-align: left;
+  vertical-align: top;
+}
+
+.markdown-rendered th {
+  background: var(--background-secondary);
+}
+
+.markdown-rendered img,
+.markdown-rendered svg {
+  max-width: 100%;
+  height: auto;
+}
+
+.markdown-rendered hr {
+  margin: 2rem 0;
+  border: 0;
+  border-top: 1px solid var(--background-modifier-border);
+}
+
+.markdown-rendered .task-list-item {
+  list-style: none;
+}
+
+.markdown-rendered .callout {
+  margin: 1rem 0;
+  padding: 0.8rem 1rem;
+  border: 1px solid rgba(var(--callout-color), 0.35);
+  border-left-width: 4px;
+  border-radius: 0.4rem;
+  background: rgba(var(--callout-color), 0.08);
+}
+
+.markdown-rendered .callout-title {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  font-weight: 650;
+}
+
+.markdown-rendered .callout-content > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-rendered .markdown-embed,
+.markdown-rendered .file-embed {
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 0.4rem;
+  background: var(--background-secondary);
+}
+
+.markdown-rendered mjx-container,
+.markdown-rendered .math {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.symposium-missing-asset {
+  display: inline-block;
+  padding: 0.2rem 0.45rem;
+  border: 1px dashed var(--background-modifier-border);
+  border-radius: 0.25rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 40rem) {
+  .publish-renderer {
+    width: min(100% - 1.25rem, 46rem);
+    padding-top: 1.5rem;
+  }
+}
+`.trim();

--- a/src/symposium/obsidianPublishBaseline.ts
+++ b/src/symposium/obsidianPublishBaseline.ts
@@ -137,6 +137,12 @@ body {
   list-style: none;
 }
 
+.symposium-task-marker {
+  display: inline-block;
+  width: 1.4em;
+  margin-left: -1.4em;
+}
+
 .markdown-rendered .callout {
   margin: 1rem 0;
   padding: 0.8rem 1rem;
@@ -166,7 +172,7 @@ body {
   background: var(--background-secondary);
 }
 
-.markdown-rendered mjx-container,
+.markdown-rendered math[display="block"],
 .markdown-rendered .math {
   max-width: 100%;
   overflow-x: auto;

--- a/src/symposium/symposiumDocument.test.ts
+++ b/src/symposium/symposiumDocument.test.ts
@@ -340,6 +340,34 @@ describe("symposiumDocument", () => {
       expect(app.vault.readBinary).not.toHaveBeenCalled();
     });
 
+    it("budgets the embedded image replacement delta instead of removed source markup", async () => {
+      const longPath = `Assets/${"a".repeat(16_000)}.png`;
+      const dataUrlBudget = SYMPOSIUM_MAX_HTML_BYTES - 10_000;
+      const imageSize = Math.floor(((dataUrlBudget - "data:image/png;base64,".length) * 3) / 4);
+      const image = createFile(longPath, undefined, imageSize);
+      const bytes = new Uint8Array(imageSize);
+      bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const app = createApp({
+        files: [image],
+        resolveLink: (link) => (link === longPath ? image : null),
+        readBinary: async () => bytes.buffer,
+      });
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        appendHtml(element, `<img alt="Near limit" data-path="${longPath}" src="local.png">`);
+      });
+
+      const result = await buildSymposiumDocument(
+        app,
+        createFile("Images.md"),
+        createComponent(),
+        document
+      );
+
+      expect(result.byteLength).toBeLessThanOrEqual(SYMPOSIUM_MAX_HTML_BYTES);
+      expect(result.html).not.toContain(longPath);
+      expect(app.vault.readBinary).toHaveBeenCalledTimes(1);
+    });
+
     it("reports the UTF-8 byte length for non-ASCII titles and rendered content", async () => {
       const app = createApp();
       const file = createFile("Notes/Résumé 🚀.md");

--- a/src/symposium/symposiumDocument.test.ts
+++ b/src/symposium/symposiumDocument.test.ts
@@ -48,7 +48,7 @@ function createApp(options: AppOptions = {}): App {
   const files = options.files ?? [];
   return {
     vault: {
-      cachedRead: jest.fn().mockResolvedValue(options.markdown ?? "# Source Markdown"),
+      read: jest.fn().mockResolvedValue(options.markdown ?? "# Source Markdown"),
       getFiles: jest.fn(() => files),
       getResourcePath: jest.fn((file: TestFile) => file.resourceUrl ?? `app://vault/${file.path}`),
       readBinary: jest.fn(options.readBinary ?? (async () => new ArrayBuffer(0))),
@@ -109,6 +109,7 @@ describe("symposiumDocument", () => {
         file.path,
         component
       );
+      expect(app.vault.read).toHaveBeenCalledWith(file);
       expect(result.title).toBe("Rendered note");
       expect(result.html).toMatch(/^<!doctype html><html lang="en"><head>/);
       expect(result.html).toContain('<meta charset="utf-8">');

--- a/src/symposium/symposiumDocument.test.ts
+++ b/src/symposium/symposiumDocument.test.ts
@@ -143,6 +143,7 @@ describe("symposiumDocument", () => {
           <a id="scheme-relative-link" href="//docs.example.com/guide">Docs</a>
           <a class="internal-link is-unresolved" data-href="Private note" href="Private note">Private</a>
           <img id="remote-image" src="https://tracker.example/pixel" referrerpolicy="unsafe-url">
+          <img id="scheme-relative-image" src="//cdn.example.com/image.png">
           <svg><a id="bad-svg-link" href="data:text/html,bad"><text>SVG</text></a></svg>
         `
         );
@@ -168,6 +169,12 @@ describe("symposiumDocument", () => {
         "//docs.example.com/guide"
       );
       expect(parsed.querySelector("#remote-image")?.getAttribute("referrerpolicy")).toBe(
+        "no-referrer"
+      );
+      expect(parsed.querySelector("#scheme-relative-image")?.getAttribute("src")).toBe(
+        "//cdn.example.com/image.png"
+      );
+      expect(parsed.querySelector("#scheme-relative-image")?.getAttribute("referrerpolicy")).toBe(
         "no-referrer"
       );
       expect(parsed.querySelector("a.internal-link")).toBeNull();
@@ -313,6 +320,24 @@ describe("symposiumDocument", () => {
         buildSymposiumDocument(app, createFile("Images.md"), createComponent(), document)
       ).rejects.toBeInstanceOf(SymposiumDocumentTooLargeError);
       expect(app.vault.readBinary).toHaveBeenCalledTimes(1);
+    });
+
+    it("reserves rendered HTML before loading an image that would exceed the combined budget", async () => {
+      const image = createFile(
+        "Assets/large.png",
+        undefined,
+        Math.floor((SYMPOSIUM_MAX_HTML_BYTES * 3) / 8)
+      );
+      const app = createApp({ files: [image] });
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        element.append("x".repeat(Math.floor(SYMPOSIUM_MAX_HTML_BYTES / 2)));
+        appendHtml(element, '<img alt="Large" src="Assets/large.png">');
+      });
+
+      await expect(
+        buildSymposiumDocument(app, createFile("Images.md"), createComponent(), document)
+      ).rejects.toBeInstanceOf(SymposiumDocumentTooLargeError);
+      expect(app.vault.readBinary).not.toHaveBeenCalled();
     });
 
     it("reports the UTF-8 byte length for non-ASCII titles and rendered content", async () => {

--- a/src/symposium/symposiumDocument.test.ts
+++ b/src/symposium/symposiumDocument.test.ts
@@ -140,6 +140,7 @@ describe("symposiumDocument", () => {
           <p id="safe" style="background:url(javascript:alert(1))" onclick="alert(1)">Text</p>
           <a id="bad-link" href="javascript:alert(1)">Bad</a>
           <a id="safe-link" href="https://example.com" ping="https://tracker.example" referrerpolicy="unsafe-url" target="_blank">External</a>
+          <a id="named-target-link" href="https://example.com/preview" target="preview" rel="opener">Preview</a>
           <a id="scheme-relative-link" href="//docs.example.com/guide">Docs</a>
           <a class="internal-link is-unresolved" data-href="Private note" href="Private note">Private</a>
           <img id="remote-image" src="https://tracker.example/pixel" referrerpolicy="unsafe-url">
@@ -165,6 +166,10 @@ describe("symposiumDocument", () => {
       expect(parsed.querySelector("#safe-link")?.hasAttribute("ping")).toBe(false);
       expect(parsed.querySelector("#safe-link")?.getAttribute("rel")).toBe("noopener noreferrer");
       expect(parsed.querySelector("#safe-link")?.hasAttribute("referrerpolicy")).toBe(false);
+      expect(parsed.querySelector("#named-target-link")?.getAttribute("target")).toBe("preview");
+      expect(parsed.querySelector("#named-target-link")?.getAttribute("rel")).toBe(
+        "noopener noreferrer"
+      );
       expect(parsed.querySelector("#scheme-relative-link")?.getAttribute("href")).toBe(
         "//docs.example.com/guide"
       );

--- a/src/symposium/symposiumDocument.test.ts
+++ b/src/symposium/symposiumDocument.test.ts
@@ -1,5 +1,9 @@
 /* eslint-disable obsidianmd/prefer-active-doc -- jsdom tests explicitly pass their single document realm */
-import { buildSymposiumDocument, SYMPOSIUM_MAX_HTML_BYTES } from "@/symposium/symposiumDocument";
+import {
+  buildSymposiumDocument,
+  SYMPOSIUM_MAX_HTML_BYTES,
+  SymposiumDocumentTooLargeError,
+} from "@/symposium/symposiumDocument";
 import { App, Component, MarkdownRenderer, TFile } from "obsidian";
 
 jest.mock("obsidian", () => ({
@@ -72,6 +76,17 @@ describe("symposiumDocument", () => {
     renderMock.mockReset();
   });
 
+  describe("SymposiumDocumentTooLargeError", () => {
+    describe("constructor()", () => {
+      it("retains the measured byte length", () => {
+        const error = new SymposiumDocumentTooLargeError(SYMPOSIUM_MAX_HTML_BYTES + 1);
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.byteLength).toBe(SYMPOSIUM_MAX_HTML_BYTES + 1);
+      });
+    });
+  });
+
   describe("buildSymposiumDocument()", () => {
     it("serializes the settled Obsidian reading-view output as a complete HTML document", async () => {
       const app = createApp({ markdown: "# Markdown that must not be reparsed" });
@@ -106,6 +121,7 @@ describe("symposiumDocument", () => {
       );
       expect(result.html).not.toContain("# Markdown that must not be reparsed");
       expect(result.byteLength).toBe(new TextEncoder().encode(result.html).byteLength);
+      expect(app.vault.getFiles).not.toHaveBeenCalled();
     });
 
     it("removes active content and dangerous attributes while retaining safe external links", async () => {
@@ -121,8 +137,9 @@ describe("symposiumDocument", () => {
           <form><input value="secret"></form>
           <p id="safe" style="background:url(javascript:alert(1))" onclick="alert(1)">Text</p>
           <a id="bad-link" href="javascript:alert(1)">Bad</a>
-          <a id="safe-link" href="https://example.com" ping="https://tracker.example" target="_blank">External</a>
+          <a id="safe-link" href="https://example.com" ping="https://tracker.example" referrerpolicy="unsafe-url" target="_blank">External</a>
           <a class="internal-link is-unresolved" data-href="Private note" href="Private note">Private</a>
+          <img id="remote-image" src="https://tracker.example/pixel" referrerpolicy="unsafe-url">
           <svg><a id="bad-svg-link" href="data:text/html,bad"><text>SVG</text></a></svg>
         `
         );
@@ -143,11 +160,50 @@ describe("symposiumDocument", () => {
       expect(parsed.querySelector("#safe-link")?.getAttribute("href")).toBe("https://example.com");
       expect(parsed.querySelector("#safe-link")?.hasAttribute("ping")).toBe(false);
       expect(parsed.querySelector("#safe-link")?.getAttribute("rel")).toBe("noopener noreferrer");
+      expect(parsed.querySelector("#safe-link")?.hasAttribute("referrerpolicy")).toBe(false);
+      expect(parsed.querySelector("#remote-image")?.getAttribute("referrerpolicy")).toBe(
+        "no-referrer"
+      );
       expect(parsed.querySelector("a.internal-link")).toBeNull();
       expect(parsed.querySelector("span.internal-link")?.textContent).toBe("Private");
       expect(parsed.querySelector("span.internal-link")?.classList.contains("is-unresolved")).toBe(
         false
       );
+      expect(app.vault.getFiles).not.toHaveBeenCalled();
+    });
+
+    it("keeps rendered math and task state without Obsidian runtime resources", async () => {
+      const app = createApp();
+      const file = createFile("Math and tasks.md");
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        appendHtml(
+          element,
+          `
+          <mjx-container class="MathJax" jax="CHTML" display="true">
+            <mjx-math><mjx-mi><mjx-c class="mjx-c1D465"></mjx-c></mjx-mi></mjx-math>
+            <mjx-assistive-mml>
+              <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+                <mi>x</mi>
+              </math>
+            </mjx-assistive-mml>
+          </mjx-container>
+          <ul class="contains-task-list">
+            <li class="task-list-item"><input class="task-list-item-checkbox" type="checkbox">Open</li>
+            <li class="task-list-item"><input class="task-list-item-checkbox" type="checkbox" checked>Done</li>
+          </ul>
+        `
+        );
+      });
+
+      const result = await buildSymposiumDocument(app, file, createComponent(), document);
+      const parsed = new DOMParser().parseFromString(result.html, "text/html");
+
+      expect(parsed.querySelector("mjx-container")).toBeNull();
+      expect(parsed.querySelector("math")?.textContent?.trim()).toBe("x");
+      expect(
+        [...parsed.querySelectorAll(".symposium-task-marker")].map((marker) => marker.textContent)
+      ).toEqual(["☐", "☑"]);
+      expect(parsed.querySelector("input")).toBeNull();
     });
 
     it("embeds vault images with content-derived MIME types and leaves remote images remote", async () => {

--- a/src/symposium/symposiumDocument.test.ts
+++ b/src/symposium/symposiumDocument.test.ts
@@ -1,0 +1,250 @@
+/* eslint-disable obsidianmd/prefer-active-doc -- jsdom tests explicitly pass their single document realm */
+import { buildSymposiumDocument, SYMPOSIUM_MAX_HTML_BYTES } from "@/symposium/symposiumDocument";
+import { App, Component, MarkdownRenderer, TFile } from "obsidian";
+
+jest.mock("obsidian", () => ({
+  MarkdownRenderer: { render: jest.fn() },
+}));
+
+const renderMock = (MarkdownRenderer as unknown as { render: jest.Mock })
+  .render as jest.MockedFunction<
+  (
+    app: App,
+    markdown: string,
+    el: HTMLElement,
+    sourcePath: string,
+    component: Component
+  ) => Promise<void>
+>;
+
+interface TestFile extends TFile {
+  resourceUrl?: string;
+}
+
+interface AppOptions {
+  markdown?: string;
+  files?: TestFile[];
+  readBinary?: (file: TFile) => Promise<ArrayBuffer>;
+  resolveLink?: (link: string, sourcePath: string) => TFile | null;
+}
+
+function createFile(path: string, resourceUrl?: string): TestFile {
+  const name = path.split("/").at(-1) ?? path;
+  const extension = name.includes(".") ? (name.split(".").at(-1) ?? "") : "";
+  return {
+    path,
+    name,
+    basename: extension ? name.slice(0, -(extension.length + 1)) : name,
+    extension,
+    resourceUrl,
+  } as TestFile;
+}
+
+function createApp(options: AppOptions = {}): App {
+  const files = options.files ?? [];
+  return {
+    vault: {
+      cachedRead: jest.fn().mockResolvedValue(options.markdown ?? "# Source Markdown"),
+      getFiles: jest.fn(() => files),
+      getResourcePath: jest.fn((file: TestFile) => file.resourceUrl ?? `app://vault/${file.path}`),
+      readBinary: jest.fn(options.readBinary ?? (async () => new ArrayBuffer(0))),
+      getAbstractFileByPath: jest.fn(
+        (path: string) => files.find((file) => file.path === path) ?? null
+      ),
+    },
+    metadataCache: {
+      getFirstLinkpathDest: jest.fn(options.resolveLink ?? (() => null)),
+    },
+  } as unknown as App;
+}
+
+function createComponent(): Component {
+  return { register: jest.fn() } as unknown as Component;
+}
+
+function appendHtml(element: HTMLElement, html: string): void {
+  const parsed = new DOMParser().parseFromString(html, "text/html");
+  element.append(...parsed.body.childNodes);
+}
+
+describe("symposiumDocument", () => {
+  beforeEach(() => {
+    renderMock.mockReset();
+  });
+
+  describe("buildSymposiumDocument()", () => {
+    it("serializes the settled Obsidian reading-view output as a complete HTML document", async () => {
+      const app = createApp({ markdown: "# Markdown that must not be reparsed" });
+      const file = createFile("Notes/Rendered note.md");
+      const component = createComponent();
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        await Promise.resolve();
+        appendHtml(
+          element,
+          '<section class="callout" data-callout="info"><p>Postprocessed output</p></section>'
+        );
+      });
+
+      const result = await buildSymposiumDocument(app, file, component, document);
+
+      expect(renderMock).toHaveBeenCalledWith(
+        app,
+        "# Markdown that must not be reparsed",
+        expect.any(HTMLElement),
+        file.path,
+        component
+      );
+      expect(result.title).toBe("Rendered note");
+      expect(result.html).toMatch(/^<!doctype html><html lang="en"><head>/);
+      expect(result.html).toContain('<meta charset="utf-8">');
+      expect(result.html).toContain("<title>Rendered note</title>");
+      expect(result.html).toContain(
+        '<article class="markdown-preview-view markdown-rendered symposium-document">'
+      );
+      expect(result.html).toContain(
+        '<section class="callout" data-callout="info"><p>Postprocessed output</p></section>'
+      );
+      expect(result.html).not.toContain("# Markdown that must not be reparsed");
+      expect(result.byteLength).toBe(new TextEncoder().encode(result.html).byteLength);
+    });
+
+    it("removes active content and dangerous attributes while retaining safe external links", async () => {
+      const app = createApp();
+      const file = createFile("Unsafe.md");
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        appendHtml(
+          element,
+          `
+          <script>alert("x")</script>
+          <style>body { display: none }</style>
+          <iframe src="https://tracker.example"></iframe>
+          <form><input value="secret"></form>
+          <p id="safe" style="background:url(javascript:alert(1))" onclick="alert(1)">Text</p>
+          <a id="bad-link" href="javascript:alert(1)">Bad</a>
+          <a id="safe-link" href="https://example.com" ping="https://tracker.example" target="_blank">External</a>
+          <a class="internal-link is-unresolved" data-href="Private note" href="Private note">Private</a>
+          <svg><a id="bad-svg-link" href="data:text/html,bad"><text>SVG</text></a></svg>
+        `
+        );
+      });
+
+      const result = await buildSymposiumDocument(app, file, createComponent(), document);
+      const parsed = new DOMParser().parseFromString(result.html, "text/html");
+
+      expect(
+        parsed.querySelector(
+          "script, style:not(#symposium-obsidian-publish-baseline), iframe, form"
+        )
+      ).toBeNull();
+      expect(parsed.querySelector("#safe")?.hasAttribute("style")).toBe(false);
+      expect(parsed.querySelector("#safe")?.hasAttribute("onclick")).toBe(false);
+      expect(parsed.querySelector("#bad-link")?.hasAttribute("href")).toBe(false);
+      expect(parsed.querySelector("#bad-svg-link")?.hasAttribute("href")).toBe(false);
+      expect(parsed.querySelector("#safe-link")?.getAttribute("href")).toBe("https://example.com");
+      expect(parsed.querySelector("#safe-link")?.hasAttribute("ping")).toBe(false);
+      expect(parsed.querySelector("#safe-link")?.getAttribute("rel")).toBe("noopener noreferrer");
+      expect(parsed.querySelector("a.internal-link")).toBeNull();
+      expect(parsed.querySelector("span.internal-link")?.textContent).toBe("Private");
+      expect(parsed.querySelector("span.internal-link")?.classList.contains("is-unresolved")).toBe(
+        false
+      );
+    });
+
+    it("embeds vault images with content-derived MIME types and leaves remote images remote", async () => {
+      const png = createFile("Assets/chart.bin", "app://vault-resource/chart");
+      const jpeg = createFile("Assets/photo.jpeg");
+      const corrupt = createFile("Assets/corrupt.png");
+      const app = createApp({
+        files: [png, jpeg, corrupt],
+        resolveLink: (link) => (link === "Assets/photo.jpeg" ? jpeg : null),
+        readBinary: async (file) => {
+          if (file.path === png.path) {
+            return new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).buffer;
+          }
+          if (file.path === jpeg.path) {
+            return new Uint8Array([0xff, 0xd8, 0xff, 0xdb]).buffer;
+          }
+          return new TextEncoder().encode("not an image").buffer as ArrayBuffer;
+        },
+      });
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        appendHtml(
+          element,
+          `
+          <img id="resource" alt="Chart" src="app://vault-resource/chart">
+          <img id="linked" alt="Photo" data-path="Assets/photo.jpeg" src="Assets/photo.jpeg">
+          <img id="remote" alt="Remote" src="https://images.example/image.png">
+          <img id="embedded" alt="Embedded" src="data:image/gif;base64,R0lGODlh">
+          <img id="corrupt" alt="Corrupt image" data-path="Assets/corrupt.png" src="Assets/corrupt.png">
+          <img id="missing" alt="Missing diagram" src="Assets/missing.png">
+        `
+        );
+      });
+
+      const result = await buildSymposiumDocument(
+        app,
+        createFile("Notes/Images.md"),
+        createComponent(),
+        document
+      );
+      const parsed = new DOMParser().parseFromString(result.html, "text/html");
+
+      expect(parsed.querySelector<HTMLImageElement>("#resource")?.src).toBe(
+        "data:image/png;base64,iVBORw0KGgo="
+      );
+      expect(parsed.querySelector<HTMLImageElement>("#linked")?.src).toBe(
+        "data:image/jpeg;base64,/9j/2w=="
+      );
+      expect(parsed.querySelector("#linked")?.hasAttribute("data-path")).toBe(false);
+      expect(parsed.querySelector<HTMLImageElement>("#remote")?.getAttribute("src")).toBe(
+        "https://images.example/image.png"
+      );
+      expect(parsed.querySelector<HTMLImageElement>("#embedded")?.getAttribute("src")).toBe(
+        "data:image/gif;base64,R0lGODlh"
+      );
+      expect(parsed.querySelector("#corrupt")).toBeNull();
+      expect(parsed.querySelector(".symposium-missing-asset")?.textContent).toBe(
+        "[Missing image: Corrupt image]"
+      );
+      expect(parsed.querySelector("#missing")).toBeNull();
+      expect(parsed.querySelectorAll(".symposium-missing-asset")[1]?.textContent).toBe(
+        "[Missing image: Missing diagram]"
+      );
+      expect(app.vault.readBinary).toHaveBeenCalledTimes(3);
+    });
+
+    it("reports the UTF-8 byte length for non-ASCII titles and rendered content", async () => {
+      const app = createApp();
+      const file = createFile("Notes/Résumé 🚀.md");
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        element.textContent = "你好 🌍";
+      });
+
+      const result = await buildSymposiumDocument(app, file, createComponent(), document);
+
+      expect(result.title).toBe("Résumé 🚀");
+      expect(result.byteLength).toBe(new TextEncoder().encode(result.html).byteLength);
+      expect(result.byteLength).toBeGreaterThan(result.html.length);
+    });
+
+    it("accepts exactly 10 MiB of final HTML and rejects one additional byte", async () => {
+      const app = createApp();
+      const file = createFile("Boundary.md");
+      let renderedText = "";
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        element.textContent = renderedText;
+      });
+
+      const empty = await buildSymposiumDocument(app, file, createComponent(), document);
+      renderedText = "x".repeat(SYMPOSIUM_MAX_HTML_BYTES - empty.byteLength);
+      const exact = await buildSymposiumDocument(app, file, createComponent(), document);
+
+      expect(exact.byteLength).toBe(SYMPOSIUM_MAX_HTML_BYTES);
+
+      renderedText += "x";
+      await expect(buildSymposiumDocument(app, file, createComponent(), document)).rejects.toThrow(
+        `Symposium HTML is ${SYMPOSIUM_MAX_HTML_BYTES + 1} bytes; the limit is ${SYMPOSIUM_MAX_HTML_BYTES} bytes.`
+      );
+    });
+  });
+});

--- a/src/symposium/symposiumDocument.test.ts
+++ b/src/symposium/symposiumDocument.test.ts
@@ -140,6 +140,7 @@ describe("symposiumDocument", () => {
           <p id="safe" style="background:url(javascript:alert(1))" onclick="alert(1)">Text</p>
           <a id="bad-link" href="javascript:alert(1)">Bad</a>
           <a id="safe-link" href="https://example.com" ping="https://tracker.example" referrerpolicy="unsafe-url" target="_blank">External</a>
+          <a id="scheme-relative-link" href="//docs.example.com/guide">Docs</a>
           <a class="internal-link is-unresolved" data-href="Private note" href="Private note">Private</a>
           <img id="remote-image" src="https://tracker.example/pixel" referrerpolicy="unsafe-url">
           <svg><a id="bad-svg-link" href="data:text/html,bad"><text>SVG</text></a></svg>
@@ -163,6 +164,9 @@ describe("symposiumDocument", () => {
       expect(parsed.querySelector("#safe-link")?.hasAttribute("ping")).toBe(false);
       expect(parsed.querySelector("#safe-link")?.getAttribute("rel")).toBe("noopener noreferrer");
       expect(parsed.querySelector("#safe-link")?.hasAttribute("referrerpolicy")).toBe(false);
+      expect(parsed.querySelector("#scheme-relative-link")?.getAttribute("href")).toBe(
+        "//docs.example.com/guide"
+      );
       expect(parsed.querySelector("#remote-image")?.getAttribute("referrerpolicy")).toBe(
         "no-referrer"
       );

--- a/src/symposium/symposiumDocument.test.ts
+++ b/src/symposium/symposiumDocument.test.ts
@@ -32,7 +32,7 @@ interface AppOptions {
   resolveLink?: (link: string, sourcePath: string) => TFile | null;
 }
 
-function createFile(path: string, resourceUrl?: string): TestFile {
+function createFile(path: string, resourceUrl?: string, size = 0): TestFile {
   const name = path.split("/").at(-1) ?? path;
   const extension = name.includes(".") ? (name.split(".").at(-1) ?? "") : "";
   return {
@@ -41,6 +41,7 @@ function createFile(path: string, resourceUrl?: string): TestFile {
     basename: extension ? name.slice(0, -(extension.length + 1)) : name,
     extension,
     resourceUrl,
+    stat: { ctime: 0, mtime: 0, size },
   } as TestFile;
 }
 
@@ -268,6 +269,46 @@ describe("symposiumDocument", () => {
         "[Missing image: Missing diagram]"
       );
       expect(app.vault.readBinary).toHaveBeenCalledTimes(3);
+    });
+
+    it("rejects an oversized local image before loading its binary", async () => {
+      const oversized = createFile(
+        "Assets/oversized.png",
+        undefined,
+        Math.floor((SYMPOSIUM_MAX_HTML_BYTES * 3) / 4) + 1
+      );
+      const app = createApp({ files: [oversized] });
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        appendHtml(element, '<img alt="Oversized" src="Assets/oversized.png">');
+      });
+
+      await expect(
+        buildSymposiumDocument(app, createFile("Images.md"), createComponent(), document)
+      ).rejects.toBeInstanceOf(SymposiumDocumentTooLargeError);
+      expect(app.vault.readBinary).not.toHaveBeenCalled();
+    });
+
+    it("rejects cumulative local image data before loading the image that exceeds the budget", async () => {
+      const imageSize = Math.floor((SYMPOSIUM_MAX_HTML_BYTES * 3) / 8);
+      const first = createFile("Assets/first.png", undefined, imageSize);
+      const second = createFile("Assets/second.png", undefined, imageSize);
+      const bytes = new Uint8Array(imageSize);
+      bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      const app = createApp({
+        files: [first, second],
+        readBinary: async () => bytes.buffer,
+      });
+      renderMock.mockImplementation(async (_app, _markdown, element) => {
+        appendHtml(
+          element,
+          '<img alt="First" src="Assets/first.png"><img alt="Second" src="Assets/second.png">'
+        );
+      });
+
+      await expect(
+        buildSymposiumDocument(app, createFile("Images.md"), createComponent(), document)
+      ).rejects.toBeInstanceOf(SymposiumDocumentTooLargeError);
+      expect(app.vault.readBinary).toHaveBeenCalledTimes(1);
     });
 
     it("reports the UTF-8 byte length for non-ASCII titles and rendered content", async () => {

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -416,7 +416,7 @@ function sanitizeAttributes(root: HTMLElement): void {
       }
     }
 
-    if (element.tagName === "A" && element.getAttribute("target") === "_blank") {
+    if (element.tagName === "A" && element.hasAttribute("target")) {
       element.setAttribute("rel", "noopener noreferrer");
     }
     if (

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -1,0 +1,383 @@
+import { OBSIDIAN_PUBLISH_BASELINE } from "@/symposium/obsidianPublishBaseline";
+import { SymposiumDocument } from "@/symposium/types";
+import { arrayBufferToBase64 } from "@/utils/base64";
+import { App, Component, MarkdownRenderer, TFile } from "obsidian";
+
+export const SYMPOSIUM_MAX_HTML_BYTES = 10 * 1024 * 1024;
+
+const ACTIVE_CONTENT_SELECTOR = [
+  "base",
+  "button",
+  "embed",
+  "form",
+  "iframe",
+  "input",
+  "link",
+  "meta",
+  "object",
+  "script",
+  "select",
+  "style",
+  "template",
+  "textarea",
+  "video",
+  "audio",
+  "applet",
+  "dialog",
+  "frame",
+  "frameset",
+  "fencedframe",
+  "foreignObject",
+  "animate",
+  "animateMotion",
+  "animateTransform",
+  "set",
+  ".collapse-indicator",
+  ".copy-code-button",
+  ".edit-block-button",
+  ".heading-collapse-indicator",
+  ".markdown-embed-link",
+].join(",");
+
+const URL_ATTRIBUTES = new Set([
+  "action",
+  "background",
+  "cite",
+  "formaction",
+  "href",
+  "poster",
+  "ping",
+  "src",
+  "xlink:href",
+]);
+
+type ModernRender = (
+  app: App,
+  markdown: string,
+  el: HTMLElement,
+  sourcePath: string,
+  component: Component
+) => Promise<void>;
+
+/**
+ * Builds the exact HTML payload sent to Symposium from Obsidian's settled reading-view DOM.
+ *
+ * @param app The Obsidian application that owns the source vault and renderer.
+ * @param file The Markdown file whose current vault contents should be published.
+ * @param component The lifecycle owner used by Obsidian's renderer and postprocessors.
+ * @param ownerDocument The window-specific document in which the detached render tree is built.
+ */
+export async function buildSymposiumDocument(
+  app: App,
+  file: TFile,
+  component: Component,
+  ownerDocument: Document
+): Promise<SymposiumDocument> {
+  const markdown = await app.vault.cachedRead(file);
+  const article = ownerDocument.createElement("article");
+  article.className = "markdown-preview-view markdown-rendered symposium-document";
+
+  const render = (MarkdownRenderer as unknown as { render: ModernRender }).render;
+  await render(app, markdown, article, file.path, component);
+
+  removeActiveContent(article);
+  normalizeInternalLinks(article);
+  await embedVaultImages(article, app, file.path);
+  sanitizeAttributes(article);
+
+  const title = file.basename;
+  const html = serializeDocument(ownerDocument, title, article);
+  const byteLength = new TextEncoder().encode(html).byteLength;
+  if (byteLength > SYMPOSIUM_MAX_HTML_BYTES) {
+    throw new Error(
+      `Symposium HTML is ${byteLength} bytes; the limit is ${SYMPOSIUM_MAX_HTML_BYTES} bytes.`
+    );
+  }
+
+  return { title, html, byteLength };
+}
+
+function removeActiveContent(root: HTMLElement): void {
+  root.querySelectorAll(ACTIVE_CONTENT_SELECTOR).forEach((element) => element.remove());
+}
+
+function normalizeInternalLinks(root: HTMLElement): void {
+  root.querySelectorAll<HTMLAnchorElement>("a.internal-link").forEach((link) => {
+    const replacement = root.doc.createElement("span");
+    replacement.className = [...link.classList]
+      .filter((name) => name !== "is-unresolved")
+      .join(" ");
+    if (!replacement.classList.contains("internal-link")) {
+      replacement.classList.add("internal-link");
+    }
+    if (link.title) {
+      replacement.title = link.title;
+    }
+    replacement.append(...link.childNodes);
+    link.replaceWith(replacement);
+  });
+}
+
+async function embedVaultImages(root: HTMLElement, app: App, sourcePath: string): Promise<void> {
+  const lookup = buildVaultFileLookup(app);
+  for (const image of root.querySelectorAll<HTMLImageElement>("img")) {
+    const source = image.getAttribute("src")?.trim() ?? "";
+    if (isRemoteImageSource(source) || isEmbeddedImageSource(source)) {
+      continue;
+    }
+
+    const file = resolveVaultImage(image, app, sourcePath, lookup);
+    if (!file) {
+      replaceMissingImage(image, source);
+      continue;
+    }
+
+    try {
+      const bytes = await app.vault.readBinary(file);
+      const mimeType = detectImageMimeType(bytes);
+      if (!mimeType) {
+        replaceMissingImage(image, file.path);
+        continue;
+      }
+      image.src = `data:${mimeType};base64,${arrayBufferToBase64(bytes)}`;
+      image.removeAttribute("data-path");
+      image.removeAttribute("data-src");
+    } catch {
+      replaceMissingImage(image, file.path);
+    }
+  }
+}
+
+function buildVaultFileLookup(app: App): Map<string, TFile> {
+  const byResourceUrl = new Map<string, TFile>();
+  for (const file of app.vault.getFiles()) {
+    byResourceUrl.set(app.vault.getResourcePath(file), file);
+  }
+  return byResourceUrl;
+}
+
+function resolveVaultImage(
+  image: HTMLImageElement,
+  app: App,
+  sourcePath: string,
+  lookup: Map<string, TFile>
+): TFile | null {
+  const references = [
+    image.getAttribute("data-path"),
+    image.getAttribute("data-src"),
+    image.getAttribute("src"),
+  ];
+
+  for (const reference of references) {
+    if (!reference) {
+      continue;
+    }
+
+    const resourceFile = lookup.get(reference);
+    if (resourceFile) {
+      return resourceFile;
+    }
+
+    const decoded = decodeUrlComponent(reference);
+    if (hasUrlScheme(decoded)) {
+      continue;
+    }
+    const linkPath = decoded.replace(/^\/+/, "").split(/[?#]/, 1)[0];
+    const resolved = app.metadataCache.getFirstLinkpathDest(linkPath, sourcePath);
+    if (resolved) {
+      return resolved;
+    }
+    const direct = app.vault.getAbstractFileByPath(linkPath);
+    if (isTFile(direct)) {
+      return direct;
+    }
+  }
+
+  return null;
+}
+
+function isTFile(value: unknown): value is TFile {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Partial<TFile>;
+  return (
+    typeof candidate.path === "string" &&
+    typeof candidate.basename === "string" &&
+    typeof candidate.extension === "string"
+  );
+}
+
+function detectImageMimeType(bytes: ArrayBuffer): string | null {
+  const header = new Uint8Array(bytes, 0, Math.min(bytes.byteLength, 512));
+  if (startsWithBytes(header, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return "image/png";
+  }
+  if (startsWithBytes(header, [0xff, 0xd8, 0xff])) {
+    return "image/jpeg";
+  }
+  if (startsWithAscii(header, "GIF87a") || startsWithAscii(header, "GIF89a")) {
+    return "image/gif";
+  }
+  if (startsWithAscii(header, "BM")) {
+    return "image/bmp";
+  }
+  if (startsWithAscii(header, "RIFF") && asciiAt(header, 8, "WEBP")) {
+    return "image/webp";
+  }
+  if (startsWithBytes(header, [0x00, 0x00, 0x01, 0x00])) {
+    return "image/x-icon";
+  }
+  if (
+    startsWithBytes(header, [0x49, 0x49, 0x2a, 0x00]) ||
+    startsWithBytes(header, [0x4d, 0x4d, 0x00, 0x2a])
+  ) {
+    return "image/tiff";
+  }
+  if (hasIsoMediaBrand(header, ["avif", "avis"])) {
+    return "image/avif";
+  }
+  if (hasIsoMediaBrand(header, ["heic", "heix", "hevc", "hevx", "heim", "heis", "hevm", "hevs"])) {
+    return "image/heic";
+  }
+  if (hasIsoMediaBrand(header, ["mif1", "msf1"])) {
+    return "image/heif";
+  }
+
+  const textHeader = new TextDecoder().decode(header).trimStart();
+  if (/^(?:<\?xml[\s\S]*?\?>\s*)?(?:<!--[\s\S]*?-->\s*)*<svg[\s>]/i.test(textHeader)) {
+    return "image/svg+xml";
+  }
+
+  return null;
+}
+
+function hasIsoMediaBrand(bytes: Uint8Array, brands: readonly string[]): boolean {
+  if (!asciiAt(bytes, 4, "ftyp")) {
+    return false;
+  }
+  const boxSize = new DataView(bytes.buffer, bytes.byteOffset, 4).getUint32(0);
+  if (boxSize < 16) {
+    return false;
+  }
+  const boxEnd = Math.min(boxSize, bytes.byteLength);
+  if (brands.some((brand) => asciiAt(bytes, 8, brand))) {
+    return true;
+  }
+  for (let offset = 16; offset + 4 <= boxEnd; offset += 4) {
+    if (brands.some((brand) => asciiAt(bytes, offset, brand))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function startsWithBytes(bytes: Uint8Array, expected: number[]): boolean {
+  return expected.every((value, index) => bytes[index] === value);
+}
+
+function startsWithAscii(bytes: Uint8Array, expected: string): boolean {
+  return asciiAt(bytes, 0, expected);
+}
+
+function asciiAt(bytes: Uint8Array, offset: number, expected: string): boolean {
+  if (bytes.byteLength < offset + expected.length) {
+    return false;
+  }
+  return [...expected].every(
+    (character, index) => bytes[offset + index] === character.charCodeAt(0)
+  );
+}
+
+function replaceMissingImage(image: HTMLImageElement, source: string): void {
+  const replacement = image.doc.createElement("span");
+  replacement.className = "symposium-missing-asset";
+  replacement.textContent = `[Missing image: ${image.alt || source || "unknown"}]`;
+  image.replaceWith(replacement);
+}
+
+function sanitizeAttributes(root: HTMLElement): void {
+  for (const element of [root, ...root.querySelectorAll<HTMLElement>("*")]) {
+    for (const attribute of [...element.attributes]) {
+      const name = attribute.name.toLowerCase();
+      if (
+        name.startsWith("on") ||
+        name === "style" ||
+        name === "srcdoc" ||
+        name === "srcset" ||
+        name === "contenteditable"
+      ) {
+        element.removeAttribute(attribute.name);
+        continue;
+      }
+      if (URL_ATTRIBUTES.has(name) && !isAllowedUrl(element, name, attribute.value)) {
+        element.removeAttribute(attribute.name);
+      }
+    }
+
+    if (element.tagName === "A" && element.getAttribute("target") === "_blank") {
+      element.setAttribute("rel", "noopener noreferrer");
+    }
+  }
+}
+
+function isAllowedUrl(element: HTMLElement, attribute: string, rawValue: string): boolean {
+  const value = rawValue.trim();
+  if (!value) {
+    return false;
+  }
+  if (value.startsWith("#")) {
+    return true;
+  }
+
+  const scheme = value.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]?.toLowerCase();
+  if (element.tagName === "IMG" && attribute === "src") {
+    return scheme === "http" || scheme === "https" || isEmbeddedImageSource(value);
+  }
+  if (element.tagName === "A" && attribute === "href") {
+    return scheme === "http" || scheme === "https" || scheme === "mailto" || scheme === "tel";
+  }
+  if (attribute === "cite") {
+    return scheme === "http" || scheme === "https";
+  }
+  return false;
+}
+
+function isRemoteImageSource(source: string): boolean {
+  return /^https?:\/\//i.test(source);
+}
+
+function isEmbeddedImageSource(source: string): boolean {
+  return /^data:image\/[a-z0-9.+-]+(?:;[a-z0-9=.+-]+)*;base64,[a-z0-9+/=\s]+$/i.test(source);
+}
+
+function hasUrlScheme(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(value) || value.startsWith("//");
+}
+
+function decodeUrlComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function serializeDocument(ownerDocument: Document, title: string, article: HTMLElement): string {
+  const titleElement = ownerDocument.createElement("title");
+  titleElement.textContent = title;
+  return [
+    "<!doctype html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charset="utf-8">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1">',
+    titleElement.outerHTML,
+    `<style id="symposium-obsidian-publish-baseline">${OBSIDIAN_PUBLISH_BASELINE}</style>`,
+    "</head>",
+    '<body><main class="publish-renderer">',
+    article.outerHTML,
+    "</main></body>",
+    "</html>",
+  ].join("");
+}

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -394,6 +394,9 @@ function isAllowedUrl(element: HTMLElement, attribute: string, rawValue: string)
   if (value.startsWith("#")) {
     return true;
   }
+  if (value.startsWith("//")) {
+    return element.tagName === "A" && attribute === "href";
+  }
 
   const scheme = value.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]?.toLowerCase();
   if (element.tagName === "IMG" && attribute === "src") {

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -61,6 +61,20 @@ type ModernRender = (
 ) => Promise<void>;
 
 /**
+ * Reports the final UTF-8 payload size when a rendered document exceeds Symposium's limit.
+ */
+export class SymposiumDocumentTooLargeError extends Error {
+  /**
+   * @param byteLength The final serialized document size.
+   */
+  constructor(public readonly byteLength: number) {
+    super(`Symposium HTML is ${byteLength} bytes; the limit is ${SYMPOSIUM_MAX_HTML_BYTES} bytes.`);
+    this.name = "SymposiumDocumentTooLargeError";
+    Object.setPrototypeOf(this, SymposiumDocumentTooLargeError.prototype);
+  }
+}
+
+/**
  * Builds the exact HTML payload sent to Symposium from Obsidian's settled reading-view DOM.
  *
  * @param app The Obsidian application that owns the source vault and renderer.
@@ -81,6 +95,8 @@ export async function buildSymposiumDocument(
   const render = (MarkdownRenderer as unknown as { render: ModernRender }).render;
   await render(app, markdown, article, file.path, component);
 
+  normalizeMath(article);
+  normalizeTaskCheckboxes(article);
   removeActiveContent(article);
   normalizeInternalLinks(article);
   await embedVaultImages(article, app, file.path);
@@ -90,12 +106,31 @@ export async function buildSymposiumDocument(
   const html = serializeDocument(ownerDocument, title, article);
   const byteLength = new TextEncoder().encode(html).byteLength;
   if (byteLength > SYMPOSIUM_MAX_HTML_BYTES) {
-    throw new Error(
-      `Symposium HTML is ${byteLength} bytes; the limit is ${SYMPOSIUM_MAX_HTML_BYTES} bytes.`
-    );
+    throw new SymposiumDocumentTooLargeError(byteLength);
   }
 
   return { title, html, byteLength };
+}
+
+function normalizeMath(root: HTMLElement): void {
+  root.querySelectorAll<HTMLElement>("mjx-container").forEach((container) => {
+    const math = container.querySelector("mjx-assistive-mml math");
+    if (math) {
+      container.replaceWith(math.cloneNode(true));
+    }
+  });
+}
+
+function normalizeTaskCheckboxes(root: HTMLElement): void {
+  root.querySelectorAll<HTMLInputElement>("input.task-list-item-checkbox").forEach((checkbox) => {
+    const marker = root.doc.createElement("span");
+    const checked = checkbox.checked || checkbox.hasAttribute("checked");
+    marker.className = "symposium-task-marker";
+    marker.setAttribute("role", "img");
+    marker.setAttribute("aria-label", checked ? "Completed task" : "Open task");
+    marker.textContent = checked ? "☑" : "☐";
+    checkbox.replaceWith(marker);
+  });
 }
 
 function removeActiveContent(root: HTMLElement): void {
@@ -120,13 +155,16 @@ function normalizeInternalLinks(root: HTMLElement): void {
 }
 
 async function embedVaultImages(root: HTMLElement, app: App, sourcePath: string): Promise<void> {
-  const lookup = buildVaultFileLookup(app);
-  for (const image of root.querySelectorAll<HTMLImageElement>("img")) {
+  const images = [...root.querySelectorAll<HTMLImageElement>("img")].filter((image) => {
     const source = image.getAttribute("src")?.trim() ?? "";
-    if (isRemoteImageSource(source) || isEmbeddedImageSource(source)) {
-      continue;
-    }
-
+    return !isRemoteImageSource(source) && !isEmbeddedImageSource(source);
+  });
+  if (images.length === 0) {
+    return;
+  }
+  const lookup = buildVaultFileLookup(app);
+  for (const image of images) {
+    const source = image.getAttribute("src")?.trim() ?? "";
     const file = resolveVaultImage(image, app, sourcePath, lookup);
     if (!file) {
       replaceMissingImage(image, source);
@@ -306,7 +344,8 @@ function sanitizeAttributes(root: HTMLElement): void {
         name === "style" ||
         name === "srcdoc" ||
         name === "srcset" ||
-        name === "contenteditable"
+        name === "contenteditable" ||
+        name === "referrerpolicy"
       ) {
         element.removeAttribute(attribute.name);
         continue;
@@ -318,6 +357,12 @@ function sanitizeAttributes(root: HTMLElement): void {
 
     if (element.tagName === "A" && element.getAttribute("target") === "_blank") {
       element.setAttribute("rel", "noopener noreferrer");
+    }
+    if (
+      element.tagName === "IMG" &&
+      isRemoteImageSource(element.getAttribute("src")?.trim() ?? "")
+    ) {
+      element.setAttribute("referrerpolicy", "no-referrer");
     }
   }
 }

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -88,7 +88,7 @@ export async function buildSymposiumDocument(
   component: Component,
   ownerDocument: Document
 ): Promise<SymposiumDocument> {
-  const markdown = await app.vault.cachedRead(file);
+  const markdown = await app.vault.read(file);
   const article = ownerDocument.createElement("article");
   article.className = "markdown-preview-view markdown-rendered symposium-document";
 

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -101,7 +101,15 @@ export async function buildSymposiumDocument(
   normalizeTaskCheckboxes(article);
   removeActiveContent(article);
   normalizeInternalLinks(article);
-  await embedVaultImages(article, app, file.path);
+  const budgetArticle = article.cloneNode(true) as HTMLElement;
+  sanitizeAttributes(budgetArticle);
+  const projectedByteLength = new TextEncoder().encode(
+    serializeDocument(ownerDocument, file.basename, budgetArticle)
+  ).byteLength;
+  if (projectedByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
+    throw new SymposiumDocumentTooLargeError(projectedByteLength);
+  }
+  await embedVaultImages(article, app, file.path, projectedByteLength);
   sanitizeAttributes(article);
 
   const title = file.basename;
@@ -156,7 +164,12 @@ function normalizeInternalLinks(root: HTMLElement): void {
   });
 }
 
-async function embedVaultImages(root: HTMLElement, app: App, sourcePath: string): Promise<void> {
+async function embedVaultImages(
+  root: HTMLElement,
+  app: App,
+  sourcePath: string,
+  initialDocumentByteLength: number
+): Promise<void> {
   const images = [...root.querySelectorAll<HTMLImageElement>("img")].filter((image) => {
     const source = image.getAttribute("src")?.trim() ?? "";
     return !isRemoteImageSource(source) && !isEmbeddedImageSource(source);
@@ -165,7 +178,7 @@ async function embedVaultImages(root: HTMLElement, app: App, sourcePath: string)
     return;
   }
   const lookup = buildVaultFileLookup(app);
-  let embeddedImageByteLength = 0;
+  let projectedDocumentByteLength = initialDocumentByteLength;
   for (const image of images) {
     const source = image.getAttribute("src")?.trim() ?? "";
     const file = resolveVaultImage(image, app, sourcePath, lookup);
@@ -176,8 +189,10 @@ async function embedVaultImages(root: HTMLElement, app: App, sourcePath: string)
 
     const projectedImageByteLength =
       MIN_IMAGE_DATA_URL_PREFIX_BYTES + 4 * Math.ceil(file.stat.size / 3);
-    if (embeddedImageByteLength + projectedImageByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
-      throw new SymposiumDocumentTooLargeError(embeddedImageByteLength + projectedImageByteLength);
+    if (projectedDocumentByteLength + projectedImageByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
+      throw new SymposiumDocumentTooLargeError(
+        projectedDocumentByteLength + projectedImageByteLength
+      );
     }
 
     let bytes: ArrayBuffer;
@@ -196,13 +211,15 @@ async function embedVaultImages(root: HTMLElement, app: App, sourcePath: string)
 
     const dataUrlPrefix = `data:${mimeType};base64,`;
     const encodedImageByteLength = dataUrlPrefix.length + 4 * Math.ceil(bytes.byteLength / 3);
-    if (embeddedImageByteLength + encodedImageByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
-      throw new SymposiumDocumentTooLargeError(embeddedImageByteLength + encodedImageByteLength);
+    if (projectedDocumentByteLength + encodedImageByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
+      throw new SymposiumDocumentTooLargeError(
+        projectedDocumentByteLength + encodedImageByteLength
+      );
     }
     image.src = `${dataUrlPrefix}${arrayBufferToBase64(bytes)}`;
     image.removeAttribute("data-path");
     image.removeAttribute("data-src");
-    embeddedImageByteLength += encodedImageByteLength;
+    projectedDocumentByteLength += encodedImageByteLength;
   }
 }
 
@@ -395,7 +412,10 @@ function isAllowedUrl(element: HTMLElement, attribute: string, rawValue: string)
     return true;
   }
   if (value.startsWith("//")) {
-    return element.tagName === "A" && attribute === "href";
+    return (
+      (element.tagName === "A" && attribute === "href") ||
+      (element.tagName === "IMG" && attribute === "src")
+    );
   }
 
   const scheme = value.match(/^([a-z][a-z0-9+.-]*):/i)?.[1]?.toLowerCase();
@@ -412,7 +432,7 @@ function isAllowedUrl(element: HTMLElement, attribute: string, rawValue: string)
 }
 
 function isRemoteImageSource(source: string): boolean {
-  return /^https?:\/\//i.test(source);
+  return /^(?:https?:)?\/\//i.test(source);
 }
 
 function isEmbeddedImageSource(source: string): boolean {

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -53,6 +53,7 @@ const URL_ATTRIBUTES = new Set([
 ]);
 
 const MIN_IMAGE_DATA_URL_PREFIX_BYTES = "data:image/png;base64,".length;
+const IMAGE_DATA_URL_PLACEHOLDER = "data:image/png;base64,A";
 
 type ModernRender = (
   app: App,
@@ -181,46 +182,69 @@ async function embedVaultImages(
   let projectedDocumentByteLength = initialDocumentByteLength;
   for (const image of images) {
     const source = image.getAttribute("src")?.trim() ?? "";
+    const originalImageByteLength = sanitizedElementByteLength(image);
     const file = resolveVaultImage(image, app, sourcePath, lookup);
     if (!file) {
-      replaceMissingImage(image, source);
+      const replacement = replaceMissingImage(image, source);
+      projectedDocumentByteLength +=
+        sanitizedElementByteLength(replacement) - originalImageByteLength;
       continue;
     }
 
-    const projectedImageByteLength =
+    const projectedDataUrlByteLength =
       MIN_IMAGE_DATA_URL_PREFIX_BYTES + 4 * Math.ceil(file.stat.size / 3);
-    if (projectedDocumentByteLength + projectedImageByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
-      throw new SymposiumDocumentTooLargeError(
-        projectedDocumentByteLength + projectedImageByteLength
-      );
+    const projectedImageByteLength = embeddedImageByteLength(image, projectedDataUrlByteLength);
+    const projectedByteLength =
+      projectedDocumentByteLength - originalImageByteLength + projectedImageByteLength;
+    if (projectedByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
+      throw new SymposiumDocumentTooLargeError(projectedByteLength);
     }
 
     let bytes: ArrayBuffer;
     try {
       bytes = await app.vault.readBinary(file);
     } catch {
-      replaceMissingImage(image, file.path);
+      const replacement = replaceMissingImage(image, file.path);
+      projectedDocumentByteLength +=
+        sanitizedElementByteLength(replacement) - originalImageByteLength;
       continue;
     }
 
     const mimeType = detectImageMimeType(bytes);
     if (!mimeType) {
-      replaceMissingImage(image, file.path);
+      const replacement = replaceMissingImage(image, file.path);
+      projectedDocumentByteLength +=
+        sanitizedElementByteLength(replacement) - originalImageByteLength;
       continue;
     }
 
     const dataUrlPrefix = `data:${mimeType};base64,`;
-    const encodedImageByteLength = dataUrlPrefix.length + 4 * Math.ceil(bytes.byteLength / 3);
-    if (projectedDocumentByteLength + encodedImageByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
-      throw new SymposiumDocumentTooLargeError(
-        projectedDocumentByteLength + encodedImageByteLength
-      );
+    const dataUrlByteLength = dataUrlPrefix.length + 4 * Math.ceil(bytes.byteLength / 3);
+    const embeddedImageMarkupByteLength = embeddedImageByteLength(image, dataUrlByteLength);
+    const embeddedDocumentByteLength =
+      projectedDocumentByteLength - originalImageByteLength + embeddedImageMarkupByteLength;
+    if (embeddedDocumentByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
+      throw new SymposiumDocumentTooLargeError(embeddedDocumentByteLength);
     }
     image.src = `${dataUrlPrefix}${arrayBufferToBase64(bytes)}`;
     image.removeAttribute("data-path");
     image.removeAttribute("data-src");
-    projectedDocumentByteLength += encodedImageByteLength;
+    projectedDocumentByteLength = embeddedDocumentByteLength;
   }
+}
+
+function sanitizedElementByteLength(element: HTMLElement): number {
+  const clone = element.cloneNode(true) as HTMLElement;
+  sanitizeAttributes(clone);
+  return new TextEncoder().encode(clone.outerHTML).byteLength;
+}
+
+function embeddedImageByteLength(image: HTMLImageElement, dataUrlByteLength: number): number {
+  const clone = image.cloneNode(true) as HTMLImageElement;
+  clone.src = IMAGE_DATA_URL_PLACEHOLDER;
+  clone.removeAttribute("data-path");
+  clone.removeAttribute("data-src");
+  return sanitizedElementByteLength(clone) - IMAGE_DATA_URL_PLACEHOLDER.length + dataUrlByteLength;
 }
 
 function buildVaultFileLookup(app: App): Map<string, TFile> {
@@ -364,11 +388,12 @@ function asciiAt(bytes: Uint8Array, offset: number, expected: string): boolean {
   );
 }
 
-function replaceMissingImage(image: HTMLImageElement, source: string): void {
+function replaceMissingImage(image: HTMLImageElement, source: string): HTMLElement {
   const replacement = image.doc.createElement("span");
   replacement.className = "symposium-missing-asset";
   replacement.textContent = `[Missing image: ${image.alt || source || "unknown"}]`;
   image.replaceWith(replacement);
+  return replacement;
 }
 
 function sanitizeAttributes(root: HTMLElement): void {

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -1,9 +1,10 @@
 import { OBSIDIAN_PUBLISH_BASELINE } from "@/symposium/obsidianPublishBaseline";
+import { SYMPOSIUM_MAX_HTML_BYTES } from "@/symposium/constants";
 import { SymposiumDocument } from "@/symposium/types";
 import { arrayBufferToBase64 } from "@/utils/base64";
 import { App, Component, MarkdownRenderer, TFile } from "obsidian";
 
-export const SYMPOSIUM_MAX_HTML_BYTES = 10 * 1024 * 1024;
+export { SYMPOSIUM_MAX_HTML_BYTES };
 
 const ACTIVE_CONTENT_SELECTOR = [
   "base",

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -52,6 +52,8 @@ const URL_ATTRIBUTES = new Set([
   "xlink:href",
 ]);
 
+const MIN_IMAGE_DATA_URL_PREFIX_BYTES = "data:image/png;base64,".length;
+
 type ModernRender = (
   app: App,
   markdown: string,
@@ -61,11 +63,11 @@ type ModernRender = (
 ) => Promise<void>;
 
 /**
- * Reports the final UTF-8 payload size when a rendered document exceeds Symposium's limit.
+ * Reports the measured or projected UTF-8 payload size when a document exceeds Symposium's limit.
  */
 export class SymposiumDocumentTooLargeError extends Error {
   /**
-   * @param byteLength The final serialized document size.
+   * @param byteLength The measured or projected serialized document size.
    */
   constructor(public readonly byteLength: number) {
     super(`Symposium HTML is ${byteLength} bytes; the limit is ${SYMPOSIUM_MAX_HTML_BYTES} bytes.`);
@@ -163,6 +165,7 @@ async function embedVaultImages(root: HTMLElement, app: App, sourcePath: string)
     return;
   }
   const lookup = buildVaultFileLookup(app);
+  let embeddedImageByteLength = 0;
   for (const image of images) {
     const source = image.getAttribute("src")?.trim() ?? "";
     const file = resolveVaultImage(image, app, sourcePath, lookup);
@@ -171,19 +174,35 @@ async function embedVaultImages(root: HTMLElement, app: App, sourcePath: string)
       continue;
     }
 
+    const projectedImageByteLength =
+      MIN_IMAGE_DATA_URL_PREFIX_BYTES + 4 * Math.ceil(file.stat.size / 3);
+    if (embeddedImageByteLength + projectedImageByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
+      throw new SymposiumDocumentTooLargeError(embeddedImageByteLength + projectedImageByteLength);
+    }
+
+    let bytes: ArrayBuffer;
     try {
-      const bytes = await app.vault.readBinary(file);
-      const mimeType = detectImageMimeType(bytes);
-      if (!mimeType) {
-        replaceMissingImage(image, file.path);
-        continue;
-      }
-      image.src = `data:${mimeType};base64,${arrayBufferToBase64(bytes)}`;
-      image.removeAttribute("data-path");
-      image.removeAttribute("data-src");
+      bytes = await app.vault.readBinary(file);
     } catch {
       replaceMissingImage(image, file.path);
+      continue;
     }
+
+    const mimeType = detectImageMimeType(bytes);
+    if (!mimeType) {
+      replaceMissingImage(image, file.path);
+      continue;
+    }
+
+    const dataUrlPrefix = `data:${mimeType};base64,`;
+    const encodedImageByteLength = dataUrlPrefix.length + 4 * Math.ceil(bytes.byteLength / 3);
+    if (embeddedImageByteLength + encodedImageByteLength > SYMPOSIUM_MAX_HTML_BYTES) {
+      throw new SymposiumDocumentTooLargeError(embeddedImageByteLength + encodedImageByteLength);
+    }
+    image.src = `${dataUrlPrefix}${arrayBufferToBase64(bytes)}`;
+    image.removeAttribute("data-path");
+    image.removeAttribute("data-src");
+    embeddedImageByteLength += encodedImageByteLength;
   }
 }
 

--- a/src/symposium/symposiumFrontmatter.test.ts
+++ b/src/symposium/symposiumFrontmatter.test.ts
@@ -58,7 +58,7 @@ describe("symposiumFrontmatter", () => {
         const error = new SymposiumFrontmatterParseError();
 
         expect(error).toBeInstanceOf(Error);
-        expect(error.message).toContain("frontmatter is not valid YAML");
+        expect(error.message).toContain("frontmatter must be a YAML property map");
       });
     });
   });
@@ -86,6 +86,18 @@ describe("symposiumFrontmatter", () => {
       const invalidYaml = createApp();
       jest.mocked(invalidYaml.app.vault.read).mockResolvedValue("---\nsymposium: [\n---\n");
       await expect(getSymposiumDocId(invalidYaml.app, file)).rejects.toBeInstanceOf(
+        SymposiumFrontmatterParseError
+      );
+    });
+
+    it.each([
+      ["sequence", "---\n- shared\n---\n"],
+      ["scalar", "---\nshared\n---\n"],
+    ])("rejects a YAML %s root that cannot hold properties", async (_case, markdown) => {
+      const nonMapping = createApp();
+      jest.mocked(nonMapping.app.vault.read).mockResolvedValue(markdown);
+
+      await expect(getSymposiumDocId(nonMapping.app, file)).rejects.toBeInstanceOf(
         SymposiumFrontmatterParseError
       );
     });

--- a/src/symposium/symposiumFrontmatter.test.ts
+++ b/src/symposium/symposiumFrontmatter.test.ts
@@ -21,8 +21,13 @@ function createApp(frontmatter: Record<string, unknown> = {}): TestApp {
     }
   );
   const app = {
-    metadataCache: {
-      getFileCache: jest.fn(() => ({ frontmatter })),
+    vault: {
+      read: jest.fn(async () => {
+        const yaml = Object.entries(frontmatter)
+          .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
+          .join("\n");
+        return yaml ? `---\n${yaml}\n---\n` : "";
+      }),
     },
     fileManager: { processFrontMatter },
   } as unknown as App;
@@ -45,17 +50,19 @@ describe("symposiumFrontmatter", () => {
   });
 
   describe("getSymposiumDocId()", () => {
-    it("reads a valid id and treats missing or malformed metadata as unpublished", () => {
+    it("reads a valid id and treats missing or malformed frontmatter as unpublished", async () => {
       const valid = createApp({ symposium: DOC_ID });
-      expect(getSymposiumDocId(valid.app, file)).toBe(DOC_ID);
+      await expect(getSymposiumDocId(valid.app, file)).resolves.toBe(DOC_ID);
 
       const malformed = createApp({ symposium: { docId: DOC_ID } });
-      expect(getSymposiumDocId(malformed.app, file)).toBeNull();
+      await expect(getSymposiumDocId(malformed.app, file)).resolves.toBeNull();
 
-      const missingCache = {
-        metadataCache: { getFileCache: jest.fn(() => null) },
-      } as unknown as App;
-      expect(getSymposiumDocId(missingCache, file)).toBeNull();
+      const missing = createApp();
+      await expect(getSymposiumDocId(missing.app, file)).resolves.toBeNull();
+
+      const invalidYaml = createApp();
+      jest.mocked(invalidYaml.app.vault.read).mockResolvedValue("---\nsymposium: [\n---\n");
+      await expect(getSymposiumDocId(invalidYaml.app, file)).resolves.toBeNull();
     });
   });
 
@@ -66,7 +73,7 @@ describe("symposiumFrontmatter", () => {
         tags: ["public"],
       });
 
-      await saveSymposiumDocId(app, file, DOC_ID);
+      await expect(saveSymposiumDocId(app, file, DOC_ID, "0123456789abcdef")).resolves.toBe(true);
 
       expect(processFrontMatter).toHaveBeenCalledWith(file, expect.any(Function));
       expect(frontmatter).toEqual({ symposium: DOC_ID, tags: ["public"] });
@@ -75,10 +82,18 @@ describe("symposiumFrontmatter", () => {
     it("rejects an invalid id before changing the note", async () => {
       const { app, processFrontMatter } = createApp();
 
-      await expect(saveSymposiumDocId(app, file, "INVALID")).rejects.toThrow(
+      await expect(saveSymposiumDocId(app, file, "INVALID", null)).rejects.toThrow(
         "Cannot save an invalid Symposium document id."
       );
       expect(processFrontMatter).not.toHaveBeenCalled();
+    });
+
+    it("does not overwrite an identity that changed after the remote action began", async () => {
+      const newerDocId = "0123456789abcdef";
+      const { app, frontmatter } = createApp({ symposium: newerDocId });
+
+      await expect(saveSymposiumDocId(app, file, DOC_ID, null)).resolves.toBe(false);
+      expect(frontmatter.symposium).toBe(newerDocId);
     });
   });
 
@@ -89,10 +104,18 @@ describe("symposiumFrontmatter", () => {
         tags: ["public"],
       });
 
-      await removeSymposiumDocId(app, file);
+      await expect(removeSymposiumDocId(app, file, DOC_ID)).resolves.toBe(true);
 
       expect(processFrontMatter).toHaveBeenCalledWith(file, expect.any(Function));
       expect(frontmatter).toEqual({ tags: ["public"] });
+    });
+
+    it("does not remove an identity that changed after the remote deletion began", async () => {
+      const newerDocId = "0123456789abcdef";
+      const { app, frontmatter } = createApp({ symposium: newerDocId });
+
+      await expect(removeSymposiumDocId(app, file, DOC_ID)).resolves.toBe(false);
+      expect(frontmatter.symposium).toBe(newerDocId);
     });
   });
 });

--- a/src/symposium/symposiumFrontmatter.test.ts
+++ b/src/symposium/symposiumFrontmatter.test.ts
@@ -3,6 +3,7 @@ import {
   parseSymposiumDocId,
   removeSymposiumDocId,
   saveSymposiumDocId,
+  SymposiumPropertyConflictError,
 } from "@/symposium/symposiumFrontmatter";
 import type { App, TFile } from "obsidian";
 
@@ -39,6 +40,17 @@ describe("symposiumFrontmatter", () => {
   // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast -- path-only test fixture
   const file = { path: "Notes/Architecture.md" } as TFile;
 
+  describe("SymposiumPropertyConflictError", () => {
+    describe("constructor()", () => {
+      it("identifies an occupied reserved property", () => {
+        const error = new SymposiumPropertyConflictError();
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toContain("already uses the symposium property");
+      });
+    });
+  });
+
   describe("parseSymposiumDocId()", () => {
     it("accepts only lowercase 16-character Symposium ids", () => {
       expect(parseSymposiumDocId(DOC_ID)).toBe(DOC_ID);
@@ -50,12 +62,9 @@ describe("symposiumFrontmatter", () => {
   });
 
   describe("getSymposiumDocId()", () => {
-    it("reads a valid id and treats missing or malformed frontmatter as unpublished", async () => {
+    it("reads a valid id and treats missing or invalid YAML as unpublished", async () => {
       const valid = createApp({ symposium: DOC_ID });
       await expect(getSymposiumDocId(valid.app, file)).resolves.toBe(DOC_ID);
-
-      const malformed = createApp({ symposium: { docId: DOC_ID } });
-      await expect(getSymposiumDocId(malformed.app, file)).resolves.toBeNull();
 
       const missing = createApp();
       await expect(getSymposiumDocId(missing.app, file)).resolves.toBeNull();
@@ -63,6 +72,14 @@ describe("symposiumFrontmatter", () => {
       const invalidYaml = createApp();
       jest.mocked(invalidYaml.app.vault.read).mockResolvedValue("---\nsymposium: [\n---\n");
       await expect(getSymposiumDocId(invalidYaml.app, file)).resolves.toBeNull();
+    });
+
+    it("rejects an occupied property whose value is not a valid document id", async () => {
+      const malformed = createApp({ symposium: { docId: DOC_ID } });
+
+      await expect(getSymposiumDocId(malformed.app, file)).rejects.toBeInstanceOf(
+        SymposiumPropertyConflictError
+      );
     });
   });
 
@@ -94,6 +111,14 @@ describe("symposiumFrontmatter", () => {
 
       await expect(saveSymposiumDocId(app, file, DOC_ID, null)).resolves.toBe(false);
       expect(frontmatter.symposium).toBe(newerDocId);
+    });
+
+    it("does not overwrite an occupied property with an unrecognized value", async () => {
+      const existingValue = { url: "https://example.com/symposium" };
+      const { app, frontmatter } = createApp({ symposium: existingValue });
+
+      await expect(saveSymposiumDocId(app, file, DOC_ID, null)).resolves.toBe(false);
+      expect(frontmatter.symposium).toBe(existingValue);
     });
   });
 

--- a/src/symposium/symposiumFrontmatter.test.ts
+++ b/src/symposium/symposiumFrontmatter.test.ts
@@ -3,6 +3,7 @@ import {
   parseSymposiumDocId,
   removeSymposiumDocId,
   saveSymposiumDocId,
+  SymposiumFrontmatterParseError,
   SymposiumPropertyConflictError,
 } from "@/symposium/symposiumFrontmatter";
 import type { App, TFile } from "obsidian";
@@ -51,6 +52,17 @@ describe("symposiumFrontmatter", () => {
     });
   });
 
+  describe("SymposiumFrontmatterParseError", () => {
+    describe("constructor()", () => {
+      it("identifies frontmatter that cannot be parsed safely", () => {
+        const error = new SymposiumFrontmatterParseError();
+
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toContain("frontmatter is not valid YAML");
+      });
+    });
+  });
+
   describe("parseSymposiumDocId()", () => {
     it("accepts only lowercase 16-character Symposium ids", () => {
       expect(parseSymposiumDocId(DOC_ID)).toBe(DOC_ID);
@@ -62,16 +74,20 @@ describe("symposiumFrontmatter", () => {
   });
 
   describe("getSymposiumDocId()", () => {
-    it("reads a valid id and treats missing or invalid YAML as unpublished", async () => {
+    it("reads a valid id and treats missing frontmatter as unpublished", async () => {
       const valid = createApp({ symposium: DOC_ID });
       await expect(getSymposiumDocId(valid.app, file)).resolves.toBe(DOC_ID);
 
       const missing = createApp();
       await expect(getSymposiumDocId(missing.app, file)).resolves.toBeNull();
+    });
 
+    it("rejects invalid YAML before its identity can be treated as unpublished", async () => {
       const invalidYaml = createApp();
       jest.mocked(invalidYaml.app.vault.read).mockResolvedValue("---\nsymposium: [\n---\n");
-      await expect(getSymposiumDocId(invalidYaml.app, file)).resolves.toBeNull();
+      await expect(getSymposiumDocId(invalidYaml.app, file)).rejects.toBeInstanceOf(
+        SymposiumFrontmatterParseError
+      );
     });
 
     it("rejects an occupied property whose value is not a valid document id", async () => {

--- a/src/symposium/symposiumFrontmatter.test.ts
+++ b/src/symposium/symposiumFrontmatter.test.ts
@@ -148,6 +148,17 @@ describe("symposiumFrontmatter", () => {
       await expect(saveSymposiumDocId(app, file, DOC_ID, null)).resolves.toBe(false);
       expect(frontmatter.symposium).toBe(existingValue);
     });
+
+    it("rejects a non-mapping root supplied by the atomic callback", async () => {
+      const processFrontMatter = jest.fn(async (_file: TFile, update: (value: unknown) => void) =>
+        update(["shared"])
+      );
+      const app = { fileManager: { processFrontMatter } } as unknown as App;
+
+      await expect(saveSymposiumDocId(app, file, DOC_ID, null)).rejects.toBeInstanceOf(
+        SymposiumFrontmatterParseError
+      );
+    });
   });
 
   describe("removeSymposiumDocId()", () => {
@@ -169,6 +180,17 @@ describe("symposiumFrontmatter", () => {
 
       await expect(removeSymposiumDocId(app, file, DOC_ID)).resolves.toBe(false);
       expect(frontmatter.symposium).toBe(newerDocId);
+    });
+
+    it("rejects a non-mapping root supplied by the atomic callback", async () => {
+      const processFrontMatter = jest.fn(async (_file: TFile, update: (value: unknown) => void) =>
+        update(["shared"])
+      );
+      const app = { fileManager: { processFrontMatter } } as unknown as App;
+
+      await expect(removeSymposiumDocId(app, file, DOC_ID)).rejects.toBeInstanceOf(
+        SymposiumFrontmatterParseError
+      );
     });
   });
 });

--- a/src/symposium/symposiumFrontmatter.test.ts
+++ b/src/symposium/symposiumFrontmatter.test.ts
@@ -1,0 +1,98 @@
+import {
+  getSymposiumDocId,
+  parseSymposiumDocId,
+  removeSymposiumDocId,
+  saveSymposiumDocId,
+} from "@/symposium/symposiumFrontmatter";
+import type { App, TFile } from "obsidian";
+
+const DOC_ID = "9f2k4mvq7t0xbz3n";
+
+interface TestApp {
+  app: App;
+  frontmatter: Record<string, unknown>;
+  processFrontMatter: jest.Mock;
+}
+
+function createApp(frontmatter: Record<string, unknown> = {}): TestApp {
+  const processFrontMatter = jest.fn(
+    async (_file: TFile, update: (value: Record<string, unknown>) => void) => {
+      update(frontmatter);
+    }
+  );
+  const app = {
+    metadataCache: {
+      getFileCache: jest.fn(() => ({ frontmatter })),
+    },
+    fileManager: { processFrontMatter },
+  } as unknown as App;
+
+  return { app, frontmatter, processFrontMatter };
+}
+
+describe("symposiumFrontmatter", () => {
+  // eslint-disable-next-line obsidianmd/no-tfile-tfolder-cast -- path-only test fixture
+  const file = { path: "Notes/Architecture.md" } as TFile;
+
+  describe("parseSymposiumDocId()", () => {
+    it("accepts only lowercase 16-character Symposium ids", () => {
+      expect(parseSymposiumDocId(DOC_ID)).toBe(DOC_ID);
+      expect(parseSymposiumDocId("9F2K4MVQ7T0XBZ3N")).toBeNull();
+      expect(parseSymposiumDocId("too-short")).toBeNull();
+      expect(parseSymposiumDocId(42)).toBeNull();
+      expect(parseSymposiumDocId(null)).toBeNull();
+    });
+  });
+
+  describe("getSymposiumDocId()", () => {
+    it("reads a valid id and treats missing or malformed metadata as unpublished", () => {
+      const valid = createApp({ symposium: DOC_ID });
+      expect(getSymposiumDocId(valid.app, file)).toBe(DOC_ID);
+
+      const malformed = createApp({ symposium: { docId: DOC_ID } });
+      expect(getSymposiumDocId(malformed.app, file)).toBeNull();
+
+      const missingCache = {
+        metadataCache: { getFileCache: jest.fn(() => null) },
+      } as unknown as App;
+      expect(getSymposiumDocId(missingCache, file)).toBeNull();
+    });
+  });
+
+  describe("saveSymposiumDocId()", () => {
+    it("writes or replaces the property through processFrontMatter", async () => {
+      const { app, frontmatter, processFrontMatter } = createApp({
+        symposium: "0123456789abcdef",
+        tags: ["public"],
+      });
+
+      await saveSymposiumDocId(app, file, DOC_ID);
+
+      expect(processFrontMatter).toHaveBeenCalledWith(file, expect.any(Function));
+      expect(frontmatter).toEqual({ symposium: DOC_ID, tags: ["public"] });
+    });
+
+    it("rejects an invalid id before changing the note", async () => {
+      const { app, processFrontMatter } = createApp();
+
+      await expect(saveSymposiumDocId(app, file, "INVALID")).rejects.toThrow(
+        "Cannot save an invalid Symposium document id."
+      );
+      expect(processFrontMatter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeSymposiumDocId()", () => {
+    it("deletes only the Symposium property through processFrontMatter", async () => {
+      const { app, frontmatter, processFrontMatter } = createApp({
+        symposium: DOC_ID,
+        tags: ["public"],
+      });
+
+      await removeSymposiumDocId(app, file);
+
+      expect(processFrontMatter).toHaveBeenCalledWith(file, expect.any(Function));
+      expect(frontmatter).toEqual({ tags: ["public"] });
+    });
+  });
+});

--- a/src/symposium/symposiumFrontmatter.ts
+++ b/src/symposium/symposiumFrontmatter.ts
@@ -17,6 +17,17 @@ export class SymposiumPropertyConflictError extends Error {
 }
 
 /**
+ * Signals that a note's frontmatter cannot be parsed safely enough to inspect its identity.
+ */
+export class SymposiumFrontmatterParseError extends Error {
+  constructor() {
+    super("This note's frontmatter is not valid YAML. Fix it before publishing to Symposium.");
+    this.name = "SymposiumFrontmatterParseError";
+    Object.setPrototypeOf(this, SymposiumFrontmatterParseError.prototype);
+  }
+}
+
+/**
  * Returns a Symposium identity only when the frontmatter value matches the server's id format.
  * Throws when the reserved property is occupied by unrelated metadata so callers cannot overwrite it.
  *
@@ -42,7 +53,7 @@ export async function getSymposiumDocId(app: App, file: TFile): Promise<string |
   try {
     frontmatter = parseYaml(yaml);
   } catch {
-    return null;
+    throw new SymposiumFrontmatterParseError();
   }
   if (!frontmatter || typeof frontmatter !== "object") {
     return null;

--- a/src/symposium/symposiumFrontmatter.ts
+++ b/src/symposium/symposiumFrontmatter.ts
@@ -21,7 +21,9 @@ export class SymposiumPropertyConflictError extends Error {
  */
 export class SymposiumFrontmatterParseError extends Error {
   constructor() {
-    super("This note's frontmatter is not valid YAML. Fix it before publishing to Symposium.");
+    super(
+      "This note's frontmatter must be a YAML property map. Fix it before publishing to Symposium."
+    );
     this.name = "SymposiumFrontmatterParseError";
     Object.setPrototypeOf(this, SymposiumFrontmatterParseError.prototype);
   }
@@ -55,8 +57,11 @@ export async function getSymposiumDocId(app: App, file: TFile): Promise<string |
   } catch {
     throw new SymposiumFrontmatterParseError();
   }
-  if (!frontmatter || typeof frontmatter !== "object") {
+  if (frontmatter === null || frontmatter === undefined) {
     return null;
+  }
+  if (typeof frontmatter !== "object" || Array.isArray(frontmatter)) {
+    throw new SymposiumFrontmatterParseError();
   }
   const properties = frontmatter as Record<string, unknown>;
   if (!Object.prototype.hasOwnProperty.call(properties, SYMPOSIUM_PROPERTY)) {

--- a/src/symposium/symposiumFrontmatter.ts
+++ b/src/symposium/symposiumFrontmatter.ts
@@ -1,0 +1,53 @@
+import { SYMPOSIUM_DOC_ID_PATTERN } from "@/symposium/constants";
+import { App, TFile } from "obsidian";
+
+const SYMPOSIUM_PROPERTY = "symposium";
+
+/**
+ * Returns a Symposium identity only when the frontmatter value matches the server's id format.
+ *
+ * @param value The raw frontmatter property value.
+ */
+export function parseSymposiumDocId(value: unknown): string | null {
+  return typeof value === "string" && SYMPOSIUM_DOC_ID_PATTERN.test(value) ? value : null;
+}
+
+/**
+ * Reads the current valid Symposium identity from Obsidian's metadata cache.
+ *
+ * @param app The Obsidian application that owns the note.
+ * @param file The note whose publication identity should be read.
+ */
+export function getSymposiumDocId(app: App, file: TFile): string | null {
+  const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+  return parseSymposiumDocId(frontmatter?.[SYMPOSIUM_PROPERTY]);
+}
+
+/**
+ * Saves a server-issued Symposium identity without replacing unrelated frontmatter.
+ *
+ * @param app The Obsidian application that owns the note.
+ * @param file The note whose publication identity should be saved.
+ * @param docId The validated identity returned by Symposium.
+ */
+export async function saveSymposiumDocId(app: App, file: TFile, docId: string): Promise<void> {
+  if (!SYMPOSIUM_DOC_ID_PATTERN.test(docId)) {
+    throw new Error("Cannot save an invalid Symposium document id.");
+  }
+
+  await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+    frontmatter[SYMPOSIUM_PROPERTY] = docId;
+  });
+}
+
+/**
+ * Removes the local Symposium identity without changing other frontmatter.
+ *
+ * @param app The Obsidian application that owns the note.
+ * @param file The note that should return to an unpublished state.
+ */
+export async function removeSymposiumDocId(app: App, file: TFile): Promise<void> {
+  await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+    delete frontmatter[SYMPOSIUM_PROPERTY];
+  });
+}

--- a/src/symposium/symposiumFrontmatter.ts
+++ b/src/symposium/symposiumFrontmatter.ts
@@ -1,5 +1,5 @@
 import { SYMPOSIUM_DOC_ID_PATTERN } from "@/symposium/constants";
-import { App, TFile } from "obsidian";
+import { App, parseYaml, TFile } from "obsidian";
 
 const SYMPOSIUM_PROPERTY = "symposium";
 
@@ -13,14 +13,28 @@ export function parseSymposiumDocId(value: unknown): string | null {
 }
 
 /**
- * Reads the current valid Symposium identity from Obsidian's metadata cache.
+ * Reads the current valid Symposium identity from the note itself.
  *
  * @param app The Obsidian application that owns the note.
  * @param file The note whose publication identity should be read.
  */
-export function getSymposiumDocId(app: App, file: TFile): string | null {
-  const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
-  return parseSymposiumDocId(frontmatter?.[SYMPOSIUM_PROPERTY]);
+export async function getSymposiumDocId(app: App, file: TFile): Promise<string | null> {
+  const markdown = (await app.vault.read(file)).replace(/^\uFEFF/, "");
+  const yaml = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/)?.[1];
+  if (yaml === undefined) {
+    return null;
+  }
+  let frontmatter: unknown;
+  try {
+    frontmatter = parseYaml(yaml);
+  } catch {
+    return null;
+  }
+  return parseSymposiumDocId(
+    frontmatter && typeof frontmatter === "object"
+      ? (frontmatter as Record<string, unknown>)[SYMPOSIUM_PROPERTY]
+      : undefined
+  );
 }
 
 /**
@@ -29,15 +43,32 @@ export function getSymposiumDocId(app: App, file: TFile): string | null {
  * @param app The Obsidian application that owns the note.
  * @param file The note whose publication identity should be saved.
  * @param docId The validated identity returned by Symposium.
+ * @param expectedDocId The identity that was current when the remote action began.
  */
-export async function saveSymposiumDocId(app: App, file: TFile, docId: string): Promise<void> {
+export async function saveSymposiumDocId(
+  app: App,
+  file: TFile,
+  docId: string,
+  expectedDocId: string | null
+): Promise<boolean> {
   if (!SYMPOSIUM_DOC_ID_PATTERN.test(docId)) {
     throw new Error("Cannot save an invalid Symposium document id.");
   }
 
+  let saved = false;
   await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+    const currentDocId = parseSymposiumDocId(frontmatter[SYMPOSIUM_PROPERTY]);
+    if (currentDocId === docId) {
+      saved = true;
+      return;
+    }
+    if (currentDocId !== expectedDocId) {
+      return;
+    }
     frontmatter[SYMPOSIUM_PROPERTY] = docId;
+    saved = true;
   });
+  return saved;
 }
 
 /**
@@ -45,9 +76,25 @@ export async function saveSymposiumDocId(app: App, file: TFile, docId: string): 
  *
  * @param app The Obsidian application that owns the note.
  * @param file The note that should return to an unpublished state.
+ * @param expectedDocId The identity whose remote document was deleted.
  */
-export async function removeSymposiumDocId(app: App, file: TFile): Promise<void> {
+export async function removeSymposiumDocId(
+  app: App,
+  file: TFile,
+  expectedDocId: string
+): Promise<boolean> {
+  let removed = false;
   await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+    if (!Object.prototype.hasOwnProperty.call(frontmatter, SYMPOSIUM_PROPERTY)) {
+      removed = true;
+      return;
+    }
+    const currentDocId = parseSymposiumDocId(frontmatter[SYMPOSIUM_PROPERTY]);
+    if (currentDocId !== expectedDocId) {
+      return;
+    }
     delete frontmatter[SYMPOSIUM_PROPERTY];
+    removed = true;
   });
+  return removed;
 }

--- a/src/symposium/symposiumFrontmatter.ts
+++ b/src/symposium/symposiumFrontmatter.ts
@@ -4,7 +4,21 @@ import { App, parseYaml, TFile } from "obsidian";
 const SYMPOSIUM_PROPERTY = "symposium";
 
 /**
+ * Signals that a note already uses the reserved Symposium property for unrelated metadata.
+ */
+export class SymposiumPropertyConflictError extends Error {
+  constructor() {
+    super(
+      "This note already uses the symposium property for an unrecognized value. Rename or remove that property before publishing."
+    );
+    this.name = "SymposiumPropertyConflictError";
+    Object.setPrototypeOf(this, SymposiumPropertyConflictError.prototype);
+  }
+}
+
+/**
  * Returns a Symposium identity only when the frontmatter value matches the server's id format.
+ * Throws when the reserved property is occupied by unrelated metadata so callers cannot overwrite it.
  *
  * @param value The raw frontmatter property value.
  */
@@ -30,11 +44,18 @@ export async function getSymposiumDocId(app: App, file: TFile): Promise<string |
   } catch {
     return null;
   }
-  return parseSymposiumDocId(
-    frontmatter && typeof frontmatter === "object"
-      ? (frontmatter as Record<string, unknown>)[SYMPOSIUM_PROPERTY]
-      : undefined
-  );
+  if (!frontmatter || typeof frontmatter !== "object") {
+    return null;
+  }
+  const properties = frontmatter as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(properties, SYMPOSIUM_PROPERTY)) {
+    return null;
+  }
+  const docId = parseSymposiumDocId(properties[SYMPOSIUM_PROPERTY]);
+  if (!docId) {
+    throw new SymposiumPropertyConflictError();
+  }
+  return docId;
 }
 
 /**
@@ -58,6 +79,9 @@ export async function saveSymposiumDocId(
   let saved = false;
   await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
     const currentDocId = parseSymposiumDocId(frontmatter[SYMPOSIUM_PROPERTY]);
+    if (Object.prototype.hasOwnProperty.call(frontmatter, SYMPOSIUM_PROPERTY) && !currentDocId) {
+      return;
+    }
     if (currentDocId === docId) {
       saved = true;
       return;

--- a/src/symposium/symposiumFrontmatter.ts
+++ b/src/symposium/symposiumFrontmatter.ts
@@ -39,6 +39,10 @@ export function parseSymposiumDocId(value: unknown): string | null {
   return typeof value === "string" && SYMPOSIUM_DOC_ID_PATTERN.test(value) ? value : null;
 }
 
+function isFrontmatterProperties(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
  * Reads the current valid Symposium identity from the note itself.
  *
@@ -60,14 +64,13 @@ export async function getSymposiumDocId(app: App, file: TFile): Promise<string |
   if (frontmatter === null || frontmatter === undefined) {
     return null;
   }
-  if (typeof frontmatter !== "object" || Array.isArray(frontmatter)) {
+  if (!isFrontmatterProperties(frontmatter)) {
     throw new SymposiumFrontmatterParseError();
   }
-  const properties = frontmatter as Record<string, unknown>;
-  if (!Object.prototype.hasOwnProperty.call(properties, SYMPOSIUM_PROPERTY)) {
+  if (!Object.prototype.hasOwnProperty.call(frontmatter, SYMPOSIUM_PROPERTY)) {
     return null;
   }
-  const docId = parseSymposiumDocId(properties[SYMPOSIUM_PROPERTY]);
+  const docId = parseSymposiumDocId(frontmatter[SYMPOSIUM_PROPERTY]);
   if (!docId) {
     throw new SymposiumPropertyConflictError();
   }
@@ -93,7 +96,10 @@ export async function saveSymposiumDocId(
   }
 
   let saved = false;
-  await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+  await app.fileManager.processFrontMatter(file, (frontmatter: unknown) => {
+    if (!isFrontmatterProperties(frontmatter)) {
+      throw new SymposiumFrontmatterParseError();
+    }
     const currentDocId = parseSymposiumDocId(frontmatter[SYMPOSIUM_PROPERTY]);
     if (Object.prototype.hasOwnProperty.call(frontmatter, SYMPOSIUM_PROPERTY) && !currentDocId) {
       return;
@@ -124,7 +130,10 @@ export async function removeSymposiumDocId(
   expectedDocId: string
 ): Promise<boolean> {
   let removed = false;
-  await app.fileManager.processFrontMatter(file, (frontmatter: Record<string, unknown>) => {
+  await app.fileManager.processFrontMatter(file, (frontmatter: unknown) => {
+    if (!isFrontmatterProperties(frontmatter)) {
+      throw new SymposiumFrontmatterParseError();
+    }
     if (!Object.prototype.hasOwnProperty.call(frontmatter, SYMPOSIUM_PROPERTY)) {
       removed = true;
       return;

--- a/src/symposium/types.ts
+++ b/src/symposium/types.ts
@@ -1,0 +1,22 @@
+export interface SymposiumDocument {
+  title: string;
+  html: string;
+  byteLength: number;
+}
+
+export interface SymposiumReceipt {
+  docId: string;
+  url: string;
+  version: number;
+}
+
+export type SymposiumAction = "publish" | "update" | "delete";
+
+export interface SymposiumErrorPayload {
+  code: string;
+  message: string;
+}
+
+export interface SymposiumErrorResponse {
+  error: SymposiumErrorPayload;
+}


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#234

## Summary

### Why

Symposium's HTML API is live, but Copilot had no path from an Obsidian note to a public link. Users could not publish the active note from the command palette or menus, update the same shared document after editing, or withdraw it without leaving Obsidian.

### What

Add one state-aware **Publish file to Symposium** flow across the command palette, File explorer menu, note menu, and editor Copilot submenu. Copilot renders the note through Obsidian's reading-view renderer, packages a neutral self-contained document with local images, and asks Symposium to Publish, Update, or Delete it.

## Decisions

- The modal names the note and explains public-link consequences before its direct Publish, Update, or Delete action.
- Issue #235 is not a dependency: this ships a neutral readable baseline, while selectable themes and richer presentation remain follow-up work.
- Symposium is the sole authority for license validity and plan eligibility. The client displays its structured `401/unauthorized` message instead of duplicating entitlement policy.
- The server owns document identity and URLs. Copilot stores only the returned 16-character `docId` in `symposium` frontmatter and uses returned URLs verbatim.
- Copied notes with the same valid id intentionally update the same shared page.
- A stale PUT falls back to POST only for structured `404/not_found`; no other error creates a new document.
- Remote success and local frontmatter failure remain explicit: the receipt survives dialog reopen and retry saves only the local identity.
- A lost or malformed initial POST receipt is treated as ambiguous and cannot be retried in the same plugin session, preventing duplicate untracked pages.
- Invalid YAML is reported before rendering or contacting Symposium.
- A successful Update whose note identity disappears or becomes unreadable retains its receipt so reopening cannot publish a second page.
- A fallback Publish whose stale identity disappears also retains its receipt instead of allowing another POST.
- Image preflight budgets the sanitized replacement delta; the exact final 10 MiB serialization check remains authoritative.
- Delete recovery survives dialog reopen, and atomic frontmatter callbacks revalidate mapping shape after remote success.
- A confirmed action may continue after its modal closes, so a stalled request cannot trap the user in the dialog.

## Scope

Budget gate: PASS — 21 files, +4197/−9; this is the smallest reviewed shape that separates the Obsidian renderer, fixed wire client, identity lifecycle, modal state, and four routing surfaces while omitting themes, previews, and local entitlement machinery.

## Changes

- `edd52953` renders reading-view DOM into self-contained neutral HTML, embeds vault images, sanitizes active content, and enforces the final 10 MiB UTF-8 limit.
- `2de89fc0` adds the fixed-origin Symposium client with strict receipt validation, structured error preservation, and idempotent Delete handling.
- `b041921b` adds frontmatter identity management, per-file action locking, state-aware confirmations, and local-only partial-success recovery.
- `ec06740e` exposes the flow through all four note surfaces with exact clicked-file targeting and documents the workflow.
- `c5cc2dd0` hardens popout routing, concurrent frontmatter writes, modal/plugin teardown, capability referrers, standalone math, task-state fidelity, and oversize error handling.
- `f1690245` publishes from a fresh vault read and directly covers modal teardown during an in-flight action.
- `f94b3a21` rejects oversized or cumulatively oversized local images before expensive reads and base64 encoding.
- `80bd2de2` rechecks note identity after a successful Update and reports partial success without rewriting a newer identity.
- `9acec11b` preserves occupied non-ID `symposium` metadata and safe scheme-relative links.
- `15eb9b73` budgets the full rendered document before asset reads and preserves scheme-relative remote images.
- `154621a7` blocks ambiguous POST retries, retains successful receipts across dialog reopen, and rejects malformed frontmatter before publishing.
- `5b93e0a1` treats accepted POSTs with malformed receipts as ambiguous so they cannot orphan a second page on retry.
- `7bd78754` retains successful Update receipts when the note identity is absent or unreadable, blocking a later duplicate Publish.
- `392d9903` retains fallback Publish receipts, rejects non-mapping YAML roots, and budgets embedded-image replacement deltas.
- `54edceb4` preserves Delete recovery across dialog reopen and revalidates atomic frontmatter mapping shape.
- `c088868d` lets users close a pending action and removes the obsolete forced-close state.
- `3603d2e2` replaces the redundant action-selector/confirmation sequence with one direct action row and keeps result actions in one footer.

## Verification

- `npm test -- --runInBand` — 343 suites and 4,886 tests passed.
- Focused final recovery tests — 2 suites and 46 tests passed.
- Focused modal and publisher lifecycle tests — 2 suites and 40 tests passed.
- Focused modal interaction tests — 1 suite and 10 tests passed.
- `npm run format` and `npm run format:check` passed.
- `npm run lint` passed.
- `npx tsc --noEmit` passed.
- `npm run build` passed.
- Live Publish/Update/Delete smoke was not run because the test-vault harness cannot inject a `requestUrl` stub; exercising it would use a real license and the production Symposium origin.

## Notes / follow-ups

- Issue #235 remains the home for selectable themes and richer presentation.
- Symposium may cache the latest public URL briefly after an update; versioned URLs and already-fetched copies cannot be recalled after withdrawal.
- GitHub did not register the cross-repo closing reference; close `logancyang/obsidian-copilot-preview#234` manually when this PR merges.

🤖 Generated with [Codex](https://openai.com/codex/)
