### PR TITLE
fix(entitlement): fail closed without signed entitlement

### DIFF
--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -11,12 +11,10 @@ jest.mock("@/encryptionService", () => ({
 
 const mockApplyEntitlement = jest.fn<Promise<boolean>, [string]>();
 const mockMarkPaidPendingEntitlement = jest.fn<void, []>();
-const mockTurnOnPaid = jest.fn<void, []>();
 const mockTurnOffPaid = jest.fn<void, [unknown?]>();
 jest.mock("@/plusUtils", () => ({
   applyEntitlement: (token: string) => mockApplyEntitlement(token),
   markPaidPendingEntitlement: () => mockMarkPaidPendingEntitlement(),
-  turnOnPaid: () => mockTurnOnPaid(),
   turnOffPaid: (app?: unknown) => mockTurnOffPaid(app),
 }));
 
@@ -41,7 +39,7 @@ function stubRequest(outcome: RequestOutcome, onRequest?: () => void): void {
   };
 }
 
-const VALID_LICENSE_RESPONSE = { entitlement: "signed-token", plan: "believer" };
+const VALID_LICENSE_RESPONSE = { entitlement: "signed-token", plan: "supporter" };
 
 describe("brevilabsClient", () => {
   describe("BrevilabsClient", () => {
@@ -57,27 +55,34 @@ describe("brevilabsClient", () => {
 
         const result = await BrevilabsClient.getInstance().validateLicenseKey();
 
-        expect(result).toEqual({ isValid: true, plan: "believer" });
+        expect(result).toEqual({ isValid: true, plan: "supporter" });
         expect(mockApplyEntitlement).toHaveBeenCalledWith("signed-token");
+        expect(mockMarkPaidPendingEntitlement).not.toHaveBeenCalled();
       });
 
       it("falls back to paid-pending when the server's token cannot be verified", async () => {
         mockApplyEntitlement.mockResolvedValue(false);
         stubRequest({ data: VALID_LICENSE_RESPONSE, error: null });
 
-        await BrevilabsClient.getInstance().validateLicenseKey();
+        const result = await BrevilabsClient.getInstance().validateLicenseKey();
 
+        expect(result).toEqual({ isValid: true, plan: "supporter" });
+        expect(mockApplyEntitlement).toHaveBeenCalledWith("signed-token");
         expect(mockMarkPaidPendingEntitlement).toHaveBeenCalled();
       });
 
-      it("marks a tokenless valid license as paid", async () => {
-        stubRequest({ data: { plan: "plus" }, error: null });
+      it.each(["lite", "plus"])(
+        "marks a tokenless %s license as paid pending entitlement",
+        async (plan) => {
+          stubRequest({ data: { plan }, error: null });
 
-        await BrevilabsClient.getInstance().validateLicenseKey();
+          const result = await BrevilabsClient.getInstance().validateLicenseKey();
 
-        expect(mockTurnOnPaid).toHaveBeenCalled();
-        expect(mockApplyEntitlement).not.toHaveBeenCalled();
-      });
+          expect(result).toEqual({ isValid: true, plan });
+          expect(mockMarkPaidPendingEntitlement).toHaveBeenCalled();
+          expect(mockApplyEntitlement).not.toHaveBeenCalled();
+        }
+      );
 
       it("revokes entitlement when the server rejects the key", async () => {
         stubRequest({ data: null, error: new Error("Invalid license key") });
@@ -100,7 +105,6 @@ describe("brevilabsClient", () => {
 
         expect(result).toEqual({ isValid: undefined });
         expect(mockApplyEntitlement).not.toHaveBeenCalled();
-        expect(mockTurnOnPaid).not.toHaveBeenCalled();
         expect(mockMarkPaidPendingEntitlement).not.toHaveBeenCalled();
       });
 

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -2,7 +2,7 @@ import { BREVILABS_API_BASE_URL } from "@/constants";
 import { getDecryptedKey } from "@/encryptionService";
 import { MissingPlusLicenseError } from "@/error";
 import { logInfo } from "@/logger";
-import { applyEntitlement, markPaidPendingEntitlement, turnOffPaid, turnOnPaid } from "@/plusUtils";
+import { applyEntitlement, markPaidPendingEntitlement, turnOffPaid } from "@/plusUtils";
 import { getSettings } from "@/settings/model";
 import { arrayBufferToBase64 } from "@/utils/base64";
 import { App, requestUrl } from "obsidian";
@@ -155,7 +155,7 @@ export interface Twitter4llmResponse {
 export interface LicenseResponse {
   is_valid: boolean;
   plan: string;
-  /** Signed entitlement token (JWS). Absent on servers that predate token issuance. */
+  /** Signed entitlement token (JWS). Absent when the server could not issue one. */
   entitlement?: string;
 }
 
@@ -256,9 +256,8 @@ export class BrevilabsClient {
 
   /**
    * Validate the license key and update the entitlement flags (isPaidUser /
-   * isPlusUser). When the server returns a signed entitlement token, the tier is
-   * derived from it; otherwise the no-token fallback marks any valid license as
-   * paid + Plus (safe until Lite/Pro ship with tokens).
+   * isPlusUser). A verified signed entitlement determines strict feature access;
+   * otherwise a confirmed license remains paid while those features stay closed.
    * @param context Optional context object containing the features that the user is using to validate the license key.
    * @returns true if the license key is valid, false if the license key is invalid, and undefined if
    * unknown error.
@@ -322,18 +321,14 @@ export class BrevilabsClient {
       return { isValid: undefined };
     }
     if (data?.entitlement) {
-      // Signed token present: derive tier (Plus vs Lite) from its claims. If it
-      // can't be verified (keys not shipped yet, kid rotation, clock skew), grant
-      // paid so general Plus features keep working, but withhold the strict gate —
-      // never grant multi-agent on an unverifiable token (an unverifiable Lite
-      // token must not bypass the gate), and never downgrade a confirmed license.
+      // An unverifiable token is not an authoritative negative, but it cannot
+      // grant strict features until its claims can be trusted.
       const verified = await applyEntitlement(data.entitlement);
       if (!verified) {
         markPaidPendingEntitlement();
       }
     } else {
-      // Pre-token server: any valid license is paid + Plus (no Lite tier yet).
-      turnOnPaid();
+      markPaidPendingEntitlement();
     }
     return { isValid: true, plan: data?.plan };
   }

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -28,10 +28,10 @@ import {
   applyEntitlement,
   canUseMultiAgent,
   checkIsPaidUser,
+  isPlusEnabled,
   isSelfHostModeValid,
   markPaidPendingEntitlement,
   turnOffPaid,
-  turnOnPaid,
   useIsSelfHostEligible,
   verifyCachedEntitlement,
 } from "@/plusUtils";
@@ -148,7 +148,6 @@ describe("plusUtils", () => {
     it.each([
       ["turnOffPaid", turnOffPaid],
       ["markPaidPendingEntitlement", markPaidPendingEntitlement],
-      ["turnOnPaid", turnOnPaid],
     ])("revokes self-host once %s drops the token", async (_name, clear) => {
       await verifySessionFeatures(["multi_agent", "self_host"]);
       mockGetSettings.mockReturnValue(tokenBackedSettings({ enableSelfHostMode: true }));
@@ -166,15 +165,34 @@ describe("plusUtils", () => {
     });
   });
 
+  describe("markPaidPendingEntitlement()", () => {
+    it("keeps paid access while clearing the entitlement and withholding strict features", async () => {
+      await verifySessionFeatures(["multi_agent", "self_host"]);
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({ enableSelfHostMode: true, isPaidUser: true, isPlusUser: true })
+      );
+      expect(isPlusEnabled()).toBe(true);
+      expect(isSelfHostModeValid()).toBe(true);
+
+      markPaidPendingEntitlement();
+
+      const pendingState = {
+        isPaidUser: true,
+        isPlusUser: false,
+        entitlementToken: "",
+        entitlementExpiresAt: 0,
+      };
+      expect(mockSetSettings).toHaveBeenCalledWith(pendingState);
+      mockGetSettings.mockReturnValue(buildSettings({ enableSelfHostMode: true, ...pendingState }));
+      expect(isPlusEnabled()).toBe(false);
+      expect(isSelfHostModeValid()).toBe(false);
+    });
+  });
+
   describe("canUseMultiAgent()", () => {
     it("returns false for a free user", () => {
       mockGetSettings.mockReturnValue(buildSettings({ isPlusUser: false }));
       expect(canUseMultiAgent()).toBe(false);
-    });
-
-    it("returns true for a Plus user on the tokenless fallback", () => {
-      mockGetSettings.mockReturnValue(buildSettings({ isPlusUser: true }));
-      expect(canUseMultiAgent()).toBe(true);
     });
 
     it("returns false for a Lite user (paid but below Plus)", () => {
@@ -217,10 +235,10 @@ describe("plusUtils", () => {
       mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123" }));
     });
 
-    it("grants Plus and self-host for a Believer token carrying both features", async () => {
+    it("grants Plus and self-host for a Supporter token carrying both features", async () => {
       mockVerifyEntitlement.mockResolvedValue({
         user_id: "user-123",
-        plan: "believer",
+        plan: "supporter",
         tier: "plus",
         features: ["multi_agent", "self_host"],
         iat: 0,
@@ -261,11 +279,11 @@ describe("plusUtils", () => {
       expect(isSelfHostModeValid()).toBe(false);
     });
 
-    it("grants Plus without self-host for a Pro token", async () => {
+    it("grants Plus without self-host for a Plus token", async () => {
       mockVerifyEntitlement.mockResolvedValue({
         user_id: "user-123",
-        plan: "pro",
-        tier: "pro",
+        plan: "plus",
+        tier: "plus",
         features: ["multi_agent"],
         iat: 0,
         exp: FUTURE_EXP_SECONDS,

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -71,10 +71,11 @@ export function isPaidEnabled(): boolean {
 }
 
 /**
- * True once the PERSISTED expiry has passed (0 = tokenless fallback, never
- * expired). This reads editable state, so it only ever tightens the reactive
- * `useIsPlusUser` render gate — the strict gates take expiry from the signed
- * claims in {@link VerifiedEntitlement}, which an edited `data.json` can't move.
+ * True once the persisted signed-entitlement expiry has passed. Zero means no
+ * token-derived expiry is stored. Because this reads editable state, it only
+ * tightens the reactive `useIsPlusUser` render gate — the strict gates take
+ * expiry from the signed claims in {@link VerifiedEntitlement}, which an edited
+ * `data.json` can't move.
  */
 function isEntitlementExpired(settings: CopilotSettings): boolean {
   return settings.entitlementExpiresAt > 0 && Date.now() >= settings.entitlementExpiresAt;
@@ -93,9 +94,9 @@ function isEntitlementExpired(settings: CopilotSettings): boolean {
  * `exp` for as long as the session lived.
  *
  * `token` is what settings must still hold for the proof to apply. That is how
- * the paths that drop the token (turnOffPaid, markPaidPendingEntitlement,
- * turnOnPaid) revoke these capabilities without touching this state: no stored
- * token can match `""` while carrying features.
+ * the paths that drop the token (turnOffPaid and markPaidPendingEntitlement)
+ * revoke these capabilities without touching this state: no stored token can
+ * match `""` while carrying features.
  */
 interface VerifiedEntitlement {
   token: string;
@@ -153,8 +154,8 @@ export function isPlusEnabled(): boolean {
   if (settings.entitlementExpiresAt > 0) {
     return hasVerifiedFeature("multi_agent");
   }
-  // Tokenless fallback (server has not issued a signed entitlement yet): no
-  // artifact exists to verify, so honor the license-confirmed flag as before.
+  // Preserve an existing tokenless state until an authoritative validation
+  // replaces it. Current tokenless successes persist this flag as false.
   return settings.isPlusUser === true;
 }
 
@@ -202,7 +203,7 @@ export async function ensureMultiAgentEntitlement(
     return true;
   }
   // Re-verify so a stale-false cache for a real Plus user still gets through;
-  // `validateLicenseKey` applies the signed entitlement (or fallback) to settings.
+  // `validateLicenseKey` applies the signed entitlement or paid-pending state.
   await BrevilabsClient.getInstance().validateLicenseKey(app, {
     feature: "multi_agent_per_turn",
     ...context,
@@ -367,27 +368,9 @@ export function navigateToPlusPage(medium: PlusUtmMedium): void {
 }
 
 /**
- * Mark the user as paid via the no-token fallback path (valid license, but the
- * server didn't issue a signed entitlement yet). Sets both flags true and clears
- * any stale token. `isPlusUser` mirrors `isPaidUser` here because no sub-Plus
- * paid tier exists until the server ships tokens + Lite/Pro together — so this is
- * safe and preserves today's behavior. See "Copilot Entitlement Token Design".
- */
-export function turnOnPaid(): void {
-  setSettings({
-    isPaidUser: true,
-    isPlusUser: true,
-    entitlementToken: "",
-    entitlementExpiresAt: 0,
-  });
-}
-
-/**
- * Paid license confirmed by the server, but its entitlement token could not be
- * verified (verifying key not shipped yet / kid rotation). Grant paid so general
- * Plus features keep working, but WITHHOLD the strict gate — otherwise an
- * unverifiable Lite token would bypass the multi-agent gate. Fails closed for
- * multi-agent until the matching public key ships.
+ * Paid license confirmed by the server, but no entitlement token was supplied
+ * or the supplied token could not be verified. Keep broad paid access while
+ * withholding strict features until a signed entitlement verifies.
  */
 export function markPaidPendingEntitlement(): void {
   setSettings({

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -146,16 +146,16 @@ export interface CopilotSettings {
   defaultConversationNoteName: string;
   // Any valid paid license (Lite and above). undefined means never checked.
   isPaidUser: boolean | undefined;
-  // Tier >= Plus (Plus, Pro, Believer, Supporter; excludes Lite). Derived from
-  // the signed entitlement token when present, else mirrors isPaidUser as a
-  // safe fallback. undefined means never checked. See plusUtils + entitlement/.
+  // Tier >= Plus (Plus, Pro, Believer, Supporter; excludes Lite). Current
+  // validations derive it from a verified signed entitlement; undefined means
+  // never checked. See plusUtils + entitlement/.
   isPlusUser: boolean | undefined;
   // Raw server-signed entitlement token (JWS). Tamper-evident, so safe to persist
-  // and trust offline until its `exp`. Empty when the server hasn't issued one.
+  // and trust offline until its `exp`. Empty when no verified token is stored.
   entitlementToken: string;
-  // Epoch ms when the entitlement token expires (0 = none / tokenless fallback).
-  // The strict isPlusUser gate honors this so multi-agent locks at expiry even
-  // while offline. Derived from the token's `exp`.
+  // Epoch ms when the entitlement token expires (0 = no verified entitlement).
+  // The reactive tier UI reads this; strict gates use the in-memory verified
+  // claims. Derived from the token's `exp`.
   entitlementExpiresAt: number;
   inlineEditCommands: LegacyCommandSettings[] | undefined;
   projectList: Array<ProjectConfig>;


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#256

## Problem

`BrevilabsClient.validateLicenseKey()` treated a successful `/license` response with no signed `entitlement` as fully Plus by calling `turnOnPaid()`. If the API signing key is missing or token issuance fails, a valid Lite license could therefore enable multi-agent even though no entitlement was verified.

## Fix

Route every success without a verified entitlement through `markPaidPendingEntitlement()`: broad paid access remains available, while Plus/multi-agent and self-host stay closed and no entitlement is stored. Signed Lite, Plus, and Supporter claims still flow through `applyEntitlement()`, and invalid-key, network-error, and stale-overlap paths are unchanged. `turnOnPaid()` and stale compatibility comments/tests are removed; raw `plan` remains return-only.

Lite rollout still depends on [Brevilabs/brevilabs-api#157](https://github.com/Brevilabs/brevilabs-api/issues/157) ensuring entitlement signing is configured and ready before launch.

GitHub did not populate `closingIssuesReferences` for this cross-repo link, so issue #256 must be verified and manually closed on merge if it remains open.

## Scope

Budget gate: PASS — 5 files, +74/−74; this reuses the existing paid-pending state for missing and unverifiable entitlements and deletes the obsolete promoter without adding a new authorization path.

## Changes

- Route tokenless license successes to the same fail-closed state as signed but unverifiable responses.
- Remove `turnOnPaid()` and update entitlement-state comments to match the verified-token contract.
- Cover tokenless Lite/Plus, signed Lite/Plus/Supporter, and unverifiable-token behavior while retaining existing failure and overlap coverage.

## Verification

- `npm run format && npm run lint` — passed.
- `npm test -- --runInBand src/LLMProviders/brevilabsClient.test.ts src/plusUtils.test.ts` — 2 suites and 39 tests passed.
- `npm run test` — 361 suites and 5,191 tests passed.
- `git diff --check` — passed.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)
