### PR TITLE
Keep declared context sources listed when a property expands past the cap

### DIFF
--- a/src/context/manifestBuilder.test.ts
+++ b/src/context/manifestBuilder.test.ts
@@ -137,4 +137,60 @@ describe("buildProjectContextBlock", () => {
     expect(md).toContain("Included properties");
     expect(md).toContain("[Topics:Physics]");
   });
+
+  it("keeps every hand-declared source when property-expanded notes overflow the cap", () => {
+    // A single `[Subject:]` inclusion enumerates every note carrying the key, which
+    // is enough to exhaust the cap on its own. The sections that follow notes in
+    // reading order must survive it — a dropped URL row loses its snapshot pointer,
+    // and that absolute cache path appears nowhere else.
+    const manyNotes = Array.from({ length: MAX_MANIFEST_ENTRIES + 20 }, (_, i) => abs(`n${i}.md`));
+    const materialized: MaterializedEntry[] = [
+      {
+        type: "web",
+        source: "https://a.com",
+        cacheFileName: "web-1.md",
+        snapshotAbsPath: "/cache/remotes/web-1.md",
+      },
+    ];
+    const md = buildProjectContextBlock(
+      sources({
+        notes: manyNotes,
+        properties: ["[Subject:]"],
+        folders: [abs("Papers", "/vault/Papers")],
+        extensions: ["*.pdf"],
+        tags: ["#physics"],
+        webUrls: ["https://a.com"],
+        youtubeUrls: ["https://youtu.be/abc"],
+        materialized,
+      })
+    );
+
+    expect(md).toContain("[Subject:]");
+    expect(md).toContain("`/vault/Papers`");
+    expect(md).toContain("`*.pdf`");
+    expect(md).toContain("#physics");
+    expect(md).toContain("https://a.com → `/cache/remotes/web-1.md`");
+    expect(md).toContain("https://youtu.be/abc");
+  });
+
+  it("spends the leftover budget on notes and counts the trimmed ones as omitted", () => {
+    // 5 hand-declared sources + 120 expanded notes = 125 total, so notes get the
+    // remaining 95 slots and the 25 they lose are what the truncation note reports.
+    const manyNotes = Array.from({ length: 120 }, (_, i) => abs(`n${i}.md`));
+    const md = buildProjectContextBlock(
+      sources({
+        notes: manyNotes,
+        properties: ["[Subject:]"],
+        folders: [abs("Papers", "/vault/Papers")],
+        extensions: ["*.pdf"],
+        tags: ["#physics"],
+        webUrls: ["https://a.com"],
+      })
+    );
+
+    const listedNotes = manyNotes.filter((note) => md.includes(`\`${note.vaultPath}\``));
+    expect(listedNotes).toHaveLength(MAX_MANIFEST_ENTRIES - 5);
+    expect(md).toContain(`Only the first ${MAX_MANIFEST_ENTRIES} of 125 sources`);
+    expect(md).toContain("25 more are omitted");
+  });
 });

--- a/src/context/manifestBuilder.test.ts
+++ b/src/context/manifestBuilder.test.ts
@@ -17,6 +17,7 @@ function sources(over: Partial<ManifestSources> = {}): ManifestSources {
     extensions: [],
     tags: [],
     properties: [],
+    propertyNotes: [],
     webUrls: [],
     youtubeUrls: [],
     materialized: [],
@@ -129,21 +130,19 @@ describe("buildProjectContextBlock", () => {
     expect(md).toContain("[Topics:Physics]");
   });
 
-  it("keeps the property label visible when matched notes overflow the entry cap", () => {
-    const manyNotes = Array.from({ length: MAX_MANIFEST_ENTRIES + 5 }, (_, i) => abs(`n${i}.md`));
+  it("lists property-matched notes under their own heading", () => {
     const md = buildProjectContextBlock(
-      sources({ notes: manyNotes, properties: ["[Topics:Physics]"] })
+      sources({ properties: ["[Topics:Physics]"], propertyNotes: [abs("p.md", "/vault/p.md")] })
     );
-    expect(md).toContain("Included properties");
-    expect(md).toContain("[Topics:Physics]");
+    expect(md).toContain("## Notes matching an included property");
+    expect(md).toContain("`/vault/p.md`");
   });
 
-  it("keeps every hand-declared source when property-expanded notes overflow the cap", () => {
-    // A single `[Subject:]` inclusion enumerates every note carrying the key, which
-    // is enough to exhaust the cap on its own. The sections that follow notes in
-    // reading order must survive it — a dropped URL row loses its snapshot pointer,
-    // and that absolute cache path appears nowhere else.
-    const manyNotes = Array.from({ length: MAX_MANIFEST_ENTRIES + 20 }, (_, i) => abs(`n${i}.md`));
+  it("keeps every declared source when property-matched notes overflow the entry cap", () => {
+    // One `[Subject:]` enumerates every note carrying the key, which alone exhausts
+    // the cap. No declared source may be pushed out by that expansion — a dropped URL
+    // row loses its snapshot pointer, and that cache path appears nowhere else.
+    const many = Array.from({ length: MAX_MANIFEST_ENTRIES + 20 }, (_, i) => abs(`n${i}.md`));
     const materialized: MaterializedEntry[] = [
       {
         type: "web",
@@ -154,9 +153,10 @@ describe("buildProjectContextBlock", () => {
     ];
     const md = buildProjectContextBlock(
       sources({
-        notes: manyNotes,
+        propertyNotes: many,
         properties: ["[Subject:]"],
         folders: [abs("Papers", "/vault/Papers")],
+        notes: [abs("Spec.md", "/vault/Spec.md")],
         extensions: ["*.pdf"],
         tags: ["#physics"],
         webUrls: ["https://a.com"],
@@ -167,19 +167,48 @@ describe("buildProjectContextBlock", () => {
 
     expect(md).toContain("[Subject:]");
     expect(md).toContain("`/vault/Papers`");
+    expect(md).toContain("`/vault/Spec.md`");
     expect(md).toContain("`*.pdf`");
     expect(md).toContain("#physics");
     expect(md).toContain("https://a.com → `/cache/remotes/web-1.md`");
     expect(md).toContain("https://youtu.be/abc");
   });
 
-  it("spends the leftover budget on notes and counts the trimmed ones as omitted", () => {
-    // 5 hand-declared sources + 120 expanded notes = 125 total, so notes get the
-    // remaining 95 slots and the 25 they lose are what the truncation note reports.
-    const manyNotes = Array.from({ length: 120 }, (_, i) => abs(`n${i}.md`));
+  it("keeps a declared note when materialized file rows overflow the entry cap", () => {
+    // A folder inclusion over a PDF-heavy folder expands to one materialized row per
+    // binary, so those rows are an expansion too and must not evict the `[[note]]`
+    // the user declared by hand — off-cwd, its absolute path here is the agent's
+    // only handle on it.
+    const materialized: MaterializedEntry[] = Array.from(
+      { length: MAX_MANIFEST_ENTRIES + 20 },
+      (_, i) => ({
+        type: "file" as const,
+        source: `Papers/p${i}.pdf`,
+        cacheFileName: `file-${i}.md`,
+        snapshotAbsPath: `/cache/files/file-${i}.md`,
+      })
+    );
     const md = buildProjectContextBlock(
       sources({
-        notes: manyNotes,
+        materialized,
+        folders: [abs("Papers", "/vault/Papers")],
+        notes: [abs("Outside/Spec.md", "/elsewhere/Outside/Spec.md")],
+        tags: ["#physics"],
+      })
+    );
+
+    expect(md).toContain("`/elsewhere/Outside/Spec.md`");
+    expect(md).toContain("#physics");
+    expect(md).toContain("`/vault/Papers`");
+  });
+
+  it("spends the leftover budget on expansions and counts the trimmed ones as omitted", () => {
+    // 5 declared sources + 120 property matches = 125 total, so the expansion gets
+    // the remaining 95 slots and the 25 it loses are what the truncation note reports.
+    const many = Array.from({ length: 120 }, (_, i) => abs(`n${i}.md`));
+    const md = buildProjectContextBlock(
+      sources({
+        propertyNotes: many,
         properties: ["[Subject:]"],
         folders: [abs("Papers", "/vault/Papers")],
         extensions: ["*.pdf"],
@@ -188,8 +217,8 @@ describe("buildProjectContextBlock", () => {
       })
     );
 
-    const listedNotes = manyNotes.filter((note) => md.includes(`\`${note.vaultPath}\``));
-    expect(listedNotes).toHaveLength(MAX_MANIFEST_ENTRIES - 5);
+    const listed = many.filter((note) => md.includes(`\`${note.vaultPath}\``));
+    expect(listed).toHaveLength(MAX_MANIFEST_ENTRIES - 5);
     expect(md).toContain(`Only the first ${MAX_MANIFEST_ENTRIES} of 125 sources`);
     expect(md).toContain("25 more are omitted");
   });

--- a/src/context/manifestBuilder.ts
+++ b/src/context/manifestBuilder.ts
@@ -26,16 +26,24 @@ export interface ManifestPathEntry {
  */
 export interface ManifestSources {
   folders: ManifestPathEntry[];
+  /** Notes the user declared one at a time as `[[title]]` inclusions. */
   notes: ManifestPathEntry[];
   extensions: string[];
   tags: string[];
   /**
    * Property inclusion patterns (e.g. `[Topics:Physics]`), listed as source
-   * labels. Property-matched notes are also enumerated under "Included notes",
-   * but a broad property can overflow the entry cap; the label ensures the agent
-   * still knows which frontmatter query produced them even when notes are cut.
+   * labels. The notes they match arrive separately in {@link propertyNotes},
+   * which a broad property can push past the entry cap; the label ensures the
+   * agent still knows which frontmatter query produced them even when cut.
    */
   properties: string[];
+  /**
+   * Notes enumerated from {@link properties}, kept apart from the declared
+   * `notes` because they are an EXPANSION — one pattern yields as many entries
+   * as the vault happens to match. See the entry-cap note in
+   * {@link buildProjectContextBlock}.
+   */
+  propertyNotes: ManifestPathEntry[];
   webUrls: string[];
   youtubeUrls: string[];
   /** Present cache files, used to resolve snapshot pointers + list file snapshots. */
@@ -79,26 +87,31 @@ export function buildProjectContextBlock(sources: ManifestSources): string {
   // pattern when the source didn't resolve to a real on-disk path.
   const pathText = (entry: ManifestPathEntry): string => `\`${entry.absPath ?? entry.vaultPath}\``;
 
-  // ORDER IS LOAD-BEARING — notes MUST stay last. Every other section grows one
-  // line per hand-added source, but notes also carry the notes a property
-  // inclusion enumerates, so one `[Subject:]` on a vault-wide key fills the cap by
-  // itself. Listing notes last means the entry-cap slice below spends the budget on
-  // the declared sources first and gives notes the remainder, instead of letting a
-  // broad property push the later sections out of the block entirely. URLs are the
-  // costly loss: a materialized snapshot's absolute cache path reaches the agent
-  // ONLY through its row here, so a dropped line takes the fetched page with it.
-  const lines: ManifestLine[] = [
+  // ORDER IS LOAD-BEARING — every DECLARED source comes before every EXPANDED one,
+  // because the entry-cap slice below simply takes the first MAX_MANIFEST_ENTRIES.
+  // A declared section grows one line per source the user added by hand, so it can
+  // only overflow deliberately. An expanded section grows with the vault: one
+  // property pattern yields a line per matching note, and one folder yields a line
+  // per PDF/image under it. Listing expansions last means neither can push a source
+  // the user actually declared out of the block. Losing one costs the agent its only
+  // handle on that source — a note or snapshot outside the session cwd is reachable
+  // ONLY through the absolute path in its row here.
+  const declared: ManifestLine[] = [
     ...sources.folders.map((e) => line("Included folders", pathText(e))),
     ...sources.properties.map((p) => line("Included properties", p)),
+    ...sources.notes.map((e) => line("Included notes", pathText(e))),
     ...sources.extensions.map((p) => line("Included file types", `\`${p}\``)),
     ...sources.tags.map((t) => line("Included tags", t)),
     ...sources.webUrls.map((u) => line("Included URLs", withPointer("web", u))),
     ...sources.youtubeUrls.map((u) => line("Included YouTube", withPointer("youtube", u))),
+  ];
+  const expanded: ManifestLine[] = [
     ...sources.materialized
       .filter((e) => e.type === "file")
       .map((e) => line("Materialized files", withPointer(e.type, e.source))),
-    ...sources.notes.map((e) => line("Included notes", pathText(e))),
+    ...sources.propertyNotes.map((e) => line("Notes matching an included property", pathText(e))),
   ];
+  const lines: ManifestLine[] = [...declared, ...expanded];
 
   const total = lines.length;
   const shown = lines.slice(0, MAX_MANIFEST_ENTRIES);
@@ -109,8 +122,8 @@ export function buildProjectContextBlock(sources: ManifestSources): string {
     "Context sources for this project, with absolute paths. Folders and tags are",
     "listed as sources, not expanded into member files — use your own search",
     "(grep/glob/read) to enumerate them. Properties are listed as source labels and",
-    'also expanded into matching notes under "Included notes" (a property pattern\'s',
-    "label is listed so it survives the entry cap; its resolved notes appear below).",
+    'also expanded into the notes they match, under "Notes matching an included',
+    'property" (the label is listed first so it survives the entry cap).',
     "Materialized snapshots of URLs, YouTube transcripts, and PDFs/images are shown",
     "inline as an absolute path after the source, formatted `<source> → <absolute path>`",
     "— read that path directly. A source with no path isn't cached (not yet converted",

--- a/src/context/manifestBuilder.ts
+++ b/src/context/manifestBuilder.ts
@@ -79,10 +79,17 @@ export function buildProjectContextBlock(sources: ManifestSources): string {
   // pattern when the source didn't resolve to a real on-disk path.
   const pathText = (entry: ManifestPathEntry): string => `\`${entry.absPath ?? entry.vaultPath}\``;
 
+  // ORDER IS LOAD-BEARING — notes MUST stay last. Every other section grows one
+  // line per hand-added source, but notes also carry the notes a property
+  // inclusion enumerates, so one `[Subject:]` on a vault-wide key fills the cap by
+  // itself. Listing notes last means the entry-cap slice below spends the budget on
+  // the declared sources first and gives notes the remainder, instead of letting a
+  // broad property push the later sections out of the block entirely. URLs are the
+  // costly loss: a materialized snapshot's absolute cache path reaches the agent
+  // ONLY through its row here, so a dropped line takes the fetched page with it.
   const lines: ManifestLine[] = [
     ...sources.folders.map((e) => line("Included folders", pathText(e))),
     ...sources.properties.map((p) => line("Included properties", p)),
-    ...sources.notes.map((e) => line("Included notes", pathText(e))),
     ...sources.extensions.map((p) => line("Included file types", `\`${p}\``)),
     ...sources.tags.map((t) => line("Included tags", t)),
     ...sources.webUrls.map((u) => line("Included URLs", withPointer("web", u))),
@@ -90,6 +97,7 @@ export function buildProjectContextBlock(sources: ManifestSources): string {
     ...sources.materialized
       .filter((e) => e.type === "file")
       .map((e) => line("Materialized files", withPointer(e.type, e.source))),
+    ...sources.notes.map((e) => line("Included notes", pathText(e))),
   ];
 
   const total = lines.length;

--- a/src/context/projectContextMaterializer.test.ts
+++ b/src/context/projectContextMaterializer.test.ts
@@ -194,9 +194,29 @@ describe("ensureProjectContextMaterialized", () => {
     const result = await ensureProjectContextMaterialized(app, "p1", CWD);
 
     expect(result.projectContextBlock).toContain("<project_context>");
-    expect(result.projectContextBlock).toContain("## Included notes");
+    // Property matches are an expansion, listed apart from the declared `[[note]]`
+    // sources so they can never push one past the entry cap.
+    expect(result.projectContextBlock).toContain("## Notes matching an included property");
     expect(result.projectContextBlock).toContain("`/vault/Notes/Relativity.md`");
     expect(result.projectContextBlock).not.toContain("Cooking");
+  });
+
+  it("lists a note reached by both a title and a property once, as a declaration", async () => {
+    getRecord.mockReturnValue(record({ inclusions: "[[Relativity]],[Topics:Physics]" }));
+    getPatterns.mockReturnValue(
+      patterns({ notePatterns: ["[[Relativity]]"], propertyPatterns: ["[Topics:Physics]"] })
+    );
+    const app = fakeApp([{ path: "Notes/Relativity.md", ext: "md" }]);
+    indexFile.mockReturnValue(true);
+
+    const result = await ensureProjectContextMaterialized(app, "p1", CWD);
+
+    const block = result.projectContextBlock ?? "";
+    expect(block.match(/\/vault\/Notes\/Relativity\.md/g)).toHaveLength(1);
+    // The declaration wins the row, so the note keeps its place among the sources
+    // that survive the entry cap rather than trailing behind the expansions.
+    expect(block).toContain("## Included notes");
+    expect(block).not.toContain("## Notes matching an included property");
   });
 
   it("still emits <project_context> for a property-only project when no note currently matches", async () => {

--- a/src/context/projectContextMaterializer.ts
+++ b/src/context/projectContextMaterializer.ts
@@ -79,6 +79,15 @@ const EMPTY_DIRECTORIES: string[] = Object.freeze([] as string[]) as string[];
 const EMPTY_MANIFEST_ENTRIES: ManifestPathEntry[] = Object.freeze(
   [] as ManifestPathEntry[]
 ) as ManifestPathEntry[];
+
+/**
+ * Identity of a resolved manifest entry for dedupe. Keyed on the absolute path
+ * when one resolved, since that is what the agent actually reads; an unresolved
+ * pattern falls back to its `vaultPath` so two of them still compare equal.
+ */
+function manifestEntryKey(entry: ManifestPathEntry): string {
+  return entry.absPath ?? entry.vaultPath;
+}
 /**
  * Frozen fallback result for the "no usable record / whole-run failure" exits —
  * NO `contextSignature`, so it never clears a caller's dirty flag (nothing was
@@ -338,20 +347,19 @@ async function runMaterialize(
       cwd,
       adapter
     );
-    // Property-matched notes join the note sources so the agent gets each note's
-    // absolute path; dedupe by resolved path so a note included via BOTH a
-    // [[title]] and a property isn't listed twice.
-    const resolvedNotes = resolveNotePaths(app, notes, adapter);
-    const propertyNotes = resolvePropertyNotePaths(app, properties, exclusions, adapter);
-    const seenNotePaths = new Set(resolvedNotes.map((entry) => entry.absPath ?? entry.vaultPath));
-    const noteEntries = [...resolvedNotes];
-    for (const entry of propertyNotes) {
-      const key = entry.absPath ?? entry.vaultPath;
-      if (!seenNotePaths.has(key)) {
-        seenNotePaths.add(key);
-        noteEntries.push(entry);
-      }
-    }
+    // Property matches stay a SEPARATE list from the declared `[[title]]` notes:
+    // the manifest lists declarations ahead of expansions so a broad property
+    // can't push a hand-added source out of the entry cap. Deduped by resolved
+    // path so a note included via BOTH a [[title]] and a property is listed once,
+    // under the declaration.
+    const noteEntries = resolveNotePaths(app, notes, adapter);
+    const declaredNotePaths = new Set(noteEntries.map(manifestEntryKey));
+    const propertyNoteEntries = resolvePropertyNotePaths(
+      app,
+      properties,
+      exclusions,
+      adapter
+    ).filter((entry) => !declaredNotePaths.has(manifestEntryKey(entry)));
 
     const files: FileSource[] = inclusions
       ? listMaterializeCandidates(app, contextSource).map((file) => ({
@@ -425,6 +433,7 @@ async function runMaterialize(
       extensions,
       tags,
       properties,
+      propertyNotes: propertyNoteEntries,
       webUrls,
       youtubeUrls,
       materialized: manifestEntries,

--- a/src/projects/projectSystemPrompt.test.ts
+++ b/src/projects/projectSystemPrompt.test.ts
@@ -47,6 +47,7 @@ describe("BUILTIN_PROJECT_SYSTEM_PROMPT", () => {
       extensions: [],
       tags: [],
       properties: [],
+      propertyNotes: [],
       webUrls: [],
       youtubeUrls: [],
       materialized: [],


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#284

## Why

The `<project_context>` block inlined into a project session's first prompt lists the project's context sources — folders, property labels, notes, file types, tags, URLs, YouTube links, materialized file pointers — and stops at 100 entries, telling the agent how many it omitted.

Two of those sections don't grow one line per source the user added — they grow with the vault. A property inclusion enumerates every note whose frontmatter matches, and a folder or extension inclusion produces one "Materialized files" row per PDF or image under it. Either can fill all 100 slots on its own: in a vault that uses a key like `Subject` broadly, the value picker's leading "Any value" option is one click away from doing it, and a research folder of 100+ PDFs does it without any property at all.

Whatever those expansions push out is a source the user declared by hand.

The rows carrying an absolute path are the expensive ones to lose. When Copilot fetches a project's web page or YouTube transcript it caches the result outside every project cwd, and a declared `[[note]]` may live outside it too; in both cases this block is the only place the agent is handed that path. Drop the row and the source is unreachable for the rest of the session. Reaching this before Property meant hand-adding 100+ individual note inclusions; now a single click does it.

## What

A project declaring `[Subject:]` alongside a folder, `*.pdf`, `#physics`, a web URL and a YouTube URL, where the property matches 120 notes:

> **Before:** the block lists the folder, the property label and 98 matched note paths, then stops. The file type, the tag and both URLs — including the web page's cached snapshot path — are absent.
>
> **After:** the folder, property label, file type, tag and both URLs are all listed, and the property's matches fill the 95 slots left over. The omitted count still reads "the first 100 of 125 sources".

The same holds with the expansion coming from the other direction: a project whose folder holds 120 PDFs keeps its declared `[[note]]` row, which previously the materialized-file rows pushed out.

| Section | Grows with | Listed |
| --- | --- | --- |
| Folders, properties, notes, file types, tags, URLs, YouTube | Sources the user adds by hand | First |
| Materialized files, notes matching a property | The vault | Last, in whatever budget remains |

Nothing else about the block changes: the same sources are eligible, the cap is still 100, and the truncation notice still reports the real total. Property-matched notes now print under their own `## Notes matching an included property` heading instead of sharing `## Included notes` with the declared ones, so the two groups stay separable.

## Non goal

- Raising or removing the 100-entry cap.
- Giving the agent a way to reach expansions trimmed past the cap — the property label is already listed for exactly that reason, and it survives.
- Changing which notes a property inclusion matches, or how the picker offers keys and values.
- The unrelated `gen-gallery-stories` suite failure on Node 20 (it imports `glob` from `node:fs/promises`, which needs Node 22).

## Screenshot

Not applicable — this changes the text of a context block sent to the agent, which has no rendered surface in the plugin UI. The before/after payloads appear under `What`.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `manifestBuilder.test.ts` covers declared-source survival under each expansion separately (property matches and materialized files) plus the leftover-budget arithmetic; `projectContextMaterializer.test.ts` covers the dedupe when a note is reached both ways |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and the 10 pre-existing cases pin the block's other output |
| A revert fully restores prior state, including persisted data | ✅ | The block is rebuilt from settings on every session start; nothing is persisted or migrated |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Reorders already-built lines; no new input is read |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `ManifestSources` gains a `propertyNotes` field, consumed only by its two in-repo callers; nothing persisted or exported to plugins |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Synchronous string building |
| No hot-path behavior lacks deterministic coverage | ✅ | Both the under-cap and over-cap paths are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the project context block; a wrong result shows in the next project session's payload |

Review: read the `declared` and `expanded` arrays in `buildProjectContextBlock` (`src/context/manifestBuilder.ts`) and confirm every vault-driven section sits in `expanded`, then the dedupe in `runMaterialize` (`src/context/projectContextMaterializer.ts`) where `propertyNoteEntries` is filtered against `declaredNotePaths`. Then run Verification step 4 and check the URL row is present.

## Verification

1. In a vault with 100+ notes sharing a frontmatter key (say `Subject`), open a project and use Manage Context → Properties → **+** to pick that key, then choose **Any value — notes that declare this key**.
2. In the same project, add a web URL and a tag, and let the URL finish materializing.
3. Start a fresh session in that project so the context block is rebuilt.
4. Inspect the outgoing `session/prompt` payload's `<project_context>` block. Expect the `## Included URLs` row with its `→ /…/web-*.md` snapshot path, the `## Included tags` row, and the `## Included properties` label all present, with `## Notes matching an included property` last and truncated. The closing line should report the honest total, e.g. `Only the first 100 of 125 sources are listed`.
5. Open one of the listed snapshot paths to confirm the agent could reach the cached page.
6. For the other expansion: point a project at a folder holding 100+ PDFs and also declare one `[[note]]`. Expect the note's row to survive, with the `## Materialized files` rows truncated instead.
