### PR TITLE
Restore local Ollama Quick Chat

### DIFF
--- a/src/LLMProviders/chatModelManager.bridge.test.ts
+++ b/src/LLMProviders/chatModelManager.bridge.test.ts
@@ -47,132 +47,163 @@ function bridgedModel(overrides: Partial<CustomModel> = {}): CustomModel {
   };
 }
 
-describe("ChatModelManager bridged models", () => {
-  const originalOpenAiKey = getSettings().openAIApiKey;
+describe("chatModelManager", () => {
+  describe("ChatModelManager", () => {
+    const originalOpenAiKey = getSettings().openAIApiKey;
 
-  afterEach(() => {
-    setSettings({ openAIApiKey: originalOpenAiKey });
-  });
-
-  it("does not fall back to a legacy top-level provider key", async () => {
-    setSettings({ openAIApiKey: "legacy-key" });
-
-    await expect(
-      ChatModelManager.getInstance().createModelInstanceFromBridged(bridgedModel())
-    ).rejects.toBeInstanceOf(MissingApiKeyError);
-  });
-
-  it("findModelByName falls back to the active bridged model so its capabilities resolve", async () => {
-    const manager = ChatModelManager.getInstance();
-    // A vision-capable Plus model that exists only as a bridged ConfiguredModel
-    // (not in legacy activeModels) — e.g. kimi-k2.7-code.
-    const model = bridgedModel({
-      name: "kimi-k2.7-code",
-      provider: ChatModelProviders.COPILOT_PLUS,
-      apiKey: "bridge-key",
-      capabilities: [ModelCapability.VISION],
+    afterEach(() => {
+      setSettings({ openAIApiKey: originalOpenAiKey });
     });
 
-    // Not findable before it's the active bridged model...
-    expect(manager.findModelByName("kimi-k2.7-code")).toBeUndefined();
+    describe("createModelInstanceFromBridged()", () => {
+      it("does not fall back to a legacy top-level provider key", async () => {
+        setSettings({ openAIApiKey: "legacy-key" });
 
-    await manager.setChatModelFromBridged(model);
+        await expect(
+          ChatModelManager.getInstance().createModelInstanceFromBridged(bridgedModel())
+        ).rejects.toBeInstanceOf(MissingApiKeyError);
+      });
 
-    // ...now resolvable by name, carrying its VISION capability so
-    // isMultimodalModel/hasCapability route images instead of dropping them.
-    const found = manager.findModelByName("kimi-k2.7-code");
-    expect(found).toBe(model);
-    expect(found?.capabilities).toContain(ModelCapability.VISION);
+      it("sends the plugin version with Copilot Plus chat requests", async () => {
+        const OpenRouterMock = jest.requireMock("./ChatOpenRouter").ChatOpenRouter as {
+          configs: Array<{ configuration?: { defaultHeaders?: Record<string, string> } }>;
+        };
+        BrevilabsClient.getInstance().setPluginVersion("4.0.0-preview-260802");
 
-    // A different name never resolves to the active bridged model.
-    expect(manager.findModelByName("some-other-model")).toBeUndefined();
-  });
+        await ChatModelManager.getInstance().createModelInstanceFromBridged(
+          bridgedModel({ provider: ChatModelProviders.COPILOT_PLUS, apiKey: "bridge-key" })
+        );
 
-  it("prefers the active bridged model over a legacy duplicate of the same id", async () => {
-    const manager = ChatModelManager.getInstance();
-    // copilot-plus-flash exists in legacy activeModels (built-in) advertising only
-    // VISION, AND as a bridged model now also carrying REASONING. The bridged one
-    // is what's running, so it must win — otherwise hasCapability(REASONING) reads
-    // the legacy entry and reasoning content is dropped.
-    const legacyFlash = {
-      name: "copilot-plus-flash",
-      provider: ChatModelProviders.COPILOT_PLUS,
-      enabled: true,
-      capabilities: [ModelCapability.VISION],
-    };
-    setSettings({ activeModels: [legacyFlash] });
+        expect(OpenRouterMock.configs.at(-1)?.configuration?.defaultHeaders).toEqual({
+          "X-Client-Version": "4.0.0-preview-260802",
+        });
+      });
 
-    const bridged = bridgedModel({
-      name: "copilot-plus-flash",
-      provider: ChatModelProviders.COPILOT_PLUS,
-      apiKey: "bridge-key",
-      capabilities: [ModelCapability.VISION, ModelCapability.REASONING],
-    });
-    await manager.setChatModelFromBridged(bridged);
+      it("does not add a browser-only flag as an OpenAI-compatible request header", async () => {
+        const model = await ChatModelManager.getInstance().createModelInstanceFromBridged(
+          bridgedModel({
+            provider: ChatModelProviders.OPENAI_FORMAT,
+            apiKey: "default-key",
+            baseUrl: "http://localhost:11434/v1",
+          })
+        );
+        const clientConfig = (
+          model as unknown as {
+            clientConfig: {
+              dangerouslyAllowBrowser?: boolean;
+              defaultHeaders?: Record<string, string>;
+            };
+          }
+        ).clientConfig;
 
-    const found = manager.findModelByName("copilot-plus-flash");
-    expect(found).toBe(bridged);
-    expect(found?.capabilities).toEqual(
-      expect.arrayContaining([ModelCapability.VISION, ModelCapability.REASONING])
-    );
+        expect(clientConfig.dangerouslyAllowBrowser).toBe(true);
+        expect(clientConfig.defaultHeaders?.["dangerously-allow-browser"]).toBeUndefined();
+      });
 
-    setSettings({ activeModels: [] });
-  });
+      it("strips a versioned Google base URL because the client appends /v1beta itself", async () => {
+        const GoogleMock = jest.requireMock("@langchain/google-genai").ChatGoogleGenerativeAI as {
+          configs: Array<{ baseUrl?: string }>;
+        };
+        const model = bridgedModel({
+          name: "gemini-2.5-flash",
+          provider: ChatModelProviders.GOOGLE,
+          apiKey: "g-key",
+          baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        });
 
-  it("sends the plugin version with Copilot Plus chat requests", async () => {
-    const OpenRouterMock = jest.requireMock("./ChatOpenRouter").ChatOpenRouter as {
-      configs: Array<{ configuration?: { defaultHeaders?: Record<string, string> } }>;
-    };
-    BrevilabsClient.getInstance().setPluginVersion("4.0.0-preview-260802");
+        await ChatModelManager.getInstance().createModelInstanceFromBridged(model);
 
-    await ChatModelManager.getInstance().createModelInstanceFromBridged(
-      bridgedModel({ provider: ChatModelProviders.COPILOT_PLUS, apiKey: "bridge-key" })
-    );
+        expect(GoogleMock.configs.at(-1)?.baseUrl).toBe(
+          "https://generativelanguage.googleapis.com"
+        );
+      });
 
-    expect(OpenRouterMock.configs.at(-1)?.configuration?.defaultHeaders).toEqual({
-      "X-Client-Version": "4.0.0-preview-260802",
-    });
-  });
+      it("strips a versioned Groq base URL because the client appends /openai/v1 itself", async () => {
+        const GroqMock = jest.requireMock("@langchain/groq").ChatGroq as {
+          configs: Array<{ baseUrl?: string }>;
+        };
+        const model = bridgedModel({
+          name: "llama-3.3-70b-versatile",
+          provider: ChatModelProviders.GROQ,
+          apiKey: "gq-key",
+          baseUrl: "https://api.groq.com/openai/v1",
+        });
 
-  it("retains the active bridged model for temperature overrides", async () => {
-    const manager = ChatModelManager.getInstance();
-    const model = bridgedModel({ apiKey: "bridge-key" });
+        await ChatModelManager.getInstance().createModelInstanceFromBridged(model);
 
-    await manager.setChatModelFromBridged(model);
-
-    expect(manager.getActiveModel()).toBe(model);
-    await expect(manager.getChatModelWithTemperature(0)).resolves.toBeDefined();
-  });
-
-  it("strips a versioned Google base URL — ChatGoogleGenerativeAI appends /v1beta itself", async () => {
-    const GoogleMock = jest.requireMock("@langchain/google-genai").ChatGoogleGenerativeAI as {
-      configs: Array<{ baseUrl?: string }>;
-    };
-    const model = bridgedModel({
-      name: "gemini-2.5-flash",
-      provider: ChatModelProviders.GOOGLE,
-      apiKey: "g-key",
-      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+        expect(GroqMock.configs.at(-1)?.baseUrl).toBe("https://api.groq.com");
+      });
     });
 
-    await ChatModelManager.getInstance().createModelInstanceFromBridged(model);
+    describe("findModelByName()", () => {
+      it("falls back to the active bridged model so its capabilities resolve", async () => {
+        const manager = ChatModelManager.getInstance();
+        // A vision-capable Plus model that exists only as a bridged ConfiguredModel
+        // (not in legacy activeModels) — e.g. kimi-k2.7-code.
+        const model = bridgedModel({
+          name: "kimi-k2.7-code",
+          provider: ChatModelProviders.COPILOT_PLUS,
+          apiKey: "bridge-key",
+          capabilities: [ModelCapability.VISION],
+        });
 
-    expect(GoogleMock.configs.at(-1)?.baseUrl).toBe("https://generativelanguage.googleapis.com");
-  });
+        // Not findable before it's the active bridged model...
+        expect(manager.findModelByName("kimi-k2.7-code")).toBeUndefined();
 
-  it("strips a versioned Groq base URL — groq-sdk appends /openai/v1 itself", async () => {
-    const GroqMock = jest.requireMock("@langchain/groq").ChatGroq as {
-      configs: Array<{ baseUrl?: string }>;
-    };
-    const model = bridgedModel({
-      name: "llama-3.3-70b-versatile",
-      provider: ChatModelProviders.GROQ,
-      apiKey: "gq-key",
-      baseUrl: "https://api.groq.com/openai/v1",
+        await manager.setChatModelFromBridged(model);
+
+        // ...now resolvable by name, carrying its VISION capability so
+        // isMultimodalModel/hasCapability route images instead of dropping them.
+        const found = manager.findModelByName("kimi-k2.7-code");
+        expect(found).toBe(model);
+        expect(found?.capabilities).toContain(ModelCapability.VISION);
+
+        // A different name never resolves to the active bridged model.
+        expect(manager.findModelByName("some-other-model")).toBeUndefined();
+      });
+
+      it("prefers the active bridged model over a legacy duplicate of the same id", async () => {
+        const manager = ChatModelManager.getInstance();
+        // copilot-plus-flash exists in legacy activeModels (built-in) advertising only
+        // VISION, AND as a bridged model now also carrying REASONING. The bridged one
+        // is what's running, so it must win — otherwise hasCapability(REASONING) reads
+        // the legacy entry and reasoning content is dropped.
+        const legacyFlash = {
+          name: "copilot-plus-flash",
+          provider: ChatModelProviders.COPILOT_PLUS,
+          enabled: true,
+          capabilities: [ModelCapability.VISION],
+        };
+        setSettings({ activeModels: [legacyFlash] });
+
+        const bridged = bridgedModel({
+          name: "copilot-plus-flash",
+          provider: ChatModelProviders.COPILOT_PLUS,
+          apiKey: "bridge-key",
+          capabilities: [ModelCapability.VISION, ModelCapability.REASONING],
+        });
+        await manager.setChatModelFromBridged(bridged);
+
+        const found = manager.findModelByName("copilot-plus-flash");
+        expect(found).toBe(bridged);
+        expect(found?.capabilities).toEqual(
+          expect.arrayContaining([ModelCapability.VISION, ModelCapability.REASONING])
+        );
+
+        setSettings({ activeModels: [] });
+      });
     });
 
-    await ChatModelManager.getInstance().createModelInstanceFromBridged(model);
+    describe("getChatModelWithTemperature()", () => {
+      it("retains the active bridged model for temperature overrides", async () => {
+        const manager = ChatModelManager.getInstance();
+        const model = bridgedModel({ apiKey: "bridge-key" });
 
-    expect(GroqMock.configs.at(-1)?.baseUrl).toBe("https://api.groq.com");
+        await manager.setChatModelFromBridged(model);
+
+        expect(manager.getActiveModel()).toBe(model);
+        await expect(manager.getChatModelWithTemperature(0)).resolves.toBeDefined();
+      });
+    });
   });
 });

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -429,7 +429,6 @@ export default class ChatModelManager {
         configuration: {
           baseURL: customModel.baseUrl,
           fetch: customModel.enableCors ? safeFetch : undefined,
-          defaultHeaders: { "dangerously-allow-browser": "true" },
         },
         ...this.getOpenAISpecialConfig(
           modelName,


### PR DESCRIPTION
Fixes #2810

## Why

Copilot v4 Quick Chat sends Ollama requests through the generic OpenAI-compatible streaming client. That path added `dangerously-allow-browser` as an HTTP header, which Ollama rejects during CORS preflight. As a result, provider verification succeeds but Quick Chat fails with `Failed to fetch` before the request reaches Ollama.

## What

> **Before:** A direct Ollama Quick Chat request is stopped by CORS because it includes the unsupported `dangerously-allow-browser` header.
>
> **After:** The browser-only setting stays in the OpenAI client configuration and is no longer sent as an HTTP header, so the request can pass preflight and reach Ollama.

## Non goal

This does not change OpenCode Agent Mode, provider routing, or route Ollama back through the native LangChain `ChatOllama` adapter.

## Screenshot

Not applicable — this changes Quick Chat's HTTP request configuration and has no visual state.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | The OpenAI-compatible client test covers both the browser option and emitted default headers |
| A defect would fail CI or be obvious on first use | ✅ | Reintroducing the header fails the focused client-configuration test |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data or migration is involved |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | API-key handling and request content are unchanged |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Only an internal client header is removed |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Request construction remains synchronous and otherwise unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | The OpenAI-compatible constructor configuration is covered directly |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A bad result appears on the next local Ollama Quick Chat request |

Review: inspect `src/LLMProviders/chatModelManager.ts` — `ChatModelManager.getModelConfig()`'s OpenAI-format case — and `src/LLMProviders/chatModelManager.bridge.test.ts` — `createModelInstanceFromBridged()` coverage — then run Verification steps 2–4.

## Verification

1. Start Ollama with a local chat model available.
2. In Copilot v4, configure the Ollama provider with `http://localhost:11434/v1`, select that model, and leave **Enable CORS** off to exercise streaming fetch.
3. Send a prompt in Quick Chat.
4. Confirm the response streams and DevTools shows no CORS rejection for a `dangerously-allow-browser` request header.
