### PR TITLE
Update the plugin description for V4 discovery

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "4.0.0",
   "minAppVersion": "1.11.4",
   "isDesktopOnly": false,
-  "description": "Your AI Copilot: Chat with Your Second Brain, Learn Faster, Work Smarter.",
+  "description": "Run Claude Code, Codex, and OpenCode as AI agents inside your vault for chat, semantic search, and LLM wiki workflows. Turn your second brain into a smart assistant that gets knowledge work done.",
   "author": "Logan Yang",
   "authorUrl": "https://twitter.com/logancyang",
   "fundingUrl": {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "4.0.0",
   "minAppVersion": "1.11.4",
   "isDesktopOnly": false,
-  "description": "Run Claude Code, Codex, and OpenCode as AI agents inside your vault for chat, semantic search, and LLM wiki workflows. Turn your second brain into a smart assistant that gets knowledge work done.",
+  "description": "Run AI agents such as Claude Code, Codex, and OpenCode inside your vault for chat, semantic search, and LLM wiki workflows. Turn your second brain into a smart assistant that gets knowledge work done.",
   "author": "Logan Yang",
   "authorUrl": "https://twitter.com/logancyang",
   "fundingUrl": {

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "version": "4.0.0",
   "minAppVersion": "1.11.4",
   "isDesktopOnly": false,
-  "description": "Run AI agents such as Claude Code, Codex, and OpenCode inside your vault for chat, semantic search, and LLM wiki workflows. Turn your second brain into a smart assistant that gets knowledge work done.",
+  "description": "Run AI agents such as Claude Code, Codex, and OpenCode inside your vault. Turn your second brain into a smart assistant that gets knowledge work done.",
   "author": "Logan Yang",
   "authorUrl": "https://twitter.com/logancyang",
   "fundingUrl": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-copilot",
   "version": "4.0.0",
-  "description": "Run Claude Code, Codex, and OpenCode as AI agents inside your vault for chat, semantic search, and LLM wiki workflows. Turn your second brain into a smart assistant that gets knowledge work done.",
+  "description": "Run AI agents such as Claude Code, Codex, and OpenCode inside your vault for chat, semantic search, and LLM wiki workflows. Turn your second brain into a smart assistant that gets knowledge work done.",
   "main": "main.js",
   "scripts": {
     "dev": "run-p dev:*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-copilot",
   "version": "4.0.0",
-  "description": "Your AI Copilot: Chat with Your Second Brain, Learn Faster, Work Smarter.",
+  "description": "Run Claude Code, Codex, and OpenCode as AI agents inside your vault for chat, semantic search, and LLM wiki workflows. Turn your second brain into a smart assistant that gets knowledge work done.",
   "main": "main.js",
   "scripts": {
     "dev": "run-p dev:*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "obsidian-copilot",
   "version": "4.0.0",
-  "description": "Run AI agents such as Claude Code, Codex, and OpenCode inside your vault for chat, semantic search, and LLM wiki workflows. Turn your second brain into a smart assistant that gets knowledge work done.",
+  "description": "Run AI agents such as Claude Code, Codex, and OpenCode inside your vault. Turn your second brain into a smart assistant that gets knowledge work done.",
   "main": "main.js",
   "scripts": {
     "dev": "run-p dev:*",


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#314

## Why

The Community Plugins listing still describes Copilot as “Your AI Copilot: Chat with Your Second Brain, Learn Faster, Work Smarter.” That copy predates V4 and does not tell people browsing the directory that Copilot runs AI agents such as Claude Code, Codex, and OpenCode. The replacement keeps the product promise broad instead of tying it to workflow labels that may narrow the perceived capability or fall out of fashion.

## What

> **Before:** The package metadata presents Copilot as a generic second-brain chat assistant.
>
> **After:** `Run AI agents such as Claude Code, Codex, and OpenCode inside your vault. Turn your second brain into a smart assistant that gets knowledge work done.`

The approved description is synchronized across `manifest.json` and `package.json`.

## Non goal

This does not change the README, runtime behavior, plugin version, release artifacts, or Store entry automatically. Publishing the Store description remains a manual post-merge step.

## Screenshot

Not applicable. This PR changes package metadata; the public Store listing updates only after the plugin owner publishes the same description.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | The diff changes copy-only package metadata and the Obsidian manifest validator accepts it |
| A defect would fail CI or be obvious on first use | ✅ | Package validation rejects invalid or mismatched manifest metadata, and the description is visible in the directory |
| A revert fully restores prior state, including persisted data | ✅ | Reverting the two metadata values restores the previous copy |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No runtime or credential path changes |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Plugin identifiers, versions, and schemas are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No executable code changes |
| No hot-path behavior lacks deterministic coverage | ✅ | No runtime path changes |
| No new dependency | ✅ | Dependency manifests and lockfiles are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The resulting copy is visible on the Copilot Store listing after publication |

Review: run Verification steps 1–5 and confirm the Store instructions match the claimed Copilot entry workflow.

## Verification

1. Read `manifest.json` and `package.json`; confirm both descriptions match the approved 150-character copy exactly.
2. Run `npm run review:obsidian`; confirm package metadata validation passes.
3. After merge, sign in to [Obsidian Community](https://community.obsidian.md), connect the repository owner’s GitHub account if needed, and open the claimed **Copilot** plugin in the developer dashboard.
4. Replace its description with the approved copy and select **Publish**.
5. Open [Copilot’s public Store page](https://community.obsidian.md/plugins/copilot) and confirm the new description appears.
