### PR TITLE
Replace atob with a pure base64 decoder in entitlement verification

### DIFF
--- a/src/entitlement/verify.test.ts
+++ b/src/entitlement/verify.test.ts
@@ -7,7 +7,7 @@
 import { webcrypto } from "crypto";
 
 import type { EntitlementClaims } from "./types";
-import { verifyEntitlement, type VerifyEntitlementOptions } from "./verify";
+import { base64UrlToBytes, verifyEntitlement, type VerifyEntitlementOptions } from "./verify";
 
 // Node's webcrypto.SubtleCrypto and the DOM SubtleCrypto differ only in unrelated
 // overloads (e.g. Ed25519); cast to the DOM type the API expects.
@@ -56,6 +56,103 @@ function plusClaims(overrides: Partial<EntitlementClaims> = {}): Record<string, 
     ...overrides,
   };
 }
+
+describe("base64UrlToBytes", () => {
+  /**
+   * Oracle: base64url decode via the platform `atob`, the browser-native path
+   * this module's decoder must match byte-for-byte — including which inputs
+   * throw — so license verification is provably unchanged.
+   */
+  function atobOracle(segment: string): Uint8Array {
+    const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  /** Assert decode output (or throwing) is identical to the atob oracle. */
+  function expectSameAsAtob(segment: string) {
+    let expected: number[] | null = null;
+    try {
+      expected = Array.from(atobOracle(segment));
+    } catch {
+      expected = null;
+    }
+    if (expected === null) {
+      expect(() => base64UrlToBytes(segment)).toThrow();
+    } else {
+      expect(Array.from(base64UrlToBytes(segment))).toEqual(expected);
+    }
+  }
+
+  it("decodes representative JWS segments identically to atob across all padding variants", () => {
+    // Byte lengths 1..6 cover every implied-padding variant ("", "=", "==") twice.
+    for (const text of ["a", "ab", "abc", "abcd", "abcde", "abcdef"]) {
+      expectSameAsAtob(base64UrlEncode(text));
+    }
+    expectSameAsAtob("");
+    expectSameAsAtob(base64UrlEncode(JSON.stringify({ alg: "ES256", typ: "JWT", kid: KID })));
+    expectSameAsAtob(base64UrlEncode(JSON.stringify(plusClaims())));
+  });
+
+  it("round-trips every byte value and pseudo-random signature-sized payloads", () => {
+    const allBytes = new Uint8Array(256).map((_, i) => i);
+    expect(Array.from(base64UrlToBytes(base64UrlEncode(allBytes)))).toEqual(Array.from(allBytes));
+
+    // Deterministic LCG so failures are reproducible; 64 bytes matches an ES256 signature.
+    let seed = 42;
+    const nextByte = () => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return seed % 256;
+    };
+    for (let round = 0; round < 50; round++) {
+      const bytes = new Uint8Array(64).map(nextByte);
+      const segment = base64UrlEncode(bytes);
+      expect(Array.from(base64UrlToBytes(segment))).toEqual(Array.from(bytes));
+      expectSameAsAtob(segment);
+    }
+  });
+
+  it("decodes multi-byte UTF-8 payloads identically to atob", () => {
+    const unicode = JSON.stringify({ user_id: "héllo-世界-🎉", note: "ünïcode✓" });
+    const segment = base64UrlEncode(unicode);
+    expectSameAsAtob(segment);
+    expect(new TextDecoder().decode(base64UrlToBytes(segment))).toBe(unicode);
+  });
+
+  it("accepts explicit padding and whitespace exactly where atob does", () => {
+    for (const segment of ["QQ==", "QUI=", "QUJD", "QQ", "QUI", "QU J", "\tQUJD\n"]) {
+      expectSameAsAtob(segment);
+    }
+  });
+
+  it("rejects exactly the malformed segments atob rejects", () => {
+    for (const segment of ["A", "abc!x", "ab=c", "€€€€", "Q===", "QUJD "]) {
+      expectSameAsAtob(segment);
+    }
+  });
+
+  it("agrees with atob on a deterministic fuzz sweep of arbitrary strings", () => {
+    const chars = "ABCXYZabcxyz0189+/-_= \t\n!€中🎉.";
+    let seed = 7;
+    const nextInt = (max: number) => {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      return seed % max;
+    };
+    for (let round = 0; round < 500; round++) {
+      const length = nextInt(24);
+      let segment = "";
+      for (let i = 0; i < length; i++) {
+        segment += chars[nextInt(chars.length)];
+      }
+      expectSameAsAtob(segment);
+    }
+  });
+});
 
 describe("verifyEntitlement", () => {
   let keyPair: CryptoKeyPair;

--- a/src/entitlement/verify.ts
+++ b/src/entitlement/verify.ts
@@ -21,16 +21,46 @@ interface JwsHeader {
   kid?: string;
 }
 
-/** Decode a base64url segment to bytes. */
-function base64UrlToBytes(segment: string): Uint8Array {
-  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
-  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
+const BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * WHATWG forgiving-base64 decode — the exact algorithm `atob` implements —
+ * in pure TypeScript. Plugin review flags `atob` as deprecated (Node typings),
+ * and the suggested `Buffer` is a desktop-only Node built-in unavailable on
+ * mobile, so neither platform decoder is usable here.
+ */
+function decodeBase64(data: string): Uint8Array {
+  let input = data.replace(/[\t\n\f\r ]/g, "");
+  if (input.length % 4 === 0) {
+    input = input.replace(/={1,2}$/, "");
+  }
+  if (input.length % 4 === 1) {
+    throw new Error("Invalid base64 length");
+  }
+  const bytes = new Uint8Array(Math.floor((input.length * 3) / 4));
+  let buffer = 0;
+  let bitCount = 0;
+  let index = 0;
+  for (const char of input) {
+    const value = BASE64_ALPHABET.indexOf(char);
+    if (value < 0) {
+      throw new Error("Invalid base64 character");
+    }
+    buffer = (buffer << 6) | value;
+    bitCount += 6;
+    if (bitCount >= 8) {
+      bitCount -= 8;
+      bytes[index++] = (buffer >> bitCount) & 0xff;
+    }
   }
   return bytes;
+}
+
+/** Decode a base64url segment to bytes. Exported for equivalence testing. */
+export function base64UrlToBytes(segment: string): Uint8Array {
+  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  return decodeBase64(padded);
 }
 
 function parseJsonSegment<T>(segment: string): T | null {


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#304

## Why

The Obsidian community scorecard ([community.obsidian.md/plugins/copilot](https://community.obsidian.md/plugins/copilot)) flags the release with "atob is deprecated. Use Buffer.from(data, 'base64') instead" (1 occurrence). That occurrence is the `atob` call in the entitlement verifier, which decodes the base64url segments (header, claims, signature) of the offline ES256 license token. The suggested `Buffer.from` replacement is a desktop-only Node built-in unavailable in mobile WebViews and would trade this warning for the mobile-incompatible Node-import warning family, so neither platform decoder can be used.

## What

License verification behavior is unchanged; the deprecated call is gone.

> **Before:** verifying an entitlement token decodes its segments through the platform `atob`, which the scorecard flags as deprecated.
>
> **After:** the same segments decode through a pure-TypeScript implementation of the WHATWG forgiving-base64 algorithm — the exact algorithm `atob` implements — producing byte-identical output (and identical rejection of malformed segments) on desktop and mobile, and no production code calls `atob`.

New equivalence tests pin the decoder to a live `atob` oracle: padding variants, multi-byte UTF-8 payloads, whitespace parity, malformed-segment throw parity, and a 500-case deterministic fuzz sweep. The suite was authored first and passes identically against the old `atob` implementation and the new decoder.

## Non goal

- The `atob` occurrences inside `builtinSkills.ts` shell-script string templates — different execution context, not flagged, and skill content must not change.
- `atob` calls inside bundled third-party dependencies.
- Other scorecard warnings (tracked in logancyang/obsidian-copilot-preview#293–#303).
- Any change to token semantics: signature verification, expiry, or user binding.

## Screenshot

Not applicable — headless license-verification internals with no visual surface.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | The `base64UrlToBytes` equivalence suite pins decode output and throw behavior to an `atob` oracle; the signed-token end-to-end tests pass unchanged |
| A defect would fail CI or be obvious on first use | ✅ | The equivalence and end-to-end token tests run in the unit suite in CI |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data or format change; the token format is untouched |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | The change rewrites how untrusted license-token input is decoded inside the entitlement verifier |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Module-internal helper; token wire format and claims are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The decoder is pure and synchronous |
| No hot-path behavior lacks deterministic coverage | ✅ | Valid decode, malformed rejection, whitespace, padding, and fuzz parity are all deterministic tests |
| No new dependency | ✅ | Pure TypeScript; dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong decode surfaces immediately as a license not being recognized |

Review: inspect `src/entitlement/verify.ts` — `decodeBase64` and `base64UrlToBytes` — line by line against the WHATWG forgiving-base64 algorithm, and `src/entitlement/verify.test.ts` — `atobOracle` and `expectSameAsAtob` — to confirm the oracle reproduces the previous implementation exactly; then run Verification steps 1–3, including the tampered-token variant.

## Verification

1. Run `npm test -- src/entitlement/verify.test.ts` and observe all `base64UrlToBytes` equivalence tests (including the fuzz sweep against the live `atob` oracle) and all `verifyEntitlement` signed-token tests pass.
2. To confirm parity with the pre-change implementation, temporarily replace the body of `base64UrlToBytes` with the `atobOracle` body from the test file and rerun step 1 — the same tests pass unchanged, because they were authored against the old implementation before the swap.
3. In a test vault with a licensed Copilot account, reload the plugin and confirm the plan is still recognized; then corrupt one character of the cached license token in the plugin's `data.json` and reload, confirming the license is treated as invalid.
