### PR TITLE
feat(agent-mode): publish Symposium pages with recoverable receipts

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -71,11 +71,9 @@ The agent never reloads or restarts Obsidian, nor does it reload, disable, or un
 
 ### Publish to Symposium
 
-Claude, Codex, and OpenCode also receive a built-in **Publish to Symposium** skill. Ask the agent to publish or share an existing Markdown note as a web page. The source note is required because it retains the published document ID. The agent creates a complete, self-contained HTML document itself, including static HTML or SVG for Obsidian-only rendered content such as Bases and Mermaid diagrams.
+Ask Claude, Codex, or OpenCode to publish an existing Markdown note as a web page. The agent creates self-contained HTML, renders Mermaid and Bases as static content, then asks for explicit confirmation because the resulting link is public.
 
-After the HTML is ready, the agent shows what it intends to publish, reminds you that anyone with the resulting link can read it, and asks for explicit confirmation. Declining sends nothing to Symposium.
-
-The skill handles an initial publish only. A successful publish records the receipt in `copilot/symposium/published-documents.md` before storing the returned document ID in the source note's `symposium` property, then returns Symposium's public URL. Use **Publish file to Symposium** from the command palette or note menu to update or withdraw an existing page.
+The skill handles initial publishing only. It appends the receipt to `copilot/symposium/published-documents.md` and stores the document ID in the required source note's `symposium` property. Use **Publish file to Symposium** to update or withdraw the page.
 
 ### Always-Enabled Tools
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -73,7 +73,7 @@ The agent never reloads or restarts Obsidian, nor does it reload, disable, or un
 
 Ask Claude, Codex, or OpenCode to publish an existing Markdown note as a web page. The agent creates self-contained HTML, renders Mermaid and Bases as static content, then asks for explicit confirmation because the resulting link is public.
 
-The skill handles initial publishing only. It appends the receipt to `copilot/symposium/published-documents.md` and stores the document ID in the required source note's `symposium` property. Use **Publish file to Symposium** to update or withdraw the page.
+The skill handles initial publishing only. It appends the receipt to `copilot/symposium/published-documents.md` and stores the full public link in the required source note's `symposium` property. Use **Publish file to Symposium** to update or withdraw the page.
 
 ### Always-Enabled Tools
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -73,7 +73,7 @@ The agent never reloads or restarts Obsidian, nor does it reload, disable, or un
 
 Ask Claude, Codex, or OpenCode to publish an existing Markdown note as a web page. The agent creates self-contained HTML, renders Mermaid and Bases as static content, then asks for explicit confirmation because the resulting link is public.
 
-The skill handles initial publishing only. It appends the receipt to `copilot/symposium/published-documents.md` and stores the full public link in the required source note's `symposium` property. Use **Publish file to Symposium** to update or withdraw the page.
+The skill handles initial publishing only. It appends the receipt to the hidden history file `.symposium/publish-history.md` and stores the full public link in the required source note's `symposium` property. Use **Publish file to Symposium** to update or withdraw the page.
 
 ### Always-Enabled Tools
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -69,6 +69,14 @@ When inspecting open tabs, the agent preserves Markdown notes, other file-backed
 
 The agent never reloads or restarts Obsidian, nor does it reload, disable, or uninstall the Copilot plugin hosting its session. Those actions terminate in-flight agent work. When a reload is required to finish verification, the agent leaves it for you to perform after the session ends. Reloading a different plugin remains available for plugin development.
 
+### Publish to Symposium
+
+Claude, Codex, and OpenCode also receive a built-in **Publish to Symposium** skill. Ask the agent to publish or share an existing Markdown note as a web page. The source note is required because it retains the published document ID. The agent creates a complete, self-contained HTML document itself, including static HTML or SVG for Obsidian-only rendered content such as Bases and Mermaid diagrams.
+
+After the HTML is ready, the agent shows what it intends to publish, reminds you that anyone with the resulting link can read it, and asks for explicit confirmation. Declining sends nothing to Symposium.
+
+The skill handles an initial publish only. A successful publish records the receipt in `copilot/symposium/published-documents.md` before storing the returned document ID in the source note's `symposium` property, then returns Symposium's public URL. Use **Publish file to Symposium** from the command palette or note menu to update or withdraw an existing page.
+
 ### Always-Enabled Tools
 
 These tools are always available and cannot be disabled:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,9 +97,9 @@ The AI will automatically include your currently open note as context, so you ca
 
 Run **Publish file to Symposium** from the command palette, a Markdown note's File explorer menu, its note menu, or the editor's **Copilot** submenu. Copilot asks for confirmation because anyone with the resulting link can read the published page.
 
-After publishing, Copilot stores the Symposium document ID in the note's `symposium` property. Run the same action again to update the existing page or withdraw its public link. Symposium deletes its stored copy, but it cannot recall copies that readers or caches already fetched. Withdrawing the page also removes the property from the note.
+After publishing, Copilot stores the full public link in the note's `symposium` property. Run the same action again to update the existing page or withdraw its public link. Symposium deletes its stored copy, but it cannot recall copies that readers or caches already fetched. Withdrawing the page also removes the property from the note.
 
-Copilot appends successful publishes, updates, and withdrawals to the plain Markdown ledger at `copilot/symposium/published-documents.md`. It is recovery history only: the note's `symposium` property remains the source of truth. If that property is damaged, recover its 16-character ID from the ledger or public URL; ledger rows remain after a note is deleted.
+Copilot appends successful publishes, updates, and withdrawals to the plain Markdown ledger at `copilot/symposium/published-documents.md`. It is recovery history only: the note's `symposium` property remains the source of truth. If that property is damaged, recover the public link from the ledger; ledger rows remain after a note is deleted.
 
 If Publish or Delete succeeds but the note's property cannot be updated, reopening the dialog resumes that local change without contacting Symposium again. If the initial publish response is lost, Copilot blocks another attempt until the plugin reloads to avoid creating a duplicate page.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,7 +99,7 @@ Run **Publish file to Symposium** from the command palette, a Markdown note's Fi
 
 After publishing, Copilot stores the full public link in the note's `symposium` property. Run the same action again to update the existing page or withdraw its public link. Symposium deletes its stored copy, but it cannot recall copies that readers or caches already fetched. Withdrawing the page also removes the property from the note.
 
-Copilot appends successful publishes, updates, and withdrawals to the plain Markdown ledger at `copilot/symposium/published-documents.md`. It is recovery history only: the note's `symposium` property remains the source of truth. If that property is damaged, recover the public link from the ledger; ledger rows remain after a note is deleted.
+Copilot appends successful publishes, updates, and withdrawals to the hidden Markdown history file at `.symposium/publish-history.md`. It is recovery history only: the note's `symposium` property remains the source of truth. If that property is damaged, recover the public link from the history file; its rows remain after a note is deleted.
 
 If Publish or Delete succeeds but the note's property cannot be updated, reopening the dialog resumes that local change without contacting Symposium again. If the initial publish response is lost, Copilot blocks another attempt until the plugin reloads to avoid creating a duplicate page.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,6 +99,10 @@ Run **Publish file to Symposium** from the command palette, a Markdown note's Fi
 
 After publishing, Copilot stores the Symposium document ID in the note's `symposium` property. Run the same action again to update the existing page or withdraw its public link. Symposium deletes its stored copy, but it cannot recall copies that readers or caches already fetched. Withdrawing the page also removes the property from the note.
 
+Copilot also appends every successful publish, update, and withdrawal to the plain Markdown ledger at `copilot/symposium/published-documents.md`. The ledger preserves document IDs and public URLs even if a source note or its property is later deleted or damaged. It is recovery history only: the note's `symposium` property remains the source of truth for Publish, Update, and Delete. Deleting the ledger does not change those actions.
+
+If a `symposium` property is damaged, recover the 16-character document ID from the ledger or from the `/d/<document-id>` part of its public URL, then repair the property before updating or withdrawing the page. Publication traces deliberately remain in the ledger after deleting a note.
+
 If Publish or Delete succeeds but the note's property cannot be updated, reopening the dialog resumes that local change without contacting Symposium again. If the initial publish response is lost, Copilot blocks another attempt until the plugin reloads to avoid creating a duplicate page.
 
 Copilot stops before publishing when a note's frontmatter is malformed or is not a YAML property map.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,9 +99,7 @@ Run **Publish file to Symposium** from the command palette, a Markdown note's Fi
 
 After publishing, Copilot stores the Symposium document ID in the note's `symposium` property. Run the same action again to update the existing page or withdraw its public link. Symposium deletes its stored copy, but it cannot recall copies that readers or caches already fetched. Withdrawing the page also removes the property from the note.
 
-Copilot also appends every successful publish, update, and withdrawal to the plain Markdown ledger at `copilot/symposium/published-documents.md`. The ledger preserves document IDs and public URLs even if a source note or its property is later deleted or damaged. It is recovery history only: the note's `symposium` property remains the source of truth for Publish, Update, and Delete. Deleting the ledger does not change those actions.
-
-If a `symposium` property is damaged, recover the 16-character document ID from the ledger or from the `/d/<document-id>` part of its public URL, then repair the property before updating or withdrawing the page. Publication traces deliberately remain in the ledger after deleting a note.
+Copilot appends successful publishes, updates, and withdrawals to the plain Markdown ledger at `copilot/symposium/published-documents.md`. It is recovery history only: the note's `symposium` property remains the source of truth. If that property is damaged, recover its 16-character ID from the ledger or public URL; ledger rows remain after a note is deleted.
 
 If Publish or Delete succeeds but the note's property cannot be updated, reopening the dialog resumes that local change without contacting Symposium again. If the initial publish response is lost, Copilot blocks another attempt until the plugin reloads to avoid creating a duplicate page.
 

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -20,6 +20,7 @@ import { ClaudeSdkBackendProcess } from "@/agentMode/sdk/ClaudeSdkBackendProcess
 import { getCachedSdkCatalog, synthesizeEffortConfigOption } from "@/agentMode/sdk/effortOption";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
 import { buildBuiltinSkillEnv } from "@/agentMode/backends/shared/builtinSkillEnv";
+import { getVaultBase } from "@/utils/vaultPath";
 import type {
   BackendConfigOption,
   EnabledModelEntry,
@@ -304,7 +305,7 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
       getEnvOverrides: () => getSettings().agentMode?.backends?.claude?.envOverrides,
       // Plugin-managed runtime paths and credentials for builtin skills.
       // Passed as a callback so `sdk/` need not import `backends/` (lint boundary).
-      getManagedEnv: () => buildBuiltinSkillEnv(args.clientVersion),
+      getManagedEnv: () => buildBuiltinSkillEnv(args.clientVersion, getVaultBase(args.app) ?? ""),
       checkAuth: async () =>
         (await getClaudeAuthStatus(claudePath, claudeChildEnv(getSettings()))).loggedIn,
       checkCompatibility: () =>

--- a/src/agentMode/backends/codex/CodexBackend.test.ts
+++ b/src/agentMode/backends/codex/CodexBackend.test.ts
@@ -6,6 +6,7 @@ import {
   updateCachedSystemPrompts,
 } from "@/system-prompts/state";
 import type { UserSystemPrompt } from "@/system-prompts/type";
+import { SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import { CodexBackend, toTomlBasicString } from "./CodexBackend";
 
 jest.mock("@/logger", () => ({
@@ -66,6 +67,7 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
     const backend = new CodexBackend();
     const desc = await backend.buildSpawnDescriptor({ vaultBasePath: "/vault" });
     expect(desc.command).toBe("/usr/local/bin/codex-acp");
+    expect(desc.env[SYMPOSIUM_WORKSPACE_ROOT_ENV]).toBe("/vault");
 
     const config = JSON.parse(desc.env.CODEX_CONFIG as string);
     expect(config.developer_instructions).toContain("Obsidian Copilot");

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -17,14 +17,14 @@ export class CodexBackend implements AcpBackend {
   readonly id = "codex" as const;
   readonly displayName = "Codex";
 
-  async buildSpawnDescriptor(_ctx: { vaultBasePath: string }): Promise<AcpSpawnDescriptor> {
+  async buildSpawnDescriptor(ctx: { vaultBasePath: string }): Promise<AcpSpawnDescriptor> {
     const descriptor = buildSimpleSpawnDescriptor(
       getSettings().agentMode?.backends?.codex?.binaryPath,
       "Codex binary path not configured. Open Agent Mode settings and set the path to codex-acp.",
       getSettings().agentMode?.backends?.codex?.envOverrides,
       {
         // Builtin skills consume plugin-managed runtime paths and credentials.
-        ...(await buildBuiltinSkillEnv()),
+        ...(await buildBuiltinSkillEnv("", ctx.vaultBasePath)),
         // Newer adapters derive the initial ACP mode from this variable rather
         // than Codex's approval/sandbox config. User env overrides still win.
         INITIAL_AGENT_MODE: "agent",

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -850,6 +850,7 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
     const desc = await backend.buildSpawnDescriptor({ vaultBasePath: "/vault/abs" });
     expect(desc.command).toBe("/path/to/opencode");
     expect(desc.args).toEqual(["acp", "--cwd", "/vault/abs"]);
+    expect(desc.env.SYMPOSIUM_WORKSPACE_ROOT).toBe("/vault/abs");
     expect(desc.env.OPENCODE_CONFIG_CONTENT).toBeDefined();
     const cfg = JSON.parse(desc.env.OPENCODE_CONFIG_CONTENT as string);
     expect(cfg.provider.anthropic.options).toEqual({ apiKey: "anth-xyz" });

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -125,7 +125,7 @@ export class OpencodeBackend implements AcpBackend {
       );
     }
     // Builtin skills consume plugin-managed runtime paths and credentials.
-    const builtinSkillEnv = await buildBuiltinSkillEnv();
+    const builtinSkillEnv = await buildBuiltinSkillEnv("", ctx.vaultBasePath);
 
     return {
       command: binaryPath,

--- a/src/agentMode/backends/shared/builtinSkillEnv.test.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.test.ts
@@ -4,7 +4,7 @@ import { getDecryptedKey } from "@/encryptionService";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
 import { BREVILABS_API_BASE_URL } from "@/constants";
 import { PLUS_ENV } from "@/agentMode/skills/builtin/builtinSkills";
-import { SYMPOSIUM_TOKEN_ENV } from "@/symposium/constants";
+import { SYMPOSIUM_TOKEN_ENV, SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import {
   COPILOT_OBSIDIAN_CLI_ENV,
   resolveObsidianCliPath,
@@ -84,6 +84,15 @@ describe("builtinSkillEnv", () => {
       mockGetMiyoCustomUrl.mockReturnValue("http://192.168.1.10:8742");
       expect(await buildBuiltinSkillEnv()).toEqual({ MIYO_URL: "http://192.168.1.10:8742" });
       // Non-Plus: no relay env, and no decryption attempted.
+      expect(mockGetDecryptedKey).not.toHaveBeenCalled();
+    });
+
+    it("injects the host workspace root independently of Plus", async () => {
+      mockGetSettings.mockReturnValue({ isPaidUser: false });
+
+      expect(await buildBuiltinSkillEnv("", "/vault")).toEqual({
+        [SYMPOSIUM_WORKSPACE_ROOT_ENV]: "/vault",
+      });
       expect(mockGetDecryptedKey).not.toHaveBeenCalled();
     });
 

--- a/src/agentMode/backends/shared/builtinSkillEnv.test.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.test.ts
@@ -4,6 +4,7 @@ import { getDecryptedKey } from "@/encryptionService";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
 import { BREVILABS_API_BASE_URL } from "@/constants";
 import { PLUS_ENV } from "@/agentMode/skills/builtin/builtinSkills";
+import { SYMPOSIUM_TOKEN_ENV } from "@/symposium/constants";
 import {
   COPILOT_OBSIDIAN_CLI_ENV,
   resolveObsidianCliPath,
@@ -35,7 +36,7 @@ describe("builtinSkillEnv", () => {
   });
 
   describe("buildBuiltinSkillEnv()", () => {
-    it("returns the decrypted license + relay config for an active Plus user", async () => {
+    it("returns the service credentials and relay config for an active Plus user", async () => {
       mockGetSettings.mockReturnValue({
         isPaidUser: true,
         plusLicenseKey: "encrypted-key",
@@ -47,6 +48,7 @@ describe("builtinSkillEnv", () => {
 
       expect(env).toEqual({
         [PLUS_ENV.licenseKey]: "plain-key",
+        [SYMPOSIUM_TOKEN_ENV]: "plain-key",
         [PLUS_ENV.baseUrl]: BREVILABS_API_BASE_URL,
         [PLUS_ENV.userId]: "user-123",
         [PLUS_ENV.clientVersion]: "4.0.0",
@@ -107,6 +109,7 @@ describe("builtinSkillEnv", () => {
       expect(await buildBuiltinSkillEnv("4.0.0")).toEqual({
         MIYO_URL: "http://miyo.example:8742",
         [PLUS_ENV.licenseKey]: "plain-key",
+        [SYMPOSIUM_TOKEN_ENV]: "plain-key",
         [PLUS_ENV.baseUrl]: BREVILABS_API_BASE_URL,
         [PLUS_ENV.userId]: "user-123",
         [PLUS_ENV.clientVersion]: "4.0.0",

--- a/src/agentMode/backends/shared/builtinSkillEnv.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.ts
@@ -5,7 +5,7 @@ import { logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
 import { PLUS_ENV } from "@/agentMode/skills/builtin/builtinSkills";
-import { SYMPOSIUM_TOKEN_ENV } from "@/symposium/constants";
+import { SYMPOSIUM_TOKEN_ENV, SYMPOSIUM_WORKSPACE_ROOT_ENV } from "@/symposium/constants";
 import {
   COPILOT_OBSIDIAN_CLI_ENV,
   resolveObsidianCliPath,
@@ -30,18 +30,24 @@ const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
  *   base URL + user id + client version, only for an active Plus subscriber with
  *   a key on file. Absent otherwise, so the relay skills exit with the upgrade
  *   prompt.
- * - **Symposium** (`SYMPOSIUM_TOKEN`): the same credential under the
- *   service-owned name expected by the portable publishing skill.
+ * - **Symposium** (`SYMPOSIUM_TOKEN`, `SYMPOSIUM_WORKSPACE_ROOT`): the same
+ *   credential under the service-owned name expected by the portable
+ *   publishing skill, plus the host workspace root for its local history.
  * - **Miyo** (`MIYO_URL`): the user's custom/remote Miyo server URL when set, so
  *   the bundled `miyo` CLI targets their configured service instead of local
  *   loopback discovery (the only way Miyo works on mobile or against a remote
  *   host). Independent of Plus — self-host users may use Miyo without a license.
+ * @param clientVersion Version reported to the Copilot Plus relay.
+ * @param workspaceRootAbs Absolute host workspace root used by portable skills.
  */
 export async function buildBuiltinSkillEnv(
-  clientVersion = ""
+  clientVersion = "",
+  workspaceRootAbs = ""
 ): Promise<Readonly<Record<string, string>>> {
   const settings = getSettings();
   const env: Record<string, string> = {};
+
+  if (workspaceRootAbs) env[SYMPOSIUM_WORKSPACE_ROOT_ENV] = workspaceRootAbs;
 
   const obsidianCliPath = resolveObsidianCliPath({
     platform: process.platform,

--- a/src/agentMode/backends/shared/builtinSkillEnv.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.ts
@@ -5,6 +5,7 @@ import { logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
 import { PLUS_ENV } from "@/agentMode/skills/builtin/builtinSkills";
+import { SYMPOSIUM_TOKEN_ENV } from "@/symposium/constants";
 import {
   COPILOT_OBSIDIAN_CLI_ENV,
   resolveObsidianCliPath,
@@ -19,7 +20,7 @@ const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
 /**
  * Build the plugin-managed environment for builtin skill scripts. Composes
  * independent contributions, all merged BEFORE the user's `envOverrides` so a
- * user can still shadow them; the decrypted key lives only in the agent
+ * user can still shadow them; the credential lives only in the agent
  * subprocess env (never written to disk in the skill files):
  *
  * - **Obsidian CLI** (`COPILOT_OBSIDIAN_CLI`): terminal-capable executable
@@ -29,6 +30,8 @@ const EMPTY_MANAGED_ENV: Readonly<Record<string, string>> = Object.freeze({});
  *   base URL + user id + client version, only for an active Plus subscriber with
  *   a key on file. Absent otherwise, so the relay skills exit with the upgrade
  *   prompt.
+ * - **Symposium** (`SYMPOSIUM_TOKEN`): the same credential under the
+ *   service-owned name expected by the portable publishing skill.
  * - **Miyo** (`MIYO_URL`): the user's custom/remote Miyo server URL when set, so
  *   the bundled `miyo` CLI targets their configured service instead of local
  *   loopback discovery (the only way Miyo works on mobile or against a remote
@@ -58,6 +61,7 @@ export async function buildBuiltinSkillEnv(
       const licenseKey = await getDecryptedKey(settings.plusLicenseKey);
       if (licenseKey) {
         env[PLUS_ENV.licenseKey] = licenseKey;
+        env[SYMPOSIUM_TOKEN_ENV] = licenseKey;
         env[PLUS_ENV.baseUrl] = BREVILABS_API_BASE_URL;
         env[PLUS_ENV.userId] = settings.userId ?? "";
         env[PLUS_ENV.clientVersion] = clientVersion;

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -204,12 +204,14 @@ describe("builtinSkills", () => {
       expect(sh).toContain(PLUS_ENV.licenseKey);
       expect(sh).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
       expect(sh).toContain('[ -f "$SOURCE" ]');
-      expect(sh).toContain('fs.readFileSync(process.argv[2], "utf8")');
+      expect(sh).toContain('properties path="$SOURCE_PATH" format=json');
+      expect(sh).toContain('json_escape "$FINAL_LF" < "$FILE"');
       expect(sh).toContain("Authorization: Bearer $KEY");
       expect(sh).toContain("--data-binary @-");
       expect(sh).toContain("source_is_unpublished");
       expect(sh).toContain("JSON.parse(input)");
       expect(sh).toContain("Number.isSafeInteger(receipt.version)");
+      expect(sh).not.toContain("command -v node");
       expect(sh).toContain("abcdefghjkmnpqrstvwxyz");
       expect(sh).toContain("Do not retry");
 
@@ -217,11 +219,12 @@ describe("builtinSkills", () => {
       expect(ps1).toContain(PLUS_ENV.licenseKey);
       expect(ps1).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
       expect(ps1).toContain("Test-Path -LiteralPath $SOURCE");
+      expect(ps1).toContain('"vault=$VAULT" properties "path=$SOURCE_PATH" "format=json"');
       expect(ps1).toContain("[System.IO.File]::ReadAllText($FILE");
       expect(ps1).toContain('Authorization = "Bearer $KEY"');
       expect(ps1).toContain("-Body $BYTES");
-      expect(ps1).toContain("TrimStart([char]0xFEFF)");
       expect(ps1).toContain("ConvertFrom-Json -ErrorAction Stop");
+      expect(ps1).toContain("$VALID_VERSION_TYPE");
       expect(ps1).toContain("9007199254740991");
       expect(ps1).toContain("abcdefghjkmnpqrstvwxyz");
       expect(ps1).toContain("Do not retry");

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,5 +1,5 @@
 import { BUILTIN_SKILLS, managedBuiltinSkills, MIYO_SEARCH_SKILL, PLUS_ENV } from "./builtinSkills";
-import { SYMPOSIUM_API_ORIGIN } from "@/symposium/constants";
+import { SYMPOSIUM_API_ORIGIN, SYMPOSIUM_TOKEN_ENV } from "@/symposium/constants";
 
 /** A script file shipped by a skill, matched by extension (".sh", ".cmd", ".ps1"). */
 function scriptOf(name: string, ext: ".sh" | ".cmd" | ".ps1" = ".sh"): string {
@@ -10,9 +10,7 @@ function scriptOf(name: string, ext: ".sh" | ".cmd" | ".ps1" = ".sh"): string {
   return file.content;
 }
 
-const RELAY_SKILLS = BUILTIN_SKILLS.filter(
-  (skill) => skill.name.startsWith("copilot-") && skill.name !== "copilot-publish-symposium"
-);
+const RELAY_SKILLS = BUILTIN_SKILLS.filter((skill) => skill.name.startsWith("copilot-"));
 
 describe("builtinSkills", () => {
   describe("BUILTIN_SKILLS", () => {
@@ -23,7 +21,7 @@ describe("builtinSkills", () => {
         "copilot-read-pdf",
         "copilot-youtube-transcript",
         "copilot-fetch-x",
-        "copilot-publish-symposium",
+        "symposium-publish",
         "obsidian-markdown",
         "obsidian-bases",
         "json-canvas",
@@ -178,40 +176,40 @@ describe("builtinSkills", () => {
     });
 
     it("publishes confirmed agent-generated HTML and retains the link on its source note", () => {
-      const skill = BUILTIN_SKILLS.find((item) => item.name === "copilot-publish-symposium");
+      const skill = BUILTIN_SKILLS.find((item) => item.name === "symposium-publish");
       expect(skill).toBeDefined();
       expect(skill!.files).toEqual([]);
-      expect(skill!.skillMd).toContain("Require one existing Markdown source note");
-      expect(skill!.skillMd).toContain("static HTML or SVG");
+      expect(skill!.skillMd).toContain("Require one existing Markdown source file");
+      expect(skill!.skillMd).toMatch(/static HTML or\s+SVG/);
       expect(skill!.skillMd).toContain("ask an explicit Yes/No confirmation");
       expect(skill!.skillMd).toContain("A previous");
       expect(skill!.skillMd).toContain("request to publish is not confirmation");
-      expect(skill!.skillMd).toContain(PLUS_ENV.licenseKey);
+      expect(skill!.skillMd).toContain(SYMPOSIUM_TOKEN_ENV);
+      expect(skill!.skillMd).not.toContain(PLUS_ENV.licenseKey);
       expect(skill!.skillMd).toContain("empty or absent");
-      expect(skill!.skillMd).toContain("app.fileManager.processFrontMatter");
       expect(skill!.skillMd).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
       expect(skill!.skillMd).toContain("POST exactly once");
       expect(skill!.skillMd).toContain("Accept: application/json");
-      expect(skill!.skillMd).toContain("`User-Agent`");
-      expect(skill!.skillMd).toContain(PLUS_ENV.clientVersion);
+      expect(skill!.skillMd).toContain("`User-Agent: Symposium-Agent`");
       expect(skill!.skillMd).toContain("error.code");
       expect(skill!.skillMd).toContain("Cloudflare 1xxx");
-      expect(skill!.skillMd).toContain("says nothing about license validity");
+      expect(skill!.skillMd).toContain("says nothing about token validity");
       expect(skill!.skillMd).toContain("positive safe integer");
       expect(skill!.skillMd).toContain("/d/<docId>");
       expect(skill!.skillMd).toContain("malformed");
       expect(skill!.skillMd).toContain("ambiguous and non-retryable");
-      expect(skill!.skillMd).toContain("copilot/symposium/published-documents.md");
-      expect(skill!.skillMd).toContain("ordinary Markdown note");
+      expect(skill!.skillMd).toContain(".symposium/publish-history.md");
       expect(skill!.skillMd).toContain("| Document ID | Status | Note | URL |");
-      expect(skill!.skillMd).toContain("normal Obsidian note tools");
-      expect(skill!.skillMd).toContain("Obsidian CLI");
+      expect(skill!.skillMd).toContain("direct filesystem");
       expect(skill!.skillMd).toContain("append only when it begins with that exact");
       expect(skill!.skillMd).toContain("Escape existing backslashes");
-      expect(skill!.skillMd).toContain("one `processFrontMatter` callback");
+      expect(skill!.skillMd).toContain("structured frontmatter API");
       expect(skill!.skillMd).toContain("server's full `url`");
-      expect(skill!.skillMd).toMatch(/only if it is still\s+absent/);
+      expect(skill!.skillMd).toMatch(/only if the property is still\s+absent/);
       expect(skill!.skillMd).toContain("server's `url` verbatim");
+      expect(skill!.skillMd).not.toContain("Copilot Plus");
+      expect(skill!.skillMd).not.toContain("Copilot-Obsidian");
+      expect(skill!.skillMd).not.toContain("Obsidian CLI");
     });
   });
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -186,6 +186,8 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("ask an explicit Yes/No confirmation");
       expect(skill!.skillMd).toContain("A previous");
       expect(skill!.skillMd).toContain("request to publish is not confirmation");
+      expect(skill!.skillMd).toContain("Before any network request");
+      expect(skill!.skillMd).toContain("capability probe fails");
       expect(skill!.skillMd).toContain(PLUS_ENV.licenseKey);
       expect(skill!.skillMd).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
       expect(skill!.skillMd).toContain("POST exactly once");

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -177,7 +177,7 @@ describe("builtinSkills", () => {
       expect(ps1).toContain("@{ pdf = $PDF; user_id = $USER_ID }");
     });
 
-    it("publishes confirmed agent-generated HTML and retains the id on its source note", () => {
+    it("publishes confirmed agent-generated HTML and retains the link on its source note", () => {
       const skill = BUILTIN_SKILLS.find((item) => item.name === "copilot-publish-symposium");
       expect(skill).toBeDefined();
       expect(skill!.files).toEqual([]);
@@ -198,6 +198,7 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("Cloudflare 1xxx");
       expect(skill!.skillMd).toContain("says nothing about license validity");
       expect(skill!.skillMd).toContain("positive safe integer");
+      expect(skill!.skillMd).toContain("/d/<docId>");
       expect(skill!.skillMd).toContain("malformed");
       expect(skill!.skillMd).toContain("ambiguous and non-retryable");
       expect(skill!.skillMd).toContain("copilot/symposium/published-documents.md");
@@ -208,7 +209,8 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("append only when it begins with that exact");
       expect(skill!.skillMd).toContain("Escape existing backslashes");
       expect(skill!.skillMd).toContain("one `processFrontMatter` callback");
-      expect(skill!.skillMd).toContain("only if it is still absent");
+      expect(skill!.skillMd).toContain("server's full `url`");
+      expect(skill!.skillMd).toMatch(/only if it is still\s+absent/);
       expect(skill!.skillMd).toContain("server's `url` verbatim");
     });
   });

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,5 +1,9 @@
 import { BUILTIN_SKILLS, managedBuiltinSkills, MIYO_SEARCH_SKILL, PLUS_ENV } from "./builtinSkills";
-import { SYMPOSIUM_API_ORIGIN, SYMPOSIUM_TOKEN_ENV } from "@/symposium/constants";
+import {
+  SYMPOSIUM_API_ORIGIN,
+  SYMPOSIUM_TOKEN_ENV,
+  SYMPOSIUM_WORKSPACE_ROOT_ENV,
+} from "@/symposium/constants";
 
 /** A script file shipped by a skill, matched by extension (".sh", ".cmd", ".ps1"). */
 function scriptOf(name: string, ext: ".sh" | ".cmd" | ".ps1" = ".sh"): string {
@@ -199,6 +203,8 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("malformed");
       expect(skill!.skillMd).toContain("ambiguous and non-retryable");
       expect(skill!.skillMd).toContain(".symposium/publish-history.md");
+      expect(skill!.skillMd).toContain(SYMPOSIUM_WORKSPACE_ROOT_ENV);
+      expect(skill!.skillMd).toContain("project-scoped");
       expect(skill!.skillMd).toContain("| Document ID | Status | Note | URL |");
       expect(skill!.skillMd).toContain("direct filesystem");
       expect(skill!.skillMd).toContain("append only when it begins with that exact");

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,6 +1,7 @@
 import { BUILTIN_SKILLS, managedBuiltinSkills, MIYO_SEARCH_SKILL, PLUS_ENV } from "./builtinSkills";
 import {
   SYMPOSIUM_API_ORIGIN,
+  SYMPOSIUM_MAX_HTML_BYTES,
   SYMPOSIUM_TOKEN_ENV,
   SYMPOSIUM_WORKSPACE_ROOT_ENV,
 } from "@/symposium/constants";
@@ -185,6 +186,7 @@ describe("builtinSkills", () => {
       expect(skill!.files).toEqual([]);
       expect(skill!.skillMd).toContain("Require one existing Markdown source file");
       expect(skill!.skillMd).toMatch(/static HTML or\s+SVG/);
+      expect(skill!.skillMd).toContain(`\`${SYMPOSIUM_MAX_HTML_BYTES}\` bytes (10 MiB)`);
       expect(skill!.skillMd).toContain("ask an explicit Yes/No confirmation");
       expect(skill!.skillMd).toContain("A previous");
       expect(skill!.skillMd).toContain("request to publish is not confirmation");

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -193,10 +193,10 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("copilot/symposium/published-documents.md");
       expect(skill!.skillMd).toContain("Append one row; never rewrite or delete older rows");
       expect(skill!.skillMd).toContain("Only after attempting the ledger write");
-      expect(skill!.skillMd).toContain("only if it is still absent");
-      expect(skill!.skillMd).toContain("property:set");
-      expect(skill!.skillMd).toContain("read the source note's `symposium`");
-      expect(skill!.skillMd).toContain("Set it to the returned `docId`");
+      expect(skill!.skillMd).toContain("one atomic");
+      expect(skill!.skillMd).toContain("processFrontMatter");
+      expect(skill!.skillMd).not.toContain("property:set path=");
+      expect(skill!.skillMd).toContain('Require the result to contain `"saved":true`');
       expect(skill!.skillMd).toContain("return the server's");
       expect(skill!.skillMd).toContain("verbatim");
 
@@ -204,11 +204,12 @@ describe("builtinSkills", () => {
       expect(sh).toContain(PLUS_ENV.licenseKey);
       expect(sh).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
       expect(sh).toContain('[ -f "$SOURCE" ]');
-      expect(sh).toContain('json_escape < "$FILE"');
+      expect(sh).toContain('fs.readFileSync(process.argv[2], "utf8")');
       expect(sh).toContain("Authorization: Bearer $KEY");
       expect(sh).toContain("--data-binary @-");
       expect(sh).toContain("source_is_unpublished");
-      expect(sh).toContain("9007199254740991");
+      expect(sh).toContain("JSON.parse(input)");
+      expect(sh).toContain("Number.isSafeInteger(receipt.version)");
       expect(sh).toContain("abcdefghjkmnpqrstvwxyz");
       expect(sh).toContain("Do not retry");
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -10,9 +10,8 @@ function scriptOf(name: string, ext: ".sh" | ".cmd" | ".ps1" = ".sh"): string {
   return file.content;
 }
 
-const SCRIPTED_PLUS_SKILLS = BUILTIN_SKILLS.filter((skill) => skill.name.startsWith("copilot-"));
-const RELAY_SKILLS = SCRIPTED_PLUS_SKILLS.filter(
-  (skill) => skill.name !== "copilot-publish-symposium"
+const RELAY_SKILLS = BUILTIN_SKILLS.filter(
+  (skill) => skill.name.startsWith("copilot-") && skill.name !== "copilot-publish-symposium"
 );
 
 describe("builtinSkills", () => {
@@ -42,7 +41,7 @@ describe("builtinSkills", () => {
     });
 
     it("ships one runnable script per OS — POSIX sh + Windows cmd/ps1, no Node", () => {
-      for (const skill of SCRIPTED_PLUS_SKILLS) {
+      for (const skill of RELAY_SKILLS) {
         const sh = skill.files.find((f) => f.path.endsWith(".sh"));
         const cmd = skill.files.find((f) => f.path.endsWith(".cmd"));
         const ps1 = skill.files.find((f) => f.path.endsWith(".ps1"));
@@ -181,53 +180,21 @@ describe("builtinSkills", () => {
     it("publishes confirmed agent-generated HTML and retains the id on its source note", () => {
       const skill = BUILTIN_SKILLS.find((item) => item.name === "copilot-publish-symposium");
       expect(skill).toBeDefined();
-      expect(skill!.skillMd).toContain("complete HTML document yourself");
-      expect(skill!.skillMd).toContain("static SVG");
-      expect(skill!.skillMd).toContain("static table or");
-      expect(skill!.skillMd).toContain("Do not publish standalone HTML without a source note");
-      expect(skill!.skillMd).toContain("Ask an explicit Yes/No question");
-      expect(skill!.skillMd).toContain("If that");
-      expect(skill!.skillMd).toContain("UI is unavailable");
-      expect(skill!.skillMd).toContain("invoke the wrapper unless the user");
-      expect(skill!.skillMd).toContain("answers Yes to this confirmation");
+      expect(skill!.files).toEqual([]);
+      expect(skill!.skillMd).toContain("Use one existing Markdown source note");
+      expect(skill!.skillMd).toContain("static HTML or SVG");
+      expect(skill!.skillMd).toContain("ask an explicit Yes/No confirmation");
+      expect(skill!.skillMd).toContain("A previous");
+      expect(skill!.skillMd).toContain("request to publish is not confirmation");
+      expect(skill!.skillMd).toContain(PLUS_ENV.licenseKey);
+      expect(skill!.skillMd).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
+      expect(skill!.skillMd).toContain("POST exactly once");
+      expect(skill!.skillMd).toContain("401/403");
       expect(skill!.skillMd).toContain("copilot/symposium/published-documents.md");
-      expect(skill!.skillMd).toContain("Append one row; never rewrite or delete older rows");
-      expect(skill!.skillMd).toContain("Only after attempting the ledger write");
-      expect(skill!.skillMd).toContain("one atomic");
-      expect(skill!.skillMd).toContain("processFrontMatter");
-      expect(skill!.skillMd).not.toContain("property:set path=");
-      expect(skill!.skillMd).toContain('Require the result to contain `"saved":true`');
-      expect(skill!.skillMd).toContain("return the server's");
+      expect(skill!.skillMd).toContain("ordinary Markdown note");
+      expect(skill!.skillMd).toContain("set the source note's `symposium` property");
+      expect(skill!.skillMd).toContain("Return the server's");
       expect(skill!.skillMd).toContain("verbatim");
-
-      const sh = scriptOf(skill!.name, ".sh");
-      expect(sh).toContain(PLUS_ENV.licenseKey);
-      expect(sh).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
-      expect(sh).toContain('[ -f "$SOURCE" ]');
-      expect(sh).toContain('properties path="$SOURCE_PATH" format=json');
-      expect(sh).toContain('json_escape "$FINAL_LF" < "$FILE"');
-      expect(sh).toContain("Authorization: Bearer $KEY");
-      expect(sh).toContain("--data-binary @-");
-      expect(sh).toContain("source_is_unpublished");
-      expect(sh).toContain("JSON.parse(input)");
-      expect(sh).toContain("Number.isSafeInteger(receipt.version)");
-      expect(sh).not.toContain("command -v node");
-      expect(sh).toContain("abcdefghjkmnpqrstvwxyz");
-      expect(sh).toContain("Do not retry");
-
-      const ps1 = scriptOf(skill!.name, ".ps1");
-      expect(ps1).toContain(PLUS_ENV.licenseKey);
-      expect(ps1).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
-      expect(ps1).toContain("Test-Path -LiteralPath $SOURCE");
-      expect(ps1).toContain('"vault=$VAULT" properties "path=$SOURCE_PATH" "format=json"');
-      expect(ps1).toContain("[System.IO.File]::ReadAllText($FILE");
-      expect(ps1).toContain('Authorization = "Bearer $KEY"');
-      expect(ps1).toContain("-Body $BYTES");
-      expect(ps1).toContain("ConvertFrom-Json -ErrorAction Stop");
-      expect(ps1).toContain("$VALID_VERSION_TYPE");
-      expect(ps1).toContain("9007199254740991");
-      expect(ps1).toContain("abcdefghjkmnpqrstvwxyz");
-      expect(ps1).toContain("Do not retry");
     });
   });
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -181,13 +181,11 @@ describe("builtinSkills", () => {
       const skill = BUILTIN_SKILLS.find((item) => item.name === "copilot-publish-symposium");
       expect(skill).toBeDefined();
       expect(skill!.files).toEqual([]);
-      expect(skill!.skillMd).toContain("Use one existing Markdown source note");
+      expect(skill!.skillMd).toContain("Require one existing Markdown source note");
       expect(skill!.skillMd).toContain("static HTML or SVG");
       expect(skill!.skillMd).toContain("ask an explicit Yes/No confirmation");
       expect(skill!.skillMd).toContain("A previous");
       expect(skill!.skillMd).toContain("request to publish is not confirmation");
-      expect(skill!.skillMd).toContain("Before any network request");
-      expect(skill!.skillMd).toContain("capability probe fails");
       expect(skill!.skillMd).toContain(PLUS_ENV.licenseKey);
       expect(skill!.skillMd).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
       expect(skill!.skillMd).toContain("POST exactly once");
@@ -197,10 +195,11 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("ambiguous and non-retryable");
       expect(skill!.skillMd).toContain("copilot/symposium/published-documents.md");
       expect(skill!.skillMd).toContain("ordinary Markdown note");
-      expect(skill!.skillMd).toContain("processFrontMatter");
-      expect(skill!.skillMd).toContain("only if the property is still absent");
-      expect(skill!.skillMd).toContain("Return the server's");
-      expect(skill!.skillMd).toContain("verbatim");
+      expect(skill!.skillMd).toContain("| Document ID | Status | Note | URL |");
+      expect(skill!.skillMd).toContain("normal Obsidian note tools");
+      expect(skill!.skillMd).toContain("Obsidian CLI");
+      expect(skill!.skillMd).toContain("only if it is still absent");
+      expect(skill!.skillMd).toContain("server's `url` verbatim");
     });
   });
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -186,13 +186,17 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("static table or");
       expect(skill!.skillMd).toContain("Do not publish standalone HTML without a source note");
       expect(skill!.skillMd).toContain("Ask an explicit Yes/No question");
-      expect(skill!.skillMd).toContain("invoke the wrapper unless the user answers Yes");
+      expect(skill!.skillMd).toContain("If that");
+      expect(skill!.skillMd).toContain("UI is unavailable");
+      expect(skill!.skillMd).toContain("invoke the wrapper unless the user");
+      expect(skill!.skillMd).toContain("answers Yes to this confirmation");
       expect(skill!.skillMd).toContain("copilot/symposium/published-documents.md");
       expect(skill!.skillMd).toContain("Append one row; never rewrite or delete older rows");
       expect(skill!.skillMd).toContain("Only after attempting the ledger write");
+      expect(skill!.skillMd).toContain("only if it is still absent");
       expect(skill!.skillMd).toContain("property:set");
-      expect(skill!.skillMd).toContain("set the source note's `symposium`");
-      expect(skill!.skillMd).toContain("text property to the returned `docId`");
+      expect(skill!.skillMd).toContain("read the source note's `symposium`");
+      expect(skill!.skillMd).toContain("Set it to the returned `docId`");
       expect(skill!.skillMd).toContain("return the server's");
       expect(skill!.skillMd).toContain("verbatim");
 
@@ -203,6 +207,9 @@ describe("builtinSkills", () => {
       expect(sh).toContain('json_escape < "$FILE"');
       expect(sh).toContain("Authorization: Bearer $KEY");
       expect(sh).toContain("--data-binary @-");
+      expect(sh).toContain("source_is_unpublished");
+      expect(sh).toContain("9007199254740991");
+      expect(sh).toContain("abcdefghjkmnpqrstvwxyz");
       expect(sh).toContain("Do not retry");
 
       const ps1 = scriptOf(skill!.name, ".ps1");
@@ -212,6 +219,10 @@ describe("builtinSkills", () => {
       expect(ps1).toContain("[System.IO.File]::ReadAllText($FILE");
       expect(ps1).toContain('Authorization = "Bearer $KEY"');
       expect(ps1).toContain("-Body $BYTES");
+      expect(ps1).toContain("TrimStart([char]0xFEFF)");
+      expect(ps1).toContain("ConvertFrom-Json -ErrorAction Stop");
+      expect(ps1).toContain("9007199254740991");
+      expect(ps1).toContain("abcdefghjkmnpqrstvwxyz");
       expect(ps1).toContain("Do not retry");
     });
   });

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,4 +1,5 @@
 import { BUILTIN_SKILLS, managedBuiltinSkills, MIYO_SEARCH_SKILL, PLUS_ENV } from "./builtinSkills";
+import { SYMPOSIUM_API_ORIGIN } from "@/symposium/constants";
 
 /** A script file shipped by a skill, matched by extension (".sh", ".cmd", ".ps1"). */
 function scriptOf(name: string, ext: ".sh" | ".cmd" | ".ps1" = ".sh"): string {
@@ -9,7 +10,10 @@ function scriptOf(name: string, ext: ".sh" | ".cmd" | ".ps1" = ".sh"): string {
   return file.content;
 }
 
-const PLUS_SKILLS = BUILTIN_SKILLS.filter((skill) => skill.name.startsWith("copilot-"));
+const SCRIPTED_PLUS_SKILLS = BUILTIN_SKILLS.filter((skill) => skill.name.startsWith("copilot-"));
+const RELAY_SKILLS = SCRIPTED_PLUS_SKILLS.filter(
+  (skill) => skill.name !== "copilot-publish-symposium"
+);
 
 describe("builtinSkills", () => {
   describe("BUILTIN_SKILLS", () => {
@@ -20,6 +24,7 @@ describe("builtinSkills", () => {
         "copilot-read-pdf",
         "copilot-youtube-transcript",
         "copilot-fetch-x",
+        "copilot-publish-symposium",
         "obsidian-markdown",
         "obsidian-bases",
         "json-canvas",
@@ -37,7 +42,7 @@ describe("builtinSkills", () => {
     });
 
     it("ships one runnable script per OS — POSIX sh + Windows cmd/ps1, no Node", () => {
-      for (const skill of PLUS_SKILLS) {
+      for (const skill of SCRIPTED_PLUS_SKILLS) {
         const sh = skill.files.find((f) => f.path.endsWith(".sh"));
         const cmd = skill.files.find((f) => f.path.endsWith(".cmd"));
         const ps1 = skill.files.find((f) => f.path.endsWith(".ps1"));
@@ -64,7 +69,7 @@ describe("builtinSkills", () => {
     });
 
     it("reads its config from the injected env and never embeds a key (both scripts)", () => {
-      for (const skill of PLUS_SKILLS) {
+      for (const skill of RELAY_SKILLS) {
         const sh = scriptOf(skill.name, ".sh");
         expect(sh).toContain(`#!/bin/sh`);
         expect(sh).toContain(PLUS_ENV.licenseKey);
@@ -97,7 +102,7 @@ describe("builtinSkills", () => {
     });
 
     it("falls back to the agent's own tools instead of blocking when Plus is absent", () => {
-      for (const skill of PLUS_SKILLS) {
+      for (const skill of RELAY_SKILLS) {
         const sh = scriptOf(skill.name, ".sh");
         // No license: tell the agent to use its own equivalent tools, never
         // refuse, and only append the upsell occasionally (gated on the pid). The
@@ -171,6 +176,43 @@ describe("builtinSkills", () => {
         "[System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes($FILE))"
       );
       expect(ps1).toContain("@{ pdf = $PDF; user_id = $USER_ID }");
+    });
+
+    it("publishes confirmed agent-generated HTML and retains the id on its source note", () => {
+      const skill = BUILTIN_SKILLS.find((item) => item.name === "copilot-publish-symposium");
+      expect(skill).toBeDefined();
+      expect(skill!.skillMd).toContain("complete HTML document yourself");
+      expect(skill!.skillMd).toContain("static SVG");
+      expect(skill!.skillMd).toContain("static table or");
+      expect(skill!.skillMd).toContain("Do not publish standalone HTML without a source note");
+      expect(skill!.skillMd).toContain("Ask an explicit Yes/No question");
+      expect(skill!.skillMd).toContain("invoke the wrapper unless the user answers Yes");
+      expect(skill!.skillMd).toContain("copilot/symposium/published-documents.md");
+      expect(skill!.skillMd).toContain("Append one row; never rewrite or delete older rows");
+      expect(skill!.skillMd).toContain("Only after attempting the ledger write");
+      expect(skill!.skillMd).toContain("property:set");
+      expect(skill!.skillMd).toContain("set the source note's `symposium`");
+      expect(skill!.skillMd).toContain("text property to the returned `docId`");
+      expect(skill!.skillMd).toContain("return the server's");
+      expect(skill!.skillMd).toContain("verbatim");
+
+      const sh = scriptOf(skill!.name, ".sh");
+      expect(sh).toContain(PLUS_ENV.licenseKey);
+      expect(sh).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
+      expect(sh).toContain('[ -f "$SOURCE" ]');
+      expect(sh).toContain('json_escape < "$FILE"');
+      expect(sh).toContain("Authorization: Bearer $KEY");
+      expect(sh).toContain("--data-binary @-");
+      expect(sh).toContain("Do not retry");
+
+      const ps1 = scriptOf(skill!.name, ".ps1");
+      expect(ps1).toContain(PLUS_ENV.licenseKey);
+      expect(ps1).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
+      expect(ps1).toContain("Test-Path -LiteralPath $SOURCE");
+      expect(ps1).toContain("[System.IO.File]::ReadAllText($FILE");
+      expect(ps1).toContain('Authorization = "Bearer $KEY"');
+      expect(ps1).toContain("-Body $BYTES");
+      expect(ps1).toContain("Do not retry");
     });
   });
 

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -187,6 +187,7 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("A previous");
       expect(skill!.skillMd).toContain("request to publish is not confirmation");
       expect(skill!.skillMd).toContain(PLUS_ENV.licenseKey);
+      expect(skill!.skillMd).toContain("app.fileManager.processFrontMatter");
       expect(skill!.skillMd).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
       expect(skill!.skillMd).toContain("POST exactly once");
       expect(skill!.skillMd).toContain("401/403");
@@ -198,6 +199,9 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("| Document ID | Status | Note | URL |");
       expect(skill!.skillMd).toContain("normal Obsidian note tools");
       expect(skill!.skillMd).toContain("Obsidian CLI");
+      expect(skill!.skillMd).toContain("append only when it begins with that exact");
+      expect(skill!.skillMd).toContain("Escape existing backslashes");
+      expect(skill!.skillMd).toContain("one `processFrontMatter` callback");
       expect(skill!.skillMd).toContain("only if it is still absent");
       expect(skill!.skillMd).toContain("server's `url` verbatim");
     });

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -187,10 +187,16 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain("A previous");
       expect(skill!.skillMd).toContain("request to publish is not confirmation");
       expect(skill!.skillMd).toContain(PLUS_ENV.licenseKey);
+      expect(skill!.skillMd).toContain("empty or absent");
       expect(skill!.skillMd).toContain("app.fileManager.processFrontMatter");
       expect(skill!.skillMd).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
       expect(skill!.skillMd).toContain("POST exactly once");
-      expect(skill!.skillMd).toContain("401/403");
+      expect(skill!.skillMd).toContain("Accept: application/json");
+      expect(skill!.skillMd).toContain("`User-Agent`");
+      expect(skill!.skillMd).toContain(PLUS_ENV.clientVersion);
+      expect(skill!.skillMd).toContain("error.code");
+      expect(skill!.skillMd).toContain("Cloudflare 1xxx");
+      expect(skill!.skillMd).toContain("says nothing about license validity");
       expect(skill!.skillMd).toContain("positive safe integer");
       expect(skill!.skillMd).toContain("malformed");
       expect(skill!.skillMd).toContain("ambiguous and non-retryable");

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -190,9 +190,13 @@ describe("builtinSkills", () => {
       expect(skill!.skillMd).toContain(`${SYMPOSIUM_API_ORIGIN}/api/v1/docs`);
       expect(skill!.skillMd).toContain("POST exactly once");
       expect(skill!.skillMd).toContain("401/403");
+      expect(skill!.skillMd).toContain("positive safe integer");
+      expect(skill!.skillMd).toContain("malformed");
+      expect(skill!.skillMd).toContain("ambiguous and non-retryable");
       expect(skill!.skillMd).toContain("copilot/symposium/published-documents.md");
       expect(skill!.skillMd).toContain("ordinary Markdown note");
-      expect(skill!.skillMd).toContain("set the source note's `symposium` property");
+      expect(skill!.skillMd).toContain("processFrontMatter");
+      expect(skill!.skillMd).toContain("only if the property is still absent");
       expect(skill!.skillMd).toContain("Return the server's");
       expect(skill!.skillMd).toContain("verbatim");
     });

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -186,7 +186,7 @@ describe("builtinSkills", () => {
       expect(skill!.files).toEqual([]);
       expect(skill!.skillMd).toContain("Require one existing Markdown source file");
       expect(skill!.skillMd).toMatch(/static HTML or\s+SVG/);
-      expect(skill!.skillMd).toContain(`\`${SYMPOSIUM_MAX_HTML_BYTES}\` bytes (10 MiB)`);
+      expect(skill!.skillMd).toContain(`\`${SYMPOSIUM_MAX_HTML_BYTES}\` bytes`);
       expect(skill!.skillMd).toContain("ask an explicit Yes/No confirmation");
       expect(skill!.skillMd).toContain("A previous");
       expect(skill!.skillMd).toContain("request to publish is not confirmation");

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -1,4 +1,5 @@
 import type { BackendId } from "@/agentMode/session/types";
+import { SYMPOSIUM_API_ORIGIN } from "@/symposium/constants";
 import { OBSIDIAN_SKILLS } from "./obsidianSkills";
 
 /**
@@ -489,6 +490,227 @@ const FETCH_X = relaySkill({
   scriptFile: "fetch-x.sh",
 });
 
+const SYMPOSIUM_PUBLISH_VERSION = 3;
+const SYMPOSIUM_PUBLISH: BuiltinSkill = {
+  name: "copilot-publish-symposium",
+  version: SYMPOSIUM_PUBLISH_VERSION,
+  enabledAgents: ["claude", "codex", "opencode"],
+  skillMd: `---
+name: copilot-publish-symposium
+description: Convert a source Markdown note into standalone HTML and publish it as a public Symposium page. Use when the user asks to publish or share a note as a web page. Initial publishing only; existing Symposium pages use Obsidian's normal Update/Delete flow. Requires an active Copilot Plus license.
+license: Copilot Plus
+metadata:
+  copilot-enabled-agents: claude, codex, opencode
+  copilot-builtin-version: "${SYMPOSIUM_PUBLISH_VERSION}"
+---
+
+# Publish Markdown to Symposium
+
+Create a standalone web page from one Markdown source note, ask the user to
+approve the finished page, and publish it once through the bundled wrapper.
+
+## 1. Require a source note
+
+Resolve an existing Markdown note and keep both its absolute path and its
+vault-relative path. Do not publish standalone HTML without a source note. If
+the requested content is not in a note yet, create the source note first.
+
+Inspect the note's \`symposium\` property before doing any network work. If it
+already contains a document id, tell the user to use **Publish file to
+Symposium** for Update/Delete. If it contains another value, stop rather than
+overwriting it.
+
+## 2. Prepare the page
+
+Create a complete HTML document yourself from the requested Markdown. The file
+must start with \`<!doctype html>\` and include its own readable layout and
+inline CSS. Send HTML, never raw Markdown.
+
+The page must be self-contained and passive:
+
+- resolve Obsidian-only rendered content into static HTML before publishing;
+  for example, turn Mermaid into static SVG and Bases into a static table or
+  card layout rather than leaving a raw code block or \`.base\` source;
+- embed required images as data URLs and do not depend on external styles,
+  scripts, fonts, frames, media, or other fetched assets;
+- include no \`script\`, \`iframe\`, form controls, embedded objects, event
+  handlers, or other executable/interactive content.
+
+Write the final HTML to a temporary \`.html\` file. Keep it unchanged after the
+confirmation question is shown.
+
+## 3. Ask before publishing
+
+Show the user the source note, title, and a concise preview or description of
+the finished page. Explain that anyone with the resulting link can read it.
+Ask an explicit Yes/No question through the agent's user-question UI. Do not
+invoke the wrapper unless the user answers Yes; a prior general request to
+publish is not this confirmation. If they decline, delete the temporary HTML
+and make no request.
+
+## 4. Publish once
+
+Find the absolute path to this SKILL.md file, then run the matching wrapper with
+exactly three arguments: the absolute source-note path, page title, and prepared
+HTML file.
+
+On macOS or Linux:
+
+\`\`\`bash
+sh "/absolute/path/to/this/skill/directory/publish-symposium.sh" "/absolute/path/to/source.md" "Page title" "/absolute/path/to/prepared.html"
+\`\`\`
+
+On Windows, call the \`.cmd\` wrapper from PowerShell:
+
+\`\`\`powershell
+& "/absolute/path/to/this/skill/directory/publish-symposium.cmd" "C:\\absolute\\path\\to\\source.md" "Page title" "C:\\absolute\\path\\to\\prepared.html"
+\`\`\`
+
+The wrapper prints the publish receipt as JSON. Validate that it contains a
+16-character lowercase \`docId\` and an HTTPS \`url\`. Never retry a publish
+after an uncertain response; it may already have created a public page.
+
+## 5. Record the receipt
+
+Before changing the source note, append the receipt to the vault-local
+\`copilot/symposium/published-documents.md\` ledger. Create its parent folder
+and this plain Markdown table when absent:
+
+\`\`\`markdown
+| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |
+| --- | --- | --- | --- | --- | ---: | --- |
+\`\`\`
+
+Append one row; never rewrite or delete older rows. Use \`published\` status,
+the vault-relative source path, the exact returned URL and version, the current
+UTC ISO timestamp, and the SHA-256 of the exact prepared HTML file. Wrap the URL
+in angle brackets and escape \`|\` in the note path as \`\\|\`.
+
+The ledger is recovery history, not publication state. If this advisory write
+fails, continue to save the source property; never publish again and never put
+the license key in the ledger.
+
+## 6. Save the identity
+
+Only after attempting the ledger write, set the source note's \`symposium\`
+text property to the returned \`docId\`, preserving all other frontmatter.
+Prefer the Obsidian CLI:
+
+\`\`\`bash
+obsidian vault="<vault>" property:set path="<vault-relative-source.md>" name=symposium value="<docId>" type=text
+\`\`\`
+
+If saving the property fails, do not publish again. Report the returned URL and
+document id so the page remains recoverable. Otherwise return the server's
+\`url\` verbatim. Always delete the temporary HTML file. Never print or write
+the license key into the note, HTML, command arguments, or chat.
+`,
+  files: [
+    {
+      path: "publish-symposium.sh",
+      content: `#!/bin/sh
+KEY="\${${PLUS_ENV.licenseKey}:-}"
+ENDPOINT="${SYMPOSIUM_API_ORIGIN}/api/v1/docs"
+
+die() {
+  printf '%s\\n' "$1" >&2
+  exit "\${2:-2}"
+}
+
+[ "$#" -eq 3 ] || die "Usage: sh publish-symposium.sh <source-note.md> <title> <prepared.html>" 1
+SOURCE=$1
+TITLE=$2
+FILE=$3
+[ -n "$KEY" ] || die "Copilot Plus is not active, so Symposium publishing is unavailable." 1
+[ -f "$SOURCE" ] && [ -r "$SOURCE" ] || die "Could not read source note: $SOURCE" 1
+case "$SOURCE" in *.[mM][dD]) ;; *) die "The Symposium source must be a Markdown note." 1 ;; esac
+[ -f "$FILE" ] && [ -r "$FILE" ] || die "Could not read prepared HTML: $FILE" 1
+
+json_escape() {
+  awk 'BEGIN { ORS=""; printf "\\"" }
+    {
+      if (NR > 1) printf "\\\\n"
+      gsub(/\\\\/, "\\\\\\\\")
+      gsub(/\\"/, "\\\\\\"")
+      gsub(/\\t/, "\\\\t")
+      gsub(/\\r/, "\\\\r")
+      printf "%s", $0
+    }
+    END { printf "\\"" }'
+}
+
+RESP=$({
+  printf '{"title":'
+  printf '%s' "$TITLE" | json_escape
+  printf ',"html":'
+  json_escape < "$FILE"
+  printf '}'
+} | curl -sS -w '\\n%{http_code}' \\
+  -X POST "$ENDPOINT" \\
+  -H "Authorization: Bearer $KEY" \\
+  -H 'Content-Type: application/json; charset=utf-8' \\
+  --data-binary @-)
+[ $? -eq 0 ] || die "Symposium may have published the page without returning a receipt. Do not retry." 1
+CODE=$(printf '%s' "$RESP" | tail -n1)
+OUT=$(printf '%s' "$RESP" | sed '$d')
+case "$CODE" in
+  201) printf '%s\\n' "$OUT" ;;
+  401|403) die "Symposium rejected the Copilot Plus license: $OUT" 1 ;;
+  2*) die "Symposium returned an unexpected success response (HTTP $CODE): $OUT. Do not retry." 1 ;;
+  *) die "Symposium publish failed (HTTP $CODE): $OUT" 1 ;;
+esac
+`,
+    },
+    {
+      path: "publish-symposium.cmd",
+      content: cmdLauncher("publish-symposium.ps1"),
+    },
+    {
+      path: "publish-symposium.ps1",
+      content: `# Publishes prepared HTML to Symposium. Windows PowerShell 5.1 only.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
+function Die($message, $code = 2) {
+  [Console]::Error.WriteLine([string]$message)
+  exit $code
+}
+
+if ($args.Count -ne 3) { Die "Usage: publish-symposium.ps1 <source-note.md> <title> <prepared.html>" 1 }
+$SOURCE = $args[0]
+$TITLE = $args[1]
+$FILE = $args[2]
+$KEY = [Environment]::GetEnvironmentVariable('${PLUS_ENV.licenseKey}')
+$ENDPOINT = '${SYMPOSIUM_API_ORIGIN}/api/v1/docs'
+if (-not $KEY) { Die "Copilot Plus is not active, so Symposium publishing is unavailable." 1 }
+if (-not (Test-Path -LiteralPath $SOURCE -PathType Leaf)) { Die "Could not read source note: $SOURCE" 1 }
+if ([System.IO.Path]::GetExtension($SOURCE) -ine '.md') { Die "The Symposium source must be a Markdown note." 1 }
+if (-not (Test-Path -LiteralPath $FILE -PathType Leaf)) { Die "Could not read prepared HTML: $FILE" 1 }
+
+try {
+  $HTML = [System.IO.File]::ReadAllText($FILE, [System.Text.Encoding]::UTF8)
+  $JSON = @{ title = $TITLE; html = $HTML } | ConvertTo-Json -Compress
+  $BYTES = [System.Text.Encoding]::UTF8.GetBytes($JSON)
+  $RESP = Invoke-WebRequest -Uri $ENDPOINT -Method Post -ContentType 'application/json; charset=utf-8' \`
+    -Headers @{ Authorization = "Bearer $KEY" } -Body $BYTES -UseBasicParsing
+} catch {
+  $R = $null
+  try { $R = $_.Exception.Response } catch {}
+  if (-not $R) { Die "Symposium may have published the page without returning a receipt. Do not retry." 1 }
+  $READER = New-Object System.IO.StreamReader($R.GetResponseStream())
+  $OUT = $READER.ReadToEnd()
+  Die "Symposium publish failed (HTTP $([int]$R.StatusCode)): $OUT" 1
+}
+if ([int]$RESP.StatusCode -ne 201) {
+  Die "Symposium returned an unexpected success response (HTTP $([int]$RESP.StatusCode)): $($RESP.Content). Do not retry." 1
+}
+[Console]::Out.WriteLine($RESP.Content)
+`,
+    },
+  ],
+};
+
 /** All always-seeded plugin-shipped skills, in display order. */
 export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
   WEB_SEARCH,
@@ -496,6 +718,7 @@ export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
   READ_PDF,
   YOUTUBE_TRANSCRIPT,
   FETCH_X,
+  SYMPOSIUM_PUBLISH,
   ...OBSIDIAN_SKILLS,
 ];
 

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -516,8 +516,8 @@ property is present, stop: this skill performs initial publishing only.
 Convert the note into a complete, self-contained, passive HTML document. Render
 source-specific content such as Mermaid and Obsidian Bases into static HTML or
 SVG, embed images, and include no scripts, frames, forms, handlers, or external
-assets. If its UTF-8 encoding exceeds \`${SYMPOSIUM_MAX_HTML_BYTES}\` bytes (10 MiB),
-stop without asking for confirmation or sending a request.
+assets. If its UTF-8 encoding exceeds \`${SYMPOSIUM_MAX_HTML_BYTES}\` bytes, stop
+without asking for confirmation or sending a request.
 
 Show the source note, title, and a concise preview. Explain that the resulting
 link is public and ask an explicit Yes/No confirmation. If the agent has no

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -537,10 +537,10 @@ error, is an edge/client rejection and says nothing about license validity. Any
 other non-201 response is a publish failure.
 
 A 201 receipt is valid only when \`docId\` is 16 lowercase Crockford characters,
-\`url\` is HTTPS, and \`version\` is a positive safe integer. Treat a malformed
-201 as ambiguous and non-retryable. Before updating the source note, append a
-\`published\` row containing that receipt, the source path, current UTC time,
-and the HTML SHA-256 to
+\`url\` is HTTPS with path \`/d/<docId>\`, and \`version\` is a positive safe integer.
+Treat a malformed 201 as ambiguous and non-retryable. Before updating the source
+note, append a \`published\` row containing that receipt, the source path, current
+UTC time, and the HTML SHA-256 to
 \`copilot/symposium/published-documents.md\`; this is an ordinary Markdown note,
 so create or append it with normal Obsidian note tools. Use this header:
 
@@ -555,8 +555,9 @@ spaces in every cell. Append in column order without rewriting old rows. If
 this advisory write fails, continue.
 
 Finally use one \`processFrontMatter\` callback to set the source note's
-\`symposium\` text property to \`docId\` only if it is still absent. If that
-fails, do not publish again; report the URL and id so they remain recoverable.
+\`symposium\` text property to the server's full \`url\` only if it is still
+absent. If that fails, do not publish again; report the URL and id so they remain
+recoverable.
 Return the server's \`url\` verbatim. Never put the license key in the note,
 HTML, ledger, command arguments, or chat.
 `,

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -490,7 +490,7 @@ const FETCH_X = relaySkill({
   scriptFile: "fetch-x.sh",
 });
 
-const SYMPOSIUM_PUBLISH_VERSION = 4;
+const SYMPOSIUM_PUBLISH_VERSION = 5;
 const SYMPOSIUM_PUBLISH: BuiltinSkill = {
   name: "copilot-publish-symposium",
   version: SYMPOSIUM_PUBLISH_VERSION,
@@ -594,20 +594,26 @@ the license key in the ledger.
 
 ## 6. Save the identity
 
-Only after attempting the ledger write, read the source note's \`symposium\`
-property again. Set it to the returned \`docId\` only if it is still absent,
-preserving all other frontmatter. Prefer the Obsidian CLI:
+Only after attempting the ledger write, save the identity through one atomic
+Obsidian \`processFrontMatter\` callback. Do not use \`property:set\`: its
+separate read and write can replace an identity saved by another publisher.
+
+Base64-encode the UTF-8 vault-relative source path without a trailing newline
+as \`<pathBase64>\`, then use the Obsidian CLI. The returned document id is
+already restricted to lowercase Crockford characters, so substitute it for
+\`<docId>\`:
 
 \`\`\`bash
-obsidian vault="<vault>" property:set path="<vault-relative-source.md>" name=symposium value="<docId>" type=text
+obsidian vault="<vault>" eval code='(async()=>{const path=new TextDecoder().decode(Uint8Array.from(atob("<pathBase64>"),c=>c.charCodeAt(0)));const docId="<docId>";const file=app.vault.getAbstractFileByPath(path);if(!file||file.extension!=="md")throw new Error("Source note unavailable");let saved=false;let current=null;await app.fileManager.processFrontMatter(file,frontmatter=>{if(!frontmatter||typeof frontmatter!=="object"||Array.isArray(frontmatter))throw new Error("Invalid frontmatter");const has=Object.prototype.hasOwnProperty.call(frontmatter,"symposium");current=has?frontmatter.symposium:null;if(current===docId){saved=true}else if(!has){frontmatter.symposium=docId;current=docId;saved=true}});return JSON.stringify({saved,current})})()'
 \`\`\`
 
-If the property now has any value, leave it unchanged and report the concurrent
-change together with the new URL and document id from the ledger. If reading or
-saving the property fails, do not publish again. Report the returned URL and
-document id so the page remains recoverable. Otherwise return the server's
-\`url\` verbatim. Always delete the temporary HTML file. Never print or write
-the license key into the note, HTML, command arguments, or chat.
+Require the result to contain \`"saved":true\`. Otherwise leave the current
+property unchanged and report the concurrent change together with the new URL
+and document id from the ledger. If saving fails, do not publish again. Report
+the returned URL and document id so the page remains recoverable. Otherwise
+return the server's \`url\` verbatim. Always delete the temporary HTML file.
+Never print or write the license key into the note, HTML, command arguments, or
+chat.
 `,
   files: [
     {
@@ -629,19 +635,7 @@ FILE=$3
 [ -f "$SOURCE" ] && [ -r "$SOURCE" ] || die "Could not read source note: $SOURCE" 1
 case "$SOURCE" in *.[mM][dD]) ;; *) die "The Symposium source must be a Markdown note." 1 ;; esac
 [ -f "$FILE" ] && [ -r "$FILE" ] || die "Could not read prepared HTML: $FILE" 1
-
-json_escape() {
-  awk 'BEGIN { ORS=""; printf "\\"" }
-    {
-      if (NR > 1) printf "\\\\n"
-      gsub(/\\\\/, "\\\\\\\\")
-      gsub(/\\"/, "\\\\\\"")
-      gsub(/\\t/, "\\\\t")
-      gsub(/\\r/, "\\\\r")
-      printf "%s", $0
-    }
-    END { printf "\\"" }'
-}
+command -v node >/dev/null 2>&1 || die "Node.js is required to publish safely to Symposium." 1
 
 source_is_unpublished() {
   awk '
@@ -662,13 +656,14 @@ invalid_receipt() {
 }
 
 source_is_unpublished || die "The source note's Symposium identity changed. Do not publish it again." 1
-RESP=$({
-  printf '{"title":'
-  printf '%s' "$TITLE" | json_escape
-  printf ',"html":'
-  json_escape < "$FILE"
-  printf '}'
-} | curl -sS -w '\\n%{http_code}' \\
+PAYLOAD=$(node -e '
+  const fs = require("fs");
+  process.stdout.write(JSON.stringify({
+    title: process.argv[1],
+    html: fs.readFileSync(process.argv[2], "utf8"),
+  }));
+' "$TITLE" "$FILE") || die "Could not encode the prepared Symposium page." 1
+RESP=$(printf '%s' "$PAYLOAD" | curl -sS -w '\\n%{http_code}' \\
   -X POST "$ENDPOINT" \\
   -H "Authorization: Bearer $KEY" \\
   -H 'Content-Type: application/json; charset=utf-8' \\
@@ -678,21 +673,31 @@ CODE=$(printf '%s' "$RESP" | tail -n1)
 OUT=$(printf '%s' "$RESP" | sed '$d')
 case "$CODE" in
   201)
-    COMPACT=$(printf '%s' "$OUT" | tr -d '[:space:]')
-    case "$COMPACT" in \\{*\\}) ;; *) invalid_receipt ;; esac
-    DOC_ID=$(printf '%s' "$COMPACT" | sed -n 's/.*"docId":"\\([^"]*\\)".*/\\1/p')
-    [ "\${#DOC_ID}" -eq 16 ] || invalid_receipt
-    case "$DOC_ID" in *[!0123456789abcdefghjkmnpqrstvwxyz]*) invalid_receipt ;; esac
-    URL=$(printf '%s' "$COMPACT" | sed -n 's/.*"url":"\\([^"]*\\)".*/\\1/p')
-    case "$URL" in https://?*) ;; *) invalid_receipt ;; esac
-    VERSION=$(printf '%s' "$COMPACT" | sed -n 's/.*"version":\\([0-9][0-9]*\\)[,}].*/\\1/p')
-    case "$VERSION" in ""|0|0*) invalid_receipt ;; esac
-    awk -v value="$VERSION" 'BEGIN {
-      max = "9007199254740991"
-      if (length(value) < length(max)) exit 0
-      if (length(value) > length(max) || ("x" value) > ("x" max)) exit 1
-    }' || invalid_receipt
-    printf '%s\\n' "$OUT"
+    CANONICAL=$(printf '%s' "$OUT" | node -e '
+      let input = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", chunk => { input += chunk; });
+      process.stdin.on("end", () => {
+        try {
+          const receipt = JSON.parse(input);
+          const url = new URL(receipt.url);
+          if (!receipt || Array.isArray(receipt) || typeof receipt !== "object" ||
+              !/^[0123456789abcdefghjkmnpqrstvwxyz]{16}$/.test(receipt.docId) ||
+              url.protocol !== "https:" || !url.hostname ||
+              !Number.isSafeInteger(receipt.version) || receipt.version < 1) {
+            throw new Error("invalid receipt");
+          }
+          process.stdout.write(JSON.stringify({
+            docId: receipt.docId,
+            url: receipt.url,
+            version: receipt.version,
+          }));
+        } catch {
+          process.exitCode = 1;
+        }
+      });
+    ') || invalid_receipt
+    printf '%s\\n' "$CANONICAL"
     ;;
   401|403) die "Symposium rejected the Copilot Plus license: $OUT" 1 ;;
   2*) die "Symposium returned an unexpected success response (HTTP $CODE): $OUT. Do not retry." 1 ;;

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -506,9 +506,9 @@ metadata:
 
 # Publish Markdown to Symposium
 
-Use one existing Markdown source note; if needed, create it first. Read its
-\`symposium\` property through Obsidian. If present, stop and use **Publish file
-to Symposium** for Update/Delete.
+Require one existing Markdown source note. Read it with normal Obsidian note
+tools. If its \`symposium\` property is present, stop and use **Publish file to
+Symposium** for Update/Delete.
 
 Convert the note into a complete, self-contained, passive HTML document. Render
 Obsidian-only content such as Mermaid and Bases into static HTML or SVG, embed
@@ -519,13 +519,9 @@ link is public and ask an explicit Yes/No confirmation. If the agent has no
 question UI, ask conversationally and stop until the user answers. A previous
 request to publish is not confirmation. On No, send nothing.
 
-Before any network request, use the Obsidian CLI to verify that it can access
-\`app.fileManager.processFrontMatter\`. If this capability probe fails, stop
-without publishing.
-
 On Yes, read \`${PLUS_ENV.licenseKey}\` from the environment without printing
-or storing it. Recheck that the source has no \`symposium\` property, then use
-the agent's available HTTP tooling to POST exactly once to
+or storing it. Recheck that the source still exists and has no \`symposium\`
+property, then use the agent's available HTTP tooling to POST exactly once to
 \`${SYMPOSIUM_API_ORIGIN}/api/v1/docs\` with Bearer authorization and JSON
 \`{"title": <title>, "html": <html>}\`. Do not retry if the request may have
 reached the server. Report 401/403 as a rejected Copilot Plus license. Any other
@@ -537,14 +533,19 @@ A 201 receipt is valid only when \`docId\` is 16 lowercase Crockford characters,
 \`published\` row containing that receipt, the source path, current UTC time,
 and the HTML SHA-256 to
 \`copilot/symposium/published-documents.md\`; this is an ordinary Markdown note,
-so create it with the existing ledger table header if absent and otherwise
-append without rewriting old rows. If this advisory write fails, continue.
+so create or append it with normal Obsidian note tools. Use this header:
 
-Finally use one Obsidian \`processFrontMatter\` call to set \`symposium\` to
-\`docId\` only if the property is still absent. Never overwrite a concurrent
-value. If this compare-and-set fails, do not publish again; report the URL and
-id so they remain recoverable. Return the server's \`url\` verbatim. Never put
-the license key in the note, HTML, ledger, command arguments, or chat.
+\`\`\`markdown
+| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |
+| --- | --- | --- | --- | --- | ---: | --- |
+\`\`\`
+
+Append in that column order without rewriting old rows. If this advisory write
+fails, continue. Then set the source note's \`symposium\` text property to
+\`docId\` with the Obsidian CLI only if it is still absent. If that fails, do
+not publish again; report the URL and id so they remain recoverable. Return the
+server's \`url\` verbatim. Never put the license key in the note, HTML, ledger,
+command arguments, or chat.
 `,
   files: [],
 };

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -1,5 +1,5 @@
 import type { BackendId } from "@/agentMode/session/types";
-import { SYMPOSIUM_API_ORIGIN } from "@/symposium/constants";
+import { SYMPOSIUM_API_ORIGIN, SYMPOSIUM_TOKEN_ENV } from "@/symposium/constants";
 import { OBSIDIAN_SKILLS } from "./obsidianSkills";
 
 /**
@@ -492,13 +492,12 @@ const FETCH_X = relaySkill({
 
 const SYMPOSIUM_PUBLISH_VERSION = 1;
 const SYMPOSIUM_PUBLISH: BuiltinSkill = {
-  name: "copilot-publish-symposium",
+  name: "symposium-publish",
   version: SYMPOSIUM_PUBLISH_VERSION,
   enabledAgents: ["claude", "codex", "opencode"],
   skillMd: `---
-name: copilot-publish-symposium
-description: Convert a source Markdown note into standalone HTML and publish it as a public Symposium page. Use when the user asks to publish or share a note as a web page. Initial publishing only; existing Symposium pages use Obsidian's normal Update/Delete flow. Requires an active Copilot Plus license.
-license: Copilot Plus
+name: symposium-publish
+description: Convert an existing source Markdown file into standalone HTML and publish it as a public Symposium page. Use when the user asks to publish or share Markdown as a web page. Handles initial publishing only; existing pages require the host's update or delete flow.
 metadata:
   copilot-enabled-agents: claude, codex, opencode
   copilot-builtin-version: "${SYMPOSIUM_PUBLISH_VERSION}"
@@ -506,60 +505,60 @@ metadata:
 
 # Publish Markdown to Symposium
 
-Require one existing Markdown source note. Read it with normal Obsidian note
-tools. If its \`symposium\` property is present, stop and use **Publish file to
-Symposium** for Update/Delete.
+Require one existing Markdown source file. If its \`symposium\` frontmatter
+property is present, stop: this skill performs initial publishing only.
 
 Convert the note into a complete, self-contained, passive HTML document. Render
-Obsidian-only content such as Mermaid and Bases into static HTML or SVG, embed
-images, and include no scripts, frames, forms, handlers, or external assets.
+source-specific content such as Mermaid and Obsidian Bases into static HTML or
+SVG, embed images, and include no scripts, frames, forms, handlers, or external
+assets.
 
 Show the source note, title, and a concise preview. Explain that the resulting
 link is public and ask an explicit Yes/No confirmation. If the agent has no
 question UI, ask conversationally and stop until the user answers. A previous
 request to publish is not confirmation. On No, send nothing.
 
-On Yes, read \`${PLUS_ENV.licenseKey}\` from the environment without printing
-or storing it. If it is empty or absent, stop without making a request. Use the
-Obsidian CLI to verify that \`app.fileManager.processFrontMatter\` is available;
-if not, stop. Recheck that the source still exists and has no \`symposium\`
-property, then use the agent's available HTTP tooling to POST exactly once to
-\`${SYMPOSIUM_API_ORIGIN}/api/v1/docs\` with Bearer authorization and JSON
-\`{"title": <title>, "html": <html>}\`. Send \`Accept: application/json\` and
-\`Content-Type: application/json\`, and set \`User-Agent\` to
-\`Copilot-Obsidian/<${PLUS_ENV.clientVersion} or unknown>\`; Python \`urllib\`'s
-default client signature is blocked by Cloudflare. Do not retry if the request
-may have reached the server.
+On Yes, read \`${SYMPOSIUM_TOKEN_ENV}\` from the environment without printing
+or storing it. If it is empty or absent, stop without making a request and
+report that Symposium authentication is unavailable. Recheck that the source
+still exists and has no \`symposium\` property, then use available HTTP tooling
+to POST exactly once to \`${SYMPOSIUM_API_ORIGIN}/api/v1/docs\` with Bearer
+authorization and JSON \`{"title": <title>, "html": <html>}\`. Send
+\`Accept: application/json\` and \`Content-Type: application/json\`, and set
+\`User-Agent: Symposium-Agent\`; Python \`urllib\`'s default client signature is
+blocked by Cloudflare. Do not retry if the request may have reached the server.
 
-Report a rejected Copilot Plus license only when the response is JSON and
+Report that Symposium rejected the token only when the response is JSON and
 \`error.code\` is \`unauthorized\`. A non-JSON 403, including a Cloudflare 1xxx
-error, is an edge/client rejection and says nothing about license validity. Any
+error, is an edge/client rejection and says nothing about token validity. Any
 other non-201 response is a publish failure.
 
 A 201 receipt is valid only when \`docId\` is 16 lowercase Crockford characters,
 \`url\` is HTTPS with path \`/d/<docId>\`, and \`version\` is a positive safe integer.
 Treat a malformed 201 as ambiguous and non-retryable. Before updating the source
 note, append a \`published\` row containing that receipt, the source path, current
-UTC time, and the HTML SHA-256 to
-\`copilot/symposium/published-documents.md\`; this is an ordinary Markdown note,
-so create or append it with normal Obsidian note tools. Use this header:
+UTC time, and the HTML SHA-256 to \`.symposium/publish-history.md\` under the
+workspace root (the vault root when running in Obsidian). Use direct filesystem
+operations because hidden directories are not ordinary indexed notes. Create
+the directory and file when absent. Use this header:
 
 \`\`\`markdown
 | Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |
 | --- | --- | --- | --- | --- | ---: | --- |
 \`\`\`
 
-Create the note if absent; otherwise append only when it begins with that exact
+If the file exists, append only when it begins with that exact
 header. Escape existing backslashes, then pipes, and replace line breaks with
 spaces in every cell. Append in column order without rewriting old rows. If
 this advisory write fails, continue.
 
-Finally use one \`processFrontMatter\` callback to set the source note's
-\`symposium\` text property to the server's full \`url\` only if it is still
-absent. If that fails, do not publish again; report the URL and id so they remain
-recoverable.
-Return the server's \`url\` verbatim. Never put the license key in the note,
-HTML, ledger, command arguments, or chat.
+Finally re-read the source and set its \`symposium\` text property to the
+server's full \`url\` only if the property is still absent. Prefer a host's
+structured frontmatter API when available; otherwise make the smallest direct
+file edit without replacing concurrent changes. If that fails, do not publish
+again; report the URL and id so they remain recoverable.
+Return the server's \`url\` verbatim. Never put the token in the note, HTML,
+ledger, command arguments, or chat.
 `,
   files: [],
 };

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -519,6 +519,10 @@ link is public and ask an explicit Yes/No confirmation. If the agent has no
 question UI, ask conversationally and stop until the user answers. A previous
 request to publish is not confirmation. On No, send nothing.
 
+Before any network request, use the Obsidian CLI to verify that it can access
+\`app.fileManager.processFrontMatter\`. If this capability probe fails, stop
+without publishing.
+
 On Yes, read \`${PLUS_ENV.licenseKey}\` from the environment without printing
 or storing it. Recheck that the source has no \`symposium\` property, then use
 the agent's available HTTP tooling to POST exactly once to

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -490,7 +490,7 @@ const FETCH_X = relaySkill({
   scriptFile: "fetch-x.sh",
 });
 
-const SYMPOSIUM_PUBLISH_VERSION = 5;
+const SYMPOSIUM_PUBLISH_VERSION = 6;
 const SYMPOSIUM_PUBLISH: BuiltinSkill = {
   name: "copilot-publish-symposium",
   version: SYMPOSIUM_PUBLISH_VERSION,
@@ -511,7 +511,7 @@ approve the finished page, and publish it once through the bundled wrapper.
 
 ## 1. Require a source note
 
-Resolve an existing Markdown note and keep both its absolute path and its
+Resolve an existing Markdown note and keep its vault name, absolute path, and
 vault-relative path. Do not publish standalone HTML without a source note. If
 the requested content is not in a note yet, create the source note first.
 
@@ -552,19 +552,19 @@ enough. If they decline, delete the temporary HTML and make no request.
 ## 4. Publish once
 
 Find the absolute path to this SKILL.md file, then run the matching wrapper with
-exactly three arguments: the absolute source-note path, page title, and prepared
-HTML file.
+exactly five arguments: the vault name, vault-relative source path, absolute
+source-note path, page title, and prepared HTML file.
 
 On macOS or Linux:
 
 \`\`\`bash
-sh "/absolute/path/to/this/skill/directory/publish-symposium.sh" "/absolute/path/to/source.md" "Page title" "/absolute/path/to/prepared.html"
+sh "/absolute/path/to/this/skill/directory/publish-symposium.sh" "Vault name" "folder/source.md" "/absolute/path/to/source.md" "Page title" "/absolute/path/to/prepared.html"
 \`\`\`
 
 On Windows, call the \`.cmd\` wrapper from PowerShell:
 
 \`\`\`powershell
-& "/absolute/path/to/this/skill/directory/publish-symposium.cmd" "C:\\absolute\\path\\to\\source.md" "Page title" "C:\\absolute\\path\\to\\prepared.html"
+& "/absolute/path/to/this/skill/directory/publish-symposium.cmd" "Vault name" "folder/source.md" "C:\\absolute\\path\\to\\source.md" "Page title" "C:\\absolute\\path\\to\\prepared.html"
 \`\`\`
 
 Immediately before POST, the wrapper verifies that the source note still has
@@ -627,28 +627,40 @@ die() {
   exit "\${2:-2}"
 }
 
-[ "$#" -eq 3 ] || die "Usage: sh publish-symposium.sh <source-note.md> <title> <prepared.html>" 1
-SOURCE=$1
-TITLE=$2
-FILE=$3
+[ "$#" -eq 5 ] || die "Usage: sh publish-symposium.sh <vault> <vault-source-path> <source-note.md> <title> <prepared.html>" 1
+VAULT=$1
+SOURCE_PATH=$2
+SOURCE=$3
+TITLE=$4
+FILE=$5
 [ -n "$KEY" ] || die "Copilot Plus is not active, so Symposium publishing is unavailable." 1
 [ -f "$SOURCE" ] && [ -r "$SOURCE" ] || die "Could not read source note: $SOURCE" 1
 case "$SOURCE" in *.[mM][dD]) ;; *) die "The Symposium source must be a Markdown note." 1 ;; esac
 [ -f "$FILE" ] && [ -r "$FILE" ] || die "Could not read prepared HTML: $FILE" 1
-command -v node >/dev/null 2>&1 || die "Node.js is required to publish safely to Symposium." 1
+command -v obsidian >/dev/null 2>&1 || die "The Obsidian CLI is required to publish safely to Symposium." 1
+
+json_escape() {
+  awk -v final_lf="\${1:-0}" 'BEGIN { ORS=""; printf "\\"" }
+    {
+      if (NR > 1) printf "\\\\n"
+      gsub(/\\\\/, "\\\\\\\\")
+      gsub(/\\"/, "\\\\\\"")
+      gsub(/\\t/, "\\\\t")
+      gsub(/\\r/, "\\\\r")
+      printf "%s", $0
+    }
+    END {
+      if (final_lf) printf "\\\\n"
+      printf "\\""
+    }'
+}
 
 source_is_unpublished() {
-  awk '
-    NR == 1 {
-      sub(/^\\357\\273\\277/, "")
-      if ($0 != "---") exit 0
-      in_yaml = 1
-      next
-    }
-    in_yaml && $0 ~ /^(---|\\.\\.\\.)[[:space:]]*$/ { exit found ? 1 : 0 }
-    in_yaml && $0 ~ /^[[:space:]]*symposium[[:space:]]*:/ { found = 1 }
-    END { if (found) exit 1 }
-  ' "$SOURCE"
+  PROPERTIES=$(obsidian vault="$VAULT" properties path="$SOURCE_PATH" format=json 2>&1)
+  PROPERTIES_B64=$(printf '%s' "$PROPERTIES" | base64 | tr -d '\\r\\n')
+  STATE=$(obsidian vault="$VAULT" eval code="(()=>{try{const input=new TextDecoder().decode(Uint8Array.from(atob('$PROPERTIES_B64'),c=>c.charCodeAt(0)));const properties=JSON.parse(input);if(!properties||Array.isArray(properties)||typeof properties!==\\"object\\")return \\"INVALID\\";return Object.prototype.hasOwnProperty.call(properties,\\"symposium\\")?\\"OCCUPIED\\":\\"CLEAR\\"}catch{return \\"INVALID\\"}})()" 2>/dev/null)
+  STATE=\${STATE#"=> "}
+  [ "$STATE" = "CLEAR" ]
 }
 
 invalid_receipt() {
@@ -656,14 +668,17 @@ invalid_receipt() {
 }
 
 source_is_unpublished || die "The source note's Symposium identity changed. Do not publish it again." 1
-PAYLOAD=$(node -e '
-  const fs = require("fs");
-  process.stdout.write(JSON.stringify({
-    title: process.argv[1],
-    html: fs.readFileSync(process.argv[2], "utf8"),
-  }));
-' "$TITLE" "$FILE") || die "Could not encode the prepared Symposium page." 1
-RESP=$(printf '%s' "$PAYLOAD" | curl -sS -w '\\n%{http_code}' \\
+FINAL_LF=0
+if [ -s "$FILE" ] && [ "$(tail -c 1 "$FILE" | wc -l | tr -d '[:space:]')" = "1" ]; then
+  FINAL_LF=1
+fi
+RESP=$({
+  printf '{"title":'
+  printf '%s' "$TITLE" | json_escape 0
+  printf ',"html":'
+  json_escape "$FINAL_LF" < "$FILE"
+  printf '}'
+} | curl -sS -w '\\n%{http_code}' \\
   -X POST "$ENDPOINT" \\
   -H "Authorization: Bearer $KEY" \\
   -H 'Content-Type: application/json; charset=utf-8' \\
@@ -673,30 +688,10 @@ CODE=$(printf '%s' "$RESP" | tail -n1)
 OUT=$(printf '%s' "$RESP" | sed '$d')
 case "$CODE" in
   201)
-    CANONICAL=$(printf '%s' "$OUT" | node -e '
-      let input = "";
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", chunk => { input += chunk; });
-      process.stdin.on("end", () => {
-        try {
-          const receipt = JSON.parse(input);
-          const url = new URL(receipt.url);
-          if (!receipt || Array.isArray(receipt) || typeof receipt !== "object" ||
-              !/^[0123456789abcdefghjkmnpqrstvwxyz]{16}$/.test(receipt.docId) ||
-              url.protocol !== "https:" || !url.hostname ||
-              !Number.isSafeInteger(receipt.version) || receipt.version < 1) {
-            throw new Error("invalid receipt");
-          }
-          process.stdout.write(JSON.stringify({
-            docId: receipt.docId,
-            url: receipt.url,
-            version: receipt.version,
-          }));
-        } catch {
-          process.exitCode = 1;
-        }
-      });
-    ') || invalid_receipt
+    RECEIPT_B64=$(printf '%s' "$OUT" | base64 | tr -d '\\r\\n')
+    CANONICAL=$(obsidian vault="$VAULT" eval code="(()=>{try{const input=new TextDecoder().decode(Uint8Array.from(atob('$RECEIPT_B64'),c=>c.charCodeAt(0)));const receipt=JSON.parse(input);const url=new URL(receipt.url);if(!receipt||Array.isArray(receipt)||typeof receipt!==\\"object\\"||!/^[0123456789abcdefghjkmnpqrstvwxyz]{16}$/.test(receipt.docId)||url.protocol!==\\"https:\\"||!url.hostname||!Number.isSafeInteger(receipt.version)||receipt.version<1)return \\"INVALID\\";return \\"VALID \\"+JSON.stringify({docId:receipt.docId,url:receipt.url,version:receipt.version})}catch{return \\"INVALID\\"}})()" 2>/dev/null)
+    CANONICAL=\${CANONICAL#"=> "}
+    case "$CANONICAL" in "VALID "*) CANONICAL=\${CANONICAL#"VALID "} ;; *) invalid_receipt ;; esac
     printf '%s\\n' "$CANONICAL"
     ;;
   401|403) die "Symposium rejected the Copilot Plus license: $OUT" 1 ;;
@@ -721,24 +716,27 @@ function Die($message, $code = 2) {
   exit $code
 }
 
-if ($args.Count -ne 3) { Die "Usage: publish-symposium.ps1 <source-note.md> <title> <prepared.html>" 1 }
-$SOURCE = $args[0]
-$TITLE = $args[1]
-$FILE = $args[2]
+if ($args.Count -ne 5) { Die "Usage: publish-symposium.ps1 <vault> <vault-source-path> <source-note.md> <title> <prepared.html>" 1 }
+$VAULT = $args[0]
+$SOURCE_PATH = $args[1]
+$SOURCE = $args[2]
+$TITLE = $args[3]
+$FILE = $args[4]
 $KEY = [Environment]::GetEnvironmentVariable('${PLUS_ENV.licenseKey}')
 $ENDPOINT = '${SYMPOSIUM_API_ORIGIN}/api/v1/docs'
 if (-not $KEY) { Die "Copilot Plus is not active, so Symposium publishing is unavailable." 1 }
 if (-not (Test-Path -LiteralPath $SOURCE -PathType Leaf)) { Die "Could not read source note: $SOURCE" 1 }
 if ([System.IO.Path]::GetExtension($SOURCE) -ine '.md') { Die "The Symposium source must be a Markdown note." 1 }
 if (-not (Test-Path -LiteralPath $FILE -PathType Leaf)) { Die "Could not read prepared HTML: $FILE" 1 }
+if (-not (Get-Command obsidian -ErrorAction SilentlyContinue)) { Die "The Obsidian CLI is required to publish safely to Symposium." 1 }
 
 try {
-  $SOURCE_TEXT = [System.IO.File]::ReadAllText($SOURCE, [System.Text.Encoding]::UTF8)
+  $PROPERTIES_JSON = (& obsidian "vault=$VAULT" properties "path=$SOURCE_PATH" "format=json" 2>&1 | Out-String)
+  $PROPERTIES = $PROPERTIES_JSON | ConvertFrom-Json -ErrorAction Stop
 } catch {
-  Die "Could not read source note: $SOURCE" 1
+  Die "Could not inspect the source note's Symposium identity." 1
 }
-$FRONTMATTER = [regex]::Match($SOURCE_TEXT.TrimStart([char]0xFEFF), '(?s)\\A---\\r?\\n(.*?)\\r?\\n(?:---|\\.\\.\\.)\\s*(?:\\r?\\n|$)')
-if ($FRONTMATTER.Success -and $FRONTMATTER.Groups[1].Value -match '(?m)^\\s*symposium\\s*:') {
+if ($null -ne $PROPERTIES.PSObject.Properties['symposium']) {
   Die "The source note's Symposium identity changed. Do not publish it again." 1
 }
 
@@ -765,6 +763,10 @@ try {
   $URL_TEXT = $RECEIPT.url
   $VERSION = $RECEIPT.version
   $URI = $null
+  $VALID_VERSION_TYPE = $VERSION -is [int] -or
+    $VERSION -is [long] -or
+    $VERSION -is [double] -or
+    $VERSION -is [decimal]
   $VALID_URL = $URL_TEXT -is [string] -and
     [Uri]::TryCreate($URL_TEXT, [UriKind]::Absolute, [ref]$URI) -and
     $URI.Scheme -eq 'https'
@@ -772,7 +774,7 @@ try {
       $DOC_ID -isnot [string] -or
       $DOC_ID -notmatch '^[0123456789abcdefghjkmnpqrstvwxyz]{16}$' -or
       -not $VALID_URL -or
-      $VERSION -is [string]) {
+      -not $VALID_VERSION_TYPE) {
     throw "invalid receipt"
   }
   $VERSION_NUMBER = [decimal]$VERSION

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -490,7 +490,7 @@ const FETCH_X = relaySkill({
   scriptFile: "fetch-x.sh",
 });
 
-const SYMPOSIUM_PUBLISH_VERSION = 6;
+const SYMPOSIUM_PUBLISH_VERSION = 7;
 const SYMPOSIUM_PUBLISH: BuiltinSkill = {
   name: "copilot-publish-symposium",
   version: SYMPOSIUM_PUBLISH_VERSION,
@@ -506,290 +506,40 @@ metadata:
 
 # Publish Markdown to Symposium
 
-Create a standalone web page from one Markdown source note, ask the user to
-approve the finished page, and publish it once through the bundled wrapper.
+Use one existing Markdown source note; if needed, create it first. Read its
+\`symposium\` property through Obsidian. If present, stop and use **Publish file
+to Symposium** for Update/Delete.
 
-## 1. Require a source note
+Convert the note into a complete, self-contained, passive HTML document. Render
+Obsidian-only content such as Mermaid and Bases into static HTML or SVG, embed
+images, and include no scripts, frames, forms, handlers, or external assets.
 
-Resolve an existing Markdown note and keep its vault name, absolute path, and
-vault-relative path. Do not publish standalone HTML without a source note. If
-the requested content is not in a note yet, create the source note first.
+Show the source note, title, and a concise preview. Explain that the resulting
+link is public and ask an explicit Yes/No confirmation. If the agent has no
+question UI, ask conversationally and stop until the user answers. A previous
+request to publish is not confirmation. On No, send nothing.
 
-Inspect the note's \`symposium\` property before doing any network work. If it
-already contains a document id, tell the user to use **Publish file to
-Symposium** for Update/Delete. If it contains another value, stop rather than
-overwriting it.
+On Yes, read \`${PLUS_ENV.licenseKey}\` from the environment without printing
+or storing it. Recheck that the source has no \`symposium\` property, then use
+the agent's available HTTP tooling to POST exactly once to
+\`${SYMPOSIUM_API_ORIGIN}/api/v1/docs\` with Bearer authorization and JSON
+\`{"title": <title>, "html": <html>}\`. Do not retry if the request may have
+reached the server. Report 401/403 as a rejected Copilot Plus license. Any other
+non-201 response is a publish failure.
 
-## 2. Prepare the page
+A 201 response must contain \`docId\`, \`url\`, and \`version\`. Before updating
+the source note, append a \`published\` row containing that receipt, the source
+path, current UTC time, and the HTML SHA-256 to
+\`copilot/symposium/published-documents.md\`; this is an ordinary Markdown note,
+so create it with the existing ledger table header if absent and otherwise
+append without rewriting old rows. If this advisory write fails, continue.
 
-Create a complete HTML document yourself from the requested Markdown. The file
-must start with \`<!doctype html>\` and include its own readable layout and
-inline CSS. Send HTML, never raw Markdown.
-
-The page must be self-contained and passive:
-
-- resolve Obsidian-only rendered content into static HTML before publishing;
-  for example, turn Mermaid into static SVG and Bases into a static table or
-  card layout rather than leaving a raw code block or \`.base\` source;
-- embed required images as data URLs and do not depend on external styles,
-  scripts, fonts, frames, media, or other fetched assets;
-- include no \`script\`, \`iframe\`, form controls, embedded objects, event
-  handlers, or other executable/interactive content.
-
-Write the final HTML to a temporary \`.html\` file. Keep it unchanged after the
-confirmation question is shown.
-
-## 3. Ask before publishing
-
-Show the user the source note, title, and a concise preview or description of
-the finished page. Explain that anyone with the resulting link can read it.
-Ask an explicit Yes/No question through the agent's user-question UI. If that
-UI is unavailable, ask the same question conversationally, stop the turn, and
-wait for the user's next message. Do not invoke the wrapper unless the user
-answers Yes to this confirmation; a prior general request to publish is not
-enough. If they decline, delete the temporary HTML and make no request.
-
-## 4. Publish once
-
-Find the absolute path to this SKILL.md file, then run the matching wrapper with
-exactly five arguments: the vault name, vault-relative source path, absolute
-source-note path, page title, and prepared HTML file.
-
-On macOS or Linux:
-
-\`\`\`bash
-sh "/absolute/path/to/this/skill/directory/publish-symposium.sh" "Vault name" "folder/source.md" "/absolute/path/to/source.md" "Page title" "/absolute/path/to/prepared.html"
-\`\`\`
-
-On Windows, call the \`.cmd\` wrapper from PowerShell:
-
-\`\`\`powershell
-& "/absolute/path/to/this/skill/directory/publish-symposium.cmd" "Vault name" "folder/source.md" "C:\\absolute\\path\\to\\source.md" "Page title" "C:\\absolute\\path\\to\\prepared.html"
-\`\`\`
-
-Immediately before POST, the wrapper verifies that the source note still has
-no \`symposium\` property. It prints a canonical, validated publish receipt as
-JSON. Never retry after an uncertain response; it may already have created a
-public page.
-
-## 5. Record the receipt
-
-Before changing the source note, append the receipt to the vault-local
-\`copilot/symposium/published-documents.md\` ledger. Create its parent folder
-and this plain Markdown table when absent:
-
-\`\`\`markdown
-| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |
-| --- | --- | --- | --- | --- | ---: | --- |
-\`\`\`
-
-Append one row; never rewrite or delete older rows. Use \`published\` status,
-the vault-relative source path, the exact returned URL and version, the current
-UTC ISO timestamp, and the SHA-256 of the exact prepared HTML file. Wrap the URL
-in angle brackets and escape \`|\` in the note path as \`\\|\`.
-
-The ledger is recovery history, not publication state. If this advisory write
-fails, continue to save the source property; never publish again and never put
-the license key in the ledger.
-
-## 6. Save the identity
-
-Only after attempting the ledger write, save the identity through one atomic
-Obsidian \`processFrontMatter\` callback. Do not use \`property:set\`: its
-separate read and write can replace an identity saved by another publisher.
-
-Base64-encode the UTF-8 vault-relative source path without a trailing newline
-as \`<pathBase64>\`, then use the Obsidian CLI. The returned document id is
-already restricted to lowercase Crockford characters, so substitute it for
-\`<docId>\`:
-
-\`\`\`bash
-obsidian vault="<vault>" eval code='(async()=>{const path=new TextDecoder().decode(Uint8Array.from(atob("<pathBase64>"),c=>c.charCodeAt(0)));const docId="<docId>";const file=app.vault.getAbstractFileByPath(path);if(!file||file.extension!=="md")throw new Error("Source note unavailable");let saved=false;let current=null;await app.fileManager.processFrontMatter(file,frontmatter=>{if(!frontmatter||typeof frontmatter!=="object"||Array.isArray(frontmatter))throw new Error("Invalid frontmatter");const has=Object.prototype.hasOwnProperty.call(frontmatter,"symposium");current=has?frontmatter.symposium:null;if(current===docId){saved=true}else if(!has){frontmatter.symposium=docId;current=docId;saved=true}});return JSON.stringify({saved,current})})()'
-\`\`\`
-
-Require the result to contain \`"saved":true\`. Otherwise leave the current
-property unchanged and report the concurrent change together with the new URL
-and document id from the ledger. If saving fails, do not publish again. Report
-the returned URL and document id so the page remains recoverable. Otherwise
-return the server's \`url\` verbatim. Always delete the temporary HTML file.
-Never print or write the license key into the note, HTML, command arguments, or
-chat.
+Finally set the source note's \`symposium\` property to \`docId\` through
+Obsidian. If that local write fails, do not publish again; report the URL and id
+so they remain recoverable. Return the server's \`url\` verbatim. Never put the
+license key in the note, HTML, ledger, command arguments, or chat.
 `,
-  files: [
-    {
-      path: "publish-symposium.sh",
-      content: `#!/bin/sh
-KEY="\${${PLUS_ENV.licenseKey}:-}"
-ENDPOINT="${SYMPOSIUM_API_ORIGIN}/api/v1/docs"
-
-die() {
-  printf '%s\\n' "$1" >&2
-  exit "\${2:-2}"
-}
-
-[ "$#" -eq 5 ] || die "Usage: sh publish-symposium.sh <vault> <vault-source-path> <source-note.md> <title> <prepared.html>" 1
-VAULT=$1
-SOURCE_PATH=$2
-SOURCE=$3
-TITLE=$4
-FILE=$5
-[ -n "$KEY" ] || die "Copilot Plus is not active, so Symposium publishing is unavailable." 1
-[ -f "$SOURCE" ] && [ -r "$SOURCE" ] || die "Could not read source note: $SOURCE" 1
-case "$SOURCE" in *.[mM][dD]) ;; *) die "The Symposium source must be a Markdown note." 1 ;; esac
-[ -f "$FILE" ] && [ -r "$FILE" ] || die "Could not read prepared HTML: $FILE" 1
-command -v obsidian >/dev/null 2>&1 || die "The Obsidian CLI is required to publish safely to Symposium." 1
-
-json_escape() {
-  awk -v final_lf="\${1:-0}" 'BEGIN { ORS=""; printf "\\"" }
-    {
-      if (NR > 1) printf "\\\\n"
-      gsub(/\\\\/, "\\\\\\\\")
-      gsub(/\\"/, "\\\\\\"")
-      gsub(/\\t/, "\\\\t")
-      gsub(/\\r/, "\\\\r")
-      printf "%s", $0
-    }
-    END {
-      if (final_lf) printf "\\\\n"
-      printf "\\""
-    }'
-}
-
-source_is_unpublished() {
-  PROPERTIES=$(obsidian vault="$VAULT" properties path="$SOURCE_PATH" format=json 2>&1)
-  PROPERTIES_B64=$(printf '%s' "$PROPERTIES" | base64 | tr -d '\\r\\n')
-  STATE=$(obsidian vault="$VAULT" eval code="(()=>{try{const input=new TextDecoder().decode(Uint8Array.from(atob('$PROPERTIES_B64'),c=>c.charCodeAt(0)));const properties=JSON.parse(input);if(!properties||Array.isArray(properties)||typeof properties!==\\"object\\")return \\"INVALID\\";return Object.prototype.hasOwnProperty.call(properties,\\"symposium\\")?\\"OCCUPIED\\":\\"CLEAR\\"}catch{return \\"INVALID\\"}})()" 2>/dev/null)
-  STATE=\${STATE#"=> "}
-  [ "$STATE" = "CLEAR" ]
-}
-
-invalid_receipt() {
-  die "Symposium may have published the page but returned an invalid receipt. Do not retry: $OUT" 1
-}
-
-source_is_unpublished || die "The source note's Symposium identity changed. Do not publish it again." 1
-FINAL_LF=0
-if [ -s "$FILE" ] && [ "$(tail -c 1 "$FILE" | wc -l | tr -d '[:space:]')" = "1" ]; then
-  FINAL_LF=1
-fi
-RESP=$({
-  printf '{"title":'
-  printf '%s' "$TITLE" | json_escape 0
-  printf ',"html":'
-  json_escape "$FINAL_LF" < "$FILE"
-  printf '}'
-} | curl -sS -w '\\n%{http_code}' \\
-  -X POST "$ENDPOINT" \\
-  -H "Authorization: Bearer $KEY" \\
-  -H 'Content-Type: application/json; charset=utf-8' \\
-  --data-binary @-)
-[ $? -eq 0 ] || die "Symposium may have published the page without returning a receipt. Do not retry." 1
-CODE=$(printf '%s' "$RESP" | tail -n1)
-OUT=$(printf '%s' "$RESP" | sed '$d')
-case "$CODE" in
-  201)
-    RECEIPT_B64=$(printf '%s' "$OUT" | base64 | tr -d '\\r\\n')
-    CANONICAL=$(obsidian vault="$VAULT" eval code="(()=>{try{const input=new TextDecoder().decode(Uint8Array.from(atob('$RECEIPT_B64'),c=>c.charCodeAt(0)));const receipt=JSON.parse(input);const url=new URL(receipt.url);if(!receipt||Array.isArray(receipt)||typeof receipt!==\\"object\\"||!/^[0123456789abcdefghjkmnpqrstvwxyz]{16}$/.test(receipt.docId)||url.protocol!==\\"https:\\"||!url.hostname||!Number.isSafeInteger(receipt.version)||receipt.version<1)return \\"INVALID\\";return \\"VALID \\"+JSON.stringify({docId:receipt.docId,url:receipt.url,version:receipt.version})}catch{return \\"INVALID\\"}})()" 2>/dev/null)
-    CANONICAL=\${CANONICAL#"=> "}
-    case "$CANONICAL" in "VALID "*) CANONICAL=\${CANONICAL#"VALID "} ;; *) invalid_receipt ;; esac
-    printf '%s\\n' "$CANONICAL"
-    ;;
-  401|403) die "Symposium rejected the Copilot Plus license: $OUT" 1 ;;
-  2*) die "Symposium returned an unexpected success response (HTTP $CODE): $OUT. Do not retry." 1 ;;
-  *) die "Symposium publish failed (HTTP $CODE): $OUT" 1 ;;
-esac
-`,
-    },
-    {
-      path: "publish-symposium.cmd",
-      content: cmdLauncher("publish-symposium.ps1"),
-    },
-    {
-      path: "publish-symposium.ps1",
-      content: `# Publishes prepared HTML to Symposium. Windows PowerShell 5.1 only.
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-$OutputEncoding = [System.Text.Encoding]::UTF8
-
-function Die($message, $code = 2) {
-  [Console]::Error.WriteLine([string]$message)
-  exit $code
-}
-
-if ($args.Count -ne 5) { Die "Usage: publish-symposium.ps1 <vault> <vault-source-path> <source-note.md> <title> <prepared.html>" 1 }
-$VAULT = $args[0]
-$SOURCE_PATH = $args[1]
-$SOURCE = $args[2]
-$TITLE = $args[3]
-$FILE = $args[4]
-$KEY = [Environment]::GetEnvironmentVariable('${PLUS_ENV.licenseKey}')
-$ENDPOINT = '${SYMPOSIUM_API_ORIGIN}/api/v1/docs'
-if (-not $KEY) { Die "Copilot Plus is not active, so Symposium publishing is unavailable." 1 }
-if (-not (Test-Path -LiteralPath $SOURCE -PathType Leaf)) { Die "Could not read source note: $SOURCE" 1 }
-if ([System.IO.Path]::GetExtension($SOURCE) -ine '.md') { Die "The Symposium source must be a Markdown note." 1 }
-if (-not (Test-Path -LiteralPath $FILE -PathType Leaf)) { Die "Could not read prepared HTML: $FILE" 1 }
-if (-not (Get-Command obsidian -ErrorAction SilentlyContinue)) { Die "The Obsidian CLI is required to publish safely to Symposium." 1 }
-
-try {
-  $PROPERTIES_JSON = (& obsidian "vault=$VAULT" properties "path=$SOURCE_PATH" "format=json" 2>&1 | Out-String)
-  $PROPERTIES = $PROPERTIES_JSON | ConvertFrom-Json -ErrorAction Stop
-} catch {
-  Die "Could not inspect the source note's Symposium identity." 1
-}
-if ($null -ne $PROPERTIES.PSObject.Properties['symposium']) {
-  Die "The source note's Symposium identity changed. Do not publish it again." 1
-}
-
-try {
-  $HTML = [System.IO.File]::ReadAllText($FILE, [System.Text.Encoding]::UTF8)
-  $JSON = @{ title = $TITLE; html = $HTML } | ConvertTo-Json -Compress
-  $BYTES = [System.Text.Encoding]::UTF8.GetBytes($JSON)
-  $RESP = Invoke-WebRequest -Uri $ENDPOINT -Method Post -ContentType 'application/json; charset=utf-8' \`
-    -Headers @{ Authorization = "Bearer $KEY" } -Body $BYTES -UseBasicParsing
-} catch {
-  $R = $null
-  try { $R = $_.Exception.Response } catch {}
-  if (-not $R) { Die "Symposium may have published the page without returning a receipt. Do not retry." 1 }
-  $READER = New-Object System.IO.StreamReader($R.GetResponseStream())
-  $OUT = $READER.ReadToEnd()
-  Die "Symposium publish failed (HTTP $([int]$R.StatusCode)): $OUT" 1
-}
-if ([int]$RESP.StatusCode -ne 201) {
-  Die "Symposium returned an unexpected success response (HTTP $([int]$RESP.StatusCode)): $($RESP.Content). Do not retry." 1
-}
-try {
-  $RECEIPT = $RESP.Content | ConvertFrom-Json -ErrorAction Stop
-  $DOC_ID = $RECEIPT.docId
-  $URL_TEXT = $RECEIPT.url
-  $VERSION = $RECEIPT.version
-  $URI = $null
-  $VALID_VERSION_TYPE = $VERSION -is [int] -or
-    $VERSION -is [long] -or
-    $VERSION -is [double] -or
-    $VERSION -is [decimal]
-  $VALID_URL = $URL_TEXT -is [string] -and
-    [Uri]::TryCreate($URL_TEXT, [UriKind]::Absolute, [ref]$URI) -and
-    $URI.Scheme -eq 'https'
-  if ($RECEIPT -isnot [PSCustomObject] -or
-      $DOC_ID -isnot [string] -or
-      $DOC_ID -notmatch '^[0123456789abcdefghjkmnpqrstvwxyz]{16}$' -or
-      -not $VALID_URL -or
-      -not $VALID_VERSION_TYPE) {
-    throw "invalid receipt"
-  }
-  $VERSION_NUMBER = [decimal]$VERSION
-  if ($VERSION_NUMBER -lt 1 -or
-      $VERSION_NUMBER -gt 9007199254740991 -or
-      $VERSION_NUMBER -ne [decimal]::Truncate($VERSION_NUMBER)) {
-    throw "invalid version"
-  }
-} catch {
-  Die "Symposium may have published the page but returned an invalid receipt. Do not retry: $($RESP.Content)" 1
-}
-[Console]::Out.WriteLine($RESP.Content)
-`,
-    },
-  ],
+  files: [],
 };
 
 /** All always-seeded plugin-shipped skills, in display order. */

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -520,8 +520,10 @@ question UI, ask conversationally and stop until the user answers. A previous
 request to publish is not confirmation. On No, send nothing.
 
 On Yes, read \`${PLUS_ENV.licenseKey}\` from the environment without printing
-or storing it. Recheck that the source still exists and has no \`symposium\`
-property, then use the agent's available HTTP tooling to POST exactly once to
+or storing it. Use the Obsidian CLI to verify that
+\`app.fileManager.processFrontMatter\` is available; if not, stop. Recheck that
+the source still exists and has no \`symposium\` property, then use the agent's
+available HTTP tooling to POST exactly once to
 \`${SYMPOSIUM_API_ORIGIN}/api/v1/docs\` with Bearer authorization and JSON
 \`{"title": <title>, "html": <html>}\`. Do not retry if the request may have
 reached the server. Report 401/403 as a rejected Copilot Plus license. Any other
@@ -540,12 +542,16 @@ so create or append it with normal Obsidian note tools. Use this header:
 | --- | --- | --- | --- | --- | ---: | --- |
 \`\`\`
 
-Append in that column order without rewriting old rows. If this advisory write
-fails, continue. Then set the source note's \`symposium\` text property to
-\`docId\` with the Obsidian CLI only if it is still absent. If that fails, do
-not publish again; report the URL and id so they remain recoverable. Return the
-server's \`url\` verbatim. Never put the license key in the note, HTML, ledger,
-command arguments, or chat.
+Create the note if absent; otherwise append only when it begins with that exact
+header. Escape existing backslashes, then pipes, and replace line breaks with
+spaces in every cell. Append in column order without rewriting old rows. If
+this advisory write fails, continue.
+
+Finally use one \`processFrontMatter\` callback to set the source note's
+\`symposium\` text property to \`docId\` only if it is still absent. If that
+fails, do not publish again; report the URL and id so they remain recoverable.
+Return the server's \`url\` verbatim. Never put the license key in the note,
+HTML, ledger, command arguments, or chat.
 `,
   files: [],
 };

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -490,7 +490,7 @@ const FETCH_X = relaySkill({
   scriptFile: "fetch-x.sh",
 });
 
-const SYMPOSIUM_PUBLISH_VERSION = 8;
+const SYMPOSIUM_PUBLISH_VERSION = 1;
 const SYMPOSIUM_PUBLISH: BuiltinSkill = {
   name: "copilot-publish-symposium",
   version: SYMPOSIUM_PUBLISH_VERSION,

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -490,7 +490,7 @@ const FETCH_X = relaySkill({
   scriptFile: "fetch-x.sh",
 });
 
-const SYMPOSIUM_PUBLISH_VERSION = 7;
+const SYMPOSIUM_PUBLISH_VERSION = 8;
 const SYMPOSIUM_PUBLISH: BuiltinSkill = {
   name: "copilot-publish-symposium",
   version: SYMPOSIUM_PUBLISH_VERSION,
@@ -520,14 +520,21 @@ question UI, ask conversationally and stop until the user answers. A previous
 request to publish is not confirmation. On No, send nothing.
 
 On Yes, read \`${PLUS_ENV.licenseKey}\` from the environment without printing
-or storing it. Use the Obsidian CLI to verify that
-\`app.fileManager.processFrontMatter\` is available; if not, stop. Recheck that
-the source still exists and has no \`symposium\` property, then use the agent's
-available HTTP tooling to POST exactly once to
+or storing it. If it is empty or absent, stop without making a request. Use the
+Obsidian CLI to verify that \`app.fileManager.processFrontMatter\` is available;
+if not, stop. Recheck that the source still exists and has no \`symposium\`
+property, then use the agent's available HTTP tooling to POST exactly once to
 \`${SYMPOSIUM_API_ORIGIN}/api/v1/docs\` with Bearer authorization and JSON
-\`{"title": <title>, "html": <html>}\`. Do not retry if the request may have
-reached the server. Report 401/403 as a rejected Copilot Plus license. Any other
-non-201 response is a publish failure.
+\`{"title": <title>, "html": <html>}\`. Send \`Accept: application/json\` and
+\`Content-Type: application/json\`, and set \`User-Agent\` to
+\`Copilot-Obsidian/<${PLUS_ENV.clientVersion} or unknown>\`; Python \`urllib\`'s
+default client signature is blocked by Cloudflare. Do not retry if the request
+may have reached the server.
+
+Report a rejected Copilot Plus license only when the response is JSON and
+\`error.code\` is \`unauthorized\`. A non-JSON 403, including a Cloudflare 1xxx
+error, is an edge/client rejection and says nothing about license validity. Any
+other non-201 response is a publish failure.
 
 A 201 receipt is valid only when \`docId\` is 16 lowercase Crockford characters,
 \`url\` is HTTPS, and \`version\` is a positive safe integer. Treat a malformed

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -527,17 +527,20 @@ the agent's available HTTP tooling to POST exactly once to
 reached the server. Report 401/403 as a rejected Copilot Plus license. Any other
 non-201 response is a publish failure.
 
-A 201 response must contain \`docId\`, \`url\`, and \`version\`. Before updating
-the source note, append a \`published\` row containing that receipt, the source
-path, current UTC time, and the HTML SHA-256 to
+A 201 receipt is valid only when \`docId\` is 16 lowercase Crockford characters,
+\`url\` is HTTPS, and \`version\` is a positive safe integer. Treat a malformed
+201 as ambiguous and non-retryable. Before updating the source note, append a
+\`published\` row containing that receipt, the source path, current UTC time,
+and the HTML SHA-256 to
 \`copilot/symposium/published-documents.md\`; this is an ordinary Markdown note,
 so create it with the existing ledger table header if absent and otherwise
 append without rewriting old rows. If this advisory write fails, continue.
 
-Finally set the source note's \`symposium\` property to \`docId\` through
-Obsidian. If that local write fails, do not publish again; report the URL and id
-so they remain recoverable. Return the server's \`url\` verbatim. Never put the
-license key in the note, HTML, ledger, command arguments, or chat.
+Finally use one Obsidian \`processFrontMatter\` call to set \`symposium\` to
+\`docId\` only if the property is still absent. Never overwrite a concurrent
+value. If this compare-and-set fails, do not publish again; report the URL and
+id so they remain recoverable. Return the server's \`url\` verbatim. Never put
+the license key in the note, HTML, ledger, command arguments, or chat.
 `,
   files: [],
 };

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -490,7 +490,7 @@ const FETCH_X = relaySkill({
   scriptFile: "fetch-x.sh",
 });
 
-const SYMPOSIUM_PUBLISH_VERSION = 3;
+const SYMPOSIUM_PUBLISH_VERSION = 4;
 const SYMPOSIUM_PUBLISH: BuiltinSkill = {
   name: "copilot-publish-symposium",
   version: SYMPOSIUM_PUBLISH_VERSION,
@@ -543,10 +543,11 @@ confirmation question is shown.
 
 Show the user the source note, title, and a concise preview or description of
 the finished page. Explain that anyone with the resulting link can read it.
-Ask an explicit Yes/No question through the agent's user-question UI. Do not
-invoke the wrapper unless the user answers Yes; a prior general request to
-publish is not this confirmation. If they decline, delete the temporary HTML
-and make no request.
+Ask an explicit Yes/No question through the agent's user-question UI. If that
+UI is unavailable, ask the same question conversationally, stop the turn, and
+wait for the user's next message. Do not invoke the wrapper unless the user
+answers Yes to this confirmation; a prior general request to publish is not
+enough. If they decline, delete the temporary HTML and make no request.
 
 ## 4. Publish once
 
@@ -566,9 +567,10 @@ On Windows, call the \`.cmd\` wrapper from PowerShell:
 & "/absolute/path/to/this/skill/directory/publish-symposium.cmd" "C:\\absolute\\path\\to\\source.md" "Page title" "C:\\absolute\\path\\to\\prepared.html"
 \`\`\`
 
-The wrapper prints the publish receipt as JSON. Validate that it contains a
-16-character lowercase \`docId\` and an HTTPS \`url\`. Never retry a publish
-after an uncertain response; it may already have created a public page.
+Immediately before POST, the wrapper verifies that the source note still has
+no \`symposium\` property. It prints a canonical, validated publish receipt as
+JSON. Never retry after an uncertain response; it may already have created a
+public page.
 
 ## 5. Record the receipt
 
@@ -592,15 +594,17 @@ the license key in the ledger.
 
 ## 6. Save the identity
 
-Only after attempting the ledger write, set the source note's \`symposium\`
-text property to the returned \`docId\`, preserving all other frontmatter.
-Prefer the Obsidian CLI:
+Only after attempting the ledger write, read the source note's \`symposium\`
+property again. Set it to the returned \`docId\` only if it is still absent,
+preserving all other frontmatter. Prefer the Obsidian CLI:
 
 \`\`\`bash
 obsidian vault="<vault>" property:set path="<vault-relative-source.md>" name=symposium value="<docId>" type=text
 \`\`\`
 
-If saving the property fails, do not publish again. Report the returned URL and
+If the property now has any value, leave it unchanged and report the concurrent
+change together with the new URL and document id from the ledger. If reading or
+saving the property fails, do not publish again. Report the returned URL and
 document id so the page remains recoverable. Otherwise return the server's
 \`url\` verbatim. Always delete the temporary HTML file. Never print or write
 the license key into the note, HTML, command arguments, or chat.
@@ -639,6 +643,25 @@ json_escape() {
     END { printf "\\"" }'
 }
 
+source_is_unpublished() {
+  awk '
+    NR == 1 {
+      sub(/^\\357\\273\\277/, "")
+      if ($0 != "---") exit 0
+      in_yaml = 1
+      next
+    }
+    in_yaml && $0 ~ /^(---|\\.\\.\\.)[[:space:]]*$/ { exit found ? 1 : 0 }
+    in_yaml && $0 ~ /^[[:space:]]*symposium[[:space:]]*:/ { found = 1 }
+    END { if (found) exit 1 }
+  ' "$SOURCE"
+}
+
+invalid_receipt() {
+  die "Symposium may have published the page but returned an invalid receipt. Do not retry: $OUT" 1
+}
+
+source_is_unpublished || die "The source note's Symposium identity changed. Do not publish it again." 1
 RESP=$({
   printf '{"title":'
   printf '%s' "$TITLE" | json_escape
@@ -654,7 +677,23 @@ RESP=$({
 CODE=$(printf '%s' "$RESP" | tail -n1)
 OUT=$(printf '%s' "$RESP" | sed '$d')
 case "$CODE" in
-  201) printf '%s\\n' "$OUT" ;;
+  201)
+    COMPACT=$(printf '%s' "$OUT" | tr -d '[:space:]')
+    case "$COMPACT" in \\{*\\}) ;; *) invalid_receipt ;; esac
+    DOC_ID=$(printf '%s' "$COMPACT" | sed -n 's/.*"docId":"\\([^"]*\\)".*/\\1/p')
+    [ "\${#DOC_ID}" -eq 16 ] || invalid_receipt
+    case "$DOC_ID" in *[!0123456789abcdefghjkmnpqrstvwxyz]*) invalid_receipt ;; esac
+    URL=$(printf '%s' "$COMPACT" | sed -n 's/.*"url":"\\([^"]*\\)".*/\\1/p')
+    case "$URL" in https://?*) ;; *) invalid_receipt ;; esac
+    VERSION=$(printf '%s' "$COMPACT" | sed -n 's/.*"version":\\([0-9][0-9]*\\)[,}].*/\\1/p')
+    case "$VERSION" in ""|0|0*) invalid_receipt ;; esac
+    awk -v value="$VERSION" 'BEGIN {
+      max = "9007199254740991"
+      if (length(value) < length(max)) exit 0
+      if (length(value) > length(max) || ("x" value) > ("x" max)) exit 1
+    }' || invalid_receipt
+    printf '%s\\n' "$OUT"
+    ;;
   401|403) die "Symposium rejected the Copilot Plus license: $OUT" 1 ;;
   2*) die "Symposium returned an unexpected success response (HTTP $CODE): $OUT. Do not retry." 1 ;;
   *) die "Symposium publish failed (HTTP $CODE): $OUT" 1 ;;
@@ -689,6 +728,16 @@ if ([System.IO.Path]::GetExtension($SOURCE) -ine '.md') { Die "The Symposium sou
 if (-not (Test-Path -LiteralPath $FILE -PathType Leaf)) { Die "Could not read prepared HTML: $FILE" 1 }
 
 try {
+  $SOURCE_TEXT = [System.IO.File]::ReadAllText($SOURCE, [System.Text.Encoding]::UTF8)
+} catch {
+  Die "Could not read source note: $SOURCE" 1
+}
+$FRONTMATTER = [regex]::Match($SOURCE_TEXT.TrimStart([char]0xFEFF), '(?s)\\A---\\r?\\n(.*?)\\r?\\n(?:---|\\.\\.\\.)\\s*(?:\\r?\\n|$)')
+if ($FRONTMATTER.Success -and $FRONTMATTER.Groups[1].Value -match '(?m)^\\s*symposium\\s*:') {
+  Die "The source note's Symposium identity changed. Do not publish it again." 1
+}
+
+try {
   $HTML = [System.IO.File]::ReadAllText($FILE, [System.Text.Encoding]::UTF8)
   $JSON = @{ title = $TITLE; html = $HTML } | ConvertTo-Json -Compress
   $BYTES = [System.Text.Encoding]::UTF8.GetBytes($JSON)
@@ -704,6 +753,31 @@ try {
 }
 if ([int]$RESP.StatusCode -ne 201) {
   Die "Symposium returned an unexpected success response (HTTP $([int]$RESP.StatusCode)): $($RESP.Content). Do not retry." 1
+}
+try {
+  $RECEIPT = $RESP.Content | ConvertFrom-Json -ErrorAction Stop
+  $DOC_ID = $RECEIPT.docId
+  $URL_TEXT = $RECEIPT.url
+  $VERSION = $RECEIPT.version
+  $URI = $null
+  $VALID_URL = $URL_TEXT -is [string] -and
+    [Uri]::TryCreate($URL_TEXT, [UriKind]::Absolute, [ref]$URI) -and
+    $URI.Scheme -eq 'https'
+  if ($RECEIPT -isnot [PSCustomObject] -or
+      $DOC_ID -isnot [string] -or
+      $DOC_ID -notmatch '^[0123456789abcdefghjkmnpqrstvwxyz]{16}$' -or
+      -not $VALID_URL -or
+      $VERSION -is [string]) {
+    throw "invalid receipt"
+  }
+  $VERSION_NUMBER = [decimal]$VERSION
+  if ($VERSION_NUMBER -lt 1 -or
+      $VERSION_NUMBER -gt 9007199254740991 -or
+      $VERSION_NUMBER -ne [decimal]::Truncate($VERSION_NUMBER)) {
+    throw "invalid version"
+  }
+} catch {
+  Die "Symposium may have published the page but returned an invalid receipt. Do not retry: $($RESP.Content)" 1
 }
 [Console]::Out.WriteLine($RESP.Content)
 `,

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -1,6 +1,7 @@
 import type { BackendId } from "@/agentMode/session/types";
 import {
   SYMPOSIUM_API_ORIGIN,
+  SYMPOSIUM_MAX_HTML_BYTES,
   SYMPOSIUM_TOKEN_ENV,
   SYMPOSIUM_WORKSPACE_ROOT_ENV,
 } from "@/symposium/constants";
@@ -515,7 +516,8 @@ property is present, stop: this skill performs initial publishing only.
 Convert the note into a complete, self-contained, passive HTML document. Render
 source-specific content such as Mermaid and Obsidian Bases into static HTML or
 SVG, embed images, and include no scripts, frames, forms, handlers, or external
-assets.
+assets. If its UTF-8 encoding exceeds \`${SYMPOSIUM_MAX_HTML_BYTES}\` bytes (10 MiB),
+stop without asking for confirmation or sending a request.
 
 Show the source note, title, and a concise preview. Explain that the resulting
 link is public and ask an explicit Yes/No confirmation. If the agent has no

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -1,5 +1,9 @@
 import type { BackendId } from "@/agentMode/session/types";
-import { SYMPOSIUM_API_ORIGIN, SYMPOSIUM_TOKEN_ENV } from "@/symposium/constants";
+import {
+  SYMPOSIUM_API_ORIGIN,
+  SYMPOSIUM_TOKEN_ENV,
+  SYMPOSIUM_WORKSPACE_ROOT_ENV,
+} from "@/symposium/constants";
 import { OBSIDIAN_SKILLS } from "./obsidianSkills";
 
 /**
@@ -538,7 +542,9 @@ A 201 receipt is valid only when \`docId\` is 16 lowercase Crockford characters,
 Treat a malformed 201 as ambiguous and non-retryable. Before updating the source
 note, append a \`published\` row containing that receipt, the source path, current
 UTC time, and the HTML SHA-256 to \`.symposium/publish-history.md\` under the
-workspace root (the vault root when running in Obsidian). Use direct filesystem
+publishing root. Use \`${SYMPOSIUM_WORKSPACE_ROOT_ENV}\` when it is nonempty;
+otherwise use the current workspace root. Do not substitute a project-scoped
+session's working directory for a host-provided root. Use direct filesystem
 operations because hidden directories are not ordinary indexed notes. Create
 the directory and file when absent. Use this header:
 

--- a/src/symposium/SymposiumClient.test.ts
+++ b/src/symposium/SymposiumClient.test.ts
@@ -139,6 +139,10 @@ describe("SymposiumClient", () => {
       it.each([
         ["invalid doc id", { docId: "UPPERCASE", url: "https://symposium.site/d/x", version: 1 }],
         ["non-HTTPS URL", { docId: DOC_ID, url: "http://symposium.site/d/x", version: 1 }],
+        [
+          "mismatched document URL",
+          { docId: DOC_ID, url: "https://symposium.site/d/0123456789abcdef", version: 1 },
+        ],
         ["non-integer version", { docId: DOC_ID, url: "https://symposium.site/d/x", version: 1.5 }],
       ])("treats a successful POST with %s as ambiguous", async (_case, receipt) => {
         mockedRequestUrl.mockResolvedValue(response(201, receipt));

--- a/src/symposium/SymposiumClient.ts
+++ b/src/symposium/SymposiumClient.ts
@@ -161,6 +161,7 @@ function parseReceipt(response: RequestUrlResponse, expectedDocId?: string): Sym
     (expectedDocId !== undefined && docId !== expectedDocId) ||
     typeof url !== "string" ||
     !isHttpsUrl(url) ||
+    new URL(url).pathname.replace(/\/$/, "") !== `/d/${docId}` ||
     typeof version !== "number" ||
     !Number.isSafeInteger(version) ||
     version < 1

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -173,7 +173,7 @@ describe("SymposiumPublisher", () => {
           kind: "failure",
           action: "publish",
           message:
-            "This note already uses the symposium property for an unrecognized value. Recover its public link from copilot/symposium/published-documents.md, then repair or remove the property before publishing.",
+            "This note already uses the symposium property for an unrecognized value. Recover its public link from .symposium/publish-history.md, then repair or remove the property before publishing.",
           accessNotice: false,
           retryable: false,
         });

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -217,16 +217,13 @@ describe("SymposiumPublisher", () => {
           receipt: { ...RECEIPT, version: 2 },
         });
         expect(harness.client.update).toHaveBeenCalledWith(DOC_ID, DOCUMENT, "decrypted-license");
-        const ledgerEntry = harness.recordLedger.mock.calls[0][0];
-        expect(ledgerEntry).toMatchObject({
-          docId: DOC_ID,
-          status: "published",
-          notePath: "Notes/Architecture.md",
-          url: RECEIPT.url,
-          version: 2,
-          contentHash: sha256(DOCUMENT.html),
-        });
-        expect(ledgerEntry.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(harness.recordLedger).toHaveBeenCalledWith(
+          expect.objectContaining({
+            docId: DOC_ID,
+            status: "published",
+            version: 2,
+          })
+        );
         expect(harness.client.publish).not.toHaveBeenCalled();
         expect(harness.processFrontMatter).not.toHaveBeenCalled();
       });

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -12,6 +12,8 @@ import type { App, TFile } from "obsidian";
 
 const DOC_ID = "9f2k4mvq7t0xbz3n";
 const NEW_DOC_ID = "0123456789abcdef";
+const DOC_URL = `https://symposium.md/d/${DOC_ID}?server=exact`;
+const NEW_DOC_URL = `https://symposium.md/d/${NEW_DOC_ID}?server=exact`;
 const DOCUMENT: SymposiumDocument = {
   title: "Architecture",
   html: "<!doctype html><html><body>Review</body></html>",
@@ -19,7 +21,7 @@ const DOCUMENT: SymposiumDocument = {
 };
 const RECEIPT: SymposiumReceipt = {
   docId: DOC_ID,
-  url: `https://symposium.md/d/${DOC_ID}?server=exact`,
+  url: DOC_URL,
   version: 1,
 };
 
@@ -145,7 +147,7 @@ describe("SymposiumPublisher", () => {
         expect(harness.recordLedger.mock.invocationCallOrder[0]).toBeLessThan(
           harness.processFrontMatter.mock.invocationCallOrder[0]
         );
-        expect(harness.frontmatter.symposium).toBe(DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(DOC_URL);
       });
 
       it("keeps a successful publish usable when the advisory ledger cannot be written", async () => {
@@ -156,7 +158,7 @@ describe("SymposiumPublisher", () => {
 
         expect(result).toEqual({ kind: "success", action: "publish", receipt: RECEIPT });
         expect(harness.recordLedger).toHaveBeenCalledTimes(1);
-        expect(harness.frontmatter.symposium).toBe(DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(DOC_URL);
       });
 
       it.each([
@@ -171,7 +173,7 @@ describe("SymposiumPublisher", () => {
           kind: "failure",
           action: "publish",
           message:
-            "This note already uses the symposium property for an unrecognized value. Recover its document id from copilot/symposium/published-documents.md, then repair or remove the property before publishing.",
+            "This note already uses the symposium property for an unrecognized value. Recover its public link from copilot/symposium/published-documents.md, then repair or remove the property before publishing.",
           accessNotice: false,
           retryable: false,
         });
@@ -206,7 +208,7 @@ describe("SymposiumPublisher", () => {
       });
 
       it("updates the current valid id without rewriting frontmatter", async () => {
-        const harness = createHarness({ symposium: DOC_ID });
+        const harness = createHarness({ symposium: DOC_URL });
 
         const result = await openAndConfirm(harness, "update");
 
@@ -229,8 +231,8 @@ describe("SymposiumPublisher", () => {
       });
 
       it("lets copied notes intentionally update the same remote id", async () => {
-        const first = createHarness({ symposium: DOC_ID });
-        const second = createHarness({ symposium: DOC_ID });
+        const first = createHarness({ symposium: DOC_URL });
+        const second = createHarness({ symposium: DOC_URL });
 
         await openAndConfirm(first, "update");
         await openAndConfirm(second, "update");
@@ -241,9 +243,9 @@ describe("SymposiumPublisher", () => {
 
       it("reports partial success without replacing a newer identity after update completes", async () => {
         const receipt = { ...RECEIPT, version: 2 };
-        const harness = createHarness({ symposium: DOC_ID });
+        const harness = createHarness({ symposium: DOC_URL });
         harness.client.update.mockImplementation(async () => {
-          harness.frontmatter.symposium = NEW_DOC_ID;
+          harness.frontmatter.symposium = NEW_DOC_URL;
           return receipt;
         });
 
@@ -256,7 +258,7 @@ describe("SymposiumPublisher", () => {
             "The original page was updated, but this note’s Symposium identity changed or could not be verified. Its current identity was left unchanged.",
           receipt,
         });
-        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_URL);
         expect(harness.processFrontMatter).not.toHaveBeenCalled();
 
         await harness.publisher.open(harness.file);
@@ -268,7 +270,7 @@ describe("SymposiumPublisher", () => {
 
       it("reports partial success when the identity cannot be read after update completes", async () => {
         const receipt = { ...RECEIPT, version: 2 };
-        const harness = createHarness({ symposium: DOC_ID });
+        const harness = createHarness({ symposium: DOC_URL });
         harness.client.update.mockImplementation(async () => {
           (harness.app.vault.read as jest.Mock).mockRejectedValueOnce(
             new Error("vault unavailable")
@@ -285,7 +287,7 @@ describe("SymposiumPublisher", () => {
             "The original page was updated, but this note’s Symposium identity changed or could not be verified. Its current identity was left unchanged.",
           receipt,
         });
-        expect(harness.frontmatter.symposium).toBe(DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(DOC_URL);
         expect(harness.processFrontMatter).not.toHaveBeenCalled();
 
         await harness.publisher.open(harness.file);
@@ -294,7 +296,7 @@ describe("SymposiumPublisher", () => {
 
       it("retains an updated receipt when the note identity disappears", async () => {
         const receipt = { ...RECEIPT, version: 2 };
-        const harness = createHarness({ symposium: DOC_ID });
+        const harness = createHarness({ symposium: DOC_URL });
         harness.client.update.mockImplementation(async () => {
           delete harness.frontmatter.symposium;
           return receipt;
@@ -322,8 +324,8 @@ describe("SymposiumPublisher", () => {
       });
 
       it("falls back once from exact PUT not_found to POST and replaces the stale id", async () => {
-        const replacement = { ...RECEIPT, docId: NEW_DOC_ID, version: 1 };
-        const harness = createHarness({ symposium: DOC_ID });
+        const replacement = { ...RECEIPT, docId: NEW_DOC_ID, url: NEW_DOC_URL, version: 1 };
+        const harness = createHarness({ symposium: DOC_URL });
         harness.client.update.mockRejectedValue(
           new SymposiumClientError("Document is gone.", "not_found", 404, false)
         );
@@ -334,12 +336,12 @@ describe("SymposiumPublisher", () => {
         expect(result).toEqual({ kind: "success", action: "publish", receipt: replacement });
         expect(harness.client.update).toHaveBeenCalledTimes(1);
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
-        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_URL);
       });
 
       it("retains a fallback POST receipt when the stale identity disappears", async () => {
-        const replacement = { ...RECEIPT, docId: NEW_DOC_ID, version: 1 };
-        const harness = createHarness({ symposium: DOC_ID });
+        const replacement = { ...RECEIPT, docId: NEW_DOC_ID, url: NEW_DOC_URL, version: 1 };
+        const harness = createHarness({ symposium: DOC_URL });
         harness.client.update.mockRejectedValue(
           new SymposiumClientError("Document is gone.", "not_found", 404, false)
         );
@@ -371,9 +373,9 @@ describe("SymposiumPublisher", () => {
       });
 
       it("does not POST a fallback when the identity changes during the failed update", async () => {
-        const harness = createHarness({ symposium: DOC_ID });
+        const harness = createHarness({ symposium: DOC_URL });
         harness.client.update.mockImplementation(async () => {
-          harness.frontmatter.symposium = NEW_DOC_ID;
+          harness.frontmatter.symposium = NEW_DOC_URL;
           throw new SymposiumClientError("Document is gone.", "not_found", 404, false);
         });
 
@@ -385,11 +387,11 @@ describe("SymposiumPublisher", () => {
           retryable: false,
         });
         expect(harness.client.publish).not.toHaveBeenCalled();
-        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_URL);
       });
 
       it("does not POST after any update failure other than structured 404 not_found", async () => {
-        const harness = createHarness({ symposium: DOC_ID });
+        const harness = createHarness({ symposium: DOC_URL });
         harness.client.update.mockRejectedValue(
           new SymposiumClientError(
             "Publishing is currently limited to lifetime license holders.",
@@ -540,7 +542,7 @@ describe("SymposiumPublisher", () => {
           .retrySave!();
 
         expect(saved).toEqual({ kind: "success", action: "publish", receipt: RECEIPT });
-        expect(harness.frontmatter.symposium).toBe(DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(DOC_URL);
         expect(harness.client.publish).toHaveBeenCalledTimes(1);
 
         harness.modalOptions[1].onClosed?.();
@@ -620,7 +622,7 @@ describe("SymposiumPublisher", () => {
       it("does not publish when the identity changes while the document is rendering", async () => {
         const harness = createHarness();
         harness.buildDocument.mockImplementation(async () => {
-          harness.frontmatter.symposium = NEW_DOC_ID;
+          harness.frontmatter.symposium = NEW_DOC_URL;
           return DOCUMENT;
         });
 
@@ -632,11 +634,11 @@ describe("SymposiumPublisher", () => {
           retryable: false,
         });
         expect(harness.client.publish).not.toHaveBeenCalled();
-        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_URL);
       });
 
       it("deletes remotely before clearing identity and retries a failed local removal only", async () => {
-        const harness = createHarness({ symposium: DOC_ID, tags: ["shared"] });
+        const harness = createHarness({ symposium: DOC_URL, tags: ["shared"] });
         harness.processFrontMatter
           .mockRejectedValueOnce(new Error("vault is read-only"))
           .mockImplementationOnce(
@@ -685,9 +687,9 @@ describe("SymposiumPublisher", () => {
       });
 
       it("does not remove a newer identity after a remote deletion completes", async () => {
-        const harness = createHarness({ symposium: DOC_ID });
+        const harness = createHarness({ symposium: DOC_URL });
         harness.client.delete.mockImplementation(async () => {
-          harness.frontmatter.symposium = NEW_DOC_ID;
+          harness.frontmatter.symposium = NEW_DOC_URL;
         });
 
         const result = await openAndConfirm(harness, "delete");
@@ -696,7 +698,7 @@ describe("SymposiumPublisher", () => {
         expect(
           (result as Extract<SymposiumModalResult, { kind: "persistence" }>).retrySave
         ).toBeUndefined();
-        expect(harness.frontmatter.symposium).toBe(NEW_DOC_ID);
+        expect(harness.frontmatter.symposium).toBe(NEW_DOC_URL);
       });
 
       it("requires a decryptable configured key without locally checking a plan", async () => {

--- a/src/symposium/SymposiumPublisher.test.ts
+++ b/src/symposium/SymposiumPublisher.test.ts
@@ -5,7 +5,9 @@ import type {
 import { SymposiumClientError } from "@/symposium/SymposiumClient";
 import { SymposiumPublisher } from "@/symposium/SymposiumPublisher";
 import { SymposiumDocumentTooLargeError } from "@/symposium/symposiumDocument";
+import type { SymposiumLedgerEntry } from "@/symposium/symposiumLedger";
 import type { SymposiumDocument, SymposiumReceipt } from "@/symposium/types";
+import { sha256 } from "@/utils/hash";
 import type { App, TFile } from "obsidian";
 
 const DOC_ID = "9f2k4mvq7t0xbz3n";
@@ -37,6 +39,7 @@ interface Harness {
   openModal: jest.Mock;
   processFrontMatter: jest.Mock;
   publisher: SymposiumPublisher;
+  recordLedger: jest.Mock<Promise<void>, [SymposiumLedgerEntry]>;
 }
 
 function createHarness(frontmatter: Record<string, unknown> = {}): Harness {
@@ -70,10 +73,14 @@ function createHarness(frontmatter: Record<string, unknown> = {}): Harness {
   const modalOptions: SymposiumModalOptions[] = [];
   const openModal = jest.fn();
   const closeModal = jest.fn();
+  const recordLedger = jest
+    .fn<Promise<void>, [SymposiumLedgerEntry]>()
+    .mockResolvedValue(undefined);
   const publisher = new SymposiumPublisher(app, {
     client,
     loadLicenseKey,
     buildDocument,
+    recordLedger,
     createModal: (options) => {
       modalOptions.push(options);
       return { open: openModal, close: closeModal };
@@ -92,6 +99,7 @@ function createHarness(frontmatter: Record<string, unknown> = {}): Harness {
     openModal,
     processFrontMatter,
     publisher,
+    recordLedger,
   };
 }
 
@@ -124,6 +132,30 @@ describe("SymposiumPublisher", () => {
         expect(harness.loadLicenseKey).toHaveBeenCalledTimes(1);
         expect(harness.buildDocument).toHaveBeenCalledWith(harness.file, activeDocument);
         expect(harness.client.publish).toHaveBeenCalledWith(DOCUMENT, "decrypted-license");
+        const ledgerEntry = harness.recordLedger.mock.calls[0][0];
+        expect(ledgerEntry).toMatchObject({
+          docId: DOC_ID,
+          status: "published",
+          notePath: "Notes/Architecture.md",
+          url: RECEIPT.url,
+          version: 1,
+          contentHash: sha256(DOCUMENT.html),
+        });
+        expect(ledgerEntry.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        expect(harness.recordLedger.mock.invocationCallOrder[0]).toBeLessThan(
+          harness.processFrontMatter.mock.invocationCallOrder[0]
+        );
+        expect(harness.frontmatter.symposium).toBe(DOC_ID);
+      });
+
+      it("keeps a successful publish usable when the advisory ledger cannot be written", async () => {
+        const harness = createHarness();
+        harness.recordLedger.mockRejectedValue(new Error("vault is read-only"));
+
+        const result = await openAndConfirm(harness, "publish");
+
+        expect(result).toEqual({ kind: "success", action: "publish", receipt: RECEIPT });
+        expect(harness.recordLedger).toHaveBeenCalledTimes(1);
         expect(harness.frontmatter.symposium).toBe(DOC_ID);
       });
 
@@ -139,7 +171,7 @@ describe("SymposiumPublisher", () => {
           kind: "failure",
           action: "publish",
           message:
-            "This note already uses the symposium property for an unrecognized value. Rename or remove that property before publishing.",
+            "This note already uses the symposium property for an unrecognized value. Recover its document id from copilot/symposium/published-documents.md, then repair or remove the property before publishing.",
           accessNotice: false,
           retryable: false,
         });
@@ -185,6 +217,16 @@ describe("SymposiumPublisher", () => {
           receipt: { ...RECEIPT, version: 2 },
         });
         expect(harness.client.update).toHaveBeenCalledWith(DOC_ID, DOCUMENT, "decrypted-license");
+        const ledgerEntry = harness.recordLedger.mock.calls[0][0];
+        expect(ledgerEntry).toMatchObject({
+          docId: DOC_ID,
+          status: "published",
+          notePath: "Notes/Architecture.md",
+          url: RECEIPT.url,
+          version: 2,
+          contentHash: sha256(DOCUMENT.html),
+        });
+        expect(ledgerEntry.publishedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
         expect(harness.client.publish).not.toHaveBeenCalled();
         expect(harness.processFrontMatter).not.toHaveBeenCalled();
       });
@@ -610,6 +652,18 @@ describe("SymposiumPublisher", () => {
 
         expect(harness.client.delete).toHaveBeenCalledWith(DOC_ID, "decrypted-license");
         expect(harness.buildDocument).not.toHaveBeenCalled();
+        expect(harness.recordLedger).toHaveBeenCalledWith({
+          docId: DOC_ID,
+          status: "unpublished",
+          notePath: "Notes/Architecture.md",
+          url: null,
+          publishedAt: null,
+          version: null,
+          contentHash: null,
+        });
+        expect(harness.recordLedger.mock.invocationCallOrder[0]).toBeLessThan(
+          harness.processFrontMatter.mock.invocationCallOrder[0]
+        );
         expect(partial).toMatchObject({ kind: "persistence", action: "delete" });
 
         harness.modalOptions[0].onClosed?.();

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -6,6 +6,7 @@ import {
   type SymposiumPersistenceResult,
 } from "@/components/modals/SymposiumModal";
 import { getDecryptedKey } from "@/encryptionService";
+import { logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
 import { SymposiumClient, SymposiumClientError } from "@/symposium/SymposiumClient";
 import {
@@ -19,7 +20,9 @@ import {
   buildSymposiumDocument,
   SymposiumDocumentTooLargeError,
 } from "@/symposium/symposiumDocument";
+import { appendSymposiumLedgerEntry, type SymposiumLedgerEntry } from "@/symposium/symposiumLedger";
 import type { SymposiumAction, SymposiumDocument, SymposiumReceipt } from "@/symposium/types";
+import { sha256 } from "@/utils/hash";
 import { App, Component, TFile } from "obsidian";
 
 interface SymposiumClientPort {
@@ -38,6 +41,7 @@ interface SymposiumPublisherDependencies {
   loadLicenseKey?: () => Promise<string>;
   buildDocument?: (file: TFile, ownerDocument: Document) => Promise<SymposiumDocument>;
   createModal?: (options: SymposiumModalOptions) => SymposiumModalPort;
+  recordLedger?: (entry: SymposiumLedgerEntry) => Promise<void>;
 }
 
 const MISSING_LICENSE_MESSAGE =
@@ -129,6 +133,7 @@ export class SymposiumPublisher {
     ownerDocument: Document
   ) => Promise<SymposiumDocument>;
   private readonly createModal: (options: SymposiumModalOptions) => SymposiumModalPort;
+  private readonly recordLedger: (entry: SymposiumLedgerEntry) => Promise<void>;
   private readonly inFlightFiles = new Set<TFile>();
   private readonly blockedPublishResults = new Map<
     TFile,
@@ -148,6 +153,8 @@ export class SymposiumPublisher {
       ((file, ownerDocument) => buildDocumentWithComponent(this.app, file, ownerDocument));
     this.createModal =
       dependencies.createModal ?? ((options) => new SymposiumModal(this.app, options));
+    this.recordLedger =
+      dependencies.recordLedger ?? ((entry) => appendSymposiumLedgerEntry(this.app.vault, entry));
   }
 
   /**
@@ -272,6 +279,15 @@ export class SymposiumPublisher {
             return identityChangedFailure(action);
           }
           await this.client.delete(docId!, licenseKey);
+          await this.recordLedgerSafely({
+            docId: docId!,
+            status: "unpublished",
+            notePath: file.path,
+            url: null,
+            publishedAt: null,
+            version: null,
+            contentHash: null,
+          });
           return await this.removeLocalIdentity(file, docId!);
         }
 
@@ -281,11 +297,13 @@ export class SymposiumPublisher {
         }
         if (action === "publish") {
           const receipt = await this.client.publish(document, licenseKey);
+          await this.recordPublishedReceipt(file, document, receipt);
           return await this.savePublishedIdentity(file, receipt, null);
         }
 
         try {
           const receipt = await this.client.update(docId!, document, licenseKey);
+          await this.recordPublishedReceipt(file, document, receipt);
           let currentDocId: string | null | undefined;
           try {
             currentDocId = await getSymposiumDocId(this.app, file);
@@ -320,6 +338,7 @@ export class SymposiumPublisher {
           return identityChangedFailure(action);
         }
         const receipt = await this.client.publish(document, licenseKey);
+        await this.recordPublishedReceipt(file, document, receipt);
         return await this.savePublishedIdentity(file, receipt, docId);
       } catch (error) {
         const failure = operationFailure(action, error);
@@ -329,6 +348,30 @@ export class SymposiumPublisher {
         return failure;
       }
     });
+  }
+
+  private async recordPublishedReceipt(
+    file: TFile,
+    document: SymposiumDocument,
+    receipt: SymposiumReceipt
+  ): Promise<void> {
+    await this.recordLedgerSafely({
+      docId: receipt.docId,
+      status: "published",
+      notePath: file.path,
+      url: receipt.url,
+      publishedAt: new Date().toISOString(),
+      version: receipt.version,
+      contentHash: sha256(document.html),
+    });
+  }
+
+  private async recordLedgerSafely(entry: SymposiumLedgerEntry): Promise<void> {
+    try {
+      await this.recordLedger(entry);
+    } catch (error) {
+      logWarn("Could not append a Symposium receipt to the recoverable ledger.", error);
+    }
   }
 
   private async savePublishedIdentity(

--- a/src/symposium/SymposiumPublisher.ts
+++ b/src/symposium/SymposiumPublisher.ts
@@ -13,7 +13,7 @@ import {
   SymposiumFrontmatterParseError,
   getSymposiumDocId,
   removeSymposiumDocId,
-  saveSymposiumDocId,
+  saveSymposiumLink,
   SymposiumPropertyConflictError,
 } from "@/symposium/symposiumFrontmatter";
 import {
@@ -267,7 +267,7 @@ export class SymposiumPublisher {
         return {
           kind: "failure",
           action,
-          message: "This note no longer has a valid Symposium document id.",
+          message: "This note no longer has a valid Symposium link.",
           accessNotice: false,
           retryable: false,
         };
@@ -380,7 +380,7 @@ export class SymposiumPublisher {
     expectedDocId: string | null
   ): Promise<SymposiumModalResult> {
     try {
-      const saved = await saveSymposiumDocId(this.app, file, receipt.docId, expectedDocId);
+      const saved = await saveSymposiumLink(this.app, file, receipt, expectedDocId);
       if (!saved) {
         const result: SymposiumPersistenceResult = {
           kind: "persistence",
@@ -418,7 +418,7 @@ export class SymposiumPublisher {
       kind: "persistence",
       action: "publish",
       message:
-        "The page is already public. Retry saving its document id to this note; this will not publish again.",
+        "The page is already public. Retry saving its link to this note; this will not publish again.",
       receipt,
       retrySave: () =>
         this.withFileLock(file, "publish", async () =>
@@ -456,7 +456,7 @@ export class SymposiumPublisher {
       kind: "persistence",
       action: "delete",
       message:
-        "The public page is already deleted. Retry removing its document id from this note; this will not contact Symposium again.",
+        "The public page is already deleted. Retry removing its link from this note; this will not contact Symposium again.",
       retrySave: () =>
         this.withFileLock(file, "delete", async () =>
           this.removeLocalIdentity(file, expectedDocId)

--- a/src/symposium/constants.ts
+++ b/src/symposium/constants.ts
@@ -1,4 +1,5 @@
 export const SYMPOSIUM_API_ORIGIN = "https://api.symposium.md";
 export const SYMPOSIUM_TOKEN_ENV = "SYMPOSIUM_TOKEN";
+export const SYMPOSIUM_WORKSPACE_ROOT_ENV = "SYMPOSIUM_WORKSPACE_ROOT";
 export const SYMPOSIUM_DOC_ID_PATTERN = /^[0123456789abcdefghjkmnpqrstvwxyz]{16}$/;
 export const SYMPOSIUM_MAX_HTML_BYTES = 10 * 1024 * 1024;

--- a/src/symposium/constants.ts
+++ b/src/symposium/constants.ts
@@ -1,3 +1,4 @@
 export const SYMPOSIUM_API_ORIGIN = "https://api.symposium.md";
+export const SYMPOSIUM_TOKEN_ENV = "SYMPOSIUM_TOKEN";
 export const SYMPOSIUM_DOC_ID_PATTERN = /^[0123456789abcdefghjkmnpqrstvwxyz]{16}$/;
 export const SYMPOSIUM_MAX_HTML_BYTES = 10 * 1024 * 1024;

--- a/src/symposium/symposiumFrontmatter.test.ts
+++ b/src/symposium/symposiumFrontmatter.test.ts
@@ -2,13 +2,17 @@ import {
   getSymposiumDocId,
   parseSymposiumDocId,
   removeSymposiumDocId,
-  saveSymposiumDocId,
+  saveSymposiumLink,
   SymposiumFrontmatterParseError,
   SymposiumPropertyConflictError,
 } from "@/symposium/symposiumFrontmatter";
 import type { App, TFile } from "obsidian";
 
 const DOC_ID = "9f2k4mvq7t0xbz3n";
+const DOC_URL = `https://symposium.site/d/${DOC_ID}`;
+const OTHER_DOC_ID = "0123456789abcdef";
+const OTHER_DOC_URL = `https://symposium.site/d/${OTHER_DOC_ID}`;
+const RECEIPT = { docId: DOC_ID, url: DOC_URL, version: 1 };
 
 interface TestApp {
   app: App;
@@ -64,18 +68,20 @@ describe("symposiumFrontmatter", () => {
   });
 
   describe("parseSymposiumDocId()", () => {
-    it("accepts only lowercase 16-character Symposium ids", () => {
-      expect(parseSymposiumDocId(DOC_ID)).toBe(DOC_ID);
-      expect(parseSymposiumDocId("9F2K4MVQ7T0XBZ3N")).toBeNull();
-      expect(parseSymposiumDocId("too-short")).toBeNull();
+    it("extracts lowercase 16-character ids only from HTTPS document links", () => {
+      expect(parseSymposiumDocId(`${DOC_URL}?source=note`)).toBe(DOC_ID);
+      expect(parseSymposiumDocId(DOC_ID)).toBeNull();
+      expect(parseSymposiumDocId(`http://symposium.site/d/${DOC_ID}`)).toBeNull();
+      expect(parseSymposiumDocId("https://symposium.site/d/UPPERCASE1234567")).toBeNull();
+      expect(parseSymposiumDocId("https://symposium.site/about")).toBeNull();
       expect(parseSymposiumDocId(42)).toBeNull();
       expect(parseSymposiumDocId(null)).toBeNull();
     });
   });
 
   describe("getSymposiumDocId()", () => {
-    it("reads a valid id and treats missing frontmatter as unpublished", async () => {
-      const valid = createApp({ symposium: DOC_ID });
+    it("reads an id from a valid link and treats missing frontmatter as unpublished", async () => {
+      const valid = createApp({ symposium: DOC_URL });
       await expect(getSymposiumDocId(valid.app, file)).resolves.toBe(DOC_ID);
 
       const missing = createApp();
@@ -102,7 +108,7 @@ describe("symposiumFrontmatter", () => {
       );
     });
 
-    it("rejects an occupied property whose value is not a valid document id", async () => {
+    it("rejects an occupied property whose value is not a valid document link", async () => {
       const malformed = createApp({ symposium: { docId: DOC_ID } });
 
       await expect(getSymposiumDocId(malformed.app, file)).rejects.toBeInstanceOf(
@@ -111,41 +117,40 @@ describe("symposiumFrontmatter", () => {
     });
   });
 
-  describe("saveSymposiumDocId()", () => {
-    it("writes or replaces the property through processFrontMatter", async () => {
+  describe("saveSymposiumLink()", () => {
+    it("writes or replaces the property with the public link through processFrontMatter", async () => {
       const { app, frontmatter, processFrontMatter } = createApp({
-        symposium: "0123456789abcdef",
+        symposium: OTHER_DOC_URL,
         tags: ["public"],
       });
 
-      await expect(saveSymposiumDocId(app, file, DOC_ID, "0123456789abcdef")).resolves.toBe(true);
+      await expect(saveSymposiumLink(app, file, RECEIPT, OTHER_DOC_ID)).resolves.toBe(true);
 
       expect(processFrontMatter).toHaveBeenCalledWith(file, expect.any(Function));
-      expect(frontmatter).toEqual({ symposium: DOC_ID, tags: ["public"] });
+      expect(frontmatter).toEqual({ symposium: DOC_URL, tags: ["public"] });
     });
 
-    it("rejects an invalid id before changing the note", async () => {
+    it("rejects a receipt whose link does not contain its id before changing the note", async () => {
       const { app, processFrontMatter } = createApp();
 
-      await expect(saveSymposiumDocId(app, file, "INVALID", null)).rejects.toThrow(
-        "Cannot save an invalid Symposium document id."
-      );
+      await expect(
+        saveSymposiumLink(app, file, { ...RECEIPT, url: OTHER_DOC_URL }, null)
+      ).rejects.toThrow("Cannot save an invalid Symposium document link.");
       expect(processFrontMatter).not.toHaveBeenCalled();
     });
 
     it("does not overwrite an identity that changed after the remote action began", async () => {
-      const newerDocId = "0123456789abcdef";
-      const { app, frontmatter } = createApp({ symposium: newerDocId });
+      const { app, frontmatter } = createApp({ symposium: OTHER_DOC_URL });
 
-      await expect(saveSymposiumDocId(app, file, DOC_ID, null)).resolves.toBe(false);
-      expect(frontmatter.symposium).toBe(newerDocId);
+      await expect(saveSymposiumLink(app, file, RECEIPT, null)).resolves.toBe(false);
+      expect(frontmatter.symposium).toBe(OTHER_DOC_URL);
     });
 
     it("does not overwrite an occupied property with an unrecognized value", async () => {
       const existingValue = { url: "https://example.com/symposium" };
       const { app, frontmatter } = createApp({ symposium: existingValue });
 
-      await expect(saveSymposiumDocId(app, file, DOC_ID, null)).resolves.toBe(false);
+      await expect(saveSymposiumLink(app, file, RECEIPT, null)).resolves.toBe(false);
       expect(frontmatter.symposium).toBe(existingValue);
     });
 
@@ -155,7 +160,7 @@ describe("symposiumFrontmatter", () => {
       );
       const app = { fileManager: { processFrontMatter } } as unknown as App;
 
-      await expect(saveSymposiumDocId(app, file, DOC_ID, null)).rejects.toBeInstanceOf(
+      await expect(saveSymposiumLink(app, file, RECEIPT, null)).rejects.toBeInstanceOf(
         SymposiumFrontmatterParseError
       );
     });
@@ -164,7 +169,7 @@ describe("symposiumFrontmatter", () => {
   describe("removeSymposiumDocId()", () => {
     it("deletes only the Symposium property through processFrontMatter", async () => {
       const { app, frontmatter, processFrontMatter } = createApp({
-        symposium: DOC_ID,
+        symposium: DOC_URL,
         tags: ["public"],
       });
 
@@ -175,11 +180,10 @@ describe("symposiumFrontmatter", () => {
     });
 
     it("does not remove an identity that changed after the remote deletion began", async () => {
-      const newerDocId = "0123456789abcdef";
-      const { app, frontmatter } = createApp({ symposium: newerDocId });
+      const { app, frontmatter } = createApp({ symposium: OTHER_DOC_URL });
 
       await expect(removeSymposiumDocId(app, file, DOC_ID)).resolves.toBe(false);
-      expect(frontmatter.symposium).toBe(newerDocId);
+      expect(frontmatter.symposium).toBe(OTHER_DOC_URL);
     });
 
     it("rejects a non-mapping root supplied by the atomic callback", async () => {

--- a/src/symposium/symposiumFrontmatter.ts
+++ b/src/symposium/symposiumFrontmatter.ts
@@ -9,7 +9,7 @@ const SYMPOSIUM_PROPERTY = "symposium";
 export class SymposiumPropertyConflictError extends Error {
   constructor() {
     super(
-      "This note already uses the symposium property for an unrecognized value. Rename or remove that property before publishing."
+      "This note already uses the symposium property for an unrecognized value. Recover its document id from copilot/symposium/published-documents.md, then repair or remove the property before publishing."
     );
     this.name = "SymposiumPropertyConflictError";
     Object.setPrototypeOf(this, SymposiumPropertyConflictError.prototype);

--- a/src/symposium/symposiumFrontmatter.ts
+++ b/src/symposium/symposiumFrontmatter.ts
@@ -1,4 +1,5 @@
 import { SYMPOSIUM_DOC_ID_PATTERN } from "@/symposium/constants";
+import type { SymposiumReceipt } from "@/symposium/types";
 import { App, parseYaml, TFile } from "obsidian";
 
 const SYMPOSIUM_PROPERTY = "symposium";
@@ -9,7 +10,7 @@ const SYMPOSIUM_PROPERTY = "symposium";
 export class SymposiumPropertyConflictError extends Error {
   constructor() {
     super(
-      "This note already uses the symposium property for an unrecognized value. Recover its document id from copilot/symposium/published-documents.md, then repair or remove the property before publishing."
+      "This note already uses the symposium property for an unrecognized value. Recover its public link from copilot/symposium/published-documents.md, then repair or remove the property before publishing."
     );
     this.name = "SymposiumPropertyConflictError";
     Object.setPrototypeOf(this, SymposiumPropertyConflictError.prototype);
@@ -30,13 +31,22 @@ export class SymposiumFrontmatterParseError extends Error {
 }
 
 /**
- * Returns a Symposium identity only when the frontmatter value matches the server's id format.
+ * Returns the document id from a valid Symposium public link.
  * Throws when the reserved property is occupied by unrelated metadata so callers cannot overwrite it.
  *
  * @param value The raw frontmatter property value.
  */
 export function parseSymposiumDocId(value: unknown): string | null {
-  return typeof value === "string" && SYMPOSIUM_DOC_ID_PATTERN.test(value) ? value : null;
+  if (typeof value !== "string") return null;
+  try {
+    const url = new URL(value);
+    const docId = url.pathname.match(/^\/d\/([^/]+)\/?$/)?.[1];
+    return url.protocol === "https:" && docId && SYMPOSIUM_DOC_ID_PATTERN.test(docId)
+      ? docId
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function isFrontmatterProperties(value: unknown): value is Record<string, unknown> {
@@ -78,21 +88,21 @@ export async function getSymposiumDocId(app: App, file: TFile): Promise<string |
 }
 
 /**
- * Saves a server-issued Symposium identity without replacing unrelated frontmatter.
+ * Saves a server-issued Symposium link without replacing unrelated frontmatter.
  *
  * @param app The Obsidian application that owns the note.
  * @param file The note whose publication identity should be saved.
- * @param docId The validated identity returned by Symposium.
+ * @param receipt The validated publication receipt returned by Symposium.
  * @param expectedDocId The identity that was current when the remote action began.
  */
-export async function saveSymposiumDocId(
+export async function saveSymposiumLink(
   app: App,
   file: TFile,
-  docId: string,
+  receipt: SymposiumReceipt,
   expectedDocId: string | null
 ): Promise<boolean> {
-  if (!SYMPOSIUM_DOC_ID_PATTERN.test(docId)) {
-    throw new Error("Cannot save an invalid Symposium document id.");
+  if (parseSymposiumDocId(receipt.url) !== receipt.docId) {
+    throw new Error("Cannot save an invalid Symposium document link.");
   }
 
   let saved = false;
@@ -104,14 +114,14 @@ export async function saveSymposiumDocId(
     if (Object.prototype.hasOwnProperty.call(frontmatter, SYMPOSIUM_PROPERTY) && !currentDocId) {
       return;
     }
-    if (currentDocId === docId) {
+    if (currentDocId === receipt.docId) {
       saved = true;
       return;
     }
     if (currentDocId !== expectedDocId) {
       return;
     }
-    frontmatter[SYMPOSIUM_PROPERTY] = docId;
+    frontmatter[SYMPOSIUM_PROPERTY] = receipt.url;
     saved = true;
   });
   return saved;

--- a/src/symposium/symposiumFrontmatter.ts
+++ b/src/symposium/symposiumFrontmatter.ts
@@ -10,7 +10,7 @@ const SYMPOSIUM_PROPERTY = "symposium";
 export class SymposiumPropertyConflictError extends Error {
   constructor() {
     super(
-      "This note already uses the symposium property for an unrecognized value. Recover its public link from copilot/symposium/published-documents.md, then repair or remove the property before publishing."
+      "This note already uses the symposium property for an unrecognized value. Recover its public link from .symposium/publish-history.md, then repair or remove the property before publishing."
     );
     this.name = "SymposiumPropertyConflictError";
     Object.setPrototypeOf(this, SymposiumPropertyConflictError.prototype);

--- a/src/symposium/symposiumLedger.test.ts
+++ b/src/symposium/symposiumLedger.test.ts
@@ -5,6 +5,9 @@ import type { Vault } from "obsidian";
 jest.mock("@/utils", () => ({ ensureFolderExists: jest.fn() }));
 
 const LEDGER_PATH = "copilot/symposium/published-documents.md";
+const LEDGER_HEADER =
+  "| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |\r\n" +
+  "| --- | --- | --- | --- | --- | ---: | --- |";
 const ENTRY: SymposiumLedgerEntry = {
   docId: "9f2k4mvq7t0xbz3n",
   status: "published",
@@ -26,9 +29,7 @@ describe("symposiumLedger", () => {
       jest.clearAllMocks();
       jest.mocked(ensureFolderExists).mockResolvedValue(undefined);
       append.mockResolvedValue(undefined);
-      read.mockResolvedValue(
-        "| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |"
-      );
+      read.mockResolvedValue(LEDGER_HEADER);
     });
 
     it("creates a readable Markdown ledger and escapes table-breaking note paths", async () => {
@@ -60,7 +61,7 @@ describe("symposiumLedger", () => {
 
       expect(append).toHaveBeenCalledWith(
         LEDGER_PATH,
-        `${String.raw`| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\\| Review.md | — | — | — | — |`}\n`
+        `\n${String.raw`| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\\| Review.md | — | — | — | — |`}\n`
       );
     });
 
@@ -75,7 +76,7 @@ describe("symposiumLedger", () => {
 
     it("refuses to append to an unrelated existing note", async () => {
       exists.mockResolvedValue(true);
-      read.mockResolvedValue("# My note");
+      read.mockResolvedValue(`${LEDGER_HEADER.split("\r\n")[0]}\nNot a ledger`);
 
       await expect(appendSymposiumLedgerEntry(vault, ENTRY)).rejects.toThrow("non-ledger note");
       expect(append).not.toHaveBeenCalled();

--- a/src/symposium/symposiumLedger.test.ts
+++ b/src/symposium/symposiumLedger.test.ts
@@ -1,0 +1,118 @@
+import {
+  appendSymposiumLedgerEntry,
+  SYMPOSIUM_LEDGER_FOLDER,
+  SYMPOSIUM_LEDGER_PATH,
+  type SymposiumLedgerEntry,
+} from "@/symposium/symposiumLedger";
+import type { Vault } from "obsidian";
+
+const ENTRY: SymposiumLedgerEntry = {
+  docId: "9f2k4mvq7t0xbz3n",
+  status: "published",
+  notePath: "Notes/Architecture | Review.md",
+  url: "https://symposium.site/d/9f2k4mvq7t0xbz3n",
+  publishedAt: "2026-07-27T18:30:00.000Z",
+  version: 1,
+  contentHash: "abc123",
+};
+
+interface VaultHarness {
+  contents: Map<string, string>;
+  mkdir: jest.Mock;
+  vault: Vault;
+  write: jest.Mock;
+}
+
+function createVault(): VaultHarness {
+  const contents = new Map<string, string>();
+  const folders = new Set<string>();
+  const mkdir = jest.fn(async (path: string) => {
+    folders.add(path);
+  });
+  const write = jest.fn(async (path: string, content: string) => {
+    contents.set(path, content);
+  });
+  const vault = {
+    getAbstractFileByPath: jest.fn((path: string) =>
+      folders.has(path) ? { path, children: [] } : null
+    ),
+    adapter: {
+      exists: jest.fn(async (path: string) => contents.has(path)),
+      mkdir,
+      read: jest.fn(async (path: string) => contents.get(path) ?? ""),
+      write,
+    },
+  } as unknown as Vault;
+  return { contents, mkdir, vault, write };
+}
+
+describe("symposiumLedger", () => {
+  describe("appendSymposiumLedgerEntry()", () => {
+    it("creates a readable Markdown ledger and escapes table-breaking note paths", async () => {
+      const harness = createVault();
+
+      await appendSymposiumLedgerEntry(harness.vault, ENTRY);
+
+      expect(harness.mkdir).toHaveBeenCalledWith("copilot");
+      expect(harness.mkdir).toHaveBeenCalledWith(SYMPOSIUM_LEDGER_FOLDER);
+      expect(harness.contents.get(SYMPOSIUM_LEDGER_PATH)).toContain(
+        "| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |"
+      );
+      expect(harness.contents.get(SYMPOSIUM_LEDGER_PATH)).toContain(
+        "| 9f2k4mvq7t0xbz3n | published | Notes/Architecture \\| Review.md | <https://symposium.site/d/9f2k4mvq7t0xbz3n> | 2026-07-27T18:30:00.000Z | 1 | abc123 |"
+      );
+    });
+
+    it("appends withdrawal records without deleting publication history", async () => {
+      const harness = createVault();
+      await appendSymposiumLedgerEntry(harness.vault, ENTRY);
+
+      await appendSymposiumLedgerEntry(harness.vault, {
+        ...ENTRY,
+        status: "unpublished",
+        url: null,
+        publishedAt: null,
+        version: null,
+        contentHash: null,
+      });
+
+      const ledger = harness.contents.get(SYMPOSIUM_LEDGER_PATH) ?? "";
+      expect(ledger.match(/\| 9f2k4mvq7t0xbz3n \|/g)).toHaveLength(2);
+      expect(ledger).toContain(
+        "| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\| Review.md | — | — | — | — |"
+      );
+    });
+
+    it("serializes concurrent writes and continues after an earlier write fails", async () => {
+      const harness = createVault();
+      let releaseFirst: (() => void) | undefined;
+      harness.write
+        .mockImplementationOnce(
+          () =>
+            new Promise<void>((_resolve, reject) => {
+              releaseFirst = () => reject(new Error("read-only"));
+            })
+        )
+        .mockImplementation(async (path: string, content: string) => {
+          harness.contents.set(path, content);
+        });
+
+      const first = appendSymposiumLedgerEntry(harness.vault, ENTRY);
+      const second = appendSymposiumLedgerEntry(harness.vault, {
+        ...ENTRY,
+        docId: "0123456789abcdef",
+      });
+      for (let turn = 0; turn < 20 && !releaseFirst; turn += 1) {
+        await Promise.resolve();
+      }
+
+      expect(releaseFirst).toBeDefined();
+      expect(harness.write).toHaveBeenCalledTimes(1);
+      releaseFirst?.();
+      await expect(first).rejects.toThrow("read-only");
+      await expect(second).resolves.toBeUndefined();
+      expect(harness.write).toHaveBeenCalledTimes(2);
+      expect(harness.contents.get(SYMPOSIUM_LEDGER_PATH)).toContain("0123456789abcdef");
+    });
+  });
+});

--- a/src/symposium/symposiumLedger.test.ts
+++ b/src/symposium/symposiumLedger.test.ts
@@ -4,7 +4,7 @@ import type { Vault } from "obsidian";
 
 jest.mock("@/utils", () => ({ ensureFolderExists: jest.fn() }));
 
-const LEDGER_PATH = "copilot/symposium/published-documents.md";
+const LEDGER_PATH = ".symposium/publish-history.md";
 const LEDGER_HEADER =
   "| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |\r\n" +
   "| --- | --- | --- | --- | --- | ---: | --- |";
@@ -32,12 +32,12 @@ describe("symposiumLedger", () => {
       read.mockResolvedValue(LEDGER_HEADER);
     });
 
-    it("creates a readable Markdown ledger and escapes table-breaking note paths", async () => {
+    it("creates hidden Markdown history and escapes table-breaking note paths", async () => {
       exists.mockResolvedValue(false);
 
       await appendSymposiumLedgerEntry(vault, ENTRY);
 
-      expect(ensureFolderExists).toHaveBeenCalledWith(vault, "copilot/symposium");
+      expect(ensureFolderExists).toHaveBeenCalledWith(vault, ".symposium");
       expect(append).toHaveBeenCalledWith(
         LEDGER_PATH,
         expect.stringContaining(
@@ -74,11 +74,11 @@ describe("symposiumLedger", () => {
       expect(append).toHaveBeenCalledWith(LEDGER_PATH, expect.stringContaining(ENTRY.docId));
     });
 
-    it("refuses to append to an unrelated existing note", async () => {
+    it("refuses to append to an unrelated existing file", async () => {
       exists.mockResolvedValue(true);
       read.mockResolvedValue(`${LEDGER_HEADER.split("\r\n")[0]}\nNot a ledger`);
 
-      await expect(appendSymposiumLedgerEntry(vault, ENTRY)).rejects.toThrow("non-ledger note");
+      await expect(appendSymposiumLedgerEntry(vault, ENTRY)).rejects.toThrow("non-ledger file");
       expect(append).not.toHaveBeenCalled();
     });
   });

--- a/src/symposium/symposiumLedger.test.ts
+++ b/src/symposium/symposiumLedger.test.ts
@@ -1,11 +1,10 @@
-import {
-  appendSymposiumLedgerEntry,
-  SYMPOSIUM_LEDGER_FOLDER,
-  SYMPOSIUM_LEDGER_PATH,
-  type SymposiumLedgerEntry,
-} from "@/symposium/symposiumLedger";
+import { appendSymposiumLedgerEntry, type SymposiumLedgerEntry } from "./symposiumLedger";
+import { ensureFolderExists } from "@/utils";
 import type { Vault } from "obsidian";
 
+jest.mock("@/utils", () => ({ ensureFolderExists: jest.fn() }));
+
+const LEDGER_PATH = "copilot/symposium/published-documents.md";
 const ENTRY: SymposiumLedgerEntry = {
   docId: "9f2k4mvq7t0xbz3n",
   status: "published",
@@ -16,67 +15,36 @@ const ENTRY: SymposiumLedgerEntry = {
   contentHash: "abc123",
 };
 
-interface VaultHarness {
-  append: jest.Mock;
-  contents: Map<string, string>;
-  exists: jest.Mock;
-  mkdir: jest.Mock;
-  vault: Vault;
-  write: jest.Mock;
-}
-
-function createVault(): VaultHarness {
-  const contents = new Map<string, string>();
-  const folders = new Set<string>();
-  const mkdir = jest.fn(async (path: string) => {
-    folders.add(path);
-  });
-  const write = jest.fn(async (path: string, content: string) => {
-    contents.set(path, content);
-  });
-  const append = jest.fn(async (path: string, content: string) => {
-    contents.set(path, `${contents.get(path) ?? ""}${content}`);
-  });
-  const exists = jest.fn(async (path: string) => contents.has(path));
-  const vault = {
-    getAbstractFileByPath: jest.fn((path: string) =>
-      folders.has(path) ? { path, children: [] } : null
-    ),
-    adapter: {
-      append,
-      exists,
-      mkdir,
-      read: jest.fn(async (path: string) => contents.get(path) ?? ""),
-      write,
-    },
-  } as unknown as Vault;
-  return { append, contents, exists, mkdir, vault, write };
-}
-
 describe("symposiumLedger", () => {
   describe("appendSymposiumLedgerEntry()", () => {
-    it("creates a readable Markdown ledger and escapes table-breaking note paths", async () => {
-      const harness = createVault();
+    const append = jest.fn();
+    const exists = jest.fn();
+    const vault = { adapter: { append, exists } } as unknown as Vault;
 
-      await appendSymposiumLedgerEntry(harness.vault, ENTRY);
-
-      expect(harness.mkdir).toHaveBeenCalledWith("copilot");
-      expect(harness.mkdir).toHaveBeenCalledWith(SYMPOSIUM_LEDGER_FOLDER);
-      expect(harness.contents.get(SYMPOSIUM_LEDGER_PATH)).toContain(
-        "| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |"
-      );
-      expect(harness.contents.get(SYMPOSIUM_LEDGER_PATH)).toContain(
-        "| 9f2k4mvq7t0xbz3n | published | Notes/Architecture \\| Review.md | <https://symposium.site/d/9f2k4mvq7t0xbz3n> | 2026-07-27T18:30:00.000Z | 1 | abc123 |"
-      );
-      expect(harness.append).toHaveBeenCalledTimes(1);
-      expect(harness.write).not.toHaveBeenCalled();
+    beforeEach(() => {
+      jest.clearAllMocks();
+      append.mockResolvedValue(undefined);
     });
 
-    it("appends withdrawal records without deleting publication history", async () => {
-      const harness = createVault();
-      await appendSymposiumLedgerEntry(harness.vault, ENTRY);
+    it("creates a readable Markdown ledger and escapes table-breaking note paths", async () => {
+      exists.mockResolvedValue(false);
 
-      await appendSymposiumLedgerEntry(harness.vault, {
+      await appendSymposiumLedgerEntry(vault, ENTRY);
+
+      expect(ensureFolderExists).toHaveBeenCalledWith(vault, "copilot/symposium");
+      expect(append).toHaveBeenCalledWith(
+        LEDGER_PATH,
+        expect.stringContaining(
+          "| 9f2k4mvq7t0xbz3n | published | Notes/Architecture \\| Review.md | <https://symposium.site/d/9f2k4mvq7t0xbz3n> | 2026-07-27T18:30:00.000Z | 1 | abc123 |"
+        )
+      );
+      expect(append.mock.calls[0][1]).toContain("| Document ID | Status | Note | URL |");
+    });
+
+    it("appends withdrawal records without adding another header", async () => {
+      exists.mockResolvedValue(true);
+
+      await appendSymposiumLedgerEntry(vault, {
         ...ENTRY,
         status: "unpublished",
         url: null,
@@ -85,59 +53,10 @@ describe("symposiumLedger", () => {
         contentHash: null,
       });
 
-      const ledger = harness.contents.get(SYMPOSIUM_LEDGER_PATH) ?? "";
-      expect(harness.append).toHaveBeenCalledTimes(2);
-      expect(ledger.match(/\| 9f2k4mvq7t0xbz3n \|/g)).toHaveLength(2);
-      expect(ledger).toContain(
-        "| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\| Review.md | — | — | — | — |"
+      expect(append).toHaveBeenCalledWith(
+        LEDGER_PATH,
+        "| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\| Review.md | — | — | — | — |\n"
       );
-    });
-
-    it("serializes concurrent writes and continues after an earlier write fails", async () => {
-      const harness = createVault();
-      let releaseFirst: (() => void) | undefined;
-      harness.append
-        .mockImplementationOnce(
-          () =>
-            new Promise<void>((_resolve, reject) => {
-              releaseFirst = () => reject(new Error("read-only"));
-            })
-        )
-        .mockImplementation(async (path: string, content: string) => {
-          harness.contents.set(path, `${harness.contents.get(path) ?? ""}${content}`);
-        });
-
-      const first = appendSymposiumLedgerEntry(harness.vault, ENTRY);
-      const second = appendSymposiumLedgerEntry(harness.vault, {
-        ...ENTRY,
-        docId: "0123456789abcdef",
-      });
-      for (let turn = 0; turn < 20 && !releaseFirst; turn += 1) {
-        await Promise.resolve();
-      }
-
-      expect(releaseFirst).toBeDefined();
-      expect(harness.append).toHaveBeenCalledTimes(1);
-      releaseFirst?.();
-      await expect(first).rejects.toThrow("read-only");
-      await expect(second).resolves.toBeUndefined();
-      expect(harness.append).toHaveBeenCalledTimes(2);
-      expect(harness.contents.get(SYMPOSIUM_LEDGER_PATH)).toContain("0123456789abcdef");
-    });
-
-    it("preserves a ledger created after a stale absence check", async () => {
-      const harness = createVault();
-      harness.exists.mockImplementationOnce(async () => {
-        harness.contents.set(SYMPOSIUM_LEDGER_PATH, "concurrent receipt\n");
-        return false;
-      });
-
-      await appendSymposiumLedgerEntry(harness.vault, ENTRY);
-
-      const ledger = harness.contents.get(SYMPOSIUM_LEDGER_PATH) ?? "";
-      expect(ledger).toContain("concurrent receipt");
-      expect(ledger).toContain(ENTRY.docId);
-      expect(harness.write).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/symposium/symposiumLedger.test.ts
+++ b/src/symposium/symposiumLedger.test.ts
@@ -19,6 +19,7 @@ const ENTRY: SymposiumLedgerEntry = {
 interface VaultHarness {
   append: jest.Mock;
   contents: Map<string, string>;
+  exists: jest.Mock;
   mkdir: jest.Mock;
   vault: Vault;
   write: jest.Mock;
@@ -36,19 +37,20 @@ function createVault(): VaultHarness {
   const append = jest.fn(async (path: string, content: string) => {
     contents.set(path, `${contents.get(path) ?? ""}${content}`);
   });
+  const exists = jest.fn(async (path: string) => contents.has(path));
   const vault = {
     getAbstractFileByPath: jest.fn((path: string) =>
       folders.has(path) ? { path, children: [] } : null
     ),
     adapter: {
       append,
-      exists: jest.fn(async (path: string) => contents.has(path)),
+      exists,
       mkdir,
       read: jest.fn(async (path: string) => contents.get(path) ?? ""),
       write,
     },
   } as unknown as Vault;
-  return { append, contents, mkdir, vault, write };
+  return { append, contents, exists, mkdir, vault, write };
 }
 
 describe("symposiumLedger", () => {
@@ -66,6 +68,8 @@ describe("symposiumLedger", () => {
       expect(harness.contents.get(SYMPOSIUM_LEDGER_PATH)).toContain(
         "| 9f2k4mvq7t0xbz3n | published | Notes/Architecture \\| Review.md | <https://symposium.site/d/9f2k4mvq7t0xbz3n> | 2026-07-27T18:30:00.000Z | 1 | abc123 |"
       );
+      expect(harness.append).toHaveBeenCalledTimes(1);
+      expect(harness.write).not.toHaveBeenCalled();
     });
 
     it("appends withdrawal records without deleting publication history", async () => {
@@ -82,7 +86,7 @@ describe("symposiumLedger", () => {
       });
 
       const ledger = harness.contents.get(SYMPOSIUM_LEDGER_PATH) ?? "";
-      expect(harness.append).toHaveBeenCalledTimes(1);
+      expect(harness.append).toHaveBeenCalledTimes(2);
       expect(ledger.match(/\| 9f2k4mvq7t0xbz3n \|/g)).toHaveLength(2);
       expect(ledger).toContain(
         "| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\| Review.md | — | — | — | — |"
@@ -92,7 +96,7 @@ describe("symposiumLedger", () => {
     it("serializes concurrent writes and continues after an earlier write fails", async () => {
       const harness = createVault();
       let releaseFirst: (() => void) | undefined;
-      harness.write
+      harness.append
         .mockImplementationOnce(
           () =>
             new Promise<void>((_resolve, reject) => {
@@ -100,7 +104,7 @@ describe("symposiumLedger", () => {
             })
         )
         .mockImplementation(async (path: string, content: string) => {
-          harness.contents.set(path, content);
+          harness.contents.set(path, `${harness.contents.get(path) ?? ""}${content}`);
         });
 
       const first = appendSymposiumLedgerEntry(harness.vault, ENTRY);
@@ -113,12 +117,27 @@ describe("symposiumLedger", () => {
       }
 
       expect(releaseFirst).toBeDefined();
-      expect(harness.write).toHaveBeenCalledTimes(1);
+      expect(harness.append).toHaveBeenCalledTimes(1);
       releaseFirst?.();
       await expect(first).rejects.toThrow("read-only");
       await expect(second).resolves.toBeUndefined();
-      expect(harness.write).toHaveBeenCalledTimes(2);
+      expect(harness.append).toHaveBeenCalledTimes(2);
       expect(harness.contents.get(SYMPOSIUM_LEDGER_PATH)).toContain("0123456789abcdef");
+    });
+
+    it("preserves a ledger created after a stale absence check", async () => {
+      const harness = createVault();
+      harness.exists.mockImplementationOnce(async () => {
+        harness.contents.set(SYMPOSIUM_LEDGER_PATH, "concurrent receipt\n");
+        return false;
+      });
+
+      await appendSymposiumLedgerEntry(harness.vault, ENTRY);
+
+      const ledger = harness.contents.get(SYMPOSIUM_LEDGER_PATH) ?? "";
+      expect(ledger).toContain("concurrent receipt");
+      expect(ledger).toContain(ENTRY.docId);
+      expect(harness.write).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/symposium/symposiumLedger.test.ts
+++ b/src/symposium/symposiumLedger.test.ts
@@ -17,6 +17,7 @@ const ENTRY: SymposiumLedgerEntry = {
 };
 
 interface VaultHarness {
+  append: jest.Mock;
   contents: Map<string, string>;
   mkdir: jest.Mock;
   vault: Vault;
@@ -32,18 +33,22 @@ function createVault(): VaultHarness {
   const write = jest.fn(async (path: string, content: string) => {
     contents.set(path, content);
   });
+  const append = jest.fn(async (path: string, content: string) => {
+    contents.set(path, `${contents.get(path) ?? ""}${content}`);
+  });
   const vault = {
     getAbstractFileByPath: jest.fn((path: string) =>
       folders.has(path) ? { path, children: [] } : null
     ),
     adapter: {
+      append,
       exists: jest.fn(async (path: string) => contents.has(path)),
       mkdir,
       read: jest.fn(async (path: string) => contents.get(path) ?? ""),
       write,
     },
   } as unknown as Vault;
-  return { contents, mkdir, vault, write };
+  return { append, contents, mkdir, vault, write };
 }
 
 describe("symposiumLedger", () => {
@@ -77,6 +82,7 @@ describe("symposiumLedger", () => {
       });
 
       const ledger = harness.contents.get(SYMPOSIUM_LEDGER_PATH) ?? "";
+      expect(harness.append).toHaveBeenCalledTimes(1);
       expect(ledger.match(/\| 9f2k4mvq7t0xbz3n \|/g)).toHaveLength(2);
       expect(ledger).toContain(
         "| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\| Review.md | — | — | — | — |"

--- a/src/symposium/symposiumLedger.test.ts
+++ b/src/symposium/symposiumLedger.test.ts
@@ -19,12 +19,16 @@ describe("symposiumLedger", () => {
   describe("appendSymposiumLedgerEntry()", () => {
     const append = jest.fn();
     const exists = jest.fn();
-    const vault = { adapter: { append, exists } } as unknown as Vault;
+    const read = jest.fn();
+    const vault = { adapter: { append, exists, read } } as unknown as Vault;
 
     beforeEach(() => {
       jest.clearAllMocks();
       jest.mocked(ensureFolderExists).mockResolvedValue(undefined);
       append.mockResolvedValue(undefined);
+      read.mockResolvedValue(
+        "| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |"
+      );
     });
 
     it("creates a readable Markdown ledger and escapes table-breaking note paths", async () => {
@@ -67,6 +71,14 @@ describe("symposiumLedger", () => {
       await appendSymposiumLedgerEntry(vault, ENTRY);
 
       expect(append).toHaveBeenCalledWith(LEDGER_PATH, expect.stringContaining(ENTRY.docId));
+    });
+
+    it("refuses to append to an unrelated existing note", async () => {
+      exists.mockResolvedValue(true);
+      read.mockResolvedValue("# My note");
+
+      await expect(appendSymposiumLedgerEntry(vault, ENTRY)).rejects.toThrow("non-ledger note");
+      expect(append).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/symposium/symposiumLedger.test.ts
+++ b/src/symposium/symposiumLedger.test.ts
@@ -23,6 +23,7 @@ describe("symposiumLedger", () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
+      jest.mocked(ensureFolderExists).mockResolvedValue(undefined);
       append.mockResolvedValue(undefined);
     });
 
@@ -57,6 +58,15 @@ describe("symposiumLedger", () => {
         LEDGER_PATH,
         "| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\| Review.md | — | — | — | — |\n"
       );
+    });
+
+    it("continues when another publish creates the ledger folder first", async () => {
+      jest.mocked(ensureFolderExists).mockRejectedValueOnce(new Error("already exists"));
+      exists.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+      await appendSymposiumLedgerEntry(vault, ENTRY);
+
+      expect(append).toHaveBeenCalledWith(LEDGER_PATH, expect.stringContaining(ENTRY.docId));
     });
   });
 });

--- a/src/symposium/symposiumLedger.test.ts
+++ b/src/symposium/symposiumLedger.test.ts
@@ -8,7 +8,7 @@ const LEDGER_PATH = "copilot/symposium/published-documents.md";
 const ENTRY: SymposiumLedgerEntry = {
   docId: "9f2k4mvq7t0xbz3n",
   status: "published",
-  notePath: "Notes/Architecture | Review.md",
+  notePath: String.raw`Notes/Architecture \| Review.md`,
   url: "https://symposium.site/d/9f2k4mvq7t0xbz3n",
   publishedAt: "2026-07-27T18:30:00.000Z",
   version: 1,
@@ -36,7 +36,7 @@ describe("symposiumLedger", () => {
       expect(append).toHaveBeenCalledWith(
         LEDGER_PATH,
         expect.stringContaining(
-          "| 9f2k4mvq7t0xbz3n | published | Notes/Architecture \\| Review.md | <https://symposium.site/d/9f2k4mvq7t0xbz3n> | 2026-07-27T18:30:00.000Z | 1 | abc123 |"
+          String.raw`| 9f2k4mvq7t0xbz3n | published | Notes/Architecture \\\| Review.md | <https://symposium.site/d/9f2k4mvq7t0xbz3n> | 2026-07-27T18:30:00.000Z | 1 | abc123 |`
         )
       );
       expect(append.mock.calls[0][1]).toContain("| Document ID | Status | Note | URL |");
@@ -56,7 +56,7 @@ describe("symposiumLedger", () => {
 
       expect(append).toHaveBeenCalledWith(
         LEDGER_PATH,
-        "| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\| Review.md | — | — | — | — |\n"
+        `${String.raw`| 9f2k4mvq7t0xbz3n | unpublished | Notes/Architecture \\\| Review.md | — | — | — | — |`}\n`
       );
     });
 

--- a/src/symposium/symposiumLedger.ts
+++ b/src/symposium/symposiumLedger.ts
@@ -15,52 +15,33 @@ export interface SymposiumLedgerEntry {
   contentHash: string | null;
 }
 
-const LEDGER_HEADER = `# Symposium publication ledger
-
-This append-only ledger keeps Symposium document IDs recoverable independently of note properties.
-
-| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |
+const LEDGER_HEADER = `| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |
 | --- | --- | --- | --- | --- | ---: | --- |
 `;
-const ledgerWriteTails = new WeakMap<Vault, Promise<void>>();
 
 function tableCell(value: string | number | null): string {
-  if (value === null) {
-    return "—";
-  }
+  if (value === null) return "—";
   return String(value).replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
 }
 
-function ledgerRow(entry: SymposiumLedgerEntry): string {
-  const url = entry.url ? `<${entry.url}>` : null;
-  return `| ${tableCell(entry.docId)} | ${entry.status} | ${tableCell(entry.notePath)} | ${tableCell(url)} | ${tableCell(entry.publishedAt)} | ${tableCell(entry.version)} | ${tableCell(entry.contentHash)} |`;
-}
-
-async function writeLedgerEntry(vault: Vault, entry: SymposiumLedgerEntry): Promise<void> {
-  await ensureFolderExists(vault, SYMPOSIUM_LEDGER_FOLDER);
-  const exists = await vault.adapter.exists(SYMPOSIUM_LEDGER_PATH);
-  const row = `${ledgerRow(entry)}\n`;
-  await vault.adapter.append(SYMPOSIUM_LEDGER_PATH, `${exists ? "" : LEDGER_HEADER}${row}`);
-}
-
-/**
- * Appends one durable publication record while serializing all writes for the vault.
- *
- * @param vault The vault that owns the human-readable ledger.
- * @param entry The successful remote action to preserve.
- */
 export async function appendSymposiumLedgerEntry(
   vault: Vault,
   entry: SymposiumLedgerEntry
 ): Promise<void> {
-  const previous = ledgerWriteTails.get(vault) ?? Promise.resolve();
-  const current = previous.catch(() => undefined).then(() => writeLedgerEntry(vault, entry));
-  ledgerWriteTails.set(vault, current);
-  try {
-    await current;
-  } finally {
-    if (ledgerWriteTails.get(vault) === current) {
-      ledgerWriteTails.delete(vault);
-    }
-  }
+  await ensureFolderExists(vault, SYMPOSIUM_LEDGER_FOLDER);
+  const row = [
+    entry.docId,
+    entry.status,
+    entry.notePath,
+    entry.url ? `<${entry.url}>` : null,
+    entry.publishedAt,
+    entry.version,
+    entry.contentHash,
+  ]
+    .map(tableCell)
+    .join(" | ");
+  await vault.adapter.append(
+    SYMPOSIUM_LEDGER_PATH,
+    `${(await vault.adapter.exists(SYMPOSIUM_LEDGER_PATH)) ? "" : LEDGER_HEADER}| ${row} |\n`
+  );
 }

--- a/src/symposium/symposiumLedger.ts
+++ b/src/symposium/symposiumLedger.ts
@@ -21,7 +21,7 @@ const LEDGER_HEADER = `| Document ID | Status | Note | URL | Published at (UTC) 
 
 function tableCell(value: string | number | null): string {
   if (value === null) return "—";
-  return String(value).replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
+  return String(value).replace(/\\/g, "\\\\").replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
 }
 
 export async function appendSymposiumLedgerEntry(

--- a/src/symposium/symposiumLedger.ts
+++ b/src/symposium/symposiumLedger.ts
@@ -40,11 +40,7 @@ async function writeLedgerEntry(vault: Vault, entry: SymposiumLedgerEntry): Prom
   await ensureFolderExists(vault, SYMPOSIUM_LEDGER_FOLDER);
   const exists = await vault.adapter.exists(SYMPOSIUM_LEDGER_PATH);
   const row = `${ledgerRow(entry)}\n`;
-  if (exists) {
-    await vault.adapter.append(SYMPOSIUM_LEDGER_PATH, row);
-  } else {
-    await vault.adapter.write(SYMPOSIUM_LEDGER_PATH, `${LEDGER_HEADER}${row}`);
-  }
+  await vault.adapter.append(SYMPOSIUM_LEDGER_PATH, `${exists ? "" : LEDGER_HEADER}${row}`);
 }
 
 /**

--- a/src/symposium/symposiumLedger.ts
+++ b/src/symposium/symposiumLedger.ts
@@ -1,0 +1,67 @@
+import { COPILOT_FOLDER_ROOT } from "@/constants";
+import { ensureFolderExists } from "@/utils";
+import type { Vault } from "obsidian";
+
+export const SYMPOSIUM_LEDGER_FOLDER = `${COPILOT_FOLDER_ROOT}/symposium`;
+export const SYMPOSIUM_LEDGER_PATH = `${SYMPOSIUM_LEDGER_FOLDER}/published-documents.md`;
+
+export interface SymposiumLedgerEntry {
+  docId: string;
+  status: "published" | "unpublished";
+  notePath: string;
+  url: string | null;
+  publishedAt: string | null;
+  version: number | null;
+  contentHash: string | null;
+}
+
+const LEDGER_HEADER = `# Symposium publication ledger
+
+This append-only ledger keeps Symposium document IDs recoverable independently of note properties.
+
+| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |
+| --- | --- | --- | --- | --- | ---: | --- |
+`;
+const ledgerWriteTails = new WeakMap<Vault, Promise<void>>();
+
+function tableCell(value: string | number | null): string {
+  if (value === null) {
+    return "—";
+  }
+  return String(value).replace(/\r?\n/g, " ").replace(/\|/g, "\\|");
+}
+
+function ledgerRow(entry: SymposiumLedgerEntry): string {
+  const url = entry.url ? `<${entry.url}>` : null;
+  return `| ${tableCell(entry.docId)} | ${entry.status} | ${tableCell(entry.notePath)} | ${tableCell(url)} | ${tableCell(entry.publishedAt)} | ${tableCell(entry.version)} | ${tableCell(entry.contentHash)} |`;
+}
+
+async function writeLedgerEntry(vault: Vault, entry: SymposiumLedgerEntry): Promise<void> {
+  await ensureFolderExists(vault, SYMPOSIUM_LEDGER_FOLDER);
+  const exists = await vault.adapter.exists(SYMPOSIUM_LEDGER_PATH);
+  const current = exists ? await vault.adapter.read(SYMPOSIUM_LEDGER_PATH) : LEDGER_HEADER;
+  const separator = current.endsWith("\n") ? "" : "\n";
+  await vault.adapter.write(SYMPOSIUM_LEDGER_PATH, `${current}${separator}${ledgerRow(entry)}\n`);
+}
+
+/**
+ * Appends one durable publication record while serializing all writes for the vault.
+ *
+ * @param vault The vault that owns the human-readable ledger.
+ * @param entry The successful remote action to preserve.
+ */
+export async function appendSymposiumLedgerEntry(
+  vault: Vault,
+  entry: SymposiumLedgerEntry
+): Promise<void> {
+  const previous = ledgerWriteTails.get(vault) ?? Promise.resolve();
+  const current = previous.catch(() => undefined).then(() => writeLedgerEntry(vault, entry));
+  ledgerWriteTails.set(vault, current);
+  try {
+    await current;
+  } finally {
+    if (ledgerWriteTails.get(vault) === current) {
+      ledgerWriteTails.delete(vault);
+    }
+  }
+}

--- a/src/symposium/symposiumLedger.ts
+++ b/src/symposium/symposiumLedger.ts
@@ -39,9 +39,12 @@ function ledgerRow(entry: SymposiumLedgerEntry): string {
 async function writeLedgerEntry(vault: Vault, entry: SymposiumLedgerEntry): Promise<void> {
   await ensureFolderExists(vault, SYMPOSIUM_LEDGER_FOLDER);
   const exists = await vault.adapter.exists(SYMPOSIUM_LEDGER_PATH);
-  const current = exists ? await vault.adapter.read(SYMPOSIUM_LEDGER_PATH) : LEDGER_HEADER;
-  const separator = current.endsWith("\n") ? "" : "\n";
-  await vault.adapter.write(SYMPOSIUM_LEDGER_PATH, `${current}${separator}${ledgerRow(entry)}\n`);
+  const row = `${ledgerRow(entry)}\n`;
+  if (exists) {
+    await vault.adapter.append(SYMPOSIUM_LEDGER_PATH, row);
+  } else {
+    await vault.adapter.write(SYMPOSIUM_LEDGER_PATH, `${LEDGER_HEADER}${row}`);
+  }
 }
 
 /**

--- a/src/symposium/symposiumLedger.ts
+++ b/src/symposium/symposiumLedger.ts
@@ -18,8 +18,7 @@ export interface SymposiumLedgerEntry {
 const LEDGER_COLUMNS =
   "| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |";
 const LEDGER_HEADER = `${LEDGER_COLUMNS}
-| --- | --- | --- | --- | --- | ---: | --- |
-`;
+| --- | --- | --- | --- | --- | ---: | --- |`;
 
 function tableCell(value: string | number | null): string {
   if (value === null) return "—";
@@ -45,8 +44,14 @@ export async function appendSymposiumLedgerEntry(
     .map(tableCell)
     .join(" | ");
   const exists = await vault.adapter.exists(SYMPOSIUM_LEDGER_PATH);
-  if (exists && !(await vault.adapter.read(SYMPOSIUM_LEDGER_PATH)).startsWith(LEDGER_COLUMNS)) {
+  const existing = exists ? await vault.adapter.read(SYMPOSIUM_LEDGER_PATH) : "";
+  const normalized = existing.replace(/\r\n?/g, "\n");
+  if (exists && normalized !== LEDGER_HEADER && !normalized.startsWith(`${LEDGER_HEADER}\n`)) {
     throw new Error(`Refusing to append to non-ledger note: ${SYMPOSIUM_LEDGER_PATH}`);
   }
-  await vault.adapter.append(SYMPOSIUM_LEDGER_PATH, `${exists ? "" : LEDGER_HEADER}| ${row} |\n`);
+  const rowPrefix = exists && !/[\r\n]$/.test(existing) ? "\n" : "";
+  await vault.adapter.append(
+    SYMPOSIUM_LEDGER_PATH,
+    `${exists ? rowPrefix : `${LEDGER_HEADER}\n`}| ${row} |\n`
+  );
 }

--- a/src/symposium/symposiumLedger.ts
+++ b/src/symposium/symposiumLedger.ts
@@ -15,7 +15,9 @@ export interface SymposiumLedgerEntry {
   contentHash: string | null;
 }
 
-const LEDGER_HEADER = `| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |
+const LEDGER_COLUMNS =
+  "| Document ID | Status | Note | URL | Published at (UTC) | Version | Content SHA-256 |";
+const LEDGER_HEADER = `${LEDGER_COLUMNS}
 | --- | --- | --- | --- | --- | ---: | --- |
 `;
 
@@ -42,8 +44,9 @@ export async function appendSymposiumLedgerEntry(
   ]
     .map(tableCell)
     .join(" | ");
-  await vault.adapter.append(
-    SYMPOSIUM_LEDGER_PATH,
-    `${(await vault.adapter.exists(SYMPOSIUM_LEDGER_PATH)) ? "" : LEDGER_HEADER}| ${row} |\n`
-  );
+  const exists = await vault.adapter.exists(SYMPOSIUM_LEDGER_PATH);
+  if (exists && !(await vault.adapter.read(SYMPOSIUM_LEDGER_PATH)).startsWith(LEDGER_COLUMNS)) {
+    throw new Error(`Refusing to append to non-ledger note: ${SYMPOSIUM_LEDGER_PATH}`);
+  }
+  await vault.adapter.append(SYMPOSIUM_LEDGER_PATH, `${exists ? "" : LEDGER_HEADER}| ${row} |\n`);
 }

--- a/src/symposium/symposiumLedger.ts
+++ b/src/symposium/symposiumLedger.ts
@@ -28,7 +28,9 @@ export async function appendSymposiumLedgerEntry(
   vault: Vault,
   entry: SymposiumLedgerEntry
 ): Promise<void> {
-  await ensureFolderExists(vault, SYMPOSIUM_LEDGER_FOLDER);
+  await ensureFolderExists(vault, SYMPOSIUM_LEDGER_FOLDER).catch(async (error) => {
+    if (!(await vault.adapter.exists(SYMPOSIUM_LEDGER_FOLDER))) throw error;
+  });
   const row = [
     entry.docId,
     entry.status,

--- a/src/symposium/symposiumLedger.ts
+++ b/src/symposium/symposiumLedger.ts
@@ -1,9 +1,8 @@
-import { COPILOT_FOLDER_ROOT } from "@/constants";
 import { ensureFolderExists } from "@/utils";
 import type { Vault } from "obsidian";
 
-export const SYMPOSIUM_LEDGER_FOLDER = `${COPILOT_FOLDER_ROOT}/symposium`;
-export const SYMPOSIUM_LEDGER_PATH = `${SYMPOSIUM_LEDGER_FOLDER}/published-documents.md`;
+export const SYMPOSIUM_LEDGER_FOLDER = ".symposium";
+export const SYMPOSIUM_LEDGER_PATH = `${SYMPOSIUM_LEDGER_FOLDER}/publish-history.md`;
 
 export interface SymposiumLedgerEntry {
   docId: string;
@@ -47,7 +46,7 @@ export async function appendSymposiumLedgerEntry(
   const existing = exists ? await vault.adapter.read(SYMPOSIUM_LEDGER_PATH) : "";
   const normalized = existing.replace(/\r\n?/g, "\n");
   if (exists && normalized !== LEDGER_HEADER && !normalized.startsWith(`${LEDGER_HEADER}\n`)) {
-    throw new Error(`Refusing to append to non-ledger note: ${SYMPOSIUM_LEDGER_PATH}`);
+    throw new Error(`Refusing to append to non-ledger file: ${SYMPOSIUM_LEDGER_PATH}`);
   }
   const rowPrefix = exists && !/[\r\n]$/.test(existing) ? "\n" : "";
   await vault.adapter.append(


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#241
Fixes logancyang/obsidian-copilot-preview#236

## Problem

Agent Mode cannot publish HTML it generated itself through Symposium. A successful receipt also lives only in a note's `symposium` property, so deleting or damaging that property can lose the only recoverable document ID.

## Fix

Seed one knowledge-only `symposium-publish` skill that tells any compatible agent to create self-contained HTML, ask for explicit confirmation, publish with `SYMPOSIUM_TOKEN`, append the receipt to hidden local history, and store the full public link in the required source note. Copilot supplies its current Plus credential under that service-owned environment name; the skill does not otherwise depend on Copilot or Obsidian CLI.

The existing note publisher appends publish, update, and withdrawal receipts to `.symposium/publish-history.md` before changing frontmatter. History failures are advisory and never block the action.

## Scope

Budget gate: PASS — 15 files, +464/−78; this is the smallest combined #236/#241 shape: one knowledge-only skill, one credential alias, one Markdown append helper, existing publisher hooks, and the existing frontmatter identity parser switched from IDs to full links. It adds no agent bridge, recovery UI, relink prompt, lock, migration, compatibility path, or second identity state machine.

## Changes

- Seed the neutral `symposium-publish` skill for Claude, Codex, and OpenCode while retaining only Copilot's required seeding metadata.
- Map Copilot's current Plus credential to `SYMPOSIUM_TOKEN`; other hosts can provide the same variable directly.
- Require a source Markdown file, agent-generated passive HTML, explicit confirmation, one initial publish, and the host's update/delete flow afterward.
- Append document ID, status, source path, URL, timestamp, version, and content hash to `.symposium/publish-history.md`.
- Store the server-returned public link in the source note and derive the API document ID from that link.

## Verification

- `npm run test -- --runInBand` — 344 suites and 4,892 tests passed.
- Focused Symposium, built-in skill, and managed-environment tests — 5 suites and 79 tests passed.
- `npm run format && npm run lint`.
- `npm run format:check`.
- `npm run build`.
- No live publish was performed because it would create a public page.

GitHub did not register the cross-repo closing references, so #236 and #241 must be closed manually on merge.

🤖 Generated with [Codex](https://openai.com/codex)
