### PR TITLE
[Provider keychain names] - Step 2: Migrate credentials safely

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -65,7 +65,7 @@ import {
 } from "@/services/webViewerService/webViewerServiceSingleton";
 import { WebSelectionTracker } from "@/services/webViewerService/webViewerServiceSelection";
 import VectorStoreManager from "@/search/vectorStoreManager";
-import { runSettingsMigrations } from "@/settings/migrations";
+import { prepareProviderStartup } from "@/services/providerStartup";
 import { CopilotSettingTab } from "@/settings/SettingsPage";
 import {
   type CopilotSettings,
@@ -229,9 +229,6 @@ export default class CopilotPlugin extends Plugin {
         syncCopilotPlusProvider(this.modelManagement, !!isPaidUser, licenseKey)
       );
     };
-    // Initial reconcile: an already-signed-in user's `isPaidUser` is restored
-    // from disk without firing the subscription, so register on load.
-    syncPlus(getSettings().isPaidUser, getSettings().plusLicenseKey);
     this.settingsUnsubscriber = subscribeToSettingsChange((prev, next) => {
       void (async () => {
         try {
@@ -255,12 +252,13 @@ export default class CopilotPlugin extends Plugin {
         }
       })();
     });
-    // One-time settings migrations. Runs after the persist subscriber is wired
-    // (so every mutation is saved) and after createModelManagement, and before
-    // agent/model-discovery init below — so migrated BYOK providers are present
-    // when OpenCode first enumerates models. Awaited for deterministic ordering;
-    // it's a fast, one-time, no-op for already-migrated/fresh vaults.
-    await runSettingsMigrations(this.modelManagement);
+    // Repair synced provider names and this device's local keychain before Plus
+    // or agent discovery can read either. Credential reconciliation runs on every
+    // load even when the versioned settings migration is already current.
+    await prepareProviderStartup(this.modelManagement);
+    // An already-signed-in user's `isPaidUser` is restored from disk without
+    // firing the subscription, so register only after provider repair settles.
+    syncPlus(getSettings().isPaidUser, getSettings().plusLicenseKey);
     const isLegacyUpgrade = getSettings().upgradedToV8FromLegacy;
     this.addSettingTab(new CopilotSettingTab(this.app, this));
 

--- a/src/modelManagement/index.ts
+++ b/src/modelManagement/index.ts
@@ -32,6 +32,14 @@ export { CatalogDownloadService } from "./catalog/CatalogDownloadService";
 export type { CatalogDownloadDeps, CatalogRefreshResult } from "./catalog/CatalogDownloadService";
 
 export { ProviderRegistry } from "./providers/ProviderRegistry";
+export type { ProviderCredentialReconciliationResult } from "./providers/ProviderRegistry";
+export {
+  allocateUniqueProviderDisplayName,
+  buildProviderKeychainId,
+  normalizeProviderDisplayName,
+  providerDisplayNameKey,
+  providerKeychainStableToken,
+} from "./providers/providerIdentity";
 export { isSelfHostedProvider, isSelfHostedUrl } from "./providers/isSelfHostedProvider";
 export { providerNeedsSelfHostWarning } from "./providers/selfHostPolicy";
 export type { SelfHostPolicyInput } from "./providers/selfHostPolicy";

--- a/src/modelManagement/providers/ProviderRegistry.test.ts
+++ b/src/modelManagement/providers/ProviderRegistry.test.ts
@@ -11,7 +11,7 @@ import { KeychainService } from "@/services/keychainService";
 
 import type { ProviderAdapter } from "./adapters/ProviderAdapter";
 import { ProviderAdapterRegistry } from "./adapters/ProviderAdapterRegistry";
-import { buildProviderKeychainId } from "./providerIdentity";
+import { buildProviderKeychainId, providerKeychainStableToken } from "./providerIdentity";
 import { ProviderRegistry } from "./ProviderRegistry";
 
 import type { App } from "obsidian";
@@ -29,19 +29,25 @@ function makeFakeApp(): {
   app: App;
   secrets: SecretStore;
   setSecret: jest.Mock<void, [string, string]>;
+  getSecret: jest.Mock<string | null, [string]>;
+  listSecrets: jest.Mock<string[], []>;
+  deleteSecret: jest.Mock<void, [string]>;
 } {
   const secrets: SecretStore = new Map();
   const setSecret = jest.fn((id: string, value: string) => {
     secrets.set(id, value);
   });
+  const getSecret = jest.fn((id: string) => (secrets.has(id) ? secrets.get(id)! : null));
+  const listSecrets = jest.fn(() => Array.from(secrets.keys()));
+  const deleteSecret = jest.fn((id: string) => {
+    secrets.delete(id);
+  });
   const app = {
     secretStorage: {
       setSecret,
-      getSecret: (id: string) => (secrets.has(id) ? secrets.get(id)! : null),
-      listSecrets: () => Array.from(secrets.keys()),
-      deleteSecret: (id: string) => {
-        secrets.delete(id);
-      },
+      getSecret,
+      listSecrets,
+      deleteSecret,
     },
     vault: {
       // FileSystemAdapter shape is irrelevant for this test — vaultId
@@ -50,7 +56,7 @@ function makeFakeApp(): {
       adapter: {},
     },
   } as unknown as App;
-  return { app, secrets, setSecret };
+  return { app, secrets, setSecret, getSecret, listSecrets, deleteSecret };
 }
 
 const anthropicStub: ProviderAdapter = {
@@ -66,12 +72,22 @@ const anthropicStub: ProviderAdapter = {
   }),
 };
 
+function setProviderPointer(providerId: string, apiKeyKeychainId: string | null | undefined): void {
+  setSettings((cur) => ({
+    providers: {
+      ...cur.providers,
+      [providerId]: { ...cur.providers[providerId], apiKeyKeychainId },
+    },
+  }));
+}
+
 describe("ProviderRegistry", () => {
   let app: App;
   let adapters: ProviderAdapterRegistry;
   let registry: ProviderRegistry;
   let secrets: SecretStore;
   let setSecret: jest.Mock<void, [string, string]>;
+  let listSecrets: jest.Mock<string[], []>;
 
   beforeEach(() => {
     resetSettings();
@@ -80,6 +96,7 @@ describe("ProviderRegistry", () => {
     app = fake.app;
     secrets = fake.secrets;
     setSecret = fake.setSecret;
+    listSecrets = fake.listSecrets;
     // Eager init so subsequent KeychainService.getInstance() calls inside
     // the registry hit the same singleton.
     KeychainService.getInstance(app);
@@ -306,6 +323,392 @@ describe("ProviderRegistry", () => {
     expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedKeychainId);
     expect(secrets.get(expectedKeychainId)).toBe("sk-legacy");
     expect(secrets.has(legacyKeychainId)).toBe(false);
+  });
+
+  describe("reconcileCredentials()", () => {
+    it("migrates an exact legacy UUID credential to the current readable ID", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Anthropic Prod",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const legacyId = `copilot-v${vaultId}-provider-${id}`;
+      const expectedId = buildProviderKeychainId(vaultId, "Anthropic Prod", id);
+      setProviderPointer(id, legacyId);
+      secrets.set(legacyId, "sk-legacy");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 1, repointed: 1, conflicts: 0 });
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedId);
+      expect(secrets.get(expectedId)).toBe("sk-legacy");
+      expect(secrets.has(legacyId)).toBe(false);
+    });
+
+    it("infers an exact legacy UUID credential for a row whose pointer predates explicit intent", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Anthropic Prod",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const legacyId = `copilot-v${vaultId}-provider-${id}`;
+      const expectedId = buildProviderKeychainId(vaultId, "Anthropic Prod", id);
+      setProviderPointer(id, undefined);
+      secrets.set(legacyId, "sk-legacy");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 1, repointed: 1, conflicts: 0 });
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedId);
+      expect(secrets.get(expectedId)).toBe("sk-legacy");
+      expect(secrets.has(legacyId)).toBe(false);
+    });
+
+    it("preserves an undefined legacy pointer when credential inference is ambiguous", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const legacyId = `copilot-v${vaultId}-provider-${id}`;
+      const oldNameId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      setProviderPointer(id, undefined);
+      secrets.set(legacyId, "sk-legacy");
+      secrets.set(oldNameId, "sk-old-name");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 0, repointed: 0, deleted: 0, conflicts: 1 });
+      expect(registry.get(id)?.apiKeyKeychainId).toBeUndefined();
+      expect(secrets.has(expectedId)).toBe(false);
+      expect(secrets.get(legacyId)).toBe("sk-legacy");
+      expect(secrets.get(oldNameId)).toBe("sk-old-name");
+    });
+
+    it("recovers a prior readable ID after synced settings already contain a rename", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "New Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const expectedId = buildProviderKeychainId(vaultId, "New Name", id);
+      const oldNameId = buildProviderKeychainId(vaultId, "Old Name", id);
+      setProviderPointer(id, expectedId);
+      secrets.set(oldNameId, "sk-local-old-name");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 1, repointed: 0, conflicts: 0 });
+      expect(secrets.get(expectedId)).toBe("sk-local-old-name");
+      expect(secrets.has(oldNameId)).toBe(false);
+    });
+
+    it("does not overwrite a populated destination that differs from the current pointer", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      const pointerId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      setProviderPointer(id, pointerId);
+      secrets.set(pointerId, "sk-pointer");
+      secrets.set(expectedId, "sk-destination");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result.conflicts).toBe(1);
+      expect(result.migrated).toBe(0);
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(pointerId);
+      await expect(registry.getApiKey(id)).resolves.toBe("sk-pointer");
+      expect(secrets.get(pointerId)).toBe("sk-pointer");
+      expect(secrets.get(expectedId)).toBe("sk-destination");
+    });
+
+    it("does not activate ambiguous stable-token candidates", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const token = providerKeychainStableToken(id);
+      const firstCandidate = `copilot-v${vaultId}-provider-a-old-${token}`;
+      const secondCandidate = `copilot-v${vaultId}-provider-b-old-${token}`;
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      setProviderPointer(id, expectedId);
+      secrets.set(secondCandidate, "sk-second");
+      secrets.set(firstCandidate, "sk-first");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result.conflicts).toBe(1);
+      expect(result.migrated).toBe(0);
+      expect(secrets.has(expectedId)).toBe(false);
+      expect(secrets.get(firstCandidate)).toBe("sk-first");
+      expect(secrets.get(secondCandidate)).toBe("sk-second");
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedId);
+    });
+
+    it("does not let an unpointed UUID credential override a differing stable alias", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const missingPointerId = buildProviderKeychainId(vaultId, "Missing Pointer", id);
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      const legacyId = `copilot-v${vaultId}-provider-${id}`;
+      const oldNameId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      setProviderPointer(id, missingPointerId);
+      secrets.set(legacyId, "sk-legacy");
+      secrets.set(oldNameId, "sk-old-name");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 0, repointed: 0, deleted: 0, conflicts: 1 });
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(missingPointerId);
+      expect(secrets.has(expectedId)).toBe(false);
+      expect(secrets.get(legacyId)).toBe("sk-legacy");
+      expect(secrets.get(oldNameId)).toBe("sk-old-name");
+    });
+
+    it("cleans listed tombstones while preserving and canonicalizing synced key intent", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const tombstoneId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      setProviderPointer(id, tombstoneId);
+      secrets.set(tombstoneId, "");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 1, repointed: 1, deleted: 1 });
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedId);
+      expect(secrets.has(tombstoneId)).toBe(false);
+      expect(secrets.get(expectedId)).toBe("");
+    });
+
+    it("leaves providers without credentials pointer-free", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 0, repointed: 0, deleted: 0 });
+      expect(registry.get(id)?.apiKeyKeychainId).toBeNull();
+      expect(secrets.size).toBe(0);
+    });
+
+    it("canonicalizes a non-null synced pointer on a device without the credential", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const priorId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      setProviderPointer(id, priorId);
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 0, repointed: 1, deleted: 0 });
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedId);
+      expect(secrets.size).toBe(0);
+    });
+
+    it("does not reactivate a leftover local credential after settings sync an explicit clear", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const oldNameId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      secrets.set(oldNameId, "sk-leftover");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 0, repointed: 0, deleted: 0 });
+      expect(registry.get(id)?.apiKeyKeychainId).toBeNull();
+      expect(secrets.has(expectedId)).toBe(false);
+      expect(secrets.get(oldNameId)).toBe("sk-leftover");
+    });
+
+    it("honors a canonical tombstone instead of resurrecting an old readable credential", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      const oldNameId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      setProviderPointer(id, oldNameId);
+      secrets.set(expectedId, "");
+      secrets.set(oldNameId, "sk-old");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({ migrated: 0, repointed: 1, conflicts: 1 });
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedId);
+      expect(secrets.get(expectedId)).toBe("");
+      expect(secrets.get(oldNameId)).toBe("sk-old");
+    });
+
+    it("propagates a pointed tombstone without reactivating a populated old alias", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      const tombstoneId = buildProviderKeychainId(vaultId, "Cleared Name", id);
+      const populatedAliasId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      setProviderPointer(id, tombstoneId);
+      secrets.set(tombstoneId, "");
+      secrets.set(populatedAliasId, "sk-old");
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result).toMatchObject({
+        migrated: 1,
+        repointed: 1,
+        deleted: 1,
+        conflicts: 1,
+      });
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedId);
+      await expect(registry.getApiKey(id)).resolves.toBe("");
+      expect(secrets.has(tombstoneId)).toBe(false);
+      expect(secrets.get(expectedId)).toBe("");
+      expect(secrets.get(populatedAliasId)).toBe("sk-old");
+    });
+
+    it("keeps a pointed tombstone active when writing the canonical tombstone fails", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      const tombstoneId = buildProviderKeychainId(vaultId, "Cleared Name", id);
+      const populatedAliasId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      setProviderPointer(id, tombstoneId);
+      secrets.set(tombstoneId, "");
+      secrets.set(populatedAliasId, "sk-old");
+      setSecret.mockImplementationOnce(() => {
+        throw new Error("keychain locked");
+      });
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result.failures).toHaveLength(1);
+      expect(result.migrated).toBe(0);
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(tombstoneId);
+      await expect(registry.getApiKey(id)).resolves.toBe("");
+      expect(secrets.has(expectedId)).toBe(false);
+      expect(secrets.get(tombstoneId)).toBe("");
+      expect(secrets.get(populatedAliasId)).toBe("sk-old");
+    });
+
+    it("leaves the source and pointer intact when the destination write fails", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const sourceId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      secrets.set(sourceId, "sk-source");
+      setProviderPointer(id, sourceId);
+      setSecret.mockImplementationOnce(() => {
+        throw new Error("keychain locked");
+      });
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result.failures).toHaveLength(1);
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(sourceId);
+      expect(secrets.get(sourceId)).toBe("sk-source");
+      expect(secrets.size).toBe(1);
+    });
+
+    it("uses known pointers safely when SecretStorage enumeration fails", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const sourceId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      secrets.set(sourceId, "sk-source");
+      setProviderPointer(id, sourceId);
+      listSecrets.mockImplementationOnce(() => {
+        throw new Error("enumeration failed");
+      });
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result.failures).toHaveLength(1);
+      expect(secrets.get(expectedId)).toBe("sk-source");
+      expect(secrets.get(sourceId)).toBe("sk-source");
+      expect(registry.get(id)?.apiKeyKeychainId).toBe(expectedId);
+    });
+
+    it("leaves an undefined legacy pointer untouched when SecretStorage enumeration fails", async () => {
+      const id = await registry.add({
+        providerType: "anthropic",
+        displayName: "Current Name",
+        origin: { kind: "byok" },
+      });
+      const vaultId = KeychainService.getInstance(app).getVaultId();
+      const expectedId = buildProviderKeychainId(vaultId, "Current Name", id);
+      const sourceId = buildProviderKeychainId(vaultId, "Prior Name", id);
+      setProviderPointer(id, undefined);
+      secrets.set(sourceId, "sk-undiscovered");
+      listSecrets.mockImplementationOnce(() => {
+        throw new Error("enumeration failed");
+      });
+
+      const result = await registry.reconcileCredentials();
+
+      expect(result.failures).toHaveLength(1);
+      expect(result.migrated).toBe(0);
+      expect(secrets.has(expectedId)).toBe(false);
+      expect(secrets.get(sourceId)).toBe("sk-undiscovered");
+      expect(registry.get(id)?.apiKeyKeychainId).toBeUndefined();
+    });
+
+    it("degrades safely when SecretStorage is unavailable", async () => {
+      KeychainService.resetInstance();
+      const unavailableApp = { vault: { adapter: {} } } as unknown as App;
+      const unavailableRegistry = new ProviderRegistry(unavailableApp, adapters);
+
+      await expect(unavailableRegistry.reconcileCredentials()).resolves.toMatchObject({
+        unavailable: true,
+        migrated: 0,
+        repointed: 0,
+      });
+    });
   });
 
   it("setApiKey mints a readable apiKeyKeychainId on first call and reuses it on rotation", async () => {

--- a/src/modelManagement/providers/ProviderRegistry.ts
+++ b/src/modelManagement/providers/ProviderRegistry.ts
@@ -22,7 +22,7 @@
 import type { App } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 
-import { logError } from "@/logger";
+import { logError, logWarn } from "@/logger";
 import { KeychainService } from "@/services/keychainService";
 import { getSettings, setSettings } from "@/settings/model";
 import { frozenOr, sliceMemo, sliceMemoByKey } from "@/utils/sliceCache";
@@ -31,11 +31,33 @@ import type { ProviderType } from "@/modelManagement/types/catalog";
 import type { Provider, ProviderOrigin } from "@/modelManagement/types/persisted";
 import type { VerificationResult } from "@/modelManagement/types/runtime";
 import type { ProviderAdapterRegistry } from "./adapters/ProviderAdapterRegistry";
-import { allocateUniqueProviderDisplayName, buildProviderKeychainId } from "./providerIdentity";
+import {
+  allocateUniqueProviderDisplayName,
+  buildProviderKeychainId,
+  providerKeychainStableToken,
+} from "./providerIdentity";
 
 // Frozen empty shared across all filtered views so consumers see a
 // stable reference even when two distinct filters both yield zero rows.
 const EMPTY_LIST: readonly Provider[] = Object.freeze([]);
+
+/** Observable outcome of one device-local provider credential reconciliation pass. */
+export interface ProviderCredentialReconciliationResult {
+  migrated: number;
+  repointed: number;
+  deleted: number;
+  conflicts: number;
+  failures: string[];
+  unavailable: boolean;
+}
+
+function addCandidate(candidates: string[], candidate: string | null | undefined): void {
+  if (candidate && !candidates.includes(candidate)) candidates.push(candidate);
+}
+
+function hasSecretValue(value: string | null): value is string {
+  return value !== null && value !== "";
+}
 
 /** Manages persisted provider identities and their vault-scoped credentials. */
 export class ProviderRegistry {
@@ -287,6 +309,350 @@ export class ProviderRegistry {
     const row = getSettings().providers[providerId];
     if (!row || !row.apiKeyKeychainId) return null;
     return KeychainService.getInstance(this.#app).getSecretById(row.apiKeyKeychainId);
+  }
+
+  /**
+   * Reconcile every provider pointer and device-local credential with its current readable ID.
+   * Runs on every startup because settings sync can deliver a rename before this device has
+   * moved the corresponding local keychain entry.
+   */
+  async reconcileCredentials(): Promise<ProviderCredentialReconciliationResult> {
+    const result: ProviderCredentialReconciliationResult = {
+      migrated: 0,
+      repointed: 0,
+      deleted: 0,
+      conflicts: 0,
+      failures: [],
+      unavailable: false,
+    };
+    const keychain = KeychainService.getInstance(this.#app);
+    if (!keychain.isAvailable()) {
+      result.unavailable = true;
+      return result;
+    }
+
+    let listedIds: string[] = [];
+    let enumerationComplete = true;
+    try {
+      listedIds = keychain.listSecretIds();
+    } catch (err) {
+      enumerationComplete = false;
+      const failure = "failed to list SecretStorage IDs";
+      result.failures.push(failure);
+      logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+    }
+    const listedIdSet = new Set(listedIds);
+    let changed = false;
+
+    for (const row of [...Object.values(getSettings().providers)].sort((a, b) =>
+      a.providerId.localeCompare(b.providerId)
+    )) {
+      const vaultId = keychain.getVaultId();
+      let expectedId: string;
+      try {
+        expectedId = buildProviderKeychainId(vaultId, row.displayName, row.providerId);
+      } catch (err) {
+        const failure = `provider ${row.providerId}: invalid readable keychain identity`;
+        result.failures.push(failure);
+        logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+        continue;
+      }
+
+      const legacyId = `copilot-v${vaultId}-provider-${row.providerId}`;
+      const providerPrefix = `copilot-v${vaultId}-provider-`;
+      const stableSuffix = `-${providerKeychainStableToken(row.providerId)}`;
+      const stableCandidates = enumerationComplete
+        ? listedIds
+            .filter((id) => id.startsWith(providerPrefix) && id.endsWith(stableSuffix))
+            .sort()
+        : [];
+      const candidateIds: string[] = [];
+      addCandidate(candidateIds, row.apiKeyKeychainId);
+      addCandidate(candidateIds, expectedId);
+      if (enumerationComplete) addCandidate(candidateIds, legacyId);
+      for (const candidate of stableCandidates) addCandidate(candidateIds, candidate);
+
+      const values = new Map<string, string | null>();
+      let readFailed = false;
+      for (const candidateId of candidateIds) {
+        try {
+          values.set(candidateId, keychain.getSecretById(candidateId));
+        } catch (err) {
+          const failure = `provider ${row.providerId}: failed to read ${candidateId}`;
+          result.failures.push(failure);
+          logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+          readFailed = true;
+          break;
+        }
+      }
+      if (readFailed) continue;
+
+      const pointerId = row.apiKeyKeychainId;
+      const destinationValue = values.get(expectedId) ?? null;
+      const populated = candidateIds.filter((id) => hasSecretValue(values.get(id) ?? null));
+
+      // Undefined predates the explicit pointer contract, so it permits inference
+      // only from a complete, unambiguous view of this device's keychain.
+      if (pointerId === undefined) {
+        if (!enumerationComplete) continue;
+        if (destinationValue === "") {
+          if (populated.length > 0) {
+            result.conflicts += 1;
+            logWarn(
+              `[modelManagement] ProviderRegistry.reconcileCredentials: provider ${row.providerId} has a canonical tombstone; preserving older credentials`
+            );
+          }
+          continue;
+        }
+
+        const inferredValues = new Set(populated.map((id) => values.get(id)!));
+        if (inferredValues.size > 1) {
+          result.conflicts += 1;
+          logWarn(
+            `[modelManagement] ProviderRegistry.reconcileCredentials: provider ${row.providerId} has ambiguous legacy credentials; preserving every candidate`
+          );
+          continue;
+        }
+        const inferredSourceId = populated[0];
+        if (!inferredSourceId) continue;
+        const inferredValue = values.get(inferredSourceId)!;
+
+        if (destinationValue === null) {
+          try {
+            keychain.setSecretById(expectedId, inferredValue);
+            result.migrated += 1;
+          } catch (err) {
+            const failure = `provider ${row.providerId}: failed to write ${expectedId}`;
+            result.failures.push(failure);
+            logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+            continue;
+          }
+        }
+
+        this.#setApiKeyKeychainId(row.providerId, expectedId);
+        result.repointed += 1;
+        changed = true;
+        for (const candidateId of candidateIds) {
+          if (candidateId === expectedId) continue;
+          const value = values.get(candidateId) ?? null;
+          const mayDelete =
+            value === inferredValue || (!hasSecretValue(value) && listedIdSet.has(candidateId));
+          if (!mayDelete) continue;
+          try {
+            keychain.deleteSecretById(candidateId);
+            result.deleted += 1;
+          } catch (err) {
+            const failure = `provider ${row.providerId}: failed to delete ${candidateId}`;
+            result.failures.push(failure);
+            logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+          }
+        }
+        continue;
+      }
+
+      // A null pointer is synced clear intent. Device-local leftovers must never
+      // reactivate a provider whose settings explicitly say it has no credential.
+      if (pointerId === null) {
+        const orphanValues = new Set(populated.map((id) => values.get(id)!));
+        if (orphanValues.size > 1) {
+          result.conflicts += 1;
+          logWarn(
+            `[modelManagement] ProviderRegistry.reconcileCredentials: provider ${row.providerId} has ambiguous orphan credentials; preserving every candidate`
+          );
+          continue;
+        }
+        if (enumerationComplete) {
+          for (const candidateId of candidateIds) {
+            if (values.get(candidateId) !== "" || !listedIdSet.has(candidateId)) continue;
+            try {
+              keychain.deleteSecretById(candidateId);
+              result.deleted += 1;
+            } catch (err) {
+              const failure = `provider ${row.providerId}: failed to delete ${candidateId}`;
+              result.failures.push(failure);
+              logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+            }
+          }
+        }
+        continue;
+      }
+
+      const pointerValue = values.get(pointerId) ?? null;
+      if (pointerValue === "") {
+        if (hasSecretValue(destinationValue)) {
+          result.conflicts += 1;
+          logWarn(
+            `[modelManagement] ProviderRegistry.reconcileCredentials: provider ${row.providerId} has a pointed tombstone and populated destination; preserving both`
+          );
+          continue;
+        }
+        if (populated.length > 0) {
+          result.conflicts += 1;
+          logWarn(
+            `[modelManagement] ProviderRegistry.reconcileCredentials: provider ${row.providerId} has a pointed tombstone; preserving older credentials`
+          );
+        }
+        if (destinationValue === null) {
+          try {
+            keychain.setSecretById(expectedId, "");
+            result.migrated += 1;
+          } catch (err) {
+            const failure = `provider ${row.providerId}: failed to write ${expectedId}`;
+            result.failures.push(failure);
+            logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+            continue;
+          }
+        }
+        if (pointerId !== expectedId) {
+          this.#setApiKeyKeychainId(row.providerId, expectedId);
+          result.repointed += 1;
+          changed = true;
+        }
+        if (enumerationComplete) {
+          for (const candidateId of candidateIds) {
+            if (
+              candidateId === expectedId ||
+              values.get(candidateId) !== "" ||
+              !listedIdSet.has(candidateId)
+            ) {
+              continue;
+            }
+            try {
+              keychain.deleteSecretById(candidateId);
+              result.deleted += 1;
+            } catch (err) {
+              const failure = `provider ${row.providerId}: failed to delete ${candidateId}`;
+              result.failures.push(failure);
+              logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+            }
+          }
+        }
+        continue;
+      }
+
+      // A tombstone at the canonical destination is stronger than any older
+      // device-local value: it prevents an alias from resurrecting a cleared key.
+      if (destinationValue === "") {
+        const oldPopulated = populated.filter((id) => id !== expectedId);
+        if (oldPopulated.length > 0) {
+          result.conflicts += 1;
+          logWarn(
+            `[modelManagement] ProviderRegistry.reconcileCredentials: provider ${row.providerId} has a canonical tombstone; preserving older credentials`
+          );
+        }
+        if (pointerId !== expectedId) {
+          this.#setApiKeyKeychainId(row.providerId, expectedId);
+          result.repointed += 1;
+          changed = true;
+        }
+        if (enumerationComplete) {
+          for (const candidateId of candidateIds) {
+            if (
+              candidateId === expectedId ||
+              values.get(candidateId) !== "" ||
+              !listedIdSet.has(candidateId)
+            ) {
+              continue;
+            }
+            try {
+              keychain.deleteSecretById(candidateId);
+              result.deleted += 1;
+            } catch (err) {
+              const failure = `provider ${row.providerId}: failed to delete ${candidateId}`;
+              result.failures.push(failure);
+              logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+            }
+          }
+        }
+        continue;
+      }
+
+      let sourceId: string | undefined;
+      if (hasSecretValue(pointerValue)) sourceId = pointerId;
+      else if (hasSecretValue(destinationValue)) sourceId = expectedId;
+
+      if (!sourceId && enumerationComplete) {
+        const unpointedIds: string[] = [];
+        addCandidate(unpointedIds, legacyId);
+        for (const candidateId of stableCandidates) addCandidate(unpointedIds, candidateId);
+        const unpointedValues = new Map<string, string>();
+        for (const candidateId of unpointedIds) {
+          const value = values.get(candidateId) ?? null;
+          if (hasSecretValue(value) && !unpointedValues.has(value)) {
+            unpointedValues.set(value, candidateId);
+          }
+        }
+        if (unpointedValues.size > 1) {
+          result.conflicts += 1;
+          logWarn(
+            `[modelManagement] ProviderRegistry.reconcileCredentials: provider ${row.providerId} has ambiguous unpointed credentials; preserving every candidate`
+          );
+          continue;
+        }
+        sourceId = unpointedValues.values().next().value;
+      }
+
+      const sourceValue = sourceId ? (values.get(sourceId) ?? null) : null;
+      if (
+        hasSecretValue(destinationValue) &&
+        hasSecretValue(sourceValue) &&
+        sourceId !== expectedId &&
+        sourceValue !== destinationValue
+      ) {
+        result.conflicts += 1;
+        logWarn(
+          `[modelManagement] ProviderRegistry.reconcileCredentials: provider ${row.providerId} has a differing destination; preserving both credentials`
+        );
+        continue;
+      }
+
+      const differingValues = new Set(populated.map((id) => values.get(id)!));
+      if (differingValues.size > 1) {
+        result.conflicts += 1;
+        logWarn(
+          `[modelManagement] ProviderRegistry.reconcileCredentials: provider ${row.providerId} has multiple credential candidates; preserving non-selected values`
+        );
+      }
+
+      if (destinationValue === null && hasSecretValue(sourceValue)) {
+        try {
+          keychain.setSecretById(expectedId, sourceValue);
+          result.migrated += 1;
+        } catch (err) {
+          const failure = `provider ${row.providerId}: failed to write ${expectedId}`;
+          result.failures.push(failure);
+          logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+          continue;
+        }
+      }
+
+      if (pointerId !== expectedId) {
+        this.#setApiKeyKeychainId(row.providerId, expectedId);
+        result.repointed += 1;
+        changed = true;
+      }
+
+      if (!enumerationComplete) continue;
+      for (const candidateId of candidateIds) {
+        if (candidateId === expectedId) continue;
+        const value = values.get(candidateId) ?? null;
+        const mayDelete =
+          (hasSecretValue(sourceValue) && value === sourceValue) ||
+          (!hasSecretValue(value) && listedIdSet.has(candidateId));
+        if (!mayDelete) continue;
+        try {
+          keychain.deleteSecretById(candidateId);
+          result.deleted += 1;
+        } catch (err) {
+          const failure = `provider ${row.providerId}: failed to delete ${candidateId}`;
+          result.failures.push(failure);
+          logError(`[modelManagement] ProviderRegistry.reconcileCredentials: ${failure}`, err);
+        }
+      }
+    }
+
+    if (changed || result.migrated > 0) this.#emit();
+    return result;
   }
 
   /** Stores the API key under the provider's readable identity and persists its pointer. */

--- a/src/modelManagement/providers/providerIdentity.test.ts
+++ b/src/modelManagement/providers/providerIdentity.test.ts
@@ -2,6 +2,8 @@ import {
   allocateUniqueProviderDisplayName,
   buildProviderKeychainId,
   normalizeProviderDisplayName,
+  providerDisplayNameKey,
+  providerKeychainStableToken,
 } from "./providerIdentity";
 
 describe("providerIdentity", () => {
@@ -32,6 +34,24 @@ describe("providerIdentity", () => {
       expect(allocateUniqueProviderDisplayName("  Anthropic Prod ", ["Anthropic Dev"])).toBe(
         "Anthropic Prod"
       );
+    });
+  });
+
+  describe("providerDisplayNameKey()", () => {
+    it("normalizes canonical Unicode forms and casing for comparison", () => {
+      expect(providerDisplayNameKey(" CAF\u00c9 ")).toBe(providerDisplayNameKey("cafe\u0301"));
+    });
+  });
+
+  describe("providerKeychainStableToken()", () => {
+    it("is deterministic and changes with the immutable provider id", () => {
+      expect(providerKeychainStableToken("provider-a")).toBe(
+        providerKeychainStableToken("provider-a")
+      );
+      expect(providerKeychainStableToken("provider-a")).not.toBe(
+        providerKeychainStableToken("provider-b")
+      );
+      expect(providerKeychainStableToken("provider-a")).toMatch(/^[a-f0-9]{8}$/);
     });
   });
 

--- a/src/modelManagement/providers/providerIdentity.ts
+++ b/src/modelManagement/providers/providerIdentity.ts
@@ -4,7 +4,8 @@ const MAX_SECRET_ID_LENGTH = 64;
 const PROVIDER_NAME_TOKEN_LENGTH = 8;
 const PROVIDER_TOKEN_LENGTH = 8;
 
-function comparableProviderName(displayName: string): string {
+/** Return the canonical comparison key used by the global uniqueness invariant. */
+export function providerDisplayNameKey(displayName: string): string {
   return normalizeProviderDisplayName(displayName).normalize("NFKC").toLowerCase();
 }
 
@@ -55,15 +56,20 @@ export function allocateUniqueProviderDisplayName(
   const reserved = new Set<string>();
   for (const name of reservedNames) {
     const normalized = name.trim();
-    if (normalized) reserved.add(comparableProviderName(normalized));
+    if (normalized) reserved.add(providerDisplayNameKey(normalized));
   }
-  if (!reserved.has(comparableProviderName(baseName))) return baseName;
+  if (!reserved.has(providerDisplayNameKey(baseName))) return baseName;
 
   let suffix = 2;
-  while (reserved.has(comparableProviderName(`${baseName} ${suffix}`))) {
+  while (reserved.has(providerDisplayNameKey(`${baseName} ${suffix}`))) {
     suffix += 1;
   }
   return `${baseName} ${suffix}`;
+}
+
+/** Return the stable suffix used to discover a provider's prior readable IDs. */
+export function providerKeychainStableToken(providerId: string): string {
+  return md5(providerId).slice(0, PROVIDER_TOKEN_LENGTH);
 }
 
 /**
@@ -89,7 +95,7 @@ export function buildProviderKeychainId(
   const prefix = `copilot-v${vaultId}-provider-`;
   const normalizedDisplayName = normalizeProviderDisplayName(displayName).normalize("NFKC");
   const nameToken = md5(normalizedDisplayName).slice(0, PROVIDER_NAME_TOKEN_LENGTH);
-  const token = md5(providerId).slice(0, PROVIDER_TOKEN_LENGTH);
+  const token = providerKeychainStableToken(providerId);
   const suffix = `-${nameToken}-${token}`;
   const nameBudget = MAX_SECRET_ID_LENGTH - prefix.length - suffix.length;
   if (nameBudget < 1) {

--- a/src/services/keychainService.test.ts
+++ b/src/services/keychainService.test.ts
@@ -208,6 +208,22 @@ describe("keychainService", () => {
       });
     });
 
+    describe("listSecretIds()", () => {
+      it("returns the IDs exposed by Obsidian SecretStorage", () => {
+        const secretStorage = makeSecretStorage();
+        secretStorage.listSecrets.mockReturnValue(["first", "second"]);
+        const service = KeychainService.getInstance(makeApp({ secretStorage }));
+
+        expect(service.listSecretIds()).toEqual(["first", "second"]);
+      });
+
+      it("throws the keychain availability error when SecretStorage is absent", () => {
+        const service = KeychainService.getInstance(makeApp({ secretStorage: null }));
+
+        expect(() => service.listSecretIds()).toThrow(/not available/i);
+      });
+    });
+
     // ---------------------------------------------------------------------------
     // hydrateFromKeychain — read-only keychain hydration
     // ---------------------------------------------------------------------------

--- a/src/services/keychainService.ts
+++ b/src/services/keychainService.ts
@@ -308,6 +308,11 @@ export class KeychainService {
     return this.storage.getSecret(keychainId);
   }
 
+  /** List keychain IDs so callers can reconcile device-local renamed entries. */
+  listSecretIds(): string[] {
+    return this.storage.listSecrets();
+  }
+
   /** Delete a keychain entry by its pre-computed ID.
    *  See `setSecretById` for the caller contract on `keychainId`. */
   deleteSecretById(keychainId: string): void {

--- a/src/services/providerStartup.test.ts
+++ b/src/services/providerStartup.test.ts
@@ -1,0 +1,56 @@
+import type { ModelManagementApi, ProviderCredentialReconciliationResult } from "@/modelManagement";
+import { runSettingsMigrations } from "@/settings/migrations";
+
+import { prepareProviderStartup } from "./providerStartup";
+
+jest.mock("@/settings/migrations", () => ({
+  runSettingsMigrations: jest.fn(),
+}));
+
+const mockRunSettingsMigrations = runSettingsMigrations as jest.MockedFunction<
+  typeof runSettingsMigrations
+>;
+
+describe("providerStartup", () => {
+  describe("prepareProviderStartup()", () => {
+    it("awaits versioned name migration before credential reconciliation", async () => {
+      const order: string[] = [];
+      const result: ProviderCredentialReconciliationResult = {
+        migrated: 1,
+        repointed: 1,
+        deleted: 1,
+        conflicts: 0,
+        failures: [],
+        unavailable: false,
+      };
+      mockRunSettingsMigrations.mockImplementation(async () => {
+        order.push("settings");
+      });
+      const reconcileCredentials = jest.fn(async () => {
+        order.push("credentials");
+        return result;
+      });
+      const api = { providerRegistry: { reconcileCredentials } } as unknown as ModelManagementApi;
+
+      await expect(prepareProviderStartup(api)).resolves.toBe(result);
+      expect(order).toEqual(["settings", "credentials"]);
+    });
+
+    it("still reconciles credentials when the versioned runner is a no-op", async () => {
+      mockRunSettingsMigrations.mockResolvedValue();
+      const reconcileCredentials = jest.fn(async () => ({
+        migrated: 0,
+        repointed: 0,
+        deleted: 0,
+        conflicts: 0,
+        failures: [],
+        unavailable: false,
+      }));
+      const api = { providerRegistry: { reconcileCredentials } } as unknown as ModelManagementApi;
+
+      await prepareProviderStartup(api);
+
+      expect(reconcileCredentials).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/services/providerStartup.ts
+++ b/src/services/providerStartup.ts
@@ -1,0 +1,13 @@
+import type { ModelManagementApi, ProviderCredentialReconciliationResult } from "@/modelManagement";
+import { runSettingsMigrations } from "@/settings/migrations";
+
+/**
+ * Prepare provider settings and device-local credentials before provider discovery begins.
+ * Versioned name repair must settle first because it determines each credential's destination.
+ */
+export async function prepareProviderStartup(
+  api: ModelManagementApi
+): Promise<ProviderCredentialReconciliationResult> {
+  await runSettingsMigrations(api);
+  return api.providerRegistry.reconcileCredentials();
+}

--- a/src/settings/migrations/index.ts
+++ b/src/settings/migrations/index.ts
@@ -17,6 +17,7 @@ import type { ModelManagementApi } from "@/modelManagement";
 import { getSettings, normalizeRootFolders, setSettings } from "@/settings/model";
 
 import { executeByokMigration } from "./byokMigration";
+import { planProviderNameMigration } from "./providerNameMigration";
 import { planRequiresApiKeyBackfill } from "./requiresApiKeyMigration";
 import { CURRENT_SETTINGS_VERSION } from "./version";
 
@@ -88,6 +89,14 @@ export async function runSettingsMigrations(api: ModelManagementApi): Promise<vo
     // so they must get the flag too. WS-D still only prompts users who actually
     // customized a folder, so a default user is never shown the modal.
     setSettings({ upgradedToV8FromLegacy: true });
+  }
+
+  // v9: provider display names become the readable keychain identity. Normalize
+  // every origin together so a synced settings file cannot contain two providers
+  // that map to the same user-facing name.
+  if (fromVersion < 9) {
+    const migrated = planProviderNameMigration(getSettings().providers);
+    if (migrated) setSettings({ providers: migrated });
   }
 
   // Bump unconditionally after the migrations so a per-provider failure can't

--- a/src/settings/migrations/providerNameMigration.test.ts
+++ b/src/settings/migrations/providerNameMigration.test.ts
@@ -1,0 +1,69 @@
+import type { Provider, ProviderOrigin, ProviderType } from "@/modelManagement";
+
+import { planProviderNameMigration } from "./providerNameMigration";
+
+function provider(
+  providerId: string,
+  displayName: string,
+  addedAt: number,
+  providerType: ProviderType = "anthropic",
+  origin: ProviderOrigin = { kind: "byok" }
+): Provider {
+  return {
+    providerId,
+    providerType,
+    displayName,
+    addedAt,
+    origin,
+    apiKeyKeychainId: null,
+  };
+}
+
+describe("providerNameMigration", () => {
+  describe("planProviderNameMigration()", () => {
+    it("keeps the oldest duplicate and assigns deterministic case-insensitive suffixes", () => {
+      const migrated = planProviderNameMigration({
+        newer: provider("provider-z", "openrouter", 20),
+        oldest: provider("provider-b", " OpenRouter ", 10),
+        tied: provider("provider-a", "OPENROUTER", 10),
+      });
+
+      expect(migrated?.oldest.displayName).toBe("OpenRouter 2");
+      expect(migrated?.tied.displayName).toBe("OPENROUTER");
+      expect(migrated?.newer.displayName).toBe("openrouter 3");
+    });
+
+    it("reserves existing suffixed names before assigning duplicate suffixes", () => {
+      const migrated = planProviderNameMigration({
+        first: provider("provider-a", "OpenRouter", 1),
+        duplicate: provider("provider-b", "openrouter", 2),
+        reserved: provider("provider-c", "OpenRouter 2", 3),
+      });
+
+      expect(migrated?.first.displayName).toBe("OpenRouter");
+      expect(migrated?.duplicate.displayName).toBe("openrouter 3");
+      expect(migrated?.reserved.displayName).toBe("OpenRouter 2");
+    });
+
+    it("repairs blank names across all origins with readable unique fallbacks", () => {
+      const migrated = planProviderNameMigration({
+        byok: provider("provider-a", " ", 1),
+        agent: provider("provider-b", "", 2, "anthropic", { kind: "agent", agentType: "claude" }),
+        plus: provider("provider-c", "\t", 3, "openai-compatible", {
+          kind: "copilot-plus",
+        }),
+      });
+
+      expect(migrated?.byok.displayName).toBe("Anthropic Provider");
+      expect(migrated?.agent.displayName).toBe("Anthropic Provider 2");
+      expect(migrated?.plus.displayName).toBe("Openai Compatible Provider");
+    });
+
+    it("returns null and preserves row references when names already satisfy the invariant", () => {
+      const first = provider("provider-a", "OpenRouter", 1);
+      const second = provider("provider-b", "Anthropic", 2);
+
+      expect(planProviderNameMigration({ first, second })).toBeNull();
+    });
+  });
+});

--- a/src/settings/migrations/providerNameMigration.ts
+++ b/src/settings/migrations/providerNameMigration.ts
@@ -1,0 +1,87 @@
+import {
+  allocateUniqueProviderDisplayName,
+  normalizeProviderDisplayName,
+  providerDisplayNameKey,
+  type Provider,
+} from "@/modelManagement";
+
+interface ProviderNameCandidate {
+  mapKey: string;
+  provider: Provider;
+  normalizedName: string;
+}
+
+function fallbackProviderName(provider: Provider): string {
+  const readableType = provider.providerType
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+  return `${readableType || "Unnamed"} Provider`;
+}
+
+function normalizedLegacyName(provider: Provider): string {
+  try {
+    return normalizeProviderDisplayName(provider.displayName);
+  } catch {
+    return fallbackProviderName(provider);
+  }
+}
+
+function compareCandidates(a: ProviderNameCandidate, b: ProviderNameCandidate): number {
+  const aAddedAt = Number.isFinite(a.provider.addedAt)
+    ? a.provider.addedAt
+    : Number.MAX_SAFE_INTEGER;
+  const bAddedAt = Number.isFinite(b.provider.addedAt)
+    ? b.provider.addedAt
+    : Number.MAX_SAFE_INTEGER;
+  if (aAddedAt !== bAddedAt) return aAddedAt - bAddedAt;
+  const providerIdOrder = a.provider.providerId.localeCompare(b.provider.providerId);
+  return providerIdOrder || a.mapKey.localeCompare(b.mapKey);
+}
+
+/**
+ * Repair every persisted provider name into the global uniqueness invariant.
+ * Returns null when no row changes so current vaults keep their providers-map reference.
+ */
+export function planProviderNameMigration(
+  providers: Record<string, Provider>
+): Record<string, Provider> | null {
+  const candidates = Object.entries(providers).map(([mapKey, provider]) => ({
+    mapKey,
+    provider,
+    normalizedName: normalizedLegacyName(provider),
+  }));
+  const groups = new Map<string, ProviderNameCandidate[]>();
+  for (const candidate of candidates) {
+    const key = providerDisplayNameKey(candidate.normalizedName);
+    const group = groups.get(key);
+    if (group) group.push(candidate);
+    else groups.set(key, [candidate]);
+  }
+
+  const reservedNames = [...groups.values()].map((group) => group[0].normalizedName);
+  const migratedNames = new Map<string, string>();
+  for (const [, group] of [...groups.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const ordered = [...group].sort(compareCandidates);
+    migratedNames.set(ordered[0].mapKey, ordered[0].normalizedName);
+    for (const duplicate of ordered.slice(1)) {
+      const uniqueName = allocateUniqueProviderDisplayName(duplicate.normalizedName, reservedNames);
+      migratedNames.set(duplicate.mapKey, uniqueName);
+      reservedNames.push(uniqueName);
+    }
+  }
+
+  let changed = false;
+  const migrated: Record<string, Provider> = {};
+  for (const candidate of candidates) {
+    const displayName = migratedNames.get(candidate.mapKey)!;
+    if (candidate.provider.displayName === displayName) {
+      migrated[candidate.mapKey] = candidate.provider;
+    } else {
+      migrated[candidate.mapKey] = { ...candidate.provider, displayName };
+      changed = true;
+    }
+  }
+  return changed ? migrated : null;
+}

--- a/src/settings/migrations/runSettingsMigrations.test.ts
+++ b/src/settings/migrations/runSettingsMigrations.test.ts
@@ -249,6 +249,43 @@ it("v7: keys off persisted enableMiyo, not the mobile-sensitive search backend",
 });
 
 describe("runSettingsMigrations()", () => {
+  it("v9: normalizes and de-duplicates provider names for a v8 vault", async () => {
+    mockGetSettings.mockReturnValue(
+      settings({
+        settingsVersion: 8,
+        providers: {
+          first: {
+            providerId: "provider-a",
+            providerType: "anthropic",
+            displayName: " OpenRouter ",
+            origin: { kind: "byok" },
+            addedAt: 1,
+            apiKeyKeychainId: null,
+          },
+          second: {
+            providerId: "provider-b",
+            providerType: "anthropic",
+            displayName: "openrouter",
+            origin: { kind: "agent", agentType: "claude" },
+            addedAt: 2,
+            apiKeyKeychainId: null,
+          },
+        },
+      })
+    );
+    const { api, setupProvider } = makeApi();
+
+    await runSettingsMigrations(api);
+
+    const providerWrite = mockSetSettings.mock.calls.find((call) => "providers" in call[0])?.[0] as
+      | { providers: Record<string, { displayName: string }> }
+      | undefined;
+    expect(providerWrite?.providers.first.displayName).toBe("OpenRouter");
+    expect(providerWrite?.providers.second.displayName).toBe("openrouter 2");
+    expect(setupProvider).not.toHaveBeenCalled();
+    expect(mockSetSettings).toHaveBeenCalledWith({ settingsVersion: CURRENT_SETTINGS_VERSION });
+  });
+
   it("v8: seeds copilotFolder for a v7 vault", async () => {
     // A v7 vault predates the configurable root and must be stamped with the
     // historical default so the derived sub-folder accessors have a base.

--- a/src/settings/migrations/version.ts
+++ b/src/settings/migrations/version.ts
@@ -16,5 +16,6 @@
  *   6   → seed `docProcessorBackend` from effective Miyo state.
  *   7   → seed `enableMiyoSearchSkill` from persisted `enableMiyo` intent.
  *   8   → seed `copilotFolder` root so derived sub-folder accessors resolve.
+ *   9   → normalize and globally de-duplicate provider display names.
  */
-export const CURRENT_SETTINGS_VERSION = 8;
+export const CURRENT_SETTINGS_VERSION = 9;


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#234

## Why

Existing users can already have duplicate provider names and credentials stored under UUID-based or earlier readable IDs. A normal write-path fix does not repair those installations, and settings sync can deliver a provider rename to a device whose local Keychain has not moved yet.

Migration must preserve the user's working account choice. An explicit clear must not resurrect an old key, and two different leftover credentials must not be resolved by arbitrary ordering.

## What

| Existing state | Startup result |
| --- | --- |
| Duplicate provider names | Settings v9 keeps the oldest deterministic winner and adds readable numbered suffixes to the others |
| One unambiguous UUID or prior-name credential | The value moves to the current name-led entry and the provider pointer follows it |
| Explicitly cleared pointer or empty Keychain tombstone | Older local aliases remain inactive and cannot resurrect the credential |
| Multiple candidates with different values | Copilot records a conflict and preserves every candidate without choosing an account |
| Keychain enumeration, read, write, or cleanup failure | Copilot avoids destructive inference, keeps the authoritative source, and retries reconciliation on a later startup |

Migration and device-local reconciliation finish before initial Plus sync and agent discovery consume provider settings.

## Non goal

- Syncing Keychain secrets between devices or automatically choosing between genuinely different conflicting credentials.
- Removing the vault namespace, supporting downgrade access, permanently dual-writing IDs, or touching another plugin's entries.
- Migrating model-specific and other non-provider credential families, or removing every remaining collision/recovery token.

## Screenshot

Not applicable — this PR changes persisted-settings migration and device-local Keychain reconciliation, with no plugin visual state.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Migration, startup, Keychain, and reconciliation tests cover every defined state |
| A defect would fail CI or be obvious on first use | ✅ | Deterministic regression tests cover duplicate repair and credential authority |
| A revert fully restores prior state, including persisted data | ❌ | Settings v9 name repairs and removed legacy Keychain entries are one-way |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Existing provider secrets are copied, repointed, and cleaned up |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The settings version and persisted provider names and pointers change |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Startup now awaits migration and reconciliation before provider consumers start |
| No hot-path behavior lacks deterministic coverage | ✅ | Null, undefined, tombstone, ambiguity, enumeration, and write/delete failure paths are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Correctness does not depend on an untested visual or manual-only path |

Review: inspect `src/settings/migrations/providerNameMigration.ts` — `planProviderNameMigration()` — `src/modelManagement/providers/ProviderRegistry.ts` — `reconcileCredentials()` — and `src/services/providerStartup.ts` — `prepareProviderStartup()` — line by line, then run Verification steps 1–3, including tombstone, conflicting-value, and forced-failure variants.

## Verification

1. Run `npm test -- src/settings/migrations/providerNameMigration.test.ts src/settings/migrations/runSettingsMigrations.test.ts src/modelManagement/providers/ProviderRegistry.test.ts src/services/keychainService.test.ts src/services/providerStartup.test.ts --runInBand` and confirm the adversarial migration and reconciliation cases pass.
2. On the preceding stack branch, create two providers with the same display name and working local keys, then load `codex/provider-keychain-migration` in the same test vault.
3. Confirm settings show deterministic numbered names, each provider still uses its original credential, the current name-led Keychain entries are authoritative, and redundant UUID entries are gone. Clear one credential and restart once more to confirm no older alias is reactivated.
