### PR TITLE
Restrict the Agent Mode frame log to its owner in the OS temp folder

### DIFF
--- a/src/agentMode/session/debugSink.test.ts
+++ b/src/agentMode/session/debugSink.test.ts
@@ -1,22 +1,50 @@
-import { FrameSink, getFrameLogPaths, NodeRuntime } from "./debugSink";
+import * as fsSync from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { FrameRecord, FrameSink, getFrameLogPaths, NodeRuntime } from "./debugSink";
+
+function makeFrame(overrides: Partial<FrameRecord> = {}): FrameRecord {
+  return {
+    ts: "2026-05-12T00:00:00.000Z",
+    dir: "→",
+    tag: "codex",
+    kind: "notif",
+    method: "session/update",
+    id: null,
+    payload: { ok: true },
+    ...overrides,
+  };
+}
+
+function errno(code: string): NodeJS.ErrnoException {
+  const error = new Error(code) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
 
 interface FakeRuntime extends NodeRuntime {
   files: Map<string, string>;
+  directories: Set<string>;
   removedPaths: string[];
 }
 
 /** Create an in-memory runtime for exercising the frame sink without disk IO. */
-function makeRuntime(tmpDir = "/tmp"): FakeRuntime {
+function makeRuntime(tmpDir = "/tmp", tempRootMode = 0o1755): FakeRuntime {
   const files = new Map<string, string>();
+  const directories = new Set<string>();
   const removedPaths: string[] = [];
   const join = (...parts: string[]) => parts.join("/").replace(/\/+/g, "/");
   return {
     files,
+    directories,
     removedPaths,
     tmpdir: () => tmpDir,
     join,
     dirname: (path) => path.slice(0, path.lastIndexOf("/")) || "/",
-    mkdir: jest.fn(async () => undefined),
+    mkdir: jest.fn(async (path) => {
+      directories.add(path);
+    }),
     appendFile: jest.fn(async (path, data) => {
       files.set(path, (files.get(path) ?? "") + data);
     }),
@@ -26,76 +54,599 @@ function makeRuntime(tmpDir = "/tmp"): FakeRuntime {
     rm: jest.fn(async (path) => {
       removedPaths.push(path);
       files.delete(path);
+      directories.delete(path);
     }),
     stat: jest.fn(async (path) => {
       const data = files.get(path);
-      if (data === undefined) throw new Error("ENOENT");
+      if (data === undefined) throw errno("ENOENT");
       return { size: data.length };
     }),
     rename: jest.fn(async (oldPath, newPath) => {
       const data = files.get(oldPath);
-      if (data === undefined) throw new Error("ENOENT");
+      if (data === undefined) throw errno("ENOENT");
       files.set(newPath, data);
       files.delete(oldPath);
     }),
+    chmod: jest.fn(async () => undefined),
+    // Known files are plain files, mkdir-ed paths plain directories, anything
+    // else ENOENT — all owned by uid 1000, so path validation passes and the
+    // queueing tests stay focused. Squatting scenarios live in the real-fs
+    // groups below.
+    lstat: jest.fn(async (path: string) => {
+      // Root directory: always owned by root (uid 0), mode 0755.
+      if (path === "/") {
+        return { uid: 0, mode: 0o755, isDirectory: true, isSymbolicLink: false };
+      }
+      if (path === tmpDir) {
+        return { uid: 1000, mode: tempRootMode, isDirectory: true, isSymbolicLink: false };
+      }
+      if (files.has(path)) {
+        return { uid: 1000, mode: 0o600, isDirectory: false, isSymbolicLink: false };
+      }
+      if (directories.has(path)) {
+        return { uid: 1000, mode: 0o700, isDirectory: true, isSymbolicLink: false };
+      }
+      throw errno("ENOENT");
+    }),
+    getuid: () => 1000,
     openPath: jest.fn(async () => ""),
   };
 }
 
-describe("FrameSink", () => {
-  it("stores frame logs in a per-vault temp directory", () => {
-    const runtime = makeRuntime("C:/Users/zero/AppData/Local/Temp");
-    const first = getFrameLogPaths("C:/Users/zero/Vault", runtime);
-    const second = getFrameLogPaths("C:/Users/zero/OtherVault", runtime);
+/** Real-fs NodeRuntime mirroring production `getNodeRuntime`, pinned to a temp base. */
+function makeRealRuntime(tmpBase: string): NodeRuntime {
+  return {
+    tmpdir: () => tmpBase,
+    join: (...segs: string[]) => path.join(...segs),
+    dirname: (p: string) => path.dirname(p),
+    mkdir: async (dirPath, opts) => {
+      await fs.mkdir(dirPath, opts);
+    },
+    appendFile: fs.appendFile,
+    writeFile: fs.writeFile,
+    rm: fs.rm,
+    stat: fs.stat,
+    rename: fs.rename,
+    chmod: fs.chmod,
+    lstat: async (p) => {
+      const st = await fs.lstat(p);
+      return {
+        uid: st.uid,
+        mode: st.mode,
+        isDirectory: st.isDirectory(),
+        isSymbolicLink: st.isSymbolicLink(),
+      };
+    },
+    getuid: process.getuid ? () => process.getuid() : undefined,
+    openPath: async () => "",
+  };
+}
 
-    expect(first.logPath).toContain("/obsidian-copilot/acp-frames/");
-    expect(first.logPath).toMatch(/\/acp-frames\.ndjson$/);
-    expect(first.rotatedPath).toMatch(/\/acp-frames\.old\.ndjson$/);
-    expect(first.dirPath).not.toBe(second.dirPath);
-  });
+const modeOf = (p: string): number => fsSync.statSync(p).mode & 0o777;
+const exists = (p: string): boolean => fsSync.existsSync(p);
+const describePosix = process.platform === "win32" ? describe.skip : describe;
 
-  it("summarizes oversized frames before appending", async () => {
-    const runtime = makeRuntime();
-    const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
-    const paths = getFrameLogPaths("/vault", runtime);
+describe("debugSink", () => {
+  describe("getFrameLogPaths()", () => {
+    it("stores frame logs in stable, distinct per-vault temp directories", () => {
+      const runtime = makeRuntime("C:/Users/zero/AppData/Local/Temp");
+      const first = getFrameLogPaths("C:/Users/zero/Vault", runtime);
+      const second = getFrameLogPaths("C:/Users/zero/OtherVault", runtime);
 
-    sink.append({
-      ts: "2026-05-12T00:00:00.000Z",
-      dir: "←",
-      tag: "codex",
-      kind: "notif",
-      method: "session/update",
-      id: null,
-      payload: {
-        update: {
-          sessionUpdate: "tool_call_update",
-          toolCallId: "call-1",
-        },
-        content: "x".repeat(100_000),
-      },
+      expect(first.logPath).toContain("/obsidian-copilot/acp-frames/");
+      expect(first.logPath).toMatch(/\/acp-frames\.ndjson$/);
+      expect(first.rotatedPath).toMatch(/\/acp-frames\.old\.ndjson$/);
+      expect(first.dirPath).not.toBe(second.dirPath);
     });
-    await sink.flush();
-
-    const log = runtime.files.get(paths.logPath) ?? "";
-    expect(log.length).toBeLessThan(5_000);
-    expect(log).toContain('"__truncated":true');
-    expect(log).toContain("sessionUpdate=tool_call_update");
-    expect(log).toContain("toolCallId=call-1");
   });
 
-  it("clears active and rotated log files", async () => {
-    const runtime = makeRuntime();
-    const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
-    const paths = getFrameLogPaths("/vault", runtime);
-    runtime.files.set(paths.logPath, "active");
-    runtime.files.set(paths.rotatedPath, "old");
+  describe("FrameSink", () => {
+    describe("append()", () => {
+      it("summarizes oversized frames before appending", async () => {
+        const runtime = makeRuntime();
+        const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+        const paths = getFrameLogPaths("/vault", runtime);
 
-    await sink.clear();
+        sink.append(
+          makeFrame({
+            dir: "←",
+            payload: {
+              update: {
+                sessionUpdate: "tool_call_update",
+                toolCallId: "call-1",
+              },
+              content: "x".repeat(100_000),
+            },
+          })
+        );
+        await sink.flush();
 
-    expect(runtime.files.has(paths.logPath)).toBe(false);
-    expect(runtime.files.has(paths.rotatedPath)).toBe(false);
-    expect(runtime.removedPaths).toEqual(
-      expect.arrayContaining([paths.logPath, paths.rotatedPath])
-    );
+        const log = runtime.files.get(paths.logPath) ?? "";
+        expect(log.length).toBeLessThan(5_000);
+        expect(log).toContain('"__truncated":true');
+        expect(log).toContain("sessionUpdate=tool_call_update");
+        expect(log).toContain("toolCallId=call-1");
+      });
+
+      // POSIX-only: on win32 the sink skips ownership and mode validation
+      // entirely, so none of these refusals apply.
+      describePosix("temp root validation", () => {
+        it.each([
+          {
+            condition: "a symlink",
+            entry: { uid: 1000, mode: 0o1777, isDirectory: true, isSymbolicLink: true },
+          },
+          {
+            condition: "not a directory",
+            entry: { uid: 1000, mode: 0o600, isDirectory: false, isSymbolicLink: false },
+          },
+          {
+            condition: "owned by another user",
+            entry: { uid: 2000, mode: 0o1777, isDirectory: true, isSymbolicLink: false },
+          },
+          {
+            condition: "group-writable without a sticky bit",
+            entry: { uid: 1000, mode: 0o770, isDirectory: true, isSymbolicLink: false },
+          },
+        ])(
+          "writes nothing while the temp root is $condition, then logs once it is safe (https://github.com/logancyang/obsidian-copilot-preview/issues/250)",
+          async ({ entry }) => {
+            const runtime = makeRuntime();
+            const paths = getFrameLogPaths("/vault", runtime);
+            const lstat = runtime.lstat as jest.MockedFunction<NodeRuntime["lstat"]>;
+            const safeLstat = lstat.getMockImplementation()!;
+            // Only the temp root is unsafe; every level below it stays valid, so
+            // a frame that still gets written proves the temp-root check is what
+            // stopped it.
+            lstat.mockImplementation(async (path: string) =>
+              path === runtime.tmpdir() ? entry : safeLstat(path)
+            );
+            const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+
+            sink.append(makeFrame({ id: "first" }));
+            await sink.flush();
+            sink.append(makeFrame({ id: "second" }));
+            await sink.flush();
+
+            expect(runtime.appendFile).not.toHaveBeenCalled();
+            expect(runtime.files.size).toBe(0);
+
+            // A refusal is never cached, so a temp root that becomes safe starts
+            // logging again without restarting the plugin.
+            lstat.mockImplementation(safeLstat);
+            sink.append(makeFrame({ id: "third" }));
+            await sink.flush();
+            expect(runtime.files.get(paths.logPath)).toContain('"id":"third"');
+          }
+        );
+
+        it("logs under a root-owned sticky temp root, the shape of a standard Linux /tmp (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRuntime();
+          const paths = getFrameLogPaths("/vault", runtime);
+          const lstat = runtime.lstat as jest.MockedFunction<NodeRuntime["lstat"]>;
+          const safeLstat = lstat.getMockImplementation()!;
+          // Linux ships /tmp as uid 0, mode 1777: owned by neither us nor any
+          // attacker, and world-writable but sticky. Both allowances are load
+          // bearing — tightening either one stops every Linux install from
+          // logging, which no refusal case can catch.
+          lstat.mockImplementation(async (target: string) =>
+            target === runtime.tmpdir()
+              ? { uid: 0, mode: 0o1777, isDirectory: true, isSymbolicLink: false }
+              : safeLstat(target)
+          );
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+
+          sink.append(makeFrame({ id: "linux-tmp" }));
+          await sink.flush();
+
+          expect(runtime.files.get(paths.logPath)).toContain('"id":"linux-tmp"');
+        });
+      });
+
+      it("refuses a level that is still not a real directory after creating it (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+        const runtime = makeRuntime();
+        const paths = getFrameLogPaths("/vault", runtime);
+        const lstat = runtime.lstat as jest.MockedFunction<NodeRuntime["lstat"]>;
+        const safeLstat = lstat.getMockImplementation()!;
+        // mkdir reports success, but re-inspecting the level finds a symlink —
+        // the race a squatter wins between the two calls.
+        lstat.mockImplementation(async (target: string) =>
+          target === paths.dirPath && runtime.directories.has(target)
+            ? { uid: 1000, mode: 0o700, isDirectory: false, isSymbolicLink: true }
+            : safeLstat(target)
+        );
+        const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+
+        sink.append(makeFrame());
+        await sink.flush();
+
+        expect(runtime.appendFile).not.toHaveBeenCalled();
+        expect(runtime.files.size).toBe(0);
+      });
+
+      it("refuses to write when a directory occupies the log file path (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+        const runtime = makeRuntime();
+        const paths = getFrameLogPaths("/vault", runtime);
+        const lstat = runtime.lstat as jest.MockedFunction<NodeRuntime["lstat"]>;
+        const safeLstat = lstat.getMockImplementation()!;
+        lstat.mockImplementation(async (target: string) =>
+          target === paths.logPath
+            ? { uid: 1000, mode: 0o700, isDirectory: true, isSymbolicLink: false }
+            : safeLstat(target)
+        );
+        const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+
+        sink.append(makeFrame());
+        await sink.flush();
+
+        // Unlike a symlink, a directory may hold content its owner needs, so it
+        // is refused rather than removed.
+        expect(runtime.appendFile).not.toHaveBeenCalled();
+        expect(runtime.rm).not.toHaveBeenCalled();
+      });
+
+      it("drops the frame instead of writing when path validation fails, then recovers (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+        const runtime = makeRuntime();
+        const lstat = runtime.lstat as jest.MockedFunction<NodeRuntime["lstat"]>;
+        // First ensure pass dies on an unreadable path — e.g. a directory the
+        // sink may not traverse. Nothing may be written in response.
+        lstat.mockRejectedValueOnce(errno("EACCES"));
+        const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+        const paths = getFrameLogPaths("/vault", runtime);
+
+        sink.append(makeFrame({ id: "first" }));
+        await sink.flush();
+        expect(runtime.appendFile).not.toHaveBeenCalled();
+        expect(runtime.writeFile).not.toHaveBeenCalled();
+
+        // The failed ensure was not cached: the next frame re-validates and
+        // lands normally.
+        sink.append(makeFrame({ id: "second" }));
+        await sink.flush();
+        expect(runtime.files.get(paths.logPath)).toContain('"id":"second"');
+      });
+    });
+
+    describe("clear()", () => {
+      it("clears active and rotated log files", async () => {
+        const runtime = makeRuntime();
+        const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+        const paths = getFrameLogPaths("/vault", runtime);
+        runtime.files.set(paths.logPath, "active");
+        runtime.files.set(paths.rotatedPath, "old");
+
+        await sink.clear();
+
+        expect(runtime.files.has(paths.logPath)).toBe(false);
+        expect(runtime.files.has(paths.rotatedPath)).toBe(false);
+        expect(runtime.removedPaths).toEqual(
+          expect.arrayContaining([paths.logPath, paths.rotatedPath])
+        );
+      });
+
+      it("deletes nothing when path validation fails (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+        const runtime = makeRuntime();
+        const lstat = runtime.lstat as jest.MockedFunction<NodeRuntime["lstat"]>;
+        lstat.mockRejectedValueOnce(errno("EACCES"));
+        const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+        const paths = getFrameLogPaths("/vault", runtime);
+        runtime.files.set(paths.logPath, "active");
+
+        await expect(sink.clear()).rejects.toThrow("EACCES");
+
+        expect(runtime.rm).not.toHaveBeenCalled();
+        expect(runtime.files.has(paths.logPath)).toBe(true);
+      });
+    });
+
+    // The groups below re-exercise append()/open()/clear() against the REAL
+    // filesystem, proving the frame log's owner-only permission boundary:
+    // mode bits under several umasks, narrowing of paths left permissive by
+    // older builds, and squatted-path containment — none of which the
+    // in-memory runtime can prove.
+    // https://github.com/logancyang/obsidian-copilot-preview/issues/250
+    // They stay separate same-callable groups (as AGENTS.md's lifecycle
+    // exception allows) because they carry a material lifecycle of their own:
+    // a per-test mkdtemp sandbox, process-umask save/restore, and a
+    // POSIX-only skip (win32 has no POSIX mode bits).
+    describePosix("on the real filesystem (POSIX)", () => {
+      let tmpBase: string;
+      let prevUmask: number;
+
+      beforeEach(async () => {
+        tmpBase = await fs.mkdtemp(path.join(os.tmpdir(), "frame-sink-realfs-"));
+        prevUmask = process.umask(0o022);
+      });
+
+      afterEach(async () => {
+        process.umask(prevUmask);
+        await fs.rm(tmpBase, { recursive: true, force: true });
+      });
+
+      describe("append()", () => {
+        it.each([[0o000], [0o022], [0o077]])(
+          "creates the directory chain 0700 and the log file 0600 under umask %o (https://github.com/logancyang/obsidian-copilot-preview/issues/250)",
+          async (umask) => {
+            process.umask(umask);
+            const runtime = makeRealRuntime(tmpBase);
+            const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+            const paths = getFrameLogPaths("/vault", runtime);
+
+            sink.append(makeFrame());
+            await sink.flush();
+
+            expect(exists(paths.logPath)).toBe(true);
+            // Every level of the predictable chain is owner-only, not just the leaf.
+            expect(modeOf(paths.dirPath)).toBe(0o700);
+            expect(modeOf(path.dirname(paths.dirPath))).toBe(0o700);
+            expect(modeOf(path.dirname(path.dirname(paths.dirPath)))).toBe(0o700);
+            expect(modeOf(paths.logPath)).toBe(0o600);
+          }
+        );
+
+        it("narrows a pre-existing permissive directory and both log generations from an older build (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          process.umask(0o000);
+          await fs.mkdir(paths.dirPath, { recursive: true });
+          await fs.writeFile(paths.logPath, "old-active\n", { mode: 0o644 });
+          await fs.writeFile(paths.rotatedPath, "old-rotated\n", { mode: 0o644 });
+          expect(modeOf(paths.dirPath)).toBe(0o777);
+
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+          sink.append(makeFrame());
+          await sink.flush();
+
+          expect(modeOf(paths.dirPath)).toBe(0o700);
+          expect(modeOf(paths.logPath)).toBe(0o600);
+          expect(modeOf(paths.rotatedPath)).toBe(0o600);
+          // The pre-existing content survived — narrowing must not truncate.
+          const content = await fs.readFile(paths.logPath, "utf8");
+          expect(content).toContain("old-active");
+          expect(content).toContain('"session/update"');
+        });
+
+        it("removes a symlink squatting the leaf directory and never writes through it (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          const victim = path.join(tmpBase, "victim");
+          await fs.mkdir(victim, { recursive: true });
+          await fs.mkdir(path.dirname(paths.dirPath), { recursive: true });
+          await fs.symlink(victim, paths.dirPath);
+
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+          sink.append(makeFrame());
+          await sink.flush();
+
+          // The victim directory never received the log file.
+          expect(exists(path.join(victim, "acp-frames.ndjson"))).toBe(false);
+          // The squatting link was replaced by a real owner-only directory.
+          const leaf = await fs.lstat(paths.dirPath);
+          expect(leaf.isSymbolicLink()).toBe(false);
+          expect(leaf.isDirectory()).toBe(true);
+          expect(modeOf(paths.dirPath)).toBe(0o700);
+          expect(modeOf(paths.logPath)).toBe(0o600);
+        });
+
+        it("refuses a plain file squatting a directory level without deleting it (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          await fs.mkdir(path.dirname(paths.dirPath), { recursive: true });
+          // A plain file may be content someone owns — unlike a symlink it is
+          // never removed; the sink fails closed instead.
+          await fs.writeFile(paths.dirPath, "someone's data", { mode: 0o644 });
+
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+          sink.append(makeFrame());
+          await sink.flush();
+
+          const leaf = await fs.lstat(paths.dirPath);
+          expect(leaf.isFile()).toBe(true);
+          expect(await fs.readFile(paths.dirPath, "utf8")).toBe("someone's data");
+          // Refusing means leaving it exactly as found: a sink that walked past
+          // this and narrowed the squatter would rewrite another user's mode.
+          expect(modeOf(paths.dirPath)).toBe(0o644);
+          expect(exists(paths.logPath)).toBe(false);
+        });
+
+        it("removes a dangling symlink squatting the leaf directory path (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          await fs.mkdir(path.dirname(paths.dirPath), { recursive: true });
+          await fs.symlink(path.join(tmpBase, "nowhere"), paths.dirPath);
+
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+          sink.append(makeFrame());
+          await sink.flush();
+
+          const leaf = await fs.lstat(paths.dirPath);
+          expect(leaf.isSymbolicLink()).toBe(false);
+          expect(leaf.isDirectory()).toBe(true);
+          expect(modeOf(paths.dirPath)).toBe(0o700);
+          expect(modeOf(paths.logPath)).toBe(0o600);
+        });
+
+        it("removes a symlink squatting the log file itself and leaves its target untouched (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          const victimFile = path.join(tmpBase, "victim.txt");
+          await fs.writeFile(victimFile, "victim-content", { mode: 0o644 });
+          await fs.mkdir(paths.dirPath, { recursive: true });
+          await fs.symlink(victimFile, paths.logPath);
+
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+          sink.append(makeFrame());
+          await sink.flush();
+
+          // The victim was neither chmodded nor appended to.
+          expect(await fs.readFile(victimFile, "utf8")).toBe("victim-content");
+          expect(modeOf(victimFile)).toBe(0o644);
+          // The log landed in a fresh private regular file.
+          const log = await fs.lstat(paths.logPath);
+          expect(log.isSymbolicLink()).toBe(false);
+          expect(modeOf(paths.logPath)).toBe(0o600);
+        });
+
+        it("refuses to write into a directory owned by another user instead of falling back (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          await fs.mkdir(paths.dirPath, { recursive: true });
+          // The on-disk uid can't differ without root, so report a foreign owner
+          // for the leaf directory alone. Shifting the runtime's whole idea of
+          // the current uid would make the temp root look foreign too, and the
+          // refusal under test would never be reached.
+          const realLstat = runtime.lstat;
+          runtime.lstat = async (target: string) => {
+            const entry = await realLstat(target);
+            return target === paths.dirPath ? { ...entry, uid: entry.uid + 1 } : entry;
+          };
+
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+          sink.append(makeFrame());
+          await sink.flush();
+
+          // No write landed anywhere — in particular no fallback recreate.
+          expect(exists(paths.logPath)).toBe(false);
+          expect(exists(paths.rotatedPath)).toBe(false);
+        });
+
+        it("leaves a log file owned by another user unread and unnarrowed (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          await fs.mkdir(paths.dirPath, { recursive: true });
+          await fs.writeFile(paths.logPath, "someone else's frames\n", { mode: 0o644 });
+          const realLstat = runtime.lstat;
+          runtime.lstat = async (target: string) => {
+            const entry = await realLstat(target);
+            return target === paths.logPath ? { ...entry, uid: entry.uid + 1 } : entry;
+          };
+
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+          sink.append(makeFrame());
+          await sink.flush();
+
+          // Narrowing a file we do not own would rewrite its owner's mode, and
+          // appending would mix our frames into their file.
+          expect(await fs.readFile(paths.logPath, "utf8")).toBe("someone else's frames\n");
+          expect(modeOf(paths.logPath)).toBe(0o644);
+        });
+
+        it("creates the fresh post-rotation file 0600 (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          await fs.mkdir(paths.dirPath, { recursive: true });
+          // A sparse active file already past the rotation threshold.
+          await fs.writeFile(paths.logPath, "", { mode: 0o644 });
+          await fs.truncate(paths.logPath, 51 * 1024 * 1024);
+
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+          // ROTATE_CHECK_EVERY (25) writes trigger the stat check and rename;
+          // one more lands in the freshly created active file.
+          for (let i = 0; i < 26; i++) sink.append(makeFrame({ id: String(i) }));
+          await sink.flush();
+
+          expect(exists(paths.rotatedPath)).toBe(true);
+          expect(modeOf(paths.rotatedPath)).toBe(0o600);
+          expect(modeOf(paths.logPath)).toBe(0o600);
+        });
+      });
+
+      describe("open()", () => {
+        it("creates a missing log file 0600 before opening it (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+
+          await sink.open();
+
+          expect(exists(paths.logPath)).toBe(true);
+          expect(modeOf(paths.logPath)).toBe(0o600);
+          expect(modeOf(paths.dirPath)).toBe(0o700);
+        });
+      });
+
+      describe("narrowLegacyLogs()", () => {
+        it("narrows both log generations an older build left world-readable (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          await fs.mkdir(paths.dirPath, { recursive: true, mode: 0o755 });
+          await fs.writeFile(paths.logPath, "old prompts\n", { mode: 0o644 });
+          await fs.writeFile(paths.rotatedPath, "older prompts\n", { mode: 0o644 });
+
+          await new FrameSink({ vaultBasePath: "/vault", runtime }).narrowLegacyLogs();
+
+          expect(modeOf(paths.logPath)).toBe(0o600);
+          expect(modeOf(paths.rotatedPath)).toBe(0o600);
+          // Narrowing must not cost the diagnostic history it is protecting.
+          expect(await fs.readFile(paths.logPath, "utf8")).toBe("old prompts\n");
+        });
+
+        it("creates nothing when no log was ever written (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+
+          await new FrameSink({ vaultBasePath: "/vault", runtime }).narrowLegacyLogs();
+
+          // This runs on every desktop startup, so someone who never enables
+          // frame logging must not find a temp directory made on their behalf.
+          expect(exists(paths.dirPath)).toBe(false);
+          expect(exists(paths.logPath)).toBe(false);
+        });
+
+        it("leaves a legacy log owned by another user untouched (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          await fs.mkdir(paths.dirPath, { recursive: true });
+          await fs.writeFile(paths.logPath, "not ours\n", { mode: 0o644 });
+          const realLstat = runtime.lstat;
+          runtime.lstat = async (target: string) => {
+            const entry = await realLstat(target);
+            return target === paths.logPath ? { ...entry, uid: entry.uid + 1 } : entry;
+          };
+
+          await new FrameSink({ vaultBasePath: "/vault", runtime }).narrowLegacyLogs();
+
+          expect(modeOf(paths.logPath)).toBe(0o644);
+        });
+
+        it("still narrows the rotated log when the active one cannot be secured (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          await fs.mkdir(paths.dirPath, { recursive: true });
+          await fs.writeFile(paths.logPath, "not ours\n", { mode: 0o644 });
+          await fs.writeFile(paths.rotatedPath, "ours, older\n", { mode: 0o644 });
+          const realLstat = runtime.lstat;
+          runtime.lstat = async (target: string) => {
+            const entry = await realLstat(target);
+            return target === paths.logPath ? { ...entry, uid: entry.uid + 1 } : entry;
+          };
+
+          await new FrameSink({ vaultBasePath: "/vault", runtime }).narrowLegacyLogs();
+
+          // Each generation stands alone: an entry this sink must refuse says
+          // nothing about the other, which is still the user's own plaintext.
+          expect(modeOf(paths.logPath)).toBe(0o644);
+          expect(modeOf(paths.rotatedPath)).toBe(0o600);
+        });
+      });
+
+      describe("clear()", () => {
+        it("does not delete through a symlink squatting the leaf directory (https://github.com/logancyang/obsidian-copilot-preview/issues/250)", async () => {
+          const runtime = makeRealRuntime(tmpBase);
+          const paths = getFrameLogPaths("/vault", runtime);
+          const victim = path.join(tmpBase, "victim");
+          await fs.mkdir(victim, { recursive: true });
+          const victimLog = path.join(victim, "acp-frames.ndjson");
+          await fs.writeFile(victimLog, "victim-data");
+          await fs.mkdir(path.dirname(paths.dirPath), { recursive: true });
+          await fs.symlink(victim, paths.dirPath);
+
+          const sink = new FrameSink({ vaultBasePath: "/vault", runtime });
+          await sink.clear();
+
+          expect(exists(victimLog)).toBe(true);
+        });
+      });
+    });
   });
 });

--- a/src/agentMode/session/debugSink.ts
+++ b/src/agentMode/session/debugSink.ts
@@ -21,6 +21,11 @@ const LOG_FILE_NAME = "acp-frames.ndjson";
 const ROTATED_FILE_NAME = "acp-frames.old.ndjson";
 const DESKTOP_UNAVAILABLE_PATH = "(Agent Mode frame logs are desktop-only)";
 const LOG_DIR_PREFIX = ["obsidian-copilot", "acp-frames"] as const;
+// Owner-only modes: the log holds full prompt/tool/note content in plaintext,
+// and on Linux os.tmpdir() can be a world-readable shared /tmp.
+// https://github.com/logancyang/obsidian-copilot-preview/issues/250
+const LOG_DIR_MODE = 0o700;
+const LOG_FILE_MODE = 0o600;
 const ROTATE_BYTES = 50 * 1024 * 1024;
 // Per-frame cap. Some backends (notably codex) re-emit the full cumulative
 // tool output on every `tool_call_update`, so a single frame can exceed 1 MB.
@@ -42,16 +47,36 @@ export interface FrameLogPaths {
   rotatedPath: string;
 }
 
+/** `lstat` result reduced to the fields the sink's path validation needs. */
+export interface RuntimeLstat {
+  uid: number;
+  mode: number;
+  isDirectory: boolean;
+  isSymbolicLink: boolean;
+}
+
 export interface NodeRuntime {
   tmpdir: () => string;
   join: (...parts: string[]) => string;
   dirname: (path: string) => string;
-  mkdir: (path: string, opts: { recursive: boolean }) => Promise<void>;
-  appendFile: (path: string, data: string, encoding: "utf8") => Promise<void>;
-  writeFile: (path: string, data: string, encoding: "utf8") => Promise<void>;
+  mkdir: (path: string, opts: { recursive: boolean; mode: number }) => Promise<void>;
+  appendFile: (
+    path: string,
+    data: string,
+    opts: { encoding: "utf8"; mode: number }
+  ) => Promise<void>;
+  writeFile: (
+    path: string,
+    data: string,
+    opts: { encoding: "utf8"; mode: number }
+  ) => Promise<void>;
   rm: (path: string, opts: { force: boolean; recursive?: boolean }) => Promise<void>;
   stat: (path: string) => Promise<{ size: number }>;
   rename: (oldPath: string, newPath: string) => Promise<void>;
+  chmod: (path: string, mode: number) => Promise<void>;
+  lstat: (path: string) => Promise<RuntimeLstat>;
+  /** Current effective uid; absent on platforms without POSIX ownership (win32). */
+  getuid?: () => number;
   openPath?: (path: string) => Promise<string | void>;
   showItemInFolder?: (path: string) => void;
 }
@@ -141,6 +166,10 @@ export class FrameSink {
       if (!paths) return;
       const runtime = this.getRuntime();
       if (!runtime) return;
+      // Same safety gate as writes: a squatted directory must not let Clear
+      // delete files at an attacker-chosen location.
+      // https://github.com/logancyang/obsidian-copilot-preview/issues/250
+      await this.ensureFolder(runtime, paths);
       await removeIfExists(runtime, paths.logPath);
       await removeIfExists(runtime, paths.rotatedPath);
     });
@@ -155,7 +184,7 @@ export class FrameSink {
       if (!paths) return;
       const runtime = this.getRuntime();
       if (!runtime) return;
-      await this.ensureFolder(runtime, paths.dirPath);
+      await this.ensureFolder(runtime, paths);
       await ensureFileExists(runtime, paths.logPath);
     });
     this.writeChain = task.catch(() => {});
@@ -183,6 +212,40 @@ export class FrameSink {
     await this.writeChain;
   }
 
+  /**
+   * Narrow logs an earlier build left readable by other local accounts, for
+   * the one case ordinary logging never reaches.
+   *
+   * The narrowing inside `ensureFolder()` only runs from `append()`, `open()`,
+   * or `clear()`, and `append()` is gated on the `debugFullFrames` toggle at
+   * its call sites. Someone who logged under an older build and then turned
+   * the toggle off would otherwise keep `0644` plaintext prompts on a shared
+   * temp root indefinitely, since nothing would ever look at them again.
+   * Deliberately does not create the directory chain: someone who never logs
+   * must not get a temp directory made for them. Best effort — a log that
+   * cannot be narrowed is left as the older build wrote it.
+   * https://github.com/logancyang/obsidian-copilot-preview/issues/250
+   */
+  async narrowLegacyLogs(): Promise<void> {
+    const task = this.writeChain.then(async () => {
+      const paths = this.resolvePaths();
+      const runtime = this.getRuntime();
+      if (!paths || !runtime) return;
+      for (const target of [paths.logPath, paths.rotatedPath]) {
+        try {
+          await narrowExistingFile(runtime, target, getPosixOwnerUid(runtime));
+        } catch {
+          // Each generation stands alone: one this sink must refuse, or a
+          // runtime that cannot report its uid, says nothing about the other,
+          // which may still hold the user's own plaintext. Startup must not
+          // fail over a diagnostic log either, so nothing propagates.
+        }
+      }
+    });
+    this.writeChain = task;
+    return task;
+  }
+
   private resolvePaths(): FrameLogPaths | null {
     const runtime = this.getRuntime();
     if (!runtime) return null;
@@ -195,10 +258,39 @@ export class FrameSink {
     return this.options.runtime ?? getNodeRuntime();
   }
 
-  private async ensureFolder(runtime: NodeRuntime, dirPath: string): Promise<void> {
-    if (this.ensuredDirPath === dirPath) return;
-    await runtime.mkdir(dirPath, { recursive: true });
-    this.ensuredDirPath = dirPath;
+  /**
+   * Establish the owner-only log location before any write or delete touches
+   * it. Validates every level of the predictable temp-path chain top-down —
+   * the sticky-bit parent only protects the first level, so an attacker who
+   * pre-created an upper level would control everything beneath it — and
+   * narrows both log generations left behind by older builds. Throws when the
+   * location cannot be made safe; callers drop the operation.
+   * https://github.com/logancyang/obsidian-copilot-preview/issues/250
+   */
+  private async ensureFolder(runtime: NodeRuntime, paths: FrameLogPaths): Promise<void> {
+    // DESIGN NOTE — the cache trusts "parents are 0700 and ours ⇒ contents
+    // stay ours": replacing a validated level afterwards requires write access
+    // inside an owner-only directory, or unlinking our entry under the
+    // sticky-bit temp root, neither of which another local account has. A
+    // first validation that finds a previously world-writable directory still
+    // has an lstat-to-chmod window; closing it needs a held descriptor
+    // (O_NOFOLLOW plus fchmod) rather than path-based calls, which this sink
+    // deliberately does not use.
+    if (this.ensuredDirPath === paths.dirPath) return;
+
+    await validateTempRoot(runtime);
+    const framesRoot = runtime.dirname(paths.dirPath);
+    const appRoot = runtime.dirname(framesRoot);
+    const ownerUid = getPosixOwnerUid(runtime);
+    for (const level of [appRoot, framesRoot, paths.dirPath]) {
+      await ensurePrivateDirectory(runtime, level, ownerUid);
+    }
+    await narrowExistingFile(runtime, paths.logPath, ownerUid);
+    await narrowExistingFile(runtime, paths.rotatedPath, ownerUid);
+
+    // Cache only after the temp root and the complete directory chain pass validation.
+
+    this.ensuredDirPath = paths.dirPath;
   }
 
   /**
@@ -266,17 +358,19 @@ export class FrameSink {
     }
 
     try {
-      await this.ensureFolder(runtime, paths.dirPath);
-      await runtime.appendFile(paths.logPath, payload, "utf8");
+      await this.ensureFolder(runtime, paths);
+      await runtime.appendFile(paths.logPath, payload, {
+        encoding: "utf8",
+        mode: LOG_FILE_MODE,
+      });
     } catch {
-      // appendFile can fail if the directory was removed while a write was
-      // queued; recreate the folder and write the frame as a fresh file.
-      try {
-        await runtime.mkdir(runtime.dirname(paths.logPath), { recursive: true });
-        await runtime.writeFile(paths.logPath, payload, "utf8");
-      } catch {
-        return;
-      }
+      // Drop the frame and forget the validated directory, so the next frame
+      // re-runs the full safety check (and recreates a deleted folder). A
+      // recovery write here would bypass the validation that just failed and
+      // could land the log outside the owner-only directory.
+      // https://github.com/logancyang/obsidian-copilot-preview/issues/250
+      this.ensuredDirPath = null;
+      return;
     }
 
     this.writeCount++;
@@ -339,6 +433,17 @@ function getNodeRuntime(): NodeRuntime | null {
       rm: fs.rm,
       stat: fs.stat,
       rename: fs.rename,
+      chmod: fs.chmod,
+      lstat: async (p) => {
+        const st = await fs.lstat(p);
+        return {
+          uid: st.uid,
+          mode: st.mode,
+          isDirectory: st.isDirectory(),
+          isSymbolicLink: st.isSymbolicLink(),
+        };
+      },
+      getuid: process.getuid ? () => process.getuid() : undefined,
       openPath: shell?.openPath?.bind(shell),
       showItemInFolder: shell?.showItemInFolder?.bind(shell),
     };
@@ -347,12 +452,194 @@ function getNodeRuntime(): NodeRuntime | null {
   }
 }
 
+/**
+ * Create the log file owner-only when Open is used before anything has been
+ * logged. A failure other than "not found" is rethrown rather than treated as
+ * a missing file, so an unreadable path cannot be answered with a fresh file
+ * at a location the caller never validated.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/250
+ */
 async function ensureFileExists(runtime: NodeRuntime, path: string): Promise<void> {
   try {
-    await runtime.stat(path);
-  } catch {
-    await runtime.writeFile(path, "", "utf8");
+    await runtime.lstat(path);
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error;
+    await runtime.writeFile(path, "", { encoding: "utf8", mode: LOG_FILE_MODE });
   }
+}
+
+/**
+ * The uid every validated path must be owned by, or `null` where POSIX
+ * ownership does not exist (win32) and the mode/owner narrowing is skipped —
+ * per-user %TEMP% already isolates there, and losing the log to an
+ * unenforceable check would be worse. A POSIX runtime that cannot report its
+ * uid fails closed instead.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/250
+ */
+function getPosixOwnerUid(runtime: NodeRuntime): number | null {
+  if (process.platform === "win32") return null;
+  const uid = runtime.getuid?.();
+  if (uid === undefined) {
+    throw new Error("Cannot verify frame-log directory ownership on this platform.");
+  }
+  return uid;
+}
+
+/**
+ * Validate the OS temp root before caching any derived frame-log path.
+ *
+ * Frame log security model (best-effort):
+ *
+ * Protects against:
+ * - Symlink squatting at any path level
+ * - Direct file replacement (TOCTOU mitigated by caching after validation)
+ * - Accidental leaks in standard temp directories (Linux /tmp 1777, macOS per-user)
+ *
+ * Does NOT protect against:
+ * - Non-standard TMPDIR in shared writable parent without sticky bit
+ * - Anything the same account can do, including planting a FIFO at the log
+ *   path so an append blocks (visible as a stalled log; delete it to recover)
+ * - NFS/FUSE uid spoofing
+ * - Kernel-level attacks
+ *
+ * Rationale: This is a debug log for developer troubleshooting. The attack
+ * requires local multi-user access, non-standard temp config, vault hash knowledge,
+ * and precise timing. Standard deployments (single-user desktop, container with
+ * per-user temp) are not affected.
+ *
+ * If absolute security is required, disable frame logging via Settings → Advanced.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/250
+ */
+async function validateTempRoot(runtime: NodeRuntime): Promise<void> {
+  if (process.platform === "win32") return;
+
+  const tmpRoot = runtime.tmpdir();
+  const entry = await runtime.lstat(tmpRoot);
+  if (entry.isSymbolicLink || !entry.isDirectory) {
+    throw new Error("Frame log temp root must be a real directory.");
+  }
+
+  const ownerUid = getPosixOwnerUid(runtime);
+  if (ownerUid !== null && entry.uid !== ownerUid && entry.uid !== 0) {
+    throw new Error("Frame log temp root is owned by another user.");
+  }
+
+  const sharedWritable = (entry.mode & 0o022) !== 0;
+  if (sharedWritable && (entry.mode & 0o1000) === 0) {
+    throw new Error("Frame log temp root is group/world-writable without a sticky bit.");
+  }
+}
+
+/**
+ * Make one level of the log path a real, owner-only directory. A symlink
+ * squatting the level is unlinked and replaced rather than refused: it is the
+ * redirect vector this validation exists to stop, deleting it loses no
+ * content, and at the sticky-bit temp root the unlink of a foreign entry fails
+ * and correctly aborts. Anything else occupying the path — a plain file, FIFO,
+ * or a real directory owned by someone else — aborts instead, because it may
+ * be content its owner still needs.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/250
+ */
+async function ensurePrivateDirectory(
+  runtime: NodeRuntime,
+  path: string,
+  ownerUid: number | null
+): Promise<void> {
+  // Inspect before creating: recursive mkdir throws EEXIST when a plain file
+  // or dangling symlink squats the path, which would make the branches below
+  // unreachable.
+  let entry: RuntimeLstat | null;
+  try {
+    entry = await runtime.lstat(path);
+  } catch (error) {
+    if (!isNotFoundError(error)) throw error;
+    entry = null;
+  }
+  if (entry?.isSymbolicLink) {
+    await runtime.rm(path, { force: true });
+    entry = null;
+  }
+  if (entry && !entry.isDirectory) {
+    throw new Error("Frame log path is occupied by a file.");
+  }
+  if (!entry) {
+    await runtime.mkdir(path, { recursive: true, mode: LOG_DIR_MODE });
+    entry = await runtime.lstat(path);
+    if (entry.isSymbolicLink || !entry.isDirectory) {
+      throw new Error("Frame log path could not be made a real directory.");
+    }
+  }
+  if (ownerUid === null) return;
+  // On a shared temp root, only the first local account to run the plugin gets
+  // a frame log: it creates `<tmp>/obsidian-copilot` owner-only, and every
+  // later account stops here. Frame logging is opt-in diagnostics, so those
+  // accounts lose a debug aid rather than a feature.
+  // https://github.com/logancyang/obsidian-copilot-preview/issues/250
+  if (entry.uid !== ownerUid) {
+    throw new Error("Frame log directory is owned by another user.");
+  }
+  // Creation mode only applies to new directories; existing ones from older
+  // builds may be wide open, so narrow any permissions or special bits.
+  if ((entry.mode & 0o7777) !== LOG_DIR_MODE) {
+    await runtime.chmod(path, LOG_DIR_MODE);
+  }
+}
+
+/**
+ * Narrow a log file left behind by an older build to owner-only, unlinking a
+ * planted symlink (the append that follows recreates a private regular file)
+ * and refusing a file owned by someone else.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/250
+ *
+ * DESIGN NOTE — chmod stops future opens but cannot revoke a descriptor
+ * another account opened while the file was still world-readable. Revoking
+ * that would need a fresh inode, which either discards or copies the existing
+ * diagnostic log, so the narrowing accepts it.
+ *
+ * DESIGN NOTE — this function does not check whether the target is a regular
+ * file before chmod. A FIFO pre-planted by the current UID would pass the
+ * owner check and block appendFile() waiting for a reader. Cross-UID planting
+ * is prevented by the 0700 directory chain validated in ensureFolder(). Same-
+ * UID processes are not part of the threat model: they can already read vault
+ * files directly. Adding isFile() would complete the leaf regular-file
+ * invariant but does not close a privilege-escalation path. The current
+ * fire-and-forget append calling pattern limits the blast radius to stalled
+ * frame writes, not session-wide hangs.
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/250
+ */
+async function narrowExistingFile(
+  runtime: NodeRuntime,
+  path: string,
+  ownerUid: number | null
+): Promise<void> {
+  let entry: RuntimeLstat;
+  try {
+    entry = await runtime.lstat(path);
+  } catch (error) {
+    if (isNotFoundError(error)) return;
+    throw error;
+  }
+  if (entry.isSymbolicLink) {
+    await runtime.rm(path, { force: true });
+    return;
+  }
+  if (entry.isDirectory) {
+    throw new Error("Frame log file path is a directory.");
+  }
+  if (ownerUid === null) return;
+  if (entry.uid !== ownerUid) {
+    throw new Error("Frame log file is owned by another user.");
+  }
+  await runtime.chmod(path, LOG_FILE_MODE);
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as NodeJS.ErrnoException).code === "ENOENT"
+  );
 }
 
 async function removeIfExists(runtime: NodeRuntime, path: string): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -301,6 +301,7 @@ export default class CopilotPlugin extends Plugin {
         CopilotAgentView,
         PlanPreviewView,
         PLAN_PREVIEW_VIEW_TYPE,
+        acpFrameSink,
         createAgentSessionManager,
         setFrameSinkVaultBasePath,
       } = await import("@/agentMode");
@@ -314,6 +315,10 @@ export default class CopilotPlugin extends Plugin {
       setFrameSinkVaultBasePath(
         adapter instanceof FileSystemAdapter ? adapter.getBasePath() : null
       );
+      // A log left permissive by an older build is only reachable here when
+      // frame logging is switched off, because nothing else would read it
+      // again. https://github.com/logancyang/obsidian-copilot-preview/issues/250
+      void acpFrameSink.narrowLegacyLogs();
 
       this.agentSessionManager = createAgentSessionManager(this.app, this);
       // Enroll agent-reported models on probe settle, even when the settings

--- a/src/settings/model.ts
+++ b/src/settings/model.ts
@@ -287,9 +287,10 @@ export interface CopilotSettings {
      */
     claudeCli?: { path?: string };
     /**
-     * Opt-in: write the full untruncated ACP JSON-RPC frames as NDJSON to
-     * `<vault>/copilot/acp-frames.ndjson`. Heavyweight — leaves the existing
-     * 400-char summary log unchanged.
+     * Write the full untruncated ACP JSON-RPC frames as NDJSON to a per-vault
+     * owner-only directory under the OS temp folder (see
+     * `getFrameLogPaths()` in `src/agentMode/session/debugSink.ts`). On by
+     * default; leaves the existing 400-char summary log unchanged.
      */
     debugFullFrames: boolean;
     /**


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#199

## Why

Agent Mode's full-frame log records every prompt, tool input/output, and note excerpt in plaintext, is on by default, and lives at a fully predictable per-vault path under the OS temp folder. On Linux machines where that resolves to a shared `/tmp`, the directory is created `755` and the files `644` — any other local account can read up to ~100 MB of a user's chat and vault content without any interaction from them.

## What

Before any write, open, or clear touches the log location, every level of the predictable path chain is now made a real, owner-only directory, and both log generations are owner-only files.

| Condition | Before | After |
| --- | --- | --- |
| Fresh install, shared `/tmp`, any umask | dirs `755`, files `644` — world-readable | dirs `0700`, files `0600` from creation |
| Directory/files left permissive by an older build | stay world-readable forever | narrowed to `0700`/`0600` on first use |
| Symlink or stray file squats a path level | written through / silently broken | squatter unlinked and replaced; the target is never touched |
| A path level is a real directory owned by another user | written into | operation refused; frame dropped, nothing written or deleted |
| Validation fails inside `append()` | a fallback re-created the path with no checks and wrote anyway | frame dropped; next frame re-validates from scratch |
| Clear button with a squatted directory | deleted files at the attacker-chosen target | validates first; refuses and shows the existing failure Notice |
| Windows | — | structural checks kept; uid/mode enforcement skipped (per-user `%TEMP%` already isolates) |

The log path, file names, and the `getPath()`/`flush()` surface the report-upload flow reads are unchanged.

## Non goal

- Revoking file descriptors another account opened before this upgrade — that needs a fresh inode and would discard or copy the existing log; documented as a DESIGN NOTE at `narrowExistingFile`.
- Moving the log out of the OS temp folder or to a randomized path — the report flow requires a stable location.
- Changing what the log records or its on-by-default setting.
- Recovering a log the plugin can no longer identify as the user's own — a legacy file owned by another account is left exactly as found rather than adopted.
- Defending a non-standard `TMPDIR` that sits in a shared writable parent without a sticky bit — the trust anchor is the OS temp root itself, and closing that gap needs anchored directory-descriptor operations rather than more path-based checks. Standard `/tmp` (`1777`), the macOS per-user temp directory, and container temp are unaffected.

## Screenshot

Not applicable — filesystem permission hardening with no visual change; the Settings surface and its copy are untouched.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Real-filesystem tests assert the mode bits, squatter handling, and refusal paths; fake-runtime tests pin the no-fallback drop/recover and clear-refusal behavior |
| A defect would fail CI or be obvious on first use | ✅ | The real-filesystem suite runs in CI on POSIX runners; a missing log is visible in Settings → Advanced |
| A revert fully restores prior state, including persisted data | ✅ | No format change; already-narrowed permissions are harmless to the old code |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | The change is OS-permission enforcement on a secrets-bearing log |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `NodeRuntime` is module-internal (implemented only in `debugSink.ts` and its tests); path layout and `getPath()`/`flush()` unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The existing single write chain still serializes everything; validation runs inside it |
| No hot-path behavior lacks deterministic coverage | ✅ | Mutation-checked: reverting the inspect-before-create ordering fails exactly the two squatter tests |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong refusal shows up as a missing frame log on the next Settings → Advanced visit |

Review: inspect `src/agentMode/session/debugSink.ts` — `ensureFolder`, `ensurePrivateDirectory`, `narrowExistingFile`, and the `doAppend` catch — line by line, then run Verification steps 3–5, which are the adversarial variants.

## Verification

On Linux or macOS:

1. With **Settings → Advanced → Log Full Agent Mode Frames** on (the default), run one agent chat turn, then check the path shown in that settings section: `ls -ld` on the log directory and its two parents shows `drwx------`; `ls -l` on `acp-frames.ndjson` shows `-rw-------`.
2. Widen them (`chmod 777` the directory, `chmod 644` the file), reload the plugin, run one turn — both are narrowed back.
3. Delete the vault-hash directory and replace it with a symlink to another directory; run a turn — the link is gone, a real `0700` directory exists, and the link target received no `acp-frames.ndjson`.
4. Replace the vault-hash directory with a plain file; run a turn — same healed outcome.
5. On Linux with a second local account: that account can neither list the log directory nor read the log file.
6. The **Open** and **Clear** buttons in Settings → Advanced still work.


