### PR TITLE
Fix overflowing labels in Agent Mode permission cards

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -37,8 +37,8 @@ The mode picker beside the message box controls how much the active agent can do
 The available modes depend on the selected agent. Copilot normalizes equivalent modes across supported versions of Claude, Codex, and OpenCode.
 
 When **Default** mode asks for permission, the request stays in the chat until
-you choose an action. Detailed permission rules appear in the card body, while
-the buttons keep short action labels.
+you choose an action, cancel the turn, or close the session. Each detailed
+permission rule appears beside its matching short action button.
 
 ### Max Iterations
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -36,6 +36,10 @@ The mode picker beside the message box controls how much the active agent can do
 
 The available modes depend on the selected agent. Copilot normalizes equivalent modes across supported versions of Claude, Codex, and OpenCode.
 
+When **Default** mode asks for permission, the request stays in the chat until
+you choose an action. Detailed permission rules appear in the card body, while
+the buttons keep short action labels.
+
 ### Max Iterations
 
 The agent works in iteration cycles (think → use a tool → think → use a tool → answer). You can control the maximum number of iterations before the agent stops:

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -1,5 +1,5 @@
 import { FileSystemAdapter, App } from "obsidian";
-import type { BackendDescriptor } from "@/agentMode/session/types";
+import type { BackendDescriptor, PermissionOption } from "@/agentMode/session/types";
 import { AcpBackendProcess } from "./AcpBackendProcess";
 import type { AcpBackend } from "./types";
 import type { VaultClient } from "./VaultClient";
@@ -83,10 +83,11 @@ function buildStubBackend(): AcpBackend {
   };
 }
 
-function buildStubDescriptor(): BackendDescriptor {
+function buildStubDescriptor(overrides: Partial<BackendDescriptor> = {}): BackendDescriptor {
   return {
     id: "opencode",
     displayName: "opencode",
+    ...overrides,
   } as unknown as BackendDescriptor;
 }
 
@@ -290,53 +291,44 @@ describe("AcpBackendProcess", () => {
     expect(response).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
-  it("preserves compact permission labels and separates policy rules before delegating", async () => {
+  it("applies the backend permission presentation hook before delegating", async () => {
+    const presentPermissionOption = jest.fn((option: PermissionOption): PermissionOption => {
+      if (option.optionId !== "backend-policy-rule") return option;
+      return {
+        ...option,
+        name: "Allow Always",
+        description: option.name,
+      };
+    });
     const backend = new AcpBackendProcess(
       buildApp(),
       buildStubBackend(),
       "1.0.0",
-      buildStubDescriptor()
+      buildStubDescriptor({ presentPermissionOption })
     );
     await backend.start();
 
     const prompter = jest.fn().mockResolvedValue({
-      outcome: { outcome: "selected", optionId: "accept_execpolicy_amendment" },
+      outcome: { outcome: "selected", optionId: "backend-policy-rule" },
     });
     backend.setPermissionPrompter(prompter);
 
     const client = getVaultClient(backend);
-    const commandRule = "Allow commands matching `/usr/local/bin/search --vault notes`";
-    const networkRule = "Allow network access to api.example.com";
+    const policyRule = "Allow commands matching `/usr/local/bin/search --vault notes`";
     const req = {
       sessionId: "s1",
       toolCall: { toolCallId: "tc1", title: "Read" },
       options: [
         { optionId: "allow_once", name: "Allow Once", kind: "allow_once" },
-        { optionId: "allow_session", name: "Allow for Session", kind: "allow_always" },
         {
-          optionId: "allow_host_session",
-          name: "Allow Host for Session",
-          kind: "allow_always",
-        },
-        {
-          optionId: "allow_root_session",
-          name: "Allow Root for Session",
-          kind: "allow_always",
-        },
-        { optionId: "reject_once", name: "No", kind: "reject_once" },
-        {
-          optionId: "accept_execpolicy_amendment",
-          name: commandRule,
-          kind: "allow_always",
-        },
-        {
-          optionId: "apply_network_policy_amendment:0",
-          name: networkRule,
+          optionId: "backend-policy-rule",
+          name: policyRule,
           kind: "allow_always",
         },
       ],
     } as unknown as Parameters<typeof client.requestPermission>[0];
     const response = await client.requestPermission(req);
+    expect(presentPermissionOption).toHaveBeenCalledTimes(2);
     expect(prompter).toHaveBeenCalledTimes(1);
     // Prompter receives a session-domain `PermissionPrompt`.
     const prompt = prompter.mock.calls[0][0];
@@ -349,40 +341,14 @@ describe("AcpBackendProcess", () => {
         kind: "allow_once",
       },
       {
-        optionId: "allow_session",
-        name: "Allow for Session",
-        kind: "allow_always",
-      },
-      {
-        optionId: "allow_host_session",
-        name: "Allow Host for Session",
-        kind: "allow_always",
-      },
-      {
-        optionId: "allow_root_session",
-        name: "Allow Root for Session",
-        kind: "allow_always",
-      },
-      {
-        optionId: "reject_once",
-        name: "No",
-        kind: "reject_once",
-      },
-      {
-        optionId: "accept_execpolicy_amendment",
+        optionId: "backend-policy-rule",
         name: "Allow Always",
-        description: commandRule,
-        kind: "allow_always",
-      },
-      {
-        optionId: "apply_network_policy_amendment:0",
-        name: "Allow Always",
-        description: networkRule,
+        description: policyRule,
         kind: "allow_always",
       },
     ]);
     expect(response).toEqual({
-      outcome: { outcome: "selected", optionId: "accept_execpolicy_amendment" },
+      outcome: { outcome: "selected", optionId: "backend-policy-rule" },
     });
   });
 

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -290,7 +290,7 @@ describe("AcpBackendProcess", () => {
     expect(response).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
-  it("delegates to the registered prompter and forwards the response", async () => {
+  it("preserves compact permission labels and separates policy rules before delegating", async () => {
     const backend = new AcpBackendProcess(
       buildApp(),
       buildStubBackend(),
@@ -311,13 +311,26 @@ describe("AcpBackendProcess", () => {
       sessionId: "s1",
       toolCall: { toolCallId: "tc1", title: "Read" },
       options: [
+        { optionId: "allow_once", name: "Allow Once", kind: "allow_once" },
+        { optionId: "allow_session", name: "Allow for Session", kind: "allow_always" },
+        {
+          optionId: "allow_host_session",
+          name: "Allow Host for Session",
+          kind: "allow_always",
+        },
+        {
+          optionId: "allow_root_session",
+          name: "Allow Root for Session",
+          kind: "allow_always",
+        },
+        { optionId: "reject_once", name: "No", kind: "reject_once" },
         {
           optionId: "accept_execpolicy_amendment",
           name: commandRule,
           kind: "allow_always",
         },
         {
-          optionId: "accept_networkpolicy_amendment",
+          optionId: "apply_network_policy_amendment:0",
           name: networkRule,
           kind: "allow_always",
         },
@@ -331,13 +344,38 @@ describe("AcpBackendProcess", () => {
     expect(prompt.toolCall.toolCallId).toBe("tc1");
     expect(prompt.options).toEqual([
       {
+        optionId: "allow_once",
+        name: "Allow Once",
+        kind: "allow_once",
+      },
+      {
+        optionId: "allow_session",
+        name: "Allow for Session",
+        kind: "allow_always",
+      },
+      {
+        optionId: "allow_host_session",
+        name: "Allow Host for Session",
+        kind: "allow_always",
+      },
+      {
+        optionId: "allow_root_session",
+        name: "Allow Root for Session",
+        kind: "allow_always",
+      },
+      {
+        optionId: "reject_once",
+        name: "No",
+        kind: "reject_once",
+      },
+      {
         optionId: "accept_execpolicy_amendment",
         name: "Allow Always",
         description: commandRule,
         kind: "allow_always",
       },
       {
-        optionId: "accept_networkpolicy_amendment",
+        optionId: "apply_network_policy_amendment:0",
         name: "Allow Always",
         description: networkRule,
         kind: "allow_always",

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -299,16 +299,29 @@ describe("AcpBackendProcess", () => {
     );
     await backend.start();
 
-    const prompter = jest
-      .fn()
-      .mockResolvedValue({ outcome: { outcome: "selected", optionId: "ok" } });
+    const prompter = jest.fn().mockResolvedValue({
+      outcome: { outcome: "selected", optionId: "accept_execpolicy_amendment" },
+    });
     backend.setPermissionPrompter(prompter);
 
     const client = getVaultClient(backend);
+    const commandRule = "Allow commands matching `/usr/local/bin/search --vault notes`";
+    const networkRule = "Allow network access to api.example.com";
     const req = {
       sessionId: "s1",
       toolCall: { toolCallId: "tc1", title: "Read" },
-      options: [{ optionId: "ok", name: "Allow", kind: "allow_once" }],
+      options: [
+        {
+          optionId: "accept_execpolicy_amendment",
+          name: commandRule,
+          kind: "allow_always",
+        },
+        {
+          optionId: "accept_networkpolicy_amendment",
+          name: networkRule,
+          kind: "allow_always",
+        },
+      ],
     } as unknown as Parameters<typeof client.requestPermission>[0];
     const response = await client.requestPermission(req);
     expect(prompter).toHaveBeenCalledTimes(1);
@@ -316,7 +329,23 @@ describe("AcpBackendProcess", () => {
     const prompt = prompter.mock.calls[0][0];
     expect(prompt.sessionId).toBe("s1");
     expect(prompt.toolCall.toolCallId).toBe("tc1");
-    expect(response).toEqual({ outcome: { outcome: "selected", optionId: "ok" } });
+    expect(prompt.options).toEqual([
+      {
+        optionId: "accept_execpolicy_amendment",
+        name: "Allow Always",
+        description: commandRule,
+        kind: "allow_always",
+      },
+      {
+        optionId: "accept_networkpolicy_amendment",
+        name: "Allow Always",
+        description: networkRule,
+        kind: "allow_always",
+      },
+    ]);
+    expect(response).toEqual({
+      outcome: { outcome: "selected", optionId: "accept_execpolicy_amendment" },
+    });
   });
 
   it("clears connection state on subprocess exit so subsequent ops fail with a clear error", async () => {

--- a/src/agentMode/acp/AcpBackendProcess.ts
+++ b/src/agentMode/acp/AcpBackendProcess.ts
@@ -669,7 +669,12 @@ export class AcpBackendProcess implements BackendProcess {
       logWarn(`[AgentMode] permission requested but no prompter is registered; auto-cancelling`);
       return { outcome: { outcome: "cancelled" } };
     }
-    const decision = await this.permissionPrompter(acpPermissionRequestToPrompt(req));
+    const decision = await this.permissionPrompter(
+      acpPermissionRequestToPrompt(
+        req,
+        (option) => this.descriptor.presentPermissionOption?.(option) ?? option
+      )
+    );
     return decisionToAcpResponse(decision);
   }
 }

--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -449,13 +449,28 @@ function permissionOptionFromAcp(opt: AcpPermissionOption): PermissionOption {
   const kind = (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
     ? opt.kind
     : "reject_once";
-  const name = permissionOptionActionName(kind);
+  if (!isPolicyAmendmentOption(opt.optionId)) {
+    return {
+      optionId: opt.optionId,
+      name: opt.name,
+      kind,
+    };
+  }
+
   return {
     optionId: opt.optionId,
-    name,
-    description: opt.name === name ? undefined : opt.name,
+    name: permissionOptionActionName(kind),
+    description: opt.name,
     kind,
   };
+}
+
+function isPolicyAmendmentOption(optionId: string): boolean {
+  // Codex policy amendments use ACP's name field for rule prose rather than an action label.
+  return (
+    optionId === "accept_execpolicy_amendment" ||
+    /^apply_network_policy_amendment:\d+$/.test(optionId)
+  );
 }
 
 function permissionOptionActionName(kind: PermissionOptionKind): string {

--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -41,6 +41,7 @@ import type {
   McpServerSpec,
   PermissionDecision,
   PermissionOption,
+  PermissionOptionKind,
   PermissionPrompt,
   PromptContent,
   SessionEvent,
@@ -445,13 +446,29 @@ export function acpPermissionRequestToPrompt(req: RequestPermissionRequest): Per
 }
 
 function permissionOptionFromAcp(opt: AcpPermissionOption): PermissionOption {
+  const kind = (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
+    ? opt.kind
+    : "reject_once";
+  const name = permissionOptionActionName(kind);
   return {
     optionId: opt.optionId,
-    name: opt.name,
-    kind: (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
-      ? opt.kind
-      : "reject_once",
+    name,
+    description: opt.name === name ? undefined : opt.name,
+    kind,
   };
+}
+
+function permissionOptionActionName(kind: PermissionOptionKind): string {
+  switch (kind) {
+    case "allow_once":
+      return "Allow";
+    case "allow_always":
+      return "Allow Always";
+    case "reject_once":
+      return "Reject";
+    case "reject_always":
+      return "Block Rule";
+  }
 }
 
 export function permissionPromptToAcp(prompt: PermissionPrompt): RequestPermissionRequest {
@@ -466,7 +483,7 @@ export function permissionPromptToAcp(prompt: PermissionPrompt): RequestPermissi
     },
     options: prompt.options.map((o) => ({
       optionId: o.optionId,
-      name: o.name,
+      name: o.description ?? o.name,
       kind: o.kind,
     })),
   };

--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -41,7 +41,6 @@ import type {
   McpServerSpec,
   PermissionDecision,
   PermissionOption,
-  PermissionOptionKind,
   PermissionPrompt,
   PromptContent,
   SessionEvent,
@@ -428,7 +427,16 @@ function acpUpdateToSessionUpdate(update: SessionNotification["update"]): Sessio
 
 // ---- Permission prompt / decision -------------------------------------
 
-export function acpPermissionRequestToPrompt(req: RequestPermissionRequest): PermissionPrompt {
+/**
+ * Convert an ACP permission request into the session-domain prompt.
+ *
+ * @param req - The request emitted by the ACP backend.
+ * @param presentPermissionOption - Optional backend-owned presentation adapter.
+ */
+export function acpPermissionRequestToPrompt(
+  req: RequestPermissionRequest,
+  presentPermissionOption?: (option: PermissionOption) => PermissionOption
+): PermissionPrompt {
   const call = req.toolCall;
   return {
     sessionId: sessionIdFromAcp(req.sessionId),
@@ -441,49 +449,22 @@ export function acpPermissionRequestToPrompt(req: RequestPermissionRequest): Per
       content: toolCallContentFromAcp(call.content),
       locations: call.locations?.map((l) => ({ path: l.path, line: l.line ?? undefined })),
     },
-    options: req.options.map(permissionOptionFromAcp),
+    options: req.options.map((option) => permissionOptionFromAcp(option, presentPermissionOption)),
   };
 }
 
-function permissionOptionFromAcp(opt: AcpPermissionOption): PermissionOption {
-  const kind = (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
-    ? opt.kind
-    : "reject_once";
-  if (!isPolicyAmendmentOption(opt.optionId)) {
-    return {
-      optionId: opt.optionId,
-      name: opt.name,
-      kind,
-    };
-  }
-
-  return {
+function permissionOptionFromAcp(
+  opt: AcpPermissionOption,
+  presentPermissionOption?: (option: PermissionOption) => PermissionOption
+): PermissionOption {
+  const option: PermissionOption = {
     optionId: opt.optionId,
-    name: permissionOptionActionName(kind),
-    description: opt.name,
-    kind,
+    name: opt.name,
+    kind: (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
+      ? opt.kind
+      : "reject_once",
   };
-}
-
-function isPolicyAmendmentOption(optionId: string): boolean {
-  // Codex policy amendments use ACP's name field for rule prose rather than an action label.
-  return (
-    optionId === "accept_execpolicy_amendment" ||
-    /^apply_network_policy_amendment:\d+$/.test(optionId)
-  );
-}
-
-function permissionOptionActionName(kind: PermissionOptionKind): string {
-  switch (kind) {
-    case "allow_once":
-      return "Allow";
-    case "allow_always":
-      return "Allow Always";
-    case "reject_once":
-      return "Reject";
-    case "reject_always":
-      return "Block Rule";
-  }
+  return presentPermissionOption?.(option) ?? option;
 }
 
 export function permissionPromptToAcp(prompt: PermissionPrompt): RequestPermissionRequest {

--- a/src/agentMode/backends/codex/descriptor.test.ts
+++ b/src/agentMode/backends/codex/descriptor.test.ts
@@ -24,15 +24,33 @@ describe("descriptor", () => {
         });
       });
 
-      it("leaves ordinary Codex permission labels unchanged", () => {
+      it("uses block language for a persistent network rejection", () => {
         const option: PermissionOption = {
-          optionId: "allow_host_session",
-          name: "Allow Host for Session",
-          kind: "allow_always",
+          optionId: "apply_network_policy_amendment:3",
+          name: "Block api.example.com in the Future",
+          kind: "reject_always",
         };
 
-        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toBe(option);
+        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toEqual({
+          optionId: "apply_network_policy_amendment:3",
+          name: "Block Always",
+          description: "Block api.example.com in the Future",
+          kind: "reject_always",
+        });
       });
+
+      it.each(["allow_host_session", "apply_network_policy_amendment:not-an-index"])(
+        "leaves the ordinary or near-match label for %s unchanged",
+        (optionId) => {
+          const option: PermissionOption = {
+            optionId,
+            name: "Allow Host for Session",
+            kind: "allow_always",
+          };
+
+          expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toBe(option);
+        }
+      );
     });
   });
 });

--- a/src/agentMode/backends/codex/descriptor.test.ts
+++ b/src/agentMode/backends/codex/descriptor.test.ts
@@ -1,0 +1,38 @@
+import type { PermissionOption } from "@/agentMode/session/types";
+import { CodexBackendDescriptor } from "./descriptor";
+
+describe("descriptor", () => {
+  describe("CodexBackendDescriptor", () => {
+    describe("presentPermissionOption()", () => {
+      it.each([
+        "accept_execpolicy_amendment",
+        "apply_network_policy_amendment:0",
+        "apply_network_policy_amendment:12",
+      ])("separates the Codex policy rule for %s", (optionId) => {
+        const rule = "Allow network access to api.example.com";
+        const option: PermissionOption = {
+          optionId,
+          name: rule,
+          kind: "allow_always",
+        };
+
+        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toEqual({
+          optionId,
+          name: "Allow Always",
+          description: rule,
+          kind: "allow_always",
+        });
+      });
+
+      it("leaves ordinary Codex permission labels unchanged", () => {
+        const option: PermissionOption = {
+          optionId: "allow_host_session",
+          name: "Allow Host for Session",
+          kind: "allow_always",
+        };
+
+        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toBe(option);
+      });
+    });
+  });
+});

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -17,7 +17,12 @@ import {
   binaryPathInstallState,
   simpleBinaryBackendProcess,
 } from "@/agentMode/backends/shared/simpleBinaryBackend";
-import type { EnabledModelEntry, ModelSelection, ModelWireCodec } from "@/agentMode/session/types";
+import type {
+  EnabledModelEntry,
+  ModelSelection,
+  ModelWireCodec,
+  PermissionOption,
+} from "@/agentMode/session/types";
 import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
 import { detectBinary } from "@/utils/detectBinary";
 import { codexAcpSearchDirs, resolveCodexAcpBinary } from "./codexBinaryResolver";
@@ -130,6 +135,20 @@ export const CodexBackendDescriptor: BackendDescriptor = {
    */
   normalizeModelName(name: string): string {
     return name.replace(/^gpt/i, "GPT");
+  },
+
+  presentPermissionOption(option: PermissionOption): PermissionOption {
+    if (
+      option.optionId !== "accept_execpolicy_amendment" &&
+      !/^apply_network_policy_amendment:\d+$/.test(option.optionId)
+    ) {
+      return option;
+    }
+    return {
+      ...option,
+      name: "Allow Always",
+      description: option.name,
+    };
   },
 
   getInstallState(settings: CopilotSettings): InstallState {

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -146,7 +146,7 @@ export const CodexBackendDescriptor: BackendDescriptor = {
     }
     return {
       ...option,
-      name: "Allow Always",
+      name: option.kind === "reject_always" ? "Block Always" : "Allow Always",
       description: option.name,
     };
   },

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -13,6 +13,7 @@ import type {
   ModelState,
   ModelWireCodec,
   ModeMapping,
+  PermissionOption,
   RawModeState,
   SessionId,
 } from "./types";
@@ -248,6 +249,15 @@ export interface BackendDescriptor {
    * reports (`gpt-5.4` → `GPT-5.4`); most backends omit it.
    */
   normalizeModelName?(name: string): string;
+
+  /**
+   * Optional: adapt a backend-native permission option for generic UI
+   * presentation. The option id remains the backend's executable decision;
+   * backends may separate wire-level rule prose from a compact action label.
+   *
+   * @param option - The neutral permission option produced at the backend boundary.
+   */
+  presentPermissionOption?(option: PermissionOption): PermissionOption;
 
   /**
    * Opt in to surfacing this backend's per-model `description` as the row

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -564,7 +564,10 @@ export const PERMISSION_REJECT_KINDS: readonly PermissionOptionKind[] = [
 /** Single option carried in a `PermissionPrompt`. */
 export interface PermissionOption {
   optionId: string;
+  /** Compact action text suitable for a permission button. */
   name: string;
+  /** Option-specific context shown next to the matching action. */
+  description?: string;
   kind: PermissionOptionKind;
 }
 

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -1,0 +1,111 @@
+import type { PermissionOption, PermissionPrompt, SessionId } from "@/agentMode/session/types";
+import { ToolPermissionCard } from "@/agentMode/ui/ToolPermissionCard";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const SESSION_ID = "session-1" as SessionId;
+const TOOL_CALL_ID = "tool-1";
+
+function makeRequest(options: PermissionOption[]): PermissionPrompt {
+  return {
+    sessionId: SESSION_ID,
+    toolCall: {
+      toolCallId: TOOL_CALL_ID,
+      title: "Tool call",
+      kind: "execute",
+      status: "pending",
+      rawInput: { command: "search" },
+    },
+    options,
+  };
+}
+
+describe("ToolPermissionCard module", () => {
+  describe("ToolPermissionCard", () => {
+    it("uses a fixed action label and presents a long option name as its description", () => {
+      const onResolve = jest.fn();
+      const longName =
+        "Allow Commands Starting With `/long/path/semantic-search.sh Search only within agents/themes/capture for LLM wiki, AI second brain, knowledge base, digital twin, and local-first Markdown knowledge workspace.`";
+
+      render(
+        <ToolPermissionCard
+          request={makeRequest([
+            { optionId: "allow_once", name: "Allow Once", kind: "allow_once" },
+            { optionId: "allow_always", name: "Allow for Session", kind: "allow_always" },
+            {
+              optionId: "accept_execpolicy_amendment",
+              name: longName,
+              kind: "allow_always",
+            },
+            { optionId: "reject_once", name: "Reject", kind: "reject_once" },
+          ])}
+          onResolve={onResolve}
+        />
+      );
+
+      expect(screen.queryByRole("button", { name: longName })).toBeNull();
+      const ruleButton = screen.getByRole("button", {
+        name: "Allow Always",
+        description: longName,
+      });
+      expect(screen.getByText(longName)).not.toBe(ruleButton);
+
+      fireEvent.click(ruleButton);
+      expect(onResolve).toHaveBeenCalledWith(TOOL_CALL_ID, "accept_execpolicy_amendment");
+    });
+
+    it("uses semantic fixed labels for every kind of descriptive option", () => {
+      const options: PermissionOption[] = [
+        {
+          optionId: "once",
+          name: "Allow this individual permission request after reviewing all of its details",
+          kind: "allow_once",
+        },
+        {
+          optionId: "always",
+          name: "Allow this permission rule for later matching tool calls in the session",
+          kind: "allow_always",
+        },
+        {
+          optionId: "reject",
+          name: "Reject this individual permission request after reviewing all of its details",
+          kind: "reject_once",
+        },
+        {
+          optionId: "block",
+          name: "Block this permission rule for later matching tool calls in the session",
+          kind: "reject_always",
+        },
+      ];
+
+      render(<ToolPermissionCard request={makeRequest(options)} onResolve={jest.fn()} />);
+
+      const expectedLabels = ["Allow", "Allow Always", "Reject", "Block Rule"];
+      for (const [index, label] of expectedLabels.entries()) {
+        expect(
+          screen.getByRole("button", { name: label, description: options[index].name })
+        ).toBeTruthy();
+      }
+    });
+
+    it("keeps compact backend labels and orders them by permission kind", () => {
+      render(
+        <ToolPermissionCard
+          request={makeRequest([
+            { optionId: "reject", name: "No", kind: "reject_once" },
+            { optionId: "session", name: "Allow for Session", kind: "allow_always" },
+            { optionId: "once", name: "Allow Once", kind: "allow_once" },
+          ])}
+          onResolve={jest.fn()}
+        />
+      );
+
+      expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual([
+        "Allow Once",
+        "Allow for Session",
+        "No",
+      ]);
+      expect(screen.queryByText("Permission details")).toBeNull();
+    });
+  });
+});

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -85,8 +85,8 @@ describe("ToolPermissionCard", () => {
       expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "accept_execpolicy_amendment");
     });
 
-    it("orders compact actions by kind and constrains their labels to the card width", () => {
-      const unbrokenLabel = "AllowAccessToNetwork.example.com";
+    it("orders compact actions by kind and makes unbroken labels shrinkable", () => {
+      const unbrokenLabel = "AllowAccessToNetwork.example.com".repeat(8);
       render(
         <ToolPermissionCard
           request={makeRequest([
@@ -103,10 +103,15 @@ describe("ToolPermissionCard", () => {
         "Allow for Session",
         "No",
       ]);
-      const labelClasses = screen.getByRole("button", { name: unbrokenLabel }).classList;
-      expect(labelClasses.contains("tw-max-w-full")).toBe(true);
-      expect(labelClasses.contains("tw-whitespace-normal")).toBe(true);
-      expect(labelClasses.contains("tw-break-words")).toBe(true);
+      const button = screen.getByRole("button", { name: unbrokenLabel });
+      expect(button.classList.contains("tw-max-w-full")).toBe(true);
+      expect(button.classList.contains("tw-min-w-0")).toBe(true);
+      expect(button.firstElementChild).toMatchObject({
+        tagName: "SPAN",
+        textContent: unbrokenLabel,
+      });
+      expect(button.firstElementChild?.classList.contains("tw-min-w-0")).toBe(true);
+      expect(button.firstElementChild?.classList.contains("tw-break-all")).toBe(true);
     });
   });
 });

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -26,8 +26,7 @@ describe("ToolPermissionCard", () => {
       const onResolve = jest.fn();
       const commandRule =
         "Allow Commands Starting With `/long/path/semantic-search.sh Search only within agents/themes/capture for LLM wiki, AI second brain, knowledge base, digital twin, and local-first Markdown knowledge workspace.`";
-      const networkRule =
-        "Allow network access to a.really-long-and-specific-subdomain.example.com for future matching requests.";
+      const networkRule = "Block a.really-long-and-specific-subdomain.example.com in the Future";
       const options: PermissionOption[] = [
         {
           optionId: "accept_execpolicy_amendment",
@@ -37,9 +36,9 @@ describe("ToolPermissionCard", () => {
         },
         {
           optionId: "apply_network_policy_amendment:0",
-          name: "Allow Always",
+          name: "Block Always",
           description: networkRule,
-          kind: "allow_always",
+          kind: "reject_always",
         },
       ];
 
@@ -61,10 +60,11 @@ describe("ToolPermissionCard", () => {
         description: commandRule,
       });
       const networkButton = within(networkRow!).getByRole("button", {
-        name: "Allow Always",
+        name: "Block Always",
         description: networkRule,
       });
       expect(commandButton.textContent).toBe("Allow Always");
+      expect(networkButton.textContent).toBe("Block Always");
 
       fireEvent.click(networkButton);
       expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "apply_network_policy_amendment:0");

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -36,7 +36,7 @@ describe("ToolPermissionCard", () => {
           kind: "allow_always",
         },
         {
-          optionId: "accept_networkpolicy_amendment",
+          optionId: "apply_network_policy_amendment:0",
           name: "Allow Always",
           description: networkRule,
           kind: "allow_always",
@@ -67,7 +67,7 @@ describe("ToolPermissionCard", () => {
       expect(commandButton.textContent).toBe("Allow Always");
 
       fireEvent.click(networkButton);
-      expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "accept_networkpolicy_amendment");
+      expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "apply_network_policy_amendment:0");
 
       rerender(
         <ToolPermissionCard

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -1,6 +1,6 @@
 import type { PermissionOption, PermissionPrompt, SessionId } from "@/agentMode/session/types";
 import { ToolPermissionCard } from "@/agentMode/ui/ToolPermissionCard";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import React from "react";
 
 const SESSION_ID = "session-1" as SessionId;
@@ -20,92 +20,93 @@ function makeRequest(options: PermissionOption[]): PermissionPrompt {
   };
 }
 
-describe("ToolPermissionCard module", () => {
-  describe("ToolPermissionCard", () => {
-    it("uses a fixed action label and presents a long option name as its description", () => {
+describe("ToolPermissionCard", () => {
+  describe("ToolPermissionCard()", () => {
+    it("keeps multiple described actions visibly paired with their respective decisions", () => {
       const onResolve = jest.fn();
-      const longName =
+      const commandRule =
         "Allow Commands Starting With `/long/path/semantic-search.sh Search only within agents/themes/capture for LLM wiki, AI second brain, knowledge base, digital twin, and local-first Markdown knowledge workspace.`";
+      const networkRule =
+        "Allow network access to a.really-long-and-specific-subdomain.example.com for future matching requests.";
+      const options: PermissionOption[] = [
+        {
+          optionId: "accept_execpolicy_amendment",
+          name: "Allow Always",
+          description: commandRule,
+          kind: "allow_always",
+        },
+        {
+          optionId: "accept_networkpolicy_amendment",
+          name: "Allow Always",
+          description: networkRule,
+          kind: "allow_always",
+        },
+      ];
 
-      render(
+      const { rerender } = render(
         <ToolPermissionCard
-          request={makeRequest([
-            { optionId: "allow_once", name: "Allow Once", kind: "allow_once" },
-            { optionId: "allow_always", name: "Allow for Session", kind: "allow_always" },
-            {
-              optionId: "accept_execpolicy_amendment",
-              name: longName,
-              kind: "allow_always",
-            },
-            { optionId: "reject_once", name: "Reject", kind: "reject_once" },
-          ])}
+          key="first-decision"
+          request={makeRequest(options)}
           onResolve={onResolve}
         />
       );
 
-      expect(screen.queryByRole("button", { name: longName })).toBeNull();
-      const ruleButton = screen.getByRole("button", {
+      const commandRow = screen.getByText(commandRule).parentElement;
+      const networkRow = screen.getByText(networkRule).parentElement;
+      expect(commandRow).not.toBeNull();
+      expect(networkRow).not.toBeNull();
+
+      const commandButton = within(commandRow!).getByRole("button", {
         name: "Allow Always",
-        description: longName,
+        description: commandRule,
       });
-      expect(screen.getByText(longName)).not.toBe(ruleButton);
+      const networkButton = within(networkRow!).getByRole("button", {
+        name: "Allow Always",
+        description: networkRule,
+      });
+      expect(commandButton.textContent).toBe("Allow Always");
 
-      fireEvent.click(ruleButton);
-      expect(onResolve).toHaveBeenCalledWith(TOOL_CALL_ID, "accept_execpolicy_amendment");
+      fireEvent.click(networkButton);
+      expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "accept_networkpolicy_amendment");
+
+      rerender(
+        <ToolPermissionCard
+          key="second-decision"
+          request={makeRequest(options)}
+          onResolve={onResolve}
+        />
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Allow Always",
+          description: commandRule,
+        })
+      );
+      expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "accept_execpolicy_amendment");
     });
 
-    it("uses semantic fixed labels for every kind of descriptive option", () => {
-      const options: PermissionOption[] = [
-        {
-          optionId: "once",
-          name: "Allow this individual permission request after reviewing all of its details",
-          kind: "allow_once",
-        },
-        {
-          optionId: "always",
-          name: "Allow this permission rule for later matching tool calls in the session",
-          kind: "allow_always",
-        },
-        {
-          optionId: "reject",
-          name: "Reject this individual permission request after reviewing all of its details",
-          kind: "reject_once",
-        },
-        {
-          optionId: "block",
-          name: "Block this permission rule for later matching tool calls in the session",
-          kind: "reject_always",
-        },
-      ];
-
-      render(<ToolPermissionCard request={makeRequest(options)} onResolve={jest.fn()} />);
-
-      const expectedLabels = ["Allow", "Allow Always", "Reject", "Block Rule"];
-      for (const [index, label] of expectedLabels.entries()) {
-        expect(
-          screen.getByRole("button", { name: label, description: options[index].name })
-        ).toBeTruthy();
-      }
-    });
-
-    it("keeps compact backend labels and orders them by permission kind", () => {
+    it("orders compact actions by kind and constrains their labels to the card width", () => {
+      const unbrokenLabel = "AllowAccessToNetwork.example.com";
       render(
         <ToolPermissionCard
           request={makeRequest([
             { optionId: "reject", name: "No", kind: "reject_once" },
             { optionId: "session", name: "Allow for Session", kind: "allow_always" },
-            { optionId: "once", name: "Allow Once", kind: "allow_once" },
+            { optionId: "once", name: unbrokenLabel, kind: "allow_once" },
           ])}
           onResolve={jest.fn()}
         />
       );
 
       expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual([
-        "Allow Once",
+        unbrokenLabel,
         "Allow for Session",
         "No",
       ]);
-      expect(screen.queryByText("Permission details")).toBeNull();
+      const labelClasses = screen.getByRole("button", { name: unbrokenLabel }).classList;
+      expect(labelClasses.contains("tw-max-w-full")).toBe(true);
+      expect(labelClasses.contains("tw-whitespace-normal")).toBe(true);
+      expect(labelClasses.contains("tw-break-words")).toBe(true);
     });
   });
 });

--- a/src/agentMode/ui/ToolPermissionCard.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.tsx
@@ -14,10 +14,6 @@ interface ToolPermissionCardProps {
   onResolve: (toolCallId: string, optionId: string) => void;
 }
 
-// ACP provides one name field, so adapters sometimes place a full permission
-// rule there even though the same value must also identify the action.
-const MAX_PERMISSION_BUTTON_LABEL_LENGTH = 32;
-
 /**
  * Inline permission card rendered at the tail of the chat scroll container
  * while a tool call is awaiting the user's decision. Replaces the modal that
@@ -26,10 +22,9 @@ const MAX_PERMISSION_BUTTON_LABEL_LENGTH = 32;
  * sessions. The card stays in-place until the user picks an option or the
  * turn is cancelled.
  *
- * The actual SDK permission update (allow_once / allow_always /
- * reject_once / reject_always semantics, including the
- * `updatedPermissions` payload for "always" choices) is handled in
- * `mapDecisionToSdk` — this component just forwards the chosen `optionId`.
+ * The backend translates one-time and persistent decisions from the selected
+ * `optionId`; this component only displays the domain prompt and forwards that
+ * identifier.
  */
 export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request, onResolve }) => {
   const { toolCall, options } = request;
@@ -86,62 +81,48 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
             </pre>
           </details>
         ) : null}
-
-        {orderedOptions.some(isDescriptiveOption) ? (
-          <div className="tw-flex tw-min-w-0 tw-flex-col tw-gap-1 tw-rounded tw-bg-primary tw-p-2">
-            <p className="tw-m-0 tw-text-xs tw-font-medium">Permission details</p>
-            {orderedOptions.map((option, index) =>
-              isDescriptiveOption(option) ? (
-                <p
-                  key={option.optionId}
-                  id={`${descriptionIdPrefix}-${index}`}
-                  className="tw-m-0 tw-min-w-0 tw-break-words tw-text-xs tw-text-muted"
-                >
-                  {option.name}
-                </p>
-              ) : null
-            )}
-          </div>
-        ) : null}
       </div>
 
       <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2 tw-border-t tw-border-solid tw-border-border tw-px-3 tw-py-2">
         {orderedOptions.map((option, index) => {
-          const descriptive = isDescriptiveOption(option);
-          return (
+          const descriptionId = `${descriptionIdPrefix}-${index}`;
+          const button = (
             <Button
               key={option.optionId}
               variant={variantForKind(option.kind)}
               size="sm"
+              className="tw-h-auto tw-min-h-6 tw-max-w-full tw-whitespace-normal tw-break-words"
               disabled={busy}
-              aria-describedby={descriptive ? `${descriptionIdPrefix}-${index}` : undefined}
+              aria-describedby={option.description ? descriptionId : undefined}
               onClick={() => choose(option.optionId)}
             >
-              {descriptive ? descriptiveOptionButtonLabel(option.kind) : option.name}
+              {option.name}
             </Button>
           );
+
+          if (option.description) {
+            return (
+              <div
+                key={option.optionId}
+                className="tw-flex tw-w-full tw-min-w-0 tw-flex-col tw-items-start tw-gap-2 tw-rounded tw-bg-primary tw-p-2"
+              >
+                <p
+                  id={descriptionId}
+                  className="tw-m-0 tw-w-full tw-min-w-0 tw-break-words tw-text-xs tw-text-muted"
+                >
+                  {option.description}
+                </p>
+                <div className="tw-flex tw-w-full tw-justify-end">{button}</div>
+              </div>
+            );
+          }
+
+          return button;
         })}
       </div>
     </div>
   );
 };
-
-function isDescriptiveOption(option: PermissionOption): boolean {
-  return option.name.length > MAX_PERMISSION_BUTTON_LABEL_LENGTH;
-}
-
-function descriptiveOptionButtonLabel(kind: PermissionOptionKind): string {
-  switch (kind) {
-    case "allow_once":
-      return "Allow";
-    case "allow_always":
-      return "Allow Always";
-    case "reject_once":
-      return "Reject";
-    case "reject_always":
-      return "Block Rule";
-  }
-}
 
 /**
  * Map `PermissionOptionKind` to a Button variant. "Once" actions stay neutral

--- a/src/agentMode/ui/ToolPermissionCard.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.tsx
@@ -91,12 +91,12 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
               key={option.optionId}
               variant={variantForKind(option.kind)}
               size="sm"
-              className="tw-h-auto tw-min-h-6 tw-max-w-full tw-whitespace-normal tw-break-words"
+              className="tw-h-auto tw-min-h-6 tw-min-w-0 tw-max-w-full tw-whitespace-normal"
               disabled={busy}
               aria-describedby={option.description ? descriptionId : undefined}
               onClick={() => choose(option.optionId)}
             >
-              {option.name}
+              <span className="tw-min-w-0 tw-break-all">{option.name}</span>
             </Button>
           );
 
@@ -108,7 +108,7 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
               >
                 <p
                   id={descriptionId}
-                  className="tw-m-0 tw-w-full tw-min-w-0 tw-break-words tw-text-xs tw-text-muted"
+                  className="tw-m-0 tw-w-full tw-min-w-0 tw-break-all tw-text-xs tw-text-muted"
                 >
                   {option.description}
                 </p>

--- a/src/agentMode/ui/ToolPermissionCard.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.tsx
@@ -7,12 +7,16 @@ import type {
 } from "@/agentMode/session/types";
 import { PERMISSION_OPTION_KINDS } from "@/agentMode/session/types";
 import { ShieldQuestion } from "lucide-react";
-import React, { useMemo, useState } from "react";
+import React, { useId, useMemo, useState } from "react";
 
 interface ToolPermissionCardProps {
   request: PermissionPrompt;
   onResolve: (toolCallId: string, optionId: string) => void;
 }
+
+// ACP provides one name field, so adapters sometimes place a full permission
+// rule there even though the same value must also identify the action.
+const MAX_PERMISSION_BUTTON_LABEL_LENGTH = 32;
 
 /**
  * Inline permission card rendered at the tail of the chat scroll container
@@ -31,6 +35,7 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
   const { toolCall, options } = request;
   const [busy, setBusy] = useState(false);
   const orderedOptions = useMemo(() => sortOptions(options), [options]);
+  const descriptionIdPrefix = useId();
   const diffContents = useMemo(() => extractDiffContents(toolCall.content), [toolCall.content]);
   const inputJson = useMemo(() => formatAgentInput(toolCall.rawInput), [toolCall.rawInput]);
   const title = toolCall.title ?? "Tool call";
@@ -81,24 +86,62 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
             </pre>
           </details>
         ) : null}
+
+        {orderedOptions.some(isDescriptiveOption) ? (
+          <div className="tw-flex tw-min-w-0 tw-flex-col tw-gap-1 tw-rounded tw-bg-primary tw-p-2">
+            <p className="tw-m-0 tw-text-xs tw-font-medium">Permission details</p>
+            {orderedOptions.map((option, index) =>
+              isDescriptiveOption(option) ? (
+                <p
+                  key={option.optionId}
+                  id={`${descriptionIdPrefix}-${index}`}
+                  className="tw-m-0 tw-min-w-0 tw-break-words tw-text-xs tw-text-muted"
+                >
+                  {option.name}
+                </p>
+              ) : null
+            )}
+          </div>
+        ) : null}
       </div>
 
       <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2 tw-border-t tw-border-solid tw-border-border tw-px-3 tw-py-2">
-        {orderedOptions.map((opt) => (
-          <Button
-            key={opt.optionId}
-            variant={variantForKind(opt.kind)}
-            size="sm"
-            disabled={busy}
-            onClick={() => choose(opt.optionId)}
-          >
-            {opt.name}
-          </Button>
-        ))}
+        {orderedOptions.map((option, index) => {
+          const descriptive = isDescriptiveOption(option);
+          return (
+            <Button
+              key={option.optionId}
+              variant={variantForKind(option.kind)}
+              size="sm"
+              disabled={busy}
+              aria-describedby={descriptive ? `${descriptionIdPrefix}-${index}` : undefined}
+              onClick={() => choose(option.optionId)}
+            >
+              {descriptive ? descriptiveOptionButtonLabel(option.kind) : option.name}
+            </Button>
+          );
+        })}
       </div>
     </div>
   );
 };
+
+function isDescriptiveOption(option: PermissionOption): boolean {
+  return option.name.length > MAX_PERMISSION_BUTTON_LABEL_LENGTH;
+}
+
+function descriptiveOptionButtonLabel(kind: PermissionOptionKind): string {
+  switch (kind) {
+    case "allow_once":
+      return "Allow";
+    case "allow_always":
+      return "Allow Always";
+    case "reject_once":
+      return "Reject";
+    case "reject_always":
+      return "Block Rule";
+  }
+}
 
 /**
  * Map `PermissionOptionKind` to a Button variant. "Once" actions stay neutral


### PR DESCRIPTION
## Summary

- preserve compact backend-provided permission labels such as `Allow for Session`
- present recognized Codex policy amendments with fixed polarity-aware actions (`Allow Always` / `Block Always`)
- render each full policy rule beside its own action with overflow-safe wrapping
- keep Codex-specific presentation in the Codex backend descriptor while preserving the original option ID

## Root cause

`ToolPermissionCard` rendered backend-provided permission text directly inside a shared nowrap button. Codex also uses that field for full executable and network policy rules, so the action could grow wider than the permission card and overflow the Agent Mode pane.

## User impact

Long policy rules remain fully visible beside their corresponding compact action, including when multiple rules share the same action kind. Ordinary ACP labels retain their original scope wording, and arbitrary unbroken labels wrap within narrow cards.

## Validation

- focused descriptor, ACP production-path, and permission-card tests
- `npm run format`
- `npm run lint`
- `npm run test -- --runInBand` — 345 suites, 4,893 tests
- `npm run build`
- `git diff --check`
- `npm run test:vault`
- live Obsidian 160px-card check with a repeated unbroken label: zero card/button horizontal overflow
- Node.js CI