### PR TITLE
feat(entitlement): gate self-host on the signed entitlement token

### DIFF
--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -99,9 +99,11 @@ Self-Host Mode lets you replace Copilot's cloud services with your own infrastru
 
 1. Go to **Settings → Copilot → Plus**
 2. Under **Self-Host Mode**, toggle **Enable Self-Host Mode**
-3. Copilot validates your license. If valid, the toggle activates.
+3. Copilot checks your plan. The toggle stays locked if your plan doesn't include Self-Host Mode.
 4. Toggle **Enable Miyo** to use the Miyo desktop app for local search, PDF parsing, and context.
 5. *(Optional)* Set **Custom Miyo Server URL** only if Miyo is running on a remote machine. Leave blank to use automatic local service discovery.
+
+**Working offline**: Self-Host Mode keeps working without an internet connection. Copilot remembers your plan for about two weeks at a time and refreshes that automatically whenever you're online, so an occasional online session is all it takes to stay activated indefinitely.
 
 ### Web Search in Self-Host Mode
 

--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -103,7 +103,7 @@ Self-Host Mode lets you replace Copilot's cloud services with your own infrastru
 4. Toggle **Enable Miyo** to use the Miyo desktop app for local search, PDF parsing, and context.
 5. *(Optional)* Set **Custom Miyo Server URL** only if Miyo is running on a remote machine. Leave blank to use automatic local service discovery.
 
-**Working offline**: Self-Host Mode keeps working without an internet connection. Copilot remembers your plan for about two weeks at a time and refreshes that automatically whenever you're online, so an occasional online session is all it takes to stay activated indefinitely.
+**Working offline**: Self-Host Mode keeps working without an internet connection for a while after your last online check, and renews itself automatically whenever you're online. How long that offline period lasts currently varies, so reconnect when you can rather than relying on a fixed window.
 
 ### Web Search in Self-Host Mode
 

--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -1,0 +1,121 @@
+import type { CopilotSettings } from "@/settings/model";
+
+const mockGetSettings = jest.fn<Partial<CopilotSettings>, []>();
+jest.mock("@/settings/model", () => ({
+  getSettings: () => mockGetSettings(),
+}));
+
+jest.mock("@/encryptionService", () => ({
+  getDecryptedKey: async (key: string) => key,
+}));
+
+const mockApplyEntitlement = jest.fn<Promise<boolean>, [string]>();
+const mockMarkPaidPendingEntitlement = jest.fn<void, []>();
+const mockTurnOnPaid = jest.fn<void, []>();
+const mockTurnOffPaid = jest.fn<void, [unknown?]>();
+jest.mock("@/plusUtils", () => ({
+  applyEntitlement: (token: string) => mockApplyEntitlement(token),
+  markPaidPendingEntitlement: () => mockMarkPaidPendingEntitlement(),
+  turnOnPaid: () => mockTurnOnPaid(),
+  turnOffPaid: (app?: unknown) => mockTurnOffPaid(app),
+}));
+
+import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
+
+interface RequestOutcome {
+  data: unknown;
+  error: Error | null;
+}
+
+/**
+ * Stub the private HTTP layer so the test drives `validateLicenseKey`'s
+ * response handling without touching the network. `onRequest` runs at the
+ * moment the request is in flight, which is where a concurrent key change has
+ * to be injected to reproduce the overlap.
+ */
+function stubRequest(outcome: RequestOutcome, onRequest?: () => void): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- reaching the private transport is the point
+  (BrevilabsClient.getInstance() as any).makeRequest = async () => {
+    onRequest?.();
+    return outcome;
+  };
+}
+
+const VALID_LICENSE_RESPONSE = { entitlement: "signed-token", plan: "believer" };
+
+describe("brevilabsClient", () => {
+  describe("BrevilabsClient", () => {
+    describe("validateLicenseKey()", () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+        mockApplyEntitlement.mockResolvedValue(true);
+        mockGetSettings.mockReturnValue({ plusLicenseKey: "key-A" });
+      });
+
+      it("applies the signed entitlement when the license key is unchanged", async () => {
+        stubRequest({ data: VALID_LICENSE_RESPONSE, error: null });
+
+        const result = await BrevilabsClient.getInstance().validateLicenseKey();
+
+        expect(result).toEqual({ isValid: true, plan: "believer" });
+        expect(mockApplyEntitlement).toHaveBeenCalledWith("signed-token");
+      });
+
+      it("falls back to paid-pending when the server's token cannot be verified", async () => {
+        mockApplyEntitlement.mockResolvedValue(false);
+        stubRequest({ data: VALID_LICENSE_RESPONSE, error: null });
+
+        await BrevilabsClient.getInstance().validateLicenseKey();
+
+        expect(mockMarkPaidPendingEntitlement).toHaveBeenCalled();
+      });
+
+      it("marks a tokenless valid license as paid", async () => {
+        stubRequest({ data: { plan: "plus" }, error: null });
+
+        await BrevilabsClient.getInstance().validateLicenseKey();
+
+        expect(mockTurnOnPaid).toHaveBeenCalled();
+        expect(mockApplyEntitlement).not.toHaveBeenCalled();
+      });
+
+      it("revokes entitlement when the server rejects the key", async () => {
+        stubRequest({ data: null, error: new Error("Invalid license key") });
+
+        const result = await BrevilabsClient.getInstance().validateLicenseKey();
+
+        expect(result).toEqual({ isValid: false });
+        expect(mockTurnOffPaid).toHaveBeenCalled();
+      });
+
+      it("discards a success that arrives after the license key changed", async () => {
+        // An eligible key's slow response landing after the user switched to a
+        // different key would otherwise re-grant that key's features — and
+        // re-persist its token — for the rest of the token's lifetime.
+        stubRequest({ data: VALID_LICENSE_RESPONSE, error: null }, () => {
+          mockGetSettings.mockReturnValue({ plusLicenseKey: "key-B" });
+        });
+
+        const result = await BrevilabsClient.getInstance().validateLicenseKey();
+
+        expect(result).toEqual({ isValid: undefined });
+        expect(mockApplyEntitlement).not.toHaveBeenCalled();
+        expect(mockTurnOnPaid).not.toHaveBeenCalled();
+        expect(mockMarkPaidPendingEntitlement).not.toHaveBeenCalled();
+      });
+
+      it("discards a rejection that arrives after the license key changed", async () => {
+        // The mirror case: a stale "Invalid license key" must not revoke the
+        // entitlement the user's newly entered key just earned.
+        stubRequest({ data: null, error: new Error("Invalid license key") }, () => {
+          mockGetSettings.mockReturnValue({ plusLicenseKey: "key-B" });
+        });
+
+        const result = await BrevilabsClient.getInstance().validateLicenseKey();
+
+        expect(result).toEqual({ isValid: undefined });
+        expect(mockTurnOffPaid).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -267,9 +267,15 @@ export class BrevilabsClient {
     app?: App,
     context?: Record<string, unknown>
   ): Promise<{ isValid: boolean | undefined; plan?: string }> {
+    // Identity this response will belong to. Validations can overlap (startup,
+    // a send-boundary re-check, the user pasting a different key), and every
+    // branch below mutates global entitlement state, so a response that outlives
+    // the key it was requested for must be discarded rather than applied.
+    const requestedLicenseKey = getSettings().plusLicenseKey;
+
     // Build the request body with proper structure
     const requestBody: Record<string, unknown> = {
-      license_key: await getDecryptedKey(getSettings().plusLicenseKey),
+      license_key: await getDecryptedKey(requestedLicenseKey),
     };
 
     // Safely spread context if provided, ensuring no conflicts with required fields
@@ -298,6 +304,14 @@ export class BrevilabsClient {
       true,
       true
     );
+
+    // The key changed under us while this was in flight, so this answer is about
+    // a license the user no longer has. Applying it would let a slow response for
+    // an eligible key land after a downgraded key's, restoring revoked features
+    // (and the token that carries them) for the rest of that token's lifetime.
+    if (getSettings().plusLicenseKey !== requestedLicenseKey) {
+      return { isValid: undefined };
+    }
 
     if (error) {
       if (error.message === "Invalid license key") {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1039,8 +1039,6 @@ export const DEFAULT_SETTINGS: CopilotSettings = {
   enableMiyo: false,
   enableMiyoSearchSkill: false,
   miyoSearchAll: false,
-  selfHostModeValidatedAt: null,
-  selfHostValidationCount: 0,
   selfHostUrl: "",
   selfHostApiKey: "",
   miyoServerUrl: "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ import { UserMemoryManager } from "@/memory/UserMemoryManager";
 import { clearRecordedPromptPayload } from "@/LLMProviders/chainRunner/utils/promptPayloadRecorder";
 import {
   checkIsPaidUser,
-  refreshSelfHostModeValidation,
+  ENTITLEMENT_REFRESH_INTERVAL_MS,
   verifyCachedEntitlement,
 } from "@/plusUtils";
 import {
@@ -236,12 +236,21 @@ export default class CopilotPlugin extends Plugin {
     // Initialize BrevilabsClient
     this.brevilabsClient = BrevilabsClient.getInstance();
     this.brevilabsClient.setPluginVersion(this.manifest.version);
-    // Re-verify the cached entitlement token offline so the strict Plus gate
-    // fails closed against an edited data.json until the signature re-proves
-    // itself. The network re-validation below overrides with the server's token.
+    // Re-verify the cached entitlement token offline so the strict Plus and
+    // self-host gates fail closed against an edited data.json until the
+    // signature re-proves itself. The network re-validation below overrides
+    // with the server's token.
     void verifyCachedEntitlement();
     void checkIsPaidUser(this.app);
-    void refreshSelfHostModeValidation();
+    // Entitlement tokens expire (~14 days), and the gates honor that expiry even
+    // mid-session. Without a refresh, an Obsidian window left open past `exp`
+    // loses self-host — which silently reroutes web search and document parsing
+    // through the cloud — despite the user being online and still entitled.
+    // Each /license call mints a fresh token, so re-validating daily keeps an
+    // online session current; offline users still lapse at `exp`, as intended.
+    this.registerInterval(
+      window.setInterval(() => void checkIsPaidUser(this.app), ENTITLEMENT_REFRESH_INTERVAL_MS)
+    );
 
     // Initialize ProjectManager
     this.projectManager = ProjectManager.getInstance(this.app, this);

--- a/src/miyo/miyoUtils.test.ts
+++ b/src/miyo/miyoUtils.test.ts
@@ -1,11 +1,3 @@
-// isSelfHostModeValidFor is a pure predicate over the passed settings; keep the
-// real implementation so seedDocProcessorBackend tests drive it via the settings
-// snapshot (proving purity) rather than through a global mock.
-jest.mock("@/plusUtils", () => ({
-  isSelfHostModeValidFor: (settings: { enableSelfHostMode?: boolean }): boolean =>
-    settings.enableSelfHostMode === true,
-}));
-
 // miyoUtils imports isMiyoAvailableForCapability (used by resolveDocProcessorBackend,
 // which is covered end-to-end in FileParserManager.test.ts). Stub the status store
 // so importing the module here doesn't pull in the real store.

--- a/src/miyo/miyoUtils.ts
+++ b/src/miyo/miyoUtils.ts
@@ -5,7 +5,6 @@ import {
   refreshMiyoStatus,
 } from "@/miyo/miyoStatusStore";
 import { shouldUseMiyo } from "@/miyo/miyoRuntimePolicy";
-import { isSelfHostModeValidFor } from "@/plusUtils";
 import { categorizePatterns, getDecodedPatterns } from "@/search/searchUtils";
 import { CopilotSettings, getSettings } from "@/settings/model";
 import { App } from "obsidian";
@@ -249,16 +248,18 @@ export function getSearchBackend(settings: CopilotSettings = getSettings()): "ke
  * circular (it would read the very field being computed) and non-deterministic
  * (it would depend on runtime connectivity at migration time).
  *
- * Both inputs are read from the passed `settings` (via the pure
- * {@link isSelfHostModeValidFor}), so the result depends only on that snapshot.
+ * Reads the raw toggles off the passed `settings` rather than the runtime
+ * `isSelfHostModeValid()` gate, which additionally consults the entitlement
+ * verified this session — a migration must not depend on whether that
+ * asynchronous verification has landed yet.
  *
  * @param settings - Settings being migrated.
- * @returns "miyo" when self-host mode is valid and Miyo is enabled, else "plus".
+ * @returns "miyo" when self-host mode and Miyo are both enabled, else "plus".
  */
 export function seedDocProcessorBackend(
   settings: CopilotSettings = getSettings()
 ): "plus" | "miyo" {
-  return isSelfHostModeValidFor(settings) && settings.enableMiyo ? "miyo" : "plus";
+  return settings.enableSelfHostMode && settings.enableMiyo ? "miyo" : "plus";
 }
 
 /**

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -368,26 +368,41 @@ describe("plusUtils", () => {
       expect(await checkIsPaidUser()).toBe(false);
     });
 
-    it("keeps a paid user working when the license server is unreachable", async () => {
+    it("keeps an unexpired entitlement working when the license server is unreachable", async () => {
       // requestUrl rejects offline, and every caller reads a rejection as "no
       // license" — which would deny the offline window the signed token exists
       // to provide. The call still runs, since it is what renews the token.
-      mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "key", isPaidUser: true }));
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
       mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
 
       expect(await checkIsPaidUser()).toBe(true);
       expect(mockValidateLicenseKey).toHaveBeenCalled();
     });
 
-    it("keeps a paid user working when the server answers without a verdict", async () => {
-      mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "key", isPaidUser: true }));
+    it("keeps an unexpired entitlement working when the server answers without a verdict", async () => {
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
       mockValidateLicenseKey.mockResolvedValue({ isValid: undefined });
 
       expect(await checkIsPaidUser()).toBe(true);
     });
 
-    it("does not grant offline access to a user with no cached paid state", async () => {
-      mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "key", isPaidUser: false }));
+    it("stops a turn whose entitlement expired while renewal was failing", async () => {
+      // The persisted isPaidUser is still true here. Answering from it would let
+      // the turn proceed with isSelfHostModeValid() already closed, rerouting a
+      // self-host user's searches to the cloud on a failed renewal.
+      await verifySessionFeatures(["multi_agent", "self_host"], PAST_EXP_SECONDS);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
+      mockValidateLicenseKey.mockResolvedValue({ isValid: undefined });
+
+      expect(await checkIsPaidUser()).toBe(false);
+    });
+
+    it("does not grant offline access on persisted flags alone (edited data.json)", async () => {
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({ plusLicenseKey: "key", isPaidUser: true })
+      );
       mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
 
       expect(await checkIsPaidUser()).toBe(false);

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -399,6 +399,27 @@ describe("plusUtils", () => {
       expect(await checkIsPaidUser()).toBe(false);
     });
 
+    it("refuses the offline fallback to an unexpired free-tier token", async () => {
+      // The backend downgrades a lapsed paid key to the free policy instead of
+      // refusing it a token, so an unexpired proof is not by itself paid access.
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "none",
+        tier: "free",
+        features: [],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      });
+      mockGetSettings.mockReturnValue(
+        buildSettings({ userId: "user-123", entitlementToken: "token" })
+      );
+      await verifyCachedEntitlement();
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
+      mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
+
+      expect(await checkIsPaidUser()).toBe(false);
+    });
+
     it("does not grant offline access on persisted flags alone (edited data.json)", async () => {
       mockGetSettings.mockReturnValue(
         tokenBackedSettings({ plusLicenseKey: "key", isPaidUser: true })

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -18,243 +18,324 @@ jest.mock("@/entitlement", () => ({
 import {
   applyEntitlement,
   canUseMultiAgent,
-  isSelfHostAccessValid,
   isSelfHostModeValid,
+  markPaidPendingEntitlement,
+  turnOffPaid,
+  turnOnPaid,
   verifyCachedEntitlement,
 } from "@/plusUtils";
 
-const SELF_HOST_GRACE_PERIOD_MS = 15 * 24 * 60 * 60 * 1000;
+const FUTURE_EXP_SECONDS = 9_999_999_999;
+const PAST_EXP_SECONDS = 1_000_000_000;
 
 function buildSettings(overrides: Partial<CopilotSettings>): CopilotSettings {
   return { ...DEFAULT_SETTINGS, ...overrides };
 }
 
-describe("isSelfHostAccessValid", () => {
-  it("returns false when selfHostModeValidatedAt is null (un-seeded receipt)", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({ selfHostModeValidatedAt: null, selfHostValidationCount: 0 })
-    );
-    expect(isSelfHostAccessValid()).toBe(false);
+/**
+ * Drive the module's in-memory verified-feature set the way the real startup
+ * path does: re-verify a persisted token whose claims grant `features`.
+ */
+async function verifySessionFeatures(
+  features: string[],
+  expSeconds: number = FUTURE_EXP_SECONDS
+): Promise<void> {
+  mockVerifyEntitlement.mockResolvedValue({
+    user_id: "user-123",
+    plan: "believer",
+    tier: "plus",
+    features,
+    iat: 0,
+    exp: expSeconds,
   });
+  mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123", entitlementToken: "token" }));
+  await verifyCachedEntitlement();
+}
 
-  it("returns true within the 15-day grace period of a freshly seeded receipt", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({ selfHostModeValidatedAt: Date.now(), selfHostValidationCount: 1 })
-    );
-    expect(isSelfHostAccessValid()).toBe(true);
+/**
+ * Settings of a user holding an unexpired, token-derived entitlement. `token`
+ * matches what {@link verifySessionFeatures} verified, so the in-memory proof
+ * belongs to the token settings currently hold.
+ */
+function tokenBackedSettings(overrides: Partial<CopilotSettings> = {}): CopilotSettings {
+  return buildSettings({
+    userId: "user-123",
+    entitlementToken: "token",
+    entitlementExpiresAt: Date.now() + 60_000,
+    ...overrides,
   });
+}
 
-  it("returns false once the grace period has expired and count < 3", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({
-        selfHostModeValidatedAt: Date.now() - SELF_HOST_GRACE_PERIOD_MS - 1000,
-        selfHostValidationCount: 1,
-      })
-    );
-    expect(isSelfHostAccessValid()).toBe(false);
-  });
-
-  it("returns true permanently once count >= 3 even after grace expiry", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({
-        selfHostModeValidatedAt: Date.now() - SELF_HOST_GRACE_PERIOD_MS - 1000,
-        selfHostValidationCount: 3,
-      })
-    );
-    expect(isSelfHostAccessValid()).toBe(true);
-  });
-});
-
-describe("canUseMultiAgent", () => {
-  // Reset the in-memory "verified this session" proof before each case so the
-  // strict gate's token-derived branch starts from a fail-closed state.
+describe("plusUtils", () => {
+  // Every gate reads the in-memory proof, so reset it to the fail-closed state.
   beforeEach(async () => {
+    mockSetSettings.mockClear();
     mockVerifyEntitlement.mockReset();
     mockGetSettings.mockReturnValue(buildSettings({ entitlementToken: "" }));
     await verifyCachedEntitlement();
   });
 
-  it("returns false for a free user (no Plus, no self-host)", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({ isPlusUser: false, enableSelfHostMode: false })
-    );
-    expect(canUseMultiAgent()).toBe(false);
-  });
+  describe("isSelfHostModeValid()", () => {
+    it("is true when the toggle is on and the entitlement grants self-host", async () => {
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
 
-  it("returns true for a Plus user", () => {
-    mockGetSettings.mockReturnValue(buildSettings({ isPlusUser: true, enableSelfHostMode: false }));
-    expect(canUseMultiAgent()).toBe(true);
-  });
-
-  it("returns false for a Lite user (paid but below Plus)", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({ isPaidUser: true, isPlusUser: false, enableSelfHostMode: false })
-    );
-    expect(canUseMultiAgent()).toBe(false);
-  });
-
-  it("returns true when self-host mode is on (believer/supporter offline path)", () => {
-    mockGetSettings.mockReturnValue(buildSettings({ isPlusUser: false, enableSelfHostMode: true }));
-    expect(canUseMultiAgent()).toBe(true);
-  });
-
-  it("returns false when the entitlement token has expired (offline lock)", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({
-        isPlusUser: true,
-        enableSelfHostMode: false,
-        entitlementExpiresAt: Date.now() - 1000,
-      })
-    );
-    expect(canUseMultiAgent()).toBe(false);
-  });
-
-  it("blocks token-derived Plus that was not verified this session (edited data.json)", () => {
-    // A persisted isPlusUser=true plus a future expiry, with no signature
-    // verified this process — the data.json-tampering case. Fails closed.
-    mockGetSettings.mockReturnValue(
-      buildSettings({
-        isPlusUser: true,
-        enableSelfHostMode: false,
-        entitlementToken: "forged-or-stale",
-        entitlementExpiresAt: Date.now() + 60_000,
-      })
-    );
-    expect(canUseMultiAgent()).toBe(false);
-  });
-
-  it("allows token-derived Plus once the signed token is verified this session", async () => {
-    // Re-verifying the cached token (offline) sets the in-memory proof, so the
-    // strict gate trusts the unexpired entitlement.
-    mockVerifyEntitlement.mockResolvedValue({
-      user_id: "user-123",
-      plan: "plus",
-      tier: "plus",
-      features: ["multi_agent"],
-      iat: 0,
-      exp: 9_999_999_999,
+      expect(isSelfHostModeValid()).toBe(true);
     });
-    mockGetSettings.mockReturnValue(
-      buildSettings({ userId: "user-123", entitlementToken: "token" })
-    );
-    await verifyCachedEntitlement();
 
-    mockGetSettings.mockReturnValue(
-      buildSettings({
-        isPlusUser: true,
-        enableSelfHostMode: false,
+    it("is false when the entitlement grants self-host but the toggle is off", async () => {
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: false }));
+
+      expect(isSelfHostModeValid()).toBe(false);
+    });
+
+    it("is false for a Plus token that does not carry the self_host feature", async () => {
+      await verifySessionFeatures(["multi_agent"]);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
+
+      expect(isSelfHostModeValid()).toBe(false);
+    });
+
+    it("is false when no token was verified this session (edited data.json)", () => {
+      // Persisted flags and a future expiry can be forged; the ES256 signature
+      // cannot, and nothing re-proved it this process.
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({ enableSelfHostMode: true, isPlusUser: true })
+      );
+
+      expect(isSelfHostModeValid()).toBe(false);
+    });
+
+    // Expiry comes from the signed claims, never from the persisted setting:
+    // data.json is editable and the ES256 signature is not. Both directions are
+    // asserted so the setting is proven inert rather than merely unused.
+    it("is false once the signed exp has passed, even with the persisted expiry edited forward", async () => {
+      await verifySessionFeatures(["multi_agent", "self_host"], PAST_EXP_SECONDS);
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({
+          enableSelfHostMode: true,
+          entitlementExpiresAt: Date.now() + 10 * 365 * 24 * 60 * 60 * 1000,
+        })
+      );
+
+      expect(isSelfHostModeValid()).toBe(false);
+    });
+
+    it("stays open while the signed exp holds, even with the persisted expiry in the past", async () => {
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({ enableSelfHostMode: true, entitlementExpiresAt: Date.now() - 1000 })
+      );
+
+      expect(isSelfHostModeValid()).toBe(true);
+    });
+
+    it.each([
+      ["turnOffPaid", turnOffPaid],
+      ["markPaidPendingEntitlement", markPaidPendingEntitlement],
+      ["turnOnPaid", turnOnPaid],
+    ])("revokes self-host once %s drops the token", async (_name, clear) => {
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
+      expect(isSelfHostModeValid()).toBe(true);
+
+      clear();
+      // These paths also zero `entitlementExpiresAt`, so the expiry check alone
+      // would not close the gate — the proof lapses because it is tagged with a
+      // token settings no longer hold.
+      mockGetSettings.mockReturnValue(
+        buildSettings({ enableSelfHostMode: true, entitlementToken: "", entitlementExpiresAt: 0 })
+      );
+
+      expect(isSelfHostModeValid()).toBe(false);
+    });
+  });
+
+  describe("canUseMultiAgent()", () => {
+    it("returns false for a free user", () => {
+      mockGetSettings.mockReturnValue(buildSettings({ isPlusUser: false }));
+      expect(canUseMultiAgent()).toBe(false);
+    });
+
+    it("returns true for a Plus user on the tokenless fallback", () => {
+      mockGetSettings.mockReturnValue(buildSettings({ isPlusUser: true }));
+      expect(canUseMultiAgent()).toBe(true);
+    });
+
+    it("returns false for a Lite user (paid but below Plus)", () => {
+      mockGetSettings.mockReturnValue(buildSettings({ isPaidUser: true, isPlusUser: false }));
+      expect(canUseMultiAgent()).toBe(false);
+    });
+
+    it("returns false once the signed exp has passed (offline lock)", async () => {
+      await verifySessionFeatures(["multi_agent"], PAST_EXP_SECONDS);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ isPlusUser: true }));
+      expect(canUseMultiAgent()).toBe(false);
+    });
+
+    it("blocks token-derived Plus that was not verified this session (edited data.json)", () => {
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ isPlusUser: true }));
+      expect(canUseMultiAgent()).toBe(false);
+    });
+
+    it("allows token-derived Plus once the signed token is verified this session", async () => {
+      await verifySessionFeatures(["multi_agent"]);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ isPlusUser: true }));
+
+      expect(canUseMultiAgent()).toBe(true);
+    });
+
+    it("is not granted by self-host mode alone", async () => {
+      // Self-host plans reach Plus through their own token's multi_agent
+      // feature, so the toggle must not act as a bypass.
+      await verifySessionFeatures(["self_host"]);
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({ enableSelfHostMode: true, isPlusUser: false })
+      );
+
+      expect(canUseMultiAgent()).toBe(false);
+    });
+  });
+
+  describe("applyEntitlement()", () => {
+    beforeEach(() => {
+      mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123" }));
+    });
+
+    it("grants Plus and self-host for a Believer token carrying both features", async () => {
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "believer",
+        tier: "plus",
+        features: ["multi_agent", "self_host"],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      });
+
+      expect(await applyEntitlement("token")).toBe(true);
+      expect(mockSetSettings).toHaveBeenCalledWith({
         entitlementToken: "token",
-        entitlementExpiresAt: Date.now() + 60_000,
-      })
-    );
-    expect(canUseMultiAgent()).toBe(true);
-  });
-});
+        entitlementExpiresAt: FUTURE_EXP_SECONDS * 1000,
+        isPaidUser: true,
+        isPlusUser: true,
+      });
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
+      expect(isSelfHostModeValid()).toBe(true);
+    });
 
-describe("applyEntitlement", () => {
-  beforeEach(() => {
-    mockSetSettings.mockClear();
-    mockVerifyEntitlement.mockReset();
-    mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123" }));
-  });
+    it("applies a Lite token as paid but neither Plus nor self-host", async () => {
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "lite",
+        tier: "lite",
+        features: [],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      });
 
-  it("grants Plus for a token carrying the multi_agent feature", async () => {
-    mockVerifyEntitlement.mockResolvedValue({
-      user_id: "user-123",
-      plan: "plus",
-      tier: "plus",
-      features: ["multi_agent", "self_host"],
-      iat: 0,
-      exp: 9_999_999_999,
+      // Returns true (verified + applied); the tier shows in the flags, not the
+      // return value.
+      expect(await applyEntitlement("token")).toBe(true);
+      expect(mockSetSettings).toHaveBeenCalledWith({
+        entitlementToken: "token",
+        entitlementExpiresAt: FUTURE_EXP_SECONDS * 1000,
+        isPaidUser: true,
+        isPlusUser: false,
+      });
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
+      expect(isSelfHostModeValid()).toBe(false);
     });
-    expect(await applyEntitlement("token")).toBe(true);
-    expect(mockSetSettings).toHaveBeenCalledWith({
-      entitlementToken: "token",
-      entitlementExpiresAt: 9_999_999_999_000,
-      isPaidUser: true,
-      isPlusUser: true,
-    });
-  });
 
-  it("applies a Lite token as paid but not Plus", async () => {
-    mockVerifyEntitlement.mockResolvedValue({
-      user_id: "user-123",
-      plan: "lite",
-      tier: "lite",
-      features: [],
-      iat: 0,
-      exp: 9_999_999_999,
-    });
-    // Returns true (verified + applied); the tier shows in the flags, not the
-    // return value.
-    expect(await applyEntitlement("token")).toBe(true);
-    expect(mockSetSettings).toHaveBeenCalledWith({
-      entitlementToken: "token",
-      entitlementExpiresAt: 9_999_999_999_000,
-      isPaidUser: true,
-      isPlusUser: false,
-    });
-  });
+    it("grants Plus without self-host for a Pro token", async () => {
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "pro",
+        tier: "pro",
+        features: ["multi_agent"],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      });
 
-  it("grants Plus for a Pro token", async () => {
-    mockVerifyEntitlement.mockResolvedValue({
-      user_id: "user-123",
-      plan: "pro",
-      tier: "pro",
-      features: ["multi_agent"],
-      iat: 0,
-      exp: 9_999_999_999,
+      expect(await applyEntitlement("token")).toBe(true);
+      expect(mockSetSettings).toHaveBeenCalledWith({
+        entitlementToken: "token",
+        entitlementExpiresAt: FUTURE_EXP_SECONDS * 1000,
+        isPaidUser: true,
+        isPlusUser: true,
+      });
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
+      expect(isSelfHostModeValid()).toBe(false);
     });
-    expect(await applyEntitlement("token")).toBe(true);
-    expect(mockSetSettings).toHaveBeenCalledWith({
-      entitlementToken: "token",
-      entitlementExpiresAt: 9_999_999_999_000,
-      isPaidUser: true,
-      isPlusUser: true,
+
+    it("does NOT change settings when the token cannot be verified", async () => {
+      // An unverifiable token (bad signature, expired, unknown kid, or empty key
+      // set during rollout) is not an authoritative negative, so flags are left
+      // untouched for the caller to decide the fallback. Only turnOffPaid clears.
+      mockVerifyEntitlement.mockResolvedValue(null);
+
+      expect(await applyEntitlement("bad")).toBe(false);
+      expect(mockSetSettings).not.toHaveBeenCalled();
     });
   });
 
-  it("does NOT change settings when the token cannot be verified", async () => {
-    // An unverifiable token (bad signature, expired, unknown kid, or empty key
-    // set during rollout) is not an authoritative negative, so flags are left
-    // untouched for the caller to decide the fallback. Only turnOffPaid clears.
-    mockVerifyEntitlement.mockResolvedValue(null);
-    expect(await applyEntitlement("bad")).toBe(false);
-    expect(mockSetSettings).not.toHaveBeenCalled();
-  });
-});
+  describe("verifyCachedEntitlement()", () => {
+    it("re-grants the cached token's features offline with no network call", async () => {
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
 
-describe("isSelfHostModeValid", () => {
-  it("returns false when the toggle is off, regardless of any receipt", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({
-        enableSelfHostMode: false,
-        selfHostModeValidatedAt: Date.now(),
-        selfHostValidationCount: 1,
-      })
-    );
-    expect(isSelfHostModeValid()).toBe(false);
-  });
+      expect(isSelfHostModeValid()).toBe(true);
+      expect(canUseMultiAgent()).toBe(true);
+    });
 
-  it("returns true when the toggle is on even with a null receipt (gates on the toggle alone)", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({
-        enableSelfHostMode: true,
-        selfHostModeValidatedAt: null,
-        selfHostValidationCount: 0,
-      })
-    );
-    expect(isSelfHostModeValid()).toBe(true);
-  });
+    it("does not clobber a fresher token applied while its verification was in flight", async () => {
+      // main.ts runs this concurrently with the online /license check. The
+      // startup re-check reads the OLD token, and /license installs a new one
+      // before that verification resolves; the stale write must be dropped or
+      // the proof ends up tagged with a token settings no longer hold.
+      const believerClaims = {
+        user_id: "user-123",
+        plan: "believer",
+        tier: "plus",
+        features: ["multi_agent", "self_host"],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      };
+      mockGetSettings.mockReturnValue(
+        buildSettings({ userId: "user-123", entitlementToken: "old-token" })
+      );
+      mockVerifyEntitlement.mockImplementation(async (token: string) => {
+        if (token === "old-token") {
+          // The concurrent /license round-trip resolves first and installs a
+          // fresher token, exactly as applyEntitlement would at startup.
+          await applyEntitlement("new-token");
+          mockGetSettings.mockReturnValue(
+            tokenBackedSettings({ entitlementToken: "new-token", enableSelfHostMode: true })
+          );
+        }
+        return believerClaims;
+      });
 
-  it("returns true when the toggle is on regardless of grace/permanent receipt state", () => {
-    mockGetSettings.mockReturnValue(
-      buildSettings({
-        enableSelfHostMode: true,
-        selfHostModeValidatedAt: Date.now() - SELF_HOST_GRACE_PERIOD_MS - 1000,
-        selfHostValidationCount: 0,
-      })
-    );
-    expect(isSelfHostModeValid()).toBe(true);
+      await verifyCachedEntitlement();
+
+      // The fresher grant survives: a paying user is not locked out for the session.
+      expect(isSelfHostModeValid()).toBe(true);
+      expect(canUseMultiAgent()).toBe(true);
+    });
+
+    it("closes every gate when the same cached token stops verifying", async () => {
+      // Kid rotation or tampering: settings still hold the token an earlier
+      // check granted, so re-tagging it with no features is what revokes.
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+
+      mockVerifyEntitlement.mockResolvedValue(null);
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({ enableSelfHostMode: true, isPlusUser: true })
+      );
+      await verifyCachedEntitlement();
+
+      expect(isSelfHostModeValid()).toBe(false);
+      expect(canUseMultiAgent()).toBe(false);
+    });
   });
 });

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -3,10 +3,13 @@ import type { CopilotSettings } from "@/settings/model";
 
 const mockGetSettings = jest.fn<CopilotSettings, []>();
 const mockSetSettings = jest.fn<void, [Partial<CopilotSettings>]>();
+const mockUpdateSetting = jest.fn<void, [string, unknown]>();
 
 jest.mock("@/settings/model", () => ({
   getSettings: () => mockGetSettings(),
   setSettings: (partial: Partial<CopilotSettings>) => mockSetSettings(partial),
+  updateSetting: (key: string, value: unknown) => mockUpdateSetting(key, value),
+  useSettingsValue: () => mockGetSettings(),
 }));
 
 const mockVerifyEntitlement = jest.fn<Promise<unknown>, [string, unknown?]>();
@@ -22,8 +25,10 @@ import {
   markPaidPendingEntitlement,
   turnOffPaid,
   turnOnPaid,
+  useIsSelfHostEligible,
   verifyCachedEntitlement,
 } from "@/plusUtils";
+import { renderHook, waitFor } from "@testing-library/react";
 
 const FUTURE_EXP_SECONDS = 9_999_999_999;
 const PAST_EXP_SECONDS = 1_000_000_000;
@@ -70,6 +75,7 @@ describe("plusUtils", () => {
   // Every gate reads the in-memory proof, so reset it to the fail-closed state.
   beforeEach(async () => {
     mockSetSettings.mockClear();
+    mockUpdateSetting.mockClear();
     mockVerifyEntitlement.mockReset();
     mockGetSettings.mockReturnValue(buildSettings({ entitlementToken: "" }));
     await verifyCachedEntitlement();
@@ -336,6 +342,56 @@ describe("plusUtils", () => {
 
       expect(isSelfHostModeValid()).toBe(false);
       expect(canUseMultiAgent()).toBe(false);
+    });
+  });
+
+  describe("useIsSelfHostEligible()", () => {
+    it("reports eligible without touching the preference when the token grants self-host", async () => {
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "believer",
+        tier: "plus",
+        features: ["multi_agent", "self_host"],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      });
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
+
+      const { result } = renderHook(() => useIsSelfHostEligible());
+
+      await waitFor(() => expect(result.current).toBe(true));
+      expect(mockUpdateSetting).not.toHaveBeenCalled();
+    });
+
+    it("clears the preference when a verified token's plan does not grant self-host", async () => {
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "plus",
+        tier: "plus",
+        features: ["multi_agent"],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      });
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
+
+      const { result } = renderHook(() => useIsSelfHostEligible());
+
+      await waitFor(() => expect(result.current).toBe(false));
+      expect(mockUpdateSetting).toHaveBeenCalledWith("enableSelfHostMode", false);
+    });
+
+    it("keeps the preference when the token cannot be verified", async () => {
+      // Unverifiable is "unknown", not "not entitled": a kid that has not
+      // shipped, unavailable WebCrypto, or an expiry crossed just before the
+      // online refresh. Clearing here would burn a preference that the next
+      // successful refresh cannot restore, silently leaving the user on cloud.
+      mockVerifyEntitlement.mockResolvedValue(null);
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
+
+      const { result } = renderHook(() => useIsSelfHostEligible());
+
+      await waitFor(() => expect(result.current).toBe(false));
+      expect(mockUpdateSetting).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -18,9 +18,16 @@ jest.mock("@/entitlement", () => ({
   verifyEntitlement: (...args: [string, unknown?]) => mockVerifyEntitlement(...args),
 }));
 
+const mockValidateLicenseKey = jest.fn<Promise<{ isValid: boolean | undefined }>, []>();
+
+jest.mock("@/LLMProviders/brevilabsClient", () => ({
+  BrevilabsClient: { getInstance: () => ({ validateLicenseKey: () => mockValidateLicenseKey() }) },
+}));
+
 import {
   applyEntitlement,
   canUseMultiAgent,
+  checkIsPaidUser,
   isSelfHostModeValid,
   markPaidPendingEntitlement,
   turnOffPaid,
@@ -77,6 +84,7 @@ describe("plusUtils", () => {
     mockSetSettings.mockClear();
     mockUpdateSetting.mockClear();
     mockVerifyEntitlement.mockReset();
+    mockValidateLicenseKey.mockReset();
     mockGetSettings.mockReturnValue(buildSettings({ entitlementToken: "" }));
     await verifyCachedEntitlement();
   });
@@ -342,6 +350,47 @@ describe("plusUtils", () => {
 
       expect(isSelfHostModeValid()).toBe(false);
       expect(canUseMultiAgent()).toBe(false);
+    });
+  });
+
+  describe("checkIsPaidUser()", () => {
+    it("returns false without reaching the server when no license key is set", async () => {
+      mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "" }));
+
+      expect(await checkIsPaidUser()).toBe(false);
+      expect(mockValidateLicenseKey).not.toHaveBeenCalled();
+    });
+
+    it("returns the server's verdict when it answers", async () => {
+      mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "key", isPaidUser: true }));
+      mockValidateLicenseKey.mockResolvedValue({ isValid: false });
+
+      expect(await checkIsPaidUser()).toBe(false);
+    });
+
+    it("keeps a paid user working when the license server is unreachable", async () => {
+      // requestUrl rejects offline, and every caller reads a rejection as "no
+      // license" — which would deny the offline window the signed token exists
+      // to provide. The call still runs, since it is what renews the token.
+      mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "key", isPaidUser: true }));
+      mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
+
+      expect(await checkIsPaidUser()).toBe(true);
+      expect(mockValidateLicenseKey).toHaveBeenCalled();
+    });
+
+    it("keeps a paid user working when the server answers without a verdict", async () => {
+      mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "key", isPaidUser: true }));
+      mockValidateLicenseKey.mockResolvedValue({ isValid: undefined });
+
+      expect(await checkIsPaidUser()).toBe(true);
+    });
+
+    it("does not grant offline access to a user with no cached paid state", async () => {
+      mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "key", isPaidUser: false }));
+      mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
+
+      expect(await checkIsPaidUser()).toBe(false);
     });
   });
 

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -9,7 +9,7 @@ import {
   PLUS_UTM_MEDIUMS,
   PlusUtmMedium,
 } from "@/constants";
-import { verifyEntitlement } from "@/entitlement";
+import { EntitlementFeature, verifyEntitlement } from "@/entitlement";
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import { logError, logInfo } from "@/logger";
 import {
@@ -29,74 +29,22 @@ export const DEFAULT_COPILOT_PLUS_EMBEDDING_MODEL = EmbeddingModels.COPILOT_PLUS
 export const DEFAULT_COPILOT_PLUS_EMBEDDING_MODEL_KEY =
   DEFAULT_COPILOT_PLUS_EMBEDDING_MODEL + "|" + EmbeddingModelProviders.COPILOT_PLUS;
 
-// ============================================================================
-// SELF-HOST MODE VALIDATION
-// ============================================================================
-// Self-host mode allows Believer/Supporter users to use their own infrastructure.
-//
-// Validation flow:
-// 1. User enables toggle → validateSelfHostMode() → count = 1, timestamp set
-// 2. Every 15+ days on plugin load → refreshSelfHostModeValidation() → count++
-// 3. After 3 successful validations → permanent (no more checks needed)
-//
-// Offline support:
-// - Within 15-day grace period: Full functionality, can toggle off/on
-// - Permanent (count >= 3): Full functionality forever
-// - Grace expired while offline: Must go online to revalidate
-//
-// Settings section visibility (useIsSelfHostEligible):
-// - Shown if: permanent OR within grace period OR API confirms eligibility
-// - Hidden if: no license key OR grace expired + offline + not permanent
-// ============================================================================
-
-/** Grace period for self-host mode: 15 days */
-const SELF_HOST_GRACE_PERIOD_MS = 15 * 24 * 60 * 60 * 1000;
-
-/** Number of successful validations required for permanent self-host mode */
-const SELF_HOST_PERMANENT_VALIDATION_COUNT = 3;
-
-/** Plans that qualify for self-host mode */
-const SELF_HOST_ELIGIBLE_PLANS = ["believer", "supporter"];
-
 /**
- * Check if self-host access is valid.
- * Valid if: permanently validated (3+ successful checks) OR within 15-day grace period.
+ * How often a running session re-validates its license. Well inside the token's
+ * ~14-day `exp` so an online user never reaches the expiry cliff, and far apart
+ * enough that a long-lived window costs one request a day.
  */
-export function isSelfHostAccessValid(): boolean {
-  const settings = getSettings();
-  if (settings.selfHostModeValidatedAt == null) {
-    return false;
-  }
-  // Permanently valid after 3 successful validations
-  if (settings.selfHostValidationCount >= SELF_HOST_PERMANENT_VALIDATION_COUNT) {
-    return true;
-  }
-  // Otherwise, check grace period
-  return Date.now() - settings.selfHostModeValidatedAt < SELF_HOST_GRACE_PERIOD_MS;
-}
+export const ENTITLEMENT_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Pure predicate for self-host mode validity, derived solely from the passed
- * settings. Prefer this at seed/migration sites that must be deterministic on a
- * specific settings snapshot rather than reading whatever is globally current.
- *
- * Gates on the toggle alone: an eligible user who turned self-host mode on may
- * use their own self-host tools (web search, YouTube) without a validation
- * receipt. The startup refreshSelfHostModeValidation() disables the toggle for
- * genuinely ineligible plans, so the toggle is a sufficient gate.
- *
- * @param settings - Settings snapshot to evaluate.
- */
-export function isSelfHostModeValidFor(settings: CopilotSettings): boolean {
-  return settings.enableSelfHostMode === true;
-}
-
-/**
- * Check if self-host mode is valid and enabled for the current global settings.
- * Thin wrapper over {@link isSelfHostModeValidFor} for runtime read-sites.
+ * Runtime gate for self-host mode: the user turned it on AND the server-signed
+ * entitlement grants `self_host`. The toggle alone is not enough — it is a user
+ * preference persisted in `data.json`, so gating on the verified entitlement is
+ * what makes a lapsed plan lose self-host once its token expires. The server
+ * owns the plan → capability policy; the client never maps plan names.
  */
 export function isSelfHostModeValid(): boolean {
-  return isSelfHostModeValidFor(getSettings());
+  return getSettings().enableSelfHostMode === true && hasVerifiedFeature("self_host");
 }
 
 /** Check if the model key is a Copilot Plus model. */
@@ -114,101 +62,101 @@ export function isPlusModel(modelKey: string): boolean {
 }
 
 /**
- * Synchronous check for paid (any valid license, incl. Lite) feature access.
- * Returns true when self-host mode is valid OR the user has any valid paid
- * subscription. Use this for the broad Plus-feature gates (model validation, UI
- * state) that should remain available to every paying user.
+ * Synchronous check for paid (any valid license, incl. Lite) feature access. Use
+ * this for the broad Plus-feature gates (model validation, UI state) that should
+ * remain available to every paying user.
  */
 export function isPaidEnabled(): boolean {
-  const settings = getSettings();
-  // Self-host mode with valid plan validation bypasses subscription requirements
-  if (isSelfHostModeValid()) {
-    return true;
-  }
-  return settings.isPaidUser === true;
+  return getSettings().isPaidUser === true;
 }
 
 /**
- * True once the entitlement token's expiry has passed. Only token-derived state
- * carries an expiry (tokenless fallback leaves it 0), so this honors the JWS
- * `exp` for the strict gate even offline, without affecting the broad paid gate.
+ * True once the PERSISTED expiry has passed (0 = tokenless fallback, never
+ * expired). This reads editable state, so it only ever tightens the reactive
+ * `useIsPlusUser` render gate — the strict gates take expiry from the signed
+ * claims in {@link VerifiedEntitlement}, which an edited `data.json` can't move.
  */
 function isEntitlementExpired(settings: CopilotSettings): boolean {
   return settings.entitlementExpiresAt > 0 && Date.now() >= settings.entitlementExpiresAt;
 }
 
 /**
- * In-memory (never persisted) proof that a signed entitlement granting the
- * `multi_agent` feature was cryptographically verified in THIS process — set by
- * {@link applyEntitlement} (server response) or {@link verifyCachedEntitlement}
- * (cached token re-checked at startup). The strict Plus gate requires it for
- * token-derived state, so an edited `data.json` (which can flip persisted
- * booleans and the expiry, but cannot forge an ES256 signature) fails closed.
+ * Proof of what a signed entitlement granted, as read from claims verified in
+ * THIS process — written by {@link applyEntitlement} (server response) and
+ * {@link verifyCachedEntitlement} (cached token re-checked at startup).
+ *
+ * Every field comes from the same verified claims, so the whole proof is
+ * signature-backed: `data.json` can flip persisted booleans and the expiry, but
+ * it cannot forge an ES256 signature, and nothing here is read back from it.
+ * Taking the expiry from settings instead would leave the gate half-editable —
+ * an edited `entitlementExpiresAt` would hold it open past the token's real
+ * `exp` for as long as the session lived.
+ *
+ * `token` is what settings must still hold for the proof to apply. That is how
+ * the paths that drop the token (turnOffPaid, markPaidPendingEntitlement,
+ * turnOnPaid) revoke these capabilities without touching this state: no stored
+ * token can match `""` while carrying features.
  */
-let strictEntitlementVerified = false;
+interface VerifiedEntitlement {
+  token: string;
+  features: ReadonlySet<EntitlementFeature>;
+  /** The claims' `exp`, in epoch ms. */
+  expiresAt: number;
+}
+
+/** Frozen "nothing verified" proof — referential stability for the empty state. */
+const NO_VERIFIED_ENTITLEMENT: VerifiedEntitlement = Object.freeze({
+  token: "",
+  features: Object.freeze(new Set<EntitlementFeature>()),
+  expiresAt: 0,
+});
+
+let verified: VerifiedEntitlement = NO_VERIFIED_ENTITLEMENT;
+
+/**
+ * Whether the entitlement verified this session still grants `feature`: the
+ * proof must belong to the token settings currently hold, and the signed `exp`
+ * must not have passed — a session running past expiry loses the capability.
+ *
+ * @param feature - Capability to check for.
+ */
+function hasVerifiedFeature(feature: EntitlementFeature): boolean {
+  return (
+    verified.token === getSettings().entitlementToken &&
+    verified.features.has(feature) &&
+    Date.now() < verified.expiresAt
+  );
+}
 
 /**
  * Synchronous check for tier >= Plus (excludes Lite) — the gate for
- * Plus-and-above features such as multi-agent fan-out. Self-host plans
- * (Believer/Supporter) are >= Plus, so a valid self-host bypass grants this too.
+ * Plus-and-above features such as multi-agent fan-out.
  */
 export function isPlusEnabled(): boolean {
   const settings = getSettings();
-  if (isSelfHostModeValid()) {
-    return true;
-  }
   // Token-derived Plus carries an expiry. Trust it only when the signed token
   // was cryptographically verified this session (not merely a persisted
   // `isPlusUser` boolean) and the `exp` has not passed — so editing data.json
   // cannot unlock the strict gate, even offline.
   if (settings.entitlementExpiresAt > 0) {
-    return strictEntitlementVerified && !isEntitlementExpired(settings);
+    return hasVerifiedFeature("multi_agent");
   }
   // Tokenless fallback (server has not issued a signed entitlement yet): no
   // artifact exists to verify, so honor the license-confirmed flag as before.
   return settings.isPlusUser === true;
 }
 
-/**
- * Self-host bypass for the reactive hooks: a license-keyed self-host user with a
- * still-valid validation receipt (permanent or within grace) is treated as
- * entitled offline. Mirrors the offline allowance in `useIsSelfHostEligible`.
- */
-function hasSelfHostHookBypass(settings: CopilotSettings): boolean {
-  if (
-    !settings.plusLicenseKey ||
-    !settings.enableSelfHostMode ||
-    settings.selfHostModeValidatedAt == null
-  ) {
-    return false;
-  }
-  if (settings.selfHostValidationCount >= SELF_HOST_PERMANENT_VALIDATION_COUNT) {
-    return true;
-  }
-  return Date.now() - settings.selfHostModeValidatedAt < SELF_HOST_GRACE_PERIOD_MS;
-}
-
-/**
- * Hook for paid status (any valid license, incl. Lite). Returns true when
- * self-host mode is valid to allow offline usage.
- */
+/** Hook for paid status (any valid license, incl. Lite). */
 export function useIsPaidUser(): boolean | undefined {
-  const settings = useSettingsValue();
-  if (hasSelfHostHookBypass(settings)) {
-    return true;
-  }
-  return settings.isPaidUser;
+  return useSettingsValue().isPaidUser;
 }
 
 /**
  * Hook for tier >= Plus (excludes Lite) — the reactive gate for Plus-and-above
- * features. Self-host plans are >= Plus, so the self-host bypass grants this too.
+ * features.
  */
 export function useIsPlusUser(): boolean | undefined {
   const settings = useSettingsValue();
-  if (hasSelfHostHookBypass(settings)) {
-    return true;
-  }
   if (isEntitlementExpired(settings)) {
     return false;
   }
@@ -274,17 +222,11 @@ export function useCanUseMultiAgent(): boolean {
 
 /**
  * Check if the user has a valid paid license (any tier, incl. Lite).
- * When self-host mode is valid, this returns true to allow offline usage.
  */
 export async function checkIsPaidUser(
   app?: App,
   context?: Record<string, unknown>
 ): Promise<boolean | undefined> {
-  // Self-host mode with valid plan validation bypasses license check
-  if (isSelfHostModeValid()) {
-    return true;
-  }
-
   if (!getSettings().plusLicenseKey) {
     turnOffPaid(app);
     return false;
@@ -294,187 +236,41 @@ export async function checkIsPaidUser(
   return result.isValid;
 }
 
-/** Check if the user is on a plan that qualifies for self-host mode. */
-async function isSelfHostEligiblePlan(): Promise<boolean> {
-  if (!getSettings().plusLicenseKey) {
-    return false;
-  }
-  const brevilabsClient = BrevilabsClient.getInstance();
-  const result = await brevilabsClient.validateLicenseKey();
-  const planName = result.plan?.toLowerCase();
-  return planName != null && SELF_HOST_ELIGIBLE_PLANS.includes(planName);
-}
-
 /**
- * Hook to check if user should see the self-host mode settings section.
- * Returns undefined while loading, boolean once checked.
+ * Reactive form of {@link isSelfHostEntitled} for the Self-Host settings tab.
+ * Re-verifies the persisted token rather than reading the module-level verified
+ * set, because that set is populated asynchronously at startup and React needs a
+ * value that settles on its own. Verification is offline (WebCrypto against the
+ * embedded public key), so this costs no network call. `undefined` means the
+ * check is still in flight.
  *
- * Eligibility rules:
- * 1. No license key: Not eligible (immediately revokes access)
- * 2. Has license key: Verify via API (handles key changes, e.g. believer → plus)
- *    - API success: Use result (revoke self-host mode if not eligible)
- *    - API failure (offline): Fall back to cached validation
- *      (permanent count >= 3 OR within 15-day grace period)
+ * Also forces `enableSelfHostMode` off once the entitlement stops granting
+ * self-host, so a lapsed plan's stale toggle doesn't keep reading as on.
  */
 export function useIsSelfHostEligible(): boolean | undefined {
   const settings = useSettingsValue();
   const [isEligible, setIsEligible] = React.useState<boolean | undefined>(undefined);
 
   React.useEffect(() => {
-    // No license key = not eligible, regardless of cached validation state.
-    // Also force self-host mode OFF so the toggle reflects the revoked state.
-    if (!settings.plusLicenseKey) {
-      if (settings.enableSelfHostMode) {
+    let cancelled = false;
+    void verifyEntitlement(settings.entitlementToken, {
+      expectedUserId: settings.userId,
+    }).then((claims) => {
+      if (cancelled) {
+        return;
+      }
+      const eligible = claims?.features.includes("self_host") === true;
+      if (!eligible && settings.enableSelfHostMode) {
         updateSetting("enableSelfHostMode", false);
       }
-      setIsEligible(false);
-      return;
-    }
-
-    // Has license key - always verify via API to handle key changes (e.g. believer → plus).
-    // Fall back to cached validation only when offline.
-    isSelfHostEligiblePlan()
-      .then((eligible) => {
-        if (!eligible && settings.enableSelfHostMode) {
-          updateSetting("enableSelfHostMode", false);
-        }
-        setIsEligible(eligible);
-      })
-      .catch(() => {
-        // Offline fallback: trust cached validation state
-        if (settings.selfHostValidationCount >= SELF_HOST_PERMANENT_VALIDATION_COUNT) {
-          setIsEligible(true);
-          return;
-        }
-        if (
-          settings.selfHostModeValidatedAt != null &&
-          Date.now() - settings.selfHostModeValidatedAt < SELF_HOST_GRACE_PERIOD_MS
-        ) {
-          setIsEligible(true);
-          return;
-        }
-        setIsEligible(false);
-      });
-  }, [
-    settings.plusLicenseKey,
-    settings.enableSelfHostMode,
-    settings.selfHostModeValidatedAt,
-    settings.selfHostValidationCount,
-  ]);
+      setIsEligible(eligible);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [settings.entitlementToken, settings.userId, settings.enableSelfHostMode]);
 
   return isEligible;
-}
-
-/**
- * Validate self-host mode when user enables the toggle.
- * Called from UI when toggle is switched ON.
- *
- * Flow:
- * 1. If permanently validated (count >= 3): Allow immediately (offline-safe)
- * 2. If within grace period: Allow immediately (offline-safe)
- * 3. Otherwise: Require API validation (online only)
- *    - Success: Set count = max(current, 1), update timestamp
- *    - Failure: Return false, UI should revert toggle
- *
- * @returns true if validation passed, false if user should not enable
- */
-export async function validateSelfHostMode(): Promise<boolean> {
-  const settings = getSettings();
-
-  // Already permanently validated - allow re-enable (offline-safe)
-  if (settings.selfHostValidationCount >= SELF_HOST_PERMANENT_VALIDATION_COUNT) {
-    updateSetting("selfHostModeValidatedAt", Date.now());
-    logInfo("Self-host mode re-enabled (permanently validated)");
-    return true;
-  }
-
-  // Within grace period - allow re-enable (offline-safe)
-  if (
-    settings.selfHostModeValidatedAt != null &&
-    Date.now() - settings.selfHostModeValidatedAt < SELF_HOST_GRACE_PERIOD_MS
-  ) {
-    logInfo("Self-host mode re-enabled (within grace period)");
-    return true;
-  }
-
-  // Not in grace period - require API validation (online only)
-  const isEligible = await isSelfHostEligiblePlan();
-  if (!isEligible) {
-    logInfo("Self-host mode requires an eligible plan (Believer, Supporter)");
-    new Notice("Self-host mode is only available for Believer and Supporter plan subscribers.");
-    return false;
-  }
-
-  // First-time or expired - set timestamp and initialize count
-  const newCount = Math.max(settings.selfHostValidationCount || 0, 1);
-  updateSetting("selfHostModeValidatedAt", Date.now());
-  updateSetting("selfHostValidationCount", newCount);
-  logInfo(`Self-host mode validation successful (${newCount}/3)`);
-  return true;
-}
-
-/**
- * Refresh self-host mode validation on plugin startup.
- * Called from main.ts on plugin load.
- *
- * Flow:
- * 1. If toggle OFF or permanently validated: No-op
- * 2. API check:
- *    - Eligible + 15+ days since last: Increment count, update timestamp
- *    - Eligible + <15 days: Log only (preserve countdown)
- *    - Not eligible: Disable toggle, reset count to 0
- *    - Offline/error: No-op (grace period continues)
- *
- * Count progression: 1 → 2 → 3 (permanent) over minimum 28 days.
- */
-export async function refreshSelfHostModeValidation(): Promise<void> {
-  const settings = getSettings();
-  if (!settings.enableSelfHostMode && !settings.enableMiyo) {
-    return;
-  }
-
-  // Already permanently validated, no need to refresh
-  if (settings.selfHostValidationCount >= SELF_HOST_PERMANENT_VALIDATION_COUNT) {
-    logInfo("Self-host mode permanently validated, skipping refresh");
-    return;
-  }
-
-  try {
-    const isEligible = await isSelfHostEligiblePlan();
-    if (isEligible) {
-      const now = Date.now();
-      const timeSinceLastValidation = now - (settings.selfHostModeValidatedAt || 0);
-      const shouldIncrementCount = timeSinceLastValidation >= SELF_HOST_GRACE_PERIOD_MS;
-
-      if (shouldIncrementCount) {
-        // 15+ days since last validation - increment count and update timestamp
-        const newCount = (settings.selfHostValidationCount || 0) + 1;
-        updateSetting("selfHostModeValidatedAt", now);
-        updateSetting("selfHostValidationCount", newCount);
-
-        if (newCount >= SELF_HOST_PERMANENT_VALIDATION_COUNT) {
-          logInfo("Self-host mode permanently validated (3/3)");
-          new Notice("Self-host mode is now permanently enabled!");
-        } else {
-          logInfo(`Self-host mode validation refreshed (${newCount}/3)`);
-        }
-      } else {
-        // Less than 15 days - don't update timestamp (preserve interval countdown)
-        logInfo("Self-host mode validated (waiting for 15-day interval to increment count)");
-      }
-    } else {
-      // User is no longer on an eligible plan, disable self-host mode
-      updateSetting("enableSelfHostMode", false);
-      updateSetting("enableMiyo", false);
-      updateSetting("selfHostModeValidatedAt", null);
-      updateSetting("selfHostValidationCount", 0);
-      logInfo("Self-host mode disabled - user is no longer on an eligible plan");
-      new Notice("Self-host mode has been disabled. An eligible plan is required.");
-    }
-  } catch (error) {
-    // Offline or API error - keep existing validation (grace period still applies)
-    logInfo("Could not refresh self-host mode validation (offline?):", error);
-  }
 }
 
 /**
@@ -603,7 +399,8 @@ export function turnOffPaid(app?: App): void {
 /**
  * Verify a signed entitlement token and, when valid, apply its claims to
  * settings: `isPaidUser` = tier is not free, `isPlusUser` = the `multi_agent`
- * capability is granted (tier >= Plus).
+ * capability is granted (tier >= Plus). The full granted feature set is also
+ * recorded in-memory, which is what the `self_host` gate reads.
  *
  * Returns true when the token verified and was applied, false when it could NOT
  * be verified (bad signature, expired, unknown `kid`, or — during rollout — an
@@ -617,32 +414,43 @@ export async function applyEntitlement(token: string): Promise<boolean> {
   if (!claims) {
     return false;
   }
-  const grantsMultiAgent = claims.features.includes("multi_agent");
+  verified = { token, features: new Set(claims.features), expiresAt: claims.exp * 1000 };
   setSettings({
     entitlementToken: token,
-    entitlementExpiresAt: claims.exp * 1000,
+    entitlementExpiresAt: verified.expiresAt,
     isPaidUser: claims.tier !== "free",
-    isPlusUser: grantsMultiAgent,
+    isPlusUser: verified.features.has("multi_agent"),
   });
-  strictEntitlementVerified = grantsMultiAgent;
   return true;
 }
 
 /**
- * Re-verify the persisted entitlement token at startup so the strict Plus gate
- * works offline WITHOUT trusting the persisted `isPlusUser` boolean. ES256
- * verification is offline (WebCrypto against the embedded public key), so a
- * genuine token re-proves itself with no network, while an edited data.json
- * (flipped booleans, future expiry, but no valid signature) leaves the in-memory
- * proof false and the strict gate closed. The online `/license` re-validation
- * still runs separately and overrides this with the server's fresh token.
+ * Re-verify the persisted entitlement token at startup so the strict gates work
+ * offline WITHOUT trusting persisted booleans. ES256 verification is offline
+ * (WebCrypto against the embedded public key), so a genuine token re-proves
+ * itself with no network, while an edited data.json (flipped booleans, future
+ * expiry, but no valid signature) leaves the in-memory feature set empty and
+ * every strict gate closed. The online `/license` re-validation still runs
+ * separately and overrides this with the server's fresh token.
  */
 export async function verifyCachedEntitlement(): Promise<void> {
   const { entitlementToken, userId } = getSettings();
-  if (!entitlementToken) {
-    strictEntitlementVerified = false;
+  const claims = entitlementToken
+    ? await verifyEntitlement(entitlementToken, { expectedUserId: userId })
+    : null;
+  // main.ts starts this alongside the online /license check, so that check may
+  // have installed a fresher token while this verification was in flight. Its
+  // result is authoritative; writing this pre-await snapshot over it would tag
+  // the proof with a token settings no longer hold, locking a legitimately
+  // entitled user out for the rest of the session.
+  if (getSettings().entitlementToken !== entitlementToken) {
     return;
   }
-  const claims = await verifyEntitlement(entitlementToken, { expectedUserId: userId });
-  strictEntitlementVerified = claims?.features.includes("multi_agent") === true;
+  // Otherwise re-tag even on failure: a token that stops verifying (kid
+  // rotation, tampering) must drop the capabilities an earlier check granted it.
+  verified = {
+    token: entitlementToken,
+    features: new Set(claims?.features),
+    expiresAt: (claims?.exp ?? 0) * 1000,
+  };
 }

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -114,18 +114,23 @@ const NO_VERIFIED_ENTITLEMENT: VerifiedEntitlement = Object.freeze({
 let verified: VerifiedEntitlement = NO_VERIFIED_ENTITLEMENT;
 
 /**
- * Whether the entitlement verified this session still grants `feature`: the
- * proof must belong to the token settings currently hold, and the signed `exp`
- * must not have passed — a session running past expiry loses the capability.
+ * Whether the entitlement verified this session still stands: the proof must
+ * belong to the token settings currently hold, and the signed `exp` must not
+ * have passed. This is the offline window — signature-backed, so unlike the
+ * persisted `isPaidUser` an edited `data.json` cannot widen it.
+ */
+function hasLiveEntitlement(): boolean {
+  return verified.token === getSettings().entitlementToken && Date.now() < verified.expiresAt;
+}
+
+/**
+ * Whether the entitlement verified this session still grants `feature` — a
+ * session running past the signed expiry loses the capability.
  *
  * @param feature - Capability to check for.
  */
 function hasVerifiedFeature(feature: EntitlementFeature): boolean {
-  return (
-    verified.token === getSettings().entitlementToken &&
-    verified.features.has(feature) &&
-    Date.now() < verified.expiresAt
-  );
+  return hasLiveEntitlement() && verified.features.has(feature);
 }
 
 /**
@@ -226,8 +231,13 @@ export function useCanUseMultiAgent(): boolean {
  * An unreachable server means "unknown", not "unentitled". `requestUrl` rejects
  * when offline, and callers read both a rejection and `undefined` as no license
  * — which would cut off the very offline window the signed token exists to
- * provide. So the call still happens (it is what renews the token), but a
- * transport failure answers from what verified locally instead.
+ * provide. So the call still happens (it is what renews the token), but an
+ * unknown answer defers to the signed entitlement.
+ *
+ * That fallback is the token, never the persisted `isPaidUser`: the flag knows
+ * nothing about expiry, so a renewal failing past `exp` would keep answering
+ * true and let a self-host user's turn proceed with the runtime gate already
+ * closed — quietly rerouting their searches to the cloud.
  */
 export async function checkIsPaidUser(
   app?: App,
@@ -242,7 +252,7 @@ export async function checkIsPaidUser(
     logInfo("License validation unreachable; falling back to the cached entitlement:", error);
     return { isValid: undefined };
   });
-  return result.isValid ?? isPaidEnabled();
+  return result.isValid ?? hasLiveEntitlement();
 }
 
 /**

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -222,6 +222,12 @@ export function useCanUseMultiAgent(): boolean {
 
 /**
  * Check if the user has a valid paid license (any tier, incl. Lite).
+ *
+ * An unreachable server means "unknown", not "unentitled". `requestUrl` rejects
+ * when offline, and callers read both a rejection and `undefined` as no license
+ * — which would cut off the very offline window the signed token exists to
+ * provide. So the call still happens (it is what renews the token), but a
+ * transport failure answers from what verified locally instead.
  */
 export async function checkIsPaidUser(
   app?: App,
@@ -232,8 +238,11 @@ export async function checkIsPaidUser(
     return false;
   }
   const brevilabsClient = BrevilabsClient.getInstance();
-  const result = await brevilabsClient.validateLicenseKey(app, context);
-  return result.isValid;
+  const result = await brevilabsClient.validateLicenseKey(app, context).catch((error) => {
+    logInfo("License validation unreachable; falling back to the cached entitlement:", error);
+    return { isValid: undefined };
+  });
+  return result.isValid ?? isPaidEnabled();
 }
 
 /**

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -237,15 +237,21 @@ export async function checkIsPaidUser(
 }
 
 /**
- * Reactive form of {@link isSelfHostEntitled} for the Self-Host settings tab.
+ * Whether the entitlement grants self-host, for the Self-Host settings tab —
+ * the entitlement half of {@link isSelfHostModeValid}, without the toggle.
  * Re-verifies the persisted token rather than reading the module-level verified
  * set, because that set is populated asynchronously at startup and React needs a
  * value that settles on its own. Verification is offline (WebCrypto against the
  * embedded public key), so this costs no network call. `undefined` means the
  * check is still in flight.
  *
- * Also forces `enableSelfHostMode` off once the entitlement stops granting
- * self-host, so a lapsed plan's stale toggle doesn't keep reading as on.
+ * Also forces `enableSelfHostMode` off when a token verifies and its plan does
+ * NOT grant self-host, so a downgraded plan's stale toggle doesn't keep reading
+ * as on. A token that fails to verify is not that signal — it means "unknown"
+ * (kid not shipped yet, WebCrypto unavailable, expired just before the online
+ * refresh), and clearing on it would destroy a preference no later success
+ * restores, silently leaving searches on Brevilabs cloud. Unknown closes the
+ * runtime gate via {@link isSelfHostModeValid} and leaves the preference alone.
  */
 export function useIsSelfHostEligible(): boolean | undefined {
   const settings = useSettingsValue();
@@ -260,7 +266,7 @@ export function useIsSelfHostEligible(): boolean | undefined {
         return;
       }
       const eligible = claims?.features.includes("self_host") === true;
-      if (!eligible && settings.enableSelfHostMode) {
+      if (claims && !eligible && settings.enableSelfHostMode) {
         updateSetting("enableSelfHostMode", false);
       }
       setIsEligible(eligible);

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -102,6 +102,12 @@ interface VerifiedEntitlement {
   features: ReadonlySet<EntitlementFeature>;
   /** The claims' `exp`, in epoch ms. */
   expiresAt: number;
+  /**
+   * Whether the signed tier is above free. The server downgrades a lapsed paid
+   * key to the free policy rather than refusing it a token, so liveness alone
+   * does not mean paid — this is the claim that does.
+   */
+  paid: boolean;
 }
 
 /** Frozen "nothing verified" proof — referential stability for the empty state. */
@@ -109,6 +115,7 @@ const NO_VERIFIED_ENTITLEMENT: VerifiedEntitlement = Object.freeze({
   token: "",
   features: Object.freeze(new Set<EntitlementFeature>()),
   expiresAt: 0,
+  paid: false,
 });
 
 let verified: VerifiedEntitlement = NO_VERIFIED_ENTITLEMENT;
@@ -252,7 +259,7 @@ export async function checkIsPaidUser(
     logInfo("License validation unreachable; falling back to the cached entitlement:", error);
     return { isValid: undefined };
   });
-  return result.isValid ?? hasLiveEntitlement();
+  return result.isValid ?? (hasLiveEntitlement() && verified.paid);
 }
 
 /**
@@ -439,11 +446,16 @@ export async function applyEntitlement(token: string): Promise<boolean> {
   if (!claims) {
     return false;
   }
-  verified = { token, features: new Set(claims.features), expiresAt: claims.exp * 1000 };
+  verified = {
+    token,
+    features: new Set(claims.features),
+    expiresAt: claims.exp * 1000,
+    paid: claims.tier !== "free",
+  };
   setSettings({
     entitlementToken: token,
     entitlementExpiresAt: verified.expiresAt,
-    isPaidUser: claims.tier !== "free",
+    isPaidUser: verified.paid,
     isPlusUser: verified.features.has("multi_agent"),
   });
   return true;
@@ -477,5 +489,6 @@ export async function verifyCachedEntitlement(): Promise<void> {
     token: entitlementToken,
     features: new Set(claims?.features),
     expiresAt: (claims?.exp ?? 0) * 1000,
+    paid: claims ? claims.tier !== "free" : false,
   };
 }

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -106,8 +106,6 @@ describe("findRelevantNotes", () => {
       miyoServerUrl: "",
       enableMiyo: false,
       enableSemanticSearchV3: false,
-      selfHostModeValidatedAt: null,
-      selfHostValidationCount: 0,
     } as CopilotSettings);
     mockedGetLinkedNotes.mockReturnValue([]);
     mockedGetBacklinkedNotes.mockReturnValue([]);

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -439,22 +439,18 @@ describe("sanitizeSettings - legacy Miyo settings cleanup", () => {
 });
 
 describe("sanitizeSettings - legacy self-host migration", () => {
-  it("renames legacy enableSelfHostedSearch=true to enableSelfHostMode without fabricating a receipt", () => {
+  it("renames legacy enableSelfHostedSearch=true to enableSelfHostMode", () => {
     const legacy = {
       ...DEFAULT_SETTINGS,
       enableSelfHostMode: undefined,
       enableSelfHostedSearch: true,
-      selfHostModeValidatedAt: null,
-      selfHostValidationCount: 0,
     } as unknown as CopilotSettings;
 
     const sanitized = sanitizeSettings(legacy);
 
+    // Only the user preference carries over; entitlement comes from the signed
+    // token, so there is no local receipt for sanitize to seed.
     expect(sanitized.enableSelfHostMode).toBe(true);
-    // The toggle alone gates self-host tools (isSelfHostModeValid), so sanitize
-    // must not invent a validation receipt — the receipt stays untouched.
-    expect(sanitized.selfHostModeValidatedAt).toBeNull();
-    expect(sanitized.selfHostValidationCount).toBe(0);
   });
 });
 

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -150,10 +150,6 @@ export interface CopilotSettings {
   enableMiyoSearchSkill: boolean;
   /** When true, omit folder_name from Miyo search requests so all indexed content is searched */
   miyoSearchAll: boolean;
-  /** Timestamp of last successful Believer validation for self-host mode (null if never validated) */
-  selfHostModeValidatedAt: number | null;
-  /** Count of successful periodic validations (3 = permanently valid) */
-  selfHostValidationCount: number;
   /** URL endpoint for the self-host mode backend */
   selfHostUrl: string;
   /** API key for the self-host mode backend (if required) */

--- a/src/settings/v2/components/SelfHostSettings.test.tsx
+++ b/src/settings/v2/components/SelfHostSettings.test.tsx
@@ -11,13 +11,12 @@ jest.mock("@/settings/model", () => ({
   useSettingsValue: () => currentSettings,
 }));
 
-// Plan-eligibility + validation surface. Eligible by default so the sub-section
-// fields aren't blocked by the toggle's own gating.
+// Entitlement surface. Eligible by default so the sub-section fields aren't
+// blocked by the toggle's own gating.
 let mockEligible: boolean | undefined = true;
 jest.mock("@/plusUtils", () => ({
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook
   useIsSelfHostEligible: () => mockEligible,
-  validateSelfHostMode: jest.fn(async () => true),
 }));
 
 jest.mock("@/contexts/TabContext", () => ({
@@ -32,6 +31,7 @@ const setSettings = (over: Partial<typeof DEFAULT_SETTINGS>) => {
 };
 
 const providerSelect = () => screen.getByRole<HTMLSelectElement>("combobox");
+const enableToggle = () => screen.getByRole("switch");
 
 describe("SelfHostSettings", () => {
   beforeEach(() => {
@@ -86,5 +86,24 @@ describe("SelfHostSettings", () => {
     render(<SelfHostSettings />);
 
     expect(providerSelect().disabled).toBe(false);
+  });
+
+  it("persists the toggle directly when the entitlement grants self-host", () => {
+    render(<SelfHostSettings />);
+    fireEvent.click(enableToggle());
+
+    expect(updateSetting).toHaveBeenCalledWith("enableSelfHostMode", true);
+  });
+
+  it.each([
+    ["the entitlement does not grant self-host", false],
+    ["the entitlement check has not settled yet", undefined],
+  ])("ignores clicks on the enable toggle while %s", (_case, eligible) => {
+    mockEligible = eligible;
+    render(<SelfHostSettings />);
+
+    expect(enableToggle().getAttribute("aria-disabled")).toBe("true");
+    fireEvent.click(enableToggle());
+    expect(updateSetting).not.toHaveBeenCalledWith("enableSelfHostMode", true);
   });
 });

--- a/src/settings/v2/components/SelfHostSettings.test.tsx
+++ b/src/settings/v2/components/SelfHostSettings.test.tsx
@@ -106,4 +106,17 @@ describe("SelfHostSettings", () => {
     fireEvent.click(enableToggle());
     expect(updateSetting).not.toHaveBeenCalledWith("enableSelfHostMode", true);
   });
+
+  it("lets an ineligible user turn self-host mode back off", () => {
+    // A token that stops verifying leaves the preference on (it is not an
+    // authoritative "not entitled"), so gating this direction too would strand
+    // the user with self-host stuck on and the toggle unreachable.
+    mockEligible = false;
+    setSettings({ enableSelfHostMode: true });
+    render(<SelfHostSettings />);
+
+    expect(enableToggle().getAttribute("aria-disabled")).not.toBe("true");
+    fireEvent.click(enableToggle());
+    expect(updateSetting).toHaveBeenCalledWith("enableSelfHostMode", false);
+  });
 });

--- a/src/settings/v2/components/SelfHostSettings.tsx
+++ b/src/settings/v2/components/SelfHostSettings.tsx
@@ -66,7 +66,10 @@ export const SelfHostSettings: React.FC = () => {
           onCheckedChange={(checked) => updateSetting("enableSelfHostMode", checked)}
           // Only an entitlement that grants self-host may flip this on; the
           // still-resolving `undefined` keeps it locked until the check settles.
-          disabled={isEligible !== true}
+          // Turning it OFF is always allowed — the preference is the user's to
+          // withdraw, and gating that direction too would strand anyone whose
+          // token stopped verifying with self-host stuck on and unreachable.
+          disabled={isEligible !== true && !selfHostOn}
         />
 
         <div className="tw-flex tw-items-start tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-px-3 tw-py-2.5 tw-text-xs tw-text-normal tw-bg-interactive-accent/10 tw-border-interactive-accent/30">

--- a/src/settings/v2/components/SelfHostSettings.tsx
+++ b/src/settings/v2/components/SelfHostSettings.tsx
@@ -4,10 +4,10 @@ import { SettingItem } from "@/components/ui/setting-item";
 import { SettingSection } from "@/components/ui/setting-section";
 import { useTab } from "@/contexts/TabContext";
 import { cn } from "@/lib/utils";
-import { useIsSelfHostEligible, validateSelfHostMode } from "@/plusUtils";
+import { useIsSelfHostEligible } from "@/plusUtils";
 import { updateSetting, useSettingsValue } from "@/settings/model";
 import { ArrowUpRight, ShieldCheck } from "lucide-react";
-import React, { useCallback, useState } from "react";
+import React from "react";
 
 /** BYOK tab id in the settings tab strip (see SettingsMainV2 TAB_IDS). */
 const BYOK_TAB_ID = "byok";
@@ -25,9 +25,10 @@ const SignUpLink: React.FC<{ href: string }> = ({ href }) => (
 
 /**
  * Self-Host tab. The Enable toggle writes the persisted `enableSelfHostMode`
- * flag — the truth source the cross-tab gating (Agents / BYOK model
- * enumeration, the agent spawn boundary) reads. Enabling requires a successful
- * plan validation; the toggle is disabled for ineligible plans.
+ * flag — the user-preference half of the gate that the cross-tab gating (Agents
+ * / BYOK model enumeration, the agent spawn boundary) reads. The entitlement
+ * half comes from the signed token's `self_host` feature, which also disables
+ * the toggle for plans that don't grant it.
  *
  * The sub-sections below (web-search providers/keys, self-hosted endpoint) are
  * editable while Self-Host Mode is on and disabled while it's off — the ancestor
@@ -38,26 +39,7 @@ export const SelfHostSettings: React.FC = () => {
   const settings = useSettingsValue();
   const { setSelectedTab } = useTab();
   const isEligible = useIsSelfHostEligible();
-  const [isValidating, setIsValidating] = useState(false);
   const selfHostOn = settings.enableSelfHostMode;
-
-  // Enabling requires a successful validation (offline-safe once permanently
-  // validated); disabling is immediate. Only `enableSelfHostMode` is touched
-  // here — the Miyo flag lives on its own tab.
-  const handleToggle = useCallback(async (enabled: boolean) => {
-    if (!enabled) {
-      updateSetting("enableSelfHostMode", false);
-      return;
-    }
-    setIsValidating(true);
-    try {
-      const isValid = await validateSelfHostMode();
-      if (isValid) updateSetting("enableSelfHostMode", true);
-      // validateSelfHostMode surfaces its own Notice on failure.
-    } finally {
-      setIsValidating(false);
-    }
-  }, []);
 
   return (
     <div className="tw-space-y-4">
@@ -77,14 +59,14 @@ export const SelfHostSettings: React.FC = () => {
           description={
             <span className="tw-inline-flex tw-items-center tw-gap-1.5">
               Route LLMs, embeddings and document understanding through your own endpoints.
-              <HelpTooltip content="Believer / Supporter only. Use your own infrastructure for full control and offline use. Re-validates every 15 days when online." />
+              <HelpTooltip content="Believer / Supporter only. Use your own infrastructure for full control and offline use. Stays available offline until your entitlement expires." />
             </span>
           }
           checked={selfHostOn}
-          onCheckedChange={(checked) => void handleToggle(checked)}
-          // Disable while a validation round-trip is in flight, and for plans
-          // that aren't self-host eligible (undefined = still resolving).
-          disabled={isValidating || isEligible === false}
+          onCheckedChange={(checked) => updateSetting("enableSelfHostMode", checked)}
+          // Only an entitlement that grants self-host may flip this on; the
+          // still-resolving `undefined` keeps it locked until the check settles.
+          disabled={isEligible !== true}
         />
 
         <div className="tw-flex tw-items-start tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-px-3 tw-py-2.5 tw-text-xs tw-text-normal tw-bg-interactive-accent/10 tw-border-interactive-accent/30">


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#201

> GitHub does not auto-close across repositories, so `closingIssuesReferences` is empty here (as it is on every Copilot PR). **Issue #201 needs a manual close on merge.**

## Problem

Self-host eligibility ran on ad-hoc local state in `src/plusUtils.ts`, not on the signed entitlement #200 introduced. `isSelfHostAccessValid()` read two persisted fields — `selfHostModeValidatedAt` and `selfHostValidationCount` — and returned `true` permanently once the count reached 3, otherwise within a 15-day grace window. `isSelfHostEligiblePlan()` re-validated `/license` and matched the returned plan name against a client-side `SELF_HOST_ELIGIBLE_PLANS = ["believer", "supporter"]`.

Two concrete failures:

- **A downgraded user keeps self-host forever.** Three successful checks over ~28 days set `selfHostValidationCount >= 3`, after which `refreshSelfHostModeValidation()` returns early ("permanently validated, skipping refresh") and never re-checks. A Believer who drops to Plus and stays offline retains self-host indefinitely.
- **The gate is editable.** Both fields live in `data.json`. Setting `selfHostValidationCount: 3` by hand grants self-host outright — no signature involved.

A third, smaller one: `refreshSelfHostModeValidation()` force-disabled `enableMiyo` for anyone `isSelfHostEligiblePlan()` rejected, and that returns `false` for a missing license key. Free users with Miyo connected had it switched off on every plugin load, even though Miyo's own settings UI has never gated on entitlement.

## Fix

Gate on the token's `features` instead. Verified against the backend before writing any of this — `_PLAN_POLICY` in `Brevilabs/brevilabs-api@main`, `app/services/entitlement_service.py`, already grants `self_host`:

```python
"believer":  ("plus", ["multi_agent", "self_host"]),
"supporter": ("plus", ["multi_agent", "self_host"]),
"master":    ("pro",  ["multi_agent", "self_host"]),  # internal
```

So this is a clean cut, not a dual-path rollout: the client stops mapping plan names entirely and the server owns the policy. Offline access is bounded by the token's `exp` (~14 days, `ENTITLEMENT_TTL_SECONDS`), which is signature-backed and cannot be extended by editing `data.json`. `enableSelfHostMode` stays a user preference; only the gate moved.

The in-memory `strictEntitlementVerified` boolean becomes a `{ token, features, expiresAt, paid }` proof that every gate reads through `hasLiveEntitlement()` / `hasVerifiedFeature()`. Each field comes from the same verified claims, so nothing about the grant is read back out of editable settings.

**Rejected alternative — a startup reconciler.** The obvious shape is a `reconcileSelfHostEntitlement()` at load that flips `enableSelfHostMode` off when the token stops granting the feature. That is compensating machinery: it leaves a window where the toggle reads on but the entitlement is gone, and it only corrects at startup. Making `isSelfHostModeValid()` consult the entitlement live removes the need for it — there is no stale state to reconcile.

**Why the proof is tagged with its token.** `turnOffPaid`, `markPaidPendingEntitlement`, and `turnOnPaid` all clear `entitlementToken` *and* zero `entitlementExpiresAt`, which makes `isEntitlementExpired()` return `false`. An untagged feature set therefore had to be cleared by hand in all three, or a revoked license would keep its capabilities for the rest of the session. Tagging removes all three clears: no stored token matches `""` while carrying features, so the grant lapses with the token rather than depending on every such path remembering.

## Scope

Budget gate: PASS — 14 files, +788/−576.

Production is **+213/−362** (8 files); the remainder is tests. The entitlement primitive already existed, so the production change is one gate rewritten plus the deletion of the machinery it replaces — net **−149** on production code. Seven review rounds have added no production weight beyond single conditions and one field on the in-memory proof; all of the growth is test coverage for the defects those rounds found, every one of which fails against the commit that introduced it.

## Changes

- **`src/plusUtils.ts`** (−330 net) — `isSelfHostModeValid()` now requires the toggle *and* `hasVerifiedFeature("self_host")`. Deleted `SELF_HOST_GRACE_PERIOD_MS`, `SELF_HOST_PERMANENT_VALIDATION_COUNT`, `SELF_HOST_ELIGIBLE_PLANS`, `isSelfHostAccessValid()`, `isSelfHostEligiblePlan()`, `hasSelfHostHookBypass()`, `validateSelfHostMode()`, `refreshSelfHostModeValidation()`, and `isSelfHostModeValidFor()`. `useIsSelfHostEligible()` now verifies the persisted token directly (offline WebCrypto, no network round-trip).
- **Self-host bypasses removed** from `isPaidEnabled()`, `isPlusEnabled()`, `checkIsPaidUser()`, `useIsPaidUser()`, and `useIsPlusUser()`. They are dead weight once tier comes from the token: a self-host plan's own token grants `multi_agent` and a non-free tier, so the normal path already covers those users.
- **`src/settings/model.ts`, `src/constants.ts`** — drop the `selfHostModeValidatedAt` / `selfHostValidationCount` fields and defaults.
- **`src/main.ts`** — drop the `refreshSelfHostModeValidation()` startup call; `verifyCachedEntitlement()` already runs there and now feeds both gates.
- **`src/settings/v2/components/SelfHostSettings.tsx`** — the toggle writes the preference directly instead of awaiting a validation round-trip. `disabled={isEligible !== true && !selfHostOn}` keeps it locked while the check is still resolving (previously `undefined` left it clickable) but never blocks turning self-host *off*.
- **`src/miyo/miyoUtils.ts`** — `seedDocProcessorBackend()` reads `settings.enableSelfHostMode` directly. It is a migration seed and must not depend on whether the async verification has landed, which is why it does not use the runtime gate.
- **`docs/copilot-plus-and-self-host.md`** — corrected the enable steps and added a plain-language note on how offline access works.

## Verification

- `npx jest` — 348 suites, 4930 passed, 7 skipped, 0 failed.
- `npx tsc --noEmit`, `npm run lint`, `npm run format` all clean.
- Backend claim checked at source rather than asserted: `gh api` read of `app/services/entitlement_service.py` on `main`. I could **not** exercise a live `/license` call — no license key exists in any local vault, and an invalid-key probe returns only `403 FORBIDDEN`. The policy map and the fact that prod already issues tokens for `multi_agent` are the evidence behind the clean cut.
- New coverage in `src/plusUtils.test.ts`: `self_host` granted/withheld per token, the edited-`data.json` case (persisted flags plus a future expiry but no signature verified this session), expiry-bound revocation, revocation through each of the three token-clearing paths, a token that stops verifying on re-check, and that self-host mode alone no longer grants multi-agent. This suite caught a real regression mid-review: an earlier form of `verifyCachedEntitlement()` skipped re-tagging on a failed check, which would have let a kid rotation leave stale capabilities in place.
- `SelfHostSettings.test.tsx` covers the toggle persisting directly when entitled and staying inert when not entitled or still resolving.
- **Not verified:** the end-to-end flow against a real Believer license in Obsidian. Worth a manual pass before merge.

### Review round 2

Two P1 findings, one root cause — the in-memory proof was not authoritative on its own:

- **Expiry was read back from editable settings.** `hasVerifiedFeature()` consulted the persisted `entitlementExpiresAt`, so editing `data.json` forward and leaving Obsidian running held the gate open past the token's signed `exp`. That defeated this PR's central claim. Expiry now travels in the proof, from the same verified claims as the features.
- **A stale write could clobber a fresher token.** `main.ts` starts `verifyCachedEntitlement()` alongside the online `/license` check; when that check installed a new token mid-await, the pre-await snapshot landed last and tagged the proof with a token settings no longer held. The reviewer read this as a bypass, but the token tag makes it fail *closed* — the real damage is a legitimately entitled user losing self-host and multi-agent for the rest of the session. It now skips the write when the token changed under it.

Four new assertions cover both, including the signed `exp` governing in **both** directions so the persisted setting is proven inert rather than merely unused. All four fail against the previous commit.

### Review round 4

One P1 taken, two rebutted.

**Taken — an unverifiable token was treated as "not entitled".** `verifyEntitlement()` returns `null` both for "verified, and this plan has no `self_host`" and for "could not verify at all", and `useIsSelfHostEligible` collapsed them, persisting `enableSelfHostMode = false` on either. A kid not yet shipped, unavailable WebCrypto, or an expiry crossed just before the online refresh would burn a user preference that no later success restores. Only a token that verifies and lacks the feature clears it now; unknown reports ineligible and lets `isSelfHostModeValid()` close the runtime gate, which it already does. That opens a trap the same commit closes: the clear was what kept an expired-token user's toggle consistent, so without it they would be stuck with self-host on, the toggle frozen, and cloud agent backends hidden by `registry.ts:34`. Hence the disable now applies only to turning it on.

**Rebutted — "guard the entitlement write after verification".** After the stale-key guard, the only `await` before the settings write is `verifyEntitlement()`, which is entirely local (`src/entitlement/verify.ts`): no network, no I/O. A stale write would need a full `/license` round trip to land inside a WebCrypto verify, and the swap that starts it would have made the earlier validation return at its own guard. A generation counter confirmed at the write would guard a state that cannot occur.

**Rebutted — "retry a failed startup validation before expiry".** `SearchTools.ts:584` is only reachable inside a chat turn, and every turn re-validates first: `CopilotPlusChainRunner.ts:770`, `AutonomousAgentChainRunner.ts:389`, and `toolExecution.ts:66-68` for each `isPlusOnly` tool. Each is a `/license` call that mints a fresh token, so an online user who reconnects and then searches cannot cross `exp` into a cloud reroute. The 24h timer is a backstop for an idle window, and an idle window performs no searches.

Three new `useIsSelfHostEligible()` cases plus one toggle-off case; all four fail against the previous commit.

### Signing key: deployed and verified ✅

Self-host requires a signed token — there is no tokenless path to it, by design. `issue_entitlement()` returns `None` when `ENTITLEMENT_SIGNING_KEY_PEM` is unset, `_license_response()` then omits the field, and the client's `turnOnPaid()` clears `entitlementToken`, so `hasVerifiedFeature("self_host")` could never hold. That made the prod deployment a precondition rather than a detail.

Checked directly against Railway (`api.brevilabs v1` / `brevilabs-api` / production) rather than assumed:

- `ENTITLEMENT_SIGNING_KEY_PEM` is **set**, and loads as an EC private key on `secp256r1` (P-256) — so `_load_signing_key()` returns a key rather than logging a failure and disabling issuance.
- `ENTITLEMENT_KID` is `ent-2026-06`, matching the client's `ENTITLEMENT_PUBLIC_KEYS` entry.
- The deployed private key's **public half matches the shipped JWK exactly** (both `x` and `y`). Prod-signed tokens verify against the key already in the plugin.

Also checked the rollout constraint from brevilabs-api#153 ("no released plugin that parses `entitlement` may lack the real verifying key when tokens start flowing"): `src/entitlement/publicKeys.ts` has exactly one commit in its history — a78b38c8 (#2644) — and it introduced the real key. The empty placeholder that PR described was populated before merge, so no released build ever parsed tokens without a usable key.

Multi-agent would have degraded gracefully here anyway (`isPlusEnabled()` falls through to the persisted `isPlusUser` when `entitlementExpiresAt` is 0); self-host deliberately does not, because the only tokenless signal for it is the plan name, and inferring capability from plan names client-side is exactly what this PR deletes.

**Operational note worth a runbook entry, not a code comment.** Two server-side config changes silently disable client gates with no client-side signal: unsetting `ENTITLEMENT_SIGNING_KEY_PEM` turns self-host off for everyone, and rotating to a new `kid` strips the strict gates from every already-installed plugin version until those users update. The server must keep signing with a shipped `kid` until old versions age out. Both rules currently live only in a merged PR description and a source comment.

### Review rounds 5-7

- **Offline was a hard failure.** `makeRequest()` has no try/catch around `requestUrl` (unlike `makeFormDataRequest`), so removing the self-host short-circuit from `checkIsPaidUser()` meant the transport error rejected all the way out and failed the turn with "Invalid license key" — `toolExecution.ts:66-68` never even reached its `isSelfHostModeValid()` fallback. The call still runs (it is what renews the token), but an unknown answer now defers to the signed entitlement.
- **The fallback then had the wrong authority, twice.** First it answered from `isPaidEnabled()`, which knows nothing about expiry — a renewal failing past `exp` would admit the turn with the runtime gate already closed, rerouting searches to cloud. Then `hasLiveEntitlement()` alone, which knows nothing about tier — and the backend downgrades a lapsed paid key to the free policy *rather than refusing it a token*, specifically so it cannot keep paid features offline. The proof now carries `paid` from the signed tier, and the fallback requires both.
- Every one of these was the same mistake in a different place: treating absence of proof as proof of absence, or a weaker persisted signal as equivalent to a signed one. The gates all read one proof now.

### Migration

None needed. `selfHostModeValidatedAt` and `selfHostValidationCount` are removals, not renames — settings load as `{ ...DEFAULT_SETTINGS, ...saved }`, so the stale keys in existing `data.json` files are simply never read again.

### Behavior change to confirm

`enableMiyo` is no longer force-disabled at startup (see the third bullet under Problem). This aligns with #195 making Miyo the primary local-context path, but if Miyo is meant to stay Believer/Supporter-gated, that gate should be added deliberately rather than restored as a side effect of the plan check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdTUSSqtjbKZbf2Py68EUB



