### PR TITLE
Preserve API keys and their provider rows through Reset Settings

### DIFF
--- a/src/components/modals/ResetSettingsConfirmModal.tsx
+++ b/src/components/modals/ResetSettingsConfirmModal.tsx
@@ -6,7 +6,12 @@ export class ResetSettingsConfirmModal extends ConfirmModal {
     super(
       app,
       onConfirm,
-      "Resetting settings will clear all settings and restore the default values. " +
+      // Reason: "clear all settings" was true only while reset also destroyed
+      // credentials. Now that keys and the rows addressing them survive, the
+      // claim is dropped rather than replaced with a list of what resets —
+      // reset fans out through settings subscribers (Copilot Plus, Agent Mode
+      // setup, per-agent model enrollment), so any such list goes stale.
+      "Resetting settings will restore the default values. " +
         'API keys are not cleared by this action — use "Delete All Keys" in Advanced Settings ' +
         "→ API Key Storage if you also want to remove them. Are you sure you want to continue?",
       "Reset Settings"

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,7 @@ import { logError, logInfo, logWarn } from "@/logger";
 import { logFileManager } from "@/logFileManager";
 import {
   createModelManagement,
+  plusSyncNeeded,
   syncCopilotPlusProvider,
   type ModelManagementApi,
 } from "@/modelManagement";
@@ -241,10 +242,7 @@ export default class CopilotPlugin extends Plugin {
           new Notice("Copilot failed to save settings. Check logs and try again.");
         }
         // Sign-in / sign-out (isPaidUser flip) or key rotation while signed in.
-        if (
-          prev?.isPaidUser !== next.isPaidUser ||
-          (next.isPaidUser && prev?.plusLicenseKey !== next.plusLicenseKey)
-        ) {
+        if (plusSyncNeeded(prev, next)) {
           syncPlus(next.isPaidUser, next.plusLicenseKey);
         }
       })();

--- a/src/modelManagement/index.ts
+++ b/src/modelManagement/index.ts
@@ -90,6 +90,7 @@ export type { PlusSetupResult, RegisterPlusProviderInput } from "./setup/Copilot
 export {
   COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
   COPILOT_PLUS_MODELS,
+  plusSyncNeeded,
   syncCopilotPlusProvider,
 } from "./setup/copilotPlusSync";
 

--- a/src/modelManagement/setup/ByokSetupApi.test.ts
+++ b/src/modelManagement/setup/ByokSetupApi.test.ts
@@ -5,7 +5,7 @@
  * same fake `app.secretStorage` shim used in `ProviderRegistry.test.ts`.
  */
 
-import { resetSettings } from "@/settings/model";
+import { resetSettings, setSettings } from "@/settings/model";
 import { KeychainService } from "@/services/keychainService";
 
 import { BackendConfigRegistry } from "@/modelManagement/backends/BackendConfigRegistry";
@@ -61,6 +61,9 @@ describe("ByokSetupApi.addModels", () => {
 
   beforeEach(() => {
     resetSettings();
+    // Reset intentionally preserves provider rows that own a keychain pointer,
+    // so clear them explicitly to get the blank slate these tests assume.
+    setSettings({ providers: {}, configuredModels: [] });
     KeychainService.resetInstance();
     const app = makeFakeApp();
     KeychainService.getInstance(app);
@@ -130,6 +133,9 @@ describe("ByokSetupApi.setupProvider", () => {
 
   beforeEach(() => {
     resetSettings();
+    // Reset intentionally preserves provider rows that own a keychain pointer,
+    // so clear them explicitly to get the blank slate these tests assume.
+    setSettings({ providers: {}, configuredModels: [] });
     KeychainService.resetInstance();
     const app = makeFakeApp();
     KeychainService.getInstance(app);

--- a/src/modelManagement/setup/copilotPlusSync.test.ts
+++ b/src/modelManagement/setup/copilotPlusSync.test.ts
@@ -3,6 +3,7 @@ import type { RegisterPlusProviderInput } from "@/modelManagement/setup/CopilotP
 import {
   COPILOT_PLUS_DEFAULT_ENABLED_MODELS,
   COPILOT_PLUS_MODELS,
+  plusSyncNeeded,
   syncCopilotPlusProvider,
 } from "@/modelManagement/setup/copilotPlusSync";
 
@@ -41,6 +42,33 @@ describe("copilotPlusSync", () => {
       "deepseek-v4-pro",
       "glm-5.2",
     ]);
+  });
+
+  describe("plusSyncNeeded()", () => {
+    const signedIn = { isPaidUser: true, plusLicenseKey: "lic-1" };
+
+    it("stays false when a signed-in user's Reset Settings preserves the paid state (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
+      // The reset write changes almost every field, but preserves both values
+      // this predicate reads — so the destructive unregister cascade (provider
+      // row, configured models, backend refs, provider keychain entry) must
+      // not fire.
+      expect(plusSyncNeeded(signedIn, { ...signedIn })).toBe(false);
+    });
+
+    it("fires on a genuine sign-out or sign-in (isPaidUser flip)", () => {
+      expect(plusSyncNeeded(signedIn, { isPaidUser: false, plusLicenseKey: "lic-1" })).toBe(true);
+      expect(plusSyncNeeded({ isPaidUser: false, plusLicenseKey: "" }, signedIn)).toBe(true);
+    });
+
+    it("fires on a key rotation while signed in, but not while signed out", () => {
+      expect(plusSyncNeeded(signedIn, { isPaidUser: true, plusLicenseKey: "lic-2" })).toBe(true);
+      expect(
+        plusSyncNeeded(
+          { isPaidUser: false, plusLicenseKey: "lic-1" },
+          { isPaidUser: false, plusLicenseKey: "lic-2" }
+        )
+      ).toBe(false);
+    });
   });
 
   describe("syncCopilotPlusProvider()", () => {

--- a/src/modelManagement/setup/copilotPlusSync.ts
+++ b/src/modelManagement/setup/copilotPlusSync.ts
@@ -13,6 +13,7 @@ import { BREVILABS_MODELS_BASE_URL, ChatModels } from "@/constants";
 import { logError } from "@/logger";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
 import type { ModelInfo } from "@/modelManagement/types/catalog";
+import type { CopilotSettings } from "@/settings/model";
 
 /**
  * The Copilot Plus models the brevilabs relay exposes. Hardcoded — there's no
@@ -112,6 +113,31 @@ export const COPILOT_PLUS_DEFAULT_ENABLED_MODELS: readonly string[] = Object.fre
   ChatModels.COPILOT_PLUS_DEEPSEEK_V4_PRO,
   ChatModels.COPILOT_PLUS_GLM_5_2,
 ]);
+
+/**
+ * Whether a settings change requires re-reconciling the Plus provider:
+ * a sign-in / sign-out (`isPaidUser` flip) or a key rotation while signed in.
+ *
+ * This is the settings subscriber's trigger, extracted so the one settings
+ * write that must NOT read as sign-out is testable: Reset Settings preserves
+ * `isPaidUser` alongside the license key, and this predicate staying false is
+ * what keeps the destructive `unregisterPlusProvider` cascade (provider row,
+ * configured models, backend refs, provider keychain entry) from firing on a
+ * signed-in user's reset.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/259
+ *
+ * @param prev - Settings before the change.
+ * @param next - Settings after the change.
+ */
+export function plusSyncNeeded(
+  prev: Pick<CopilotSettings, "isPaidUser" | "plusLicenseKey">,
+  next: Pick<CopilotSettings, "isPaidUser" | "plusLicenseKey">
+): boolean {
+  return (
+    prev.isPaidUser !== next.isPaidUser ||
+    (!!next.isPaidUser && prev.plusLicenseKey !== next.plusLicenseKey)
+  );
+}
 
 /**
  * Register or unregister the Plus provider to match Plus state. Best-effort:

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -766,6 +766,28 @@ describe("plusUtils", () => {
 
       expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
     });
+
+    it("leaves the retained paid state untouched when validation is unreachable after reset (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", async () => {
+      // The post-reset shape: reset kept isPaidUser and the license key but
+      // dropped the entitlement token. An unreachable server means "unknown",
+      // not "unentitled" — writing the paid flag here would read as sign-out
+      // to the settings subscriber (`plusSyncNeeded`) and tear down the
+      // preserved Plus provider and its keychain entry.
+      mockGetSettings.mockReturnValue(
+        buildSettings({
+          plusLicenseKey: "key",
+          isPaidUser: true,
+          isPlusUser: false,
+          entitlementToken: "",
+        })
+      );
+      mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
+
+      expect(await checkIsPaidUser(undefined, { trigger: "manual" })).toBe(false);
+      expect(mockValidateLicenseKey).toHaveBeenCalled();
+      expect(mockSetSettings).not.toHaveBeenCalled();
+      expect(mockUpdateSetting).not.toHaveBeenCalled();
+    });
   });
 
   describe("useLicenseState()", () => {

--- a/src/plusUtils.test.ts
+++ b/src/plusUtils.test.ts
@@ -779,6 +779,7 @@ describe("plusUtils", () => {
           isPaidUser: true,
           isPlusUser: false,
           entitlementToken: "",
+          entitlementExpiresAt: FUTURE_EXP_SECONDS * 1000,
         })
       );
       mockValidateLicenseKey.mockRejectedValue(new Error("net::ERR_INTERNET_DISCONNECTED"));
@@ -830,6 +831,26 @@ describe("plusUtils", () => {
       // stops naming a plan whose entitlement has already closed.
       await verifySessionClaims({ plan: "plus", tier: "plus", exp: PAST_EXP_SECONDS });
       mockGetSettings.mockReturnValue(tokenBackedSettings({ plusLicenseKey: "key" }));
+
+      const { result } = renderHook(() => useLicenseState());
+
+      expect(result.current).toEqual({ status: "inactive" });
+    });
+
+    it("reports inactive once the retained post-reset expiry has passed (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
+      // The post-reset shape: reset kept isPaidUser and the original expiry
+      // but dropped the token, so no signed claims exist. The retained expiry
+      // is what keeps this display time-bounded — without it a reset user
+      // offline would read Active forever.
+      mockGetSettings.mockReturnValue(
+        buildSettings({
+          plusLicenseKey: "key",
+          isPaidUser: true,
+          isPlusUser: false,
+          entitlementToken: "",
+          entitlementExpiresAt: PAST_EXP_SECONDS * 1000,
+        })
+      );
 
       const { result } = renderHook(() => useLicenseState());
 

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -1074,8 +1074,8 @@ describe("model", () => {
     it("preserves the top-level vendor config a retained key needs to reach its service", () => {
       // Reason: these are not secrets, so the secret-key heuristic misses them,
       // but a key without them is unusable — Azure composes its request URL
-      // from the instance/deployment/version trio, Bedrock signs for a region,
-      // and a zeroed Copilot expiry forces a refresh that fails while offline.
+      // from the instance/deployment/version trio, and Bedrock signs for a
+      // region.
       const vendorConfig = {
         openAIOrgId: "org-123",
         azureOpenAIApiInstanceName: "my-instance",
@@ -1083,7 +1083,6 @@ describe("model", () => {
         azureOpenAIApiVersion: "2025-01-01-preview",
         azureOpenAIApiEmbeddingDeploymentName: "embed-deploy",
         amazonBedrockRegion: "eu-west-1",
-        githubCopilotTokenExpiresAt: 1893456000000,
       };
       settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, ...vendorConfig });
 
@@ -1100,13 +1099,36 @@ describe("model", () => {
       settingsStore.set(settingsAtom, {
         ...DEFAULT_SETTINGS,
         plusLicenseKey: "lic-12345",
-        entitlementToken: "eyJhbGciOiJFUzI1NiJ9.stale",
+        entitlementToken: "test-stale-entitlement-token",
       });
 
       resetSettings();
 
       const after = settingsStore.get(settingsAtom);
       expect(after.plusLicenseKey).toBe("lic-12345");
+      expect(after.entitlementToken).toBe(DEFAULT_SETTINGS.entitlementToken);
+    });
+
+    it("keeps a signed-in user's paid state so reset never reads as sign-out (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
+      // Reason: the settings subscriber treats an `isPaidUser` flip as
+      // sign-out and tears down the Plus provider, its models, and its
+      // keychain entry — destroying exactly what reset preserves. The strict
+      // `isPlusUser` flag still resets: its proof (the entitlement token) is
+      // dropped, and the next validation re-derives it.
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        isPaidUser: true,
+        isPlusUser: true,
+        plusLicenseKey: "lic-12345",
+        entitlementToken: "test-stale-entitlement-token",
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      expect(after.isPaidUser).toBe(true);
+      expect(after.plusLicenseKey).toBe("lic-12345");
+      expect(after.isPlusUser).toBe(DEFAULT_SETTINGS.isPlusUser);
       expect(after.entitlementToken).toBe(DEFAULT_SETTINGS.entitlementToken);
     });
 

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -964,7 +964,7 @@ describe("model", () => {
       expect(new Set(after.copilotRootHistory)).toEqual(new Set(["copilot", "ai", "team-ai"]));
     });
 
-    it("preserves providers with keychain credentials", () => {
+    it("preserves providers with keychain credentials (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
       settingsStore.set(settingsAtom, {
         ...DEFAULT_SETTINGS,
         providers: {
@@ -1032,7 +1032,7 @@ describe("model", () => {
       }
     );
 
-    it("preserves every custom model, including rows that carry no key", () => {
+    it("preserves every custom model, including rows that carry no key (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
       // Reason: the keychain is the sole secret store, so an empty in-memory
       // apiKey may just mean this session's keychain read failed. Dropping the
       // row would strand the entry with no identity left to reattach it to.
@@ -1080,7 +1080,7 @@ describe("model", () => {
       expect(after.googleApiKey).toBe(DEFAULT_SETTINGS.googleApiKey);
     });
 
-    it("preserves the top-level vendor config a retained key needs to reach its service", () => {
+    it("preserves the top-level vendor config a retained key needs to reach its service (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
       // Reason: these are not secrets, so the secret-key heuristic misses them,
       // but a key without them is unusable — Azure composes its request URL
       // from the instance/deployment/version trio, and Bedrock signs for a
@@ -1100,7 +1100,7 @@ describe("model", () => {
       expect(settingsStore.get(settingsAtom)).toMatchObject(vendorConfig);
     });
 
-    it("drops the entitlement token, whose identity binding reset invalidates", () => {
+    it("drops the entitlement token, whose identity binding reset invalidates (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
       // Reason: `verifyEntitlement` checks the token against `settings.userId`,
       // and reset replaces that with a fresh uuid — a carried-over token could
       // never verify again. `plusLicenseKey` is the credential worth keeping;
@@ -1146,7 +1146,7 @@ describe("model", () => {
       expect(after.entitlementToken).toBe(DEFAULT_SETTINGS.entitlementToken);
     });
 
-    it("drops a bundle value whose type its consumer cannot handle", () => {
+    it("drops a bundle value whose type its consumer cannot handle (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
       // Reason: a hand-edited or cross-version `data.json` can hold a non-string
       // where a string is expected. Carrying it through reset would move the
       // failure to the consumer — chatModelManager calls `.trim()` on the region.
@@ -1163,7 +1163,7 @@ describe("model", () => {
       expect(after.amazonBedrockRegion).toBe(DEFAULT_SETTINGS.amazonBedrockRegion);
     });
 
-    it("preserves the Azure routing fields on a builtin embedding row alongside its key", () => {
+    it("preserves the Azure routing fields on a builtin embedding row alongside its key (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
       // Reason: Azure is the one builtin row whose request URL is assembled
       // from per-row fields (embeddingManager reads instance + embedding
       // deployment + version). Keeping only the key would leave it pointed at
@@ -1220,7 +1220,7 @@ describe("model", () => {
       expect(restored!.apiKey).toBe(BUILTIN_CHAT_MODELS[0].apiKey);
     });
 
-    it("preserves configured models belonging to preserved providers", () => {
+    it("preserves configured models belonging to preserved providers (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", () => {
       const providerId1 = "prov-with-key";
       const providerId2 = "prov-no-key";
       settingsStore.set(settingsAtom, {

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -5,6 +5,8 @@ import {
   DEFAULT_SYSTEM_PROMPT,
   DEFAULT_SETTINGS,
   SEND_SHORTCUT,
+  BUILTIN_CHAT_MODELS,
+  BUILTIN_EMBEDDING_MODELS,
 } from "@/constants";
 import {
   normalizeRootFolders,
@@ -16,7 +18,9 @@ import {
   settingsStore,
   validateCopilotFolder,
   CopilotSettings,
+  getModelKeyFromModel,
 } from "@/settings/model";
+import { CustomModel } from "@/aiParams";
 import { getEffectiveUserPrompt, getSystemPrompt } from "@/system-prompts/systemPromptBuilder";
 import * as systemPromptsState from "@/system-prompts/state";
 import * as settingsModel from "@/settings/model";
@@ -958,6 +962,300 @@ describe("model", () => {
       expect(after.copilotFolder).toBe(DEFAULT_SETTINGS.copilotFolder);
       // Legacy + historical + pre-reset active root all survive the reset.
       expect(new Set(after.copilotRootHistory)).toEqual(new Set(["copilot", "ai", "team-ai"]));
+    });
+
+    it("preserves providers with keychain credentials", () => {
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        providers: {
+          byok_openai: {
+            providerId: "byok_openai",
+            providerType: "openai-compatible",
+            displayName: "My OpenAI",
+            apiKeyKeychainId: "keychain-id-123",
+            origin: { kind: "byok" },
+            addedAt: Date.now(),
+          },
+          byok_anthropic: {
+            providerId: "byok_anthropic",
+            providerType: "anthropic",
+            displayName: "No Key",
+            origin: { kind: "byok" },
+            addedAt: Date.now(),
+          },
+        },
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      expect(after.providers.byok_openai).toBeDefined();
+      expect(after.providers.byok_openai.apiKeyKeychainId).toBe("keychain-id-123");
+      expect(after.providers.byok_anthropic).toBeUndefined();
+    });
+
+    it("preserves a builtin model's key and endpoint while resetting its preferences", () => {
+      // Reason: the endpoint has to survive alongside the key. Resetting only
+      // baseUrl would leave a proxy credential pointed at the provider's
+      // default host, sending the user's key somewhere they never configured.
+      const customGpt4: CustomModel = {
+        ...BUILTIN_CHAT_MODELS[0],
+        enabled: false,
+        apiKey: "sk-saved",
+        baseUrl: "https://proxy.example.test/v1",
+        temperature: 0.9,
+      };
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        activeModels: [customGpt4],
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      const restored = after.activeModels.find(
+        (m) => getModelKeyFromModel(m) === getModelKeyFromModel(BUILTIN_CHAT_MODELS[0])
+      );
+      expect(restored).toBeDefined();
+      expect(restored!.apiKey).toBe("sk-saved");
+      expect(restored!.baseUrl).toBe("https://proxy.example.test/v1");
+      expect(restored!.enabled).toBe(BUILTIN_CHAT_MODELS[0].enabled);
+      expect(restored!.temperature).toBe(BUILTIN_CHAT_MODELS[0].temperature);
+    });
+
+    it("preserves every custom model, including rows that carry no key", () => {
+      // Reason: the keychain is the sole secret store, so an empty in-memory
+      // apiKey may just mean this session's keychain read failed. Dropping the
+      // row would strand the entry with no identity left to reattach it to.
+      const withKey: CustomModel = {
+        name: "my-llama",
+        provider: "openai",
+        enabled: true,
+        apiKey: "sk-custom",
+        baseUrl: "http://localhost:1234",
+      };
+      const withoutKey: CustomModel = {
+        name: "ollama-llama",
+        provider: "ollama",
+        enabled: true,
+      };
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        activeModels: [withKey, withoutKey],
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      const myLlama = after.activeModels.find((m) => m.name === "my-llama");
+      expect(myLlama?.apiKey).toBe("sk-custom");
+      expect(myLlama?.baseUrl).toBe("http://localhost:1234");
+      expect(after.activeModels.find((m) => m.name === "ollama-llama")).toBeDefined();
+    });
+
+    it("filters out null/undefined top-level secrets", () => {
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        openAIApiKey: "valid-key",
+        plusLicenseKey: "lic-12345",
+        anthropicApiKey: null as unknown as string,
+        googleApiKey: undefined as unknown as string,
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      expect(after.openAIApiKey).toBe("valid-key");
+      expect(after.plusLicenseKey).toBe("lic-12345");
+      expect(after.anthropicApiKey).toBe(DEFAULT_SETTINGS.anthropicApiKey);
+      expect(after.googleApiKey).toBe(DEFAULT_SETTINGS.googleApiKey);
+    });
+
+    it("preserves the top-level vendor config a retained key needs to reach its service", () => {
+      // Reason: these are not secrets, so the secret-key heuristic misses them,
+      // but a key without them is unusable — Azure composes its request URL
+      // from the instance/deployment/version trio, Bedrock signs for a region,
+      // and a zeroed Copilot expiry forces a refresh that fails while offline.
+      const vendorConfig = {
+        openAIOrgId: "org-123",
+        azureOpenAIApiInstanceName: "my-instance",
+        azureOpenAIApiDeploymentName: "chat-deploy",
+        azureOpenAIApiVersion: "2025-01-01-preview",
+        azureOpenAIApiEmbeddingDeploymentName: "embed-deploy",
+        amazonBedrockRegion: "eu-west-1",
+        githubCopilotTokenExpiresAt: 1893456000000,
+      };
+      settingsStore.set(settingsAtom, { ...DEFAULT_SETTINGS, ...vendorConfig });
+
+      resetSettings();
+
+      expect(settingsStore.get(settingsAtom)).toMatchObject(vendorConfig);
+    });
+
+    it("drops the entitlement token, whose identity binding reset invalidates", () => {
+      // Reason: `verifyEntitlement` checks the token against `settings.userId`,
+      // and reset replaces that with a fresh uuid — a carried-over token could
+      // never verify again. `plusLicenseKey` is the credential worth keeping;
+      // the next license check re-issues the token from it.
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        plusLicenseKey: "lic-12345",
+        entitlementToken: "eyJhbGciOiJFUzI1NiJ9.stale",
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      expect(after.plusLicenseKey).toBe("lic-12345");
+      expect(after.entitlementToken).toBe(DEFAULT_SETTINGS.entitlementToken);
+    });
+
+    it("drops a bundle value whose type its consumer cannot handle", () => {
+      // Reason: a hand-edited or cross-version `data.json` can hold a non-string
+      // where a string is expected. Carrying it through reset would move the
+      // failure to the consumer — chatModelManager calls `.trim()` on the region.
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        amazonBedrockApiKey: "bedrock-key",
+        amazonBedrockRegion: {} as unknown as string,
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      expect(after.amazonBedrockApiKey).toBe("bedrock-key");
+      expect(after.amazonBedrockRegion).toBe(DEFAULT_SETTINGS.amazonBedrockRegion);
+    });
+
+    it("preserves the Azure routing fields on a builtin embedding row alongside its key", () => {
+      // Reason: Azure is the one builtin row whose request URL is assembled
+      // from per-row fields (embeddingManager reads instance + embedding
+      // deployment + version). Keeping only the key would leave it pointed at
+      // an address that cannot be built.
+      const azureDefault = BUILTIN_EMBEDDING_MODELS.find((m) => m.provider === "azure openai");
+      expect(azureDefault).toBeDefined();
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        activeEmbeddingModels: [
+          {
+            ...azureDefault!,
+            apiKey: "az-key",
+            azureOpenAIApiInstanceName: "my-instance",
+            azureOpenAIApiEmbeddingDeploymentName: "embed-deploy",
+            azureOpenAIApiVersion: "2025-01-01-preview",
+            enabled: false,
+          },
+        ],
+      });
+
+      resetSettings();
+
+      const restored = settingsStore
+        .get(settingsAtom)
+        .activeEmbeddingModels.find(
+          (m) => getModelKeyFromModel(m) === getModelKeyFromModel(azureDefault!)
+        );
+      expect(restored).toMatchObject({
+        apiKey: "az-key",
+        azureOpenAIApiInstanceName: "my-instance",
+        azureOpenAIApiEmbeddingDeploymentName: "embed-deploy",
+        azureOpenAIApiVersion: "2025-01-01-preview",
+      });
+      expect(restored!.enabled).toBe(azureDefault!.enabled);
+    });
+
+    it("filters out null/undefined model secrets", () => {
+      const modelWithNull: CustomModel = {
+        ...BUILTIN_CHAT_MODELS[0],
+        apiKey: null as unknown as string,
+      };
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        activeModels: [modelWithNull],
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      const restored = after.activeModels.find(
+        (m) => getModelKeyFromModel(m) === getModelKeyFromModel(BUILTIN_CHAT_MODELS[0])
+      );
+      expect(restored).toBeDefined();
+      expect(restored!.apiKey).toBe(BUILTIN_CHAT_MODELS[0].apiKey);
+    });
+
+    it("preserves configured models belonging to preserved providers", () => {
+      const providerId1 = "prov-with-key";
+      const providerId2 = "prov-no-key";
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        providers: {
+          [providerId1]: {
+            providerId: providerId1,
+            providerType: "openai-compatible",
+            displayName: "Provider With Key",
+            apiKeyKeychainId: "kc-123",
+            origin: { kind: "byok" },
+            addedAt: Date.now(),
+          },
+          [providerId2]: {
+            providerId: providerId2,
+            providerType: "openai-compatible",
+            displayName: "Provider No Key (Ollama)",
+            origin: { kind: "byok" },
+            addedAt: Date.now(),
+          },
+        },
+        configuredModels: [
+          {
+            configuredModelId: "model-1",
+            providerId: providerId1,
+            info: { id: "gpt-4", displayName: "GPT-4" },
+            configuredAt: Date.now(),
+          },
+          {
+            configuredModelId: "model-2",
+            providerId: providerId2,
+            info: { id: "llama3", displayName: "Llama 3" },
+            configuredAt: Date.now(),
+          },
+        ],
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      expect(after.providers[providerId1]).toBeDefined();
+      expect(after.providers[providerId2]).toBeUndefined();
+      expect(after.configuredModels.length).toBe(1);
+      expect(after.configuredModels[0].configuredModelId).toBe("model-1");
+      expect(after.configuredModels[0].providerId).toBe(providerId1);
+    });
+
+    it("clears backends regardless of preserved providers", () => {
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        providers: {
+          prov1: {
+            providerId: "prov1",
+            providerType: "openai-compatible",
+            displayName: "Provider",
+            apiKeyKeychainId: "kc-123",
+            origin: { kind: "byok" },
+            addedAt: Date.now(),
+          },
+        },
+        backends: {
+          chat: { enabledModels: ["model-1", "model-2"] },
+          opencode: { enabledModels: ["model-3"] },
+        },
+      });
+
+      resetSettings();
+
+      const after = settingsStore.get(settingsAtom);
+      expect(after.providers.prov1).toBeDefined();
+      expect(after.backends).toEqual(DEFAULT_SETTINGS.backends);
     });
   });
 });

--- a/src/settings/model.test.ts
+++ b/src/settings/model.test.ts
@@ -994,34 +994,43 @@ describe("model", () => {
       expect(after.providers.byok_anthropic).toBeUndefined();
     });
 
-    it("preserves a builtin model's key and endpoint while resetting its preferences", () => {
-      // Reason: the endpoint has to survive alongside the key. Resetting only
-      // baseUrl would leave a proxy credential pointed at the provider's
-      // default host, sending the user's key somewhere they never configured.
-      const customGpt4: CustomModel = {
-        ...BUILTIN_CHAT_MODELS[0],
-        enabled: false,
-        apiKey: "sk-saved",
-        baseUrl: "https://proxy.example.test/v1",
-        temperature: 0.9,
-      };
-      settingsStore.set(settingsAtom, {
-        ...DEFAULT_SETTINGS,
-        activeModels: [customGpt4],
-      });
+    it.each([false, true])(
+      "preserves a builtin model's credential routing, including enableCors=%s, while resetting its preferences (https://github.com/logancyang/obsidian-copilot-preview/issues/259)",
+      (enableCors) => {
+        // Reason: the endpoint has to survive alongside the key. Resetting only
+        // baseUrl would leave a proxy credential pointed at the provider's
+        // default host, sending the user's key somewhere they never configured.
+        // `enableCors` is the one boolean in the bundle — `false` surviving is
+        // exactly what its dedicated `carriesConfiguration` branch exists for.
+        const customGpt4: CustomModel = {
+          ...BUILTIN_CHAT_MODELS[0],
+          enabled: false,
+          apiKey: "sk-saved",
+          baseUrl: "https://proxy.example.test/v1",
+          openAIOrgId: "org-model",
+          enableCors,
+          temperature: 0.9,
+        };
+        settingsStore.set(settingsAtom, {
+          ...DEFAULT_SETTINGS,
+          activeModels: [customGpt4],
+        });
 
-      resetSettings();
+        resetSettings();
 
-      const after = settingsStore.get(settingsAtom);
-      const restored = after.activeModels.find(
-        (m) => getModelKeyFromModel(m) === getModelKeyFromModel(BUILTIN_CHAT_MODELS[0])
-      );
-      expect(restored).toBeDefined();
-      expect(restored!.apiKey).toBe("sk-saved");
-      expect(restored!.baseUrl).toBe("https://proxy.example.test/v1");
-      expect(restored!.enabled).toBe(BUILTIN_CHAT_MODELS[0].enabled);
-      expect(restored!.temperature).toBe(BUILTIN_CHAT_MODELS[0].temperature);
-    });
+        const after = settingsStore.get(settingsAtom);
+        const restored = after.activeModels.find(
+          (m) => getModelKeyFromModel(m) === getModelKeyFromModel(BUILTIN_CHAT_MODELS[0])
+        );
+        expect(restored).toBeDefined();
+        expect(restored!.apiKey).toBe("sk-saved");
+        expect(restored!.baseUrl).toBe("https://proxy.example.test/v1");
+        expect(restored!.openAIOrgId).toBe("org-model");
+        expect(restored!.enableCors).toBe(enableCors);
+        expect(restored!.enabled).toBe(BUILTIN_CHAT_MODELS[0].enabled);
+        expect(restored!.temperature).toBe(BUILTIN_CHAT_MODELS[0].temperature);
+      }
+    );
 
     it("preserves every custom model, including rows that carry no key", () => {
       // Reason: the keychain is the sole secret store, so an empty in-memory
@@ -1121,12 +1130,17 @@ describe("model", () => {
         isPlusUser: true,
         plusLicenseKey: "lic-12345",
         entitlementToken: "test-stale-entitlement-token",
+        entitlementExpiresAt: 4_000_000_000_000,
       });
 
       resetSettings();
 
       const after = settingsStore.get(settingsAtom);
       expect(after.isPaidUser).toBe(true);
+      // The expiry travels with the paid flag: it is tighten-only, and
+      // zeroing it would leave the license UI showing Active forever while
+      // offline.
+      expect(after.entitlementExpiresAt).toBe(4_000_000_000_000);
       expect(after.plusLicenseKey).toBe("lic-12345");
       expect(after.isPlusUser).toBe(DEFAULT_SETTINGS.isPlusUser);
       expect(after.entitlementToken).toBe(DEFAULT_SETTINGS.entitlementToken);

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -619,6 +619,7 @@ export function getSettings(): Readonly<CopilotSettings> {
  * embedding row. Azure's *chat* deployment and `bedrockRegion` are absent
  * because no builtin row uses those providers; custom rows survive whole and
  * never consult this list.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/259
  */
 const MODEL_CREDENTIAL_BUNDLE_FIELDS = [
   ...MODEL_SECRET_FIELDS,
@@ -638,6 +639,7 @@ const MODEL_CREDENTIAL_BUNDLE_FIELDS = [
  * in-process entitlement looking live while the Plus provider is unregistered.
  * `plusLicenseKey` is the real credential and is preserved; the next license
  * check re-issues this token.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/259
  */
 const SESSION_PROOF_FIELD = "entitlementToken";
 
@@ -738,6 +740,7 @@ function preserveModelCredentials(
   // read failed". Dropping the row on that signal would strand the keychain
   // entry with no `name|provider` identity left to reattach it to. Reset is not
   // a cleanup tool, so it errs toward keeping rows.
+  // https://github.com/logancyang/obsidian-copilot-preview/issues/259
   const customModels = currentModels.filter(
     (model) => !defaultKeys.has(getModelKeyFromModel(model))
   );
@@ -755,6 +758,7 @@ function preserveModelCredentials(
  * credential. Whole rows survive because `baseUrl` / `extras` / `providerType`
  * are what make the key usable; keyless rows (Ollama, LMStudio) carry nothing
  * and are reset away.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/259
  *
  * @param providers - The pre-reset provider rows.
  */

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -657,16 +657,14 @@ const TOP_LEVEL_CREDENTIAL_COMPANION_FIELDS = [
   "azureOpenAIApiVersion",
   "azureOpenAIApiEmbeddingDeploymentName",
   "amazonBedrockRegion",
-  "githubCopilotTokenExpiresAt",
 ] as const satisfies readonly (keyof CopilotSettings)[];
 
 /**
  * The top-level counterpart of {@link MODEL_CREDENTIAL_BUNDLE_FIELDS}.
  *
  * Kept separate from the model list rather than merged into one array because
- * the two address different objects with different field names, types, and
- * lifetimes — `githubCopilotTokenExpiresAt` is a number that only exists at
- * top level, `enableCors` only exists per row.
+ * the two address different objects with different field names — the Azure
+ * deployment trio only exists at top level, `enableCors` only exists per row.
  */
 const TOP_LEVEL_CREDENTIAL_BUNDLE_FIELDS: readonly string[] = [
   ...TOP_LEVEL_SECRET_FIELDS.filter((field) => field !== SESSION_PROOF_FIELD),
@@ -679,7 +677,7 @@ const TOP_LEVEL_CREDENTIAL_BUNDLE_FIELDS: readonly string[] = [
  * Reason: the bundles are almost entirely strings, and the string check is what
  * stops a corrupted or cross-version value (say `amazonBedrockRegion: {}` from
  * a hand-edited `data.json`) from surviving reset and then throwing at its
- * consumer. Only two fields are legitimately non-string, so they are named here
+ * consumer. Only `enableCors` is legitimately non-string, so it is named here
  * rather than widening the check for everything.
  *
  * @param field - Bundle field being considered, which decides the expected type.
@@ -687,9 +685,6 @@ const TOP_LEVEL_CREDENTIAL_BUNDLE_FIELDS: readonly string[] = [
  */
 function carriesConfiguration(field: string, value: unknown): boolean {
   if (field === "enableCors") return typeof value === "boolean";
-  if (field === "githubCopilotTokenExpiresAt") {
-    return typeof value === "number" && Number.isFinite(value);
-  }
   return typeof value === "string" && value.length > 0;
 }
 
@@ -859,6 +854,16 @@ export function resetSettings(): void {
   const defaultSettingsWithBuiltIns = {
     ...DEFAULT_SETTINGS,
     ...preservedTopLevelSecrets,
+    // Reason: reset is not a sign-out event. Flipping `isPaidUser` to the
+    // default `false` reads as sign-out to the settings subscriber, whose
+    // Plus reconcile tears down the preserved Plus provider, its models, and
+    // its keychain entry (`plusSyncNeeded` → `unregisterPlusProvider`). Keep
+    // the last server-confirmed paid state until the preserved license is
+    // revalidated. The strict `isPlusUser` flag is NOT kept: reset drops the
+    // signed entitlement token, and the strict gate must never trust a bare
+    // boolean without that proof — the next validation re-derives it.
+    // https://github.com/logancyang/obsidian-copilot-preview/issues/259
+    isPaidUser: current.isPaidUser,
     activeModels: preserveModelCredentials(
       BUILTIN_CHAT_MODELS.map((model) => ({ ...model, enabled: true })),
       current.activeModels ?? []

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -828,6 +828,13 @@ function preserveConfiguredModelsForProviders(
  * Preserving the rows above is what makes that note safe: the keychain entries
  * this function deliberately leaves behind stay reachable, instead of becoming
  * orphans no surviving pointer names.
+ *
+ * DESIGN NOTE — `_keychainVaultId` needs no entry in the preserved lists.
+ * `setSettings` merges (`{ ...prev, ...partial }`), and neither
+ * `DEFAULT_SETTINGS` nor the preserved slices carry that key, so the
+ * pre-reset keychain namespace flows through reset untouched; the
+ * reset → persist → reload integration test asserts it survives to disk.
+ * If a future review flags this again, point them at this note.
  */
 export function resetSettings(): void {
   const current = getSettings();

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -679,6 +679,7 @@ const TOP_LEVEL_CREDENTIAL_BUNDLE_FIELDS: readonly string[] = [
  * a hand-edited `data.json`) from surviving reset and then throwing at its
  * consumer. Only `enableCors` is legitimately non-string, so it is named here
  * rather than widening the check for everything.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/259
  *
  * @param field - Bundle field being considered, which decides the expected type.
  * @param value - The pre-reset value.
@@ -858,12 +859,17 @@ export function resetSettings(): void {
     // default `false` reads as sign-out to the settings subscriber, whose
     // Plus reconcile tears down the preserved Plus provider, its models, and
     // its keychain entry (`plusSyncNeeded` → `unregisterPlusProvider`). Keep
-    // the last server-confirmed paid state until the preserved license is
-    // revalidated. The strict `isPlusUser` flag is NOT kept: reset drops the
-    // signed entitlement token, and the strict gate must never trust a bare
-    // boolean without that proof — the next validation re-derives it.
+    // the last server-confirmed paid state AND its original expiry bound until
+    // the preserved license is revalidated — the expiry is tighten-only data
+    // (`isEntitlementExpired`), so keeping it can only close the license UI
+    // earlier, never hold it open; zeroing it would leave a tokenless
+    // paid-Active display with no time bound while offline. The strict
+    // `isPlusUser` flag is NOT kept: reset drops the signed entitlement
+    // token, and the strict gate must never trust a bare boolean without
+    // that proof — the next validation re-derives it.
     // https://github.com/logancyang/obsidian-copilot-preview/issues/259
     isPaidUser: current.isPaidUser,
+    entitlementExpiresAt: current.entitlementExpiresAt,
     activeModels: preserveModelCredentials(
       BUILTIN_CHAT_MODELS.map((model) => ({ ...model, enabled: true })),
       current.activeModels ?? []

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import type { CopilotMode, ModelSelection } from "@/agentMode";
 import { ChainType } from "@/chainType";
 import type { BackendConfig, BackendType, ConfiguredModel, Provider } from "@/modelManagement";
+import { MODEL_SECRET_FIELDS, TOP_LEVEL_SECRET_FIELDS } from "@/services/settingsSecretTransforms";
 import { type SortStrategy, isSortStrategy } from "@/utils/recentUsageManager";
 import {
   AGENT_MAX_ITERATIONS_LIMIT,
@@ -605,7 +606,215 @@ export function getSettings(): Readonly<CopilotSettings> {
 }
 
 /**
- * Resets the settings to the default values.
+ * A builtin model row's credential bundle: the key, plus the non-secret fields
+ * without which that key cannot reach its service.
+ *
+ * Reason: none of the added fields is a secret, so they are deliberately kept
+ * out of `MODEL_SECRET_FIELDS`, which also drives persist-time secret
+ * stripping — listing them there would blank routing config on every save.
+ * They belong here because a key without its routing is worse than no key at
+ * all: `baseUrl` decides which host receives it (a reset endpoint sends a proxy
+ * key to the provider's default host), and the Azure trio is what
+ * `embeddingManager` composes into the request URL for the builtin Azure
+ * embedding row. Azure's *chat* deployment and `bedrockRegion` are absent
+ * because no builtin row uses those providers; custom rows survive whole and
+ * never consult this list.
+ */
+const MODEL_CREDENTIAL_BUNDLE_FIELDS = [
+  ...MODEL_SECRET_FIELDS,
+  "baseUrl",
+  "enableCors",
+  "openAIOrgId",
+  "azureOpenAIApiInstanceName",
+  "azureOpenAIApiVersion",
+  "azureOpenAIApiEmbeddingDeploymentName",
+] as const satisfies readonly (keyof CustomModel)[];
+
+/**
+ * A session proof rather than a credential, despite matching the secret-key
+ * heuristic. `verifyEntitlement` checks it against `settings.userId`, which
+ * reset replaces with a fresh `uuidv4()`, so a carried-over token could never
+ * verify again — it would only survive as dead state that keeps the
+ * in-process entitlement looking live while the Plus provider is unregistered.
+ * `plusLicenseKey` is the real credential and is preserved; the next license
+ * check re-issues this token.
+ */
+const SESSION_PROOF_FIELD = "entitlementToken";
+
+/**
+ * Non-secret top-level fields a preserved credential needs in order to reach
+ * its service: the vendor config a model row falls back to when it does not
+ * carry its own.
+ *
+ * Typed against `CopilotSettings` so a mistyped name fails the build. The
+ * secret half cannot be typed this way because it is derived at runtime from
+ * `DEFAULT_SETTINGS`, which is exactly why the hand-written half is.
+ */
+const TOP_LEVEL_CREDENTIAL_COMPANION_FIELDS = [
+  "openAIOrgId",
+  "azureOpenAIApiInstanceName",
+  "azureOpenAIApiDeploymentName",
+  "azureOpenAIApiVersion",
+  "azureOpenAIApiEmbeddingDeploymentName",
+  "amazonBedrockRegion",
+  "githubCopilotTokenExpiresAt",
+] as const satisfies readonly (keyof CopilotSettings)[];
+
+/**
+ * The top-level counterpart of {@link MODEL_CREDENTIAL_BUNDLE_FIELDS}.
+ *
+ * Kept separate from the model list rather than merged into one array because
+ * the two address different objects with different field names, types, and
+ * lifetimes — `githubCopilotTokenExpiresAt` is a number that only exists at
+ * top level, `enableCors` only exists per row.
+ */
+const TOP_LEVEL_CREDENTIAL_BUNDLE_FIELDS: readonly string[] = [
+  ...TOP_LEVEL_SECRET_FIELDS.filter((field) => field !== SESSION_PROOF_FIELD),
+  ...TOP_LEVEL_CREDENTIAL_COMPANION_FIELDS,
+];
+
+/**
+ * Whether a pre-reset value is usable configuration worth carrying over.
+ *
+ * Reason: the bundles are almost entirely strings, and the string check is what
+ * stops a corrupted or cross-version value (say `amazonBedrockRegion: {}` from
+ * a hand-edited `data.json`) from surviving reset and then throwing at its
+ * consumer. Only two fields are legitimately non-string, so they are named here
+ * rather than widening the check for everything.
+ *
+ * @param field - Bundle field being considered, which decides the expected type.
+ * @param value - The pre-reset value.
+ */
+function carriesConfiguration(field: string, value: unknown): boolean {
+  if (field === "enableCors") return typeof value === "boolean";
+  if (field === "githubCopilotTokenExpiresAt") {
+    return typeof value === "number" && Number.isFinite(value);
+  }
+  return typeof value === "string" && value.length > 0;
+}
+
+/**
+ * Overlay a preserved credential bundle onto a default model row.
+ *
+ * Reason: a builtin model's identity and parameters belong to the shipped
+ * default, but its credential belongs to the user — and a credential is only
+ * usable against the service it was issued for. This narrow allowlist resets
+ * preferences such as enabled state and temperature while keeping the retained
+ * key pointed where the user aimed it.
+ *
+ * @param defaultModel - The freshly built default row that owns the identity.
+ * @param source - The pre-reset row supplying the credential bundle.
+ */
+function withPreservedModelCredential(defaultModel: CustomModel, source: CustomModel): CustomModel {
+  const merged = { ...defaultModel } as unknown as Record<string, unknown>;
+  const sourceRecord = source as unknown as Record<string, unknown>;
+  for (const field of MODEL_CREDENTIAL_BUNDLE_FIELDS) {
+    const value = sourceRecord[field];
+    if (carriesConfiguration(field, value)) {
+      merged[field] = value;
+    }
+  }
+  return merged as unknown as CustomModel;
+}
+
+/**
+ * Rebuild one model list for reset: builtin rows return to their defaults but
+ * keep their credential and its endpoint, and every custom row survives intact.
+ *
+ * @param defaultModels - Builtin rows as a fresh install would have them.
+ * @param currentModels - The pre-reset rows to harvest credentials from.
+ */
+function preserveModelCredentials(
+  defaultModels: CustomModel[],
+  currentModels: CustomModel[]
+): CustomModel[] {
+  const currentByKey = new Map(currentModels.map((model) => [getModelKeyFromModel(model), model]));
+  const defaultKeys = new Set(defaultModels.map((model) => getModelKeyFromModel(model)));
+
+  const restoredBuiltIns = defaultModels.map((defaultModel) => {
+    const previous = currentByKey.get(getModelKeyFromModel(defaultModel));
+    return previous ? withPreservedModelCredential(defaultModel, previous) : defaultModel;
+  });
+
+  // Reason: every custom row is kept, including apparently keyless ones. The
+  // keychain is the sole secret store, so an empty in-memory `apiKey` is
+  // ambiguous — it means either "no credential" or "this session's keychain
+  // read failed". Dropping the row on that signal would strand the keychain
+  // entry with no `name|provider` identity left to reattach it to. Reset is not
+  // a cleanup tool, so it errs toward keeping rows.
+  const customModels = currentModels.filter(
+    (model) => !defaultKeys.has(getModelKeyFromModel(model))
+  );
+
+  return [...restoredBuiltIns, ...customModels];
+}
+
+/**
+ * Keep only the provider rows that own a credential, so reset does not orphan
+ * the keychain entries those rows point at.
+ *
+ * Selection is by pointer truthiness rather than `requiresApiKey`: Plus sign-in
+ * creates its provider with `requiresApiKey: false` and then stores the license
+ * key via `setApiKey`, so filtering on that flag would silently drop a real
+ * credential. Whole rows survive because `baseUrl` / `extras` / `providerType`
+ * are what make the key usable; keyless rows (Ollama, LMStudio) carry nothing
+ * and are reset away.
+ *
+ * @param providers - The pre-reset provider rows.
+ */
+function preserveProvidersWithCredentials(
+  providers: Record<string, Provider> | undefined
+): Record<string, Provider> {
+  const preserved = Object.entries(providers ?? {}).filter(
+    ([, provider]) => !!provider?.apiKeyKeychainId
+  );
+  return preserved.length > 0 ? Object.fromEntries(preserved) : EMPTY_PROVIDERS;
+}
+
+/**
+ * Keep only the configured models belonging to providers that were preserved.
+ *
+ * Reason: a `ConfiguredModel` doesn't directly carry a credential, but its
+ * existence depends on the parent provider's credential. When a provider is
+ * preserved, its models must be too — otherwise the user sees "API key set"
+ * but "No models added", and their model configuration is lost. When a provider
+ * is dropped (e.g. Ollama with no key), its models go with it.
+ *
+ * @param configuredModels - The pre-reset configured model rows.
+ * @param preservedProviderIds - Set of provider IDs that survived the reset.
+ */
+function preserveConfiguredModelsForProviders(
+  configuredModels: ConfiguredModel[] | undefined,
+  preservedProviderIds: Set<string>
+): ConfiguredModel[] {
+  if (!Array.isArray(configuredModels) || configuredModels.length === 0) {
+    return EMPTY_CONFIGURED_MODELS;
+  }
+  const preserved = configuredModels.filter((model) => preservedProviderIds.has(model.providerId));
+  return preserved.length > 0 ? preserved : EMPTY_CONFIGURED_MODELS;
+}
+
+/**
+ * Resets the settings to the default values while preserving credentials.
+ *
+ * Reset restores every non-credential setting to its default, but deliberately
+ * carries forward the user's API keys: the top-level secret fields, the
+ * credential and endpoint on builtin model rows, custom model rows that carry a
+ * credential, and the provider rows that own a keychain pointer. Configured
+ * models belonging to preserved providers are also kept — dropping them would
+ * orphan the user's model configuration while the provider's credential
+ * survives.
+ *
+ * Reset is not a way to erase secrets — "Delete All Keys" (Advanced Settings →
+ * API Key Storage, backed by `KeychainService.forgetAllSecrets`) is the
+ * dedicated path for that, and it also clears the OS keychain, which reset
+ * never touches.
+ *
+ * `backends` is cleared: it holds per-backend model enrollment (references to
+ * `configuredModelId`), which is a user preference rather than structure needed
+ * to address a keychain entry. Preserved models stay visible in settings, but
+ * each backend's picker reads `enabledModels` as authoritative and shows
+ * nothing until the user re-enables them there.
  *
  * DESIGN NOTE — does NOT clear secrets from the Obsidian Keychain. Reset only
  * rewrites `data.json` to defaults while leaving its Obsidian Keychain
@@ -615,9 +824,14 @@ export function getSettings(): Readonly<CopilotSettings> {
  * the keychain service and its callbacks through `SettingsMainV2`, and is
  * intentionally left out of the synchronous reset path.
  * If a future review flags this again, point them at this note.
+ *
+ * Preserving the rows above is what makes that note safe: the keychain entries
+ * this function deliberately leaves behind stay reachable, instead of becoming
+ * orphans no surviving pointer names.
  */
 export function resetSettings(): void {
   const current = getSettings();
+  const currentRecord = current as unknown as Record<string, unknown>;
   // Reset is a deterministic path, not best-effort: preserve the root-exclusion
   // history and fold in the pre-reset active root before it is replaced by the
   // default. Otherwise a reset would drop every historical root and leave that
@@ -626,10 +840,31 @@ export function resetSettings(): void {
     ...(Array.isArray(current.copilotRootHistory) ? current.copilotRootHistory : []),
     current.copilotFolder,
   ]);
+  const preservedTopLevelSecrets: Record<string, unknown> = {};
+  for (const field of TOP_LEVEL_CREDENTIAL_BUNDLE_FIELDS) {
+    const value = currentRecord[field];
+    if (carriesConfiguration(field, value)) {
+      preservedTopLevelSecrets[field] = value;
+    }
+  }
+  const preservedProviders = preserveProvidersWithCredentials(current.providers);
+  const preservedProviderIds = new Set(Object.keys(preservedProviders));
   const defaultSettingsWithBuiltIns = {
     ...DEFAULT_SETTINGS,
-    activeModels: BUILTIN_CHAT_MODELS.map((model) => ({ ...model, enabled: true })),
-    activeEmbeddingModels: BUILTIN_EMBEDDING_MODELS.map((model) => ({ ...model, enabled: true })),
+    ...preservedTopLevelSecrets,
+    activeModels: preserveModelCredentials(
+      BUILTIN_CHAT_MODELS.map((model) => ({ ...model, enabled: true })),
+      current.activeModels ?? []
+    ),
+    activeEmbeddingModels: preserveModelCredentials(
+      BUILTIN_EMBEDDING_MODELS.map((model) => ({ ...model, enabled: true })),
+      current.activeEmbeddingModels ?? []
+    ),
+    providers: preservedProviders,
+    configuredModels: preserveConfiguredModelsForProviders(
+      current.configuredModels,
+      preservedProviderIds
+    ),
     copilotRootHistory: preservedRootHistory,
   };
   setSettings(defaultSettingsWithBuiltIns);

--- a/src/settings/resetSettings.integration.test.ts
+++ b/src/settings/resetSettings.integration.test.ts
@@ -217,12 +217,15 @@ describe("model", () => {
   describe("resetSettings()", () => {
     it("keeps top-level, per-model, provider credentials, and configured models reachable after a reload", async () => {
       const keychainStore = new Map<string, string>();
-      const { settingsModel, persistenceModule, seedSettings } = await loadModule({
+      const { settingsModel, persistenceModule, keychain, seedSettings } = await loadModule({
         keychainStore,
       });
 
+      // Reason: must be valid 8-hex or the loader silently ignores it and falls
+      // back to the mock's "vault1234" — masking whether the persisted
+      // namespace actually round-trips.
       seedSettings({
-        _keychainVaultId: "vault1234",
+        _keychainVaultId: "a1b2c3d4",
         openAIApiKey: "sk-top-level",
         providers: {
           byok_openai: makeProvider({
@@ -258,6 +261,10 @@ describe("model", () => {
         savedToDisk = structuredClone(data);
       });
 
+      // The keychain namespace survives reset: `setSettings` merges rather
+      // than replaces, and neither DEFAULT_SETTINGS nor the preserved slices
+      // carry the key, so the pre-reset value flows through to disk untouched.
+      expect(savedToDisk?._keychainVaultId).toBe("a1b2c3d4");
       // data.json must never carry the plaintext in keychain-only mode.
       expect(savedToDisk?.openAIApiKey).toBe("");
       expect(savedToDisk?.activeModels.find((m) => m.name === "custom-gpt")?.apiKey).toBe("");
@@ -268,6 +275,10 @@ describe("model", () => {
         noLegacyBackup
       );
 
+      // Reload adopted the persisted namespace, not the getVaultId() fallback
+      // ("vault1234") — proving preserved keys stay addressable under their
+      // original vault id.
+      expect(keychain.setVaultId).toHaveBeenCalledWith("a1b2c3d4");
       expect(reloaded.openAIApiKey).toBe("sk-top-level");
       expect(reloaded.activeModels.find((m) => m.name === "custom-gpt")?.apiKey).toBe(
         "sk-model-key"
@@ -286,7 +297,7 @@ describe("model", () => {
 
       const builtin = BUILTIN_CHAT_MODELS[0];
       seedSettings({
-        _keychainVaultId: "vault1234",
+        _keychainVaultId: "a1b2c3d4",
         activeModels: [
           makeModel({
             name: builtin.name,

--- a/src/settings/resetSettings.integration.test.ts
+++ b/src/settings/resetSettings.integration.test.ts
@@ -5,337 +5,201 @@
  * hands back.
  *
  * These cases live outside `model.test.ts` because of a test-lifecycle
- * constraint that file cannot meet: each case re-imports `@/settings/model`
- * and `@/services/settingsPersistence` under a fresh module registry with a
- * fake keychain installed, so reset, save, and hydrate run against one
- * coherent store. `model.test.ts` drives the already-imported singleton and so
- * can only observe the in-memory half.
+ * constraint that file cannot meet: they drive the REAL `KeychainService`
+ * (map-backed `app.secretStorage`) and the real persistence module, whose
+ * module-level state (`lastPersistedSettings`, the write queue) must be reset
+ * per case via `resetPersistenceState()`. `model.test.ts` observes only the
+ * in-memory half of reset.
  */
 
+import type { App } from "obsidian";
+
 import { BUILTIN_CHAT_MODELS, DEFAULT_SETTINGS } from "@/constants";
-import { isSensitiveKey } from "@/services/settingsSecretTransforms";
+import { KeychainService } from "@/services/keychainService";
+import {
+  loadSettingsWithKeychain,
+  persistSettings,
+  resetPersistenceState,
+} from "@/services/settingsPersistence";
 import type { CustomModel } from "@/aiParams";
-import type { CopilotSettings } from "@/settings/model";
 import type { Provider } from "@/modelManagement";
+import type { CopilotSettings } from "@/settings/model";
+import { getSettings, resetSettings, settingsAtom, settingsStore } from "@/settings/model";
+
+jest.mock("@/logger", () => ({
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+  logError: jest.fn(),
+}));
 
 // Polyfill structuredClone for jsdom
 if (typeof window.structuredClone === "undefined") {
   window.structuredClone = <T>(val: T): T => JSON.parse(JSON.stringify(val)) as T;
 }
 
-/**
- * Fake keychain id for a model row, mirroring the real service's
- * `name|provider` identity scheme closely enough for these tests.
- */
-function modelKeychainId(model: Record<string, unknown>): string {
-  return `kc-model-${String(model.name)}-${String(model.provider)}`;
-}
-
 /** These tests seed post-v4 settings, so the legacy backup never applies. */
 const noLegacyBackup = async () => ({ status: "not-needed" }) as const;
 
-function makeSettings(overrides: Partial<CopilotSettings> = {}): CopilotSettings {
+const VAULT_ID = "a1b2c3d4";
+const BYOK_POINTER = `copilot-v${VAULT_ID}-provider-byok_openai`;
+const PLUS_POINTER = `copilot-v${VAULT_ID}-provider-plus_1`;
+
+let secrets: Map<string, string>;
+let app: App;
+
+function makeApp(): App {
   return {
-    ...DEFAULT_SETTINGS,
-    ...overrides,
-  };
+    secretStorage: {
+      setSecret: (id: string, value: string) => {
+        secrets.set(id, value);
+      },
+      getSecret: (id: string) => (secrets.has(id) ? secrets.get(id)! : null),
+      listSecrets: () => Array.from(secrets.keys()),
+      deleteSecret: (id: string) => {
+        secrets.delete(id);
+      },
+    },
+    // No base path: the service takes the explicit `setVaultId` below.
+    vault: { adapter: {} },
+  } as unknown as App;
 }
 
-function makeModel(overrides: Partial<CustomModel> = {}): CustomModel {
-  const base: CustomModel = {
-    name: "gpt-4",
-    provider: "openai",
-    enabled: true,
-  };
-  // Only add properties from overrides that are not undefined
-  Object.entries(overrides).forEach(([key, value]) => {
-    if (value !== undefined) {
-      (base as unknown as Record<string, unknown>)[key] = value;
-    }
-  });
-  return base;
-}
-
-function makeProvider(overrides: Partial<Provider> = {}): Provider {
+function makeProvider(overrides: Partial<Provider>): Provider {
   return {
     providerId: "byok_openai",
     providerType: "openai-compatible",
     displayName: "My OpenAI",
     origin: { kind: "byok" },
-    addedAt: Date.now(),
-    configuredModels: [],
+    addedAt: 0,
+    requiresApiKey: true,
     ...overrides,
-  } as Provider;
-}
-
-/** Load a fresh module instance with isolated mocks. */
-async function loadModule(overrides?: {
-  keychainStore?: Map<string, string>;
-  getDecryptedKey?: (value: string) => Promise<string>;
-}) {
-  jest.resetModules();
-
-  const keychainStore = overrides?.keychainStore ?? new Map<string, string>();
-
-  const keychain = {
-    isAvailable: jest.fn().mockReturnValue(true),
-    getVaultId: jest.fn().mockReturnValue("vault1234"),
-    setVaultId: jest.fn(),
-    hydrateFromKeychain: jest.fn(async (settings: CopilotSettings) => {
-      // Simulate keychain hydration: read secrets from keychainStore
-      const hydrated = structuredClone(settings);
-      const hydratedRecord = hydrated as unknown as Record<string, unknown>;
-
-      // Hydrate top-level secrets
-      for (const key of Object.keys(hydratedRecord)) {
-        if (!isSensitiveKey(key)) continue;
-        const keychainId = `kc-${key}`;
-        const secret = keychainStore.get(keychainId);
-        if (secret) {
-          hydratedRecord[key] = secret;
-        }
-      }
-
-      // Hydrate model secrets
-      for (const listKey of ["activeModels", "activeEmbeddingModels"] as const) {
-        const models = hydratedRecord[listKey];
-        if (!Array.isArray(models)) continue;
-        for (const model of models) {
-          if (!model || typeof model !== "object") continue;
-          const modelRecord = model as Record<string, unknown>;
-          const keychainId = modelKeychainId(modelRecord);
-          const secret = keychainStore.get(keychainId);
-          if (secret) {
-            modelRecord.apiKey = secret;
-          }
-        }
-      }
-
-      // Hydrate provider secrets
-      const providers = hydratedRecord.providers;
-      if (providers && typeof providers === "object") {
-        for (const provider of Object.values(providers)) {
-          if (!provider || typeof provider !== "object") continue;
-          const providerRecord = provider as Record<string, unknown>;
-          const keychainId = providerRecord.apiKeyKeychainId;
-          if (typeof keychainId === "string" && keychainId.startsWith("kc-")) {
-            const secret = keychainStore.get(keychainId);
-            if (secret) providerRecord.apiKey = secret;
-          }
-        }
-      }
-
-      return { settings: hydrated, hadFailures: false };
-    }),
-    persistSecrets: jest.fn((settings: CopilotSettings) => {
-      // Simulate keychain persistence: write secrets to keychainStore
-      const secretEntries: Array<[string, string]> = [];
-      const keychainIdsToDelete: string[] = [];
-      const settingsRecord = settings as unknown as Record<string, unknown>;
-
-      // Persist top-level secrets
-      for (const key of Object.keys(settingsRecord)) {
-        if (!isSensitiveKey(key)) continue;
-        const value = settingsRecord[key];
-        if (typeof value === "string" && value.length > 0 && !value.startsWith("kc-")) {
-          const keychainId = `kc-${key}`;
-          keychainStore.set(keychainId, value);
-          secretEntries.push([keychainId, value]);
-        }
-      }
-
-      // Persist model secrets
-      for (const listKey of ["activeModels", "activeEmbeddingModels"] as const) {
-        const models = settingsRecord[listKey];
-        if (!Array.isArray(models)) continue;
-        for (const model of models) {
-          if (!model || typeof model !== "object") continue;
-          const modelRecord = model as Record<string, unknown>;
-          const apiKey = modelRecord.apiKey;
-          if (typeof apiKey === "string" && apiKey.length > 0 && !apiKey.startsWith("kc-")) {
-            const keychainId = modelKeychainId(modelRecord);
-            keychainStore.set(keychainId, apiKey);
-            secretEntries.push([keychainId, apiKey]);
-          }
-        }
-      }
-
-      // Persist provider secrets
-      const providers = settingsRecord.providers;
-      if (providers && typeof providers === "object") {
-        for (const provider of Object.values(providers)) {
-          if (!provider || typeof provider !== "object") continue;
-          const providerRecord = provider as Record<string, unknown>;
-          const apiKey = providerRecord.apiKey;
-          const keychainId = providerRecord.apiKeyKeychainId;
-          if (typeof apiKey === "string" && apiKey.length > 0 && typeof keychainId === "string") {
-            keychainStore.set(keychainId, apiKey);
-            secretEntries.push([keychainId, apiKey]);
-          }
-        }
-      }
-
-      return { secretEntries, keychainIdsToDelete };
-    }),
-    setSecretById: jest.fn(),
-    deleteSecretById: jest.fn(),
-    getSecret: jest.fn().mockReturnValue(null),
-    getModelSecret: jest.fn().mockReturnValue(null),
   };
-
-  jest.doMock("@/services/keychainService", () => ({
-    KeychainService: { getInstance: jest.fn(() => keychain) },
-    // Production `isSecretKey` is `isSensitiveKey` widened by an exception
-    // list that is currently empty, so the shared heuristic is a faithful fake.
-    isSecretKey: jest.fn((key: string) => isSensitiveKey(key)),
-  }));
-
-  jest.doMock("@/logger", () => ({ logWarn: jest.fn(), logError: jest.fn() }));
-
-  // Reason: do NOT mock getSettings/setSettings. `resetSettings()` calls
-  // `getSettings()` as a module-internal reference, so a `jest.doMock` on the
-  // export table would leave the internal call reading the real jotai store —
-  // reset would see the built-in model list instead of the test's setup. Drive
-  // the real store instead, which is also what production does.
-  const settingsModel = await import("@/settings/model");
-  const persistenceModule = await import("@/services/settingsPersistence");
-
-  /** Seed the real settings store, the way production `setSettings` would. */
-  const seedSettings = (overrides: Partial<CopilotSettings> = {}): CopilotSettings => {
-    settingsModel.settingsStore.set(settingsModel.settingsAtom, makeSettings(overrides));
-    return settingsModel.getSettings();
-  };
-
-  return { settingsModel, persistenceModule, keychain, keychainStore, seedSettings };
 }
-
-afterEach(() => {
-  jest.restoreAllMocks();
-});
 
 describe("model", () => {
   describe("resetSettings()", () => {
-    it("keeps top-level, per-model, provider credentials, and configured models reachable after a reload", async () => {
-      const keychainStore = new Map<string, string>();
-      const { settingsModel, persistenceModule, keychain, seedSettings } = await loadModule({
-        keychainStore,
-      });
+    beforeEach(() => {
+      secrets = new Map();
+      app = makeApp();
+      resetPersistenceState();
+      KeychainService.resetInstance();
+      KeychainService.getInstance(app).setVaultId(VAULT_ID);
+    });
 
-      // Reason: must be valid 8-hex or the loader silently ignores it and falls
-      // back to the mock's "vault1234" — masking whether the persisted
-      // namespace actually round-trips.
-      seedSettings({
-        _keychainVaultId: "a1b2c3d4",
+    it("keeps every credential — top-level, builtin/custom model, BYOK and signed-in Plus provider — reachable through reset, persistence, and a fresh hydration cycle (https://github.com/logancyang/obsidian-copilot-preview/issues/259)", async () => {
+      const builtin = BUILTIN_CHAT_MODELS[0];
+      const builtinRow: CustomModel = {
+        name: builtin.name,
+        provider: builtin.provider,
+        apiKey: "sk-builtin-override",
+        baseUrl: "https://proxy.example.test/v1",
+        enabled: false,
+        temperature: 0.9,
+      };
+      const customRow: CustomModel = {
+        name: "custom-gpt",
+        provider: "openai",
+        apiKey: "sk-model-key",
+        baseUrl: "http://localhost:9999/v1",
+        enabled: true,
+      };
+      // Provider secrets are written by `ProviderRegistry.setApiKey`, outside
+      // the persist path — seed this device's entries directly.
+      secrets.set(BYOK_POINTER, "sk-provider-key");
+      secrets.set(PLUS_POINTER, "lic-12345");
+
+      settingsStore.set(settingsAtom, {
+        ...DEFAULT_SETTINGS,
+        _keychainVaultId: VAULT_ID,
         openAIApiKey: "sk-top-level",
+        azureOpenAIApiInstanceName: "my-instance",
+        isPaidUser: true,
+        plusLicenseKey: "lic-12345",
+        entitlementToken: "test-stale-entitlement-token",
+        showSuggestedPrompts: false,
+        activeModels: [builtinRow, customRow],
         providers: {
-          byok_openai: makeProvider({
-            providerId: "byok_openai",
-            apiKeyKeychainId: "kc-provider-openai",
+          byok_openai: makeProvider({ apiKeyKeychainId: BYOK_POINTER }),
+          plus_1: makeProvider({
+            providerId: "plus_1",
+            displayName: "Copilot",
+            origin: { kind: "copilot-plus" },
+            requiresApiKey: false,
+            apiKeyKeychainId: PLUS_POINTER,
           }),
         },
-        activeModels: [
-          makeModel({ name: "custom-gpt", provider: "openai", apiKey: "sk-model-key" }),
-        ],
         configuredModels: [
           {
             configuredModelId: "cm-1",
             providerId: "byok_openai",
             info: { id: "gpt-4", displayName: "GPT-4" },
-            configuredAt: Date.now(),
+            configuredAt: 0,
           },
         ],
       });
-      // The provider secret lives only in the keychain — the row holds a pointer.
-      keychainStore.set("kc-provider-openai", "sk-provider-key");
 
-      settingsModel.resetSettings();
+      // Baseline persist: the real service moves the seeded plaintext secrets
+      // into the keychain, as a running session would have before reset.
+      await persistSettings(getSettings(), async () => {});
 
-      const afterReset = settingsModel.getSettings();
-      expect(afterReset.providers.byok_openai?.apiKeyKeychainId).toBe("kc-provider-openai");
-      expect(afterReset.activeModels.find((m) => m.name === "custom-gpt")).toBeDefined();
-      expect(afterReset.configuredModels.length).toBe(1);
-      expect(afterReset.configuredModels[0].configuredModelId).toBe("cm-1");
+      resetSettings();
 
       let savedToDisk: CopilotSettings | undefined;
-      await persistenceModule.persistSettings(afterReset, async (data) => {
+      await persistSettings(getSettings(), async (data) => {
         savedToDisk = structuredClone(data);
       });
 
-      // The keychain namespace survives reset: `setSettings` merges rather
-      // than replaces, and neither DEFAULT_SETTINGS nor the preserved slices
-      // carry the key, so the pre-reset value flows through to disk untouched.
-      expect(savedToDisk?._keychainVaultId).toBe("a1b2c3d4");
-      // data.json must never carry the plaintext in keychain-only mode.
+      // data.json never carries plaintext in keychain-only mode, and the
+      // keychain namespace plus the provider pointer survive the reset write.
       expect(savedToDisk?.openAIApiKey).toBe("");
       expect(savedToDisk?.activeModels.find((m) => m.name === "custom-gpt")?.apiKey).toBe("");
+      expect(savedToDisk?._keychainVaultId).toBe(VAULT_ID);
+      expect(savedToDisk?.providers.byok_openai?.apiKeyKeychainId).toBe(BYOK_POINTER);
 
-      const reloaded = await persistenceModule.loadSettingsWithKeychain(
+      // Fresh service instance = the next launch on this device.
+      KeychainService.resetInstance();
+      KeychainService.getInstance(app);
+      const reloaded = await loadSettingsWithKeychain(
+        app,
         savedToDisk,
         async () => {},
         noLegacyBackup
       );
 
-      // Reload adopted the persisted namespace, not the getVaultId() fallback
-      // ("vault1234") — proving preserved keys stay addressable under their
-      // original vault id.
-      expect(keychain.setVaultId).toHaveBeenCalledWith("a1b2c3d4");
+      // Reload adopted the persisted namespace, not a re-derived one.
+      expect(KeychainService.getInstance(app).getVaultId()).toBe(VAULT_ID);
+
+      // Top-level credential and its vendor routing survive; preferences reset.
       expect(reloaded.openAIApiKey).toBe("sk-top-level");
-      expect(reloaded.activeModels.find((m) => m.name === "custom-gpt")?.apiKey).toBe(
-        "sk-model-key"
-      );
-      expect(reloaded.providers.byok_openai?.apiKeyKeychainId).toBe("kc-provider-openai");
-      expect(keychainStore.get("kc-provider-openai")).toBe("sk-provider-key");
-      expect(reloaded.configuredModels.length).toBe(1);
-      expect(reloaded.configuredModels[0].configuredModelId).toBe("cm-1");
-    });
+      expect(reloaded.azureOpenAIApiInstanceName).toBe("my-instance");
+      expect(reloaded.showSuggestedPrompts).toBe(DEFAULT_SETTINGS.showSuggestedPrompts);
 
-    it("keeps a builtin model's key and endpoint through persistence and reload", async () => {
-      const keychainStore = new Map<string, string>();
-      const { settingsModel, persistenceModule, seedSettings } = await loadModule({
-        keychainStore,
-      });
+      // Builtin row: key + endpoint kept, preferences back to defaults.
+      const reloadedBuiltin = reloaded.activeModels.find((m) => m.name === builtin.name);
+      expect(reloadedBuiltin?.apiKey).toBe("sk-builtin-override");
+      expect(reloadedBuiltin?.baseUrl).toBe("https://proxy.example.test/v1");
+      expect(reloadedBuiltin?.enabled).toBe(true);
+      expect(reloadedBuiltin?.temperature).toBeUndefined();
 
-      const builtin = BUILTIN_CHAT_MODELS[0];
-      seedSettings({
-        _keychainVaultId: "a1b2c3d4",
-        activeModels: [
-          makeModel({
-            name: builtin.name,
-            provider: builtin.provider,
-            apiKey: "sk-builtin-override",
-            baseUrl: "https://proxy.example.test/v1",
-            enabled: false,
-            temperature: 0.9,
-          }),
-        ],
-      });
+      // Custom row survives whole.
+      const reloadedCustom = reloaded.activeModels.find((m) => m.name === "custom-gpt");
+      expect(reloadedCustom?.apiKey).toBe("sk-model-key");
+      expect(reloadedCustom?.baseUrl).toBe("http://localhost:9999/v1");
 
-      settingsModel.resetSettings();
+      // BYOK provider row, its keychain entry, and its configured model stay
+      // reachable.
+      expect(reloaded.providers.byok_openai?.apiKeyKeychainId).toBe(BYOK_POINTER);
+      expect(secrets.get(BYOK_POINTER)).toBe("sk-provider-key");
+      expect(reloaded.configuredModels.map((m) => m.configuredModelId)).toEqual(["cm-1"]);
 
-      const afterReset = settingsModel.getSettings();
-      const resetRow = afterReset.activeModels.find(
-        (m) => m.name === builtin.name && m.provider === builtin.provider
-      );
-      expect(resetRow?.apiKey).toBe("sk-builtin-override");
-      expect(resetRow?.baseUrl).toBe("https://proxy.example.test/v1");
-      expect(resetRow?.temperature).toBe(builtin.temperature);
-
-      let savedToDisk: CopilotSettings | undefined;
-      await persistenceModule.persistSettings(afterReset, async (data) => {
-        savedToDisk = structuredClone(data);
-      });
-
-      const reloaded = await persistenceModule.loadSettingsWithKeychain(
-        savedToDisk,
-        async () => {},
-        noLegacyBackup
-      );
-
-      const reloadedRow = reloaded.activeModels.find(
-        (m) => m.name === builtin.name && m.provider === builtin.provider
-      );
-      expect(reloadedRow?.apiKey).toBe("sk-builtin-override");
-      expect(reloadedRow?.baseUrl).toBe("https://proxy.example.test/v1");
+      // Signed-in Plus: paid state and the provider row survive so the
+      // settings subscriber never reads reset as sign-out; the entitlement
+      // token still resets (its identity binding is invalidated).
+      expect(reloaded.isPaidUser).toBe(true);
+      expect(reloaded.plusLicenseKey).toBe("lic-12345");
+      expect(reloaded.providers.plus_1?.apiKeyKeychainId).toBe(PLUS_POINTER);
+      expect(secrets.get(PLUS_POINTER)).toBe("lic-12345");
+      expect(reloaded.entitlementToken).toBe(DEFAULT_SETTINGS.entitlementToken);
     });
   });
 });

--- a/src/settings/resetSettings.integration.test.ts
+++ b/src/settings/resetSettings.integration.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Integration coverage for `resetSettings()` across the persistence cycle,
+ * required by issue #259: credentials must stay reachable "through persistence
+ * and a subsequent hydration cycle", not merely in the settings object reset
+ * hands back.
+ *
+ * These cases live outside `model.test.ts` because of a test-lifecycle
+ * constraint that file cannot meet: each case re-imports `@/settings/model`
+ * and `@/services/settingsPersistence` under a fresh module registry with a
+ * fake keychain installed, so reset, save, and hydrate run against one
+ * coherent store. `model.test.ts` drives the already-imported singleton and so
+ * can only observe the in-memory half.
+ */
+
+import { BUILTIN_CHAT_MODELS, DEFAULT_SETTINGS } from "@/constants";
+import { isSensitiveKey } from "@/services/settingsSecretTransforms";
+import type { CustomModel } from "@/aiParams";
+import type { CopilotSettings } from "@/settings/model";
+import type { Provider } from "@/modelManagement";
+
+// Polyfill structuredClone for jsdom
+if (typeof window.structuredClone === "undefined") {
+  window.structuredClone = <T>(val: T): T => JSON.parse(JSON.stringify(val)) as T;
+}
+
+/**
+ * Fake keychain id for a model row, mirroring the real service's
+ * `name|provider` identity scheme closely enough for these tests.
+ */
+function modelKeychainId(model: Record<string, unknown>): string {
+  return `kc-model-${String(model.name)}-${String(model.provider)}`;
+}
+
+/** These tests seed post-v4 settings, so the legacy backup never applies. */
+const noLegacyBackup = async () => ({ status: "not-needed" }) as const;
+
+function makeSettings(overrides: Partial<CopilotSettings> = {}): CopilotSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...overrides,
+  };
+}
+
+function makeModel(overrides: Partial<CustomModel> = {}): CustomModel {
+  const base: CustomModel = {
+    name: "gpt-4",
+    provider: "openai",
+    enabled: true,
+  };
+  // Only add properties from overrides that are not undefined
+  Object.entries(overrides).forEach(([key, value]) => {
+    if (value !== undefined) {
+      (base as unknown as Record<string, unknown>)[key] = value;
+    }
+  });
+  return base;
+}
+
+function makeProvider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    providerId: "byok_openai",
+    providerType: "openai-compatible",
+    displayName: "My OpenAI",
+    origin: { kind: "byok" },
+    addedAt: Date.now(),
+    configuredModels: [],
+    ...overrides,
+  } as Provider;
+}
+
+/** Load a fresh module instance with isolated mocks. */
+async function loadModule(overrides?: {
+  keychainStore?: Map<string, string>;
+  getDecryptedKey?: (value: string) => Promise<string>;
+}) {
+  jest.resetModules();
+
+  const keychainStore = overrides?.keychainStore ?? new Map<string, string>();
+
+  const keychain = {
+    isAvailable: jest.fn().mockReturnValue(true),
+    getVaultId: jest.fn().mockReturnValue("vault1234"),
+    setVaultId: jest.fn(),
+    hydrateFromKeychain: jest.fn(async (settings: CopilotSettings) => {
+      // Simulate keychain hydration: read secrets from keychainStore
+      const hydrated = structuredClone(settings);
+      const hydratedRecord = hydrated as unknown as Record<string, unknown>;
+
+      // Hydrate top-level secrets
+      for (const key of Object.keys(hydratedRecord)) {
+        if (!isSensitiveKey(key)) continue;
+        const keychainId = `kc-${key}`;
+        const secret = keychainStore.get(keychainId);
+        if (secret) {
+          hydratedRecord[key] = secret;
+        }
+      }
+
+      // Hydrate model secrets
+      for (const listKey of ["activeModels", "activeEmbeddingModels"] as const) {
+        const models = hydratedRecord[listKey];
+        if (!Array.isArray(models)) continue;
+        for (const model of models) {
+          if (!model || typeof model !== "object") continue;
+          const modelRecord = model as Record<string, unknown>;
+          const keychainId = modelKeychainId(modelRecord);
+          const secret = keychainStore.get(keychainId);
+          if (secret) {
+            modelRecord.apiKey = secret;
+          }
+        }
+      }
+
+      // Hydrate provider secrets
+      const providers = hydratedRecord.providers;
+      if (providers && typeof providers === "object") {
+        for (const provider of Object.values(providers)) {
+          if (!provider || typeof provider !== "object") continue;
+          const providerRecord = provider as Record<string, unknown>;
+          const keychainId = providerRecord.apiKeyKeychainId;
+          if (typeof keychainId === "string" && keychainId.startsWith("kc-")) {
+            const secret = keychainStore.get(keychainId);
+            if (secret) providerRecord.apiKey = secret;
+          }
+        }
+      }
+
+      return { settings: hydrated, hadFailures: false };
+    }),
+    persistSecrets: jest.fn((settings: CopilotSettings) => {
+      // Simulate keychain persistence: write secrets to keychainStore
+      const secretEntries: Array<[string, string]> = [];
+      const keychainIdsToDelete: string[] = [];
+      const settingsRecord = settings as unknown as Record<string, unknown>;
+
+      // Persist top-level secrets
+      for (const key of Object.keys(settingsRecord)) {
+        if (!isSensitiveKey(key)) continue;
+        const value = settingsRecord[key];
+        if (typeof value === "string" && value.length > 0 && !value.startsWith("kc-")) {
+          const keychainId = `kc-${key}`;
+          keychainStore.set(keychainId, value);
+          secretEntries.push([keychainId, value]);
+        }
+      }
+
+      // Persist model secrets
+      for (const listKey of ["activeModels", "activeEmbeddingModels"] as const) {
+        const models = settingsRecord[listKey];
+        if (!Array.isArray(models)) continue;
+        for (const model of models) {
+          if (!model || typeof model !== "object") continue;
+          const modelRecord = model as Record<string, unknown>;
+          const apiKey = modelRecord.apiKey;
+          if (typeof apiKey === "string" && apiKey.length > 0 && !apiKey.startsWith("kc-")) {
+            const keychainId = modelKeychainId(modelRecord);
+            keychainStore.set(keychainId, apiKey);
+            secretEntries.push([keychainId, apiKey]);
+          }
+        }
+      }
+
+      // Persist provider secrets
+      const providers = settingsRecord.providers;
+      if (providers && typeof providers === "object") {
+        for (const provider of Object.values(providers)) {
+          if (!provider || typeof provider !== "object") continue;
+          const providerRecord = provider as Record<string, unknown>;
+          const apiKey = providerRecord.apiKey;
+          const keychainId = providerRecord.apiKeyKeychainId;
+          if (typeof apiKey === "string" && apiKey.length > 0 && typeof keychainId === "string") {
+            keychainStore.set(keychainId, apiKey);
+            secretEntries.push([keychainId, apiKey]);
+          }
+        }
+      }
+
+      return { secretEntries, keychainIdsToDelete };
+    }),
+    setSecretById: jest.fn(),
+    deleteSecretById: jest.fn(),
+    getSecret: jest.fn().mockReturnValue(null),
+    getModelSecret: jest.fn().mockReturnValue(null),
+  };
+
+  jest.doMock("@/services/keychainService", () => ({
+    KeychainService: { getInstance: jest.fn(() => keychain) },
+    // Production `isSecretKey` is `isSensitiveKey` widened by an exception
+    // list that is currently empty, so the shared heuristic is a faithful fake.
+    isSecretKey: jest.fn((key: string) => isSensitiveKey(key)),
+  }));
+
+  jest.doMock("@/logger", () => ({ logWarn: jest.fn(), logError: jest.fn() }));
+
+  // Reason: do NOT mock getSettings/setSettings. `resetSettings()` calls
+  // `getSettings()` as a module-internal reference, so a `jest.doMock` on the
+  // export table would leave the internal call reading the real jotai store —
+  // reset would see the built-in model list instead of the test's setup. Drive
+  // the real store instead, which is also what production does.
+  const settingsModel = await import("@/settings/model");
+  const persistenceModule = await import("@/services/settingsPersistence");
+
+  /** Seed the real settings store, the way production `setSettings` would. */
+  const seedSettings = (overrides: Partial<CopilotSettings> = {}): CopilotSettings => {
+    settingsModel.settingsStore.set(settingsModel.settingsAtom, makeSettings(overrides));
+    return settingsModel.getSettings();
+  };
+
+  return { settingsModel, persistenceModule, keychain, keychainStore, seedSettings };
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("model", () => {
+  describe("resetSettings()", () => {
+    it("keeps top-level, per-model, provider credentials, and configured models reachable after a reload", async () => {
+      const keychainStore = new Map<string, string>();
+      const { settingsModel, persistenceModule, seedSettings } = await loadModule({
+        keychainStore,
+      });
+
+      seedSettings({
+        _keychainVaultId: "vault1234",
+        openAIApiKey: "sk-top-level",
+        providers: {
+          byok_openai: makeProvider({
+            providerId: "byok_openai",
+            apiKeyKeychainId: "kc-provider-openai",
+          }),
+        },
+        activeModels: [
+          makeModel({ name: "custom-gpt", provider: "openai", apiKey: "sk-model-key" }),
+        ],
+        configuredModels: [
+          {
+            configuredModelId: "cm-1",
+            providerId: "byok_openai",
+            info: { id: "gpt-4", displayName: "GPT-4" },
+            configuredAt: Date.now(),
+          },
+        ],
+      });
+      // The provider secret lives only in the keychain — the row holds a pointer.
+      keychainStore.set("kc-provider-openai", "sk-provider-key");
+
+      settingsModel.resetSettings();
+
+      const afterReset = settingsModel.getSettings();
+      expect(afterReset.providers.byok_openai?.apiKeyKeychainId).toBe("kc-provider-openai");
+      expect(afterReset.activeModels.find((m) => m.name === "custom-gpt")).toBeDefined();
+      expect(afterReset.configuredModels.length).toBe(1);
+      expect(afterReset.configuredModels[0].configuredModelId).toBe("cm-1");
+
+      let savedToDisk: CopilotSettings | undefined;
+      await persistenceModule.persistSettings(afterReset, async (data) => {
+        savedToDisk = structuredClone(data);
+      });
+
+      // data.json must never carry the plaintext in keychain-only mode.
+      expect(savedToDisk?.openAIApiKey).toBe("");
+      expect(savedToDisk?.activeModels.find((m) => m.name === "custom-gpt")?.apiKey).toBe("");
+
+      const reloaded = await persistenceModule.loadSettingsWithKeychain(
+        savedToDisk,
+        async () => {},
+        noLegacyBackup
+      );
+
+      expect(reloaded.openAIApiKey).toBe("sk-top-level");
+      expect(reloaded.activeModels.find((m) => m.name === "custom-gpt")?.apiKey).toBe(
+        "sk-model-key"
+      );
+      expect(reloaded.providers.byok_openai?.apiKeyKeychainId).toBe("kc-provider-openai");
+      expect(keychainStore.get("kc-provider-openai")).toBe("sk-provider-key");
+      expect(reloaded.configuredModels.length).toBe(1);
+      expect(reloaded.configuredModels[0].configuredModelId).toBe("cm-1");
+    });
+
+    it("keeps a builtin model's key and endpoint through persistence and reload", async () => {
+      const keychainStore = new Map<string, string>();
+      const { settingsModel, persistenceModule, seedSettings } = await loadModule({
+        keychainStore,
+      });
+
+      const builtin = BUILTIN_CHAT_MODELS[0];
+      seedSettings({
+        _keychainVaultId: "vault1234",
+        activeModels: [
+          makeModel({
+            name: builtin.name,
+            provider: builtin.provider,
+            apiKey: "sk-builtin-override",
+            baseUrl: "https://proxy.example.test/v1",
+            enabled: false,
+            temperature: 0.9,
+          }),
+        ],
+      });
+
+      settingsModel.resetSettings();
+
+      const afterReset = settingsModel.getSettings();
+      const resetRow = afterReset.activeModels.find(
+        (m) => m.name === builtin.name && m.provider === builtin.provider
+      );
+      expect(resetRow?.apiKey).toBe("sk-builtin-override");
+      expect(resetRow?.baseUrl).toBe("https://proxy.example.test/v1");
+      expect(resetRow?.temperature).toBe(builtin.temperature);
+
+      let savedToDisk: CopilotSettings | undefined;
+      await persistenceModule.persistSettings(afterReset, async (data) => {
+        savedToDisk = structuredClone(data);
+      });
+
+      const reloaded = await persistenceModule.loadSettingsWithKeychain(
+        savedToDisk,
+        async () => {},
+        noLegacyBackup
+      );
+
+      const reloadedRow = reloaded.activeModels.find(
+        (m) => m.name === builtin.name && m.provider === builtin.provider
+      );
+      expect(reloadedRow?.apiKey).toBe("sk-builtin-override");
+      expect(reloadedRow?.baseUrl).toBe("https://proxy.example.test/v1");
+    });
+  });
+});


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#259

## Why

The Reset Settings confirmation promises "API keys are not cleared by this action — use 'Delete All Keys' … if you also want to remove them", but confirming it destroyed them anyway. `resetSettings()` replaced every secret-bearing field with defaults, the persistence subscriber saw those values become empty and tombstoned the corresponding Keychain entries, and provider rows lost the `apiKeyKeychainId` pointer that made their Keychain entries reachable. A user who configured an OpenAI key and a custom model with its own Base URL, then pressed Reset and restarted Obsidian, found every provider showing as unconfigured and their model list gone — the opposite of what the dialog told them.

## What

Reset now behaves as the dialog describes: preferences return to defaults, credentials and the rows needed to address them survive.

| State | Before (after reset + restart) | After |
| --- | --- | --- |
| Non-credential preferences (e.g. "Open Plugin In") | Reset to default | Reset to default (unchanged) |
| Top-level API keys and their vendor config (Azure instance/deployments, Bedrock region, OpenAI org) | Wiped and tombstoned in Keychain | Preserved |
| Provider rows holding a stored key, and their configured models | Pointer wiped; Keychain entries orphaned | Preserved together |
| Builtin model rows | Key and Base URL wiped | Key + endpoint preserved; preferences (enabled, temperature) reset |
| Custom model rows | Dropped | Kept whole |
| Plus license key | Wiped | Preserved; the short-lived entitlement session token is intentionally dropped and re-issued on the next license check (it binds to the `userId` that reset regenerates) |

The confirmation copy drops the now-false words "clear all settings and"; the rest of the dialog is unchanged.

## Non goal

- No v3 credential migration or decryption (issue boundary).
- Reset still never touches the OS Keychain; "Delete All Keys" remains the only settings action that removes credentials.
- Per-backend model enrollment (`backends.enabledModels`) is a preference and still resets; preserved models remain in settings but must be re-enabled per backend.
- Stale `apiKeyKeychainId` pointers left by "Delete All Keys" across devices are a separate defect (logancyang/obsidian-copilot-preview#261) and are not addressed here.

## Screenshot

The only visual change is dialog copy (four words removed):

> **Before:** Resetting settings will clear all settings and restore the default values. API keys are not cleared by this action — …
>
> **After:** Resetting settings will restore the default values. API keys are not cleared by this action — …

Device screenshots of the new dialog and post-reset settings exist from real-device verification, but image upload requires the authenticated web PR editor, which this environment cannot drive; the copy diff above is the complete visual delta.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or cosmetic/copy change, or deterministic tests cover the changed behavior | ✅ | `model.test.ts` covers every preservation branch; `resetSettings.integration.test.ts` covers the full persist → hydrate cycle |
| A defect would fail CI or be obvious on first use | ✅ | The reset tests run in CI; a wrongly dropped row is visible on the next settings screen |
| A revert fully restores prior state, including persisted data | ✅ | No schema change — `data.json` keeps the same fields; revert restores the old wipe-on-reset behavior only |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Changes which secret fields survive reset, and newly drops the entitlement session token |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Same `data.json` keys; no renamed or added persisted fields |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Reset remains a synchronous in-memory rebuild |
| No hot-path behavior lacks deterministic coverage | ✅ | All bundle-field and provider/model preservation branches are unit-tested; persistence round-trip is integration-tested |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to Reset Settings; wrong results appear immediately in the settings UI |

Review: inspect `src/settings/model.ts` line by line — `resetSettings()`, `carriesConfiguration()`, `withPreservedModelCredential()`, `preserveModelCredentials()`, `preserveProvidersWithCredentials()`, `preserveConfiguredModelsForProviders()`, and the `MODEL_CREDENTIAL_BUNDLE_FIELDS` / `TOP_LEVEL_CREDENTIAL_BUNDLE_FIELDS` constants — then run Verification steps 1–5, including the adversarial variants in step 6.

## Verification

1. Configure any provider with a (fake) API key, add a custom model with Base URL `http://localhost:9999/v1`, set a non-default preference (e.g. "Open Plugin In" → Editor), and enter a Plus license key.
2. Open Settings → Copilot → Reset Settings. The dialog should read "Resetting settings will restore the default values. API keys are not cleared by this action — …".
3. Confirm the reset, then fully quit and restart Obsidian.
4. Observe: the provider still shows its key as set, the custom model and its Base URL are intact, the license key is retained, and the preference is back to its default.
5. Advanced Settings → API Key Storage → Delete All Keys: keys are actually removed — still the only removal path.
6. Adversarial: hand-edit `data.json` so `amazonBedrockRegion` is a non-string value, then reset — the corrupted value must not survive (asserted in `model.test.ts`). Force a keychain-tombstoned key (empty string) — the row must still be treated as keyless rather than configured.

## Note

The entitlement-token exclusion cannot be device-verified without a real Copilot Plus license (a fake key never activates, so there is no observable transition). The unit test locks the contract: the session token is dropped on reset while `plusLicenseKey` survives, and the next license validation re-issues it.
