### PR TITLE
[Agent usage caps] - Step 2: Show Copilot Plus plan caps

### DIFF
--- a/src/LLMProviders/brevilabsClient.test.ts
+++ b/src/LLMProviders/brevilabsClient.test.ts
@@ -15,6 +15,14 @@ jest.mock("@/plusUtils", () => ({
 }));
 
 import { BrevilabsClient } from "@/LLMProviders/brevilabsClient";
+import { BREVILABS_MODELS_BASE_URL } from "@/constants";
+
+import * as obsidianModule from "obsidian";
+
+/** The obsidian mock's seam for stubbing `requestUrl` per test. */
+const { __setRequestUrlImpl: setRequestUrlImpl } = obsidianModule as unknown as {
+  __setRequestUrlImpl: (impl: unknown) => void;
+};
 
 interface RequestOutcome {
   data: unknown;
@@ -169,6 +177,85 @@ describe("brevilabsClient", () => {
 
         expect(result).toEqual({ isValid: undefined });
         expect(mockTurnOffPaid).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("getUsage()", () => {
+      const requestUrlMock = jest.fn();
+      beforeEach(() => {
+        jest.clearAllMocks();
+        mockGetSettings.mockReturnValue({ plusLicenseKey: "key-A" });
+        setRequestUrlImpl(requestUrlMock);
+      });
+
+      it("reads the usage endpoint on the MODELS host with the license key as bearer auth", async () => {
+        // The caps are enforced by the model proxy, so their read side lives beside
+        // them; api.brevilabs.com has no such route and answers 404.
+        requestUrlMock.mockResolvedValue({
+          status: 200,
+          json: { used: { weekly: { usedPercent: 21 } } },
+        });
+
+        const usage = await BrevilabsClient.getInstance().getUsage();
+
+        expect(usage).toEqual({ used: { weekly: { usedPercent: 21 } } });
+        const call = requestUrlMock.mock.calls[0][0] as {
+          url: string;
+          method: string;
+          headers: Record<string, string>;
+        };
+        expect(call.url).toBe(`${BREVILABS_MODELS_BASE_URL}/usage`);
+        expect(call.method).toBe("GET");
+        expect(call.headers.Authorization).toBe("Bearer key-A");
+      });
+
+      it("answers null without a request when there is no license key", async () => {
+        mockGetSettings.mockReturnValue({ plusLicenseKey: "" });
+
+        await expect(BrevilabsClient.getInstance().getUsage()).resolves.toBeNull();
+        expect(requestUrlMock).not.toHaveBeenCalled();
+      });
+
+      it.each([
+        ["a non-200 response", () => requestUrlMock.mockResolvedValue({ status: 503 })],
+        ["a thrown request", () => requestUrlMock.mockRejectedValue(new Error("offline"))],
+      ])("answers null for %s rather than throwing", async (_label, arrange) => {
+        // This feeds a meter; a meter that cannot be drawn is not an error worth
+        // interrupting anyone over.
+        arrange();
+
+        await expect(BrevilabsClient.getInstance().getUsage()).resolves.toBeNull();
+      });
+    });
+
+    describe("getModels()", () => {
+      const requestUrlMock = jest.fn();
+      beforeEach(() => {
+        jest.clearAllMocks();
+        setRequestUrlImpl(requestUrlMock);
+      });
+
+      it("reads the public catalog from the MODELS host without authorization", async () => {
+        requestUrlMock.mockResolvedValue({
+          status: 200,
+          json: { data: [{ id: "gemini-3-pro", context_length: "1M" }] },
+        });
+
+        const models = await BrevilabsClient.getInstance().getModels();
+
+        expect(models).toEqual({ data: [{ id: "gemini-3-pro", context_length: "1M" }] });
+        const call = requestUrlMock.mock.calls[0][0] as { url: string; headers: object };
+        expect(call.url).toBe(`${BREVILABS_MODELS_BASE_URL}/models`);
+        expect(call.headers).not.toHaveProperty("Authorization");
+      });
+
+      it.each([
+        ["a non-200 response", () => requestUrlMock.mockResolvedValue({ status: 500 })],
+        ["a thrown request", () => requestUrlMock.mockRejectedValue(new Error("offline"))],
+      ])("answers null for %s rather than throwing", async (_label, arrange) => {
+        arrange();
+
+        await expect(BrevilabsClient.getInstance().getModels()).resolves.toBeNull();
       });
     });
   });

--- a/src/LLMProviders/brevilabsClient.ts
+++ b/src/LLMProviders/brevilabsClient.ts
@@ -1,4 +1,4 @@
-import { BREVILABS_API_BASE_URL } from "@/constants";
+import { BREVILABS_API_BASE_URL, BREVILABS_MODELS_BASE_URL } from "@/constants";
 import { MissingPlusLicenseError } from "@/error";
 import { logInfo } from "@/logger";
 import { applyEntitlement, markPaidPendingEntitlement, turnOffPaid } from "@/plusUtils";
@@ -149,6 +149,31 @@ export interface Youtube4llmResponse {
 export interface Twitter4llmResponse {
   response: string;
   elapsed_time_ms: number;
+}
+
+/**
+ * `GET /usage` — the account's plan-cap utilization, for the usage meter.
+ *
+ * A window appears only when the plan caps it, and none appear when the counters
+ * cannot be read, so an absent window means "no meter" rather than "0% used".
+ * `usedPercent` is 0-100 and may exceed 100 while an account is served past its cap
+ * on purchased credit. `resetsAt` is epoch SECONDS.
+ */
+export interface UsageResponse {
+  used?: Record<string, { usedPercent?: number; resetsAt?: number } | null> | null;
+  dashboard_url?: string;
+}
+
+/** One entry of the models host's public `GET /models` listing. */
+export interface BrevilabsModelEntry {
+  id?: string;
+  label?: string;
+  /** Input context window as a display string: `1M`, `256K`. */
+  context_length?: string;
+}
+
+export interface BrevilabsModelsResponse {
+  data?: BrevilabsModelEntry[];
 }
 
 export interface LicenseResponse {
@@ -366,6 +391,68 @@ export class BrevilabsClient {
     }
 
     return data;
+  }
+
+  /**
+   * Read the account's 5-hour and weekly cap utilization.
+   *
+   * Talks to the MODELS host, not the tools/license API the rest of this client uses.
+   * The caps are enforced by the model proxy on the request path, so their read side
+   * lives beside them; `api.brevilabs.com` has no such route and answers 404.
+   *
+   * Returns null instead of throwing: this feeds a meter, and a meter that cannot be
+   * drawn is not an error worth interrupting anyone over. The endpoint is read-only and
+   * consumes no quota, so it is safe to poll.
+   */
+  async getUsage(): Promise<UsageResponse | null> {
+    const licenseKey = getSettings().plusLicenseKey;
+    if (!licenseKey) return null;
+
+    try {
+      const response = await requestUrl({
+        url: `${BREVILABS_MODELS_BASE_URL}/usage`,
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${licenseKey}`,
+          ...this.getPluginVersionHeaders(),
+        },
+        throw: false,
+      });
+      if (response.status !== 200) {
+        logInfo(`[BrevilabsClient] usage read returned ${response.status}; no cap meters`);
+        return null;
+      }
+      return response.json as UsageResponse;
+    } catch (error) {
+      logInfo("[BrevilabsClient] usage read failed; no cap meters", error);
+      return null;
+    }
+  }
+
+  /**
+   * The models host's public catalog. Unauthenticated, and the only place the context
+   * window of a Copilot Plus model is published, so the usage meter can size its ring.
+   *
+   * Returns null rather than throwing, for the same reason as {@link getUsage}: this
+   * feeds a gauge, and a gauge that cannot be drawn is not an error worth raising.
+   */
+  async getModels(): Promise<BrevilabsModelsResponse | null> {
+    try {
+      const response = await requestUrl({
+        url: `${BREVILABS_MODELS_BASE_URL}/models`,
+        method: "GET",
+        headers: this.getPluginVersionHeaders(),
+        throw: false,
+      });
+      if (response.status !== 200) {
+        logInfo(`[BrevilabsClient] models read returned ${response.status}`);
+        return null;
+      }
+      return response.json as BrevilabsModelsResponse;
+    } catch (error) {
+      logInfo("[BrevilabsClient] models read failed", error);
+      return null;
+    }
   }
 
   async url4llm(url: string): Promise<Url4llmResponse> {

--- a/src/agentMode/acp/AcpBackendProcess.test.ts
+++ b/src/agentMode/acp/AcpBackendProcess.test.ts
@@ -39,6 +39,7 @@ jest.mock("@agentclientprotocol/sdk", () => {
     loadSession = (...args: unknown[]) => mockLoadSession(...args);
     prompt = jest.fn(async () => ({ stopReason: "end_turn" }));
     cancel = jest.fn(async () => undefined);
+    unstable_setSessionModel = jest.fn(async () => ({}));
   }
   return {
     RequestError,
@@ -702,6 +703,540 @@ describe("AcpBackendProcess", () => {
         usedTokens: 5000,
         contextWindow: 200_000,
       });
+    });
+  });
+
+  describe("plan caps", () => {
+    const PLAN_USAGE = {
+      windows: [{ id: "weekly", label: "Weekly", percent: 13 }],
+      updatedAt: 1_000,
+    };
+    const USAGE_READING = { kind: "usage", planUsage: PLAN_USAGE };
+
+    /** The read is fired without being awaited, so let its microtasks drain. */
+    const settle = () => new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    function planEvents(handler: jest.Mock): unknown[] {
+      return handler.mock.calls
+        .map(([e]) => e as { update: { sessionUpdate: string } })
+        .filter((e) => e.update.sessionUpdate === "plan_usage_update");
+    }
+
+    async function makeBackend(
+      readPlanUsage?: AcpBackend["readPlanUsage"]
+    ): Promise<AcpBackendProcess> {
+      const backend = new AcpBackendProcess(
+        buildApp(),
+        { ...buildStubBackend(), readPlanUsage },
+        "1.0.0",
+        buildStubDescriptor()
+      );
+      await backend.start();
+      return backend;
+    }
+
+    it("publishes the caps as soon as a chat opens, without waiting for a turn", async () => {
+      // The caps outlive the process, so the first chat of a run has somewhere to read
+      // them from and should not make the user send a message to see them.
+      const backend = await makeBackend(jest.fn().mockResolvedValue(USAGE_READING));
+      const handler = jest.fn();
+
+      backend.registerSessionHandler("s1", handler);
+      await settle();
+
+      expect(planEvents(handler)).toEqual([
+        { sessionId: "s1", update: { sessionUpdate: "plan_usage_update", planUsage: PLAN_USAGE } },
+      ]);
+    });
+
+    it("republishes the caps a turn moved, to every attached session", async () => {
+      // The number describes the account, so it is equally true of every open chat.
+      // Routing it to one would leave the others stale until they each ran a turn.
+      const spent = {
+        windows: [{ id: "weekly", label: "Weekly", percent: 27 }],
+        updatedAt: 2_000,
+      };
+      const backend = await makeBackend(
+        jest
+          .fn()
+          .mockResolvedValueOnce(USAGE_READING)
+          .mockResolvedValue({ kind: "usage", planUsage: spent })
+      );
+      const first = jest.fn();
+      const second = jest.fn();
+      backend.registerSessionHandler("s1", first);
+      backend.registerSessionHandler("s2", second);
+      await settle();
+      first.mockClear();
+      second.mockClear();
+
+      await backend.prompt({ sessionId: "s1", prompt: [] });
+      await settle();
+
+      for (const handler of [first, second]) {
+        expect(planEvents(handler)).toEqual([
+          expect.objectContaining({
+            update: { sessionUpdate: "plan_usage_update", planUsage: spent },
+          }),
+        ]);
+      }
+    });
+
+    it("replays the last caps to a session that attaches later, without re-reading", async () => {
+      const readPlanUsage = jest.fn().mockResolvedValue(USAGE_READING);
+      const backend = await makeBackend(readPlanUsage);
+      backend.registerSessionHandler("s1", jest.fn());
+      await settle();
+
+      const later = jest.fn();
+      backend.registerSessionHandler("s2", later);
+
+      expect(planEvents(later)).toEqual([
+        { sessionId: "s2", update: { sessionUpdate: "plan_usage_update", planUsage: PLAN_USAGE } },
+      ]);
+      expect(readPlanUsage).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops an expired window instead of replaying it (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
+      // The process outlives many chats; a snapshot taken before a reset describes a
+      // period that has ended and must not be shown as the current one.
+      const expiring = {
+        windows: [{ id: "five_hour", label: "5h", percent: 55, resetsAt: Date.now() - 1 }],
+        updatedAt: 1_000,
+      };
+      const readPlanUsage = jest
+        .fn()
+        .mockResolvedValueOnce({ kind: "usage", planUsage: expiring })
+        .mockResolvedValue({ kind: "unavailable" });
+      const backend = await makeBackend(readPlanUsage);
+      backend.registerSessionHandler("s1", jest.fn());
+      await settle();
+
+      const later = jest.fn();
+      backend.registerSessionHandler("s2", later);
+
+      expect(planEvents(later)).toHaveLength(0);
+    });
+
+    it("keeps the last good snapshot when a later read is unusable or throws", async () => {
+      const readPlanUsage = jest
+        .fn()
+        .mockResolvedValueOnce(USAGE_READING)
+        .mockResolvedValueOnce({ kind: "unavailable" })
+        .mockRejectedValueOnce(new Error("endpoint gone"));
+      const backend = await makeBackend(readPlanUsage);
+      const handler = jest.fn();
+      backend.registerSessionHandler("s1", handler);
+      await settle();
+
+      for (let turn = 0; turn < 2; turn++) {
+        await backend.prompt({ sessionId: "s1", prompt: [] });
+        await settle();
+      }
+
+      // One published event, and the snapshot still replays — a failed read is "no
+      // news", never a reason to blank a meter the user is reading.
+      expect(planEvents(handler)).toHaveLength(1);
+      const later = jest.fn();
+      backend.registerSessionHandler("s2", later);
+      expect(planEvents(later)).toHaveLength(1);
+    });
+
+    it("clears the meters when a read says this login has no caps", async () => {
+      // "None" is an explicit provider statement — an unmetered login — not a failed
+      // read, so caps still on screen describe an account the user is no longer on.
+      const readPlanUsage = jest
+        .fn()
+        .mockResolvedValueOnce(USAGE_READING)
+        .mockResolvedValue({ kind: "none" });
+      const backend = await makeBackend(readPlanUsage);
+      const handler = jest.fn();
+      backend.registerSessionHandler("s1", handler);
+      await settle();
+      handler.mockClear();
+
+      await backend.prompt({ sessionId: "s1", prompt: [] });
+      await settle();
+
+      expect(planEvents(handler)).toEqual([
+        { sessionId: "s1", update: { sessionUpdate: "plan_usage_update", planUsage: null } },
+      ]);
+    });
+
+    it("re-reads rather than reusing a snapshot from before the backend restarted", async () => {
+      // A backend that starts again may be pointed at different credentials, so the
+      // snapshot cannot outlive it — otherwise the first chat back shows the previous
+      // account's caps.
+      const reauthed = {
+        windows: [{ id: "weekly", label: "Weekly", percent: 3 }],
+        updatedAt: 3_000,
+      };
+      const readPlanUsage = jest
+        .fn()
+        .mockResolvedValueOnce(USAGE_READING)
+        .mockResolvedValue({ kind: "usage", planUsage: reauthed });
+      const backend = await makeBackend(readPlanUsage);
+      backend.registerSessionHandler("s1", jest.fn());
+      await settle();
+
+      await backend.shutdown();
+      await backend.start();
+      const afterRestart = jest.fn();
+      backend.registerSessionHandler("s2", afterRestart);
+      await settle();
+
+      expect(planEvents(afterRestart)).toEqual([
+        { sessionId: "s2", update: { sessionUpdate: "plan_usage_update", planUsage: reauthed } },
+      ]);
+    });
+
+    it("shares one read among chats that attach while it is in flight", async () => {
+      // Several chats restoring at startup must not fire one account read each, and an
+      // early success must not be discarded because a later duplicate failed.
+      let release!: (reading: unknown) => void;
+      const readPlanUsage = jest
+        .fn()
+        .mockReturnValueOnce(new Promise((resolve) => (release = resolve)))
+        .mockResolvedValue({ kind: "unavailable" });
+      const backend = await makeBackend(readPlanUsage);
+      const first = jest.fn();
+      const second = jest.fn();
+      backend.registerSessionHandler("s1", first);
+      backend.registerSessionHandler("s2", second); // joins s1's in-flight read
+
+      release({ kind: "usage", planUsage: PLAN_USAGE });
+      await settle();
+
+      expect(planEvents(first)).toHaveLength(1);
+      expect(planEvents(second)).toHaveLength(1);
+      // The joined trigger queues at most one follow-up read; no read per attach.
+      expect(readPlanUsage.mock.calls.length).toBeLessThanOrEqual(2);
+    });
+
+    it("ignores an older read that resolves after a newer one", async () => {
+      // An attach-time read and a turn-end read can be in flight together, and nothing
+      // promises they resolve in start order. The older answer arriving last must not
+      // roll the meters backward.
+      const fresh = {
+        windows: [{ id: "weekly", label: "Weekly", percent: 40 }],
+        updatedAt: 2_000,
+      };
+      let releaseStaleRead!: (reading: unknown) => void;
+      const readPlanUsage = jest
+        .fn()
+        .mockReturnValueOnce(new Promise((resolve) => (releaseStaleRead = resolve)))
+        .mockResolvedValue({ kind: "usage", planUsage: fresh });
+      const backend = await makeBackend(readPlanUsage);
+      const handler = jest.fn();
+      backend.registerSessionHandler("s1", handler); // starts the read that will stall
+
+      await backend.prompt({ sessionId: "s1", prompt: [] }); // starts the newer read
+      await settle();
+      releaseStaleRead({ kind: "usage", planUsage: PLAN_USAGE }); // the 13% snapshot
+      await settle();
+
+      const events = planEvents(handler) as { update: { planUsage: unknown } }[];
+      expect(events[events.length - 1]?.update.planUsage).toEqual(fresh);
+      // And the stale answer must not have replaced the cached snapshot either.
+      const later = jest.fn();
+      backend.registerSessionHandler("s2", later);
+      const replayed = planEvents(later) as { update: { planUsage: unknown } }[];
+      expect(replayed[0]?.update.planUsage).toEqual(fresh);
+    });
+
+    it("drops a read that resolves after the backend shut down", async () => {
+      // Without this, a slow read races shutdown(): its answer lands after the reset,
+      // survives into the next start(), and the first chat back replays caps from an
+      // account the backend may no longer be authenticated as.
+      let releaseFirstRead!: (reading: unknown) => void;
+      const readPlanUsage = jest
+        .fn()
+        .mockReturnValueOnce(new Promise((resolve) => (releaseFirstRead = resolve)))
+        .mockResolvedValue({ kind: "unavailable" });
+      const backend = await makeBackend(readPlanUsage);
+      backend.registerSessionHandler("s1", jest.fn()); // triggers the slow read
+
+      await backend.shutdown();
+      releaseFirstRead(USAGE_READING);
+      await settle();
+
+      await backend.start();
+      const afterRestart = jest.fn();
+      backend.registerSessionHandler("s2", afterRestart);
+      await settle();
+
+      expect(planEvents(afterRestart)).toHaveLength(0);
+    });
+
+    it("stays quiet for a backend that has no plan caps to report", async () => {
+      const backend = await makeBackend();
+      const handler = jest.fn();
+      backend.registerSessionHandler("s1", handler);
+
+      await backend.prompt({ sessionId: "s1", prompt: [] });
+      await settle();
+
+      expect(planEvents(handler)).toHaveLength(0);
+    });
+  });
+
+  describe("per-model cap applicability", () => {
+    const PLAN_USAGE = {
+      windows: [{ id: "weekly", label: "Weekly", percent: 13 }],
+      updatedAt: 1_000,
+    };
+    const settle = () => new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    function lastPlanEvent(handler: jest.Mock): { update: { planUsage: unknown } } | undefined {
+      const events = handler.mock.calls
+        .map(([e]) => e)
+        .filter((e) => e.update.sessionUpdate === "plan_usage_update");
+      return events[events.length - 1];
+    }
+
+    /**
+     * Backend gated the way OpencodeBackend is: the account caps meter only sessions on
+     * a `metered/` model. Two sessions are opened on different models so one broadcast
+     * exercises both sides of the gate.
+     */
+    async function makeGatedSessions(): Promise<{
+      backend: AcpBackendProcess;
+      readPlanUsage: jest.Mock;
+      metered: jest.Mock;
+      unmetered: jest.Mock;
+    }> {
+      const readPlanUsage = jest.fn().mockResolvedValue({ kind: "usage", planUsage: PLAN_USAGE });
+      const backend = new AcpBackendProcess(
+        buildApp(),
+        {
+          ...buildStubBackend(),
+          readPlanUsage,
+          planUsageAppliesTo: (wireModelId: string | null | undefined) =>
+            typeof wireModelId === "string" && wireModelId.startsWith("metered/"),
+        },
+        "1.0.0",
+        buildStubDescriptor({
+          wire: {
+            encode: (selection: { baseModelId: string }) => selection.baseModelId,
+            decode: (wireId: string) => ({
+              selection: { baseModelId: wireId },
+              provider: null,
+            }),
+          },
+        } as unknown as Partial<BackendDescriptor>)
+      );
+      await backend.start();
+      mockNewSession.mockResolvedValueOnce({
+        sessionId: "s-metered",
+        models: { availableModels: [], currentModelId: "metered/gemini-3-pro" },
+      } as unknown as { sessionId: string });
+      await backend.newSession({ cwd: "/vault" });
+      mockNewSession.mockResolvedValueOnce({
+        sessionId: "s-byok",
+        models: { availableModels: [], currentModelId: "google/gemini-3-pro" },
+      } as unknown as { sessionId: string });
+      await backend.newSession({ cwd: "/vault" });
+      const metered = jest.fn();
+      const unmetered = jest.fn();
+      backend.registerSessionHandler("s-metered", metered);
+      backend.registerSessionHandler("s-byok", unmetered);
+      await settle();
+      return { backend, readPlanUsage, metered, unmetered };
+    }
+
+    it("shows the caps only to sessions whose model bills the metered account", async () => {
+      // Selection is the whole test: a session on the user's own key shares the process
+      // but not the billing, and must see no cap meters.
+      const { metered, unmetered } = await makeGatedSessions();
+
+      expect(lastPlanEvent(metered)?.update.planUsage).toEqual(PLAN_USAGE);
+      expect(lastPlanEvent(unmetered)?.update.planUsage).toBeNull();
+    });
+
+    it("clears a session's meters the moment it switches off a metered model, without a new read", async () => {
+      const { backend, readPlanUsage, metered } = await makeGatedSessions();
+      const readsBefore = readPlanUsage.mock.calls.length;
+
+      await backend.setSessionModel({ sessionId: "s-metered", modelId: "google/gemini-3-pro" });
+
+      expect(lastPlanEvent(metered)?.update.planUsage).toBeNull();
+      expect(readPlanUsage.mock.calls.length).toBe(readsBefore);
+    });
+
+    it("shows the cached snapshot the moment a session switches onto a metered model", async () => {
+      const { backend, unmetered } = await makeGatedSessions();
+
+      await backend.setSessionModel({ sessionId: "s-byok", modelId: "metered/kimi-k2" });
+
+      expect(lastPlanEvent(unmetered)?.update.planUsage).toEqual(PLAN_USAGE);
+    });
+  });
+
+  describe("backend-supplied context window", () => {
+    const settle = () => new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    function usageEvents(handler: jest.Mock): { update: { usage: Record<string, unknown> } }[] {
+      return handler.mock.calls
+        .map(([e]) => e)
+        .filter((e) => e.update.sessionUpdate === "usage_update");
+    }
+
+    /**
+     * Backend whose agent advertises a current model on `session/new`, wired the way
+     * OpencodeBackend is: the process asks `readContextWindow` with the wire model id.
+     */
+    async function makeBackend(
+      readContextWindow: jest.Mock
+    ): Promise<{ backend: AcpBackendProcess; handler: jest.Mock }> {
+      mockNewSession.mockResolvedValue({
+        sessionId: "s1",
+        models: { availableModels: [], currentModelId: "copilot-plus/gemini-3-pro" },
+      } as unknown as { sessionId: string });
+      const backend = new AcpBackendProcess(
+        buildApp(),
+        { ...buildStubBackend(), readContextWindow },
+        "1.0.0",
+        buildStubDescriptor(modelCapableDescriptor())
+      );
+      await backend.start();
+      await backend.newSession({ cwd: "/vault" });
+      const handler = jest.fn();
+      backend.registerSessionHandler("s1", handler);
+      return { backend, handler };
+    }
+
+    /** Enough descriptor for `computeState` to translate a `models` wire state. */
+    function modelCapableDescriptor(): Partial<BackendDescriptor> {
+      return {
+        wire: {
+          encode: (selection: { baseModelId: string }) => selection.baseModelId,
+          decode: (wireId: string) => ({
+            selection: { baseModelId: wireId },
+            provider: null,
+          }),
+        },
+      } as unknown as Partial<BackendDescriptor>;
+    }
+
+    function sendUsage(backend: AcpBackendProcess, used: number, size?: number): Promise<void> {
+      const client = getVaultClient(backend);
+      return client.sessionUpdate({
+        sessionId: "s1",
+        update: { sessionUpdate: "usage_update", used, ...(size ? { size } : {}) },
+      } as unknown as Parameters<typeof client.sessionUpdate>[0]);
+    }
+
+    it("answers readContextWindow from one backend read, cached per model", async () => {
+      // The public seam a session uses to size a reopened chat's ring at seed time.
+      const readContextWindow = jest.fn().mockResolvedValue(1_048_576);
+      const { backend } = await makeBackend(readContextWindow);
+
+      await expect(backend.readContextWindow("copilot-plus/gemini-3-pro")).resolves.toBe(1_048_576);
+      await expect(backend.readContextWindow("copilot-plus/gemini-3-pro")).resolves.toBe(1_048_576);
+      expect(readContextWindow).toHaveBeenCalledTimes(1);
+      await expect(backend.readContextWindow(null)).resolves.toBeNull();
+    });
+
+    it("republishes a windowless usage snapshot once the backend has supplied the window", async () => {
+      const readContextWindow = jest.fn().mockResolvedValue(1_048_576);
+      const { backend, handler } = await makeBackend(readContextWindow);
+
+      await sendUsage(backend, 5_000);
+      await settle();
+
+      expect(readContextWindow).toHaveBeenCalledWith("copilot-plus/gemini-3-pro");
+      const events = usageEvents(handler);
+      expect(events[events.length - 1].update.usage).toMatchObject({
+        usedTokens: 5_000,
+        contextWindow: 1_048_576,
+      });
+    });
+
+    it("enriches later snapshots inline, not a beat behind", async () => {
+      // AgentSession ignores a windowless snapshot once it holds a windowed one, so an
+      // async-only fill would fight every later live update and stall the meter.
+      const readContextWindow = jest.fn().mockResolvedValue(1_048_576);
+      const { backend, handler } = await makeBackend(readContextWindow);
+      await sendUsage(backend, 5_000);
+      await settle();
+      handler.mockClear();
+
+      await sendUsage(backend, 6_000);
+
+      expect(usageEvents(handler)).toEqual([
+        expect.objectContaining({
+          update: expect.objectContaining({
+            usage: expect.objectContaining({ usedTokens: 6_000, contextWindow: 1_048_576 }),
+          }),
+        }),
+      ]);
+      expect(readContextWindow).toHaveBeenCalledTimes(1);
+    });
+
+    it("discards a window answer that arrives after the session switched models", async () => {
+      // Republishing the old model's snapshot would hand AgentSession a windowed
+      // reading it treats as authoritative, re-freezing the ring its model-change
+      // handling just cleared.
+      let release!: (window: number) => void;
+      const readContextWindow = jest.fn(() => new Promise((resolve) => (release = resolve)));
+      const { backend, handler } = await makeBackend(readContextWindow);
+
+      await sendUsage(backend, 5_000); // windowless: starts the catalog read
+      await backend.setSessionModel({ sessionId: "s1", modelId: "ollama/llama" });
+      handler.mockClear();
+      release(1_048_576);
+      await settle();
+
+      expect(usageEvents(handler)).toHaveLength(0);
+    });
+
+    it("leaves a window the wire itself reported alone", async () => {
+      const readContextWindow = jest.fn().mockResolvedValue(1_048_576);
+      const { backend, handler } = await makeBackend(readContextWindow);
+
+      await sendUsage(backend, 5_000, 200_000);
+
+      expect(readContextWindow).not.toHaveBeenCalled();
+      expect(usageEvents(handler)[0].update.usage).toMatchObject({ contextWindow: 200_000 });
+    });
+
+    it("asks again after an unanswered read instead of caching the failure", async () => {
+      // The backend answers null both for a model it does not know and for a catalog it
+      // could not reach, so remembering null would turn one transient failure into a
+      // bare token count for the rest of the session.
+      const readContextWindow = jest.fn().mockResolvedValueOnce(null).mockResolvedValue(1_048_576);
+      const { backend, handler } = await makeBackend(readContextWindow);
+
+      await sendUsage(backend, 5_000);
+      await settle();
+      await sendUsage(backend, 6_000);
+      await settle();
+
+      expect(readContextWindow).toHaveBeenCalledTimes(2);
+      const events = usageEvents(handler);
+      expect(events[events.length - 1].update.usage).toMatchObject({ contextWindow: 1_048_576 });
+    });
+
+    it("passes the snapshot through untouched when the session's model is unknown", async () => {
+      const readContextWindow = jest.fn().mockResolvedValue(1_048_576);
+      mockNewSession.mockResolvedValue({ sessionId: "s1" }); // no models state at all
+      const backend = new AcpBackendProcess(
+        buildApp(),
+        { ...buildStubBackend(), readContextWindow },
+        "1.0.0",
+        buildStubDescriptor()
+      );
+      await backend.start();
+      await backend.newSession({ cwd: "/vault" });
+      const handler = jest.fn();
+      backend.registerSessionHandler("s1", handler);
+
+      await sendUsage(backend, 5_000);
+      await settle();
+
+      expect(readContextWindow).not.toHaveBeenCalled();
+      expect(usageEvents(handler)).toHaveLength(1);
+      expect(usageEvents(handler)[0].update.usage.contextWindow).toBeUndefined();
     });
   });
 });

--- a/src/agentMode/acp/AcpBackendProcess.ts
+++ b/src/agentMode/acp/AcpBackendProcess.ts
@@ -34,11 +34,18 @@ import type {
   PromptOutput,
   ResumeSessionInput,
   ResumeSessionOutput,
+  SessionEvent,
   SessionId,
   SessionUpdateHandler as DomainSessionUpdateHandler,
+  SessionUsage,
 } from "@/agentMode/session/types";
 import { wrapStreamsForDebug } from "./debugTap";
 import { AcpBackend } from "./types";
+import {
+  withoutExpiredWindows,
+  type PlanUsage,
+  type PlanUsageReading,
+} from "@/agentMode/session/planUsage";
 import {
   consumeReplayUpdate,
   createReplayTranscriptState,
@@ -167,6 +174,33 @@ export class AcpBackendProcess implements BackendProcess {
   // restore, and no measurement suggests the size is a problem. If a future
   // review flags this again, point them at this note.
   private readonly loadSessionCollectors = new Map<SessionId, ReplayTranscriptState>();
+  /**
+   * Last plan-cap snapshot read from the backend.
+   *
+   * The caps belong to the account, not to a conversation, so one session's reading is
+   * true for every other. Held process-wide and replayed on attach, a new or switched
+   * chat shows the caps immediately instead of blanking until its own first turn.
+   */
+  private lastPlanUsage: PlanUsage | null = null;
+  /**
+   * The in-flight plan-usage read, when one is running. Reads are strictly sequential:
+   * a trigger that arrives mid-read joins it instead of racing it — overlapping reads
+   * can resolve out of start order and roll the meters backward, and several chats
+   * attaching at once would otherwise fire one identical account read each — and sets
+   * {@link planUsageReadQueued} so exactly one follow-up read runs afterwards, because
+   * a turn that ended mid-read has moved the numbers the running read will report.
+   */
+  private planUsageRead: Promise<void> | null = null;
+  private planUsageReadQueued = false;
+  /**
+   * Context windows the backend supplied for models the wire reports no window for,
+   * keyed by wire model id — windows belong to models, so a model switch needs no
+   * invalidation. A synchronous mirror of the backend's async answer on purpose:
+   * AgentSession ignores a windowless snapshot once it holds a windowed one, so every
+   * usage update after the first must be enriched inline or the meter would go stale
+   * for the rest of the session.
+   */
+  private readonly backendContextWindows = new Map<string, number>();
 
   constructor(
     private readonly app: App,
@@ -212,6 +246,12 @@ export class AcpBackendProcess implements BackendProcess {
       this.loadSessionCollectors.clear();
       this.permissionPrompter = null;
       this.capabilities.clear();
+      // Dropped rather than kept: a backend that starts again may be pointed at
+      // different credentials, and a snapshot held across that would show the previous
+      // account's caps. The next chat to attach reads fresh.
+      this.lastPlanUsage = null;
+      this.planUsageReadQueued = false;
+      this.backendContextWindows.clear();
       for (const fn of this.exitListeners) {
         try {
           fn();
@@ -301,6 +341,23 @@ export class AcpBackendProcess implements BackendProcess {
         }
       }
     }
+    // Expired windows are dropped rather than replayed: this process outlives many
+    // chats, and a snapshot taken before a reset describes a period that has ended.
+    this.lastPlanUsage = this.lastPlanUsage && withoutExpiredWindows(this.lastPlanUsage);
+    if (this.lastPlanUsage) {
+      try {
+        handler({
+          sessionId,
+          update: { sessionUpdate: "plan_usage_update", planUsage: this.planUsageFor(sessionId) },
+        });
+      } catch (e) {
+        logWarn(`[AgentMode] replay of plan usage threw for ${sessionId}`, e);
+      }
+    } else {
+      // Nothing read yet this run. The caps outlive the process, so the first chat to
+      // open has somewhere to read them from and should not have to run a turn first.
+      void this.refreshPlanUsage();
+    }
     return () => {
       // Only tear down if THIS handler is still the registered one — a later
       // re-register for the same sessionId (resume/reconnect) must not have its
@@ -348,23 +405,113 @@ export class AcpBackendProcess implements BackendProcess {
     if (usage && !this.sawLiveUsage.has(params.sessionId)) {
       const handler = this.domainHandlers.get(params.sessionId);
       if (handler) {
-        handler({
-          sessionId: params.sessionId,
-          update: {
-            sessionUpdate: "usage_update",
-            usage: {
-              usedTokens: usage.totalTokens,
-              inputTokens: usage.inputTokens,
-              outputTokens: usage.outputTokens,
-              cacheReadTokens: usage.cachedReadTokens ?? undefined,
-              cacheWriteTokens: usage.cachedWriteTokens ?? undefined,
-              updatedAt: Date.now(),
+        handler(
+          this.withBackendContextWindow({
+            sessionId: params.sessionId,
+            update: {
+              sessionUpdate: "usage_update",
+              usage: {
+                usedTokens: usage.totalTokens,
+                inputTokens: usage.inputTokens,
+                outputTokens: usage.outputTokens,
+                cacheReadTokens: usage.cachedReadTokens ?? undefined,
+                cacheWriteTokens: usage.cachedWriteTokens ?? undefined,
+                updatedAt: Date.now(),
+              },
             },
-          },
-        });
+          })
+        );
       }
     }
+    // A turn is what moves the caps, so its end is the moment to look again. Not
+    // awaited: the turn is over, and making the user wait on the read to see it end
+    // would trade a visible delay for a meter that refreshes a beat later.
+    void this.refreshPlanUsage();
     return { stopReason: stopReasonFromAcp(resp.stopReason) };
+  }
+
+  /**
+   * Ask the backend for the account's plan-cap utilization and publish what it says.
+   *
+   * Best-effort by construction: a backend with no source omits `readPlanUsage`
+   * entirely, and a read that failed or was unusable changes nothing — we learned
+   * nothing about the account, so the last good snapshot stands rather than blanking a
+   * meter the user is reading. A read that succeeded and reported no caps is different:
+   * this login is not metered by plan limits, so any caps on screen describe an account
+   * the user is no longer on and are cleared
+   * (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+   *
+   * Published to every attached session, not to whichever one prompted the read: the
+   * number describes the account, so it is equally true of every open chat, and routing
+   * it to one would leave the others showing a stale number until they each ran a turn.
+   */
+  private refreshPlanUsage(): Promise<void> {
+    if (!this.backend.readPlanUsage || !this.connection) return Promise.resolve();
+    if (this.planUsageRead) {
+      this.planUsageReadQueued = true;
+      return this.planUsageRead;
+    }
+    this.planUsageRead = this.readAndPublishPlanUsage().finally(() => {
+      this.planUsageRead = null;
+      if (this.planUsageReadQueued) {
+        this.planUsageReadQueued = false;
+        void this.refreshPlanUsage();
+      }
+    });
+    return this.planUsageRead;
+  }
+
+  private async readAndPublishPlanUsage(): Promise<void> {
+    if (!this.backend.readPlanUsage) return;
+    let reading: PlanUsageReading;
+    try {
+      reading = await this.backend.readPlanUsage();
+    } catch (e) {
+      logWarn(`[AgentMode] ${this.backend.id} plan usage read threw`, e);
+      return;
+    }
+    // Shut down (or exited) while the read was in flight: the answer describes an
+    // account the next start() may no longer be on, so it must not outlive the reset.
+    if (!this.connection) return;
+    if (reading.kind === "unavailable") return;
+    this.lastPlanUsage = reading.kind === "usage" ? reading.planUsage : null;
+    for (const [sessionId, handler] of this.domainHandlers) {
+      try {
+        handler({
+          sessionId,
+          update: { sessionUpdate: "plan_usage_update", planUsage: this.planUsageFor(sessionId) },
+        });
+      } catch (e) {
+        logWarn(`[AgentMode] plan usage dispatch threw for ${sessionId}`, e);
+      }
+    }
+  }
+
+  /**
+   * The account cap snapshot as one session should see it: the caps meter a session
+   * only while its current model bills the metered account (see
+   * {@link AcpBackend.planUsageAppliesTo}), so a session on some other billing source
+   * gets `null` — its meters stay off, or clear — while the snapshot itself stays
+   * cached for the sessions the caps do describe.
+   */
+  private planUsageFor(sessionId: SessionId): PlanUsage | null {
+    if (!this.lastPlanUsage) return null;
+    const applies = this.backend.planUsageAppliesTo?.(this.currentWireModelId(sessionId)) ?? true;
+    return applies ? this.lastPlanUsage : null;
+  }
+
+  /**
+   * Re-send one session's gated view of the caps after its model may have changed: a
+   * switch off a metered model clears its meters at once, a switch onto one shows the
+   * cached snapshot at once, and neither waits for the next turn to end. A no-op until
+   * a snapshot exists — with nothing cached there is nothing to show or clear.
+   */
+  private republishPlanUsage(sessionId: SessionId): void {
+    if (!this.lastPlanUsage || !this.backend.planUsageAppliesTo) return;
+    this.domainHandlers.get(sessionId)?.({
+      sessionId,
+      update: { sessionUpdate: "plan_usage_update", planUsage: this.planUsageFor(sessionId) },
+    });
   }
 
   async cancel(params: CancelInput): Promise<void> {
@@ -414,6 +561,7 @@ export class AcpBackendProcess implements BackendProcess {
         wire.configOptions = updateModelConfigOptionValue(wire.configOptions, params.modelId);
       }
     }
+    this.republishPlanUsage(params.sessionId);
     return this.computeState(params.sessionId);
   }
 
@@ -456,6 +604,9 @@ export class AcpBackendProcess implements BackendProcess {
     if (wire) {
       wire.configOptions = resp.configOptions;
     }
+    // A config option can be the model itself (opencode ≥ 1.15.13), so the session's
+    // gated view of the caps may just have changed with it.
+    this.republishPlanUsage(params.sessionId);
     return this.computeState(params.sessionId);
   }
 
@@ -597,6 +748,10 @@ export class AcpBackendProcess implements BackendProcess {
     this.sawLiveUsage.clear();
     this.permissionPrompter = null;
     this.capabilities.clear();
+    // Same reasoning as the exit handler: the next start() may authenticate as a
+    // different account, so nothing about this one may survive the restart.
+    this.lastPlanUsage = null;
+    this.backendContextWindows.clear();
     if (this.process) {
       try {
         await this.process.shutdown();
@@ -708,11 +863,100 @@ export class AcpBackendProcess implements BackendProcess {
         sessionId,
         update: { sessionUpdate: "state_changed", state: this.computeState(sessionId) },
       });
+      // An agent-initiated config change can carry a new model (opencode ≥ 1.15.13
+      // keeps its catalog in a config option), moving the session on or off the
+      // metered account.
+      if (sub === "config_option_update") this.republishPlanUsage(sessionId);
       return;
     }
 
     for (const event of acpNotificationToEvents(update, this.todoToolCallIdsFor(sessionId)))
-      handler(event);
+      handler(this.withBackendContextWindow(event));
+  }
+
+  /**
+   * Fill in a context window the wire did not supply, from the backend's own knowledge
+   * of the model (see {@link AcpBackend.readContextWindow}). Enriched inline when the
+   * window is already known; the first windowless snapshot for a model triggers the
+   * async read instead, and is republished once the answer arrives.
+   */
+  private withBackendContextWindow(event: SessionEvent): SessionEvent {
+    if (!this.backend.readContextWindow) return event;
+    if (event.update.sessionUpdate !== "usage_update") return event;
+    const usage = event.update.usage;
+    if (usage.contextWindow) return event; // the wire knew; nothing to add
+    const wireModelId = this.currentWireModelId(event.sessionId);
+    if (!wireModelId) return event;
+    const known = this.backendContextWindows.get(wireModelId);
+    if (known === undefined) {
+      void this.resolveBackendContextWindow(event.sessionId, wireModelId, usage);
+      return event;
+    }
+    return {
+      sessionId: event.sessionId,
+      update: { sessionUpdate: "usage_update", usage: { ...usage, contextWindow: known } },
+    };
+  }
+
+  /**
+   * The context window the backend's own catalog gives a model, through this process's
+   * cache. Public as `BackendProcess.readContextWindow`: a session seeding persisted
+   * usage asks here so a reopened chat's ring does not wait for its next turn.
+   *
+   * A null answer is deliberately not cached: the backend answers null both for a
+   * model it does not know and for a source it could not reach, so remembering it
+   * would turn one transient failure into a bare token count for the rest of the
+   * session.
+   */
+  async readContextWindow(wireModelId: string | null | undefined): Promise<number | null> {
+    if (!wireModelId || !this.backend.readContextWindow) return null;
+    const known = this.backendContextWindows.get(wireModelId);
+    if (known !== undefined) return known;
+    let contextWindow: number | null;
+    try {
+      contextWindow = (await this.backend.readContextWindow(wireModelId)) ?? null;
+    } catch (e) {
+      logWarn(`[AgentMode] ${this.backend.id} context window read threw for ${wireModelId}`, e);
+      return null;
+    }
+    if (contextWindow) this.backendContextWindows.set(wireModelId, contextWindow);
+    return contextWindow;
+  }
+
+  private async resolveBackendContextWindow(
+    sessionId: SessionId,
+    wireModelId: string,
+    usage: SessionUsage
+  ): Promise<void> {
+    const contextWindow = await this.readContextWindow(wireModelId);
+    if (!contextWindow) return;
+    // The session may have switched models while the catalog answered. Republishing the
+    // old model's snapshot now would hand AgentSession a windowed reading it treats as
+    // authoritative — re-freezing the very ring its model-change handling just cleared.
+    if (this.currentWireModelId(sessionId) !== wireModelId) return;
+    // Republish the snapshot that arrived windowless so the ring fills in now rather
+    // than on the next usage report.
+    this.domainHandlers.get(sessionId)?.({
+      sessionId,
+      update: { sessionUpdate: "usage_update", usage: { ...usage, contextWindow } },
+    });
+  }
+
+  /**
+   * Wire model id the session is currently on, from the cached wire state — the
+   * dedicated `models` state when the agent has one, else the `category:"model"` config
+   * option (opencode ≥ 1.15.13 exposes the catalog only there).
+   */
+  private currentWireModelId(sessionId: SessionId): string | null {
+    const wire = this.sessionWireState.get(sessionId);
+    if (!wire) return null;
+    if (wire.models?.currentModelId) return wire.models.currentModelId;
+    for (const option of wire.configOptions ?? []) {
+      if (option.type === "select" && option.category === "model" && option.currentValue) {
+        return option.currentValue;
+      }
+    }
+    return null;
   }
 
   private async handlePermission(

--- a/src/agentMode/acp/types.ts
+++ b/src/agentMode/acp/types.ts
@@ -1,4 +1,5 @@
 import type { BackendId } from "@/agentMode/session/types";
+import type { PlanUsageReading } from "@/agentMode/session/planUsage";
 
 /**
  * Spawn descriptor for an ACP-speaking agent backend. Backends produce these
@@ -24,4 +25,35 @@ export interface AcpBackend {
   readonly displayName: string;
   /** Build the spawn descriptor (BYOK keys decrypted, env composed). */
   buildSpawnDescriptor(ctx: { vaultBasePath: string }): Promise<AcpSpawnDescriptor>;
+  /**
+   * Read the account's plan-cap utilization, for backends that have somewhere to read it
+   * from. Optional because ACP has no session update for caps: a backend that reports
+   * them at all reports them off the wire, in a way only that backend knows about.
+   * Omitting this is how a backend says its caps are unavailable, and the meters stay off.
+   *
+   * Called at turn boundaries, so it must resolve rather than throw.
+   */
+  readPlanUsage?(): Promise<PlanUsageReading>;
+  /**
+   * Whether the account's plan caps meter a session currently on this model. Optional:
+   * omitting it means they always do (a Claude or Codex login meters every model that
+   * agent serves). A backend that routes to more than one billing source — opencode
+   * serves Copilot Plus models next to BYOK ones — answers per model, so a session on
+   * the user's own key shows no cap meters. Pure and synchronous: it is consulted every
+   * time a cap snapshot is dispatched or the session's model changes.
+   *
+   * @param wireModelId - Model id as it travels to the agent, provider prefix included.
+   *   Null when the session's model is not known yet, which must read as "not metered".
+   */
+  planUsageAppliesTo?(wireModelId: string | null | undefined): boolean;
+  /**
+   * Context window of a model the agent does not advertise one for, in tokens.
+   *
+   * Most agents report the window on the wire. Backends serving hosted models sometimes
+   * cannot, and only the vendor's own catalog knows the number, so this lets that backend
+   * supply it rather than the meter falling back to a bare token count.
+   *
+   * @param wireModelId - Model id as it travels to the agent, provider prefix included.
+   */
+  readContextWindow?(wireModelId: string | null | undefined): Promise<number | null>;
 }

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -11,7 +11,9 @@ import { composeDenyList, getManagedSkills, SkillManager } from "@/agentMode/ski
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
 import { buildBuiltinSkillEnv } from "@/agentMode/backends/shared/builtinSkillEnv";
 import { OpencodeBackendDescriptor } from "./descriptor";
-import { mapProviderToOpencodeId } from "./opencodeModelResolve";
+import { copilotPlusModelId, mapProviderToOpencodeId } from "./opencodeModelResolve";
+import type { PlanUsageReading } from "@/agentMode/session/planUsage";
+import { CopilotPlusUsageReader } from "@/agentMode/backends/shared/copilotPlusUsage";
 
 /**
  * Maps Copilot's `ChatModelProviders` to OpenCode's provider id. Used for the
@@ -79,8 +81,34 @@ export class OpencodeBackend implements AcpBackend {
 
   readonly #deps: OpencodeModelDeps;
 
+  /**
+   * Copilot Plus caps and model windows. Held per backend instance so its catalog cache
+   * dies with the process that owns it, and shared with any other backend serving the
+   * same hosted models.
+   */
+  readonly #copilotPlus = new CopilotPlusUsageReader();
+
   constructor(deps: OpencodeModelDeps) {
     this.#deps = deps;
+  }
+
+  /** Copilot Plus account caps, read from the models host that enforces them. */
+  async readPlanUsage(): Promise<PlanUsageReading> {
+    return this.#copilotPlus.readPlanUsage();
+  }
+
+  /**
+   * Selection is the whole test: only a session on a `copilot-plus/` model is metered
+   * by these caps. A user on their own key reaches this backend too, and must see no
+   * cap meters (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+   */
+  planUsageAppliesTo(wireModelId: string | null | undefined): boolean {
+    return copilotPlusModelId(wireModelId) !== null;
+  }
+
+  /** Copilot Plus models carry no window on the wire; the published catalog has it. */
+  async readContextWindow(wireModelId: string | null | undefined): Promise<number | null> {
+    return this.#copilotPlus.readContextWindow(copilotPlusModelId(wireModelId));
   }
 
   async buildSpawnDescriptor(ctx: { vaultBasePath: string }): Promise<AcpSpawnDescriptor> {

--- a/src/agentMode/backends/opencode/opencodeModelResolve.test.ts
+++ b/src/agentMode/backends/opencode/opencodeModelResolve.test.ts
@@ -3,6 +3,7 @@ import type { ConfiguredModel, Provider, ProviderOrigin, ProviderType } from "@/
 import { ChatModelProviders } from "@/constants";
 import {
   COPILOT_PLUS_OPENCODE_PROVIDER_ID,
+  copilotPlusModelId,
   isOpencodeZenWireId,
   mapProviderToOpencodeId,
   opencodeEnabledModelEntries,
@@ -266,6 +267,22 @@ describe("opencodeModelResolve", () => {
       // `ChatModelProviders.COPILOT_PLUS`, because this module sits behind the
       // desktop-only Agent Mode barrel. Drift would silently stop it matching.
       expect(COPILOT_PLUS_OPENCODE_PROVIDER_ID).toBe(ChatModelProviders.COPILOT_PLUS);
+    });
+  });
+
+  describe("copilotPlusModelId", () => {
+    it("strips opencode's Copilot Plus prefix down to the bare model id", () => {
+      expect(copilotPlusModelId("copilot-plus/gemini-3-pro")).toBe("gemini-3-pro");
+    });
+
+    it.each([
+      ["a BYOK model on the user's own key", "google/gemini-3-pro"],
+      ["an agent-hosted model", "opencode/grok-code"],
+      ["a bare id with no provider prefix", "gemini-3-pro"],
+      ["null", null],
+      ["undefined", undefined],
+    ])("answers null for %s — Copilot Plus caps must not apply to it", (_label, wireId) => {
+      expect(copilotPlusModelId(wireId)).toBeNull();
     });
   });
 

--- a/src/agentMode/backends/opencode/opencodeModelResolve.ts
+++ b/src/agentMode/backends/opencode/opencodeModelResolve.ts
@@ -22,6 +22,22 @@ export interface OpencodeProviderMapping {
 export const COPILOT_PLUS_OPENCODE_PROVIDER_ID = "copilot-plus";
 
 /**
+ * The bare Copilot Plus model id behind an opencode wire id, or null for anything else.
+ *
+ * The prefix is the whole test for whether Copilot Plus caps apply to a session: a user
+ * on their own API key reaches this same backend but is not metered by them, and must see
+ * no cap meters. Other backends serving these models spell their wire ids differently, so
+ * each strips its own prefix before asking the shared reader about the account.
+ *
+ * @param wireModelId - Model id as it travels to the agent, provider prefix included.
+ */
+export function copilotPlusModelId(wireModelId: string | null | undefined): string | null {
+  const prefix = `${COPILOT_PLUS_OPENCODE_PROVIDER_ID}/`;
+  if (typeof wireModelId !== "string" || !wireModelId.startsWith(prefix)) return null;
+  return wireModelId.slice(prefix.length);
+}
+
+/**
  * opencode Zen — opencode's own hosted gateway provider. Its models carry the
  * `opencode/` wire-id prefix and make up opencode's free model tier. We surface
  * a privacy warning for them because, unlike a self-hosted/BYOK model, prompts

--- a/src/agentMode/backends/shared/copilotPlusUsage.test.ts
+++ b/src/agentMode/backends/shared/copilotPlusUsage.test.ts
@@ -1,0 +1,182 @@
+import {
+  CopilotPlusUsageReader,
+  parseContextLength,
+  planUsageFromCopilotPlusUsage,
+} from "./copilotPlusUsage";
+
+jest.mock("@/logger", () => ({
+  logInfo: jest.fn(),
+  logWarn: jest.fn(),
+  logError: jest.fn(),
+}));
+
+const mockGetUsage = jest.fn();
+const mockGetModels = jest.fn();
+jest.mock("@/LLMProviders/brevilabsClient", () => ({
+  BrevilabsClient: {
+    getInstance: () => ({
+      getUsage: (...args: unknown[]) => mockGetUsage(...args),
+      getModels: (...args: unknown[]) => mockGetModels(...args),
+    }),
+  },
+}));
+
+describe("copilotPlusUsage", () => {
+  beforeEach(() => {
+    mockGetUsage.mockReset();
+    mockGetModels.mockReset();
+  });
+
+  describe("planUsageFromCopilotPlusUsage()", () => {
+    it("normalizes both windows, converting resetsAt from epoch seconds to milliseconds", () => {
+      const reading = planUsageFromCopilotPlusUsage(
+        {
+          used: {
+            five_hour: { usedPercent: 12, resetsAt: 1_755_300_000 },
+            weekly: { usedPercent: 34, resetsAt: 1_755_700_000 },
+          },
+        },
+        9_000
+      );
+
+      expect(reading).toEqual({
+        kind: "usage",
+        planUsage: {
+          windows: [
+            { id: "five_hour", label: "5h", percent: 12, resetsAt: 1_755_300_000_000 },
+            { id: "weekly", label: "Weekly", percent: 34, resetsAt: 1_755_700_000_000 },
+          ],
+          updatedAt: 9_000,
+        },
+      });
+    });
+
+    it("keeps a window whose reset time is missing, without one of its own", () => {
+      const reading = planUsageFromCopilotPlusUsage({ used: { weekly: { usedPercent: 5 } } }, 1);
+
+      expect(reading).toEqual({
+        kind: "usage",
+        planUsage: {
+          windows: [{ id: "weekly", label: "Weekly", percent: 5, resetsAt: undefined }],
+          updatedAt: 1,
+        },
+      });
+    });
+
+    it("passes a percentage above 100 through unclamped — the account is genuinely over", () => {
+      const reading = planUsageFromCopilotPlusUsage({ used: { weekly: { usedPercent: 137 } } }, 1);
+
+      expect(reading).toMatchObject({
+        kind: "usage",
+        planUsage: { windows: [expect.objectContaining({ percent: 137 })] },
+      });
+    });
+
+    it.each([
+      ["a null snapshot", null],
+      ["a snapshot with no used block", {}],
+      ["windows the normalizer does not recognize", { used: { daily: { usedPercent: 3 } } }],
+      ["windows without a readable percent", { used: { weekly: { usedPercent: "12" } } }],
+    ])(
+      "reports %s unusable rather than clearing the meters (https://github.com/logancyang/obsidian-copilot-preview/issues/193)",
+      (_label, snapshot) => {
+        // The endpoint omits a window both when the plan does not cap it and when the
+        // counters cannot be read. The two are indistinguishable, so neither may clear
+        // a meter the user is looking at.
+        expect(planUsageFromCopilotPlusUsage(snapshot as never)).toEqual({ kind: "unavailable" });
+      }
+    );
+  });
+
+  describe("parseContextLength()", () => {
+    it.each([
+      ["1M", 1_048_576],
+      ["256K", 262_144],
+      ["192k", 196_608],
+      ["8192", 8_192],
+      [" 64 K ", 65_536],
+    ])("reads %s as %i tokens (binary suffixes, as published)", (display, tokens) => {
+      expect(parseContextLength(display)).toBe(tokens);
+    });
+
+    it.each([
+      ["an unknown suffix", "1G"],
+      ["prose", "one million"],
+      ["a zero", "0"],
+      ["a negative", "-5K"],
+      ["a non-string", 200_000],
+      ["undefined", undefined],
+    ])("returns null for %s", (_label, display) => {
+      expect(parseContextLength(display)).toBeNull();
+    });
+  });
+
+  describe("CopilotPlusUsageReader", () => {
+    it("reads plan usage through the Brevilabs client", async () => {
+      mockGetUsage.mockResolvedValue({ used: { weekly: { usedPercent: 21 } } });
+
+      const reading = await new CopilotPlusUsageReader().readPlanUsage();
+
+      expect(reading).toMatchObject({
+        kind: "usage",
+        planUsage: { windows: [expect.objectContaining({ id: "weekly", percent: 21 })] },
+      });
+    });
+
+    it("answers context windows from one catalog fetch, shared across models and calls", async () => {
+      mockGetModels.mockResolvedValue({
+        data: [
+          { id: "gemini-3-pro", context_length: "1M" },
+          { id: "kimi-k2", context_length: "256K" },
+          { id: "no-window-published" },
+        ],
+      });
+      const reader = new CopilotPlusUsageReader();
+
+      await expect(reader.readContextWindow("gemini-3-pro")).resolves.toBe(1_048_576);
+      await expect(reader.readContextWindow("kimi-k2")).resolves.toBe(262_144);
+      await expect(reader.readContextWindow("no-window-published")).resolves.toBeNull();
+      await expect(reader.readContextWindow("not-in-catalog")).resolves.toBeNull();
+      expect(mockGetModels).toHaveBeenCalledTimes(1);
+    });
+
+    it("answers null for a null model id without touching the network", async () => {
+      // Null is the caller saying "not a Copilot Plus model" — its backend-specific
+      // prefix did not match — so there is nothing to look up.
+      await expect(new CopilotPlusUsageReader().readContextWindow(null)).resolves.toBeNull();
+      expect(mockGetModels).not.toHaveBeenCalled();
+    });
+
+    it("shares one in-flight fetch between concurrent callers", async () => {
+      let release!: (value: { data: { id: string; context_length: string }[] }) => void;
+      mockGetModels.mockReturnValue(new Promise((resolve) => (release = resolve)));
+      const reader = new CopilotPlusUsageReader();
+
+      const first = reader.readContextWindow("gemini-3-pro");
+      const second = reader.readContextWindow("kimi-k2");
+      release({
+        data: [
+          { id: "gemini-3-pro", context_length: "1M" },
+          { id: "kimi-k2", context_length: "256K" },
+        ],
+      });
+
+      await expect(first).resolves.toBe(1_048_576);
+      await expect(second).resolves.toBe(262_144);
+      expect(mockGetModels).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries after a failed catalog fetch instead of caching the failure (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
+      // One transient outage at the wrong moment must not strand the context ring on a
+      // bare token count for the rest of the session.
+      mockGetModels
+        .mockResolvedValueOnce(null)
+        .mockResolvedValue({ data: [{ id: "gemini-3-pro", context_length: "1M" }] });
+      const reader = new CopilotPlusUsageReader();
+
+      await expect(reader.readContextWindow("gemini-3-pro")).resolves.toBeNull();
+      await expect(reader.readContextWindow("gemini-3-pro")).resolves.toBe(1_048_576);
+      expect(mockGetModels).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/agentMode/backends/shared/copilotPlusUsage.ts
+++ b/src/agentMode/backends/shared/copilotPlusUsage.ts
@@ -1,0 +1,136 @@
+import type { PlanUsageReading, UsageWindow } from "@/agentMode/session/planUsage";
+import { planUsageReading, toUsagePercent } from "@/agentMode/session/planUsage";
+import { BrevilabsClient, type UsageResponse } from "@/LLMProviders/brevilabsClient";
+import { logInfo } from "@/logger";
+
+/**
+ * Copilot Plus account caps and model context windows, read from the Brevilabs hosts.
+ *
+ * Shared rather than owned by one backend: the caps belong to the Copilot Plus account,
+ * and the same models reach the agent through more than one backend. Each backend knows
+ * how its own wire ids are spelled and hands this module a bare Copilot Plus model id;
+ * nothing here knows or cares which backend asked.
+ */
+
+/** The windows the endpoint can report, in the order they should be shown. */
+const COPILOT_PLUS_WINDOWS: ReadonlyArray<readonly [string, string]> = [
+  ["five_hour", "5h"],
+  ["weekly", "Weekly"],
+];
+
+/**
+ * Epoch milliseconds from the endpoint's epoch SECONDS, or undefined when unusable.
+ * Providers disagree on encoding — Claude sends ISO 8601, this sends seconds — so each
+ * adapter converts its own.
+ */
+function epochSecondsToMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+  return Math.round(value * 1000);
+}
+
+/**
+ * Normalize the Brevilabs usage endpoint.
+ *
+ * The endpoint omits a window the plan does not cap, and returns no windows at all when
+ * the counters cannot be read. Those two are indistinguishable in the response, so
+ * neither clears the meters: an absent window is reported as an unusable read rather than
+ * as "this account has no caps"
+ * (https://github.com/logancyang/obsidian-copilot-preview/issues/193). Percentages above
+ * 100 are real — an account served past its cap on purchased credit — and pass through
+ * unclamped.
+ */
+export function planUsageFromCopilotPlusUsage(
+  snapshot: UsageResponse | null | undefined,
+  now: number = Date.now()
+): PlanUsageReading {
+  const used = snapshot?.used;
+  if (!used) return { kind: "unavailable" };
+
+  const windows: UsageWindow[] = [];
+  for (const [id, label] of COPILOT_PLUS_WINDOWS) {
+    const raw = used[id];
+    const percent = toUsagePercent(raw?.usedPercent);
+    if (percent === null) continue;
+    windows.push({ id, label, percent, resetsAt: epochSecondsToMs(raw?.resetsAt) });
+  }
+
+  return planUsageReading(windows, now);
+}
+
+/**
+ * Token count from the display string the models endpoint publishes (`1M`, `256K`,
+ * `192K`), or null when it is not a form we recognize.
+ *
+ * The suffixes are binary: `1M` is the 1,048,576-token Gemini window and `256K` the
+ * 262,144-token Kimi one, both rounded for display. Reading them as powers of ten would
+ * put every meter about 5% off — harmless for a gauge, but wrong for no reason.
+ */
+export function parseContextLength(display: unknown): number | null {
+  if (typeof display !== "string") return null;
+  const match = /^\s*([\d.]+)\s*([KMkm])?\s*$/.exec(display);
+  if (!match) return null;
+
+  const value = Number(match[1]);
+  if (!Number.isFinite(value) || value <= 0) return null;
+
+  const unit = match[2]?.toUpperCase();
+  const multiplier = unit === "M" ? 1024 * 1024 : unit === "K" ? 1024 : 1;
+  return Math.round(value * multiplier);
+}
+
+/**
+ * Reads Copilot Plus caps and model context windows on behalf of whichever backend is
+ * serving those models, caching the published catalog for that backend's lifetime.
+ *
+ * The catalog changes when we publish a new model list, not while a vault is open, so it
+ * is fetched at most once — but only a successful fetch is remembered. Caching a failure
+ * would strand the context ring for the rest of the session after one transient outage
+ * (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+ */
+export class CopilotPlusUsageReader {
+  private contextWindows: Map<string, number> | null = null;
+  private inFlight: Promise<Map<string, number> | null> | null = null;
+
+  /** The account's cap utilization as the models host currently reports it. */
+  async readPlanUsage(): Promise<PlanUsageReading> {
+    const snapshot = await BrevilabsClient.getInstance().getUsage();
+    return planUsageFromCopilotPlusUsage(snapshot);
+  }
+
+  /**
+   * Published context window of a Copilot Plus model.
+   *
+   * @param modelId - Bare Copilot Plus model id, with any backend-specific wire prefix
+   *   already stripped by the caller. Null for a model this account does not serve.
+   */
+  async readContextWindow(modelId: string | null): Promise<number | null> {
+    if (!modelId) return null;
+    const catalog = await this.loadCatalog();
+    return catalog?.get(modelId) ?? null;
+  }
+
+  private async loadCatalog(): Promise<Map<string, number> | null> {
+    if (this.contextWindows) return this.contextWindows;
+    // Share one request between concurrent callers, but do not remember a failed one.
+    this.inFlight ??= this.fetchCatalog().finally(() => {
+      this.inFlight = null;
+    });
+    const catalog = await this.inFlight;
+    if (catalog) this.contextWindows = catalog;
+    return catalog;
+  }
+
+  private async fetchCatalog(): Promise<Map<string, number> | null> {
+    const response = await BrevilabsClient.getInstance().getModels();
+    if (!response?.data) {
+      logInfo("[AgentMode] Copilot Plus catalog unavailable; context ring will retry");
+      return null;
+    }
+    const windows = new Map<string, number>();
+    for (const entry of response.data) {
+      const tokens = parseContextLength(entry?.context_length);
+      if (entry?.id && tokens !== null) windows.set(entry.id, tokens);
+    }
+    return windows;
+  }
+}

--- a/src/agentMode/session/AgentSession.test.ts
+++ b/src/agentMode/session/AgentSession.test.ts
@@ -508,6 +508,160 @@ describe("AgentSession session usage", () => {
     });
   });
 
+  it("fills a seeded snapshot's missing window from the backend catalog (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
+    // A reopened chat's persisted usage can predate the window being known — hosted
+    // models never carry one on the wire — and its ring must not wait for a turn.
+    const mock = makeMockBackend();
+    const readContextWindow = jest.fn(async () => 1_048_576);
+    (mock.asBackend as { readContextWindow?: unknown }).readContextWindow = readContextWindow;
+    const session = makeSession(mock);
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "state_changed",
+        state: {
+          model: {
+            current: { baseModelId: "copilot-plus/gemini-3-pro", effort: null },
+            apply: { kind: "setModel" },
+            availableModels: [],
+          },
+          mode: null,
+        },
+      },
+    });
+
+    session.seedSessionUsage({ usedTokens: 27_514, updatedAt: 1 });
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(readContextWindow).toHaveBeenCalledWith("copilot-plus/gemini-3-pro");
+    expect(session.getSessionUsage()).toEqual({
+      usedTokens: 27_514,
+      updatedAt: 1,
+      contextWindow: 1_048_576,
+    });
+  });
+
+  it("fills the window for a chat seeded into a still-starting session (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
+    // A chat with no resumable backend session is seeded into a freshly created one
+    // before newSession resolves, when the model is not yet known. The lookup must
+    // wait for readiness instead of silently skipping.
+    const mock = makeMockBackend();
+    const readContextWindow = jest.fn(async () => 1_048_576);
+    (mock.asBackend as { readContextWindow?: unknown }).readContextWindow = readContextWindow;
+    mock.newSession.mockResolvedValueOnce({
+      sessionId: "acp-1",
+      state: {
+        model: {
+          current: { baseModelId: "copilot-plus/gemini-3-pro", effort: null },
+          apply: { kind: "setModel" },
+          availableModels: [],
+        },
+        mode: null,
+      },
+    });
+    const session = AgentSession.start({
+      backend: mock.asBackend,
+      cwd: "/vault",
+      internalId: "internal-1",
+      backendId: "opencode",
+    });
+
+    // Seeded immediately, the way AgentSessionManager does — before `ready` settles.
+    session.seedSessionUsage({ usedTokens: 27_514, updatedAt: 1 });
+    await session.ready;
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(session.getSessionUsage()).toEqual({
+      usedTokens: 27_514,
+      updatedAt: 1,
+      contextWindow: 1_048_576,
+    });
+  });
+
+  it("leaves a live snapshot alone when the seed's window answer arrives late", async () => {
+    let release!: (window: number) => void;
+    const mock = makeMockBackend();
+    (mock.asBackend as { readContextWindow?: unknown }).readContextWindow = jest.fn(
+      () => new Promise((resolve) => (release = resolve))
+    );
+    const session = makeSession(mock);
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "state_changed",
+        state: {
+          model: {
+            current: { baseModelId: "copilot-plus/gemini-3-pro", effort: null },
+            apply: { kind: "setModel" },
+            availableModels: [],
+          },
+          mode: null,
+        },
+      },
+    });
+    session.seedSessionUsage({ usedTokens: 27_514, updatedAt: 1 });
+    // Let the readiness await settle so the catalog read is actually in flight.
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    // A live update lands while the catalog answer is still in flight.
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "usage_update",
+        usage: { usedTokens: 31_000, contextWindow: 200_000, updatedAt: 2 },
+      },
+    });
+    release(1_048_576);
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+    expect(session.getSessionUsage()).toEqual({
+      usedTokens: 31_000,
+      contextWindow: 200_000,
+      updatedAt: 2,
+    });
+  });
+
+  it("drops the held context window when the model changes, so the next snapshot applies (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", () => {
+    // The window belongs to the model that reported it. Kept across a switch to a
+    // model that reports none, it would pair the old window with new counts forever —
+    // the windowless-snapshot guard above would reject every later update.
+    const stateOn = (baseModelId: string): BackendState => ({
+      model: {
+        current: { baseModelId, effort: null },
+        apply: { kind: "setModel" },
+        availableModels: [],
+      },
+      mode: null,
+    });
+    const mock = makeMockBackend();
+    const session = makeSession(mock);
+    mock.emit({
+      sessionId: "acp-1",
+      update: { sessionUpdate: "state_changed", state: stateOn("copilot-plus/gemini-3-pro") },
+    });
+    mock.emit({
+      sessionId: "acp-1",
+      update: {
+        sessionUpdate: "usage_update",
+        usage: { usedTokens: 5000, contextWindow: 1_048_576, updatedAt: 1 },
+      },
+    });
+
+    mock.emit({
+      sessionId: "acp-1",
+      update: { sessionUpdate: "state_changed", state: stateOn("ollama/llama") },
+    });
+
+    expect(session.getSessionUsage()).toEqual({ usedTokens: 5000, updatedAt: 1 });
+
+    // And the new model's windowless snapshots are no longer rejected.
+    mock.emit({
+      sessionId: "acp-1",
+      update: { sessionUpdate: "usage_update", usage: { usedTokens: 800, updatedAt: 2 } },
+    });
+    expect(session.getSessionUsage()).toEqual({ usedTokens: 800, updatedAt: 2 });
+  });
+
   it("lets a fuller snapshot's contextWindow replace an earlier one", () => {
     const mock = makeMockBackend();
     const session = makeSession(mock);

--- a/src/agentMode/session/AgentSession.ts
+++ b/src/agentMode/session/AgentSession.ts
@@ -631,6 +631,7 @@ export class AgentSession {
       sessionId: this.backendSessionId,
       modelId,
     });
+    this.dropUsageWindowOnModelChange(next);
     this.currentState = next;
     this.notifyModelChanged();
   }
@@ -716,6 +717,8 @@ export class AgentSession {
       configId,
       value,
     });
+    // A config option can be the model itself (opencode ≥ 1.15.13).
+    this.dropUsageWindowOnModelChange(next);
     this.currentState = next;
     this.notifyModelChanged();
     this.clearCurrentPlanIfModeLeft();
@@ -1481,6 +1484,44 @@ export class AgentSession {
     if (!usage) return;
     this.currentUsage = usage;
     this.notifyMessages();
+    // A persisted snapshot can predate the model's window being known — hosted models
+    // never carry one on the wire, and older chats were saved before windows were
+    // filled in at all — so without this a reopened chat shows a bare count until its
+    // next turn (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+    if (usage.contextWindow === undefined) void this.fillSeededContextWindow(usage);
+  }
+
+  /**
+   * Ask the backend's catalog for the seeded snapshot's missing window and fill it in
+   * place. Quietly does nothing when the backend has no catalog, does not know the
+   * model, or the snapshot was superseded while the answer was in flight — a live
+   * update or a model switch is fresher than the seed by definition.
+   */
+  private async fillSeededContextWindow(seeded: SessionUsage): Promise<void> {
+    if (!this.backend.readContextWindow) return;
+    // A chat with no resumable backend session is seeded into a freshly created one,
+    // BEFORE its `newSession` has resolved — so at call time the model is not known
+    // yet. Wait for startup to settle rather than silently skipping, or exactly those
+    // older chats would stay count-only until their next turn
+    // (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+    try {
+      await this.ready;
+    } catch {
+      return;
+    }
+    const wireModelId = this.currentState?.model?.current.baseModelId ?? null;
+    if (!wireModelId) return;
+    let contextWindow: number | null = null;
+    try {
+      contextWindow = await this.backend.readContextWindow(wireModelId);
+    } catch {
+      return;
+    }
+    if (!contextWindow) return;
+    if (this.currentUsage !== seeded) return;
+    if (this.currentState?.model?.current.baseModelId !== wireModelId) return;
+    this.currentUsage = { ...seeded, contextWindow };
+    this.notifyMessages();
   }
 
   /**
@@ -1496,6 +1537,25 @@ export class AgentSession {
       return;
     }
     this.currentUsage = usage;
+    this.notifyMessages();
+  }
+
+  /**
+   * Drop the held context window when the session's model changes, keeping the count.
+   *
+   * The window belongs to the model that reported it. Without this, switching to a
+   * model that reports no window would leave the old model's window in place forever:
+   * {@link applyUsageUpdate} ignores windowless snapshots while a windowed one is held,
+   * so no later update could correct the meter. With the window dropped, the next
+   * snapshot applies, and the ring re-forms once the new model's window is learned
+   * (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+   */
+  private dropUsageWindowOnModelChange(next: BackendState | null): void {
+    const before = this.currentState?.model?.current.baseModelId;
+    const after = next?.model?.current.baseModelId;
+    if (!before || !after || before === after) return;
+    if (this.currentUsage?.contextWindow === undefined) return;
+    this.currentUsage = { ...this.currentUsage, contextWindow: undefined };
     this.notifyMessages();
   }
 
@@ -1764,6 +1824,7 @@ export class AgentSession {
       return;
     }
     if (update.sessionUpdate === "state_changed") {
+      this.dropUsageWindowOnModelChange(update.state);
       this.currentState = update.state;
       this.notifyModelChanged();
       this.clearCurrentPlanIfModeLeft();

--- a/src/agentMode/session/types.ts
+++ b/src/agentMode/session/types.ts
@@ -768,6 +768,15 @@ export interface BackendProcess {
    * sessions; ACP backends governed by the shared prompter omit it.
    */
   setReadOnlySessionPredicate?(fn: (sessionId: SessionId) => boolean): void;
+  /**
+   * Optional: the context window of a model, in tokens, when the backend knows it from
+   * a catalog of its own rather than the session stream. A reopened chat's persisted
+   * usage can predate the window being known — hosted models never carry one on the
+   * wire — and its ring must not wait for the next turn, so the session asks here at
+   * seed time. Missing means the stream is the only window source. Resolves rather
+   * than throws; null means the backend does not know this model's window.
+   */
+  readContextWindow?(wireModelId: string | null | undefined): Promise<number | null>;
   registerSessionHandler(sessionId: SessionId, handler: SessionUpdateHandler): () => void;
   newSession(params: OpenSessionInput): Promise<OpenSessionOutput>;
   prompt(params: PromptInput): Promise<PromptOutput>;


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#193

## Why

The previous PR in this stack gives Claude Code sessions their plan caps. A user on Copilot's own models still saw none — and saw less than that, because the backend they run through never advertises a context window either, so the meter fell back to a bare token count with no ring and no bar. Two users of the same feature got visibly different products.

Their caps are also not knowable the same way. Claude reports its own through the session; Copilot Plus caps belong to the account and are enforced by the model proxy, so nothing in the session stream can report them. And unlike a Claude login, the agent serving these models serves other billing sources too: the same process can host one chat on a Copilot Plus model and another on the user's own API key, and only the first is metered by these caps.

## What

Copilot Plus sessions get the same meter Claude Code sessions have: a ring in the control row, and a tooltip with a context bar followed by a row per cap window.

> **Before:** a `27k` chip. Hovering it says `Context used: 27,514` and nothing more — no percentage, because nothing tells the plugin how big the window is, and no caps.
>
> **After:** a ring showing `31.2k / 1.0M (3%)`, then `5h · resets in 1h 13m` and `Weekly · resets in 1d 20h` with percentages and bars.

Both figures come from the models host: the caps from its usage endpoint, read when the first chat opens and again at the end of every turn — the moments the numbers move — and the context window from its public model catalog, fetched once and remembered only on success, so one transient outage cannot strand the ring for the rest of the session. A reopened chat gets its ring before its first turn too: its persisted usage snapshot may predate the window being known, so the missing window is filled from the same catalog at load.

Selection is the whole test for showing the caps. A session on a `copilot-plus/` model is metered by them; one on the user's own key shares the agent process but not the billing, and shows none. Switching models re-sends the session's view at once — off Copilot Plus clears the rows immediately, onto it shows the cached snapshot immediately — rather than leaving numbers on screen that describe a model no longer in use. A failed read keeps the last good snapshot rather than blanking a meter mid-read, and a context length that will not parse leaves the count-only form rather than sizing a ring against a guess.

Because the caps describe the account, one read is broadcast to every open chat on the process, each behind its own model gate, and a snapshot never survives the agent restarting — the next start may be authenticated differently.

## Non goal

- No caps for Codex. Its adapter files the rate limits away without forwarding them over ACP, so they need their own read side — the next PR in this stack.
- Does not bound how fast a client may poll; that has to sit in front of authentication to protect anything, which is its own change.
- Does not add context-window data to the models service. The catalog already publishes it, so it is read rather than duplicated.

## Screenshot

Rendered in the test vault on `copilot-plus-flash`, hovering the meter: a ring in the control row, then `Context window 31.2k / 1.0M (3%)` with a bar, then `5h · resets in 1h 13m — 0%` and `Weekly · resets in 1d 20h — 2%`.

Image not attached: the terminal running this work lacks macOS Screen Recording permission, so the capture could not be taken programmatically. The layout is byte-identical to the Claude Code tooltip in the previous PR, since both render through the same component.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `copilotPlusUsage.test.ts` covers the response shapes, context-length parsing, catalog retry, and every empty case; the `AcpBackendProcess` suites cover broadcast, replay, expiry, the shutdown race, the model gate, and window enrichment |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a wrong percentage is visible the first time the tooltip opens |
| A revert fully restores prior state, including persisted data | ✅ | Nothing persisted; every read is in-memory and dies with the process |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Sends the existing license key to a second Brevilabs host, the models service, which the plugin already talks to for chat |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Consumes two existing endpoints; adds no route and changes no stored format |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | An unawaited cap refresh joins the turn boundary in `AcpBackendProcess.prompt`, and a windowless usage snapshot is republished asynchronously once its window resolves |
| No hot-path behavior lacks deterministic coverage | ✅ | The turn-boundary refresh never blocks the reply — it is fired after the prompt resolves — and the race a slow read can lose against shutdown has a regression test |
| No new dependency | ✅ | `package.json` unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the usage meter; a wrong number appears on the next tooltip open and affects no request that is served |

Review: inspect `src/agentMode/acp/AcpBackendProcess.ts` — `refreshPlanUsage`, `planUsageFor`, `republishPlanUsage`, and `withBackendContextWindow`/`resolveBackendContextWindow` — line by line, confirming a failed read cannot clear a meter and a shutdown cannot be outlived by an in-flight one. Then `CopilotPlusUsageReader.loadCatalog` in `src/agentMode/backends/shared/copilotPlusUsage.ts`, confirming only a successful fetch is cached. Then `getUsage` and `getModels` in `src/LLMProviders/brevilabsClient.ts`, confirming both target `BREVILABS_MODELS_BASE_URL` and return null rather than throwing. Then run Verification steps 2–4, including the model-switch variant.

## Verification

1. Build the branch into a vault (`npm run test:vault`) with a valid Copilot Plus license, and open Agent Mode.
2. Select `copilot-plus-flash` and hover the meter in the composer's control row. Expect a ring, a context bar with a percentage, and `5h` and `Weekly` rows. Compare the percentages against the same account's dashboard at obsidiancopilot.com/en/dashboard/token-usage.
3. Send a message and hover again after the turn ends. The cap percentages should track the dashboard.
4. Switch to a model outside Copilot Plus. The cap rows should disappear at once rather than showing the previous model's numbers; switch back and they should reappear without waiting for a turn.
5. Open an older saved chat that used a Copilot Plus model, without sending anything. The meter should show the ring with a percentage, not a bare token count.

## Note

The usage endpoint lives on the models host, not the tools and license API this client otherwise talks to. The caps are enforced by the model proxy on the request path, so their read side sits beside them; `api.brevilabs.com` has no such route and answers 404.

The catalog publishes each window as a display string, and its suffixes are binary: `1M` is the 1,048,576-token Gemini window and `256K` the 262,144-token Kimi one, both rounded for display. Reading them as powers of ten would put every meter about 5% off for no reason.

The reader lives in `backends/shared/` and speaks only bare Copilot Plus model ids: the same hosted models will be reachable through more than one agent backend (Pi is planned), so each backend strips its own wire prefix — opencode via `copilotPlusModelId` — and a future backend adds one mapping function and nothing else.
