### PR TITLE
[Node runtime guards] - Step 1: Guard eager Node imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -396,21 +396,16 @@ export default [
   // Agent Mode: backends spawn subprocesses (ACP) and the in-process Claude
   // SDK uses node:async_hooks. The plugin runs in Electron renderer where
   // these modules are available; the desktop-only Agent Mode is also gated by
-  // `Platform.isMobile` at runtime in main.ts.
-  // detectBinary / binaryPath / nodeToolBinDirs / rendererEventsShim are
-  // sibling utilities pulled in by agent-mode wiring and share the same
-  // Electron-renderer assumptions. The Symposium handoff consumer is likewise
-  // desktop-only, but remains in the host publishing layer. openVaultPath
-  // lazy-requires node:fs behind a desktop vault-base guard, mirroring
-  // opencodeLog.
+  // `Platform.isMobile` at runtime in main.ts. The Symposium handoff consumer
+  // is likewise desktop-only, but remains in the host publishing layer.
+  // openVaultPath lazy-requires node:fs behind a desktop vault-base guard,
+  // mirroring opencodeLog. Modules converted to call-time
+  // `requireNodeModule()` guards (see src/utils/desktopRuntime.ts) need no
+  // exemption; the goal is to shrink this list to empty as remaining
+  // subsystems convert (logancyang/obsidian-copilot-preview#299).
   {
     files: [
       "src/agentMode/**",
-      "src/utils/appPaths.ts",
-      "src/utils/detectBinary.ts",
-      "src/utils/binaryPath.ts",
-      "src/utils/nodeToolBinDirs.ts",
-      "src/utils/rendererEventsShim.ts",
       "src/utils/issueReport.ts",
       "src/utils/opencodeLog.ts",
       "src/utils/openVaultPath.ts",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -401,8 +401,7 @@ export default [
   // openVaultPath lazy-requires node:fs behind a desktop vault-base guard,
   // mirroring opencodeLog. Modules converted to call-time
   // `requireNodeModule()` guards (see src/utils/desktopRuntime.ts) need no
-  // exemption; the goal is to shrink this list to empty as remaining
-  // subsystems convert (logancyang/obsidian-copilot-preview#299).
+  // exemption.
   {
     files: [
       "src/agentMode/**",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -393,28 +393,6 @@ export default [
     },
   },
 
-  // Agent Mode: backends spawn subprocesses (ACP) and the in-process Claude
-  // SDK uses node:async_hooks. The plugin runs in Electron renderer where
-  // these modules are available; the desktop-only Agent Mode is also gated by
-  // `Platform.isMobile` at runtime in main.ts. The Symposium handoff consumer
-  // is likewise desktop-only, but remains in the host publishing layer.
-  // openVaultPath lazy-requires node:fs behind a desktop vault-base guard,
-  // mirroring opencodeLog. Modules converted to call-time
-  // `requireNodeModule()` guards (see src/utils/desktopRuntime.ts) need no
-  // exemption.
-  {
-    files: [
-      "src/agentMode/**",
-      "src/utils/issueReport.ts",
-      "src/utils/opencodeLog.ts",
-      "src/utils/openVaultPath.ts",
-      "src/symposium/symposiumAgentHandoff.ts",
-    ],
-    rules: {
-      "import/no-nodejs-modules": "off",
-    },
-  },
-
   // Element types (order matters — first match wins; files before folders):
   //   registry     src/agentMode/backends/registry.ts (file)
   //   barrel       src/agentMode/index.ts (file)

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -3,6 +3,8 @@ jest.mock("obsidian", () => ({
   // referenced by the manager class but not by these tests.
   FileSystemAdapter: class {},
   requestUrl: jest.fn(),
+  // requireNodeModule() gates the Node built-ins these paths resolve through.
+  Platform: { isDesktopApp: true, isMobile: false },
 }));
 
 jest.mock("@/logger", () => ({

--- a/src/utils/appPaths.test.ts
+++ b/src/utils/appPaths.test.ts
@@ -1,5 +1,5 @@
 import type { App } from "obsidian";
-import { FileSystemAdapter } from "obsidian";
+import { FileSystemAdapter, Platform } from "obsidian";
 import * as path from "node:path";
 import { md5 } from "@/utils/hash";
 import { COPILOT_APP_DIR_NAME, copilotAppDataDir, getVaultId } from "./appPaths";
@@ -13,6 +13,36 @@ describe("copilotAppDataDir", () => {
     expect(COPILOT_APP_DIR_NAME).toBe(".obsidian-copilot");
     // Guard against a regression to the GitHub-Copilot-CLI-colliding name.
     expect(COPILOT_APP_DIR_NAME).not.toBe(".copilot");
+  });
+
+  it("throws the desktop-only error on non-desktop runtimes instead of a TypeError", () => {
+    const platform = Platform as { isMobile: boolean };
+    platform.isMobile = true;
+    try {
+      expect(() => copilotAppDataDir("/Users/me")).toThrow(/unavailable outside the desktop/);
+    } finally {
+      platform.isMobile = false;
+    }
+  });
+});
+
+describe("module evaluation", () => {
+  it("does not require Node built-ins at module evaluation time", () => {
+    // appPaths sits on the eager context-cache import graph, which mobile
+    // also evaluates; an eval-time require would crash the plugin at load.
+    const throwingIds = ["path", "node:path"];
+    try {
+      jest.isolateModules(() => {
+        for (const id of throwingIds) {
+          jest.doMock(id, () => {
+            throw new Error(`eager require of ${id}`);
+          });
+        }
+        expect(() => void jest.requireActual("./appPaths")).not.toThrow();
+      });
+    } finally {
+      for (const id of throwingIds) jest.dontMock(id);
+    }
   });
 });
 

--- a/src/utils/appPaths.test.ts
+++ b/src/utils/appPaths.test.ts
@@ -4,71 +4,73 @@ import * as path from "node:path";
 import { md5 } from "@/utils/hash";
 import { COPILOT_APP_DIR_NAME, copilotAppDataDir, getVaultId } from "./appPaths";
 
-describe("copilotAppDataDir", () => {
-  it("is ~/.obsidian-copilot under the given home dir", () => {
-    expect(copilotAppDataDir("/Users/me")).toBe(path.join("/Users/me", ".obsidian-copilot"));
+describe("appPaths", () => {
+  describe("copilotAppDataDir()", () => {
+    it("is ~/.obsidian-copilot under the given home dir", () => {
+      expect(copilotAppDataDir("/Users/me")).toBe(path.join("/Users/me", ".obsidian-copilot"));
+    });
+
+    it("uses the dotted, obsidian-prefixed namespace (not ~/.copilot)", () => {
+      expect(COPILOT_APP_DIR_NAME).toBe(".obsidian-copilot");
+      // Guard against a regression to the GitHub-Copilot-CLI-colliding name.
+      expect(COPILOT_APP_DIR_NAME).not.toBe(".copilot");
+    });
+
+    it("throws the desktop-only error on non-desktop runtimes instead of a TypeError", () => {
+      const platform = Platform as { isMobile: boolean };
+      platform.isMobile = true;
+      try {
+        expect(() => copilotAppDataDir("/Users/me")).toThrow(/unavailable outside the desktop/);
+      } finally {
+        platform.isMobile = false;
+      }
+    });
   });
 
-  it("uses the dotted, obsidian-prefixed namespace (not ~/.copilot)", () => {
-    expect(COPILOT_APP_DIR_NAME).toBe(".obsidian-copilot");
-    // Guard against a regression to the GitHub-Copilot-CLI-colliding name.
-    expect(COPILOT_APP_DIR_NAME).not.toBe(".copilot");
+  describe("module evaluation", () => {
+    it("does not require Node built-ins at module evaluation time", () => {
+      // appPaths sits on the eager context-cache import graph, which mobile
+      // also evaluates; an eval-time require would crash the plugin at load.
+      const throwingIds = ["path", "node:path"];
+      try {
+        jest.isolateModules(() => {
+          for (const id of throwingIds) {
+            jest.doMock(id, () => {
+              throw new Error(`eager require of ${id}`);
+            });
+          }
+          expect(() => void jest.requireActual("./appPaths")).not.toThrow();
+        });
+      } finally {
+        for (const id of throwingIds) jest.dontMock(id);
+      }
+    });
   });
 
-  it("throws the desktop-only error on non-desktop runtimes instead of a TypeError", () => {
-    const platform = Platform as { isMobile: boolean };
-    platform.isMobile = true;
-    try {
-      expect(() => copilotAppDataDir("/Users/me")).toThrow(/unavailable outside the desktop/);
-    } finally {
-      platform.isMobile = false;
-    }
-  });
-});
+  describe("getVaultId()", () => {
+    const appWith = (adapter: unknown): App => ({ vault: { adapter } }) as unknown as App;
+    // The jsdom mock's FileSystemAdapter takes a base path; the real obsidian
+    // type declares a 0-arg constructor, so cast to build a hashable instance.
+    const FsAdapter = FileSystemAdapter as unknown as new (basePath: string) => FileSystemAdapter;
 
-describe("module evaluation", () => {
-  it("does not require Node built-ins at module evaluation time", () => {
-    // appPaths sits on the eager context-cache import graph, which mobile
-    // also evaluates; an eval-time require would crash the plugin at load.
-    const throwingIds = ["path", "node:path"];
-    try {
-      jest.isolateModules(() => {
-        for (const id of throwingIds) {
-          jest.doMock(id, () => {
-            throw new Error(`eager require of ${id}`);
-          });
-        }
-        expect(() => void jest.requireActual("./appPaths")).not.toThrow();
-      });
-    } finally {
-      for (const id of throwingIds) jest.dontMock(id);
-    }
-  });
-});
+    it("is the first 8 hex chars of md5(vaultBasePath) for a desktop adapter", () => {
+      const app = appWith(new FsAdapter("/Users/me/My Vault"));
+      expect(getVaultId(app)).toBe(md5("/Users/me/My Vault").slice(0, 8));
+      expect(getVaultId(app)).toHaveLength(8);
+    });
 
-describe("getVaultId", () => {
-  const appWith = (adapter: unknown): App => ({ vault: { adapter } }) as unknown as App;
-  // The jsdom mock's FileSystemAdapter takes a base path; the real obsidian
-  // type declares a 0-arg constructor, so cast to build a hashable instance.
-  const FsAdapter = FileSystemAdapter as unknown as new (basePath: string) => FileSystemAdapter;
+    it("stays equivalent to the legacy inline computation it replaced", () => {
+      const basePath = "/vault";
+      const app = appWith(new FsAdapter(basePath));
+      // The exact expression previously inlined in agentMode/index.ts.
+      const legacy = basePath ? md5(basePath).slice(0, 8) : "default";
+      expect(getVaultId(app)).toBe(legacy);
+    });
 
-  it("is the first 8 hex chars of md5(vaultBasePath) for a desktop adapter", () => {
-    const app = appWith(new FsAdapter("/Users/me/My Vault"));
-    expect(getVaultId(app)).toBe(md5("/Users/me/My Vault").slice(0, 8));
-    expect(getVaultId(app)).toHaveLength(8);
-  });
-
-  it("stays equivalent to the legacy inline computation it replaced", () => {
-    const basePath = "/vault";
-    const app = appWith(new FsAdapter(basePath));
-    // The exact expression previously inlined in agentMode/index.ts.
-    const legacy = basePath ? md5(basePath).slice(0, 8) : "default";
-    expect(getVaultId(app)).toBe(legacy);
-  });
-
-  it('falls back to "default" when the adapter is not a FileSystemAdapter', () => {
-    // e.g. mobile / in-memory adapters expose no stable absolute base path.
-    const app = appWith({ getBasePath: () => "/unused" });
-    expect(getVaultId(app)).toBe("default");
+    it('falls back to "default" when the adapter is not a FileSystemAdapter', () => {
+      // e.g. mobile / in-memory adapters expose no stable absolute base path.
+      const app = appWith({ getBasePath: () => "/unused" });
+      expect(getVaultId(app)).toBe("default");
+    });
   });
 });

--- a/src/utils/appPaths.ts
+++ b/src/utils/appPaths.ts
@@ -1,5 +1,5 @@
 import { type App, FileSystemAdapter } from "obsidian";
-import * as path from "node:path";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { md5 } from "@/utils/hash";
 
 /**
@@ -25,6 +25,7 @@ export const COPILOT_APP_DIR_NAME = ".obsidian-copilot";
  * `os.homedir()`.
  */
 export function copilotAppDataDir(homeDir: string): string {
+  const path = requireNodeModule<typeof import("node:path")>("path");
   return path.join(homeDir, COPILOT_APP_DIR_NAME);
 }
 

--- a/src/utils/binaryPath.test.ts
+++ b/src/utils/binaryPath.test.ts
@@ -1,8 +1,13 @@
+import { Platform } from "obsidian";
+import * as os from "node:os";
+import * as path from "node:path";
+
 import { resolveNodeToolBinDirs } from "@/utils/nodeToolBinDirs";
 
 import {
   augmentPathForDetection,
   detectionSearchDirs,
+  formatBinaryPathForDisplay,
   mergePath,
   WELL_KNOWN_BIN_DIRS,
 } from "./binaryPath";
@@ -66,5 +71,53 @@ describe("augmentPathForDetection", () => {
     // This is the exact PATH Obsidian sees when launched from Finder/Dock.
     const result = augmentPathForDetection("/usr/bin:/bin:/usr/sbin:/sbin");
     expect(result.split(":")).toContain("/opt/homebrew/bin");
+  });
+
+  test("throws the desktop-only error on non-desktop runtimes instead of a TypeError", () => {
+    const platform = Platform as { isMobile: boolean };
+    platform.isMobile = true;
+    try {
+      expect(() => augmentPathForDetection("/usr/bin")).toThrow(/unavailable outside the desktop/);
+    } finally {
+      platform.isMobile = false;
+    }
+  });
+});
+
+describe("formatBinaryPathForDisplay", () => {
+  test("collapses the home directory to ~ on desktop", () => {
+    const abs = path.join(os.homedir(), ".local", "bin", "claude");
+    expect(formatBinaryPathForDisplay(abs)).toMatch(/^~[/\\]/);
+  });
+
+  test("throws the desktop-only error on non-desktop runtimes instead of a TypeError", () => {
+    const platform = Platform as { isMobile: boolean };
+    platform.isMobile = true;
+    try {
+      expect(() => formatBinaryPathForDisplay("/x/y")).toThrow(/unavailable outside the desktop/);
+    } finally {
+      platform.isMobile = false;
+    }
+  });
+});
+
+describe("module evaluation", () => {
+  test("does not require Node built-ins at module evaluation time", () => {
+    // The module is on the eager settings-UI import graph, which mobile also
+    // evaluates; an eval-time require of a Node built-in would crash the
+    // plugin at load there.
+    const throwingIds = ["os", "fs", "path", "node:os", "node:fs", "node:path"];
+    try {
+      jest.isolateModules(() => {
+        for (const id of throwingIds) {
+          jest.doMock(id, () => {
+            throw new Error(`eager require of ${id}`);
+          });
+        }
+        expect(() => void jest.requireActual("./binaryPath")).not.toThrow();
+      });
+    } finally {
+      for (const id of throwingIds) jest.dontMock(id);
+    }
   });
 });

--- a/src/utils/binaryPath.test.ts
+++ b/src/utils/binaryPath.test.ts
@@ -18,106 +18,113 @@ jest.mock("@/utils/nodeToolBinDirs", () => ({ resolveNodeToolBinDirs: jest.fn(()
 
 const resolveMock = resolveNodeToolBinDirs as jest.MockedFunction<typeof resolveNodeToolBinDirs>;
 
-afterEach(() => resolveMock.mockReturnValue([]));
+describe("binaryPath", () => {
+  afterEach(() => resolveMock.mockReturnValue([]));
 
-describe("mergePath", () => {
-  test("prepends candidates and dedupes against inherited PATH", () => {
-    const result = mergePath(["/opt/homebrew/bin", "/usr/local/bin"], "/usr/bin:/bin");
-    expect(result).toBe("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin");
+  describe("mergePath()", () => {
+    test("prepends candidates and dedupes against inherited PATH", () => {
+      const result = mergePath(["/opt/homebrew/bin", "/usr/local/bin"], "/usr/bin:/bin");
+      expect(result).toBe("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin");
+    });
+
+    test("drops duplicates while preserving first-seen order", () => {
+      const result = mergePath(
+        ["/opt/homebrew/bin", "/usr/bin"],
+        "/usr/bin:/bin:/opt/homebrew/bin"
+      );
+      expect(result).toBe("/opt/homebrew/bin:/usr/bin:/bin");
+    });
+
+    test("handles undefined / empty inherited PATH", () => {
+      expect(mergePath(["/opt/homebrew/bin"], undefined)).toBe("/opt/homebrew/bin");
+      expect(mergePath(["/opt/homebrew/bin"], "")).toBe("/opt/homebrew/bin");
+    });
   });
 
-  test("drops duplicates while preserving first-seen order", () => {
-    const result = mergePath(["/opt/homebrew/bin", "/usr/bin"], "/usr/bin:/bin:/opt/homebrew/bin");
-    expect(result).toBe("/opt/homebrew/bin:/usr/bin:/bin");
+  describe("detectionSearchDirs()", () => {
+    test("lists version-manager bins ahead of the well-known dirs", () => {
+      const nvmBin = "/home/me/.nvm/versions/node/v20.18.0/bin";
+      resolveMock.mockReturnValue([nvmBin]);
+      const dirs = detectionSearchDirs();
+      expect(dirs[0]).toBe(nvmBin);
+      expect(dirs.indexOf(nvmBin)).toBeLessThan(dirs.indexOf("/opt/homebrew/bin"));
+      expect(dirs).toEqual([nvmBin, ...WELL_KNOWN_BIN_DIRS]);
+    });
   });
 
-  test("handles undefined / empty inherited PATH", () => {
-    expect(mergePath(["/opt/homebrew/bin"], undefined)).toBe("/opt/homebrew/bin");
-    expect(mergePath(["/opt/homebrew/bin"], "")).toBe("/opt/homebrew/bin");
-  });
-});
+  describe("augmentPathForDetection()", () => {
+    test("prepends all well-known dirs ahead of the inherited PATH", () => {
+      const result = augmentPathForDetection("/usr/bin:/bin");
+      const parts = result.split(":");
+      for (const dir of WELL_KNOWN_BIN_DIRS) {
+        expect(parts).toContain(dir);
+      }
+      // Homebrew must come before whatever launchd already had.
+      expect(parts.indexOf("/opt/homebrew/bin")).toBeLessThan(parts.indexOf("/usr/bin"));
+    });
 
-describe("detectionSearchDirs", () => {
-  test("lists version-manager bins ahead of the well-known dirs", () => {
-    const nvmBin = "/home/me/.nvm/versions/node/v20.18.0/bin";
-    resolveMock.mockReturnValue([nvmBin]);
-    const dirs = detectionSearchDirs();
-    expect(dirs[0]).toBe(nvmBin);
-    expect(dirs.indexOf(nvmBin)).toBeLessThan(dirs.indexOf("/opt/homebrew/bin"));
-    expect(dirs).toEqual([nvmBin, ...WELL_KNOWN_BIN_DIRS]);
-  });
-});
+    test("prepends a discovered version-manager dir ahead of the inherited PATH", () => {
+      const nvmBin = "/home/me/.nvm/versions/node/v20.18.0/bin";
+      resolveMock.mockReturnValue([nvmBin]);
+      const parts = augmentPathForDetection("/usr/bin:/bin:/usr/sbin:/sbin").split(":");
+      expect(parts[0]).toBe(nvmBin);
+      expect(parts.indexOf(nvmBin)).toBeLessThan(parts.indexOf("/usr/bin"));
+    });
 
-describe("augmentPathForDetection", () => {
-  test("prepends all well-known dirs ahead of the inherited PATH", () => {
-    const result = augmentPathForDetection("/usr/bin:/bin");
-    const parts = result.split(":");
-    for (const dir of WELL_KNOWN_BIN_DIRS) {
-      expect(parts).toContain(dir);
-    }
-    // Homebrew must come before whatever launchd already had.
-    expect(parts.indexOf("/opt/homebrew/bin")).toBeLessThan(parts.indexOf("/usr/bin"));
-  });
+    test("covers the sparse launchd PATH that triggers the bug", () => {
+      // This is the exact PATH Obsidian sees when launched from Finder/Dock.
+      const result = augmentPathForDetection("/usr/bin:/bin:/usr/sbin:/sbin");
+      expect(result.split(":")).toContain("/opt/homebrew/bin");
+    });
 
-  test("prepends a discovered version-manager dir ahead of the inherited PATH", () => {
-    const nvmBin = "/home/me/.nvm/versions/node/v20.18.0/bin";
-    resolveMock.mockReturnValue([nvmBin]);
-    const parts = augmentPathForDetection("/usr/bin:/bin:/usr/sbin:/sbin").split(":");
-    expect(parts[0]).toBe(nvmBin);
-    expect(parts.indexOf(nvmBin)).toBeLessThan(parts.indexOf("/usr/bin"));
-  });
-
-  test("covers the sparse launchd PATH that triggers the bug", () => {
-    // This is the exact PATH Obsidian sees when launched from Finder/Dock.
-    const result = augmentPathForDetection("/usr/bin:/bin:/usr/sbin:/sbin");
-    expect(result.split(":")).toContain("/opt/homebrew/bin");
+    test("throws the desktop-only error on non-desktop runtimes instead of a TypeError", () => {
+      const platform = Platform as { isMobile: boolean };
+      platform.isMobile = true;
+      try {
+        expect(() => augmentPathForDetection("/usr/bin")).toThrow(
+          /unavailable outside the desktop/
+        );
+      } finally {
+        platform.isMobile = false;
+      }
+    });
   });
 
-  test("throws the desktop-only error on non-desktop runtimes instead of a TypeError", () => {
-    const platform = Platform as { isMobile: boolean };
-    platform.isMobile = true;
-    try {
-      expect(() => augmentPathForDetection("/usr/bin")).toThrow(/unavailable outside the desktop/);
-    } finally {
-      platform.isMobile = false;
-    }
-  });
-});
+  describe("formatBinaryPathForDisplay()", () => {
+    test("collapses the home directory to ~ on desktop", () => {
+      const abs = path.join(os.homedir(), ".local", "bin", "claude");
+      expect(formatBinaryPathForDisplay(abs)).toMatch(/^~[/\\]/);
+    });
 
-describe("formatBinaryPathForDisplay", () => {
-  test("collapses the home directory to ~ on desktop", () => {
-    const abs = path.join(os.homedir(), ".local", "bin", "claude");
-    expect(formatBinaryPathForDisplay(abs)).toMatch(/^~[/\\]/);
+    test("throws the desktop-only error on non-desktop runtimes instead of a TypeError", () => {
+      const platform = Platform as { isMobile: boolean };
+      platform.isMobile = true;
+      try {
+        expect(() => formatBinaryPathForDisplay("/x/y")).toThrow(/unavailable outside the desktop/);
+      } finally {
+        platform.isMobile = false;
+      }
+    });
   });
 
-  test("throws the desktop-only error on non-desktop runtimes instead of a TypeError", () => {
-    const platform = Platform as { isMobile: boolean };
-    platform.isMobile = true;
-    try {
-      expect(() => formatBinaryPathForDisplay("/x/y")).toThrow(/unavailable outside the desktop/);
-    } finally {
-      platform.isMobile = false;
-    }
-  });
-});
-
-describe("module evaluation", () => {
-  test("does not require Node built-ins at module evaluation time", () => {
-    // The module is on the eager settings-UI import graph, which mobile also
-    // evaluates; an eval-time require of a Node built-in would crash the
-    // plugin at load there.
-    const throwingIds = ["os", "fs", "path", "node:os", "node:fs", "node:path"];
-    try {
-      jest.isolateModules(() => {
-        for (const id of throwingIds) {
-          jest.doMock(id, () => {
-            throw new Error(`eager require of ${id}`);
-          });
-        }
-        expect(() => void jest.requireActual("./binaryPath")).not.toThrow();
-      });
-    } finally {
-      for (const id of throwingIds) jest.dontMock(id);
-    }
+  describe("module evaluation", () => {
+    test("does not require Node built-ins at module evaluation time", () => {
+      // The module is on the eager settings-UI import graph, which mobile also
+      // evaluates; an eval-time require of a Node built-in would crash the
+      // plugin at load there.
+      const throwingIds = ["os", "fs", "path", "node:os", "node:fs", "node:path"];
+      try {
+        jest.isolateModules(() => {
+          for (const id of throwingIds) {
+            jest.doMock(id, () => {
+              throw new Error(`eager require of ${id}`);
+            });
+          }
+          expect(() => void jest.requireActual("./binaryPath")).not.toThrow();
+        });
+      } finally {
+        for (const id of throwingIds) jest.dontMock(id);
+      }
+    });
   });
 });

--- a/src/utils/binaryPath.ts
+++ b/src/utils/binaryPath.ts
@@ -1,6 +1,4 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
-
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { collapseHomeDir } from "@/utils/pathUtils";
 import { resolveNodeToolBinDirs } from "@/utils/nodeToolBinDirs";
 
@@ -48,6 +46,8 @@ export function mergePath(candidates: readonly string[], inherited: string | und
  * nvm `node` on PATH.
  */
 function nodeToolBinDirs(): string[] {
+  const os = requireNodeModule<typeof import("node:os")>("os");
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
   return resolveNodeToolBinDirs({
     homeDir: os.homedir(),
     platform: process.platform,
@@ -96,5 +96,6 @@ export function augmentPathForDetection(inherited: string | undefined): string {
  * Display-only — the stored/spawned path keeps its real absolute form.
  */
 export function formatBinaryPathForDisplay(absolutePath: string): string {
+  const os = requireNodeModule<typeof import("node:os")>("os");
   return collapseHomeDir(absolutePath, os.homedir(), process.platform === "win32");
 }

--- a/src/utils/desktopRuntime.test.ts
+++ b/src/utils/desktopRuntime.test.ts
@@ -1,6 +1,7 @@
 jest.mock("obsidian", () => ({ Platform: { isDesktopApp: false, isMobile: false } }));
 
-import { isDesktopRuntime } from "./desktopRuntime";
+import { EventEmitter } from "node:events";
+import { isDesktopRuntime, requireNodeModule } from "./desktopRuntime";
 
 const obsidian: { Platform: { isDesktopApp: boolean; isMobile: boolean } } =
   jest.requireMock("obsidian");
@@ -31,5 +32,33 @@ describe("isDesktopRuntime", () => {
   it("is false on any non-desktop runtime", () => {
     setPlatform(false, false);
     expect(isDesktopRuntime()).toBe(false);
+  });
+});
+
+describe("requireNodeModule", () => {
+  it("returns the live built-in module on desktop — the same instance static importers see", () => {
+    setPlatform(true, false);
+    // Node's events module IS the EventEmitter class; identity (not a copy)
+    // is what lets rendererEventsShim patch the property every importer reads.
+    const events = requireNodeModule<typeof import("node:events")>("events");
+    expect(events.EventEmitter).toBe(EventEmitter);
+  });
+
+  it("resolves working module functions on desktop", () => {
+    setPlatform(true, false);
+    const path = requireNodeModule<typeof import("node:path")>("path");
+    expect(path.posix.join("a", "b")).toBe("a/b");
+  });
+
+  it("throws a clear error naming the module on real mobile", () => {
+    setPlatform(false, true);
+    expect(() => requireNodeModule("path")).toThrow(
+      'Node built-in module "path" is unavailable outside the desktop runtime.'
+    );
+  });
+
+  it("throws under app.emulateMobile(true) — isDesktopApp stays true but Node is stubbed", () => {
+    setPlatform(true, true);
+    expect(() => requireNodeModule("child_process")).toThrow(/unavailable outside the desktop/);
   });
 });

--- a/src/utils/desktopRuntime.test.ts
+++ b/src/utils/desktopRuntime.test.ts
@@ -11,54 +11,56 @@ function setPlatform(isDesktopApp: boolean, isMobile: boolean): void {
   obsidian.Platform.isMobile = isMobile;
 }
 
-describe("isDesktopRuntime", () => {
-  it("is true on the real desktop app", () => {
-    setPlatform(true, false);
-    expect(isDesktopRuntime()).toBe(true);
+describe("desktopRuntime", () => {
+  describe("isDesktopRuntime()", () => {
+    it("is true on the real desktop app", () => {
+      setPlatform(true, false);
+      expect(isDesktopRuntime()).toBe(true);
+    });
+
+    it("is false under app.emulateMobile(true) — isDesktopApp stays true but isMobile flips", () => {
+      // The bug this guards: gating only on Platform.isDesktopApp let desktop-only
+      // code load under emulateMobile (where Node is stubbed), crashing the plugin.
+      setPlatform(true, true);
+      expect(isDesktopRuntime()).toBe(false);
+    });
+
+    it("is false on real mobile", () => {
+      setPlatform(false, true);
+      expect(isDesktopRuntime()).toBe(false);
+    });
+
+    it("is false on any non-desktop runtime", () => {
+      setPlatform(false, false);
+      expect(isDesktopRuntime()).toBe(false);
+    });
   });
 
-  it("is false under app.emulateMobile(true) — isDesktopApp stays true but isMobile flips", () => {
-    // The bug this guards: gating only on Platform.isDesktopApp let desktop-only
-    // code load under emulateMobile (where Node is stubbed), crashing the plugin.
-    setPlatform(true, true);
-    expect(isDesktopRuntime()).toBe(false);
-  });
+  describe("requireNodeModule()", () => {
+    it("returns the live built-in module on desktop — the same instance static importers see", () => {
+      setPlatform(true, false);
+      // Node's events module IS the EventEmitter class; identity (not a copy)
+      // is what lets rendererEventsShim patch the property every importer reads.
+      const events = requireNodeModule<typeof import("node:events")>("events");
+      expect(events.EventEmitter).toBe(EventEmitter);
+    });
 
-  it("is false on real mobile", () => {
-    setPlatform(false, true);
-    expect(isDesktopRuntime()).toBe(false);
-  });
+    it("resolves working module functions on desktop", () => {
+      setPlatform(true, false);
+      const path = requireNodeModule<typeof import("node:path")>("path");
+      expect(path.posix.join("a", "b")).toBe("a/b");
+    });
 
-  it("is false on any non-desktop runtime", () => {
-    setPlatform(false, false);
-    expect(isDesktopRuntime()).toBe(false);
-  });
-});
+    it("throws a clear error naming the module on real mobile", () => {
+      setPlatform(false, true);
+      expect(() => requireNodeModule("path")).toThrow(
+        'Node built-in module "path" is unavailable outside the desktop runtime.'
+      );
+    });
 
-describe("requireNodeModule", () => {
-  it("returns the live built-in module on desktop — the same instance static importers see", () => {
-    setPlatform(true, false);
-    // Node's events module IS the EventEmitter class; identity (not a copy)
-    // is what lets rendererEventsShim patch the property every importer reads.
-    const events = requireNodeModule<typeof import("node:events")>("events");
-    expect(events.EventEmitter).toBe(EventEmitter);
-  });
-
-  it("resolves working module functions on desktop", () => {
-    setPlatform(true, false);
-    const path = requireNodeModule<typeof import("node:path")>("path");
-    expect(path.posix.join("a", "b")).toBe("a/b");
-  });
-
-  it("throws a clear error naming the module on real mobile", () => {
-    setPlatform(false, true);
-    expect(() => requireNodeModule("path")).toThrow(
-      'Node built-in module "path" is unavailable outside the desktop runtime.'
-    );
-  });
-
-  it("throws under app.emulateMobile(true) — isDesktopApp stays true but Node is stubbed", () => {
-    setPlatform(true, true);
-    expect(() => requireNodeModule("child_process")).toThrow(/unavailable outside the desktop/);
+    it("throws under app.emulateMobile(true) — isDesktopApp stays true but Node is stubbed", () => {
+      setPlatform(true, true);
+      expect(() => requireNodeModule("child_process")).toThrow(/unavailable outside the desktop/);
+    });
   });
 });

--- a/src/utils/desktopRuntime.ts
+++ b/src/utils/desktopRuntime.ts
@@ -16,3 +16,29 @@ export function isDesktopRuntime(): boolean {
   // eslint-disable-next-line no-restricted-properties -- this helper owns the canonical check
   return Platform.isDesktopApp && !Platform.isMobile;
 }
+
+/**
+ * Lazily load a Node built-in module at call time, guarded by
+ * {@link isDesktopRuntime}.
+ *
+ * A static `import` of a Node built-in compiles to a module-evaluation-time
+ * `require`, which also runs on mobile — where the built-ins resolve to
+ * `undefined` — so any module-scope use crashes the whole plugin at load.
+ * Routing built-in access through this accessor keeps the module graph
+ * mobile-safe by construction: nothing touches Node until a desktop-gated
+ * code path actually runs, and a non-desktop caller gets a clear error
+ * instead of an `undefined`-module TypeError. Type the result with an erased
+ * `typeof import("node:...")` query so typing stays exact at zero runtime
+ * cost.
+ *
+ * @param id - Built-in module id without the `node:` prefix (e.g. `"path"`,
+ *   `"child_process"`) — the form the desktop runtime's `require` resolves
+ *   and the same module instance the `node:`-prefixed id names.
+ */
+export function requireNodeModule<T>(id: string): T {
+  if (!isDesktopRuntime()) {
+    throw new Error(`Node built-in module "${id}" is unavailable outside the desktop runtime.`);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- runtime require is the point: deferring resolution to call time keeps Node built-ins off the mobile load path
+  return require(id) as T;
+}

--- a/src/utils/detectBinary.test.ts
+++ b/src/utils/detectBinary.test.ts
@@ -39,172 +39,174 @@ jest.mock("child_process", () => {
 });
 
 describe("detectBinary", () => {
-  const originalPlatform = process.platform;
-  const originalPath = process.env.PATH;
+  describe("detectBinary()", () => {
+    const originalPlatform = process.platform;
+    const originalPath = process.env.PATH;
 
-  beforeEach(() => {
-    execFileMock.mockReset();
-  });
+    beforeEach(() => {
+      execFileMock.mockReset();
+    });
 
-  afterEach(() => {
-    Object.defineProperty(process, "platform", { value: originalPlatform });
-    process.env.PATH = originalPath;
-  });
+    afterEach(() => {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+      process.env.PATH = originalPath;
+    });
 
-  function setPlatform(p: NodeJS.Platform): void {
-    Object.defineProperty(process, "platform", { value: p });
-  }
-
-  test("rejects binary names with invalid characters", async () => {
-    await expect(detectBinary("../evil")).rejects.toThrow(/Invalid binary name/);
-    await expect(detectBinary("a b")).rejects.toThrow(/Invalid binary name/);
-    expect(execFileMock).not.toHaveBeenCalled();
-  });
-
-  test("posix: augments PATH with /opt/homebrew/bin and /usr/local/bin ahead of inherited PATH", async () => {
-    setPlatform("darwin");
-    // The sparse launchd PATH that triggers the bug on macOS GUI launches.
-    process.env.PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
-
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-      cb(null, "/opt/homebrew/bin/codex-acp\n", "")
-    );
-
-    const found = await detectBinary("codex-acp");
-    expect(found).toBe("/opt/homebrew/bin/codex-acp");
-
-    expect(execFileMock).toHaveBeenCalledTimes(1);
-    const [cmd, args, opts] = execFileMock.mock.calls[0];
-    expect(cmd).toBe("which");
-    expect(args).toEqual(["codex-acp"]);
-    expect(opts.env).toBeDefined();
-    const pathParts = (opts.env?.PATH ?? "").split(":");
-    expect(pathParts).toContain("/opt/homebrew/bin");
-    expect(pathParts).toContain("/usr/local/bin");
-    // Augmented dirs must precede whatever the GUI shell already had.
-    expect(pathParts.indexOf("/opt/homebrew/bin")).toBeLessThan(pathParts.indexOf("/usr/bin"));
-  });
-
-  test("windows: augments PATH and calls `where`", async () => {
-    setPlatform("win32");
-    process.env.PATH = "C:\\Windows\\System32;C:\\Windows";
-
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-      cb(null, "C:\\tools\\codex-acp.exe\r\n", "")
-    );
-
-    const found = await detectBinary("codex-acp");
-    expect(found).toBe("C:\\tools\\codex-acp.exe");
-
-    const [cmd, , opts] = execFileMock.mock.calls[0];
-    expect(cmd).toBe("where");
-    // A fresh env object (not process.env) with an augmented PATH, so the
-    // GUI-app sparse PATH still reaches %APPDATA%\npm etc.
-    expect(opts.env).not.toBe(process.env);
-    expect(opts.env?.PATH).toContain("C:\\Windows\\System32");
-  });
-
-  test("windows: prefers the .exe over a sibling .cmd shim", async () => {
-    setPlatform("win32");
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-      cb(null, "C:\\npm\\codex-acp.cmd\r\nC:\\npm\\codex-acp.exe\r\n", "")
-    );
-    await expect(detectBinary("codex-acp")).resolves.toBe("C:\\npm\\codex-acp.exe");
-  });
-
-  test("windows: treats a .cmd-only result as not found (unspawnable over stdio)", async () => {
-    setPlatform("win32");
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-      cb(null, "C:\\npm\\codex-acp.cmd\r\nC:\\npm\\codex-acp.ps1\r\n", "")
-    );
-    await expect(detectBinary("codex-acp")).resolves.toBeNull();
-  });
-
-  test("windows: prefers the .exe over a sibling extensionless cmd-shim", async () => {
-    setPlatform("win32");
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-      cb(null, "C:\\npm\\codex-acp\r\nC:\\npm\\codex-acp.exe\r\n", "")
-    );
-    await expect(detectBinary("codex-acp")).resolves.toBe("C:\\npm\\codex-acp.exe");
-  });
-
-  test("windows: treats an extensionless cmd-shim-only result as not found", async () => {
-    setPlatform("win32");
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-      cb(null, "C:\\npm\\codex-acp\r\nC:\\npm\\codex-acp.ps1\r\n", "")
-    );
-    await expect(detectBinary("codex-acp")).resolves.toBeNull();
-  });
-
-  test("returns null when the lookup tool exits non-zero", async () => {
-    setPlatform("darwin");
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-      cb(new Error("exit code 1"), "", "")
-    );
-    await expect(detectBinary("missing")).resolves.toBeNull();
-  });
-
-  test("returns only the first match when `which`/`where` print several", async () => {
-    setPlatform("darwin");
-    execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
-      cb(null, "/opt/homebrew/bin/codex-acp\n/usr/local/bin/codex-acp\n", "")
-    );
-    await expect(detectBinary("codex-acp")).resolves.toBe("/opt/homebrew/bin/codex-acp");
-  });
-
-  test("does not require Node built-ins at module evaluation time", () => {
-    // A module-scope promisify(execFile) dereferences an undefined module on
-    // mobile and kills the plugin at load. Bare "child_process" is file-wide
-    // mocked above so it stays benign here; an eager regression still
-    // surfaces through "util" (module-scope promisify) or any node:-prefixed
-    // static import.
-    const throwingIds = [
-      "util",
-      "fs",
-      "path",
-      "os",
-      "node:child_process",
-      "node:util",
-      "node:fs",
-      "node:path",
-      "node:os",
-    ];
-    try {
-      jest.isolateModules(() => {
-        for (const id of throwingIds) {
-          jest.doMock(id, () => {
-            throw new Error(`eager require of ${id}`);
-          });
-        }
-        expect(() => void jest.requireActual("./detectBinary")).not.toThrow();
-      });
-    } finally {
-      for (const id of throwingIds) jest.dontMock(id);
+    function setPlatform(p: NodeJS.Platform): void {
+      Object.defineProperty(process, "platform", { value: p });
     }
-  });
 
-  test("rejects with the desktop-only error on non-desktop runtimes instead of a TypeError", async () => {
-    const platform = Platform as { isMobile: boolean };
-    platform.isMobile = true;
-    try {
-      await expect(detectBinary("codex-acp")).rejects.toThrow(/unavailable outside the desktop/);
+    test("rejects binary names with invalid characters", async () => {
+      await expect(detectBinary("../evil")).rejects.toThrow(/Invalid binary name/);
+      await expect(detectBinary("a b")).rejects.toThrow(/Invalid binary name/);
       expect(execFileMock).not.toHaveBeenCalled();
-    } finally {
-      platform.isMobile = false;
-    }
-  });
-});
+    });
 
-describe("validateExecutableFile", () => {
-  test("rejects with the desktop-only error on non-desktop runtimes instead of a TypeError", async () => {
-    const platform = Platform as { isMobile: boolean };
-    platform.isMobile = true;
-    try {
-      await expect(validateExecutableFile("/usr/local/bin/tool")).rejects.toThrow(
-        /unavailable outside the desktop/
+    test("posix: augments PATH with /opt/homebrew/bin and /usr/local/bin ahead of inherited PATH", async () => {
+      setPlatform("darwin");
+      // The sparse launchd PATH that triggers the bug on macOS GUI launches.
+      process.env.PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+
+      execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+        cb(null, "/opt/homebrew/bin/codex-acp\n", "")
       );
-    } finally {
-      platform.isMobile = false;
-    }
+
+      const found = await detectBinary("codex-acp");
+      expect(found).toBe("/opt/homebrew/bin/codex-acp");
+
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+      const [cmd, args, opts] = execFileMock.mock.calls[0];
+      expect(cmd).toBe("which");
+      expect(args).toEqual(["codex-acp"]);
+      expect(opts.env).toBeDefined();
+      const pathParts = (opts.env?.PATH ?? "").split(":");
+      expect(pathParts).toContain("/opt/homebrew/bin");
+      expect(pathParts).toContain("/usr/local/bin");
+      // Augmented dirs must precede whatever the GUI shell already had.
+      expect(pathParts.indexOf("/opt/homebrew/bin")).toBeLessThan(pathParts.indexOf("/usr/bin"));
+    });
+
+    test("windows: augments PATH and calls `where`", async () => {
+      setPlatform("win32");
+      process.env.PATH = "C:\\Windows\\System32;C:\\Windows";
+
+      execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+        cb(null, "C:\\tools\\codex-acp.exe\r\n", "")
+      );
+
+      const found = await detectBinary("codex-acp");
+      expect(found).toBe("C:\\tools\\codex-acp.exe");
+
+      const [cmd, , opts] = execFileMock.mock.calls[0];
+      expect(cmd).toBe("where");
+      // A fresh env object (not process.env) with an augmented PATH, so the
+      // GUI-app sparse PATH still reaches %APPDATA%\npm etc.
+      expect(opts.env).not.toBe(process.env);
+      expect(opts.env?.PATH).toContain("C:\\Windows\\System32");
+    });
+
+    test("windows: prefers the .exe over a sibling .cmd shim", async () => {
+      setPlatform("win32");
+      execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+        cb(null, "C:\\npm\\codex-acp.cmd\r\nC:\\npm\\codex-acp.exe\r\n", "")
+      );
+      await expect(detectBinary("codex-acp")).resolves.toBe("C:\\npm\\codex-acp.exe");
+    });
+
+    test("windows: treats a .cmd-only result as not found (unspawnable over stdio)", async () => {
+      setPlatform("win32");
+      execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+        cb(null, "C:\\npm\\codex-acp.cmd\r\nC:\\npm\\codex-acp.ps1\r\n", "")
+      );
+      await expect(detectBinary("codex-acp")).resolves.toBeNull();
+    });
+
+    test("windows: prefers the .exe over a sibling extensionless cmd-shim", async () => {
+      setPlatform("win32");
+      execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+        cb(null, "C:\\npm\\codex-acp\r\nC:\\npm\\codex-acp.exe\r\n", "")
+      );
+      await expect(detectBinary("codex-acp")).resolves.toBe("C:\\npm\\codex-acp.exe");
+    });
+
+    test("windows: treats an extensionless cmd-shim-only result as not found", async () => {
+      setPlatform("win32");
+      execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+        cb(null, "C:\\npm\\codex-acp\r\nC:\\npm\\codex-acp.ps1\r\n", "")
+      );
+      await expect(detectBinary("codex-acp")).resolves.toBeNull();
+    });
+
+    test("returns null when the lookup tool exits non-zero", async () => {
+      setPlatform("darwin");
+      execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+        cb(new Error("exit code 1"), "", "")
+      );
+      await expect(detectBinary("missing")).resolves.toBeNull();
+    });
+
+    test("returns only the first match when `which`/`where` print several", async () => {
+      setPlatform("darwin");
+      execFileMock.mockImplementation((_cmd, _args, _opts, cb) =>
+        cb(null, "/opt/homebrew/bin/codex-acp\n/usr/local/bin/codex-acp\n", "")
+      );
+      await expect(detectBinary("codex-acp")).resolves.toBe("/opt/homebrew/bin/codex-acp");
+    });
+
+    test("does not require Node built-ins at module evaluation time", () => {
+      // A module-scope promisify(execFile) dereferences an undefined module on
+      // mobile and kills the plugin at load. Bare "child_process" is file-wide
+      // mocked above so it stays benign here; an eager regression still
+      // surfaces through "util" (module-scope promisify) or any node:-prefixed
+      // static import.
+      const throwingIds = [
+        "util",
+        "fs",
+        "path",
+        "os",
+        "node:child_process",
+        "node:util",
+        "node:fs",
+        "node:path",
+        "node:os",
+      ];
+      try {
+        jest.isolateModules(() => {
+          for (const id of throwingIds) {
+            jest.doMock(id, () => {
+              throw new Error(`eager require of ${id}`);
+            });
+          }
+          expect(() => void jest.requireActual("./detectBinary")).not.toThrow();
+        });
+      } finally {
+        for (const id of throwingIds) jest.dontMock(id);
+      }
+    });
+
+    test("rejects with the desktop-only error on non-desktop runtimes instead of a TypeError", async () => {
+      const platform = Platform as { isMobile: boolean };
+      platform.isMobile = true;
+      try {
+        await expect(detectBinary("codex-acp")).rejects.toThrow(/unavailable outside the desktop/);
+        expect(execFileMock).not.toHaveBeenCalled();
+      } finally {
+        platform.isMobile = false;
+      }
+    });
+  });
+
+  describe("validateExecutableFile()", () => {
+    test("rejects with the desktop-only error on non-desktop runtimes instead of a TypeError", async () => {
+      const platform = Platform as { isMobile: boolean };
+      platform.isMobile = true;
+      try {
+        await expect(validateExecutableFile("/usr/local/bin/tool")).rejects.toThrow(
+          /unavailable outside the desktop/
+        );
+      } finally {
+        platform.isMobile = false;
+      }
+    });
   });
 });

--- a/src/utils/detectBinary.test.ts
+++ b/src/utils/detectBinary.test.ts
@@ -1,6 +1,7 @@
+import { Platform } from "obsidian";
 import { promisify } from "node:util";
 
-import { detectBinary } from "./detectBinary";
+import { detectBinary, validateExecutableFile } from "./detectBinary";
 
 // Keep the augmented PATH deterministic across CI/dev machines; the live
 // version-manager probe is covered in nodeToolBinDirs.test.ts.
@@ -16,7 +17,9 @@ type ExecFileArgs = [
 
 const execFileMock = jest.fn<void, ExecFileArgs>();
 
-jest.mock("node:child_process", () => {
+// Mock the bare module id — the form requireNodeModule() resolves at call
+// time (it names the same core module instance as "node:child_process").
+jest.mock("child_process", () => {
   const fn = (...args: ExecFileArgs): void => execFileMock(...args);
   // `node:util.promisify` consults this symbol to resolve to `{ stdout, stderr }`.
   // Without it the promisified call resolves to just `stdout`, which would
@@ -147,5 +150,61 @@ describe("detectBinary", () => {
       cb(null, "/opt/homebrew/bin/codex-acp\n/usr/local/bin/codex-acp\n", "")
     );
     await expect(detectBinary("codex-acp")).resolves.toBe("/opt/homebrew/bin/codex-acp");
+  });
+
+  test("does not require Node built-ins at module evaluation time", () => {
+    // A module-scope promisify(execFile) dereferences an undefined module on
+    // mobile and kills the plugin at load. Bare "child_process" is file-wide
+    // mocked above so it stays benign here; an eager regression still
+    // surfaces through "util" (module-scope promisify) or any node:-prefixed
+    // static import.
+    const throwingIds = [
+      "util",
+      "fs",
+      "path",
+      "os",
+      "node:child_process",
+      "node:util",
+      "node:fs",
+      "node:path",
+      "node:os",
+    ];
+    try {
+      jest.isolateModules(() => {
+        for (const id of throwingIds) {
+          jest.doMock(id, () => {
+            throw new Error(`eager require of ${id}`);
+          });
+        }
+        expect(() => void jest.requireActual("./detectBinary")).not.toThrow();
+      });
+    } finally {
+      for (const id of throwingIds) jest.dontMock(id);
+    }
+  });
+
+  test("rejects with the desktop-only error on non-desktop runtimes instead of a TypeError", async () => {
+    const platform = Platform as { isMobile: boolean };
+    platform.isMobile = true;
+    try {
+      await expect(detectBinary("codex-acp")).rejects.toThrow(/unavailable outside the desktop/);
+      expect(execFileMock).not.toHaveBeenCalled();
+    } finally {
+      platform.isMobile = false;
+    }
+  });
+});
+
+describe("validateExecutableFile", () => {
+  test("rejects with the desktop-only error on non-desktop runtimes instead of a TypeError", async () => {
+    const platform = Platform as { isMobile: boolean };
+    platform.isMobile = true;
+    try {
+      await expect(validateExecutableFile("/usr/local/bin/tool")).rejects.toThrow(
+        /unavailable outside the desktop/
+      );
+    } finally {
+      platform.isMobile = false;
+    }
   });
 });

--- a/src/utils/detectBinary.ts
+++ b/src/utils/detectBinary.ts
@@ -1,11 +1,19 @@
-import { execFile } from "node:child_process";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import { promisify } from "node:util";
-
 import { augmentPathForDetection } from "@/utils/binaryPath";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
-const execFileAsync = promisify(execFile);
+/**
+ * Promisified `execFile` resolved at call time so the module evaluates
+ * without touching Node built-ins (mobile-safe module graph).
+ */
+function getExecFileAsync(): (
+  cmd: string,
+  args: readonly string[],
+  options: { timeout: number; env: NodeJS.ProcessEnv }
+) => Promise<{ stdout: string; stderr: string }> {
+  const { execFile } = requireNodeModule<typeof import("node:child_process")>("child_process");
+  const { promisify } = requireNodeModule<typeof import("node:util")>("util");
+  return promisify(execFile);
+}
 
 /**
  * Allowed shape for binary names handed to `which`/`where`. Restricts to
@@ -48,6 +56,7 @@ export async function detectBinary(name: string): Promise<string | null> {
   const isWindows = process.platform === "win32";
   const cmd = isWindows ? "where" : "which";
   const env = { ...process.env, PATH: augmentPathForDetection(process.env.PATH) };
+  const execFileAsync = getExecFileAsync();
   try {
     const { stdout } = await execFileAsync(cmd, [name], { timeout: 5000, env });
     const matches = stdout
@@ -70,6 +79,7 @@ export async function detectBinary(name: string): Promise<string | null> {
  * than handing back a path that fails to launch.
  */
 function pickWindowsExecutable(matches: string[]): string | null {
+  const path = requireNodeModule<typeof import("node:path")>("path");
   const spawnable = matches.filter(
     (m) => !/\.(cmd|bat|ps1)$/i.test(m) && path.win32.extname(m) !== ""
   );
@@ -84,6 +94,7 @@ function pickWindowsExecutable(matches: string[]): string | null {
  * misconfigurations at config time rather than at spawn time.
  */
 export async function validateExecutableFile(p: string): Promise<string | null> {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
   const stat = await fs.promises.stat(p).catch(() => null);
   if (!stat || !stat.isFile()) return `No file at ${p}.`;
   if (process.platform !== "win32") {

--- a/src/utils/nodeToolBinDirs.test.ts
+++ b/src/utils/nodeToolBinDirs.test.ts
@@ -1,3 +1,5 @@
+import { Platform } from "obsidian";
+
 import { resolveNodeToolBinDirs } from "@/utils/nodeToolBinDirs";
 import type { NodeToolBinDirsInput, NodeToolFs } from "@/utils/nodeToolBinDirs";
 
@@ -238,5 +240,35 @@ describe("resolveNodeToolBinDirs (windows)", () => {
       winInput({ env: { NVM_SYMLINK: symlink }, fs: makeFs({ dirs: [symlink] }) })
     );
     expect(dirs).toContain(symlink);
+  });
+});
+
+describe("module evaluation", () => {
+  test("does not require Node built-ins at module evaluation time", () => {
+    // The module is imported by settings-UI helpers that mobile also
+    // evaluates; an eval-time require would crash the plugin at load there.
+    const throwingIds = ["path", "node:path"];
+    try {
+      jest.isolateModules(() => {
+        for (const id of throwingIds) {
+          jest.doMock(id, () => {
+            throw new Error(`eager require of ${id}`);
+          });
+        }
+        expect(() => void jest.requireActual("./nodeToolBinDirs")).not.toThrow();
+      });
+    } finally {
+      for (const id of throwingIds) jest.dontMock(id);
+    }
+  });
+
+  test("throws the desktop-only error when resolving on non-desktop runtimes", () => {
+    const platform = Platform as { isMobile: boolean };
+    platform.isMobile = true;
+    try {
+      expect(() => resolveNodeToolBinDirs(unixInput())).toThrow(/unavailable outside the desktop/);
+    } finally {
+      platform.isMobile = false;
+    }
   });
 });

--- a/src/utils/nodeToolBinDirs.test.ts
+++ b/src/utils/nodeToolBinDirs.test.ts
@@ -44,231 +44,240 @@ function unixInput(overrides: Partial<NodeToolBinDirsInput> = {}): NodeToolBinDi
   };
 }
 
-describe("resolveNodeToolBinDirs (unix)", () => {
-  test("returns NVM_BIN when set and present", () => {
-    const dir = "/home/me/.nvm/versions/node/v20.18.0/bin";
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({ env: { NVM_BIN: dir }, fs: makeFs({ dirs: [dir] }) })
-    );
-    expect(dirs).toContain(dir);
-  });
-
-  test("resolves the nvm default alias to its version's bin dir", () => {
-    const versions = "/home/me/.nvm/versions/node";
-    const v20 = `${versions}/v20.18.0/bin`;
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        fs: makeFs({
-          dirs: [v20, `${versions}/v18.20.0/bin`],
-          files: { "/home/me/.nvm/alias/default": "20\n" },
-          listings: { [versions]: ["v18.20.0", "v20.18.0"] },
-        }),
-      })
-    );
-    expect(dirs).toContain(v20);
-  });
-
-  test("follows nvm alias chains (default -> lts/* -> version)", () => {
-    const versions = "/home/me/.nvm/versions/node";
-    const v18 = `${versions}/v18.20.0/bin`;
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        fs: makeFs({
-          dirs: [v18],
-          files: {
-            "/home/me/.nvm/alias/default": "lts/*",
-            "/home/me/.nvm/alias/lts/*": "lts/hydrogen",
-            "/home/me/.nvm/alias/lts/hydrogen": "v18.20.0",
-          },
-          listings: { [versions]: ["v18.20.0"] },
-        }),
-      })
-    );
-    expect(dirs).toContain(v18);
-  });
-
-  test("enumerates every installed nvm version newest-first, default first", () => {
-    const versions = "/home/me/.nvm/versions/node";
-    const v18 = `${versions}/v18.20.0/bin`;
-    const v20 = `${versions}/v20.18.0/bin`;
-    const v22 = `${versions}/v22.1.0/bin`;
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        fs: makeFs({
-          dirs: [v18, v20, v22],
-          files: { "/home/me/.nvm/alias/default": "18" },
-          listings: { [versions]: ["v18.20.0", "v20.18.0", "v22.1.0"] },
-        }),
-      })
-    );
-    // Default (v18) wins, then the rest sorted newest-first.
-    expect(dirs).toEqual([v18, v22, v20]);
-  });
-
-  test("ignores an unparseable nvm default alias but still enumerates versions", () => {
-    const versions = "/home/me/.nvm/versions/node";
-    const v20 = `${versions}/v20.18.0/bin`;
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        fs: makeFs({
-          dirs: [v20],
-          files: { "/home/me/.nvm/alias/default": "lts/argon" }, // not installed
-          listings: { [versions]: ["v20.18.0"] },
-        }),
-      })
-    );
-    expect(dirs).toEqual([v20]);
-  });
-
-  test("honors $NVM_DIR over the default ~/.nvm location", () => {
-    const versions = "/opt/nvm/versions/node";
-    const v20 = `${versions}/v20.18.0/bin`;
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        env: { NVM_DIR: "/opt/nvm" },
-        fs: makeFs({ dirs: [v20], listings: { [versions]: ["v20.18.0"] } }),
-      })
-    );
-    expect(dirs).toContain(v20);
-  });
-
-  test("finds fnm's active multishell bin", () => {
-    const bin = "/run/fnm/abc/bin";
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({ env: { FNM_MULTISHELL_PATH: "/run/fnm/abc" }, fs: makeFs({ dirs: [bin] }) })
-    );
-    expect(dirs).toContain(bin);
-  });
-
-  test("enumerates fnm node-versions under the macOS base dir", () => {
-    const base = "/home/me/Library/Application Support/fnm/node-versions";
-    const v20 = `${base}/v20.18.0/installation/bin`;
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        platform: "darwin",
-        fs: makeFs({ dirs: [v20], listings: { [base]: ["v20.18.0"] } }),
-      })
-    );
-    expect(dirs).toContain(v20);
-  });
-
-  test("finds asdf shims, Volta, n, and npm_config_prefix bins", () => {
-    const shims = "/home/me/.asdf/shims";
-    const volta = "/home/me/.volta/bin";
-    const nbin = "/usr/local/n/bin";
-    const npmPrefix = "/home/me/.npm-global/custom/bin";
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        env: { N_PREFIX: "/usr/local/n", npm_config_prefix: "/home/me/.npm-global/custom" },
-        fs: makeFs({ dirs: [shims, volta, nbin, npmPrefix] }),
-      })
-    );
-    expect(dirs).toEqual(expect.arrayContaining([shims, volta, nbin, npmPrefix]));
-  });
-
-  test("prefers an existing ~/.asdf data dir over an ASDF_DIR install path", () => {
-    // Homebrew-style: ASDF_DIR points at the install dir, shims stay under the
-    // default ~/.asdf data dir. The install dir has no shims/bin of its own.
-    const shims = "/home/me/.asdf/shims";
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        env: { ASDF_DIR: "/opt/homebrew/opt/asdf/libexec" },
-        fs: makeFs({ dirs: [shims] }),
-      })
-    );
-    expect(dirs).toContain(shims);
-  });
-
-  test("honors ASDF_DATA_DIR over both ~/.asdf and ASDF_DIR", () => {
-    const shims = "/custom/asdf/shims";
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        env: { ASDF_DATA_DIR: "/custom/asdf", ASDF_DIR: "/opt/homebrew/opt/asdf/libexec" },
-        fs: makeFs({ dirs: [shims, "/home/me/.asdf/shims"] }),
-      })
-    );
-    expect(dirs).toContain(shims);
-  });
-
-  test("falls back to ASDF_DIR shims when no ~/.asdf data dir exists", () => {
-    const shims = "/opt/asdf/shims";
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({
-        env: { ASDF_DIR: "/opt/asdf" },
-        fs: makeFs({ dirs: [shims] }),
-      })
-    );
-    expect(dirs).toContain(shims);
-  });
-
-  test("drops candidate dirs that do not exist", () => {
-    const dirs = resolveNodeToolBinDirs(
-      unixInput({ env: { VOLTA_HOME: "/home/me/.volta" }, fs: makeFs({ dirs: [] }) })
-    );
-    expect(dirs).toEqual([]);
-  });
-
-  test("~/.local/bin is included when present", () => {
-    const local = "/home/me/.local/bin";
-    const dirs = resolveNodeToolBinDirs(unixInput({ fs: makeFs({ dirs: [local] }) }));
-    expect(dirs).toContain(local);
-  });
-});
-
-describe("resolveNodeToolBinDirs (windows)", () => {
-  function winInput(overrides: Partial<NodeToolBinDirsInput> = {}): NodeToolBinDirsInput {
-    return {
-      homeDir: "C:\\Users\\me",
-      platform: "win32",
-      env: {},
-      fs: makeFs({}),
-      ...overrides,
-    };
-  }
-
-  test("finds the npm global dir under %APPDATA%", () => {
-    const npm = "C:\\Users\\me\\AppData\\Roaming\\npm";
-    const dirs = resolveNodeToolBinDirs(
-      winInput({ env: { APPDATA: "C:\\Users\\me\\AppData\\Roaming" }, fs: makeFs({ dirs: [npm] }) })
-    );
-    expect(dirs).toContain(npm);
-  });
-
-  test("finds the nvm-windows symlink dir", () => {
-    const symlink = "C:\\nvm4w\\nodejs";
-    const dirs = resolveNodeToolBinDirs(
-      winInput({ env: { NVM_SYMLINK: symlink }, fs: makeFs({ dirs: [symlink] }) })
-    );
-    expect(dirs).toContain(symlink);
-  });
-});
-
-describe("module evaluation", () => {
-  test("does not require Node built-ins at module evaluation time", () => {
-    // The module is imported by settings-UI helpers that mobile also
-    // evaluates; an eval-time require would crash the plugin at load there.
-    const throwingIds = ["path", "node:path"];
-    try {
-      jest.isolateModules(() => {
-        for (const id of throwingIds) {
-          jest.doMock(id, () => {
-            throw new Error(`eager require of ${id}`);
-          });
-        }
-        expect(() => void jest.requireActual("./nodeToolBinDirs")).not.toThrow();
+describe("nodeToolBinDirs", () => {
+  describe("resolveNodeToolBinDirs()", () => {
+    describe("unix", () => {
+      test("returns NVM_BIN when set and present", () => {
+        const dir = "/home/me/.nvm/versions/node/v20.18.0/bin";
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({ env: { NVM_BIN: dir }, fs: makeFs({ dirs: [dir] }) })
+        );
+        expect(dirs).toContain(dir);
       });
-    } finally {
-      for (const id of throwingIds) jest.dontMock(id);
-    }
+
+      test("resolves the nvm default alias to its version's bin dir", () => {
+        const versions = "/home/me/.nvm/versions/node";
+        const v20 = `${versions}/v20.18.0/bin`;
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            fs: makeFs({
+              dirs: [v20, `${versions}/v18.20.0/bin`],
+              files: { "/home/me/.nvm/alias/default": "20\n" },
+              listings: { [versions]: ["v18.20.0", "v20.18.0"] },
+            }),
+          })
+        );
+        expect(dirs).toContain(v20);
+      });
+
+      test("follows nvm alias chains (default -> lts/* -> version)", () => {
+        const versions = "/home/me/.nvm/versions/node";
+        const v18 = `${versions}/v18.20.0/bin`;
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            fs: makeFs({
+              dirs: [v18],
+              files: {
+                "/home/me/.nvm/alias/default": "lts/*",
+                "/home/me/.nvm/alias/lts/*": "lts/hydrogen",
+                "/home/me/.nvm/alias/lts/hydrogen": "v18.20.0",
+              },
+              listings: { [versions]: ["v18.20.0"] },
+            }),
+          })
+        );
+        expect(dirs).toContain(v18);
+      });
+
+      test("enumerates every installed nvm version newest-first, default first", () => {
+        const versions = "/home/me/.nvm/versions/node";
+        const v18 = `${versions}/v18.20.0/bin`;
+        const v20 = `${versions}/v20.18.0/bin`;
+        const v22 = `${versions}/v22.1.0/bin`;
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            fs: makeFs({
+              dirs: [v18, v20, v22],
+              files: { "/home/me/.nvm/alias/default": "18" },
+              listings: { [versions]: ["v18.20.0", "v20.18.0", "v22.1.0"] },
+            }),
+          })
+        );
+        // Default (v18) wins, then the rest sorted newest-first.
+        expect(dirs).toEqual([v18, v22, v20]);
+      });
+
+      test("ignores an unparseable nvm default alias but still enumerates versions", () => {
+        const versions = "/home/me/.nvm/versions/node";
+        const v20 = `${versions}/v20.18.0/bin`;
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            fs: makeFs({
+              dirs: [v20],
+              files: { "/home/me/.nvm/alias/default": "lts/argon" }, // not installed
+              listings: { [versions]: ["v20.18.0"] },
+            }),
+          })
+        );
+        expect(dirs).toEqual([v20]);
+      });
+
+      test("honors $NVM_DIR over the default ~/.nvm location", () => {
+        const versions = "/opt/nvm/versions/node";
+        const v20 = `${versions}/v20.18.0/bin`;
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            env: { NVM_DIR: "/opt/nvm" },
+            fs: makeFs({ dirs: [v20], listings: { [versions]: ["v20.18.0"] } }),
+          })
+        );
+        expect(dirs).toContain(v20);
+      });
+
+      test("finds fnm's active multishell bin", () => {
+        const bin = "/run/fnm/abc/bin";
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({ env: { FNM_MULTISHELL_PATH: "/run/fnm/abc" }, fs: makeFs({ dirs: [bin] }) })
+        );
+        expect(dirs).toContain(bin);
+      });
+
+      test("enumerates fnm node-versions under the macOS base dir", () => {
+        const base = "/home/me/Library/Application Support/fnm/node-versions";
+        const v20 = `${base}/v20.18.0/installation/bin`;
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            platform: "darwin",
+            fs: makeFs({ dirs: [v20], listings: { [base]: ["v20.18.0"] } }),
+          })
+        );
+        expect(dirs).toContain(v20);
+      });
+
+      test("finds asdf shims, Volta, n, and npm_config_prefix bins", () => {
+        const shims = "/home/me/.asdf/shims";
+        const volta = "/home/me/.volta/bin";
+        const nbin = "/usr/local/n/bin";
+        const npmPrefix = "/home/me/.npm-global/custom/bin";
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            env: { N_PREFIX: "/usr/local/n", npm_config_prefix: "/home/me/.npm-global/custom" },
+            fs: makeFs({ dirs: [shims, volta, nbin, npmPrefix] }),
+          })
+        );
+        expect(dirs).toEqual(expect.arrayContaining([shims, volta, nbin, npmPrefix]));
+      });
+
+      test("prefers an existing ~/.asdf data dir over an ASDF_DIR install path", () => {
+        // Homebrew-style: ASDF_DIR points at the install dir, shims stay under the
+        // default ~/.asdf data dir. The install dir has no shims/bin of its own.
+        const shims = "/home/me/.asdf/shims";
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            env: { ASDF_DIR: "/opt/homebrew/opt/asdf/libexec" },
+            fs: makeFs({ dirs: [shims] }),
+          })
+        );
+        expect(dirs).toContain(shims);
+      });
+
+      test("honors ASDF_DATA_DIR over both ~/.asdf and ASDF_DIR", () => {
+        const shims = "/custom/asdf/shims";
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            env: { ASDF_DATA_DIR: "/custom/asdf", ASDF_DIR: "/opt/homebrew/opt/asdf/libexec" },
+            fs: makeFs({ dirs: [shims, "/home/me/.asdf/shims"] }),
+          })
+        );
+        expect(dirs).toContain(shims);
+      });
+
+      test("falls back to ASDF_DIR shims when no ~/.asdf data dir exists", () => {
+        const shims = "/opt/asdf/shims";
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({
+            env: { ASDF_DIR: "/opt/asdf" },
+            fs: makeFs({ dirs: [shims] }),
+          })
+        );
+        expect(dirs).toContain(shims);
+      });
+
+      test("drops candidate dirs that do not exist", () => {
+        const dirs = resolveNodeToolBinDirs(
+          unixInput({ env: { VOLTA_HOME: "/home/me/.volta" }, fs: makeFs({ dirs: [] }) })
+        );
+        expect(dirs).toEqual([]);
+      });
+
+      test("~/.local/bin is included when present", () => {
+        const local = "/home/me/.local/bin";
+        const dirs = resolveNodeToolBinDirs(unixInput({ fs: makeFs({ dirs: [local] }) }));
+        expect(dirs).toContain(local);
+      });
+    });
+
+    describe("windows", () => {
+      function winInput(overrides: Partial<NodeToolBinDirsInput> = {}): NodeToolBinDirsInput {
+        return {
+          homeDir: "C:\\Users\\me",
+          platform: "win32",
+          env: {},
+          fs: makeFs({}),
+          ...overrides,
+        };
+      }
+
+      test("finds the npm global dir under %APPDATA%", () => {
+        const npm = "C:\\Users\\me\\AppData\\Roaming\\npm";
+        const dirs = resolveNodeToolBinDirs(
+          winInput({
+            env: { APPDATA: "C:\\Users\\me\\AppData\\Roaming" },
+            fs: makeFs({ dirs: [npm] }),
+          })
+        );
+        expect(dirs).toContain(npm);
+      });
+
+      test("finds the nvm-windows symlink dir", () => {
+        const symlink = "C:\\nvm4w\\nodejs";
+        const dirs = resolveNodeToolBinDirs(
+          winInput({ env: { NVM_SYMLINK: symlink }, fs: makeFs({ dirs: [symlink] }) })
+        );
+        expect(dirs).toContain(symlink);
+      });
+    });
+
+    test("throws the desktop-only error when resolving on non-desktop runtimes", () => {
+      const platform = Platform as { isMobile: boolean };
+      platform.isMobile = true;
+      try {
+        expect(() => resolveNodeToolBinDirs(unixInput())).toThrow(
+          /unavailable outside the desktop/
+        );
+      } finally {
+        platform.isMobile = false;
+      }
+    });
   });
 
-  test("throws the desktop-only error when resolving on non-desktop runtimes", () => {
-    const platform = Platform as { isMobile: boolean };
-    platform.isMobile = true;
-    try {
-      expect(() => resolveNodeToolBinDirs(unixInput())).toThrow(/unavailable outside the desktop/);
-    } finally {
-      platform.isMobile = false;
-    }
+  describe("module evaluation", () => {
+    test("does not require Node built-ins at module evaluation time", () => {
+      // The module is imported by settings-UI helpers that mobile also
+      // evaluates; an eval-time require would crash the plugin at load there.
+      const throwingIds = ["path", "node:path"];
+      try {
+        jest.isolateModules(() => {
+          for (const id of throwingIds) {
+            jest.doMock(id, () => {
+              throw new Error(`eager require of ${id}`);
+            });
+          }
+          expect(() => void jest.requireActual("./nodeToolBinDirs")).not.toThrow();
+        });
+      } finally {
+        for (const id of throwingIds) jest.dontMock(id);
+      }
+    });
   });
 });

--- a/src/utils/nodeToolBinDirs.ts
+++ b/src/utils/nodeToolBinDirs.ts
@@ -16,7 +16,10 @@
  * Pure leaf: callers inject `homeDir`, `platform`, `env`, and `fs` so tests
  * don't touch real disk.
  */
-import * as path from "node:path";
+import { requireNodeModule } from "@/utils/desktopRuntime";
+
+type PathModule = typeof import("node:path");
+type PlatformPath = PathModule["posix"];
 
 export interface NodeToolFs {
   existsSync: (p: string) => boolean;
@@ -42,7 +45,11 @@ export interface NodeToolBinDirsInput {
  * registered.
  */
 export function nodeToolBinDirCandidates(input: NodeToolBinDirsInput): string[] {
-  const candidates = input.platform === "win32" ? windowsCandidates(input) : unixCandidates(input);
+  const path = requireNodeModule<PathModule>("path");
+  const candidates =
+    input.platform === "win32"
+      ? windowsCandidates(input, path.win32)
+      : unixCandidates(input, path.posix);
   const seen = new Set<string>();
   const out: string[] = [];
   for (const dir of candidates) {
@@ -69,9 +76,8 @@ function dirExists(fs: NodeToolFs, dir: string): boolean {
   }
 }
 
-function unixCandidates(input: NodeToolBinDirsInput): Array<string | null> {
+function unixCandidates(input: NodeToolBinDirsInput, p: PlatformPath): Array<string | null> {
   const { homeDir, env, fs, platform } = input;
-  const p = path.posix;
   const dirs: Array<string | null> = [];
 
   // nvm — NVM_BIN (set only inside an interactive shell) plus the default and
@@ -80,7 +86,7 @@ function unixCandidates(input: NodeToolBinDirsInput): Array<string | null> {
   dirs.push(env.NVM_BIN ?? null);
   const nvmDir = env.NVM_DIR ?? p.join(homeDir, ".nvm");
   const nvmVersions = p.join(nvmDir, "versions", "node");
-  const nvmDefault = resolveNvmDefaultBin(nvmDir, nvmVersions, fs);
+  const nvmDefault = resolveNvmDefaultBin(nvmDir, nvmVersions, fs, p);
   if (nvmDefault) dirs.push(nvmDefault);
   dirs.push(...enumerateVersionBins(fs, nvmVersions, ["bin"], p));
 
@@ -122,9 +128,8 @@ function unixCandidates(input: NodeToolBinDirsInput): Array<string | null> {
   return dirs;
 }
 
-function windowsCandidates(input: NodeToolBinDirsInput): Array<string | null> {
+function windowsCandidates(input: NodeToolBinDirsInput, p: PlatformPath): Array<string | null> {
   const { homeDir, env } = input;
-  const p = path.win32;
   const dirs: Array<string | null> = [];
 
   // npm global (`npm i -g` drops shims here) — the most common GUI-app gap.
@@ -149,7 +154,7 @@ function fnmBaseDirs(
   homeDir: string,
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform,
-  p: path.PlatformPath
+  p: PlatformPath
 ): string[] {
   if (env.FNM_DIR) return [env.FNM_DIR];
   if (platform === "darwin") {
@@ -170,7 +175,7 @@ function enumerateVersionBins(
   fs: NodeToolFs,
   versionsDir: string,
   subPath: string[],
-  p: path.PlatformPath
+  p: PlatformPath
 ): string[] {
   let entries: string[];
   try {
@@ -192,16 +197,21 @@ const NVM_LATEST_ALIASES = new Set(["node", "stable"]);
  * pointer to the user's chosen default. Aliases can chain (`default → lts/* →
  * lts/hydrogen → vX.Y.Z`); unresolvable ones yield null.
  */
-function resolveNvmDefaultBin(nvmDir: string, versionsDir: string, fs: NodeToolFs): string | null {
+function resolveNvmDefaultBin(
+  nvmDir: string,
+  versionsDir: string,
+  fs: NodeToolFs,
+  p: PlatformPath
+): string | null {
   let alias: string;
   try {
-    alias = fs.readFileSync(path.posix.join(nvmDir, "alias", "default"), "utf8").trim();
+    alias = fs.readFileSync(p.join(nvmDir, "alias", "default"), "utf8").trim();
   } catch {
     return null;
   }
   if (!alias) return null;
 
-  const resolved = resolveNvmAlias(nvmDir, alias, fs, 0);
+  const resolved = resolveNvmAlias(nvmDir, alias, fs, p, 0);
   if (!resolved) return null;
 
   let entries: string[];
@@ -215,24 +225,23 @@ function resolveNvmDefaultBin(nvmDir: string, versionsDir: string, fs: NodeToolF
   }
 
   const matched = matchNvmVersion(entries, resolved);
-  return matched ? path.posix.join(versionsDir, matched, "bin") : null;
+  return matched ? p.join(versionsDir, matched, "bin") : null;
 }
 
 function resolveNvmAlias(
   nvmDir: string,
   alias: string,
   fs: NodeToolFs,
+  p: PlatformPath,
   depth: number
 ): string | null {
   if (depth > 5) return null;
   if (/^\d/.test(alias) || alias.startsWith("v")) return alias;
   if (NVM_LATEST_ALIASES.has(alias)) return alias;
   try {
-    const target = fs
-      .readFileSync(path.posix.join(nvmDir, "alias", ...alias.split("/")), "utf8")
-      .trim();
+    const target = fs.readFileSync(p.join(nvmDir, "alias", ...alias.split("/")), "utf8").trim();
     if (!target) return null;
-    return resolveNvmAlias(nvmDir, target, fs, depth + 1);
+    return resolveNvmAlias(nvmDir, target, fs, p, depth + 1);
   } catch {
     return null;
   }

--- a/src/utils/rendererEventsShim.test.ts
+++ b/src/utils/rendererEventsShim.test.ts
@@ -1,15 +1,17 @@
-jest.mock("obsidian", () => ({ Platform: { isMobile: false } }));
+jest.mock("obsidian", () => ({ Platform: { isDesktopApp: true, isMobile: false } }));
 
 import { EventEmitter } from "node:events";
 import { installRendererEventsShim } from "./rendererEventsShim";
 
-const obsidian: { Platform: { isMobile: boolean } } = jest.requireMock("obsidian");
+const obsidian: { Platform: { isDesktopApp: boolean; isMobile: boolean } } =
+  jest.requireMock("obsidian");
 
 describe("installRendererEventsShim", () => {
   let original: typeof EventEmitter.setMaxListeners;
 
   beforeEach(() => {
     original = EventEmitter.setMaxListeners;
+    obsidian.Platform.isDesktopApp = true;
     obsidian.Platform.isMobile = false;
   });
 
@@ -28,6 +30,24 @@ describe("installRendererEventsShim", () => {
   it("has no load-time side effect — patching only happens when called", () => {
     // Importing the module above must not have patched anything on its own.
     expect(EventEmitter.setMaxListeners).toBe(original);
+  });
+
+  it("evaluates without requiring node:events — safe in the mobile module graph", () => {
+    // On mobile the events module resolves to undefined, so any require at
+    // module-evaluation time would crash the whole plugin at load.
+    const throwingIds = ["events", "node:events"];
+    try {
+      jest.isolateModules(() => {
+        for (const id of throwingIds) {
+          jest.doMock(id, () => {
+            throw new Error(`eager require of ${id}`);
+          });
+        }
+        expect(() => void jest.requireActual("./rendererEventsShim")).not.toThrow();
+      });
+    } finally {
+      for (const id of throwingIds) jest.dontMock(id);
+    }
   });
 
   it("on desktop, swallows setMaxListeners misuse with AbortSignal-shaped targets", () => {

--- a/src/utils/rendererEventsShim.ts
+++ b/src/utils/rendererEventsShim.ts
@@ -1,5 +1,4 @@
-import { Platform } from "obsidian";
-import { EventEmitter } from "node:events";
+import { isDesktopRuntime, requireNodeModule } from "@/utils/desktopRuntime";
 
 type SetMaxListenersFn = (n?: number, ...targets: unknown[]) => void;
 type MarkedFn = SetMaxListenersFn & { [APPLIED]?: boolean };
@@ -21,35 +20,32 @@ function hasAbortSignalShape(value: unknown): boolean {
  * `isEventTarget` check, throwing `ERR_INVALID_ARG_TYPE`. The behaviour is
  * intermittent across environments.
  *
- * We must patch the **EventEmitter class** itself, not the namespace object
- * produced by `import * as events from "node:events"`. esbuild's CJS interop
- * compiles a star-import to `W(require("node:events"))`, where `W` returns a
- * fresh `{ default: target, ...target }` namespace — a *copy* of the
- * module's properties. Mutating that copy does not affect what other
- * consumers see when they read `require("events").setMaxListeners` live at
- * call time (which is exactly what the bundled SDK does).
- *
- * Node's events module is the EventEmitter class itself
- * (`module.exports = EventEmitter`, plus a `module.exports.EventEmitter`
- * self-reference). A named import resolves to that class — not a wrapper —
- * so assigning to its static `setMaxListeners` mutates the live property
- * every other importer reads. The patch runs as a side effect at module
- * load; a side-effect import in `main.ts` placed before any SDK-touching
- * import is sufficient because ES module evaluation follows the dependency
- * graph.
+ * We must patch the **EventEmitter class** itself, not a namespace copy such
+ * as the `{ default: target, ...target }` object esbuild's CJS interop
+ * builds for `import * as events from "node:events"` — mutating a copy does
+ * not affect what other consumers see when they read
+ * `require("events").setMaxListeners` live at call time (which is exactly
+ * what the bundled SDK does). Node's events module is the EventEmitter class
+ * itself (`module.exports = EventEmitter`, plus a `module.exports.EventEmitter`
+ * self-reference), so reading `.EventEmitter` off the live
+ * `require("events")` module object yields that class — not a wrapper — and
+ * assigning to its static `setMaxListeners` mutates the property every other
+ * importer reads.
  *
  * The wrapper drops the throw only when every supplied target looks like an
  * `AbortSignal`; unrelated misuse still propagates.
  *
- * Desktop (Electron renderer) only. On mobile there is no `node:events` (it's
- * marked external and resolves to `undefined`) and no Claude Agent SDK to shim,
- * so this is a no-op there. The mobile guard returns BEFORE any `EventEmitter`
- * access, which is why this must not run at module load: a side-effect call
- * referencing `EventEmitter` crashes the whole plugin on mobile during import
- * (`undefined is not an object`). Call it once from `onload` instead.
+ * Desktop (Electron renderer) only. On mobile (including
+ * `app.emulateMobile(true)`) there is no `node:events` (it's marked external
+ * and resolves to `undefined`) and no Claude Agent SDK to shim, so this is a
+ * no-op there. The desktop-runtime guard returns BEFORE the events module is
+ * required, and the require itself happens at call time — never at module
+ * evaluation — so importing this module is safe on every platform. Call it
+ * once from `onload`.
  */
 export function installRendererEventsShim(): void {
-  if (Platform.isMobile) return;
+  if (!isDesktopRuntime()) return;
+  const { EventEmitter } = requireNodeModule<typeof import("node:events")>("events");
   const target = EventEmitter as unknown as { setMaxListeners: MarkedFn };
   const original = target.setMaxListeners;
   if (original[APPLIED]) return;


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#299

## Why

The plugin's community scorecard warns prospective installers about mobile compatibility: `manifest.json` ships `isDesktopOnly: false`, yet dozens of first-party modules statically import Node built-ins that do not exist on phones and tablets. Static imports run at module evaluation, so today the plugin survives mobile load only through an implicit contract of build-time stubs tolerating `undefined` modules. Two of the riskiest cases load eagerly: `rendererEventsShim` (`node:events`) evaluates from `main.ts` on every platform, and `detectBinary` builds a promisified `execFile` at module scope — on mobile that is a property read off an `undefined` module, which would kill the whole plugin at load the moment the eager graph reaches it.

## What

Phase 1 of the issue's one-subsystem-per-PR plan: the renderer events shim and the binary-detection/path utilities reachable from the settings UI now load Node built-ins through a shared, desktop-gated call-time accessor.

| Condition | Before | After |
| --- | --- | --- |
| Module evaluation on mobile | Node built-ins required at load; safety depends on build-time stubs tolerating `undefined` modules | No Node access at evaluation time, by construction |
| Desktop call paths | Static imports resolve at load | The same modules resolve through the same `require` at first call — behavior unchanged |
| Node-dependent call on a non-desktop runtime (e.g. binary detection) | `TypeError` from an `undefined` module | Clear error naming the unavailable built-in |

Converted imports: `rendererEventsShim` (`node:events`), `binaryPath` (`node:fs`, `node:os`), `detectBinary` (`node:child_process`, `node:util`, `node:fs`, `node:path`), `nodeToolBinDirs` (`node:path`), `appPaths` (`node:path`). These converted files now produce no `obsidianmd/no-nodejs-modules` warnings; the remaining warnings stay visible for the follow-up migration.

## Non goal

- The Agent Mode ACP/coding-agent backends bulk (~40 imports), the context conversion cache, and the Symposium agent handoff — later phases of #299.
- Making Agent Mode or any other desktop-only feature work on mobile — guards make them fail safe, not function.
- Converting the three `buffer` polyfill imports (`src/utils.ts`, `src/utils/base64.ts`, `src/LLMProviders/BedrockChatModel.ts`) — mobile-safe by design and deliberately retained.
- Removing the esbuild `process` banner shim or the externals list — bundled dependencies still rely on them.
- Flipping `isDesktopOnly` in `manifest.json` or changing which features are desktop-gated.

## Screenshot

Not applicable — no visual change; the conversions preserve desktop behavior and only move module resolution from load time to call time.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Each converted suite gains an eval-time isolation test (module import must not touch Node built-ins) plus non-desktop guard tests; existing desktop-path tests still pass unchanged |
| A defect would fail CI or be obvious on first use | ✅ | The new tests run in `npm run test`; a desktop resolution defect also surfaces on the first binary detection or Agent Mode start |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data, settings schema, or migration is touched |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The binary-name validation in `detectBinary` is byte-identical |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Every exported signature is unchanged; only import mechanics move |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Requires stay synchronous; only their timing moves from module load to first call |
| No hot-path behavior lacks deterministic coverage | ✅ | Desktop resolution, the live-`EventEmitter` patch identity, and every guard branch are unit-tested |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong guard shows up immediately as a plugin load error or a binary-detection error in Agent settings |

Review: skim `Why` and `What`, spot-check `requireNodeModule` in `src/utils/desktopRuntime.ts`, run Verification step 3, and confirm CI is green.

## Verification

1. Build and install the branch in a desktop test vault, then reload Obsidian — the plugin loads with no console errors.
2. In Settings → Copilot → Agent settings, trigger binary detection for a coding agent (e.g. Claude Code) — the detected path appears exactly as on `master`, with the home directory collapsed to `~`.
3. In the developer console run `app.emulateMobile(true)` and reload — the plugin still loads cleanly (this is the stricter case where Node modules are stubbed to null while `Platform.isDesktopApp` stays true). Run `app.emulateMobile(false)` to restore.
