### PR TITLE
Keep invalid review fixtures out of source scans

### DIFF
--- a/designdocs/OBSIDIAN_COMMUNITY_REVIEW.md
+++ b/designdocs/OBSIDIAN_COMMUNITY_REVIEW.md
@@ -81,6 +81,5 @@ Never edit `styles.css` directly; regenerate it with `npm run build:tailwind`.
 - [`stylelint.packaged.config.mjs`](../stylelint.packaged.config.mjs)
 - [`scripts/review-obsidian-package.mjs`](../scripts/review-obsidian-package.mjs)
 - [`scripts/review-obsidian-fixtures.mjs`](../scripts/review-obsidian-fixtures.mjs)
-- [`src/review-fixtures/`](../src/review-fixtures/)
 - [Pull-request workflow](../.github/workflows/node.js.yml)
 - [Release workflow](../.github/workflows/release.yml)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,7 +17,6 @@ export default [
       "designdocs/**",
       "docs/**",
       ".claude/**",
-      "src/review-fixtures/**",
     ],
   },
 

--- a/scripts/review-obsidian-fixtures.mjs
+++ b/scripts/review-obsidian-fixtures.mjs
@@ -35,6 +35,14 @@ async function lintSourceFixture(code, filePath) {
   const eslint = new ESLint({
     cwd: repositoryRoot,
     ignore: false,
+    overrideConfig: {
+      languageOptions: {
+        parserOptions: {
+          // CI single-run programs otherwise replace lintText input with the anchor file on disk.
+          disallowAutomaticSingleRunInference: true,
+        },
+      },
+    },
     overrideConfigFile: resolve(repositoryRoot, "eslint.review.config.mjs"),
   });
   const [result] = await eslint.lintText(code, {

--- a/scripts/review-obsidian-fixtures.mjs
+++ b/scripts/review-obsidian-fixtures.mjs
@@ -1,6 +1,7 @@
 import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { ESLint } from "eslint";
 import {
   collectPackageFindings,
   getManifestFilename,
@@ -9,14 +10,51 @@ import {
 
 const repositoryRoot = resolve(fileURLToPath(new URL("..", import.meta.url)));
 
+// Negative examples must not be real source files because the authenticated
+// community reviewer scans them without the repository's local ignore rules.
+const invalidSourceFixture = `import "node:fs";
+
+// eslint-disable-next-line no-console
+console.log(fetch("https://example.com"));
+`;
+const invalidStyleWarningFixture = `.review-fixture:has(button) {
+  display: block !important;
+}
+`;
+const invalidStyleErrorFixture = `.review-fixture {
+  background-image: url("https://example.com/review-fixture.png");
+}
+`;
+const invalidLicenseFixture = "Copyright (C) 2020-2025 by Dynalist Inc.\n";
+
 function assert(condition, message) {
   if (!condition) throw new Error(message);
 }
 
-function expectRejected(command, args, expectedRules) {
+async function lintSourceFixture(code, filePath) {
+  const eslint = new ESLint({
+    cwd: repositoryRoot,
+    ignore: false,
+    overrideConfigFile: resolve(repositoryRoot, "eslint.review.config.mjs"),
+  });
+  const [result] = await eslint.lintText(code, {
+    filePath: resolve(repositoryRoot, filePath),
+  });
+  return result;
+}
+
+function expectEslintRules(result, expectedRules) {
+  const reportedRules = new Set(result.messages.map((message) => message.ruleId));
+  for (const rule of expectedRules) {
+    assert(reportedRules.has(rule), `ESLint fixture did not exercise ${rule}`);
+  }
+}
+
+function expectRejected(command, args, expectedRules, input) {
   const result = spawnSync(command, args, {
     cwd: repositoryRoot,
     encoding: "utf8",
+    input,
   });
   const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
   assert(result.status !== 0, `${command} unexpectedly accepted its invalid review fixture`);
@@ -25,10 +63,11 @@ function expectRejected(command, args, expectedRules) {
   }
 }
 
-function expectReported(command, args, expectedRules) {
+function expectReported(command, args, expectedRules, input) {
   const result = spawnSync(command, args, {
     cwd: repositoryRoot,
     encoding: "utf8",
+    input,
   });
   const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`;
   assert(result.status === 0, `${command} treated a warning-only fixture as blocking`);
@@ -38,66 +77,62 @@ function expectReported(command, args, expectedRules) {
 }
 
 async function main() {
-  expectRejected(
-    process.execPath,
-    [
-      resolve(repositoryRoot, "node_modules/eslint/bin/eslint.js"),
-      "--config",
-      "eslint.review.config.mjs",
-      "--no-ignore",
-      "src/review-fixtures/invalid-review.ts",
-    ],
-    [
-      "obsidianmd/no-nodejs-modules",
-      "no-restricted-globals",
-      "eslint-comments/require-description",
-      "eslint-comments/no-restricted-disable",
-    ]
+  const invalidSourceResult = await lintSourceFixture(invalidSourceFixture, "src/utils.ts");
+  assert(invalidSourceResult.errorCount > 0, "ESLint accepted its invalid source fixture");
+  expectEslintRules(invalidSourceResult, [
+    "obsidianmd/no-nodejs-modules",
+    "no-restricted-globals",
+    "eslint-comments/require-description",
+    "eslint-comments/no-restricted-disable",
+  ]);
+  const invalidLicenseResult = await lintSourceFixture(invalidLicenseFixture, "LICENSE");
+  assert(
+    invalidLicenseResult.errorCount === 0,
+    "ESLint treated a warning-only LICENSE fixture as blocking"
   );
+  expectEslintRules(invalidLicenseResult, ["obsidianmd/validate-license"]);
+
   expectRejected(
     process.execPath,
     [
       resolve(repositoryRoot, "node_modules/stylelint/bin/stylelint.mjs"),
+      "--stdin",
+      "--stdin-filename",
       "src/review-fixtures/invalid-review.css",
       "--config",
       "stylelint.config.mjs",
       "--max-warnings",
       "0",
     ],
-    ["declaration-no-important", "selector-pseudo-class-disallowed-list"]
+    ["declaration-no-important", "selector-pseudo-class-disallowed-list"],
+    invalidStyleWarningFixture
   );
   expectReported(
     process.execPath,
     [
       resolve(repositoryRoot, "node_modules/stylelint/bin/stylelint.mjs"),
+      "--stdin",
+      "--stdin-filename",
       "src/review-fixtures/invalid-review.css",
       "--config",
       "stylelint.config.mjs",
     ],
-    ["declaration-no-important", "selector-pseudo-class-disallowed-list"]
+    ["declaration-no-important", "selector-pseudo-class-disallowed-list"],
+    invalidStyleWarningFixture
   );
   expectRejected(
     process.execPath,
     [
       resolve(repositoryRoot, "node_modules/stylelint/bin/stylelint.mjs"),
+      "--stdin",
+      "--stdin-filename",
       "src/review-fixtures/invalid-review-error.css",
       "--config",
       "stylelint.config.mjs",
     ],
-    ["function-url-scheme-disallowed-list"]
+    ["function-url-scheme-disallowed-list"],
+    invalidStyleErrorFixture
   );
-  expectReported(
-    process.execPath,
-    [
-      resolve(repositoryRoot, "node_modules/eslint/bin/eslint.js"),
-      "--config",
-      "eslint.review.config.mjs",
-      "--no-ignore",
-      "src/review-fixtures/invalid-review-LICENSE",
-    ],
-    ["obsidianmd/validate-license"]
-  );
-
   const invalidManifestAccepted = await validateSelectedManifest(
     resolve(repositoryRoot, "manifest-beta.json"),
     JSON.stringify({

--- a/src/review-fixtures/invalid-review-LICENSE
+++ b/src/review-fixtures/invalid-review-LICENSE
@@ -1,1 +1,0 @@
-Copyright (C) 2020-2025 by Dynalist Inc.

--- a/src/review-fixtures/invalid-review-error.css
+++ b/src/review-fixtures/invalid-review-error.css
@@ -1,3 +1,0 @@
-.review-fixture {
-  background-image: url("https://example.com/review-fixture.png");
-}

--- a/src/review-fixtures/invalid-review.css
+++ b/src/review-fixtures/invalid-review.css
@@ -1,3 +1,0 @@
-.review-fixture:has(button) {
-  display: block !important;
-}

--- a/src/review-fixtures/invalid-review.ts
+++ b/src/review-fixtures/invalid-review.ts
@@ -1,4 +1,0 @@
-import "node:fs";
-
-// eslint-disable-next-line no-console
-console.log(fetch("https://example.com"));


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#285

## Why

The authenticated Obsidian review of `master@c93ecf0` still fails because it scans physical negative fixtures as plugin code. The TypeScript fixture produces two errors for its intentionally forbidden directive, while the CSS external-URL fixture produces two more errors; the CSS warning fixture also appears in the report for its intentional `!important` and `:has` cases.

## What

Keep the same negative ESLint, Stylelint, and license coverage, but store the examples as text in the fixture runner and lint them through virtual filenames. Disable TypeScript ESLint's automatic CI single-run inference for the in-memory source fixture so it cannot substitute the anchor file from disk. Delete the physical invalid source, CSS, and license files and their obsolete ESLint ignore so the authenticated reviewer cannot treat test data as shipped plugin content.

Plugin runtime behavior and UI are unchanged.

## Non goal

This does not clean up nonblocking review warnings, weaken any error rule, or change providers, settings, persistence, or user-facing behavior.

## Screenshot

Not applicable — this changes review-fixture representation only and has no rendered plugin UI.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | The fixture gate deterministically asserts the same source, style, and license findings from virtual inputs |
| A defect would fail CI or be obvious on first use | ✅ | `review:obsidian:fixtures` fails if any required rule is no longer exercised |
| A revert fully restores prior state, including persisted data | ✅ | The change is tooling-only and writes no user or repository state |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No plugin runtime code or external input path changes |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Only private review-test representation changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The plugin runtime is untouched |
| No hot-path behavior lacks deterministic coverage | ✅ | No hot-path behavior changes; the affected fixture paths are exercised deterministically |
| No new dependency | ✅ | Dependency manifests are unchanged and the runner uses the existing ESLint package |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The only external check is reviewer file discovery; a rerun immediately shows whether fixture errors remain |

Review: inspect `scripts/review-obsidian-fixtures.mjs` — `lintSourceFixture`, `expectEslintRules`, and the Stylelint stdin calls — plus the removed fixture ignore in `eslint.config.mjs`, then run Verification steps 2–4.

## Verification

1. Install the locked dependencies with `npm ci`.
2. Run `npm run review:obsidian:fixtures` and `CI=true npm run review:obsidian:fixtures`; expect the intentional source, style, license, and manifest failures to be exercised and both fixture gates to pass.
3. Run `npm run review:obsidian`; expect no errors from `src/review-fixtures`. Existing warnings remain nonblocking.
4. Run the authenticated community review for the branch; expect no errors or warnings whose path starts with `src/review-fixtures/`.