### PR TITLE
refactor(gallery): drop the story-level width parameter

### DIFF
--- a/designdocs/agents/TESTING_GUIDE.md
+++ b/designdocs/agents/TESTING_GUIDE.md
@@ -406,7 +406,7 @@ Use the component gallery whenever a feature adds or changes a user-visible Reac
 2. Import `Meta` and `StoryObj` from `@/lib/story`, declare component metadata with `satisfies Meta<Props>`, and type every named story as `StoryObj<Props>`.
 3. Cover the load-bearing states a user can actually see: default, empty, loading, success, error, disabled, overflow-prone content, or other states introduced by the feature. Use realistic copy and fixture props rather than production stores or runtime singletons.
 4. Prefer `args` for ordinary prop states and `render` for compositions. Hook-backed render functions are supported. Keep fixtures deterministic and actions inert unless interaction is the behavior under test.
-5. Choose `parameters.gallery.host` (`leaf`, `modal`, `popover`, or `settings-tab`), `layout` (`padded`, `centered`, or `fullscreen`), and an optional supported `width` (`300`, `340`, `400`, or `600`) that match the real component boundary. Use `coverage: false` only for an intentional presentational-component opt-out.
+5. Choose `parameters.gallery.host` (`leaf`, `modal`, `popover`, or `settings-tab`) and `layout` (`padded`, `centered`, or `fullscreen`) to match the real component boundary. Use `coverage: false` only for an intentional presentational-component opt-out. Stories cannot pin a canvas width — width is view state owned by the gallery's width toolbar, so check a component at other widths with that toolbar or sweep them all via `audit()`. Never add a story whose only difference from a sibling is the width you wish it rendered at; it will render identically.
 6. If a component cannot render without plugin state, extract or expose a presentational boundary that accepts the required data as props; do not widen the Gallery import fence to reach settings, stores, or runtime singletons.
 
 A minimal adjacent story looks like this:
@@ -418,7 +418,7 @@ import { StatusCard, type StatusCardProps } from "./StatusCard";
 const meta = {
   title: "Feature/Status Card",
   component: StatusCard,
-  parameters: { gallery: { host: "leaf", layout: "padded", width: 300 } },
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
 } satisfies Meta<StatusCardProps>;
 export default meta;
 

--- a/dev/gallery/Gallery.test.tsx
+++ b/dev/gallery/Gallery.test.tsx
@@ -15,7 +15,7 @@ import {
   resolveGalleryViewState,
   type StoryDefinition,
 } from "./Gallery";
-import type { GalleryParameters, GalleryWidth, Host, Layout } from "@/lib/story";
+import type { GalleryParameters, Host, Layout } from "@/lib/story";
 
 jest.mock("@/components/modals/ReactModal", () => {
   const close = jest.fn();
@@ -65,7 +65,6 @@ function makeStory(
     layout?: Layout;
     name?: string;
     node?: React.ReactNode;
-    width?: GalleryWidth;
   } = {}
 ): StoryDefinition {
   const segments = id.split("/");
@@ -79,7 +78,6 @@ function makeStory(
     name: options.name ?? exportName,
     render: () => options.node ?? <div>{`${id} content`}</div>,
     title: segments.join("/"),
-    width: options.width,
   };
 }
 
@@ -89,7 +87,7 @@ function makeCatalog(): GalleryCatalog {
     coveredCount: 4,
     stories: [
       makeStory("Agent Mode/Agent Welcome Card/Default", { layout: "fullscreen" }),
-      makeStory("UI/Badge/Status", { layout: "centered", width: 340 }),
+      makeStory("UI/Badge/Status", { layout: "centered" }),
       makeStory("UI/Button/Modal", { host: "modal" }),
       makeStory("UI/Button/Popover", { host: "popover" }),
       makeStory("UI/Button/Primary", {
@@ -155,7 +153,6 @@ describe("Gallery", () => {
       expect(catalog.coveredCount).toBe(3);
       expect(catalog.stories.map((story) => story.id)).toEqual([
         "Agent Mode/Agent Welcome Card/Default",
-        "Agent Mode/Agent Welcome Card/Narrow",
         "Gallery/Host Environments/DefaultLeaf",
         "Gallery/Host Environments/DeleteConfirmation",
         "Gallery/Host Environments/ModelPreferences",
@@ -166,7 +163,6 @@ describe("Gallery", () => {
         "UI/Button/Sizes",
         "UI/Button/Variants",
       ]);
-      expect(catalog.stories.find((story) => story.id.endsWith("/Narrow"))?.width).toBe(300);
       expect(
         catalog.stories.find((story) => story.id === "Gallery/Host Environments/DefaultLeaf")
       ).toMatchObject({ host: "leaf", layout: "fullscreen" });
@@ -208,7 +204,7 @@ describe("Gallery", () => {
               },
               Example: {
                 name: "Renamed example",
-                parameters: { gallery: { host: "leaf", width: 340 } },
+                parameters: { gallery: { host: "leaf" } },
                 render: () => "Covered story",
               },
             },
@@ -245,7 +241,6 @@ describe("Gallery", () => {
         host: "leaf",
         layout: "padded",
         name: "Renamed example",
-        width: 340,
       });
     });
 
@@ -273,15 +268,18 @@ describe("Gallery", () => {
       story.unmount();
     });
 
-    it("rejects unsupported story widths at compile time", () => {
+    it("rejects story-declared canvas widths at compile time", () => {
+      // Canvas width is view state owned by the width toolbar, not story metadata:
+      // a declared width would apply to the first render and be silently ignored
+      // afterwards, making two stories that differ only by width indistinguishable.
       const parameters: GalleryParameters = {
         gallery: {
-          // @ts-expect-error The gallery offers only its declared viewport presets to stories.
-          width: 500,
+          // @ts-expect-error Stories cannot pin the canvas width; use the width toolbar.
+          width: 300,
         },
       };
 
-      expect(parameters.gallery?.width).toBe(500);
+      expect(parameters.gallery).toEqual({ width: 300 });
     });
 
     it("rejects a story without a render function or meta component", () => {
@@ -303,17 +301,14 @@ describe("Gallery", () => {
   });
 
   describe("resolveGalleryViewState()", () => {
-    it("restores valid identities and gallery widths", () => {
-      const stories = [
-        makeStory("UI/Button/Default"),
-        makeStory("UI/Button/Narrow", { width: 340 }),
-      ];
+    it("restores valid identities and persisted widths", () => {
+      const stories = [makeStory("UI/Button/Default"), makeStory("UI/Button/Sizes")];
 
       expect(
         resolveGalleryViewState(
           {
             contactSheet: true,
-            selectedStoryId: "UI/Button/Narrow",
+            selectedStoryId: "UI/Button/Sizes",
             selectedSubtree: "UI",
             width: 600,
           },
@@ -321,14 +316,14 @@ describe("Gallery", () => {
         )
       ).toEqual({
         contactSheet: true,
-        selectedStoryId: "UI/Button/Narrow",
+        selectedStoryId: "UI/Button/Sizes",
         selectedSubtree: "UI",
         width: 600,
       });
     });
 
-    it("falls back to an available story, its metadata width, and its title", () => {
-      const stories = [makeStory("UI/Button/Narrow", { width: 340 })];
+    it("falls back to an available story, its title, and the default width", () => {
+      const stories = [makeStory("UI/Button/Sizes")];
 
       expect(
         resolveGalleryViewState(
@@ -342,9 +337,9 @@ describe("Gallery", () => {
         )
       ).toEqual({
         contactSheet: false,
-        selectedStoryId: "UI/Button/Narrow",
+        selectedStoryId: "UI/Button/Sizes",
         selectedSubtree: "UI/Button",
-        width: 340,
+        width: 400,
       });
     });
 

--- a/dev/gallery/Gallery.tsx
+++ b/dev/gallery/Gallery.tsx
@@ -2,12 +2,13 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ReactModal } from "@/components/modals/ReactModal";
 import { useApp } from "@/context";
-import type { GalleryParameters, GalleryWidth, Host, Layout } from "@/lib/story";
+import type { GalleryParameters, Host, Layout } from "@/lib/story";
 import { cn } from "@/lib/utils";
 import type { App } from "obsidian";
 import * as React from "react";
 
 export const GALLERY_WIDTHS = [300, 340, 400, 600] as const;
+type GalleryPresetWidth = (typeof GALLERY_WIDTHS)[number];
 
 export type GalleryHostChange = (storyId: string, close: (() => void) | null) => void;
 interface StoryModuleMeta {
@@ -41,7 +42,6 @@ export interface StoryDefinition {
   name: string;
   render(): React.ReactNode;
   title: string;
-  width?: GalleryWidth;
 }
 
 export interface GalleryCatalog {
@@ -99,7 +99,7 @@ interface CustomWidthDraft {
   value: string;
 }
 
-const DEFAULT_WIDTH: GalleryWidth = 400;
+const DEFAULT_WIDTH: GalleryPresetWidth = 400;
 
 function isPositiveWidth(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
@@ -675,7 +675,6 @@ export function createGalleryCatalog(
             ? React.createElement(story.render, args)
             : React.createElement(meta.component!, args),
         title: meta.title,
-        width: gallery.width,
       });
     }
   }
@@ -693,7 +692,7 @@ export function createGalleryCatalog(
  * Restores only valid gallery state and falls back to the first available story when needed.
  *
  * @param value - ItemView state supplied by Obsidian or the current controlled gallery state.
- * @param stories - Available stories used to validate persisted identities and metadata defaults.
+ * @param stories - Available stories used to validate persisted identities.
  */
 export function resolveGalleryViewState(
   value: unknown,
@@ -712,11 +711,7 @@ export function resolveGalleryViewState(
   const selectedSubtree = selectedSubtreeIsValid
     ? requestedSubtree
     : (selectedStory?.title ?? null);
-  const width = isPositiveWidth(state.width)
-    ? state.width
-    : isPositiveWidth(selectedStory?.width)
-      ? selectedStory.width
-      : DEFAULT_WIDTH;
+  const width = isPositiveWidth(state.width) ? state.width : DEFAULT_WIDTH;
 
   return {
     contactSheet: state.contactSheet === true,

--- a/dev/gallery/main.test.ts
+++ b/dev/gallery/main.test.ts
@@ -493,7 +493,6 @@ describe("main", () => {
 
         expect(handle.list()).toEqual([
           "Agent Mode/Agent Welcome Card/Default",
-          "Agent Mode/Agent Welcome Card/Narrow",
           "Gallery/Host Environments/DefaultLeaf",
           "Gallery/Host Environments/DeleteConfirmation",
           "Gallery/Host Environments/ModelPreferences",

--- a/src/agentMode/ui/AgentStatusCard.stories.tsx
+++ b/src/agentMode/ui/AgentStatusCard.stories.tsx
@@ -7,7 +7,7 @@ type AgentStatusCardProps = React.ComponentProps<typeof AgentStatusCard>;
 const meta = {
   title: "Agent Mode/Agent Status Card",
   component: AgentStatusCard,
-  parameters: { gallery: { host: "leaf", layout: "padded", width: 300 } },
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
 } satisfies Meta<AgentStatusCardProps>;
 export default meta;
 

--- a/src/agentMode/ui/AgentWelcomeCard.stories.tsx
+++ b/src/agentMode/ui/AgentWelcomeCard.stories.tsx
@@ -16,7 +16,3 @@ const meta = {
 export default meta;
 
 export const Default: StoryObj<AgentWelcomeCardProps> = {};
-
-export const Narrow: StoryObj<AgentWelcomeCardProps> = {
-  parameters: { gallery: { width: 300 } },
-};

--- a/src/components/ui/button.stories.tsx
+++ b/src/components/ui/button.stories.tsx
@@ -23,7 +23,6 @@ export default meta;
 
 export const Disabled: StoryObj<ButtonProps> = {
   args: { disabled: true, children: "Working…" },
-  parameters: { gallery: { width: 300 } },
 };
 
 export const Variants: StoryObj<ButtonProps> = {

--- a/src/lib/story.ts
+++ b/src/lib/story.ts
@@ -2,11 +2,17 @@ import type { ComponentType } from "react";
 
 export type Host = "leaf" | "modal" | "popover" | "settings-tab";
 export type Layout = "padded" | "centered" | "fullscreen";
-export type GalleryWidth = 300 | 340 | 400 | 600;
 
-/** Namespaced so it can never collide with a real Storybook addon's parameters. */
+/**
+ * Namespaced so it can never collide with a real Storybook addon's parameters.
+ *
+ * Deliberately has no `width`: canvas width is view state owned by the gallery's
+ * width toolbar and persisted per view, so a story that declared one would be
+ * honoured on the very first render and silently ignored from then on. Check a
+ * component at other widths with the toolbar, or sweep them all via `audit()`.
+ */
 export interface GalleryParameters {
-  gallery?: { host?: Host; layout?: Layout; width?: GalleryWidth; coverage?: boolean };
+  gallery?: { host?: Host; layout?: Layout; coverage?: boolean };
 }
 
 /** Strict subset of CSF3 ComponentAnnotations. */


### PR DESCRIPTION
## Problem

`Agent Mode/Agent Welcome Card` had two stories, `Default` and `Narrow`, that rendered **pixel-identically**. Verified live in the test vault:

| Story | `data-story-width` | rendered card |
|---|---|---|
| Default | 400 | 400 × 168 |
| Narrow | 400 | 400 × 168 |

Identical markup too (2917 chars each).

## Root cause

A story could declare `gallery: { width }`, but the gallery only ever read it **once** — as a seed in `resolveGalleryViewState`, and only when the view had no persisted width. After that:

- `selectStory` spreads `...state`, preserving `width` across story changes
- `showStory` falls back to `this.state.width`, never `story.width`

So the width toolbar is the sole authority and a declared width is silently ignored. Driving the gallery handle makes it obvious — note row 2, where **Default** inherits 300 despite declaring no width at all:

| call | rendered |
|---|---|
| `show(Narrow, {width: 300})` | 300 × 183 |
| `show(Default)` — no width | **300 × 183** |
| `show(Narrow)` — no width | 300 × 183 |

## Fix

Remove the parameter rather than make it work. Applying a story's width on selection would hijack a width the user just picked in the toolbar, and responsive checking is already covered better by the toolbar (300/340/400/600 + custom) and by `audit()`, which sweeps every preset automatically.

- `width` dropped from `GalleryParameters` and `StoryDefinition`, with a comment on `GalleryParameters` recording why it can't come back
- Width resolution collapses to persisted-or-default
- The preset union is now derived from `GALLERY_WIDTHS` instead of hand-maintained in the story API, so the two can't drift
- Deletes the width-only `AgentWelcomeCard/Narrow`, plus the same dead `width: 300` on `Button/Disabled` and `AgentStatusCard`'s meta

The compile-time guard is repurposed rather than dropped: it used to assert `500` was rejected as a non-preset, now it asserts stories can't declare *any* width.

## Verification

- `npx tsc -noEmit` clean, `npm run lint` clean
- `npm run test` — 373 suites / 5279 tests pass
- Rebuilt and deployed to the test vault: welcome card list is now `["Agent Mode/Agent Welcome Card/Default"]`, sidebar reads "1 leaf story"
- Toolbar path still works end to end — the same story renders 300 × 183 at 300px and 600 × 152 at 600px

🤖 Generated with [Claude Code](https://claude.com/claude-code)