### PR TITLE
feat(project): add Property (frontmatter) as a context source

### DIFF
--- a/designdocs/AGENT_HOME_ARCHITECTURE.md
+++ b/designdocs/AGENT_HOME_ARCHITECTURE.md
@@ -213,9 +213,11 @@ user prompt. The block lists absolute paths to the snapshots so the agent can
 read them directly; the composer shows a context status icon and queues sends
 while context is still materializing.
 
-Folders, notes, tags, and extensions are listed in the same block by path/pattern
-(they need no conversion); folders that live outside the session cwd are also
-reported as `additionalDirectories` to widen the agent's searchable roots.
+Folders, notes, tags, extensions, and properties are listed in the same block by
+path/pattern (they need no conversion); folders that live outside the session cwd
+are also reported as `additionalDirectories` to widen the agent's searchable
+roots. Property inclusions additionally enumerate the notes they matched, because
+a frontmatter value is not something the agent could grep its way to.
 
 **Contract (relied on by the session manager):** materialization **never
 rejects** — any failure degrades to a best-effort partial / empty result so

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -68,10 +68,17 @@ Projects let you pre-load context that is always available in the project's chat
 
 ### File Inclusions and Exclusions
 
-Specify which notes or folders to include in this project's context:
+Specify which notes or folders to include in this project's context. You can include by:
 
-- **Inclusions**: Only these notes/folders are available for search and context
-- **Exclusions**: These notes/folders are excluded from context
+- **Tag** (e.g. `#research`) — all notes with that frontmatter tag. Expanded at query time, so new notes are included automatically.
+- **Folder** (e.g. `daily/`) — all markdown files in the folder, recursively. Also expanded at query time.
+- **Note link** (e.g. `[[Project Brief]]`) — a specific note, included verbatim. Use this for pinning a foundational document or README.
+- **Extension** (e.g. `*.py`) — all files with that extension. Expanded at query time.
+- **Property** (e.g. `[Topics:Physics]` or `[Subject:]`) — notes matching a frontmatter field. Syntax:
+  - `[key:value]` — include notes where the property `key` equals `value` (case-insensitive, trimmed). A list property matches when any element matches.
+  - `[key:]` — include notes that declare the property `key`, regardless of its value.
+
+**Exclusions**: These notes/folders are excluded from context.
 
 This scopes the AI's knowledge to just the notes relevant to your project.
 

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -225,13 +225,13 @@ const sessionCreateSpy = jest.spyOn(AgentSession, "start").mockImplementation((o
 
 function buildApp(basePath = "/vault"): App {
   const adapter = new (FileSystemAdapter as unknown as new (basePath: string) => unknown)(basePath);
-  // The ProjectContentTracker registers vault event listeners at construction;
-  // provide no-op `on`/`offref` so a manager can be built in tests.
-  const vaultEvents = {
+  // The ProjectContentTracker registers vault AND metadata-cache event listeners
+  // at construction; provide no-op `on`/`offref` on both so a manager can be built.
+  const events = {
     on: jest.fn(() => ({}) as never),
     offref: jest.fn(),
   };
-  return { vault: { adapter, ...vaultEvents } } as unknown as App;
+  return { vault: { adapter, ...events }, metadataCache: { ...events } } as unknown as App;
 }
 
 function buildPlugin(): { manifest: { version: string } } {
@@ -2035,6 +2035,9 @@ describe("AgentSessionManager chat history aggregation", () => {
           const fm = frontmatterByPath[file.path];
           return fm ? { frontmatter: fm } : null;
         },
+        // ProjectContentTracker also registers a metadata-cache "changed" listener.
+        on: jest.fn(() => ({}) as never),
+        offref: jest.fn(),
       },
     } as unknown as App;
     const plugin = {

--- a/src/agentMode/ui/hooks/usePersistentContextDrop.test.tsx
+++ b/src/agentMode/ui/hooks/usePersistentContextDrop.test.tsx
@@ -134,6 +134,27 @@ describe("usePersistentContextDrop", () => {
     expect(mockUpdateProject).not.toHaveBeenCalled();
   });
 
+  it("preserves existing property patterns when a file is dropped", async () => {
+    seedProject(
+      makeProject({
+        contextSource: {
+          inclusions: createPatternSettingsValue({ propertyPatterns: ["[Topics:Physics]"] }),
+        },
+      })
+    );
+    const file = new (TFile as unknown as new (p: string) => TFile)("notes/Intro.md");
+    const app = makeApp({ "notes/Intro.md": file });
+
+    const { getByTestId } = render(<Harness app={app} projectId="p1" />);
+    dispatchDrop(getByTestId("zone"), [{ kind: "string", value: "notes/Intro.md" }]);
+
+    await waitFor(() => expect(mockUpdateProject).toHaveBeenCalledTimes(1));
+    const [, nextConfig] = mockUpdateProject.mock.calls[0];
+    const patterns = getDecodedPatterns(nextConfig.contextSource.inclusions);
+    expect(patterns).toContain("[[Intro]]");
+    expect(patterns).toContain("[Topics:Physics]");
+  });
+
   it("rejects external OS files (no vault item resolved)", async () => {
     seedProject(makeProject());
     const app = makeApp({});

--- a/src/agentMode/ui/hooks/usePersistentContextDrop.ts
+++ b/src/agentMode/ui/hooks/usePersistentContextDrop.ts
@@ -100,6 +100,10 @@ async function persistInclusions(
   const notePatterns = new Set(existing?.notePatterns ?? []);
   const tagPatterns = new Set(existing?.tagPatterns ?? []);
   const extensionPatterns = new Set(existing?.extensionPatterns ?? []);
+  // Drops only add folders/notes, but every existing category must be carried
+  // through the rebuild — omitting property patterns here would silently erase
+  // a project's `[key:value]` sources on the next drop.
+  const propertyPatterns = new Set(existing?.propertyPatterns ?? []);
 
   let added = 0;
   for (const file of files) {
@@ -125,6 +129,7 @@ async function persistInclusions(
     extensionPatterns: [...extensionPatterns],
     folderPatterns: [...folderPatterns],
     notePatterns: [...notePatterns],
+    propertyPatterns: [...propertyPatterns],
   });
   const next: ProjectConfig = {
     ...project,

--- a/src/components/modals/CustomPatternInputModal.tsx
+++ b/src/components/modals/CustomPatternInputModal.tsx
@@ -25,9 +25,8 @@ function CustomPatternInputModalContent({
     <div className="tw-flex tw-flex-col tw-gap-4">
       <div className="tw-flex tw-flex-col tw-gap-4">
         <div>
-          Comma separated list of paths, tags, note titles, file extensions or frontmatter
-          properties e.g. folder1, folder1/folder2, #tag1, #tag2, [[note1]], [[note2]], *.jpg,
-          *.excallidraw.md, [Topics:Physics], [Subject:]
+          Comma separated list of paths, tags, note titles or file extension e.g. folder1,
+          folder1/folder2, #tag1, #tag2, [[note1]], [[note2]], *.jpg, *.excallidraw.md
         </div>
         <Input
           placeholder="Enter the pattern"

--- a/src/components/modals/CustomPatternInputModal.tsx
+++ b/src/components/modals/CustomPatternInputModal.tsx
@@ -25,8 +25,9 @@ function CustomPatternInputModalContent({
     <div className="tw-flex tw-flex-col tw-gap-4">
       <div className="tw-flex tw-flex-col tw-gap-4">
         <div>
-          Comma separated list of paths, tags, note titles or file extension e.g. folder1,
-          folder1/folder2, #tag1, #tag2, [[note1]], [[note2]], *.jpg, *.excallidraw.md
+          Comma separated list of paths, tags, note titles, file extensions or frontmatter
+          properties e.g. folder1, folder1/folder2, #tag1, #tag2, [[note1]], [[note2]], *.jpg,
+          *.excallidraw.md, [Topics:Physics], [Subject:]
         </div>
         <Input
           placeholder="Enter the pattern"

--- a/src/components/modals/PropertySearchModal.test.ts
+++ b/src/components/modals/PropertySearchModal.test.ts
@@ -1,0 +1,200 @@
+import { PropertySearchModal, PropertyValueModal } from "@/components/modals/PropertySearchModal";
+import { App, TFile } from "obsidian";
+
+interface FakeNote {
+  path: string;
+  frontmatter?: Record<string, unknown>;
+}
+
+/** Build a minimal App exposing only the vault + metadataCache surface the two
+ * property modals read: markdown files and each file's frontmatter cache. The
+ * modals treat a file as an opaque handle (they only read `.path`), so plain
+ * path stubs stand in for real TFile instances. */
+function makeApp(notes: FakeNote[]): App {
+  const files = notes.map((n) => ({ path: n.path }));
+  const frontmatterByPath = new Map(notes.map((n) => [n.path, n.frontmatter]));
+  return {
+    vault: {
+      getMarkdownFiles: () => files,
+    },
+    metadataCache: {
+      getFileCache: (file: TFile) => {
+        const frontmatter = frontmatterByPath.get(file.path);
+        return frontmatter ? { frontmatter } : null;
+      },
+    },
+  } as unknown as App;
+}
+
+describe("PropertySearchModal", () => {
+  describe("PropertySearchModal", () => {
+    describe("getItems()", () => {
+      it("returns the vault's distinct frontmatter keys, sorted", () => {
+        const app = makeApp([
+          { path: "a.md", frontmatter: { Topics: "Physics", Subject: "Einstein" } },
+          { path: "b.md", frontmatter: { Topics: "Chemistry" } },
+          { path: "c.md" }, // no frontmatter — contributes nothing
+        ]);
+        const modal = new PropertySearchModal(app, jest.fn());
+
+        expect(modal.getItems()).toEqual(["Subject", "Topics"]);
+      });
+
+      it("excludes Obsidian's injected `position` frontmatter key", () => {
+        // Obsidian's metadata cache adds a `position` key to every frontmatter
+        // object; it must not appear as a selectable property.
+        const app = makeApp([
+          { path: "a.md", frontmatter: { position: { start: 0 }, Topics: "Physics" } },
+        ]);
+        const modal = new PropertySearchModal(app, jest.fn());
+        expect(modal.getItems()).toEqual(["Topics"]);
+      });
+
+      it("omits keys the [key:value] grammar cannot represent (colon/brackets)", () => {
+        // A frontmatter key containing ":" would be misparsed by the pattern
+        // grammar, so it must not be offered for selection.
+        const app = makeApp([
+          { path: "a.md", frontmatter: { "a:b": "x", Topics: "Physics", "c[d]": "y" } },
+        ]);
+        const modal = new PropertySearchModal(app, jest.fn());
+        expect(modal.getItems()).toEqual(["Topics"]);
+      });
+
+      it("omits keys with leading or trailing whitespace", () => {
+        // parsePropertyPattern trims the key, so " Topics " would be stored as
+        // "Topics" and never match; such keys must not be offered.
+        const app = makeApp([{ path: "a.md", frontmatter: { " Topics ": "x", Subject: "y" } }]);
+        const modal = new PropertySearchModal(app, jest.fn());
+        expect(modal.getItems()).toEqual(["Subject"]);
+      });
+
+      it("omits an empty-string key", () => {
+        // `"": Physics` is valid YAML, but `[:Physics]` has no key segment and
+        // would be reclassified as a folder pattern, so it must not be offered.
+        const app = makeApp([{ path: "a.md", frontmatter: { "": "Physics", Subject: "y" } }]);
+        const modal = new PropertySearchModal(app, jest.fn());
+        expect(modal.getItems()).toEqual(["Subject"]);
+      });
+
+      it("omits keys that only exist under a system Copilot root", () => {
+        // Saved chats live in the Copilot root and carry their own frontmatter, but
+        // `shouldIndexFile` drops them, so a key sourced only from there would be
+        // selectable while matching no note. Both picker steps enumerate the same
+        // candidate set as the materializer.
+        const app = makeApp([
+          { path: "Notes/a.md", frontmatter: { Topics: "Physics" } },
+          { path: "copilot/copilot-conversations/chat.md", frontmatter: { mode: "agent" } },
+        ]);
+        const modal = new PropertySearchModal(app, jest.fn());
+        expect(modal.getItems()).toEqual(["Topics"]);
+      });
+
+      it("returns an empty list when no note has frontmatter", () => {
+        const modal = new PropertySearchModal(makeApp([{ path: "a.md" }]), jest.fn());
+        expect(modal.getItems()).toEqual([]);
+      });
+    });
+
+    describe("getItemText()", () => {
+      it("shows the key verbatim", () => {
+        const modal = new PropertySearchModal(makeApp([]), jest.fn());
+        expect(modal.getItemText("Topics")).toBe("Topics");
+      });
+    });
+
+    describe("onChooseItem()", () => {
+      it("defers to the value step without emitting a pattern yet", () => {
+        const onChoose = jest.fn();
+        const app = makeApp([{ path: "a.md", frontmatter: { Topics: "Physics" } }]);
+        const modal = new PropertySearchModal(app, onChoose);
+
+        modal.onChooseItem("Topics");
+
+        // Choosing a key opens the value picker; the pattern is only built once a
+        // value (or "any value") is chosen there.
+        expect(onChoose).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("PropertyValueModal", () => {
+    describe("getItems()", () => {
+      it("leads with the any-value choice, then the key's distinct sorted values", () => {
+        const app = makeApp([
+          { path: "a.md", frontmatter: { Topics: "Physics" } },
+          { path: "b.md", frontmatter: { Topics: ["Chemistry", "Physics"] } }, // list expands, dedupes
+        ]);
+        const modal = new PropertyValueModal(app, "Topics", jest.fn());
+
+        expect(modal.getItems()).toEqual([null, "Chemistry", "Physics"]);
+      });
+
+      it("omits values that cannot round-trip through the [key:value] grammar", () => {
+        const app = makeApp([
+          { path: "a.md", frontmatter: { Topics: "Physics" } },
+          { path: "empty.md", frontmatter: { Topics: "" } }, // trims to "" → would flip to key-only [Topics:]
+          { path: "blank.md", frontmatter: { Topics: "   " } }, // whitespace-only, trims to ""
+          { path: "multi.md", frontmatter: { Topics: "line one\nline two" } }, // internal newline → folder fallthrough
+          { path: "ls.md", frontmatter: { Topics: "a\u2028b" } }, // U+2028 line separator, also unmatched by regex `.`
+        ]);
+        const modal = new PropertyValueModal(app, "Topics", jest.fn());
+
+        expect(modal.getItems()).toEqual([null, "Physics"]);
+      });
+
+      it("trims surrounding whitespace so a padded value round-trips as its matcher form", () => {
+        // The matcher trims both sides, so a block scalar's trailing newline (or
+        // any surrounding whitespace) must not hide an otherwise-selectable value;
+        // it is normalized and deduped against the same value elsewhere.
+        const app = makeApp([
+          { path: "a.md", frontmatter: { Topics: "Physics\n" } }, // YAML block scalar trailing newline
+          { path: "b.md", frontmatter: { Topics: "  Physics  " } },
+          { path: "c.md", frontmatter: { Topics: "Chemistry" } },
+        ]);
+        const modal = new PropertyValueModal(app, "Topics", jest.fn());
+
+        expect(modal.getItems()).toEqual([null, "Chemistry", "Physics"]);
+      });
+      it("omits values that only exist under a system Copilot root", () => {
+        // The value step must use the same candidate set as the key step and the
+        // materializer; otherwise a chat-only value would be offered and then match
+        // nothing once the materializer filters that note out.
+        const app = makeApp([
+          { path: "Notes/a.md", frontmatter: { Topics: "Physics" } },
+          { path: "copilot/copilot-conversations/chat.md", frontmatter: { Topics: "ChatOnly" } },
+        ]);
+        const modal = new PropertyValueModal(app, "Topics", jest.fn());
+
+        expect(modal.getItems()).toEqual([null, "Physics"]);
+      });
+    });
+
+    describe("getItemText()", () => {
+      it("labels the any-value choice and shows a real value verbatim", () => {
+        const modal = new PropertyValueModal(makeApp([]), "Topics", jest.fn());
+        expect(modal.getItemText(null)).toBe("(any value)");
+        expect(modal.getItemText("Physics")).toBe("Physics");
+      });
+    });
+
+    describe("onChooseItem()", () => {
+      it("emits a key:value pattern for a chosen value", () => {
+        const onChoose = jest.fn();
+        const modal = new PropertyValueModal(makeApp([]), "Topics", onChoose);
+
+        modal.onChooseItem("Physics");
+
+        expect(onChoose).toHaveBeenCalledWith("[Topics:Physics]");
+      });
+
+      it("emits a key-only pattern for the any-value choice", () => {
+        const onChoose = jest.fn();
+        const modal = new PropertyValueModal(makeApp([]), "Topics", onChoose);
+
+        modal.onChooseItem(null);
+
+        expect(onChoose).toHaveBeenCalledWith("[Topics:]");
+      });
+    });
+  });
+});

--- a/src/components/modals/PropertySearchModal.test.ts
+++ b/src/components/modals/PropertySearchModal.test.ts
@@ -172,8 +172,18 @@ describe("PropertySearchModal", () => {
     describe("getItemText()", () => {
       it("labels the any-value choice and shows a real value verbatim", () => {
         const modal = new PropertyValueModal(makeApp([]), "Topics", jest.fn());
-        expect(modal.getItemText(null)).toBe("(any value)");
+        expect(modal.getItemText(null)).toBe("Any value — notes that declare this key");
         expect(modal.getItemText("Physics")).toBe("Physics");
+      });
+
+      it("keeps the any-value label distinct from a note whose value is literally that text", () => {
+        // Both entries are offered together, and they build very different patterns
+        // ([Topics:] vs [Topics:(any value)]), so their labels must never coincide.
+        const app = makeApp([{ path: "Notes/a.md", frontmatter: { Topics: "(any value)" } }]);
+        const modal = new PropertyValueModal(app, "Topics", jest.fn());
+
+        expect(modal.getItems()).toEqual([null, "(any value)"]);
+        expect(modal.getItemText("(any value)")).not.toBe(modal.getItemText(null));
       });
     });
 

--- a/src/components/modals/PropertySearchModal.tsx
+++ b/src/components/modals/PropertySearchModal.tsx
@@ -87,15 +87,15 @@ function collectPropertyValues(app: App, key: string): string[] {
   return Array.from(values).sort((a, b) => a.localeCompare(b));
 }
 
-/** A value choice in step two. `null` is the "(any value)" option → key-only pattern. */
+/** A value choice in step two. `null` is the any-value option → key-only pattern. */
 type PropertyValueChoice = string | null;
 
 /**
  * Step two of {@link PropertySearchModal}: pick a value for the already-chosen
- * key, or "(any value)" to match any note that has the key. Opened as a fresh
- * modal by the key picker so its input and placeholder reset cleanly. Exported
- * so the value step's item list and pattern building can be tested in isolation
- * from the key step that normally precedes it.
+ * key, or the any-value option to match any note that has the key. Opened as a
+ * fresh modal by the key picker so its input and placeholder reset cleanly.
+ * Exported so the value step's item list and pattern building can be tested in
+ * isolation from the key step that normally precedes it.
  */
 export class PropertyValueModal extends FuzzySuggestModal<PropertyValueChoice> {
   constructor(
@@ -113,7 +113,10 @@ export class PropertyValueModal extends FuzzySuggestModal<PropertyValueChoice> {
   }
 
   getItemText(choice: PropertyValueChoice): string {
-    return choice === null ? "(any value)" : choice;
+    // Reason: the sentinel's label must not collide with a real value. A note whose
+    // frontmatter literally holds "(any value)" would otherwise render an entry
+    // identical to this option while producing the far narrower `[key:(any value)]`.
+    return choice === null ? "Any value — notes that declare this key" : choice;
   }
 
   onChooseItem(choice: PropertyValueChoice): void {
@@ -124,7 +127,7 @@ export class PropertyValueModal extends FuzzySuggestModal<PropertyValueChoice> {
 /**
  * Two-step picker for the Project "Property" (frontmatter) context source. Step
  * one lists every frontmatter key in the vault; choosing one opens a second
- * picker of that key's values (plus an "(any value)" option that yields the
+ * picker of that key's values (plus an any-value option that yields the
  * key-only pattern). Both steps select from real vault data — never free-typed —
  * so the resulting `[key:value]` pattern always matches at least the note it came
  * from. The finished pattern is delivered through the `onChoose` callback.

--- a/src/components/modals/PropertySearchModal.tsx
+++ b/src/components/modals/PropertySearchModal.tsx
@@ -1,0 +1,155 @@
+import { getPropertyPattern, shouldIndexFile } from "@/search/searchUtils";
+import { getPropertyValuesFromNote } from "@/utils";
+import { App, FuzzySuggestModal, TFile } from "obsidian";
+
+/**
+ * Whether a frontmatter key can be offered in the property picker. Excluded
+ * because selecting them would misbehave:
+ * - empty key: `"": value` is valid YAML, but `[:value]` has no key segment
+ *   (the grammar requires one), so it would be reclassified as a folder and
+ *   never match.
+ * - `position`: Obsidian's FrontMatterCache extends CacheItem, so every
+ *   frontmatter object carries a `position` key holding the block's parse
+ *   location — parser metadata, not a user property.
+ * - keys containing ":", "[" or "]": the `[key:value]` pattern grammar splits on
+ *   the first ":" and forbids brackets in the key, so such a key (valid but rare
+ *   YAML, e.g. "a:b") would be silently misparsed into the wrong key. Omitting it
+ *   is safer than offering it and then never matching the note it came from.
+ */
+function isSelectablePropertyKey(key: string): boolean {
+  // key === key.trim(): parsePropertyPattern trims the key, so a key with leading
+  // or trailing whitespace would be stored trimmed and then never match the note.
+  return key.length > 0 && key !== "position" && key === key.trim() && !/[:[\]]/.test(key);
+}
+
+/**
+ * The notes a property pattern can ever match. Both picker steps enumerate from
+ * this set so the offered keys and values agree with what the materializer will
+ * later resolve: it filters candidates through the same {@link shouldIndexFile}
+ * contract, which drops Copilot's own roots (active and historical) and internal
+ * files. Scanning every markdown file instead would offer frontmatter that only
+ * exists in, say, a saved chat — a selectable source that then matches no note.
+ */
+function selectablePropertyNotes(app: App): TFile[] {
+  return app.vault.getMarkdownFiles().filter((file) => shouldIndexFile(app, file, null, null));
+}
+
+/**
+ * Collect every distinct, selectable frontmatter property key across the vault's
+ * markdown notes, sorted. Enumerating real keys (instead of letting the user type
+ * one) is what makes the property source dependable: a mistyped key silently
+ * matches nothing, which is the failure mode this source exists to avoid.
+ */
+function collectPropertyKeys(app: App): string[] {
+  const keys = new Set<string>();
+  for (const file of selectablePropertyNotes(app)) {
+    const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+    if (frontmatter) {
+      Object.keys(frontmatter).forEach((key) => {
+        if (isSelectablePropertyKey(key)) keys.add(key);
+      });
+    }
+  }
+  return Array.from(keys).sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Whether a trimmed property value can be offered in the value picker. The input
+ * is already normalized with `trim()` to mirror how the matcher compares values
+ * ({@link matchFilePathWithProperties} trims both sides), so what the picker
+ * offers is exactly what will match. Two kinds are still rejected because they
+ * cannot round-trip through the `[key:value]` grammar:
+ * - empty (after trim): `getPropertyPattern(key, "")` yields the key-only `[key:]`
+ *   form, so offering it would silently flip "equals this value" into "matches any
+ *   value".
+ * - containing a line terminator: the grammar is single-line (its regex `.`
+ *   matches none of \r \n \u2028 \u2029), so such a value would be reclassified as
+ *   a folder pattern and match nothing.
+ */
+function isRepresentablePropertyValue(trimmedValue: string): boolean {
+  return trimmedValue.length > 0 && !/[\r\n\u2028\u2029]/.test(trimmedValue);
+}
+
+/**
+ * Collect the distinct values a given key takes across the vault, sorted. List
+ * (array) properties contribute each element, via {@link getPropertyValuesFromNote}.
+ * Values are trimmed to match the matcher's comparison, so e.g. a YAML block
+ * scalar's trailing newline never hides an otherwise-selectable value.
+ */
+function collectPropertyValues(app: App, key: string): string[] {
+  const values = new Set<string>();
+  for (const file of selectablePropertyNotes(app)) {
+    getPropertyValuesFromNote(app, file, key).forEach((value) => {
+      const normalized = value.trim();
+      if (isRepresentablePropertyValue(normalized)) values.add(normalized);
+    });
+  }
+  return Array.from(values).sort((a, b) => a.localeCompare(b));
+}
+
+/** A value choice in step two. `null` is the "(any value)" option → key-only pattern. */
+type PropertyValueChoice = string | null;
+
+/**
+ * Step two of {@link PropertySearchModal}: pick a value for the already-chosen
+ * key, or "(any value)" to match any note that has the key. Opened as a fresh
+ * modal by the key picker so its input and placeholder reset cleanly. Exported
+ * so the value step's item list and pattern building can be tested in isolation
+ * from the key step that normally precedes it.
+ */
+export class PropertyValueModal extends FuzzySuggestModal<PropertyValueChoice> {
+  constructor(
+    app: App,
+    private readonly key: string,
+    private readonly onChoose: (pattern: string) => void
+  ) {
+    super(app);
+    this.setPlaceholder(`Select a value for "${key}"`);
+  }
+
+  getItems(): PropertyValueChoice[] {
+    // Reason: lead with the any-value option so key-only inclusion is one keystroke away.
+    return [null, ...collectPropertyValues(this.app, this.key)];
+  }
+
+  getItemText(choice: PropertyValueChoice): string {
+    return choice === null ? "(any value)" : choice;
+  }
+
+  onChooseItem(choice: PropertyValueChoice): void {
+    this.onChoose(getPropertyPattern(this.key, choice ?? undefined));
+  }
+}
+
+/**
+ * Two-step picker for the Project "Property" (frontmatter) context source. Step
+ * one lists every frontmatter key in the vault; choosing one opens a second
+ * picker of that key's values (plus an "(any value)" option that yields the
+ * key-only pattern). Both steps select from real vault data — never free-typed —
+ * so the resulting `[key:value]` pattern always matches at least the note it came
+ * from. The finished pattern is delivered through the `onChoose` callback.
+ */
+export class PropertySearchModal extends FuzzySuggestModal<string> {
+  constructor(
+    app: App,
+    private readonly onChoose: (pattern: string) => void
+  ) {
+    super(app);
+    this.setPlaceholder("Select a property key");
+  }
+
+  getItems(): string[] {
+    return collectPropertyKeys(this.app);
+  }
+
+  getItemText(key: string): string {
+    return key;
+  }
+
+  onChooseItem(key: string): void {
+    // Chain to the value step in a fresh modal — this one closes as the value
+    // picker opens, sidestepping the re-open ordering hazard of a single
+    // stateful modal (Obsidian closes the modal right after onChooseItem).
+    new PropertyValueModal(this.app, key, this.onChoose).open();
+  }
+}

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -10,7 +10,9 @@ import {
 import { useAgentProcessingItems } from "@/components/project/useAgentProcessingItems";
 import { openAgentCachedItemPreview, openCachedProjectFile } from "@/utils/cacheFileOpener";
 import { ProjectFileSelectModal } from "@/components/modals/ProjectFileSelectModal";
+import { PropertySearchModal } from "@/components/modals/PropertySearchModal";
 import { TagSearchModal } from "@/components/modals/TagSearchModal";
+import { getBadgeLabel } from "@/components/project/ProjectContextBadgeList";
 import { TruncatedText } from "@/components/TruncatedText";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -40,6 +42,7 @@ import {
   Loader2,
   Plus,
   PlusCircle,
+  SlidersHorizontal,
   TagIcon,
   XIcon,
 } from "lucide-react";
@@ -79,6 +82,7 @@ type ActiveSection =
   | "folders"
   | "files"
   | "extensions"
+  | "properties"
   | "ignoreFiles"
   | "search"
   | "links"
@@ -434,6 +438,10 @@ function CategoryItemCard({
       IconComponent = TagIcon;
       iconColorClassName = "tw-text-context-manager-orange";
       break;
+    case "property":
+      IconComponent = SlidersHorizontal;
+      iconColorClassName = "tw-text-context-manager-purple";
+      break;
     case "folder":
       IconComponent = FolderIcon;
       iconColorClassName = "tw-text-context-manager-yellow";
@@ -498,6 +506,7 @@ interface GroupListItem {
   tags: Record<string, Array<GroupItem>>;
   folders: Record<string, Array<GroupItem>>;
   extensions: Record<string, Array<GroupItem>>;
+  properties: Record<string, Array<GroupItem>>;
   notes: Array<GroupItem>;
 }
 
@@ -508,7 +517,7 @@ interface IgnoreItems {
 interface CategoryItem {
   id: string;
   name: string;
-  type: "tag" | "folder" | "files" | "ignoreFiles" | "web" | "youtube";
+  type: "tag" | "folder" | "files" | "property" | "ignoreFiles" | "web" | "youtube";
   originalId?: string;
   count: number;
 }
@@ -632,7 +641,7 @@ function ContextManage({
       const processPatternGroup = (
         file: TFile,
         patterns: string[] | undefined,
-        patternType: "tagPatterns" | "folderPatterns" | "extensionPatterns",
+        patternType: "tagPatterns" | "folderPatterns" | "extensionPatterns" | "propertyPatterns",
         targetGroup: Record<string, Array<GroupItem>>
       ) => {
         if (patterns) {
@@ -655,6 +664,7 @@ function ContextManage({
       const tags: Record<string, Array<GroupItem>> = {};
       const folders: Record<string, Array<GroupItem>> = {};
       const extensions: Record<string, Array<GroupItem>> = {};
+      const properties: Record<string, Array<GroupItem>> = {};
       const notes: Array<GroupItem> = [];
 
       (inclusionPatterns?.tagPatterns ?? []).forEach((tag) => {
@@ -665,6 +675,9 @@ function ContextManage({
       });
       (inclusionPatterns?.extensionPatterns ?? []).forEach((extension) => {
         extensions[extension] = [];
+      });
+      (inclusionPatterns?.propertyPatterns ?? []).forEach((property) => {
+        properties[property] = [];
       });
 
       // Traverse the files and populate them into corresponding groups
@@ -681,6 +694,14 @@ function ContextManage({
           inclusionPatterns?.extensionPatterns,
           "extensionPatterns",
           extensions
+        );
+
+        // property
+        processPatternGroup(
+          file,
+          inclusionPatterns?.propertyPatterns,
+          "propertyPatterns",
+          properties
         );
 
         // note/file
@@ -706,6 +727,7 @@ function ContextManage({
         tags,
         folders,
         extensions,
+        properties,
         notes,
       };
     },
@@ -774,6 +796,7 @@ function ContextManage({
       const tagPatterns = Object.keys(list.tags);
       const folderPatterns = Object.keys(list.folders);
       const extensionPatterns = Object.keys(list.extensions);
+      const propertyPatterns = Object.keys(list.properties);
       const notePatterns = list.notes
         .map((note) => {
           const file = app.vault.getAbstractFileByPath(note.id);
@@ -787,6 +810,7 @@ function ContextManage({
         tagPatterns,
         folderPatterns,
         extensionPatterns,
+        propertyPatterns,
         notePatterns,
       });
     },
@@ -826,6 +850,7 @@ function ContextManage({
       groupList.tags,
       groupList.folders,
       groupList.extensions,
+      groupList.properties,
       { notes: groupList.notes },
     ];
 
@@ -975,6 +1000,27 @@ function ContextManage({
       return [];
     }
 
+    if (activeSection === "properties" && activeItem) {
+      const propertyFiles = groupList.properties[activeItem];
+      if (propertyFiles) {
+        return propertyFiles;
+      }
+      return [];
+    }
+
+    // Clicking the Properties header (agent Links variant) lists every property.
+    if (activeSection === "properties") {
+      return sortItems(
+        Object.entries(groupList.properties).map(([propertyId, files]) => ({
+          id: `property:${propertyId}`,
+          name: getBadgeLabel({ pattern: propertyId, type: "property" }),
+          type: "property",
+          originalId: propertyId,
+          count: files.length,
+        }))
+      );
+    }
+
     if (activeSection === "ignoreFiles") {
       return Array.from(ignoreItems.files).map((file) => ({
         id: file.path,
@@ -1000,6 +1046,16 @@ function ContextManage({
           name: folderId,
           type: "folder",
           originalId: folderId,
+          count: files.length,
+        }))
+      );
+
+      const propertyItems = sortItems(
+        Object.entries(groupList.properties).map(([propertyId, files]) => ({
+          id: `property:${propertyId}`,
+          name: getBadgeLabel({ pattern: propertyId, type: "property" }),
+          type: "property",
+          originalId: propertyId,
           count: files.length,
         }))
       );
@@ -1045,7 +1101,14 @@ function ContextManage({
           : []),
       ];
 
-      return [...linkItems, ...tagItems, ...folderItems, ...filesItem, ...ignoreFilesItem];
+      return [
+        ...linkItems,
+        ...tagItems,
+        ...propertyItems,
+        ...folderItems,
+        ...filesItem,
+        ...ignoreFilesItem,
+      ];
     }
 
     return [];
@@ -1060,6 +1123,7 @@ function ContextManage({
     groupList.folders,
     groupList.notes,
     groupList.extensions,
+    groupList.properties,
     ignoreItems.files,
     sortItems,
     enableLinks,
@@ -1084,7 +1148,7 @@ function ContextManage({
 
   const addPatternToGroup = useCallback(
     (
-      groupType: "tags" | "folders" | "extensions",
+      groupType: "tags" | "folders" | "extensions" | "properties",
       pattern: string,
       patternConfig: PatternCategory
     ) => {
@@ -1121,6 +1185,7 @@ function ContextManage({
         tags: { ...groupList.tags },
         folders: { ...groupList.folders },
         extensions: { ...groupList.extensions },
+        properties: { ...groupList.properties },
         notes: [...groupList.notes],
       };
 
@@ -1133,6 +1198,7 @@ function ContextManage({
       removeFileFromGroupObject(newGroupList.tags);
       removeFileFromGroupObject(newGroupList.folders);
       removeFileFromGroupObject(newGroupList.extensions);
+      removeFileFromGroupObject(newGroupList.properties);
 
       // Remove file from notes
       newGroupList.notes = newGroupList.notes.filter((item) => item.id !== filePath);
@@ -1175,6 +1241,7 @@ function ContextManage({
         tag: createDeleteHandler("tags"),
         folder: createDeleteHandler("folders"),
         extension: createDeleteHandler("extensions"),
+        property: createDeleteHandler("properties"),
       },
 
       add: {
@@ -1182,6 +1249,16 @@ function ContextManage({
           new TagSearchModal(app, (tagName) => {
             const tagPattern = getTagPattern(tagName);
             addPatternToGroup("tags", tagPattern, { tagPatterns: [tagPattern] });
+          }).open();
+        },
+
+        property: () => {
+          // The modal builds the `[key:value]` pattern from real vault data; add it
+          // straight to the group keyed by that pattern (mirrors the tag flow).
+          new PropertySearchModal(app, (propertyPattern) => {
+            addPatternToGroup("properties", propertyPattern, {
+              propertyPatterns: [propertyPattern],
+            });
           }).open();
         },
 
@@ -1255,6 +1332,10 @@ function ContextManage({
           setActiveState("tags", tagId);
         },
 
+        property: (propertyId: string) => {
+          setActiveState("properties", propertyId);
+        },
+
         folder: (folderId: string) => {
           setActiveState("folders", folderId);
         },
@@ -1285,6 +1366,8 @@ function ContextManage({
     (item: CategoryItem) => {
       if (item.type === "tag" && item.originalId) {
         groupHandlers.click.tag(item.originalId);
+      } else if (item.type === "property" && item.originalId) {
+        groupHandlers.click.property(item.originalId);
       } else if (item.type === "folder" && item.originalId) {
         groupHandlers.click.folder(item.originalId);
       } else if (item.type === "files") {
@@ -1307,6 +1390,10 @@ function ContextManage({
       return `Tag: ${activeItem}`;
     }
     if (activeSection === "tags") return "Tags";
+    if (activeSection === "properties" && activeItem) {
+      return `Property: ${getBadgeLabel({ pattern: activeItem, type: "property" })}`;
+    }
+    if (activeSection === "properties") return "Properties";
     if (activeSection === "folders" && activeItem) {
       return `Folder: ${activeItem}`;
     }
@@ -1323,7 +1410,9 @@ function ContextManage({
   // entries on the right. Those are CategoryItems, so the right pane must use the
   // category-card branch (not the file ItemCard branch) for these states.
   const showingCategoryItems =
-    !searchTerm && !activeItem && (activeSection === "tags" || activeSection === "folders");
+    !searchTerm &&
+    !activeItem &&
+    (activeSection === "tags" || activeSection === "folders" || activeSection === "properties");
 
   const handleDeleteItem = (e: React.MouseEvent, item: GroupItem) => {
     e.stopPropagation();
@@ -1442,6 +1531,29 @@ function ContextManage({
                   onDeleteItem={(e, item) => groupHandlers.delete.tag(e, item)}
                   tooltip="must be in note property"
                   onSectionClick={enableLinks ? () => setActiveState("tags", null) : undefined}
+                />
+
+                <Separator />
+
+                {/* Properties Section — includes notes by a frontmatter property
+                    (e.g. Topics: Physics), the taxonomy some vaults use instead of tags. */}
+                <SectionList
+                  title="Properties"
+                  IconComponent={SlidersHorizontal}
+                  iconColorClassName="tw-text-context-manager-purple"
+                  items={makeSectionItem(groupList.properties, (pattern) =>
+                    getBadgeLabel({ pattern, type: "property" })
+                  )}
+                  activeItem={activeItem}
+                  activeSection={activeSection}
+                  sectionType="properties"
+                  onItemClick={groupHandlers.click.property}
+                  onAddClick={groupHandlers.add.property}
+                  onDeleteItem={(e, item) => groupHandlers.delete.property(e, item)}
+                  tooltip="Include notes by a frontmatter property, e.g. Topics: Physics"
+                  onSectionClick={
+                    enableLinks ? () => setActiveState("properties", null) : undefined
+                  }
                 />
 
                 <Separator />

--- a/src/components/modals/project/context-manage-modal.tsx
+++ b/src/components/modals/project/context-manage-modal.tsx
@@ -423,6 +423,18 @@ function ItemCard({
   );
 }
 
+/**
+ * DESIGN NOTE — this modal's property visual states (the icon below, the
+ * Properties section, its value rows) have no component-gallery story, unlike
+ * the sibling editors ProjectContextBadgeList and ProjectContextSourceEditor.
+ * A story can only mount an exported component, and this file exports just the
+ * Obsidian `Modal` subclass; every React part here is module-private. Covering
+ * it would mean exporting `ContextManage` solely so the gallery can reach it,
+ * which no story in this repo does — the widened production surface costs more
+ * than the coverage buys, since the property icon and hue are identical to the
+ * two components that are covered. If a future review flags this again, point
+ * them at this note.
+ */
 function CategoryItemCard({
   item,
   onClick,

--- a/src/components/project/ProjectContextBadgeList.stories.tsx
+++ b/src/components/project/ProjectContextBadgeList.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import * as React from "react";
+import { ProjectContextBadgeList } from "./ProjectContextBadgeList";
+
+type Props = React.ComponentProps<typeof ProjectContextBadgeList>;
+
+/**
+ * Patterns are persisted URL-encoded and comma-joined, so fixtures encode the
+ * same way the settings value does rather than passing raw bracket syntax.
+ */
+const patterns = (...raw: string[]) => raw.map(encodeURIComponent).join(",");
+
+const meta = {
+  title: "Project/Context Badge List",
+  component: ProjectContextBadgeList,
+  parameters: { gallery: { host: "modal", layout: "padded" } },
+} satisfies Meta<Props>;
+export default meta;
+
+/** All five source types together — the only place their icons and hues are compared. */
+export const AllSourceTypes: StoryObj<Props> = {
+  args: {
+    inclusions: patterns(
+      "notes/research",
+      "#machine-learning",
+      "[[Project Brief]]",
+      "*.pdf",
+      "[Topics:Physics]"
+    ),
+  },
+};
+
+/**
+ * The two property label shapes. Unlike the other four types, a property badge
+ * renders a *transformed* label, so both forms need to be legible as such.
+ */
+export const PropertyLabelForms: StoryObj<Props> = {
+  args: {
+    inclusions: patterns("[Topics:Physics]", "[Subject:]", "[Status:In Progress]"),
+  },
+};
+
+/** A property value long enough to hit the badge's truncation boundary. */
+export const LongPropertyValue: StoryObj<Props> = {
+  args: {
+    inclusions: patterns("[Subject:Quantum Mechanics and General Relativity]", "[Topics:Physics]"),
+  },
+};
+
+/** Exclusions render dimmed beside inclusions of the same types. */
+export const WithExclusions: StoryObj<Props> = {
+  args: {
+    inclusions: patterns("notes/research", "[Topics:Physics]"),
+    exclusions: patterns("notes/archive", "[Status:Draft]"),
+  },
+};
+
+/** Passing the change handlers turns every badge into a removable chip. */
+export const Removable: StoryObj<Props> = {
+  args: {
+    inclusions: patterns("notes/research", "#machine-learning", "[Topics:Physics]", "*.pdf"),
+    exclusions: patterns("[Status:Draft]"),
+    onInclusionsChange: () => {},
+    onExclusionsChange: () => {},
+  },
+};
+
+/** Enough sources to exceed the collapsed height and expose the expand control. */
+export const Overflowing: StoryObj<Props> = {
+  args: {
+    maxCollapsedHeight: 64,
+    inclusions: patterns(
+      "notes/research",
+      "notes/archive",
+      "notes/daily",
+      "#machine-learning",
+      "#physics",
+      "[[Project Brief]]",
+      "[[Reading List]]",
+      "*.pdf",
+      "*.docx",
+      "[Topics:Physics]",
+      "[Topics:Chemistry]",
+      "[Subject:]"
+    ),
+  },
+};
+
+/** No sources configured — the empty state the editor shows before any pick. */
+export const Empty: StoryObj<Props> = {
+  args: { inclusions: "", exclusions: "" },
+};

--- a/src/components/project/ProjectContextBadgeList.test.ts
+++ b/src/components/project/ProjectContextBadgeList.test.ts
@@ -1,123 +1,126 @@
 import { buildBadgeItems, getBadgeLabel, removePattern } from "./ProjectContextBadgeList";
 
-describe("buildBadgeItems", () => {
-  it("returns empty array for empty/undefined input", () => {
-    expect(buildBadgeItems("")).toEqual([]);
-    expect(buildBadgeItems(undefined)).toEqual([]);
+describe("ProjectContextBadgeList", () => {
+  describe("buildBadgeItems()", () => {
+    it("returns empty array for empty/undefined input", () => {
+      expect(buildBadgeItems("")).toEqual([]);
+      expect(buildBadgeItems(undefined)).toEqual([]);
+    });
+
+    it("categorizes patterns by type", () => {
+      // Encoded: folder, #tag, [[note]], *.pdf, [Topics:Physics], [Topics:]
+      const value =
+        "my-folder,%23tag,%5B%5Bnote%5D%5D,*.pdf,%5BTopics%3APhysics%5D,%5BTopics%3A%5D";
+      const items = buildBadgeItems(value);
+
+      expect(items).toEqual([
+        { pattern: "my-folder", type: "folder" },
+        { pattern: "#tag", type: "tag" },
+        { pattern: "[[note]]", type: "note" },
+        { pattern: "*.pdf", type: "extension" },
+        { pattern: "[Topics:Physics]", type: "property" },
+        { pattern: "[Topics:]", type: "property" },
+      ]);
+    });
+
+    it("deduplicates patterns", () => {
+      const value = "my-folder,my-folder";
+      const items = buildBadgeItems(value);
+
+      expect(items).toHaveLength(1);
+      expect(items[0]).toEqual({ pattern: "my-folder", type: "folder" });
+    });
+
+    it("handles multiple patterns of the same type", () => {
+      const value = "folder-a,folder-b,%23tag1,%23tag2";
+      const items = buildBadgeItems(value);
+
+      expect(items).toEqual([
+        { pattern: "folder-a", type: "folder" },
+        { pattern: "folder-b", type: "folder" },
+        { pattern: "#tag1", type: "tag" },
+        { pattern: "#tag2", type: "tag" },
+      ]);
+    });
   });
 
-  it("categorizes patterns by type", () => {
-    // Encoded: folder, #tag, [[note]], *.pdf, [Topics:Physics], [Topics:]
-    const value = "my-folder,%23tag,%5B%5Bnote%5D%5D,*.pdf,%5BTopics%3APhysics%5D,%5BTopics%3A%5D";
-    const items = buildBadgeItems(value);
+  describe("removePattern()", () => {
+    it("removes a folder pattern", () => {
+      const value = "folder-a,folder-b,%23tag1";
+      const result = removePattern(value, "folder-a", "folder");
 
-    expect(items).toEqual([
-      { pattern: "my-folder", type: "folder" },
-      { pattern: "#tag", type: "tag" },
-      { pattern: "[[note]]", type: "note" },
-      { pattern: "*.pdf", type: "extension" },
-      { pattern: "[Topics:Physics]", type: "property" },
-      { pattern: "[Topics:]", type: "property" },
-    ]);
+      expect(result).toContain("folder-b");
+      expect(result).toContain("%23tag1");
+      expect(result).not.toContain(encodeURIComponent("folder-a"));
+    });
+
+    it("removes a tag pattern", () => {
+      const value = "%23tag1,%23tag2,my-folder";
+      const result = removePattern(value, "#tag1", "tag");
+
+      expect(result).toContain("%23tag2");
+      expect(result).toContain("my-folder");
+      // Verify #tag1 is gone — check decoded result doesn't include it
+      const remaining = decodeURIComponent(result);
+      expect(remaining).not.toContain("#tag1");
+    });
+
+    it("removes a note pattern", () => {
+      const value = "%5B%5Bnote%5D%5D,my-folder";
+      const result = removePattern(value, "[[note]]", "note");
+
+      expect(result).toContain("my-folder");
+      expect(result).not.toContain("%5B%5Bnote%5D%5D");
+    });
+
+    it("removes an extension pattern", () => {
+      const value = "*.pdf,my-folder";
+      const result = removePattern(value, "*.pdf", "extension");
+
+      expect(result).toContain("my-folder");
+      expect(result).not.toContain("*.pdf");
+    });
+
+    it("removes a property pattern", () => {
+      const value = "%5BTopics%3APhysics%5D,%23tag1";
+      const result = removePattern(value, "[Topics:Physics]", "property");
+
+      expect(result).toContain("%23tag1");
+      expect(decodeURIComponent(result)).not.toContain("[Topics:Physics]");
+    });
+
+    it("returns empty string when removing the last pattern", () => {
+      const value = "my-folder";
+      const result = removePattern(value, "my-folder", "folder");
+
+      expect(result).toBe("");
+    });
+
+    it("handles undefined input", () => {
+      const result = removePattern(undefined, "my-folder", "folder");
+      expect(result).toBe("");
+    });
   });
 
-  it("deduplicates patterns", () => {
-    const value = "my-folder,my-folder";
-    const items = buildBadgeItems(value);
+  describe("getBadgeLabel()", () => {
+    it("renders a property pattern as `key: value`", () => {
+      expect(getBadgeLabel({ pattern: "[Topics:Physics]", type: "property" })).toBe(
+        "Topics: Physics"
+      );
+    });
 
-    expect(items).toHaveLength(1);
-    expect(items[0]).toEqual({ pattern: "my-folder", type: "folder" });
-  });
+    it("renders a key-only property pattern as `key: (any)`", () => {
+      expect(getBadgeLabel({ pattern: "[Topics:]", type: "property" })).toBe("Topics: (any)");
+    });
 
-  it("handles multiple patterns of the same type", () => {
-    const value = "folder-a,folder-b,%23tag1,%23tag2";
-    const items = buildBadgeItems(value);
+    it("returns the raw pattern for non-property types", () => {
+      expect(getBadgeLabel({ pattern: "#tag", type: "tag" })).toBe("#tag");
+      expect(getBadgeLabel({ pattern: "my-folder", type: "folder" })).toBe("my-folder");
+    });
 
-    expect(items).toEqual([
-      { pattern: "folder-a", type: "folder" },
-      { pattern: "folder-b", type: "folder" },
-      { pattern: "#tag1", type: "tag" },
-      { pattern: "#tag2", type: "tag" },
-    ]);
-  });
-});
-
-describe("removePattern", () => {
-  it("removes a folder pattern", () => {
-    const value = "folder-a,folder-b,%23tag1";
-    const result = removePattern(value, "folder-a", "folder");
-
-    expect(result).toContain("folder-b");
-    expect(result).toContain("%23tag1");
-    expect(result).not.toContain(encodeURIComponent("folder-a"));
-  });
-
-  it("removes a tag pattern", () => {
-    const value = "%23tag1,%23tag2,my-folder";
-    const result = removePattern(value, "#tag1", "tag");
-
-    expect(result).toContain("%23tag2");
-    expect(result).toContain("my-folder");
-    // Verify #tag1 is gone — check decoded result doesn't include it
-    const remaining = decodeURIComponent(result);
-    expect(remaining).not.toContain("#tag1");
-  });
-
-  it("removes a note pattern", () => {
-    const value = "%5B%5Bnote%5D%5D,my-folder";
-    const result = removePattern(value, "[[note]]", "note");
-
-    expect(result).toContain("my-folder");
-    expect(result).not.toContain("%5B%5Bnote%5D%5D");
-  });
-
-  it("removes an extension pattern", () => {
-    const value = "*.pdf,my-folder";
-    const result = removePattern(value, "*.pdf", "extension");
-
-    expect(result).toContain("my-folder");
-    expect(result).not.toContain("*.pdf");
-  });
-
-  it("removes a property pattern", () => {
-    const value = "%5BTopics%3APhysics%5D,%23tag1";
-    const result = removePattern(value, "[Topics:Physics]", "property");
-
-    expect(result).toContain("%23tag1");
-    expect(decodeURIComponent(result)).not.toContain("[Topics:Physics]");
-  });
-
-  it("returns empty string when removing the last pattern", () => {
-    const value = "my-folder";
-    const result = removePattern(value, "my-folder", "folder");
-
-    expect(result).toBe("");
-  });
-
-  it("handles undefined input", () => {
-    const result = removePattern(undefined, "my-folder", "folder");
-    expect(result).toBe("");
-  });
-});
-
-describe("getBadgeLabel", () => {
-  it("renders a property pattern as `key: value`", () => {
-    expect(getBadgeLabel({ pattern: "[Topics:Physics]", type: "property" })).toBe(
-      "Topics: Physics"
-    );
-  });
-
-  it("renders a key-only property pattern as `key: (any)`", () => {
-    expect(getBadgeLabel({ pattern: "[Topics:]", type: "property" })).toBe("Topics: (any)");
-  });
-
-  it("returns the raw pattern for non-property types", () => {
-    expect(getBadgeLabel({ pattern: "#tag", type: "tag" })).toBe("#tag");
-    expect(getBadgeLabel({ pattern: "my-folder", type: "folder" })).toBe("my-folder");
-  });
-
-  it("falls back to the raw pattern when a property pattern cannot be parsed", () => {
-    // A malformed pattern that slipped through as `property`: no crash, show it verbatim.
-    expect(getBadgeLabel({ pattern: "not-a-property", type: "property" })).toBe("not-a-property");
+    it("falls back to the raw pattern when a property pattern cannot be parsed", () => {
+      // A malformed pattern that slipped through as `property`: no crash, show it verbatim.
+      expect(getBadgeLabel({ pattern: "not-a-property", type: "property" })).toBe("not-a-property");
+    });
   });
 });

--- a/src/components/project/ProjectContextBadgeList.test.ts
+++ b/src/components/project/ProjectContextBadgeList.test.ts
@@ -1,4 +1,4 @@
-import { buildBadgeItems, removePattern } from "./ProjectContextBadgeList";
+import { buildBadgeItems, getBadgeLabel, removePattern } from "./ProjectContextBadgeList";
 
 describe("buildBadgeItems", () => {
   it("returns empty array for empty/undefined input", () => {
@@ -7,8 +7,8 @@ describe("buildBadgeItems", () => {
   });
 
   it("categorizes patterns by type", () => {
-    // Encoded: folder, #tag, [[note]], *.pdf
-    const value = "my-folder,%23tag,%5B%5Bnote%5D%5D,*.pdf";
+    // Encoded: folder, #tag, [[note]], *.pdf, [Topics:Physics], [Topics:]
+    const value = "my-folder,%23tag,%5B%5Bnote%5D%5D,*.pdf,%5BTopics%3APhysics%5D,%5BTopics%3A%5D";
     const items = buildBadgeItems(value);
 
     expect(items).toEqual([
@@ -16,6 +16,8 @@ describe("buildBadgeItems", () => {
       { pattern: "#tag", type: "tag" },
       { pattern: "[[note]]", type: "note" },
       { pattern: "*.pdf", type: "extension" },
+      { pattern: "[Topics:Physics]", type: "property" },
+      { pattern: "[Topics:]", type: "property" },
     ]);
   });
 
@@ -77,6 +79,14 @@ describe("removePattern", () => {
     expect(result).not.toContain("*.pdf");
   });
 
+  it("removes a property pattern", () => {
+    const value = "%5BTopics%3APhysics%5D,%23tag1";
+    const result = removePattern(value, "[Topics:Physics]", "property");
+
+    expect(result).toContain("%23tag1");
+    expect(decodeURIComponent(result)).not.toContain("[Topics:Physics]");
+  });
+
   it("returns empty string when removing the last pattern", () => {
     const value = "my-folder";
     const result = removePattern(value, "my-folder", "folder");
@@ -87,5 +97,27 @@ describe("removePattern", () => {
   it("handles undefined input", () => {
     const result = removePattern(undefined, "my-folder", "folder");
     expect(result).toBe("");
+  });
+});
+
+describe("getBadgeLabel", () => {
+  it("renders a property pattern as `key: value`", () => {
+    expect(getBadgeLabel({ pattern: "[Topics:Physics]", type: "property" })).toBe(
+      "Topics: Physics"
+    );
+  });
+
+  it("renders a key-only property pattern as `key: (any)`", () => {
+    expect(getBadgeLabel({ pattern: "[Topics:]", type: "property" })).toBe("Topics: (any)");
+  });
+
+  it("returns the raw pattern for non-property types", () => {
+    expect(getBadgeLabel({ pattern: "#tag", type: "tag" })).toBe("#tag");
+    expect(getBadgeLabel({ pattern: "my-folder", type: "folder" })).toBe("my-folder");
+  });
+
+  it("falls back to the raw pattern when a property pattern cannot be parsed", () => {
+    // A malformed pattern that slipped through as `property`: no crash, show it verbatim.
+    expect(getBadgeLabel({ pattern: "not-a-property", type: "property" })).toBe("not-a-property");
   });
 });

--- a/src/components/project/ProjectContextBadgeList.tsx
+++ b/src/components/project/ProjectContextBadgeList.tsx
@@ -1,6 +1,15 @@
 import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
 
-import { ChevronDown, ChevronUp, FileText, Folder, Hash, Tag, X } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronUp,
+  FileText,
+  Folder,
+  Hash,
+  SlidersHorizontal,
+  Tag,
+  X,
+} from "lucide-react";
 
 import { TruncatedText } from "@/components/TruncatedText";
 import { Badge } from "@/components/ui/badge";
@@ -10,6 +19,7 @@ import {
   categorizePatterns,
   createPatternSettingsValue,
   getDecodedPatterns,
+  parsePropertyPattern,
 } from "@/search/searchUtils";
 
 const PATTERN_TYPE_CONFIG = {
@@ -17,23 +27,37 @@ const PATTERN_TYPE_CONFIG = {
   tag: { icon: Tag, colorClass: "tw-text-context-manager-orange" },
   note: { icon: FileText, colorClass: "tw-text-context-manager-blue" },
   extension: { icon: Hash, colorClass: "tw-text-context-manager-green" },
+  property: { icon: SlidersHorizontal, colorClass: "tw-text-context-manager-purple" },
 } as const;
 
 type PatternType = keyof typeof PATTERN_TYPE_CONFIG;
 
 /** Ordered list of pattern types for consistent badge rendering */
-const PATTERN_TYPES: PatternType[] = ["folder", "tag", "note", "extension"];
+const PATTERN_TYPES: PatternType[] = ["folder", "tag", "note", "extension", "property"];
 
 const CATEGORY_MAP = {
   folder: "folderPatterns",
   tag: "tagPatterns",
   note: "notePatterns",
   extension: "extensionPatterns",
+  property: "propertyPatterns",
 } as const;
 
 interface BadgeItem {
   pattern: string;
   type: PatternType;
+}
+
+/**
+ * Display label for a badge/chip. Property patterns render as `key: value` (or
+ * `key: (any)` for the key-only form) so they read like the frontmatter the user
+ * wrote; every other type shows its raw pattern unchanged.
+ */
+export function getBadgeLabel(item: BadgeItem): string {
+  if (item.type !== "property") return item.pattern;
+  const parsed = parsePropertyPattern(item.pattern);
+  if (!parsed) return item.pattern;
+  return parsed.value ? `${parsed.key}: ${parsed.value}` : `${parsed.key}: (any)`;
 }
 
 interface ProjectContextBadgeListProps {
@@ -146,6 +170,7 @@ export const ProjectContextBadgeList: React.FC<ProjectContextBadgeListProps> = (
   ) => {
     const config = PATTERN_TYPE_CONFIG[item.type];
     const Icon = config.icon;
+    const label = getBadgeLabel(item);
     return (
       <Badge
         key={`${isExclusion ? "ex" : "in"}:${item.type}:${item.pattern}`}
@@ -156,14 +181,12 @@ export const ProjectContextBadgeList: React.FC<ProjectContextBadgeListProps> = (
         )}
       >
         <Icon className={cn("tw-size-4 tw-shrink-0 sm:tw-size-3", config.colorClass)} />
-        <TruncatedText className="tw-max-w-[100px] sm:tw-max-w-[120px]">
-          {item.pattern}
-        </TruncatedText>
+        <TruncatedText className="tw-max-w-[100px] sm:tw-max-w-[120px]">{label}</TruncatedText>
         {onRemove && (
           <Button
             variant="ghost2"
             size="fit"
-            aria-label={`Remove ${item.pattern}`}
+            aria-label={`Remove ${label}`}
             className="tw-h-auto tw-p-0"
             onClick={() => onRemove(item.pattern, item.type)}
           >

--- a/src/components/project/ProjectContextSourceEditor.stories.tsx
+++ b/src/components/project/ProjectContextSourceEditor.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import * as React from "react";
+import { ProjectContextSourceEditor } from "./ProjectContextSourceEditor";
+
+type Props = React.ComponentProps<typeof ProjectContextSourceEditor>;
+
+/**
+ * Patterns are persisted URL-encoded and comma-joined, so fixtures encode the
+ * same way the settings value does rather than passing raw bracket syntax.
+ */
+const patterns = (...raw: string[]) => raw.map(encodeURIComponent).join(",");
+
+const noop = () => {};
+
+const meta = {
+  title: "Project/Context Source Editor",
+  component: ProjectContextSourceEditor,
+  args: { onChange: noop, onManage: noop },
+  parameters: { gallery: { host: "modal", layout: "padded" } },
+} satisfies Meta<Props>;
+export default meta;
+
+/**
+ * All five source types together. This editor keeps its own chip icons and hues
+ * rather than reusing ProjectContextBadgeList's pills, so property's glyph and
+ * color need comparing against its siblings here too. `showHelperText` renders
+ * the description that names the supported source types.
+ */
+export const AllSourceTypes: StoryObj<Props> = {
+  args: {
+    showHelperText: true,
+    contextSource: {
+      inclusions: patterns(
+        "notes/research",
+        "#machine-learning",
+        "[[Project Brief]]",
+        "*.pdf",
+        "[Topics:Physics]"
+      ),
+    },
+  },
+};
+
+/**
+ * The two property label shapes. Unlike the other four types, a property chip
+ * renders a *transformed* label via `getBadgeLabel`, so both forms need to be
+ * legible as such.
+ */
+export const PropertyLabelForms: StoryObj<Props> = {
+  args: {
+    contextSource: {
+      inclusions: patterns("[Topics:Physics]", "[Subject:]", "[Status:In Progress]"),
+    },
+  },
+};
+
+/** Excluded property chips render dimmed below the divider. */
+export const WithExclusions: StoryObj<Props> = {
+  args: {
+    contextSource: {
+      inclusions: patterns("notes/research", "[Topics:Physics]"),
+      exclusions: patterns("notes/archive", "[Status:Draft]"),
+    },
+  },
+};
+
+/** The empty placeholder, whose hint names the source types Manage can add. */
+export const Empty: StoryObj<Props> = {
+  args: { contextSource: { inclusions: "", exclusions: "" } },
+};

--- a/src/components/project/ProjectContextSourceEditor.tsx
+++ b/src/components/project/ProjectContextSourceEditor.tsx
@@ -1,12 +1,16 @@
 import type { ProjectConfig } from "@/aiParams";
 import { AddUrlPopover } from "@/components/project/AddUrlPopover";
 import { ContextChip } from "@/components/project/ContextChip";
-import { buildBadgeItems, removePattern } from "@/components/project/ProjectContextBadgeList";
+import {
+  buildBadgeItems,
+  getBadgeLabel,
+  removePattern,
+} from "@/components/project/ProjectContextBadgeList";
 import { UrlTypeIcon } from "@/components/project/UrlTypeIcon";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { parseProjectUrls, serializeProjectUrls, type UrlItem } from "@/utils/urlTagUtils";
-import { FileText, Folder, Hash, Inbox, Settings, Tag } from "lucide-react";
+import { FileText, Folder, Hash, Inbox, Settings, SlidersHorizontal, Tag } from "lucide-react";
 import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
 
 type ContextSource = NonNullable<ProjectConfig["contextSource"]>;
@@ -43,6 +47,7 @@ const FILE_CHIP_CONFIG = {
   tag: { Icon: Tag, colorClass: "tw-text-context-manager-orange" },
   note: { Icon: FileText, colorClass: "tw-text-context-manager-blue" },
   extension: { Icon: Hash, colorClass: "tw-text-context-manager-green" },
+  property: { Icon: SlidersHorizontal, colorClass: "tw-text-context-manager-purple" },
 } as const;
 
 /**
@@ -139,7 +144,7 @@ export function ProjectContextSourceEditor({
             key={`file:${item.type}:${item.pattern}`}
             icon={<Icon className="tw-size-3.5" />}
             colorClass={colorClass}
-            label={item.pattern}
+            label={getBadgeLabel(item)}
             onRemove={() => handleRemoveFile(item.pattern, item.type)}
           />
         );
@@ -168,7 +173,7 @@ export function ProjectContextSourceEditor({
         key={`ex:${item.type}:${item.pattern}`}
         icon={<Icon className="tw-size-3.5" />}
         colorClass={colorClass}
-        label={item.pattern}
+        label={getBadgeLabel(item)}
         dim
         onRemove={() => handleRemoveExclusion(item.pattern, item.type)}
       />
@@ -212,7 +217,9 @@ export function ProjectContextSourceEditor({
                 : "No context yet"}
             </div>
             <div className="tw-text-xs tw-text-muted">
-              {droppable ? "or use Manage to add inclusion / tag / URL" : "Add via + URL or Manage"}
+              {droppable
+                ? "or use Manage to add inclusion / tag / property / URL"
+                : "Add via + URL or Manage"}
             </div>
           </div>
         ) : (
@@ -324,8 +331,8 @@ export function ProjectContextSourceEditor({
   return (
     <div className="tw-flex tw-flex-col tw-gap-2">
       <div className="tw-text-sm tw-text-muted">
-        Define patterns to include specific files, folders or tags in the project context. You can
-        also add web pages or YouTube videos.
+        Define patterns to include specific files, folders, tags or properties in the project
+        context. You can also add web pages or YouTube videos.
       </div>
       {editorBox}
     </div>

--- a/src/components/project/ProjectContextSourceEditor.tsx
+++ b/src/components/project/ProjectContextSourceEditor.tsx
@@ -52,7 +52,7 @@ const FILE_CHIP_CONFIG = {
 
 /**
  * The shared, controlled mixed file+URL context editor (design H / E). Renders
- * inclusions (folder/tag/file/extension via {@link buildBadgeItems}) and URLs
+ * inclusions (folder/tag/file/extension/property via {@link buildBadgeItems}) and URLs
  * (via {@link parseProjectUrls}) as one wrapped {@link ContextChip} flow that
  * fills the box and scrolls internally when it overflows, then a footer pinned at
  * the box floor (drag hint · +URL · Manage). Pure / controlled: deletes and the

--- a/src/context/contextUpdatesBlockBuilder.test.ts
+++ b/src/context/contextUpdatesBlockBuilder.test.ts
@@ -5,7 +5,7 @@ describe("buildProjectContextUpdatesBlock", () => {
     const block = buildProjectContextUpdatesBlock();
     expect(block).toContain("<project_context_updates>");
     expect(block).toContain("</project_context_updates>");
-    expect(block).toContain("re-check declared folders/tags/files before answering");
+    expect(block).toContain("re-check the declared project context before answering");
   });
 
   it("is a stable, source-agnostic constant (no per-path detail)", () => {

--- a/src/context/contextUpdatesBlockBuilder.ts
+++ b/src/context/contextUpdatesBlockBuilder.ts
@@ -11,7 +11,7 @@
  */
 const PROJECT_CONTEXT_UPDATES_BLOCK = [
   "<project_context_updates>",
-  "Project sources may have changed, re-check declared folders/tags/files before answering.",
+  "Project sources may have changed; re-check the declared project context before answering.",
   "</project_context_updates>",
 ].join("\n");
 

--- a/src/context/manifestBuilder.test.ts
+++ b/src/context/manifestBuilder.test.ts
@@ -16,6 +16,7 @@ function sources(over: Partial<ManifestSources> = {}): ManifestSources {
     notes: [],
     extensions: [],
     tags: [],
+    properties: [],
     webUrls: [],
     youtubeUrls: [],
     materialized: [],
@@ -120,5 +121,20 @@ describe("buildProjectContextBlock", () => {
   it("omits the truncation note when under the cap", () => {
     const md = buildProjectContextBlock(sources({ folders: [abs("A"), abs("B")] }));
     expect(md).not.toContain("omitted");
+  });
+
+  it("lists a property inclusion as a source label", () => {
+    const md = buildProjectContextBlock(sources({ properties: ["[Topics:Physics]"] }));
+    expect(md).toContain("Included properties");
+    expect(md).toContain("[Topics:Physics]");
+  });
+
+  it("keeps the property label visible when matched notes overflow the entry cap", () => {
+    const manyNotes = Array.from({ length: MAX_MANIFEST_ENTRIES + 5 }, (_, i) => abs(`n${i}.md`));
+    const md = buildProjectContextBlock(
+      sources({ notes: manyNotes, properties: ["[Topics:Physics]"] })
+    );
+    expect(md).toContain("Included properties");
+    expect(md).toContain("[Topics:Physics]");
   });
 });

--- a/src/context/manifestBuilder.test.ts
+++ b/src/context/manifestBuilder.test.ts
@@ -115,7 +115,7 @@ describe("buildProjectContextBlock", () => {
 
     expect(md).toContain(`Only the first ${MAX_MANIFEST_ENTRIES} of ${folders.length} sources`);
     expect(md).toContain("25 more are omitted");
-    expect(md).toContain("Use folder/tag search");
+    expect(md).toContain("Use the declared context sources above");
   });
 
   it("omits the truncation note when under the cap", () => {

--- a/src/context/manifestBuilder.ts
+++ b/src/context/manifestBuilder.ts
@@ -98,9 +98,9 @@ export function buildProjectContextBlock(sources: ManifestSources): string {
 
   const out: string[] = [
     "<project_context>",
-    "Context sources for this project, with absolute paths. Folders and tags are",
-    "listed as sources, not expanded into member files — use your own search",
-    "(grep/glob/read) to enumerate them. Materialized snapshots of URLs, YouTube",
+    "Context sources for this project, with absolute paths. Folders, tags, and",
+    "properties are listed as sources, not expanded into member files — use your own",
+    "search (grep/glob/read) to enumerate them. Materialized snapshots of URLs, YouTube",
     "transcripts, and PDFs/images are shown inline as an absolute path after the",
     "source, formatted `<source> → <absolute path>` — read that path directly. A source",
     "with no path isn't cached (not yet converted or conversion failed); use the source itself.",

--- a/src/context/manifestBuilder.ts
+++ b/src/context/manifestBuilder.ts
@@ -29,6 +29,13 @@ export interface ManifestSources {
   notes: ManifestPathEntry[];
   extensions: string[];
   tags: string[];
+  /**
+   * Property inclusion patterns (e.g. `[Topics:Physics]`), listed as source
+   * labels. Property-matched notes are also enumerated under "Included notes",
+   * but a broad property can overflow the entry cap; the label ensures the agent
+   * still knows which frontmatter query produced them even when notes are cut.
+   */
+  properties: string[];
   webUrls: string[];
   youtubeUrls: string[];
   /** Present cache files, used to resolve snapshot pointers + list file snapshots. */
@@ -74,6 +81,7 @@ export function buildProjectContextBlock(sources: ManifestSources): string {
 
   const lines: ManifestLine[] = [
     ...sources.folders.map((e) => line("Included folders", pathText(e))),
+    ...sources.properties.map((p) => line("Included properties", p)),
     ...sources.notes.map((e) => line("Included notes", pathText(e))),
     ...sources.extensions.map((p) => line("Included file types", `\`${p}\``)),
     ...sources.tags.map((t) => line("Included tags", t)),

--- a/src/context/manifestBuilder.ts
+++ b/src/context/manifestBuilder.ts
@@ -122,7 +122,7 @@ export function buildProjectContextBlock(sources: ManifestSources): string {
     out.push(
       "",
       `> Only the first ${shown.length} of ${total} sources are listed; ${omitted} more are omitted. ` +
-        `Use folder/tag search (grep/find) to find the rest.`
+        `Use the declared context sources above with grep/glob/read to find the rest.`
     );
   }
   out.push("</project_context>");

--- a/src/context/manifestBuilder.ts
+++ b/src/context/manifestBuilder.ts
@@ -98,12 +98,15 @@ export function buildProjectContextBlock(sources: ManifestSources): string {
 
   const out: string[] = [
     "<project_context>",
-    "Context sources for this project, with absolute paths. Folders, tags, and",
-    "properties are listed as sources, not expanded into member files — use your own",
-    "search (grep/glob/read) to enumerate them. Materialized snapshots of URLs, YouTube",
-    "transcripts, and PDFs/images are shown inline as an absolute path after the",
-    "source, formatted `<source> → <absolute path>` — read that path directly. A source",
-    "with no path isn't cached (not yet converted or conversion failed); use the source itself.",
+    "Context sources for this project, with absolute paths. Folders and tags are",
+    "listed as sources, not expanded into member files — use your own search",
+    "(grep/glob/read) to enumerate them. Properties are listed as source labels and",
+    'also expanded into matching notes under "Included notes" (a property pattern\'s',
+    "label is listed so it survives the entry cap; its resolved notes appear below).",
+    "Materialized snapshots of URLs, YouTube transcripts, and PDFs/images are shown",
+    "inline as an absolute path after the source, formatted `<source> → <absolute path>`",
+    "— read that path directly. A source with no path isn't cached (not yet converted",
+    "or conversion failed); use the source itself.",
   ];
 
   let currentSection = "";

--- a/src/context/projectContentTracker.test.ts
+++ b/src/context/projectContentTracker.test.ts
@@ -29,24 +29,32 @@ jest.mock("@/projects/state", () => ({
 
 type Handler = (file: unknown, oldPath?: string) => void;
 
-/** A fake vault that records event handlers so a test can fire them by hand. */
-function makeApp(): { app: App; fire: (event: string, file: unknown, oldPath?: string) => void } {
+/** A fake vault + metadata cache that record event handlers so a test can fire
+ * them by hand. Vault and metadata cache use separate `offref` mocks so a test can
+ * assert teardown routes each ref to its own emitter. */
+function makeApp(): {
+  app: App;
+  fire: (event: string, file: unknown, oldPath?: string) => void;
+  vaultOffref: jest.Mock;
+  metadataOffref: jest.Mock;
+} {
   const handlers = new Map<string, Handler[]>();
+  const register = (event: string, handler: Handler) => {
+    const list = handlers.get(event) ?? [];
+    list.push(handler);
+    handlers.set(event, list);
+    return { event };
+  };
+  const vaultOffref = jest.fn();
+  const metadataOffref = jest.fn();
   const app = {
-    vault: {
-      on: (event: string, handler: Handler) => {
-        const list = handlers.get(event) ?? [];
-        list.push(handler);
-        handlers.set(event, list);
-        return { event };
-      },
-      offref: jest.fn(),
-    },
+    vault: { on: register, offref: vaultOffref },
+    metadataCache: { on: register, offref: metadataOffref },
   } as unknown as App;
   const fire = (event: string, file: unknown, oldPath?: string) => {
     for (const handler of handlers.get(event) ?? []) handler(file, oldPath);
   };
-  return { app, fire };
+  return { app, fire, vaultOffref, metadataOffref };
 }
 
 function record(id: string, contextSource: Record<string, string>): ProjectFileRecord {
@@ -161,6 +169,77 @@ describe("ProjectContentTracker", () => {
     tracker.flushNow();
 
     expect(tracker.getEpoch("a")).toBe(0);
+    tracker.dispose();
+  });
+
+  it("conservatively dirties a property-declaring project on ANY markdown change (frontmatter is unresolvable from a path)", () => {
+    // Editing a note's frontmatter is a plain markdown modify; the changed file is
+    // out of any folder scope, but the project includes notes by a property whose
+    // value can't be read from the path — so it dirties conservatively, like a tag.
+    mockRecords(record("a", { inclusions: "[Topics:Physics]" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("Anywhere/note.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
+    tracker.dispose();
+  });
+
+  it("does NOT dirty a property-declaring project on a non-markdown change out of scope", () => {
+    mockRecords(record("a", { inclusions: "[Topics:Physics]" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("Anywhere/image.png"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(0);
+    tracker.dispose();
+  });
+
+  it("does NOT dirty a property-declaring project on a markdown change under a system Copilot root", () => {
+    // The vault `modify` half of the same rule the metadata event follows: a note
+    // under the Copilot root (chat autosave, on by default) is dropped by
+    // `shouldIndexFile`, so it can never enter a property source's note set.
+    mockRecords(record("a", { inclusions: "[Topics:Physics]" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("copilot/copilot-conversations/chat.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(0);
+    tracker.dispose();
+  });
+
+  it("still dirties a TAG-declaring project under a system Copilot root (tag scope is unchanged)", () => {
+    // The system-root skip is property-specific; tags keep their pre-existing
+    // broader rule, so this must not regress when the two predicates split.
+    mockRecords(record("a", { inclusions: "#physics" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("copilot/copilot-conversations/chat.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
+    tracker.dispose();
+  });
+
+  it("conservatively dirties a project declaring a property EXCLUSION on a markdown change out of folder scope", () => {
+    // A note inside the included folder can flip its excluded status when its
+    // frontmatter changes; the change fires for a note OUTSIDE the folder, yet the
+    // property exclusion still forces a conservative dirty (over-dirty is safe).
+    mockRecords(record("a", { inclusions: "Notes", exclusions: "[Draft:true]" }));
+    const { app, fire } = makeApp();
+    const tracker = new ProjectContentTracker(app);
+
+    fire("modify", file("Anywhere/note.md"));
+    tracker.flushNow();
+
+    expect(tracker.getEpoch("a")).toBe(1);
     tracker.dispose();
   });
 
@@ -298,5 +377,106 @@ describe("ProjectContentTracker", () => {
     tracker.flushNow();
 
     expect(tracker.getEpoch("a")).toBe(0);
+  });
+
+  describe("metadata-cache (property freshness)", () => {
+    it("re-dirties a property-inclusion project on a metadata change once the cache is fresh", () => {
+      mockRecords(record("p", { inclusions: "[Topics:Physics]" }));
+      const { app, fire } = makeApp();
+      const tracker = new ProjectContentTracker(app);
+
+      // A frontmatter edit fires vault `modify` first (cache still stale), then the
+      // metadata cache `changed` once it has re-parsed. Flushing between them (as a
+      // send/open would) lands each in its own drain; the SECOND bump is the one that
+      // re-resolves the property source against fresh frontmatter.
+      fire("modify", file("Notes/a.md"));
+      tracker.flushNow();
+      fire("changed", file("Notes/a.md"));
+      tracker.flushNow();
+
+      expect(tracker.getEpoch("p")).toBe(2);
+      tracker.dispose();
+    });
+
+    it("collapses a modify and its metadata change in one debounce window to a single bump", () => {
+      mockRecords(record("p", { inclusions: "[Topics:Physics]" }));
+      const { app, fire } = makeApp();
+      const tracker = new ProjectContentTracker(app);
+
+      fire("modify", file("Notes/a.md"));
+      fire("changed", file("Notes/a.md"));
+      tracker.flushNow();
+
+      expect(tracker.getEpoch("p")).toBe(1);
+      tracker.dispose();
+    });
+
+    it("ignores a metadata change for projects that declare no property inclusion", () => {
+      mockRecords(
+        record("folderProj", { inclusions: "Notes" }),
+        record("tagProj", { inclusions: "#physics" }),
+        record("propProj", { inclusions: "[Topics:Physics]" })
+      );
+      const { app, fire } = makeApp();
+      const tracker = new ProjectContentTracker(app);
+
+      fire("changed", file("Notes/a.md"));
+      tracker.flushNow();
+
+      expect(tracker.getEpoch("folderProj")).toBe(0);
+      expect(tracker.getEpoch("tagProj")).toBe(0);
+      expect(tracker.getEpoch("propProj")).toBe(1);
+      tracker.dispose();
+    });
+
+    it("ignores a metadata change on an internal Copilot file", () => {
+      mockRecords(record("p", { inclusions: "[Topics:Physics]" }));
+      const { app, fire } = makeApp();
+      const tracker = new ProjectContentTracker(app);
+
+      fire("changed", file("copilot/copilot-log.md"));
+      tracker.flushNow();
+
+      expect(tracker.getEpoch("p")).toBe(0);
+      tracker.dispose();
+    });
+
+    it("ignores a metadata change under a system Copilot root that property enumeration cannot reach", () => {
+      // Chat autosave writes frontmatter-bearing notes into the Copilot root every
+      // few seconds. `shouldIndexFile` always drops them, so they can never join a
+      // property source's note set and must not dirty the project.
+      mockRecords(record("p", { inclusions: "[Topics:Physics]" }));
+      const { app, fire } = makeApp();
+      const tracker = new ProjectContentTracker(app);
+
+      fire("changed", file("copilot/copilot-conversations/chat.md"));
+      tracker.flushNow();
+
+      expect(tracker.getEpoch("p")).toBe(0);
+      tracker.dispose();
+    });
+
+    it("tears down the metadata-cache listener via metadataCache.offref on dispose", () => {
+      mockRecords(record("p", { inclusions: "[Topics:Physics]" }));
+      const { app, metadataOffref, vaultOffref } = makeApp();
+      const tracker = new ProjectContentTracker(app);
+
+      tracker.dispose();
+
+      expect(metadataOffref).toHaveBeenCalledTimes(1);
+      expect(vaultOffref).toHaveBeenCalled();
+    });
+
+    it("stays inert to metadata events after dispose", () => {
+      mockRecords(record("p", { inclusions: "[Topics:Physics]" }));
+      const { app, fire } = makeApp();
+      const tracker = new ProjectContentTracker(app);
+      tracker.dispose();
+
+      fire("changed", file("Notes/a.md"));
+      tracker.flushNow();
+
+      expect(tracker.getEpoch("p")).toBe(0);
+    });
   });
 });

--- a/src/context/projectContentTracker.ts
+++ b/src/context/projectContentTracker.ts
@@ -4,6 +4,7 @@ import type { ProjectFileRecord } from "@/projects/type";
 import {
   getMatchingPatterns,
   isInternalExcludedPath,
+  isSystemExcludedPath,
   type PatternCategory,
 } from "@/search/searchUtils";
 import { debounce, type DebouncedFunction } from "@/utils/debounce";
@@ -18,7 +19,7 @@ const DEBOUNCE_MS = 2000;
  * a queued pre-rename event. Snapshotting the strings at enqueue time keeps the
  * old/new paths correct.
  */
-type VaultEventKind = "create" | "modify" | "delete" | "rename";
+type VaultEventKind = "create" | "modify" | "delete" | "rename" | "metadata";
 
 interface PendingChange {
   kind: VaultEventKind;
@@ -43,6 +44,7 @@ interface PendingChange {
  */
 export class ProjectContentTracker {
   private readonly vaultRefs: EventRef[] = [];
+  private readonly metadataRefs: EventRef[] = [];
   private readonly pending: PendingChange[] = [];
   private readonly epochs = new Map<string, number>();
   private readonly listeners = new Set<(projectId: string) => void>();
@@ -63,6 +65,17 @@ export class ProjectContentTracker {
       this.app.vault.on("rename", (file: TAbstractFile, oldPath: string) =>
         this.enqueue("rename", file, oldPath)
       )
+    );
+    // The metadata cache re-parses a note's frontmatter asynchronously, AFTER the
+    // vault `modify` event. A property source resolved on `modify` would read the
+    // stale cache and never re-resolve, staying permanently out of date. The
+    // `changed` event fires once the cache is current, so enqueue it as a distinct
+    // `metadata` kind that (see changeAffectsProject) re-dirties ONLY property-
+    // inclusion projects — no other source reads the cache, so none should react.
+    // Registered on the metadata cache, a different emitter than the vault, so its
+    // refs are tracked and torn down separately (metadataCache.offref).
+    this.metadataRefs.push(
+      this.app.metadataCache.on("changed", (file: TFile) => this.enqueue("metadata", file))
     );
   }
 
@@ -104,6 +117,8 @@ export class ProjectContentTracker {
     this.debouncedDrain.cancel();
     for (const ref of this.vaultRefs) this.app.vault.offref(ref);
     this.vaultRefs.length = 0;
+    for (const ref of this.metadataRefs) this.app.metadataCache.offref(ref);
+    this.metadataRefs.length = 0;
     this.pending.length = 0;
     this.listeners.clear();
     this.epochs.clear();
@@ -169,20 +184,44 @@ function changeAffectsProject(change: PendingChange, record: ProjectFileRecord):
   // A project with no inclusions materializes nothing, so nothing can dirty it.
   if (!inclusions) return false;
 
+  // A `metadata` event means the cache finished re-parsing a note's frontmatter —
+  // the moment a property source can resolve against fresh data. It matters ONLY to
+  // projects that ENUMERATE notes from frontmatter, i.e. that declare a property
+  // INCLUSION (resolvePropertyNotePaths). Tags carry a static label and never read
+  // the cache; folder/note/extension match by path; a bare property exclusion never
+  // enumerates. So this event dirties a project iff it declares a property inclusion
+  // and the changed file is a real markdown note that property enumeration can reach
+  // — every other source is left untouched, avoiding needless invalidation and
+  // startup-index churn.
+  if (change.kind === "metadata") {
+    return (
+      (inclusions.propertyPatterns?.length ?? 0) > 0 &&
+      change.isMarkdown &&
+      isPropertyCandidatePath(change.path)
+    );
+  }
+
   const paths = change.oldPath ? [change.path, change.oldPath] : [change.path];
   // Only a folder RENAME or DELETE can change which files exist under a scope; a
   // folder CREATE is an empty directory with no members, so it can't dirty anything.
   const folderMembershipEvent =
     change.isFolder && (change.kind === "rename" || change.kind === "delete");
 
-  // Tag membership can't be recovered from a path (and the metadata cache may not
-  // have parsed a just-edited file yet), so conservatively dirty a tag-declaring
-  // project on ANY event that could change which files carry a tag: a markdown
-  // change (checked on BOTH rename sides — a `.md → .txt` rename leaves tag scope)
-  // or a folder rename/delete that could move tagged notes. Skip when every side is
-  // an internal Copilot file (a `project.md` edit must not spray notes) — but keep
-  // it when one side is a user path (an internal ↔ user rename still counts).
-  if (declaresTagPattern(inclusions, exclusions) && paths.some((p) => !isInternalExcludedPath(p))) {
+  // A tag's membership and a property's value both live in a note's frontmatter/
+  // metadata and can't be recovered from a path (the metadata cache may also not
+  // have re-parsed a just-edited file yet), so conservatively dirty a project that
+  // declares EITHER on any event that could change which files carry a tag or hold
+  // a property value: a markdown change (checked on BOTH rename sides — a
+  // `.md → .txt` rename leaves frontmatter scope) or a folder rename/delete that
+  // could move such notes. Each source uses its own reachability rule: a tag only
+  // skips internal Copilot files, while a property additionally skips the system
+  // Copilot roots its enumeration can never return (see isPropertyCandidatePath).
+  // Keep the event when ANY side is reachable — an internal ↔ user rename counts.
+  const tagReaches =
+    declaresTagPattern(inclusions, exclusions) && paths.some((p) => !isInternalExcludedPath(p));
+  const propertyReaches =
+    declaresPropertyPattern(inclusions, exclusions) && paths.some(isPropertyCandidatePath);
+  if (tagReaches || propertyReaches) {
     const touchesMarkdown = change.isMarkdown || paths.some((p) => p.toLowerCase().endsWith(".md"));
     if (touchesMarkdown || folderMembershipEvent) return true;
   }
@@ -218,11 +257,47 @@ function changeAffectsProject(change: PendingChange, record: ProjectFileRecord):
   return paths.some((path) => fileMatchesInclusions(path, inclusions));
 }
 
+/**
+ * Whether a project declares a tag source. Tag membership lives in a note's
+ * frontmatter/metadata and can't be resolved from a path alone, so a project
+ * declaring one must be dirtied conservatively on any metadata-bearing change.
+ * Checks exclusions too: a tag EXCLUSION also shifts the materialized set when a
+ * note's frontmatter changes.
+ */
 function declaresTagPattern(
   inclusions: PatternCategory,
   exclusions: PatternCategory | null
 ): boolean {
   return (inclusions.tagPatterns?.length ?? 0) > 0 || (exclusions?.tagPatterns?.length ?? 0) > 0;
+}
+
+/**
+ * Whether a project declares a property source, the property counterpart of
+ * {@link declaresTagPattern}. Kept separate from the tag check because the two
+ * reach different files: property enumeration runs through `shouldIndexFile`, so
+ * it can never return a note under a system Copilot root, while tags keep their
+ * pre-existing broader rule.
+ */
+function declaresPropertyPattern(
+  inclusions: PatternCategory,
+  exclusions: PatternCategory | null
+): boolean {
+  return (
+    (inclusions.propertyPatterns?.length ?? 0) > 0 ||
+    (exclusions?.propertyPatterns?.length ?? 0) > 0
+  );
+}
+
+/**
+ * Whether a path is one that property enumeration could ever return. Mirrors the
+ * `shouldIndexFile` exclusions `resolvePropertyNotePaths` runs through: internal
+ * Copilot files and the system Copilot roots (active and historical) are always
+ * dropped there, so a change to one cannot alter a property source's note set.
+ * Without the system-root half, Copilot's own chat autosave — on by default, and
+ * frontmatter-bearing — would dirty every property project every few seconds.
+ */
+function isPropertyCandidatePath(path: string): boolean {
+  return !isInternalExcludedPath(path) && !isSystemExcludedPath(path);
 }
 
 function fileMatchesInclusions(path: string, inclusions: PatternCategory): boolean {

--- a/src/context/projectContentTracker.ts
+++ b/src/context/projectContentTracker.ts
@@ -301,6 +301,17 @@ function isPropertyCandidatePath(path: string): boolean {
 }
 
 function fileMatchesInclusions(path: string, inclusions: PatternCategory): boolean {
+  // DESIGN NOTE — no `propertyPatterns` branch here, deliberately.
+  //
+  // Every markdown event on a path property enumeration can reach has already
+  // returned through the `propertyReaches` gate above. A markdown event that
+  // still arrives here is under an internal/system root, which that enumeration
+  // can never return. The only other case is a non-markdown path, and
+  // `resolvePropertyNotePaths` enumerates `vault.getMarkdownFiles()` only — so
+  // creating or deleting a `.pdf` cannot change a property source's note set.
+  // A branch here would be dead code guarding a state that cannot occur.
+  // If a future review flags the missing property case again, point them here.
+  //
   // Internal Copilot files (project.md, the AGENTS.md mirror, the log) can be
   // caught by a `*.md` or projects-folder pattern but must never count as a
   // context source — mirror shouldIndexFile's exclusion for the dead-path case.

--- a/src/context/projectContextMaterializer.test.ts
+++ b/src/context/projectContextMaterializer.test.ts
@@ -21,7 +21,7 @@ jest.mock("@/LLMProviders/brevilabsClient", () => ({
 
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import { getCachedProjectRecordById } from "@/projects/state";
-import { getMatchingPatterns } from "@/search/searchUtils";
+import { getMatchingPatterns, shouldIndexFile } from "@/search/searchUtils";
 import {
   ensureProjectContextMaterialized,
   materializeProjectContextSource,
@@ -30,6 +30,7 @@ import {
 
 const getRecord = getCachedProjectRecordById as jest.Mock;
 const getPatterns = getMatchingPatterns as jest.Mock;
+const indexFile = shouldIndexFile as jest.Mock;
 const getClient = BrevilabsClient.getInstance as jest.Mock;
 
 const CWD = "/vault/Proj";
@@ -91,6 +92,7 @@ function fakeApp(files: Array<{ path: string; ext: string }> = [], folders: stri
     vault: {
       adapter: new FsAdapter("/vault"),
       getFiles: () => tfiles,
+      getMarkdownFiles: () => tfiles.filter((f) => f.extension === "md"),
       getAbstractFileByPath: (p: string) => (folderSet.has(p) ? new Folder(p) : null),
       readBinary: jest.fn(async () => new ArrayBuffer(4)),
     },
@@ -101,6 +103,8 @@ beforeEach(() => {
   mockFs = memFs();
   jest.clearAllMocks();
   getPatterns.mockReturnValue(patterns());
+  // Reset the default so a per-test property matcher override never leaks forward.
+  indexFile.mockReturnValue(true);
   getClient.mockReturnValue({
     url4llm: jest.fn(async () => ({ response: "url text" })),
     youtube4llm: jest.fn(async () => ({ response: { transcript: "yt text" } })),
@@ -175,6 +179,54 @@ describe("ensureProjectContextMaterialized", () => {
 
     expect(result.projectContextBlock).toContain("`/vault/A/Spec.md`");
     expect(result.projectContextBlock).toContain("`/vault/B/Spec.md`");
+  });
+
+  it("counts a property-only inclusion as a source and enumerates matching notes by absolute path", async () => {
+    getRecord.mockReturnValue(record({ inclusions: "[Topics:Physics]" }));
+    getPatterns.mockReturnValue(patterns({ propertyPatterns: ["[Topics:Physics]"] }));
+    const app = fakeApp([
+      { path: "Notes/Relativity.md", ext: "md" },
+      { path: "Notes/Cooking.md", ext: "md" },
+    ]);
+    // Only the physics note carries the matching frontmatter property.
+    indexFile.mockImplementation((_app: unknown, file: { path: string }) => file.path === "Notes/Relativity.md"); // prettier-ignore
+
+    const result = await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    expect(result.projectContextBlock).toContain("<project_context>");
+    expect(result.projectContextBlock).toContain("## Included notes");
+    expect(result.projectContextBlock).toContain("`/vault/Notes/Relativity.md`");
+    expect(result.projectContextBlock).not.toContain("Cooking");
+  });
+
+  it("still emits <project_context> for a property-only project when no note currently matches", async () => {
+    getRecord.mockReturnValue(record({ inclusions: "[Topics:Physics]" }));
+    getPatterns.mockReturnValue(patterns({ propertyPatterns: ["[Topics:Physics]"] }));
+    const app = fakeApp([{ path: "Notes/Cooking.md", ext: "md" }]);
+    indexFile.mockReturnValue(false); // nothing matches the property yet
+
+    const result = await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    // The declared property is a real source, so the block IS emitted (not the
+    // frozen empty result) — otherwise a stale empty landing would be reused. It
+    // simply lists no note until one matches.
+    expect(result.projectContextBlock).toContain("<project_context>");
+    expect(result.projectContextBlock).not.toContain("## Included notes");
+  });
+
+  it("lists a note matched by BOTH a note inclusion and a property only once", async () => {
+    getRecord.mockReturnValue(record({ inclusions: "[[Relativity]],[Topics:Physics]" }));
+    getPatterns.mockReturnValue(
+      patterns({ notePatterns: ["[[Relativity]]"], propertyPatterns: ["[Topics:Physics]"] })
+    );
+    const app = fakeApp([{ path: "Notes/Relativity.md", ext: "md" }]);
+    indexFile.mockReturnValue(true); // the note also matches the property
+
+    const result = await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    const block = result.projectContextBlock ?? "";
+    const occurrences = block.split("`/vault/Notes/Relativity.md`").length - 1;
+    expect(occurrences).toBe(1);
   });
 
   it("materializes in-vault PDFs but ignores markdown files", async () => {

--- a/src/context/projectContextMaterializer.ts
+++ b/src/context/projectContextMaterializer.ts
@@ -3,7 +3,7 @@ import { err2String } from "@/errorFormat";
 import { logInfo, logWarn } from "@/logger";
 import { getCachedProjectRecordById } from "@/projects/state";
 import { getProjectContextSignature } from "@/projects/projectContextSignature";
-import { getMatchingPatterns } from "@/search/searchUtils";
+import { getMatchingPatterns, shouldIndexFile, type PatternCategory } from "@/search/searchUtils";
 import { listMaterializeCandidates } from "@/context/materializeCandidates";
 import { Mutex } from "async-mutex";
 import { App, FileSystemAdapter, TFile, TFolder } from "obsidian";
@@ -75,6 +75,10 @@ export type ContextMaterializeProgressFn = (progress: ContextMaterializeProgress
 
 // Referential stability: a single frozen empty array for every "no context" exit.
 const EMPTY_DIRECTORIES: string[] = Object.freeze([] as string[]) as string[];
+// Referential stability: one frozen empty array for the "no property notes" exit.
+const EMPTY_MANIFEST_ENTRIES: ManifestPathEntry[] = Object.freeze(
+  [] as ManifestPathEntry[]
+) as ManifestPathEntry[];
 /**
  * Frozen fallback result for the "no usable record / whole-run failure" exits —
  * NO `contextSignature`, so it never clears a caller's dirty flag (nothing was
@@ -305,7 +309,7 @@ async function runMaterialize(
     // included folder. That "粒度错配的洞" is explicitly acknowledged-and-unblocked
     // — hard enforcement needs a backend/OS sandbox (Tier 2/3), deferred past PR2.
     // See designdocs/agent-projects/PR2_DESIGN.md §4.1.1.
-    const { inclusions } = getMatchingPatterns({
+    const { inclusions, exclusions } = getMatchingPatterns({
       inclusions: contextSource.inclusions,
       exclusions: contextSource.exclusions,
       isProject: true,
@@ -322,6 +326,10 @@ async function runMaterialize(
     // See designdocs/agent-projects/PR2_DESIGN.md §4.1.
     const extensions = inclusions?.extensionPatterns ?? [];
     const tags = inclusions?.tagPatterns ?? [];
+    // Property inclusions can't be resolved from a path like folders/notes — their
+    // values live in frontmatter — so they're enumerated to concrete matching
+    // notes below and counted as a real source in `hasAnySource`.
+    const properties = inclusions?.propertyPatterns ?? [];
 
     const adapter = getVaultFileSystemAdapter(app);
     const { entries: folderEntries, additionalDirectories } = resolveFolderPaths(
@@ -330,7 +338,20 @@ async function runMaterialize(
       cwd,
       adapter
     );
-    const noteEntries = resolveNotePaths(app, notes, adapter);
+    // Property-matched notes join the note sources so the agent gets each note's
+    // absolute path; dedupe by resolved path so a note included via BOTH a
+    // [[title]] and a property isn't listed twice.
+    const resolvedNotes = resolveNotePaths(app, notes, adapter);
+    const propertyNotes = resolvePropertyNotePaths(app, properties, exclusions, adapter);
+    const seenNotePaths = new Set(resolvedNotes.map((entry) => entry.absPath ?? entry.vaultPath));
+    const noteEntries = [...resolvedNotes];
+    for (const entry of propertyNotes) {
+      const key = entry.absPath ?? entry.vaultPath;
+      if (!seenNotePaths.has(key)) {
+        seenNotePaths.add(key);
+        noteEntries.push(entry);
+      }
+    }
 
     const files: FileSource[] = inclusions
       ? listMaterializeCandidates(app, contextSource).map((file) => ({
@@ -349,6 +370,7 @@ async function runMaterialize(
       notes.length > 0 ||
       extensions.length > 0 ||
       tags.length > 0 ||
+      properties.length > 0 ||
       additionalDirectories.length > 0;
     if (!hasAnySource) return { additionalDirectories: EMPTY_DIRECTORIES, contextSignature };
 
@@ -402,6 +424,7 @@ async function runMaterialize(
       notes: noteEntries,
       extensions,
       tags,
+      properties,
       webUrls,
       youtubeUrls,
       materialized: manifestEntries,
@@ -628,6 +651,36 @@ function resolveNotePaths(
       absPath: adapter.getFullPath(file.path),
     }));
   });
+}
+
+/**
+ * Enumerate the markdown notes whose frontmatter matches a project's property
+ * inclusions, resolved to absolute `ManifestPathEntry`s. Unlike folders/notes/tags
+ * — which are listed as SOURCE LABELS the agent expands with its own search — a
+ * property value lives in frontmatter the agent's native search can't discover
+ * (it's a vault-specific taxonomy, not a grep-able `#tag`), so the matching notes
+ * are enumerated concretely here. Reuses the Phase 1 matcher through the exported
+ * {@link shouldIndexFile} contract (property-only inclusions + the project's real
+ * exclusions), so match semantics stay identical to indexing/QA. Sorted by path
+ * for a stable listing; empty (frozen) when the project declares no property.
+ */
+function resolvePropertyNotePaths(
+  app: App,
+  propertyPatterns: string[],
+  exclusions: PatternCategory | null,
+  adapter: FileSystemAdapter | null
+): ManifestPathEntry[] {
+  if (propertyPatterns.length === 0) return EMPTY_MANIFEST_ENTRIES;
+  const inclusions: PatternCategory = { propertyPatterns };
+  return app.vault
+    .getMarkdownFiles()
+    .filter((file) => shouldIndexFile(app, file, inclusions, exclusions, true))
+    .sort((a, b) => a.path.localeCompare(b.path))
+    .map((file) =>
+      adapter
+        ? { vaultPath: file.path, absPath: adapter.getFullPath(file.path) }
+        : { vaultPath: file.path }
+    );
 }
 
 /**

--- a/src/miyo/miyoUtils.test.ts
+++ b/src/miyo/miyoUtils.test.ts
@@ -338,6 +338,13 @@ describe("getMiyoFolderInclusions", () => {
     expect(getMiyoFolderInclusions("[[Daily]], *.md")).toEqual({});
   });
 
+  it("FALLS BACK to no filter when a [key:value] property inclusion is present", () => {
+    // A frontmatter match has no folder/extension equivalent, so whitelisting only
+    // "Research" would drop every [Topics:Physics] note living outside it.
+    expect(getMiyoFolderInclusions("[Topics:Physics], Research")).toEqual({});
+    expect(getMiyoFolderInclusions("[Subject:], *.md")).toEqual({});
+  });
+
   it("drops root/parent pointers from include_folders", () => {
     expect(getMiyoFolderInclusions("./")).toEqual({});
     expect(getMiyoFolderInclusions("projects, .")).toEqual({ include_folders: ["projects"] });

--- a/src/miyo/miyoUtils.ts
+++ b/src/miyo/miyoUtils.ts
@@ -172,33 +172,35 @@ const EMPTY_MIYO_FOLDER_INCLUSIONS: MiyoFolderInclusions = Object.freeze({});
  * filter is a whitelist: per the folder API, if `include_folders` OR
  * `include_patterns` is non-empty, a file is in scope ONLY if it's under an
  * include folder or matches an include pattern. So dropping an un-mappable
- * inclusion (a `#tag` / `[[note]]`, which Miyo can't express) while still sending
- * the mappable ones would OVER-restrict — Miyo would index only the folders we
- * mapped and silently drop everything the tag/note inclusion was meant to keep.
- * That is the harmful direction (missing search results).
+ * inclusion (a `#tag` / `[[note]]` / `[key:value]`, which Miyo can't express)
+ * while still sending the mappable ones would OVER-restrict — Miyo would index
+ * only the folders we mapped and silently drop everything the un-mappable
+ * inclusion was meant to keep. That is the harmful direction (missing search
+ * results).
  *
  * So we send includes ONLY when `qaInclusions` maps CLEANLY AND COMPLETELY to
- * folder/extension terms (no tag or note components). If any tag/note pattern is
- * present, we send NO include filter at all — Miyo indexes the whole vault and
- * Copilot\'s own filters narrow results at query time. Under-indexing never
- * happens; at worst Miyo indexes a little extra, matching the exclusions bias.
+ * folder/extension terms (no tag, note, or property components). If any such
+ * pattern is present, we send NO include filter at all — Miyo indexes the whole
+ * vault and Copilot\'s own filters narrow results at query time. Under-indexing
+ * never happens; at worst Miyo indexes a little extra, matching the exclusions bias.
  *
  * @param qaInclusions - The raw `qaInclusions` settings string.
  * @returns Include fields to merge into the add-folder request; frozen-empty when
- *          nothing maps or when a tag/note pattern forces the whole-vault fallback.
+ *          nothing maps or when a tag/note/property pattern forces the whole-vault
+ *          fallback.
  */
 export function getMiyoFolderInclusions(qaInclusions: string): MiyoFolderInclusions {
   if (!qaInclusions.trim()) {
     return EMPTY_MIYO_FOLDER_INCLUSIONS;
   }
 
-  const { tagPatterns, notePatterns, extensionPatterns, folderPatterns } = categorizePatterns(
-    getDecodedPatterns(qaInclusions)
-  );
+  const { tagPatterns, notePatterns, propertyPatterns, extensionPatterns, folderPatterns } =
+    categorizePatterns(getDecodedPatterns(qaInclusions));
 
-  // Any tag/note inclusion → whitelist can\'t represent it → fall back to
-  // no-filter (index everything) rather than over-restrict.
-  if (tagPatterns.length > 0 || notePatterns.length > 0) {
+  // Any tag/note/property inclusion → whitelist can\'t represent it → fall back to
+  // no-filter (index everything) rather than over-restrict. A property matches on
+  // frontmatter, which no folder/extension term can express.
+  if (tagPatterns.length > 0 || notePatterns.length > 0 || propertyPatterns.length > 0) {
     return EMPTY_MIYO_FOLDER_INCLUSIONS;
   }
 

--- a/src/projects/projectSystemPrompt.test.ts
+++ b/src/projects/projectSystemPrompt.test.ts
@@ -46,6 +46,7 @@ describe("BUILTIN_PROJECT_SYSTEM_PROMPT", () => {
       notes: [],
       extensions: [],
       tags: [],
+      properties: [],
       webUrls: [],
       youtubeUrls: [],
       materialized: [],

--- a/src/search/searchUtils.test.ts
+++ b/src/search/searchUtils.test.ts
@@ -8,6 +8,7 @@ import {
   createPatternSettingsValue,
   getDecodedPatterns,
   getMatchingPatterns,
+  getPropertyPattern,
   getSystemExcludedFolders,
   isInternalExcludedPath,
   parsePropertyPattern,
@@ -728,6 +729,20 @@ describe("searchUtils", () => {
       } finally {
         Object.assign(platform, restore);
       }
+    });
+  });
+
+  describe("getPropertyPattern()", () => {
+    it("returns [key:value] when value is provided", () => {
+      expect(getPropertyPattern("Topics", "Physics")).toBe("[Topics:Physics]");
+    });
+
+    it("returns [key:] when value is omitted", () => {
+      expect(getPropertyPattern("Topics")).toBe("[Topics:]");
+    });
+
+    it("returns [key:] when value is empty string", () => {
+      expect(getPropertyPattern("Topics", "")).toBe("[Topics:]");
     });
   });
 });

--- a/src/search/searchUtils.test.ts
+++ b/src/search/searchUtils.test.ts
@@ -10,6 +10,7 @@ import {
   getMatchingPatterns,
   getSystemExcludedFolders,
   isInternalExcludedPath,
+  parsePropertyPattern,
   previewPatternValue,
   shouldIndexFile,
 } from "./searchUtils";
@@ -64,6 +65,8 @@ jest.mock(
   (): Record<string, unknown> => ({
     ...jest.requireActual("@/utils"),
     getTagsFromNote: jest.fn(),
+    getPropertyValuesFromNote: jest.fn(),
+    noteHasProperty: jest.fn(),
   })
 );
 
@@ -241,6 +244,47 @@ describe("searchUtils", () => {
       };
       expect(shouldIndexFile(window.app, file, null, exclusions)).toBe(false);
     });
+
+    it("should include a note whose property value matches", () => {
+      const file = createTestFile("notes/physics.md");
+      (utils.getPropertyValuesFromNote as jest.Mock).mockReturnValue(["Physics", "Math"]);
+
+      const inclusions = { propertyPatterns: ["[Topics:Physics]"] };
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(true);
+    });
+
+    it("should match a property value case-insensitively", () => {
+      const file = createTestFile("notes/physics.md");
+      (utils.getPropertyValuesFromNote as jest.Mock).mockReturnValue(["physics"]);
+
+      const inclusions = { propertyPatterns: ["[Topics:Physics]"] };
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(true);
+    });
+
+    it("should exclude a note whose property value does not match", () => {
+      const file = createTestFile("notes/chem.md");
+      (utils.getPropertyValuesFromNote as jest.Mock).mockReturnValue(["Chemistry"]);
+
+      const inclusions = { propertyPatterns: ["[Topics:Physics]"] };
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(false);
+    });
+
+    it("should include any note that has the key for a key-only property pattern", () => {
+      const file = createTestFile("notes/any.md");
+      // A key-only pattern matches on key presence, even when the value is empty.
+      (utils.noteHasProperty as jest.Mock).mockReturnValue(true);
+
+      const inclusions = { propertyPatterns: ["[Topics:]"] };
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(true);
+    });
+
+    it("should exclude a note missing the key for a key-only property pattern", () => {
+      const file = createTestFile("notes/none.md");
+      (utils.noteHasProperty as jest.Mock).mockReturnValue(false);
+
+      const inclusions = { propertyPatterns: ["[Topics:]"] };
+      expect(shouldIndexFile(window.app, file, inclusions, null)).toBe(false);
+    });
   });
 
   describe("categorizePatterns", () => {
@@ -288,15 +332,68 @@ describe("searchUtils", () => {
       expect(notePatterns).toEqual(patterns);
     });
 
+    it("should correctly categorize property patterns", () => {
+      const patterns = ["[Topics:Physics]", "[Subject:Einstein]", "[Token:]"];
+      const { propertyPatterns, tagPatterns, folderPatterns, notePatterns } =
+        categorizePatterns(patterns);
+
+      expect(propertyPatterns).toEqual(patterns);
+      expect(tagPatterns).toEqual([]);
+      expect(folderPatterns).toEqual([]);
+      expect(notePatterns).toEqual([]);
+    });
+
+    it("should not mistake a double-bracket note pattern for a property", () => {
+      // A note title may itself contain a colon; the double-bracket form must
+      // still win over the single-bracket property form.
+      const { notePatterns, propertyPatterns } = categorizePatterns(["[[Note 1]]", "[[Topics:x]]"]);
+
+      expect(notePatterns).toEqual(["[[Note 1]]", "[[Topics:x]]"]);
+      expect(propertyPatterns).toEqual([]);
+    });
+
+    it("should treat a bracketed value with an empty key as a folder, not a property", () => {
+      const { folderPatterns, propertyPatterns } = categorizePatterns(["[:onlyvalue]"]);
+
+      expect(propertyPatterns).toEqual([]);
+      expect(folderPatterns).toEqual(["[:onlyvalue]"]);
+    });
+
     it("should correctly categorize mixed patterns", () => {
-      const patterns = ["#important", "*.pdf", "folder1", "[[Note 1]]"];
-      const { tagPatterns, extensionPatterns, folderPatterns, notePatterns } =
+      const patterns = ["#important", "*.pdf", "folder1", "[[Note 1]]", "[Topics:Physics]"];
+      const { tagPatterns, extensionPatterns, folderPatterns, notePatterns, propertyPatterns } =
         categorizePatterns(patterns);
 
       expect(tagPatterns).toEqual(["#important"]);
       expect(extensionPatterns).toEqual(["*.pdf"]);
       expect(folderPatterns).toEqual(["folder1"]);
       expect(notePatterns).toEqual(["[[Note 1]]"]);
+      expect(propertyPatterns).toEqual(["[Topics:Physics]"]);
+    });
+  });
+
+  describe("parsePropertyPattern()", () => {
+    it("splits a property pattern into trimmed key and value", () => {
+      expect(parsePropertyPattern("[Topics:Physics]")).toEqual({
+        key: "Topics",
+        value: "Physics",
+      });
+    });
+
+    it("keeps spaces and later colons inside the value by splitting on the first colon", () => {
+      expect(parsePropertyPattern("[Subject:2024: a talk]")).toEqual({
+        key: "Subject",
+        value: "2024: a talk",
+      });
+    });
+
+    it("returns an empty value for a key-only pattern", () => {
+      expect(parsePropertyPattern("[Topics:]")).toEqual({ key: "Topics", value: "" });
+    });
+
+    it("returns null for a non-property pattern", () => {
+      expect(parsePropertyPattern("[[Note]]")).toBeNull();
+      expect(parsePropertyPattern("folder1")).toBeNull();
     });
   });
 
@@ -376,6 +473,21 @@ describe("searchUtils", () => {
       });
       expect(result).toBe("%23tag1,%23tag2,*.pdf,%5B%5BNote%201%5D%5D,folder1");
     });
+
+    it("should round-trip a property pattern through categorizePatterns", () => {
+      const value = createPatternSettingsValue({ propertyPatterns: ["[Topics:Physics]"] });
+      expect(categorizePatterns(getDecodedPatterns(value)).propertyPatterns).toEqual([
+        "[Topics:Physics]",
+      ]);
+    });
+
+    it("should round-trip a property value containing commas and percent signs", () => {
+      // The stored form is a comma-joined, percent-encoded list, so a value with
+      // its own commas or percent signs must survive encode -> decode intact.
+      const pattern = "[Topics:a, b 50%]";
+      const value = createPatternSettingsValue({ propertyPatterns: [pattern] });
+      expect(categorizePatterns(getDecodedPatterns(value)).propertyPatterns).toEqual([pattern]);
+    });
   });
 
   describe("getDecodedPatterns", () => {
@@ -446,6 +558,7 @@ describe("searchUtils", () => {
         extensionPatterns: ["*.pdf"],
         tagPatterns: ["#important"],
         notePatterns: ["[[Note 1]]"],
+        propertyPatterns: [],
       });
       expect(exclusions).toBeNull();
     });
@@ -464,6 +577,7 @@ describe("searchUtils", () => {
         tagPatterns: ["#draft"],
         extensionPatterns: ["*.tmp"],
         notePatterns: [],
+        propertyPatterns: [],
       });
     });
 
@@ -480,12 +594,14 @@ describe("searchUtils", () => {
         tagPatterns: ["#important"],
         extensionPatterns: [],
         notePatterns: [],
+        propertyPatterns: [],
       });
       expect(exclusions).toEqual({
         folderPatterns: ["private"],
         tagPatterns: ["#draft"],
         extensionPatterns: [],
         notePatterns: [],
+        propertyPatterns: [],
       });
     });
   });

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -394,6 +394,18 @@ function matchFilePathWithTags(app: App, file: TFile, tagPatterns: string[]): bo
  * case-insensitively after trimming, and a list property matches when any of
  * its elements matches; a key-only pattern (`[key:]`) matches any note that
  * has the key.
+ *
+ * DESIGN NOTE — the KEY is matched case-sensitively while the VALUE is not.
+ * Obsidian folds only its reserved keys (`tags`, `aliases`, `cssclasses`); a
+ * user-defined key keeps the exact spelling it was written with, and the
+ * metadata cache exposes the raw frontmatter object, so `Topics` and `topics`
+ * are genuinely two keys. The picker enumerates real vault keys, so it offers
+ * whichever spellings actually exist and a chosen one always matches the notes
+ * it came from. Folding keys was considered and rejected: it would have to pick
+ * a winner when both spellings exist with different values, and it would make
+ * `[key:]` match notes the user never declared under that spelling.
+ * If a future review flags the case-sensitive key lookup again, point them here.
+ *
  * @param propertyPatterns - The property patterns to match the note against.
  * @returns True if the note satisfies any property pattern, false otherwise.
  */

--- a/src/search/searchUtils.ts
+++ b/src/search/searchUtils.ts
@@ -6,7 +6,7 @@ import { logError, logInfo, logWarn } from "@/logger";
 import { getSettings, normalizeRootFolders, type CopilotSettings } from "@/settings/model";
 import { getEffectiveProjectsFolder } from "@/settings/copilotFolder";
 import { logFileManager } from "@/logFileManager";
-import { getTagsFromNote, stripHash } from "@/utils";
+import { getPropertyValuesFromNote, getTagsFromNote, noteHasProperty, stripHash } from "@/utils";
 import { Embeddings } from "@langchain/core/embeddings";
 import { App, Platform, TFile } from "obsidian";
 
@@ -15,6 +15,7 @@ export interface PatternCategory {
   extensionPatterns?: string[];
   folderPatterns?: string[];
   notePatterns?: string[];
+  propertyPatterns?: string[];
 }
 
 export async function getVectorLength(embeddingInstance: Embeddings | undefined): Promise<number> {
@@ -285,10 +286,25 @@ export function categorizePatterns(patterns: string[]) {
   const extensionPatterns: string[] = [];
   const folderPatterns: string[] = [];
   const notePatterns: string[] = [];
+  const propertyPatterns: string[] = [];
 
   const tagRegex = /^#[^\s#]+$/; // Matches #tag format
   const extensionRegex = /^\*\.([a-zA-Z0-9.]+)$/; // Matches *.extension format
   const noteRegex = /^\[\[(.*?)\]\]$/; // Matches [[note name]] format - removed global flag and added ^ $
+  // Matches the single-bracket [key:value] property form. Tested after noteRegex
+  // (double-bracket) so it never swallows a [[note]], and before the folder
+  // fallthrough so it isn't mistaken for a folder path.
+  //
+  // DESIGN NOTE: like #tag, *.ext, and [[note]], a pattern is an untyped string
+  // classified purely by its shape — there is no per-entry type tag and no
+  // migration. A pre-existing folder pattern shaped exactly like [key:value] would
+  // now be read as a property, but that requires a ":" inside a folder name, which
+  // Obsidian's primary platforms (macOS/Windows) forbid; the identical
+  // shape-ambiguity already exists for a folder literally named [[x]]. Reserving
+  // this shape for properties keeps the grammar consistent; a typed marker would
+  // change the serialized format for every source. If a future review flags this,
+  // point them here.
+  const propertyRegex = /^\[([^[\]:]+):(.*)\]$/;
 
   patterns.forEach((pattern) => {
     if (tagRegex.test(pattern)) {
@@ -297,12 +313,29 @@ export function categorizePatterns(patterns: string[]) {
       extensionPatterns.push(pattern);
     } else if (noteRegex.test(pattern)) {
       notePatterns.push(pattern);
+    } else if (propertyRegex.test(pattern)) {
+      propertyPatterns.push(pattern);
     } else {
       folderPatterns.push(pattern);
     }
   });
 
-  return { tagPatterns, extensionPatterns, folderPatterns, notePatterns };
+  return { tagPatterns, extensionPatterns, folderPatterns, notePatterns, propertyPatterns };
+}
+
+/**
+ * Split a `[key:value]` property pattern into its key and value. Splits on the
+ * first colon only, so a value may itself contain spaces and colons (the reason
+ * some vaults use frontmatter properties instead of tags).
+ *
+ * @param pattern - A property pattern produced by {@link getPropertyPattern}.
+ * @returns The trimmed key and value, or null when the input is not a property
+ * pattern. A key-only pattern (`[key:]`) yields an empty-string value.
+ */
+export function parsePropertyPattern(pattern: string): { key: string; value: string } | null {
+  const match = pattern.match(/^\[([^[\]:]+):(.*)\]$/);
+  if (!match) return null;
+  return { key: match[1].trim(), value: match[2].trim() };
 }
 
 /**
@@ -328,11 +361,13 @@ export function createPatternSettingsValue({
   extensionPatterns,
   folderPatterns,
   notePatterns,
+  propertyPatterns,
 }: PatternCategory) {
   const patterns = [
     ...(tagPatterns ?? []),
     ...(extensionPatterns ?? []),
     ...(notePatterns ?? []),
+    ...(propertyPatterns ?? []),
     ...(folderPatterns ?? []),
   ].map((pattern) => encodeURIComponent(pattern));
 
@@ -352,6 +387,27 @@ function matchFilePathWithTags(app: App, file: TFile, tagPatterns: string[]): bo
   return tagPatterns.some((pattern) =>
     tags.some((tag) => tag.toLowerCase() === stripHash(pattern).toLowerCase())
   );
+}
+
+/**
+ * Match a note against `[key:value]` property patterns. A value matches
+ * case-insensitively after trimming, and a list property matches when any of
+ * its elements matches; a key-only pattern (`[key:]`) matches any note that
+ * has the key.
+ * @param propertyPatterns - The property patterns to match the note against.
+ * @returns True if the note satisfies any property pattern, false otherwise.
+ */
+function matchFilePathWithProperties(app: App, file: TFile, propertyPatterns: string[]): boolean {
+  if (propertyPatterns.length === 0) return false;
+
+  return propertyPatterns.some((pattern) => {
+    const parsed = parsePropertyPattern(pattern);
+    if (!parsed) return false;
+    if (parsed.value === "") return noteHasProperty(app, file, parsed.key);
+    const values = getPropertyValuesFromNote(app, file, parsed.key);
+    const target = parsed.value.toLowerCase();
+    return values.some((value) => value.trim().toLowerCase() === target);
+  });
 }
 
 /**
@@ -421,13 +477,15 @@ function matchFilePathWithNotes(file: TFile, noteTitles: string[]): boolean {
 function matchFilePathWithPatterns(app: App, file: TFile, patterns: PatternCategory): boolean {
   if (!patterns) return false;
 
-  const { tagPatterns, extensionPatterns, folderPatterns, notePatterns } = patterns;
+  const { tagPatterns, extensionPatterns, folderPatterns, notePatterns, propertyPatterns } =
+    patterns;
 
   return (
     matchFilePathWithTags(app, file, tagPatterns ?? []) ||
     matchFilePathWithExtensions(file.path, extensionPatterns ?? []) ||
     matchFilePathWithFolders(file.path, folderPatterns ?? []) ||
-    matchFilePathWithNotes(file, notePatterns ?? [])
+    matchFilePathWithNotes(file, notePatterns ?? []) ||
+    matchFilePathWithProperties(app, file, propertyPatterns ?? [])
   );
 }
 
@@ -459,6 +517,14 @@ export function extractAppIgnoreSettings(app: App): string[] {
 
 export function getTagPattern(tag: string): string {
   return `#${tag}`;
+}
+
+/**
+ * Build a `[key:value]` property inclusion pattern. Omitting the value yields
+ * the key-only form `[key:]`, which matches any note that has the key.
+ */
+export function getPropertyPattern(key: string, value?: string): string {
+  return value ? `[${key}:${value}]` : `[${key}:]`;
 }
 
 export function getFilePattern(file: TFile): string {

--- a/src/settings/v2/components/PatternListEditor.tsx
+++ b/src/settings/v2/components/PatternListEditor.tsx
@@ -69,6 +69,13 @@ export const PatternListEditor: React.FC<PatternListEditorProps> = ({
   // Parse and deduplicate patterns
   const patterns = useMemo(() => getUniquePatterns(value), [value]);
 
+  // DESIGN NOTE — this editor owns four of the five categories `categorizePatterns`
+  // returns. The fifth, `propertyPatterns`, belongs to project context; here it has
+  // no badge, and the rebuilds in `updatePatterns` and `handleAddCustom` name their
+  // keys explicitly, so a property pattern typed in or synced from elsewhere is
+  // dropped on the next edit. The matcher itself honours stored property patterns,
+  // which is why nothing in this UI may offer `[key:value]` until the editor can
+  // show and remove them. If a future review flags this again, point them at this note.
   const { tagPatterns, extensionPatterns, folderPatterns, notePatterns } = useMemo(
     () => categorizePatterns(patterns),
     [patterns]

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -7,6 +7,8 @@ import {
   getModelInfo,
   getNotesFromPath,
   getNotesFromTags,
+  getPropertyValuesFromNote,
+  noteHasProperty,
   getUtf8ByteLength,
   insertAtCursor,
   isFolderMatch,
@@ -340,6 +342,95 @@ describe("getNotesFromTags", () => {
     const result = getNotesFromTags(mockApp, tags);
 
     expect(result).toEqual([]); // Should return empty since inline tags are ignored
+  });
+});
+
+describe("getPropertyValuesFromNote()", () => {
+  // getPropertyValuesFromNote only reads app.metadataCache.getFileCache(file),
+  // which is mocked per-case, so the file argument itself is never inspected.
+  const file = new TFile();
+  const withFrontmatter = (frontmatter: Record<string, unknown>) =>
+    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter });
+
+  beforeEach(() => {
+    mockMetadataCache.getFileCache.mockReset();
+  });
+
+  it("returns each element of a list property as a string", () => {
+    withFrontmatter({ Topics: ["Physics", "Math"] });
+    expect(getPropertyValuesFromNote(mockApp, file, "Topics")).toEqual(["Physics", "Math"]);
+  });
+
+  it("wraps a scalar property in a single-element array", () => {
+    withFrontmatter({ Subject: "Einstein" });
+    expect(getPropertyValuesFromNote(mockApp, file, "Subject")).toEqual(["Einstein"]);
+  });
+
+  it("stringifies non-string scalar values", () => {
+    withFrontmatter({ Year: 2024 });
+    expect(getPropertyValuesFromNote(mockApp, file, "Year")).toEqual(["2024"]);
+  });
+
+  it("returns an empty array when the key is absent", () => {
+    withFrontmatter({ Topics: ["Physics"] });
+    expect(getPropertyValuesFromNote(mockApp, file, "Subject")).toEqual([]);
+  });
+
+  it("returns an empty array when the note has no frontmatter", () => {
+    mockMetadataCache.getFileCache.mockReturnValue({});
+    expect(getPropertyValuesFromNote(mockApp, file, "Topics")).toEqual([]);
+  });
+
+  it("drops non-scalar values instead of collapsing them to [object Object]", () => {
+    withFrontmatter({ meta: { owner: "Alice" } });
+    expect(getPropertyValuesFromNote(mockApp, file, "meta")).toEqual([]);
+  });
+
+  it("keeps only the scalar elements of a mixed list", () => {
+    withFrontmatter({ Topics: ["Physics", { nested: true }, 2024] });
+    expect(getPropertyValuesFromNote(mockApp, file, "Topics")).toEqual(["Physics", "2024"]);
+  });
+
+  it("returns an empty array for a key inherited from Object.prototype", () => {
+    withFrontmatter({ Topics: "Physics" });
+    expect(getPropertyValuesFromNote(mockApp, file, "constructor")).toEqual([]);
+  });
+});
+
+describe("noteHasProperty()", () => {
+  const file = new TFile();
+
+  beforeEach(() => {
+    mockMetadataCache.getFileCache.mockReset();
+  });
+
+  it("returns true when the key is present with a value", () => {
+    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: "Physics" } });
+    expect(noteHasProperty(mockApp, file, "Topics")).toBe(true);
+  });
+
+  it("returns true when the key is present but its value is empty or null", () => {
+    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: null } });
+    expect(noteHasProperty(mockApp, file, "Topics")).toBe(true);
+
+    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: [] } });
+    expect(noteHasProperty(mockApp, file, "Topics")).toBe(true);
+  });
+
+  it("returns false when the key is absent", () => {
+    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Subject: "x" } });
+    expect(noteHasProperty(mockApp, file, "Topics")).toBe(false);
+  });
+
+  it("returns false when the note has no frontmatter", () => {
+    mockMetadataCache.getFileCache.mockReturnValue({});
+    expect(noteHasProperty(mockApp, file, "Topics")).toBe(false);
+  });
+
+  it("returns false for a key inherited from Object.prototype", () => {
+    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: "Physics" } });
+    expect(noteHasProperty(mockApp, file, "constructor")).toBe(false);
+    expect(noteHasProperty(mockApp, file, "toString")).toBe(false);
   });
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -345,92 +345,94 @@ describe("getNotesFromTags", () => {
   });
 });
 
-describe("getPropertyValuesFromNote()", () => {
-  // getPropertyValuesFromNote only reads app.metadataCache.getFileCache(file),
-  // which is mocked per-case, so the file argument itself is never inspected.
-  const file = new TFile();
-  const withFrontmatter = (frontmatter: Record<string, unknown>) =>
-    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter });
+describe("utils", () => {
+  describe("getPropertyValuesFromNote()", () => {
+    // getPropertyValuesFromNote only reads app.metadataCache.getFileCache(file),
+    // which is mocked per-case, so the file argument itself is never inspected.
+    const file = new TFile();
+    const withFrontmatter = (frontmatter: Record<string, unknown>) =>
+      mockMetadataCache.getFileCache.mockReturnValue({ frontmatter });
 
-  beforeEach(() => {
-    mockMetadataCache.getFileCache.mockReset();
+    beforeEach(() => {
+      mockMetadataCache.getFileCache.mockReset();
+    });
+
+    it("returns each element of a list property as a string", () => {
+      withFrontmatter({ Topics: ["Physics", "Math"] });
+      expect(getPropertyValuesFromNote(mockApp, file, "Topics")).toEqual(["Physics", "Math"]);
+    });
+
+    it("wraps a scalar property in a single-element array", () => {
+      withFrontmatter({ Subject: "Einstein" });
+      expect(getPropertyValuesFromNote(mockApp, file, "Subject")).toEqual(["Einstein"]);
+    });
+
+    it("stringifies non-string scalar values", () => {
+      withFrontmatter({ Year: 2024 });
+      expect(getPropertyValuesFromNote(mockApp, file, "Year")).toEqual(["2024"]);
+    });
+
+    it("returns an empty array when the key is absent", () => {
+      withFrontmatter({ Topics: ["Physics"] });
+      expect(getPropertyValuesFromNote(mockApp, file, "Subject")).toEqual([]);
+    });
+
+    it("returns an empty array when the note has no frontmatter", () => {
+      mockMetadataCache.getFileCache.mockReturnValue({});
+      expect(getPropertyValuesFromNote(mockApp, file, "Topics")).toEqual([]);
+    });
+
+    it("drops non-scalar values instead of collapsing them to [object Object]", () => {
+      withFrontmatter({ meta: { owner: "Alice" } });
+      expect(getPropertyValuesFromNote(mockApp, file, "meta")).toEqual([]);
+    });
+
+    it("keeps only the scalar elements of a mixed list", () => {
+      withFrontmatter({ Topics: ["Physics", { nested: true }, 2024] });
+      expect(getPropertyValuesFromNote(mockApp, file, "Topics")).toEqual(["Physics", "2024"]);
+    });
+
+    it("returns an empty array for a key inherited from Object.prototype", () => {
+      withFrontmatter({ Topics: "Physics" });
+      expect(getPropertyValuesFromNote(mockApp, file, "constructor")).toEqual([]);
+    });
   });
 
-  it("returns each element of a list property as a string", () => {
-    withFrontmatter({ Topics: ["Physics", "Math"] });
-    expect(getPropertyValuesFromNote(mockApp, file, "Topics")).toEqual(["Physics", "Math"]);
-  });
+  describe("noteHasProperty()", () => {
+    const file = new TFile();
 
-  it("wraps a scalar property in a single-element array", () => {
-    withFrontmatter({ Subject: "Einstein" });
-    expect(getPropertyValuesFromNote(mockApp, file, "Subject")).toEqual(["Einstein"]);
-  });
+    beforeEach(() => {
+      mockMetadataCache.getFileCache.mockReset();
+    });
 
-  it("stringifies non-string scalar values", () => {
-    withFrontmatter({ Year: 2024 });
-    expect(getPropertyValuesFromNote(mockApp, file, "Year")).toEqual(["2024"]);
-  });
+    it("returns true when the key is present with a value", () => {
+      mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: "Physics" } });
+      expect(noteHasProperty(mockApp, file, "Topics")).toBe(true);
+    });
 
-  it("returns an empty array when the key is absent", () => {
-    withFrontmatter({ Topics: ["Physics"] });
-    expect(getPropertyValuesFromNote(mockApp, file, "Subject")).toEqual([]);
-  });
+    it("returns true when the key is present but its value is empty or null", () => {
+      mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: null } });
+      expect(noteHasProperty(mockApp, file, "Topics")).toBe(true);
 
-  it("returns an empty array when the note has no frontmatter", () => {
-    mockMetadataCache.getFileCache.mockReturnValue({});
-    expect(getPropertyValuesFromNote(mockApp, file, "Topics")).toEqual([]);
-  });
+      mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: [] } });
+      expect(noteHasProperty(mockApp, file, "Topics")).toBe(true);
+    });
 
-  it("drops non-scalar values instead of collapsing them to [object Object]", () => {
-    withFrontmatter({ meta: { owner: "Alice" } });
-    expect(getPropertyValuesFromNote(mockApp, file, "meta")).toEqual([]);
-  });
+    it("returns false when the key is absent", () => {
+      mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Subject: "x" } });
+      expect(noteHasProperty(mockApp, file, "Topics")).toBe(false);
+    });
 
-  it("keeps only the scalar elements of a mixed list", () => {
-    withFrontmatter({ Topics: ["Physics", { nested: true }, 2024] });
-    expect(getPropertyValuesFromNote(mockApp, file, "Topics")).toEqual(["Physics", "2024"]);
-  });
+    it("returns false when the note has no frontmatter", () => {
+      mockMetadataCache.getFileCache.mockReturnValue({});
+      expect(noteHasProperty(mockApp, file, "Topics")).toBe(false);
+    });
 
-  it("returns an empty array for a key inherited from Object.prototype", () => {
-    withFrontmatter({ Topics: "Physics" });
-    expect(getPropertyValuesFromNote(mockApp, file, "constructor")).toEqual([]);
-  });
-});
-
-describe("noteHasProperty()", () => {
-  const file = new TFile();
-
-  beforeEach(() => {
-    mockMetadataCache.getFileCache.mockReset();
-  });
-
-  it("returns true when the key is present with a value", () => {
-    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: "Physics" } });
-    expect(noteHasProperty(mockApp, file, "Topics")).toBe(true);
-  });
-
-  it("returns true when the key is present but its value is empty or null", () => {
-    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: null } });
-    expect(noteHasProperty(mockApp, file, "Topics")).toBe(true);
-
-    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: [] } });
-    expect(noteHasProperty(mockApp, file, "Topics")).toBe(true);
-  });
-
-  it("returns false when the key is absent", () => {
-    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Subject: "x" } });
-    expect(noteHasProperty(mockApp, file, "Topics")).toBe(false);
-  });
-
-  it("returns false when the note has no frontmatter", () => {
-    mockMetadataCache.getFileCache.mockReturnValue({});
-    expect(noteHasProperty(mockApp, file, "Topics")).toBe(false);
-  });
-
-  it("returns false for a key inherited from Object.prototype", () => {
-    mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: "Physics" } });
-    expect(noteHasProperty(mockApp, file, "constructor")).toBe(false);
-    expect(noteHasProperty(mockApp, file, "toString")).toBe(false);
+    it("returns false for a key inherited from Object.prototype", () => {
+      mockMetadataCache.getFileCache.mockReturnValue({ frontmatter: { Topics: "Physics" } });
+      expect(noteHasProperty(mockApp, file, "constructor")).toBe(false);
+      expect(noteHasProperty(mockApp, file, "toString")).toBe(false);
+    });
   });
 });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -396,6 +396,30 @@ describe("utils", () => {
       withFrontmatter({ Topics: "Physics" });
       expect(getPropertyValuesFromNote(mockApp, file, "constructor")).toEqual([]);
     });
+
+    it("returns the canonical empty array for null values", () => {
+      withFrontmatter({ Topics: null });
+      const result1 = getPropertyValuesFromNote(mockApp, file, "Topics");
+      const result2 = getPropertyValuesFromNote(mockApp, file, "Topics");
+      expect(result1).toEqual([]);
+      expect(result1).toBe(result2); // referential stability
+    });
+
+    it("returns the canonical empty array for empty list values", () => {
+      withFrontmatter({ Topics: [] });
+      const result1 = getPropertyValuesFromNote(mockApp, file, "Topics");
+      const result2 = getPropertyValuesFromNote(mockApp, file, "Topics");
+      expect(result1).toEqual([]);
+      expect(result1).toBe(result2); // referential stability
+    });
+
+    it("returns the canonical empty array for non-scalar-only lists", () => {
+      withFrontmatter({ Topics: [{ nested: true }, { another: "object" }] });
+      const result1 = getPropertyValuesFromNote(mockApp, file, "Topics");
+      const result2 = getPropertyValuesFromNote(mockApp, file, "Topics");
+      expect(result1).toEqual([]);
+      expect(result1).toBe(result2); // referential stability
+    });
   });
 
   describe("noteHasProperty()", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -230,6 +230,9 @@ export function getTagsFromNote(app: App, file: TFile, frontmatterOnly = true): 
   return Array.from(allTags);
 }
 
+/** Canonical empty array for property values, frozen for referential stability. */
+const EMPTY_PROPERTY_VALUES = Object.freeze([]) as unknown as string[];
+
 /**
  * Read the values of a single frontmatter property from a note. Backs the
  * Project "Property" context source, which includes notes by a user-defined
@@ -248,7 +251,7 @@ export function getPropertyValuesFromNote(app: App, file: TFile, key: string): s
   // member — e.g. `key: "constructor"` on a note without it would otherwise
   // surface the prototype's function value.
   if (!frontmatter || !Object.hasOwn(frontmatter, key)) {
-    return [];
+    return EMPTY_PROPERTY_VALUES;
   }
   const raw = (frontmatter as Record<string, unknown>)[key];
   // Reason: only scalars round-trip through the `[key:value]` grammar. An object

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -231,6 +231,61 @@ export function getTagsFromNote(app: App, file: TFile, frontmatterOnly = true): 
 }
 
 /**
+ * Read the values of a single frontmatter property from a note. Backs the
+ * Project "Property" context source, which includes notes by a user-defined
+ * frontmatter field (e.g. `Topics: Physics`) rather than by tag — the taxonomy
+ * some vaults use in place of tags, which forbid spaces and slugs.
+ *
+ * @param app - The Obsidian app instance.
+ * @param file - The note whose frontmatter is read.
+ * @param key - The frontmatter property name to read.
+ * @returns The property's values as strings: each element for a list property,
+ * a single element for a scalar, and an empty array when the key is absent.
+ */
+export function getPropertyValuesFromNote(app: App, file: TFile, key: string): string[] {
+  const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+  // Reason: `hasOwnProperty` (not `in`) so an absent key never reads an inherited
+  // member — e.g. `key: "constructor"` on a note without it would otherwise
+  // surface the prototype's function value.
+  if (!frontmatter || !Object.hasOwn(frontmatter, key)) {
+    return [];
+  }
+  const raw = (frontmatter as Record<string, unknown>)[key];
+  // Reason: only scalars round-trip through the `[key:value]` grammar. An object
+  // value would collapse to "[object Object]" (many distinct maps → one indistinct
+  // value), so drop non-scalars here rather than match on an ambiguous string.
+  const values: unknown[] = Array.isArray(raw) ? (raw as unknown[]) : [raw];
+  const scalars = values.filter(isScalarPropertyValue);
+  return scalars.map((value) => String(value));
+}
+
+/** Whether a frontmatter value is a scalar that the `[key:value]` grammar can represent. */
+function isScalarPropertyValue(value: unknown): value is string | number | boolean {
+  const type = typeof value;
+  return type === "string" || type === "number" || type === "boolean";
+}
+
+/**
+ * Whether a note declares a frontmatter property, regardless of its value.
+ * Backs the key-only Project property source (`[key:]`): a note with an empty
+ * or null-valued key (e.g. `Topics:` or `Topics: []`) still has the key and so
+ * must match, which a values-length check would miss.
+ *
+ * @param app - The Obsidian app instance.
+ * @param file - The note whose frontmatter is inspected.
+ * @param key - The frontmatter property name to look for.
+ * @returns True when the note's frontmatter contains the key.
+ */
+export function noteHasProperty(app: App, file: TFile, key: string): boolean {
+  const frontmatter: Record<string, unknown> | undefined =
+    app.metadataCache.getFileCache(file)?.frontmatter;
+  // Reason: `hasOwnProperty` (not `in`) so `[constructor:]` / `[toString:]` match
+  // only notes that actually declare that key, not every note whose frontmatter
+  // inherits it from Object.prototype.
+  return frontmatter != null && Object.hasOwn(frontmatter, key);
+}
+
+/**
  * Get notes from tags.
  * @param app - The Obsidian app instance.
  * @param tags - The tags to get notes from. Tags should be with the hash symbol.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -259,6 +259,9 @@ export function getPropertyValuesFromNote(app: App, file: TFile, key: string): s
   // value), so drop non-scalars here rather than match on an ambiguous string.
   const values: unknown[] = Array.isArray(raw) ? (raw as unknown[]) : [raw];
   const scalars = values.filter(isScalarPropertyValue);
+  if (scalars.length === 0) {
+    return EMPTY_PROPERTY_VALUES;
+  }
   return scalars.map((value) => String(value));
 }
 


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#222

_Cross-repo `Fixes` did not register a closing reference on this PR (`closingIssuesReferences` is empty), so the issue needs a manual close on merge._

## Problem

A Project can include notes by tag, extension, note link, or folder — nothing else. Obsidian tags are slug-only and forbid spaces, so a vault that organizes by frontmatter fields (`Topics: Quantum Mechanics`, `Subject: Organic Chemistry`) cannot express its own taxonomy as a Project source. `categorizePatterns` in `src/search/searchUtils.ts` recognized four pattern shapes and dropped everything else into `folderPatterns`, so there was no syntax a user could type to say "every note whose `Topics` is `Physics`". Those users had to hand-add each note, and re-add on every new note.

## Fix

A fifth context source, Property, matching on frontmatter:

- `[key:value]` — the note's `key` equals `value` (case-insensitive, trimmed; a list property matches when any element matches).
- `[key:]` — the note declares `key`, whatever its value.

The pattern is classified **by shape**, reusing the existing untyped-string grammar of `#tag` / `*.ext` / `[[note]]`. That choice is what keeps the diff small: no per-entry type tag, no new persisted format, and therefore no migration — existing `contextSource.inclusions` strings load unchanged.

The rejected alternative was a typed marker (`property:[key:value]`). It removes a shape ambiguity that is already accepted elsewhere in this grammar — a folder literally named `[[x]]` reads as a note today — and it would have changed the serialized format for every source type. A `DESIGN NOTE` beside `propertyRegex` records this, including why the ambiguity is not reachable in practice: a colliding folder name needs a `:`, which macOS and Windows forbid.

Property matches are **enumerated concretely** in the manifest, unlike folders and tags, which are listed as labels the agent expands with its own search. A frontmatter value is a vault-specific taxonomy, not a grep-able `#tag`, so the agent cannot discover those notes on its own.

## Scope

Budget gate: PASS — 20 files, +1327/−56 against `v4-preview`. Production is +593/−34 across 10 files; the remaining +734 is unit coverage. Every new helper has a named production caller, and the superseded `declaresFrontmatterPattern` was deleted rather than left beside its replacement.

The smallest shape that solves this: one new bucket in the existing pattern grammar plus one matcher, reusing `shouldIndexFile` for enumeration rather than adding a parallel filtering path.

## Changes

- **`src/search/searchUtils.ts`** — `categorizePatterns` gains a `propertyPatterns` bucket (tested after `noteRegex` so it never swallows a `[[note]]`, before the folder fallthrough so it is not mistaken for a path). `parsePropertyPattern` splits on the first colon only, so a value may contain spaces and colons. `matchFilePathWithProperties` joins the existing matcher chain.
- **`src/utils.ts`** — `getPropertyValuesFromNote` reads a note's values (own-property via `Object.hasOwn`, scalars only, so an object value cannot collapse to `[object Object]` and match unrelated notes). `noteHasProperty` backs the key-only form; using `Object.hasOwn` rather than `in` is what stops `[constructor:]` from matching every note with frontmatter.
- **`src/context/projectContextMaterializer.ts`** — resolves property inclusions through the shared `shouldIndexFile` contract, so match semantics stay identical to indexing/QA, and merges the results into the note set deduped against other sources.
- **`src/context/projectContentTracker.ts`** — adds a `metadataCache` `"changed"` listener. The metadata cache re-parses frontmatter *after* the vault `modify` event, so resolving a property source on `modify` reads a stale cache and never re-resolves. The event dirties a project only when its inclusions declare a property pattern, leaving tag/folder/note/extension projects untouched. Property reachability additionally skips the system Copilot roots that enumeration can never return; the tag predicate keeps its pre-existing, broader rule.
- **`src/context/manifestBuilder.ts`** — emits an `Included properties` label ahead of the enumerated notes, so a broad property's label survives the 100-entry cap.
- **`src/components/modals/PropertySearchModal.tsx`** — a two-step key → value picker over real vault data, never free-typed, filtered through the same `shouldIndexFile` boundary as the materializer so every offered choice can actually match. It drops keys the grammar cannot represent (empty, `position`, colon/bracket, surrounding whitespace) and normalizes values with `trim()` to mirror the matcher — a trailing-newline block scalar is offered in its matching form, while empty/whitespace-only values and any value carrying a line terminator (`\r`, `\n`, U+2028, U+2029) are rejected.
- **`ProjectContextBadgeList.tsx` / `ProjectContextSourceEditor.tsx` / `context-manage-modal.tsx`** — render and manage property sources beside the other types; badges read as `key: value` or `key: (any)`.
- **`src/agentMode/ui/hooks/usePersistentContextDrop.ts`** — carries `propertyPatterns` through the inclusion rebuild, so dropping a file into a project no longer erases its property sources.

## Verification

Commands run, with their actual results:

- `npm run test` — 5279 passed, 7 + 2 integration suites skipped
- `npx tsc --noEmit`, `npm run lint`, `npm run format:check` — all exit 0

Unit coverage added for the new surface: pattern categorization and parsing edge cases, property matching (value / key-only / list / case-insensitivity), the frontmatter helpers (own-property, scalar gate, absent key), picker key and value filtering, the manifest label under the entry cap, tracker invalidation on **both** the metadata and modify axes plus a guard asserting tag behavior is unchanged, and drop persistence.

**End-to-end in a real Obsidian vault**, checked against the captured `session/prompt` payload rather than the agent's own answer — an agent reporting "not found" only proves it did not grep, while the payload is what the backend actually receives:

```
<project_context>
## Included properties
- [Topics:Physics]
- [Subject:]

## Included notes
- `/…/property-e2e-chemistry.md`
- `/…/property-e2e-physics.md`
</project_context>
```

That payload confirms both directions: the two matching notes are present, while a note whose `Topics` does not match and which has no `Subject` is absent, and so is a frontmatter-bearing note inside the Copilot root (system-root exclusion holds). The picker's candidate list excluded `position`, `a:b`, `c[d]`, `" Topics "`, the empty key, and values sourced only from the Copilot root. The agent then answered content questions using only the two included notes. No console errors.

## Notes for reviewers

- **Rebased onto current `v4-preview`** (22 upstream commits). Upstream's `f66133b8` made `shouldIndexFile` exclude the Copilot root unconditionally; this branch adopts that boundary at all three points where the feature enumerates vault files, and the tag predicate's guard is byte-identical to upstream's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
