### PR TITLE
[Provider keychain names] - Step 3: Require unique provider names

### DIFF
--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -8,13 +8,13 @@ Copilot includes 16 built-in AI providers, and you can add an unlimited number o
 
 1. Go to **Settings → Copilot → Models (BYOK)**
 2. Add a provider
-3. Enter the provider API key and select the models you want to configure
+3. Enter a unique provider display name, the provider API key, and the models you want to configure
 4. Click Save
 5. Enable models for chat under **Basic → Agents → Quick Chat models**
 
-You can configure multiple providers simultaneously and switch between them by changing the default model.
+You can configure multiple providers simultaneously and switch between them by changing the default model. Provider display names must be unique across Copilot (names that differ only by capitalization or Unicode formatting count as the same name). When you add another instance of a provider, Copilot suggests the next available numbered name, such as `OpenRouter 2`.
 
-Copilot stores provider credentials in this device's Obsidian Keychain. Synced vault settings do not transfer credentials to another device, so enter the required keys separately on each device.
+Copilot stores provider credentials in this device's Obsidian Keychain. The keychain entry uses a readable, safely encoded form of the provider display name, and renaming a provider moves its credential to an entry that matches the new name. Synced vault settings do not transfer credentials to another device, so enter the required keys separately on each device.
 
 ---
 

--- a/src/components/ui/form-field.test.tsx
+++ b/src/components/ui/form-field.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { FormField } from "./form-field";
+
+describe("form-field", () => {
+  describe("FormField()", () => {
+    it("associates its label, required indication, and identified alert with the caller's input", () => {
+      render(
+        <FormField
+          label="Display name"
+          htmlFor="provider-name"
+          required
+          error
+          errorMessage="Choose a different name."
+          errorMessageId="provider-name-error"
+        >
+          <input id="provider-name" aria-describedby="provider-name-error" />
+        </FormField>
+      );
+
+      const input = screen.getByRole("textbox", { name: "Display name (required)" });
+      expect(input.getAttribute("id")).toBe("provider-name");
+      expect(input.hasAttribute("required")).toBe(false);
+      const alert = screen.getByRole("alert");
+      expect(alert.getAttribute("id")).toBe("provider-name-error");
+      expect(alert.textContent).toBe("Choose a different name.");
+    });
+  });
+});

--- a/src/components/ui/form-field.tsx
+++ b/src/components/ui/form-field.tsx
@@ -3,31 +3,47 @@ import { Label } from "./label";
 
 interface FormFieldProps {
   label?: string | React.ReactNode;
+  htmlFor?: string;
   required?: boolean;
   error?: boolean;
   description?: string;
   errorMessage?: string;
+  errorMessageId?: string;
   children: React.ReactNode;
 }
 
 export const FormField: React.FC<FormFieldProps> = ({
   label,
+  htmlFor,
   required = false,
   error = false,
   description,
   errorMessage = "This field is required",
+  errorMessageId,
   children,
 }) => {
   return (
     <div className="tw-space-y-2">
       {label && (
-        <Label className={error ? "tw-text-error" : ""}>
-          {label} {required && <span className="tw-text-error">*</span>}
+        <Label htmlFor={htmlFor} className={error ? "tw-text-error" : ""}>
+          {label}{" "}
+          {required && (
+            <>
+              <span className="tw-text-error" aria-hidden="true">
+                *
+              </span>
+              <span className="tw-sr-only"> (required)</span>
+            </>
+          )}
         </Label>
       )}
       {description && <p className="tw-text-sm tw-text-muted">{description}</p>}
       {children}
-      {error && <p className="tw-text-xs tw-text-error">{errorMessage}</p>}
+      {error && (
+        <p id={errorMessageId} role="alert" className="tw-text-xs tw-text-error">
+          {errorMessage}
+        </p>
+      )}
     </div>
   );
 };

--- a/src/modelManagement/providers/providerIdentity.test.ts
+++ b/src/modelManagement/providers/providerIdentity.test.ts
@@ -3,6 +3,7 @@ import {
   buildProviderKeychainId,
   normalizeProviderDisplayName,
   providerDisplayNameKey,
+  providerDisplayNameValidationError,
   providerKeychainStableToken,
 } from "./providerIdentity";
 
@@ -40,6 +41,18 @@ describe("providerIdentity", () => {
   describe("providerDisplayNameKey()", () => {
     it("normalizes canonical Unicode forms and casing for comparison", () => {
       expect(providerDisplayNameKey(" CAF\u00c9 ")).toBe(providerDisplayNameKey("cafe\u0301"));
+    });
+  });
+
+  describe("providerDisplayNameValidationError()", () => {
+    it("rejects blank and globally duplicate names using the canonical comparison", () => {
+      expect(providerDisplayNameValidationError(" \t ", ["OpenRouter"])).toBe(
+        "Enter a provider name."
+      );
+      expect(providerDisplayNameValidationError(" ｏｐｅｎｒｏｕｔｅｒ ", ["OpenRouter"])).toBe(
+        "A provider with this name already exists. Choose a different name."
+      );
+      expect(providerDisplayNameValidationError("OpenRouter 2", ["OpenRouter"])).toBeNull();
     });
   });
 

--- a/src/modelManagement/providers/providerIdentity.ts
+++ b/src/modelManagement/providers/providerIdentity.ts
@@ -9,6 +9,27 @@ export function providerDisplayNameKey(displayName: string): string {
   return normalizeProviderDisplayName(displayName).normalize("NFKC").toLowerCase();
 }
 
+/**
+ * Return the user-facing validation error for a requested provider name.
+ *
+ * @param displayName - Name currently entered by the user.
+ * @param reservedNames - Names owned by every other persisted provider.
+ */
+export function providerDisplayNameValidationError(
+  displayName: string,
+  reservedNames: Iterable<string>
+): string | null {
+  if (!displayName.trim()) return "Enter a provider name.";
+
+  const requestedKey = providerDisplayNameKey(displayName);
+  for (const reservedName of reservedNames) {
+    if (reservedName.trim() && providerDisplayNameKey(reservedName) === requestedKey) {
+      return "A provider with this name already exists. Choose a different name.";
+    }
+  }
+  return null;
+}
+
 function readableKeychainSegment(displayName: string): string {
   const normalizedDisplayName = normalizeProviderDisplayName(displayName);
   let segment = "";

--- a/src/modelManagement/ui/components/ProviderDisplayNameField.stories.tsx
+++ b/src/modelManagement/ui/components/ProviderDisplayNameField.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import {
+  ProviderDisplayNameField,
+  type ProviderDisplayNameFieldProps,
+} from "./ProviderDisplayNameField";
+
+const meta = {
+  title: "Model Management/Provider Display Name Field",
+  component: ProviderDisplayNameField,
+  args: { onChange: () => {} },
+  parameters: { gallery: { host: "modal", layout: "padded" } },
+} satisfies Meta<ProviderDisplayNameFieldProps>;
+export default meta;
+
+export const Valid: StoryObj<ProviderDisplayNameFieldProps> = {
+  args: { value: "OpenRouter 2" },
+};
+
+export const DuplicateName: StoryObj<ProviderDisplayNameFieldProps> = {
+  args: {
+    value: "OpenRouter",
+    errorMessage: "A provider with this name already exists. Choose a different name.",
+  },
+};

--- a/src/modelManagement/ui/components/ProviderDisplayNameField.test.tsx
+++ b/src/modelManagement/ui/components/ProviderDisplayNameField.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { ProviderDisplayNameField } from "./ProviderDisplayNameField";
+
+describe("ProviderDisplayNameField", () => {
+  describe("ProviderDisplayNameField()", () => {
+    it("renders a valid name and reports edits", () => {
+      const onChange = jest.fn();
+      render(<ProviderDisplayNameField value="OpenRouter 2" onChange={onChange} />);
+
+      const input = screen.getByRole("textbox", { name: /Display name/i });
+      expect(input.getAttribute("aria-invalid")).toBe("false");
+      expect(input.hasAttribute("required")).toBe(true);
+      expect(input.getAttribute("id")).toBeTruthy();
+      expect(document.querySelector(`label[for="${input.getAttribute("id")}"]`)).toBeTruthy();
+      expect(input.getAttribute("aria-describedby")).toBeNull();
+      expect(input.getAttribute("aria-errormessage")).toBeNull();
+      fireEvent.change(input, { target: { value: "OpenRouter production" } });
+      expect(onChange).toHaveBeenCalledWith("OpenRouter production");
+    });
+
+    it("renders the inline uniqueness error and marks the input invalid", () => {
+      render(
+        <ProviderDisplayNameField
+          value="OpenRouter"
+          onChange={jest.fn()}
+          errorMessage="A provider with this name already exists. Choose a different name."
+        />
+      );
+
+      const alert = screen.getByRole("alert");
+      expect(alert.textContent).toMatch(/already exists/i);
+      const input = screen.getByRole("textbox", { name: /Display name/i });
+      expect(input.getAttribute("aria-invalid")).toBe("true");
+      expect(input.getAttribute("aria-describedby")).toBe(alert.getAttribute("id"));
+      expect(input.getAttribute("aria-errormessage")).toBe(alert.getAttribute("id"));
+    });
+  });
+});

--- a/src/modelManagement/ui/components/ProviderDisplayNameField.tsx
+++ b/src/modelManagement/ui/components/ProviderDisplayNameField.tsx
@@ -1,0 +1,40 @@
+import { FormField } from "@/components/ui/form-field";
+import { Input } from "@/components/ui/input";
+import React from "react";
+
+export interface ProviderDisplayNameFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  errorMessage?: string | null;
+}
+
+export const ProviderDisplayNameField: React.FC<ProviderDisplayNameFieldProps> = ({
+  value,
+  onChange,
+  errorMessage,
+}) => {
+  const inputId = React.useId();
+  const errorMessageId = `${inputId}-error`;
+  const hasError = errorMessage != null;
+
+  return (
+    <FormField
+      label="Display name"
+      htmlFor={inputId}
+      required
+      error={hasError}
+      errorMessage={errorMessage ?? undefined}
+      errorMessageId={errorMessageId}
+    >
+      <Input
+        id={inputId}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        required
+        aria-invalid={hasError}
+        aria-describedby={hasError ? errorMessageId : undefined}
+        aria-errormessage={hasError ? errorMessageId : undefined}
+      />
+    </FormField>
+  );
+};

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
@@ -40,27 +40,35 @@ jest.mock("@/modelManagement/ui/ModelManagementContext", () => ({
 jest.mock("@/context", () => ({ useApp: () => ({}) }));
 jest.mock("@/modelManagement/state/atoms", () => {
   const jotai = jest.requireActual<typeof import("jotai")>("jotai");
+  const providers = {
+    p1: {
+      providerId: "p1",
+      providerType: "anthropic",
+      displayName: "Anthropic",
+      baseUrl: "https://api.anthropic.com",
+      origin: { kind: "byok", catalogProviderId: "anthropic" },
+      addedAt: 0,
+    },
+    "p-custom": {
+      // Catalog-less edit-mode row (template-origin); used to assert the
+      // fetch path works with a saved key when the user hasn't re-typed it.
+      providerId: "p-custom",
+      providerType: "openai-compatible",
+      displayName: "Custom",
+      baseUrl: "https://proxy.example/v1",
+      origin: { kind: "byok" },
+      addedAt: 0,
+    },
+    "p-agent": {
+      providerId: "p-agent",
+      providerType: "openai-compatible",
+      displayName: "Agent Shared",
+      origin: { kind: "agent", agentType: "opencode" },
+      addedAt: 0,
+    },
+  };
   return {
-    byokProvidersAtom: jotai.atom([
-      {
-        providerId: "p1",
-        providerType: "anthropic",
-        displayName: "Anthropic",
-        baseUrl: "https://api.anthropic.com",
-        origin: { kind: "byok", catalogProviderId: "anthropic" },
-        addedAt: 0,
-      },
-      {
-        // Catalog-less edit-mode row (template-origin); used to assert the
-        // fetch path works with a saved key when the user hasn't re-typed it.
-        providerId: "p-custom",
-        providerType: "openai-compatible",
-        displayName: "Custom",
-        baseUrl: "https://proxy.example/v1",
-        origin: { kind: "byok" },
-        addedAt: 0,
-      },
-    ]),
+    providersAtom: jotai.atom(providers),
     configuredModelsAtom: jotai.atom([
       {
         configuredModelId: "cm1",
@@ -168,6 +176,49 @@ function rowCheckbox(id: string): HTMLElement {
 }
 
 describe("ConfigureProviderForm (new mode)", () => {
+  it("suggests the next available provider name across all persisted providers", () => {
+    render(
+      <ConfigureProviderForm
+        state={{ mode: "new", source: { ...ollamaSource, displayName: "Agent Shared" } }}
+        onClose={jest.fn()}
+      />
+    );
+
+    expect(screen.getByRole<HTMLInputElement>("textbox", { name: /Display name/i }).value).toBe(
+      "Agent Shared 2"
+    );
+  });
+
+  it("shows an inline error and disables Save for a globally duplicate typed name", () => {
+    render(
+      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
+    );
+    manualAddId("llama3.2");
+
+    fireEvent.change(screen.getByRole("textbox", { name: /Display name/i }), {
+      target: { value: " ＡＧＥＮＴ ＳＨＡＲＥＤ " },
+    });
+
+    expect(screen.getByText(/already exists/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(mockSetupProvider).not.toHaveBeenCalled();
+  });
+
+  it("shows an inline error and disables Save for a blank name", () => {
+    render(
+      <ConfigureProviderForm state={{ mode: "new", source: ollamaSource }} onClose={jest.fn()} />
+    );
+    manualAddId("llama3.2");
+
+    fireEvent.change(screen.getByRole("textbox", { name: /Display name/i }), {
+      target: { value: "   " },
+    });
+
+    expect(screen.getByText("Enter a provider name.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
+  });
+
   it("skips the mount fetch when the source requires an API key and the field is empty", () => {
     render(
       <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />
@@ -232,7 +283,7 @@ describe("ConfigureProviderForm (new mode)", () => {
       expect.objectContaining({
         catalogProviderId: "anthropic",
         providerType: "anthropic",
-        displayName: "Anthropic",
+        displayName: "Anthropic 2",
         baseUrl: "https://api.anthropic.com",
         models: [
           // The manually-added id matches a catalog entry, so the saved
@@ -327,6 +378,24 @@ describe("ConfigureProviderForm (new mode)", () => {
 });
 
 describe("ConfigureProviderForm (edit mode)", () => {
+  it("excludes the provider being edited but blocks another provider's name", async () => {
+    render(
+      <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />
+    );
+
+    const nameInput = await screen.findByRole<HTMLInputElement>("textbox", {
+      name: /Display name/i,
+    });
+    expect(nameInput.value).toBe("Anthropic");
+    expect(screen.queryByText(/already exists/i)).toBeNull();
+
+    fireEvent.change(nameInput, { target: { value: " custom " } });
+    expect(screen.getByText(/already exists/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("seeds the selection from existing configured models", async () => {
     render(
       <ConfigureProviderForm state={{ mode: "edit", providerId: "p1" }} onClose={jest.fn()} />

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -31,13 +31,19 @@ import { SearchBar } from "@/components/ui/SearchBar";
 import { useApp } from "@/context";
 import { logError } from "@/logger";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
+import {
+  allocateUniqueProviderDisplayName,
+  normalizeProviderDisplayName,
+  providerDisplayNameValidationError,
+} from "@/modelManagement/providers/providerIdentity";
 import { BYOK_DEFAULT_AUTO_ENROLL } from "@/modelManagement/setup/ByokSetupApi";
 import { providerRequiresApiKey } from "@/modelManagement/providers/providerRequiresApiKey";
-import { byokProvidersAtom, configuredModelsAtom } from "@/modelManagement/state/atoms";
+import { configuredModelsAtom, providersAtom } from "@/modelManagement/state/atoms";
 import type { ModelInfo, ProviderType } from "@/modelManagement/types/catalog";
 import type { ConfiguredModel, Provider } from "@/modelManagement/types/persisted";
 import type { ProviderDefinition, VerificationResult } from "@/modelManagement/types/runtime";
 import { ModelChecklist } from "@/modelManagement/ui/components/ModelChecklist";
+import { ProviderDisplayNameField } from "@/modelManagement/ui/components/ProviderDisplayNameField";
 import {
   ModelManagementProvider,
   useModelManagement,
@@ -83,15 +89,20 @@ interface ConfigureProviderFormProps {
  */
 export const ConfigureProviderForm: React.FC<ConfigureProviderFormProps> = ({ state, onClose }) => {
   const api = useModelManagement();
-  const byokProviders = useAtomValue(byokProvidersAtom, { store: settingsStore });
+  const providersById = useAtomValue(providersAtom, { store: settingsStore });
   const configuredModels = useAtomValue(configuredModelsAtom, { store: settingsStore });
+
+  const providers = useMemo(() => Object.values(providersById), [providersById]);
 
   const provider = useMemo<Provider | undefined>(
     () =>
       state.mode === "edit"
-        ? byokProviders.find((p) => p.providerId === state.providerId)
+        ? providers.find(
+            (candidate) =>
+              candidate.providerId === state.providerId && candidate.origin.kind === "byok"
+          )
         : undefined,
-    [state, byokProviders]
+    [state, providers]
   );
 
   const existingModels = useMemo(
@@ -145,6 +156,7 @@ export const ConfigureProviderForm: React.FC<ConfigureProviderFormProps> = ({ st
       state={state}
       onClose={onClose}
       provider={provider}
+      providers={providers}
       existingModels={existingModels}
       initialApiKey={initialApiKey}
     />
@@ -156,6 +168,7 @@ interface ConfigureProviderBodyProps {
   onClose: () => void;
   /** Guaranteed defined in edit mode (the gate waits for it); undefined in new mode. */
   provider: Provider | undefined;
+  providers: readonly Provider[];
   existingModels: readonly ConfiguredModel[];
   /** Edit mode: the stored API key, resolved by the gate. `null` for a
    *  keyless provider (or a probe failure). Always `null` in new mode. */
@@ -166,6 +179,7 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
   state,
   onClose,
   provider,
+  providers,
   existingModels,
   initialApiKey,
 }) => {
@@ -213,9 +227,13 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- catalogVersion intentionally invalidates metadata read through catalogService
   }, [catalogProviderId, api, catalogVersion]);
 
-  const [displayName, setDisplayName] = useState(() =>
-    state.mode === "new" ? state.source.displayName : (provider?.displayName ?? "")
-  );
+  const [displayName, setDisplayName] = useState(() => {
+    if (state.mode === "edit") return provider?.displayName ?? "";
+    return allocateUniqueProviderDisplayName(
+      state.source.displayName,
+      providers.map((candidate) => candidate.displayName)
+    );
+  });
   // Edit mode seeds with the resolved stored key (plaintext — it's what
   // opencode injects; the field masks it via PasswordInput's reveal toggle).
   const [apiKey, setApiKey] = useState(() => initialApiKey ?? "");
@@ -229,6 +247,17 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
   const [testing, setTesting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [modelQuery, setModelQuery] = useState("");
+
+  const reservedProviderNames = useMemo(
+    () =>
+      providers
+        .filter((candidate) => state.mode !== "edit" || candidate.providerId !== state.providerId)
+        .map((candidate) => candidate.displayName),
+    [providers, state]
+  );
+  const displayNameError = providerDisplayNameValidationError(displayName, reservedProviderNames);
+  const validatedDisplayName =
+    displayNameError === null ? normalizeProviderDisplayName(displayName) : null;
 
   // Whether this provider needs a key. New mode reads the picked definition;
   // edit mode reads the explicit persisted flag — never inferred from the
@@ -326,7 +355,7 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
   };
 
   const handleSaveNew = async (): Promise<void> => {
-    if (state.mode !== "new" || !providerType) return;
+    if (state.mode !== "new" || !providerType || validatedDisplayName === null) return;
     setSaving(true);
     try {
       // B2: auto-verify a present key before persisting so an untested-but-
@@ -343,7 +372,7 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
       await api.setup.byok.setupProvider({
         catalogProviderId: state.source.catalogProviderId,
         providerType,
-        displayName,
+        displayName: validatedDisplayName,
         baseUrl: effectiveBaseUrl || undefined,
         apiKey: apiKey || undefined,
         requiresApiKey: state.source.requiresApiKey,
@@ -360,7 +389,7 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
   };
 
   const handleSaveEdit = async (): Promise<void> => {
-    if (state.mode !== "edit" || !provider) return;
+    if (state.mode !== "edit" || !provider || validatedDisplayName === null) return;
     setSaving(true);
     try {
       // B2: re-verify only a *changed* key (unchanged keys skip the probe and
@@ -377,7 +406,7 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
         providerId: state.providerId,
         apiKey,
         initialApiKey,
-        displayName,
+        displayName: validatedDisplayName,
         effectiveBaseUrl,
         extras,
         existingModels,
@@ -438,7 +467,11 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
   // requires working credentials) or ones the user explicitly typed, so a
   // non-empty selection already implies a usable setup. On top of that, gate
   // on a present + non-conclusively-invalid key.
-  const canSave = pool.selectedWireIds.size > 0 && !missingRequiredKey && !verificationBlocksSave;
+  const canSave =
+    pool.selectedWireIds.size > 0 &&
+    !missingRequiredKey &&
+    !verificationBlocksSave &&
+    displayNameError === null;
 
   const testFailed = verification?.ok === false;
 
@@ -456,9 +489,11 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
       </div>
 
       <div className="tw-flex tw-min-h-0 tw-flex-1 tw-flex-col tw-gap-4 tw-overflow-y-auto tw-px-2 tw-py-1">
-        <FormField label="Display name">
-          <Input value={displayName} onChange={(e) => setDisplayName(e.target.value)} />
-        </FormField>
+        <ProviderDisplayNameField
+          value={displayName}
+          onChange={setDisplayName}
+          errorMessage={displayNameError}
+        />
 
         <FormField
           label={


### PR DESCRIPTION
Relates to Brevilabs/obsidian-copilot-private#234

## Why

Readable provider Keychain entries depend on provider display names being unique, but the provider dialog previously allowed blank or duplicate names. A user could add two visually identical OpenRouter providers and only discover the ambiguity later in settings or the Keychain manager.

The dialog should prevent ordinary collisions before save while still giving a useful default when someone intentionally adds a second instance.

## What

> **Before:** Adding another provider starts with the same display name, and Save does not explain that the name is blank or already used.
>
> **After:** Copilot suggests the next available numbered name, validates against BYOK, Plus, and agent providers, and shows an associated inline error while Save is disabled for blank or equivalent names.

Names that differ only by surrounding whitespace, capitalization, or Unicode compatibility formatting count as the same name. Editing a provider keeps its current name valid while reserving every other provider's name.

## Non goal

- Adding rename controls for Plus or agent providers; their names participate in uniqueness but remain managed by their existing flows.
- Removing the registry's final suffixing safeguard for a rare save-time race.
- Removing the vault namespace, supporting downgrade access, permanently dual-writing IDs, touching another plugin's entries, or changing non-provider credential naming.

## Screenshot

Not available — the isolated valid and duplicate-name stories bundle successfully, but the aggregate gallery is currently blocked by pre-existing SVG-loader and Claude SDK Node-built-in errors, so no GitHub-hosted rendered capture could be produced.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Identity, dialog, field, and shared form tests cover suggestions, validation, save guards, and accessibility |
| A defect would fail CI or be obvious on first use | ✅ | Invalid-name saves and accessible error relationships are deterministic test assertions |
| A revert fully restores prior state, including persisted data | ✅ | This slice adds validation and documentation without a new migration |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Provider-name input handling and save eligibility change |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The shared form props are additive and internal; persisted schema is unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Existing save lifecycle remains; validation only guards entry to it |
| No hot-path behavior lacks deterministic coverage | ✅ | New/edit, blank, duplicate, Unicode, self-exclusion, and race fallback behavior are covered |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Any visual defect is confined to the provider dialog and appears while typing |

Review: inspect `src/modelManagement/providers/providerIdentity.ts` — `providerDisplayNameValidationError()` — `src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx` — `ConfigureProviderForm` and `ConfigureProviderBody` — `src/modelManagement/ui/components/ProviderDisplayNameField.tsx` — `ProviderDisplayNameField` — and `src/components/ui/form-field.tsx` — `FormField` — then run Verification steps 1–3 with blank, full-width Unicode, and existing-name inputs.

## Verification

1. Load `codex/provider-name-validation` in a test vault, open **Settings → Copilot → Models (BYOK)**, and add a second OpenRouter provider. Confirm the suggested name is `OpenRouter 2` or the next available suffix.
2. Replace the name with blanks, then with an existing provider name using different case or full-width Unicode characters. Confirm the inline explanation is associated with the field and Save remains disabled.
3. Edit an existing provider: confirm its unchanged name remains valid, another provider's name is rejected, and a trimmed unique name saves. Run `npm test -- src/modelManagement/providers/providerIdentity.test.ts src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx src/modelManagement/ui/components/ProviderDisplayNameField.test.tsx src/components/ui/form-field.test.tsx --runInBand` for the deterministic variants.
