### PR TITLE
[Obsidian review blockers] - Step 3: Use document-aware DOM helpers

### DIFF
--- a/dev/gallery/audit.ts
+++ b/dev/gallery/audit.ts
@@ -226,7 +226,7 @@ function hasVisibleUnsupportedColor(value: string): boolean {
  */
 export function resolveObsidianColorTokens(doc: Document): ReadonlySet<string> {
   const colors = new Set<string>();
-  const probe = doc.createElement("span");
+  const probe = doc.createSpan();
   probe.hidden = true;
   doc.body.append(probe);
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -23,6 +23,40 @@ if (typeof Node !== "undefined" && !Object.prototype.hasOwnProperty.call(Node.pr
   });
 }
 
+// Polyfill Obsidian's element-construction helpers so tests exercise the same
+// document-aware calls that run inside the plugin and its popout windows.
+function installCreateElHelpers(prototype) {
+  if (typeof prototype.createEl !== "function") {
+    prototype.createEl = function (tag, options = {}) {
+      const doc = this instanceof Document ? this : (this.ownerDocument ?? window.document);
+      const element = doc.createElement(tag);
+      if (options.cls) {
+        const classes = Array.isArray(options.cls) ? options.cls : options.cls.split(" ");
+        element.classList.add(...classes.filter(Boolean));
+      }
+      if (options.text !== undefined) element.textContent = String(options.text);
+      for (const [name, value] of Object.entries(options.attr ?? {})) {
+        element.setAttribute(name, String(value));
+      }
+      if (!(this instanceof Document)) this.appendChild(element);
+      return element;
+    };
+  }
+  if (typeof prototype.createDiv !== "function") {
+    prototype.createDiv = function (options) {
+      return this.createEl("div", options);
+    };
+  }
+  if (typeof prototype.createSpan !== "function") {
+    prototype.createSpan = function (options) {
+      return this.createEl("span", options);
+    };
+  }
+}
+
+if (typeof Document !== "undefined") installCreateElHelpers(Document.prototype);
+if (typeof HTMLElement !== "undefined") installCreateElHelpers(HTMLElement.prototype);
+
 // Polyfill Obsidian's `HTMLElement.setCssProps` augmentation (sets one or more
 // CSS custom properties) so plugin code that calls it — e.g. the autosizing
 // `Textarea` — works under jsdom.

--- a/src/agentMode/skills/ui/MigrateSkillConfirmModal.ts
+++ b/src/agentMode/skills/ui/MigrateSkillConfirmModal.ts
@@ -130,8 +130,8 @@ export class MigrateSkillConfirmModal extends Modal {
         const li = list.createEl("li", {
           cls: "tw-flex tw-items-baseline tw-gap-2",
         });
-        li.createEl("span", { cls: "tw-text-faint", text: "•" });
-        li.createEl("span", { cls: "tw-flex-1", text: path });
+        li.createSpan({ cls: "tw-text-faint", text: "•" });
+        li.createSpan({ cls: "tw-flex-1", text: path });
       }
     }
 
@@ -147,7 +147,7 @@ export class MigrateSkillConfirmModal extends Modal {
     }
 
     // "Copilot will:" action list.
-    const willHeader = contentEl.createEl("div", {
+    const willHeader = contentEl.createDiv({
       cls: "tw-text-ui-smaller tw-text-muted",
       text: "Copilot will:",
     });
@@ -159,15 +159,15 @@ export class MigrateSkillConfirmModal extends Modal {
       const li = actionList.createEl("li", {
         cls: "tw-flex tw-items-baseline tw-gap-2",
       });
-      li.createEl("span", { cls: "tw-text-faint", text: "•" });
-      const body = li.createEl("span", { cls: "tw-flex-1" });
-      body.createEl("span", {
+      li.createSpan({ cls: "tw-text-faint", text: "•" });
+      const body = li.createSpan({ cls: "tw-flex-1" });
+      body.createSpan({
         cls: "tw-inline-block tw-min-w-[64px] tw-text-muted",
         text: line.verb,
       });
-      body.createEl("span", { text: ` ${line.detail}` });
+      body.createSpan({ text: ` ${line.detail}` });
       if (line.note !== undefined && line.note.length > 0) {
-        body.createEl("span", {
+        body.createSpan({
           cls: "tw-ml-1.5 tw-font-sans tw-text-smallest tw-text-faint",
           text: line.note,
         });
@@ -194,10 +194,10 @@ export class MigrateSkillConfirmModal extends Modal {
     checkbox.addEventListener("change", () => {
       this.suppressFuture = checkbox.checked;
     });
-    checkboxRow.createEl("span", { text: "Don't ask again for future migrations" });
+    checkboxRow.createSpan({ text: "Don't ask again for future migrations" });
 
     // Buttons.
-    const buttonRow = contentEl.createEl("div", {
+    const buttonRow = contentEl.createDiv({
       cls: "tw-flex tw-justify-end tw-gap-2 tw-pt-2",
     });
     const cancelBtn = buttonRow.createEl("button", {

--- a/src/commands/CustomCommandChatModal.tsx
+++ b/src/commands/CustomCommandChatModal.tsx
@@ -636,7 +636,7 @@ export class CustomCommandChatModal {
     const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
 
     const doc = this.resolveDocument(activeView);
-    this.container = doc.createElement("div");
+    this.container = doc.createDiv();
     this.container.className = "copilot-menu-command-modal-container";
     doc.body.appendChild(this.container);
 

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -147,7 +147,7 @@ const linkInlineCitations = (root: HTMLElement): void => {
     const text = node.textContent || "";
     INLINE_CITATION_RE.lastIndex = 0;
 
-    const fragment = doc.createDocumentFragment();
+    const fragment = createFragment();
     let lastIndex = 0;
     let match: RegExpExecArray | null;
 
@@ -161,13 +161,13 @@ const linkInlineCitations = (root: HTMLElement): void => {
       const allResolved = nums.every((num) => citationAnchors.has(num));
 
       if (allResolved) {
-        const span = doc.createElement("span");
+        const span = doc.createSpan();
         span.className = "copilot-citation-group";
         span.appendChild(doc.createTextNode("["));
         nums.forEach((num, i) => {
           if (i > 0) span.appendChild(doc.createTextNode(", "));
           const sourceAnchor = citationAnchors.get(num)!;
-          const link = doc.createElement("a");
+          const link = doc.createEl("a");
           // Copy all attributes from the source anchor so Obsidian internal-link
           // metadata (e.g. data-href, class="internal-link") is preserved.
           for (const attr of Array.from(sourceAnchor.attributes)) {
@@ -690,7 +690,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
             // Find where to insert this text segment
             const insertBefore = contentRef.current!.children[currentIndex];
 
-            const textDiv = doc.createElement("div");
+            const textDiv = doc.createDiv();
             // `markdown-rendered` opts the container into Obsidian's native
             // reading-view stylesheet so reloaded messages match the live
             // render path (AgentMarkdownText). Most visibly, it restores the
@@ -713,7 +713,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
 
             if (!container) {
               const insertBefore = contentRef.current!.children[currentIndex];
-              const toolDiv = doc.createElement("div");
+              const toolDiv = doc.createDiv();
               toolDiv.className = "tool-call-container";
               toolDiv.id = `tool-call-${toolCallId}`;
 
@@ -747,7 +747,7 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
             if (!container) {
               // Insert error block at the current stream position
               const insertBefore = contentRef.current!.children[currentIndex];
-              const errorDiv = doc.createElement("div");
+              const errorDiv = doc.createDiv();
               errorDiv.className = "error-block-container";
               errorDiv.id = `error-block-${errorId}`;
 

--- a/src/components/chat-components/openImagePicker.ts
+++ b/src/components/chat-components/openImagePicker.ts
@@ -24,7 +24,7 @@ interface ImagePickerHandlers {
  * in the window hosting the view, not whichever window is focused (popout-safe).
  */
 export function openImagePicker(doc: Document, handlers: ImagePickerHandlers): void {
-  const input = doc.createElement("input");
+  const input = doc.createEl("input");
   input.type = "file";
   input.accept = "image/*";
   input.multiple = true;

--- a/src/components/chat-components/pills/ActiveNotePillNode.tsx
+++ b/src/components/chat-components/pills/ActiveNotePillNode.tsx
@@ -45,7 +45,7 @@ export class ActiveNotePillNode extends BasePillNode {
   }
 
   createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
+    const span = getEditorDocument(editor).createSpan();
     span.className = "active-note-pill-wrapper";
     return span;
   }
@@ -77,7 +77,7 @@ export class ActiveNotePillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
+    const element = getEditorDocument(editor).createSpan();
     element.setAttribute("data-lexical-active-note-pill", "true");
     element.textContent = "{activeNote}";
     return { element };

--- a/src/components/chat-components/pills/ActiveWebTabPillNode.tsx
+++ b/src/components/chat-components/pills/ActiveWebTabPillNode.tsx
@@ -46,7 +46,7 @@ export class ActiveWebTabPillNode extends BasePillNode {
   }
 
   createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
+    const span = getEditorDocument(editor).createSpan();
     span.className = "active-web-tab-pill-wrapper";
     return span;
   }
@@ -78,7 +78,7 @@ export class ActiveWebTabPillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
+    const element = getEditorDocument(editor).createSpan();
     element.setAttribute("data-lexical-active-web-tab-pill", "true");
     element.textContent = ACTIVE_WEB_TAB_MARKER;
     return { element };

--- a/src/components/chat-components/pills/BasePillNode.tsx
+++ b/src/components/chat-components/pills/BasePillNode.tsx
@@ -118,7 +118,7 @@ export abstract class BasePillNode extends DecoratorNode<JSX.Element> implements
    * Default DOM creation - subclasses can override for custom elements.
    */
   createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
+    const span = getEditorDocument(editor).createSpan();
     span.className = this.getClassName();
     return span;
   }
@@ -127,7 +127,7 @@ export abstract class BasePillNode extends DecoratorNode<JSX.Element> implements
    * Default DOM export - subclasses can override for custom attributes.
    */
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
+    const element = getEditorDocument(editor).createSpan();
     element.setAttribute(this.getDataAttribute(), "");
     element.setAttribute("data-pill-value", this.__value);
     element.textContent = this.__value;

--- a/src/components/chat-components/pills/FolderPillNode.tsx
+++ b/src/components/chat-components/pills/FolderPillNode.tsx
@@ -95,7 +95,7 @@ export class FolderPillNode extends BasePillNode {
    * Override to export DOM with curly braces
    */
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
+    const element = getEditorDocument(editor).createSpan();
     element.setAttribute(this.getDataAttribute(), "");
     element.setAttribute("data-pill-value", this.__value);
     element.textContent = `{${this.getFolderPath()}}`;

--- a/src/components/chat-components/pills/NotePillNode.tsx
+++ b/src/components/chat-components/pills/NotePillNode.tsx
@@ -45,7 +45,7 @@ export class NotePillNode extends BasePillNode {
   }
 
   createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
+    const span = getEditorDocument(editor).createSpan();
     span.className = "note-pill-wrapper";
     return span;
   }
@@ -80,7 +80,7 @@ export class NotePillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
+    const element = getEditorDocument(editor).createSpan();
     element.setAttribute("data-lexical-note-pill", "true");
     element.setAttribute("data-note-title", this.__noteTitle);
     element.setAttribute("data-note-path", this.__notePath);

--- a/src/components/chat-components/pills/URLPillNode.tsx
+++ b/src/components/chat-components/pills/URLPillNode.tsx
@@ -51,7 +51,7 @@ export class URLPillNode extends BasePillNode {
   }
 
   createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
+    const span = getEditorDocument(editor).createSpan();
     span.className = "url-pill-wrapper";
     return span;
   }
@@ -87,7 +87,7 @@ export class URLPillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
+    const element = getEditorDocument(editor).createSpan();
     element.setAttribute("data-lexical-url-pill", "true");
     element.setAttribute("data-url", this.__url);
     if (this.__title) {

--- a/src/components/chat-components/pills/WebTabPillNode.tsx
+++ b/src/components/chat-components/pills/WebTabPillNode.tsx
@@ -65,7 +65,7 @@ export class WebTabPillNode extends BasePillNode {
   }
 
   createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
+    const span = getEditorDocument(editor).createSpan();
     span.className = "web-tab-pill-wrapper";
     return span;
   }
@@ -101,7 +101,7 @@ export class WebTabPillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
+    const element = getEditorDocument(editor).createSpan();
     element.setAttribute("data-lexical-web-tab-pill", "true");
     element.setAttribute("data-url", this.__url);
     if (this.__title) {

--- a/src/components/command-ui/markdown-preview.tsx
+++ b/src/components/command-ui/markdown-preview.tsx
@@ -25,13 +25,16 @@ export function MarkdownPreview({ content, renderMarkdown, className }: Markdown
     // Reason: Render into a detached element so that if content changes
     // mid-render, the stale result never touches the live DOM.
     // Reason: Use the target's doc for popout-window safety in Obsidian
-    const scratchEl = targetEl.doc.createElement("div");
+    const scratchEl = targetEl.doc.createDiv();
 
     targetEl.replaceChildren();
     renderMarkdown(content, scratchEl)
       .then(() => {
         if (currentGen !== renderGenRef.current) return;
-        targetEl.replaceChildren(...Array.from(scratchEl.childNodes));
+        targetEl.replaceChildren();
+        while (scratchEl.firstChild) {
+          targetEl.appendChild(scratchEl.firstChild);
+        }
         // Propagate the markdown-rendered class that MarkdownRenderer adds
         if (scratchEl.classList.contains("markdown-rendered")) {
           targetEl.classList.add("markdown-rendered");

--- a/src/components/modals/CachePreviewModal.ts
+++ b/src/components/modals/CachePreviewModal.ts
@@ -34,7 +34,7 @@ export class CachePreviewModal extends Modal {
     const { contentEl, modalEl } = this;
 
     // Reason: override default modal width for wider content preview
-    modalEl.addClass("!tw-w-[90vw]", "!tw-max-w-[800px]");
+    modalEl.addClass("tw-w-[90vw]", "tw-max-w-[800px]");
 
     contentEl.empty();
     contentEl.addClass("tw-flex", "tw-flex-col", "tw-p-0");
@@ -57,7 +57,7 @@ export class CachePreviewModal extends Modal {
     });
     const fileIconEl = titleWrapper.createDiv({ cls: "tw-text-muted tw-shrink-0" });
     setIcon(fileIconEl, "file-text");
-    titleWrapper.createEl("span", {
+    titleWrapper.createSpan({
       text: this.title,
       cls: "tw-font-semibold tw-text-normal tw-truncate",
     });

--- a/src/components/modals/SourcesModal.tsx
+++ b/src/components/modals/SourcesModal.tsx
@@ -181,7 +181,7 @@ export class SourcesModal extends Modal {
     // Create explanation text without "Why this ranked here:" header
     if (details.length > 0) {
       details.forEach((detail) => {
-        const detailDiv = explanationDiv.createEl("div");
+        const detailDiv = explanationDiv.createDiv();
         detailDiv.addClass("tw-mb-1");
         detailDiv.textContent = `• ${detail}`;
       });

--- a/src/components/quick-ask/QuickAskOverlay.tsx
+++ b/src/components/quick-ask/QuickAskOverlay.tsx
@@ -314,7 +314,7 @@ export class QuickAskOverlay {
     if (QuickAskOverlay.overlayRoot) return QuickAskOverlay.overlayRoot;
 
     const doc = host.doc;
-    const root = doc.createElement("div");
+    const root = doc.createDiv();
     root.className = "copilot-quick-ask-overlay-root";
     host.appendChild(root);
     host.classList.add("copilot-quick-ask-overlay-host");
@@ -334,7 +334,7 @@ export class QuickAskOverlay {
     this.ownerWindow = win;
 
     const overlayRoot = QuickAskOverlay.getOverlayRoot(overlayHost);
-    const overlayContainer = doc.createElement("div");
+    const overlayContainer = doc.createDiv();
     overlayContainer.className = "copilot-quick-ask-overlay";
     overlayRoot.appendChild(overlayContainer);
     this.overlayContainer = overlayContainer;

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -258,7 +258,7 @@ export async function buildSymposiumDocument(
   ownerDocument: Document
 ): Promise<SymposiumDocument> {
   const markdown = await app.vault.read(file);
-  const article = ownerDocument.createElement("article");
+  const article = ownerDocument.createEl("article");
   article.className = "markdown-preview-view markdown-rendered symposium-document";
 
   const render = (MarkdownRenderer as unknown as { render: ModernRender }).render;
@@ -295,7 +295,7 @@ function normalizeMath(root: HTMLElement): void {
 
 function normalizeTaskCheckboxes(root: HTMLElement): void {
   root.querySelectorAll<HTMLInputElement>("input.task-list-item-checkbox").forEach((checkbox) => {
-    const marker = root.doc.createElement("span");
+    const marker = root.doc.createSpan();
     const checked = checkbox.checked || checkbox.hasAttribute("checked");
     marker.className = "symposium-task-marker";
     marker.setAttribute("role", "img");
@@ -311,7 +311,7 @@ function removeUnsupportedContent(root: HTMLElement): void {
 
 function normalizeInternalLinks(root: HTMLElement): void {
   root.querySelectorAll<HTMLAnchorElement>("a.internal-link").forEach((link) => {
-    const replacement = root.doc.createElement("span");
+    const replacement = root.doc.createSpan();
     replacement.className = [...link.classList]
       .filter((name) => name !== "is-unresolved")
       .join(" ");
@@ -550,7 +550,7 @@ function asciiAt(bytes: Uint8Array, offset: number, expected: string): boolean {
 }
 
 function replaceMissingImage(image: HTMLImageElement, source: string): HTMLElement {
-  const replacement = image.doc.createElement("span");
+  const replacement = image.doc.createSpan();
   replacement.className = "symposium-missing-asset";
   replacement.textContent = `[Missing image: ${image.alt || source || "unknown"}]`;
   image.replaceWith(replacement);
@@ -638,7 +638,7 @@ function decodeUrlComponent(value: string): string {
 }
 
 function serializeDocument(ownerDocument: Document, title: string, article: HTMLElement): string {
-  const titleElement = ownerDocument.createElement("title");
+  const titleElement = ownerDocument.createEl("title");
   titleElement.textContent = title;
   return [
     "<!doctype html>",


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#285

## Why

Obsidian's review reports raw `document.createElement` calls throughout chat rendering, modals, quick ask, gallery auditing, and Symposium serialization. Those calls bypass Obsidian's document-aware helpers, which matters when plugin UI renders in a popout window rather than the main document.

## What

Affected elements are created through the owning Obsidian document or element helper while retaining the same tag, classes, text, attributes, insertion order, and serialized output. Tests now install the same helper surface in jsdom so these paths remain executable outside Obsidian.

> **Before:** UI code creates nodes through raw DOM factories and relies on callers to preserve the correct document.
>
> **After:** UI code creates the same nodes through Obsidian's document-aware helpers, including in popout-owned documents.

## Non goal

- Redesign Copilot settings, chat, Agent Mode, search, or Symposium UX.
- Change rendered copy, layout, or component structure.
- Rewrite UI architecture beyond local element construction.
- Change persisted settings, chat formats, credentials, or user data schemas.
- Address non-DOM review findings in this stack step.
- Reimplement or authenticate against Obsidian's private review service.

## Screenshot

Not applicable — element tags, classes, content, and placement are unchanged.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ❌ | Chat, gallery, and Symposium paths are covered, but every modal and pill surface lacks a dedicated render test |
| A defect would fail CI or be obvious on first use | ✅ | Invalid helper use throws during the affected render path |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Element construction only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Existing component and serialization contracts remain unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | DOM construction remains synchronous |
| No hot-path behavior lacks deterministic coverage | ✅ | Chat message construction is covered by `ChatSingleMessage.test.tsx` |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ❌ | Residual visual verification spans several existing UI surfaces |

Review: inspect the element substitutions in `src/components/chat-components/ChatSingleMessage.tsx`, `src/agentMode/skills/ui/MigrateSkillConfirmModal.ts`, and `src/symposium/symposiumDocument.ts`, then run Verification steps 1–3.

## Verification

1. Run `npm test -- --runTestsByPath dev/gallery/audit.test.ts src/components/chat-components/ChatSingleMessage.test.tsx src/symposium/symposiumDocument.test.ts --runInBand`.
2. Run `npm run build`.
3. In Obsidian, open a chat containing citations and tool calls, open Quick Ask and the skill-migration dialog, and confirm their content and interactions are unchanged.

## Note

`npm run format` passes. The repo-wide `npm run lint` command still reports later review families tracked by issue #285; the reported DOM warnings fall from 42 to the test-only baseline, and this commit's staged-file lint hook passes.