### PR TITLE
Remove graduated alpha labels and distinguish Quick Chat

### DIFF
--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -25,7 +25,7 @@ The most powerful mode. Requires a [Copilot Plus](copilot-plus-and-self-host.md)
 - Remember things across conversations
 - Use a growing set of tools automatically
 
-### Projects (alpha)
+### Projects
 
 Focused workspaces with their own context, model, system prompt, and isolated chat history. Useful for keeping separate AI conversations per project. See [Projects](projects.md) for details.
 
@@ -157,7 +157,7 @@ Click the **pencil/new chat icon** to start a fresh conversation. This:
 2. Clears the chat window
 3. Resets the context to your currently active note
 
-You can also use the command palette: **New Copilot Chat**.
+You can also use the command palette: **New Copilot Quick Chat**.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ Use the **Default Mode** dropdown to set which mode opens by default:
 - **Chat** — General conversation, good for most tasks
 - **Vault QA** — Ask questions answered from your notes
 - **Copilot Plus** — Advanced mode with autonomous agent and tools (requires Copilot Plus license)
-- **Projects** — Focused workspaces (alpha feature)
+- **Projects** — Focused workspaces with their own context and chat history
 
 Most users should start with **Chat** mode.
 
@@ -117,7 +117,7 @@ These are the default shortcuts. You can customize them in **Obsidian Settings**
 | ----------------------------- | ------------------------------- |
 | Open Copilot Chat Window      | _(unbound — assign in Hotkeys)_ |
 | Toggle Copilot Chat Window    | _(unbound — assign in Hotkeys)_ |
-| New Copilot Chat              | _(unbound — assign in Hotkeys)_ |
+| New Copilot Quick Chat        | _(unbound — assign in Hotkeys)_ |
 | Quick Ask (floating input)    | _(unbound — assign in Hotkeys)_ |
 | Trigger Quick Command         | _(unbound — assign in Hotkeys)_ |
 | Add selection to chat context | _(unbound — assign in Hotkeys)_ |

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -6,10 +6,6 @@ of work.
 
 Projects support **50+ file types** beyond markdown, including PDFs, Word documents, PowerPoint, Excel, images, and more — making them ideal for analyzing large or diverse document collections.
 
-> **Note**: Projects is an alpha feature. It may have rough edges and is subject to change.
-
----
-
 ## Overview
 
 In regular chat, all conversations share the same settings and model. Projects let you create dedicated workspaces with:
@@ -31,7 +27,7 @@ In regular chat, all conversations share the same settings and model. Projects l
 
 1. Open the chat panel
 2. Click the mode selector at the top of the chat
-3. Select **Projects (alpha)**
+3. Select **Projects**
 4. Click **New Project** (or the `+` button)
 5. Fill in the project details and save
 
@@ -135,7 +131,7 @@ Sort strategy: **Settings → Copilot → Basic → Project list sort strategy**
 
 ## Limitations
 
-As an alpha feature, projects have some known limitations:
+Projects have some known limitations:
 
 - Large context sources (many notes or large files) may slow down context loading
 - The context loading on project switch is synchronous — the AI isn't available until loading completes

--- a/docs/troubleshooting-and-faq.md
+++ b/docs/troubleshooting-and-faq.md
@@ -307,7 +307,7 @@ Click the mode selector at the top of the chat panel. Available modes:
 - Chat
 - Vault QA (Basic)
 - Copilot Plus (requires license)
-- Projects (alpha)
+- Projects
 
 ### The AI keeps forgetting what we talked about earlier
 

--- a/src/commands/index.test.ts
+++ b/src/commands/index.test.ts
@@ -17,6 +17,20 @@ function markdownFile(path: string): TFile {
 
 describe("commands", () => {
   describe("registerCommands()", () => {
+    it("registers the new Quick Chat command with a name distinct from Agent Chat", () => {
+      const commands: Command[] = [];
+      const plugin = {
+        addCommand: jest.fn((command: Command) => commands.push(command)),
+        app: { workspace: { getActiveFile: jest.fn(() => null) } },
+      } as unknown as CopilotPlugin;
+
+      registerCommands(plugin, jest.fn());
+
+      const command = commands.find(({ id }) => id === COMMAND_IDS.NEW_CHAT);
+      expect(command?.name).toBe("New Copilot Quick Chat");
+      expect(command?.name).not.toBe(COMMAND_NAMES[COMMAND_IDS.NEW_AGENT_CHAT]);
+    });
+
     it("registers the Symposium palette command and publishes the active Markdown file", () => {
       const activeFile = markdownFile("Notes/Active.md");
       const commands: Command[] = [];

--- a/src/components/chat-components/ChatControls.tsx
+++ b/src/components/chat-components/ChatControls.tsx
@@ -263,7 +263,7 @@ export function ChatControls({
                   copilot plus
                 </div>
               )}
-              {selectedChain === ChainType.PROJECT_CHAIN && "projects (alpha)"}
+              {selectedChain === ChainType.PROJECT_CHAIN && "projects"}
               <ChevronDown className="tw-mt-0.5 tw-size-5" />
             </Button>
           </DropdownMenuTrigger>
@@ -313,7 +313,7 @@ export function ChatControls({
                 }}
               >
                 <LibraryBig className="tw-size-4" />
-                projects (alpha)
+                projects
               </DropdownMenuItem>
             ) : (
               <DropdownMenuItem

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -885,7 +885,7 @@ export const COMMAND_NAMES: Record<CommandId, string> = {
   [COMMAND_IDS.INSPECT_COPILOT_INDEX_BY_NOTE_PATHS]: "Inspect Copilot index by note paths (debug)",
   [COMMAND_IDS.LIST_INDEXED_FILES]: "List all indexed files (debug)",
   [COMMAND_IDS.LOAD_COPILOT_CHAT_CONVERSATION]: "Load Copilot chat conversation",
-  [COMMAND_IDS.NEW_CHAT]: "New Copilot Chat",
+  [COMMAND_IDS.NEW_CHAT]: "New Copilot Quick Chat",
   [COMMAND_IDS.NEW_AGENT_CHAT]: "New Copilot Agent Chat",
   [COMMAND_IDS.OPEN_COPILOT_CHAT_WINDOW]: "Open Copilot Chat Window",
   [COMMAND_IDS.OPEN_AGENT_CHAT_WINDOW]: "Open Copilot Agent Chat Window",

--- a/src/core/ContextManager.ts
+++ b/src/core/ContextManager.ts
@@ -231,8 +231,7 @@ export class ContextManager {
       let finalProcessedMessage = processedUserMessage + contextPortion;
 
       // 10. Auto-compact if context exceeds threshold (tokens * 4 = chars estimate)
-      // Projects mode uses a fixed 800k token threshold
-      // TODO(logan): deprecate this threshold when Projects mode is out of alpha
+      // Projects mode uses a fixed 1M token threshold.
       const PROJECT_COMPACT_THRESHOLD = 1000000;
       const tokenThreshold =
         chainType === ChainType.PROJECT_CHAIN

--- a/src/settings/v2/components/AgentSettings.test.tsx
+++ b/src/settings/v2/components/AgentSettings.test.tsx
@@ -174,10 +174,10 @@ describe("AgentSettings", () => {
     await waitFor(() => expect(mockPreloadModels).toHaveBeenCalledWith("opencode"));
   });
 
-  it("labels the section Agents and marks it alpha", () => {
+  it("labels the section Agents without an alpha badge", () => {
     render(<AgentSettings />);
     expect(screen.getByText("Agents")).not.toBeNull();
-    expect(screen.getByText("alpha")).not.toBeNull();
+    expect(screen.queryByText("alpha")).toBeNull();
   });
 
   it("renders the four sub-tabs in order: OpenCode, Claude, Codex, Quick Chat", () => {

--- a/src/settings/v2/components/AgentSettings.tsx
+++ b/src/settings/v2/components/AgentSettings.tsx
@@ -37,19 +37,6 @@ function getScrollableParent(el: HTMLElement): HTMLElement | null {
 }
 
 /**
- * Section label for the Agents block. The `alpha` badge is deliberately quiet —
- * it qualifies the heading rather than competing with it.
- */
-const AGENTS_SECTION_LABEL = (
-  <span className="tw-inline-flex tw-items-center tw-gap-1.5">
-    Agents
-    <Badge variant="outline" className="tw-px-1.5 tw-py-0 tw-font-normal">
-      alpha
-    </Badge>
-  </span>
-);
-
-/**
  * The "Agents" section of the Basic settings tab. Owns the global
  * default-backend picker and a sub-tab strip with one panel per backend plus a
  * Quick Chat panel. Each backend panel curates that backend's default model,
@@ -112,7 +99,7 @@ export const AgentSettings: React.FC = () => {
 
   return (
     <section className="tw-space-y-4">
-      <SettingSection label={AGENTS_SECTION_LABEL}>
+      <SettingSection label="Agents">
         <SettingItem
           type="select"
           title="Default backend"


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#290

## Why

The Agents heading and Projects mode still show Alpha labels even though those features have graduated. The regular-chat reset command is also named “New Copilot Chat,” which is ambiguous beside the separate “New Copilot Agent Chat” command.

## What

| Surface | Before | After |
| --- | --- | --- |
| Agents settings | “Agents” with an Alpha badge | “Agents” |
| Projects mode | “Projects (alpha)” | “Projects” |
| Regular-chat command | “New Copilot Chat” | “New Copilot Quick Chat” |

Existing command IDs, hotkeys, and behavior remain unchanged, and current user documentation now matches the product copy.

## Non goal

- Redesigning Agents settings, Projects, Quick Chat, or Agent Chat.
- Changing command IDs, existing hotkey assignments, new-chat behavior, or Projects runtime behavior.

## Screenshot

**Before**

![Agents heading with Alpha badge](https://github.com/user-attachments/assets/51b4c2d9-c0be-4be5-b5ef-8b733035a623)

**After**

![Agents heading without Alpha badge](https://github.com/user-attachments/assets/1dc5c402-bc4c-44d1-9066-33c4b500f255)

Command-palette before/after evidence is omitted because Obsidian retains cached plugin command labels across hot reloads until the application fully restarts; restarting the shared development app would disrupt other open vaults.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | This is copy and documentation cleanup; deterministic tests cover the Agents label and Quick Chat command registration |
| A defect would fail CI or be obvious on first use | ✅ | The focused assertions fail on stale labels, and incorrect copy is visible when the settings or command palette opens |
| A revert fully restores prior state, including persisted data | ✅ | No settings or persisted data changes |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Display copy only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The existing command ID and persisted formats are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No lifecycle or state logic changes |
| No hot-path behavior lacks deterministic coverage | ✅ | No hot-path behavior changes |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The affected labels appear immediately in settings, the mode selector, and command palette |

Review: run Verification steps 1–3, confirm CI is green, and merge without a line-by-line code review.

## Verification

1. Check out the branch, run `npm run test:vault`, and fully restart Obsidian so its command-palette cache refreshes.
2. Open **Settings → Copilot → Basic** and confirm the heading reads **Agents** without an Alpha badge; open the chat mode selector and confirm it reads **Projects**.
3. Search the command palette for “New Copilot” and confirm it shows **New Copilot Quick Chat** separately from **New Copilot Agent Chat**.