### PR TITLE
Align nested gallery subtree labels with story rows

### DIFF
--- a/dev/gallery/Gallery.test.tsx
+++ b/dev/gallery/Gallery.test.tsx
@@ -470,7 +470,10 @@ describe("Gallery", () => {
         within(navigation).queryByRole("button", { name: /(Fold|Unfold) UI subtree/ })
       ).toBeNull();
       expect(within(navigation).getByRole("button", { name: "Default" })).toBeTruthy();
-      expect(selectSubtreeButton("UI/Badge")).toBeTruthy();
+      const badgeSubtreeButton = selectSubtreeButton("UI/Badge");
+      expect(badgeSubtreeButton).toBeTruthy();
+      expect(badgeSubtreeButton.parentElement?.classList.contains("tw-gap-1")).toBe(false);
+      expect(badgeSubtreeButton.classList.contains("tw-pl-2")).toBe(true);
       expect(selectSubtreeButton("UI/Button")).toBeTruthy();
       expect(navigation.querySelector('[data-gallery-story-button="UI/Badge/Status"]')).toBeNull();
 

--- a/dev/gallery/Gallery.tsx
+++ b/dev/gallery/Gallery.tsx
@@ -587,7 +587,7 @@ function StoryTree({
 
         return (
           <li key={node.path}>
-            <div className="tw-flex tw-items-center tw-gap-1">
+            <div className="tw-flex tw-items-center">
               {canFold && (
                 <Button
                   aria-expanded={expanded}
@@ -615,7 +615,7 @@ function StoryTree({
               <Button
                 aria-label={`Show ${node.path} contact sheet`}
                 aria-pressed={subtreeSelected}
-                className="tw-min-w-0 tw-flex-1 tw-justify-start tw-text-left tw-font-semibold"
+                className="tw-min-w-0 tw-flex-1 tw-justify-start tw-pl-2 tw-text-left tw-font-semibold"
                 onClick={() => {
                   onSelectSubtree(node.path);
                   if (canFold && !expandAll) {


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#280

## Why

In the component gallery, a nested subtree name sits farther right than the story names directly beneath it. The extra space after the disclosure caret makes the hierarchy look uneven and makes the child stories appear to start in a different column.

## What

Nested subtree names now share the same visual left edge as their story names. The caret still has its own click target, and clicking either the caret or subtree name preserves the existing fold and contact-sheet behavior.

## Non goal

- Changing tree depth, divider placement, or top-level category layout.
- Changing how stories or contact sheets are selected and rendered.

## Screenshot

**Before (`v4-preview`)**

<img width="1920" height="1050" alt="Gallery tree before: subtree label offset to the right of story label" src="https://github.com/user-attachments/assets/f576eb61-6340-4c03-972e-2fa156d289bc" />

**After (this branch)**

<img width="1920" height="1050" alt="Gallery tree after: subtree and story labels aligned" src="https://github.com/user-attachments/assets/cd717f41-b65a-4fa2-aabb-e0313e0bedf6" />

Direct measurement shows the subtree/story offset change from 7 px on `v4-preview` to the 1 px tree-divider edge on this branch.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | This is a cosmetic gallery-tree alignment change with deterministic coverage for the spacing classes |
| A defect would fail CI or be obvious on first use | ✅ | The gallery test covers the class contract and any visual regression is visible when opening a nested subtree |
| A revert fully restores prior state, including persisted data | ✅ | The change only adjusts rendered classes and stores no data |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Gallery navigation styling is the only affected surface |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Component contracts and persisted gallery state are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Folding and selection handlers are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | The existing nested-subtree test now checks both alignment conditions |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The alignment is immediately visible in the component-gallery tree |

Review: run Verification and confirm the nested subtree and story labels share one left edge while both disclosure controls still work.

## Verification

1. Run `npm run gallery:vault` with the Copilot test vault configured.
2. Open **Component gallery**, then select **Agent Mode → Agent Turn Duration Indicator → Complete**.
3. Confirm **Agent Turn Duration Indicator** and **Complete** start on the same visual left edge.
4. Click the subtree caret and subtree name separately; confirm folding and contact-sheet selection still behave as before.
