### PR TITLE
Show only the working Buy Me a Coffee button

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ Your notes remain plain files in your vault, and the search index is stored loca
 If you share our vision for a powerful, portable AI agent for your second brain, consider [sponsoring Copilot on GitHub](https://github.com/sponsors/logancyang) or buying us a coffee.
 
 <p align="center">
-  <a href="https://github.com/sponsors/logancyang"><img src="https://img.shields.io/github/sponsors/logancyang?style=for-the-badge&logo=githubsponsors&label=Sponsor" alt="Sponsor Copilot on GitHub"></a>
-  <img src="https://camo.githubusercontent.com/7b8f7343bfc6e3c65c7901846637b603fd812f1a5f768d8b0572558bde859eb9/68747470733a2f2f63646e2e6275796d6561636f666665652e636f6d2f627574746f6e732f76322f64656661756c742d79656c6c6f772e706e67" alt="Buy Me a Coffee" width="165">
+  <a href="https://www.buymeacoffee.com/logancyang"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me a Coffee" width="165"></a>
 </p>
 
 ### Thank you to our GitHub Sponsors


### PR DESCRIPTION
## Why

The README's support section shows a separate GitHub Sponsor badge next to a broken "Buy Me a Coffee" image. The intended layout keeps the sponsorship link in the surrounding copy and presents only the working coffee button below it.

## What

The support section removes the GitHub Sponsor badge, loads the official Buy Me a Coffee button asset, and opens the project's canonical Buy Me a Coffee profile when clicked.

## Non goal

- No changes to the surrounding fundraising copy, its GitHub Sponsors link, or plugin funding metadata.

## Screenshot

Not included — the supplied reproduction is a local attachment and cannot be embedded in a GitHub PR body through the CLI. The rendered branch README provides the end-to-end visual check.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | This is a README-only button and layout correction visible in the rendered support section |
| A defect would fail CI or be obvious on first use | ✅ | An extra badge, broken image, or incorrect destination is visible immediately in the rendered README |
| A revert fully restores prior state, including persisted data | ✅ | Reverting the Markdown restores the previous markup; no data is written |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Static public links are the only changed values |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Plugin runtime and persisted formats are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The change is static README markup |
| No hot-path behavior lacks deterministic coverage | ✅ | No runtime path changes |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Verification is confined to the README support section |

Review: run Verification steps 1–2 and confirm the button layout and destination behave as described.

## Verification

1. Open the branch README on GitHub and scroll to **Support the project**; confirm only the yellow Buy Me a Coffee button renders below the copy, with no GitHub Sponsor badge.
2. Click the button and confirm it opens `https://www.buymeacoffee.com/logancyang`.
