### PR TITLE
Add local Miyo documents and proactive web routing

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -86,9 +86,9 @@ Web research normally starts with one discovery search followed by targeted page
 For PDF and EPUB files, the **Document Processor** choice under **Settings → Copilot → Miyo** also controls Agent Mode:
 
 - **Plus** uses the Copilot Plus PDF reader and can fall back to another available document-reading tool.
-- **Miyo** parses PDF and EPUB files locally with the Miyo CLI, including files outside the vault. Copilot removes the Plus PDF skill from the agent's skills folder while this is selected, so a document cannot reach a cloud parser by mistake. If local parsing fails, the agent reports the error and stops.
+- **Miyo** parses PDF and EPUB files locally, including files outside the vault. Copilot removes the Plus PDF skill from the agent's skills folder while this is selected, so a document cannot reach a cloud parser by mistake. If local parsing fails, the agent reports the error and stops.
 
-Switching between the two reseeds the skills folder and restarts running agents, so the change applies without a reload.
+Unlike chat, Agent Mode parses through the Miyo CLI rather than the Miyo server, so the Miyo option needs the app installed on the same machine as Obsidian; a remote Miyo server does not enable it. Without a local install, either install Miyo or set Document Processor back to **Plus**. Switching between the two reseeds the skills folder and restarts running agents, so either choice applies without a reload.
 
 ### Publish to Symposium
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -77,6 +77,17 @@ When inspecting open tabs, the agent preserves Markdown notes, other file-backed
 
 The agent never reloads or restarts Obsidian, nor does it reload, disable, or uninstall the Copilot plugin hosting its session. Those actions terminate in-flight agent work. When a reload is required to finish verification, the agent leaves it for you to perform after the session ends. Reloading a different plugin remains available for plugin development.
 
+### Web and document routing
+
+Claude, Codex, and OpenCode choose between vault and web evidence from the question. They search the vault first for questions about your own notes. For current facts, external topics, and third-party documentation, they can proactively search the web without requiring an explicit “search the web” instruction. A weak or empty vault search can also lead to web research when the question is external in nature.
+
+Web research normally starts with one discovery search followed by targeted page fetches. The agent does not put text from your vault into a web query unless your request clearly requires researching that text.
+
+For PDF and EPUB files, the **Document Processor** choice under **Settings → Copilot → Miyo** also controls Agent Mode:
+
+- **Plus** uses the Copilot Plus PDF reader and can fall back to another available document-reading tool.
+- **Miyo** parses PDF and EPUB files locally with the Miyo CLI, including files outside the vault. If local parsing fails, the agent reports the error and does not upload the document to a cloud parser.
+
 ### Publish to Symposium
 
 Ask Claude, Codex, or OpenCode to publish an existing Markdown note as a web page. The agent creates self-contained HTML, renders Mermaid and Bases as static content, then asks for explicit confirmation because the resulting link is public.

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -86,7 +86,9 @@ Web research normally starts with one discovery search followed by targeted page
 For PDF and EPUB files, the **Document Processor** choice under **Settings → Copilot → Miyo** also controls Agent Mode:
 
 - **Plus** uses the Copilot Plus PDF reader and can fall back to another available document-reading tool.
-- **Miyo** parses PDF and EPUB files locally with the Miyo CLI, including files outside the vault. If local parsing fails, the agent reports the error and does not upload the document to a cloud parser.
+- **Miyo** parses PDF and EPUB files locally with the Miyo CLI, including files outside the vault. Copilot removes the Plus PDF skill from the agent's skills folder while this is selected, so a document cannot reach a cloud parser by mistake. If local parsing fails, the agent reports the error and stops.
+
+Switching between the two reseeds the skills folder and restarts running agents, so the change applies without a reload.
 
 ### Publish to Symposium
 

--- a/src/agentMode/backends/shared/agentSystemPrompt.test.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.test.ts
@@ -8,7 +8,9 @@ import {
 import type { UserSystemPrompt } from "@/system-prompts/type";
 import {
   buildAgentSystemPrompt,
+  COPILOT_MIYO_DOCUMENT_STEERING,
   COPILOT_MIYO_SEARCH_STEERING,
+  COPILOT_PLUS_DOCUMENT_STEERING,
   COPILOT_PLUS_TOOLS_STEERING,
   COPILOT_PROMPT_BASE,
 } from "./agentSystemPrompt";
@@ -89,6 +91,7 @@ describe("buildAgentSystemPrompt", () => {
     // users fall back to their own tools via the steering's fallback clause.
     const nonPlus = buildAgentSystemPrompt();
     expect(nonPlus).toContain(COPILOT_PLUS_TOOLS_STEERING);
+    expect(nonPlus).toContain(COPILOT_PLUS_DOCUMENT_STEERING);
     expect(nonPlus).toContain("copilot-web-search");
     expect(nonPlus).toContain("copilot-web-fetch");
     expect(nonPlus).toContain("copilot-read-pdf");
@@ -107,10 +110,34 @@ describe("buildAgentSystemPrompt", () => {
     expect(buildAgentSystemPrompt()).toContain(COPILOT_PLUS_TOOLS_STEERING);
   });
 
+  it("proactively routes external questions to bounded web research without leaking vault text", () => {
+    const prompt = buildAgentSystemPrompt();
+    expect(prompt).toMatch(/current facts, external topics, or third-party documentation/i);
+    expect(prompt).toMatch(/without waiting for an explicit web-search request/i);
+    expect(prompt).toMatch(/local search is empty or weak/i);
+    expect(prompt).toMatch(/instead of answering from memory/i);
+    expect(prompt).toMatch(/questions about the user's own notes or vault, search locally first/i);
+    expect(prompt).toMatch(/Do not place text from the vault into a web query/i);
+    expect(prompt).toMatch(/one discovery search followed by targeted page fetches/i);
+    expect(prompt).toMatch(/do not start repeated or open-ended search chains/i);
+  });
+
+  it("uses the local fail-closed document route only when Miyo is selected", () => {
+    updateSetting("docProcessorBackend", "miyo");
+    const prompt = buildAgentSystemPrompt();
+    expect(prompt).toContain(COPILOT_MIYO_DOCUMENT_STEERING);
+    expect(prompt).not.toContain(COPILOT_PLUS_DOCUMENT_STEERING);
+    expect(prompt).toContain("miyo-parse");
+    expect(prompt).toMatch(/Never use `copilot-read-pdf` or another cloud parser as a fallback/i);
+    expect(prompt).toMatch(/without uploading the document elsewhere/i);
+  });
+
   it("suppresses the steering when the builtin prompt is disabled", () => {
     setDisableBuiltinSystemPrompt(true);
     const prompt = buildAgentSystemPrompt();
     expect(prompt).not.toContain(COPILOT_PLUS_TOOLS_STEERING);
+    expect(prompt).not.toContain(COPILOT_PLUS_DOCUMENT_STEERING);
+    expect(prompt).not.toContain(COPILOT_MIYO_DOCUMENT_STEERING);
   });
 
   it("omits the Miyo steering when the search skill is not installed", () => {

--- a/src/agentMode/backends/shared/agentSystemPrompt.test.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.test.ts
@@ -110,26 +110,24 @@ describe("buildAgentSystemPrompt", () => {
     expect(buildAgentSystemPrompt()).toContain(COPILOT_PLUS_TOOLS_STEERING);
   });
 
-  it("proactively routes external questions to bounded web research without leaking vault text", () => {
+  it("routes external questions to the web proactively and keeps vault text out of queries", () => {
     const prompt = buildAgentSystemPrompt();
-    expect(prompt).toMatch(/current facts, external topics, or third-party documentation/i);
+    // Both halves of the routing rule, plus the privacy constraint on queries.
+    expect(prompt).toMatch(/search locally first/i);
     expect(prompt).toMatch(/without waiting for an explicit web-search request/i);
-    expect(prompt).toMatch(/local search is empty or weak/i);
-    expect(prompt).toMatch(/instead of answering from memory/i);
-    expect(prompt).toMatch(/questions about the user's own notes or vault, search locally first/i);
     expect(prompt).toMatch(/Do not place text from the vault into a web query/i);
-    expect(prompt).toMatch(/one discovery search followed by targeted page fetches/i);
-    expect(prompt).toMatch(/do not start repeated or open-ended search chains/i);
   });
 
   it("uses the local fail-closed document route only when Miyo is selected", () => {
     updateSetting("docProcessorBackend", "miyo");
     const prompt = buildAgentSystemPrompt();
     expect(prompt).toContain(COPILOT_MIYO_DOCUMENT_STEERING);
+    // The Plus route must be absent, not merely outranked: `copilot-read-pdf` is
+    // pruned from disk in this mode, so steering toward it would dead-end.
     expect(prompt).not.toContain(COPILOT_PLUS_DOCUMENT_STEERING);
     expect(prompt).toContain("miyo-parse");
-    expect(prompt).toMatch(/Never use `copilot-read-pdf` or another cloud parser as a fallback/i);
-    expect(prompt).toMatch(/without uploading the document elsewhere/i);
+    // Cancels the blanket fallback clause the Plus tools steering sets up.
+    expect(prompt).toMatch(/fallback rule above does NOT apply/i);
   });
 
   it("suppresses the steering when the builtin prompt is disabled", () => {

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -70,10 +70,10 @@ Default to one discovery search followed by targeted page fetches, or fetch dire
 If a skill is missing, disabled, reports that Copilot Plus is not active, or fails for this particular request (for example a page it can't fetch or any other relay error), silently fall back to your own equivalent tool (or, if you have none for that task, tell the user it's unavailable) and complete the request — never refuse and never block the user on upgrading. Only pass along an upgrade or renewal note when the skill's own message explicitly invites it, and keep any such mention brief and occasional.`;
 
 /**
- * Document steering when Copilot Plus is the selected Document Processor. Kept
- * out of `COPILOT_PLUS_TOOLS_STEERING` because the Miyo alternative below must
- * be able to replace it wholesale: naming `copilot-read-pdf` in an
- * always-sent block would point a Miyo user at a skill that is not seeded.
+ * Document steering when Copilot Plus is the selected Document Processor. Split
+ * out of `COPILOT_PLUS_TOOLS_STEERING` so the Miyo alternative can replace it
+ * wholesale — naming `copilot-read-pdf` in an always-sent block would point a
+ * Miyo user at a skill that is not seeded.
  */
 export const COPILOT_PLUS_DOCUMENT_STEERING = `## Document processing
 For reading a PDF file, prefer the bundled \`copilot-read-pdf\` skill over any built-in tool of your own. The fallback rule above applies to it: if it is missing, disabled, or fails for this file, use your own equivalent tool instead.`;

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -69,13 +69,25 @@ Default to one discovery search followed by targeted page fetches, or fetch dire
 
 If a skill is missing, disabled, reports that Copilot Plus is not active, or fails for this particular request (for example a page it can't fetch or any other relay error), silently fall back to your own equivalent tool (or, if you have none for that task, tell the user it's unavailable) and complete the request — never refuse and never block the user on upgrading. Only pass along an upgrade or renewal note when the skill's own message explicitly invites it, and keep any such mention brief and occasional.`;
 
-/** Cloud PDF steering used when Copilot Plus is the selected document processor. */
+/**
+ * Document steering when Copilot Plus is the selected Document Processor. Kept
+ * out of `COPILOT_PLUS_TOOLS_STEERING` because the Miyo alternative below must
+ * be able to replace it wholesale: naming `copilot-read-pdf` in an
+ * always-sent block would point a Miyo user at a skill that is not seeded.
+ */
 export const COPILOT_PLUS_DOCUMENT_STEERING = `## Document processing
-For reading a PDF file, prefer the bundled \`copilot-read-pdf\` skill over your own tool. If the skill is missing, disabled, unavailable to the user's Copilot Plus account, or fails for this file, silently fall back to your own equivalent tool. If no document-reading tool is available, tell the user; never block them on upgrading.`;
+For reading a PDF file, prefer the bundled \`copilot-read-pdf\` skill over any built-in tool of your own. The fallback rule above applies to it: if it is missing, disabled, or fails for this file, use your own equivalent tool instead.`;
 
-/** Local, fail-closed document steering used when Miyo is selected. */
-export const COPILOT_MIYO_DOCUMENT_STEERING = `## Local document processing (Miyo)
-Miyo is the selected Document Processor. For any PDF or EPUB file, use the \`miyo-parse\` skill, which parses the document locally. Never use \`copilot-read-pdf\` or another cloud parser as a fallback. If the Miyo skill is missing or fails, report the problem clearly without uploading the document elsewhere.`;
+/**
+ * Document steering when Miyo is the selected Document Processor. Fails closed
+ * on purpose — it must cancel the blanket fallback clause in
+ * `COPILOT_PLUS_TOOLS_STEERING`, or the agent could read "silently fall back to
+ * your own equivalent tool" as permission to send the document to the cloud.
+ */
+export const COPILOT_MIYO_DOCUMENT_STEERING = `## Document processing (local, Miyo)
+The user selected Miyo as their Document Processor, so PDFs and EPUBs must stay on their machine. For any PDF or EPUB file, use the \`miyo-parse\` skill, which parses it locally.
+
+The fallback rule above does NOT apply here. If \`miyo-parse\` is missing or fails, report the problem and stop — never send the document to \`copilot-read-pdf\`, another cloud parser, or any other web service.`;
 
 /**
  * Steers the agent toward the bundled `miyo-search` skill for vault search. A

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -13,10 +13,10 @@
  *   1. `COPILOT_PROMPT_BASE` (the Obsidian-vault identity) — unless the user
  *      enabled Settings → System prompts → "Disable builtin system prompt".
  *      Followed by `COPILOT_PLUS_TOOLS_STEERING` (prefer the builtin Copilot
- *      Plus skills, with a fallback to the agent's own tools) — sent to everyone.
- *      Then `COPILOT_MIYO_SEARCH_STEERING` — appended only when `shouldUseMiyo`
- *      is true, so the agent is pointed at the `miyo-search` skill only while
- *      Miyo is enabled and available.
+ *      Plus web/media skills and proactively route external questions to them)
+ *      and document steering selected by `docProcessorBackend`.
+ *      Then `COPILOT_MIYO_SEARCH_STEERING` — appended only when the dedicated
+ *      Miyo search-skill setting is enabled.
  *   2. The pill-syntax directive (`buildPillSyntaxDirective`) — always present;
  *      it teaches the agent how to read the chat editor's `[[note]]`/`{folder}`
  *      tokens and is functional wiring, not "builtin framing" the user toggles.
@@ -55,13 +55,27 @@ export const COPILOT_PLUS_TOOLS_STEERING = `## Copilot Plus tools
 For these requests, prefer the bundled Copilot skill over any built-in tool of your own:
 - Searching the web → the \`copilot-web-search\` skill
 - Fetching or reading a specific web page → the \`copilot-web-fetch\` skill
-- Reading a PDF file → the \`copilot-read-pdf\` skill
 - Getting a YouTube video's transcript → the \`copilot-youtube-transcript\` skill
 - Fetching an X (Twitter) post → the \`copilot-fetch-x\` skill
 
 Each skill ships a runnable script per OS — a \`.sh\` for macOS/Linux and a \`.cmd\` for Windows. Follow the skill's own "How to run" instructions for the right command; both runtimes are always present, so nothing needs to be installed.
 
+Choose vault or web evidence from the request:
+- For questions about the user's own notes or vault, search locally first. Do not place text from the vault into a web query unless the request clearly requires researching that text.
+- For current facts, external topics, or third-party documentation, proactively use web search or fetch without waiting for an explicit web-search request.
+- If local search is empty or weak and the question is external in nature, switch to web evidence instead of answering from memory.
+
+Default to one discovery search followed by targeted page fetches, or fetch directly when the user supplied a specific URL. Stop when you have enough evidence; do not start repeated or open-ended search chains.
+
 If a skill is missing, disabled, reports that Copilot Plus is not active, or fails for this particular request (for example a page it can't fetch or any other relay error), silently fall back to your own equivalent tool (or, if you have none for that task, tell the user it's unavailable) and complete the request — never refuse and never block the user on upgrading. Only pass along an upgrade or renewal note when the skill's own message explicitly invites it, and keep any such mention brief and occasional.`;
+
+/** Cloud PDF steering used when Copilot Plus is the selected document processor. */
+export const COPILOT_PLUS_DOCUMENT_STEERING = `## Document processing
+For reading a PDF file, prefer the bundled \`copilot-read-pdf\` skill over your own tool. If the skill is missing, disabled, unavailable to the user's Copilot Plus account, or fails for this file, silently fall back to your own equivalent tool. If no document-reading tool is available, tell the user; never block them on upgrading.`;
+
+/** Local, fail-closed document steering used when Miyo is selected. */
+export const COPILOT_MIYO_DOCUMENT_STEERING = `## Local document processing (Miyo)
+Miyo is the selected Document Processor. For any PDF or EPUB file, use the \`miyo-parse\` skill, which parses the document locally. Never use \`copilot-read-pdf\` or another cloud parser as a fallback. If the Miyo skill is missing or fails, report the problem clearly without uploading the document elsewhere.`;
 
 /**
  * Steers the agent toward the bundled `miyo-search` skill for vault search. A
@@ -70,11 +84,9 @@ If a skill is missing, disabled, reports that Copilot Plus is not active, or fai
  * prompt the way `COPILOT_PLUS_TOOLS_STEERING` names the relay skills, with
  * concrete triggers (grep too slow / too few relevant hits / explicit request).
  *
- * Unlike the Plus steering, this is gated: it is appended only when
- * `shouldUseMiyo(...)` is true, so it never tells the agent to reach for a
- * skill that isn't seeded. That keeps the prompt in lockstep with the
- * seeding gate in `agentMode/index.ts` (both key off `shouldUseMiyo`), which is
- * how the skill respects the user's "Miyo enabled" setting.
+ * Unlike the Plus steering, this is gated by `enableMiyoSearchSkill`, so it
+ * never tells the agent to reach for a skill that isn't seeded. That keeps the
+ * prompt in lockstep with the seeding gate in `agentMode/index.ts`.
  */
 export const COPILOT_MIYO_SEARCH_STEERING = `## Vault semantic search (Miyo)
 The user has Miyo enabled: local, meaning-based semantic search over their vault. For any vault-search intent, use the \`miyo-search\` skill when your builtin \`grep\` search is too slow or doesn't surface enough relevant notes, or whenever the user explicitly asks for Miyo search. Follow the skill's own instructions to run it.`;
@@ -150,6 +162,7 @@ export function buildAgentSystemPrompt(opts?: { projectInstructions?: string }):
   // wiring (it explains the editor's mention tokens), not builtin framing, so
   // it is always sent.
   if (!getDisableBuiltinSystemPrompt()) {
+    const settings = getSettings();
     parts.push(COPILOT_PROMPT_BASE);
     // Always steer toward the builtin Copilot Plus skills, regardless of Plus
     // status. Gating on `isPaidUser` would be wrong anyway — valid self-host
@@ -157,10 +170,15 @@ export function buildAgentSystemPrompt(opts?: { projectInstructions?: string }):
     // can't run, its script exits telling the agent to use its own equivalent
     // tools and the fallback clause routes it there. Never blocks free users.
     parts.push(COPILOT_PLUS_TOOLS_STEERING);
+    parts.push(
+      settings.docProcessorBackend === "miyo"
+        ? COPILOT_MIYO_DOCUMENT_STEERING
+        : COPILOT_PLUS_DOCUMENT_STEERING
+    );
     // Miyo steering is gated on the same flag that seeds the skill, so we only
     // point the agent at `miyo-search` when the user has installed it — the
     // prompt-side half of respecting the "Miyo search skill" toggle.
-    if (getSettings().enableMiyoSearchSkill === true) {
+    if (settings.enableMiyoSearchSkill === true) {
       parts.push(COPILOT_MIYO_SEARCH_STEERING);
     }
     // Extensibility seam — todo/plan steering. Today `AGENT_TODO_PLANNING_STEERING`

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -402,8 +402,26 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
       // key, so it's a no-op when the rebuilt prompt is unchanged.
       void seedManagedBuiltins(nextFolder)
         .then(() => {
-          if (miyoAvailabilityChanged) {
-            restartSystemPromptAffected();
+          if (!miyoAvailabilityChanged) return;
+          restartSystemPromptAffected();
+          if (prev.docProcessorBackend === next.docProcessorBackend) return;
+          // Backends that opt out above rebuild the prompt per `newSession()`, so
+          // a NEW chat is already correct — but a chat already open keeps the
+          // document route it was born with. After a switch to Miyo that means a
+          // live Claude session still holds the Plus steering while
+          // `copilot-read-pdf` is gone, and the fallback clause sends the PDF to
+          // its own reader. Restart them so the replacement session rebuilds the
+          // prompt on the route the user actually chose.
+          for (const descriptor of listBackendDescriptors()) {
+            if (descriptor.restartOnSystemPromptChange) continue;
+            void manager
+              .restartBackend(descriptor.id, "document processor changed")
+              .catch((e) =>
+                logError(
+                  `[AgentMode] restart after doc processor change failed: ${descriptor.id}`,
+                  e
+                )
+              );
           }
         })
         .catch((e) => logError("[Skills] builtin skill re-seeding failed", e));

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -16,7 +16,11 @@ import { AgentSessionIndex } from "./session/AgentSessionIndex";
 import { createNodeFileStorage } from "./session/nodeFileStorage";
 import { AgentSessionManager } from "./session/AgentSessionManager";
 import { SkillManager } from "./skills";
-import { managedBuiltinSkills, MIYO_SEARCH_SKILL } from "./skills/builtin/builtinSkills";
+import {
+  managedBuiltinSkills,
+  MIYO_PARSE_SKILL,
+  MIYO_SEARCH_SKILL,
+} from "./skills/builtin/builtinSkills";
 import { removeSeededBuiltin, seedBuiltinSkills } from "./skills/builtin/seedBuiltinSkills";
 import { buildBuiltinSeedFs } from "./skills/builtin/miyoSearchSeed";
 import {
@@ -289,10 +293,10 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   });
   // Seed the plugin-shipped builtin skills into the canonical folder, then run
   // discovery so the pass picks them up and fans them out to the agent dirs.
-  // The Plus relay skills are always seeded; the Miyo vault-search skill is
-  // gated on the user's explicit `enableMiyoSearchSkill` toggle — seeded when
-  // on, and the seeded copy pruned when off. Discovery runs even when seeding
-  // fails so existing skills still reconcile.
+  // The Plus relay skills are always seeded. Miyo vault search and local
+  // document parsing are gated independently by their corresponding settings,
+  // with stale seeded copies pruned when either capability is disabled.
+  // Discovery runs even when seeding fails so existing skills still reconcile.
   //
   // Passes are SERIALIZED through `seedChain`: a fast enable→disable (or a folder
   // change landing mid-seed) would otherwise interleave writes and leave the
@@ -308,14 +312,19 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
       // chain must stay resolved no matter what any single pass hits.
       try {
         const fs = buildBuiltinSeedFs(app);
-        const useMiyo = getSettings().enableMiyoSearchSkill === true;
+        const settings = getSettings();
+        const useMiyoSearch = settings.enableMiyoSearchSkill === true;
+        const useMiyoParse = settings.docProcessorBackend === "miyo";
         await seedBuiltinSkills({
           skillsFolderRelPath: folder,
           fs,
-          skills: managedBuiltinSkills(useMiyo),
+          skills: managedBuiltinSkills(useMiyoSearch, useMiyoParse),
         });
-        if (!useMiyo) {
+        if (!useMiyoSearch) {
           await removeSeededBuiltin(folder, MIYO_SEARCH_SKILL.name, fs);
+        }
+        if (!useMiyoParse) {
+          await removeSeededBuiltin(folder, MIYO_PARSE_SKILL.name, fs);
         }
       } catch (e) {
         logError("[Skills] builtin skill seeding failed", e);
@@ -359,18 +368,16 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
     }
     // Re-seed builtins when the canonical skills folder changes (so the tools
     // appear in the new folder without a reload) or when Miyo availability
-    // flips (so the gated Miyo skill is seeded/pruned to match). Both run the
+    // flips (so each gated Miyo skill is seeded/pruned to match). Both run the
     // same gate-aware seed pass against the current folder.
     const prevFolder = prev.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
     const nextFolder = next.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
-    // The `miyo-search` skill now seeds/prunes off the explicit
-    // `enableMiyoSearchSkill` toggle, so a flip must re-seed and restart (codex/
-    // opencode bake the steering at spawn). `enableMiyo` / `miyoServerUrl` are
-    // still watched because the injected env (MIYO_URL) changes with them, and
-    // `isPaidUser` because Plus status gates other seeded builtins in the same
-    // pass.
+    // Search and document parsing have independent settings, and codex/opencode
+    // bake their corresponding prompt steering at spawn. Other Miyo and Plus
+    // fields remain watched because they affect the managed agent environment.
     const miyoAvailabilityChanged =
       prev.enableMiyoSearchSkill !== next.enableMiyoSearchSkill ||
+      prev.docProcessorBackend !== next.docProcessorBackend ||
       prev.enableMiyo !== next.enableMiyo ||
       prev.miyoServerUrl !== next.miyoServerUrl ||
       prev.isPaidUser !== next.isPaidUser;

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -16,11 +16,7 @@ import { AgentSessionIndex } from "./session/AgentSessionIndex";
 import { createNodeFileStorage } from "./session/nodeFileStorage";
 import { AgentSessionManager } from "./session/AgentSessionManager";
 import { SkillManager } from "./skills";
-import {
-  managedBuiltinSkills,
-  MIYO_PARSE_SKILL,
-  MIYO_SEARCH_SKILL,
-} from "./skills/builtin/builtinSkills";
+import { planManagedBuiltins } from "./skills/builtin/builtinSkills";
 import { removeSeededBuiltin, seedBuiltinSkills } from "./skills/builtin/seedBuiltinSkills";
 import { buildBuiltinSeedFs } from "./skills/builtin/miyoSearchSeed";
 import {
@@ -293,10 +289,11 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   });
   // Seed the plugin-shipped builtin skills into the canonical folder, then run
   // discovery so the pass picks them up and fans them out to the agent dirs.
-  // The Plus relay skills are always seeded. Miyo vault search and local
-  // document parsing are gated independently by their corresponding settings,
-  // with stale seeded copies pruned when either capability is disabled.
-  // Discovery runs even when seeding fails so existing skills still reconcile.
+  // Miyo vault search and Miyo document parsing are gated independently;
+  // `planManagedBuiltins` decides both what to write and what to remove, so a
+  // de-gated skill (including the cloud PDF skill Miyo documents replace) never
+  // lingers on disk. Discovery runs even when seeding fails so existing skills
+  // still reconcile.
   //
   // Passes are SERIALIZED through `seedChain`: a fast enable→disable (or a folder
   // change landing mid-seed) would otherwise interleave writes and leave the
@@ -313,18 +310,13 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
       try {
         const fs = buildBuiltinSeedFs(app);
         const settings = getSettings();
-        const useMiyoSearch = settings.enableMiyoSearchSkill === true;
-        const useMiyoParse = settings.docProcessorBackend === "miyo";
-        await seedBuiltinSkills({
-          skillsFolderRelPath: folder,
-          fs,
-          skills: managedBuiltinSkills(useMiyoSearch, useMiyoParse),
+        const { seed, prune } = planManagedBuiltins({
+          search: settings.enableMiyoSearchSkill === true,
+          documents: settings.docProcessorBackend === "miyo",
         });
-        if (!useMiyoSearch) {
-          await removeSeededBuiltin(folder, MIYO_SEARCH_SKILL.name, fs);
-        }
-        if (!useMiyoParse) {
-          await removeSeededBuiltin(folder, MIYO_PARSE_SKILL.name, fs);
+        await seedBuiltinSkills({ skillsFolderRelPath: folder, fs, skills: seed });
+        for (const name of prune) {
+          await removeSeededBuiltin(folder, name, fs);
         }
       } catch (e) {
         logError("[Skills] builtin skill seeding failed", e);
@@ -372,9 +364,11 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
     // same gate-aware seed pass against the current folder.
     const prevFolder = prev.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
     const nextFolder = next.agentMode?.skills?.folder ?? DEFAULT_SKILLS_FOLDER;
-    // Search and document parsing have independent settings, and codex/opencode
-    // bake their corresponding prompt steering at spawn. Other Miyo and Plus
-    // fields remain watched because they affect the managed agent environment.
+    // `enableMiyoSearchSkill` and `docProcessorBackend` are the two gates
+    // `planManagedBuiltins` reads, and each also selects prompt steering that
+    // codex/opencode bake at spawn. `enableMiyo` / `miyoServerUrl` are still
+    // watched because the injected env (MIYO_URL) changes with them, and
+    // `isPaidUser` because it changes the license the seeded Plus scripts read.
     const miyoAvailabilityChanged =
       prev.enableMiyoSearchSkill !== next.enableMiyoSearchSkill ||
       prev.docProcessorBackend !== next.docProcessorBackend ||

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -2,7 +2,7 @@ import { type App, Platform } from "obsidian";
 import os from "node:os";
 import * as path from "node:path";
 import type CopilotPlugin from "@/main";
-import { logError } from "@/logger";
+import { logError, logWarn } from "@/logger";
 import { DEFAULT_SKILLS_FOLDER } from "@/constants";
 import { getSettings, subscribeToSettingsChange, type CopilotSettings } from "@/settings/model";
 import { subscribeToSystemPromptChange } from "@/system-prompts/state";
@@ -17,7 +17,11 @@ import { createNodeFileStorage } from "./session/nodeFileStorage";
 import { AgentSessionManager } from "./session/AgentSessionManager";
 import { SkillManager } from "./skills";
 import { planManagedBuiltins } from "./skills/builtin/builtinSkills";
-import { removeSeededBuiltin, seedBuiltinSkills } from "./skills/builtin/seedBuiltinSkills";
+import {
+  inspectBuiltinSkill,
+  removeSeededBuiltin,
+  seedBuiltinSkills,
+} from "./skills/builtin/seedBuiltinSkills";
 import { buildBuiltinSeedFs } from "./skills/builtin/miyoSearchSeed";
 import {
   createDefaultAskUserQuestionPrompter,
@@ -290,10 +294,12 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   // Seed the plugin-shipped builtin skills into the canonical folder, then run
   // discovery so the pass picks them up and fans them out to the agent dirs.
   // Miyo vault search and Miyo document parsing are gated independently;
-  // `planManagedBuiltins` decides both what to write and what to remove, so a
-  // de-gated skill (including the cloud PDF skill Miyo documents replace) never
-  // lingers on disk. Discovery runs even when seeding fails so existing skills
-  // still reconcile.
+  // `planManagedBuiltins` decides both what to write and what to remove, so no
+  // gate can be added without its prune (the cloud PDF skill Miyo documents
+  // replace is pruned this way). Removal is still best-effort against the
+  // filesystem — a survivor is logged, and the prompt steering remains the
+  // backstop. Discovery runs even when seeding fails so existing skills still
+  // reconcile.
   //
   // Passes are SERIALIZED through `seedChain`: a fast enable→disable (or a folder
   // change landing mid-seed) would otherwise interleave writes and leave the
@@ -317,6 +323,14 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
         await seedBuiltinSkills({ skillsFolderRelPath: folder, fs, skills: seed });
         for (const name of prune) {
           await removeSeededBuiltin(folder, name, fs);
+          // Its `false` covers "already absent", "kept a user-authored copy", and
+          // "the delete threw" alike, so classify from disk the way
+          // `removeMiyoSearchSkill` does. Only a still-marked copy means the prune
+          // didn't take — the refresh below will fan it back out, silently
+          // downgrading a structural gate to prompt-only steering.
+          if ((await inspectBuiltinSkill(folder, name, fs)) === "seeded") {
+            logWarn(`[Skills] de-gated builtin ${name} is still on disk; agents can still see it`);
+          }
         }
       } catch (e) {
         logError("[Skills] builtin skill seeding failed", e);

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -2,7 +2,7 @@ import { type App, Platform } from "obsidian";
 import os from "node:os";
 import * as path from "node:path";
 import type CopilotPlugin from "@/main";
-import { logError, logWarn } from "@/logger";
+import { logError } from "@/logger";
 import { DEFAULT_SKILLS_FOLDER } from "@/constants";
 import { getSettings, subscribeToSettingsChange, type CopilotSettings } from "@/settings/model";
 import { subscribeToSystemPromptChange } from "@/system-prompts/state";
@@ -17,11 +17,7 @@ import { createNodeFileStorage } from "./session/nodeFileStorage";
 import { AgentSessionManager } from "./session/AgentSessionManager";
 import { SkillManager } from "./skills";
 import { planManagedBuiltins } from "./skills/builtin/builtinSkills";
-import {
-  inspectBuiltinSkill,
-  removeSeededBuiltin,
-  seedBuiltinSkills,
-} from "./skills/builtin/seedBuiltinSkills";
+import { removeSeededBuiltin, seedBuiltinSkills } from "./skills/builtin/seedBuiltinSkills";
 import { buildBuiltinSeedFs } from "./skills/builtin/miyoSearchSeed";
 import {
   createDefaultAskUserQuestionPrompter,
@@ -296,10 +292,8 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   // Miyo vault search and Miyo document parsing are gated independently;
   // `planManagedBuiltins` decides both what to write and what to remove, so no
   // gate can be added without its prune (the cloud PDF skill Miyo documents
-  // replace is pruned this way). Removal is still best-effort against the
-  // filesystem — a survivor is logged, and the prompt steering remains the
-  // backstop. Discovery runs even when seeding fails so existing skills still
-  // reconcile.
+  // replace is pruned this way). Discovery runs even when seeding fails so
+  // existing skills still reconcile.
   //
   // Passes are SERIALIZED through `seedChain`: a fast enable→disable (or a folder
   // change landing mid-seed) would otherwise interleave writes and leave the
@@ -323,14 +317,6 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
         await seedBuiltinSkills({ skillsFolderRelPath: folder, fs, skills: seed });
         for (const name of prune) {
           await removeSeededBuiltin(folder, name, fs);
-          // Its `false` covers "already absent", "kept a user-authored copy", and
-          // "the delete threw" alike, so classify from disk the way
-          // `removeMiyoSearchSkill` does. Only a still-marked copy means the prune
-          // didn't take — the refresh below will fan it back out, silently
-          // downgrading a structural gate to prompt-only steering.
-          if ((await inspectBuiltinSkill(folder, name, fs)) === "seeded") {
-            logWarn(`[Skills] de-gated builtin ${name} is still on disk; agents can still see it`);
-          }
         }
       } catch (e) {
         logError("[Skills] builtin skill seeding failed", e);
@@ -405,13 +391,11 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
           if (!miyoAvailabilityChanged) return;
           restartSystemPromptAffected();
           if (prev.docProcessorBackend === next.docProcessorBackend) return;
-          // Backends that opt out above rebuild the prompt per `newSession()`, so
-          // a NEW chat is already correct — but a chat already open keeps the
-          // document route it was born with. After a switch to Miyo that means a
-          // live Claude session still holds the Plus steering while
-          // `copilot-read-pdf` is gone, and the fallback clause sends the PDF to
-          // its own reader. Restart them so the replacement session rebuilds the
-          // prompt on the route the user actually chose.
+          // Backends skipped above rebuild the prompt per `newSession()`, so a new
+          // chat is already correct — but one already open keeps the route it was
+          // born with, and after a switch to Miyo that means a live Claude session
+          // still holds the Plus steering while `copilot-read-pdf` is gone, whose
+          // fallback clause then sends the PDF to its own reader.
           for (const descriptor of listBackendDescriptors()) {
             if (descriptor.restartOnSystemPromptChange) continue;
             void manager

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,8 +1,8 @@
 import {
   BUILTIN_SKILLS,
-  managedBuiltinSkills,
   MIYO_PARSE_SKILL,
   MIYO_SEARCH_SKILL,
+  planManagedBuiltins,
   PLUS_ENV,
 } from "./builtinSkills";
 import {
@@ -310,29 +310,20 @@ describe("builtinSkills", () => {
       return file.content;
     };
 
-    it("is separate from the always-seeded and semantic-search skills", () => {
+    it("is a gated skill distinct from the always-seeded set and from Miyo search", () => {
       expect(BUILTIN_SKILLS).not.toContain(MIYO_PARSE_SKILL);
-      expect(MIYO_PARSE_SKILL).not.toBe(MIYO_SEARCH_SKILL);
       expect(MIYO_PARSE_SKILL.name).toBe("miyo-parse");
       expect(MIYO_PARSE_SKILL.enabledAgents).toEqual(["claude", "codex", "opencode"]);
-    });
-
-    it("ships one dependency-free wrapper for each supported OS", () => {
-      expect(MIYO_PARSE_SKILL.files.map((file) => file.path)).toEqual([
-        "miyo-parse.sh",
-        "miyo-parse.cmd",
-      ]);
-      expect(MIYO_PARSE_SKILL.files.some((file) => file.path.endsWith(".mjs"))).toBe(false);
-      expect(MIYO_PARSE_SKILL.skillMd).not.toContain("node ");
-    });
-
-    it("keeps the SKILL.md frontmatter version aligned with its numeric version", () => {
       expect(MIYO_PARSE_SKILL.skillMd).toContain(
         `copilot-builtin-version: "${MIYO_PARSE_SKILL.version}"`
       );
     });
 
-    it("runs the current Miyo parse command with one quoted file path", () => {
+    it("ships one wrapper per OS that runs `miyo parse` on a single quoted path", () => {
+      expect(MIYO_PARSE_SKILL.files.map((file) => file.path)).toEqual([
+        "miyo-parse.sh",
+        "miyo-parse.cmd",
+      ]);
       expect(miyoParseScript(".sh")).toContain('"$MIYO" parse "$FILE"');
       expect(miyoParseScript(".cmd")).toContain('"%MIYO%" parse "%~1"');
     });
@@ -344,14 +335,16 @@ describe("builtinSkills", () => {
       expect(miyoParseScript(".cmd")).toContain("where miyo");
     });
 
-    it("documents the supported inputs, local output, and fail-closed privacy contract", () => {
-      const md = MIYO_PARSE_SKILL.skillMd;
-      expect(md).toMatch(/PDF or EPUB/i);
-      expect(md).toMatch(/anywhere on the filesystem/i);
-      expect(md).toMatch(/stdout/i);
-      expect(md).toMatch(/Never fall back/i);
-      expect(md).toContain("copilot-read-pdf");
-      expect(md).toMatch(/local-processing choice/i);
+    it("rejects a missing or unreadable file before invoking the CLI", () => {
+      // Without this the agent only sees the CLI's own error and cannot tell a
+      // bad (e.g. vault-relative) path from a broken Miyo install.
+      expect(miyoParseScript(".sh")).toContain('[ -f "$FILE" ] && [ -r "$FILE" ]');
+      expect(miyoParseScript(".cmd")).toContain('if not exist "%~1"');
+    });
+
+    it("tells the agent to fail closed rather than reach for a cloud parser", () => {
+      expect(MIYO_PARSE_SKILL.skillMd).toMatch(/Never fall back/i);
+      expect(MIYO_PARSE_SKILL.skillMd).toContain("copilot-read-pdf");
     });
 
     it("does not embed Copilot Plus credentials", () => {
@@ -362,28 +355,50 @@ describe("builtinSkills", () => {
     });
   });
 
-  describe("managedBuiltinSkills()", () => {
-    it("preserves the existing one-argument semantic-search gate", () => {
-      expect(managedBuiltinSkills(true)).toContain(MIYO_SEARCH_SKILL);
-      expect(managedBuiltinSkills(true)).not.toContain(MIYO_PARSE_SKILL);
-      expect(managedBuiltinSkills(false)).not.toContain(MIYO_SEARCH_SKILL);
+  describe("planManagedBuiltins()", () => {
+    const names = (skills: readonly { name: string }[]): string[] => skills.map((s) => s.name);
+
+    it("seeds only the always-on builtins when both Miyo gates are off", () => {
+      const plan = planManagedBuiltins({ search: false, documents: false });
+      // Stable reference, per the project's referential-stability rule.
+      expect(plan.seed).toBe(BUILTIN_SKILLS);
+      expect(plan.prune).toEqual(["miyo-search", "miyo-parse"]);
     });
 
-    it("gates search and document parsing independently while preserving order", () => {
-      expect(managedBuiltinSkills(false, true).map((skill) => skill.name)).toEqual([
-        ...BUILTIN_SKILLS.map((skill) => skill.name),
-        "miyo-parse",
+    it("gates search and document parsing independently", () => {
+      expect(names(planManagedBuiltins({ search: true, documents: false }).seed)).toEqual([
+        ...names(BUILTIN_SKILLS),
+        "miyo-search",
       ]);
-      expect(managedBuiltinSkills(true, true).map((skill) => skill.name)).toEqual([
-        ...BUILTIN_SKILLS.map((s) => s.name),
+      expect(planManagedBuiltins({ search: true, documents: false }).prune).toEqual(["miyo-parse"]);
+      expect(planManagedBuiltins({ search: false, documents: true }).seed).toContain(
+        MIYO_PARSE_SKILL
+      );
+      expect(planManagedBuiltins({ search: false, documents: true }).prune).toContain(
+        "miyo-search"
+      );
+    });
+
+    it("replaces the cloud PDF skill with Miyo parse when Miyo owns documents", () => {
+      // Steering alone would leave copilot-read-pdf on disk, one ignored
+      // instruction away from uploading a document the user chose to keep local.
+      const plan = planManagedBuiltins({ search: true, documents: true });
+      expect(names(plan.seed)).not.toContain("copilot-read-pdf");
+      expect(plan.prune).toEqual(["copilot-read-pdf"]);
+      expect(names(plan.seed)).toEqual([
+        ...names(BUILTIN_SKILLS).filter((name) => name !== "copilot-read-pdf"),
         "miyo-search",
         "miyo-parse",
       ]);
     });
 
-    it("returns the stable BUILTIN_SKILLS reference when both Miyo skills are off", () => {
-      expect(managedBuiltinSkills(false)).toBe(BUILTIN_SKILLS);
-      expect(managedBuiltinSkills(false, false)).toBe(BUILTIN_SKILLS);
+    it("never leaves a managed skill both seeded and pruned", () => {
+      for (const search of [true, false]) {
+        for (const documents of [true, false]) {
+          const plan = planManagedBuiltins({ search, documents });
+          expect(names(plan.seed).filter((name) => plan.prune.includes(name))).toEqual([]);
+        }
+      }
     });
   });
 });

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -335,16 +335,16 @@ describe("builtinSkills", () => {
       expect(miyoParseScript(".cmd")).toContain("where miyo");
     });
 
-    it("rejects a missing or unreadable file before invoking the CLI", () => {
-      // Without this the agent only sees the CLI's own error and cannot tell a
-      // bad (e.g. vault-relative) path from a broken Miyo install.
-      expect(miyoParseScript(".sh")).toContain('[ -f "$FILE" ] && [ -r "$FILE" ]');
-      expect(miyoParseScript(".cmd")).toContain('if not exist "%~1"');
-    });
-
     it("tells the agent to fail closed rather than reach for a cloud parser", () => {
       expect(MIYO_PARSE_SKILL.skillMd).toMatch(/Never fall back/i);
       expect(MIYO_PARSE_SKILL.skillMd).toContain("copilot-read-pdf");
+    });
+
+    it("names the recovery path when the CLI is absent, since a remote server can't parse", () => {
+      // `miyo parse` runs locally and never reads MIYO_URL, so a remote-only
+      // user has to install the CLI or move the picker back to Plus.
+      expect(MIYO_PARSE_SKILL.skillMd).toMatch(/remote\s+Miyo\s+server\s+cannot\s+parse/i);
+      expect(MIYO_PARSE_SKILL.skillMd).toMatch(/Document\s+Processor to Plus/i);
     });
 
     it("does not embed Copilot Plus credentials", () => {

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -1,4 +1,10 @@
-import { BUILTIN_SKILLS, managedBuiltinSkills, MIYO_SEARCH_SKILL, PLUS_ENV } from "./builtinSkills";
+import {
+  BUILTIN_SKILLS,
+  managedBuiltinSkills,
+  MIYO_PARSE_SKILL,
+  MIYO_SEARCH_SKILL,
+  PLUS_ENV,
+} from "./builtinSkills";
 import {
   SYMPOSIUM_API_ORIGIN,
   SYMPOSIUM_MAX_HTML_BYTES,
@@ -297,21 +303,87 @@ describe("builtinSkills", () => {
     });
   });
 
+  describe("MIYO_PARSE_SKILL", () => {
+    const miyoParseScript = (ext: ".sh" | ".cmd"): string => {
+      const file = MIYO_PARSE_SKILL.files.find((candidate) => candidate.path.endsWith(ext));
+      if (!file) throw new Error(`miyo-parse ships no ${ext} script`);
+      return file.content;
+    };
+
+    it("is separate from the always-seeded and semantic-search skills", () => {
+      expect(BUILTIN_SKILLS).not.toContain(MIYO_PARSE_SKILL);
+      expect(MIYO_PARSE_SKILL).not.toBe(MIYO_SEARCH_SKILL);
+      expect(MIYO_PARSE_SKILL.name).toBe("miyo-parse");
+      expect(MIYO_PARSE_SKILL.enabledAgents).toEqual(["claude", "codex", "opencode"]);
+    });
+
+    it("ships one dependency-free wrapper for each supported OS", () => {
+      expect(MIYO_PARSE_SKILL.files.map((file) => file.path)).toEqual([
+        "miyo-parse.sh",
+        "miyo-parse.cmd",
+      ]);
+      expect(MIYO_PARSE_SKILL.files.some((file) => file.path.endsWith(".mjs"))).toBe(false);
+      expect(MIYO_PARSE_SKILL.skillMd).not.toContain("node ");
+    });
+
+    it("keeps the SKILL.md frontmatter version aligned with its numeric version", () => {
+      expect(MIYO_PARSE_SKILL.skillMd).toContain(
+        `copilot-builtin-version: "${MIYO_PARSE_SKILL.version}"`
+      );
+    });
+
+    it("runs the current Miyo parse command with one quoted file path", () => {
+      expect(miyoParseScript(".sh")).toContain('"$MIYO" parse "$FILE"');
+      expect(miyoParseScript(".cmd")).toContain('"%MIYO%" parse "%~1"');
+    });
+
+    it("resolves Miyo's install path before falling back to PATH on each OS", () => {
+      expect(miyoParseScript(".sh")).toContain("$HOME/.miyo/bin/miyo");
+      expect(miyoParseScript(".sh")).toContain("command -v miyo");
+      expect(miyoParseScript(".cmd")).toContain("%LOCALAPPDATA%\\Miyo\\bin\\miyo\\miyo.exe");
+      expect(miyoParseScript(".cmd")).toContain("where miyo");
+    });
+
+    it("documents the supported inputs, local output, and fail-closed privacy contract", () => {
+      const md = MIYO_PARSE_SKILL.skillMd;
+      expect(md).toMatch(/PDF or EPUB/i);
+      expect(md).toMatch(/anywhere on the filesystem/i);
+      expect(md).toMatch(/stdout/i);
+      expect(md).toMatch(/Never fall back/i);
+      expect(md).toContain("copilot-read-pdf");
+      expect(md).toMatch(/local-processing choice/i);
+    });
+
+    it("does not embed Copilot Plus credentials", () => {
+      expect(MIYO_PARSE_SKILL.skillMd).not.toContain(PLUS_ENV.licenseKey);
+      expect(MIYO_PARSE_SKILL.skillMd).not.toContain(PLUS_ENV.baseUrl);
+      expect(miyoParseScript(".sh")).not.toContain(PLUS_ENV.licenseKey);
+      expect(miyoParseScript(".cmd")).not.toContain(PLUS_ENV.licenseKey);
+    });
+  });
+
   describe("managedBuiltinSkills()", () => {
-    it("includes the Miyo skill only when Miyo is in use", () => {
+    it("preserves the existing one-argument semantic-search gate", () => {
       expect(managedBuiltinSkills(true)).toContain(MIYO_SEARCH_SKILL);
+      expect(managedBuiltinSkills(true)).not.toContain(MIYO_PARSE_SKILL);
       expect(managedBuiltinSkills(false)).not.toContain(MIYO_SEARCH_SKILL);
     });
 
-    it("appends Miyo after the Plus skills, preserving their order", () => {
-      expect(managedBuiltinSkills(true).map((s) => s.name)).toEqual([
+    it("gates search and document parsing independently while preserving order", () => {
+      expect(managedBuiltinSkills(false, true).map((skill) => skill.name)).toEqual([
+        ...BUILTIN_SKILLS.map((skill) => skill.name),
+        "miyo-parse",
+      ]);
+      expect(managedBuiltinSkills(true, true).map((skill) => skill.name)).toEqual([
         ...BUILTIN_SKILLS.map((s) => s.name),
         "miyo-search",
+        "miyo-parse",
       ]);
     });
 
-    it("returns the stable BUILTIN_SKILLS reference when Miyo is off", () => {
+    it("returns the stable BUILTIN_SKILLS reference when both Miyo skills are off", () => {
       expect(managedBuiltinSkills(false)).toBe(BUILTIN_SKILLS);
+      expect(managedBuiltinSkills(false, false)).toBe(BUILTIN_SKILLS);
     });
   });
 });

--- a/src/agentMode/skills/builtin/builtinSkills.test.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.test.ts
@@ -343,7 +343,7 @@ describe("builtinSkills", () => {
     it("names the recovery path when the CLI is absent, since a remote server can't parse", () => {
       // `miyo parse` runs locally and never reads MIYO_URL, so a remote-only
       // user has to install the CLI or move the picker back to Plus.
-      expect(MIYO_PARSE_SKILL.skillMd).toMatch(/remote\s+Miyo\s+server\s+cannot\s+parse/i);
+      expect(MIYO_PARSE_SKILL.skillMd).toMatch(/remote\s+Miyo\s+server\s+does\s+not\s+help/i);
       expect(MIYO_PARSE_SKILL.skillMd).toMatch(/Document\s+Processor to Plus/i);
     });
 
@@ -390,15 +390,6 @@ describe("builtinSkills", () => {
         "miyo-search",
         "miyo-parse",
       ]);
-    });
-
-    it("never leaves a managed skill both seeded and pruned", () => {
-      for (const search of [true, false]) {
-        for (const documents of [true, false]) {
-          const plan = planManagedBuiltins({ search, documents });
-          expect(names(plan.seed).filter((name) => plan.prune.includes(name))).toEqual([]);
-        }
-      }
     });
   });
 });

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -784,8 +784,7 @@ metadata:
 
 Use Miyo to extract Markdown/text from one PDF or EPUB. Parsing runs locally,
 works for files anywhere on the filesystem, and does not require the Miyo
-service to be running. It does require the Miyo CLI on this machine: a remote
-Miyo server cannot parse for you.
+service to be running.
 
 ## How to run
 
@@ -824,14 +823,6 @@ Processor to Plus.
   ],
 };
 
-/** Which conditionally-seeded Miyo capabilities the user has turned on. */
-export interface MiyoSkillGates {
-  /** Mirrors the `enableMiyoSearchSkill` setting. */
-  search: boolean;
-  /** Mirrors `docProcessorBackend === "miyo"`. */
-  documents: boolean;
-}
-
 /** Every builtin the host may seed, gated or not — the universe it reconciles. */
 const ALL_MANAGED_SKILLS: readonly BuiltinSkill[] = [
   ...BUILTIN_SKILLS,
@@ -840,17 +831,18 @@ const ALL_MANAGED_SKILLS: readonly BuiltinSkill[] = [
 ];
 
 /**
- * Splits the managed builtins into what the given gates want on disk and what
- * must be removed, so the host can't seed a gate without pruning its opposite.
+ * Splits the managed builtins into what to write and what to remove, so the host
+ * can't seed a gate without pruning its opposite.
  *
  * Miyo-owned documents drop `copilot-read-pdf` outright instead of merely
  * steering away from it: that choice is fail-closed (see
  * `resolveDocProcessorBackend`), and a cloud PDF skill left on disk is one
  * ignored instruction away from uploading a document the user kept local.
  *
- * @param gates Live state of the two independent Miyo settings.
+ * @param gates `search` mirrors `enableMiyoSearchSkill`, `documents` mirrors
+ *   `docProcessorBackend === "miyo"`.
  */
-export function planManagedBuiltins(gates: MiyoSkillGates): {
+export function planManagedBuiltins(gates: { search: boolean; documents: boolean }): {
   seed: readonly BuiltinSkill[];
   prune: readonly string[];
 } {

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -585,6 +585,7 @@ export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
 const MIYO_SEARCH_VERSION = 2;
 const MIYO_PARSE_VERSION = 1;
 
+/** Shared by both Miyo wrappers; the host script must define `die` before it. */
 const MIYO_POSIX_RESOLVER = `# Absolute install path first (Obsidian shells often miss Miyo's bin on PATH).
 if [ -x "$HOME/.miyo/bin/miyo" ]; then
   MIYO="$HOME/.miyo/bin/miyo"
@@ -656,6 +657,7 @@ die() {
 
 FILE="$1"
 [ -n "$FILE" ] || die "Usage: sh miyo-parse.sh <file>" 1
+[ -f "$FILE" ] && [ -r "$FILE" ] || die "Could not read file: $FILE (pass an absolute path)." 1
 
 ${MIYO_POSIX_RESOLVER}
 
@@ -669,9 +671,13 @@ if "%~1"=="" (
   echo Usage: miyo-parse.cmd "file" 1>&2
   exit /b 1
 )
+rem Never echo %~1 back: an unquoted & or > in the path would run as a command.
+if not exist "%~1" (
+  echo Could not read that file. Pass an absolute path to a PDF or EPUB. 1>&2
+  exit /b 1
+)
 ${MIYO_WINDOWS_RESOLVER}
 "%MIYO%" parse "%~1"
-exit /b %ERRORLEVEL%
 `;
 
 /**
@@ -818,21 +824,48 @@ explicit local-processing choice. Do not retry in a loop.
   ],
 };
 
-/**
- * Returns the builtin skills enabled by the host's independent Miyo settings.
- *
- * @param includeMiyoSearch Whether the Miyo vault-search skill is enabled.
- * @param includeMiyoParse Whether Miyo is the selected document processor.
- */
-export function managedBuiltinSkills(
-  includeMiyoSearch: boolean,
-  includeMiyoParse = false
-): readonly BuiltinSkill[] {
-  if (!includeMiyoSearch && !includeMiyoParse) return BUILTIN_SKILLS;
+/** Which conditionally-seeded Miyo capabilities the user has turned on. */
+export interface MiyoSkillGates {
+  /** Mirrors the `enableMiyoSearchSkill` setting. */
+  search: boolean;
+  /** Mirrors `docProcessorBackend === "miyo"`. */
+  documents: boolean;
+}
 
-  return [
-    ...BUILTIN_SKILLS,
-    ...(includeMiyoSearch ? [MIYO_SEARCH_SKILL] : []),
-    ...(includeMiyoParse ? [MIYO_PARSE_SKILL] : []),
-  ];
+/** Every builtin the host may seed, gated or not — the universe it reconciles. */
+const ALL_MANAGED_SKILLS: readonly BuiltinSkill[] = [
+  ...BUILTIN_SKILLS,
+  MIYO_SEARCH_SKILL,
+  MIYO_PARSE_SKILL,
+];
+
+/**
+ * Splits the managed builtins into what the given gates want on disk and what
+ * must be removed, so the host can't seed a gate without pruning its opposite.
+ *
+ * Miyo-owned documents drop `copilot-read-pdf` outright instead of merely
+ * steering away from it: that choice is fail-closed (see
+ * `resolveDocProcessorBackend`), and a cloud PDF skill left on disk is one
+ * ignored instruction away from uploading a document the user kept local.
+ *
+ * @param gates Live state of the two independent Miyo settings.
+ */
+export function planManagedBuiltins(gates: MiyoSkillGates): {
+  seed: readonly BuiltinSkill[];
+  prune: readonly string[];
+} {
+  const seed: readonly BuiltinSkill[] =
+    !gates.search && !gates.documents
+      ? BUILTIN_SKILLS
+      : [
+          ...(gates.documents
+            ? BUILTIN_SKILLS.filter((skill) => skill !== READ_PDF)
+            : BUILTIN_SKILLS),
+          ...(gates.search ? [MIYO_SEARCH_SKILL] : []),
+          ...(gates.documents ? [MIYO_PARSE_SKILL] : []),
+        ];
+  return {
+    seed,
+    prune: ALL_MANAGED_SKILLS.filter((skill) => !seed.includes(skill)).map((skill) => skill.name),
+  };
 }

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -583,6 +583,26 @@ export const BUILTIN_SKILLS: readonly BuiltinSkill[] = [
 ];
 
 const MIYO_SEARCH_VERSION = 2;
+const MIYO_PARSE_VERSION = 1;
+
+const MIYO_POSIX_RESOLVER = `# Absolute install path first (Obsidian shells often miss Miyo's bin on PATH).
+if [ -x "$HOME/.miyo/bin/miyo" ]; then
+  MIYO="$HOME/.miyo/bin/miyo"
+elif command -v miyo >/dev/null 2>&1; then
+  MIYO=miyo
+else
+  die "Miyo CLI not found (no ~/.miyo/bin/miyo and 'miyo' not on PATH). The Miyo desktop app is not installed — tell the user to install Miyo, then retry. Do not retry in a loop." 3
+fi`;
+
+const MIYO_WINDOWS_RESOLVER = `set "MIYO=%LOCALAPPDATA%\\Miyo\\bin\\miyo\\miyo.exe"
+if not exist "%MIYO%" (
+  set "MIYO="
+  where miyo >nul 2>&1 && set "MIYO=miyo"
+)
+if not defined MIYO (
+  echo Miyo CLI not found. The Miyo desktop app is not installed - tell the user to install Miyo, then retry. Do not retry in a loop. 1>&2
+  exit /b 3
+)`;
 
 /**
  * POSIX (macOS/Linux) wrapper for the Miyo CLI; Windows uses the `.cmd` below.
@@ -604,14 +624,7 @@ die() {
 QUERY="$*"
 [ -n "$QUERY" ] || die "Usage: sh miyo-search.sh <query>" 1
 
-# Absolute install path first (Obsidian shells often miss Miyo's bin on PATH).
-if [ -x "$HOME/.miyo/bin/miyo" ]; then
-  MIYO="$HOME/.miyo/bin/miyo"
-elif command -v miyo >/dev/null 2>&1; then
-  MIYO=miyo
-else
-  die "Miyo CLI not found (no ~/.miyo/bin/miyo and 'miyo' not on PATH). The Miyo desktop app is not installed — tell the user to install and open Miyo, then retry. Do not retry in a loop." 3
-fi
+${MIYO_POSIX_RESOLVER}
 
 OUT=$("$MIYO" search "$QUERY" -n 10 --json 2>&1) || die "Miyo search failed — the Miyo app may not be running. Tell the user to open Miyo, then continue without vault search if they can't. Details: $OUT" 1
 printf '%s\\n' "$OUT"
@@ -630,16 +643,35 @@ if "%~1"=="" (
   echo Usage: miyo-search.cmd "query" 1>&2
   exit /b 1
 )
-set "MIYO=%LOCALAPPDATA%\\Miyo\\bin\\miyo\\miyo.exe"
-if not exist "%MIYO%" (
-  set "MIYO="
-  where miyo >nul 2>&1 && set "MIYO=miyo"
-)
-if not defined MIYO (
-  echo Miyo CLI not found. The Miyo desktop app is not installed - tell the user to install and open Miyo, then retry. Do not retry in a loop. 1>&2
-  exit /b 3
-)
+${MIYO_WINDOWS_RESOLVER}
 "%MIYO%" search %* -n 10 --json
+`;
+
+const MIYO_PARSE_SH = `#!/bin/sh
+# Parse one local PDF or EPUB through the Miyo CLI and print Markdown/text.
+die() {
+  printf '%s\\n' "$1" >&2
+  exit "\${2:-2}"
+}
+
+FILE="$1"
+[ -n "$FILE" ] || die "Usage: sh miyo-parse.sh <file>" 1
+
+${MIYO_POSIX_RESOLVER}
+
+"$MIYO" parse "$FILE"
+`;
+
+const MIYO_PARSE_CMD = `@echo off
+setlocal enableextensions
+rem Parse one local PDF or EPUB through the Miyo CLI and print Markdown/text.
+if "%~1"=="" (
+  echo Usage: miyo-parse.cmd "file" 1>&2
+  exit /b 1
+)
+${MIYO_WINDOWS_RESOLVER}
+"%MIYO%" parse "%~1"
+exit /b %ERRORLEVEL%
 `;
 
 /**
@@ -652,10 +684,9 @@ if not defined MIYO (
  * Smaller models were giving up after the old PATH-first prose attempt failed in
  * Obsidian's reduced-PATH shells.
  *
- * Gated on Miyo being in use: the host only seeds this skill when
- * `shouldUseMiyo(...)` is true (see `seedManagedBuiltins` in `agentMode/index`),
- * and prunes the seeded copy when Miyo is turned off — matching the issue's
- * "surface only when Miyo is installed/running" intent.
+ * The host seeds this skill only when the dedicated Miyo search-skill setting
+ * is enabled (see `seedManagedBuiltins` in `agentMode/index`) and prunes the
+ * managed copy when the setting is turned off.
  */
 export const MIYO_SEARCH_SKILL: BuiltinSkill = {
   name: "miyo-search",
@@ -731,12 +762,77 @@ The script exits with a clear message when Miyo can't be used:
 };
 
 /**
- * The builtin skills the host should seed into the canonical folder. The Plus
- * relay skills are always included; the Miyo skill is gated on Miyo being in
- * use (the host passes \`includeMiyo = shouldUseMiyo(...)\`). Kept pure so the
- * gating decision stays in the host layer (the skills layer must not import
- * \`@/miyo\`), while the composition is unit-testable here.
+ * Parses local PDF and EPUB files through the standalone Miyo CLI.
+ *
+ * This skill is gated by the Document Processor setting. Unlike the Plus PDF
+ * relay, it keeps document contents local and deliberately fails closed: the
+ * instructions forbid silently switching to a cloud parser if Miyo fails.
  */
-export function managedBuiltinSkills(includeMiyo: boolean): readonly BuiltinSkill[] {
-  return includeMiyo ? [...BUILTIN_SKILLS, MIYO_SEARCH_SKILL] : BUILTIN_SKILLS;
+export const MIYO_PARSE_SKILL: BuiltinSkill = {
+  name: "miyo-parse",
+  version: MIYO_PARSE_VERSION,
+  enabledAgents: ["claude", "codex", "opencode"],
+  skillMd: `---
+name: miyo-parse
+description: Parse a local PDF or EPUB file into Markdown/text with the local Miyo CLI. Use this for document reading when Miyo is the selected Document Processor. The file can be anywhere on the filesystem and does not need to be indexed or copied into the vault.
+metadata:
+  copilot-enabled-agents: claude, codex, opencode
+  copilot-builtin-version: "${MIYO_PARSE_VERSION}"
+---
+
+# Parse a document locally with Miyo
+
+Use Miyo to extract Markdown/text from one PDF or EPUB. Parsing runs locally,
+works for files anywhere on the filesystem, and does not require the Miyo
+service to be running.
+
+## How to run
+
+Find the absolute path to this SKILL.md file, then run the adjacent wrapper
+with exactly one quoted file path.
+
+On macOS or Linux:
+
+\`\`\`bash
+sh "/absolute/path/to/this/skill/directory/miyo-parse.sh" "/absolute/path/to/document.pdf"
+\`\`\`
+
+On Windows PowerShell:
+
+\`\`\`powershell
+& "/absolute/path/to/this/skill/directory/miyo-parse.cmd" "C:\\absolute\\path\\to\\document.pdf"
+\`\`\`
+
+The wrapper prints the parsed Markdown/text to stdout. Use that output to
+answer the user's question.
+
+## If it reports a problem
+
+Report the error clearly and stop parsing that document. Never fall back to
+\`copilot-read-pdf\` or any other cloud document parser: selecting Miyo is an
+explicit local-processing choice. Do not retry in a loop.
+`,
+  files: [
+    { path: "miyo-parse.sh", content: MIYO_PARSE_SH },
+    { path: "miyo-parse.cmd", content: MIYO_PARSE_CMD },
+  ],
+};
+
+/**
+ * Returns the builtin skills enabled by the host's independent Miyo settings.
+ *
+ * @param includeMiyoSearch Whether the Miyo vault-search skill is enabled.
+ * @param includeMiyoParse Whether Miyo is the selected document processor.
+ */
+export function managedBuiltinSkills(
+  includeMiyoSearch: boolean,
+  includeMiyoParse = false
+): readonly BuiltinSkill[] {
+  if (!includeMiyoSearch && !includeMiyoParse) return BUILTIN_SKILLS;
+
+  return [
+    ...BUILTIN_SKILLS,
+    ...(includeMiyoSearch ? [MIYO_SEARCH_SKILL] : []),
+    ...(includeMiyoParse ? [MIYO_PARSE_SKILL] : []),
+  ];
 }

--- a/src/agentMode/skills/builtin/builtinSkills.ts
+++ b/src/agentMode/skills/builtin/builtinSkills.ts
@@ -657,7 +657,6 @@ die() {
 
 FILE="$1"
 [ -n "$FILE" ] || die "Usage: sh miyo-parse.sh <file>" 1
-[ -f "$FILE" ] && [ -r "$FILE" ] || die "Could not read file: $FILE (pass an absolute path)." 1
 
 ${MIYO_POSIX_RESOLVER}
 
@@ -669,11 +668,6 @@ setlocal enableextensions
 rem Parse one local PDF or EPUB through the Miyo CLI and print Markdown/text.
 if "%~1"=="" (
   echo Usage: miyo-parse.cmd "file" 1>&2
-  exit /b 1
-)
-rem Never echo %~1 back: an unquoted & or > in the path would run as a command.
-if not exist "%~1" (
-  echo Could not read that file. Pass an absolute path to a PDF or EPUB. 1>&2
   exit /b 1
 )
 ${MIYO_WINDOWS_RESOLVER}
@@ -790,7 +784,8 @@ metadata:
 
 Use Miyo to extract Markdown/text from one PDF or EPUB. Parsing runs locally,
 works for files anywhere on the filesystem, and does not require the Miyo
-service to be running.
+service to be running. It does require the Miyo CLI on this machine: a remote
+Miyo server cannot parse for you.
 
 ## How to run
 
@@ -817,6 +812,11 @@ answer the user's question.
 Report the error clearly and stop parsing that document. Never fall back to
 \`copilot-read-pdf\` or any other cloud document parser: selecting Miyo is an
 explicit local-processing choice. Do not retry in a loop.
+
+If it reports that the Miyo CLI is not installed, say that pointing Copilot at a
+remote Miyo server does not help here, and that the user's options are to
+install Miyo on this machine or switch Settings → Copilot → Miyo → Document
+Processor to Plus.
 `,
   files: [
     { path: "miyo-parse.sh", content: MIYO_PARSE_SH },


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#197
Fixes logancyang/obsidian-copilot-preview#185

## Problem

Agent Mode did not honor the selected local Miyo document processor. Its system prompt always preferred the Copilot Plus PDF relay, so a PDF could leave the machine even after the user selected Miyo.

Agent Mode also lacked an explicit vault-versus-web heuristic. Current or external questions could be answered from model memory unless the user asked for web search directly, even when the vault had no useful evidence.

## Fix

Seed a managed `miyo-parse` skill whenever Miyo is the selected Document Processor. Its macOS/Linux and Windows wrappers call the current `miyo parse <file>` CLI contract for local PDF and EPUB extraction.

Selecting Miyo also **removes** `copilot-read-pdf` from the canonical skills folder rather than only steering away from it. `resolveDocProcessorBackend`'s locked design note requires an explicit `docProcessorBackend === "miyo"` to fail closed, and prompt wording alone cannot enforce that: a cloud PDF skill left on disk is one ignored instruction away from uploading a document the user chose to keep local. `planManagedBuiltins` returns both the skills to seed and the names to prune, so the host cannot add a gate without its opposite.

Document prompt steering selects one non-contradictory route: Plus may use the cloud PDF relay and fall back, while the Miyo steering explicitly cancels the blanket "silently fall back to your own equivalent tool" clause so the agent cannot read it as permission to reach the cloud.

The shared Agent Mode prompt now routes vault questions locally first, proactively uses web search/fetch for current or external questions, escalates weak external vault results to web evidence, avoids putting vault text in queries unless required, and limits the default loop to one discovery search followed by targeted fetches.

## Scope

6 files changed, 353 additions, 68 deletions.

This is limited to Agent Mode skill seeding, system-prompt steering, unit coverage, and user documentation. It does not change the settings schema, migrations, the normal-chat document parser, or provider prompts.

## Changes

- Add cross-platform, dependency-free `miyo-parse` wrappers and reuse the existing Miyo executable resolution.
- Replace `managedBuiltinSkills(includeMiyo)` with `planManagedBuiltins(gates)`, returning the seed set and the prune list together.
- Gate Miyo search and document parsing independently while preserving the stable `BUILTIN_SKILLS` reference when both are off.
- Keep the selected document processor aligned across startup, settings changes, managed skill discovery, and system prompts.
- Add bounded proactive web-routing and vault-query privacy guidance.
- Cover the read-pdf swap, the seed/prune invariant, independent gates, prompt selection, privacy, and fallback.
- Document Agent Mode web and document routing.

## Known limitations

- **Remote-only Miyo has no Agent Mode document route.** `miyo parse` runs locally and never reads `MIYO_URL`; the server-side `/v0/parse-doc` only resolves vault-relative paths inside a registered folder, so it cannot back a skill whose contract is "any filesystem path". A remote-only user is told to install Miyo locally or move the picker back to Plus. `miyo-search` already carries the same local-CLI requirement. Worth a follow-up.
- **Per-agent choices for `copilot-read-pdf` reset across a processor switch.** `copilot-enabled-agents` in SKILL.md is the only persistence, and pruning deletes it. This is a property of the existing gate-and-prune mechanism — toggling `miyo-search` off and on already discards its choices — and a real fix means persisting per-agent enablement outside the seeded file, in the Skills layer.

## Verification

- `npm run test` — 348 suites and 4,925 tests passed
- `npm run lint` (exit 0), `npm run format:check`, `npm run build`
- Confirmed the CLI contract directly: `miyo parse --help` documents "the file may be any filesystem path (it does not need to be in an indexed Miyo folder) and the command works without the Miyo service running", with dedicated exit codes 4/5 for file-not-found and file-not-readable.
- Not exercised in a live vault: the seed/prune pass and backend restart on a Document Processor switch are covered by unit tests, not by a manual end-to-end run.

🤖 Generated with [Codex](https://openai.com/codex/) and [Claude Code](https://claude.com/claude-code)
