### PR TITLE
Report idle Miyo chat search as ready

### DIFF
--- a/src/miyo/miyoStatusStore.test.ts
+++ b/src/miyo/miyoStatusStore.test.ts
@@ -94,9 +94,9 @@ describe("getMiyoStatusSnapshot (initial)", () => {
 });
 
 describe("refreshMiyoStatus health mapping", () => {
-  it("maps a full healthy payload to per-capability available", async () => {
+  it("maps a full healthy payload with idle chat sync to per-capability available", async () => {
     mockFetchHealth.mockResolvedValue(
-      okHealth({ relay: { status: "connected" }, chat_sync: { configured: true, active: true } })
+      okHealth({ relay: { status: "connected" }, chat_sync: { configured: true, active: false } })
     );
     const store = loadStore();
     const snap = await store.refreshMiyoStatus();
@@ -105,6 +105,15 @@ describe("refreshMiyoStatus health mapping", () => {
     expect(snap.chatSync).toBe("available");
     expect(snap.documentProcessor).toBe("available");
     expect(snap.source).toBe("fresh");
+  });
+
+  it("reports unconfigured chat sync as unavailable", async () => {
+    mockFetchHealth.mockResolvedValue(
+      okHealth({ chat_sync: { configured: false, active: false } })
+    );
+    const store = loadStore();
+
+    expect((await store.refreshMiyoStatus()).chatSync).toBe("unavailable");
   });
 
   it("degrades only the connector when relay is absent (unknown, not off)", async () => {

--- a/src/miyo/miyoStatusStore.ts
+++ b/src/miyo/miyoStatusStore.ts
@@ -297,8 +297,9 @@ function mapConnector(relay: MiyoHealthResponse["relay"]): CapabilityStatus {
 }
 
 /**
- * chat_sync absent → unknown; any platform syncing → syncing;
- * configured && active → available; otherwise unavailable.
+ * chat_sync absent → unknown; any platform syncing → syncing; configured →
+ * available; otherwise unavailable. `active` tracks syncing/connecting work,
+ * so it is normally false once chat history is ready.
  */
 function mapChatSync(chatSync: MiyoHealthResponse["chat_sync"]): CapabilityStatus {
   if (!chatSync) {
@@ -307,7 +308,7 @@ function mapChatSync(chatSync: MiyoHealthResponse["chat_sync"]): CapabilityStatu
   if (hasSyncingPlatform(chatSync.platforms)) {
     return "syncing";
   }
-  return chatSync.configured === true && chatSync.active === true ? "available" : "unavailable";
+  return chatSync.configured === true ? "available" : "unavailable";
 }
 
 function hasSyncingPlatform(


### PR DESCRIPTION
Fixes #2834

## Why

When Miyo has chat sources configured and their sync is idle, Copilot V4's Miyo settings tab incorrectly shows “Not set up — add chat sources in Miyo.” Miyo reports this healthy state as `configured: true` and `active: false`; `active` means sync or connection work is currently running, not that chat search is available.

## What

Treat configured, idle chat sync as available while preserving the existing syncing and unconfigured states. Add deterministic coverage for both configured-idle and unconfigured health responses.

## Non goal

- Changing how users configure or sync chat sources in Miyo.
- Redesigning the Miyo settings tab or changing the Connector and semantic-search rows.

## Screenshot

Not captured — the test vault retained its previously loaded Copilot bundle after deployment, and loading the new JavaScript requires a full Obsidian restart. The issue contains the before-state screenshot.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Status-store tests cover configured idle, syncing, and unconfigured chat sync |
| A defect would fail CI or be obvious on first use | ✅ | The focused status-store tests run in CI, and an incorrect state appears when the Miyo tab opens |
| A revert fully restores prior state, including persisted data | ✅ | The change performs no writes or migration |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The change only maps an existing health response to a display status |
| No public API, plugin API, message, or on-disk contract changes | ✅ | The existing `chat_sync.configured` health field is read without changing its contract |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The mapping remains synchronous and side-effect free |
| No hot-path behavior lacks deterministic coverage | ✅ | Every changed branch has deterministic status-store coverage |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The result is confined to the Miyo settings status row and appears on the next tab open |

Review: inspect `src/miyo/miyoStatusStore.ts` — `mapChatSync` — then run Verification steps 1–4.

## Verification

1. Run Miyo with chat sources configured and allow sync to finish so `/v0/health` reports `chat_sync.configured: true`, `active: false`, and every platform `syncing: false`.
2. Open Copilot Settings → Miyo and confirm Search chat reads “Ready · chats indexed.”
3. Start a chat sync and confirm the row reads “Syncing chats…”.
4. Use an unconfigured Miyo instance and confirm the row reads “Not set up — add chat sources in Miyo.”
