### PR TITLE
fix(agent-mode): repair Codex permission prompts

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -37,8 +37,8 @@ The mode picker beside the message box controls how much the active agent can do
 The available modes depend on the selected agent. Copilot normalizes equivalent modes across supported versions of Claude, Codex, and OpenCode.
 
 When **Default** mode asks for permission, the request stays in the chat until
-you choose an action. Detailed permission rules appear in the card body, while
-the buttons keep short action labels.
+you choose an action, cancel the turn, or close the session. Each detailed
+permission rule appears beside its matching short action button.
 
 ### Max Iterations
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -37,8 +37,8 @@ The mode picker beside the message box controls how much the active agent can do
 The available modes depend on the selected agent. Copilot normalizes equivalent modes across supported versions of Claude, Codex, and OpenCode.
 
 When **Default** mode asks for permission, the request stays in the chat until
-you choose an action, cancel the turn, or close the session. Each detailed
-permission rule appears beside its matching short action button.
+you choose an action, cancel the turn, or close the session. Hover or focus a
+persistent action to inspect its detailed permission rule.
 
 ### Max Iterations
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -36,6 +36,10 @@ The mode picker beside the message box controls how much the active agent can do
 
 The available modes depend on the selected agent. Copilot normalizes equivalent modes across supported versions of Claude, Codex, and OpenCode.
 
+When **Default** mode asks for permission, the request stays in the chat until
+you choose an action. Detailed permission rules appear in the card body, while
+the buttons keep short action labels.
+
 ### Max Iterations
 
 The agent works in iteration cycles (think → use a tool → think → use a tool → answer). You can control the maximum number of iterations before the agent stops:

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -291,15 +291,20 @@ describe("AcpBackendProcess", () => {
     expect(response).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
-  it("applies the backend permission presentation hook before delegating", async () => {
-    const presentPermissionOption = jest.fn((option: PermissionOption): PermissionOption => {
-      if (option.optionId !== "backend-policy-rule") return option;
-      return {
-        ...option,
-        name: "Allow Always",
-        description: option.name,
-      };
-    });
+  it("forwards opaque option metadata unchanged to the presentation hook before delegating", async () => {
+    const policyMetadata = {
+      codex: { decision: "acceptWithExecpolicyAmendment" },
+    };
+    const presentPermissionOption = jest.fn(
+      (option: PermissionOption, metadata: unknown): PermissionOption => {
+        if (metadata !== policyMetadata) return option;
+        return {
+          ...option,
+          name: "Allow Always",
+          description: option.name,
+        };
+      }
+    );
     const backend = new AcpBackendProcess(
       buildApp(),
       buildStubBackend(),
@@ -324,11 +329,13 @@ describe("AcpBackendProcess", () => {
           optionId: "backend-policy-rule",
           name: policyRule,
           kind: "allow_always",
+          _meta: policyMetadata,
         },
       ],
     } as unknown as Parameters<typeof client.requestPermission>[0];
     const response = await client.requestPermission(req);
     expect(presentPermissionOption).toHaveBeenCalledTimes(2);
+    expect(presentPermissionOption.mock.calls[1][1]).toBe(policyMetadata);
     expect(prompter).toHaveBeenCalledTimes(1);
     // Prompter receives a session-domain `PermissionPrompt`.
     const prompt = prompter.mock.calls[0][0];

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -1,5 +1,5 @@
 import { FileSystemAdapter, App } from "obsidian";
-import type { BackendDescriptor } from "@/agentMode/session/types";
+import type { BackendDescriptor, PermissionOption } from "@/agentMode/session/types";
 import { AcpBackendProcess } from "./AcpBackendProcess";
 import type { AcpBackend } from "./types";
 import type { VaultClient } from "./VaultClient";
@@ -83,10 +83,11 @@ function buildStubBackend(): AcpBackend {
   };
 }
 
-function buildStubDescriptor(): BackendDescriptor {
+function buildStubDescriptor(overrides: Partial<BackendDescriptor> = {}): BackendDescriptor {
   return {
     id: "opencode",
     displayName: "opencode",
+    ...overrides,
   } as unknown as BackendDescriptor;
 }
 
@@ -290,53 +291,44 @@ describe("AcpBackendProcess", () => {
     expect(response).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
-  it("preserves compact permission labels and separates policy rules before delegating", async () => {
+  it("applies the backend permission presentation hook before delegating", async () => {
+    const presentPermissionOption = jest.fn((option: PermissionOption): PermissionOption => {
+      if (option.optionId !== "backend-policy-rule") return option;
+      return {
+        ...option,
+        name: "Allow Always",
+        description: option.name,
+      };
+    });
     const backend = new AcpBackendProcess(
       buildApp(),
       buildStubBackend(),
       "1.0.0",
-      buildStubDescriptor()
+      buildStubDescriptor({ presentPermissionOption })
     );
     await backend.start();
 
     const prompter = jest.fn().mockResolvedValue({
-      outcome: { outcome: "selected", optionId: "accept_execpolicy_amendment" },
+      outcome: { outcome: "selected", optionId: "backend-policy-rule" },
     });
     backend.setPermissionPrompter(prompter);
 
     const client = getVaultClient(backend);
-    const commandRule = "Allow commands matching `/usr/local/bin/search --vault notes`";
-    const networkRule = "Allow network access to api.example.com";
+    const policyRule = "Allow commands matching `/usr/local/bin/search --vault notes`";
     const req = {
       sessionId: "s1",
       toolCall: { toolCallId: "tc1", title: "Read" },
       options: [
         { optionId: "allow_once", name: "Allow Once", kind: "allow_once" },
-        { optionId: "allow_session", name: "Allow for Session", kind: "allow_always" },
         {
-          optionId: "allow_host_session",
-          name: "Allow Host for Session",
-          kind: "allow_always",
-        },
-        {
-          optionId: "allow_root_session",
-          name: "Allow Root for Session",
-          kind: "allow_always",
-        },
-        { optionId: "reject_once", name: "No", kind: "reject_once" },
-        {
-          optionId: "accept_execpolicy_amendment",
-          name: commandRule,
-          kind: "allow_always",
-        },
-        {
-          optionId: "apply_network_policy_amendment:0",
-          name: networkRule,
+          optionId: "backend-policy-rule",
+          name: policyRule,
           kind: "allow_always",
         },
       ],
     } as unknown as Parameters<typeof client.requestPermission>[0];
     const response = await client.requestPermission(req);
+    expect(presentPermissionOption).toHaveBeenCalledTimes(2);
     expect(prompter).toHaveBeenCalledTimes(1);
     // Prompter receives a session-domain `PermissionPrompt`.
     const prompt = prompter.mock.calls[0][0];
@@ -349,40 +341,14 @@ describe("AcpBackendProcess", () => {
         kind: "allow_once",
       },
       {
-        optionId: "allow_session",
-        name: "Allow for Session",
-        kind: "allow_always",
-      },
-      {
-        optionId: "allow_host_session",
-        name: "Allow Host for Session",
-        kind: "allow_always",
-      },
-      {
-        optionId: "allow_root_session",
-        name: "Allow Root for Session",
-        kind: "allow_always",
-      },
-      {
-        optionId: "reject_once",
-        name: "No",
-        kind: "reject_once",
-      },
-      {
-        optionId: "accept_execpolicy_amendment",
+        optionId: "backend-policy-rule",
         name: "Allow Always",
-        description: commandRule,
-        kind: "allow_always",
-      },
-      {
-        optionId: "apply_network_policy_amendment:0",
-        name: "Allow Always",
-        description: networkRule,
+        description: policyRule,
         kind: "allow_always",
       },
     ]);
     expect(response).toEqual({
-      outcome: { outcome: "selected", optionId: "accept_execpolicy_amendment" },
+      outcome: { outcome: "selected", optionId: "backend-policy-rule" },
     });
   });
 

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -290,7 +290,7 @@ describe("AcpBackendProcess", () => {
     expect(response).toEqual({ outcome: { outcome: "cancelled" } });
   });
 
-  it("delegates to the registered prompter and forwards the response", async () => {
+  it("preserves compact permission labels and separates policy rules before delegating", async () => {
     const backend = new AcpBackendProcess(
       buildApp(),
       buildStubBackend(),
@@ -311,13 +311,26 @@ describe("AcpBackendProcess", () => {
       sessionId: "s1",
       toolCall: { toolCallId: "tc1", title: "Read" },
       options: [
+        { optionId: "allow_once", name: "Allow Once", kind: "allow_once" },
+        { optionId: "allow_session", name: "Allow for Session", kind: "allow_always" },
+        {
+          optionId: "allow_host_session",
+          name: "Allow Host for Session",
+          kind: "allow_always",
+        },
+        {
+          optionId: "allow_root_session",
+          name: "Allow Root for Session",
+          kind: "allow_always",
+        },
+        { optionId: "reject_once", name: "No", kind: "reject_once" },
         {
           optionId: "accept_execpolicy_amendment",
           name: commandRule,
           kind: "allow_always",
         },
         {
-          optionId: "accept_networkpolicy_amendment",
+          optionId: "apply_network_policy_amendment:0",
           name: networkRule,
           kind: "allow_always",
         },
@@ -331,13 +344,38 @@ describe("AcpBackendProcess", () => {
     expect(prompt.toolCall.toolCallId).toBe("tc1");
     expect(prompt.options).toEqual([
       {
+        optionId: "allow_once",
+        name: "Allow Once",
+        kind: "allow_once",
+      },
+      {
+        optionId: "allow_session",
+        name: "Allow for Session",
+        kind: "allow_always",
+      },
+      {
+        optionId: "allow_host_session",
+        name: "Allow Host for Session",
+        kind: "allow_always",
+      },
+      {
+        optionId: "allow_root_session",
+        name: "Allow Root for Session",
+        kind: "allow_always",
+      },
+      {
+        optionId: "reject_once",
+        name: "No",
+        kind: "reject_once",
+      },
+      {
         optionId: "accept_execpolicy_amendment",
         name: "Allow Always",
         description: commandRule,
         kind: "allow_always",
       },
       {
-        optionId: "accept_networkpolicy_amendment",
+        optionId: "apply_network_policy_amendment:0",
         name: "Allow Always",
         description: networkRule,
         kind: "allow_always",

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -299,16 +299,29 @@ describe("AcpBackendProcess", () => {
     );
     await backend.start();
 
-    const prompter = jest
-      .fn()
-      .mockResolvedValue({ outcome: { outcome: "selected", optionId: "ok" } });
+    const prompter = jest.fn().mockResolvedValue({
+      outcome: { outcome: "selected", optionId: "accept_execpolicy_amendment" },
+    });
     backend.setPermissionPrompter(prompter);
 
     const client = getVaultClient(backend);
+    const commandRule = "Allow commands matching `/usr/local/bin/search --vault notes`";
+    const networkRule = "Allow network access to api.example.com";
     const req = {
       sessionId: "s1",
       toolCall: { toolCallId: "tc1", title: "Read" },
-      options: [{ optionId: "ok", name: "Allow", kind: "allow_once" }],
+      options: [
+        {
+          optionId: "accept_execpolicy_amendment",
+          name: commandRule,
+          kind: "allow_always",
+        },
+        {
+          optionId: "accept_networkpolicy_amendment",
+          name: networkRule,
+          kind: "allow_always",
+        },
+      ],
     } as unknown as Parameters<typeof client.requestPermission>[0];
     const response = await client.requestPermission(req);
     expect(prompter).toHaveBeenCalledTimes(1);
@@ -316,7 +329,23 @@ describe("AcpBackendProcess", () => {
     const prompt = prompter.mock.calls[0][0];
     expect(prompt.sessionId).toBe("s1");
     expect(prompt.toolCall.toolCallId).toBe("tc1");
-    expect(response).toEqual({ outcome: { outcome: "selected", optionId: "ok" } });
+    expect(prompt.options).toEqual([
+      {
+        optionId: "accept_execpolicy_amendment",
+        name: "Allow Always",
+        description: commandRule,
+        kind: "allow_always",
+      },
+      {
+        optionId: "accept_networkpolicy_amendment",
+        name: "Allow Always",
+        description: networkRule,
+        kind: "allow_always",
+      },
+    ]);
+    expect(response).toEqual({
+      outcome: { outcome: "selected", optionId: "accept_execpolicy_amendment" },
+    });
   });
 
   it("clears connection state on subprocess exit so subsequent ops fail with a clear error", async () => {

--- a/src/agentMode/acp/AcpBackendProcess.ts
+++ b/src/agentMode/acp/AcpBackendProcess.ts
@@ -672,7 +672,7 @@ export class AcpBackendProcess implements BackendProcess {
     const decision = await this.permissionPrompter(
       acpPermissionRequestToPrompt(
         req,
-        (option) => this.descriptor.presentPermissionOption?.(option) ?? option
+        (option, metadata) => this.descriptor.presentPermissionOption?.(option, metadata) ?? option
       )
     );
     return decisionToAcpResponse(decision);

--- a/src/agentMode/acp/AcpBackendProcess.ts
+++ b/src/agentMode/acp/AcpBackendProcess.ts
@@ -669,7 +669,12 @@ export class AcpBackendProcess implements BackendProcess {
       logWarn(`[AgentMode] permission requested but no prompter is registered; auto-cancelling`);
       return { outcome: { outcome: "cancelled" } };
     }
-    const decision = await this.permissionPrompter(acpPermissionRequestToPrompt(req));
+    const decision = await this.permissionPrompter(
+      acpPermissionRequestToPrompt(
+        req,
+        (option) => this.descriptor.presentPermissionOption?.(option) ?? option
+      )
+    );
     return decisionToAcpResponse(decision);
   }
 }

--- a/src/agentMode/acp/wireTranslate.test.ts
+++ b/src/agentMode/acp/wireTranslate.test.ts
@@ -1,5 +1,6 @@
-import type { SessionNotification } from "@agentclientprotocol/sdk";
-import { acpNotificationToEvents } from "./wireTranslate";
+import type { RequestPermissionRequest, SessionNotification } from "@agentclientprotocol/sdk";
+import type { PermissionOption } from "@/agentMode/session/types";
+import { acpNotificationToEvents, acpPermissionRequestToPrompt } from "./wireTranslate";
 
 const SESSION_ID = "sess-1";
 
@@ -13,7 +14,7 @@ const VALID_TODOS = [
   { content: "Review and polish", status: "pending", priority: "medium" },
 ];
 
-describe("acpNotificationToEvents — todowrite → synthesized plan", () => {
+const testAcpNotificationToEvents = () => {
   it("appends a plan event after a todowrite tool_call carrying rawInput.todos", () => {
     const events = acpNotificationToEvents(
       notification({
@@ -181,36 +182,92 @@ describe("acpNotificationToEvents — todowrite → synthesized plan", () => {
       entries: [{ content: "step", status: "pending", priority: "medium" }],
     });
   });
-});
-
-describe("acpNotificationToEvents — usage_update → SessionUsage", () => {
-  const FIXED_NOW = 1_700_000_000_000;
-  let nowSpy: jest.SpyInstance;
-
-  beforeEach(() => {
-    nowSpy = jest.spyOn(Date, "now").mockReturnValue(FIXED_NOW);
-  });
-  afterEach(() => nowSpy.mockRestore());
 
   it("maps size→contextWindow and used→usedTokens, ignoring any cost", () => {
-    const events = acpNotificationToEvents(
-      notification({
+    const fixedNow = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(fixedNow);
+    try {
+      const events = acpNotificationToEvents(
+        notification({
+          sessionUpdate: "usage_update",
+          size: 200_000,
+          used: 42_000,
+          // cost is no longer part of the usage model — it must be dropped.
+          cost: { amount: 0.1234, currency: "USD" },
+        })
+      );
+      expect(events).toHaveLength(1);
+      expect(events[0].sessionId).toBe(SESSION_ID);
+      expect(events[0].update).toEqual({
         sessionUpdate: "usage_update",
-        size: 200_000,
-        used: 42_000,
-        // cost is no longer part of the usage model — it must be dropped.
-        cost: { amount: 0.1234, currency: "USD" },
-      })
-    );
-    expect(events).toHaveLength(1);
-    expect(events[0].sessionId).toBe(SESSION_ID);
-    expect(events[0].update).toEqual({
-      sessionUpdate: "usage_update",
-      usage: {
-        usedTokens: 42_000,
-        contextWindow: 200_000,
-        updatedAt: FIXED_NOW,
-      },
-    });
+        usage: {
+          usedTokens: 42_000,
+          contextWindow: 200_000,
+          updatedAt: fixedNow,
+        },
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
   });
+};
+
+const testAcpPermissionRequestToPrompt = () => {
+  function permissionRequest(metadata: unknown): RequestPermissionRequest {
+    return {
+      sessionId: SESSION_ID,
+      toolCall: {
+        toolCallId: "tool-1",
+        title: "Run command",
+        kind: "execute",
+        status: "pending",
+      },
+      options: [
+        {
+          optionId: "opaque-option",
+          name: "Allow",
+          kind: "allow_always",
+          _meta: metadata,
+        },
+      ],
+    } as RequestPermissionRequest;
+  }
+
+  it("passes unchanged metadata to the presentation adapter", () => {
+    const metadata = { codex: { decision: "accept" } };
+    const presentPermissionOption = jest.fn((option: PermissionOption, _metadata: unknown) => ({
+      ...option,
+      name: "Allow Always",
+    }));
+
+    const prompt = acpPermissionRequestToPrompt(
+      permissionRequest(metadata),
+      presentPermissionOption
+    );
+
+    expect(presentPermissionOption).toHaveBeenCalledTimes(1);
+    expect(presentPermissionOption.mock.calls[0][1]).toBe(metadata);
+    expect(prompt.options).toEqual([
+      {
+        optionId: "opaque-option",
+        name: "Allow Always",
+        kind: "allow_always",
+      },
+    ]);
+  });
+
+  it("uses the wire option unchanged when no presentation adapter exists", () => {
+    expect(acpPermissionRequestToPrompt(permissionRequest({ backend: "opaque" })).options).toEqual([
+      {
+        optionId: "opaque-option",
+        name: "Allow",
+        kind: "allow_always",
+      },
+    ]);
+  });
+};
+
+describe("wireTranslate", () => {
+  describe("acpNotificationToEvents()", testAcpNotificationToEvents);
+  describe("acpPermissionRequestToPrompt()", testAcpPermissionRequestToPrompt);
 });

--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -435,7 +435,7 @@ function acpUpdateToSessionUpdate(update: SessionNotification["update"]): Sessio
  */
 export function acpPermissionRequestToPrompt(
   req: RequestPermissionRequest,
-  presentPermissionOption?: (option: PermissionOption) => PermissionOption
+  presentPermissionOption?: (option: PermissionOption, metadata: unknown) => PermissionOption
 ): PermissionPrompt {
   const call = req.toolCall;
   return {
@@ -455,7 +455,7 @@ export function acpPermissionRequestToPrompt(
 
 function permissionOptionFromAcp(
   opt: AcpPermissionOption,
-  presentPermissionOption?: (option: PermissionOption) => PermissionOption
+  presentPermissionOption?: (option: PermissionOption, metadata: unknown) => PermissionOption
 ): PermissionOption {
   const option: PermissionOption = {
     optionId: opt.optionId,
@@ -464,7 +464,7 @@ function permissionOptionFromAcp(
       ? opt.kind
       : "reject_once",
   };
-  return presentPermissionOption?.(option) ?? option;
+  return presentPermissionOption?.(option, opt._meta) ?? option;
 }
 
 export function permissionPromptToAcp(prompt: PermissionPrompt): RequestPermissionRequest {

--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -449,13 +449,28 @@ function permissionOptionFromAcp(opt: AcpPermissionOption): PermissionOption {
   const kind = (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
     ? opt.kind
     : "reject_once";
-  const name = permissionOptionActionName(kind);
+  if (!isPolicyAmendmentOption(opt.optionId)) {
+    return {
+      optionId: opt.optionId,
+      name: opt.name,
+      kind,
+    };
+  }
+
   return {
     optionId: opt.optionId,
-    name,
-    description: opt.name === name ? undefined : opt.name,
+    name: permissionOptionActionName(kind),
+    description: opt.name,
     kind,
   };
+}
+
+function isPolicyAmendmentOption(optionId: string): boolean {
+  // Codex policy amendments use ACP's name field for rule prose rather than an action label.
+  return (
+    optionId === "accept_execpolicy_amendment" ||
+    /^apply_network_policy_amendment:\d+$/.test(optionId)
+  );
 }
 
 function permissionOptionActionName(kind: PermissionOptionKind): string {

--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -479,7 +479,7 @@ export function permissionPromptToAcp(prompt: PermissionPrompt): RequestPermissi
     },
     options: prompt.options.map((o) => ({
       optionId: o.optionId,
-      name: o.description ?? o.name,
+      name: o.name,
       kind: o.kind,
     })),
   };

--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -41,6 +41,7 @@ import type {
   McpServerSpec,
   PermissionDecision,
   PermissionOption,
+  PermissionOptionKind,
   PermissionPrompt,
   PromptContent,
   SessionEvent,
@@ -445,13 +446,29 @@ export function acpPermissionRequestToPrompt(req: RequestPermissionRequest): Per
 }
 
 function permissionOptionFromAcp(opt: AcpPermissionOption): PermissionOption {
+  const kind = (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
+    ? opt.kind
+    : "reject_once";
+  const name = permissionOptionActionName(kind);
   return {
     optionId: opt.optionId,
-    name: opt.name,
-    kind: (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
-      ? opt.kind
-      : "reject_once",
+    name,
+    description: opt.name === name ? undefined : opt.name,
+    kind,
   };
+}
+
+function permissionOptionActionName(kind: PermissionOptionKind): string {
+  switch (kind) {
+    case "allow_once":
+      return "Allow";
+    case "allow_always":
+      return "Allow Always";
+    case "reject_once":
+      return "Reject";
+    case "reject_always":
+      return "Block Rule";
+  }
 }
 
 export function permissionPromptToAcp(prompt: PermissionPrompt): RequestPermissionRequest {
@@ -466,7 +483,7 @@ export function permissionPromptToAcp(prompt: PermissionPrompt): RequestPermissi
     },
     options: prompt.options.map((o) => ({
       optionId: o.optionId,
-      name: o.name,
+      name: o.description ?? o.name,
       kind: o.kind,
     })),
   };

--- a/src/agentMode/acp/wireTranslate.ts
+++ b/src/agentMode/acp/wireTranslate.ts
@@ -41,7 +41,6 @@ import type {
   McpServerSpec,
   PermissionDecision,
   PermissionOption,
-  PermissionOptionKind,
   PermissionPrompt,
   PromptContent,
   SessionEvent,
@@ -428,7 +427,16 @@ function acpUpdateToSessionUpdate(update: SessionNotification["update"]): Sessio
 
 // ---- Permission prompt / decision -------------------------------------
 
-export function acpPermissionRequestToPrompt(req: RequestPermissionRequest): PermissionPrompt {
+/**
+ * Convert an ACP permission request into the session-domain prompt.
+ *
+ * @param req - The request emitted by the ACP backend.
+ * @param presentPermissionOption - Optional backend-owned presentation adapter.
+ */
+export function acpPermissionRequestToPrompt(
+  req: RequestPermissionRequest,
+  presentPermissionOption?: (option: PermissionOption) => PermissionOption
+): PermissionPrompt {
   const call = req.toolCall;
   return {
     sessionId: sessionIdFromAcp(req.sessionId),
@@ -441,49 +449,22 @@ export function acpPermissionRequestToPrompt(req: RequestPermissionRequest): Per
       content: toolCallContentFromAcp(call.content),
       locations: call.locations?.map((l) => ({ path: l.path, line: l.line ?? undefined })),
     },
-    options: req.options.map(permissionOptionFromAcp),
+    options: req.options.map((option) => permissionOptionFromAcp(option, presentPermissionOption)),
   };
 }
 
-function permissionOptionFromAcp(opt: AcpPermissionOption): PermissionOption {
-  const kind = (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
-    ? opt.kind
-    : "reject_once";
-  if (!isPolicyAmendmentOption(opt.optionId)) {
-    return {
-      optionId: opt.optionId,
-      name: opt.name,
-      kind,
-    };
-  }
-
-  return {
+function permissionOptionFromAcp(
+  opt: AcpPermissionOption,
+  presentPermissionOption?: (option: PermissionOption) => PermissionOption
+): PermissionOption {
+  const option: PermissionOption = {
     optionId: opt.optionId,
-    name: permissionOptionActionName(kind),
-    description: opt.name,
-    kind,
+    name: opt.name,
+    kind: (PERMISSION_OPTION_KINDS as readonly string[]).includes(opt.kind)
+      ? opt.kind
+      : "reject_once",
   };
-}
-
-function isPolicyAmendmentOption(optionId: string): boolean {
-  // Codex policy amendments use ACP's name field for rule prose rather than an action label.
-  return (
-    optionId === "accept_execpolicy_amendment" ||
-    /^apply_network_policy_amendment:\d+$/.test(optionId)
-  );
-}
-
-function permissionOptionActionName(kind: PermissionOptionKind): string {
-  switch (kind) {
-    case "allow_once":
-      return "Allow";
-    case "allow_always":
-      return "Allow Always";
-    case "reject_once":
-      return "Reject";
-    case "reject_always":
-      return "Block Rule";
-  }
+  return presentPermissionOption?.(option) ?? option;
 }
 
 export function permissionPromptToAcp(prompt: PermissionPrompt): RequestPermissionRequest {

--- a/src/agentMode/backends/codex/CodexBackend.test.ts
+++ b/src/agentMode/backends/codex/CodexBackend.test.ts
@@ -187,6 +187,8 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
         "-c",
         'approval_policy="on-request"',
         "-c",
+        'approvals_reviewer="user"',
+        "-c",
         'sandbox_mode="workspace-write"',
       ])
     );

--- a/src/agentMode/backends/codex/CodexBackend.test.ts
+++ b/src/agentMode/backends/codex/CodexBackend.test.ts
@@ -174,7 +174,7 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
     expect(toTomlBasicString("über — café")).toBe('"über — café"');
   });
 
-  it("pins spawn-time approval_policy + sandbox_mode to canonical 'auto' preset", async () => {
+  it("pins spawn-time approval policy, reviewer, and sandbox to canonical Default mode", async () => {
     // Without these overrides codex-acp derives the initial mode from
     // ~/.codex/config.toml, which can land on read-only and surface as
     // "Plan" in our picker for a brief moment before the post-spawn
@@ -193,6 +193,7 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
     expect(JSON.parse(desc.env.CODEX_CONFIG as string)).toEqual(
       expect.objectContaining({
         approval_policy: "on-request",
+        approvals_reviewer: "user",
         sandbox_mode: "workspace-write",
       })
     );
@@ -215,6 +216,7 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
                 model: "custom-model",
                 developer_instructions: "drop Copilot prompt",
                 approval_policy: "never",
+                approvals_reviewer: "auto_review",
                 sandbox_mode: "danger-full-access",
               }),
             },
@@ -229,6 +231,7 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
       expect.objectContaining({
         model: "custom-model",
         approval_policy: "on-request",
+        approvals_reviewer: "user",
         sandbox_mode: "workspace-write",
       })
     );

--- a/src/agentMode/backends/codex/CodexBackend.test.ts
+++ b/src/agentMode/backends/codex/CodexBackend.test.ts
@@ -187,8 +187,6 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
         "-c",
         'approval_policy="on-request"',
         "-c",
-        'approvals_reviewer="user"',
-        "-c",
         'sandbox_mode="workspace-write"',
       ])
     );

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -46,7 +46,7 @@ export class CodexBackend implements AcpBackend {
       ...descriptor.args,
       "-c",
       `developer_instructions=${toTomlBasicString(directive)}`,
-      // Pin spawn-time approval/reviewer/sandbox so legacy codex-acp's first
+      // Pin spawn-time approval/sandbox so legacy codex-acp's first
       // `currentModeId` report matches its canonical `auto` preset
       // (workspace-write + on-request), which Agent Mode surfaces as
       // canonical `default` (ask mode). Without this, codex-acp derives
@@ -57,8 +57,6 @@ export class CodexBackend implements AcpBackend {
       // and `Thread::modes()` in codex-acp/src/thread.rs.
       "-c",
       'approval_policy="on-request"',
-      "-c",
-      'approvals_reviewer="user"',
       "-c",
       'sandbox_mode="workspace-write"',
     ];

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -46,7 +46,7 @@ export class CodexBackend implements AcpBackend {
       ...descriptor.args,
       "-c",
       `developer_instructions=${toTomlBasicString(directive)}`,
-      // Pin spawn-time approval/sandbox so legacy codex-acp's first
+      // Pin spawn-time approval/reviewer/sandbox so legacy codex-acp's first
       // `currentModeId` report matches its canonical `auto` preset
       // (workspace-write + on-request), which Agent Mode surfaces as
       // canonical `default` (ask mode). Without this, codex-acp derives
@@ -57,6 +57,8 @@ export class CodexBackend implements AcpBackend {
       // and `Thread::modes()` in codex-acp/src/thread.rs.
       "-c",
       'approval_policy="on-request"',
+      "-c",
+      'approvals_reviewer="user"',
       "-c",
       'sandbox_mode="workspace-write"',
     ];

--- a/src/agentMode/backends/codex/codexConfigEnv.test.ts
+++ b/src/agentMode/backends/codex/codexConfigEnv.test.ts
@@ -1,0 +1,32 @@
+import { mergeCodexConfigEnv } from "@/agentMode/backends/codex/codexConfigEnv";
+
+describe("codexConfigEnv", () => {
+  describe("mergeCodexConfigEnv()", () => {
+    it("builds the managed Codex configuration without inherited values", () => {
+      expect(JSON.parse(mergeCodexConfigEnv(undefined, "Use the vault."))).toEqual({
+        developer_instructions: "Use the vault.",
+        approval_policy: "on-request",
+        approvals_reviewer: "user",
+        sandbox_mode: "workspace-write",
+      });
+    });
+
+    it("preserves unrelated values while overriding inherited managed fields", () => {
+      const existing = JSON.stringify({
+        model: "custom-model",
+        developer_instructions: "Ignore the vault.",
+        approval_policy: "never",
+        approvals_reviewer: "auto_review",
+        sandbox_mode: "danger-full-access",
+      });
+
+      expect(JSON.parse(mergeCodexConfigEnv(existing, "Use the vault."))).toEqual({
+        model: "custom-model",
+        developer_instructions: "Use the vault.",
+        approval_policy: "on-request",
+        approvals_reviewer: "user",
+        sandbox_mode: "workspace-write",
+      });
+    });
+  });
+});

--- a/src/agentMode/backends/codex/codexConfigEnv.ts
+++ b/src/agentMode/backends/codex/codexConfigEnv.ts
@@ -1,6 +1,7 @@
 interface CodexManagedConfig {
   developer_instructions: string;
   approval_policy: "on-request";
+  approvals_reviewer: "user";
   sandbox_mode: "workspace-write";
 }
 
@@ -32,6 +33,7 @@ export function mergeCodexConfigEnv(
   const managed: CodexManagedConfig = {
     developer_instructions: developerInstructions,
     approval_policy: "on-request",
+    approvals_reviewer: "user",
     sandbox_mode: "workspace-write",
   };
   return JSON.stringify({ ...parseCodexConfig(existing), ...managed });

--- a/src/agentMode/backends/codex/descriptor.test.ts
+++ b/src/agentMode/backends/codex/descriptor.test.ts
@@ -5,18 +5,19 @@ describe("descriptor", () => {
   describe("CodexBackendDescriptor", () => {
     describe("presentPermissionOption()", () => {
       it.each([
-        "accept_execpolicy_amendment",
-        "apply_network_policy_amendment:0",
-        "apply_network_policy_amendment:12",
-      ])("separates the Codex policy rule for %s", (optionId) => {
-        const rule = "Allow network access to api.example.com";
+        ["opaque-exec-decision", "acceptWithExecpolicyAmendment"],
+        ["opaque-network-decision", "applyNetworkPolicyAmendment"],
+      ])("separates the Codex policy rule using %s metadata", (optionId, decision) => {
+        const rule = "Allow commands starting with mkdir";
         const option: PermissionOption = {
           optionId,
           name: rule,
           kind: "allow_always",
         };
 
-        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toEqual({
+        expect(
+          CodexBackendDescriptor.presentPermissionOption?.(option, { codex: { decision } })
+        ).toEqual({
           optionId,
           name: "Allow Always",
           description: rule,
@@ -26,31 +27,52 @@ describe("descriptor", () => {
 
       it("uses block language for a persistent network rejection", () => {
         const option: PermissionOption = {
-          optionId: "apply_network_policy_amendment:3",
+          optionId: "opaque-network-rejection",
           name: "Block api.example.com in the Future",
           kind: "reject_always",
         };
 
-        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toEqual({
-          optionId: "apply_network_policy_amendment:3",
+        expect(
+          CodexBackendDescriptor.presentPermissionOption?.(option, {
+            codex: { decision: "applyNetworkPolicyAmendment" },
+          })
+        ).toEqual({
+          optionId: "opaque-network-rejection",
           name: "Block Always",
           description: "Block api.example.com in the Future",
           kind: "reject_always",
         });
       });
 
-      it.each(["allow_host_session", "apply_network_policy_amendment:not-an-index"])(
-        "leaves the ordinary or near-match label for %s unchanged",
-        (optionId) => {
-          const option: PermissionOption = {
-            optionId,
-            name: "Allow Host for Session",
-            kind: "allow_always",
-          };
+      it("leaves a session decision unchanged even when its opaque id resembles a policy amendment", () => {
+        const option: PermissionOption = {
+          optionId: "accept_execpolicy_amendment",
+          name: "Allow Host for Session",
+          kind: "allow_always",
+        };
 
-          expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toBe(option);
-        }
-      );
+        expect(
+          CodexBackendDescriptor.presentPermissionOption?.(option, {
+            codex: { decision: "acceptForSession" },
+          })
+        ).toBe(option);
+      });
+
+      it.each([
+        undefined,
+        null,
+        { codex: null },
+        { codex: { decision: "unknown" } },
+        { codex: { decision: "acceptWithExecpolicyAmendment" } },
+      ])("leaves malformed or contradictory metadata unchanged", (metadata) => {
+        const option: PermissionOption = {
+          optionId: "opaque-decision",
+          name: "Backend-provided label",
+          kind: "reject_always",
+        };
+
+        expect(CodexBackendDescriptor.presentPermissionOption?.(option, metadata)).toBe(option);
+      });
     });
   });
 });

--- a/src/agentMode/backends/codex/descriptor.test.ts
+++ b/src/agentMode/backends/codex/descriptor.test.ts
@@ -24,15 +24,33 @@ describe("descriptor", () => {
         });
       });
 
-      it("leaves ordinary Codex permission labels unchanged", () => {
+      it("uses block language for a persistent network rejection", () => {
         const option: PermissionOption = {
-          optionId: "allow_host_session",
-          name: "Allow Host for Session",
-          kind: "allow_always",
+          optionId: "apply_network_policy_amendment:3",
+          name: "Block api.example.com in the Future",
+          kind: "reject_always",
         };
 
-        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toBe(option);
+        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toEqual({
+          optionId: "apply_network_policy_amendment:3",
+          name: "Block Always",
+          description: "Block api.example.com in the Future",
+          kind: "reject_always",
+        });
       });
+
+      it.each(["allow_host_session", "apply_network_policy_amendment:not-an-index"])(
+        "leaves the ordinary or near-match label for %s unchanged",
+        (optionId) => {
+          const option: PermissionOption = {
+            optionId,
+            name: "Allow Host for Session",
+            kind: "allow_always",
+          };
+
+          expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toBe(option);
+        }
+      );
     });
   });
 });

--- a/src/agentMode/backends/codex/descriptor.test.ts
+++ b/src/agentMode/backends/codex/descriptor.test.ts
@@ -1,0 +1,38 @@
+import type { PermissionOption } from "@/agentMode/session/types";
+import { CodexBackendDescriptor } from "./descriptor";
+
+describe("descriptor", () => {
+  describe("CodexBackendDescriptor", () => {
+    describe("presentPermissionOption()", () => {
+      it.each([
+        "accept_execpolicy_amendment",
+        "apply_network_policy_amendment:0",
+        "apply_network_policy_amendment:12",
+      ])("separates the Codex policy rule for %s", (optionId) => {
+        const rule = "Allow network access to api.example.com";
+        const option: PermissionOption = {
+          optionId,
+          name: rule,
+          kind: "allow_always",
+        };
+
+        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toEqual({
+          optionId,
+          name: "Allow Always",
+          description: rule,
+          kind: "allow_always",
+        });
+      });
+
+      it("leaves ordinary Codex permission labels unchanged", () => {
+        const option: PermissionOption = {
+          optionId: "allow_host_session",
+          name: "Allow Host for Session",
+          kind: "allow_always",
+        };
+
+        expect(CodexBackendDescriptor.presentPermissionOption?.(option)).toBe(option);
+      });
+    });
+  });
+});

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -17,7 +17,12 @@ import {
   binaryPathInstallState,
   simpleBinaryBackendProcess,
 } from "@/agentMode/backends/shared/simpleBinaryBackend";
-import type { EnabledModelEntry, ModelSelection, ModelWireCodec } from "@/agentMode/session/types";
+import type {
+  EnabledModelEntry,
+  ModelSelection,
+  ModelWireCodec,
+  PermissionOption,
+} from "@/agentMode/session/types";
 import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
 import { detectBinary } from "@/utils/detectBinary";
 import { codexAcpSearchDirs, resolveCodexAcpBinary } from "./codexBinaryResolver";
@@ -130,6 +135,20 @@ export const CodexBackendDescriptor: BackendDescriptor = {
    */
   normalizeModelName(name: string): string {
     return name.replace(/^gpt/i, "GPT");
+  },
+
+  presentPermissionOption(option: PermissionOption): PermissionOption {
+    if (
+      option.optionId !== "accept_execpolicy_amendment" &&
+      !/^apply_network_policy_amendment:\d+$/.test(option.optionId)
+    ) {
+      return option;
+    }
+    return {
+      ...option,
+      name: "Allow Always",
+      description: option.name,
+    };
   },
 
   getInstallState(settings: CopilotSettings): InstallState {

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -137,13 +137,15 @@ export const CodexBackendDescriptor: BackendDescriptor = {
     return name.replace(/^gpt/i, "GPT");
   },
 
-  presentPermissionOption(option: PermissionOption): PermissionOption {
-    if (
-      option.optionId !== "accept_execpolicy_amendment" &&
-      !/^apply_network_policy_amendment:\d+$/.test(option.optionId)
-    ) {
-      return option;
-    }
+  presentPermissionOption(option: PermissionOption, metadata: unknown): PermissionOption {
+    const decision = codexPermissionDecision(metadata);
+    const isExecpolicyAmendment =
+      decision === "acceptWithExecpolicyAmendment" && option.kind === "allow_always";
+    const isNetworkPolicyAmendment =
+      decision === "applyNetworkPolicyAmendment" &&
+      (option.kind === "allow_always" || option.kind === "reject_always");
+    if (!isExecpolicyAmendment && !isNetworkPolicyAmendment) return option;
+
     return {
       ...option,
       name: option.kind === "reject_always" ? "Block Always" : "Allow Always",
@@ -191,3 +193,10 @@ export const CodexBackendDescriptor: BackendDescriptor = {
     return buildCodexModeMapping(modeState);
   },
 };
+
+function codexPermissionDecision(metadata: unknown): unknown {
+  if (metadata === null || typeof metadata !== "object") return undefined;
+  const codex = (metadata as Record<string, unknown>).codex;
+  if (codex === null || typeof codex !== "object") return undefined;
+  return (codex as Record<string, unknown>).decision;
+}

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -146,7 +146,7 @@ export const CodexBackendDescriptor: BackendDescriptor = {
     }
     return {
       ...option,
-      name: "Allow Always",
+      name: option.kind === "reject_always" ? "Block Always" : "Allow Always",
       description: option.name,
     };
   },

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -13,6 +13,7 @@ import type {
   ModelState,
   ModelWireCodec,
   ModeMapping,
+  PermissionOption,
   RawModeState,
   SessionId,
 } from "./types";
@@ -248,6 +249,15 @@ export interface BackendDescriptor {
    * reports (`gpt-5.4` → `GPT-5.4`); most backends omit it.
    */
   normalizeModelName?(name: string): string;
+
+  /**
+   * Optional: adapt a backend-native permission option for generic UI
+   * presentation. The option id remains the backend's executable decision;
+   * backends may separate wire-level rule prose from a compact action label.
+   *
+   * @param option - The neutral permission option produced at the backend boundary.
+   */
+  presentPermissionOption?(option: PermissionOption): PermissionOption;
 
   /**
    * Opt in to surfacing this backend's per-model `description` as the row

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -256,8 +256,9 @@ export interface BackendDescriptor {
    * backends may separate wire-level rule prose from a compact action label.
    *
    * @param option - The neutral permission option produced at the backend boundary.
+   * @param metadata - Opaque backend metadata forwarded unchanged from the ACP option.
    */
-  presentPermissionOption?(option: PermissionOption): PermissionOption;
+  presentPermissionOption?(option: PermissionOption, metadata: unknown): PermissionOption;
 
   /**
    * Opt in to surfacing this backend's per-model `description` as the row

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -566,7 +566,7 @@ export interface PermissionOption {
   optionId: string;
   /** Compact action text suitable for a permission button. */
   name: string;
-  /** Option-specific context shown next to the matching action. */
+  /** Option-specific context exposed by the matching action. */
   description?: string;
   kind: PermissionOptionKind;
 }

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -564,7 +564,10 @@ export const PERMISSION_REJECT_KINDS: readonly PermissionOptionKind[] = [
 /** Single option carried in a `PermissionPrompt`. */
 export interface PermissionOption {
   optionId: string;
+  /** Compact action text suitable for a permission button. */
   name: string;
+  /** Option-specific context shown next to the matching action. */
+  description?: string;
   kind: PermissionOptionKind;
 }
 

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -108,6 +108,25 @@ describe("ToolPermissionCard", () => {
       expect(screen.getByRole("button", { name: "Block Always" })).toBeTruthy();
     });
 
+    it("keeps generated suffixes distinct from backend-provided labels", () => {
+      render(
+        <ToolPermissionCard
+          request={makeRequest([
+            { optionId: "first", name: "Allow Always", kind: "allow_always" },
+            { optionId: "second", name: "Allow Always", kind: "allow_always" },
+            { optionId: "third", name: "Allow Always 1", kind: "allow_always" },
+          ])}
+          onResolve={jest.fn()}
+        />
+      );
+
+      expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual([
+        "Allow Always 2",
+        "Allow Always 3",
+        "Allow Always 1",
+      ]);
+    });
+
     it("orders compact actions by kind and makes unbroken labels shrinkable", () => {
       const unbrokenLabel = "AllowAccessToNetwork.example.com".repeat(8);
       render(

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -1,6 +1,6 @@
 import type { PermissionOption, PermissionPrompt, SessionId } from "@/agentMode/session/types";
 import { ToolPermissionCard } from "@/agentMode/ui/ToolPermissionCard";
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
 const SESSION_ID = "session-1" as SessionId;
@@ -22,67 +22,90 @@ function makeRequest(options: PermissionOption[]): PermissionPrompt {
 
 describe("ToolPermissionCard", () => {
   describe("ToolPermissionCard()", () => {
-    it("keeps multiple described actions visibly paired with their respective decisions", () => {
+    it("keeps duplicate described actions together and numbers their tooltip triggers", async () => {
       const onResolve = jest.fn();
-      const commandRule =
-        "Allow Commands Starting With `/long/path/semantic-search.sh Search only within agents/themes/capture for LLM wiki, AI second brain, knowledge base, digital twin, and local-first Markdown knowledge workspace.`";
-      const networkRule = "Block a.really-long-and-specific-subdomain.example.com in the Future";
+      const firstRule = "Allow commands starting with mkdir";
+      const secondRule = "Allow commands starting with dir";
       const options: PermissionOption[] = [
         {
           optionId: "accept_execpolicy_amendment",
           name: "Allow Always",
-          description: commandRule,
+          description: firstRule,
           kind: "allow_always",
         },
         {
           optionId: "apply_network_policy_amendment:0",
-          name: "Block Always",
-          description: networkRule,
-          kind: "reject_always",
+          name: "Allow Always",
+          description: secondRule,
+          kind: "allow_always",
         },
+        { optionId: "reject", name: "Reject", kind: "reject_once" },
       ];
 
-      const { rerender } = render(
-        <ToolPermissionCard
-          key="first-decision"
-          request={makeRequest(options)}
-          onResolve={onResolve}
-        />
-      );
+      render(<ToolPermissionCard request={makeRequest(options)} onResolve={onResolve} />);
 
-      const commandRow = screen.getByText(commandRule).parentElement;
-      const networkRow = screen.getByText(networkRule).parentElement;
-      expect(commandRow).not.toBeNull();
-      expect(networkRow).not.toBeNull();
+      expect(screen.queryByText(firstRule)).toBeNull();
+      expect(screen.queryByText(secondRule)).toBeNull();
 
-      const commandButton = within(commandRow!).getByRole("button", {
-        name: "Allow Always",
-        description: commandRule,
-      });
-      const networkButton = within(networkRow!).getByRole("button", {
-        name: "Block Always",
-        description: networkRule,
-      });
-      expect(commandButton.textContent).toBe("Allow Always");
-      expect(networkButton.textContent).toBe("Block Always");
+      const firstButton = screen.getByRole("button", { name: "Allow Always 1" });
+      const secondButton = screen.getByRole("button", { name: "Allow Always 2" });
+      const rejectButton = screen.getByRole("button", { name: "Reject" });
+      expect(firstButton.parentElement).toBe(secondButton.parentElement);
+      expect(secondButton.parentElement).toBe(rejectButton.parentElement);
 
-      fireEvent.click(networkButton);
+      fireEvent.pointerMove(firstButton, { pointerType: "mouse" });
+      expect((await screen.findByRole("tooltip")).textContent).toBe(firstRule);
+
+      fireEvent.click(secondButton);
       expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "apply_network_policy_amendment:0");
+    });
 
-      rerender(
+    it("leaves a single described action unnumbered", () => {
+      const description = "Allow commands starting with mkdir";
+      const onResolve = jest.fn();
+      render(
         <ToolPermissionCard
-          key="second-decision"
-          request={makeRequest(options)}
+          request={makeRequest([
+            {
+              optionId: "accept_execpolicy_amendment",
+              name: "Allow Always",
+              description,
+              kind: "allow_always",
+            },
+          ])}
           onResolve={onResolve}
         />
       );
-      fireEvent.click(
-        screen.getByRole("button", {
-          name: "Allow Always",
-          description: commandRule,
-        })
-      );
+
+      expect(screen.queryByText(description)).toBeNull();
+      const button = screen.getByRole("button", { name: "Allow Always" });
+      fireEvent.click(button);
       expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "accept_execpolicy_amendment");
+    });
+
+    it("does not number distinct persistent action labels", () => {
+      render(
+        <ToolPermissionCard
+          request={makeRequest([
+            {
+              optionId: "allow",
+              name: "Allow Always",
+              description: "Allow example.com",
+              kind: "allow_always",
+            },
+            {
+              optionId: "block",
+              name: "Block Always",
+              description: "Block example.net",
+              kind: "reject_always",
+            },
+          ])}
+          onResolve={jest.fn()}
+        />
+      );
+
+      expect(screen.getByRole("button", { name: "Allow Always" })).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Block Always" })).toBeTruthy();
     });
 
     it("orders compact actions by kind and makes unbroken labels shrinkable", () => {

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -1,0 +1,111 @@
+import type { PermissionOption, PermissionPrompt, SessionId } from "@/agentMode/session/types";
+import { ToolPermissionCard } from "@/agentMode/ui/ToolPermissionCard";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const SESSION_ID = "session-1" as SessionId;
+const TOOL_CALL_ID = "tool-1";
+
+function makeRequest(options: PermissionOption[]): PermissionPrompt {
+  return {
+    sessionId: SESSION_ID,
+    toolCall: {
+      toolCallId: TOOL_CALL_ID,
+      title: "Tool call",
+      kind: "execute",
+      status: "pending",
+      rawInput: { command: "search" },
+    },
+    options,
+  };
+}
+
+describe("ToolPermissionCard module", () => {
+  describe("ToolPermissionCard", () => {
+    it("uses a fixed action label and presents a long option name as its description", () => {
+      const onResolve = jest.fn();
+      const longName =
+        "Allow Commands Starting With `/long/path/semantic-search.sh Search only within agents/themes/capture for LLM wiki, AI second brain, knowledge base, digital twin, and local-first Markdown knowledge workspace.`";
+
+      render(
+        <ToolPermissionCard
+          request={makeRequest([
+            { optionId: "allow_once", name: "Allow Once", kind: "allow_once" },
+            { optionId: "allow_always", name: "Allow for Session", kind: "allow_always" },
+            {
+              optionId: "accept_execpolicy_amendment",
+              name: longName,
+              kind: "allow_always",
+            },
+            { optionId: "reject_once", name: "Reject", kind: "reject_once" },
+          ])}
+          onResolve={onResolve}
+        />
+      );
+
+      expect(screen.queryByRole("button", { name: longName })).toBeNull();
+      const ruleButton = screen.getByRole("button", {
+        name: "Allow Always",
+        description: longName,
+      });
+      expect(screen.getByText(longName)).not.toBe(ruleButton);
+
+      fireEvent.click(ruleButton);
+      expect(onResolve).toHaveBeenCalledWith(TOOL_CALL_ID, "accept_execpolicy_amendment");
+    });
+
+    it("uses semantic fixed labels for every kind of descriptive option", () => {
+      const options: PermissionOption[] = [
+        {
+          optionId: "once",
+          name: "Allow this individual permission request after reviewing all of its details",
+          kind: "allow_once",
+        },
+        {
+          optionId: "always",
+          name: "Allow this permission rule for later matching tool calls in the session",
+          kind: "allow_always",
+        },
+        {
+          optionId: "reject",
+          name: "Reject this individual permission request after reviewing all of its details",
+          kind: "reject_once",
+        },
+        {
+          optionId: "block",
+          name: "Block this permission rule for later matching tool calls in the session",
+          kind: "reject_always",
+        },
+      ];
+
+      render(<ToolPermissionCard request={makeRequest(options)} onResolve={jest.fn()} />);
+
+      const expectedLabels = ["Allow", "Allow Always", "Reject", "Block Rule"];
+      for (const [index, label] of expectedLabels.entries()) {
+        expect(
+          screen.getByRole("button", { name: label, description: options[index].name })
+        ).toBeTruthy();
+      }
+    });
+
+    it("keeps compact backend labels and orders them by permission kind", () => {
+      render(
+        <ToolPermissionCard
+          request={makeRequest([
+            { optionId: "reject", name: "No", kind: "reject_once" },
+            { optionId: "session", name: "Allow for Session", kind: "allow_always" },
+            { optionId: "once", name: "Allow Once", kind: "allow_once" },
+          ])}
+          onResolve={jest.fn()}
+        />
+      );
+
+      expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual([
+        "Allow Once",
+        "Allow for Session",
+        "No",
+      ]);
+      expect(screen.queryByText("Permission details")).toBeNull();
+    });
+  });
+});

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -85,8 +85,8 @@ describe("ToolPermissionCard", () => {
       expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "accept_execpolicy_amendment");
     });
 
-    it("orders compact actions by kind and constrains their labels to the card width", () => {
-      const unbrokenLabel = "AllowAccessToNetwork.example.com";
+    it("orders compact actions by kind and makes unbroken labels shrinkable", () => {
+      const unbrokenLabel = "AllowAccessToNetwork.example.com".repeat(8);
       render(
         <ToolPermissionCard
           request={makeRequest([
@@ -103,10 +103,15 @@ describe("ToolPermissionCard", () => {
         "Allow for Session",
         "No",
       ]);
-      const labelClasses = screen.getByRole("button", { name: unbrokenLabel }).classList;
-      expect(labelClasses.contains("tw-max-w-full")).toBe(true);
-      expect(labelClasses.contains("tw-whitespace-normal")).toBe(true);
-      expect(labelClasses.contains("tw-break-words")).toBe(true);
+      const button = screen.getByRole("button", { name: unbrokenLabel });
+      expect(button.classList.contains("tw-max-w-full")).toBe(true);
+      expect(button.classList.contains("tw-min-w-0")).toBe(true);
+      expect(button.firstElementChild).toMatchObject({
+        tagName: "SPAN",
+        textContent: unbrokenLabel,
+      });
+      expect(button.firstElementChild?.classList.contains("tw-min-w-0")).toBe(true);
+      expect(button.firstElementChild?.classList.contains("tw-break-all")).toBe(true);
     });
   });
 });

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -26,8 +26,7 @@ describe("ToolPermissionCard", () => {
       const onResolve = jest.fn();
       const commandRule =
         "Allow Commands Starting With `/long/path/semantic-search.sh Search only within agents/themes/capture for LLM wiki, AI second brain, knowledge base, digital twin, and local-first Markdown knowledge workspace.`";
-      const networkRule =
-        "Allow network access to a.really-long-and-specific-subdomain.example.com for future matching requests.";
+      const networkRule = "Block a.really-long-and-specific-subdomain.example.com in the Future";
       const options: PermissionOption[] = [
         {
           optionId: "accept_execpolicy_amendment",
@@ -37,9 +36,9 @@ describe("ToolPermissionCard", () => {
         },
         {
           optionId: "apply_network_policy_amendment:0",
-          name: "Allow Always",
+          name: "Block Always",
           description: networkRule,
-          kind: "allow_always",
+          kind: "reject_always",
         },
       ];
 
@@ -61,10 +60,11 @@ describe("ToolPermissionCard", () => {
         description: commandRule,
       });
       const networkButton = within(networkRow!).getByRole("button", {
-        name: "Allow Always",
+        name: "Block Always",
         description: networkRule,
       });
       expect(commandButton.textContent).toBe("Allow Always");
+      expect(networkButton.textContent).toBe("Block Always");
 
       fireEvent.click(networkButton);
       expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "apply_network_policy_amendment:0");

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -36,7 +36,7 @@ describe("ToolPermissionCard", () => {
           kind: "allow_always",
         },
         {
-          optionId: "accept_networkpolicy_amendment",
+          optionId: "apply_network_policy_amendment:0",
           name: "Allow Always",
           description: networkRule,
           kind: "allow_always",
@@ -67,7 +67,7 @@ describe("ToolPermissionCard", () => {
       expect(commandButton.textContent).toBe("Allow Always");
 
       fireEvent.click(networkButton);
-      expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "accept_networkpolicy_amendment");
+      expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "apply_network_policy_amendment:0");
 
       rerender(
         <ToolPermissionCard

--- a/src/agentMode/ui/ToolPermissionCard.test.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.test.tsx
@@ -1,6 +1,6 @@
 import type { PermissionOption, PermissionPrompt, SessionId } from "@/agentMode/session/types";
 import { ToolPermissionCard } from "@/agentMode/ui/ToolPermissionCard";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import React from "react";
 
 const SESSION_ID = "session-1" as SessionId;
@@ -20,92 +20,93 @@ function makeRequest(options: PermissionOption[]): PermissionPrompt {
   };
 }
 
-describe("ToolPermissionCard module", () => {
-  describe("ToolPermissionCard", () => {
-    it("uses a fixed action label and presents a long option name as its description", () => {
+describe("ToolPermissionCard", () => {
+  describe("ToolPermissionCard()", () => {
+    it("keeps multiple described actions visibly paired with their respective decisions", () => {
       const onResolve = jest.fn();
-      const longName =
+      const commandRule =
         "Allow Commands Starting With `/long/path/semantic-search.sh Search only within agents/themes/capture for LLM wiki, AI second brain, knowledge base, digital twin, and local-first Markdown knowledge workspace.`";
+      const networkRule =
+        "Allow network access to a.really-long-and-specific-subdomain.example.com for future matching requests.";
+      const options: PermissionOption[] = [
+        {
+          optionId: "accept_execpolicy_amendment",
+          name: "Allow Always",
+          description: commandRule,
+          kind: "allow_always",
+        },
+        {
+          optionId: "accept_networkpolicy_amendment",
+          name: "Allow Always",
+          description: networkRule,
+          kind: "allow_always",
+        },
+      ];
 
-      render(
+      const { rerender } = render(
         <ToolPermissionCard
-          request={makeRequest([
-            { optionId: "allow_once", name: "Allow Once", kind: "allow_once" },
-            { optionId: "allow_always", name: "Allow for Session", kind: "allow_always" },
-            {
-              optionId: "accept_execpolicy_amendment",
-              name: longName,
-              kind: "allow_always",
-            },
-            { optionId: "reject_once", name: "Reject", kind: "reject_once" },
-          ])}
+          key="first-decision"
+          request={makeRequest(options)}
           onResolve={onResolve}
         />
       );
 
-      expect(screen.queryByRole("button", { name: longName })).toBeNull();
-      const ruleButton = screen.getByRole("button", {
+      const commandRow = screen.getByText(commandRule).parentElement;
+      const networkRow = screen.getByText(networkRule).parentElement;
+      expect(commandRow).not.toBeNull();
+      expect(networkRow).not.toBeNull();
+
+      const commandButton = within(commandRow!).getByRole("button", {
         name: "Allow Always",
-        description: longName,
+        description: commandRule,
       });
-      expect(screen.getByText(longName)).not.toBe(ruleButton);
+      const networkButton = within(networkRow!).getByRole("button", {
+        name: "Allow Always",
+        description: networkRule,
+      });
+      expect(commandButton.textContent).toBe("Allow Always");
 
-      fireEvent.click(ruleButton);
-      expect(onResolve).toHaveBeenCalledWith(TOOL_CALL_ID, "accept_execpolicy_amendment");
+      fireEvent.click(networkButton);
+      expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "accept_networkpolicy_amendment");
+
+      rerender(
+        <ToolPermissionCard
+          key="second-decision"
+          request={makeRequest(options)}
+          onResolve={onResolve}
+        />
+      );
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: "Allow Always",
+          description: commandRule,
+        })
+      );
+      expect(onResolve).toHaveBeenLastCalledWith(TOOL_CALL_ID, "accept_execpolicy_amendment");
     });
 
-    it("uses semantic fixed labels for every kind of descriptive option", () => {
-      const options: PermissionOption[] = [
-        {
-          optionId: "once",
-          name: "Allow this individual permission request after reviewing all of its details",
-          kind: "allow_once",
-        },
-        {
-          optionId: "always",
-          name: "Allow this permission rule for later matching tool calls in the session",
-          kind: "allow_always",
-        },
-        {
-          optionId: "reject",
-          name: "Reject this individual permission request after reviewing all of its details",
-          kind: "reject_once",
-        },
-        {
-          optionId: "block",
-          name: "Block this permission rule for later matching tool calls in the session",
-          kind: "reject_always",
-        },
-      ];
-
-      render(<ToolPermissionCard request={makeRequest(options)} onResolve={jest.fn()} />);
-
-      const expectedLabels = ["Allow", "Allow Always", "Reject", "Block Rule"];
-      for (const [index, label] of expectedLabels.entries()) {
-        expect(
-          screen.getByRole("button", { name: label, description: options[index].name })
-        ).toBeTruthy();
-      }
-    });
-
-    it("keeps compact backend labels and orders them by permission kind", () => {
+    it("orders compact actions by kind and constrains their labels to the card width", () => {
+      const unbrokenLabel = "AllowAccessToNetwork.example.com";
       render(
         <ToolPermissionCard
           request={makeRequest([
             { optionId: "reject", name: "No", kind: "reject_once" },
             { optionId: "session", name: "Allow for Session", kind: "allow_always" },
-            { optionId: "once", name: "Allow Once", kind: "allow_once" },
+            { optionId: "once", name: unbrokenLabel, kind: "allow_once" },
           ])}
           onResolve={jest.fn()}
         />
       );
 
       expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual([
-        "Allow Once",
+        unbrokenLabel,
         "Allow for Session",
         "No",
       ]);
-      expect(screen.queryByText("Permission details")).toBeNull();
+      const labelClasses = screen.getByRole("button", { name: unbrokenLabel }).classList;
+      expect(labelClasses.contains("tw-max-w-full")).toBe(true);
+      expect(labelClasses.contains("tw-whitespace-normal")).toBe(true);
+      expect(labelClasses.contains("tw-break-words")).toBe(true);
     });
   });
 });

--- a/src/agentMode/ui/ToolPermissionCard.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.tsx
@@ -14,10 +14,6 @@ interface ToolPermissionCardProps {
   onResolve: (toolCallId: string, optionId: string) => void;
 }
 
-// ACP provides one name field, so adapters sometimes place a full permission
-// rule there even though the same value must also identify the action.
-const MAX_PERMISSION_BUTTON_LABEL_LENGTH = 32;
-
 /**
  * Inline permission card rendered at the tail of the chat scroll container
  * while a tool call is awaiting the user's decision. Replaces the modal that
@@ -26,10 +22,9 @@ const MAX_PERMISSION_BUTTON_LABEL_LENGTH = 32;
  * sessions. The card stays in-place until the user picks an option or the
  * turn is cancelled.
  *
- * The actual SDK permission update (allow_once / allow_always /
- * reject_once / reject_always semantics, including the
- * `updatedPermissions` payload for "always" choices) is handled in
- * `mapDecisionToSdk` — this component just forwards the chosen `optionId`.
+ * The backend translates one-time and persistent decisions from the selected
+ * `optionId`; this component only displays the domain prompt and forwards that
+ * identifier.
  */
 export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request, onResolve }) => {
   const { toolCall, options } = request;
@@ -86,62 +81,48 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
             </pre>
           </details>
         ) : null}
-
-        {orderedOptions.some(isDescriptiveOption) ? (
-          <div className="tw-flex tw-min-w-0 tw-flex-col tw-gap-1 tw-rounded tw-bg-primary tw-p-2">
-            <p className="tw-m-0 tw-text-xs tw-font-medium">Permission details</p>
-            {orderedOptions.map((option, index) =>
-              isDescriptiveOption(option) ? (
-                <p
-                  key={option.optionId}
-                  id={`${descriptionIdPrefix}-${index}`}
-                  className="tw-m-0 tw-min-w-0 tw-break-words tw-text-xs tw-text-muted"
-                >
-                  {option.name}
-                </p>
-              ) : null
-            )}
-          </div>
-        ) : null}
       </div>
 
       <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2 tw-border-t tw-border-solid tw-border-border tw-px-3 tw-py-2">
         {orderedOptions.map((option, index) => {
-          const descriptive = isDescriptiveOption(option);
-          return (
+          const descriptionId = `${descriptionIdPrefix}-${index}`;
+          const button = (
             <Button
               key={option.optionId}
               variant={variantForKind(option.kind)}
               size="sm"
+              className="tw-h-auto tw-min-h-6 tw-max-w-full tw-whitespace-normal tw-break-words"
               disabled={busy}
-              aria-describedby={descriptive ? `${descriptionIdPrefix}-${index}` : undefined}
+              aria-describedby={option.description ? descriptionId : undefined}
               onClick={() => choose(option.optionId)}
             >
-              {descriptive ? descriptiveOptionButtonLabel(option.kind) : option.name}
+              {option.name}
             </Button>
           );
+
+          if (option.description) {
+            return (
+              <div
+                key={option.optionId}
+                className="tw-flex tw-w-full tw-min-w-0 tw-flex-col tw-items-start tw-gap-2 tw-rounded tw-bg-primary tw-p-2"
+              >
+                <p
+                  id={descriptionId}
+                  className="tw-m-0 tw-w-full tw-min-w-0 tw-break-words tw-text-xs tw-text-muted"
+                >
+                  {option.description}
+                </p>
+                <div className="tw-flex tw-w-full tw-justify-end">{button}</div>
+              </div>
+            );
+          }
+
+          return button;
         })}
       </div>
     </div>
   );
 };
-
-function isDescriptiveOption(option: PermissionOption): boolean {
-  return option.name.length > MAX_PERMISSION_BUTTON_LABEL_LENGTH;
-}
-
-function descriptiveOptionButtonLabel(kind: PermissionOptionKind): string {
-  switch (kind) {
-    case "allow_once":
-      return "Allow";
-    case "allow_always":
-      return "Allow Always";
-    case "reject_once":
-      return "Reject";
-    case "reject_always":
-      return "Block Rule";
-  }
-}
 
 /**
  * Map `PermissionOptionKind` to a Button variant. "Once" actions stay neutral

--- a/src/agentMode/ui/ToolPermissionCard.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.tsx
@@ -91,12 +91,12 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
               key={option.optionId}
               variant={variantForKind(option.kind)}
               size="sm"
-              className="tw-h-auto tw-min-h-6 tw-max-w-full tw-whitespace-normal tw-break-words"
+              className="tw-h-auto tw-min-h-6 tw-min-w-0 tw-max-w-full tw-whitespace-normal"
               disabled={busy}
               aria-describedby={option.description ? descriptionId : undefined}
               onClick={() => choose(option.optionId)}
             >
-              {option.name}
+              <span className="tw-min-w-0 tw-break-all">{option.name}</span>
             </Button>
           );
 
@@ -108,7 +108,7 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
               >
                 <p
                   id={descriptionId}
-                  className="tw-m-0 tw-w-full tw-min-w-0 tw-break-words tw-text-xs tw-text-muted"
+                  className="tw-m-0 tw-w-full tw-min-w-0 tw-break-all tw-text-xs tw-text-muted"
                 >
                   {option.description}
                 </p>

--- a/src/agentMode/ui/ToolPermissionCard.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.tsx
@@ -15,6 +15,8 @@ interface ToolPermissionCardProps {
   onResolve: (toolCallId: string, optionId: string) => void;
 }
 
+const EMPTY_OPTION_NAMES: readonly string[] = Object.freeze([]);
+
 /**
  * Inline permission card rendered at the tail of the chat scroll container
  * while a tool call is awaiting the user's decision. Replaces the modal that
@@ -148,9 +150,12 @@ function sortOptions(options: PermissionOption[]): PermissionOption[] {
   );
 }
 
-function disambiguateOptionNames(options: PermissionOption[]): string[] {
+function disambiguateOptionNames(options: PermissionOption[]): readonly string[] {
+  if (options.length === 0) return EMPTY_OPTION_NAMES;
+
   const totals = new Map<string, number>();
-  const occurrences = new Map<string, number>();
+  const suffixes = new Map<string, number>();
+  const reservedNames = new Set(options.map((option) => option.name));
 
   for (const option of options) {
     totals.set(option.name, (totals.get(option.name) ?? 0) + 1);
@@ -159,8 +164,12 @@ function disambiguateOptionNames(options: PermissionOption[]): string[] {
   return options.map((option) => {
     if (totals.get(option.name) === 1) return option.name;
 
-    const occurrence = (occurrences.get(option.name) ?? 0) + 1;
-    occurrences.set(option.name, occurrence);
-    return `${option.name} ${occurrence}`;
+    let suffix = (suffixes.get(option.name) ?? 0) + 1;
+    while (reservedNames.has(`${option.name} ${suffix}`)) suffix++;
+    suffixes.set(option.name, suffix);
+
+    const name = `${option.name} ${suffix}`;
+    reservedNames.add(name);
+    return name;
   });
 }

--- a/src/agentMode/ui/ToolPermissionCard.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { extractDiffContents, formatAgentInput, renderDiff } from "@/agentMode/ui/diffRender";
 import type {
   PermissionOption,
@@ -7,7 +8,7 @@ import type {
 } from "@/agentMode/session/types";
 import { PERMISSION_OPTION_KINDS } from "@/agentMode/session/types";
 import { ShieldQuestion } from "lucide-react";
-import React, { useId, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 
 interface ToolPermissionCardProps {
   request: PermissionPrompt;
@@ -30,7 +31,7 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
   const { toolCall, options } = request;
   const [busy, setBusy] = useState(false);
   const orderedOptions = useMemo(() => sortOptions(options), [options]);
-  const descriptionIdPrefix = useId();
+  const optionNames = useMemo(() => disambiguateOptionNames(orderedOptions), [orderedOptions]);
   const diffContents = useMemo(() => extractDiffContents(toolCall.content), [toolCall.content]);
   const inputJson = useMemo(() => formatAgentInput(toolCall.rawInput), [toolCall.rawInput]);
   const title = toolCall.title ?? "Tool call";
@@ -84,41 +85,36 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
       </div>
 
       <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2 tw-border-t tw-border-solid tw-border-border tw-px-3 tw-py-2">
-        {orderedOptions.map((option, index) => {
-          const descriptionId = `${descriptionIdPrefix}-${index}`;
-          const button = (
-            <Button
-              key={option.optionId}
-              variant={variantForKind(option.kind)}
-              size="sm"
-              className="tw-h-auto tw-min-h-6 tw-min-w-0 tw-max-w-full tw-whitespace-normal"
-              disabled={busy}
-              aria-describedby={option.description ? descriptionId : undefined}
-              onClick={() => choose(option.optionId)}
-            >
-              <span className="tw-min-w-0 tw-break-all">{option.name}</span>
-            </Button>
-          );
-
-          if (option.description) {
-            return (
-              <div
+        <TooltipProvider delayDuration={0}>
+          {orderedOptions.map((option, index) => {
+            const button = (
+              <Button
                 key={option.optionId}
-                className="tw-flex tw-w-full tw-min-w-0 tw-flex-col tw-items-start tw-gap-2 tw-rounded tw-bg-primary tw-p-2"
+                variant={variantForKind(option.kind)}
+                size="sm"
+                className="tw-h-auto tw-min-h-6 tw-min-w-0 tw-max-w-full tw-whitespace-normal"
+                disabled={busy}
+                onClick={() => choose(option.optionId)}
               >
-                <p
-                  id={descriptionId}
-                  className="tw-m-0 tw-w-full tw-min-w-0 tw-break-all tw-text-xs tw-text-muted"
+                <span className="tw-min-w-0 tw-break-all">{optionNames[index]}</span>
+              </Button>
+            );
+
+            if (!option.description) return button;
+
+            return (
+              <Tooltip key={option.optionId}>
+                <TooltipTrigger asChild>{button}</TooltipTrigger>
+                <TooltipContent
+                  side="top"
+                  className="tw-max-w-sm tw-whitespace-pre-wrap tw-break-words"
                 >
                   {option.description}
-                </p>
-                <div className="tw-flex tw-w-full tw-justify-end">{button}</div>
-              </div>
+                </TooltipContent>
+              </Tooltip>
             );
-          }
-
-          return button;
-        })}
+          })}
+        </TooltipProvider>
       </div>
     </div>
   );
@@ -150,4 +146,21 @@ function sortOptions(options: PermissionOption[]): PermissionOption[] {
   return [...options].sort(
     (a, b) => PERMISSION_OPTION_KINDS.indexOf(a.kind) - PERMISSION_OPTION_KINDS.indexOf(b.kind)
   );
+}
+
+function disambiguateOptionNames(options: PermissionOption[]): string[] {
+  const totals = new Map<string, number>();
+  const occurrences = new Map<string, number>();
+
+  for (const option of options) {
+    totals.set(option.name, (totals.get(option.name) ?? 0) + 1);
+  }
+
+  return options.map((option) => {
+    if (totals.get(option.name) === 1) return option.name;
+
+    const occurrence = (occurrences.get(option.name) ?? 0) + 1;
+    occurrences.set(option.name, occurrence);
+    return `${option.name} ${occurrence}`;
+  });
 }

--- a/src/agentMode/ui/ToolPermissionCard.tsx
+++ b/src/agentMode/ui/ToolPermissionCard.tsx
@@ -7,12 +7,16 @@ import type {
 } from "@/agentMode/session/types";
 import { PERMISSION_OPTION_KINDS } from "@/agentMode/session/types";
 import { ShieldQuestion } from "lucide-react";
-import React, { useMemo, useState } from "react";
+import React, { useId, useMemo, useState } from "react";
 
 interface ToolPermissionCardProps {
   request: PermissionPrompt;
   onResolve: (toolCallId: string, optionId: string) => void;
 }
+
+// ACP provides one name field, so adapters sometimes place a full permission
+// rule there even though the same value must also identify the action.
+const MAX_PERMISSION_BUTTON_LABEL_LENGTH = 32;
 
 /**
  * Inline permission card rendered at the tail of the chat scroll container
@@ -31,6 +35,7 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
   const { toolCall, options } = request;
   const [busy, setBusy] = useState(false);
   const orderedOptions = useMemo(() => sortOptions(options), [options]);
+  const descriptionIdPrefix = useId();
   const diffContents = useMemo(() => extractDiffContents(toolCall.content), [toolCall.content]);
   const inputJson = useMemo(() => formatAgentInput(toolCall.rawInput), [toolCall.rawInput]);
   const title = toolCall.title ?? "Tool call";
@@ -81,24 +86,62 @@ export const ToolPermissionCard: React.FC<ToolPermissionCardProps> = ({ request,
             </pre>
           </details>
         ) : null}
+
+        {orderedOptions.some(isDescriptiveOption) ? (
+          <div className="tw-flex tw-min-w-0 tw-flex-col tw-gap-1 tw-rounded tw-bg-primary tw-p-2">
+            <p className="tw-m-0 tw-text-xs tw-font-medium">Permission details</p>
+            {orderedOptions.map((option, index) =>
+              isDescriptiveOption(option) ? (
+                <p
+                  key={option.optionId}
+                  id={`${descriptionIdPrefix}-${index}`}
+                  className="tw-m-0 tw-min-w-0 tw-break-words tw-text-xs tw-text-muted"
+                >
+                  {option.name}
+                </p>
+              ) : null
+            )}
+          </div>
+        ) : null}
       </div>
 
       <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2 tw-border-t tw-border-solid tw-border-border tw-px-3 tw-py-2">
-        {orderedOptions.map((opt) => (
-          <Button
-            key={opt.optionId}
-            variant={variantForKind(opt.kind)}
-            size="sm"
-            disabled={busy}
-            onClick={() => choose(opt.optionId)}
-          >
-            {opt.name}
-          </Button>
-        ))}
+        {orderedOptions.map((option, index) => {
+          const descriptive = isDescriptiveOption(option);
+          return (
+            <Button
+              key={option.optionId}
+              variant={variantForKind(option.kind)}
+              size="sm"
+              disabled={busy}
+              aria-describedby={descriptive ? `${descriptionIdPrefix}-${index}` : undefined}
+              onClick={() => choose(option.optionId)}
+            >
+              {descriptive ? descriptiveOptionButtonLabel(option.kind) : option.name}
+            </Button>
+          );
+        })}
       </div>
     </div>
   );
 };
+
+function isDescriptiveOption(option: PermissionOption): boolean {
+  return option.name.length > MAX_PERMISSION_BUTTON_LABEL_LENGTH;
+}
+
+function descriptiveOptionButtonLabel(kind: PermissionOptionKind): string {
+  switch (kind) {
+    case "allow_once":
+      return "Allow";
+    case "allow_always":
+      return "Allow Always";
+    case "reject_once":
+      return "Reject";
+    case "reject_always":
+      return "Block Rule";
+  }
+}
 
 /**
  * Map `PermissionOptionKind` to a Button variant. "Once" actions stay neutral


### PR DESCRIPTION
## Demo

**Watch the Codex permission walkthrough:** [Watch video](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/obsidian-copilot/pr-2710/codex-permission-demo.mp4)

Fixes logancyang/obsidian-copilot-preview#249

> GitHub does not register this cross-repository closing reference in the PR metadata; manually verify and close issue #249 after merge if necessary.

## Problem

Codex permission requests could inherit the automatic approval reviewer, so Default mode did not reliably surface a user permission card. When a card did appear, persistent Codex policy rules were used as button labels and could overflow into separate rows, obscuring which decision each action represented.

ACP option kinds are not enough to distinguish a session grant from a persistent Codex policy amendment, and option IDs are backend-owned response tokens rather than presentation data.

## Fix

- Pin Codex Default mode to the user approval reviewer so permission requests reach the chat card.
- Preserve every backend-provided decision and its opaque `optionId`.
- Forward ACP option metadata unchanged through the generic boundary; interpret `_meta.codex.decision` only in the Codex descriptor.
- Present persistent policy amendments as compact `Allow Always` or `Block Always` actions, with the full rule in a hover/focus tooltip.
- Keep all actions in one wrapping footer and number only duplicate compact labels.

## Scope

Budget gate: PASS — 12 files, +395/−31. Of the added lines, 271 are behavioral tests; the runtime and documentation change is 124 added lines. The diff contains the permission routing fix, a single optional backend presentation hook, Codex-specific interpretation, the compact card presentation, and corresponding documentation. An unused reverse presentation transform was removed during simplification.

This supersedes the permission-card presentation approach in #2705 without changing that PR.

## Changes

- Add the managed Codex `approvals_reviewer = "user"` setting and regression coverage.
- Add an opaque metadata pass-through hook at the ACP/backend descriptor boundary.
- Classify only validated Codex policy amendment decisions as persistent action labels.
- Render descriptions in accessible tooltips while preserving exact option IDs on selection.
- Cover multiple policies, session decisions, malformed metadata, rejection polarity, ordering, layout constraints, and click routing.

## Verification

- `npm run format`
- `npm run lint`
- `npm test -- --runInBand` — 345 suites, 4,898 tests passed
- `npm run build`
- `git diff --check FETCH_HEAD...HEAD`
- Focused permission coverage — 4 suites, 46 tests passed
- `npm run test:vault` — deployed clean head `f1b31f1e` and exercised a real Codex Default-mode permission request.
- Live card rendered `Allow Once`, `Allow for Session`, `Allow Always`, and `Reject` in one footer on the same baseline. The full `mkdir` policy rule was hidden until hovering `Allow Always`, then rendered in a 384×46 px tooltip without moving the actions.
- Rejected the live request; the target directory remained absent, the permission card cleared, and Obsidian reported no uncaught or console errors. The shared vault's pre-existing live build, on-disk build, settings, and content were restored afterward.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
