### PR TITLE
Let users choose what Claude's Auto mode permits

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -61,12 +61,12 @@ The mode picker beside the message box controls how much the active agent can do
 
 - **Default** — the agent can work in your vault and asks before sensitive actions.
 - **Plan** — the agent reads and reasons without changing your vault.
-- **Auto** — the agent can work without individual approval prompts. Use it only when you trust the task and workspace.
+- **Auto** — the agent works with its Auto permissions. Depending on the agent and its configuration, some actions may still require approval.
 
 The available modes depend on the selected agent. Copilot normalizes equivalent modes across supported versions of Claude, Codex, and OpenCode.
 
 With Claude you can decide how much **Auto** actually hands over, under
-**Settings → Copilot → Agent → Claude → Auto mode permissions**:
+**Settings → Copilot → Agents → Claude → Auto mode permissions**:
 
 - **Auto** (default) — Claude judges each request itself, approving routine work and still asking about risky actions.
 - **Accept edits** — file edits are approved automatically; everything else still asks.

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -65,6 +65,15 @@ The mode picker beside the message box controls how much the active agent can do
 
 The available modes depend on the selected agent. Copilot normalizes equivalent modes across supported versions of Claude, Codex, and OpenCode.
 
+With Claude you can decide how much **Auto** actually hands over, under
+**Settings → Copilot → Agent → Claude → Auto mode permissions**:
+
+- **Auto** (default) — Claude judges each request itself, approving routine work and still asking about risky actions.
+- **Accept edits** — file edits are approved automatically; everything else still asks.
+- **Bypass permissions** — nothing is checked. Use it only in a workspace you fully trust.
+
+Changing this takes effect the next time you pick **Auto**, so an open chat keeps the permissions it started with.
+
 When **Default** mode asks for permission, the request stays in the chat until
 you choose an action, cancel the turn, or close the session. Hover or focus a
 persistent action to inspect its detailed permission rule.

--- a/src/agentMode/backends/claude/ClaudeSettingsPanel.tsx
+++ b/src/agentMode/backends/claude/ClaudeSettingsPanel.tsx
@@ -1,15 +1,21 @@
 import { EnvOverridesSetting } from "@/agentMode/backends/shared/EnvOverridesSetting";
 import { SettingItem } from "@/components/ui/setting-item";
 import type CopilotPlugin from "@/main";
-import { useSettingsValue } from "@/settings/model";
+import { useSettingsValue, type ClaudeAutoModePermission } from "@/settings/model";
 import type { App } from "obsidian";
 import React from "react";
-import { updateClaudeFields } from "./descriptor";
+import { resolveClaudeAutoModePermission, updateClaudeFields } from "./descriptor";
 
 interface Props {
   plugin: CopilotPlugin;
   app: App;
 }
+
+const AUTO_MODE_OPTIONS: { label: string; value: ClaudeAutoModePermission }[] = [
+  { label: "Auto", value: "auto" },
+  { label: "Accept edits", value: "acceptEdits" },
+  { label: "Bypass permissions", value: "bypassPermissions" },
+];
 
 /**
  * Claude card extras. CLI detection / path / auth configuration lives in the
@@ -21,6 +27,17 @@ export const ClaudeSettingsPanel: React.FC<Props> = () => {
   const settings = useSettingsValue();
   return (
     <>
+      <SettingItem
+        type="select"
+        title="Auto mode permissions"
+        description="What the chat's Auto mode hands over. Auto lets Claude judge each request and still ask about risky ones, Accept edits auto-approves file edits only, and Bypass permissions skips every check."
+        value={resolveClaudeAutoModePermission(settings)}
+        options={AUTO_MODE_OPTIONS}
+        onChange={(value) =>
+          updateClaudeFields({ autoModePermission: value as ClaudeAutoModePermission })
+        }
+      />
+
       <SettingItem
         type="switch"
         title="Show extended thinking"

--- a/src/agentMode/backends/claude/ClaudeSettingsPanel.tsx
+++ b/src/agentMode/backends/claude/ClaudeSettingsPanel.tsx
@@ -1,7 +1,8 @@
 import { EnvOverridesSetting } from "@/agentMode/backends/shared/EnvOverridesSetting";
+import { ClaudeAutoModePermissionSetting } from "@/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting";
 import { SettingItem } from "@/components/ui/setting-item";
 import type CopilotPlugin from "@/main";
-import { useSettingsValue, type ClaudeAutoModePermission } from "@/settings/model";
+import { useSettingsValue } from "@/settings/model";
 import type { App } from "obsidian";
 import React from "react";
 import { resolveClaudeAutoModePermission, updateClaudeFields } from "./descriptor";
@@ -10,12 +11,6 @@ interface Props {
   plugin: CopilotPlugin;
   app: App;
 }
-
-const AUTO_MODE_OPTIONS: { label: string; value: ClaudeAutoModePermission }[] = [
-  { label: "Auto", value: "auto" },
-  { label: "Accept edits", value: "acceptEdits" },
-  { label: "Bypass permissions", value: "bypassPermissions" },
-];
 
 /**
  * Claude card extras. CLI detection / path / auth configuration lives in the
@@ -27,15 +22,9 @@ export const ClaudeSettingsPanel: React.FC<Props> = () => {
   const settings = useSettingsValue();
   return (
     <>
-      <SettingItem
-        type="select"
-        title="Auto mode permissions"
-        description="What the chat's Auto mode hands over. Auto lets Claude judge each request and still ask about risky ones, Accept edits auto-approves file edits only, and Bypass permissions skips every check."
+      <ClaudeAutoModePermissionSetting
         value={resolveClaudeAutoModePermission(settings)}
-        options={AUTO_MODE_OPTIONS}
-        onChange={(value) =>
-          updateClaudeFields({ autoModePermission: value as ClaudeAutoModePermission })
-        }
+        onChange={(autoModePermission) => updateClaudeFields({ autoModePermission })}
       />
 
       <SettingItem

--- a/src/agentMode/backends/claude/descriptor.test.ts
+++ b/src/agentMode/backends/claude/descriptor.test.ts
@@ -1,13 +1,15 @@
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type { BackendState, InstallState } from "@/agentMode/session/types";
-import type { CopilotSettings } from "@/settings/model";
+import { resetSettings, type CopilotSettings } from "@/settings/model";
 import { resolveClaudeBinary } from "./claudeBinaryResolver";
 import { claudeCompatibilityStore } from "./claudeCompatibilityStore";
 import {
   ClaudeBackendDescriptor,
   getClaudeInstallState,
   refreshClaudeInstallState,
+  resolveClaudeAutoModePermission,
   subscribeClaudeInstallState,
+  updateClaudeFields,
 } from "./descriptor";
 
 jest.mock("./claudeBinaryResolver", () => ({
@@ -177,6 +179,43 @@ describe("claude descriptor", () => {
       });
 
       expect(applyModelWireId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resolveClaudeAutoModePermission()", () => {
+    it("falls back to Claude's classifier mode when nothing is persisted", () => {
+      expect(resolveClaudeAutoModePermission({ agentMode: {} } as CopilotSettings)).toBe("auto");
+    });
+
+    it("returns the persisted permission mode", () => {
+      const settings = {
+        agentMode: { backends: { claude: { autoModePermission: "acceptEdits" } } },
+      } as unknown as CopilotSettings;
+
+      expect(resolveClaudeAutoModePermission(settings)).toBe("acceptEdits");
+    });
+  });
+
+  describe("ClaudeBackendDescriptor.getModeMapping()", () => {
+    afterEach(() => {
+      resetSettings();
+    });
+
+    it("points the auto pill at Claude's classifier mode by default", () => {
+      resetSettings();
+
+      expect(ClaudeBackendDescriptor.getModeMapping?.(null, null)).toEqual({
+        kind: "setMode",
+        canonical: { default: "default", plan: "plan", auto: "auto" },
+      });
+    });
+
+    it("points the auto pill at the user's configured permission mode", () => {
+      updateClaudeFields({ autoModePermission: "bypassPermissions" });
+
+      expect(ClaudeBackendDescriptor.getModeMapping?.(null, null)?.canonical.auto).toBe(
+        "bypassPermissions"
+      );
     });
   });
 });

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -57,6 +57,8 @@ export interface ClaudeDescriptor extends BackendDescriptor {
  * over. Unconfigured, it is Claude's own classifier-driven `auto`: it approves
  * routine requests and still escalates the risky ones, the closest match to
  * what "Auto" promises in the picker.
+ *
+ * @param settings Settings snapshot from which to resolve the persisted Claude permission.
  */
 export function resolveClaudeAutoModePermission(
   settings: CopilotSettings

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -7,6 +7,7 @@ import {
   getSettings,
   subscribeToSettingsChange,
   updateAgentModeBackendFields,
+  type ClaudeAutoModePermission,
   type ClaudeBackendSettings,
   type CopilotSettings,
 } from "@/settings/model";
@@ -47,6 +48,20 @@ const ABSENT_INSTALL_STATE: InstallState = Object.freeze({ kind: "absent" });
 export interface ClaudeDescriptor extends BackendDescriptor {
   auth: BackendAuth;
   getResolvedBinaryPath(settings: CopilotSettings): string | null;
+}
+
+/**
+ * The native permission mode Claude enters when the user picks the canonical
+ * `auto` pill. Copilot's three-mode picker can't express Claude's full
+ * permission vocabulary, so this preference decides how much the pill hands
+ * over. Unconfigured, it is Claude's own classifier-driven `auto`: it approves
+ * routine requests and still escalates the risky ones, the closest match to
+ * what "Auto" promises in the picker.
+ */
+export function resolveClaudeAutoModePermission(
+  settings: CopilotSettings
+): ClaudeAutoModePermission {
+  return settings.agentMode?.backends?.claude?.autoModePermission ?? "auto";
 }
 
 export function updateClaudeFields(partial: Partial<ClaudeBackendSettings>): void {
@@ -347,9 +362,10 @@ export const ClaudeBackendDescriptor: ClaudeDescriptor = {
 
   /**
    * Map Copilot's canonical modes onto the SDK's `PermissionMode` strings.
-   * `acceptEdits` / `dontAsk` exist upstream but stay hidden — the picker is
-   * a 3-mode UI (default / plan / auto). The session adapter normalizes
-   * unknown ids to `default`.
+   * The picker is a 3-mode UI (default / plan / auto), so the several native
+   * modes that trade prompts for autonomy collapse onto `auto` — which one
+   * is the user's choice. `dontAsk` stays hidden. The session adapter
+   * normalizes unknown ids to `default`.
    */
   getModeMapping(): ModeMapping {
     return {
@@ -357,7 +373,7 @@ export const ClaudeBackendDescriptor: ClaudeDescriptor = {
       canonical: {
         default: "default",
         plan: "plan",
-        auto: "bypassPermissions",
+        auto: resolveClaudeAutoModePermission(getSettings()),
       },
     };
   },

--- a/src/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting.stories.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting.stories.tsx
@@ -1,0 +1,27 @@
+import {
+  ClaudeAutoModePermissionSetting,
+  type ClaudeAutoModePermissionSettingProps,
+} from "@/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting";
+import type { Meta, StoryObj } from "@/lib/story";
+
+const meta = {
+  title: "Agent Mode/Claude Auto Mode Permission Setting",
+  component: ClaudeAutoModePermissionSetting,
+  args: {
+    value: "auto",
+    onChange: () => undefined,
+  },
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<ClaudeAutoModePermissionSettingProps>;
+export default meta;
+
+/** The default uses Claude's classifier and can still ask before risky actions. */
+export const Auto: StoryObj<ClaudeAutoModePermissionSettingProps> = {};
+
+export const AcceptEdits: StoryObj<ClaudeAutoModePermissionSettingProps> = {
+  args: { value: "acceptEdits" },
+};
+
+export const BypassPermissions: StoryObj<ClaudeAutoModePermissionSettingProps> = {
+  args: { value: "bypassPermissions" },
+};

--- a/src/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting.test.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { ClaudeAutoModePermissionSetting } from "@/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting";
+import React from "react";
+
+describe("ClaudeAutoModePermissionSetting", () => {
+  describe("ClaudeAutoModePermissionSetting()", () => {
+    it("shows every supported permission choice and reports the selected value", () => {
+      const onChange = jest.fn();
+      render(<ClaudeAutoModePermissionSetting value="auto" onChange={onChange} />);
+
+      const selector = screen.getByRole("combobox");
+      expect(selector).toEqual(expect.objectContaining({ value: "auto" }));
+      expect(screen.getByRole("option", { name: "Auto" })).toBeTruthy();
+      expect(screen.getByRole("option", { name: "Accept edits" })).toBeTruthy();
+      expect(screen.getByRole("option", { name: "Bypass permissions" })).toBeTruthy();
+
+      fireEvent.change(selector, { target: { value: "acceptEdits" } });
+
+      expect(onChange).toHaveBeenCalledWith("acceptEdits");
+    });
+  });
+});

--- a/src/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting.tsx
@@ -21,7 +21,7 @@ export const ClaudeAutoModePermissionSetting: React.FC<ClaudeAutoModePermissionS
   <SettingItem
     type="select"
     title="Auto mode permissions"
-    description="What the chat's Auto mode hands over. Auto lets Claude judge each request and still ask about risky ones, Accept edits auto-approves file edits only, and Bypass permissions skips every check."
+    description="Auto lets Claude judge each request and still ask about risky ones, Accept edits auto-approves file edits only, and Bypass permissions skips every check."
     value={value}
     options={AUTO_MODE_OPTIONS}
     onChange={(next) => onChange(next as ClaudeAutoModePermission)}

--- a/src/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting.tsx
+++ b/src/agentMode/backends/claude/ui/ClaudeAutoModePermissionSetting.tsx
@@ -1,0 +1,29 @@
+import { SettingItem } from "@/components/ui/setting-item";
+import type { ClaudeAutoModePermission } from "@/settings/model";
+import React from "react";
+
+const AUTO_MODE_OPTIONS: { label: string; value: ClaudeAutoModePermission }[] = [
+  { label: "Auto", value: "auto" },
+  { label: "Accept edits", value: "acceptEdits" },
+  { label: "Bypass permissions", value: "bypassPermissions" },
+];
+
+export interface ClaudeAutoModePermissionSettingProps {
+  value: ClaudeAutoModePermission;
+  onChange: (value: ClaudeAutoModePermission) => void;
+}
+
+/** Presentational settings row for choosing what Claude's canonical Auto mode permits. */
+export const ClaudeAutoModePermissionSetting: React.FC<ClaudeAutoModePermissionSettingProps> = ({
+  value,
+  onChange,
+}) => (
+  <SettingItem
+    type="select"
+    title="Auto mode permissions"
+    description="What the chat's Auto mode hands over. Auto lets Claude judge each request and still ask about risky ones, Accept edits auto-approves file edits only, and Bypass permissions skips every check."
+    value={value}
+    options={AUTO_MODE_OPTIONS}
+    onChange={(next) => onChange(next as ClaudeAutoModePermission)}
+  />
+);

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -947,6 +947,49 @@ describe("ClaudeSdkBackendProcess", () => {
     };
   }
 
+  describe("setSessionMode()", () => {
+    beforeEach(() => {
+      queryMock.mockReset();
+      createSdkMcpServerMock.mockClear();
+    });
+
+    function makeProcess(): ClaudeSdkBackendProcess {
+      return new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+    }
+
+    it.each(["default", "plan", "acceptEdits", "auto", "bypassPermissions"])(
+      "carries the %s permission mode into the next turn",
+      async (modeId) => {
+        queryMock.mockImplementation(() => makeQuery([resultMessage()]));
+        const proc = makeProcess();
+
+        const { sessionId } = await proc.newSession({ cwd: "/vault" });
+        proc.registerSessionHandler(sessionId, () => {});
+        await proc.setSessionMode({ sessionId, modeId });
+        await proc.prompt({ sessionId, prompt: [{ type: "text", text: "hi" }] });
+
+        const call = getPromptQueryCalls()[0][0] as { options: { permissionMode?: string } };
+        expect(call.options.permissionMode).toBe(modeId);
+      }
+    );
+
+    it("rejects a permission mode the SDK does not define", async () => {
+      const proc = makeProcess();
+
+      const { sessionId } = await proc.newSession({ cwd: "/vault" });
+
+      await expect(proc.setSessionMode({ sessionId, modeId: "dontAsk" })).rejects.toThrow(
+        "Unsupported mode dontAsk"
+      );
+    });
+  });
+
   describe("setProjectProfileProvider()", () => {
     beforeEach(() => {
       queryMock.mockReset();

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -228,15 +228,20 @@ export interface ClaudeSdkBackendProcessOptions {
 }
 
 /**
- * Static mode catalog for the Claude SDK. `acceptEdits` and `dontAsk`
- * are intentionally excluded from the picker.
+ * Static mode catalog for the Claude SDK — the native modes the descriptor is
+ * allowed to project onto Copilot's canonical picker. `acceptEdits`, `auto`,
+ * and `bypassPermissions` are all candidates for the `auto` pill; the
+ * descriptor's mapping picks one, so listing all three here does not widen the
+ * picker. `dontAsk` is intentionally excluded.
  */
 const STATIC_SDK_MODES: RawModeState = {
   currentModeId: "default",
   availableModes: [
     { id: "default", name: "Default" },
     { id: "plan", name: "Plan" },
-    { id: "bypassPermissions", name: "Auto" },
+    { id: "acceptEdits", name: "Accept Edits" },
+    { id: "auto", name: "Auto" },
+    { id: "bypassPermissions", name: "Bypass Permissions" },
   ],
 };
 
@@ -1025,6 +1030,7 @@ function canonicalModeToSdk(modeId: string): PermissionMode | null {
   switch (modeId) {
     case "default":
     case "acceptEdits":
+    case "auto":
     case "bypassPermissions":
     case "plan":
       return modeId;

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -1464,6 +1464,75 @@ describe("AgentSessionManager.applySelection", () => {
   });
 });
 
+describe("AgentSessionManager.applyMode", () => {
+  function buildModeManager(
+    getModeMapping: BackendDescriptor["getModeMapping"]
+  ): AgentSessionManager {
+    const descriptor = {
+      ...buildDescriptor(),
+      id: "claude",
+      displayName: "Claude",
+      getModeMapping,
+    } as BackendDescriptor;
+    const modelPreloader = {
+      getCachedModelCatalog: jest.fn(() => null),
+      getEffortCatalog: jest.fn(() => null),
+      preload: jest.fn(async () => undefined),
+      refresh: jest.fn(() => null),
+      subscribe: jest.fn(() => () => {}),
+      shutdown: jest.fn(),
+      clearCached: jest.fn(),
+      takeWarm: jest.fn(() => null),
+      getWarmProcs: jest.fn(() => []),
+    };
+    return new AgentSessionManager(
+      buildApp(),
+      buildPlugin() as unknown as ConstructorParameters<typeof AgentSessionManager>[1],
+      {
+        permissionPrompter: jest.fn(),
+        resolveDescriptor: (id) => (id === descriptor.id ? descriptor : undefined),
+        modelPreloader: modelPreloader as unknown as ConstructorParameters<
+          typeof AgentSessionManager
+        >[2]["modelPreloader"],
+      }
+    );
+  }
+
+  it("refreshes a state-independent native mapping before dispatch", async () => {
+    const manager = buildModeManager(() => ({
+      kind: "setMode",
+      canonical: { default: "default", plan: "plan", auto: "auto" },
+    }));
+    const session = await manager.createSession("claude");
+
+    await manager.applyMode("claude", "auto", {
+      kind: "setMode",
+      nativeId: "bypassPermissions",
+    });
+
+    expect(session.setMode).toHaveBeenCalledWith("auto");
+  });
+
+  it("uses the translated spec when the mapping requires live backend state", async () => {
+    const manager = buildModeManager((modeState) =>
+      modeState
+        ? {
+            kind: "setMode",
+            canonical: { default: "default", plan: "plan", auto: "full-access" },
+          }
+        : null
+    );
+    const session = await manager.createSession("claude");
+
+    await manager.applyMode("claude", "auto", {
+      kind: "setMode",
+      nativeId: "cached-auto",
+    });
+
+    expect(session.setMode).toHaveBeenCalledWith("cached-auto");
+  });
+});
+
 describe("AgentSessionManager default-model settings subscription", () => {
   // The per-session apply chain hops through several resolved promises
   // (prior link → session.ready → apply). Drain enough microtasks that a

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -2081,18 +2081,30 @@ export class AgentSessionManager {
 
   /**
    * Apply a canonical mode change against the active session. `spec` carries
-   * the native dispatch info (which ACP RPC + payload); `mode` is the canonical
-   * id to persist. After a successful apply, `mode` becomes the backend's sticky
-   * default so the next new conversation reopens in it — symmetric with
-   * `applySelection`. If the apply throws, no persistence occurs.
+   * the translated native dispatch info (which ACP RPC + payload). A descriptor
+   * whose mapping does not depend on live backend state gets one final lookup
+   * here so settings changes made after the picker rendered take effect on the
+   * click. After a successful apply, `mode` becomes the backend's sticky default
+   * so the next new conversation reopens in it — symmetric with `applySelection`.
+   * If the apply throws, no persistence occurs.
+   *
+   * @param backendId Backend expected to own the active session.
+   * @param mode Canonical mode selected in the picker.
+   * @param spec Translated fallback for mappings that require live backend state.
    */
   async applyMode(backendId: BackendId, mode: CopilotMode, spec: ModeApplySpec): Promise<void> {
     const session = this.getActiveSession();
     if (!session || session.backendId !== backendId) return;
-    if (spec.kind === "setMode") {
-      await session.setMode(spec.nativeId);
+    const latestMapping = this.resolveDescriptor(backendId).getModeMapping?.(null, null);
+    const latestNativeId =
+      latestMapping?.kind === "setMode" ? latestMapping.canonical[mode] : undefined;
+    const resolvedSpec: ModeApplySpec = latestNativeId
+      ? { kind: "setMode", nativeId: latestNativeId }
+      : spec;
+    if (resolvedSpec.kind === "setMode") {
+      await session.setMode(resolvedSpec.nativeId);
     } else {
-      await session.setConfigOption(spec.configId, spec.value);
+      await session.setConfigOption(resolvedSpec.configId, resolvedSpec.value);
     }
     await this.persistDefaultMode(backendId, mode);
   }

--- a/src/components/ui/ModePicker.stories.tsx
+++ b/src/components/ui/ModePicker.stories.tsx
@@ -1,0 +1,26 @@
+import { ModePicker } from "@/components/ui/ModePicker";
+import type { Meta, StoryObj } from "@/lib/story";
+import type { ComponentProps } from "react";
+
+type ModePickerProps = ComponentProps<typeof ModePicker>;
+
+const meta = {
+  title: "UI/Mode Picker",
+  component: ModePicker,
+  args: {
+    override: {
+      options: [
+        { label: "Default", value: "default" },
+        { label: "Plan", value: "plan" },
+        { label: "Auto", value: "auto" },
+      ],
+      value: "auto",
+      onChange: () => undefined,
+    },
+  },
+  parameters: { gallery: { host: "popover", layout: "padded" } },
+} satisfies Meta<ModePickerProps>;
+export default meta;
+
+/** Auto copy stays permission-neutral because each backend maps it differently. */
+export const Auto: StoryObj<ModePickerProps> = {};

--- a/src/components/ui/ModePicker.tsx
+++ b/src/components/ui/ModePicker.tsx
@@ -28,7 +28,7 @@ interface ModePickerProps {
 const MODE_DISPLAY: Record<CopilotMode, { label: string; description: string }> = {
   auto: {
     label: "Auto",
-    description: "Runs tools and edits files without asking.",
+    description: "Uses the agent's Auto permissions for tools and edits.",
   },
   plan: {
     label: "Plan",

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -397,32 +397,6 @@ describe("sanitizeEnvOverrides", () => {
   });
 });
 
-describe("sanitizeSettings - Claude auto-mode permission", () => {
-  function sanitizeClaudeSlice(autoModePermission: unknown): CopilotSettings {
-    return sanitizeSettings({
-      ...DEFAULT_SETTINGS,
-      agentMode: {
-        enabled: true,
-        byok: {},
-        activeBackend: "claude",
-        backends: { claude: { autoModePermission } },
-      },
-    } as unknown as CopilotSettings);
-  }
-
-  it("keeps a permission mode the Claude SDK understands", () => {
-    const sanitized = sanitizeClaudeSlice("acceptEdits");
-
-    expect(sanitized.agentMode.backends.claude?.autoModePermission).toBe("acceptEdits");
-  });
-
-  it("drops a permission mode outside the supported set so the descriptor default applies", () => {
-    const sanitized = sanitizeClaudeSlice("dontAsk");
-
-    expect(sanitized.agentMode.backends.claude?.autoModePermission).toBeUndefined();
-  });
-});
-
 describe("sanitizeSettings - legacy Miyo settings cleanup", () => {
   it("migrates legacy Miyo settings and strips obsolete remote vault path state", () => {
     const legacySettings = {
@@ -714,6 +688,30 @@ describe("sanitizeSettings - docProcessorBackend (v6 field)", () => {
 
 describe("model", () => {
   describe("sanitizeSettings()", () => {
+    function sanitizeClaudeSlice(autoModePermission: unknown): CopilotSettings {
+      return sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        agentMode: {
+          enabled: true,
+          byok: {},
+          activeBackend: "claude",
+          backends: { claude: { autoModePermission } },
+        },
+      } as unknown as CopilotSettings);
+    }
+
+    it("keeps a Claude auto permission mode the SDK understands", () => {
+      const sanitized = sanitizeClaudeSlice("acceptEdits");
+
+      expect(sanitized.agentMode.backends.claude?.autoModePermission).toBe("acceptEdits");
+    });
+
+    it("drops an unsupported Claude auto permission mode so the descriptor default applies", () => {
+      const sanitized = sanitizeClaudeSlice("dontAsk");
+
+      expect(sanitized.agentMode.backends.claude?.autoModePermission).toBeUndefined();
+    });
+
     it("defaults to the historical root when empty", () => {
       const out = sanitizeSettings({
         ...DEFAULT_SETTINGS,

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -397,6 +397,32 @@ describe("sanitizeEnvOverrides", () => {
   });
 });
 
+describe("sanitizeSettings - Claude auto-mode permission", () => {
+  function sanitizeClaudeSlice(autoModePermission: unknown): CopilotSettings {
+    return sanitizeSettings({
+      ...DEFAULT_SETTINGS,
+      agentMode: {
+        enabled: true,
+        byok: {},
+        activeBackend: "claude",
+        backends: { claude: { autoModePermission } },
+      },
+    } as unknown as CopilotSettings);
+  }
+
+  it("keeps a permission mode the Claude SDK understands", () => {
+    const sanitized = sanitizeClaudeSlice("acceptEdits");
+
+    expect(sanitized.agentMode.backends.claude?.autoModePermission).toBe("acceptEdits");
+  });
+
+  it("drops a permission mode outside the supported set so the descriptor default applies", () => {
+    const sanitized = sanitizeClaudeSlice("dontAsk");
+
+    expect(sanitized.agentMode.backends.claude?.autoModePermission).toBeUndefined();
+  });
+});
+
 describe("sanitizeSettings - legacy Miyo settings cleanup", () => {
   it("migrates legacy Miyo settings and strips obsolete remote vault path state", () => {
     const legacySettings = {

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -335,6 +335,13 @@ export interface CopilotSettings {
 }
 
 /**
+ * Native Claude permission mode that Copilot's canonical `auto` pill drives.
+ * `auto` lets Claude's classifier approve or deny each request, `acceptEdits`
+ * auto-approves file edits only, and `bypassPermissions` skips every check.
+ */
+export type ClaudeAutoModePermission = "acceptEdits" | "auto" | "bypassPermissions";
+
+/**
  * Settings slice owned by the Claude (Agent SDK) backend. The user-
  * installed `claude` CLI path lives at top-level `agentMode.claudeCli.path`
  * so the resolver can be reused independently of which Anthropic
@@ -345,6 +352,11 @@ export interface ClaudeBackendSettings {
   defaultModel?: ModelSelection | null;
   /** Sticky permission-mode preference (default/plan/auto). Unset = the agent's natural starting mode. */
   defaultMode?: CopilotMode | null;
+  /**
+   * Which native permission mode the `auto` pill switches Claude into. Unset =
+   * Claude's classifier-driven `auto`.
+   */
+  autoModePermission?: ClaudeAutoModePermission;
   /**
    * Opt-in: pass `thinking: { type: "enabled" }` to the SDK so the agent
    * surfaces reasoning chunks. Off by default (matches SDK default).
@@ -1335,12 +1347,28 @@ export function sanitizeEnvOverrides(raw: unknown): Record<string, string> | und
   return Object.keys(out).length > 0 ? out : undefined;
 }
 
+// Closed set mirroring the `ClaudeAutoModePermission` union; an unknown value
+// falls back to the descriptor's default rather than reaching the SDK, which
+// rejects permission modes it doesn't know.
+const CLAUDE_AUTO_MODE_PERMISSIONS: readonly ClaudeAutoModePermission[] = [
+  "acceptEdits",
+  "auto",
+  "bypassPermissions",
+];
+function sanitizeClaudeAutoModePermission(raw: unknown): ClaudeAutoModePermission | undefined {
+  return typeof raw === "string" &&
+    (CLAUDE_AUTO_MODE_PERMISSIONS as readonly string[]).includes(raw)
+    ? (raw as ClaudeAutoModePermission)
+    : undefined;
+}
+
 function sanitizeClaudeBackendSettings(raw: unknown): ClaudeBackendSettings {
   if (!raw || typeof raw !== "object") return {};
   const r = raw as Record<string, unknown>;
   return {
     defaultModel: sanitizeDefaultModel(r.defaultModel),
     defaultMode: sanitizeDefaultMode(r.defaultMode),
+    autoModePermission: sanitizeClaudeAutoModePermission(r.autoModePermission),
     enableThinking: typeof r.enableThinking === "boolean" ? r.enableThinking : undefined,
     envOverrides: sanitizeEnvOverrides(r.envOverrides),
   };


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#275

## Why

The mode picker beside the chat box offers Default, Plan and Auto, and the docs describe Auto as "the agent can work without individual approval prompts." For Claude that has meant exactly one thing: nothing is checked, ever. Claude itself has gentler settings — a classifier that approves routine requests and still stops to ask about risky ones, and an accept-edits level that auto-approves file writes and nothing else — but neither was reachable from Copilot. Someone who wanted to stop approving every single read had only one place to go, and it was the place where an agent can also delete notes and run shell commands unasked.

## What

Auto still means "hand some control over"; how much is now the user's call, on the Claude card under Agents settings.

| Auto mode permissions | What happens when Claude wants to use a tool |
| --- | --- |
| Auto (new default) | Claude judges the request: routine work proceeds, risky actions still ask |
| Accept edits | File edits apply without asking; everything else still asks |
| Bypass permissions | Nothing is checked — what Auto did before this PR |

Default and Plan are untouched, and the picker still shows three pills. Anyone who never opens the setting gets the classifier instead of the old bypass-everything behavior, so an agent in Auto will occasionally ask before something destructive where it previously asked nothing — worth a line in the release notes.

## Non goal

- Codex and OpenCode keep their current Auto mapping; this is the Claude card only.
- No new pills in the chat's mode picker — the extra permission levels are a setting, not modes.
- An open chat is not re-permissioned underneath the user: it keeps what it started with until Auto is picked again.
- Claude's deny-unless-pre-approved level stays unexposed; it has no matching pill.

## Screenshot

Claude card in Agents settings, same scroll position on both builds.

**Before** — the card goes straight from the model list to **Show extended thinking**; Auto is bypass-everything with nothing to configure.

<img width="901" height="708" alt="Claude settings card before this change" src="https://github.com/user-attachments/assets/3cf51720-8eef-4c79-ab86-e4bf57f53146" />

**After** — **Auto mode permissions** sits above **Show extended thinking**, defaulted to *Auto*.

<img width="901" height="708" alt="Claude settings card with the Auto mode permissions setting" src="https://github.com/user-attachments/assets/05f7ac54-05ed-4ccb-8f15-07a3c7fc10c2" />

The three levels a user can pick:

<img width="901" height="708" alt="Auto mode permissions dropdown open, showing Auto, Accept edits and Bypass permissions" src="https://github.com/user-attachments/assets/ca916912-8f85-4275-8324-8cbc062a3b7c" />

## Verification

1. Open Settings → Copilot → Agents → Claude. **Auto mode permissions** reads *Auto*, above **Show extended thinking**.
2. Start an agent chat on Claude and pick **Auto** in the mode picker. Ask for something routine ("summarize the note I have open") — it proceeds untouched. Ask for something destructive ("delete that note") — Claude asks before doing it.
3. Set the setting to **Bypass permissions**, start a new chat, pick **Auto**, and repeat the destructive request — no prompt this time.
4. Set it to **Accept edits**, start a new chat, pick **Auto**: an edit to a note applies without asking, while a shell command still asks.
5. Quit and reopen Obsidian, then reopen the setting — the choice is still there.
