### PR TITLE
Route production console logging through the project logger

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,36 @@ import tailwind from "eslint-plugin-tailwindcss";
 import boundaries from "eslint-plugin-boundaries";
 import globals from "globals";
 
+const restrictedSourceImports = [
+  {
+    selector:
+      "ImportDeclaration[source.value=/^\\.\\.($|\\u002f)/], ImportExpression[source.value=/^\\.\\.($|\\u002f)/]",
+    message:
+      "Parent-relative imports (`../foo`) are banned. Use the `@/` path alias (e.g. `@/components/Foo`) instead.",
+  },
+  {
+    selector:
+      "ImportDeclaration[source.value='react-dom/client'] ImportSpecifier[imported.name='createRoot']",
+    message:
+      "Use createPluginRoot from '@/utils/react/createPluginRoot' instead. It wraps the root in <AppContext.Provider> so descendants can rely on useApp() unconditionally (see PR #2466).",
+  },
+];
+
+const restrictedConsoleCalls = [
+  {
+    selector: "CallExpression[callee.object.name='console'][callee.property.name='log']",
+    message: "Use logInfo() from '@/logger' instead of console.log().",
+  },
+  {
+    selector: "CallExpression[callee.object.name='console'][callee.property.name='warn']",
+    message: "Use logWarn() from '@/logger' instead of console.warn().",
+  },
+  {
+    selector: "CallExpression[callee.object.name='console'][callee.property.name='error']",
+    message: "Use logError() from '@/logger' instead of console.error().",
+  },
+];
+
 export default [
   {
     ignores: [
@@ -84,6 +114,19 @@ export default [
     rules: {
       // Carry-over from legacy .eslintrc
       "no-prototype-builtins": "off",
+      // Use project-specific console-call messages below while preserving the
+      // Obsidian config's custom message for the Function constructor.
+      "obsidianmd/rule-custom-message": [
+        "error",
+        {
+          "no-new-func": {
+            messages: {
+              "The Function constructor is eval":
+                "Using the `Function` constructor is dangerous because it executes arbitrary code, similar to `eval()`",
+            },
+          },
+        },
+      ],
       "tailwindcss/classnames-order": "error",
       "tailwindcss/enforces-negative-arbitrary-values": "error",
       "tailwindcss/enforces-shorthand": "error",
@@ -169,21 +212,25 @@ export default [
     files: ["src/**/*.{ts,tsx}"],
     ignores: ["src/utils/react/createPluginRoot.tsx"],
     rules: {
-      "no-restricted-syntax": [
-        "error",
-        {
-          selector:
-            "ImportDeclaration[source.value=/^\\.\\.($|\\u002f)/], ImportExpression[source.value=/^\\.\\.($|\\u002f)/]",
-          message:
-            "Parent-relative imports (`../foo`) are banned. Use the `@/` path alias (e.g. `@/components/Foo`) instead.",
-        },
-        {
-          selector:
-            "ImportDeclaration[source.value='react-dom/client'] ImportSpecifier[imported.name='createRoot']",
-          message:
-            "Use createPluginRoot from '@/utils/react/createPluginRoot' instead. It wraps the root in <AppContext.Provider> so descendants can rely on useApp() unconditionally (see PR #2466).",
-        },
-      ],
+      "no-restricted-syntax": ["error", ...restrictedSourceImports, ...restrictedConsoleCalls],
+    },
+  },
+
+  // createPluginRoot owns the otherwise-restricted React root import, but it
+  // still belongs to the production logging boundary.
+  {
+    files: ["src/utils/react/createPluginRoot.tsx"],
+    rules: {
+      "no-restricted-syntax": ["error", ...restrictedConsoleCalls],
+    },
+  },
+
+  // Test output is intentionally written to the console. Keep the production
+  // import restrictions without applying the logging boundary to test files.
+  {
+    files: ["src/**/*.test.{js,jsx,ts,tsx}", "src/integration_tests/**"],
+    rules: {
+      "no-restricted-syntax": ["error", ...restrictedSourceImports],
     },
   },
 
@@ -588,15 +635,6 @@ export default [
           presets: ["native", "microutilities", "preferred"],
         },
       ],
-    },
-  },
-
-  // logger.ts is the central logging utility and must call console.* directly.
-  // scripts/** are CLI tools that print to stdout.
-  {
-    files: ["src/logger.ts", "scripts/**"],
-    rules: {
-      "obsidianmd/rule-custom-message": "off",
     },
   },
 

--- a/src/LLMProviders/chainManager.ts
+++ b/src/LLMProviders/chainManager.ts
@@ -156,9 +156,7 @@ export default class ChainManager {
           await this.refreshVaultIndex();
         }
       } else {
-        console.error(
-          "createChainWithNewModel: skipping chain-type housekeeping — no chat model set."
-        );
+        logError("createChainWithNewModel: skipping chain-type housekeeping — no chat model set.");
       }
       logInfo(`Setting chat model to configuredModelId=${selectedModelId}`);
     } catch (error) {

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -7,7 +7,7 @@ import {
   ModelCapability,
   ProviderInfo,
 } from "@/constants";
-import { logError, logInfo } from "@/logger";
+import { logError, logInfo, logWarn } from "@/logger";
 import { isPaidEnabled } from "@/plusUtils";
 import {
   CopilotSettings,
@@ -737,7 +737,7 @@ export default class ChatModelManager {
     allModels.forEach((model) => {
       if (model.enabled) {
         if (!Object.values(ChatModelProviders).includes(model.provider as ChatModelProviders)) {
-          console.warn(`Unknown provider: ${model.provider} for model: ${model.name}`);
+          logWarn(`Unknown provider: ${model.provider} for model: ${model.name}`);
           return;
         }
 
@@ -783,7 +783,7 @@ export default class ChatModelManager {
       model.provider as ChatModelProviders
     ] as unknown as ChatConstructorType;
     if (!constructor) {
-      console.warn(`Unknown provider: ${model.provider} for model: ${model.name}`);
+      logWarn(`Unknown provider: ${model.provider} for model: ${model.name}`);
       throw new Error(`Unknown provider: ${model.provider} for model: ${model.name}`);
     }
     return constructor;

--- a/src/LLMProviders/embeddingManager.ts
+++ b/src/LLMProviders/embeddingManager.ts
@@ -1,7 +1,7 @@
 import { CustomModel } from "@/aiParams";
 import { BREVILABS_MODELS_BASE_URL, EmbeddingModelProviders, ProviderInfo } from "@/constants";
 import { CustomError } from "@/error";
-import { logInfo } from "@/logger";
+import { logInfo, logWarn } from "@/logger";
 import { getModelKeyFromModel, getSettings, subscribeToSettingsChange } from "@/settings/model";
 import { err2String, safeFetch } from "@/utils";
 import { Embeddings } from "@langchain/core/embeddings";
@@ -79,7 +79,7 @@ export default class EmbeddingManager {
   getProviderConstructor(model: CustomModel): EmbeddingConstructorType {
     const constructor = EMBEDDING_PROVIDER_CONSTRUCTORS[model.provider as EmbeddingModelProviders];
     if (!constructor) {
-      console.warn(`Unknown provider: ${model.provider} for model: ${model.name}`);
+      logWarn(`Unknown provider: ${model.provider} for model: ${model.name}`);
       throw new Error(`Unknown provider: ${model.provider} for model: ${model.name}`);
     }
     return constructor;
@@ -97,7 +97,7 @@ export default class EmbeddingManager {
             model.provider as EmbeddingModelProviders
           )
         ) {
-          console.warn(`Unknown provider: ${model.provider} for embedding model: ${model.name}`);
+          logWarn(`Unknown provider: ${model.provider} for embedding model: ${model.name}`);
           return;
         }
         const constructor = this.getProviderConstructor(model);

--- a/src/components/chat-components/utils/notePreviewUtils.ts
+++ b/src/components/chat-components/utils/notePreviewUtils.ts
@@ -1,4 +1,5 @@
 import { TFile, App } from "obsidian";
+import { logWarn } from "@/logger";
 
 /**
  * Loads and processes note content for preview display.
@@ -33,7 +34,7 @@ async function loadNoteContentForPreview(
 
     return truncatedContent;
   } catch (error) {
-    console.warn("Failed to read note content:", error);
+    logWarn("Failed to read note content:", error);
     return "Failed to load content";
   }
 }

--- a/src/imageProcessing/imageProcessor.ts
+++ b/src/imageProcessing/imageProcessor.ts
@@ -1,4 +1,4 @@
-import { logError } from "@/logger";
+import { logError, logWarn } from "@/logger";
 import { safeFetch } from "@/utils";
 import { arrayBufferToBase64 } from "@/utils/base64";
 import { Notice, TFile, Vault } from "obsidian";
@@ -82,7 +82,7 @@ export class ImageProcessor {
           } else {
             // HEAD succeeded, but Content-Type is not image/*
             // Trust the explicit Content-Type over heuristics
-            console.warn(
+            logWarn(
               `HEAD request succeeded for ${url} but Content-Type (${contentType}) is not image/*.`
             );
             return false; // Return false immediately
@@ -91,10 +91,7 @@ export class ImageProcessor {
         } catch (headError) {
           // HEAD request might fail (e.g., CORS, network issue, server doesn't support HEAD, 404)
           // Log as warning, as this is handled by falling back to heuristics.
-          console.warn(
-            `HEAD request failed for URL: ${url}. Proceeding to heuristic check.`,
-            headError
-          );
+          logWarn(`HEAD request failed for URL: ${url}. Proceeding to heuristic check.`, headError);
           // Proceed to heuristic check ONLY if HEAD failed
           const searchParams = urlObj.searchParams;
           const imageIndicators = [
@@ -293,7 +290,7 @@ export class ImageProcessor {
       if (file instanceof TFile) {
         return await this.handleVaultImage(file, vault);
       } else {
-        console.warn(`Could not find attachment file in vault: ${filePath}`);
+        logWarn(`Could not find attachment file in vault: ${filePath}`);
         return null;
       }
     }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,6 +3,7 @@ import { logFileManager } from "@/logFileManager";
 
 export function logInfo(...args: unknown[]) {
   if (getSettings().debug) {
+    // eslint-disable-next-line no-restricted-syntax -- logInfo is the approved console.log boundary.
     console.log(...args);
   }
   // Always append to rolling file log
@@ -12,6 +13,7 @@ export function logInfo(...args: unknown[]) {
 export function logError(...args: unknown[]) {
   // Always include stack traces by default; console logs still respect debug
   if (getSettings().debug) {
+    // eslint-disable-next-line no-restricted-syntax -- logError is the approved console.error boundary.
     console.error(...args);
   }
   void logFileManager.append("ERROR", ...args);
@@ -19,6 +21,7 @@ export function logError(...args: unknown[]) {
 
 export function logWarn(...args: unknown[]) {
   if (getSettings().debug) {
+    // eslint-disable-next-line no-restricted-syntax -- logWarn is the approved console.warn boundary.
     console.warn(...args);
   }
   void logFileManager.append("WARN", ...args);

--- a/src/search/chunkedStorage.ts
+++ b/src/search/chunkedStorage.ts
@@ -1,6 +1,6 @@
 // DEPRECATED: Legacy partitioned Orama store. v3 uses JSONL snapshots + MemoryIndexManager.
 import { CustomError } from "@/error";
-import { logInfo } from "@/logger";
+import { logError, logInfo, logWarn } from "@/logger";
 import type { CopilotOrama, CopilotOramaSchema } from "@/search/dbOperations";
 import { getSettings } from "@/settings/model";
 import { create, load, RawData, save } from "@orama/orama";
@@ -90,7 +90,7 @@ export class ChunkedStorage {
     if (getSettings().debug) {
       logInfo(`Total documents distributed: ${totalDistributed}`);
       if (totalDistributed !== documents.length) {
-        console.error(
+        logError(
           `Document count mismatch! Original: ${documents.length}, Distributed: ${totalDistributed}`
         );
       }
@@ -238,7 +238,7 @@ export class ChunkedStorage {
         logInfo("Saved all partitions");
       }
     } catch (error) {
-      console.error(`Error saving database:`, error);
+      logError(`Error saving database:`, error);
       throw new CustomError(`Failed to save database: ${(error as Error).message}`);
     }
   }
@@ -321,7 +321,7 @@ export class ChunkedStorage {
           orderedDocs[nextDocId.toString()] = doc;
           nextDocId++;
         } else if (getSettings().debug) {
-          console.warn(`Document ${internalId} not found in any chunk`);
+          logWarn(`Document ${internalId} not found in any chunk`);
         }
       }
 
@@ -347,7 +347,7 @@ export class ChunkedStorage {
       load(newDb, mergedData as RawData);
       return newDb;
     } catch (error) {
-      console.error(`Error loading database:`, error);
+      logError(`Error loading database:`, error);
       throw new CustomError(`Failed to load database: ${(error as Error).message}`);
     }
   }
@@ -370,7 +370,7 @@ export class ChunkedStorage {
         }
       }
     } catch (error) {
-      console.error(`Error clearing storage:`, error);
+      logError(`Error clearing storage:`, error);
       throw new CustomError(`Failed to clear storage: ${(error as Error).message}`);
     }
   }

--- a/src/search/dbOperations.ts
+++ b/src/search/dbOperations.ts
@@ -2,7 +2,7 @@
 // backward compatibility where needed; new features should not depend on this module.
 import EmbeddingsManager from "@/LLMProviders/embeddingManager";
 import { CustomError } from "@/error";
-import { logError, logInfo } from "@/logger";
+import { logError, logInfo, logWarn } from "@/logger";
 import { getSettings, subscribeToSettingsChange } from "@/settings/model";
 import { areEmbeddingModelsSame } from "@/utils";
 import { Embeddings } from "@langchain/core/embeddings";
@@ -230,7 +230,7 @@ export class DBOperations {
 
   public getDb(): CopilotOrama | undefined {
     if (!this.oramaDb) {
-      console.warn("Database not initialized. Some features may be limited.");
+      logWarn("Database not initialized. Some features may be limited.");
     }
     return this.oramaDb;
   }

--- a/src/search/hybridRetriever.ts
+++ b/src/search/hybridRetriever.ts
@@ -1,7 +1,7 @@
 // DEPRECATED: Legacy hybrid retriever backed by Orama. Replaced by v3 TieredLexicalRetriever + MemoryIndexManager.
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import EmbeddingManager from "@/LLMProviders/embeddingManager";
-import { logInfo } from "@/logger";
+import { logError, logInfo, logWarn } from "@/logger";
 import VectorStoreManager from "@/search/vectorStoreManager";
 import { getSettings } from "@/settings/model";
 import { extractNoteFiles, withSuppressedTokenWarnings } from "@/utils";
@@ -152,7 +152,7 @@ export class HybridRetriever extends BaseRetriever {
     try {
       queryVector = await this.convertQueryToVector(query);
     } catch (error) {
-      console.error(
+      logError(
         "Error in convertQueryToVector, please ensure your embedding model is working and has an adequate context length:",
         error,
         "\nQuery:",
@@ -281,7 +281,7 @@ export class HybridRetriever extends BaseRetriever {
 
     // Add null check and validation for search results
     if (!searchResults || !searchResults.hits) {
-      console.warn("Search results or hits are undefined");
+      logWarn("Search results or hits are undefined");
       return [];
     }
 
@@ -289,12 +289,12 @@ export class HybridRetriever extends BaseRetriever {
     return searchResults.hits
       .map((hit) => {
         if (!hit || !hit.document) {
-          console.warn("Invalid hit or document in search results");
+          logWarn("Invalid hit or document in search results");
           return null;
         }
 
         if (typeof hit.score !== "number" || isNaN(hit.score)) {
-          console.warn("NaN/invalid score detected:", {
+          logWarn("NaN/invalid score detected:", {
             score: hit.score,
             path: hit.document.path,
             title: hit.document.title,

--- a/src/search/indexOperations.ts
+++ b/src/search/indexOperations.ts
@@ -523,7 +523,7 @@ export class IndexOperations {
     if (filePath) {
       if (context.batch) {
         // Detailed batch processing error logging
-        console.error("Batch processing error:", {
+        logError("Batch processing error:", {
           error,
           batchSize: context.batch.length || 0,
           firstChunk: context.batch[0]
@@ -537,11 +537,11 @@ export class IndexOperations {
           errorMessage: error instanceof Error ? error.message : String(error),
         });
       } else {
-        console.error(`Error indexing file ${filePath}:`, error);
+        logError(`Error indexing file ${filePath}:`, error);
       }
       context.errors?.push(filePath);
     } else {
-      console.error("Fatal error during indexing:", error);
+      logError("Fatal error during indexing:", error);
     }
 
     // Handle json stringify string length error consistently

--- a/src/search/vectorStoreManager.ts
+++ b/src/search/vectorStoreManager.ts
@@ -2,7 +2,7 @@
 // for legacy Orama-based flows and should not be referenced by new code.
 import { updateIndexingProgressState } from "@/aiParams";
 import { CustomError } from "@/error";
-import { logInfo, logWarn } from "@/logger";
+import { logError, logInfo, logWarn } from "@/logger";
 import EmbeddingsManager from "@/LLMProviders/embeddingManager";
 import { getSearchBackend } from "@/miyo/miyoUtils";
 import { CopilotSettings, getSettings, subscribeToSettingsChange } from "@/settings/model";
@@ -118,12 +118,12 @@ export default class VectorStoreManager {
             "Failed to initialize vector store. Please make sure you have a valid API key " +
               "for your embedding model and restart the plugin."
           );
-          console.error("Failed to initialize vector store:", error);
+          logError("Failed to initialize vector store:", error);
           break;
         }
       }
     } catch (error) {
-      console.error("Failed to initialize vector store:", error);
+      logError("Failed to initialize vector store:", error);
     }
   }
 

--- a/src/services/keychainService.test.ts
+++ b/src/services/keychainService.test.ts
@@ -35,6 +35,12 @@ jest.mock("@/settings/model", () => {
   };
 });
 
+jest.mock("@/logger", () => ({
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+  logError: jest.fn(),
+}));
+
 jest.mock("@/services/settingsSecretTransforms", () => ({
   MODEL_SECRET_FIELDS: ["apiKey"] as const,
   isSensitiveKey: jest.fn((key: string) => {

--- a/src/services/keychainService.ts
+++ b/src/services/keychainService.ts
@@ -10,10 +10,10 @@ import {
 } from "@/services/settingsSecretTransforms";
 import { Notice } from "obsidian";
 import { md5 } from "@/utils/hash";
+// The logger is safe even though this module runs during settings loading
+// (before setSettings): getSettings() falls back to DEFAULT_SETTINGS, and log
+// entries buffer in memory until the app is attached to the log file manager.
 import { logError, logWarn } from "@/logger";
-// Reason: do NOT import logInfo/logWarn/logError here. The logger depends on
-// getSettings(), but this module runs during settings loading (before setSettings).
-// Use console.* directly for all logging in this file.
 
 /**
  * Fields that are sensitive but don't match the `isSensitiveKey()` heuristic.

--- a/src/services/keychainService.ts
+++ b/src/services/keychainService.ts
@@ -10,6 +10,7 @@ import {
 } from "@/services/settingsSecretTransforms";
 import { Notice } from "obsidian";
 import { md5 } from "@/utils/hash";
+import { logError, logWarn } from "@/logger";
 // Reason: do NOT import logInfo/logWarn/logError here. The logger depends on
 // getSettings(), but this module runs during settings loading (before setSettings).
 // Use console.* directly for all logging in this file.
@@ -387,7 +388,7 @@ export class KeychainService {
       try {
         keychainValue = this.getSecret(key);
       } catch (e) {
-        console.warn(`Keychain read failed for "${key}".`, e);
+        logWarn(`Keychain read failed for "${key}".`, e);
         hadFailures = true;
         continue;
       }
@@ -414,7 +415,7 @@ export class KeychainService {
     hadFailures = hadFailures || embeddingResult.hadFailures;
 
     if (hadFailures) {
-      console.warn("Keychain hydrate: some keychain reads failed — values left as-is.");
+      logWarn("Keychain hydrate: some keychain reads failed — values left as-is.");
     }
 
     return { settings: hydrated, hadFailures };
@@ -575,7 +576,7 @@ export class KeychainService {
     try {
       await saveData(toSave);
     } catch (error) {
-      console.error("forgetAllSecrets: saveData failed — aborting keychain clear", error);
+      logError("forgetAllSecrets: saveData failed — aborting keychain clear", error);
       new Notice(
         "Failed to remove API keys from data.json. Obsidian Keychain was NOT cleared. Please try again."
       );
@@ -636,7 +637,7 @@ export class KeychainService {
         try {
           keychainValue = this.getModelSecret(scope, identity, field);
         } catch (e) {
-          console.warn(`Keychain read failed for model "${identity}" field "${field}".`, e);
+          logWarn(`Keychain read failed for model "${identity}" field "${field}".`, e);
           hadFailures = true;
           continue;
         }

--- a/src/tools/SearchTools.ts
+++ b/src/tools/SearchTools.ts
@@ -2,7 +2,7 @@ import { getStandaloneQuestion } from "@/chainUtils";
 import { TEXT_WEIGHT } from "@/constants";
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
 import { hasSelfHostSearchKey, selfHostWebSearch } from "@/LLMProviders/selfHostServices";
-import { logInfo } from "@/logger";
+import { logError, logInfo } from "@/logger";
 import { getSearchBackend } from "@/miyo/miyoUtils";
 import { isSelfHostModeValid } from "@/plusUtils";
 import { RetrieverFactory } from "@/search/RetrieverFactory";
@@ -607,7 +607,7 @@ const webSearchTool = createLangChainTool({
 
       return formattedResults;
     } catch (error) {
-      console.error(`Error processing web search query ${query}:`, error);
+      logError(`Error processing web search query ${query}:`, error);
       return { error: `Web search failed: ${error}` };
     }
   },

--- a/src/tools/TimeTools.test.ts
+++ b/src/tools/TimeTools.test.ts
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon";
+import * as logger from "@/logger";
 import { getTimeRangeMsTool } from "./TimeTools";
 
 type InvokableTool = { invoke: (args: Record<string, unknown>) => Promise<string> };
@@ -363,16 +364,16 @@ describe("Time Expression Tests", () => {
   });
 
   describe("Invalid Expressions", () => {
-    let consoleWarnSpy: jest.SpyInstance;
+    let logWarnSpy: jest.SpyInstance;
 
     beforeEach(() => {
-      // Mock console.warn to suppress expected warnings
-      consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+      // Mock logWarn to suppress expected warnings
+      logWarnSpy = jest.spyOn(logger, "logWarn").mockImplementation(() => {});
     });
 
     afterEach(() => {
-      // Restore console.warn after each test
-      consoleWarnSpy.mockRestore();
+      // Restore logWarn after each test
+      logWarnSpy.mockRestore();
     });
 
     test.each(["invalid time", "", "random text", "week of invalid"])(
@@ -380,10 +381,8 @@ describe("Time Expression Tests", () => {
       async (expression) => {
         const result = await getTimeRangeMs(expression);
         expect(result).toBeUndefined();
-        // Verify that console.warn was called with the expected message
-        expect(consoleWarnSpy).toHaveBeenCalledWith(
-          `Unable to parse time expression: ${expression}`
-        );
+        // Verify that logWarn was called with the expected message
+        expect(logWarnSpy).toHaveBeenCalledWith(`Unable to parse time expression: ${expression}`);
       }
     );
   });

--- a/src/tools/TimeTools.ts
+++ b/src/tools/TimeTools.ts
@@ -2,6 +2,7 @@ import * as chrono from "chrono-node";
 import { DateTime } from "luxon";
 import { z } from "zod";
 import { createLangChainTool } from "./createLangChainTool";
+import { logWarn } from "@/logger";
 
 export interface TimeInfo {
   epoch: number;
@@ -451,7 +452,7 @@ function getTimeRangeMs(timeExpression: string) {
     };
   }
 
-  console.warn(`Unable to parse time expression: ${timeExpression}`);
+  logWarn(`Unable to parse time expression: ${timeExpression}`);
   return undefined;
 }
 

--- a/src/tools/YoutubeTools.ts
+++ b/src/tools/YoutubeTools.ts
@@ -5,6 +5,7 @@ import { getSettings } from "@/settings/model";
 import { extractAllYoutubeUrls } from "@/utils";
 import { z } from "zod";
 import { createLangChainTool } from "./createLangChainTool";
+import { logError } from "@/logger";
 
 // Maximum input length to prevent potential DoS attacks
 const MAX_USER_MESSAGE_LENGTH = 50000; // Maximum number of characters
@@ -78,7 +79,7 @@ const youtubeTranscriptionTool = createLangChainTool({
             elapsed_time_ms: response.elapsed_time_ms,
           };
         } catch (error) {
-          console.error(`Error transcribing YouTube video ${url}:`, error);
+          logError(`Error transcribing YouTube video ${url}:`, error);
           return {
             url,
             success: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -521,7 +521,7 @@ function resolveNoteFilesFromTitles(noteTitles: string[], vault: Vault): TFile[]
         } else {
           // Multiple files with same title - this shouldn't happen
           // as we should be using full paths for duplicate titles
-          console.warn(
+          logWarn(
             `Found multiple files with title "${noteTitle}". Expected a full path for duplicate titles.`
           );
         }


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#305

## Why

The Obsidian community scorecard ([community.obsidian.md/plugins/copilot](https://community.obsidian.md/plugins/copilot)) flags the warning family "Avoid unnecessary logging to console" in the latest release bundle. Production code still calls `console.log/warn/error` directly in 30 places across 15 files — a user with devtools open sees stray Copilot warnings like `Unknown provider: … for model: …` or `Keychain read failed for "…"` even with the plugin's debug setting off, and those messages never reach the rolling Copilot log file that support asks users for.

## What

Every remaining direct console call in production `src/` now goes through the project logger, keeping its level (`warn` → `logWarn`, `error` → `logError`) and its exact message and arguments. `src/logger.ts` is now the only production module that touches the console.

> **Before:** with debug off, a failed keychain read prints `Keychain read failed for "openAIApiKey".` straight to the developer console and is absent from the Copilot log file.
>
> **After:** the same event is recorded with its WARN level in the rolling Copilot log file, and prints to the console only when the debug setting is on.

## Non goal

- Other scorecard warning families — tracked separately (logancyang/obsidian-copilot-preview#293, #294, #295, #302, #304).
- Console use in test files, `__mocks__`, and integration tests — never shipped in the bundle.
- The `console.warn` suppression wrapper in `src/utils.ts`, which reassigns `console.warn` to silence a noisy third-party library and does not log.
- Any change to logger semantics: debug gating, file-log format, or log retention.

## Screenshot

Not applicable — this PR only changes where diagnostic messages are routed; no rendered surface changes.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ❌ | Console visibility of 30 diagnostics becomes debug-gated; only the TimeTools invalid-expression and keychain read-failure branches have deterministic `logWarn` assertions in this diff |
| A defect would fail CI or be obvious on first use | ✅ | A wrong import or symbol fails the TypeScript check in CI; a mis-leveled entry shows its level prefix in the log file the next time it fires |
| A revert fully restores prior state, including persisted data | ✅ | No data migration; the rolling log file is an export artifact rebuilt from an in-memory buffer |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Keychain read/write logic is untouched; the changed keychain lines are diagnostics whose arguments are unchanged and contain key names, never secret values |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Logging destination only; no exported signature changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Call sites are synchronous one-line swaps; the logger's fire-and-forget file append is pre-existing |
| No hot-path behavior lacks deterministic coverage | ✅ | Changed lines are error and warning branches, not hot paths |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A missed or mis-leveled message is confined to diagnostics and shows the next time that branch fires |

Review: check the level mapping hunk by hunk (`console.warn` → `logWarn`, `console.error` → `logError`, messages unchanged), then inspect `src/services/keychainService.ts` — the module header comment plus `hydrateFromKeychain()` and `forgetAllSecrets()` — against the Note below, and run Verification steps 2–4.

## Verification

1. Build this branch and load it in a test vault (`npm run build`, copy `main.js`/`manifest.json`/`styles.css` into the vault's plugin folder, reload Obsidian).
2. With the Copilot debug setting off (Settings → Copilot → Advanced), open the developer console and use the plugin (send a chat message, run a vault search): no Copilot `console.log/warn` output appears.
3. Turn the debug setting on and repeat: diagnostics appear in the console.
4. Open the Copilot log file from Advanced settings and confirm entries carry `WARN`/`ERROR` level prefixes for warning and error events.

## Note

`src/services/keychainService.ts` previously carried a comment forbidding logger imports because the module runs during settings loading, before `setSettings`. That hazard no longer exists: `getSettings()` falls back to `DEFAULT_SETTINGS` (`settingsAtom` in `src/settings/model.ts`), and `logFileManager.append` only buffers in memory until the app is attached (`flush` guards on `app?.vault?.adapter`). The comment now states the current invariant.
