### PR TITLE
Send license-check triggers from Copilot

### DIFF
--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -36,6 +36,7 @@ function stubRequest(outcome: RequestOutcome, onRequest?: () => void): void {
 }
 
 const VALID_LICENSE_RESPONSE = { entitlement: "signed-token", plan: "supporter" };
+const MANUAL_LICENSE_CHECK = { trigger: "manual" } as const;
 
 describe("brevilabsClient", () => {
   describe("BrevilabsClient", () => {
@@ -49,18 +50,50 @@ describe("brevilabsClient", () => {
       it("applies the signed entitlement when the license key is unchanged", async () => {
         stubRequest({ data: VALID_LICENSE_RESPONSE, error: null });
 
-        const result = await BrevilabsClient.getInstance().validateLicenseKey();
+        const result = await BrevilabsClient.getInstance().validateLicenseKey(
+          undefined,
+          MANUAL_LICENSE_CHECK
+        );
 
         expect(result).toEqual({ isValid: true, plan: "supporter" });
         expect(mockApplyEntitlement).toHaveBeenCalledWith("signed-token");
         expect(mockMarkPaidPendingEntitlement).not.toHaveBeenCalled();
       });
 
+      it("forwards the required trigger and optional feature to the license endpoint", async () => {
+        const makeRequest = jest.fn().mockResolvedValue({
+          data: VALID_LICENSE_RESPONSE,
+          error: null,
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- verifies the private HTTP boundary
+        (BrevilabsClient.getInstance() as any).makeRequest = makeRequest;
+
+        await BrevilabsClient.getInstance().validateLicenseKey(undefined, {
+          trigger: "chat_turn",
+          feature: "multi_agent_per_turn",
+        });
+
+        expect(makeRequest).toHaveBeenCalledWith(
+          "/license",
+          {
+            license_key: "key-A",
+            trigger: "chat_turn",
+            feature: "multi_agent_per_turn",
+          },
+          "POST",
+          true,
+          true
+        );
+      });
+
       it("falls back to paid-pending when the server's token cannot be verified", async () => {
         mockApplyEntitlement.mockResolvedValue(false);
         stubRequest({ data: VALID_LICENSE_RESPONSE, error: null });
 
-        const result = await BrevilabsClient.getInstance().validateLicenseKey();
+        const result = await BrevilabsClient.getInstance().validateLicenseKey(
+          undefined,
+          MANUAL_LICENSE_CHECK
+        );
 
         expect(result).toEqual({ isValid: true, plan: "supporter" });
         expect(mockApplyEntitlement).toHaveBeenCalledWith("signed-token");
@@ -72,7 +105,10 @@ describe("brevilabsClient", () => {
         async (plan) => {
           stubRequest({ data: { plan }, error: null });
 
-          const result = await BrevilabsClient.getInstance().validateLicenseKey();
+          const result = await BrevilabsClient.getInstance().validateLicenseKey(
+            undefined,
+            MANUAL_LICENSE_CHECK
+          );
 
           expect(result).toEqual({ isValid: true, plan });
           expect(mockMarkPaidPendingEntitlement).toHaveBeenCalled();
@@ -83,7 +119,10 @@ describe("brevilabsClient", () => {
       it("revokes entitlement when the server rejects the key", async () => {
         stubRequest({ data: null, error: new Error("Invalid license key") });
 
-        const result = await BrevilabsClient.getInstance().validateLicenseKey();
+        const result = await BrevilabsClient.getInstance().validateLicenseKey(
+          undefined,
+          MANUAL_LICENSE_CHECK
+        );
 
         expect(result).toEqual({ isValid: false });
         expect(mockTurnOffPaid).toHaveBeenCalled();
@@ -97,7 +136,10 @@ describe("brevilabsClient", () => {
           mockGetSettings.mockReturnValue({ plusLicenseKey: "key-B" });
         });
 
-        const result = await BrevilabsClient.getInstance().validateLicenseKey();
+        const result = await BrevilabsClient.getInstance().validateLicenseKey(
+          undefined,
+          MANUAL_LICENSE_CHECK
+        );
 
         expect(result).toEqual({ isValid: undefined });
         expect(mockApplyEntitlement).not.toHaveBeenCalled();
@@ -111,7 +153,10 @@ describe("brevilabsClient", () => {
           mockGetSettings.mockReturnValue({ plusLicenseKey: "key-B" });
         });
 
-        const result = await BrevilabsClient.getInstance().validateLicenseKey();
+        const result = await BrevilabsClient.getInstance().validateLicenseKey(
+          undefined,
+          MANUAL_LICENSE_CHECK
+        );
 
         expect(result).toEqual({ isValid: undefined });
         expect(mockTurnOffPaid).not.toHaveBeenCalled();

--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -60,7 +60,7 @@ describe("brevilabsClient", () => {
         expect(mockMarkPaidPendingEntitlement).not.toHaveBeenCalled();
       });
 
-      it("forwards the required trigger and optional feature to the license endpoint", async () => {
+      it("forwards the required trigger to the license endpoint", async () => {
         const makeRequest = jest.fn().mockResolvedValue({
           data: VALID_LICENSE_RESPONSE,
           error: null,
@@ -70,7 +70,6 @@ describe("brevilabsClient", () => {
 
         await BrevilabsClient.getInstance().validateLicenseKey(undefined, {
           trigger: "chat_turn",
-          feature: "multi_agent_per_turn",
         });
 
         expect(makeRequest).toHaveBeenCalledWith(
@@ -78,7 +77,6 @@ describe("brevilabsClient", () => {
           {
             license_key: "key-A",
             trigger: "chat_turn",
-            feature: "multi_agent_per_turn",
           },
           "POST",
           true,

--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -69,14 +69,14 @@ describe("brevilabsClient", () => {
         (BrevilabsClient.getInstance() as any).makeRequest = makeRequest;
 
         await BrevilabsClient.getInstance().validateLicenseKey(undefined, {
-          trigger: "chat_turn",
+          trigger: "legacy_chat_turn",
         });
 
         expect(makeRequest).toHaveBeenCalledWith(
           "/license",
           {
             license_key: "key-A",
-            trigger: "chat_turn",
+            trigger: "legacy_chat_turn",
           },
           "POST",
           true,

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -163,7 +163,7 @@ export type LicenseCheckTrigger =
   | "startup"
   | "manual"
   | "refresh"
-  | "chat_turn"
+  | "legacy_chat_turn"
   | "multi_agent_per_turn"
   | "tool_call"
   | "model_gate";

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -164,6 +164,7 @@ export type LicenseCheckTrigger =
   | "manual"
   | "refresh"
   | "chat_turn"
+  | "multi_agent_per_turn"
   | "tool_call"
   | "model_gate";
 

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -170,7 +170,6 @@ export type LicenseCheckTrigger =
 /** Product context attached to each license validation request. */
 export interface LicenseCheckContext {
   trigger: LicenseCheckTrigger;
-  feature?: string;
   [key: string]: unknown;
 }
 

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -158,6 +158,22 @@ export interface LicenseResponse {
   entitlement?: string;
 }
 
+/** Why the plugin is revalidating a stored license. */
+export type LicenseCheckTrigger =
+  | "startup"
+  | "manual"
+  | "refresh"
+  | "chat_turn"
+  | "tool_call"
+  | "model_gate";
+
+/** Product context attached to each license validation request. */
+export interface LicenseCheckContext {
+  trigger: LicenseCheckTrigger;
+  feature?: string;
+  [key: string]: unknown;
+}
+
 export class BrevilabsClient {
   private static instance: BrevilabsClient;
   private pluginVersion: string = "Unknown";
@@ -257,13 +273,13 @@ export class BrevilabsClient {
    * Validate the license key and update the entitlement flags (isPaidUser /
    * isPlusUser). A verified signed entitlement determines strict feature access;
    * otherwise a confirmed license remains paid while those features stay closed.
-   * @param context Optional context object containing the features that the user is using to validate the license key.
+   * @param context Required product context describing why the license key is being validated.
    * @returns true if the license key is valid, false if the license key is invalid, and undefined if
    * unknown error.
    */
   async validateLicenseKey(
-    app?: App,
-    context?: Record<string, unknown>
+    app: App | undefined,
+    context: LicenseCheckContext
   ): Promise<{ isValid: boolean | undefined; plan?: string }> {
     // Identity this response will belong to. Validations can overlap (startup,
     // a send-boundary re-check, the user pasting a different key), and every

--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -387,7 +387,7 @@ export class AutonomousAgentChainRunner extends CopilotPlusChainRunner {
     this.lastDisplayedContent = "";
 
     const isPaidUser = await checkIsPaidUser(this.chainManager.app, {
-      trigger: "chat_turn",
+      trigger: "legacy_chat_turn",
       isAutonomousAgent: true,
     });
 

--- a/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
+++ b/src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts
@@ -387,6 +387,7 @@ export class AutonomousAgentChainRunner extends CopilotPlusChainRunner {
     this.lastDisplayedContent = "";
 
     const isPaidUser = await checkIsPaidUser(this.chainManager.app, {
+      trigger: "chat_turn",
       isAutonomousAgent: true,
     });
 

--- a/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
+++ b/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
@@ -768,7 +768,7 @@ Include your extracted terms as: [SALIENT_TERMS: term1, term2, term3]`;
     let sources: { title: string; path: string; score: number; explanation?: unknown }[] = [];
 
     const isPaidUser = await checkIsPaidUser(this.chainManager.app, {
-      trigger: "chat_turn",
+      trigger: "legacy_chat_turn",
       isCopilotPlus: true,
     });
     if (!isPaidUser) {

--- a/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
+++ b/src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts
@@ -768,6 +768,7 @@ Include your extracted terms as: [SALIENT_TERMS: term1, term2, term3]`;
     let sources: { title: string; path: string; score: number; explanation?: unknown }[] = [];
 
     const isPaidUser = await checkIsPaidUser(this.chainManager.app, {
+      trigger: "chat_turn",
       isCopilotPlus: true,
     });
     if (!isPaidUser) {

--- a/src/LLMProviders/chainRunner/utils/toolExecution.test.ts
+++ b/src/LLMProviders/chainRunner/utils/toolExecution.test.ts
@@ -98,6 +98,7 @@ describe("toolExecution", () => {
         result: "Error: plusTool requires a Copilot Plus subscription",
         success: false,
       });
+      expect(mockCheckIsPaidUser).toHaveBeenCalledWith(undefined, { trigger: "tool_call" });
       expect(mockCallTool).not.toHaveBeenCalled();
     });
 

--- a/src/LLMProviders/chainRunner/utils/toolExecution.ts
+++ b/src/LLMProviders/chainRunner/utils/toolExecution.ts
@@ -64,7 +64,7 @@ export async function executeSequentialToolCall(
 
     // Check if tool requires Plus subscription
     if (metadata?.isPlusOnly) {
-      const isPaidUser = await checkIsPaidUser();
+      const isPaidUser = await checkIsPaidUser(undefined, { trigger: "tool_call" });
       if (!isPaidUser && !isSelfHostModeValid()) {
         return {
           toolName: toolCall.name,

--- a/src/LLMProviders/embeddingManager.ts
+++ b/src/LLMProviders/embeddingManager.ts
@@ -154,7 +154,9 @@ export default class EmbeddingManager {
     // Check if model is believer-exclusive but user is not on believer plan
     if (customModel.believerExclusive) {
       const brevilabsClient = BrevilabsClient.getInstance();
-      const result = await brevilabsClient.validateLicenseKey();
+      const result = await brevilabsClient.validateLicenseKey(undefined, {
+        trigger: "model_gate",
+      });
       if (!result.plan || result.plan.toLowerCase() !== "believer") {
         new Notice("Believer-only model, please consider upgrading to Believer to access it.");
         throw new CustomError("Believer-only model selected but user is not on Believer plan");

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -1672,8 +1672,11 @@ describe("ensureMultiAgentEntitlement (paywall helper)", () => {
     const ensure = await loadHelper(false);
     await expect(ensure()).resolves.toBe(true);
     expect(validateLicenseKey).toHaveBeenCalledTimes(1);
-    // The feature context is forwarded for backend telemetry/upsell.
-    expect(validateLicenseKey.mock.calls[0][1]).toMatchObject({ feature: "multi_agent_per_turn" });
+    // The trigger and feature context are forwarded for backend telemetry/upsell.
+    expect(validateLicenseKey.mock.calls[0][1]).toMatchObject({
+      trigger: "chat_turn",
+      feature: "multi_agent_per_turn",
+    });
   });
 
   it("slow path: a Lite user (paid but below Plus) is blocked", async () => {

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -1670,7 +1670,9 @@ describe("ensureMultiAgentEntitlement (paywall helper)", () => {
     const ensure = await loadHelper(false);
     await expect(ensure()).resolves.toBe(true);
     expect(validateLicenseKey).toHaveBeenCalledTimes(1);
-    expect(validateLicenseKey.mock.calls[0][1]).toMatchObject({ trigger: "chat_turn" });
+    expect(validateLicenseKey.mock.calls[0][1]).toMatchObject({
+      trigger: "multi_agent_per_turn",
+    });
   });
 
   it("slow path: a Lite user (paid but below Plus) is blocked", async () => {

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -1633,9 +1633,7 @@ describe("ensureMultiAgentEntitlement (paywall helper)", () => {
     validateLicenseKey.mockReset();
   });
 
-  async function loadHelper(
-    isPlus: boolean
-  ): Promise<(app?: unknown, ctx?: Record<string, unknown>) => Promise<boolean>> {
+  async function loadHelper(isPlus: boolean): Promise<(app?: unknown) => Promise<boolean>> {
     settings = { isPlusUser: isPlus, isPaidUser: isPlus, enableSelfHostMode: false };
     jest.doMock("@/plusUtils", () => jest.requireActual("@/plusUtils"));
     jest.doMock("@/logger", () => ({
@@ -1672,11 +1670,7 @@ describe("ensureMultiAgentEntitlement (paywall helper)", () => {
     const ensure = await loadHelper(false);
     await expect(ensure()).resolves.toBe(true);
     expect(validateLicenseKey).toHaveBeenCalledTimes(1);
-    // The trigger and feature context are forwarded for backend telemetry/upsell.
-    expect(validateLicenseKey.mock.calls[0][1]).toMatchObject({
-      trigger: "chat_turn",
-      feature: "multi_agent_per_turn",
-    });
+    expect(validateLicenseKey.mock.calls[0][1]).toMatchObject({ trigger: "chat_turn" });
   });
 
   it("slow path: a Lite user (paid but below Plus) is blocked", async () => {

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -1229,7 +1229,7 @@ export class AgentSession {
    * against `/license`.
    */
   private ensureMultiAgentEntitlement(): Promise<boolean> {
-    return ensureMultiAgentEntitlement(this.getApp?.(), { feature: "multi_agent_per_turn" });
+    return ensureMultiAgentEntitlement(this.getApp?.());
   }
 
   /**

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -673,7 +673,7 @@ export function registerCommands(plugin: CopilotPlugin, publish: PublishFile) {
 
   // Add command to download YouTube script (Copilot Plus only)
   addCommand(plugin, COMMAND_IDS.DOWNLOAD_YOUTUBE_SCRIPT, async () => {
-    const isPaidUser = await checkIsPaidUser(plugin.app);
+    const isPaidUser = await checkIsPaidUser(plugin.app, { trigger: "tool_call" });
     if (!isPaidUser) {
       new Notice("Download YouTube Script (plus) is a Copilot Plus feature");
       return;

--- a/src/main.ts
+++ b/src/main.ts
@@ -284,7 +284,7 @@ export default class CopilotPlugin extends Plugin {
     // signature re-proves itself. The network re-validation below overrides
     // with the server's token.
     void verifyCachedEntitlement();
-    if (!isLegacyUpgrade) void checkIsPaidUser(this.app);
+    if (!isLegacyUpgrade) void checkIsPaidUser(this.app, { trigger: "startup" });
     // Entitlement tokens expire (~14 days), and the gates honor that expiry even
     // mid-session. Without a refresh, an Obsidian window left open past `exp`
     // loses self-host — which silently reroutes web search and document parsing
@@ -292,7 +292,10 @@ export default class CopilotPlugin extends Plugin {
     // Each /license call mints a fresh token, so re-validating daily keeps an
     // online session current; offline users still lapse at `exp`, as intended.
     this.registerInterval(
-      window.setInterval(() => void checkIsPaidUser(this.app), ENTITLEMENT_REFRESH_INTERVAL_MS)
+      window.setInterval(
+        () => void checkIsPaidUser(this.app, { trigger: "refresh" }),
+        ENTITLEMENT_REFRESH_INTERVAL_MS
+      )
     );
 
     // Initialize ProjectManager
@@ -552,7 +555,7 @@ export default class CopilotPlugin extends Plugin {
         }
       : null;
     if (isLegacyUpgrade) {
-      void checkIsPaidUser(needsLicenseReentry ? undefined : this.app);
+      void checkIsPaidUser(needsLicenseReentry ? undefined : this.app, { trigger: "startup" });
     }
 
     await runStartupMigrationSummary({

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -32,10 +32,18 @@ jest.mock("@/entitlement", () => ({
   verifyEntitlement: (...args: [string, unknown?]) => mockVerifyEntitlement(...args),
 }));
 
-const mockValidateLicenseKey = jest.fn<Promise<{ isValid: boolean | undefined }>, []>();
+const mockValidateLicenseKey = jest.fn<
+  Promise<{ isValid: boolean | undefined }>,
+  [unknown, Record<string, unknown>]
+>();
 
 jest.mock("@/LLMProviders/brevilabsClient", () => ({
-  BrevilabsClient: { getInstance: () => ({ validateLicenseKey: () => mockValidateLicenseKey() }) },
+  BrevilabsClient: {
+    getInstance: () => ({
+      validateLicenseKey: (app: unknown, context: Record<string, unknown>) =>
+        mockValidateLicenseKey(app, context),
+    }),
+  },
 }));
 
 const mockSetModelKey = jest.fn<void, [string]>();
@@ -686,7 +694,7 @@ describe("plusUtils", () => {
     it("returns false without reaching the server when no license key is set", async () => {
       mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "" }));
 
-      expect(await checkIsPaidUser()).toBe(false);
+      expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
       expect(mockValidateLicenseKey).not.toHaveBeenCalled();
     });
 
@@ -694,7 +702,8 @@ describe("plusUtils", () => {
       mockGetSettings.mockReturnValue(buildSettings({ plusLicenseKey: "key", isPaidUser: true }));
       mockValidateLicenseKey.mockResolvedValue({ isValid: false });
 
-      expect(await checkIsPaidUser()).toBe(false);
+      expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
+      expect(mockValidateLicenseKey).toHaveBeenCalledWith(undefined, { trigger: "manual" });
     });
 
     it("keeps an unexpired entitlement working when the license server is unreachable", async () => {
@@ -705,7 +714,7 @@ describe("plusUtils", () => {
       mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
       mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
 
-      expect(await checkIsPaidUser()).toBe(true);
+      expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(true);
       expect(mockValidateLicenseKey).toHaveBeenCalled();
     });
 
@@ -714,7 +723,7 @@ describe("plusUtils", () => {
       mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
       mockValidateLicenseKey.mockResolvedValue({ isValid: undefined });
 
-      expect(await checkIsPaidUser()).toBe(true);
+      expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(true);
     });
 
     it("stops a turn whose entitlement expired while renewal was failing", async () => {
@@ -725,7 +734,7 @@ describe("plusUtils", () => {
       mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
       mockValidateLicenseKey.mockResolvedValue({ isValid: undefined });
 
-      expect(await checkIsPaidUser()).toBe(false);
+      expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
     });
 
     it("refuses the offline fallback to an unexpired free-tier token", async () => {
@@ -746,7 +755,7 @@ describe("plusUtils", () => {
       mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
       mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
 
-      expect(await checkIsPaidUser()).toBe(false);
+      expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
     });
 
     it("does not grant offline access on persisted flags alone (edited data.json)", async () => {
@@ -755,7 +764,7 @@ describe("plusUtils", () => {
       );
       mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
 
-      expect(await checkIsPaidUser()).toBe(false);
+      expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
     });
   });
 

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -229,19 +229,14 @@ export function canUseMultiAgent(): boolean {
  * broad `isValid`) so Lite stays blocked. Anything not confirmed >= Plus is a
  * HARD block (no single-agent fallback).
  */
-export async function ensureMultiAgentEntitlement(
-  app?: App,
-  context?: Record<string, unknown>
-): Promise<boolean> {
+export async function ensureMultiAgentEntitlement(app?: App): Promise<boolean> {
   if (isPlusEnabled()) {
     return true;
   }
   // Re-verify so a stale-false cache for a real Plus user still gets through;
   // `validateLicenseKey` applies the signed entitlement or paid-pending state.
   await BrevilabsClient.getInstance().validateLicenseKey(app, {
-    ...context,
     trigger: "chat_turn",
-    feature: "multi_agent_per_turn",
   });
   return isPlusEnabled();
 }

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -8,7 +8,7 @@ import {
   PlusUtmMedium,
 } from "@/constants";
 import { EntitlementFeature, verifyEntitlement } from "@/entitlement";
-import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
+import { BrevilabsClient, LicenseCheckContext } from "@/LLMProviders/brevilabsClient";
 import { logError, logInfo, logWarn } from "@/logger";
 import {
   CopilotSettings,
@@ -239,8 +239,9 @@ export async function ensureMultiAgentEntitlement(
   // Re-verify so a stale-false cache for a real Plus user still gets through;
   // `validateLicenseKey` applies the signed entitlement or paid-pending state.
   await BrevilabsClient.getInstance().validateLicenseKey(app, {
-    feature: "multi_agent_per_turn",
     ...context,
+    trigger: "chat_turn",
+    feature: "multi_agent_per_turn",
   });
   return isPlusEnabled();
 }
@@ -282,8 +283,8 @@ export function useCanUseMultiAgent(): boolean {
  * closed — quietly rerouting their searches to the cloud.
  */
 export async function checkIsPaidUser(
-  app?: App,
-  context?: Record<string, unknown>
+  app: App | undefined,
+  context: LicenseCheckContext
 ): Promise<boolean | undefined> {
   if (!getSettings().plusLicenseKey) {
     turnOffPaid(app);

--- a/src/plusUtils.ts
+++ b/src/plusUtils.ts
@@ -236,7 +236,7 @@ export async function ensureMultiAgentEntitlement(app?: App): Promise<boolean> {
   // Re-verify so a stale-false cache for a real Plus user still gets through;
   // `validateLicenseKey` applies the signed entitlement or paid-pending state.
   await BrevilabsClient.getInstance().validateLicenseKey(app, {
-    trigger: "chat_turn",
+    trigger: "multi_agent_per_turn",
   });
   return isPlusEnabled();
 }

--- a/src/settings/v2/components/PlusSettings.test.tsx
+++ b/src/settings/v2/components/PlusSettings.test.tsx
@@ -3,6 +3,7 @@ import { act, render, screen } from "@testing-library/react";
 import React from "react";
 
 const updateSetting = jest.fn<void, unknown[]>();
+const mockApp = {};
 let currentSettings = { ...DEFAULT_SETTINGS };
 jest.mock("@/settings/model", () => ({
   updateSetting: (...a: unknown[]) => updateSetting(...a),
@@ -27,7 +28,7 @@ jest.mock("@/plusUtils", () => ({
 
 jest.mock("@/context", () => ({
   // eslint-disable-next-line @eslint-react/hooks-extra/no-unnecessary-use-prefix -- mocks the real hook
-  useApp: () => ({}),
+  useApp: () => mockApp,
 }));
 
 jest.mock("@/components/modals/CopilotPlusWelcomeModal", () => ({
@@ -93,6 +94,7 @@ describe("PlusSettings", () => {
         screen.getByRole("button", { name: "Apply" }).click();
       });
 
+      expect(checkIsPaidUser).toHaveBeenCalledWith(mockApp, { trigger: "manual" });
       expect(screen.queryByText("Inactive")).toBeNull();
       expect(screen.queryByText("All of it for a few dollars a month.")).toBeNull();
 

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -128,7 +128,7 @@ export function PlusSettings() {
           onClick={async () => {
             updateSetting("plusLicenseKey", localLicenseKey);
             setIsChecking(true);
-            const result = await checkIsPaidUser(app);
+            const result = await checkIsPaidUser(app, { trigger: "manual" });
             setIsChecking(false);
             if (!result) {
               setError("Invalid license key");


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#292

## Why

The API records license checks, but Copilot does not consistently say why each check happened. Startup checks, a user applying a key, legacy paid chat turns, and V4 multi-agent entitlement gates therefore look identical in analytics, which makes onboarding and the V4 launch hard to evaluate.

## What

Each license request now carries one stable trigger.

| Condition | Trigger |
| --- | --- |
| Plugin load | `startup` |
| User applies a license key | `manual` |
| Scheduled entitlement renewal | `refresh` |
| Legacy Plus/autonomous chat turn | `legacy_chat_turn` |
| V4 multi-agent per-turn entitlement gate | `multi_agent_per_turn` |
| Paid tool execution | `tool_call` |
| Believer-only model check | `model_gate` |

Keeping the V4 trigger separate preserves launch attribution while the legacy Plus/autonomous paths are deprecated. License validity, entitlement, and offline behavior do not change.

## Non goal

- Adding a PostHog SDK or sending analytics directly from the plugin.
- Changing license validity, retry, entitlement, or offline-access rules.
- Removing `legacy_chat_turn` before its callers are retired.
- Adding settings or user-facing analytics controls.

## Screenshot

Not applicable — this PR only adds metadata to the existing license request and has no visual change.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Request-forwarding and call-site tests cover the new required trigger context |
| A defect would fail CI or be obvious on first use | ❌ | A semantically wrong trigger could reach analytics without changing the user-visible license result |
| A revert fully restores prior state, including persisted data | ✅ | The field is additive and no user data is migrated or rewritten |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | The authenticated license-validation request gains metadata, although credential handling is unchanged |
| No public API, plugin API, message, or on-disk contract changes | ❌ | The `/license` request body gains a required caller-supplied trigger contract |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Existing request timing and entitlement transitions are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | Legacy chat, V4 multi-agent, and paid-tool forwarding are asserted, and unsupported or missing triggers fail type-checking |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ❌ | Attribution spans several license-check paths and is observed in request or analytics data rather than the UI |

Review: inspect `src/LLMProviders/brevilabsClient.ts` — `LicenseCheckContext` and `validateLicenseKey` — plus the `checkIsPaidUser` call sites in `src/main.ts`, `src/plusUtils.ts`, `src/commands/index.ts`, `src/LLMProviders/embeddingManager.ts`, `src/LLMProviders/chainRunner/CopilotPlusChainRunner.ts`, and `src/LLMProviders/chainRunner/AutonomousAgentChainRunner.ts`; then run Verification steps 2–5, including invalid-key and offline variants.

## Verification

1. Build and load this branch in the Copilot test vault, then open Obsidian Developer Tools to the Network panel.
2. Apply a valid license in Copilot settings. Confirm the `/v1/license` JSON body includes `trigger: "manual"` and the request retains the `X-Client-Version` header.
3. Reload Copilot and start a legacy paid chat turn. Confirm subsequent license requests use `startup` and `legacy_chat_turn` respectively.
4. Exercise the V4 multi-agent entitlement slow path, a Plus-only tool, and a Believer-only model gate. Confirm their license requests use `multi_agent_per_turn`, `tool_call`, and `model_gate` respectively.
5. Repeat the manual check with an invalid key, then with the license endpoint offline. Confirm the same trigger metadata is dispatched and the existing invalid/offline behavior remains unchanged.


