### PR TITLE
fix(agent-mode): jump to bottom on tab switch

### DIFF
--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -925,6 +925,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
                 ) : (
                   <>
                     <AgentChatMessages
+                      key={sessionId}
                       messages={messages}
                       app={app}
                       currentPlan={currentPlan}


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#251

GitHub does not populate cross-repository closing references for this link; close issue #251 manually when the PR merges.

## Problem

Agent Mode keeps `AgentHome` mounted while switching session tabs. That also keeps `useChatScrolling`'s prior-session tracking state alive, so replacing the transcript can be mistaken for a newly appended user message and trigger a smooth scroll. On a long session, opening the tab visibly animates through the transcript before reaching the bottom.

A live before-change probe reproduced the tab switch as `scrollTo({ top: 28994, behavior: "smooth" })`.

## Fix

Key `AgentChatMessages` by the existing `sessionId`. Switching tabs now remounts only the transcript, which reuses the existing mount-time instant scroll. `AgentHome` and the composer stay mounted, while same-session message updates keep their existing smooth scrolling.

## Scope

Budget gate: PASS — 1 file, +1/−0. Keying the transcript by its existing session identity is the smallest shape that resets scroll state on tab changes without remounting `AgentHome` or changing same-session smooth scrolling.

## Verification

- `npm run format`
- `npm run lint`
- `npm run test -- --runInBand` — 348 suites, 4,916 tests passed
- `npm run build`
- `git diff --check`
- `npm run test:vault`
- Live test-vault wiring probe: switching sessions invoked only `scrollTo({ behavior: "instant" })`
- Before/after recording using synthetic `copilot-test-vault` data only: [watch the tab-switch demo](https://pub-d0d5db63b5e446cc848d32b65229d622.r2.dev/obsidian-copilot/pr-2714/tab-scroll-demo.mp4)

🤖 Generated with [Codex](https://openai.com/codex/)
