### PR TITLE
[Agent usage caps] - Step 1: Show Claude Code plan caps

### DIFF
--- a/docs/agent-mode-and-tools.md
+++ b/docs/agent-mode-and-tools.md
@@ -54,6 +54,7 @@ Click the **Agent** ribbon icon or run **Open Copilot Agent Chat Window** from t
 - Use **New Chat** to reset the current tab. Use **Recent Chats** on Agent Home, or **Chat History** during a conversation, to resume saved work.
 - Before the first message, you can switch an empty session to another installed agent without losing the draft. After chat history exists, that session stays with its agent.
 - Add the active note, selected text, other notes, the active Copilot web tab, or supported images. You can also mention a note with `[[Note title]]`.
+- Hover the small ring next to the send controls to see how full the conversation's context window is. When your account has usage limits the agent can report — such as a 5-hour or weekly cap on a subscription plan — the same panel shows how much of each limit is used and when it resets. If your setup has no such limits (for example, your own API key), no limit rows appear.
 
 Type `/` to insert an enabled skill or [custom command](custom-commands.md). For a small question without opening Agent chat, use [Quick Ask](custom-commands.md#quick-ask).
 

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.test.ts
@@ -1150,4 +1150,179 @@ describe("ClaudeSdkBackendProcess", () => {
       await expect(invoke("Read", { file_path: "note.md" })).resolves.toEqual({});
     });
   });
+
+  describe("plan usage", () => {
+    it("replays the last known caps to a newly attached session", async () => {
+      // The caps belong to the account, not the conversation. Without this, opening or
+      // switching to another chat showed no caps until that chat had taken its own turn,
+      // which reads as the meters having vanished.
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+
+      const planUsage = {
+        windows: [{ id: "seven_day", label: "Weekly", percent: 21 }],
+        updatedAt: 1,
+      };
+      // Stand in for a read that already happened on an earlier session.
+      (proc as unknown as { lastPlanUsage: unknown }).lastPlanUsage = planUsage;
+
+      const { sessionId } = await proc.newSession({ cwd: "/vault" });
+      const events: SessionEvent[] = [];
+      proc.registerSessionHandler(sessionId, (e) => events.push(e));
+
+      expect(events).toContainEqual({
+        sessionId,
+        update: { sessionUpdate: "plan_usage_update", planUsage },
+      });
+    });
+
+    it("sends no caps to a new session before any have been read", async () => {
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+
+      const { sessionId } = await proc.newSession({ cwd: "/vault" });
+      const events: SessionEvent[] = [];
+      proc.registerSessionHandler(sessionId, (e) => events.push(e));
+
+      expect(events.some((e) => e.update.sessionUpdate === "plan_usage_update")).toBe(false);
+    });
+
+    it("does not replay a window whose reset has already passed (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
+      // This process outlives many chats. Replaying a snapshot taken before a reset shows
+      // the previous period's percentage as if it described the current one.
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+
+      (proc as unknown as { lastPlanUsage: unknown }).lastPlanUsage = {
+        windows: [
+          { id: "five_hour", label: "5h", percent: 88, resetsAt: Date.now() - 1_000 },
+          { id: "seven_day", label: "Weekly", percent: 21, resetsAt: Date.now() + 60_000 },
+        ],
+        updatedAt: 1,
+      };
+
+      const { sessionId } = await proc.newSession({ cwd: "/vault" });
+      const events: SessionEvent[] = [];
+      proc.registerSessionHandler(sessionId, (e) => events.push(e));
+
+      const replayed = events.find((e) => e.update.sessionUpdate === "plan_usage_update");
+      expect(replayed?.update).toMatchObject({
+        planUsage: { windows: [{ id: "seven_day" }] },
+      });
+    });
+
+    it("publishes a reading to every live session, not only the one that took the turn", async () => {
+      // The caps describe the account, so they are equally true of every open chat.
+      // Routing them to one leaves the others showing a stale number until they each run
+      // a turn (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+
+      const first = await proc.newSession({ cwd: "/vault" });
+      const second = await proc.newSession({ cwd: "/vault" });
+      const firstEvents: SessionEvent[] = [];
+      const secondEvents: SessionEvent[] = [];
+      proc.registerSessionHandler(first.sessionId, (e) => firstEvents.push(e));
+      proc.registerSessionHandler(second.sessionId, (e) => secondEvents.push(e));
+
+      await (
+        proc as unknown as { refreshPlanUsage: (q: unknown) => Promise<void> }
+      ).refreshPlanUsage({
+        usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET: () =>
+          Promise.resolve({
+            rate_limits_available: true,
+            rate_limits: { seven_day: { utilization: 21 } },
+          }),
+      });
+
+      for (const events of [firstEvents, secondEvents]) {
+        expect(events.filter((e) => e.update.sessionUpdate === "plan_usage_update")).toHaveLength(
+          1
+        );
+      }
+    });
+
+    it("clears the meters when the account turns out not to be metered by plan caps (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
+      // Switching an external Claude login from OAuth to an API key mid-session leaves
+      // subscription caps on screen that no longer apply to anything.
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+      (proc as unknown as { lastPlanUsage: unknown }).lastPlanUsage = {
+        windows: [{ id: "seven_day", label: "Weekly", percent: 21 }],
+        updatedAt: 1,
+      };
+
+      const { sessionId } = await proc.newSession({ cwd: "/vault" });
+      const events: SessionEvent[] = [];
+      proc.registerSessionHandler(sessionId, (e) => events.push(e));
+
+      await (
+        proc as unknown as { refreshPlanUsage: (q: unknown) => Promise<void> }
+      ).refreshPlanUsage({
+        usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET: () =>
+          Promise.resolve({ rate_limits_available: false }),
+      });
+
+      expect(events.at(-1)?.update).toEqual({
+        sessionUpdate: "plan_usage_update",
+        planUsage: null,
+      });
+    });
+
+    it("keeps the last good reading when the usage call fails", async () => {
+      const proc = new ClaudeSdkBackendProcess({
+        pathToClaudeCodeExecutable: "/usr/local/bin/claude",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        app: { vault: {} } as any,
+        clientVersion: "1.2.3",
+        descriptor: fakeDescriptor(),
+      });
+      const planUsage = {
+        windows: [{ id: "seven_day", label: "Weekly", percent: 21 }],
+        updatedAt: 1,
+      };
+      (proc as unknown as { lastPlanUsage: unknown }).lastPlanUsage = planUsage;
+
+      const { sessionId } = await proc.newSession({ cwd: "/vault" });
+      const events: SessionEvent[] = [];
+      proc.registerSessionHandler(sessionId, (e) => events.push(e));
+      events.length = 0;
+
+      await (
+        proc as unknown as { refreshPlanUsage: (q: unknown) => Promise<void> }
+      ).refreshPlanUsage({
+        usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET: () =>
+          Promise.reject(new Error("transport closed")),
+      });
+
+      // A failed read is the absence of news, never a reason to blank a live meter.
+      expect(events).toHaveLength(0);
+      expect((proc as unknown as { lastPlanUsage: unknown }).lastPlanUsage).toBe(planUsage);
+    });
+  });
 });

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -25,7 +25,10 @@ import { App } from "obsidian";
 import { v4 as uuidv4 } from "uuid";
 import { translateBackendState } from "@/agentMode/session/translateBackendState";
 import { parseClaudeTranscript } from "./claudeSessionTranscript";
+import { readClaudePlanUsage } from "./claudePlanUsage";
+import { withoutExpiredWindows } from "@/agentMode/session/planUsage";
 import type {
+  PlanUsage,
   AgentChatMessage,
   BackendConfigOption,
   BackendDescriptor,
@@ -238,6 +241,15 @@ const STATIC_SDK_MODES: RawModeState = {
 export class ClaudeSdkBackendProcess implements BackendProcess {
   private readonly sessionHandlers = new Map<SessionId, SessionUpdateHandler>();
   private readonly pendingUpdates = new Map<SessionId, SessionEvent[]>();
+
+  /**
+   * Last plan-cap snapshot read from any session on this process.
+   *
+   * The caps belong to the account, not to a conversation, so one session's reading is
+   * true for every other. Held here and replayed on attach, a new or switched chat shows
+   * the caps immediately instead of blanking until its own first turn.
+   */
+  private lastPlanUsage: PlanUsage | null = null;
   private static readonly PENDING_UPDATE_LIMIT = 32;
   private readonly sessions = new Map<SessionId, SessionState>();
   private permissionPrompter: ((req: PermissionPrompt) => Promise<PermissionDecision>) | null =
@@ -310,6 +322,19 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
         } catch (e) {
           logWarn(`[AgentMode] replay of buffered SDK event threw for ${sessionId}`, e);
         }
+      }
+    }
+    // Expired windows are dropped rather than replayed: this process outlives many
+    // chats, and a snapshot taken before a reset describes a period that has ended.
+    this.lastPlanUsage = this.lastPlanUsage && withoutExpiredWindows(this.lastPlanUsage);
+    if (this.lastPlanUsage) {
+      try {
+        handler({
+          sessionId,
+          update: { sessionUpdate: "plan_usage_update", planUsage: this.lastPlanUsage },
+        });
+      } catch (e) {
+        logWarn(`[AgentMode] replay of plan usage threw for ${sessionId}`, e);
       }
     }
     return () => {
@@ -486,9 +511,21 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     let stopReason: StopReason = "end_turn";
     let resultErrorMessage: string | null = null;
     try {
+      let planUsageRequested = false;
       for await (const sdkMsg of stream) {
         if (this.shuttingDown) break;
         logSdkInbound(describeSdkMessage(sdkMsg), sdkMsg, params.sessionId);
+        // Ask for the plan caps on the very first message of the turn, whatever it is.
+        // The usage API is a control request on the query, so it only answers while the
+        // query is open — and the window is narrower than it looks. With partial
+        // streaming on, `assistant` lands about ten milliseconds before `result`, at
+        // which point the query is already closing and the read is rejected with "Query
+        // closed before response received". The first message (a `system` init) leaves
+        // more than a second of headroom.
+        if (!planUsageRequested) {
+          planUsageRequested = true;
+          void this.refreshPlanUsage(q);
+        }
         const events = translateSdkMessage(sdkMsg, params.sessionId, translatorState);
         for (const e of events) this.dispatchEvent(e);
         if (sdkMsg.type === "result") {
@@ -879,6 +916,32 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
       sessionId,
       update: { sessionUpdate: "state_changed", state },
     });
+  }
+
+  /**
+   * Ask the live query for the account's plan-cap utilization and publish what it says.
+   *
+   * A read that failed changes nothing — we learned nothing about the account, so the
+   * last good snapshot stands rather than blanking a meter the user is reading. A read
+   * that succeeded and reported no caps is different: it means this session is not
+   * metered by plan limits (an API-key, Bedrock, or Vertex login), so any caps on screen
+   * describe an account the user is no longer on and are cleared
+   * (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+   *
+   * The answer goes to every live session, not to the one that prompted the read: the
+   * caps belong to the account, so they are equally true of every open chat, and routing
+   * them to one would leave the others showing a stale number until they each ran a turn.
+   */
+  private async refreshPlanUsage(query: unknown): Promise<void> {
+    const reading = await readClaudePlanUsage(query);
+    if (this.shuttingDown || reading.kind === "unavailable") return;
+    this.lastPlanUsage = reading.kind === "usage" ? reading.planUsage : null;
+    for (const sessionId of this.sessionHandlers.keys()) {
+      this.dispatchEvent({
+        sessionId,
+        update: { sessionUpdate: "plan_usage_update", planUsage: this.lastPlanUsage },
+      });
+    }
   }
 
   private dispatchEvent(event: SessionEvent): void {

--- a/src/agentMode/sdk/claudePlanUsage.test.ts
+++ b/src/agentMode/sdk/claudePlanUsage.test.ts
@@ -1,0 +1,200 @@
+import {
+  isoToEpochMs,
+  planUsageFromClaudeUsage,
+  readClaudePlanUsage,
+} from "@/agentMode/sdk/claudePlanUsage";
+
+jest.mock("@/logger", () => ({ logInfo: jest.fn() }));
+
+const USAGE_METHOD = "usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET";
+
+/** A real response body from the SDK's usage API. */
+const LIVE_SNAPSHOT = {
+  rate_limits_available: true,
+  rate_limits: {
+    five_hour: { utilization: 10, resets_at: "2026-08-15T04:49:59Z" },
+    seven_day: { utilization: 21, resets_at: "2026-08-19T19:59:59Z" },
+  },
+};
+
+describe("claudePlanUsage", () => {
+  describe("planUsageFromClaudeUsage()", () => {
+    it("reads both windows as percentages, not fractions", () => {
+      // `utilization` is 0-100. The same numbers appear in the response's parallel
+      // `limits[]` array under a field named `percent`, which is what settles it.
+      const reading = planUsageFromClaudeUsage(LIVE_SNAPSHOT, 1_000);
+
+      expect(reading).toEqual({
+        kind: "usage",
+        planUsage: {
+          windows: [
+            { id: "five_hour", label: "5h", percent: 10, resetsAt: 1_786_769_399_000 },
+            { id: "seven_day", label: "Weekly", percent: 21, resetsAt: 1_787_169_599_000 },
+          ],
+          updatedAt: 1_000,
+        },
+      });
+    });
+
+    it("names each per-model window after the model it caps", () => {
+      const reading = planUsageFromClaudeUsage({
+        rate_limits_available: true,
+        rate_limits: {
+          model_scoped: [{ display_name: "Fable", utilization: 44, resets_at: null }],
+        },
+      });
+
+      expect(reading).toMatchObject({
+        kind: "usage",
+        planUsage: {
+          windows: [{ id: "model_scoped:Fable", label: "Weekly (Fable)", percent: 44 }],
+        },
+      });
+    });
+
+    it("reads the qualified weekly buckets the SDK documents (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", () => {
+      // A legacy plan's per-model weekly limit arrives as seven_day_opus /
+      // seven_day_sonnet, not as model_scoped, and OAuth-app usage has its own weekly
+      // bucket. For those accounts these are the caps they can actually hit.
+      const reading = planUsageFromClaudeUsage({
+        rate_limits_available: true,
+        rate_limits: {
+          seven_day_oauth_apps: { utilization: 5 },
+          seven_day_opus: { utilization: 61 },
+          seven_day_sonnet: { utilization: 17 },
+        },
+      });
+
+      expect(reading).toMatchObject({
+        kind: "usage",
+        planUsage: {
+          windows: [
+            { id: "seven_day_oauth_apps", label: "Weekly (OAuth apps)", percent: 5 },
+            { id: "seven_day_opus", label: "Weekly (Opus)", percent: 61 },
+            { id: "seven_day_sonnet", label: "Weekly (Sonnet)", percent: 17 },
+          ],
+        },
+      });
+    });
+
+    it("keeps a percentage above 100 for an account served past its cap", () => {
+      const reading = planUsageFromClaudeUsage({
+        rate_limits_available: true,
+        rate_limits: { seven_day: { utilization: 137 } },
+      });
+
+      expect(reading).toMatchObject({ planUsage: { windows: [{ percent: 137 }] } });
+    });
+
+    it("keeps a window whose reset timestamp is unusable", () => {
+      const reading = planUsageFromClaudeUsage({
+        rate_limits_available: true,
+        rate_limits: { five_hour: { utilization: 12, resets_at: "not a date" } },
+      });
+
+      expect(reading).toMatchObject({
+        planUsage: { windows: [{ percent: 12, resetsAt: undefined }] },
+      });
+    });
+
+    it("skips a window that reports a reset but no utilization", () => {
+      const reading = planUsageFromClaudeUsage({
+        rate_limits_available: true,
+        rate_limits: { five_hour: { resets_at: "2026-08-15T04:49:59Z" } },
+      });
+
+      expect(reading).toEqual({ kind: "unavailable" });
+    });
+
+    it("ignores codenamed buckets the SDK does not document", () => {
+      const reading = planUsageFromClaudeUsage({
+        rate_limits_available: true,
+        rate_limits: {
+          five_hour: { utilization: 10 },
+          // Buckets like this come and go between SDK releases; rendering one would put
+          // an unexplained row in front of the user.
+          some_codename: { utilization: 99 },
+        } as never,
+      });
+
+      expect(reading).toMatchObject({ planUsage: { windows: [{ id: "five_hour" }] } });
+    });
+
+    it("reports no caps only when the SDK says plan limits do not apply, so the caller clears what it was showing (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", () => {
+      // An API-key, Bedrock, or Vertex login is not metered by plan caps. That is a
+      // successful answer, not a failed read: keeping the previous subscription caps
+      // on screen would state a limit this account does not have.
+      expect(planUsageFromClaudeUsage({ rate_limits_available: false })).toEqual({ kind: "none" });
+    });
+
+    it.each([
+      ["no response at all", null],
+      ["a response carrying no rate limits", { rate_limits_available: true, rate_limits: null }],
+      ["a shape we do not recognize", { unexpected: true } as never],
+    ])("reports the read unusable for %s rather than clearing the meters", (_label, snapshot) => {
+      // Only an explicit "limits do not apply" clears. An answer we could not read is the
+      // absence of that statement, so the last good reading stands.
+      expect(planUsageFromClaudeUsage(snapshot)).toEqual({ kind: "unavailable" });
+    });
+  });
+
+  describe("readClaudePlanUsage()", () => {
+    it("returns the normalized windows from the live query", async () => {
+      const query = { [USAGE_METHOD]: jest.fn().mockResolvedValue(LIVE_SNAPSHOT) };
+
+      const reading = await readClaudePlanUsage(query);
+
+      expect(reading).toMatchObject({
+        kind: "usage",
+        planUsage: { windows: [{ label: "5h" }, { label: "Weekly" }] },
+      });
+    });
+
+    it("distinguishes a successful no-caps answer from a failed read", async () => {
+      const query = {
+        [USAGE_METHOD]: jest.fn().mockResolvedValue({ rate_limits_available: false }),
+      };
+
+      await expect(readClaudePlanUsage(query)).resolves.toEqual({ kind: "none" });
+    });
+
+    it.each([
+      ["the SDK no longer exposes the method", {}],
+      [
+        "the response is not the shape we validate",
+        { [USAGE_METHOD]: () => ({ unexpected: true }) },
+      ],
+    ])("reports the read unusable when %s", async (_label, query) => {
+      // The method name says the API may change or vanish in any release. When it does,
+      // the meter keeps showing its last good reading instead of the turn breaking.
+      await expect(readClaudePlanUsage(query)).resolves.toEqual({ kind: "unavailable" });
+    });
+
+    it("reports the read unusable when the usage call rejects", async () => {
+      const query = { [USAGE_METHOD]: jest.fn().mockRejectedValue(new Error("transport closed")) };
+
+      await expect(readClaudePlanUsage(query)).resolves.toEqual({ kind: "unavailable" });
+    });
+
+    it.each([
+      ["a null query", null],
+      ["an undefined query", undefined],
+    ])("reports the read unusable for %s", async (_label, query) => {
+      await expect(readClaudePlanUsage(query)).resolves.toEqual({ kind: "unavailable" });
+    });
+  });
+
+  describe("isoToEpochMs()", () => {
+    it("converts the ISO 8601 timestamps Claude sends", () => {
+      expect(isoToEpochMs("2026-08-15T04:49:59Z")).toBe(1_786_769_399_000);
+    });
+
+    it.each([
+      ["an unparseable string", "not a date"],
+      ["a non-string", 1_786_769_399_000],
+      ["null", null],
+    ])("returns undefined for %s, costing the countdown but never the meter", (_label, value) => {
+      expect(isoToEpochMs(value)).toBeUndefined();
+    });
+  });
+});

--- a/src/agentMode/sdk/claudePlanUsage.ts
+++ b/src/agentMode/sdk/claudePlanUsage.ts
@@ -1,0 +1,164 @@
+import type { PlanUsageReading, UsageWindow } from "@/agentMode/session/planUsage";
+import { planUsageReading, toUsagePercent } from "@/agentMode/session/planUsage";
+import { logInfo } from "@/logger";
+
+/**
+ * The SDK method that reports plan-cap utilization. Its name says what it is: the API is
+ * experimental and the SDK asks callers not to depend on it. We do, because it is the
+ * only source of these numbers — the streamed `rate_limit_event` carries a reset time and
+ * a status but no utilization at all — and a cap meter needs a percentage.
+ *
+ * That dependency is why every call goes through this module: one place that reaches for
+ * the method, one place that stops caring the moment it disappears.
+ */
+const USAGE_METHOD = "usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET" as const;
+
+/** The slice of the SDK `Query` this module needs. */
+type UsageCapableQuery = {
+  [USAGE_METHOD]?: () => Promise<unknown>;
+};
+
+/** One window of the Claude Agent SDK's usage response. */
+interface ClaudeWindow {
+  utilization?: number | null;
+  resets_at?: string | null;
+}
+
+interface ClaudeModelScopedWindow extends ClaudeWindow {
+  display_name?: string | null;
+}
+
+/**
+ * The part of the SDK's usage response we read. Declared structurally rather than
+ * imported: the SDK marks this API experimental, so the plugin states the shape it
+ * depends on and validates against it instead of binding to a type that may move.
+ */
+export interface ClaudeUsageSnapshot {
+  rate_limits_available?: boolean;
+  rate_limits?: {
+    five_hour?: ClaudeWindow | null;
+    seven_day?: ClaudeWindow | null;
+    seven_day_oauth_apps?: ClaudeWindow | null;
+    seven_day_opus?: ClaudeWindow | null;
+    seven_day_sonnet?: ClaudeWindow | null;
+    model_scoped?: ClaudeModelScopedWindow[] | null;
+  } | null;
+}
+
+/**
+ * The account-level windows the SDK documents, in the order they should be shown. The
+ * three qualified weekly buckets are real caps an account can hit — a legacy plan's
+ * per-model weekly limit arrives as `seven_day_opus`/`seven_day_sonnet`, not as
+ * `model_scoped` — so omitting them would leave exactly those users unwarned
+ * (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+ */
+const CLAUDE_WINDOWS = [
+  ["five_hour", "5h"],
+  ["seven_day", "Weekly"],
+  ["seven_day_oauth_apps", "Weekly (OAuth apps)"],
+  ["seven_day_opus", "Weekly (Opus)"],
+  ["seven_day_sonnet", "Weekly (Sonnet)"],
+] as const;
+
+/**
+ * Epoch milliseconds from an ISO 8601 timestamp, or undefined when unparseable — a bad
+ * timestamp costs the reset countdown, never the meter. Claude sends ISO 8601 where other
+ * providers send epoch seconds, so each adapter converts its own encoding.
+ */
+export function isoToEpochMs(value: unknown): number | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function claudeWindow(
+  id: string,
+  label: string,
+  raw: ClaudeWindow | null | undefined
+): UsageWindow | null {
+  if (!raw) return null;
+  const percent = toUsagePercent(raw.utilization);
+  if (percent === null) return null;
+  return { id, label, percent, resetsAt: isoToEpochMs(raw.resets_at) };
+}
+
+/**
+ * Normalize Claude Code's usage response.
+ *
+ * `utilization` is a percentage, 0–100 — not a fraction. The same numbers appear in the
+ * response's parallel `limits[]` array under a field named `percent`, which is what
+ * settles it.
+ *
+ * Reports no caps when plan limits do not apply to the session at all: an API-key,
+ * Bedrock, or Vertex run answers `rate_limits_available: false`. That is a successful
+ * answer, not a failed read, and the caller must clear any caps it was showing rather
+ * than keep them (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+ *
+ * Only the windows the SDK documents are read. The live response also carries codenamed
+ * buckets that come and go between releases; rendering those would put unexplained rows
+ * in front of users.
+ */
+export function planUsageFromClaudeUsage(
+  snapshot: ClaudeUsageSnapshot | null | undefined,
+  now: number = Date.now()
+): PlanUsageReading {
+  // The one statement that justifies clearing meters: this login is not metered by plan
+  // caps at all. Every other empty answer is a read we could not use, which changes
+  // nothing (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+  if (snapshot?.rate_limits_available === false) return { kind: "none" };
+  const limits = snapshot?.rate_limits;
+  if (!limits) return { kind: "unavailable" };
+
+  const windows: UsageWindow[] = [];
+  for (const [id, label] of CLAUDE_WINDOWS) {
+    const window = claudeWindow(id, label, limits[id]);
+    if (window) windows.push(window);
+  }
+
+  for (const scoped of limits.model_scoped ?? []) {
+    const name = typeof scoped?.display_name === "string" ? scoped.display_name.trim() : "";
+    if (!name) continue;
+    const scopedWindow = claudeWindow(`model_scoped:${name}`, `Weekly (${name})`, scoped);
+    if (scopedWindow) windows.push(scopedWindow);
+  }
+
+  return planUsageReading(windows, now);
+}
+
+/**
+ * Read the account's plan-cap utilization from a live SDK query.
+ *
+ * Reports `unavailable` for every way the read itself can fail, because none of them tell
+ * us anything about the account:
+ *
+ *   - the SDK renamed or dropped the method (it warned us it might);
+ *   - the call threw or the transport died mid-turn;
+ *   - the response is not the shape we validate.
+ *
+ * Reports `none` only when the SDK answers that plan limits do not apply. The caller
+ * treats those two very differently, which is the whole reason they are separate.
+ *
+ * It never throws, so a usage read can't fail a turn that was otherwise fine.
+ */
+export async function readClaudePlanUsage(query: unknown): Promise<PlanUsageReading> {
+  const usageMethod = (query as UsageCapableQuery | null | undefined)?.[USAGE_METHOD];
+  if (typeof usageMethod !== "function") {
+    // Expected the day the SDK stabilizes or removes it; not an error condition.
+    logInfo("[AgentMode] Claude SDK exposes no usage API; plan caps unavailable");
+    return { kind: "unavailable" };
+  }
+
+  try {
+    const snapshot = await usageMethod.call(query);
+    const reading = planUsageFromClaudeUsage(snapshot as ClaudeUsageSnapshot);
+    logInfo(
+      reading.kind === "usage"
+        ? `[AgentMode] read ${reading.planUsage.windows.length} plan cap window(s)`
+        : `[AgentMode] usage read reported ${reading.kind === "none" ? "no plan caps" : "nothing usable"}`
+    );
+    return reading;
+  } catch (error) {
+    logInfo("[AgentMode] Claude SDK usage read failed; plan caps unavailable", error);
+    return { kind: "unavailable" };
+  }
+}

--- a/src/agentMode/session/AgentChatBackend.ts
+++ b/src/agentMode/session/AgentChatBackend.ts
@@ -10,6 +10,7 @@ import type {
   PermissionPrompt,
   PlanDecisionAction,
   PromptContent,
+  PlanUsage,
   SessionUsage,
 } from "./types";
 
@@ -102,6 +103,13 @@ export interface AgentChatBackend {
    * persisted usage). The UI renders this as a context-window indicator.
    */
   getSessionUsage(): SessionUsage | null;
+
+  /**
+   * Latest account-level plan-cap snapshot, or `null` when this backend reports none —
+   * either because it has no usage API, or because plan caps do not apply to how the
+   * user authenticated (an API key rather than a subscription).
+   */
+  getPlanUsage(): PlanUsage | null;
 
   /**
    * True when an ExitPlanMode permission is currently pending. The chat input

--- a/src/agentMode/session/AgentChatUIState.ts
+++ b/src/agentMode/session/AgentChatUIState.ts
@@ -12,6 +12,7 @@ import type {
   PermissionPrompt,
   PlanDecisionAction,
   PromptContent,
+  PlanUsage,
   SessionUsage,
 } from "@/agentMode/session/types";
 import type { MessageContext } from "@/types/message";
@@ -161,6 +162,10 @@ export class AgentChatUIState implements AgentChatBackend {
 
   getSessionUsage(): SessionUsage | null {
     return this.session.getSessionUsage();
+  }
+
+  getPlanUsage(): PlanUsage | null {
+    return this.session.getPlanUsage();
   }
 
   async resolvePlanProposal(

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -28,6 +28,7 @@ import {
   PromptOutput,
   SessionEvent,
   SessionId,
+  PlanUsage,
   SessionUsage,
   StopReason,
   ToolCallContent,
@@ -458,6 +459,13 @@ export class AgentSession {
   // `usage_update` (or a persisted snapshot seeded on resume). Session-scoped:
   // not tied to any turn placeholder.
   private currentUsage: SessionUsage | null = null;
+
+  /**
+   * Latest account-level plan-cap snapshot. Unlike {@link currentUsage} this is not a
+   * property of the session — the caps keep counting elsewhere — so it is live-only and
+   * never persisted: a stale percentage read off disk would be worse than none.
+   */
+  private currentPlanUsage: PlanUsage | null = null;
   // Monotonic counter for `currentPlan.id` so the React tree can detect a
   // *new* plan-mode review (vs. an in-place revision that bumps `revision`).
   private planSeq = 0;
@@ -1459,6 +1467,11 @@ export class AgentSession {
     return this.currentUsage;
   }
 
+  /** Latest plan-cap snapshot, or `null` when the backend has reported none. */
+  getPlanUsage(): PlanUsage | null {
+    return this.currentPlanUsage;
+  }
+
   /**
    * Seed the usage snapshot from persisted frontmatter on resume, so a reopened
    * chat shows its last-known usage immediately instead of blank-until-next-turn.
@@ -1767,6 +1780,11 @@ export class AgentSession {
     }
     if (update.sessionUpdate === "usage_update") {
       this.applyUsageUpdate(update.usage);
+      return;
+    }
+    if (update.sessionUpdate === "plan_usage_update") {
+      this.currentPlanUsage = update.planUsage;
+      this.notifyMessages();
       return;
     }
 

--- a/src/agentMode/session/planUsage.test.ts
+++ b/src/agentMode/session/planUsage.test.ts
@@ -1,0 +1,79 @@
+import {
+  planUsageReading,
+  toUsagePercent,
+  withoutExpiredWindows,
+  type UsageWindow,
+} from "@/agentMode/session/planUsage";
+
+const WEEKLY: UsageWindow = { id: "weekly", label: "Weekly", percent: 21, resetsAt: 2_000 };
+const FIVE_HOUR: UsageWindow = { id: "five_hour", label: "5h", percent: 10, resetsAt: 1_500 };
+
+describe("planUsage", () => {
+  describe("toUsagePercent()", () => {
+    it("passes a percentage above 100 through unclamped", () => {
+      // An account still being served past its cap is genuinely over. Clamping would make
+      // "just hit the cap" and "far past it" look identical.
+      expect(toUsagePercent(137)).toBe(137);
+    });
+
+    it("floors a negative percentage at zero", () => {
+      expect(toUsagePercent(-5)).toBe(0);
+    });
+
+    it.each([
+      ["a non-number", "21"],
+      ["NaN", Number.NaN],
+      ["infinity", Number.POSITIVE_INFINITY],
+      ["null", null],
+    ])("returns null for %s", (_label, value) => {
+      expect(toUsagePercent(value)).toBeNull();
+    });
+  });
+
+  describe("planUsageReading()", () => {
+    it("reports usage when at least one window was normalized", () => {
+      expect(planUsageReading([WEEKLY], 1_000)).toEqual({
+        kind: "usage",
+        planUsage: { windows: [WEEKLY], updatedAt: 1_000 },
+      });
+    });
+
+    it("reports an empty window list unusable rather than clearing the meters (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", () => {
+      // Never 0% used, and never "this account has no caps" either. Only a provider
+      // explicitly saying limits do not apply justifies clearing; a payload we could not
+      // read is the absence of that statement, so the last good reading stands.
+      expect(planUsageReading([])).toEqual({ kind: "unavailable" });
+    });
+  });
+
+  describe("withoutExpiredWindows()", () => {
+    it("drops a window whose reset has passed (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", () => {
+      // A backend process outlives many chats. Replaying a snapshot taken before a reset
+      // would show the previous period's percentage as if it were the current one.
+      const planUsage = { windows: [FIVE_HOUR, WEEKLY], updatedAt: 1_000 };
+
+      expect(withoutExpiredWindows(planUsage, 1_800)).toEqual({
+        windows: [WEEKLY],
+        updatedAt: 1_000,
+      });
+    });
+
+    it("returns null once every window has reset", () => {
+      const planUsage = { windows: [FIVE_HOUR, WEEKLY], updatedAt: 1_000 };
+
+      expect(withoutExpiredWindows(planUsage, 9_000)).toBeNull();
+    });
+
+    it("keeps a window with no reset time, which carries no claim we can falsify", () => {
+      const planUsage = { windows: [{ id: "weekly", label: "Weekly", percent: 21 }], updatedAt: 1 };
+
+      expect(withoutExpiredWindows(planUsage, 9_000)).toBe(planUsage);
+    });
+
+    it("returns the same object when nothing expired, so React skips the re-render", () => {
+      const planUsage = { windows: [WEEKLY], updatedAt: 1_000 };
+
+      expect(withoutExpiredWindows(planUsage, 1_000)).toBe(planUsage);
+    });
+  });
+});

--- a/src/agentMode/session/planUsage.ts
+++ b/src/agentMode/session/planUsage.ts
@@ -1,0 +1,87 @@
+/**
+ * Plan usage — how much of a provider's rolling usage caps the account has spent.
+ *
+ * Distinct from {@link SessionUsage}, which measures the current session's context
+ * occupancy. Caps are per-ACCOUNT and outlive any session: they keep counting across
+ * sessions, vaults, and devices, and they are what actually stops a user working.
+ *
+ * Providers report them in their own shapes, so each backend normalizes its own source
+ * into this type and publishes it as a `plan_usage_update`. This module owns the shape
+ * every backend agrees on; it knows nothing about any particular provider.
+ */
+
+/** One capped window (5-hour, weekly, per-model weekly, ...). */
+export interface UsageWindow {
+  /** Stable identity, for React keys and for replacing a window on refresh. */
+  id: string;
+  /** Short label for the meter row: `5h`, `Weekly`, `Weekly (Fable)`. */
+  label: string;
+  /**
+   * Percent of the window consumed, 0–100 and beyond. Values above 100 are real and are
+   * not clamped: an account still being served past its cap is genuinely over, and
+   * clamping would make "just hit the cap" and "far past it" look identical.
+   */
+  percent: number;
+  /** Epoch milliseconds when the window resets, when the source reports one. */
+  resetsAt?: number;
+}
+
+export interface PlanUsage {
+  windows: UsageWindow[];
+  /** Epoch milliseconds when this snapshot was taken. */
+  updatedAt: number;
+}
+
+/**
+ * What a backend learned when it went looking for the account's caps.
+ *
+ * The three cases exist because "no meters on screen" has two very different causes and
+ * only one of them should discard what we already knew. A read that failed tells us
+ * nothing, so the previous snapshot stands; a read that succeeded and reported no caps is
+ * new information, and leaving the old meters up would state a limit the account no
+ * longer has (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+ */
+export type PlanUsageReading =
+  | { kind: "usage"; planUsage: PlanUsage }
+  | { kind: "none" }
+  | { kind: "unavailable" };
+
+/** Percent, coerced to a finite non-negative number, or null when unusable. */
+export function toUsagePercent(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return Math.max(0, value);
+}
+
+/**
+ * Build a reading from the windows a backend managed to normalize.
+ *
+ * No windows means `unavailable`, never `none`. Only a provider explicitly saying "plan
+ * limits do not apply to this account" justifies clearing meters, and a response we could
+ * not read is not that statement — it is the absence of one. Erring the other way would
+ * let one malformed payload wipe a meter the user was reading.
+ */
+export function planUsageReading(
+  windows: UsageWindow[],
+  now: number = Date.now()
+): PlanUsageReading {
+  if (windows.length === 0) return { kind: "unavailable" };
+  return { kind: "usage", planUsage: { windows, updatedAt: now } };
+}
+
+/**
+ * Drop windows whose reset has already passed, or null when that leaves nothing.
+ *
+ * A backend process outlives many chats, so a snapshot cached at open can be replayed
+ * days later. Once a window has rolled over its percentage describes a period that has
+ * ended, and showing it would understate or overstate what the user has left in the
+ * window they are actually in (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+ * Windows with no reset time are kept: they carry no claim we can falsify.
+ */
+export function withoutExpiredWindows(
+  planUsage: PlanUsage,
+  now: number = Date.now()
+): PlanUsage | null {
+  const windows = planUsage.windows.filter((w) => w.resetsAt === undefined || w.resetsAt > now);
+  if (windows.length === 0) return null;
+  return windows.length === planUsage.windows.length ? planUsage : { ...planUsage, windows };
+}

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -3,6 +3,9 @@ import type { ModelCapability } from "@/constants";
 import type { FormattedDateTime, MessageContext } from "@/types/message";
 // `import type` keeps the cycle with `fanoutTypes` compile-time only.
 import type { FanoutTurn } from "@/agentMode/session/fanout/fanoutTypes";
+import type { PlanUsage } from "@/agentMode/session/planUsage";
+
+export type { PlanUsage, UsageWindow } from "@/agentMode/session/planUsage";
 import type { ProjectScopeId } from "./scope";
 
 export type {
@@ -521,7 +524,9 @@ export type SessionUpdate =
   | { sessionUpdate: "current_mode_update"; currentModeId: string }
   | { sessionUpdate: "config_option_update"; configOptions: BackendConfigOption[] }
   | { sessionUpdate: "state_changed"; state: BackendState }
-  | { sessionUpdate: "usage_update"; usage: SessionUsage };
+  | { sessionUpdate: "usage_update"; usage: SessionUsage }
+  // `null` clears the meters: the backend asked and was told this account has no caps.
+  | { sessionUpdate: "plan_usage_update"; planUsage: PlanUsage | null };
 
 /**
  * Backend-agnostic token-usage snapshot for a session. Every coding-agent

--- a/src/agentMode/ui/AgentContextMeter.stories.tsx
+++ b/src/agentMode/ui/AgentContextMeter.stories.tsx
@@ -1,0 +1,126 @@
+import { UsageMeter, type UsageMeterProps } from "@/agentMode/ui/AgentContextMeter";
+import type { Meta, StoryObj } from "@/lib/story";
+
+/**
+ * The meter has two independent inputs — context occupancy and account plan caps — and a
+ * backend can report either, both, or neither. These stories pin the combinations that
+ * look materially different, because the tooltip's contents change shape between them and
+ * only the rendered result shows whether the layout still reads.
+ */
+const meta = {
+  title: "Agent Mode/UsageMeter",
+  component: UsageMeter,
+} satisfies Meta<UsageMeterProps>;
+export default meta;
+
+const HOUR = 60 * 60 * 1000;
+
+/**
+ * The rendering instant, because the component compares every `resetsAt` against the
+ * real clock. A fixed historical instant would decay: once it passed, every countdown
+ * would render as already-reset and the stories could no longer audit the reset text.
+ * The offsets are whole hours, so the coarse `resets in 3h` output is stable anyway.
+ */
+const NOW = Date.now();
+
+const CONTEXT: UsageMeterProps["usage"] = {
+  usedTokens: 48_000,
+  contextWindow: 200_000,
+  updatedAt: NOW,
+};
+
+/** Both windows, mid-usage: the everyday Claude Code and Copilot Plus state. */
+export const ContextAndCaps: StoryObj<UsageMeterProps> = {
+  args: {
+    usage: CONTEXT,
+    contextWindow: 200_000,
+    planUsage: {
+      windows: [
+        { id: "five_hour", label: "5h", percent: 12, resetsAt: NOW + 3 * HOUR },
+        { id: "seven_day", label: "Weekly", percent: 21, resetsAt: NOW + 52 * HOUR },
+      ],
+      updatedAt: NOW,
+    },
+  },
+};
+
+/** Context only — a key-authenticated login, which is not metered by plan caps. */
+export const ContextOnly: StoryObj<UsageMeterProps> = {
+  args: { usage: CONTEXT, contextWindow: 200_000, planUsage: null },
+};
+
+/**
+ * Caps with no context window. Codex on a Pro plan reports a single weekly cap, and some
+ * models never advertise a window, so the context row degrades to a bare count while the
+ * cap rows still render.
+ */
+export const CapsWithoutContextWindow: StoryObj<UsageMeterProps> = {
+  args: {
+    usage: { usedTokens: 12_400, updatedAt: NOW },
+    contextWindow: null,
+    planUsage: {
+      windows: [{ id: "primary", label: "Weekly", percent: 15, resetsAt: NOW + 80 * HOUR }],
+      updatedAt: NOW,
+    },
+  },
+};
+
+/** Past the warning threshold, where the ring changes colour. */
+export const ContextNearlyFull: StoryObj<UsageMeterProps> = {
+  args: {
+    usage: { usedTokens: 186_000, contextWindow: 200_000, updatedAt: NOW },
+    contextWindow: 200_000,
+    planUsage: {
+      windows: [{ id: "seven_day", label: "Weekly", percent: 91, resetsAt: NOW + 4 * HOUR }],
+      updatedAt: NOW,
+    },
+  },
+};
+
+/**
+ * Over the cap. An account served past its limit on purchased credit reports above 100%,
+ * and the number is deliberately not clamped — "just hit it" and "far past it" must not
+ * look the same.
+ */
+export const OverCap: StoryObj<UsageMeterProps> = {
+  args: {
+    usage: CONTEXT,
+    contextWindow: 200_000,
+    planUsage: {
+      windows: [{ id: "seven_day", label: "Weekly", percent: 143, resetsAt: NOW + 9 * HOUR }],
+      updatedAt: NOW,
+    },
+  },
+};
+
+/** A window whose source gave no reset time: the row keeps its percentage, drops the countdown. */
+export const CapWithoutReset: StoryObj<UsageMeterProps> = {
+  args: {
+    usage: CONTEXT,
+    contextWindow: 200_000,
+    planUsage: {
+      windows: [{ id: "seven_day", label: "Weekly", percent: 21 }],
+      updatedAt: NOW,
+    },
+  },
+};
+
+/** Per-model caps, which arrive alongside the account-wide ones and name their model. */
+export const ModelScopedCaps: StoryObj<UsageMeterProps> = {
+  args: {
+    usage: CONTEXT,
+    contextWindow: 200_000,
+    planUsage: {
+      windows: [
+        { id: "seven_day", label: "Weekly", percent: 21, resetsAt: NOW + 52 * HOUR },
+        {
+          id: "model_scoped:Fable",
+          label: "Weekly (Fable)",
+          percent: 64,
+          resetsAt: NOW + 52 * HOUR,
+        },
+      ],
+      updatedAt: NOW,
+    },
+  },
+};

--- a/src/agentMode/ui/AgentContextMeter.test.tsx
+++ b/src/agentMode/ui/AgentContextMeter.test.tsx
@@ -1,5 +1,5 @@
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
-import type { SessionUsage } from "@/agentMode/session/types";
+import type { PlanUsage, SessionUsage } from "@/agentMode/session/types";
 import AgentContextMeter from "@/agentMode/ui/AgentContextMeter";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { fireEvent, render, screen } from "@testing-library/react";
@@ -11,9 +11,14 @@ beforeAll(() => {
 });
 
 /** Minimal backend stub exposing just the getters/subscribe the meter reads. */
-function makeBackend(usage: SessionUsage | null): AgentChatBackend {
+function makeBackend(
+  usage: SessionUsage | null,
+  planUsage: PlanUsage | null = null
+): AgentChatBackend {
   return {
     getSessionUsage: () => usage,
+    getPlanUsage: () => planUsage,
+    getBackendState: () => null,
     subscribe: () => () => {},
   } as unknown as AgentChatBackend;
 }
@@ -42,7 +47,7 @@ describe("AgentContextMeter", () => {
     renderMeter(makeBackend(usage));
 
     // The trigger is an icon-sized button with just the ring (no inline % text).
-    const trigger = screen.getByLabelText("Context usage");
+    const trigger = screen.getByLabelText("Usage");
     expect(trigger.textContent).not.toContain("25%");
 
     // The tooltip opens on hover/focus, not click.
@@ -66,7 +71,7 @@ describe("AgentContextMeter", () => {
     };
     renderMeter(makeBackend(usage));
 
-    const trigger = screen.getByLabelText("Context usage");
+    const trigger = screen.getByLabelText("Usage");
     // The warning accent lives on the trigger itself.
     expect(trigger.className).toContain("tw-text-warning");
     expect(trigger.className).not.toContain("tw-text-accent");
@@ -84,7 +89,7 @@ describe("AgentContextMeter", () => {
     };
     renderMeter(makeBackend(usage));
 
-    const trigger = screen.getByLabelText("Context usage");
+    const trigger = screen.getByLabelText("Usage");
     expect(trigger.className).toContain("tw-text-accent");
     expect(trigger.className).not.toContain("tw-text-warning");
   });
@@ -114,5 +119,91 @@ describe("AgentContextMeter", () => {
     const { container } = render(<AgentContextMeter backend={makeBackend(usage)} />);
     expect(container.childElementCount).toBe(0);
     expect(screen.queryByLabelText("Context usage")).toBeNull();
+  });
+
+  it("shows each plan cap window, its percentage and its reset, under the context bar", () => {
+    const usage: SessionUsage = { usedTokens: 50_000, contextWindow: 200_000, updatedAt: 1 };
+    const planUsage: PlanUsage = {
+      windows: [
+        { id: "five_hour", label: "5h", percent: 10, resetsAt: Date.now() + 2 * 3_600_000 },
+        { id: "seven_day", label: "Weekly", percent: 21, resetsAt: Date.now() + 3 * 86_400_000 },
+      ],
+      updatedAt: 1,
+    };
+    renderMeter(makeBackend(usage, planUsage));
+
+    fireEvent.focus(screen.getByLabelText("Usage"));
+
+    expect(screen.getAllByText("10%").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("21%").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/resets in 2h/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/resets in 3d/).length).toBeGreaterThan(0);
+  });
+
+  it("drops a cap window whose reset has passed by render time (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", () => {
+    // A chat left open across a reset gets no new event to correct its snapshot, so the
+    // finished period's percentage must be filtered where it is rendered.
+    const usage: SessionUsage = { usedTokens: 50_000, contextWindow: 200_000, updatedAt: 1 };
+    const planUsage: PlanUsage = {
+      windows: [
+        { id: "five_hour", label: "5h", percent: 95, resetsAt: Date.now() - 1 },
+        { id: "seven_day", label: "Weekly", percent: 21, resetsAt: Date.now() + 3 * 86_400_000 },
+      ],
+      updatedAt: 1,
+    };
+    renderMeter(makeBackend(usage, planUsage));
+
+    fireEvent.focus(screen.getByLabelText("Usage"));
+
+    expect(screen.queryByText("95%")).toBeNull();
+    expect(screen.getAllByText("21%").length).toBeGreaterThan(0);
+  });
+
+  it("shows the real figure when an account is past its cap", () => {
+    const usage: SessionUsage = { usedTokens: 1_000, contextWindow: 200_000, updatedAt: 1 };
+    const planUsage: PlanUsage = {
+      windows: [{ id: "seven_day", label: "Weekly", percent: 137 }],
+      updatedAt: 1,
+    };
+    renderMeter(makeBackend(usage, planUsage));
+
+    fireEvent.focus(screen.getByLabelText("Usage"));
+
+    // Not clamped to 100: "just hit the cap" and "far past it" must not look alike.
+    expect(screen.getAllByText("137%").length).toBeGreaterThan(0);
+  });
+
+  it("renders no cap rows when the backend reports no plan usage", () => {
+    const usage: SessionUsage = { usedTokens: 50_000, contextWindow: 200_000, updatedAt: 1 };
+    renderMeter(makeBackend(usage, null));
+
+    fireEvent.focus(screen.getByLabelText("Usage"));
+
+    // A backend with no usage API, or an account not metered by plan caps, shows
+    // nothing rather than a fabricated 0%.
+    expect(screen.queryAllByText(/resets in/)).toHaveLength(0);
+    expect(screen.queryAllByText("0%")).toHaveLength(0);
+  });
+
+  it("shows plan caps even when the backend reports no context window", () => {
+    // Copilot Plus models arrive without a window. The meter used to fall straight
+    // through to the count-only chip here, computing the caps and then dropping them,
+    // so a user on those models saw a bare token count and no caps at all.
+    const usage: SessionUsage = { usedTokens: 27_514, updatedAt: 1 };
+    const planUsage: PlanUsage = {
+      windows: [
+        { id: "five_hour", label: "5h", percent: 8, resetsAt: Date.now() + 3_600_000 },
+        { id: "weekly", label: "Weekly", percent: 25, resetsAt: Date.now() + 86_400_000 },
+      ],
+      updatedAt: 1,
+    };
+    renderMeter(makeBackend(usage, planUsage));
+
+    fireEvent.focus(screen.getByLabelText("Usage"));
+
+    expect(screen.getAllByText("8%").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("25%").length).toBeGreaterThan(0);
+    // The context row still reports the count it does know, without a bogus percentage.
+    expect(screen.getAllByText("27.5k").length).toBeGreaterThan(0);
   });
 });

--- a/src/agentMode/ui/AgentContextMeter.tsx
+++ b/src/agentMode/ui/AgentContextMeter.tsx
@@ -1,5 +1,7 @@
 import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
-import type { SessionUsage } from "@/agentMode/session/types";
+import { withoutExpiredWindows } from "@/agentMode/session/planUsage";
+import type { PlanUsage, SessionUsage } from "@/agentMode/session/types";
+import { usePlanUsage } from "@/agentMode/ui/hooks/usePlanUsage";
 import { useSessionUsage } from "@/agentMode/ui/hooks/useSessionUsage";
 import { TokenCounter } from "@/components/chat-components/TokenCounter";
 import { Button } from "@/components/ui/button";
@@ -60,14 +62,95 @@ function ContextRing({ fraction }: { fraction: number }) {
   );
 }
 
-/** Full % ring trigger + a horizontal context-window bar in a hover tooltip. */
-function RingMeter({ usage, contextWindow }: { usage: SessionUsage; contextWindow: number }) {
+/**
+ * `resets in 2h 14m` — coarse on purpose. These windows run for hours or days, so
+ * ticking seconds would be noise, and this does not re-render on a timer. Returns null
+ * once the reset is in the past rather than counting up.
+ */
+function formatResetsIn(resetsAt: number | undefined, now: number): string | null {
+  if (resetsAt === undefined) return null;
+  const ms = resetsAt - now;
+  if (ms <= 0) return null;
+  const minutes = Math.round(ms / 60_000);
+  if (minutes < 60) return `resets in ${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    const rest = minutes % 60;
+    return rest === 0 ? `resets in ${hours}h` : `resets in ${hours}h ${rest}m`;
+  }
+  const days = Math.floor(hours / 24);
+  const restHours = hours % 24;
+  return restHours === 0 ? `resets in ${days}d` : `resets in ${days}d ${restHours}h`;
+}
+
+/**
+ * The account's plan caps, one row per window. They sit under the context bar because
+ * they answer a different question: the context bar is about this conversation, these
+ * are about how much of the plan is left before work stops entirely.
+ */
+function PlanUsageRows({ planUsage }: { planUsage: PlanUsage }) {
+  const now = Date.now();
+  // Filtered at render, not only when a snapshot arrives or replays: a chat left open
+  // across a reset gets no new event to correct it, and this component mounts fresh
+  // each time the tooltip opens, so rendering is the last moment the claim is made and
+  // the right place to check it
+  // (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+  const current = withoutExpiredWindows(planUsage, now);
+  if (!current) return null;
+  return (
+    <div className="tw-flex tw-flex-col tw-gap-2">
+      {current.windows.map((window) => {
+        const resetsIn = formatResetsIn(window.resetsAt, now);
+        const percent = Math.round(window.percent);
+        const isWarning = window.percent >= WARNING_THRESHOLD * 100;
+        return (
+          <div key={window.id} className="tw-flex tw-flex-col tw-gap-1">
+            <div className="tw-flex tw-items-center tw-justify-between tw-gap-3 tw-text-ui-smaller">
+              <span className="tw-whitespace-nowrap tw-text-muted">
+                {window.label}
+                {resetsIn && <span className="tw-text-faint"> · {resetsIn}</span>}
+              </span>
+              <span
+                className={cn(
+                  "tw-whitespace-nowrap tw-tabular-nums",
+                  isWarning && "tw-text-warning"
+                )}
+              >
+                {percent}%
+              </span>
+            </div>
+            {/* Clamped for the bar only — a bar cannot render past full, while the
+                number above it still shows the real figure for an account being
+                served past its cap. */}
+            <Progress value={Math.min(100, percent)} className="tw-h-1.5" />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * The meter itself: a trigger in the control row, and a hover tooltip holding a context
+ * row plus any plan-cap rows.
+ *
+ * `contextWindow` is optional because not every backend reports one. When it is absent
+ * the context row falls back to a bare token count, and the plan caps still render —
+ * they are account-level and do not depend on knowing the window.
+ */
+export interface UsageMeterProps {
+  usage: SessionUsage | null;
+  contextWindow: number | null;
+  planUsage: PlanUsage | null;
+}
+
+export function UsageMeter({ usage, contextWindow, planUsage }: UsageMeterProps) {
   // Guard a non-finite `usedTokens` (e.g. NaN from a malformed upstream value)
   // so it can't propagate into the rendered percent or the SVG dashoffset.
-  const used = Number.isFinite(usage.usedTokens) ? usage.usedTokens : 0;
-  const fraction = Math.min(1, Math.max(0, used / contextWindow));
+  const used = usage && Number.isFinite(usage.usedTokens) ? usage.usedTokens : 0;
+  const fraction = contextWindow ? Math.min(1, Math.max(0, used / contextWindow)) : 0;
   const percent = Math.round(fraction * 100);
-  const isWarning = fraction >= WARNING_THRESHOLD;
+  const isWarning = contextWindow !== null && fraction >= WARNING_THRESHOLD;
 
   // Radix Tooltip handles hover/focus open/close and hoverable content natively,
   // so no manual open state or close timer is needed.
@@ -78,22 +161,32 @@ function RingMeter({ usage, contextWindow }: { usage: SessionUsage; contextWindo
           variant="ghost2"
           size="icon"
           className={cn(isWarning ? "tw-text-warning" : "tw-text-accent")}
-          aria-label="Context usage"
+          aria-label="Usage"
         >
-          <ContextRing fraction={fraction} />
+          {contextWindow !== null ? <ContextRing fraction={fraction} /> : formatTokens(used)}
         </Button>
       </TooltipTrigger>
       <TooltipContent align="end" side="top" className="tw-w-80">
         <div className="tw-flex tw-flex-col tw-gap-2">
-          <div className="tw-flex tw-items-center tw-justify-between tw-gap-3 tw-text-ui-smaller">
-            <span className="tw-whitespace-nowrap tw-text-muted">Context window</span>
-            <span
-              className={cn("tw-whitespace-nowrap tw-tabular-nums", isWarning && "tw-text-warning")}
-            >
-              {formatTokens(used)} / {formatTokens(contextWindow)} ({percent}%)
-            </span>
-          </div>
-          <Progress value={percent} className="tw-h-1.5" />
+          {usage && (
+            <>
+              <div className="tw-flex tw-items-center tw-justify-between tw-gap-3 tw-text-ui-smaller">
+                <span className="tw-whitespace-nowrap tw-text-muted">Context window</span>
+                <span
+                  className={cn(
+                    "tw-whitespace-nowrap tw-tabular-nums",
+                    isWarning && "tw-text-warning"
+                  )}
+                >
+                  {contextWindow !== null
+                    ? `${formatTokens(used)} / ${formatTokens(contextWindow)} (${percent}%)`
+                    : formatTokens(used)}
+                </span>
+              </div>
+              {contextWindow !== null && <Progress value={percent} className="tw-h-1.5" />}
+            </>
+          )}
+          {planUsage && <PlanUsageRows planUsage={planUsage} />}
         </div>
       </TooltipContent>
     </Tooltip>
@@ -101,26 +194,37 @@ function RingMeter({ usage, contextWindow }: { usage: SessionUsage; contextWindo
 }
 
 /**
- * Circular context-window meter for the agent control bar. Renders as a single
- * icon-sized button that sits alongside the other row controls (no separator of
- * its own). Render ladder from the backend's {@link SessionUsage}:
+ * Usage meter for the agent control bar: a single icon-sized control beside the other
+ * row buttons, whose tooltip carries the session's context occupancy and the account's
+ * plan caps.
  *
- *   - a positive `contextWindow` → the % ring with a hover tooltip (the
- *     percentage and token numbers live inside the tooltip);
- *   - `usedTokens` known but no window → the legacy count-only `TokenCounter`
- *     chip;
- *   - no usage at all → `null` (renders nothing, so the row shows no control).
+ * The two are independent. A backend can report a context window with no caps (a key-
+ * authenticated Claude session), caps with no window (Copilot Plus models, whose window
+ * the agent does not advertise), both, or neither. Each is rendered when present, so
+ * caps are never dropped just because there is nothing to measure the context against.
+ *
+ * With nothing to report the control disappears rather than showing an empty meter.
  */
 export default function AgentContextMeter({ backend }: AgentContextMeterProps) {
   const usage = useSessionUsage(backend);
-  if (usage === null) return null;
+  const planUsage = usePlanUsage(backend);
 
-  const window = usage.contextWindow;
-  if (typeof window === "number" && Number.isFinite(window) && window > 0) {
-    return <RingMeter usage={usage} contextWindow={window} />;
+  const rawWindow = usage?.contextWindow;
+  const contextWindow =
+    typeof rawWindow === "number" && Number.isFinite(rawWindow) && rawWindow > 0 ? rawWindow : null;
+  const hasTokens = usage !== null && usage.usedTokens > 0;
+
+  if (contextWindow !== null || planUsage !== null) {
+    return (
+      <UsageMeter
+        usage={hasTokens || contextWindow !== null ? usage : null}
+        contextWindow={contextWindow}
+        planUsage={planUsage}
+      />
+    );
   }
 
-  // Count-only fallback: render nothing when there is no usage to show.
-  if (!(usage.usedTokens > 0)) return null;
+  // Nothing but a raw count to show: the long-standing count-only chip.
+  if (!hasTokens) return null;
   return <TokenCounter tokenCount={usage.usedTokens} />;
 }

--- a/src/agentMode/ui/hooks/usePlanUsage.ts
+++ b/src/agentMode/ui/hooks/usePlanUsage.ts
@@ -1,0 +1,36 @@
+import type { AgentChatBackend } from "@/agentMode/session/AgentChatBackend";
+import type { PlanUsage } from "@/agentMode/session/planUsage";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Reactive snapshot of the backend's latest plan-cap report, kept in sync through the
+ * same single subscription the rest of the runtime state uses. Returns `null` until a
+ * backend reports caps — a fresh session, a backend with no usage API, or an account
+ * whose authentication is not metered by plan caps all look the same here, and all mean
+ * the same thing to the UI: render no cap meters.
+ *
+ * Mirrors {@link useSessionUsage}: a fresh sync on every `backend` change, and a mount
+ * guard so a notification racing an unmount is a no-op.
+ */
+export function usePlanUsage(backend: AgentChatBackend): PlanUsage | null {
+  const [planUsage, setPlanUsage] = useState<PlanUsage | null>(() => backend.getPlanUsage());
+
+  const isMountedRef = useRef(false);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const sync = () => setPlanUsage(backend.getPlanUsage());
+    sync();
+    return backend.subscribe(() => {
+      if (!isMountedRef.current) return;
+      sync();
+    });
+  }, [backend]);
+
+  return planUsage;
+}


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#193

## Why

A Claude subscription meters usage in rolling windows. Agent Mode showed how full the context window was, but nothing about the limits that actually stop you working — so the first sign of one was the turn that came back refused, with no warning it was close and no way to tell whether you were minutes or days from working again.

## What

The usage meter's tooltip gains a row per plan window under the context bar: a label, the percentage consumed, a bar, and when it resets.

> **Before:** the tooltip shows `Context window 42.1k / 1.0M (4%)` and nothing else. Whether you are at 5% or 95% of your weekly limit is invisible until a turn is refused.
>
> **After:** the same context bar, then `5h · resets in 3h 53m — 14%` and `Weekly · resets in 4d 19h — 21%`, plus any per-model window the plan reports.

The caps describe the account, not the conversation, so they survive opening or switching chats rather than blanking until each new chat takes a turn of its own.

Nothing is shown where nothing is known. A session that plan limits do not apply to — an API key, Bedrock, Vertex — reports no windows and draws no rows, rather than a confident 0%. A percentage above 100 is passed through rather than clamped, so an account served past its cap does not look like one that merely reached it.

## Non goal

- No caps for Codex or Copilot Plus models. Copilot Plus is the next PR in this stack; Codex depends on whether `codex-acp` forwards its rate limits over ACP at all, which is unverified.
- Caps are not persisted. They are read live, so a fresh plugin load shows them once the first turn starts rather than restoring a percentage from disk that may be hours stale.
- No change to what happens when a cap is actually hit; this only makes the approach visible.

## Screenshot

Rendered in the test vault on the Claude Code backend, hovering the meter:

`Context window 42.1k / 1.0M (4%)` · `5h · resets in 3h 53m — 14%` · `Weekly · resets in 4d 19h — 21%` · `Weekly (Fable) · resets in 4d 19h — 14%`

Image not attached: the terminal running this work lacks macOS Screen Recording permission, so the capture could not be taken programmatically. The values above are from a live session and match what the SDK reported for the same account at that moment.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `planUsage.test.ts`, `claudePlanUsage.test.ts`, and the meter tests cover the parsing, every failure mode, and the render ladder |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a wrong percentage is visible the first time the tooltip opens |
| A revert fully restores prior state, including persisted data | ✅ | Nothing is persisted; the snapshot is in-memory and dies with the process |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Reads an existing authenticated SDK session; no credential path changes |
| No public API, plugin API, message, or on-disk contract changes | ❌ | Adds `getPlanUsage()` to the `AgentChatBackend` interface and a `plan_usage_update` session update; both are internal to the plugin and have one implementer |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | Starts an unawaited control request inside the turn's message loop |
| No hot-path behavior lacks deterministic coverage | ✅ | The read cannot throw into the turn, and its failure modes are unit-covered |
| No new dependency | ✅ | Uses the already-pinned Agent SDK |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the usage meter; a wrong number is visible immediately and affects no turn |

Review: read `refreshPlanUsage` and its call site in `src/agentMode/sdk/ClaudeSdkBackendProcess.ts` — the read is deliberately started on the turn's first message and left unawaited, and the reason is timing rather than taste (see Note). Then `readClaudePlanUsage` in `src/agentMode/sdk/claudePlanUsage.ts`, confirming every path returns null rather than throwing. Then run Verification steps 2 and 3.

## Verification

1. Build the branch into a vault (`npm run test:vault`) and open Agent Mode on the Claude Code backend with a subscription-authenticated session.
2. Send any message, then hover the meter in the composer's control row. Expect a context row plus one row per plan window, each with a percentage and a reset time. Compare them against `/usage` in the Claude Code CLI for the same account.
3. Open a second chat and hover again without sending anything. The cap rows should already be there.
4. Switch to a backend other than Claude Code. The cap rows should disappear rather than showing stale numbers.

## Note

The read is a control request on the turn's query, and the window to make it is narrower than it looks. With partial streaming enabled — which this plugin sets — the `assistant` message arrives about ten milliseconds before `result`, at which point the query is already closing and the request is rejected with "Query closed before response received". Measured against the plugin's own options: `system` at 1.4s, `assistant` at 2.744s, `result` at 2.754s; a read started at the first message resolves in 275ms. Hence the trigger is the turn's first message, whatever it is.

The SDK method is named `usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET`. We rely on it because it is the only source of these numbers: the streamed `rate_limit_event` carries a reset time and a status but no utilization at all, verified against a live session. Every reach for it is isolated in one module that returns null for a renamed method, a throw, or an unrecognized shape, so the day it changes the meter goes quiet and nothing else does.

`utilization` is a percentage, 0-100, not a fraction. The response's parallel `limits[]` array reports the same values under a field named `percent`, which is what settles it; reading them as fractions would have rendered 1000%.
