### PR TITLE
feat(agent-mode): cycle sample prompts in the composer placeholder

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -26,6 +26,16 @@ When the autonomous agent is enabled, Copilot can:
 
 The agent activates automatically when you're in **Copilot Plus** mode. You don't need to do anything special — just ask your question.
 
+## Sample Prompts in the Message Box
+
+When you open a new agent chat and the message box is empty, Copilot types out sample prompts there one at a time — each appears character by character, pauses so you can read it, clears itself, and gives way to the next. They are examples of what the agent can do with your vault, not something being sent.
+
+- Press **Tab** while a suggestion is on screen to drop the whole prompt into the message box. Nothing is sent: edit it first, or press Enter to send it as-is.
+- Start typing at any point and the suggestions disappear. Clear the box again and they come back.
+- Once the conversation has started, the suggestions stop for that chat.
+
+If you've turned on reduced motion in your operating system, the prompts still rotate but appear and disappear whole instead of typing out.
+
 ## Choosing an Operating Mode
 
 The mode picker beside the message box controls how much the active agent can do:

--- a/src/agentMode/ui/AgentChatInput.test.tsx
+++ b/src/agentMode/ui/AgentChatInput.test.tsx
@@ -1,5 +1,6 @@
 import { EMPTY_AGENT_MENTION_BRANDS } from "@/components/chat-components/hooks/useAtMentionCategories";
 import { AgentChatInput } from "@/agentMode/ui/AgentChatInput";
+import { AGENT_PROMPT_SUGGESTIONS } from "@/agentMode/ui/agentPromptSuggestions";
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
 import type { AgentInputDraftControls } from "@/agentMode/ui/hooks/useAgentInputDrafts";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -33,15 +34,18 @@ jest.mock("@/agentMode/ui/mentionedAgents", () => ({
 // key hits (send-flow regression tests).
 let capturedAgentBrands: ReadonlyArray<unknown> | undefined;
 let capturedTopRightAccessory: React.ReactNode | undefined;
+let capturedPlaceholderPrompts: ReadonlyArray<string> | undefined;
 jest.mock("@/components/chat-components/ChatInput", () => ({
   __esModule: true,
   default: (props: {
     agentBrands?: ReadonlyArray<unknown>;
     topRightAccessory?: React.ReactNode;
+    placeholderPrompts?: ReadonlyArray<string>;
     handleSendMessage?: () => void;
   }) => {
     capturedAgentBrands = props.agentBrands;
     capturedTopRightAccessory = props.topRightAccessory;
+    capturedPlaceholderPrompts = props.placeholderPrompts;
     return (
       <>
         {props.topRightAccessory}
@@ -169,6 +173,37 @@ describe("AgentChatInput identity and agent-mention gate", () => {
       makeDraft()
     );
     expect(capturedAgentBrands).toBe(EMPTY_AGENT_MENTION_BRANDS);
+  });
+});
+
+describe("AgentChatInput sample-prompt placeholder", () => {
+  const backend = () =>
+    ({ sendMessage: jest.fn(), cancel: jest.fn() }) as unknown as AgentChatBackend;
+
+  beforeEach(() => {
+    capturedPlaceholderPrompts = undefined;
+    mockUseCanUseMultiAgent.mockReturnValue(true);
+  });
+
+  it("offers the sample prompts on an untouched landing", () => {
+    renderInput(backend(), makeDraft({ input: "" }), { isLanding: true });
+    expect(capturedPlaceholderPrompts).toBe(AGENT_PROMPT_SUGGESTIONS);
+  });
+
+  it("withholds them in a conversation, where the composer is no longer a landing", () => {
+    renderInput(backend(), makeDraft({ input: "" }), { isLanding: false });
+    expect(capturedPlaceholderPrompts).toBeUndefined();
+  });
+
+  it("offers them again once a draft is cleared, including a suggestion the user took", () => {
+    const chat = backend();
+    const view = renderInput(chat, makeDraft({ input: "" }), { isLanding: true });
+
+    // Accepting a suggestion (or typing) fills the composer — Lexical hides the
+    // placeholder while it holds text.
+    view.rerender(inputNode(chat, makeDraft({ input: "Summarize my week" }), { isLanding: true }));
+    view.rerender(inputNode(chat, makeDraft({ input: "" }), { isLanding: true }));
+    expect(capturedPlaceholderPrompts).toBe(AGENT_PROMPT_SUGGESTIONS);
   });
 });
 

--- a/src/agentMode/ui/AgentChatInput.test.tsx
+++ b/src/agentMode/ui/AgentChatInput.test.tsx
@@ -137,298 +137,302 @@ const renderInput = (
   extraProps: Partial<React.ComponentProps<typeof AgentChatInput>> = {}
 ) => render(inputNode(backend, draft, extraProps));
 
-describe("AgentChatInput identity and agent-mention gate", () => {
-  beforeEach(() => {
-    capturedAgentBrands = undefined;
-    mockNavigateToPlusPage.mockClear();
-  });
-
-  it("passes the real installed-agent list when entitled", () => {
-    mockUseCanUseMultiAgent.mockReturnValue(true);
-    renderInput(
-      { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend,
-      makeDraft()
-    );
-    expect(capturedAgentBrands).toBe(FAKE_BRANDS);
-  });
-
-  it("clears input-scoped context only when the logical chat input changes", () => {
-    const clearSelectedTextContexts = jest.requireMock("@/aiParams")
-      .clearSelectedTextContexts as jest.Mock;
-    clearSelectedTextContexts.mockClear();
-    const backend = { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend;
-    const draft = makeDraft();
-    const view = renderInput(backend, draft);
-
-    view.rerender(inputNode(backend, draft, { chatInputId: "input-1" }));
-    expect(clearSelectedTextContexts).not.toHaveBeenCalled();
-    view.rerender(inputNode(backend, draft, { chatInputId: "input-2" }));
-    expect(clearSelectedTextContexts).toHaveBeenCalledTimes(1);
-  });
-
-  it("passes the frozen empty list (not a fresh []) when not entitled", () => {
-    mockUseCanUseMultiAgent.mockReturnValue(false);
-    renderInput(
-      { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend,
-      makeDraft()
-    );
-    expect(capturedAgentBrands).toBe(EMPTY_AGENT_MENTION_BRANDS);
-  });
-});
-
-describe("AgentChatInput sample-prompt placeholder", () => {
-  const backend = () =>
-    ({ sendMessage: jest.fn(), cancel: jest.fn() }) as unknown as AgentChatBackend;
-
-  beforeEach(() => {
-    capturedPlaceholderPrompts = undefined;
-    mockUseCanUseMultiAgent.mockReturnValue(true);
-  });
-
-  it("offers the sample prompts on an untouched landing", () => {
-    renderInput(backend(), makeDraft({ input: "" }), { isLanding: true });
-    expect(capturedPlaceholderPrompts).toBe(AGENT_PROMPT_SUGGESTIONS);
-  });
-
-  it("withholds them in a conversation, where the composer is no longer a landing", () => {
-    renderInput(backend(), makeDraft({ input: "" }), { isLanding: false });
-    expect(capturedPlaceholderPrompts).toBeUndefined();
-  });
-
-  it("offers them again once a draft is cleared, including a suggestion the user took", () => {
-    const chat = backend();
-    const view = renderInput(chat, makeDraft({ input: "" }), { isLanding: true });
-
-    // Accepting a suggestion (or typing) fills the composer — Lexical hides the
-    // placeholder while it holds text.
-    view.rerender(inputNode(chat, makeDraft({ input: "Summarize my week" }), { isLanding: true }));
-    view.rerender(inputNode(chat, makeDraft({ input: "" }), { isLanding: true }));
-    expect(capturedPlaceholderPrompts).toBe(AGENT_PROMPT_SUGGESTIONS);
-  });
-});
-
-describe("AgentChatInput turn-completion loading reset", () => {
-  it("regression: clears draft.loading when the turn resolves after the composer unmounted", async () => {
-    // First send from a landing: the user message lands, AgentHome flips
-    // landing→conversation, and the composer remounts mid-turn. The unmounting
-    // instance's runSend must still clear the shared draft's loading flag,
-    // or the Thinking spinner / stop button stick forever (#stuck-thinking).
-    let resolveTurn!: () => void;
-    const turn = new Promise<void>((resolve) => {
-      resolveTurn = resolve;
-    });
-    const backend = {
-      sendMessage: jest.fn(() => ({ turn })),
-      cancel: jest.fn(),
-    } as unknown as AgentChatBackend;
-    const draft = makeDraft();
-
-    const { unmount } = renderInput(backend, draft);
-    fireEvent.click(screen.getByText("send"));
-
-    await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(true));
-    expect(backend.sendMessage).toHaveBeenCalledTimes(1);
-
-    // The landing→conversation flip unmounts this composer instance while the
-    // turn is still in flight.
-    unmount();
-
-    await act(async () => {
-      resolveTurn();
-      await turn;
+describe("AgentChatInput", () => {
+  describe("identity and agent-mention gate", () => {
+    beforeEach(() => {
+      capturedAgentBrands = undefined;
+      mockNavigateToPlusPage.mockClear();
     });
 
-    await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(false));
-  });
-});
-
-describe("AgentChatInput queue reason", () => {
-  const makeBackend = () =>
-    ({
-      sendMessage: jest.fn(() => ({ turn: Promise.resolve() })),
-      cancel: jest.fn(),
-    }) as unknown as AgentChatBackend;
-
-  /** Apply the functional updater handed to setQueue and return the enqueued item. */
-  const enqueuedItem = (setQueue: jest.Mock) => {
-    const updater = setQueue.mock.calls[0][0] as (
-      q: readonly unknown[]
-    ) => { queueReason?: string }[];
-    return updater([])[0];
-  };
-
-  beforeEach(() => {
-    mockUseCanUseMultiAgent.mockReturnValue(true);
-  });
-
-  it("snapshots 'context' when the send is held for project-context materialization", async () => {
-    const backend = makeBackend();
-    const draft = makeDraft();
-
-    renderInput(backend, draft, { activeProjectId: "proj-1", contextLoadBlocking: true });
-    fireEvent.click(screen.getByText("send"));
-    await waitFor(() => expect(draft.setQueue).toHaveBeenCalled());
-
-    expect(backend.sendMessage).not.toHaveBeenCalled();
-    expect(enqueuedItem(draft.setQueue as jest.Mock).queueReason).toBe("context");
-  });
-
-  it("snapshots 'busy' when queued behind an in-flight turn", async () => {
-    const backend = makeBackend();
-    const draft = makeDraft({ loading: true });
-
-    renderInput(backend, draft);
-    fireEvent.click(screen.getByText("send"));
-    await waitFor(() => expect(draft.setQueue).toHaveBeenCalled());
-
-    expect(backend.sendMessage).not.toHaveBeenCalled();
-    expect(enqueuedItem(draft.setQueue as jest.Mock).queueReason).toBe("busy");
-  });
-
-  it("labels only context-held rows with the amber waiting prefix", () => {
-    const draft = makeDraft({
-      queue: [
-        {
-          id: "q1",
-          text: "held for context",
-          rawInput: "held for context",
-          queueReason: "context",
-        },
-        { id: "q2", text: "held while busy", rawInput: "held while busy", queueReason: "busy" },
-      ],
+    it("passes the real installed-agent list when entitled", () => {
+      mockUseCanUseMultiAgent.mockReturnValue(true);
+      renderInput(
+        { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend,
+        makeDraft()
+      );
+      expect(capturedAgentBrands).toBe(FAKE_BRANDS);
     });
 
-    renderInput(makeBackend(), draft);
+    it("clears input-scoped context only when the logical chat input changes", () => {
+      const clearSelectedTextContexts = jest.requireMock("@/aiParams")
+        .clearSelectedTextContexts as jest.Mock;
+      clearSelectedTextContexts.mockClear();
+      const backend = { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend;
+      const draft = makeDraft();
+      const view = renderInput(backend, draft);
 
-    const rows = screen.getAllByTitle(/held/);
-    expect(rows[0].textContent).toContain("Waiting for context · held for context");
-    expect(rows[1].textContent).toContain("held while busy");
-    expect(rows[1].textContent).not.toContain("Waiting for context");
-  });
-
-  it("keeps queued images when the active model is known not to support vision", async () => {
-    const backend = makeBackend();
-    const draft = makeDraft({
-      queue: [
-        {
-          id: "q1",
-          text: "describe this",
-          rawInput: "describe this",
-          promptContent: [{ type: "image", mimeType: "image/png", data: "AA==" }],
-        },
-      ],
+      view.rerender(inputNode(backend, draft, { chatInputId: "input-1" }));
+      expect(clearSelectedTextContexts).not.toHaveBeenCalled();
+      view.rerender(inputNode(backend, draft, { chatInputId: "input-2" }));
+      expect(clearSelectedTextContexts).toHaveBeenCalledTimes(1);
     });
 
-    renderInput(backend, draft, {
-      modelPickerOverride: {
-        models: [
+    it("passes the frozen empty list (not a fresh []) when not entitled", () => {
+      mockUseCanUseMultiAgent.mockReturnValue(false);
+      renderInput(
+        { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend,
+        makeDraft()
+      );
+      expect(capturedAgentBrands).toBe(EMPTY_AGENT_MENTION_BRANDS);
+    });
+  });
+
+  describe("sample-prompt placeholder", () => {
+    const backend = () =>
+      ({ sendMessage: jest.fn(), cancel: jest.fn() }) as unknown as AgentChatBackend;
+
+    beforeEach(() => {
+      capturedPlaceholderPrompts = undefined;
+      mockUseCanUseMultiAgent.mockReturnValue(true);
+    });
+
+    it("offers the sample prompts on an untouched landing", () => {
+      renderInput(backend(), makeDraft({ input: "" }), { isLanding: true });
+      expect(capturedPlaceholderPrompts).toBe(AGENT_PROMPT_SUGGESTIONS);
+    });
+
+    it("withholds them in a conversation, where the composer is no longer a landing", () => {
+      renderInput(backend(), makeDraft({ input: "" }), { isLanding: false });
+      expect(capturedPlaceholderPrompts).toBeUndefined();
+    });
+
+    it("offers them again once a draft is cleared, including a suggestion the user took", () => {
+      const chat = backend();
+      const view = renderInput(chat, makeDraft({ input: "" }), { isLanding: true });
+
+      // Accepting a suggestion (or typing) fills the composer — Lexical hides the
+      // placeholder while it holds text.
+      view.rerender(
+        inputNode(chat, makeDraft({ input: "Summarize my week" }), { isLanding: true })
+      );
+      view.rerender(inputNode(chat, makeDraft({ input: "" }), { isLanding: true }));
+      expect(capturedPlaceholderPrompts).toBe(AGENT_PROMPT_SUGGESTIONS);
+    });
+  });
+
+  describe("turn-completion loading reset", () => {
+    it("regression: clears draft.loading when the turn resolves after the composer unmounted", async () => {
+      // First send from a landing: the user message lands, AgentHome flips
+      // landing→conversation, and the composer remounts mid-turn. The unmounting
+      // instance's runSend must still clear the shared draft's loading flag,
+      // or the Thinking spinner / stop button stick forever (#stuck-thinking).
+      let resolveTurn!: () => void;
+      const turn = new Promise<void>((resolve) => {
+        resolveTurn = resolve;
+      });
+      const backend = {
+        sendMessage: jest.fn(() => ({ turn })),
+        cancel: jest.fn(),
+      } as unknown as AgentChatBackend;
+      const draft = makeDraft();
+
+      const { unmount } = renderInput(backend, draft);
+      fireEvent.click(screen.getByText("send"));
+
+      await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(true));
+      expect(backend.sendMessage).toHaveBeenCalledTimes(1);
+
+      // The landing→conversation flip unmounts this composer instance while the
+      // turn is still in flight.
+      unmount();
+
+      await act(async () => {
+        resolveTurn();
+        await turn;
+      });
+
+      await waitFor(() => expect(draft.setLoading).toHaveBeenCalledWith(false));
+    });
+  });
+
+  describe("queue reason", () => {
+    const makeBackend = () =>
+      ({
+        sendMessage: jest.fn(() => ({ turn: Promise.resolve() })),
+        cancel: jest.fn(),
+      }) as unknown as AgentChatBackend;
+
+    /** Apply the functional updater handed to setQueue and return the enqueued item. */
+    const enqueuedItem = (setQueue: jest.Mock) => {
+      const updater = setQueue.mock.calls[0][0] as (
+        q: readonly unknown[]
+      ) => { queueReason?: string }[];
+      return updater([])[0];
+    };
+
+    beforeEach(() => {
+      mockUseCanUseMultiAgent.mockReturnValue(true);
+    });
+
+    it("snapshots 'context' when the send is held for project-context materialization", async () => {
+      const backend = makeBackend();
+      const draft = makeDraft();
+
+      renderInput(backend, draft, { activeProjectId: "proj-1", contextLoadBlocking: true });
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(draft.setQueue).toHaveBeenCalled());
+
+      expect(backend.sendMessage).not.toHaveBeenCalled();
+      expect(enqueuedItem(draft.setQueue as jest.Mock).queueReason).toBe("context");
+    });
+
+    it("snapshots 'busy' when queued behind an in-flight turn", async () => {
+      const backend = makeBackend();
+      const draft = makeDraft({ loading: true });
+
+      renderInput(backend, draft);
+      fireEvent.click(screen.getByText("send"));
+      await waitFor(() => expect(draft.setQueue).toHaveBeenCalled());
+
+      expect(backend.sendMessage).not.toHaveBeenCalled();
+      expect(enqueuedItem(draft.setQueue as jest.Mock).queueReason).toBe("busy");
+    });
+
+    it("labels only context-held rows with the amber waiting prefix", () => {
+      const draft = makeDraft({
+        queue: [
           {
-            name: "text-only",
-            provider: "agent",
-            enabled: true,
-            capabilities: [],
+            id: "q1",
+            text: "held for context",
+            rawInput: "held for context",
+            queueReason: "context",
+          },
+          { id: "q2", text: "held while busy", rawInput: "held while busy", queueReason: "busy" },
+        ],
+      });
+
+      renderInput(makeBackend(), draft);
+
+      const rows = screen.getAllByTitle(/held/);
+      expect(rows[0].textContent).toContain("Waiting for context · held for context");
+      expect(rows[1].textContent).toContain("held while busy");
+      expect(rows[1].textContent).not.toContain("Waiting for context");
+    });
+
+    it("keeps queued images when the active model is known not to support vision", async () => {
+      const backend = makeBackend();
+      const draft = makeDraft({
+        queue: [
+          {
+            id: "q1",
+            text: "describe this",
+            rawInput: "describe this",
+            promptContent: [{ type: "image", mimeType: "image/png", data: "AA==" }],
           },
         ],
-        value: "text-only|agent",
-        onChange: jest.fn(),
-      },
+      });
+
+      renderInput(backend, draft, {
+        modelPickerOverride: {
+          models: [
+            {
+              name: "text-only",
+              provider: "agent",
+              enabled: true,
+              capabilities: [],
+            },
+          ],
+          value: "text-only|agent",
+          onChange: jest.fn(),
+        },
+      });
+      await act(async () => {});
+
+      expect(backend.sendMessage).not.toHaveBeenCalled();
+      expect(draft.setQueue).not.toHaveBeenCalled();
     });
-    await act(async () => {});
-
-    expect(backend.sendMessage).not.toHaveBeenCalled();
-    expect(draft.setQueue).not.toHaveBeenCalled();
-  });
-});
-
-describe("AgentChatInput status-icon boundary", () => {
-  // Locks the #205 layering decision: AgentChatInput owns the project-context
-  // status node and hands it to the shared ChatInput only through the neutral
-  // topRightAccessory slot — the shared component never learns what it is.
-  beforeEach(() => {
-    capturedTopRightAccessory = undefined;
-    mockUseCanUseMultiAgent.mockReturnValue(true);
   });
 
-  it("passes the indicator through the accessory slot when mounted", () => {
-    const backend = { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend;
-
-    renderInput(backend, makeDraft(), { contextStatusIndicator: <span>status</span> });
-    expect(capturedTopRightAccessory).toBeTruthy();
-    expect(screen.getByText("status")).toBeTruthy();
-  });
-
-  it("passes no accessory when there is no indicator (global scope)", () => {
-    const backend = { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend;
-
-    renderInput(backend, makeDraft());
-    expect(capturedTopRightAccessory).toBeUndefined();
-  });
-});
-
-describe("AgentChatInput compose reset ordering", () => {
-  beforeEach(() => {
-    mockUseCanUseMultiAgent.mockReturnValue(true);
-  });
-
-  it("regression: clears the composer before awaiting attached-image conversion (#211)", async () => {
-    // Hold the image read open so ordering is observable. The composer must
-    // clear the instant the user sends, not after every File.arrayBuffer()
-    // resolves — leaving the draft populated across those awaits let the
-    // Lexical editor race resetCompose and strand the just-sent text in the
-    // input when text was sent alongside images.
-    let resolveRead!: (buf: ArrayBuffer) => void;
-    const image = {
-      type: "image/png",
-      arrayBuffer: () =>
-        new Promise<ArrayBuffer>((resolve) => {
-          resolveRead = resolve;
-        }),
-    } as unknown as File;
-
-    const backend = {
-      sendMessage: jest.fn(() => ({ turn: Promise.resolve() })),
-      cancel: jest.fn(),
-    } as unknown as AgentChatBackend;
-    const draft = makeDraft({ images: [image] });
-
-    renderInput(backend, draft);
-    fireEvent.click(screen.getByText("send"));
-
-    // Composer is cleared while the image read is still pending, before the
-    // turn is dispatched.
-    await waitFor(() => expect(draft.resetCompose).toHaveBeenCalledTimes(1));
-    expect(backend.sendMessage).not.toHaveBeenCalled();
-
-    // Finishing the read lets the turn fire with the converted image attached.
-    await act(async () => {
-      resolveRead(new ArrayBuffer(1));
-      await Promise.resolve();
+  describe("status-icon boundary", () => {
+    // Locks the #205 layering decision: AgentChatInput owns the project-context
+    // status node and hands it to the shared ChatInput only through the neutral
+    // topRightAccessory slot — the shared component never learns what it is.
+    beforeEach(() => {
+      capturedTopRightAccessory = undefined;
+      mockUseCanUseMultiAgent.mockReturnValue(true);
     });
-    await waitFor(() => expect(backend.sendMessage).toHaveBeenCalledTimes(1));
-    const promptContent = (backend.sendMessage as jest.Mock).mock.calls[0][2];
-    expect(promptContent).toHaveLength(1);
-    expect(promptContent[0].type).toBe("image");
+
+    it("passes the indicator through the accessory slot when mounted", () => {
+      const backend = { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend;
+
+      renderInput(backend, makeDraft(), { contextStatusIndicator: <span>status</span> });
+      expect(capturedTopRightAccessory).toBeTruthy();
+      expect(screen.getByText("status")).toBeTruthy();
+    });
+
+    it("passes no accessory when there is no indicator (global scope)", () => {
+      const backend = { sendMessage: jest.fn(), cancel: jest.fn() } as unknown as AgentChatBackend;
+
+      renderInput(backend, makeDraft());
+      expect(capturedTopRightAccessory).toBeUndefined();
+    });
   });
-});
 
-describe("AgentChatInput hard-disable", () => {
-  it("drops a send when the composer is disabled (orphaned project)", async () => {
-    // The mocked ChatInput's send button routes through handleSendMessage — the
-    // same entry the real Lexical editor's Enter key hits. A hard-disabled
-    // composer only dims + blocks pointer events in the DOM, so this keyboard
-    // path must be gated in the handler or a turn leaks into a dead project.
-    const backend = {
-      sendMessage: jest.fn(() => ({ turn: Promise.resolve() })),
-      cancel: jest.fn(),
-    } as unknown as AgentChatBackend;
-    const draft = makeDraft();
+  describe("compose reset ordering", () => {
+    beforeEach(() => {
+      mockUseCanUseMultiAgent.mockReturnValue(true);
+    });
 
-    renderInput(backend, draft, { disabled: true });
-    fireEvent.click(screen.getByText("send"));
-    await act(async () => {});
+    it("regression: clears the composer before awaiting attached-image conversion (#211)", async () => {
+      // Hold the image read open so ordering is observable. The composer must
+      // clear the instant the user sends, not after every File.arrayBuffer()
+      // resolves — leaving the draft populated across those awaits let the
+      // Lexical editor race resetCompose and strand the just-sent text in the
+      // input when text was sent alongside images.
+      let resolveRead!: (buf: ArrayBuffer) => void;
+      const image = {
+        type: "image/png",
+        arrayBuffer: () =>
+          new Promise<ArrayBuffer>((resolve) => {
+            resolveRead = resolve;
+          }),
+      } as unknown as File;
 
-    expect(backend.sendMessage).not.toHaveBeenCalled();
-    expect(draft.setLoading).not.toHaveBeenCalledWith(true);
-    expect(draft.resetCompose).not.toHaveBeenCalled();
+      const backend = {
+        sendMessage: jest.fn(() => ({ turn: Promise.resolve() })),
+        cancel: jest.fn(),
+      } as unknown as AgentChatBackend;
+      const draft = makeDraft({ images: [image] });
+
+      renderInput(backend, draft);
+      fireEvent.click(screen.getByText("send"));
+
+      // Composer is cleared while the image read is still pending, before the
+      // turn is dispatched.
+      await waitFor(() => expect(draft.resetCompose).toHaveBeenCalledTimes(1));
+      expect(backend.sendMessage).not.toHaveBeenCalled();
+
+      // Finishing the read lets the turn fire with the converted image attached.
+      await act(async () => {
+        resolveRead(new ArrayBuffer(1));
+        await Promise.resolve();
+      });
+      await waitFor(() => expect(backend.sendMessage).toHaveBeenCalledTimes(1));
+      const promptContent = (backend.sendMessage as jest.Mock).mock.calls[0][2];
+      expect(promptContent).toHaveLength(1);
+      expect(promptContent[0].type).toBe("image");
+    });
+  });
+
+  describe("hard-disable", () => {
+    it("drops a send when the composer is disabled (orphaned project)", async () => {
+      // The mocked ChatInput's send button routes through handleSendMessage — the
+      // same entry the real Lexical editor's Enter key hits. A hard-disabled
+      // composer only dims + blocks pointer events in the DOM, so this keyboard
+      // path must be gated in the handler or a turn leaks into a dead project.
+      const backend = {
+        sendMessage: jest.fn(() => ({ turn: Promise.resolve() })),
+        cancel: jest.fn(),
+      } as unknown as AgentChatBackend;
+      const draft = makeDraft();
+
+      renderInput(backend, draft, { disabled: true });
+      fireEvent.click(screen.getByText("send"));
+      await act(async () => {});
+
+      expect(backend.sendMessage).not.toHaveBeenCalled();
+      expect(draft.setLoading).not.toHaveBeenCalledWith(true);
+      expect(draft.resetCompose).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -3,6 +3,10 @@ import { GLOBAL_SCOPE } from "@/agentMode/session/scope";
 import { expandCustomCommandPrefix } from "@/agentMode/session/expandCustomCommandPrefix";
 import { resolveActiveNoteToken } from "@/agentMode/session/resolveActiveNoteToken";
 import type { PromptContent } from "@/agentMode/session/types";
+import {
+  AGENT_COMPOSER_PLACEHOLDER,
+  AGENT_PROMPT_SUGGESTIONS,
+} from "@/agentMode/ui/agentPromptSuggestions";
 import type {
   AgentInputDraftControls,
   QueuedAgentMessage,
@@ -95,6 +99,12 @@ interface AgentChatInputProps {
    * top-right accessory column (see the DESIGN NOTE at the mount point).
    */
   contextStatusIndicator?: React.ReactNode;
+  /**
+   * This session has no user-visible messages yet. Gates the rotating sample
+   * prompts to the landing — the one surface where they showcase rather than
+   * distract.
+   */
+  isLanding?: boolean;
 }
 
 // Stable no-op handler for required ChatInput props that don't apply to
@@ -196,6 +206,7 @@ export const AgentChatInput = memo(function AgentChatInput({
   contextLoadBlocking = false,
   disabled = false,
   contextStatusIndicator,
+  isLanding = false,
 }: AgentChatInputProps) {
   const eventTarget = useContext(EventTargetContext);
 
@@ -564,6 +575,12 @@ export const AgentChatInput = memo(function AgentChatInput({
         <ChatInput
           key={chatInputId}
           isAgentMode
+          placeholder={AGENT_COMPOSER_PLACEHOLDER}
+          // Whether the composer is empty is not this component's business:
+          // the placeholder slot only exists while it is, so a landing can
+          // offer suggestions unconditionally and get "gone while they type,
+          // back once they clear it" for free.
+          placeholderPrompts={isLanding ? AGENT_PROMPT_SUGGESTIONS : undefined}
           inputMessage={inputMessage}
           setInputMessage={setInputMessage}
           handleSendMessage={(meta) => handleSendMessage(meta?.webTabs)}

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -740,6 +740,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
       contextLoadBlocking={contextLoadBlocking}
       disabled={isOrphanedProject}
       contextStatusIndicator={contextStatusIndicator}
+      isLanding={isLanding}
     />
   );
 

--- a/src/agentMode/ui/agentPromptSuggestions.ts
+++ b/src/agentMode/ui/agentPromptSuggestions.ts
@@ -1,0 +1,32 @@
+/**
+ * Sample prompts the Agent Mode composer types out on an empty landing, one at
+ * a time, to show what the agent can actually do with a vault (see
+ * `PromptSuggestionPlaceholder`). A frozen pool, like `LANDING_GREETINGS` — no
+ * live LLM call.
+ *
+ * Keep entries short enough to read at sidebar width (~65 characters),
+ * self-contained (no `<topic>` fill-in-the-blank), plain text (they're inserted
+ * verbatim when accepted), and free of any assumption about how a vault is
+ * organized — every one has to make sense in a stranger's notes.
+ */
+export const AGENT_PROMPT_SUGGESTIONS: readonly string[] = Object.freeze([
+  "Summarize what I worked on this week",
+  "Turn my meeting notes into a task list with links",
+  "Find notes that say contradictory things and show me",
+  "Draft a note that connects my recent reading",
+  "Rename my untitled notes based on what's in them",
+  "Pull every open question out of my notes",
+  "Find near-duplicate notes and suggest which to merge",
+  "Rewrite the current note as a step-by-step guide",
+  "Build an index note linking everything on one theme",
+  "Clean up the headings and formatting across my notes",
+  "Tell me what my notes are missing on a topic I care about",
+  "Read this note and give me three sharper questions",
+]);
+
+/**
+ * Static composer copy for Agent Mode — shown before the rotation starts, and
+ * once the user has typed. Names the affordances the agent composer actually
+ * has (`/` opens skills and commands here, not chat's custom prompts).
+ */
+export const AGENT_COMPOSER_PLACEHOLDER = "Ask anything • @ to add context • / for commands";

--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -53,6 +53,9 @@ import { $createAgentPillNode } from "./pills/AgentPillNode";
 const ACCENT_CIRCLE_BUTTON_CLASS =
   "tw-rounded-full tw-bg-interactive-accent tw-text-on-accent hover:tw-bg-interactive-accent-hover";
 
+const DEFAULT_PLACEHOLDER =
+  "Your AI assistant for Obsidian • @ to add context • / for custom prompts";
+
 export interface ChatInputProps {
   /**
    * Accessory rendered in a structural column to the right of the
@@ -64,6 +67,10 @@ export interface ChatInputProps {
    * consolidate into a config object, not more props.
    */
   topRightAccessory?: React.ReactNode;
+  /** Overrides the default composer placeholder copy. */
+  placeholder?: string;
+  /** Forwarded to the editor's placeholder slot — see {@link LexicalEditor}. */
+  placeholderPrompts?: readonly string[];
   inputMessage: string;
   setInputMessage: (message: string) => void;
   handleSendMessage: (metadata?: {
@@ -220,6 +227,8 @@ export interface ChatInputHandle {
 const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput(
   {
     topRightAccessory,
+    placeholder = DEFAULT_PLACEHOLDER,
+    placeholderPrompts,
     inputMessage,
     setInputMessage,
     handleSendMessage,
@@ -879,9 +888,8 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
               onEditorReady={onEditorReady}
               onImagePaste={onAddImage}
               onTagSelected={onTagSelected}
-              placeholder={
-                "Your AI assistant for Obsidian • @ to add context • / for custom prompts"
-              }
+              placeholder={placeholder}
+              placeholderPrompts={placeholderPrompts}
               disabled={isProjectLoading}
               isCopilotPlus={isCopilotPlus}
               showTools={showAtMentionTools}

--- a/src/components/chat-components/LexicalEditor.tsx
+++ b/src/components/chat-components/LexicalEditor.tsx
@@ -32,6 +32,7 @@ import { ActiveNotePillSyncPlugin } from "./plugins/ActiveNotePillSyncPlugin";
 import { WebTabPillSyncPlugin } from "./plugins/WebTabPillSyncPlugin";
 import { AgentPillSyncPlugin } from "./plugins/AgentPillSyncPlugin";
 import { PastePlugin } from "./plugins/PastePlugin";
+import { PromptSuggestionPlaceholder } from "./PromptSuggestionPlaceholder";
 import { TextInsertionPlugin } from "./plugins/TextInsertionPlugin";
 import { useChatInput } from "@/context/ChatInputContext";
 import { cn } from "@/lib/utils";
@@ -47,6 +48,13 @@ interface LexicalEditorProps {
   onChange: (value: string) => void;
   onSubmit: () => void;
   placeholder?: string;
+  /**
+   * Sample prompts to type out in the placeholder, one at a time, while the
+   * editor is empty (Tab accepts the one on screen). When set and non-empty it
+   * replaces `placeholder`. Must be referentially stable — see
+   * {@link PromptSuggestionPlaceholder}.
+   */
+  placeholderPrompts?: readonly string[];
   disabled?: boolean;
   className?: string;
   onNotesChange?: (notes: { path: string; basename: string }[]) => void;
@@ -87,6 +95,7 @@ const LexicalEditor: React.FC<LexicalEditorProps> = ({
   onChange,
   onSubmit,
   placeholder = "Type a message...",
+  placeholderPrompts,
   disabled = false,
   className = "",
   onNotesChange,
@@ -197,7 +206,11 @@ const LexicalEditor: React.FC<LexicalEditorProps> = ({
               }
               placeholder={
                 <div className="tw-pointer-events-none tw-absolute tw-left-2 tw-top-0 tw-select-none tw-text-sm tw-text-muted/60">
-                  {placeholder}
+                  {placeholderPrompts && placeholderPrompts.length > 0 ? (
+                    <PromptSuggestionPlaceholder prompts={placeholderPrompts} />
+                  ) : (
+                    placeholder
+                  )}
                 </div>
               }
               ErrorBoundary={LexicalErrorBoundary}

--- a/src/components/chat-components/LexicalEditor.tsx
+++ b/src/components/chat-components/LexicalEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useId } from "react";
 import { $getRoot, EditorState, LexicalEditor as LexicalEditorType } from "lexical";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
@@ -184,6 +184,11 @@ const LexicalEditor: React.FC<LexicalEditorProps> = ({
     [onChange]
   );
 
+  // Unique per editor: Agent Home and a popout composer can be mounted at once,
+  // and a duplicated id would point both at the first one's description.
+  const promptSuggestionId = useId();
+  const showPromptSuggestions = !!placeholderPrompts && placeholderPrompts.length > 0;
+
   const handleEditorReady = useCallback(
     (editor: LexicalEditorType) => {
       setEditorInstance(editor);
@@ -202,12 +207,19 @@ const LexicalEditor: React.FC<LexicalEditorProps> = ({
                 <ContentEditable
                   className="tw-max-h-60 tw-min-h-[60px] tw-w-full tw-resize-none tw-overflow-y-auto tw-rounded-md tw-border-none tw-bg-transparent tw-px-2 tw-text-sm tw-text-normal tw-outline-none focus-visible:tw-ring-0"
                   aria-label="Chat input"
+                  // The suggestions bind Tab, so a screen reader has to hear
+                  // what that key will do before it is pressed — the animated
+                  // text itself stays hidden.
+                  aria-describedby={showPromptSuggestions ? promptSuggestionId : undefined}
                 />
               }
               placeholder={
                 <div className="tw-pointer-events-none tw-absolute tw-left-2 tw-top-0 tw-select-none tw-text-sm tw-text-muted/60">
-                  {placeholderPrompts && placeholderPrompts.length > 0 ? (
-                    <PromptSuggestionPlaceholder prompts={placeholderPrompts} />
+                  {showPromptSuggestions ? (
+                    <PromptSuggestionPlaceholder
+                      prompts={placeholderPrompts}
+                      descriptionId={promptSuggestionId}
+                    />
                   ) : (
                     placeholder
                   )}

--- a/src/components/chat-components/PromptSuggestionPlaceholder.test.tsx
+++ b/src/components/chat-components/PromptSuggestionPlaceholder.test.tsx
@@ -16,6 +16,7 @@ import React from "react";
 // promptTypewriter.test.ts.
 const PROMPT = "hi there";
 const PROMPTS = Object.freeze([PROMPT]);
+const DESCRIPTION_ID = "suggestion-description";
 const { typeMs, deleteMs, holdMs, gapMs } = TYPEWRITER_TIMINGS;
 
 let editor: LexicalEditorType;
@@ -38,7 +39,7 @@ function renderPlaceholder() {
       }}
     >
       <EditorCapture />
-      <PromptSuggestionPlaceholder prompts={PROMPTS} />
+      <PromptSuggestionPlaceholder prompts={PROMPTS} descriptionId={DESCRIPTION_ID} />
     </LexicalComposer>
   );
   // Stand in for TextInsertionPlugin, which owns this command in the real
@@ -121,13 +122,39 @@ describe("PromptSuggestionPlaceholder", () => {
   it("surfaces the Tab affordance only while a prompt is fully shown", () => {
     renderPlaceholder();
     advance(typeMs);
-    expect(screen.queryByText(/Tab/)).toBeNull();
+    expect(screen.queryByText("⇥ Tab")).toBeNull();
 
     for (let i = 1; i < PROMPT.length; i++) advance(typeMs);
-    expect(screen.getByText(/Tab/)).toBeTruthy();
+    expect(screen.getByText("⇥ Tab")).toBeTruthy();
 
     advance(holdMs);
-    expect(screen.queryByText(/Tab/)).toBeNull();
+    expect(screen.queryByText("⇥ Tab")).toBeNull();
+  });
+
+  it("describes the whole prompt and its shortcut from the first typed character", () => {
+    const { container } = renderPlaceholder();
+    const description = () => container.querySelector(`#${DESCRIPTION_ID}`)?.textContent;
+
+    advance(typeMs);
+    expect(screen.getByText("h")).toBeTruthy();
+    // Announced before Tab is ever pressed, and naming what Tab commits —
+    // not the single character currently on screen.
+    expect(description()).toBe(`Suggested prompt: ${PROMPT}. Press Tab to insert it.`);
+
+    // Stable while the animation runs: a per-character description would make
+    // the composer unusable with a screen reader.
+    advance(typeMs);
+    advance(typeMs);
+    expect(description()).toBe(`Suggested prompt: ${PROMPT}. Press Tab to insert it.`);
+  });
+
+  it("describes nothing in the beat between two prompts, where Tab is unbound", () => {
+    const { container } = renderPlaceholder();
+    typeOutPrompt();
+    advance(holdMs);
+    for (let i = 1; i < PROMPT.length; i++) advance(deleteMs);
+
+    expect(container.querySelector(`#${DESCRIPTION_ID}`)?.textContent).toBe("");
   });
 
   it("commits the whole prompt on Tab even when only part of it is typed", () => {

--- a/src/components/chat-components/PromptSuggestionPlaceholder.test.tsx
+++ b/src/components/chat-components/PromptSuggestionPlaceholder.test.tsx
@@ -1,0 +1,185 @@
+import { PromptSuggestionPlaceholder } from "@/components/chat-components/PromptSuggestionPlaceholder";
+import { INSERT_TEXT_WITH_PILLS_COMMAND } from "@/components/chat-components/utils/lexicalTextUtils";
+import { TYPEWRITER_TIMINGS } from "@/components/chat-components/utils/promptTypewriter";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { act, render, screen } from "@testing-library/react";
+import {
+  COMMAND_PRIORITY_EDITOR,
+  KEY_TAB_COMMAND,
+  type LexicalEditor as LexicalEditorType,
+} from "lexical";
+import React from "react";
+
+// One prompt: the pool shuffle is then an identity, so the assertions read
+// against a known string. Rotation across a pool is covered in
+// promptTypewriter.test.ts.
+const PROMPT = "hi there";
+const PROMPTS = Object.freeze([PROMPT]);
+const { typeMs, deleteMs, holdMs, gapMs } = TYPEWRITER_TIMINGS;
+
+let editor: LexicalEditorType;
+/** Text the placeholder asked the editor to commit, in dispatch order. */
+let insertedText: string[];
+
+function EditorCapture(): null {
+  [editor] = useLexicalComposerContext();
+  return null;
+}
+
+function renderPlaceholder() {
+  const result = render(
+    <LexicalComposer
+      initialConfig={{
+        namespace: "prompt-suggestion-test",
+        onError: (error: Error) => {
+          throw error;
+        },
+      }}
+    >
+      <EditorCapture />
+      <PromptSuggestionPlaceholder prompts={PROMPTS} />
+    </LexicalComposer>
+  );
+  // Stand in for TextInsertionPlugin, which owns this command in the real
+  // composer, so the test asserts what the placeholder asked for.
+  editor.registerCommand(
+    INSERT_TEXT_WITH_PILLS_COMMAND,
+    (payload: { text: string }) => {
+      insertedText.push(payload.text);
+      return true;
+    },
+    COMMAND_PRIORITY_EDITOR
+  );
+  return result;
+}
+
+/**
+ * Run the clock forward. Exactly one frame timer is ever pending, and the frame
+ * it renders only schedules its successor once React flushes — so every call
+ * advances at most one frame. Pass a phase's own delay to stay on the machine's
+ * real clock rather than skipping ahead of it.
+ */
+function advance(ms: number) {
+  act(() => {
+    jest.advanceTimersByTime(ms);
+  });
+}
+
+/** Type the prompt out character by character, landing on the held frame. */
+function typeOutPrompt() {
+  for (let i = 0; i < PROMPT.length; i++) advance(typeMs);
+}
+
+function pressTab(modifiers: Partial<KeyboardEvent> = {}): boolean {
+  const event = { preventDefault: jest.fn(), ...modifiers } as unknown as KeyboardEvent;
+  let handled = false;
+  act(() => {
+    handled = editor.dispatchCommand(KEY_TAB_COMMAND, event);
+  });
+  return handled;
+}
+
+describe("PromptSuggestionPlaceholder", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    insertedText = [];
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("types the prompt in one character at a time", () => {
+    renderPlaceholder();
+    expect(screen.queryByText(/./)).toBeNull();
+
+    advance(typeMs);
+    expect(screen.getByText("h")).toBeTruthy();
+
+    advance(typeMs);
+    advance(typeMs);
+    advance(typeMs);
+    expect(screen.getByText("hi t")).toBeTruthy();
+  });
+
+  it("keeps the finished prompt on screen before clearing it a character at a time", () => {
+    renderPlaceholder();
+    typeOutPrompt();
+    expect(screen.getByText(PROMPT)).toBeTruthy();
+
+    // Still whole a tick short of the hold expiring.
+    advance(holdMs - 1);
+    expect(screen.getByText(PROMPT)).toBeTruthy();
+
+    advance(1);
+    expect(screen.getByText("hi ther")).toBeTruthy();
+    advance(deleteMs);
+    expect(screen.getByText("hi the")).toBeTruthy();
+  });
+
+  it("surfaces the Tab affordance only while a prompt is fully shown", () => {
+    renderPlaceholder();
+    advance(typeMs);
+    expect(screen.queryByText(/Tab/)).toBeNull();
+
+    for (let i = 1; i < PROMPT.length; i++) advance(typeMs);
+    expect(screen.getByText(/Tab/)).toBeTruthy();
+
+    advance(holdMs);
+    expect(screen.queryByText(/Tab/)).toBeNull();
+  });
+
+  it("commits the whole prompt on Tab even when only part of it is typed", () => {
+    renderPlaceholder();
+    advance(typeMs);
+
+    expect(pressTab()).toBe(true);
+    expect(insertedText).toEqual([PROMPT]);
+  });
+
+  it("commits the prompt on Tab while it is holding", () => {
+    renderPlaceholder();
+    typeOutPrompt();
+
+    expect(pressTab()).toBe(true);
+    expect(insertedText).toEqual([PROMPT]);
+  });
+
+  it("leaves Tab alone in the beat between two prompts", () => {
+    renderPlaceholder();
+    typeOutPrompt();
+    // Hold expires, then every character is cleared: nothing is on screen.
+    advance(holdMs);
+    for (let i = 1; i < PROMPT.length; i++) advance(deleteMs);
+    expect(screen.queryByText(/./)).toBeNull();
+
+    expect(pressTab()).toBe(false);
+    expect(insertedText).toEqual([]);
+
+    // The gap elapses, the next prompt starts typing, and Tab works again.
+    advance(gapMs);
+    advance(typeMs);
+    expect(pressTab()).toBe(true);
+    expect(insertedText).toEqual([PROMPT]);
+  });
+
+  it("ignores Tab pressed with a modifier, leaving Shift+Tab to the mode cycler", () => {
+    renderPlaceholder();
+    typeOutPrompt();
+
+    expect(pressTab({ shiftKey: true })).toBe(false);
+    expect(pressTab({ metaKey: true })).toBe(false);
+    expect(pressTab({ ctrlKey: true })).toBe(false);
+    expect(pressTab({ altKey: true })).toBe(false);
+    expect(insertedText).toEqual([]);
+  });
+
+  it("stops its timers when unmounted mid-animation", () => {
+    const { unmount } = renderPlaceholder();
+    advance(typeMs);
+    unmount();
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/src/components/chat-components/PromptSuggestionPlaceholder.tsx
+++ b/src/components/chat-components/PromptSuggestionPlaceholder.tsx
@@ -1,0 +1,99 @@
+import { INSERT_TEXT_WITH_PILLS_COMMAND } from "@/components/chat-components/utils/lexicalTextUtils";
+import {
+  initialTypewriterState,
+  nextTypewriterFrame,
+  shufflePrompts,
+  visiblePromptText,
+} from "@/components/chat-components/utils/promptTypewriter";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { COMMAND_PRIORITY_LOW, KEY_TAB_COMMAND } from "lexical";
+import React, { useEffect, useMemo, useState } from "react";
+
+interface PromptSuggestionPlaceholderProps {
+  /**
+   * Non-empty pool of sample prompts to cycle through. Must be referentially
+   * stable (a frozen module constant) — a new array identity reshuffles the
+   * pool and restarts the rotation.
+   */
+  prompts: readonly string[];
+}
+
+/**
+ * Rotating sample prompts for an empty composer: each types in a character at a
+ * time, holds while it's readable, deletes itself the same way, and gives way to
+ * the next. Tab commits the prompt on screen to the real input.
+ *
+ * Mounted as Lexical's `placeholder`, which is why one component owns both the
+ * animation and the Tab binding. That slot renders inside the composer, so the
+ * editor context is reachable; and Lexical unmounts it the moment the editor
+ * holds text, which is what stops the rotation on the user's first keystroke —
+ * no editor-value subscription of our own, and nothing to tear down by hand.
+ * Holding the per-character state here also confines a ~22fps re-render to this
+ * leaf instead of the whole composer tree.
+ */
+export const PromptSuggestionPlaceholder: React.FC<PromptSuggestionPlaceholderProps> = ({
+  prompts,
+}) => {
+  const [editor] = useLexicalComposerContext();
+  const pool = useMemo(() => shufflePrompts(prompts), [prompts]);
+  // Read once at mount: an OS preference nobody flips mid-chat, so this stays
+  // free of a media-query subscription.
+  const [instant] = useState(
+    () => window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false
+  );
+  const [state, setState] = useState(initialTypewriterState);
+
+  // Each frame schedules the next one, so the per-phase delays vary without an
+  // interval that has to be reconciled against them.
+  useEffect(() => {
+    const { state: next, delayMs } = nextTypewriterFrame(state, pool, instant);
+    const timer = window.setTimeout(() => setState(next), delayMs);
+    return () => window.clearTimeout(timer);
+  }, [state, pool, instant]);
+
+  const visible = visiblePromptText(state, pool);
+  // Tab commits the WHOLE prompt even mid-animation — what you accept is the
+  // prompt, never the fragment on screen. In the beat between two prompts
+  // there's nothing to accept, so Tab falls through to its default behavior.
+  const acceptText = visible.length > 0 ? pool[state.index] : null;
+
+  useEffect(() => {
+    if (!acceptText) return;
+    return editor.registerCommand(
+      KEY_TAB_COMMAND,
+      (event: KeyboardEvent | null) => {
+        // Shift+Tab is the mode cycler (KeyboardPlugin); the rest are the
+        // platform's own bindings. Only bare Tab accepts a suggestion.
+        if (!event || event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) {
+          return false;
+        }
+        event.preventDefault();
+        editor.dispatchCommand(INSERT_TEXT_WITH_PILLS_COMMAND, {
+          text: acceptText,
+          options: { insertAtSelection: true },
+        });
+        return true;
+      },
+      // Below the typeahead menus, which claim Tab at HIGH priority while open.
+      COMMAND_PRIORITY_LOW
+    );
+  }, [editor, acceptText]);
+
+  // aria-hidden: decorative motion. The composer is already labelled, and a
+  // string that rewrites itself every 45ms is noise to a screen reader. The
+  // hint is a sibling of the prompt, not a child, so the prompt keeps its own
+  // text node — the chip must not read as part of the suggestion.
+  return (
+    <>
+      <span aria-hidden="true">{visible}</span>
+      {state.phase === "holding" && (
+        <span
+          aria-hidden="true"
+          className="tw-ml-1.5 tw-whitespace-nowrap tw-text-ui-smaller tw-opacity-80"
+        >
+          ⇥ Tab
+        </span>
+      )}
+    </>
+  );
+};

--- a/src/components/chat-components/PromptSuggestionPlaceholder.tsx
+++ b/src/components/chat-components/PromptSuggestionPlaceholder.tsx
@@ -16,6 +16,12 @@ interface PromptSuggestionPlaceholderProps {
    * pool and restarts the rotation.
    */
   prompts: readonly string[];
+  /**
+   * Id of this component's screen-reader description, which the composer points
+   * at with `aria-describedby`. Supplied by the caller because the element that
+   * needs describing is the editor, not anything rendered here.
+   */
+  descriptionId: string;
 }
 
 /**
@@ -33,6 +39,7 @@ interface PromptSuggestionPlaceholderProps {
  */
 export const PromptSuggestionPlaceholder: React.FC<PromptSuggestionPlaceholderProps> = ({
   prompts,
+  descriptionId,
 }) => {
   const [editor] = useLexicalComposerContext();
   const pool = useMemo(() => shufflePrompts(prompts), [prompts]);
@@ -79,10 +86,13 @@ export const PromptSuggestionPlaceholder: React.FC<PromptSuggestionPlaceholderPr
     );
   }, [editor, acceptText]);
 
-  // aria-hidden: decorative motion. The composer is already labelled, and a
-  // string that rewrites itself every 45ms is noise to a screen reader. The
-  // hint is a sibling of the prompt, not a child, so the prompt keeps its own
-  // text node — the chip must not read as part of the suggestion.
+  // The animation is hidden from assistive tech — a string that rewrites itself
+  // every 45ms is noise — but Tab is bound whenever a prompt is loaded, so what
+  // that key will do has to be announced anyway. The description carries the
+  // whole prompt (what Tab actually commits) and changes once per rotation
+  // rather than per character. The hint is a sibling of the prompt, not a
+  // child, so the prompt keeps its own text node — the chip must not read as
+  // part of the suggestion.
   return (
     <>
       <span aria-hidden="true">{visible}</span>
@@ -94,6 +104,9 @@ export const PromptSuggestionPlaceholder: React.FC<PromptSuggestionPlaceholderPr
           ⇥ Tab
         </span>
       )}
+      <span id={descriptionId} className="tw-sr-only">
+        {acceptText ? `Suggested prompt: ${acceptText}. Press Tab to insert it.` : ""}
+      </span>
     </>
   );
 };

--- a/src/components/chat-components/utils/promptTypewriter.test.ts
+++ b/src/components/chat-components/utils/promptTypewriter.test.ts
@@ -1,0 +1,106 @@
+import {
+  initialTypewriterState,
+  nextTypewriterFrame,
+  shufflePrompts,
+  TYPEWRITER_TIMINGS,
+  visiblePromptText,
+  type TypewriterState,
+} from "@/components/chat-components/utils/promptTypewriter";
+
+const PROMPTS = ["ab", "cd"] as const;
+
+/**
+ * Drive the machine until `frames` frames have been produced, collecting what
+ * the composer would show at each one alongside how long the frame *before* it
+ * stayed up — the scheduler's contract: wait `delayMs`, then show `text`.
+ */
+function run(
+  prompts: readonly string[],
+  frames: number,
+  instant = false
+): { text: string; delayMs: number }[] {
+  let state = initialTypewriterState();
+  const timeline: { text: string; delayMs: number }[] = [];
+  for (let i = 0; i < frames; i++) {
+    const next = nextTypewriterFrame(state, prompts, instant);
+    timeline.push({ text: visiblePromptText(next.state, prompts), delayMs: next.delayMs });
+    state = next.state;
+  }
+  return timeline;
+}
+
+describe("promptTypewriter", () => {
+  describe("initialTypewriterState()", () => {
+    it("opens on the first prompt with nothing typed yet", () => {
+      expect(initialTypewriterState()).toEqual({ index: 0, charCount: 0, phase: "typing" });
+    });
+  });
+
+  describe("visiblePromptText()", () => {
+    it("shows only the leading characters the frame has typed", () => {
+      const state: TypewriterState = { index: 1, charCount: 1, phase: "typing" };
+      expect(visiblePromptText(state, PROMPTS)).toBe("c");
+    });
+  });
+
+  describe("nextTypewriterFrame()", () => {
+    const { typeMs, deleteMs, holdMs, gapMs } = TYPEWRITER_TIMINGS;
+
+    it("types a prompt in one character at a time, then leaves the whole thing up for the hold", () => {
+      expect(run(PROMPTS, 3)).toEqual([
+        { text: "a", delayMs: typeMs },
+        { text: "ab", delayMs: typeMs },
+        // The completed prompt is the held frame, so holdMs is what elapses
+        // before the first character comes back off.
+        { text: "a", delayMs: holdMs },
+      ]);
+    });
+
+    it("deletes a character at a time and moves on to the next prompt", () => {
+      expect(run(PROMPTS, 6).slice(3)).toEqual([
+        // Cleared, then the empty beat before the next prompt starts typing.
+        { text: "", delayMs: deleteMs },
+        { text: "", delayMs: gapMs },
+        { text: "c", delayMs: typeMs },
+      ]);
+    });
+
+    it("cycles back to the first prompt after the last one clears", () => {
+      const wrapped = nextTypewriterFrame(
+        { index: PROMPTS.length - 1, charCount: 0, phase: "gap" },
+        PROMPTS
+      );
+      expect(wrapped.state).toEqual({ index: 0, charCount: 0, phase: "typing" });
+    });
+
+    it("shows and clears whole prompts with no per-character motion when instant", () => {
+      expect(run(PROMPTS, 4, true)).toEqual([
+        { text: "ab", delayMs: typeMs },
+        { text: "", delayMs: holdMs },
+        { text: "", delayMs: gapMs },
+        { text: "cd", delayMs: typeMs },
+      ]);
+    });
+
+    it("passes through a zero-length prompt instead of stalling on it", () => {
+      const timeline = run(["", "cd"], 4);
+      expect(timeline.map((frame) => frame.text)).toEqual(["", "", "", "c"]);
+    });
+  });
+
+  describe("shufflePrompts()", () => {
+    it("returns a reordered copy, leaving the source pool untouched", () => {
+      const source = Object.freeze(["a", "b", "c", "d"]);
+      const shuffled = shufflePrompts(source);
+      expect([...shuffled].sort()).toEqual(["a", "b", "c", "d"]);
+      expect(source).toEqual(["a", "b", "c", "d"]);
+    });
+
+    it("walks the pool back to front, swapping with the drawn index", () => {
+      // Every draw lands on 0: [a,b,c] -> swap(2,0) -> [c,b,a] -> swap(1,0) -> [b,c,a].
+      jest.spyOn(Math, "random").mockReturnValue(0);
+      expect(shufflePrompts(["a", "b", "c"])).toEqual(["b", "c", "a"]);
+      jest.spyOn(Math, "random").mockRestore();
+    });
+  });
+});

--- a/src/components/chat-components/utils/promptTypewriter.ts
+++ b/src/components/chat-components/utils/promptTypewriter.ts
@@ -1,0 +1,100 @@
+/**
+ * Frame machine behind the composer's rotating sample prompts: one prompt types
+ * in a character at a time, holds while it's fully readable, deletes itself the
+ * same way, and hands over to the next. Kept as pure transitions (no timers, no
+ * React) so the cadence is testable and the component stays a thin renderer.
+ */
+
+export type TypewriterPhase = "typing" | "holding" | "deleting" | "gap";
+
+export interface TypewriterState {
+  /** Index into the prompt pool of the prompt currently on screen. */
+  index: number;
+  /** How many of that prompt's leading characters are visible. */
+  charCount: number;
+  /** `gap` is the cleared beat between one prompt and the next. */
+  phase: TypewriterPhase;
+}
+
+/**
+ * Per-phase pacing, in milliseconds. Deleting runs faster than typing because
+ * that's how a person clears a line — they hold backspace.
+ */
+export const TYPEWRITER_TIMINGS = Object.freeze({
+  typeMs: 45,
+  deleteMs: 25,
+  /** How long a fully-typed prompt stays put before it starts deleting. */
+  holdMs: 5000,
+  /** Empty-composer beat between one prompt clearing and the next starting. */
+  gapMs: 500,
+});
+
+export const initialTypewriterState = (): TypewriterState => ({
+  index: 0,
+  charCount: 0,
+  phase: "typing",
+});
+
+/** The characters of `state`'s prompt that are currently on screen. */
+export function visiblePromptText(state: TypewriterState, prompts: readonly string[]): string {
+  return prompts[state.index].slice(0, state.charCount);
+}
+
+/**
+ * Advance one frame: wait `delayMs`, then put `state` on screen.
+ *
+ * A phase's dwell is therefore returned by the transition *out of* it — the
+ * held frame is what stays for `holdMs`, so `holdMs` is what the hold hands to
+ * the first delete step.
+ *
+ * @param state The frame currently on screen.
+ * @param prompts The prompt pool, cycled in order. Must not be empty.
+ * @param instant Skip the per-character animation and jump straight to the
+ *   whole prompt (and straight back to empty) — how the rotation renders for a
+ *   reader who asked their OS for reduced motion.
+ */
+export function nextTypewriterFrame(
+  state: TypewriterState,
+  prompts: readonly string[],
+  instant = false
+): { state: TypewriterState; delayMs: number } {
+  const prompt = prompts[state.index];
+  const { typeMs, deleteMs, holdMs, gapMs } = TYPEWRITER_TIMINGS;
+
+  switch (state.phase) {
+    case "typing": {
+      const charCount = instant ? prompt.length : Math.min(state.charCount + 1, prompt.length);
+      const phase = charCount >= prompt.length ? "holding" : "typing";
+      return { state: { ...state, charCount, phase }, delayMs: typeMs };
+    }
+    // Holding and deleting clear the same way — a held frame is a full one, so
+    // "one character less" is the first delete step for both — and differ only
+    // in how long the frame they're replacing stayed up.
+    case "holding":
+    case "deleting": {
+      const charCount = instant ? 0 : Math.max(state.charCount - 1, 0);
+      return {
+        state: { ...state, charCount, phase: charCount > 0 ? "deleting" : "gap" },
+        delayMs: state.phase === "holding" ? holdMs : deleteMs,
+      };
+    }
+    case "gap":
+      return {
+        state: { index: (state.index + 1) % prompts.length, charCount: 0, phase: "typing" },
+        delayMs: gapMs,
+      };
+  }
+}
+
+/**
+ * Fisher-Yates copy, so a pool cycles in a different order every time the
+ * composer mounts instead of always opening on the same prompt.
+ */
+export function shufflePrompts(prompts: readonly string[]): string[] {
+  const shuffled = [...prompts];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#258

_Cross-repo `Fixes` did not register a closing reference on this PR (`closingIssuesReferences` is empty), so the issue needs a manual close on merge._

## Problem

The Agent Mode composer renders chat's placeholder verbatim — `"Your AI assistant for Obsidian • @ to add context • / for custom prompts"`, hardcoded at the `LexicalEditor` mount in `src/components/chat-components/ChatInput.tsx`. It is wrong on its face for Agent Mode, where `/` opens skills and commands, not chat's custom prompts. It also wastes the one screen where a new user is deciding what to ask an agent: Agent Home's landing rotates a greeting (`landingGreetings.ts`) but never shows a prompt worth stealing.

## Fix

An empty landing composer now types out sample prompts one at a time — type in, hold 5s, delete, next — and Tab commits the one on screen into the real input.

The design decision that carries the PR is **where the rotation lives**: it is mounted as Lexical's `placeholder` slot. Lexical renders that slot only while the editor is empty (`Placeholder` returns `null` when `useCanShowPlaceholder` is false, `@lexical/react` 0.34), which buys three requirements for free:

- The first keystroke unmounts the component, stopping the animation and clearing its pending timer — there is no editor-value subscription anywhere in this diff.
- Clearing the composer remounts it, so suggestions come back.
- IME composition hides it, because Lexical passes `isComposing` into that check.

That slot also renders *inside* `LexicalComposer`, so the same component can register `KEY_TAB_COMMAND` — which is why one component owns both the frames and the key binding instead of a plugin/renderer pair passing state between them. Holding the per-character state there confines a ~22fps re-render to that leaf rather than re-rendering `ChatInput` and its 20-plugin editor tree on every character.

Rejected: driving the rotation from `AgentChatInput` state and passing the text down as a prop. It is the obvious shape, and it re-renders the whole composer tree 22 times a second.

Tab is claimed only while a suggestion is visible and unmodified, at `COMMAND_PRIORITY_LOW` — below the typeahead menus' `HIGH` binding — so `@`/`/` selection and the Shift+Tab mode cycler are untouched, and Tab in the beat between two prompts falls through to its default. Accepting routes through the existing `INSERT_TEXT_WITH_PILLS_COMMAND` rather than `setInputMessage`: it reuses the mounted `TextInsertionPlugin`, resolves `[[note]]` links to pills, and leaves the caret at the end (`ValueSyncPlugin` rebuilds the root without setting a selection).

## Scope

`Budget gate: PASS — 11 files, +887/−225.` Read that with `-w`: **673 added, 11 removed**. The 214-line gap is one reindent — `AgentChatInput.test.tsx` had seven top-level `describe` blocks before this PR and review asked for one, so its existing groups were renamed and nested with no test-body edits (`git diff -w` on that file: +45/−6).

Of the real additions, 371 are tests. The production surface is three new files (the pure frame machine, the leaf component, the prompt pool) plus two optional pass-through props; the mechanism lives in `chat-components` and the copy in `agentMode`, so nothing generic learns about Agent Mode. The gate's own trim removed the duplicated "referentially stable" prop docs — the rule is now stated once, on the component that enforces it.

## Changes

- `utils/promptTypewriter.ts` — pure frame machine (`typing → holding → deleting → gap`) with no timers or React, so the cadence is directly testable. `delayMs` precedes the frame it is paired with, which is what puts the 5s hold on the completed prompt rather than its second-to-last character.
- `PromptSuggestionPlaceholder.tsx` — the leaf: self-scheduling `setTimeout` chain, the Tab binding, and a `⇥ Tab` hint rendered only during the hold (without it the affordance is undiscoverable). Honors `prefers-reduced-motion` by rotating whole prompts instead of animating characters — the rotation loops for as long as the landing is open, which is exactly the case that preference exists for. The animation is `aria-hidden`, but since Tab is bound from the first typed character it also renders a stable `sr-only` description ("Suggested prompt: … Press Tab to insert it.") that the composer points at with `aria-describedby` — otherwise the ordinary focus-navigation key silently inserts text a screen-reader user was never told about.
- `docs/agent-mode-and-tools.md` — the user-facing behavior: what rotates, Tab to insert (it does not send), typing to dismiss, clearing to bring it back, and the reduced-motion variant.
- `agentMode/ui/agentPromptSuggestions.ts` — 12 vault-capability prompts, deliberately free of any assumption about how a vault is organized, plus the Agent Mode-accurate static line.
- `ChatInput.tsx` / `LexicalEditor.tsx` — two optional props; the previously inline placeholder string becomes `DEFAULT_PLACEHOLDER`, so chat mode is byte-identical.
- `AgentChatInput.tsx` / `AgentHome.tsx` — pass the existing `isLanding` down and offer the pool when it is true. No emptiness check: the placeholder slot only exists while the composer is empty.

## Verification

- `npx jest src/agentMode src/components/chat-components` — 134 suites, 1750 tests, all pass. New coverage: the machine's full cycle, wrap-around, reduced-motion path and zero-length prompt; the component's per-character render, the 5s hold boundary, Tab mid-type vs. holding vs. in the gap, modifier rejection, and timer teardown on unmount; and `AgentChatInput`'s landing gate including the clear-and-resume case.
- `npx tsc --noEmit`, `npm run lint`, `npm run format` — clean.
- Manual: exercised by the author in a live vault, which is how the one behavioral bug in this PR was caught — an earlier revision latched "user has typed" and so refused to bring the suggestions back after a Tab-accepted prompt was cleared. The latch is gone (a net deletion) and the case is now a test. I have not personally watched the animation run in Obsidian; the timing constants are asserted in tests, not eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
