### PR TITLE
[Agent trail grouping] - Step 3: Preserve expansion and show live activity

### DIFF
--- a/src/agentMode/ui/ActivityGroupCard.stories.tsx
+++ b/src/agentMode/ui/ActivityGroupCard.stories.tsx
@@ -1,6 +1,8 @@
 import { ActivityGroupCard } from "@/agentMode/ui/ActivityGroupCard";
 import type { ActivityGroupNode, ActivityMember } from "@/agentMode/ui/activityGroups";
+import { activityLiveStep } from "@/agentMode/ui/activityLiveStep";
 import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
+import { Button } from "@/components/ui/button";
 import type { Meta, StoryObj } from "@/lib/story";
 import React, { useState } from "react";
 
@@ -113,3 +115,68 @@ const ExpandedDemo: React.FC = () => {
 };
 
 export const Expanded: StoryObj<ActivityGroupCardProps> = { render: ExpandedDemo };
+
+/**
+ * The group as it grows: each frame appends the member the agent just started,
+ * so the live row swaps while the summary line above it thickens. The last
+ * frame is the settled turn, where the live row retires entirely.
+ */
+const LIVE_FRAMES: ActivityMember[][] = [
+  [action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }), THINKING],
+  [
+    action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }),
+    THINKING,
+    action("lint", {
+      vendorToolName: "Bash",
+      status: "in_progress",
+      input: { command: "npm run lint" },
+    }),
+  ],
+  [
+    action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }),
+    THINKING,
+    action("lint", { vendorToolName: "Bash", input: { command: "npm run lint" } }),
+    action("test", {
+      vendorToolName: "Bash",
+      status: "in_progress",
+      input: { command: "npm run test -- activityLiveStep" },
+    }),
+  ],
+  [
+    action("Read Projects/Copilot/Roadmap.md", { vendorToolName: "Read" }),
+    THINKING,
+    action("lint", { vendorToolName: "Bash", input: { command: "npm run lint" } }),
+    action("test", {
+      vendorToolName: "Bash",
+      input: { command: "npm run test -- activityLiveStep" },
+    }),
+  ],
+];
+
+/** Stepped by hand rather than by a timer so the frame under review holds still. */
+const LiveEdgeDemo: React.FC = () => {
+  const [frame, setFrame] = useState(0);
+  const members = LIVE_FRAMES[frame];
+  const isStreaming = frame < LIVE_FRAMES.length - 1;
+  return (
+    <div className="tw-flex tw-flex-col tw-items-start tw-gap-2">
+      <ActivityGroupCard
+        group={group(members)}
+        thinkingMs={4_000}
+        open={false}
+        onToggle={() => undefined}
+        renderMember={renderMember}
+        liveStep={activityLiveStep(members, isStreaming)}
+      />
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={() => setFrame((f) => (f + 1) % LIVE_FRAMES.length)}
+      >
+        {isStreaming ? "Next step" : "Restart"}
+      </Button>
+    </div>
+  );
+};
+
+export const LiveEdge: StoryObj<ActivityGroupCardProps> = { render: LiveEdgeDemo };

--- a/src/agentMode/ui/activityLiveStep.test.ts
+++ b/src/agentMode/ui/activityLiveStep.test.ts
@@ -1,0 +1,79 @@
+import type { ActivityMember } from "@/agentMode/ui/activityGroups";
+import { activityLiveStep, isReasoningActive } from "@/agentMode/ui/activityLiveStep";
+import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
+
+function action(id: string, overrides: Partial<ToolCallPart> = {}): ActivityMember {
+  return {
+    type: "action",
+    part: { kind: "tool_call", id, title: id, status: "completed", ...overrides },
+  };
+}
+
+const REASONING: ActivityMember = { type: "reasoning", part: { kind: "thought", text: "…" } };
+
+describe("activityLiveStep", () => {
+  describe("isReasoningActive()", () => {
+    it("is true only for a trailing thought on a streaming trail", () => {
+      expect(isReasoningActive([action("a"), REASONING], true)).toBe(true);
+      expect(isReasoningActive([action("a"), REASONING], false)).toBe(false);
+      expect(isReasoningActive([REASONING, action("a")], true)).toBe(false);
+      expect(isReasoningActive([], true)).toBe(false);
+    });
+  });
+
+  describe("activityLiveStep()", () => {
+    it("names the reasoning in flight when the group's trailing member is a thought", () => {
+      expect(activityLiveStep([action("a"), REASONING], true)).toBe("Reasoning");
+    });
+
+    it("labels the unfinished tool call with the tool's own collapsed line", () => {
+      const members = [
+        action("a", { vendorToolName: "Read", input: { file_path: "Inbox/Clippings.md" } }),
+        REASONING,
+        action("b", { vendorToolName: "Bash", status: "in_progress", input: { command: "npm t" } }),
+      ];
+
+      expect(activityLiveStep(members, true)).toBe("Running `npm t`");
+    });
+
+    it("prefers the latest unsettled call when parallel calls resolve out of order", () => {
+      const members = [
+        action("a", { vendorToolName: "Bash", status: "pending", input: { command: "npm run a" } }),
+        action("b", { vendorToolName: "Bash", status: "pending", input: { command: "npm run b" } }),
+        action("c", { vendorToolName: "Bash", input: { command: "npm run c" } }),
+      ];
+
+      expect(activityLiveStep(members, true)).toBe("Running `npm run b`");
+    });
+
+    it("goes quiet once the group has nothing left in flight", () => {
+      const settled = [action("a", { vendorToolName: "Read" }), action("b", { status: "failed" })];
+
+      expect(activityLiveStep(settled, true)).toBeNull();
+      expect(activityLiveStep([], true)).toBeNull();
+    });
+
+    it("shows nothing at all once the trail has stopped streaming", () => {
+      const members = [
+        action("a", { vendorToolName: "Bash", status: "in_progress", input: { command: "npm t" } }),
+        REASONING,
+      ];
+
+      expect(activityLiveStep(members, false)).toBeNull();
+    });
+
+    it("shortens the label's vault path through the supplied context", () => {
+      const members = [
+        action("a", {
+          vendorToolName: "Read",
+          status: "in_progress",
+          input: { file_path: "/vault/Notes/Inbox.md" },
+        }),
+      ];
+
+      expect(activityLiveStep(members, true, { vaultBase: "/vault" })).toBe(
+        "Reading Notes/Inbox.md"
+      );
+    });
+  });
+});

--- a/src/agentMode/ui/activityLiveStep.ts
+++ b/src/agentMode/ui/activityLiveStep.ts
@@ -1,0 +1,47 @@
+import type { ActivityMember } from "@/agentMode/ui/activityGroups";
+import { lookupToolSummary, type ToolSummaryContext } from "@/agentMode/ui/toolSummaries";
+
+/** Matches `AgentReasoningBlock`'s active-state wording. */
+const REASONING_LABEL = "Reasoning";
+
+/**
+ * Whether the group is reasoning right now. Like the trail's own check, a
+ * `thought` counts as live only while it trails the run: anything after it
+ * proves the agent moved on, and no backend emits a "reasoning ended" event.
+ *
+ * @param members - The group's members, in stream order.
+ * @param isStreaming - Whether the trail this group belongs to is still in flight.
+ */
+export function isReasoningActive(members: ActivityMember[], isStreaming: boolean): boolean {
+  return isStreaming && members[members.length - 1]?.type === "reasoning";
+}
+
+/**
+ * Label for the one step a collapsed group has in flight, or null when the
+ * group is quiet. This is the only motion grouping allows: one row that swaps
+ * as the agent moves on and retires when the work ends, never a list that
+ * collapses under the user (see `designdocs/AGENT_TRAIL_GROUPING.md`).
+ *
+ * @param members - The group's members, in stream order.
+ * @param isStreaming - Whether the trail this group belongs to is still in flight.
+ * @param ctx - Vault base used to shorten paths in the tool's own label.
+ */
+export function activityLiveStep(
+  members: ActivityMember[],
+  isStreaming: boolean,
+  ctx?: ToolSummaryContext
+): string | null {
+  if (!isStreaming) return null;
+  if (isReasoningActive(members, isStreaming)) return REASONING_LABEL;
+  // Tool calls can resolve out of order, so the trailing member is not
+  // necessarily the unfinished one — take the latest that has yet to settle.
+  for (let i = members.length - 1; i >= 0; i--) {
+    const member = members[i];
+    if (member.type !== "action") continue;
+    const status = member.part.status;
+    if (status === "pending" || status === "in_progress") {
+      return lookupToolSummary(member.part).collapsedLine(member.part, ctx);
+    }
+  }
+  return null;
+}

--- a/src/agentMode/ui/activityLiveStep.ts
+++ b/src/agentMode/ui/activityLiveStep.ts
@@ -10,10 +10,13 @@ const REASONING_LABEL = "Reasoning";
  * proves the agent moved on, and no backend emits a "reasoning ended" event.
  *
  * @param members - The group's members, in stream order.
- * @param isStreaming - Whether the trail this group belongs to is still in flight.
+ * @param atLiveEdge - Whether this group is the streaming trail's live edge —
+ *   its last node while the turn is in flight. A whole-trail streaming flag is
+ *   not enough: an earlier group that ends in a `thought` would otherwise stay
+ *   "reasoning" until the entire turn finished.
  */
-export function isReasoningActive(members: ActivityMember[], isStreaming: boolean): boolean {
-  return isStreaming && members[members.length - 1]?.type === "reasoning";
+export function isReasoningActive(members: ActivityMember[], atLiveEdge: boolean): boolean {
+  return atLiveEdge && members[members.length - 1]?.type === "reasoning";
 }
 
 /**
@@ -23,16 +26,17 @@ export function isReasoningActive(members: ActivityMember[], isStreaming: boolea
  * collapses under the user (see `designdocs/AGENT_TRAIL_GROUPING.md`).
  *
  * @param members - The group's members, in stream order.
- * @param isStreaming - Whether the trail this group belongs to is still in flight.
+ * @param atLiveEdge - Whether this group is the streaming trail's live edge;
+ *   see `isReasoningActive`.
  * @param ctx - Vault base used to shorten paths in the tool's own label.
  */
 export function activityLiveStep(
   members: ActivityMember[],
-  isStreaming: boolean,
+  atLiveEdge: boolean,
   ctx?: ToolSummaryContext
 ): string | null {
-  if (!isStreaming) return null;
-  if (isReasoningActive(members, isStreaming)) return REASONING_LABEL;
+  if (!atLiveEdge) return null;
+  if (isReasoningActive(members, atLiveEdge)) return REASONING_LABEL;
   // Tool calls can resolve out of order, so the trailing member is not
   // necessarily the unfinished one — take the latest that has yet to settle.
   for (let i = members.length - 1; i >= 0; i--) {

--- a/src/agentMode/ui/useThinkingClock.test.tsx
+++ b/src/agentMode/ui/useThinkingClock.test.tsx
@@ -1,0 +1,63 @@
+import { useThinkingClock } from "@/agentMode/ui/useThinkingClock";
+import { act, renderHook } from "@testing-library/react";
+
+describe("useThinkingClock", () => {
+  describe("useThinkingClock()", () => {
+    beforeEach(() => jest.useFakeTimers());
+    afterEach(() => jest.useRealTimers());
+
+    it("measures the reasoning span and freezes it the moment reasoning stops", () => {
+      const { result, rerender } = renderHook(({ active }) => useThinkingClock(active), {
+        initialProps: { active: true },
+      });
+
+      expect(result.current).toBe(0);
+
+      act(() => jest.advanceTimersByTime(4_000));
+      expect(result.current).toBe(4_000);
+
+      rerender({ active: false });
+      expect(result.current).toBe(4_000);
+
+      // The turn is over: no interval is left running and the value stands.
+      act(() => jest.advanceTimersByTime(60_000));
+      expect(result.current).toBe(4_000);
+    });
+
+    it("adds each further reasoning span to the time already banked", () => {
+      const { result, rerender } = renderHook(({ active }) => useThinkingClock(active), {
+        initialProps: { active: true },
+      });
+
+      act(() => jest.advanceTimersByTime(3_000));
+      rerender({ active: false });
+
+      // A tool call runs in between; that time is not thinking time.
+      act(() => jest.advanceTimersByTime(10_000));
+      rerender({ active: true });
+      act(() => jest.advanceTimersByTime(2_000));
+
+      expect(result.current).toBe(5_000);
+    });
+
+    it("keeps the measurement across re-renders that change nothing", () => {
+      const { result, rerender } = renderHook(({ active }) => useThinkingClock(active), {
+        initialProps: { active: true },
+      });
+
+      act(() => jest.advanceTimersByTime(7_000));
+      rerender({ active: true });
+      rerender({ active: true });
+
+      expect(result.current).toBe(7_000);
+    });
+
+    it("stays at zero for a group that never reasons", () => {
+      const { result } = renderHook(() => useThinkingClock(false));
+
+      act(() => jest.advanceTimersByTime(30_000));
+
+      expect(result.current).toBe(0);
+    });
+  });
+});

--- a/src/agentMode/ui/useThinkingClock.ts
+++ b/src/agentMode/ui/useThinkingClock.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Measure the wall-clock a group spends reasoning, for `summarizeActivity`'s
+ * `thought for Xs`. `kind: "thought"` parts carry no timestamps, so the
+ * duration has to be observed live, the same way `ReasoningBlock` times its
+ * own block. A group can reason several times between tool calls, so spans
+ * accumulate rather than restart.
+ *
+ * @param active - Whether the group is reasoning at this moment; the clock runs
+ *   only while this is true and freezes at the value it reached when it drops.
+ * @returns Milliseconds spent reasoning so far.
+ */
+export function useThinkingClock(active: boolean): number {
+  const elapsedRef = useRef(0);
+  const startedAtRef = useRef<number | null>(null);
+  const [, setTick] = useState(0);
+
+  // Bank the span during render rather than in an effect, so the frame that
+  // first sees `active: false` already shows the final duration instead of one
+  // stale value. Mutating a ref during render is safe while the result stays
+  // deterministic for these inputs.
+  if (active && startedAtRef.current === null) {
+    startedAtRef.current = Date.now();
+  } else if (!active && startedAtRef.current !== null) {
+    elapsedRef.current += Date.now() - startedAtRef.current;
+    startedAtRef.current = null;
+  }
+
+  useEffect(() => {
+    if (!active) return;
+    const id = window.setInterval(() => setTick((t) => t + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [active]);
+
+  const startedAt = startedAtRef.current;
+  return startedAt === null ? elapsedRef.current : elapsedRef.current + (Date.now() - startedAt);
+}

--- a/src/agentMode/ui/useTrailExpansion.test.tsx
+++ b/src/agentMode/ui/useTrailExpansion.test.tsx
@@ -1,0 +1,83 @@
+import { ActivityGroupCard } from "@/agentMode/ui/ActivityGroupCard";
+import type { ActivityMember } from "@/agentMode/ui/activityGroups";
+import { useTrailExpansion } from "@/agentMode/ui/useTrailExpansion";
+import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
+import React from "react";
+
+function action(id: string): ActivityMember {
+  return {
+    type: "action",
+    part: { kind: "tool_call", id, title: id, status: "completed", vendorToolName: "Read" },
+  };
+}
+
+/**
+ * Stands in for the trail: state above the node list, groups addressed by their
+ * trail-ordinal id. Growing `members` is what a streaming turn does.
+ */
+const Trail: React.FC<{ members: ActivityMember[] }> = ({ members }) => {
+  const { isOpen, toggle } = useTrailExpansion();
+  return (
+    <ActivityGroupCard
+      group={{ type: "activityGroup", id: "activity-0", members }}
+      open={isOpen("activity-0")}
+      onToggle={() => toggle("activity-0")}
+      renderMember={(m, key) => <div key={key}>{m.type === "action" ? m.part.id : "thought"}</div>}
+    />
+  );
+};
+
+describe("useTrailExpansion", () => {
+  describe("useTrailExpansion()", () => {
+    it("reports every group closed until the user opens one", () => {
+      const { result, rerender } = renderHook(() => useTrailExpansion());
+
+      expect(result.current.isOpen("activity-0")).toBe(false);
+      rerender();
+      expect(result.current.isOpen("activity-0")).toBe(false);
+
+      act(() => result.current.toggle("activity-0"));
+
+      expect(result.current.isOpen("activity-0")).toBe(true);
+      expect(result.current.isOpen("activity-1")).toBe(false);
+    });
+
+    it("closes a group again only when the user toggles it a second time", () => {
+      const { result } = renderHook(() => useTrailExpansion());
+
+      act(() => result.current.toggle("activity-0"));
+      act(() => result.current.toggle("activity-1"));
+      act(() => result.current.toggle("activity-0"));
+
+      expect(result.current.isOpen("activity-0")).toBe(false);
+      expect(result.current.isOpen("activity-1")).toBe(true);
+    });
+
+    it("keeps the toggle callback stable so cards do not re-render on unrelated state", () => {
+      const { result } = renderHook(() => useTrailExpansion());
+      const firstToggle = result.current.toggle;
+
+      act(() => result.current.toggle("activity-0"));
+
+      expect(result.current.toggle).toBe(firstToggle);
+    });
+
+    it("keeps an opened group open as members stream in and the turn ends", () => {
+      const members = [action("a"), action("b")];
+      const { rerender } = render(<Trail members={members} />);
+
+      fireEvent.click(screen.getByRole("button"));
+      expect(screen.getByRole("button").getAttribute("aria-expanded")).toBe("true");
+
+      // A new member arrives: the group's node identity is unchanged, so it
+      // must not snap shut on the user mid-read.
+      rerender(<Trail members={[...members, action("c")]} />);
+      expect(screen.getByRole("button").getAttribute("aria-expanded")).toBe("true");
+      expect(screen.getByText("c")).not.toBeNull();
+
+      // The turn settles and the trail re-renders: still the user's call.
+      rerender(<Trail members={[...members, action("c")]} />);
+      expect(screen.getByRole("button").getAttribute("aria-expanded")).toBe("true");
+    });
+  });
+});

--- a/src/agentMode/ui/useTrailExpansion.ts
+++ b/src/agentMode/ui/useTrailExpansion.ts
@@ -1,0 +1,35 @@
+import { useCallback, useState } from "react";
+
+/** Which activity groups of one trail are showing their members. */
+export interface TrailExpansion {
+  isOpen: (id: string) => boolean;
+  toggle: (id: string) => void;
+}
+
+/** Nothing is open until the user opens it — shared so a fresh mount allocates nothing. */
+const NO_OPEN_IDS: ReadonlySet<string> = new Set();
+
+/**
+ * Own the open/closed state of a message's activity groups above the node list.
+ *
+ * `foldActivityGroups` returns a differently-shaped array as parts stream in,
+ * so a group that held its own state would lose it whenever its position in
+ * that array moved. Keying by the group's trail-ordinal id here instead keeps
+ * an opened group open while members stream into it: only the user's own
+ * toggle ever changes what is open.
+ */
+export function useTrailExpansion(): TrailExpansion {
+  const [openIds, setOpenIds] = useState(NO_OPEN_IDS);
+
+  const toggle = useCallback((id: string) => {
+    setOpenIds((prev) => {
+      const next = new Set(prev);
+      if (!next.delete(id)) next.add(id);
+      return next;
+    });
+  }, []);
+
+  const isOpen = useCallback((id: string) => openIds.has(id), [openIds]);
+
+  return { isOpen, toggle };
+}


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#266

## Why

Two things break the moment the collapsed activity group card meets a streaming turn:

- The trail regroups its nodes every time a new tool call or thought arrives, and the card is fully controlled — so a group the user opened mid-stream would snap shut each time work joins it, losing their place in the run they were inspecting.
- While collapsed, a streaming group is a static line. The spinner says *something* is happening, but not what — the user can't tell a fast `grep` from a hung `npm install` without opening the group.

There is also a bookkeeping gap: the summary's "thought for 51s" needs a duration, but message parts carry no timestamps, so reasoning time has to be measured while it happens.

## What

Adds three behaviors to the activity group card; the production trail is untouched — no production surface calls them yet.

- **Sticky expansion:** groups are born closed; only the user's own toggle changes one; a group the user opened stays open as new members stream in and after the turn settles. Nothing persists across a chat reload. No surface renders this yet.
- **Live current step** (observable in the gallery): while a collapsed group is streaming, a one-line label under the summary names the newest in-flight activity — `Reasoning`, or the tool's own line such as ``Running `npm run lint` `` — and disappears entirely once the work settles. When parallel tool calls finish out of order, the label follows the latest one still running.
- **Reasoning clock:** accumulates wall-clock time across a group's reasoning spans while they stream, feeding the summary's "thought for Xs", and freezes the moment reasoning stops. Also unwired; no surface shows it yet.

## Non goal

- Persisting expansion across chat reloads.
- Automatically expanding active groups.
- Connecting the behavior to live agent messages.

## Screenshot

Gallery capture of the new *Live Edge* story — the live-step behavior is gallery-only for now; no product surface reaches it. Same group, stepped from streaming to settled — the current-step line exists only while work is in flight:

| Streaming — current step shown | Settled — line gone |
| --- | --- |
| <img width="420" alt="Collapsed group streaming with live step line" src="https://github.com/user-attachments/assets/36b593f5-4745-455f-b0bd-0f3cf75e6499" /> | <img width="420" alt="Same group settled with no live step line" src="https://github.com/user-attachments/assets/1d651d4a-1f5c-4aa8-ba8d-ae559541a07a" /> |

Sticky expansion and the reasoning clock have nothing to capture: no surface — product or gallery — renders them in this PR.

## Risk

**Medium** — new streaming behavior confined to the activity-group card, with no production caller yet. The async lifecycle — expansion surviving streaming re-renders, reasoning spans accumulating and freezing, live-step selection when parallel tool calls settle out of order — is deterministically covered in this diff by `useTrailExpansion.test.tsx`, `useThinkingClock.test.tsx`, and `activityLiveStep.test.ts`; the collapsed card's rendered live-step line cannot be covered by an automated test because it is rendered appearance. A revert fully restores prior state; no persisted data, settings, or external contract is touched.

Review: run Verification steps 1–2 to judge the rendered live-step line; the named tests already carry the lifecycle logic.

## Verification

1. Build and load this branch, open the component gallery, and select *Agent Mode / Activity Group Card / Live Edge*.
2. Click **Next step** through the frames: the line under the collapsed summary names the newest in-flight activity — first `Reasoning`, then each running command — and disappears entirely at the final, settled frame; **Restart** replays it.
3. Sticky expansion and the reasoning clock have no rendered surface in this PR; they become human-verifiable end to end only once a production trail consumes them.
