### PR TITLE
Give vault instructions editor the full settings width

### DIFF
--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -13,7 +13,6 @@ import { cn } from "@/lib/utils";
 import { verifyMiyoScope } from "@/miyo/miyoResync";
 import { shouldSurfaceMiyoResync } from "@/miyo/miyoUtils";
 import { openAgentsFile, writeAgentsFile } from "@/instructions/agentsFile";
-import { InstructionsTextarea } from "@/instructions/InstructionsTextarea";
 import { useAgentsFileDraft } from "@/instructions/useAgentsFileDraft";
 import { logError } from "@/logger";
 import { debounce } from "@/utils/debounce";
@@ -33,10 +32,11 @@ import {
 import { DesktopOnlySettingsPanel } from "@/settings/v2/components/DesktopOnlySettingsPanel";
 import { LegacyChatPromptsNotice } from "@/settings/v2/components/LegacyChatPromptsNotice";
 import { PlusSettings } from "@/settings/v2/components/PlusSettings";
+import { VaultInstructionsSetting } from "@/settings/v2/components/VaultInstructionsSetting";
 import { formatDateTime } from "@/utils";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { revealFolderInExplorer } from "@/utils/revealFolderInExplorer";
-import { ArrowUpRight, Folder, FolderSync, Loader2 } from "lucide-react";
+import { Folder, FolderSync, Loader2 } from "lucide-react";
 import { Notice } from "obsidian";
 import React, { useEffect, useMemo, useState } from "react";
 
@@ -371,30 +371,15 @@ export const BasicSettings: React.FC = () => {
       <SettingSection label="Custom instructions">
         <LegacyChatPromptsNotice />
         {vaultInstructions !== null && (
-          <SettingItem
-            type="custom"
-            // Rows are vertically centered by default, which leaves the label floating beside
-            // the middle of an editor this tall.
-            className="sm:tw-items-start"
-            title="Custom vault instructions"
-            description="Your custom instructions for the agent to follow for every vault interaction. Saved to AGENTS.md in your vault root, which you can also edit as a note."
-          >
-            <div className="tw-flex tw-w-full tw-flex-col tw-items-end tw-gap-2">
-              <InstructionsTextarea
-                label="Custom vault instructions"
-                value={vaultInstructions}
-                onChange={(next) => {
-                  setVaultInstructions(next);
-                  // Typing never waits on the write; only Open does, via `flush()`.
-                  void saveVaultInstructions(next);
-                }}
-              />
-              <Button variant="secondary" onClick={() => void handleOpenVaultInstructions()}>
-                <ArrowUpRight className="tw-size-4" />
-                Open AGENTS.md
-              </Button>
-            </div>
-          </SettingItem>
+          <VaultInstructionsSetting
+            value={vaultInstructions}
+            onChange={(next) => {
+              setVaultInstructions(next);
+              // Typing never waits on the write; only Open does, via `flush()`.
+              void saveVaultInstructions(next);
+            }}
+            onOpen={() => void handleOpenVaultInstructions()}
+          />
         )}
       </SettingSection>
 

--- a/src/settings/v2/components/VaultInstructionsSetting.stories.tsx
+++ b/src/settings/v2/components/VaultInstructionsSetting.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@/lib/story";
 import {
   VaultInstructionsSetting,
   type VaultInstructionsSettingProps,
-} from "@/settings/v2/components/VaultInstructionsSetting";
+} from "./VaultInstructionsSetting";
 
 const meta = {
   title: "Settings/Vault Instructions Setting",

--- a/src/settings/v2/components/VaultInstructionsSetting.stories.tsx
+++ b/src/settings/v2/components/VaultInstructionsSetting.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import {
+  VaultInstructionsSetting,
+  type VaultInstructionsSettingProps,
+} from "@/settings/v2/components/VaultInstructionsSetting";
+
+const meta = {
+  title: "Settings/Vault Instructions Setting",
+  component: VaultInstructionsSetting,
+  args: {
+    value:
+      "Put new notes in Inbox/ and link them to a related note.\n\nAsk before editing anything under Archive/.",
+    onChange: () => {},
+    onOpen: () => {},
+  },
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<VaultInstructionsSettingProps>;
+export default meta;
+
+export const Default: StoryObj<VaultInstructionsSettingProps> = {};

--- a/src/settings/v2/components/VaultInstructionsSetting.test.tsx
+++ b/src/settings/v2/components/VaultInstructionsSetting.test.tsx
@@ -1,0 +1,44 @@
+import { VaultInstructionsSetting } from "@/settings/v2/components/VaultInstructionsSetting";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+describe("VaultInstructionsSetting", () => {
+  describe("VaultInstructionsSetting()", () => {
+    it("places the file action beside the description and the full-width editor underneath", () => {
+      render(
+        <VaultInstructionsSetting
+          value="Cite every source."
+          onChange={jest.fn()}
+          onOpen={jest.fn()}
+        />
+      );
+
+      const title = screen.getByText("Custom vault instructions");
+      const openButton = screen.getByRole("button", { name: "Open AGENTS.md" });
+      const editor = screen.getByRole<HTMLTextAreaElement>("textbox", {
+        name: "Custom vault instructions",
+      });
+      const headerRow = title.parentElement?.parentElement;
+
+      expect(headerRow).not.toBeNull();
+      expect(headerRow?.contains(openButton)).toBe(true);
+      expect(headerRow?.contains(editor)).toBe(false);
+      expect(editor.parentElement).toBe(headerRow?.parentElement);
+      expect(editor.classList.contains("tw-w-full")).toBe(true);
+    });
+
+    it("forwards editor changes and the open action", () => {
+      const onChange = jest.fn();
+      const onOpen = jest.fn();
+      render(<VaultInstructionsSetting value="" onChange={onChange} onOpen={onOpen} />);
+
+      fireEvent.change(screen.getByRole("textbox", { name: "Custom vault instructions" }), {
+        target: { value: "Use short filenames." },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Open AGENTS.md" }));
+
+      expect(onChange).toHaveBeenCalledWith("Use short filenames.");
+      expect(onOpen).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/settings/v2/components/VaultInstructionsSetting.tsx
+++ b/src/settings/v2/components/VaultInstructionsSetting.tsx
@@ -1,0 +1,36 @@
+import { Button } from "@/components/ui/button";
+import { InstructionsTextarea } from "@/instructions/InstructionsTextarea";
+import { ArrowUpRight } from "lucide-react";
+import React from "react";
+
+export interface VaultInstructionsSettingProps {
+  value: string;
+  onChange: (next: string) => void;
+  onOpen: () => void;
+}
+
+/**
+ * Presents vault-wide agent instructions while leaving vault file operations to its host.
+ */
+export const VaultInstructionsSetting: React.FC<VaultInstructionsSettingProps> = ({
+  value,
+  onChange,
+  onOpen,
+}) => (
+  <div className="tw-flex tw-w-full tw-flex-col tw-gap-4 tw-py-4">
+    <div className="tw-grid tw-w-full tw-grid-cols-[minmax(0,1fr)_auto] tw-items-center tw-gap-4">
+      <div className="tw-space-y-1.5">
+        <div className="tw-text-sm tw-font-medium tw-leading-none">Custom vault instructions</div>
+        <div className="tw-text-xs tw-text-muted">
+          Your custom instructions for the agent to follow for every vault interaction. Saved to
+          AGENTS.md in your vault root, which you can also edit as a note.
+        </div>
+      </div>
+      <Button variant="secondary" onClick={onOpen}>
+        <ArrowUpRight className="tw-size-4" />
+        Open AGENTS.md
+      </Button>
+    </div>
+    <InstructionsTextarea label="Custom vault instructions" value={value} onChange={onChange} />
+  </div>
+);


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#238

## Why

In **Settings → Copilot → Basic → Custom instructions**, the vault instruction editor sits only in the right-hand control column. Because the editor is tall, the title and description occupy the top-left while a large blank area remains beneath them, making the setting feel lopsided and reducing the useful editing width.

## What

The setting now uses a compact header with the title and description on the left and **Open AGENTS.md** on the right. The instruction editor spans the full card width underneath.

> **Before:** The textarea is constrained to the right-hand settings column, leaving unused space below the label.
>
> **After:** The label and file action share the header, and the textarea uses the full row below it.

## Non goal

This does not change AGENTS.md loading, debounced saving, the save-before-open behavior, project instruction editing, instruction migration, discovery, or backend prompt behavior.

## Screenshot

**Before**

<img width="900" height="700" alt="vault-instructions-before" src="https://github.com/user-attachments/assets/0e53e9cf-b841-407a-865b-90cafda241a6" />

**After**

<img width="900" height="700" alt="vault-instructions-after" src="https://github.com/user-attachments/assets/22bcf56c-23fb-4ace-86a1-d3fb72294c6b" />

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | This is a settings-layout change, and the component test covers the header/editor structure plus both callbacks |
| A defect would fail CI or be obvious on first use | ✅ | The structural test runs in CI, and an incorrect column layout is immediately visible in Custom instructions |
| A revert fully restores prior state, including persisted data | ✅ | The change does not migrate or rewrite stored instructions |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing change and open callbacks are passed through unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The AGENTS.md contract and plugin interfaces are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Only the presentational boundary changes; Basic settings retains its existing save/open orchestration |
| No hot-path behavior lacks deterministic coverage | ✅ | This settings-only component is not a hot path, and its interactions are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The visual result is confined to one Basic settings card and appears as soon as it is opened |

Review: skim `src/settings/v2/components/VaultInstructionsSetting.tsx` — `VaultInstructionsSetting` — then run Verification steps 2–4.

## Verification

1. Deploy the PR branch to the configured test vault with `npm run test:vault`.
2. Open **Settings → Copilot → Basic** and scroll to **Custom instructions**.
3. Confirm the title and description sit on the left, **Open AGENTS.md** sits on the right, and the textarea spans the full card width underneath without horizontal overflow.
4. Type in the editor, then select **Open AGENTS.md** and confirm the latest text is present in the opened note.
