### PR TITLE
Remove every !important from the plugin stylesheet

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -15,11 +15,6 @@ If your plugin does not need CSS, delete this file.
 
 */
 
-/* Popover needs to render on top of the workspace-leaf-resize-handle */
-[data-radix-popper-content-wrapper] {
-  z-index: 9999 !important;
-}
-
 .copilot-symposium-modal {
   width: min(32rem, calc(100vw - 2rem));
   min-width: 0;
@@ -406,7 +401,7 @@ If your plugin does not need CSS, delete this file.
   background-color: transparent;
   padding: 0;
   color: var(--code-normal);
-  line-height: 1.5 !important;
+  line-height: 1.5;
   display: block;
   white-space: pre-wrap;
   word-wrap: break-word;
@@ -1084,21 +1079,27 @@ If your plugin does not need CSS, delete this file.
   position: relative;
 }
 
-/* Override Obsidian's default contenteditable border */
-.copilot-quick-ask-overlay [contenteditable] {
-  border: none !important;
-  box-shadow: none !important;
-  outline: none !important;
+/* Override Obsidian's default contenteditable border. The extra ancestor and
+   explicit focus states outrank app/theme [contenteditable] and focus rules
+   (themes load after plugin CSS) without !important. */
+.copilot-quick-ask-overlay-root .copilot-quick-ask-overlay [contenteditable],
+.copilot-quick-ask-overlay-root .copilot-quick-ask-overlay [contenteditable]:focus,
+.copilot-quick-ask-overlay-root .copilot-quick-ask-overlay [contenteditable]:focus-visible {
+  border: none;
+  box-shadow: none;
+  outline: none;
 }
 
-/* Reason: The overlay is mounted inside CM6 editor DOM, which has its own
-   selection handling that prevents normal text selection in child elements.
-   Only target message text containers (marked with data-quick-ask-selectable)
-   to avoid overriding user-select on buttons and other interactive controls. */
+/* Obsidian sets `user-select: none` on `body`, so every element in the overlay
+   inherits it and message text cannot be selected. Naming the text containers
+   directly restores selection: a rule that matches the element always beats an
+   inherited value, so no !important is needed. Only the message containers
+   (marked with data-quick-ask-selectable) are targeted, to leave buttons and
+   other interactive controls unselectable. */
 .copilot-quick-ask-overlay [data-quick-ask-selectable],
 .copilot-quick-ask-overlay [data-quick-ask-selectable] * {
-  user-select: text !important;
-  -webkit-user-select: text !important;
+  user-select: text;
+  -webkit-user-select: text;
 }
 
 .copilot-quick-ask-overlay-root {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -139,7 +139,7 @@ If your plugin does not need CSS, delete this file.
 .note-badge {
   font-size: 10px;
   padding: 0 4px;
-  background: rgba(0, 0, 0, 0.2);
+  background: rgb(0 0 0 / 20%);
   border-radius: 3px;
 }
 
@@ -633,7 +633,7 @@ If your plugin does not need CSS, delete this file.
 
 .edit-textarea:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+  box-shadow: 0 0 0 2px rgb(0 123 255 / 25%);
 }
 
 .copilot-notice-container {
@@ -729,7 +729,7 @@ If your plugin does not need CSS, delete this file.
     background: var(--background-primary-alt);
     border-radius: 8px;
     padding: 0 16px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
   }
 
   .model-card-header {
@@ -791,7 +791,7 @@ If your plugin does not need CSS, delete this file.
   .model-select-content,
   .chain-select-content {
     background: var(--background-primary);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
   }
 
   .model-select-content [role="menuitem"],
@@ -817,7 +817,7 @@ If your plugin does not need CSS, delete this file.
   background: var(--background-primary-alt);
   border-radius: 8px;
   padding: 0 16px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
   transition: all 0.3s ease;
   position: relative;
   border-left: 4px solid transparent;


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#294

## Why

The Obsidian community scorecard (https://community.obsidian.md/plugins/copilot) flags "Avoid `!important`". Each one also removes a community theme's ability to override that declaration normally — a theme that restyles chat code blocks or the Quick Ask input silently loses to the plugin, with no escape hatch short of another `!important`.

`src/styles/tailwind.css` carries seven `!important` declarations on master. This PR removes all seven. None survives.

## What

Rather than reason about which ones were still needed, each was traced to the PR that introduced it, then removed and tested in a live vault against that original use case. Two turned out to be doing nothing, one was defending against something that had never been the real adversary, and one was load-bearing in a way that did not require `!important` at all.

| Declaration | Introduced by | Original stated reason | Verdict |
| --- | --- | --- | --- |
| `[data-radix-popper-content-wrapper] { z-index: 9999 }` | #981 | "Popover needs to render on top of the workspace-leaf-resize-handle" | **Rule deleted** — see below |
| Quick Ask `user-select` ×2 | #2276 | "Fix text selection in Quick Ask overlay (user-select on CM6 DOM)" | **`!important` removed**, rule kept |
| Quick Ask `border` / `box-shadow` / `outline` | #2139 | "Override Obsidian's default contenteditable border" | **`!important` removed**, selector raised |
| Chat code block `line-height` | #888 | none stated (bundled into the Tailwind/shadcn migration) | **`!important` removed** |

### The Radix `z-index` rule is deleted outright

Reading `@radix-ui/react-popper@1.2.8`: on mount it copies the *content* element's computed `z-index` onto the wrapper as an inline style.

```js
useLayoutEffect(() => { if (content) setContentZIndex(window.getComputedStyle(content).zIndex) }, [content]);
// ...
style: { ...floatingStyles, minWidth: "max-content", zIndex: contentZIndex, ... }
```

Every popper-based content component in this codebase sets an explicit token — `popover.tsx` `tw-z-popover` (30), `select.tsx` `tw-z-modal` (50), `tooltip.tsx` and `dropdown-menu.tsx` `tw-z-[50]`. So the wrapper always receives an inline numeric `z-index`, and an inline style beats a normal-weight rule. **Without `!important` the declaration can never apply** — keeping it unprefixed would leave dead code that looks load-bearing. The honest options were "keep `!important`" or "delete", and the measurement below settles it: the lowest token, 30, already outranks the resize handle's 15, which is the only thing the rule was written to defeat.

Deleting also stops Copilot popovers from covering Obsidian's own notices (60), menus (65), and tooltips (70), which `z-index: 9999` did.

The modal case does not depend on this either: popovers hosted in a modal are portaled into the modal's `contentEl` (`PopoverContent`'s `container` prop, documented at `AddUrlPopover.tsx:15`), so they stack inside it rather than against it.

### Also included: five legacy `rgba()` values

Separate second commit, pre-existing on master and unrelated to the `!important` work. Each of five `rgba(r, g, b, 0.x)` declarations tripped three stylelint rules simultaneously — `alpha-value-notation`, `color-function-alias-notation`, and `color-function-notation`. Rewriting them as `rgb(r g b / x%)` satisfies all three, taking the source stylesheet from 61 review warnings to 46. Chromium parses both spellings to the identical computed value (`rgba(0, 0, 0, 0.2)`), confirmed in a live vault, so nothing renders differently.

### The Quick Ask `user-select` comment was wrong about the cause

The rule is genuinely load-bearing — remove it and selection breaks. But the adversary is not CM6. Enumerating every loaded rule that sets `user-select` and matches the message text returns exactly two: Obsidian's `body { user-select: none }` and our own. The `body` declaration reaches the message text by **inheritance**, and a rule that matches the element directly always beats an inherited value regardless of specificity. `!important` was never what made this work. The comment now describes the real mechanism.

## Non goal

- No component-level restacking of Radix content; each component keeps its existing layer token.
- No redesign of the Quick Ask overlay.
- No direct edits to the generated `styles.css` (gitignored, rebuilt at build time) and no changes to the community-review gate itself.
- The Tailwind `!`-prefixed utilities in TSX (`!tw-leading-[1.6]`, `!tw-border-none`, ~20 others) are a separate and larger `!important` surface in the built stylesheet. Not touched here.
- The issue's suggested follow-up (teaching `npm run review:obsidian` to track the `!important` count) is not included.

## Screenshot

Screenshots are weak evidence for this change — two images that look alike do not tell you whether a declaration won the cascade or was simply uncontested. Testing was done by measuring the cascade and hit-testing paint order in a live vault (`copilot-test-vault`, Obsidian 1.12.x), driving the app with trusted CDP input events. Visual captures corroborate each result.

**Radix z-index, tested against #981's exact scenario.** The right sidebar was narrowed to 230px so a popover was forced to overflow across the resize handle, then `document.elementFromPoint` was sampled inside the overlap. Tested with `AddContextButton`, which uses the *lowest* token in the codebase (`tw-z-popover` = 30):

| Config | wrapper inline z | computed z | handle z | element on top at overlap |
| --- | --- | --- | --- | --- |
| master (`!important`) | 50 | 9999 | 15 | inside popover |
| `!important` stripped | 30 | 30 | 15 | inside popover |
| **rule deleted (this PR)** | 30 | 30 | 15 | **inside popover** |

Also confirmed a Radix tooltip opened inside the settings modal: it portals to `body`, ties at z-50 with `.modal-container`, and wins on DOM order — hit-test lands inside the tooltip.

**Quick Ask `user-select`,** tested by dispatching a real trusted mouse drag across an assistant response and reading `window.getSelection()`:

| Config | computed `user-select` | drag selection result |
| --- | --- | --- |
| master (`!important`) | `text` | `"lpha bravo charlie delta echo foxtrot golf hot"` |
| **`!important` removed (this PR)** | `text` | `"lpha bravo charlie delta echo foxtrot golf hot"` |
| rule removed entirely | `none` | `""` (selection fails) |

The third row is the control proving the rule still earns its place. Scoping is preserved: buttons in the overlay compute `user-select: none`, message text computes `text`.

**Quick Ask `[contenteditable]` reset,** measured on the focused input: `border-width: 0px`, `outline-style: none`, `box-shadow: none`.

All measurements above were re-run against a real `npm run test:vault` build with the source edits applied, not just live CSSOM edits. `dev:errors` reported no uncaught plugin errors.

One caveat found while testing, unrelated to this change: the component gallery deploys as a **separate** plugin (`copilot-component-gallery`) carrying its own `styles.css` built from this same source, and `npm run test:vault` does not refresh it. Both inject global CSS into one document, so a stale gallery copy competes in the cascade — it initially masked this PR's changes entirely. Verify CSS with `npm run test:vault && npm run gallery:vault`, or with the gallery disabled. Filed separately.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ❌ | Cascade and paint-order outcomes depend on rendered state in Obsidian and cannot be covered by an automated test. Measured directly in a live vault instead — evidence, not coverage |
| A defect would fail CI or be obvious on first use | ✅ | A lost override shows immediately as a popover behind a pane edge, unselectable response text, a stray input outline, or wrong code line spacing |
| A revert fully restores prior state, including persisted data | ✅ | CSS-only; no data written |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Stylesheet only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `styles.css` is regenerated from this source at build time; no schema or API touched |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No TypeScript changed |
| No hot-path behavior lacks deterministic coverage | ✅ | No logic path changed; the review gate deterministically reports the remaining `!important` count in the source stylesheet (7 → 0) |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Each affected surface regresses visibly on first render |

Review: the load-bearing judgment is the Radix deletion. It rests on every popper content component declaring a z-index token — if a future Radix component is added without one, its wrapper inherits `z-index: auto` and could fall behind a pane edge; the fix then belongs on that component, not back here. Worth a second opinion on whether dropping Copilot popovers from 9999 to 30/50 is desirable: it means another plugin's high-z overlay can now paint over them (this test vault has a third-party plugin using z-index 100 and 1000), traded against no longer covering Obsidian's own notices and menus.

## Verification

Run against a build of this branch, with the component gallery plugin disabled or redeployed.

1. `npm run test:vault && npm run gallery:vault`.
2. Narrow the right sidebar so a chat popover must overflow past the pane edge, then open "Add context". Confirm it renders above the resize handle and is fully clickable across the boundary.
3. Open a Copilot popover inside the settings modal and inside a project context modal; confirm each renders above its host.
4. Open Quick Ask (`Cmd+K` in Live Preview), send a prompt, and drag-select the response with the mouse. Confirm text selects, and that dragging across a button does not select its label.
5. In chat, ask for a fenced code block; confirm code line spacing is unchanged, then repeat under a community theme.

Residual risk is themes and third-party plugins not exercised — a theme shipping a higher-specificity `pre code` line-height rule, or a plugin overlay with a z-index above 50, would now win where `!important` previously blocked it. That is the intended trade; it is the thing to watch for in bug reports.
