### PR TITLE
[Obsidian review blockers] - Step 4: Contain async UI work

### DIFF
--- a/dev/gallery/main.test.ts
+++ b/dev/gallery/main.test.ts
@@ -1,5 +1,5 @@
 import { mountPluginViewRoot, type PluginViewRootHandle } from "@/utils/react/mountPluginViewRoot";
-import { fireEvent, render, type RenderResult } from "@testing-library/react";
+import { fireEvent, render, waitFor, type RenderResult } from "@testing-library/react";
 import GalleryPlugin, { GALLERY_VIEWTYPE, type GalleryHandle } from "./main";
 import type { AuditReport } from "./audit";
 import type { GalleryViewState } from "./Gallery";
@@ -71,9 +71,9 @@ jest.mock("obsidian", () => {
     constructor(leaf: unknown) {
       this.app = (leaf as { app?: unknown }).app;
       this.leaf = leaf;
-      this.containerEl = activeDocument.createElement("div");
-      this.containerEl.append(activeDocument.createElement("div"));
-      this.contentEl = activeDocument.createElement("div");
+      this.containerEl = activeDocument.body.createDiv();
+      this.containerEl.append(activeDocument.body.createDiv());
+      this.contentEl = activeDocument.body.createDiv();
       this.contentEl.setText = (text: string) => {
         this.contentEl.textContent = text;
       };
@@ -195,7 +195,8 @@ describe("main", () => {
       createView = viewCreator as (leaf: WorkspaceLeaf) => GalleryViewContract;
     });
 
-    await plugin.onload();
+    plugin.onload();
+    await waitFor(() => expect(registerView).toHaveBeenCalled());
 
     if (!createView) {
       throw new Error("Gallery view was not registered");
@@ -231,7 +232,7 @@ describe("main", () => {
         return;
       }
 
-      const storyElement = activeDocument.createElement("div");
+      const storyElement = activeDocument.body.createDiv();
       storyElement.dataset.story = story.id;
       storyElement.dataset.storyWidth = String(state.width);
       storyElement.dataset.galleryOwner = ownerId;
@@ -739,7 +740,8 @@ describe("main", () => {
         const replacement = new GalleryPlugin(app, {
           id: "copilot-component-gallery",
         } as PluginManifest);
-        await replacement.onload();
+        replacement.onload();
+        await waitFor(() => expect(window.__gallery).not.toBe(firstHandle));
         const replacementHandle = window.__gallery;
 
         plugin.onunload();

--- a/dev/gallery/main.ts
+++ b/dev/gallery/main.ts
@@ -1,5 +1,5 @@
 import { mountPluginViewRoot, type PluginViewRootHandle } from "@/utils/react/mountPluginViewRoot";
-import { ItemView, Plugin, type WorkspaceLeaf } from "obsidian";
+import { ItemView, Notice, Plugin, type WorkspaceLeaf } from "obsidian";
 import * as React from "react";
 import {
   createGalleryCatalog,
@@ -403,7 +403,14 @@ export default class GalleryPlugin extends Plugin {
   private operationAbortController = new AbortController();
   private readonly views = new Set<GalleryView>();
 
-  async onload(): Promise<void> {
+  onload(): void {
+    void this.loadGallery().catch((error: unknown) => {
+      const detail = error instanceof Error ? error.message : String(error);
+      new Notice(`Component gallery failed to load: ${detail}`);
+    });
+  }
+
+  private async loadGallery(): Promise<void> {
     const storyModules = await Promise.all(
       modules.map(async ({ componentId, load }) => ({
         componentId,

--- a/src/agentMode/backends/shared/BinaryPathSetting.tsx
+++ b/src/agentMode/backends/shared/BinaryPathSetting.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { logError } from "@/logger";
 import { detectionSearchDirs } from "@/utils/binaryPath";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { detectBinary } from "@/utils/detectBinary";
 import { Notice } from "obsidian";
 import React from "react";
@@ -143,15 +144,30 @@ export const BinaryPathSetting: React.FC<Props> = ({
           onChange={(e) => setPathInput(e.target.value)}
           className="tw-flex-1"
         />
-        <Button variant="secondary" size="default" onClick={autoDetect} disabled={busy}>
+        <Button
+          variant="secondary"
+          size="default"
+          onClick={toVoidHandler(autoDetect, "Auto-detect binary")}
+          disabled={busy}
+        >
           Auto-detect
         </Button>
         {showClear ? (
-          <Button variant="destructive" size="default" onClick={clear} disabled={busy}>
+          <Button
+            variant="destructive"
+            size="default"
+            onClick={toVoidHandler(clear, "Clear binary path")}
+            disabled={busy}
+          >
             Clear
           </Button>
         ) : showApply ? (
-          <Button variant="default" size="default" onClick={apply} disabled={busy}>
+          <Button
+            variant="default"
+            size="default"
+            onClick={toVoidHandler(apply, "Apply binary path")}
+            disabled={busy}
+          >
             Apply
           </Button>
         ) : null}

--- a/src/agentMode/ui/AgentChatInput.tsx
+++ b/src/agentMode/ui/AgentChatInput.tsx
@@ -582,10 +582,26 @@ export const AgentChatInput = memo(function AgentChatInput({
           placeholderPrompts={isLanding ? AGENT_PROMPT_SUGGESTIONS : undefined}
           inputMessage={inputMessage}
           setInputMessage={setInputMessage}
-          handleSendMessage={(meta) => handleSendMessage(meta?.webTabs)}
+          handleSendMessage={(meta) => {
+            void handleSendMessage(meta?.webTabs).catch((error: unknown) =>
+              logError("Send agent message failed", error)
+            );
+          }}
           isGenerating={loading}
-          onStopGenerating={handleStopGenerating}
-          onEscape={loading ? handleStopGenerating : undefined}
+          onStopGenerating={() => {
+            void handleStopGenerating().catch((error: unknown) =>
+              logError("Stop agent generation failed", error)
+            );
+          }}
+          onEscape={
+            loading
+              ? () => {
+                  void handleStopGenerating().catch((error: unknown) =>
+                    logError("Stop agent generation failed", error)
+                  );
+                }
+              : undefined
+          }
           onShiftTab={modePickerOverride ? onCycleMode : undefined}
           app={app}
           contextNotes={contextNotes}

--- a/src/agentMode/ui/AgentContextStatusIcon.tsx
+++ b/src/agentMode/ui/AgentContextStatusIcon.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { settingsStore } from "@/settings/model";
 import { openAgentCachedItemPreview } from "@/utils/cacheFileOpener";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { useAtomValue } from "jotai";
 import { AlertCircle, CheckCircle, CircleDashed, Loader2 } from "lucide-react";
 import { App } from "obsidian";
@@ -419,7 +420,7 @@ export default function AgentContextStatusIcon({
             app={app}
             project={project}
             hasConfiguredContextSource={hasConfiguredContextSource}
-            onRetryItem={handleRetryItem}
+            onRetryItem={toVoidHandler(handleRetryItem, "Retry context item")}
             onRetryAll={handleRetryAll}
             onEditContext={() => {
               handleOpenChange(false);

--- a/src/agentMode/ui/AgentHome.tsx
+++ b/src/agentMode/ui/AgentHome.tsx
@@ -22,6 +22,7 @@ import {
 import { ProjectPickerList } from "@/agentMode/ui/ProjectPickerList";
 import { RelevantNotesShelfPanel } from "@/agentMode/ui/RelevantNotesShelfPanel";
 import { useRelevantNotesPaneOpen } from "@/agentMode/ui/useRelevantNotesPaneOpen";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { useAgentChatRuntimeState } from "@/agentMode/ui/hooks/useAgentChatRuntimeState";
 import { useAgentHistoryControls } from "@/agentMode/ui/hooks/useAgentHistoryControls";
 import { useAgentInputDrafts } from "@/agentMode/ui/hooks/useAgentInputDrafts";
@@ -358,7 +359,11 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   // appear in an id, so distinct id sets always produce distinct keys.
   const sessions = manager.getSessions();
   const liveKey = sessions.map((s) => s.chatInputId).join("\0");
-  const liveChatInputIds = useMemo(() => sessions.map((s) => s.chatInputId), [liveKey]); // eslint-disable-line react-hooks/exhaustive-deps
+  const liveChatInputIds = useMemo(
+    () => sessions.map((s) => s.chatInputId),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- liveKey invalidates the external session snapshot
+    [liveKey]
+  );
   // Per-chat-input compose drafts live in the shell (the common owner) so the
   // active turn's `loading` (transcript spinner) and the drop overlay's drag
   // state can be read directly here, instead of being mirrored up from the
@@ -441,7 +446,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
     if (!isProjectScope) return null;
     const record = getCachedProjectRecordById(activeProjectId);
     return record ? getProjectLandingCaptureSignature(app, record) : null;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the stable session identity owns this one-time synchronization
   }, [app, isProjectScope, activeProjectId, projects]);
   useRefreshEmptyLandingOnContextSourceChange({
     activeProjectId,
@@ -499,7 +504,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
   // a session, so it doesn't flicker as tokens arrive. sessionId is the
   // intentional re-roll trigger — not read inside the factory, so exhaustive-deps
   // flags it; the dep is deliberate (same as the liveChatInputIds memo above).
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- route changes, not callback identity, trigger restoration
   const greeting = useMemo(() => pickRandomGreeting(), [sessionId]);
 
   // Populate the chats list whenever a landing (global or per-project) is shown
@@ -545,7 +550,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
             onUpdateTitle={handleUpdateChatTitle}
             onDeleteChat={handleDeleteChat}
             onOpenSourceFile={handleOpenSourceFile}
-            onLoadHistory={handleLoadChatHistory}
+            onLoadHistory={toVoidHandler(handleLoadChatHistory, "Load chat history")}
             runningChatIds={runningChatIds}
             attentionChatIds={attentionChatIds}
             projectNamesById={projectNamesById}
@@ -633,7 +638,7 @@ const AgentHomeInternal: React.FC<AgentHomeProps> = ({
             onUpdateTitle={handleUpdateChatTitle}
             onDeleteChat={handleDeleteChat}
             onOpenSourceFile={handleOpenSourceFile}
-            onLoadHistory={handleLoadChatHistory}
+            onLoadHistory={toVoidHandler(handleLoadChatHistory, "Load chat history")}
             runningChatIds={runningChatIds}
             attentionChatIds={attentionChatIds}
           />

--- a/src/agentMode/ui/GlobalRecentChatsSection.tsx
+++ b/src/agentMode/ui/GlobalRecentChatsSection.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { isNativeChatId } from "@/utils/nativeChatId";
 import { formatCompactRelativeTime } from "@/utils/formatRelativeTime";
 import { sortByStrategy } from "@/utils/recentUsageManager";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import {
   ArrowUpRight,
   Check,
@@ -485,7 +486,7 @@ export const GlobalRecentChatsSection = memo(function GlobalRecentChatsSection({
                   // every keystroke.
                   editingTitle={editingId === item.id ? editingTitle : ""}
                   confirmingDelete={confirmDeleteId === item.id}
-                  onOpen={onLoadChat}
+                  onOpen={toVoidHandler(onLoadChat, "Open recent chat")}
                   onStartEdit={handleStartEdit}
                   onEditingTitleChange={setEditingTitle}
                   // Only the editing row needs the live save handler (it changes

--- a/src/agentMode/ui/PlanProposalCard.tsx
+++ b/src/agentMode/ui/PlanProposalCard.tsx
@@ -7,6 +7,7 @@ import type {
   PlanProposalDecision,
 } from "@/agentMode/session/types";
 import { closePlanPreview, openPlanPreview } from "@/agentMode/ui/PlanPreviewView";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { Check, ClipboardList, FileText, Send, X as XIcon } from "lucide-react";
 import { App } from "obsidian";
 import React, { useEffect, useState } from "react";
@@ -98,7 +99,11 @@ export const PlanProposalCard: React.FC<PlanProposalCardProps> = ({ plan, app, c
       </div>
 
       <div className="tw-flex tw-flex-wrap tw-items-center tw-justify-end tw-gap-2 tw-border-t tw-border-solid tw-border-border tw-px-3 tw-py-2">
-        <Button variant="secondary" size="sm" onClick={handleOpen}>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={toVoidHandler(handleOpen, "Open plan preview")}
+        >
           <FileText className="tw-size-4" />
           Open
         </Button>
@@ -108,12 +113,17 @@ export const PlanProposalCard: React.FC<PlanProposalCardProps> = ({ plan, app, c
               variant="destructive"
               size="sm"
               disabled={busy}
-              onClick={() => decide("reject")}
+              onClick={toVoidHandler(() => decide("reject"), "Reject plan")}
             >
               <XIcon className="tw-size-4" />
               Reject
             </Button>
-            <Button variant="success" size="sm" disabled={busy} onClick={() => decide("approve")}>
+            <Button
+              variant="success"
+              size="sm"
+              disabled={busy}
+              onClick={toVoidHandler(() => decide("approve"), "Approve plan")}
+            >
               <Check className="tw-size-4" />
               Approve
             </Button>

--- a/src/commands/CustomCommandChatModal.tsx
+++ b/src/commands/CustomCommandChatModal.tsx
@@ -21,6 +21,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { preprocessAIResponse } from "@/utils/markdownPreprocess";
 import { Root } from "react-dom/client";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { CustomCommand } from "@/commands/type";
 import { useSettingsValue, updateSetting } from "@/settings/model";
 import {
@@ -426,12 +427,12 @@ function CustomCommandChatModalContent({
       onEditableContentChange={setEditedText}
       followUpValue={followUpValue}
       onFollowUpChange={setFollowUpValue}
-      onFollowUpSubmit={handleFollowUpSubmit}
+      onFollowUpSubmit={toVoidHandler(handleFollowUpSubmit, "Submit command follow-up")}
       selectedModel={chatPicker.value}
       onSelectModel={chatPicker.onChange}
       models={chatPicker.models}
       onStop={handleStop}
-      onCopy={handleCopy}
+      onCopy={toVoidHandler(handleCopy, "Copy command response")}
       onInsert={handleInsert}
       onReplace={handleReplace}
       initialPosition={initialPosition}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -51,6 +51,7 @@ import { FileParserManager } from "@/tools/FileParserManager";
 import { ChatMessage } from "@/types/message";
 import { err2String, isPlusChain, modelSupportsVision } from "@/utils";
 import { arrayBufferToBase64 } from "@/utils/base64";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { appendUniqueFiles } from "@/utils/fileListUtils";
 import { Notice, TFile } from "obsidian";
 import { ContextManageModal } from "@/components/modals/project/context-manage-modal";
@@ -894,9 +895,9 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
           loading={loading}
           loadingMessage={loadingMessage}
           app={app}
-          onRegenerate={handleRegenerate}
-          onEdit={handleEdit}
-          onDelete={handleDelete}
+          onRegenerate={toVoidHandler(handleRegenerate, "Regenerate message")}
+          onEdit={toVoidHandler(handleEdit, "Edit message")}
+          onDelete={toVoidHandler(handleDelete, "Delete message")}
           onReplaceChat={setInputMessage}
           showHelperComponents={selectedChain !== ChainType.PROJECT_CHAIN}
         />
@@ -954,7 +955,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
             <ChatInput
               inputMessage={inputMessage}
               setInputMessage={setInputMessage}
-              handleSendMessage={handleSendMessage}
+              handleSendMessage={toVoidHandler(handleSendMessage, "Send chat message")}
               isGenerating={loading}
               onStopGenerating={() => handleStopGenerating(ABORT_REASON.USER_STOPPED)}
               app={app}

--- a/src/components/chat-components/ChatHistoryPopover.tsx
+++ b/src/components/chat-components/ChatHistoryPopover.tsx
@@ -10,6 +10,7 @@ import { ChatIconWithAttention } from "@/components/chat-components/ChatIconWith
 import { logError } from "@/logger";
 import { useSettingsValue } from "@/settings/model";
 import { sortByStrategy } from "@/utils/recentUsageManager";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { Platform } from "obsidian";
 
 /** Number of chat history items loaded per page. */
@@ -347,12 +348,16 @@ export function ChatHistoryPopover({
                             editingTitle={editingTitle}
                             onEditingTitleChange={setEditingTitle}
                             onStartEdit={handleStartEdit}
-                            onSaveEdit={handleSaveEdit}
+                            onSaveEdit={toVoidHandler(handleSaveEdit, "Save chat title")}
                             onCancelEdit={handleCancelEdit}
-                            onDelete={handleDelete}
+                            onDelete={toVoidHandler(handleDelete, "Delete chat")}
                             onCancelDelete={handleCancelDelete}
-                            onLoadChat={handleLoadChat}
-                            onOpenSourceFile={onOpenSourceFile}
+                            onLoadChat={toVoidHandler(handleLoadChat, "Load chat")}
+                            onOpenSourceFile={
+                              onOpenSourceFile
+                                ? toVoidHandler(onOpenSourceFile, "Open chat source")
+                                : undefined
+                            }
                             isMobile={isMobile}
                             confirmDeleteId={confirmDeleteId}
                             getIcon={getIcon}

--- a/src/components/chat-components/ProjectList.tsx
+++ b/src/components/chat-components/ProjectList.tsx
@@ -21,6 +21,7 @@ import { logError, logWarn } from "@/logger";
 import { ProjectFileManager } from "@/projects/ProjectFileManager";
 import { useSettingsValue } from "@/settings/model";
 import { sortByStrategy } from "@/utils/recentUsageManager";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import {
   ArrowUpRight,
   ChevronDown,
@@ -200,11 +201,11 @@ export const ProjectList = memo(
       if (!selectedProject) return;
       const stillExists = projects.some((p) => p.id === selectedProject.id);
       if (stillExists) return;
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- reset selection when the project list becomes unavailable
       setSelectedProject(null);
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- select the only project when the external list collapses to one item
       setShowChatInput(false);
-      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect
+      // eslint-disable-next-line @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- discard a selection removed by an external project update
       setIsOpen(true);
       showChatUI(false);
     }, [projects, selectedProject, showChatUI]);
@@ -473,7 +474,7 @@ export const ProjectList = memo(
                             project={project}
                             loadContext={handleLoadContext}
                             onEdit={handleEditProject}
-                            onDelete={handleDeleteProject}
+                            onDelete={toVoidHandler(handleDeleteProject, "Delete project")}
                           />
                         ))}
                       </div>

--- a/src/components/composer/ApplyView.tsx
+++ b/src/components/composer/ApplyView.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
 import { getSettings, updateSetting } from "@/settings/model";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { Change, diffArrays } from "diff";
 import { Check, X as XIcon } from "lucide-react";
 import { App, ItemView, Notice, TFile, WorkspaceLeaf } from "obsidian";
@@ -566,11 +567,19 @@ const ApplyViewRoot: React.FC<ApplyViewRootProps> = ({ app, state, close }) => {
   return (
     <div className="tw-relative tw-flex tw-h-full tw-flex-col">
       <div className="tw-fixed tw-bottom-4 tw-left-1/2 tw-z-[9999] tw-flex tw-gap-2 tw-rounded-md tw-border tw-border-solid tw-border-border tw-bg-secondary tw-p-2 tw-shadow-lg">
-        <Button variant="destructive" size="sm" onClick={handleReject}>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={toVoidHandler(handleReject, "Reject composer changes")}
+        >
           <XIcon className="tw-size-4" />
           Reject
         </Button>
-        <Button variant="success" size="sm" onClick={handleAccept}>
+        <Button
+          variant="success"
+          size="sm"
+          onClick={toVoidHandler(handleAccept, "Accept composer changes")}
+        >
           <Check className="tw-size-4" />
           Accept
         </Button>

--- a/src/components/modals/SymposiumModal.tsx
+++ b/src/components/modals/SymposiumModal.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { openWithSystemDefault } from "@/utils/openWithSystemDefault";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import type { SymposiumAction, SymposiumDocument, SymposiumReceipt } from "@/symposium/types";
 import { App, Modal } from "obsidian";
 import React, { useState } from "react";
@@ -105,7 +106,7 @@ function SymposiumReceiptView({ receipt, actions }: SymposiumReceiptViewProps) {
       <div className="tw-flex tw-items-center tw-justify-end tw-gap-2">
         {copyMessage && <span className="tw-text-small tw-text-muted">{copyMessage}</span>}
         {actions}
-        <Button variant="secondary" onClick={copyUrl}>
+        <Button variant="secondary" onClick={toVoidHandler(copyUrl, "Copy Symposium URL")}>
           Copy
         </Button>
         <Button onClick={openUrl}>Open</Button>

--- a/src/components/modals/project/AddProjectModal.tsx
+++ b/src/components/modals/project/AddProjectModal.tsx
@@ -34,6 +34,7 @@ import { Settings } from "lucide-react";
 import { type UrlItem, parseProjectUrls, serializeProjectUrls } from "@/utils/urlTagUtils";
 import type CopilotPlugin from "@/main";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { useChatBackendModelOptions } from "@/hooks/useChatBackendModelOptions";
 import { App, Modal, Notice } from "obsidian";
 import React, { useEffect, useMemo, useState } from "react";
@@ -613,7 +614,10 @@ export function AddProjectModalContent({
           <Button variant="ghost" onClick={onCancel} disabled={isSubmitting}>
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={isSubmitting || !isFormValid()}>
+          <Button
+            onClick={toVoidHandler(handleSave, "Save project")}
+            disabled={isSubmitting || !isFormValid()}
+          >
             {isSubmitting ? "Saving..." : "Save"}
           </Button>
         </div>

--- a/src/components/project/progress-card.tsx
+++ b/src/components/project/progress-card.tsx
@@ -19,6 +19,7 @@ import { TruncatedText } from "@/components/TruncatedText";
 import { ProcessingStatus } from "@/components/project/processing-status";
 import { useProjectProcessingData } from "@/components/project/useProjectProcessingData";
 import { openCachedItemPreview } from "@/utils/cacheFileOpener";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import type { ProcessingItem } from "@/components/project/processingAdapter";
 import { ProjectFileManager } from "@/projects/ProjectFileManager";
 import { splitUrlsStringToArray } from "@/projects/projectUtils";
@@ -185,7 +186,7 @@ export default function ProgressCard({ plugin, setHiddenCard, onEditContext }: P
                     items={processingData.items}
                     onRetry={handleRetry}
                     onOpenCachedItem={projectCache != null ? handleOpenCachedItem : undefined}
-                    onRemoveUrl={handleRemoveUrl}
+                    onRemoveUrl={toVoidHandler(handleRemoveUrl, "Remove project URL")}
                     defaultExpanded
                     maxHeight="200px"
                   />

--- a/src/components/quick-ask/QuickAskPanel.tsx
+++ b/src/components/quick-ask/QuickAskPanel.tsx
@@ -14,6 +14,7 @@ import { useDraggable } from "@/hooks/use-draggable";
 import type { ResizeDirection } from "@/hooks/use-resizable";
 import { useSettingsValue, updateSetting } from "@/settings/model";
 import { cleanMessageForCopy } from "@/utils";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { ModelSelector } from "@/components/ui/ModelSelector";
 import { useChatModelPicker } from "@/components/chat-components/useChatModelPicker";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -305,7 +306,7 @@ export function QuickAskPanel({
               message={msg}
               isStreaming={isStreaming && msg.id === lastMessageId && msg.role === "assistant"}
               isLastAssistantMessage={msg.role === "assistant" && idx === lastAssistantIdx}
-              onCopy={handleCopy}
+              onCopy={toVoidHandler(handleCopy, "Copy quick ask response")}
               onInsert={handleInsert}
               onReplace={handleReplace}
               hasSelection={hasSelection}
@@ -327,7 +328,7 @@ export function QuickAskPanel({
         <QuickAskInput
           value={inputText}
           onChange={setInputText}
-          onSubmit={handleSubmit}
+          onSubmit={toVoidHandler(handleSubmit, "Submit quick ask")}
           sendShortcut={settings.defaultSendShortcut}
           placeholder={isStreaming ? "Generating..." : "Ask a question... "}
           currentActiveFile={currentActiveFile}
@@ -385,7 +386,7 @@ export function QuickAskPanel({
             <Button
               variant="default"
               size="icon"
-              onClick={handleSubmit}
+              onClick={toVoidHandler(handleSubmit, "Submit quick ask")}
               disabled={!inputText.trim()}
               title="Send message"
             >

--- a/src/components/ui/ModelSelector.tsx
+++ b/src/components/ui/ModelSelector.tsx
@@ -164,7 +164,7 @@ export function ModelSelector({
               <DropdownMenuItem
                 disabled={itemDisabled}
                 title={disabledReason ?? undefined}
-                onSelect={async (event) => {
+                onSelect={(event) => {
                   if (itemDisabled) {
                     event.preventDefault();
                     return;

--- a/src/components/ui/url-tag-input.tsx
+++ b/src/components/ui/url-tag-input.tsx
@@ -79,15 +79,17 @@ export function UrlTagInput({ urls, onAdd, onRemove }: UrlTagInputProps) {
     setInputValue("");
   };
 
-  const handlePasteFromClipboard = async () => {
-    try {
-      const text = await navigator.clipboard.readText();
-      if (text) {
-        parseAndAddUrls(text);
-      }
-    } catch {
-      // Clipboard API not available or permission denied in Obsidian
-    }
+  const handlePasteFromClipboard = () => {
+    void navigator.clipboard
+      .readText()
+      .then((text) => {
+        if (text) {
+          parseAndAddUrls(text);
+        }
+      })
+      .catch(() => {
+        // Clipboard API not available or permission denied in Obsidian
+      });
   };
 
   const webUrls = urls.filter((u) => u.type === "web");

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,6 +85,7 @@ import { dehydrateDeviceProfile, hydrateDeviceProfile } from "@/settings/deviceP
 import { getDeviceId } from "@/utils/deviceId";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { installRendererEventsShim } from "@/utils/rendererEventsShim";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { ProjectContextCache } from "@/cache/projectContextCache";
 import { ContextProcessor } from "@/contextProcessor";
 import { CustomCommandManager } from "@/commands/customCommandManager";
@@ -179,7 +180,13 @@ export default class CopilotPlugin extends Plugin {
   private lastSelectionSignature?: string;
   private webSelectionTracker?: WebSelectionTracker;
   private readonly chatHistoryLastAccessedAtManager = new RecentUsageManager<string>();
-  async onload(): Promise<void> {
+  onload(): void {
+    void this.loadPlugin().catch((error: unknown) =>
+      logError("Copilot plugin failed to load", error)
+    );
+  }
+
+  private async loadPlugin(): Promise<void> {
     // Patch Node's `events.setMaxListeners` so the Claude Agent SDK's call with
     // a web-realm AbortSignal stops throwing in Electron's renderer. No-ops on
     // mobile (no node:events / no SDK). Must run before any Agent Mode session;
@@ -535,7 +542,7 @@ export default class CopilotPlugin extends Plugin {
     }
   }
 
-  async onunload() {
+  onunload(): void {
     // End the Miyo mutation lifecycle HERE, as the first statement: everything
     // above the first `await` runs before the next `onload()` can possibly
     // start, so this carries none of the late-continuation risk that keeps
@@ -545,6 +552,12 @@ export default class CopilotPlugin extends Plugin {
     // that is never followed by a re-enable, or while another vault is opening.
     resetMiyoMutations();
 
+    void this.finishUnload().catch((error: unknown) =>
+      logError("Copilot plugin failed to unload cleanly", error)
+    );
+  }
+
+  private async finishUnload(): Promise<void> {
     // Best-effort flush of pending keychain/data.json writes.
     // Reason: onunload() is void in Obsidian's type system, but awaiting here
     // is no worse than fire-and-forget, and consistent with the log flush below.
@@ -1160,7 +1173,7 @@ export default class CopilotPlugin extends Plugin {
       this.app,
       chatFiles,
       this.chatHistoryLastAccessedAtManager,
-      this.loadChatHistory.bind(this) as (file: TFile) => void
+      toVoidHandler((file: TFile) => this.loadChatHistory(file), "Load chat history")
     ).open();
   }
 

--- a/src/modelManagement/ui/components/ByokGlobalTable.tsx
+++ b/src/modelManagement/ui/components/ByokGlobalTable.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { SelfHostCloudWarningIcon } from "@/components/ui/SelfHostCloudWarningIcon";
 import type { ConfiguredModel, Provider } from "@/modelManagement/types/persisted";
 import { useModelManagement } from "@/modelManagement/ui/ModelManagementContext";
@@ -260,9 +261,10 @@ const ProviderCard: React.FC<ProviderCardProps> = ({
                 <ModelRow
                   key={model.configuredModelId}
                   model={model}
-                  onRemove={() =>
-                    handleRemoveModel(model.configuredModelId, model.info.displayName)
-                  }
+                  onRemove={toVoidHandler(
+                    () => handleRemoveModel(model.configuredModelId, model.info.displayName),
+                    "Remove configured model"
+                  )}
                 />
               ))}
             </div>

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -28,6 +28,7 @@ import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { SearchBar } from "@/components/ui/SearchBar";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { useApp } from "@/context";
 import { logError } from "@/logger";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
@@ -210,7 +211,7 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
     if (!catalogProviderId) return EMPTY_METADATA;
     return api.catalogService.getProvider(catalogProviderId)?.models ?? EMPTY_METADATA;
     // `catalogVersion` re-runs this once the catalog lands.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- provider identity, not callback identity, controls form reset
   }, [catalogProviderId, api, catalogVersion]);
 
   const [displayName, setDisplayName] = useState(() =>
@@ -486,7 +487,11 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
               }}
               placeholder={state.mode === "edit" ? "No API key set" : "Paste your API key"}
             />
-            <Button variant="secondary" onClick={handleTest} disabled={testing}>
+            <Button
+              variant="secondary"
+              onClick={toVoidHandler(handleTest, "Test provider")}
+              disabled={testing}
+            >
               {testing ? <Loader2 className="tw-size-4 tw-animate-spin" /> : "Test"}
             </Button>
             {state.mode === "edit" && apiKey.length > 0 && (
@@ -543,7 +548,11 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
           <Button variant="secondary" onClick={onClose} disabled={saving}>
             Cancel
           </Button>
-          <Button variant="default" onClick={handleSaveNew} disabled={!canSave || saving}>
+          <Button
+            variant="default"
+            onClick={toVoidHandler(handleSaveNew, "Save provider")}
+            disabled={!canSave || saving}
+          >
             {saving ? <Loader2 className="tw-size-4 tw-animate-spin" /> : "Save"}
           </Button>
         </div>
@@ -556,7 +565,11 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
             <Button variant="secondary" onClick={onClose} disabled={saving}>
               Cancel
             </Button>
-            <Button variant="default" onClick={handleSaveEdit} disabled={!canSave || saving}>
+            <Button
+              variant="default"
+              onClick={toVoidHandler(handleSaveEdit, "Update provider")}
+              disabled={!canSave || saving}
+            >
               {saving ? <Loader2 className="tw-size-4 tw-animate-spin" /> : "Save"}
             </Button>
           </div>

--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -27,6 +27,7 @@ import { ConfirmModal } from "@/components/modals/ConfirmModal";
 import { Notice } from "obsidian";
 import React, { useCallback, useEffect, useState } from "react";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
+import { toVoidHandler } from "@/utils/asyncHandler";
 
 const DESKTOP_UNAVAILABLE_FRAME_LOG_PATH = "(Agent Mode frame logs are desktop-only)";
 
@@ -200,7 +201,7 @@ export const AdvancedSettings: React.FC = () => {
             <Button
               variant="destructive"
               size="sm"
-              onClick={handleForgetAllSecrets}
+              onClick={toVoidHandler(handleForgetAllSecrets, "Forget saved secrets")}
               disabled={forgetting || !keychainAvailable}
               title={
                 keychainAvailable
@@ -280,7 +281,7 @@ export const AdvancedSettings: React.FC = () => {
             <Button
               variant="secondary"
               size="sm"
-              onClick={async () => {
+              onClick={toVoidHandler(async () => {
                 if (!isDesktopRuntime()) {
                   new Notice("Agent Mode frame logs are available on desktop only.");
                   return;
@@ -292,14 +293,14 @@ export const AdvancedSettings: React.FC = () => {
                 } catch {
                   new Notice("Failed to open Agent Mode frame log.");
                 }
-              }}
+              }, "Open Agent Mode frame log")}
             >
               Open
             </Button>
             <Button
               variant="secondary"
               size="sm"
-              onClick={async () => {
+              onClick={toVoidHandler(async () => {
                 if (!isDesktopRuntime()) {
                   new Notice("Agent Mode frame logs are available on desktop only.");
                   return;
@@ -312,7 +313,7 @@ export const AdvancedSettings: React.FC = () => {
                 } catch {
                   new Notice("Failed to clear Agent Mode frame log.");
                 }
-              }}
+              }, "Clear Agent Mode frame log")}
             >
               Clear
             </Button>

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -31,6 +31,7 @@ import {
 import { CSS } from "@dnd-kit/utilities";
 
 import { cn } from "@/lib/utils";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { logError } from "@/logger";
 import { updateSetting, useSettingsValue } from "@/settings/model";
 import { PromptSortStrategy } from "@/types";
@@ -132,15 +133,17 @@ const MobileCommandCard: React.FC<{
         </div>
         <Checkbox
           checked={command.showInSlashMenu}
-          onCheckedChange={(checked) =>
-            onUpdate(
-              {
-                ...command,
-                showInSlashMenu: checked === true,
-              },
-              command.title
-            )
-          }
+          onCheckedChange={toVoidHandler(
+            (checked) =>
+              onUpdate(
+                {
+                  ...command,
+                  showInSlashMenu: checked === true,
+                },
+                command.title
+              ),
+            "Update slash command visibility"
+          )}
         />
       </div>
     </div>
@@ -224,15 +227,17 @@ const SortableTableRow: React.FC<{
       <TableCell className="tw-text-center">
         <Checkbox
           checked={command.showInSlashMenu}
-          onCheckedChange={(checked) =>
-            onUpdate(
-              {
-                ...command,
-                showInSlashMenu: checked === true,
-              },
-              command.title
-            )
-          }
+          onCheckedChange={toVoidHandler(
+            (checked) =>
+              onUpdate(
+                {
+                  ...command,
+                  showInSlashMenu: checked === true,
+                },
+                command.title
+              ),
+            "Update slash command visibility"
+          )}
           className="tw-mx-auto"
         />
       </TableCell>
@@ -258,7 +263,7 @@ const SortableTableRow: React.FC<{
           <Button
             variant="ghost"
             size="icon"
-            onClick={() => onCopy(command)}
+            onClick={toVoidHandler(() => onCopy(command), "Duplicate command")}
             title="Duplicate command"
           >
             <CopyPlus className="tw-size-4" />

--- a/src/settings/v2/components/ModelImporter.tsx
+++ b/src/settings/v2/components/ModelImporter.tsx
@@ -11,6 +11,7 @@ import {
   verifyAndAddModel,
 } from "@/settings/v2/utils/modelActions";
 import { err2String, getProviderLabel } from "@/utils";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { Loader2 } from "lucide-react";
 import { Notice } from "obsidian";
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -219,7 +220,7 @@ export function ModelImporter({
           </div>
           <div className="tw-w-[72px]">
             <Button
-              onClick={handleAddModel}
+              onClick={toVoidHandler(handleAddModel, "Add imported model")}
               disabled={!selectedModel || verifying}
               variant="secondary"
               size="sm"

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -12,6 +12,7 @@ import {
   useLicenseState,
 } from "@/plusUtils";
 import { updateSetting, useSettingsValue } from "@/settings/model";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { ExternalLink, Loader2 } from "lucide-react";
 import React, { useState } from "react";
 
@@ -125,18 +126,21 @@ export function PlusSettings() {
         />
         <Button
           disabled={isChecking}
-          onClick={async () => {
+          onClick={toVoidHandler(async () => {
             updateSetting("plusLicenseKey", localLicenseKey);
             setIsChecking(true);
-            const result = await checkIsPaidUser(app);
-            setIsChecking(false);
-            if (!result) {
-              setError("Invalid license key");
-            } else {
-              setError(null);
-              new CopilotPlusWelcomeModal(app).open();
+            try {
+              const result = await checkIsPaidUser(app);
+              if (!result) {
+                setError("Invalid license key");
+              } else {
+                setError(null);
+                new CopilotPlusWelcomeModal(app).open();
+              }
+            } finally {
+              setIsChecking(false);
             }
-          }}
+          }, "Validate Plus license")}
           className="tw-min-w-10 tw-text-xs md:tw-text-sm"
         >
           {isChecking ? <Loader2 className="tw-size-2 tw-animate-spin md:tw-size-4" /> : "Apply"}

--- a/src/state/ChatUIState.ts
+++ b/src/state/ChatUIState.ts
@@ -47,7 +47,7 @@ export interface ChatUIState {
   readonly chatHistory: ChatMessage[];
   addMessage(message: ChatMessage): void;
   clearChatHistory(): void;
-  replaceMessages(messages: ChatMessage[]): void;
+  replaceMessages(messages: ChatMessage[]): Promise<void>;
   getDebugInfo(): unknown;
   loadMessages(messages: ChatMessage[]): Promise<void>;
   handleProjectSwitch(): Promise<void>;

--- a/src/system-prompts/SystemPromptAddModal.tsx
+++ b/src/system-prompts/SystemPromptAddModal.tsx
@@ -7,6 +7,7 @@ import { Lightbulb } from "lucide-react";
 import { App, Modal, Notice, Platform } from "obsidian";
 import { Root } from "react-dom/client";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
+import { toVoidHandler } from "@/utils/asyncHandler";
 import { UserSystemPrompt } from "@/system-prompts/type";
 import { validatePromptName } from "@/system-prompts/systemPromptUtils";
 import { SystemPromptManager } from "@/system-prompts/systemPromptManager";
@@ -269,7 +270,7 @@ export class SystemPromptAddModal extends Modal {
     this.root.render(
       <SystemPromptAddModalContent
         prompts={this.prompts}
-        onConfirm={handleConfirm}
+        onConfirm={toVoidHandler(handleConfirm, "Create system prompt")}
         onCancel={() => this.close()}
         contentEl={contentEl}
       />

--- a/src/utils/asyncHandler.test.ts
+++ b/src/utils/asyncHandler.test.ts
@@ -1,0 +1,46 @@
+jest.mock("@/logger", () => ({ logError: jest.fn() }));
+
+import { logError } from "@/logger";
+import { toVoidHandler } from "@/utils/asyncHandler";
+
+describe("asyncHandler", () => {
+  describe("toVoidHandler()", () => {
+    beforeEach(() => {
+      jest.mocked(logError).mockClear();
+    });
+
+    it("forwards arguments and returns void", async () => {
+      const handler = jest.fn(async (_value: string) => {});
+      const voidHandler = toVoidHandler(handler, "save draft");
+
+      const result = voidHandler("content");
+      await Promise.resolve();
+
+      expect(result).toBeUndefined();
+      expect(handler).toHaveBeenCalledWith("content");
+      expect(logError).not.toHaveBeenCalled();
+    });
+
+    it("reports a rejected callback promise", async () => {
+      const failure = new Error("rejected");
+      const rejection = Promise.reject(failure);
+      const voidHandler = toVoidHandler(() => rejection, "save draft");
+
+      voidHandler();
+      await rejection.catch(() => undefined);
+
+      expect(logError).toHaveBeenCalledWith("save draft failed", failure);
+    });
+
+    it("reports a callback that throws before returning a promise", () => {
+      const failure = new Error("thrown");
+      const handler = (() => {
+        throw failure;
+      }) as () => Promise<void>;
+
+      toVoidHandler(handler, "save draft")();
+
+      expect(logError).toHaveBeenCalledWith("save draft failed", failure);
+    });
+  });
+});

--- a/src/utils/asyncHandler.ts
+++ b/src/utils/asyncHandler.ts
@@ -1,0 +1,24 @@
+import { logError } from "@/logger";
+
+/**
+ * Adapt an async callback to a void-returning UI handler while ensuring every
+ * synchronous throw and promise rejection reaches the plugin logger.
+ *
+ * @param handler - Async callback to invoke with the UI-provided arguments.
+ * @param context - Operation label included with any reported failure.
+ * @returns A void-returning callback suitable for lifecycle and UI APIs.
+ */
+export function toVoidHandler<Args extends unknown[]>(
+  handler: (...args: Args) => void | Promise<unknown>,
+  context: string
+): (...args: Args) => void {
+  return (...args: Args): void => {
+    try {
+      void Promise.resolve(handler(...args)).catch((error: unknown) =>
+        logError(`${context} failed`, error)
+      );
+    } catch (error) {
+      logError(`${context} failed`, error);
+    }
+  };
+}


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#285

## Why

Obsidian's review identifies floating promises and async callbacks passed to void-returning UI and plugin lifecycle boundaries. Rejections at those boundaries can otherwise escape without context, while changing every callback into ad hoc `void` expressions would make the error policy inconsistent.

## What

This step adds one small `toVoidHandler` boundary helper that preserves callback arguments and reports synchronous throws and rejected promises through the existing logger. Affected React handlers, Obsidian modal callbacks, gallery lifecycle hooks, and plugin lifecycle entry points now make their fire-and-forget behavior explicit without changing the underlying async work or ordering.

> **Before:** async UI and lifecycle callbacks rely on implicit promise disposal, with inconsistent rejection handling.
>
> **After:** those same callbacks enter through an explicit void boundary that logs failures and preserves existing behavior.

## Non goal

- Change task ordering, retry behavior, cancellation, or concurrency.
- Redesign chat, settings, Agent Mode, gallery, or modal UX.
- Change persisted settings, chat formats, credentials, or user data schemas.
- Add new dependencies or a new async abstraction layer.
- Address CSS, dependency, or remaining strict-lint review findings in this stack step.
- Reimplement or authenticate against Obsidian's private review service.

## Screenshot

Not applicable — UI structure, copy, styling, and interaction outcomes are unchanged.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ❌ | Async entry points span several UI surfaces; focused tests cover representative paths but not every click handler |
| A defect would fail CI or be obvious on first use | ✅ | Boundary mistakes surface as failed focused tests, build errors, or logged callback failures |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Existing handler inputs are forwarded unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The helper is internal and existing data contracts are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Plugin lifecycle and chat/settings callbacks are explicitly wrapped |
| No hot-path behavior lacks deterministic coverage | ❌ | Representative chat, gallery, settings, and helper paths are covered, but not every affected handler |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ❌ | Manual verification spans plugin load, chat, settings, and Agent Mode |

Review: start with `src/utils/asyncHandler.ts` and `src/main.ts`, then inspect representative call sites in `src/components/Chat.tsx`, `src/agentMode/ui/AgentChatInput.tsx`, and `src/settings/v2/components/PlusSettings.tsx`.

## Verification

1. Run `npm test -- --runInBand dev/gallery/main.test.ts src/utils/asyncHandler.test.ts`.
2. Run `npm test -- --runInBand src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx src/agentMode/ui/AgentChatInput.test.tsx src/settings/v2/components/PlusSettings.test.tsx`.
3. Run `npm run build`.
4. In Obsidian, load and unload Copilot, then exercise chat send, Agent Mode input, provider configuration, and Plus settings actions; confirm outcomes are unchanged and failures are logged rather than emitted as unhandled rejections.

## Note

`npm run format` passes. The staged-file lint gate passes with one pre-existing test-only mobile warning in the gallery fixture. Repo-wide `npm run lint` still reports later review families tracked by issue #285; those are intentionally isolated into subsequent stack steps.