### PR TITLE
fix(search): enforce live scope in Related Notes

### DIFF
--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -8,6 +8,7 @@ import {
   getVaultRelativeMiyoPath,
   getSearchBackend,
 } from "@/miyo/miyoUtils";
+import { createCopilotPatternFilter } from "@/search/searchUtils";
 import { getSettings, type CopilotSettings } from "@/settings/model";
 import VectorStoreManager from "@/search/vectorStoreManager";
 
@@ -18,6 +19,10 @@ jest.mock("@/noteUtils", () => ({
 
 jest.mock("@/settings/model", () => ({
   getSettings: jest.fn(),
+}));
+
+jest.mock("@/search/searchUtils", () => ({
+  createCopilotPatternFilter: jest.fn(),
 }));
 
 const mockGetDocumentsByPath = jest.fn();
@@ -79,6 +84,9 @@ function createMarkdownFile(path: string): TFile {
 describe("findRelevantNotes", () => {
   const mockedGetSettings = getSettings as jest.MockedFunction<typeof getSettings>;
   const mockedGetSearchBackend = getSearchBackend as jest.MockedFunction<typeof getSearchBackend>;
+  const mockedCreateCopilotPatternFilter = createCopilotPatternFilter as jest.MockedFunction<
+    typeof createCopilotPatternFilter
+  >;
   const mockedGetLinkedNotes = getLinkedNotes as jest.MockedFunction<typeof getLinkedNotes>;
   const mockedGetBacklinkedNotes = getBacklinkedNotes as jest.MockedFunction<
     typeof getBacklinkedNotes
@@ -101,6 +109,7 @@ describe("findRelevantNotes", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedGetSearchBackend.mockReturnValue("keyword");
+    mockedCreateCopilotPatternFilter.mockReturnValue(() => true);
     mockedGetSettings.mockReturnValue({
       debug: false,
       miyoServerUrl: "",
@@ -253,6 +262,30 @@ describe("findRelevantNotes", () => {
       folderName: "vault",
       limit: 20,
     });
+  });
+
+  it("applies the live Copilot scope to semantic and linked candidates", async () => {
+    mockedGetSearchBackend.mockReturnValue("miyo");
+    mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
+    mockSearchRelated.mockResolvedValue({
+      results: [
+        { id: "allowed", path: "vault/beta.md", score: 0.8 },
+        { id: "excluded", path: "vault/alpha.md", score: 0.9 },
+      ],
+    });
+    mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+    const isAllowed = jest.fn((path: string) => path === "beta.md");
+    mockedCreateCopilotPatternFilter.mockReturnValue(isAllowed);
+
+    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+    expect(result.map((entry) => entry.note.path)).toEqual(["beta.md"]);
+    expect(mockedCreateCopilotPatternFilter).toHaveBeenCalledWith(window.app);
+    expect(isAllowed.mock.calls.map(([path]) => path)).toEqual([
+      "beta.md",
+      "alpha.md",
+      "linked-only.md",
+    ]);
   });
 
   it("falls back to Miyo when Orama docs exist but have no embeddings and have content", async () => {

--- a/src/search/findRelevantNotes.test.ts
+++ b/src/search/findRelevantNotes.test.ts
@@ -106,243 +106,247 @@ describe("findRelevantNotes", () => {
   };
   const mockedMiyoClient = MiyoClient as unknown as jest.Mock;
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockedGetSearchBackend.mockReturnValue("keyword");
-    mockedCreateCopilotPatternFilter.mockReturnValue(() => true);
-    mockedGetSettings.mockReturnValue({
-      debug: false,
-      miyoServerUrl: "",
-      enableMiyo: false,
-      enableSemanticSearchV3: false,
-    } as CopilotSettings);
-    mockedGetLinkedNotes.mockReturnValue([]);
-    mockedGetBacklinkedNotes.mockReturnValue([]);
-    mockedGetMiyoFolderName.mockReturnValue("vault");
-    mockedGetMiyoFilePath.mockImplementation((_: unknown, path: string) => `vault/${path}`);
-    mockedGetVaultRelativeMiyoPath.mockImplementation((_: unknown, path: string) =>
-      path.replace(/^vault\//, "")
-    );
+  describe("findRelevantNotes()", () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockedGetSearchBackend.mockReturnValue("keyword");
+      mockedCreateCopilotPatternFilter.mockReturnValue(() => true);
+      mockedGetSettings.mockReturnValue({
+        debug: false,
+        miyoServerUrl: "",
+        enableMiyo: false,
+        enableSemanticSearchV3: false,
+      } as CopilotSettings);
+      mockedGetLinkedNotes.mockReturnValue([]);
+      mockedGetBacklinkedNotes.mockReturnValue([]);
+      mockedGetMiyoFolderName.mockReturnValue("vault");
+      mockedGetMiyoFilePath.mockImplementation((_: unknown, path: string) => `vault/${path}`);
+      mockedGetVaultRelativeMiyoPath.mockImplementation((_: unknown, path: string) =>
+        path.replace(/^vault\//, "")
+      );
 
-    const source = createMarkdownFile("source.md");
-    const first = createMarkdownFile("first.md");
-    const second = createMarkdownFile("second.md");
-    const alpha = createMarkdownFile("alpha.md");
-    const beta = createMarkdownFile("beta.md");
-    const linkedOnly = createMarkdownFile("linked-only.md");
+      const source = createMarkdownFile("source.md");
+      const first = createMarkdownFile("first.md");
+      const second = createMarkdownFile("second.md");
+      const alpha = createMarkdownFile("alpha.md");
+      const beta = createMarkdownFile("beta.md");
+      const linkedOnly = createMarkdownFile("linked-only.md");
 
-    const filesByPath = new Map<string, TFile>([
-      ["source.md", source],
-      ["first.md", first],
-      ["second.md", second],
-      ["alpha.md", alpha],
-      ["beta.md", beta],
-      ["linked-only.md", linkedOnly],
-    ]);
-
-    (window.app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((path: string) => {
-      return filesByPath.get(path) ?? null;
-    });
-
-    mockedVectorStoreManager
-      .getInstance()
-      .getDocumentsByPath.mockImplementation(mockGetDocumentsByPath);
-    mockedVectorStoreManager.getInstance().getDb.mockImplementation(mockGetDb);
-    mockedMiyoClient.mockImplementation(() => ({
-      resolveBaseUrl: mockResolveBaseUrl,
-      searchRelated: mockSearchRelated,
-    }));
-  });
-
-  it("uses Orama similarity scoring when source note has embeddings", async () => {
-    mockGetDocumentsByPath.mockResolvedValue([
-      {
-        id: "chunk-1",
-        path: "source.md",
-        content: "chunk one",
-        embedding: [0.1, 0.2],
-      },
-      {
-        id: "chunk-2",
-        path: "source.md",
-        content: "chunk two",
-        embedding: [0.3, 0.4],
-      },
-    ]);
-    mockGetDb.mockResolvedValue({ db: "orama" });
-    mockGetDocsByEmbedding
-      .mockResolvedValueOnce([
-        { score: 0.82, document: { path: "second.md" } },
-        { score: 0.5, document: { path: "source.md" } },
-      ])
-      .mockResolvedValueOnce([
-        { score: 0.79, document: { path: "first.md" } },
-        { score: 0.66, document: { path: "second.md" } },
+      const filesByPath = new Map<string, TFile>([
+        ["source.md", source],
+        ["first.md", first],
+        ["second.md", second],
+        ["alpha.md", alpha],
+        ["beta.md", beta],
+        ["linked-only.md", linkedOnly],
       ]);
-    mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("second.md")]);
-    mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
-    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+      (window.app.vault.getAbstractFileByPath as jest.Mock).mockImplementation((path: string) => {
+        return filesByPath.get(path) ?? null;
+      });
 
-    expect(result.map((entry) => entry.note.path)).toEqual([
-      "second.md",
-      "first.md",
-      "linked-only.md",
-    ]);
-    expect(result.find((entry) => entry.note.path === "second.md")?.metadata.similarityScore).toBe(
-      0.82
-    );
-    expect(mockGetDb).toHaveBeenCalledTimes(1);
-    expect(mockGetDocsByEmbedding).toHaveBeenCalledTimes(2);
-    expect(mockSearchRelated).not.toHaveBeenCalled();
-  });
-
-  it("ranks by similarity only — a backlink does not boost a lower-similarity note above a higher one", async () => {
-    mockGetDocumentsByPath.mockResolvedValue([
-      { id: "chunk-1", path: "source.md", content: "chunk one", embedding: [0.1, 0.2] },
-    ]);
-    mockGetDb.mockResolvedValue({ db: "orama" });
-    // alpha (0.6) has no links; beta (0.58) is backlinked. The old merged-score
-    // ranking boosted beta above alpha despite its lower similarity.
-    mockGetDocsByEmbedding.mockResolvedValueOnce([
-      { score: 0.6, document: { path: "alpha.md" } },
-      { score: 0.58, document: { path: "beta.md" } },
-    ]);
-    mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("beta.md")]);
-
-    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
-
-    expect(result.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
-    expect(result[0].metadata.similarityScore).toBe(0.6);
-    expect(result.find((entry) => entry.note.path === "beta.md")?.metadata.hasBacklinks).toBe(true);
-  });
-
-  it("uses Miyo when shouldUseMiyoForRelevantNotes is true (enableMiyo=true and valid self-host)", async () => {
-    mockedGetSearchBackend.mockReturnValue("miyo");
-    mockedGetSettings.mockReturnValue({
-      debug: false,
-      miyoServerUrl: "http://127.0.0.1:8742",
-      enableMiyo: true,
-      enableSemanticSearchV3: true,
-    } as CopilotSettings);
-    mockGetDocumentsByPath.mockResolvedValue([
-      {
-        id: "chunk-a",
-        path: "source.md",
-        content: "source chunk A",
-        embedding: [],
-      },
-      {
-        id: "chunk-b",
-        path: "source.md",
-        content: "source chunk B",
-        embedding: [],
-      },
-    ]);
-    mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
-    mockSearchRelated.mockResolvedValue({
-      results: [
-        { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
-        { id: "a-1", path: "vault/alpha.md", score: 0.45, chunk_text: "alpha1" },
-        { id: "b-1", path: "vault/beta.md", score: 0.88, chunk_text: "beta" },
-        { id: "a-2", path: "vault/alpha.md", score: 0.6, chunk_text: "alpha2" },
-      ],
+      mockedVectorStoreManager
+        .getInstance()
+        .getDocumentsByPath.mockImplementation(mockGetDocumentsByPath);
+      mockedVectorStoreManager.getInstance().getDb.mockImplementation(mockGetDb);
+      mockedMiyoClient.mockImplementation(() => ({
+        resolveBaseUrl: mockResolveBaseUrl,
+        searchRelated: mockSearchRelated,
+      }));
     });
 
-    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+    it("uses Orama similarity scoring when source note has embeddings", async () => {
+      mockGetDocumentsByPath.mockResolvedValue([
+        {
+          id: "chunk-1",
+          path: "source.md",
+          content: "chunk one",
+          embedding: [0.1, 0.2],
+        },
+        {
+          id: "chunk-2",
+          path: "source.md",
+          content: "chunk two",
+          embedding: [0.3, 0.4],
+        },
+      ]);
+      mockGetDb.mockResolvedValue({ db: "orama" });
+      mockGetDocsByEmbedding
+        .mockResolvedValueOnce([
+          { score: 0.82, document: { path: "second.md" } },
+          { score: 0.5, document: { path: "source.md" } },
+        ])
+        .mockResolvedValueOnce([
+          { score: 0.79, document: { path: "first.md" } },
+          { score: 0.66, document: { path: "second.md" } },
+        ]);
+      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("second.md")]);
+      mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
 
-    expect(result.map((entry) => entry.note.path)).toEqual(["beta.md", "alpha.md"]);
-    expect(result.find((entry) => entry.note.path === "alpha.md")?.metadata.similarityScore).toBe(
-      0.6
-    );
-    expect(mockGetDb).not.toHaveBeenCalled();
-    expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
-    expect(mockSearchRelated).toHaveBeenCalledTimes(1);
-    expect(mockSearchRelated).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault/source.md", {
-      folderName: "vault",
-      limit: 20,
-    });
-  });
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-  it("applies the live Copilot scope to semantic and linked candidates", async () => {
-    mockedGetSearchBackend.mockReturnValue("miyo");
-    mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
-    mockSearchRelated.mockResolvedValue({
-      results: [
-        { id: "allowed", path: "vault/beta.md", score: 0.8 },
-        { id: "excluded", path: "vault/alpha.md", score: 0.9 },
-      ],
-    });
-    mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
-    const isAllowed = jest.fn((path: string) => path === "beta.md");
-    mockedCreateCopilotPatternFilter.mockReturnValue(isAllowed);
-
-    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
-
-    expect(result.map((entry) => entry.note.path)).toEqual(["beta.md"]);
-    expect(mockedCreateCopilotPatternFilter).toHaveBeenCalledWith(window.app);
-    expect(isAllowed.mock.calls.map(([path]) => path)).toEqual([
-      "beta.md",
-      "alpha.md",
-      "linked-only.md",
-    ]);
-  });
-
-  it("falls back to Miyo when Orama docs exist but have no embeddings and have content", async () => {
-    // enableMiyo=false ensures shouldUseMiyoForRelevantNotes() returns false,
-    // so the no-embeddings fallback path (line 212 of findRelevantNotes.ts) is exercised.
-    mockedGetSettings.mockReturnValue({
-      debug: false,
-      miyoServerUrl: "http://127.0.0.1:8742",
-      enableMiyo: false,
-      enableSemanticSearchV3: true,
-    } as CopilotSettings);
-    mockGetDocumentsByPath.mockResolvedValue([
-      { id: "chunk-a", path: "source.md", content: "source chunk content", embedding: [] },
-    ]);
-    mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
-    mockSearchRelated.mockResolvedValue({
-      results: [
-        { id: "a-1", path: "vault/alpha.md", score: 0.75, chunk_text: "alpha chunk" },
-        { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
-      ],
+      expect(result.map((entry) => entry.note.path)).toEqual([
+        "second.md",
+        "first.md",
+        "linked-only.md",
+      ]);
+      expect(
+        result.find((entry) => entry.note.path === "second.md")?.metadata.similarityScore
+      ).toBe(0.82);
+      expect(mockGetDb).toHaveBeenCalledTimes(1);
+      expect(mockGetDocsByEmbedding).toHaveBeenCalledTimes(2);
+      expect(mockSearchRelated).not.toHaveBeenCalled();
     });
 
-    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+    it("ranks by similarity only — a backlink does not boost a lower-similarity note above a higher one", async () => {
+      mockGetDocumentsByPath.mockResolvedValue([
+        { id: "chunk-1", path: "source.md", content: "chunk one", embedding: [0.1, 0.2] },
+      ]);
+      mockGetDb.mockResolvedValue({ db: "orama" });
+      // alpha (0.6) has no links; beta (0.58) is backlinked. The old merged-score
+      // ranking boosted beta above alpha despite its lower similarity.
+      mockGetDocsByEmbedding.mockResolvedValueOnce([
+        { score: 0.6, document: { path: "alpha.md" } },
+        { score: 0.58, document: { path: "beta.md" } },
+      ]);
+      mockedGetBacklinkedNotes.mockReturnValue([createMarkdownFile("beta.md")]);
 
-    expect(result.map((e) => e.note.path)).toEqual(["alpha.md"]);
-    expect(result[0].metadata.similarityScore).toBe(0.75);
-    // Orama path not taken (no embeddings); Miyo called as fallback
-    expect(mockGetDocsByEmbedding).not.toHaveBeenCalled();
-    expect(mockSearchRelated).toHaveBeenCalledTimes(1);
-  });
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
 
-  it("falls back to link-only relevance when Miyo related-note search fails", async () => {
-    mockedGetSearchBackend.mockReturnValue("miyo");
-    mockedGetSettings.mockReturnValue({
-      debug: false,
-      miyoServerUrl: "http://127.0.0.1:8742",
-      enableMiyo: true,
-      enableSemanticSearchV3: true,
-    } as CopilotSettings);
-    mockGetDocumentsByPath.mockResolvedValue([
-      {
-        id: "chunk-a",
-        path: "source.md",
-        content: "source chunk A",
-        embedding: [],
-      },
-    ]);
-    mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
-    mockSearchRelated.mockRejectedValue(new Error("Miyo unavailable"));
-    mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+      expect(result.map((entry) => entry.note.path)).toEqual(["alpha.md", "beta.md"]);
+      expect(result[0].metadata.similarityScore).toBe(0.6);
+      expect(result.find((entry) => entry.note.path === "beta.md")?.metadata.hasBacklinks).toBe(
+        true
+      );
+    });
 
-    const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+    it("uses Miyo when shouldUseMiyoForRelevantNotes is true (enableMiyo=true and valid self-host)", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetSettings.mockReturnValue({
+        debug: false,
+        miyoServerUrl: "http://127.0.0.1:8742",
+        enableMiyo: true,
+        enableSemanticSearchV3: true,
+      } as CopilotSettings);
+      mockGetDocumentsByPath.mockResolvedValue([
+        {
+          id: "chunk-a",
+          path: "source.md",
+          content: "source chunk A",
+          embedding: [],
+        },
+        {
+          id: "chunk-b",
+          path: "source.md",
+          content: "source chunk B",
+          embedding: [],
+        },
+      ]);
+      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
+      mockSearchRelated.mockResolvedValue({
+        results: [
+          { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
+          { id: "a-1", path: "vault/alpha.md", score: 0.45, chunk_text: "alpha1" },
+          { id: "b-1", path: "vault/beta.md", score: 0.88, chunk_text: "beta" },
+          { id: "a-2", path: "vault/alpha.md", score: 0.6, chunk_text: "alpha2" },
+        ],
+      });
 
-    expect(result).toHaveLength(1);
-    expect(result[0].note.path).toBe("linked-only.md");
-    expect(result[0].metadata.similarityScore).toBeUndefined();
-    expect(result[0].metadata.hasOutgoingLinks).toBe(true);
-    expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result.map((entry) => entry.note.path)).toEqual(["beta.md", "alpha.md"]);
+      expect(result.find((entry) => entry.note.path === "alpha.md")?.metadata.similarityScore).toBe(
+        0.6
+      );
+      expect(mockGetDb).not.toHaveBeenCalled();
+      expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
+      expect(mockSearchRelated).toHaveBeenCalledTimes(1);
+      expect(mockSearchRelated).toHaveBeenCalledWith("http://127.0.0.1:8742", "vault/source.md", {
+        folderName: "vault",
+        limit: 20,
+      });
+    });
+
+    it("applies the live Copilot scope to semantic and linked candidates", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
+      mockSearchRelated.mockResolvedValue({
+        results: [
+          { id: "allowed", path: "vault/beta.md", score: 0.8 },
+          { id: "excluded", path: "vault/alpha.md", score: 0.9 },
+        ],
+      });
+      mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+      const isAllowed = jest.fn((path: string) => path === "beta.md");
+      mockedCreateCopilotPatternFilter.mockReturnValue(isAllowed);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result.map((entry) => entry.note.path)).toEqual(["beta.md"]);
+      expect(mockedCreateCopilotPatternFilter).toHaveBeenCalledWith(window.app);
+      expect(isAllowed.mock.calls.map(([path]) => path)).toEqual([
+        "beta.md",
+        "alpha.md",
+        "linked-only.md",
+      ]);
+    });
+
+    it("falls back to Miyo when Orama docs exist but have no embeddings and have content", async () => {
+      // enableMiyo=false ensures shouldUseMiyoForRelevantNotes() returns false,
+      // so the no-embeddings fallback path (line 212 of findRelevantNotes.ts) is exercised.
+      mockedGetSettings.mockReturnValue({
+        debug: false,
+        miyoServerUrl: "http://127.0.0.1:8742",
+        enableMiyo: false,
+        enableSemanticSearchV3: true,
+      } as CopilotSettings);
+      mockGetDocumentsByPath.mockResolvedValue([
+        { id: "chunk-a", path: "source.md", content: "source chunk content", embedding: [] },
+      ]);
+      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
+      mockSearchRelated.mockResolvedValue({
+        results: [
+          { id: "a-1", path: "vault/alpha.md", score: 0.75, chunk_text: "alpha chunk" },
+          { id: "self", path: "vault/source.md", score: 0.99, chunk_text: "self" },
+        ],
+      });
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result.map((e) => e.note.path)).toEqual(["alpha.md"]);
+      expect(result[0].metadata.similarityScore).toBe(0.75);
+      // Orama path not taken (no embeddings); Miyo called as fallback
+      expect(mockGetDocsByEmbedding).not.toHaveBeenCalled();
+      expect(mockSearchRelated).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to link-only relevance when Miyo related-note search fails", async () => {
+      mockedGetSearchBackend.mockReturnValue("miyo");
+      mockedGetSettings.mockReturnValue({
+        debug: false,
+        miyoServerUrl: "http://127.0.0.1:8742",
+        enableMiyo: true,
+        enableSemanticSearchV3: true,
+      } as CopilotSettings);
+      mockGetDocumentsByPath.mockResolvedValue([
+        {
+          id: "chunk-a",
+          path: "source.md",
+          content: "source chunk A",
+          embedding: [],
+        },
+      ]);
+      mockResolveBaseUrl.mockResolvedValue("http://127.0.0.1:8742");
+      mockSearchRelated.mockRejectedValue(new Error("Miyo unavailable"));
+      mockedGetLinkedNotes.mockReturnValue([createMarkdownFile("linked-only.md")]);
+
+      const result = await findRelevantNotes({ app: window.app, filePath: "source.md" });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].note.path).toBe("linked-only.md");
+      expect(result[0].metadata.similarityScore).toBeUndefined();
+      expect(result[0].metadata.hasOutgoingLinks).toBe(true);
+      expect(mockGetDocumentsByPath).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/search/findRelevantNotes.ts
+++ b/src/search/findRelevantNotes.ts
@@ -10,6 +10,7 @@ import {
 import { getBacklinkedNotes, getLinkedNotes } from "@/noteUtils";
 import { DBOperations } from "@/search/dbOperations";
 import type { SemanticIndexDocument } from "@/search/indexBackend/SemanticIndexBackend";
+import { createCopilotPatternFilter } from "@/search/searchUtils";
 import VectorStoreManager from "@/search/vectorStoreManager";
 import { getSettings } from "@/settings/model";
 import { InternalTypedDocument, Orama, Result } from "@orama/orama";
@@ -264,12 +265,13 @@ export type RelevantNoteEntry = {
 };
 
 /**
- * Finds the relevant notes for the given file path.
+ * Finds relevant notes for a file while enforcing Copilot's live search scope
+ * across semantic and link-derived candidates.
  *
  * @param app - The Obsidian app instance.
  * @param filePath - The file path to find relevant notes for.
- * @returns The relevant notes hits for the given file path. Empty array if no
- *   relevant notes are found or the index does not exist.
+ * @returns Relevant-note hits allowed by the current inclusion/exclusion rules.
+ *   Empty when no allowed notes are found or the index does not exist.
  */
 export async function findRelevantNotes({
   app,
@@ -292,14 +294,16 @@ export async function findRelevantNotes({
   // the bottom (they render without a meter in the UI).
   const candidatePaths = new Set<string>([...similarityScoreMap.keys(), ...noteLinks.keys()]);
   candidatePaths.delete(filePath);
-  const sortedPaths = Array.from(candidatePaths).sort((aPath, bPath) => {
-    const aScore = similarityScoreMap.get(aPath);
-    const bScore = similarityScoreMap.get(bPath);
-    if (aScore == null && bScore == null) return 0;
-    if (aScore == null) return 1;
-    if (bScore == null) return -1;
-    return bScore - aScore;
-  });
+  const sortedPaths = Array.from(candidatePaths)
+    .filter(createCopilotPatternFilter(app))
+    .sort((aPath, bPath) => {
+      const aScore = similarityScoreMap.get(aPath);
+      const bScore = similarityScoreMap.get(bPath);
+      if (aScore == null && bScore == null) return 0;
+      if (aScore == null) return 1;
+      if (bScore == null) return -1;
+      return bScore - aScore;
+    });
   return sortedPaths
     .map((path) => {
       const file = app.vault.getAbstractFileByPath(path);


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#264

> GitHub did not register the cross-repo closing reference. Verify and close issue #264 manually when this PR merges.

## Problem

`findRelevantNotes` combines semantic-search paths with outgoing links and backlinks, then ranks and returns them without a final live Copilot scope check. Miyo's Related Notes path calls its related-search API directly, so it does not pass through `MiyoSemanticRetriever.filterByCopilotPatterns`. An independently configured or stale Miyo result can therefore surface a note that Copilot currently excludes.

The accepted scope is the [Copilot-side boundary decision](https://github.com/logancyang/obsidian-copilot-preview/issues/264#issuecomment-5170067395): Copilot must enforce its own live rules when consuming results, regardless of what Miyo or another candidate source returns.

## User experience

Before this change, a note excluded by Copilot could remain visible in Related Notes when a search backend or note link returned it. After this change, Related Notes respects Copilot's current inclusion and exclusion rules across every candidate source.

Users do not need to change, re-enter, or migrate settings. Miyo's own exclusion settings remain independent.

## Fix

Apply the existing Copilot pattern filter once, after semantic and link-derived candidates are combined and before they are ranked and rendered. This shared boundary covers Miyo, Orama, outgoing links, and backlinks without source-specific branches.

Synchronizing Copilot and Miyo after registration was rejected because Miyo owns an independent scope. Registration is the initial handoff, not a contract that the two settings remain continuously synchronized.

## Explicit non-goals

- Remove stale embeddings from Miyo's serving index.
- Synchronize Miyo and Copilot exclusion settings after registration.
- Re-register or backfill existing Miyo indexes.
- Refill Miyo's result window when excluded candidates have already consumed backend result slots.
- Change search ranking or Related Notes presentation.

## Scope

Budget gate: PASS — 2 files, +251/−210; production remains one shared-boundary filter, and the review-only churn is the formatter-required nesting of all existing callable tests under the repository's single-suite contract.

## Changes

- `src/search/findRelevantNotes.ts`: filter the combined candidate set with Copilot's live pattern rules before sorting and materializing notes.
- `src/search/findRelevantNotes.test.ts`: verify the final boundary rejects excluded semantic and link-derived candidates while preserving an allowed Miyo result, with all cases grouped under the required `findRelevantNotes()` suite.

## Verification

- `npm run format` — completed successfully.
- `npm run lint` — passed.
- `npm test -- --runInBand src/search/findRelevantNotes.test.ts` — 1 suite and 6 tests passed.
- `npm run test -- --runInBand` — 363 suites and 5,214 tests passed.
- `npm run build` — production TypeScript, Tailwind, and esbuild build passed before the test-only suite nesting; production code did not change afterward.
- Manual Obsidian reproduction was not run; the focused regression test exercises the Miyo result and linked-note boundary directly.

🤖 Generated with [OpenAI Codex](https://openai.com/codex/)