### PR TITLE
Update managed OpenCode to 1.18.16

### DIFF
--- a/designdocs/AGENT_INSTRUCTIONS_AND_PROMPT_CACHING.md
+++ b/designdocs/AGENT_INSTRUCTIONS_AND_PROMPT_CACHING.md
@@ -39,6 +39,11 @@ So the single region we could have kept permanently cached was instead the one t
 
 This is one captured request, OpenCode 1.16.0, session opened at the vault root. Character counts are for the complete serialized sections, not the visible excerpt.
 
+> Update (2026-08-10): the managed OpenCode pin advanced to 1.18.16 after a
+> real ACP initialize/session/config-option/prompt smoke test. The measurements
+> below remain the historical 1.16.0 capture; they were not relabeled as new
+> wire evidence.
+
 ```text
   ┌─ Tool definitions ─────────────────────── 49,940 chars ─┐
   ├─ System message (OpenCode joins 4 parts)   47,781 chars ─┤
@@ -254,7 +259,7 @@ Each of these would couple Copilot to OpenCode internals or provider-specific wi
 2. **No cutting the tool array**, despite it being the single largest region at 49,940 characters. It is the best-behaved region we have: byte-identical on every request at a pinned version, sorted upstream, fully cached. The only lever is OpenCode's per-agent `tools: {write: false}` map, which its own documentation marks **deprecated**, and which is keyed by version-specific tool names. A rename on upgrade would silently re-enable what we disabled. That trades a cached-token saving for an upgrade-fragility bug.
 3. **No suppression of the legacy `~/.claude/CLAUDE.md` global fallback.** Upstream-owned, observable, out of scope.
 4. **No provider cache breakpoints, `cache_control` objects, or routing keys.** These vary by OpenCode version, SDK and provider.
-5. **No OpenCode pin change.** The version-pinned wire smoke test that would gate a future pin bump is follow-up work.
+5. **No OpenCode pin change in this analysis.** The later 1.18.16 bump was gated by a real ACP initialize/session/config-option/prompt smoke test; recapturing provider request bytes remains follow-up work.
 6. **No Pi cache assessment.** The payload observer and normalized section capture belong to the Pi integration work.
 
 ## How the contract is enforced

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -312,9 +312,9 @@ export async function buildOpencodeConfig(
   // native `build` agent this only adds the external_directory key — bash/edit
   // stay at opencode's permissive defaults, so it does not start asking.
   //
-  // NOTE (version-sensitive, pinned opencode 1.16.0): the `external_directory`
+  // NOTE (version-sensitive, pinned opencode 1.18.16): the `external_directory`
   // permission key and the `{ "<glob>": "allow" }` shape are confirmed against
-  // 1.16.0; re-verify when the pinned opencode version changes.
+  // 1.18.16; re-verify when the pinned opencode version changes.
   const externalDirectoryPermission = cacheRoot
     ? { external_directory: { [`${cacheRoot}/**`]: "allow" } }
     : undefined;

--- a/src/agentMode/backends/opencode/ui/opencodeVersion.ts
+++ b/src/agentMode/backends/opencode/ui/opencodeVersion.ts
@@ -2,7 +2,7 @@
 // versions the installer uses without widening the story import fence.
 
 /** opencode release Copilot downloads for a managed installation. */
-export const OPENCODE_PINNED_VERSION = "1.16.0";
+export const OPENCODE_PINNED_VERSION = "1.18.16";
 
 /**
  * Oldest opencode release that satisfies Agent Mode's ACP contract. Version

--- a/src/agentMode/backends/shared/agentSystemPrompt.ts
+++ b/src/agentMode/backends/shared/agentSystemPrompt.ts
@@ -131,7 +131,7 @@ When the conversation includes a \`<project_context>\` block:
 
 /**
  * Resolves conflicts between the two AGENTS.md scopes. Each harness loads instruction files
- * with its own rules — opencode 1.16.0 collects every ancestor AGENTS.md nearest-first, so
+ * with its own rules — opencode 1.18.16 collects every ancestor AGENTS.md nearest-first, so
  * the project file arrives *before* the vault one — and none of those orders is configurable
  * through a documented seam. Stating the rule in prompt text is therefore the only place the
  * precedence holds for every backend at once, and it costs the same bytes in all of them.


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#238

## Why

Managed OpenCode installs still download 1.16.0 even though 1.18.16 is the current upstream release. That leaves new Agent Mode installs on an older backend and makes the version-sensitive compatibility notes stale.

## What

> **Before:** Downloading managed OpenCode installs 1.16.0.
>
> **After:** Downloading managed OpenCode installs the official 1.18.16 release, while the minimum supported ACP version remains 1.16.0.

The permission schema and ancestor `AGENTS.md` discovery assumptions remain valid at the new pin.

## Non goal

- Changing the minimum supported OpenCode version or custom-binary behavior.
- Changing permission policy, instruction precedence, prompt layout, or cache behavior.
- Relabeling the historical 1.16.0 provider-request measurements as 1.18.16 evidence; a fresh wire-byte capture remains follow-up work.

## Screenshot

Not applicable — this changes the managed runtime version, not layout or copy. Verification exposes the installed version in the existing settings path.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `OpencodeBinaryManager.test.ts` covers pin-driven release metadata, asset selection, version parsing, and managed install state |
| A defect would fail CI or be obvious on first use | ✅ | The manager tests run in CI, and Settings shows the installed version immediately after download |
| A revert fully restores prior state, including persisted data | ✅ | Reverting restores the prior download pin; no user data or schema is migrated |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Permission behavior is unchanged and was revalidated against 1.18.16 |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The managed binary location keeps the existing versioned layout and ACP protocol |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Install and session lifecycle code is unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | No hot path changes; existing manager tests cover the pin consumers |
| No new dependency | ✅ | Dependency manifests are unchanged; the existing managed runtime advances versions |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A mismatch appears in the opencode Settings row or when the first session starts |

Review: run Verification steps 2–4 and confirm the managed path reports 1.18.16 before starting the chat.

## Verification

1. Check out this branch, point `COPILOT_TEST_VAULT_PATH` at the dedicated test vault, and run `npm run test:vault`.
2. In Obsidian, open **Settings → Copilot → Basic → Agents → opencode**, click **Download opencode**, and observe **Ready** with `~/.obsidian-copilot/opencode/1.18.16/bin/opencode`.
3. Select opencode as the default backend, open Copilot Agent Chat, and start a new session. Observe an opencode tab and an advertised model.
4. Send `Reply with exactly OPENCODE_UI_E2E_OK. Do not use tools.` and observe `OPENCODE_UI_E2E_OK` in the response.
