### PR TITLE
Show the Copilot model lineup to users without a license

### DIFF
--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -15,7 +15,7 @@ Copilot Plus is a subscription that enables:
 - **Web search** — Search the internet from chat
 - **YouTube transcription** — Fetch video transcripts and use them as context
 - **Memory system** — Persistent memory across conversations
-- **Copilot Plus Flash model** — A built-in model that requires no separate API key
+- **Included models** — A set of chat models that need no API key of your own, from fast everyday ones to top-tier reasoners ([the full list](#models-included-with-your-license))
 - **URL processing** — Fetch and summarize web pages as context
 - **Copilot Plus embedding models** — High-quality embeddings, selected under semantic search rather than by activating a license
 
@@ -46,16 +46,47 @@ or upgrade.
 
 ---
 
-## Copilot Plus Flash Model
+## Models included with your license
 
-**Copilot Plus Flash** is a built-in AI model included with your Copilot Plus subscription:
+Your license comes with a set of models Copilot runs for you. None of them need
+an API key of your own.
 
-- No separate API key needed
-- Works out of the box once your license key is active
-- Supports vision (image inputs)
-- Good for general-purpose tasks
+Three are switched on the moment your license activates, chosen to cover the
+range: the fastest one, the strongest reasoner, and a frontier open model.
 
-It appears as `copilot-plus-flash` in the model selector.
+| Model                  | What it's for                                                        |
+| ---------------------- | -------------------------------------------------------------------- |
+| **Copilot Plus Flash** | The default. Fastest responses and the most quota. Accepts images.   |
+| **DeepSeek V4 Pro**    | The hardest reasoning and agentic tasks.                             |
+| **GLM-5.2**            | A long-horizon frontier open model that rivals the best closed ones. |
+
+The rest are included too, switched off until you want them:
+
+| Model                      | What it's for                                                    |
+| -------------------------- | ---------------------------------------------------------------- |
+| **DeepSeek V4 Flash 0731** | The newest DeepSeek V4 Flash snapshot: fast, cheap, and capable. |
+| **Kimi K2.7 Code**         | Coding tasks. Accepts images.                                    |
+| **Kimi K2.6**              | Long-running reasoning tasks.                                    |
+| **MiMo V2.5**              | Cost-effective and capable for everyday use.                     |
+| **MiniMax M2.7**           | Lightweight tasks, compact and efficient.                        |
+
+Turn any of them on under **Settings → Basic → Agents**, in the list for the
+place you want it: **Quick Chat** for the chat model picker, or an agent's own
+list for Agent Mode.
+
+### Where they show up
+
+In **Quick Chat**, they appear in the model picker alongside any models you
+added yourself.
+
+In **Agent Mode**, the picker groups models by agent, and these appear inside
+each agent that can run them — **OpenCode** today. **Claude Code** and **Codex**
+bring their own models from their own subscriptions, so your Copilot models do
+not appear under those two.
+
+**Copilot Plus Flash** becomes the default for chat and for every agent that can
+run it if you accept the offer in the welcome dialog when your license
+activates — see [Setting Up Copilot Plus](#setting-up-copilot-plus) above.
 
 ---
 
@@ -119,7 +150,7 @@ Self-Host Mode lets you replace Copilot's cloud services with your own infrastru
 2. Under **Self-Host Mode**, toggle **Enable Self-Host Mode**
 3. Copilot checks your plan. The toggle stays locked if your plan doesn't include Self-Host Mode.
 4. Toggle **Enable Miyo** to use the Miyo desktop app for local search, PDF parsing, and context.
-5. *(Optional)* Set **Custom Miyo Server URL** only if Miyo is running on a remote machine. Leave blank to use automatic local service discovery.
+5. _(Optional)_ Set **Custom Miyo Server URL** only if Miyo is running on a remote machine. Leave blank to use automatic local service discovery.
 
 **Working offline**: Self-Host Mode keeps working without an internet connection for a while after your last online check, and renews itself automatically whenever you're online. How long that offline period lasts currently varies, so reconnect when you can rather than relying on a fixed window.
 

--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -88,6 +88,14 @@ not appear under those two.
 run it if you accept the offer in the welcome dialog when your license
 activates — see [Setting Up Copilot Plus](#setting-up-copilot-plus) above.
 
+### Before you have a license
+
+The three models a license switches on still appear in both pickers, greyed out
+and marked with a lock. Hovering the lock reads "Copilot license required".
+They are there so you can see what a license adds; they cannot be selected, and
+they leave your own models exactly where they were. Activate a license and the
+locks come off the same rows.
+
 ---
 
 ## Memory System

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@ Welcome to the official documentation for **Copilot for Obsidian**, an AI-powere
 | [Getting Started](getting-started.md)                       | Installation, first-time setup, opening the chat panel, keyboard shortcuts      |
 | [Chat Interface](chat-interface.md)                         | Chat modes, sending messages, history, settings, auto-compact                   |
 | [LLM Providers](llm-providers.md)                           | All 16+ supported providers and how to set them up                              |
-| [Models and Parameters](models-and-parameters.md)           | Chat models, embedding models, temperature, max tokens, and other parameters    |
+| [Models](models-and-parameters.md)                          | Which chat models ship with Copilot, adding your own, and the default model     |
 | [Context and Mentions](context-and-mentions.md)             | Active note context, @-mentions, URLs, tags, and the web viewer                 |
 | [Custom Commands](custom-commands.md)                       | Creating and using preset prompts, template variables, Quick Command, Quick Ask |
 | [Vault Search and Indexing](vault-search-and-indexing.md)   | Lexical search, semantic search, index management, exclusions                   |

--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -188,5 +188,5 @@ For any API that follows the OpenAI API format. Useful for custom deployments, p
 
 ## Related
 
-- [Models and Parameters](models-and-parameters.md) — Enable, disable, and configure models
+- [Models](models-and-parameters.md) — Enable, disable, and configure models
 - [Getting Started](getting-started.md) — First-time setup

--- a/docs/models-and-parameters.md
+++ b/docs/models-and-parameters.md
@@ -1,6 +1,7 @@
-# Models and Parameters
+# Models
 
-This guide explains how to manage chat models, embedding models, and the parameters that control how the AI behaves.
+This guide explains which chat models Copilot ships with, how to add your own,
+and how to choose the one new chats start on.
 
 ---
 
@@ -53,102 +54,6 @@ You can automatically import the full list of available models from a provider:
 2. Add or edit a provider
 3. Copilot will fetch the provider's model list so you can select models to configure
 
----
-
-## Embedding Models
-
-Embedding models convert text into numerical vectors, which powers semantic (meaning-based) search in Vault QA and the "Relevant Notes" feature.
-
-### Built-In Embedding Models
-
-| Model                         | Provider                     |
-| ----------------------------- | ---------------------------- |
-| copilot-plus-small            | Copilot (Plus exclusive)     |
-| copilot-plus-large            | Copilot (Believer exclusive) |
-| copilot-plus-multilingual     | Copilot (Plus exclusive)     |
-| openai/text-embedding-3-small | OpenRouter                   |
-| text-embedding-3-small        | OpenAI                       |
-| text-embedding-3-large        | OpenAI                       |
-| embed-multilingual-light-v3.0 | Cohere                       |
-| text-embedding-004            | Google                       |
-| gemini-embedding-001          | Google                       |
-| Qwen3-Embedding-0.6B          | SiliconFlow                  |
-
-### Selecting an Embedding Model
-
-Go to **Settings → Copilot → QA** → **Embedding Model**.
-
-If you change embedding models, you must rebuild the vault index because the old vectors are incompatible with the new model. Copilot will prompt you to confirm before rebuilding.
-
-### What Embeddings Affect
-
-- **Vault QA mode** — Uses embeddings to find relevant notes by meaning
-- **Semantic Search** — The "Enable Semantic Search" toggle in QA settings
-- **Relevant Notes** — Shows semantically similar notes in its own pane (command palette: **Open Relevant Notes**)
-
----
-
-## Model Parameters
-
-These settings control how the AI responds. Global defaults live in Settings → Copilot → Model. You can override them per-session using the gear icon in the chat panel.
-
-### Temperature
-
-Controls how random or creative the responses are.
-
-- **Range**: 0.0–1.0
-- **Default**: 0.1
-- **Low (0.0–0.2)**: Precise, factual, deterministic
-- **Medium (0.4–0.6)**: Balanced
-- **High (0.8–1.0)**: Creative, varied, less predictable
-
-### Max Tokens
-
-Maximum number of tokens in the AI's response. A **token** is roughly ¾ of a word (so 1,000 tokens ≈ 750 words).
-
-- **Default**: 6,000
-- Higher values allow longer responses but cost more
-
-### Conversation Turns in Context
-
-How many past conversation turns to include in each request. More turns = more context but larger requests.
-
-- **Default**: 15 turns
-- Reduce this if you hit context limits or want to lower costs
-
-### Auto-Compact Threshold
-
-When the conversation reaches this many tokens, older messages are automatically summarized.
-
-- **Default**: 128,000 tokens
-- **Range**: 64,000–1,000,000 tokens
-- See [Chat Interface](chat-interface.md#auto-compact) for details
-
-### Reasoning Effort
-
-For reasoning-capable models (like deepseek-reasoner, claude-opus-4-6), controls how much internal reasoning the model does before responding.
-
-- **Options**: minimal, low, medium, high, xhigh
-- **Default**: low
-- Higher effort = better results on complex tasks, slower responses
-
-### Verbosity
-
-For models that support it, controls response length and detail.
-
-- **Options**: low, medium, high
-- **Default**: medium
-
-### Top P
-
-An alternative to temperature for controlling randomness. Leave at default unless you have a specific reason to change it.
-
-### Frequency Penalty
-
-Reduces the likelihood of the model repeating itself.
-
----
-
 ## Default Model Selection
 
 Your **default model** is the one Copilot uses when you open a new chat. Set it in:
@@ -161,4 +66,4 @@ The dropdown contains models enabled under **Quick Chat models**, in that same p
 ## Related
 
 - [LLM Providers](llm-providers.md) — Set up API keys for your provider
-- [Vault Search and Indexing](vault-search-and-indexing.md) — How embedding models are used
+- [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) — The models included with a license

--- a/docs/models-and-parameters.md
+++ b/docs/models-and-parameters.md
@@ -8,41 +8,17 @@ This guide explains how to manage chat models, embedding models, and the paramet
 
 ### Built-In Models
 
-Copilot comes with a set of built-in models across many providers. Some are always included ("core" models); others can be enabled or disabled.
+Copilot ships with a starter set of models for every provider it supports, so a
+provider's models are ready to enable the moment you add its API key. Which
+models those are changes with each release as providers ship new ones, so the
+live list lives in the app rather than here: **Settings → Copilot → Models
+(BYOK)** shows what is available for each provider you have added, and **Import
+models from provider** fetches anything newer than the shipped set.
 
-| Model                         | Provider   | Capabilities      |
-| ----------------------------- | ---------- | ----------------- |
-| copilot-plus-flash            | Copilot    | Vision, Reasoning |
-| deepseek-v4-pro               | Copilot    | Reasoning         |
-| glm-5.2                       | Copilot    | Reasoning         |
-| deepseek-v4-flash-0731        | Copilot    | Reasoning         |
-| kimi-k2.7-code                | Copilot    | Vision, Reasoning |
-| kimi-k2.6                     | Copilot    | —                 |
-| mimo-v2.5                     | Copilot    | Reasoning         |
-| minimax-m2.7                  | Copilot    | Reasoning         |
-| google/gemini-2.5-flash       | OpenRouter | Vision            |
-| google/gemini-2.5-pro         | OpenRouter | Vision            |
-| google/gemini-3.5-flash       | OpenRouter | Vision, Reasoning |
-| google/gemini-3.1-pro-preview | OpenRouter | Vision, Reasoning |
-| openai/gpt-5.4                | OpenRouter | Vision            |
-| openai/gpt-5-mini             | OpenRouter | Vision            |
-| gpt-5.4                       | OpenAI     | Vision            |
-| gpt-5-mini                    | OpenAI     | Vision            |
-| gpt-4.1                       | OpenAI     | Vision            |
-| gpt-4.1-mini                  | OpenAI     | Vision            |
-| claude-opus-4-6               | Anthropic  | Vision, Reasoning |
-| claude-sonnet-4-5-20250929    | Anthropic  | Vision, Reasoning |
-| gemini-2.5-pro                | Google     | Vision            |
-| gemini-2.5-flash              | Google     | Vision            |
-| gemini-3.5-flash              | Google     | Vision, Reasoning |
-| grok-4-1-fast                 | XAI        | Vision            |
-| deepseek-chat                 | DeepSeek   | —                 |
-| deepseek-reasoner             | DeepSeek   | Reasoning         |
-
-Models whose provider is **Copilot** run on your license and need no API key of
-your own — three are on by default and the rest are yours to switch on. See
+Providers covered out of the box: OpenAI, Anthropic, Google, xAI, DeepSeek,
+OpenRouter, and SiliconFlow — each needs your own API key. The Copilot models
+need no key of your own; see
 [Models included with your license](copilot-plus-and-self-host.md#models-included-with-your-license).
-Every other provider needs your own key, added on the **Models (BYOK)** tab.
 
 ### Model Capability Badges
 

--- a/docs/models-and-parameters.md
+++ b/docs/models-and-parameters.md
@@ -10,27 +10,39 @@ This guide explains how to manage chat models, embedding models, and the paramet
 
 Copilot comes with a set of built-in models across many providers. Some are always included ("core" models); others can be enabled or disabled.
 
-| Model                         | Provider   | Capabilities            |
-| ----------------------------- | ---------- | ----------------------- |
-| copilot-plus-flash            | Copilot    | Vision (Plus exclusive) |
-| google/gemini-2.5-flash       | OpenRouter | Vision                  |
-| google/gemini-2.5-pro         | OpenRouter | Vision                  |
-| google/gemini-3.5-flash       | OpenRouter | Vision, Reasoning       |
-| google/gemini-3.1-pro-preview | OpenRouter | Vision, Reasoning       |
-| openai/gpt-5.4                | OpenRouter | Vision                  |
-| openai/gpt-5-mini             | OpenRouter | Vision                  |
-| gpt-5.4                       | OpenAI     | Vision                  |
-| gpt-5-mini                    | OpenAI     | Vision                  |
-| gpt-4.1                       | OpenAI     | Vision                  |
-| gpt-4.1-mini                  | OpenAI     | Vision                  |
-| claude-opus-4-6               | Anthropic  | Vision, Reasoning       |
-| claude-sonnet-4-5-20250929    | Anthropic  | Vision, Reasoning       |
-| gemini-2.5-pro                | Google     | Vision                  |
-| gemini-2.5-flash              | Google     | Vision                  |
-| gemini-3.5-flash              | Google     | Vision, Reasoning       |
-| grok-4-1-fast                 | XAI        | Vision                  |
-| deepseek-chat                 | DeepSeek   | —                       |
-| deepseek-reasoner             | DeepSeek   | Reasoning               |
+| Model                         | Provider   | Capabilities      |
+| ----------------------------- | ---------- | ----------------- |
+| copilot-plus-flash            | Copilot    | Vision, Reasoning |
+| deepseek-v4-pro               | Copilot    | Reasoning         |
+| glm-5.2                       | Copilot    | Reasoning         |
+| deepseek-v4-flash-0731        | Copilot    | Reasoning         |
+| kimi-k2.7-code                | Copilot    | Vision, Reasoning |
+| kimi-k2.6                     | Copilot    | —                 |
+| mimo-v2.5                     | Copilot    | Reasoning         |
+| minimax-m2.7                  | Copilot    | Reasoning         |
+| google/gemini-2.5-flash       | OpenRouter | Vision            |
+| google/gemini-2.5-pro         | OpenRouter | Vision            |
+| google/gemini-3.5-flash       | OpenRouter | Vision, Reasoning |
+| google/gemini-3.1-pro-preview | OpenRouter | Vision, Reasoning |
+| openai/gpt-5.4                | OpenRouter | Vision            |
+| openai/gpt-5-mini             | OpenRouter | Vision            |
+| gpt-5.4                       | OpenAI     | Vision            |
+| gpt-5-mini                    | OpenAI     | Vision            |
+| gpt-4.1                       | OpenAI     | Vision            |
+| gpt-4.1-mini                  | OpenAI     | Vision            |
+| claude-opus-4-6               | Anthropic  | Vision, Reasoning |
+| claude-sonnet-4-5-20250929    | Anthropic  | Vision, Reasoning |
+| gemini-2.5-pro                | Google     | Vision            |
+| gemini-2.5-flash              | Google     | Vision            |
+| gemini-3.5-flash              | Google     | Vision, Reasoning |
+| grok-4-1-fast                 | XAI        | Vision            |
+| deepseek-chat                 | DeepSeek   | —                 |
+| deepseek-reasoner             | DeepSeek   | Reasoning         |
+
+Models whose provider is **Copilot** run on your license and need no API key of
+your own — three are on by default and the rest are yours to switch on. See
+[Models included with your license](copilot-plus-and-self-host.md#models-included-with-your-license).
+Every other provider needs your own key, added on the **Models (BYOK)** tab.
 
 ### Model Capability Badges
 

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -177,5 +177,4 @@ On mobile, you can still use Vault QA with lexical search, but semantic search w
 ## Related
 
 - [Agent Mode and Tools](agent-mode-and-tools.md) — How @vault uses the index in Plus mode
-- [Models and Parameters](models-and-parameters.md) — Choosing an embedding model
 - [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) — Miyo-powered local semantic search

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -218,6 +218,7 @@ export const ClaudeBackendDescriptor: ClaudeDescriptor = {
   Icon: ClaudeLogo,
   // Cloud agent — flagged with a cloud-egress warning while Self-Host Mode is on.
   selfHostable: false,
+  routesCopilotModels: false,
   setupDescription:
     "Anthropic models, billed to your Claude Code subscription. Runs the claude CLI already on your machine.",
   skillsProjectDir: ".claude/skills",

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -104,6 +104,7 @@ export const CodexBackendDescriptor: BackendDescriptor = {
   Icon: CodexLogo,
   // Cloud agent — flagged with a cloud-egress warning while Self-Host Mode is on.
   selfHostable: false,
+  routesCopilotModels: false,
   setupDescription:
     "OpenAI models, billed to your ChatGPT subscription. Runs the codex-acp adapter on your machine.",
   skillsProjectDir: ".agents/skills",

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -125,6 +125,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
   // opencode routes through user-controlled / self-hosted endpoints, so it
   // stays available in Self-Host Mode.
   selfHostable: true,
+  routesCopilotModels: true,
   setupDescription:
     "Copilot Plus models, or any model on your own provider key. Copilot can download and manage the binary for you.",
   skillsProjectDir: ".opencode/skills",

--- a/src/agentMode/session/descriptor.ts
+++ b/src/agentMode/session/descriptor.ts
@@ -106,6 +106,19 @@ export interface BackendDescriptor {
   readonly selfHostable: boolean;
 
   /**
+   * Whether this backend can run the Copilot-hosted models. `true` for backends
+   * that route Copilot's provider (opencode); `false` for agents that bring
+   * their own models from their own subscription (Claude Code, Codex).
+   *
+   * Read when no license is active, to decide whose section previews the locked
+   * Copilot lineup — which is why it cannot be derived from the configured
+   * models: without a license there is no Copilot provider to inspect.
+   *
+   * Required (not optional) so a new backend must make an explicit decision.
+   */
+  readonly routesCopilotModels: boolean;
+
+  /**
    * One-paragraph pitch shown beside this backend in the agent select view:
    * which models the user gets from it, and whose plan pays for them. That
    * trade-off is the only thing separating the agents from a user's point of

--- a/src/agentMode/ui/ModelEnableList.stories.tsx
+++ b/src/agentMode/ui/ModelEnableList.stories.tsx
@@ -81,3 +81,55 @@ export const ShortCatalog: StoryObj<ModelEnableListProps> = {
 export const Empty: StoryObj<ModelEnableListProps> = {
   render: () => <Controlled groups={[]} />,
 };
+
+/**
+ * No license: the Copilot group is synthesized rather than absent, in the same
+ * highlighted first position a licensed user's group occupies. Every row carries
+ * a lock and a disabled toggle — the group is an advertisement, not a control.
+ */
+export const LockedCopilotCatalog: StoryObj<ModelEnableListProps> = {
+  args: {
+    groups: [
+      {
+        key: "locked:copilot-plus",
+        label: "Copilot",
+        badge: "privacy",
+        tooltip: "Copilot license required",
+        highlight: true,
+        rows: [
+          {
+            id: "__locked_copilot__copilot-plus-flash",
+            label: "Copilot Plus Flash",
+            description: "The default model: fastest responses and the most quota.",
+            enabled: false,
+            locked: true,
+          },
+          {
+            id: "__locked_copilot__deepseek-v4-pro",
+            label: "DeepSeek V4 Pro",
+            description: "A top-tier model for the hardest reasoning and agentic tasks.",
+            enabled: false,
+            locked: true,
+          },
+          {
+            id: "__locked_copilot__glm-5.2",
+            label: "GLM-5.2",
+            description:
+              "A long-horizon frontier open model that beats some of the best closed models.",
+            enabled: false,
+            locked: true,
+          },
+        ],
+      },
+      {
+        key: "byok:openrouter",
+        label: "OpenRouter",
+        badge: "BYOK",
+        rows: [
+          { id: "or-1", label: "google/gemini-3.5-flash", enabled: true },
+          { id: "or-2", label: "qwen3-30b-a3b-thinking-2507", enabled: false },
+        ],
+      },
+    ],
+  },
+};

--- a/src/agentMode/ui/ModelEnableList.tsx
+++ b/src/agentMode/ui/ModelEnableList.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { FreeModelWarningIcon } from "@/components/ui/FreeModelWarningIcon";
+import { LicenseRequiredIcon } from "@/components/ui/LicenseRequiredIcon";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { ModelCapabilityIcons, hasCapabilityIcons } from "@/components/ui/model-display";
 import { SearchBar } from "@/components/ui/SearchBar";
@@ -31,6 +32,12 @@ export interface ModelEnableRow {
    * (Ollama, LM Studio) are excluded.
    */
   isFree?: boolean;
+  /**
+   * `true` for a Copilot model the user has no license to run, listed so the
+   * lineup is discoverable before they buy. Renders a lock icon beside the label
+   * and a disabled toggle — the row is an advertisement, not a control.
+   */
+  locked?: boolean;
 }
 
 /** A provider-display-name-grouped section of model rows. */
@@ -128,6 +135,7 @@ export const ModelEnableList: React.FC<ModelEnableListProps> = ({
           <div className="tw-min-w-0">
             <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1">
               <span className="tw-truncate">{row.label}</span>
+              {row.locked && <LicenseRequiredIcon />}
               {row.isFree && <FreeModelWarningIcon />}
               {hasCapabilityIcons(row.capabilities) && (
                 <span className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
@@ -139,7 +147,11 @@ export const ModelEnableList: React.FC<ModelEnableListProps> = ({
               <div className="tw-truncate tw-text-xs tw-text-muted">{row.description}</div>
             )}
           </div>
-          <SettingSwitch checked={row.enabled} onCheckedChange={(next) => onToggle(row.id, next)} />
+          <SettingSwitch
+            checked={row.enabled}
+            disabled={row.locked}
+            onCheckedChange={(next) => onToggle(row.id, next)}
+          />
         </div>
       ))}
     </div>

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -185,7 +185,7 @@ function makeManager(opts: {
   } as unknown as AgentSessionManager;
 }
 
-const emptySettings = {} as CopilotSettings;
+const emptySettings = { providers: {} } as unknown as CopilotSettings;
 
 function claudeWithInstallState(installState: InstallState): BackendDescriptor {
   return {
@@ -232,7 +232,6 @@ describe("buildPickerEntries", () => {
 
     const { entries } = buildPickerEntries(manager, [descriptor], {} as ModelActiveContext, {
       ...emptySettings,
-      isPaidUser: false,
     });
 
     const locked = entries.filter((model) => model._needsLicense);
@@ -258,13 +257,12 @@ describe("buildPickerEntries", () => {
 
     const { entries } = buildPickerEntries(manager, [claude], {} as ModelActiveContext, {
       ...emptySettings,
-      isPaidUser: false,
     });
 
     expect(entries.some((entry) => entry._needsLicense)).toBe(false);
   });
 
-  it("previews nothing once a license is active, since the real models are there", () => {
+  it("previews nothing once the Copilot provider is registered, since the real models are there", () => {
     const entry = makeModelEntry("catalog-model");
     const descriptor = {
       ...makeDescriptor("opencode"),
@@ -281,7 +279,15 @@ describe("buildPickerEntries", () => {
 
     const { entries } = buildPickerEntries(manager, [descriptor], {} as ModelActiveContext, {
       ...emptySettings,
-      isPaidUser: true,
+      providers: {
+        "plus-1": {
+          providerId: "plus-1",
+          providerType: "openai-compatible",
+          displayName: "Copilot",
+          origin: { kind: "copilot-plus" },
+          addedAt: 0,
+        },
+      },
     });
 
     expect(entries.map((model) => model.name)).toEqual(["catalog-model"]);
@@ -303,7 +309,6 @@ describe("buildPickerEntries", () => {
 
     const { entries } = buildPickerEntries(manager, [descriptor], {} as ModelActiveContext, {
       ...emptySettings,
-      isPaidUser: false,
     });
 
     expect(entries.some((entry) => entry._disabledReason === "Loading…")).toBe(true);

--- a/src/agentMode/ui/agentModelPickerHelpers.test.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.test.ts
@@ -215,6 +215,100 @@ function managerWithSonnet(): AgentSessionManager {
 // ---- buildPickerEntries ----
 
 describe("buildPickerEntries", () => {
+  it("previews the locked Copilot lineup above a routing agent's own models when unlicensed", () => {
+    const entry = makeModelEntry("catalog-model");
+    const descriptor = {
+      ...makeDescriptor("opencode"),
+      routesCopilotModels: true,
+      getEnabledModelEntries: () => [
+        { baseModelId: entry.baseModelId, name: entry.name, credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = {
+      getCachedModelCatalog: () => ({ availableModels: [entry] }),
+      getPreloadStatus: () => "ready",
+      getDefaultSelection: () => null,
+    } as unknown as AgentSessionManager;
+
+    const { entries } = buildPickerEntries(manager, [descriptor], {} as ModelActiveContext, {
+      ...emptySettings,
+      isPaidUser: false,
+    });
+
+    const locked = entries.filter((model) => model._needsLicense);
+    expect(locked.length).toBeGreaterThan(0);
+    // Locked rows lead the section, so the offer is the first thing read.
+    expect(entries.slice(0, locked.length).every((model) => model._needsLicense)).toBe(true);
+    expect(entries[entries.length - 1].name).toBe("catalog-model");
+    expect(locked.every((model) => model._group === descriptor.displayName)).toBe(true);
+  });
+
+  it("previews nothing for an agent that cannot route Copilot models", () => {
+    const claude = {
+      ...makeDescriptor("claude"),
+      routesCopilotModels: false,
+      getEnabledModelEntries: () => [
+        { baseModelId: "sonnet", name: "Sonnet", credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = makeManager({
+      catalogById: { claude: null },
+      preloadStatusById: { claude: "ready" },
+    });
+
+    const { entries } = buildPickerEntries(manager, [claude], {} as ModelActiveContext, {
+      ...emptySettings,
+      isPaidUser: false,
+    });
+
+    expect(entries.some((entry) => entry._needsLicense)).toBe(false);
+  });
+
+  it("previews nothing once a license is active, since the real models are there", () => {
+    const entry = makeModelEntry("catalog-model");
+    const descriptor = {
+      ...makeDescriptor("opencode"),
+      routesCopilotModels: true,
+      getEnabledModelEntries: () => [
+        { baseModelId: entry.baseModelId, name: entry.name, credentialState: "ok" as const },
+      ],
+    } as unknown as BackendDescriptor;
+    const manager = {
+      getCachedModelCatalog: () => ({ availableModels: [entry] }),
+      getPreloadStatus: () => "ready",
+      getDefaultSelection: () => null,
+    } as unknown as AgentSessionManager;
+
+    const { entries } = buildPickerEntries(manager, [descriptor], {} as ModelActiveContext, {
+      ...emptySettings,
+      isPaidUser: true,
+    });
+
+    expect(entries.map((model) => model.name)).toEqual(["catalog-model"]);
+  });
+
+  it("still shows a loading placeholder for a routing agent whose preload has not settled", () => {
+    // The locked rows must not satisfy the "section produced nothing" check, or
+    // an unlicensed user loses the per-agent loading row.
+    const descriptor = {
+      ...makeDescriptor("opencode"),
+      routesCopilotModels: true,
+      getEnabledModelEntries: () => [],
+    } as unknown as BackendDescriptor;
+    const manager = {
+      getCachedModelCatalog: () => null,
+      getPreloadStatus: () => "pending",
+      getDefaultSelection: () => null,
+    } as unknown as AgentSessionManager;
+
+    const { entries } = buildPickerEntries(manager, [descriptor], {} as ModelActiveContext, {
+      ...emptySettings,
+      isPaidUser: false,
+    });
+
+    expect(entries.some((entry) => entry._disabledReason === "Loading…")).toBe(true);
+  });
+
   it("builds shared choices from the model catalog", () => {
     const entry = makeModelEntry("catalog-model");
     const descriptor = {

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -376,7 +376,7 @@ export function buildPickerEntries(
     // above so neither relabels these rows: an unset-up agent's readiness reason
     // would replace "Copilot license required" with the wrong fix, and the
     // emptiness check for the loading/error placeholder must not count them.
-    if (descriptor.routesCopilotModels && shouldPreviewCopilotModels(settings)) {
+    if (descriptor.routesCopilotModels && shouldPreviewCopilotModels(settings.providers)) {
       entries.splice(
         sectionStart,
         0,

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -2,7 +2,7 @@ import { Notice } from "obsidian";
 import { logError } from "@/logger";
 import type { ModelCapability } from "@/constants";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
-import { lockedCopilotEntries } from "@/lib/lockedCopilotEntries";
+import { lockedCopilotEntries, shouldPreviewCopilotModels } from "@/lib/lockedCopilotEntries";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type { AgentChatUIState } from "@/agentMode/session/AgentChatUIState";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
@@ -376,7 +376,7 @@ export function buildPickerEntries(
     // above so neither relabels these rows: an unset-up agent's readiness reason
     // would replace "Copilot license required" with the wrong fix, and the
     // emptiness check for the loading/error placeholder must not count them.
-    if (descriptor.routesCopilotModels && !settings.isPaidUser) {
+    if (descriptor.routesCopilotModels && shouldPreviewCopilotModels(settings)) {
       entries.splice(
         sectionStart,
         0,

--- a/src/agentMode/ui/agentModelPickerHelpers.ts
+++ b/src/agentMode/ui/agentModelPickerHelpers.ts
@@ -2,6 +2,7 @@ import { Notice } from "obsidian";
 import { logError } from "@/logger";
 import type { ModelCapability } from "@/constants";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
+import { lockedCopilotEntries } from "@/lib/lockedCopilotEntries";
 import type { AgentSession } from "@/agentMode/session/AgentSession";
 import type { AgentChatUIState } from "@/agentMode/session/AgentChatUIState";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
@@ -369,6 +370,18 @@ export function buildPickerEntries(
       for (let i = sectionStart; i < entries.length; i++) {
         entries[i]._needsSelfHostWarning = true;
       }
+    }
+    // Advertise the Copilot lineup to a user who has no license, at the top of
+    // the section for each agent that could run it. Spliced in after the passes
+    // above so neither relabels these rows: an unset-up agent's readiness reason
+    // would replace "Copilot license required" with the wrong fix, and the
+    // emptiness check for the loading/error placeholder must not count them.
+    if (descriptor.routesCopilotModels && !settings.isPaidUser) {
+      entries.splice(
+        sectionStart,
+        0,
+        ...lockedCopilotEntries({ group: descriptor.displayName, backendId: descriptor.id })
+      );
     }
   }
 

--- a/src/components/chat-components/useChatModelPicker.ts
+++ b/src/components/chat-components/useChatModelPicker.ts
@@ -63,8 +63,9 @@ export function useChatModelPicker(params: {
   // Advertised, never selectable: kept out of `models` below so selection,
   // fallback, and the stored value can never resolve to one.
   const lockedRows = React.useMemo(
-    () => (shouldPreviewCopilotModels(settings) ? lockedCopilotEntries() : EMPTY_LOCKED_ROWS),
-    [settings]
+    () =>
+      shouldPreviewCopilotModels(settings.providers) ? lockedCopilotEntries() : EMPTY_LOCKED_ROWS,
+    [settings.providers]
   );
 
   const { models, byModelKey, idToModelKey } = React.useMemo(() => {

--- a/src/components/chat-components/useChatModelPicker.ts
+++ b/src/components/chat-components/useChatModelPicker.ts
@@ -5,10 +5,9 @@ import {
   providerRequiresApiKey,
   resolveChatModelSelectionId,
 } from "@/modelManagement";
-import { getModelKeyFromModel, settingsStore } from "@/settings/model";
+import { getModelKeyFromModel, settingsStore, useSettingsValue } from "@/settings/model";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
-import { lockedCopilotEntries } from "@/lib/lockedCopilotEntries";
-import { useIsPaidUser } from "@/plusUtils";
+import { lockedCopilotEntries, shouldPreviewCopilotModels } from "@/lib/lockedCopilotEntries";
 import { useAtomValue } from "jotai";
 import React from "react";
 
@@ -59,13 +58,13 @@ export function useChatModelPicker(params: {
 }): ChatModelPickerOverride {
   const { value, onChange } = params;
   const entries = useAtomValue(backendPickerAtomFamily("chat"), { store: settingsStore });
-  const isPaidUser = useIsPaidUser();
+  const settings = useSettingsValue();
 
   // Advertised, never selectable: kept out of `models` below so selection,
   // fallback, and the stored value can never resolve to one.
   const lockedRows = React.useMemo(
-    () => (isPaidUser ? EMPTY_LOCKED_ROWS : lockedCopilotEntries()),
-    [isPaidUser]
+    () => (shouldPreviewCopilotModels(settings) ? lockedCopilotEntries() : EMPTY_LOCKED_ROWS),
+    [settings]
   );
 
   const { models, byModelKey, idToModelKey } = React.useMemo(() => {

--- a/src/components/chat-components/useChatModelPicker.ts
+++ b/src/components/chat-components/useChatModelPicker.ts
@@ -7,6 +7,8 @@ import {
 } from "@/modelManagement";
 import { getModelKeyFromModel, settingsStore } from "@/settings/model";
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
+import { lockedCopilotEntries } from "@/lib/lockedCopilotEntries";
+import { useIsPaidUser } from "@/plusUtils";
 import { useAtomValue } from "jotai";
 import React from "react";
 
@@ -22,6 +24,9 @@ export interface ChatModelPickerOverride {
 }
 
 const NOOP = () => {};
+
+/** See AGENTS.md → "Referential stability". */
+const EMPTY_LOCKED_ROWS: readonly ModelSelectorEntry[] = Object.freeze([]);
 
 /**
  * Synthetic disabled row shown when no chat model is enabled, so the picker
@@ -54,6 +59,14 @@ export function useChatModelPicker(params: {
 }): ChatModelPickerOverride {
   const { value, onChange } = params;
   const entries = useAtomValue(backendPickerAtomFamily("chat"), { store: settingsStore });
+  const isPaidUser = useIsPaidUser();
+
+  // Advertised, never selectable: kept out of `models` below so selection,
+  // fallback, and the stored value can never resolve to one.
+  const lockedRows = React.useMemo(
+    () => (isPaidUser ? EMPTY_LOCKED_ROWS : lockedCopilotEntries()),
+    [isPaidUser]
+  );
 
   const { models, byModelKey, idToModelKey } = React.useMemo(() => {
     const models: ModelSelectorEntry[] = [];
@@ -114,8 +127,15 @@ export function useChatModelPicker(params: {
   );
 
   if (displayModels.length === 0) {
-    return { models: [EMPTY_ENTRY], value: EMPTY_ENTRY_KEY, onChange: NOOP };
+    // A brand-new user has no models at all, which is exactly who most needs to
+    // learn the Copilot lineup exists — so the locked rows lead, and the
+    // guidance row still explains how to add one of their own.
+    return { models: [...lockedRows, EMPTY_ENTRY], value: EMPTY_ENTRY_KEY, onChange: NOOP };
   }
 
-  return { models: displayModels, value: resolvedValue, onChange: handleChange };
+  return {
+    models: lockedRows.length > 0 ? [...lockedRows, ...displayModels] : displayModels,
+    value: resolvedValue,
+    onChange: handleChange,
+  };
 }

--- a/src/components/modals/CopilotPlusWelcomeModal.test.tsx
+++ b/src/components/modals/CopilotPlusWelcomeModal.test.tsx
@@ -11,6 +11,16 @@ describe("CopilotPlusWelcomeModal", () => {
       expect(screen.getByText(/default model for chat and your agents/)).toBeTruthy();
     });
 
+    it("names what the license unlocks, including the symposium link", () => {
+      render(<CopilotPlusWelcomeModalContent onConfirm={jest.fn()} onCancel={jest.fn()} />);
+
+      const link = screen.getByRole("link", { name: "symposium.md" });
+      expect(link.getAttribute("href")).toBe("https://symposium.md");
+      expect(screen.getByText(/Copilot exclusive/)).toBeTruthy();
+      expect(screen.getByText(/cross-agent skills/)).toBeTruthy();
+      expect(screen.getByText(/multi-agent features/)).toBeTruthy();
+    });
+
     it("offers to apply no mode, no embedding model, and no vault rebuild", () => {
       const { container } = render(
         <CopilotPlusWelcomeModalContent onConfirm={jest.fn()} onCancel={jest.fn()} />

--- a/src/components/modals/CopilotPlusWelcomeModal.test.tsx
+++ b/src/components/modals/CopilotPlusWelcomeModal.test.tsx
@@ -11,14 +11,24 @@ describe("CopilotPlusWelcomeModal", () => {
       expect(screen.getByText(/default model for chat and your agents/)).toBeTruthy();
     });
 
-    it("names what the license unlocks, including the symposium link", () => {
+    it("names what the license includes, including the symposium link", () => {
       render(<CopilotPlusWelcomeModalContent onConfirm={jest.fn()} onCancel={jest.fn()} />);
 
       const link = screen.getByRole("link", { name: "symposium.md" });
       expect(link.getAttribute("href")).toBe("https://symposium.md");
       expect(screen.getByText(/Copilot exclusive/)).toBeTruthy();
       expect(screen.getByText(/cross-agent skills/)).toBeTruthy();
-      expect(screen.getByText(/multi-agent features/)).toBeTruthy();
+    });
+
+    it("promises no capability a lower paid tier may not have", () => {
+      const { container } = render(
+        <CopilotPlusWelcomeModalContent onConfirm={jest.fn()} onCancel={jest.fn()} />
+      );
+
+      // Multi-agent is tier >= Plus (see `canUseMultiAgent`), so a Lite user
+      // opening this modal must not be told they have it. Same for a blanket
+      // "full power" claim, which is true of no single tier.
+      expect(container.textContent).not.toMatch(/multi-agent|full power|full potential/i);
     });
 
     it("offers to apply no mode, no embedding model, and no vault rebuild", () => {

--- a/src/components/modals/CopilotPlusWelcomeModal.tsx
+++ b/src/components/modals/CopilotPlusWelcomeModal.tsx
@@ -20,8 +20,9 @@ export function CopilotPlusWelcomeModalContent({
     <div className="tw-flex tw-flex-col tw-gap-4">
       <div>
         <p>
-          Thanks for purchasing! You have unlocked the full power of Copilot, featuring chat
-          context, PDF and image support, exclusive chat and embedding models, and much more!
+          Thanks for purchasing! You have unlocked the full power of Copilot: Copilot exclusive
+          models, cross-agent skills, multi-agent features, access to the{" "}
+          <a href="https://symposium.md">symposium.md</a> doc sharing service, and much more!
         </p>
         <p>
           Would you like to make <b className="tw-text-accent">{DEFAULT_COPILOT_PLUS_CHAT_MODEL}</b>{" "}

--- a/src/components/modals/CopilotPlusWelcomeModal.tsx
+++ b/src/components/modals/CopilotPlusWelcomeModal.tsx
@@ -20,9 +20,9 @@ export function CopilotPlusWelcomeModalContent({
     <div className="tw-flex tw-flex-col tw-gap-4">
       <div>
         <p>
-          Thanks for purchasing! You have unlocked the full power of Copilot: Copilot exclusive
-          models, cross-agent skills, multi-agent features, access to the{" "}
-          <a href="https://symposium.md">symposium.md</a> doc sharing service, and much more!
+          Thanks for purchasing! Your license includes Copilot exclusive models, cross-agent skills,
+          access to the <a href="https://symposium.md">symposium.md</a> doc sharing service, and
+          much more!
         </p>
         <p>
           Would you like to make <b className="tw-text-accent">{DEFAULT_COPILOT_PLUS_CHAT_MODEL}</b>{" "}

--- a/src/components/ui/LicenseRequiredIcon.test.tsx
+++ b/src/components/ui/LicenseRequiredIcon.test.tsx
@@ -1,0 +1,24 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { LicenseRequiredIcon } from "./LicenseRequiredIcon";
+
+describe("LicenseRequiredIcon", () => {
+  describe("LicenseRequiredIcon()", () => {
+    it("stays hoverable on a row that has turned pointer events off", () => {
+      const { container } = render(<LicenseRequiredIcon />);
+
+      // The lock only ever sits on a disabled row, and a disabled
+      // `DropdownMenuItem` sets `pointer-events: none`, which descendants
+      // inherit. Without the reset the tooltip cannot open and the greyed row
+      // has nothing left to say why it is locked.
+      expect(container.firstElementChild?.className).toContain("tw-pointer-events-auto");
+    });
+
+    it("keeps a caller's classes alongside its own", () => {
+      const { container } = render(<LicenseRequiredIcon className="tw-mt-0.5" />);
+
+      expect(container.firstElementChild?.className).toContain("tw-mt-0.5");
+      expect(container.firstElementChild?.className).toContain("tw-pointer-events-auto");
+    });
+  });
+});

--- a/src/components/ui/LicenseRequiredIcon.test.tsx
+++ b/src/components/ui/LicenseRequiredIcon.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 import { LicenseRequiredIcon } from "./LicenseRequiredIcon";
 
@@ -12,6 +12,15 @@ describe("LicenseRequiredIcon", () => {
       // inherit. Without the reset the tooltip cannot open and the greyed row
       // has nothing left to say why it is locked.
       expect(container.firstElementChild?.className).toContain("tw-pointer-events-auto");
+    });
+
+    it("states the reason in text, since the tooltip only answers a hover", () => {
+      render(<LicenseRequiredIcon />);
+
+      // The tooltip content renders on hover, and a disabled row can take
+      // neither hover nor focus from a keyboard, so this hidden copy is the
+      // reason's only route into the row's accessible name.
+      expect(screen.getByText("Copilot license required")).toBeTruthy();
     });
 
     it("keeps a caller's classes alongside its own", () => {

--- a/src/components/ui/LicenseRequiredIcon.tsx
+++ b/src/components/ui/LicenseRequiredIcon.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/lib/utils";
+import { HelpTooltip } from "@/components/ui/help-tooltip";
+import { Lock } from "lucide-react";
+import React from "react";
+
+const LICENSE_REQUIRED = "Copilot license required";
+
+/**
+ * Small lock icon shown beside a Copilot model a user cannot run yet, so the
+ * lineup is discoverable before anyone pays for it. The row it sits on is
+ * already greyed and non-selectable; this is what says why.
+ *
+ * Parallels {@link FreeModelWarningIcon}: same Radix `HelpTooltip` with
+ * `delayDuration={0}` for instant hover, and no `aria-label` (that makes
+ * Obsidian attach its own native tooltip, which throws `isShown is not a
+ * function` here — the tooltip text already conveys the meaning). Muted rather
+ * than amber: a locked model is an offer, not a warning.
+ */
+export function LicenseRequiredIcon({ className }: { className?: string }) {
+  return (
+    <span
+      // Stop the click from reaching the surrounding row.
+      onClick={(e) => e.stopPropagation()}
+      className={cn("tw-flex tw-shrink-0 tw-items-center tw-text-muted", className)}
+    >
+      <HelpTooltip content={LICENSE_REQUIRED} side="top" delayDuration={0}>
+        <Lock className="tw-size-3.5" />
+      </HelpTooltip>
+    </span>
+  );
+}

--- a/src/components/ui/LicenseRequiredIcon.tsx
+++ b/src/components/ui/LicenseRequiredIcon.tsx
@@ -13,8 +13,8 @@ const LICENSE_REQUIRED = "Copilot license required";
  * Parallels {@link FreeModelWarningIcon}: same Radix `HelpTooltip` with
  * `delayDuration={0}` for instant hover, and no `aria-label` (that makes
  * Obsidian attach its own native tooltip, which throws `isShown is not a
- * function` here — the tooltip text already conveys the meaning). Muted rather
- * than amber: a locked model is an offer, not a warning.
+ * function` here). Muted rather than amber: a locked model is an offer, not a
+ * warning.
  */
 export function LicenseRequiredIcon({ className }: { className?: string }) {
   return (
@@ -33,6 +33,10 @@ export function LicenseRequiredIcon({ className }: { className?: string }) {
       <HelpTooltip content={LICENSE_REQUIRED} side="top" delayDuration={0}>
         <Lock className="tw-size-3.5" />
       </HelpTooltip>
+      {/* A hover tooltip reaches pointer users only, and the row is disabled, so
+          nothing in it can take focus. Carrying the reason as hidden text folds
+          it into the row's accessible name instead. */}
+      <span className="tw-sr-only">{LICENSE_REQUIRED}</span>
     </span>
   );
 }

--- a/src/components/ui/LicenseRequiredIcon.tsx
+++ b/src/components/ui/LicenseRequiredIcon.tsx
@@ -21,7 +21,14 @@ export function LicenseRequiredIcon({ className }: { className?: string }) {
     <span
       // Stop the click from reaching the surrounding row.
       onClick={(e) => e.stopPropagation()}
-      className={cn("tw-flex tw-shrink-0 tw-items-center tw-text-muted", className)}
+      className={cn(
+        // The lock always sits on a row that is disabled — and a disabled
+        // `DropdownMenuItem` sets `pointer-events: none`, which every descendant
+        // inherits. Without this reset the tooltip can never be hovered, leaving
+        // the row greyed with nothing to say why.
+        "tw-pointer-events-auto tw-flex tw-shrink-0 tw-items-center tw-text-muted",
+        className
+      )}
     >
       <HelpTooltip content={LICENSE_REQUIRED} side="top" delayDuration={0}>
         <Lock className="tw-size-3.5" />

--- a/src/components/ui/ModelEffortPicker.tsx
+++ b/src/components/ui/ModelEffortPicker.tsx
@@ -3,6 +3,7 @@ import { ChevronDown } from "lucide-react";
 import * as SliderPrimitive from "@radix-ui/react-slider";
 import { Button } from "@/components/ui/button";
 import { FreeModelWarningIcon } from "@/components/ui/FreeModelWarningIcon";
+import { LicenseRequiredIcon } from "@/components/ui/LicenseRequiredIcon";
 import { SelfHostCloudWarningIcon } from "@/components/ui/SelfHostCloudWarningIcon";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ModelDisplay } from "@/components/ui/model-display";
@@ -241,7 +242,9 @@ export function ModelEffortPicker({ override, className }: ModelEffortPickerProp
             const key = getModelKeyFromModel(entry);
             const disabledReason = entry._disabledReason;
             const itemDisabled = Boolean(disabledReason);
-            const rightLabel = disabledReason ?? null;
+            // A locked Copilot row says why through its lock icon; repeating the
+            // reason per row would print the same sentence down the whole group.
+            const rightLabel = entry._needsLicense ? null : (disabledReason ?? null);
             const isHighlight = key === highlightKey;
             const isActive = key === draftModelKey;
             const showHeader = entry._group !== undefined && entry._group !== lastGroup;
@@ -282,6 +285,7 @@ export function ModelEffortPicker({ override, className }: ModelEffortPickerProp
                     <div className="tw-min-w-0">
                       <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1">
                         <ModelDisplay model={entry} iconSize={12} />
+                        {entry._needsLicense && <LicenseRequiredIcon />}
                         {entry._isFree && <FreeModelWarningIcon />}
                         {entry._needsSelfHostWarning && <SelfHostCloudWarningIcon />}
                       </div>

--- a/src/components/ui/ModelSelector.stories.tsx
+++ b/src/components/ui/ModelSelector.stories.tsx
@@ -82,9 +82,11 @@ export const Licensed: StoryObj<ModelSelectorProps> = {};
 
 /**
  * No license: the Copilot lineup leads the section, greyed and non-selectable,
- * each row marked by a lock whose hover reads "Copilot license required". The
- * rows carry no right-side label — the lock says it once instead of repeating
- * the sentence down the group. Open the picker, then hover a lock.
+ * each row marked by a lock whose hover reads "Copilot license required" and
+ * subtitled with what the model is for. The rows carry no right-side label —
+ * the lock says it once instead of repeating the sentence down the group. Open
+ * the picker, then hover a lock: the row is pointer-disabled but the lock is
+ * not, which is what keeps the reason reachable here.
  */
 export const Unlicensed: StoryObj<ModelSelectorProps> = {
   args: {

--- a/src/components/ui/ModelSelector.stories.tsx
+++ b/src/components/ui/ModelSelector.stories.tsx
@@ -1,0 +1,101 @@
+import { ModelSelector, type ModelSelectorEntry } from "@/components/ui/ModelSelector";
+import type { Meta, StoryObj } from "@/lib/story";
+import type { ComponentProps } from "react";
+
+type ModelSelectorProps = ComponentProps<typeof ModelSelector>;
+
+/**
+ * The Copilot rows as `lockedCopilotEntries` builds them, written out as
+ * fixtures so the story stays deterministic if the lineup or the default-on set
+ * changes. `_needsLicense` is what draws the lock and suppresses the right-side
+ * label; `_disabledReason` is what disables the row.
+ */
+const LOCKED_COPILOT_ROWS: ModelSelectorEntry[] = [
+  {
+    name: "copilot-plus-flash",
+    provider: "copilot-plus",
+    displayName: "Copilot Plus Flash",
+    enabled: true,
+    _group: "OpenCode",
+    _backendId: "opencode",
+    _needsLicense: true,
+    _disabledReason: "Copilot license required",
+    _subtitle: "The default model: fastest responses and the most quota.",
+  },
+  {
+    name: "deepseek-v4-pro",
+    provider: "copilot-plus",
+    displayName: "DeepSeek V4 Pro",
+    enabled: true,
+    _group: "OpenCode",
+    _backendId: "opencode",
+    _needsLicense: true,
+    _disabledReason: "Copilot license required",
+    _subtitle: "A top-tier model for the hardest reasoning and agentic tasks.",
+  },
+  {
+    name: "glm-5.2",
+    provider: "copilot-plus",
+    displayName: "GLM-5.2",
+    enabled: true,
+    _group: "OpenCode",
+    _backendId: "opencode",
+    _needsLicense: true,
+    _disabledReason: "Copilot license required",
+    _subtitle: "A long-horizon frontier open model that beats some of the best closed models.",
+  },
+];
+
+/** The models an unlicensed OpenCode user has of their own. */
+const OWN_MODELS: ModelSelectorEntry[] = [
+  {
+    name: "grok-code",
+    provider: "opencode",
+    displayName: "opencode/grok-code",
+    enabled: true,
+    _group: "OpenCode",
+    _isFree: true,
+  },
+  {
+    name: "claude-sonnet-4-6",
+    provider: "anthropic",
+    displayName: "anthropic/claude-sonnet-4-6",
+    enabled: true,
+    _group: "OpenCode",
+  },
+];
+
+const meta = {
+  title: "UI/Model Selector",
+  component: ModelSelector,
+  args: {
+    value: "grok-code|opencode",
+    onChange: () => undefined,
+    models: OWN_MODELS,
+  },
+  parameters: { gallery: { host: "popover", layout: "padded" } },
+} satisfies Meta<ModelSelectorProps>;
+export default meta;
+
+/** A licensed user: their models, nothing locked. Open the picker to see the rows. */
+export const Licensed: StoryObj<ModelSelectorProps> = {};
+
+/**
+ * No license: the Copilot lineup leads the section, greyed and non-selectable,
+ * each row marked by a lock whose hover reads "Copilot license required". The
+ * rows carry no right-side label — the lock says it once instead of repeating
+ * the sentence down the group. Open the picker, then hover a lock.
+ */
+export const Unlicensed: StoryObj<ModelSelectorProps> = {
+  args: {
+    models: [...LOCKED_COPILOT_ROWS, ...OWN_MODELS],
+  },
+};
+
+/** The case a brand-new user hits: nothing of their own, so the offer is all there is. */
+export const UnlicensedWithNoModelsOfTheirOwn: StoryObj<ModelSelectorProps> = {
+  args: {
+    value: "",
+    models: LOCKED_COPILOT_ROWS,
+  },
+};

--- a/src/components/ui/ModelSelector.test.tsx
+++ b/src/components/ui/ModelSelector.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { ModelSelector } from "./ModelSelector";
 import type { ModelSelectorEntry } from "./ModelSelector";
@@ -12,6 +12,10 @@ jest.mock("@/components/ui/SelfHostCloudWarningIcon", () => ({
     cloudWarningProps.push(props);
     return <span data-testid="cloud-warning" />;
   },
+}));
+
+jest.mock("@/components/ui/LicenseRequiredIcon", () => ({
+  LicenseRequiredIcon: () => <span data-testid="license-lock" />,
 }));
 
 const model = (over: Partial<ModelSelectorEntry>): ModelSelectorEntry => ({
@@ -40,6 +44,30 @@ describe("ModelSelector", () => {
       render(<ModelSelector value="gpt-5|openai" onChange={jest.fn()} models={[local]} />);
 
       expect(screen.queryByTestId("cloud-warning")).toBeNull();
+    });
+
+    it("marks a licence-locked row with the lock and drops its right-side reason", async () => {
+      const locked = model({
+        name: "copilot-plus-flash",
+        provider: "copilot-plus",
+        displayName: "Copilot Plus Flash",
+        _needsLicense: true,
+        _disabledReason: "Copilot license required",
+      });
+      render(<ModelSelector value="gpt-5|openai" onChange={jest.fn()} models={[locked]} />);
+      fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+
+      expect(await screen.findByTestId("license-lock")).toBeTruthy();
+      // The lock carries the reason; a per-row label would repeat it down the group.
+      expect(screen.queryByText("Copilot license required")).toBeNull();
+    });
+
+    it("keeps the right-side reason for a row disabled for any other cause", async () => {
+      const needsKey = model({ _disabledReason: "Add API key" });
+      render(<ModelSelector value="gpt-5|openai" onChange={jest.fn()} models={[needsKey]} />);
+      fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+
+      expect(await screen.findByText("Add API key")).toBeTruthy();
     });
   });
 });

--- a/src/components/ui/ModelSelector.test.tsx
+++ b/src/components/ui/ModelSelector.test.tsx
@@ -62,6 +62,24 @@ describe("ModelSelector", () => {
       expect(screen.queryByText("Copilot license required")).toBeNull();
     });
 
+    it("renders a row's subtitle under its name and keeps it off the collapsed trigger", async () => {
+      const described = model({
+        displayName: "Copilot Plus Flash",
+        _subtitle: "The default model: fastest responses and the most quota.",
+      });
+      render(<ModelSelector value="gpt-5|openai" onChange={jest.fn()} models={[described]} />);
+
+      expect(
+        screen.queryByText("The default model: fastest responses and the most quota.")
+      ).toBeNull();
+
+      fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+
+      expect(
+        await screen.findByText("The default model: fastest responses and the most quota.")
+      ).toBeTruthy();
+    });
+
     it("keeps the right-side reason for a row disabled for any other cause", async () => {
       const needsKey = model({ _disabledReason: "Add API key" });
       render(<ModelSelector value="gpt-5|openai" onChange={jest.fn()} models={[needsKey]} />);

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ModelDisplay } from "@/components/ui/model-display";
+import { LicenseRequiredIcon } from "@/components/ui/LicenseRequiredIcon";
 import { SelfHostCloudWarningIcon } from "@/components/ui/SelfHostCloudWarningIcon";
 import { checkModelApiKey, err2String } from "@/lib/model-display-utils";
 import type { ModelApiKeySettings } from "@/lib/model-display-utils";
@@ -59,6 +60,14 @@ export type ModelSelectorEntry = CustomModel & {
    * the model stays selectable (Self-Host Mode marks, it doesn't block).
    */
   _needsSelfHostWarning?: boolean;
+  /**
+   * `true` for a Copilot model the user has no license to run, shown so the
+   * lineup is discoverable before they buy. The row renders a lock icon +
+   * tooltip beside the name and suppresses the right-side `_disabledReason`
+   * label, which would otherwise repeat the same sentence down the whole group.
+   * Always paired with a `_disabledReason` — that is what disables the row.
+   */
+  _needsLicense?: boolean;
 };
 
 interface ModelSelectorProps {
@@ -135,7 +144,11 @@ export function ModelSelector({
             ? checkModelApiKey(model, apiKeySettings).hasApiKey
             : true;
           const itemDisabled = Boolean(disabledReason) || !hasApiKey;
-          const rightLabel = disabledReason ?? (!hasApiKey ? "Needs API key" : null);
+          // A locked Copilot row says why through its lock icon; repeating the
+          // reason per row would print the same sentence down the whole group.
+          const rightLabel = model._needsLicense
+            ? null
+            : (disabledReason ?? (!hasApiKey ? "Needs API key" : null));
           const showHeader = model._group !== undefined && model._group !== lastGroup;
           const headerKey = `__group__${model._group}__${getModelKeyFromModel(model)}`;
           lastGroup = model._group;
@@ -177,6 +190,7 @@ export function ModelSelector({
               >
                 <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1">
                   <ModelDisplay model={model} iconSize={12} />
+                  {model._needsLicense && <LicenseRequiredIcon />}
                   {model._needsSelfHostWarning && <SelfHostCloudWarningIcon />}
                 </div>
                 {rightLabel && (

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -42,10 +42,9 @@ export type ModelSelectorEntry = CustomModel & {
   _group?: string;
   _backendId?: string;
   /**
-   * Optional second line rendered beneath the title in the dropdown row
-   * (agent backends only). Carries the model's capability blurb so the
-   * picker row matches the settings list row. The collapsed trigger pill
-   * ignores it and stays single-line.
+   * Optional second line rendered beneath the title in the dropdown row.
+   * Carries the model's capability blurb so the picker row matches the settings
+   * list row. The collapsed trigger pill ignores it and stays single-line.
    */
   _subtitle?: string;
   /**
@@ -188,10 +187,15 @@ export function ModelSelector({
                 }}
                 className={itemDisabled ? "tw-cursor-not-allowed tw-opacity-50" : ""}
               >
-                <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1">
-                  <ModelDisplay model={model} iconSize={12} />
-                  {model._needsLicense && <LicenseRequiredIcon />}
-                  {model._needsSelfHostWarning && <SelfHostCloudWarningIcon />}
+                <div className="tw-min-w-0">
+                  <div className="tw-flex tw-min-w-0 tw-items-center tw-gap-1">
+                    <ModelDisplay model={model} iconSize={12} />
+                    {model._needsLicense && <LicenseRequiredIcon />}
+                    {model._needsSelfHostWarning && <SelfHostCloudWarningIcon />}
+                  </div>
+                  {model._subtitle && (
+                    <div className="tw-truncate tw-text-xs tw-text-muted">{model._subtitle}</div>
+                  )}
                 </div>
                 {rightLabel && (
                   <span className="tw-ml-auto tw-text-smallest tw-text-faint">{rightLabel}</span>

--- a/src/lib/lockedCopilotEntries.test.ts
+++ b/src/lib/lockedCopilotEntries.test.ts
@@ -1,0 +1,49 @@
+import { COPILOT_PLUS_DEFAULT_ENABLED_MODELS, COPILOT_PLUS_MODELS } from "@/modelManagement";
+import { lockedCopilotEntries } from "./lockedCopilotEntries";
+
+describe("lockedCopilotEntries", () => {
+  describe("lockedCopilotEntries()", () => {
+    it("previews exactly the models a license switches on, in lineup order", () => {
+      const previewed = lockedCopilotEntries().map((entry) => entry.name);
+
+      expect(previewed).toEqual(
+        COPILOT_PLUS_MODELS.filter((model) =>
+          COPILOT_PLUS_DEFAULT_ENABLED_MODELS.includes(model.id)
+        ).map((model) => model.id)
+      );
+      // The cap is the point: a full lineup would push the user's own models
+      // past the fold of a 288px picker.
+      expect(previewed.length).toBeLessThan(COPILOT_PLUS_MODELS.length);
+    });
+
+    it("marks every row as needing a license and as non-selectable", () => {
+      const entries = lockedCopilotEntries();
+
+      expect(entries.length).toBeGreaterThan(0);
+      for (const entry of entries) {
+        expect(entry._needsLicense).toBe(true);
+        // `_disabledReason` is what actually disables the row; the lock explains it.
+        expect(entry._disabledReason).toBe("Copilot license required");
+        expect(entry.enabled).toBe(true);
+      }
+    });
+
+    it("carries each model's display name and description so the row says what it is for", () => {
+      const flash = lockedCopilotEntries()[0];
+      const source = COPILOT_PLUS_MODELS.find((model) => model.id === flash.name);
+
+      expect(flash.displayName).toBe(source?.displayName);
+      expect(flash._subtitle).toBe(source?.description);
+    });
+
+    it("files rows under a group and backend when one is given, and leaves them flat otherwise", () => {
+      const grouped = lockedCopilotEntries({ group: "OpenCode", backendId: "opencode" });
+      const flat = lockedCopilotEntries();
+
+      expect(grouped.every((entry) => entry._group === "OpenCode")).toBe(true);
+      expect(grouped.every((entry) => entry._backendId === "opencode")).toBe(true);
+      expect(flat.every((entry) => entry._group === undefined)).toBe(true);
+      expect(flat.every((entry) => entry._backendId === undefined)).toBe(true);
+    });
+  });
+});

--- a/src/lib/lockedCopilotEntries.test.ts
+++ b/src/lib/lockedCopilotEntries.test.ts
@@ -3,17 +3,17 @@ import { lockedCopilotEntries, shouldPreviewCopilotModels } from "./lockedCopilo
 
 import type { CopilotSettings } from "@/settings/model";
 
-function settingsWithProviders(providers: Record<string, unknown>): CopilotSettings {
-  return { providers } as unknown as CopilotSettings;
+function providerRows(providers: Record<string, unknown>): CopilotSettings["providers"] {
+  return providers as unknown as CopilotSettings["providers"];
 }
 
 describe("lockedCopilotEntries", () => {
   describe("shouldPreviewCopilotModels()", () => {
     it("previews when no Copilot provider is registered", () => {
-      expect(shouldPreviewCopilotModels(settingsWithProviders({}))).toBe(true);
+      expect(shouldPreviewCopilotModels(providerRows({}))).toBe(true);
       expect(
         shouldPreviewCopilotModels(
-          settingsWithProviders({ "byok-1": { providerId: "byok-1", origin: { kind: "byok" } } })
+          providerRows({ "byok-1": { providerId: "byok-1", origin: { kind: "byok" } } })
         )
       ).toBe(true);
     });
@@ -21,7 +21,7 @@ describe("lockedCopilotEntries", () => {
     it("stops previewing once the Copilot provider is registered, so locked copies never sit beside working models", () => {
       expect(
         shouldPreviewCopilotModels(
-          settingsWithProviders({
+          providerRows({
             "plus-1": { providerId: "plus-1", origin: { kind: "copilot-plus" } },
           })
         )

--- a/src/lib/lockedCopilotEntries.test.ts
+++ b/src/lib/lockedCopilotEntries.test.ts
@@ -1,7 +1,34 @@
 import { COPILOT_PLUS_DEFAULT_ENABLED_MODELS, COPILOT_PLUS_MODELS } from "@/modelManagement";
-import { lockedCopilotEntries } from "./lockedCopilotEntries";
+import { lockedCopilotEntries, shouldPreviewCopilotModels } from "./lockedCopilotEntries";
+
+import type { CopilotSettings } from "@/settings/model";
+
+function settingsWithProviders(providers: Record<string, unknown>): CopilotSettings {
+  return { providers } as unknown as CopilotSettings;
+}
 
 describe("lockedCopilotEntries", () => {
+  describe("shouldPreviewCopilotModels()", () => {
+    it("previews when no Copilot provider is registered", () => {
+      expect(shouldPreviewCopilotModels(settingsWithProviders({}))).toBe(true);
+      expect(
+        shouldPreviewCopilotModels(
+          settingsWithProviders({ "byok-1": { providerId: "byok-1", origin: { kind: "byok" } } })
+        )
+      ).toBe(true);
+    });
+
+    it("stops previewing once the Copilot provider is registered, so locked copies never sit beside working models", () => {
+      expect(
+        shouldPreviewCopilotModels(
+          settingsWithProviders({
+            "plus-1": { providerId: "plus-1", origin: { kind: "copilot-plus" } },
+          })
+        )
+      ).toBe(false);
+    });
+  });
+
   describe("lockedCopilotEntries()", () => {
     it("previews exactly the models a license switches on, in lineup order", () => {
       const previewed = lockedCopilotEntries().map((entry) => entry.name);

--- a/src/lib/lockedCopilotEntries.ts
+++ b/src/lib/lockedCopilotEntries.ts
@@ -1,5 +1,6 @@
 import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
 import { ChatModelProviders } from "@/constants";
+import type { CopilotSettings } from "@/settings/model";
 import { COPILOT_PLUS_DEFAULT_ENABLED_MODELS, COPILOT_PLUS_MODELS } from "@/modelManagement";
 
 /** See AGENTS.md → "Referential stability". */
@@ -19,6 +20,22 @@ const LICENSE_REQUIRED = "Copilot license required";
 const PREVIEWED_MODELS = COPILOT_PLUS_MODELS.filter((model) =>
   COPILOT_PLUS_DEFAULT_ENABLED_MODELS.includes(model.id)
 );
+
+/**
+ * Whether the pickers should advertise the lineup — true exactly when no Copilot
+ * provider is registered, which is the absence these rows exist to fill.
+ *
+ * Deliberately not `!isPaidUser`: the two agree in practice, but a license state
+ * that has not resolved while the provider is still registered would put locked
+ * copies beside working models. Asking about the provider cannot produce that.
+ *
+ * @param settings - Caller-owned settings snapshot holding the provider rows.
+ */
+export function shouldPreviewCopilotModels(settings: CopilotSettings): boolean {
+  return !Object.values(settings.providers).some(
+    (provider) => provider.origin.kind === "copilot-plus"
+  );
+}
 
 /**
  * Non-selectable rows advertising the Copilot models a license would unlock.

--- a/src/lib/lockedCopilotEntries.ts
+++ b/src/lib/lockedCopilotEntries.ts
@@ -22,19 +22,22 @@ const PREVIEWED_MODELS = COPILOT_PLUS_MODELS.filter((model) =>
 );
 
 /**
- * Whether the pickers should advertise the lineup — true exactly when no Copilot
+ * Whether a surface should advertise the lineup — true exactly when no Copilot
  * provider is registered, which is the absence these rows exist to fill.
  *
  * Deliberately not `!isPaidUser`: the two agree in practice, but a license state
  * that has not resolved while the provider is still registered would put locked
  * copies beside working models. Asking about the provider cannot produce that.
  *
- * @param settings - Caller-owned settings snapshot holding the provider rows.
+ * Equally deliberately not "are there Copilot rows to render": registering the
+ * provider and reconciling its models are separate writes, so a failure between
+ * them leaves a licensed user with the provider and no rows — and inferring from
+ * the rows would then advertise a license they already bought.
+ *
+ * @param providers - Caller-owned provider rows, keyed by provider id.
  */
-export function shouldPreviewCopilotModels(settings: CopilotSettings): boolean {
-  return !Object.values(settings.providers).some(
-    (provider) => provider.origin.kind === "copilot-plus"
-  );
+export function shouldPreviewCopilotModels(providers: CopilotSettings["providers"]): boolean {
+  return !Object.values(providers).some((provider) => provider.origin.kind === "copilot-plus");
 }
 
 /**

--- a/src/lib/lockedCopilotEntries.ts
+++ b/src/lib/lockedCopilotEntries.ts
@@ -1,0 +1,56 @@
+import type { ModelSelectorEntry } from "@/components/ui/ModelSelector";
+import { ChatModelProviders } from "@/constants";
+import { COPILOT_PLUS_DEFAULT_ENABLED_MODELS, COPILOT_PLUS_MODELS } from "@/modelManagement";
+
+/** See AGENTS.md → "Referential stability". */
+const EMPTY_ENTRIES: readonly ModelSelectorEntry[] = Object.freeze([]);
+
+const LICENSE_REQUIRED = "Copilot license required";
+
+/**
+ * The lineup previewed to a user without a license: exactly the models a
+ * license switches on, so the preview and the outcome match — activate, and
+ * these three rows lose their locks in place rather than being replaced by a
+ * different set.
+ *
+ * Showing all eight would bury the user's own models: the picker is 288px tall,
+ * so a full lineup pushes the checkmark on their current model below the fold.
+ */
+const PREVIEWED_MODELS = COPILOT_PLUS_MODELS.filter((model) =>
+  COPILOT_PLUS_DEFAULT_ENABLED_MODELS.includes(model.id)
+);
+
+/**
+ * Non-selectable rows advertising the Copilot models a license would unlock.
+ *
+ * These exist only for the duration of a render — they are never `Provider` or
+ * `ConfiguredModel` rows, so nothing can select, enroll, or default to one, and
+ * a licensed user never sees them (the real models are there instead). That
+ * separation is the point: without a license the provider is unregistered, so a
+ * picker built from settings alone has nothing Copilot to show and the user has
+ * no way to learn the models exist.
+ *
+ * @param opts.group - Section header to file the rows under, for pickers that
+ *   group by agent. Omit for a flat picker.
+ * @param opts.backendId - Backend the rows belong to, which keeps their picker
+ *   keys distinct when several agents each preview the same model.
+ */
+export function lockedCopilotEntries(
+  opts: { group?: string; backendId?: string } = {}
+): readonly ModelSelectorEntry[] {
+  if (PREVIEWED_MODELS.length === 0) return EMPTY_ENTRIES;
+  return PREVIEWED_MODELS.map((model) => ({
+    name: model.id,
+    provider: ChatModelProviders.COPILOT_PLUS,
+    displayName: model.displayName || model.id,
+    enabled: true,
+    isBuiltIn: false,
+    // `_disabledReason` is what disables the row; the lock icon is what explains
+    // it, so the same sentence serves as the native title fallback.
+    _disabledReason: LICENSE_REQUIRED,
+    _needsLicense: true,
+    _subtitle: model.description,
+    _group: opts.group,
+    _backendId: opts.backendId,
+  }));
+}

--- a/src/modelManagement/index.ts
+++ b/src/modelManagement/index.ts
@@ -87,7 +87,11 @@ export type {
 
 export { CopilotPlusSetupApi } from "./setup/CopilotPlusSetupApi";
 export type { PlusSetupResult, RegisterPlusProviderInput } from "./setup/CopilotPlusSetupApi";
-export { COPILOT_PLUS_MODELS, syncCopilotPlusProvider } from "./setup/copilotPlusSync";
+export {
+  COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
+  COPILOT_PLUS_MODELS,
+  syncCopilotPlusProvider,
+} from "./setup/copilotPlusSync";
 
 // ---------------------------------------------------------------------------
 // Top-level factory + coordinator

--- a/src/settings/v2/components/ChatModelEnableList.tsx
+++ b/src/settings/v2/components/ChatModelEnableList.tsx
@@ -40,8 +40,11 @@ export const ChatModelEnableList: React.FC = () => {
     [configuredModels, providers, enabledIds]
   );
 
+  // The locked Copilot group is an opencode-list feature, so the last argument
+  // never reaches it: this list is where a user curates chat models they can run,
+  // and the Quick Chat picker is where the lineup gets advertised.
   const groups = React.useMemo<ModelEnableGroup[]>(
-    () => buildModelEnableGroups(partition, false, query),
+    () => buildModelEnableGroups(partition, false, query, false),
     [partition, query]
   );
 

--- a/src/settings/v2/components/ConfiguredModelEnableList.tsx
+++ b/src/settings/v2/components/ConfiguredModelEnableList.tsx
@@ -12,6 +12,7 @@ import {
   useModelManagement,
   type AgentType,
 } from "@/modelManagement";
+import { shouldPreviewCopilotModels } from "@/lib/lockedCopilotEntries";
 import { settingsStore } from "@/settings/model";
 import { useAtomValue } from "jotai";
 import React from "react";
@@ -72,9 +73,16 @@ export const ConfiguredModelEnableList: React.FC<ConfiguredModelEnableListProps>
     [configuredModels, providers, enabledIds, agentType, isOpencode]
   );
 
+  // Ask the provider rows, as both pickers do, rather than letting the grouping
+  // infer a missing license from the rows it just built: registering the provider
+  // and reconciling its models are separate writes, so a licensed user can hold
+  // the provider with nothing under it, and that user must not be shown a locked
+  // group telling them a license is required.
+  const copilotProviderMissing = shouldPreviewCopilotModels(providers);
+
   const groups = React.useMemo<ModelEnableGroup[]>(
-    () => buildModelEnableGroups(partition, isOpencode, query),
-    [partition, isOpencode, query]
+    () => buildModelEnableGroups(partition, isOpencode, query, copilotProviderMissing),
+    [partition, isOpencode, query, copilotProviderMissing]
   );
 
   const handleToggle = React.useCallback(

--- a/src/settings/v2/components/configuredModelGrouping.test.ts
+++ b/src/settings/v2/components/configuredModelGrouping.test.ts
@@ -405,6 +405,83 @@ describe("buildModelEnableGroups", () => {
     expect(groups[0].label).toBe("Codex");
   });
 
+  it("synthesizes a locked Copilot group for opencode when no Copilot provider is registered", () => {
+    const partition = {
+      byokPlusCandidates: [
+        {
+          configuredModel: model("m-byok", "byok-1", "claude-sonnet-4-5"),
+          provider: byok,
+          enabled: true,
+        },
+      ],
+      agentOriginCandidates: [],
+    };
+
+    const groups = buildModelEnableGroups(partition, true, "");
+
+    // Same position, badge, and tooltip a licensed user's group gets — only the
+    // rows differ, and only by being unusable.
+    expect(groups[0].label).toBe("Copilot");
+    expect(groups[0].badge).toBe("privacy");
+    expect(groups[0].tooltip).toBe("Copilot license required");
+    expect(groups[0].highlight).toBe(true);
+    expect(groups[0].rows.length).toBeGreaterThan(0);
+    expect(groups[0].rows.every((row) => row.locked && !row.enabled)).toBe(true);
+  });
+
+  it("leaves the real Copilot group alone rather than adding a locked one beside it", () => {
+    const plusProvider: Provider = {
+      providerId: "plus-1",
+      providerType: "openai-compatible",
+      displayName: "Copilot",
+      origin: { kind: "copilot-plus" },
+      addedAt: 0,
+    };
+    const partition = {
+      byokPlusCandidates: [
+        {
+          configuredModel: model("m-plus", "plus-1", "copilot-plus-flash"),
+          provider: plusProvider,
+          enabled: true,
+        },
+      ],
+      agentOriginCandidates: [],
+    };
+
+    const groups = buildModelEnableGroups(partition, true, "");
+
+    expect(groups.filter((g) => g.label === "Copilot")).toHaveLength(1);
+    expect(groups[0].rows.every((row) => row.locked)).toBe(false);
+  });
+
+  it("adds no locked group for an agent that cannot route Copilot models", () => {
+    const partition = {
+      byokPlusCandidates: [],
+      agentOriginCandidates: [
+        {
+          configuredModel: model("m-cx", "cx-agent", "gpt-5-codex"),
+          provider: agentProvider("cx-agent", "codex", "Codex"),
+          enabled: true,
+        },
+      ],
+    };
+
+    const groups = buildModelEnableGroups(partition, false, "");
+
+    expect(groups.some((g) => g.rows.some((row) => row.locked))).toBe(false);
+  });
+
+  it("filters the locked rows by the search query like any others", () => {
+    const empty = { byokPlusCandidates: [], agentOriginCandidates: [] };
+
+    const matching = buildModelEnableGroups(empty, true, "flash");
+    const missing = buildModelEnableGroups(empty, true, "no-such-model");
+
+    expect(matching[0].rows.length).toBeGreaterThan(0);
+    expect(matching[0].rows.every((row) => /flash/i.test(row.label + row.wireId))).toBe(true);
+    expect(missing).toHaveLength(0);
+  });
+
   it("badges non-Plus origins when the list mixes origins (opencode)", () => {
     const plusProvider: Provider = {
       providerId: "plus-1",

--- a/src/settings/v2/components/configuredModelGrouping.test.ts
+++ b/src/settings/v2/components/configuredModelGrouping.test.ts
@@ -357,7 +357,7 @@ describe("buildModelEnableGroups", () => {
         },
       ],
     };
-    const groups = buildModelEnableGroups(partition, true, "");
+    const groups = buildModelEnableGroups(partition, true, "", false);
     const byokGroup = groups.find((g) => g.key === "byok:byok-1");
     expect(byokGroup?.label).toBe("Anthropic");
 
@@ -383,7 +383,7 @@ describe("buildModelEnableGroups", () => {
         },
       ],
     };
-    const groups = buildModelEnableGroups(partition, true, "pickle");
+    const groups = buildModelEnableGroups(partition, true, "pickle", false);
     expect(groups.map((g) => g.label)).toEqual(["opencode"]);
     expect(groups[0].rows.map((r) => r.id)).toEqual(["m-oc1"]);
   });
@@ -400,7 +400,7 @@ describe("buildModelEnableGroups", () => {
         },
       ],
     };
-    const groups = buildModelEnableGroups(partition, false, "");
+    const groups = buildModelEnableGroups(partition, false, "", false);
     expect(groups).toHaveLength(1);
     expect(groups[0].label).toBe("Codex");
   });
@@ -417,7 +417,7 @@ describe("buildModelEnableGroups", () => {
       agentOriginCandidates: [],
     };
 
-    const groups = buildModelEnableGroups(partition, true, "");
+    const groups = buildModelEnableGroups(partition, true, "", true);
 
     // Same position, badge, and tooltip a licensed user's group gets — only the
     // rows differ, and only by being unusable.
@@ -429,7 +429,7 @@ describe("buildModelEnableGroups", () => {
     expect(groups[0].rows.every((row) => row.locked && !row.enabled)).toBe(true);
   });
 
-  it("leaves the real Copilot group alone rather than adding a locked one beside it", () => {
+  it("adds no locked group once a Copilot provider is registered, whether or not it has rows yet", () => {
     const plusProvider: Provider = {
       providerId: "plus-1",
       providerType: "openai-compatible",
@@ -448,10 +448,21 @@ describe("buildModelEnableGroups", () => {
       agentOriginCandidates: [],
     };
 
-    const groups = buildModelEnableGroups(partition, true, "");
+    const withRows = buildModelEnableGroups(partition, true, "", false);
+    // Registering the provider and reconciling its models are separate writes, so
+    // a licensed user can hold the provider with nothing under it. Inferring the
+    // lock from the groups built here told exactly that user a license was
+    // required, over eight toggles they had already paid for.
+    const beforeRows = buildModelEnableGroups(
+      { byokPlusCandidates: [], agentOriginCandidates: [] },
+      true,
+      "",
+      false
+    );
 
-    expect(groups.filter((g) => g.label === "Copilot")).toHaveLength(1);
-    expect(groups[0].rows.every((row) => row.locked)).toBe(false);
+    expect(withRows.filter((g) => g.label === "Copilot")).toHaveLength(1);
+    expect(withRows[0].rows.every((row) => row.locked)).toBe(false);
+    expect(beforeRows).toHaveLength(0);
   });
 
   it("adds no locked group for an agent that cannot route Copilot models", () => {
@@ -466,7 +477,7 @@ describe("buildModelEnableGroups", () => {
       ],
     };
 
-    const groups = buildModelEnableGroups(partition, false, "");
+    const groups = buildModelEnableGroups(partition, false, "", true);
 
     expect(groups.some((g) => g.rows.some((row) => row.locked))).toBe(false);
   });
@@ -474,8 +485,8 @@ describe("buildModelEnableGroups", () => {
   it("filters the locked rows by the search query like any others", () => {
     const empty = { byokPlusCandidates: [], agentOriginCandidates: [] };
 
-    const matching = buildModelEnableGroups(empty, true, "flash");
-    const missing = buildModelEnableGroups(empty, true, "no-such-model");
+    const matching = buildModelEnableGroups(empty, true, "flash", true);
+    const missing = buildModelEnableGroups(empty, true, "no-such-model", true);
 
     expect(matching[0].rows.length).toBeGreaterThan(0);
     expect(matching[0].rows.every((row) => /flash/i.test(row.label + row.wireId))).toBe(true);
@@ -511,7 +522,7 @@ describe("buildModelEnableGroups", () => {
         },
       ],
     };
-    const groups = buildModelEnableGroups(partition, true, "");
+    const groups = buildModelEnableGroups(partition, true, "", false);
     expect(groups.find((g) => g.key === "byok:byok-1")?.badge).toBe("BYOK");
     expect(groups.find((g) => g.label === "opencode")?.badge).toBe("Agent Provided");
   });
@@ -545,7 +556,7 @@ describe("buildModelEnableGroups", () => {
         },
       ],
     };
-    const groups = buildModelEnableGroups(partition, true, "");
+    const groups = buildModelEnableGroups(partition, true, "", false);
     // Copilot Plus is first regardless of candidate order.
     expect(groups[0].key).toBe("byok:plus-1");
     expect(groups[0].highlight).toBe(true);
@@ -567,7 +578,7 @@ describe("buildModelEnableGroups", () => {
         },
       ],
     };
-    const groups = buildModelEnableGroups(partition, false, "");
+    const groups = buildModelEnableGroups(partition, false, "", false);
     expect(groups[0].badge).toBeUndefined();
   });
 });

--- a/src/settings/v2/components/configuredModelGrouping.ts
+++ b/src/settings/v2/components/configuredModelGrouping.ts
@@ -169,11 +169,18 @@ interface OriginGroup {
  * Each group maps to a single origin, so when the list spans more than one
  * origin (opencode mixes BYOK/Plus/agent) we tag every group with an origin
  * badge to disambiguate; a single-origin list (claude/codex) gets none.
+ *
+ * @param copilotProviderMissing - Whether no Copilot provider is registered,
+ *   which is when the lineup is worth advertising as a locked group. The caller
+ *   answers it because only it can see the provider rows — and the answer is not
+ *   inferable from the groups built here, since registering the provider and
+ *   reconciling its models are separate writes.
  */
 export function buildModelEnableGroups(
   partition: CandidatePartition,
   isOpencode: boolean,
-  query: string
+  query: string,
+  copilotProviderMissing: boolean
 ): ModelEnableGroup[] {
   const q = query.trim().toLowerCase();
   const out: OriginGroup[] = [];
@@ -220,7 +227,7 @@ export function buildModelEnableGroups(
   // below apply to it unchanged — a locked group is the same group, minus the
   // ability to act on it. Only opencode can route these models, and only its
   // list mixes in non-agent providers at all.
-  if (isOpencode && !out.some((o) => o.kind === "copilot-plus")) {
+  if (isOpencode && copilotProviderMissing) {
     const rows = COPILOT_PLUS_MODELS.map(
       (model): ModelEnableRow => ({
         id: `__locked_copilot__${model.id}`,

--- a/src/settings/v2/components/configuredModelGrouping.ts
+++ b/src/settings/v2/components/configuredModelGrouping.ts
@@ -2,6 +2,7 @@
 
 import { isOpencodeZenWireId, type ModelEnableGroup, type ModelEnableRow } from "@/agentMode";
 import {
+  COPILOT_PLUS_MODELS,
   capabilitiesFromConfiguredInfo,
   type ConfiguredModel,
   type Provider,
@@ -211,6 +212,31 @@ export function buildModelEnableGroups(
   }
   for (const [label, { rows }] of bySubGroup) {
     out.push({ group: { key: `agent:${label}`, label, rows }, kind: "agent" });
+  }
+
+  // No Copilot provider means no license, which is exactly when the lineup is
+  // worth advertising: synthesize the group so it is discoverable instead of
+  // absent. Tagged `copilot-plus` so the highlight, badge, tooltip, and float
+  // below apply to it unchanged — a locked group is the same group, minus the
+  // ability to act on it. Only opencode can route these models, and only its
+  // list mixes in non-agent providers at all.
+  if (isOpencode && !out.some((o) => o.kind === "copilot-plus")) {
+    const rows = COPILOT_PLUS_MODELS.map(
+      (model): ModelEnableRow => ({
+        id: `__locked_copilot__${model.id}`,
+        label: model.displayName || model.id,
+        description: model.description,
+        wireId: model.id,
+        enabled: false,
+        locked: true,
+      })
+    ).filter((row) => rowMatches(row, q));
+    if (rows.length > 0) {
+      out.push({
+        group: { key: "locked:copilot-plus", label: "Copilot", rows },
+        kind: "copilot-plus",
+      });
+    }
   }
 
   // Copilot Plus is highlighted and floated to the top; its provider name


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#283

## Why

Open the Agent Mode model picker without a license and you see the models OpenCode reports, plus anything you added with your own API key. Nothing else. Not a greyed row, not a badge — the Copilot models are simply absent, because `syncCopilotPlusProvider` registers the Copilot provider only for a paying user and unregisters it otherwise, which cascade-removes its configured models and their enrollment. A picker built from settings has nothing Copilot left to draw.

So the eight models a license includes are invisible to exactly the people who have not bought one. The only Plus upsell in Agent Mode pitches a different feature ("Mention multiple agents with @"), and the `"Copilot license required"` tooltip that already exists in the settings model list decorates a provider group that, without a license, does not exist.

The docs did not cover for it either: they named Copilot Plus Flash as "a built-in model" and stopped there, while the relay serves eight. The built-in chat-model table in `models-and-parameters.md` was worse — it named seven models that no longer exist and omitted eight that do.

## What

The pickers now advertise the lineup when it is absent.

| Surface | Before | After (no license) | After (licensed) |
| --- | --- | --- | --- |
| Agent Mode picker, OpenCode section | your models only | three Copilot rows on top, greyed, locked | unchanged — real Copilot rows |
| Agent Mode picker, Claude Code / Codex | your models only | unchanged | unchanged |
| Quick Chat picker | your models only | same three rows on top | unchanged |
| Quick Chat with no models at all | "No models — enable in…" | the three rows, then that same guidance | unchanged |
| Locked row's right-side label | — | none; the lock carries the reason | — |

Each locked row shows the model's name, the relay's own one-line description as a subtitle, and a lock icon whose hover reads **"Copilot license required"**. The rows are non-selectable: clicking does nothing, and keyboard navigation skips them.

> **Before:** a new user opens the picker, sees two models they set up themselves, and has no way to learn a license would add more.
>
> **After:** the same picker leads with Copilot Plus Flash, DeepSeek V4 Pro, and GLM-5.2 — locked, described, and unmistakably on offer.

Three deliberate choices are worth the reviewer's attention:

**It previews the three a license switches on, not all eight.** The preview then matches the outcome — activate, and the locks come off the same rows in the same order rather than being replaced by a different set — and the user's own models keep their place above the fold of a 288px picker.

**Rows are synthesized per render and never persisted.** They are not `Provider` or `ConfiguredModel` rows, so nothing can select, enroll, seed, or default to one; a licensed user never sees them because the real models are there instead.

**The gate is "no Copilot provider registered", not `!isPaidUser`.** The two agree in practice, but only the first is the question these rows answer, and a license state that had not resolved while the provider was still registered would otherwise put locked copies beside the models they advertise.

The docs now list all eight models, name the three that are on by default, say where they appear in each picker, and describe the locked state.

`models-and-parameters.md` also loses the parts v4 removed. The built-in chat-model table is gone rather than refreshed — a hand-maintained list of 25 names cannot stay true, and three model bumps landed in this branch's own base — so the doc names the providers covered and points at the live list in **Settings → Models (BYOK)**. Its "Embedding Models" and "Model Parameters" sections are gone too: they sent readers to a QA tab and a Model tab that no longer exist, for an embedding picker and parameter editors that no longer exist either. What remains is accurate, so the file stays, retitled **Models**, with its index entry and inbound links updated.

## Non goal

- Locked rows are not clickable through to the plans page; that needs an action escape hatch in the shared `ModelSelector`, which every picker in the app consumes.
- No provider or configured model is registered without a license — that would make unusable models selectable and let license-time seeding point at one.
- Nothing changes for a licensed user in any picker.
- The relay's lineup, model ids, and descriptions are untouched.
- No upsell is added to Claude Code or Codex, whose models come from their own subscriptions.
- `vault-search-and-indexing.md` still discusses embedding models and their cost; auditing what semantic search means under Miyo is its own change.

## Screenshot

No image embedded — attaching one needs GitHub's browser editor rather than the API. The states are reviewable in the component gallery instead, which is where the change was designed:

```bash
npm run gallery:vault   # then open the gallery view and pick UI/Model Selector
```

`UI/Model Selector` carries three stories: `Licensed` (your models, nothing locked), `Unlicensed` (the locked rows leading the section — open the picker, then hover a lock), and `UnlicensedWithNoModelsOfTheirOwn` (the brand-new-user case). Story fixtures are literal rather than built from the production helper, so the states stay put if the lineup changes.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `lockedCopilotEntries.test.ts` covers the row contents and the provider gate; `agentModelPickerHelpers.test.ts` covers placement, per-agent eligibility, the licensed case, and that locked rows do not suppress the loading placeholder; `ModelSelector.test.tsx` opens the menu and asserts the lock renders with no right-side label |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a wrong result is a visible row in the first picker anyone opens |
| A revert fully restores prior state, including persisted data | ✅ | Nothing is written — the rows exist only for the duration of a render |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Reads the provider list; no credential path touched |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `BackendDescriptor.routesCopilotModels` is internal to Agent Mode and all three implementers are updated in this diff; `_needsLicense` is an optional field on an internal picker type |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Pure synthesis inside existing render paths |
| No hot-path behavior lacks deterministic coverage | ✅ | Every branch of the synthesizer, the gate, and the placement is covered |
| No new dependency | ✅ | Dependency manifests unchanged; the lock is a lucide icon already bundled |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the two model pickers, visible immediately |

Review: skim `src/lib/lockedCopilotEntries.ts` for what a row is and when it appears, then run Verification step 1. If you only read one hunk, read the splice in `buildPickerEntries` — its position after the readiness and self-host passes is what keeps a locked row from being relabelled with the wrong reason.

## Verification

1. In a vault with no license, open the Agent Mode composer's model picker. Copilot Plus Flash, DeepSeek V4 Pro, and GLM-5.2 lead the OpenCode section, greyed, each with a lock and a one-line description. Hover a lock: "Copilot license required". Click a locked row and arrow through the list — neither can select one.
2. Confirm the Claude Code and Codex sections show only their own models, with no locked rows.
3. Open the Quick Chat model picker and confirm the same three rows lead it.
4. Enter a valid license key. Both pickers now show the real Copilot models — no locks, no duplicates, and the rows sit where the locked ones did.
5. Remove the license key. The locked rows come back and the real ones go.
6. Read the **Models included with your license** section of `docs/copilot-plus-and-self-host.md` and confirm all eight models are listed with the three defaults called out.
7. Open **Settings → Copilot → Models (BYOK)** and confirm the built-in models it offers match what `docs/models-and-parameters.md` now describes — providers, not a fixed list of names.
8. Read that doc end to end and confirm every settings path it names exists: there is no QA tab, no Model tab, and no embedding-model picker to send anyone to.

## Note

The lock says what is missing but cannot say where to fix it — a disabled row is unclickable by construction (`ModelEffortPicker` filters selection on `!_disabledReason`). Making the row navigate to the plans page is the obvious next step for conversion and is listed as a non-goal here because it changes a component every picker shares. If the funnel wants it, the cheaper half is the settings model list, which renders rows rather than a select and can carry a real link without touching shared components.
