### PR TITLE
[Obsidian review blockers] - Step 1: Use the vault config directory

### DIFF
--- a/src/settings/copilotRootChange.test.ts
+++ b/src/settings/copilotRootChange.test.ts
@@ -36,7 +36,7 @@ jest.mock("@/settings/copilotSaveData", () => ({
 }));
 
 /** Minimal App; the plugin lookup is mocked away via getCopilotSaveData. */
-const app = {} as App;
+const app = { vault: { configDir: ".vault-config" } } as unknown as App;
 
 /** Minimal App whose vault reports the given Markdown file paths. */
 function appWithMarkdown(paths: string[]): App {

--- a/src/settings/copilotRootChange.ts
+++ b/src/settings/copilotRootChange.ts
@@ -197,7 +197,7 @@ export function findCopilotRootFileConflict(app: App, folder: string): string | 
  * @param newRoot - The user-entered root; re-validated defensively.
  */
 export async function applyCopilotRootChange(app: App, newRoot: string): Promise<void> {
-  const validation = validateCopilotFolder(newRoot);
+  const validation = validateCopilotFolder(newRoot, app.vault.configDir);
   if (!validation.ok) {
     logWarn("Copilot root change rejected an invalid folder value.", validation.reason);
     return;

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -744,6 +744,15 @@ describe("model", () => {
       expect(out.copilotFolder).toBe("notes/ai");
     });
 
+    it("preserves an existing config-like root without vault context", () => {
+      const out = sanitizeSettings({
+        ...DEFAULT_SETTINGS,
+        copilotFolder: ".vault-config/plugins/copilot-data",
+      });
+
+      expect(out.copilotFolder).toBe(".vault-config/plugins/copilot-data");
+    });
+
     it("rejects a parent-traversal path", () => {
       const out = sanitizeSettings({
         ...DEFAULT_SETTINGS,
@@ -767,6 +776,7 @@ describe("model", () => {
       });
       expect(out.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
     });
+
     it("unions the active root into a normalized, deduped history", () => {
       const out = sanitizeSettings({
         ...DEFAULT_SETTINGS,
@@ -828,10 +838,12 @@ describe("model", () => {
       expect(validateCopilotFolder("a/./b").ok).toBe(false);
     });
 
-    it("rejects the Obsidian config folder case-insensitively", () => {
-      // eslint-disable-next-line obsidianmd/hardcoded-config-path -- the test asserts rejection of the conventional config dir literal
-      expect(validateCopilotFolder(".obsidian").ok).toBe(false);
-      expect(validateCopilotFolder(".Obsidian/plugins").ok).toBe(false);
+    it("rejects roots that overlap the active config folder at a segment boundary", () => {
+      const configDir = ".vault-config";
+      expect(validateCopilotFolder(configDir, configDir).ok).toBe(false);
+      expect(validateCopilotFolder(`${configDir.toUpperCase()}/plugins`, configDir).ok).toBe(false);
+      expect(validateCopilotFolder("copilot", "copilot/system-prompts").ok).toBe(false);
+      expect(validateCopilotFolder("copilot-data", "copilot/system-prompts").ok).toBe(true);
     });
 
     it("rejects Windows-illegal characters in any segment", () => {

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -938,7 +938,7 @@ export function sanitizeSettings(settings: CopilotSettings): CopilotSettings {
 
   // Coerce copilotFolder to a valid vault-relative path. validateCopilotFolder
   // is the single source of truth for root syntax (empty, traversal, absolute,
-  // .obsidian, control/Windows-illegal chars) shared with the settings UI; an
+  // control/Windows-illegal chars) shared with the settings UI; an
   // invalid persisted value falls back to the default rather than being trusted.
   const copilotFolderValidation = validateCopilotFolder(
     typeof settingsToSanitize.copilotFolder === "string" ? settingsToSanitize.copilotFolder : ""
@@ -1124,17 +1124,8 @@ function sanitizeAgentMode(raw: unknown): CopilotSettings["agentMode"] {
 // creating `NUL` or `con.md` fails or misbehaves at the filesystem layer.
 const WINDOWS_RESERVED_NAME_RE = /^(con|prn|aux|nul|com[1-9]|lpt[1-9])(\..*)?$/i;
 
-// eslint-disable-next-line no-control-regex
+// eslint-disable-next-line no-control-regex -- settings paths must reject embedded control bytes
 const CONTROL_CHAR_RE = /[\u0000-\u001f\u007f]/;
-
-/**
- * The conventional Obsidian config-folder name, rejected as a Copilot root so a
- * misconfigured root can't collide with Obsidian's own config. This is a pure,
- * Vault-less syntax check, so it can only guard the near-universal default —
- * users who relocated their config dir get no false positive here.
- */
-// eslint-disable-next-line obsidianmd/hardcoded-config-path -- pure validator has no Vault to read configDir; guard the conventional default
-const CONVENTIONAL_OBSIDIAN_CONFIG_DIR = ".obsidian";
 
 /**
  * Validate a user-entered "Skills folder" value against the rules in
@@ -1205,25 +1196,27 @@ export function validateSkillsFolder(
 }
 
 /**
- * Validate a user-entered Copilot root folder (`copilotFolder`) for syntax
- * only — the reusable check shared by `sanitizeSettings` (every load / Sync /
- * hand-edited data.json passes through it) and the settings UI for early
- * feedback before Apply. Vault-content checks that need App/Vault access
- * (rejecting a root that already holds ordinary notes) live in
- * `copilotRootChange`, not here.
+ * Validate a Copilot root folder (`copilotFolder`) for portable path syntax and,
+ * when supplied, overlap with the active Obsidian configuration directory.
+ * Persisted settings intentionally omit `configDir` so changing a vault's
+ * configuration directory cannot silently relocate existing Copilot data.
+ * New settings values pass `configDir` before Apply. Vault-content checks that
+ * need App/Vault access live in `copilotRootChange`, not here.
  *
  * Unlike {@link validateSkillsFolder}, absolute and drive-letter paths are
  * rejected rather than stripped: the root is the trust boundary every derived
  * sub-folder inherits, so a leading-slash value is treated as a mistake to
- * surface, not silently rewritten. The `.obsidian` config folder is rejected
- * to keep Copilot data from colliding with Obsidian's own config.
+ * surface, not silently rewritten. The active config folder is rejected to
+ * keep Copilot data from colliding with Obsidian's own configuration.
  *
  * @param value Raw user input.
+ * @param configDir Active vault configuration directory when validating a new value.
  * @returns `{ ok: true, folder }` with the trimmed, trailing-slash-stripped
  *   value, or `{ ok: false, reason }` carrying a UI-ready message.
  */
 export function validateCopilotFolder(
-  value: string
+  value: string,
+  configDir?: string
 ): { ok: true; folder: string } | { ok: false; reason: string } {
   if (typeof value !== "string" || value.trim().length === 0) {
     return { ok: false, reason: "Folder name cannot be empty." };
@@ -1237,6 +1230,23 @@ export function validateCopilotFolder(
   const cleaned = trimmed.replace(/\\/g, "/").replace(/\/+$/, "");
   if (cleaned.length === 0) {
     return { ok: false, reason: "Folder name cannot be empty." };
+  }
+  const normalizedConfigDir = configDir
+    ?.trim()
+    .replace(/\\/g, "/")
+    .replace(/^\/+|\/+$/g, "")
+    .toLowerCase();
+  const cleanedLower = cleaned.toLowerCase();
+  if (
+    normalizedConfigDir &&
+    (cleanedLower === normalizedConfigDir ||
+      cleanedLower.startsWith(`${normalizedConfigDir}/`) ||
+      normalizedConfigDir.startsWith(`${cleanedLower}/`))
+  ) {
+    return {
+      ok: false,
+      reason: "Folder path cannot use the Obsidian config folder.",
+    };
   }
   for (const segment of cleaned.split("/")) {
     if (segment.length === 0) {
@@ -1267,12 +1277,6 @@ export function validateCopilotFolder(
     // editable — real support needs adapter-backed CRUD plus frontmatter
     // handling. Deferred as a follow-up.
     // If a future review flags this again, point them at this note.
-    if (segment.toLowerCase() === CONVENTIONAL_OBSIDIAN_CONFIG_DIR) {
-      return {
-        ok: false,
-        reason: "Folder path cannot use the Obsidian config folder.",
-      };
-    }
     if (CONTROL_CHAR_RE.test(segment)) {
       return { ok: false, reason: "Folder path contains illegal control characters." };
     }

--- a/src/settings/v2/components/BasicSettings.test.tsx
+++ b/src/settings/v2/components/BasicSettings.test.tsx
@@ -22,7 +22,10 @@ jest.mock("@/utils/desktopRuntime", () => ({ isDesktopRuntime: () => isDesktopRu
 jest.mock("@/context", () => {
   // One object for the whole suite: the real useApp reads a context-provided singleton, so a
   // fresh object per render would hand hooks a changing dependency Obsidian never gives them.
-  const app = { vault: { getMarkdownFiles: () => [] }, setting: { close: jest.fn() } };
+  const app = {
+    vault: { configDir: ".vault-config", getMarkdownFiles: () => [] },
+    setting: { close: jest.fn() },
+  };
   return {
     // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook; name must match the export
     useApp: () => app,
@@ -163,6 +166,18 @@ describe("BasicSettings", () => {
     render(<BasicSettings />);
     fireEvent.change(screen.getByLabelText("Copilot folder"), { target: { value: "../escape" } });
     fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+    expect(Notice).toHaveBeenCalledTimes(1);
+    expect(modalCtor).not.toHaveBeenCalled();
+    expect(applyCopilotRootChange).not.toHaveBeenCalled();
+  });
+
+  it("rejects a root inside the vault's active config directory", () => {
+    render(<BasicSettings />);
+    fireEvent.change(screen.getByLabelText("Copilot folder"), {
+      target: { value: ".vault-config/plugins" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Apply Copilot folder" }));
+
     expect(Notice).toHaveBeenCalledTimes(1);
     expect(modalCtor).not.toHaveBeenCalled();
     expect(applyCopilotRootChange).not.toHaveBeenCalled();

--- a/src/settings/v2/components/BasicSettings.tsx
+++ b/src/settings/v2/components/BasicSettings.tsx
@@ -108,7 +108,7 @@ export const BasicSettings: React.FC = () => {
   useEffect(() => {
     /* eslint-disable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- resync the draft when the persisted root changes underneath us (e.g. Reset Settings or a completed change) */
     setFolderDraft(persistedRoot);
-    /* eslint-enable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect */
+    /* eslint-enable @eslint-react/hooks-extra/no-direct-set-state-in-use-effect -- resume checking after persisted-root synchronization */
   }, [persistedRoot]);
 
   const [vaultInstructions, setVaultInstructions] = useAgentsFileDraft(app, "");
@@ -154,7 +154,7 @@ export const BasicSettings: React.FC = () => {
   };
 
   const applyFolderChange = () => {
-    const validation = validateCopilotFolder(folderDraft);
+    const validation = validateCopilotFolder(folderDraft, app.vault.configDir);
     if (!validation.ok) {
       new Notice(`Invalid Copilot folder: ${validation.reason}`, 5000);
       return;


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#285

## Why

The Copilot root validator assumes the conventional Obsidian configuration-folder name. Vaults can use a different configuration directory, so the current check can reject a harmless folder while allowing a newly selected Copilot root to overlap the real configuration directory.

## What

New Copilot-root selections are validated against the active vault configuration directory. Existing persisted roots remain addressable during settings loading and are not reset, moved, or migrated.

## Non goal

- Add declarative or searchable settings; that warning is deferred because it changes the settings rendering lifecycle.
- Redesign the settings UI or change labels, defaults, and storage formats.
- Move, rename, or delete existing Copilot data.

## Screenshot

Not applicable — this PR does not change rendered settings UI.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Deterministic validator and settings-component tests cover active config-directory rejection and legacy-root preservation |
| A defect would fail CI or be obvious on first use | ✅ | The changed validation branches are exercised by unit tests |
| A revert fully restores prior state, including persisted data | ✅ | The PR performs no data migration or irreversible write |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Copilot-root input validation changes |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Persisted values and storage formats are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Validation remains synchronous |
| No hot-path behavior lacks deterministic coverage | ✅ | Both UI validation and defensive apply-time validation are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Rejection appears immediately when applying an invalid root |

Review: inspect validateCopilotFolder in src/settings/model.ts, applyCopilotRootChange in src/settings/copilotRootChange.ts, and applyFolderChange in src/settings/v2/components/BasicSettings.tsx; then follow Verification steps 1–3.

## Verification

1. Open Copilot Basic settings in a vault with a custom Obsidian configuration directory.
2. Enter that configuration directory, or one of its descendants, as the Copilot folder and apply it. Confirm that the value is rejected before the confirmation dialog opens.
3. Restart with an existing syntactically valid custom Copilot root. Confirm that the stored root remains unchanged and its existing data remains available.