### PR TITLE
[Agent trail grouping] - Step 1: Define activity group behavior

### DIFF
--- a/designdocs/AGENT_TRAIL_GROUPING.md
+++ b/designdocs/AGENT_TRAIL_GROUPING.md
@@ -1,0 +1,111 @@
+# Agent trail grouping
+
+How the Agent Mode trail folds a turn's activity into readable units, and why
+each rule is shaped the way it is. `src/agentMode/ui/agentTrail.ts` builds the
+render tree; `src/agentMode/ui/activityGroups.ts` folds that tree into activity
+groups.
+
+## The problem
+
+A turn's `AgentMessagePart[]` interleaves tool calls, reasoning, and prose. The
+shipping trail compacts only **runs of consecutive same-`toolKey` tool calls**,
+which almost never fires: the agent emits a `thought` between nearly every pair
+of tool calls, and a thought breaks the run. The result is one row per tool call
+plus one row per thought, and the turn's actual writing ends up buried under
+them.
+
+An earlier fix collapsed the whole trail once a turn ended. It was removed
+because it hid content the user was mid-read — a visible-to-hidden transition
+they never asked for — and because a turn's closing line ("done") is often less
+informative than the explanation above it.
+
+## The measurement
+
+The rules below were validated by replaying 56 recorded Claude Agent SDK turns
+(1,956 tool calls, 510 reasoning blocks) from the frame log through both the
+shipping renderer and the proposed one. The metric is the **wall**: the longest
+run of machine rows before the next piece of prose.
+
+|                          | ships today | grouped |
+| ------------------------ | ----------- | ------- |
+| longest wall, worst turn | 21 rows     | 5       |
+| turns with a wall over 5 | 19 of 56    | 0       |
+| reasoning rows           | 510         | 90      |
+| total rows               | 1,839       | 1,088   |
+
+## What an activity group is
+
+A maximal run of consecutive **tool calls and reasoning blocks**, folded into
+one collapsed row summarizing the work: `Ran 1 skill, 12 commands, thought for
+51s`. A run of one member keeps its own row — a single `Read` gets no group
+chrome.
+
+### What breaks a run
+
+- **Prose.** A `text` part always renders at full size, in place. This is what
+  keeps a mid-turn explanation visible instead of buried under the closing line.
+- **Sub-agent launches.** A delegation owns a nested trail and a report of its
+  own, so it stays its own row rather than becoming a count inside someone
+  else's summary. Costs 17 rows across the sample and raises the worst-case wall
+  from 2 to 5.
+- **Interactive tool calls** — `AskUserQuestion`, `ExitPlanMode`,
+  `EnterPlanMode`. Folding a question the agent is waiting on would hide the
+  thing the user has to act on.
+- **Plan checklists.** Status, not work.
+
+### What folds in
+
+- **Reasoning**, as `thought for Xs` at the end of the line. This is the single
+  largest win — larger than folding tool calls — because a thought sits between
+  nearly every pair of tool calls.
+- **Every tool family**, heterogeneously. Unlike the shipping compaction, a
+  `Read` and a `Bash` in the same run fold into one row.
+
+### How the line reads
+
+Families are named in first-appearance order, capped at three, then `+N more`.
+Two rules came out of the replay:
+
+- **Unregistered tools keep their own identity.** Bucketing everything
+  unrecognized into "tool calls" produced lines like `Made 16 tool calls` on
+  real sessions, which lean heavily on tools with no built-in summary. They key
+  on their own name instead: `Design sync ×16`. MCP tools key per server.
+- **A verb that repeats the previous phrase's is dropped.** `Ran 1 skill, ran 12
+commands` reads as two facts; `Ran 1 skill, 12 commands` reads as one.
+
+Reasoning duration is **not** derivable from the parts — `kind: "thought"`
+carries no timestamps. The caller measures it live and passes `thinkingMs` to
+`summarizeActivity`, the same way `ReasoningBlock` measures its own timer today.
+
+## Interaction invariants
+
+These are what make grouping safe where the removed auto-fold was not:
+
+1. **A group is born collapsed and never closes itself.** There is no
+   expanded-to-collapsed transition. Nothing the user is reading disappears,
+   because it was never expanded to begin with.
+2. **User expansion is sticky.** Once opened, a group stays open for the life of
+   the session, including as new members stream into it.
+3. **Motion lives only at the live edge.** While a group has work in flight it
+   renders one transient row showing the current step, which swaps as the agent
+   moves on and retires when the group goes quiet. One row changing, never a
+   list collapsing.
+
+Invariant 2 requires a group identity that survives streaming. Groups are
+identified by their **ordinal within the trail**: parts are append-only, so a
+group's position never changes once it exists, and appending a member does not
+change its id. Keying React state by array index instead would remount an open
+group whenever the node list changed shape.
+
+## Planned deletions
+
+Activity groups subsume `AggregateCard` and the homogeneous `aggregate` render
+node. When grouping is wired into `AgentTrailView`, all three of these go:
+
+- the `aggregate` branch of `foldNodes` in `agentTrail.ts`
+- `AggregateCard.tsx`
+- `ToolSummary.aggregate` and its ~20 per-family implementations in
+  `toolSummaries.ts`
+
+Until then `aggregate` nodes still exist, so `foldActivityGroups` flattens them
+back into their member parts. That branch is deleted along with the rest.

--- a/designdocs/AGENT_TRAIL_GROUPING.md
+++ b/designdocs/AGENT_TRAIL_GROUPING.md
@@ -36,8 +36,8 @@ run of machine rows before the next piece of prose.
 ## What an activity group is
 
 A maximal run of consecutive **tool calls and reasoning blocks**, folded into
-one collapsed row summarizing the work: `Ran 1 skill, 12 commands, thought for
-51s`. A run of one member keeps its own row — a single `Read` gets no group
+one collapsed row summarizing the work: `Read 2 files, ran 12 commands, thought
+for 51s`. A run of one member keeps its own row — a single `Read` gets no group
 chrome.
 
 ### What breaks a run
@@ -63,15 +63,27 @@ chrome.
 
 ### How the line reads
 
-Families are named in first-appearance order, capped at three, then `+N more`.
-Two rules came out of the replay:
+The vocabulary is deliberately coarse — three families plus reasoning, named in
+first-appearance order:
 
-- **Unregistered tools keep their own identity.** Bucketing everything
-  unrecognized into "tool calls" produced lines like `Made 16 tool calls` on
-  real sessions, which lean heavily on tools with no built-in summary. They key
-  on their own name instead: `Design sync ×16`. MCP tools key per server.
-- **A verb that repeats the previous phrase's is dropped.** `Ran 1 skill, ran 12
-commands` reads as two facts; `Ran 1 skill, 12 commands` reads as one.
+- **read** — `Read` / `NotebookRead` by vendor name, or the ACP
+  `toolKind: "read"` fallback, so a backend that sends no vendor names still
+  says `read 2 files`.
+- **edit** — `Edit` / `MultiEdit` / `Write` / `NotebookEdit`, or
+  `toolKind: "edit"`.
+- **command** — everything else, no exceptions: shell commands, searches,
+  fetches, skills, MCP calls, tools that do not exist yet.
+
+`Read 2 files, edited 1 file, ran 5 commands, thought for 51s` is the longest
+shape the line can take. An earlier revision named more families (searches,
+fetches, skills), kept unregistered tools under their own name (`Design sync
+×16`), and keyed MCP tools per server — which then needed a family cap with
+`+N more` and verb dedup to stay readable. It was dropped: every new tool was
+new phrasing surface, and the identity the coarse line gives up is one click
+away in the expanded rows, which show each call's own summary. Calling a fetch
+or an MCP call a "command" is a stretch that only lasts until the group is
+opened — and a lone call never enters a group at all, so it keeps its precise
+row.
 
 Reasoning duration is **not** derivable from the parts — `kind: "thought"`
 carries no timestamps. The caller measures it live and passes `thinkingMs` to

--- a/src/agentMode/ui/activityGroups.test.ts
+++ b/src/agentMode/ui/activityGroups.test.ts
@@ -1,0 +1,323 @@
+import {
+  foldActivityGroups,
+  summarizeActivity,
+  type ActivityMember,
+  type GroupedTrailNode,
+} from "@/agentMode/ui/activityGroups";
+import { buildAgentTrail, type RenderNode, type ToolCallPart } from "@/agentMode/ui/agentTrail";
+import type { AgentMessagePart } from "@/agentMode/session/types";
+
+function tool(id: string, overrides: Partial<ToolCallPart> = {}): ToolCallPart {
+  return { kind: "tool_call", id, title: id, status: "completed", ...overrides };
+}
+
+function action(id: string, overrides: Partial<ToolCallPart> = {}): RenderNode {
+  return { type: "action", part: tool(id, overrides) };
+}
+
+function reasoning(text = "thinking"): RenderNode {
+  return { type: "reasoning", part: { kind: "thought", text } };
+}
+
+function prose(text = "Here is what I found."): RenderNode {
+  return { type: "text", part: { kind: "text", text } };
+}
+
+function member(id: string, overrides: Partial<ToolCallPart> = {}): ActivityMember {
+  return { type: "action", part: tool(id, overrides) };
+}
+
+const REASONING_MEMBER: ActivityMember = {
+  type: "reasoning",
+  part: { kind: "thought", text: "…" },
+};
+
+function types(nodes: GroupedTrailNode[]): string[] {
+  return nodes.map((n) => n.type);
+}
+
+function groupAt(nodes: GroupedTrailNode[], index: number) {
+  const node = nodes[index];
+  if (node.type !== "activityGroup") throw new Error(`node ${index} is ${node.type}`);
+  return node;
+}
+
+describe("activityGroups", () => {
+  describe("foldActivityGroups()", () => {
+    it("folds a run of different tool families into one group", () => {
+      const grouped = foldActivityGroups([
+        action("a", { vendorToolName: "Read" }),
+        action("b", { vendorToolName: "Bash" }),
+        action("c", { vendorToolName: "Edit" }),
+      ]);
+      expect(types(grouped)).toEqual(["activityGroup"]);
+      expect(groupAt(grouped, 0).members).toHaveLength(3);
+    });
+
+    it("folds reasoning together with the tool calls around it", () => {
+      const grouped = foldActivityGroups([
+        reasoning(),
+        action("a", { vendorToolName: "Bash" }),
+        reasoning(),
+        action("b", { vendorToolName: "Bash" }),
+      ]);
+      expect(types(grouped)).toEqual(["activityGroup"]);
+      expect(groupAt(grouped, 0).members.map((m) => m.type)).toEqual([
+        "reasoning",
+        "action",
+        "reasoning",
+        "action",
+      ]);
+    });
+
+    it("leaves a lone tool call as a plain action row rather than a one-member group", () => {
+      const grouped = foldActivityGroups([action("a", { vendorToolName: "Read" }), prose()]);
+      expect(types(grouped)).toEqual(["action", "text"]);
+    });
+
+    it("leaves a lone reasoning block as a plain reasoning row", () => {
+      const grouped = foldActivityGroups([prose(), reasoning(), prose()]);
+      expect(types(grouped)).toEqual(["text", "reasoning", "text"]);
+    });
+
+    it("splits a run in two when prose interrupts it", () => {
+      const grouped = foldActivityGroups([
+        action("a", { vendorToolName: "Read" }),
+        action("b", { vendorToolName: "Bash" }),
+        prose(),
+        action("c", { vendorToolName: "Edit" }),
+        action("d", { vendorToolName: "Edit" }),
+      ]);
+      expect(types(grouped)).toEqual(["activityGroup", "text", "activityGroup"]);
+    });
+
+    it("keeps a sub-agent launch as its own row and breaks the run around it", () => {
+      const grouped = foldActivityGroups([
+        action("a", { vendorToolName: "Read" }),
+        action("b", { vendorToolName: "Bash" }),
+        { type: "subagent", parent: tool("t", { vendorToolName: "Task" }), children: [] },
+        action("c", { vendorToolName: "Read" }),
+        action("d", { vendorToolName: "Bash" }),
+      ]);
+      expect(types(grouped)).toEqual(["activityGroup", "subagent", "activityGroup"]);
+    });
+
+    it.each(["AskUserQuestion", "ExitPlanMode", "EnterPlanMode"])(
+      "keeps %s out of a group so the user can still act on it",
+      (vendorToolName) => {
+        const grouped = foldActivityGroups([
+          action("a", { vendorToolName: "Read" }),
+          action("b", { vendorToolName: "Bash" }),
+          action("q", { vendorToolName }),
+          action("c", { vendorToolName: "Read" }),
+          action("d", { vendorToolName: "Bash" }),
+        ]);
+        expect(types(grouped)).toEqual(["activityGroup", "action", "activityGroup"]);
+      }
+    );
+
+    it("groups an MCP tool that shares a bare name with an interactive native tool", () => {
+      const grouped = foldActivityGroups([
+        action("a", { vendorToolName: "Read" }),
+        action("q", { vendorToolName: "ExitPlanMode", mcpServer: "srv" }),
+      ]);
+      expect(types(grouped)).toEqual(["activityGroup"]);
+      expect(groupAt(grouped, 0).members).toHaveLength(2);
+    });
+
+    it("breaks the run on a plan checklist", () => {
+      const grouped = foldActivityGroups([
+        action("a", { vendorToolName: "Read" }),
+        action("b", { vendorToolName: "Bash" }),
+        { type: "plan", part: { kind: "plan", entries: [] } },
+        action("c", { vendorToolName: "Read" }),
+        action("d", { vendorToolName: "Bash" }),
+      ]);
+      expect(types(grouped)).toEqual(["activityGroup", "plan", "activityGroup"]);
+    });
+
+    it("pools a homogeneous aggregate's members with their neighbours", () => {
+      const grouped = foldActivityGroups([
+        {
+          type: "aggregate",
+          toolKey: "Read",
+          parts: [tool("r1", { vendorToolName: "Read" }), tool("r2", { vendorToolName: "Read" })],
+        },
+        action("b", { vendorToolName: "Bash" }),
+      ]);
+      expect(types(grouped)).toEqual(["activityGroup"]);
+      expect(groupAt(grouped, 0).members).toHaveLength(3);
+    });
+
+    it("numbers groups by position so an id survives members streaming in", () => {
+      const first = foldActivityGroups([
+        action("a", { vendorToolName: "Read" }),
+        action("b", { vendorToolName: "Bash" }),
+        prose(),
+        action("c", { vendorToolName: "Read" }),
+        action("d", { vendorToolName: "Bash" }),
+      ]);
+      const grown = foldActivityGroups([
+        action("a", { vendorToolName: "Read" }),
+        action("b", { vendorToolName: "Bash" }),
+        prose(),
+        action("c", { vendorToolName: "Read" }),
+        action("d", { vendorToolName: "Bash" }),
+        action("e", { vendorToolName: "Edit" }),
+      ]);
+      expect(groupAt(first, 0).id).toBe("activity-0");
+      expect(groupAt(first, 2).id).toBe("activity-1");
+      expect(groupAt(grown, 2).id).toBe("activity-1");
+      expect(groupAt(grown, 2).members).toHaveLength(3);
+    });
+
+    it("returns an empty trail unchanged", () => {
+      expect(foldActivityGroups([])).toEqual([]);
+    });
+
+    it("groups the interleaved tool-and-reasoning stream a real turn produces", () => {
+      const parts: AgentMessagePart[] = [
+        { kind: "thought", text: "plan" },
+        tool("s", { vendorToolName: "Skill" }),
+        { kind: "thought", text: "next" },
+        tool("b1", { vendorToolName: "Bash" }),
+        { kind: "thought", text: "next" },
+        tool("b2", { vendorToolName: "Bash" }),
+        { kind: "text", text: "Found it." },
+        tool("e", { vendorToolName: "Edit" }),
+      ];
+      const grouped = foldActivityGroups(buildAgentTrail(parts));
+      expect(types(grouped)).toEqual(["activityGroup", "text", "action"]);
+      expect(groupAt(grouped, 0).members).toHaveLength(6);
+    });
+  });
+
+  describe("summarizeActivity()", () => {
+    it("names each tool family in first-appearance order", () => {
+      const { line } = summarizeActivity([
+        member("a", { vendorToolName: "Read" }),
+        member("b", { vendorToolName: "Read" }),
+        member("c", { vendorToolName: "Bash" }),
+      ]);
+      expect(line).toBe("Read 2 files, ran 1 command");
+    });
+
+    it("pools tools that mean the same thing into one phrase", () => {
+      const { line } = summarizeActivity([
+        member("a", { vendorToolName: "Edit" }),
+        member("b", { vendorToolName: "Write" }),
+        member("c", { vendorToolName: "MultiEdit" }),
+      ]);
+      expect(line).toBe("Edited 3 files");
+    });
+
+    it("falls back to the ACP tool kind when there is no vendor name", () => {
+      const { line } = summarizeActivity([
+        member("a", { toolKind: "execute" }),
+        member("b", { toolKind: "read" }),
+      ]);
+      expect(line).toBe("Ran 1 command, read 1 file");
+    });
+
+    it("names an unregistered tool instead of pooling it as an anonymous call", () => {
+      const { line } = summarizeActivity(
+        Array.from({ length: 16 }, (_, i) => member(`d${i}`, { vendorToolName: "DesignSync" }))
+      );
+      expect(line).toBe("Design sync ×16");
+    });
+
+    it("keeps two different unregistered tools apart", () => {
+      const { line } = summarizeActivity([
+        member("a", { vendorToolName: "DesignSync" }),
+        member("b", { vendorToolName: "TaskOutput" }),
+      ]);
+      expect(line).toBe("Ran design sync, task output");
+    });
+
+    it("keys MCP tools by server", () => {
+      const { line } = summarizeActivity([
+        member("a", { vendorToolName: "search_screens", mcpServer: "mobbin" }),
+        member("b", { vendorToolName: "search_flows", mcpServer: "mobbin" }),
+      ]);
+      expect(line).toBe("Mobbin · 2 calls");
+    });
+
+    it("drops a verb that repeats the previous phrase's", () => {
+      const { line } = summarizeActivity([
+        member("s", { vendorToolName: "Skill" }),
+        ...Array.from({ length: 12 }, (_, i) => member(`b${i}`, { vendorToolName: "Bash" })),
+      ]);
+      expect(line).toBe("Ran 1 skill, 12 commands");
+    });
+
+    it("keeps the verb when the repeat is not adjacent", () => {
+      const { line } = summarizeActivity([
+        member("b", { vendorToolName: "Bash" }),
+        member("r", { vendorToolName: "Read" }),
+        member("g", { vendorToolName: "Grep" }),
+      ]);
+      expect(line).toBe("Ran 1 command, read 1 file, ran 1 search");
+    });
+
+    it("elides families past the cap", () => {
+      const { line } = summarizeActivity([
+        member("a", { vendorToolName: "Read" }),
+        member("b", { vendorToolName: "Bash" }),
+        member("c", { vendorToolName: "WebFetch" }),
+        member("d", { vendorToolName: "LS" }),
+        member("e", { vendorToolName: "TodoWrite" }),
+      ]);
+      expect(line).toBe("Read 1 file, ran 1 command, fetched 1 URL, +2 more");
+    });
+
+    it("honors a caller-supplied family cap", () => {
+      const { line } = summarizeActivity(
+        [
+          member("a", { vendorToolName: "Read" }),
+          member("b", { vendorToolName: "Bash" }),
+          member("c", { vendorToolName: "WebFetch" }),
+        ],
+        { maxPhrases: 2 }
+      );
+      expect(line).toBe("Read 1 file, ran 1 command, +1 more");
+    });
+
+    it("appends the measured reasoning time", () => {
+      const { line } = summarizeActivity(
+        [member("a", { vendorToolName: "Bash" }), REASONING_MEMBER],
+        { thinkingMs: 51_000 }
+      );
+      expect(line).toBe("Ran 1 command, thought for 51s");
+    });
+
+    it("omits a reasoning duration under a second rather than saying '< 1s'", () => {
+      const { line } = summarizeActivity(
+        [member("a", { vendorToolName: "Bash" }), REASONING_MEMBER],
+        { thinkingMs: 400 }
+      );
+      expect(line).toBe("Ran 1 command");
+    });
+
+    it("still reports reasoning when it is all the group did", () => {
+      const { line } = summarizeActivity([REASONING_MEMBER, REASONING_MEMBER]);
+      expect(line).toBe("Thought");
+    });
+
+    it("counts failed members without naming them in the line", () => {
+      const { line, failed } = summarizeActivity([
+        member("a", { vendorToolName: "Bash" }),
+        member("b", { vendorToolName: "Bash", status: "failed" }),
+      ]);
+      expect(line).toBe("Ran 2 commands");
+      expect(failed).toBe(1);
+    });
+
+    it("reports no failures for a clean group", () => {
+      expect(summarizeActivity([member("a", { vendorToolName: "Bash" })]).failed).toBe(0);
+    });
+
+    it("describes an empty group without producing an empty line", () => {
+      expect(summarizeActivity([])).toEqual({ line: "Worked", failed: 0 });
+    });
+  });
+});

--- a/src/agentMode/ui/activityGroups.test.ts
+++ b/src/agentMode/ui/activityGroups.test.ts
@@ -219,67 +219,31 @@ describe("activityGroups", () => {
       expect(line).toBe("Ran 1 command, read 1 file");
     });
 
-    it("names an unregistered tool instead of pooling it as an anonymous call", () => {
-      const { line } = summarizeActivity(
-        Array.from({ length: 16 }, (_, i) => member(`d${i}`, { vendorToolName: "DesignSync" }))
-      );
-      expect(line).toBe("Design sync ×16");
-    });
-
-    it("keeps two different unregistered tools apart", () => {
+    it("counts every tool that is not a read or an edit as a command", () => {
       const { line } = summarizeActivity([
-        member("a", { vendorToolName: "DesignSync" }),
-        member("b", { vendorToolName: "TaskOutput" }),
+        member("a", { vendorToolName: "Grep" }),
+        member("b", { vendorToolName: "WebFetch" }),
+        member("c", { vendorToolName: "Skill" }),
+        member("d", { vendorToolName: "DesignSync" }),
+        member("e", { vendorToolName: "search_flows", mcpServer: "mobbin" }),
       ]);
-      expect(line).toBe("Ran design sync, task output");
+      expect(line).toBe("Ran 5 commands");
     });
 
-    it("keys MCP tools by server", () => {
-      const { line } = summarizeActivity([
-        member("a", { vendorToolName: "search_screens", mcpServer: "mobbin" }),
-        member("b", { vendorToolName: "search_flows", mcpServer: "mobbin" }),
-      ]);
-      expect(line).toBe("Mobbin · 2 calls");
-    });
-
-    it("drops a verb that repeats the previous phrase's", () => {
-      const { line } = summarizeActivity([
-        member("s", { vendorToolName: "Skill" }),
-        ...Array.from({ length: 12 }, (_, i) => member(`b${i}`, { vendorToolName: "Bash" })),
-      ]);
-      expect(line).toBe("Ran 1 skill, 12 commands");
-    });
-
-    it("keeps the verb when the repeat is not adjacent", () => {
+    it("adds a later member of an earlier family to its count rather than a new phrase", () => {
       const { line } = summarizeActivity([
         member("b", { vendorToolName: "Bash" }),
         member("r", { vendorToolName: "Read" }),
         member("g", { vendorToolName: "Grep" }),
       ]);
-      expect(line).toBe("Ran 1 command, read 1 file, ran 1 search");
+      expect(line).toBe("Ran 2 commands, read 1 file");
     });
 
-    it("elides families past the cap", () => {
+    it("does not let an MCP tool named like a native read count as one", () => {
       const { line } = summarizeActivity([
-        member("a", { vendorToolName: "Read" }),
-        member("b", { vendorToolName: "Bash" }),
-        member("c", { vendorToolName: "WebFetch" }),
-        member("d", { vendorToolName: "LS" }),
-        member("e", { vendorToolName: "TodoWrite" }),
+        member("a", { vendorToolName: "Read", mcpServer: "srv" }),
       ]);
-      expect(line).toBe("Read 1 file, ran 1 command, fetched 1 URL, +2 more");
-    });
-
-    it("honors a caller-supplied family cap", () => {
-      const { line } = summarizeActivity(
-        [
-          member("a", { vendorToolName: "Read" }),
-          member("b", { vendorToolName: "Bash" }),
-          member("c", { vendorToolName: "WebFetch" }),
-        ],
-        { maxPhrases: 2 }
-      );
-      expect(line).toBe("Read 1 file, ran 1 command, +1 more");
+      expect(line).toBe("Ran 1 command");
     });
 
     it("appends the measured reasoning time", () => {

--- a/src/agentMode/ui/activityGroups.test.ts
+++ b/src/agentMode/ui/activityGroups.test.ts
@@ -116,6 +116,17 @@ describe("activityGroups", () => {
       }
     );
 
+    it("keeps a backend-neutral switch-mode tool out of a group", () => {
+      const grouped = foldActivityGroups([
+        action("a", { toolKind: "read" }),
+        action("b", { toolKind: "execute" }),
+        action("plan", { toolKind: "switch_mode" }),
+        action("c", { toolKind: "read" }),
+        action("d", { toolKind: "execute" }),
+      ]);
+      expect(types(grouped)).toEqual(["activityGroup", "action", "activityGroup"]);
+    });
+
     it("groups an MCP tool that shares a bare name with an interactive native tool", () => {
       const grouped = foldActivityGroups([
         action("a", { vendorToolName: "Read" }),
@@ -171,8 +182,9 @@ describe("activityGroups", () => {
       expect(groupAt(grown, 2).members).toHaveLength(3);
     });
 
-    it("returns an empty trail unchanged", () => {
+    it("returns the same canonical empty trail on every empty call", () => {
       expect(foldActivityGroups([])).toEqual([]);
+      expect(foldActivityGroups([])).toBe(foldActivityGroups([]));
     });
 
     it("groups the interleaved tool-and-reasoning stream a real turn produces", () => {

--- a/src/agentMode/ui/activityGroups.ts
+++ b/src/agentMode/ui/activityGroups.ts
@@ -1,5 +1,5 @@
 import type { RenderNode, ThoughtPart, ToolCallPart } from "@/agentMode/ui/agentTrail";
-import { humanizeToolName, pluralize } from "@/agentMode/ui/toolSummaries";
+import { pluralize } from "@/agentMode/ui/toolSummaries";
 import { formatDuration } from "@/lib/duration";
 
 /**
@@ -89,99 +89,51 @@ export function foldActivityGroups(nodes: RenderNode[]): GroupedTrailNode[] {
 }
 
 /**
- * Bucket key for the summary line. Recognized tools share a bucket so a `Write`
- * and an `Edit` read as one phrase; everything else keys on its own identity,
- * because real sessions lean on tools with no built-in summary and pooling them
- * produces an uninformative "made 16 tool calls".
+ * Bucket for the summary line. The vocabulary is deliberately coarse: reads and
+ * edits are named because they are what users scan a turn for; everything else —
+ * searches, fetches, skills, MCP calls, tools that do not exist yet — counts as
+ * a command, so no new tool can ever change how the line reads. The identity
+ * the line gives up is one click away in the expanded rows, and a lone call
+ * never enters a group at all, so it keeps its precise row.
  */
-function familyKey(part: ToolCallPart): string {
-  if (part.mcpServer) return `mcp:${part.mcpServer}`;
-  switch (part.vendorToolName) {
-    case "Read":
-    case "NotebookRead":
-      return "read";
-    case "Edit":
-    case "MultiEdit":
-    case "Write":
-    case "NotebookEdit":
-      return "edit";
-    case "Grep":
-    case "Glob":
-    case "WebSearch":
-      return "search";
-    case "Bash":
-    case "BashOutput":
-    case "KillShell":
-      return "run";
-    case "WebFetch":
-      return "fetch";
-    case "LS":
-      return "list";
-    case "TodoWrite":
-      return "todo";
-    case "Skill":
-      return "skill";
+type ActivityFamily = "read" | "edit" | "command";
+
+function familyFor(part: ToolCallPart): ActivityFamily {
+  // An MCP tool whose bare name collides with a native one (e.g.
+  // `mcp__srv__read`) must not masquerade as it; only the ACP `toolKind` —
+  // a semantic classification, not a name — can vouch for an MCP call.
+  if (!part.mcpServer) {
+    switch (part.vendorToolName) {
+      case "Read":
+      case "NotebookRead":
+        return "read";
+      case "Edit":
+      case "MultiEdit":
+      case "Write":
+      case "NotebookEdit":
+        return "edit";
+    }
   }
   switch (part.toolKind) {
     case "read":
       return "read";
     case "edit":
       return "edit";
-    case "search":
-      return "search";
-    case "execute":
-      return "run";
-    case "fetch":
-      return "fetch";
+    default:
+      return "command";
   }
-  return part.vendorToolName ? `tool:${part.vendorToolName}` : "other";
 }
 
 /** Lowercase sentence fragment for one family's contribution to the line. */
-function phraseFor(key: string, n: number): string {
-  if (key.startsWith("mcp:")) return `${key.slice(4)} · ${pluralize(n, "call")}`;
-  if (key.startsWith("tool:")) {
-    // `humanizeToolName` capitalizes for a standalone label; a phrase joins
-    // mid-line, so it starts lowercase and `summarizeActivity` capitalizes the
-    // line's first character.
-    const name = humanizeToolName(key.slice(5)).toLowerCase();
-    return n === 1 ? `ran ${name}` : `${name} ×${n}`;
-  }
-  switch (key) {
+function phraseFor(family: ActivityFamily, n: number): string {
+  switch (family) {
     case "read":
       return `read ${pluralize(n, "file")}`;
     case "edit":
       return `edited ${pluralize(n, "file")}`;
-    case "search":
-      return `ran ${pluralize(n, "search", "searches")}`;
-    case "run":
+    case "command":
       return `ran ${pluralize(n, "command")}`;
-    case "fetch":
-      return `fetched ${pluralize(n, "URL")}`;
-    case "list":
-      return `listed ${pluralize(n, "folder")}`;
-    case "todo":
-      return "updated the task list";
-    case "skill":
-      return `ran ${pluralize(n, "skill")}`;
-    default:
-      return `made ${pluralize(n, "tool call")}`;
   }
-}
-
-/**
- * "Ran 1 skill, ran 12 commands" reads as two facts; dropping the repeat makes
- * it one. Only an immediately repeated verb is dropped, so a later phrase that
- * happens to share the verb of an earlier non-adjacent one keeps it.
- */
-function dropRepeatedVerbs(phrases: string[]): string[] {
-  let previousVerb = "";
-  return phrases.map((phrase) => {
-    const verb = phrase.slice(0, phrase.indexOf(" "));
-    const repeated = verb.length > 0 && verb === previousVerb;
-    previousVerb = verb;
-    return repeated ? phrase.slice(verb.length + 1) : phrase;
-  });
 }
 
 export interface ActivitySummaryOptions {
@@ -191,33 +143,28 @@ export interface ActivitySummaryOptions {
    * measures it live and passes it in. Omitted or zero renders no duration.
    */
   thinkingMs?: number;
-  /** Families named before the rest elide to `+N more`. Defaults to 3. */
-  maxPhrases?: number;
 }
 
 export interface ActivitySummary {
-  /** The collapsed row's line, e.g. `Ran 1 skill, 12 commands, thought for 51s`. */
+  /** The collapsed row's line, e.g. `Read 2 files, ran 12 commands, thought for 51s`. */
   line: string;
   /** Members that failed, surfaced by the card as a badge. */
   failed: number;
 }
 
-const DEFAULT_MAX_PHRASES = 3;
-
 /**
  * Build the collapsed summary line for an activity group: what the agent did,
- * pooled by tool family in first-appearance order.
+ * pooled by family in first-appearance order.
  *
  * @param members - The group's tool calls and reasoning, in stream order.
- * @param options - Measured reasoning time and how many families to name.
+ * @param options - Measured reasoning time.
  */
 export function summarizeActivity(
   members: ActivityMember[],
   options: ActivitySummaryOptions = {}
 ): ActivitySummary {
-  const maxPhrases = options.maxPhrases ?? DEFAULT_MAX_PHRASES;
-  const order: string[] = [];
-  const counts = new Map<string, number>();
+  const order: ActivityFamily[] = [];
+  const counts = new Map<ActivityFamily, number>();
   let thoughts = 0;
   let failed = 0;
 
@@ -227,15 +174,12 @@ export function summarizeActivity(
       continue;
     }
     if (member.part.status === "failed") failed++;
-    const key = familyKey(member.part);
-    if (!counts.has(key)) order.push(key);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
+    const family = familyFor(member.part);
+    if (!counts.has(family)) order.push(family);
+    counts.set(family, (counts.get(family) ?? 0) + 1);
   }
 
-  const phrases = order.map((key) => phraseFor(key, counts.get(key) ?? 0));
-  const named = dropRepeatedVerbs(phrases.slice(0, maxPhrases));
-  const elided = phrases.length - named.length;
-  const parts = elided > 0 ? [...named, `+${elided} more`] : named;
+  const parts = order.map((family) => phraseFor(family, counts.get(family) ?? 0));
 
   const thinkingMs = options.thinkingMs ?? 0;
   if (thoughts > 0) {

--- a/src/agentMode/ui/activityGroups.ts
+++ b/src/agentMode/ui/activityGroups.ts
@@ -35,8 +35,15 @@ export type GroupedTrailNode = RenderNode | ActivityGroupNode;
 function isInteractive(part: ToolCallPart): boolean {
   if (part.mcpServer) return false;
   const name = part.vendorToolName;
-  return name === "AskUserQuestion" || name === "ExitPlanMode" || name === "EnterPlanMode";
+  return (
+    part.toolKind === "switch_mode" ||
+    name === "AskUserQuestion" ||
+    name === "ExitPlanMode" ||
+    name === "EnterPlanMode"
+  );
 }
+
+const EMPTY_GROUPED_TRAIL = Object.freeze([]) as unknown as GroupedTrailNode[];
 
 /**
  * Fold runs of consecutive tool calls and reasoning into activity groups. A run
@@ -46,6 +53,7 @@ function isInteractive(part: ToolCallPart): boolean {
  * @param nodes - The trail as built by `buildAgentTrail`, in stream order.
  */
 export function foldActivityGroups(nodes: RenderNode[]): GroupedTrailNode[] {
+  if (nodes.length === 0) return EMPTY_GROUPED_TRAIL;
   const out: GroupedTrailNode[] = [];
   let run: ActivityMember[] = [];
   let groupCount = 0;

--- a/src/agentMode/ui/activityGroups.ts
+++ b/src/agentMode/ui/activityGroups.ts
@@ -1,0 +1,251 @@
+import type { RenderNode, ThoughtPart, ToolCallPart } from "@/agentMode/ui/agentTrail";
+import { humanizeToolName, pluralize } from "@/agentMode/ui/toolSummaries";
+import { formatDuration } from "@/lib/duration";
+
+/**
+ * One unit of work inside an activity group — a tool call the agent made or a
+ * block of reasoning it produced. Sub-agent launches are deliberately absent:
+ * they break a group rather than joining one.
+ */
+export type ActivityMember =
+  | { type: "action"; part: ToolCallPart }
+  | { type: "reasoning"; part: ThoughtPart };
+
+/**
+ * A run of consecutive tool calls and reasoning blocks, collapsed behind one
+ * summary line. See `designdocs/AGENT_TRAIL_GROUPING.md` for what breaks a run
+ * and why.
+ */
+export interface ActivityGroupNode {
+  type: "activityGroup";
+  /**
+   * Position of this group among the trail's groups. Parts are append-only, so
+   * a group's position never changes once it exists and appending a member
+   * leaves the id alone — which is what lets the UI keep an opened group open
+   * while work streams into it.
+   */
+  id: string;
+  members: ActivityMember[];
+}
+
+/** The trail after grouping: every `RenderNode`, plus collapsed activity runs. */
+export type GroupedTrailNode = RenderNode | ActivityGroupNode;
+
+/** Tool calls that own an interactive surface and must stay visible. */
+function isInteractive(part: ToolCallPart): boolean {
+  if (part.mcpServer) return false;
+  const name = part.vendorToolName;
+  return name === "AskUserQuestion" || name === "ExitPlanMode" || name === "EnterPlanMode";
+}
+
+/**
+ * Fold runs of consecutive tool calls and reasoning into activity groups. A run
+ * of a single member is left as the plain node it already was, so one `Read`
+ * never gains group chrome.
+ *
+ * @param nodes - The trail as built by `buildAgentTrail`, in stream order.
+ */
+export function foldActivityGroups(nodes: RenderNode[]): GroupedTrailNode[] {
+  const out: GroupedTrailNode[] = [];
+  let run: ActivityMember[] = [];
+  let groupCount = 0;
+
+  const flush = () => {
+    if (run.length === 0) return;
+    if (run.length === 1) {
+      out.push(run[0]);
+    } else {
+      out.push({ type: "activityGroup", id: `activity-${groupCount++}`, members: run });
+    }
+    run = [];
+  };
+
+  for (const node of nodes) {
+    switch (node.type) {
+      case "reasoning":
+        run.push(node);
+        break;
+      case "action":
+        if (isInteractive(node.part)) {
+          flush();
+          out.push(node);
+        } else {
+          run.push(node);
+        }
+        break;
+      case "aggregate":
+        // Transitional: homogeneous aggregates are subsumed by grouping and go
+        // away with the `aggregate` node type. Until then, flatten them back so
+        // their members can pool with neighbours of other families.
+        for (const part of node.parts) run.push({ type: "action", part });
+        break;
+      default:
+        flush();
+        out.push(node);
+    }
+  }
+  flush();
+  return out;
+}
+
+/**
+ * Bucket key for the summary line. Recognized tools share a bucket so a `Write`
+ * and an `Edit` read as one phrase; everything else keys on its own identity,
+ * because real sessions lean on tools with no built-in summary and pooling them
+ * produces an uninformative "made 16 tool calls".
+ */
+function familyKey(part: ToolCallPart): string {
+  if (part.mcpServer) return `mcp:${part.mcpServer}`;
+  switch (part.vendorToolName) {
+    case "Read":
+    case "NotebookRead":
+      return "read";
+    case "Edit":
+    case "MultiEdit":
+    case "Write":
+    case "NotebookEdit":
+      return "edit";
+    case "Grep":
+    case "Glob":
+    case "WebSearch":
+      return "search";
+    case "Bash":
+    case "BashOutput":
+    case "KillShell":
+      return "run";
+    case "WebFetch":
+      return "fetch";
+    case "LS":
+      return "list";
+    case "TodoWrite":
+      return "todo";
+    case "Skill":
+      return "skill";
+  }
+  switch (part.toolKind) {
+    case "read":
+      return "read";
+    case "edit":
+      return "edit";
+    case "search":
+      return "search";
+    case "execute":
+      return "run";
+    case "fetch":
+      return "fetch";
+  }
+  return part.vendorToolName ? `tool:${part.vendorToolName}` : "other";
+}
+
+/** Lowercase sentence fragment for one family's contribution to the line. */
+function phraseFor(key: string, n: number): string {
+  if (key.startsWith("mcp:")) return `${key.slice(4)} · ${pluralize(n, "call")}`;
+  if (key.startsWith("tool:")) {
+    // `humanizeToolName` capitalizes for a standalone label; a phrase joins
+    // mid-line, so it starts lowercase and `summarizeActivity` capitalizes the
+    // line's first character.
+    const name = humanizeToolName(key.slice(5)).toLowerCase();
+    return n === 1 ? `ran ${name}` : `${name} ×${n}`;
+  }
+  switch (key) {
+    case "read":
+      return `read ${pluralize(n, "file")}`;
+    case "edit":
+      return `edited ${pluralize(n, "file")}`;
+    case "search":
+      return `ran ${pluralize(n, "search", "searches")}`;
+    case "run":
+      return `ran ${pluralize(n, "command")}`;
+    case "fetch":
+      return `fetched ${pluralize(n, "URL")}`;
+    case "list":
+      return `listed ${pluralize(n, "folder")}`;
+    case "todo":
+      return "updated the task list";
+    case "skill":
+      return `ran ${pluralize(n, "skill")}`;
+    default:
+      return `made ${pluralize(n, "tool call")}`;
+  }
+}
+
+/**
+ * "Ran 1 skill, ran 12 commands" reads as two facts; dropping the repeat makes
+ * it one. Only an immediately repeated verb is dropped, so a later phrase that
+ * happens to share the verb of an earlier non-adjacent one keeps it.
+ */
+function dropRepeatedVerbs(phrases: string[]): string[] {
+  let previousVerb = "";
+  return phrases.map((phrase) => {
+    const verb = phrase.slice(0, phrase.indexOf(" "));
+    const repeated = verb.length > 0 && verb === previousVerb;
+    previousVerb = verb;
+    return repeated ? phrase.slice(verb.length + 1) : phrase;
+  });
+}
+
+export interface ActivitySummaryOptions {
+  /**
+   * Wall-clock the group spent reasoning. `kind: "thought"` parts carry no
+   * timestamps, so the duration cannot be derived here — the rendering layer
+   * measures it live and passes it in. Omitted or zero renders no duration.
+   */
+  thinkingMs?: number;
+  /** Families named before the rest elide to `+N more`. Defaults to 3. */
+  maxPhrases?: number;
+}
+
+export interface ActivitySummary {
+  /** The collapsed row's line, e.g. `Ran 1 skill, 12 commands, thought for 51s`. */
+  line: string;
+  /** Members that failed, surfaced by the card as a badge. */
+  failed: number;
+}
+
+const DEFAULT_MAX_PHRASES = 3;
+
+/**
+ * Build the collapsed summary line for an activity group: what the agent did,
+ * pooled by tool family in first-appearance order.
+ *
+ * @param members - The group's tool calls and reasoning, in stream order.
+ * @param options - Measured reasoning time and how many families to name.
+ */
+export function summarizeActivity(
+  members: ActivityMember[],
+  options: ActivitySummaryOptions = {}
+): ActivitySummary {
+  const maxPhrases = options.maxPhrases ?? DEFAULT_MAX_PHRASES;
+  const order: string[] = [];
+  const counts = new Map<string, number>();
+  let thoughts = 0;
+  let failed = 0;
+
+  for (const member of members) {
+    if (member.type === "reasoning") {
+      thoughts++;
+      continue;
+    }
+    if (member.part.status === "failed") failed++;
+    const key = familyKey(member.part);
+    if (!counts.has(key)) order.push(key);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+
+  const phrases = order.map((key) => phraseFor(key, counts.get(key) ?? 0));
+  const named = dropRepeatedVerbs(phrases.slice(0, maxPhrases));
+  const elided = phrases.length - named.length;
+  const parts = elided > 0 ? [...named, `+${elided} more`] : named;
+
+  const thinkingMs = options.thinkingMs ?? 0;
+  if (thoughts > 0) {
+    if (thinkingMs >= 1000) parts.push(`thought for ${formatDuration(thinkingMs)}`);
+    else if (parts.length === 0) parts.push("thought");
+  }
+
+  const line = parts.join(", ");
+  return {
+    line: line.length > 0 ? line.charAt(0).toUpperCase() + line.slice(1) : "Worked",
+    failed,
+  };
+}

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -136,7 +136,7 @@ function targetFromTitle(part: ToolCallPart): string {
  * snake_case / kebab-case into words, lowercase, then capitalize the first
  * letter. "AskUserQuestion" → "Ask user question"; "query-docs" → "Query docs".
  */
-export function humanizeToolName(name: string): string {
+function humanizeToolName(name: string): string {
   const words = name
     .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")

--- a/src/agentMode/ui/toolSummaries.ts
+++ b/src/agentMode/ui/toolSummaries.ts
@@ -116,7 +116,7 @@ function statusSuffix(parts: ToolCallPart[]): string {
   return ` · ${bits.join(" · ")}`;
 }
 
-function pluralize(n: number, singular: string, plural?: string): string {
+export function pluralize(n: number, singular: string, plural?: string): string {
   return `${n} ${n === 1 ? singular : (plural ?? `${singular}s`)}`;
 }
 
@@ -136,7 +136,7 @@ function targetFromTitle(part: ToolCallPart): string {
  * snake_case / kebab-case into words, lowercase, then capitalize the first
  * letter. "AskUserQuestion" → "Ask user question"; "query-docs" → "Query docs".
  */
-function humanizeToolName(name: string): string {
+export function humanizeToolName(name: string): string {
   const words = name
     .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
     .replace(/([a-z0-9])([A-Z])/g, "$1 $2")


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#266

## Why

In a tool-heavy agent turn today, the trail renders one row per tool call and one row per thought. Even a small four-tool turn stacks seven rows — "Thought for 1s", "Searched · 3 queries", "Thought for < 1s", "Read 2026 Inspiration.md", "Thought for 1s", "Ran Count words…", "Thought for 2s" — between the user's question and the agent's first sentence. Replaying a recorded 56-turn, 1,956-tool-call session, the worst case is a wall of 21 consecutive activity rows, and the agent's actual writing is what gets buried.

The trail has compaction today, but it only merges adjacent calls of the *same* tool family, and a thought between two calls breaks the run — so it almost never fires in practice. An earlier fix (#2652) collapsed the trail after the turn completed and was removed for hiding content users were still reading. So the folding rules need to be explicit about what may fold and what must always stay visible, before any UI renders them.

## What

Defines the folding model and its boundaries; no production surface renders it yet, so the shipping trail is unchanged.

| Trail content | Folds into one summary? |
| --- | --- |
| Consecutive tool calls, and the thinking between them (mixed families welcome) | Yes — one group |
| A run of exactly one activity | No — stays a plain row, no group chrome |
| Agent prose, plan checklists, sub-agent launches | Never — always their own row |
| Interactive tools the user must answer (questions, plan proposals) | Never — always their own row |

The collapsed one-liner uses a deliberately coarse vocabulary — **read**, **edit**, and **command**, named in first-appearance order, with reasoning time appended — e.g. `Read 2 files, ran 12 commands, thought for 51s`. Everything that is not a read or an edit counts as a command, so a new tool, skill, or MCP server can never change how the line reads; the identity the line gives up is one click away in the expanded rows, and a lone call never enters a group at all. On the replayed session the grouping rules cut the worst wall from 21 rows to 5 and total rows from 1,839 to 1,088.

The design doc also fixes the interaction contract for any surface that renders groups: a group is born collapsed and never closes itself, and user expansion is sticky for the life of the session.

## Non goal

- Rendering groups in the agent trail (this PR is model + design doc only).
- Implementing expansion behavior or live activity status — this PR only specifies them.

## Screenshot

Not applicable — nothing renders the folding model yet; the production trail is pixel-identical to the base branch.

## Risk

**Low** — adds an unmounted folding module no production surface renders, so shipped behavior is unchanged; the one touched production line makes an existing helper exportable without changing it; every folding boundary and summary rule is covered by the deterministic `foldActivityGroups` / `summarizeActivity` tests added in this PR, so a defect would fail CI; a revert removes the module cleanly — no dependency, settings, or persisted-data changes.

Review: confirm CI is green; if a boundary in the table above looks surprising, Verification step 2 maps each row to a named test.

## Verification

1. Run `npm test -- activityGroups` and confirm the suite passes.
2. Read the decision table above against `src/agentMode/ui/activityGroups.test.ts`: each row — mixed-family folding, the lone-activity rule, and the prose, sub-agent, interactive-tool, and plan-checklist breaks — has a test named for it.
3. Confirm the rationale in `designdocs/AGENT_TRAIL_GROUPING.md` matches what the tests pin, including the coarse read/edit/command vocabulary and the born-collapsed, sticky-expansion invariants any rendering surface must honor.
