### PR TITLE
[Agent view onboarding] - Step 2: Centralize agent setup copy and ordering

### DIFF
--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -11,6 +11,7 @@ import {
   type CopilotSettings,
 } from "@/settings/model";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
+import { NO_SETUP_HIGHLIGHTS } from "@/agentMode/session/descriptor";
 import { MethodUnsupportedError } from "@/agentMode/session/errors";
 import { claudeBinarySearchDirs, resolveClaudeBinary } from "./claudeBinaryResolver";
 import { getClaudeAuthStatus, signInToClaude } from "./claudeAuth";
@@ -196,6 +197,9 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
   Icon: ClaudeLogo,
   // Cloud agent — flagged with a cloud-egress warning while Self-Host Mode is on.
   selfHostable: false,
+  setupDescription:
+    "Anthropic models, billed to your Claude Code subscription. Runs the claude CLI already on your machine.",
+  setupHighlights: NO_SETUP_HIGHLIGHTS,
   skillsProjectDir: ".claude/skills",
   crossDiscoveredAgents: [],
   restartOnManagedSkillsChange: false,

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -11,7 +11,6 @@ import {
   type CopilotSettings,
 } from "@/settings/model";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
-import { NO_SETUP_HIGHLIGHTS } from "@/agentMode/session/descriptor";
 import { MethodUnsupportedError } from "@/agentMode/session/errors";
 import { claudeBinarySearchDirs, resolveClaudeBinary } from "./claudeBinaryResolver";
 import { getClaudeAuthStatus, signInToClaude } from "./claudeAuth";
@@ -199,7 +198,6 @@ export const ClaudeBackendDescriptor: BackendDescriptor = {
   selfHostable: false,
   setupDescription:
     "Anthropic models, billed to your Claude Code subscription. Runs the claude CLI already on your machine.",
-  setupHighlights: NO_SETUP_HIGHLIGHTS,
   skillsProjectDir: ".claude/skills",
   crossDiscoveredAgents: [],
   restartOnManagedSkillsChange: false,

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -12,7 +12,6 @@ import { CodexInstallModal } from "./CodexInstallModal";
 import CodexLogo from "./logo.svg";
 import { CodexSettingsPanel } from "./CodexSettingsPanel";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
-import { NO_SETUP_HIGHLIGHTS } from "@/agentMode/session/descriptor";
 import { agentOriginEnabledModelEntries } from "@/agentMode/backends/shared/agentEnabledModels";
 import {
   binaryPathInstallState,
@@ -112,7 +111,6 @@ export const CodexBackendDescriptor: BackendDescriptor = {
   selfHostable: false,
   setupDescription:
     "OpenAI models, billed to your ChatGPT subscription. Runs the codex-acp adapter on your machine.",
-  setupHighlights: NO_SETUP_HIGHLIGHTS,
   skillsProjectDir: ".agents/skills",
   crossDiscoveredAgents: [],
   restartOnManagedSkillsChange: false,

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -12,6 +12,7 @@ import { CodexInstallModal } from "./CodexInstallModal";
 import CodexLogo from "./logo.svg";
 import { CodexSettingsPanel } from "./CodexSettingsPanel";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
+import { NO_SETUP_HIGHLIGHTS } from "@/agentMode/session/descriptor";
 import { agentOriginEnabledModelEntries } from "@/agentMode/backends/shared/agentEnabledModels";
 import {
   binaryPathInstallState,
@@ -109,6 +110,9 @@ export const CodexBackendDescriptor: BackendDescriptor = {
   Icon: CodexLogo,
   // Cloud agent — flagged with a cloud-egress warning while Self-Host Mode is on.
   selfHostable: false,
+  setupDescription:
+    "OpenAI models, billed to your ChatGPT subscription. Runs the codex-acp adapter on your machine.",
+  setupHighlights: NO_SETUP_HIGHLIGHTS,
   skillsProjectDir: ".agents/skills",
   crossDiscoveredAgents: [],
   restartOnManagedSkillsChange: false,

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -141,6 +141,9 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
   // opencode routes through user-controlled / self-hosted endpoints, so it
   // stays available in Self-Host Mode.
   selfHostable: true,
+  setupDescription:
+    "Copilot Plus models, or any model on your own provider key. Copilot can download and manage the binary for you.",
+  setupHighlights: ["Copilot Plus models", "Your own provider key"],
   skillsProjectDir: ".opencode/skills",
   crossDiscoveredAgents: ["claude", "codex"],
   restartOnManagedSkillsChange: true,

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -143,7 +143,6 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
   selfHostable: true,
   setupDescription:
     "Copilot Plus models, or any model on your own provider key. Copilot can download and manage the binary for you.",
-  setupHighlights: ["Copilot Plus models", "Your own provider key"],
   skillsProjectDir: ".opencode/skills",
   crossDiscoveredAgents: ["claude", "codex"],
   restartOnManagedSkillsChange: true,

--- a/src/agentMode/backends/registry.test.ts
+++ b/src/agentMode/backends/registry.test.ts
@@ -1,9 +1,12 @@
 import type { CopilotSettings } from "@/settings/model";
 import {
+  backendDisplayOrder,
   backendNeedsSelfHostWarning,
+  backendRegistry,
   getActiveBackendDescriptor,
   getCloudAgentIds,
   listBackendDescriptors,
+  RECOMMENDED_BACKEND_ID,
 } from "./registry";
 import { ClaudeBackendDescriptor } from "./claude";
 import { CodexBackendDescriptor } from "./codex/descriptor";
@@ -45,6 +48,48 @@ describe("backendRegistry", () => {
 
   it("listBackendDescriptors includes OpenCode", () => {
     expect(listBackendDescriptors()).toContain(OpencodeBackendDescriptor);
+  });
+
+  describe("backendDisplayOrder()", () => {
+    it("lists opencode, then Claude, then Codex", () => {
+      expect(backendDisplayOrder()).toEqual([
+        OpencodeBackendDescriptor,
+        ClaudeBackendDescriptor,
+        CodexBackendDescriptor,
+      ]);
+    });
+
+    it("covers every registered backend exactly once", () => {
+      const ids = backendDisplayOrder().map((descriptor) => descriptor.id);
+      expect([...ids].sort()).toEqual(Object.keys(backendRegistry).sort());
+    });
+
+    it("returns a stable reference across calls", () => {
+      expect(backendDisplayOrder()).toBe(backendDisplayOrder());
+    });
+  });
+
+  describe("RECOMMENDED_BACKEND_ID", () => {
+    it("names a registered backend", () => {
+      expect(backendRegistry[RECOMMENDED_BACKEND_ID]).toBeDefined();
+    });
+  });
+
+  describe("agent setup copy", () => {
+    it("every registered backend states which models it serves and who pays", () => {
+      for (const descriptor of listBackendDescriptors()) {
+        expect(descriptor.setupDescription.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("highlights model sources only for the backend where the model is a variable", () => {
+      expect(OpencodeBackendDescriptor.setupHighlights).toEqual([
+        "Copilot Plus models",
+        "Your own provider key",
+      ]);
+      expect(ClaudeBackendDescriptor.setupHighlights).toEqual([]);
+      expect(CodexBackendDescriptor.setupHighlights).toEqual([]);
+    });
   });
 
   describe("Self-Host Mode marking", () => {

--- a/src/agentMode/backends/registry.test.ts
+++ b/src/agentMode/backends/registry.test.ts
@@ -81,15 +81,6 @@ describe("backendRegistry", () => {
         expect(descriptor.setupDescription.length).toBeGreaterThan(0);
       }
     });
-
-    it("highlights model sources only for the backend where the model is a variable", () => {
-      expect(OpencodeBackendDescriptor.setupHighlights).toEqual([
-        "Copilot Plus models",
-        "Your own provider key",
-      ]);
-      expect(ClaudeBackendDescriptor.setupHighlights).toEqual([]);
-      expect(CodexBackendDescriptor.setupHighlights).toEqual([]);
-    });
   });
 
   describe("Self-Host Mode marking", () => {

--- a/src/agentMode/backends/registry.ts
+++ b/src/agentMode/backends/registry.ts
@@ -21,6 +21,31 @@ export const backendRegistry: Record<BackendId, BackendDescriptor> = {
 };
 
 /**
+ * The backend a first-run user is steered to. A single constant rather than a
+ * per-descriptor flag, so two backends can never both claim the title.
+ */
+export const RECOMMENDED_BACKEND_ID: BackendId = "opencode";
+
+let displayOrderCache: BackendDescriptor[] | null = null;
+
+/**
+ * Every registered backend descriptor in the order the UI presents them —
+ * the self-hostable opencode first, then the cloud agents. The one ordering
+ * every setup and settings surface reads, so a backend can't end up ordered
+ * differently in two places. Computed lazily and memoized for the same reason
+ * as `getCloudAgentIds`.
+ */
+export function backendDisplayOrder(): BackendDescriptor[] {
+  if (!displayOrderCache) {
+    const ids: BackendId[] = ["opencode", "claude", "codex"];
+    displayOrderCache = ids
+      .map((id) => backendRegistry[id])
+      .filter((descriptor): descriptor is BackendDescriptor => descriptor !== undefined);
+  }
+  return displayOrderCache;
+}
+
+/**
  * Whether a backend carries a cloud-egress warning under the current Self-Host
  * Mode state. Cloud agents (`selfHostable: false`) are flagged while the mode is
  * on so the UI shows a warning marker beside them; nothing is flagged when the

--- a/src/agentMode/backends/registry.ts
+++ b/src/agentMode/backends/registry.ts
@@ -37,10 +37,11 @@ let displayOrderCache: BackendDescriptor[] | null = null;
  */
 export function backendDisplayOrder(): BackendDescriptor[] {
   if (!displayOrderCache) {
-    const ids: BackendId[] = ["opencode", "claude", "codex"];
-    displayOrderCache = ids
-      .map((id) => backendRegistry[id])
-      .filter((descriptor): descriptor is BackendDescriptor => descriptor !== undefined);
+    displayOrderCache = [
+      OpencodeBackendDescriptor,
+      ClaudeBackendDescriptor,
+      CodexBackendDescriptor,
+    ];
   }
   return displayOrderCache;
 }

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -61,10 +61,12 @@ export type { PlanPreviewViewState } from "./ui/PlanPreviewView";
 export { ReportIssueModal } from "./ui/ReportIssueModal";
 export type { ReportIssueModalParams } from "./ui/ReportIssueModal";
 export {
+  backendDisplayOrder,
   backendNeedsSelfHostWarning,
   getActiveBackendDescriptor,
   getCloudAgentIds,
   listBackendDescriptors,
+  RECOMMENDED_BACKEND_ID,
 } from "./backends/registry";
 export { frameSink as acpFrameSink, setFrameSinkVaultBasePath } from "./session/debugSink";
 export { getManagedSkills, SkillManager, SkillsSettings, useManagedSkills } from "./skills";

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -69,13 +69,6 @@ export interface BackendAuth {
 }
 
 /**
- * Shared empty value for `BackendDescriptor.setupHighlights`, so backends with
- * nothing to highlight all point at one frozen array instead of each allocating
- * their own.
- */
-export const NO_SETUP_HIGHLIGHTS: ReadonlyArray<string> = Object.freeze([]);
-
-/**
  * Backend-agnostic descriptor consumed by `session/` and `ui/`. Each backend
  * exports one of these from its own folder; the registry maps `BackendId →
  * BackendDescriptor`. Adding a new backend is exactly: implement
@@ -121,17 +114,6 @@ export interface BackendDescriptor {
    * Required (not optional) so a new backend must make an explicit decision.
    */
   readonly setupDescription: string;
-
-  /**
-   * Short badge labels rendered under `setupDescription` in the agent select
-   * view, naming the model sources this backend can draw from. Meant for
-   * backends where the model is a variable the user chooses; `[]` is the right
-   * answer when the backend serves exactly one vendor's models and the
-   * description already says so.
-   *
-   * Required (not optional) so a new backend must make an explicit decision.
-   */
-  readonly setupHighlights: ReadonlyArray<string>;
 
   /**
    * Project-relative POSIX path of the directory this backend reads skills

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -69,6 +69,13 @@ export interface BackendAuth {
 }
 
 /**
+ * Shared empty value for `BackendDescriptor.setupHighlights`, so backends with
+ * nothing to highlight all point at one frozen array instead of each allocating
+ * their own.
+ */
+export const NO_SETUP_HIGHLIGHTS: ReadonlyArray<string> = Object.freeze([]);
+
+/**
  * Backend-agnostic descriptor consumed by `session/` and `ui/`. Each backend
  * exports one of these from its own folder; the registry maps `BackendId →
  * BackendDescriptor`. Adding a new backend is exactly: implement
@@ -104,6 +111,27 @@ export interface BackendDescriptor {
    * spawning or rewrites settings.
    */
   readonly selfHostable: boolean;
+
+  /**
+   * One-paragraph pitch shown beside this backend in the agent select view:
+   * which models the user gets from it, and whose plan pays for them. That
+   * trade-off is the only thing separating the agents from a user's point of
+   * view, so every backend must state it.
+   *
+   * Required (not optional) so a new backend must make an explicit decision.
+   */
+  readonly setupDescription: string;
+
+  /**
+   * Short badge labels rendered under `setupDescription` in the agent select
+   * view, naming the model sources this backend can draw from. Meant for
+   * backends where the model is a variable the user chooses; `[]` is the right
+   * answer when the backend serves exactly one vendor's models and the
+   * description already says so.
+   *
+   * Required (not optional) so a new backend must make an explicit decision.
+   */
+  readonly setupHighlights: ReadonlyArray<string>;
 
   /**
    * Project-relative POSIX path of the directory this backend reads skills

--- a/src/settings/v2/components/AgentSettings.test.tsx
+++ b/src/settings/v2/components/AgentSettings.test.tsx
@@ -55,7 +55,7 @@ const mockGetCachedModelCatalog = jest.fn();
 const mockPreloadModels = jest.fn();
 
 jest.mock("@/agentMode", () => ({
-  listBackendDescriptors: () => DESCRIPTORS,
+  backendDisplayOrder: () => DESCRIPTORS,
   backendNeedsSelfHostWarning: (
     descriptor: { selfHostable?: boolean },
     settings: { enableSelfHostMode?: boolean }

--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -1,11 +1,10 @@
 import {
   AgentDefaultModelSetting,
+  backendDisplayOrder,
   backendNeedsSelfHostWarning,
   InstallBadge,
-  listBackendDescriptors,
   useBackendInstallState,
   type BackendDescriptor,
-  type BackendId,
 } from "@/agentMode";
 import { Button } from "@/components/ui/button";
 import { SettingItem } from "@/components/ui/setting-item";
@@ -22,12 +21,6 @@ import { Platform } from "obsidian";
 import React from "react";
 import { ChatModelEnableList } from "./ChatModelEnableList";
 import { ConfiguredModelEnableList } from "./ConfiguredModelEnableList";
-
-/**
- * Explicit ordering for backend sub-tabs. Keeps Opencode → Claude → Codex
- * regardless of what `listBackendDescriptors()` returns.
- */
-const BACKEND_ORDER: BackendId[] = ["opencode", "claude", "codex"];
 
 /** Synthetic sub-tab id for the (non-backend) Quick Chat model curation. */
 const QUICK_CHAT_TAB_ID = "quickchat";
@@ -52,7 +45,7 @@ function getScrollableParent(el: HTMLElement): HTMLElement | null {
 export const AgentSettings: React.FC = () => {
   const settings = useSettingsValue();
   const plugin = usePlugin();
-  const [selectedTab, setSelectedTab] = React.useState<string>(BACKEND_ORDER[0]);
+  const [selectedTab, setSelectedTab] = React.useState<string>(() => backendDisplayOrder()[0].id);
   const tabStripRef = React.useRef<HTMLDivElement>(null);
   const pendingAnchorTop = React.useRef<number | null>(null);
 
@@ -89,11 +82,8 @@ export const AgentSettings: React.FC = () => {
 
   // Every registered backend shows here — Self-Host Mode marks cloud agents
   // (warning banner in their panel) rather than hiding them. Cloud agents sort
-  // last because `BACKEND_ORDER` lists the self-hostable opencode first.
-  const allDescriptors = listBackendDescriptors();
-  const orderedDescriptors = BACKEND_ORDER.map((id) =>
-    allDescriptors.find((d) => d.id === id)
-  ).filter((d): d is BackendDescriptor => d !== undefined);
+  // last because `backendDisplayOrder()` lists the self-hostable opencode first.
+  const orderedDescriptors = backendDisplayOrder();
 
   const tabs: TabItemType[] = [
     ...orderedDescriptors.map((d) => ({


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#228

## Why

Today, Settings → Copilot → Agents is the only surface that presents the agents, and it alone decides they appear as opencode, then Claude, then Codex. Nowhere is there a shared statement of what each agent offers a user — which models it serves and whose subscription pays for them — or of which agent a first-run user should be steered to. The upcoming agent onboarding view must present the same agents with the same order and explanation, and without one shared source its copy and ordering could drift from what settings shows.

## What

Every agent now carries a one-paragraph setup pitch stating which models it serves and whose plan pays (for example, opencode's: "Copilot Plus models, or any model on your own provider key. Copilot can download and manage the binary for you."), one agent — opencode — is designated as the recommendation, and a single shared display order drives every surface that lists agents.

> **Before:** The agent order lives only inside the Agents settings tab; no per-agent setup pitch or recommended agent exists anywhere.
>
> **After:** One shared source defines each agent's setup pitch, the recommended agent, and the opencode → Claude → Codex order; the Agents settings tab reads that order and renders exactly as before.

## Non goal

- Render the new onboarding view.
- Show the new setup copy anywhere — no surface displays it yet.
- Change the current agent order or settings navigation.

## Screenshot

Not applicable — this PR centralizes copy and ordering data behind unchanged surfaces; the Agents settings tabs render identically and the new setup copy has no surface yet.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Existing settings order is unchanged and registry tests pin all new metadata |
| A defect would fail CI or be obvious on first use | ✅ | Missing copy or an incomplete display order fails the registry suites or compilation |
| A revert fully restores prior state, including persisted data | ✅ | The change adds descriptor metadata and centralizes an existing order |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No credential or user-input path is touched |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `BackendDescriptor` is an internal Agent Mode contract |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The registry lookup remains synchronous |
| No hot-path behavior lacks deterministic coverage | ✅ | No runtime hot path changes |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Not applicable; the changed contract is deterministically tested and not rendered yet |

Review: confirm CI is green, then run Verification step 1 only if you want to inspect the unchanged settings tabs.

## Verification

1. Open Settings → Copilot → Agents and confirm the sub-tabs still appear as opencode, Claude, and Codex in that order, and each tab opens its panel as before. This PR intentionally adds no new visible surface.
