### PR TITLE
Preserve OpenCode literal model IDs and saved selections

### DIFF
--- a/src/agentMode/agentModelDiscovery.test.ts
+++ b/src/agentMode/agentModelDiscovery.test.ts
@@ -1,3 +1,5 @@
+import { getSettings, updateAgentModeBackendFields, type CopilotSettings } from "@/settings/model";
+import { normalizeOpencodeSelection } from "@/agentMode/backends/opencode/opencodeModelMigration";
 /**
  * Tests for the M3 probe-settle discovery orchestrator.
  *
@@ -23,6 +25,11 @@ import { waitFor } from "@testing-library/react";
 
 let mockDescriptors: BackendDescriptor[] = [];
 
+jest.mock("@/settings/model", () => ({
+  getSettings: jest.fn(() => ({ agentMode: {} })),
+  updateAgentModeBackendFields: jest.fn(),
+}));
+
 jest.mock("@/logger", () => ({
   logInfo: jest.fn(),
   logWarn: jest.fn(),
@@ -31,6 +38,8 @@ jest.mock("@/logger", () => ({
 
 jest.mock("@/agentMode", () => ({
   listBackendDescriptors: () => mockDescriptors,
+  legacyOpencodeModelIds: jest.requireActual("@/agentMode/backends/opencode/opencodeModelMigration")
+    .legacyOpencodeModelIds,
   // Real-equivalent pure helpers.
   partitionOpencodeOnlyWireIds: (reported: string[], managed: Set<string>) =>
     reported.filter((w) => !managed.has(w.split("/")[0])),
@@ -181,6 +190,8 @@ async function waitForDiscoveryLog(message: string): Promise<void> {
 beforeEach(() => {
   mockDescriptors = [];
   mockedLogInfo.mockClear();
+  jest.mocked(getSettings).mockReturnValue({ agentMode: {} } as CopilotSettings);
+  jest.mocked(updateAgentModeBackendFields).mockClear();
 });
 
 // ---------------------------------------------------------------------------
@@ -189,6 +200,50 @@ beforeEach(() => {
 
 describe("agentModelDiscovery", () => {
   describe("wireAgentModelDiscovery()", () => {
+    it("repairs the saved default synchronously and passes legacy aliases before discovery can remove curated rows (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)", async () => {
+      jest.mocked(getSettings).mockReturnValue({
+        agentMode: {
+          backends: {
+            opencode: {
+              defaultModel: { baseModelId: "anthropic/vendor", effort: "low" },
+            },
+          },
+        },
+      } as CopilotSettings);
+      mockDescriptors = [
+        makeDescriptor({
+          id: "opencode",
+          wire: { ...identityWire, normalizeSelection: normalizeOpencodeSelection },
+        }),
+      ];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      a.agentProviders.push({
+        providerId: "opencode-provider",
+        origin: { kind: "agent", agentType: "opencode" },
+      });
+      m.setCatalog(
+        "opencode",
+        catalogWithModels(["anthropic/vendor/high", "anthropic/vendor/low"])
+      );
+      const unsubscribe = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      expect(updateAgentModeBackendFields).toHaveBeenCalledWith("opencode", {
+        defaultModel: { baseModelId: "anthropic/vendor/low", effort: null },
+      });
+      expect(a.syncAgentModels).not.toHaveBeenCalled();
+      await waitFor(() =>
+        expect(a.syncAgentModels).toHaveBeenCalledWith(
+          expect.objectContaining({
+            legacyModelIds: new Map([
+              ["anthropic/vendor/high", "anthropic/vendor"],
+              ["anthropic/vendor/low", "anthropic/vendor"],
+            ]),
+          })
+        )
+      );
+      unsubscribe();
+    });
+
     it("first enrollment registers a provider and enrolls reported models", async () => {
       mockDescriptors = [makeDescriptor({ id: "codex" })];
       const m = makeManagerFake();

--- a/src/agentMode/agentModelDiscovery.test.ts
+++ b/src/agentMode/agentModelDiscovery.test.ts
@@ -187,320 +187,326 @@ beforeEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("wireAgentModelDiscovery", () => {
-  it("first enrollment registers a provider and enrolls reported models", async () => {
-    mockDescriptors = [makeDescriptor({ id: "codex" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    m.setCatalog("codex", catalogWithModels(["gpt-5", "gpt-5.5"]));
+describe("agentModelDiscovery", () => {
+  describe("wireAgentModelDiscovery()", () => {
+    it("first enrollment registers a provider and enrolls reported models", async () => {
+      mockDescriptors = [makeDescriptor({ id: "codex" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      m.setCatalog("codex", catalogWithModels(["gpt-5", "gpt-5.5"]));
 
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("first enrollment for codex");
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("first enrollment for codex");
 
-    expect(a.registerAgentProvider).toHaveBeenCalledTimes(1);
-    expect(a.registerAgentProvider.mock.calls[0][0]).toMatchObject({
-      agentType: "codex",
-      providerType: "openai-compatible",
-      wireModelIds: ["gpt-5", "gpt-5.5"],
-    });
-    expect(a.syncAgentModels).not.toHaveBeenCalled();
-    expect(a.setEnabledModels).not.toHaveBeenCalled();
-    unsub();
-  });
-
-  it("omits a reported empty name from fallbackDisplayNames (never overwrites with '')", async () => {
-    mockDescriptors = [makeDescriptor({ id: "codex" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    m.setCatalog("codex", {
-      availableModels: [
-        { baseModelId: "gpt-5", name: "GPT-5", provider: null, effortOptions: [] },
-        { baseModelId: "blank", name: "", provider: null, effortOptions: [] },
-      ],
+      expect(a.registerAgentProvider).toHaveBeenCalledTimes(1);
+      expect(a.registerAgentProvider.mock.calls[0][0]).toMatchObject({
+        agentType: "codex",
+        providerType: "openai-compatible",
+        wireModelIds: ["gpt-5", "gpt-5.5"],
+      });
+      expect(a.syncAgentModels).not.toHaveBeenCalled();
+      expect(a.setEnabledModels).not.toHaveBeenCalled();
+      unsub();
     });
 
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("first enrollment for codex");
+    it("omits a reported empty name from fallbackDisplayNames (never overwrites with '')", async () => {
+      mockDescriptors = [makeDescriptor({ id: "codex" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      m.setCatalog("codex", {
+        availableModels: [
+          { baseModelId: "gpt-5", name: "GPT-5", provider: null, effortOptions: [] },
+          { baseModelId: "blank", name: "", provider: null, effortOptions: [] },
+        ],
+      });
 
-    // "blank" is still enrolled (it's a real wire id) but contributes no
-    // display-name fallback, so resolution falls back to catalog/id instead.
-    expect(a.registerAgentProvider.mock.calls[0][0].fallbackDisplayNames).toEqual({
-      "gpt-5": "GPT-5",
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("first enrollment for codex");
+
+      // "blank" is still enrolled (it's a real wire id) but contributes no
+      // display-name fallback, so resolution falls back to catalog/id instead.
+      expect(a.registerAgentProvider.mock.calls[0][0].fallbackDisplayNames).toEqual({
+        "gpt-5": "GPT-5",
+      });
+      unsub();
     });
-    unsub();
-  });
 
-  it("leaves autoEnrollModelIds unset for codex so its whole catalog starts enabled", async () => {
-    mockDescriptors = [makeDescriptor({ id: "codex" })];
-    const a = makeApiFake();
-    const catalog = catalogWithModels(["gpt-5", "gpt-5.5"]);
-    const manager = {
-      getCachedModelCatalog: jest.fn(() => catalog),
-      subscribeModelCache: jest.fn(() => () => {}),
-    } as unknown as AgentSessionManager;
+    it("leaves autoEnrollModelIds unset for codex so its whole catalog starts enabled", async () => {
+      mockDescriptors = [makeDescriptor({ id: "codex" })];
+      const a = makeApiFake();
+      const catalog = catalogWithModels(["gpt-5", "gpt-5.5"]);
+      const manager = {
+        getCachedModelCatalog: jest.fn(() => catalog),
+        subscribeModelCache: jest.fn(() => () => {}),
+      } as unknown as AgentSessionManager;
 
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), manager);
-    await waitForDiscoveryLog("first enrollment for codex");
-    expect(a.registerAgentProvider.mock.calls[0][0].wireModelIds).toEqual(["gpt-5", "gpt-5.5"]);
-    expect(a.registerAgentProvider.mock.calls[0][0].autoEnrollModelIds).toBeUndefined();
-    expect(a.setEnabledModels).not.toHaveBeenCalled();
-    unsub();
-  });
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), manager);
+      await waitForDiscoveryLog("first enrollment for codex");
+      expect(a.registerAgentProvider.mock.calls[0][0].wireModelIds).toEqual(["gpt-5", "gpt-5.5"]);
+      expect(a.registerAgentProvider.mock.calls[0][0].autoEnrollModelIds).toBeUndefined();
+      expect(a.setEnabledModels).not.toHaveBeenCalled();
+      unsub();
+    });
 
-  it("enrolls every remaining OpenCode model after managed-provider suppression", async () => {
-    mockDescriptors = [makeDescriptor({ id: "opencode" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    a.byok.push({ origin: { kind: "byok", catalogProviderId: "anthropic" } });
-    m.setCatalog(
-      "opencode",
-      catalogWithModels([
-        "anthropic/claude-sonnet-4-5",
+    it("enrolls every remaining OpenCode model after managed-provider suppression", async () => {
+      mockDescriptors = [makeDescriptor({ id: "opencode" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      a.byok.push({ origin: { kind: "byok", catalogProviderId: "anthropic" } });
+      m.setCatalog(
+        "opencode",
+        catalogWithModels([
+          "anthropic/claude-sonnet-4-5",
+          "opencode/big-pickle",
+          "opencode/small-gherkin",
+        ])
+      );
+
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("first enrollment for opencode");
+
+      expect(a.registerAgentProvider.mock.calls[0][0].wireModelIds).toEqual([
         "opencode/big-pickle",
         "opencode/small-gherkin",
-      ])
-    );
+      ]);
+      expect(a.setEnabledModels).not.toHaveBeenCalled();
+      unsub();
+    });
 
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("first enrollment for opencode");
+    it("enables only the first three OpenCode models while enrolling the rest", async () => {
+      mockDescriptors = [makeDescriptor({ id: "opencode" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      m.setCatalog(
+        "opencode",
+        catalogWithModels([
+          "opencode/big-pickle",
+          "opencode/claude-fable-5",
+          "opencode/claude-haiku-4-5",
+          "opencode/claude-opus-4-1",
+          "opencode/small-gherkin",
+        ])
+      );
 
-    expect(a.registerAgentProvider.mock.calls[0][0].wireModelIds).toEqual([
-      "opencode/big-pickle",
-      "opencode/small-gherkin",
-    ]);
-    expect(a.setEnabledModels).not.toHaveBeenCalled();
-    unsub();
-  });
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("first enrollment for opencode");
 
-  it("enables only the first three OpenCode models while enrolling the rest", async () => {
-    mockDescriptors = [makeDescriptor({ id: "opencode" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    m.setCatalog(
-      "opencode",
-      catalogWithModels([
+      const input = a.registerAgentProvider.mock.calls[0][0];
+      // Every model is still enrolled, so the curation UI can list all five.
+      expect(input.wireModelIds).toHaveLength(5);
+      expect(input.autoEnrollModelIds).toEqual([
         "opencode/big-pickle",
         "opencode/claude-fable-5",
         "opencode/claude-haiku-4-5",
-        "opencode/claude-opus-4-1",
-        "opencode/small-gherkin",
-      ])
-    );
-
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("first enrollment for opencode");
-
-    const input = a.registerAgentProvider.mock.calls[0][0];
-    // Every model is still enrolled, so the curation UI can list all five.
-    expect(input.wireModelIds).toHaveLength(5);
-    expect(input.autoEnrollModelIds).toEqual([
-      "opencode/big-pickle",
-      "opencode/claude-fable-5",
-      "opencode/claude-haiku-4-5",
-    ]);
-    unsub();
-  });
-
-  it("enables every OpenCode model when fewer than three survive suppression", async () => {
-    mockDescriptors = [makeDescriptor({ id: "opencode" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    m.setCatalog("opencode", catalogWithModels(["opencode/big-pickle"]));
-
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("first enrollment for opencode");
-
-    expect(a.registerAgentProvider.mock.calls[0][0].autoEnrollModelIds).toEqual([
-      "opencode/big-pickle",
-    ]);
-    unsub();
-  });
-
-  it("does NOT call setEnabledModels when a single model is reported (no churn)", async () => {
-    mockDescriptors = [makeDescriptor({ id: "codex" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    // One reported model is already the entire enabled set → no narrowing.
-    m.setCatalog("codex", catalogWithModels(["gpt-5"]));
-
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("first enrollment for codex");
-
-    expect(a.setEnabledModels).not.toHaveBeenCalled();
-    unsub();
-  });
-
-  it("recurring probe (provider already exists) takes the sync branch, no register, no re-seed", async () => {
-    mockDescriptors = [makeDescriptor({ id: "codex" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    m.setCatalog("codex", catalogWithModels(["gpt-5"]));
-
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("first enrollment for codex");
-
-    // A new probe reports a changed list; provider now exists → sync only.
-    m.setCatalog("codex", catalogWithModels(["gpt-5", "gpt-5.5"]));
-    m.emit();
-    await waitFor(() => expect(a.syncAgentModels).toHaveBeenCalledTimes(1));
-
-    expect(a.registerAgentProvider).toHaveBeenCalledTimes(1);
-    expect(a.syncAgentModels).toHaveBeenCalledTimes(1);
-    expect(a.syncAgentModels.mock.calls[0][0]).toEqual({
-      agentType: "codex",
-      wireModelIds: ["gpt-5", "gpt-5.5"],
-      fallbackDisplayNames: { "gpt-5": "gpt-5", "gpt-5.5": "gpt-5.5" },
-      fallbackDescriptions: {},
+      ]);
+      unsub();
     });
-    // Discovery never narrows the enabled set on either branch.
-    expect(a.setEnabledModels).not.toHaveBeenCalled();
-    unsub();
-  });
 
-  it("re-probe with an unchanged list is a no-op (no register, no sync)", async () => {
-    mockDescriptors = [makeDescriptor({ id: "codex" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    m.setCatalog("codex", catalogWithModels(["gpt-5"]));
+    it("enables every OpenCode model when fewer than three survive suppression", async () => {
+      mockDescriptors = [makeDescriptor({ id: "opencode" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      m.setCatalog("opencode", catalogWithModels(["opencode/big-pickle"]));
 
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("first enrollment for codex");
-    a.syncAgentModels.mockClear();
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("first enrollment for opencode");
 
-    // Same list re-reported.
-    m.emit();
-
-    expect(a.syncAgentModels).not.toHaveBeenCalled();
-    unsub();
-  });
-
-  it("opencode suppresses BYOK-managed models and enrolls only opencode-only ids", async () => {
-    mockDescriptors = [makeDescriptor({ id: "opencode" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    a.byok.push({ origin: { kind: "byok", catalogProviderId: "anthropic" } });
-    m.setCatalog(
-      "opencode",
-      catalogWithModels(["anthropic/claude-sonnet-4-5", "opencode/big-pickle"])
-    );
-
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("first enrollment for opencode");
-
-    // anthropic/* is suppressed (BYOK-managed); only opencode/* enrolls.
-    expect(a.registerAgentProvider.mock.calls[0][0].wireModelIds).toEqual(["opencode/big-pickle"]);
-    unsub();
-  });
-
-  it("does NOT register/sync on a settled-but-empty probe (transient/degraded)", async () => {
-    mockDescriptors = [makeDescriptor({ id: "codex" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    // A settled state that reports zero models (distinct from null/no-state).
-    m.setCatalog("codex", catalogWithModels([]));
-
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("empty model list for codex");
-
-    expect(a.registerAgentProvider).not.toHaveBeenCalled();
-    expect(a.syncAgentModels).not.toHaveBeenCalled();
-    unsub();
-  });
-
-  it("does NOT cascade-remove when opencode's reported list fully suppresses to empty", async () => {
-    // Regression: a BYOK-only user whose opencode probe reports only
-    // BYOK-managed (anthropic/*) ids. After suppression the list is empty;
-    // running syncAgentModels({ wireModelIds: [] }) on the existing provider
-    // would cascade-REMOVE every prior opencode agent model. Guard against it.
-    mockDescriptors = [makeDescriptor({ id: "opencode" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    // An opencode agent provider already exists (prior enrollment).
-    a.agentProviders.push({
-      providerId: "prov-opencode",
-      origin: { kind: "agent", agentType: "opencode" },
+      expect(a.registerAgentProvider.mock.calls[0][0].autoEnrollModelIds).toEqual([
+        "opencode/big-pickle",
+      ]);
+      unsub();
     });
-    a.byok.push({ origin: { kind: "byok", catalogProviderId: "anthropic" } });
-    m.setCatalog("opencode", catalogWithModels(["anthropic/claude-sonnet-4-5"]));
 
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    await waitForDiscoveryLog("empty model list for opencode");
+    it("does NOT call setEnabledModels when a single model is reported (no churn)", async () => {
+      mockDescriptors = [makeDescriptor({ id: "codex" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      // One reported model is already the entire enabled set → no narrowing.
+      m.setCatalog("codex", catalogWithModels(["gpt-5"]));
 
-    // All reported ids are suppressed → empty list → no destructive sync.
-    expect(a.syncAgentModels).not.toHaveBeenCalled();
-    expect(a.registerAgentProvider).not.toHaveBeenCalled();
-    unsub();
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("first enrollment for codex");
+
+      expect(a.setEnabledModels).not.toHaveBeenCalled();
+      unsub();
+    });
+
+    it("recurring probe (provider already exists) takes the sync branch, no register, no re-seed", async () => {
+      mockDescriptors = [makeDescriptor({ id: "codex" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      m.setCatalog("codex", catalogWithModels(["gpt-5"]));
+
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("first enrollment for codex");
+
+      // A new probe reports a changed list; provider now exists → sync only.
+      m.setCatalog("codex", catalogWithModels(["gpt-5", "gpt-5.5"]));
+      m.emit();
+      await waitFor(() => expect(a.syncAgentModels).toHaveBeenCalledTimes(1));
+
+      expect(a.registerAgentProvider).toHaveBeenCalledTimes(1);
+      expect(a.syncAgentModels).toHaveBeenCalledTimes(1);
+      expect(a.syncAgentModels.mock.calls[0][0]).toEqual({
+        agentType: "codex",
+        wireModelIds: ["gpt-5", "gpt-5.5"],
+        fallbackDisplayNames: { "gpt-5": "gpt-5", "gpt-5.5": "gpt-5.5" },
+        fallbackDescriptions: {},
+      });
+      // Discovery never narrows the enabled set on either branch.
+      expect(a.setEnabledModels).not.toHaveBeenCalled();
+      unsub();
+    });
+
+    it("re-probe with an unchanged list is a no-op (no register, no sync)", async () => {
+      mockDescriptors = [makeDescriptor({ id: "codex" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      m.setCatalog("codex", catalogWithModels(["gpt-5"]));
+
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("first enrollment for codex");
+      a.syncAgentModels.mockClear();
+
+      // Same list re-reported.
+      m.emit();
+
+      expect(a.syncAgentModels).not.toHaveBeenCalled();
+      unsub();
+    });
+
+    it("opencode suppresses BYOK-managed models and enrolls only opencode-only ids", async () => {
+      mockDescriptors = [makeDescriptor({ id: "opencode" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      a.byok.push({ origin: { kind: "byok", catalogProviderId: "anthropic" } });
+      m.setCatalog(
+        "opencode",
+        catalogWithModels(["anthropic/claude-sonnet-4-5", "opencode/big-pickle"])
+      );
+
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("first enrollment for opencode");
+
+      // anthropic/* is suppressed (BYOK-managed); only opencode/* enrolls.
+      expect(a.registerAgentProvider.mock.calls[0][0].wireModelIds).toEqual([
+        "opencode/big-pickle",
+      ]);
+      unsub();
+    });
+
+    it("does NOT register/sync on a settled-but-empty probe (transient/degraded)", async () => {
+      mockDescriptors = [makeDescriptor({ id: "codex" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      // A settled state that reports zero models (distinct from null/no-state).
+      m.setCatalog("codex", catalogWithModels([]));
+
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("empty model list for codex");
+
+      expect(a.registerAgentProvider).not.toHaveBeenCalled();
+      expect(a.syncAgentModels).not.toHaveBeenCalled();
+      unsub();
+    });
+
+    it("does NOT cascade-remove when opencode's reported list fully suppresses to empty", async () => {
+      // Regression: a BYOK-only user whose opencode probe reports only
+      // BYOK-managed (anthropic/*) ids. After suppression the list is empty;
+      // running syncAgentModels({ wireModelIds: [] }) on the existing provider
+      // would cascade-REMOVE every prior opencode agent model. Guard against it.
+      mockDescriptors = [makeDescriptor({ id: "opencode" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      // An opencode agent provider already exists (prior enrollment).
+      a.agentProviders.push({
+        providerId: "prov-opencode",
+        origin: { kind: "agent", agentType: "opencode" },
+      });
+      a.byok.push({ origin: { kind: "byok", catalogProviderId: "anthropic" } });
+      m.setCatalog("opencode", catalogWithModels(["anthropic/claude-sonnet-4-5"]));
+
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      await waitForDiscoveryLog("empty model list for opencode");
+
+      // All reported ids are suppressed → empty list → no destructive sync.
+      expect(a.syncAgentModels).not.toHaveBeenCalled();
+      expect(a.registerAgentProvider).not.toHaveBeenCalled();
+      unsub();
+    });
+
+    it("ignores a backend that has not reported a model catalog yet", () => {
+      mockDescriptors = [makeDescriptor({ id: "codex" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+      m.setCatalog("codex", null);
+
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+
+      expect(a.registerAgentProvider).not.toHaveBeenCalled();
+      expect(a.syncAgentModels).not.toHaveBeenCalled();
+      unsub();
+    });
+
+    it("after unsubscribe, further cache emits do nothing", () => {
+      mockDescriptors = [makeDescriptor({ id: "codex" })];
+      const m = makeManagerFake();
+      const a = makeApiFake();
+
+      const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+      unsub();
+
+      m.setCatalog("codex", catalogWithModels(["gpt-5"]));
+      m.emit();
+      expect(a.registerAgentProvider).not.toHaveBeenCalled();
+    });
   });
 
-  it("ignores a backend that has not reported a model catalog yet", () => {
-    mockDescriptors = [makeDescriptor({ id: "codex" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
-    m.setCatalog("codex", null);
+  describe("buildManagedOpencodeProviderIds()", () => {
+    /** Build a minimal `Provider` row for a given origin. */
+    function makeProvider(providerId: string, origin: ProviderOrigin): Provider {
+      return {
+        providerId,
+        providerType: "anthropic",
+        displayName: providerId,
+        origin,
+        addedAt: 0,
+      };
+    }
 
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
+    it("maps BYOK providers through their catalog provider id", () => {
+      const managed = buildManagedOpencodeProviderIds([
+        makeProvider("p1", { kind: "byok", catalogProviderId: "anthropic" }),
+        makeProvider("p2", { kind: "byok", catalogProviderId: "openai" }),
+      ]);
+      expect(managed).toEqual(new Set(["anthropic", "openai"]));
+    });
 
-    expect(a.registerAgentProvider).not.toHaveBeenCalled();
-    expect(a.syncAgentModels).not.toHaveBeenCalled();
-    unsub();
-  });
+    it("maps copilot-plus to the reserved opencode provider id", () => {
+      const managed = buildManagedOpencodeProviderIds([
+        makeProvider("p1", { kind: "copilot-plus" }),
+      ]);
+      expect(managed).toEqual(new Set(["copilot-plus"]));
+    });
 
-  it("after unsubscribe, further cache emits do nothing", () => {
-    mockDescriptors = [makeDescriptor({ id: "codex" })];
-    const m = makeManagerFake();
-    const a = makeApiFake();
+    it("excludes unroutable BYOK providers (no catalog id → null mapping)", () => {
+      const managed = buildManagedOpencodeProviderIds([
+        makeProvider("p1", { kind: "byok" }), // custom endpoint, no catalogProviderId
+        makeProvider("p2", { kind: "byok", catalogProviderId: "google" }),
+      ]);
+      expect(managed).toEqual(new Set(["google"]));
+    });
 
-    const unsub = wireAgentModelDiscovery(makePlugin(a.api), m.manager);
-    unsub();
+    it("excludes agent-origin providers so they never suppress themselves", () => {
+      const managed = buildManagedOpencodeProviderIds([
+        makeProvider("opencode-agent", { kind: "agent", agentType: "opencode" }),
+        makeProvider("p1", { kind: "byok", catalogProviderId: "anthropic" }),
+      ]);
+      expect(managed).toEqual(new Set(["anthropic"]));
+    });
 
-    m.setCatalog("codex", catalogWithModels(["gpt-5"]));
-    m.emit();
-    expect(a.registerAgentProvider).not.toHaveBeenCalled();
-  });
-});
-
-describe("buildManagedOpencodeProviderIds", () => {
-  /** Build a minimal `Provider` row for a given origin. */
-  function makeProvider(providerId: string, origin: ProviderOrigin): Provider {
-    return {
-      providerId,
-      providerType: "anthropic",
-      displayName: providerId,
-      origin,
-      addedAt: 0,
-    };
-  }
-
-  it("maps BYOK providers through their catalog provider id", () => {
-    const managed = buildManagedOpencodeProviderIds([
-      makeProvider("p1", { kind: "byok", catalogProviderId: "anthropic" }),
-      makeProvider("p2", { kind: "byok", catalogProviderId: "openai" }),
-    ]);
-    expect(managed).toEqual(new Set(["anthropic", "openai"]));
-  });
-
-  it("maps copilot-plus to the reserved opencode provider id", () => {
-    const managed = buildManagedOpencodeProviderIds([makeProvider("p1", { kind: "copilot-plus" })]);
-    expect(managed).toEqual(new Set(["copilot-plus"]));
-  });
-
-  it("excludes unroutable BYOK providers (no catalog id → null mapping)", () => {
-    const managed = buildManagedOpencodeProviderIds([
-      makeProvider("p1", { kind: "byok" }), // custom endpoint, no catalogProviderId
-      makeProvider("p2", { kind: "byok", catalogProviderId: "google" }),
-    ]);
-    expect(managed).toEqual(new Set(["google"]));
-  });
-
-  it("excludes agent-origin providers so they never suppress themselves", () => {
-    const managed = buildManagedOpencodeProviderIds([
-      makeProvider("opencode-agent", { kind: "agent", agentType: "opencode" }),
-      makeProvider("p1", { kind: "byok", catalogProviderId: "anthropic" }),
-    ]);
-    expect(managed).toEqual(new Set(["anthropic"]));
-  });
-
-  it("returns an empty set for no providers", () => {
-    expect(buildManagedOpencodeProviderIds([])).toEqual(new Set());
+    it("returns an empty set for no providers", () => {
+      expect(buildManagedOpencodeProviderIds([])).toEqual(new Set());
+    });
   });
 });

--- a/src/agentMode/agentModelDiscovery.ts
+++ b/src/agentMode/agentModelDiscovery.ts
@@ -15,11 +15,13 @@
  * derived from the wire-id prefix.
  */
 
+import { getSettings, updateAgentModeBackendFields } from "@/settings/model";
 import { logError, logInfo } from "@/logger";
 import type CopilotPlugin from "@/main";
 import type { AgentType, ModelManagementApi, Provider, ProviderType } from "@/modelManagement";
 import {
   listBackendDescriptors,
+  legacyOpencodeModelIds,
   mapProviderToOpencodeId,
   partitionOpencodeOnlyWireIds,
   type AgentSessionManager,
@@ -66,6 +68,16 @@ export function wireAgentModelDiscovery(
     const catalog = manager.getCachedModelCatalog(descriptor.id);
     const reported = reportedModels(catalog);
     if (reported === null) return; // No catalog yet — the probe hasn't settled.
+    const saved = getSettings().agentMode?.backends?.opencode?.defaultModel;
+    // Repair the durable preference before asynchronous enrollment or fan-out can
+    // consume a catalog whose literal model IDs no longer match it.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+    if (descriptor.id === "opencode" && saved && catalog?.availableModels) {
+      const normalized = descriptor.wire.normalizeSelection?.(saved, catalog.availableModels);
+      if (normalized && normalized !== saved) {
+        updateAgentModeBackendFields("opencode", { defaultModel: normalized });
+      }
+    }
 
     // Include the display strings in the signature so a CLI upgrade that
     // renames a model (or rewrites its blurb) re-syncs the persisted info.
@@ -163,6 +175,8 @@ async function enrollBackend(
     await api.setup.agent.syncAgentModels({
       agentType,
       wireModelIds,
+      legacyModelIds:
+        descriptor.id === "opencode" ? legacyOpencodeModelIds(wireModelIds) : undefined,
       fallbackDisplayNames,
       fallbackDescriptions,
     });

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -38,77 +38,42 @@ describe("descriptor", () => {
         });
       });
 
-      it("parses 3-segment ids as variants when the suffix is a known effort", () => {
-        expect(decode("anthropic/claude-sonnet-4-5/medium")).toEqual({
-          selection: { baseModelId: "anthropic/claude-sonnet-4-5", effort: "medium" },
-          provider: "anthropic",
-        });
-        expect(decode("openai/gpt-5/minimal")).toEqual({
-          selection: { baseModelId: "openai/gpt-5", effort: "minimal" },
-          provider: "openai",
-        });
-      });
-
-      it("recognizes opencode's full effort vocabulary (none/minimal/low/medium/high/xhigh/max)", () => {
-        // Opencode advertises Anthropic models with `/max` and `/xhigh` and
-        // OpenRouter reasoning models with `/none`. Each must collapse onto
-        // its bare base.
-        for (const effort of ["none", "minimal", "low", "medium", "high", "xhigh", "max"]) {
-          expect(decode(`anthropic/claude-opus-4-7/${effort}`)).toEqual({
-            selection: { baseModelId: "anthropic/claude-opus-4-7", effort },
-            provider: "anthropic",
-          });
-        }
-      });
-
-      it("returns no-effort representation for 3-segment ids whose suffix isn't a known effort", () => {
-        // OpenRouter-style 3-segment ids without an effort suffix — the
-        // trailing segment is part of the model name. The whole id is the
-        // baseModelId; provider is still attributed from the leading segment.
-        expect(decode("openrouter/anthropic/claude-sonnet-4-5")).toEqual({
-          selection: { baseModelId: "openrouter/anthropic/claude-sonnet-4-5", effort: null },
-          provider: "openrouterai",
-        });
+      it("keeps an umbrella provider's id whole, attributing only the leading segment", () => {
+        // `claude-3.5-haiku` and `gpt-5` are part of the model name, not an effort.
+        // opencode reports effort as a separate `thought_level` config option, so no
+        // trailing segment is ever peeled off.
         expect(decode("openrouter/anthropic/claude-3.5-haiku")).toEqual({
           selection: { baseModelId: "openrouter/anthropic/claude-3.5-haiku", effort: null },
           provider: "openrouterai",
         });
-      });
-
-      it("parses 4-segment umbrella ids as variants when the last segment is a known effort", () => {
-        // OpenRouter wraps native ids under `openrouter/`, so its variants
-        // are 4-segment: `openrouter/<sub>/<model>/<effort>`. Without this
-        // case the picker would render seven duplicate rows per OpenRouter
-        // reasoning model.
-        expect(decode("openrouter/anthropic/claude-sonnet-4.5/high")).toEqual({
-          selection: { baseModelId: "openrouter/anthropic/claude-sonnet-4.5", effort: "high" },
+        expect(decode("openrouter/openai/gpt-5")).toEqual({
+          selection: { baseModelId: "openrouter/openai/gpt-5", effort: null },
           provider: "openrouterai",
         });
-        expect(decode("openrouter/anthropic/claude-sonnet-4.5/none")).toEqual({
-          selection: { baseModelId: "openrouter/anthropic/claude-sonnet-4.5", effort: "none" },
-          provider: "openrouterai",
-        });
-        expect(decode("openrouter/openai/gpt-5/xhigh")).toEqual({
-          selection: { baseModelId: "openrouter/openai/gpt-5", effort: "xhigh" },
-          provider: "openrouterai",
-        });
-        // OpenRouter route variants like `:exacto` live inside the model
-        // segment — the effort suffix still attaches at the trailing slash.
-        expect(decode("openrouter/openai/gpt-oss-120b:exacto/none")).toEqual({
-          selection: { baseModelId: "openrouter/openai/gpt-oss-120b:exacto", effort: "none" },
+        // OpenRouter route variants like `:exacto` live inside the model segment.
+        expect(decode("openrouter/openai/gpt-oss-120b:exacto")).toEqual({
+          selection: { baseModelId: "openrouter/openai/gpt-oss-120b:exacto", effort: null },
           provider: "openrouterai",
         });
       });
 
-      it("returns no-effort representation for unparseable shapes (1 segment or unknown trailing segment)", () => {
-        // 1-segment ids have no provider segment to attribute.
+      it("keeps a trailing segment that reads like an effort, since effort never rides the id", () => {
+        // A model literally named `.../high` would once have been mis-split into a
+        // base model plus an effort. The vocabulary that made that possible is gone.
+        expect(decode("anthropic/claude-sonnet-4-5/high")).toEqual({
+          selection: { baseModelId: "anthropic/claude-sonnet-4-5/high", effort: null },
+          provider: "anthropic",
+        });
+      });
+
+      it("attributes no provider to a single-segment id", () => {
         expect(decode("just-a-name")).toEqual({
           selection: { baseModelId: "just-a-name", effort: null },
           provider: null,
         });
-        // 4+ segment ids whose trailing segment isn't a known effort fall
-        // through to a no-effort representation. The leading segment still
-        // attributes a provider when it maps.
+      });
+
+      it("attributes a provider only when the leading segment maps to a Copilot one", () => {
         expect(decode("anthropic/foo/bar/baz")).toEqual({
           selection: { baseModelId: "anthropic/foo/bar/baz", effort: null },
           provider: "anthropic",
@@ -129,27 +94,22 @@ describe("descriptor", () => {
         );
       });
 
-      it("appends the variant when effort is set", () => {
+      it("drops effort, which opencode carries in its own config option rather than the id", () => {
         expect(encode({ baseModelId: "anthropic/claude-sonnet-4-5", effort: "high" })).toBe(
-          "anthropic/claude-sonnet-4-5/high"
+          "anthropic/claude-sonnet-4-5"
         );
       });
 
       it("round-trips via wire.decode", () => {
         const ids = [
           "anthropic/claude-sonnet-4-5",
-          "anthropic/claude-sonnet-4-5/low",
-          "openai/gpt-5/high",
-          "anthropic/claude-opus-4-7/max",
           "openrouter/anthropic/claude-sonnet-4.5",
-          "openrouter/anthropic/claude-sonnet-4.5/none",
-          "openrouter/anthropic/claude-sonnet-4.5/high",
+          "openrouter/openai/gpt-oss-120b:exacto",
           // Catalog-less BYOK (openai-compatible) — provider id is the synthetic
           // copilot providerId, and the model id may itself contain slashes
           // (LM Studio repo-prefixed ids like `lmstudio-community/Qwen-…-GGUF`).
-          // The trailing segment isn't a known effort, so decode treats the
-          // whole string as `baseModelId` with `effort: null` — and encode
-          // reproduces it verbatim.
+          // decode treats the whole string as `baseModelId`, and encode reproduces
+          // it verbatim.
           "lmstudio-byok-id/lmstudio-community/Qwen2.5-7B-Instruct-GGUF",
           "ollama-byok-id/llama3.2",
         ];

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -29,77 +29,42 @@ describe("OpencodeBackendDescriptor.wire.decode", () => {
     });
   });
 
-  it("parses 3-segment ids as variants when the suffix is a known effort", () => {
-    expect(decode("anthropic/claude-sonnet-4-5/medium")).toEqual({
-      selection: { baseModelId: "anthropic/claude-sonnet-4-5", effort: "medium" },
-      provider: "anthropic",
-    });
-    expect(decode("openai/gpt-5/minimal")).toEqual({
-      selection: { baseModelId: "openai/gpt-5", effort: "minimal" },
-      provider: "openai",
-    });
-  });
-
-  it("recognizes opencode's full effort vocabulary (none/minimal/low/medium/high/xhigh/max)", () => {
-    // Opencode advertises Anthropic models with `/max` and `/xhigh` and
-    // OpenRouter reasoning models with `/none`. Each must collapse onto
-    // its bare base.
-    for (const effort of ["none", "minimal", "low", "medium", "high", "xhigh", "max"]) {
-      expect(decode(`anthropic/claude-opus-4-7/${effort}`)).toEqual({
-        selection: { baseModelId: "anthropic/claude-opus-4-7", effort },
-        provider: "anthropic",
-      });
-    }
-  });
-
-  it("returns no-effort representation for 3-segment ids whose suffix isn't a known effort", () => {
-    // OpenRouter-style 3-segment ids without an effort suffix — the
-    // trailing segment is part of the model name. The whole id is the
-    // baseModelId; provider is still attributed from the leading segment.
-    expect(decode("openrouter/anthropic/claude-sonnet-4-5")).toEqual({
-      selection: { baseModelId: "openrouter/anthropic/claude-sonnet-4-5", effort: null },
-      provider: "openrouterai",
-    });
+  it("keeps an umbrella provider's id whole, attributing only the leading segment", () => {
+    // `claude-3.5-haiku` and `gpt-5` are part of the model name, not an effort.
+    // opencode reports effort as a separate `thought_level` config option, so no
+    // trailing segment is ever peeled off.
     expect(decode("openrouter/anthropic/claude-3.5-haiku")).toEqual({
       selection: { baseModelId: "openrouter/anthropic/claude-3.5-haiku", effort: null },
       provider: "openrouterai",
     });
-  });
-
-  it("parses 4-segment umbrella ids as variants when the last segment is a known effort", () => {
-    // OpenRouter wraps native ids under `openrouter/`, so its variants
-    // are 4-segment: `openrouter/<sub>/<model>/<effort>`. Without this
-    // case the picker would render seven duplicate rows per OpenRouter
-    // reasoning model.
-    expect(decode("openrouter/anthropic/claude-sonnet-4.5/high")).toEqual({
-      selection: { baseModelId: "openrouter/anthropic/claude-sonnet-4.5", effort: "high" },
+    expect(decode("openrouter/openai/gpt-5")).toEqual({
+      selection: { baseModelId: "openrouter/openai/gpt-5", effort: null },
       provider: "openrouterai",
     });
-    expect(decode("openrouter/anthropic/claude-sonnet-4.5/none")).toEqual({
-      selection: { baseModelId: "openrouter/anthropic/claude-sonnet-4.5", effort: "none" },
-      provider: "openrouterai",
-    });
-    expect(decode("openrouter/openai/gpt-5/xhigh")).toEqual({
-      selection: { baseModelId: "openrouter/openai/gpt-5", effort: "xhigh" },
-      provider: "openrouterai",
-    });
-    // OpenRouter route variants like `:exacto` live inside the model
-    // segment — the effort suffix still attaches at the trailing slash.
-    expect(decode("openrouter/openai/gpt-oss-120b:exacto/none")).toEqual({
-      selection: { baseModelId: "openrouter/openai/gpt-oss-120b:exacto", effort: "none" },
+    // OpenRouter route variants like `:exacto` live inside the model segment.
+    expect(decode("openrouter/openai/gpt-oss-120b:exacto")).toEqual({
+      selection: { baseModelId: "openrouter/openai/gpt-oss-120b:exacto", effort: null },
       provider: "openrouterai",
     });
   });
 
-  it("returns no-effort representation for unparseable shapes (1 segment or unknown trailing segment)", () => {
-    // 1-segment ids have no provider segment to attribute.
+  it("keeps a trailing segment that reads like an effort, since effort never rides the id", () => {
+    // A model literally named `.../high` would once have been mis-split into a
+    // base model plus an effort. The vocabulary that made that possible is gone.
+    expect(decode("anthropic/claude-sonnet-4-5/high")).toEqual({
+      selection: { baseModelId: "anthropic/claude-sonnet-4-5/high", effort: null },
+      provider: "anthropic",
+    });
+  });
+
+  it("attributes no provider to a single-segment id", () => {
     expect(decode("just-a-name")).toEqual({
       selection: { baseModelId: "just-a-name", effort: null },
       provider: null,
     });
-    // 4+ segment ids whose trailing segment isn't a known effort fall
-    // through to a no-effort representation. The leading segment still
-    // attributes a provider when it maps.
+  });
+
+  it("attributes a provider only when the leading segment maps to a Copilot one", () => {
     expect(decode("anthropic/foo/bar/baz")).toEqual({
       selection: { baseModelId: "anthropic/foo/bar/baz", effort: null },
       provider: "anthropic",
@@ -120,27 +85,22 @@ describe("OpencodeBackendDescriptor.wire.encode", () => {
     );
   });
 
-  it("appends the variant when effort is set", () => {
+  it("drops effort, which opencode carries in its own config option rather than the id", () => {
     expect(encode({ baseModelId: "anthropic/claude-sonnet-4-5", effort: "high" })).toBe(
-      "anthropic/claude-sonnet-4-5/high"
+      "anthropic/claude-sonnet-4-5"
     );
   });
 
   it("round-trips via wire.decode", () => {
     const ids = [
       "anthropic/claude-sonnet-4-5",
-      "anthropic/claude-sonnet-4-5/low",
-      "openai/gpt-5/high",
-      "anthropic/claude-opus-4-7/max",
       "openrouter/anthropic/claude-sonnet-4.5",
-      "openrouter/anthropic/claude-sonnet-4.5/none",
-      "openrouter/anthropic/claude-sonnet-4.5/high",
+      "openrouter/openai/gpt-oss-120b:exacto",
       // Catalog-less BYOK (openai-compatible) — provider id is the synthetic
       // copilot providerId, and the model id may itself contain slashes
       // (LM Studio repo-prefixed ids like `lmstudio-community/Qwen-…-GGUF`).
-      // The trailing segment isn't a known effort, so decode treats the
-      // whole string as `baseModelId` with `effort: null` — and encode
-      // reproduces it verbatim.
+      // decode treats the whole string as `baseModelId`, and encode reproduces
+      // it verbatim.
       "lmstudio-byok-id/lmstudio-community/Qwen2.5-7B-Instruct-GGUF",
       "ollama-byok-id/llama3.2",
     ];

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -1,3 +1,4 @@
+import { FanoutOrchestrator } from "@/agentMode/session/fanout/FanoutOrchestrator";
 import { getOpencodeBinaryManager, OpencodeBackendDescriptor } from "./descriptor";
 import { legacyVaultDataDir } from "./OpencodeBinaryManager";
 import * as fs from "node:fs";
@@ -132,6 +133,63 @@ describe("descriptor", () => {
           provider: null,
         });
         expect(OpencodeBackendDescriptor.wire.encode(decoded.selection)).toBe(wireId);
+      });
+    });
+
+    describe("wire.normalizeSelection()", () => {
+      it("restores a saved literal model in standalone fan-out before sending the prompt (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)", async () => {
+        const state: BackendState = {
+          mode: null,
+          model: {
+            current: { baseModelId: "opencode/default", effort: null },
+            availableModels: [
+              {
+                baseModelId: "anthropic/vendor/high",
+                name: "Vendor",
+                provider: null,
+                effortOptions: [],
+              },
+            ],
+            apply: { kind: "setConfigOption", configId: "model", effortConfigId: "thought_level" },
+          },
+        };
+        const setSessionConfigOption = jest.fn(async () => state);
+        const prompt = jest.fn(async () => ({ stopReason: "end_turn" }));
+        const proc = {
+          newSession: async () => ({ sessionId: "fanout-literal", state }),
+          registerSessionHandler: () => () => {},
+          setSessionConfigOption,
+          prompt,
+          closeSession: async () => {},
+        } as unknown as BackendProcess;
+        const orchestrator = new FanoutOrchestrator({
+          ensureBackendForFanout: async () => ({ proc, descriptor: OpencodeBackendDescriptor }),
+          getDefaultSelection: () => ({ baseModelId: "anthropic/vendor", effort: "high" }),
+          getDisplayName: () => "OpenCode",
+          getCwd: () => "/vault",
+          registerReadOnlySession: () => () => {},
+          excludeSubSessionFromHistory: () => {},
+        });
+        await orchestrator.run({
+          agents: ["opencode"],
+          mainAgent: "opencode",
+          prompt: [],
+          originalPromptText: "test",
+          signal: new AbortController().signal,
+          onChange: () => {},
+        });
+        expect(setSessionConfigOption).toHaveBeenCalledWith({
+          sessionId: "fanout-literal",
+          configId: "model",
+          value: "anthropic/vendor/high",
+        });
+        expect(setSessionConfigOption).not.toHaveBeenCalledWith(
+          expect.objectContaining({ configId: "thought_level" })
+        );
+        expect(prompt).toHaveBeenCalled();
+        expect(setSessionConfigOption.mock.invocationCallOrder[0]).toBeLessThan(
+          prompt.mock.invocationCallOrder[0]
+        );
       });
     });
 

--- a/src/agentMode/backends/opencode/descriptor.test.ts
+++ b/src/agentMode/backends/opencode/descriptor.test.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { FileSystemAdapter } from "obsidian";
-import type { AgentSession } from "@/agentMode/session/AgentSession";
+import { AgentSession } from "@/agentMode/session/AgentSession";
 import type {
   BackendProcess,
   BackendState,
@@ -179,6 +179,75 @@ describe("descriptor", () => {
           setConfigOption,
         };
       }
+
+      it("restores a saved split model during session startup before ready settles (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)", async () => {
+        const initialState: BackendState = {
+          model: {
+            current: { baseModelId: "opencode/default", effort: null },
+            availableModels: [entryOffering("anthropic/vendor/high", [])],
+            apply: { kind: "setConfigOption", configId: "model" },
+          },
+          mode: null,
+        };
+        const setSessionConfigOption = jest.fn(async () => ({
+          ...initialState,
+          model: {
+            ...initialState.model!,
+            current: { baseModelId: "anthropic/vendor/high", effort: null },
+          },
+        }));
+        const session = new AgentSession({
+          backend: {
+            registerSessionHandler: () => () => {},
+            setSessionConfigOption,
+          } as unknown as BackendProcess,
+          internalId: "restore-saved-model",
+          backendId: "opencode",
+          backendSessionId: "restored-session",
+          initialState,
+          defaultModelSelection: { baseModelId: "anthropic/vendor", effort: "high" },
+          getDescriptor: () => OpencodeBackendDescriptor,
+        });
+        await session.ready;
+        expect(setSessionConfigOption).toHaveBeenCalledWith({
+          sessionId: "restored-session",
+          configId: "model",
+          value: "anthropic/vendor/high",
+        });
+        expect(session.getState()?.model?.current).toEqual({
+          baseModelId: "anthropic/vendor/high",
+          effort: null,
+        });
+      });
+
+      it.each([
+        { catalog: ["anthropic/vendor/high"], effort: "high", expected: "anthropic/vendor/high" },
+        {
+          catalog: ["anthropic/vendor", "anthropic/vendor/high"],
+          effort: "high",
+          expected: "anthropic/vendor",
+        },
+        { catalog: ["anthropic/other"], effort: "high", expected: "anthropic/vendor" },
+        { catalog: ["anthropic/vendor/high"], effort: null, expected: "anthropic/vendor" },
+      ])(
+        "restores a split saved model only when the catalog identifies it: $catalog / $effort (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)",
+        async ({ catalog, effort, expected }) => {
+          const { session, applyModelWireId, setConfigOption } = makeSession({
+            model: {
+              current: { baseModelId: "opencode/default", effort: null },
+              availableModels: catalog.map((id) => entryOffering(id, [])),
+              apply: { kind: "setConfigOption", configId: "model" },
+            },
+            mode: null,
+          });
+          await OpencodeBackendDescriptor.applySelection(session, {
+            baseModelId: "anthropic/vendor",
+            effort,
+          });
+          expect(applyModelWireId).toHaveBeenCalledWith(expected);
+          expect(setConfigOption).not.toHaveBeenCalled();
+        }
+      );
 
       it("routes config-option-backed effort through the thought-level option", async () => {
         const { session, applyModelWireId, setConfigOption } = makeSession({

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -48,46 +48,23 @@ const EMPTY_EFFORT_CATALOG: Record<string, EffortOption[]> = Object.freeze({});
 let managerRef: OpencodeBinaryManager | null = null;
 
 /**
- * Effort suffixes opencode appends to model ids. Used to disambiguate
- * genuine effort variants from ids whose trailing segment is part of
- * the model name (e.g. `openrouter/anthropic/claude-3.5-haiku` — the
- * last segment `claude-3.5-haiku` is the model, not an effort).
- */
-const KNOWN_OPENCODE_EFFORTS = new Set([
-  "none",
-  "minimal",
-  "low",
-  "medium",
-  "high",
-  "xhigh",
-  "max",
-]);
-
-/**
- * Wire-format codec for Opencode. Native providers emit
- * `<provider>/<model>[/<effort>]` (3 segments with effort); umbrella
- * providers like OpenRouter emit `<provider>/<sub>/<model>[/<effort>]`
- * (4 segments with effort). The leading segment is always the opencode
- * provider id, mapped onto a Copilot `ChatModelProviders` value via
- * `OPENCODE_PROVIDER_MAP` for picker section grouping. We classify the
- * trailing segment as effort iff it's in the known effort vocabulary —
- * that gates out 3-seg umbrella ids whose last segment is part of the
- * model name (e.g. `openrouter/anthropic/claude-3.5-haiku`).
+ * Wire-format codec for Opencode. A model id is `<provider>/<model>` for native
+ * providers and `<provider>/<sub>/<model>` for umbrella providers like
+ * OpenRouter; the leading segment is always the opencode provider id, mapped
+ * onto a Copilot `ChatModelProviders` value via `OPENCODE_PROVIDER_MAP` for
+ * picker section grouping.
+ *
+ * Effort never rides the id: opencode reports it as a sibling
+ * `category:"thought_level"` config option, scoped to the active model, which
+ * `applySelection` and `prefetchEffortCatalog` read. So `decode` leaves the id
+ * whole — no trailing segment is an effort, and none is guessed.
  */
 const opencodeWire: ModelWireCodec = {
-  encode: (selection: ModelSelection) =>
-    selection.effort ? `${selection.baseModelId}/${selection.effort}` : selection.baseModelId,
+  encode: (selection: ModelSelection) => selection.baseModelId,
   decode: (wireId: string) => {
     if (!wireId) return { selection: { baseModelId: wireId, effort: null }, provider: null };
     const segments = wireId.split("/");
     const provider = segments.length >= 2 ? opencodeProviderToCopilot(segments[0]) : null;
-    const last = segments[segments.length - 1];
-    if (segments.length >= 3 && KNOWN_OPENCODE_EFFORTS.has(last)) {
-      return {
-        selection: { baseModelId: segments.slice(0, -1).join("/"), effort: last },
-        provider,
-      };
-    }
     return { selection: { baseModelId: wireId, effort: null }, provider };
   },
 };
@@ -198,9 +175,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
         ? context.backendReportedCurrent?.baseModelId
         : session.getState()?.model?.current.baseModelId;
       if (currentBase !== selection.baseModelId) {
-        await session.applyModelWireId(
-          opencodeWire.encode({ baseModelId: selection.baseModelId, effort: null })
-        );
+        await session.applyModelWireId(opencodeWire.encode(selection));
       }
       if (selection.effort !== null) {
         const refreshedApply = session.getState()?.model?.apply;
@@ -234,10 +209,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
     // the effort options the refreshed state reports for it.
     if (modelState.apply.kind !== "setConfigOption") return EMPTY_EFFORT_CATALOG;
     const configId = modelState.apply.configId;
-    const originalWire = opencodeWire.encode({
-      baseModelId: modelState.current.baseModelId,
-      effort: null,
-    });
+    const originalWire = opencodeWire.encode(modelState.current);
     const out: Record<string, EffortOption[]> = {};
     try {
       for (const model of enabledModels) {

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -168,7 +168,18 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
   },
 
   async applySelection(session: AgentSession, selection: ModelSelection, context): Promise<void> {
-    const apply = session.getState()?.model?.apply;
+    const model = session.getState()?.model;
+    // Native discovery could persist a literal trailing segment as effort. Restore
+    // that model only when the catalog rules out the saved base, so a real effort
+    // preference cannot redirect the user to a different model.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+    if (selection.effort && !findModelEntry(model ?? null, selection.baseModelId)) {
+      const literalId = `${selection.baseModelId}/${selection.effort}`;
+      if (findModelEntry(model ?? null, literalId)) {
+        selection = { baseModelId: literalId, effort: null };
+      }
+    }
+    const apply = model?.apply;
     // A config-option catalog takes bare model ids only. Effort travels through
     // its own option when the model publishes one and is dropped otherwise; a
     // saved level the model does not offer must never become a `/<effort>`

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -35,7 +35,6 @@ import type {
   SessionId,
 } from "@/agentMode/session/types";
 import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
-import { EFFORT_LEVELS_ASCENDING } from "@/agentMode/session/types";
 import { findModelEntry } from "@/agentMode/session/translateBackendState";
 
 /** Config option id OpenCode uses to switch the active agent at runtime. */
@@ -50,38 +49,23 @@ const EMPTY_EFFORT_CATALOG: Record<string, EffortOption[]> = Object.freeze({});
 let managerRef: OpencodeBinaryManager | null = null;
 
 /**
- * Effort suffixes opencode appends to model ids. Used to disambiguate
- * genuine effort variants from ids whose trailing segment is part of
- * the model name (e.g. `openrouter/anthropic/claude-3.5-haiku` — the
- * last segment `claude-3.5-haiku` is the model, not an effort).
- */
-const KNOWN_OPENCODE_EFFORTS = new Set(EFFORT_LEVELS_ASCENDING);
-
-/**
- * Wire-format codec for Opencode. Native providers emit
- * `<provider>/<model>[/<effort>]` (3 segments with effort); umbrella
- * providers like OpenRouter emit `<provider>/<sub>/<model>[/<effort>]`
- * (4 segments with effort). The leading segment is always the opencode
- * provider id, mapped onto a Copilot `ChatModelProviders` value via
- * `OPENCODE_PROVIDER_MAP` for picker section grouping. We classify the
- * trailing segment as effort iff it's in the known effort vocabulary —
- * that gates out 3-seg umbrella ids whose last segment is part of the
- * model name (e.g. `openrouter/anthropic/claude-3.5-haiku`).
+ * Wire-format codec for Opencode. A model id is `<provider>/<model>` for native
+ * providers and `<provider>/<sub>/<model>` for umbrella providers like
+ * OpenRouter; the leading segment is always the opencode provider id, mapped
+ * onto a Copilot `ChatModelProviders` value via `OPENCODE_PROVIDER_MAP` for
+ * picker section grouping.
+ *
+ * Effort never rides the id: opencode reports it as a sibling
+ * `category:"thought_level"` config option, scoped to the active model, which
+ * `applySelection` and `prefetchEffortCatalog` read. So `decode` leaves the id
+ * whole — no trailing segment is an effort, and none is guessed.
  */
 const opencodeWire: ModelWireCodec = {
-  encode: (selection: ModelSelection) =>
-    selection.effort ? `${selection.baseModelId}/${selection.effort}` : selection.baseModelId,
+  encode: (selection: ModelSelection) => selection.baseModelId,
   decode: (wireId: string) => {
     if (!wireId) return { selection: { baseModelId: wireId, effort: null }, provider: null };
     const segments = wireId.split("/");
     const provider = segments.length >= 2 ? opencodeProviderToCopilot(segments[0]) : null;
-    const last = segments[segments.length - 1];
-    if (segments.length >= 3 && KNOWN_OPENCODE_EFFORTS.has(last)) {
-      return {
-        selection: { baseModelId: segments.slice(0, -1).join("/"), effort: last },
-        provider,
-      };
-    }
     return { selection: { baseModelId: wireId, effort: null }, provider };
   },
 };
@@ -197,9 +181,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
         ? context.backendReportedCurrent?.baseModelId
         : session.getState()?.model?.current.baseModelId;
       if (currentBase !== selection.baseModelId) {
-        await session.applyModelWireId(
-          opencodeWire.encode({ baseModelId: selection.baseModelId, effort: null })
-        );
+        await session.applyModelWireId(opencodeWire.encode(selection));
       }
       if (selection.effort !== null) {
         const refreshed = session.getState()?.model;
@@ -240,10 +222,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
     // the effort options the refreshed state reports for it.
     if (modelState.apply.kind !== "setConfigOption") return EMPTY_EFFORT_CATALOG;
     const configId = modelState.apply.configId;
-    const originalWire = opencodeWire.encode({
-      baseModelId: modelState.current.baseModelId,
-      effort: null,
-    });
+    const originalWire = opencodeWire.encode(modelState.current);
     const out: Record<string, EffortOption[]> = {};
     try {
       for (const model of enabledModels) {

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -20,6 +20,7 @@ import {
   toOpencodeInstallState,
 } from "./OpencodeBinaryManager";
 import { opencodeEnabledModelEntries, opencodeWireBaseIdFor } from "./opencodeModelResolve";
+import { normalizeOpencodeSelection } from "./opencodeModelMigration";
 import { OpencodeSettingsPanel } from "./OpencodeSettingsPanel";
 import { mapNodeArch, mapNodePlatform } from "./platformResolver";
 import { cacheRoot } from "@/context/conversionsLocation";
@@ -61,6 +62,7 @@ let managerRef: OpencodeBinaryManager | null = null;
  * whole — no trailing segment is an effort, and none is guessed.
  */
 const opencodeWire: ModelWireCodec = {
+  normalizeSelection: normalizeOpencodeSelection,
   encode: (selection: ModelSelection) => selection.baseModelId,
   decode: (wireId: string) => {
     if (!wireId) return { selection: { baseModelId: wireId, effort: null }, provider: null };
@@ -169,16 +171,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
 
   async applySelection(session: AgentSession, selection: ModelSelection, context): Promise<void> {
     const model = session.getState()?.model;
-    // Native discovery could persist a literal trailing segment as effort. Restore
-    // that model only when the catalog rules out the saved base, so a real effort
-    // preference cannot redirect the user to a different model.
-    // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
-    if (selection.effort && !findModelEntry(model ?? null, selection.baseModelId)) {
-      const literalId = `${selection.baseModelId}/${selection.effort}`;
-      if (findModelEntry(model ?? null, literalId)) {
-        selection = { baseModelId: literalId, effort: null };
-      }
-    }
+    if (model) selection = normalizeOpencodeSelection(selection, model.availableModels);
     const apply = model?.apply;
     // A config-option catalog takes bare model ids only. Effort travels through
     // its own option when the model publishes one and is dropped otherwise; a

--- a/src/agentMode/backends/opencode/opencodeModelMigration.test.ts
+++ b/src/agentMode/backends/opencode/opencodeModelMigration.test.ts
@@ -1,0 +1,55 @@
+import { legacyOpencodeModelIds, normalizeOpencodeSelection } from "./opencodeModelMigration";
+import type { ModelEntry } from "@/agentMode/session/types";
+
+const issue = "https://github.com/Brevilabs/obsidian-copilot-private/issues/219";
+const entries = (...ids: string[]): ModelEntry[] =>
+  ids.map((baseModelId) => ({
+    baseModelId,
+    name: baseModelId,
+    provider: null,
+    effortOptions: [],
+  }));
+
+describe("opencodeModelMigration", () => {
+  describe("legacyOpencodeModelIds()", () => {
+    it(`identifies every literal variant of a historically grouped row (${issue})`, () => {
+      expect(legacyOpencodeModelIds(["anthropic/vendor/high", "anthropic/vendor/low"])).toEqual(
+        new Map([
+          ["anthropic/vendor/high", "anthropic/vendor"],
+          ["anthropic/vendor/low", "anthropic/vendor"],
+        ])
+      );
+    });
+    it(`does not alias real bases, arbitrary names, or two-segment IDs (${issue})`, () => {
+      expect(
+        legacyOpencodeModelIds([
+          "anthropic/vendor",
+          "anthropic/vendor/high",
+          "anthropic/high",
+          "anthropic/vendor/future",
+        ])
+      ).toEqual(new Map());
+    });
+  });
+  describe("normalizeOpencodeSelection()", () => {
+    it(`uses the explicit saved suffix when several literal variants exist (${issue})`, () => {
+      expect(
+        normalizeOpencodeSelection(
+          { baseModelId: "anthropic/vendor", effort: "low" },
+          entries("anthropic/vendor/high", "anthropic/vendor/low")
+        )
+      ).toEqual({ baseModelId: "anthropic/vendor/low", effort: null });
+    });
+    it.each([
+      { effort: null, catalog: ["anthropic/vendor/high"] },
+      { effort: "high", catalog: ["anthropic/vendor", "anthropic/vendor/high"] },
+      { effort: "high", catalog: [] },
+    ])(
+      `preserves unresolved or already-valid selections by reference: $effort / $catalog (${issue})`,
+      ({ effort, catalog }) => {
+        const selection = { baseModelId: "anthropic/vendor", effort };
+        expect(normalizeOpencodeSelection(selection, entries(...catalog))).toBe(selection);
+      }
+    );
+  });
+});

--- a/src/agentMode/backends/opencode/opencodeModelMigration.ts
+++ b/src/agentMode/backends/opencode/opencodeModelMigration.ts
@@ -1,0 +1,51 @@
+import type { ModelEntry, ModelSelection } from "@/agentMode/session/types";
+
+// The historical decoder split only these suffixes. This compatibility list must
+// not grow when an agent introduces another effort level.
+// https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+const LEGACY_EFFORTS = new Set(["none", "minimal", "low", "medium", "high", "xhigh", "max"]);
+
+/**
+ * Identify reported literal IDs previously collapsed into a discovered model row.
+ * @param modelIds - Complete IDs in the current agent catalog.
+ */
+export function legacyOpencodeModelIds(modelIds: readonly string[]): ReadonlyMap<string, string> {
+  const ids = new Set(modelIds);
+  const aliases = new Map<string, string>();
+  for (const id of ids) {
+    const segments = id.split("/");
+    const base = segments.slice(0, -1).join("/");
+    // A real base model must retain its identity and enabled state.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+    if (
+      segments.length >= 3 &&
+      LEGACY_EFFORTS.has(segments[segments.length - 1]) &&
+      !ids.has(base)
+    ) {
+      aliases.set(id, base);
+    }
+  }
+  return aliases;
+}
+
+/**
+ * Restore the exact literal model selected through the historical suffix decoder.
+ * @param selection - Saved or already-captured model preference.
+ * @param availableModels - Current catalog used to distinguish model IDs from effort.
+ */
+export function normalizeOpencodeSelection(
+  selection: ModelSelection,
+  availableModels: readonly ModelEntry[]
+): ModelSelection {
+  const literalId = `${selection.baseModelId}/${selection.effort}`;
+  // The explicit saved suffix identifies the model even when discovery collapsed
+  // several literal IDs into one row. Never infer a choice from catalog order.
+  // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+  if (
+    selection.effort &&
+    legacyOpencodeModelIds(availableModels.map((m) => m.baseModelId)).has(literalId)
+  ) {
+    return { baseModelId: literalId, effort: null };
+  }
+  return selection;
+}

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -466,3 +466,5 @@ export function createAgentSessionManager(app: App, plugin: CopilotPlugin): Agen
   }
   return manager;
 }
+
+export { legacyOpencodeModelIds } from "./backends/opencode/opencodeModelMigration";

--- a/src/agentMode/session/fanout/FanoutOrchestrator.ts
+++ b/src/agentMode/session/fanout/FanoutOrchestrator.ts
@@ -6,6 +6,7 @@ import type {
   BackendProcess,
   ModelApplySpec,
   ModelSelection,
+  ModelState,
   PromptContent,
   SessionEvent,
   SessionId,
@@ -277,10 +278,9 @@ export class FanoutOrchestrator {
         // round-trips concurrently. The model channel comes from the sub-session's
         // own `BackendState.model.apply` spec, so config-option backends (opencode
         // ≥ 1.15.13) route through the same RPC the visible session would.
-        const modelApply = opened.state.model?.apply ?? null;
         await Promise.all([
           this.applyReadOnlyMode(proc, descriptor, sessionId),
-          this.applyDefaultModel(proc, descriptor, backendId, sessionId, modelApply),
+          this.applyDefaultModel(proc, descriptor, backendId, sessionId, opened.state.model),
         ]);
 
         // If the race already won during setup, do NOT dispatch: the slot is
@@ -498,10 +498,16 @@ export class FanoutOrchestrator {
     descriptor: BackendDescriptor,
     backendId: BackendId,
     sessionId: SessionId,
-    modelApply: ModelApplySpec | null
+    modelState: ModelState | null
   ): Promise<void> {
-    const selection = this.host.getDefaultSelection(backendId);
+    let selection = this.host.getDefaultSelection(backendId);
     if (!selection) return;
+    // Fan-out may start before discovery has rewritten a saved model ID.
+    // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+    if (modelState && descriptor.wire.normalizeSelection) {
+      selection = descriptor.wire.normalizeSelection(selection, modelState.availableModels);
+    }
+    const modelApply = modelState?.apply;
     try {
       if (modelApply?.kind === "setConfigOption") {
         await this.applyConfigOptionModel(proc, descriptor, sessionId, selection, modelApply);

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -248,7 +248,7 @@ export interface ModelState {
  * For descriptor-style backends (Claude SDK), effort lives outside the
  * wire id and `effortConfigFor` exposes the `BackendConfigOption`
  * dispatched via `setSessionConfigOption`. For suffix-style backends
- * (codex, opencode), effort is encoded into the wire id and
+ * (codex), effort is encoded into the wire id and
  * `effortConfigFor` is omitted.
  */
 export interface ModelWireCodec {
@@ -258,6 +258,16 @@ export interface ModelWireCodec {
    * is the bare `baseModelId`).
    */
   encode(selection: ModelSelection): string;
+
+  /**
+   * Restore a persisted selection whose wire representation changed.
+   * @param selection - Saved preference, possibly captured before discovery completed.
+   * @param availableModels - Current catalog that proves a legacy ID's replacement.
+   */
+  normalizeSelection?(
+    selection: ModelSelection,
+    availableModels: readonly ModelEntry[]
+  ): ModelSelection;
 
   /**
    * Decode a wire-form id into a normalized selection plus the Copilot

--- a/src/modelManagement/setup/AgentSetupApi.test.ts
+++ b/src/modelManagement/setup/AgentSetupApi.test.ts
@@ -131,6 +131,10 @@ class FakeBackendConfigRegistry {
     }
   });
 
+  get(backend: BackendType) {
+    return { enabledModels: this.enabledFor(backend) };
+  }
+
   enabledFor(backend: BackendType): string[] {
     return this.enabled.get(backend) ?? [];
   }
@@ -575,6 +579,102 @@ describe("AgentSetupApi", () => {
     // ---------------------------------------------------------------------------
 
     describe("syncAgentModels()", () => {
+      it("retains legacy model ownership across multiple agent providers (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)", async () => {
+        const h = makeHarness([CLAUDE_CATALOG, GOOGLE_CATALOG]);
+        const first = await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "anthropic",
+          displayName: "Anthropic",
+          wireModelIds: ["anthropic/vendor"],
+        });
+        const second = await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "google",
+          displayName: "Google",
+          wireModelIds: ["google/vendor"],
+        });
+        await h.api.syncAgentModels({
+          agentType: "opencode",
+          wireModelIds: ["anthropic/vendor/high", "google/vendor/low"],
+          legacyModelIds: new Map([
+            ["anthropic/vendor/high", "anthropic/vendor"],
+            ["google/vendor/low", "google/vendor"],
+          ]),
+        });
+        expect(h.models.get(first.configuredModelIds[0])?.info.id).toBe("anthropic/vendor/high");
+        expect(h.models.get(second.configuredModelIds[0])?.info.id).toBe("google/vendor/low");
+        expect(h.backends.enabledFor("opencode")).toEqual([
+          ...first.configuredModelIds,
+          ...second.configuredModelIds,
+        ]);
+      });
+
+      it("transfers an enabled legacy reference to an already-discovered literal row without duplicating it (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)", async () => {
+        const h = makeHarness();
+        const registered = await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "anthropic",
+          displayName: "OpenCode",
+          wireModelIds: ["anthropic/vendor", "anthropic/vendor/high"],
+          autoEnrollModelIds: ["anthropic/vendor"],
+        });
+        await h.api.syncAgentModels({
+          agentType: "opencode",
+          wireModelIds: ["anthropic/vendor/high"],
+          legacyModelIds: new Map([["anthropic/vendor/high", "anthropic/vendor"]]),
+        });
+        expect(
+          h.models.listByProvider(registered.providerId).map((row) => row.configuredModelId)
+        ).toEqual([registered.configuredModelIds[1]]);
+        expect(h.backends.enabledFor("opencode")).toEqual([registered.configuredModelIds[1]]);
+      });
+
+      it.each([true, false])(
+        "retains a grouped model's enabled=%s state and configured ID across literal suffix expansion (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)",
+        async (enabled) => {
+          const h = makeHarness();
+          const registered = await h.api.registerAgentProvider({
+            agentType: "opencode",
+            providerType: "anthropic",
+            displayName: "OpenCode",
+            wireModelIds: ["anthropic/vendor"],
+            autoEnrollModelIds: enabled ? ["anthropic/vendor"] : [],
+          });
+          const oldId = registered.configuredModelIds[0];
+          const wireModelIds = ["anthropic/vendor/high", "anthropic/vendor/low"];
+          await h.api.syncAgentModels({
+            agentType: "opencode",
+            wireModelIds,
+            legacyModelIds: new Map(wireModelIds.map((id) => [id, "anthropic/vendor"])),
+          });
+          const rows = h.models.listByProvider(registered.providerId);
+          expect(rows.map((row) => row.info.id)).toEqual(wireModelIds);
+          expect(rows[0].configuredModelId).toBe(oldId);
+          expect(h.backends.enabledFor("opencode")).toEqual(
+            enabled ? rows.map((row) => row.configuredModelId) : []
+          );
+          await h.api.syncAgentModels({ agentType: "opencode", wireModelIds });
+          expect(h.models.listByProvider(registered.providerId)).toEqual(rows);
+        }
+      );
+
+      it("keeps a real base's identity when literal suffix models coexist (https://github.com/Brevilabs/obsidian-copilot-private/issues/219)", async () => {
+        const h = makeHarness();
+        const registered = await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "anthropic",
+          displayName: "OpenCode",
+          wireModelIds: ["anthropic/vendor"],
+        });
+        await h.api.syncAgentModels({
+          agentType: "opencode",
+          wireModelIds: ["anthropic/vendor", "anthropic/vendor/high"],
+          legacyModelIds: new Map([["anthropic/vendor/high", "anthropic/vendor"]]),
+        });
+        expect(h.models.get(registered.configuredModelIds[0])?.info.id).toBe("anthropic/vendor");
+        expect(h.backends.enabledFor("opencode")).toEqual(registered.configuredModelIds);
+      });
+
       it("no-ops when no agent provider exists for the agentType", async () => {
         const h = makeHarness();
         const result = await h.api.syncAgentModels({

--- a/src/modelManagement/setup/AgentSetupApi.test.ts
+++ b/src/modelManagement/setup/AgentSetupApi.test.ts
@@ -223,510 +223,531 @@ beforeEach(() => {
 // registerAgentProvider
 // ---------------------------------------------------------------------------
 
-describe("AgentSetupApi.registerAgentProvider", () => {
-  it("creates exactly one agent-origin provider, N models, all enrolled into the agent backend only", async () => {
-    const h = makeHarness();
-    const result = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
+describe("AgentSetupApi", () => {
+  describe("AgentSetupApi", () => {
+    describe("registerAgentProvider()", () => {
+      it("creates exactly one agent-origin provider, N models, all enrolled into the agent backend only", async () => {
+        const h = makeHarness();
+        const result = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
+        });
+
+        // One provider, correct origin.
+        expect(h.providers.rows.size).toBe(1);
+        const provider = h.providers.get(result.providerId)!;
+        expect(provider.origin).toEqual({ kind: "agent", agentType: "claude" });
+        expect(provider.providerType).toBe("anthropic");
+        expect(provider.displayName).toBe("Claude Code");
+
+        // Two ConfiguredModels.
+        expect(result.configuredModelIds).toHaveLength(2);
+        expect(
+          h.models
+            .listByProvider(result.providerId)
+            .map((m) => m.info.id)
+            .sort()
+        ).toEqual(["claude-opus-4-5", "claude-sonnet-4-5"]);
+
+        // Enrolled into backends["claude"] only — not chat or other agents.
+        expect(h.backends.enabledFor("claude").sort()).toEqual(
+          [...result.configuredModelIds].sort()
+        );
+        expect(h.backends.enabledFor("chat")).toEqual([]);
+        expect(h.backends.enabledFor("opencode")).toEqual([]);
+        expect(h.backends.enabledFor("codex")).toEqual([]);
+      });
+
+      it("enables only autoEnrollModelIds while still creating every reported model", async () => {
+        const h = makeHarness();
+        const result = await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "openai-compatible",
+          displayName: "opencode",
+          apiKey: null,
+          wireModelIds: ["opencode/a", "opencode/b", "opencode/c"],
+          autoEnrollModelIds: ["opencode/a", "opencode/c"],
+        });
+
+        // All three exist, so the curation UI can list — and the user can toggle —
+        // the ones that ship off.
+        expect(result.configuredModelIds).toHaveLength(3);
+
+        const enabledWireIds = h.backends
+          .enabledFor("opencode")
+          .map((id) => h.models.get(id)!.info.id)
+          .sort();
+        expect(enabledWireIds).toEqual(["opencode/a", "opencode/c"]);
+      });
+
+      it("leaves the backend's other picks intact when auto-enrolling a subset", async () => {
+        const h = makeHarness();
+        // A model the user already curated into the opencode backend from another
+        // origin (BYOK / Plus). Enrollment must add to that set, never replace it.
+        await h.backends.enableModel("opencode", "pre-existing-byok-model");
+
+        await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "openai-compatible",
+          displayName: "opencode",
+          apiKey: null,
+          wireModelIds: ["opencode/a", "opencode/b"],
+          autoEnrollModelIds: ["opencode/a"],
+        });
+
+        expect(h.backends.enabledFor("opencode")).toContain("pre-existing-byok-model");
+      });
+
+      it("enables nothing when autoEnrollModelIds is empty", async () => {
+        const h = makeHarness();
+        const result = await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "openai-compatible",
+          displayName: "opencode",
+          apiKey: null,
+          wireModelIds: ["opencode/a", "opencode/b"],
+          autoEnrollModelIds: [],
+        });
+
+        expect(result.configuredModelIds).toHaveLength(2);
+        expect(h.backends.enabledFor("opencode")).toEqual([]);
+      });
+
+      it("lets the agent-reported name + description win over catalog metadata", async () => {
+        const h = makeHarness();
+        // Catalog knows "claude-sonnet-4-5" as "Claude Sonnet 4.5"; the agent's
+        // own name/description must override so settings match the chat picker.
+        const result = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5"],
+          fallbackDisplayNames: { "claude-sonnet-4-5": "Sonnet" },
+          fallbackDescriptions: { "claude-sonnet-4-5": "Sonnet 4.6 · Best for everyday tasks" },
+        });
+        const info = h.models.listByProvider(result.providerId)[0].info;
+        expect(info.displayName).toBe("Sonnet");
+        expect(info.description).toBe("Sonnet 4.6 · Best for everyday tasks");
+      });
+
+      it("uses the fallback name + description for wire ids the catalog doesn't know", async () => {
+        const h = makeHarness();
+        const result = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["default"],
+          fallbackDisplayNames: { default: "Default (recommended)" },
+          fallbackDescriptions: {
+            default: "Opus 4.7 with 1M context · Most capable for complex work",
+          },
+        });
+        const info = h.models.listByProvider(result.providerId)[0].info;
+        expect(info.id).toBe("default");
+        expect(info.displayName).toBe("Default (recommended)");
+        expect(info.description).toBe("Opus 4.7 with 1M context · Most capable for complex work");
+      });
+
+      it("refreshes an existing model's display strings on re-register, preserving its id", async () => {
+        const h = makeHarness();
+        const first = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["default"],
+          fallbackDisplayNames: { default: "default" }, // stale, pre-feature label
+        });
+        const idBefore = h.models.listByProvider(first.providerId)[0].configuredModelId;
+
+        await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["default"],
+          fallbackDisplayNames: { default: "Default (recommended)" },
+          fallbackDescriptions: {
+            default: "Opus 4.7 with 1M context · Most capable for complex work",
+          },
+        });
+
+        const row = h.models.listByProvider(first.providerId)[0];
+        // Same row (enabled-set refs don't churn), refreshed strings.
+        expect(row.configuredModelId).toBe(idBefore);
+        expect(row.info.displayName).toBe("Default (recommended)");
+        expect(row.info.description).toBe(
+          "Opus 4.7 with 1M context · Most capable for complex work"
+        );
+      });
+
+      it("is idempotent on (agentType, providerType): re-running updates in place, no duplicate provider", async () => {
+        const h = makeHarness();
+        const first = await h.api.registerAgentProvider({
+          agentType: "codex",
+          providerType: "openai-compatible",
+          displayName: "Codex",
+          apiKey: null,
+          wireModelIds: ["gpt-5"],
+          fallbackDisplayNames: { "gpt-5": "GPT-5" },
+        });
+
+        // Clear the model-mutation spies so the second run's call counts
+        // reflect only what the identical re-register triggers.
+        h.models.add.mockClear();
+        h.backends.enableModel.mockClear();
+        h.coordinator.removeConfiguredModel.mockClear();
+
+        const second = await h.api.registerAgentProvider({
+          agentType: "codex",
+          providerType: "openai-compatible",
+          displayName: "Codex CLI", // changed label
+          apiKey: null,
+          wireModelIds: ["gpt-5"],
+          fallbackDisplayNames: { "gpt-5": "GPT-5" },
+        });
+
+        expect(second.providerId).toBe(first.providerId);
+        expect(h.providers.rows.size).toBe(1);
+        expect(h.providers.add).toHaveBeenCalledTimes(1);
+        expect(h.providers.update).toHaveBeenCalledTimes(1);
+        expect(h.providers.get(first.providerId)!.displayName).toBe("Codex CLI");
+        // Same single model, same id preserved.
+        expect(second.configuredModelIds).toEqual(first.configuredModelIds);
+        // Idempotent model reconcile: an unchanged wire-id list is a pure
+        // no-op — no add, no re-enroll, no cascade-remove ("only real
+        // add/remove deltas write settings", per the risk table).
+        expect(h.models.add).not.toHaveBeenCalled();
+        expect(h.backends.enableModel).not.toHaveBeenCalled();
+        expect(h.coordinator.removeConfiguredModel).not.toHaveBeenCalled();
+      });
+
+      it("adds a newly-reported wire id (new model enrolled) and preserves existing rows' ids + enable state", async () => {
+        const h = makeHarness();
+        const first = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5"],
+        });
+        const sonnetId = first.configuredModelIds[0];
+
+        // Simulate user disabling/curating: leave enable state as-is and re-run
+        // with an extra reported model.
+        const second = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
+        });
+
+        // Existing row kept its id.
+        expect(second.configuredModelIds).toContain(sonnetId);
+        expect(h.models.getByWireId(first.providerId, "claude-sonnet-4-5")!.configuredModelId).toBe(
+          sonnetId
+        );
+        // New row added + enrolled.
+        const opusId = h.models.getByWireId(first.providerId, "claude-opus-4-5")!.configuredModelId;
+        expect(opusId).toBeDefined();
+        expect(h.backends.enabledFor("claude")).toContain(opusId);
+        // Only the genuinely-new id triggered an add.
+        expect(h.models.add).toHaveBeenCalledTimes(2);
+      });
+
+      it("cascade-removes a vanished wire id (model removed + backend refs dropped via coordinator)", async () => {
+        const h = makeHarness();
+        const first = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
+        });
+        const opusId = h.models.getByWireId(first.providerId, "claude-opus-4-5")!.configuredModelId;
+
+        await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5"], // opus vanished
+        });
+
+        expect(h.coordinator.removeConfiguredModel).toHaveBeenCalledWith(opusId);
+        expect(h.models.getByWireId(first.providerId, "claude-opus-4-5")).toBeUndefined();
+        expect(h.backends.enabledFor("claude")).not.toContain(opusId);
+        // Surviving model still enrolled.
+        const sonnetId = h.models.getByWireId(
+          first.providerId,
+          "claude-sonnet-4-5"
+        )!.configuredModelId;
+        expect(h.backends.enabledFor("claude")).toContain(sonnetId);
+      });
+
+      it("does not call setApiKey for CLI-managed agents (apiKey: null) — keychain id stays null", async () => {
+        const h = makeHarness();
+        const result = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5"],
+        });
+        expect(h.providers.setApiKey).not.toHaveBeenCalled();
+        expect(h.providers.get(result.providerId)!.apiKeyKeychainId).toBeNull();
+      });
+
+      it("calls setApiKey when a key is supplied (subscription-style agent)", async () => {
+        const h = makeHarness();
+        const result = await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "anthropic",
+          displayName: "OpenCode",
+          apiKey: "sk-agent",
+          wireModelIds: ["claude-sonnet-4-5"],
+        });
+        expect(h.providers.setApiKey).toHaveBeenCalledWith(result.providerId, "sk-agent");
+        expect(h.providers.get(result.providerId)!.apiKeyKeychainId).toBeTruthy();
+      });
+
+      it("enriches info from the catalog on a hit and falls back on a miss", async () => {
+        const h = makeHarness();
+        const result = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5", "unknown-model"],
+          fallbackDisplayNames: { "unknown-model": "Unknown Model" },
+        });
+
+        const hit = h.models.getByWireId(result.providerId, "claude-sonnet-4-5")!;
+        // Full catalog metadata copied onto the snapshot.
+        expect(hit.info.displayName).toBe("Claude Sonnet 4.5");
+        expect(hit.info.reasoning).toBe(true);
+
+        const miss = h.models.getByWireId(result.providerId, "unknown-model")!;
+        expect(miss.info).toEqual({ id: "unknown-model", displayName: "Unknown Model" });
+      });
+
+      it("falls back to the bare wire id when there is no catalog hit and no fallback name", async () => {
+        const h = makeHarness();
+        const result = await h.api.registerAgentProvider({
+          agentType: "codex",
+          providerType: "openai-compatible",
+          displayName: "Codex",
+          apiKey: null,
+          wireModelIds: ["o4-mini"],
+        });
+        const row = h.models.getByWireId(result.providerId, "o4-mini")!;
+        expect(row.info).toEqual({ id: "o4-mini", displayName: "o4-mini" });
+      });
+
+      it("still snapshots every wire id when the catalog is unreachable", async () => {
+        // Unreachable catalog: ensureLoaded throws AND memory is empty (no
+        // providers ever loaded), so enrichment must fall back per wire id.
+        const h = makeHarness([]);
+        h.ensureLoaded.mockRejectedValueOnce(new Error("offline"));
+        const result = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5"],
+          fallbackDisplayNames: { "claude-sonnet-4-5": "Sonnet (fallback)" },
+        });
+        // Catalog enrichment failed → fallback used, but the model still exists.
+        const row = h.models.getByWireId(result.providerId, "claude-sonnet-4-5")!;
+        expect(row.info).toEqual({ id: "claude-sonnet-4-5", displayName: "Sonnet (fallback)" });
+        expect(h.backends.enabledFor("claude")).toContain(row.configuredModelId);
+      });
     });
 
-    // One provider, correct origin.
-    expect(h.providers.rows.size).toBe(1);
-    const provider = h.providers.get(result.providerId)!;
-    expect(provider.origin).toEqual({ kind: "agent", agentType: "claude" });
-    expect(provider.providerType).toBe("anthropic");
-    expect(provider.displayName).toBe("Claude Code");
+    // ---------------------------------------------------------------------------
+    // syncAgentModels
+    // ---------------------------------------------------------------------------
 
-    // Two ConfiguredModels.
-    expect(result.configuredModelIds).toHaveLength(2);
-    expect(
-      h.models
-        .listByProvider(result.providerId)
-        .map((m) => m.info.id)
-        .sort()
-    ).toEqual(["claude-opus-4-5", "claude-sonnet-4-5"]);
+    describe("syncAgentModels()", () => {
+      it("no-ops when no agent provider exists for the agentType", async () => {
+        const h = makeHarness();
+        const result = await h.api.syncAgentModels({
+          agentType: "claude",
+          wireModelIds: ["claude-sonnet-4-5"],
+        });
+        expect(result).toEqual({ added: [], removed: [] });
+        expect(h.models.add).not.toHaveBeenCalled();
+        expect(h.providers.add).not.toHaveBeenCalled();
+      });
 
-    // Enrolled into backends["claude"] only — not chat or other agents.
-    expect(h.backends.enabledFor("claude").sort()).toEqual([...result.configuredModelIds].sort());
-    expect(h.backends.enabledFor("chat")).toEqual([]);
-    expect(h.backends.enabledFor("opencode")).toEqual([]);
-    expect(h.backends.enabledFor("codex")).toEqual([]);
-  });
+      it("reconciles models without touching the provider row", async () => {
+        const h = makeHarness();
+        const reg = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5"],
+        });
+        const sonnetId = reg.configuredModelIds[0];
 
-  it("enables only autoEnrollModelIds while still creating every reported model", async () => {
-    const h = makeHarness();
-    const result = await h.api.registerAgentProvider({
-      agentType: "opencode",
-      providerType: "openai-compatible",
-      displayName: "opencode",
-      apiKey: null,
-      wireModelIds: ["opencode/a", "opencode/b", "opencode/c"],
-      autoEnrollModelIds: ["opencode/a", "opencode/c"],
+        h.providers.add.mockClear();
+        h.providers.update.mockClear();
+
+        const result = await h.api.syncAgentModels({
+          agentType: "claude",
+          wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
+        });
+
+        // Provider row untouched.
+        expect(h.providers.add).not.toHaveBeenCalled();
+        expect(h.providers.update).not.toHaveBeenCalled();
+
+        // New model added but left DISABLED; existing one preserved + still enabled.
+        expect(result.added).toHaveLength(1);
+        expect(result.removed).toHaveLength(0);
+        const opusId = h.models.getByWireId(reg.providerId, "claude-opus-4-5")!.configuredModelId;
+        expect(result.added).toEqual([opusId]);
+        expect(h.backends.enabledFor("claude")).toEqual([sonnetId]);
+        expect(h.backends.enabledFor("claude")).not.toContain(opusId);
+      });
+
+      it("leaves every model a later probe introduces disabled (only the seeded one stays on)", async () => {
+        // Mirrors opencode's first→follow-up flow: enrollment seeds one model, then
+        // a later probe floods in many more — none of which should turn themselves on.
+        const h = makeHarness();
+        const reg = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5"],
+        });
+        const sonnetId = reg.configuredModelIds[0];
+
+        await h.api.syncAgentModels({
+          agentType: "claude",
+          wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5", "claude-haiku-4-5"],
+        });
+
+        // The enabled set is unchanged: still just the seeded model.
+        expect(h.backends.enabledFor("claude")).toEqual([sonnetId]);
+        // ...even though both new models now exist as configured (toggleable) rows.
+        expect(h.models.getByWireId(reg.providerId, "claude-opus-4-5")).toBeDefined();
+        expect(h.models.getByWireId(reg.providerId, "claude-haiku-4-5")).toBeDefined();
+      });
+
+      it("cascade-removes a vanished model on sync", async () => {
+        const h = makeHarness();
+        const reg = await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
+        });
+        const opusId = h.models.getByWireId(reg.providerId, "claude-opus-4-5")!.configuredModelId;
+
+        const result = await h.api.syncAgentModels({
+          agentType: "claude",
+          wireModelIds: ["claude-sonnet-4-5"],
+        });
+
+        expect(result.removed).toEqual([opusId]);
+        expect(h.coordinator.removeConfiguredModel).toHaveBeenCalledWith(opusId);
+        expect(h.models.getByWireId(reg.providerId, "claude-opus-4-5")).toBeUndefined();
+      });
+
+      it("is a pure no-op when the reported list is unchanged", async () => {
+        const h = makeHarness();
+        await h.api.registerAgentProvider({
+          agentType: "claude",
+          providerType: "anthropic",
+          displayName: "Claude Code",
+          apiKey: null,
+          wireModelIds: ["claude-sonnet-4-5"],
+        });
+        h.models.add.mockClear();
+        h.coordinator.removeConfiguredModel.mockClear();
+
+        const result = await h.api.syncAgentModels({
+          agentType: "claude",
+          wireModelIds: ["claude-sonnet-4-5"],
+        });
+
+        expect(result).toEqual({ added: [], removed: [] });
+        expect(h.models.add).not.toHaveBeenCalled();
+        expect(h.coordinator.removeConfiguredModel).not.toHaveBeenCalled();
+      });
+
+      it("multi-provider: partitions wire ids per owning provider without corrupting another provider's list", async () => {
+        // opencode with two agent providers (anthropic + google). A later
+        // sync drops one model from each provider's owned set and reports an
+        // unowned wire id; the unowned id must NOT be added (no providerType
+        // to resolve it), and neither provider's surviving model is touched.
+        const h = makeHarness([CLAUDE_CATALOG, GOOGLE_CATALOG]);
+        const anthropic = await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "anthropic",
+          displayName: "OpenCode (Anthropic)",
+          apiKey: "sk-a",
+          wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
+        });
+        const google = await h.api.registerAgentProvider({
+          agentType: "opencode",
+          providerType: "google",
+          displayName: "OpenCode (Google)",
+          apiKey: "sk-g",
+          wireModelIds: ["gemini-2-5-pro", "gemini-2-5-flash"],
+        });
+
+        const opusId = h.models.getByWireId(
+          anthropic.providerId,
+          "claude-opus-4-5"
+        )!.configuredModelId;
+        const flashId = h.models.getByWireId(
+          google.providerId,
+          "gemini-2-5-flash"
+        )!.configuredModelId;
+        const sonnetId = h.models.getByWireId(
+          anthropic.providerId,
+          "claude-sonnet-4-5"
+        )!.configuredModelId;
+        const proId = h.models.getByWireId(google.providerId, "gemini-2-5-pro")!.configuredModelId;
+
+        h.models.add.mockClear();
+
+        // Report: each provider keeps one model; opus + flash vanish; an
+        // unowned wire id ("mystery-model") is reported but belongs to no
+        // existing provider.
+        const result = await h.api.syncAgentModels({
+          agentType: "opencode",
+          wireModelIds: ["claude-sonnet-4-5", "gemini-2-5-pro", "mystery-model"],
+        });
+
+        // Both vanished models cascade-removed, scoped to their own provider.
+        expect(result.removed.sort()).toEqual([opusId, flashId].sort());
+        expect(h.coordinator.removeConfiguredModel).toHaveBeenCalledWith(opusId);
+        expect(h.coordinator.removeConfiguredModel).toHaveBeenCalledWith(flashId);
+        // Unowned wire id is NOT enrolled (no providerType to place it).
+        expect(result.added).toEqual([]);
+        expect(h.models.add).not.toHaveBeenCalled();
+        // Each surviving model is preserved on its own provider; no cross-
+        // provider corruption.
+        expect(
+          h.models.getByWireId(anthropic.providerId, "claude-sonnet-4-5")!.configuredModelId
+        ).toBe(sonnetId);
+        expect(h.models.getByWireId(google.providerId, "gemini-2-5-pro")!.configuredModelId).toBe(
+          proId
+        );
+        expect(h.backends.enabledFor("opencode").sort()).toEqual([sonnetId, proId].sort());
+      });
     });
-
-    // All three exist, so the curation UI can list — and the user can toggle —
-    // the ones that ship off.
-    expect(result.configuredModelIds).toHaveLength(3);
-
-    const enabledWireIds = h.backends
-      .enabledFor("opencode")
-      .map((id) => h.models.get(id)!.info.id)
-      .sort();
-    expect(enabledWireIds).toEqual(["opencode/a", "opencode/c"]);
-  });
-
-  it("leaves the backend's other picks intact when auto-enrolling a subset", async () => {
-    const h = makeHarness();
-    // A model the user already curated into the opencode backend from another
-    // origin (BYOK / Plus). Enrollment must add to that set, never replace it.
-    await h.backends.enableModel("opencode", "pre-existing-byok-model");
-
-    await h.api.registerAgentProvider({
-      agentType: "opencode",
-      providerType: "openai-compatible",
-      displayName: "opencode",
-      apiKey: null,
-      wireModelIds: ["opencode/a", "opencode/b"],
-      autoEnrollModelIds: ["opencode/a"],
-    });
-
-    expect(h.backends.enabledFor("opencode")).toContain("pre-existing-byok-model");
-  });
-
-  it("enables nothing when autoEnrollModelIds is empty", async () => {
-    const h = makeHarness();
-    const result = await h.api.registerAgentProvider({
-      agentType: "opencode",
-      providerType: "openai-compatible",
-      displayName: "opencode",
-      apiKey: null,
-      wireModelIds: ["opencode/a", "opencode/b"],
-      autoEnrollModelIds: [],
-    });
-
-    expect(result.configuredModelIds).toHaveLength(2);
-    expect(h.backends.enabledFor("opencode")).toEqual([]);
-  });
-
-  it("lets the agent-reported name + description win over catalog metadata", async () => {
-    const h = makeHarness();
-    // Catalog knows "claude-sonnet-4-5" as "Claude Sonnet 4.5"; the agent's
-    // own name/description must override so settings match the chat picker.
-    const result = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5"],
-      fallbackDisplayNames: { "claude-sonnet-4-5": "Sonnet" },
-      fallbackDescriptions: { "claude-sonnet-4-5": "Sonnet 4.6 · Best for everyday tasks" },
-    });
-    const info = h.models.listByProvider(result.providerId)[0].info;
-    expect(info.displayName).toBe("Sonnet");
-    expect(info.description).toBe("Sonnet 4.6 · Best for everyday tasks");
-  });
-
-  it("uses the fallback name + description for wire ids the catalog doesn't know", async () => {
-    const h = makeHarness();
-    const result = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["default"],
-      fallbackDisplayNames: { default: "Default (recommended)" },
-      fallbackDescriptions: { default: "Opus 4.7 with 1M context · Most capable for complex work" },
-    });
-    const info = h.models.listByProvider(result.providerId)[0].info;
-    expect(info.id).toBe("default");
-    expect(info.displayName).toBe("Default (recommended)");
-    expect(info.description).toBe("Opus 4.7 with 1M context · Most capable for complex work");
-  });
-
-  it("refreshes an existing model's display strings on re-register, preserving its id", async () => {
-    const h = makeHarness();
-    const first = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["default"],
-      fallbackDisplayNames: { default: "default" }, // stale, pre-feature label
-    });
-    const idBefore = h.models.listByProvider(first.providerId)[0].configuredModelId;
-
-    await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["default"],
-      fallbackDisplayNames: { default: "Default (recommended)" },
-      fallbackDescriptions: { default: "Opus 4.7 with 1M context · Most capable for complex work" },
-    });
-
-    const row = h.models.listByProvider(first.providerId)[0];
-    // Same row (enabled-set refs don't churn), refreshed strings.
-    expect(row.configuredModelId).toBe(idBefore);
-    expect(row.info.displayName).toBe("Default (recommended)");
-    expect(row.info.description).toBe("Opus 4.7 with 1M context · Most capable for complex work");
-  });
-
-  it("is idempotent on (agentType, providerType): re-running updates in place, no duplicate provider", async () => {
-    const h = makeHarness();
-    const first = await h.api.registerAgentProvider({
-      agentType: "codex",
-      providerType: "openai-compatible",
-      displayName: "Codex",
-      apiKey: null,
-      wireModelIds: ["gpt-5"],
-      fallbackDisplayNames: { "gpt-5": "GPT-5" },
-    });
-
-    // Clear the model-mutation spies so the second run's call counts
-    // reflect only what the identical re-register triggers.
-    h.models.add.mockClear();
-    h.backends.enableModel.mockClear();
-    h.coordinator.removeConfiguredModel.mockClear();
-
-    const second = await h.api.registerAgentProvider({
-      agentType: "codex",
-      providerType: "openai-compatible",
-      displayName: "Codex CLI", // changed label
-      apiKey: null,
-      wireModelIds: ["gpt-5"],
-      fallbackDisplayNames: { "gpt-5": "GPT-5" },
-    });
-
-    expect(second.providerId).toBe(first.providerId);
-    expect(h.providers.rows.size).toBe(1);
-    expect(h.providers.add).toHaveBeenCalledTimes(1);
-    expect(h.providers.update).toHaveBeenCalledTimes(1);
-    expect(h.providers.get(first.providerId)!.displayName).toBe("Codex CLI");
-    // Same single model, same id preserved.
-    expect(second.configuredModelIds).toEqual(first.configuredModelIds);
-    // Idempotent model reconcile: an unchanged wire-id list is a pure
-    // no-op — no add, no re-enroll, no cascade-remove ("only real
-    // add/remove deltas write settings", per the risk table).
-    expect(h.models.add).not.toHaveBeenCalled();
-    expect(h.backends.enableModel).not.toHaveBeenCalled();
-    expect(h.coordinator.removeConfiguredModel).not.toHaveBeenCalled();
-  });
-
-  it("adds a newly-reported wire id (new model enrolled) and preserves existing rows' ids + enable state", async () => {
-    const h = makeHarness();
-    const first = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5"],
-    });
-    const sonnetId = first.configuredModelIds[0];
-
-    // Simulate user disabling/curating: leave enable state as-is and re-run
-    // with an extra reported model.
-    const second = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
-    });
-
-    // Existing row kept its id.
-    expect(second.configuredModelIds).toContain(sonnetId);
-    expect(h.models.getByWireId(first.providerId, "claude-sonnet-4-5")!.configuredModelId).toBe(
-      sonnetId
-    );
-    // New row added + enrolled.
-    const opusId = h.models.getByWireId(first.providerId, "claude-opus-4-5")!.configuredModelId;
-    expect(opusId).toBeDefined();
-    expect(h.backends.enabledFor("claude")).toContain(opusId);
-    // Only the genuinely-new id triggered an add.
-    expect(h.models.add).toHaveBeenCalledTimes(2);
-  });
-
-  it("cascade-removes a vanished wire id (model removed + backend refs dropped via coordinator)", async () => {
-    const h = makeHarness();
-    const first = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
-    });
-    const opusId = h.models.getByWireId(first.providerId, "claude-opus-4-5")!.configuredModelId;
-
-    await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5"], // opus vanished
-    });
-
-    expect(h.coordinator.removeConfiguredModel).toHaveBeenCalledWith(opusId);
-    expect(h.models.getByWireId(first.providerId, "claude-opus-4-5")).toBeUndefined();
-    expect(h.backends.enabledFor("claude")).not.toContain(opusId);
-    // Surviving model still enrolled.
-    const sonnetId = h.models.getByWireId(first.providerId, "claude-sonnet-4-5")!.configuredModelId;
-    expect(h.backends.enabledFor("claude")).toContain(sonnetId);
-  });
-
-  it("does not call setApiKey for CLI-managed agents (apiKey: null) — keychain id stays null", async () => {
-    const h = makeHarness();
-    const result = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5"],
-    });
-    expect(h.providers.setApiKey).not.toHaveBeenCalled();
-    expect(h.providers.get(result.providerId)!.apiKeyKeychainId).toBeNull();
-  });
-
-  it("calls setApiKey when a key is supplied (subscription-style agent)", async () => {
-    const h = makeHarness();
-    const result = await h.api.registerAgentProvider({
-      agentType: "opencode",
-      providerType: "anthropic",
-      displayName: "OpenCode",
-      apiKey: "sk-agent",
-      wireModelIds: ["claude-sonnet-4-5"],
-    });
-    expect(h.providers.setApiKey).toHaveBeenCalledWith(result.providerId, "sk-agent");
-    expect(h.providers.get(result.providerId)!.apiKeyKeychainId).toBeTruthy();
-  });
-
-  it("enriches info from the catalog on a hit and falls back on a miss", async () => {
-    const h = makeHarness();
-    const result = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5", "unknown-model"],
-      fallbackDisplayNames: { "unknown-model": "Unknown Model" },
-    });
-
-    const hit = h.models.getByWireId(result.providerId, "claude-sonnet-4-5")!;
-    // Full catalog metadata copied onto the snapshot.
-    expect(hit.info.displayName).toBe("Claude Sonnet 4.5");
-    expect(hit.info.reasoning).toBe(true);
-
-    const miss = h.models.getByWireId(result.providerId, "unknown-model")!;
-    expect(miss.info).toEqual({ id: "unknown-model", displayName: "Unknown Model" });
-  });
-
-  it("falls back to the bare wire id when there is no catalog hit and no fallback name", async () => {
-    const h = makeHarness();
-    const result = await h.api.registerAgentProvider({
-      agentType: "codex",
-      providerType: "openai-compatible",
-      displayName: "Codex",
-      apiKey: null,
-      wireModelIds: ["o4-mini"],
-    });
-    const row = h.models.getByWireId(result.providerId, "o4-mini")!;
-    expect(row.info).toEqual({ id: "o4-mini", displayName: "o4-mini" });
-  });
-
-  it("still snapshots every wire id when the catalog is unreachable", async () => {
-    // Unreachable catalog: ensureLoaded throws AND memory is empty (no
-    // providers ever loaded), so enrichment must fall back per wire id.
-    const h = makeHarness([]);
-    h.ensureLoaded.mockRejectedValueOnce(new Error("offline"));
-    const result = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5"],
-      fallbackDisplayNames: { "claude-sonnet-4-5": "Sonnet (fallback)" },
-    });
-    // Catalog enrichment failed → fallback used, but the model still exists.
-    const row = h.models.getByWireId(result.providerId, "claude-sonnet-4-5")!;
-    expect(row.info).toEqual({ id: "claude-sonnet-4-5", displayName: "Sonnet (fallback)" });
-    expect(h.backends.enabledFor("claude")).toContain(row.configuredModelId);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// syncAgentModels
-// ---------------------------------------------------------------------------
-
-describe("AgentSetupApi.syncAgentModels", () => {
-  it("no-ops when no agent provider exists for the agentType", async () => {
-    const h = makeHarness();
-    const result = await h.api.syncAgentModels({
-      agentType: "claude",
-      wireModelIds: ["claude-sonnet-4-5"],
-    });
-    expect(result).toEqual({ added: [], removed: [] });
-    expect(h.models.add).not.toHaveBeenCalled();
-    expect(h.providers.add).not.toHaveBeenCalled();
-  });
-
-  it("reconciles models without touching the provider row", async () => {
-    const h = makeHarness();
-    const reg = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5"],
-    });
-    const sonnetId = reg.configuredModelIds[0];
-
-    h.providers.add.mockClear();
-    h.providers.update.mockClear();
-
-    const result = await h.api.syncAgentModels({
-      agentType: "claude",
-      wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
-    });
-
-    // Provider row untouched.
-    expect(h.providers.add).not.toHaveBeenCalled();
-    expect(h.providers.update).not.toHaveBeenCalled();
-
-    // New model added but left DISABLED; existing one preserved + still enabled.
-    expect(result.added).toHaveLength(1);
-    expect(result.removed).toHaveLength(0);
-    const opusId = h.models.getByWireId(reg.providerId, "claude-opus-4-5")!.configuredModelId;
-    expect(result.added).toEqual([opusId]);
-    expect(h.backends.enabledFor("claude")).toEqual([sonnetId]);
-    expect(h.backends.enabledFor("claude")).not.toContain(opusId);
-  });
-
-  it("leaves every model a later probe introduces disabled (only the seeded one stays on)", async () => {
-    // Mirrors opencode's first→follow-up flow: enrollment seeds one model, then
-    // a later probe floods in many more — none of which should turn themselves on.
-    const h = makeHarness();
-    const reg = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5"],
-    });
-    const sonnetId = reg.configuredModelIds[0];
-
-    await h.api.syncAgentModels({
-      agentType: "claude",
-      wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5", "claude-haiku-4-5"],
-    });
-
-    // The enabled set is unchanged: still just the seeded model.
-    expect(h.backends.enabledFor("claude")).toEqual([sonnetId]);
-    // ...even though both new models now exist as configured (toggleable) rows.
-    expect(h.models.getByWireId(reg.providerId, "claude-opus-4-5")).toBeDefined();
-    expect(h.models.getByWireId(reg.providerId, "claude-haiku-4-5")).toBeDefined();
-  });
-
-  it("cascade-removes a vanished model on sync", async () => {
-    const h = makeHarness();
-    const reg = await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
-    });
-    const opusId = h.models.getByWireId(reg.providerId, "claude-opus-4-5")!.configuredModelId;
-
-    const result = await h.api.syncAgentModels({
-      agentType: "claude",
-      wireModelIds: ["claude-sonnet-4-5"],
-    });
-
-    expect(result.removed).toEqual([opusId]);
-    expect(h.coordinator.removeConfiguredModel).toHaveBeenCalledWith(opusId);
-    expect(h.models.getByWireId(reg.providerId, "claude-opus-4-5")).toBeUndefined();
-  });
-
-  it("is a pure no-op when the reported list is unchanged", async () => {
-    const h = makeHarness();
-    await h.api.registerAgentProvider({
-      agentType: "claude",
-      providerType: "anthropic",
-      displayName: "Claude Code",
-      apiKey: null,
-      wireModelIds: ["claude-sonnet-4-5"],
-    });
-    h.models.add.mockClear();
-    h.coordinator.removeConfiguredModel.mockClear();
-
-    const result = await h.api.syncAgentModels({
-      agentType: "claude",
-      wireModelIds: ["claude-sonnet-4-5"],
-    });
-
-    expect(result).toEqual({ added: [], removed: [] });
-    expect(h.models.add).not.toHaveBeenCalled();
-    expect(h.coordinator.removeConfiguredModel).not.toHaveBeenCalled();
-  });
-
-  it("multi-provider: partitions wire ids per owning provider without corrupting another provider's list", async () => {
-    // opencode with two agent providers (anthropic + google). A later
-    // sync drops one model from each provider's owned set and reports an
-    // unowned wire id; the unowned id must NOT be added (no providerType
-    // to resolve it), and neither provider's surviving model is touched.
-    const h = makeHarness([CLAUDE_CATALOG, GOOGLE_CATALOG]);
-    const anthropic = await h.api.registerAgentProvider({
-      agentType: "opencode",
-      providerType: "anthropic",
-      displayName: "OpenCode (Anthropic)",
-      apiKey: "sk-a",
-      wireModelIds: ["claude-sonnet-4-5", "claude-opus-4-5"],
-    });
-    const google = await h.api.registerAgentProvider({
-      agentType: "opencode",
-      providerType: "google",
-      displayName: "OpenCode (Google)",
-      apiKey: "sk-g",
-      wireModelIds: ["gemini-2-5-pro", "gemini-2-5-flash"],
-    });
-
-    const opusId = h.models.getByWireId(anthropic.providerId, "claude-opus-4-5")!.configuredModelId;
-    const flashId = h.models.getByWireId(google.providerId, "gemini-2-5-flash")!.configuredModelId;
-    const sonnetId = h.models.getByWireId(
-      anthropic.providerId,
-      "claude-sonnet-4-5"
-    )!.configuredModelId;
-    const proId = h.models.getByWireId(google.providerId, "gemini-2-5-pro")!.configuredModelId;
-
-    h.models.add.mockClear();
-
-    // Report: each provider keeps one model; opus + flash vanish; an
-    // unowned wire id ("mystery-model") is reported but belongs to no
-    // existing provider.
-    const result = await h.api.syncAgentModels({
-      agentType: "opencode",
-      wireModelIds: ["claude-sonnet-4-5", "gemini-2-5-pro", "mystery-model"],
-    });
-
-    // Both vanished models cascade-removed, scoped to their own provider.
-    expect(result.removed.sort()).toEqual([opusId, flashId].sort());
-    expect(h.coordinator.removeConfiguredModel).toHaveBeenCalledWith(opusId);
-    expect(h.coordinator.removeConfiguredModel).toHaveBeenCalledWith(flashId);
-    // Unowned wire id is NOT enrolled (no providerType to place it).
-    expect(result.added).toEqual([]);
-    expect(h.models.add).not.toHaveBeenCalled();
-    // Each surviving model is preserved on its own provider; no cross-
-    // provider corruption.
-    expect(h.models.getByWireId(anthropic.providerId, "claude-sonnet-4-5")!.configuredModelId).toBe(
-      sonnetId
-    );
-    expect(h.models.getByWireId(google.providerId, "gemini-2-5-pro")!.configuredModelId).toBe(
-      proId
-    );
-    expect(h.backends.enabledFor("opencode").sort()).toEqual([sonnetId, proId].sort());
   });
 });

--- a/src/modelManagement/setup/AgentSetupApi.ts
+++ b/src/modelManagement/setup/AgentSetupApi.ts
@@ -54,6 +54,8 @@ export interface RegisterAgentProviderInput {
 }
 
 export interface SyncAgentModelsInput {
+  /** Catalog-confirmed current ID to historical ID mappings, used to retain curated rows. */
+  legacyModelIds?: ReadonlyMap<string, string>;
   agentType: AgentType;
   wireModelIds: readonly string[];
   /** See `RegisterAgentProviderInput.fallbackDisplayNames`. */
@@ -206,7 +208,7 @@ export class AgentSetupApi {
         input.agentType,
         provider.providerId,
         infos,
-        { autoEnrollModelIds: ENROLL_NONE }
+        { autoEnrollModelIds: ENROLL_NONE, legacyModelIds: input.legacyModelIds }
       );
       return {
         added: added.map((a) => a.configuredModelId),
@@ -223,7 +225,13 @@ export class AgentSetupApi {
     for (const provider of providers) {
       const ownedWireIds: string[] = [];
       for (const wireId of wireIdSet) {
-        if (this.#models.getByWireId(provider.providerId, wireId)) {
+        const legacyId = input.legacyModelIds?.get(wireId);
+        // A renamed model still belongs to its original agent provider.
+        // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+        if (
+          this.#models.getByWireId(provider.providerId, wireId) ||
+          (legacyId && this.#models.getByWireId(provider.providerId, legacyId))
+        ) {
           ownedWireIds.push(wireId);
         }
       }
@@ -240,7 +248,7 @@ export class AgentSetupApi {
         input.agentType,
         provider.providerId,
         infos,
-        { autoEnrollModelIds: ENROLL_NONE }
+        { autoEnrollModelIds: ENROLL_NONE, legacyModelIds: input.legacyModelIds }
       );
       for (const a of added) addedAll.push(a.configuredModelId);
       for (const r of removed) removedAll.push(r.configuredModelId);
@@ -417,7 +425,7 @@ export class AgentSetupApi {
     agentType: AgentType,
     providerId: string,
     infos: readonly ModelInfo[],
-    opts: { autoEnrollModelIds?: readonly string[] }
+    opts: { autoEnrollModelIds?: readonly string[]; legacyModelIds?: ReadonlyMap<string, string> }
   ): Promise<{
     added: Array<{ wireId: string; configuredModelId: string }>;
     removed: Array<{ wireId: string; configuredModelId: string }>;
@@ -427,15 +435,35 @@ export class AgentSetupApi {
     const desiredWireIds = new Set(infos.map((info) => info.id));
     const autoEnrollFilter = opts.autoEnrollModelIds ? new Set(opts.autoEnrollModelIds) : null;
 
+    const migratedIds = new Set<string>();
+    const enabledIds = opts.legacyModelIds
+      ? new Set(this.#backends.get(agentType).enabledModels)
+      : null;
     const added: Array<{ wireId: string; configuredModelId: string }> = [];
     for (const info of infos) {
-      const current = existingByWireId.get(info.id);
+      const legacyId = opts.legacyModelIds?.get(info.id);
+      const legacy =
+        legacyId && !desiredWireIds.has(legacyId) ? existingByWireId.get(legacyId) : undefined;
+      // A historical grouped row can represent several literal IDs. Keep its
+      // identity for one and retain its toggle for the others through normal
+      // enrollment. A real catalog base is never treated as a legacy alias.
+      // https://github.com/Brevilabs/obsidian-copilot-private/issues/219
+      const current =
+        existingByWireId.get(info.id) ??
+        (legacy && !migratedIds.has(legacy.configuredModelId) ? legacy : undefined);
+      const inheritEnabled = legacy && enabledIds?.has(legacy.configuredModelId);
+      if (current && legacy) {
+        if (current === legacy) migratedIds.add(legacy.configuredModelId);
+        if (inheritEnabled && current !== legacy) {
+          await this.#backends.enableModel(agentType, current.configuredModelId);
+        }
+      }
       if (!current) {
         const configuredModelId = await this.#models.add({ providerId, info });
         // Enroll into this agent's backend only — agent models never leak into
         // chat or another agent's picker. A wire id outside `autoEnrollFilter`
         // (when set) ships available-but-off.
-        if (!autoEnrollFilter || autoEnrollFilter.has(info.id)) {
+        if (!autoEnrollFilter || autoEnrollFilter.has(info.id) || inheritEnabled) {
           await this.#backends.enableModel(agentType, configuredModelId);
         }
         added.push({ wireId: info.id, configuredModelId });
@@ -444,18 +472,19 @@ export class AgentSetupApi {
       // Refresh display strings in place when they drifted, without touching the
       // configuredModelId (so `BackendConfig.enabledModels` refs don't churn).
       if (
+        current.info.id !== info.id ||
         current.info.displayName !== info.displayName ||
         current.info.description !== info.description
       ) {
         await this.#models.update(current.configuredModelId, {
-          info: { displayName: info.displayName, description: info.description },
+          info: { id: info.id, displayName: info.displayName, description: info.description },
         });
       }
     }
 
     const removed: Array<{ wireId: string; configuredModelId: string }> = [];
     for (const model of existing) {
-      if (desiredWireIds.has(model.info.id)) continue;
+      if (desiredWireIds.has(model.info.id) || migratedIds.has(model.configuredModelId)) continue;
       await this.#coordinator.removeConfiguredModel(model.configuredModelId);
       removed.push({ wireId: model.info.id, configuredModelId: model.configuredModelId });
     }


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#219

## Why

OpenCode supplies effort through a separate selector. Its model-ID decoder still carries a hardcoded effort vocabulary and can incorrectly peel a valid trailing model-name segment from an ID. Native discovery can then save that truncated ID as a default, causing later sessions to select the wrong model.

## What

Keep complete OpenCode model IDs and send effort through the separate selector. Restore legacy defaults only when the live catalog confirms the full ID and excludes the saved base. Apply that normalization in ordinary chats and multi-agent sessions, including before discovery finishes.

Discovery repairs saved defaults and reconciles legacy configured rows through existing enrollment. Preserve the original configured ID for one replacement and retain enabled or disabled choices across literal IDs that were previously grouped together. Real base models take precedence. The historical effort list is confined to migration compatibility.

Commit `e11d782a` only groups existing tests under module/class/callable suites. The behavior fix is in `dc686e1d`.

## Non goal

Change OpenCode's minimum supported version, effort-selection behavior, provider mapping, or Codex.

## Screenshot

Not applicable. This removes obsolete parsing behavior; supported OpenCode catalogs and existing controls should look unchanged.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Tests cover full IDs, ordinary and multi-agent selection, discovery defaults, and preservation of configured IDs and enabled choices. |
| A defect would fail CI or be obvious on first use | ✅ | Parsing and selection regressions have deterministic coverage. |
| A revert fully restores prior state, including persisted data | ❌ | Discovery repairs stored model IDs and defaults; rollback needs a settings backup. |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Legacy saved selections are interpreted against the live catalog; tests cover existing-base precedence, absent IDs, and null effort. |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Legacy stored model IDs and defaults are normalized against the live catalog. |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Selection order and lifecycle are unchanged. |
| No hot-path behavior lacks deterministic coverage | ✅ | Codec and effort-dispatch paths have coverage. |
| No new dependency | ✅ | Dependencies are unchanged. |
| Human-only behavior stays in one feature area and surfaces quickly | ❌ | The supported-adapter contract also needs live verification; fixtures cannot prove every installed adapter's output. |

Review: confirm the existing version floor and ready-state gates in `src/agentMode/backends/opencode/OpencodeBinaryManager.ts` (`isOpencodeVersionOutdated`, `toOpencodeInstallState`), `src/agentMode/session/AgentModelPreloader.ts` (`preload`), and `src/agentMode/session/AgentSessionManager.ts` (`isBackendInstalled`). Inspect `src/agentMode/backends/opencode/descriptor.ts` (`opencodeWire`, `applySelection`, `prefetchEffortCatalog`) and follow Verification steps 1–4. Also inspect `opencodeModelMigration.ts`, `wireAgentModelDiscovery`, and `AgentSetupApi.syncAgentModels` for catalog-confirmed normalization and enabled-state preservation. Back up settings before live verification; reverting code does not undo repaired preferences.

## Verification

1. Back up test-vault settings, then load this branch with a supported OpenCode installation and an umbrella provider such as OpenRouter. Each configured model should retain its complete name and appear once.
2. Select a reasoning-capable model, choose an effort, send a message, then switch models and back. The effort control should reflect the active model.
3. Point settings at OpenCode older than 1.16.0. Setup should require an upgrade and prevent a chat from starting with that binary.

4. In a test vault with a legacy saved default for a literal model ID ending in an effort-like segment, open a new chat. It should select the complete ID when only that ID exists in the catalog. If both the shortened base and full ID exist, it must keep the saved base.

5. Start with an enabled or disabled legacy configured row whose old ID grouped multiple literal suffix IDs. Trigger discovery and confirm the replacement rows preserve that toggle. Run a multi-agent answer immediately after startup and confirm the exact saved model is used. Repeat with a real base model present; its identity must remain unchanged.
