### PR TITLE
[Agent view onboarding] - Step 5: Show agent selection on a cold start

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -26,6 +26,17 @@ When the autonomous agent is enabled, Copilot can:
 
 The agent activates automatically when you're in **Copilot Plus** mode. You don't need to do anything special — just ask your question.
 
+### Starting Agent Mode for the First Time
+
+If the agent Copilot would normally start is not set up and there is no chat or runtime error to recover, Agent Mode opens with **Select your agent**. Each row shows what that agent uses and its current setup state:
+
+- **Installed** can start a chat. Copilot checks sign-in after the agent starts.
+- **Checking…** is temporarily unavailable while Copilot verifies the installation.
+- **Update required** or **Error** opens Configure with the specific recovery guidance.
+- A row without a status badge is not installed and opens Configure.
+
+Selecting a row only previews its action. **Start chat** saves that agent as the default and starts it; **Configure** opens its setup without changing the default. After a chat starts, use the agent and model picker to switch agents or choose one of that agent's models.
+
 ## Sample Prompts in the Message Box
 
 When you open a new agent chat and the message box is empty, Copilot types out sample prompts there one at a time — each appears character by character, pauses so you can read it, clears itself, and gives way to the next. They are examples of what the agent can do with your vault, not something being sent.

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -475,6 +475,53 @@ describe("AgentSessionManager warm-backend reuse", () => {
     expect(opts).not.toHaveProperty("backendSessionId");
   });
 
+  it("waits for an in-flight preload and adopts its process instead of spawning a second one", async () => {
+    let resolvePreload!: () => void;
+    let preloadSettled = false;
+    const preloadPromise = new Promise<void>((resolve) => {
+      resolvePreload = resolve;
+    });
+    const warmProc = makeMockBackendProcess();
+    const descriptor = buildDescriptor();
+    const preloader = {
+      getCachedModelCatalog: jest.fn(() => null),
+      getEffortCatalog: jest.fn(() => null),
+      preload: jest.fn(() => preloadPromise),
+      refresh: jest.fn(() => null),
+      subscribe: jest.fn(() => () => {}),
+      shutdown: jest.fn(),
+      clearCached: jest.fn(),
+      takeWarm: jest.fn(() => (preloadSettled ? { proc: warmProc } : null)),
+      getWarmProcs: jest.fn(() => []),
+    };
+    const mgr = new AgentSessionManager(
+      buildApp(),
+      buildPlugin() as unknown as ConstructorParameters<typeof AgentSessionManager>[1],
+      {
+        permissionPrompter: jest.fn(),
+        resolveDescriptor: (id) => (id === descriptor.id ? descriptor : undefined),
+        modelPreloader: preloader as unknown as ConstructorParameters<
+          typeof AgentSessionManager
+        >[2]["modelPreloader"],
+      }
+    );
+    mgr.registerPreload("opencode", preloadPromise);
+
+    const sessionPromise = mgr.createSession();
+    await Promise.resolve();
+
+    expect(preloader.preload).toHaveBeenCalledWith("opencode");
+    expect(descriptor.createBackendProcess).not.toHaveBeenCalled();
+
+    preloadSettled = true;
+    resolvePreload();
+    await sessionPromise;
+
+    expect(preloader.takeWarm).toHaveBeenCalledWith("opencode");
+    expect(descriptor.createBackendProcess).not.toHaveBeenCalled();
+    expect(mockBackendStart).not.toHaveBeenCalled();
+  });
+
   it("falls back to a fresh spawn when no warm entry is available", async () => {
     // takeWarm returning null is the second-and-later session path.
     const mgr = buildManager();

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -3305,24 +3305,30 @@ export class AgentSessionManager {
     if (existing && existing.isRunning()) return existing;
     const inflight = this.starting.get(backendId);
     if (inflight) return inflight;
-
-    const warm = this.preloader.takeWarm(backendId);
-    if (warm) {
-      // Probe subprocess is already started + initialize-handshaken —
-      // wire it into the manager without paying either cost again.
-      this.wirePrompters(warm.proc);
-      this.installBackendExitHandler(backendId, warm.proc, descriptor);
-      this.backends.set(backendId, warm.proc);
-      return warm.proc;
-    }
-
-    const proc = descriptor.createBackendProcess({
-      plugin: this.plugin,
-      app: this.app,
-      clientVersion: this.plugin.manifest.version,
-      descriptor,
-    });
     const startPromise = (async () => {
+      // A plugin-load probe owns the only process for this backend until it
+      // settles. Await that same deduped probe so a user selection cannot race
+      // it and spawn a second process before the warm entry exists.
+      if (!this.isPreloadReady(backendId)) {
+        await this.preloader.preload(backendId);
+      }
+
+      const warm = this.preloader.takeWarm(backendId);
+      if (warm) {
+        // Probe subprocess is already started + initialize-handshaken —
+        // wire it into the manager without paying either cost again.
+        this.wirePrompters(warm.proc);
+        this.installBackendExitHandler(backendId, warm.proc, descriptor);
+        this.backends.set(backendId, warm.proc);
+        return warm.proc;
+      }
+
+      const proc = descriptor.createBackendProcess({
+        plugin: this.plugin,
+        app: this.app,
+        clientVersion: this.plugin.manifest.version,
+        descriptor,
+      });
       // ACP backends declare `start()` to spawn the subprocess and run the
       // initialize handshake. In-process adapters (Claude SDK) omit it.
       if (proc.start) await proc.start();

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -340,7 +340,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
     if (isOrphanedProject) new Notice("This project no longer exists.");
   }, [isOrphanedProject]);
 
-  const modelPickerOverride = useAgentModelPicker(manager);
+  const modelPickerOverride = useAgentModelPicker(manager, plugin);
   const modePickerOverride = useAgentModePicker(manager);
 
   const handleCycleMode = useCallback(() => {

--- a/src/agentMode/ui/AgentModeChat.test.tsx
+++ b/src/agentMode/ui/AgentModeChat.test.tsx
@@ -17,7 +17,7 @@ let mockInstallState: InstallState = { kind: "ready", source: "custom" };
 // expected here.
 /* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 jest.mock("@/agentMode/ui/useBackendDescriptor", () => ({
-  useActiveBackendDescriptor: () => ({ id: "claude", openInstallUI: jest.fn() }),
+  useSessionBackendDescriptor: () => ({ id: "claude", openInstallUI: jest.fn() }),
   useBackendInstallState: () => mockInstallState,
 }));
 /* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
@@ -42,6 +42,7 @@ interface ManagerStub {
   scopeSessions: AgentSession[];
   poolSessions: AgentSession[];
   lastError?: string | null;
+  starting?: boolean;
 }
 
 function makeManager({
@@ -49,6 +50,7 @@ function makeManager({
   scopeSessions,
   poolSessions,
   lastError = null,
+  starting = false,
 }: ManagerStub) {
   const getOrCreateActiveSession = jest.fn(async () => session("spawned"));
   const manager = {
@@ -57,7 +59,7 @@ function makeManager({
     getSessions: jest.fn(() => poolSessions),
     getSessionsForScope: jest.fn(() => scopeSessions),
     getActiveProjectId: jest.fn(() => activeProjectId),
-    getIsStarting: jest.fn(() => false),
+    getIsStarting: jest.fn(() => starting),
     getLastError: jest.fn(() => lastError),
     getActiveSession: jest.fn(() => null),
     getActiveChatUIState: jest.fn(() => null),
@@ -74,13 +76,14 @@ function renderChat(manager: AgentSessionManager) {
 }
 
 /** Render the no-session fallback with the given readiness and boot error. */
-function renderFallback(installState: InstallState, lastError: string | null) {
+function renderFallback(installState: InstallState, lastError: string | null, starting = false) {
   mockInstallState = installState;
   const { manager } = makeManager({
     activeProjectId: GLOBAL_SCOPE,
     scopeSessions: [],
     poolSessions: [],
     lastError,
+    starting,
   });
   renderChat(manager);
 }
@@ -166,6 +169,13 @@ describe("AgentModeChat", () => {
       // `checking` resolves on its own; flashing the select view and swapping it
       // straight back out is worse than the card's one-line "Checking…".
       renderFallback({ kind: "checking", source: "custom" }, null);
+
+      expect(screen.getByTestId("status-card")).toBeTruthy();
+      expect(screen.queryByTestId("select-panel")).toBeNull();
+    });
+
+    it("keeps the compact card while a backend session is already starting", () => {
+      renderFallback({ kind: "absent" }, null, true);
 
       expect(screen.getByTestId("status-card")).toBeTruthy();
       expect(screen.queryByTestId("select-panel")).toBeNull();

--- a/src/agentMode/ui/AgentModeChat.test.tsx
+++ b/src/agentMode/ui/AgentModeChat.test.tsx
@@ -2,9 +2,14 @@ import { AgentModeChat } from "@/agentMode/ui/AgentModeChat";
 import { GLOBAL_SCOPE } from "@/agentMode/session/scope";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import type { InstallState } from "@/agentMode/session/types";
 import type CopilotPlugin from "@/main";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
+
+// Readiness of the backend the pane would run, swapped per test. Declared with
+// the `mock` prefix so Jest allows the mock factory below to close over it.
+let mockInstallState: InstallState = { kind: "ready", source: "custom" };
 
 // Stub the descriptor hooks so the effect's `preloadReady`/install gates are
 // satisfied without the real backend registry / jotai atoms. The mock factory
@@ -13,14 +18,22 @@ import React from "react";
 /* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 jest.mock("@/agentMode/ui/useBackendDescriptor", () => ({
   useActiveBackendDescriptor: () => ({ id: "claude", openInstallUI: jest.fn() }),
-  useBackendInstallState: () => ({ kind: "ready", source: "custom" }),
+  useBackendInstallState: () => mockInstallState,
 }));
 /* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
 
-// Heavy children are irrelevant to the auto-spawn guard — render nothing.
+// Heavy children are irrelevant to the guards under test — render markers so
+// the no-session fallback's branch is observable without their real trees.
 jest.mock("@/agentMode/ui/AgentHome", () => ({ AgentHome: () => null }));
-jest.mock("@/agentMode/ui/AgentModeStatus", () => ({ AgentModeStatus: () => null }));
-jest.mock("@/agentMode/ui/AgentChatControls", () => ({ AgentChatControls: () => null }));
+jest.mock("@/agentMode/ui/AgentModeStatus", () => ({
+  AgentModeStatus: () => <div data-testid="status-card" />,
+}));
+jest.mock("@/agentMode/ui/AgentSelectPanel", () => ({
+  AgentSelectPanel: () => <div data-testid="select-panel" />,
+}));
+jest.mock("@/agentMode/ui/AgentChatControls", () => ({
+  AgentChatControls: () => <div data-testid="chat-controls" />,
+}));
 
 const session = (id: string): AgentSession => ({ internalId: id }) as unknown as AgentSession;
 
@@ -28,9 +41,15 @@ interface ManagerStub {
   activeProjectId: string;
   scopeSessions: AgentSession[];
   poolSessions: AgentSession[];
+  lastError?: string | null;
 }
 
-function makeManager({ activeProjectId, scopeSessions, poolSessions }: ManagerStub) {
+function makeManager({
+  activeProjectId,
+  scopeSessions,
+  poolSessions,
+  lastError = null,
+}: ManagerStub) {
   const getOrCreateActiveSession = jest.fn(async () => session("spawned"));
   const manager = {
     subscribe: jest.fn(() => () => {}),
@@ -39,7 +58,7 @@ function makeManager({ activeProjectId, scopeSessions, poolSessions }: ManagerSt
     getSessionsForScope: jest.fn(() => scopeSessions),
     getActiveProjectId: jest.fn(() => activeProjectId),
     getIsStarting: jest.fn(() => false),
-    getLastError: jest.fn(() => null),
+    getLastError: jest.fn(() => lastError),
     getActiveSession: jest.fn(() => null),
     getActiveChatUIState: jest.fn(() => null),
     getOrCreateActiveSession,
@@ -54,45 +73,131 @@ function renderChat(manager: AgentSessionManager) {
   );
 }
 
-describe("AgentModeChat auto-spawn guard (scope-aware)", () => {
-  it("regression: spawns the current project scope's session even when another scope still has sessions", async () => {
-    // The closed scope (project-1) is empty, but the global pool still holds a
-    // session. A whole-pool guard would skip the spawn and strand the pane on
-    // the no-session fallback; the scope-aware guard must re-spawn project-1.
-    const { manager, getOrCreateActiveSession } = makeManager({
-      activeProjectId: "project-1",
-      scopeSessions: [],
-      poolSessions: [session("global-1")],
-    });
+/** Render the no-session fallback with the given readiness and boot error. */
+function renderFallback(installState: InstallState, lastError: string | null) {
+  mockInstallState = installState;
+  const { manager } = makeManager({
+    activeProjectId: GLOBAL_SCOPE,
+    scopeSessions: [],
+    poolSessions: [],
+    lastError,
+  });
+  renderChat(manager);
+}
 
-    renderChat(manager);
-
-    await waitFor(() => expect(getOrCreateActiveSession).toHaveBeenCalledTimes(1));
+describe("AgentModeChat", () => {
+  afterEach(() => {
+    mockInstallState = { kind: "ready", source: "custom" };
   });
 
-  it("spawns the global scope's session when global is empty but a project still has sessions", async () => {
-    const { manager, getOrCreateActiveSession } = makeManager({
-      activeProjectId: GLOBAL_SCOPE,
-      scopeSessions: [],
-      poolSessions: [session("project-1-s1")],
+  describe("auto-spawn guard (scope-aware)", () => {
+    it("regression: spawns the current project scope's session even when another scope still has sessions", async () => {
+      // The closed scope (project-1) is empty, but the global pool still holds a
+      // session. A whole-pool guard would skip the spawn and strand the pane on
+      // the no-session fallback; the scope-aware guard must re-spawn project-1.
+      const { manager, getOrCreateActiveSession } = makeManager({
+        activeProjectId: "project-1",
+        scopeSessions: [],
+        poolSessions: [session("global-1")],
+      });
+
+      renderChat(manager);
+
+      await waitFor(() => expect(getOrCreateActiveSession).toHaveBeenCalledTimes(1));
     });
 
-    renderChat(manager);
+    it("spawns the global scope's session when global is empty but a project still has sessions", async () => {
+      const { manager, getOrCreateActiveSession } = makeManager({
+        activeProjectId: GLOBAL_SCOPE,
+        scopeSessions: [],
+        poolSessions: [session("project-1-s1")],
+      });
 
-    await waitFor(() => expect(getOrCreateActiveSession).toHaveBeenCalledTimes(1));
+      renderChat(manager);
+
+      await waitFor(() => expect(getOrCreateActiveSession).toHaveBeenCalledTimes(1));
+    });
+
+    it("does not spawn when the current scope already has a session (single-scope behavior unchanged)", async () => {
+      const { manager, getOrCreateActiveSession } = makeManager({
+        activeProjectId: GLOBAL_SCOPE,
+        scopeSessions: [session("global-1")],
+        poolSessions: [session("global-1")],
+      });
+
+      renderChat(manager);
+
+      // Flush effects, then assert the guard short-circuited.
+      await waitFor(() => expect(manager.getSessionsForScope).toHaveBeenCalled());
+      expect(getOrCreateActiveSession).not.toHaveBeenCalled();
+    });
   });
 
-  it("does not spawn when the current scope already has a session (single-scope behavior unchanged)", async () => {
-    const { manager, getOrCreateActiveSession } = makeManager({
-      activeProjectId: GLOBAL_SCOPE,
-      scopeSessions: [session("global-1")],
-      poolSessions: [session("global-1")],
+  describe("no-session fallback", () => {
+    it("takes the pane over with the agent select view when no agent is set up", () => {
+      renderFallback({ kind: "absent" }, null);
+
+      expect(screen.getByTestId("select-panel")).toBeTruthy();
+      expect(screen.queryByTestId("status-card")).toBeNull();
     });
 
-    renderChat(manager);
+    it("takes the pane over when the agent's binary is too old to run", () => {
+      renderFallback(
+        {
+          kind: "incompatible",
+          source: "custom",
+          currentVersion: "2.1.205",
+          minVersion: "2.1.206",
+          message: "too old",
+        },
+        null
+      );
 
-    // Flush effects, then assert the guard short-circuited.
-    await waitFor(() => expect(manager.getSessionsForScope).toHaveBeenCalled());
-    expect(getOrCreateActiveSession).not.toHaveBeenCalled();
+      expect(screen.getByTestId("select-panel")).toBeTruthy();
+    });
+
+    it("takes the pane over when the agent's readiness check failed", () => {
+      renderFallback({ kind: "error", message: "not executable" }, null);
+
+      expect(screen.getByTestId("select-panel")).toBeTruthy();
+    });
+
+    it("keeps the compact card while a readiness check is in flight", () => {
+      // `checking` resolves on its own; flashing the select view and swapping it
+      // straight back out is worse than the card's one-line "Checking…".
+      renderFallback({ kind: "checking", source: "custom" }, null);
+
+      expect(screen.getByTestId("status-card")).toBeTruthy();
+      expect(screen.queryByTestId("select-panel")).toBeNull();
+    });
+
+    it("regression: keeps the compact card when a boot error coincides with an absent backend", () => {
+      // Deleting the binary under a running agent sets both. A setup screen
+      // would bury the failure that just happened; the card still surfaces the
+      // Install call to action for an absent backend.
+      renderFallback({ kind: "absent" }, "opencode backend exited unexpectedly.");
+
+      expect(screen.getByTestId("status-card")).toBeTruthy();
+      expect(screen.queryByTestId("select-panel")).toBeNull();
+    });
+
+    it("keeps the compact card when a ready agent crashed with no surviving session", () => {
+      renderFallback({ kind: "ready", source: "custom" }, "claude backend exited unexpectedly.");
+
+      expect(screen.getByTestId("status-card")).toBeTruthy();
+      expect(screen.queryByTestId("select-panel")).toBeNull();
+    });
+
+    it("leaves Agent Mode reachable below the select view", () => {
+      renderFallback({ kind: "absent" }, null);
+
+      expect(screen.getByTestId("chat-controls")).toBeTruthy();
+    });
+
+    it("leaves Agent Mode reachable below the compact card", () => {
+      renderFallback({ kind: "ready", source: "custom" }, "boom");
+
+      expect(screen.getByTestId("chat-controls")).toBeTruthy();
+    });
   });
 });

--- a/src/agentMode/ui/AgentModeChat.tsx
+++ b/src/agentMode/ui/AgentModeChat.tsx
@@ -2,9 +2,10 @@ import { AgentChatControls } from "@/agentMode/ui/AgentChatControls";
 import { AgentHome } from "@/agentMode/ui/AgentHome";
 import { AgentModeStatus } from "@/agentMode/ui/AgentModeStatus";
 import { AgentSelectPanel } from "@/agentMode/ui/AgentSelectPanel";
+import { AgentSelectPane } from "@/agentMode/ui/AgentSelectPane";
 import {
-  useActiveBackendDescriptor,
   useBackendInstallState,
+  useSessionBackendDescriptor,
 } from "@/agentMode/ui/useBackendDescriptor";
 import type CopilotPlugin from "@/main";
 import { logError } from "@/logger";
@@ -28,7 +29,7 @@ export const AgentModeChat: React.FC<Props> = ({
   updateUserMessageHistory,
 }) => {
   const manager = plugin.agentSessionManager;
-  const descriptor = useActiveBackendDescriptor();
+  const descriptor = useSessionBackendDescriptor(manager);
   const installState = useBackendInstallState(descriptor, plugin);
   const [tick, setTick] = React.useState(0);
 
@@ -39,9 +40,9 @@ export const AgentModeChat: React.FC<Props> = ({
 
   // Manager fires `notify()` on preload settle, which bumps `tick` above and
   // re-renders this component — so we can read the flag directly each render.
-  // Gate only on the *active* backend so a slow non-active backend never
-  // holds the chat hostage; the picker shows per-backend loading rows for
-  // the others.
+  // Gate only on the backend being started or shown so a slow unrelated
+  // backend never holds the chat hostage; the picker shows per-backend
+  // loading rows for the others.
   const preloadReady = manager?.isPreloadReady(descriptor.id) ?? true;
 
   // Auto-spawn the first session on mount. The manager de-dupes concurrent
@@ -121,33 +122,26 @@ export const AgentModeChat: React.FC<Props> = ({
   //  - `checking`: transient and Claude-only. Flashing the select view and
   //    swapping it out is worse than the one-line "Checking … version…".
   const isColdStart =
+    !manager.getIsStarting() &&
     manager.getLastError() === null &&
     (installState.kind === "absent" ||
       installState.kind === "incompatible" ||
       installState.kind === "error");
 
-  // Render the chain switcher below either surface so the user can still leave
-  // Agent Mode without going through settings or the command palette.
+  if (isColdStart) {
+    return (
+      <AgentSelectPane controls={<AgentChatControls />}>
+        <AgentSelectPanel plugin={plugin} manager={manager} />
+      </AgentSelectPane>
+    );
+  }
+
+  // Render the chain switcher below the status surface so the user can still
+  // leave Agent Mode without going through settings or the command palette.
   return (
     <div className="tw-flex tw-size-full tw-flex-col tw-overflow-hidden">
-      {isColdStart ? (
-        // The select view owns the whole free height and centres itself with an
-        // auto margin rather than `justify-center`: auto margins collapse to
-        // zero once the card outgrows the pane, so a short pane scrolls from
-        // the card's top instead of clipping it.
-        <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-y-auto tw-p-2">
-          <div className="tw-m-auto tw-w-full">
-            <AgentSelectPanel plugin={plugin} manager={manager} />
-          </div>
-        </div>
-      ) : (
-        // The compact status card is a status line for the controls below it,
-        // so it stays pinned to the bottom of the pane.
-        <>
-          <div className="tw-flex-1" />
-          <AgentModeStatus manager={manager} plugin={plugin} onInstallClick={handleInstall} />
-        </>
-      )}
+      <div className="tw-flex-1" />
+      <AgentModeStatus manager={manager} plugin={plugin} onInstallClick={handleInstall} />
       <AgentChatControls />
     </div>
   );

--- a/src/agentMode/ui/AgentModeChat.tsx
+++ b/src/agentMode/ui/AgentModeChat.tsx
@@ -1,6 +1,7 @@
 import { AgentChatControls } from "@/agentMode/ui/AgentChatControls";
 import { AgentHome } from "@/agentMode/ui/AgentHome";
 import { AgentModeStatus } from "@/agentMode/ui/AgentModeStatus";
+import { AgentSelectPanel } from "@/agentMode/ui/AgentSelectPanel";
 import {
   useActiveBackendDescriptor,
   useBackendInstallState,
@@ -106,13 +107,37 @@ export const AgentModeChat: React.FC<Props> = ({
     );
   }
 
-  // No active session (binary missing, booting, or boot error). Render the
-  // chain switcher above the status pill so the user can still leave Agent
-  // Mode without going through settings or the command palette.
+  // No active session (binary missing, booting, or boot error). The agent
+  // select view is a *cold-start* surface, so it takes the pane over only when
+  // nothing is actively erroring and the agent that would run isn't set up —
+  // the mirror image of the auto-spawn gate above. Two states deliberately keep
+  // the compact card instead:
+  //  - any `lastError`: a crashed agent, expired credentials, or a failed resume
+  //    is a runtime failure, not "no agent is set up". Replacing a working
+  //    panel with a setup screen would misdiagnose it, and the card's Retry /
+  //    Configure action is the fix. `lastError` therefore wins when both are
+  //    true — `AgentModeStatus` still checks install state first internally, so
+  //    an absent backend keeps its Install call to action there.
+  //  - `checking`: transient and Claude-only. Flashing the select view and
+  //    swapping it out is worse than the one-line "Checking … version…".
+  const isColdStart =
+    manager.getLastError() === null &&
+    (installState.kind === "absent" ||
+      installState.kind === "incompatible" ||
+      installState.kind === "error");
+
+  // Render the chain switcher below either surface so the user can still leave
+  // Agent Mode without going through settings or the command palette.
   return (
     <div className="tw-flex tw-size-full tw-flex-col tw-overflow-hidden">
       <div className="tw-flex-1" />
-      <AgentModeStatus manager={manager} plugin={plugin} onInstallClick={handleInstall} />
+      {isColdStart ? (
+        <div className="tw-min-h-0 tw-overflow-y-auto tw-p-2">
+          <AgentSelectPanel plugin={plugin} manager={manager} />
+        </div>
+      ) : (
+        <AgentModeStatus manager={manager} plugin={plugin} onInstallClick={handleInstall} />
+      )}
       <AgentChatControls />
     </div>
   );

--- a/src/agentMode/ui/AgentModeChat.tsx
+++ b/src/agentMode/ui/AgentModeChat.tsx
@@ -130,13 +130,23 @@ export const AgentModeChat: React.FC<Props> = ({
   // Agent Mode without going through settings or the command palette.
   return (
     <div className="tw-flex tw-size-full tw-flex-col tw-overflow-hidden">
-      <div className="tw-flex-1" />
       {isColdStart ? (
-        <div className="tw-min-h-0 tw-overflow-y-auto tw-p-2">
-          <AgentSelectPanel plugin={plugin} manager={manager} />
+        // The select view owns the whole free height and centres itself with an
+        // auto margin rather than `justify-center`: auto margins collapse to
+        // zero once the card outgrows the pane, so a short pane scrolls from
+        // the card's top instead of clipping it.
+        <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-y-auto tw-p-2">
+          <div className="tw-m-auto tw-w-full">
+            <AgentSelectPanel plugin={plugin} manager={manager} />
+          </div>
         </div>
       ) : (
-        <AgentModeStatus manager={manager} plugin={plugin} onInstallClick={handleInstall} />
+        // The compact status card is a status line for the controls below it,
+        // so it stays pinned to the bottom of the pane.
+        <>
+          <div className="tw-flex-1" />
+          <AgentModeStatus manager={manager} plugin={plugin} onInstallClick={handleInstall} />
+        </>
       )}
       <AgentChatControls />
     </div>

--- a/src/agentMode/ui/AgentSelectPane.stories.tsx
+++ b/src/agentMode/ui/AgentSelectPane.stories.tsx
@@ -54,7 +54,7 @@ const meta = {
     ),
     controls: <AgentControlsFixture />,
   },
-  parameters: { gallery: { host: "leaf", layout: "fullscreen", width: 300 } },
+  parameters: { gallery: { host: "leaf", layout: "fullscreen" } },
 } satisfies Meta<AgentSelectPaneProps>;
 export default meta;
 

--- a/src/agentMode/ui/AgentSelectPane.stories.tsx
+++ b/src/agentMode/ui/AgentSelectPane.stories.tsx
@@ -1,0 +1,61 @@
+import { AgentSelectPane, type AgentSelectPaneProps } from "@/agentMode/ui/AgentSelectPane";
+import { AgentSelectView } from "@/agentMode/ui/AgentSelectView";
+import type { AgentSelectRow } from "@/agentMode/ui/agentSelectModel";
+import type { Meta, StoryObj } from "@/lib/story";
+import React from "react";
+
+const ROWS: readonly AgentSelectRow[] = [
+  {
+    id: "opencode",
+    name: "opencode",
+    description: "Copilot Plus models, or any model on your own provider key.",
+    status: "absent",
+    recommended: true,
+    statusMessage: null,
+  },
+  {
+    id: "claude",
+    name: "Claude",
+    description: "Anthropic models, billed to your Claude Code subscription.",
+    status: "installed",
+    recommended: false,
+    statusMessage: null,
+  },
+  {
+    id: "codex",
+    name: "Codex",
+    description: "OpenAI models, billed to your ChatGPT subscription.",
+    status: "checking",
+    recommended: false,
+    statusMessage: null,
+  },
+];
+
+const AgentControlsFixture = () => (
+  <div className="copilot-divider-t tw-flex tw-items-center tw-justify-between tw-p-2 tw-text-ui-smaller tw-text-muted">
+    <span>Agent Mode</span>
+    <span>Default</span>
+  </div>
+);
+
+const meta = {
+  title: "Agent Mode/Agent Select Pane",
+  component: AgentSelectPane,
+  args: {
+    children: (
+      <AgentSelectView
+        rows={ROWS}
+        selectedId="opencode"
+        onSelect={() => undefined}
+        ctaLabel="Configure"
+        footerNote="opencode isn't set up on this machine yet."
+        onCta={() => undefined}
+      />
+    ),
+    controls: <AgentControlsFixture />,
+  },
+  parameters: { gallery: { host: "leaf", layout: "fullscreen", width: 300 } },
+} satisfies Meta<AgentSelectPaneProps>;
+export default meta;
+
+export const ColdStart: StoryObj<AgentSelectPaneProps> = {};

--- a/src/agentMode/ui/AgentSelectPane.test.tsx
+++ b/src/agentMode/ui/AgentSelectPane.test.tsx
@@ -1,0 +1,21 @@
+import { AgentSelectPane } from "@/agentMode/ui/AgentSelectPane";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("AgentSelectPane", () => {
+  describe("AgentSelectPane()", () => {
+    it("keeps the chooser in a scrollable area above the persistent controls", () => {
+      const { container } = render(
+        <AgentSelectPane controls={<div>Agent controls</div>}>
+          <div>Agent chooser</div>
+        </AgentSelectPane>
+      );
+
+      expect(screen.getByText("Agent chooser").parentElement?.className).toContain("tw-m-auto");
+      expect(screen.getByText("Agent chooser").parentElement?.parentElement?.className).toContain(
+        "tw-overflow-y-auto"
+      );
+      expect(container.textContent).toBe("Agent chooserAgent controls");
+    });
+  });
+});

--- a/src/agentMode/ui/AgentSelectPane.tsx
+++ b/src/agentMode/ui/AgentSelectPane.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+export interface AgentSelectPaneProps {
+  /** Live chooser card supplied by the runtime container. */
+  children: React.ReactNode;
+  /** Persistent Agent Mode controls shown below the chooser. */
+  controls: React.ReactNode;
+}
+
+/**
+ * Full cold-start pane layout around the agent chooser. The scroll area uses
+ * auto margins so the card is centered when space permits and starts at the
+ * top, without clipping, when the pane becomes shorter than the card.
+ */
+export const AgentSelectPane: React.FC<AgentSelectPaneProps> = ({ children, controls }) => (
+  <div className="tw-flex tw-size-full tw-flex-col tw-overflow-hidden">
+    <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-overflow-y-auto tw-p-2">
+      <div className="tw-m-auto tw-w-full">{children}</div>
+    </div>
+    {controls}
+  </div>
+);

--- a/src/agentMode/ui/AgentSelectPanel.test.tsx
+++ b/src/agentMode/ui/AgentSelectPanel.test.tsx
@@ -1,0 +1,52 @@
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { AgentSelectPanel } from "@/agentMode/ui/AgentSelectPanel";
+import type { AgentSelectState } from "@/agentMode/ui/useAgentSelect";
+import type CopilotPlugin from "@/main";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const mockState: AgentSelectState = {
+  rows: [
+    {
+      id: "opencode",
+      name: "opencode",
+      description: "opencode description",
+      highlights: [],
+      status: "absent",
+      recommended: true,
+      statusMessage: null,
+    },
+  ],
+  selectedId: "opencode",
+  select: jest.fn(),
+  cta: {
+    label: "Configure",
+    note: "opencode isn't set up on this machine yet.",
+    action: "configure",
+  },
+  runCta: jest.fn(),
+};
+
+// The panel owns no derivation, so stubbing the hook leaves exactly the wiring
+// under test. The mock factory name must match the real export, so the no-hook
+// `use` prefix is expected here.
+/* eslint-disable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
+jest.mock("@/agentMode/ui/useAgentSelect", () => ({
+  useAgentSelect: () => mockState,
+}));
+/* eslint-enable @eslint-react/hooks-extra/no-unnecessary-use-prefix */
+
+describe("AgentSelectPanel", () => {
+  describe("AgentSelectPanel()", () => {
+    it("renders the selected agent's call to action and runs it on press", () => {
+      const plugin = {} as CopilotPlugin;
+      const manager = {} as AgentSessionManager;
+
+      render(<AgentSelectPanel plugin={plugin} manager={manager} />);
+
+      expect(screen.getByText("opencode isn't set up on this machine yet.")).toBeTruthy();
+      fireEvent.click(screen.getByRole("button", { name: "Configure" }));
+      expect(mockState.runCta).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/agentMode/ui/AgentSelectPanel.test.tsx
+++ b/src/agentMode/ui/AgentSelectPanel.test.tsx
@@ -11,7 +11,6 @@ const mockState: AgentSelectState = {
       id: "opencode",
       name: "opencode",
       description: "opencode description",
-      highlights: [],
       status: "absent",
       recommended: true,
       statusMessage: null,

--- a/src/agentMode/ui/AgentSelectPanel.tsx
+++ b/src/agentMode/ui/AgentSelectPanel.tsx
@@ -6,7 +6,7 @@ import React from "react";
 
 interface Props {
   plugin: CopilotPlugin;
-  manager: AgentSessionManager | null | undefined;
+  manager: AgentSessionManager;
 }
 
 /**

--- a/src/agentMode/ui/AgentSelectPanel.tsx
+++ b/src/agentMode/ui/AgentSelectPanel.tsx
@@ -27,6 +27,7 @@ export const AgentSelectPanel: React.FC<Props> = ({ plugin, manager }) => {
       ctaLabel={cta.label}
       footerNote={cta.note}
       onCta={runCta}
+      ctaDisabled={cta.action === "wait"}
     />
   );
 };

--- a/src/agentMode/ui/AgentSelectPanel.tsx
+++ b/src/agentMode/ui/AgentSelectPanel.tsx
@@ -1,0 +1,32 @@
+import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
+import { AgentSelectView } from "@/agentMode/ui/AgentSelectView";
+import { useAgentSelect } from "@/agentMode/ui/useAgentSelect";
+import type CopilotPlugin from "@/main";
+import React from "react";
+
+interface Props {
+  plugin: CopilotPlugin;
+  manager: AgentSessionManager | null | undefined;
+}
+
+/**
+ * Binds the pure `AgentSelectView` to the plugin's live backend state. It owns
+ * no derivation of its own — `useAgentSelect` decides which agents exist, which
+ * one is selected, and what the single call to action does — so the view stays
+ * mountable from the component gallery with fixture props alone.
+ * @param plugin - Plugin instance backing readiness subscriptions and Configure dialogs.
+ * @param manager - Session manager that commits the choice and spawns the chat.
+ */
+export const AgentSelectPanel: React.FC<Props> = ({ plugin, manager }) => {
+  const { rows, selectedId, select, cta, runCta } = useAgentSelect(plugin, manager);
+  return (
+    <AgentSelectView
+      rows={rows}
+      selectedId={selectedId}
+      onSelect={select}
+      ctaLabel={cta.label}
+      footerNote={cta.note}
+      onCta={runCta}
+    />
+  );
+};

--- a/src/agentMode/ui/AgentSelectView.stories.tsx
+++ b/src/agentMode/ui/AgentSelectView.stories.tsx
@@ -74,9 +74,9 @@ export const NothingSetUp: StoryObj<AgentSelectViewProps> = {
   render: AgentSelectStory,
 };
 
-export const OpencodeConnected: StoryObj<AgentSelectViewProps> = {
+export const OpencodeInstalled: StoryObj<AgentSelectViewProps> = {
   args: {
-    rows: [{ ...OPENCODE, status: "connected" }, CLAUDE, CODEX],
+    rows: [{ ...OPENCODE, status: "installed" }, CLAUDE, CODEX],
   },
   render: AgentSelectStory,
 };
@@ -92,7 +92,7 @@ export const ClaudeChecking: StoryObj<AgentSelectViewProps> = {
 export const ClaudeUpdateRequired: StoryObj<AgentSelectViewProps> = {
   args: {
     rows: [
-      { ...OPENCODE, status: "connected" },
+      { ...OPENCODE, status: "installed" },
       {
         ...CLAUDE,
         status: "outdated",
@@ -129,7 +129,7 @@ export const LongAgentName: StoryObj<AgentSelectViewProps> = {
         name: "Very Long Local Agent Backend Name",
         description:
           "Runs every Copilot Plus model plus anything reachable on your own provider key, and Copilot will download, verify, and keep the managed binary up to date for you without leaving the vault.",
-        status: "connected",
+        status: "installed",
       },
       CLAUDE,
       CODEX,

--- a/src/agentMode/ui/AgentSelectView.test.tsx
+++ b/src/agentMode/ui/AgentSelectView.test.tsx
@@ -131,5 +131,12 @@ describe("AgentSelectView", () => {
 
       expect(screen.getByText("Ready to go.")).toBeTruthy();
     });
+
+    it("omits the footer note when the selected agent needs no attention", () => {
+      renderView({ footerNote: null, ctaLabel: "Start chat" });
+
+      expect(screen.queryByText("opencode isn't set up on this machine yet.")).toBeNull();
+      expect(screen.getByRole("button", { name: "Start chat" })).toBeTruthy();
+    });
   });
 });

--- a/src/agentMode/ui/AgentSelectView.test.tsx
+++ b/src/agentMode/ui/AgentSelectView.test.tsx
@@ -55,7 +55,7 @@ describe("AgentSelectView", () => {
 
     it.each<[AgentSelectStatus, string]>([
       ["checking", "Checking…"],
-      ["connected", "Connected"],
+      ["installed", "Installed"],
       ["outdated", "Update required"],
       ["error", "Error"],
     ])("badges the %s status on the agent's row", (status, label) => {
@@ -67,7 +67,7 @@ describe("AgentSelectView", () => {
     it("shows no status badge for an agent that is not set up", () => {
       renderView({ rows: [row({ id: "claude", status: "absent" })] });
 
-      expect(screen.queryByText("Connected")).toBeNull();
+      expect(screen.queryByText("Installed")).toBeNull();
       expect(screen.queryByText("Update required")).toBeNull();
       expect(screen.queryByText("Error")).toBeNull();
       expect(screen.queryByText(/not found/i)).toBeNull();

--- a/src/agentMode/ui/AgentSelectView.tsx
+++ b/src/agentMode/ui/AgentSelectView.tsx
@@ -24,7 +24,7 @@ interface StatusBadgeSpec {
  */
 const STATUS_BADGES: Partial<Record<AgentSelectStatus, StatusBadgeSpec>> = {
   checking: { label: "Checking…", variant: "secondary", Icon: LoaderCircle },
-  connected: { label: "Connected", variant: "success", Icon: Check },
+  installed: { label: "Installed", variant: "success", Icon: Check },
   outdated: { label: "Update required", variant: "destructive", Icon: AlertTriangle },
   error: { label: "Error", variant: "destructive", Icon: AlertTriangle },
 };

--- a/src/agentMode/ui/AgentSelectView.tsx
+++ b/src/agentMode/ui/AgentSelectView.tsx
@@ -34,8 +34,8 @@ interface AgentSelectViewProps {
   selectedId: BackendId;
   onSelect: (id: BackendId) => void;
   ctaLabel: string;
-  /** Footer text left of the button, explaining what pressing it will do. */
-  footerNote: string;
+  /** Footer text left of the button when the selected agent needs attention. */
+  footerNote: string | null;
   onCta: () => void;
   /** Prevents a transient readiness state from exposing an action. */
   ctaDisabled?: boolean;
@@ -163,10 +163,17 @@ export const AgentSelectView: React.FC<AgentSelectViewProps> = ({
         })}
       </div>
 
-      <div className="copilot-divider-t tw-flex tw-flex-wrap tw-items-center tw-justify-between tw-gap-2 tw-pt-3">
-        <span className="tw-min-w-0 tw-flex-1 tw-break-words tw-text-ui-smaller tw-text-muted">
-          {footerNote}
-        </span>
+      <div
+        className={cn(
+          "copilot-divider-t tw-flex tw-flex-wrap tw-items-center tw-gap-2 tw-pt-3",
+          footerNote ? "tw-justify-between" : "tw-justify-end"
+        )}
+      >
+        {footerNote && (
+          <span className="tw-min-w-0 tw-flex-1 tw-break-words tw-text-ui-smaller tw-text-muted">
+            {footerNote}
+          </span>
+        )}
         <Button size="sm" onClick={onCta} disabled={ctaDisabled} className="tw-shrink-0">
           {ctaLabel}
         </Button>

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -1,5 +1,6 @@
 import {
   appendBackendSection,
+  backendReadinessReason,
   buildEffortOptionsByModelKey,
   buildEffortSibling,
   buildModelOnChange,
@@ -15,6 +16,7 @@ import type {
   BackendState,
   EffortOption,
   EnabledModelEntry,
+  InstallState,
   ModelEntry,
   ModelState,
 } from "@/agentMode/session/types";
@@ -109,10 +111,14 @@ describe("collectModelActiveContext", () => {
 
 // ---- helpers for builder tests ----------------------------------------
 
-function makeDescriptor(id: "codex" | "claude" | "opencode"): BackendDescriptor {
+function makeDescriptor(
+  id: "codex" | "claude" | "opencode",
+  installState: InstallState = { kind: "ready", source: "custom" }
+): BackendDescriptor {
   return {
     id,
     displayName: id,
+    getInstallState: () => installState,
     wire: {
       encode: () => "",
       decode: () => ({ selection: { baseModelId: "", effort: null }, provider: null }),
@@ -944,5 +950,139 @@ describe("buildPickerEntries — persisted capability propagation", () => {
     const { entries } = buildPickerEntries(manager, [claude], ctxFor("claude"), emptySettings);
     const entry = entries.find((e) => e.name === "claude-sonnet-4-5");
     expect(entry?.capabilities).toBeUndefined();
+  });
+});
+
+describe("backendReadinessReason()", () => {
+  it("labels each state a user must fix before the backend can run", () => {
+    expect(backendReadinessReason({ kind: "absent" })).toBe("Not set up");
+    expect(
+      backendReadinessReason({
+        kind: "incompatible",
+        source: "custom",
+        currentVersion: "1.0.0",
+        minVersion: "2.0.0",
+        message: "too old",
+      })
+    ).toBe("Update required");
+    expect(backendReadinessReason({ kind: "error", message: "boom" })).toBe("Setup error");
+  });
+
+  it("leaves rows selectable while the backend is ready or still being checked", () => {
+    expect(backendReadinessReason({ kind: "ready", source: "custom" })).toBeUndefined();
+    // Transient: labelling a backend "not set up" for the moment a version probe
+    // takes would be wrong more often than right.
+    expect(backendReadinessReason({ kind: "checking", source: "custom" })).toBeUndefined();
+  });
+});
+
+describe("buildPickerEntries — backend readiness", () => {
+  function claudeWith(installState: InstallState): BackendDescriptor {
+    return {
+      ...makeDescriptor("claude", installState),
+      getEnabledModelEntries: () => [
+        { baseModelId: "sonnet", name: "Sonnet", credentialState: "ok" as const },
+      ],
+    };
+  }
+
+  function noSessionCtx(): ModelActiveContext {
+    return {
+      activeSession: null,
+      activeChatUIState: null,
+      activeBackendId: null,
+      activeDescriptor: undefined,
+      activeSessionHasHistory: false,
+      activeModelState: null,
+      activeCurrentEntry: undefined,
+    };
+  }
+
+  const managerWithSonnet = () =>
+    makeManager({ catalogById: { claude: makeCatalog([makeModelEntry("sonnet")]) } });
+
+  it("marks rows of a backend that isn't set up so the pick can't be made", () => {
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [claudeWith({ kind: "absent" })],
+      noSessionCtx(),
+      emptySettings
+    );
+    expect(entries.map((e) => e._disabledReason)).toEqual(["Not set up"]);
+  });
+
+  it("marks rows of a backend whose binary is too old", () => {
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [
+        claudeWith({
+          kind: "incompatible",
+          source: "custom",
+          currentVersion: "2.1.205",
+          minVersion: "2.1.206",
+          message: "too old",
+        }),
+      ],
+      noSessionCtx(),
+      emptySettings
+    );
+    expect(entries.map((e) => e._disabledReason)).toEqual(["Update required"]);
+  });
+
+  it("marks rows of a backend whose readiness check failed", () => {
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [claudeWith({ kind: "error", message: "not executable" })],
+      noSessionCtx(),
+      emptySettings
+    );
+    expect(entries.map((e) => e._disabledReason)).toEqual(["Setup error"]);
+  });
+
+  it("keeps rows selectable while a readiness check is still in flight", () => {
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [claudeWith({ kind: "checking", source: "custom" })],
+      noSessionCtx(),
+      emptySettings
+    );
+    expect(entries.map((e) => e._disabledReason)).toEqual([undefined]);
+  });
+
+  it("reports the unset-up backend rather than a per-model credential problem", () => {
+    const claude = {
+      ...makeDescriptor("claude", { kind: "absent" }),
+      getEnabledModelEntries: () => [
+        { baseModelId: "sonnet", name: "Sonnet", credentialState: "missing_key" as const },
+      ],
+    } as unknown as BackendDescriptor;
+
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [claude],
+      noSessionCtx(),
+      emptySettings
+    );
+
+    // "Add API key" would send the user to the wrong fix while the agent that
+    // would consume the key isn't installed at all.
+    expect(entries[0]._disabledReason).toBe("Not set up");
+  });
+
+  it("regression: never disables the running backend's own rows when its binary goes missing", () => {
+    // The merged picker seeds its draft from selectable rows only, so disabling
+    // the active session's rows would silently draft a different backend's model
+    // and commit it when the popover closes.
+    const claude = claudeWith({ kind: "absent" });
+    const ctx: ModelActiveContext = {
+      ...noSessionCtx(),
+      activeSession: { backendId: "claude" } as unknown as AgentSession,
+      activeBackendId: "claude",
+      activeDescriptor: claude,
+    };
+
+    const { entries } = buildPickerEntries(managerWithSonnet(), [claude], ctx, emptySettings);
+
+    expect(entries.map((e) => e._disabledReason)).toEqual([undefined]);
   });
 });

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -187,6 +187,31 @@ function makeManager(opts: {
 
 const emptySettings = {} as CopilotSettings;
 
+function claudeWithInstallState(installState: InstallState): BackendDescriptor {
+  return {
+    ...makeDescriptor("claude", installState),
+    getEnabledModelEntries: () => [
+      { baseModelId: "sonnet", name: "Sonnet", credentialState: "ok" as const },
+    ],
+  };
+}
+
+function noSessionContext(): ModelActiveContext {
+  return {
+    activeSession: null,
+    activeChatUIState: null,
+    activeBackendId: null,
+    activeDescriptor: undefined,
+    activeSessionHasHistory: false,
+    activeModelState: null,
+    activeCurrentEntry: undefined,
+  };
+}
+
+function managerWithSonnet(): AgentSessionManager {
+  return makeManager({ catalogById: { claude: makeCatalog([makeModelEntry("sonnet")]) } });
+}
+
 // ---- buildPickerEntries ----
 
 describe("buildPickerEntries", () => {
@@ -567,6 +592,91 @@ describe("buildPickerEntries", () => {
     const { entries } = buildPickerEntries(manager, [codex], ctx, emptySettings);
     expect(entries[0].name).toBe("ghost-model");
     expect(entries[0]._needsSelfHostWarning).toBe(true);
+  });
+
+  it("marks rows of a backend that isn't set up so the pick can't be made", () => {
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [claudeWithInstallState({ kind: "absent" })],
+      noSessionContext(),
+      emptySettings
+    );
+    expect(entries.map((entry) => entry._disabledReason)).toEqual(["Not set up"]);
+  });
+
+  it("marks rows of a backend whose binary is too old", () => {
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [
+        claudeWithInstallState({
+          kind: "incompatible",
+          source: "custom",
+          currentVersion: "2.1.205",
+          minVersion: "2.1.206",
+          message: "too old",
+        }),
+      ],
+      noSessionContext(),
+      emptySettings
+    );
+    expect(entries.map((entry) => entry._disabledReason)).toEqual(["Update required"]);
+  });
+
+  it("marks rows of a backend whose readiness check failed", () => {
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [claudeWithInstallState({ kind: "error", message: "not executable" })],
+      noSessionContext(),
+      emptySettings
+    );
+    expect(entries.map((entry) => entry._disabledReason)).toEqual(["Setup error"]);
+  });
+
+  it("keeps rows selectable while a readiness check is still in flight", () => {
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [claudeWithInstallState({ kind: "checking", source: "custom" })],
+      noSessionContext(),
+      emptySettings
+    );
+    expect(entries.map((entry) => entry._disabledReason)).toEqual([undefined]);
+  });
+
+  it("reports the unset-up backend rather than a per-model credential problem", () => {
+    const claude = {
+      ...makeDescriptor("claude", { kind: "absent" }),
+      getEnabledModelEntries: () => [
+        { baseModelId: "sonnet", name: "Sonnet", credentialState: "missing_key" as const },
+      ],
+    } as unknown as BackendDescriptor;
+
+    const { entries } = buildPickerEntries(
+      managerWithSonnet(),
+      [claude],
+      noSessionContext(),
+      emptySettings
+    );
+
+    // "Add API key" would send the user to the wrong fix while the agent that
+    // would consume the key isn't installed at all.
+    expect(entries[0]._disabledReason).toBe("Not set up");
+  });
+
+  it("regression: never disables the running backend's own rows when its binary goes missing", () => {
+    // The merged picker seeds its draft from selectable rows only, so disabling
+    // the active session's rows would silently draft a different backend's model
+    // and commit it when the popover closes.
+    const claude = claudeWithInstallState({ kind: "absent" });
+    const ctx: ModelActiveContext = {
+      ...noSessionContext(),
+      activeSession: { backendId: "claude" } as unknown as AgentSession,
+      activeBackendId: "claude",
+      activeDescriptor: claude,
+    };
+
+    const { entries } = buildPickerEntries(managerWithSonnet(), [claude], ctx, emptySettings);
+
+    expect(entries.map((entry) => entry._disabledReason)).toEqual([undefined]);
   });
 });
 
@@ -973,116 +1083,5 @@ describe("backendReadinessReason()", () => {
     // Transient: labelling a backend "not set up" for the moment a version probe
     // takes would be wrong more often than right.
     expect(backendReadinessReason({ kind: "checking", source: "custom" })).toBeUndefined();
-  });
-});
-
-describe("buildPickerEntries — backend readiness", () => {
-  function claudeWith(installState: InstallState): BackendDescriptor {
-    return {
-      ...makeDescriptor("claude", installState),
-      getEnabledModelEntries: () => [
-        { baseModelId: "sonnet", name: "Sonnet", credentialState: "ok" as const },
-      ],
-    };
-  }
-
-  function noSessionCtx(): ModelActiveContext {
-    return {
-      activeSession: null,
-      activeChatUIState: null,
-      activeBackendId: null,
-      activeDescriptor: undefined,
-      activeSessionHasHistory: false,
-      activeModelState: null,
-      activeCurrentEntry: undefined,
-    };
-  }
-
-  const managerWithSonnet = () =>
-    makeManager({ catalogById: { claude: makeCatalog([makeModelEntry("sonnet")]) } });
-
-  it("marks rows of a backend that isn't set up so the pick can't be made", () => {
-    const { entries } = buildPickerEntries(
-      managerWithSonnet(),
-      [claudeWith({ kind: "absent" })],
-      noSessionCtx(),
-      emptySettings
-    );
-    expect(entries.map((e) => e._disabledReason)).toEqual(["Not set up"]);
-  });
-
-  it("marks rows of a backend whose binary is too old", () => {
-    const { entries } = buildPickerEntries(
-      managerWithSonnet(),
-      [
-        claudeWith({
-          kind: "incompatible",
-          source: "custom",
-          currentVersion: "2.1.205",
-          minVersion: "2.1.206",
-          message: "too old",
-        }),
-      ],
-      noSessionCtx(),
-      emptySettings
-    );
-    expect(entries.map((e) => e._disabledReason)).toEqual(["Update required"]);
-  });
-
-  it("marks rows of a backend whose readiness check failed", () => {
-    const { entries } = buildPickerEntries(
-      managerWithSonnet(),
-      [claudeWith({ kind: "error", message: "not executable" })],
-      noSessionCtx(),
-      emptySettings
-    );
-    expect(entries.map((e) => e._disabledReason)).toEqual(["Setup error"]);
-  });
-
-  it("keeps rows selectable while a readiness check is still in flight", () => {
-    const { entries } = buildPickerEntries(
-      managerWithSonnet(),
-      [claudeWith({ kind: "checking", source: "custom" })],
-      noSessionCtx(),
-      emptySettings
-    );
-    expect(entries.map((e) => e._disabledReason)).toEqual([undefined]);
-  });
-
-  it("reports the unset-up backend rather than a per-model credential problem", () => {
-    const claude = {
-      ...makeDescriptor("claude", { kind: "absent" }),
-      getEnabledModelEntries: () => [
-        { baseModelId: "sonnet", name: "Sonnet", credentialState: "missing_key" as const },
-      ],
-    } as unknown as BackendDescriptor;
-
-    const { entries } = buildPickerEntries(
-      managerWithSonnet(),
-      [claude],
-      noSessionCtx(),
-      emptySettings
-    );
-
-    // "Add API key" would send the user to the wrong fix while the agent that
-    // would consume the key isn't installed at all.
-    expect(entries[0]._disabledReason).toBe("Not set up");
-  });
-
-  it("regression: never disables the running backend's own rows when its binary goes missing", () => {
-    // The merged picker seeds its draft from selectable rows only, so disabling
-    // the active session's rows would silently draft a different backend's model
-    // and commit it when the popover closes.
-    const claude = claudeWith({ kind: "absent" });
-    const ctx: ModelActiveContext = {
-      ...noSessionCtx(),
-      activeSession: { backendId: "claude" } as unknown as AgentSession,
-      activeBackendId: "claude",
-      activeDescriptor: claude,
-    };
-
-    const { entries } = buildPickerEntries(managerWithSonnet(), [claude], ctx, emptySettings);
-
-    expect(entries.map((e) => e._disabledReason)).toEqual([undefined]);
   });
 });

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -15,6 +15,7 @@ import type {
   EffortOption,
   EnabledModelCredentialState,
   EnabledModelEntry,
+  InstallState,
   ModelEntry,
   ModelState,
 } from "@/agentMode/session/types";
@@ -183,6 +184,32 @@ function credentialDisabledReason(
   return undefined;
 }
 
+/**
+ * Map a backend's readiness to a `_disabledReason` for every row it
+ * contributes, or `undefined` when its rows stay selectable. Picking a model on
+ * a backend that isn't set up can only end in a failed spawn, so the picker says
+ * so up front instead of letting the user find out by losing their pane.
+ *
+ * `checking` stays selectable: it is a transient probe that resolves on its own,
+ * and labelling a backend "not set up" for the moment it takes to read a version
+ * would be wrong more often than it is right. `error` reads `Setup error` rather
+ * than the preload placeholder's `Unavailable` — the distinction matters because
+ * this one is fixed in the backend's Configure dialog, not by waiting.
+ */
+export function backendReadinessReason(state: InstallState): string | undefined {
+  switch (state.kind) {
+    case "absent":
+      return "Not set up";
+    case "incompatible":
+      return "Update required";
+    case "error":
+      return "Setup error";
+    case "checking":
+    case "ready":
+      return undefined;
+  }
+}
+
 export function synthesizeAgentEntry(
   baseModelId: string,
   humanName: string,
@@ -314,6 +341,27 @@ export function buildPickerEntries(
         entries.push(synthesizePreloadPlaceholder(descriptor, "pending"));
       } else if (preloadStatus === "ready" || preloadStatus === "error") {
         entries.push(synthesizePreloadPlaceholder(descriptor, "error"));
+      }
+    }
+    // Mark every row of a backend that can't run, so a doomed cross-backend
+    // pick is never offered as if it were selectable. This overwrites a
+    // per-model credential reason on purpose: an agent that isn't set up is the
+    // root cause, and "Add API key" would send the user to the wrong fix.
+    // The *active* backend is exempt — its rows are the running session's own
+    // selection, and disabling them would strand the current model (the merged
+    // picker seeds its draft from selectable rows only, so it would silently
+    // draft a different backend's model instead).
+    // Readiness is read from `settings`, which is already a dependency of the
+    // caller's memo, so every settings-driven transition (path saved, binary
+    // installed) relabels. The one transition that isn't settings-driven is
+    // Claude's async version probe, and it starts from `checking` — which
+    // carries no label — so it can never leave a row stuck as unselectable.
+    if (!isActiveBackend) {
+      const readiness = backendReadinessReason(descriptor.getInstallState(settings));
+      if (readiness) {
+        for (let i = sectionStart; i < entries.length; i++) {
+          entries[i]._disabledReason = readiness;
+        }
       }
     }
     // Flag this backend's rows when Self-Host Mode marks it as cloud. Registry

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -351,11 +351,9 @@ export function buildPickerEntries(
     // selection, and disabling them would strand the current model (the merged
     // picker seeds its draft from selectable rows only, so it would silently
     // draft a different backend's model instead).
-    // Readiness is read from `settings`, which is already a dependency of the
-    // caller's memo, so every settings-driven transition (path saved, binary
-    // installed) relabels. The one transition that isn't settings-driven is
-    // Claude's async version probe, and it starts from `checking` — which
-    // carries no label — so it can never leave a row stuck as unselectable.
+    // The caller subscribes to every descriptor's install-state store as well
+    // as settings, so async compatibility probes relabel these rows even when
+    // no persisted setting changed.
     if (!isActiveBackend) {
       const readiness = backendReadinessReason(descriptor.getInstallState(settings));
       if (readiness) {

--- a/src/agentMode/ui/agentSelectModel.test.ts
+++ b/src/agentMode/ui/agentSelectModel.test.ts
@@ -131,7 +131,7 @@ describe("agentSelectModel", () => {
     it("offers to start a chat on an installed agent without claiming authentication", () => {
       expect(resolveAgentSelectCta(rowWith({ status: "installed" }))).toEqual({
         label: "Start chat",
-        note: "Installed. Start this agent to check sign-in and begin chatting.",
+        note: null,
         action: "start",
       });
     });

--- a/src/agentMode/ui/agentSelectModel.test.ts
+++ b/src/agentMode/ui/agentSelectModel.test.ts
@@ -42,14 +42,14 @@ function rowWith(overrides: Partial<AgentSelectRow> = {}): AgentSelectRow {
 
 describe("agentSelectModel", () => {
   describe("buildAgentSelectRows()", () => {
-    it("reports a ready backend as connected with no status message", () => {
+    it("reports a ready backend as installed with no status message", () => {
       const [row] = buildAgentSelectRows(
         [OPENCODE],
         { opencode: { kind: "ready", source: "managed" } },
         "opencode"
       );
 
-      expect(row.status).toBe("connected");
+      expect(row.status).toBe("installed");
       expect(row.statusMessage).toBeNull();
     });
 
@@ -128,10 +128,10 @@ describe("agentSelectModel", () => {
       });
     });
 
-    it("offers to start a chat on a connected agent", () => {
-      expect(resolveAgentSelectCta(rowWith({ status: "connected" }))).toEqual({
+    it("offers to start a chat on an installed agent without claiming authentication", () => {
+      expect(resolveAgentSelectCta(rowWith({ status: "installed" }))).toEqual({
         label: "Start chat",
-        note: "Ready to go. You can switch agents any time from the agent picker.",
+        note: "Installed. Start this agent to check sign-in and begin chatting.",
         action: "start",
       });
     });

--- a/src/agentMode/ui/agentSelectModel.ts
+++ b/src/agentMode/ui/agentSelectModel.ts
@@ -24,15 +24,13 @@ export interface AgentSelectRow {
 /** What the view's single call to action does for the selected row. */
 export type AgentSelectAction = "start" | "configure" | "wait";
 
-/** Label, explanatory note, and behavior of the select view's one call to action. */
+/** Label, optional explanatory note, and behavior of the select view's one call to action. */
 export interface AgentSelectCta {
   label: string;
-  /** Footer text beside the button, explaining what pressing it will do. */
-  note: string;
+  /** Footer text beside the button when the selected agent needs attention. */
+  note: string | null;
   action: AgentSelectAction;
 }
-
-const INSTALLED_NOTE = "Installed. Start this agent to check sign-in and begin chatting.";
 
 const EMPTY_AGENT_SELECT_ROWS: readonly AgentSelectRow[] = Object.freeze([]);
 
@@ -103,7 +101,7 @@ export function resolveAgentSelectCta(row: AgentSelectRow): AgentSelectCta {
     };
   }
   if (row.status === "installed") {
-    return { label: "Start chat", note: INSTALLED_NOTE, action: "start" };
+    return { label: "Start chat", note: null, action: "start" };
   }
   return {
     label: "Configure",

--- a/src/agentMode/ui/agentSelectModel.ts
+++ b/src/agentMode/ui/agentSelectModel.ts
@@ -3,7 +3,7 @@ import type { BackendDescriptor, BackendId, InstallState } from "@/agentMode/ses
 /**
  * Readiness of one agent as the select view words it.
  */
-export type AgentSelectStatus = "checking" | "connected" | "outdated" | "absent" | "error";
+export type AgentSelectStatus = "checking" | "installed" | "outdated" | "absent" | "error";
 
 /** One agent row in the select view. */
 export interface AgentSelectRow {
@@ -14,7 +14,7 @@ export interface AgentSelectRow {
   /** True for the single backend a first-run user is steered to. */
   recommended: boolean;
   /**
-   * Operator-facing detail behind a non-`connected` status, carried straight
+   * Operator-facing detail behind a non-`installed` status, carried straight
    * from `InstallState.message` so version prose is never re-derived here.
    * `null` when the install state has no message to offer.
    */
@@ -32,7 +32,7 @@ export interface AgentSelectCta {
   action: AgentSelectAction;
 }
 
-const READY_NOTE = "Ready to go. You can switch agents any time from the agent picker.";
+const INSTALLED_NOTE = "Installed. Start this agent to check sign-in and begin chatting.";
 
 const EMPTY_AGENT_SELECT_ROWS: readonly AgentSelectRow[] = Object.freeze([]);
 
@@ -46,7 +46,7 @@ const EMPTY_AGENT_SELECT_ROWS: readonly AgentSelectRow[] = Object.freeze([]);
 function toSelectStatus(kind: InstallState["kind"]): AgentSelectStatus {
   switch (kind) {
     case "ready":
-      return "connected";
+      return "installed";
     case "checking":
       return "checking";
     case "incompatible":
@@ -89,7 +89,7 @@ export function buildAgentSelectRows(
 }
 
 /**
- * Resolve the one call to action the select view ends in. A connected agent can
+ * Resolve the one call to action the select view ends in. An installed agent can
  * be started; everything else routes to that agent's Configure dialog, with the
  * note explaining why.
  * @param row - The currently selected row.
@@ -102,8 +102,8 @@ export function resolveAgentSelectCta(row: AgentSelectRow): AgentSelectCta {
       action: "wait",
     };
   }
-  if (row.status === "connected") {
-    return { label: "Start chat", note: READY_NOTE, action: "start" };
+  if (row.status === "installed") {
+    return { label: "Start chat", note: INSTALLED_NOTE, action: "start" };
   }
   return {
     label: "Configure",

--- a/src/agentMode/ui/useAgentModelPicker.test.tsx
+++ b/src/agentMode/ui/useAgentModelPicker.test.tsx
@@ -3,9 +3,33 @@ import type { AgentChatUIState } from "@/agentMode/session/AgentChatUIState";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import type { BackendDescriptor, BackendState } from "@/agentMode/session/types";
+import type CopilotPlugin from "@/main";
 import { useAgentModelPicker } from "./useAgentModelPicker";
 
-const mockDescriptors = [{ id: "opencode" }] as BackendDescriptor[];
+let mockInstallKind: "ready" | "incompatible" = "ready";
+let mockInstallListener: (() => void) | null = null;
+const mockDescriptors = [
+  {
+    id: "opencode",
+    getInstallState: () =>
+      mockInstallKind === "ready"
+        ? ({ kind: "ready", source: "managed" } as const)
+        : ({
+            kind: "incompatible",
+            source: "managed",
+            currentVersion: "1.15.0",
+            minVersion: "1.16.0",
+            message: "Update required",
+          } as const),
+    subscribeInstallState: (_plugin: CopilotPlugin, listener: () => void) => {
+      mockInstallListener = listener;
+      return () => {
+        mockInstallListener = null;
+      };
+    },
+  },
+] as unknown as BackendDescriptor[];
+const plugin = {} as CopilotPlugin;
 
 jest.mock("@/settings/model", () => ({
   useSettingsValue: jest.fn().mockReturnValue({}),
@@ -16,11 +40,17 @@ jest.mock("@/agentMode/backends/registry", () => ({
 }));
 
 jest.mock("./agentModelPickerHelpers", () => ({
-  buildAgentModelPicker: ({ manager }: { manager: AgentSessionManager }) => ({
+  buildAgentModelPicker: ({
+    manager,
+    descriptors,
+  }: {
+    manager: AgentSessionManager;
+    descriptors: BackendDescriptor[];
+  }) => ({
     models: [],
     value: `${
       manager.getActiveSession()?.getState()?.model?.current.baseModelId ?? ""
-    }:${manager.getModelCacheSignature("opencode")}`,
+    }:${manager.getModelCacheSignature("opencode")}:${descriptors[0].getInstallState({} as never).kind}`,
     onChange: jest.fn(),
   }),
 }));
@@ -37,8 +67,13 @@ function stateWithModel(baseModelId: string): BackendState {
 }
 
 describe("useAgentModelPicker", () => {
+  beforeEach(() => {
+    mockInstallKind = "ready";
+    mockInstallListener = null;
+  });
+
   describe("useAgentModelPicker()", () => {
-    it("rerenders from session and catalog signals without reading the legacy backend cache", () => {
+    it("rerenders from session, catalog, and backend readiness signals", () => {
       let state = stateWithModel("first");
       let catalogSignal = "catalog-one";
       let activeListener: (() => void) | null = null;
@@ -71,16 +106,20 @@ describe("useAgentModelPicker", () => {
         getModelCacheSignature: () => catalogSignal,
       } as unknown as AgentSessionManager;
 
-      const { result } = renderHook(() => useAgentModelPicker(manager));
-      expect(result.current?.value).toBe("first:catalog-one");
+      const { result } = renderHook(() => useAgentModelPicker(manager, plugin));
+      expect(result.current?.value).toBe("first:catalog-one:ready");
 
       state = stateWithModel("second");
       act(() => activeListener?.());
-      expect(result.current?.value).toBe("second:catalog-one");
+      expect(result.current?.value).toBe("second:catalog-one:ready");
 
       catalogSignal = "catalog-two";
       act(() => cacheListener?.());
-      expect(result.current?.value).toBe("second:catalog-two");
+      expect(result.current?.value).toBe("second:catalog-two:ready");
+
+      mockInstallKind = "incompatible";
+      act(() => mockInstallListener?.());
+      expect(result.current?.value).toBe("second:catalog-two:incompatible");
     });
   });
 });

--- a/src/agentMode/ui/useAgentModelPicker.ts
+++ b/src/agentMode/ui/useAgentModelPicker.ts
@@ -5,8 +5,10 @@ import { listBackendDescriptors } from "@/agentMode/backends/registry";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import { modelStateSignature } from "@/agentMode/session/translateBackendState";
 import type { BackendDescriptor } from "@/agentMode/session/types";
+import { useBackendInstallStates } from "@/agentMode/ui/useBackendDescriptor";
 import { buildAgentModelPicker } from "./agentModelPickerHelpers";
 import { useManagerSubscribe } from "./useManagerSubscribe";
+import type CopilotPlugin from "@/main";
 
 export interface AgentModelPickerOverride {
   models: ModelSelectorEntry[];
@@ -86,18 +88,21 @@ function useAgentModelSignal(
  * Mode is *not* part of this override — see `useAgentModePicker` for that.
  */
 export function useAgentModelPicker(
-  manager: AgentSessionManager | null
+  manager: AgentSessionManager | null,
+  plugin: CopilotPlugin
 ): AgentModelPickerOverride | null {
   const settings = useSettingsValue();
   // Every registered backend shows in the picker; Self-Host Mode marks cloud
   // agents (via `settings` in `buildAgentModelPicker`) rather than hiding them.
   // The registry is static, so the descriptor list is a stable module constant.
   const descriptors = useMemo(() => listBackendDescriptors(), []);
+  const installStates = useBackendInstallStates(plugin);
   const signal = useAgentModelSignal(manager, descriptors);
   return useMemo(() => {
-    // `signal` is a memo invalidator — referenced here so
-    // react-hooks/exhaustive-deps accepts it in the dep array.
+    // These are memo invalidators: the builder reads the manager and
+    // descriptors directly after either external store reports a change.
     void signal;
+    void installStates;
     return buildAgentModelPicker({ manager, descriptors, settings });
-  }, [manager, descriptors, settings, signal]);
+  }, [manager, descriptors, settings, signal, installStates]);
 }

--- a/src/agentMode/ui/useAgentSelect.test.tsx
+++ b/src/agentMode/ui/useAgentSelect.test.tsx
@@ -103,7 +103,7 @@ describe("useAgentSelect", () => {
       expect(manager.getOrCreateActiveSession).not.toHaveBeenCalled();
     });
 
-    it("persists the choice and spawns a session when starting a connected agent", () => {
+    it("persists the choice and spawns a session when starting an installed agent", () => {
       const manager = makeManager();
       const { result } = render({ claude: { kind: "ready", source: "custom" } }, manager);
       act(() => result.current.select("claude"));


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#228

## Why

Open Agent Mode today on a machine where no agent is set up and the pane is empty except for a one-line pill at the bottom: "opencode not installed — Install opencode". Nothing tells a first-time user that Copilot supports three agents (opencode, Claude, Codex), which of them are already on their machine, or where to start — the first run reads as one broken agent rather than a choice.

Copilot already has a "Select your agent" view that lists all three agents with their setup status, but no pane state renders it — a user can never reach it. This PR wires it into the pane for that first-run moment — and only that moment. Two adjacent surfaces already handle their own states and must not be swallowed by onboarding:

- A running agent that crashes (or loses credentials) also ends up with no session. That is a runtime failure, not a first run — it must keep the recovery card with Retry, not a setup screen that hides what just went wrong.
- The model picker lists models from every agent. When an agent can't currently run (binary removed, too old), picking one of its models can only end in a failed spawn — the picker should say so up front instead of offering the row as selectable.

## What

- **Cold start** — no chat to restore, nothing erroring, and the agent that would run isn't set up: the pane now shows the centered agent selection view with each agent's setup status and one call to action (Configure for an agent that needs setup, Start chat for one that's ready). A ready agent is badged "Installed" rather than "Connected" — sign-in is only checked after it starts.
- **Start chat during startup** — pressing Start chat while the plugin's readiness probe is still running now waits for that probe and adopts its agent process instead of racing it into a duplicate spawn.
- **Runtime failure** — unchanged: the compact recovery card stays, even when the failing agent's binary is also missing. The crash is surfaced first; the card still offers Install/Configure.
- **Transient "Checking version…"** — unchanged: keeps the card rather than flashing the selection view while the probe resolves on its own.
- **Model picker** — rows of an agent that can't currently run are disabled and labeled with the reason ("Not set up", "Update required", "Setup error"). The active session's own rows are never disabled.

## Non goal

- Redesign the agent selection view or configuration dialogs.
- Add placeholder model rows for agents that have never loaded.

## Screenshot

| Before — cold start today | After — the same cold start |
| --- | --- |
| <img width="420" alt="Empty pane with a one-line install pill at the bottom" src="https://github.com/user-attachments/assets/e2567230-0efa-437e-9996-8fe3bb395d4a" /> | <img width="420" alt="Agent selection view centered in the pane" src="https://github.com/user-attachments/assets/b3cd2917-7f42-4a3b-892f-2f13efed0e96" /> |

**After — model picker while an agent is unavailable** (opencode's binary went missing during a Claude session): its rows are disabled with the reason instead of selectable.

<img width="500" alt="Model picker with opencode rows disabled and labeled Not set up" src="https://github.com/user-attachments/assets/0fcc7faf-654e-4607-b68f-1a87a33cd88d" />

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ❌ | Tests cover routing and deduplication, but real subprocess startup timing is not reproducible in CI |
| A defect would fail CI or be obvious on first use | ❌ | A duplicate spawn can pass deterministic tests and appear only during an in-flight live preload |
| A revert fully restores prior state, including persisted data | ✅ | No settings or session format changes; a revert restores the previous startup order |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The change uses existing backend setup and recovery actions |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Session-manager and picker changes are internal |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Every chat start now coordinates with the preload lifecycle and no-session routing |
| No hot-path behavior lacks deterministic coverage | ❌ | Live process startup is a core path whose timing cannot be fully automated |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Failures stay in Agent Mode and surface as duplicate processes or the wrong fallback |

Review: inspect `src/agentMode/session/AgentSessionManager.ts` — `ensureBackend` — and `src/agentMode/ui/AgentModeChat.tsx` — `AgentModeChat`'s `isColdStart` branch — line by line, then run Verification steps 3–5 with the missing-binary, runtime-failure, and in-flight-preload variants.

## Verification

1. In a test vault with no agent set up (e.g. clear opencode's binary entry from the plugin settings), open Agent Mode: the centered "Select your agent" view appears; the selected agent shows Configure, a connected one shows Start chat.
2. Press Start chat on a connected agent: a chat session opens.
3. Make a running agent fail (e.g. remove its binary mid-session and send a message): the compact card with Retry appears — not the selection view.
4. With a session on one agent, make another agent unavailable (remove its binary, or mark its recorded version below the minimum) and open the model picker: that agent's rows are grayed out with the reason while the active agent's rows stay selectable.
5. Reload the plugin and, before its readiness check settles (the row still shows "Checking…" or the pane has just appeared), start a chat: exactly one chat opens, and only one agent process is running (e.g. a single `opencode` process in Activity Monitor) — no duplicate spawn and no error card.
