### PR TITLE
Correct v4 Agent Mode and paid-plan documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Copilot is a product of Brevilabs LLC and is not affiliated with Obsidian. Plus 
 - Paid hosted models and cloud-backed features require network access.
 - **Privacy and data handling:**
   - **Free tier:** Your messages and notes are sent only to your configured LLM provider, such as OpenAI, Anthropic, or Google. Nothing goes to Brevilabs servers.
-  - **Eligible paid tiers:** Messages go to your configured LLM provider. Brevilabs processes files and external sources only for hosted features you configure or invoke, including paid Quick Chat `@` commands and Agent Mode project context.
+  - **Eligible paid tiers:** Messages and attached note context go to the model provider you select. If you select an included Copilot-hosted chat model, that provider is Brevilabs and it receives the full prompt. If you select an included Copilot-hosted embedding model, Brevilabs receives the note text being indexed. Brevilabs also receives inputs for hosted features you invoke, including search queries, URLs, and files used by paid Quick Chat `@` commands and Agent Mode project context.
   - **Processing, not retention:** We process data to deliver the feature you requested, then discard it. No message content, file uploads, or documents are retained on our servers after processing.
   - **User ID:** A randomly generated UUID is sent with hosted feature requests for service delivery, license abuse prevention, and rate limiting. It is not used for tracking, profiling, or analytics.
 - See the [privacy policy](https://www.obsidiancopilot.com/en/privacy) for more details.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Copilot is a product of Brevilabs LLC and is not affiliated with Obsidian. Plus 
 - Paid hosted models and cloud-backed features require network access.
 - **Privacy and data handling:**
   - **Free tier:** Your messages and notes are sent only to your configured LLM provider, such as OpenAI, Anthropic, or Google. Nothing goes to Brevilabs servers.
-  - **Plus tier:** Messages go to your configured LLM provider. File conversions, including PDF, DOCX, EPUB, and images, are processed by Brevilabs servers only when you explicitly trigger those features through `@` commands.
+  - **Plus tier:** Messages go to your configured LLM provider. Brevilabs processes files and external sources only for hosted features you configure or invoke, including paid Quick Chat `@` commands and Agent Mode project context.
   - **Processing, not retention:** We process data to deliver the feature you requested, then discard it. No message content, file uploads, or documents are retained on our servers after processing.
   - **User ID:** A randomly generated UUID is sent with Plus API requests for service delivery, license abuse prevention, and rate limiting. It is not used for tracking, profiling, or analytics.
 - See the [privacy policy](https://www.obsidiancopilot.com/en/privacy) for more details.

--- a/README.md
+++ b/README.md
@@ -167,9 +167,9 @@ Copilot is a product of Brevilabs LLC and is not affiliated with Obsidian. Plus 
 - Paid hosted models and cloud-backed features require network access.
 - **Privacy and data handling:**
   - **Free tier:** Your messages and notes are sent only to your configured LLM provider, such as OpenAI, Anthropic, or Google. Nothing goes to Brevilabs servers.
-  - **Plus tier:** Messages go to your configured LLM provider. Brevilabs processes files and external sources only for hosted features you configure or invoke, including paid Quick Chat `@` commands and Agent Mode project context.
+  - **Eligible paid tiers:** Messages go to your configured LLM provider. Brevilabs processes files and external sources only for hosted features you configure or invoke, including paid Quick Chat `@` commands and Agent Mode project context.
   - **Processing, not retention:** We process data to deliver the feature you requested, then discard it. No message content, file uploads, or documents are retained on our servers after processing.
-  - **User ID:** A randomly generated UUID is sent with Plus API requests for service delivery, license abuse prevention, and rate limiting. It is not used for tracking, profiling, or analytics.
+  - **User ID:** A randomly generated UUID is sent with hosted feature requests for service delivery, license abuse prevention, and rate limiting. It is not used for tracking, profiling, or analytics.
 - See the [privacy policy](https://www.obsidiancopilot.com/en/privacy) for more details.
 - The Copilot plugin frontend is fully open source. Backend services that facilitate AI agents are closed source and proprietary.
 - We offer a full refund within 14 days of purchase if you are not satisfied.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ V4 is an entire rewrite. Instead of a single built-in assistant, real agents pla
 ## One prompt, every agent
 
 > [!IMPORTANT]
-> Multi-agent collaboration is a **Copilot Plus** feature, included for Plus subscribers and Supporters.
+> Multi-agent collaboration is included with the **Plus** and **Supporter** plans.
 
 Mention several agents in one prompt and each works it in parallel. Copilot combines their answers into a single result, so you get three perspectives for the effort of one question.
 
@@ -132,14 +132,14 @@ Built-in models with zero setup, multi-agent collaboration, a web-search backend
 <details>
 <summary><strong>I'm a V3 user. What happens to my setup?</strong></summary>
 
-V4 arrives as a normal plugin update. Your settings, custom prompts, API keys, and existing Copilot Plus license carry over, and Quick Ask plus vault QA keep working as before.
+V4 arrives as a normal plugin update. Your settings, custom prompts, API keys, and existing Copilot license carry over, and Quick Ask plus vault QA keep working as before.
 
 </details>
 
 <details>
 <summary><strong>How is my data handled?</strong></summary>
 
-Your notes remain plain files in your vault, and the search index is stored locally. On the free tier, requests go only to the model provider you configure. Licensed features may use Brevilabs services for the processing you explicitly request. See the [disclosure below](#copilot-plus-disclosure) and the [privacy policy](https://www.obsidiancopilot.com/en/privacy).
+Your notes remain plain files in your vault, and the search index is stored locally. On the free tier, requests go only to the model provider you configure. Licensed features may use Brevilabs services for the processing you explicitly request. See the [disclosure below](#paid-plan-disclosure) and the [privacy policy](https://www.obsidiancopilot.com/en/privacy).
 
 </details>
 
@@ -159,12 +159,12 @@ If you share our vision for a powerful, portable AI agent for your second brain,
 
 Special thanks to our top sponsors: @mikelaaron, @pedramamini, @Arlorean, @dashinja, @azagore, @MTGMAD, @gpythomas, @emaynard, @scmarinelli, @borthwick, @adamhill, @gluecode, @rusi, @timgrote, @JiaruiYu-Consilium, @ddocta, @AMOz1, @chchwy, @pborenstein, @GitTom, @kazukgw, @mjluser1, @joesfer, @rwaal, @turnoutnow-harpreet, @dreznicek, @xrise-informatik, @jeremygentles, @ZhengRui, @bfoujols, @jsmith0475, @pagiaddlemon, @sebbyyyywebbyyy, @royschwartz2, @vikram11, @amiable-dev, @khalidhalim, @DrJsPBs, @chishaku, @Andrea18500, @shayonpal, @rhm2k, @snorcup, @JohnBub, @obstinatelark, @jonashaefele, @vishnu2kmohan
 
-## Copilot Plus Disclosure
+## Paid Plan Disclosure
 
-Copilot Plus is a premium product of Brevilabs LLC and is not affiliated with Obsidian. Visit [obsidiancopilot.com](https://obsidiancopilot.com/) for details.
+Copilot is a product of Brevilabs LLC and is not affiliated with Obsidian. Plus is one of its paid plan tiers. Visit [obsidiancopilot.com](https://obsidiancopilot.com/) for details.
 
 - An account and payment are required for full access.
-- Copilot Plus requires network access to provide its AI agent services.
+- Paid hosted models and cloud-backed features require network access.
 - **Privacy and data handling:**
   - **Free tier:** Your messages and notes are sent only to your configured LLM provider, such as OpenAI, Anthropic, or Google. Nothing goes to Brevilabs servers.
   - **Plus tier:** Messages go to your configured LLM provider. File conversions, including PDF, DOCX, EPUB, and images, are processed by Brevilabs servers only when you explicitly trigger those features through `@` commands.

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -1,53 +1,72 @@
 # Agent Mode and Tools
 
-Copilot Plus includes an **autonomous agent** that can reason step-by-step and decide which tools to use to answer your question. Instead of you specifying every step, the agent figures out what to do on its own.
+Agent Mode is Copilot's dedicated desktop workspace for tasks that need more than a single chat response. It connects Obsidian to a supported coding agent, which can inspect your vault, use its own tools and skills, and make changes with the permissions you choose.
 
-This feature requires a [Copilot Plus](copilot-plus-and-self-host.md) license.
+A single-agent chat does **not** require Copilot Plus. You need one supported agent and whatever account or model access that agent requires. Copilot Plus adds [multi-agent work and relay-backed skills](copilot-plus-and-self-host.md#agent-mode-and-copilot-plus).
 
----
-
-## Overview
-
-When the autonomous agent is enabled, Copilot can:
-
-1. Break down your request into sub-tasks
-2. Use tools to gather information (search your vault, search the web, read a note)
-3. Create or edit notes
-4. Combine results and give you a comprehensive answer
-
-**Example**: Ask "What did I work on last week?" and the agent will automatically search your vault for dated notes from the past 7 days, read the relevant ones, and summarize your week.
+Agent Mode is available in the desktop app, not on mobile.
 
 ---
 
-## Enabling Agent Mode
+## Open Agent Mode
 
-1. Go to **Settings → Copilot → Plus**
-2. Turn on **Enable Autonomous Agent**
+- Click the **Agent** icon in the left ribbon.
+- Or run **Open Copilot Agent Chat Window** from the command palette.
 
-The agent activates automatically when you're in **Copilot Plus** mode. You don't need to do anything special — just ask your question.
+Agent Mode is a separate view from [Quick Chat](chat-interface.md). The Chat, Vault QA, Copilot Plus, and Projects modes in Quick Chat continue to work independently.
 
-### Starting Agent Mode for the First Time
+On first use, Agent Mode asks you to select and configure an agent:
 
-If the agent Copilot would normally start is not set up and there is no chat or runtime error to recover, Agent Mode opens with **Select your agent**. Each row shows what that agent uses and its current setup state:
+- **OpenCode** — recommended. Copilot can download and manage OpenCode for you, or use an existing installation.
+- **Claude** — uses Claude Code and your Anthropic sign-in.
+- **Codex** — uses Codex and your OpenAI sign-in.
 
-- **Installed** can start a chat. Copilot checks sign-in after the agent starts.
-- **Checking…** is temporarily unavailable while Copilot verifies the installation.
-- **Update required** or **Error** opens Configure with the specific recovery guidance.
-- A row without a status badge is not installed and opens Configure.
+An **Installed** agent can start. **Update required** or **Error** opens setup with recovery guidance. Selecting an unconfigured agent opens its setup without changing your default until you start a chat.
 
-Selecting a row only previews its action. **Start chat** saves that agent as the default and starts it; **Configure** opens its setup without changing the default. After a chat starts, use the agent and model picker to switch agents or choose one of that agent's models.
+After the chat starts, use the picker beside the message box to change the agent or model. Your draft message and attachments stay in place when you switch. **New Chat** starts with an empty message box.
 
-The Claude setup dialog can also sign you in before a chat starts. After confirming or auto-detecting the Claude Code binary, click **Sign in** to open Claude's browser login. If the Claude CLI cannot open the browser itself, click **Open sign-in page** while sign-in is running to open the fallback URL.
+### Configure OpenCode
 
-Under **Settings → Copilot → Basic → Agents**, each enabled agent can use a default model and effort for new chats. **Default effort** stays in place when you switch models; if the selected model does not offer effort levels, the control is disabled and shows **Not supported**.
+Open **Settings → Copilot → Basic → Agents → OpenCode**.
 
-### Choosing the OpenCode Binary Source
+- Choose **Download OpenCode** to let Copilot install and update an official release.
+- Choose **I already have it** to find an installation on your computer or enter its path.
 
-Before OpenCode is set up, its row under **Settings → Copilot → Basic → Agents → opencode** offers both sources directly: **Download opencode** fetches an official release for Copilot to manage, and **I already have it** looks for an OpenCode you installed yourself. If that search finds nothing, a **Configure** button appears next to them so you can type the path by hand.
+Looking at a different source in the setup dialog does not switch the active binary. The switch happens only when you install the managed copy or apply your own binary path.
 
-Once OpenCode is set up, that row's **Configure** button opens the setup dialog, which shows the same two sources one at a time: **Managed by Copilot**, where Copilot downloads and updates an official release for you, and **My own binary**, where you point Copilot at an OpenCode you already have installed.
+### Configure Claude or Codex
 
-Switching between the two views only changes which controls you see — it never changes the binary in use. The actual switch happens when you act: **Download & install** activates the managed copy, and applying a path under **My own binary** activates yours. Your saved custom path is kept while you browse the managed view, and the dialog tells you whenever the source you're looking at is not the one currently in use.
+Install the corresponding command-line agent, sign in, then open **Settings → Copilot → Basic → Agents** and configure its binary. Windows users can follow [Windows Setup for Agent Mode](agent-mode-windows-setup.md).
+
+Claude Agent Mode requires Claude Code 2.1.206 or newer. Copilot marks an older installation as incompatible and links back to the setup dialog.
+
+---
+
+## Choose an Operating Mode
+
+The mode picker beside the message box controls what the active agent may do:
+
+- **Default** — works in your vault and asks before sensitive actions.
+- **Plan** — reads and reasons without changing your vault.
+- **Auto** — works with the automatic permissions configured for that agent. Some actions can still require approval.
+
+Available modes vary by agent. Copilot remembers the last mode used with each agent.
+
+For Claude, configure **Auto mode permissions** under **Settings → Copilot → Basic → Agents → Claude**:
+
+- **Auto** — Claude approves routine work and asks about risky actions.
+- **Accept edits** — file edits are approved automatically; other actions still ask.
+- **Bypass permissions** — skips permission checks. Use only in a vault and environment you fully trust.
+
+When Agent Mode asks for permission, the request remains in the chat until you answer, cancel the turn, or close the session.
+
+### Sign in to Claude
+
+The Claude setup dialog can sign you in before a chat starts. After confirming or auto-detecting the Claude Code binary, click **Sign in** to open Claude's browser login. If the CLI cannot open the browser itself, click **Open sign-in page** while sign-in is running to use the fallback URL.
+
+### Set a default model and effort
+
+Under **Settings → Copilot → Basic → Agents**, each enabled agent can use a default model and effort for new chats. **Default effort** stays selected when you switch models. If a model does not offer effort levels, the control is disabled and shows **Not supported**.
 
 ## Sample Prompts in the Message Box
 
@@ -67,276 +86,84 @@ While a reasoning step is active, its brain row shows an animated ellipsis rathe
 
 When the turn finishes, the time freezes and the Copilot icon becomes static. The completed duration moves to the leading edge of the same footer row as the response controls. When a duration is unavailable, the message timestamp appears in that position instead; only one of the two is shown. The duration remains visible until you send the next prompt, when that completed response falls back to its timestamp and the new turn owns the live counter. Leading zero units are omitted, so durations appear as `18s`, `2m 18s`, or `1h 2m 18s`.
 
-## Choosing an Operating Mode
-
-The mode picker beside the message box controls how much the active agent can do:
-
-- **Default** — the agent can work in your vault and asks before sensitive actions.
-- **Plan** — the agent reads and reasons without changing your vault.
-- **Auto** — the agent works with its Auto permissions. Depending on the agent and its configuration, some actions may still require approval.
-
-The available modes depend on the selected agent. Copilot normalizes equivalent modes across supported versions of Claude, Codex, and OpenCode.
-Your most recent mode is remembered per agent and applied when you start a new chat or reopen a saved one.
-
-With Claude you can decide how much **Auto** actually hands over, under
-**Settings → Copilot → Agents → Claude → Auto mode permissions**:
-
-- **Auto** (default) — Claude judges each request itself, approving routine work and still asking about risky actions.
-- **Accept edits** — file edits are approved automatically; everything else still asks.
-- **Bypass permissions** — nothing is checked. Use it only in a workspace you fully trust.
-
-Changing this takes effect the next time you pick **Auto**, so an open chat keeps the permissions it started with.
-
-When **Default** mode asks for permission, the request stays in the chat until
-you choose an action, cancel the turn, or close the session. Hover or focus a
-persistent action to inspect its detailed permission rule.
-
-### Switching Agents and Models
-
-Changing the agent or model from the picker keeps the text and attachments currently in the message box. This lets you continue composing the same message after switching between Claude, Codex, and OpenCode. **New Chat** intentionally starts with an empty message box.
-
-### Max Iterations
-
-The agent works in iteration cycles (think → use a tool → think → use a tool → answer). You can control the maximum number of iterations before the agent stops:
-
-- **Default**: 4 iterations
-- **Maximum**: 16 iterations
-- **Setting**: **Settings → Copilot → Plus → Autonomous Agent Max Iterations**
-
-The agent also has a maximum runtime of 5 minutes per response, regardless of iteration count.
+> The **Autonomous Agent Max Iterations**, **Tool Settings**, diff preview, and auto-accept controls under the Plus settings belong to the legacy Copilot Plus mode in Quick Chat. They do not limit or configure a dedicated Agent Mode session.
 
 ---
 
-## Available Tools
+## Add Context
 
-Copilot Plus has 13 built-in tools. Some are always active; others can be enabled or disabled.
+Agent Mode can receive:
+
+- the active note;
+- notes you select or mention;
+- selected text;
+- the active Copilot web tab;
+- images when the chosen model supports vision; and
+- project context when you open an [Agent Mode project](projects.md).
+
+Use the context controls above the message box, drag in an image, or mention a note with `[[Note Title]]`. Type `/` to use custom commands and available skills.
+
+The `@vault`, `@websearch`, `@composer`, and `@memory` tool mentions are controls for Copilot Plus mode in Quick Chat. In Agent Mode, the selected agent decides when to use its native tools and installed skills.
+
+---
+
+## Skills and Tools
+
+Claude, Codex, and OpenCode bring their own tools for reading files, searching, running commands, and editing. Copilot also seeds skills that teach them how to work safely with Obsidian.
+
+Manage skills under **Settings → Copilot → Skills**. Each skill can be enabled or disabled per agent, and Copilot preserves those choices when it updates a built-in skill.
 
 ### Built-in Obsidian skills
 
-Copilot also seeds four Obsidian-native skills for Claude, Codex, and OpenCode:
-
 - **Obsidian Markdown** — wikilinks, embeds, block references, callouts, properties, tags, and comments.
-- **Obsidian Bases** — valid `.base` schemas, filters, formulas, views, summaries, quoting, and date/duration behavior.
-- **JSON Canvas** — the `.canvas` schema, nodes, edges, groups, layout, colors, IDs, and link integrity.
-- **Obsidian CLI** — runtime and indexed operations such as currently open notes and tabs, workspace layout, daily notes, typed properties, tasks, backlinks, Bases queries, template resolution, link-aware moves, registered commands, and plugin debugging.
+- **Obsidian Bases** — `.base` files, filters, formulas, views, summaries, quoting, and dates.
+- **JSON Canvas** — `.canvas` nodes, edges, groups, layouts, colors, IDs, and links.
+- **Obsidian CLI** — the current workspace, open tabs, daily notes, properties, tasks, backlinks, Bases queries, templates, link-aware moves, commands, and plugin debugging.
 
-These skills appear under **Settings → Copilot → Skills**, where each one can be enabled or disabled per agent. Existing choices are preserved when Copilot refreshes a built-in skill.
+The Obsidian CLI skill requires a compatible Obsidian installation and a running desktop app. If the CLI is unavailable, the agent falls back to normal file operations where possible. The agent will not reload Obsidian or disable, uninstall, or reload the Copilot plugin while it is hosting the session.
 
-The Obsidian CLI skill first verifies that the CLI's `version` command succeeds. When available, Copilot passes the platform-specific CLI executable from the running Obsidian installation directly to the agent, so this probe does not depend on the backend's `PATH`. The CLI still requires a compatible Obsidian installer and a running Obsidian app; if it is unavailable, the agent falls back to normal filesystem operations where possible. Copilot does not change its minimum supported Obsidian version or attempt to install or repair the CLI.
+### Web and document skills
 
-When inspecting open tabs, the agent preserves Markdown notes, other file-backed tabs, and non-file views as workspace context. It reads content only from explicit vault paths reported by Obsidian and never treats a tab title or ID as a filename.
+Agents choose between vault and web evidence based on your request. They normally search your vault for questions about your notes and the web for current or external information. Copilot never intentionally adds text from your vault to a web query unless your request requires researching that text.
 
-The agent never reloads or restarts Obsidian, nor does it reload, disable, or uninstall the Copilot plugin hosting its session. Those actions terminate in-flight agent work. When a reload is required to finish verification, the agent leaves it for you to perform after the session ends. Reloading a different plugin remains available for plugin development.
+Copilot Plus can provide relay-backed skills for web search and fetch, PDF reading, YouTube transcripts, and X posts. Without a license, the agent can use its native alternatives when available.
 
-### Web and document routing
+For PDF and EPUB files, **Settings → Copilot → Miyo → Document Processor** also applies to Agent Mode:
 
-Claude, Codex, and OpenCode choose between vault and web evidence from the question. They search the vault first for questions about your own notes. For current facts, external topics, and third-party documentation, they can proactively search the web without requiring an explicit “search the web” instruction. A weak or empty vault search can also lead to web research when the question is external in nature.
+- **Plus** uses the Copilot Plus document reader, with another available reader as a fallback.
+- **Miyo** parses documents locally. It requires the Miyo app on the same computer as Obsidian; a remote Miyo server is not enough for Agent Mode document parsing.
 
-Web research normally starts with one discovery search followed by targeted page fetches. The agent does not put text from your vault into a web query unless your request clearly requires researching that text.
-
-For PDF and EPUB files, the **Document Processor** choice under **Settings → Copilot → Miyo** also controls Agent Mode:
-
-- **Plus** uses the Copilot Plus PDF reader and can fall back to another available document-reading tool.
-- **Miyo** parses PDF and EPUB files locally, including files outside the vault. Copilot removes the Plus PDF skill from the agent's skills folder while this is selected, so a document cannot reach a cloud parser by mistake. If local parsing fails, the agent reports the error and stops.
-
-Unlike chat, Agent Mode parses through the Miyo CLI rather than the Miyo server, so the Miyo option needs the app installed on the same machine as Obsidian; a remote Miyo server does not enable it. Without a local install, either install Miyo or set Document Processor back to **Plus**. Switching between the two reseeds the skills folder and restarts running agents, so either choice applies without a reload.
+When Miyo is selected, Copilot removes the cloud PDF skill so the document is not sent to that parser accidentally. Changing the processor restarts running agents so the new choice takes effect.
 
 ### Publish to Symposium
 
-Ask Claude, Codex, or OpenCode to publish an existing Markdown note as a web page. The agent finishes a self-contained HTML document, including static Mermaid and Bases output, before handing it to Copilot. Copilot rejects scripts, forms, frames, handlers, redirects, executable URLs, externally loaded assets, and CSS resource URLs before consuming the staged file. It then shows the source note, title, size, fingerprint, and a link that opens a sandboxed rendering of those exact captured bytes in your default browser. The full-page preview remains scrollable, but navigation, context menus, dragging, and submissions are blocked. Return to Obsidian after reviewing the page; nothing is sent to Symposium until you explicitly confirm.
+Ask the agent to publish an existing Markdown note as a web page. It prepares a self-contained HTML page, and Copilot validates it and opens a sandboxed preview. Nothing is published until you confirm in Obsidian.
 
-Ask the agent to delete, remove, or withdraw an existing Symposium page to open the same host-owned management flow without generating HTML. Copilot reads the note's current identity, then you choose **Delete** in Obsidian; the agent cannot supply the action or document id. The public URL itself is not a deletion interface.
-
-When staged HTML fails validation, Copilot leaves that file in place and reports every actionable issue in one bounded message. The agent may correct that same file and retry once; it does not create new filenames or repeatedly simplify unrelated styling.
-
-Copilot removes each agent-staged artifact as soon as it captures the reviewed bytes and removes the temporary browser preview when the review ends. It verifies that the local preview still matches the captured payload immediately before publishing. Canceling the review, asking the agent to regenerate, changing the preview file, or encountering a later failure sends nothing. Regenerated HTML is a new handoff and must pass through a fresh review. Copilot reads the source note's current `symposium` property itself: a note without an identity creates a page, while a note with a valid identity can only update that page. A failed update never creates a replacement page or changes the existing identity.
-
-After a successful publish or update, Copilot appends the receipt to `.symposium/publish-history.md` and stores or preserves the full public link in the source note's `symposium` property. Use **Publish file to Symposium** to withdraw the page.
-
-The Symposium skill does not give the agent a Symposium credential or API endpoint. Agent Mode still passes the raw `COPILOT_PLUS_LICENSE_KEY` to agent processes for other Copilot Plus relay tools; removing that broader exposure is tracked separately in [logancyang/obsidian-copilot-preview#105](https://github.com/logancyang/obsidian-copilot-preview/issues/105).
-
-### Always-Enabled Tools
-
-These tools are always available and cannot be disabled:
-
-#### Get Current Time
-
-Gets the current time in any timezone. Useful for time-aware queries like "what should I do today?"
-
-#### Get Time Range
-
-Converts natural time expressions (like "last week" or "yesterday") into exact date ranges. Usually called automatically before a time-based vault search.
-
-#### Get Time Info
-
-Converts an epoch timestamp to a human-readable date and time.
-
-#### Convert Timezones
-
-Converts a time from one timezone to another. Ask: "What time is 3pm EST in Tokyo?"
-
-#### Read Note
-
-Reads the content of a specific note. The agent uses this to inspect a note it found via search, or that you mentioned explicitly. Works on large notes by reading them in chunks.
-
-#### File Tree
-
-Browses the file structure of your vault. The agent uses this to find folder paths before creating new notes or to count files in a folder.
-
-#### Tag List
-
-Lists all tags in your vault with usage statistics. Useful for tag reorganization or finding notes by tag patterns.
-
-#### Update Memory
-
-Saves information to your memory when you explicitly ask the AI to remember something. See [Copilot Plus and Self-Host](copilot-plus-and-self-host.md#memory-system) for details.
-
-> **Requires**: **Settings → Copilot → Plus → Reference Saved Memories** must be enabled. If this setting is off, the tool is not registered and memory commands will not work.
-
-### Configurable Tools
-
-These tools can be individually enabled or disabled in **Settings → Copilot → Plus → Tool Settings**:
-
-#### Vault Search
-
-Searches your vault notes by content. The agent uses this to find notes relevant to your question.
-
-- **Trigger**: Automatically for vault-related questions, or explicitly with `@vault`
-- **Uses**: Both semantic search (if enabled) and lexical search
-
-#### Web Search
-
-Searches the internet for current information.
-
-- **Trigger**: Automatically when your question implies web/online content, or explicitly with `@websearch` or `@web`
-- **Requires**: A web search service configured (Firecrawl or Perplexity in self-host mode, or handled by Plus)
-
-#### Write to File
-
-Creates a new note or overwrites an existing one entirely.
-
-- **Trigger**: Automatically for "create a note" requests, or explicitly with `@composer` (available in both Copilot Plus and Projects mode)
-- **Behavior**: Shows a preview of the content before writing. You can review and accept or reject the change.
-- **Auto-accept**: Enable **Settings → Copilot → Plus → Auto-accept edits** to skip the preview
-
-#### Replace in File
-
-Makes targeted changes to an existing note using search-and-replace blocks.
-
-- **Use case**: Small edits (adding a bullet, updating a section) — more precise than rewriting the whole note
-- **Behavior**: Shows a diff preview before applying the change
-- **Auto-accept**: Same setting as Write to File
-
-#### YouTube Transcription
-
-Fetches the transcript of a YouTube video.
-
-- **Trigger**: Automatically when you paste a YouTube URL in your message
-- **No extra setup needed**: Just include the URL in your message
-- **Self-host option**: Use your own Supadata API key for transcription in self-host mode
+After a successful publish, Copilot stores the public link in the note's `symposium` property and records the receipt in `.symposium/publish-history.md`. Ask the agent to update or withdraw the same page, or run **Publish file to Symposium** yourself. See [Getting Started](getting-started.md#publish-a-note-to-symposium) for the manual workflow.
 
 ---
 
-## Tool Settings
+## Follow the Agent's Work
 
-Go to **Settings → Copilot → Plus → Tool Settings** to:
+While the agent is running, Agent Mode shows activity such as reading files, searching, running commands, thinking, and compacting context. Consecutive background actions collapse into a summary row; open it to inspect the details. Agent messages, plans, questions, and delegated agents remain separate.
 
-- See all available tools
-- Enable or disable individual configurable tools
-- View what each tool does
+The **Worked for** timer covers the full turn, including tool use and time waiting for your answer. Finished reasoning rows show **Thought for** with their own duration.
 
----
-
-## Using Tools Explicitly
-
-While the agent automatically decides when to use tools, you can also trigger them explicitly with @-mentions:
-
-```
-@vault find all notes about my reading list
-@websearch what is the latest version of Python?
-@composer create a new meeting notes template
-@memory remember that I prefer bullet points for lists
-```
-
-See [Context and Mentions](context-and-mentions.md) for the full @-mention reference.
+In the current Claude integration, delegated local agents and shell commands run synchronously. Workflow and remote-isolated background agents are temporarily unavailable. If Claude reports that its usage is exhausted, wait for its reset time or switch agents.
 
 ---
 
-## Tool Call Indicators
+## Report a Problem
 
-While the agent is working, the chat shows what it is doing. A single action gets its own status line, such as:
+Open **Settings → Copilot → Advanced → Agent Mode debugging** and choose **Report an Issue**. Copilot saves a screenshot of the Agent Mode pane and a recent activity log, opens their folder, and opens a prefilled GitHub issue. The files are not uploaded automatically.
 
-- "Reading files"
-- "Searching the web"
-- "Reading file tree"
-- "Compacting"
-
-When the agent performs several actions in a row, they are collapsed into one summary row instead of a long list — for example "Read 2 files, ran 5 commands, thought for 51s". While that work is still in progress, the current step (like the command being run) appears beneath the summary and updates as the agent moves on.
-
-Reasoning, individual tool calls, grouped activity, and delegated agents use the same aligned status-row style. Whenever a row has more detail, it shows the same disclosure arrow and can be opened with a click or the keyboard. Expanded details appear on the same indented rail, and an activity group stays open — even as new actions stream into it — until you collapse it again.
-
-Only background work is grouped this way. The agent's own messages, plan checklists, questions to you, and delegated sub-agents always stay visible as separate rows.
-
-### Delegated Agents and Shell Commands
-
-For v4, Claude runs delegated agents and Bash commands synchronously. Copilot waits for each supported tool to finish within the current response so the result arrives predictably before the turn ends. This temporarily favors reliable completion over parallel background execution.
-
-The Workflow tool and remote-isolated agents are temporarily unavailable because they require background execution. Local agents, including worktree-isolated agents, remain available and run synchronously. Background execution will return after Copilot moves Claude sessions to a persistent streaming lifecycle.
-
-This requires Claude Code 2.1.206 or newer. Copilot checks the installed version when it starts and whenever you apply or auto-detect a Claude binary. An older binary is marked **Incompatible version** in Settings → Copilot → Basic → Agents → Claude and cannot start a session. If you select Claude in chat, Copilot shows the required version and a **Configure Claude** button that opens the same setup dialog; installation guidance stays in that dialog.
-
-If Claude's usage is exhausted, Copilot shows Claude's own error in chat, including the reset time when Claude provides one. You can wait until the limit resets or switch to another agent.
-
----
-
-## File Editing: Preview and Diff
-
-When the agent uses **Write to File** or **Replace in File**, it shows a preview before making changes:
-
-- **Split view**: Before/after shown side by side
-- **Side-by-side view**: Changes highlighted inline
-
-In Agent Mode, the activity trail names the target of a single-file edit and shows a file count when one action changes multiple files.
-
-You can choose your preferred diff view in **Settings → Copilot → Plus → Diff View Mode**.
-
-Review the proposed change and click:
-
-- **Accept** — Apply the change to your note
-- **Reject** — Discard without making any changes
-- **Revert** — Undo a change that was already accepted
-
-### Auto-Accept Edits
-
-If you trust the agent and don't want to review every file change, enable **Auto-accept edits** in **Settings → Copilot → Plus**. File changes will be applied immediately without a confirmation step.
-
----
-
-## Reporting an Issue
-
-When something goes wrong in Agent Mode, the **Report an Issue** button under **Settings → Copilot → Advanced → Agent Mode debugging** bundles everything a maintainer needs to diagnose it.
-
-Clicking it opens a short form where you describe what happened. When you submit, Copilot:
-
-1. Saves a screenshot of the **Agent Mode chat pane** (just the agent panel, not your whole screen).
-2. Saves a recent **Agent Mode log** of the behind-the-scenes messages between Copilot and the agent. This log is captured automatically so a report always has recent activity to include; you can turn it off under **Settings → Copilot → Advanced → Keep an Agent Mode activity log**.
-3. Opens the folder containing those files in your file manager.
-4. Opens a prefilled GitHub issue in your browser.
-
-The files are **not uploaded for you** — drag them from the opened folder into the GitHub issue to attach them.
-
-> **Privacy note:** The Agent Mode log can contain your prompts, note contents, and tool inputs/outputs in plaintext. Review the saved files before sharing them publicly.
-
-### Including the OpenCode log
-
-When the **OpenCode** backend is active, the form shows an optional checkbox to include OpenCode's own log. It is **off by default** because OpenCode's log is shared across all of your OpenCode sessions, so it may contain activity from unrelated projects. Turn it on only when the issue involves the OpenCode backend itself.
-
-This feature is available on desktop only.
+Review the files before attaching them: the activity log can contain prompts, note content, and tool inputs or outputs. OpenCode's own shared log is optional and off by default because it can include activity from unrelated OpenCode sessions.
 
 ---
 
 ## Related
 
-- [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) — Licensing and memory
-- [Vault Search and Indexing](vault-search-and-indexing.md) — How vault search works
-- [Context and Mentions](context-and-mentions.md) — @-mention triggers for tools
+- [Getting Started](getting-started.md) — Install Copilot and start your first chat
+- [Context and Mentions](context-and-mentions.md) — Control what information Copilot receives
+- [Projects](projects.md) — Give Agent Mode reusable project context and instructions
+- [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) — Licensing, models, and relay-backed features

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -21,7 +21,7 @@ On first use, Agent Mode asks you to select and configure an agent:
 - **Claude** — uses Claude Code and your Anthropic sign-in.
 - **Codex** — uses Codex and your OpenAI sign-in.
 
-An **Installed** agent can start. **Update required** or **Error** opens setup with recovery guidance. Selecting an unconfigured agent opens its setup without changing your default until you start a chat.
+For an **Installed** agent, select it and choose **Start chat**. For an unconfigured agent or one marked **Update required** or **Error**, select it and choose **Configure** to open setup with recovery guidance. Your default changes only when you start a chat.
 
 After the chat starts, use the picker beside the message box to change the agent or model. Your draft message and attachments stay in place when you switch. **New Chat** starts with an empty message box.
 
@@ -128,10 +128,12 @@ Agents choose between vault and web evidence based on your request. They normall
 
 A Copilot license can unlock relay-backed skills for web search and fetch, PDF reading, YouTube transcripts, and X posts. Without a license, the agent can use its native alternatives when available.
 
-For PDF and EPUB files, **Settings → Copilot → Miyo → Document Processor** also applies to Agent Mode:
+For PDF files, **Settings → Copilot → Miyo → Document Processor** also applies to Agent Mode:
 
-- **Plus** (the plan-tier option shown in settings) uses the hosted document reader, with another available reader as a fallback.
-- **Miyo** parses documents locally. It requires the Miyo app on the same computer as Obsidian; a remote Miyo server is not enough for Agent Mode document parsing.
+- **Plus** (the plan-tier option shown in settings) uses the hosted PDF reader, with another available reader as a fallback.
+- **Miyo** parses PDF and EPUB files locally. It requires the Miyo app on the same computer as Obsidian; a remote Miyo server is not enough for Agent Mode document parsing.
+
+With Plus selected, EPUB support depends on the active agent's own tools; Copilot does not provide a hosted EPUB reader in Agent Mode.
 
 When Miyo is selected, Copilot removes the cloud PDF skill so the document is not sent to that parser accidentally. Changing the processor restarts running agents so the new choice takes effect.
 

--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -2,7 +2,7 @@
 
 Agent Mode is Copilot's dedicated desktop workspace for tasks that need more than a single chat response. It connects Obsidian to a supported coding agent, which can inspect your vault, use its own tools and skills, and make changes with the permissions you choose.
 
-A single-agent chat does **not** require Copilot Plus. You need one supported agent and whatever account or model access that agent requires. Copilot Plus adds [multi-agent work and relay-backed skills](copilot-plus-and-self-host.md#agent-mode-and-copilot-plus).
+A single-agent chat does **not** require a Copilot license. You need one supported agent and whatever account or model access that agent requires. A [paid Copilot plan](copilot-plus-and-self-host.md#agent-mode-with-a-copilot-license) can add multi-agent work and relay-backed skills.
 
 Agent Mode is available in the desktop app, not on mobile.
 
@@ -13,7 +13,7 @@ Agent Mode is available in the desktop app, not on mobile.
 - Click the **Agent** icon in the left ribbon.
 - Or run **Open Copilot Agent Chat Window** from the command palette.
 
-Agent Mode is a separate view from [Quick Chat](chat-interface.md). The Chat, Vault QA, Copilot Plus, and Projects modes in Quick Chat continue to work independently.
+Agent Mode is a separate view from [Quick Chat](chat-interface.md). The Chat, Vault QA, paid Quick Chat, and Projects workflows continue to work independently.
 
 On first use, Agent Mode asks you to select and configure an agent:
 
@@ -86,7 +86,7 @@ While a reasoning step is active, its brain row shows an animated ellipsis rathe
 
 When the turn finishes, the time freezes and the Copilot icon becomes static. The completed duration moves to the leading edge of the same footer row as the response controls. When a duration is unavailable, the message timestamp appears in that position instead; only one of the two is shown. The duration remains visible until you send the next prompt, when that completed response falls back to its timestamp and the new turn owns the live counter. Leading zero units are omitted, so durations appear as `18s`, `2m 18s`, or `1h 2m 18s`.
 
-> The **Autonomous Agent Max Iterations**, **Tool Settings**, diff preview, and auto-accept controls under the Plus settings belong to the legacy Copilot Plus mode in Quick Chat. They do not limit or configure a dedicated Agent Mode session.
+> The **Autonomous Agent Max Iterations**, **Tool Settings**, diff preview, and auto-accept controls under **Settings → Copilot → Plus** belong to the legacy paid Quick Chat tool loop. They do not limit or configure a dedicated Agent Mode session.
 
 ---
 
@@ -103,7 +103,7 @@ Agent Mode can receive:
 
 Use the context controls above the message box, drag in an image, or mention a note with `[[Note Title]]`. Type `/` to use custom commands and available skills.
 
-The `@vault`, `@websearch`, `@composer`, and `@memory` tool mentions are controls for Copilot Plus mode in Quick Chat. In Agent Mode, the selected agent decides when to use its native tools and installed skills.
+The `@vault`, `@websearch`, `@composer`, and `@memory` tool mentions are controls for paid Quick Chat. In Agent Mode, the selected agent decides when to use its native tools and installed skills.
 
 ---
 
@@ -126,11 +126,11 @@ The Obsidian CLI skill requires a compatible Obsidian installation and a running
 
 Agents choose between vault and web evidence based on your request. They normally search your vault for questions about your notes and the web for current or external information. Copilot never intentionally adds text from your vault to a web query unless your request requires researching that text.
 
-Copilot Plus can provide relay-backed skills for web search and fetch, PDF reading, YouTube transcripts, and X posts. Without a license, the agent can use its native alternatives when available.
+A Copilot license can unlock relay-backed skills for web search and fetch, PDF reading, YouTube transcripts, and X posts. Without a license, the agent can use its native alternatives when available.
 
 For PDF and EPUB files, **Settings → Copilot → Miyo → Document Processor** also applies to Agent Mode:
 
-- **Plus** uses the Copilot Plus document reader, with another available reader as a fallback.
+- **Plus** (the plan-tier option shown in settings) uses the hosted document reader, with another available reader as a fallback.
 - **Miyo** parses documents locally. It requires the Miyo app on the same computer as Obsidian; a remote Miyo server is not enough for Agent Mode document parsing.
 
 When Miyo is selected, Copilot removes the cloud PDF skill so the document is not sent to that parser accidentally. Changing the processor restarts running agents so the new choice takes effect.
@@ -166,4 +166,4 @@ Review the files before attaching them: the activity log can contain prompts, no
 - [Getting Started](getting-started.md) — Install Copilot and start your first chat
 - [Context and Mentions](context-and-mentions.md) — Control what information Copilot receives
 - [Projects](projects.md) — Give Agent Mode reusable project context and instructions
-- [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) — Licensing, models, and relay-backed features
+- [Paid Plans and Self-Host](copilot-plus-and-self-host.md) — Licensing, models, and relay-backed features

--- a/docs/agent-mode-windows-setup.md
+++ b/docs/agent-mode-windows-setup.md
@@ -1,6 +1,12 @@
 # Windows Setup for Agent Mode
 
-Use this guide to connect Claude Code or Codex to Copilot Agent Mode on Windows.
+Use this guide to connect OpenCode, Claude Code, or Codex to Copilot Agent Mode on Windows.
+
+## OpenCode (Recommended)
+
+Open Agent Mode from the left ribbon or run **Open Copilot Agent Chat Window**. Choose **OpenCode**, then select **Download OpenCode** to let Copilot install and manage it for you.
+
+If you already installed OpenCode, choose **I already have it** and let Copilot find the binary or enter its path. You can change the source later under **Settings → Copilot → Basic → Agents → OpenCode → Configure**.
 
 ## Claude Code
 
@@ -14,7 +20,7 @@ When Claude asks you to sign in, finish the browser login. The installer copies 
 
 In Obsidian: **Settings -> Copilot -> Basic -> Agents -> Claude -> Configure -> Auto-detect**. If it doesn't find Claude, paste the copied path into the binary path field, then save.
 
-Open a Copilot chat, switch to **Agent Mode**, pick **Claude**, and send a message.
+Run **Open Copilot Agent Chat Window**, pick **Claude**, and send a message.
 
 > A "not in your PATH" warning is normal and does not matter: Copilot finds Claude by file path, not PATH.
 
@@ -30,6 +36,6 @@ When Codex asks you to sign in, finish the login. The installer copies the `code
 
 In Obsidian: **Settings -> Copilot -> Basic -> Agents -> Codex -> Configure**. Paste the copied path into the binary path field, leave **Environment variables** empty, then save.
 
-Open a Copilot chat, switch to **Agent Mode**, pick **Codex**, and send a message.
+Run **Open Copilot Agent Chat Window**, pick **Codex**, and send a message.
 
 > Use the copied `codex-acp.exe` path only. Do not use `codex.exe`, `codex.cmd`, or `codex-acp.cmd`.

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -18,16 +18,16 @@ General-purpose conversation. Good for writing, brainstorming, summarizing, or a
 
 Ask questions about your vault content. Copilot uses lexical search (keyword matching) to find relevant notes and passes them as context to the AI. No indexing required. Good for quick questions about your notes.
 
-### Copilot Plus
+### Paid Quick Chat
 
-Requires a [Copilot Plus](copilot-plus-and-self-host.md) license. Combines Chat and Vault QA with the legacy Quick Chat autonomous loop, which can:
+Requires an active [Copilot license](copilot-plus-and-self-host.md). Combines Chat and Vault QA with the legacy Quick Chat autonomous loop, which can:
 
 - Search your vault and the web
 - Read and edit notes
 - Remember things across conversations
 - Use a growing set of tools automatically
 
-This is different from the dedicated Agent Mode view. A single Agent Mode session does not require a Copilot Plus license.
+This is different from the dedicated Agent Mode view. A single Agent Mode session does not require a Copilot license.
 
 ### Projects (alpha)
 

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -1,12 +1,14 @@
-# Chat Interface
+# Quick Chat Interface
 
-The Copilot chat panel is the main way you interact with AI in Obsidian. This guide covers everything about the chat UI: modes, message controls, history, settings, and advanced features like auto-compact.
+Quick Chat is Copilot's conversational panel for asking questions, working with the active note, and searching your vault. This guide covers its modes, message controls, history, settings, and auto-compact behavior.
+
+For longer tasks that use a coding agent and its tools, open the separate [Agent Mode](agent-mode-and-tools.md) desktop view.
 
 ---
 
 ## Chat Modes
 
-Copilot offers four modes. You can switch between them using the mode selector at the top of the chat panel.
+Quick Chat offers four modes. Switch between them with the mode selector at the top of the panel.
 
 ### Chat
 
@@ -18,16 +20,22 @@ Ask questions about your vault content. Copilot uses lexical search (keyword mat
 
 ### Copilot Plus
 
-The most powerful mode. Requires a [Copilot Plus](copilot-plus-and-self-host.md) license. Combines Chat and Vault QA with an autonomous agent that can:
+Requires a [Copilot Plus](copilot-plus-and-self-host.md) license. Combines Chat and Vault QA with the legacy Quick Chat autonomous loop, which can:
 
 - Search your vault and the web
 - Read and edit notes
 - Remember things across conversations
 - Use a growing set of tools automatically
 
-### Projects
+This is different from the dedicated Agent Mode view. A single Agent Mode session does not require a Copilot Plus license.
+
+### Projects (alpha)
 
 Focused workspaces with their own context, model, system prompt, and isolated chat history. Useful for keeping separate AI conversations per project. See [Projects](projects.md) for details.
+
+## Agent Mode
+
+Agent Mode is not another Quick Chat mode. On desktop, click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window**. It connects Copilot to OpenCode, Claude, or Codex and gives that agent its native tools, skills, and permission controls. See [Agent Mode and Tools](agent-mode-and-tools.md).
 
 ---
 
@@ -165,5 +173,5 @@ You can also use the command palette: **New Copilot Quick Chat**.
 
 - [Context and Mentions](context-and-mentions.md) — Control what context the AI sees
 - [System Prompts](system-prompts.md) — Customize AI behavior with system prompts
-- [Agent Mode and Tools](agent-mode-and-tools.md) — What Plus mode can do
+- [Agent Mode and Tools](agent-mode-and-tools.md) — Use OpenCode, Claude, or Codex in the dedicated desktop view
 - [Projects](projects.md) — Isolated workspaces with separate histories

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -18,9 +18,9 @@ General-purpose conversation. Good for writing, brainstorming, summarizing, or a
 
 Ask questions about your vault content. Copilot uses lexical search (keyword matching) to find relevant notes and passes them as context to the AI. No indexing required. Good for quick questions about your notes.
 
-### Paid Quick Chat
+### Paid Quick Chat (shown as `copilot plus`)
 
-Requires an active [Copilot license](copilot-plus-and-self-host.md). Combines Chat and Vault QA with the legacy Quick Chat autonomous loop, which can:
+Select **copilot plus** in the mode selector. This paid Quick Chat mode requires an active [Copilot license](copilot-plus-and-self-host.md) and combines Chat and Vault QA with the legacy Quick Chat autonomous loop, which can:
 
 - Search your vault and the web
 - Read and edit notes

--- a/docs/context-and-mentions.md
+++ b/docs/context-and-mentions.md
@@ -1,6 +1,6 @@
 # Context and Mentions
 
-Copilot uses **context** to give the AI information about your notes, selected text, web content, and more. You can control exactly what context the AI sees using automatic context, @-mentions, and manual commands.
+Copilot uses **context** to give the AI information about your notes, selected text, web content, and more. Quick Chat uses automatic context and @-mentions. The separate Agent Mode view has its own context controls and native agent tools.
 
 ---
 
@@ -78,18 +78,35 @@ URL processing requires Copilot Plus. YouTube URLs are handled specially — Cop
 
 These special @-mentions explicitly trigger tools in Copilot Plus mode:
 
-| Mention | What it does |
-|---|---|
-| `@vault` | Search your vault notes for relevant information |
-| `@websearch` or `@web` | Search the internet |
-| `@composer` | Create or edit a note |
-| `@memory` | Access or update your memory |
+| Mention                | What it does                                     |
+| ---------------------- | ------------------------------------------------ |
+| `@vault`               | Search your vault notes for relevant information |
+| `@websearch` or `@web` | Search the internet                              |
+| `@composer`            | Create or edit a note                            |
+| `@memory`              | Access or update your memory                     |
 
 Example:
+
 ```
 @vault what did I write about machine learning last month?
 @websearch what are the latest changes to the Python packaging ecosystem?
 ```
+
+These tool mentions do not appear in Agent Mode. There, OpenCode, Claude, or Codex decides when to use its own vault, web, and file tools.
+
+---
+
+## Context in Agent Mode
+
+In the dedicated desktop Agent Mode view, use the controls above the message box to add or remove:
+
+- the active note;
+- selected notes;
+- selected text;
+- the active Copilot web tab; and
+- images when the selected model supports vision.
+
+You can also mention a note with `[[Note Title]]`, use `/` to expand a custom command or skill, and open an [Agent Mode project](projects.md) to load reusable project context. Mentioning multiple agents with `@` starts multi-agent work and requires Copilot Plus.
 
 ---
 
@@ -125,21 +142,21 @@ When context items are added to your message, Copilot shows small pills or badge
 
 ## Context Behavior by Mode
 
-| Context Type | Chat | Vault QA | Copilot Plus |
-|---|---|---|---|
-| Active note | Yes (auto) | Yes (auto) | Yes (auto) |
-| Selected text | Yes (auto) | Yes (auto) | Yes (auto) |
-| @note / @folder | Yes | Yes | Yes |
-| @URL processing | Copilot Plus only | Copilot Plus only | Yes |
-| @vault search | Yes (explicit) | Auto | Auto |
-| @websearch | No | No | Yes |
-| Images (vision) | Yes | Yes | Yes |
-| Active web tab | Desktop only | Desktop only | Desktop only |
+| Context Type           | Chat              | Vault QA          | Copilot Plus | Agent Mode            |
+| ---------------------- | ----------------- | ----------------- | ------------ | --------------------- |
+| Active note            | Yes (auto)        | Yes (auto)        | Yes (auto)   | Yes (toggle)          |
+| Selected text          | Yes (auto)        | Yes (auto)        | Yes (auto)   | Yes                   |
+| Note / folder mentions | Yes               | Yes               | Yes          | Notes                 |
+| URL processing         | Copilot Plus only | Copilot Plus only | Yes          | Native agent or skill |
+| `@vault` search        | Yes (explicit)    | Auto              | Auto         | Not shown             |
+| `@websearch`           | No                | No                | Yes          | Not shown             |
+| Images (vision)        | Yes               | Yes               | Yes          | Yes                   |
+| Active web tab         | Desktop only      | Desktop only      | Desktop only | Desktop only          |
 
 ---
 
 ## Related
 
 - [Chat Interface](chat-interface.md) — How the chat panel works
-- [Agent Mode and Tools](agent-mode-and-tools.md) — More on @vault and @websearch
+- [Agent Mode and Tools](agent-mode-and-tools.md) — Agent context, permissions, skills, and tools
 - [Vault Search and Indexing](vault-search-and-indexing.md) — How vault search works

--- a/docs/context-and-mentions.md
+++ b/docs/context-and-mentions.md
@@ -72,11 +72,11 @@ Paste a URL or type `@https://...` to fetch and include a web page's content:
 @https://example.com/article summarize this article
 ```
 
-URL processing requires Copilot Plus. YouTube URLs are handled specially — Copilot will fetch the video transcript automatically.
+URL processing requires an active Copilot license. YouTube URLs are handled specially — Copilot will fetch the video transcript automatically.
 
 ### Tool Mentions
 
-These special @-mentions explicitly trigger tools in Copilot Plus mode:
+These special @-mentions explicitly trigger paid Quick Chat tools:
 
 | Mention                | What it does                                     |
 | ---------------------- | ------------------------------------------------ |
@@ -106,7 +106,7 @@ In the dedicated desktop Agent Mode view, use the controls above the message box
 - the active Copilot web tab; and
 - images when the selected model supports vision.
 
-You can also mention a note with `[[Note Title]]`, use `/` to expand a custom command or skill, and open an [Agent Mode project](projects.md) to load reusable project context. Mentioning multiple agents with `@` starts multi-agent work and requires Copilot Plus.
+You can also mention a note with `[[Note Title]]`, use `/` to expand a custom command or skill, and open an [Agent Mode project](projects.md) to load reusable project context. Mentioning multiple agents with `@` starts multi-agent work and requires a paid plan with multi-agent access.
 
 ---
 
@@ -124,7 +124,7 @@ Use the command palette: **Add web selection to chat context**
 
 Works similarly but captures selected text from the Web Viewer. Available on desktop only.
 
-### Adding a PDF as Context (Copilot Plus)
+### Adding a PDF as Context (Copilot License)
 
 Click the **+ Add context** button above the chat input to attach a PDF file. The PDF is converted to text and included as context for your message.
 
@@ -142,16 +142,16 @@ When context items are added to your message, Copilot shows small pills or badge
 
 ## Context Behavior by Mode
 
-| Context Type           | Chat              | Vault QA          | Copilot Plus | Agent Mode            |
-| ---------------------- | ----------------- | ----------------- | ------------ | --------------------- |
-| Active note            | Yes (auto)        | Yes (auto)        | Yes (auto)   | Yes (toggle)          |
-| Selected text          | Yes (auto)        | Yes (auto)        | Yes (auto)   | Yes                   |
-| Note / folder mentions | Yes               | Yes               | Yes          | Notes                 |
-| URL processing         | Copilot Plus only | Copilot Plus only | Yes          | Native agent or skill |
-| `@vault` search        | Yes (explicit)    | Auto              | Auto         | Not shown             |
-| `@websearch`           | No                | No                | Yes          | Not shown             |
-| Images (vision)        | Yes               | Yes               | Yes          | Yes                   |
-| Active web tab         | Desktop only      | Desktop only      | Desktop only | Desktop only          |
+| Context Type           | Chat             | Vault QA         | Paid Quick Chat | Agent Mode            |
+| ---------------------- | ---------------- | ---------------- | --------------- | --------------------- |
+| Active note            | Yes (auto)       | Yes (auto)       | Yes (auto)      | Yes (toggle)          |
+| Selected text          | Yes (auto)       | Yes (auto)       | Yes (auto)      | Yes                   |
+| Note / folder mentions | Yes              | Yes              | Yes             | Notes                 |
+| URL processing         | License required | License required | Yes             | Native agent or skill |
+| `@vault` search        | Yes (explicit)   | Auto             | Auto            | Not shown             |
+| `@websearch`           | No               | No               | Yes             | Not shown             |
+| Images (vision)        | Yes              | Yes              | Yes             | Yes                   |
+| Active web tab         | Desktop only     | Desktop only     | Desktop only    | Desktop only          |
 
 ---
 

--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -1,16 +1,16 @@
-# Copilot Plus and Self-Host
+# Paid Plans and Self-Host
 
-**Copilot Plus** is a premium tier that unlocks advanced features beyond the free, API-key-based experience. **Self-Host Mode** is an additional option for Copilot Plus Lifetime/Believer subscribers who want to run their own infrastructure.
+Copilot's paid plans unlock features beyond the free, API-key-based experience. **Plus** is one paid plan tier; it is not a separate Copilot product. **Self-Host Mode** is an additional option for eligible Lifetime and legacy Believer or Supporter license holders who want to run their own infrastructure.
 
 ---
 
-## Copilot Plus
+## Paid Copilot Plans
 
-### What Is Copilot Plus?
+### What Does a Paid Plan Include?
 
-Copilot Plus is a subscription that enables:
+A paid Copilot plan can enable:
 
-- **Copilot Plus mode in Quick Chat** — An autonomous tool loop for search, memory, and file work
+- **Paid Quick Chat tools** — An autonomous tool loop for search, memory, and file work
 - **Multi-agent work in Agent Mode** — Mention several agents with `@` to delegate parts of a task
 - **Relay-backed Agent Mode skills** — Web search and fetch, PDF reading, YouTube transcripts, and X posts
 - **File editing tools** — Write to File and Replace in File for AI-driven note editing
@@ -19,13 +19,13 @@ Copilot Plus is a subscription that enables:
 - **Memory system** — Persistent memory across conversations
 - **Included models** — A set of chat models that need no API key of your own, from fast everyday ones to top-tier reasoners ([the full list](#models-included-with-your-license))
 - **URL processing** — Fetch and summarize web pages as context
-- **Copilot Plus embedding models** — High-quality embeddings, selected under semantic search rather than by activating a license
+- **Licensed embedding models** — High-quality embeddings selected under semantic search
 
-### Setting Up Copilot Plus
+### Activate a Copilot License
 
 1. Get a license key from your dashboard at **https://www.obsidiancopilot.com/en/dashboard**
-2. Go to **Settings → Copilot → Basic** (or the Plus banner in the settings)
-3. Enter your license key in the **Copilot Plus License Key** field
+2. Go to **Settings → Copilot → Basic → Copilot License**
+3. Enter your license key
 4. Features unlock automatically
 
 A welcome dialog then offers to make **copilot-plus-flash** your default model.
@@ -39,11 +39,11 @@ Applying it never changes your embedding model or rebuilds your vault index.
 Semantic search is configured separately — see
 [Vault search and indexing](vault-search-and-indexing.md).
 
-### Agent Mode and Copilot Plus
+### Agent Mode with a Copilot License
 
-You do not need a Copilot Plus license to run one OpenCode, Claude, or Codex session in Agent Mode. The selected agent still needs its own account or model access.
+You do not need a Copilot license to run one OpenCode, Claude, or Codex session in Agent Mode. The selected agent still needs its own account or model access.
 
-Copilot Plus adds multi-agent mentions and relay-backed skills for web research, documents, YouTube, and X. When a relay skill is unavailable, the agent can fall back to a native tool when it has one. Copilot-hosted models currently appear under OpenCode; Claude and Codex continue to use models from their own subscriptions.
+A paid plan can add multi-agent mentions and relay-backed skills for web research, documents, YouTube, and X. When a relay skill is unavailable, the agent can fall back to a native tool when it has one. Copilot-hosted models currently appear under OpenCode; Claude and Codex continue to use models from their own subscriptions.
 
 The badge at the top of the license section names your plan once the key is
 working — **Plus**, **Lite**, or **Lifetime** for a Believer or Supporter
@@ -94,7 +94,7 @@ not appear under those two.
 
 **Copilot Plus Flash** becomes the default for chat and for every agent that can
 run it if you accept the offer in the welcome dialog when your license
-activates — see [Setting Up Copilot Plus](#setting-up-copilot-plus) above.
+activates — see [Activate a Copilot License](#activate-a-copilot-license) above.
 
 ### Before you have a license
 
@@ -136,7 +136,7 @@ Copilot saves this to a memory file in your vault and references it in future co
 
 ## Document Processor
 
-When Copilot processes PDFs and other non-markdown files (in Plus mode), it converts them to markdown for the AI to read.
+When Copilot processes PDFs and other non-markdown files through paid Quick Chat, it converts them to markdown for the AI to read.
 
 You can optionally save the converted markdown to a folder in your vault:
 
@@ -149,9 +149,9 @@ You can optionally save the converted markdown to a folder in your vault:
 
 ### What Is Self-Host Mode?
 
-Self-Host Mode lets you replace Copilot's cloud services with your own infrastructure. Instead of relying on Copilot's Plus backend, you run everything locally or on your own server.
+Self-Host Mode lets you replace Copilot's hosted backend services with your own infrastructure, running them locally or on your own server.
 
-**Requires**: A Copilot Plus Lifetime or Believer license (not available on monthly subscriptions).
+**Requires**: An eligible Lifetime, legacy Believer, or Supporter license (not available on monthly subscriptions).
 
 ### What Self-Host Mode Enables
 

--- a/docs/copilot-plus-and-self-host.md
+++ b/docs/copilot-plus-and-self-host.md
@@ -10,7 +10,9 @@
 
 Copilot Plus is a subscription that enables:
 
-- **Autonomous agent mode** — AI that reasons step-by-step and uses tools automatically
+- **Copilot Plus mode in Quick Chat** — An autonomous tool loop for search, memory, and file work
+- **Multi-agent work in Agent Mode** — Mention several agents with `@` to delegate parts of a task
+- **Relay-backed Agent Mode skills** — Web search and fetch, PDF reading, YouTube transcripts, and X posts
 - **File editing tools** — Write to File and Replace in File for AI-driven note editing
 - **Web search** — Search the internet from chat
 - **YouTube transcription** — Fetch video transcripts and use them as context
@@ -36,6 +38,12 @@ default yourself under **Settings → Basic → Agents**, per agent and for Quic
 Applying it never changes your embedding model or rebuilds your vault index.
 Semantic search is configured separately — see
 [Vault search and indexing](vault-search-and-indexing.md).
+
+### Agent Mode and Copilot Plus
+
+You do not need a Copilot Plus license to run one OpenCode, Claude, or Codex session in Agent Mode. The selected agent still needs its own account or model access.
+
+Copilot Plus adds multi-agent mentions and relay-backed skills for web research, documents, YouTube, and X. When a relay skill is unavailable, the agent can fall back to a native tool when it has one. Copilot-hosted models currently appear under OpenCode; Claude and Codex continue to use models from their own subscriptions.
 
 The badge at the top of the license section names your plan once the key is
 working — **Plus**, **Lite**, or **Lifetime** for a Believer or Supporter
@@ -211,6 +219,6 @@ Leave empty to use automatic local discovery.
 
 ## Related
 
-- [Agent Mode and Tools](agent-mode-and-tools.md) — Using the autonomous agent
+- [Agent Mode and Tools](agent-mode-and-tools.md) — Use OpenCode, Claude, or Codex in the dedicated desktop view
 - [Vault Search and Indexing](vault-search-and-indexing.md) — How Miyo enhances semantic search
 - [Getting Started](getting-started.md) — First-time setup

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -9,6 +9,7 @@ Custom commands are preset AI prompts you define once and reuse on any note or s
 A custom command is like a template prompt. You write an instruction (with optional variables) and save it. From then on, you can apply it to any note or selected text with a single click.
 
 **Examples of what you might create:**
+
 - "Summarize this note in bullet points"
 - "Extract all action items as a task list"
 - "Rewrite this in a more formal tone"
@@ -44,17 +45,18 @@ You can also create a command on the fly:
 
 Inside your prompt, you can use variables that get replaced with real content when the command runs:
 
-| Variable | What it inserts |
-|---|---|
-| `{}` or `{selected_text}` | The text currently selected in the editor |
-| `{activeNote}` | The full content of the currently active note |
-| `{[[Note Title]]}` | The content of a specific note by title |
-| `{FolderPath}` | All notes within a specific folder |
-| `{#tag1, #tag2}` | All notes with any of the specified tags |
+| Variable                  | What it inserts                               |
+| ------------------------- | --------------------------------------------- |
+| `{}` or `{selected_text}` | The text currently selected in the editor     |
+| `{activeNote}`            | The full content of the currently active note |
+| `{[[Note Title]]}`        | The content of a specific note by title       |
+| `{FolderPath}`            | All notes within a specific folder            |
+| `{#tag1, #tag2}`          | All notes with any of the specified tags      |
 
 > **Important**: Tags in `{#tag1, #tag2}` must be in the note's **properties (frontmatter)**, not inline tags within the note body.
 
 **Example — quiz generator using two variables:**
+
 ```
 Come up with multiple choice questions using {activeNote}, and follow
 the format of {[[Quiz Template]]} to start a quiz session.
@@ -65,11 +67,13 @@ Repeat until the user says STOP.
 ```
 
 **Example — comparison using specific notes:**
+
 ```
 Compare my notes on {[[Product Roadmap]]} and {[[Competitor Analysis]]} and identify gaps.
 ```
 
 **Example — acting on selected text:**
+
 ```
 Rewrite this in a more formal tone: {selected_text}
 ```
@@ -83,6 +87,7 @@ Variable substitution must be enabled in **Settings → Copilot → Command → 
 ### From the Right-Click Context Menu
 
 If a command has **Show in context menu** enabled:
+
 1. Select some text in a note (optional)
 2. Right-click to open the context menu
 3. Hover over **Copilot** → select your command
@@ -152,4 +157,4 @@ Quick Ask is great for things like "rephrase this sentence," "what does this ter
 
 - [Chat Interface](chat-interface.md) — Using slash commands in chat
 - [Context and Mentions](context-and-mentions.md) — How context is passed to commands
-- [Agent Mode and Tools](agent-mode-and-tools.md) — More powerful note editing with @composer
+- [Agent Mode and Tools](agent-mode-and-tools.md) — Use custom commands and agent skills in the dedicated desktop view

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -110,7 +110,7 @@ Inside the chat input, type `/` followed by the command name to run it:
 
 The command runs in the context of your current chat session and active note.
 
-> **Note**: The `@composer` mention (for AI note editing) requires Copilot Plus. In free modes, `@composer` will not be available.
+> **Note**: The `@composer` mention (for AI note editing) requires an active Copilot license. In free modes, `@composer` will not be available.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ Use the **Default Mode** dropdown to set which mode opens by default:
 
 - **Chat** — General conversation, good for most tasks
 - **Vault QA** — Ask questions answered from your notes
-- **Paid Quick Chat** — Licensed mode with web, memory, and autonomous tools
+- **copilot plus** — Paid Quick Chat with licensed web, memory, and autonomous tools
 - **Projects** — Focused workspaces (alpha feature)
 
 Most users should start with **Chat** mode.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,11 +31,15 @@ Copilot is now installed. An Agent icon appears in the left sidebar ribbon on de
 
 ## First-Time Setup
 
-### Step 1: Open Plugin Settings
+Quick Chat and Agent Mode have separate setup requirements. Choose either path below; you can set up the other later.
+
+### Quick Chat Setup
+
+#### 1. Open Plugin Settings
 
 Go to **Settings** → **Copilot** (scroll down to the Community Plugins section).
 
-### Step 2: Add an API Key
+#### 2. Add an API Key
 
 On the **Basic** tab, click **Set Keys** to open the API key dialog. Enter the key for your chosen provider:
 
@@ -48,11 +52,11 @@ On the **Basic** tab, click **Set Keys** to open the API key dialog. Enter the k
 
 The default model is **OpenRouter Gemini 2.5 Flash**, which requires an OpenRouter API key. If you'd prefer a different provider, set up that key first, then change the default model.
 
-### Step 3: Choose a Default Model
+#### 3. Choose a Default Model
 
 Add a provider and its models on the **Models (BYOK)** tab, then open **Basic → Agents → Quick Chat**: enable the ones you want to see in chat under **Quick Chat models**, and pick the one new chats start with under **Default model**.
 
-### Step 4: Choose a Quick Chat Mode
+#### 4. Choose a Quick Chat Mode
 
 Use the **Default Mode** dropdown to set which mode opens by default:
 
@@ -63,9 +67,9 @@ Use the **Default Mode** dropdown to set which mode opens by default:
 
 Most users should start with **Chat** mode.
 
-### Step 5: Set Up Agent Mode (Optional, Desktop)
+### Agent Mode Setup (Desktop)
 
-Agent Mode is a separate desktop view for longer tasks. Click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window**, then choose:
+You do not need to complete the Quick Chat setup above. Click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window**, then choose:
 
 - **OpenCode** — recommended; Copilot can download and manage it for you.
 - **Claude** — uses Claude Code and your Anthropic sign-in.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,6 +12,7 @@ Copilot for Obsidian is an AI-powered plugin that brings large language models (
 - **Public sharing**: Publish Markdown notes to Symposium with a shareable link
 - **Web search**: Fetch and summarize information from the internet
 - **Memory**: Have the AI remember facts about you across conversations
+- **Agent Mode**: Use OpenCode, Claude, or Codex for multi-step work in your vault on desktop
 
 Copilot supports 16+ AI providers including OpenAI, Anthropic, Google Gemini, Ollama (local), and more.
 
@@ -24,7 +25,7 @@ Copilot supports 16+ AI providers including OpenAI, Anthropic, Google Gemini, Ol
 3. Click **Browse** and search for **Copilot**
 4. Click **Install**, then **Enable**
 
-Copilot is now installed. A robot icon will appear in the left sidebar ribbon.
+Copilot is now installed. An Agent icon appears in the left sidebar ribbon on desktop.
 
 ---
 
@@ -51,26 +52,37 @@ The default model is **OpenRouter Gemini 2.5 Flash**, which requires an OpenRout
 
 Add a provider and its models on the **Models (BYOK)** tab, then open **Basic → Agents → Quick Chat**: enable the ones you want to see in chat under **Quick Chat models**, and pick the one new chats start with under **Default model**.
 
-### Step 4: Choose a Chat Mode
+### Step 4: Choose a Quick Chat Mode
 
 Use the **Default Mode** dropdown to set which mode opens by default:
 
 - **Chat** — General conversation, good for most tasks
 - **Vault QA** — Ask questions answered from your notes
-- **Copilot Plus** — Advanced mode with autonomous agent and tools (requires Copilot Plus license)
-- **Projects** — Focused workspaces with their own context and chat history
+- **Copilot Plus** — Licensed Quick Chat mode with web, memory, and autonomous tools
+- **Projects** — Focused workspaces (alpha feature)
 
 Most users should start with **Chat** mode.
 
+### Step 5: Set Up Agent Mode (Optional, Desktop)
+
+Agent Mode is a separate desktop view for longer tasks. Click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window**, then choose:
+
+- **OpenCode** — recommended; Copilot can download and manage it for you.
+- **Claude** — uses Claude Code and your Anthropic sign-in.
+- **Codex** — uses Codex and your OpenAI sign-in.
+
+A single-agent session does not require Copilot Plus. The selected agent still needs its own account or model access. See [Agent Mode and Tools](agent-mode-and-tools.md) for setup and permissions.
+
 ---
 
-## Opening the Chat Panel
+## Opening Quick Chat
 
 You can open Copilot in several ways:
 
-- Click the **robot icon** in the left ribbon (sidebar)
 - Use the command palette: `Ctrl/Cmd+P` → **Open Copilot Chat Window**
 - Use the hotkey `Ctrl/Cmd+P` → **Toggle Copilot Chat Window** to show/hide it
+
+To open Agent Mode instead, click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window**.
 
 ### Sidebar vs. Editor Tab
 
@@ -81,7 +93,7 @@ By default, Copilot opens as a **view** (sidebar panel). You can change this in 
 
 ---
 
-## Your First Conversation
+## Your First Quick Chat Conversation
 
 1. Open the chat panel
 2. Type your message in the input box at the bottom
@@ -161,6 +173,7 @@ A database that stores your notes as mathematical vectors (embeddings) so they c
 ## Next Steps
 
 - [Chat Interface](chat-interface.md) — Learn about modes, history, and settings
+- [Agent Mode and Tools](agent-mode-and-tools.md) — Set up an agent for multi-step work
 - [LLM Providers](llm-providers.md) — Set up your preferred AI provider
 - [Context and Mentions](context-and-mentions.md) — Control what context the AI sees
 - [Vault Search and Indexing](vault-search-and-indexing.md) — Set up semantic search over your notes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,7 @@ Use the **Default Mode** dropdown to set which mode opens by default:
 
 - **Chat** — General conversation, good for most tasks
 - **Vault QA** — Ask questions answered from your notes
-- **Copilot Plus** — Licensed Quick Chat mode with web, memory, and autonomous tools
+- **Paid Quick Chat** — Licensed mode with web, memory, and autonomous tools
 - **Projects** — Focused workspaces (alpha feature)
 
 Most users should start with **Chat** mode.
@@ -71,7 +71,7 @@ Agent Mode is a separate desktop view for longer tasks. Click the **Agent** ribb
 - **Claude** — uses Claude Code and your Anthropic sign-in.
 - **Codex** — uses Codex and your OpenAI sign-in.
 
-A single-agent session does not require Copilot Plus. The selected agent still needs its own account or model access. See [Agent Mode and Tools](agent-mode-and-tools.md) for setup and permissions.
+A single-agent session does not require a Copilot license. The selected agent still needs its own account or model access. See [Agent Mode and Tools](agent-mode-and-tools.md) for setup and permissions.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,16 +6,16 @@ Welcome to the official documentation for **Copilot for Obsidian**, an AI-powere
 
 | Document                                                    | What it covers                                                                  |
 | ----------------------------------------------------------- | ------------------------------------------------------------------------------- |
-| [Getting Started](getting-started.md)                       | Installation, first-time setup, opening the chat panel, keyboard shortcuts      |
-| [Chat Interface](chat-interface.md)                         | Chat modes, sending messages, history, settings, auto-compact                   |
+| [Getting Started](getting-started.md)                       | Installation, first-time setup, Quick Chat, Agent Mode, keyboard shortcuts      |
+| [Quick Chat Interface](chat-interface.md)                   | Quick Chat modes, messages, history, settings, and auto-compact                 |
 | [LLM Providers](llm-providers.md)                           | All 16+ supported providers and how to set them up                              |
 | [Models](models-and-parameters.md)                          | Which chat models ship with Copilot, adding your own, and the default model     |
 | [Context and Mentions](context-and-mentions.md)             | Active note context, @-mentions, URLs, tags, and the web viewer                 |
 | [Custom Commands](custom-commands.md)                       | Creating and using preset prompts, template variables, Quick Command, Quick Ask |
 | [Vault Search and Indexing](vault-search-and-indexing.md)   | Lexical search, semantic search, index management, exclusions                   |
-| [Agent Mode and Tools](agent-mode-and-tools.md)             | Autonomous agent, all 13 tools, file editing, web search                        |
-| [Windows Setup for Agent Mode](agent-mode-windows-setup.md) | Installing Claude Code or Codex on Windows and connecting it to Agent Mode      |
-| [Projects](projects.md)                                     | Focused workspaces with isolated context, model, and chat history               |
+| [Agent Mode and Tools](agent-mode-and-tools.md)             | Dedicated OpenCode, Claude, and Codex workspace, permissions, skills, and tools |
+| [Windows Setup for Agent Mode](agent-mode-windows-setup.md) | Connecting OpenCode, Claude Code, or Codex to Agent Mode on Windows             |
+| [Projects](projects.md)                                     | Focused Agent Mode and Quick Chat workspaces with isolated context and history  |
 | [System Prompts](system-prompts.md)                         | Customizing AI behavior with built-in and custom system prompts                 |
 | [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) | Copilot Plus features, memory system, self-host mode, Miyo                      |
 | [Troubleshooting and FAQ](troubleshooting-and-faq.md)       | Common errors, provider-specific issues, performance, FAQ                       |
@@ -23,8 +23,8 @@ Welcome to the official documentation for **Copilot for Obsidian**, an AI-powere
 ## Quick Start
 
 1. Install Copilot from Obsidian Community Plugins
-2. Add an API key in Settings → Copilot → Basic → API Keys
-3. Open the chat panel with the robot icon in the left ribbon
-4. Start chatting!
+2. Add a provider under Settings → Copilot → Models (BYOK)
+3. Run **Open Copilot Chat Window** for Quick Chat, or click the Agent ribbon icon for Agent Mode
+4. Start chatting
 
 For a full walkthrough, see [Getting Started](getting-started.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,8 +23,9 @@ Welcome to the official documentation for **Copilot for Obsidian**, an AI-powere
 ## Quick Start
 
 1. Install Copilot from Obsidian Community Plugins
-2. Add a provider under Settings → Copilot → Models (BYOK)
-3. Run **Open Copilot Chat Window** for Quick Chat, or click the Agent ribbon icon for Agent Mode
-4. Start chatting
+2. Choose a path:
+   - **Quick Chat:** Add a provider under **Settings → Copilot → Models (BYOK)**, then run **Open Copilot Chat Window**.
+   - **Agent Mode:** Click the Agent ribbon icon and set up OpenCode, Claude, or Codex with that agent's own account or model access.
+3. Start chatting
 
 For a full walkthrough, see [Getting Started](getting-started.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Welcome to the official documentation for **Copilot for Obsidian**, an AI-powere
 | [Windows Setup for Agent Mode](agent-mode-windows-setup.md) | Connecting OpenCode, Claude Code, or Codex to Agent Mode on Windows             |
 | [Projects](projects.md)                                     | Focused Agent Mode and Quick Chat workspaces with isolated context and history  |
 | [System Prompts](system-prompts.md)                         | Customizing AI behavior with built-in and custom system prompts                 |
-| [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) | Copilot Plus features, memory system, self-host mode, Miyo                      |
+| [Paid Plans and Self-Host](copilot-plus-and-self-host.md)   | Paid-plan features, memory system, self-host mode, Miyo                         |
 | [Troubleshooting and FAQ](troubleshooting-and-faq.md)       | Common errors, provider-specific issues, performance, FAQ                       |
 
 ## Quick Start

--- a/docs/miyo-api.md
+++ b/docs/miyo-api.md
@@ -468,4 +468,4 @@ Shape varies — includes at minimum:
 }
 ```
 
-Plus live stats fields populated by the folder manager.
+Additional live stats fields are populated by the folder manager.

--- a/docs/models-and-parameters.md
+++ b/docs/models-and-parameters.md
@@ -66,4 +66,4 @@ The dropdown contains models enabled under **Quick Chat models**, in that same p
 ## Related
 
 - [LLM Providers](llm-providers.md) — Set up API keys for your provider
-- [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) — The models included with a license
+- [Paid Plans and Self-Host](copilot-plus-and-self-host.md) — The models included with a license

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -40,8 +40,8 @@ Projects can prepare these sources for each conversation:
 - **Note link**, such as `[[Project Brief]]` — one specific note.
 - **Extension**, such as `*.py` — files with that extension.
 - **Property**, such as `[Topics:Physics]` or `[Subject:]` — notes whose frontmatter value matches, or notes that declare the property.
-- **Web URL** — fetched page content.
-- **YouTube URL** — the video's transcript.
+- **Web URL** — page content fetched through Copilot's hosted service; requires a Copilot license.
+- **YouTube URL** — the transcript fetched through Copilot's hosted service; requires a Copilot license.
 
 You can also exclude notes and folders. Large source sets take longer to prepare. If you send a message while context is still loading, Agent Mode queues it and runs it when the context is ready.
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -1,148 +1,77 @@
 # Projects
 
-Projects are focused AI workspaces. Each project has its own instructions, context sources, and
-isolated chat history. Use projects to keep separate AI conversations per client, topic, or area
-of work.
+Projects are focused AI workspaces with their own instructions, reusable context, and isolated chat history. Use them to separate work by client, topic, or area of responsibility.
 
-Projects support **50+ file types** beyond markdown, including PDFs, Word documents, PowerPoint, Excel, images, and more — making them ideal for analyzing large or diverse document collections.
+Projects are an alpha feature and may change.
 
-## Overview
-
-In regular chat, all conversations share the same settings and model. Projects let you create dedicated workspaces with:
-
-- **A specific context** — Specific notes, folders, URLs, or YouTube videos the AI always has access to
-- **A dedicated model** — Different projects can use different AI models
-- **Project instructions** — Each Agent Mode project can have its own `AGENTS.md`
-- **Isolated chat history** — Conversations in one project don't mix with conversations in another
-
-**Example use cases:**
-
-- A "Research" project that always has your research notes as context
-- A "Client Work" project with a specific system prompt and access to client-related notes
-- A "Learning" project with YouTube video URLs for study materials
+Projects can work with 50+ file types when the selected agent and document skills support them, including PDFs, Office documents, images, and source code.
 
 ---
 
-## Creating a Project
+## Projects in Agent Mode
 
-1. Open the chat panel
-2. Click the mode selector at the top of the chat
-3. Select **Projects**
-4. Click **New Project** (or the `+` button)
-5. Fill in the project details and save
+Open the dedicated Agent Mode view from the ribbon or run **Open Copilot Agent Chat Window**. Agent Home shows your projects; choose one or select **New Project**.
 
----
+An Agent Mode project contains:
 
-## Project Configuration
+- a name and optional description;
+- context sources that are prepared when the project opens;
+- project-specific instructions in `AGENTS.md`; and
+- chat history isolated from other projects and non-project chats.
 
-Each project has the following settings:
+Agent Mode uses the currently selected agent, model, and operating mode. It does not store a separate project model, temperature, or max-token override.
 
-### Name
+### Project instructions
 
-A short name for the project. Appears in the project list.
+Open the project info popover and select **AGENTS.md**, or edit **Project instructions** in the project dialog. Both surfaces edit the same file.
 
-### Description
+Vault-wide instructions apply first, followed by the project's `AGENTS.md`, so the project can add more specific rules. Copilot also keeps Claude's sibling `CLAUDE.md` pointed at `AGENTS.md`, letting Claude, Codex, and OpenCode share the same project instructions.
 
-An optional description of what the project is for.
+Older projects remain compatible. If an old project has a Project System Prompt but no `AGENTS.md`, Copilot moves those instructions into `AGENTS.md` when the project is opened or its next session starts. User-authored files are not replaced.
 
-### Model
+`project.md` remains the project's metadata and context record; it is not renamed into the instruction file.
 
-Choose which AI model to use for this project. The available options are the models enabled under
-**Settings → Copilot → Basic → Agents → Quick Chat models**.
+### Context sources
 
-### Model Settings
+Projects can prepare these sources for each conversation:
 
-Override the default temperature and max tokens specifically for this project.
+- **Tag**, such as `#research` — matching notes, expanded when the context is prepared.
+- **Folder**, such as `daily/` — Markdown notes in that folder and its subfolders.
+- **Note link**, such as `[[Project Brief]]` — one specific note.
+- **Extension**, such as `*.py` — files with that extension.
+- **Property**, such as `[Topics:Physics]` or `[Subject:]` — notes whose frontmatter value matches, or notes that declare the property.
+- **Web URL** — fetched page content.
+- **YouTube URL** — the video's transcript.
 
-### Agent Mode Instructions
+You can also exclude notes and folders. Large source sets take longer to prepare. If you send a message while context is still loading, Agent Mode queues it and runs it when the context is ready.
 
-Open the project info popover and select **AGENTS.md**. This opens the real file in Obsidian; there
-is no separate prompt editor in project settings.
+Projects can work with many file formats through the active agent and available document skills. Whether a particular file can be read depends on the selected agent, installed skills, and document processor.
 
-Vault instructions apply first, followed by the project's `AGENTS.md`, so project rules take
-precedence. For an older project without `AGENTS.md`, the file is initialized from the Project
-System Prompt already stored in `project.md` — the first time you open it, or automatically when
-you next start a chat in that project, so existing projects keep working without any migration
-step. A legacy Copilot-generated mirror is converted to that same text; user-authored files are
-left alone, and a project with no instructions gets no file at all.
+### Switch or manage projects
 
-`project.md` remains the project's metadata and context configuration record. It is not the agent
-instruction file and is not renamed or migrated.
+Use the project picker in Agent Mode to switch projects. The active history and prepared context change with the project.
 
----
+From the picker you can edit or delete a project and sort the list by recent use or alphabetically. Deleting a project entry does not delete conversation notes that were already saved in your vault.
 
-## Context Sources
-
-Projects let you pre-load context that is always available in the project's chat.
-
-### File Inclusions and Exclusions
-
-Specify which notes or folders to include in this project's context. You can include by:
-
-- **Tag** (e.g. `#research`) — all notes with that frontmatter tag. Expanded at query time, so new notes are included automatically.
-- **Folder** (e.g. `daily/`) — all markdown files in the folder, recursively. Also expanded at query time.
-- **Note link** (e.g. `[[Project Brief]]`) — a specific note, included verbatim. Use this for pinning a foundational document or README.
-- **Extension** (e.g. `*.py`) — all files with that extension. Expanded at query time.
-- **Property** (e.g. `[Topics:Physics]` or `[Subject:]`) — notes matching a frontmatter field. Syntax:
-  - `[key:value]` — include notes where the property `key` equals `value` (case-insensitive, trimmed). A list property matches when any element matches.
-  - `[key:]` — include notes that declare the property `key`, regardless of its value.
-
-**Exclusions**: These notes/folders are excluded from context.
-
-This scopes the AI's knowledge to just the notes relevant to your project.
-
-### Web URLs
-
-Add web page URLs that are fetched and included as context for every conversation in this project. Useful for documentation, reference pages, or web resources you frequently consult.
-
-### YouTube URLs
-
-Add YouTube video URLs whose transcripts are loaded into context for every conversation.
+Set the order under **Settings → Copilot → Basic → Project list sort strategy**.
 
 ---
 
-## Working in a Project
+## Projects in Quick Chat
 
-### Switching Projects
+The older Quick Chat project experience is still available:
 
-Use the project selector at the top of the chat panel to switch between projects. When you switch, the chat history clears and the new project's context loads.
+1. Open **Copilot Chat Window**.
+2. Choose **Projects (alpha)** from the mode selector.
+3. Select **New Project**.
 
-### Isolated Chat History
-
-Each project maintains its own chat history, completely separate from other projects and from regular (non-project) chat. Conversations don't bleed across projects.
-
-### Context Loading
-
-When you open a project, Copilot loads the configured context (notes, URLs, etc.) automatically. For large projects with many notes, this may take a moment.
-
----
-
-## Project List Management
-
-Go to the project selector to manage your projects:
-
-- **Sort**: Projects can be sorted by most recently used or alphabetically
-- **Edit**: Click the edit icon to change a project's settings
-- **Delete**: Remove the project entry from the list (saved conversation files in your vault are not deleted)
-
-Sort strategy: **Settings → Copilot → Basic → Project list sort strategy**
-
----
-
-## Limitations
-
-Projects have some known limitations:
-
-- Large context sources (many notes or large files) may slow down context loading
-- The context loading on project switch is synchronous — the AI isn't available until loading completes
-- Some features available in regular Plus mode may behave differently in projects
-- Auto-compact behavior is the same as regular chat
+Quick Chat projects keep their legacy model, temperature, max-token, and Project System Prompt settings. Those controls do not configure the agent used by Agent Mode.
 
 ---
 
 ## Related
 
-- [Chat Interface](chat-interface.md) — Chat modes overview, new chat behavior, history
+- [Agent Mode and Tools](agent-mode-and-tools.md) — Set up an agent and choose permissions
 - [Instructions and System Prompts](system-prompts.md) — Vault and project instructions
-- [Context and Mentions](context-and-mentions.md) — How context works
-- [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) — Plus features
+- [Context and Mentions](context-and-mentions.md) — Add context outside a project
+- [Quick Chat Interface](chat-interface.md) — Use the legacy Projects chat mode

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -4,7 +4,7 @@ Projects are focused AI workspaces with their own instructions, reusable context
 
 Projects are an alpha feature and may change.
 
-Projects can work with 50+ file types when the selected agent and document skills support them, including PDFs, Office documents, images, and source code.
+Projects can work with 50+ file types, including PDFs, Office documents, images, and source code. Copilot prepares supported binary project files with its hosted document service before the agent runs; this requires a Copilot license.
 
 ---
 
@@ -45,7 +45,7 @@ Projects can prepare these sources for each conversation:
 
 You can also exclude notes and folders. Large source sets take longer to prepare. If you send a message while context is still loading, Agent Mode queues it and runs it when the context is ready.
 
-Projects can work with many file formats through the active agent and available document skills. Whether a particular file can be read depends on the selected agent, installed skills, and document processor.
+PDFs, EPUBs, and other supported binary files included through a project source are converted by Copilot's hosted document service before the agent runs. This project-context path requires a Copilot license and does not use the **Document Processor** setting, so choosing Miyo does not keep those project files local. For local-only handling, do not include those files in project context; ask the active agent to read them with its own local tools or skills instead.
 
 ### Switch or manage projects
 

--- a/docs/projects.md
+++ b/docs/projects.md
@@ -43,7 +43,9 @@ Projects can prepare these sources for each conversation:
 - **Web URL** — page content fetched through Copilot's hosted service; requires a Copilot license.
 - **YouTube URL** — the transcript fetched through Copilot's hosted service; requires a Copilot license.
 
-You can also exclude notes and folders. Large source sets take longer to prepare. If you send a message while context is still loading, Agent Mode queues it and runs it when the context is ready.
+You can also exclude notes and folders from prepared context. Exclusions are not access controls: an agent's native tools can still read an excluded file inside an included folder. Do not include a folder that contains confidential files the agent must not access.
+
+Large source sets take longer to prepare. If you send a message while context is still loading, Agent Mode queues it and runs it when the context is ready.
 
 PDFs, EPUBs, and other supported binary files included through a project source are converted by Copilot's hosted document service before the agent runs. This project-context path requires a Copilot license and does not use the **Document Processor** setting, so choosing Miyo does not keep those project files local. For local-only handling, do not include those files in project context; ask the active agent to read them with its own local tools or skills instead.
 

--- a/docs/system-prompts.md
+++ b/docs/system-prompts.md
@@ -8,14 +8,14 @@ A system prompt is a set of instructions you give the AI that shapes how it beha
 
 Copilot has two instruction surfaces:
 
-1. **Built-in system prompt** — Internal Agent Mode behavior maintained by Copilot.
+1. **Built-in system prompt** — Internal Copilot behavior maintained by the plugin.
 2. **User instructions** — `AGENTS.md` for Agent Mode; selectable custom prompt files for Chat mode.
 
 ---
 
 ## Built-In System Prompt
 
-The built-in prompt is always active and cannot be edited. It tells the AI:
+The built-in prompt is active by default and cannot be edited. It tells the AI:
 
 - It is "Obsidian Copilot" — an AI integrated into Obsidian
 - How to format Obsidian internal links: `[[Note Title]]`
@@ -28,7 +28,7 @@ The built-in prompt is always active and cannot be edited. It tells the AI:
 
 This prompt ensures Copilot's output is correctly formatted for Obsidian and aware of its context.
 
-> **Warning**: Disabling the built-in prompt can break features like Vault QA, memory, and agent tools. Avoid disabling it unless you have a specific reason.
+You can disable it for a session from the chat settings. Doing so can break features such as Vault QA and memory, so leave it enabled unless you have a specific replacement.
 
 ---
 

--- a/docs/troubleshooting-and-faq.md
+++ b/docs/troubleshooting-and-faq.md
@@ -74,7 +74,7 @@ Before diving into specific fixes, try these steps first:
 
 Even after indexing, relevant notes aren't being returned? Try:
 
-1. Switch to **paid Quick Chat** and use `@vault` for more powerful search
+1. Switch to **copilot plus** (paid Quick Chat) and use `@vault` for more powerful search
 2. Try the **multilingual embedding model** for non-English notes
 3. Review your QA inclusions/exclusions to confirm the notes aren't filtered out
 4. Run **List all indexed files** (debug command) to verify the notes are indexed
@@ -84,7 +84,7 @@ Even after indexing, relevant notes aren't being returned? Try:
 
 **Cause**: You tried to use a PDF, image, or other non-markdown file as context in a free mode.
 
-**Fix**: In Quick Chat, switch to paid Quick Chat or convert the file to markdown manually. In Agent Mode, document support depends on the active agent, its skills, and the selected document processor.
+**Fix**: In Quick Chat, switch to **copilot plus** (paid Quick Chat) or convert the file to markdown manually. In Agent Mode, document support depends on the active agent, its skills, and the selected document processor.
 
 ---
 
@@ -307,7 +307,7 @@ Click the mode selector at the top of Quick Chat. Available modes:
 
 - Chat
 - Vault QA (Basic)
-- Paid Quick Chat (requires a license)
+- **copilot plus** (paid Quick Chat; requires a license)
 - Projects
 
 Agent Mode is a separate desktop view, not an item in this selector. Click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window**, then choose OpenCode, Claude, or Codex.

--- a/docs/troubleshooting-and-faq.md
+++ b/docs/troubleshooting-and-faq.md
@@ -74,17 +74,17 @@ Before diving into specific fixes, try these steps first:
 
 Even after indexing, relevant notes aren't being returned? Try:
 
-1. Switch to **Copilot Plus** mode and use `@vault` for more powerful search
+1. Switch to **paid Quick Chat** and use `@vault` for more powerful search
 2. Try the **multilingual embedding model** for non-English notes
 3. Review your QA inclusions/exclusions to confirm the notes aren't filtered out
 4. Run **List all indexed files** (debug command) to verify the notes are indexed
 5. Run **Force reindex vault** for a clean rebuild
 
-### "Non-markdown files are only available in Copilot Plus"
+### "Non-markdown files require a Copilot license"
 
 **Cause**: You tried to use a PDF, image, or other non-markdown file as context in a free mode.
 
-**Fix**: In Quick Chat, switch to Copilot Plus mode or convert the file to markdown manually. In Agent Mode, document support depends on the active agent, its skills, and the selected document processor.
+**Fix**: In Quick Chat, switch to paid Quick Chat or convert the file to markdown manually. In Agent Mode, document support depends on the active agent, its skills, and the selected document processor.
 
 ---
 
@@ -234,9 +234,9 @@ For reporting bugs:
 
 Copilot itself doesn't store your notes on any server. However, when you send a message, the content (including any context from your notes) is sent to the AI provider you've configured (OpenAI, Anthropic, etc.) via their API. Each provider has its own privacy policy. Your notes are not sent anywhere until you actively use the chat.
 
-The memory system stores data in your vault locally. Chat history is saved as markdown files in your vault. Nothing is stored on Copilot's servers unless you use Copilot Plus cloud features.
+The memory system stores data in your vault locally. Chat history is saved as markdown files in your vault. Nothing is stored on Copilot's servers unless you use licensed cloud features.
 
-**For maximum privacy**: Google Gemini's paid API (the basis for copilot-plus-flash) does not use API request data to train its models. For complete local privacy, consider using Ollama or LM Studio with a local model — nothing leaves your machine. Self-host mode is available now for lifetime license holders — see [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) for details.
+**For maximum privacy**: Google Gemini's paid API (the basis for copilot-plus-flash) does not use API request data to train its models. For complete local privacy, consider using Ollama or LM Studio with a local model — nothing leaves your machine. Self-host mode is available now for eligible lifetime license holders — see [Paid Plans and Self-Host](copilot-plus-and-self-host.md) for details.
 
 ### Can I reference a specific note in chat?
 
@@ -259,7 +259,7 @@ Yes, but only with models that have **Vision** capability (shown by a vision ico
 ### Why can't Copilot read my PDF?
 
 - Large PDFs (over 10 MB) should be converted to markdown first
-- In Copilot Plus mode, use **+ Add context** to attach a PDF — it will be converted automatically
+- In paid Quick Chat, use **+ Add context** to attach a PDF — it will be converted automatically
 - In Agent Mode, use an agent or document skill that supports PDF, or choose Miyo as the local document processor
 - For reusable document collections, add the sources to a project
 
@@ -274,7 +274,7 @@ Lexical vault search works offline. Semantic search requires an embedding model,
 - **Chat** — General conversation. The AI only has access to your current note and anything you explicitly mention.
 - **Vault QA** — Specifically designed for asking questions about your vault. Copilot automatically searches your notes for relevant content and includes it as context.
 
-For most question-and-answer tasks over your vault, use **Vault QA** or **Copilot Plus** mode.
+For most question-and-answer tasks over your vault, use **Vault QA** or paid Quick Chat.
 
 ### Can I use multiple providers at the same time?
 
@@ -307,7 +307,7 @@ Click the mode selector at the top of Quick Chat. Available modes:
 
 - Chat
 - Vault QA (Basic)
-- Copilot Plus (requires license)
+- Paid Quick Chat (requires a license)
 - Projects
 
 Agent Mode is a separate desktop view, not an item in this selector. Click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window**, then choose OpenCode, Claude, or Codex.

--- a/docs/troubleshooting-and-faq.md
+++ b/docs/troubleshooting-and-faq.md
@@ -84,7 +84,7 @@ Even after indexing, relevant notes aren't being returned? Try:
 
 **Cause**: You tried to use a PDF, image, or other non-markdown file as context in a free mode.
 
-**Fix**: Switch to Copilot Plus mode, or convert the file to markdown manually.
+**Fix**: In Quick Chat, switch to Copilot Plus mode or convert the file to markdown manually. In Agent Mode, document support depends on the active agent, its skills, and the selected document processor.
 
 ---
 
@@ -260,7 +260,8 @@ Yes, but only with models that have **Vision** capability (shown by a vision ico
 
 - Large PDFs (over 10 MB) should be converted to markdown first
 - In Copilot Plus mode, use **+ Add context** to attach a PDF — it will be converted automatically
-- For large PDF collections, **Projects mode** is better suited (supports PDF as context natively)
+- In Agent Mode, use an agent or document skill that supports PDF, or choose Miyo as the local document processor
+- For reusable document collections, add the sources to a project
 
 ### Can I use Copilot offline?
 
@@ -302,12 +303,14 @@ You can rename this root in **Settings → Copilot → Basic → Copilot folder 
 
 ### How do I switch modes?
 
-Click the mode selector at the top of the chat panel. Available modes:
+Click the mode selector at the top of Quick Chat. Available modes:
 
 - Chat
 - Vault QA (Basic)
 - Copilot Plus (requires license)
 - Projects
+
+Agent Mode is a separate desktop view, not an item in this selector. Click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window**, then choose OpenCode, Claude, or Codex.
 
 ### The AI keeps forgetting what we talked about earlier
 

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -43,7 +43,7 @@ Controls when Copilot automatically updates the index:
 | ------------------ | -------------------------------------------------------------------- |
 | **NEVER**          | Manual only — you must trigger indexing yourself                     |
 | **ON STARTUP**     | Updates when Obsidian starts or the plugin reloads                   |
-| **ON MODE SWITCH** | Updates when you switch to Vault QA or paid Quick Chat (Recommended) |
+| **ON MODE SWITCH** | Updates when you switch to Vault QA or **copilot plus** (paid Quick Chat) |
 
 The default is **ON MODE SWITCH**.
 

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -23,7 +23,7 @@ Lexical search finds notes that contain the exact words you used. It's fast, req
 
 Semantic search finds notes that are conceptually related, even if they don't share exact words.
 
-- **Used in**: Vault QA and Copilot Plus modes — but **disabled by default**. You must explicitly enable it.
+- **Used in**: Vault QA and paid Quick Chat — but **disabled by default**. You must explicitly enable it.
 - **How it works**: Converts your notes into numerical vectors (using an embedding model), then finds notes whose vectors are closest to your query
 - **Strengths**: Finds notes by concept and meaning, great for "fuzzy" recall
 - **Cost**: Requires embedding API calls (costs money for paid embedding models)
@@ -39,11 +39,11 @@ The semantic search index stores the vector embeddings of your notes. Manage it 
 
 Controls when Copilot automatically updates the index:
 
-| Strategy           | When the index updates                                                 |
-| ------------------ | ---------------------------------------------------------------------- |
-| **NEVER**          | Manual only — you must trigger indexing yourself                       |
-| **ON STARTUP**     | Updates when Obsidian starts or the plugin reloads                     |
-| **ON MODE SWITCH** | Updates when you switch to Vault QA or Copilot Plus mode (Recommended) |
+| Strategy           | When the index updates                                               |
+| ------------------ | -------------------------------------------------------------------- |
+| **NEVER**          | Manual only — you must trigger indexing yourself                     |
+| **ON STARTUP**     | Updates when Obsidian starts or the plugin reloads                   |
+| **ON MODE SWITCH** | Updates when you switch to Vault QA or paid Quick Chat (Recommended) |
 
 The default is **ON MODE SWITCH**.
 
@@ -179,4 +179,4 @@ On mobile, you can still use Vault QA with lexical search, but semantic search w
 ## Related
 
 - [Agent Mode and Tools](agent-mode-and-tools.md) — How coding agents work with vault and web evidence
-- [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) — Miyo-powered local semantic search
+- [Paid Plans and Self-Host](copilot-plus-and-self-host.md) — Miyo-powered local semantic search

--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -39,10 +39,10 @@ The semantic search index stores the vector embeddings of your notes. Manage it 
 
 Controls when Copilot automatically updates the index:
 
-| Strategy | When the index updates |
-|---|---|
-| **NEVER** | Manual only — you must trigger indexing yourself |
-| **ON STARTUP** | Updates when Obsidian starts or the plugin reloads |
+| Strategy           | When the index updates                                                 |
+| ------------------ | ---------------------------------------------------------------------- |
+| **NEVER**          | Manual only — you must trigger indexing yourself                       |
+| **ON STARTUP**     | Updates when Obsidian starts or the plugin reloads                     |
 | **ON MODE SWITCH** | Updates when you switch to Vault QA or Copilot Plus mode (Recommended) |
 
 The default is **ON MODE SWITCH**.
@@ -60,6 +60,7 @@ Updates only notes that have been added, modified, or deleted since the last ind
 **Command palette → Force reindex vault**
 
 Rebuilds the entire index from scratch. Use this if:
+
 - You changed your embedding model
 - The index seems corrupted or missing results
 - You've made many changes and want a clean state
@@ -104,6 +105,7 @@ This shows the total token count across your vault, which you can use to estimat
 **Settings → Copilot → QA → Exclusions**
 
 Comma-separated list of patterns. Notes matching these patterns are excluded. Supports:
+
 - Folder names: `private` — excludes the folder named "private"
 - Folder paths: `Work/Confidential` — excludes that specific subfolder
 - File extensions: `.pdf` — excludes all PDF files
@@ -176,5 +178,5 @@ On mobile, you can still use Vault QA with lexical search, but semantic search w
 
 ## Related
 
-- [Agent Mode and Tools](agent-mode-and-tools.md) — How @vault uses the index in Plus mode
+- [Agent Mode and Tools](agent-mode-and-tools.md) — How coding agents work with vault and web evidence
 - [Copilot Plus and Self-Host](copilot-plus-and-self-host.md) — Miyo-powered local semantic search


### PR DESCRIPTION
Relates to Brevilabs/app-sites#281

## Why

The customer guides describe the dedicated v4 Agent Mode as the old autonomous Quick Chat loop, imply that one agent requires a paid license, repeatedly use “Copilot Plus” as if it were a separate product, present project exclusions like access controls, and do not fully disclose the content sent through Copilot-hosted chat, embedding, and project-source services. Current v4 instead provides a dedicated desktop OpenCode, Claude, or Codex workspace: one agent uses that agent's own access, project exclusions only affect prepared context, and a Copilot license can unlock multi-agent work, hosted models, relay-backed skills, and hosted project-source conversion. Plus is one paid plan tier.

## What

> **Before:** Users configure legacy Plus controls expecting them to govern Agent Mode, encounter project behavior the implementation does not provide, can mistake project exclusions for access controls, can include project files and external sources without understanding the hosted conversion path, and are told to obtain the “Copilot Plus” product.
>
> **After:** The guides separate paid Quick Chat from Agent Mode, branch first-time setup before Quick Chat BYOK steps, name the visible `copilot plus` selector when users must choose it, document the select-then-**Start chat** or **Configure** setup flow, distinguish prepared-context exclusions from agent filesystem access, distinguish hosted PDF support from Miyo's local PDF and EPUB support, disclose the prompts, note text, files, and external-source inputs sent through Copilot-hosted features, explain the project-source path's Miyo limitation across eligible paid tiers, and use “Copilot license” or “paid Copilot plan” except when naming the Plus tier, an exact settings label, or the Copilot Plus Flash model.

## Non goal

- Change Copilot runtime behavior, UI labels, model identifiers, or internal legacy symbols.
- Rebuild or publish the website copy; the app-sites PR handles that surface.
- Redesign marketing, pricing, account, or dashboard behavior.
- Translate the English documentation.

## Screenshot

Not applicable — this PR changes repository authoring guidance and the README, not a rendered plugin surface.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Only customer-facing Markdown changes; plugin runtime files are unchanged |
| A defect would fail CI or be obvious on first use | ✅ | Incorrect setup, plan, licensing, and data-path claims are visible while following the guides |
| A revert fully restores prior state, including persisted data | ✅ | Reverting restores only Markdown |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Permission and document-processing behavior are described but not changed |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No runtime contract changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No executable code changes |
| No hot-path behavior lacks deterministic coverage | ✅ | No hot-path behavior changes |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Review is limited to customer-facing Copilot guidance |

Review: follow Verification steps 1–7 while reading `README.md`, `docs/agent-mode-and-tools.md`, `docs/projects.md`, `docs/chat-interface.md`, and `docs/copilot-plus-and-self-host.md`.

## Verification

1. Open Agent Mode on desktop and confirm Quick Start does not require a BYOK provider for this path, and the first-use guide tells users to select an agent and then choose **Start chat** when installed or **Configure** when setup or recovery is required, without requiring a Copilot license.
2. Start one agent and compare the Default, Plan, and Auto controls, context attachments, skills, and project behavior with the guides.
3. Ask Agent Mode to read a PDF and EPUB with the Document Processor set to Plus and then Miyo; confirm the guide limits the hosted reader to PDF, leaves Plus EPUB handling to agent-native tools, and documents Miyo's local PDF and EPUB path.
4. Select an included Copilot-hosted chat model and embedding model, then add a PDF or EPUB through an Agent Mode project folder or extension source and add a Web URL and YouTube URL; confirm the README discloses the prompt, attached-note, indexed-note, file, query, and URL inputs Brevilabs receives, and that the Miyo Document Processor setting does not control project preparation.
5. Include a broad project folder and exclude a nested confidential file; confirm the guide warns that exclusions only affect prepared context and the agent's native tools can still read files under the included folder.
6. Open Quick Chat and confirm the paid mode is visibly labeled `copilot plus`, while its conceptual description remains paid Quick Chat and stays separate from Agent Mode.
7. Search the README and customer docs for “Copilot Plus”; confirm only Copilot Plus Flash and the separate ChatGPT Plus product remain, while bare Plus identifies the tier or an exact settings label.
