### PR TITLE
[Obsidian review blockers] - Step 2: Preserve provider request semantics

### DIFF
--- a/src/LLMProviders/BedrockChatModel.ts
+++ b/src/LLMProviders/BedrockChatModel.ts
@@ -1,5 +1,6 @@
 // The trailing slash resolves the browser-compatible npm package instead of Node's built-in.
 import { Buffer } from "buffer/";
+import { getNativeStreamingFetch } from "@/network/streamingFetch";
 
 import {
   BaseChatModel,
@@ -123,13 +124,7 @@ export class BedrockChatModel extends BaseChatModel<BedrockChatModelCallOptions>
 
     super(baseParams);
 
-    // scorecard: streaming requires fetch — cannot use requestUrl
-    const globalFetch = typeof fetch !== "undefined" ? fetch.bind(window) : undefined;
-
-    this.fetchImpl = fetchImplementation ?? globalFetch;
-    if (!this.fetchImpl) {
-      throw new Error("No fetch implementation available for Amazon Bedrock requests.");
-    }
+    this.fetchImpl = fetchImplementation ?? getNativeStreamingFetch();
 
     if ((baseParams as { streaming?: boolean }).streaming && !streamEndpoint) {
       logWarn(

--- a/src/LLMProviders/CustomJinaEmbeddings.ts
+++ b/src/LLMProviders/CustomJinaEmbeddings.ts
@@ -169,7 +169,7 @@ export class CustomJinaEmbeddings extends Embeddings implements JinaEmbeddingsPa
    * Sends a single embeddings request and returns vectors in response order.
    */
   private async embeddingWithRetry(body: EmbeddingCreateParams): Promise<number[][]> {
-    const response = await fetch(this.baseUrl, {
+    const response = await safeFetchNoThrow(this.baseUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -184,3 +184,4 @@ export class CustomJinaEmbeddings extends Embeddings implements JinaEmbeddingsPa
     return (embeddingData as EmbeddingResponse).data.map(({ embedding }) => embedding);
   }
 }
+import { safeFetchNoThrow } from "@/utils";

--- a/src/LLMProviders/githubCopilot/GitHubCopilotChatModel.ts
+++ b/src/LLMProviders/githubCopilot/GitHubCopilotChatModel.ts
@@ -3,6 +3,7 @@ import { ChatOpenAICompletions } from "@langchain/openai";
 import { COPILOT_API_BASE, GitHubCopilotProvider } from "./GitHubCopilotProvider";
 import { buildGitHubCopilotAuthedFetch } from "./GitHubCopilotResponsesModel";
 import type { FetchImplementation } from "@/utils";
+import { getNativeStreamingFetch } from "@/network/streamingFetch";
 import { extractTextFromChunk } from "@/utils";
 
 // Approximate characters per token for English text
@@ -104,8 +105,7 @@ export class GitHubCopilotChatModel extends ChatOpenAICompletions {
     const { fetchImplementation, configuration, apiKey, ...rest } = fields;
 
     const provider = GitHubCopilotProvider.getInstance();
-    // scorecard: streaming requires fetch — cannot use requestUrl
-    const baseFetch = fetchImplementation ?? configuration?.fetch ?? fetch;
+    const baseFetch = fetchImplementation ?? configuration?.fetch ?? getNativeStreamingFetch();
     const authedFetch = GitHubCopilotChatModel.buildAuthedFetch(provider, baseFetch);
 
     super({

--- a/src/LLMProviders/githubCopilot/GitHubCopilotResponsesModel.ts
+++ b/src/LLMProviders/githubCopilot/GitHubCopilotResponsesModel.ts
@@ -1,6 +1,7 @@
 import { ChatOpenAI } from "@langchain/openai";
 import { COPILOT_API_BASE, GitHubCopilotProvider } from "./GitHubCopilotProvider";
 import type { FetchImplementation } from "@/utils";
+import { getNativeStreamingFetch } from "@/network/streamingFetch";
 
 /** Extract the constructor fields type from ChatOpenAI. */
 type ChatOpenAIFields = NonNullable<ConstructorParameters<typeof ChatOpenAI>[0]>;
@@ -92,7 +93,7 @@ export class GitHubCopilotResponsesModel extends ChatOpenAI {
     const { fetchImplementation, configuration, apiKey, ...rest } = fields;
 
     const provider = GitHubCopilotProvider.getInstance();
-    const baseFetch = fetchImplementation ?? configuration?.fetch ?? fetch;
+    const baseFetch = fetchImplementation ?? configuration?.fetch ?? getNativeStreamingFetch();
     const authedFetch = buildGitHubCopilotAuthedFetch(provider, baseFetch);
 
     super({

--- a/src/network/streamingFetch.test.ts
+++ b/src/network/streamingFetch.test.ts
@@ -1,0 +1,23 @@
+import { getNativeStreamingFetch } from "@/network/streamingFetch";
+
+describe("streamingFetch", () => {
+  describe("getNativeStreamingFetch()", () => {
+    it("uses the active Obsidian window as the native fetch receiver", async () => {
+      const response = {} as Response;
+      const fetchMock = jest.fn(function (this: Window) {
+        expect(this).toBe(activeWindow);
+        return Promise.resolve(response);
+      });
+      const originalFetch = activeWindow.fetch;
+      activeWindow.fetch = fetchMock;
+
+      try {
+        const streamingFetch = getNativeStreamingFetch();
+
+        await expect(streamingFetch("https://example.com/stream")).resolves.toBe(response);
+      } finally {
+        activeWindow.fetch = originalFetch;
+      }
+    });
+  });
+});

--- a/src/network/streamingFetch.ts
+++ b/src/network/streamingFetch.ts
@@ -1,0 +1,12 @@
+export type StreamingFetch = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+/**
+ * Return the active Obsidian window's native fetch implementation for APIs
+ * whose response bodies must remain stream-readable. `requestUrl` buffers the
+ * response and therefore cannot implement these provider streaming contracts.
+ *
+ * @returns A fetch-compatible function bound to the active window.
+ */
+export function getNativeStreamingFetch(): StreamingFetch {
+  return (input, init) => activeWindow.fetch(input, init);
+}


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#285

## Why

Obsidian's review flags direct `fetch` use in Bedrock, Jina, and GitHub Copilot providers. Replacing every call with `requestUrl` would break streaming providers because `requestUrl` buffers the response body, while leaving scattered global-fetch calls makes the exception hard to audit.

## What

Buffered provider requests use Obsidian's `requestUrl` API. Providers that require a readable response stream obtain native fetch through one active-window adapter, preserving the existing streaming contract and receiver binding.

| Request kind | Before | After |
| --- | --- | --- |
| Buffered Jina request | Global `fetch` | Obsidian `requestUrl` |
| Bedrock streaming | Window-bound global fetch inline | Audited active-window streaming adapter |
| GitHub Copilot streaming | Direct global `fetch` reference | Shared active-window streaming adapter |

## Non goal

- Redesign provider configuration or authentication.
- Replace streaming protocols with buffered responses.
- Rewrite provider architecture beyond a local transport boundary.
- Change persisted settings, credentials, or user data schemas.
- Address review findings outside provider transport in this stack step.
- Reimplement or authenticate against Obsidian's private review service.

## Screenshot

Not applicable — this step changes provider request transport and has no visual behavior.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ❌ | Receiver binding is deterministic, but live provider compatibility depends on third-party streaming services |
| A defect would fail CI or be obvious on first use | ✅ | A transport failure surfaces on the next affected provider request |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data changes |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Provider HTTP transport is an external input/output boundary |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Provider and plugin interfaces are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | The core provider request path selects a different transport boundary |
| No hot-path behavior lacks deterministic coverage | ❌ | End-to-end streaming requires live Bedrock or GitHub Copilot services and credentials unavailable to CI |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any residual defect stays in provider requests and appears on the first request |

Review: inspect `src/network/streamingFetch.ts` — `getNativeStreamingFetch` — and the transport selection in the four changed provider modules line by line, then run Verification steps 1–4.

## Verification

1. Run `npm test -- --runTestsByPath src/network/streamingFetch.test.ts --runInBand`.
2. Run `npm test -- --runTestsByPath src/LLMProviders/BedrockChatModel.test.ts --runInBand`.
3. Run `npm run build`.
4. With configured credentials, send one streaming request through Bedrock and GitHub Copilot and one embedding request through Jina; confirm each returns normally.

## Note

`npm run format` passes. The repo-wide `npm run lint` command still reports the review backlog tracked by issue #285; this commit's staged-file lint hook passes, and later stack steps remove that backlog.