### PR TITLE
[Agent trail grouping] - Step 2: Add the collapsible activity card

### DIFF
--- a/src/agentMode/ui/ActivityGroupCard.stories.tsx
+++ b/src/agentMode/ui/ActivityGroupCard.stories.tsx
@@ -1,0 +1,126 @@
+import { ActivityGroupCard } from "@/agentMode/ui/ActivityGroupCard";
+import type { ActivityGroupNode, ActivityMember } from "@/agentMode/ui/activityGroups";
+import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
+import type { Meta, StoryObj } from "@/lib/story";
+import React, { useState } from "react";
+
+type ActivityGroupCardProps = React.ComponentProps<typeof ActivityGroupCard>;
+
+function action(title: string, overrides: Partial<ToolCallPart> = {}): ActivityMember {
+  return {
+    type: "action",
+    part: { kind: "tool_call", id: title, title, status: "completed", ...overrides },
+  };
+}
+
+const THINKING: ActivityMember = {
+  type: "reasoning",
+  part: { kind: "thought", text: "The migration note is the one that changed most recently." },
+};
+
+function group(members: ActivityMember[]): ActivityGroupNode {
+  return { type: "activityGroup", id: "activity-0", members };
+}
+
+/** Stands in for the trail's dispatch so stories stay free of plugin state. */
+function renderMember(member: ActivityMember, key: string | number): React.ReactNode {
+  return (
+    <div key={key} className="tw-truncate tw-py-1 tw-text-sm tw-text-muted">
+      {member.type === "action" ? member.part.title : "Thought about the vault layout"}
+    </div>
+  );
+}
+
+const MIXED = group([
+  action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }),
+  THINKING,
+  action("npm run lint", { vendorToolName: "Bash" }),
+  action("npm run test -- activityGroups", { vendorToolName: "Bash" }),
+  action("Edit Projects/Copilot/Roadmap.md", { vendorToolName: "Edit" }),
+]);
+
+const meta = {
+  title: "Agent Mode/Activity Group Card",
+  component: ActivityGroupCard,
+  args: {
+    group: MIXED,
+    open: false,
+    onToggle: () => undefined,
+    renderMember,
+    thinkingMs: 51_000,
+  },
+  parameters: { gallery: { host: "leaf", layout: "padded", width: 340 } },
+} satisfies Meta<ActivityGroupCardProps>;
+export default meta;
+
+export const Collapsed: StoryObj<ActivityGroupCardProps> = {};
+
+export const WithFailure: StoryObj<ActivityGroupCardProps> = {
+  args: {
+    group: group([
+      action("rg --files Daily/", { vendorToolName: "Grep" }),
+      action("npm run build", { vendorToolName: "Bash", status: "failed" }),
+      THINKING,
+      action("npm run build", { vendorToolName: "Bash" }),
+    ]),
+    thinkingMs: 7_000,
+  },
+};
+
+export const InFlight: StoryObj<ActivityGroupCardProps> = {
+  args: {
+    group: group([
+      action("Read Meetings/2026-08-03 Standup.md", { vendorToolName: "Read" }),
+      THINKING,
+      action("npm run test -- ActivityGroupCard", {
+        vendorToolName: "Bash",
+        status: "in_progress",
+      }),
+    ]),
+    thinkingMs: 3_000,
+    liveStep: "npm run test -- ActivityGroupCard",
+  },
+};
+
+export const ManyFamilies: StoryObj<ActivityGroupCardProps> = {
+  args: {
+    group: group([
+      action("Read Inbox/Clippings.md", { vendorToolName: "Read" }),
+      action("Grep for “embedding”", { vendorToolName: "Grep" }),
+      action("npm run format", { vendorToolName: "Bash" }),
+      action("Fetch https://docs.obsidian.md/Plugins", { vendorToolName: "WebFetch" }),
+      action("List Attachments/", { vendorToolName: "LS" }),
+      THINKING,
+    ]),
+  },
+};
+
+export const LongLine: StoryObj<ActivityGroupCardProps> = {
+  args: {
+    group: group([
+      action("Read Research/Vector Stores.md", { vendorToolName: "Read" }),
+      action("Read Research/Chunking.md", { vendorToolName: "Read" }),
+      action("mcp call", { mcpServer: "obsidian-vault-search" }),
+      action("mcp call", { mcpServer: "obsidian-vault-search" }),
+      action("Design sync", { vendorToolName: "DesignSyncFromFigmaWorkspace" }),
+      THINKING,
+    ]),
+    thinkingMs: 214_000,
+  },
+};
+
+/** Expansion is owned by the trail, so a story has to supply the state itself. */
+const ExpandedDemo: React.FC = () => {
+  const [open, setOpen] = useState(true);
+  return (
+    <ActivityGroupCard
+      group={MIXED}
+      thinkingMs={51_000}
+      open={open}
+      onToggle={() => setOpen((v) => !v)}
+      renderMember={renderMember}
+    />
+  );
+};
+
+export const Expanded: StoryObj<ActivityGroupCardProps> = { render: ExpandedDemo };

--- a/src/agentMode/ui/ActivityGroupCard.stories.tsx
+++ b/src/agentMode/ui/ActivityGroupCard.stories.tsx
@@ -82,25 +82,14 @@ export const InFlight: StoryObj<ActivityGroupCardProps> = {
   },
 };
 
-export const ManyFamilies: StoryObj<ActivityGroupCardProps> = {
-  args: {
-    group: group([
-      action("Read Inbox/Clippings.md", { vendorToolName: "Read" }),
-      action("Grep for “embedding”", { vendorToolName: "Grep" }),
-      action("npm run format", { vendorToolName: "Bash" }),
-      action("Fetch https://docs.obsidian.md/Plugins", { vendorToolName: "WebFetch" }),
-      action("List Attachments/", { vendorToolName: "LS" }),
-      THINKING,
-    ]),
-  },
-};
-
+/** Searches, fetches, MCP calls, unregistered tools — all pool as commands. */
 export const LongLine: StoryObj<ActivityGroupCardProps> = {
   args: {
     group: group([
       action("Read Research/Vector Stores.md", { vendorToolName: "Read" }),
       action("Read Research/Chunking.md", { vendorToolName: "Read" }),
-      action("mcp call", { mcpServer: "obsidian-vault-search" }),
+      action("Grep for “embedding”", { vendorToolName: "Grep" }),
+      action("Fetch https://docs.obsidian.md/Plugins", { vendorToolName: "WebFetch" }),
       action("mcp call", { mcpServer: "obsidian-vault-search" }),
       action("Design sync", { vendorToolName: "DesignSyncFromFigmaWorkspace" }),
       THINKING,

--- a/src/agentMode/ui/ActivityGroupCard.test.tsx
+++ b/src/agentMode/ui/ActivityGroupCard.test.tsx
@@ -1,0 +1,153 @@
+import { ActivityGroupCard } from "@/agentMode/ui/ActivityGroupCard";
+import type { ActivityGroupNode, ActivityMember } from "@/agentMode/ui/activityGroups";
+import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+function action(id: string, overrides: Partial<ToolCallPart> = {}): ActivityMember {
+  return {
+    type: "action",
+    part: { kind: "tool_call", id, title: id, status: "completed", ...overrides },
+  };
+}
+
+const REASONING: ActivityMember = { type: "reasoning", part: { kind: "thought", text: "…" } };
+
+function group(members: ActivityMember[]): ActivityGroupNode {
+  return { type: "activityGroup", id: "activity-0", members };
+}
+
+/** Stand-in for the trail's real dispatch, so the card's own behavior is what's asserted. */
+function renderMember(member: ActivityMember, key: string | number): React.ReactNode {
+  return <div key={key}>{member.type === "action" ? member.part.title : "reasoning"}</div>;
+}
+
+function renderCard(props: Partial<React.ComponentProps<typeof ActivityGroupCard>> = {}) {
+  return render(
+    <ActivityGroupCard
+      group={group([action("a", { vendorToolName: "Read" })])}
+      open={false}
+      onToggle={jest.fn()}
+      renderMember={renderMember}
+      {...props}
+    />
+  );
+}
+
+describe("ActivityGroupCard", () => {
+  describe("ActivityGroupCard()", () => {
+    it("summarizes every family in the run plus the measured thinking time", () => {
+      renderCard({
+        group: group([
+          action("a", { vendorToolName: "Read" }),
+          REASONING,
+          action("b", { vendorToolName: "Bash" }),
+          action("c", { vendorToolName: "Bash" }),
+        ]),
+        thinkingMs: 51_000,
+      });
+
+      expect(screen.getByRole("button").textContent).toContain(
+        "Read 1 file, ran 2 commands, thought for 51s"
+      );
+    });
+
+    it("surfaces how many members failed", () => {
+      const { rerender } = renderCard({
+        group: group([
+          action("a", { vendorToolName: "Bash", status: "failed" }),
+          action("b", { vendorToolName: "Bash", status: "failed" }),
+          action("c", { vendorToolName: "Bash" }),
+        ]),
+      });
+
+      expect(screen.getByText("2 failed")).not.toBeNull();
+
+      rerender(
+        <ActivityGroupCard
+          group={group([action("a", { vendorToolName: "Bash" })])}
+          open={false}
+          onToggle={jest.fn()}
+          renderMember={renderMember}
+        />
+      );
+      expect(screen.queryByText(/failed/)).toBeNull();
+    });
+
+    it("spins only while a member tool call is still running", () => {
+      const { container, rerender } = renderCard({
+        group: group([action("a", { vendorToolName: "Read" }), action("b", { status: "failed" })]),
+      });
+
+      expect(container.querySelector(".tw-animate-spin")).toBeNull();
+
+      rerender(
+        <ActivityGroupCard
+          group={group([
+            action("a", { vendorToolName: "Read" }),
+            action("b", { vendorToolName: "Bash", status: "in_progress" }),
+          ])}
+          open={false}
+          onToggle={jest.fn()}
+          renderMember={renderMember}
+        />
+      );
+      expect(container.querySelector(".tw-animate-spin")).not.toBeNull();
+    });
+
+    it("asks its owner to toggle instead of opening itself", () => {
+      const onToggle = jest.fn();
+      renderCard({ group: group([action("a"), action("b")]), onToggle });
+
+      const header = screen.getByRole("button");
+      expect(header.getAttribute("aria-expanded")).toBe("false");
+
+      fireEvent.click(header);
+      expect(onToggle).toHaveBeenCalledTimes(1);
+      // Controlled: the card stays closed until the owner says otherwise.
+      expect(screen.getByRole("button").getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("renders members only once open, in the region the header controls", () => {
+      const members = [action("Read notes/Inbox.md"), REASONING];
+      const { container, rerender } = renderCard({ group: group(members) });
+
+      expect(screen.queryByText("Read notes/Inbox.md")).toBeNull();
+
+      rerender(
+        <ActivityGroupCard
+          group={group(members)}
+          open
+          onToggle={jest.fn()}
+          renderMember={renderMember}
+        />
+      );
+
+      const header = screen.getByRole("button");
+      expect(header.getAttribute("aria-expanded")).toBe("true");
+      const body = container.querySelector(`[id="${header.getAttribute("aria-controls")}"]`);
+      expect(body?.textContent).toBe("Read notes/Inbox.mdreasoning");
+    });
+
+    it("shows the live step only while collapsed", () => {
+      const members = [action("a"), action("b")];
+      const { rerender } = renderCard({
+        group: group(members),
+        liveStep: <span>Running npm test</span>,
+      });
+
+      expect(screen.getByText("Running npm test")).not.toBeNull();
+
+      rerender(
+        <ActivityGroupCard
+          group={group(members)}
+          open
+          onToggle={jest.fn()}
+          renderMember={renderMember}
+          liveStep={<span>Running npm test</span>}
+        />
+      );
+      expect(screen.queryByText("Running npm test")).toBeNull();
+    });
+  });
+});

--- a/src/agentMode/ui/ActivityGroupCard.tsx
+++ b/src/agentMode/ui/ActivityGroupCard.tsx
@@ -1,0 +1,119 @@
+import React, { useId } from "react";
+import { ChevronDown, ChevronRight, Layers, Loader2, type LucideIcon } from "lucide-react";
+import {
+  summarizeActivity,
+  type ActivityGroupNode,
+  type ActivityMember,
+} from "@/agentMode/ui/activityGroups";
+import { pickToolIcon } from "@/agentMode/ui/toolIcons";
+
+export interface ActivityGroupCardProps {
+  group: ActivityGroupNode;
+  /**
+   * Measured reasoning wall-clock for this group, passed through to
+   * `summarizeActivity`. The card never measures time itself — `thought`
+   * parts carry no timestamps, so the trail owns the clock.
+   */
+  thinkingMs?: number;
+  /**
+   * Whether the body is showing. Fully controlled: a group must stay open
+   * across streaming updates, which only works if the owner of the trail holds
+   * this state.
+   */
+  open: boolean;
+  onToggle: () => void;
+  /**
+   * Renders one member. Injected rather than imported so this file stays
+   * unaware of the concrete cards the trail dispatches to.
+   */
+  renderMember: (member: ActivityMember, key: string | number) => React.ReactNode;
+  /**
+   * Transient row for the step currently in flight, shown under the summary
+   * line while the group is collapsed. When the group is open the live member
+   * is already visible in the body, so the row would only duplicate it.
+   */
+  liveStep?: React.ReactNode;
+}
+
+/**
+ * One collapsed run of the agent's tool calls and reasoning, summarized as a
+ * single line the user can open. Groups are born collapsed and never close
+ * themselves, so nothing the user is mid-read disappears; see
+ * `designdocs/AGENT_TRAIL_GROUPING.md`.
+ */
+export const ActivityGroupCard: React.FC<ActivityGroupCardProps> = ({
+  group,
+  thinkingMs,
+  open,
+  onToggle,
+  renderMember,
+  liveStep,
+}) => {
+  const bodyId = useId();
+  const summary = summarizeActivity(group.members, { thinkingMs });
+  const Icon = groupIcon(group.members);
+  const isProcessing = group.members.some(
+    (m) => m.type === "action" && (m.part.status === "pending" || m.part.status === "in_progress")
+  );
+
+  return (
+    <div className="tw-my-1 tw-flex tw-flex-col tw-gap-0.5">
+      {/* A native `button` here inherits Obsidian's button chrome — a grey fill
+          and an inset shadow that no Tailwind reset outranks — so the row would
+          render as a pill among the trail's flat rows. Every sibling card uses
+          this shape for the same reason; the keyboard handler keeps it operable. */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        aria-controls={bodyId}
+        onClick={onToggle}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter" && e.key !== " ") return;
+          e.preventDefault();
+          onToggle();
+        }}
+        className="tw-flex tw-cursor-pointer tw-items-center tw-gap-1.5 tw-text-sm tw-text-muted hover:tw-text-normal"
+      >
+        <Icon className="tw-size-3.5 tw-shrink-0 tw-text-muted" />
+        <span className="tw-flex-1 tw-truncate tw-font-medium">{summary.line}</span>
+        {summary.failed > 0 ? (
+          <span className="tw-shrink-0 tw-text-xs tw-text-muted">{summary.failed} failed</span>
+        ) : null}
+        {isProcessing ? (
+          <Loader2 className="tw-size-3 tw-shrink-0 tw-animate-spin tw-text-loading" />
+        ) : null}
+        {open ? (
+          <ChevronDown className="tw-size-3 tw-shrink-0 tw-text-muted" />
+        ) : (
+          <ChevronRight className="tw-size-3 tw-shrink-0 tw-text-muted" />
+        )}
+      </div>
+      {!open && liveStep ? (
+        <div className="tw-truncate tw-pl-5 tw-text-xs tw-text-muted">{liveStep}</div>
+      ) : null}
+      {open ? (
+        <div
+          id={bodyId}
+          className="tw-mt-1 tw-flex tw-flex-col tw-border-l tw-border-border tw-pl-3"
+        >
+          {group.members.map((m, i) => renderMember(m, i))}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+/**
+ * The group's leading glyph: its members' own icon when they all resolve to
+ * one, and a neutral stack when the run mixes families — inventing a winner
+ * among unrelated tools would misdescribe the row.
+ */
+function groupIcon(members: ActivityMember[]): LucideIcon {
+  const icons = new Set<LucideIcon>();
+  for (const m of members) {
+    if (m.type !== "action") continue;
+    icons.add(pickToolIcon({ vendorToolName: m.part.vendorToolName, toolKind: m.part.toolKind }));
+  }
+  return icons.size === 1 ? [...icons][0] : Layers;
+}


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#266

## Why

The folding model turns a run of tool calls and thoughts into one group — but nothing can display a group. Today every activity renders as its own full-width row, and there is no component that can say "Read 1 file, ran 2 commands, thought for 51s" on one line while still letting the user open it and see each of those activities in full.

That one line has to carry more than a label: a run with a failure inside must say so without being opened, and a run that is still streaming must look alive rather than finished.

## What

Adds the activity group card, reachable only from the component gallery — the production agent trail is unchanged; no production surface mounts it yet.

- **Collapsed row:** a tool icon (the family's own icon when all members match, a neutral stack for mixed runs), the one-line summary, and a chevron.
- **Failure and progress at a glance:** a `1 failed` badge when any member failed; a spinner while any member is still running, with an optional one-line "current step" under the summary.
- **Expanded body:** an indented list rendering every member with its normal card — nothing is summarized away.
- The card is fully controlled by its parent: it never opens or closes itself. In the gallery, only the *Expanded* story wires a live toggle; the other stories are static states.

## Non goal

- Connecting the card to live agent messages.
- Automatically opening or closing a group.

## Screenshot

Gallery captures — the card cannot be reached in the product yet, so the component gallery is the only surface that renders it.

| Collapsed | With a failure inside |
| --- | --- |
| <img width="420" alt="Collapsed activity group card" src="https://github.com/user-attachments/assets/ccfd0da8-361b-4c53-a7ee-56937cb8eb09" /> | <img width="420" alt="Collapsed card with 1 failed badge" src="https://github.com/user-attachments/assets/90d1fa05-ed4b-4f5a-9c4f-0ae83aa3b015" /> |

| Still streaming (spinner + current step) | Expanded |
| --- | --- |
| <img width="420" alt="In-flight card with spinner and live step" src="https://github.com/user-attachments/assets/3f3507f2-9d5d-40d6-9cda-708ebd6f118a" /> | <img width="420" alt="Expanded card revealing every member" src="https://github.com/user-attachments/assets/d1686502-2b34-41e6-a70e-43ae834b8431" /> |

## Risk

**Low** — an additions-only component reachable solely from the component gallery, so no production behavior changes and a revert removes it entirely; the summary line, failed badge, spinner, controlled toggle, member rendering, and collapsed-only live step are each covered by tests in `ActivityGroupCard.test.tsx`, and rendered layout and truncation cannot be covered by an automated test because they are rendered appearance.

Review: skim Why and What and confirm CI is green; if checking appearance, walk Verification steps 2–3 against the screenshots above.

## Verification

1. Deploy this branch and open the component gallery; go to *Agent Mode / Activity Group Card*.
2. Check *Collapsed*, *WithFailure* (failed badge without opening), *InFlight* (spinner and current-step line), and *LongLine* (searches, fetches, and MCP calls pooling as commands; clean truncation at narrow widths).
3. Open the *Expanded* story and toggle the header: the body reveals every covered activity and collapses back on a second toggle.
