### PR TITLE
[Node runtime guards] - Step 2: Guard remaining Node imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,65 @@ import reactHooks from "eslint-plugin-react-hooks";
 import tailwind from "eslint-plugin-tailwindcss";
 import boundaries from "eslint-plugin-boundaries";
 import globals from "globals";
+import { isBuiltin } from "node:module";
+
+const NODE_IMPORT_GUIDANCE =
+  "Use requireNodeModule() from '@/utils/desktopRuntime' for runtime access; use an import(\"node:...\") type query when only a type is needed.";
+
+const noDirectNodeImportsRule = {
+  meta: {
+    type: "problem",
+    schema: [],
+    messages: {
+      directNodeImport: `Do not access Node.js built-in module "{{moduleName}}" directly. ${NODE_IMPORT_GUIDANCE}`,
+    },
+  },
+  create(context) {
+    const reportIfBuiltin = (node, moduleName) => {
+      if (typeof moduleName === "string" && isBuiltin(moduleName)) {
+        context.report({
+          node,
+          messageId: "directNodeImport",
+          data: { moduleName },
+        });
+      }
+    };
+
+    return {
+      ImportDeclaration(node) {
+        reportIfBuiltin(node, node.source.value);
+      },
+      ExportNamedDeclaration(node) {
+        if (node.source) {
+          reportIfBuiltin(node, node.source.value);
+        }
+      },
+      ExportAllDeclaration(node) {
+        reportIfBuiltin(node, node.source.value);
+      },
+      ImportExpression(node) {
+        if (node.source.type === "Literal") {
+          reportIfBuiltin(node, node.source.value);
+        }
+      },
+      CallExpression(node) {
+        if (
+          node.callee.type === "Identifier" &&
+          node.callee.name === "require" &&
+          node.arguments[0]?.type === "Literal"
+        ) {
+          reportIfBuiltin(node, node.arguments[0].value);
+        }
+      },
+    };
+  },
+};
+
+const copilotLintPlugin = {
+  rules: {
+    "no-direct-node-imports": noDirectNodeImportsRule,
+  },
+};
 
 const restrictedSourceImports = [
   {
@@ -188,6 +247,17 @@ export default [
             "Use isDesktopRuntime() from @/utils/desktopRuntime instead. Platform.isDesktopApp stays true under app.emulateMobile(true) (Node stubbed to null), so desktop-only/Node code still runs there and crashes.",
         },
       ],
+    },
+  },
+
+  // Runtime Node access in plugin source must cross the shared desktop guard.
+  // Tests may import Node directly because they execute under Jest, not Obsidian.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    ignores: ["src/**/*.test.{ts,tsx}", "src/**/__mocks__/**", "src/integration_tests/**"],
+    plugins: { copilot: copilotLintPlugin },
+    rules: {
+      "copilot/no-direct-node-imports": "error",
     },
   },
 

--- a/scripts/review-obsidian-fixtures.mjs
+++ b/scripts/review-obsidian-fixtures.mjs
@@ -16,9 +16,26 @@ const reviewSourceExtensions = new Set([".cjs", ".js", ".jsx", ".mjs", ".ts", ".
 // Negative examples must not be real source files because the authenticated
 // community reviewer scans them without the repository's local ignore rules.
 const invalidSourceFixture = `import "node:fs";
+export { promisify } from "node:util";
+const path = require("path");
+void path;
+async function loadOs() {
+  return import("node:os");
+}
+void loadOs;
 
 // eslint-disable-next-line no-console
 console.log(fetch("https://example.com"));
+`;
+const validNodeBoundaryFixture = `import { Buffer } from "buffer/";
+import { requireNodeModule } from "@/utils/desktopRuntime";
+
+type Stats = import("node:fs").Stats;
+
+export function encodeSize(stats: Stats): string {
+  const path = requireNodeModule<typeof import("node:path")>("path");
+  return Buffer.from(path.basename(String(stats.size))).toString("base64");
+}
 `;
 const invalidStyleWarningFixture = `.review-fixture:has(button) {
   display: block !important;
@@ -114,10 +131,29 @@ async function main() {
   assert(invalidSourceResult.errorCount > 0, "ESLint accepted its invalid source fixture");
   expectEslintRules(invalidSourceResult, [
     "obsidianmd/no-nodejs-modules",
+    "copilot/no-direct-node-imports",
     "no-restricted-globals",
     "eslint-comments/require-description",
     "eslint-comments/no-restricted-disable",
   ]);
+  assert(
+    ["node:fs", "node:util", "path", "node:os"].every((moduleName) =>
+      invalidSourceResult.messages.some(
+        (message) =>
+          message.ruleId === "copilot/no-direct-node-imports" &&
+          message.message.includes(`"${moduleName}"`) &&
+          message.message.includes("requireNodeModule()")
+      )
+    ),
+    "direct Node access guidance did not cover imports, re-exports, and require() calls"
+  );
+  const validNodeBoundaryResult = await lintSourceFixture(validNodeBoundaryFixture, "src/utils.ts");
+  assert(
+    validNodeBoundaryResult.messages.every(
+      (message) => message.ruleId !== "copilot/no-direct-node-imports"
+    ),
+    "browser polyfills or guarded/type-only Node access were rejected"
+  );
   const invalidLicenseResult = await lintSourceFixture(invalidLicenseFixture, "LICENSE");
   assert(
     invalidLicenseResult.errorCount === 0,

--- a/src/LLMProviders/BedrockChatModel.ts
+++ b/src/LLMProviders/BedrockChatModel.ts
@@ -1,6 +1,6 @@
 // Reason: `buffer` is the npm polyfill (browser-compatible), bundled by esbuild
 // so the same Buffer code path works on desktop (Electron) and mobile (WebView).
-import { Buffer } from "buffer";
+import { Buffer } from "buffer/";
 
 import {
   BaseChatModel,

--- a/src/agentMode/acp/AcpProcessManager.ts
+++ b/src/agentMode/acp/AcpProcessManager.ts
@@ -1,6 +1,13 @@
 import { logError, logInfo, logWarn } from "@/logger";
-import { ChildProcessByStdio, spawn } from "node:child_process";
-import { Readable, Writable } from "node:stream";
+import { requireNodeModule } from "@/utils/desktopRuntime";
+
+type ChildProcessByStdio = import("node:child_process").ChildProcessByStdio<
+  Writable,
+  Readable,
+  Readable
+>;
+type Readable = import("node:stream").Readable;
+type Writable = import("node:stream").Writable;
 
 const SIGTERM_GRACE_MS = 3_000;
 
@@ -25,7 +32,7 @@ export interface AcpProcessManagerOptions {
  * graceful SIGTERM→SIGKILL teardown.
  */
 export class AcpProcessManager {
-  private child: ChildProcessByStdio<Writable, Readable, Readable> | null = null;
+  private child: ChildProcessByStdio | null = null;
   private exitListeners = new Set<(code: number | null, signal: NodeJS.Signals | null) => void>();
   private hasExited = false;
   private exitCode: number | null = null;
@@ -42,6 +49,8 @@ export class AcpProcessManager {
       throw new Error("AcpProcessManager already started");
     }
     const tag = this.opts.logTag ?? "acp";
+    const { spawn } = requireNodeModule<typeof import("node:child_process")>("child_process");
+    const { Readable, Writable } = requireNodeModule<typeof import("node:stream")>("stream");
     logInfo(`[AgentMode] spawning ${this.opts.command} ${this.opts.args.join(" ")} (tag=${tag})`);
     const child = spawn(this.opts.command, this.opts.args, {
       env: this.opts.env,

--- a/src/agentMode/acp/VaultClient.ts
+++ b/src/agentMode/acp/VaultClient.ts
@@ -12,7 +12,7 @@ import type {
 import { RequestError } from "@agentclientprotocol/sdk";
 import { logInfo, logWarn } from "@/logger";
 import { App, FileSystemAdapter, normalizePath } from "obsidian";
-import * as path from "node:path";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 export interface PermissionPrompter {
   (req: RequestPermissionRequest): Promise<RequestPermissionResponse>;
@@ -65,6 +65,7 @@ export class VaultClient implements Client {
   }
 
   async writeTextFile(params: WriteTextFileRequest): Promise<WriteTextFileResponse> {
+    const path = requireNodeModule<typeof import("node:path")>("path");
     const rel = this.resolveVaultRelative(params.path);
     const adapter = this.app.vault.adapter;
     const dir = path.posix.dirname(rel);
@@ -82,6 +83,7 @@ export class VaultClient implements Client {
    * `RequestError.invalidParams` if the path escapes the vault.
    */
   private resolveVaultRelative(p: string): string {
+    const path = requireNodeModule<typeof import("node:path")>("path");
     const adapter = this.app.vault.adapter;
     if (!(adapter instanceof FileSystemAdapter)) {
       throw RequestError.invalidParams(

--- a/src/agentMode/acp/nodeShebangPath.ts
+++ b/src/agentMode/acp/nodeShebangPath.ts
@@ -1,6 +1,5 @@
-import * as path from "node:path";
-
 import { detectionSearchDirs, mergePath } from "@/utils/binaryPath";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 /**
  * macOS GUI apps (Obsidian) inherit a minimal PATH that omits Homebrew and
@@ -19,5 +18,6 @@ export function augmentPathForNodeShebang(
   binaryPath: string,
   inherited: string | undefined
 ): string {
+  const path = requireNodeModule<typeof import("node:path")>("path");
   return mergePath([path.dirname(binaryPath), ...detectionSearchDirs()], inherited);
 }

--- a/src/agentMode/backends/claude/claudeAuth.ts
+++ b/src/agentMode/backends/claude/claudeAuth.ts
@@ -9,13 +9,11 @@
  * listener, and persisting credentials to the OS keychain. We never read or
  * write the token ourselves; we only invoke the CLI and re-read its status.
  */
-import { execFile, spawn } from "node:child_process";
-import { type Readable } from "node:stream";
-import { promisify } from "node:util";
 import { logInfo, logWarn } from "@/logger";
 import { err2String } from "@/utils";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
-const execFileAsync = promisify(execFile);
+type Readable = import("node:stream").Readable;
 
 /** `claude auth status` is a quick local read; cap it so a wedged CLI can't hang the UI. */
 const STATUS_TIMEOUT_MS = 10_000;
@@ -71,6 +69,9 @@ export async function getClaudeAuthStatus(
   claudePath: string,
   env: NodeJS.ProcessEnv
 ): Promise<ClaudeAuthStatus> {
+  const { execFile } = requireNodeModule<typeof import("node:child_process")>("child_process");
+  const { promisify } = requireNodeModule<typeof import("node:util")>("util");
+  const execFileAsync = promisify(execFile);
   try {
     const { stdout } = await execFileAsync(claudePath, ["auth", "status", "--json"], {
       timeout: STATUS_TIMEOUT_MS,
@@ -113,6 +114,7 @@ export function signInToClaude(
   env: NodeJS.ProcessEnv,
   handlers: SignInHandlers = {}
 ): ClaudeSignInController {
+  const { spawn } = requireNodeModule<typeof import("node:child_process")>("child_process");
   logInfo("[AgentMode] spawning claude auth login");
   const child = spawn(claudePath, ["auth", "login", "--claudeai"], {
     env,

--- a/src/agentMode/backends/claude/claudeBinaryResolver.ts
+++ b/src/agentMode/backends/claude/claudeBinaryResolver.ts
@@ -10,9 +10,8 @@
  * Pure leaf: callers inject `homeDir`, `platform`, `env`, and `fs` so tests
  * don't touch real disk.
  */
-import * as path from "node:path";
-
 import { WELL_KNOWN_BIN_DIRS } from "@/utils/binaryPath";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { nodeToolBinDirCandidates, type NodeToolFs } from "@/utils/nodeToolBinDirs";
 
 export type ClaudeBinaryResolverFs = NodeToolFs;
@@ -46,6 +45,7 @@ export function resolveClaudeBinary(input: ClaudeBinaryResolverInput): string | 
 
 export function claudeBinarySearchDirs(input: ClaudeBinaryResolverInput): string[] {
   const candidates = input.platform === "win32" ? windowsCandidates(input) : unixCandidates(input);
+  const path = requireNodeModule<typeof import("node:path")>("path");
   const pathImpl = input.platform === "win32" ? path.win32 : path.posix;
   return Array.from(
     new Set(
@@ -56,10 +56,8 @@ export function claudeBinarySearchDirs(input: ClaudeBinaryResolverInput): string
   );
 }
 
-const posix = path.posix;
-const win = path.win32;
-
 function unixCandidates(input: ClaudeBinaryResolverInput): Array<string | null> {
+  const posix = requireNodeModule<typeof import("node:path")>("path").posix;
   const { homeDir, env } = input;
   // Every bin dir a Node version manager / npm-global install might use, plus
   // the well-known system prefixes — then `claude` under each.
@@ -93,6 +91,7 @@ function unixCandidates(input: ClaudeBinaryResolverInput): Array<string | null> 
 }
 
 function windowsCandidates(input: ClaudeBinaryResolverInput): Array<string | null> {
+  const win = requireNodeModule<typeof import("node:path")>("path").win32;
   const { homeDir, env } = input;
   const localAppData = env.LOCALAPPDATA ?? win.join(homeDir, "AppData", "Local");
   const programFiles = env.ProgramFiles ?? "C:\\Program Files";

--- a/src/agentMode/backends/claude/claudeVersion.ts
+++ b/src/agentMode/backends/claude/claudeVersion.ts
@@ -1,8 +1,6 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { compareSemver } from "@/utils/semver";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
-const execFileAsync = promisify(execFile);
 const VERSION_TIMEOUT_MS = 10_000;
 
 export const CLAUDE_MIN_VERSION = "2.1.206";
@@ -12,6 +10,16 @@ export type ClaudeVersionRunner = (
   args: string[],
   options: { env: NodeJS.ProcessEnv; timeout: number }
 ) => Promise<{ stdout: string }>;
+
+async function runClaudeVersion(
+  claudePath: string,
+  args: string[],
+  options: { env: NodeJS.ProcessEnv; timeout: number }
+): Promise<{ stdout: string }> {
+  const { execFile } = requireNodeModule<typeof import("node:child_process")>("child_process");
+  const { promisify } = requireNodeModule<typeof import("node:util")>("util");
+  return promisify(execFile)(claudePath, args, options);
+}
 
 /**
  * The resolver's npm-package fallbacks (`cli.js` / `cli-wrapper.cjs`) are Node
@@ -57,7 +65,7 @@ export type ClaudeVersionCompatibility =
 export async function probeClaudeVersion(
   claudePath: string,
   env: NodeJS.ProcessEnv,
-  run: ClaudeVersionRunner = execFileAsync
+  run: ClaudeVersionRunner = runClaudeVersion
 ): Promise<ClaudeVersionCompatibility> {
   const invocation = buildVersionInvocation(claudePath, env);
   let stdout: string;
@@ -98,7 +106,7 @@ export async function probeClaudeVersion(
 export async function assertClaudeVersionSupported(
   claudePath: string,
   env: NodeJS.ProcessEnv,
-  run: ClaudeVersionRunner = execFileAsync
+  run: ClaudeVersionRunner = runClaudeVersion
 ): Promise<void> {
   const compatibility = await probeClaudeVersion(claudePath, env, run);
   if (compatibility.kind === "incompatible") throw new Error(compatibility.message);

--- a/src/agentMode/backends/claude/descriptor.ts
+++ b/src/agentMode/backends/claude/descriptor.ts
@@ -1,8 +1,6 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
-import * as path from "node:path";
 import { logWarn } from "@/logger";
 import type CopilotPlugin from "@/main";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import {
   getSettings,
   subscribeToSettingsChange,
@@ -97,6 +95,8 @@ const claudeWire: ModelWireCodec = {
  * and real `fs` accessors.
  */
 function claudeResolverEnv(): Omit<Parameters<typeof resolveClaudeBinary>[0], "override"> {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const os = requireNodeModule<typeof import("node:os")>("os");
   return {
     homeDir: os.homedir(),
     platform: process.platform,
@@ -199,6 +199,7 @@ export function subscribeClaudeInstallState(listener: () => void): () => void {
  * native separators on macOS/Linux/Windows.
  */
 function isClaudePlanModePlanFilePath(absolutePath: string): boolean {
+  const path = requireNodeModule<typeof import("node:path")>("path");
   if (!path.isAbsolute(absolutePath)) return false;
   if (!absolutePath.endsWith(".md")) return false;
   const dir = path.dirname(absolutePath);

--- a/src/agentMode/backends/codex/codexBinaryResolver.ts
+++ b/src/agentMode/backends/codex/codexBinaryResolver.ts
@@ -4,8 +4,7 @@
  * Agent Mode's no-shell ACP process path, so this resolver probes native
  * `.exe` locations first and only falls back to the generic PATH detector.
  */
-import * as path from "node:path";
-
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { nodeToolBinDirCandidates, type NodeToolFs } from "@/utils/nodeToolBinDirs";
 
 export type CodexAcpBinaryResolverFs = NodeToolFs;
@@ -31,14 +30,13 @@ export function resolveCodexAcpBinary(input: CodexAcpBinaryResolverInput): strin
 
 export function codexAcpSearchDirs(input: CodexAcpBinaryResolverInput): string[] {
   const candidates = input.platform === "win32" ? windowsCandidates(input) : unixCandidates(input);
+  const path = requireNodeModule<typeof import("node:path")>("path");
   const pathImpl = input.platform === "win32" ? path.win32 : path.posix;
   return Array.from(new Set(candidates.map((candidate) => pathImpl.dirname(candidate))));
 }
 
-const posix = path.posix;
-const win = path.win32;
-
 function unixCandidates(input: CodexAcpBinaryResolverInput): string[] {
+  const posix = requireNodeModule<typeof import("node:path")>("path").posix;
   const { homeDir } = input;
   const dirs = [
     posix.join(homeDir, ".local", "bin"),
@@ -51,6 +49,7 @@ function unixCandidates(input: CodexAcpBinaryResolverInput): string[] {
 }
 
 function windowsCandidates(input: CodexAcpBinaryResolverInput): string[] {
+  const win = requireNodeModule<typeof import("node:path")>("path").win32;
   const { homeDir, env } = input;
   const localAppData = env.LOCALAPPDATA ?? win.join(homeDir, "AppData", "Local");
   const appData = env.APPDATA ?? win.join(homeDir, "AppData", "Roaming");

--- a/src/agentMode/backends/codex/descriptor.ts
+++ b/src/agentMode/backends/codex/descriptor.ts
@@ -1,6 +1,5 @@
-import * as fs from "node:fs";
-import * as os from "node:os";
 import type CopilotPlugin from "@/main";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import {
   subscribeToSettingsChange,
   updateAgentModeBackendFields,
@@ -41,6 +40,8 @@ export function updateCodexFields(partial: Partial<CodexBackendSettings>): void 
 }
 
 function codexAcpResolverEnv(): Parameters<typeof resolveCodexAcpBinary>[0] {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const os = requireNodeModule<typeof import("node:os")>("os");
   return {
     homeDir: os.homedir(),
     platform: process.platform,

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.test.ts
@@ -15,8 +15,8 @@ jest.mock("@/logger", () => ({
 
 // Override only homedir so tests can redirect the OS-local install root into a
 // temp dir; tmpdir() and everything else stay real.
-jest.mock("node:os", () => {
-  const actual = jest.requireActual("node:os");
+jest.mock("os", () => {
+  const actual = jest.requireActual("os");
   return { ...actual, homedir: jest.fn(() => actual.homedir()) };
 });
 
@@ -60,7 +60,7 @@ jest.mock("./opencodeCliDetector", () => ({
 import { OPENCODE_MIN_ACP_VERSION, OPENCODE_PINNED_VERSION } from "./ui/opencodeVersion";
 import { copilotAppDataDir } from "@/utils/appPaths";
 import * as fs from "node:fs";
-import * as os from "node:os";
+import * as os from "os";
 import * as path from "node:path";
 import {
   computeInstallState,

--- a/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
+++ b/src/agentMode/backends/opencode/OpencodeBinaryManager.ts
@@ -4,22 +4,35 @@ import { compareSemver } from "@/utils/semver";
 import { logError, logInfo, logWarn } from "@/logger";
 import type CopilotPlugin from "@/main";
 import { getSettings, setSettings, type OpencodeBackendSettings } from "@/settings/model";
-import { execFile, spawn } from "node:child_process";
-import { randomBytes } from "node:crypto";
-import * as fs from "node:fs";
-import * as https from "node:https";
-import { IncomingMessage } from "node:http";
 import { FileSystemAdapter, requestUrl } from "obsidian";
-import * as os from "node:os";
-import * as path from "node:path";
-import { promisify } from "node:util";
 import { renameWithRetry } from "@/agentMode/skills/renameWithRetry";
 import { copilotAppDataDir } from "@/utils/appPaths";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { detectOpencodeCliPath } from "./opencodeCliDetector";
 import { expectedBinaryName, resolveOpencodeTarget } from "./platformResolver";
 import type { InstallState as BackendInstallState } from "@/agentMode/session/types";
 
-const execFileAsync = promisify(execFile);
+type IncomingMessage = import("node:http").IncomingMessage;
+type Dirent = import("node:fs").Dirent;
+
+function nodeFs(): typeof import("node:fs") {
+  return requireNodeModule<typeof import("node:fs")>("fs");
+}
+
+function nodePath(): typeof import("node:path") {
+  return requireNodeModule<typeof import("node:path")>("path");
+}
+
+async function execFileAsync(
+  file: string,
+  args: string[],
+  options: Pick<import("node:child_process").ExecFileOptions, "timeout" | "windowsHide">
+): Promise<{ stdout: string | Buffer }> {
+  const { execFile } = requireNodeModule<typeof import("node:child_process")>("child_process");
+  const { promisify } = requireNodeModule<typeof import("node:util")>("util");
+  const { stdout } = await promisify(execFile)(file, args, options);
+  return { stdout };
+}
 const DOWNLOAD_INACTIVITY_TIMEOUT_MS = 30_000;
 // Generous: first-run on Windows (Defender real-time scan) and macOS
 // (Gatekeeper translocation) can add a few seconds before the binary responds.
@@ -157,7 +170,7 @@ export function pickMatchingAsset(release: GithubRelease, candidates: string[]):
  */
 export function computeInstallState(
   opencode: OpencodeBackendSettings | undefined,
-  fileExists: (path: string) => boolean = (p) => fs.existsSync(p)
+  fileExists: (path: string) => boolean = (p) => nodeFs().existsSync(p)
 ): InstallState {
   const s = opencode ?? {};
   if (s.binaryPath && s.binaryVersion && fileExists(s.binaryPath)) {
@@ -241,7 +254,7 @@ function clearOpencodeBinary(): void {
  * scope while staying per-user.
  */
 export function opencodeManagedDataDir(homeDir: string): string {
-  return path.join(copilotAppDataDir(homeDir), "opencode");
+  return nodePath().join(copilotAppDataDir(homeDir), "opencode");
 }
 
 /**
@@ -258,7 +271,7 @@ export function legacyVaultDataDir(
   configDir: string,
   pluginId: string
 ): string {
-  return path.join(vaultBasePath, configDir, "plugins", pluginId, "data", "opencode");
+  return nodePath().join(vaultBasePath, configDir, "plugins", pluginId, "data", "opencode");
 }
 
 /**
@@ -456,13 +469,13 @@ export class OpencodeBinaryManager {
     if (!(adapter instanceof FileSystemAdapter)) {
       throw new Error("Agent Mode requires desktop Obsidian (FileSystemAdapter).");
     }
-    const home = os.homedir();
+    const home = requireNodeModule<typeof import("node:os")>("os").homedir();
     // Guard against a missing/garbage home dir (empty string, or the filesystem
     // root) before we build an install path under it: `os.homedir()` can return
     // "" in broken/sandboxed environments, and installing into `/.obsidian-copilot`
     // would be wrong and almost certainly unwritable. Fail with an actionable
     // message instead of a confusing downstream spawn error.
-    if (!home || !path.isAbsolute(home) || path.parse(home).root === home) {
+    if (!home || !nodePath().isAbsolute(home) || nodePath().parse(home).root === home) {
       throw new Error(
         "Could not resolve your home directory to install the opencode runtime. " +
           "Agent Mode installs it under ~/.obsidian-copilot; check that your account has a valid home directory."
@@ -507,7 +520,7 @@ export class OpencodeBinaryManager {
   ): Promise<{ version: string; path: string }> {
     const version = opts.version ?? OPENCODE_PINNED_VERSION;
     const dataDir = this.getDataDir();
-    const versionDir = path.join(dataDir, version);
+    const versionDir = nodePath().join(dataDir, version);
 
     opts.onProgress?.({ phase: "resolve", message: "Resolving platform asset…" });
     const { target, candidates } = await resolveOpencodeTarget();
@@ -519,10 +532,10 @@ export class OpencodeBinaryManager {
     const asset = pickMatchingAsset(release, candidates);
 
     const binName = expectedBinaryName(target.platform);
-    const finalBinPath = path.join(versionDir, "bin", binName);
+    const finalBinPath = nodePath().join(versionDir, "bin", binName);
 
     // Idempotency: if the existing manifest matches and the binary is in place, no-op.
-    const existing = await readManifest(path.join(versionDir, "install-manifest.json"));
+    const existing = await readManifest(nodePath().join(versionDir, "install-manifest.json"));
     if (existing && existing.assetName === asset.name && (await fileExists(finalBinPath))) {
       logInfo(`[AgentMode] opencode ${version} already installed at ${finalBinPath}`);
       // Skip the write when settings already match — avoids spuriously waking
@@ -548,45 +561,46 @@ export class OpencodeBinaryManager {
     // fails here with an actionable message naming the path, rather than later
     // mid-extraction.
     try {
-      await fs.promises.mkdir(dataDir, { recursive: true });
+      await nodeFs().promises.mkdir(dataDir, { recursive: true });
     } catch (e) {
       throw new Error(
         `Could not create the opencode install directory at ${dataDir}: ` +
           `${e instanceof Error ? e.message : String(e)}. Check that it is writable.`
       );
     }
-    const tmpDir = path.join(dataDir, `.tmp-${version}-${randomBytes(4).toString("hex")}`);
-    await fs.promises.mkdir(tmpDir, { recursive: true });
+    const randomBytes = requireNodeModule<typeof import("node:crypto")>("crypto").randomBytes;
+    const tmpDir = nodePath().join(dataDir, `.tmp-${version}-${randomBytes(4).toString("hex")}`);
+    await nodeFs().promises.mkdir(tmpDir, { recursive: true });
 
     try {
-      const archivePath = path.join(tmpDir, asset.name);
+      const archivePath = nodePath().join(tmpDir, asset.name);
       await downloadToFile(asset.browser_download_url, archivePath, asset.size, opts);
       this.throwIfAborted(opts.signal);
 
       opts.onProgress?.({ phase: "extract", message: "Extracting archive…" });
-      const extractDir = path.join(tmpDir, "extract");
-      await fs.promises.mkdir(extractDir, { recursive: true });
+      const extractDir = nodePath().join(tmpDir, "extract");
+      await nodeFs().promises.mkdir(extractDir, { recursive: true });
       await extractArchive(archivePath, extractDir);
       this.throwIfAborted(opts.signal);
 
       const extractedBin = await locateFile(extractDir, binName);
       if (target.platform !== "windows") {
-        await fs.promises.chmod(extractedBin, 0o755);
+        await nodeFs().promises.chmod(extractedBin, 0o755);
       }
 
       // Stage the final layout under tmpDir, then atomically rename into place.
-      const stageDir = path.join(tmpDir, "stage");
-      const stageBinDir = path.join(stageDir, "bin");
-      await fs.promises.mkdir(stageBinDir, { recursive: true });
-      await fs.promises.rename(extractedBin, path.join(stageBinDir, binName));
+      const stageDir = nodePath().join(tmpDir, "stage");
+      const stageBinDir = nodePath().join(stageDir, "bin");
+      await nodeFs().promises.mkdir(stageBinDir, { recursive: true });
+      await nodeFs().promises.rename(extractedBin, nodePath().join(stageBinDir, binName));
 
       const manifest: InstallManifest = {
         version,
         assetName: asset.name,
         installedAt: new Date().toISOString(),
       };
-      await fs.promises.writeFile(
-        path.join(stageDir, "install-manifest.json"),
+      await nodeFs().promises.writeFile(
+        nodePath().join(stageDir, "install-manifest.json"),
         JSON.stringify(manifest, null, 2)
       );
 
@@ -664,7 +678,7 @@ export class OpencodeBinaryManager {
         prev.binaryVersion &&
         prev.binaryVersion !== result.version
       ) {
-        const oldDir = path.join(this.getDataDir(), prev.binaryVersion);
+        const oldDir = nodePath().join(this.getDataDir(), prev.binaryVersion);
         await removeDir(oldDir).catch((e) =>
           logWarn(`[AgentMode] failed to remove old opencode ${oldDir}: ${e}`)
         );
@@ -800,13 +814,15 @@ export class OpencodeBinaryManager {
       clearOpencodeBinary();
       return;
     }
-    const stat = await fs.promises.stat(p).catch(() => null);
+    const stat = await nodeFs()
+      .promises.stat(p)
+      .catch(() => null);
     if (!stat || !stat.isFile()) {
       throw new Error(`No file at ${p}`);
     }
     if (process.platform !== "win32") {
       try {
-        await fs.promises.access(p, fs.constants.X_OK);
+        await nodeFs().promises.access(p, nodeFs().constants.X_OK);
       } catch {
         throw new Error(`${p} is not executable. chmod +x and try again.`);
       }
@@ -857,7 +873,7 @@ export function parseVersionFromStdout(stdout: string): string | undefined {
 
 async function fileExists(p: string): Promise<boolean> {
   try {
-    await fs.promises.access(p);
+    await nodeFs().promises.access(p);
     return true;
   } catch {
     return false;
@@ -866,7 +882,7 @@ async function fileExists(p: string): Promise<boolean> {
 
 async function readManifest(p: string): Promise<InstallManifest | null> {
   try {
-    const raw = await fs.promises.readFile(p, "utf-8");
+    const raw = await nodeFs().promises.readFile(p, "utf-8");
     return JSON.parse(raw) as InstallManifest;
   } catch {
     return null;
@@ -874,25 +890,25 @@ async function readManifest(p: string): Promise<InstallManifest | null> {
 }
 
 async function removeDir(p: string): Promise<void> {
-  await fs.promises.rm(p, { recursive: true, force: true });
+  await nodeFs().promises.rm(p, { recursive: true, force: true });
 }
 
 /** Recursively sum the byte size of all files under `dir`; 0 if it's absent. */
 async function dirSize(dir: string): Promise<number> {
-  let entries: fs.Dirent[];
+  let entries: Dirent[];
   try {
-    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    entries = await nodeFs().promises.readdir(dir, { withFileTypes: true });
   } catch {
     return 0;
   }
   let total = 0;
   for (const e of entries) {
-    const full = path.join(dir, e.name);
+    const full = nodePath().join(dir, e.name);
     if (e.isDirectory()) {
       total += await dirSize(full);
     } else if (e.isFile()) {
-      total += await fs.promises
-        .stat(full)
+      total += await nodeFs()
+        .promises.stat(full)
         .then((s) => s.size)
         .catch(() => 0);
     }
@@ -910,6 +926,7 @@ function httpsGetWithRedirects(
   signal: AbortSignal | undefined,
   maxRedirects = 5
 ): Promise<IncomingMessage> {
+  const https = requireNodeModule<typeof import("node:https")>("https");
   return new Promise((resolve, reject) => {
     const request = (currentUrl: string, redirectsLeft: number): void => {
       let onAbort: (() => void) | null = null;
@@ -972,7 +989,7 @@ async function downloadToFile(
   expectedSize: number | undefined,
   opts: InstallPipelineOptions
 ): Promise<void> {
-  const assetName = path.basename(dest);
+  const assetName = nodePath().basename(dest);
   const res = await httpsGetWithRedirects(url, opts.signal);
   const total =
     expectedSize ??
@@ -981,7 +998,7 @@ async function downloadToFile(
   let received = 0;
   let stalled = false;
   let inactivityTimer: number | null = null;
-  const out = fs.createWriteStream(dest);
+  const out = nodeFs().createWriteStream(dest);
   await new Promise<void>((resolve, reject) => {
     const clearInactivity = (): void => {
       if (inactivityTimer) {
@@ -1032,6 +1049,7 @@ async function downloadToFile(
  * re-implementing extraction in JS.
  */
 async function extractArchive(archivePath: string, destDir: string): Promise<void> {
+  const { spawn } = requireNodeModule<typeof import("node:child_process")>("child_process");
   // Cross-platform: macOS and Linux ship `tar`; Windows 10 1803+ ships `tar.exe`
   // built in (`bsdtar`), which handles .zip / .tar.gz / .tar.xz transparently.
   await new Promise<void>((resolve, reject) => {
@@ -1066,9 +1084,9 @@ async function locateFile(root: string, name: string): Promise<string> {
   const queue: string[] = [root];
   while (queue.length > 0) {
     const dir = queue.shift() as string;
-    const entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    const entries = await nodeFs().promises.readdir(dir, { withFileTypes: true });
     for (const e of entries) {
-      const full = path.join(dir, e.name);
+      const full = nodePath().join(dir, e.name);
       if (e.isDirectory()) queue.push(full);
       else if (e.isFile() && e.name === name) return full;
     }

--- a/src/agentMode/backends/opencode/opencodeBinaryResolver.ts
+++ b/src/agentMode/backends/opencode/opencodeBinaryResolver.ts
@@ -9,9 +9,8 @@
  * never emit `.cmd` / `.bat` / `.ps1` shims — ACP spawns over stdio without
  * `shell: true`, so those break stream-json.
  */
-import * as path from "node:path";
-
 import { WELL_KNOWN_BIN_DIRS } from "@/utils/binaryPath";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { nodeToolBinDirCandidates, type NodeToolFs } from "@/utils/nodeToolBinDirs";
 
 export type OpencodeBinaryResolverFs = NodeToolFs;
@@ -43,10 +42,8 @@ export function resolveOpencodeBinary(input: OpencodeBinaryResolverInput): strin
   return null;
 }
 
-const posix = path.posix;
-const win = path.win32;
-
 function unixCandidates(input: OpencodeBinaryResolverInput): Array<string | null> {
+  const posix = requireNodeModule<typeof import("node:path")>("path").posix;
   const { homeDir } = input;
   // Native installer (`curl -fsSL https://opencode.ai/install | bash`) lands at
   // ~/.opencode/bin/opencode; `bun install -g` lands at ~/.bun/bin. Probe these
@@ -61,6 +58,7 @@ function unixCandidates(input: OpencodeBinaryResolverInput): Array<string | null
 }
 
 function windowsCandidates(input: OpencodeBinaryResolverInput): Array<string | null> {
+  const win = requireNodeModule<typeof import("node:path")>("path").win32;
   const { homeDir, env } = input;
   const localAppData = env.LOCALAPPDATA ?? win.join(homeDir, "AppData", "Local");
   const programFiles = env.ProgramFiles ?? "C:\\Program Files";

--- a/src/agentMode/backends/opencode/opencodeCliDetector.ts
+++ b/src/agentMode/backends/opencode/opencodeCliDetector.ts
@@ -1,6 +1,5 @@
 import { detectBinary } from "@/utils/detectBinary";
-import * as fs from "node:fs";
-import * as os from "node:os";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { resolveOpencodeBinary } from "./opencodeBinaryResolver";
 
 /**
@@ -18,6 +17,8 @@ import { resolveOpencodeBinary } from "./opencodeBinaryResolver";
  * needs this detect inside its single-flight boundary.
  */
 export async function detectOpencodeCliPath(): Promise<string | null> {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const os = requireNodeModule<typeof import("node:os")>("os");
   const fromResolver = resolveOpencodeBinary({
     override: undefined,
     homeDir: os.homedir(),

--- a/src/agentMode/backends/opencode/platformResolver.ts
+++ b/src/agentMode/backends/opencode/platformResolver.ts
@@ -1,8 +1,4 @@
-import { execFile as execFileCb } from "node:child_process";
-import * as fs from "node:fs";
-import { promisify } from "node:util";
-
-const execFile = promisify(execFileCb);
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 export type OpencodePlatform = "darwin" | "linux" | "windows";
 export type OpencodeArch = "x64" | "arm64" | "arm";
@@ -62,6 +58,11 @@ export function mapNodeArch(nodeArch: string): OpencodeArch | undefined {
  */
 export async function detectMusl(): Promise<boolean> {
   if (process.platform !== "linux") return false;
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const { execFile: execFileCb } =
+    requireNodeModule<typeof import("node:child_process")>("child_process");
+  const { promisify } = requireNodeModule<typeof import("node:util")>("util");
+  const execFile = promisify(execFileCb);
   try {
     await fs.promises.access("/etc/alpine-release");
     return true;
@@ -83,6 +84,11 @@ export async function detectMusl(): Promise<boolean> {
  */
 export async function detectAvx2(): Promise<boolean> {
   if (process.arch !== "x64") return false;
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const { execFile: execFileCb } =
+    requireNodeModule<typeof import("node:child_process")>("child_process");
+  const { promisify } = requireNodeModule<typeof import("node:util")>("util");
+  const execFile = promisify(execFileCb);
   try {
     if (process.platform === "darwin") {
       const { stdout } = await execFile("sysctl", ["-n", "hw.optional.avx2_0"]);

--- a/src/agentMode/backends/shared/builtinSkillEnv.ts
+++ b/src/agentMode/backends/shared/builtinSkillEnv.ts
@@ -1,4 +1,3 @@
-import * as os from "node:os";
 import { BREVILABS_API_BASE_URL } from "@/constants";
 import { getSettings } from "@/settings/model";
 import { getMiyoCustomUrl } from "@/miyo/miyoUtils";
@@ -8,6 +7,7 @@ import {
   COPILOT_OBSIDIAN_CLI_ENV,
   resolveObsidianCliPath,
 } from "@/agentMode/backends/shared/obsidianCliPath";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 /** Env var the bundled `miyo` CLI reads to target a non-default Miyo service. */
 const MIYO_URL_ENV = "MIYO_URL";
@@ -41,6 +41,7 @@ export async function buildBuiltinSkillEnv(
   clientVersion = "",
   workspaceRootAbs = ""
 ): Promise<Readonly<Record<string, string>>> {
+  const os = requireNodeModule<typeof import("node:os")>("os");
   const settings = getSettings();
   const env: Record<string, string> = {};
 

--- a/src/agentMode/backends/shared/obsidianCliPath.ts
+++ b/src/agentMode/backends/shared/obsidianCliPath.ts
@@ -1,5 +1,4 @@
-import * as fs from "node:fs";
-import * as path from "node:path";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 export const COPILOT_OBSIDIAN_CLI_ENV = "COPILOT_OBSIDIAN_CLI";
 
@@ -19,6 +18,7 @@ interface ObsidianCliPathInput {
  */
 export function resolveObsidianCliPath(input: ObsidianCliPathInput): string | null {
   if (!input.resourcesPath) return null;
+  const path = requireNodeModule<typeof import("node:path")>("path");
   const pathApi = input.platform === "win32" ? path.win32 : path.posix;
   const installDir = pathApi.dirname(input.resourcesPath);
   const candidates =
@@ -36,6 +36,7 @@ export function resolveObsidianCliPath(input: ObsidianCliPathInput): string | nu
     input.isExecutable ??
     ((candidate: string): boolean => {
       try {
+        const fs = requireNodeModule<typeof import("node:fs")>("fs");
         fs.accessSync(candidate, fs.constants.X_OK);
         return true;
       } catch {

--- a/src/agentMode/backends/shared/simpleBinaryBackend.ts
+++ b/src/agentMode/backends/shared/simpleBinaryBackend.ts
@@ -1,10 +1,10 @@
-import * as fs from "node:fs";
 import type { App } from "obsidian";
 import type CopilotPlugin from "@/main";
 import { AcpBackendProcess } from "@/agentMode/acp/AcpBackendProcess";
 import type { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
 import { augmentPathForNodeShebang } from "@/agentMode/acp/nodeShebangPath";
 import type { BackendDescriptor, BackendProcess, InstallState } from "@/agentMode/session/types";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 /**
  * Build a spawn descriptor for a backend whose only configuration is a
@@ -47,7 +47,8 @@ export function buildSimpleSpawnDescriptor(
  */
 export function binaryPathInstallState(
   binaryPath: string | undefined,
-  fileExists: (path: string) => boolean = (p) => fs.existsSync(p)
+  fileExists: (path: string) => boolean = (p) =>
+    requireNodeModule<typeof import("node:fs")>("fs").existsSync(p)
 ): InstallState {
   if (!binaryPath || !fileExists(binaryPath)) return { kind: "absent" };
   return { kind: "ready", source: "custom" };

--- a/src/agentMode/index.ts
+++ b/src/agentMode/index.ts
@@ -1,12 +1,11 @@
 import { type App, Platform } from "obsidian";
-import os from "node:os";
-import * as path from "node:path";
 import type CopilotPlugin from "@/main";
 import { logError } from "@/logger";
 import { getSettings, subscribeToSettingsChange, type CopilotSettings } from "@/settings/model";
 import { deriveSkillsFolder, getEffectiveSkillsFolder } from "@/settings/copilotFolder";
 import { subscribeToSystemPromptChange } from "@/system-prompts/state";
 import { copilotAppDataDir, getVaultId } from "@/utils/appPaths";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { buildAgentSystemPrompt } from "./backends/shared/agentSystemPrompt";
 import { backendRegistry, listBackendDescriptors } from "./backends/registry";
 import type { BackendId } from "./session/types";
@@ -166,6 +165,8 @@ function backendEnvOverridesKey(settings: CopilotSettings, backendId: BackendId)
  * the existing manager and call this again.
  */
 export function createAgentSessionManager(app: App, plugin: CopilotPlugin): AgentSessionManager {
+  const os = requireNodeModule<typeof import("node:os")>("os");
+  const path = requireNodeModule<typeof import("node:path")>("path");
   const skillManager = SkillManager.initialize(app, collectAgentSkillsDirsProjectRel());
   const preloader = new AgentModelPreloader(app, plugin, (id) => backendRegistry[id]);
   const persistenceManager = new AgentChatPersistenceManager(app);

--- a/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
+++ b/src/agentMode/sdk/ClaudeSdkBackendProcess.ts
@@ -22,9 +22,6 @@ import {
   type SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { App } from "obsidian";
-import { access, readFile } from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { v4 as uuidv4 } from "uuid";
 import { translateBackendState } from "@/agentMode/session/translateBackendState";
 import { parseClaudeTranscript } from "./claudeSessionTranscript";
@@ -56,6 +53,7 @@ import type {
 } from "@/agentMode/session/types";
 import type { ProjectScopeId } from "@/agentMode/session/scope";
 import { AuthRequiredError, MethodUnsupportedError } from "@/agentMode/session/errors";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { createClaudeTaskPlanState, type ClaudeTaskPlanState } from "./claudeTodoPlan";
 import { ClaudeBackgroundTaskStateMachine } from "./claudeTaskProtocol";
 import { createTranslatorState, mapStopReason, translateSdkMessage } from "./sdkMessageTranslator";
@@ -656,6 +654,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
     cwd: string;
   }): Promise<AgentChatMessage[]> {
     try {
+      const { readFile } = requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
       const file = await this.claudeTranscriptPath(params.sessionId, params.cwd);
       const text = await readFile(file, "utf8");
       return parseClaudeTranscript(text);
@@ -673,6 +672,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
    */
   async sessionExistsLocally(params: { sessionId: SessionId; cwd: string }): Promise<boolean> {
     try {
+      const { access } = requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
       await access(await this.claudeTranscriptPath(params.sessionId, params.cwd));
       return true;
     } catch {
@@ -688,6 +688,7 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
    * non-alphanumeric character replaced by `-`, matching the CLI's encoding.
    */
   private async claudeTranscriptPath(sessionId: string, cwd: string): Promise<string> {
+    const path = requireNodeModule<typeof import("node:path")>("path");
     const configDir = (await this.resolveClaudeConfigDir()).trim();
     const projectDir = cwd.replace(/[^a-zA-Z0-9]/g, "-");
     return path.join(configDir, "projects", projectDir, `${sessionId}.jsonl`);
@@ -708,6 +709,8 @@ export class ClaudeSdkBackendProcess implements BackendProcess {
    */
   private async resolveClaudeConfigDir(): Promise<string> {
     if (this.resolvedConfigDir !== null) return this.resolvedConfigDir;
+    const os = requireNodeModule<typeof import("node:os")>("os");
+    const path = requireNodeModule<typeof import("node:path")>("path");
     const envOverrides = this.opts.getEnvOverrides?.() ?? {};
     const managedEnv = (await this.opts.getManagedEnv?.()) ?? {};
     this.resolvedConfigDir =

--- a/src/agentMode/session/debugSink.ts
+++ b/src/agentMode/session/debugSink.ts
@@ -5,6 +5,8 @@
  * land in the same NDJSON file. `tag` distinguishes the source.
  */
 
+import { requireNodeModule } from "@/utils/desktopRuntime";
+
 export interface FrameRecord {
   ts: string;
   dir: "→" | "←";
@@ -308,12 +310,9 @@ export function getFrameLogPaths(vaultBasePath: string, runtime: NodeRuntime): F
 
 function getNodeRuntime(): NodeRuntime | null {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- optional desktop logging loads Node APIs lazily and degrades to no-op when unavailable
-    const fs = require("node:fs/promises") as typeof import("node:fs/promises");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- optional desktop logging loads Node APIs lazily and degrades to no-op when unavailable
-    const os = require("node:os") as typeof import("node:os");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- optional desktop logging loads Node APIs lazily and degrades to no-op when unavailable
-    const path = require("node:path") as typeof import("node:path");
+    const fs = requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
+    const os = requireNodeModule<typeof import("node:os")>("os");
+    const path = requireNodeModule<typeof import("node:path")>("path");
     // eslint-disable-next-line @typescript-eslint/no-require-imports -- Electron shell support is optional and resolved with the same lazy desktop boundary
     const electron = require("electron") as {
       shell?: {

--- a/src/agentMode/session/nodeFileStorage.ts
+++ b/src/agentMode/session/nodeFileStorage.ts
@@ -1,6 +1,5 @@
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
-import * as path from "node:path";
 import type { AgentSessionIndexStorage } from "./AgentSessionIndex";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 /**
  * `AgentSessionIndexStorage` backed by Node's filesystem, for storing the
@@ -12,6 +11,9 @@ import type { AgentSessionIndexStorage } from "./AgentSessionIndex";
  * sync conflicts on other devices. Desktop-only, matching Agent Mode.
  */
 export function createNodeFileStorage(): AgentSessionIndexStorage {
+  const { mkdir, readFile, stat, writeFile } =
+    requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
+  const path = requireNodeModule<typeof import("node:path")>("path");
   return {
     exists: async (p) => {
       try {

--- a/src/agentMode/session/sessionScope.ts
+++ b/src/agentMode/session/sessionScope.ts
@@ -1,6 +1,6 @@
-import { dirname, join } from "node:path";
 import { getCachedProjectRecordById, getCachedProjectRecords } from "@/projects/state";
 import { GLOBAL_SCOPE, type ProjectScopeId } from "@/agentMode/session/scope";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 /**
  * Raised when a project-scoped session points at a project whose registry
@@ -25,11 +25,12 @@ export class OrphanedProjectError extends Error {
  */
 export function resolveScopeCwd(vaultBasePath: string, projectId: ProjectScopeId): string {
   if (projectId === GLOBAL_SCOPE) return vaultBasePath;
+  const path = requireNodeModule<typeof import("node:path")>("path");
   const record = getCachedProjectRecordById(projectId);
   if (!record) throw new OrphanedProjectError(projectId);
   // Reason: project folders live at `dirname(config)`; a config sitting at the
   // vault root yields ".", which join() collapses back to the vault root.
-  return join(vaultBasePath, dirname(record.filePath));
+  return path.join(vaultBasePath, path.dirname(record.filePath));
 }
 
 /** Whether `projectId` still resolves to a live scope (global is always live). */
@@ -47,11 +48,12 @@ export function isLiveScope(projectId: ProjectScopeId): boolean {
  * exact-cwd vault filter.
  */
 export function resolveProjectIdForCwd(vaultBasePath: string, cwd: string): string | undefined {
+  const path = requireNodeModule<typeof import("node:path")>("path");
   const norm = (p: string) => p.replace(/[/\\]+$/, "");
   const target = norm(cwd);
   if (target === norm(vaultBasePath)) return undefined;
   for (const record of getCachedProjectRecords()) {
-    if (target === norm(join(vaultBasePath, dirname(record.filePath)))) {
+    if (target === norm(path.join(vaultBasePath, path.dirname(record.filePath)))) {
       return record.project.id;
     }
   }

--- a/src/agentMode/skills/nodeFsAdapters.ts
+++ b/src/agentMode/skills/nodeFsAdapters.ts
@@ -1,9 +1,8 @@
 import { logWarn } from "@/logger";
-import * as fs from "node:fs";
-import * as path from "node:path";
 import type { ProjectDiscoveryFs } from "./discoverProjectSkills";
 import type { MigrateSkillFs } from "./migrateProjectSkill";
 import { errCode } from "@/utils/errorUtils";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import type { ReconcileFs } from "./reconcile";
 import type { SymlinksFs } from "./symlinks";
 
@@ -18,6 +17,7 @@ import type { SymlinksFs } from "./symlinks";
  * directory-only (which is exactly what skills need).
  */
 export function createNodeMigrateSkillFs(): MigrateSkillFs {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
   return {
     ...createNodeSymlinksFs(),
     async readFile(p) {
@@ -34,6 +34,7 @@ export function createNodeMigrateSkillFs(): MigrateSkillFs {
 }
 
 async function nodeList(p: string, warn = false): Promise<string[]> {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
   try {
     return await fs.promises.readdir(p);
   } catch (err) {
@@ -45,6 +46,8 @@ async function nodeList(p: string, warn = false): Promise<string[]> {
 }
 
 async function nodeReadlinkAbs(p: string): Promise<string | null> {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const path = requireNodeModule<typeof import("node:path")>("path");
   try {
     const target = await fs.promises.readlink(p);
     return path.isAbsolute(target) ? target : path.resolve(path.dirname(p), target);
@@ -59,6 +62,8 @@ async function nodeReadlinkAbs(p: string): Promise<string | null> {
  * reconcile logic.
  */
 export function createNodeSymlinksFs(): SymlinksFs {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const path = requireNodeModule<typeof import("node:path")>("path");
   return {
     async exists(p) {
       try {
@@ -115,6 +120,7 @@ export function createNodeSymlinksFs(): SymlinksFs {
  * links via lstat).
  */
 export function createNodeProjectDiscoveryFs(): ProjectDiscoveryFs {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
   return {
     ...createNodeSymlinksFs(),
     list: (p) => nodeList(p),
@@ -129,6 +135,7 @@ export function createNodeProjectDiscoveryFs(): ProjectDiscoveryFs {
  * with shallow listing + readlink resolution used for orphan sweep.
  */
 export function createNodeReconcileFs(): ReconcileFs {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
   return {
     ...createNodeSymlinksFs(),
     list: (p) => nodeList(p),

--- a/src/agentMode/skills/renameWithRetry.ts
+++ b/src/agentMode/skills/renameWithRetry.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 /**
  * Retry-aware `fs.rename`. Windows commonly fails the first attempt when
@@ -15,6 +15,7 @@ import * as fs from "node:fs";
  * @param attempts Total attempts (default 3).
  */
 export async function renameWithRetry(from: string, to: string, attempts = 3): Promise<void> {
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
   let lastErr: unknown;
   for (let i = 0; i < attempts; i++) {
     try {

--- a/src/agentMode/ui/ReportIssueModal.tsx
+++ b/src/agentMode/ui/ReportIssueModal.tsx
@@ -4,7 +4,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
 import { logError, logInfo } from "@/logger";
 import { captureViewScreenshot } from "@/utils/captureViewScreenshot";
-import { isDesktopRuntime } from "@/utils/desktopRuntime";
+import { isDesktopRuntime, requireNodeModule } from "@/utils/desktopRuntime";
 import { assembleReportBundle, type ReportEnvInfo } from "@/utils/issueReport";
 import { findLatestOpencodeLog } from "@/utils/opencodeLog";
 import { createPluginRoot } from "@/utils/react/createPluginRoot";
@@ -52,10 +52,8 @@ function getElectronShell(): ElectronShell | null {
 
 function reportsRootDir(): string | null {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- report paths use Node only inside this optional desktop runtime probe
-    const os = require("node:os") as typeof import("node:os");
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- report paths use Node only inside this optional desktop runtime probe
-    const path = require("node:path") as typeof import("node:path");
+    const os = requireNodeModule<typeof import("node:os")>("os");
+    const path = requireNodeModule<typeof import("node:path")>("path");
     return path.join(os.tmpdir(), "obsidian-copilot", "reports");
   } catch {
     return null;
@@ -258,8 +256,7 @@ export class ReportIssueModal extends Modal {
 
 async function resolveOpencodeLogPath(): Promise<string | null> {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- Opencode log discovery is a desktop-only best-effort path
-    const os = require("node:os") as typeof import("node:os");
+    const os = requireNodeModule<typeof import("node:os")>("os");
     // Resolve the log dir from the same env OpencodeBackend spawns opencode with:
     // user env overrides (e.g. XDG_DATA_HOME / HOME) relocate opencode's data dir,
     // so the log lives wherever the merged env points, not the ambient one.

--- a/src/context/contextCacheFs.ts
+++ b/src/context/contextCacheFs.ts
@@ -1,3 +1,5 @@
+import { requireNodeModule } from "@/utils/desktopRuntime";
+
 /**
  * Minimal filesystem surface the project-context materializer needs. Kept as an
  * injectable interface so the cache logic stays pure and unit-testable with an
@@ -51,7 +53,7 @@ let atomicTempSeq = 0;
  * paths are resolved only in `conversionsLocation` — and every operation is
  * confined under `root`.
  *
- * `node:fs` / `node:path` are loaded lazily (via `require`) inside the factory,
+ * `node:fs` / `node:path` are loaded lazily (via `requireNodeModule`) inside the factory,
  * not at module top-level. Reason: this file also exports the node-free
  * {@link ContextCacheFs} interface; a top-level `import "node:fs"` would
  * evaluate Node builtins for *any* importer of this module — including
@@ -68,10 +70,8 @@ let atomicTempSeq = 0;
  *  - `list` / `remove` / `clear` tolerate a missing target (`[]` / idempotent).
  */
 export function createNodeContextCacheFs(root: string): NodeContextCacheFs {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- desktop cache access is loaded only inside this explicitly constructed Node adapter
-  const fs = require("node:fs") as typeof import("node:fs");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- desktop path handling stays behind the same Node adapter boundary
-  const nodePath = require("node:path") as typeof import("node:path");
+  const fs = requireNodeModule<typeof import("node:fs")>("fs");
+  const nodePath = requireNodeModule<typeof import("node:path")>("path");
 
   const rootAbs = nodePath.resolve(root);
 

--- a/src/context/conversionsLocation.ts
+++ b/src/context/conversionsLocation.ts
@@ -1,11 +1,14 @@
 import type { App } from "obsidian";
 // These builders produce absolute, OS-native paths for the desktop-only
 // off-vault cache; mobile never reaches them (Agent Mode is desktop-gated).
-import os from "node:os";
-import * as path from "node:path";
 import { copilotAppDataDir, getVaultId } from "@/utils/appPaths";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { md5 } from "@/utils/hash";
 import type { MaterializedSourceType } from "./contextCacheStore";
+
+function joinPath(...parts: string[]): string {
+  return requireNodeModule<typeof import("node:path")>("path").join(...parts);
+}
 
 /**
  * Single source of truth for where this vault's shared, off-vault conversion
@@ -47,17 +50,18 @@ import type { MaterializedSourceType } from "./contextCacheStore";
  * storage doesn't fit the absolute-path/off-vault/cross-project-dedup needs here).
  */
 export function cacheRoot(app: App): string {
-  return path.join(copilotAppDataDir(os.homedir()), "vaults", getVaultId(app), "context-cache");
+  const os = requireNodeModule<typeof import("node:os")>("os");
+  return joinPath(copilotAppDataDir(os.homedir()), "vaults", getVaultId(app), "context-cache");
 }
 
 /** Shared snapshots for remote sources (web pages, YouTube transcripts). */
 export function remotesDir(app: App): string {
-  return path.join(cacheRoot(app), "remotes");
+  return joinPath(cacheRoot(app), "remotes");
 }
 
 /** Shared snapshots for converted vault binaries (PDF, image, …), keyed by vault path. */
 export function filesDir(app: App): string {
-  return path.join(cacheRoot(app), "files");
+  return joinPath(cacheRoot(app), "files");
 }
 
 /**
@@ -65,7 +69,7 @@ export function filesDir(app: App): string {
  * are shared but a failure is meaningful only to the project that hit it.
  */
 export function markersDir(app: App, projectId: string): string {
-  return path.join(cacheRoot(app), "markers", md5(projectId));
+  return joinPath(cacheRoot(app), "markers", md5(projectId));
 }
 
 /**
@@ -76,5 +80,5 @@ export function markersDir(app: App, projectId: string): string {
  * absolute path is the only pointer reachable across all three backends).
  */
 export function snapshotAbsPath(app: App, type: MaterializedSourceType, fileName: string): string {
-  return path.join(type === "file" ? filesDir(app) : remotesDir(app), fileName);
+  return joinPath(type === "file" ? filesDir(app) : remotesDir(app), fileName);
 }

--- a/src/symposium/symposiumAgentHandoff.ts
+++ b/src/symposium/symposiumAgentHandoff.ts
@@ -1,13 +1,9 @@
-import { lstat, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import * as path from "node:path";
-import { pathToFileURL } from "node:url";
-
 import { SYMPOSIUM_AGENT_HANDOFF_DIR, SYMPOSIUM_MAX_HTML_BYTES } from "@/symposium/constants";
 import {
   SymposiumDocumentUnsafeError,
   validateSymposiumReviewHtml,
 } from "@/symposium/symposiumDocument";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 
 /** Signals that a filesystem-backed agent handoff cannot be consumed safely. */
 class SymposiumAgentHandoffError extends Error {
@@ -61,6 +57,8 @@ function getDirectHandoffName(stagedHtmlPath: string): string {
 }
 
 async function getHandoffRoot(vaultRootAbs: string): Promise<string> {
+  const { lstat } = requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
+  const path = requireNodeModule<typeof import("node:path")>("path");
   const symposiumRoot = path.resolve(vaultRootAbs, ".symposium");
   const handoffRoot = path.join(symposiumRoot, "handoffs");
   try {
@@ -86,6 +84,7 @@ function decodeUtf8(bytes: Uint8Array): string {
 }
 
 async function removeHandoff(stagedPath: string): Promise<void> {
+  const { unlink } = requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
   try {
     await unlink(stagedPath);
   } catch (error) {
@@ -148,6 +147,11 @@ seal();
 }
 
 async function createLocalPreview(html: string): Promise<SymposiumAgentHandoff> {
+  const { lstat, mkdtemp, readFile, rm, writeFile } =
+    requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
+  const { tmpdir } = requireNodeModule<typeof import("node:os")>("os");
+  const path = requireNodeModule<typeof import("node:path")>("path");
+  const { pathToFileURL } = requireNodeModule<typeof import("node:url")>("url");
   const previewRoot = await mkdtemp(path.join(tmpdir(), PREVIEW_FOLDER_PREFIX));
   const previewPath = path.join(previewRoot, PREVIEW_FILE_NAME);
   const browserPreview = createBrowserPreview(html);
@@ -189,6 +193,8 @@ export async function consumeSymposiumAgentHandoff(
   vaultRootAbs: string,
   stagedHtmlPath: string
 ): Promise<SymposiumAgentHandoff> {
+  const { lstat, readFile } = requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
+  const path = requireNodeModule<typeof import("node:path")>("path");
   const fileName = getDirectHandoffName(stagedHtmlPath);
   const handoffRoot = await getHandoffRoot(vaultRootAbs);
   const stagedPath = path.join(handoffRoot, fileName);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 // Reason: `buffer` is the npm polyfill (browser-compatible), bundled by esbuild
 // so the same Buffer code path works on desktop (Electron) and mobile (WebView).
-import { Buffer } from "buffer";
+import { Buffer } from "buffer/";
 
 import { ChainType } from "@/chainType";
 import {
@@ -822,7 +822,7 @@ export async function safeFetch(
       // Reason: Buffer (from the `buffer` polyfill imported above) is the
       // cross-platform path — bare global Buffer is undefined in mobile WebView.
       const buf = Buffer.from(base64, "base64");
-      return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+      return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
     },
     blob: () => {
       throw new Error("not implemented");

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -3,7 +3,7 @@
 // no Node globals, so bare `Buffer` throws "Can't find variable: Buffer" on iOS
 // WebKit. esbuild bundles this polyfill into main.js so the same code path
 // works on both desktop and mobile.
-import { Buffer } from "buffer";
+import { Buffer } from "buffer/";
 
 export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   return Buffer.from(buffer).toString("base64");
@@ -11,5 +11,5 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
 
 export function base64ToArrayBuffer(base64: string): ArrayBuffer {
   const buf = Buffer.from(base64, "base64");
-  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
 }

--- a/src/utils/issueReport.ts
+++ b/src/utils/issueReport.ts
@@ -14,6 +14,7 @@
  */
 
 import { redactLogText } from "./redactLog";
+import { requireNodeModule } from "./desktopRuntime";
 
 /**
  * End-user reports go to the PUBLIC repo. The private `obsidian-copilot-preview`
@@ -187,10 +188,8 @@ export function buildReportIssueUrl(input: ReportInput, attachedFiles: string[])
 }
 
 function getNodeReportRuntime(): ReportRuntime {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- report bundle writing is invoked only by the desktop report flow
-  const fs = require("node:fs/promises") as typeof import("node:fs/promises");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- report bundle paths stay inside the same desktop-only runtime adapter
-  const path = require("node:path") as typeof import("node:path");
+  const fs = requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
+  const path = requireNodeModule<typeof import("node:path")>("path");
   return {
     join: (...parts: string[]) => path.join(...parts),
     mkdir: async (p, opts) => {

--- a/src/utils/openVaultPath.test.ts
+++ b/src/utils/openVaultPath.test.ts
@@ -9,6 +9,7 @@ import { App, FileSystemAdapter } from "obsidian";
 jest.mock("@/logger", () => ({ logInfo: jest.fn(), logWarn: jest.fn(), logError: jest.fn() }));
 jest.mock("@/utils/openWithSystemDefault", () => ({ openWithSystemDefault: jest.fn() }));
 jest.mock("obsidian", () => ({
+  Platform: { isDesktopApp: true, isMobile: false },
   FileSystemAdapter: class FileSystemAdapter {
     private readonly base: string;
     constructor(base = "/vault") {

--- a/src/utils/openVaultPath.ts
+++ b/src/utils/openVaultPath.ts
@@ -1,4 +1,5 @@
 import { openWithSystemDefault } from "@/utils/openWithSystemDefault";
+import { requireNodeModule } from "@/utils/desktopRuntime";
 import { getVaultBase, isAbsolutePath, toVaultRelative } from "@/utils/vaultPath";
 import { App } from "obsidian";
 
@@ -82,8 +83,7 @@ function resolveUnindexedVaultPath(app: App, filePath: string): UnindexedPathRes
   try {
     // Desktop-only: loaded lazily after the vault-base guard, which is null
     // wherever the FileSystemAdapter (and thus node) is unavailable.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports -- realpath is loaded only after confirming a desktop filesystem adapter
-    const fs = require("node:fs") as typeof import("node:fs");
+    const fs = requireNodeModule<typeof import("node:fs")>("fs");
     // Realpath both sides so a vault base that itself sits behind a symlink
     // (e.g. /tmp on macOS) still compares equal to the resolved target.
     const absolutePath = fs.realpathSync(`${vaultBase}/${filePath}`);

--- a/src/utils/opencodeLog.ts
+++ b/src/utils/opencodeLog.ts
@@ -8,6 +8,8 @@
  * directory may not exist, in which case the caller proceeds without the log.
  */
 
+import { requireNodeModule } from "./desktopRuntime";
+
 export interface OpencodeLogRuntime {
   join: (...parts: string[]) => string;
   readdir: (dir: string) => Promise<string[]>;
@@ -62,10 +64,8 @@ export async function findLatestOpencodeLog(
 }
 
 function getNodeOpencodeLogRuntime(): OpencodeLogRuntime {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Opencode log access is contained in this desktop runtime adapter
-  const fs = require("node:fs/promises") as typeof import("node:fs/promises");
-  // eslint-disable-next-line @typescript-eslint/no-require-imports -- Opencode log paths stay inside the same desktop runtime adapter
-  const path = require("node:path") as typeof import("node:path");
+  const fs = requireNodeModule<typeof import("node:fs/promises")>("fs/promises");
+  const path = requireNodeModule<typeof import("node:path")>("path");
   return {
     join: (...parts: string[]) => path.join(...parts),
     readdir: (dir: string) => fs.readdir(dir),


### PR DESCRIPTION
Relates to logancyang/obsidian-copilot-preview#299

## Why

PR #2829 removes the riskiest eager Node imports, but the active `obsidianmd/no-nodejs-modules` rule still found Node built-ins throughout Agent Mode, the context cache, the Symposium handoff, and desktop report/path adapters. Those imports resolved during module evaluation even though their call paths were desktop-only, so mobile loading depended on the bundle tolerating modules that do not exist there.

The rule also treated three imports of the browser-compatible `buffer` package as Node built-ins because its bare package name matches Node's built-in module name. That left false-positive warnings in the review output after the unsafe imports were migrated.

## What

Desktop-only Node modules now resolve at call time behind the shared desktop-runtime guard. Mobile bundle evaluation no longer loads those built-ins, while desktop subprocess, filesystem, binary-management, report, and Symposium behavior remains unchanged.

The browser `buffer` package now uses its explicit package entry point. Review tooling can distinguish it from Node's built-in `buffer`, so `obsidianmd/no-nodejs-modules` reports no warnings without disabling or suppressing the rule.

An error-level `copilot/no-direct-node-imports` rule prevents direct runtime access to Node built-ins from returning. It covers imports, re-exports, dynamic imports, and literal `require()` calls, and directs contributors to `requireNodeModule()` for runtime access or a Node import type query for types. Tests and mocks remain exempt because they execute under Jest rather than the Obsidian renderer.

## Non goal

- Making subprocesses, native filesystem access, or Agent Mode function on mobile; unsupported calls still fail at the shared desktop guard.
- Changing binary discovery, installation, authentication, session persistence, Symposium validation, report-bundle behavior, or binary encoding behavior.
- Changing dependencies, build externals, the `process` banner shim, or plugin manifests.
- Addressing unrelated pre-existing Obsidian review warnings.

## Screenshot

Not applicable — this changes internal runtime module resolution and review output, with no visual change.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Existing unit coverage exercises the migrated adapters and browser-compatible byte conversions |
| A defect would fail CI or be obvious on first use | ✅ | Type checking, lint, mobile bundle evaluation, and unit tests run in CI |
| A revert fully restores prior state, including persisted data | ✅ | No settings, files, schemas, or migrations change |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Auth and path-validation behavior are unchanged; only module-resolution timing changes |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Exported signatures and serialized formats are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Existing subprocess, installer, and persistence flows retain their ordering and control flow |
| No hot-path behavior lacks deterministic coverage | ❌ | Live OS-specific spawn, download, and archive behavior cannot be reproduced across every supported desktop platform in CI |
| No new dependency | ✅ | The browser `buffer` package was already a direct dependency |
| Human-only behavior stays in one feature area and surfaces quickly | ❌ | Desktop module access spans several internal Agent Mode and utility workflows |

Review: inspect the call-time module access in `src/agentMode/backends/opencode/OpencodeBinaryManager.ts`, the explicit browser package imports in `src/utils/base64.ts`, `src/utils.ts`, and `src/LLMProviders/BedrockChatModel.ts`, and the enforcement in `eslint.config.mjs`, then follow Verification.

## Verification

1. Run `npm run lint` and confirm it reports no `obsidianmd/no-nodejs-modules` warnings and rejects the direct-Node negative fixtures with `copilot/no-direct-node-imports`.
2. Run `npm run review:obsidian` and confirm the review regression fixtures pass.
3. Run `npm run test:mobile-load` and confirm the production bundle evaluates while Node built-ins are unavailable.
4. On desktop, start a configured Agent Mode backend and confirm it launches and responds normally.

## Note

Node's module detector classifies the bare name `buffer` as built-in even when esbuild resolves the installed browser polyfill. Naming the dependency's package entry point removes that ambiguity while keeping the review rule enabled globally.
