### PR TITLE
Route Jina embeddings through requestUrl and disclose streaming fetch sites

### DIFF
--- a/designdocs/OBSIDIAN_COMMUNITY_REVIEW.md
+++ b/designdocs/OBSIDIAN_COMMUNITY_REVIEW.md
@@ -53,6 +53,15 @@ npm audit --omit=dev --audit-level=critical
 
 Warnings remain for cases where automatic cleanup could change behavior or UI, including desktop Node imports, streaming `fetch`, async React callbacks, Obsidian DOM helpers, declarative settings search, `!important`, `:has()`, and manifest copy. Do not suppress them. Fix one warning family at a time with behavior-specific tests.
 
+### Permanent `fetch` disclosures
+
+`requestUrl` supports neither streaming responses nor AbortSignal, so the following call sites must keep `fetch` and carry a `// scorecard:` comment. Any remaining scorecard `fetch` warning must match this list:
+
+- `src/LLMProviders/BedrockChatModel.ts` — Bedrock SSE streaming.
+- `src/LLMProviders/ChatLMStudio.ts` — `window.fetch` fallback wrapped for LM Studio body sanitization in a streaming ChatOpenAI.
+
+Non-streaming JSON requests (for example the Jina and custom OpenAI embedding adapters) route through `safeFetchNoThrow`, which uses `requestUrl`.
+
 Provider smoke tests for Jina and Bedrock streaming/non-streaming are needed only when their adapters or network boundaries change.
 
 ## Maintenance checklist

--- a/src/LLMProviders/ChatLMStudio.ts
+++ b/src/LLMProviders/ChatLMStudio.ts
@@ -28,6 +28,7 @@ export interface ChatLMStudioInput {
  * tools are stripped regardless of which LangChain code path produced them.
  */
 function createLMStudioFetch(baseFetch?: typeof window.fetch): typeof window.fetch {
+  // scorecard: streaming requires fetch — cannot use requestUrl
   const underlyingFetch = baseFetch || window.fetch;
 
   return async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {

--- a/src/LLMProviders/CustomJinaEmbeddings.test.ts
+++ b/src/LLMProviders/CustomJinaEmbeddings.test.ts
@@ -1,38 +1,138 @@
-import { CustomJinaEmbeddings } from "./CustomJinaEmbeddings";
+import { CustomJinaEmbeddings } from "@/LLMProviders/CustomJinaEmbeddings";
+
+const mockFetch = jest.fn<Promise<unknown>, [string, RequestInit | undefined]>();
+
+jest.mock("@/utils", () => {
+  const actual = jest.requireActual<Record<string, unknown>>("@/utils");
+  return {
+    ...actual,
+    safeFetchNoThrow: (url: string, options?: RequestInit): unknown => mockFetch(url, options),
+  };
+});
+
+/**
+ * Builds a minimal safeFetchNoThrow-shaped response. safeFetchNoThrow never
+ * throws on HTTP error status, so error bodies arrive through json() exactly
+ * like success bodies.
+ */
+function jsonResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function makeEmbeddings(fields?: Partial<ConstructorParameters<typeof CustomJinaEmbeddings>[0]>) {
+  return new CustomJinaEmbeddings({
+    apiKey: "test-key",
+    model: "jina-clip-v2",
+    maxRetries: 0,
+    ...fields,
+  });
+}
 
 describe("CustomJinaEmbeddings", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
   describe("CustomJinaEmbeddings", () => {
     describe("embedQuery()", () => {
-      afterEach(() => {
-        delete (window as { fetch?: typeof fetch }).fetch;
+      it("sends a JSON POST through safeFetchNoThrow with auth header and retrieval.query task", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ data: [{ index: 0, embedding: [1, 2, 3] }] }));
+
+        await makeEmbeddings().embedQuery("hello\nworld");
+
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+        const [url, options] = mockFetch.mock.calls[0];
+        expect(url).toBe("https://api.jina.ai/v1/embeddings");
+        expect(options?.method).toBe("POST");
+        expect(options?.headers).toMatchObject({
+          "Content-Type": "application/json",
+          Authorization: "Bearer test-key",
+        });
+        expect(JSON.parse(options?.body as string)).toMatchObject({
+          model: "jina-clip-v2",
+          input: ["hello world"],
+          task: "retrieval.query",
+        });
       });
 
-      it("forwards configured headers with an embeddings request", async () => {
-        const fetchSpy = jest.fn().mockResolvedValue({
-          json: async () => ({
-            model: "jina-clip-v2",
-            object: "list",
-            usage: { total_tokens: 1, prompt_tokens: 1 },
-            data: [{ object: "embedding", index: 0, embedding: [0.25] }],
-          }),
+      it("forwards configured headers alongside the content-type and auth headers", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ data: [{ index: 0, embedding: [0.25] }] }));
+
+        await expect(
+          makeEmbeddings({
+            apiKey: "plus-token",
+            headers: { "X-Client-Version": "4.0.0-preview-260802" },
+          }).embedQuery("hello")
+        ).resolves.toEqual([0.25]);
+
+        const [, options] = mockFetch.mock.calls[0];
+        expect(options?.headers).toEqual({
+          "Content-Type": "application/json",
+          Authorization: "Bearer plus-token",
+          "X-Client-Version": "4.0.0-preview-260802",
         });
-        window.fetch = fetchSpy as typeof fetch;
-        const embeddings = new CustomJinaEmbeddings({
-          apiKey: "plus-token",
-          headers: { "X-Client-Version": "4.0.0-preview-260802" },
+      });
+
+      it("returns the first embedding vector from the response", async () => {
+        mockFetch.mockResolvedValue(
+          jsonResponse({ data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }] })
+        );
+
+        await expect(makeEmbeddings().embedQuery("hello")).resolves.toEqual([0.1, 0.2, 0.3]);
+      });
+
+      it("throws an error carrying the JSON `detail` message on a non-200 error body", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ detail: "Invalid API key" }, 401));
+
+        await expect(makeEmbeddings().embedQuery("hello")).rejects.toThrow("Invalid API key");
+      });
+
+      it("propagates the parse error when the response body is not JSON", async () => {
+        mockFetch.mockResolvedValue({
+          ok: false,
+          status: 502,
+          json: () => Promise.reject(new SyntaxError("Unexpected token < in JSON")),
         });
 
-        await expect(embeddings.embedQuery("hello")).resolves.toEqual([0.25]);
-        expect(fetchSpy).toHaveBeenCalledWith(
-          "https://api.jina.ai/v1/embeddings",
-          expect.objectContaining({
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: "Bearer plus-token",
-              "X-Client-Version": "4.0.0-preview-260802",
-            },
+        await expect(makeEmbeddings().embedQuery("hello")).rejects.toThrow(SyntaxError);
+      });
+
+      it("propagates a network failure rejection from safeFetchNoThrow", async () => {
+        mockFetch.mockRejectedValue(new TypeError("Failed to fetch"));
+
+        await expect(makeEmbeddings().embedQuery("hello")).rejects.toThrow("Failed to fetch");
+      });
+    });
+
+    describe("embedDocuments()", () => {
+      it("sends passages with the retrieval.passage task and returns vectors in input order", async () => {
+        mockFetch.mockResolvedValue(
+          jsonResponse({
+            data: [
+              { index: 0, embedding: [1] },
+              { index: 1, embedding: [2] },
+            ],
           })
         );
+
+        const result = await makeEmbeddings().embedDocuments(["a", "b"]);
+
+        expect(result).toEqual([[1], [2]]);
+        const [, options] = mockFetch.mock.calls[0];
+        expect(JSON.parse(options?.body as string)).toMatchObject({
+          input: ["a", "b"],
+          task: "retrieval.passage",
+        });
+      });
+
+      it("throws an error carrying the JSON `detail` message on a non-200 error body", async () => {
+        mockFetch.mockResolvedValue(jsonResponse({ detail: "Rate limit exceeded" }, 429));
+
+        await expect(makeEmbeddings().embedDocuments(["a"])).rejects.toThrow("Rate limit exceeded");
       });
     });
   });

--- a/src/LLMProviders/CustomJinaEmbeddings.ts
+++ b/src/LLMProviders/CustomJinaEmbeddings.ts
@@ -4,6 +4,7 @@
  * Source: https://github.com/langchain-ai/langchainjs-community/blob/886df5749a926f59e6fdf38a3465c62ec9e7ce32/libs/community/src/embeddings/jina.ts
  */
 
+import { safeFetchNoThrow } from "@/utils";
 import { Embeddings, type EmbeddingsParams } from "@langchain/core/embeddings";
 import { chunkArray } from "@langchain/core/utils/chunk_array";
 import { getEnvironmentVariable } from "@langchain/core/utils/env";
@@ -173,7 +174,7 @@ export class CustomJinaEmbeddings extends Embeddings implements JinaEmbeddingsPa
    * Sends a single embeddings request and returns vectors in response order.
    */
   private async embeddingWithRetry(body: EmbeddingCreateParams): Promise<number[][]> {
-    const response = await fetch(this.baseUrl, {
+    const response = await safeFetchNoThrow(this.baseUrl, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#301

## Why

The Obsidian community scorecard flags 3 uses of `fetch` with "Use the built-in requestUrl function instead of fetch". Two of them inject `fetch` into the Bedrock streaming adapter, where `requestUrl` cannot work — it supports neither streaming responses nor AbortSignal. The third is different: the Jina embeddings adapter sends a plain non-streaming JSON POST through the browser's `fetch`, so a user who selects Jina as their embedding provider can hit CORS failures on mobile or behind strict CORS setups — failures the custom OpenAI embeddings adapter already avoids by routing through `safeFetchNoThrow` (Obsidian's `requestUrl`).

## What

> **Before:** A Jina embedding request (indexing or vault search) goes through the browser `fetch` and is subject to CORS; the scorecard flags the call site alongside the streaming adapters.
>
> **After:** The same request routes through `safeFetchNoThrow` (`requestUrl`) like the other embedding adapters, bypassing CORS on mobile. Error handling is unchanged: a Jina error body's `detail` message still surfaces verbatim, and non-JSON bodies and network failures still throw. The two streaming call sites that must keep `fetch` (Bedrock SSE, LM Studio) each carry a `// scorecard:` comment and are listed as permanent disclosures in `designdocs/OBSIDIAN_COMMUNITY_REVIEW.md`, so every remaining scorecard fetch warning matches the documented list.

## Non goal

- Migrating the streaming adapters (Bedrock, LM Studio) to `requestUrl` — it cannot stream.
- Suppressing, downgrading, or disabling the `no-restricted-globals` fetch rule in `eslint.review.config.mjs`.
- Changing the `safeFetch`/`safeFetchNoThrow` implementations in `src/utils.ts`.

## Screenshot

Not applicable — this PR changes the network transport of Jina embedding requests and review documentation; no UI renders differently.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `src/LLMProviders/CustomJinaEmbeddings.test.ts` covers routing through `safeFetchNoThrow`, vector extraction, and all three error paths |
| A defect would fail CI or be obvious on first use | ❌ | a live-transport defect (`requestUrl` vs browser fetch against the real Jina API) passes CI and surfaces only when a Jina user first indexes |
| A revert fully restores prior state, including persisted data | ✅ | no persisted data or settings touched; revert restores the browser-fetch path |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | the same bearer key is sent in the same Authorization header to the same endpoint |
| No public API, plugin API, message, or on-disk contract changes | ✅ | change is internal to one embedding adapter |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | the request stays a single awaited JSON POST |
| No hot-path behavior lacks deterministic coverage | ✅ | error-`detail`, non-JSON-body, and network-failure branches each have a test; the live transport itself cannot be covered by an automated test because it depends on the live Jina service and the Obsidian runtime |
| No new dependency | ✅ | dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | a defect is confined to Jina embeddings and surfaces on the first index or search attempt |

Review: read `embeddingWithRetry()` in `src/LLMProviders/CustomJinaEmbeddings.ts` against the same pattern in `src/LLMProviders/CustomOpenAIEmbeddings.ts` (`callEmbeddingAPI()`), then run Verification steps 1–3 once with a live Jina key.

## Verification

1. Load the PR build in a test vault, set the embedding provider to Jina with a valid Jina API key, and rebuild the vault index — indexing completes and a vault QA search returns results (this is the Jina provider smoke test `designdocs/OBSIDIAN_COMMUNITY_REVIEW.md` requires when this adapter changes).
2. Replace the key with an invalid one and rebuild — the error notice shows Jina's own `detail` message (an invalid-key description), not a generic failure.
3. Run `npm run review:obsidian` — `CustomJinaEmbeddings.ts` produces no fetch warning, and every remaining fetch warning matches the "Permanent `fetch` disclosures" list in `designdocs/OBSIDIAN_COMMUNITY_REVIEW.md`.

## Note

The Jina provider smoke test in step 1 requires a live Jina API key, which this environment does not have; it is the pre-merge verification for this PR.

