### PR TITLE
Fold unselected component gallery subtrees

### DIFF
--- a/designdocs/agents/TESTING_GUIDE.md
+++ b/designdocs/agents/TESTING_GUIDE.md
@@ -435,6 +435,8 @@ npm run gallery:build
 
 Deploy to the non-production test vault configured by `COPILOT_TEST_VAULT_PATH` with `npm run gallery:vault`. Before any CLI or UI mutation, verify that the resolved vault name and path match that configuration; never rely on the implicitly focused renderer.
 
+The story tree keeps its top-level categories open. Select a category label to show its contact sheet; for nested categories, use the adjacent chevron button to fold or unfold that subtree. Selecting a different story or contact sheet does not close branches you already opened.
+
 ### Agent verification loop
 
 When the development-only component gallery plugin is loaded, its typed

--- a/dev/gallery/Gallery.test.tsx
+++ b/dev/gallery/Gallery.test.tsx
@@ -3,7 +3,7 @@ import * as galleryHostStories from "@/components/gallery-hosts.stories";
 import * as badgeStories from "@/components/ui/badge.stories";
 import * as buttonStories from "@/components/ui/button.stories";
 import { AppContext } from "@/context";
-import { act, fireEvent, render, within } from "@testing-library/react";
+import { act, fireEvent, render, type RenderResult, within } from "@testing-library/react";
 import type { App } from "obsidian";
 import * as React from "react";
 import {
@@ -128,6 +128,26 @@ function GalleryHarness({
       />
     </AppContext.Provider>
   );
+}
+
+/** Walks the folded tree the way a user does: expand every ancestor subtree, then pick the story. */
+function selectStoryInTree(gallery: RenderResult, storyId: string): void {
+  const segments = storyId.split("/");
+  segments.pop();
+  let path = "";
+
+  for (const segment of segments) {
+    path = path ? `${path}/${segment}` : segment;
+    fireEvent.click(gallery.getByRole("button", { name: `Show ${path} contact sheet` }));
+  }
+
+  const storyButton = gallery.container.querySelector<HTMLButtonElement>(
+    `[data-gallery-story-button="${storyId}"]`
+  );
+  if (!storyButton) {
+    throw new Error(`No story button for ${storyId}`);
+  }
+  fireEvent.click(storyButton);
 }
 
 describe("Gallery", () => {
@@ -401,11 +421,6 @@ describe("Gallery", () => {
       });
       expect(selectedStoryButton.getAttribute("aria-current")).toBe("true");
       expect(selectedStoryButton.classList.contains("mod-cta")).toBe(true);
-
-      const unselectedStoryButton = within(navigation).getByRole("button", { name: "Status" });
-      expect(unselectedStoryButton.classList.contains("clickable-icon")).toBe(true);
-      expect(unselectedStoryButton.classList.contains("tw-bg-transparent")).toBe(true);
-      expect(unselectedStoryButton.classList.contains("mod-cta")).toBe(false);
       expect(gallery.getByText("Agent Mode/Agent Welcome Card/Default")).toBeTruthy();
       expect(gallery.container.querySelectorAll("[data-gallery-story-id]")).toHaveLength(1);
       expect(
@@ -427,9 +442,45 @@ describe("Gallery", () => {
           Boolean(element?.tagName === "P" && element.textContent?.startsWith("Subtree:"))
         )
       ).toBeNull();
+
+      selectStoryInTree(gallery, "UI/Button/Primary");
+      const unselectedStoryButton = within(navigation).getByRole("button", { name: "Modal" });
+      expect(unselectedStoryButton.classList.contains("clickable-icon")).toBe(true);
+      expect(unselectedStoryButton.classList.contains("tw-bg-transparent")).toBe(true);
+      expect(unselectedStoryButton.classList.contains("mod-cta")).toBe(false);
     });
 
-    it("filters by component title or story name and restores the tree when cleared", () => {
+    it("keeps every subtree folded except the selected path", () => {
+      const gallery = render(<GalleryHarness catalog={makeCatalog()} />);
+      const navigation = gallery.getByRole("complementary", {
+        name: "Component and story navigation",
+      });
+      const subtreeButton = (path: string) =>
+        within(navigation).getByRole("button", { name: `Show ${path} contact sheet` });
+
+      expect(subtreeButton("Agent Mode").getAttribute("aria-expanded")).toBe("true");
+      expect(within(navigation).getByRole("button", { name: "Default Selected" })).toBeTruthy();
+      expect(subtreeButton("UI").getAttribute("aria-expanded")).toBe("false");
+      expect(
+        within(navigation).queryByRole("button", { name: "Show UI/Badge contact sheet" })
+      ).toBeNull();
+
+      fireEvent.click(subtreeButton("UI"));
+      expect(subtreeButton("UI").getAttribute("aria-expanded")).toBe("true");
+      expect(subtreeButton("Agent Mode").getAttribute("aria-expanded")).toBe("false");
+      expect(within(navigation).queryByRole("button", { name: "Default" })).toBeNull();
+      expect(subtreeButton("UI/Badge").getAttribute("aria-expanded")).toBe("false");
+      expect(navigation.querySelector('[data-gallery-story-button="UI/Badge/Status"]')).toBeNull();
+
+      fireEvent.click(subtreeButton("UI/Badge"));
+      expect(
+        navigation.querySelector('[data-gallery-story-button="UI/Badge/Status"]')
+      ).toBeTruthy();
+      expect(subtreeButton("UI").getAttribute("aria-expanded")).toBe("true");
+      expect(subtreeButton("UI/Button").getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("filters by component title or story name and refolds to the selected path when cleared", () => {
       const gallery = render(<GalleryHarness catalog={makeCatalog()} />);
       const filter = gallery.getByRole("searchbox", {
         name: "Filter components and stories",
@@ -444,14 +495,15 @@ describe("Gallery", () => {
       expect(gallery.queryByRole("button", { name: "Status" })).toBeNull();
 
       fireEvent.change(filter, { target: { value: "" } });
-      expect(gallery.getByRole("button", { name: "Status" })).toBeTruthy();
-      expect(gallery.getByRole("button", { name: "Primary" })).toBeTruthy();
+      expect(gallery.queryByRole("button", { name: "Status" })).toBeNull();
+      expect(gallery.queryByRole("button", { name: "Primary" })).toBeNull();
+      expect(gallery.getByRole("button", { name: "Default Selected" })).toBeTruthy();
     });
 
     it("switches rendered stories with mouse clicks and keeps arrow keys among siblings", () => {
       const gallery = render(<GalleryHarness catalog={makeCatalog()} />);
 
-      fireEvent.click(gallery.getByRole("button", { name: "Status" }));
+      selectStoryInTree(gallery, "UI/Badge/Status");
       expect(gallery.getByText("UI/Badge/Status")).toBeTruthy();
       expect(gallery.container.querySelectorAll("[data-gallery-story-id]")).toHaveLength(1);
 
@@ -460,7 +512,7 @@ describe("Gallery", () => {
       fireEvent.keyDown(statusButton, { key: "ArrowDown" });
       expect(gallery.getByText("UI/Badge/Status")).toBeTruthy();
 
-      fireEvent.click(gallery.getByRole("button", { name: "Primary" }));
+      selectStoryInTree(gallery, "UI/Button/Primary");
       fireEvent.keyDown(gallery.getByRole("button", { name: "Primary Selected" }), {
         key: "ArrowUp",
       });
@@ -495,7 +547,7 @@ describe("Gallery", () => {
 
       fireEvent.click(gallery.getByRole("button", { name: "Show UI contact sheet" }));
 
-      fireEvent.click(gallery.getByRole("button", { name: "Modal" }));
+      selectStoryInTree(gallery, "UI/Button/Modal");
       expect(gallery.getByText("UI/Button/Modal")).toBeTruthy();
       expect(gallery.container.querySelectorAll("[data-gallery-story-id]")).toHaveLength(1);
     });
@@ -538,7 +590,7 @@ describe("Gallery", () => {
         <GalleryHarness catalog={makeCatalog()} onHostChange={onHostChange} />
       );
 
-      fireEvent.click(gallery.getByRole("button", { name: "Modal" }));
+      selectStoryInTree(gallery, "UI/Button/Modal");
       expect(getGalleryModalMock().open).toHaveBeenCalledTimes(1);
       expect(gallery.queryByText("UI/Button/Modal content")).toBeNull();
       expect(gallery.getByRole("button", { name: "Reopen modal story" })).toBeTruthy();
@@ -593,7 +645,7 @@ describe("Gallery", () => {
     it("places stable story and width selectors on every actual host case", () => {
       const gallery = render(<GalleryHarness catalog={makeCatalog()} />);
 
-      fireEvent.click(gallery.getByRole("button", { name: "Modal" }));
+      selectStoryInTree(gallery, "UI/Button/Modal");
       const modal = getGalleryModalMock().open.mock.calls[0][0] as {
         renderContent(): React.ReactElement;
       };
@@ -612,7 +664,7 @@ describe("Gallery", () => {
       expect(popoverStory?.dataset.galleryOwner).toBe("test-gallery");
       expect(popoverStory?.style.width).toBe("400px");
 
-      fireEvent.click(gallery.getByRole("button", { name: "Preferences" }));
+      selectStoryInTree(gallery, "UI/Setting Item/Preferences");
       expect(
         gallery.container.querySelector(
           '[data-gallery-host="settings-tab"][data-story="UI/Setting Item/Preferences"][data-story-width="400"]'
@@ -656,7 +708,7 @@ describe("Gallery", () => {
         <GalleryHarness catalog={makeCatalog()} onHostChange={onHostChange} />
       );
 
-      fireEvent.click(gallery.getByRole("button", { name: "Popover" }));
+      selectStoryInTree(gallery, "UI/Button/Popover");
 
       const trigger = gallery.getByRole("button", { name: "Toggle popover story" });
       expect(trigger.getAttribute("aria-expanded")).toBe("true");
@@ -684,7 +736,7 @@ describe("Gallery", () => {
         <GalleryHarness catalog={makeCatalog()} onHostChange={onHostChange} />
       );
 
-      fireEvent.click(gallery.getByRole("button", { name: "Preferences" }));
+      selectStoryInTree(gallery, "UI/Setting Item/Preferences");
 
       expect(gallery.getByText("Settings example")).toBeTruthy();
       expect(
@@ -720,7 +772,7 @@ describe("Gallery", () => {
       expect(canvas?.classList.contains("tw-h-full")).toBe(true);
       expect(canvas?.parentElement?.parentElement?.classList.contains("tw-p-4")).toBe(false);
 
-      fireEvent.click(gallery.getByRole("button", { name: "Status" }));
+      selectStoryInTree(gallery, "UI/Badge/Status");
       expect(canvas?.dataset.galleryWidth).toBe("300");
       const centeredContent = gallery.container.querySelector<HTMLElement>(
         '[data-gallery-story-id="UI/Badge/Status"] > div'
@@ -730,7 +782,7 @@ describe("Gallery", () => {
       expect(centeredContent?.classList.contains("tw-justify-center")).toBe(true);
       expect(centeredContent?.classList.contains("tw-p-4")).toBe(true);
 
-      fireEvent.click(gallery.getByRole("button", { name: "Primary" }));
+      selectStoryInTree(gallery, "UI/Button/Primary");
       const paddedContent = gallery.container.querySelector<HTMLElement>(
         '[data-gallery-story-id="UI/Button/Primary"] > div'
       );
@@ -765,7 +817,7 @@ describe("Gallery", () => {
       expect(customWidth.value).toBe("1440");
       expect(gallery.container.ownerDocument.activeElement).toBe(applyCustomWidth);
 
-      fireEvent.click(gallery.getByRole("button", { name: "Status" }));
+      selectStoryInTree(gallery, "UI/Badge/Status");
       expect(canvas?.dataset.galleryWidth).toBe("1440");
       expect(
         gallery.container.querySelector('[data-story="UI/Badge/Status"][data-story-width="1440"]')
@@ -779,7 +831,7 @@ describe("Gallery", () => {
 
       fireEvent.click(gallery.getByRole("button", { name: "600" }));
       expect(customWidth.value).toBe("");
-      fireEvent.click(gallery.getByRole("button", { name: "Primary" }));
+      selectStoryInTree(gallery, "UI/Button/Primary");
       expect(canvas?.dataset.galleryWidth).toBe("600");
     });
 

--- a/dev/gallery/Gallery.test.tsx
+++ b/dev/gallery/Gallery.test.tsx
@@ -130,15 +130,22 @@ function GalleryHarness({
   );
 }
 
-/** Walks the folded tree the way a user does: expand every ancestor subtree, then pick the story. */
+/** Walks the tree the way a user does: unfold each nested ancestor, then pick the story. */
 function selectStoryInTree(gallery: RenderResult, storyId: string): void {
   const segments = storyId.split("/");
   segments.pop();
   let path = "";
 
-  for (const segment of segments) {
+  for (const [index, segment] of segments.entries()) {
     path = path ? `${path}/${segment}` : segment;
-    fireEvent.click(gallery.getByRole("button", { name: `Show ${path} contact sheet` }));
+    if (index === 0) {
+      continue;
+    }
+
+    const unfoldButton = gallery.queryByRole("button", { name: `Unfold ${path} subtree` });
+    if (unfoldButton) {
+      fireEvent.click(unfoldButton);
+    }
   }
 
   const storyButton = gallery.container.querySelector<HTMLButtonElement>(
@@ -450,34 +457,48 @@ describe("Gallery", () => {
       expect(unselectedStoryButton.classList.contains("mod-cta")).toBe(false);
     });
 
-    it("keeps every subtree folded except the selected path", () => {
+    it("keeps top-level subtrees open and folds nested subtrees only from their icons", () => {
       const gallery = render(<GalleryHarness catalog={makeCatalog()} />);
       const navigation = gallery.getByRole("complementary", {
         name: "Component and story navigation",
       });
-      const subtreeButton = (path: string) =>
+      const selectSubtreeButton = (path: string) =>
         within(navigation).getByRole("button", { name: `Show ${path} contact sheet` });
 
-      expect(subtreeButton("Agent Mode").getAttribute("aria-expanded")).toBe("true");
-      expect(within(navigation).getByRole("button", { name: "Default Selected" })).toBeTruthy();
-      expect(subtreeButton("UI").getAttribute("aria-expanded")).toBe("false");
       expect(
-        within(navigation).queryByRole("button", { name: "Show UI/Badge contact sheet" })
+        within(navigation).queryByRole("button", { name: /(Fold|Unfold) Agent Mode subtree/ })
       ).toBeNull();
-
-      fireEvent.click(subtreeButton("UI"));
-      expect(subtreeButton("UI").getAttribute("aria-expanded")).toBe("true");
-      expect(subtreeButton("Agent Mode").getAttribute("aria-expanded")).toBe("false");
-      expect(within(navigation).queryByRole("button", { name: "Default" })).toBeNull();
-      expect(subtreeButton("UI/Badge").getAttribute("aria-expanded")).toBe("false");
+      expect(
+        within(navigation).queryByRole("button", { name: /(Fold|Unfold) UI subtree/ })
+      ).toBeNull();
+      expect(within(navigation).getByRole("button", { name: "Default Selected" })).toBeTruthy();
+      expect(selectSubtreeButton("UI/Badge")).toBeTruthy();
+      expect(selectSubtreeButton("UI/Button")).toBeTruthy();
       expect(navigation.querySelector('[data-gallery-story-button="UI/Badge/Status"]')).toBeNull();
 
-      fireEvent.click(subtreeButton("UI/Badge"));
+      fireEvent.click(within(navigation).getByRole("button", { name: "Unfold UI/Badge subtree" }));
       expect(
         navigation.querySelector('[data-gallery-story-button="UI/Badge/Status"]')
       ).toBeTruthy();
-      expect(subtreeButton("UI").getAttribute("aria-expanded")).toBe("true");
-      expect(subtreeButton("UI/Button").getAttribute("aria-expanded")).toBe("false");
+      expect(within(navigation).getByRole("button", { name: "Default Selected" })).toBeTruthy();
+
+      fireEvent.click(selectSubtreeButton("UI/Button"));
+      expect(selectSubtreeButton("UI/Button").getAttribute("aria-pressed")).toBe("true");
+      expect(
+        within(navigation).getByRole("button", { name: "Unfold UI/Button subtree" })
+      ).toBeTruthy();
+      expect(
+        within(navigation).getByRole("button", { name: "Fold UI/Badge subtree" })
+      ).toBeTruthy();
+
+      fireEvent.click(within(navigation).getByRole("button", { name: "Unfold UI/Button subtree" }));
+      expect(
+        navigation.querySelector('[data-gallery-story-button="UI/Button/Primary"]')
+      ).toBeTruthy();
+      fireEvent.click(within(navigation).getByRole("button", { name: "Fold UI/Button subtree" }));
+      expect(
+        navigation.querySelector('[data-gallery-story-button="UI/Button/Primary"]')
+      ).toBeNull();
     });
 
     it("filters by component title or story name and refolds to the selected path when cleared", () => {
@@ -543,6 +564,8 @@ describe("Gallery", () => {
       fireEvent.click(gallery.getByRole("button", { name: "Open modal story" }));
       expect(getGalleryModalMock().open).toHaveBeenCalledTimes(1);
       expect(gallery.getByText("UI/Button/Modal")).toBeTruthy();
+      expect(gallery.getByRole("button", { name: "Unfold UI/Button subtree" })).toBeTruthy();
+      fireEvent.click(gallery.getByRole("button", { name: "Unfold UI/Button subtree" }));
       expect(gallery.getByRole("button", { name: "Modal Selected" })).toBeTruthy();
 
       fireEvent.click(gallery.getByRole("button", { name: "Show UI contact sheet" }));

--- a/dev/gallery/Gallery.tsx
+++ b/dev/gallery/Gallery.tsx
@@ -75,10 +75,13 @@ interface StoryTreeNode {
 }
 
 interface StoryTreeProps {
+  depth?: number;
   expandAll: boolean;
+  expandedSubtrees: ReadonlySet<string>;
   nodes: StoryTreeNode[];
   onSelectStory: (story: StoryDefinition) => void;
   onSelectSubtree: (path: string) => void;
+  onToggleSubtree: (path: string) => void;
   selectedStoryId: string | null;
   selectedSubtree: string | null;
   showContactSheet: boolean;
@@ -557,10 +560,13 @@ function renderHostCard(
 }
 
 function StoryTree({
+  depth = 0,
   expandAll,
+  expandedSubtrees,
   nodes,
   onSelectStory,
   onSelectSubtree,
+  onToggleSubtree,
   selectedStoryId,
   selectedSubtree,
   showContactSheet,
@@ -569,28 +575,46 @@ function StoryTree({
     <ul className="tw-m-0 tw-flex tw-list-none tw-flex-col tw-gap-1 tw-p-0">
       {nodes.map((node) => {
         const subtreeSelected = showContactSheet && selectedSubtree === node.path;
-        const expanded =
-          expandAll || (selectedSubtree !== null && isWithinSubtree(selectedSubtree, node.path));
+        const canFold = depth > 0;
+        const expanded = !canFold || expandAll || expandedSubtrees.has(node.path);
 
         return (
           <li key={node.path}>
-            <Button
-              aria-expanded={expanded}
-              aria-label={`Show ${node.path} contact sheet`}
-              aria-pressed={subtreeSelected}
-              className="tw-w-full tw-justify-start tw-gap-1 tw-text-left tw-font-semibold"
-              onClick={() => onSelectSubtree(node.path)}
-              size="sm"
-              type="button"
-              variant={subtreeSelected ? "default" : "ghost2"}
-            >
-              {expanded ? (
-                <ChevronDown className="tw-size-3" />
-              ) : (
-                <ChevronRight className="tw-size-3" />
+            <div className="tw-flex tw-items-center tw-gap-1">
+              {canFold && (
+                <Button
+                  aria-expanded={expanded}
+                  aria-label={
+                    expandAll
+                      ? `${node.path} subtree is expanded while filtering`
+                      : `${expanded ? "Fold" : "Unfold"} ${node.path} subtree`
+                  }
+                  className="tw-size-6 tw-shrink-0"
+                  disabled={expandAll}
+                  onClick={() => onToggleSubtree(node.path)}
+                  size="icon"
+                  type="button"
+                  variant="ghost2"
+                >
+                  {expanded ? (
+                    <ChevronDown className="tw-size-3" />
+                  ) : (
+                    <ChevronRight className="tw-size-3" />
+                  )}
+                </Button>
               )}
-              {node.label}
-            </Button>
+              <Button
+                aria-label={`Show ${node.path} contact sheet`}
+                aria-pressed={subtreeSelected}
+                className="tw-min-w-0 tw-flex-1 tw-justify-start tw-text-left tw-font-semibold"
+                onClick={() => onSelectSubtree(node.path)}
+                size="sm"
+                type="button"
+                variant={subtreeSelected ? "default" : "ghost2"}
+              >
+                {node.label}
+              </Button>
+            </div>
 
             {expanded && (node.stories.length > 0 || node.children.size > 0) && (
               <div className="copilot-gallery-divider-l tw-ml-3 tw-pl-2">
@@ -618,10 +642,13 @@ function StoryTree({
                 })}
                 {node.children.size > 0 && (
                   <StoryTree
+                    depth={depth + 1}
                     expandAll={expandAll}
+                    expandedSubtrees={expandedSubtrees}
                     nodes={[...node.children.values()]}
                     onSelectStory={onSelectStory}
                     onSelectSubtree={onSelectSubtree}
+                    onToggleSubtree={onToggleSubtree}
                     selectedStoryId={selectedStoryId}
                     selectedSubtree={selectedSubtree}
                     showContactSheet={showContactSheet}
@@ -759,6 +786,16 @@ export function Gallery({
   const storyTree = React.useMemo(() => buildStoryTree(filteredStories), [filteredStories]);
   const selectedStory = catalog.stories.find((story) => story.id === state.selectedStoryId) ?? null;
   const selectedSubtree = state.selectedSubtree ?? selectedStory?.title ?? null;
+  const [expandedSubtrees, setExpandedSubtrees] = React.useState<ReadonlySet<string>>(() => {
+    const paths = new Set<string>();
+    const segments = selectedStory?.title.split("/") ?? [];
+
+    for (let index = 1; index < segments.length; index += 1) {
+      paths.add(segments.slice(0, index + 1).join("/"));
+    }
+    return paths;
+  });
+
   const contactSheetStories = selectedSubtree
     ? catalog.stories.filter(
         (story) => story.host === "leaf" && isWithinSubtree(story.title, selectedSubtree)
@@ -815,6 +852,17 @@ export function Gallery({
   const selectSubtree = (path: string) => {
     onStateChange({ ...state, contactSheet: true, selectedSubtree: path });
   };
+  const toggleSubtree = (path: string) => {
+    setExpandedSubtrees((current) => {
+      const next = new Set(current);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  };
 
   return (
     <div className="tw-flex tw-h-full tw-min-h-0 tw-bg-primary tw-text-normal">
@@ -849,9 +897,11 @@ export function Gallery({
           {storyTree.length > 0 ? (
             <StoryTree
               expandAll={filter.trim() !== ""}
+              expandedSubtrees={expandedSubtrees}
               nodes={storyTree}
               onSelectStory={selectStory}
               onSelectSubtree={selectSubtree}
+              onToggleSubtree={toggleSubtree}
               selectedStoryId={state.selectedStoryId}
               selectedSubtree={selectedSubtree}
               showContactSheet={state.contactSheet}

--- a/dev/gallery/Gallery.tsx
+++ b/dev/gallery/Gallery.tsx
@@ -4,6 +4,7 @@ import { ReactModal } from "@/components/modals/ReactModal";
 import { useApp } from "@/context";
 import type { GalleryParameters, GalleryWidth, Host, Layout } from "@/lib/story";
 import { cn } from "@/lib/utils";
+import { ChevronDown, ChevronRight } from "lucide-react";
 import type { App } from "obsidian";
 import * as React from "react";
 
@@ -74,6 +75,7 @@ interface StoryTreeNode {
 }
 
 interface StoryTreeProps {
+  expandAll: boolean;
   nodes: StoryTreeNode[];
   onSelectStory: (story: StoryDefinition) => void;
   onSelectSubtree: (path: string) => void;
@@ -176,8 +178,8 @@ function CustomWidthControl({ onApply, width }: CustomWidthControlProps): React.
   );
 }
 
-function storyBelongsToSubtree(story: StoryDefinition, subtree: string): boolean {
-  return story.title === subtree || story.title.startsWith(`${subtree}/`);
+function isWithinSubtree(path: string, subtree: string): boolean {
+  return path === subtree || path.startsWith(`${subtree}/`);
 }
 
 function storyMatchesFilter(story: StoryDefinition, filter: string): boolean {
@@ -555,6 +557,7 @@ function renderHostCard(
 }
 
 function StoryTree({
+  expandAll,
   nodes,
   onSelectStory,
   onSelectSubtree,
@@ -566,22 +569,30 @@ function StoryTree({
     <ul className="tw-m-0 tw-flex tw-list-none tw-flex-col tw-gap-1 tw-p-0">
       {nodes.map((node) => {
         const subtreeSelected = showContactSheet && selectedSubtree === node.path;
+        const expanded =
+          expandAll || (selectedSubtree !== null && isWithinSubtree(selectedSubtree, node.path));
 
         return (
           <li key={node.path}>
             <Button
+              aria-expanded={expanded}
               aria-label={`Show ${node.path} contact sheet`}
               aria-pressed={subtreeSelected}
-              className="tw-w-full tw-justify-between tw-text-left tw-font-semibold"
+              className="tw-w-full tw-justify-start tw-gap-1 tw-text-left tw-font-semibold"
               onClick={() => onSelectSubtree(node.path)}
               size="sm"
               type="button"
               variant={subtreeSelected ? "default" : "ghost2"}
             >
+              {expanded ? (
+                <ChevronDown className="tw-size-3" />
+              ) : (
+                <ChevronRight className="tw-size-3" />
+              )}
               {node.label}
             </Button>
 
-            {(node.stories.length > 0 || node.children.size > 0) && (
+            {expanded && (node.stories.length > 0 || node.children.size > 0) && (
               <div className="copilot-gallery-divider-l tw-ml-3 tw-pl-2">
                 {node.stories.map((story) => {
                   const selected = story.id === selectedStoryId && !showContactSheet;
@@ -607,6 +618,7 @@ function StoryTree({
                 })}
                 {node.children.size > 0 && (
                   <StoryTree
+                    expandAll={expandAll}
                     nodes={[...node.children.values()]}
                     onSelectStory={onSelectStory}
                     onSelectSubtree={onSelectSubtree}
@@ -708,7 +720,7 @@ export function resolveGalleryViewState(
   const selectedSubtreeIsValid =
     requestedSubtree !== null &&
     (stories.length === 0 ||
-      stories.some((story) => storyBelongsToSubtree(story, requestedSubtree)));
+      stories.some((story) => isWithinSubtree(story.title, requestedSubtree)));
   const selectedSubtree = selectedSubtreeIsValid
     ? requestedSubtree
     : (selectedStory?.title ?? null);
@@ -749,12 +761,12 @@ export function Gallery({
   const selectedSubtree = state.selectedSubtree ?? selectedStory?.title ?? null;
   const contactSheetStories = selectedSubtree
     ? catalog.stories.filter(
-        (story) => story.host === "leaf" && storyBelongsToSubtree(story, selectedSubtree)
+        (story) => story.host === "leaf" && isWithinSubtree(story.title, selectedSubtree)
       )
     : [];
   const hostCardStories = selectedSubtree
     ? catalog.stories.filter(
-        (story) => story.host !== "leaf" && storyBelongsToSubtree(story, selectedSubtree)
+        (story) => story.host !== "leaf" && isWithinSubtree(story.title, selectedSubtree)
       )
     : [];
   const selectStory = (story: StoryDefinition) => {
@@ -836,6 +848,7 @@ export function Gallery({
         <nav aria-label="Story tree" className="tw-min-h-0 tw-flex-1 tw-overflow-y-auto tw-p-2">
           {storyTree.length > 0 ? (
             <StoryTree
+              expandAll={filter.trim() !== ""}
               nodes={storyTree}
               onSelectStory={selectStory}
               onSelectSubtree={selectSubtree}

--- a/dev/gallery/main.test.ts
+++ b/dev/gallery/main.test.ts
@@ -123,20 +123,22 @@ function getGeneratedMock(): { loaders: jest.Mock[] } {
     .galleryGeneratedMock;
 }
 
-/** Expands the folded story tree down to a story so its tree button becomes clickable. */
-function expandStoryPath(
-  gallery: RenderResult,
-  storyId: string,
-  rerenderGallery: () => void
-): void {
+/** Unfolds nested ancestors so a story button becomes clickable. */
+function expandStoryPath(gallery: RenderResult, storyId: string): void {
   const segments = storyId.split("/");
   segments.pop();
   let path = "";
 
-  for (const segment of segments) {
+  for (const [index, segment] of segments.entries()) {
     path = path ? `${path}/${segment}` : segment;
-    fireEvent.click(gallery.getByRole("button", { name: `Show ${path} contact sheet` }));
-    rerenderGallery();
+    if (index === 0) {
+      continue;
+    }
+
+    const unfoldButton = gallery.queryByRole("button", { name: `Unfold ${path} subtree` });
+    if (unfoldButton) {
+      fireEvent.click(unfoldButton);
+    }
   }
 }
 
@@ -446,7 +448,7 @@ describe("main", () => {
 
         fireEvent.click(gallery.getByRole("button", { name: "600" }));
         rerenderGallery();
-        expandStoryPath(gallery, "UI/Button/Disabled", rerenderGallery);
+        expandStoryPath(gallery, "UI/Button/Disabled");
         fireEvent.click(gallery.getByRole("button", { name: "Disabled" }));
 
         expect(view.getState()).toMatchObject({
@@ -455,8 +457,8 @@ describe("main", () => {
           selectedSubtree: "UI/Button",
           width: 600,
         });
-        // Width, both subtree expansions, and the story pick each persist.
-        expect(requestSaveLayout).toHaveBeenCalledTimes(4);
+        // Tree folds are view-local; only the width and story pick persist.
+        expect(requestSaveLayout).toHaveBeenCalledTimes(2);
 
         gallery.unmount();
       });
@@ -690,7 +692,7 @@ describe("main", () => {
         }
         const firstGallery = render(renderTree() as ReactElement);
         const rerenderGallery = () => firstGallery.rerender(renderTree() as ReactElement);
-        expandStoryPath(firstGallery, "UI/Button/Sizes", rerenderGallery);
+        expandStoryPath(firstGallery, "UI/Button/Sizes");
         fireEvent.click(firstGallery.getByRole("button", { name: "Sizes" }));
         rerenderGallery();
         await view.onClose();

--- a/dev/gallery/main.test.ts
+++ b/dev/gallery/main.test.ts
@@ -1,5 +1,5 @@
 import { mountPluginViewRoot, type PluginViewRootHandle } from "@/utils/react/mountPluginViewRoot";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, type RenderResult } from "@testing-library/react";
 import GalleryPlugin, { GALLERY_VIEWTYPE, type GalleryHandle } from "./main";
 import type { AuditReport } from "./audit";
 import type { GalleryViewState } from "./Gallery";
@@ -121,6 +121,23 @@ interface RecordedViewState {
 function getGeneratedMock(): { loaders: jest.Mock[] } {
   return jest.requireMock<{ galleryGeneratedMock: { loaders: jest.Mock[] } }>("./stories.generated")
     .galleryGeneratedMock;
+}
+
+/** Expands the folded story tree down to a story so its tree button becomes clickable. */
+function expandStoryPath(
+  gallery: RenderResult,
+  storyId: string,
+  rerenderGallery: () => void
+): void {
+  const segments = storyId.split("/");
+  segments.pop();
+  let path = "";
+
+  for (const segment of segments) {
+    path = path ? `${path}/${segment}` : segment;
+    fireEvent.click(gallery.getByRole("button", { name: `Show ${path} contact sheet` }));
+    rerenderGallery();
+  }
 }
 
 describe("main", () => {
@@ -420,13 +437,16 @@ describe("main", () => {
 
       it("persists mouse and width changes through ItemView state", async () => {
         await view.onOpen();
-        if (!renderView) {
+        const renderTree = renderView;
+        if (!renderTree) {
           throw new Error("Gallery view did not provide a React tree");
         }
-        const gallery = render(renderView() as ReactElement);
+        const gallery = render(renderTree() as ReactElement);
+        const rerenderGallery = () => gallery.rerender(renderTree() as ReactElement);
 
         fireEvent.click(gallery.getByRole("button", { name: "600" }));
-        gallery.rerender(renderView() as ReactElement);
+        rerenderGallery();
+        expandStoryPath(gallery, "UI/Button/Disabled", rerenderGallery);
         fireEvent.click(gallery.getByRole("button", { name: "Disabled" }));
 
         expect(view.getState()).toMatchObject({
@@ -435,7 +455,8 @@ describe("main", () => {
           selectedSubtree: "UI/Button",
           width: 600,
         });
-        expect(requestSaveLayout).toHaveBeenCalledTimes(2);
+        // Width, both subtree expansions, and the story pick each persist.
+        expect(requestSaveLayout).toHaveBeenCalledTimes(4);
 
         gallery.unmount();
       });
@@ -663,12 +684,15 @@ describe("main", () => {
 
       it("restores the selected story after its prior tab closes and the command reopens it", async () => {
         await view.onOpen();
-        if (!renderView || !createView) {
+        const renderTree = renderView;
+        if (!renderTree || !createView) {
           throw new Error("Gallery view did not initialize");
         }
-        const firstGallery = render(renderView() as ReactElement);
+        const firstGallery = render(renderTree() as ReactElement);
+        const rerenderGallery = () => firstGallery.rerender(renderTree() as ReactElement);
+        expandStoryPath(firstGallery, "UI/Button/Sizes", rerenderGallery);
         fireEvent.click(firstGallery.getByRole("button", { name: "Sizes" }));
-        firstGallery.rerender(renderView() as ReactElement);
+        rerenderGallery();
         await view.onClose();
         firstGallery.unmount();
 


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#266

## Why

The component gallery opens every catalog subtree at once. As the gallery gains the stories needed to review Agent Mode work, its sidebar becomes a long list that makes the selected component and nearby stories hard to find.

## What

> **Before:** Opening a story leaves every catalog subtree expanded, so unrelated components fill the sidebar.
>
> **After:** The selected story's ancestor path stays expanded while unrelated subtrees fold. Selecting another subtree folds the previous path, and filtering temporarily expands all matching paths so hidden results remain discoverable.

## Non goal

This PR does not change story content, component rendering, or the Agent Mode runtime UI.

## Screenshot

**Before — every catalog subtree stays expanded**

<img width="3024" height="1898" alt="Component gallery before: every subtree expanded" src="https://github.com/user-attachments/assets/6ba5e8c6-fe99-40da-98b1-7b28a2f9c65c" />

**After — only the selected story path stays expanded**

<img width="3024" height="1898" alt="Component gallery after: only selected path expanded" src="https://github.com/user-attachments/assets/b4043f23-00d4-4710-a979-5da2ca920eca" />

## Verification

1. Run `npm run gallery:vault` and open **Component gallery** in the configured test vault.
2. Select a story and confirm only its ancestor path is expanded.
3. Select a different top-level subtree and confirm the previous path folds while the new path opens.
4. Filter for a story under a folded subtree, confirm the match appears, then clear the filter and confirm the tree returns to the selected path.
