### PR TITLE
fix(chat): stop Obsidian tooltip on the chat composer

### DIFF
--- a/src/components/chat-components/LexicalEditor.tsx
+++ b/src/components/chat-components/LexicalEditor.tsx
@@ -189,6 +189,10 @@ const LexicalEditor: React.FC<LexicalEditorProps> = ({
   const promptSuggestionId = useId();
   const showPromptSuggestions = !!placeholderPrompts && placeholderPrompts.length > 0;
 
+  // Obsidian pops its own tooltip for anything carrying `aria-label`, which is
+  // noise on an element the size of the composer — name it out of band instead.
+  const editorLabelId = useId();
+
   const handleEditorReady = useCallback(
     (editor: LexicalEditorType) => {
       setEditorInstance(editor);
@@ -202,11 +206,14 @@ const LexicalEditor: React.FC<LexicalEditorProps> = ({
       <ActiveFileProvider currentActiveFile={currentActiveFile}>
         <CloudAgentProvider cloudAgentIds={cloudAgentIds}>
           <div className={cn("tw-relative", className)}>
+            <span id={editorLabelId} className="tw-sr-only">
+              Chat input
+            </span>
             <PlainTextPlugin
               contentEditable={
                 <ContentEditable
                   className="tw-max-h-60 tw-min-h-[60px] tw-w-full tw-resize-none tw-overflow-y-auto tw-rounded-md tw-border-none tw-bg-transparent tw-px-2 tw-text-sm tw-text-normal tw-outline-none focus-visible:tw-ring-0"
-                  aria-label="Chat input"
+                  aria-labelledby={editorLabelId}
                   // The suggestions bind Tab, so a screen reader has to hear
                   // what that key will do before it is pressed — the animated
                   // text itself stays hidden.


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#268

## Problem

Hovering anywhere over the chat composer pops an Obsidian tooltip reading "Chat input".

The mechanism is Obsidian's global tooltip handler, not our own component: on hover it runs `closest("[aria-label]")` and, on a match, renders a tooltip from `getAttribute("aria-label")` (verified by disassembling `Obsidian.app/Contents/Resources/obsidian.asar` — the same code path `setTooltip()` feeds by writing `aria-label`). The Lexical `ContentEditable` in `src/components/chat-components/LexicalEditor.tsx` carried `aria-label="Chat input"` purely as an accessible name, so every hover over the plugin's biggest and most-rested-on target produced a popup. The tooltip string matches that attribute value exactly, and "Chat input" appears nowhere else in `src/`.

## User experience

Before: resting the pointer on the message box shows a small "Chat input" bubble that states the obvious and covers part of the conversation behind it.

After: hovering the message box shows nothing.

Unchanged: the send, stop, and chat-control buttons keep their tooltips — those are icon-only, where the tooltip is the affordance. Screen readers still announce the composer as "Chat input". Nothing to relearn, re-enter, or migrate.

## Fix

Name the element out of band: a visually hidden (`tw-sr-only`) `<span>` holds the text, and the `ContentEditable` points at it with `aria-labelledby` instead of carrying `aria-label`. The accessible name is identical in the accessibility tree; Obsidian's `closest("[aria-label]")` no longer matches anything in that subtree.

The `id` comes from `useId()` because Agent Home and a popout composer can be mounted at once — the same reason the neighboring `promptSuggestionId` in this file is generated rather than hardcoded.

Rejected alternative: deleting `aria-label` outright. It is a smaller diff (−1 line) and kills the tooltip, but it strips the composer's accessible name — Lexical renders its placeholder as a sibling `div`, so nothing else would name the field.

## Explicit non-goals

- No sweep of `aria-label` elsewhere in the plugin. Most remaining ones are icon-only buttons where the Obsidian tooltip is intentional. Suggested follow-up: audit icon-only controls whose tooltip duplicates an adjacent visible label.
- No replacement or restyling of Obsidian's tooltip system.
- No change to placeholder text, prompt suggestions, or composer layout.
- No change to the Agent Mode composer's own controls.

## Scope

Budget gate: PASS — 1 file, +8/−1; the tooltip has exactly one source (the `aria-label` on the composer's `ContentEditable`), and this replaces that attribute with the smallest equivalent that keeps the accessible name.

No story was added: the label span is visually hidden, so there is no new rendered state for the gallery to show.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run lint` — clean. `npm run format` applied (pre-commit hook re-ran Prettier and ESLint on the staged file).
- `npx jest src/components/chat-components` — 97 tests pass across 11 suites. 5 suites fail to load in this worktree with `Cannot find module 'yaml' from __mocks__/obsidian.js`; that is the worktree having no `node_modules` of its own, not this change — the same suites pass when run from the primary checkout (`PromptSuggestionPlaceholder.test.tsx`, `utils/lexicalTextUtils.test.ts`: 30/30 pass there).
- Cause confirmed against Obsidian's shipped bundle as described under Problem, rather than inferred.
- Not verified: I have not observed the hover in a running vault — builds are the maintainer's step. The claim rests on Obsidian's handler matching `[aria-label]`, which the diff removes from that subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> Cross-repo `Fixes` references do not register a closing link on this repo pair, so logancyang/obsidian-copilot-preview#268 needs a manual close when this merges.
