### PR TITLE
chore(agents): enforce Brevilabs skill requirements via a PreToolUse gate

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "gate=\"$HOME/.cache/brevilabs-skills/current/hooks/enforce-brevilabs-skills.py\"; [ -x \"$gate\" ] && exec \"$gate\" || exit 0",
+            "timeout": 10,
+            "statusMessage": "Checking for a matching Brevilabs skill..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Relates to Brevilabs/brevilabs-skills#52

## Why

Brevilabs skills carry requirements a skill description alone cannot enforce —
every PR opens as a draft, every issue gets an assignee and exactly one
`P0`-`P3` label, board moves go through `kanban.sh`. Nothing checked those
before a command ran, so a bare `gh pr create` silently skipped them. The gate
that enforces them (Brevilabs/brevilabs-skills#47) is delivered per-repo: a
repo is only covered once it checks the hook into its own settings. This repo
is not covered yet.

## What

Adds `.claude/settings.json` with a `PreToolUse`/`Bash` hook. In this repo,
`gh pr create` without `--draft`, `gh pr ready --undo`, `gh issue create`
without an assignee and exactly one priority label, and raw project-board
mutations that skip `kanban.sh` are now refused with a message naming the
skill to run instead. Everything else is untouched — the hook exits 0 for any
command that is not one of those.

The command indirects through `~/.cache/brevilabs-skills/current`, a stable
path `install.sh` maintains, so the script itself is never vendored here and
updates arrive without touching this repo.

## Non goal

- No change to this repo's build, tests, or runtime. The only file added is
  `.claude/settings.json`; nothing imports it.
- Does not gate operations that bypass the Bash tool, such as MCP GitHub tools
  or the web UI.
- Does not make a missing gate loud: if `install.sh` has never run on a
  machine, the path is absent and the hook exits 0 with no enforcement and no
  warning. Tracked in Brevilabs/brevilabs-skills#52.

## Screenshot

None — this PR adds a config file with no visual surface.

## Verification

Requires `python3` on `PATH`, and `install.sh` from `brevilabs-skills` to have
run at least once (otherwise the hook is inert and everything below is allowed).

From a checkout of this repo, confirm the gate refuses and permits correctly:

    echo '{"tool_input":{"command":"gh pr create --title x"}}' \
      | "$HOME/.cache/brevilabs-skills/current/hooks/enforce-brevilabs-skills.py"

Expect a JSON `permissionDecision: deny`. Then confirm a compliant command and
an unrelated one both pass with no output:

    echo '{"tool_input":{"command":"gh pr create --draft --title x"}}' \
      | "$HOME/.cache/brevilabs-skills/current/hooks/enforce-brevilabs-skills.py"
    echo '{"tool_input":{"command":"ls -la"}}' \
      | "$HOME/.cache/brevilabs-skills/current/hooks/enforce-brevilabs-skills.py"

In a live session, `gh pr create` without `--draft` should be blocked with a
message pointing at the pr-description skill.

## Note

The settings file is byte-identical to the one `brevilabs-skills` ships for
itself, so all gated repos stay in sync by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
