### PR TITLE
Send plugin versions with Copilot Plus requests

### DIFF
--- a/src/LLMProviders/CustomJinaEmbeddings.test.ts
+++ b/src/LLMProviders/CustomJinaEmbeddings.test.ts
@@ -1,0 +1,39 @@
+import { CustomJinaEmbeddings } from "./CustomJinaEmbeddings";
+
+describe("CustomJinaEmbeddings", () => {
+  describe("CustomJinaEmbeddings", () => {
+    describe("embedQuery()", () => {
+      afterEach(() => {
+        delete (window as { fetch?: typeof fetch }).fetch;
+      });
+
+      it("forwards configured headers with an embeddings request", async () => {
+        const fetchSpy = jest.fn().mockResolvedValue({
+          json: async () => ({
+            model: "jina-clip-v2",
+            object: "list",
+            usage: { total_tokens: 1, prompt_tokens: 1 },
+            data: [{ object: "embedding", index: 0, embedding: [0.25] }],
+          }),
+        });
+        window.fetch = fetchSpy as typeof fetch;
+        const embeddings = new CustomJinaEmbeddings({
+          apiKey: "plus-token",
+          headers: { "X-Client-Version": "4.0.0-preview-260802" },
+        });
+
+        await expect(embeddings.embedQuery("hello")).resolves.toEqual([0.25]);
+        expect(fetchSpy).toHaveBeenCalledWith(
+          "https://api.jina.ai/v1/embeddings",
+          expect.objectContaining({
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: "Bearer plus-token",
+              "X-Client-Version": "4.0.0-preview-260802",
+            },
+          })
+        );
+      });
+    });
+  });
+});

--- a/src/LLMProviders/CustomJinaEmbeddings.ts
+++ b/src/LLMProviders/CustomJinaEmbeddings.ts
@@ -25,6 +25,8 @@ export interface JinaEmbeddingsParams extends EmbeddingsParams {
   dimensions?: number;
   /** Whether to L2-normalize the embedding vectors. */
   normalized?: boolean;
+  /** Additional headers to send with each embeddings request. */
+  headers?: Record<string, string>;
 }
 
 type JinaMultiModelInput =
@@ -73,6 +75,7 @@ export class CustomJinaEmbeddings extends Embeddings implements JinaEmbeddingsPa
   dimensions = 1024;
   apiKey: string;
   normalized = true;
+  headers: Record<string, string> = {};
 
   /**
    * Creates a Jina embeddings client using local configuration or Jina environment variables.
@@ -99,6 +102,7 @@ export class CustomJinaEmbeddings extends Embeddings implements JinaEmbeddingsPa
     this.batchSize = fieldsWithDefaults?.batchSize ?? this.batchSize;
     this.stripNewLines = fieldsWithDefaults?.stripNewLines ?? this.stripNewLines;
     this.normalized = fieldsWithDefaults?.normalized ?? this.normalized;
+    this.headers = fieldsWithDefaults?.headers ?? this.headers;
   }
 
   /**
@@ -174,6 +178,7 @@ export class CustomJinaEmbeddings extends Embeddings implements JinaEmbeddingsPa
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${this.apiKey}`,
+        ...this.headers,
       },
       body: JSON.stringify(body),
     });

--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -40,6 +40,17 @@ const MANUAL_LICENSE_CHECK = { trigger: "manual" } as const;
 
 describe("brevilabsClient", () => {
   describe("BrevilabsClient", () => {
+    describe("getPluginVersionHeaders()", () => {
+      it("exposes the plugin version as the shared client-version header", () => {
+        const client = BrevilabsClient.getInstance();
+        client.setPluginVersion("4.0.0-preview-260802");
+
+        expect(client.getPluginVersionHeaders()).toEqual({
+          "X-Client-Version": "4.0.0-preview-260802",
+        });
+      });
+    });
+
     describe("validateLicenseKey()", () => {
       beforeEach(() => {
         jest.clearAllMocks();

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -197,6 +197,10 @@ export class BrevilabsClient {
     this.pluginVersion = pluginVersion;
   }
 
+  getPluginVersionHeaders(): Record<string, string> {
+    return { "X-Client-Version": this.pluginVersion };
+  }
+
   private async makeRequest<T>(
     endpoint: string,
     body: Record<string, unknown>,
@@ -219,7 +223,7 @@ export class BrevilabsClient {
     }
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      "X-Client-Version": this.pluginVersion,
+      ...this.getPluginVersionHeaders(),
     };
     if (!excludeAuthHeader) {
       headers.Authorization = `Bearer ${getSettings().plusLicenseKey}`;
@@ -258,7 +262,7 @@ export class BrevilabsClient {
         headers: {
           "Content-Type": contentType,
           Authorization: `Bearer ${getSettings().plusLicenseKey}`,
-          "X-Client-Version": this.pluginVersion,
+          ...this.getPluginVersionHeaders(),
         },
         body,
         throw: false,

--- a/src/LLMProviders/chatModelManager.bridge.test.ts
+++ b/src/LLMProviders/chatModelManager.bridge.test.ts
@@ -26,6 +26,17 @@ jest.mock("@langchain/google-genai", () => {
   }
   return { ChatGoogleGenerativeAI };
 });
+jest.mock("./ChatOpenRouter", () => {
+  class ChatOpenRouter {
+    static configs: unknown[] = [];
+    constructor(config: unknown) {
+      ChatOpenRouter.configs.push(config);
+    }
+  }
+  return { ChatOpenRouter };
+});
+
+import { BrevilabsClient } from "./brevilabsClient";
 
 function bridgedModel(overrides: Partial<CustomModel> = {}): CustomModel {
   return {
@@ -106,6 +117,21 @@ describe("ChatModelManager bridged models", () => {
     );
 
     setSettings({ activeModels: [] });
+  });
+
+  it("sends the plugin version with Copilot Plus chat requests", async () => {
+    const OpenRouterMock = jest.requireMock("./ChatOpenRouter").ChatOpenRouter as {
+      configs: Array<{ configuration?: { defaultHeaders?: Record<string, string> } }>;
+    };
+    BrevilabsClient.getInstance().setPluginVersion("4.0.0-preview-260802");
+
+    await ChatModelManager.getInstance().createModelInstanceFromBridged(
+      bridgedModel({ provider: ChatModelProviders.COPILOT_PLUS, apiKey: "bridge-key" })
+    );
+
+    expect(OpenRouterMock.configs.at(-1)?.configuration?.defaultHeaders).toEqual({
+      "X-Client-Version": "4.0.0-preview-260802",
+    });
   });
 
   it("retains the active bridged model for temperature overrides", async () => {

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -39,6 +39,7 @@ import { Notice } from "obsidian";
 import { ChatOpenRouter } from "./ChatOpenRouter";
 import { ChatLMStudio } from "./ChatLMStudio";
 import { BedrockChatModel, type BedrockChatModelFields } from "./BedrockChatModel";
+import { BrevilabsClient } from "./brevilabsClient";
 import { GitHubCopilotChatModel } from "@/LLMProviders/githubCopilot/GitHubCopilotChatModel";
 import { GitHubCopilotResponsesModel } from "@/LLMProviders/githubCopilot/GitHubCopilotResponsesModel";
 import type { SafetySetting } from "@google/generative-ai";
@@ -465,6 +466,7 @@ export default class ChatModelManager {
         configuration: {
           baseURL: BREVILABS_MODELS_BASE_URL,
           fetch: safeFetch,
+          defaultHeaders: BrevilabsClient.getInstance().getPluginVersionHeaders(),
         },
         // Reasoning is opt-in: forward the user's per-model effort pick only for
         // REASONING-capable models, and gate enableReasoning on an EXPLICIT effort.

--- a/src/LLMProviders/embeddingManager.clientVersion.test.ts
+++ b/src/LLMProviders/embeddingManager.clientVersion.test.ts
@@ -1,0 +1,36 @@
+import type { CustomModel } from "@/aiParams";
+import { EmbeddingModelProviders } from "@/constants";
+import { setSettings } from "@/settings/model";
+import { BrevilabsClient } from "./brevilabsClient";
+import EmbeddingManager from "./embeddingManager";
+
+describe("embeddingManager", () => {
+  describe("EmbeddingManager", () => {
+    describe("getEmbeddingConfig()", () => {
+      beforeEach(() => {
+        setSettings({ plusLicenseKey: "plus-token", embeddingBatchSize: 16 });
+        BrevilabsClient.getInstance().setPluginVersion("4.0.0-preview-260802");
+      });
+
+      it.each([EmbeddingModelProviders.COPILOT_PLUS, EmbeddingModelProviders.COPILOT_PLUS_JINA])(
+        "adds the plugin version to %s requests",
+        async (provider) => {
+          const model: CustomModel = {
+            name: "embedding-model",
+            provider,
+            enabled: true,
+          };
+
+          const manager = Object.create(EmbeddingManager.prototype) as unknown as {
+            getEmbeddingConfig(model: CustomModel): Promise<Record<string, unknown>>;
+          };
+          const config = await manager.getEmbeddingConfig(model);
+
+          expect(config.headers).toEqual({
+            "X-Client-Version": "4.0.0-preview-260802",
+          });
+        }
+      );
+    });
+  });
+});

--- a/src/LLMProviders/embeddingManager.ts
+++ b/src/LLMProviders/embeddingManager.ts
@@ -211,6 +211,7 @@ export default class EmbeddingManager {
       [EmbeddingModelProviders.COPILOT_PLUS]: {
         modelName,
         apiKey: settings.plusLicenseKey,
+        headers: BrevilabsClient.getInstance().getPluginVersionHeaders(),
         timeout: 10000,
         batchSize: getSettings().embeddingBatchSize,
         configuration: {
@@ -221,6 +222,7 @@ export default class EmbeddingManager {
       [EmbeddingModelProviders.COPILOT_PLUS_JINA]: {
         model: modelName,
         apiKey: settings.plusLicenseKey,
+        headers: BrevilabsClient.getInstance().getPluginVersionHeaders(),
         timeout: 10000,
         batchSize: getSettings().embeddingBatchSize,
         dimensions: customModel.dimensions,

--- a/src/agentMode/backends/codex/CodexBackend.test.ts
+++ b/src/agentMode/backends/codex/CodexBackend.test.ts
@@ -95,6 +95,16 @@ describe("CodexBackend.buildSpawnDescriptor", () => {
     expect(value).not.toContain("copilot/skills/<name>/SKILL.md");
   });
 
+  it("passes the plugin version to built-in Copilot Plus skills", async () => {
+    setSettings({ isPaidUser: true, plusLicenseKey: "plus-token", userId: "user-1" });
+
+    const desc = await new CodexBackend("4.0.0-preview-260802").buildSpawnDescriptor({
+      vaultBasePath: "/vault",
+    });
+
+    expect(desc.env.COPILOT_CLIENT_VERSION).toBe("4.0.0-preview-260802");
+  });
+
   it("encodes the shared product prompt into both paths, byte for byte", async () => {
     const desc = await new CodexBackend().buildSpawnDescriptor({ vaultBasePath: "/vault" });
     const shared = buildAgentSystemPrompt();

--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -17,6 +17,8 @@ export class CodexBackend implements AcpBackend {
   readonly id = "codex" as const;
   readonly displayName = "Codex";
 
+  constructor(private readonly clientVersion = "") {}
+
   async buildSpawnDescriptor(ctx: { vaultBasePath: string }): Promise<AcpSpawnDescriptor> {
     const descriptor = buildSimpleSpawnDescriptor(
       getSettings().agentMode?.backends?.codex?.binaryPath,
@@ -24,7 +26,7 @@ export class CodexBackend implements AcpBackend {
       getSettings().agentMode?.backends?.codex?.envOverrides,
       {
         // Builtin skills consume plugin-managed runtime paths and credentials.
-        ...(await buildBuiltinSkillEnv("", ctx.vaultBasePath)),
+        ...(await buildBuiltinSkillEnv(this.clientVersion, ctx.vaultBasePath)),
         // Newer adapters derive the initial ACP mode from this variable rather
         // than Codex's approval/sandbox config. User env overrides still win.
         INITIAL_AGENT_MODE: "agent",

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -182,7 +182,7 @@ export const CodexBackendDescriptor: BackendDescriptor = {
     // symlink. The per-agent toggle drives whether the symlink exists; no
     // deny synthesis is needed because Codex does not cross-discover from
     // `.claude/skills/` or `.opencode/skills/`.
-    return simpleBinaryBackendProcess(args, new CodexBackend());
+    return simpleBinaryBackendProcess(args, new CodexBackend(args.clientVersion));
   },
 
   SettingsPanel: CodexSettingsPanel,

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -548,13 +548,14 @@ describe("buildOpencodeConfig — provider/model injection", () => {
       resolved: [okEntry(provider, makeModel("p-plus", "copilot-plus-flash"))],
       keys: { "p-plus": "plus-token-123" },
     });
+    deps.clientVersion = "4.0.0-preview-260802";
     const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
       provider: Record<
         string,
         {
           npm?: string;
           name?: string;
-          options?: { baseURL?: string; apiKey?: string };
+          options?: { baseURL?: string; apiKey?: string; headers?: Record<string, string> };
           models?: Record<string, unknown>;
         }
       >;
@@ -564,6 +565,9 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     expect(cp.name).toBe("Copilot Plus");
     expect(cp.options?.baseURL).toBe("https://models.brevilabs.com/v1");
     expect(cp.options?.apiKey).toBe("plus-token-123");
+    expect(cp.options?.headers).toEqual({
+      "X-Client-Version": "4.0.0-preview-260802",
+    });
     expect(cp.models).toEqual({ "copilot-plus-flash": {} });
   });
 });
@@ -868,6 +872,26 @@ describe("OpencodeBackend.buildSpawnDescriptor", () => {
     const cfg = JSON.parse(desc.env.OPENCODE_CONFIG_CONTENT as string);
     expect(cfg.provider.anthropic.options).toEqual({ apiKey: "anth-xyz" });
     expect(cfg.provider.anthropic.models).toEqual({ "claude-sonnet-4-6": {} });
+  });
+
+  it("passes the plugin version to built-in Copilot Plus skills", async () => {
+    setSettings({ isPaidUser: true, plusLicenseKey: "plus-token", userId: "user-1" });
+    updateSetting("agentMode", {
+      byok: {},
+      activeBackend: "opencode",
+      debugFullFrames: false,
+      welcomeDismissed: false,
+      skills: { folder: "copilot/skills" },
+      backends: { opencode: { binaryPath: "/path/to/opencode" } },
+    });
+    const backend = new OpencodeBackend({
+      ...NO_MODELS_DEPS,
+      clientVersion: "4.0.0-preview-260802",
+    });
+
+    const desc = await backend.buildSpawnDescriptor({ vaultBasePath: "/vault/abs" });
+
+    expect(desc.env.COPILOT_CLIENT_VERSION).toBe("4.0.0-preview-260802");
   });
 
   it("threads the injected getCacheRoot into the spawned external_directory allow", async () => {

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -57,6 +57,7 @@ export const OPENCODE_CANONICAL_MODE_AGENT_IDS: Partial<Record<CopilotMode, stri
 export interface OpencodeModelDeps {
   providerRegistry: ProviderRegistry;
   backendConfigRegistry: BackendConfigRegistry;
+  clientVersion?: string;
   /**
    * Resolves the off-vault shared conversions cache root (absolute path) for
    * this vault, or `undefined` when unavailable. Injected so this backend never
@@ -120,7 +121,7 @@ export class OpencodeBackend implements AcpBackend {
       );
     }
     // Builtin skills consume plugin-managed runtime paths and credentials.
-    const builtinSkillEnv = await buildBuiltinSkillEnv("", ctx.vaultBasePath);
+    const builtinSkillEnv = await buildBuiltinSkillEnv(this.#deps.clientVersion, ctx.vaultBasePath);
 
     return {
       command: binaryPath,
@@ -242,6 +243,9 @@ export async function buildOpencodeConfig(
         options: {
           ...(apiKey ? { apiKey } : {}),
           ...(baseURL ? { baseURL } : {}),
+          ...(origin.kind === "copilot-plus" && deps.clientVersion
+            ? { headers: { "X-Client-Version": deps.clientVersion } }
+            : {}),
         },
       };
       provider[mapping.id] = providerConfig;

--- a/src/agentMode/backends/opencode/descriptor.ts
+++ b/src/agentMode/backends/opencode/descriptor.ts
@@ -279,6 +279,7 @@ export const OpencodeBackendDescriptor: BackendDescriptor = {
       new OpencodeBackend({
         providerRegistry,
         backendConfigRegistry,
+        clientVersion: args.clientVersion,
         // Activates the opencode external_directory allow rule for the off-vault
         // shared conversions cache. vaultId/path derivation lives entirely in
         // conversionsLocation — this backend never duplicates it.


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#306

## Why

Copilot sends `X-Client-Version` with license/API requests but omits it from several Copilot Plus model paths. Production analytics consequently records most model calls and embeddings as `plugin_version=unknown`, even though license checks from the same installations carry valid release, preview, or development versions.

## What

Every plugin-managed Brevilabs request path now forwards the running plugin version.

| Request path | Before | After |
| --- | --- | --- |
| Brevilabs API and license checks | Version header | Version header |
| Copilot Plus chat | No version header | Version header |
| OpenAI-compatible and Jina embeddings | No version header | Version header |
| OpenCode Copilot Plus models | No version header | Version header |
| OpenCode and Codex built-in relay skills | Empty version | Running plugin version |

Model inputs, outputs, selection, and entitlement decisions are unchanged.

## Non goal

- Changing the plugin manifest version format.
- Changing model selection, request bodies, license validity, or entitlement behavior.
- Adding direct PostHog ingestion to the plugin.

## Screenshot

Not applicable — this PR changes request metadata and has no visual effect.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Constructor-config, transport, and Agent Mode spawn tests cover every changed request boundary |
| A defect would fail CI or be obvious on first use | ✅ | Missing or misplaced headers fail the focused unit tests |
| A revert fully restores prior state, including persisted data | ✅ | The change adds transient request metadata and writes no user data |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Authenticated Brevilabs requests gain a client-version header |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Copilot now consistently supplies the server's `X-Client-Version` request contract |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Request timing, retries, model lifecycle, and Agent Mode state transitions are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | Chat, both embedding clients, OpenCode provider config, and built-in skill environments are asserted |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Header presence is visible on the next Copilot Plus request in the network inspector |

Review: inspect `src/LLMProviders/brevilabsClient.ts` — `getPluginVersionHeaders`; `src/LLMProviders/chatModelManager.ts` and `src/LLMProviders/embeddingManager.ts` — the Copilot Plus provider configs; `src/LLMProviders/CustomJinaEmbeddings.ts` — `embeddingWithRetry`; and the `buildSpawnDescriptor`/`buildOpencodeConfig` changes under `src/agentMode/backends/codex` and `src/agentMode/backends/opencode`, then run Verification steps 2–4.

## Verification

1. Build and load this branch in the Copilot test vault, then open Obsidian Developer Tools to the Network panel.
2. Send a Copilot Plus chat request and trigger both Copilot Plus embedding providers. Confirm each request includes `X-Client-Version` with the manifest version and that responses are unchanged.
3. Start OpenCode Agent Mode with a Copilot Plus model. Confirm its provider request includes the same header and a built-in relay skill receives `COPILOT_CLIENT_VERSION`.
4. Start Codex Agent Mode and invoke a built-in relay skill. Confirm it receives the same version; then repeat without an active Plus license and confirm no relay credential environment is exposed.
5. Run the focused header tests for the Brevilabs client, chat manager, embedding manager, Jina client, OpenCode backend, and Codex backend.
