### PR TITLE
[Agent view onboarding] - Step 3: Define agent selection states and actions

### DIFF
--- a/src/agentMode/ui/agentSelectModel.test.ts
+++ b/src/agentMode/ui/agentSelectModel.test.ts
@@ -1,4 +1,3 @@
-import { NO_SETUP_HIGHLIGHTS } from "@/agentMode/session/descriptor";
 import type { BackendDescriptor, BackendId, InstallState } from "@/agentMode/session/types";
 import {
   buildAgentSelectRows,
@@ -11,15 +10,11 @@ function descriptor(id: BackendId, overrides: Partial<BackendDescriptor> = {}): 
     id,
     displayName: id,
     setupDescription: `${id} description`,
-    setupHighlights: NO_SETUP_HIGHLIGHTS,
     ...overrides,
   } as BackendDescriptor;
 }
 
-const OPENCODE = descriptor("opencode", {
-  displayName: "opencode",
-  setupHighlights: Object.freeze(["Copilot Plus models", "Your own provider key"]),
-});
+const OPENCODE = descriptor("opencode", { displayName: "opencode" });
 const CLAUDE = descriptor("claude", { displayName: "Claude" });
 const CODEX = descriptor("codex", { displayName: "Codex" });
 const DISPLAY_ORDER = [OPENCODE, CLAUDE, CODEX];
@@ -38,7 +33,6 @@ function rowWith(overrides: Partial<AgentSelectRow> = {}): AgentSelectRow {
     id: "opencode",
     name: "opencode",
     description: "opencode description",
-    highlights: NO_SETUP_HIGHLIGHTS,
     status: "absent",
     recommended: false,
     statusMessage: null,
@@ -108,20 +102,11 @@ describe("agentSelectModel", () => {
       expect(rows.filter((row) => row.recommended).map((row) => row.id)).toEqual(["opencode"]);
     });
 
-    it("copies name, description, and highlights from the descriptor", () => {
+    it("copies the name and description from the descriptor", () => {
       const [row] = buildAgentSelectRows([OPENCODE], {}, "opencode");
 
       expect(row.name).toBe("opencode");
       expect(row.description).toBe("opencode description");
-      expect(row.highlights).toEqual(["Copilot Plus models", "Your own provider key"]);
-    });
-
-    it("reuses one array identity for every empty highlights list across calls", () => {
-      const first = buildAgentSelectRows(DISPLAY_ORDER, {}, "opencode");
-      const second = buildAgentSelectRows(DISPLAY_ORDER, {}, "opencode");
-
-      expect(first[1].highlights).toBe(NO_SETUP_HIGHLIGHTS);
-      expect(second[2].highlights).toBe(first[1].highlights);
     });
 
     it("returns one shared frozen slice when there are no descriptors", () => {

--- a/src/agentMode/ui/agentSelectModel.test.ts
+++ b/src/agentMode/ui/agentSelectModel.test.ts
@@ -1,0 +1,174 @@
+import { NO_SETUP_HIGHLIGHTS } from "@/agentMode/session/descriptor";
+import type { BackendDescriptor, BackendId, InstallState } from "@/agentMode/session/types";
+import {
+  buildAgentSelectRows,
+  resolveAgentSelectCta,
+  type AgentSelectRow,
+} from "./agentSelectModel";
+
+function descriptor(id: BackendId, overrides: Partial<BackendDescriptor> = {}): BackendDescriptor {
+  return {
+    id,
+    displayName: id,
+    setupDescription: `${id} description`,
+    setupHighlights: NO_SETUP_HIGHLIGHTS,
+    ...overrides,
+  } as BackendDescriptor;
+}
+
+const OPENCODE = descriptor("opencode", {
+  displayName: "opencode",
+  setupHighlights: Object.freeze(["Copilot Plus models", "Your own provider key"]),
+});
+const CLAUDE = descriptor("claude", { displayName: "Claude" });
+const CODEX = descriptor("codex", { displayName: "Codex" });
+const DISPLAY_ORDER = [OPENCODE, CLAUDE, CODEX];
+
+const INCOMPATIBLE: InstallState = {
+  kind: "incompatible",
+  source: "custom",
+  currentVersion: "1.15.0",
+  minVersion: "1.16.0",
+  message: "opencode v1.15.0 is not supported. Copilot requires opencode v1.16.0 or newer.",
+};
+const ERRORED: InstallState = { kind: "error", message: "opencode binary is not executable." };
+
+function rowWith(overrides: Partial<AgentSelectRow> = {}): AgentSelectRow {
+  return {
+    id: "opencode",
+    name: "opencode",
+    description: "opencode description",
+    highlights: NO_SETUP_HIGHLIGHTS,
+    status: "absent",
+    recommended: false,
+    statusMessage: null,
+    ...overrides,
+  };
+}
+
+describe("agentSelectModel", () => {
+  describe("buildAgentSelectRows()", () => {
+    it("reports a ready backend as connected with no status message", () => {
+      const [row] = buildAgentSelectRows(
+        [OPENCODE],
+        { opencode: { kind: "ready", source: "managed" } },
+        "opencode"
+      );
+
+      expect(row.status).toBe("connected");
+      expect(row.statusMessage).toBeNull();
+    });
+
+    it("reports an incompatible backend as outdated and carries its message", () => {
+      const [row] = buildAgentSelectRows([OPENCODE], { opencode: INCOMPATIBLE }, "opencode");
+
+      expect(row.status).toBe("outdated");
+      expect(row.statusMessage).toBe(INCOMPATIBLE.message);
+    });
+
+    it("reports an errored backend as error and carries its message", () => {
+      const [row] = buildAgentSelectRows([OPENCODE], { opencode: ERRORED }, "opencode");
+
+      expect(row.status).toBe("error");
+      expect(row.statusMessage).toBe(ERRORED.message);
+    });
+
+    it("reports an absent backend as absent", () => {
+      const [row] = buildAgentSelectRows([OPENCODE], { opencode: { kind: "absent" } }, "opencode");
+
+      expect(row.status).toBe("absent");
+      expect(row.statusMessage).toBeNull();
+    });
+
+    it("folds the transient checking state into absent rather than a fifth status", () => {
+      const [row] = buildAgentSelectRows(
+        [CLAUDE],
+        { claude: { kind: "checking", source: "custom" } },
+        "opencode"
+      );
+
+      expect(row.status).toBe("absent");
+    });
+
+    it("treats a backend with no reported install state as absent", () => {
+      const [row] = buildAgentSelectRows([CODEX], {}, "opencode");
+
+      expect(row.status).toBe("absent");
+    });
+
+    it("preserves the caller's descriptor order", () => {
+      const rows = buildAgentSelectRows(DISPLAY_ORDER, {}, "opencode");
+
+      expect(rows.map((row) => row.id)).toEqual(["opencode", "claude", "codex"]);
+    });
+
+    it("marks exactly one row as recommended", () => {
+      const rows = buildAgentSelectRows(DISPLAY_ORDER, {}, "opencode");
+
+      expect(rows.filter((row) => row.recommended).map((row) => row.id)).toEqual(["opencode"]);
+    });
+
+    it("copies name, description, and highlights from the descriptor", () => {
+      const [row] = buildAgentSelectRows([OPENCODE], {}, "opencode");
+
+      expect(row.name).toBe("opencode");
+      expect(row.description).toBe("opencode description");
+      expect(row.highlights).toEqual(["Copilot Plus models", "Your own provider key"]);
+    });
+
+    it("reuses one array identity for every empty highlights list across calls", () => {
+      const first = buildAgentSelectRows(DISPLAY_ORDER, {}, "opencode");
+      const second = buildAgentSelectRows(DISPLAY_ORDER, {}, "opencode");
+
+      expect(first[1].highlights).toBe(NO_SETUP_HIGHLIGHTS);
+      expect(second[2].highlights).toBe(first[1].highlights);
+    });
+
+    it("returns one shared frozen slice when there are no descriptors", () => {
+      const first = buildAgentSelectRows([], {}, "opencode");
+      const second = buildAgentSelectRows([], {}, "opencode");
+
+      expect(first).toHaveLength(0);
+      expect(second).toBe(first);
+      expect(Object.isFrozen(first)).toBe(true);
+    });
+  });
+
+  describe("resolveAgentSelectCta()", () => {
+    it("offers to start a chat on a connected agent", () => {
+      expect(resolveAgentSelectCta(rowWith({ status: "connected" }))).toEqual({
+        label: "Start chat",
+        note: "Ready to go. You can switch agents any time from the agent picker.",
+        action: "start",
+      });
+    });
+
+    it("routes an outdated agent to configure and reuses its install message verbatim", () => {
+      expect(
+        resolveAgentSelectCta(rowWith({ status: "outdated", statusMessage: INCOMPATIBLE.message }))
+      ).toEqual({
+        label: "Configure",
+        note: INCOMPATIBLE.message,
+        action: "configure",
+      });
+    });
+
+    it("routes an errored agent to configure and reuses its error message verbatim", () => {
+      expect(
+        resolveAgentSelectCta(rowWith({ status: "error", statusMessage: ERRORED.message }))
+      ).toEqual({
+        label: "Configure",
+        note: ERRORED.message,
+        action: "configure",
+      });
+    });
+
+    it("routes an absent agent to configure and names it in the note", () => {
+      expect(resolveAgentSelectCta(rowWith({ status: "absent", name: "Codex" }))).toEqual({
+        label: "Configure",
+        note: "Codex isn't set up on this machine yet.",
+        action: "configure",
+      });
+    });
+  });
+});

--- a/src/agentMode/ui/agentSelectModel.test.ts
+++ b/src/agentMode/ui/agentSelectModel.test.ts
@@ -74,14 +74,14 @@ describe("agentSelectModel", () => {
       expect(row.statusMessage).toBeNull();
     });
 
-    it("folds the transient checking state into absent rather than a fifth status", () => {
+    it("reports an in-flight readiness probe as checking", () => {
       const [row] = buildAgentSelectRows(
         [CLAUDE],
         { claude: { kind: "checking", source: "custom" } },
         "opencode"
       );
 
-      expect(row.status).toBe("absent");
+      expect(row.status).toBe("checking");
     });
 
     it("treats a backend with no reported install state as absent", () => {
@@ -120,6 +120,14 @@ describe("agentSelectModel", () => {
   });
 
   describe("resolveAgentSelectCta()", () => {
+    it("keeps a checking agent non-actionable until its probe settles", () => {
+      expect(resolveAgentSelectCta(rowWith({ status: "checking", name: "Claude" }))).toEqual({
+        label: "Checking…",
+        note: "Checking Claude setup…",
+        action: "wait",
+      });
+    });
+
     it("offers to start a chat on a connected agent", () => {
       expect(resolveAgentSelectCta(rowWith({ status: "connected" }))).toEqual({
         label: "Start chat",

--- a/src/agentMode/ui/agentSelectModel.ts
+++ b/src/agentMode/ui/agentSelectModel.ts
@@ -1,11 +1,9 @@
 import type { BackendDescriptor, BackendId, InstallState } from "@/agentMode/session/types";
 
 /**
- * Readiness of one agent as the select view words it. Deliberately narrower than
- * `InstallState`: the view only distinguishes states the user can act on, and it
- * is never rendered while a readiness check is in flight.
+ * Readiness of one agent as the select view words it.
  */
-export type AgentSelectStatus = "connected" | "outdated" | "absent" | "error";
+export type AgentSelectStatus = "checking" | "connected" | "outdated" | "absent" | "error";
 
 /** One agent row in the select view. */
 export interface AgentSelectRow {
@@ -24,7 +22,7 @@ export interface AgentSelectRow {
 }
 
 /** What the view's single call to action does for the selected row. */
-export type AgentSelectAction = "start" | "configure";
+export type AgentSelectAction = "start" | "configure" | "wait";
 
 /** Label, explanatory note, and behavior of the select view's one call to action. */
 export interface AgentSelectCta {
@@ -41,22 +39,21 @@ const EMPTY_AGENT_SELECT_ROWS: readonly AgentSelectRow[] = Object.freeze([]);
 /**
  * Narrow a backend's install state to the vocabulary the select view renders.
  *
- * `checking` collapses to `absent`: it is a transient state only Claude enters,
- * and Step 5's integration keeps the compact status card on screen for it, so it
- * never reaches this view. Folding it into the most conservative "not usable
- * yet" bucket keeps the UI vocabulary at four states instead of inventing a
- * fifth that nothing renders.
+ * A readiness probe can be in flight for one row while another unavailable
+ * backend causes the chooser to mount, so `checking` must remain distinct and
+ * non-actionable instead of making a temporary absence claim.
  */
 function toSelectStatus(kind: InstallState["kind"]): AgentSelectStatus {
   switch (kind) {
     case "ready":
       return "connected";
+    case "checking":
+      return "checking";
     case "incompatible":
       return "outdated";
     case "error":
       return "error";
     case "absent":
-    case "checking":
       return "absent";
   }
 }
@@ -98,6 +95,13 @@ export function buildAgentSelectRows(
  * @param row - The currently selected row.
  */
 export function resolveAgentSelectCta(row: AgentSelectRow): AgentSelectCta {
+  if (row.status === "checking") {
+    return {
+      label: "Checking…",
+      note: `Checking ${row.name} setup…`,
+      action: "wait",
+    };
+  }
   if (row.status === "connected") {
     return { label: "Start chat", note: READY_NOTE, action: "start" };
   }

--- a/src/agentMode/ui/agentSelectModel.ts
+++ b/src/agentMode/ui/agentSelectModel.ts
@@ -12,7 +12,6 @@ export interface AgentSelectRow {
   id: BackendId;
   name: string;
   description: string;
-  highlights: ReadonlyArray<string>;
   status: AgentSelectStatus;
   /** True for the single backend a first-run user is steered to. */
   recommended: boolean;
@@ -85,10 +84,6 @@ export function buildAgentSelectRows(
       id: descriptor.id,
       name: descriptor.displayName,
       description: descriptor.setupDescription,
-      // Handed through by reference: descriptors own frozen arrays (the empty
-      // case is the shared `NO_SETUP_HIGHLIGHTS`), so rebuilding rows never
-      // hands consumers a fresh identity for unchanged highlights.
-      highlights: descriptor.setupHighlights,
       status: toSelectStatus(state.kind),
       recommended: descriptor.id === recommendedId,
       statusMessage: statusMessageOf(state),

--- a/src/agentMode/ui/agentSelectModel.ts
+++ b/src/agentMode/ui/agentSelectModel.ts
@@ -1,0 +1,114 @@
+import type { BackendDescriptor, BackendId, InstallState } from "@/agentMode/session/types";
+
+/**
+ * Readiness of one agent as the select view words it. Deliberately narrower than
+ * `InstallState`: the view only distinguishes states the user can act on, and it
+ * is never rendered while a readiness check is in flight.
+ */
+export type AgentSelectStatus = "connected" | "outdated" | "absent" | "error";
+
+/** One agent row in the select view. */
+export interface AgentSelectRow {
+  id: BackendId;
+  name: string;
+  description: string;
+  highlights: ReadonlyArray<string>;
+  status: AgentSelectStatus;
+  /** True for the single backend a first-run user is steered to. */
+  recommended: boolean;
+  /**
+   * Operator-facing detail behind a non-`connected` status, carried straight
+   * from `InstallState.message` so version prose is never re-derived here.
+   * `null` when the install state has no message to offer.
+   */
+  statusMessage: string | null;
+}
+
+/** What the view's single call to action does for the selected row. */
+export type AgentSelectAction = "start" | "configure";
+
+/** Label, explanatory note, and behavior of the select view's one call to action. */
+export interface AgentSelectCta {
+  label: string;
+  /** Footer text beside the button, explaining what pressing it will do. */
+  note: string;
+  action: AgentSelectAction;
+}
+
+const READY_NOTE = "Ready to go. You can switch agents any time from the agent picker.";
+
+const EMPTY_AGENT_SELECT_ROWS: readonly AgentSelectRow[] = Object.freeze([]);
+
+/**
+ * Narrow a backend's install state to the vocabulary the select view renders.
+ *
+ * `checking` collapses to `absent`: it is a transient state only Claude enters,
+ * and Step 5's integration keeps the compact status card on screen for it, so it
+ * never reaches this view. Folding it into the most conservative "not usable
+ * yet" bucket keeps the UI vocabulary at four states instead of inventing a
+ * fifth that nothing renders.
+ */
+function toSelectStatus(kind: InstallState["kind"]): AgentSelectStatus {
+  switch (kind) {
+    case "ready":
+      return "connected";
+    case "incompatible":
+      return "outdated";
+    case "error":
+      return "error";
+    case "absent":
+    case "checking":
+      return "absent";
+  }
+}
+
+function statusMessageOf(state: InstallState): string | null {
+  return state.kind === "incompatible" || state.kind === "error" ? state.message : null;
+}
+
+/**
+ * Project the registered backends onto the select view's row model, preserving
+ * the caller's descriptor order so a single ordering source stays authoritative.
+ * @param descriptors - Backends to list, already in display order.
+ * @param states - Latest install state per backend id; a missing entry is treated as not set up.
+ * @param recommendedId - The backend to mark as recommended, at most one row.
+ */
+export function buildAgentSelectRows(
+  descriptors: readonly BackendDescriptor[],
+  states: Partial<Record<BackendId, InstallState>>,
+  recommendedId: BackendId
+): readonly AgentSelectRow[] {
+  if (descriptors.length === 0) return EMPTY_AGENT_SELECT_ROWS;
+  return descriptors.map((descriptor) => {
+    const state = states[descriptor.id] ?? { kind: "absent" as const };
+    return {
+      id: descriptor.id,
+      name: descriptor.displayName,
+      description: descriptor.setupDescription,
+      // Handed through by reference: descriptors own frozen arrays (the empty
+      // case is the shared `NO_SETUP_HIGHLIGHTS`), so rebuilding rows never
+      // hands consumers a fresh identity for unchanged highlights.
+      highlights: descriptor.setupHighlights,
+      status: toSelectStatus(state.kind),
+      recommended: descriptor.id === recommendedId,
+      statusMessage: statusMessageOf(state),
+    };
+  });
+}
+
+/**
+ * Resolve the one call to action the select view ends in. A connected agent can
+ * be started; everything else routes to that agent's Configure dialog, with the
+ * note explaining why.
+ * @param row - The currently selected row.
+ */
+export function resolveAgentSelectCta(row: AgentSelectRow): AgentSelectCta {
+  if (row.status === "connected") {
+    return { label: "Start chat", note: READY_NOTE, action: "start" };
+  }
+  return {
+    label: "Configure",
+    note: row.statusMessage ?? `${row.name} isn't set up on this machine yet.`,
+    action: "configure",
+  };
+}

--- a/src/agentMode/ui/useAgentSelect.test.tsx
+++ b/src/agentMode/ui/useAgentSelect.test.tsx
@@ -1,0 +1,142 @@
+import { backendRegistry } from "@/agentMode/backends/registry";
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import type { BackendId, InstallState } from "@/agentMode/session/types";
+import { logError } from "@/logger";
+import type CopilotPlugin from "@/main";
+import { act, renderHook } from "@testing-library/react";
+import { useAgentSelect } from "./useAgentSelect";
+import { useBackendInstallStates, useSessionBackendDescriptor } from "./useBackendDescriptor";
+
+jest.mock("@/logger", () => ({ logError: jest.fn() }));
+
+jest.mock("./useBackendDescriptor", () => ({
+  useBackendInstallStates: jest.fn(),
+  useSessionBackendDescriptor: jest.fn(),
+}));
+
+jest.mock("@/agentMode/backends/registry", () => {
+  const openInstallUI = jest.fn();
+  const make = (id: string, displayName: string) => ({
+    id,
+    displayName,
+    setupDescription: `${displayName} description`,
+    setupHighlights: [],
+    openInstallUI,
+  });
+  const order = [make("opencode", "opencode"), make("claude", "Claude"), make("codex", "Codex")];
+  return {
+    backendDisplayOrder: () => order,
+    backendRegistry: Object.fromEntries(order.map((descriptor) => [descriptor.id, descriptor])),
+    RECOMMENDED_BACKEND_ID: "opencode",
+  };
+});
+
+const mockInstallStates = useBackendInstallStates as jest.MockedFunction<
+  typeof useBackendInstallStates
+>;
+const mockSessionDescriptor = useSessionBackendDescriptor as jest.MockedFunction<
+  typeof useSessionBackendDescriptor
+>;
+const openInstallUI = backendRegistry.codex.openInstallUI as jest.Mock;
+
+const plugin = {} as CopilotPlugin;
+
+function makeManager(startResult: Promise<unknown> = Promise.resolve({})) {
+  return {
+    setDefaultBackend: jest.fn(),
+    getOrCreateActiveSession: jest.fn().mockReturnValue(startResult),
+  } as unknown as AgentSessionManager & {
+    setDefaultBackend: jest.Mock;
+    getOrCreateActiveSession: jest.Mock;
+  };
+}
+
+function render(
+  states: Partial<Record<BackendId, InstallState>>,
+  manager: ReturnType<typeof makeManager>
+) {
+  mockInstallStates.mockReturnValue(states as Record<BackendId, InstallState>);
+  return renderHook(() => useAgentSelect(plugin, manager));
+}
+
+describe("useAgentSelect", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSessionDescriptor.mockReturnValue(backendRegistry.opencode);
+  });
+
+  describe("useAgentSelect()", () => {
+    it("lists every backend in display order with the recommended one marked", () => {
+      const { result } = render({}, makeManager());
+
+      expect(result.current.rows.map((row) => row.id)).toEqual(["opencode", "claude", "codex"]);
+      expect(result.current.rows.filter((row) => row.recommended).map((row) => row.id)).toEqual([
+        "opencode",
+      ]);
+    });
+
+    it("preselects the backend the session would run on", () => {
+      mockSessionDescriptor.mockReturnValue(backendRegistry.claude);
+
+      const { result } = render({}, makeManager());
+
+      expect(result.current.selectedId).toBe("claude");
+    });
+
+    it("follows the selected row when resolving the call to action", () => {
+      const { result } = render(
+        { opencode: { kind: "absent" }, claude: { kind: "ready", source: "custom" } },
+        makeManager()
+      );
+
+      expect(result.current.cta.label).toBe("Configure");
+      act(() => result.current.select("claude"));
+      expect(result.current.cta.label).toBe("Start chat");
+    });
+
+    it("does not persist the default backend when a row is merely selected", () => {
+      const manager = makeManager();
+      const { result } = render({ claude: { kind: "ready", source: "custom" } }, manager);
+
+      act(() => result.current.select("claude"));
+
+      expect(manager.setDefaultBackend).not.toHaveBeenCalled();
+      expect(manager.getOrCreateActiveSession).not.toHaveBeenCalled();
+    });
+
+    it("persists the choice and spawns a session when starting a connected agent", () => {
+      const manager = makeManager();
+      const { result } = render({ claude: { kind: "ready", source: "custom" } }, manager);
+      act(() => result.current.select("claude"));
+
+      act(() => result.current.runCta());
+
+      expect(manager.setDefaultBackend).toHaveBeenCalledWith("claude");
+      expect(manager.getOrCreateActiveSession).toHaveBeenCalled();
+      expect(openInstallUI).not.toHaveBeenCalled();
+    });
+
+    it("opens the selected backend's install dialog when it is not ready", () => {
+      const manager = makeManager();
+      const { result } = render({ codex: { kind: "error", message: "boom" } }, manager);
+      act(() => result.current.select("codex"));
+
+      act(() => result.current.runCta());
+
+      expect(openInstallUI).toHaveBeenCalledWith(plugin);
+      expect(manager.setDefaultBackend).not.toHaveBeenCalled();
+    });
+
+    it("logs a failed session spawn instead of rejecting", async () => {
+      const failure = new Error("spawn failed");
+      const manager = makeManager(Promise.reject(failure));
+      const { result } = render({ opencode: { kind: "ready", source: "managed" } }, manager);
+
+      await act(async () => {
+        result.current.runCta();
+      });
+
+      expect(logError).toHaveBeenCalledWith("[AgentMode] agent select start failed", failure);
+    });
+  });
+});

--- a/src/agentMode/ui/useAgentSelect.test.tsx
+++ b/src/agentMode/ui/useAgentSelect.test.tsx
@@ -20,7 +20,6 @@ jest.mock("@/agentMode/backends/registry", () => {
     id,
     displayName,
     setupDescription: `${displayName} description`,
-    setupHighlights: [],
     openInstallUI,
   });
   const order = [make("opencode", "opencode"), make("claude", "Claude"), make("codex", "Codex")];

--- a/src/agentMode/ui/useAgentSelect.test.tsx
+++ b/src/agentMode/ui/useAgentSelect.test.tsx
@@ -126,6 +126,18 @@ describe("useAgentSelect", () => {
       expect(manager.setDefaultBackend).not.toHaveBeenCalled();
     });
 
+    it("does nothing while the selected backend's readiness check is in flight", () => {
+      const manager = makeManager();
+      const { result } = render({ claude: { kind: "checking", source: "custom" } }, manager);
+      act(() => result.current.select("claude"));
+
+      act(() => result.current.runCta());
+
+      expect(openInstallUI).not.toHaveBeenCalled();
+      expect(manager.setDefaultBackend).not.toHaveBeenCalled();
+      expect(manager.getOrCreateActiveSession).not.toHaveBeenCalled();
+    });
+
     it("logs a failed session spawn instead of rejecting", async () => {
       const failure = new Error("spawn failed");
       const manager = makeManager(Promise.reject(failure));

--- a/src/agentMode/ui/useAgentSelect.ts
+++ b/src/agentMode/ui/useAgentSelect.ts
@@ -1,0 +1,75 @@
+import {
+  backendDisplayOrder,
+  backendRegistry,
+  RECOMMENDED_BACKEND_ID,
+} from "@/agentMode/backends/registry";
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import type { BackendId } from "@/agentMode/session/types";
+import {
+  buildAgentSelectRows,
+  resolveAgentSelectCta,
+  type AgentSelectCta,
+  type AgentSelectRow,
+} from "@/agentMode/ui/agentSelectModel";
+import {
+  useBackendInstallStates,
+  useSessionBackendDescriptor,
+} from "@/agentMode/ui/useBackendDescriptor";
+import { logError } from "@/logger";
+import React from "react";
+import type CopilotPlugin from "@/main";
+
+/** Everything the agent select view renders and the one action it commits. */
+export interface AgentSelectState {
+  rows: readonly AgentSelectRow[];
+  selectedId: BackendId;
+  /** Highlight a different agent. Local only — nothing is persisted until `runCta`. */
+  select: (id: BackendId) => void;
+  cta: AgentSelectCta;
+  /** Start a chat on the selected agent, or open its Configure dialog. */
+  runCta: () => void;
+}
+
+/**
+ * Wire the agent select view to the registry, live install states, and the
+ * session manager. Derivation lives in `agentSelectModel`; this hook only owns
+ * the transient selection and turns the resolved call to action into an effect.
+ * @param plugin - Plugin instance backing readiness subscriptions and Configure dialogs.
+ * @param manager - Session manager that commits the choice and spawns the chat.
+ */
+export function useAgentSelect(
+  plugin: CopilotPlugin,
+  manager: AgentSessionManager | null | undefined
+): AgentSelectState {
+  const descriptors = backendDisplayOrder();
+  const states = useBackendInstallStates(plugin);
+  // Until the user picks a row, the selection follows whichever backend would
+  // actually run, so the view opens on the agent the CTA would act upon.
+  const sessionBackendId = useSessionBackendDescriptor(manager).id;
+  const [pickedId, setPickedId] = React.useState<BackendId | null>(null);
+  const selectedId = pickedId ?? sessionBackendId;
+
+  const rows = React.useMemo(
+    () => buildAgentSelectRows(descriptors, states, RECOMMENDED_BACKEND_ID),
+    [descriptors, states]
+  );
+  const selectedRow = rows.find((row) => row.id === selectedId) ?? rows[0];
+  const cta = React.useMemo(() => resolveAgentSelectCta(selectedRow), [selectedRow]);
+
+  const runCta = React.useCallback(() => {
+    const id = selectedRow.id;
+    if (cta.action === "configure") {
+      backendRegistry[id].openInstallUI(plugin);
+      return;
+    }
+    if (!manager) return;
+    // Persisting the choice is the point: without it the next launch would drop
+    // the user back here instead of on the agent they deliberately picked.
+    manager.setDefaultBackend(id);
+    manager.getOrCreateActiveSession().catch((e) => {
+      logError("[AgentMode] agent select start failed", e);
+    });
+  }, [cta.action, manager, plugin, selectedRow.id]);
+
+  return { rows, selectedId, select: setPickedId, cta, runCta };
+}

--- a/src/agentMode/ui/useAgentSelect.ts
+++ b/src/agentMode/ui/useAgentSelect.ts
@@ -58,6 +58,7 @@ export function useAgentSelect(
 
   const runCta = React.useCallback(() => {
     const id = selectedRow.id;
+    if (cta.action === "wait") return;
     if (cta.action === "configure") {
       backendRegistry[id].openInstallUI(plugin);
       return;

--- a/src/agentMode/ui/useBackendDescriptor.test.tsx
+++ b/src/agentMode/ui/useBackendDescriptor.test.tsx
@@ -1,11 +1,16 @@
 import { act, renderHook } from "@testing-library/react";
 import { backendRegistry, getActiveBackendDescriptor } from "@/agentMode/backends/registry";
+import type { BackendId } from "@/agentMode/session/types";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import type { BackendDescriptor, InstallState } from "@/agentMode/session/types";
 import type CopilotPlugin from "@/main";
 import type { CopilotSettings } from "@/settings/model";
 import React from "react";
-import { useBackendInstallState, useSessionBackendDescriptor } from "./useBackendDescriptor";
+import {
+  useBackendInstallState,
+  useBackendInstallStates,
+  useSessionBackendDescriptor,
+} from "./useBackendDescriptor";
 
 let mockSettings = {} as CopilotSettings;
 
@@ -13,10 +18,14 @@ jest.mock("@/settings/model", () => ({
   useSettingsValue: () => React.useMemo(() => mockSettings, []),
 }));
 
-jest.mock("@/agentMode/backends/registry", () => ({
-  backendRegistry: {},
-  getActiveBackendDescriptor: jest.fn(),
-}));
+jest.mock("@/agentMode/backends/registry", () => {
+  const registry: Record<string, unknown> = {};
+  return {
+    backendRegistry: registry,
+    getActiveBackendDescriptor: jest.fn(),
+    listBackendDescriptors: () => Object.values(registry),
+  };
+});
 
 const mockGetActiveBackendDescriptor = getActiveBackendDescriptor as jest.MockedFunction<
   typeof getActiveBackendDescriptor
@@ -51,11 +60,11 @@ function makeManager() {
   };
 }
 
-function makeInstallDescriptor(initial: InstallState) {
+function makeInstallDescriptor(initial: InstallState, id: BackendId = "claude") {
   let state = initial;
   const listeners = new Set<() => void>();
   const backend = {
-    id: "claude",
+    id,
     getInstallState: () => ({ ...state }),
     subscribeInstallState: (_plugin: CopilotPlugin, listener: () => void) => {
       listeners.add(listener);
@@ -163,6 +172,60 @@ describe("useBackendDescriptor", () => {
       unmount();
 
       expect(fake.unsubscribed()).toBe(true);
+    });
+  });
+
+  describe("useBackendInstallStates()", () => {
+    it("reports every registered backend's state keyed by id", () => {
+      const opencode = makeInstallDescriptor({ kind: "ready", source: "managed" }, "opencode");
+      const claude = makeInstallDescriptor({ kind: "absent" }, "claude");
+      registry.opencode = opencode.backend;
+      registry.claude = claude.backend;
+
+      const { result } = renderHook(() => useBackendInstallStates({} as CopilotPlugin));
+
+      expect(result.current).toEqual({
+        opencode: { kind: "ready", source: "managed" },
+        claude: { kind: "absent" },
+      });
+    });
+
+    it("updates when any single backend's install state changes", () => {
+      const opencode = makeInstallDescriptor({ kind: "ready", source: "managed" }, "opencode");
+      const claude = makeInstallDescriptor({ kind: "absent" }, "claude");
+      registry.opencode = opencode.backend;
+      registry.claude = claude.backend;
+      const { result } = renderHook(() => useBackendInstallStates({} as CopilotPlugin));
+
+      act(() => claude.emit({ kind: "ready", source: "custom" }));
+
+      expect(result.current.claude).toEqual({ kind: "ready", source: "custom" });
+      expect(result.current.opencode).toEqual({ kind: "ready", source: "managed" });
+    });
+
+    it("keeps the same record identity when a notification changes nothing", () => {
+      const ready: InstallState = { kind: "ready", source: "managed" };
+      const opencode = makeInstallDescriptor(ready, "opencode");
+      registry.opencode = opencode.backend;
+      const { result } = renderHook(() => useBackendInstallStates({} as CopilotPlugin));
+      const before = result.current;
+
+      act(() => opencode.emit(ready));
+
+      expect(result.current).toBe(before);
+    });
+
+    it("unsubscribes from every backend on unmount", () => {
+      const opencode = makeInstallDescriptor({ kind: "absent" }, "opencode");
+      const claude = makeInstallDescriptor({ kind: "absent" }, "claude");
+      registry.opencode = opencode.backend;
+      registry.claude = claude.backend;
+      const { unmount } = renderHook(() => useBackendInstallStates({} as CopilotPlugin));
+
+      unmount();
+
+      expect(opencode.unsubscribed()).toBe(true);
+      expect(claude.unsubscribed()).toBe(true);
     });
   });
 });

--- a/src/agentMode/ui/useBackendDescriptor.test.tsx
+++ b/src/agentMode/ui/useBackendDescriptor.test.tsx
@@ -5,7 +5,6 @@ import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManage
 import type { BackendDescriptor, InstallState } from "@/agentMode/session/types";
 import type CopilotPlugin from "@/main";
 import type { CopilotSettings } from "@/settings/model";
-import React from "react";
 import {
   useBackendInstallState,
   useBackendInstallStates,
@@ -14,9 +13,11 @@ import {
 
 let mockSettings = {} as CopilotSettings;
 
+/* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mock name must match */
 jest.mock("@/settings/model", () => ({
-  useSettingsValue: () => React.useMemo(() => mockSettings, []),
+  useSettingsValue: () => mockSettings,
 }));
+/* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 
 jest.mock("@/agentMode/backends/registry", () => {
   const registry: Record<string, unknown> = {};
@@ -176,6 +177,17 @@ describe("useBackendDescriptor", () => {
   });
 
   describe("useBackendInstallStates()", () => {
+    it("reuses one frozen empty record across settings identity changes", () => {
+      const { result, rerender } = renderHook(() => useBackendInstallStates({} as CopilotPlugin));
+      const first = result.current;
+
+      mockSettings = { ...mockSettings };
+      rerender();
+
+      expect(result.current).toBe(first);
+      expect(Object.isFrozen(result.current)).toBe(true);
+    });
+
     it("reports every registered backend's state keyed by id", () => {
       const opencode = makeInstallDescriptor({ kind: "ready", source: "managed" }, "opencode");
       const claude = makeInstallDescriptor({ kind: "absent" }, "claude");

--- a/src/agentMode/ui/useBackendDescriptor.ts
+++ b/src/agentMode/ui/useBackendDescriptor.ts
@@ -16,6 +16,8 @@ import { Notice } from "obsidian";
 import React from "react";
 import type CopilotPlugin from "@/main";
 
+const EMPTY_BACKEND_INSTALL_STATES = Object.freeze({}) as Record<BackendId, InstallState>;
+
 function installStateSignature(state: InstallState): string {
   switch (state.kind) {
     case "absent":
@@ -133,8 +135,10 @@ export function useBackendInstallStates(plugin: CopilotPlugin): Record<BackendId
   const signature = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   return React.useMemo(() => {
     void signature;
+    const descriptors = listBackendDescriptors();
+    if (descriptors.length === 0) return EMPTY_BACKEND_INSTALL_STATES;
     const states = {} as Record<BackendId, InstallState>;
-    for (const descriptor of listBackendDescriptors()) {
+    for (const descriptor of descriptors) {
       states[descriptor.id] = descriptor.getInstallState(settings);
     }
     return states;

--- a/src/agentMode/ui/useBackendDescriptor.ts
+++ b/src/agentMode/ui/useBackendDescriptor.ts
@@ -1,6 +1,15 @@
-import { backendRegistry, getActiveBackendDescriptor } from "@/agentMode/backends/registry";
+import {
+  backendRegistry,
+  getActiveBackendDescriptor,
+  listBackendDescriptors,
+} from "@/agentMode/backends/registry";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
-import type { BackendAuthStatus, BackendDescriptor, InstallState } from "@/agentMode/session/types";
+import type {
+  BackendAuthStatus,
+  BackendDescriptor,
+  BackendId,
+  InstallState,
+} from "@/agentMode/session/types";
 import { logError } from "@/logger";
 import { useSettingsValue } from "@/settings/model";
 import { Notice } from "obsidian";
@@ -87,6 +96,49 @@ export function useBackendInstallState(
     void signature;
     return descriptor.getInstallState(settings);
   }, [descriptor, settings, signature]);
+}
+
+/**
+ * Same contract as `useBackendInstallState`, widened to every registered
+ * backend at once, for surfaces that list all agents side by side. One store
+ * subscription fans out to every descriptor and the snapshot is the joined
+ * signature, so a descriptor that allocates a fresh state object per read still
+ * cannot force a rerender — and the returned record keeps its identity until a
+ * backend's readiness actually changes.
+ * @param plugin - The plugin instance used to subscribe to backend-specific readiness changes.
+ */
+export function useBackendInstallStates(plugin: CopilotPlugin): Record<BackendId, InstallState> {
+  const settings = useSettingsValue();
+  const subscribe = React.useCallback(
+    (listener: () => void) => {
+      const unsubscribes = listBackendDescriptors().map((descriptor) =>
+        descriptor.subscribeInstallState(plugin, listener)
+      );
+      return () => {
+        for (const unsubscribe of unsubscribes) unsubscribe();
+      };
+    },
+    [plugin]
+  );
+  const getSnapshot = React.useCallback(
+    () =>
+      listBackendDescriptors()
+        .map(
+          (descriptor) =>
+            `${descriptor.id}=${installStateSignature(descriptor.getInstallState(settings))}`
+        )
+        .join("|"),
+    [settings]
+  );
+  const signature = React.useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return React.useMemo(() => {
+    void signature;
+    const states = {} as Record<BackendId, InstallState>;
+    for (const descriptor of listBackendDescriptors()) {
+      states[descriptor.id] = descriptor.getInstallState(settings);
+    }
+    return states;
+  }, [settings, signature]);
 }
 
 export interface BackendAuthUiState {


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#228

## Why

First-run Agent Mode currently describes only one unavailable agent and offers one action: a user whose recommended opencode backend is missing sees only opencode's setup prompt, even when another agent such as Claude or Codex is already installed and could start a chat immediately. Nothing compares the agents side by side or tells the user whether the one they pick can start now or needs setup first.

## What

The selection model now lists every registered agent in display order, marks the recommended agent, shows each agent's live readiness as install checks settle, and derives one action from the selected agent's readiness:

| Agent readiness | Selection status | Action | Confirming the action |
| --- | --- | --- | --- |
| Ready | Connected | Start chat | Save the selected agent and start its session |
| Install check in flight | Checking | Checking… (non-actionable) | Does nothing until the check settles |
| Unsupported version | Outdated | Configure | Open that agent's setup without changing the saved agent |
| Installation error | Error | Configure | Show the existing error and open that agent's setup |
| Not installed | Not set up | Configure | Explain that setup is required and open it |

Selecting a row is temporary: it changes neither settings nor sessions until the user confirms the action.

## Non goal

- Render or mount the agent selection view.
- Change backend readiness probing, model picking, or configuration dialogs.

## Screenshot

Not applicable — this PR defines the selection states and their actions without mounting any view, so there is no rendered surface to capture.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | The unmounted selection contract and every readiness/action branch have deterministic Jest coverage |
| A defect would fail CI or be obvious on first use | ✅ | `agentSelectModel`, `useAgentSelect`, and `useBackendDescriptor` tests pin the contract |
| A revert fully restores prior state, including persisted data | ✅ | The selection model and hooks are additive and persist only on confirmation |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The new actions reuse existing setup and session entry points |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The selection types are internal and no persisted format changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The new state model is not mounted on a shipped path in this PR |
| No hot-path behavior lacks deterministic coverage | ✅ | Every decision branch is covered before a view consumes it |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Not applicable; this slice has no rendered surface and is deterministically covered |

Review: skim the decision table in **What**, confirm CI is green, and run Verification steps 1–3 if you want to inspect the branch coverage locally.

## Verification

1. On the PR branch, run `npm run test -- src/agentMode/ui` and confirm all three suites pass.
2. Confirm the passing `agentSelectModel` cases cover every readiness in the table above, including that outdated and errored agents reuse their install message verbatim as the action's note.
3. Confirm the passing `useAgentSelect` cases show that highlighting a row persists nothing, **Start chat** saves the agent and spawns its session, **Configure** opens that agent's setup without changing the saved agent, and a checking agent stays non-actionable.
