### PR TITLE
Open agent links that point at symlink aliases instead of erroring

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -333,7 +333,9 @@ export default [
   // detectBinary / binaryPath / nodeToolBinDirs / rendererEventsShim are
   // sibling utilities pulled in by agent-mode wiring and share the same
   // Electron-renderer assumptions. The Symposium handoff consumer is likewise
-  // desktop-only, but remains in the host publishing layer.
+  // desktop-only, but remains in the host publishing layer. openVaultPath
+  // lazy-requires node:fs behind a desktop vault-base guard, mirroring
+  // opencodeLog.
   {
     files: [
       "src/agentMode/**",
@@ -344,6 +346,7 @@ export default [
       "src/utils/rendererEventsShim.ts",
       "src/utils/issueReport.ts",
       "src/utils/opencodeLog.ts",
+      "src/utils/openVaultPath.ts",
       "src/symposium/symposiumAgentHandoff.ts",
     ],
     rules: {

--- a/src/utils/openVaultPath.test.ts
+++ b/src/utils/openVaultPath.test.ts
@@ -1,6 +1,9 @@
 import { openVaultPath } from "@/utils/openVaultPath";
 import { openWithSystemDefault } from "@/utils/openWithSystemDefault";
 import { __resetVaultBaseCache } from "@/utils/vaultPath";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as nodePath from "node:path";
 import { App, FileSystemAdapter } from "obsidian";
 
 jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
@@ -92,5 +95,79 @@ describe("openVaultPath", () => {
     const app = buildApp();
     openVaultPath(app as unknown as App, "Some Note", { sourcePath: "source.md" });
     expect(app.workspace.openLinkText).toHaveBeenCalledWith("Some Note", "source.md", false);
+  });
+
+  describe("unindexed paths that exist on disk", () => {
+    let vaultDir: string;
+
+    beforeEach(() => {
+      vaultDir = fs.realpathSync(fs.mkdtempSync(nodePath.join(os.tmpdir(), "ovp-vault-")));
+      fs.mkdirSync(nodePath.join(vaultDir, "copilot/skills"), { recursive: true });
+      fs.writeFileSync(nodePath.join(vaultDir, "copilot/skills/voice-profile.md"), "hi");
+      fs.mkdirSync(nodePath.join(vaultDir, ".claude"));
+      fs.symlinkSync(
+        nodePath.join(vaultDir, "copilot/skills"),
+        nodePath.join(vaultDir, ".claude/skills")
+      );
+    });
+
+    afterEach(() => {
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    });
+
+    it("opens a dot-folder symlink alias as its canonical indexed note", () => {
+      const app = buildApp(vaultDir, ["copilot/skills/voice-profile.md"]);
+      open(app, ".claude/skills/voice-profile.md");
+      expect(app.workspace.openLinkText).toHaveBeenCalledWith(
+        "copilot/skills/voice-profile.md",
+        "",
+        false
+      );
+      expect(openWithSystemDefault).not.toHaveBeenCalled();
+    });
+
+    it("preserves the heading anchor when canonicalizing a symlink alias", () => {
+      const app = buildApp(vaultDir, ["copilot/skills/voice-profile.md"]);
+      open(app, ".claude/skills/voice-profile.md#Closings");
+      expect(app.workspace.openLinkText).toHaveBeenCalledWith(
+        "copilot/skills/voice-profile.md#Closings",
+        "",
+        false
+      );
+    });
+
+    it("opens an existing file with no indexed canonical path via the OS", () => {
+      fs.writeFileSync(nodePath.join(vaultDir, ".claude/settings.json"), "{}");
+      const app = buildApp(vaultDir);
+      open(app, ".claude/settings.json");
+      expect(app.workspace.openLinkText).not.toHaveBeenCalled();
+      expect(openWithSystemDefault).toHaveBeenCalledWith(
+        nodePath.join(vaultDir, ".claude/settings.json")
+      );
+    });
+
+    it("hands a symlink that resolves outside the vault to the OS", () => {
+      const outsideDir = fs.realpathSync(fs.mkdtempSync(nodePath.join(os.tmpdir(), "ovp-out-")));
+      try {
+        fs.writeFileSync(nodePath.join(outsideDir, "secret.md"), "hi");
+        fs.symlinkSync(
+          nodePath.join(outsideDir, "secret.md"),
+          nodePath.join(vaultDir, "escape.md")
+        );
+        const app = buildApp(vaultDir);
+        open(app, "escape.md");
+        expect(app.workspace.openLinkText).not.toHaveBeenCalled();
+        expect(openWithSystemDefault).toHaveBeenCalledWith(nodePath.join(outsideDir, "secret.md"));
+      } finally {
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
+
+    it("still routes a genuinely missing note through openLinkText's create flow", () => {
+      const app = buildApp(vaultDir);
+      open(app, "Ideas/Not Written Yet");
+      expect(app.workspace.openLinkText).toHaveBeenCalledWith("Ideas/Not Written Yet", "", false);
+      expect(openWithSystemDefault).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/utils/openVaultPath.test.ts
+++ b/src/utils/openVaultPath.test.ts
@@ -126,6 +126,17 @@ describe("openVaultPath", () => {
       expect(openWithSystemDefault).not.toHaveBeenCalled();
     });
 
+    it("opens a root-relative dot-folder symlink alias as its canonical indexed note", () => {
+      const app = buildApp(vaultDir, ["copilot/skills/voice-profile.md"]);
+      open(app, "/.claude/skills/voice-profile.md");
+      expect(app.workspace.openLinkText).toHaveBeenCalledWith(
+        "copilot/skills/voice-profile.md",
+        "",
+        false
+      );
+      expect(openWithSystemDefault).not.toHaveBeenCalled();
+    });
+
     it("preserves the heading anchor when canonicalizing a symlink alias", () => {
       const app = buildApp(vaultDir, ["copilot/skills/voice-profile.md"]);
       open(app, ".claude/skills/voice-profile.md#Closings");

--- a/src/utils/openVaultPath.ts
+++ b/src/utils/openVaultPath.ts
@@ -115,8 +115,7 @@ function toExistingRootRelativeVaultPath(app: App, href: string): string | null 
   if (!href.startsWith("/") || href.startsWith("//")) return null;
   const rel = href.replace(/^\/+/, "");
   if (!rel) return null;
-  const anchorIndex = rel.indexOf("#");
-  const filePath = anchorIndex === -1 ? rel : rel.slice(0, anchorIndex);
+  const { filePath } = splitAnchor(rel);
   if (!filePath) return null;
   return app.vault.getAbstractFileByPath(filePath) ? rel : null;
 }

--- a/src/utils/openVaultPath.ts
+++ b/src/utils/openVaultPath.ts
@@ -117,5 +117,7 @@ function toExistingRootRelativeVaultPath(app: App, href: string): string | null 
   if (!rel) return null;
   const { filePath } = splitAnchor(rel);
   if (!filePath) return null;
-  return app.vault.getAbstractFileByPath(filePath) ? rel : null;
+  return app.vault.getAbstractFileByPath(filePath) || resolveUnindexedVaultPath(app, filePath)
+    ? rel
+    : null;
 }

--- a/src/utils/openVaultPath.ts
+++ b/src/utils/openVaultPath.ts
@@ -17,6 +17,12 @@ export interface OpenVaultPathOptions {
  * agent-response surface that turns a path into a click target (rendered
  * markdown links, tool-call cards).
  *
+ * Paths Obsidian doesn't index — symlink aliases like `.claude/skills/...`
+ * and files under dotfile folders — are resolved against the real filesystem
+ * on desktop: an alias whose target is an indexed note opens in the editor
+ * under its canonical path, and an existing-but-unindexed file opens via the
+ * OS instead of tripping `openLinkText`'s create-note flow.
+ *
  * Callers that source the path from a URL-encoded DOM `href` must
  * `decodeURIComponent` first — decoding is correct only for encoded hrefs,
  * not for raw filesystem paths (a real file can contain a literal `%`).
@@ -33,7 +39,70 @@ export function openVaultPath(app: App, rawPath: string, opts: OpenVaultPathOpti
     }
     path = rel;
   }
+  const { filePath, anchor } = splitAnchor(path);
+  if (filePath && !app.vault.getAbstractFileByPath(filePath)) {
+    const resolved = resolveUnindexedVaultPath(app, filePath);
+    if (resolved) {
+      if (resolved.indexedPath) {
+        void app.workspace.openLinkText(
+          resolved.indexedPath + anchor,
+          opts.sourcePath ?? "",
+          opts.newLeaf ?? false
+        );
+      } else {
+        // Exists on disk but Obsidian can't index it (dotfile folder, or the
+        // alias escapes the vault) — openLinkText would create a phantom note.
+        void openWithSystemDefault(resolved.absolutePath);
+      }
+      return;
+    }
+  }
   void app.workspace.openLinkText(path, opts.sourcePath ?? "", opts.newLeaf ?? false);
+}
+
+interface UnindexedPathResolution {
+  /** Fully symlink-resolved absolute filesystem path. */
+  absolutePath: string;
+  /** Canonical vault-relative path when the target is an indexed file. */
+  indexedPath: string | null;
+}
+
+/**
+ * Resolve a vault-relative path that Obsidian's index doesn't know about by
+ * following symlinks in every path component on disk. Returns null on mobile,
+ * or when the path doesn't exist — a missing target must keep flowing through
+ * `openLinkText` so intentional links to not-yet-created notes still work.
+ *
+ * @param app The Obsidian `App` used for the vault base and index lookups.
+ * @param filePath Vault-relative path with any `#anchor` already stripped.
+ */
+function resolveUnindexedVaultPath(app: App, filePath: string): UnindexedPathResolution | null {
+  const vaultBase = getVaultBase(app);
+  if (!vaultBase) return null;
+  try {
+    // Desktop-only: loaded lazily after the vault-base guard, which is null
+    // wherever the FileSystemAdapter (and thus node) is unavailable.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require("node:fs") as typeof import("node:fs");
+    // Realpath both sides so a vault base that itself sits behind a symlink
+    // (e.g. /tmp on macOS) still compares equal to the resolved target.
+    const absolutePath = fs.realpathSync(`${vaultBase}/${filePath}`);
+    const canonicalBase = fs.realpathSync(vaultBase);
+    const rel = toVaultRelative(absolutePath, canonicalBase);
+    if (rel === absolutePath) return { absolutePath, indexedPath: null };
+    return {
+      absolutePath,
+      indexedPath: app.vault.getAbstractFileByPath(rel) ? rel : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function splitAnchor(path: string): { filePath: string; anchor: string } {
+  const anchorIndex = path.indexOf("#");
+  if (anchorIndex === -1) return { filePath: path, anchor: "" };
+  return { filePath: path.slice(0, anchorIndex), anchor: path.slice(anchorIndex) };
 }
 
 /**


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#270

## Why

Agent chat renders every path the agent touches as a click target — "Edited .claude/skills/linkedin-post/references/voice-profile.md" in a tool card, for example. Managed skills live behind dot-folder symlinks (`.claude/skills/...` → `copilot/skills/...`), and Obsidian doesn't index dot folders, so clicking such a link today shows a "Folder already exists" notice and opens nothing: the shared opener only recognizes indexed paths, and everything else falls into `openLinkText`'s create-note flow, which collides with the existing dot folder.

## What

When a clicked vault-relative path isn't in Obsidian's index, the opener now resolves it against the real filesystem (desktop only) before deciding what to do.

> **Before:** clicking `.claude/skills/linkedin-post/references/voice-profile.md` in an agent conversation shows "Folder already exists" and nothing opens.
>
> **After:** the same click opens `copilot/skills/linkedin-post/references/voice-profile.md` in the note editor, with any `#heading` anchor preserved.

| Clicked path | Before | After |
| --- | --- | --- |
| Symlink alias of an indexed note | "Folder already exists" error | Opens the canonical note in the editor |
| Existing file Obsidian can't index (e.g. `.claude/settings.json`) | "Folder already exists" error | Opens via the OS default app |
| Symlink resolving outside the vault | create-note flow could fire | Opens via the OS default app |
| Genuinely missing note | Obsidian's create-note flow | Unchanged |

## Non goal

- Indexing dot folders or changing what Obsidian's vault index covers.
- A hardcoded `.claude/skills → copilot/skills` alias map — resolution comes from the filesystem so Codex/OpenCode aliases and Windows junctions behave identically.
- Mobile behavior changes; resolution is guarded to desktop and mobile keeps today's behavior.

## Screenshot

Not applicable — no rendered surface changes; the fix changes where an existing link click navigates. The outcome is covered by the Verification path below.

## Verification

1. Build the branch into a test vault (`npm run test:vault`) and open that vault in Obsidian.
2. In the vault, create `copilot/skills/demo/note.md`, then `mkdir .claude && ln -s "$(pwd)/copilot/skills" .claude/skills` from the vault root.
3. In an agent conversation, have the agent mention or edit `.claude/skills/demo/note.md`, then click the rendered path.
4. Observe the note opens in the editor at `copilot/skills/demo/note.md` — no "Folder already exists" notice.
5. Click a path to an existing non-note file under `.claude/` (e.g. `.claude/settings.json`) and observe it opens in the OS default app.
