### PR TITLE
[Obsidian review blockers] - Step 1: Guard desktop runtime access

### DIFF
--- a/src/LLMProviders/BedrockChatModel.ts
+++ b/src/LLMProviders/BedrockChatModel.ts
@@ -1,7 +1,5 @@
-// Reason: `buffer` is the npm polyfill (browser-compatible), bundled by esbuild
-// so the same Buffer code path works on desktop (Electron) and mobile (WebView).
-// eslint-disable-next-line import/no-nodejs-modules
-import { Buffer } from "buffer";
+// The trailing slash resolves the browser-compatible npm package instead of Node's built-in.
+import { Buffer } from "buffer/";
 
 import {
   BaseChatModel,

--- a/src/agentMode/acp/AcpProcessManager.ts
+++ b/src/agentMode/acp/AcpProcessManager.ts
@@ -1,6 +1,11 @@
 import { logError, logInfo, logWarn } from "@/logger";
-import { ChildProcessByStdio, spawn } from "node:child_process";
-import { Readable, Writable } from "node:stream";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+type Readable = import("node:stream").Readable;
+type Writable = import("node:stream").Writable;
+
+const { spawn } = requireDesktopModule<typeof import("node:child_process")>("node:child_process");
+const { Readable, Writable } = requireDesktopModule<typeof import("node:stream")>("node:stream");
 
 const SIGTERM_GRACE_MS = 3_000;
 
@@ -25,7 +30,9 @@ export interface AcpProcessManagerOptions {
  * graceful SIGTERM→SIGKILL teardown.
  */
 export class AcpProcessManager {
-  private child: ChildProcessByStdio<Writable, Readable, Readable> | null = null;
+  private child:
+    | import("node:child_process").ChildProcessByStdio<Writable, Readable, Readable>
+    | null = null;
   private exitListeners = new Set<(code: number | null, signal: NodeJS.Signals | null) => void>();
   private hasExited = false;
   private exitCode: number | null = null;

--- a/src/agentMode/acp/VaultClient.ts
+++ b/src/agentMode/acp/VaultClient.ts
@@ -12,7 +12,9 @@ import type {
 import { RequestError } from "@agentclientprotocol/sdk";
 import { logInfo, logWarn } from "@/logger";
 import { App, FileSystemAdapter, normalizePath } from "obsidian";
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 
 export interface PermissionPrompter {
   (req: RequestPermissionRequest): Promise<RequestPermissionResponse>;

--- a/src/agentMode/acp/nodeShebangPath.ts
+++ b/src/agentMode/acp/nodeShebangPath.ts
@@ -1,4 +1,6 @@
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 
 import { detectionSearchDirs, mergePath } from "@/utils/binaryPath";
 

--- a/src/agentMode/backends/claude/claudeAuth.ts
+++ b/src/agentMode/backends/claude/claudeAuth.ts
@@ -9,11 +9,15 @@
  * listener, and persisting credentials to the OS keychain. We never read or
  * write the token ourselves; we only invoke the CLI and re-read its status.
  */
-import { execFile, spawn } from "node:child_process";
-import { type Readable } from "node:stream";
-import { promisify } from "node:util";
 import { logInfo, logWarn } from "@/logger";
 import { err2String } from "@/utils";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+type Readable = import("node:stream").Readable;
+
+const { execFile, spawn } =
+  requireDesktopModule<typeof import("node:child_process")>("node:child_process");
+const { promisify } = requireDesktopModule<typeof import("node:util")>("node:util");
 
 const execFileAsync = promisify(execFile);
 

--- a/src/agentMode/backends/claude/claudeBinaryResolver.ts
+++ b/src/agentMode/backends/claude/claudeBinaryResolver.ts
@@ -10,7 +10,9 @@
  * Pure leaf: callers inject `homeDir`, `platform`, `env`, and `fs` so tests
  * don't touch real disk.
  */
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 
 import { WELL_KNOWN_BIN_DIRS } from "@/utils/binaryPath";
 import { nodeToolBinDirCandidates, type NodeToolFs } from "@/utils/nodeToolBinDirs";

--- a/src/agentMode/backends/claude/claudeVersion.ts
+++ b/src/agentMode/backends/claude/claudeVersion.ts
@@ -1,6 +1,9 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { compareSemver } from "@/utils/semver";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const { execFile } =
+  requireDesktopModule<typeof import("node:child_process")>("node:child_process");
+const { promisify } = requireDesktopModule<typeof import("node:util")>("node:util");
 
 const execFileAsync = promisify(execFile);
 const VERSION_TIMEOUT_MS = 10_000;

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -1,6 +1,8 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+const os = requireDesktopModule<typeof import("node:os")>("node:os");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 import { logWarn } from "@/logger";
 import type CopilotPlugin from "@/main";
 import {

--- a/src/agentMode/backends/codex/codexBinaryResolver.ts
+++ b/src/agentMode/backends/codex/codexBinaryResolver.ts
@@ -4,7 +4,9 @@
  * Agent Mode's no-shell ACP process path, so this resolver probes native
  * `.exe` locations first and only falls back to the generic PATH detector.
  */
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 
 import { nodeToolBinDirCandidates, type NodeToolFs } from "@/utils/nodeToolBinDirs";
 

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -1,5 +1,7 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+const os = requireDesktopModule<typeof import("node:os")>("node:os");
 import type CopilotPlugin from "@/main";
 import {
   subscribeToSettingsChange,

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -2,6 +2,7 @@ jest.mock("obsidian", () => ({
   // pickMatchingAsset is pure; FileSystemAdapter and requestUrl are
   // referenced by the manager class but not by these tests.
   FileSystemAdapter: class {},
+  Platform: { isDesktop: true, isDesktopApp: true, isMobile: false },
   requestUrl: jest.fn(),
 }));
 

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -4,20 +4,24 @@ import { compareSemver } from "@/utils/semver";
 import { logError, logInfo, logWarn } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { getSettings, setSettings, type OpencodeBackendSettings } from "@/settings/model";
-import { execFile, spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
-import * as fs from "node:fs";
-import * as https from "node:https";
-import { IncomingMessage } from "node:http";
 import { FileSystemAdapter, requestUrl } from "obsidian";
-import * as os from "node:os";
-import * as path from "node:path";
-import { promisify } from "node:util";
 import { renameWithRetry } from "@/agentMode/skills/renameWithRetry";
 import { copilotAppDataDir } from "@/utils/appPaths";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
 import { detectOpencodeCliPath } from "./opencodeCliDetector";
 import { expectedBinaryName, resolveOpencodeTarget } from "./platformResolver";
 import type { InstallState as BackendInstallState } from "@/agentMode/session/types";
+
+type IncomingMessage = import("node:http").IncomingMessage;
+
+const { execFile, spawn } =
+  requireDesktopModule<typeof import("node:child_process")>("node:child_process");
+const { randomBytes } = requireDesktopModule<typeof import("node:crypto")>("node:crypto");
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+const https = requireDesktopModule<typeof import("node:https")>("node:https");
+const os = requireDesktopModule<typeof import("node:os")>("node:os");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
+const { promisify } = requireDesktopModule<typeof import("node:util")>("node:util");
 
 const execFileAsync = promisify(execFile);
 const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000;
@@ -879,7 +883,7 @@ async function removeDir(p: string): Promise<void> {
 
 /** Recursively sum the byte size of all files under `dir`; 0 if it's absent. */
 async function dirSize(dir: string): Promise<number> {
-  let entries: fs.Dirent[];
+  let entries: import("node:fs").Dirent[];
   try {
     entries = await fs.promises.readdir(dir, { withFileTypes: true });
   } catch {

--- a/src/agentMode/backends/opencode/opencodeBinaryResolver.ts
+++ b/src/agentMode/backends/opencode/opencodeBinaryResolver.ts
@@ -9,7 +9,9 @@
  * never emit `.cmd` / `.bat` / `.ps1` shims — ACP spawns over stdio without
  * `shell: true`, so those break stream-json.
  */
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 
 import { WELL_KNOWN_BIN_DIRS } from "@/utils/binaryPath";
 import { nodeToolBinDirCandidates, type NodeToolFs } from "@/utils/nodeToolBinDirs";

--- a/src/agentMode/backends/opencode/opencodeCliDetector.ts
+++ b/src/agentMode/backends/opencode/opencodeCliDetector.ts
@@ -1,6 +1,8 @@
 import { detectBinary } from "@/utils/detectBinary";
-import * as fs from "node:fs";
-import * as os from "node:os";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+const os = requireDesktopModule<typeof import("node:os")>("node:os");
 import { resolveOpencodeBinary } from "./opencodeBinaryResolver";
 
 /**

--- a/src/agentMode/backends/opencode/platformResolver.ts
+++ b/src/agentMode/backends/opencode/platformResolver.ts
@@ -1,6 +1,9 @@
-import { execFile as execFileCb } from "node:child_process";
-import * as fs from "node:fs";
-import { promisify } from "node:util";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const { execFile: execFileCb } =
+  requireDesktopModule<typeof import("node:child_process")>("node:child_process");
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+const { promisify } = requireDesktopModule<typeof import("node:util")>("node:util");
 
 const execFile = promisify(execFileCb);
 

--- a/src/agentMode/backends/registry.test.ts
+++ b/src/agentMode/backends/registry.test.ts
@@ -23,7 +23,7 @@ jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError:
 jest.mock("obsidian", () => ({
   Modal: class {},
   Notice: class {},
-  Platform: { isMobile: false },
+  Platform: { isDesktop: true, isDesktopApp: true, isMobile: false },
 }));
 
 describe("backendRegistry", () => {

--- a/src/agentMode/backends/shared/builtinSkillEnv.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.ts
@@ -1,4 +1,6 @@
-import * as os from "node:os";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const os = requireDesktopModule<typeof import("node:os")>("node:os");
 import { BREVILABS_API_BASE_URL } from "@/constants";
 import { getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";

--- a/src/agentMode/backends/shared/obsidianCliPath.ts
+++ b/src/agentMode/backends/shared/obsidianCliPath.ts
@@ -1,5 +1,7 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 
 export const COPILOT_OBSIDIAN_CLI_ENV = "COPILOT_OBSIDIAN_CLI";
 

--- a/src/agentMode/backends/shared/simpleBinaryBackend.ts
+++ b/src/agentMode/backends/shared/simpleBinaryBackend.ts
@@ -1,4 +1,6 @@
-import * as fs from "node:fs";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
 import type { App } from "obsidian";
 import type CopilotPlugin from "@/main";
 import { AcpBackendProcess } from "@/agentMode/acp/AcpBackendProcess";

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -1,6 +1,8 @@
 import { type App, Platform } from "obsidian";
-import os from "node:os";
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const os = requireDesktopModule<typeof import("node:os")>("node:os");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 import type CopilotPlugin from "@/main";
 import { logError } from "@/logger";
 import { getSettings, subscribeToSettingsChange, type CopilotSettings } from "@/settings/model";

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -22,9 +22,12 @@ import {
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { App } from "obsidian";
-import { access, readFile } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const { access, readFile } =
+  requireDesktopModule<typeof import("node:fs/promises")>("node:fs/promises");
+const os = requireDesktopModule<typeof import("node:os")>("node:os");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 import { v4 as uuidv4 } from "uuid";
 import { translateBackendState } from "@/agentMode/session/translateBackendState";
 import { parseClaudeTranscript } from "./claudeSessionTranscript";

--- a/src/agentMode/session/debugSink.ts
+++ b/src/agentMode/session/debugSink.ts
@@ -5,6 +5,8 @@
  * land in the same NDJSON file. `tag` distinguishes the source.
  */
 
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
 export interface FrameRecord {
   ts: string;
   dir: "→" | "←";
@@ -308,14 +310,10 @@ export function getFrameLogPaths(vaultBasePath: string, runtime: NodeRuntime): F
 
 function getNodeRuntime(): NodeRuntime | null {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const fs = require("node:fs/promises") as typeof import("node:fs/promises");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const os = require("node:os") as typeof import("node:os");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const path = require("node:path") as typeof import("node:path");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const electron = require("electron") as {
+    const fs = requireDesktopModule<typeof import("node:fs/promises")>("node:fs/promises");
+    const os = requireDesktopModule<typeof import("node:os")>("node:os");
+    const path = requireDesktopModule<typeof import("node:path")>("node:path");
+    const electron = requireDesktopModule<{
       shell?: {
         openPath?: (path: string) => Promise<string>;
         showItemInFolder?: (path: string) => void;
@@ -326,7 +324,7 @@ function getNodeRuntime(): NodeRuntime | null {
           showItemInFolder?: (path: string) => void;
         };
       };
-    };
+    }>("electron");
     const shell = electron.shell ?? electron.remote?.shell;
     return {
       tmpdir: () => os.tmpdir(),

--- a/src/agentMode/session/nodeFileStorage.ts
+++ b/src/agentMode/session/nodeFileStorage.ts
@@ -1,5 +1,8 @@
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const { mkdir, readFile, stat, writeFile } =
+  requireDesktopModule<typeof import("node:fs/promises")>("node:fs/promises");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 import type { AgentSessionIndexStorage } from "./AgentSessionIndex";
 
 /**

--- a/src/agentMode/session/sessionScope.ts
+++ b/src/agentMode/session/sessionScope.ts
@@ -1,4 +1,6 @@
-import { dirname, join } from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const nodePath = requireDesktopModule<typeof import("node:path")>("node:path");
 import { getCachedProjectRecordById, getCachedProjectRecords } from "@/projects/state";
 import { GLOBAL_SCOPE, type ProjectScopeId } from "@/agentMode/session/scope";
 
@@ -29,7 +31,7 @@ export function resolveScopeCwd(vaultBasePath: string, projectId: ProjectScopeId
   if (!record) throw new OrphanedProjectError(projectId);
   // Reason: project folders live at `dirname(config)`; a config sitting at the
   // vault root yields ".", which join() collapses back to the vault root.
-  return join(vaultBasePath, dirname(record.filePath));
+  return nodePath.join(vaultBasePath, nodePath.dirname(record.filePath));
 }
 
 /** Whether `projectId` still resolves to a live scope (global is always live). */
@@ -51,7 +53,7 @@ export function resolveProjectIdForCwd(vaultBasePath: string, cwd: string): stri
   const target = norm(cwd);
   if (target === norm(vaultBasePath)) return undefined;
   for (const record of getCachedProjectRecords()) {
-    if (target === norm(join(vaultBasePath, dirname(record.filePath)))) {
+    if (target === norm(nodePath.join(vaultBasePath, nodePath.dirname(record.filePath)))) {
       return record.project.id;
     }
   }

--- a/src/agentMode/skills/nodeFsAdapters.ts
+++ b/src/agentMode/skills/nodeFsAdapters.ts
@@ -1,6 +1,8 @@
 import { logWarn } from "@/logger";
-import * as fs from "node:fs";
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 import type { ProjectDiscoveryFs } from "./discoverProjectSkills";
 import type { MigrateSkillFs } from "./migrateProjectSkill";
 import { errCode } from "@/utils/errorUtils";

--- a/src/agentMode/skills/renameWithRetry.ts
+++ b/src/agentMode/skills/renameWithRetry.ts
@@ -1,4 +1,6 @@
-import * as fs from "node:fs";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
 
 /**
  * Retry-aware `fs.rename`. Windows commonly fails the first attempt when

--- a/src/agentMode/ui/ReportIssueModal.tsx
+++ b/src/agentMode/ui/ReportIssueModal.tsx
@@ -4,7 +4,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
 import { logError, logInfo } from "@/logger";
 import { captureViewScreenshot } from "@/utils/captureViewScreenshot";
-import { isDesktopRuntime } from "@/utils/desktopRuntime";
+import { isDesktopRuntime, requireDesktopModule } from "@/utils/desktopRuntime";
 import { assembleReportBundle, type ReportEnvInfo } from "@/utils/issueReport";
 import { findLatestOpencodeLog } from "@/utils/opencodeLog";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
@@ -40,10 +40,9 @@ interface ElectronShell {
 
 function getElectronShell(): ElectronShell | null {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const electron = require("electron") as
-      | { shell?: ElectronShell; remote?: { shell?: ElectronShell } }
-      | undefined;
+    const electron = requireDesktopModule<
+      { shell?: ElectronShell; remote?: { shell?: ElectronShell } } | undefined
+    >("electron");
     return electron?.shell ?? electron?.remote?.shell ?? null;
   } catch {
     return null;
@@ -52,10 +51,8 @@ function getElectronShell(): ElectronShell | null {
 
 function reportsRootDir(): string | null {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const os = require("node:os") as typeof import("node:os");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const path = require("node:path") as typeof import("node:path");
+    const os = requireDesktopModule<typeof import("node:os")>("node:os");
+    const path = requireDesktopModule<typeof import("node:path")>("node:path");
     return path.join(os.tmpdir(), "obsidian-copilot", "reports");
   } catch {
     return null;
@@ -258,8 +255,7 @@ export class ReportIssueModal extends Modal {
 
 async function resolveOpencodeLogPath(): Promise<string | null> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const os = require("node:os") as typeof import("node:os");
+    const os = requireDesktopModule<typeof import("node:os")>("node:os");
     // Resolve the log dir from the same env OpencodeBackend spawns opencode with:
     // user env overrides (e.g. XDG_DATA_HOME / HOME) relocate opencode's data dir,
     // so the log lives wherever the merged env points, not the ambient one.

--- a/src/context/contextCacheFs.ts
+++ b/src/context/contextCacheFs.ts
@@ -1,3 +1,5 @@
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
 /**
  * Minimal filesystem surface the project-context materializer needs. Kept as an
  * injectable interface so the cache logic stays pure and unit-testable with an
@@ -68,10 +70,8 @@ let atomicTempSeq = 0;
  *  - `list` / `remove` / `clear` tolerate a missing target (`[]` / idempotent).
  */
 export function createNodeContextCacheFs(root: string): NodeContextCacheFs {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
-  const fs = require("node:fs") as typeof import("node:fs");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-nodejs-modules
-  const nodePath = require("node:path") as typeof import("node:path");
+  const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+  const nodePath = requireDesktopModule<typeof import("node:path")>("node:path");
 
   const rootAbs = nodePath.resolve(root);
 

--- a/src/context/conversionsLocation.ts
+++ b/src/context/conversionsLocation.ts
@@ -1,10 +1,10 @@
 import type { App } from "obsidian";
 // These builders produce absolute, OS-native paths for the desktop-only
 // off-vault cache; mobile never reaches them (Agent Mode is desktop-gated).
-// eslint-disable-next-line import/no-nodejs-modules
-import os from "node:os";
-// eslint-disable-next-line import/no-nodejs-modules
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const os = requireDesktopModule<typeof import("node:os")>("node:os");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 import { copilotAppDataDir, getVaultId } from "@/utils/appPaths";
 import { md5 } from "@/utils/hash";
 import type { MaterializedSourceType } from "./contextCacheStore";

--- a/src/symposium/symposiumAgentHandoff.ts
+++ b/src/symposium/symposiumAgentHandoff.ts
@@ -1,7 +1,10 @@
-import { lstat, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import * as path from "node:path";
-import { pathToFileURL } from "node:url";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const { lstat, mkdtemp, readFile, rm, unlink, writeFile } =
+  requireDesktopModule<typeof import("node:fs/promises")>("node:fs/promises");
+const { tmpdir } = requireDesktopModule<typeof import("node:os")>("node:os");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
+const { pathToFileURL } = requireDesktopModule<typeof import("node:url")>("node:url");
 
 import { SYMPOSIUM_AGENT_HANDOFF_DIR, SYMPOSIUM_MAX_HTML_BYTES } from "@/symposium/constants";
 import {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,5 @@
-// Reason: `buffer` is the npm polyfill (browser-compatible), bundled by esbuild
-// so the same Buffer code path works on desktop (Electron) and mobile (WebView).
-// eslint-disable-next-line import/no-nodejs-modules
-import { Buffer } from "buffer";
+// The trailing slash resolves the browser-compatible npm package instead of Node's built-in.
+import { Buffer } from "buffer/";
 
 import { ChainType } from "@/chainType";
 import {
@@ -823,7 +821,7 @@ export async function safeFetch(
       // Reason: Buffer (from the `buffer` polyfill imported above) is the
       // cross-platform path — bare global Buffer is undefined in mobile WebView.
       const buf = Buffer.from(base64, "base64");
-      return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+      return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
     },
     blob: () => {
       throw new Error("not implemented");

--- a/src/utils/appPaths.ts
+++ b/src/utils/appPaths.ts
@@ -1,5 +1,7 @@
 import { type App, FileSystemAdapter } from "obsidian";
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 import { md5 } from "@/utils/hash";
 
 /**

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,10 +1,5 @@
-// Reason: explicit import from the `buffer` npm polyfill (a browser-compatible
-// drop-in, not a runtime use of Node's built-in). Mobile Obsidian's WebView has
-// no Node globals, so bare `Buffer` throws "Can't find variable: Buffer" on iOS
-// WebKit. esbuild bundles this polyfill into main.js so the same code path
-// works on both desktop and mobile.
-// eslint-disable-next-line import/no-nodejs-modules
-import { Buffer } from "buffer";
+// The trailing slash resolves the browser-compatible npm package instead of Node's built-in.
+import { Buffer } from "buffer/";
 
 export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   return Buffer.from(buffer).toString("base64");
@@ -12,5 +7,5 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
 
 export function base64ToArrayBuffer(base64: string): ArrayBuffer {
   const buf = Buffer.from(base64, "base64");
-  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
 }

--- a/src/utils/binaryPath.ts
+++ b/src/utils/binaryPath.ts
@@ -1,5 +1,7 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+const os = requireDesktopModule<typeof import("node:os")>("node:os");
 
 import { collapseHomeDir } from "@/utils/pathUtils";
 import { resolveNodeToolBinDirs } from "@/utils/nodeToolBinDirs";

--- a/src/utils/captureViewScreenshot.ts
+++ b/src/utils/captureViewScreenshot.ts
@@ -1,4 +1,5 @@
 import { logWarn } from "@/logger";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
 
 interface ElectronRect {
   x: number;
@@ -33,8 +34,7 @@ interface ElectronRemote {
  */
 export async function captureViewScreenshot(el: HTMLElement): Promise<Uint8Array | null> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const electron = require("electron") as { remote?: ElectronRemote } | undefined;
+    const electron = requireDesktopModule<{ remote?: ElectronRemote } | undefined>("electron");
     const remote = electron?.remote;
     if (!remote) return null;
 

--- a/src/utils/desktopRuntime.test.ts
+++ b/src/utils/desktopRuntime.test.ts
@@ -1,35 +1,63 @@
-jest.mock("obsidian", () => ({ Platform: { isDesktopApp: false, isMobile: false } }));
+jest.mock("obsidian", () => ({
+  Platform: { isDesktop: false, isDesktopApp: false, isMobile: false },
+}));
 
-import { isDesktopRuntime } from "./desktopRuntime";
+import { isDesktopRuntime, requireDesktopModule } from "./desktopRuntime";
 
-const obsidian: { Platform: { isDesktopApp: boolean; isMobile: boolean } } =
-  jest.requireMock("obsidian");
+const obsidian: {
+  Platform: { isDesktop: boolean; isDesktopApp: boolean; isMobile: boolean };
+} = jest.requireMock("obsidian");
 
 function setPlatform(isDesktopApp: boolean, isMobile: boolean): void {
+  obsidian.Platform.isDesktop = isDesktopApp;
   obsidian.Platform.isDesktopApp = isDesktopApp;
   obsidian.Platform.isMobile = isMobile;
 }
 
-describe("isDesktopRuntime", () => {
-  it("is true on the real desktop app", () => {
-    setPlatform(true, false);
-    expect(isDesktopRuntime()).toBe(true);
+describe("desktopRuntime", () => {
+  describe("isDesktopRuntime()", () => {
+    it("is true on the real desktop app", () => {
+      setPlatform(true, false);
+      expect(isDesktopRuntime()).toBe(true);
+    });
+
+    it("is false under app.emulateMobile(true) — isDesktopApp stays true but isMobile flips", () => {
+      // The bug this guards: gating only on Platform.isDesktopApp let desktop-only
+      // code load under emulateMobile (where Node is stubbed), crashing the plugin.
+      setPlatform(true, true);
+      expect(isDesktopRuntime()).toBe(false);
+    });
+
+    it("is false on real mobile", () => {
+      setPlatform(false, true);
+      expect(isDesktopRuntime()).toBe(false);
+    });
+
+    it("is false on any non-desktop runtime", () => {
+      setPlatform(false, false);
+      expect(isDesktopRuntime()).toBe(false);
+    });
   });
 
-  it("is false under app.emulateMobile(true) — isDesktopApp stays true but isMobile flips", () => {
-    // The bug this guards: gating only on Platform.isDesktopApp let desktop-only
-    // code load under emulateMobile (where Node is stubbed), crashing the plugin.
-    setPlatform(true, true);
-    expect(isDesktopRuntime()).toBe(false);
-  });
+  describe("requireDesktopModule()", () => {
+    it("loads a Node module in a real desktop runtime", () => {
+      setPlatform(true, false);
 
-  it("is false on real mobile", () => {
-    setPlatform(false, true);
-    expect(isDesktopRuntime()).toBe(false);
-  });
+      const path = requireDesktopModule<typeof import("node:path")>("node:path");
 
-  it("is false on any non-desktop runtime", () => {
-    setPlatform(false, false);
-    expect(isDesktopRuntime()).toBe(false);
+      expect(path.join("vault", "note.md")).toBe("vault/note.md");
+    });
+
+    it("rejects Node access on real mobile", () => {
+      setPlatform(false, true);
+
+      expect(() => requireDesktopModule("node:path")).toThrow("outside Obsidian desktop");
+    });
+
+    it("rejects Node access while desktop is emulating mobile", () => {
+      setPlatform(true, true);
+
+      expect(() => requireDesktopModule("node:path")).toThrow("mobile mode is active");
+    });
   });
 });

--- a/src/utils/desktopRuntime.ts
+++ b/src/utils/desktopRuntime.ts
@@ -16,3 +16,20 @@ export function isDesktopRuntime(): boolean {
   // eslint-disable-next-line no-restricted-properties -- this helper owns the canonical check
   return Platform.isDesktopApp && !Platform.isMobile;
 }
+
+/**
+ * Load a Node module only after both Obsidian and the emulation-aware runtime
+ * check confirm that Node APIs are available.
+ *
+ * @param moduleId - Node module identifier to load from Electron's CommonJS runtime.
+ * @returns The requested Node module.
+ */
+export function requireDesktopModule<T>(moduleId: string): T {
+  if (!Platform.isDesktop) {
+    throw new Error(`Node module "${moduleId}" is unavailable outside Obsidian desktop.`);
+  }
+  if (!isDesktopRuntime()) {
+    throw new Error(`Node module "${moduleId}" is unavailable while mobile mode is active.`);
+  }
+  return module.require(moduleId) as T;
+}

--- a/src/utils/detectBinary.ts
+++ b/src/utils/detectBinary.ts
@@ -1,7 +1,10 @@
-import { execFile } from "node:child_process";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { promisify } from "node:util";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const { execFile } =
+  requireDesktopModule<typeof import("node:child_process")>("node:child_process");
+const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
+const { promisify } = requireDesktopModule<typeof import("node:util")>("node:util");
 
 import { augmentPathForDetection } from "@/utils/binaryPath";
 

--- a/src/utils/issueReport.ts
+++ b/src/utils/issueReport.ts
@@ -13,6 +13,7 @@
  * absolute home paths and may carry tokens or emails.
  */
 
+import { requireDesktopModule } from "@/utils/desktopRuntime";
 import { redactLogText } from "./redactLog";
 
 /**
@@ -187,10 +188,8 @@ export function buildReportIssueUrl(input: ReportInput, attachedFiles: string[])
 }
 
 function getNodeReportRuntime(): ReportRuntime {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const fs = require("node:fs/promises") as typeof import("node:fs/promises");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const path = require("node:path") as typeof import("node:path");
+  const fs = requireDesktopModule<typeof import("node:fs/promises")>("node:fs/promises");
+  const path = requireDesktopModule<typeof import("node:path")>("node:path");
   return {
     join: (...parts: string[]) => path.join(...parts),
     mkdir: async (p, opts) => {

--- a/src/utils/nodeToolBinDirs.ts
+++ b/src/utils/nodeToolBinDirs.ts
@@ -16,7 +16,9 @@
  * Pure leaf: callers inject `homeDir`, `platform`, `env`, and `fs` so tests
  * don't touch real disk.
  */
-import * as path from "node:path";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
+const path = requireDesktopModule<typeof import("node:path")>("node:path");
 
 export interface NodeToolFs {
   existsSync: (p: string) => boolean;
@@ -149,7 +151,7 @@ function fnmBaseDirs(
   homeDir: string,
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
-  p: path.PlatformPath
+  p: import("node:path").PlatformPath
 ): string[] {
   if (env.FNM_DIR) return [env.FNM_DIR];
   if (platform === "darwin") {
@@ -170,7 +172,7 @@ function enumerateVersionBins(
   fs: NodeToolFs,
   versionsDir: string,
   subPath: string[],
-  p: path.PlatformPath
+  p: import("node:path").PlatformPath
 ): string[] {
   let entries: string[];
   try {

--- a/src/utils/openVaultPath.test.ts
+++ b/src/utils/openVaultPath.test.ts
@@ -19,6 +19,7 @@ jest.mock("obsidian", () => ({
     }
   },
   Notice: jest.fn(),
+  Platform: { isDesktop: true, isDesktopApp: true, isMobile: false },
 }));
 
 const VAULT = "/Users/me/vault";

--- a/src/utils/openVaultPath.ts
+++ b/src/utils/openVaultPath.ts
@@ -1,4 +1,5 @@
 import { openWithSystemDefault } from "@/utils/openWithSystemDefault";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
 import { getVaultBase, isAbsolutePath, toVaultRelative } from "@/utils/vaultPath";
 import { App } from "obsidian";
 
@@ -82,8 +83,7 @@ function resolveUnindexedVaultPath(app: App, filePath: string): UnindexedPathRes
   try {
     // Desktop-only: loaded lazily after the vault-base guard, which is null
     // wherever the FileSystemAdapter (and thus node) is unavailable.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const fs = require("node:fs") as typeof import("node:fs");
+    const fs = requireDesktopModule<typeof import("node:fs")>("node:fs");
     // Realpath both sides so a vault base that itself sits behind a symlink
     // (e.g. /tmp on macOS) still compares equal to the resolved target.
     const absolutePath = fs.realpathSync(`${vaultBase}/${filePath}`);

--- a/src/utils/openWithSystemDefault.ts
+++ b/src/utils/openWithSystemDefault.ts
@@ -1,4 +1,5 @@
 import { logError } from "@/logger";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
 import { Notice } from "obsidian";
 
 /**
@@ -12,11 +13,10 @@ import { Notice } from "obsidian";
  */
 export async function openWithSystemDefault(absPath: string): Promise<void> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const electron = require("electron") as {
+    const electron = requireDesktopModule<{
       shell?: { openPath?: (path: string) => Promise<string> };
       remote?: { shell?: { openPath?: (path: string) => Promise<string> } };
-    };
+    }>("electron");
     const shell = electron.shell ?? electron.remote?.shell;
     if (!shell?.openPath) {
       new Notice(`Open this file manually: ${absPath}`);

--- a/src/utils/opencodeLog.ts
+++ b/src/utils/opencodeLog.ts
@@ -8,6 +8,8 @@
  * directory may not exist, in which case the caller proceeds without the log.
  */
 
+import { requireDesktopModule } from "@/utils/desktopRuntime";
+
 export interface OpencodeLogRuntime {
   join: (...parts: string[]) => string;
   readdir: (dir: string) => Promise<string[]>;
@@ -62,10 +64,8 @@ export async function findLatestOpencodeLog(
 }
 
 function getNodeOpencodeLogRuntime(): OpencodeLogRuntime {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const fs = require("node:fs/promises") as typeof import("node:fs/promises");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const path = require("node:path") as typeof import("node:path");
+  const fs = requireDesktopModule<typeof import("node:fs/promises")>("node:fs/promises");
+  const path = requireDesktopModule<typeof import("node:path")>("node:path");
   return {
     join: (...parts: string[]) => path.join(...parts),
     readdir: (dir: string) => fs.readdir(dir),

--- a/src/utils/rendererEventsShim.test.ts
+++ b/src/utils/rendererEventsShim.test.ts
@@ -1,9 +1,13 @@
-jest.mock("obsidian", () => ({ Platform: { isMobile: false } }));
+jest.mock("obsidian", () => ({
+  Platform: { isDesktop: true, isDesktopApp: true, isMobile: false },
+}));
 
 import { EventEmitter } from "node:events";
 import { installRendererEventsShim } from "./rendererEventsShim";
 
-const obsidian: { Platform: { isMobile: boolean } } = jest.requireMock("obsidian");
+const obsidian: {
+  Platform: { isDesktop: boolean; isDesktopApp: boolean; isMobile: boolean };
+} = jest.requireMock("obsidian");
 
 describe("installRendererEventsShim", () => {
   let original: typeof EventEmitter.setMaxListeners;

--- a/src/utils/rendererEventsShim.ts
+++ b/src/utils/rendererEventsShim.ts
@@ -1,5 +1,5 @@
 import { Platform } from "obsidian";
-import { EventEmitter } from "node:events";
+import { requireDesktopModule } from "@/utils/desktopRuntime";
 
 type SetMaxListenersFn = (n?: number, ...targets: unknown[]) => void;
 type MarkedFn = SetMaxListenersFn & { [APPLIED]?: boolean };
@@ -50,6 +50,7 @@ function hasAbortSignalShape(value: unknown): boolean {
  */
 export function installRendererEventsShim(): void {
   if (Platform.isMobile) return;
+  const { EventEmitter } = requireDesktopModule<typeof import("node:events")>("node:events");
   const target = EventEmitter as unknown as { setMaxListeners: MarkedFn };
   const original = target.setMaxListeners;
   if (original[APPLIED]) return;


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#285

## Why

Obsidian's review reports desktop-only Node and Electron modules as mobile-unsafe across Agent Mode, provider, context-cache, report, and utility entry points. Some of those modules are reachable while Obsidian desktop is emulating mobile, where Node is unavailable and plugin startup can fail before a feature-level guard runs.

## What

All shipped Node and Electron access now crosses one runtime boundary that requires both a real desktop platform and mobile emulation to be off. Browser-compatible Buffer imports resolve the npm polyfill explicitly.

| Runtime | Before | After |
| --- | --- | --- |
| Desktop | Desktop modules load directly | Desktop modules load through the guarded boundary |
| Real mobile | Static imports can be evaluated | The boundary rejects Node access |
| Desktop emulating mobile | `isDesktopApp` alone can still be true | The boundary rejects Node access while emulation is active |

Desktop Agent Mode behavior remains available, and the existing mobile-load smoke test continues to pass. Tests that exercise desktop-only paths now declare the complete Obsidian desktop platform contract, so CI does not treat an impossible partial mock as mobile.

## Non goal

- Redesign Copilot settings, chat, Agent Mode, or search UX.
- Remove desktop-only Agent Mode capabilities.
- Rewrite provider or storage architecture beyond the local platform boundary.
- Change persisted settings, chat formats, credentials, or user data schemas.
- Address review findings unrelated to mobile-safe module loading in this stack step.
- Reimplement or authenticate against Obsidian's private review service.

## Screenshot

Not applicable — this step changes runtime module loading and has no visual behavior.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `desktopRuntime.test.ts` covers desktop, real mobile, and desktop mobile-emulation outcomes; the four affected desktop-path suites cover their corrected mocks |
| A defect would fail CI or be obvious on first use | ✅ | Production build and mobile-load smoke exercise the affected startup boundary |
| A revert fully restores prior state, including persisted data | ✅ | No data or schema migration is introduced |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Only platform-gated module loading changes |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The new boundary is an internal utility |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Module resolution remains synchronous |
| No hot-path behavior lacks deterministic coverage | ✅ | The changed platform decision is unit-covered and the bundle is smoke-tested |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | No human-only behavior remains unverified; desktop and mobile paths are automated |

Review: inspect `src/utils/desktopRuntime.ts` — `requireDesktopModule` — and `src/utils/desktopRuntime.test.ts` line by line, then run Verification steps 1–3.

## Verification

1. Run `npm test -- --runTestsByPath src/utils/desktopRuntime.test.ts src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts src/agentMode/backends/registry.test.ts src/utils/openVaultPath.test.ts src/utils/rendererEventsShim.test.ts --runInBand`.
2. Run `npm run build`.
3. Run `npm run test:mobile-load`.
4. On desktop, open Agent Mode and confirm an installed backend can still be detected or launched.