### PR TITLE
Replace the deprecated lucide Youtube icon with SquarePlay

### DIFF
--- a/src/components/modals/project/ContextManageLinksPanel.tsx
+++ b/src/components/modals/project/ContextManageLinksPanel.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { openAgentCachedItemPreview } from "@/utils/cacheFileOpener";
 import type { UrlItem, UrlKind } from "@/utils/urlTagUtils";
-import { ArrowUpRight, Globe, Link, PlusCircle, X, Youtube } from "lucide-react";
+import { ArrowUpRight, Globe, Link, PlusCircle, SquarePlay, X } from "lucide-react";
 import { App } from "obsidian";
 import React from "react";
 
@@ -82,7 +82,7 @@ export function LinksSidebarSection({
         onClick={() => onSelect("web")}
       />
       <LinkSubItem
-        Icon={Youtube}
+        Icon={SquarePlay}
         label="YouTube"
         count={youtubeCount}
         active={activeSection === "youtube"}

--- a/src/components/project/UrlTypeIcon.tsx
+++ b/src/components/project/UrlTypeIcon.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 import type { UrlKind } from "@/utils/urlTagUtils";
-import { Globe, Youtube } from "lucide-react";
+import { Globe, SquarePlay } from "lucide-react";
 import * as React from "react";
 
 /**
@@ -10,7 +10,7 @@ import * as React from "react";
  */
 export function UrlTypeIcon({ type, className }: { type: UrlKind; className?: string }) {
   return type === "youtube" ? (
-    <Youtube className={cn("tw-text-error", className)} />
+    <SquarePlay className={cn("tw-text-error", className)} />
   ) : (
     <Globe className={cn("tw-text-context-manager-cyan", className)} />
   );


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#291

## Why

The official Obsidian community plugin scorecard flags the lucide-react `Youtube` brand icon: "Youtube is deprecated. Brand icons have been deprecated... This icon will be removed in v1.0" (2 occurrences). The icon renders as the red YouTube play glyph on every URL surface in Projects — the Manage Links panel's "YouTube" sub-item, the +URL popover, the context source editor rows, and the context chips. Once lucide removes the icon, those surfaces would break at build time; until then the warning stays on the scorecard.

## What

Both usages of the deprecated `Youtube` icon now render lucide's `SquarePlay` — a rounded-square play glyph that keeps the "video" meaning without the brand mark. Sizing, color (`tw-text-error` red), and all other props are unchanged, so the only visible difference is the glyph outline: a square instead of the YouTube rounded rectangle. Web URLs keep the cyan globe. No lucide brand icon imports remain anywhere in the plugin.

## Non goal

- No redesign of URL-type iconography or colors; the red-video / cyan-web scheme stays as is.
- No changes to YouTube functionality itself (transcript tools, URL detection, `UrlKind` classification).
- No update to the scorecard snapshot body in logancyang/obsidian-copilot-preview#291; per its own workflow the snapshot is replaced only after the next official authenticated review.

## Screenshot

Cannot capture: this change was made in a headless background session with no Obsidian test vault or authenticated GitHub web editor available for image upload. The visual delta is confined to the glyph outline — lucide `Youtube` (rounded rectangle with play triangle) becomes lucide `SquarePlay` (rounded square with play triangle) — at identical size and color; Verification step 2 reaches the affected surfaces directly.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Pure glyph swap, visible on every Projects URL surface where it renders |
| A defect would fail CI or be obvious on first use | ✅ | A missing lucide export fails the TypeScript build; a wrong glyph is visible on the first Manage Links open |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data touched; reverting the two files restores the old glyph |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Icon components only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `UrlTypeIcon`'s props and `UrlKind` are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Synchronous render-only change |
| No hot-path behavior lacks deterministic coverage | ✅ | Rendering-only change; the full unit suite passes unchanged |
| No new dependency | ✅ | `SquarePlay` ships in the already-installed lucide-react 0.462.0 |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to Projects URL surfaces; visible on the next Manage Links open |

Review: skim `Why` and `What`, run Verification step 2, confirm CI is green, and merge.

## Verification

1. Build this branch (`npm run build`) and load the plugin in a test vault.
2. Open a Project's context manager and its Manage Links panel: the "YouTube" sub-item shows a red rounded-square play icon in place of the YouTube brand mark, and the "Web" sub-item keeps the cyan globe.
3. Add a YouTube URL as project context and confirm the same red square-play glyph appears in the +URL popover suggestions, the context source rows, and the context chips at the usual sizes.
