### PR TITLE
fix(settings): show the plan name and one inactive state on the license badge

### DIFF
--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -26,6 +26,13 @@ Copilot Plus is a subscription that enables:
 3. Enter your license key in the **Copilot Plus License Key** field
 4. Features unlock automatically
 
+The badge at the top of the license section names your plan once the key is
+working — **Plus**, **Lite**, or **Lifetime** for a Believer or Supporter
+purchase. It reads **Inactive** whenever the stored key grants nothing: a
+subscription that ended, a key that was revoked or mistyped, or a plan whose
+included access has run out. The plans link in that section is where you renew
+or upgrade.
+
 ---
 
 ## Copilot Plus Flash Model

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -185,6 +185,7 @@ export const LOADING_MESSAGES = {
 export const PLUS_UTM_MEDIUMS = {
   SETTINGS: "settings",
   EXPIRED_MODAL: "expired_modal",
+  EXPIRED_SETTINGS: "expired_settings",
   CHAT_MODE_SELECT: "chat_mode_select",
   MODE_SELECT_TOOLTIP: "mode_select_tooltip",
   MULTI_AGENT: "multi_agent",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -185,7 +185,6 @@ export const LOADING_MESSAGES = {
 export const PLUS_UTM_MEDIUMS = {
   SETTINGS: "settings",
   EXPIRED_MODAL: "expired_modal",
-  EXPIRED_SETTINGS: "expired_settings",
   CHAT_MODE_SELECT: "chat_mode_select",
   MODE_SELECT_TOOLTIP: "mode_select_tooltip",
   MULTI_AGENT: "multi_agent",

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -466,10 +466,10 @@ describe("plusUtils", () => {
       await waitFor(() => expect(result.current).toEqual({ status: "active", plan: "believer" }));
     });
 
-    it("reports expired for a lapsed key the server downgraded to the free tier", async () => {
+    it("reports inactive for a lapsed key the server downgraded to the free tier", async () => {
       // The server keeps answering is_valid for a lapsed key but issues a
       // free-tier token that still names the plan, so the tier — not the plan
-      // name — is what says this user has to renew.
+      // name — is what says this user has nothing.
       mockVerifyEntitlement.mockResolvedValue({
         user_id: "user-123",
         plan: "plus",
@@ -484,11 +484,11 @@ describe("plusUtils", () => {
 
       const { result } = renderHook(() => useLicenseState());
 
-      await waitFor(() => expect(result.current.status).toBe("expired"));
+      await waitFor(() => expect(result.current.status).toBe("inactive"));
       expect(result.current.plan).toBeUndefined();
     });
 
-    it("reports expired when the stored token's offline window has run out", async () => {
+    it("reports inactive when the stored token's offline window has run out", async () => {
       mockVerifyEntitlement.mockResolvedValue(null);
       mockGetSettings.mockReturnValue(
         buildSettings({
@@ -502,10 +502,23 @@ describe("plusUtils", () => {
 
       const { result } = renderHook(() => useLicenseState());
 
-      await waitFor(() => expect(result.current.status).toBe("expired"));
+      await waitFor(() => expect(result.current.status).toBe("inactive"));
     });
 
-    it("falls back to a nameless active state for a paid key with no verifiable token", async () => {
+    it("reports inactive for a stored key the server rejected outright", async () => {
+      // turnOffPaid clears the token and the expiry, so nothing but the key and
+      // the downgraded flag survive an invalid or revoked key.
+      mockVerifyEntitlement.mockResolvedValue(null);
+      mockGetSettings.mockReturnValue(
+        buildSettings({ userId: "user-123", plusLicenseKey: "key", isPaidUser: false })
+      );
+
+      const { result } = renderHook(() => useLicenseState());
+
+      await waitFor(() => expect(result.current.status).toBe("inactive"));
+    });
+
+    it("keeps a paid key active when the server confirmed it without signing a token", async () => {
       mockVerifyEntitlement.mockResolvedValue(null);
       mockGetSettings.mockReturnValue(
         buildSettings({ userId: "user-123", plusLicenseKey: "key", isPaidUser: true })
@@ -517,19 +530,18 @@ describe("plusUtils", () => {
       expect(result.current).toEqual({ status: "active" });
     });
 
-    it("reports nothing to show while a stored key has no resolved paid status", async () => {
-      mockVerifyEntitlement.mockResolvedValue(null);
-      mockGetSettings.mockReturnValue(
-        buildSettings({ userId: "user-123", plusLicenseKey: "key", isPaidUser: undefined })
-      );
+    it("shows nothing until the first verification answers", () => {
+      // A paying user must never see their license called inactive for the
+      // moment the check is in flight.
+      mockVerifyEntitlement.mockReturnValue(new Promise(() => {}));
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
 
       const { result } = renderHook(() => useLicenseState());
 
-      await waitFor(() => expect(mockVerifyEntitlement).toHaveBeenCalled());
       expect(result.current.status).toBe("none");
     });
 
-    it("reports nothing to show when no license key is stored", async () => {
+    it("shows nothing when no license key is stored", async () => {
       mockVerifyEntitlement.mockResolvedValue(null);
       mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123", isPaidUser: false }));
 

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -530,10 +530,11 @@ describe("plusUtils", () => {
       expect(result.current).toEqual({ status: "active" });
     });
 
-    it("does not judge a newly entered key by the previous verification", async () => {
-      // A free user's empty token resolves to "nothing verified" immediately.
-      // Pasting a key must not be answered by that verdict while its own check
-      // is still in flight, or the badge rejects a license they just bought.
+    it("does not answer a changed key with the previous key's verdict", async () => {
+      // The result carries the key it describes, so a verdict for the old key
+      // reads as unanswered until the new one's check lands. The settings
+      // section covers the rest of that window, where the stored token is still
+      // empty and the server has not answered yet.
       mockVerifyEntitlement.mockResolvedValueOnce(null).mockReturnValueOnce(new Promise(() => {}));
       mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123" }));
 
@@ -546,30 +547,44 @@ describe("plusUtils", () => {
       expect(result.current.status).toBe("none");
     });
 
-    it("stops reporting the plan once the verified claims reach their expiry", async () => {
-      // Claims are only unexpired as of the moment they verified; a settings tab
-      // left open past `exp` must not keep naming a plan whose gates have closed.
+    it("stops naming the plan when the claims expire while the section stays open", async () => {
+      // Nothing re-renders merely because time passed, so the expiry has to be
+      // its own invalidation source: a settings tab left open across `exp` must
+      // not keep naming a plan whose entitlement gates have already closed.
       mockVerifyEntitlement.mockResolvedValue({
         user_id: "user-123",
         plan: "plus",
         tier: "plus",
         features: ["multi_agent"],
         iat: 0,
-        exp: PAST_EXP_SECONDS,
+        exp: (Date.now() + 50) / 1000,
       });
-      mockGetSettings.mockReturnValue(
-        buildSettings({
-          userId: "user-123",
-          plusLicenseKey: "key",
-          entitlementToken: "token",
-          entitlementExpiresAt: PAST_EXP_SECONDS * 1000,
-          isPaidUser: true,
-        })
-      );
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
 
       const { result } = renderHook(() => useLicenseState());
 
+      await waitFor(() => expect(result.current.status).toBe("active"));
       await waitFor(() => expect(result.current.status).toBe("inactive"));
+    });
+
+    it("keeps naming the plan when the expiry is further out than a timer can hold", async () => {
+      // A delay past the 32-bit limit wraps to immediate, which would blank the
+      // badge the moment it rendered.
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "plus",
+        tier: "plus",
+        features: ["multi_agent"],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      });
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
+
+      const { result } = renderHook(() => useLicenseState());
+
+      await waitFor(() => expect(result.current).toEqual({ status: "active", plan: "plus" }));
+      await new Promise((resolve) => window.setTimeout(resolve, 20));
+      expect(result.current).toEqual({ status: "active", plan: "plus" });
     });
 
     it("shows nothing until the first verification answers", () => {

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -33,6 +33,7 @@ import {
   markPaidPendingEntitlement,
   turnOffPaid,
   useIsSelfHostEligible,
+  useLicenseState,
   verifyCachedEntitlement,
 } from "@/plusUtils";
 import { renderHook, waitFor } from "@testing-library/react";
@@ -445,6 +446,97 @@ describe("plusUtils", () => {
       mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
 
       expect(await checkIsPaidUser()).toBe(false);
+    });
+  });
+
+  describe("useLicenseState()", () => {
+    it("names the plan the verified token was issued for", async () => {
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "believer",
+        tier: "plus",
+        features: ["multi_agent"],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      });
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
+
+      const { result } = renderHook(() => useLicenseState());
+
+      await waitFor(() => expect(result.current).toEqual({ status: "active", plan: "believer" }));
+    });
+
+    it("reports expired for a lapsed key the server downgraded to the free tier", async () => {
+      // The server keeps answering is_valid for a lapsed key but issues a
+      // free-tier token that still names the plan, so the tier — not the plan
+      // name — is what says this user has to renew.
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "plus",
+        tier: "free",
+        features: [],
+        iat: 0,
+        exp: FUTURE_EXP_SECONDS,
+      });
+      mockGetSettings.mockReturnValue(
+        tokenBackedSettings({ plusLicenseKey: "key", isPaidUser: false })
+      );
+
+      const { result } = renderHook(() => useLicenseState());
+
+      await waitFor(() => expect(result.current.status).toBe("expired"));
+      expect(result.current.plan).toBeUndefined();
+    });
+
+    it("reports expired when the stored token's offline window has run out", async () => {
+      mockVerifyEntitlement.mockResolvedValue(null);
+      mockGetSettings.mockReturnValue(
+        buildSettings({
+          userId: "user-123",
+          plusLicenseKey: "key",
+          entitlementToken: "token",
+          entitlementExpiresAt: PAST_EXP_SECONDS * 1000,
+          isPaidUser: true,
+        })
+      );
+
+      const { result } = renderHook(() => useLicenseState());
+
+      await waitFor(() => expect(result.current.status).toBe("expired"));
+    });
+
+    it("falls back to a nameless active state for a paid key with no verifiable token", async () => {
+      mockVerifyEntitlement.mockResolvedValue(null);
+      mockGetSettings.mockReturnValue(
+        buildSettings({ userId: "user-123", plusLicenseKey: "key", isPaidUser: true })
+      );
+
+      const { result } = renderHook(() => useLicenseState());
+
+      await waitFor(() => expect(mockVerifyEntitlement).toHaveBeenCalled());
+      expect(result.current).toEqual({ status: "active" });
+    });
+
+    it("reports nothing to show while a stored key has no resolved paid status", async () => {
+      mockVerifyEntitlement.mockResolvedValue(null);
+      mockGetSettings.mockReturnValue(
+        buildSettings({ userId: "user-123", plusLicenseKey: "key", isPaidUser: undefined })
+      );
+
+      const { result } = renderHook(() => useLicenseState());
+
+      await waitFor(() => expect(mockVerifyEntitlement).toHaveBeenCalled());
+      expect(result.current.status).toBe("none");
+    });
+
+    it("reports nothing to show when no license key is stored", async () => {
+      mockVerifyEntitlement.mockResolvedValue(null);
+      mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123", isPaidUser: false }));
+
+      const { result } = renderHook(() => useLicenseState());
+
+      await waitFor(() => expect(mockVerifyEntitlement).toHaveBeenCalled());
+      expect(result.current.status).toBe("none");
     });
   });
 

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -530,6 +530,48 @@ describe("plusUtils", () => {
       expect(result.current).toEqual({ status: "active" });
     });
 
+    it("does not judge a newly entered key by the previous verification", async () => {
+      // A free user's empty token resolves to "nothing verified" immediately.
+      // Pasting a key must not be answered by that verdict while its own check
+      // is still in flight, or the badge rejects a license they just bought.
+      mockVerifyEntitlement.mockResolvedValueOnce(null).mockReturnValueOnce(new Promise(() => {}));
+      mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123" }));
+
+      const { result, rerender } = renderHook(() => useLicenseState());
+      await waitFor(() => expect(mockVerifyEntitlement).toHaveBeenCalledTimes(1));
+
+      mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123", plusLicenseKey: "key" }));
+      rerender();
+
+      expect(result.current.status).toBe("none");
+    });
+
+    it("stops reporting the plan once the verified claims reach their expiry", async () => {
+      // Claims are only unexpired as of the moment they verified; a settings tab
+      // left open past `exp` must not keep naming a plan whose gates have closed.
+      mockVerifyEntitlement.mockResolvedValue({
+        user_id: "user-123",
+        plan: "plus",
+        tier: "plus",
+        features: ["multi_agent"],
+        iat: 0,
+        exp: PAST_EXP_SECONDS,
+      });
+      mockGetSettings.mockReturnValue(
+        buildSettings({
+          userId: "user-123",
+          plusLicenseKey: "key",
+          entitlementToken: "token",
+          entitlementExpiresAt: PAST_EXP_SECONDS * 1000,
+          isPaidUser: true,
+        })
+      );
+
+      const { result } = renderHook(() => useLicenseState());
+
+      await waitFor(() => expect(result.current.status).toBe("inactive"));
+    });
+
     it("shows nothing until the first verification answers", () => {
       // A paying user must never see their license called inactive for the
       // moment the check is in flight.

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -479,6 +479,17 @@ describe("plusUtils", () => {
       expect(result.current).toEqual({ status: "active", plan: "believer" });
     });
 
+    it("returns the same object across renders while the plan is unchanged", async () => {
+      await verifySessionClaims({ plan: "believer", tier: "plus" });
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
+
+      const { result, rerender } = renderHook(() => useLicenseState());
+      const first = result.current;
+      rerender();
+
+      expect(result.current).toBe(first);
+    });
+
     it("reports inactive for a lapsed key the server downgraded to the free tier", async () => {
       // The server keeps answering is_valid for a lapsed key but issues a
       // free-tier entitlement that still names the plan, so the tier — not the

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -79,6 +79,26 @@ function tokenBackedSettings(overrides: Partial<CopilotSettings> = {}): CopilotS
   });
 }
 
+/**
+ * Drive the module's verified proof from a token whose claims are given, the
+ * way the real startup path does.
+ */
+async function verifySessionClaims(
+  claims: Partial<{ plan: string; tier: string; features: string[]; exp: number }>
+): Promise<void> {
+  mockVerifyEntitlement.mockResolvedValue({
+    user_id: "user-123",
+    plan: "believer",
+    tier: "plus",
+    features: [],
+    iat: 0,
+    exp: FUTURE_EXP_SECONDS,
+    ...claims,
+  });
+  mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123", entitlementToken: "token" }));
+  await verifyCachedEntitlement();
+}
+
 describe("plusUtils", () => {
   // Every gate reads the in-memory proof, so reset it to the fail-closed state.
   beforeEach(async () => {
@@ -450,162 +470,68 @@ describe("plusUtils", () => {
   });
 
   describe("useLicenseState()", () => {
-    it("names the plan the verified token was issued for", async () => {
-      mockVerifyEntitlement.mockResolvedValue({
-        user_id: "user-123",
-        plan: "believer",
-        tier: "plus",
-        features: ["multi_agent"],
-        iat: 0,
-        exp: FUTURE_EXP_SECONDS,
-      });
+    it("names the plan the session-verified entitlement carries", async () => {
+      await verifySessionClaims({ plan: "believer", tier: "plus" });
       mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
 
       const { result } = renderHook(() => useLicenseState());
 
-      await waitFor(() => expect(result.current).toEqual({ status: "active", plan: "believer" }));
+      expect(result.current).toEqual({ status: "active", plan: "believer" });
     });
 
     it("reports inactive for a lapsed key the server downgraded to the free tier", async () => {
       // The server keeps answering is_valid for a lapsed key but issues a
-      // free-tier token that still names the plan, so the tier — not the plan
-      // name — is what says this user has nothing.
-      mockVerifyEntitlement.mockResolvedValue({
-        user_id: "user-123",
-        plan: "plus",
-        tier: "free",
-        features: [],
-        iat: 0,
-        exp: FUTURE_EXP_SECONDS,
-      });
+      // free-tier entitlement that still names the plan, so the tier — not the
+      // plan name — is what says this user has nothing.
+      await verifySessionClaims({ plan: "plus", tier: "free" });
       mockGetSettings.mockReturnValue(
         tokenBackedSettings({ plusLicenseKey: "key", isPaidUser: false })
       );
 
       const { result } = renderHook(() => useLicenseState());
 
-      await waitFor(() => expect(result.current.status).toBe("inactive"));
-      expect(result.current.plan).toBeUndefined();
+      expect(result.current).toEqual({ status: "inactive" });
     });
 
-    it("reports inactive when the stored token's offline window has run out", async () => {
-      mockVerifyEntitlement.mockResolvedValue(null);
-      mockGetSettings.mockReturnValue(
-        buildSettings({
-          userId: "user-123",
-          plusLicenseKey: "key",
-          entitlementToken: "token",
-          entitlementExpiresAt: PAST_EXP_SECONDS * 1000,
-          isPaidUser: true,
-        })
-      );
+    it("reports inactive once the signed expiry has passed", async () => {
+      // Shares the gates' liveness bound, so a section left open across `exp`
+      // stops naming a plan whose entitlement has already closed.
+      await verifySessionClaims({ plan: "plus", tier: "plus", exp: PAST_EXP_SECONDS });
+      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
 
       const { result } = renderHook(() => useLicenseState());
 
-      await waitFor(() => expect(result.current.status).toBe("inactive"));
+      expect(result.current).toEqual({ status: "inactive" });
     });
 
     it("reports inactive for a stored key the server rejected outright", async () => {
       // turnOffPaid clears the token and the expiry, so nothing but the key and
       // the downgraded flag survive an invalid or revoked key.
-      mockVerifyEntitlement.mockResolvedValue(null);
       mockGetSettings.mockReturnValue(
         buildSettings({ userId: "user-123", plusLicenseKey: "key", isPaidUser: false })
       );
 
       const { result } = renderHook(() => useLicenseState());
 
-      await waitFor(() => expect(result.current.status).toBe("inactive"));
+      expect(result.current).toEqual({ status: "inactive" });
     });
 
-    it("keeps a paid key active when the server confirmed it without signing a token", async () => {
-      mockVerifyEntitlement.mockResolvedValue(null);
+    it("keeps a paid key active when the server confirmed it without signing a token", () => {
       mockGetSettings.mockReturnValue(
         buildSettings({ userId: "user-123", plusLicenseKey: "key", isPaidUser: true })
       );
 
       const { result } = renderHook(() => useLicenseState());
 
-      await waitFor(() => expect(mockVerifyEntitlement).toHaveBeenCalled());
       expect(result.current).toEqual({ status: "active" });
     });
 
-    it("does not answer a changed key with the previous key's verdict", async () => {
-      // The result carries the key it describes, so a verdict for the old key
-      // reads as unanswered until the new one's check lands. The settings
-      // section covers the rest of that window, where the stored token is still
-      // empty and the server has not answered yet.
-      mockVerifyEntitlement.mockResolvedValueOnce(null).mockReturnValueOnce(new Promise(() => {}));
-      mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123" }));
-
-      const { result, rerender } = renderHook(() => useLicenseState());
-      await waitFor(() => expect(mockVerifyEntitlement).toHaveBeenCalledTimes(1));
-
-      mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123", plusLicenseKey: "key" }));
-      rerender();
-
-      expect(result.current.status).toBe("none");
-    });
-
-    it("stops naming the plan when the claims expire while the section stays open", async () => {
-      // Nothing re-renders merely because time passed, so the expiry has to be
-      // its own invalidation source: a settings tab left open across `exp` must
-      // not keep naming a plan whose entitlement gates have already closed.
-      mockVerifyEntitlement.mockResolvedValue({
-        user_id: "user-123",
-        plan: "plus",
-        tier: "plus",
-        features: ["multi_agent"],
-        iat: 0,
-        exp: (Date.now() + 50) / 1000,
-      });
-      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
-
-      const { result } = renderHook(() => useLicenseState());
-
-      await waitFor(() => expect(result.current.status).toBe("active"));
-      await waitFor(() => expect(result.current.status).toBe("inactive"));
-    });
-
-    it("keeps naming the plan when the expiry is further out than a timer can hold", async () => {
-      // A delay past the 32-bit limit wraps to immediate, which would blank the
-      // badge the moment it rendered.
-      mockVerifyEntitlement.mockResolvedValue({
-        user_id: "user-123",
-        plan: "plus",
-        tier: "plus",
-        features: ["multi_agent"],
-        iat: 0,
-        exp: FUTURE_EXP_SECONDS,
-      });
-      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
-
-      const { result } = renderHook(() => useLicenseState());
-
-      await waitFor(() => expect(result.current).toEqual({ status: "active", plan: "plus" }));
-      await new Promise((resolve) => window.setTimeout(resolve, 20));
-      expect(result.current).toEqual({ status: "active", plan: "plus" });
-    });
-
-    it("shows nothing until the first verification answers", () => {
-      // A paying user must never see their license called inactive for the
-      // moment the check is in flight.
-      mockVerifyEntitlement.mockReturnValue(new Promise(() => {}));
-      mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
-
-      const { result } = renderHook(() => useLicenseState());
-
-      expect(result.current.status).toBe("none");
-    });
-
-    it("shows nothing when no license key is stored", async () => {
-      mockVerifyEntitlement.mockResolvedValue(null);
+    it("shows nothing when no license key is stored", () => {
       mockGetSettings.mockReturnValue(buildSettings({ userId: "user-123", isPaidUser: false }));
 
       const { result } = renderHook(() => useLicenseState());
 
-      await waitFor(() => expect(mockVerifyEntitlement).toHaveBeenCalled());
-      expect(result.current.status).toBe("none");
+      expect(result.current).toEqual({ status: "none" });
     });
   });
 

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -282,6 +282,17 @@ export interface LicenseState {
   plan?: string;
 }
 
+/**
+ * A verification tagged with what it describes. The key and token are what
+ * settings must still hold for the claims to mean anything, so a stored key
+ * that changed under an in-flight check can never be judged by the old answer.
+ */
+interface VerificationResult {
+  licenseKey: string;
+  token: string;
+  claims: EntitlementClaims | null;
+}
+
 const NO_LICENSE: LicenseState = Object.freeze({ status: "none" });
 const INACTIVE_LICENSE: LicenseState = Object.freeze({ status: "inactive" });
 /** Paid, but with no verifiable token to name the plan (legacy tokenless keys). */
@@ -299,28 +310,34 @@ const UNNAMED_ACTIVE_LICENSE: LicenseState = Object.freeze({ status: "active" })
  */
 export function useLicenseState(): LicenseState {
   const settings = useSettingsValue();
-  // `undefined` until the first verification answers, so a paying user never
-  // sees their license called inactive for the moment that check is in flight.
-  const [claims, setClaims] = React.useState<EntitlementClaims | null | undefined>(undefined);
+  const [result, setResult] = React.useState<VerificationResult | null>(null);
 
   React.useEffect(() => {
     let cancelled = false;
-    void verifyEntitlement(settings.entitlementToken, {
-      expectedUserId: settings.userId,
-    }).then((verifiedClaims) => {
+    const subject = { licenseKey: settings.plusLicenseKey, token: settings.entitlementToken };
+    void verifyEntitlement(subject.token, { expectedUserId: settings.userId }).then((claims) => {
       if (!cancelled) {
-        setClaims(verifiedClaims);
+        setResult({ ...subject, claims });
       }
     });
     return () => {
       cancelled = true;
     };
-  }, [settings.entitlementToken, settings.userId]);
+  }, [settings.plusLicenseKey, settings.entitlementToken, settings.userId]);
 
   return React.useMemo(() => {
-    if (!settings.plusLicenseKey || claims === undefined) {
+    // A result for a different key or token says nothing about the one stored
+    // now, so it reads as unanswered — otherwise a free user's "no token"
+    // verdict would reject the key they just pasted for the whole round-trip.
+    const answered =
+      result?.licenseKey === settings.plusLicenseKey && result?.token === settings.entitlementToken;
+    if (!settings.plusLicenseKey || !answered) {
       return NO_LICENSE;
     }
+    // Claims were unexpired when verified, which is not the same as now: a
+    // settings tab left open past `exp` must stop reporting the plan its gates
+    // have already closed.
+    const claims = result.claims && result.claims.exp * 1000 > Date.now() ? result.claims : null;
     if (claims) {
       return claims.tier === "free"
         ? INACTIVE_LICENSE
@@ -333,7 +350,7 @@ export function useLicenseState(): LicenseState {
     return settings.isPaidUser === true && !isEntitlementExpired(settings)
       ? UNNAMED_ACTIVE_LICENSE
       : INACTIVE_LICENSE;
-  }, [claims, settings]);
+  }, [result, settings]);
 }
 
 /**

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -265,10 +265,12 @@ export async function checkIsPaidUser(
 
 /**
  * What the license section should report about the stored license key.
- * `none` also covers "not resolved yet", so the UI shows nothing rather than
- * guessing while the first validation is in flight.
+ * `none` means there is nothing to say — no key, or the first check has not
+ * answered yet. Everything a stored key can be other than working is `inactive`:
+ * lapsed, revoked, mistyped, or past the offline window all leave the user in
+ * the same place, with the same thing to do about it.
  */
-export type LicenseStatus = "none" | "active" | "expired";
+export type LicenseStatus = "none" | "active" | "inactive";
 
 /** Stored license as the settings UI should present it. */
 export interface LicenseState {
@@ -281,24 +283,25 @@ export interface LicenseState {
 }
 
 const NO_LICENSE: LicenseState = Object.freeze({ status: "none" });
-const EXPIRED_LICENSE: LicenseState = Object.freeze({ status: "expired" });
+const INACTIVE_LICENSE: LicenseState = Object.freeze({ status: "inactive" });
 /** Paid, but with no verifiable token to name the plan (legacy tokenless keys). */
 const UNNAMED_ACTIVE_LICENSE: LicenseState = Object.freeze({ status: "active" });
 
 /**
- * The stored license as the settings badge should show it, taken from the
+ * The stored license as the settings section should show it, taken from the
  * signed claims rather than the `/license` response so the plan name survives a
  * restart, shows up offline, and can't be renamed by editing `data.json`.
  *
- * A lapsed key is `expired`, not `none`: the server keeps answering `is_valid`
- * for it but downgrades the entitlement to the free policy, so the paid tier —
- * not the plan name, which still names the plan that lapsed — is what separates
- * a paying user from one who needs to renew. A stored token whose offline
- * window ran out reads the same way, since nothing has re-confirmed the plan.
+ * The paid tier decides, never the plan name: the server answers `is_valid` for
+ * a lapsed key and downgrades its entitlement to the free policy while the name
+ * still says what lapsed, so reading the name would call a former subscriber a
+ * Plus user.
  */
 export function useLicenseState(): LicenseState {
   const settings = useSettingsValue();
-  const [claims, setClaims] = React.useState<EntitlementClaims | null>(null);
+  // `undefined` until the first verification answers, so a paying user never
+  // sees their license called inactive for the moment that check is in flight.
+  const [claims, setClaims] = React.useState<EntitlementClaims | null | undefined>(undefined);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -315,21 +318,21 @@ export function useLicenseState(): LicenseState {
   }, [settings.entitlementToken, settings.userId]);
 
   return React.useMemo(() => {
-    if (!settings.plusLicenseKey) {
+    if (!settings.plusLicenseKey || claims === undefined) {
       return NO_LICENSE;
     }
     if (claims) {
       return claims.tier === "free"
-        ? EXPIRED_LICENSE
+        ? INACTIVE_LICENSE
         : { status: "active" as const, plan: claims.plan };
     }
-    // No claims to read: either the token is gone (an authoritative negative
-    // cleared it) or it no longer verifies. Both are "was a license, isn't
-    // entitled now" once the persisted flags say so.
-    if (isEntitlementExpired(settings) || settings.isPaidUser === false) {
-      return EXPIRED_LICENSE;
-    }
-    return settings.isPaidUser === true ? UNNAMED_ACTIVE_LICENSE : NO_LICENSE;
+    // Nothing verifies. The server can confirm a paid license without signing
+    // one (an unshipped `kid`, no WebCrypto), so keep those users active but
+    // unnamed — unless a stored expiry has already passed, which no later
+    // success has replaced.
+    return settings.isPaidUser === true && !isEntitlementExpired(settings)
+      ? UNNAMED_ACTIVE_LICENSE
+      : INACTIVE_LICENSE;
   }, [claims, settings]);
 }
 

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -282,6 +282,9 @@ export interface LicenseState {
   plan?: string;
 }
 
+/** Longest delay `setTimeout` can hold; anything larger wraps to immediate. */
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
 /**
  * A verification tagged with what it describes. The key and token are what
  * settings must still hold for the claims to mean anything, so a stored key
@@ -314,14 +317,27 @@ export function useLicenseState(): LicenseState {
 
   React.useEffect(() => {
     let cancelled = false;
+    let expiryTimer: number | undefined;
     const subject = { licenseKey: settings.plusLicenseKey, token: settings.entitlementToken };
     void verifyEntitlement(subject.token, { expectedUserId: settings.userId }).then((claims) => {
-      if (!cancelled) {
-        setResult({ ...subject, claims });
+      if (cancelled) {
+        return;
+      }
+      setResult({ ...subject, claims });
+      // Claims are unexpired only as of this moment, and time is the one input
+      // nothing else reports: a section left open across `exp` would otherwise
+      // keep naming a plan whose entitlement has already lapsed.
+      const untilExpiry = claims ? claims.exp * 1000 - Date.now() : 0;
+      // A delay past the 32-bit limit wraps and fires at once, which would blank
+      // the plan name instantly. Entitlements last ~14 days, so a horizon that
+      // far out is not one worth re-arming a timer to reach.
+      if (untilExpiry > 0 && untilExpiry <= MAX_TIMEOUT_MS) {
+        expiryTimer = window.setTimeout(() => setResult({ ...subject, claims: null }), untilExpiry);
       }
     });
     return () => {
       cancelled = true;
+      window.clearTimeout(expiryTimer);
     };
   }, [settings.plusLicenseKey, settings.entitlementToken, settings.userId]);
 
@@ -334,11 +350,8 @@ export function useLicenseState(): LicenseState {
     if (!settings.plusLicenseKey || !answered) {
       return NO_LICENSE;
     }
-    // Claims were unexpired when verified, which is not the same as now: a
-    // settings tab left open past `exp` must stop reporting the plan its gates
-    // have already closed.
-    const claims = result.claims && result.claims.exp * 1000 > Date.now() ? result.claims : null;
-    if (claims) {
+    if (result.claims) {
+      const claims = result.claims;
       return claims.tier === "free"
         ? INACTIVE_LICENSE
         : { status: "active" as const, plan: claims.plan };

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -9,7 +9,7 @@ import {
   PLUS_UTM_MEDIUMS,
   PlusUtmMedium,
 } from "@/constants";
-import { EntitlementClaims, EntitlementFeature, verifyEntitlement } from "@/entitlement";
+import { EntitlementFeature, verifyEntitlement } from "@/entitlement";
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import { logError, logInfo } from "@/logger";
 import {
@@ -101,6 +101,8 @@ function isEntitlementExpired(settings: CopilotSettings): boolean {
 interface VerifiedEntitlement {
   token: string;
   features: ReadonlySet<EntitlementFeature>;
+  /** The claims' plan name, for display only — never gated on. */
+  plan: string;
   /** The claims' `exp`, in epoch ms. */
   expiresAt: number;
   /**
@@ -115,6 +117,7 @@ interface VerifiedEntitlement {
 const NO_VERIFIED_ENTITLEMENT: VerifiedEntitlement = Object.freeze({
   token: "",
   features: Object.freeze(new Set<EntitlementFeature>()),
+  plan: "",
   expiresAt: 0,
   paid: false,
 });
@@ -282,29 +285,18 @@ export interface LicenseState {
   plan?: string;
 }
 
-/** Longest delay `setTimeout` can hold; anything larger wraps to immediate. */
-const MAX_TIMEOUT_MS = 2_147_483_647;
-
-/**
- * A verification tagged with what it describes. The key and token are what
- * settings must still hold for the claims to mean anything, so a stored key
- * that changed under an in-flight check can never be judged by the old answer.
- */
-interface VerificationResult {
-  licenseKey: string;
-  token: string;
-  claims: EntitlementClaims | null;
-}
-
 const NO_LICENSE: LicenseState = Object.freeze({ status: "none" });
 const INACTIVE_LICENSE: LicenseState = Object.freeze({ status: "inactive" });
 /** Paid, but with no verifiable token to name the plan (legacy tokenless keys). */
 const UNNAMED_ACTIVE_LICENSE: LicenseState = Object.freeze({ status: "active" });
 
 /**
- * The stored license as the settings section should show it, taken from the
- * signed claims rather than the `/license` response so the plan name survives a
- * restart, shows up offline, and can't be renamed by editing `data.json`.
+ * The stored license as the settings section should show it, read from the same
+ * session-verified proof the runtime gates use. Sharing that state is what keeps
+ * the badge from ever disagreeing with what the user can actually do, and it
+ * carries the two properties this would otherwise have to rebuild: the proof is
+ * tagged with the token settings must still hold, and {@link hasLiveEntitlement}
+ * treats the signed `exp` as its liveness bound.
  *
  * The paid tier decides, never the plan name: the server answers `is_valid` for
  * a lapsed key and downgrades its entitlement to the free policy while the name
@@ -313,57 +305,19 @@ const UNNAMED_ACTIVE_LICENSE: LicenseState = Object.freeze({ status: "active" })
  */
 export function useLicenseState(): LicenseState {
   const settings = useSettingsValue();
-  const [result, setResult] = React.useState<VerificationResult | null>(null);
-
-  React.useEffect(() => {
-    let cancelled = false;
-    let expiryTimer: number | undefined;
-    const subject = { licenseKey: settings.plusLicenseKey, token: settings.entitlementToken };
-    void verifyEntitlement(subject.token, { expectedUserId: settings.userId }).then((claims) => {
-      if (cancelled) {
-        return;
-      }
-      setResult({ ...subject, claims });
-      // Claims are unexpired only as of this moment, and time is the one input
-      // nothing else reports: a section left open across `exp` would otherwise
-      // keep naming a plan whose entitlement has already lapsed.
-      const untilExpiry = claims ? claims.exp * 1000 - Date.now() : 0;
-      // A delay past the 32-bit limit wraps and fires at once, which would blank
-      // the plan name instantly. Entitlements last ~14 days, so a horizon that
-      // far out is not one worth re-arming a timer to reach.
-      if (untilExpiry > 0 && untilExpiry <= MAX_TIMEOUT_MS) {
-        expiryTimer = window.setTimeout(() => setResult({ ...subject, claims: null }), untilExpiry);
-      }
-    });
-    return () => {
-      cancelled = true;
-      window.clearTimeout(expiryTimer);
-    };
-  }, [settings.plusLicenseKey, settings.entitlementToken, settings.userId]);
-
-  return React.useMemo(() => {
-    // A result for a different key or token says nothing about the one stored
-    // now, so it reads as unanswered — otherwise a free user's "no token"
-    // verdict would reject the key they just pasted for the whole round-trip.
-    const answered =
-      result?.licenseKey === settings.plusLicenseKey && result?.token === settings.entitlementToken;
-    if (!settings.plusLicenseKey || !answered) {
-      return NO_LICENSE;
-    }
-    if (result.claims) {
-      const claims = result.claims;
-      return claims.tier === "free"
-        ? INACTIVE_LICENSE
-        : { status: "active" as const, plan: claims.plan };
-    }
-    // Nothing verifies. The server can confirm a paid license without signing
-    // one (an unshipped `kid`, no WebCrypto), so keep those users active but
-    // unnamed — unless a stored expiry has already passed, which no later
-    // success has replaced.
-    return settings.isPaidUser === true && !isEntitlementExpired(settings)
-      ? UNNAMED_ACTIVE_LICENSE
-      : INACTIVE_LICENSE;
-  }, [result, settings]);
+  if (!settings.plusLicenseKey) {
+    return NO_LICENSE;
+  }
+  if (hasLiveEntitlement()) {
+    return verified.paid ? { status: "active", plan: verified.plan } : INACTIVE_LICENSE;
+  }
+  // Nothing verified this session. The server can confirm a paid license
+  // without signing one (an unshipped `kid`, no WebCrypto), so keep those users
+  // active but unnamed — unless a stored expiry has already passed, which no
+  // later success has replaced.
+  return settings.isPaidUser === true && !isEntitlementExpired(settings)
+    ? UNNAMED_ACTIVE_LICENSE
+    : INACTIVE_LICENSE;
 }
 
 /**
@@ -535,6 +489,7 @@ export async function applyEntitlement(token: string): Promise<boolean> {
   verified = {
     token,
     features: new Set(claims.features),
+    plan: claims.plan,
     expiresAt: claims.exp * 1000,
     paid: claims.tier !== "free",
   };
@@ -574,6 +529,7 @@ export async function verifyCachedEntitlement(): Promise<void> {
   verified = {
     token: entitlementToken,
     features: new Set(claims?.features),
+    plan: claims?.plan ?? "",
     expiresAt: (claims?.exp ?? 0) * 1000,
     paid: claims ? claims.tier !== "free" : false,
   };

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -9,7 +9,7 @@ import {
   PLUS_UTM_MEDIUMS,
   PlusUtmMedium,
 } from "@/constants";
-import { EntitlementFeature, verifyEntitlement } from "@/entitlement";
+import { EntitlementClaims, EntitlementFeature, verifyEntitlement } from "@/entitlement";
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import { logError, logInfo } from "@/logger";
 import {
@@ -261,6 +261,76 @@ export async function checkIsPaidUser(
     return { isValid: undefined };
   });
   return result.isValid ?? (hasLiveEntitlement() && verified.paid);
+}
+
+/**
+ * What the license section should report about the stored license key.
+ * `none` also covers "not resolved yet", so the UI shows nothing rather than
+ * guessing while the first validation is in flight.
+ */
+export type LicenseStatus = "none" | "active" | "expired";
+
+/** Stored license as the settings UI should present it. */
+export interface LicenseState {
+  status: LicenseStatus;
+  /**
+   * Plan the entitlement names, lowercased by the server (e.g. `"believer"`).
+   * Absent when no token verifies, which is why callers need a generic label.
+   */
+  plan?: string;
+}
+
+const NO_LICENSE: LicenseState = Object.freeze({ status: "none" });
+const EXPIRED_LICENSE: LicenseState = Object.freeze({ status: "expired" });
+/** Paid, but with no verifiable token to name the plan (legacy tokenless keys). */
+const UNNAMED_ACTIVE_LICENSE: LicenseState = Object.freeze({ status: "active" });
+
+/**
+ * The stored license as the settings badge should show it, taken from the
+ * signed claims rather than the `/license` response so the plan name survives a
+ * restart, shows up offline, and can't be renamed by editing `data.json`.
+ *
+ * A lapsed key is `expired`, not `none`: the server keeps answering `is_valid`
+ * for it but downgrades the entitlement to the free policy, so the paid tier —
+ * not the plan name, which still names the plan that lapsed — is what separates
+ * a paying user from one who needs to renew. A stored token whose offline
+ * window ran out reads the same way, since nothing has re-confirmed the plan.
+ */
+export function useLicenseState(): LicenseState {
+  const settings = useSettingsValue();
+  const [claims, setClaims] = React.useState<EntitlementClaims | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    void verifyEntitlement(settings.entitlementToken, {
+      expectedUserId: settings.userId,
+    }).then((verifiedClaims) => {
+      if (!cancelled) {
+        setClaims(verifiedClaims);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [settings.entitlementToken, settings.userId]);
+
+  return React.useMemo(() => {
+    if (!settings.plusLicenseKey) {
+      return NO_LICENSE;
+    }
+    if (claims) {
+      return claims.tier === "free"
+        ? EXPIRED_LICENSE
+        : { status: "active" as const, plan: claims.plan };
+    }
+    // No claims to read: either the token is gone (an authoritative negative
+    // cleared it) or it no longer verifies. Both are "was a license, isn't
+    // entitled now" once the persisted flags say so.
+    if (isEntitlementExpired(settings) || settings.isPaidUser === false) {
+      return EXPIRED_LICENSE;
+    }
+    return settings.isPaidUser === true ? UNNAMED_ACTIVE_LICENSE : NO_LICENSE;
+  }, [claims, settings]);
 }
 
 /**

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -305,11 +305,22 @@ const UNNAMED_ACTIVE_LICENSE: LicenseState = Object.freeze({ status: "active" })
  */
 export function useLicenseState(): LicenseState {
   const settings = useSettingsValue();
+  // The fixed states are frozen constants; a named plan is the one result that
+  // has to be built, so it is kept until the name itself changes. Keying on the
+  // returned value rather than on `settings` is what stops the cache from
+  // outliving a proof that changed without one.
+  const namedActive = React.useRef<LicenseState | null>(null);
   if (!settings.plusLicenseKey) {
     return NO_LICENSE;
   }
   if (hasLiveEntitlement()) {
-    return verified.paid ? { status: "active", plan: verified.plan } : INACTIVE_LICENSE;
+    if (!verified.paid) {
+      return INACTIVE_LICENSE;
+    }
+    if (namedActive.current?.plan !== verified.plan) {
+      namedActive.current = { status: "active", plan: verified.plan };
+    }
+    return namedActive.current;
   }
   // Nothing verified this session. The server can confirm a paid license
   // without signing one (an unshipped `kid`, no WebCrypto), so keep those users

--- a/src/settings/v2/components/PlusSettings.test.tsx
+++ b/src/settings/v2/components/PlusSettings.test.tsx
@@ -46,59 +46,61 @@ describe("PlusSettings", () => {
     mockIsPaidUser = false;
   });
 
-  it("names a lifetime purchase Lifetime rather than its stored plan", () => {
-    mockLicenseState = { status: "active", plan: "believer" };
-    mockIsPaidUser = true;
+  describe("PlusSettings()", () => {
+    it("names a lifetime purchase Lifetime rather than its stored plan", () => {
+      mockLicenseState = { status: "active", plan: "believer" };
+      mockIsPaidUser = true;
 
-    render(<PlusSettings />);
+      render(<PlusSettings />);
 
-    expect(screen.getByText("Lifetime")).toBeTruthy();
-    expect(screen.queryByText(/believer/i)).toBeNull();
-  });
-
-  it("shows a recurring plan under its own name", () => {
-    mockLicenseState = { status: "active", plan: "lite" };
-    mockIsPaidUser = true;
-
-    render(<PlusSettings />);
-
-    expect(screen.getByText("lite")).toBeTruthy();
-  });
-
-  it("reports a stored key that grants nothing as inactive, alongside the pitch", () => {
-    mockLicenseState = { status: "inactive" };
-
-    render(<PlusSettings />);
-
-    expect(screen.getByText("Inactive")).toBeTruthy();
-    expect(screen.getByText("All of it for a few dollars a month.")).toBeTruthy();
-  });
-
-  it("says nothing about a key while its validation is still in flight", async () => {
-    // The hook only sees the stored token, which stays empty until the server
-    // answers, so a freshly applied key reads as inactive there. Rejecting a
-    // license the user just bought — for the length of a network call — is the
-    // regression this guards.
-    mockLicenseState = { status: "inactive" };
-    let resolveValidation: (value: boolean) => void = () => {};
-    checkIsPaidUser.mockReturnValue(
-      new Promise<boolean>((resolve) => {
-        resolveValidation = resolve;
-      })
-    );
-
-    render(<PlusSettings />);
-    act(() => {
-      screen.getByRole("button", { name: "Apply" }).click();
+      expect(screen.getByText("Lifetime")).toBeTruthy();
+      expect(screen.queryByText(/believer/i)).toBeNull();
     });
 
-    expect(screen.queryByText("Inactive")).toBeNull();
-    expect(screen.queryByText("All of it for a few dollars a month.")).toBeNull();
+    it("shows a recurring plan under its own name", () => {
+      mockLicenseState = { status: "active", plan: "lite" };
+      mockIsPaidUser = true;
 
-    await act(async () => {
-      resolveValidation(true);
+      render(<PlusSettings />);
+
+      expect(screen.getByText("lite")).toBeTruthy();
     });
 
-    expect(screen.getByText("Inactive")).toBeTruthy();
+    it("reports a stored key that grants nothing as inactive, alongside the pitch", () => {
+      mockLicenseState = { status: "inactive" };
+
+      render(<PlusSettings />);
+
+      expect(screen.getByText("Inactive")).toBeTruthy();
+      expect(screen.getByText("All of it for a few dollars a month.")).toBeTruthy();
+    });
+
+    it("says nothing about a key while its validation is still in flight", async () => {
+      // The hook only sees the stored token, which stays empty until the server
+      // answers, so a freshly applied key reads as inactive there. Rejecting a
+      // license the user just bought — for the length of a network call — is the
+      // regression this guards.
+      mockLicenseState = { status: "inactive" };
+      let resolveValidation: (value: boolean) => void = () => {};
+      checkIsPaidUser.mockReturnValue(
+        new Promise<boolean>((resolve) => {
+          resolveValidation = resolve;
+        })
+      );
+
+      render(<PlusSettings />);
+      act(() => {
+        screen.getByRole("button", { name: "Apply" }).click();
+      });
+
+      expect(screen.queryByText("Inactive")).toBeNull();
+      expect(screen.queryByText("All of it for a few dollars a month.")).toBeNull();
+
+      await act(async () => {
+        resolveValidation(true);
+      });
+
+      expect(screen.getByText("Inactive")).toBeTruthy();
+    });
   });
 });

--- a/src/settings/v2/components/PlusSettings.test.tsx
+++ b/src/settings/v2/components/PlusSettings.test.tsx
@@ -1,0 +1,104 @@
+import { DEFAULT_SETTINGS } from "@/constants";
+import { act, render, screen } from "@testing-library/react";
+import React from "react";
+
+const updateSetting = jest.fn<void, unknown[]>();
+let currentSettings = { ...DEFAULT_SETTINGS };
+jest.mock("@/settings/model", () => ({
+  updateSetting: (...a: unknown[]) => updateSetting(...a),
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
+  useSettingsValue: () => currentSettings,
+}));
+
+// Entitlement surface. `useLicenseState` is the hook under test elsewhere; here
+// it only has to produce the states this section renders.
+let mockLicenseState: { status: string; plan?: string } = { status: "none" };
+let mockIsPaidUser: boolean | undefined = false;
+const checkIsPaidUser = jest.fn<Promise<boolean | undefined>, unknown[]>();
+jest.mock("@/plusUtils", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook
+  useLicenseState: () => mockLicenseState,
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook
+  useIsPaidUser: () => mockIsPaidUser,
+  checkIsPaidUser: (...a: unknown[]) => checkIsPaidUser(...a),
+  createPlusPageUrl: () => "https://example.test/plans",
+  navigateToPlusPage: jest.fn(),
+}));
+
+jest.mock("@/context", () => ({
+  // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook
+  useApp: () => ({}),
+}));
+
+jest.mock("@/components/modals/CopilotPlusWelcomeModal", () => ({
+  CopilotPlusWelcomeModal: class {
+    open() {}
+  },
+}));
+
+import { PlusSettings } from "./PlusSettings";
+
+describe("PlusSettings", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentSettings = { ...DEFAULT_SETTINGS };
+    mockLicenseState = { status: "none" };
+    mockIsPaidUser = false;
+  });
+
+  it("names a lifetime purchase Lifetime rather than its stored plan", () => {
+    mockLicenseState = { status: "active", plan: "believer" };
+    mockIsPaidUser = true;
+
+    render(<PlusSettings />);
+
+    expect(screen.getByText("Lifetime")).toBeTruthy();
+    expect(screen.queryByText(/believer/i)).toBeNull();
+  });
+
+  it("shows a recurring plan under its own name", () => {
+    mockLicenseState = { status: "active", plan: "lite" };
+    mockIsPaidUser = true;
+
+    render(<PlusSettings />);
+
+    expect(screen.getByText("lite")).toBeTruthy();
+  });
+
+  it("reports a stored key that grants nothing as inactive, alongside the pitch", () => {
+    mockLicenseState = { status: "inactive" };
+
+    render(<PlusSettings />);
+
+    expect(screen.getByText("Inactive")).toBeTruthy();
+    expect(screen.getByText("All of it for a few dollars a month.")).toBeTruthy();
+  });
+
+  it("says nothing about a key while its validation is still in flight", async () => {
+    // The hook only sees the stored token, which stays empty until the server
+    // answers, so a freshly applied key reads as inactive there. Rejecting a
+    // license the user just bought — for the length of a network call — is the
+    // regression this guards.
+    mockLicenseState = { status: "inactive" };
+    let resolveValidation: (value: boolean) => void = () => {};
+    checkIsPaidUser.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveValidation = resolve;
+      })
+    );
+
+    render(<PlusSettings />);
+    act(() => {
+      screen.getByRole("button", { name: "Apply" }).click();
+    });
+
+    expect(screen.queryByText("Inactive")).toBeNull();
+    expect(screen.queryByText("All of it for a few dollars a month.")).toBeNull();
+
+    await act(async () => {
+      resolveValidation(true);
+    });
+
+    expect(screen.getByText("Inactive")).toBeTruthy();
+  });
+});

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -24,6 +24,17 @@ function getPlusUsageMock(): { currentPct: number; weeklyPct: number } | null {
   return null;
 }
 
+/**
+ * Labels for plans whose stored name is not what we want to show a customer.
+ * Supporter and legacy Believer are one lifetime purchase as far as anyone
+ * outside billing is concerned, and no signal the client receives separates
+ * them anyway. Anything absent here shows its own name.
+ */
+const PLAN_LABELS: Record<string, string> = {
+  believer: "Lifetime",
+  supporter: "Lifetime",
+};
+
 export function PlusSettings() {
   const app = useApp();
   const settings = useSettingsValue();
@@ -31,10 +42,6 @@ export function PlusSettings() {
   const [isChecking, setIsChecking] = useState(false);
   const isPaidUser = useIsPaidUser();
   const license = useLicenseState();
-  // Applying a key stores it before the server answers, and an unresolved key
-  // reads as lapsed — so without this a first-time subscriber would be told
-  // their brand-new license had expired for as long as validation takes.
-  const isExpired = license.status === "expired" && !isChecking;
   const [localLicenseKey, setLocalLicenseKey] = useState(settings.plusLicenseKey);
   const usageData = getPlusUsageMock();
 
@@ -44,10 +51,12 @@ export function PlusSettings() {
         <span>Copilot License</span>
         {license.status === "active" && (
           <Badge className="tw-rounded-full tw-bg-success tw-capitalize tw-text-success">
-            {license.plan ?? "Active"}
+            {license.plan ? (PLAN_LABELS[license.plan] ?? license.plan) : "Active"}
           </Badge>
         )}
-        {isExpired && <Badge className="tw-rounded-full tw-bg-error tw-text-error">Expired</Badge>}
+        {license.status === "inactive" && (
+          <Badge className="tw-rounded-full tw-bg-error tw-text-error">Inactive</Badge>
+        )}
       </div>
       <div className="tw-flex tw-flex-col tw-gap-2 tw-text-sm tw-text-muted">
         <div>
@@ -76,32 +85,13 @@ export function PlusSettings() {
         </div>
       </div>
 
-      {/* A lapsed license reads as unpaid, so it would otherwise land in the
-          new-user upsell below — which sells plans this user already bought and
-          never says the license stopped working. */}
-      {isExpired && (
-        <div className="tw-flex tw-flex-col tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-bg-primary tw-p-3 tw-border-interactive-accent/30">
-          <div className="tw-text-sm tw-text-normal">
-            Your license has expired. Premium models, document understanding, advanced web search,
-            and multi-agent capabilities stay off until you{" "}
-            <a
-              href={createPlusPageUrl(PLUS_UTM_MEDIUMS.EXPIRED_SETTINGS)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="tw-font-semibold tw-text-accent"
-            >
-              renew your subscription
-            </a>
-            .
-          </div>
-        </div>
-      )}
-
-      {/* Free-user value + upsell. Gated on `isPaidUser === false` (not
-          `!isPaidUser`): the flag is `boolean | undefined`, defaulting to false
-          and staying on a cached value through network errors, so `=== false`
-          avoids flashing this block while the paid status is still resolving. */}
-      {isPaidUser === false && !isExpired && (
+      {/* One pitch for everyone without working access — never paid, or paid
+          once and no longer. Both want the same thing from this screen, and the
+          badge already says which they are. `isPaidUser === false` (not
+          `!isPaidUser`) keeps it from flashing while the flag is still
+          undefined; the status covers a key that stopped working while the
+          cached flag still reads paid. */}
+      {(isPaidUser === false || license.status === "inactive") && (
         <div className="tw-flex tw-flex-col tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-bg-primary tw-p-3 tw-border-interactive-accent/30">
           <div className="tw-text-sm tw-text-normal">All of it for a few dollars a month.</div>
           <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -25,15 +25,12 @@ function getPlusUsageMock(): { currentPct: number; weeklyPct: number } | null {
 }
 
 /**
- * Labels for plans whose stored name is not what we want to show a customer.
- * Supporter and legacy Believer are one lifetime purchase as far as anyone
- * outside billing is concerned, and no signal the client receives separates
- * them anyway. Anything absent here shows its own name.
+ * The one plan whose stored name is not what we show a customer: `believer`
+ * covers both the legacy Believer and the newer Supporter purchase, and nothing
+ * the client — or the billing data behind it — can separate them. Every other
+ * plan shows its own name.
  */
-const PLAN_LABELS: Record<string, string> = {
-  believer: "Lifetime",
-  supporter: "Lifetime",
-};
+const LIFETIME_PLAN = "believer";
 
 export function PlusSettings() {
   const app = useApp();
@@ -51,7 +48,7 @@ export function PlusSettings() {
         <span>Copilot License</span>
         {license.status === "active" && (
           <Badge className="tw-rounded-full tw-bg-success tw-capitalize tw-text-success">
-            {license.plan ? (PLAN_LABELS[license.plan] ?? license.plan) : "Active"}
+            {license.plan === LIFETIME_PLAN ? "Lifetime" : (license.plan ?? "Active")}
           </Badge>
         )}
         {license.status === "inactive" && (

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -39,6 +39,10 @@ export function PlusSettings() {
   const [isChecking, setIsChecking] = useState(false);
   const isPaidUser = useIsPaidUser();
   const license = useLicenseState();
+  // A key being validated is unknown, not rejected. The hook only sees the
+  // stored token, which is still empty until the server answers, so it would
+  // otherwise report a freshly pasted key as inactive for the whole round-trip.
+  const licenseStatus = isChecking ? "none" : license.status;
   const [localLicenseKey, setLocalLicenseKey] = useState(settings.plusLicenseKey);
   const usageData = getPlusUsageMock();
 
@@ -46,12 +50,12 @@ export function PlusSettings() {
     <section className="tw-flex tw-flex-col tw-gap-4 tw-rounded-xl tw-border tw-border-solid tw-p-4 tw-shadow-sm tw-bg-interactive-accent/10 tw-border-interactive-accent/40">
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-text-lg tw-font-semibold">
         <span>Copilot License</span>
-        {license.status === "active" && (
+        {licenseStatus === "active" && (
           <Badge className="tw-rounded-full tw-bg-success tw-capitalize tw-text-success">
             {license.plan === LIFETIME_PLAN ? "Lifetime" : (license.plan ?? "Active")}
           </Badge>
         )}
-        {license.status === "inactive" && (
+        {licenseStatus === "inactive" && (
           <Badge className="tw-rounded-full tw-bg-error tw-text-error">Inactive</Badge>
         )}
       </div>
@@ -88,7 +92,7 @@ export function PlusSettings() {
           `!isPaidUser`) keeps it from flashing while the flag is still
           undefined; the status covers a key that stopped working while the
           cached flag still reads paid. */}
-      {(isPaidUser === false || license.status === "inactive") && (
+      {(isPaidUser === false || licenseStatus === "inactive") && !isChecking && (
         <div className="tw-flex tw-flex-col tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-bg-primary tw-p-3 tw-border-interactive-accent/30">
           <div className="tw-text-sm tw-text-normal">All of it for a few dollars a month.</div>
           <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -4,7 +4,13 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { PasswordInput } from "@/components/ui/password-input";
 import { MIYO_HOMEPAGE_URL, PLUS_UTM_MEDIUMS } from "@/constants";
-import { checkIsPaidUser, createPlusPageUrl, navigateToPlusPage, useIsPaidUser } from "@/plusUtils";
+import {
+  checkIsPaidUser,
+  createPlusPageUrl,
+  navigateToPlusPage,
+  useIsPaidUser,
+  useLicenseState,
+} from "@/plusUtils";
 import { updateSetting, useSettingsValue } from "@/settings/model";
 import { ExternalLink, Loader2 } from "lucide-react";
 import React, { useState } from "react";
@@ -24,6 +30,11 @@ export function PlusSettings() {
   const [error, setError] = useState<string | null>(null);
   const [isChecking, setIsChecking] = useState(false);
   const isPaidUser = useIsPaidUser();
+  const license = useLicenseState();
+  // Applying a key stores it before the server answers, and an unresolved key
+  // reads as lapsed — so without this a first-time subscriber would be told
+  // their brand-new license had expired for as long as validation takes.
+  const isExpired = license.status === "expired" && !isChecking;
   const [localLicenseKey, setLocalLicenseKey] = useState(settings.plusLicenseKey);
   const usageData = getPlusUsageMock();
 
@@ -31,9 +42,12 @@ export function PlusSettings() {
     <section className="tw-flex tw-flex-col tw-gap-4 tw-rounded-xl tw-border tw-border-solid tw-p-4 tw-shadow-sm tw-bg-interactive-accent/10 tw-border-interactive-accent/40">
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-text-lg tw-font-semibold">
         <span>Copilot License</span>
-        {isPaidUser && (
-          <Badge className="tw-rounded-full tw-bg-success tw-text-success">Active</Badge>
+        {license.status === "active" && (
+          <Badge className="tw-rounded-full tw-bg-success tw-capitalize tw-text-success">
+            {license.plan ?? "Active"}
+          </Badge>
         )}
+        {isExpired && <Badge className="tw-rounded-full tw-bg-error tw-text-error">Expired</Badge>}
       </div>
       <div className="tw-flex tw-flex-col tw-gap-2 tw-text-sm tw-text-muted">
         <div>
@@ -62,11 +76,32 @@ export function PlusSettings() {
         </div>
       </div>
 
+      {/* A lapsed license reads as unpaid, so it would otherwise land in the
+          new-user upsell below — which sells plans this user already bought and
+          never says the license stopped working. */}
+      {isExpired && (
+        <div className="tw-flex tw-flex-col tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-bg-primary tw-p-3 tw-border-interactive-accent/30">
+          <div className="tw-text-sm tw-text-normal">
+            Your license has expired. Premium models, document understanding, advanced web search,
+            and multi-agent capabilities stay off until you{" "}
+            <a
+              href={createPlusPageUrl(PLUS_UTM_MEDIUMS.EXPIRED_SETTINGS)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="tw-font-semibold tw-text-accent"
+            >
+              renew your subscription
+            </a>
+            .
+          </div>
+        </div>
+      )}
+
       {/* Free-user value + upsell. Gated on `isPaidUser === false` (not
           `!isPaidUser`): the flag is `boolean | undefined`, defaulting to false
           and staying on a cached value through network errors, so `=== false`
           avoids flashing this block while the paid status is still resolving. */}
-      {isPaidUser === false && (
+      {isPaidUser === false && !isExpired && (
         <div className="tw-flex tw-flex-col tw-gap-2 tw-rounded-lg tw-border tw-border-solid tw-bg-primary tw-p-3 tw-border-interactive-accent/30">
           <div className="tw-text-sm tw-text-normal">All of it for a few dollars a month.</div>
           <div className="tw-flex tw-flex-wrap tw-items-center tw-gap-2">


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#263

Cross-repo `Fixes` references do not auto-close on merge, so #263 needs a manual close.

## Problem

`PlusSettings.tsx` renders a hardcoded `Active` badge for anyone paid, so a lifetime owner and a Plus subscriber see the same word and settings never says which plan the key carries — even though the signed entitlement already ships the plan name in its `plan` claim.

A dead license is worse than uninformative. The server keeps answering `is_valid: true` for a key whose subscription ended and downgrades the entitlement to the free policy, so `applyEntitlement` persists `isPaidUser: false`. The badge disappears and the section falls back to the new-user pitch, with nothing anywhere saying the license stopped working.

## User experience

A paying user sees what they actually have — `Plus`, `Lite`, or `Lifetime` — where it used to say "Active". Someone whose license stopped working, for any reason, sees `Inactive` and the same short pitch a new user sees, with a link to the plans. Nothing changes for people who have never bought a license, and nobody has to re-enter a key or take a recovery step.

## Fix

Read the plan from the verified claims rather than the `/license` response: it survives a restart, works offline, and an edited `data.json` cannot rename a Lite plan to Plus, because the name only counts when the ES256 signature verifies.

Everything a stored key can be other than working is **one** state. Lapsed, revoked, mistyped, and past-the-offline-window all leave the user in the same place with the same thing to do about it, so they share one word and one pitch — no separate "expired" copy, no second call to action. That collapse is why this diff removes UI rather than adding it.

The state keys on the **tier**, never the plan name: a lapsed token still names the plan that lapsed, so the name alone would call a former subscriber a Plus user.

The badge reads the same session-verified proof the runtime gates use, so the two can never disagree. That proof is already tagged with the token settings must still hold, and its liveness check is the signed `exp`; it was missing only the plan name, so it carries that now and the hook is a synchronous read.

An earlier revision kept a private cached verification here instead, which needed its own staleness tagging, then an expiry check, then a timer, then a clamp on that timer. Sharing the existing state removes all of it.

One thing the hook genuinely cannot know: whether a stored key has been validated yet. A key pasted into settings has no token until the server answers, and "never validated" is indistinguishable from "validated and rejected" — both leave `isPaidUser` false with no token. So the section that starts that call withholds the verdict until it returns, which is where that knowledge lives.

A lifetime purchase displays as `Lifetime`. Both the legacy Believer and the newer Supporter arrive as `believer` — the plan enum has no Supporter value — and nothing in the billing data separates them once manual extensions are accounted for. Every other plan shows its own name, so an unrecognized future plan reads plainer, never wrong.

## Explicit non-goals

- Distinguishing Supporter from legacy Believer. Closed as won't-do in Brevilabs/app-sites#250: manual grants carry neither a price ID nor a trustworthy end date, so any rule would be wrong for a real population.
- Any change to what an entitlement grants. Presentation only — `isPlusEnabled`, `isSelfHostModeValid`, and `canUseMultiAgent` are untouched.
- Fixing the Apply handler, which treats a lapsed key's `isValid: true` as success and opens the "Welcome to Copilot Plus" modal. Real, adjacent, separate diff. Suggested follow-up: *Reject a dead license key on Apply instead of showing the welcome modal*.
- Any usage/quota display. The `getPlusUsageMock` footer is unchanged.

## Scope

Budget gate: PASS — 5 files, +291/−8; the hook is the only new concept and it is a read of state the module already keeps, so most of the addition is the coverage tables for the hook's states and the section's rendering. Review rounds found bugs in exactly the paths that had none, which is why that spend is deliberate.

## Changes

- `src/plusUtils.ts` — the verified proof carries the plan name, and `useLicenseState()` reads it to return `none` / `active` / `inactive`, with frozen constants for the fixed results.
- `src/settings/v2/components/PlusSettings.tsx` — plan-name badge with the `Lifetime` label for lifetime purchases, an `Inactive` badge, and the existing pitch widened to cover dead licenses instead of a second block of expired-specific copy.
- `src/plusUtils.test.ts` — the hook's states: named plan, free-tier downgrade, signed expiry passed, outright rejection, tokenless paid, and no key.
- `src/settings/v2/components/PlusSettings.test.tsx` — what the section renders: the Lifetime label, a recurring plan under its own name, inactive alongside the pitch, and silence while a key is being validated.
- `docs/copilot-plus-and-self-host.md` — what the badge reports and where to renew, per the AGENTS.md docs rule for user-facing changes.

## Verification

- `npm run test` — 364 suites, 5223 tests, all passing.
- `npx tsc --noEmit`, `npm run lint`, `npm run format` — clean.
- Traced the lapsed path against the backends to confirm the state the client receives: app-sites returns `backendAccess: false` with the plan intact, brevilabs-api lowercases it and downgrades tier/features to free while keeping the `plan` claim — which is why the tier, not the name, drives the inactive state.
- Not exercised in a live vault: the states are verified through unit tests over the hook, not `npm run test:vault`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdTUSSqtjbKZbf2Py68EUB
