### PR TITLE
Surface Copilot settings in Obsidian settings search

### DIFF
--- a/__mocks__/obsidian.js
+++ b/__mocks__/obsidian.js
@@ -73,6 +73,13 @@ module.exports = {
   parseYaml: jest.fn().mockImplementation((content) => {
     return parseYamlString(content);
   }),
+  PluginSettingTab: class PluginSettingTab {
+    constructor(app, plugin) {
+      this.app = app;
+      this.plugin = plugin;
+      this.containerEl = window.document.createElement("div");
+    }
+  },
   Modal: class Modal {
     constructor() {
       this.open = jest.fn();

--- a/designdocs/OBSIDIAN_COMMUNITY_REVIEW.md
+++ b/designdocs/OBSIDIAN_COMMUNITY_REVIEW.md
@@ -49,7 +49,9 @@ npm audit --omit=dev --audit-level=critical
 
 ## Retained warnings
 
-Warnings remain for cases where automatic cleanup could change behavior or UI, including desktop Node imports, streaming `fetch`, async React callbacks, Obsidian DOM helpers, declarative settings search, `!important`, `:has()`, and manifest copy. Do not suppress them. Fix one warning family at a time with behavior-specific tests.
+Warnings remain for cases where automatic cleanup could change behavior or UI, including desktop Node imports, streaming `fetch`, async React callbacks, Obsidian DOM helpers, `!important`, `:has()`, and manifest copy. Do not suppress them. Fix one warning family at a time with behavior-specific tests.
+
+Declarative settings search is addressed: `CopilotSettingTab.getSettingDefinitions()` serves searchable definitions from the manifest in `src/settings/v2/settingsSearch.ts`, and chosen results deep-link into the React settings UI. The React controls themselves stay imperative; `getControlValue`/`setControlValue` round-tripping is a separate project.
 
 Provider smoke tests for Jina, Bedrock streaming/non-streaming, and legacy GitHub Copilot models are needed only when their adapters or network boundaries change.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,6 +39,8 @@ Quick Chat and Agent Mode have separate setup requirements. Choose either path b
 
 Go to **Settings** → **Copilot** (scroll down to the Community Plugins section).
 
+On Obsidian 1.13 or newer you can also type a Copilot setting's name (for example "Send Shortcut" or "Debug Mode") into the search box at the top of the Settings window — picking the result opens Copilot's settings on the right tab and jumps to that setting.
+
 #### 2. Add an API Key
 
 On the **Basic** tab, click **Set Keys** to open the API key dialog. Enter the key for your chosen provider:

--- a/src/agentMode/skills/ui/SkillsSettings.tsx
+++ b/src/agentMode/skills/ui/SkillsSettings.tsx
@@ -23,6 +23,7 @@ import { deriveSkillsFolder } from "@/settings/copilotFolder";
 import { openWithSystemDefault } from "@/utils/openWithSystemDefault";
 import { getVaultBase, toVaultRelative } from "@/utils/vaultPath";
 import { useSettingsValue } from "@/settings/model";
+import { settingsSearchAnchorAttrs } from "@/lib/settingsSearchAnchor";
 import { AlertTriangle, Search } from "lucide-react";
 import { App, FileSystemAdapter, Notice, TFile, TFolder } from "obsidian";
 import { useApp } from "@/context";
@@ -208,7 +209,10 @@ export const SkillsSettings: React.FC = () => {
   return (
     <div ref={containerRef} className="tw-space-y-4">
       <section>
-        <div className="tw-mb-4 tw-flex tw-flex-col tw-gap-2">
+        <div
+          {...settingsSearchAnchorAttrs("Skills")}
+          className="tw-mb-4 tw-flex tw-flex-col tw-gap-2"
+        >
           <div className="tw-text-xl tw-font-bold">Skills</div>
           <div className="tw-text-sm tw-text-muted">
             Skills are instruction packets your agents can run - things like &ldquo;review a

--- a/src/components/ui/setting-item.tsx
+++ b/src/components/ui/setting-item.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { cn } from "@/lib/utils";
+import { settingsSearchAnchorAttrs } from "@/lib/settingsSearchAnchor";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
 import { Textarea } from "@/components/ui/textarea";
@@ -219,6 +220,7 @@ export function SettingItem(props: SettingItemProps) {
 
   return (
     <div
+      {...settingsSearchAnchorAttrs(title)}
       className={cn(
         "tw-flex tw-flex-col tw-items-start tw-justify-between tw-gap-4 tw-py-4 sm:tw-flex-row sm:tw-items-center",
         "tw-w-full",

--- a/src/lib/settingsSearchAnchor.test.ts
+++ b/src/lib/settingsSearchAnchor.test.ts
@@ -1,0 +1,31 @@
+import {
+  SETTINGS_SEARCH_ANCHOR_ATTR,
+  settingsSearchAnchor,
+  settingsSearchAnchorAttrs,
+} from "@/lib/settingsSearchAnchor";
+
+describe("settingsSearchAnchor", () => {
+  describe("settingsSearchAnchor()", () => {
+    it("lowercases the title and collapses separator runs into single hyphens", () => {
+      expect(settingsSearchAnchor("LLM & embedding models")).toBe("llm-embedding-models");
+    });
+
+    it("strips leading and trailing separators", () => {
+      expect(settingsSearchAnchor("(advanced) Remote server!")).toBe("advanced-remote-server");
+    });
+  });
+
+  describe("settingsSearchAnchorAttrs()", () => {
+    it("derives the anchor attribute from a string title", () => {
+      expect(settingsSearchAnchorAttrs("Debug Mode")).toEqual({
+        [SETTINGS_SEARCH_ANCHOR_ATTR]: "debug-mode",
+      });
+    });
+
+    it("returns undefined for empty or non-string titles", () => {
+      expect(settingsSearchAnchorAttrs("")).toBeUndefined();
+      expect(settingsSearchAnchorAttrs(undefined)).toBeUndefined();
+      expect(settingsSearchAnchorAttrs({ node: true })).toBeUndefined();
+    });
+  });
+});

--- a/src/lib/settingsSearchAnchor.ts
+++ b/src/lib/settingsSearchAnchor.ts
@@ -1,0 +1,35 @@
+/**
+ * Anchor derivation for the settings-search deep links.
+ *
+ * A settings row's DOM anchor derives from its display title, so the search
+ * manifest (`@/settings/v2/settingsSearch`) and the row components that
+ * stamp the attribute stay linked by the title string alone. Lives in
+ * `@/lib` because presentational components consume it and must not reach
+ * into `@/settings`.
+ */
+
+/** Attribute stamped on a rendered settings row so deep links can find it. */
+export const SETTINGS_SEARCH_ANCHOR_ATTR = "data-copilot-setting";
+
+/**
+ * Derives the stable DOM anchor for a setting from its display title.
+ * @param name The setting's display title as shown in the settings UI.
+ */
+export function settingsSearchAnchor(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Spread-ready anchor attribute for a settings row, derived from its title.
+ * Returns undefined when the title is not a plain string (rows with rich
+ * titles get no anchor and fall back to tab-level navigation).
+ * @param title The row title as passed to the row component; only plain
+ * strings produce an anchor.
+ */
+export function settingsSearchAnchorAttrs(title: unknown): Record<string, string> | undefined {
+  if (typeof title !== "string" || title.length === 0) return undefined;
+  return { [SETTINGS_SEARCH_ANCHOR_ATTR]: settingsSearchAnchor(title) };
+}

--- a/src/modelManagement/ui/tabs/ByokPanel.tsx
+++ b/src/modelManagement/ui/tabs/ByokPanel.tsx
@@ -28,6 +28,7 @@ import {
 import { AddProviderModal } from "@/modelManagement/ui/dialogs/AddProviderDialog";
 import { ConfigureProviderModal } from "@/modelManagement/ui/dialogs/ConfigureProviderDialog";
 import { settingsStore, useSettingsValue } from "@/settings/model";
+import { settingsSearchAnchorAttrs } from "@/lib/settingsSearchAnchor";
 import { useAtomValue } from "jotai";
 import { Plus, ShieldCheck } from "lucide-react";
 import { Notice } from "obsidian";
@@ -138,7 +139,10 @@ export const ByokPanel: React.FC = () => {
 
   return (
     <div className="tw-flex tw-flex-col tw-gap-4 tw-py-4">
-      <div className="tw-flex tw-items-start tw-justify-between tw-gap-4">
+      <div
+        {...settingsSearchAnchorAttrs("Bring Your Own Key")}
+        className="tw-flex tw-items-start tw-justify-between tw-gap-4"
+      >
         <div className="tw-flex tw-flex-col tw-gap-1">
           <div className="tw-text-xl tw-font-bold tw-text-normal">Bring Your Own Key</div>
           <div className="tw-max-w-xl tw-text-sm tw-text-muted">

--- a/src/settings/SettingsPage.test.tsx
+++ b/src/settings/SettingsPage.test.tsx
@@ -1,0 +1,96 @@
+import type { App, Setting } from "obsidian";
+import type CopilotPlugin from "@/main";
+import { CopilotSettingTab, type CopilotSettingDefinition } from "@/settings/SettingsPage";
+import { settingsSearchAnchor } from "@/lib/settingsSearchAnchor";
+import {
+  SETTINGS_SEARCH_MANIFEST,
+  subscribeSettingsDeepLink,
+  type SettingsDeepLink,
+} from "@/settings/v2/settingsSearch";
+
+// The tab under test only touches the declarative-definition surface; the
+// React app and plugin runtime behind `display()` stay out of scope here.
+jest.mock("@/settings/v2/SettingsMainV2", () => ({ __esModule: true, default: () => null }));
+jest.mock("@/components/CopilotView", () => ({ __esModule: true, default: class {} }));
+jest.mock("@/settings/model", () => ({ getSettings: jest.fn() }));
+
+function createTab(): CopilotSettingTab {
+  return new CopilotSettingTab({} as App, {} as CopilotPlugin);
+}
+
+function createFakeSetting(): { setting: Setting; settingEl: HTMLElement } {
+  const settingEl = window.document.createElement("div");
+  return { setting: { settingEl } as unknown as Setting, settingEl };
+}
+
+describe("SettingsPage", () => {
+  afterEach(() => {
+    subscribeSettingsDeepLink(() => {})();
+  });
+
+  describe("CopilotSettingTab", () => {
+    describe("getSettingDefinitions()", () => {
+      it("returns the React app host first, excluded from search", () => {
+        const definitions = createTab().getSettingDefinitions();
+
+        expect(definitions[0].searchable).toBe(false);
+        expect(typeof definitions[0].render).toBe("function");
+      });
+
+      it("returns one searchable marker per manifest entry, carrying name, desc, and aliases", () => {
+        const markers = createTab().getSettingDefinitions().slice(1);
+
+        expect(markers.map((definition) => definition.name)).toEqual(
+          SETTINGS_SEARCH_MANIFEST.map((entry) => entry.name)
+        );
+        for (const [index, marker] of markers.entries()) {
+          const entry = SETTINGS_SEARCH_MANIFEST[index];
+          expect(marker.desc).toBe(entry.desc);
+          expect(marker.aliases).toEqual(entry.aliases ? [...entry.aliases] : undefined);
+          expect(marker.searchable).toBeUndefined();
+        }
+      });
+
+      it("hides a marker's row when Obsidian renders it", () => {
+        const marker = createTab().getSettingDefinitions()[1];
+        const { setting, settingEl } = createFakeSetting();
+
+        const cleanup = marker.render(setting);
+
+        expect(settingEl.classList.contains("copilot-setting-search-marker")).toBe(true);
+        expect(cleanup).toBeUndefined();
+      });
+    });
+
+    describe("getElementForDefinition()", () => {
+      it("routes a marker definition into a tab + anchor deep link and lets Obsidian skip its own scroll", () => {
+        const tab = createTab();
+        const markers = tab.getSettingDefinitions().slice(1);
+        const target = markers[markers.length - 1];
+        const entry = SETTINGS_SEARCH_MANIFEST[SETTINGS_SEARCH_MANIFEST.length - 1];
+        const received: SettingsDeepLink[] = [];
+        const unsubscribe = subscribeSettingsDeepLink((link) => received.push(link));
+
+        const element = tab.getElementForDefinition(target);
+
+        expect(element).toBeUndefined();
+        expect(received).toEqual([
+          { tabId: entry.tabId, anchor: settingsSearchAnchor(entry.name) },
+        ]);
+        unsubscribe();
+      });
+
+      it("ignores definitions it did not produce", () => {
+        const tab = createTab();
+        tab.getSettingDefinitions();
+        const foreign: CopilotSettingDefinition = { name: "Foreign", render: () => {} };
+        const received: SettingsDeepLink[] = [];
+        const unsubscribe = subscribeSettingsDeepLink((link) => received.push(link));
+
+        expect(tab.getElementForDefinition(foreign)).toBeUndefined();
+        expect(received).toEqual([]);
+        unsubscribe();
+      });
+    });
+  });
+});

--- a/src/settings/SettingsPage.tsx
+++ b/src/settings/SettingsPage.tsx
@@ -3,13 +3,35 @@ import { CHAT_VIEWTYPE } from "@/constants";
 import CopilotPlugin from "@/main";
 import { getSettings } from "@/settings/model";
 import { logInfo, logError } from "@/logger";
-import { App, Notice, PluginSettingTab } from "obsidian";
+import { App, Notice, PluginSettingTab, type Setting } from "obsidian";
 import React from "react";
 import SettingsMainV2 from "@/settings/v2/SettingsMainV2";
+import { settingsSearchAnchor } from "@/lib/settingsSearchAnchor";
+import {
+  requestSettingsDeepLink,
+  SETTINGS_SEARCH_MANIFEST,
+  type SettingsSearchEntry,
+} from "@/settings/v2/settingsSearch";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
+
+/**
+ * Structural subset of Obsidian 1.13's `SettingDefinition` contract. The
+ * pinned `obsidian` typings predate the declarative settings API (bumping
+ * them is blocked by exact-peer conflicts), so the members Copilot uses are
+ * declared locally; assignment-compatible with the real declarations once
+ * the typings catch up.
+ */
+export interface CopilotSettingDefinition {
+  name: string;
+  desc?: string;
+  aliases?: string[];
+  searchable?: boolean;
+  render: (setting: Setting) => void | (() => void);
+}
 
 export class CopilotSettingTab extends PluginSettingTab {
   plugin: CopilotPlugin;
+  private searchEntryByDefinition = new Map<CopilotSettingDefinition, SettingsSearchEntry>();
 
   constructor(app: App, plugin: CopilotPlugin) {
     super(app, plugin);
@@ -60,6 +82,76 @@ export class CopilotSettingTab extends PluginSettingTab {
     }
   }
 
+  /**
+   * Declarative definitions for Obsidian 1.13+ (settings search and tab
+   * rendering). The first definition hosts the whole React settings app;
+   * the rest are hidden, search-only markers derived from the manifest.
+   * When these are returned, Obsidian renders the tab from them and never
+   * calls `display()` — that method stays only as the pre-1.13 fallback.
+   */
+  getSettingDefinitions(): CopilotSettingDefinition[] {
+    this.searchEntryByDefinition = new Map();
+
+    const appHost: CopilotSettingDefinition = {
+      name: "Copilot settings",
+      searchable: false,
+      render: (setting) => this.mountSettingsApp(setting),
+    };
+
+    const markers = SETTINGS_SEARCH_MANIFEST.map((entry) => {
+      const definition: CopilotSettingDefinition = {
+        name: entry.name,
+        desc: entry.desc,
+        aliases: entry.aliases ? [...entry.aliases] : undefined,
+        // The row exists so Obsidian can index and target the definition;
+        // the visible UI for the setting lives inside the React app.
+        render: (setting) => {
+          setting.settingEl.classList.add("copilot-setting-search-marker");
+        },
+      };
+      this.searchEntryByDefinition.set(definition, entry);
+      return definition;
+    });
+
+    return [appHost, ...markers];
+  }
+
+  /**
+   * Called by Obsidian when a settings-search result for this tab is chosen.
+   * Marker rows are hidden, so instead of handing Obsidian an element to
+   * scroll to, this routes the target through the deep-link channel — the
+   * React app switches to the mapped tab and scrolls the anchored row into
+   * view. Returning undefined makes Obsidian skip its own scroll/focus.
+   * @param definition The chosen search result's definition object.
+   */
+  getElementForDefinition(definition: CopilotSettingDefinition): HTMLElement | undefined {
+    const entry = this.searchEntryByDefinition.get(definition);
+    if (!entry) return undefined;
+    requestSettingsDeepLink({ tabId: entry.tabId, anchor: settingsSearchAnchor(entry.name) });
+    return undefined;
+  }
+
+  /**
+   * Mounts the React settings app into the host definition's row, undoing
+   * the standard setting-row chrome. Returns the cleanup Obsidian invokes
+   * when the row is torn down (tab switch or modal close).
+   */
+  private mountSettingsApp(setting: Setting): () => void {
+    const host = setting.settingEl;
+    host.empty();
+    host.classList.add("copilot-settings-app-host", "tw-select-text");
+    // The enclosing `.setting-items` list paints a card (background + border)
+    // around its rows; tag it so the app isn't framed inside one.
+    host.parentElement?.classList.add("copilot-settings-app-items");
+    const root = createPluginRoot(host, this.app);
+    root.render(<SettingsMainV2 plugin={this.plugin} />);
+    return () => root.unmount();
+  }
+
+  /**
+   * Pre-1.13 fallback: Obsidian only calls this when `getSettingDefinitions`
+   * is unsupported (or returns nothing); newer versions render declaratively.
+   */
   display(): void {
     const { containerEl } = this;
     containerEl.empty();

--- a/src/settings/v2/SettingsMainV2.test.tsx
+++ b/src/settings/v2/SettingsMainV2.test.tsx
@@ -7,16 +7,20 @@
 
 import type CopilotPlugin from "@/main";
 import SettingsMainV2 from "@/settings/v2/SettingsMainV2";
-import { render, screen } from "@testing-library/react";
+import { requestSettingsDeepLink } from "@/settings/v2/settingsSearch";
+import { act, render, screen } from "@testing-library/react";
 import React from "react";
 
 // Every tab body is stubbed empty. The real panels reach for the keychain, Node,
-// and the network, none of which has any bearing on the strip above them.
+// and the network, none of which has any bearing on the strip above them. The
+// Advanced stub renders one anchored row so deep-link scrolling is observable.
 jest.mock("@/settings/v2/components/BasicSettings", () => ({ BasicSettings: () => null }));
 jest.mock("@/settings/v2/components/MiyoSettings", () => ({ MiyoSettings: () => null }));
 jest.mock("@/settings/v2/components/SelfHostSettings", () => ({ SelfHostSettings: () => null }));
 jest.mock("@/settings/v2/components/CommandSettings", () => ({ CommandSettings: () => null }));
-jest.mock("@/settings/v2/components/AdvancedSettings", () => ({ AdvancedSettings: () => null }));
+jest.mock("@/settings/v2/components/AdvancedSettings", () => ({
+  AdvancedSettings: () => <div data-copilot-setting="debug-mode" data-testid="debug-mode-row" />,
+}));
 jest.mock("@/settings/v2/components/DesktopOnlySettingsPanel", () => ({
   DesktopOnlySettingsPanel: () => null,
 }));
@@ -53,6 +57,44 @@ describe("SettingsMainV2", () => {
       render(<SettingsMainV2 plugin={plugin} />);
 
       expect(screen.queryByRole("tab", { name: /agents/i })).toBeNull();
+    });
+
+    it("switches to the deep-linked tab and scrolls its anchored row into view", () => {
+      const scrollIntoView = jest.fn();
+      window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+      render(<SettingsMainV2 plugin={plugin} />);
+
+      act(() => {
+        requestSettingsDeepLink({ tabId: "advanced", anchor: "debug-mode" });
+      });
+
+      expect(screen.getByRole("tab", { name: "Advanced" }).getAttribute("aria-selected")).toBe(
+        "true"
+      );
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center" });
+      expect(screen.getByTestId("debug-mode-row").classList.contains("is-flashing")).toBe(true);
+    });
+
+    it("still switches tabs when the deep-linked anchor is absent from the tab", () => {
+      render(<SettingsMainV2 plugin={plugin} />);
+
+      act(() => {
+        requestSettingsDeepLink({ tabId: "command", anchor: "not-rendered" });
+      });
+
+      expect(screen.getByRole("tab", { name: "Command" }).getAttribute("aria-selected")).toBe(
+        "true"
+      );
+    });
+
+    it("applies a deep link buffered before the settings UI mounted", () => {
+      requestSettingsDeepLink({ tabId: "selfhost", anchor: "enable-self-host-mode" });
+
+      render(<SettingsMainV2 plugin={plugin} />);
+
+      expect(screen.getByRole("tab", { name: "Self-Host" }).getAttribute("aria-selected")).toBe(
+        "true"
+      );
     });
   });
 });

--- a/src/settings/v2/SettingsMainV2.tsx
+++ b/src/settings/v2/SettingsMainV2.tsx
@@ -11,6 +11,12 @@ import { CommandSettings } from "@/settings/v2/components/CommandSettings";
 import { Cog, Command, Cpu, ShieldCheck, Sigma, Sparkle, Wrench } from "lucide-react";
 import React from "react";
 import { isDesktopRuntime } from "@/utils/desktopRuntime";
+import { SETTINGS_SEARCH_ANCHOR_ATTR } from "@/lib/settingsSearchAnchor";
+import {
+  SETTINGS_TAB_IDS,
+  subscribeSettingsDeepLink,
+  type SettingsTabId,
+} from "@/settings/v2/settingsSearch";
 import { AdvancedSettings } from "./components/AdvancedSettings";
 import { BasicSettings } from "./components/BasicSettings";
 import { DesktopOnlySettingsPanel } from "./components/DesktopOnlySettingsPanel";
@@ -33,8 +39,8 @@ import { SelfHostSettings } from "./components/SelfHostSettings";
 // The relabeled "Keyword (built-in) vs Miyo (semantic search)" engine toggle
 // and honest embedding-caveat copy land in a follow-up PR, not here. If a review
 // flags the missing QA/search UI again, point them at this note.
-const TAB_IDS = ["basic", "byok", "miyo", "skills", "command", "selfhost", "advanced"] as const;
-type TabId = (typeof TAB_IDS)[number];
+const TAB_IDS = SETTINGS_TAB_IDS;
+type TabId = SettingsTabId;
 
 const LazySkillsSettings = React.lazy(() =>
   import("@/agentMode").then((module) => ({ default: module.SkillsSettings }))
@@ -95,11 +101,54 @@ const tabs: TabItemType[] = TAB_IDS.map((id) => ({
   label: TAB_LABELS[id],
 }));
 
+/** How long the deep-linked row keeps Obsidian's `is-flashing` highlight. */
+const DEEP_LINK_FLASH_MS = 750;
+
 const SettingsContent: React.FC = () => {
   const { selectedTab, setSelectedTab } = useTab();
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  // The anchor rides in a ref (it must not retrigger renders on its own);
+  // the tick is the state that sequences "scroll after the tab committed".
+  const pendingAnchorRef = React.useRef<string | null>(null);
+  const [deepLinkTick, setDeepLinkTick] = React.useState(0);
+
+  // Settings-search deep links: switch to the mapped tab first, then scroll
+  // once that tab's content has committed (the effect below).
+  React.useEffect(() => {
+    return subscribeSettingsDeepLink((link) => {
+      pendingAnchorRef.current = link.anchor;
+      setSelectedTab(link.tabId);
+      setDeepLinkTick((tick) => tick + 1);
+    });
+  }, [setSelectedTab]);
+
+  React.useEffect(() => {
+    if (deepLinkTick === 0) return;
+    const anchor = pendingAnchorRef.current;
+    pendingAnchorRef.current = null;
+    if (!anchor) return;
+    const target = rootRef.current?.querySelector<HTMLElement>(
+      `[${SETTINGS_SEARCH_ANCHOR_ATTR}="${anchor}"]`
+    );
+    // Anchors are best-effort: rows hidden behind collapsed or conditional UI
+    // may be absent, in which case landing on the tab is the whole deep link.
+    if (!target) return;
+    target.scrollIntoView({ block: "center" });
+    // Obsidian's own settings search flashes its target row via this class;
+    // reusing it keeps the highlight native-looking and theme-aware.
+    target.classList.add("is-flashing");
+    const flashTimeout = window.setTimeout(
+      () => target.classList.remove("is-flashing"),
+      DEEP_LINK_FLASH_MS
+    );
+    return () => {
+      window.clearTimeout(flashTimeout);
+      target.classList.remove("is-flashing");
+    };
+  }, [deepLinkTick]);
 
   return (
-    <div className="tw-flex tw-flex-col">
+    <div ref={rootRef} className="tw-flex tw-flex-col">
       <div className="tw-flex tw-flex-wrap tw-rounded-lg">
         {tabs.map((tab, index) => (
           <TabItem

--- a/src/settings/v2/components/CommandSettings.tsx
+++ b/src/settings/v2/components/CommandSettings.tsx
@@ -33,6 +33,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { cn } from "@/lib/utils";
 import { logError } from "@/logger";
 import { updateSetting, useSettingsValue } from "@/settings/model";
+import { settingsSearchAnchorAttrs } from "@/lib/settingsSearchAnchor";
 import { PromptSortStrategy } from "@/types";
 import { HelpTooltip } from "@/components/ui/help-tooltip";
 import { EMPTY_COMMAND } from "@/commands/constants";
@@ -408,7 +409,10 @@ export const CommandSettings: React.FC = () => {
   return (
     <div className="tw-space-y-4" ref={containerRef}>
       <section className={cn("tw-flex tw-flex-col tw-gap-4")}>
-        <div className="tw-flex tw-flex-col tw-gap-2">
+        <div
+          {...settingsSearchAnchorAttrs("Custom Commands")}
+          className="tw-flex tw-flex-col tw-gap-2"
+        >
           <div className="tw-text-xl tw-font-bold">Custom Commands</div>
           <div className="tw-text-sm tw-text-muted">
             Preset prompts you trigger from the editor right-click menu or with a <code>/</code>{" "}

--- a/src/settings/v2/components/MiyoSettings.tsx
+++ b/src/settings/v2/components/MiyoSettings.tsx
@@ -38,6 +38,7 @@ import {
   MiyoConnectModal,
 } from "@/settings/v2/components/MiyoConnectModal";
 import { MiyoStatusRow } from "@/settings/v2/components/MiyoStatusRow";
+import { settingsSearchAnchorAttrs } from "@/lib/settingsSearchAnchor";
 import { err2String } from "@/utils";
 import { getVaultBase } from "@/utils/vaultPath";
 import { extractAppIgnoreSettings, getSystemExcludedFolders } from "@/search/searchUtils";
@@ -104,6 +105,7 @@ const CapabilityRow: React.FC<CapabilityRowProps> = ({
   indented = false,
 }) => (
   <div
+    {...settingsSearchAnchorAttrs(title)}
     className={cn(
       "tw-flex tw-flex-col tw-items-start tw-justify-between tw-gap-4 tw-py-4 sm:tw-flex-row sm:tw-items-center",
       // `!` so the indent beats the parent's `[&>*]:tw-px-4` (equal specificity,

--- a/src/settings/v2/components/MiyoStatusRow.tsx
+++ b/src/settings/v2/components/MiyoStatusRow.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { type CapabilityStatus } from "@/miyo/miyoStatusStore";
+import { settingsSearchAnchorAttrs } from "@/lib/settingsSearchAnchor";
 import { ArrowUpRight } from "lucide-react";
 import React from "react";
 
@@ -60,7 +61,10 @@ export const MiyoStatusRow: React.FC<MiyoStatusRowProps> = ({
 }) => (
   // items-start (not center): the status sub-line makes the left column taller, and
   // the mock top-aligns the action button against it (dc.html Connector/Search chat).
-  <div className="tw-flex tw-flex-col tw-items-start tw-justify-between tw-gap-4 tw-py-4 sm:tw-flex-row sm:tw-items-start">
+  <div
+    {...settingsSearchAnchorAttrs(title)}
+    className="tw-flex tw-flex-col tw-items-start tw-justify-between tw-gap-4 tw-py-4 sm:tw-flex-row sm:tw-items-start"
+  >
     <div className="tw-w-full tw-space-y-1.5 sm:tw-w-[320px]">
       <div className="tw-flex tw-items-center tw-gap-2 tw-text-sm tw-font-medium tw-leading-none">
         {title}

--- a/src/settings/v2/components/PlusSettings.tsx
+++ b/src/settings/v2/components/PlusSettings.tsx
@@ -12,6 +12,7 @@ import {
   useLicenseState,
 } from "@/plusUtils";
 import { updateSetting, useSettingsValue } from "@/settings/model";
+import { settingsSearchAnchorAttrs } from "@/lib/settingsSearchAnchor";
 import { ExternalLink, Loader2 } from "lucide-react";
 import React, { useState } from "react";
 
@@ -47,7 +48,10 @@ export function PlusSettings() {
   const usageData = getPlusUsageMock();
 
   return (
-    <section className="tw-flex tw-flex-col tw-gap-4 tw-rounded-xl tw-border tw-border-solid tw-border-border tw-p-4 tw-shadow-sm tw-bg-interactive-accent/10">
+    <section
+      {...settingsSearchAnchorAttrs("Copilot License")}
+      className="tw-flex tw-flex-col tw-gap-4 tw-rounded-xl tw-border tw-border-solid tw-border-border tw-p-4 tw-shadow-sm tw-bg-interactive-accent/10"
+    >
       <div className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-text-lg tw-font-semibold">
         <span>Copilot License</span>
         {licenseStatus === "active" && (

--- a/src/settings/v2/components/VaultInstructionsSetting.tsx
+++ b/src/settings/v2/components/VaultInstructionsSetting.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { InstructionsTextarea } from "@/instructions/InstructionsTextarea";
+import { settingsSearchAnchorAttrs } from "@/lib/settingsSearchAnchor";
 import { ArrowUpRight } from "lucide-react";
 import React from "react";
 
@@ -17,7 +18,10 @@ export const VaultInstructionsSetting: React.FC<VaultInstructionsSettingProps> =
   onChange,
   onOpen,
 }) => (
-  <div className="tw-flex tw-w-full tw-flex-col tw-gap-4 tw-py-4">
+  <div
+    {...settingsSearchAnchorAttrs("Custom vault instructions")}
+    className="tw-flex tw-w-full tw-flex-col tw-gap-4 tw-py-4"
+  >
     <div className="tw-grid tw-w-full tw-grid-cols-[minmax(0,1fr)_auto] tw-items-center tw-gap-4">
       <div className="tw-space-y-1.5">
         <div className="tw-text-sm tw-font-medium tw-leading-none">Custom vault instructions</div>

--- a/src/settings/v2/settingsSearch.test.ts
+++ b/src/settings/v2/settingsSearch.test.ts
@@ -1,0 +1,89 @@
+import { settingsSearchAnchor } from "@/lib/settingsSearchAnchor";
+import {
+  requestSettingsDeepLink,
+  SETTINGS_SEARCH_MANIFEST,
+  SETTINGS_TAB_IDS,
+  subscribeSettingsDeepLink,
+  type SettingsDeepLink,
+} from "@/settings/v2/settingsSearch";
+
+describe("settingsSearch", () => {
+  // The deep-link channel is module-level state; drain any buffered link so
+  // one test's leftovers never leak into the next.
+  afterEach(() => {
+    subscribeSettingsDeepLink(() => {})();
+  });
+
+  describe("SETTINGS_SEARCH_MANIFEST", () => {
+    it("references only valid tab ids", () => {
+      for (const entry of SETTINGS_SEARCH_MANIFEST) {
+        expect(SETTINGS_TAB_IDS).toContain(entry.tabId);
+      }
+    });
+
+    it("covers every settings tab with at least one entry", () => {
+      const coveredTabs = new Set(SETTINGS_SEARCH_MANIFEST.map((entry) => entry.tabId));
+      expect([...SETTINGS_TAB_IDS].sort()).toEqual([...coveredTabs].sort());
+    });
+
+    it("gives every entry a globally unique name and anchor", () => {
+      const names = SETTINGS_SEARCH_MANIFEST.map((entry) => entry.name);
+      const anchors = SETTINGS_SEARCH_MANIFEST.map((entry) => settingsSearchAnchor(entry.name));
+      expect(new Set(names).size).toBe(names.length);
+      expect(new Set(anchors).size).toBe(anchors.length);
+    });
+
+    it("gives every entry a non-empty name, description, and anchor", () => {
+      for (const entry of SETTINGS_SEARCH_MANIFEST) {
+        expect(entry.name).not.toBe("");
+        expect(entry.desc).not.toBe("");
+        expect(settingsSearchAnchor(entry.name)).not.toBe("");
+      }
+    });
+  });
+
+  describe("requestSettingsDeepLink()", () => {
+    it("delivers the link immediately to the current subscriber", () => {
+      const received: SettingsDeepLink[] = [];
+      const unsubscribe = subscribeSettingsDeepLink((link) => received.push(link));
+
+      requestSettingsDeepLink({ tabId: "advanced", anchor: "debug-mode" });
+
+      expect(received).toEqual([{ tabId: "advanced", anchor: "debug-mode" }]);
+      unsubscribe();
+    });
+
+    it("buffers the link while no subscriber exists and flushes it to the next one", () => {
+      requestSettingsDeepLink({ tabId: "miyo", anchor: "semantic-search" });
+
+      const received: SettingsDeepLink[] = [];
+      const unsubscribe = subscribeSettingsDeepLink((link) => received.push(link));
+
+      expect(received).toEqual([{ tabId: "miyo", anchor: "semantic-search" }]);
+      unsubscribe();
+    });
+  });
+
+  describe("subscribeSettingsDeepLink()", () => {
+    it("stops delivering after unsubscribe", () => {
+      const received: SettingsDeepLink[] = [];
+      subscribeSettingsDeepLink((link) => received.push(link))();
+
+      requestSettingsDeepLink({ tabId: "basic", anchor: "send-shortcut" });
+
+      expect(received).toEqual([]);
+    });
+
+    it("keeps a newer subscriber registered when a stale unsubscribe runs", () => {
+      const stale = subscribeSettingsDeepLink(() => {});
+      const received: SettingsDeepLink[] = [];
+      const unsubscribe = subscribeSettingsDeepLink((link) => received.push(link));
+      stale();
+
+      requestSettingsDeepLink({ tabId: "byok", anchor: "bring-your-own-key" });
+
+      expect(received).toEqual([{ tabId: "byok", anchor: "bring-your-own-key" }]);
+      unsubscribe();
+    });
+  });
+});

--- a/src/settings/v2/settingsSearch.ts
+++ b/src/settings/v2/settingsSearch.ts
@@ -1,0 +1,298 @@
+/**
+ * Settings-search support for Obsidian 1.13+.
+ *
+ * Obsidian's global settings search indexes the definitions a
+ * `PluginSettingTab` returns from `getSettingDefinitions()`. Copilot's
+ * settings UI is a React app, so instead of migrating every control to
+ * declarative definitions, this module keeps a manifest of the user-facing
+ * settings (name, description, aliases, owning tab) that
+ * `CopilotSettingTab` turns into searchable definitions, plus the deep-link
+ * channel that routes a chosen search result into the React UI (switch tab,
+ * scroll the anchored row into view).
+ *
+ * DOM anchors derive from a setting's display title via
+ * `settingsSearchAnchor()` (`@/lib/settingsSearchAnchor`); shared row
+ * components stamp the same derived anchor, so a manifest entry and its
+ * rendered row stay linked by the title string alone.
+ */
+
+/** Tab ids of SettingsMainV2, in display order. */
+export const SETTINGS_TAB_IDS = [
+  "basic",
+  "byok",
+  "miyo",
+  "skills",
+  "command",
+  "selfhost",
+  "advanced",
+] as const;
+
+export type SettingsTabId = (typeof SETTINGS_TAB_IDS)[number];
+
+/** One user-facing setting exposed to Obsidian's settings search. */
+export interface SettingsSearchEntry {
+  /** The SettingsMainV2 tab that renders this setting. */
+  tabId: SettingsTabId;
+  /** Display name, as rendered in the settings UI. Also drives the anchor. */
+  name: string;
+  /** Search-matchable description; mirrors the rendered description text. */
+  desc: string;
+  /** Extra search terms not present in the name or description. */
+  aliases?: readonly string[];
+}
+
+/** A pending navigation from a settings-search result into the React UI. */
+export interface SettingsDeepLink {
+  tabId: SettingsTabId;
+  anchor: string;
+}
+
+let pendingDeepLink: SettingsDeepLink | null = null;
+let deepLinkListener: ((link: SettingsDeepLink) => void) | null = null;
+
+/**
+ * Routes a settings-search selection into the React settings UI. If the UI
+ * is not mounted yet (Obsidian navigates before React commits), the link is
+ * buffered and delivered to the next subscriber.
+ * @param link The tab to select and the row anchor to scroll into view.
+ */
+export function requestSettingsDeepLink(link: SettingsDeepLink): void {
+  if (deepLinkListener) {
+    deepLinkListener(link);
+  } else {
+    pendingDeepLink = link;
+  }
+}
+
+/**
+ * Registers the settings UI as the deep-link consumer, immediately flushing
+ * any link buffered while the UI was unmounted. Only one consumer exists at
+ * a time (the latest mounted settings root).
+ * @param listener Called with each deep link to apply to the UI.
+ * @returns Unsubscribe callback; clears the listener if still registered.
+ */
+export function subscribeSettingsDeepLink(listener: (link: SettingsDeepLink) => void): () => void {
+  deepLinkListener = listener;
+  const buffered = pendingDeepLink;
+  if (buffered) {
+    pendingDeepLink = null;
+    listener(buffered);
+  }
+  return () => {
+    if (deepLinkListener === listener) {
+      deepLinkListener = null;
+    }
+  };
+}
+
+/**
+ * The stable, named settings of every tab, in tab order. Dynamic per-item
+ * rows (configured models, individual custom commands, individual skills)
+ * are deliberately absent — only rows with a fixed identity are indexable.
+ */
+export const SETTINGS_SEARCH_MANIFEST: readonly SettingsSearchEntry[] = [
+  // basic
+  {
+    tabId: "basic",
+    name: "Copilot License",
+    desc: "Enter your Copilot Plus license key to unlock premium features.",
+    aliases: ["license key", "plus", "believer", "supporter"],
+  },
+  {
+    tabId: "basic",
+    name: "Default backend",
+    desc: "Used when you click + to start a new session and for auto-spawn on mount.",
+    aliases: ["agent", "claude code", "codex"],
+  },
+  {
+    tabId: "basic",
+    name: "Default model",
+    desc: "The model new chats start with. Pick from your enabled Quick Chat models.",
+    aliases: ["chat model", "quick chat"],
+  },
+  {
+    tabId: "basic",
+    name: "Open Plugin In",
+    desc: "Choose where to open the plugin.",
+    aliases: ["sidebar", "editor"],
+  },
+  {
+    tabId: "basic",
+    name: "Send Shortcut",
+    desc: "Keyboard shortcut to send messages.",
+    aliases: ["enter", "hotkey"],
+  },
+  {
+    tabId: "basic",
+    name: "Copilot folder location",
+    desc: "Where Copilot keeps conversations, prompts, memory and more.",
+    aliases: ["conversations folder"],
+  },
+  {
+    tabId: "basic",
+    name: "Custom vault instructions",
+    desc: "Instructions Copilot follows in every chat in this vault.",
+    aliases: ["system prompt", "persona"],
+  },
+  {
+    tabId: "basic",
+    name: "Autosave Chat as Markdown",
+    desc: "Writes each chat to a Markdown note in your vault after every user message and AI response.",
+    aliases: ["save chat"],
+  },
+  {
+    tabId: "basic",
+    name: "Conversation Filename Template",
+    desc: "Customize the format of saved conversation note names.",
+    aliases: ["note name"],
+  },
+  // byok
+  {
+    tabId: "byok",
+    name: "Bring Your Own Key",
+    desc: "Set up your own providers and models to use in Copilot.",
+    aliases: ["byok", "api key", "provider", "models", "openai", "anthropic"],
+  },
+  // miyo
+  {
+    tabId: "miyo",
+    name: "Miyo",
+    desc: "Runs locally and connects automatically.",
+    aliases: ["local ai", "connect", "disconnect"],
+  },
+  {
+    tabId: "miyo",
+    name: "Connector",
+    desc: "Let ChatGPT / Claude read-write your local files and vault from the cloud.",
+    aliases: ["relay", "cloud"],
+  },
+  {
+    tabId: "miyo",
+    name: "Remote Miyo server (advanced)",
+    desc: "Leave blank for local discovery, or point at a remote Miyo instance.",
+    aliases: ["url", "endpoint"],
+  },
+  {
+    tabId: "miyo",
+    name: "Semantic search",
+    desc: "Understands meaning, not just keywords — finds related notes on-device.",
+    aliases: ["embedding", "search skill", "related notes"],
+  },
+  {
+    tabId: "miyo",
+    name: "Search scope",
+    desc: "Only the current vault, or everything Miyo has indexed.",
+    aliases: ["vault scope"],
+  },
+  {
+    tabId: "miyo",
+    name: "Search chat",
+    desc: "Search your ChatGPT / Claude chats locally.",
+    aliases: ["chat history"],
+  },
+  {
+    tabId: "miyo",
+    name: "Document Processor",
+    desc: "Processes PDF & EPUB locally via Miyo; other formats use Plus cloud.",
+    aliases: ["pdf", "epub"],
+  },
+  // skills
+  {
+    tabId: "skills",
+    name: "Skills",
+    desc: "Instruction packets your agents can run, loaded from your skills folders.",
+    aliases: ["agent skills"],
+  },
+  // command
+  {
+    tabId: "command",
+    name: "Custom Commands",
+    desc: "Preset prompts you trigger from the editor right-click menu or with a / command in chat.",
+    aliases: ["custom prompts", "slash commands"],
+  },
+  {
+    tabId: "command",
+    name: "Custom Prompt Templating",
+    desc: "Process variables like {activenote}, {foldername}, or {#tag} in prompts.",
+    aliases: ["variables"],
+  },
+  {
+    tabId: "command",
+    name: "Custom Prompts Sort Strategy",
+    desc: "Sort order for slash command menu prompts.",
+    aliases: ["sort order"],
+  },
+  // selfhost
+  {
+    tabId: "selfhost",
+    name: "Enable Self-Host Mode",
+    desc: "Route LLMs, embeddings and document understanding through your own endpoints.",
+    aliases: ["self host", "offline", "privacy"],
+  },
+  {
+    tabId: "selfhost",
+    name: "Web Search Provider",
+    desc: "Web search provider used by the agent search skill.",
+    aliases: ["firecrawl", "perplexity"],
+  },
+  {
+    tabId: "selfhost",
+    name: "Firecrawl API Key",
+    desc: "Web search & fetch via Firecrawl.",
+  },
+  {
+    tabId: "selfhost",
+    name: "Perplexity API Key",
+    desc: "Web search via Perplexity Sonar.",
+    aliases: ["sonar"],
+  },
+  {
+    tabId: "selfhost",
+    name: "Supadata API Key",
+    desc: "YouTube transcripts via Supadata.",
+    aliases: ["youtube", "transcript"],
+  },
+  {
+    tabId: "selfhost",
+    name: "LLM & embedding models",
+    desc: "Add local / self-hosted models as an OpenAI-compatible endpoint in BYOK.",
+    aliases: ["local models", "openai compatible"],
+  },
+  // advanced
+  {
+    tabId: "advanced",
+    name: "API Key Storage",
+    desc: "API keys are stored in this device's Obsidian Keychain.",
+    aliases: ["keychain", "secrets", "delete all keys"],
+  },
+  {
+    tabId: "advanced",
+    name: "Debug Mode",
+    desc: "Logs Copilot chat activity to the developer console.",
+    aliases: ["console", "logs"],
+  },
+  {
+    tabId: "advanced",
+    name: "Create Log File",
+    desc: "Save and open the regular Copilot chat log to share when reporting a chat issue.",
+    aliases: ["log file"],
+  },
+  {
+    tabId: "advanced",
+    name: "Report an Issue",
+    desc: "Bundles a screenshot of the Agent Mode chat pane and a recent activity log, then opens a prefilled GitHub issue.",
+    aliases: ["github", "bug report"],
+  },
+  {
+    tabId: "advanced",
+    name: "Keep an Agent Mode activity log",
+    desc: "Records the behind-the-scenes messages between Copilot and the agent.",
+    aliases: ["agent log"],
+  },
+  {
+    tabId: "advanced",
+    name: "Agent Mode activity log file",
+    desc: "Open or clear the log file on disk.",
+    aliases: ["open log"],
+  },
+];

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1261,3 +1261,37 @@ body.is-mobile div[data-radix-popper-content-wrapper] {
 .copilot-fade-mask-bottom {
   background: linear-gradient(to top, var(--background-primary), transparent);
 }
+
+/* Settings-search support (Obsidian 1.13+ declarative tab rendering).
+   The host row carries the whole React settings app: undo the standard
+   setting-row chrome (row layout, card padding, divider) so the app lays
+   out exactly like the pre-1.13 container. The compound selectors match
+   the specificity of Obsidian's grouped-row rules so the reset wins. */
+.copilot-settings-app-host,
+.setting-group .setting-item.copilot-settings-app-host {
+  display: block;
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+  padding: 0;
+  margin: 0;
+}
+
+.setting-group .setting-item.copilot-settings-app-host::before {
+  content: none;
+}
+
+/* The `.setting-items` list around the host paints a card (background +
+   border); the app supplies its own surfaces, so drop the frame. */
+.setting-group .setting-items.copilot-settings-app-items {
+  background-color: transparent;
+  border: none;
+}
+
+/* Marker rows exist only so Obsidian can index and target a setting in
+   search; they are never shown (Obsidian's own show/hide only touches
+   inline display, so this class keeps them hidden). */
+.copilot-setting-search-marker,
+.setting-group .setting-item.copilot-setting-search-marker {
+  display: none;
+}


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#297
Part of logancyang/obsidian-copilot-preview#345

## Why

Obsidian 1.13 added a global settings search, but typing a Copilot setting's name (say "Debug Mode" or "Send Shortcut") into it returns nothing: Copilot's settings are a React app mounted from `display()`, invisible to the search index. A user has to know the setting is Copilot's, open the Copilot tab, and hunt through seven sub-tabs by hand. The community plugin scorecard flags the missing `getSettingDefinitions()` for the same reason.

## What

> **Before:** Searching "Debug Mode" in Obsidian's settings search finds nothing; opening Copilot's settings always lands on the Basic tab.
>
> **After:** The same search shows "Debug Mode" under Copilot; picking it opens Copilot's settings with the Advanced tab active and the Debug Mode row scrolled into view with Obsidian's native highlight flash.

Every stable, named setting across all seven tabs (Basic, BYOK, Miyo, Skills, Command, Self-Host, Advanced) is searchable by name, description, and aliases. Settings hidden behind collapsed or conditional UI still open the right tab; only the scroll is skipped. On Obsidian older than 1.13 nothing changes — the settings page renders exactly as before.

The settings themselves are untouched: no migration, no values to re-enter, and the settings page looks and behaves the same when opened directly.

## Non goal

- Rewriting the React settings UI into declarative controls with `getControlValue`/`setControlValue` round-tripping (issue's suggested follow-up).
- The broader settings-page UX redesign tracked in logancyang/obsidian-copilot-preview#89 and logancyang/obsidian-copilot-preview#195.
- Indexing dynamic per-item rows (individually configured models, custom command entries, individual skills); only stable named settings are searchable.
- Bumping the pinned `obsidian` typings (see Note).

## Screenshot

Cannot capture: rendering the search flow requires the branch build installed in a live Obsidian 1.13 vault, and this environment has no `COPILOT_TEST_VAULT_PATH` configured for the documented build-and-deploy flow (`npm run test:vault`).

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `settingsSearch.test.ts` (manifest covers all seven tabs, unique names/anchors), `SettingsPage.test.tsx` (definitions + deep-link routing), `SettingsMainV2.test.tsx` (tab switch, scroll, flash, buffered link), `settingsSearchAnchor.test.ts` |
| A defect would fail CI or be obvious on first use | ✅ | A broken definition list makes the settings tab itself misrender, visible on first open of Settings → Copilot |
| A revert fully restores prior state, including persisted data | ✅ | No settings schema or persisted-data change; `display()` fallback is untouched |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Search metadata and navigation only |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Adopts Obsidian 1.13's declarative `PluginSettingTab` interface via local structural types (pinned typings predate it); verified against the shipped 1.13 runtime, no existing consumer contract changed |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Deep links are a single buffered handoff; chat, indexing, and agent paths untouched |
| No hot-path behavior lacks deterministic coverage | ❌ | The Obsidian-side render/search integration cannot be covered by an automated test because it requires the live Obsidian 1.13 app; everything plugin-side is jest-covered |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the settings page; a defect shows the moment settings open, and a revert fully undoes it |

Review: inspect `src/settings/SettingsPage.tsx` — `getSettingDefinitions()`, `getElementForDefinition()`, and `mountSettingsApp()` — and the deep-link effects in `SettingsContent` in `src/settings/v2/SettingsMainV2.tsx`, then run Verification steps 2–6 in a real Obsidian 1.13 vault; do not merge on green CI alone.

## Verification

1. Build the branch and install it into an Obsidian **1.13+** vault (`npm run build`, then copy `main.js`, `styles.css`, `manifest.json` into `<vault>/.obsidian/plugins/copilot/`, or use `npm run test:vault`).
2. Open Settings → Copilot directly: the page must render exactly as on master (tabs, header, reset button), with no extra card frame or empty rows.
3. In Settings, type "Debug Mode" into the search box: a result appears under Copilot; selecting it opens Copilot with the **Advanced** tab active and the Debug Mode row centered and briefly highlighted.
4. Repeat with "Semantic search" (**Miyo** tab) and "Custom Prompt Templating" (**Command** tab).
5. Search "Conversation Filename Template" (hidden behind a collapsed disclosure): selecting it opens the **Basic** tab without scrolling — the tab landing alone is the deep link.
6. While Copilot's settings are already open on Basic, search and select "Debug Mode" again: the tab switches to Advanced and scrolls without reopening the settings page.

## Note

The issue's first checkbox proposed bumping the `obsidian` typings to 1.13.x. That bump is blocked: `obsidian@1.13.1` peer-pins `@codemirror/state@6.5.0` (below our declared `^6.5.2`) and the pinned `eslint-plugin-obsidianmd@0.4.1` peer-pins `obsidian@1.8.7`, so the bump would force unrelated downgrades. Per the issue's risk section, the tab instead declares a narrow structural subset of the `SettingDefinition` contract (`CopilotSettingDefinition`), checked against the shipped Obsidian 1.13 runtime (search indexing, `renderTab`, `getElementForDefinition`, cleanup paths were all verified against the app bundle). It is assignment-compatible with the real declarations once the typings catch up.
