### PR TITLE
[Agent view onboarding] - Step 4: Render the agent selection view

### DIFF
--- a/src/agentMode/ui/AgentSelectView.stories.tsx
+++ b/src/agentMode/ui/AgentSelectView.stories.tsx
@@ -65,7 +65,7 @@ const meta = {
     footerNote: "opencode isn't set up on this machine yet.",
     onCta: () => undefined,
   },
-  parameters: { gallery: { host: "leaf", layout: "padded", width: 300 } },
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
 } satisfies Meta<AgentSelectViewProps>;
 export default meta;
 

--- a/src/agentMode/ui/AgentSelectView.stories.tsx
+++ b/src/agentMode/ui/AgentSelectView.stories.tsx
@@ -10,7 +10,6 @@ const OPENCODE: AgentSelectRow = {
   name: "opencode",
   description:
     "Copilot Plus models, or any model on your own provider key. Copilot can download and manage the binary for you.",
-  highlights: ["Copilot Plus models", "Your own provider key"],
   status: "absent",
   recommended: true,
   statusMessage: null,
@@ -21,7 +20,6 @@ const CLAUDE: AgentSelectRow = {
   name: "Claude",
   description:
     "Anthropic models, billed to your Claude Code subscription. Runs the claude CLI already on your machine.",
-  highlights: [],
   status: "absent",
   recommended: false,
   statusMessage: null,
@@ -32,7 +30,6 @@ const CODEX: AgentSelectRow = {
   name: "Codex",
   description:
     "OpenAI models, billed to your ChatGPT subscription. Runs the codex-acp adapter on your machine.",
-  highlights: [],
   status: "absent",
   recommended: false,
   statusMessage: null,

--- a/src/agentMode/ui/AgentSelectView.stories.tsx
+++ b/src/agentMode/ui/AgentSelectView.stories.tsx
@@ -35,19 +35,21 @@ const CODEX: AgentSelectRow = {
   statusMessage: null,
 };
 
-const AgentSelectStory: React.FC<AgentSelectViewProps> = (args) => {
-  const [selectedId, setSelectedId] = React.useState(args.selectedId);
-  const selectedRow = args.rows.find((row) => row.id === selectedId) ?? args.rows[0];
+const AgentSelectStory: React.FC<Partial<AgentSelectViewProps>> = (args) => {
+  const rows = args.rows ?? [OPENCODE, CLAUDE, CODEX];
+  const [selectedId, setSelectedId] = React.useState(args.selectedId ?? "opencode");
+  const selectedRow = rows.find((row) => row.id === selectedId) ?? rows[0];
   const cta = resolveAgentSelectCta(selectedRow);
 
   return (
     <AgentSelectView
-      {...args}
+      rows={rows}
       selectedId={selectedId}
       onSelect={setSelectedId}
       ctaLabel={cta.label}
       footerNote={cta.note}
       ctaDisabled={cta.action === "wait"}
+      onCta={args.onCta ?? (() => undefined)}
     />
   );
 };
@@ -63,19 +65,20 @@ const meta = {
     footerNote: "opencode isn't set up on this machine yet.",
     onCta: () => undefined,
   },
-  render: (args) => <AgentSelectStory {...args} />,
   parameters: { gallery: { host: "leaf", layout: "padded", width: 300 } },
 } satisfies Meta<AgentSelectViewProps>;
 export default meta;
 
 export const NothingSetUp: StoryObj<AgentSelectViewProps> = {
   args: {},
+  render: AgentSelectStory,
 };
 
 export const OpencodeConnected: StoryObj<AgentSelectViewProps> = {
   args: {
     rows: [{ ...OPENCODE, status: "connected" }, CLAUDE, CODEX],
   },
+  render: AgentSelectStory,
 };
 
 export const ClaudeChecking: StoryObj<AgentSelectViewProps> = {
@@ -83,6 +86,7 @@ export const ClaudeChecking: StoryObj<AgentSelectViewProps> = {
     rows: [OPENCODE, { ...CLAUDE, status: "checking" }, CODEX],
     selectedId: "claude",
   },
+  render: AgentSelectStory,
 };
 
 export const ClaudeUpdateRequired: StoryObj<AgentSelectViewProps> = {
@@ -98,6 +102,7 @@ export const ClaudeUpdateRequired: StoryObj<AgentSelectViewProps> = {
     ],
     selectedId: "claude",
   },
+  render: AgentSelectStory,
 };
 
 export const CodexError: StoryObj<AgentSelectViewProps> = {
@@ -113,6 +118,7 @@ export const CodexError: StoryObj<AgentSelectViewProps> = {
     ],
     selectedId: "codex",
   },
+  render: AgentSelectStory,
 };
 
 export const LongAgentName: StoryObj<AgentSelectViewProps> = {
@@ -129,4 +135,5 @@ export const LongAgentName: StoryObj<AgentSelectViewProps> = {
       CODEX,
     ],
   },
+  render: AgentSelectStory,
 };

--- a/src/agentMode/ui/AgentSelectView.stories.tsx
+++ b/src/agentMode/ui/AgentSelectView.stories.tsx
@@ -1,0 +1,119 @@
+import type { AgentSelectRow } from "@/agentMode/ui/agentSelectModel";
+import { AgentSelectView } from "@/agentMode/ui/AgentSelectView";
+import type { Meta, StoryObj } from "@/lib/story";
+import type * as React from "react";
+
+type AgentSelectViewProps = React.ComponentProps<typeof AgentSelectView>;
+
+const OPENCODE: AgentSelectRow = {
+  id: "opencode",
+  name: "opencode",
+  description:
+    "Copilot Plus models, or any model on your own provider key. Copilot can download and manage the binary for you.",
+  highlights: ["Copilot Plus models", "Your own provider key"],
+  status: "absent",
+  recommended: true,
+  statusMessage: null,
+};
+
+const CLAUDE: AgentSelectRow = {
+  id: "claude",
+  name: "Claude",
+  description:
+    "Anthropic models, billed to your Claude Code subscription. Runs the claude CLI already on your machine.",
+  highlights: [],
+  status: "absent",
+  recommended: false,
+  statusMessage: null,
+};
+
+const CODEX: AgentSelectRow = {
+  id: "codex",
+  name: "Codex",
+  description:
+    "OpenAI models, billed to your ChatGPT subscription. Runs the codex-acp adapter on your machine.",
+  highlights: [],
+  status: "absent",
+  recommended: false,
+  statusMessage: null,
+};
+
+const meta = {
+  title: "Agent Mode/Agent Select View",
+  component: AgentSelectView,
+  args: {
+    rows: [OPENCODE, CLAUDE, CODEX],
+    selectedId: "opencode",
+    onSelect: () => undefined,
+    onCta: () => undefined,
+  },
+  parameters: { gallery: { host: "leaf", layout: "padded", width: 300 } },
+} satisfies Meta<AgentSelectViewProps>;
+export default meta;
+
+export const NothingSetUp: StoryObj<AgentSelectViewProps> = {
+  args: {
+    ctaLabel: "Configure",
+    footerNote: "opencode isn't set up on this machine yet.",
+  },
+};
+
+export const OpencodeConnected: StoryObj<AgentSelectViewProps> = {
+  args: {
+    rows: [{ ...OPENCODE, status: "connected" }, CLAUDE, CODEX],
+    ctaLabel: "Start chat",
+    footerNote: "Ready to go. You can switch agents any time from the agent picker.",
+  },
+};
+
+export const ClaudeUpdateRequired: StoryObj<AgentSelectViewProps> = {
+  args: {
+    rows: [
+      { ...OPENCODE, status: "connected" },
+      {
+        ...CLAUDE,
+        status: "outdated",
+        statusMessage: "Claude 2.1.205 is not supported. Copilot requires 2.1.206 or newer.",
+      },
+      CODEX,
+    ],
+    selectedId: "claude",
+    ctaLabel: "Configure",
+    footerNote: "Claude 2.1.205 is not supported. Copilot requires 2.1.206 or newer.",
+  },
+};
+
+export const CodexError: StoryObj<AgentSelectViewProps> = {
+  args: {
+    rows: [
+      OPENCODE,
+      CLAUDE,
+      {
+        ...CODEX,
+        status: "error",
+        statusMessage: "Could not read the Codex binary at /usr/local/bin/codex-acp.",
+      },
+    ],
+    selectedId: "codex",
+    ctaLabel: "Configure",
+    footerNote: "Could not read the Codex binary at /usr/local/bin/codex-acp.",
+  },
+};
+
+export const LongAgentName: StoryObj<AgentSelectViewProps> = {
+  args: {
+    rows: [
+      {
+        ...OPENCODE,
+        name: "Very Long Local Agent Backend Name",
+        description:
+          "Runs every Copilot Plus model plus anything reachable on your own provider key, and Copilot will download, verify, and keep the managed binary up to date for you without leaving the vault.",
+        status: "connected",
+      },
+      CLAUDE,
+      CODEX,
+    ],
+    ctaLabel: "Start chat",
+    footerNote: "Ready to go. You can switch agents any time from the agent picker.",
+  },
+};

--- a/src/agentMode/ui/AgentSelectView.stories.tsx
+++ b/src/agentMode/ui/AgentSelectView.stories.tsx
@@ -1,7 +1,7 @@
-import type { AgentSelectRow } from "@/agentMode/ui/agentSelectModel";
+import { resolveAgentSelectCta, type AgentSelectRow } from "@/agentMode/ui/agentSelectModel";
 import { AgentSelectView } from "@/agentMode/ui/AgentSelectView";
 import type { Meta, StoryObj } from "@/lib/story";
-import type * as React from "react";
+import React from "react";
 
 type AgentSelectViewProps = React.ComponentProps<typeof AgentSelectView>;
 
@@ -35,6 +35,23 @@ const CODEX: AgentSelectRow = {
   statusMessage: null,
 };
 
+const AgentSelectStory: React.FC<AgentSelectViewProps> = (args) => {
+  const [selectedId, setSelectedId] = React.useState(args.selectedId);
+  const selectedRow = args.rows.find((row) => row.id === selectedId) ?? args.rows[0];
+  const cta = resolveAgentSelectCta(selectedRow);
+
+  return (
+    <AgentSelectView
+      {...args}
+      selectedId={selectedId}
+      onSelect={setSelectedId}
+      ctaLabel={cta.label}
+      footerNote={cta.note}
+      ctaDisabled={cta.action === "wait"}
+    />
+  );
+};
+
 const meta = {
   title: "Agent Mode/Agent Select View",
   component: AgentSelectView,
@@ -42,24 +59,29 @@ const meta = {
     rows: [OPENCODE, CLAUDE, CODEX],
     selectedId: "opencode",
     onSelect: () => undefined,
+    ctaLabel: "Configure",
+    footerNote: "opencode isn't set up on this machine yet.",
     onCta: () => undefined,
   },
+  render: (args) => <AgentSelectStory {...args} />,
   parameters: { gallery: { host: "leaf", layout: "padded", width: 300 } },
 } satisfies Meta<AgentSelectViewProps>;
 export default meta;
 
 export const NothingSetUp: StoryObj<AgentSelectViewProps> = {
-  args: {
-    ctaLabel: "Configure",
-    footerNote: "opencode isn't set up on this machine yet.",
-  },
+  args: {},
 };
 
 export const OpencodeConnected: StoryObj<AgentSelectViewProps> = {
   args: {
     rows: [{ ...OPENCODE, status: "connected" }, CLAUDE, CODEX],
-    ctaLabel: "Start chat",
-    footerNote: "Ready to go. You can switch agents any time from the agent picker.",
+  },
+};
+
+export const ClaudeChecking: StoryObj<AgentSelectViewProps> = {
+  args: {
+    rows: [OPENCODE, { ...CLAUDE, status: "checking" }, CODEX],
+    selectedId: "claude",
   },
 };
 
@@ -75,8 +97,6 @@ export const ClaudeUpdateRequired: StoryObj<AgentSelectViewProps> = {
       CODEX,
     ],
     selectedId: "claude",
-    ctaLabel: "Configure",
-    footerNote: "Claude 2.1.205 is not supported. Copilot requires 2.1.206 or newer.",
   },
 };
 
@@ -92,8 +112,6 @@ export const CodexError: StoryObj<AgentSelectViewProps> = {
       },
     ],
     selectedId: "codex",
-    ctaLabel: "Configure",
-    footerNote: "Could not read the Codex binary at /usr/local/bin/codex-acp.",
   },
 };
 
@@ -110,7 +128,5 @@ export const LongAgentName: StoryObj<AgentSelectViewProps> = {
       CLAUDE,
       CODEX,
     ],
-    ctaLabel: "Start chat",
-    footerNote: "Ready to go. You can switch agents any time from the agent picker.",
   },
 };

--- a/src/agentMode/ui/AgentSelectView.test.tsx
+++ b/src/agentMode/ui/AgentSelectView.test.tsx
@@ -54,6 +54,7 @@ describe("AgentSelectView", () => {
     });
 
     it.each<[AgentSelectStatus, string]>([
+      ["checking", "Checking…"],
       ["connected", "Connected"],
       ["outdated", "Update required"],
       ["error", "Error"],
@@ -94,6 +95,14 @@ describe("AgentSelectView", () => {
 
       expect(onCta).toHaveBeenCalledTimes(1);
       expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("disables the call to action while readiness is being checked", () => {
+      const { onCta } = renderView({ ctaLabel: "Checking…", ctaDisabled: true });
+
+      fireEvent.click(screen.getByRole("button", { name: "Checking…" }));
+
+      expect(onCta).not.toHaveBeenCalled();
     });
 
     it("moves the selection with the arrow keys, wrapping past both ends", () => {

--- a/src/agentMode/ui/AgentSelectView.test.tsx
+++ b/src/agentMode/ui/AgentSelectView.test.tsx
@@ -48,6 +48,12 @@ describe("AgentSelectView", () => {
       expect(checked[0].textContent).toContain("claude");
     });
 
+    it("omits the redundant agent explanation", () => {
+      renderView();
+
+      expect(screen.queryByText(/An agent runs your tasks on this machine/)).toBeNull();
+    });
+
     it.each<[AgentSelectStatus, string]>([
       ["connected", "Connected"],
       ["outdated", "Update required"],

--- a/src/agentMode/ui/AgentSelectView.test.tsx
+++ b/src/agentMode/ui/AgentSelectView.test.tsx
@@ -7,7 +7,6 @@ function row(overrides: Partial<AgentSelectRow> & Pick<AgentSelectRow, "id">): A
   return {
     name: overrides.id,
     description: `${overrides.id} description`,
-    highlights: [],
     status: "absent",
     recommended: false,
     statusMessage: null,
@@ -16,7 +15,7 @@ function row(overrides: Partial<AgentSelectRow> & Pick<AgentSelectRow, "id">): A
 }
 
 const ROWS: readonly AgentSelectRow[] = [
-  row({ id: "opencode", highlights: ["Copilot Plus models"], recommended: true }),
+  row({ id: "opencode", recommended: true }),
   row({ id: "claude" }),
   row({ id: "codex" }),
 ];
@@ -73,11 +72,10 @@ describe("AgentSelectView", () => {
       expect(screen.queryByText(/not found/i)).toBeNull();
     });
 
-    it("renders the recommendation and highlight badges of the rows that carry them", () => {
+    it("renders the recommendation badge on the row that carries it", () => {
       renderView();
 
       expect(screen.getAllByText("Recommended")).toHaveLength(1);
-      expect(screen.getByText("Copilot Plus models")).toBeTruthy();
     });
 
     it("reports the clicked agent without running the call to action", () => {

--- a/src/agentMode/ui/AgentSelectView.test.tsx
+++ b/src/agentMode/ui/AgentSelectView.test.tsx
@@ -1,0 +1,122 @@
+import type { AgentSelectRow, AgentSelectStatus } from "@/agentMode/ui/agentSelectModel";
+import { AgentSelectView } from "@/agentMode/ui/AgentSelectView";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+function row(overrides: Partial<AgentSelectRow> & Pick<AgentSelectRow, "id">): AgentSelectRow {
+  return {
+    name: overrides.id,
+    description: `${overrides.id} description`,
+    highlights: [],
+    status: "absent",
+    recommended: false,
+    statusMessage: null,
+    ...overrides,
+  };
+}
+
+const ROWS: readonly AgentSelectRow[] = [
+  row({ id: "opencode", highlights: ["Copilot Plus models"], recommended: true }),
+  row({ id: "claude" }),
+  row({ id: "codex" }),
+];
+
+function renderView(overrides: Partial<React.ComponentProps<typeof AgentSelectView>> = {}) {
+  const props = {
+    rows: ROWS,
+    selectedId: "opencode" as const,
+    onSelect: jest.fn(),
+    ctaLabel: "Configure",
+    footerNote: "opencode isn't set up on this machine yet.",
+    onCta: jest.fn(),
+    ...overrides,
+  };
+  render(<AgentSelectView {...props} />);
+  return props;
+}
+
+describe("AgentSelectView", () => {
+  describe("AgentSelectView()", () => {
+    it("names the radiogroup after the visible heading and marks exactly one row checked", () => {
+      renderView({ selectedId: "claude" });
+
+      expect(screen.getByRole("radiogroup", { name: "Select your agent" })).toBeTruthy();
+      const checked = screen
+        .getAllByRole("radio")
+        .filter((radio) => radio.getAttribute("aria-checked") === "true");
+      expect(checked).toHaveLength(1);
+      expect(checked[0].textContent).toContain("claude");
+    });
+
+    it.each<[AgentSelectStatus, string]>([
+      ["connected", "Connected"],
+      ["outdated", "Update required"],
+      ["error", "Error"],
+    ])("badges the %s status on the agent's row", (status, label) => {
+      renderView({ rows: [row({ id: "claude", status })] });
+
+      expect(screen.getByText(label)).toBeTruthy();
+    });
+
+    it("shows no status badge for an agent that is not set up", () => {
+      renderView({ rows: [row({ id: "claude", status: "absent" })] });
+
+      expect(screen.queryByText("Connected")).toBeNull();
+      expect(screen.queryByText("Update required")).toBeNull();
+      expect(screen.queryByText("Error")).toBeNull();
+      expect(screen.queryByText(/not found/i)).toBeNull();
+    });
+
+    it("renders the recommendation and highlight badges of the rows that carry them", () => {
+      renderView();
+
+      expect(screen.getAllByText("Recommended")).toHaveLength(1);
+      expect(screen.getByText("Copilot Plus models")).toBeTruthy();
+    });
+
+    it("reports the clicked agent without running the call to action", () => {
+      const { onSelect, onCta } = renderView();
+
+      fireEvent.click(screen.getAllByRole("radio")[1]);
+
+      expect(onSelect).toHaveBeenCalledWith("claude");
+      expect(onCta).not.toHaveBeenCalled();
+    });
+
+    it("runs the call to action when its button is pressed", () => {
+      const { onCta, onSelect } = renderView({ ctaLabel: "Start chat" });
+
+      fireEvent.click(screen.getByRole("button", { name: "Start chat" }));
+
+      expect(onCta).toHaveBeenCalledTimes(1);
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("moves the selection with the arrow keys, wrapping past both ends", () => {
+      const { onSelect } = renderView();
+      const radios = screen.getAllByRole("radio");
+
+      fireEvent.keyDown(radios[0], { key: "ArrowDown" });
+      expect(onSelect).toHaveBeenLastCalledWith("claude");
+
+      fireEvent.keyDown(radios[0], { key: "ArrowUp" });
+      expect(onSelect).toHaveBeenLastCalledWith("codex");
+    });
+
+    it("keeps the selected row as the group's only tab stop", () => {
+      renderView({ selectedId: "codex" });
+
+      expect(screen.getAllByRole("radio").map((radio) => radio.getAttribute("tabindex"))).toEqual([
+        "-1",
+        "-1",
+        "0",
+      ]);
+    });
+
+    it("shows the footer note beside the call to action", () => {
+      renderView({ footerNote: "Ready to go." });
+
+      expect(screen.getByText("Ready to go.")).toBeTruthy();
+    });
+  });
+});

--- a/src/agentMode/ui/AgentSelectView.tsx
+++ b/src/agentMode/ui/AgentSelectView.tsx
@@ -1,0 +1,184 @@
+import type { BackendId } from "@/agentMode/session/types";
+import type { AgentSelectRow, AgentSelectStatus } from "@/agentMode/ui/agentSelectModel";
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { AlertTriangle, Check, type LucideIcon } from "lucide-react";
+import React from "react";
+
+interface StatusBadgeSpec {
+  label: string;
+  variant: BadgeProps["variant"];
+  Icon: LucideIcon;
+}
+
+/**
+ * Status vocabulary shown beside an agent's name. `absent` is deliberately
+ * absent from this map: the design communicates "not set up" through the
+ * footer note and the Configure call to action, not a badge on the row.
+ *
+ * `error` is not drawn in the design. It reuses the `outdated` treatment and
+ * says only "Error" — the row's `statusMessage` already reaches the user
+ * through the footer note whenever that row is selected, so repeating the
+ * prose here would only cost width in a 300px leaf.
+ */
+const STATUS_BADGES: Partial<Record<AgentSelectStatus, StatusBadgeSpec>> = {
+  connected: { label: "Connected", variant: "success", Icon: Check },
+  outdated: { label: "Update required", variant: "destructive", Icon: AlertTriangle },
+  error: { label: "Error", variant: "destructive", Icon: AlertTriangle },
+};
+
+interface AgentSelectViewProps {
+  rows: readonly AgentSelectRow[];
+  selectedId: BackendId;
+  onSelect: (id: BackendId) => void;
+  ctaLabel: string;
+  /** Footer text left of the button, explaining what pressing it will do. */
+  footerNote: string;
+  onCta: () => void;
+}
+
+/**
+ * First-run agent chooser: lists every agent with its readiness and ends in a
+ * single call to action. Pure presentation — the caller owns which agent is
+ * selected, what the button says, and what pressing it does, so this component
+ * can be mounted from the component gallery with fixture props alone.
+ */
+export const AgentSelectView: React.FC<AgentSelectViewProps> = ({
+  rows,
+  selectedId,
+  onSelect,
+  ctaLabel,
+  footerNote,
+  onCta,
+}) => {
+  const headingId = React.useId();
+  const rowRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
+  const selectedIndex = rows.findIndex((row) => row.id === selectedId);
+  // Roving tabindex anchors on the selected row, falling back to the first row
+  // so keyboard users can always tab into the group.
+  const tabStopIndex = selectedIndex === -1 ? 0 : selectedIndex;
+
+  /** Move focus and selection to the adjacent row, wrapping around. */
+  const selectAdjacent = (currentIndex: number, direction: 1 | -1) => {
+    const nextIndex = (currentIndex + direction + rows.length) % rows.length;
+    rowRefs.current[nextIndex]?.focus();
+    onSelect(rows[nextIndex].id);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    switch (event.key) {
+      case "ArrowDown":
+      case "ArrowRight":
+        event.preventDefault();
+        selectAdjacent(index, 1);
+        break;
+      case "ArrowUp":
+      case "ArrowLeft":
+        event.preventDefault();
+        selectAdjacent(index, -1);
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-3 tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-3">
+      <div className="tw-flex tw-flex-col tw-gap-1">
+        <h3
+          id={headingId}
+          className="tw-m-0 tw-text-ui-medium tw-font-semibold tw-leading-tight tw-text-normal"
+        >
+          Select your agent
+        </h3>
+        <p className="tw-m-0 tw-text-ui-smaller tw-text-muted">
+          An agent runs your tasks on this machine. All three do the same work — what differs is
+          which models you can use and whose plan pays for them.
+        </p>
+      </div>
+
+      <div role="radiogroup" aria-labelledby={headingId} className="tw-flex tw-flex-col tw-gap-1">
+        {rows.map((row, index) => {
+          const isSelected = row.id === selectedId;
+          const status = STATUS_BADGES[row.status];
+          return (
+            <button
+              key={row.id}
+              ref={(node) => {
+                rowRefs.current[index] = node;
+              }}
+              type="button"
+              role="radio"
+              aria-checked={isSelected}
+              tabIndex={index === tabStopIndex ? 0 : -1}
+              onClick={() => onSelect(row.id)}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+              // `!` overrides: this is a raw <button>, so Obsidian's native button
+              // chrome (background, box-shadow, rounding, one-line 30px height,
+              // centered nowrap text) would otherwise win on specificity and
+              // collapse the row into a pill with its description clipped. Height
+              // and alignment must give way for a multi-line row. Background lives
+              // only in the selected/unselected branch, never both, so nothing
+              // collides.
+              className={cn(
+                "tw-flex tw-h-auto tw-w-full tw-cursor-pointer tw-items-start tw-gap-2 !tw-whitespace-normal !tw-rounded-md tw-border-none !tw-p-2 tw-text-left !tw-shadow-none tw-transition-colors focus-visible:tw-outline-none focus-visible:tw-ring-1 focus-visible:tw-ring-ring",
+                isSelected
+                  ? "!tw-bg-modifier-hover"
+                  : "!tw-bg-transparent hover:!tw-bg-modifier-hover"
+              )}
+            >
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "tw-mt-0.5 tw-flex tw-size-4 tw-shrink-0 tw-items-center tw-justify-center tw-rounded-full tw-border tw-border-solid",
+                  isSelected ? "tw-border-interactive-accent" : "tw-border-border"
+                )}
+              >
+                {isSelected && (
+                  <span className="tw-size-2 tw-rounded-full tw-bg-interactive-accent" />
+                )}
+              </span>
+
+              <span className="tw-flex tw-min-w-0 tw-flex-1 tw-flex-col tw-gap-1">
+                <span className="tw-flex tw-flex-wrap tw-items-center tw-gap-1.5">
+                  <span className="tw-break-words tw-text-ui-small tw-font-semibold tw-text-normal">
+                    {row.name}
+                  </span>
+                  {status && (
+                    <Badge variant={status.variant} className="tw-gap-1">
+                      <status.Icon aria-hidden className="tw-size-3" />
+                      {status.label}
+                    </Badge>
+                  )}
+                  {row.recommended && <Badge variant="accent">Recommended</Badge>}
+                </span>
+                <span className="tw-break-words tw-text-ui-smaller tw-text-muted">
+                  {row.description}
+                </span>
+                {row.highlights.length > 0 && (
+                  <span className="tw-flex tw-flex-wrap tw-gap-1">
+                    {row.highlights.map((highlight) => (
+                      <Badge key={highlight} variant="outline">
+                        {highlight}
+                      </Badge>
+                    ))}
+                  </span>
+                )}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-t tw-border-solid tw-border-border tw-pt-3">
+        <span className="tw-min-w-0 tw-flex-1 tw-break-words tw-text-ui-smaller tw-text-muted">
+          {footerNote}
+        </span>
+        <Button size="sm" onClick={onCta} className="tw-shrink-0">
+          {ctaLabel}
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/src/agentMode/ui/AgentSelectView.tsx
+++ b/src/agentMode/ui/AgentSelectView.tsx
@@ -85,18 +85,12 @@ export const AgentSelectView: React.FC<AgentSelectViewProps> = ({
 
   return (
     <div className="tw-flex tw-w-full tw-flex-col tw-gap-3 tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-3">
-      <div className="tw-flex tw-flex-col tw-gap-1">
-        <h3
-          id={headingId}
-          className="tw-m-0 tw-text-ui-medium tw-font-semibold tw-leading-tight tw-text-normal"
-        >
-          Select your agent
-        </h3>
-        <p className="tw-m-0 tw-text-ui-smaller tw-text-muted">
-          An agent runs your tasks on this machine. All three do the same work — what differs is
-          which models you can use and whose plan pays for them.
-        </p>
-      </div>
+      <h3
+        id={headingId}
+        className="tw-m-0 tw-text-ui-medium tw-font-semibold tw-leading-tight tw-text-normal"
+      >
+        Select your agent
+      </h3>
 
       <div role="radiogroup" aria-labelledby={headingId} className="tw-flex tw-flex-col tw-gap-1">
         {rows.map((row, index) => {

--- a/src/agentMode/ui/AgentSelectView.tsx
+++ b/src/agentMode/ui/AgentSelectView.tsx
@@ -150,15 +150,6 @@ export const AgentSelectView: React.FC<AgentSelectViewProps> = ({
                 <span className="tw-break-words tw-text-ui-smaller tw-text-muted">
                   {row.description}
                 </span>
-                {row.highlights.length > 0 && (
-                  <span className="tw-flex tw-flex-wrap tw-gap-1">
-                    {row.highlights.map((highlight) => (
-                      <Badge key={highlight} variant="outline">
-                        {highlight}
-                      </Badge>
-                    ))}
-                  </span>
-                )}
               </span>
             </button>
           );

--- a/src/agentMode/ui/AgentSelectView.tsx
+++ b/src/agentMode/ui/AgentSelectView.tsx
@@ -3,7 +3,7 @@ import type { AgentSelectRow, AgentSelectStatus } from "@/agentMode/ui/agentSele
 import { Badge, type BadgeProps } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { AlertTriangle, Check, type LucideIcon } from "lucide-react";
+import { AlertTriangle, Check, LoaderCircle, type LucideIcon } from "lucide-react";
 import React from "react";
 
 interface StatusBadgeSpec {
@@ -23,6 +23,7 @@ interface StatusBadgeSpec {
  * prose here would only cost width in a 300px leaf.
  */
 const STATUS_BADGES: Partial<Record<AgentSelectStatus, StatusBadgeSpec>> = {
+  checking: { label: "Checking…", variant: "secondary", Icon: LoaderCircle },
   connected: { label: "Connected", variant: "success", Icon: Check },
   outdated: { label: "Update required", variant: "destructive", Icon: AlertTriangle },
   error: { label: "Error", variant: "destructive", Icon: AlertTriangle },
@@ -36,6 +37,8 @@ interface AgentSelectViewProps {
   /** Footer text left of the button, explaining what pressing it will do. */
   footerNote: string;
   onCta: () => void;
+  /** Prevents a transient readiness state from exposing an action. */
+  ctaDisabled?: boolean;
 }
 
 /**
@@ -51,6 +54,7 @@ export const AgentSelectView: React.FC<AgentSelectViewProps> = ({
   ctaLabel,
   footerNote,
   onCta,
+  ctaDisabled = false,
 }) => {
   const headingId = React.useId();
   const rowRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
@@ -141,7 +145,10 @@ export const AgentSelectView: React.FC<AgentSelectViewProps> = ({
                   </span>
                   {status && (
                     <Badge variant={status.variant} className="tw-gap-1">
-                      <status.Icon aria-hidden className="tw-size-3" />
+                      <status.Icon
+                        aria-hidden
+                        className={cn("tw-size-3", row.status === "checking" && "tw-animate-spin")}
+                      />
                       {status.label}
                     </Badge>
                   )}
@@ -160,7 +167,7 @@ export const AgentSelectView: React.FC<AgentSelectViewProps> = ({
         <span className="tw-min-w-0 tw-flex-1 tw-break-words tw-text-ui-smaller tw-text-muted">
           {footerNote}
         </span>
-        <Button size="sm" onClick={onCta} className="tw-shrink-0">
+        <Button size="sm" onClick={onCta} disabled={ctaDisabled} className="tw-shrink-0">
           {ctaLabel}
         </Button>
       </div>

--- a/src/agentMode/ui/AgentSelectView.tsx
+++ b/src/agentMode/ui/AgentSelectView.tsx
@@ -171,7 +171,7 @@ export const AgentSelectView: React.FC<AgentSelectViewProps> = ({
         })}
       </div>
 
-      <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-border-t tw-border-solid tw-border-border tw-pt-3">
+      <div className="copilot-divider-t tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-pt-3">
         <span className="tw-min-w-0 tw-flex-1 tw-break-words tw-text-ui-smaller tw-text-muted">
           {footerNote}
         </span>


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#228

## Why

Agent Mode supports three agent backends — opencode, Claude, and Codex — and the selection model already resolves each one's readiness and the right next action, but nothing renders it. A new user opening Agent Mode still has no place to see which agents exist, whether each is set up on this machine, which one is recommended, or what to press next.

## What

Adds the agent selection view: a radio list where each row shows the agent's name, its model source and billing in one line of copy, a Recommended badge on the suggested agent, and a readiness badge — Checking…, Connected, Update required, or Error — while an agent that simply isn't set up shows no badge and lets the footer carry that fact. The footer pairs a note explaining the selected agent's state with a single button — Configure or Start chat — that is disabled while readiness is still being checked. Arrow keys move selection through the list, wrapping past both ends, and only the selected row is a tab stop.

## Non goal

- Mount the view in the live Agent Mode pane.
- Change configuration dialogs or introduce a reusable radio-group component.

## Screenshot

![Agent selection view](https://github.com/user-attachments/assets/13f19366-940d-4508-b9d5-b428d4faa08b)

The view is new, so there is no before state to pair with. The remaining gallery states (Connected, Update required, Error, long names) are unevidenced: rendered evidence was not captured in this session because the PR branch was not built and loaded in Obsidian.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ❌ | The new 300px layout and Obsidian button chrome require rendered inspection |
| A defect would fail CI or be obvious on first use | ✅ | Interaction defects fail `AgentSelectView` tests; layout defects are visible in the gallery |
| A revert fully restores prior state, including persisted data | ✅ | The presentation component, stories, and tests are additive |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The pure view only emits selection and action callbacks |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The component props are internal UI contracts |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | This slice renders existing selection state without mounting it in Agent Mode |
| No hot-path behavior lacks deterministic coverage | ✅ | No runtime hot path changes |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Visual exposure is confined to this view and visible in its gallery stories |

Review: run Verification steps 2–3, checking keyboard wrapping and 300px clipping across every badge state.

## Verification

1. Open the component gallery and go to `Agent Mode / Agent Select View`.
2. In `Nothing Set Up`, click each row, then press ArrowUp/ArrowDown from a focused row: exactly one row is marked selected, selection wraps past both ends, and Tab enters the list on the selected row only.
3. Walk `Opencode Connected`, `Claude Checking`, `Claude Update Required`, `Codex Error`, and `Long Agent Name` at the default 300px width: badges, long names, and descriptions wrap without clipping, and the footer note matches the selected row's state.
4. In `Claude Checking`, select Claude and press the footer button: nothing fires while it reads `Checking…`; in any other state, pressing the button leaves the row selection unchanged.
