### PR TITLE
Apply saved agent config when resuming chats

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -72,6 +72,7 @@ The mode picker beside the message box controls how much the active agent can do
 - **Auto** — the agent works with its Auto permissions. Depending on the agent and its configuration, some actions may still require approval.
 
 The available modes depend on the selected agent. Copilot normalizes equivalent modes across supported versions of Claude, Codex, and OpenCode.
+Your most recent mode is remembered per agent and applied when you start a new chat or reopen a saved one.
 
 With Claude you can decide how much **Auto** actually hands over, under
 **Settings → Copilot → Agents → Claude → Auto mode permissions**:

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -382,13 +382,14 @@ export const ClaudeBackendDescriptor: ClaudeDescriptor = {
   },
 
   /**
-   * Replay the intended effort on a freshly created session. The Claude
+   * Replay the intended effort before a fresh or resumed session becomes
+   * ready for user input. The Claude
    * SDK adapter probes the model catalog asynchronously, so the effort
    * `SessionConfigOption` may not be present yet when this runs;
    * `replayPersistedEffort` subscribes to the session and applies once the
    * option arrives (with a timeout guard to avoid leaking listeners on
-   * agents that never report effort). Mode is never persisted — the
-   * Claude SDK's natural starting mode is already canonical `default`.
+   * agents that never report effort). Mode persistence is handled by the
+   * session manager after this hook settles.
    *
    * A transient cross-backend pick seeds the session with the user's drafted
    * effort via `seededSelection`; that intent wins over the persisted default,

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -29,7 +29,14 @@ import {
 } from "@/aiParams";
 import type { ProjectFileRecord } from "@/projects/type";
 import { getProjectContextSignature } from "@/projects/projectContextSignature";
-import type { BackendDescriptor, BackendModelCatalog, InstallState } from "./types";
+import { MethodUnsupportedError } from "@/agentMode/session/errors";
+import type {
+  BackendDescriptor,
+  BackendId,
+  BackendModelCatalog,
+  BackendState,
+  InstallState,
+} from "./types";
 
 const mockEnsureMaterialized = ensureProjectContextMaterialized as jest.Mock;
 
@@ -2028,6 +2035,9 @@ describe("AgentSessionManager chat history aggregation", () => {
     probeSessionId?: string;
     /** Defaults to true; set false to model a non-summarizing backend (codex). */
     summarizesSessionTitle?: boolean;
+    backendId?: BackendId;
+    createBackendProcess?: jest.Mock;
+    applyInitialSessionConfig?: BackendDescriptor["applyInitialSessionConfig"];
   }) {
     const frontmatterByPath = opts?.files ?? {};
     const hiddenByPath = opts?.hiddenFiles ?? {};
@@ -2075,12 +2085,18 @@ describe("AgentSessionManager chat history aggregation", () => {
       deleteFile: jest.fn(async () => undefined),
     };
     const index = new AgentSessionIndex(makeIndexStorage(), "plugins/copilot/index.json");
+    const backendId = opts?.backendId ?? "opencode";
     const descriptor = {
       ...buildDescriptor(),
+      id: backendId,
       summarizesSessionTitle: opts?.summarizesSessionTitle ?? true,
       getProbeSessionId: jest.fn(() => opts?.probeSessionId),
+      applyInitialSessionConfig: opts?.applyInitialSessionConfig,
     } as unknown as BackendDescriptor;
-    if (opts?.listSessions) {
+    if (opts?.createBackendProcess) {
+      (descriptor as unknown as { createBackendProcess: jest.Mock }).createBackendProcess =
+        opts.createBackendProcess;
+    } else if (opts?.listSessions) {
       (descriptor as unknown as { createBackendProcess: jest.Mock }).createBackendProcess = jest.fn(
         () => ({ ...makeMockBackendProcess(), listSessions: opts.listSessions })
       );
@@ -2090,7 +2106,7 @@ describe("AgentSessionManager chat history aggregation", () => {
       plugin as unknown as ConstructorParameters<typeof AgentSessionManager>[1],
       {
         permissionPrompter: jest.fn(),
-        resolveDescriptor: (id) => (id === "opencode" ? descriptor : undefined),
+        resolveDescriptor: (id) => (id === backendId ? descriptor : undefined),
         modelPreloader: {
           getCachedModelCatalog: jest.fn(() => null),
           preload: jest.fn(async () => undefined),
@@ -2105,7 +2121,7 @@ describe("AgentSessionManager chat history aggregation", () => {
             if (opts.warmListSessions) proc.listSessions = opts.warmListSessions;
             if (opts.warmSessionExistsLocally)
               proc.sessionExistsLocally = opts.warmSessionExistsLocally;
-            return [{ backendId: "opencode", proc }];
+            return [{ backendId, proc }];
           }),
         } as unknown as ConstructorParameters<typeof AgentSessionManager>[2]["modelPreloader"],
         persistenceManager: persistence as unknown as ConstructorParameters<
@@ -2289,19 +2305,87 @@ describe("AgentSessionManager chat history aggregation", () => {
     expect(live.setLabel).not.toHaveBeenCalled();
   });
 
-  it("matches live sessions by the (backendId, sessionId) pair, not session id alone", async () => {
-    const { manager } = buildHistoryHarness();
-    const session = await manager.createSession("opencode");
-    const liveId = session.getBackendSessionId()!;
+  describe("loadNativeSessionFromHistory()", () => {
+    it("matches live sessions by the (backendId, sessionId) pair, not session id alone", async () => {
+      const { manager } = buildHistoryHarness();
+      const session = await manager.createSession("opencode");
+      const liveId = session.getBackendSessionId()!;
 
-    // Same backend + session id: focuses the existing tab.
-    await expect(manager.loadNativeSessionFromHistory("opencode", liveId)).resolves.toBe(session);
+      // Same backend + session id: focuses the existing tab.
+      await expect(manager.loadNativeSessionFromHistory("opencode", liveId)).resolves.toBe(session);
 
-    // Same session id on a DIFFERENT backend must not focus the opencode
-    // tab — it falls through to the resume path (which here fails on the
-    // unknown backend rather than silently hijacking the wrong session).
-    await expect(manager.loadNativeSessionFromHistory("codex", liveId)).rejects.toThrow();
-    expect(manager.getActiveSession()).toBe(session);
+      // Same session id on a DIFFERENT backend must not focus the opencode
+      // tab — it falls through to the resume path (which here fails on the
+      // unknown backend rather than silently hijacking the wrong session).
+      await expect(manager.loadNativeSessionFromHistory("codex", liveId)).rejects.toThrow();
+      expect(manager.getActiveSession()).toBe(session);
+    });
+
+    it("applies initial backend config before returning a resumed session", async () => {
+      const backendState = (effort: string): BackendState => ({
+        model: {
+          current: { baseModelId: "sonnet", effort },
+          availableModels: [],
+          apply: { kind: "setModel" },
+        },
+        mode: null,
+      });
+      const setSessionConfigOption = jest.fn(async () => backendState("high"));
+      const backend = {
+        ...makeMockBackendProcess(),
+        loadSession: jest.fn(async () => {
+          throw new MethodUnsupportedError("session/load");
+        }),
+        resumeSession: jest.fn(async ({ sessionId }: { sessionId: string }) => ({
+          sessionId,
+          state: backendState("low"),
+        })),
+        setSessionConfigOption,
+      };
+      let releaseApply: () => void = () => {};
+      let markApplyStarted: () => void = () => {};
+      const applyStarted = new Promise<void>((resolve) => {
+        markApplyStarted = resolve;
+      });
+      const applyRelease = new Promise<void>((resolve) => {
+        releaseApply = resolve;
+      });
+      const applyInitialSessionConfig = jest.fn(async (session: AgentSession) => {
+        markApplyStarted();
+        await applyRelease;
+        await session.setConfigOption("effort", "high");
+      });
+      const { manager } = buildHistoryHarness({
+        backendId: "claude",
+        createBackendProcess: jest.fn(() => backend),
+        applyInitialSessionConfig,
+      });
+
+      let returned = false;
+      const loading = manager
+        .loadNativeSessionFromHistory("claude", "saved-chat")
+        .then((session) => {
+          returned = true;
+          return session;
+        });
+      await applyStarted;
+      await Promise.resolve();
+      expect(returned).toBe(false);
+
+      releaseApply();
+      const session = await loading;
+
+      expect(applyInitialSessionConfig).toHaveBeenCalledWith(
+        session,
+        expect.objectContaining({ agentMode: expect.any(Object) })
+      );
+      expect(setSessionConfigOption).toHaveBeenCalledWith({
+        sessionId: "saved-chat",
+        configId: "effort",
+        value: "high",
+      });
+      expect(session.getState()?.model?.current.effort).toBe("high");
+    });
   });
 
   it("hides a markdown chat whose backend session is absent on this device", async () => {

--- a/src/agentMode/session/AgentSessionManager.test.ts
+++ b/src/agentMode/session/AgentSessionManager.test.ts
@@ -2321,16 +2321,27 @@ describe("AgentSessionManager chat history aggregation", () => {
       expect(manager.getActiveSession()).toBe(session);
     });
 
-    it("applies initial backend config before returning a resumed session", async () => {
-      const backendState = (effort: string): BackendState => ({
+    it("applies persisted backend config and mode before returning a resumed session", async () => {
+      const backendState = (effort: string, mode: "default" | "auto"): BackendState => ({
         model: {
           current: { baseModelId: "sonnet", effort },
           availableModels: [],
           apply: { kind: "setModel" },
         },
-        mode: null,
+        mode: {
+          current: mode,
+          options: [
+            { value: "default", label: "Default" },
+            { value: "auto", label: "Auto" },
+          ],
+          apply: {
+            default: { kind: "setMode", nativeId: "default" },
+            auto: { kind: "setMode", nativeId: "bypassPermissions" },
+          },
+        },
       });
-      const setSessionConfigOption = jest.fn(async () => backendState("high"));
+      const setSessionConfigOption = jest.fn(async () => backendState("high", "default"));
+      const setSessionMode = jest.fn(async () => backendState("high", "auto"));
       const backend = {
         ...makeMockBackendProcess(),
         loadSession: jest.fn(async () => {
@@ -2338,9 +2349,10 @@ describe("AgentSessionManager chat history aggregation", () => {
         }),
         resumeSession: jest.fn(async ({ sessionId }: { sessionId: string }) => ({
           sessionId,
-          state: backendState("low"),
+          state: backendState("low", "default"),
         })),
         setSessionConfigOption,
+        setSessionMode,
       };
       let releaseApply: () => void = () => {};
       let markApplyStarted: () => void = () => {};
@@ -2360,6 +2372,13 @@ describe("AgentSessionManager chat history aggregation", () => {
         createBackendProcess: jest.fn(() => backend),
         applyInitialSessionConfig,
       });
+      const settings = {
+        agentMode: {
+          activeBackend: "claude",
+          backends: { claude: { defaultMode: "auto" } },
+        },
+      };
+      (mockedGetSettings as jest.Mock).mockReturnValueOnce(settings).mockReturnValueOnce(settings);
 
       let returned = false;
       const loading = manager
@@ -2384,7 +2403,98 @@ describe("AgentSessionManager chat history aggregation", () => {
         configId: "effort",
         value: "high",
       });
+      expect(setSessionMode).toHaveBeenCalledWith({
+        sessionId: "saved-chat",
+        modeId: "bypassPermissions",
+      });
       expect(session.getState()?.model?.current.effort).toBe("high");
+      expect(session.getState()?.mode?.current).toBe("auto");
+    });
+
+    it("keeps focus on the most recently opened history row when resumes finish out of order", async () => {
+      const backend = {
+        ...makeMockBackendProcess(),
+        loadSession: jest.fn(async () => {
+          throw new MethodUnsupportedError("session/load");
+        }),
+        resumeSession: jest.fn(async ({ sessionId }: { sessionId: string }) => ({
+          sessionId,
+          state: { model: null, mode: null },
+        })),
+      };
+      let releaseFirst: () => void = () => {};
+      let markFirstStarted: () => void = () => {};
+      const firstStarted = new Promise<void>((resolve) => {
+        markFirstStarted = resolve;
+      });
+      const firstRelease = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const applyInitialSessionConfig = jest.fn(async (session: AgentSession) => {
+        if (session.getBackendSessionId() !== "first-chat") return;
+        markFirstStarted();
+        await firstRelease;
+      });
+      const { manager } = buildHistoryHarness({
+        backendId: "claude",
+        createBackendProcess: jest.fn(() => backend),
+        applyInitialSessionConfig,
+      });
+
+      const firstLoading = manager.loadNativeSessionFromHistory("claude", "first-chat");
+      await firstStarted;
+      const second = await manager.loadNativeSessionFromHistory("claude", "second-chat");
+      expect(manager.getActiveSession()).toBe(second);
+
+      releaseFirst();
+      const first = await firstLoading;
+
+      expect(first).not.toBe(second);
+      expect(manager.getSessions()).toHaveLength(2);
+      expect(manager.getActiveSession()).toBe(second);
+    });
+
+    it("shares one in-flight resume when the same history row is opened twice", async () => {
+      const resumeSession = jest.fn(async ({ sessionId }: { sessionId: string }) => ({
+        sessionId,
+        state: { model: null, mode: null },
+      }));
+      const backend = {
+        ...makeMockBackendProcess(),
+        loadSession: jest.fn(async () => {
+          throw new MethodUnsupportedError("session/load");
+        }),
+        resumeSession,
+      };
+      let releaseApply: () => void = () => {};
+      let markApplyStarted: () => void = () => {};
+      const applyStarted = new Promise<void>((resolve) => {
+        markApplyStarted = resolve;
+      });
+      const applyRelease = new Promise<void>((resolve) => {
+        releaseApply = resolve;
+      });
+      const applyInitialSessionConfig = jest.fn(async () => {
+        markApplyStarted();
+        await applyRelease;
+      });
+      const { manager } = buildHistoryHarness({
+        backendId: "claude",
+        createBackendProcess: jest.fn(() => backend),
+        applyInitialSessionConfig,
+      });
+
+      const firstLoading = manager.loadNativeSessionFromHistory("claude", "saved-chat");
+      await applyStarted;
+      const secondLoading = manager.loadNativeSessionFromHistory("claude", "saved-chat");
+      releaseApply();
+      const [first, second] = await Promise.all([firstLoading, secondLoading]);
+
+      expect(first).toBe(second);
+      expect(resumeSession).toHaveBeenCalledTimes(1);
+      expect(applyInitialSessionConfig).toHaveBeenCalledTimes(1);
+      expect(manager.getSessions()).toEqual([first]);
+      expect(manager.getActiveSession()).toBe(first);
     });
   });
 

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -3070,6 +3070,21 @@ export class AgentSessionManager {
           }
         : {}),
     });
+    if (descriptor.applyInitialSessionConfig) {
+      try {
+        await descriptor.applyInitialSessionConfig(session, getSettings());
+      } catch (e) {
+        logWarn(
+          `[AgentMode] applyInitialSessionConfig failed for resumed ${backendId} session; continuing`,
+          e
+        );
+      }
+    }
+    if (this.disposed) {
+      await session.dispose();
+      this.finishPendingCreate();
+      return null;
+    }
     if (projectId !== GLOBAL_SCOPE) {
       this.lastSeenProjectContentEpochBySession.set(internalId, RESUMED_SESSION_BEHIND_EPOCH);
     }

--- a/src/agentMode/session/AgentSessionManager.ts
+++ b/src/agentMode/session/AgentSessionManager.ts
@@ -317,6 +317,13 @@ export class AgentSessionManager {
   // Serializes replacements for one logical input even after its runtime session id changes.
   // The cursor retains the last successful owner when an individual replacement fails.
   private readonly replacementCursorByChatInputId = new Map<string, Promise<string>>();
+  // Native session identity is stable across markdown/native history surfaces.
+  // Sharing one resume prevents duplicate AgentSessions and backend handlers
+  // when the same row is opened again before the first load settles.
+  private readonly resumedSessionPromiseById = new Map<string, Promise<AgentSession | null>>();
+  // History opens may finish out of order. Only the most recent request may
+  // move focus; older successful loads remain available as background tabs.
+  private latestHistoryLoadRequestId = 0;
   private pendingCreates = 0;
   private listeners = new Set<() => void>();
   private disposed = false;
@@ -2734,6 +2741,7 @@ export class AgentSessionManager {
     if (this.disposed) {
       throw new Error("AgentSessionManager has been shut down");
     }
+    const requestId = ++this.latestHistoryLoadRequestId;
 
     for (const [internalId, state] of this.sessionState.entries()) {
       if (state.path !== file.path) continue;
@@ -2793,9 +2801,11 @@ export class AgentSessionManager {
       // merged history ranks this chat correctly after a reopen.
       void this.opts.sessionIndex?.touch(loaded.backendId, loaded.sessionId);
     }
-    this.lastActiveByScope.set(projectId, session.internalId);
-    this.absorbIntoEmptyActiveTab(session, previousActiveId);
-    this.notify();
+    if (requestId === this.latestHistoryLoadRequestId) {
+      this.setActiveSession(session.internalId);
+      this.absorbIntoEmptyActiveTab(session, previousActiveId);
+      this.notify();
+    }
     return session;
   }
 
@@ -2841,6 +2851,7 @@ export class AgentSessionManager {
     if (this.disposed) {
       throw new Error("AgentSessionManager has been shut down");
     }
+    const requestId = ++this.latestHistoryLoadRequestId;
     // Identity is the (backendId, sessionId) pair — searched together so an
     // id collision across backends can't hide the correct already-open tab.
     const existing = this.findLiveSession(backendId, sessionId);
@@ -2895,9 +2906,11 @@ export class AgentSessionManager {
       session.restoreLabel(entry.title, entry.titleSource === "user" ? "user" : "agent");
     }
     if (index) await index.touch(backendId, sessionId);
-    this.lastActiveByScope.set(projectId, session.internalId);
-    this.absorbIntoEmptyActiveTab(session, previousActiveId);
-    this.notify();
+    if (requestId === this.latestHistoryLoadRequestId) {
+      this.setActiveSession(session.internalId);
+      this.absorbIntoEmptyActiveTab(session, previousActiveId);
+      this.notify();
+    }
     return session;
   }
 
@@ -2939,6 +2952,27 @@ export class AgentSessionManager {
    * fresh session.
    */
   private async tryResumeSessionFromHistory(
+    backendId: BackendId,
+    sessionId: SessionId,
+    projectId: ProjectScopeId
+  ): Promise<AgentSession | null> {
+    const existing = this.findLiveSession(backendId, sessionId);
+    if (existing) return existing;
+
+    const key = buildNativeChatId(backendId, sessionId);
+    const inFlight = this.resumedSessionPromiseById.get(key);
+    if (inFlight) return inFlight;
+
+    const resume = this.resumeSessionFromHistory(backendId, sessionId, projectId).finally(() => {
+      if (this.resumedSessionPromiseById.get(key) === resume) {
+        this.resumedSessionPromiseById.delete(key);
+      }
+    });
+    this.resumedSessionPromiseById.set(key, resume);
+    return resume;
+  }
+
+  private async resumeSessionFromHistory(
     backendId: BackendId,
     sessionId: SessionId,
     projectId: ProjectScopeId
@@ -3080,6 +3114,7 @@ export class AgentSessionManager {
         );
       }
     }
+    await replayPersistedMode(session, this.getDefaultMode(backendId));
     if (this.disposed) {
       await session.dispose();
       this.finishPendingCreate();
@@ -3091,9 +3126,6 @@ export class AgentSessionManager {
     this.sessions.set(session.internalId, session);
     this.chatUIStates.set(session.internalId, new AgentChatUIState(session));
     this.detachedFromTabIds.delete(session.internalId);
-    this.activeSessionId = session.internalId;
-    this.activeProjectId = projectId;
-    this.lastActiveByScope.set(projectId, session.internalId);
     this.attachAutoSave(session);
     this.attachAttentionTracking(session);
     this.lastError = null;

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -342,11 +342,12 @@ export interface BackendDescriptor {
   ): ModeMapping | null;
 
   /**
-   * Optional: replay persisted state on a freshly created session. Runs
-   * once after `createSession` resolves. `seededSelection` is the exact
-   * (model, effort) the session was created with — a transient cross-backend
-   * pick carries the user's drafted effort here, which must win over the
-   * backend's persisted default so the pick isn't overwritten on startup.
+   * Optional: replay persisted state before a newly created or resumed session
+   * becomes ready for user input. `seededSelection` is the exact (model, effort)
+   * used for a fresh session; it is absent on resume because the existing
+   * backend session supplies its model. A transient cross-backend pick carries
+   * the user's drafted effort here, which must win over the backend's persisted
+   * default so the pick isn't overwritten on startup.
    */
   applyInitialSessionConfig?(
     session: AgentSession,

--- a/src/agentMode/session/replayPersistedMode.ts
+++ b/src/agentMode/session/replayPersistedMode.ts
@@ -4,8 +4,8 @@ import { MethodUnsupportedError } from "./errors";
 import type { CopilotMode } from "./types";
 
 /**
- * Re-apply the user's sticky permission-mode preference to a freshly created
- * session, so a new conversation reopens in the mode they last chose (e.g.
+ * Re-apply the user's sticky permission-mode preference to a newly created or
+ * resumed session, so a conversation opens in the mode they last chose (e.g.
  * `auto`) instead of always resetting to the agent's natural starting mode.
  *
  * Backend-agnostic: it dispatches through the canonical `mode.apply` spec the


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#130

## Why

When Agent Home reopens a saved Claude chat, the resumed backend reports its fallback effort (`low`) and the history path makes that session active without replaying the user's saved default effort. Fresh chats already replay the same initial configuration, so a user who selected `high` sees different behavior depending on whether a chat is new or resumed.

## What

> **Before:** Reopening a saved Claude chat can show and use `low` even when the agent's default effort is `high`.
>
> **After:** The resumed chat applies the backend's initial configuration before it becomes active, so it opens with `high` and cannot accept a prompt while that write is pending.

If initial configuration fails, the chat still opens with the backend-reported state, matching fresh-chat fallback behavior.

## Non goal

- Persisting and restoring each chat's own model and effort selection; that remains the broader work in logancyang/obsidian-copilot-preview#130.
- Changing fresh-chat or fan-out initialization.
- Addressing OpenCode's delayed effort-option startup tracked in logancyang/obsidian-copilot-preview#252.

## Screenshot

Not applicable — this changes resumed-session initialization; Agent Home layout and copy are unchanged.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | The resumed-session regression test covers the `low` to `high` transition and send gating |
| A defect would fail CI or be obvious on first use | ✅ | The manager test fails if the resumed session returns before initial configuration settles |
| A revert fully restores prior state, including persisted data | ✅ | The change performs no migration or irreversible write |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Session model configuration is the only affected surface |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Only internal resume sequencing changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Resumed session creation now awaits backend initialization and handles shutdown during that await |
| No hot-path behavior lacks deterministic coverage | ✅ | History-resume application and delayed completion are covered deterministically |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any regression appears immediately when a saved Agent chat is reopened |

Review: inspect `AgentSessionManager.tryResumeSessionFromHistory` in `src/agentMode/session/AgentSessionManager.ts` and the `loadNativeSessionFromHistory()` tests in `src/agentMode/session/AgentSessionManager.test.ts` line by line, then run Verification steps 2–4.

## Verification

1. Load the branch in the documented test vault and enable Claude.
2. Set Claude's default model to Sonnet and default effort to `high`, create a chat, then return it to Recent Chats.
3. Reload the plugin, reopen that saved chat, and confirm the picker shows `high` before the composer becomes sendable.
4. Repeat with a Claude model that does not expose effort, then reload while reopening the chat; confirm Agent Home does not hang or retain an orphaned resumed session.
