### PR TITLE
[Provider keychain names] - Step 1: Use readable provider identities

### DIFF
--- a/src/modelManagement/providers/ProviderRegistry.test.ts
+++ b/src/modelManagement/providers/ProviderRegistry.test.ts
@@ -6,11 +6,12 @@
  * `resetSettings` / `setSettings`).
  */
 
-import { resetSettings, getSettings } from "@/settings/model";
+import { resetSettings, getSettings, setSettings } from "@/settings/model";
 import { KeychainService } from "@/services/keychainService";
 
 import type { ProviderAdapter } from "./adapters/ProviderAdapter";
 import { ProviderAdapterRegistry } from "./adapters/ProviderAdapterRegistry";
+import { buildProviderKeychainId } from "./providerIdentity";
 import { ProviderRegistry } from "./ProviderRegistry";
 
 import type { App } from "obsidian";
@@ -24,13 +25,18 @@ jest.mock("@/logger", () => ({
 
 type SecretStore = Map<string, string>;
 
-function makeFakeApp(): { app: App; secrets: SecretStore } {
+function makeFakeApp(): {
+  app: App;
+  secrets: SecretStore;
+  setSecret: jest.Mock<void, [string, string]>;
+} {
   const secrets: SecretStore = new Map();
+  const setSecret = jest.fn((id: string, value: string) => {
+    secrets.set(id, value);
+  });
   const app = {
     secretStorage: {
-      setSecret: (id: string, value: string) => {
-        secrets.set(id, value);
-      },
+      setSecret,
       getSecret: (id: string) => (secrets.has(id) ? secrets.get(id)! : null),
       listSecrets: () => Array.from(secrets.keys()),
       deleteSecret: (id: string) => {
@@ -44,7 +50,7 @@ function makeFakeApp(): { app: App; secrets: SecretStore } {
       adapter: {},
     },
   } as unknown as App;
-  return { app, secrets };
+  return { app, secrets, setSecret };
 }
 
 const anthropicStub: ProviderAdapter = {
@@ -64,12 +70,16 @@ describe("ProviderRegistry", () => {
   let app: App;
   let adapters: ProviderAdapterRegistry;
   let registry: ProviderRegistry;
+  let secrets: SecretStore;
+  let setSecret: jest.Mock<void, [string, string]>;
 
   beforeEach(() => {
     resetSettings();
     KeychainService.resetInstance();
     const fake = makeFakeApp();
     app = fake.app;
+    secrets = fake.secrets;
+    setSecret = fake.setSecret;
     // Eager init so subsequent KeychainService.getInstance() calls inside
     // the registry hit the same singleton.
     KeychainService.getInstance(app);
@@ -95,6 +105,39 @@ describe("ProviderRegistry", () => {
     expect(row?.origin).toEqual({ kind: "byok" });
     expect(row?.addedAt).toBeGreaterThanOrEqual(before);
     expect(row?.apiKeyKeychainId).toBeNull();
+  });
+
+  it("add() trims names and allocates case-insensitive suffixes without collisions", async () => {
+    const first = await registry.add({
+      providerType: "anthropic",
+      displayName: " OpenRouter ",
+      origin: { kind: "byok" },
+    });
+    const second = await registry.add({
+      providerType: "anthropic",
+      displayName: "openrouter 2",
+      origin: { kind: "byok" },
+    });
+    const third = await registry.add({
+      providerType: "anthropic",
+      displayName: "OPENROUTER",
+      origin: { kind: "byok" },
+    });
+
+    expect(registry.get(first)?.displayName).toBe("OpenRouter");
+    expect(registry.get(second)?.displayName).toBe("openrouter 2");
+    expect(registry.get(third)?.displayName).toBe("OPENROUTER 3");
+  });
+
+  it("add() rejects a blank provider name without persisting a row", async () => {
+    await expect(
+      registry.add({
+        providerType: "anthropic",
+        displayName: "  ",
+        origin: { kind: "byok" },
+      })
+    ).rejects.toThrow(/cannot be empty/i);
+    expect(registry.list()).toHaveLength(0);
   });
 
   it("list() / listByOrigin / listByProviderType return stable references when settings unchanged", async () => {
@@ -166,7 +209,106 @@ describe("ProviderRegistry", () => {
     await expect(registry.update("nope", { displayName: "x" })).rejects.toThrow(/unknown/);
   });
 
-  it("setApiKey mints apiKeyKeychainId on first call and reuses it on rotation", async () => {
+  it("update() keeps renamed providers unique and moves their existing secret", async () => {
+    await registry.add({
+      providerType: "anthropic",
+      displayName: "OpenRouter",
+      origin: { kind: "byok" },
+    });
+    const id = await registry.add({
+      providerType: "anthropic",
+      displayName: "Anthropic",
+      origin: { kind: "byok" },
+    });
+    await registry.setApiKey(id, "sk-real");
+    const oldKeychainId = registry.get(id)!.apiKeyKeychainId!;
+
+    await registry.update(id, { displayName: " openrouter " });
+
+    const row = registry.get(id)!;
+    const expectedKeychainId = buildProviderKeychainId(
+      KeychainService.getInstance(app).getVaultId(),
+      "openrouter 2",
+      id
+    );
+    expect(row.displayName).toBe("openrouter 2");
+    expect(row.apiKeyKeychainId).toBe(expectedKeychainId);
+    expect(secrets.get(expectedKeychainId)).toBe("sk-real");
+    expect(secrets.has(oldKeychainId)).toBe(false);
+  });
+
+  it.each([
+    ["punctuation-equivalent slugs", "Open.Router", "Open Router"],
+    ["Unicode-only names", "\u6d4b\u8bd5", "\u751f\u4ea7"],
+    [
+      "long names with the same readable prefix",
+      `${"Long Provider ".repeat(8)}First`,
+      `${"Long Provider ".repeat(8)}Second`,
+    ],
+  ])("update() moves the secret when renaming %s", async (_scenario, firstName, secondName) => {
+    const id = await registry.add({
+      providerType: "anthropic",
+      displayName: firstName,
+      origin: { kind: "byok" },
+    });
+    await registry.setApiKey(id, "sk-real");
+    const oldKeychainId = registry.get(id)!.apiKeyKeychainId!;
+
+    await registry.update(id, { displayName: secondName });
+
+    const row = registry.get(id)!;
+    expect(row.apiKeyKeychainId).not.toBe(oldKeychainId);
+    expect(secrets.get(row.apiKeyKeychainId!)).toBe("sk-real");
+    expect(secrets.has(oldKeychainId)).toBe(false);
+  });
+
+  it("update() leaves the old name, pointer, and secret intact when the new write fails", async () => {
+    const id = await registry.add({
+      providerType: "anthropic",
+      displayName: "Original",
+      origin: { kind: "byok" },
+    });
+    await registry.setApiKey(id, "sk-real");
+    const oldRow = registry.get(id)!;
+    const oldKeychainId = oldRow.apiKeyKeychainId!;
+    setSecret.mockImplementationOnce(() => {
+      throw new Error("keychain rejected write");
+    });
+
+    await expect(registry.update(id, { displayName: "Renamed" })).rejects.toThrow(
+      "keychain rejected write"
+    );
+
+    expect(registry.get(id)).toEqual(oldRow);
+    expect(secrets.get(oldKeychainId)).toBe("sk-real");
+    expect(secrets.size).toBe(1);
+  });
+
+  it("update() reconciles a legacy UUID pointer during a non-name update", async () => {
+    const id = await registry.add({
+      providerType: "anthropic",
+      displayName: "Anthropic Prod",
+      origin: { kind: "byok" },
+    });
+    const vaultId = KeychainService.getInstance(app).getVaultId();
+    const legacyKeychainId = `copilot-v${vaultId}-provider-${id}`;
+    secrets.set(legacyKeychainId, "sk-legacy");
+    setSettings((cur) => ({
+      providers: {
+        ...cur.providers,
+        [id]: { ...cur.providers[id], apiKeyKeychainId: legacyKeychainId },
+      },
+    }));
+
+    await registry.update(id, { baseUrl: "https://example.test" });
+
+    const expectedKeychainId = buildProviderKeychainId(vaultId, "Anthropic Prod", id);
+    expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedKeychainId);
+    expect(secrets.get(expectedKeychainId)).toBe("sk-legacy");
+    expect(secrets.has(legacyKeychainId)).toBe(false);
+  });
+
+  it("setApiKey mints a readable apiKeyKeychainId on first call and reuses it on rotation", async () => {
     const id = await registry.add({
       providerType: "anthropic",
       displayName: "A",
@@ -177,9 +319,8 @@ describe("ProviderRegistry", () => {
     await registry.setApiKey(id, "sk-first");
     const firstKeychainId = registry.get(id)!.apiKeyKeychainId;
     const vaultId = KeychainService.getInstance(app).getVaultId();
-    // Vault-namespaced so `KeychainService.clearAllVaultSecrets()` (which
-    // filters by `copilot-v{vaultId}-`) sweeps these entries.
-    expect(firstKeychainId).toBe(`copilot-v${vaultId}-provider-${id}`);
+    expect(firstKeychainId).toBe(buildProviderKeychainId(vaultId, "A", id));
+    expect(firstKeychainId).toMatch(/^copilot-v[a-z0-9]+-provider-a-[a-f0-9]{8}-[a-f0-9]{8}$/);
     expect(await registry.getApiKey(id)).toBe("sk-first");
 
     await registry.setApiKey(id, "sk-rotated");

--- a/src/modelManagement/providers/ProviderRegistry.ts
+++ b/src/modelManagement/providers/ProviderRegistry.ts
@@ -31,21 +31,13 @@ import type { ProviderType } from "@/modelManagement/types/catalog";
 import type { Provider, ProviderOrigin } from "@/modelManagement/types/persisted";
 import type { VerificationResult } from "@/modelManagement/types/runtime";
 import type { ProviderAdapterRegistry } from "./adapters/ProviderAdapterRegistry";
+import { allocateUniqueProviderDisplayName, buildProviderKeychainId } from "./providerIdentity";
 
 // Frozen empty shared across all filtered views so consumers see a
 // stable reference even when two distinct filters both yield zero rows.
 const EMPTY_LIST: readonly Provider[] = Object.freeze([]);
 
-/** Format the keychain id for a given providerId.
- *
- * Reason: vault-namespaced (`copilot-v{vaultId}-...`) so the entry is
- * picked up by `KeychainService.clearAllVaultSecrets()`, which scopes
- * cleanup by that exact prefix. A flat `copilot-provider-{id}` id would
- * silently leak past "Delete All Keys" and vault uninstall. */
-function providerKeychainId(vaultId: string, providerId: string): string {
-  return `copilot-v${vaultId}-provider-${providerId}`;
-}
-
+/** Manages persisted provider identities and their vault-scoped credentials. */
 export class ProviderRegistry {
   readonly #app: App;
   readonly #adapters: ProviderAdapterRegistry;
@@ -139,8 +131,13 @@ export class ProviderRegistry {
    */
   async add(input: Omit<Provider, "providerId" | "addedAt" | "apiKeyKeychainId">): Promise<string> {
     const providerId = uuidv4();
+    const displayName = allocateUniqueProviderDisplayName(
+      input.displayName,
+      Object.values(getSettings().providers).map((provider) => provider.displayName)
+    );
     const row: Provider = {
       ...input,
+      displayName,
       providerId,
       addedAt: Date.now(),
       apiKeyKeychainId: null,
@@ -187,8 +184,48 @@ export class ProviderRegistry {
     delete safePatch.apiKeyKeychainId;
     delete safePatch.providerType;
     delete safePatch.origin;
+    if ("displayName" in safePatch) {
+      if (typeof safePatch.displayName !== "string") {
+        throw new Error("Provider name must be a string");
+      }
+      safePatch.displayName = allocateUniqueProviderDisplayName(
+        safePatch.displayName,
+        Object.values(getSettings().providers)
+          .filter((provider) => provider.providerId !== providerId)
+          .map((provider) => provider.displayName)
+      );
+    }
     if (Object.keys(safePatch).length === 0) return;
     const next: Provider = { ...existing, ...(safePatch as Partial<Provider>) };
+
+    if (existing.apiKeyKeychainId) {
+      const keychain = KeychainService.getInstance(this.#app);
+      const nextKeychainId = buildProviderKeychainId(
+        keychain.getVaultId(),
+        next.displayName,
+        providerId
+      );
+      if (nextKeychainId !== existing.apiKeyKeychainId) {
+        const apiKey = keychain.getSecretById(existing.apiKeyKeychainId);
+        if (apiKey !== null) {
+          keychain.setSecretById(nextKeychainId, apiKey);
+        }
+        setSettings((cur) => ({
+          providers: {
+            ...cur.providers,
+            [providerId]: { ...next, apiKeyKeychainId: nextKeychainId },
+          },
+        }));
+        try {
+          keychain.deleteSecretById(existing.apiKeyKeychainId);
+        } catch (err) {
+          logError(`[modelManagement] ProviderRegistry.update: failed to clear old keychain`, err);
+        }
+        this.#emit();
+        return;
+      }
+    }
+
     setSettings((cur) => ({
       providers: { ...cur.providers, [providerId]: next },
     }));
@@ -252,9 +289,7 @@ export class ProviderRegistry {
     return KeychainService.getInstance(this.#app).getSecretById(row.apiKeyKeychainId);
   }
 
-  /** Generates a fresh `apiKeyKeychainId` if the provider doesn't
-   *  yet have one; persists the row. Re-calling with a different key
-   *  rotates in place (same keychain id, new value). */
+  /** Stores the API key under the provider's readable identity and persists its pointer. */
   async setApiKey(providerId: string, apiKey: string): Promise<void> {
     const row = getSettings().providers[providerId];
     if (!row) {
@@ -263,17 +298,23 @@ export class ProviderRegistry {
       );
     }
     const keychain = KeychainService.getInstance(this.#app);
-    const keychainId =
-      row.apiKeyKeychainId ?? providerKeychainId(keychain.getVaultId(), providerId);
-    // Persist the row's pointer BEFORE writing to the keychain so a
-    // crash (or a keychain write that throws) between the two leaves a
-    // recoverable dangling pointer (empty keychain → getApiKey returns
-    // null; clearApiKey / remove still know which id to clean up)
-    // rather than an orphaned keychain entry that no row points at.
+    const keychainId = buildProviderKeychainId(keychain.getVaultId(), row.displayName, providerId);
+    // The destination must be durable before the settings pointer moves;
+    // otherwise a rejected keychain write would make the existing secret unreachable.
+    keychain.setSecretById(keychainId, apiKey);
     if (row.apiKeyKeychainId !== keychainId) {
       this.#setApiKeyKeychainId(providerId, keychainId);
+      if (row.apiKeyKeychainId) {
+        try {
+          keychain.deleteSecretById(row.apiKeyKeychainId);
+        } catch (err) {
+          logError(
+            `[modelManagement] ProviderRegistry.setApiKey: failed to clear old keychain`,
+            err
+          );
+        }
+      }
     }
-    keychain.setSecretById(keychainId, apiKey);
     this.#emit();
   }
 

--- a/src/modelManagement/providers/providerIdentity.test.ts
+++ b/src/modelManagement/providers/providerIdentity.test.ts
@@ -1,0 +1,102 @@
+import {
+  allocateUniqueProviderDisplayName,
+  buildProviderKeychainId,
+  normalizeProviderDisplayName,
+} from "./providerIdentity";
+
+describe("providerIdentity", () => {
+  describe("normalizeProviderDisplayName()", () => {
+    it("trims a non-empty provider name", () => {
+      expect(normalizeProviderDisplayName("  OpenRouter production  ")).toBe(
+        "OpenRouter production"
+      );
+    });
+
+    it("rejects a blank provider name", () => {
+      expect(() => normalizeProviderDisplayName(" \t ")).toThrow(/cannot be empty/i);
+    });
+  });
+
+  describe("allocateUniqueProviderDisplayName()", () => {
+    it("compares names case-insensitively and fills the first available numeric suffix", () => {
+      expect(
+        allocateUniqueProviderDisplayName(" openrouter ", [
+          "OpenRouter",
+          "OPENROUTER 2",
+          "OpenRouter 4",
+        ])
+      ).toBe("openrouter 3");
+    });
+
+    it("preserves a trimmed name that is not reserved", () => {
+      expect(allocateUniqueProviderDisplayName("  Anthropic Prod ", ["Anthropic Dev"])).toBe(
+        "Anthropic Prod"
+      );
+    });
+  });
+
+  describe("buildProviderKeychainId()", () => {
+    it("includes a readable normalized name and stable provider token", () => {
+      const first = buildProviderKeychainId(
+        "1234abcd",
+        "Caf\u00e9 / Open.Router (Prod)",
+        "019ff1f2-0da5-7ab2-b3ef-ef40df54b76a"
+      );
+      const second = buildProviderKeychainId(
+        "1234abcd",
+        "Caf\u00e9 / Open.Router (Prod)",
+        "019ff1f2-0da5-7ab2-b3ef-ef40df54b76a"
+      );
+
+      expect(first).toBe(second);
+      expect(first).toContain("copilot-v1234abcd-provider-cafe-open-router");
+      expect(first).toMatch(/-[a-f0-9]{8}-[a-f0-9]{8}$/);
+      expect(first).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    });
+
+    it.each([
+      ["punctuation-equivalent slugs", "Open.Router", "Open Router"],
+      ["Unicode-only names", "\u6d4b\u8bd5", "\u751f\u4ea7"],
+      [
+        "long names with the same readable prefix",
+        `${"Long Provider ".repeat(8)}First`,
+        `${"Long Provider ".repeat(8)}Second`,
+      ],
+    ])("changes when %s change", (_scenario, firstName, secondName) => {
+      const providerId = "019ff1f2-0da5-7ab2-b3ef-ef40df54b76a";
+      const firstId = buildProviderKeychainId("1234abcd", firstName, providerId);
+      const secondId = buildProviderKeychainId("1234abcd", secondName, providerId);
+
+      expect(firstId).not.toBe(secondId);
+      expect(firstId.slice(-8)).toBe(secondId.slice(-8));
+    });
+
+    it("encodes Chinese, mixed Unicode, and emoji names into readable safe segments", () => {
+      const providerId = "019ff1f2-0da5-7ab2-b3ef-ef40df54b76a";
+      const chineseId = buildProviderKeychainId("1234abcd", "\u6d4b\u8bd5", providerId);
+      const mixedId = buildProviderKeychainId("1234abcd", "A\u6d4b\ud83d\ude80", providerId);
+      const emojiId = buildProviderKeychainId("1234abcd", "\ud83d\ude80", providerId);
+      const punctuationId = buildProviderKeychainId("1234abcd", "!!", providerId);
+
+      expect(chineseId).toMatch(/^copilot-v1234abcd-provider-u6d4b-u8bd5-[a-f0-9]{8}-[a-f0-9]{8}$/);
+      expect(mixedId).toMatch(
+        /^copilot-v1234abcd-provider-a-u6d4b-u1f680-[a-f0-9]{8}-[a-f0-9]{8}$/
+      );
+      expect(emojiId).toMatch(/^copilot-v1234abcd-provider-u1f680-[a-f0-9]{8}-[a-f0-9]{8}$/);
+      expect(punctuationId).toMatch(/^copilot-v1234abcd-provider-u21-u21-[a-f0-9]{8}-[a-f0-9]{8}$/);
+    });
+
+    it("caps long encoded IDs at 64 SecretStorage-safe characters", () => {
+      const providerId = "019ff1f2-0da5-7ab2-b3ef-ef40df54b76a";
+      const longId = buildProviderKeychainId(
+        "1234abcd",
+        `${"\u6d4b\u8bd5\ud83d\ude80".repeat(12)}${" Very Long Provider Name".repeat(8)}`,
+        providerId
+      );
+
+      expect(longId.length).toBeLessThanOrEqual(64);
+      expect(longId).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+      expect(longId).toContain("provider-u6d4b-u8bd5-u1f680");
+    });
+  });
+});

--- a/src/modelManagement/providers/providerIdentity.ts
+++ b/src/modelManagement/providers/providerIdentity.ts
@@ -1,0 +1,101 @@
+import { md5 } from "@/utils/hash";
+
+const MAX_SECRET_ID_LENGTH = 64;
+const PROVIDER_NAME_TOKEN_LENGTH = 8;
+const PROVIDER_TOKEN_LENGTH = 8;
+
+function comparableProviderName(displayName: string): string {
+  return normalizeProviderDisplayName(displayName).normalize("NFKC").toLowerCase();
+}
+
+function readableKeychainSegment(displayName: string): string {
+  const normalizedDisplayName = normalizeProviderDisplayName(displayName);
+  let segment = "";
+  for (const character of normalizedDisplayName.normalize("NFKD")) {
+    const codePoint = character.codePointAt(0)!;
+    if (codePoint >= 0x0300 && codePoint <= 0x036f) continue;
+
+    if (/^[a-z0-9]$/i.test(character)) {
+      segment += character.toLowerCase();
+    } else if (codePoint <= 0x7f) {
+      segment += "-";
+    } else {
+      segment += `-u${codePoint.toString(16)}-`;
+    }
+  }
+  const readableSegment = segment.replace(/-+/g, "-").replace(/^-+|-+$/g, "");
+  if (readableSegment) return readableSegment;
+
+  return Array.from(
+    normalizedDisplayName,
+    (character) => `u${character.codePointAt(0)!.toString(16)}`
+  ).join("-");
+}
+
+/** Normalize a provider's persisted, user-visible identity. */
+export function normalizeProviderDisplayName(displayName: string): string {
+  const normalized = displayName.trim();
+  if (!normalized) {
+    throw new Error("Provider name cannot be empty");
+  }
+  return normalized;
+}
+
+/**
+ * Allocate a unique provider name without changing the requested name unless it collides.
+ *
+ * @param requestedName - User-visible name requested for the provider.
+ * @param reservedNames - Names already owned by other providers.
+ */
+export function allocateUniqueProviderDisplayName(
+  requestedName: string,
+  reservedNames: Iterable<string>
+): string {
+  const baseName = normalizeProviderDisplayName(requestedName);
+  const reserved = new Set<string>();
+  for (const name of reservedNames) {
+    const normalized = name.trim();
+    if (normalized) reserved.add(comparableProviderName(normalized));
+  }
+  if (!reserved.has(comparableProviderName(baseName))) return baseName;
+
+  let suffix = 2;
+  while (reserved.has(comparableProviderName(`${baseName} ${suffix}`))) {
+    suffix += 1;
+  }
+  return `${baseName} ${suffix}`;
+}
+
+/**
+ * Build the readable, vault-scoped SecretStorage ID for a provider credential.
+ * A display-name fingerprint distinguishes names whose readable segments normalize
+ * or truncate identically. The final provider token remains stable across renames.
+ * The short provider token keeps the mapping recoverable when a renamed provider
+ * reaches another device before that device has moved its local keychain entry.
+ *
+ * @param vaultId - Stable vault namespace owned by KeychainService.
+ * @param displayName - Provider's unique persisted display name.
+ * @param providerId - Provider's immutable UUID.
+ */
+export function buildProviderKeychainId(
+  vaultId: string,
+  displayName: string,
+  providerId: string
+): string {
+  if (!/^[a-z0-9]+$/.test(vaultId)) {
+    throw new Error("Vault keychain ID must contain only lowercase alphanumeric characters");
+  }
+
+  const prefix = `copilot-v${vaultId}-provider-`;
+  const normalizedDisplayName = normalizeProviderDisplayName(displayName).normalize("NFKC");
+  const nameToken = md5(normalizedDisplayName).slice(0, PROVIDER_NAME_TOKEN_LENGTH);
+  const token = md5(providerId).slice(0, PROVIDER_TOKEN_LENGTH);
+  const suffix = `-${nameToken}-${token}`;
+  const nameBudget = MAX_SECRET_ID_LENGTH - prefix.length - suffix.length;
+  if (nameBudget < 1) {
+    throw new Error("Vault keychain ID is too long for provider credentials");
+  }
+
+  const readableName = readableKeychainSegment(displayName).slice(0, nameBudget).replace(/-+$/, "");
+  return `${prefix}${readableName}${suffix}`;
+}

--- a/src/modelManagement/types/persisted.ts
+++ b/src/modelManagement/types/persisted.ts
@@ -68,11 +68,11 @@ export type ProviderOrigin =
  * doesn't enforce singleton.
  */
 export interface Provider {
-  /** UUID; primary key. Also the keychain namespace (BYOK only). */
+  /** UUID; immutable primary key for persisted provider and model references. */
   providerId: string;
   /** Single dispatch field. See `ProviderType` in catalog.ts. */
   providerType: ProviderType;
-  /** User-editable label (BYOK) or auto-assigned (agent / Plus). */
+  /** Unique user-editable label (BYOK) or auto-assigned name (agent / Plus). */
   displayName: string;
   /** Overrides what the wizard pre-filled from catalog / template. */
   baseUrl?: string;


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#234

## Why

Obsidian exposes Copilot's SecretStorage IDs in its Keychain manager. Provider credentials currently appear under raw UUID-based entries, so a user cannot tell whether an entry belongs to OpenRouter, OpenAI, or another provider before removing it.

Renaming a provider also needs one authoritative credential location: the visible provider name and the local Keychain pointer must not drift apart or leave the working key behind.

## What

| Scenario | Before | After |
| --- | --- | --- |
| Add a provider | Credential entry is led by an opaque provider UUID | Entry is led by a safely encoded form of the unique provider name |
| Add another provider with the same name | Duplicate display names are persisted | Copilot allocates the next readable numbered name |
| Rename a provider | The old Keychain pointer can remain authoritative | Copilot writes the credential under the new name first, updates the pointer, then removes the old entry |
| Destination write fails | A partial rename can strand the credential | The old name, pointer, and credential remain authoritative |

## Non goal

- Removing the vault namespace or preserving downgrade access to builds that only understand the UUID entry.
- Permanently dual-writing old and new IDs, or touching Keychain entries owned by other plugins.
- Removing every opaque collision/recovery token or changing model and non-provider credential names; this slice makes provider entries name-led.
- Keeping the Keychain ID unchanged after a provider rename; this design safely moves the local credential to follow the unique display name.

## Screenshot

Not available — the changed surface is Obsidian's external Keychain manager, and this branch was not loaded into the configured test vault for a GitHub-hosted capture.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Provider identity and registry tests cover naming, collisions, Unicode encoding, rename, and rollback |
| A defect would fail CI or be obvious on first use | ✅ | Deterministic tests exercise every changed registry write path |
| A revert fully restores prior state, including persisted data | ❌ | A reverted build may not recognize a pointer already moved to the new Keychain ID |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Provider secret naming and movement change |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The persisted Keychain pointer contract changes from UUID-led to name-led IDs |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Provider rename and API-key writes use a new write-before-pointer sequence |
| No hot-path behavior lacks deterministic coverage | ✅ | Add, update, rename, set-key, collision, and failure directions are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | No untested human-only behavior is required for correctness |

Review: inspect `src/modelManagement/providers/providerIdentity.ts` — provider-name normalization and Keychain-ID construction — and `src/modelManagement/providers/ProviderRegistry.ts` — `add()`, `update()`, and `setApiKey()` — line by line, then run Verification steps 2–3, including the destination-write failure cases.

## Verification

1. Load `codex/provider-keychain-identity` in a test vault and add a provider named `OpenRouter Work` with a working key.
2. Open Obsidian's Keychain manager and confirm the Copilot entry is name-led rather than UUID-led; use the provider once to confirm the credential remains usable.
3. Rename it to `OpenRouter Personal`; confirm the new entry becomes authoritative and the old entry is removed. Then run `npm test -- src/modelManagement/providers/providerIdentity.test.ts src/modelManagement/providers/ProviderRegistry.test.ts --runInBand` to exercise Unicode, collision, and forced write-failure variants.
