### PR TITLE
Keep Escape inside the chat composer without blocking IME

### DIFF
--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -762,8 +762,10 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
 
     const doc = containerRef.current?.doc;
     if (!doc) return;
-    doc.addEventListener("keydown", handleKeyDown);
-    return () => doc.removeEventListener("keydown", handleKeyDown);
+    // Capture edit cancellation before the composer contains Escape at its own boundary.
+    // https://github.com/logancyang/obsidian-copilot-preview/issues/302
+    doc.addEventListener("keydown", handleKeyDown, true);
+    return () => doc.removeEventListener("keydown", handleKeyDown, true);
   }, [editMode, onEditCancel]);
 
   useImperativeHandle(

--- a/src/components/chat-components/plugins/KeyboardPlugin.test.ts
+++ b/src/components/chat-components/plugins/KeyboardPlugin.test.ts
@@ -1,5 +1,11 @@
 import { SEND_SHORTCUT } from "@/constants";
-import { checkShortcutMatch, isImeCompositionEvent } from "./KeyboardPlugin";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { fireEvent, render } from "@testing-library/react";
+import { COMMAND_PRIORITY_HIGH, KEY_ESCAPE_COMMAND, type LexicalEditor } from "lexical";
+import React from "react";
+import { KeyboardPlugin, checkShortcutMatch, isImeCompositionEvent } from "./KeyboardPlugin";
 
 /**
  * Helper function to create a mock KeyboardEvent with specified fields
@@ -19,10 +25,121 @@ function createMockKeyboardEvent(fields: {
     ctrlKey: fields.ctrlKey || false,
     altKey: fields.altKey || false,
     isComposing: fields.isComposing || false,
-  } as KeyboardEvent;
+    preventDefault: jest.fn(),
+    stopPropagation: jest.fn(),
+  } as unknown as KeyboardEvent;
+}
+
+let editor: LexicalEditor;
+
+function EditorCapture(): null {
+  [editor] = useLexicalComposerContext();
+  return null;
+}
+
+interface RenderedKeyboardPlugin {
+  input: HTMLElement;
+  boundary: HTMLElement;
+}
+
+function renderKeyboardPlugin(onEscape?: () => void): RenderedKeyboardPlugin {
+  const result = render(
+    React.createElement(
+      LexicalComposer,
+      {
+        initialConfig: {
+          namespace: "keyboard-plugin-test",
+          onError: (error: Error) => {
+            throw error;
+          },
+        },
+      },
+      React.createElement(ContentEditable, { "aria-label": "Chat input" }),
+      React.createElement(EditorCapture),
+      React.createElement(KeyboardPlugin, {
+        onSubmit: jest.fn(),
+        sendShortcut: SEND_SHORTCUT.ENTER,
+        onEscape,
+      })
+    )
+  );
+  return {
+    input: result.getByRole("textbox", { name: "Chat input" }),
+    boundary: result.container,
+  };
+}
+
+function dispatchEscape(target: HTMLElement, init: KeyboardEventInit = {}): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "Escape",
+    code: "Escape",
+    bubbles: true,
+    cancelable: true,
+    ...init,
+  });
+  fireEvent(target, event);
+  return event;
 }
 
 describe("KeyboardPlugin", () => {
+  describe("KeyboardPlugin()", () => {
+    it("should contain IME-owned Escape without blocking native composition cancellation (https://github.com/logancyang/obsidian-copilot-preview/issues/302)", () => {
+      const onEscape = jest.fn();
+      const boundaryHandler = jest.fn();
+      const { input, boundary } = renderKeyboardPlugin(onEscape);
+      boundary.addEventListener("keydown", boundaryHandler);
+      input.focus();
+      fireEvent.compositionStart(input);
+
+      const event = dispatchEscape(input, { isComposing: true });
+
+      expect(boundaryHandler).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(input);
+      expect(event.defaultPrevented).toBe(false);
+      expect(onEscape).not.toHaveBeenCalled();
+      fireEvent.compositionEnd(input);
+    });
+
+    it("should contain plain Escape when no chat action is configured (https://github.com/logancyang/obsidian-copilot-preview/issues/302)", () => {
+      const boundaryHandler = jest.fn();
+      const { input, boundary } = renderKeyboardPlugin();
+      boundary.addEventListener("keydown", boundaryHandler);
+      input.focus();
+
+      const event = dispatchEscape(input);
+
+      expect(boundaryHandler).not.toHaveBeenCalled();
+      expect(document.activeElement).toBe(input);
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("should contain plain Escape before a higher-priority chat action handles it (https://github.com/logancyang/obsidian-copilot-preview/issues/302)", () => {
+      const typeaheadEscapeHandler = jest.fn(() => true);
+      const boundaryHandler = jest.fn();
+      const { input, boundary } = renderKeyboardPlugin();
+      editor.registerCommand(KEY_ESCAPE_COMMAND, typeaheadEscapeHandler, COMMAND_PRIORITY_HIGH);
+      boundary.addEventListener("keydown", boundaryHandler);
+
+      const event = dispatchEscape(input);
+
+      expect(boundaryHandler).not.toHaveBeenCalled();
+      expect(typeaheadEscapeHandler).toHaveBeenCalledWith(event, editor);
+    });
+
+    it("should contain plain Escape and invoke its configured chat action (https://github.com/logancyang/obsidian-copilot-preview/issues/302)", () => {
+      const onEscape = jest.fn();
+      const boundaryHandler = jest.fn();
+      const { input, boundary } = renderKeyboardPlugin(onEscape);
+      boundary.addEventListener("keydown", boundaryHandler);
+
+      const event = dispatchEscape(input);
+
+      expect(boundaryHandler).not.toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(true);
+      expect(onEscape).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("checkShortcutMatch()", () => {
     describe("ENTER shortcut", () => {
       it("should match plain Enter key", () => {
@@ -123,7 +240,7 @@ describe("KeyboardPlugin", () => {
       expect(isImeCompositionEvent(event)).toBe(true);
     });
 
-    it("should detect IME-consumed keys reported as key 'Process' even when isComposing is false", () => {
+    it("should keep chat shortcuts inactive for IME-consumed Process keys (https://github.com/logancyang/obsidian-copilot-preview/issues/302)", () => {
       const event = createMockKeyboardEvent({ key: "Process", isComposing: false });
       expect(isImeCompositionEvent(event)).toBe(true);
     });

--- a/src/components/chat-components/plugins/KeyboardPlugin.test.ts
+++ b/src/components/chat-components/plugins/KeyboardPlugin.test.ts
@@ -1,10 +1,11 @@
 import { SEND_SHORTCUT } from "@/constants";
-import { checkShortcutMatch } from "./KeyboardPlugin";
+import { checkShortcutMatch, isImeCompositionEvent } from "./KeyboardPlugin";
 
 /**
- * Helper function to create a mock KeyboardEvent with specified modifiers
+ * Helper function to create a mock KeyboardEvent with specified fields
  */
-function createMockKeyboardEvent(modifiers: {
+function createMockKeyboardEvent(fields: {
+  key?: string;
   shiftKey?: boolean;
   metaKey?: boolean;
   ctrlKey?: boolean;
@@ -12,109 +13,129 @@ function createMockKeyboardEvent(modifiers: {
   isComposing?: boolean;
 }): KeyboardEvent {
   return {
-    shiftKey: modifiers.shiftKey || false,
-    metaKey: modifiers.metaKey || false,
-    ctrlKey: modifiers.ctrlKey || false,
-    altKey: modifiers.altKey || false,
-    isComposing: modifiers.isComposing || false,
+    key: fields.key || "Enter",
+    shiftKey: fields.shiftKey || false,
+    metaKey: fields.metaKey || false,
+    ctrlKey: fields.ctrlKey || false,
+    altKey: fields.altKey || false,
+    isComposing: fields.isComposing || false,
   } as KeyboardEvent;
 }
 
-describe("KeyboardPlugin - checkShortcutMatch", () => {
-  describe("ENTER shortcut", () => {
-    it("should match plain Enter key", () => {
-      const event = createMockKeyboardEvent({});
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(true);
-    });
-
-    it("should not match when Shift is pressed", () => {
-      const event = createMockKeyboardEvent({ shiftKey: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
-    });
-
-    it("should not match when Meta is pressed", () => {
-      const event = createMockKeyboardEvent({ metaKey: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
-    });
-
-    it("should not match when Ctrl is pressed", () => {
-      const event = createMockKeyboardEvent({ ctrlKey: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
-    });
-
-    it("should not match when Alt is pressed", () => {
-      const event = createMockKeyboardEvent({ altKey: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
-    });
-
-    it("should not match when multiple modifiers are pressed", () => {
-      const event = createMockKeyboardEvent({ shiftKey: true, ctrlKey: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
-    });
-  });
-
-  describe("SHIFT_ENTER shortcut", () => {
-    it("should match Shift+Enter", () => {
-      const event = createMockKeyboardEvent({ shiftKey: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(true);
-    });
-
-    it("should not match plain Enter", () => {
-      const event = createMockKeyboardEvent({});
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
-    });
-
-    it("should not match when Meta is also pressed", () => {
-      const event = createMockKeyboardEvent({ shiftKey: true, metaKey: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
-    });
-
-    it("should not match when Ctrl is also pressed", () => {
-      const event = createMockKeyboardEvent({ shiftKey: true, ctrlKey: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
-    });
-
-    it("should not match when Alt is also pressed", () => {
-      const event = createMockKeyboardEvent({ shiftKey: true, altKey: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
-    });
-  });
-
-  describe("IME Composition", () => {
-    it("should still match shortcuts during IME composition (checkShortcutMatch only checks modifiers)", () => {
-      // Note: The actual IME protection happens in the KeyboardPlugin component,
-      // not in checkShortcutMatch. This test verifies that checkShortcutMatch
-      // doesn't interfere with IME handling.
-      const event = createMockKeyboardEvent({ isComposing: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(true);
-    });
-
-    it("should match ENTER shortcut even when isComposing is true (IME check is in plugin)", () => {
-      const event = createMockKeyboardEvent({ isComposing: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(true);
-    });
-
-    it("should match SHIFT_ENTER shortcut even when isComposing is true", () => {
-      const event = createMockKeyboardEvent({ shiftKey: true, isComposing: true });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(true);
-    });
-  });
-
-  describe("Edge cases", () => {
-    it("should return false for invalid shortcut type", () => {
-      const event = createMockKeyboardEvent({});
-      expect(checkShortcutMatch(event, "invalid-shortcut" as SEND_SHORTCUT)).toBe(false);
-    });
-
-    it("should not match when all modifiers are pressed", () => {
-      const event = createMockKeyboardEvent({
-        shiftKey: true,
-        metaKey: true,
-        ctrlKey: true,
-        altKey: true,
+describe("KeyboardPlugin", () => {
+  describe("checkShortcutMatch()", () => {
+    describe("ENTER shortcut", () => {
+      it("should match plain Enter key", () => {
+        const event = createMockKeyboardEvent({});
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(true);
       });
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
-      expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
+
+      it("should not match when Shift is pressed", () => {
+        const event = createMockKeyboardEvent({ shiftKey: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
+      });
+
+      it("should not match when Meta is pressed", () => {
+        const event = createMockKeyboardEvent({ metaKey: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
+      });
+
+      it("should not match when Ctrl is pressed", () => {
+        const event = createMockKeyboardEvent({ ctrlKey: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
+      });
+
+      it("should not match when Alt is pressed", () => {
+        const event = createMockKeyboardEvent({ altKey: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
+      });
+
+      it("should not match when multiple modifiers are pressed", () => {
+        const event = createMockKeyboardEvent({ shiftKey: true, ctrlKey: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
+      });
+    });
+
+    describe("SHIFT_ENTER shortcut", () => {
+      it("should match Shift+Enter", () => {
+        const event = createMockKeyboardEvent({ shiftKey: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(true);
+      });
+
+      it("should not match plain Enter", () => {
+        const event = createMockKeyboardEvent({});
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
+      });
+
+      it("should not match when Meta is also pressed", () => {
+        const event = createMockKeyboardEvent({ shiftKey: true, metaKey: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
+      });
+
+      it("should not match when Ctrl is also pressed", () => {
+        const event = createMockKeyboardEvent({ shiftKey: true, ctrlKey: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
+      });
+
+      it("should not match when Alt is also pressed", () => {
+        const event = createMockKeyboardEvent({ shiftKey: true, altKey: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
+      });
+    });
+
+    describe("IME Composition", () => {
+      it("should still match shortcuts during IME composition (checkShortcutMatch only checks modifiers)", () => {
+        // Note: The actual IME protection happens in the KeyboardPlugin component
+        // via isImeCompositionEvent, not in checkShortcutMatch. This test verifies
+        // that checkShortcutMatch doesn't interfere with IME handling.
+        const event = createMockKeyboardEvent({ isComposing: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(true);
+      });
+
+      it("should match SHIFT_ENTER shortcut even when isComposing is true", () => {
+        const event = createMockKeyboardEvent({ shiftKey: true, isComposing: true });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(true);
+      });
+    });
+
+    describe("Edge cases", () => {
+      it("should return false for invalid shortcut type", () => {
+        const event = createMockKeyboardEvent({});
+        expect(checkShortcutMatch(event, "invalid-shortcut" as SEND_SHORTCUT)).toBe(false);
+      });
+
+      it("should not match when all modifiers are pressed", () => {
+        const event = createMockKeyboardEvent({
+          shiftKey: true,
+          metaKey: true,
+          ctrlKey: true,
+          altKey: true,
+        });
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.ENTER)).toBe(false);
+        expect(checkShortcutMatch(event, SEND_SHORTCUT.SHIFT_ENTER)).toBe(false);
+      });
+    });
+  });
+
+  describe("isImeCompositionEvent()", () => {
+    it("should detect an active composition session via isComposing", () => {
+      const event = createMockKeyboardEvent({ key: "Enter", isComposing: true });
+      expect(isImeCompositionEvent(event)).toBe(true);
+    });
+
+    it("should detect IME-consumed keys reported as key 'Process' even when isComposing is false", () => {
+      const event = createMockKeyboardEvent({ key: "Process", isComposing: false });
+      expect(isImeCompositionEvent(event)).toBe(true);
+    });
+
+    it("should not flag a plain Enter keydown outside composition", () => {
+      const event = createMockKeyboardEvent({ key: "Enter" });
+      expect(isImeCompositionEvent(event)).toBe(false);
+    });
+
+    it("should not flag a plain Escape keydown outside composition", () => {
+      const event = createMockKeyboardEvent({ key: "Escape" });
+      expect(isImeCompositionEvent(event)).toBe(false);
     });
   });
 });

--- a/src/components/chat-components/plugins/KeyboardPlugin.tsx
+++ b/src/components/chat-components/plugins/KeyboardPlugin.tsx
@@ -16,10 +16,24 @@ interface KeyboardPluginProps {
   onSubmit: () => void;
   /** Send shortcut configuration */
   sendShortcut: SEND_SHORTCUT;
-  /** Optional callback fired when ESC is pressed; when set, swallows the event. */
+  /** Optional callback fired when ESC is pressed outside IME composition. */
   onEscape?: () => void;
   /** Optional callback fired when Shift+Tab is pressed; when set, swallows the event. */
   onShiftTab?: () => void;
+}
+
+function registerEscapeContainment(rootElement: HTMLElement): () => void {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape") return;
+
+    // Lexical skips key commands while composing, so contain Escape on the native
+    // editor root before Obsidian can move focus into the note editor.
+    // https://github.com/logancyang/obsidian-copilot-preview/issues/302
+    event.stopPropagation();
+  };
+
+  rootElement.addEventListener("keydown", handleKeyDown);
+  return () => rootElement.removeEventListener("keydown", handleKeyDown);
 }
 
 /**
@@ -64,15 +78,26 @@ export function KeyboardPlugin({
   }, [editor, onSubmit, sendShortcut]);
 
   useEffect(() => {
+    let removeEscapeContainment: (() => void) | undefined;
+
+    const unregisterRootListener = editor.registerRootListener((rootElement) => {
+      removeEscapeContainment?.();
+      removeEscapeContainment = rootElement ? registerEscapeContainment(rootElement) : undefined;
+    });
+
+    return () => {
+      unregisterRootListener();
+      removeEscapeContainment?.();
+    };
+  }, [editor]);
+
+  useEffect(() => {
     if (!onEscape) return;
     return editor.registerCommand(
       KEY_ESCAPE_COMMAND,
       (event: KeyboardEvent | null) => {
         if (!event) return false;
-        // Some IMEs use ESC to dismiss the candidate window — don't cancel mid-composition.
-        if (isImeCompositionEvent(event)) {
-          return false;
-        }
+        if (isImeCompositionEvent(event)) return true;
         event.preventDefault();
         onEscape();
         return true;
@@ -102,11 +127,8 @@ export function KeyboardPlugin({
 }
 
 /**
- * Detects keydown events that belong to an active IME composition session
- * (e.g., Chinese, Japanese, Korean input) so handlers can avoid acting on them.
- * event.isComposing is set by the browser while a composition session is active;
- * key "Process" is the standard value browsers report for keys consumed by an IME.
- * Exported for testing purposes.
+ * Prevents IME candidate confirmation or dismissal from triggering chat shortcuts.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/302
  * @param event - The keyboard event to check
  * @returns True if the event is part of an IME composition session
  */

--- a/src/components/chat-components/plugins/KeyboardPlugin.tsx
+++ b/src/components/chat-components/plugins/KeyboardPlugin.tsx
@@ -44,9 +44,7 @@ export function KeyboardPlugin({
         }
 
         // Ignore Enter key during IME composition (e.g., Chinese, Japanese, Korean input).
-        // event.isComposing is set by the browser while a composition session is active.
-        // key "Process" is the standard indicator used during IME input.
-        if (event.isComposing || event.key === "Process") {
+        if (isImeCompositionEvent(event)) {
           event.preventDefault();
           return true;
         }
@@ -72,7 +70,7 @@ export function KeyboardPlugin({
       (event: KeyboardEvent | null) => {
         if (!event) return false;
         // Some IMEs use ESC to dismiss the candidate window — don't cancel mid-composition.
-        if (event.isComposing || event.keyCode === 229) {
+        if (isImeCompositionEvent(event)) {
           return false;
         }
         event.preventDefault();
@@ -101,6 +99,19 @@ export function KeyboardPlugin({
   }, [editor, onShiftTab]);
 
   return null;
+}
+
+/**
+ * Detects keydown events that belong to an active IME composition session
+ * (e.g., Chinese, Japanese, Korean input) so handlers can avoid acting on them.
+ * event.isComposing is set by the browser while a composition session is active;
+ * key "Process" is the standard value browsers report for keys consumed by an IME.
+ * Exported for testing purposes.
+ * @param event - The keyboard event to check
+ * @returns True if the event is part of an IME composition session
+ */
+export function isImeCompositionEvent(event: KeyboardEvent): boolean {
+  return event.isComposing || event.key === "Process";
 }
 
 /**


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#302

## Why

Agent Mode added Escape-to-stop while the chat input already had to yield Escape to CJK input methods that use it to dismiss their candidate window. The original guard protected that interaction, but it reused the legacy `keyCode === 229` fallback from an older Enter workaround. That deprecated property is the scorecard violation tracked by the originating issue.

There is also a user-visible failure behind the guard. With Apple Pinyin active in Obsidian desktop, Escape arrives at the composer as `key: "Escape"` with `isComposing: true`; it cancels composition, then bubbles into Obsidian and moves focus from the chat input to the note editor. Escape originating in the chat composer should remain within that surface regardless of whether an IME is active.

## What

| Composer state | Before | After |
| --- | --- | --- |
| IME composition active | Escape dismisses the candidate window, then focus moves to the note editor | Escape dismisses the candidate window and focus stays in the chat input |
| No chat-local Escape action | Escape can reach Obsidian's editor shortcuts | Escape stays within the chat composer |
| Agent generation, typeahead, or message edit active | The local Escape action runs | The same local Escape action runs |
| Enter during IME composition | The IME owns the key | Unchanged |

The IME guard is shared by the Enter and Escape shortcut paths without reading `KeyboardEvent.keyCode`. Every behavioral branch and its regression coverage links directly to the originating ticket.

## Non goal

- Other scorecard warnings, including logancyang/obsidian-copilot-preview#294 and logancyang/obsidian-copilot-preview#295.
- Changing Enter or Shift+Enter send-shortcut matching.
- Removing `keyCode` occurrences from bundled third-party dependencies.
- Changing the chat input's visual design or the IME's native candidate behavior.

## Screenshot

Not applicable — this changes keyboard-event propagation and focus behavior without changing the rendered chat input.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | DOM-level `KeyboardPlugin` tests cover composing, plain, higher-priority, and configured-action Escape paths |
| A defect would fail CI or be obvious on first use | ❌ | OS-level IME event ordering is outside CI and a defect appears only when Escape is pressed during composition |
| A revert fully restores prior state, including persisted data | ✅ | The change is confined to runtime event handling and writes no persisted data |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Chat keyboard input handling changes |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The behavior remains internal to the chat composer |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Escape handling is synchronous and listener cleanup follows the existing editor lifecycle |
| No hot-path behavior lacks deterministic coverage | ❌ | Native candidate-window dismissal requires a real OS input method even though DOM propagation is covered deterministically |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong result is visible on the first composer Escape press |

Review: inspect `src/components/chat-components/plugins/KeyboardPlugin.tsx` — `registerEscapeContainment()`, `KeyboardPlugin()`, and `isImeCompositionEvent()` — plus the edit-mode Escape effect in `src/components/chat-components/ChatInput.tsx`; then run Verification steps 2–5.

## Verification

1. Build this branch, load it in the documented Obsidian test vault, and open a Copilot chat.
2. Enable Apple Pinyin or another CJK IME, type a romanization such as `nihao` so composition is active, and press Escape. The candidate window dismisses, the chat input keeps focus, and no Agent Mode stop action fires.
3. With no composition and no chat-local Escape action active, press Escape in the chat input. Focus stays in the chat input rather than moving to the note editor.
4. Exercise a chat-local Escape action: cancel message editing, dismiss a typeahead menu, or stop active Agent Mode generation. The local action still runs and Escape does not reach the note editor.
5. Start another IME composition and press Enter once. The composition commits without sending; the configured send shortcut continues to work after composition ends.

## Note

The original IME condition came from the commit that introduced Agent Mode's Escape-to-stop behavior: it prevented candidate dismissal from also stopping generation. The legacy `229` fallback was copied from the older Enter guard rather than added from a documented Obsidian WebKit reproduction.

[UI Events](https://www.w3.org/TR/uievents/) defines `isComposing`, standardizes `key` values, and treats `keyCode` as legacy and implementation-dependent; [`"Process"`](https://www.w3.org/TR/uievents-key/#key-Process) is the standardized IME key value. [WebKit bug 165004](https://bugs.webkit.org/show_bug.cgi?id=165004) documents a historical Safari ordering case where `isComposing` alone can be false, but the only `onEscape` consumer here is desktop-only Agent Mode. Restoring `229` would retain the exact scorecard violation without fixing the reproduced Obsidian focus leak.
