### PR TITLE
Offer DeepSeek V4 Flash 0731 in the Copilot Plus lineup

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -229,6 +229,7 @@ export enum ChatModels {
   COPILOT_PLUS_GLM_5_2 = "glm-5.2",
   COPILOT_PLUS_KIMI_K2_7_CODE = "kimi-k2.7-code",
   COPILOT_PLUS_DEEPSEEK_V4_PRO = "deepseek-v4-pro",
+  COPILOT_PLUS_DEEPSEEK_V4_FLASH_0731 = "deepseek-v4-flash-0731",
   COPILOT_PLUS_MIMO_V2_5 = "mimo-v2.5",
   COPILOT_PLUS_MINIMAX_M2_7 = "minimax-m2.7",
   GPT_5_5 = "gpt-5.5",

--- a/src/modelManagement/setup/copilotPlusSync.test.ts
+++ b/src/modelManagement/setup/copilotPlusSync.test.ts
@@ -32,6 +32,7 @@ describe("copilotPlusSync", () => {
       "glm-5.2",
       "kimi-k2.7-code",
       "deepseek-v4-pro",
+      "deepseek-v4-flash-0731",
       "mimo-v2.5",
       "minimax-m2.7",
     ]);
@@ -68,6 +69,7 @@ describe("copilotPlusSync", () => {
         "glm-5.2": true,
         "kimi-k2.7-code": true,
         "deepseek-v4-pro": true,
+        "deepseek-v4-flash-0731": true,
         "mimo-v2.5": true,
         "minimax-m2.7": true,
       });

--- a/src/modelManagement/setup/copilotPlusSync.ts
+++ b/src/modelManagement/setup/copilotPlusSync.ts
@@ -72,6 +72,14 @@ export const COPILOT_PLUS_MODELS: readonly ModelInfo[] = Object.freeze([
     modalities: { input: ["text"], output: ["text"] },
   },
   {
+    id: ChatModels.COPILOT_PLUS_DEEPSEEK_V4_FLASH_0731,
+    displayName: "DeepSeek V4 Flash 0731",
+    description: "The newest DeepSeek V4 Flash snapshot: fast, cheap, and broadly capable.",
+    toolCall: true,
+    reasoning: true,
+    modalities: { input: ["text"], output: ["text"] },
+  },
+  {
     id: ChatModels.COPILOT_PLUS_MIMO_V2_5,
     displayName: "MiMo V2.5",
     description: "Cost-effective and capable for everyday use.",


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#282

## Why

The Plus lineup in `COPILOT_PLUS_MODELS` is a hand-maintained mirror of what `models.brevilabs.com/v1/models` serves — the relay has no catalog endpoint to fetch. The relay is adding `deepseek-v4-flash-0731` (Brevilabs/brevilabs-models#74), so until the plugin lists it, Plus users cannot select a model their license already covers.

## What changed

One `ChatModels` entry and one `COPILOT_PLUS_MODELS` row: **DeepSeek V4 Flash 0731**, text-only, `toolCall: true`, `reasoning: true` (the relay accepts an effort for it, so the picker shows the effort control).

It ships **available-but-off** — `COPILOT_PLUS_DEFAULT_ENABLED_MODELS` is untouched, so users opt in from the picker like they do for every other non-flash Plus model.

## Non-goals

Not default-enabled. No move away from the hardcoded lineup toward a fetched relay catalog — that drift is real but it is a separate change.

## Risk: low

Additive data only: no control flow, no types, no migration. The failure mode if the ids ever disagree is a picker entry the relay rejects, which is why the wire id here was checked against the relay's own constant rather than typed from memory.

**How to review:** confirm the id string matches `DEEPSEEK_V4_FLASH_0731_ALIAS` in the models service, and that the entry is absent from the default-enabled list.

## Verification

- `npx jest src/modelManagement` — 34 suites, 359 tests passing, including the lineup-order and reasoning-map assertions updated here.
- `npx tsc -noEmit -skipLibCheck` clean; eslint and prettier clean on the touched files.
- Live-checked the underlying model on DeepInfra (real completion returned) while preparing the relay side, so the capability flags in this row reflect the actual deployment rather than a spec sheet.

No screenshots: the visible change is one extra row in the model picker, rendered entirely by existing list code from this data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
