### PR TITLE
Expand selected gallery story subtrees

### DIFF
--- a/designdocs/agents/TESTING_GUIDE.md
+++ b/designdocs/agents/TESTING_GUIDE.md
@@ -435,7 +435,7 @@ npm run gallery:build
 
 Deploy to the non-production test vault configured by `COPILOT_TEST_VAULT_PATH` with `npm run gallery:vault`. Before any CLI or UI mutation, verify that the resolved vault name and path match that configuration; never rely on the implicitly focused renderer.
 
-The story tree keeps its top-level categories open. Select a category label to show its contact sheet; for nested categories, use the adjacent chevron button to fold or unfold that subtree. Selecting a different story or contact sheet does not close branches you already opened.
+The story tree keeps its top-level categories open. Select a category label to show its contact sheet. For nested categories, the label also folds or unfolds the subtree; use the adjacent chevron when you want to toggle it without changing the selected contact sheet. Selecting a different story or contact sheet does not close branches you already opened.
 
 ### Agent verification loop
 

--- a/dev/gallery/Gallery.test.tsx
+++ b/dev/gallery/Gallery.test.tsx
@@ -419,10 +419,11 @@ describe("Gallery", () => {
         within(navigation).getByRole("button", { name: "Show UI contact sheet" })
       ).toBeTruthy();
       const selectedStoryButton = within(navigation).getByRole("button", {
-        name: "Default Selected",
+        name: "Default",
       });
       expect(selectedStoryButton.getAttribute("aria-current")).toBe("true");
       expect(selectedStoryButton.classList.contains("mod-cta")).toBe(true);
+      expect(within(navigation).queryByText("Selected")).toBeNull();
       expect(gallery.getByText("Agent Mode/Agent Welcome Card/Default")).toBeTruthy();
       expect(gallery.container.querySelectorAll("[data-gallery-story-id]")).toHaveLength(1);
       expect(
@@ -466,7 +467,7 @@ describe("Gallery", () => {
       expect(
         within(navigation).queryByRole("button", { name: /(Fold|Unfold) UI subtree/ })
       ).toBeNull();
-      expect(within(navigation).getByRole("button", { name: "Default Selected" })).toBeTruthy();
+      expect(within(navigation).getByRole("button", { name: "Default" })).toBeTruthy();
       expect(selectSubtreeButton("UI/Badge")).toBeTruthy();
       expect(selectSubtreeButton("UI/Button")).toBeTruthy();
       expect(navigation.querySelector('[data-gallery-story-button="UI/Badge/Status"]')).toBeNull();
@@ -475,7 +476,7 @@ describe("Gallery", () => {
       expect(
         navigation.querySelector('[data-gallery-story-button="UI/Badge/Status"]')
       ).toBeTruthy();
-      expect(within(navigation).getByRole("button", { name: "Default Selected" })).toBeTruthy();
+      expect(within(navigation).getByRole("button", { name: "Default" })).toBeTruthy();
 
       fireEvent.click(selectSubtreeButton("UI/Button"));
       expect(selectSubtreeButton("UI/Button").getAttribute("aria-pressed")).toBe("true");
@@ -513,7 +514,7 @@ describe("Gallery", () => {
       fireEvent.change(filter, { target: { value: "" } });
       expect(gallery.queryByRole("button", { name: "Status" })).toBeNull();
       expect(gallery.queryByRole("button", { name: "Primary" })).toBeNull();
-      expect(gallery.getByRole("button", { name: "Default Selected" })).toBeTruthy();
+      expect(gallery.getByRole("button", { name: "Default" })).toBeTruthy();
     });
 
     it("switches rendered stories with mouse clicks and keeps arrow keys among siblings", () => {
@@ -523,13 +524,13 @@ describe("Gallery", () => {
       expect(gallery.getByText("UI/Badge/Status")).toBeTruthy();
       expect(gallery.container.querySelectorAll("[data-gallery-story-id]")).toHaveLength(1);
 
-      const statusButton = gallery.getByRole("button", { name: "Status Selected" });
+      const statusButton = gallery.getByRole("button", { name: "Status" });
       statusButton.focus();
       fireEvent.keyDown(statusButton, { key: "ArrowDown" });
       expect(gallery.getByText("UI/Badge/Status")).toBeTruthy();
 
       selectStoryInTree(gallery, "UI/Button/Primary");
-      fireEvent.keyDown(gallery.getByRole("button", { name: "Primary Selected" }), {
+      fireEvent.keyDown(gallery.getByRole("button", { name: "Primary" }), {
         key: "ArrowUp",
       });
       expect(gallery.getByText("UI/Button/Popover")).toBeTruthy();
@@ -559,9 +560,14 @@ describe("Gallery", () => {
       fireEvent.click(gallery.getByRole("button", { name: "Open modal story" }));
       expect(getGalleryModalMock().open).toHaveBeenCalledTimes(1);
       expect(gallery.getByText("UI/Button/Modal")).toBeTruthy();
-      expect(gallery.getByRole("button", { name: "Unfold UI/Button subtree" })).toBeTruthy();
-      fireEvent.click(gallery.getByRole("button", { name: "Unfold UI/Button subtree" }));
-      expect(gallery.getByRole("button", { name: "Modal Selected" })).toBeTruthy();
+      expect(
+        gallery
+          .getByRole("button", { name: "UI/Button subtree contains selected story" })
+          .hasAttribute("disabled")
+      ).toBe(true);
+      expect(gallery.getByRole("button", { name: "Modal" }).getAttribute("aria-current")).toBe(
+        "true"
+      );
 
       fireEvent.click(gallery.getByRole("button", { name: "Show UI contact sheet" }));
 
@@ -620,7 +626,7 @@ describe("Gallery", () => {
       expect(getGalleryModalMock().close).toHaveBeenCalled();
       fireEvent.click(gallery.getByRole("button", { name: "300" }));
       expect(getGalleryModalMock().open).toHaveBeenCalledTimes(1);
-      expect(gallery.getByRole("button", { name: "Modal Selected" })).toBeTruthy();
+      expect(gallery.getByRole("button", { name: "Modal" })).toBeTruthy();
 
       fireEvent.click(gallery.getByRole("button", { name: "Primary" }));
       fireEvent.click(gallery.getByRole("button", { name: "Modal" }));

--- a/dev/gallery/Gallery.test.tsx
+++ b/dev/gallery/Gallery.test.tsx
@@ -453,7 +453,7 @@ describe("Gallery", () => {
       expect(unselectedStoryButton.classList.contains("mod-cta")).toBe(false);
     });
 
-    it("keeps top-level subtrees open and folds nested subtrees only from their icons", () => {
+    it("keeps top-level subtrees open and toggles nested subtrees from icons or titles", () => {
       const gallery = render(<GalleryHarness catalog={makeCatalog()} />);
       const navigation = gallery.getByRole("complementary", {
         name: "Component and story navigation",
@@ -481,20 +481,27 @@ describe("Gallery", () => {
       fireEvent.click(selectSubtreeButton("UI/Button"));
       expect(selectSubtreeButton("UI/Button").getAttribute("aria-pressed")).toBe("true");
       expect(
-        within(navigation).getByRole("button", { name: "Unfold UI/Button subtree" })
+        navigation.querySelector('[data-gallery-story-button="UI/Button/Primary"]')
       ).toBeTruthy();
       expect(
         within(navigation).getByRole("button", { name: "Fold UI/Badge subtree" })
+      ).toBeTruthy();
+      expect(
+        within(navigation).getByRole("button", { name: "Fold UI/Button subtree" })
+      ).toBeTruthy();
+
+      fireEvent.click(selectSubtreeButton("UI/Button"));
+      expect(
+        navigation.querySelector('[data-gallery-story-button="UI/Button/Primary"]')
+      ).toBeNull();
+      expect(
+        within(navigation).getByRole("button", { name: "Unfold UI/Button subtree" })
       ).toBeTruthy();
 
       fireEvent.click(within(navigation).getByRole("button", { name: "Unfold UI/Button subtree" }));
       expect(
         navigation.querySelector('[data-gallery-story-button="UI/Button/Primary"]')
       ).toBeTruthy();
-      fireEvent.click(within(navigation).getByRole("button", { name: "Fold UI/Button subtree" }));
-      expect(
-        navigation.querySelector('[data-gallery-story-button="UI/Button/Primary"]')
-      ).toBeNull();
     });
 
     it("filters by component title or story name and refolds to the selected path when cleared", () => {

--- a/dev/gallery/Gallery.tsx
+++ b/dev/gallery/Gallery.tsx
@@ -83,6 +83,7 @@ interface StoryTreeProps {
   onSelectSubtree: (path: string) => void;
   onToggleSubtree: (path: string) => void;
   selectedStoryId: string | null;
+  selectedStoryTitle: string | null;
   selectedSubtree: string | null;
   showContactSheet: boolean;
 }
@@ -568,6 +569,7 @@ function StoryTree({
   onSelectSubtree,
   onToggleSubtree,
   selectedStoryId,
+  selectedStoryTitle,
   selectedSubtree,
   showContactSheet,
 }: StoryTreeProps): React.ReactElement {
@@ -576,7 +578,12 @@ function StoryTree({
       {nodes.map((node) => {
         const subtreeSelected = showContactSheet && selectedSubtree === node.path;
         const canFold = depth > 0;
-        const expanded = !canFold || expandAll || expandedSubtrees.has(node.path);
+        const containsSelectedStory =
+          !showContactSheet &&
+          selectedStoryTitle !== null &&
+          isWithinSubtree(selectedStoryTitle, node.path);
+        const expanded =
+          !canFold || expandAll || containsSelectedStory || expandedSubtrees.has(node.path);
 
         return (
           <li key={node.path}>
@@ -587,10 +594,12 @@ function StoryTree({
                   aria-label={
                     expandAll
                       ? `${node.path} subtree is expanded while filtering`
-                      : `${expanded ? "Fold" : "Unfold"} ${node.path} subtree`
+                      : containsSelectedStory
+                        ? `${node.path} subtree contains selected story`
+                        : `${expanded ? "Fold" : "Unfold"} ${node.path} subtree`
                   }
                   className="tw-size-6 tw-shrink-0"
-                  disabled={expandAll}
+                  disabled={expandAll || containsSelectedStory}
                   onClick={() => onToggleSubtree(node.path)}
                   size="icon"
                   type="button"
@@ -636,7 +645,6 @@ function StoryTree({
                       variant={selected ? "default" : "ghost2"}
                     >
                       <span>{story.name}</span>
-                      {selected && <span className="tw-text-smallest">Selected</span>}
                     </Button>
                   );
                 })}
@@ -650,6 +658,7 @@ function StoryTree({
                     onSelectSubtree={onSelectSubtree}
                     onToggleSubtree={onToggleSubtree}
                     selectedStoryId={selectedStoryId}
+                    selectedStoryTitle={selectedStoryTitle}
                     selectedSubtree={selectedSubtree}
                     showContactSheet={showContactSheet}
                   />
@@ -780,16 +789,11 @@ export function Gallery({
   );
   const storyTree = React.useMemo(() => buildStoryTree(filteredStories), [filteredStories]);
   const selectedStory = catalog.stories.find((story) => story.id === state.selectedStoryId) ?? null;
+  const selectedStoryTitle = selectedStory?.title ?? null;
   const selectedSubtree = state.selectedSubtree ?? selectedStory?.title ?? null;
-  const [expandedSubtrees, setExpandedSubtrees] = React.useState<ReadonlySet<string>>(() => {
-    const paths = new Set<string>();
-    const segments = selectedStory?.title.split("/") ?? [];
-
-    for (let index = 1; index < segments.length; index += 1) {
-      paths.add(segments.slice(0, index + 1).join("/"));
-    }
-    return paths;
-  });
+  const [expandedSubtrees, setExpandedSubtrees] = React.useState<ReadonlySet<string>>(
+    () => new Set()
+  );
 
   const contactSheetStories = selectedSubtree
     ? catalog.stories.filter(
@@ -898,6 +902,7 @@ export function Gallery({
               onSelectSubtree={selectSubtree}
               onToggleSubtree={toggleSubtree}
               selectedStoryId={state.selectedStoryId}
+              selectedStoryTitle={selectedStoryTitle}
               selectedSubtree={selectedSubtree}
               showContactSheet={state.contactSheet}
             />

--- a/dev/gallery/Gallery.tsx
+++ b/dev/gallery/Gallery.tsx
@@ -81,7 +81,7 @@ interface StoryTreeProps {
   nodes: StoryTreeNode[];
   onSelectStory: (story: StoryDefinition) => void;
   onSelectSubtree: (path: string) => void;
-  onToggleSubtree: (path: string) => void;
+  onToggleSubtree: (path: string, expanded: boolean) => void;
   selectedStoryId: string | null;
   selectedStoryTitle: string | null;
   selectedSubtree: string | null;
@@ -600,7 +600,7 @@ function StoryTree({
                   }
                   className="tw-size-6 tw-shrink-0"
                   disabled={expandAll || containsSelectedStory}
-                  onClick={() => onToggleSubtree(node.path)}
+                  onClick={() => onToggleSubtree(node.path, expanded)}
                   size="icon"
                   type="button"
                   variant="ghost2"
@@ -616,7 +616,12 @@ function StoryTree({
                 aria-label={`Show ${node.path} contact sheet`}
                 aria-pressed={subtreeSelected}
                 className="tw-min-w-0 tw-flex-1 tw-justify-start tw-text-left tw-font-semibold"
-                onClick={() => onSelectSubtree(node.path)}
+                onClick={() => {
+                  onSelectSubtree(node.path);
+                  if (canFold && !expandAll) {
+                    onToggleSubtree(node.path, expanded);
+                  }
+                }}
                 size="sm"
                 type="button"
                 variant={subtreeSelected ? "default" : "ghost2"}
@@ -851,10 +856,10 @@ export function Gallery({
   const selectSubtree = (path: string) => {
     onStateChange({ ...state, contactSheet: true, selectedSubtree: path });
   };
-  const toggleSubtree = (path: string) => {
+  const toggleSubtree = (path: string, expanded: boolean) => {
     setExpandedSubtrees((current) => {
       const next = new Set(current);
-      if (next.has(path)) {
+      if (expanded) {
         next.delete(path);
       } else {
         next.add(path);

--- a/dev/gallery/main.test.ts
+++ b/dev/gallery/main.test.ts
@@ -414,7 +414,7 @@ describe("main", () => {
     });
 
     describe("onOpen()", () => {
-      it("shows a visible nested list, selected marker, exact current id, and one story", async () => {
+      it("shows a visible nested list, selected styling, exact current id, and one story", async () => {
         await view.onOpen();
 
         expect(mountViewRoot).toHaveBeenCalledWith(view.containerEl, app, expect.any(Function));
@@ -428,9 +428,10 @@ describe("main", () => {
         ).toBeTruthy();
         expect(gallery.getByRole("button", { name: "Show Agent Mode contact sheet" })).toBeTruthy();
         expect(gallery.getByRole("button", { name: "Show UI contact sheet" })).toBeTruthy();
-        expect(gallery.getByRole("button", { name: "Default Selected" }).textContent).toContain(
-          "Selected"
-        );
+        const selectedStory = gallery.getByRole("button", { name: "Default" });
+        expect(selectedStory.getAttribute("aria-current")).toBe("true");
+        expect(selectedStory.classList.contains("mod-cta")).toBe(true);
+        expect(gallery.queryByText("Selected")).toBeNull();
         expect(gallery.getByText("Agent Mode/Agent Welcome Card/Default")).toBeTruthy();
         expect(gallery.container.querySelectorAll("[data-gallery-story-id]")).toHaveLength(1);
 


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#273

## Why

When a component-gallery story is selected from a contact sheet, its component subtree can remain folded. The canvas and header show the new story, but the highlighted row is hidden in the navigation, so the tree does not reveal which story is active. When the row is visible, it also repeats the selection state with a `Selected` label even though the highlight already communicates it.

## What

> **Before:** Selecting `UI/Button/Sizes` while the Button subtree is folded leaves the subtree closed, hiding the active row; visible selected rows append `Selected`.
>
> **After:** Selecting the same story expands its ancestor subtree, keeps that active branch open, and shows a highlighted `Sizes` row with no extra label.

Manual expansion of other subtrees continues to work, and contact-sheet mode can fold branches because it highlights the selected subtree rather than an individual story.

## Non goal

- Persist manual subtree expansion across gallery tabs or restarts.
- Change contact-sheet selection or rendering behavior.

## Screenshot

Before/after screenshots were captured from the configured non-production Obsidian test vault at 1920×1050, but they cannot be attached because this Codex session has no connected authenticated browser surface for GitHub’s PR editor. The base capture shows `UI/Button/Sizes` active while the Button subtree is folded; the PR capture shows Button expanded with the highlighted `Sizes` row and no `Selected` label.

## Risk

**Low** — the change is limited to component-gallery navigation, is covered by deterministic gallery and ItemView tests, touches no persisted data or external contract, and a revert fully restores the prior behavior.

Review: run Verification steps 2–4 and confirm the active branch and row states.

## Verification

1. Deploy this branch to the configured non-production test vault with `npm run gallery:vault`, then open **Component gallery** in Obsidian.
2. Select the **UI** contact sheet while the **Button** subtree is folded, then choose **Open modal story** from the contact sheet.
3. Confirm the **Button** subtree opens automatically, the **Modal** row is highlighted without a `Selected` label, and its fold control cannot hide the active row.
4. Select a different story or return to a contact sheet and confirm non-active subtrees remain manually foldable.
