### PR TITLE
[Obsidian review blockers] - Step 4: Keep default effort visible

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -39,6 +39,8 @@ Selecting a row only previews its action. **Start chat** saves that agent as the
 
 The Claude setup dialog can also sign you in before a chat starts. After confirming or auto-detecting the Claude Code binary, click **Sign in** to open Claude's browser login. If the Claude CLI cannot open the browser itself, click **Open sign-in page** while sign-in is running to open the fallback URL.
 
+Under **Settings → Copilot → Basic → Agents**, each enabled agent can use a default model and effort for new chats. **Default effort** stays in place when you switch models; if the selected model does not offer effort levels, the control is disabled and shows **Not supported**.
+
 ### Choosing the OpenCode Binary Source
 
 Before OpenCode is set up, its row under **Settings → Copilot → Basic → Agents → opencode** offers both sources directly: **Download opencode** fetches an official release for Copilot to manage, and **I already have it** looks for an OpenCode you installed yourself. If that search finds nothing, a **Configure** button appears next to them so you can type the path by hand.

--- a/src/agentMode/ui/AgentDefaultEffortSetting.stories.tsx
+++ b/src/agentMode/ui/AgentDefaultEffortSetting.stories.tsx
@@ -1,0 +1,35 @@
+import {
+  AgentDefaultEffortSetting,
+  type AgentDefaultEffortSettingProps,
+} from "@/agentMode/ui/AgentDefaultEffortSetting";
+import type { Meta, StoryObj } from "@/lib/story";
+
+const meta = {
+  title: "Agent Mode/Default Effort Setting",
+  component: AgentDefaultEffortSetting,
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<AgentDefaultEffortSettingProps>;
+export default meta;
+
+export const Supported: StoryObj<AgentDefaultEffortSettingProps> = {
+  args: {
+    value: null,
+    options: [
+      { value: null, label: "Agent default" },
+      { value: "low", label: "Low" },
+      { value: "medium", label: "Medium" },
+      { value: "high", label: "High" },
+    ],
+    disabledLabel: "Not supported",
+    onChange: () => undefined,
+  },
+};
+
+export const Unsupported: StoryObj<AgentDefaultEffortSettingProps> = {
+  args: {
+    value: null,
+    options: [],
+    disabledLabel: "Not supported",
+    onChange: () => undefined,
+  },
+};

--- a/src/agentMode/ui/AgentDefaultEffortSetting.test.tsx
+++ b/src/agentMode/ui/AgentDefaultEffortSetting.test.tsx
@@ -1,0 +1,46 @@
+import {
+  AgentDefaultEffortSetting,
+  type AgentDefaultEffortSettingProps,
+} from "@/agentMode/ui/AgentDefaultEffortSetting";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+function renderSetting(props?: Partial<AgentDefaultEffortSettingProps>) {
+  const onChange = props?.onChange ?? jest.fn();
+  render(
+    <AgentDefaultEffortSetting
+      value={props?.value ?? null}
+      options={props?.options ?? []}
+      disabledLabel={props?.disabledLabel ?? "Not supported"}
+      onChange={onChange}
+    />
+  );
+  return { onChange };
+}
+
+describe("AgentDefaultEffortSetting", () => {
+  it("renders an unsupported effort state as a disabled select", () => {
+    renderSetting();
+
+    const select = screen.getByRole<HTMLSelectElement>("combobox");
+    expect(select.disabled).toBe(true);
+    expect(select.value).toBe("");
+    expect(screen.getByDisplayValue("Not supported")).toBe(select);
+  });
+
+  it("renders supported options and reports concrete and agent-default changes", () => {
+    const { onChange } = renderSetting({
+      options: [
+        { value: null, label: "Agent default" },
+        { value: "high", label: "High" },
+      ],
+    });
+
+    const select = screen.getByRole<HTMLSelectElement>("combobox");
+    expect(select.disabled).toBe(false);
+    fireEvent.change(select, { target: { value: "high" } });
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onChange).toHaveBeenNthCalledWith(1, "high");
+    expect(onChange).toHaveBeenNthCalledWith(2, null);
+  });
+});

--- a/src/agentMode/ui/AgentDefaultEffortSetting.tsx
+++ b/src/agentMode/ui/AgentDefaultEffortSetting.tsx
@@ -1,0 +1,39 @@
+import type { EffortOption } from "@/agentMode/session/types";
+import { SettingItem } from "@/components/ui/setting-item";
+import React from "react";
+
+export interface AgentDefaultEffortSettingProps {
+  value: string | null;
+  options: EffortOption[];
+  disabledLabel: string;
+  onChange: (effort: string | null) => void;
+}
+
+/**
+ * Stable settings row for a backend's default effort. Capability changes only
+ * enable or disable its select so the model list below never shifts vertically.
+ *
+ * @param props - Current effort state and the options exposed by the selected model.
+ */
+export function AgentDefaultEffortSetting({
+  value,
+  options,
+  disabledLabel,
+  onChange,
+}: AgentDefaultEffortSettingProps) {
+  const supported = options.length > 0;
+  const selectOptions = supported
+    ? options.map((option) => ({ label: option.label, value: option.value ?? "" }))
+    : [{ label: disabledLabel, value: "" }];
+
+  return (
+    <SettingItem
+      type="select"
+      title="Default effort"
+      value={supported ? (value ?? "") : ""}
+      onChange={(nextValue) => onChange(nextValue === "" ? null : nextValue)}
+      options={selectOptions}
+      disabled={!supported}
+    />
+  );
+}

--- a/src/agentMode/ui/AgentDefaultModelSetting.test.tsx
+++ b/src/agentMode/ui/AgentDefaultModelSetting.test.tsx
@@ -44,6 +44,13 @@ function makeManager(opts: {
   } as unknown as AgentSessionManager;
 }
 
+function getSettingSelect(title: string): HTMLSelectElement {
+  const row = screen.getByText(title).parentElement?.parentElement;
+  const select = row?.querySelector("select");
+  if (!(select instanceof HTMLSelectElement)) throw new Error(`${title} select was not rendered`);
+  return select;
+}
+
 describe("AgentDefaultModelSetting", () => {
   it("persists a model-only change with agent-default effort, not the first option", () => {
     const persist = jest.fn().mockResolvedValue(undefined);
@@ -90,16 +97,41 @@ describe("AgentDefaultModelSetting", () => {
     expect(screen.queryByText(/BYOK \(Add API key\)/)).not.toBeNull();
   });
 
-  it("represents an unset default as 'Agent default' with no effort row", () => {
+  it("represents an unset default as 'Agent default' with a disabled effort row", () => {
     const manager = makeManager({
       defaultSelection: null,
       effortByModel: { opus: [{ value: "high", label: "High" }] },
     });
     render(<AgentDefaultModelSetting descriptor={makeDescriptor()} manager={manager} />);
     // The model select shows the sentinel, not the first enabled model.
-    expect(screen.getByDisplayValue("Agent default")).not.toBeNull();
-    // No concrete default → the agent picks effort, so no Default effort row.
-    expect(screen.queryByText("Default effort")).toBeNull();
+    expect(getSettingSelect("Default model").value).toBe("__agent_default__");
+    // No concrete default → the agent picks effort, but the row keeps its layout space.
+    expect(getSettingSelect("Default effort").disabled).toBe(true);
+  });
+
+  it("keeps the same effort row mounted while model support changes", () => {
+    const descriptor = makeDescriptor();
+    const supportedManager = makeManager({
+      defaultSelection: { baseModelId: "opus", effort: null },
+      effortByModel: { opus: [{ value: "high", label: "High" }] },
+    });
+    const unsupportedManager = makeManager({
+      defaultSelection: { baseModelId: "sonnet", effort: null },
+    });
+    const { rerender } = render(
+      <AgentDefaultModelSetting descriptor={descriptor} manager={supportedManager} />
+    );
+
+    const effortTitle = screen.getByText("Default effort");
+    expect(getSettingSelect("Default effort").disabled).toBe(false);
+
+    rerender(<AgentDefaultModelSetting descriptor={descriptor} manager={unsupportedManager} />);
+    expect(screen.getByText("Default effort")).toBe(effortTitle);
+    expect(getSettingSelect("Default effort").disabled).toBe(true);
+
+    rerender(<AgentDefaultModelSetting descriptor={descriptor} manager={supportedManager} />);
+    expect(screen.getByText("Default effort")).toBe(effortTitle);
+    expect(getSettingSelect("Default effort").disabled).toBe(false);
   });
 
   it("selecting 'Agent default' clears the stored default", () => {

--- a/src/agentMode/ui/AgentDefaultModelSetting.tsx
+++ b/src/agentMode/ui/AgentDefaultModelSetting.tsx
@@ -4,6 +4,7 @@ import { useSettingsValue } from "@/settings/model";
 import React, { useSyncExternalStore } from "react";
 import type { AgentSessionManager } from "@/agentMode/session/AgentSessionManager";
 import type { BackendDescriptor, EnabledModelEntry } from "@/agentMode/session/types";
+import { AgentDefaultEffortSetting } from "@/agentMode/ui/AgentDefaultEffortSetting";
 import {
   EMPTY_EFFORT_OPTIONS,
   MISSING_KEY_LABEL,
@@ -19,6 +20,7 @@ interface Props {
 /** Sentinel option representing "no stored default — let the agent choose". */
 const AGENT_DEFAULT_VALUE = "__agent_default__";
 const AGENT_DEFAULT_LABEL = "Agent default";
+const EFFORT_NOT_SUPPORTED_LABEL = "Not supported";
 
 /**
  * Per-agent "Default model" picker shown in each toggled-on agent's settings
@@ -59,8 +61,9 @@ export const AgentDefaultModelSetting: React.FC<Props> = ({ descriptor, manager 
   if ((!enabled || enabled.length === 0) && !hasExplicitDefault) return null;
 
   const selectedBaseId = current?.baseModelId ?? AGENT_DEFAULT_VALUE;
-  // Only a concrete default exposes an effort row; the agent-default case
-  // lets the agent choose effort, so there's nothing to persist.
+  // Only a concrete default can expose effort options. The row itself stays
+  // mounted so async catalog refreshes and model toggles cannot shift the
+  // settings below it; unsupported states disable the control instead.
   const rawEffortOptions = hasExplicitDefault
     ? resolveEffortOptions(manager, descriptor.id, selectedBaseId)
     : EMPTY_EFFORT_OPTIONS;
@@ -74,7 +77,6 @@ export const AgentDefaultModelSetting: React.FC<Props> = ({ descriptor, manager 
     rawEffortOptions.length > 0 && !rawEffortOptions.some((o) => o.value === null)
       ? [{ value: null, label: AGENT_DEFAULT_LABEL }, ...rawEffortOptions]
       : rawEffortOptions;
-
   const onModelChange = (baseModelId: string): void => {
     if (baseModelId === AGENT_DEFAULT_VALUE) {
       manager
@@ -127,15 +129,12 @@ export const AgentDefaultModelSetting: React.FC<Props> = ({ descriptor, manager 
         onChange={onModelChange}
         options={modelOptions}
       />
-      {effortOptions.length > 0 && (
-        <SettingItem
-          type="select"
-          title="Default effort"
-          value={current?.effort ?? ""}
-          onChange={(value) => onEffortChange(value === "" ? null : value)}
-          options={effortOptions.map((o) => ({ label: o.label, value: o.value ?? "" }))}
-        />
-      )}
+      <AgentDefaultEffortSetting
+        value={current?.effort ?? null}
+        options={effortOptions}
+        disabledLabel={hasExplicitDefault ? EFFORT_NOT_SUPPORTED_LABEL : AGENT_DEFAULT_LABEL}
+        onChange={onEffortChange}
+      />
     </>
   );
 };


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#285

## Why

In **Settings → Copilot → Basic → Agents → opencode**, switching between models with and without effort levels removes and recreates the **Default effort** row. That makes the model list jump vertically while the user is toggling models.

## What

The **Default effort** row now keeps its place whenever the default-model setting is visible. Models with effort levels keep the existing selectable options; models without them show a disabled **Not supported** select. Choosing the agent-native default shows the same stable row in its disabled **Agent default** state.

## Non goal

This PR does not change model discovery, effort-capability detection, default-model persistence, session behavior, or CSS.

## Screenshot

Unavailable — the full component-gallery build is blocked on the base branch by existing SVG-loader and Node-builtin bundling errors. The exact supported and unsupported states are included as focused gallery stories and covered by deterministic component tests.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Component tests cover the supported → unsupported → supported transition, stable row identity, disabled state, labels, and value mapping |
| A defect would fail CI or be obvious on first use | ✅ | The regression test fails if the row unmounts or the disabled state is wrong |
| A revert fully restores prior state, including persisted data | ✅ | Rendering changes only; no stored settings or vault files are written differently |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The change is limited to an existing settings select |
| No public API, plugin API, message, or on-disk contract changes | ✅ | All existing runtime and persistence contracts are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Capability results are rendered synchronously from the existing model catalog |
| No hot-path behavior lacks deterministic coverage | ✅ | This settings-only path has direct transition and presentation coverage |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any layout or disabled-state regression is visible immediately in the OpenCode settings row |

Review: skim **Why** and **What**, run Verification steps 2–4, confirm CI is green, and merge without reading the diff.

## Verification

1. Build and load this branch in the documented test vault, then open **Settings → Copilot → Basic → Agents → opencode**.
2. Select an enabled OpenCode model that offers effort levels and confirm **Default effort** is enabled with its normal options.
3. Select a model that does not offer effort levels and confirm the same row remains in place, its select is greyed out with **Not supported**, and the model list below does not shift.
4. Switch back to the first model and confirm the select becomes enabled again without the row or model list moving.
