### PR TITLE
[Codex effort] - Step 4: Use base-model descriptions

### DIFF
--- a/src/agentMode/backends/codex/descriptor.test.ts
+++ b/src/agentMode/backends/codex/descriptor.test.ts
@@ -1,6 +1,7 @@
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { translateBackendState } from "@/agentMode/session/translateBackendState";
 import type {
+  BackendConfigOption,
   BackendState,
   EffortOption,
   PermissionOption,
@@ -45,7 +46,7 @@ const SOL_EFFORTS: EffortOption[] = ["low", "medium", "high", "xhigh", "max", "u
 /**
  * Transcribed from a live `codex-acp@1.1.10` `session/new` reply: one entry per
  * (base model × effort) pair, addressed as `<base>[<effort>]`, with a different
- * effort set per model.
+ * effort set per model and a blurb describing that one effort.
  */
 const ADVERTISED_CATALOG: RawModelState = {
   currentModelId: "gpt-5.6-sol[high]",
@@ -53,15 +54,34 @@ const ADVERTISED_CATALOG: RawModelState = {
     ...["low", "medium", "high", "xhigh", "max", "ultra"].map((effort) => ({
       modelId: `gpt-5.6-sol[${effort}]`,
       name: `GPT-5.6-Sol (${effort})`,
-      description: "Latest frontier agentic coding model.",
+      description: `Latest frontier agentic coding model. Reasoning depth: ${effort}`,
     })),
     ...["low", "medium", "high", "xhigh"].map((effort) => ({
       modelId: `gpt-5.5[${effort}]`,
       name: `GPT-5.5 (${effort})`,
-      description: "Frontier model for complex coding, research, and real-world work.",
+      description: `Frontier model for complex coding. Reasoning depth: ${effort}`,
     })),
   ],
 };
+
+/** The `category:"model"` option the same reply carries, listing base models only. */
+const ADVERTISED_CONFIG_OPTIONS: BackendConfigOption[] = [
+  {
+    id: "model",
+    type: "select",
+    category: "model",
+    name: "Model",
+    currentValue: "gpt-5.6-sol",
+    options: [
+      {
+        value: "gpt-5.6-sol",
+        name: "GPT-5.6-Sol",
+        description: "Latest frontier agentic coding model.",
+      },
+      { value: "gpt-5.5", name: "GPT-5.5", description: "Frontier model for complex coding." },
+    ],
+  },
+];
 
 describe("descriptor", () => {
   describe("CodexBackendDescriptor", () => {
@@ -124,6 +144,19 @@ describe("descriptor", () => {
         // The same catalog gives gpt-5.5 no `max`/`ultra` — availability is
         // per-model, never a vocabulary Copilot applies uniformly.
         expect(efforts("gpt-5.5")).toEqual(["low", "medium", "high", "xhigh"]);
+      });
+
+      it("describes a collapsed row with the base model's blurb, not the first variant's", () => {
+        const state = translateBackendState(
+          { models: ADVERTISED_CATALOG, modes: null, configOptions: ADVERTISED_CONFIG_OPTIONS },
+          CodexBackendDescriptor
+        );
+
+        // Without the config option the row would inherit `[low]`'s blurb —
+        // "Fast responses with lighter reasoning" on a row spanning low→ultra.
+        expect(
+          state.model?.availableModels.find((e) => e.baseModelId === "gpt-5.6-sol")?.description
+        ).toBe("Latest frontier agentic coding model.");
       });
 
       it("reports the agent's active model and effort as the current selection", () => {

--- a/src/agentMode/backends/codex/descriptor.test.ts
+++ b/src/agentMode/backends/codex/descriptor.test.ts
@@ -18,7 +18,11 @@ const mockedResolveCodexAcpBinary = jest.mocked(resolveCodexAcpBinary);
 const mockedIsSupportedCodexAcpPath = jest.mocked(isSupportedCodexAcpPath);
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { translateBackendState } from "@/agentMode/session/translateBackendState";
-import type { BackendConfigOption, PermissionOption, RawModelState } from "@/agentMode/session/types";
+import type {
+  BackendConfigOption,
+  PermissionOption,
+  RawModelState,
+} from "@/agentMode/session/types";
 
 /**
  * Transcribed from a live `codex-acp@1.1.10` `session/new` reply: one entry per
@@ -161,14 +165,13 @@ describe("descriptor", () => {
         expect(efforts("gpt-5.5")).toEqual(["low", "medium", "high", "xhigh"]);
       });
 
-      it("describes a collapsed row with the base model's blurb, not the first variant's", () => {
+      it("describes a collapsed row with the base model's blurb, not the first variant's (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)", () => {
         const state = translateBackendState(
           { models: ADVERTISED_CATALOG, modes: null, configOptions: ADVERTISED_CONFIG_OPTIONS },
           CodexBackendDescriptor
         );
 
-        // Without the config option the row would inherit `[low]`'s blurb —
-        // "Fast responses with lighter reasoning" on a row spanning low→ultra.
+        // The base description must not imply low effort for every variant.
         expect(
           state.model?.availableModels.find((e) => e.baseModelId === "gpt-5.6-sol")?.description
         ).toBe("Latest frontier agentic coding model.");

--- a/src/agentMode/backends/codex/descriptor.test.ts
+++ b/src/agentMode/backends/codex/descriptor.test.ts
@@ -18,12 +18,12 @@ const mockedResolveCodexAcpBinary = jest.mocked(resolveCodexAcpBinary);
 const mockedIsSupportedCodexAcpPath = jest.mocked(isSupportedCodexAcpPath);
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import { translateBackendState } from "@/agentMode/session/translateBackendState";
-import type { PermissionOption, RawModelState } from "@/agentMode/session/types";
+import type { BackendConfigOption, PermissionOption, RawModelState } from "@/agentMode/session/types";
 
 /**
  * Transcribed from a live `codex-acp@1.1.10` `session/new` reply: one entry per
  * (base model × effort) pair, addressed as `<base>[<effort>]`, with a different
- * effort set per model.
+ * effort set per model and a blurb describing that one effort.
  */
 const ADVERTISED_CATALOG: RawModelState = {
   currentModelId: "gpt-5.6-sol[high]",
@@ -31,15 +31,34 @@ const ADVERTISED_CATALOG: RawModelState = {
     ...["low", "medium", "high", "xhigh", "max", "ultra"].map((effort) => ({
       modelId: `gpt-5.6-sol[${effort}]`,
       name: `GPT-5.6-Sol (${effort})`,
-      description: "Latest frontier agentic coding model.",
+      description: `Latest frontier agentic coding model. Reasoning depth: ${effort}`,
     })),
     ...["low", "medium", "high", "xhigh"].map((effort) => ({
       modelId: `gpt-5.5[${effort}]`,
       name: `GPT-5.5 (${effort})`,
-      description: "Frontier model for complex coding, research, and real-world work.",
+      description: `Frontier model for complex coding. Reasoning depth: ${effort}`,
     })),
   ],
 };
+
+/** The `category:"model"` option the same reply carries, listing base models only. */
+const ADVERTISED_CONFIG_OPTIONS: BackendConfigOption[] = [
+  {
+    id: "model",
+    type: "select",
+    category: "model",
+    name: "Model",
+    currentValue: "gpt-5.6-sol",
+    options: [
+      {
+        value: "gpt-5.6-sol",
+        name: "GPT-5.6-Sol",
+        description: "Latest frontier agentic coding model.",
+      },
+      { value: "gpt-5.5", name: "GPT-5.5", description: "Frontier model for complex coding." },
+    ],
+  },
+];
 
 describe("descriptor", () => {
   describe("detectCodexAcpPath()", () => {
@@ -140,6 +159,19 @@ describe("descriptor", () => {
         // The same catalog gives gpt-5.5 no `max`/`ultra` — availability is
         // per-model, never a vocabulary Copilot applies uniformly.
         expect(efforts("gpt-5.5")).toEqual(["low", "medium", "high", "xhigh"]);
+      });
+
+      it("describes a collapsed row with the base model's blurb, not the first variant's", () => {
+        const state = translateBackendState(
+          { models: ADVERTISED_CATALOG, modes: null, configOptions: ADVERTISED_CONFIG_OPTIONS },
+          CodexBackendDescriptor
+        );
+
+        // Without the config option the row would inherit `[low]`'s blurb —
+        // "Fast responses with lighter reasoning" on a row spanning low→ultra.
+        expect(
+          state.model?.availableModels.find((e) => e.baseModelId === "gpt-5.6-sol")?.description
+        ).toBe("Latest frontier agentic coding model.");
       });
 
       it("https://github.com/Brevilabs/obsidian-copilot-private/issues/219 reports the agent's active model and effort as the current selection", () => {

--- a/src/agentMode/session/translateBackendState.test.ts
+++ b/src/agentMode/session/translateBackendState.test.ts
@@ -243,6 +243,63 @@ describe("translateBackendState — name normalization + description", () => {
     const state = translateBackendState({ models, modes: null, configOptions: null }, desc);
     expect(findModelEntry(state.model, "gpt-x")?.name).toBe("GPT-x");
   });
+
+  it("prefers the base-model blurb from a model config option over a per-effort one", () => {
+    // codex publishes both channels: `models` carries a per-effort blurb on
+    // every variant, the config option carries the base model's own.
+    const models: RawModelState = {
+      currentModelId: "oai/sol/low",
+      availableModels: [
+        {
+          modelId: "oai/sol/low",
+          name: "Sol (low)",
+          description: "Frontier model. Lighter reasoning",
+        },
+        {
+          modelId: "oai/sol/max",
+          name: "Sol (max)",
+          description: "Frontier model. Maximum reasoning",
+        },
+      ],
+    };
+    const configOptions: BackendConfigOption[] = [
+      {
+        id: "model",
+        type: "select",
+        category: "model",
+        name: "Model",
+        currentValue: "oai/sol",
+        options: [{ value: "oai/sol", name: "Sol", description: "Frontier model." }],
+      },
+    ];
+    const state = translateBackendState(
+      { models, modes: null, configOptions },
+      suffixDescriptor({ showModelDescriptions: true })
+    );
+    expect(findModelEntry(state.model, "oai/sol")?.description).toBe("Frontier model.");
+  });
+
+  it("keeps the reported blurb for a model the config option doesn't list", () => {
+    const models: RawModelState = {
+      currentModelId: "m",
+      availableModels: [{ modelId: "m", name: "M", description: "reported blurb" }],
+    };
+    const configOptions: BackendConfigOption[] = [
+      {
+        id: "model",
+        type: "select",
+        category: "model",
+        name: "Model",
+        currentValue: "other",
+        options: [{ value: "other", name: "Other", description: "other blurb" }],
+      },
+    ];
+    const state = translateBackendState(
+      { models, modes: null, configOptions },
+      descriptor({ showModelDescriptions: true })
+    );
+    expect(findModelEntry(state.model, "m")?.description).toBe("reported blurb");
+  });
 });
 
 describe("translateBackendState — suffix-style backends", () => {

--- a/src/agentMode/session/translateBackendState.test.ts
+++ b/src/agentMode/session/translateBackendState.test.ts
@@ -346,6 +346,63 @@ describe("translateBackendState", () => {
         const state = translateBackendState({ models, modes: null, configOptions: null }, desc);
         expect(findModelEntry(state.model, "gpt-x")?.name).toBe("GPT-x");
       });
+
+      it("prefers the base-model blurb from a model config option over a per-effort one", () => {
+        // codex publishes both channels: `models` carries a per-effort blurb on
+        // every variant, the config option carries the base model's own.
+        const models: RawModelState = {
+          currentModelId: "oai/sol/low",
+          availableModels: [
+            {
+              modelId: "oai/sol/low",
+              name: "Sol (low)",
+              description: "Frontier model. Lighter reasoning",
+            },
+            {
+              modelId: "oai/sol/max",
+              name: "Sol (max)",
+              description: "Frontier model. Maximum reasoning",
+            },
+          ],
+        };
+        const configOptions: BackendConfigOption[] = [
+          {
+            id: "model",
+            type: "select",
+            category: "model",
+            name: "Model",
+            currentValue: "oai/sol",
+            options: [{ value: "oai/sol", name: "Sol", description: "Frontier model." }],
+          },
+        ];
+        const state = translateBackendState(
+          { models, modes: null, configOptions },
+          suffixDescriptor({ showModelDescriptions: true })
+        );
+        expect(findModelEntry(state.model, "oai/sol")?.description).toBe("Frontier model.");
+      });
+
+      it("keeps the reported blurb for a model the config option doesn't list", () => {
+        const models: RawModelState = {
+          currentModelId: "m",
+          availableModels: [{ modelId: "m", name: "M", description: "reported blurb" }],
+        };
+        const configOptions: BackendConfigOption[] = [
+          {
+            id: "model",
+            type: "select",
+            category: "model",
+            name: "Model",
+            currentValue: "other",
+            options: [{ value: "other", name: "Other", description: "other blurb" }],
+          },
+        ];
+        const state = translateBackendState(
+          { models, modes: null, configOptions },
+          descriptor({ showModelDescriptions: true })
+        );
+        expect(findModelEntry(state.model, "m")?.description).toBe("reported blurb");
+      });
     });
 
     describe("suffix-style backends", () => {

--- a/src/agentMode/session/translateBackendState.test.ts
+++ b/src/agentMode/session/translateBackendState.test.ts
@@ -347,7 +347,7 @@ describe("translateBackendState", () => {
         expect(findModelEntry(state.model, "gpt-x")?.name).toBe("GPT-x");
       });
 
-      it("prefers the base-model blurb from a model config option over a per-effort one", () => {
+      it("prefers the base-model blurb from a model config option over a per-effort one (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)", () => {
         // codex publishes both channels: `models` carries a per-effort blurb on
         // every variant, the config option carries the base model's own.
         const models: RawModelState = {
@@ -382,7 +382,34 @@ describe("translateBackendState", () => {
         expect(findModelEntry(state.model, "oai/sol")?.description).toBe("Frontier model.");
       });
 
-      it("keeps the reported blurb for a model the config option doesn't list", () => {
+      it.each([true, false])(
+        "respects description visibility (%s) for a current model missing from the catalog (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)",
+        (showModelDescriptions) => {
+          const models: RawModelState = {
+            currentModelId: "oai/sol/max",
+            availableModels: [],
+          };
+          const configOptions: BackendConfigOption[] = [
+            {
+              id: "model",
+              type: "select",
+              category: "model",
+              name: "Model",
+              currentValue: "oai/sol",
+              options: [{ value: "oai/sol", name: "Sol", description: "Frontier model." }],
+            },
+          ];
+          const state = translateBackendState(
+            { models, modes: null, configOptions },
+            suffixDescriptor({ showModelDescriptions })
+          );
+          const entry = findModelEntry(state.model, "oai/sol");
+          expect(entry).toBeDefined();
+          expect(entry?.description).toBe(showModelDescriptions ? "Frontier model." : undefined);
+        }
+      );
+
+      it("keeps the reported blurb for a model the config option doesn't list (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)", () => {
         const models: RawModelState = {
           currentModelId: "m",
           availableModels: [{ modelId: "m", name: "M", description: "reported blurb" }],

--- a/src/agentMode/session/translateBackendState.ts
+++ b/src/agentMode/session/translateBackendState.ts
@@ -76,6 +76,9 @@ function translateModel(
   const fromConfig = inputs.models ? null : modelStateFromConfigOption(inputs.configOptions);
   const modelState = inputs.models ?? fromConfig?.state ?? null;
   if (!modelState) return null;
+  // Only when `models` won: where it IS the catalog, every group already
+  // carries the option's own description.
+  const baseDescriptions = inputs.models ? baseModelDescriptions(inputs.configOptions) : null;
   const effortFromConfig = fromConfig ? effortConfigOption(inputs.configOptions) : null;
   const apply: ModelApplySpec = fromConfig
     ? {
@@ -133,7 +136,9 @@ function translateModel(
     ),
     // Only backends that opt in surface their per-model blurb; others (opencode)
     // would just add noisy/duplicative lines, so the field is dropped here.
-    description: descriptor.showModelDescriptions ? g.description : undefined,
+    description: descriptor.showModelDescriptions
+      ? (baseDescriptions?.get(g.baseModelId) ?? g.description)
+      : undefined,
     provider: g.provider,
     effortOptions: deriveEffortOptions(g, descriptor),
   }));
@@ -215,6 +220,30 @@ function modelStateFromConfigOption(
     state: { currentModelId: String(opt.currentValue), availableModels },
     configId: opt.id,
   };
+}
+
+/**
+ * Base-model blurbs from a `category:"model"` config option, keyed by model id,
+ * or `null` when the agent publishes none.
+ *
+ * For a backend that advertises both channels (codex), the `models` catalog
+ * holds one entry per (model × effort) pair and each blurb describes that
+ * effort — so a collapsed row would inherit whichever variant came first
+ * ("…Fast responses with lighter reasoning" on a row spanning low→ultra). The
+ * config option lists base models, so its description is the one that describes
+ * the whole row. Names need no such overlay: `stripEffortSuffix` already
+ * resolves them from the variants themselves.
+ */
+function baseModelDescriptions(
+  configOptions: BackendConfigOption[] | null
+): Map<string, string> | null {
+  const fromConfig = modelStateFromConfigOption(configOptions);
+  if (!fromConfig) return null;
+  const byModelId = new Map<string, string>();
+  for (const model of fromConfig.state.availableModels) {
+    if (model.description) byModelId.set(model.modelId, model.description);
+  }
+  return byModelId.size > 0 ? byModelId : null;
 }
 
 function effortConfigOption(

--- a/src/agentMode/session/translateBackendState.ts
+++ b/src/agentMode/session/translateBackendState.ts
@@ -77,6 +77,14 @@ function translateModel(
   const fromConfig = inputs.models ? null : modelStateFromConfigOption(inputs.configOptions);
   const modelState = inputs.models ?? fromConfig?.state ?? null;
   if (!modelState) return null;
+  // Dedicated catalogs describe effort variants; the model option describes
+  // the whole model. https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+  const baseDescriptions = new Map<string, string>();
+  if (inputs.models && configModel) {
+    for (const model of configModel.state.availableModels) {
+      if (model.description) baseDescriptions.set(model.modelId, model.description);
+    }
+  }
   const effortFromConfig = fromConfig ? effortConfigOption(inputs.configOptions) : null;
   const apply: ModelApplySpec = fromConfig
     ? {
@@ -134,7 +142,9 @@ function translateModel(
     ),
     // Only backends that opt in surface their per-model blurb; others (opencode)
     // would just add noisy/duplicative lines, so the field is dropped here.
-    description: descriptor.showModelDescriptions ? g.description : undefined,
+    description: descriptor.showModelDescriptions
+      ? (baseDescriptions.get(g.baseModelId) ?? g.description)
+      : undefined,
     provider: g.provider,
     effortOptions: deriveEffortOptions(g, descriptor),
   }));

--- a/src/agentMode/session/translateBackendState.ts
+++ b/src/agentMode/session/translateBackendState.ts
@@ -74,7 +74,8 @@ function translateModel(
   // Newer opencode (≥ 1.15.13) dropped that field and advertises its catalog
   // only through a generic `category:"model"` select config option, switched
   // via `session/set_config_option` instead of `session/set_model`.
-  const fromConfig = inputs.models ? null : modelStateFromConfigOption(inputs.configOptions);
+  const configModel = modelStateFromConfigOption(inputs.configOptions);
+  const fromConfig = inputs.models ? null : configModel;
   const modelState = inputs.models ?? fromConfig?.state ?? null;
   if (!modelState) return null;
   // Dedicated catalogs describe effort variants; the model option describes
@@ -163,6 +164,11 @@ function translateModel(
     currentEntry = {
       baseModelId: currentBaseId,
       name: normalizeName(currentBaseId, descriptor),
+      // A stale catalog must not hide the active model's available description.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+      description: descriptor.showModelDescriptions
+        ? baseDescriptions.get(currentBaseId)
+        : undefined,
       provider: decodedCurrent.provider,
       effortOptions: synthEffortOptions,
     };


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#219

## Why

A collapsed Codex row can inherit the first effort variant's description, such as "lighter reasoning", even when the row offers much higher effort levels.

## What

Prefer the adapter's base-model description for a collapsed row. If that description is unavailable, keep the catalog description. An active model missing from a stale catalog still receives its available base-model description. Model names, effort choices, and selection behavior stay the same.

## Non goal

Change model names, row grouping, effort dispatch, or saved settings.

## Screenshot

No new rendered capture. This publication pass does not load a test vault. Translator and descriptor fixtures verify the displayed description and fallback; verify the actual picker below.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Translator and descriptor tests cover the preferred description and fallback. |
| A defect would fail CI or be obvious on first use | ✅ | A wrong description is tested and visible in the picker. |
| A revert fully restores prior state, including persisted data | ✅ | Display-time derivation writes no persisted data. |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No authentication or input validation changes. |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No wire or saved-data contract changes. |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Synchronous description lookup only. |
| No hot-path behavior lacks deterministic coverage | ✅ | Preferred and fallback descriptions have deterministic coverage. |
| No new dependency | ✅ | Dependencies are unchanged. |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Remaining visual verification is confined to model rows. |

Review: follow Verification steps 1–2 and confirm CI is green.

## Verification

1. Load this branch in a test vault with Codex installed. Open the model picker and find a model offering several efforts. Its description should describe the base model without a clause specific to the first effort.
2. Confirm the same description in Settings → Agent → Codex. Row counts and effort choices should remain unchanged.
