### PR TITLE
feat(settings): fold Agents into Basic (v4, part 3)

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -39,7 +39,7 @@ Selecting a row only previews its action. **Start chat** saves that agent as the
 
 ### Choosing the OpenCode Binary Source
 
-The OpenCode setup dialog (**Settings → Copilot → Agents → opencode → Configure**) offers two ways to provide the binary, shown one at a time: **Managed by Copilot**, where Copilot downloads and updates an official release for you, and **My own binary**, where you point Copilot at an OpenCode you already have installed.
+The OpenCode setup dialog (**Settings → Copilot → Basic → Agents → opencode → Configure**) offers two ways to provide the binary, shown one at a time: **Managed by Copilot**, where Copilot downloads and updates an official release for you, and **My own binary**, where you point Copilot at an OpenCode you already have installed.
 
 Switching between the two views only changes which controls you see — it never changes the binary in use. The actual switch happens when you act: **Download & install** activates the managed copy, and applying a path under **My own binary** activates yours. Your saved custom path is kept while you browse the managed view, and the dialog tells you whenever the source you're looking at is not the one currently in use.
 
@@ -259,7 +259,7 @@ For v4, Claude runs delegated agents and Bash commands synchronously. Copilot wa
 
 The Workflow tool and remote-isolated agents are temporarily unavailable because they require background execution. Local agents, including worktree-isolated agents, remain available and run synchronously. Background execution will return after Copilot moves Claude sessions to a persistent streaming lifecycle.
 
-This requires Claude Code 2.1.206 or newer. Copilot checks the installed version when it starts and whenever you apply or auto-detect a Claude binary. An older binary is marked **Incompatible version** in Settings → Copilot → Agents → Claude and cannot start a session. If you select Claude in chat, Copilot shows the required version and a **Configure Claude** button that opens the same setup dialog; installation guidance stays in that dialog.
+This requires Claude Code 2.1.206 or newer. Copilot checks the installed version when it starts and whenever you apply or auto-detect a Claude binary. An older binary is marked **Incompatible version** in Settings → Copilot → Basic → Agents → Claude and cannot start a session. If you select Claude in chat, Copilot shows the required version and a **Configure Claude** button that opens the same setup dialog; installation guidance stays in that dialog.
 
 If Claude's usage is exhausted, Copilot shows Claude's own error in chat, including the reset time when Claude provides one. You can wait until the limit resets or switch to another agent.
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -39,7 +39,9 @@ Selecting a row only previews its action. **Start chat** saves that agent as the
 
 ### Choosing the OpenCode Binary Source
 
-The OpenCode setup dialog (**Settings → Copilot → Basic → Agents → opencode → Configure**) offers two ways to provide the binary, shown one at a time: **Managed by Copilot**, where Copilot downloads and updates an official release for you, and **My own binary**, where you point Copilot at an OpenCode you already have installed.
+Before OpenCode is set up, its row under **Settings → Copilot → Basic → Agents → opencode** offers both sources directly: **Download opencode** fetches an official release for Copilot to manage, and **I already have it** looks for an OpenCode you installed yourself. If that search finds nothing, a **Configure** button appears next to them so you can type the path by hand.
+
+Once OpenCode is set up, that row's **Configure** button opens the setup dialog, which shows the same two sources one at a time: **Managed by Copilot**, where Copilot downloads and updates an official release for you, and **My own binary**, where you point Copilot at an OpenCode you already have installed.
 
 Switching between the two views only changes which controls you see — it never changes the binary in use. The actual switch happens when you act: **Download & install** activates the managed copy, and applying a path under **My own binary** activates yours. Your saved custom path is kept while you browse the managed view, and the dialog tells you whenever the source you're looking at is not the one currently in use.
 

--- a/docs/agent-mode-windows-setup.md
+++ b/docs/agent-mode-windows-setup.md
@@ -12,7 +12,7 @@ irm https://gist.githubusercontent.com/logancyang/7a87eb38d91015eac567521f8cc9c7
 
 When Claude asks you to sign in, finish the browser login. The installer copies the `claude.exe` path to your clipboard.
 
-In Obsidian: **Settings -> Copilot -> Agents -> Claude -> Configure -> Auto-detect**. If it doesn't find Claude, paste the copied path into the binary path field, then save.
+In Obsidian: **Settings -> Copilot -> Basic -> Agents -> Claude -> Configure -> Auto-detect**. If it doesn't find Claude, paste the copied path into the binary path field, then save.
 
 Open a Copilot chat, switch to **Agent Mode**, pick **Claude**, and send a message.
 
@@ -28,7 +28,7 @@ irm https://gist.githubusercontent.com/logancyang/380ef4dbf9f98900771da76eca3d21
 
 When Codex asks you to sign in, finish the login. The installer copies the `codex-acp.exe` path to your clipboard.
 
-In Obsidian: **Settings -> Copilot -> Agents -> Codex -> Configure**. Paste the copied path into the binary path field, leave **Environment variables** empty, then save.
+In Obsidian: **Settings -> Copilot -> Basic -> Agents -> Codex -> Configure**. Paste the copied path into the binary path field, leave **Environment variables** empty, then save.
 
 Open a Copilot chat, switch to **Agent Mode**, pick **Codex**, and send a message.
 

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -89,7 +89,7 @@ Where:
 - `{$date}` — Date in YYYY-MM-DD format
 - `{$time}` — Time in HH-MM-SS format
 
-All three variables are required. You can customize the format in Settings → Basic → **Conversation note name**.
+All three variables are required. To customize the format, turn on **Autosave Chat as Markdown** in Settings → Basic → Saving conversations, then expand **Advanced** in that same section.
 
 ### AI-Generated Titles
 

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -89,7 +89,7 @@ Where:
 - `{$date}` — Date in YYYY-MM-DD format
 - `{$time}` — Time in HH-MM-SS format
 
-All three variables are required. To customize the format, turn on **Autosave Chat as Markdown** in Settings → Basic → Saving conversations, then expand **Advanced** in that same section.
+All three variables are required. To customize the format, expand **Advanced** under Settings → Basic → Saving conversations. The template names both autosaved notes and the ones you save yourself with **Save Chat as Note**.
 
 ### AI-Generated Titles
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,7 @@ The default model is **OpenRouter Gemini 2.5 Flash**, which requires an OpenRout
 
 ### Step 3: Choose a Default Model
 
-Add a provider and its models on the **Models (BYOK)** tab, then choose which of those models appear in chat under **Basic → Agents → Quick Chat models**. On the **Basic** tab, use the **Default Chat Model** dropdown to select the model you want to use.
+Add a provider and its models on the **Models (BYOK)** tab, then open **Basic → Agents → Quick Chat**: enable the ones you want to see in chat under **Quick Chat models**, and pick the one new chats start with under **Default model**.
 
 ### Step 4: Choose a Chat Mode
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,7 @@ The default model is **OpenRouter Gemini 2.5 Flash**, which requires an OpenRout
 
 ### Step 3: Choose a Default Model
 
-Add a provider and its models on the **Models (BYOK)** tab, then choose which of those models appear in chat under **Agents → Quick Chat models**. On the **Basic** tab, use the **Default Chat Model** dropdown to select the model you want to use.
+Add a provider and its models on the **Models (BYOK)** tab, then choose which of those models appear in chat under **Basic → Agents → Quick Chat models**. On the **Basic** tab, use the **Default Chat Model** dropdown to select the model you want to use.
 
 ### Step 4: Choose a Chat Mode
 

--- a/docs/install-claude-agent-mode-windows.ps1
+++ b/docs/install-claude-agent-mode-windows.ps1
@@ -68,5 +68,5 @@ Write-Host ""
 Write-Host "Done. $clipboardMessage"
 Write-Host $claude
 Write-Host ""
-Write-Host "Next: Obsidian -> Settings -> Copilot -> Agents -> Claude -> Configure"
+Write-Host "Next: Obsidian -> Settings -> Copilot -> Basic -> Agents -> Claude -> Configure"
 Write-Host "Click Auto-detect. If needed, paste this path into the binary path field, then save."

--- a/docs/install-codex-agent-mode-windows.ps1
+++ b/docs/install-codex-agent-mode-windows.ps1
@@ -171,5 +171,5 @@ Write-Host ""
 Write-Host "Done. $clipboardMessage"
 Write-Host $acp
 Write-Host ""
-Write-Host "Next: Obsidian -> Settings -> Copilot -> Agents -> Codex -> Configure"
+Write-Host "Next: Obsidian -> Settings -> Copilot -> Basic -> Agents -> Codex -> Configure"
 Write-Host "Paste this path into the binary path field, leave Environment variables empty, then save."

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -10,7 +10,7 @@ Copilot includes 16 built-in AI providers, and you can add an unlimited number o
 2. Add a provider
 3. Enter the provider API key and select the models you want to configure
 4. Click Save
-5. Enable models for chat under **Agents → Quick Chat models**
+5. Enable models for chat under **Basic → Agents → Quick Chat models**
 
 You can configure multiple providers simultaneously and switch between them by changing the default model.
 

--- a/docs/models-and-parameters.md
+++ b/docs/models-and-parameters.md
@@ -164,9 +164,9 @@ Reduces the likelihood of the model repeating itself.
 ## Default Model Selection
 
 Your **default model** is the one Copilot uses when you open a new chat. Set it in:
-**Settings → Copilot → Basic → Default Chat Model**
+**Settings → Copilot → Basic → Agents → Quick Chat → Default model**
 
-The dropdown contains models enabled under **Basic → Agents → Quick Chat models**.
+The dropdown contains models enabled under **Quick Chat models**, in that same panel.
 
 ---
 

--- a/docs/models-and-parameters.md
+++ b/docs/models-and-parameters.md
@@ -43,7 +43,8 @@ Models may show capability badges:
 ### Managing Models
 
 Go to **Settings → Copilot → Models (BYOK)** to add or edit providers and choose the models
-available from each provider. Then go to **Settings → Copilot → Agents → Quick Chat models** to
+available from each provider. Then go to **Settings → Copilot → Basic → Agents → Quick Chat
+models** to
 control which configured models appear in chat model selectors.
 
 ### Adding Custom Models
@@ -165,7 +166,7 @@ Reduces the likelihood of the model repeating itself.
 Your **default model** is the one Copilot uses when you open a new chat. Set it in:
 **Settings → Copilot → Basic → Default Chat Model**
 
-The dropdown contains models enabled under **Agents → Quick Chat models**.
+The dropdown contains models enabled under **Basic → Agents → Quick Chat models**.
 
 ---
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -50,7 +50,7 @@ An optional description of what the project is for.
 ### Model
 
 Choose which AI model to use for this project. The available options are the models enabled under
-**Settings → Copilot → Agents → Quick Chat models**.
+**Settings → Copilot → Basic → Agents → Quick Chat models**.
 
 ### Model Settings
 

--- a/src/LLMProviders/chainManager.ts
+++ b/src/LLMProviders/chainManager.ts
@@ -127,7 +127,7 @@ export default class ChainManager {
         );
         if (!resolution.ok) {
           throw new MissingModelKeyError(
-            "No chat model enabled. Enable a model under Settings → Agents → Quick Chat, " +
+            "No chat model enabled. Enable a model under Settings → Basic → Agents → Quick Chat, " +
               "or add one on the Models (BYOK) tab."
           );
         }

--- a/src/agentMode/agentModelDiscovery.test.ts
+++ b/src/agentMode/agentModelDiscovery.test.ts
@@ -230,7 +230,7 @@ describe("wireAgentModelDiscovery", () => {
     unsub();
   });
 
-  it("keeps every registered model enabled regardless of catalog order", async () => {
+  it("leaves autoEnrollModelIds unset for codex so its whole catalog starts enabled", async () => {
     mockDescriptors = [makeDescriptor({ id: "codex" })];
     const a = makeApiFake();
     const catalog = catalogWithModels(["gpt-5", "gpt-5.5"]);
@@ -242,11 +242,12 @@ describe("wireAgentModelDiscovery", () => {
     const unsub = wireAgentModelDiscovery(makePlugin(a.api), manager);
     await waitForDiscoveryLog("first enrollment for codex");
     expect(a.registerAgentProvider.mock.calls[0][0].wireModelIds).toEqual(["gpt-5", "gpt-5.5"]);
+    expect(a.registerAgentProvider.mock.calls[0][0].autoEnrollModelIds).toBeUndefined();
     expect(a.setEnabledModels).not.toHaveBeenCalled();
     unsub();
   });
 
-  it("keeps every remaining OpenCode model enabled after managed-provider suppression", async () => {
+  it("enrolls every remaining OpenCode model after managed-provider suppression", async () => {
     mockDescriptors = [makeDescriptor({ id: "opencode" })];
     const m = makeManagerFake();
     const a = makeApiFake();
@@ -268,6 +269,50 @@ describe("wireAgentModelDiscovery", () => {
       "opencode/small-gherkin",
     ]);
     expect(a.setEnabledModels).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it("enables only the first three OpenCode models while enrolling the rest", async () => {
+    mockDescriptors = [makeDescriptor({ id: "opencode" })];
+    const m = makeManagerFake();
+    const a = makeApiFake();
+    m.setCatalog(
+      "opencode",
+      catalogWithModels([
+        "opencode/big-pickle",
+        "opencode/claude-fable-5",
+        "opencode/claude-haiku-4-5",
+        "opencode/claude-opus-4-1",
+        "opencode/small-gherkin",
+      ])
+    );
+
+    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+    await waitForDiscoveryLog("first enrollment for opencode");
+
+    const input = a.registerAgentProvider.mock.calls[0][0];
+    // Every model is still enrolled, so the curation UI can list all five.
+    expect(input.wireModelIds).toHaveLength(5);
+    expect(input.autoEnrollModelIds).toEqual([
+      "opencode/big-pickle",
+      "opencode/claude-fable-5",
+      "opencode/claude-haiku-4-5",
+    ]);
+    unsub();
+  });
+
+  it("enables every OpenCode model when fewer than three survive suppression", async () => {
+    mockDescriptors = [makeDescriptor({ id: "opencode" })];
+    const m = makeManagerFake();
+    const a = makeApiFake();
+    m.setCatalog("opencode", catalogWithModels(["opencode/big-pickle"]));
+
+    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+    await waitForDiscoveryLog("first enrollment for opencode");
+
+    expect(a.registerAgentProvider.mock.calls[0][0].autoEnrollModelIds).toEqual([
+      "opencode/big-pickle",
+    ]);
     unsub();
   });
 

--- a/src/agentMode/agentModelDiscovery.ts
+++ b/src/agentMode/agentModelDiscovery.ts
@@ -4,9 +4,10 @@
  * `origin: "agent"` `ConfiguredModel` so the curation UI and chat picker can
  * show the agent-discovered set.
  *
- * First enrollment of an `agentType` creates the provider and enables every
- * reported model; every later probe only reconciles the model list (no
- * provider-row write), so re-probes don't churn settings.
+ * First enrollment of an `agentType` creates the provider and enrolls every
+ * reported model, enabling all of them (opencode: only the first few — see
+ * `OPENCODE_DEFAULT_ENABLED_COUNT`); every later probe only reconciles the
+ * model list (no provider-row write), so re-probes don't churn settings.
  *
  * opencode enrolls all its models under a single agent provider, each
  * `ConfiguredModel.info.id` keeping the full prefixed wire form (e.g.
@@ -35,6 +36,13 @@ const PROVIDER_TYPE_BY_AGENT: Record<AgentType, ProviderType> = {
   codex: "openai-compatible",
   opencode: "openai-compatible",
 };
+
+/**
+ * How many opencode models start enabled on first enrollment. Small enough to
+ * keep the model picker scannable without hiding the catalog — the rest are
+ * enrolled and one toggle away in Settings.
+ */
+const OPENCODE_DEFAULT_ENABLED_COUNT = 3;
 
 /**
  * Subscribe (for the plugin's lifetime) to the model cache and enroll each
@@ -107,7 +115,7 @@ export function wireAgentModelDiscovery(
 
 /**
  * Enroll one backend's reported wire ids through `AgentSetupApi`: first
- * enrollment registers the provider and keeps every reported model enabled;
+ * enrollment registers the provider and picks the initially-enabled set;
  * later enrollments only reconcile the model list. opencode first drops models
  * it shares with a Copilot-managed provider.
  */
@@ -161,8 +169,21 @@ async function enrollBackend(
     return;
   }
 
-  // First enrollment keeps every registered model enabled. Catalog ordering
-  // carries no backend-default semantics.
+  // opencode advertises a large hosted catalog and, unlike codex, gets no
+  // (model × effort) collapsing in the picker — one reported model is one row.
+  // Enabling all of them buries the picker in scroll on a fresh install, so
+  // only the first few start on; the rest are still enrolled and one toggle
+  // away in Settings.
+  //
+  // "First few" is presentation order, not a quality ranking: the protocol
+  // carries no recommendation or default signal, so this is a deterministic
+  // fallback for a count the product chose, not an assertion about which
+  // models are best.
+  const autoEnrollModelIds =
+    descriptor.id === "opencode"
+      ? wireModelIds.slice(0, OPENCODE_DEFAULT_ENABLED_COUNT)
+      : undefined;
+
   const result = await api.setup.agent.registerAgentProvider({
     agentType,
     providerType: PROVIDER_TYPE_BY_AGENT[agentType],
@@ -171,13 +192,15 @@ async function enrollBackend(
     // own models, so the keychain id stays null.
     apiKey: null,
     wireModelIds,
+    autoEnrollModelIds,
     fallbackDisplayNames,
     fallbackDescriptions,
   });
 
   logInfo(
     `[AgentMode] model discovery: first enrollment for ${agentType} — ` +
-      `${result.configuredModelIds.length} model(s) configured and enabled`
+      `${result.configuredModelIds.length} model(s) configured, ` +
+      `${autoEnrollModelIds?.length ?? result.configuredModelIds.length} enabled`
   );
 }
 

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -673,6 +673,29 @@ describe("OpencodeBinaryManager runtime state", () => {
     expect(mgr.isBusy()).toBe(false);
   });
 
+  it("drops a settled error when a new plugin lifecycle starts", async () => {
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+    await expect(mgr.adoptExistingBinary()).rejects.toBeInstanceOf(OpencodeNotFoundError);
+
+    mgr.forgetSettledError();
+
+    // The manager is a module-level singleton, so without this the next vault
+    // opened in the same process would greet the user with this vault's error.
+    expect(mgr.getRuntimeState()).toEqual({ kind: "idle" });
+  });
+
+  it("keeps a running operation visible across a lifecycle boundary", async () => {
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+    const inFlight = mgr.setCustomBinaryPath(process.execPath);
+
+    mgr.forgetSettledError();
+
+    // A run still belongs to this process; the new lifecycle adopts it rather
+    // than dropping to idle and offering a rival action underneath it.
+    expect(mgr.getRuntimeState()).toEqual({ kind: "busy" });
+    await inFlight;
+  });
+
   it("is not busy before anything has run", () => {
     expect(new OpencodeBinaryManager(fakePlugin).isBusy()).toBe(false);
   });

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -60,6 +60,7 @@ import {
   legacyVaultDataDir,
   opencodeManagedDataDir,
   OpencodeBinaryManager,
+  OperationInFlightError,
   parseVersionFromStdout,
   pickMatchingAsset,
   toOpencodeInstallState,
@@ -581,5 +582,80 @@ describe("OpencodeBinaryManager.uninstall / downloadsSize", () => {
     } finally {
       await fs.promises.rm(vaultBase, { recursive: true, force: true });
     }
+  });
+});
+
+describe("OpencodeBinaryManager runtime state", () => {
+  beforeEach(() => settingsMock.__reset({}));
+
+  it("starts idle and hands every subscriber the same snapshot object", () => {
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+    expect(mgr.getRuntimeState()).toEqual({ kind: "idle" });
+    // useSyncExternalStore compares snapshots by identity; an unchanged store
+    // returning a fresh object every call would re-render on every commit.
+    expect(mgr.getRuntimeState()).toBe(mgr.getRuntimeState());
+  });
+
+  it("notifies subscribers on each transition and stops after unsubscribe", async () => {
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+    const seen: string[] = [];
+    const unsubscribe = mgr.subscribeRuntimeState(() => seen.push(mgr.getRuntimeState().kind));
+
+    await mgr.setCustomBinaryPath(process.execPath);
+    expect(seen).toEqual(["busy", "idle"]);
+
+    unsubscribe();
+    await mgr.setCustomBinaryPath(null);
+    expect(seen).toEqual(["busy", "idle"]);
+  });
+
+  it("reports a failed operation as an error state the next reader can show", async () => {
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+    await expect(mgr.setCustomBinaryPath("/definitely/not/here")).rejects.toThrow(/No file at/);
+    // Durable rather than announced: whichever surface mounts next renders it.
+    expect(mgr.getRuntimeState()).toEqual({
+      kind: "error",
+      message: expect.stringContaining("No file at"),
+    });
+  });
+
+  it("clears a previous error once the next operation succeeds", async () => {
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+    await expect(mgr.setCustomBinaryPath("/definitely/not/here")).rejects.toThrow();
+
+    await mgr.setCustomBinaryPath(process.execPath);
+
+    expect(mgr.getRuntimeState()).toEqual({ kind: "idle" });
+  });
+
+  it("refuses a second operation while one holds the binary-path lock", async () => {
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+    // The lock is taken synchronously, before the first await inside the
+    // operation, so the call below is genuinely the second one in.
+    const first = mgr.setCustomBinaryPath(process.execPath);
+    expect(mgr.isBusy()).toBe(true);
+
+    // Both writers persist binaryPath/binarySource, so letting them overlap is
+    // what lets whichever settles last name a source the user did not choose.
+    await expect(mgr.adoptExistingBinary()).rejects.toBeInstanceOf(OperationInFlightError);
+
+    await first;
+    expect(settingsMock.__get().binaryPath).toBe(process.execPath);
+  });
+
+  it("frees the lock once the operation settles, including on failure", async () => {
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+    await expect(mgr.setCustomBinaryPath("/definitely/not/here")).rejects.toThrow();
+
+    expect(mgr.isBusy()).toBe(false);
+    await expect(mgr.setCustomBinaryPath(process.execPath)).resolves.toBeUndefined();
+  });
+
+  it("is not busy before anything has run", () => {
+    expect(new OpencodeBinaryManager(fakePlugin).isBusy()).toBe(false);
+  });
+
+  it("ignores a cancel when nothing is running", () => {
+    expect(() => new OpencodeBinaryManager(fakePlugin).cancelCurrentOperation()).not.toThrow();
   });
 });

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -592,7 +592,7 @@ describe("OpencodeBinaryManager.uninstall / downloadsSize", () => {
   });
 });
 
-describe("OpencodeBinaryManager runtime state", () => {
+describe("OpencodeBinaryManager.runtimeState", () => {
   beforeEach(() => settingsMock.__reset({}));
 
   it("starts idle and hands every subscriber the same snapshot object", () => {

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -49,6 +49,12 @@ jest.mock("@/settings/model", () => {
   };
 });
 
+// The real detector walks this machine's PATH and install dirs, so adopt tests
+// would pass or fail on whether the developer happens to have opencode.
+jest.mock("./opencodeCliDetector", () => ({
+  detectOpencodeCliPath: jest.fn(async () => null),
+}));
+
 import { OPENCODE_MIN_ACP_VERSION, OPENCODE_PINNED_VERSION } from "./ui/opencodeVersion";
 import { copilotAppDataDir } from "@/utils/appPaths";
 import * as fs from "node:fs";
@@ -60,6 +66,7 @@ import {
   legacyVaultDataDir,
   opencodeManagedDataDir,
   OpencodeBinaryManager,
+  OpencodeNotFoundError,
   OperationInFlightError,
   parseVersionFromStdout,
   pickMatchingAsset,
@@ -649,6 +656,21 @@ describe("OpencodeBinaryManager runtime state", () => {
 
     expect(mgr.isBusy()).toBe(false);
     await expect(mgr.setCustomBinaryPath(process.execPath)).resolves.toBeUndefined();
+  });
+
+  it("leaves a fruitless detect in the error state rather than back at idle", async () => {
+    const mgr = new OpencodeBinaryManager(fakePlugin);
+
+    await expect(mgr.adoptExistingBinary()).rejects.toBeInstanceOf(OpencodeNotFoundError);
+
+    // Resolving would settle the store back to idle, and the settings row only
+    // offers Configure — the one way to name a binary the search cannot see —
+    // while an error is showing.
+    expect(mgr.getRuntimeState()).toEqual({
+      kind: "error",
+      message: expect.stringContaining("Couldn't find opencode"),
+    });
+    expect(mgr.isBusy()).toBe(false);
   });
 
   it("is not busy before anything has run", () => {

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -15,6 +15,7 @@ import * as path from "node:path";
 import { promisify } from "node:util";
 import { renameWithRetry } from "@/agentMode/skills/renameWithRetry";
 import { copilotAppDataDir } from "@/utils/appPaths";
+import { detectOpencodeCliPath } from "./opencodeCliDetector";
 import { expectedBinaryName, resolveOpencodeTarget } from "./platformResolver";
 import type { InstallState as BackendInstallState } from "@/agentMode/session/types";
 
@@ -42,6 +43,32 @@ export interface InstallOptions {
 export type InstallState =
   | { kind: "absent" }
   | { kind: "installed"; version: string; path: string; source: "managed" | "custom" };
+
+/**
+ * What the manager is currently doing to the opencode binary, as opposed to
+ * {@link InstallState}, which is what the *persisted settings* say. Every UI
+ * that can start one of these operations reads this, so none of them offers a
+ * competing action while one is running.
+ *
+ * `busy` covers the operations with nothing to show but the fact that they are
+ * running; `installing` is separate because it carries download progress.
+ */
+export type RuntimeState =
+  | { kind: "idle" }
+  | { kind: "detecting" }
+  | { kind: "installing"; progress: ProgressEvent | null }
+  | { kind: "busy" }
+  | { kind: "error"; message: string };
+
+/** Thrown when a second binary-path operation is started while one is running. */
+export class OperationInFlightError extends Error {
+  constructor() {
+    super("An opencode setup operation is already running.");
+    this.name = "OperationInFlightError";
+  }
+}
+
+const describeOperationError = (e: unknown): string => (e instanceof Error ? e.message : String(e));
 
 interface GithubAsset {
   name: string;
@@ -217,6 +244,122 @@ export function legacyVaultDataDir(
 export class OpencodeBinaryManager {
   constructor(private readonly plugin: CopilotPlugin) {}
 
+  /**
+   * The operation currently holding the binary-path write lock, or null. Only
+   * one may run at a time: `install` lands a managed binary and
+   * `setCustomBinaryPath` saves a user-supplied one, but both write the same
+   * `binaryPath`/`binarySource` settings, so two in flight would let whichever
+   * settled last decide the source the user did not choose last.
+   *
+   * DESIGN NOTE — this deliberately outlives a plugin lifecycle. Module scope
+   * survives disable→enable, dev hot reload, and "Open another vault" in the
+   * same process (`main.ts` says so where it resets the persistence
+   * singletons), and `getOpencodeBinaryManager` caches this manager at module
+   * scope, so an operation started in one lifecycle is still here in the next.
+   * That carry-over is coherent rather than corrupting: every UI reads the same
+   * runtime state and offers no competing action while it is set, so the next
+   * lifecycle adopts the run instead of starting a rival one.
+   *
+   * The one effect that crosses the boundary is the settings write when an
+   * install lands, and it is accurate: `getDataDir()` builds under
+   * `os.homedir()`, so the binary it names really is installed for whatever
+   * vault is open. The vault that started the download is the one left out, and
+   * it self-heals — `install()` is idempotent, so Download there returns
+   * instantly off the existing manifest.
+   * If a future review flags the lifecycle boundary, point them at this note.
+   */
+  private operation: { controller: AbortController } | null = null;
+  private runtimeState: RuntimeState = { kind: "idle" };
+  private readonly runtimeSubscribers = new Set<() => void>();
+
+  /**
+   * Subscribe to {@link getRuntimeState}. Bound once so React's
+   * `useSyncExternalStore` sees a stable reference and does not resubscribe on
+   * every render.
+   */
+  readonly subscribeRuntimeState = (onChange: () => void): (() => void) => {
+    this.runtimeSubscribers.add(onChange);
+    return () => {
+      this.runtimeSubscribers.delete(onChange);
+    };
+  };
+
+  /**
+   * Current runtime state. The returned object is replaced, never mutated, so
+   * `useSyncExternalStore` can compare snapshots by identity.
+   */
+  readonly getRuntimeState = (): RuntimeState => this.runtimeState;
+
+  private setRuntimeState(next: RuntimeState): void {
+    this.runtimeState = next;
+    this.runtimeSubscribers.forEach((notify) => notify());
+  }
+
+  /** Whether a binary-path operation is running, from any entry point. */
+  isBusy(): boolean {
+    return this.operation !== null;
+  }
+
+  /**
+   * Cancel the running operation, if it is one that can be cancelled. A no-op
+   * otherwise — only the managed install is interruptible.
+   */
+  cancelCurrentOperation(): void {
+    this.operation?.controller.abort();
+  }
+
+  /**
+   * Run `body` as the one binary-path operation, publishing `running` for its
+   * duration and settling back to idle (or to an error the UI can show).
+   *
+   * Every public method that writes `binaryPath`/`binarySource` goes through
+   * here, which is what makes the lock complete: guarding only the managed
+   * install would still let the Configure dialog apply a custom path
+   * underneath it.
+   *
+   * @param running - State published while `body` runs.
+   * @param body - Receives the signal to honour for cancellation.
+   */
+  private async runExclusive<T>(
+    running: RuntimeState,
+    body: (signal: AbortSignal) => Promise<T>
+  ): Promise<T> {
+    if (this.operation) throw new OperationInFlightError();
+    const controller = new AbortController();
+    this.operation = { controller };
+    this.setRuntimeState(running);
+    try {
+      const result = await body(controller.signal);
+      this.operation = null;
+      this.setRuntimeState({ kind: "idle" });
+      return result;
+    } catch (e) {
+      this.operation = null;
+      // A cancellation is the user's own doing, so it returns to idle rather
+      // than reporting a failure they would have to dismiss.
+      if (e instanceof AbortError || (e as Error | undefined)?.name === "AbortError") {
+        this.setRuntimeState({ kind: "idle" });
+      } else {
+        this.setRuntimeState({ kind: "error", message: describeOperationError(e) });
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Link a caller-supplied signal to this operation's own controller, so a
+   * caller that already had one (the Configure dialog) keeps working while the
+   * manager stays the single place that can cancel.
+   */
+  private static linkSignal(external: AbortSignal | undefined, controller: AbortController): void {
+    if (!external) return;
+    if (external.aborted) {
+      controller.abort();
+      return;
+    }
+    external.addEventListener("abort", () => controller.abort(), { once: true });
+  }
+
   getInstallState(): InstallState {
     return computeInstallState(readOpencodeSettings());
   }
@@ -270,11 +413,46 @@ export class OpencodeBinaryManager {
   }
 
   /**
+   * Download and activate the pinned opencode build, holding the binary-path
+   * lock for the whole run and publishing download progress as it goes.
+   *
+   * `opts.signal` still works and is linked to the manager's own controller, so
+   * an existing caller keeps its cancellation while
+   * {@link cancelCurrentOperation} can reach the same run.
+   */
+  async install(opts: InstallOptions = {}): Promise<{ version: string; path: string }> {
+    return this.runExclusive({ kind: "installing", progress: null }, (signal) => {
+      OpencodeBinaryManager.linkSignal(opts.signal, this.operationController());
+      return this.installPipeline({
+        ...opts,
+        signal,
+        onProgress: (e) => {
+          this.setRuntimeState({ kind: "installing", progress: e });
+          opts.onProgress?.(e);
+        },
+      });
+    });
+  }
+
+  /** The controller of the operation `runExclusive` just opened. */
+  private operationController(): AbortController {
+    if (!this.operation) throw new Error("No opencode operation is running.");
+    return this.operation.controller;
+  }
+
+  /**
    * Full install pipeline: resolve target → fetch release metadata →
    * download → extract → atomic rename → persist settings. Idempotent when
    * an existing install matches the pinned manifest.
+   *
+   * Private and lock-free on purpose: {@link install} and
+   * {@link upgradeManaged} are the entry points that own an operation, and
+   * upgrade calls this directly so it does not re-enter the lock it already
+   * holds — or settle the run to idle before it has removed the old version.
    */
-  async install(opts: InstallOptions = {}): Promise<{ version: string; path: string }> {
+  private async installPipeline(
+    opts: InstallOptions = {}
+  ): Promise<{ version: string; path: string }> {
     const version = opts.version ?? OPENCODE_PINNED_VERSION;
     const dataDir = this.getDataDir();
     const versionDir = path.join(dataDir, version);
@@ -412,21 +590,36 @@ export class OpencodeBinaryManager {
    * Upgrade a managed install to the pinned version: install the pinned binary
    * (atomic — the existing one keeps working until the new one is staged in),
    * then remove the previously-active managed version dir when it differs.
+   *
+   * Owns the operation itself and drives {@link installPipeline} directly, so
+   * the run stays locked — and the row stays on "installing" — until the old
+   * version dir is gone, not just until the new binary lands.
    */
   async upgradeManaged(opts: InstallOptions = {}): Promise<{ version: string; path: string }> {
-    const prev = readOpencodeSettings();
-    const result = await this.install({ ...opts, version: OPENCODE_PINNED_VERSION });
-    if (
-      prev.binarySource === "managed" &&
-      prev.binaryVersion &&
-      prev.binaryVersion !== result.version
-    ) {
-      const oldDir = path.join(this.getDataDir(), prev.binaryVersion);
-      await removeDir(oldDir).catch((e) =>
-        logWarn(`[AgentMode] failed to remove old opencode ${oldDir}: ${e}`)
-      );
-    }
-    return result;
+    return this.runExclusive({ kind: "installing", progress: null }, async (signal) => {
+      OpencodeBinaryManager.linkSignal(opts.signal, this.operationController());
+      const prev = readOpencodeSettings();
+      const result = await this.installPipeline({
+        ...opts,
+        signal,
+        version: OPENCODE_PINNED_VERSION,
+        onProgress: (e) => {
+          this.setRuntimeState({ kind: "installing", progress: e });
+          opts.onProgress?.(e);
+        },
+      });
+      if (
+        prev.binarySource === "managed" &&
+        prev.binaryVersion &&
+        prev.binaryVersion !== result.version
+      ) {
+        const oldDir = path.join(this.getDataDir(), prev.binaryVersion);
+        await removeDir(oldDir).catch((e) =>
+          logWarn(`[AgentMode] failed to remove old opencode ${oldDir}: ${e}`)
+        );
+      }
+      return result;
+    });
   }
 
   /**
@@ -436,34 +629,36 @@ export class OpencodeBinaryManager {
    * are untouched. Throws with a readable message on failure.
    */
   async upgradeCustomBinary(): Promise<{ version: string; path: string }> {
-    const s = readOpencodeSettings();
-    if (s.binarySource !== "custom" || !s.binaryPath) {
-      throw new Error("No custom opencode binary is configured to upgrade.");
-    }
-    const binaryPath = s.binaryPath;
-    try {
-      await execFileAsync(binaryPath, ["upgrade"], {
-        timeout: UPGRADE_BINARY_TIMEOUT_MS,
-        windowsHide: true,
-      });
-    } catch (e) {
-      const err = e as NodeJS.ErrnoException;
-      throw new Error(`\`${binaryPath} upgrade\` failed: ${err.message ?? String(err)}`);
-    }
-    const { stdout } = await verifyOpencodeBinary(binaryPath);
-    const version = parseVersionFromStdout(stdout);
-    if (!version) {
-      throw new Error(`${binaryPath} --version didn't report a version after upgrade.`);
-    }
-    if (isOpencodeVersionOutdated(version)) {
-      throw new Error(
-        `opencode upgrade did not reach the required version ${OPENCODE_MIN_ACP_VERSION}+ ` +
-          `(still v${version}).`
-      );
-    }
-    updateOpencodeFields({ binaryVersion: version, binaryPath, binarySource: "custom" });
-    logInfo(`[AgentMode] upgraded custom opencode to ${version}`);
-    return { version, path: binaryPath };
+    return this.runExclusive({ kind: "busy" }, async () => {
+      const s = readOpencodeSettings();
+      if (s.binarySource !== "custom" || !s.binaryPath) {
+        throw new Error("No custom opencode binary is configured to upgrade.");
+      }
+      const binaryPath = s.binaryPath;
+      try {
+        await execFileAsync(binaryPath, ["upgrade"], {
+          timeout: UPGRADE_BINARY_TIMEOUT_MS,
+          windowsHide: true,
+        });
+      } catch (e) {
+        const err = e as NodeJS.ErrnoException;
+        throw new Error(`\`${binaryPath} upgrade\` failed: ${err.message ?? String(err)}`);
+      }
+      const { stdout } = await verifyOpencodeBinary(binaryPath);
+      const version = parseVersionFromStdout(stdout);
+      if (!version) {
+        throw new Error(`${binaryPath} --version didn't report a version after upgrade.`);
+      }
+      if (isOpencodeVersionOutdated(version)) {
+        throw new Error(
+          `opencode upgrade did not reach the required version ${OPENCODE_MIN_ACP_VERSION}+ ` +
+            `(still v${version}).`
+        );
+      }
+      updateOpencodeFields({ binaryVersion: version, binaryPath, binarySource: "custom" });
+      logInfo(`[AgentMode] upgraded custom opencode to ${version}`);
+      return { version, path: binaryPath };
+    });
   }
 
   /**
@@ -509,10 +704,12 @@ export class OpencodeBinaryManager {
    * left untouched — it lives outside our dirs and belongs to the user.
    */
   async uninstall(): Promise<void> {
-    await Promise.all(this.reclaimableDirs().map((dir) => removeDir(dir)));
-    if (readOpencodeSettings().binarySource !== "custom") {
-      clearOpencodeBinary();
-    }
+    return this.runExclusive({ kind: "busy" }, async () => {
+      await Promise.all(this.reclaimableDirs().map((dir) => removeDir(dir)));
+      if (readOpencodeSettings().binarySource !== "custom") {
+        clearOpencodeBinary();
+      }
+    });
   }
 
   /**
@@ -522,6 +719,31 @@ export class OpencodeBinaryManager {
    * paths are caught at config time rather than later when ACP tries to boot.
    */
   async setCustomBinaryPath(p: string | null): Promise<void> {
+    return this.runExclusive({ kind: "busy" }, () => this.writeCustomBinaryPath(p));
+  }
+
+  /**
+   * Find an opencode the user installed themselves and adopt it.
+   *
+   * One operation rather than a detect the caller follows with
+   * {@link setCustomBinaryPath}: the lock has to span the search as well as the
+   * write, or a managed install started while the search was still running
+   * would land in between and leave settings naming a source the user did not
+   * choose last.
+   *
+   * @returns the adopted path, or null when nothing was found.
+   */
+  async adoptExistingBinary(): Promise<string | null> {
+    return this.runExclusive({ kind: "detecting" }, async () => {
+      const found = await detectOpencodeCliPath();
+      if (!found) return null;
+      await this.writeCustomBinaryPath(found);
+      return found;
+    });
+  }
+
+  /** Validate and persist a custom binary path. Assumes the lock is held. */
+  private async writeCustomBinaryPath(p: string | null): Promise<void> {
     if (p === null) {
       clearOpencodeBinary();
       return;

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -68,6 +68,23 @@ export class OperationInFlightError extends Error {
   }
 }
 
+/**
+ * Thrown when auto-detect finds no opencode to adopt. A failure rather than an
+ * empty success so it lands in the runtime error state: the settings row swaps
+ * its adopt action for Configure only while showing an error, and Configure is
+ * the sole way to reach a binary outside the searched locations.
+ *
+ * The message names no control, because every surface subscribed to the runtime
+ * state renders it — including the Configure dialog itself, where telling the
+ * user to open Configure would contradict where they already are.
+ */
+export class OpencodeNotFoundError extends Error {
+  constructor() {
+    super("Couldn't find opencode in the usual install locations or on PATH.");
+    this.name = "OpencodeNotFoundError";
+  }
+}
+
 const describeOperationError = (e: unknown): string => (e instanceof Error ? e.message : String(e));
 
 interface GithubAsset {
@@ -731,12 +748,13 @@ export class OpencodeBinaryManager {
    * would land in between and leave settings naming a source the user did not
    * choose last.
    *
-   * @returns the adopted path, or null when nothing was found.
+   * @returns the adopted path.
+   * @throws OpencodeNotFoundError when the search turns up nothing.
    */
-  async adoptExistingBinary(): Promise<string | null> {
+  async adoptExistingBinary(): Promise<string> {
     return this.runExclusive({ kind: "detecting" }, async () => {
       const found = await detectOpencodeCliPath();
-      if (!found) return null;
+      if (!found) throw new OpencodeNotFoundError();
       await this.writeCustomBinaryPath(found);
       return found;
     });

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -35,9 +35,18 @@ export type ProgressEvent =
 
 export interface InstallOptions {
   onProgress?: (e: ProgressEvent) => void;
-  signal?: AbortSignal;
   /** Override pinned version. Defaults to OPENCODE_PINNED_VERSION. */
   version?: string;
+}
+
+/**
+ * What the install pipeline needs on top of the public options. The signal is
+ * absent from {@link InstallOptions} on purpose: the manager owns cancellation
+ * through {@link OpencodeBinaryManager.cancelCurrentOperation}, so a caller
+ * cannot supply one, and the pipeline only ever receives the manager's own.
+ */
+interface InstallPipelineOptions extends InstallOptions {
+  signal?: AbortSignal;
 }
 
 export type InstallState =
@@ -312,6 +321,21 @@ export class OpencodeBinaryManager {
     this.runtimeSubscribers.forEach((notify) => notify());
   }
 
+  /**
+   * Drop a failure left over from a previous plugin lifecycle, so a new one
+   * does not open showing an error nobody here caused.
+   *
+   * The rest of the runtime state is deliberately kept: a run still in flight
+   * belongs to this process and the new lifecycle adopts it rather than
+   * offering a rival action (see the note on {@link operation}). Only a settled
+   * error is stale — it describes an attempt that ended, in a vault that may
+   * not even be the one now open.
+   */
+  forgetSettledError(): void {
+    if (this.operation || this.runtimeState.kind !== "error") return;
+    this.setRuntimeState({ kind: "idle" });
+  }
+
   /** Whether a binary-path operation is running, from any entry point. */
   isBusy(): boolean {
     return this.operation !== null;
@@ -329,10 +353,11 @@ export class OpencodeBinaryManager {
    * Run `body` as the one binary-path operation, publishing `running` for its
    * duration and settling back to idle (or to an error the UI can show).
    *
-   * Every public method that writes `binaryPath`/`binarySource` goes through
-   * here, which is what makes the lock complete: guarding only the managed
-   * install would still let the Configure dialog apply a custom path
-   * underneath it.
+   * Every *user-triggered* operation that writes `binaryPath`/`binarySource`
+   * goes through here, which is what makes the lock useful: guarding only the
+   * managed install would still let the Configure dialog apply a custom path
+   * underneath it. {@link refreshInstallState} is the one writer outside, and
+   * says there why.
    *
    * @param running - State published while `body` runs.
    * @param body - Receives the signal to honour for cancellation.
@@ -363,20 +388,6 @@ export class OpencodeBinaryManager {
     }
   }
 
-  /**
-   * Link a caller-supplied signal to this operation's own controller, so a
-   * caller that already had one (the Configure dialog) keeps working while the
-   * manager stays the single place that can cancel.
-   */
-  private static linkSignal(external: AbortSignal | undefined, controller: AbortController): void {
-    if (!external) return;
-    if (external.aborted) {
-      controller.abort();
-      return;
-    }
-    external.addEventListener("abort", () => controller.abort(), { once: true });
-  }
-
   getInstallState(): InstallState {
     return computeInstallState(readOpencodeSettings());
   }
@@ -387,6 +398,19 @@ export class OpencodeBinaryManager {
    * restored a vault from backup, etc.), demote to `absent`. Skipped for
    * custom-source installs — re-checking on every plugin load would punish
    * users for transient filesystem hiccups (network mounts, etc.).
+   *
+   * DESIGN NOTE — this is the one `binaryPath` writer that stays outside
+   * {@link runExclusive}, and the residual race is accepted. To lose data a
+   * user needs a managed path whose file is already gone, an install still
+   * running from a previous lifecycle, a reload landing mid-run, AND the
+   * single `fileExists` stat below straddling the instant that install
+   * persists its result — at which point the clear would wipe the fresh
+   * install. Taking the lock here would be worse: a reconcile at load would
+   * throw `OperationInFlightError` on every plugin load that happens during a
+   * download, turning a millisecond-wide race into a routine failure. If a
+   * future review flags this again, point them at this note; the cheap fix, if
+   * it ever bites, is to re-read settings after the await and only clear when
+   * the path still matches the one checked.
    */
   async refreshInstallState(): Promise<void> {
     // Read raw settings (not getInstallState) so we can still see a configured
@@ -432,14 +456,9 @@ export class OpencodeBinaryManager {
   /**
    * Download and activate the pinned opencode build, holding the binary-path
    * lock for the whole run and publishing download progress as it goes.
-   *
-   * `opts.signal` still works and is linked to the manager's own controller, so
-   * an existing caller keeps its cancellation while
-   * {@link cancelCurrentOperation} can reach the same run.
    */
   async install(opts: InstallOptions = {}): Promise<{ version: string; path: string }> {
     return this.runExclusive({ kind: "installing", progress: null }, (signal) => {
-      OpencodeBinaryManager.linkSignal(opts.signal, this.operationController());
       return this.installPipeline({
         ...opts,
         signal,
@@ -449,12 +468,6 @@ export class OpencodeBinaryManager {
         },
       });
     });
-  }
-
-  /** The controller of the operation `runExclusive` just opened. */
-  private operationController(): AbortController {
-    if (!this.operation) throw new Error("No opencode operation is running.");
-    return this.operation.controller;
   }
 
   /**
@@ -468,7 +481,7 @@ export class OpencodeBinaryManager {
    * holds — or settle the run to idle before it has removed the old version.
    */
   private async installPipeline(
-    opts: InstallOptions = {}
+    opts: InstallPipelineOptions = {}
   ): Promise<{ version: string; path: string }> {
     const version = opts.version ?? OPENCODE_PINNED_VERSION;
     const dataDir = this.getDataDir();
@@ -614,7 +627,6 @@ export class OpencodeBinaryManager {
    */
   async upgradeManaged(opts: InstallOptions = {}): Promise<{ version: string; path: string }> {
     return this.runExclusive({ kind: "installing", progress: null }, async (signal) => {
-      OpencodeBinaryManager.linkSignal(opts.signal, this.operationController());
       const prev = readOpencodeSettings();
       const result = await this.installPipeline({
         ...opts,
@@ -936,7 +948,7 @@ async function downloadToFile(
   url: string,
   dest: string,
   expectedSize: number | undefined,
-  opts: InstallOptions
+  opts: InstallPipelineOptions
 ): Promise<void> {
   const assetName = path.basename(dest);
   const res = await httpsGetWithRedirects(url, opts.signal);

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
@@ -320,6 +320,44 @@ describe("OpencodeInlineInstall", () => {
       expect(await screen.findByText(/Couldn't find opencode on this device/)).not.toBeNull();
     });
 
+    // A failure published to zero rows is silent, while both success paths
+    // already announce unconditionally. These cover the asymmetry.
+    it("announces an install failure that lands while no row is mounted", async () => {
+      const pending = deferredInstall();
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+      await screen.findByRole("button", { name: "Cancel" });
+      unmount();
+
+      await act(async () => {
+        pending.fail(new Error("GitHub API rate-limited"));
+      });
+
+      expect(Notice).toHaveBeenCalledWith("opencode setup failed: GitHub API rate-limited");
+    });
+
+    it("announces a failed detect that lands while no row is mounted", async () => {
+      let resolveDetect: (path: string | null) => void = () => {};
+      detectOpencodeCliPath.mockImplementation(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveDetect = resolve;
+          })
+      );
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+      await screen.findByRole("button", { name: "Looking…" });
+      unmount();
+
+      await act(async () => {
+        resolveDetect(null);
+      });
+
+      expect(Notice).toHaveBeenCalledWith(
+        expect.stringContaining("Couldn't find opencode on this device")
+      );
+    });
+
     it("returns a remounted row to the idle actions when the install succeeds", async () => {
       const pending = deferredInstall();
       const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
@@ -1,7 +1,8 @@
+import { OpencodeAbsentInstallActions } from "@/agentMode/backends/opencode/OpencodeInlineInstall";
 import {
-  OpencodeAbsentInstallActions,
-  __resetInFlightInstallForTests,
-} from "@/agentMode/backends/opencode/OpencodeInlineInstall";
+  OperationInFlightError,
+  type RuntimeState,
+} from "@/agentMode/backends/opencode/OpencodeBinaryManager";
 import type CopilotPlugin from "@/main";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Notice } from "obsidian";
@@ -9,70 +10,61 @@ import React from "react";
 
 jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
 
-const install = jest.fn();
-const setCustomBinaryPath = jest.fn();
-const detectOpencodeCliPath = jest.fn();
 const openInstallUI = jest.fn();
 
+/**
+ * Stands in for the manager's runtime store. Deliberately a store rather than
+ * per-call stubs: the component subscribes to it, so `subscribeRuntimeState`
+ * and `getRuntimeState` have to keep stable identities across renders or
+ * `useSyncExternalStore` resubscribes every commit and the assertions go green
+ * against a component that never really subscribed.
+ */
+function makeFakeManager() {
+  let state: RuntimeState = { kind: "idle" };
+  const listeners = new Set<() => void>();
+  const install = jest.fn<Promise<{ version: string; path: string }>, []>();
+  const adoptExistingBinary = jest.fn<Promise<string | null>, []>();
+  const cancelCurrentOperation = jest.fn();
+
+  return {
+    manager: {
+      subscribeRuntimeState: (onChange: () => void) => {
+        listeners.add(onChange);
+        return () => listeners.delete(onChange);
+      },
+      getRuntimeState: () => state,
+      install,
+      adoptExistingBinary,
+      cancelCurrentOperation,
+    },
+    install,
+    adoptExistingBinary,
+    cancelCurrentOperation,
+    /** Drive the store the way the real manager's operations would. */
+    publish(next: RuntimeState) {
+      state = next;
+      act(() => listeners.forEach((notify) => notify()));
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+let fake: ReturnType<typeof makeFakeManager>;
+
 jest.mock("@/agentMode/backends/opencode/descriptor", () => ({
-  getOpencodeBinaryManager: () => ({
-    install: (...args: unknown[]) => install(...args),
-    setCustomBinaryPath: (...args: unknown[]) => setCustomBinaryPath(...args),
-  }),
-  detectOpencodeCliPath: () => detectOpencodeCliPath(),
+  getOpencodeBinaryManager: () => fake.manager,
   OpencodeBackendDescriptor: { openInstallUI: (...args: unknown[]) => openInstallUI(...args) },
 }));
 
 const plugin = {} as CopilotPlugin;
 
-/** A pending install whose progress/settlement the test drives by hand. */
-function deferredInstall() {
-  let resolve!: (value: { version: string; path: string }) => void;
-  let reject!: (reason: unknown) => void;
-  let onProgress: ((e: unknown) => void) | undefined;
-  let signal: AbortSignal | undefined;
-  install.mockImplementation(
-    (opts: { onProgress?: (e: unknown) => void; signal?: AbortSignal }) => {
-      onProgress = opts.onProgress;
-      signal = opts.signal;
-      return new Promise<{ version: string; path: string }>((res, rej) => {
-        resolve = res;
-        reject = rej;
-        // The manager rejects with an AbortError once the caller aborts.
-        opts.signal?.addEventListener("abort", () => {
-          const err = new Error("Aborted");
-          err.name = "AbortError";
-          rej(err);
-        });
-      });
-    }
-  );
-  return {
-    resolve,
-    get reject() {
-      return reject;
-    },
-    get onProgress() {
-      return onProgress;
-    },
-    get signal() {
-      return signal;
-    },
-    settle: (value: { version: string; path: string }) => resolve(value),
-    fail: (reason: unknown) => reject(reason),
-  };
-}
-
 describe("OpencodeInlineInstall", () => {
   describe("OpencodeAbsentInstallActions()", () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      // The install is module-scoped so it can outlive a remount; without this
-      // a test that leaves one pending would block the next test's download.
-      __resetInFlightInstallForTests();
-      install.mockResolvedValue({ version: "1.2.3", path: "/bin/opencode" });
-      setCustomBinaryPath.mockResolvedValue(undefined);
-      detectOpencodeCliPath.mockResolvedValue("/usr/local/bin/opencode");
+      fake = makeFakeManager();
+      fake.install.mockResolvedValue({ version: "1.2.3", path: "/bin/opencode" });
+      fake.adoptExistingBinary.mockResolvedValue("/usr/local/bin/opencode");
     });
 
     it("offers a download and an adopt-existing action while nothing is running", () => {
@@ -81,331 +73,155 @@ describe("OpencodeInlineInstall", () => {
       expect(screen.getByRole("button", { name: "I already have it" })).not.toBeNull();
     });
 
-    it("replaces the actions with live progress and a cancel control during a download", async () => {
-      const pending = deferredInstall();
+    it("replaces the actions with live progress and a cancel control during a download", () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
 
-      await screen.findByRole("button", { name: "Cancel" });
-      expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
-
-      act(() => {
-        pending.onProgress?.({
-          phase: "download",
-          received: 512,
-          total: 1024,
-          assetName: "opencode.zip",
-        });
+      fake.publish({
+        kind: "installing",
+        progress: { phase: "download", received: 512, total: 1024, assetName: "opencode.zip" },
       });
+
       expect(screen.getByText("Downloading opencode.zip — 512 B / 1.0 KB (50%)")).not.toBeNull();
+      expect(screen.getByRole("button", { name: "Cancel" })).not.toBeNull();
+      expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
     });
 
-    it("carries a first install through to completion and names the version it landed", async () => {
+    it("names the version a finished install landed", async () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
       fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
 
       await waitFor(() => expect(Notice).toHaveBeenCalledWith("opencode v1.2.3 installed."));
-      expect(install).toHaveBeenCalledWith(
-        expect.objectContaining({ signal: expect.anything(), onProgress: expect.any(Function) })
-      );
-      // A finished install leaves neither a download in flight nor a failure to
-      // retry; the row itself goes away when the panel flips to ready.
-      expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
-      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
     });
 
-    it("aborts the install and returns to the idle actions when the user cancels", async () => {
-      const pending = deferredInstall();
+    it("cancels through the manager rather than a controller of its own", () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+      fake.publish({ kind: "installing", progress: null });
 
-      fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
-      expect(pending.signal?.aborted).toBe(true);
-      await screen.findByRole("button", { name: "Download opencode" });
-      // A cancellation is not a failure, so no error is surfaced.
-      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+      expect(fake.cancelCurrentOperation).toHaveBeenCalled();
     });
 
-    it("surfaces the failure reason and offers a retry when the install pipeline throws", async () => {
-      install.mockRejectedValue(new Error("GitHub API rate-limited"));
+    it("surfaces the failure reason and offers a retry when an operation fails", () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
 
-      expect(await screen.findByText("GitHub API rate-limited")).not.toBeNull();
+      fake.publish({ kind: "error", message: "GitHub API rate-limited" });
+
+      expect(screen.getByText("GitHub API rate-limited")).not.toBeNull();
       expect(screen.getByRole("button", { name: "Try again" })).not.toBeNull();
     });
 
     it("runs a fresh install when the user retries after a failure", async () => {
-      install.mockRejectedValueOnce(new Error("network down"));
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+      fake.publish({ kind: "error", message: "network down" });
 
-      fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+      fireEvent.click(screen.getByRole("button", { name: "Try again" }));
 
-      await waitFor(() => expect(install).toHaveBeenCalledTimes(2));
-      await waitFor(() => expect(screen.queryByText("network down")).toBeNull());
+      await waitFor(() => expect(fake.install).toHaveBeenCalledTimes(1));
     });
 
-    it("adopts a detected binary by persisting it through the manager's validation", async () => {
+    it("adopts a detected binary through the manager's own detect-and-persist", async () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
       fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
 
+      await waitFor(() => expect(fake.adoptExistingBinary).toHaveBeenCalled());
       await waitFor(() =>
-        expect(setCustomBinaryPath).toHaveBeenCalledWith("/usr/local/bin/opencode")
+        expect(Notice).toHaveBeenCalledWith("Using the opencode at /usr/local/bin/opencode.")
       );
     });
 
     it("points the user at Configure when no opencode is found on the device", async () => {
-      detectOpencodeCliPath.mockResolvedValue(null);
+      fake.adoptExistingBinary.mockResolvedValue(null);
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
       fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
 
-      expect(await screen.findByText(/Couldn't find opencode on this device/)).not.toBeNull();
-      expect(setCustomBinaryPath).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(Notice).toHaveBeenCalledWith(
+          "Couldn't find opencode on this device. Use Configure to enter its path."
+        )
+      );
     });
 
-    it("opens the Configure dialog from the failure state so a custom path stays reachable", async () => {
-      detectOpencodeCliPath.mockResolvedValue(null);
+    it("opens the Configure dialog from the failure state so a custom path stays reachable", () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+      fake.publish({ kind: "error", message: "nothing found" });
 
-      fireEvent.click(await screen.findByRole("button", { name: "Configure" }));
+      fireEvent.click(screen.getByRole("button", { name: "Configure" }));
+
       expect(openInstallUI).toHaveBeenCalledWith(plugin);
     });
 
-    it("blocks a download while a detect is in flight so the two can't both write the binary path", async () => {
-      let finishDetect!: (path: string | null) => void;
-      detectOpencodeCliPath.mockReturnValue(
-        new Promise<string | null>((resolve) => {
-          finishDetect = resolve;
-        })
-      );
+    it("blocks a download while a detect is in flight so the two can't both write the path", () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
 
-      const download = await screen.findByRole<HTMLButtonElement>("button", {
+      fake.publish({ kind: "detecting" });
+
+      const download = screen.getByRole<HTMLButtonElement>("button", {
         name: "Download opencode",
       });
       expect(download.disabled).toBe(true);
       fireEvent.click(download);
-      expect(install).not.toHaveBeenCalled();
-
-      await act(async () => {
-        finishDetect(null);
-      });
+      expect(fake.install).not.toHaveBeenCalled();
     });
 
-    it.each([
-      ["the detected path is no longer a file", "No file at /usr/local/bin/opencode"],
-      [
-        "the binary is not executable",
-        "/usr/local/bin/opencode is not executable. chmod +x and try again.",
-      ],
-      [
-        "the version probe reports nothing usable",
-        "/usr/local/bin/opencode --version output didn't include a version number. Is this an opencode binary?",
-      ],
-    ])("reports the manager's reason when %s", async (_case, message) => {
-      setCustomBinaryPath.mockRejectedValue(new Error(message));
+    // `busy` covers the operations only the Configure dialog can start — upgrade,
+    // uninstall, applying a custom path. The row cannot show their progress, but
+    // it must not offer either of its own writers underneath them.
+    it("hides both binary-path writers while another surface holds the manager", () => {
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
 
-      expect(await screen.findByText(message)).not.toBeNull();
-    });
+      fake.publish({ kind: "busy" });
 
-    it("leaves an in-flight install running and stops updating state once unmounted", async () => {
-      const pending = deferredInstall();
-      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
-      await screen.findByRole("button", { name: "Cancel" });
-
-      const emitProgress = pending.onProgress;
-      unmount();
-
-      // Switching agent sub-tabs unmounts this row, so unmounting must not
-      // cancel a download the user never cancelled.
-      expect(pending.signal?.aborted).toBe(false);
-      // A late progress callback must not reach setState on an unmounted tree;
-      // React would warn, and jest.setup promotes console noise into failures.
-      expect(() =>
-        emitProgress?.({ phase: "extract", message: "Extracting archive…" })
-      ).not.toThrow();
-    });
-
-    it("shows the running install again when the row remounts, rather than an idle button", async () => {
-      const pending = deferredInstall();
-      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
-      await screen.findByRole("button", { name: "Cancel" });
-      act(() => pending.onProgress?.({ phase: "extract", message: "Extracting archive…" }));
-      unmount();
-
-      // Coming back to the tab must pick the install up where it is.
-      render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      expect(screen.getByRole("button", { name: "Cancel" })).not.toBeNull();
-      expect(screen.getByText("Extracting archive…")).not.toBeNull();
-      expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
-    });
-
-    it("hides both binary-path writers while a managed install is still running", async () => {
-      deferredInstall();
-      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
-      await screen.findByRole("button", { name: "Cancel" });
-      unmount();
-
-      // Adopting and installing both persist the binary path, so a remounted
-      // row must offer neither: whichever settled last would win, leaving
-      // settings naming a source the user did not choose last.
-      render(<OpencodeAbsentInstallActions plugin={plugin} />);
       expect(screen.queryByRole("button", { name: "I already have it" })).toBeNull();
-      expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
-      expect(setCustomBinaryPath).not.toHaveBeenCalled();
-      expect(install).toHaveBeenCalledTimes(1);
-    });
-
-    // Every install outcome has to reach whichever row is on screen, not just
-    // the one that started it. A row that mounts mid-download and never hears
-    // the end would sit on a progress bar whose Cancel points at nothing.
-    // Adopt is the other writer of the binary path, so it belongs to the same
-    // shared lifecycle as the managed install — a remounted row must not offer
-    // Download on top of a detect that is still about to persist a path.
-    it("keeps a detect visible across a remount instead of offering Download", async () => {
-      let resolveDetect: (path: string | null) => void = () => {};
-      detectOpencodeCliPath.mockImplementation(
-        () =>
-          new Promise<string | null>((resolve) => {
-            resolveDetect = resolve;
-          })
-      );
-      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
-      await screen.findByRole("button", { name: "Looking…" });
-      unmount();
-
-      render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      expect(screen.getByRole("button", { name: "Looking…" })).not.toBeNull();
       expect(
         screen.getByRole("button", { name: "Download opencode" }).hasAttribute("disabled")
       ).toBe(true);
-
-      await act(async () => {
-        resolveDetect("/usr/local/bin/opencode");
-      });
-      await waitFor(() =>
-        expect(setCustomBinaryPath).toHaveBeenCalledWith("/usr/local/bin/opencode")
-      );
-      expect(install).not.toHaveBeenCalled();
     });
 
-    it("surfaces a failed detect on a remounted row", async () => {
-      let resolveDetect: (path: string | null) => void = () => {};
-      detectOpencodeCliPath.mockImplementation(
-        () =>
-          new Promise<string | null>((resolve) => {
-            resolveDetect = resolve;
-          })
-      );
-      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
-      await screen.findByRole("button", { name: "Looking…" });
-      unmount();
+    it("shows the running operation when the row mounts into one already in flight", () => {
+      // The state lives on the manager, so a row that never saw the operation
+      // start still renders it — this is what a settings sub-tab switch does.
+      fake.publish({ kind: "installing", progress: { phase: "extract", message: "Extracting…" } });
+
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
 
-      await act(async () => {
-        resolveDetect(null);
-      });
-
-      expect(await screen.findByText(/Couldn't find opencode on this device/)).not.toBeNull();
+      expect(screen.getByText("Extracting…")).not.toBeNull();
+      expect(screen.getByRole("button", { name: "Cancel" })).not.toBeNull();
+      expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
     });
 
-    // A failure published to zero rows is silent, while both success paths
-    // already announce unconditionally. These cover the asymmetry.
-    it("announces an install failure that lands while no row is mounted", async () => {
-      const pending = deferredInstall();
-      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
-      await screen.findByRole("button", { name: "Cancel" });
-      unmount();
+    it("shows a failure that settled before it mounted", () => {
+      fake.publish({ kind: "error", message: "Network unreachable" });
 
-      await act(async () => {
-        pending.fail(new Error("GitHub API rate-limited"));
-      });
-
-      expect(Notice).toHaveBeenCalledWith("opencode setup failed: GitHub API rate-limited");
-    });
-
-    it("announces a failed detect that lands while no row is mounted", async () => {
-      let resolveDetect: (path: string | null) => void = () => {};
-      detectOpencodeCliPath.mockImplementation(
-        () =>
-          new Promise<string | null>((resolve) => {
-            resolveDetect = resolve;
-          })
-      );
-      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
-      await screen.findByRole("button", { name: "Looking…" });
-      unmount();
-
-      await act(async () => {
-        resolveDetect(null);
-      });
-
-      expect(Notice).toHaveBeenCalledWith(
-        expect.stringContaining("Couldn't find opencode on this device")
-      );
-    });
-
-    it("returns a remounted row to the idle actions when the install succeeds", async () => {
-      const pending = deferredInstall();
-      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
-      await screen.findByRole("button", { name: "Cancel" });
-      unmount();
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
 
-      await act(async () => {
-        pending.settle({ version: "1.2.3", path: "/bin/opencode" });
-      });
-
-      expect(await screen.findByRole("button", { name: "Download opencode" })).not.toBeNull();
-      expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
-    });
-
-    it("shows the failure on a remounted row when the install throws", async () => {
-      const pending = deferredInstall();
-      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
-      await screen.findByRole("button", { name: "Cancel" });
-      unmount();
-      render(<OpencodeAbsentInstallActions plugin={plugin} />);
-
-      await act(async () => {
-        pending.fail(new Error("Network unreachable"));
-      });
-
-      expect(await screen.findByText("Network unreachable")).not.toBeNull();
+      expect(screen.getByText("Network unreachable")).not.toBeNull();
       expect(screen.getByRole("button", { name: "Try again" })).not.toBeNull();
     });
 
-    it("returns a remounted row to idle when the install is cancelled from it", async () => {
-      const pending = deferredInstall();
+    it("stops listening once unmounted, leaving the operation running", () => {
       const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
-      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
-      await screen.findByRole("button", { name: "Cancel" });
+      fake.publish({ kind: "installing", progress: null });
+      expect(fake.listenerCount()).toBe(1);
+
       unmount();
+
+      // Switching agent sub-tabs unmounts this row; that must drop the
+      // subscription without touching the run itself.
+      expect(fake.listenerCount()).toBe(0);
+      expect(fake.cancelCurrentOperation).not.toHaveBeenCalled();
+    });
+
+    it("stays quiet when an action loses the race for the manager", async () => {
+      fake.install.mockRejectedValue(new OperationInFlightError());
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
 
-      // The remounted row's Cancel must reach the live controller, not the
-      // dead one from the mount that started the download.
-      await act(async () => {
-        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-      });
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
 
-      expect(pending.signal?.aborted).toBe(true);
-      expect(await screen.findByRole("button", { name: "Download opencode" })).not.toBeNull();
+      // Another surface got there first; the state it publishes is the report,
+      // so this must not raise a second one of its own.
+      await waitFor(() => expect(fake.install).toHaveBeenCalled());
+      expect(Notice).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
@@ -1,8 +1,11 @@
 import { OpencodeAbsentInstallActions } from "@/agentMode/backends/opencode/OpencodeInlineInstall";
 import {
+  AbortError,
+  OpencodeNotFoundError,
   OperationInFlightError,
   type RuntimeState,
 } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
+import { logError } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Notice } from "obsidian";
@@ -23,7 +26,7 @@ function makeFakeManager() {
   let state: RuntimeState = { kind: "idle" };
   const listeners = new Set<() => void>();
   const install = jest.fn<Promise<{ version: string; path: string }>, []>();
-  const adoptExistingBinary = jest.fn<Promise<string | null>, []>();
+  const adoptExistingBinary = jest.fn<Promise<string>, []>();
   const cancelCurrentOperation = jest.fn();
 
   return {
@@ -130,16 +133,44 @@ describe("OpencodeInlineInstall", () => {
       );
     });
 
-    it("points the user at Configure when no opencode is found on the device", async () => {
-      fake.adoptExistingBinary.mockResolvedValue(null);
+    // Asserting the rendered controls rather than the Notice copy: an earlier
+    // version checked only that the message was raised, so it stayed green
+    // while the button that message depends on had vanished from the row.
+    it("reveals Configure and retires the adopt action when no opencode is found", async () => {
+      fake.adoptExistingBinary.mockImplementation(() => {
+        fake.publish({ kind: "error", message: new OpencodeNotFoundError().message });
+        return Promise.reject(new OpencodeNotFoundError());
+      });
       render(<OpencodeAbsentInstallActions plugin={plugin} />);
+
       fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
 
-      await waitFor(() =>
-        expect(Notice).toHaveBeenCalledWith(
-          "Couldn't find opencode on this device. Use Configure to enter its path."
-        )
-      );
+      await waitFor(() => expect(screen.getByRole("button", { name: "Configure" })).not.toBeNull());
+      expect(screen.queryByRole("button", { name: "I already have it" })).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: "Configure" }));
+      expect(openInstallUI).toHaveBeenCalledWith(plugin);
+    });
+
+    it("keeps a fruitless detect out of the error log, since the row already carries it", async () => {
+      fake.adoptExistingBinary.mockRejectedValue(new OpencodeNotFoundError());
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+
+      await waitFor(() => expect(fake.adoptExistingBinary).toHaveBeenCalled());
+      expect(logError).not.toHaveBeenCalled();
+      expect(Notice).not.toHaveBeenCalled();
+    });
+
+    it("keeps a cancelled download out of the error log", async () => {
+      fake.install.mockRejectedValue(new AbortError());
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+
+      // Cancelling is the user's own doing, so it is an outcome, not a fault.
+      await waitFor(() => expect(fake.install).toHaveBeenCalled());
+      expect(logError).not.toHaveBeenCalled();
     });
 
     it("opens the Configure dialog from the failure state so a custom path stays reachable", () => {

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.test.tsx
@@ -1,0 +1,373 @@
+import {
+  OpencodeAbsentInstallActions,
+  __resetInFlightInstallForTests,
+} from "@/agentMode/backends/opencode/OpencodeInlineInstall";
+import type CopilotPlugin from "@/main";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { Notice } from "obsidian";
+import React from "react";
+
+jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
+
+const install = jest.fn();
+const setCustomBinaryPath = jest.fn();
+const detectOpencodeCliPath = jest.fn();
+const openInstallUI = jest.fn();
+
+jest.mock("@/agentMode/backends/opencode/descriptor", () => ({
+  getOpencodeBinaryManager: () => ({
+    install: (...args: unknown[]) => install(...args),
+    setCustomBinaryPath: (...args: unknown[]) => setCustomBinaryPath(...args),
+  }),
+  detectOpencodeCliPath: () => detectOpencodeCliPath(),
+  OpencodeBackendDescriptor: { openInstallUI: (...args: unknown[]) => openInstallUI(...args) },
+}));
+
+const plugin = {} as CopilotPlugin;
+
+/** A pending install whose progress/settlement the test drives by hand. */
+function deferredInstall() {
+  let resolve!: (value: { version: string; path: string }) => void;
+  let reject!: (reason: unknown) => void;
+  let onProgress: ((e: unknown) => void) | undefined;
+  let signal: AbortSignal | undefined;
+  install.mockImplementation(
+    (opts: { onProgress?: (e: unknown) => void; signal?: AbortSignal }) => {
+      onProgress = opts.onProgress;
+      signal = opts.signal;
+      return new Promise<{ version: string; path: string }>((res, rej) => {
+        resolve = res;
+        reject = rej;
+        // The manager rejects with an AbortError once the caller aborts.
+        opts.signal?.addEventListener("abort", () => {
+          const err = new Error("Aborted");
+          err.name = "AbortError";
+          rej(err);
+        });
+      });
+    }
+  );
+  return {
+    resolve,
+    get reject() {
+      return reject;
+    },
+    get onProgress() {
+      return onProgress;
+    },
+    get signal() {
+      return signal;
+    },
+    settle: (value: { version: string; path: string }) => resolve(value),
+    fail: (reason: unknown) => reject(reason),
+  };
+}
+
+describe("OpencodeInlineInstall", () => {
+  describe("OpencodeAbsentInstallActions()", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      // The install is module-scoped so it can outlive a remount; without this
+      // a test that leaves one pending would block the next test's download.
+      __resetInFlightInstallForTests();
+      install.mockResolvedValue({ version: "1.2.3", path: "/bin/opencode" });
+      setCustomBinaryPath.mockResolvedValue(undefined);
+      detectOpencodeCliPath.mockResolvedValue("/usr/local/bin/opencode");
+    });
+
+    it("offers a download and an adopt-existing action while nothing is running", () => {
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      expect(screen.getByRole("button", { name: "Download opencode" })).not.toBeNull();
+      expect(screen.getByRole("button", { name: "I already have it" })).not.toBeNull();
+    });
+
+    it("replaces the actions with live progress and a cancel control during a download", async () => {
+      const pending = deferredInstall();
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+
+      await screen.findByRole("button", { name: "Cancel" });
+      expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
+
+      act(() => {
+        pending.onProgress?.({
+          phase: "download",
+          received: 512,
+          total: 1024,
+          assetName: "opencode.zip",
+        });
+      });
+      expect(screen.getByText("Downloading opencode.zip — 512 B / 1.0 KB (50%)")).not.toBeNull();
+    });
+
+    it("carries a first install through to completion and names the version it landed", async () => {
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+
+      await waitFor(() => expect(Notice).toHaveBeenCalledWith("opencode v1.2.3 installed."));
+      expect(install).toHaveBeenCalledWith(
+        expect.objectContaining({ signal: expect.anything(), onProgress: expect.any(Function) })
+      );
+      // A finished install leaves neither a download in flight nor a failure to
+      // retry; the row itself goes away when the panel flips to ready.
+      expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    });
+
+    it("aborts the install and returns to the idle actions when the user cancels", async () => {
+      const pending = deferredInstall();
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+
+      fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+
+      expect(pending.signal?.aborted).toBe(true);
+      await screen.findByRole("button", { name: "Download opencode" });
+      // A cancellation is not a failure, so no error is surfaced.
+      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    });
+
+    it("surfaces the failure reason and offers a retry when the install pipeline throws", async () => {
+      install.mockRejectedValue(new Error("GitHub API rate-limited"));
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+
+      expect(await screen.findByText("GitHub API rate-limited")).not.toBeNull();
+      expect(screen.getByRole("button", { name: "Try again" })).not.toBeNull();
+    });
+
+    it("runs a fresh install when the user retries after a failure", async () => {
+      install.mockRejectedValueOnce(new Error("network down"));
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+
+      fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+
+      await waitFor(() => expect(install).toHaveBeenCalledTimes(2));
+      await waitFor(() => expect(screen.queryByText("network down")).toBeNull());
+    });
+
+    it("adopts a detected binary by persisting it through the manager's validation", async () => {
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+
+      await waitFor(() =>
+        expect(setCustomBinaryPath).toHaveBeenCalledWith("/usr/local/bin/opencode")
+      );
+    });
+
+    it("points the user at Configure when no opencode is found on the device", async () => {
+      detectOpencodeCliPath.mockResolvedValue(null);
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+
+      expect(await screen.findByText(/Couldn't find opencode on this device/)).not.toBeNull();
+      expect(setCustomBinaryPath).not.toHaveBeenCalled();
+    });
+
+    it("opens the Configure dialog from the failure state so a custom path stays reachable", async () => {
+      detectOpencodeCliPath.mockResolvedValue(null);
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+
+      fireEvent.click(await screen.findByRole("button", { name: "Configure" }));
+      expect(openInstallUI).toHaveBeenCalledWith(plugin);
+    });
+
+    it("blocks a download while a detect is in flight so the two can't both write the binary path", async () => {
+      let finishDetect!: (path: string | null) => void;
+      detectOpencodeCliPath.mockReturnValue(
+        new Promise<string | null>((resolve) => {
+          finishDetect = resolve;
+        })
+      );
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+
+      const download = await screen.findByRole<HTMLButtonElement>("button", {
+        name: "Download opencode",
+      });
+      expect(download.disabled).toBe(true);
+      fireEvent.click(download);
+      expect(install).not.toHaveBeenCalled();
+
+      await act(async () => {
+        finishDetect(null);
+      });
+    });
+
+    it.each([
+      ["the detected path is no longer a file", "No file at /usr/local/bin/opencode"],
+      [
+        "the binary is not executable",
+        "/usr/local/bin/opencode is not executable. chmod +x and try again.",
+      ],
+      [
+        "the version probe reports nothing usable",
+        "/usr/local/bin/opencode --version output didn't include a version number. Is this an opencode binary?",
+      ],
+    ])("reports the manager's reason when %s", async (_case, message) => {
+      setCustomBinaryPath.mockRejectedValue(new Error(message));
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+
+      expect(await screen.findByText(message)).not.toBeNull();
+    });
+
+    it("leaves an in-flight install running and stops updating state once unmounted", async () => {
+      const pending = deferredInstall();
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+      await screen.findByRole("button", { name: "Cancel" });
+
+      const emitProgress = pending.onProgress;
+      unmount();
+
+      // Switching agent sub-tabs unmounts this row, so unmounting must not
+      // cancel a download the user never cancelled.
+      expect(pending.signal?.aborted).toBe(false);
+      // A late progress callback must not reach setState on an unmounted tree;
+      // React would warn, and jest.setup promotes console noise into failures.
+      expect(() =>
+        emitProgress?.({ phase: "extract", message: "Extracting archive…" })
+      ).not.toThrow();
+    });
+
+    it("shows the running install again when the row remounts, rather than an idle button", async () => {
+      const pending = deferredInstall();
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+      await screen.findByRole("button", { name: "Cancel" });
+      act(() => pending.onProgress?.({ phase: "extract", message: "Extracting archive…" }));
+      unmount();
+
+      // Coming back to the tab must pick the install up where it is.
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      expect(screen.getByRole("button", { name: "Cancel" })).not.toBeNull();
+      expect(screen.getByText("Extracting archive…")).not.toBeNull();
+      expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
+    });
+
+    it("hides both binary-path writers while a managed install is still running", async () => {
+      deferredInstall();
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+      await screen.findByRole("button", { name: "Cancel" });
+      unmount();
+
+      // Adopting and installing both persist the binary path, so a remounted
+      // row must offer neither: whichever settled last would win, leaving
+      // settings naming a source the user did not choose last.
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      expect(screen.queryByRole("button", { name: "I already have it" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
+      expect(setCustomBinaryPath).not.toHaveBeenCalled();
+      expect(install).toHaveBeenCalledTimes(1);
+    });
+
+    // Every install outcome has to reach whichever row is on screen, not just
+    // the one that started it. A row that mounts mid-download and never hears
+    // the end would sit on a progress bar whose Cancel points at nothing.
+    // Adopt is the other writer of the binary path, so it belongs to the same
+    // shared lifecycle as the managed install — a remounted row must not offer
+    // Download on top of a detect that is still about to persist a path.
+    it("keeps a detect visible across a remount instead of offering Download", async () => {
+      let resolveDetect: (path: string | null) => void = () => {};
+      detectOpencodeCliPath.mockImplementation(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveDetect = resolve;
+          })
+      );
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+      await screen.findByRole("button", { name: "Looking…" });
+      unmount();
+
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      expect(screen.getByRole("button", { name: "Looking…" })).not.toBeNull();
+      expect(
+        screen.getByRole("button", { name: "Download opencode" }).hasAttribute("disabled")
+      ).toBe(true);
+
+      await act(async () => {
+        resolveDetect("/usr/local/bin/opencode");
+      });
+      await waitFor(() =>
+        expect(setCustomBinaryPath).toHaveBeenCalledWith("/usr/local/bin/opencode")
+      );
+      expect(install).not.toHaveBeenCalled();
+    });
+
+    it("surfaces a failed detect on a remounted row", async () => {
+      let resolveDetect: (path: string | null) => void = () => {};
+      detectOpencodeCliPath.mockImplementation(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveDetect = resolve;
+          })
+      );
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "I already have it" }));
+      await screen.findByRole("button", { name: "Looking…" });
+      unmount();
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+
+      await act(async () => {
+        resolveDetect(null);
+      });
+
+      expect(await screen.findByText(/Couldn't find opencode on this device/)).not.toBeNull();
+    });
+
+    it("returns a remounted row to the idle actions when the install succeeds", async () => {
+      const pending = deferredInstall();
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+      await screen.findByRole("button", { name: "Cancel" });
+      unmount();
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+
+      await act(async () => {
+        pending.settle({ version: "1.2.3", path: "/bin/opencode" });
+      });
+
+      expect(await screen.findByRole("button", { name: "Download opencode" })).not.toBeNull();
+      expect(screen.queryByRole("button", { name: "Cancel" })).toBeNull();
+    });
+
+    it("shows the failure on a remounted row when the install throws", async () => {
+      const pending = deferredInstall();
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+      await screen.findByRole("button", { name: "Cancel" });
+      unmount();
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+
+      await act(async () => {
+        pending.fail(new Error("Network unreachable"));
+      });
+
+      expect(await screen.findByText("Network unreachable")).not.toBeNull();
+      expect(screen.getByRole("button", { name: "Try again" })).not.toBeNull();
+    });
+
+    it("returns a remounted row to idle when the install is cancelled from it", async () => {
+      const pending = deferredInstall();
+      const { unmount } = render(<OpencodeAbsentInstallActions plugin={plugin} />);
+      fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+      await screen.findByRole("button", { name: "Cancel" });
+      unmount();
+      render(<OpencodeAbsentInstallActions plugin={plugin} />);
+
+      // The remounted row's Cancel must reach the live controller, not the
+      // dead one from the mount that started the download.
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      });
+
+      expect(pending.signal?.aborted).toBe(true);
+      expect(await screen.findByRole("button", { name: "Download opencode" })).not.toBeNull();
+    });
+  });
+});

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
@@ -46,6 +46,22 @@ const isAbort = (e: unknown): boolean =>
  * Holding it here is what makes the row's state a view of the work rather than
  * a private copy of it: the work survives a tab switch, any row can show it,
  * and while it runs no row offers either action.
+ *
+ * DESIGN NOTE — why this lives in the UI module and not in the manager.
+ * `useBackendInstallState` / `descriptor.subscribeInstallState` is the codebase's
+ * cross-mount install-state convention, but it reports only *persisted* state
+ * (absent / ready / incompatible, derived from `binaryPath` & friends in
+ * settings). It cannot express detecting, installing, progress, the
+ * `AbortController`, or a failure that never reached settings — so it does not
+ * subsume this. The better long-term home is `OpencodeBinaryManager`, which
+ * `getOpencodeBinaryManager` already returns as a cached singleton
+ * (`descriptor.ts` `managerRef`): it would own the in-flight run behind a
+ * `useSyncExternalStore` snapshot and leave this file with no module state at
+ * all. That move rewrites the manager's API and its tests, relocates the adopt
+ * detect across a dependency edge, and needs a settled contract for how runtime
+ * state merges with persisted state — an install-architecture change, not a
+ * settings-row fix. Deferred deliberately.
+ * If a future review flags this shape again, point them at this note.
  */
 type InFlightWork =
   | { kind: "installing"; controller: AbortController; progress: ProgressEvent | null }
@@ -76,6 +92,32 @@ const rows = new Set<(state: Run) => void>();
  */
 const publish = (state: Run): void => {
   rows.forEach((notify) => notify(state));
+};
+
+/**
+ * Report a failure through the row when one is mounted, and through a `Notice`
+ * when none is — the work can outlive every row, and `publish` to an empty set
+ * is silent. Both success paths already announce unconditionally; without this
+ * a first run that failed while the user was on another tab would leave them
+ * back at an idle Download button with no reason given.
+ *
+ * The Notice names opencode because it appears with no surrounding context; the
+ * row does not, since it sits inside the opencode panel.
+ *
+ * DESIGN NOTE — the failure is announced once, not replayed. A row mounting
+ * *after* a failure already settled shows idle actions, not the old error:
+ * nothing outlives the announcement, by design. Making terminal errors
+ * replayable means persisting them, which is a runtime-state contract that
+ * belongs with the manager-owned store described above, not another module
+ * variable here. Retrying is one click and re-surfaces any error that persists.
+ * If a future review flags the missing replay, point them at this note.
+ */
+const announceFailure = (message: string): void => {
+  if (rows.size > 0) {
+    publish({ kind: "error", message });
+    return;
+  }
+  new Notice(`opencode setup failed: ${message}`);
 };
 
 /** Test seam: no production caller, since a real install always settles. */
@@ -136,7 +178,7 @@ export const OpencodeAbsentInstallActions: React.FC<{ plugin: CopilotPlugin }> =
           return;
         }
         logError("[AgentMode] inline opencode install failed", err);
-        publish({ kind: "error", message: describeError(err) });
+        announceFailure(describeError(err));
       });
   }, [plugin]);
 
@@ -156,10 +198,9 @@ export const OpencodeAbsentInstallActions: React.FC<{ plugin: CopilotPlugin }> =
         const found = await detectOpencodeCliPath();
         if (!found) {
           inFlight = null;
-          publish({
-            kind: "error",
-            message: "Couldn't find opencode on this device. Use Configure to enter its path.",
-          });
+          announceFailure(
+            "Couldn't find opencode on this device. Use Configure to enter its path."
+          );
           return;
         }
         await getOpencodeBinaryManager(plugin).setCustomBinaryPath(found);
@@ -169,7 +210,7 @@ export const OpencodeAbsentInstallActions: React.FC<{ plugin: CopilotPlugin }> =
       } catch (e) {
         inFlight = null;
         logError("[AgentMode] adopting an existing opencode failed", e);
-        publish({ kind: "error", message: describeError(e) });
+        announceFailure(describeError(e));
       }
     })();
   }, [plugin]);

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
@@ -61,6 +61,24 @@ const isAbort = (e: unknown): boolean =>
  * detect across a dependency edge, and needs a settled contract for how runtime
  * state merges with persisted state — an install-architecture change, not a
  * settings-row fix. Deferred deliberately.
+ *
+ * DESIGN NOTE — racing Configure dialogs (issue #TBD).
+ * While an inline install runs, persisted installState is still `absent`, so
+ * every Configure entry point (AgentModeChat, AgentHome, AgentModeStatus,
+ * useAgentSelect, and the non-inline AgentSettings branch) can still open the
+ * dialog. From there the user can save a custom binary path or start another
+ * managed install, racing this pending one and letting whichever writer settles
+ * last choose the saved opencode source despite the inline row hiding its own
+ * competing actions.
+ * The correct fix is a single-flight token in `OpencodeBinaryManager`: only one
+ * of `install()`, `upgradeCustomBinary()`, `uninstall()`, `setCustomBinaryPath()`
+ * may run at a time; a second caller is rejected with a clear error rather than
+ * racing. That serializes ALL entry points (including ones not yet written) at
+ * the one choke point, and it puts the lifecycle on the manager surface where
+ * AGENTS.md:117-123 asks for it. Deferred as a follow-up: this PR is 8 review
+ * rounds deep, already carries 215 lines of module-scoped async state, and
+ * adding manager-level concurrency control is an install-architecture change
+ * that should land independently.
  * If a future review flags this shape again, point them at this note.
  */
 type InFlightWork =

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
@@ -1,0 +1,197 @@
+import {
+  detectOpencodeCliPath,
+  getOpencodeBinaryManager,
+  OpencodeBackendDescriptor,
+} from "@/agentMode/backends/opencode/descriptor";
+import { phaseLabel, phaseProgress } from "@/agentMode/backends/opencode/installProgress";
+import {
+  AbortError,
+  type ProgressEvent,
+} from "@/agentMode/backends/opencode/OpencodeBinaryManager";
+import {
+  OpencodeAbsentInstallView,
+  type OpencodeAbsentInstallState,
+} from "@/agentMode/backends/opencode/ui/OpencodeAbsentInstallView";
+import { logError } from "@/logger";
+import type CopilotPlugin from "@/main";
+import { Notice } from "obsidian";
+import React from "react";
+
+/** What the row's action cluster is currently doing. */
+type Run =
+  | { kind: "idle" }
+  | { kind: "detecting" }
+  | { kind: "installing"; progress: ProgressEvent | null }
+  | { kind: "error"; message: string };
+
+const describeError = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+
+const isAbort = (e: unknown): boolean =>
+  e instanceof AbortError || (e as Error | undefined)?.name === "AbortError";
+
+/**
+ * Work that persists the opencode binary path, held at module scope rather than
+ * in the row that started it.
+ *
+ * Both members write the same setting: the managed install lands a downloaded
+ * binary, and adopting an existing one saves a custom path. Either can outlive
+ * the row — this row unmounts routinely, since the panel flips to "ready" on
+ * success and switching agent sub-tabs drops the whole panel (`TabContent`
+ * renders null when unselected). Parked in component state, that work would
+ * either die with the row or keep running invisibly, and a remounted row would
+ * offer the *other* writer while the first was still about to land. Whichever
+ * settled last would win, leaving settings naming a source the user did not
+ * choose last.
+ *
+ * Holding it here is what makes the row's state a view of the work rather than
+ * a private copy of it: the work survives a tab switch, any row can show it,
+ * and while it runs no row offers either action.
+ */
+type InFlightWork =
+  | { kind: "installing"; controller: AbortController; progress: ProgressEvent | null }
+  | { kind: "detecting" };
+
+let inFlight: InFlightWork | null = null;
+
+/** The `Run` a freshly mounted row should start from. */
+const stateOf = (work: InFlightWork | null): Run => {
+  if (!work) return { kind: "idle" };
+  return work.kind === "installing"
+    ? { kind: "installing", progress: work.progress }
+    : { kind: "detecting" };
+};
+
+/**
+ * Every mounted row. The work outlives any one of them, so it cannot hold a
+ * `setState` from the row that happened to start it — it publishes here and
+ * whichever row is on screen picks it up.
+ */
+const rows = new Set<(state: Run) => void>();
+
+/**
+ * Announce a state to whatever row is mounted. Every transition goes through
+ * here, not just progress: a row that mounts mid-download would otherwise never
+ * learn the install finished, and would sit on a progress bar whose Cancel
+ * button no longer points at anything.
+ */
+const publish = (state: Run): void => {
+  rows.forEach((notify) => notify(state));
+};
+
+/** Test seam: no production caller, since a real install always settles. */
+export function __resetInFlightInstallForTests(): void {
+  inFlight = null;
+}
+
+/**
+ * Inline install actions for opencode, rendered by the generic backend panel
+ * while the binary is absent. opencode is the one backend the plugin can
+ * install itself, so this owns the whole first-run path — download, progress,
+ * cancel, retry, and adopting an existing binary — and the Configure dialog
+ * stays reserved for upgrade, uninstall, and custom paths.
+ */
+export const OpencodeAbsentInstallActions: React.FC<{ plugin: CopilotPlugin }> = ({ plugin }) => {
+  // Adopt an install already running, so returning to this tab shows progress
+  // Start from whatever work is already running, so returning to this tab shows
+  // it rather than an action that would start a competing one.
+  const [run, setRun] = React.useState<Run>(() => stateOf(inFlight));
+
+  React.useEffect(() => {
+    // Subscribe unconditionally: this row may start the work itself, or may
+    // mount into work already running. Either way it reaches the row here.
+    const onWorkState = (state: Run) => setRun(state);
+    rows.add(onWorkState);
+    return () => {
+      rows.delete(onWorkState);
+    };
+  }, []);
+
+  const startInstall = React.useCallback(() => {
+    const task: InFlightWork = {
+      kind: "installing",
+      controller: new AbortController(),
+      progress: null,
+    };
+    inFlight = task;
+    publish({ kind: "installing", progress: null });
+    getOpencodeBinaryManager(plugin)
+      .install({
+        signal: task.controller.signal,
+        onProgress: (e) => {
+          // Recorded on the task as well as published, so a row that mounts
+          // later starts from the current progress rather than zero.
+          task.progress = e;
+          publish({ kind: "installing", progress: e });
+        },
+      })
+      .then(({ version }) => {
+        inFlight = null;
+        publish({ kind: "idle" });
+        new Notice(`opencode v${version} installed.`);
+      })
+      .catch((err: unknown) => {
+        inFlight = null;
+        if (isAbort(err)) {
+          publish({ kind: "idle" });
+          return;
+        }
+        logError("[AgentMode] inline opencode install failed", err);
+        publish({ kind: "error", message: describeError(err) });
+      });
+  }, [plugin]);
+
+  // Adopting an existing binary is one detect plus the same validation the
+  // Configure dialog runs (file exists, executable, answers `--version`), so a
+  // binary that can't actually run is rejected here rather than at ACP boot.
+  //
+  // Shared rather than row-local even though nothing here is cancellable: the
+  // detect ends in `setCustomBinaryPath`, which writes the same setting a
+  // managed install does. A row that unmounted mid-detect would leave that
+  // write invisible, and the next row would offer Download on top of it.
+  const adoptExisting = React.useCallback(() => {
+    inFlight = { kind: "detecting" };
+    publish({ kind: "detecting" });
+    void (async () => {
+      try {
+        const found = await detectOpencodeCliPath();
+        if (!found) {
+          inFlight = null;
+          publish({
+            kind: "error",
+            message: "Couldn't find opencode on this device. Use Configure to enter its path.",
+          });
+          return;
+        }
+        await getOpencodeBinaryManager(plugin).setCustomBinaryPath(found);
+        inFlight = null;
+        publish({ kind: "idle" });
+        new Notice(`Using the opencode at ${found}.`);
+      } catch (e) {
+        inFlight = null;
+        logError("[AgentMode] adopting an existing opencode failed", e);
+        publish({ kind: "error", message: describeError(e) });
+      }
+    })();
+  }, [plugin]);
+
+  const state: OpencodeAbsentInstallState =
+    run.kind === "installing"
+      ? {
+          kind: "installing",
+          label: phaseLabel(run.progress),
+          percent: phaseProgress(run.progress) ?? 0,
+        }
+      : run;
+
+  return (
+    <OpencodeAbsentInstallView
+      state={state}
+      onInstall={startInstall}
+      onCancel={() => {
+        if (inFlight?.kind === "installing") inFlight.controller.abort();
+      }}
+      onAdoptExisting={adoptExisting}
+      onConfigure={() => OpencodeBackendDescriptor.openInstallUI(plugin)}
+    />
+  );
+};

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
@@ -1,6 +1,6 @@
 import { getOpencodeBinaryManager, OpencodeBackendDescriptor } from "./descriptor";
 import { phaseLabel, phaseProgress } from "./installProgress";
-import { OperationInFlightError } from "./OpencodeBinaryManager";
+import { AbortError, OpencodeNotFoundError, OperationInFlightError } from "./OpencodeBinaryManager";
 import {
   OpencodeAbsentInstallView,
   type OpencodeAbsentInstallState,
@@ -34,10 +34,18 @@ export const OpencodeAbsentInstallActions: React.FC<{ plugin: CopilotPlugin }> =
 
   // The manager already records a failure in its runtime state, where the next
   // row to mount will show it — so a rejection here needs no reporting of its
-  // own. `OperationInFlightError` is swallowed entirely: it only means the user
-  // reached an action the state says is unavailable.
+  // own. Three rejections are outcomes rather than faults and stay out of the
+  // log entirely: losing the race for the manager, cancelling a download, and a
+  // detect that searched everywhere it knows and came up empty.
   const report = (context: string) => (e: unknown) => {
-    if (e instanceof OperationInFlightError) return;
+    if (
+      e instanceof OperationInFlightError ||
+      e instanceof OpencodeNotFoundError ||
+      e instanceof AbortError ||
+      (e as Error | undefined)?.name === "AbortError"
+    ) {
+      return;
+    }
     logError(`[AgentMode] ${context}`, e);
   };
 
@@ -51,13 +59,10 @@ export const OpencodeAbsentInstallActions: React.FC<{ plugin: CopilotPlugin }> =
   const adoptExisting = React.useCallback(() => {
     manager
       .adoptExistingBinary()
-      .then((found) => {
-        new Notice(
-          found
-            ? `Using the opencode at ${found}.`
-            : "Couldn't find opencode on this device. Use Configure to enter its path."
-        );
-      })
+      // Finding nothing rejects rather than resolving, so it reaches the row as
+      // the error state that reveals Configure — the only way left to name a
+      // binary the search cannot reach.
+      .then((found) => new Notice(`Using the opencode at ${found}.`))
       .catch(report("adopting an existing opencode failed"));
   }, [manager]);
 

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
@@ -69,6 +69,26 @@ type InFlightWork =
 
 let inFlight: InFlightWork | null = null;
 
+/**
+ * DESIGN NOTE — this state deliberately outlives a plugin lifecycle, and that
+ * is safe. Module scope survives disable→enable, dev hot reload, and "Open
+ * another vault" in the same process (`main.ts` says so where it resets the
+ * persistence singletons), so a download started in one lifecycle is still
+ * here in the next. Nothing resets `inFlight` outside tests, which is what
+ * makes the carry-over coherent rather than corrupting: a row that sees work
+ * in flight shows its progress and Cancel and never offers Download, so the
+ * next lifecycle adopts the run instead of starting a rival one — and there is
+ * no second task for the old continuation to clobber when it settles.
+ *
+ * The one effect that does cross the boundary is the manager's own settings
+ * write when the install lands. It is accurate: `getDataDir()` builds under
+ * `os.homedir()`, so the binary it names really is installed for whatever vault
+ * is open. The vault that started the download is the one left out, and it
+ * self-heals — `install()` is idempotent, so Download there returns instantly
+ * off the existing manifest.
+ * If a future review flags the lifecycle boundary, point them at this note.
+ */
+
 /** The `Run` a freshly mounted row should start from. */
 const stateOf = (work: InFlightWork | null): Run => {
   if (!work) return { kind: "idle" };

--- a/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInlineInstall.tsx
@@ -1,167 +1,14 @@
-import {
-  detectOpencodeCliPath,
-  getOpencodeBinaryManager,
-  OpencodeBackendDescriptor,
-} from "@/agentMode/backends/opencode/descriptor";
-import { phaseLabel, phaseProgress } from "@/agentMode/backends/opencode/installProgress";
-import {
-  AbortError,
-  type ProgressEvent,
-} from "@/agentMode/backends/opencode/OpencodeBinaryManager";
+import { getOpencodeBinaryManager, OpencodeBackendDescriptor } from "./descriptor";
+import { phaseLabel, phaseProgress } from "./installProgress";
+import { OperationInFlightError } from "./OpencodeBinaryManager";
 import {
   OpencodeAbsentInstallView,
   type OpencodeAbsentInstallState,
-} from "@/agentMode/backends/opencode/ui/OpencodeAbsentInstallView";
+} from "./ui/OpencodeAbsentInstallView";
 import { logError } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { Notice } from "obsidian";
 import React from "react";
-
-/** What the row's action cluster is currently doing. */
-type Run =
-  | { kind: "idle" }
-  | { kind: "detecting" }
-  | { kind: "installing"; progress: ProgressEvent | null }
-  | { kind: "error"; message: string };
-
-const describeError = (e: unknown): string => (e instanceof Error ? e.message : String(e));
-
-const isAbort = (e: unknown): boolean =>
-  e instanceof AbortError || (e as Error | undefined)?.name === "AbortError";
-
-/**
- * Work that persists the opencode binary path, held at module scope rather than
- * in the row that started it.
- *
- * Both members write the same setting: the managed install lands a downloaded
- * binary, and adopting an existing one saves a custom path. Either can outlive
- * the row — this row unmounts routinely, since the panel flips to "ready" on
- * success and switching agent sub-tabs drops the whole panel (`TabContent`
- * renders null when unselected). Parked in component state, that work would
- * either die with the row or keep running invisibly, and a remounted row would
- * offer the *other* writer while the first was still about to land. Whichever
- * settled last would win, leaving settings naming a source the user did not
- * choose last.
- *
- * Holding it here is what makes the row's state a view of the work rather than
- * a private copy of it: the work survives a tab switch, any row can show it,
- * and while it runs no row offers either action.
- *
- * DESIGN NOTE — why this lives in the UI module and not in the manager.
- * `useBackendInstallState` / `descriptor.subscribeInstallState` is the codebase's
- * cross-mount install-state convention, but it reports only *persisted* state
- * (absent / ready / incompatible, derived from `binaryPath` & friends in
- * settings). It cannot express detecting, installing, progress, the
- * `AbortController`, or a failure that never reached settings — so it does not
- * subsume this. The better long-term home is `OpencodeBinaryManager`, which
- * `getOpencodeBinaryManager` already returns as a cached singleton
- * (`descriptor.ts` `managerRef`): it would own the in-flight run behind a
- * `useSyncExternalStore` snapshot and leave this file with no module state at
- * all. That move rewrites the manager's API and its tests, relocates the adopt
- * detect across a dependency edge, and needs a settled contract for how runtime
- * state merges with persisted state — an install-architecture change, not a
- * settings-row fix. Deferred deliberately.
- *
- * DESIGN NOTE — racing Configure dialogs (issue #TBD).
- * While an inline install runs, persisted installState is still `absent`, so
- * every Configure entry point (AgentModeChat, AgentHome, AgentModeStatus,
- * useAgentSelect, and the non-inline AgentSettings branch) can still open the
- * dialog. From there the user can save a custom binary path or start another
- * managed install, racing this pending one and letting whichever writer settles
- * last choose the saved opencode source despite the inline row hiding its own
- * competing actions.
- * The correct fix is a single-flight token in `OpencodeBinaryManager`: only one
- * of `install()`, `upgradeCustomBinary()`, `uninstall()`, `setCustomBinaryPath()`
- * may run at a time; a second caller is rejected with a clear error rather than
- * racing. That serializes ALL entry points (including ones not yet written) at
- * the one choke point, and it puts the lifecycle on the manager surface where
- * AGENTS.md:117-123 asks for it. Deferred as a follow-up: this PR is 8 review
- * rounds deep, already carries 215 lines of module-scoped async state, and
- * adding manager-level concurrency control is an install-architecture change
- * that should land independently.
- * If a future review flags this shape again, point them at this note.
- */
-type InFlightWork =
-  | { kind: "installing"; controller: AbortController; progress: ProgressEvent | null }
-  | { kind: "detecting" };
-
-let inFlight: InFlightWork | null = null;
-
-/**
- * DESIGN NOTE — this state deliberately outlives a plugin lifecycle, and that
- * is safe. Module scope survives disable→enable, dev hot reload, and "Open
- * another vault" in the same process (`main.ts` says so where it resets the
- * persistence singletons), so a download started in one lifecycle is still
- * here in the next. Nothing resets `inFlight` outside tests, which is what
- * makes the carry-over coherent rather than corrupting: a row that sees work
- * in flight shows its progress and Cancel and never offers Download, so the
- * next lifecycle adopts the run instead of starting a rival one — and there is
- * no second task for the old continuation to clobber when it settles.
- *
- * The one effect that does cross the boundary is the manager's own settings
- * write when the install lands. It is accurate: `getDataDir()` builds under
- * `os.homedir()`, so the binary it names really is installed for whatever vault
- * is open. The vault that started the download is the one left out, and it
- * self-heals — `install()` is idempotent, so Download there returns instantly
- * off the existing manifest.
- * If a future review flags the lifecycle boundary, point them at this note.
- */
-
-/** The `Run` a freshly mounted row should start from. */
-const stateOf = (work: InFlightWork | null): Run => {
-  if (!work) return { kind: "idle" };
-  return work.kind === "installing"
-    ? { kind: "installing", progress: work.progress }
-    : { kind: "detecting" };
-};
-
-/**
- * Every mounted row. The work outlives any one of them, so it cannot hold a
- * `setState` from the row that happened to start it — it publishes here and
- * whichever row is on screen picks it up.
- */
-const rows = new Set<(state: Run) => void>();
-
-/**
- * Announce a state to whatever row is mounted. Every transition goes through
- * here, not just progress: a row that mounts mid-download would otherwise never
- * learn the install finished, and would sit on a progress bar whose Cancel
- * button no longer points at anything.
- */
-const publish = (state: Run): void => {
-  rows.forEach((notify) => notify(state));
-};
-
-/**
- * Report a failure through the row when one is mounted, and through a `Notice`
- * when none is — the work can outlive every row, and `publish` to an empty set
- * is silent. Both success paths already announce unconditionally; without this
- * a first run that failed while the user was on another tab would leave them
- * back at an idle Download button with no reason given.
- *
- * The Notice names opencode because it appears with no surrounding context; the
- * row does not, since it sits inside the opencode panel.
- *
- * DESIGN NOTE — the failure is announced once, not replayed. A row mounting
- * *after* a failure already settled shows idle actions, not the old error:
- * nothing outlives the announcement, by design. Making terminal errors
- * replayable means persisting them, which is a runtime-state contract that
- * belongs with the manager-owned store described above, not another module
- * variable here. Retrying is one click and re-surfaces any error that persists.
- * If a future review flags the missing replay, point them at this note.
- */
-const announceFailure = (message: string): void => {
-  if (rows.size > 0) {
-    publish({ kind: "error", message });
-    return;
-  }
-  new Notice(`opencode setup failed: ${message}`);
-};
-
-/** Test seam: no production caller, since a real install always settles. */
-export function __resetInFlightInstallForTests(): void {
-  inFlight = null;
-}
 
 /**
  * Inline install actions for opencode, rendered by the generic backend panel
@@ -169,89 +16,50 @@ export function __resetInFlightInstallForTests(): void {
  * install itself, so this owns the whole first-run path — download, progress,
  * cancel, retry, and adopting an existing binary — and the Configure dialog
  * stays reserved for upgrade, uninstall, and custom paths.
+ *
+ * The row renders the manager's runtime state and owns none of it. That is what
+ * makes it safe for this row to come and go: it unmounts routinely (the panel
+ * flips to "ready" on success, and switching agent sub-tabs drops the panel
+ * entirely), while a download has to outlive it. Every other entry point that
+ * can start a competing operation reads the same state, so whichever surface is
+ * on screen shows the one run and offers no rival action.
  */
 export const OpencodeAbsentInstallActions: React.FC<{ plugin: CopilotPlugin }> = ({ plugin }) => {
-  // Adopt an install already running, so returning to this tab shows progress
-  // Start from whatever work is already running, so returning to this tab shows
-  // it rather than an action that would start a competing one.
-  const [run, setRun] = React.useState<Run>(() => stateOf(inFlight));
+  const manager = React.useMemo(() => getOpencodeBinaryManager(plugin), [plugin]);
+  const run = React.useSyncExternalStore(
+    manager.subscribeRuntimeState,
+    manager.getRuntimeState,
+    manager.getRuntimeState
+  );
 
-  React.useEffect(() => {
-    // Subscribe unconditionally: this row may start the work itself, or may
-    // mount into work already running. Either way it reaches the row here.
-    const onWorkState = (state: Run) => setRun(state);
-    rows.add(onWorkState);
-    return () => {
-      rows.delete(onWorkState);
-    };
-  }, []);
+  // The manager already records a failure in its runtime state, where the next
+  // row to mount will show it — so a rejection here needs no reporting of its
+  // own. `OperationInFlightError` is swallowed entirely: it only means the user
+  // reached an action the state says is unavailable.
+  const report = (context: string) => (e: unknown) => {
+    if (e instanceof OperationInFlightError) return;
+    logError(`[AgentMode] ${context}`, e);
+  };
 
   const startInstall = React.useCallback(() => {
-    const task: InFlightWork = {
-      kind: "installing",
-      controller: new AbortController(),
-      progress: null,
-    };
-    inFlight = task;
-    publish({ kind: "installing", progress: null });
-    getOpencodeBinaryManager(plugin)
-      .install({
-        signal: task.controller.signal,
-        onProgress: (e) => {
-          // Recorded on the task as well as published, so a row that mounts
-          // later starts from the current progress rather than zero.
-          task.progress = e;
-          publish({ kind: "installing", progress: e });
-        },
-      })
-      .then(({ version }) => {
-        inFlight = null;
-        publish({ kind: "idle" });
-        new Notice(`opencode v${version} installed.`);
-      })
-      .catch((err: unknown) => {
-        inFlight = null;
-        if (isAbort(err)) {
-          publish({ kind: "idle" });
-          return;
-        }
-        logError("[AgentMode] inline opencode install failed", err);
-        announceFailure(describeError(err));
-      });
-  }, [plugin]);
+    manager
+      .install()
+      .then(({ version }) => new Notice(`opencode v${version} installed.`))
+      .catch(report("inline opencode install failed"));
+  }, [manager]);
 
-  // Adopting an existing binary is one detect plus the same validation the
-  // Configure dialog runs (file exists, executable, answers `--version`), so a
-  // binary that can't actually run is rejected here rather than at ACP boot.
-  //
-  // Shared rather than row-local even though nothing here is cancellable: the
-  // detect ends in `setCustomBinaryPath`, which writes the same setting a
-  // managed install does. A row that unmounted mid-detect would leave that
-  // write invisible, and the next row would offer Download on top of it.
   const adoptExisting = React.useCallback(() => {
-    inFlight = { kind: "detecting" };
-    publish({ kind: "detecting" });
-    void (async () => {
-      try {
-        const found = await detectOpencodeCliPath();
-        if (!found) {
-          inFlight = null;
-          announceFailure(
-            "Couldn't find opencode on this device. Use Configure to enter its path."
-          );
-          return;
-        }
-        await getOpencodeBinaryManager(plugin).setCustomBinaryPath(found);
-        inFlight = null;
-        publish({ kind: "idle" });
-        new Notice(`Using the opencode at ${found}.`);
-      } catch (e) {
-        inFlight = null;
-        logError("[AgentMode] adopting an existing opencode failed", e);
-        announceFailure(describeError(e));
-      }
-    })();
-  }, [plugin]);
+    manager
+      .adoptExistingBinary()
+      .then((found) => {
+        new Notice(
+          found
+            ? `Using the opencode at ${found}.`
+            : "Couldn't find opencode on this device. Use Configure to enter its path."
+        );
+      })
+      .catch(report("adopting an existing opencode failed"));
+  }, [manager]);
 
   const state: OpencodeAbsentInstallState =
     run.kind === "installing"
@@ -260,15 +68,18 @@ export const OpencodeAbsentInstallActions: React.FC<{ plugin: CopilotPlugin }> =
           label: phaseLabel(run.progress),
           percent: phaseProgress(run.progress) ?? 0,
         }
-      : run;
+      : // `busy` belongs to operations this row cannot start (upgrade, uninstall,
+        // a custom path applied from the dialog). Showing it as a detect keeps
+        // both writers off screen without inventing a fifth visual state.
+        run.kind === "busy"
+        ? { kind: "detecting" }
+        : run;
 
   return (
     <OpencodeAbsentInstallView
       state={state}
       onInstall={startInstall}
-      onCancel={() => {
-        if (inFlight?.kind === "installing") inFlight.controller.abort();
-      }}
+      onCancel={() => manager.cancelCurrentOperation()}
       onAdoptExisting={adoptExisting}
       onConfigure={() => OpencodeBackendDescriptor.openInstallUI(plugin)}
     />

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.test.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.test.tsx
@@ -18,6 +18,7 @@ jest.mock("@/components/modals/ConfirmModal", () => ({
 import { DEFAULT_SETTINGS } from "@/constants";
 import {
   AbortError,
+  OperationInFlightError,
   type OpencodeBinaryManager,
   type ProgressEvent,
   type RuntimeState,
@@ -322,6 +323,40 @@ describe("OpencodeInstallModal", () => {
 
       expect(setCustomBinaryPath).toHaveBeenCalledWith(null);
       expect(noticeMessages()).toContain("Custom opencode path cleared.");
+    });
+
+    it("explains a clear that lost the binary-path lock instead of failing silently", async () => {
+      setOpencodeSettings({
+        binaryPath: EXISTING_BINARY_PATH,
+        binaryVersion: "1.16.0",
+        binarySource: "custom",
+      });
+      const { manager, setCustomBinaryPath } = makeManager();
+      setCustomBinaryPath.mockRejectedValue(new OperationInFlightError());
+      renderContainer(manager);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+      });
+
+      // The caller awaits this with no catch of its own, so an unreported
+      // rejection would leave the button resetting with nothing said.
+      expect(noticeMessages().join(" ")).toContain("Couldn't clear the custom path");
+      expect(noticeMessages()).not.toContain("Custom opencode path cleared.");
+    });
+
+    it("names the operation that won when a download loses the race", async () => {
+      const { manager, installDeferred } = makeManager();
+      renderContainer(manager);
+
+      fireEvent.click(screen.getByRole("button", { name: "Download & install" }));
+      await act(async () => {
+        installDeferred().reject(new OperationInFlightError());
+      });
+
+      // This is the one failure the shared runtime state cannot render: it
+      // belongs to the operation that won, not to this dialog.
+      expect(noticeMessages().join(" ")).toContain("already running");
     });
 
     it("uninstalls only after the size-annotated confirmation is accepted", async () => {

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.test.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.test.tsx
@@ -20,6 +20,7 @@ import {
   AbortError,
   type OpencodeBinaryManager,
   type ProgressEvent,
+  type RuntimeState,
 } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
 import { OpencodeConfigContainer } from "@/agentMode/backends/opencode/OpencodeInstallModal";
 import { getSettings, settingsAtom, settingsStore } from "@/settings/model";
@@ -40,6 +41,8 @@ const makeManager = (): {
   manager: OpencodeBinaryManager;
   installCalls: Array<{ signal?: AbortSignal; onProgress?: (e: ProgressEvent) => void }>;
   installDeferred: () => Deferred<{ version: string; path: string }>;
+  publish: (state: RuntimeState) => void;
+  cancelCurrentOperation: jest.Mock;
   upgradeManaged: jest.Mock;
   upgradeCustomBinary: jest.Mock;
   setCustomBinaryPath: jest.Mock;
@@ -51,9 +54,28 @@ const makeManager = (): {
   const upgradeCustomBinary = jest.fn().mockResolvedValue({ version: "1.16.0", path: "/custom" });
   const setCustomBinaryPath = jest.fn().mockResolvedValue(undefined);
   const uninstall = jest.fn().mockResolvedValue(undefined);
+  const cancelCurrentOperation = jest.fn();
+
+  // The dialog reads progress off the manager now, so the fake has to be a
+  // store: `subscribeRuntimeState`/`getRuntimeState` must keep stable
+  // identities or `useSyncExternalStore` resubscribes on every commit.
+  let runtime: RuntimeState = { kind: "idle" };
+  const listeners = new Set<() => void>();
+  const publish = (state: RuntimeState) => {
+    runtime = state;
+    act(() => listeners.forEach((notify) => notify()));
+  };
+
   const manager = {
+    subscribeRuntimeState: (onChange: () => void) => {
+      listeners.add(onChange);
+      return () => listeners.delete(onChange);
+    },
+    getRuntimeState: () => runtime,
+    cancelCurrentOperation,
     install: jest.fn((opts: { signal?: AbortSignal; onProgress?: (e: ProgressEvent) => void }) => {
       installCalls.push(opts);
+      publish({ kind: "installing", progress: null });
       return new Promise<{ version: string; path: string }>((resolve, reject) => {
         deferreds.push({ resolve, reject });
       });
@@ -69,6 +91,8 @@ const makeManager = (): {
     manager,
     installCalls,
     installDeferred: () => deferreds[deferreds.length - 1],
+    publish,
+    cancelCurrentOperation,
     upgradeManaged,
     upgradeCustomBinary,
     setCustomBinaryPath,
@@ -86,7 +110,7 @@ const setOpencodeSettings = (opencode: OpencodeBackendSettings | undefined): voi
   });
 };
 
-const renderContainer = (manager: OpencodeBinaryManager) => {
+const renderContainer = (manager: OpencodeBinaryManager) =>
   render(
     <OpencodeConfigContainer
       manager={manager}
@@ -96,7 +120,6 @@ const renderContainer = (manager: OpencodeBinaryManager) => {
       onClose={jest.fn()}
     />
   );
-};
 
 const noticeMessages = (): string[] =>
   (Notice as unknown as jest.Mock).mock.calls.map((c) => String(c[0]));
@@ -151,19 +174,22 @@ describe("OpencodeInstallModal", () => {
     });
 
     it("translates download progress events into the label and percent it renders", async () => {
-      const { manager, installCalls, installDeferred } = makeManager();
+      const { manager, publish, installDeferred } = makeManager();
       renderContainer(manager);
 
       fireEvent.click(screen.getByRole("button", { name: "Download & install" }));
       expect(screen.getByText("Starting…")).toBeTruthy();
 
-      act(() => {
-        installCalls[0].onProgress?.({
+      // Progress arrives through the manager's runtime state now, so the row
+      // and this dialog show the same run rather than each tracking its own.
+      publish({
+        kind: "installing",
+        progress: {
           phase: "download",
           received: 300,
           total: 1000,
           assetName: "opencode-darwin-arm64.zip",
-        });
+        },
       });
       expect(
         screen.getByText("Downloading opencode-darwin-arm64.zip — 300 B / 1000 B (30%)")
@@ -172,33 +198,42 @@ describe("OpencodeInstallModal", () => {
       await act(async () => {
         installDeferred().resolve({ version: "1.16.0", path: "/managed/opencode" });
       });
+      publish({ kind: "idle" });
       expect(noticeMessages()).toContain("opencode v1.16.0 installed.");
       expect(screen.getByRole("button", { name: "Download & install" })).toBeTruthy();
     });
 
-    it("aborts the in-flight download on Cancel and returns to idle without an error", async () => {
-      const { manager, installCalls, installDeferred } = makeManager();
-      renderContainer(manager);
+    it("cancels through the manager so closing the dialog cannot kill the run", async () => {
+      const { manager, cancelCurrentOperation, publish, installDeferred } = makeManager();
+      const { unmount } = renderContainer(manager);
 
       fireEvent.click(screen.getByRole("button", { name: "Download & install" }));
       fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-      expect(installCalls[0].signal?.aborted).toBe(true);
+      expect(cancelCurrentOperation).toHaveBeenCalled();
 
       await act(async () => {
         installDeferred().reject(new AbortError());
       });
+      publish({ kind: "idle" });
       expect(screen.getByRole("button", { name: "Download & install" })).toBeTruthy();
       expect(screen.queryByText("Aborted")).toBeNull();
+
+      // Unmounting is not a cancellation: the settings row may still be showing
+      // this same operation.
+      cancelCurrentOperation.mockClear();
+      unmount();
+      expect(cancelCurrentOperation).not.toHaveBeenCalled();
     });
 
     it("surfaces an install failure and keeps the retry available", async () => {
-      const { manager, installDeferred } = makeManager();
+      const { manager, publish, installDeferred } = makeManager();
       renderContainer(manager);
 
       fireEvent.click(screen.getByRole("button", { name: "Download & install" }));
       await act(async () => {
         installDeferred().reject(new Error("tar exited with 1"));
       });
+      publish({ kind: "error", message: "tar exited with 1" });
 
       expect(screen.getByText("tar exited with 1")).toBeTruthy();
       expect(screen.getByRole("button", { name: "Download & install" })).toBeTruthy();

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.test.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.test.tsx
@@ -257,6 +257,97 @@ describe("OpencodeInstallModal", () => {
       expect(upgradeCustomBinary).not.toHaveBeenCalled();
       expect(noticeMessages()).toContain("opencode upgraded to v1.16.0.");
     });
+    it("drops a failed upgrade's reason once an install has replaced the binary", async () => {
+      setOpencodeSettings({
+        binaryPath: EXISTING_BINARY_PATH,
+        binaryVersion: "1.15.12",
+        binarySource: "managed",
+      });
+      const { manager, upgradeManaged, installDeferred, publish } = makeManager();
+      upgradeManaged.mockRejectedValue(new Error("tar exited with 1"));
+      renderContainer(manager);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Upgrade to latest" }));
+      });
+      expect(screen.getByText("tar exited with 1")).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("button", { name: "Reinstall" }));
+      await act(async () => {
+        installDeferred().resolve({ version: "1.16.0", path: "/managed" });
+      });
+      publish({ kind: "idle" });
+
+      // The reason described a binary this install has replaced. It survives a
+      // *failed* install on purpose: nothing changed, so it is still true.
+      expect(screen.queryByText("tar exited with 1")).toBeNull();
+    });
+
+    it("leaves a running install visible when an upgrade loses the race for it", async () => {
+      setOpencodeSettings({
+        binaryPath: EXISTING_BINARY_PATH,
+        binaryVersion: "1.15.12",
+        binarySource: "managed",
+      });
+      const { manager, upgradeManaged } = makeManager();
+      upgradeManaged.mockRejectedValue(new OperationInFlightError());
+      renderContainer(manager);
+
+      // The reinstall takes the lock; the upgrade clicked underneath it never
+      // owns the run, so it must not take the run's display with it.
+      fireEvent.click(screen.getByRole("button", { name: "Reinstall" }));
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Upgrade to latest" }));
+      });
+
+      expect(screen.getAllByRole("progressbar")).toHaveLength(1);
+      expect(noticeMessages().join(" ")).toContain("already running");
+    });
+
+    it("treats a cancelled upgrade as cancelled, not as a failure", async () => {
+      setOpencodeSettings({
+        binaryPath: EXISTING_BINARY_PATH,
+        binaryVersion: "1.15.12",
+        binarySource: "managed",
+      });
+      const { manager, upgradeManaged } = makeManager();
+      upgradeManaged.mockRejectedValue(new AbortError());
+      renderContainer(manager);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Upgrade to latest" }));
+      });
+
+      // Cancel is the user's own doing; the strip must go back to offering the
+      // upgrade rather than reporting "Aborted" as a failure.
+      expect(screen.queryByText("Aborted")).toBeNull();
+      expect(screen.getByRole("button", { name: "Upgrade to latest" })).toBeTruthy();
+    });
+
+    it("drops a failed upgrade's reason once another binary is applied", async () => {
+      setOpencodeSettings({
+        binaryPath: EXISTING_BINARY_PATH,
+        binaryVersion: "1.15.12",
+        binarySource: "managed",
+      });
+      const { manager, upgradeManaged } = makeManager();
+      upgradeManaged.mockRejectedValue(new Error("GitHub API rate-limited"));
+      renderContainer(manager);
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Upgrade to latest" }));
+      });
+      expect(screen.getByText("GitHub API rate-limited")).toBeTruthy();
+
+      fireEvent.click(screen.getByRole("radio", { name: "My own binary" }));
+      fireEvent.change(screen.getByPlaceholderText("/absolute/path/to/opencode"), {
+        target: { value: "/opt/homebrew/bin/opencode" },
+      });
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Apply" }));
+      });
+
+      // The reason belonged to the managed download, not to the binary now in play.
+      expect(screen.queryByText("GitHub API rate-limited")).toBeNull();
+    });
 
     it("upgrades an outdated custom binary through its own upgrade command", async () => {
       setOpencodeSettings({

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -93,17 +93,30 @@ export const OpencodeConfigContainer: React.FC<{
     manager.getRuntimeState,
     manager.getRuntimeState
   );
+  const [upgradeRun, setUpgradeRun] = React.useState<OpencodeRunState>({ kind: "idle" });
+
+  /**
+   * Drop the last upgrade's outcome, because the binary it described has just
+   * been replaced. Called on the success of every operation that changes which
+   * binary is in play — never before one, since an operation that fails leaves
+   * that outcome as true as it was, and the strip is the only place it is shown.
+   */
+  const forgetUpgradeOutcome = React.useCallback(() => setUpgradeRun({ kind: "idle" }), []);
   // DESIGN NOTE — `detecting` and `busy` deliberately map to idle, not to
   // `running`. `running` is the shape this dialog uses for a cancellable
   // download: it replaces the whole managed section with a progress bar and a
   // Cancel. None of the operations behind those two kinds takes a signal
   // (their `runExclusive` bodies declare no parameter), so Cancel would be a
-  // control that does nothing — and during a custom-binary upgrade the section
-  // would also fight the dialog's own `upgradeRun`. The real harm in the
+  // control that does nothing. The real harm in the
   // reported case was a Download click that reported nothing; that is fixed
   // where it happens, by surfacing `OperationInFlightError` below, instead of
   // by borrowing a state whose meaning does not fit.
   // If a future review flags this again, point them at this note.
+  // Mirrors the manager unconditionally. An earlier attempt let a local
+  // `upgradeRun` suppress this so a managed upgrade would not draw two progress
+  // bars — but a dialog-local value vetoing a shared run produced four defects
+  // in as many review rounds, including hiding an install started from another
+  // surface. Showing one run twice is a cosmetic cost; hiding it is not.
   const installRun: OpencodeRunState =
     runtime.kind === "installing"
       ? runningState(runtime.progress)
@@ -114,7 +127,10 @@ export const OpencodeConfigContainer: React.FC<{
   const install = React.useCallback(() => {
     manager
       .install()
-      .then(({ version }) => new Notice(`opencode v${version} installed.`))
+      .then(({ version }) => {
+        forgetUpgradeOutcome();
+        new Notice(`opencode v${version} installed.`);
+      })
       .catch((err: unknown) => {
         // Cancellation is not a failure, and a real failure is already in the
         // manager's runtime state, which this dialog renders.
@@ -128,7 +144,7 @@ export const OpencodeConfigContainer: React.FC<{
         }
         logError("[AgentMode] opencode install failed", err);
       });
-  }, [manager]);
+  }, [manager, forgetUpgradeOutcome]);
 
   const cancelInstall = React.useCallback(() => manager.cancelCurrentOperation(), [manager]);
 
@@ -144,6 +160,7 @@ export const OpencodeConfigContainer: React.FC<{
       async () => {
         try {
           await manager.uninstall();
+          forgetUpgradeOutcome();
           new Notice(`opencode uninstalled${bytes > 0 ? ` (freed ${formatBytes(bytes)})` : ""}.`);
         } catch (e) {
           logError("[AgentMode] uninstall failed", e);
@@ -155,9 +172,8 @@ export const OpencodeConfigContainer: React.FC<{
       "Uninstall opencode",
       "Uninstall"
     ).open();
-  }, [app, manager]);
+  }, [app, manager, forgetUpgradeOutcome]);
 
-  const [upgradeRun, setUpgradeRun] = React.useState<OpencodeRunState>({ kind: "idle" });
   const upgrade = React.useCallback(() => {
     setUpgradeRun(runningState(null));
     // A user-supplied binary upgrades itself in place; the managed one is
@@ -172,6 +188,20 @@ export const OpencodeConfigContainer: React.FC<{
         new Notice(`opencode upgraded to v${version}.`);
       })
       .catch((err: unknown) => {
+        // Cancelling is the user's own doing, and losing the race means this
+        // upgrade never owned the run at all. Either way `upgradeRun` must go
+        // back to idle: the section below reads a non-idle value as "an upgrade
+        // is showing this run", and would otherwise hide the operation that
+        // actually holds the manager.
+        if (err instanceof AbortError || (err as Error)?.name === "AbortError") {
+          setUpgradeRun({ kind: "idle" });
+          return;
+        }
+        if (err instanceof OperationInFlightError) {
+          setUpgradeRun({ kind: "idle" });
+          new Notice(err.message);
+          return;
+        }
         logError("[AgentMode] opencode upgrade failed", err);
         setUpgradeRun(errorState(err));
       });
@@ -184,10 +214,11 @@ export const OpencodeConfigContainer: React.FC<{
       } catch (e) {
         return e instanceof Error ? e.message : String(e);
       }
+      forgetUpgradeOutcome();
       new Notice("Custom opencode binary path saved.");
       return null;
     },
-    [manager]
+    [manager, forgetUpgradeOutcome]
   );
 
   const clearCustomPath = React.useCallback(async (): Promise<void> => {
@@ -201,8 +232,9 @@ export const OpencodeConfigContainer: React.FC<{
       new Notice(`Couldn't clear the custom path: ${e instanceof Error ? e.message : String(e)}`);
       return;
     }
+    forgetUpgradeOutcome();
     new Notice("Custom opencode path cleared.");
-  }, [manager]);
+  }, [manager, forgetUpgradeOutcome]);
 
   return (
     <OpencodeConfigView

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -84,30 +84,34 @@ export const OpencodeConfigContainer: React.FC<{
     opencode?.binarySource ?? "managed"
   );
 
-  const [installRun, setInstallRun] = React.useState<OpencodeRunState>({ kind: "idle" });
-  const abortRef = React.useRef<AbortController | null>(null);
-  React.useEffect(() => () => abortRef.current?.abort(), []);
+  // Read from the manager rather than kept here: the dialog is one of several
+  // surfaces that can start an install, and closing it must not cancel a run
+  // the inline settings row is also showing. Cancel is now explicit only.
+  const runtime = React.useSyncExternalStore(
+    manager.subscribeRuntimeState,
+    manager.getRuntimeState,
+    manager.getRuntimeState
+  );
+  const installRun: OpencodeRunState =
+    runtime.kind === "installing"
+      ? runningState(runtime.progress)
+      : runtime.kind === "error"
+        ? { kind: "error", message: runtime.message }
+        : { kind: "idle" };
 
   const install = React.useCallback(() => {
-    const controller = new AbortController();
-    abortRef.current = controller;
-    setInstallRun(runningState(null));
     manager
-      .install({ signal: controller.signal, onProgress: (e) => setInstallRun(runningState(e)) })
-      .then(({ version }) => {
-        setInstallRun({ kind: "idle" });
-        new Notice(`opencode v${version} installed.`);
-      })
+      .install()
+      .then(({ version }) => new Notice(`opencode v${version} installed.`))
       .catch((err: unknown) => {
-        if (err instanceof AbortError || (err as Error)?.name === "AbortError") {
-          setInstallRun({ kind: "idle" });
-          return;
-        }
-        setInstallRun(errorState(err));
+        // Cancellation is not a failure, and a real failure is already in the
+        // manager's runtime state, which this dialog renders.
+        if (err instanceof AbortError || (err as Error)?.name === "AbortError") return;
+        logError("[AgentMode] opencode install failed", err);
       });
   }, [manager]);
 
-  const cancelInstall = React.useCallback(() => abortRef.current?.abort(), []);
+  const cancelInstall = React.useCallback(() => manager.cancelCurrentOperation(), [manager]);
 
   // Uninstall fully reclaims opencode: it removes every downloaded copy — all
   // versions under ~/.obsidian-copilot/opencode AND the old pre-migration copy

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -6,6 +6,7 @@ import {
 import {
   AbortError,
   computeInstallState,
+  OperationInFlightError,
   toOpencodeInstallState,
   type ProgressEvent,
 } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
@@ -92,6 +93,17 @@ export const OpencodeConfigContainer: React.FC<{
     manager.getRuntimeState,
     manager.getRuntimeState
   );
+  // DESIGN NOTE — `detecting` and `busy` deliberately map to idle, not to
+  // `running`. `running` is the shape this dialog uses for a cancellable
+  // download: it replaces the whole managed section with a progress bar and a
+  // Cancel. None of the operations behind those two kinds takes a signal
+  // (their `runExclusive` bodies declare no parameter), so Cancel would be a
+  // control that does nothing — and during a custom-binary upgrade the section
+  // would also fight the dialog's own `upgradeRun`. The real harm in the
+  // reported case was a Download click that reported nothing; that is fixed
+  // where it happens, by surfacing `OperationInFlightError` below, instead of
+  // by borrowing a state whose meaning does not fit.
+  // If a future review flags this again, point them at this note.
   const installRun: OpencodeRunState =
     runtime.kind === "installing"
       ? runningState(runtime.progress)
@@ -107,6 +119,13 @@ export const OpencodeConfigContainer: React.FC<{
         // Cancellation is not a failure, and a real failure is already in the
         // manager's runtime state, which this dialog renders.
         if (err instanceof AbortError || (err as Error)?.name === "AbortError") return;
+        // Losing the race is the one failure the runtime state cannot show:
+        // it belongs to the operation that won, which is rendering its own
+        // progress elsewhere. Without this the button would look inert.
+        if (err instanceof OperationInFlightError) {
+          new Notice(err.message);
+          return;
+        }
         logError("[AgentMode] opencode install failed", err);
       });
   }, [manager]);
@@ -172,7 +191,16 @@ export const OpencodeConfigContainer: React.FC<{
   );
 
   const clearCustomPath = React.useCallback(async (): Promise<void> => {
-    await manager.setCustomBinaryPath(null);
+    // The caller (`BinaryPathSetting`) awaits this in a try/finally with no
+    // catch, so anything thrown here becomes an unhandled rejection the user
+    // never sees — and clearing can now fail, because it takes the same
+    // binary-path lock every other write does.
+    try {
+      await manager.setCustomBinaryPath(null);
+    } catch (e) {
+      new Notice(`Couldn't clear the custom path: ${e instanceof Error ? e.message : String(e)}`);
+      return;
+    }
     new Notice("Custom opencode path cleared.");
   }, [manager]);
 

--- a/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
+++ b/src/agentMode/backends/opencode/OpencodeInstallModal.tsx
@@ -14,17 +14,12 @@ import { detectOpencodeCliPath } from "@/agentMode/backends/opencode/descriptor"
 import { ReactModal } from "@/components/modals/ReactModal";
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { formatBinaryPathForDisplay } from "@/utils/binaryPath";
+import { formatBytes } from "@/utils/formatBytes";
 import { OPENCODE_PINNED_VERSION } from "@/agentMode/backends/opencode/ui/opencodeVersion";
 import { logError } from "@/logger";
 import { useSettingsValue } from "@/settings/model";
 import { App, Notice } from "obsidian";
 import React from "react";
-
-const formatBytes = (bytes: number): string => {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-};
 
 /**
  * Turn a binary-manager progress event into the display-ready running state the

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -1,5 +1,3 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
 import { OpencodeInstallModal } from "@/agentMode/backends/opencode/OpencodeInstallModal";
 import { OpencodeAbsentInstallActions } from "@/agentMode/backends/opencode/OpencodeInlineInstall";
 import OpencodeLogo from "@/agentMode/backends/opencode/logo.svg";
@@ -23,9 +21,7 @@ import {
 } from "./OpencodeBinaryManager";
 import { opencodeEnabledModelEntries } from "./opencodeModelResolve";
 import { OpencodeSettingsPanel } from "./OpencodeSettingsPanel";
-import { resolveOpencodeBinary } from "./opencodeBinaryResolver";
 import { mapNodeArch, mapNodePlatform } from "./platformResolver";
-import { detectBinary } from "@/utils/detectBinary";
 import { cacheRoot } from "@/context/conversionsLocation";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { simpleBinaryBackendProcess } from "@/agentMode/backends/shared/simpleBinaryBackend";
@@ -106,29 +102,11 @@ export function getOpencodeBinaryManager(plugin: CopilotPlugin): OpencodeBinaryM
 }
 
 /**
- * Run an auto-detect for an externally-installed `opencode`, ignoring any
- * stale custom-path override (e.g. a POSIX path synced from a macOS profile
- * onto Windows). Walks well-known native-install layouts (`~/.opencode/bin`,
- * `~/.bun/bin`, `~/.local/bin`, `%LOCALAPPDATA%\opencode\bin`, ProgramFiles)
- * plus the shared node-tool dirs, then falls back to a PATH walk via
- * `detectBinary` so users with a non-standard install dir on PATH still match.
- * Independent of the managed binary.
+ * Re-exported so existing importers keep their path. The implementation lives
+ * in `opencodeCliDetector` because the manager needs it too, and importing it
+ * from here would close a descriptor↔manager cycle.
  */
-export async function detectOpencodeCliPath(): Promise<string | null> {
-  const fromResolver = resolveOpencodeBinary({
-    override: undefined,
-    homeDir: os.homedir(),
-    platform: process.platform,
-    env: process.env,
-    fs: {
-      existsSync: (p) => fs.existsSync(p),
-      readFileSync: (p, encoding) => fs.readFileSync(p, encoding),
-      readdirSync: (p) => fs.readdirSync(p),
-    },
-  });
-  if (fromResolver) return fromResolver;
-  return detectBinary("opencode");
-}
+export { detectOpencodeCliPath } from "./opencodeCliDetector";
 
 /**
  * Descriptor for the OpenCode backend. This is the contract `session/` and

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import { OpencodeInstallModal } from "@/agentMode/backends/opencode/OpencodeInstallModal";
+import { OpencodeAbsentInstallActions } from "@/agentMode/backends/opencode/OpencodeInlineInstall";
 import OpencodeLogo from "@/agentMode/backends/opencode/logo.svg";
 import type CopilotPlugin from "@/main";
 import { logWarn } from "@/logger";
@@ -186,6 +187,8 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
       arch: mapNodeArch(process.arch) ?? process.arch,
     }).open();
   },
+
+  AbsentInstallActions: OpencodeAbsentInstallActions,
 
   async upgrade(plugin: CopilotPlugin): Promise<void> {
     const manager = getOpencodeBinaryManager(plugin);

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -280,7 +280,13 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
   SettingsPanel: OpencodeSettingsPanel,
 
   async onPluginLoad(plugin: CopilotPlugin): Promise<void> {
-    await getOpencodeBinaryManager(plugin).refreshInstallState();
+    const manager = getOpencodeBinaryManager(plugin);
+    // The manager is a module-level singleton, so it survives disable→enable
+    // and "Open another vault" in the same process. Clearing at the START of a
+    // lifecycle is the convention `main.ts` documents for exactly that carry-
+    // over — and here it stops a failure from one vault greeting the next.
+    manager.forgetSettledError();
+    await manager.refreshInstallState();
   },
 
   getProbeSessionId(settings: CopilotSettings): string | undefined {

--- a/src/agentMode/backends/opencode/installProgress.test.ts
+++ b/src/agentMode/backends/opencode/installProgress.test.ts
@@ -1,0 +1,75 @@
+import { phaseLabel, phaseProgress } from "@/agentMode/backends/opencode/installProgress";
+
+describe("installProgress", () => {
+  describe("phaseLabel()", () => {
+    it("says the install is starting before the first progress event arrives", () => {
+      expect(phaseLabel(null)).toBe("Starting…");
+    });
+
+    it("caps the percentage it reports at 100, like the bar beside it", () => {
+      // A server that under-reports `Content-Length` delivers more than it
+      // promised. The bar clamps, so an uncapped label would read "300%" next to
+      // a full bar and neither number could be trusted.
+      expect(
+        phaseLabel({ phase: "download", received: 300, total: 100, assetName: "opencode" })
+      ).toContain("(100%)");
+    });
+
+    it("passes through the message carried by the resolve and extract phases", () => {
+      expect(phaseLabel({ phase: "resolve", message: "Resolving platform asset…" })).toBe(
+        "Resolving platform asset…"
+      );
+      expect(phaseLabel({ phase: "extract", message: "Extracting archive…" })).toBe(
+        "Extracting archive…"
+      );
+    });
+
+    it("shows received bytes, total bytes and a percentage for a sized download", () => {
+      expect(
+        phaseLabel({
+          phase: "download",
+          received: 1024 * 1024,
+          total: 4 * 1024 * 1024,
+          assetName: "opencode.zip",
+        })
+      ).toBe("Downloading opencode.zip — 1.0 MB / 4.0 MB (25%)");
+    });
+
+    it("omits the total and percentage when the server sent no content length", () => {
+      expect(phaseLabel({ phase: "download", received: 2048, assetName: "opencode.zip" })).toBe(
+        "Downloading opencode.zip — 2.0 KB"
+      );
+    });
+
+    it("reports completion for the done phase", () => {
+      expect(phaseLabel({ phase: "done", version: "1.2.3", path: "/bin/opencode" })).toBe("Done");
+    });
+  });
+
+  describe("phaseProgress()", () => {
+    it("has no percentage before the first event or during phases with no measurable fraction", () => {
+      expect(phaseProgress(null)).toBeUndefined();
+      expect(phaseProgress({ phase: "resolve", message: "…" })).toBeUndefined();
+      expect(
+        phaseProgress({ phase: "download", received: 500, assetName: "a.zip" })
+      ).toBeUndefined();
+    });
+
+    it("derives the percentage from received over total while downloading", () => {
+      expect(phaseProgress({ phase: "download", received: 25, total: 100, assetName: "a" })).toBe(
+        25
+      );
+    });
+
+    it("never exceeds 100 when a server over-reports received bytes", () => {
+      expect(phaseProgress({ phase: "download", received: 300, total: 100, assetName: "a" })).toBe(
+        100
+      );
+    });
+
+    it("holds just short of complete while extracting and reaches 100 when done", () => {
+      expect(phaseProgress({ phase: "extract", message: "…" })).toBe(98);
+      expect(phaseProgress({ phase: "done", version: "1", path: "/p" })).toBe(100);
+    });
+  });
+});

--- a/src/agentMode/backends/opencode/installProgress.ts
+++ b/src/agentMode/backends/opencode/installProgress.ts
@@ -1,0 +1,57 @@
+import type { ProgressEvent } from "@/agentMode/backends/opencode/OpencodeBinaryManager";
+import { formatBytes } from "@/utils/formatBytes";
+
+/**
+ * Narrates where a managed opencode install currently is. Shared by the
+ * Configure dialog and the inline install row so both surfaces describe the
+ * same pipeline with the same words.
+ *
+ * @param e - Latest progress event, or `null` before the first one arrives.
+ */
+export function phaseLabel(e: ProgressEvent | null): string {
+  if (!e) return "Starting…";
+  switch (e.phase) {
+    case "resolve":
+      return e.message;
+    case "download":
+      if (e.total) {
+        // Capped like the bar's own value: a server that under-reports its
+        // `Content-Length` sends more bytes than it promised, and the two
+        // surfaces would then disagree — a full bar beside "300%".
+        //
+        // DESIGN NOTE: this repeats one line of `phaseProgress` on purpose.
+        // Delegating to it instead reads `phaseProgress(e) ?? 0`, and that
+        // fallback is unreachable — the `if (e.total)` above is exactly the
+        // condition under which `phaseProgress` returns a number — so it is a
+        // defensive branch for an impossible state. Extracting a shared helper
+        // was considered and rejected: two adjacent call sites of one clamp do
+        // not add up to a domain concept worth a name and a jump.
+        // If a future review flags this again, point them at this note.
+        const pct = Math.min(100, Math.floor((e.received / e.total) * 100));
+        return `Downloading ${e.assetName} — ${formatBytes(e.received)} / ${formatBytes(e.total)} (${pct}%)`;
+      }
+      return `Downloading ${e.assetName} — ${formatBytes(e.received)}`;
+    case "extract":
+      return e.message;
+    case "done":
+      return "Done";
+  }
+}
+
+/**
+ * Completion percentage for the progress bar. Returns `undefined` for phases
+ * that carry no measurable fraction (resolving, or a download the server sent
+ * no content-length for) so the bar shows its zero state instead of inventing
+ * progress.
+ *
+ * @param e - Latest progress event, or `null` before the first one arrives.
+ */
+export function phaseProgress(e: ProgressEvent | null): number | undefined {
+  if (!e) return undefined;
+  if (e.phase === "download" && e.total) {
+    return Math.min(100, Math.floor((e.received / e.total) * 100));
+  }
+  if (e.phase === "extract") return 98;
+  if (e.phase === "done") return 100;
+  return undefined;
+}

--- a/src/agentMode/backends/opencode/opencodeCliDetector.ts
+++ b/src/agentMode/backends/opencode/opencodeCliDetector.ts
@@ -1,0 +1,34 @@
+import { detectBinary } from "@/utils/detectBinary";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import { resolveOpencodeBinary } from "./opencodeBinaryResolver";
+
+/**
+ * Run an auto-detect for an externally-installed `opencode`, ignoring any
+ * stale custom-path override (e.g. a POSIX path synced from a macOS profile
+ * onto Windows). Walks well-known native-install layouts (`~/.opencode/bin`,
+ * `~/.bun/bin`, `~/.local/bin`, `%LOCALAPPDATA%\opencode\bin`, ProgramFiles)
+ * plus the shared node-tool dirs, then falls back to a PATH walk via
+ * `detectBinary` so users with a non-standard install dir on PATH still match.
+ * Independent of the managed binary.
+ *
+ * Lives here rather than in `descriptor.ts` so `OpencodeBinaryManager` can call
+ * it: the descriptor already imports the manager, so a manager→descriptor
+ * import would close a cycle. The manager owns the adopt-existing flow, which
+ * needs this detect inside its single-flight boundary.
+ */
+export async function detectOpencodeCliPath(): Promise<string | null> {
+  const fromResolver = resolveOpencodeBinary({
+    override: undefined,
+    homeDir: os.homedir(),
+    platform: process.platform,
+    env: process.env,
+    fs: {
+      existsSync: (p) => fs.existsSync(p),
+      readFileSync: (p, encoding) => fs.readFileSync(p, encoding),
+      readdirSync: (p) => fs.readdirSync(p),
+    },
+  });
+  if (fromResolver) return fromResolver;
+  return detectBinary("opencode");
+}

--- a/src/agentMode/backends/opencode/ui/OpencodeAbsentInstallView.stories.tsx
+++ b/src/agentMode/backends/opencode/ui/OpencodeAbsentInstallView.stories.tsx
@@ -1,0 +1,61 @@
+import {
+  OpencodeAbsentInstallView,
+  type OpencodeAbsentInstallActionsProps,
+} from "@/agentMode/backends/opencode/ui/OpencodeAbsentInstallView";
+import type { Meta, StoryObj } from "@/lib/story";
+
+const meta = {
+  title: "Agent Mode/Opencode Absent Install",
+  component: OpencodeAbsentInstallView,
+  args: {
+    onInstall: () => undefined,
+    onCancel: () => undefined,
+    onAdoptExisting: () => undefined,
+    onConfigure: () => undefined,
+  },
+  // `settings-tab`, because this row lives in the opencode settings panel and
+  // its buttons inherit Obsidian's settings-pane chrome.
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<OpencodeAbsentInstallActionsProps>;
+export default meta;
+
+/** First run: download leads, adopting an existing binary is the quiet second. */
+export const Idle: StoryObj<OpencodeAbsentInstallActionsProps> = {
+  args: { state: { kind: "idle" } },
+};
+
+/** Detect in flight — both actions lock so the two cannot both write the path. */
+export const Detecting: StoryObj<OpencodeAbsentInstallActionsProps> = {
+  args: { state: { kind: "detecting" } },
+};
+
+export const Downloading: StoryObj<OpencodeAbsentInstallActionsProps> = {
+  args: {
+    state: {
+      kind: "installing",
+      label: "Downloading opencode-darwin-arm64.zip — 12.4 MB / 38.1 MB (32%)",
+      percent: 32,
+    },
+  },
+};
+
+/** The label is the longest thing in the row, so it has to truncate, not wrap. */
+export const DownloadingLongLabel: StoryObj<OpencodeAbsentInstallActionsProps> = {
+  args: {
+    state: {
+      kind: "installing",
+      label: "Downloading opencode-linux-x64-musl-static-with-a-very-long-asset-name.tar.gz",
+      percent: 71,
+    },
+  },
+};
+
+/** Failure swaps the second action for Configure, since detection has nothing left to try. */
+export const Failed: StoryObj<OpencodeAbsentInstallActionsProps> = {
+  args: {
+    state: {
+      kind: "error",
+      message: "Couldn't find opencode on this device. Use Configure to enter its path.",
+    },
+  },
+};

--- a/src/agentMode/backends/opencode/ui/OpencodeAbsentInstallView.tsx
+++ b/src/agentMode/backends/opencode/ui/OpencodeAbsentInstallView.tsx
@@ -1,0 +1,97 @@
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Download } from "lucide-react";
+import React from "react";
+
+/** What the row shows, already reduced from install progress to display values. */
+export type OpencodeAbsentInstallState =
+  | { kind: "idle" }
+  | { kind: "detecting" }
+  | { kind: "installing"; label: string; percent: number }
+  | { kind: "error"; message: string };
+
+/**
+ * The row's four actions. Injected rather than reached for so this view stays
+ * free of the binary manager and plugin, which is what lets it into the gallery.
+ */
+export interface OpencodeAbsentInstallActionsProps {
+  state: OpencodeAbsentInstallState;
+  /** Download and install the pinned release. */
+  onInstall: () => void;
+  /** Abort a download in progress — the only path that cancels one. */
+  onCancel: () => void;
+  /** Detect an opencode already on this device and adopt it. */
+  onAdoptExisting: () => void;
+  /** Open the Configure dialog, where a path can be typed by hand. */
+  onConfigure: () => void;
+}
+
+/**
+ * The actions shown in the opencode settings row while no binary is installed:
+ * download, adopt an existing one, live progress with cancel, and the failure
+ * state. Purely presentational — the container owns the install lifecycle.
+ */
+export const OpencodeAbsentInstallView: React.FC<OpencodeAbsentInstallActionsProps> = ({
+  state,
+  onInstall,
+  onCancel,
+  onAdoptExisting,
+  onConfigure,
+}) => {
+  if (state.kind === "installing") {
+    return (
+      <div className="tw-flex tw-w-56 tw-shrink-0 tw-items-center tw-gap-2">
+        <div className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-1">
+          <span className="tw-truncate tw-text-xs tw-text-muted" title={state.label}>
+            {state.label}
+          </span>
+          <Progress value={state.percent} />
+        </div>
+        <Button variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="tw-flex tw-shrink-0 tw-flex-col tw-items-end tw-gap-1">
+      <div className="tw-flex tw-items-center tw-gap-2">
+        {/* Both actions write the same backend binary path, so they must not
+            race — a detect landing mid-download would flip the row to ready
+            under a download the user asked for. The download leads: it is the
+            one action a first-run user is meant to take. */}
+        <Button
+          variant="default"
+          size="default"
+          onClick={onInstall}
+          disabled={state.kind === "detecting"}
+        >
+          <Download className="tw-size-4" />
+          {state.kind === "error" ? "Try again" : "Download opencode"}
+        </Button>
+        {state.kind === "error" ? (
+          // Detection only walks the well-known install locations and PATH, so a
+          // binary somewhere else can only be reached by typing its path — and
+          // the row hides its usual Configure entry point while absent. Without
+          // this the failure message would name a button that isn't on screen.
+          <Button variant="ghost" size="default" onClick={onConfigure}>
+            Configure
+          </Button>
+        ) : (
+          <Button
+            variant="ghost"
+            size="default"
+            onClick={onAdoptExisting}
+            disabled={state.kind === "detecting"}
+          >
+            {state.kind === "detecting" ? "Looking…" : "I already have it"}
+          </Button>
+        )}
+      </div>
+      {state.kind === "error" && (
+        <span className="tw-max-w-xs tw-text-right tw-text-xs tw-text-error">{state.message}</span>
+      )}
+    </div>
+  );
+};

--- a/src/agentMode/backends/opencode/ui/OpencodeAbsentInstallView.tsx
+++ b/src/agentMode/backends/opencode/ui/OpencodeAbsentInstallView.tsx
@@ -74,7 +74,7 @@ export const OpencodeAbsentInstallView: React.FC<OpencodeAbsentInstallActionsPro
           // Detection only walks the well-known install locations and PATH, so a
           // binary somewhere else can only be reached by typing its path — and
           // the row hides its usual Configure entry point while absent. Without
-          // this the failure message would name a button that isn't on screen.
+          // this a failed detect would leave that binary with no way in at all.
           <Button variant="ghost" size="default" onClick={onConfigure}>
             Configure
           </Button>

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -206,6 +206,16 @@ export interface BackendDescriptor {
   openInstallUI(plugin: CopilotPlugin): void;
 
   /**
+   * Optional: actions rendered inline in the settings row while this backend is
+   * absent, in place of the generic Configure button. Backends the plugin can
+   * install itself own their whole first-run path (download, progress, cancel,
+   * adopting an existing binary), so the user never has to open a dialog to get
+   * started. Backends that only document an external install omit it and keep
+   * the Configure button.
+   */
+  AbsentInstallActions?: React.ComponentType<{ plugin: CopilotPlugin }>;
+
+  /**
    * Optional: upgrade the installed binary in place (managed reinstall, or the
    * CLI's own `upgrade`). Resolves when done. Changing the persisted version
    * restarts the backend via the `subscribeInstallState` subscription, so the

--- a/src/agentMode/ui/ModelEnableList.stories.tsx
+++ b/src/agentMode/ui/ModelEnableList.stories.tsx
@@ -1,0 +1,83 @@
+import { ModelEnableList, type ModelEnableGroup } from "@/agentMode/ui/ModelEnableList";
+import type { ModelCapability } from "@/constants";
+import type { Meta, StoryObj } from "@/lib/story";
+import * as React from "react";
+
+type ModelEnableListProps = React.ComponentProps<typeof ModelEnableList>;
+
+/** Enough rows to exceed the `max-h-80` cap, so the internal scroll is the thing on screen. */
+const LONG_GROUP: ModelEnableGroup = {
+  key: "byok",
+  label: "OpenAI",
+  badge: "BYOK",
+  rows: Array.from({ length: 18 }, (_, i) => ({
+    id: `openai/model-${i}`,
+    label: `gpt-nova-${i}`,
+    enabled: i < 3,
+  })),
+};
+
+const PLUS_GROUP: ModelEnableGroup = {
+  key: "plus",
+  label: "Copilot Plus",
+  badge: "privacy",
+  tooltip: "Copilot license required",
+  highlight: true,
+  rows: [
+    {
+      id: "plus/flash",
+      label: "copilot-plus-flash",
+      enabled: true,
+      // Cast rather than importing the enum: the gallery fence bars runtime
+      // values from `@/constants`, and a story only needs the wire string.
+      capabilities: ["vision" as ModelCapability],
+    },
+    { id: "plus/deepseek", label: "copilot-plus-deepseek-v4-pro", enabled: true, capabilities: [] },
+    { id: "plus/glm", label: "copilot-plus-glm-5.2", enabled: false, capabilities: [] },
+  ],
+};
+
+/**
+ * `isFree` belongs here rather than on a Plus row: it marks a zero-cost model
+ * routed through a third party, which is what earns the privacy warning. A paid
+ * Plus model carrying that flag is a combination production never produces.
+ */
+const FREE_GROUP: ModelEnableGroup = {
+  key: "agent",
+  label: "OpenCode",
+  badge: "Agent Provided",
+  rows: [{ id: "opencode/grok-code", label: "grok-code-fast-1", enabled: true, isFree: true }],
+};
+
+/** Search is controlled, so a story has to own the query for the field to behave. */
+const Controlled: React.FC<{ groups: ModelEnableGroup[] }> = ({ groups }) => {
+  const [query, setQuery] = React.useState("");
+  return (
+    <ModelEnableList
+      groups={groups}
+      query={query}
+      onQueryChange={setQuery}
+      onToggle={() => undefined}
+    />
+  );
+};
+
+const meta = {
+  title: "Agent Mode/Model Enable List",
+  component: ModelEnableList,
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<ModelEnableListProps>;
+export default meta;
+
+/** The state the height cap exists for: a catalog longer than the card. */
+export const OverflowingCatalog: StoryObj<ModelEnableListProps> = {
+  render: () => <Controlled groups={[PLUS_GROUP, FREE_GROUP, LONG_GROUP]} />,
+};
+
+export const ShortCatalog: StoryObj<ModelEnableListProps> = {
+  render: () => <Controlled groups={[PLUS_GROUP, FREE_GROUP]} />,
+};
+
+export const Empty: StoryObj<ModelEnableListProps> = {
+  render: () => <Controlled groups={[]} />,
+};

--- a/src/agentMode/ui/ModelEnableList.tsx
+++ b/src/agentMode/ui/ModelEnableList.tsx
@@ -151,7 +151,10 @@ export const ModelEnableList: React.FC<ModelEnableListProps> = ({
     <div className="tw-flex tw-flex-col tw-gap-2">
       <SearchBar value={query} onChange={onQueryChange} placeholder={searchPlaceholder} />
 
-      <div className="tw-max-h-[36rem] tw-overflow-y-auto tw-pr-1">
+      {/* Caps the list at roughly ten rows (a row is ~32px: 20px of text, 8px of
+          padding, 4px of gap) so a long catalog scrolls inside the card instead
+          of pushing everything below it off the settings pane. */}
+      <div className="tw-max-h-80 tw-overflow-y-auto tw-pr-1">
         {!hasRows ? (
           <div className="tw-py-6 tw-text-center tw-text-sm tw-text-muted">
             {emptyState ?? (searching ? `No models match “${query.trim()}”.` : "No models.")}

--- a/src/components/chat-components/useChatModelPicker.ts
+++ b/src/components/chat-components/useChatModelPicker.ts
@@ -30,7 +30,7 @@ const NOOP = () => {};
 const EMPTY_ENTRY: ModelSelectorEntry = {
   name: "__chat_no_models__",
   provider: "",
-  displayName: "No models — enable under Agents → Quick Chat",
+  displayName: "No models — enable in Basic → Agents → Quick Chat",
   enabled: true,
   _disabledReason: "Add a model",
 };

--- a/src/components/ui/obsidian-native-select.tsx
+++ b/src/components/ui/obsidian-native-select.tsx
@@ -26,7 +26,10 @@ export function ObsidianNativeSelect({
         className={cn(
           "tw-w-full tw-appearance-none",
           "tw-flex tw-h-9 tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-dropdown tw-px-3 tw-py-1 tw-pr-8",
-          "tw-text-sm tw-shadow tw-transition-colors",
+          // See the matching note in `setting-item.tsx`: Obsidian's macOS
+          // settings pane right-aligns bare `select` text, which reads as a
+          // stray gap inside our fixed-width control.
+          "tw-text-left tw-text-sm tw-shadow tw-transition-colors",
           "focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-ring",
           "disabled:tw-cursor-not-allowed disabled:tw-opacity-50",
           "hover:tw-bg-interactive-hover hover:tw-text-normal",

--- a/src/components/ui/setting-disclosure.stories.tsx
+++ b/src/components/ui/setting-disclosure.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import type * as React from "react";
+import { SettingDisclosure } from "./setting-disclosure";
+
+type SettingDisclosureProps = React.ComponentProps<typeof SettingDisclosure>;
+
+const meta = {
+  title: "UI/Setting Disclosure",
+  component: SettingDisclosure,
+  args: { open: false },
+  // `settings-tab` because the row's `!` resets exist to beat Obsidian's
+  // settings-pane button styling — under any other host it would look correct
+  // for the wrong reason.
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<SettingDisclosureProps>;
+export default meta;
+
+export const Collapsed: StoryObj<SettingDisclosureProps> = {};
+
+export const Expanded: StoryObj<SettingDisclosureProps> = {
+  args: { open: true },
+};
+
+export const CustomLabel: StoryObj<SettingDisclosureProps> = {
+  args: { label: "Developer options" },
+};

--- a/src/components/ui/setting-disclosure.test.tsx
+++ b/src/components/ui/setting-disclosure.test.tsx
@@ -1,0 +1,55 @@
+import { SettingDisclosure } from "@/components/ui/setting-disclosure";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("setting-disclosure", () => {
+  describe("SettingDisclosure", () => {
+    it("exposes a button named after the label, defaulting to Advanced", () => {
+      const { rerender } = render(<SettingDisclosure open={false} />);
+      expect(screen.getByRole("button", { name: "Advanced" })).not.toBeNull();
+
+      rerender(<SettingDisclosure open={false} label="Debugging" />);
+      expect(screen.getByRole("button", { name: "Debugging" })).not.toBeNull();
+    });
+
+    it("reports the disclosed state through aria-expanded", () => {
+      const { rerender } = render(<SettingDisclosure open={false} />);
+      expect(screen.getByRole("button", { name: "Advanced" }).getAttribute("aria-expanded")).toBe(
+        "false"
+      );
+
+      rerender(<SettingDisclosure open />);
+      expect(screen.getByRole("button", { name: "Advanced" }).getAttribute("aria-expanded")).toBe(
+        "true"
+      );
+    });
+
+    it("forwards click handling to the caller", () => {
+      const onClick = jest.fn();
+      render(<SettingDisclosure open={false} onClick={onClick} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    // The row doubles as a Radix `CollapsibleTrigger asChild` target, which only
+    // works if the component forwards its ref and the injected props.
+    it("drives a Collapsible when used as its trigger", () => {
+      render(
+        <Collapsible>
+          <CollapsibleTrigger asChild>
+            <SettingDisclosure open={false} />
+          </CollapsibleTrigger>
+          <CollapsibleContent>Filename template</CollapsibleContent>
+        </Collapsible>
+      );
+      expect(screen.queryByText("Filename template")).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
+
+      expect(screen.getByText("Filename template")).not.toBeNull();
+    });
+  });
+});

--- a/src/components/ui/setting-disclosure.tsx
+++ b/src/components/ui/setting-disclosure.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+import { ChevronRight } from "lucide-react";
+import React from "react";
+
+interface SettingDisclosureProps extends React.ComponentPropsWithoutRef<"button"> {
+  /** Whether the disclosed content is showing — drives the chevron and `aria-expanded`. */
+  open: boolean;
+  /** Row label; defaults to the only one in use today. */
+  label?: string;
+}
+
+/**
+ * Disclosure row for the tail of a `SettingSection` card — the "Advanced" escape
+ * hatch that keeps a rarely-touched control out of the default view. It reads as
+ * a quiet row of the card, never as a control of its own.
+ *
+ * Kept as a native `<button>` so it can double as a Radix
+ * `CollapsibleTrigger asChild` target. Obsidian styles buttons inside the
+ * settings pane through a descendant selector that outranks plain utility
+ * classes, so the resets here need `!` — without them the row renders as an OS
+ * button box.
+ */
+export const SettingDisclosure = React.forwardRef<HTMLButtonElement, SettingDisclosureProps>(
+  ({ open, label = "Advanced", className, ...props }, ref) => (
+    <button
+      ref={ref}
+      type="button"
+      aria-expanded={open}
+      className={cn(
+        "tw-flex tw-w-full tw-cursor-pointer tw-items-center !tw-justify-start tw-gap-1.5",
+        "!tw-border-none !tw-bg-transparent !tw-px-0 !tw-py-3 !tw-shadow-none",
+        "tw-text-left tw-text-sm tw-font-medium tw-text-muted hover:tw-text-normal",
+        className
+      )}
+      {...props}
+    >
+      <ChevronRight className={cn("tw-size-3.5 tw-transition-transform", open && "tw-rotate-90")} />
+      {label}
+    </button>
+  )
+);
+SettingDisclosure.displayName = "SettingDisclosure";

--- a/src/components/ui/setting-item.tsx
+++ b/src/components/ui/setting-item.tsx
@@ -164,7 +164,12 @@ export function SettingItem(props: SettingItemProps) {
               className={cn(
                 "tw-w-full tw-appearance-none",
                 "tw-flex tw-h-9 tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-dropdown tw-px-3 tw-py-1 tw-pr-8",
-                "tw-text-sm !tw-shadow tw-transition-colors",
+                // `tw-text-left` overrides Obsidian's macOS settings default
+                // (`--dropdown-text-align: end` applied to bare `select`), which
+                // strands the label against the right edge of our fixed-width
+                // control. A plain class wins on specificity — neither rule is
+                // `!important`, and a class outranks an element selector.
+                "tw-text-left tw-text-sm !tw-shadow tw-transition-colors",
                 "focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-ring",
                 "disabled:tw-cursor-not-allowed disabled:tw-opacity-50",
                 "hover:tw-bg-interactive-hover hover:tw-text-normal"

--- a/src/components/ui/setting-tabs.stories.tsx
+++ b/src/components/ui/setting-tabs.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import { Cog, Cpu, Sigma } from "lucide-react";
+import * as React from "react";
+import { TabContent, TabItem, type TabVariant } from "./setting-tabs";
+
+const TABS = [
+  { id: "basic", label: "Basic", icon: <Cog className="tw-size-5" /> },
+  { id: "models", label: "Models", icon: <Cpu className="tw-size-5" /> },
+  { id: "miyo", label: "Miyo", icon: <Sigma className="tw-size-5" /> },
+];
+
+type TabItemProps = React.ComponentProps<typeof TabItem>;
+
+/** A whole strip plus its panel — the unit a reader actually judges the variant by. */
+const Strip: React.FC<{ variant: TabVariant; labels?: string[] }> = ({ variant, labels }) => {
+  const tabs = labels ? labels.map((label, i) => ({ id: `t${i}`, label, icon: null })) : TABS;
+  const [selected, setSelected] = React.useState(tabs[0].id);
+  return (
+    <div className="tw-flex tw-flex-col">
+      <div className="tw-flex tw-flex-wrap tw-gap-1" role="tablist">
+        {tabs.map((tab, index) => (
+          <TabItem
+            key={tab.id}
+            tab={tab}
+            isSelected={selected === tab.id}
+            onClick={() => setSelected(tab.id)}
+            isFirst={index === 0}
+            isLast={index === tabs.length - 1}
+            variant={variant}
+          />
+        ))}
+      </div>
+      <TabContent id={selected} isSelected variant={variant}>
+        <div className="tw-rounded-md tw-bg-primary tw-p-4 tw-text-sm">Panel for {selected}</div>
+      </TabContent>
+    </div>
+  );
+};
+
+const meta = {
+  title: "UI/Setting Tabs",
+  component: TabItem,
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<TabItemProps>;
+export default meta;
+
+/** Pane-edge strip: rounded at the top only, and its panel paints the grey backdrop. */
+export const PageVariant: StoryObj<TabItemProps> = {
+  render: () => <Strip variant="page" />,
+};
+
+/** Nested chips: uniformly rounded, accent outline when selected, no second backdrop. */
+export const InlineVariant: StoryObj<TabItemProps> = {
+  render: () => <Strip variant="inline" />,
+};
+
+/**
+ * The real Agents strip: four tabs whose labels are long enough to wrap once the
+ * canvas is narrow. Narrow the gallery's width toolbar over this one — a story
+ * cannot pin a width, so the fixture supplies the content and the toolbar
+ * supplies the boundary.
+ */
+export const LongLabels: StoryObj<TabItemProps> = {
+  render: () => (
+    <div className="tw-flex tw-flex-col tw-gap-4">
+      <Strip variant="page" labels={["OpenCode", "Claude", "Codex", "Quick Chat"]} />
+      <Strip variant="inline" labels={["OpenCode", "Claude", "Codex", "Quick Chat"]} />
+    </div>
+  ),
+};

--- a/src/components/ui/setting-tabs.tsx
+++ b/src/components/ui/setting-tabs.tsx
@@ -7,15 +7,33 @@ export interface TabItem {
   id: string;
 }
 
+/**
+ * Which level of the settings pane a strip belongs to. The design gives the two
+ * levels different shapes on purpose: `page` tabs sit on the pane's edge, so
+ * they are rounded at the top only and their panel paints the grey content
+ * backdrop; `inline` tabs are chips nested inside a tab's content, uniformly
+ * rounded, and their panel adds no backdrop of its own (the enclosing page
+ * panel already supplies one — a second layer would just flatten the cards).
+ */
+export type TabVariant = "page" | "inline";
+
 interface TabItemProps {
   tab: TabItem;
   isSelected: boolean;
   onClick: () => void;
   isFirst: boolean;
   isLast: boolean;
+  variant?: TabVariant;
 }
 
-export const TabItem: React.FC<TabItemProps> = ({ tab, isSelected, onClick, isFirst, isLast }) => {
+export const TabItem: React.FC<TabItemProps> = ({
+  tab,
+  isSelected,
+  onClick,
+  isFirst,
+  isLast,
+  variant = "page",
+}) => {
   return (
     <div
       role="tab"
@@ -44,7 +62,7 @@ export const TabItem: React.FC<TabItemProps> = ({ tab, isSelected, onClick, isFi
         "tw-whitespace-nowrap",
         "tw-text-sm",
         "tw-border tw-border-solid tw-border-border",
-        "tw-rounded-b-[2px] tw-rounded-t-sm",
+        variant === "page" ? "tw-rounded-b-[2px] tw-rounded-t-sm" : "tw-rounded-md",
         "tw-bg-primary",
         "tw-transition-all tw-duration-300 tw-ease-in-out",
         "hover:tw-border-interactive-accent",
@@ -56,6 +74,10 @@ export const TabItem: React.FC<TabItemProps> = ({ tab, isSelected, onClick, isFi
           "tw-transition-all tw-duration-300 tw-ease-in-out",
           "tw-delay-100",
         ],
+        // Inline chips only. A page tab keeps its neutral border when selected:
+        // it sits against the pane edge, where an accent outline would read as a
+        // second boundary rather than as selection.
+        isSelected && variant === "inline" && "!tw-border-interactive-accent",
         "lg:tw-max-w-32",
         "md:tw-max-w-32"
       )}
@@ -91,9 +113,15 @@ interface TabContentProps {
   id: string;
   children: React.ReactNode;
   isSelected: boolean;
+  variant?: TabVariant;
 }
 
-export const TabContent: React.FC<TabContentProps> = ({ id, children, isSelected }) => {
+export const TabContent: React.FC<TabContentProps> = ({
+  id,
+  children,
+  isSelected,
+  variant = "page",
+}) => {
   if (!isSelected) return null;
 
   return (
@@ -105,7 +133,7 @@ export const TabContent: React.FC<TabContentProps> = ({ id, children, isSelected
         // Grey backdrop so the white section cards visually separate (design:
         // grey content area + white cards). Without it the cards blend into the
         // modal background and only their borders show, reading as boxed rows.
-        "tw-mt-4 tw-rounded-lg tw-bg-secondary tw-p-4",
+        variant === "page" ? "tw-mt-4 tw-rounded-lg tw-bg-secondary tw-p-4" : "tw-mt-3",
         "tw-transition-all tw-duration-200 tw-ease-in-out",
         isSelected ? "tw-translate-y-0 tw-opacity-100" : "tw-translate-y-2 tw-opacity-0"
       )}

--- a/src/modelManagement/chatModel/resolveChatBackendModel.ts
+++ b/src/modelManagement/chatModel/resolveChatBackendModel.ts
@@ -7,7 +7,7 @@
  *   - the passed `configuredModelId` if it's still enabled in `backends.chat`;
  *   - otherwise the first enabled chat model (stale/removed selection);
  *   - otherwise `{ ok: false, reason: "empty" }` — nothing enabled, UI prompts
- *     the user to enable a model under Settings → Agents → Quick Chat.
+ *     the user to enable a model under Settings → Basic → Agents → Quick Chat.
  */
 
 import { CustomModel } from "@/aiParams";

--- a/src/modelManagement/setup/AgentSetupApi.test.ts
+++ b/src/modelManagement/setup/AgentSetupApi.test.ts
@@ -257,6 +257,61 @@ describe("AgentSetupApi.registerAgentProvider", () => {
     expect(h.backends.enabledFor("codex")).toEqual([]);
   });
 
+  it("enables only autoEnrollModelIds while still creating every reported model", async () => {
+    const h = makeHarness();
+    const result = await h.api.registerAgentProvider({
+      agentType: "opencode",
+      providerType: "openai-compatible",
+      displayName: "opencode",
+      apiKey: null,
+      wireModelIds: ["opencode/a", "opencode/b", "opencode/c"],
+      autoEnrollModelIds: ["opencode/a", "opencode/c"],
+    });
+
+    // All three exist, so the curation UI can list — and the user can toggle —
+    // the ones that ship off.
+    expect(result.configuredModelIds).toHaveLength(3);
+
+    const enabledWireIds = h.backends
+      .enabledFor("opencode")
+      .map((id) => h.models.get(id)!.info.id)
+      .sort();
+    expect(enabledWireIds).toEqual(["opencode/a", "opencode/c"]);
+  });
+
+  it("leaves the backend's other picks intact when auto-enrolling a subset", async () => {
+    const h = makeHarness();
+    // A model the user already curated into the opencode backend from another
+    // origin (BYOK / Plus). Enrollment must add to that set, never replace it.
+    await h.backends.enableModel("opencode", "pre-existing-byok-model");
+
+    await h.api.registerAgentProvider({
+      agentType: "opencode",
+      providerType: "openai-compatible",
+      displayName: "opencode",
+      apiKey: null,
+      wireModelIds: ["opencode/a", "opencode/b"],
+      autoEnrollModelIds: ["opencode/a"],
+    });
+
+    expect(h.backends.enabledFor("opencode")).toContain("pre-existing-byok-model");
+  });
+
+  it("enables nothing when autoEnrollModelIds is empty", async () => {
+    const h = makeHarness();
+    const result = await h.api.registerAgentProvider({
+      agentType: "opencode",
+      providerType: "openai-compatible",
+      displayName: "opencode",
+      apiKey: null,
+      wireModelIds: ["opencode/a", "opencode/b"],
+      autoEnrollModelIds: [],
+    });
+
+    expect(result.configuredModelIds).toHaveLength(2);
+    expect(h.backends.enabledFor("opencode")).toEqual([]);
+  });
+
   it("lets the agent-reported name + description win over catalog metadata", async () => {
     const h = makeHarness();
     // Catalog knows "claude-sonnet-4-5" as "Claude Sonnet 4.5"; the agent's

--- a/src/modelManagement/setup/AgentSetupApi.ts
+++ b/src/modelManagement/setup/AgentSetupApi.ts
@@ -3,13 +3,13 @@
  * `Provider` per `(agentType, providerType)` with `origin: "agent"` and
  * snapshots a `ConfiguredModel` per `wireModelId`.
  *
- * Enablement follows one rule: only the agent's *current* model ends up
- * enabled. `registerAgentProvider` (first enrollment) auto-enrolls every model
- * into `backends[agentType]` so the discovery wiring can then narrow the
- * enabled set down to the current model; `syncAgentModels` (later probes) adds
- * newly-reported models *disabled*, so a model the agent introduces later never
- * silently turns itself on. Either way agent-owned models stay exclusive to
- * their agent's picker.
+ * Every reported model becomes a `ConfiguredModel`, so all of them show up in
+ * the curation UI for the user to toggle. Which ones start *enabled* is the
+ * caller's call: `registerAgentProvider` (first enrollment) auto-enrolls the
+ * subset named by `autoEnrollModelIds`, or every model when that is omitted.
+ * `syncAgentModels` (later probes) adds newly-reported models *disabled*, so a
+ * model the agent introduces later never silently turns itself on. Either way
+ * agent-owned models stay exclusive to their agent's picker.
  *
  * `registerAgentProvider` is idempotent on `(agentType, providerType)`:
  * re-running reconciles the model list. `syncAgentModels` is the narrower
@@ -39,6 +39,13 @@ export interface RegisterAgentProviderInput {
   /** Full set of wire ids the agent reports; the existing model set is diffed
    *  against this list. */
   wireModelIds: readonly string[];
+  /**
+   * Wire ids to enable on first enrollment. Ids outside this set are still
+   * created (so the curation UI lists them) but ship off. Omit to enable every
+   * reported model — the right default for agents whose catalog is small
+   * enough to show in full.
+   */
+  autoEnrollModelIds?: readonly string[];
   /** Agent-reported display names, keyed by wire id. For agent-origin
    *  providers these win over catalog metadata (the agent owns the name). */
   fallbackDisplayNames?: Record<string, string>;
@@ -64,6 +71,13 @@ export interface AgentSyncResult {
   added: string[];
   removed: string[];
 }
+
+/**
+ * Auto-enroll set meaning "enable nothing" — what later syncs pass so a
+ * newly-reported model stays off until the user enables it. A frozen module
+ * constant rather than a fresh `[]`, which would be a new identity per call.
+ */
+const ENROLL_NONE: readonly string[] = Object.freeze([]);
 
 export class AgentSetupApi {
   readonly #providers: ProviderRegistry;
@@ -135,10 +149,8 @@ export class AgentSetupApi {
       input.fallbackDisplayNames,
       input.fallbackDescriptions
     );
-    // First enrollment enables every model; the discovery wiring narrows the
-    // enabled set to the current model afterward.
     const { added, removed } = await this.#reconcileModels(input.agentType, providerId, infos, {
-      enableNewModels: true,
+      autoEnrollModelIds: input.autoEnrollModelIds,
     });
 
     // Return the configured-model ids in wire-id order, joining freshly-added
@@ -173,7 +185,7 @@ export class AgentSetupApi {
    *
    * Newly-reported models are added *disabled*: a model the agent introduces on
    * a later probe never turns itself on, so the enabled set keeps reflecting the
-   * user's curation (only the current model was seeded at first enrollment).
+   * user's curation (only the first-enrollment subset was seeded).
    */
   async syncAgentModels(input: SyncAgentModelsInput): Promise<AgentSyncResult> {
     const providers = this.#listAgentProviders(input.agentType);
@@ -194,7 +206,7 @@ export class AgentSetupApi {
         input.agentType,
         provider.providerId,
         infos,
-        { enableNewModels: false }
+        { autoEnrollModelIds: ENROLL_NONE }
       );
       return {
         added: added.map((a) => a.configuredModelId),
@@ -228,7 +240,7 @@ export class AgentSetupApi {
         input.agentType,
         provider.providerId,
         infos,
-        { enableNewModels: false }
+        { autoEnrollModelIds: ENROLL_NONE }
       );
       for (const a of added) addedAll.push(a.configuredModelId);
       for (const r of removed) removedAll.push(r.configuredModelId);
@@ -390,16 +402,22 @@ export class AgentSetupApi {
    * write, so re-syncing an unchanged list is a no-op that never resets user
    * curation.
    *
-   * `enableNewModels` controls whether each freshly-added model is enrolled into
-   * `backends[agentType]`: `true` on first enrollment (the discovery wiring
-   * narrows to the current model afterward), `false` on later syncs so a model
-   * the agent introduces later stays disabled until the user enables it.
+   * `autoEnrollModelIds` selects which freshly-added models are enrolled into
+   * `backends[agentType]`: `undefined` enrolls every one of them (first
+   * enrollment of an agent whose whole catalog should start on), a subset
+   * enrolls just those, and `ENROLL_NONE` enrolls none — what later syncs pass,
+   * so a model the agent introduces later stays disabled until the user enables
+   * it. Models outside the set are still created, so the curation UI lists them.
+   *
+   * Enrollment is per-model (`enableModel`), never a bulk replace of the
+   * backend's enabled set: for opencode that set also holds the user's BYOK and
+   * Plus picks, which a wholesale overwrite would silently drop.
    */
   async #reconcileModels(
     agentType: AgentType,
     providerId: string,
     infos: readonly ModelInfo[],
-    opts: { enableNewModels: boolean }
+    opts: { autoEnrollModelIds?: readonly string[] }
   ): Promise<{
     added: Array<{ wireId: string; configuredModelId: string }>;
     removed: Array<{ wireId: string; configuredModelId: string }>;
@@ -407,6 +425,7 @@ export class AgentSetupApi {
     const existing = this.#models.listByProvider(providerId);
     const existingByWireId = new Map(existing.map((m) => [m.info.id, m]));
     const desiredWireIds = new Set(infos.map((info) => info.id));
+    const autoEnrollFilter = opts.autoEnrollModelIds ? new Set(opts.autoEnrollModelIds) : null;
 
     const added: Array<{ wireId: string; configuredModelId: string }> = [];
     for (const info of infos) {
@@ -414,9 +433,9 @@ export class AgentSetupApi {
       if (!current) {
         const configuredModelId = await this.#models.add({ providerId, info });
         // Enroll into this agent's backend only — agent models never leak into
-        // chat or another agent's picker. Skipped on sync so later-discovered
-        // models stay disabled until the user enables them.
-        if (opts.enableNewModels) {
+        // chat or another agent's picker. A wire id outside `autoEnrollFilter`
+        // (when set) ships available-but-off.
+        if (!autoEnrollFilter || autoEnrollFilter.has(info.id)) {
           await this.#backends.enableModel(agentType, configuredModelId);
         }
         added.push({ wireId: info.id, configuredModelId });

--- a/src/modelManagement/setup/copilotPlusSync.test.ts
+++ b/src/modelManagement/setup/copilotPlusSync.test.ts
@@ -25,7 +25,7 @@ function makeApi() {
 }
 
 describe("copilotPlusSync", () => {
-  it("defines the curated lineup and default-enabled model", () => {
+  it("defines the curated lineup and default-enabled models", () => {
     expect(COPILOT_PLUS_MODELS.map((model) => model.id)).toEqual([
       "copilot-plus-flash",
       "kimi-k2.6",
@@ -35,7 +35,11 @@ describe("copilotPlusSync", () => {
       "mimo-v2.5",
       "minimax-m2.7",
     ]);
-    expect(COPILOT_PLUS_DEFAULT_ENABLED_MODELS).toEqual(["copilot-plus-flash"]);
+    expect(COPILOT_PLUS_DEFAULT_ENABLED_MODELS).toEqual([
+      "copilot-plus-flash",
+      "deepseek-v4-pro",
+      "glm-5.2",
+    ]);
   });
 
   describe("syncCopilotPlusProvider()", () => {

--- a/src/modelManagement/setup/copilotPlusSync.ts
+++ b/src/modelManagement/setup/copilotPlusSync.ts
@@ -20,9 +20,9 @@ import type { ModelInfo } from "@/modelManagement/types/catalog";
  * `models.brevilabs.com/v1/models`. Wire ids must match what the relay accepts;
  * opencode routes them as `copilot-plus/<id>` (see `mapProviderToOpencodeId`).
  *
- * Only `copilot-plus-flash` is enabled by default (see
- * `COPILOT_PLUS_DEFAULT_ENABLED_MODELS`); the rest ship available-but-off in the
- * chat + opencode pickers for the user to toggle on.
+ * `COPILOT_PLUS_DEFAULT_ENABLED_MODELS` names the few enabled by default; the
+ * rest ship available-but-off in the chat + opencode pickers for the user to
+ * toggle on.
  *
  * `reasoning: true` marks the models the relay accepts an effort level for (it
  * matches the models service's `supports_reasoning`). The chat + agent pickers
@@ -94,9 +94,15 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
  * registered. Everything else in `COPILOT_PLUS_MODELS` is added but left
  * unenrolled, so users opt into the extra models themselves. Passed to
  * `registerPlusProvider` as `autoEnrollModelIds`.
+ *
+ * Three models are enabled by default to give users immediate access to
+ * representative capabilities: fastest responses (Flash), top-tier reasoning
+ * (DeepSeek V4 Pro), and long-horizon frontier open model (GLM-5.2).
  */
 export const COPILOT_PLUS_DEFAULT_ENABLED_MODELS: readonly string[] = Object.freeze([
   ChatModels.COPILOT_PLUS_FLASH,
+  ChatModels.COPILOT_PLUS_DEEPSEEK_V4_PRO,
+  ChatModels.COPILOT_PLUS_GLM_5_2,
 ]);
 
 /**

--- a/src/settings/v2/SettingsMainV2.test.tsx
+++ b/src/settings/v2/SettingsMainV2.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * Locks the tab strip's shape. `Record<TabId, …>` only forces the four
+ * registration sites to agree with each other — it says nothing about which tabs
+ * exist or what order they appear in, so folding Agents into Basic or reordering
+ * the strip can be undone without a single type error.
+ */
+
+import type CopilotPlugin from "@/main";
+import SettingsMainV2 from "@/settings/v2/SettingsMainV2";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+// Every tab body is stubbed empty. The real panels reach for the keychain, Node,
+// and the network, none of which has any bearing on the strip above them.
+jest.mock("@/settings/v2/components/BasicSettings", () => ({ BasicSettings: () => null }));
+jest.mock("@/settings/v2/components/MiyoSettings", () => ({ MiyoSettings: () => null }));
+jest.mock("@/settings/v2/components/SelfHostSettings", () => ({ SelfHostSettings: () => null }));
+jest.mock("@/settings/v2/components/CommandSettings", () => ({ CommandSettings: () => null }));
+jest.mock("@/settings/v2/components/AdvancedSettings", () => ({ AdvancedSettings: () => null }));
+jest.mock("@/settings/v2/components/DesktopOnlySettingsPanel", () => ({
+  DesktopOnlySettingsPanel: () => null,
+}));
+jest.mock("@/agentMode", () => ({ SkillsSettings: () => null }));
+jest.mock("@/modelManagement", () => ({
+  ByokPanel: () => null,
+  ModelManagementProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock("@/settings/model", () => ({ resetSettings: jest.fn() }));
+jest.mock("@/hooks/useLatestVersion", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; the name must match the export
+  useLatestVersion: () => ({ latestVersion: null, hasUpdate: false }),
+}));
+
+const plugin = { app: {}, manifest: { version: "1.2.3" } } as unknown as CopilotPlugin;
+
+describe("SettingsMainV2", () => {
+  describe("SettingsMainV2()", () => {
+    it("lists the tabs in the agreed order", () => {
+      render(<SettingsMainV2 plugin={plugin} />);
+
+      expect(screen.getAllByRole("tab").map((tab) => tab.textContent)).toEqual([
+        "Basic",
+        "BYOK",
+        "Miyo",
+        "Skills",
+        "Command",
+        "Self-Host",
+        "Advanced",
+      ]);
+    });
+
+    it("offers no Agents tab, because agent settings live on the Basic tab", () => {
+      render(<SettingsMainV2 plugin={plugin} />);
+
+      expect(screen.queryByRole("tab", { name: /agents/i })).toBeNull();
+    });
+  });
+});

--- a/src/settings/v2/SettingsMainV2.tsx
+++ b/src/settings/v2/SettingsMainV2.tsx
@@ -8,11 +8,12 @@ import CopilotPlugin from "@/main";
 import { ByokPanel, ModelManagementProvider } from "@/modelManagement";
 import { resetSettings } from "@/settings/model";
 import { CommandSettings } from "@/settings/v2/components/CommandSettings";
-import { Bot, Cog, Command, Cpu, ShieldCheck, Sigma, Sparkle, Wrench } from "lucide-react";
+import { Cog, Command, Cpu, ShieldCheck, Sigma, Sparkle, Wrench } from "lucide-react";
 import React from "react";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { AdvancedSettings } from "./components/AdvancedSettings";
 import { BasicSettings } from "./components/BasicSettings";
+import { DesktopOnlySettingsPanel } from "./components/DesktopOnlySettingsPanel";
 import { MiyoSettings } from "./components/MiyoSettings";
 import { SelfHostSettings } from "./components/SelfHostSettings";
 
@@ -32,42 +33,20 @@ import { SelfHostSettings } from "./components/SelfHostSettings";
 // The relabeled "Keyword (built-in) vs Miyo (semantic search)" engine toggle
 // and honest embedding-caveat copy land in a follow-up PR, not here. If a review
 // flags the missing QA/search UI again, point them at this note.
-const TAB_IDS = [
-  "basic",
-  "byok",
-  "agent",
-  "miyo",
-  "selfhost",
-  "command",
-  "skills",
-  "advanced",
-] as const;
+const TAB_IDS = ["basic", "byok", "miyo", "skills", "command", "selfhost", "advanced"] as const;
 type TabId = (typeof TAB_IDS)[number];
 
-const LazyAgentSettings = React.lazy(() =>
-  import("./components/AgentSettings").then((module) => ({ default: module.AgentSettings }))
-);
 const LazySkillsSettings = React.lazy(() =>
   import("@/agentMode").then((module) => ({ default: module.SkillsSettings }))
 );
 
-const DesktopOnlySettingsPanel: React.FC = () => (
-  <section className="tw-rounded-md tw-border tw-border-solid tw-border-border tw-p-4 tw-text-sm tw-text-muted">
-    Agent settings are available on desktop.
-  </section>
-);
-
-const AgentSettingsPanel: React.FC = () => {
-  if (!isDesktopRuntime()) return <DesktopOnlySettingsPanel />;
-  return (
-    <React.Suspense fallback={null}>
-      <LazyAgentSettings />
-    </React.Suspense>
-  );
-};
-
 const SkillsSettingsPanel: React.FC = () => {
-  if (!isDesktopRuntime()) return <DesktopOnlySettingsPanel />;
+  // Gate before the dynamic import: on mobile the `@/agentMode` barrel pulls in
+  // Node-only modules that throw while being evaluated, so the desktop check
+  // has to happen before the import is ever requested.
+  if (!isDesktopRuntime()) {
+    return <DesktopOnlySettingsPanel message="Skills are available on desktop." />;
+  }
   return (
     <React.Suspense fallback={null}>
       <LazySkillsSettings />
@@ -79,7 +58,6 @@ const SkillsSettingsPanel: React.FC = () => {
 const icons: Record<TabId, JSX.Element> = {
   basic: <Cog className="tw-size-5" />,
   byok: <Cpu className="tw-size-5" />,
-  agent: <Bot className="tw-size-5" />,
   miyo: <Sigma className="tw-size-5" />,
   selfhost: <ShieldCheck className="tw-size-5" />,
   command: <Command className="tw-size-5" />,
@@ -91,7 +69,6 @@ const icons: Record<TabId, JSX.Element> = {
 const components: Record<TabId, React.FC> = {
   basic: () => <BasicSettings />,
   byok: () => <ByokPanel />,
-  agent: AgentSettingsPanel,
   miyo: () => <MiyoSettings />,
   selfhost: () => <SelfHostSettings />,
   command: () => <CommandSettings />,
@@ -99,12 +76,11 @@ const components: Record<TabId, React.FC> = {
   advanced: () => <AdvancedSettings />,
 };
 
-// Tab labels — most tabs derive from the id, but "agent" capitalizes to a
-// human-friendly label.
+// Tab labels — most tabs derive from the id, but a few need a display form the
+// id can't produce ("byok" → "BYOK", "selfhost" → "Self-Host").
 const TAB_LABELS: Record<TabId, string> = {
   basic: "Basic",
   byok: "BYOK",
-  agent: "Agents",
   miyo: "Miyo",
   selfhost: "Self-Host",
   command: "Command",
@@ -174,7 +150,11 @@ const SettingsMainV2: React.FC<SettingsMainV2Props> = ({ plugin }) => {
     <PluginProvider plugin={plugin}>
       <ModelManagementProvider api={plugin.modelManagement}>
         <TabProvider>
-          <div>
+          {/* Obsidian 1.13 made the settings window resizable, and the panel has
+              no width of its own — without a cap the rows stretch to whatever
+              the user dragged the window to and every control drifts far from
+              its label. */}
+          <div className="tw-mx-auto tw-max-w-[860px]">
             <div className="tw-mb-4 tw-flex tw-flex-col tw-gap-2">
               {/* Reason: Obsidian's settings modal CSS hides plugin-rendered <h1>
                 elements (display: none) because Obsidian reserves the top-level

--- a/src/settings/v2/components/AgentSettings.test.tsx
+++ b/src/settings/v2/components/AgentSettings.test.tsx
@@ -9,8 +9,25 @@ jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError:
 // branch and the first thing a new user touches), so the binary manager behind
 // it is the only thing stubbed.
 const install = jest.fn();
+// The inline row subscribes to the manager's runtime store, so the stub has to
+// expose it with stable identities — an inline arrow per call would make
+// `useSyncExternalStore` resubscribe on every commit.
+const opencodeRuntimeListeners = new Set<() => void>();
+// One frozen snapshot, not a fresh object per call: `useSyncExternalStore`
+// compares by identity, so returning a new literal each time re-renders forever.
+const IDLE_RUNTIME = Object.freeze({ kind: "idle" as const });
+const opencodeManagerStub = {
+  install,
+  adoptExistingBinary: jest.fn().mockResolvedValue(null),
+  cancelCurrentOperation: jest.fn(),
+  subscribeRuntimeState: (onChange: () => void) => {
+    opencodeRuntimeListeners.add(onChange);
+    return () => opencodeRuntimeListeners.delete(onChange);
+  },
+  getRuntimeState: () => IDLE_RUNTIME,
+};
 jest.mock("@/agentMode/backends/opencode/descriptor", () => ({
-  getOpencodeBinaryManager: () => ({ install }),
+  getOpencodeBinaryManager: () => opencodeManagerStub,
   detectOpencodeCliPath: jest.fn(),
   OpencodeBackendDescriptor: { openInstallUI: jest.fn() },
 }));

--- a/src/settings/v2/components/AgentSettings.test.tsx
+++ b/src/settings/v2/components/AgentSettings.test.tsx
@@ -1,10 +1,19 @@
+import { OpencodeAbsentInstallActions } from "@/agentMode/backends/opencode/OpencodeInlineInstall";
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import React from "react";
 import { AgentSettings } from "./AgentSettings";
 
 jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
 
-jest.mock("obsidian", () => ({ Platform: { isMobile: false } }));
+// The inline install row is rendered for real (it is the panel's absent-state
+// branch and the first thing a new user touches), so the binary manager behind
+// it is the only thing stubbed.
+const install = jest.fn();
+jest.mock("@/agentMode/backends/opencode/descriptor", () => ({
+  getOpencodeBinaryManager: () => ({ install }),
+  detectOpencodeCliPath: jest.fn(),
+  OpencodeBackendDescriptor: { openInstallUI: jest.fn() },
+}));
 
 let mockSettings: {
   agentMode: { activeBackend: string; backends: Record<string, unknown> };
@@ -32,6 +41,22 @@ const installStates: Record<string, { kind: string; [key: string]: unknown }> = 
   codex: { kind: "ready", source: "custom" },
 };
 
+/** Binary path each backend reports as resolved; absent means "not installed". */
+let resolvedPaths: Record<string, string | null> = {};
+
+/** Outside any home directory, so the display form is the path verbatim. */
+const MANAGED_BINARY_PATH = "/opt/copilot/opencode/bin/opencode";
+
+/**
+ * Stands in for the settings subscription the real descriptors use, so a test can
+ * move a backend's install state the way a finished install does and see the
+ * panel react instead of re-rendering it by hand.
+ */
+const installStateListeners = new Set<() => void>();
+function publishInstallState() {
+  for (const listener of installStateListeners) listener();
+}
+
 function makeDescriptor(id: string, displayName: string, selfHostable = false) {
   return {
     id,
@@ -39,9 +64,12 @@ function makeDescriptor(id: string, displayName: string, selfHostable = false) {
     selfHostable,
     Icon,
     getInstallState: () => installStates[id],
-    getResolvedBinaryPath: () => null,
+    getResolvedBinaryPath: () => resolvedPaths[id] ?? null,
     openInstallUI: jest.fn(),
     SettingsPanel: () => <div data-testid={`panel-${id}`}>settings panel</div>,
+    // Only a backend the plugin can install itself ships inline actions; the
+    // panel's absent-state branch keys off that.
+    ...(id === "opencode" ? { AbsentInstallActions: OpencodeAbsentInstallActions } : {}),
   };
 }
 
@@ -60,10 +88,18 @@ jest.mock("@/agentMode", () => ({
     descriptor: { selfHostable?: boolean },
     settings: { enableSelfHostMode?: boolean }
   ) => Boolean(settings.enableSelfHostMode) && !descriptor.selfHostable,
-  InstallBadge: () => <span data-testid="install-badge" />,
-  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook export
-  useBackendInstallState: (descriptor: { getInstallState: () => unknown }) =>
-    descriptor.getInstallState(),
+  // The real badge, so "Ready" is the word the user actually sees.
+  InstallBadge: jest.requireActual<typeof import("@/agentMode/backends/shared/installStatus")>(
+    "@/agentMode/backends/shared/installStatus"
+  ).InstallBadge,
+  useBackendInstallState: (descriptor: { getInstallState: () => unknown }) => {
+    const subscribe = React.useCallback((listener: () => void) => {
+      installStateListeners.add(listener);
+      return () => installStateListeners.delete(listener);
+    }, []);
+    const read = () => descriptor.getInstallState();
+    return React.useSyncExternalStore(subscribe, read, read);
+  },
   AgentDefaultModelSetting: ({ descriptor }: { descriptor: { id: string } }) => (
     <div data-testid={`default-model-${descriptor.id}`}>default model</div>
   ),
@@ -92,6 +128,8 @@ jest.mock("./ConfiguredModelEnableList", () => ({
 
 describe("AgentSettings", () => {
   beforeEach(() => {
+    jest.clearAllMocks();
+    install.mockResolvedValue({ version: "1.2.3", path: MANAGED_BINARY_PATH });
     mockSettings = {
       agentMode: { activeBackend: "opencode", backends: {} },
       enableSelfHostMode: false,
@@ -101,6 +139,7 @@ describe("AgentSettings", () => {
     installStates.codex = { kind: "ready", source: "custom" };
     mockGetCachedModelCatalog.mockReset().mockReturnValue({ availableModels: [] });
     mockPreloadModels.mockReset().mockResolvedValue(undefined);
+    resolvedPaths = {};
   });
 
   it("skips model preload when the shared catalog is already available", async () => {
@@ -116,6 +155,12 @@ describe("AgentSettings", () => {
     render(<AgentSettings />);
 
     await waitFor(() => expect(mockPreloadModels).toHaveBeenCalledWith("opencode"));
+  });
+
+  it("labels the section Agents and marks it alpha", () => {
+    render(<AgentSettings />);
+    expect(screen.getByText("Agents")).not.toBeNull();
+    expect(screen.getByText("alpha")).not.toBeNull();
   });
 
   it("renders the four sub-tabs in order: OpenCode, Claude, Codex, Quick Chat", () => {
@@ -185,5 +230,53 @@ describe("AgentSettings", () => {
     // Claude runs in the cloud — the banner appears while Self-Host Mode is on.
     fireEvent.click(screen.getByRole("tab", { name: "Claude" }));
     expect(screen.getByText("Cloud service.")).toBeTruthy();
+  });
+
+  it("replaces Configure with the backend's inline install actions while it is absent", () => {
+    installStates.opencode = { kind: "absent" };
+    render(<AgentSettings />);
+    expect(screen.getByRole("button", { name: "Download opencode" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Configure" })).toBeNull();
+    expect(screen.getByText("Recommended")).not.toBeNull();
+    expect(screen.getByText(/add providers on the BYOK tab/)).not.toBeNull();
+  });
+
+  it("keeps the Configure button for an absent backend that ships no inline actions", () => {
+    installStates.claude = { kind: "absent" };
+    render(<AgentSettings />);
+    fireEvent.click(screen.getByRole("tab", { name: "Claude" }));
+    expect(screen.getByRole("button", { name: "Configure" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
+    // The BYOK hint would be wrong advice for a backend with its own account.
+    expect(screen.queryByText("Recommended")).toBeNull();
+    expect(screen.queryByText(/add providers on the BYOK tab/)).toBeNull();
+  });
+
+  it("drops the inline install actions once the backend reports ready", () => {
+    render(<AgentSettings />);
+    expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Configure" })).not.toBeNull();
+  });
+
+  it("turns the absent row into the ready row when a first inline install lands", async () => {
+    installStates.opencode = { kind: "absent" };
+    install.mockImplementation(async () => {
+      // What the manager does on success: persist the binary it just installed,
+      // which is what the panel computes its install state from.
+      installStates.opencode = { kind: "ready", source: "managed" };
+      resolvedPaths.opencode = MANAGED_BINARY_PATH;
+      publishInstallState();
+      return { version: "1.2.3", path: MANAGED_BINARY_PATH };
+    });
+    render(<AgentSettings />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Download opencode" }));
+
+    // The whole point of the inline row: the user never leaves the Basic tab and
+    // never opens the Configure dialog to get from "not installed" to usable.
+    expect(await screen.findByText("Ready")).not.toBeNull();
+    expect(screen.getByText(MANAGED_BINARY_PATH)).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Configure" })).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Download opencode" })).toBeNull();
   });
 });

--- a/src/settings/v2/components/AgentSettings.test.tsx
+++ b/src/settings/v2/components/AgentSettings.test.tsx
@@ -18,7 +18,7 @@ const opencodeRuntimeListeners = new Set<() => void>();
 const IDLE_RUNTIME = Object.freeze({ kind: "idle" as const });
 const opencodeManagerStub = {
   install,
-  adoptExistingBinary: jest.fn().mockResolvedValue(null),
+  adoptExistingBinary: jest.fn().mockResolvedValue("/usr/local/bin/opencode"),
   cancelCurrentOperation: jest.fn(),
   subscribeRuntimeState: (onChange: () => void) => {
     opencodeRuntimeListeners.add(onChange);

--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -7,6 +7,7 @@ import {
   type BackendDescriptor,
 } from "@/agentMode";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { SettingItem } from "@/components/ui/setting-item";
 import { SettingSection } from "@/components/ui/setting-section";
 import { TabContent, TabItem, type TabItem as TabItemType } from "@/components/ui/setting-tabs";
@@ -17,7 +18,6 @@ import { logError } from "@/logger";
 import { setSettings, updateSetting, useSettingsValue } from "@/settings/model";
 import { formatBinaryPathForDisplay } from "@/utils/binaryPath";
 import { AlertTriangle, MessageCircle } from "lucide-react";
-import { Platform } from "obsidian";
 import React from "react";
 import { ChatModelEnableList } from "./ChatModelEnableList";
 import { ConfiguredModelEnableList } from "./ConfiguredModelEnableList";
@@ -37,10 +37,26 @@ function getScrollableParent(el: HTMLElement): HTMLElement | null {
 }
 
 /**
- * Top-level "Agents" settings tab. Owns the global default-backend picker and
- * a sub-tab strip with one panel per backend plus a Quick Chat panel. Each
- * backend panel curates that backend's default model, enabled models, and
- * binary/auth config.
+ * Section label for the Agents block. The `alpha` badge is deliberately quiet —
+ * it qualifies the heading rather than competing with it.
+ */
+const AGENTS_SECTION_LABEL = (
+  <span className="tw-inline-flex tw-items-center tw-gap-1.5">
+    Agents
+    <Badge variant="outline" className="tw-px-1.5 tw-py-0 tw-font-normal">
+      alpha
+    </Badge>
+  </span>
+);
+
+/**
+ * The "Agents" section of the Basic settings tab. Owns the global
+ * default-backend picker and a sub-tab strip with one panel per backend plus a
+ * Quick Chat panel. Each backend panel curates that backend's default model,
+ * enabled models, and binary/auth config.
+ *
+ * Desktop-only: the caller must gate on `isDesktopRuntime()` before rendering
+ * this, because the `@/agentMode` barrel it imports pulls in Node-only modules.
  */
 export const AgentSettings: React.FC = () => {
   const settings = useSettingsValue();
@@ -69,17 +85,6 @@ export const AgentSettings: React.FC = () => {
     setSelectedTab(id);
   }, []);
 
-  if (Platform.isMobile) {
-    return (
-      <section>
-        <div className="tw-mb-3 tw-text-xl tw-font-bold">Agents</div>
-        <div className="tw-text-muted">
-          Agent Mode is desktop only. Open the desktop app to configure agents.
-        </div>
-      </section>
-    );
-  }
-
   // Every registered backend shows here — Self-Host Mode marks cloud agents
   // (warning banner in their panel) rather than hiding them. Cloud agents sort
   // last because `backendDisplayOrder()` lists the self-hostable opencode first.
@@ -106,49 +111,52 @@ export const AgentSettings: React.FC = () => {
     : orderedDescriptors[0].id;
 
   return (
-    <section>
-      <div className="tw-mb-3 tw-text-xl tw-font-bold">Agents (alpha)</div>
-      <div className="tw-space-y-4">
-        <SettingSection>
-          <SettingItem
-            type="select"
-            title="Default backend"
-            description="Used when you click + to start a new session and for auto-spawn on mount. Selecting a model from the model picker also updates this."
-            value={activeBackendValue}
-            onChange={(value) =>
-              setSettings((cur) => ({ agentMode: { ...cur.agentMode, activeBackend: value } }))
-            }
-            options={orderedDescriptors.map((d) => ({ label: d.displayName, value: d.id }))}
-          />
-        </SettingSection>
+    <section className="tw-space-y-4">
+      <SettingSection label={AGENTS_SECTION_LABEL}>
+        <SettingItem
+          type="select"
+          title="Default backend"
+          description="Used when you click + to start a new session and for auto-spawn on mount. Selecting a model from the model picker also updates this."
+          value={activeBackendValue}
+          onChange={(value) =>
+            setSettings((cur) => ({ agentMode: { ...cur.agentMode, activeBackend: value } }))
+          }
+          options={orderedDescriptors.map((d) => ({ label: d.displayName, value: d.id }))}
+        />
+      </SettingSection>
 
-        <div className="tw-flex tw-flex-col">
-          <div ref={tabStripRef} className="tw-flex tw-flex-wrap tw-gap-1" role="tablist">
-            {tabs.map((tab, index) => (
-              <TabItem
-                key={tab.id}
-                tab={tab}
-                isSelected={selectedTabId === tab.id}
-                onClick={() => handleSelectTab(tab.id)}
-                isFirst={index === 0}
-                isLast={index === tabs.length - 1}
-              />
-            ))}
-          </div>
-
-          {orderedDescriptors.map((descriptor) => (
-            <TabContent
-              key={descriptor.id}
-              id={descriptor.id}
-              isSelected={selectedTabId === descriptor.id}
-            >
-              <BackendPanel descriptor={descriptor} plugin={plugin} />
-            </TabContent>
+      <div className="tw-flex tw-flex-col">
+        <div ref={tabStripRef} className="tw-flex tw-flex-wrap tw-gap-1" role="tablist">
+          {tabs.map((tab, index) => (
+            <TabItem
+              key={tab.id}
+              tab={tab}
+              isSelected={selectedTabId === tab.id}
+              onClick={() => handleSelectTab(tab.id)}
+              isFirst={index === 0}
+              isLast={index === tabs.length - 1}
+              variant="inline"
+            />
           ))}
-          <TabContent id={QUICK_CHAT_TAB_ID} isSelected={selectedTabId === QUICK_CHAT_TAB_ID}>
-            <QuickChatPanel />
-          </TabContent>
         </div>
+
+        {orderedDescriptors.map((descriptor) => (
+          <TabContent
+            key={descriptor.id}
+            id={descriptor.id}
+            isSelected={selectedTabId === descriptor.id}
+            variant="inline"
+          >
+            <BackendPanel descriptor={descriptor} plugin={plugin} />
+          </TabContent>
+        ))}
+        <TabContent
+          id={QUICK_CHAT_TAB_ID}
+          isSelected={selectedTabId === QUICK_CHAT_TAB_ID}
+          variant="inline"
+        >
+          <QuickChatPanel />
+        </TabContent>
       </div>
     </section>
   );
@@ -167,8 +175,8 @@ const QuickChatPanel: React.FC = () => {
   const hasDefault = resolvedDefaultModelId !== undefined;
 
   return (
-    <div className="tw-space-y-3">
-      <div className="tw-flex tw-min-w-0 tw-flex-col">
+    <SettingSection>
+      <div className="tw-flex tw-min-w-0 tw-flex-col tw-py-4">
         <span className="tw-text-base tw-font-semibold">Quick Chat models</span>
         <span className="tw-text-xs tw-text-muted">
           Models shown in the chat model picker. Add providers on the Models (BYOK) tab.
@@ -190,8 +198,10 @@ const QuickChatPanel: React.FC = () => {
         }
         placeholder="Model"
       />
-      <ChatModelEnableList />
-    </div>
+      <div className="tw-py-4">
+        <ChatModelEnableList />
+      </div>
+    </SettingSection>
   );
 };
 
@@ -226,6 +236,13 @@ const BackendPanel: React.FC<{
 
   const Icon = descriptor.Icon;
   const showCloudWarning = backendNeedsSelfHostWarning(descriptor, settings);
+  // Only a backend the plugin can install itself offers inline actions, and
+  // that is also the only kind whose models run on the user's own keys — so the
+  // same condition gates the recommendation and the BYOK hint. A vendor backend
+  // (claude, codex) authenticates against its own subscription, where "add
+  // providers on the BYOK tab" would be wrong advice.
+  const InlineInstall =
+    installState.kind === "absent" ? descriptor.AbsentInstallActions : undefined;
 
   return (
     <div className="tw-space-y-3">
@@ -239,41 +256,73 @@ const BackendPanel: React.FC<{
           </div>
         </div>
       )}
-      <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
-        <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
-          <Icon className="tw-size-4 tw-shrink-0" />
-          <div className="tw-flex tw-min-w-0 tw-flex-col">
-            <div className="tw-flex tw-items-center tw-gap-2">
-              <span className="tw-text-base tw-font-semibold">{descriptor.displayName}</span>
-              <InstallBadge state={installState} />
+      {/* One card per panel, rows divided by `SettingSection`. It insets and
+          divides its DIRECT children, so each block below has to be a single
+          row-shaped element carrying its own vertical padding — the rows that
+          come from `SettingItem` / `EnvOverridesSetting` already do. The cloud
+          warning stays outside: it qualifies the whole backend, not one row. */}
+      <SettingSection>
+        <div className="tw-flex tw-flex-col tw-gap-2 tw-py-4">
+          <div className="tw-flex tw-items-center tw-justify-between tw-gap-2">
+            <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2">
+              <Icon className="tw-size-4 tw-shrink-0" />
+              <div className="tw-flex tw-min-w-0 tw-flex-col">
+                <div className="tw-flex tw-items-center tw-gap-2">
+                  <span className="tw-text-base tw-font-semibold">{descriptor.displayName}</span>
+                  <InstallBadge state={installState} />
+                  {InlineInstall && (
+                    <Badge variant="accent" className="tw-font-normal">
+                      Recommended
+                    </Badge>
+                  )}
+                </div>
+                {resolvedPath && (
+                  <TruncatedText className="tw-max-w-[90%] tw-font-mono tw-text-xs tw-text-muted">
+                    {formatBinaryPathForDisplay(resolvedPath)}
+                  </TruncatedText>
+                )}
+                {InlineInstall && (
+                  <span className="tw-text-xs tw-text-muted">
+                    Not installed — one download away.
+                  </span>
+                )}
+                {(installState.kind === "incompatible" || installState.kind === "error") && (
+                  <span className="tw-text-xs tw-text-error">{installState.message}</span>
+                )}
+              </div>
             </div>
-            {resolvedPath && (
-              <TruncatedText className="tw-max-w-[90%] tw-font-mono tw-text-xs tw-text-muted">
-                {formatBinaryPathForDisplay(resolvedPath)}
-              </TruncatedText>
-            )}
-            {(installState.kind === "incompatible" || installState.kind === "error") && (
-              <span className="tw-text-xs tw-text-error">{installState.message}</span>
+            {InlineInstall ? (
+              <InlineInstall plugin={plugin} />
+            ) : (
+              <Button
+                className="tw-shrink-0"
+                size="default"
+                variant={installState.kind === "ready" ? "secondary" : "default"}
+                onClick={() => descriptor.openInstallUI(plugin)}
+              >
+                Configure
+              </Button>
             )}
           </div>
+          {InlineInstall && (
+            <div className="tw-text-xs tw-text-muted">
+              Works with Copilot Plus or your own API keys — add providers on the BYOK tab.
+            </div>
+          )}
         </div>
-        <Button
-          className="tw-shrink-0"
-          size="default"
-          variant={installState.kind === "ready" ? "secondary" : "default"}
-          onClick={() => descriptor.openInstallUI(plugin)}
-        >
-          Configure
-        </Button>
-      </div>
 
-      {installState.kind === "ready" && manager && (
-        <AgentDefaultModelSetting descriptor={descriptor} manager={manager} />
-      )}
+        {installState.kind === "ready" && manager && (
+          <AgentDefaultModelSetting descriptor={descriptor} manager={manager} />
+        )}
 
-      {installState.kind === "ready" && <ConfiguredModelEnableList descriptor={descriptor} />}
+        {installState.kind === "ready" && (
+          <div className="tw-py-4">
+            <ConfiguredModelEnableList descriptor={descriptor} />
+          </div>
+        )}
 
-      {Panel && <Panel plugin={plugin} app={plugin.app} />}
+        {Panel && <Panel plugin={plugin} app={plugin.app} />}
+      </SettingSection>
     </div>
   );
 };

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -8,6 +8,15 @@ import React from "react";
 // Stub the Plus banner to keep its dependency chain out of the test.
 jest.mock("@/settings/v2/components/PlusSettings", () => ({ PlusSettings: () => null }));
 
+// The Agents section is lazily imported behind a desktop gate; stub the module
+// the lazy import resolves to so the test never pulls in the agentMode barrel.
+jest.mock("@/settings/v2/components/AgentSettings", () => ({
+  AgentSettings: () => <div data-testid="agents-section">agents</div>,
+}));
+
+const isDesktopRuntime = jest.fn<boolean, []>().mockReturnValue(true);
+jest.mock("@/utils/desktopRuntime", () => ({ isDesktopRuntime: () => isDesktopRuntime() }));
+
 // App is threaded via useApp; the root-change orchestration is unit-tested in
 // copilotRootChange.test, so mock it here to observe the UI's decisions.
 jest.mock("@/context", () => ({
@@ -74,6 +83,44 @@ describe("BasicSettings", () => {
     isKnownCopilotRoot.mockReturnValue(false);
     shouldSurfaceMiyoResync.mockReturnValue(false);
     verifyMiyoScope.mockResolvedValue("unregistered");
+    isDesktopRuntime.mockReturnValue(true);
+  });
+
+  it("puts the Agents section above General so setup comes before preferences", async () => {
+    render(<BasicSettings />);
+    const agents = await screen.findByTestId("agents-section");
+    const general = screen.getByText("General");
+    // DOCUMENT_POSITION_FOLLOWING means `general` comes after `agents`.
+    expect(agents.compareDocumentPosition(general) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("renders a desktop-only placeholder instead of the Agents section on mobile", async () => {
+    isDesktopRuntime.mockReturnValue(false);
+    render(<BasicSettings />);
+    expect(screen.getByText("Agent settings are available on desktop.")).not.toBeNull();
+    expect(screen.queryByTestId("agents-section")).toBeNull();
+    // The rest of Basic still renders.
+    expect(screen.getByText("General")).not.toBeNull();
+  });
+
+  it("hides the filename template behind a collapsed Advanced disclosure", () => {
+    render(<BasicSettings />);
+    expect(screen.getByRole("button", { name: "Advanced" })).not.toBeNull();
+    expect(screen.queryByText("Conversation Filename Template")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
+    expect(screen.getByText("Conversation Filename Template")).not.toBeNull();
+  });
+
+  it("drops the template disclosure entirely when autosave is off", () => {
+    settingsStore.set(settingsAtom, {
+      ...DEFAULT_SETTINGS,
+      copilotFolder: "copilot",
+      autosaveChat: false,
+    });
+    render(<BasicSettings />);
+    expect(screen.queryByRole("button", { name: "Advanced" })).toBeNull();
+    expect(screen.queryByText("Conversation Filename Template")).toBeNull();
   });
 
   it("binds the Copilot folder input to the persisted root", () => {

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -112,15 +112,19 @@ describe("BasicSettings", () => {
     expect(screen.getByText("Conversation Filename Template")).not.toBeNull();
   });
 
-  it("drops the template disclosure entirely when autosave is off", () => {
+  it("keeps the template reachable when autosave is off", () => {
     settingsStore.set(settingsAtom, {
       ...DEFAULT_SETTINGS,
       copilotFolder: "copilot",
       autosaveChat: false,
     });
     render(<BasicSettings />);
-    expect(screen.queryByRole("button", { name: "Advanced" })).toBeNull();
-    expect(screen.queryByText("Conversation Filename Template")).toBeNull();
+
+    // Autosave off is exactly when the manual "Save Chat as Note" button
+    // appears, and it names its note from this template — so this is the one
+    // state where the template must not be hidden.
+    fireEvent.click(screen.getByRole("button", { name: "Advanced" }));
+    expect(screen.getByText("Conversation Filename Template")).not.toBeNull();
   });
 
   it("binds the Copilot folder input to the persisted root", () => {

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -330,86 +330,85 @@ export const BasicSettings: React.FC = () => {
           onCheckedChange={(checked) => updateSetting("autosaveChat", checked)}
         />
 
-        {/* The template only ever produces a filename for the note autosave
-            writes, so with autosave off there is nothing for it to name. */}
-        {settings.autosaveChat && (
-          <Collapsible open={templateOpen} onOpenChange={setTemplateOpen}>
-            <CollapsibleTrigger asChild>
-              <SettingDisclosure open={templateOpen} />
-            </CollapsibleTrigger>
-            <CollapsibleContent>
-              <SettingItem
-                type="custom"
-                title="Conversation Filename Template"
-                description={
-                  <div className="tw-flex tw-items-start tw-gap-1.5 ">
-                    <span className="tw-leading-none">
-                      Customize the format of saved conversation note names.
-                    </span>
-                    <HelpTooltip
-                      content={
-                        <div className="tw-flex tw-max-w-96 tw-flex-col tw-gap-2 tw-py-4">
-                          <div className="tw-text-sm tw-font-medium tw-text-accent">
-                            Note: All the following variables must be included in the template.
-                          </div>
-                          <div>
-                            <div className="tw-text-sm tw-font-medium tw-text-muted">
-                              Available variables:
-                            </div>
-                            <ul className="tw-pl-4 tw-text-sm tw-text-muted">
-                              <li>
-                                <strong>{"{$date}"}</strong>: Date in YYYYMMDD format
-                              </li>
-                              <li>
-                                <strong>{"{$time}"}</strong>: Time in HHMMSS format
-                              </li>
-                              <li>
-                                <strong>{"{$topic}"}</strong>: Chat conversation topic
-                              </li>
-                            </ul>
-                            <i className="tw-mt-2 tw-text-sm tw-text-muted">
-                              Example: {"{$date}_{$time}__{$topic}"} →
-                              20250114_153232__polish_this_article_[[Readme]]
-                            </i>
-                          </div>
+        {/* Not gated on autosave: the "Save Chat as Note" button appears only
+            when autosave is off, and it names its note from this same template,
+            so gating would hide the control exactly where it is the only one. */}
+        <Collapsible open={templateOpen} onOpenChange={setTemplateOpen}>
+          <CollapsibleTrigger asChild>
+            <SettingDisclosure open={templateOpen} />
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <SettingItem
+              type="custom"
+              title="Conversation Filename Template"
+              description={
+                <div className="tw-flex tw-items-start tw-gap-1.5 ">
+                  <span className="tw-leading-none">
+                    Customize the format of saved conversation note names.
+                  </span>
+                  <HelpTooltip
+                    content={
+                      <div className="tw-flex tw-max-w-96 tw-flex-col tw-gap-2 tw-py-4">
+                        <div className="tw-text-sm tw-font-medium tw-text-accent">
+                          Note: All the following variables must be included in the template.
                         </div>
-                      }
-                    />
-                  </div>
-                }
-              >
-                <div className="tw-flex tw-w-[320px] tw-items-center tw-gap-1.5">
-                  <Input
-                    type="text"
-                    className={cn(
-                      "tw-min-w-[80px] tw-grow tw-transition-all tw-duration-200",
-                      isChecking ? "tw-w-[80px]" : "tw-w-[120px]"
-                    )}
-                    placeholder="{$date}_{$time}__{$topic}"
-                    value={conversationNoteName}
-                    onChange={(e) => setConversationNoteName(e.target.value)}
-                    disabled={isChecking}
+                        <div>
+                          <div className="tw-text-sm tw-font-medium tw-text-muted">
+                            Available variables:
+                          </div>
+                          <ul className="tw-pl-4 tw-text-sm tw-text-muted">
+                            <li>
+                              <strong>{"{$date}"}</strong>: Date in YYYYMMDD format
+                            </li>
+                            <li>
+                              <strong>{"{$time}"}</strong>: Time in HHMMSS format
+                            </li>
+                            <li>
+                              <strong>{"{$topic}"}</strong>: Chat conversation topic
+                            </li>
+                          </ul>
+                          <i className="tw-mt-2 tw-text-sm tw-text-muted">
+                            Example: {"{$date}_{$time}__{$topic}"} →
+                            20250114_153232__polish_this_article_[[Readme]]
+                          </i>
+                        </div>
+                      </div>
+                    }
                   />
-
-                  <Button
-                    onClick={() => applyCustomNoteFormat()}
-                    disabled={isChecking}
-                    variant="secondary"
-                  >
-                    {isChecking ? (
-                      <>
-                        <Loader2 className="tw-mr-2 tw-size-4 tw-animate-spin" />
-                        Apply
-                      </>
-                    ) : (
-                      "Apply"
-                    )}
-                  </Button>
                 </div>
-              </SettingItem>
-            </CollapsibleContent>
-          </Collapsible>
-        )}
+              }
+            >
+              <div className="tw-flex tw-w-[320px] tw-items-center tw-gap-1.5">
+                <Input
+                  type="text"
+                  className={cn(
+                    "tw-min-w-[80px] tw-grow tw-transition-all tw-duration-200",
+                    isChecking ? "tw-w-[80px]" : "tw-w-[120px]"
+                  )}
+                  placeholder="{$date}_{$time}__{$topic}"
+                  value={conversationNoteName}
+                  onChange={(e) => setConversationNoteName(e.target.value)}
+                  disabled={isChecking}
+                />
+
+                <Button
+                  onClick={() => applyCustomNoteFormat()}
+                  disabled={isChecking}
+                  variant="secondary"
+                >
+                  {isChecking ? (
+                    <>
+                      <Loader2 className="tw-mr-2 tw-size-4 tw-animate-spin" />
+                      Apply
+                    </>
+                  ) : (
+                    "Apply"
+                  )}
+                </Button>
+              </div>
+            </SettingItem>
+          </CollapsibleContent>
+        </Collapsible>
       </SettingSection>
     </div>
   );

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -1,8 +1,10 @@
 import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { Input } from "@/components/ui/input";
 import { SettingItem } from "@/components/ui/setting-item";
+import { SettingDisclosure } from "@/components/ui/setting-disclosure";
 import { SettingSection } from "@/components/ui/setting-section";
 import { DEFAULT_OPEN_AREA, SEND_SHORTCUT } from "@/constants";
 import { useApp } from "@/context";
@@ -23,12 +25,37 @@ import {
   useSettingsValue,
   validateCopilotFolder,
 } from "@/settings/model";
+import { DesktopOnlySettingsPanel } from "@/settings/v2/components/DesktopOnlySettingsPanel";
 import { PlusSettings } from "@/settings/v2/components/PlusSettings";
 import { formatDateTime } from "@/utils";
+import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { revealFolderInExplorer } from "@/utils/revealFolderInExplorer";
 import { Folder, FolderSync, Loader2 } from "lucide-react";
 import { Notice } from "obsidian";
 import React, { useEffect, useState } from "react";
+
+const LazyAgentSettings = React.lazy(() =>
+  import("@/settings/v2/components/AgentSettings").then((module) => ({
+    default: module.AgentSettings,
+  }))
+);
+
+/**
+ * The Agents block of the Basic tab, behind the desktop gate. `React.lazy`
+ * defers the import until this actually renders, so the desktop check runs
+ * before the `@/agentMode` barrel — which pulls in Node-only modules that throw
+ * on evaluation under a mobile runtime — is ever requested.
+ */
+const AgentsSection: React.FC = () => {
+  if (!isDesktopRuntime()) {
+    return <DesktopOnlySettingsPanel message="Agent settings are available on desktop." />;
+  }
+  return (
+    <React.Suspense fallback={null}>
+      <LazyAgentSettings />
+    </React.Suspense>
+  );
+};
 
 /**
  * Body of the "Change Copilot folder" confirmation modal. Leads with a
@@ -61,6 +88,7 @@ export const BasicSettings: React.FC = () => {
   // incoming lifecycle while still holding the outgoing vault's `app`.
   const { miyoMutationSession } = usePlugin();
   const [isChecking, setIsChecking] = useState(false);
+  const [templateOpen, setTemplateOpen] = useState(false);
   const [conversationNoteName, setConversationNoteName] = useState(
     settings.defaultConversationNoteName || "{$date}_{$time}__{$topic}"
   );
@@ -209,6 +237,8 @@ export const BasicSettings: React.FC = () => {
     <div className="tw-space-y-4">
       <PlusSettings />
 
+      <AgentsSection />
+
       {/* General Section */}
       <SettingSection label="General">
         <SettingItem
@@ -300,75 +330,86 @@ export const BasicSettings: React.FC = () => {
           onCheckedChange={(checked) => updateSetting("autosaveChat", checked)}
         />
 
-        <SettingItem
-          type="custom"
-          title="Conversation Filename Template"
-          description={
-            <div className="tw-flex tw-items-start tw-gap-1.5 ">
-              <span className="tw-leading-none">
-                Customize the format of saved conversation note names.
-              </span>
-              <HelpTooltip
-                content={
-                  <div className="tw-flex tw-max-w-96 tw-flex-col tw-gap-2 tw-py-4">
-                    <div className="tw-text-sm tw-font-medium tw-text-accent">
-                      Note: All the following variables must be included in the template.
-                    </div>
-                    <div>
-                      <div className="tw-text-sm tw-font-medium tw-text-muted">
-                        Available variables:
-                      </div>
-                      <ul className="tw-pl-4 tw-text-sm tw-text-muted">
-                        <li>
-                          <strong>{"{$date}"}</strong>: Date in YYYYMMDD format
-                        </li>
-                        <li>
-                          <strong>{"{$time}"}</strong>: Time in HHMMSS format
-                        </li>
-                        <li>
-                          <strong>{"{$topic}"}</strong>: Chat conversation topic
-                        </li>
-                      </ul>
-                      <i className="tw-mt-2 tw-text-sm tw-text-muted">
-                        Example: {"{$date}_{$time}__{$topic}"} →
-                        20250114_153232__polish_this_article_[[Readme]]
-                      </i>
-                    </div>
+        {/* The template only ever produces a filename for the note autosave
+            writes, so with autosave off there is nothing for it to name. */}
+        {settings.autosaveChat && (
+          <Collapsible open={templateOpen} onOpenChange={setTemplateOpen}>
+            <CollapsibleTrigger asChild>
+              <SettingDisclosure open={templateOpen} />
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <SettingItem
+                type="custom"
+                title="Conversation Filename Template"
+                description={
+                  <div className="tw-flex tw-items-start tw-gap-1.5 ">
+                    <span className="tw-leading-none">
+                      Customize the format of saved conversation note names.
+                    </span>
+                    <HelpTooltip
+                      content={
+                        <div className="tw-flex tw-max-w-96 tw-flex-col tw-gap-2 tw-py-4">
+                          <div className="tw-text-sm tw-font-medium tw-text-accent">
+                            Note: All the following variables must be included in the template.
+                          </div>
+                          <div>
+                            <div className="tw-text-sm tw-font-medium tw-text-muted">
+                              Available variables:
+                            </div>
+                            <ul className="tw-pl-4 tw-text-sm tw-text-muted">
+                              <li>
+                                <strong>{"{$date}"}</strong>: Date in YYYYMMDD format
+                              </li>
+                              <li>
+                                <strong>{"{$time}"}</strong>: Time in HHMMSS format
+                              </li>
+                              <li>
+                                <strong>{"{$topic}"}</strong>: Chat conversation topic
+                              </li>
+                            </ul>
+                            <i className="tw-mt-2 tw-text-sm tw-text-muted">
+                              Example: {"{$date}_{$time}__{$topic}"} →
+                              20250114_153232__polish_this_article_[[Readme]]
+                            </i>
+                          </div>
+                        </div>
+                      }
+                    />
                   </div>
                 }
-              />
-            </div>
-          }
-        >
-          <div className="tw-flex tw-w-[320px] tw-items-center tw-gap-1.5">
-            <Input
-              type="text"
-              className={cn(
-                "tw-min-w-[80px] tw-grow tw-transition-all tw-duration-200",
-                isChecking ? "tw-w-[80px]" : "tw-w-[120px]"
-              )}
-              placeholder="{$date}_{$time}__{$topic}"
-              value={conversationNoteName}
-              onChange={(e) => setConversationNoteName(e.target.value)}
-              disabled={isChecking}
-            />
+              >
+                <div className="tw-flex tw-w-[320px] tw-items-center tw-gap-1.5">
+                  <Input
+                    type="text"
+                    className={cn(
+                      "tw-min-w-[80px] tw-grow tw-transition-all tw-duration-200",
+                      isChecking ? "tw-w-[80px]" : "tw-w-[120px]"
+                    )}
+                    placeholder="{$date}_{$time}__{$topic}"
+                    value={conversationNoteName}
+                    onChange={(e) => setConversationNoteName(e.target.value)}
+                    disabled={isChecking}
+                  />
 
-            <Button
-              onClick={() => applyCustomNoteFormat()}
-              disabled={isChecking}
-              variant="secondary"
-            >
-              {isChecking ? (
-                <>
-                  <Loader2 className="tw-mr-2 tw-size-4 tw-animate-spin" />
-                  Apply
-                </>
-              ) : (
-                "Apply"
-              )}
-            </Button>
-          </div>
-        </SettingItem>
+                  <Button
+                    onClick={() => applyCustomNoteFormat()}
+                    disabled={isChecking}
+                    variant="secondary"
+                  >
+                    {isChecking ? (
+                      <>
+                        <Loader2 className="tw-mr-2 tw-size-4 tw-animate-spin" />
+                        Apply
+                      </>
+                    ) : (
+                      "Apply"
+                    )}
+                  </Button>
+                </div>
+              </SettingItem>
+            </CollapsibleContent>
+          </Collapsible>
+        )}
       </SettingSection>
     </div>
   );

--- a/src/settings/v2/components/DesktopOnlySettingsPanel.test.tsx
+++ b/src/settings/v2/components/DesktopOnlySettingsPanel.test.tsx
@@ -1,0 +1,12 @@
+import { DesktopOnlySettingsPanel } from "@/settings/v2/components/DesktopOnlySettingsPanel";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("DesktopOnlySettingsPanel", () => {
+  describe("DesktopOnlySettingsPanel()", () => {
+    it("renders the caller's explanation so each gated panel names its own feature", () => {
+      render(<DesktopOnlySettingsPanel message="Skills are available on desktop." />);
+      expect(screen.getByText("Skills are available on desktop.")).not.toBeNull();
+    });
+  });
+});

--- a/src/settings/v2/components/DesktopOnlySettingsPanel.tsx
+++ b/src/settings/v2/components/DesktopOnlySettingsPanel.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface DesktopOnlySettingsPanelProps {
+  /**
+   * What is unavailable, phrased for this specific panel. Required rather than
+   * defaulted because every caller gates a different feature — one shared
+   * sentence would be wrong for all but the panel it was written for.
+   */
+  message: string;
+}
+
+/**
+ * Stand-in for a settings panel whose feature needs the desktop (Electron)
+ * runtime. It renders nothing but the explanation, so it can be shown on mobile
+ * without pulling the gated feature's module graph into the bundle.
+ *
+ * DESIGN NOTE — deliberately has no adjacent gallery story, despite the
+ * component-gallery workflow in `designdocs/agents/TESTING_GUIDE.md`. The
+ * gallery import fence (`eslint.config.mjs`) admits only UI primitives, shared
+ * libraries, and the Obsidian host seams; `settings/v2/components/` is outside
+ * it, so a story here fails lint rather than merely being low-value. Covering
+ * it would mean relocating this component into `components/ui/`, which is a
+ * bigger move than the one static sentence it renders can justify — and its two
+ * real messages are already asserted in `DesktopOnlySettingsPanel.test.tsx`.
+ * If a future review flags this again, point them at this note.
+ */
+export const DesktopOnlySettingsPanel: React.FC<DesktopOnlySettingsPanelProps> = ({ message }) => (
+  <section className="tw-rounded-md tw-border tw-border-solid tw-border-border tw-p-4 tw-text-sm tw-text-muted">
+    {message}
+  </section>
+);

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SegmentedControl } from "@/components/ui/segmented-control";
+import { SettingDisclosure } from "@/components/ui/setting-disclosure";
 import { SettingItem } from "@/components/ui/setting-item";
 import { SettingSection } from "@/components/ui/setting-section";
 import { SettingSwitch } from "@/components/ui/setting-switch";
@@ -40,7 +41,7 @@ import { MiyoStatusRow } from "@/settings/v2/components/MiyoStatusRow";
 import { err2String } from "@/utils";
 import { getVaultBase } from "@/utils/vaultPath";
 import { extractAppIgnoreSettings, getSystemExcludedFolders } from "@/search/searchUtils";
-import { ArrowUpRight, ChevronRight, CornerDownRight, TriangleAlert } from "lucide-react";
+import { ArrowUpRight, CornerDownRight, TriangleAlert } from "lucide-react";
 import { Notice, Platform } from "obsidian";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 
@@ -875,20 +876,7 @@ export const MiyoSettings: React.FC = () => {
 
         {/* Advanced — the remote Miyo URL is an escape hatch, tucked away by default. */}
         <div>
-          {/* Plain disclosure row, not a button box: the `!` resets override
-              Obsidian's native button chrome (border/background/shadow/padding)
-              that a raw <button> inherits inside the settings pane. */}
-          <button
-            type="button"
-            className="tw-flex tw-w-full tw-cursor-pointer tw-items-center !tw-justify-start tw-gap-1.5 !tw-border-none !tw-bg-transparent !tw-px-0 !tw-py-3 tw-text-left tw-text-sm tw-font-medium tw-text-muted !tw-shadow-none hover:tw-text-normal"
-            aria-expanded={advancedOpen}
-            onClick={() => setAdvancedOpen((open) => !open)}
-          >
-            <ChevronRight
-              className={cn("tw-size-3.5 tw-transition-transform", advancedOpen && "tw-rotate-90")}
-            />
-            Advanced
-          </button>
+          <SettingDisclosure open={advancedOpen} onClick={() => setAdvancedOpen((open) => !open)} />
 
           {advancedOpen && (
             <div className="tw-pb-2">

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -47,7 +47,7 @@ export function PlusSettings() {
   const usageData = getPlusUsageMock();
 
   return (
-    <section className="tw-flex tw-flex-col tw-gap-4 tw-rounded-xl tw-border tw-border-solid tw-p-4 tw-shadow-sm tw-bg-interactive-accent/10 tw-border-interactive-accent/40">
+    <section className="tw-flex tw-flex-col tw-gap-4 tw-rounded-xl tw-border tw-border-solid tw-border-border tw-p-4 tw-shadow-sm tw-bg-interactive-accent/10">
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-text-lg tw-font-semibold">
         <span>Copilot License</span>
         {licenseStatus === "active" && (
@@ -93,7 +93,7 @@ export function PlusSettings() {
           undefined; the status covers a key that stopped working while the
           cached flag still reads paid. */}
       {(isPaidUser === false || licenseStatus === "inactive") && !isChecking && (
-        <div className="tw-flex tw-flex-col tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-bg-primary tw-p-3 tw-border-interactive-accent/30">
+        <div className="tw-flex tw-flex-col tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-border-border tw-bg-primary tw-p-3">
           <div className="tw-text-sm tw-text-normal">All of it for a few dollars a month.</div>
           <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">
             <Button

--- a/src/utils/formatBytes.test.ts
+++ b/src/utils/formatBytes.test.ts
@@ -1,0 +1,19 @@
+import { formatBytes } from "@/utils/formatBytes";
+
+describe("formatBytes", () => {
+  describe("formatBytes()", () => {
+    it("reports sub-kilobyte counts in whole bytes", () => {
+      expect(formatBytes(0)).toBe("0 B");
+      expect(formatBytes(512)).toBe("512 B");
+      expect(formatBytes(1023)).toBe("1023 B");
+    });
+
+    it("switches to kilobytes at 1 KiB and to megabytes at 1 MiB", () => {
+      expect(formatBytes(1024)).toBe("1.0 KB");
+      expect(formatBytes(2048)).toBe("2.0 KB");
+      expect(formatBytes(1024 * 1024)).toBe("1.0 MB");
+      expect(formatBytes(5 * 1024 * 1024)).toBe("5.0 MB");
+      expect(formatBytes(26_214_400)).toBe("25.0 MB");
+    });
+  });
+});

--- a/src/utils/formatBytes.ts
+++ b/src/utils/formatBytes.ts
@@ -1,0 +1,6 @@
+/** Byte count in the largest unit that keeps the number readable. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}


### PR DESCRIPTION
Part of logancyang/obsidian-copilot-preview#195 (the Agents-in-Basic piece of the
settings redesign; the umbrella issue stays open for the remaining parts).

> **This PR was split.** It previously carried the guided report flow as well.
> That half now lives in its own PR stacked on this one — see *Split* below.
> Force-pushed, so review comments anchored to the old SHAs are stale.

## Problem

**The Agents settings sat in their own tab** while the v4 redesign folds them
into Basic, and installing opencode meant leaving settings for a separate modal.

## Fix

Agents becomes a section of Basic rather than a top-level tab, behind the
existing desktop gate. Supporting UI work that fell out of it:

- `page` / `inline` tab variants, so a nested tab strip reads as chips inside a
  tab's content instead of repeating the pane-edge treatment and painting a
  second grey backdrop over the section cards.
- `SettingDisclosure`, extracted from the hand-rolled disclosure row in
  `MiyoSettings` so both Advanced rows are one component.
- Inline opencode install with progress, replacing the separate modal.
- `formatBytes`, split out as its own commit because the stacked report PR needs
  it too.

## Scope

46 files changed, +1592 / −275, across 6 commits. Each commit is independently
buildable and testable.

## Changes

- **`settings/v2/components/BasicSettings.tsx`** — lazy-loaded `AgentsSection`
  behind `isDesktopRuntime()`; the gate runs before the dynamic import because
  the `@/agentMode` barrel pulls in Node-only modules that throw on evaluation
  under a mobile runtime.
- **`settings/v2/SettingsMainV2.tsx`** — `agent` tab entry removed; the shared
  desktop-only placeholder moves to its own component.
- **`settings/v2/components/AgentSettings.tsx`** — now a Basic section rather
  than a tab, with a quiet `alpha` badge on the heading.
- **`components/ui/setting-tabs.tsx`** — `TabVariant` (`page` | `inline`).
- **`components/ui/setting-disclosure.tsx`** (new) — the Advanced disclosure row.
- **`agentMode/backends/opencode/`** — `OpencodeInlineInstall` + an
  `installProgress` state machine.
- **`utils/formatBytes.ts`** (new) — shared with the report PR.

## Split

The guided report flow (`ReportIssueFlow`, `ReportIssueModal`, `issueReport`,
uploader, `redactLog` / `logFileManager` changes) moved to the stacked PR. The
two features touch disjoint files; `formatBytes` is the only shared dependency,
which is why it is its own commit at the base of both.

Verified at blob level that the split lost nothing: all 54 files from the
original combined commit reproduce byte-identically across the two branches,
except the four that upstream itself has since changed.

## Verification

- `npm run test` — 393 suites, 5492 tests, all passing.
- `npx tsc --noEmit` clean at every commit, not just the tip.
- `npm run lint`, `npm run format:check` — clean.
- Rebased onto current `v4-preview` (three times, as it moved). Conflicts were
  resolved keeping both sides. Notably:
  - `AgentSettings` — upstream removed Managed MCP (#2749), so `<McpServersPanel />`
    and the test asserting its placement are gone, while the `inline` tab variant
    and section label stay. It also adopts upstream's extracted
    `backendDisplayOrder()` rather than keeping a local `BACKEND_ORDER` copy.
  - `OpencodeInstallModal` — upstream rewrote it around `OpencodeConfigView`
    (#2744). Took that rewrite wholesale, then re-applied the one thing this PR
    contributes there: its local `formatBytes` copy swapped for the shared helper.
  - Stories dropped their `width` parameter, which upstream removed (#2757).

## Actual Effect
<img width="2016" height="1960" alt="Obsidian 2026-07-31 01 37 15" src="https://github.com/user-attachments/assets/e83d25fc-6a4a-4d0e-9a6b-a0fe1bb22cfc" />

