### PR TITLE
Distinguish and align agent trail status rows

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -63,7 +63,7 @@ While an agent turn is running, the activity trail shows **Worked for** with a l
 
 While a reasoning step is active, its brain row shows an animated ellipsis rather than a second timer. When that step finishes, the row changes to **Thought for** with its frozen duration.
 
-When the turn finishes, the time freezes and the Copilot icon becomes static. The completed duration moves to the leading edge of the same footer row as the response controls; when a response timestamp is shown, it follows the duration. The duration remains visible until you send the next prompt, when a new counter takes its place. Leading zero units are omitted, so durations appear as `18s`, `2m 18s`, or `1h 2m 18s`.
+When the turn finishes, the time freezes and the Copilot icon becomes static. The completed duration moves to the leading edge of the same footer row as the response controls. When a duration is unavailable, the message timestamp appears in that position instead; only one of the two is shown. The duration remains visible until you send the next prompt, when that completed response falls back to its timestamp and the new turn owns the live counter. Leading zero units are omitted, so durations appear as `18s`, `2m 18s`, or `1h 2m 18s`.
 
 ## Choosing an Operating Mode
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -61,7 +61,9 @@ If you've turned on reduced motion in your operating system, the prompts still r
 
 While an agent turn is running, the activity trail shows **Worked for** with a live elapsed-time counter and the animated Copilot icon. The counter measures the full wall-clock time from sending the prompt until the turn finishes, including tool use and any time spent waiting for a permission or answer.
 
-When the turn finishes, the time freezes and the Copilot icon becomes static. The completed duration remains visible beneath the latest response until you send the next prompt, when a new counter takes its place. Leading zero units are omitted, so durations appear as `18s`, `2m 18s`, or `1h 2m 18s`.
+While a reasoning step is active, its brain row shows an animated ellipsis rather than a second timer. When that step finishes, the row changes to **Thought for** with its frozen duration.
+
+When the turn finishes, the time freezes and the Copilot icon becomes static. The completed duration moves into the same footer row as the response controls and remains visible until you send the next prompt, when a new counter takes its place. Leading zero units are omitted, so durations appear as `18s`, `2m 18s`, or `1h 2m 18s`.
 
 ## Choosing an Operating Mode
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -270,7 +270,7 @@ While the agent is working, the chat shows what it is doing. A single action get
 
 When the agent performs several actions in a row, they are collapsed into one summary row instead of a long list — for example "Read 2 files, ran 5 commands, thought for 51s". While that work is still in progress, the current step (like the command being run) appears beneath the summary and updates as the agent moves on.
 
-Click a summary row to expand it and see every action inside, each with its own status line. An expanded row stays open — even as new actions stream into it — until you collapse it again.
+Reasoning, individual tool calls, grouped activity, and delegated agents use the same aligned status-row style. Whenever a row has more detail, it shows the same disclosure arrow and can be opened with a click or the keyboard. Expanded details appear on the same indented rail, and an activity group stays open — even as new actions stream into it — until you collapse it again.
 
 Only background work is grouped this way. The agent's own messages, plan checklists, questions to you, and delegated sub-agents always stay visible as separate rows.
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -63,7 +63,7 @@ While an agent turn is running, the activity trail shows **Worked for** with a l
 
 While a reasoning step is active, its brain row shows an animated ellipsis rather than a second timer. When that step finishes, the row changes to **Thought for** with its frozen duration.
 
-When the turn finishes, the time freezes and the Copilot icon becomes static. The completed duration moves into the same footer row as the response controls and remains visible until you send the next prompt, when a new counter takes its place. Leading zero units are omitted, so durations appear as `18s`, `2m 18s`, or `1h 2m 18s`.
+When the turn finishes, the time freezes and the Copilot icon becomes static. The completed duration moves to the leading edge of the same footer row as the response controls; when a response timestamp is shown, it follows the duration. The duration remains visible until you send the next prompt, when a new counter takes its place. Leading zero units are omitted, so durations appear as `18s`, `2m 18s`, or `1h 2m 18s`.
 
 ## Choosing an Operating Mode
 

--- a/src/agentMode/ui/ActionCard.tsx
+++ b/src/agentMode/ui/ActionCard.tsx
@@ -1,13 +1,13 @@
 import React, { useMemo } from "react";
-import { ChevronDown, ChevronRight, Loader2, Check, X } from "lucide-react";
+import { Loader2, Check, X } from "lucide-react";
 import type { ToolCallPart } from "@/agentMode/ui/agentTrail";
 import type { AgentToolStatus } from "@/agentMode/session/types";
 import { lookupToolSummary } from "@/agentMode/ui/toolSummaries";
 import { renderDiff } from "@/agentMode/ui/diffRender";
 import { getVaultBase } from "@/utils/vaultPath";
 import { openVaultPath } from "@/utils/openVaultPath";
-import { cn } from "@/lib/utils";
 import { useApp } from "@/context";
+import { AgentActivityCard } from "@/components/chat-components/AgentActivityCard";
 
 interface ActionCardProps {
   part: ToolCallPart;
@@ -34,23 +34,14 @@ export const ActionCard: React.FC<ActionCardProps> = ({ part, open, onToggle }) 
   const targetPath =
     part.status === "completed" ? (summary.targetPath?.(part, summaryCtx) ?? null) : null;
 
-  const headerClasses = cn(
-    "tw-flex tw-items-center tw-gap-1.5 tw-text-sm tw-text-muted",
-    expandable && "tw-cursor-pointer hover:tw-text-normal"
-  );
-
   return (
-    <div className="tw-my-1 tw-flex tw-flex-col tw-gap-0.5">
-      <div
-        className={headerClasses}
-        onClick={expandable ? onToggle : undefined}
-        role={expandable ? "button" : undefined}
-      >
-        <Icon className="tw-size-3.5 tw-shrink-0 tw-text-muted" />
-        {targetPath ? (
+    <AgentActivityCard
+      icon={Icon}
+      label={
+        targetPath ? (
           <a
             href="#"
-            className="tw-flex-1 tw-truncate tw-font-medium tw-text-inherit hover:tw-text-accent hover:tw-underline"
+            className="tw-min-w-0 tw-truncate tw-text-inherit hover:tw-text-accent hover:tw-underline"
             onClick={(e) => {
               e.preventDefault();
               e.stopPropagation();
@@ -64,46 +55,40 @@ export const ActionCard: React.FC<ActionCardProps> = ({ part, open, onToggle }) 
             {line}
           </a>
         ) : (
-          <span className="tw-flex-1 tw-truncate tw-font-medium">{line}</span>
-        )}
-        <StatusBadge status={part.status} />
-        {expandable &&
-          (open ? (
-            <ChevronDown className="tw-size-3 tw-text-muted" />
-          ) : (
-            <ChevronRight className="tw-size-3 tw-text-muted" />
-          ))}
-      </div>
-      {expandable && open ? (
-        <div className="tw-mt-1 tw-flex tw-flex-col tw-gap-1">
-          {details ? (
-            <pre className="tw-max-h-40 tw-overflow-auto tw-whitespace-pre-wrap tw-rounded tw-bg-secondary-alt tw-p-1 tw-text-xs">
-              {details}
-            </pre>
-          ) : null}
-          {outcome ? <div className="tw-text-xs tw-text-muted">{outcome}</div> : null}
-          {outputs.map((o, i) =>
-            o.type === "text" ? (
-              <pre
-                // eslint-disable-next-line @eslint-react/no-array-index-key -- tool outputs are append-only; index is stable
-                key={`text-${i}`}
-                className="tw-max-h-40 tw-overflow-auto tw-whitespace-pre-wrap tw-rounded tw-bg-secondary-alt tw-p-1 tw-text-xs"
-              >
-                {o.text}
-              </pre>
-            ) : (
-              // eslint-disable-next-line @eslint-react/no-array-index-key -- tool outputs are append-only; index is stable
-              <div key={`diff-${i}-${o.path}`} className="tw-rounded tw-bg-secondary-alt tw-p-1">
-                <p className="tw-font-mono tw-text-xs tw-text-muted">{o.path}</p>
-                <pre className="tw-max-h-40 tw-overflow-auto tw-whitespace-pre-wrap tw-text-xs">
-                  {renderDiff(o.oldText, o.newText)}
-                </pre>
-              </div>
-            )
-          )}
-        </div>
+          <span className="tw-truncate">{line}</span>
+        )
+      }
+      trailing={<StatusBadge status={part.status} />}
+      expandable={expandable}
+      open={open}
+      onToggle={onToggle}
+    >
+      {details ? (
+        <pre className="tw-max-h-40 tw-overflow-auto tw-whitespace-pre-wrap tw-rounded tw-bg-secondary-alt tw-p-1 tw-text-xs">
+          {details}
+        </pre>
       ) : null}
-    </div>
+      {outcome ? <div className="tw-text-xs tw-text-muted">{outcome}</div> : null}
+      {outputs.map((o, i) =>
+        o.type === "text" ? (
+          <pre
+            // eslint-disable-next-line @eslint-react/no-array-index-key -- tool outputs are append-only; index is stable
+            key={`text-${i}`}
+            className="tw-max-h-40 tw-overflow-auto tw-whitespace-pre-wrap tw-rounded tw-bg-secondary-alt tw-p-1 tw-text-xs"
+          >
+            {o.text}
+          </pre>
+        ) : (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- tool outputs are append-only; index is stable
+          <div key={`diff-${i}-${o.path}`} className="tw-rounded tw-bg-secondary-alt tw-p-1">
+            <p className="tw-font-mono tw-text-xs tw-text-muted">{o.path}</p>
+            <pre className="tw-max-h-40 tw-overflow-auto tw-whitespace-pre-wrap tw-text-xs">
+              {renderDiff(o.oldText, o.newText)}
+            </pre>
+          </div>
+        )
+      )}
+    </AgentActivityCard>
   );
 };
 

--- a/src/agentMode/ui/ActivityGroupCard.tsx
+++ b/src/agentMode/ui/ActivityGroupCard.tsx
@@ -1,11 +1,12 @@
-import React, { useId } from "react";
-import { ChevronDown, ChevronRight, Layers, Loader2, type LucideIcon } from "lucide-react";
+import React from "react";
+import { Layers, Loader2, type LucideIcon } from "lucide-react";
 import {
   summarizeActivity,
   type ActivityGroupNode,
   type ActivityMember,
 } from "@/agentMode/ui/activityGroups";
 import { pickToolIcon } from "@/agentMode/ui/toolIcons";
+import { AgentActivityCard } from "@/components/chat-components/AgentActivityCard";
 
 export interface ActivityGroupCardProps {
   group: ActivityGroupNode;
@@ -49,7 +50,6 @@ export const ActivityGroupCard: React.FC<ActivityGroupCardProps> = ({
   renderMember,
   liveStep,
 }) => {
-  const bodyId = useId();
   const summary = summarizeActivity(group.members, { thinkingMs });
   const Icon = groupIcon(group.members);
   const isProcessing = group.members.some(
@@ -57,50 +57,26 @@ export const ActivityGroupCard: React.FC<ActivityGroupCardProps> = ({
   );
 
   return (
-    <div className="tw-my-1 tw-flex tw-flex-col tw-gap-0.5">
-      {/* A native `button` here inherits Obsidian's button chrome — a grey fill
-          and an inset shadow that no Tailwind reset outranks — so the row would
-          render as a pill among the trail's flat rows. Every sibling card uses
-          this shape for the same reason; the keyboard handler keeps it operable. */}
-      <div
-        role="button"
-        tabIndex={0}
-        aria-expanded={open}
-        aria-controls={bodyId}
-        onClick={onToggle}
-        onKeyDown={(e) => {
-          if (e.key !== "Enter" && e.key !== " ") return;
-          e.preventDefault();
-          onToggle();
-        }}
-        className="tw-flex tw-cursor-pointer tw-items-center tw-gap-1.5 tw-text-sm tw-text-muted hover:tw-text-normal"
-      >
-        <Icon className="tw-size-3.5 tw-shrink-0 tw-text-muted" />
-        <span className="tw-flex-1 tw-truncate tw-font-medium">{summary.line}</span>
-        {summary.failed > 0 ? (
-          <span className="tw-shrink-0 tw-text-xs tw-text-muted">{summary.failed} failed</span>
-        ) : null}
-        {isProcessing ? (
-          <Loader2 className="tw-size-3 tw-shrink-0 tw-animate-spin tw-text-loading" />
-        ) : null}
-        {open ? (
-          <ChevronDown className="tw-size-3 tw-shrink-0 tw-text-muted" />
-        ) : (
-          <ChevronRight className="tw-size-3 tw-shrink-0 tw-text-muted" />
-        )}
-      </div>
-      {!open && liveStep ? (
-        <div className="tw-truncate tw-pl-5 tw-text-xs tw-text-muted">{liveStep}</div>
-      ) : null}
-      {open ? (
-        <div
-          id={bodyId}
-          className="tw-mt-1 tw-flex tw-flex-col tw-border-l tw-border-border tw-pl-3"
-        >
-          {group.members.map((m, i) => renderMember(m, i))}
-        </div>
-      ) : null}
-    </div>
+    <AgentActivityCard
+      icon={Icon}
+      label={summary.line}
+      trailing={
+        <>
+          {summary.failed > 0 ? (
+            <span className="tw-shrink-0 tw-text-xs tw-text-muted">{summary.failed} failed</span>
+          ) : null}
+          {isProcessing ? (
+            <Loader2 className="tw-size-3 tw-shrink-0 tw-animate-spin tw-text-loading" />
+          ) : null}
+        </>
+      }
+      secondary={!open ? liveStep : undefined}
+      expandable
+      open={open}
+      onToggle={onToggle}
+    >
+      {group.members.map((m, i) => renderMember(m, i))}
+    </AgentActivityCard>
   );
 };
 

--- a/src/agentMode/ui/AgentChatMessages.test.tsx
+++ b/src/agentMode/ui/AgentChatMessages.test.tsx
@@ -16,7 +16,18 @@ jest.mock("@/hooks/useChatScrolling", () => ({
 
 jest.mock("@/components/chat-components/ChatSingleMessage", () => ({
   __esModule: true,
-  default: ({ message }: { message: { message: string } }) => <div>{message.message}</div>,
+  default: ({
+    message,
+    footerStart,
+  }: {
+    message: { message: string };
+    footerStart?: React.ReactNode;
+  }) => (
+    <div>
+      {message.message}
+      <div data-testid="single-message-footer">{footerStart}</div>
+    </div>
+  ),
 }));
 
 function assistantMessage(
@@ -64,6 +75,9 @@ describe("AgentChatMessages", () => {
       );
 
       expect(screen.getByText("2m 18s")).toBeTruthy();
+      expect(screen.getByTestId("single-message-footer").textContent).toContain(
+        "Worked for 2m 18s"
+      );
       expect(container.querySelector(".copilot-spinner")).toBeTruthy();
       expect(container.querySelector(".copilot-spinner-dot-0")).toBeNull();
     });

--- a/src/agentMode/ui/AgentChatMessages.test.tsx
+++ b/src/agentMode/ui/AgentChatMessages.test.tsx
@@ -30,6 +30,12 @@ jest.mock("@/components/chat-components/ChatSingleMessage", () => ({
   ),
 }));
 
+jest.mock("@/agentMode/ui/AgentTrailView", () => ({
+  AgentTrail: ({ timestamp }: { timestamp?: string }) => (
+    <div data-testid="agent-trail-timestamp">{timestamp}</div>
+  ),
+}));
+
 function assistantMessage(
   id: string,
   timestampMs: number,
@@ -97,6 +103,21 @@ describe("AgentChatMessages", () => {
 
       act(() => jest.advanceTimersByTime(1_000));
       expect(screen.getByText("3s")).toBeTruthy();
+    });
+
+    it("passes the message timestamp to a structured trail without a duration", () => {
+      const timestamp = "2026/08/07 20:31:10";
+      renderMessages(
+        [
+          assistantMessage("answer-1", 62_000, {
+            timestamp: { epoch: 62_000, display: timestamp, fileName: "20260807_203110" },
+            parts: [{ kind: "thought", text: "Inspect the response." }],
+          }),
+        ],
+        false
+      );
+
+      expect(screen.getByTestId("agent-trail-timestamp").textContent).toBe(timestamp);
     });
   });
 });

--- a/src/agentMode/ui/AgentChatMessages.tsx
+++ b/src/agentMode/ui/AgentChatMessages.tsx
@@ -137,13 +137,16 @@ const AgentChatMessages = memo(
               ownsTurnDuration && message.id === streamingMessageId
                 ? message.timestamp?.epoch
                 : undefined;
-            const standaloneTurnDuration =
+            const completedTurnDuration =
               completedTurnDurationMs !== undefined ? (
                 <AgentTurnDurationIndicator
                   status="complete"
                   durationMs={completedTurnDurationMs}
+                  inline
                 />
-              ) : runningTurnStartedAtMs !== undefined ? (
+              ) : null;
+            const runningTurnDuration =
+              runningTurnStartedAtMs !== undefined ? (
                 <AgentTurnDurationIndicator status="running" startedAtMs={runningTurnStartedAtMs} />
               ) : null;
             // The streaming placeholder (empty body, no parts) renders the
@@ -169,11 +172,16 @@ const AgentChatMessages = memo(
               >
                 {fanoutTurn ? (
                   <div className="tw-px-3 tw-pt-2">
-                    <FanoutMessageCard message={message} turn={fanoutTurn} app={app} />
-                    {standaloneTurnDuration}
+                    <FanoutMessageCard
+                      message={message}
+                      turn={fanoutTurn}
+                      app={app}
+                      footerStart={completedTurnDuration}
+                    />
+                    {runningTurnDuration}
                   </div>
                 ) : isStreamingPlaceholder ? (
-                  <div className="tw-px-3 tw-pt-2">{standaloneTurnDuration}</div>
+                  <div className="tw-px-3 tw-pt-2">{runningTurnDuration}</div>
                 ) : renderTrail ? (
                   <div className="tw-px-3 tw-pt-2">
                     <AgentTrail
@@ -191,9 +199,14 @@ const AgentChatMessages = memo(
                   // lifecycle handlers are wired — ChatButtons renders only the
                   // copy / insert actions it can honor.
                   <>
-                    <ChatSingleMessage message={adaptedMessage} app={app} isStreaming={false} />
-                    {standaloneTurnDuration ? (
-                      <div className="tw-px-3">{standaloneTurnDuration}</div>
+                    <ChatSingleMessage
+                      message={adaptedMessage}
+                      app={app}
+                      isStreaming={false}
+                      footerStart={completedTurnDuration}
+                    />
+                    {runningTurnDuration ? (
+                      <div className="tw-px-3">{runningTurnDuration}</div>
                     ) : null}
                   </>
                 )}

--- a/src/agentMode/ui/AgentChatMessages.tsx
+++ b/src/agentMode/ui/AgentChatMessages.tsx
@@ -189,6 +189,7 @@ const AgentChatMessages = memo(
                       isStreaming={message.id === streamingMessageId}
                       turnStartedAtMs={runningTurnStartedAtMs}
                       turnDurationMs={completedTurnDurationMs}
+                      timestamp={message.timestamp?.display}
                       app={app}
                       turnStopReason={message.turnStopReason}
                     />

--- a/src/agentMode/ui/AgentMessageActions.tsx
+++ b/src/agentMode/ui/AgentMessageActions.tsx
@@ -1,3 +1,4 @@
+import { AgentTurnDurationIndicator } from "@/agentMode/ui/AgentTurnDurationIndicator";
 import { CopyButton } from "@/components/chat-components/CopyButton";
 import { MessageActionButton } from "@/components/chat-components/MessageActionButton";
 import { cn } from "@/lib/utils";
@@ -11,6 +12,8 @@ interface AgentMessageActionsProps {
    *  `cleanMessageForCopy` by the trail. Copied / inserted verbatim. */
   text: string;
   app: App;
+  /** Frozen wall-clock duration shown beside the completed response controls. */
+  durationMs?: number;
 }
 
 /**
@@ -19,17 +22,31 @@ interface AgentMessageActionsProps {
  * but acts on the trail's final answer text rather than a `ChatMessage` —
  * regenerate / edit / delete can slot into this same row later.
  */
-export const AgentMessageActions: React.FC<AgentMessageActionsProps> = ({ text, app }) => (
+export const AgentMessageActions: React.FC<AgentMessageActionsProps> = ({
+  text,
+  app,
+  durationMs,
+}) => (
   <div
-    className={cn("tw-flex tw-justify-end tw-gap-1", {
-      "group-hover:opacity-100 opacity-0": !Platform.isMobile,
-    })}
+    className={cn(
+      "tw-flex tw-items-center",
+      durationMs === undefined ? "tw-justify-end" : "tw-justify-between"
+    )}
   >
-    <MessageActionButton
-      label="Insert / Replace at cursor"
-      icon={TextCursorInput}
-      onClick={() => void insertAtCursor(app, text)}
-    />
-    <CopyButton text={text} />
+    {durationMs !== undefined ? (
+      <AgentTurnDurationIndicator status="complete" durationMs={durationMs} inline />
+    ) : null}
+    <div
+      className={cn("tw-flex tw-items-center tw-gap-1", {
+        "group-hover:opacity-100 opacity-0": !Platform.isMobile,
+      })}
+    >
+      <MessageActionButton
+        label="Insert / Replace at cursor"
+        icon={TextCursorInput}
+        onClick={() => void insertAtCursor(app, text)}
+      />
+      <CopyButton text={text} />
+    </div>
   </div>
 );

--- a/src/agentMode/ui/AgentMessageActions.tsx
+++ b/src/agentMode/ui/AgentMessageActions.tsx
@@ -15,6 +15,8 @@ interface AgentMessageActionsProps {
   app: App;
   /** Frozen wall-clock duration shown beside the completed response controls. */
   durationMs?: number;
+  /** Message creation time used when no completed duration is available. */
+  timestamp?: string;
 }
 
 /**
@@ -27,6 +29,7 @@ export const AgentMessageActions: React.FC<AgentMessageActionsProps> = ({
   text,
   app,
   durationMs,
+  timestamp,
 }) => (
   <AssistantResponseFooter
     leading={
@@ -34,6 +37,7 @@ export const AgentMessageActions: React.FC<AgentMessageActionsProps> = ({
         <AgentTurnDurationIndicator status="complete" durationMs={durationMs} inline />
       ) : undefined
     }
+    timestamp={timestamp}
     actions={
       <div
         className={cn("tw-flex tw-items-center tw-gap-1", {

--- a/src/agentMode/ui/AgentMessageActions.tsx
+++ b/src/agentMode/ui/AgentMessageActions.tsx
@@ -1,6 +1,7 @@
 import { AgentTurnDurationIndicator } from "@/agentMode/ui/AgentTurnDurationIndicator";
 import { CopyButton } from "@/components/chat-components/CopyButton";
 import { MessageActionButton } from "@/components/chat-components/MessageActionButton";
+import { AssistantResponseFooter } from "@/components/ui/AssistantResponseFooter";
 import { cn } from "@/lib/utils";
 import { insertAtCursor } from "@/utils";
 import { TextCursorInput } from "lucide-react";
@@ -27,26 +28,25 @@ export const AgentMessageActions: React.FC<AgentMessageActionsProps> = ({
   app,
   durationMs,
 }) => (
-  <div
-    className={cn(
-      "tw-flex tw-items-center",
-      durationMs === undefined ? "tw-justify-end" : "tw-justify-between"
-    )}
-  >
-    {durationMs !== undefined ? (
-      <AgentTurnDurationIndicator status="complete" durationMs={durationMs} inline />
-    ) : null}
-    <div
-      className={cn("tw-flex tw-items-center tw-gap-1", {
-        "group-hover:opacity-100 opacity-0": !Platform.isMobile,
-      })}
-    >
-      <MessageActionButton
-        label="Insert / Replace at cursor"
-        icon={TextCursorInput}
-        onClick={() => void insertAtCursor(app, text)}
-      />
-      <CopyButton text={text} />
-    </div>
-  </div>
+  <AssistantResponseFooter
+    leading={
+      durationMs !== undefined ? (
+        <AgentTurnDurationIndicator status="complete" durationMs={durationMs} inline />
+      ) : undefined
+    }
+    actions={
+      <div
+        className={cn("tw-flex tw-items-center tw-gap-1", {
+          "group-hover:opacity-100 opacity-0": !Platform.isMobile,
+        })}
+      >
+        <MessageActionButton
+          label="Insert / Replace at cursor"
+          icon={TextCursorInput}
+          onClick={() => void insertAtCursor(app, text)}
+        />
+        <CopyButton text={text} />
+      </div>
+    }
+  />
 );

--- a/src/agentMode/ui/AgentTrailView.stories.tsx
+++ b/src/agentMode/ui/AgentTrailView.stories.tsx
@@ -80,7 +80,9 @@ const TrailDemo: React.FC<{ parts: AgentMessagePart[]; isStreaming?: boolean }> 
         parts={parts}
         isStreaming={isStreaming}
         turnStartedAtMs={isStreaming ? Date.now() - 138_000 : undefined}
+        turnDurationMs={isStreaming ? undefined : 138_000}
         app={app}
+        turnStopReason={isStreaming ? undefined : "end_turn"}
       />
     </TooltipProvider>
   );

--- a/src/agentMode/ui/AgentTrailView.stories.tsx
+++ b/src/agentMode/ui/AgentTrailView.stories.tsx
@@ -63,6 +63,28 @@ const STREAMING: AgentMessagePart[] = [
   }),
 ];
 
+/** Every expandable activity family sharing one header and folding treatment. */
+const UNIFIED_CARDS: AgentMessagePart[] = [
+  think("I should inspect the source before changing it."),
+  say("The reasoning row uses the same inset and disclosure treatment as the work below."),
+  tool("read-1", "Read", {
+    locations: [{ path: "src/agentMode/ui/AgentTrailView.tsx" }],
+    output: [{ type: "text", text: "export const AgentTrail = ..." }],
+  }),
+  say("A single expandable tool remains its own row."),
+  tool("read-2", "Read", { locations: [{ path: "src/agentMode/ui/ActionCard.tsx" }] }),
+  tool("test-1", "Bash", { input: { description: "Run focused activity-card tests" } }),
+  say("Consecutive work folds into a group with the same header geometry."),
+  tool("delegate-1", "Task", {
+    input: { subagent_type: "Explore", description: "Check nested trail cards" },
+  }),
+  tool("delegate-read", "Read", {
+    parentToolCallId: "delegate-1",
+    locations: [{ path: "src/agentMode/ui/SubAgentCard.tsx" }],
+  }),
+  say("Reasoning, individual tools, grouped work, and delegated work now align."),
+];
+
 /**
  * `AgentTrail` renders markdown, so it needs the host's real `App`. The
  * `TooltipProvider` is the story's own scaffolding: a completed turn renders
@@ -103,4 +125,9 @@ export const GroupedTurn: StoryObj<AgentTrailProps> = {
 /** The last group shows the step in flight; earlier groups stay quiet. */
 export const Streaming: StoryObj<AgentTrailProps> = {
   render: () => <TrailDemo parts={STREAMING} isStreaming />,
+};
+
+/** Reasoning and every tool-card family share one inset, chevron, and expanded rail. */
+export const UnifiedCardStyles: StoryObj<AgentTrailProps> = {
+  render: () => <TrailDemo parts={UNIFIED_CARDS} />,
 };

--- a/src/agentMode/ui/AgentTrailView.stories.tsx
+++ b/src/agentMode/ui/AgentTrailView.stories.tsx
@@ -91,10 +91,11 @@ const UNIFIED_CARDS: AgentMessagePart[] = [
  * the Copy / Insert row, whose `MessageActionButton` expects a provider from an
  * ancestor rather than supplying its own.
  */
-const TrailDemo: React.FC<{ parts: AgentMessagePart[]; isStreaming?: boolean }> = ({
-  parts,
-  isStreaming = false,
-}) => {
+const TrailDemo: React.FC<{
+  parts: AgentMessagePart[];
+  isStreaming?: boolean;
+  showCompletedDuration?: boolean;
+}> = ({ parts, isStreaming = false, showCompletedDuration = true }) => {
   const app = useApp();
   return (
     <TooltipProvider>
@@ -102,7 +103,8 @@ const TrailDemo: React.FC<{ parts: AgentMessagePart[]; isStreaming?: boolean }> 
         parts={parts}
         isStreaming={isStreaming}
         turnStartedAtMs={isStreaming ? Date.now() - 138_000 : undefined}
-        turnDurationMs={isStreaming ? undefined : 138_000}
+        turnDurationMs={!isStreaming && showCompletedDuration ? 138_000 : undefined}
+        timestamp="2026/08/07 20:31:10"
         app={app}
         turnStopReason={isStreaming ? undefined : "end_turn"}
       />
@@ -130,4 +132,9 @@ export const Streaming: StoryObj<AgentTrailProps> = {
 /** Reasoning and every tool-card family share one inset, chevron, and expanded rail. */
 export const UnifiedCardStyles: StoryObj<AgentTrailProps> = {
   render: () => <TrailDemo parts={UNIFIED_CARDS} />,
+};
+
+/** A restored structured turn falls back to its timestamp when no duration was persisted. */
+export const CompletedWithoutDuration: StoryObj<AgentTrailProps> = {
+  render: () => <TrailDemo parts={UNIFIED_CARDS} showCompletedDuration={false} />,
 };

--- a/src/agentMode/ui/AgentTrailView.test.tsx
+++ b/src/agentMode/ui/AgentTrailView.test.tsx
@@ -162,6 +162,31 @@ describe("AgentTrail", () => {
     expect(screen.getByText("Search vault")).toBeTruthy();
   });
 
+  it("uses one aligned folding header for reasoning and every tool-card family", () => {
+    const { container } = renderTrail({
+      parts: [
+        { kind: "thought", text: "Inspect the trail first." },
+        text("Reasoning complete."),
+        { ...READ_A, output: [{ type: "text", text: "file contents" }] },
+        text("Single tool complete."),
+        READ_B,
+        LINT,
+        text("Grouped tools complete."),
+        toolCall("task1", {
+          vendorToolName: "Task",
+          input: { subagent_type: "Explore", description: "Check nested cards" },
+        }),
+        { ...READ_A, id: "nested-read", parentToolCallId: "task1" },
+      ],
+    });
+
+    const headers = [...container.querySelectorAll("[data-agent-activity-card-header]")];
+    expect(headers).toHaveLength(4);
+    expect(headers.every((header) => header.classList.contains("tw-pl-1"))).toBe(true);
+    expect(headers.every((header) => header.getAttribute("aria-expanded") === "false")).toBe(true);
+    expect(container.querySelectorAll(".lucide-chevron-right")).toHaveLength(4);
+  });
+
   it("shows progress on a childless background subagent card", () => {
     renderTrail({
       parts: [

--- a/src/agentMode/ui/AgentTrailView.test.tsx
+++ b/src/agentMode/ui/AgentTrailView.test.tsx
@@ -126,10 +126,23 @@ describe("AgentTrail", () => {
     expect(screen.queryByTitle("Insert / Replace at cursor")).toBeNull();
   });
 
+  it("shows the running duration instead of the timestamp while streaming", () => {
+    renderTrail({
+      isStreaming: true,
+      turnStopReason: undefined,
+      turnStartedAtMs: Date.now() - 24_000,
+      timestamp: "2026/08/07 20:31:10",
+    });
+
+    expect(screen.getByText("Worked for")).toBeTruthy();
+    expect(screen.queryByText("2026/08/07 20:31:10")).toBeNull();
+  });
+
   it("renders neither button when the turn was cancelled", () => {
-    renderTrail({ turnStopReason: "cancelled" });
+    renderTrail({ turnStopReason: "cancelled", timestamp: "2026/08/07 20:31:10" });
     expect(screen.queryByTitle("Copy")).toBeNull();
     expect(screen.queryByTitle("Insert / Replace at cursor")).toBeNull();
+    expect(screen.getByText("2026/08/07 20:31:10")).toBeTruthy();
   });
 
   it("renders neither button when the turn produced no trailing prose", () => {
@@ -137,6 +150,15 @@ describe("AgentTrail", () => {
     expect(screen.queryByTitle("Copy")).toBeNull();
     expect(screen.queryByTitle("Insert / Replace at cursor")).toBeNull();
   });
+
+  it("shows the timestamp with response controls when a completed duration is unavailable", () => {
+    renderTrail({ timestamp: "2026/08/07 20:31:10" });
+
+    expect(screen.getByText("2026/08/07 20:31:10")).toBeTruthy();
+    expect(screen.getByTitle("Copy")).toBeTruthy();
+    expect(screen.queryByText("Worked for")).toBeNull();
+  });
+
   it("keeps research inline while showing a non-collapsible completed duration", () => {
     renderTrail({
       parts: [
@@ -147,10 +169,12 @@ describe("AgentTrail", () => {
       ],
       turnStopReason: "end_turn",
       turnDurationMs: 138_000,
+      timestamp: "2026/08/07 20:31:10",
     });
 
     expect(screen.getByText("Worked for")).toBeTruthy();
     expect(screen.getByText("2m 18s")).toBeTruthy();
+    expect(screen.queryByText("2026/08/07 20:31:10")).toBeNull();
     expect(screen.queryByRole("button", { name: /Worked for/i })).toBeNull();
     const footer = screen.getByText("Worked for").closest(".tw-justify-between");
     expect(footer?.classList.contains("tw-items-center")).toBe(true);

--- a/src/agentMode/ui/AgentTrailView.test.tsx
+++ b/src/agentMode/ui/AgentTrailView.test.tsx
@@ -152,6 +152,10 @@ describe("AgentTrail", () => {
     expect(screen.getByText("Worked for")).toBeTruthy();
     expect(screen.getByText("2m 18s")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Worked for/i })).toBeNull();
+    const footer = screen.getByText("Worked for").closest(".tw-justify-between");
+    expect(footer?.classList.contains("tw-items-center")).toBe(true);
+    expect(footer?.contains(screen.getByTitle("Copy"))).toBe(true);
+    expect(footer?.contains(screen.getByTitle("Insert / Replace at cursor"))).toBe(true);
     // The trailing prose renders as the final answer.
     expect(screen.getByText("The final answer.")).toBeTruthy();
     // The research tool card renders inline (not folded behind a toggle).

--- a/src/agentMode/ui/AgentTrailView.tsx
+++ b/src/agentMode/ui/AgentTrailView.tsx
@@ -18,6 +18,7 @@ import type { ToolSummaryContext } from "@/agentMode/ui/toolSummaries";
 import { useThinkingClock } from "@/agentMode/ui/useThinkingClock";
 import { useTrailExpansion, type TrailExpansion } from "@/agentMode/ui/useTrailExpansion";
 import { AgentTurnDurationIndicator } from "@/agentMode/ui/AgentTurnDurationIndicator";
+import { AssistantResponseFooter } from "@/components/ui/AssistantResponseFooter";
 import { getVaultBase } from "@/utils/vaultPath";
 import { App } from "obsidian";
 
@@ -30,6 +31,8 @@ interface AgentTrailProps {
   turnStartedAtMs?: number;
   /** Frozen whole-turn duration retained after the latest turn completes. */
   turnDurationMs?: number;
+  /** Message creation time used when this turn has no visible duration. */
+  timestamp?: string;
   /** Obsidian `App` for the markdown renderer used by `text` parts. */
   app: App;
   /** Backend stopReason once the turn has ended. Only `cancelled` suppresses
@@ -42,6 +45,7 @@ export const AgentTrail: React.FC<AgentTrailProps> = ({
   isStreaming,
   turnStartedAtMs,
   turnDurationMs,
+  timestamp,
   app,
   turnStopReason,
 }) => {
@@ -49,17 +53,29 @@ export const AgentTrail: React.FC<AgentTrailProps> = ({
   // the message is still streaming and on cancelled turns (treated as having no
   // user-visible answer), plus whenever there is no prose to act on.
   const answer = agentResponseText(parts);
+  const hasRunningDuration = isStreaming && turnStartedAtMs !== undefined;
   const footer =
     !isStreaming && turnStopReason !== "cancelled" && answer.length > 0 ? (
-      <AgentMessageActions text={answer} app={app} durationMs={turnDurationMs} />
+      <AgentMessageActions
+        text={answer}
+        app={app}
+        durationMs={turnDurationMs}
+        timestamp={timestamp}
+      />
     ) : turnDurationMs !== undefined ? (
-      <AgentTurnDurationIndicator status="complete" durationMs={turnDurationMs} inline />
+      <AssistantResponseFooter
+        leading={
+          <AgentTurnDurationIndicator status="complete" durationMs={turnDurationMs} inline />
+        }
+      />
+    ) : !hasRunningDuration && timestamp ? (
+      <AssistantResponseFooter timestamp={timestamp} />
     ) : null;
 
   return (
     <div className="tw-group tw-flex tw-flex-col tw-gap-1">
       <LinearTrail parts={parts} isStreaming={isStreaming} app={app} />
-      {isStreaming && turnStartedAtMs !== undefined ? (
+      {hasRunningDuration ? (
         <AgentTurnDurationIndicator status="running" startedAtMs={turnStartedAtMs} />
       ) : null}
       {footer}

--- a/src/agentMode/ui/AgentTrailView.tsx
+++ b/src/agentMode/ui/AgentTrailView.tsx
@@ -24,7 +24,7 @@ import { App } from "obsidian";
 interface AgentTrailProps {
   parts: AgentMessagePart[];
   /** True iff this message is the one currently being streamed by the
-   *  agent. Drives reasoning-block spinner / timer. */
+   *  agent. Drives the reasoning block and whole-turn live states. */
   isStreaming: boolean;
   /** Turn start used by the live whole-turn timer. */
   turnStartedAtMs?: number;
@@ -49,20 +49,20 @@ export const AgentTrail: React.FC<AgentTrailProps> = ({
   // the message is still streaming and on cancelled turns (treated as having no
   // user-visible answer), plus whenever there is no prose to act on.
   const answer = agentResponseText(parts);
-  const actions =
+  const footer =
     !isStreaming && turnStopReason !== "cancelled" && answer.length > 0 ? (
-      <AgentMessageActions text={answer} app={app} />
+      <AgentMessageActions text={answer} app={app} durationMs={turnDurationMs} />
+    ) : turnDurationMs !== undefined ? (
+      <AgentTurnDurationIndicator status="complete" durationMs={turnDurationMs} inline />
     ) : null;
 
   return (
     <div className="tw-group tw-flex tw-flex-col tw-gap-1">
       <LinearTrail parts={parts} isStreaming={isStreaming} app={app} />
-      {turnDurationMs !== undefined ? (
-        <AgentTurnDurationIndicator status="complete" durationMs={turnDurationMs} />
-      ) : isStreaming && turnStartedAtMs !== undefined ? (
+      {isStreaming && turnStartedAtMs !== undefined ? (
         <AgentTurnDurationIndicator status="running" startedAtMs={turnStartedAtMs} />
       ) : null}
-      {actions}
+      {footer}
     </div>
   );
 };

--- a/src/agentMode/ui/AgentTurnDurationIndicator.stories.tsx
+++ b/src/agentMode/ui/AgentTurnDurationIndicator.stories.tsx
@@ -1,5 +1,7 @@
+import { AgentMessageActions } from "@/agentMode/ui/AgentMessageActions";
 import { AgentMarkdownText } from "@/agentMode/ui/AgentMarkdownText";
 import { AgentTurnDurationIndicator } from "@/agentMode/ui/AgentTurnDurationIndicator";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { useApp } from "@/context";
 import type { Meta, StoryObj } from "@/lib/story";
 import React from "react";
@@ -28,13 +30,19 @@ export const Complete: StoryObj<AgentTurnDurationIndicatorProps> = {
 const AlignedWithResponseDemo: React.FC = () => {
   const app = useApp();
   return (
-    <div>
-      <AgentMarkdownText
-        text="I excluded generated Copilot conversation logs and notes where AI was only mentioned incidentally."
-        app={app}
-      />
-      <AgentTurnDurationIndicator status="complete" durationMs={24_000} />
-    </div>
+    <TooltipProvider>
+      <div className="tw-group tw-flex tw-flex-col tw-gap-1">
+        <AgentMarkdownText
+          text="I excluded generated Copilot conversation logs and notes where AI was only mentioned incidentally."
+          app={app}
+        />
+        <AgentMessageActions
+          text="I excluded generated Copilot conversation logs and notes where AI was only mentioned incidentally."
+          app={app}
+          durationMs={24_000}
+        />
+      </div>
+    </TooltipProvider>
   );
 };
 

--- a/src/agentMode/ui/AgentTurnDurationIndicator.stories.tsx
+++ b/src/agentMode/ui/AgentTurnDurationIndicator.stories.tsx
@@ -1,4 +1,6 @@
+import { AgentMarkdownText } from "@/agentMode/ui/AgentMarkdownText";
 import { AgentTurnDurationIndicator } from "@/agentMode/ui/AgentTurnDurationIndicator";
+import { useApp } from "@/context";
 import type { Meta, StoryObj } from "@/lib/story";
 import React from "react";
 
@@ -23,14 +25,19 @@ export const Complete: StoryObj<AgentTurnDurationIndicatorProps> = {
   args: { status: "complete", durationMs: 138_000 },
 };
 
-export const AlignedWithResponse: StoryObj<AgentTurnDurationIndicatorProps> = {
-  render: () => (
+const AlignedWithResponseDemo: React.FC = () => {
+  const app = useApp();
+  return (
     <div>
-      <div className="tw-p-1 tw-text-sm">
-        I excluded generated Copilot conversation logs and notes where AI was only mentioned
-        incidentally.
-      </div>
+      <AgentMarkdownText
+        text="I excluded generated Copilot conversation logs and notes where AI was only mentioned incidentally."
+        app={app}
+      />
       <AgentTurnDurationIndicator status="complete" durationMs={24_000} />
     </div>
-  ),
+  );
+};
+
+export const AlignedWithResponse: StoryObj<AgentTurnDurationIndicatorProps> = {
+  render: AlignedWithResponseDemo,
 };

--- a/src/agentMode/ui/AgentTurnDurationIndicator.test.tsx
+++ b/src/agentMode/ui/AgentTurnDurationIndicator.test.tsx
@@ -91,5 +91,18 @@ describe("AgentTurnDurationIndicator", () => {
 
       expect(screen.getByText("2m 18s")).toBeTruthy();
     });
+
+    it("removes block spacing when the completed duration shares a response footer", () => {
+      const { container } = render(
+        <AgentTurnDurationIndicator status="complete" durationMs={24_000} inline />
+      );
+
+      const root = container.firstElementChild;
+      const row = screen.getByText("Worked for").parentElement?.parentElement;
+      expect(root?.classList.contains("tw-mb-2")).toBe(false);
+      expect(root?.classList.contains("tw-mt-1")).toBe(false);
+      expect(row?.classList.contains("tw-items-center")).toBe(true);
+      expect(row?.classList.contains("tw-pl-1")).toBe(true);
+    });
   });
 });

--- a/src/agentMode/ui/AgentTurnDurationIndicator.test.tsx
+++ b/src/agentMode/ui/AgentTurnDurationIndicator.test.tsx
@@ -64,7 +64,7 @@ describe("AgentTurnDurationIndicator", () => {
       }
     });
 
-    it("freezes the duration and keeps a static icon after completion", () => {
+    it("freezes the duration with a static icon aligned to response content after completion", () => {
       const { container } = render(
         <AgentTurnDurationIndicator status="complete" durationMs={138_000} />
       );
@@ -75,6 +75,11 @@ describe("AgentTurnDurationIndicator", () => {
       ).toBe(true);
       expect(container.querySelector(".copilot-spinner")).toBeTruthy();
       expect(container.querySelector(".copilot-spinner-dot-0")).toBeNull();
+      expect(
+        container
+          .querySelector(".copilot-spinner")
+          ?.parentElement?.classList.contains("tw-justify-start")
+      ).toBe(true);
       expect(
         container
           .querySelector(".copilot-spinner")

--- a/src/agentMode/ui/AgentTurnDurationIndicator.tsx
+++ b/src/agentMode/ui/AgentTurnDurationIndicator.tsx
@@ -1,12 +1,18 @@
 import { CopilotSpinner } from "@/components/chat-components/CopilotSpinner";
+import { cn } from "@/lib/utils";
 import React, { useEffect, useRef, useState } from "react";
 
-interface RunningTurnDurationProps {
+interface TurnDurationLayoutProps {
+  /** Remove block spacing when the duration shares a response footer row. */
+  inline?: boolean;
+}
+
+interface RunningTurnDurationProps extends TurnDurationLayoutProps {
   status: "running";
   startedAtMs: number;
 }
 
-interface CompletedTurnDurationProps {
+interface CompletedTurnDurationProps extends TurnDurationLayoutProps {
   status: "complete";
   durationMs: number;
 }
@@ -48,9 +54,17 @@ export const AgentTurnDurationIndicator: React.FC<AgentTurnDurationIndicatorProp
   return (
     <div
       ref={rootRef}
-      className="tw-mb-2 tw-mt-1 tw-w-full tw-text-ui-medium max-md:tw-mb-1.5 max-md:tw-mt-0.5"
+      className={cn(
+        "tw-text-ui-medium",
+        !props.inline && "tw-mb-2 tw-mt-1 tw-w-full max-md:tw-mb-1.5 max-md:tw-mt-0.5"
+      )}
     >
-      <div className="tw-flex tw-w-full tw-items-center tw-gap-1.5 tw-pl-1 tw-text-left tw-text-ui-small tw-text-muted">
+      <div
+        className={cn(
+          "tw-flex tw-items-center tw-gap-1.5 tw-pl-1 tw-text-left tw-text-ui-small tw-text-muted",
+          !props.inline && "tw-w-full"
+        )}
+      >
         <span className="tw-flex tw-size-icon-xs tw-shrink-0 tw-items-center tw-justify-start">
           <CopilotSpinner animated={isRunning} />
         </span>

--- a/src/agentMode/ui/AgentTurnDurationIndicator.tsx
+++ b/src/agentMode/ui/AgentTurnDurationIndicator.tsx
@@ -51,7 +51,7 @@ export const AgentTurnDurationIndicator: React.FC<AgentTurnDurationIndicatorProp
       className="tw-mb-2 tw-mt-1 tw-w-full tw-text-ui-medium max-md:tw-mb-1.5 max-md:tw-mt-0.5"
     >
       <div className="tw-flex tw-w-full tw-items-center tw-gap-1.5 tw-pl-1 tw-text-left tw-text-ui-small tw-text-muted">
-        <span className="tw-flex tw-size-icon-xs tw-shrink-0 tw-items-center tw-justify-center">
+        <span className="tw-flex tw-size-icon-xs tw-shrink-0 tw-items-center tw-justify-start">
           <CopilotSpinner animated={isRunning} />
         </span>
         <span>

--- a/src/agentMode/ui/FanoutMessageCard.test.tsx
+++ b/src/agentMode/ui/FanoutMessageCard.test.tsx
@@ -31,7 +31,7 @@ jest.mock("obsidian", () => ({
 
 describe("FanoutMessageCard", () => {
   describe("FanoutMessageCard()", () => {
-    it("places supplied duration metadata before the timestamp in the response footer", () => {
+    it("shows supplied duration metadata instead of the timestamp in the response footer", () => {
       const timestamp = "2026/08/07 20:31:10";
       const message: AgentChatMessage = {
         id: "fanout-1",
@@ -45,7 +45,7 @@ describe("FanoutMessageCard", () => {
         summary: { status: "done", text: "Summary response" },
       };
 
-      render(
+      const { rerender } = render(
         <TooltipProvider>
           <FanoutMessageCard
             message={message}
@@ -60,12 +60,14 @@ describe("FanoutMessageCard", () => {
       const footer = duration.closest(".tw-justify-between");
       expect(footer?.classList.contains("tw-items-center")).toBe(true);
       expect(footer?.contains(screen.getByTitle("Copy"))).toBe(true);
-      expect(
-        Boolean(
-          duration.compareDocumentPosition(screen.getByText(timestamp)) &
-          Node.DOCUMENT_POSITION_FOLLOWING
-        )
-      ).toBe(true);
+      expect(screen.queryByText(timestamp)).toBeNull();
+
+      rerender(
+        <TooltipProvider>
+          <FanoutMessageCard message={message} turn={turn} app={{} as never} />
+        </TooltipProvider>
+      );
+      expect(screen.getByText(timestamp)).toBeTruthy();
     });
   });
 });

--- a/src/agentMode/ui/FanoutMessageCard.test.tsx
+++ b/src/agentMode/ui/FanoutMessageCard.test.tsx
@@ -1,0 +1,63 @@
+import type { FanoutTurn } from "@/agentMode/session/fanout/fanoutTypes";
+import type { AgentChatMessage } from "@/agentMode/session/types";
+import { FanoutMessageCard } from "@/agentMode/ui/FanoutMessageCard";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { AI_SENDER } from "@/constants";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+jest.mock("@/agentMode/ui/FanoutTurnView", () => ({
+  FanoutTurnView: () => <div>Summary response</div>,
+}));
+
+jest.mock("@/agentMode/ui/fanoutDropdown", () => ({
+  defaultFanoutOption: () => "summary",
+  fanoutDisplayName: (backendId: string) => backendId,
+  FANOUT_SUMMARY_OPTION: "summary",
+}));
+
+jest.mock("@/agentMode/session/fanout/fanoutTypes", () => ({
+  renderFanoutComposite: () => "Summary response",
+}));
+
+jest.mock("@/utils", () => ({
+  cleanMessageForCopy: (text: string) => text,
+  insertAtCursor: jest.fn(),
+}));
+
+jest.mock("obsidian", () => ({
+  Platform: { isMobile: false },
+}));
+
+describe("FanoutMessageCard", () => {
+  describe("FanoutMessageCard()", () => {
+    it("places supplied duration metadata in the centered response footer", () => {
+      const message: AgentChatMessage = {
+        id: "fanout-1",
+        sender: AI_SENDER,
+        message: "Summary response",
+        timestamp: { epoch: 1, display: "now", fileName: "now" },
+        isVisible: true,
+      };
+      const turn: FanoutTurn = {
+        answers: {},
+        summary: { status: "done", text: "Summary response" },
+      };
+
+      render(
+        <TooltipProvider>
+          <FanoutMessageCard
+            message={message}
+            turn={turn}
+            app={{} as never}
+            footerStart={<span>Worked for 24s</span>}
+          />
+        </TooltipProvider>
+      );
+
+      const footer = screen.getByText("Worked for 24s").closest(".tw-justify-between");
+      expect(footer?.classList.contains("tw-items-center")).toBe(true);
+      expect(footer?.contains(screen.getByTitle("Copy"))).toBe(true);
+    });
+  });
+});

--- a/src/agentMode/ui/FanoutMessageCard.test.tsx
+++ b/src/agentMode/ui/FanoutMessageCard.test.tsx
@@ -31,12 +31,13 @@ jest.mock("obsidian", () => ({
 
 describe("FanoutMessageCard", () => {
   describe("FanoutMessageCard()", () => {
-    it("places supplied duration metadata in the centered response footer", () => {
+    it("places supplied duration metadata before the timestamp in the response footer", () => {
+      const timestamp = "2026/08/07 20:31:10";
       const message: AgentChatMessage = {
         id: "fanout-1",
         sender: AI_SENDER,
         message: "Summary response",
-        timestamp: { epoch: 1, display: "now", fileName: "now" },
+        timestamp: { epoch: 1, display: timestamp, fileName: "now" },
         isVisible: true,
       };
       const turn: FanoutTurn = {
@@ -55,9 +56,16 @@ describe("FanoutMessageCard", () => {
         </TooltipProvider>
       );
 
-      const footer = screen.getByText("Worked for 24s").closest(".tw-justify-between");
+      const duration = screen.getByText("Worked for 24s");
+      const footer = duration.closest(".tw-justify-between");
       expect(footer?.classList.contains("tw-items-center")).toBe(true);
       expect(footer?.contains(screen.getByTitle("Copy"))).toBe(true);
+      expect(
+        Boolean(
+          duration.compareDocumentPosition(screen.getByText(timestamp)) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+        )
+      ).toBe(true);
     });
   });
 });

--- a/src/agentMode/ui/FanoutMessageCard.tsx
+++ b/src/agentMode/ui/FanoutMessageCard.tsx
@@ -6,6 +6,7 @@ import {
   type FanoutOptionValue,
 } from "@/agentMode/ui/fanoutDropdown";
 import { ChatButtons } from "@/components/chat-components/ChatButtons";
+import { AssistantResponseFooter } from "@/components/ui/AssistantResponseFooter";
 import type { FanoutTurn } from "@/agentMode/session/fanout/fanoutTypes";
 import { renderFanoutComposite } from "@/agentMode/session/fanout/fanoutTypes";
 import type { AgentChatMessage } from "@/agentMode/session/types";
@@ -19,7 +20,7 @@ interface FanoutMessageCardProps {
   message: AgentChatMessage;
   turn: FanoutTurn;
   app: App;
-  /** Agent Mode metadata placed beside the timestamp in the response footer. */
+  /** Agent Mode metadata placed at the response footer's leading edge, before the timestamp. */
   footerStart?: React.ReactNode;
 }
 
@@ -72,17 +73,17 @@ export const FanoutMessageCard: React.FC<FanoutMessageCardProps> = memo(
         <div className="tw-group tw-mx-2 tw-rounded-md tw-p-2">
           <div className="tw-flex tw-max-w-full tw-flex-col tw-gap-2 tw-overflow-hidden">
             <FanoutTurnView turn={turn} app={app} value={activeValue} onSelect={setSelected} />
-            <div className="tw-flex tw-items-center tw-justify-between">
-              <div className="tw-flex tw-items-center tw-gap-2">
-                <div className="tw-text-xs tw-text-faint">{message.timestamp?.display}</div>
-                {footerStart}
-              </div>
-              <ChatButtons
-                message={buttonsMessage}
-                onInsertIntoEditor={handleInsert}
-                hasSources={false}
-              />
-            </div>
+            <AssistantResponseFooter
+              leading={footerStart}
+              timestamp={message.timestamp?.display}
+              actions={
+                <ChatButtons
+                  message={buttonsMessage}
+                  onInsertIntoEditor={handleInsert}
+                  hasSources={false}
+                />
+              }
+            />
           </div>
         </div>
       </div>

--- a/src/agentMode/ui/FanoutMessageCard.tsx
+++ b/src/agentMode/ui/FanoutMessageCard.tsx
@@ -19,6 +19,8 @@ interface FanoutMessageCardProps {
   message: AgentChatMessage;
   turn: FanoutTurn;
   app: App;
+  /** Agent Mode metadata placed beside the timestamp in the response footer. */
+  footerStart?: React.ReactNode;
 }
 
 /**
@@ -29,7 +31,7 @@ interface FanoutMessageCardProps {
  * selected tab so the action bar can target it.
  */
 export const FanoutMessageCard: React.FC<FanoutMessageCardProps> = memo(
-  ({ message, turn, app }) => {
+  ({ message, turn, app, footerStart }) => {
     const [selected, setSelected] = useState<FanoutOptionValue>(() => defaultFanoutOption(turn));
 
     // Fall back to the summary if the selected slot disappears (defensive).
@@ -71,7 +73,10 @@ export const FanoutMessageCard: React.FC<FanoutMessageCardProps> = memo(
           <div className="tw-flex tw-max-w-full tw-flex-col tw-gap-2 tw-overflow-hidden">
             <FanoutTurnView turn={turn} app={app} value={activeValue} onSelect={setSelected} />
             <div className="tw-flex tw-items-center tw-justify-between">
-              <div className="tw-text-xs tw-text-faint">{message.timestamp?.display}</div>
+              <div className="tw-flex tw-items-center tw-gap-2">
+                <div className="tw-text-xs tw-text-faint">{message.timestamp?.display}</div>
+                {footerStart}
+              </div>
               <ChatButtons
                 message={buttonsMessage}
                 onInsertIntoEditor={handleInsert}

--- a/src/agentMode/ui/ReasoningBlock.stories.tsx
+++ b/src/agentMode/ui/ReasoningBlock.stories.tsx
@@ -1,0 +1,46 @@
+import { AgentMarkdownText } from "@/agentMode/ui/AgentMarkdownText";
+import { AgentTurnDurationIndicator } from "@/agentMode/ui/AgentTurnDurationIndicator";
+import { ReasoningBlock } from "@/agentMode/ui/ReasoningBlock";
+import { useApp } from "@/context";
+import type { Meta, StoryObj } from "@/lib/story";
+import React from "react";
+
+type ReasoningBlockProps = React.ComponentProps<typeof ReasoningBlock>;
+
+const REASONING = {
+  kind: "thought" as const,
+  text: "Comparing the implementation with the current interface before making the change.",
+};
+
+const meta = {
+  title: "Agent Mode/Reasoning Block",
+  component: ReasoningBlock,
+  args: { part: REASONING, isStreaming: false },
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
+} satisfies Meta<ReasoningBlockProps>;
+export default meta;
+
+export const Complete: StoryObj<ReasoningBlockProps> = {};
+
+export const Active: StoryObj<ReasoningBlockProps> = {
+  args: { isStreaming: true },
+};
+
+/** Matches the real trail order so all three content edges can be inspected together. */
+const ReasoningResponseDurationDemo: React.FC = () => {
+  const app = useApp();
+  return (
+    <div>
+      <ReasoningBlock part={REASONING} isStreaming />
+      <AgentMarkdownText
+        text="The reasoning and duration indicators now share the response's left edge."
+        app={app}
+      />
+      <AgentTurnDurationIndicator status="running" startedAtMs={Date.now() - 138_000} />
+    </div>
+  );
+};
+
+export const WithResponseAndWorkedFor: StoryObj<ReasoningBlockProps> = {
+  render: ReasoningResponseDurationDemo,
+};

--- a/src/agentMode/ui/ReasoningBlock.stories.tsx
+++ b/src/agentMode/ui/ReasoningBlock.stories.tsx
@@ -1,6 +1,7 @@
+import { AgentMessageActions } from "@/agentMode/ui/AgentMessageActions";
 import { AgentMarkdownText } from "@/agentMode/ui/AgentMarkdownText";
-import { AgentTurnDurationIndicator } from "@/agentMode/ui/AgentTurnDurationIndicator";
 import { ReasoningBlock } from "@/agentMode/ui/ReasoningBlock";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { useApp } from "@/context";
 import type { Meta, StoryObj } from "@/lib/story";
 import React from "react";
@@ -26,18 +27,24 @@ export const Active: StoryObj<ReasoningBlockProps> = {
   args: { isStreaming: true },
 };
 
-/** Matches the real trail order so all three content edges can be inspected together. */
+/** Matches the completed trail order so the response footer can be inspected as one row. */
 const ReasoningResponseDurationDemo: React.FC = () => {
   const app = useApp();
   return (
-    <div>
-      <ReasoningBlock part={REASONING} isStreaming />
-      <AgentMarkdownText
-        text="The reasoning and duration indicators now share the response's left edge."
-        app={app}
-      />
-      <AgentTurnDurationIndicator status="running" startedAtMs={Date.now() - 138_000} />
-    </div>
+    <TooltipProvider>
+      <div className="tw-group tw-flex tw-flex-col tw-gap-1">
+        <ReasoningBlock part={REASONING} isStreaming={false} />
+        <AgentMarkdownText
+          text="The completed duration now shares a centered footer with the response controls."
+          app={app}
+        />
+        <AgentMessageActions
+          text="The completed duration now shares a centered footer with the response controls."
+          app={app}
+          durationMs={138_000}
+        />
+      </div>
+    </TooltipProvider>
   );
 };
 

--- a/src/agentMode/ui/ReasoningBlock.tsx
+++ b/src/agentMode/ui/ReasoningBlock.tsx
@@ -5,13 +5,13 @@ import type { ThoughtPart } from "@/agentMode/ui/agentTrail";
 interface ReasoningBlockProps {
   part: ThoughtPart;
   /** True when this part belongs to the actively streaming assistant
-   *  message — drives the spinner + live timer. */
+   *  message — drives the active label and live timer. */
   isStreaming: boolean;
 }
 
 /**
  * Adapter that maps an agent-mode `thought` part onto the existing
- * `AgentReasoningBlock` UI (spinner, timer, collapse-on-done). The store
+ * `AgentReasoningBlock` UI (brain icon, timer, collapse-on-done). The store
  * folds streamed `agent_thought_chunk`s into a single `thought` part, so
  * we have one part per assistant turn — `steps` derives from paragraph
  * splits within `part.text`.

--- a/src/agentMode/ui/ReasoningBlock.tsx
+++ b/src/agentMode/ui/ReasoningBlock.tsx
@@ -5,13 +5,13 @@ import type { ThoughtPart } from "@/agentMode/ui/agentTrail";
 interface ReasoningBlockProps {
   part: ThoughtPart;
   /** True when this part belongs to the actively streaming assistant
-   *  message — drives the active label and live timer. */
+   *  message — drives the active label and captures its final duration. */
   isStreaming: boolean;
 }
 
 /**
  * Adapter that maps an agent-mode `thought` part onto the existing
- * `AgentReasoningBlock` UI (brain icon, timer, collapse-on-done). The store
+ * `AgentReasoningBlock` UI (brain icon, final duration, collapse-on-done). The store
  * folds streamed `agent_thought_chunk`s into a single `thought` part, so
  * we have one part per assistant turn — `steps` derives from paragraph
  * splits within `part.text`.

--- a/src/agentMode/ui/SubAgentCard.tsx
+++ b/src/agentMode/ui/SubAgentCard.tsx
@@ -10,6 +10,7 @@ import {
   extractSubAgentReturnText,
   lookupToolSummary,
 } from "@/agentMode/ui/toolSummaries";
+import { AgentActivityCard } from "@/components/chat-components/AgentActivityCard";
 
 interface SubAgentCardProps {
   parent: ToolCallPart;
@@ -47,63 +48,52 @@ export const SubAgentCard: React.FC<SubAgentCardProps> = ({
   const returnText = extractSubAgentReturnText(parent);
 
   return (
-    <div className="tw-my-1 tw-flex tw-flex-col tw-gap-0.5">
-      <div
-        className="tw-flex tw-cursor-pointer tw-items-center tw-gap-1.5 tw-text-sm tw-text-muted hover:tw-text-normal"
-        onClick={() => setOpen((v) => !v)}
-        role="button"
-      >
-        <Icon className="tw-size-3.5 tw-shrink-0 tw-text-muted" />
-        <span className="tw-flex-1 tw-truncate tw-font-medium">{line}</span>
-        <StatusBadge status={parent.status} />
-        {open ? (
-          <ChevronDown className="tw-size-3 tw-text-muted" />
-        ) : (
-          <ChevronRight className="tw-size-3 tw-text-muted" />
-        )}
-      </div>
-      {outcome ? <div className="tw-pl-5 tw-text-xs tw-text-muted">{outcome}</div> : null}
-      {open ? (
-        <div className="tw-mt-2 tw-flex tw-flex-col tw-gap-1 tw-border-l tw-border-border tw-pl-3">
-          {childCounts.tools > 0 || childCounts.reasoning > 0 || truncated ? (
-            <div className="tw-text-xs tw-text-muted">{describeCounts(childCounts, truncated)}</div>
-          ) : null}
-          {inputPrompt ? (
-            <div className="tw-my-1">
-              <div
-                className="tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-text-xs tw-text-muted"
-                onClick={() => setPromptOpen((v) => !v)}
-                role="button"
-              >
-                <span className="tw-flex-1 tw-truncate">Prompt</span>
-                {promptOpen ? (
-                  <ChevronDown className="tw-size-3" />
-                ) : (
-                  <ChevronRight className="tw-size-3" />
-                )}
-              </div>
-              {promptOpen ? (
-                <div className="tw-mt-1 tw-border-l-[2px] tw-border-border tw-pl-2">
-                  <AgentMarkdownText text={inputPrompt} app={app} />
-                </div>
-              ) : null}
-            </div>
-          ) : null}
-          {truncated ? (
-            <div className="tw-text-xs tw-text-muted">
-              Nested sub-agent — expand the parent to drill in.
-            </div>
-          ) : (
-            childNodes.map((c, i) => renderNode(c, i))
-          )}
-          {returnText ? (
-            <div className="tw-my-1 tw-border-l-[2px] tw-border-border tw-pl-2">
-              <AgentMarkdownText text={returnText} app={app} />
+    <AgentActivityCard
+      icon={Icon}
+      label={line}
+      trailing={<StatusBadge status={parent.status} />}
+      secondary={outcome}
+      expandable
+      open={open}
+      onToggle={() => setOpen((value) => !value)}
+    >
+      {childCounts.tools > 0 || childCounts.reasoning > 0 || truncated ? (
+        <div className="tw-text-xs tw-text-muted">{describeCounts(childCounts, truncated)}</div>
+      ) : null}
+      {inputPrompt ? (
+        <div className="tw-my-1">
+          <div
+            className="tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-text-xs tw-text-muted"
+            onClick={() => setPromptOpen((v) => !v)}
+            role="button"
+          >
+            <span className="tw-flex-1 tw-truncate">Prompt</span>
+            {promptOpen ? (
+              <ChevronDown className="tw-size-3" />
+            ) : (
+              <ChevronRight className="tw-size-3" />
+            )}
+          </div>
+          {promptOpen ? (
+            <div className="tw-mt-1 tw-border-l-[2px] tw-border-border tw-pl-2">
+              <AgentMarkdownText text={inputPrompt} app={app} />
             </div>
           ) : null}
         </div>
       ) : null}
-    </div>
+      {truncated ? (
+        <div className="tw-text-xs tw-text-muted">
+          Nested sub-agent — expand the parent to drill in.
+        </div>
+      ) : (
+        childNodes.map((c, i) => renderNode(c, i))
+      )}
+      {returnText ? (
+        <div className="tw-my-1 tw-border-l-[2px] tw-border-border tw-pl-2">
+          <AgentMarkdownText text={returnText} app={app} />
+        </div>
+      ) : null}
+    </AgentActivityCard>
   );
 };
 

--- a/src/components/chat-components/AgentActivityCard.test.tsx
+++ b/src/components/chat-components/AgentActivityCard.test.tsx
@@ -1,0 +1,59 @@
+import { AgentActivityCard } from "@/components/chat-components/AgentActivityCard";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Brain } from "lucide-react";
+import React from "react";
+
+describe("AgentActivityCard", () => {
+  describe("AgentActivityCard()", () => {
+    it("uses the shared inset without exposing static rows as controls", () => {
+      const { container } = render(<AgentActivityCard icon={Brain} label="Reasoning" />);
+
+      const header = container.querySelector("[data-agent-activity-card-header]");
+      expect(header?.classList.contains("tw-pl-1")).toBe(true);
+      expect(container.querySelector(".lucide-brain")).not.toBeNull();
+      expect(screen.queryByRole("button")).toBeNull();
+    });
+
+    it("toggles through the same pointer and keyboard interaction contract", () => {
+      const onToggle = jest.fn();
+      const { container, rerender } = render(
+        <AgentActivityCard
+          icon={Brain}
+          label="Reasoning"
+          expandable
+          open={false}
+          onToggle={onToggle}
+        >
+          <span>Details</span>
+        </AgentActivityCard>
+      );
+
+      const closedHeader = screen.getByRole("button", { name: "Reasoning" });
+      expect(closedHeader.getAttribute("aria-expanded")).toBe("false");
+      expect(screen.queryByText("Details")).toBeNull();
+
+      fireEvent.click(closedHeader);
+      fireEvent.keyDown(closedHeader, { key: "Enter" });
+      fireEvent.keyDown(closedHeader, { key: " " });
+      expect(onToggle).toHaveBeenCalledTimes(3);
+
+      rerender(
+        <AgentActivityCard icon={Brain} label="Reasoning" expandable open onToggle={onToggle}>
+          <span>Details</span>
+        </AgentActivityCard>
+      );
+
+      const openHeader = screen.getByRole("button", { name: "Reasoning" });
+      expect(openHeader.getAttribute("aria-expanded")).toBe("true");
+      expect(screen.getByText("Details")).not.toBeNull();
+      expect(
+        container.querySelector(".lucide-chevron-right")?.classList.contains("tw-rotate-90")
+      ).toBe(true);
+      expect(
+        container
+          .querySelector(`[id="${openHeader.getAttribute("aria-controls")}"]`)
+          ?.classList.contains("tw-border-l")
+      ).toBe(true);
+    });
+  });
+});

--- a/src/components/chat-components/AgentActivityCard.tsx
+++ b/src/components/chat-components/AgentActivityCard.tsx
@@ -1,0 +1,84 @@
+import { cn } from "@/lib/utils";
+import { ChevronRight, type LucideIcon } from "lucide-react";
+import React, { useId } from "react";
+
+export interface AgentActivityCardProps {
+  icon: LucideIcon;
+  label: React.ReactNode;
+  trailing?: React.ReactNode;
+  secondary?: React.ReactNode;
+  expandable?: boolean;
+  open?: boolean;
+  onToggle?: () => void;
+  children?: React.ReactNode;
+}
+
+/**
+ * Provides one visual and interaction contract for reasoning, tools, grouped activity, and delegated work.
+ */
+export const AgentActivityCard: React.FC<AgentActivityCardProps> = ({
+  icon: Icon,
+  label,
+  trailing,
+  secondary,
+  expandable = false,
+  open = false,
+  onToggle,
+  children,
+}) => {
+  const bodyId = useId();
+  const canToggle = expandable && onToggle !== undefined;
+
+  return (
+    <div className="tw-my-1 tw-flex tw-w-full tw-flex-col tw-gap-0.5">
+      <div
+        data-agent-activity-card-header
+        className={cn(
+          "tw-flex tw-w-full tw-items-center tw-gap-1.5 tw-pl-1 tw-text-left tw-text-sm tw-text-muted",
+          canToggle ? "tw-cursor-pointer hover:tw-text-normal" : "tw-cursor-default"
+        )}
+        role={canToggle ? "button" : undefined}
+        tabIndex={canToggle ? 0 : undefined}
+        aria-expanded={canToggle ? open : undefined}
+        aria-controls={canToggle ? bodyId : undefined}
+        onClick={canToggle ? onToggle : undefined}
+        onKeyDown={
+          canToggle
+            ? (event) => {
+                if (event.key !== "Enter" && event.key !== " ") return;
+                event.preventDefault();
+                onToggle();
+              }
+            : undefined
+        }
+      >
+        <span className="tw-flex tw-size-3.5 tw-shrink-0 tw-items-center tw-justify-center">
+          <Icon className="tw-size-3.5 tw-text-muted" />
+        </span>
+        <div className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1 tw-truncate tw-font-medium">
+          {label}
+        </div>
+        {trailing}
+        {canToggle ? (
+          <ChevronRight
+            className={cn(
+              "tw-size-3 tw-shrink-0 tw-text-muted tw-transition-transform",
+              open && "tw-rotate-90"
+            )}
+          />
+        ) : null}
+      </div>
+      {secondary ? (
+        <div className="tw-truncate tw-pl-6 tw-text-xs tw-text-muted">{secondary}</div>
+      ) : null}
+      {canToggle && open ? (
+        <div
+          id={bodyId}
+          className="tw-ml-1 tw-mt-1 tw-flex tw-flex-col tw-gap-1 tw-border-l tw-border-border tw-pl-3"
+        >
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/src/components/chat-components/AgentReasoningBlock.test.tsx
+++ b/src/components/chat-components/AgentReasoningBlock.test.tsx
@@ -1,5 +1,5 @@
 import { AgentReasoningBlock } from "@/components/chat-components/AgentReasoningBlock";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 
 describe("AgentReasoningBlock", () => {
@@ -16,6 +16,9 @@ describe("AgentReasoningBlock", () => {
 
       expect(container.querySelector(".lucide-brain")).toBeTruthy();
       expect(container.querySelector(".copilot-spinner")).toBeNull();
+      expect(container.textContent).toContain("Reasoning...");
+      expect(screen.queryByText("3s")).toBeNull();
+      expect(container.querySelector(".copilot-shimmer-text")?.textContent).toBe("...");
       expect(
         container
           .querySelector(".lucide-brain")
@@ -33,6 +36,9 @@ describe("AgentReasoningBlock", () => {
 
       expect(container.querySelector(".lucide-brain")).toBeTruthy();
       expect(container.querySelector(".copilot-spinner")).toBeNull();
+      expect(screen.getByText("Thought for")).toBeTruthy();
+      expect(screen.getByText("4s")).toBeTruthy();
+      expect(container.querySelector(".copilot-shimmer-text")).toBeNull();
     });
   });
 });

--- a/src/components/chat-components/AgentReasoningBlock.test.tsx
+++ b/src/components/chat-components/AgentReasoningBlock.test.tsx
@@ -1,0 +1,38 @@
+import { AgentReasoningBlock } from "@/components/chat-components/AgentReasoningBlock";
+import { render } from "@testing-library/react";
+import React from "react";
+
+describe("AgentReasoningBlock", () => {
+  describe("AgentReasoningBlock()", () => {
+    it("keeps the brain icon when reasoning changes from active to complete", () => {
+      const { container, rerender } = render(
+        <AgentReasoningBlock
+          status="reasoning"
+          elapsedSeconds={3}
+          steps={["Inspecting the current interface"]}
+          isStreaming
+        />
+      );
+
+      expect(container.querySelector(".lucide-brain")).toBeTruthy();
+      expect(container.querySelector(".copilot-spinner")).toBeNull();
+      expect(
+        container
+          .querySelector(".lucide-brain")
+          ?.parentElement?.parentElement?.classList.contains("tw-pl-1")
+      ).toBe(true);
+
+      rerender(
+        <AgentReasoningBlock
+          status="complete"
+          elapsedSeconds={4}
+          steps={["Inspecting the current interface"]}
+          isStreaming={false}
+        />
+      );
+
+      expect(container.querySelector(".lucide-brain")).toBeTruthy();
+      expect(container.querySelector(".copilot-spinner")).toBeNull();
+    });
+  });
+});

--- a/src/components/chat-components/AgentReasoningBlock.tsx
+++ b/src/components/chat-components/AgentReasoningBlock.tsx
@@ -1,8 +1,7 @@
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { AgentActivityCard } from "@/components/chat-components/AgentActivityCard";
 import { formatDuration } from "@/lib/duration";
-import { cn } from "@/lib/utils";
 import { ReasoningStatus } from "@/LLMProviders/chainRunner/utils/AgentReasoningState";
-import { Brain, ChevronRight } from "lucide-react";
+import { Brain } from "lucide-react";
 import React, { useState } from "react";
 
 interface AgentReasoningBlockProps {
@@ -39,25 +38,11 @@ export const AgentReasoningBlock: React.FC<AgentReasoningBlockProps> = ({
   const canExpand = steps.length > 0;
 
   return (
-    <Collapsible
-      open={isExpanded}
-      onOpenChange={canExpand ? setIsExpanded : undefined}
-      disabled={!canExpand}
-      className="tw-my-1 tw-flex tw-w-full tw-flex-col tw-gap-0.5"
-    >
-      <CollapsibleTrigger asChild disabled={!canExpand}>
-        <div
-          className={cn(
-            "tw-flex tw-w-full tw-items-center tw-gap-1.5 tw-pl-1 tw-text-left tw-text-sm tw-text-muted hover:tw-text-normal",
-            canExpand ? "tw-cursor-pointer" : "tw-cursor-default"
-          )}
-        >
-          {/* Reasoning keeps one identity while the separate turn-duration row owns the Copilot mark. */}
-          <span className="tw-flex tw-size-3.5 tw-shrink-0 tw-items-center tw-justify-center">
-            <Brain className="tw-size-3.5 tw-text-muted" />
-          </span>
-
-          <span className="tw-font-medium">
+    <AgentActivityCard
+      icon={Brain}
+      label={
+        <>
+          <span>
             {isActive ? (
               <>
                 Reasoning
@@ -70,33 +55,24 @@ export const AgentReasoningBlock: React.FC<AgentReasoningBlockProps> = ({
             )}
           </span>
           {!isActive ? (
-            <span className="tw-text-muted">{formatDuration(elapsedSeconds * 1000)}</span>
+            <span className="tw-font-normal tw-text-muted">
+              {formatDuration(elapsedSeconds * 1000)}
+            </span>
           ) : null}
-
-          {canExpand && (
-            <ChevronRight
-              className={cn(
-                "tw-ml-auto tw-size-3 tw-text-muted tw-transition-transform",
-                isExpanded && "tw-rotate-90"
-              )}
-            />
-          )}
-        </div>
-      </CollapsibleTrigger>
-
-      {/* Steps - visible when expanded or actively reasoning */}
-      <CollapsibleContent>
-        {steps.length > 0 && (
-          <ul className="tw-mt-1 tw-list-outside tw-list-disc tw-space-y-1.5 tw-pl-5 max-md:tw-space-y-1">
-            {steps.map((step, i) => (
-              // eslint-disable-next-line @eslint-react/no-array-index-key -- steps are append-only with no stable id; text may repeat
-              <li key={i} className="tw-text-xs tw-leading-[1.4] tw-text-muted">
-                {step}
-              </li>
-            ))}
-          </ul>
-        )}
-      </CollapsibleContent>
-    </Collapsible>
+        </>
+      }
+      expandable={canExpand}
+      open={isExpanded}
+      onToggle={() => setIsExpanded((expanded) => !expanded)}
+    >
+      <ul className="tw-list-outside tw-list-disc tw-space-y-1.5 tw-pl-4 max-md:tw-space-y-1">
+        {steps.map((step, i) => (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- steps are append-only with no stable id; text may repeat
+          <li key={i} className="tw-text-xs tw-leading-[1.4] tw-text-muted">
+            {step}
+          </li>
+        ))}
+      </ul>
+    </AgentActivityCard>
   );
 };

--- a/src/components/chat-components/AgentReasoningBlock.tsx
+++ b/src/components/chat-components/AgentReasoningBlock.tsx
@@ -57,9 +57,21 @@ export const AgentReasoningBlock: React.FC<AgentReasoningBlockProps> = ({
             <Brain className="tw-size-3.5 tw-text-muted" />
           </span>
 
-          {/* Title and timer */}
-          <span className="tw-font-medium">{isActive ? "Reasoning" : "Thought for"}</span>
-          <span className="tw-text-muted">{formatDuration(elapsedSeconds * 1000)}</span>
+          <span className="tw-font-medium">
+            {isActive ? (
+              <>
+                Reasoning
+                <span className="copilot-shimmer-text" aria-hidden="true">
+                  ...
+                </span>
+              </>
+            ) : (
+              "Thought for"
+            )}
+          </span>
+          {!isActive ? (
+            <span className="tw-text-muted">{formatDuration(elapsedSeconds * 1000)}</span>
+          ) : null}
 
           {canExpand && (
             <ChevronRight

--- a/src/components/chat-components/AgentReasoningBlock.tsx
+++ b/src/components/chat-components/AgentReasoningBlock.tsx
@@ -1,5 +1,4 @@
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { CopilotSpinner } from "@/components/chat-components/CopilotSpinner";
 import { formatDuration } from "@/lib/duration";
 import { cn } from "@/lib/utils";
 import { ReasoningStatus } from "@/LLMProviders/chainRunner/utils/AgentReasoningState";
@@ -49,13 +48,13 @@ export const AgentReasoningBlock: React.FC<AgentReasoningBlockProps> = ({
       <CollapsibleTrigger asChild disabled={!canExpand}>
         <div
           className={cn(
-            "tw-flex tw-w-full tw-items-center tw-gap-1.5 tw-text-left tw-text-sm tw-text-muted hover:tw-text-normal",
+            "tw-flex tw-w-full tw-items-center tw-gap-1.5 tw-pl-1 tw-text-left tw-text-sm tw-text-muted hover:tw-text-normal",
             canExpand ? "tw-cursor-pointer" : "tw-cursor-default"
           )}
         >
-          {/* Persistent identity icon: spinner while active, Brain when idle/complete */}
+          {/* Reasoning keeps one identity while the separate turn-duration row owns the Copilot mark. */}
           <span className="tw-flex tw-size-3.5 tw-shrink-0 tw-items-center tw-justify-center">
-            {isActive ? <CopilotSpinner /> : <Brain className="tw-size-3.5 tw-text-muted" />}
+            <Brain className="tw-size-3.5 tw-text-muted" />
           </span>
 
           {/* Title and timer */}

--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -354,11 +354,12 @@ describe("ChatSingleMessage", () => {
     expect(messageSegment?.classList.contains("markdown-rendered")).toBe(true);
   });
 
-  it("places supplied Agent Mode metadata in the centered response footer", async () => {
+  it("places supplied Agent Mode metadata before the timestamp in the response footer", async () => {
+    const timestamp = "2026/08/07 20:31:10";
     render(
       <TooltipProvider>
         <ChatSingleMessage
-          message={baseMessage}
+          message={{ ...baseMessage, timestamp: { epoch: 1, display: timestamp, fileName: "now" } }}
           app={createAppStub()}
           isStreaming={false}
           footerStart={<span>Worked for 24s</span>}
@@ -368,8 +369,15 @@ describe("ChatSingleMessage", () => {
 
     await waitFor(() => expect(renderMarkdownMock).toHaveBeenCalled());
 
-    const footer = screen.getByText("Worked for 24s").closest(".tw-justify-between");
+    const duration = screen.getByText("Worked for 24s");
+    const footer = duration.closest(".tw-justify-between");
     expect(footer?.classList.contains("tw-items-center")).toBe(true);
     expect(footer?.contains(screen.getByTitle("Copy"))).toBe(true);
+    expect(
+      Boolean(
+        duration.compareDocumentPosition(screen.getByText(timestamp)) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+      )
+    ).toBe(true);
   });
 });

--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -354,9 +354,9 @@ describe("ChatSingleMessage", () => {
     expect(messageSegment?.classList.contains("markdown-rendered")).toBe(true);
   });
 
-  it("places supplied Agent Mode metadata before the timestamp in the response footer", async () => {
+  it("shows supplied Agent Mode metadata instead of the timestamp in the response footer", async () => {
     const timestamp = "2026/08/07 20:31:10";
-    render(
+    const { rerender } = render(
       <TooltipProvider>
         <ChatSingleMessage
           message={{ ...baseMessage, timestamp: { epoch: 1, display: timestamp, fileName: "now" } }}
@@ -373,11 +373,17 @@ describe("ChatSingleMessage", () => {
     const footer = duration.closest(".tw-justify-between");
     expect(footer?.classList.contains("tw-items-center")).toBe(true);
     expect(footer?.contains(screen.getByTitle("Copy"))).toBe(true);
-    expect(
-      Boolean(
-        duration.compareDocumentPosition(screen.getByText(timestamp)) &
-        Node.DOCUMENT_POSITION_FOLLOWING
-      )
-    ).toBe(true);
+    expect(screen.queryByText(timestamp)).toBeNull();
+
+    rerender(
+      <TooltipProvider>
+        <ChatSingleMessage
+          message={{ ...baseMessage, timestamp: { epoch: 1, display: timestamp, fileName: "now" } }}
+          app={createAppStub()}
+          isStreaming={false}
+        />
+      </TooltipProvider>
+    );
+    expect(screen.getByText(timestamp)).toBeTruthy();
   });
 });

--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import ChatSingleMessage, {
   normalizeFootnoteRendering,
 } from "@/components/chat-components/ChatSingleMessage";
@@ -352,5 +352,24 @@ describe("ChatSingleMessage", () => {
     const messageSegment = container.querySelector(".message-segment");
     expect(messageSegment).toBeTruthy();
     expect(messageSegment?.classList.contains("markdown-rendered")).toBe(true);
+  });
+
+  it("places supplied Agent Mode metadata in the centered response footer", async () => {
+    render(
+      <TooltipProvider>
+        <ChatSingleMessage
+          message={baseMessage}
+          app={createAppStub()}
+          isStreaming={false}
+          footerStart={<span>Worked for 24s</span>}
+        />
+      </TooltipProvider>
+    );
+
+    await waitFor(() => expect(renderMarkdownMock).toHaveBeenCalled());
+
+    const footer = screen.getByText("Worked for 24s").closest(".tw-justify-between");
+    expect(footer?.classList.contains("tw-items-center")).toBe(true);
+    expect(footer?.contains(screen.getByTitle("Copy"))).toBe(true);
   });
 });

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -1,4 +1,5 @@
 import { ChatButtons } from "@/components/chat-components/ChatButtons";
+import { AssistantResponseFooter } from "@/components/ui/AssistantResponseFooter";
 import { SourcesModal } from "@/components/modals/SourcesModal";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -303,7 +304,7 @@ interface ChatSingleMessageProps {
   onRegenerate?: () => void;
   onEdit?: (newMessage: string) => void;
   onDelete?: () => void;
-  /** Agent Mode metadata placed beside the timestamp in the response footer. */
+  /** Agent Mode metadata placed at the response footer's leading edge, before the timestamp. */
   footerStart?: React.ReactNode;
 }
 
@@ -1005,21 +1006,21 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
           )}
 
           {!isStreaming && (
-            <div className="tw-flex tw-items-center tw-justify-between">
-              <div className="tw-flex tw-items-center tw-gap-2">
-                <div className="tw-text-xs tw-text-faint">{message.timestamp?.display}</div>
-                {footerStart}
-              </div>
-              <ChatButtons
-                message={message}
-                onInsertIntoEditor={handleInsertIntoEditor}
-                onRegenerate={onRegenerate}
-                onEdit={onEdit ? handleEdit : undefined}
-                onDelete={onDelete}
-                onShowSources={handleShowSources}
-                hasSources={message.sources && message.sources.length > 0 ? true : false}
-              />
-            </div>
+            <AssistantResponseFooter
+              leading={footerStart}
+              timestamp={message.timestamp?.display}
+              actions={
+                <ChatButtons
+                  message={message}
+                  onInsertIntoEditor={handleInsertIntoEditor}
+                  onRegenerate={onRegenerate}
+                  onEdit={onEdit ? handleEdit : undefined}
+                  onDelete={onDelete}
+                  onShowSources={handleShowSources}
+                  hasSources={message.sources && message.sources.length > 0 ? true : false}
+                />
+              }
+            />
           )}
         </div>
       </div>

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -303,6 +303,8 @@ interface ChatSingleMessageProps {
   onRegenerate?: () => void;
   onEdit?: (newMessage: string) => void;
   onDelete?: () => void;
+  /** Agent Mode metadata placed beside the timestamp in the response footer. */
+  footerStart?: React.ReactNode;
 }
 
 const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
@@ -312,6 +314,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
   onRegenerate,
   onEdit,
   onDelete,
+  footerStart,
 }) => {
   const [isEditing, setIsEditing] = useState<boolean>(false);
   const parsedReasoningBlock = useMemo(
@@ -1003,7 +1006,10 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
 
           {!isStreaming && (
             <div className="tw-flex tw-items-center tw-justify-between">
-              <div className="tw-text-xs tw-text-faint">{message.timestamp?.display}</div>
+              <div className="tw-flex tw-items-center tw-gap-2">
+                <div className="tw-text-xs tw-text-faint">{message.timestamp?.display}</div>
+                {footerStart}
+              </div>
               <ChatButtons
                 message={message}
                 onInsertIntoEditor={handleInsertIntoEditor}

--- a/src/components/ui/AssistantResponseFooter.stories.tsx
+++ b/src/components/ui/AssistantResponseFooter.stories.tsx
@@ -35,16 +35,7 @@ const CompletedDuration: React.FC = () => (
 const CompletedResponseVariantsDemo: React.FC = () => (
   <div className="tw-flex tw-min-w-0 tw-flex-col tw-gap-5">
     <section className="tw-min-w-0">
-      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">
-        Structured activity trail
-      </div>
-      <AssistantResponseFooter leading={<CompletedDuration />} actions={<StoryActions />} />
-    </section>
-
-    <section className="tw-min-w-0">
-      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">
-        Plain Agent Mode response
-      </div>
+      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">Latest structured turn</div>
       <AssistantResponseFooter
         leading={<CompletedDuration />}
         timestamp="2026/08/07 20:31:10"
@@ -54,7 +45,14 @@ const CompletedResponseVariantsDemo: React.FC = () => (
 
     <section className="tw-min-w-0">
       <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">
-        Multi-agent fan-out response
+        Structured turn without a duration
+      </div>
+      <AssistantResponseFooter timestamp="2026/08/07 20:31:10" actions={<StoryActions />} />
+    </section>
+
+    <section className="tw-min-w-0">
+      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">
+        Plain or fan-out response with a duration
       </div>
       <AssistantResponseFooter
         leading={<CompletedDuration />}
@@ -65,7 +63,7 @@ const CompletedResponseVariantsDemo: React.FC = () => (
   </div>
 );
 
-/** Full timestamps exercise the narrow-pane ordering called out in review. */
+/** Every footer shows either the duration or its timestamp, never both. */
 export const CompletedResponseVariants: StoryObj<AssistantResponseFooterProps> = {
   render: CompletedResponseVariantsDemo,
 };

--- a/src/components/ui/AssistantResponseFooter.stories.tsx
+++ b/src/components/ui/AssistantResponseFooter.stories.tsx
@@ -1,0 +1,71 @@
+import {
+  AssistantResponseFooter,
+  type AssistantResponseFooterProps,
+} from "@/components/ui/AssistantResponseFooter";
+import type { Meta, StoryObj } from "@/lib/story";
+import { Copy, Sparkles, TextCursorInput } from "lucide-react";
+import React from "react";
+
+const meta = {
+  title: "Agent Mode/Assistant Response Footer",
+  component: AssistantResponseFooter,
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
+} satisfies Meta<AssistantResponseFooterProps>;
+export default meta;
+
+const StoryActions: React.FC = () => (
+  <div className="tw-flex tw-items-center tw-gap-2 tw-text-muted">
+    <TextCursorInput className="tw-size-icon-xs" />
+    <Copy className="tw-size-icon-xs" />
+  </div>
+);
+
+const CompletedDuration: React.FC = () => (
+  <div className="tw-flex tw-items-center tw-gap-1.5 tw-pl-1 tw-text-ui-small tw-text-muted">
+    <span className="tw-flex tw-size-icon-xs tw-shrink-0 tw-items-center tw-justify-start">
+      <Sparkles className="tw-size-icon-xs" />
+    </span>
+    <span>
+      <span className="tw-font-medium">Worked for</span>{" "}
+      <span className="tw-tabular-nums">24s</span>
+    </span>
+  </div>
+);
+
+const CompletedResponseVariantsDemo: React.FC = () => (
+  <div className="tw-flex tw-min-w-0 tw-flex-col tw-gap-5">
+    <section className="tw-min-w-0">
+      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">
+        Structured activity trail
+      </div>
+      <AssistantResponseFooter leading={<CompletedDuration />} actions={<StoryActions />} />
+    </section>
+
+    <section className="tw-min-w-0">
+      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">
+        Plain Agent Mode response
+      </div>
+      <AssistantResponseFooter
+        leading={<CompletedDuration />}
+        timestamp="2026/08/07 20:31:10"
+        actions={<StoryActions />}
+      />
+    </section>
+
+    <section className="tw-min-w-0">
+      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">
+        Multi-agent fan-out response
+      </div>
+      <AssistantResponseFooter
+        leading={<CompletedDuration />}
+        timestamp="2026/08/07 20:31:10"
+        actions={<StoryActions />}
+      />
+    </section>
+  </div>
+);
+
+/** Full timestamps exercise the narrow-pane ordering called out in review. */
+export const CompletedResponseVariants: StoryObj<AssistantResponseFooterProps> = {
+  render: CompletedResponseVariantsDemo,
+};

--- a/src/components/ui/AssistantResponseFooter.stories.tsx
+++ b/src/components/ui/AssistantResponseFooter.stories.tsx
@@ -35,7 +35,7 @@ const CompletedDuration: React.FC = () => (
 const CompletedResponseVariantsDemo: React.FC = () => (
   <div className="tw-flex tw-min-w-0 tw-flex-col tw-gap-5">
     <section className="tw-min-w-0">
-      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">Latest structured turn</div>
+      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">Completed duration</div>
       <AssistantResponseFooter
         leading={<CompletedDuration />}
         timestamp="2026/08/07 20:31:10"
@@ -44,21 +44,8 @@ const CompletedResponseVariantsDemo: React.FC = () => (
     </section>
 
     <section className="tw-min-w-0">
-      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">
-        Structured turn without a duration
-      </div>
+      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">Timestamp fallback</div>
       <AssistantResponseFooter timestamp="2026/08/07 20:31:10" actions={<StoryActions />} />
-    </section>
-
-    <section className="tw-min-w-0">
-      <div className="tw-mb-2 tw-text-xs tw-font-medium tw-text-muted">
-        Plain or fan-out response with a duration
-      </div>
-      <AssistantResponseFooter
-        leading={<CompletedDuration />}
-        timestamp="2026/08/07 20:31:10"
-        actions={<StoryActions />}
-      />
     </section>
   </div>
 );

--- a/src/components/ui/AssistantResponseFooter.test.tsx
+++ b/src/components/ui/AssistantResponseFooter.test.tsx
@@ -1,0 +1,42 @@
+import {
+  AssistantResponseFooter,
+  type AssistantResponseFooterProps,
+} from "@/components/ui/AssistantResponseFooter";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+const renderFooter = (props: Partial<AssistantResponseFooterProps> = {}) =>
+  render(<AssistantResponseFooter actions={<span>Actions</span>} {...props} />);
+
+describe("AssistantResponseFooter", () => {
+  describe("AssistantResponseFooter()", () => {
+    it("places leading metadata before the timestamp and keeps actions at the trailing edge", () => {
+      const { container } = renderFooter({
+        leading: <span>Worked for 24s</span>,
+        timestamp: "2026/08/07 20:31:10",
+      });
+
+      const footer = container.firstElementChild;
+      const leading = screen.getByText("Worked for 24s");
+      const timestamp = screen.getByText("2026/08/07 20:31:10");
+      const actions = screen.getByText("Actions");
+
+      expect(
+        Boolean(leading.compareDocumentPosition(timestamp) & Node.DOCUMENT_POSITION_FOLLOWING)
+      ).toBe(true);
+      expect(timestamp.classList.contains("tw-truncate")).toBe(true);
+      expect(actions.parentElement?.classList.contains("tw-ml-auto")).toBe(true);
+      expect(footer?.classList.contains("tw-min-w-0")).toBe(true);
+    });
+
+    it("right-aligns actions when the footer has no metadata", () => {
+      const { container } = renderFooter({ leading: null });
+
+      expect(screen.getByText("Actions").parentElement?.classList.contains("tw-ml-auto")).toBe(
+        true
+      );
+      expect(screen.queryByText("Worked for 24s")).toBeNull();
+      expect(container.querySelector("[data-response-footer-leading]")).toBeNull();
+    });
+  });
+});

--- a/src/components/ui/AssistantResponseFooter.test.tsx
+++ b/src/components/ui/AssistantResponseFooter.test.tsx
@@ -10,23 +10,30 @@ const renderFooter = (props: Partial<AssistantResponseFooterProps> = {}) =>
 
 describe("AssistantResponseFooter", () => {
   describe("AssistantResponseFooter()", () => {
-    it("places leading metadata before the timestamp and keeps actions at the trailing edge", () => {
+    it("prefers leading metadata over the timestamp and keeps actions at the trailing edge", () => {
       const { container } = renderFooter({
         leading: <span>Worked for 24s</span>,
         timestamp: "2026/08/07 20:31:10",
       });
 
       const footer = container.firstElementChild;
-      const leading = screen.getByText("Worked for 24s");
-      const timestamp = screen.getByText("2026/08/07 20:31:10");
       const actions = screen.getByText("Actions");
 
-      expect(
-        Boolean(leading.compareDocumentPosition(timestamp) & Node.DOCUMENT_POSITION_FOLLOWING)
-      ).toBe(true);
-      expect(timestamp.classList.contains("tw-truncate")).toBe(true);
+      expect(screen.getByText("Worked for 24s")).toBeTruthy();
+      expect(screen.queryByText("2026/08/07 20:31:10")).toBeNull();
       expect(actions.parentElement?.classList.contains("tw-ml-auto")).toBe(true);
       expect(footer?.classList.contains("tw-min-w-0")).toBe(true);
+    });
+
+    it("shows a truncating timestamp when leading metadata is absent", () => {
+      const { container } = renderFooter({
+        timestamp: "2026/08/07 20:31:10",
+        actions: undefined,
+      });
+
+      expect(screen.getByText("2026/08/07 20:31:10").classList.contains("tw-truncate")).toBe(true);
+      expect(container.querySelector("[data-response-footer-leading]")).toBeNull();
+      expect(container.querySelector("[data-response-footer-actions]")).toBeNull();
     });
 
     it("right-aligns actions when the footer has no metadata", () => {

--- a/src/components/ui/AssistantResponseFooter.tsx
+++ b/src/components/ui/AssistantResponseFooter.tsx
@@ -3,10 +3,10 @@ import React from "react";
 export interface AssistantResponseFooterProps {
   /** Metadata anchored to the response's leading edge, such as whole-turn duration. */
   leading?: React.ReactNode;
-  /** Optional creation time shown after leading metadata. */
+  /** Creation time shown only when leading metadata is absent. */
   timestamp?: React.ReactNode;
   /** Response controls anchored to the trailing edge. */
-  actions: React.ReactNode;
+  actions?: React.ReactNode;
 }
 
 /**
@@ -18,7 +18,9 @@ export const AssistantResponseFooter: React.FC<AssistantResponseFooterProps> = (
   actions,
 }) => {
   const hasLeading = leading !== undefined && leading !== null && leading !== false;
-  const hasTimestamp = timestamp !== undefined && timestamp !== null && timestamp !== false;
+  const hasTimestamp =
+    !hasLeading && timestamp !== undefined && timestamp !== null && timestamp !== false;
+  const hasActions = actions !== undefined && actions !== null && actions !== false;
   const hasMetadata = hasLeading || hasTimestamp;
 
   return (
@@ -35,7 +37,11 @@ export const AssistantResponseFooter: React.FC<AssistantResponseFooterProps> = (
           ) : null}
         </div>
       ) : null}
-      <div className="tw-ml-auto tw-shrink-0">{actions}</div>
+      {hasActions ? (
+        <div data-response-footer-actions className="tw-ml-auto tw-shrink-0">
+          {actions}
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/components/ui/AssistantResponseFooter.tsx
+++ b/src/components/ui/AssistantResponseFooter.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+export interface AssistantResponseFooterProps {
+  /** Metadata anchored to the response's leading edge, such as whole-turn duration. */
+  leading?: React.ReactNode;
+  /** Optional creation time shown after leading metadata. */
+  timestamp?: React.ReactNode;
+  /** Response controls anchored to the trailing edge. */
+  actions: React.ReactNode;
+}
+
+/**
+ * Keeps completed assistant metadata and controls in one responsive footer treatment.
+ */
+export const AssistantResponseFooter: React.FC<AssistantResponseFooterProps> = ({
+  leading,
+  timestamp,
+  actions,
+}) => {
+  const hasLeading = leading !== undefined && leading !== null && leading !== false;
+  const hasTimestamp = timestamp !== undefined && timestamp !== null && timestamp !== false;
+  const hasMetadata = hasLeading || hasTimestamp;
+
+  return (
+    <div className="tw-flex tw-min-w-0 tw-items-center tw-justify-between tw-gap-2">
+      {hasMetadata ? (
+        <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-2 tw-overflow-hidden">
+          {hasLeading ? (
+            <div data-response-footer-leading className="tw-shrink-0">
+              {leading}
+            </div>
+          ) : null}
+          {hasTimestamp ? (
+            <div className="tw-truncate tw-text-xs tw-text-faint">{timestamp}</div>
+          ) : null}
+        </div>
+      ) : null}
+      <div className="tw-ml-auto tw-shrink-0">{actions}</div>
+    </div>
+  );
+};


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#266

## Why

Streaming reasoning showed a changing elapsed time beside each reasoning card, then repeated timing again as “Worked for” below the response. The reasoning, response text, and whole-turn status also did not share a consistent left edge, while completed duration sat apart from the response controls.

## What

Active reasoning now keeps the brain icon and shows an animated `Reasoning...` label without an individual elapsed time. Once reasoning finishes, the card still reports `Thought for X`.

The animated Copilot mark remains reserved for whole-turn duration. When the session completes, `Worked for X` moves into the same vertically centered footer row as the response controls. The reasoning icon, rendered response text, and duration icon share one left edge across structured agent trails, plain responses, and fan-out responses.

## Non goal

This PR does not change activity grouping, hide agent prose, persist expansion state, or alter individual tool and sub-agent card layouts.

## Screenshot

**Streaming reasoning**

<img width="1405" height="768" alt="Streaming reasoning uses the brain icon and an animated Reasoning ellipsis without elapsed time" src="https://github.com/user-attachments/assets/058b4a4c-2c94-49b2-bc0a-12e342fe50d1" />

**Completed response**

<img width="1405" height="768" alt="Completed response shows Thought for duration and Worked for duration centered with response controls" src="https://github.com/user-attachments/assets/3e6a8f38-ff48-4152-bb9d-0280b6596083" />

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Focused component tests cover streaming and completed reasoning labels, duration placement, and footer composition |
| A defect would fail CI or be obvious on first use | ✅ | Six focused suites cover all affected response shapes, and the combined gallery story exposes the complete layout |
| A revert fully restores prior state, including persisted data | ✅ | The change only affects presentation components, tests, stories, and documentation |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The agent trail remains display-only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Persisted agent messages and external component contracts remain unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The existing timers still determine the final reasoning and turn durations |
| No hot-path behavior lacks deterministic coverage | ✅ | Thirty-two focused tests exercise the affected reasoning, trail, plain-response, fan-out, and footer states |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | All changed presentation is visible within a single completed agent turn |

Review: run Verification steps 2–4 and confirm the streaming label, completed timing labels, and shared response footer.

## Verification

1. Deploy the branch to the configured test vault with `npm run gallery:vault`.
2. Open **Agent Mode → Reasoning Block → Active** and confirm the brain appears beside animated `Reasoning...` with no elapsed time.
3. Open **Complete** and confirm the card reads `Thought for X`.
4. Open **WithResponseAndWorkedFor** and confirm `Worked for X` shares a vertically centered footer row with the response controls, while the reasoning icon, response text, and duration icon share one left edge.
5. Resize the gallery panel to narrow and wide widths and confirm the footer does not overflow.
