### PR TITLE
[Agent usage caps] - Step 3: Show Codex plan caps

### DIFF
--- a/src/agentMode/backends/codex/CodexBackend.ts
+++ b/src/agentMode/backends/codex/CodexBackend.ts
@@ -3,6 +3,8 @@ import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
 import { buildSimpleSpawnDescriptor } from "@/agentMode/backends/shared/simpleBinaryBackend";
 import { buildAgentSystemPrompt } from "@/agentMode/backends/shared/agentSystemPrompt";
 import { buildBuiltinSkillEnv } from "@/agentMode/backends/shared/builtinSkillEnv";
+import type { PlanUsageReading } from "@/agentMode/session/planUsage";
+import { defaultCodexHome, readCodexPlanUsage } from "./codexPlanUsage";
 import { mergeCodexConfigEnv } from "./codexConfigEnv";
 
 /**
@@ -16,6 +18,13 @@ import { mergeCodexConfigEnv } from "./codexConfigEnv";
 export class CodexBackend implements AcpBackend {
   readonly id = "codex" as const;
   readonly displayName = "Codex";
+
+  /**
+   * Where the spawned Codex keeps its state, taken from the env we actually gave it so a
+   * user who redirects `CODEX_HOME` has their caps read from the same place Codex writes
+   * them. Null until the first spawn, because until then there is no Codex to read from.
+   */
+  private codexHome: string | null = null;
 
   constructor(private readonly clientVersion = "") {}
 
@@ -63,7 +72,17 @@ export class CodexBackend implements AcpBackend {
     ];
     // Deliberately no `project_doc_fallback_filenames=["project.md"]`: project.md is metadata,
     // while Codex discovers the canonical AGENTS.md instructions from the session cwd.
+    this.codexHome = descriptor.env.CODEX_HOME ?? defaultCodexHome();
     return descriptor;
+  }
+
+  /**
+   * Codex's caps, read back from the rollout it writes for every turn. See
+   * `codexPlanUsage.ts` for why that file is the only structured source a client has.
+   * Before the first spawn there is no Codex to read from, so there is no news yet.
+   */
+  async readPlanUsage(): Promise<PlanUsageReading> {
+    return this.codexHome === null ? { kind: "unavailable" } : readCodexPlanUsage(this.codexHome);
   }
 }
 

--- a/src/agentMode/backends/codex/codexPlanUsage.test.ts
+++ b/src/agentMode/backends/codex/codexPlanUsage.test.ts
@@ -1,0 +1,338 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { PlanUsageReading, UsageWindow } from "@/agentMode/session/planUsage";
+import { lastRateLimits, planUsageFromCodexRateLimits, readCodexPlanUsage } from "./codexPlanUsage";
+
+jest.mock("@/logger", () => ({ logInfo: jest.fn() }));
+
+const UNAVAILABLE: PlanUsageReading = { kind: "unavailable" };
+
+/** The windows of a usage reading, or the empty list for any other kind. */
+function windowsOf(reading: PlanUsageReading): UsageWindow[] {
+  return reading.kind === "usage" ? reading.planUsage.windows : [];
+}
+
+describe("codexPlanUsage", () => {
+  describe("planUsageFromCodexRateLimits()", () => {
+    /** The `rate_limits` object from a real Codex rollout, on a Pro account. */
+    const LIVE_PRO_SNAPSHOT = {
+      limit_id: "codex",
+      limit_name: null,
+      primary: { used_percent: 13.0, window_minutes: 10_080, resets_at: 1_787_196_738 },
+      secondary: null,
+      credits: { has_credits: false, unlimited: false, balance: "0" },
+      plan_type: "pro",
+    };
+
+    it("reads the single weekly window a Pro account reports", () => {
+      // Codex fills `primary` with whatever window the plan has, so on this account the
+      // weekly cap arrives in the slot other plans use for a shorter one. Naming the row
+      // after the slot would have labelled this "5h".
+      const reading = planUsageFromCodexRateLimits(LIVE_PRO_SNAPSHOT, 1_000);
+
+      expect(reading).toEqual({
+        kind: "usage",
+        planUsage: {
+          windows: [{ id: "primary", label: "Weekly", percent: 13.0, resetsAt: 1_787_196_738_000 }],
+          updatedAt: 1_000,
+        },
+      });
+    });
+
+    it("reads both windows when the plan caps two", () => {
+      const reading = planUsageFromCodexRateLimits({
+        primary: { used_percent: 42, window_minutes: 300, resets_at: 1_787_196_738 },
+        secondary: { used_percent: 8, window_minutes: 10_080, resets_at: 1_787_800_000 },
+      });
+
+      expect(windowsOf(reading).map((w) => [w.label, w.percent])).toEqual([
+        ["5h", 42],
+        ["Weekly", 8],
+      ]);
+    });
+
+    it.each([
+      ["a five-hour window", 300, "5h"],
+      ["a weekly window", 10_080, "Weekly"],
+      ["a daily window", 1440, "1d"],
+      ["a fortnight", 20_160, "14d"],
+      ["a sub-hour window", 45, "45m"],
+      ["an odd duration", 90, "90m"],
+    ])("labels %s", (_label, windowMinutes, expected) => {
+      const reading = planUsageFromCodexRateLimits({
+        primary: { used_percent: 1, window_minutes: windowMinutes },
+      });
+
+      expect(windowsOf(reading)[0]?.label).toBe(expected);
+    });
+
+    it("keeps a percentage above 100 for an account served past its cap", () => {
+      const reading = planUsageFromCodexRateLimits({
+        primary: { used_percent: 118, window_minutes: 10_080 },
+      });
+
+      expect(windowsOf(reading)[0]?.percent).toBe(118);
+    });
+
+    it("keeps the window when its reset is missing", () => {
+      const reading = planUsageFromCodexRateLimits({
+        primary: { used_percent: 13, window_minutes: 10_080, resets_at: null },
+      });
+
+      expect(windowsOf(reading)[0]?.resetsAt).toBeUndefined();
+    });
+
+    it("drops a window whose duration it cannot name", () => {
+      // A percentage with no window is a number with no meaning attached; rendering it
+      // would put an unlabelled row in front of the user.
+      const reading = planUsageFromCodexRateLimits({
+        primary: { used_percent: 13, window_minutes: null },
+        secondary: { used_percent: 8, window_minutes: 10_080 },
+      });
+
+      expect(windowsOf(reading).map((w) => w.id)).toEqual(["secondary"]);
+    });
+
+    it.each([
+      ["a failed read", null],
+      ["a snapshot with no windows", {}],
+      ["windows the plan does not cap", { primary: null, secondary: null }],
+      ["a window with no percentage", { primary: { window_minutes: 10_080 } }],
+    ])(
+      "reports %s unavailable rather than clearing the meters (https://github.com/logancyang/obsidian-copilot-preview/issues/193)",
+      (_label, limits) => {
+        // A rollout can never affirm that an account is unmetered, so an empty snapshot
+        // is the absence of news, never a statement that clears a meter.
+        expect(planUsageFromCodexRateLimits(limits as never)).toEqual(UNAVAILABLE);
+      }
+    );
+  });
+
+  describe("readCodexPlanUsage()", () => {
+    /**
+     * A future reset, because the reader drops windows whose recorded reset has passed
+     * — a fixed instant here would expire and start failing these tests on real time.
+     */
+    const RESETS_AT_SECONDS = Math.floor(Date.now() / 1000) + 3_600;
+
+    /** A `token_count` event as Codex appends it, trimmed to the fields this reads. */
+    function tokenCountLine(
+      usedPercent: number,
+      windowMinutes = 10_080,
+      resetsAt = RESETS_AT_SECONDS
+    ): string {
+      return JSON.stringify({
+        timestamp: "2026-08-15T04:39:03.544Z",
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: { model_context_window: 258_400 },
+          rate_limits: {
+            limit_id: "codex",
+            primary: {
+              used_percent: usedPercent,
+              window_minutes: windowMinutes,
+              resets_at: resetsAt,
+            },
+            secondary: null,
+          },
+        },
+      });
+    }
+
+    let codexHome: string;
+
+    beforeEach(() => {
+      codexHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-plan-usage-"));
+    });
+
+    afterEach(() => {
+      fs.rmSync(codexHome, { recursive: true, force: true });
+    });
+
+    /** Write a rollout under `sessions/<day>/`, optionally stamping its modification time. */
+    function writeRollout(day: string, name: string, lines: string[], mtime?: Date): string {
+      const dir = path.join(codexHome, "sessions", ...day.split("/"));
+      fs.mkdirSync(dir, { recursive: true });
+      const file = path.join(dir, name);
+      fs.writeFileSync(file, lines.join("\n") + "\n");
+      if (mtime) fs.utimesSync(file, mtime, mtime);
+      return file;
+    }
+
+    it("reads the newest rate limits from the rollout", async () => {
+      writeRollout("2026/08/14", "rollout-2026-08-14T21-38-38-abc.jsonl", [
+        tokenCountLine(11),
+        tokenCountLine(13),
+      ]);
+
+      const reading = await readCodexPlanUsage(codexHome);
+
+      expect(windowsOf(reading)).toEqual([
+        { id: "primary", label: "Weekly", percent: 13, resetsAt: RESETS_AT_SECONDS * 1000 },
+      ]);
+    });
+
+    it("takes the most recently written rollout, not the most recently dated directory", async () => {
+      // A session opened yesterday and still running now keeps appending to yesterday's
+      // directory, so the newest numbers can sit behind an older-looking path.
+      writeRollout(
+        "2026/09/01",
+        "rollout-2026-09-01T00-05-00-new.jsonl",
+        [tokenCountLine(4)],
+        new Date("2026-09-01T00:05:00Z")
+      );
+      writeRollout(
+        "2026/08/31",
+        "rollout-2026-08-31T09-00-00-old.jsonl",
+        [tokenCountLine(37)],
+        new Date("2026-09-01T22:00:00Z")
+      );
+
+      const reading = await readCodexPlanUsage(codexHome);
+
+      expect(windowsOf(reading)[0]?.percent).toBe(37);
+    });
+
+    it("reports a snapshot whose recorded reset has passed unavailable (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
+      // A rollout can be arbitrarily old. After a long idle, presenting the finished
+      // period's 95% as current would be worse than showing nothing.
+      writeRollout("2026/08/10", "rollout-2026-08-10T10-00-00-idle.jsonl", [
+        tokenCountLine(95, 10_080, Math.floor(Date.now() / 1000) - 60),
+      ]);
+
+      await expect(readCodexPlanUsage(codexHome)).resolves.toEqual(UNAVAILABLE);
+    });
+
+    it("falls back past a rollout that has no limits recorded yet (https://github.com/logancyang/obsidian-copilot-preview/issues/193)", async () => {
+      // Opening a chat creates a rollout holding only session metadata, and on a fresh
+      // plugin start there is no in-memory snapshot to keep showing — the account's
+      // last recorded caps live in the next-newest file.
+      writeRollout(
+        "2026/08/14",
+        "rollout-2026-08-14T09-00-00-prior.jsonl",
+        [tokenCountLine(13)],
+        new Date("2026-08-14T09:00:00Z")
+      );
+      writeRollout(
+        "2026/08/14",
+        "rollout-2026-08-14T10-00-00-fresh.jsonl",
+        [JSON.stringify({ type: "session_meta", payload: { id: "new-session" } })],
+        new Date("2026-08-14T10:00:00Z")
+      );
+
+      const reading = await readCodexPlanUsage(codexHome);
+
+      expect(windowsOf(reading)[0]?.percent).toBe(13);
+    });
+
+    it("still finds a session active for days behind newer day directories", async () => {
+      // A rollout is filed under the day its session STARTED, so a chat kept open all
+      // week appends to a directory several dates behind the newest one.
+      for (let day = 11; day <= 14; day++) {
+        writeRollout(
+          `2026/08/${day}`,
+          `rollout-2026-08-${day}T09-00-00-done.jsonl`,
+          [tokenCountLine(day)],
+          new Date(`2026-08-${day}T09:00:00Z`)
+        );
+      }
+      writeRollout(
+        "2026/08/10",
+        "rollout-2026-08-10T08-00-00-active.jsonl",
+        [tokenCountLine(55)],
+        new Date("2026-08-14T23:00:00Z")
+      );
+
+      const reading = await readCodexPlanUsage(codexHome);
+
+      expect(windowsOf(reading)[0]?.percent).toBe(55);
+    });
+
+    it("ignores files that are not rollouts", async () => {
+      writeRollout("2026/08/14", "rollout-2026-08-14T10-00-00-real.jsonl", [tokenCountLine(13)]);
+      writeRollout(
+        "2026/08/14",
+        "notes.jsonl",
+        [tokenCountLine(99)],
+        new Date("2026-12-01T00:00:00Z")
+      );
+
+      const reading = await readCodexPlanUsage(codexHome);
+
+      expect(windowsOf(reading)[0]?.percent).toBe(13);
+    });
+
+    /** Filler wide enough that the head of the file falls outside the 256KB tail read. */
+    function pastTheTail(): string[] {
+      const line = JSON.stringify({
+        type: "event_msg",
+        payload: { type: "agent_message", text: "x".repeat(500) },
+      });
+      return Array.from({ length: 1200 }, () => line);
+    }
+
+    it("finds the limits at the end of a rollout larger than the tail read", async () => {
+      const file = writeRollout("2026/08/14", "rollout-2026-08-14T10-00-00-big.jsonl", [
+        ...pastTheTail(),
+        tokenCountLine(13),
+      ]);
+
+      // The bound only means something if the file actually exceeds it.
+      expect(fs.statSync(file).size).toBeGreaterThan(256 * 1024);
+      const reading = await readCodexPlanUsage(codexHome);
+
+      expect(windowsOf(reading)[0]?.percent).toBe(13);
+    });
+
+    it("does not read limits that fall outside the tail", async () => {
+      // Rollouts reach megabytes and this runs at every attach and turn boundary, so the
+      // read is bounded. Limits that old are stale anyway, and a stale number on a cap
+      // meter is worse than no number.
+      writeRollout("2026/08/14", "rollout-2026-08-14T10-00-00-old.jsonl", [
+        tokenCountLine(13),
+        ...pastTheTail(),
+      ]);
+
+      await expect(readCodexPlanUsage(codexHome)).resolves.toEqual(UNAVAILABLE);
+    });
+
+    it.each([
+      ["Codex has never run here", () => undefined],
+      [
+        "the rollout carries no rate limits",
+        () =>
+          writeRollout("2026/08/14", "rollout-2026-08-14T10-00-00-quiet.jsonl", [
+            JSON.stringify({ type: "event_msg", payload: { type: "agent_message" } }),
+          ]),
+      ],
+      [
+        "the rollout is unreadable",
+        () => writeRollout("2026/08/14", "rollout-2026-08-14T10-00-00-bad.jsonl", ["{not json"]),
+      ],
+    ])("reports unavailable when %s", async (_label, setup) => {
+      setup();
+
+      await expect(readCodexPlanUsage(codexHome)).resolves.toEqual(UNAVAILABLE);
+    });
+
+    it("reports unavailable when the home directory does not exist", async () => {
+      await expect(readCodexPlanUsage(path.join(codexHome, "nope"))).resolves.toEqual(UNAVAILABLE);
+    });
+
+    describe("lastRateLimits()", () => {
+      it("skips a truncated leading line", () => {
+        // The tail read starts mid-file, so the first line is normally a fragment.
+        const tail = ['_count","rate_limits":{"primary"', tokenCountLine(13)].join("\n");
+
+        expect(lastRateLimits(tail)?.primary?.used_percent).toBe(13);
+      });
+
+      it("returns null when no line carries rate limits", () => {
+        expect(lastRateLimits('{"type":"event_msg"}\n')).toBeNull();
+      });
+    });
+  });
+});

--- a/src/agentMode/backends/codex/codexPlanUsage.ts
+++ b/src/agentMode/backends/codex/codexPlanUsage.ts
@@ -1,0 +1,269 @@
+import { requireNodeModule } from "@/utils/desktopRuntime";
+import type { PlanUsageReading, UsageWindow } from "@/agentMode/session/planUsage";
+import {
+  planUsageReading,
+  toUsagePercent,
+  withoutExpiredWindows,
+} from "@/agentMode/session/planUsage";
+import { logInfo } from "@/logger";
+
+/**
+ * Codex's plan caps do not cross the ACP wire.
+ *
+ * `codex-acp` receives them from Codex as an `account/rateLimits/updated` notification,
+ * stores them on its own session state, and returns null instead of forwarding a session
+ * update — verified in the shipped bundles of both 1.1.7 and 1.3.0. Its only exposure is
+ * the `/status` slash command, which renders them as prose into the conversation.
+ *
+ * Codex itself writes them to disk, though: every turn appends a `token_count` event to
+ * the session's rollout file under `CODEX_HOME/sessions/`, and that event carries the
+ * `rate_limits` object verbatim. Reading the newest one back is the only structured
+ * source available to a client, so that is what this module does. The snapshot's shape
+ * is Codex's own, so its normalizer lives here beside the reader, the way the Claude
+ * normalizer lives with the SDK adapter that knows its shape.
+ *
+ * It is an undocumented internal format and it may change without notice. Every failure
+ * — a moved directory, a renamed field, a file we cannot read — reads as "unavailable",
+ * which the caller treats as no news and leaves the previous meters standing. A rollout
+ * can never affirm that an account is unmetered, so this source never clears them
+ * (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+ */
+
+/** One window of a Codex rate-limit snapshot. */
+interface CodexWindow {
+  used_percent?: number | null;
+  window_minutes?: number | null;
+  resets_at?: number | null;
+}
+
+/**
+ * The `rate_limits` object Codex records against a turn.
+ *
+ * The two slots are positional, not named windows: which durations they hold depends on
+ * the plan. A Pro account reports a single weekly window in `primary` and leaves
+ * `secondary` empty; plans with a shorter burst window put that in `primary` and the
+ * weekly one in `secondary`.
+ */
+export interface CodexRateLimits {
+  primary?: CodexWindow | null;
+  secondary?: CodexWindow | null;
+}
+
+/**
+ * Name a Codex window by how long it is, because Codex reports a duration where the other
+ * providers report a named bucket. Weekly is spelled out to match what the other meters
+ * call it; anything else reads as its own duration.
+ */
+function codexWindowLabel(minutes: unknown): string | null {
+  if (typeof minutes !== "number" || !Number.isFinite(minutes) || minutes <= 0) return null;
+  if (minutes === 10_080) return "Weekly";
+  if (minutes % 1440 === 0) return `${minutes / 1440}d`;
+  if (minutes % 60 === 0) return `${minutes / 60}h`;
+  return `${Math.round(minutes)}m`;
+}
+
+/**
+ * Epoch milliseconds from Codex's epoch SECONDS, or undefined when unusable. Providers
+ * disagree on encoding — Claude sends ISO 8601, Codex seconds — so each adapter converts
+ * its own.
+ */
+function epochSecondsToMs(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return undefined;
+  return Math.round(value * 1000);
+}
+
+/** The slots Codex can fill, in the order they should be shown. */
+const CODEX_WINDOWS = ["primary", "secondary"] as const;
+
+/**
+ * Normalize a Codex rate-limit snapshot.
+ *
+ * A slot the plan does not cap is empty rather than zero, and a snapshot that yields no
+ * usable slot is indistinguishable from one we failed to read, so it reports unavailable
+ * — never "0% used", and never a reason to clear a meter. Percentages pass through
+ * unclamped for the same reason as every other source.
+ */
+export function planUsageFromCodexRateLimits(
+  limits: CodexRateLimits | null | undefined,
+  now: number = Date.now()
+): PlanUsageReading {
+  const windows: UsageWindow[] = [];
+  for (const id of CODEX_WINDOWS) {
+    const raw = limits?.[id];
+    const percent = toUsagePercent(raw?.used_percent);
+    const label = codexWindowLabel(raw?.window_minutes);
+    if (percent === null || label === null) continue;
+    windows.push({ id, label, percent, resetsAt: epochSecondsToMs(raw?.resets_at) });
+  }
+  return planUsageReading(windows, now);
+}
+
+/**
+ * How many day-directories back to look for the newest rollout.
+ *
+ * Rollouts are filed under the date the session STARTED, so a long-lived session keeps
+ * appending to the directory of the day it opened while newer-dated directories fill
+ * with other files. A week covers any session Obsidian realistically keeps alive; the
+ * file is then chosen by modification time, not by which directory it sits in.
+ */
+const RECENT_DAY_DIRS = 7;
+
+/**
+ * How many rollouts, newest-written first, to inspect before giving up.
+ *
+ * The newest file can legitimately hold no rate limits yet — a session that just opened
+ * has only its metadata written — and on a fresh plugin start there is no in-memory
+ * snapshot to fall back on, so stopping at the first file would show no caps until a
+ * turn ran. A burst of just-opened sessions is the only way several limitless files
+ * stack up, so a handful of candidates finds the last recorded snapshot while keeping
+ * the read bounded.
+ */
+const MAX_ROLLOUT_CANDIDATES = 8;
+
+/**
+ * How much of the rollout tail to read. Rollouts grow to megabytes and this runs at every
+ * turn boundary, so it reads the end rather than the file: `token_count` events are
+ * appended throughout a turn, and the most recent one is what we want anyway.
+ */
+const TAIL_BYTES = 256 * 1024;
+
+// Codex state only exists on desktop, where Agent Mode runs; the lazy accessors keep
+// Node built-ins off the mobile load path (see desktopRuntime.requireNodeModule).
+function nodeFs(): typeof import("node:fs") {
+  return requireNodeModule<typeof import("node:fs")>("fs");
+}
+function nodePath(): typeof import("node:path") {
+  return requireNodeModule<typeof import("node:path")>("path");
+}
+
+/** Where Codex keeps its state when the environment does not say otherwise. */
+export function defaultCodexHome(): string {
+  const os = requireNodeModule<typeof import("node:os")>("os");
+  return nodePath().join(os.homedir(), ".codex");
+}
+
+/**
+ * The account's plan-cap utilization as of Codex's last recorded turn.
+ *
+ * The snapshot is account-scoped, so the newest rollout on disk answers for every session
+ * — including turns the user ran in their own terminal, which are spending the same caps.
+ */
+export async function readCodexPlanUsage(codexHome: string): Promise<PlanUsageReading> {
+  try {
+    const dirs = await recentDayDirs(nodePath().join(codexHome, "sessions"), RECENT_DAY_DIRS);
+    const rollouts = await rolloutsByRecency(dirs);
+    for (const rollout of rollouts.slice(0, MAX_ROLLOUT_CANDIDATES)) {
+      const limits = lastRateLimits(await readTail(rollout));
+      // A just-opened session's rollout holds only its metadata; the account's last
+      // recorded snapshot is in the next-newest file, not nowhere.
+      if (!limits) continue;
+      const reading = planUsageFromCodexRateLimits(limits);
+      if (reading.kind !== "usage") return reading;
+      // A disk snapshot can be arbitrarily old. A window whose recorded reset has
+      // passed describes a finished period — after a long idle it would present the
+      // previous week's percentage as current — and an older rollout would only be
+      // staler, so there is nothing better to fall back to
+      // (https://github.com/logancyang/obsidian-copilot-preview/issues/193).
+      const current = withoutExpiredWindows(reading.planUsage);
+      return current ? { kind: "usage", planUsage: current } : { kind: "unavailable" };
+    }
+    logInfo("[AgentMode] no Codex rollout carries rate limits; plan caps unavailable");
+    return { kind: "unavailable" };
+  } catch (error) {
+    logInfo("[AgentMode] Codex plan cap read failed; plan caps unavailable", error);
+    return { kind: "unavailable" };
+  }
+}
+
+/**
+ * The most recent day-directories under `sessions/`, newest first.
+ *
+ * The tree is `YYYY/MM/DD` with zero-padded names, so descending lexicographic order is
+ * descending chronological order, and walking it that way crosses month and year
+ * boundaries without any date arithmetic.
+ */
+async function recentDayDirs(root: string, limit: number): Promise<string[]> {
+  const out: string[] = [];
+  for (const year of await descendingSubdirs(root)) {
+    for (const month of await descendingSubdirs(nodePath().join(root, year))) {
+      for (const day of await descendingSubdirs(nodePath().join(root, year, month))) {
+        out.push(nodePath().join(root, year, month, day));
+        if (out.length >= limit) return out;
+      }
+    }
+  }
+  return out;
+}
+
+/** Subdirectory names of `dir`, newest-looking first; empty when it cannot be listed. */
+async function descendingSubdirs(dir: string): Promise<string[]> {
+  try {
+    const entries = await nodeFs().promises.readdir(dir, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort()
+      .reverse();
+  } catch {
+    return [];
+  }
+}
+
+/** Every rollout across `dirs`, most recently written first. */
+async function rolloutsByRecency(dirs: string[]): Promise<string[]> {
+  const rollouts: { file: string; mtimeMs: number }[] = [];
+  for (const dir of dirs) {
+    let names: string[];
+    try {
+      names = await nodeFs().promises.readdir(dir);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (!name.startsWith("rollout-") || !name.endsWith(".jsonl")) continue;
+      const file = nodePath().join(dir, name);
+      try {
+        const stat = await nodeFs().promises.stat(file);
+        rollouts.push({ file, mtimeMs: stat.mtimeMs });
+      } catch {
+        // Raced with Codex archiving or deleting the session; the next one will do.
+      }
+    }
+  }
+  return rollouts.sort((a, b) => b.mtimeMs - a.mtimeMs).map((rollout) => rollout.file);
+}
+
+/** The last {@link TAIL_BYTES} of `file` as whole lines. */
+async function readTail(file: string): Promise<string> {
+  const handle = await nodeFs().promises.open(file, "r");
+  try {
+    const { size } = await handle.stat();
+    const start = Math.max(0, size - TAIL_BYTES);
+    const buffer = Buffer.alloc(size - start);
+    await handle.read(buffer, 0, buffer.length, start);
+    const text = buffer.toString("utf-8");
+    if (start === 0) return text;
+    // Starting mid-file cuts a line in half; drop it rather than parse a fragment.
+    const firstBreak = text.indexOf("\n");
+    return firstBreak === -1 ? "" : text.slice(firstBreak + 1);
+  } finally {
+    await handle.close();
+  }
+}
+
+/** The rate limits from the newest event in `tail` that carries them. */
+export function lastRateLimits(tail: string): CodexRateLimits | null {
+  const lines = tail.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i];
+    if (!line?.includes('"rate_limits"')) continue;
+    try {
+      const event = JSON.parse(line) as { payload?: { rate_limits?: CodexRateLimits | null } };
+      const limits = event.payload?.rate_limits;
+      if (limits) return limits;
+    } catch {
+      // Not JSON we understand — an event shape we do not read, or a truncated line.
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#193

## Why

Agent Mode's usage meter shows Codex a context bar and nothing else. Claude Code and Copilot Plus sessions expand the meter into cap rows — "Weekly 21%", with a countdown to the reset — and a Codex session has that space sitting empty, so the one number that tells a user whether they are about to be cut off is the one number Codex users cannot see.

It is missing because the caps never reach the client. Codex sends them to `codex-acp` as an `account/rateLimits/updated` notification; `codex-acp` files them on its own session state and returns null instead of forwarding a session update. That is true in both the currently installed 1.1.7 and the latest 1.3.0, so waiting for a newer adapter does not fix it. Its only exposure is the `/status` slash command, which prints them as prose into the conversation.

Codex does write them down, though. Every turn appends a `token_count` event to that session's rollout file under `CODEX_HOME/sessions/`, and the event carries the rate-limit object verbatim.

## What

A Codex session's meter now shows the same cap rows as Claude Code and Copilot Plus: a ring on the collapsed meter and a labelled row with a reset countdown when it is opened. Nothing else about the meter changes. The previous PR in this stack put the generic read-and-broadcast wiring in the shared ACP process; this one adds only Codex's reader, so its diff is the rollout read and the snapshot's normalizer.

> **Before:** Opening the meter on a Codex chat shows the context bar alone. Whether the weekly cap is at 15% or 95% is invisible in Obsidian.
>
> **After:** The same meter shows `Weekly 15%`, with the time until the cap resets, and it updates after every turn.

Codex reports how long a window is rather than naming it, and which slot holds which window depends on the plan: a Pro account's single weekly cap arrives in the slot other plans use for a five-hour one. Rows are therefore named from the duration, so the label is right on either plan, and a plan with both windows shows both.

| When | What the meter shows |
| --- | --- |
| A chat opens, Codex has run before | The caps, read from disk, without waiting for a turn |
| A turn finishes | The caps as that turn left them |
| The user switches chats | The same reading, straight away |
| A read fails, or Codex has never run | The previous reading if there is one, otherwise no cap rows |

## Non goal

- No change to the context-window bar, which already works for Codex.
- No new source for Claude Code or Copilot Plus; both keep the sources the previous two PRs shipped.
- No upstream fix to `codex-acp` to forward the caps over ACP. That is the right long-term home for this and would let the file read be deleted, but it is not in this repo.
- No cap enforcement, warning banner, or blocking behavior. This shows a number; it does not act on it.
- No caps for opencode's own providers, which expose none; Copilot Plus models running through opencode got theirs in the previous PR.

## Screenshot

Not attached: this terminal has no macOS Screen Recording permission, so the meter cannot be captured. The branch is built and running in a real vault, and the reader returns this from the live Codex state on that machine:

```
{ "windows": [ { "id": "primary", "label": "Weekly", "percent": 15, "resetsAt": 1787196738000 } ] }
```

which the meter renders as a `Weekly` row at 15% with a countdown to the reset. Verification below walks a reviewer to the same view.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `codexPlanUsage.test.ts` covers the normalizer's labelling and every empty case against a real Pro-account snapshot, plus directory selection, newest-by-write-time, and both sides of the tail bound over real temp-dir rollouts |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a wrong reading is a wrong number on the meter |
| A revert fully restores prior state, including persisted data | ✅ | Read-only; the change writes nothing to disk and stores nothing persistent |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | New parsing of a file the plugin did not previously read. Only `payload.rate_limits` is taken from it, the read is capped at 256KB, every parse is guarded, and nothing from the file leaves the process |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Implements the optional `readPlanUsage` seam the previous PR added; no wire or on-disk format changes, and Codex's rollout is only read |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The unawaited turn-boundary refresh is the previous PR's wiring; this diff adds a reader that is called through it and swallows its own failures |
| No hot-path behavior lacks deterministic coverage | ✅ | Every branch of the reader is covered, including the tail bound and every failure path |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the Agent Mode usage meter, and a wrong value is visible on the next turn |

Review: inspect `src/agentMode/backends/codex/codexPlanUsage.ts` — `planUsageFromCodexRateLimits`, `readCodexPlanUsage`, `recentDayDirs`, `newestRollout`, `readTail`, and `lastRateLimits` — line by line, confirming every failure resolves to "unavailable" and nothing read from the file goes anywhere but the meter, then `readPlanUsage` in `src/agentMode/backends/codex/CodexBackend.ts`, then run Verification steps 1 to 6 including the empty-home variant.

## Verification

1. Build this branch and load it in a desktop vault with the Codex backend configured and `codex login` done.
2. Open a new Agent Mode chat on Codex. If you have used Codex on this machine before, the meter already shows a cap row before you send anything. Open the meter and confirm the row reads `Weekly` with a percentage and a reset countdown, laid out the same as a Claude Code chat's rows.
3. Send a prompt. When the turn ends, confirm the row is still there and its percentage reflects the turn.
4. Switch to another chat and back. Confirm the row appears immediately rather than blanking.
5. Compare the number against Codex itself: run `codex` in a terminal and use `/status`. The weekly figure there is reported as percent remaining, so it should be 100 minus what the meter shows, within whatever has been spent between the two readings.
6. For the failure path, temporarily point the backend at an empty Codex home by setting `CODEX_HOME` to a new directory in the Codex backend's env overrides, then reload. Confirm the meter shows the context bar with no cap rows, and that chatting still works normally.

## Note

The rollout file is an undocumented internal format and can change without notice. It is read in one module, and every failure — a moved directory, a renamed field, a file that cannot be parsed — reads as "unavailable", which leaves the previous reading in place and eventually shows no cap rows rather than a wrong number. It also never clears meters: a rollout can never affirm that an account is unmetered. This is the same posture step 1 takes toward the Claude SDK's `usage_EXPERIMENTAL_MAY_CHANGE_DO_NOT_RELY_ON_THIS_API_YET`, for the same reason: it is the only source that exists.

The reading is account-scoped, so it deliberately reflects the newest Codex activity in that Codex home, including turns run in the user's own terminal. Those spend the same caps, so counting them is what makes the number true. The exception worth knowing: a user who gives the plugin a different Codex credential through env overrides while sharing the default Codex home would see the terminal account's caps. Pointing `CODEX_HOME` at a separate directory alongside such a credential keeps the two apart.
