### PR TITLE
Build DOM through Obsidian's createEl helpers

### DIFF
--- a/dev/gallery/audit.ts
+++ b/dev/gallery/audit.ts
@@ -226,9 +226,8 @@ function hasVisibleUnsupportedColor(value: string): boolean {
  */
 export function resolveObsidianColorTokens(doc: Document): ReadonlySet<string> {
   const colors = new Set<string>();
-  const probe = doc.createElement("span");
+  const probe = doc.body.createSpan();
   probe.hidden = true;
-  doc.body.append(probe);
 
   for (const source of [doc.documentElement, doc.body]) {
     const styles = source.win.getComputedStyle(source);

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,6 +64,38 @@ const copilotLintPlugin = {
   },
 };
 
+// obsidianmd ships its rules as warnings, and a warning stream nobody gates on
+// is how 30 `prefer-create-el` violations reached the plugin's community listing
+// unnoticed. Promote every rule the codebase already satisfies to an error so
+// the next one fails `npm run lint` in CI on the PR that introduces it. Rules
+// listed here keep the recommended severity because they have a known backlog or
+// a deliberate override; each needs its own reason, not a blanket exemption.
+const OBSIDIANMD_UNRATCHETED = new Set([
+  // Declarative settings migration, tracked by logancyang/obsidian-copilot-preview#297.
+  "settings-tab/prefer-setting-definitions",
+  // Turned off below; promoting here would resurrect them.
+  "ui/sentence-case",
+  "platform",
+  // Configured below with a project-specific message payload.
+  "rule-custom-message",
+]);
+
+// Only raise the severity of rules the recommended config already turns on.
+// Rules it leaves off are its own judgement call; adopting one is a separate
+// decision with its own cleanup, not something this ratchet should smuggle in.
+const OBSIDIANMD_RATCHET = Object.fromEntries(
+  Object.entries(
+    (Array.isArray(obsidianmd.configs.recommended)
+      ? obsidianmd.configs.recommended
+      : [obsidianmd.configs.recommended]
+    ).reduce((rules, block) => Object.assign(rules, block.rules), {})
+  )
+    .filter(([id]) => id.startsWith("obsidianmd/"))
+    .filter(([, severity]) => severity !== "off" && severity !== 0)
+    .filter(([id]) => !OBSIDIANMD_UNRATCHETED.has(id.slice("obsidianmd/".length)))
+    .map(([id]) => [id, "error"])
+);
+
 const restrictedSourceImports = [
   {
     selector:
@@ -633,11 +665,7 @@ export default [
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-unsafe-return": "error",
       "@typescript-eslint/unbound-method": "error",
-      // The community directory surfaces native DOM construction as a warning on
-      // the plugin's listing. Source is clean of it, so block regressions here
-      // rather than letting them accumulate back into the listing. Type-aware, so
-      // it can only live in this block.
-      "obsidianmd/prefer-create-el": "error",
+      ...OBSIDIANMD_RATCHET,
       // TypeScript handles undefined-identifier detection (and does so cross-realm
       // correctly); per typescript-eslint's own guidance, disable no-undef on TS.
       "no-undef": "off",
@@ -698,13 +726,16 @@ export default [
     },
   },
 
-  // Tests build fixture DOM against jsdom, which has no Obsidian helpers, so the
-  // native API is the right call there. Same "placed last" reason as above: the
-  // TS-only block promotes this rule to an error for shipped source.
+  // Tests run under Jest against jsdom, not inside Obsidian on a phone: they
+  // build fixture DOM with the native API because the Obsidian helpers do not
+  // exist there, and they import Node built-ins directly because Node is the
+  // runtime. Both rules stay errors for shipped source; this block is placed
+  // last so it overrides the ratchet in the TS-only block above.
   {
     files: ["**/*.test.{ts,tsx}"],
     rules: {
       "obsidianmd/prefer-create-el": "off",
+      "obsidianmd/no-nodejs-modules": "off",
     },
   },
 ];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -633,6 +633,11 @@ export default [
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-unsafe-return": "error",
       "@typescript-eslint/unbound-method": "error",
+      // The community directory surfaces native DOM construction as a warning on
+      // the plugin's listing. Source is clean of it, so block regressions here
+      // rather than letting them accumulate back into the listing. Type-aware, so
+      // it can only live in this block.
+      "obsidianmd/prefer-create-el": "error",
       // TypeScript handles undefined-identifier detection (and does so cross-realm
       // correctly); per typescript-eslint's own guidance, disable no-undef on TS.
       "no-undef": "off",
@@ -690,6 +695,16 @@ export default [
     files: ["**/*.test.{ts,tsx}"],
     rules: {
       "@typescript-eslint/unbound-method": "off",
+    },
+  },
+
+  // Tests build fixture DOM against jsdom, which has no Obsidian helpers, so the
+  // native API is the right call there. Same "placed last" reason as above: the
+  // TS-only block promotes this rule to an error for shipped source.
+  {
+    files: ["**/*.test.{ts,tsx}"],
+    rules: {
+      "obsidianmd/prefer-create-el": "off",
     },
   },
 ];

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -23,6 +23,75 @@ if (typeof Node !== "undefined" && !Object.prototype.hasOwnProperty.call(Node.pr
   });
 }
 
+// Polyfill Obsidian's DOM creation helpers. Obsidian installs `createEl` and
+// friends on every window and on `Node.prototype`; jsdom has neither, so plugin
+// code that builds elements through them would throw under test.
+function applyDomElementInfo(el, info) {
+  if (info.cls) {
+    el.className = Array.isArray(info.cls) ? info.cls.join(" ") : info.cls;
+  }
+  if (info.text != null) {
+    if (info.text instanceof Node) {
+      el.replaceChildren(info.text);
+    } else {
+      el.textContent = String(info.text);
+    }
+  }
+  for (const [name, value] of Object.entries(info.attr ?? {})) {
+    if (value === null) {
+      el.removeAttribute(name);
+    } else {
+      el.setAttribute(name, String(value));
+    }
+  }
+  for (const key of ["title", "value", "type", "placeholder", "href"]) {
+    if (info[key] !== undefined) {
+      el[key] = info[key];
+    }
+  }
+}
+
+function toDomElementInfo(info) {
+  return typeof info === "string" ? { cls: info } : { ...info };
+}
+
+if (typeof window.createEl !== "function") {
+  window.createEl = function (tag, info, callback) {
+    const options = toDomElementInfo(info);
+    const el = window.document.createElement(tag);
+    applyDomElementInfo(el, options);
+    // Obsidian runs the callback before attaching, so callers can finish
+    // building the element without the parent seeing a half-built child.
+    callback?.(el);
+    if (options.parent) {
+      if (options.prepend) {
+        options.parent.insertBefore(el, options.parent.firstChild);
+      } else {
+        options.parent.appendChild(el);
+      }
+    }
+    return el;
+  };
+  window.createDiv = (info, callback) => window.createEl("div", info, callback);
+  window.createSpan = (info, callback) => window.createEl("span", info, callback);
+  window.createFragment = (callback) => {
+    const fragment = window.document.createDocumentFragment();
+    callback?.(fragment);
+    return fragment;
+  };
+}
+if (typeof Node !== "undefined" && typeof Node.prototype.createEl !== "function") {
+  Node.prototype.createEl = function (tag, info, callback) {
+    return window.createEl(tag, { ...toDomElementInfo(info), parent: this }, callback);
+  };
+  Node.prototype.createDiv = function (info, callback) {
+    return this.createEl("div", info, callback);
+  };
+  Node.prototype.createSpan = function (info, callback) {
+    return this.createEl("span", info, callback);
+  };
+}
+
 // Polyfill Obsidian's `HTMLElement.setCssProps` augmentation (sets one or more
 // CSS custom properties) so plugin code that calls it — e.g. the autosizing
 // `Textarea` — works under jsdom.

--- a/src/commands/CustomCommandChatModal.tsx
+++ b/src/commands/CustomCommandChatModal.tsx
@@ -636,9 +636,7 @@ export class CustomCommandChatModal {
     const activeView = this.app.workspace.getActiveViewOfType(MarkdownView);
 
     const doc = this.resolveDocument(activeView);
-    this.container = doc.createElement("div");
-    this.container.className = "copilot-menu-command-modal-container";
-    doc.body.appendChild(this.container);
+    this.container = doc.body.createDiv("copilot-menu-command-modal-container");
 
     this.root = createPluginRoot(this.container, this.app);
 

--- a/src/components/chat-components/ChatSingleMessage.test.tsx
+++ b/src/components/chat-components/ChatSingleMessage.test.tsx
@@ -334,6 +334,50 @@ describe("ChatSingleMessage", () => {
     expect(messageSegment?.querySelector('a[href="#fn-2"]')?.textContent).toBe("2");
   });
 
+  it("turns an inline citation marker into a link that keeps the source anchor's Obsidian metadata", async () => {
+    renderMarkdownMock.mockImplementation(
+      async (_app: unknown, _markdown: string, el: HTMLElement) => {
+        el.append(
+          ...new DOMParser().parseFromString(
+            `
+        <p>A claim <span class="copilot-citation-ref">[1]</span></p>
+        <div class="copilot-sources">
+          <div class="copilot-sources__item">
+            <span class="copilot-sources__index">[1]</span>
+            <span class="copilot-sources__text">
+              <a class="internal-link" data-href="Some Note">Some Note</a>
+            </span>
+          </div>
+        </div>
+      `,
+            "text/html"
+          ).body.children
+        );
+      }
+    );
+
+    const { container } = render(
+      <TooltipProvider>
+        <ChatSingleMessage
+          message={baseMessage}
+          app={createAppStub()}
+          isStreaming={false}
+          onDelete={() => {}}
+        />
+      </TooltipProvider>
+    );
+
+    await waitFor(() => expect(container.querySelector(".copilot-citation-group")).not.toBeNull());
+
+    const group = container.querySelector(".copilot-citation-group");
+    expect(group?.textContent).toBe("[1]");
+    const link = group?.querySelector("a.copilot-citation-link");
+    expect(link?.textContent).toBe("1");
+    expect(link?.getAttribute("aria-label")).toBe("Source 1");
+    expect(link?.getAttribute("data-href")).toBe("Some Note");
+    expect(container.querySelector(".copilot-citation-ref")).toBeNull();
+  });
+
   it("marks rendered text segments with markdown-rendered for native reading-view styling", async () => {
     const { container } = render(
       <TooltipProvider>

--- a/src/components/chat-components/ChatSingleMessage.tsx
+++ b/src/components/chat-components/ChatSingleMessage.tsx
@@ -147,7 +147,7 @@ const linkInlineCitations = (root: HTMLElement): void => {
     const text = node.textContent || "";
     INLINE_CITATION_RE.lastIndex = 0;
 
-    const fragment = doc.createDocumentFragment();
+    const fragment = doc.win.createFragment();
     let lastIndex = 0;
     let match: RegExpExecArray | null;
 
@@ -161,13 +161,12 @@ const linkInlineCitations = (root: HTMLElement): void => {
       const allResolved = nums.every((num) => citationAnchors.has(num));
 
       if (allResolved) {
-        const span = doc.createElement("span");
-        span.className = "copilot-citation-group";
+        const span = doc.win.createSpan("copilot-citation-group");
         span.appendChild(doc.createTextNode("["));
         nums.forEach((num, i) => {
           if (i > 0) span.appendChild(doc.createTextNode(", "));
           const sourceAnchor = citationAnchors.get(num)!;
-          const link = doc.createElement("a");
+          const link = doc.win.createEl("a");
           // Copy all attributes from the source anchor so Obsidian internal-link
           // metadata (e.g. data-href, class="internal-link") is preserved.
           for (const attr of Array.from(sourceAnchor.attributes)) {
@@ -690,12 +689,11 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
             // Find where to insert this text segment
             const insertBefore = contentRef.current!.children[currentIndex];
 
-            const textDiv = doc.createElement("div");
             // `markdown-rendered` opts the container into Obsidian's native
             // reading-view stylesheet so reloaded messages match the live
             // render path (AgentMarkdownText). Most visibly, it restores the
             // gray background pill on inline `<code>` spans.
-            textDiv.className = "message-segment markdown-rendered";
+            const textDiv = doc.win.createDiv("message-segment markdown-rendered");
 
             if (insertBefore) {
               contentRef.current!.insertBefore(textDiv, insertBefore);
@@ -713,9 +711,10 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
 
             if (!container) {
               const insertBefore = contentRef.current!.children[currentIndex];
-              const toolDiv = doc.createElement("div");
-              toolDiv.className = "tool-call-container";
-              toolDiv.id = `tool-call-${toolCallId}`;
+              const toolDiv = doc.win.createDiv({
+                cls: "tool-call-container",
+                attr: { id: `tool-call-${toolCallId}` },
+              });
 
               if (insertBefore) {
                 contentRef.current!.insertBefore(toolDiv, insertBefore);
@@ -747,9 +746,10 @@ const ChatSingleMessage: React.FC<ChatSingleMessageProps> = ({
             if (!container) {
               // Insert error block at the current stream position
               const insertBefore = contentRef.current!.children[currentIndex];
-              const errorDiv = doc.createElement("div");
-              errorDiv.className = "error-block-container";
-              errorDiv.id = `error-block-${errorId}`;
+              const errorDiv = doc.win.createDiv({
+                cls: "error-block-container",
+                attr: { id: `error-block-${errorId}` },
+              });
 
               if (insertBefore) {
                 contentRef.current!.insertBefore(errorDiv, insertBefore);

--- a/src/components/chat-components/openImagePicker.ts
+++ b/src/components/chat-components/openImagePicker.ts
@@ -24,12 +24,10 @@ interface ImagePickerHandlers {
  * in the window hosting the view, not whichever window is focused (popout-safe).
  */
 export function openImagePicker(doc: Document, handlers: ImagePickerHandlers): void {
-  const input = doc.createElement("input");
-  input.type = "file";
-  input.accept = "image/*";
-  input.multiple = true;
-  input.classList.add("tw-hidden");
-  doc.body.appendChild(input);
+  const input = doc.body.createEl("input", {
+    cls: "tw-hidden",
+    attr: { type: "file", accept: "image/*", multiple: true },
+  });
 
   const settle = (): void => {
     input.remove();

--- a/src/components/chat-components/pills/ActiveNotePillNode.tsx
+++ b/src/components/chat-components/pills/ActiveNotePillNode.tsx
@@ -3,7 +3,6 @@ import {
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
-  EditorConfig,
   LexicalEditor,
   LexicalNode,
   NodeKey,
@@ -44,12 +43,6 @@ export class ActiveNotePillNode extends BasePillNode {
     return "data-lexical-active-note-pill";
   }
 
-  createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
-    span.className = "active-note-pill-wrapper";
-    return span;
-  }
-
   static importDOM(): DOMConversionMap | null {
     return {
       span: (node: HTMLElement) => {
@@ -77,9 +70,10 @@ export class ActiveNotePillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
-    element.setAttribute("data-lexical-active-note-pill", "true");
-    element.textContent = "{activeNote}";
+    const element = getEditorDocument(editor).win.createSpan({
+      text: "{activeNote}",
+      attr: { "data-lexical-active-note-pill": "true" },
+    });
     return { element };
   }
 

--- a/src/components/chat-components/pills/ActiveWebTabPillNode.tsx
+++ b/src/components/chat-components/pills/ActiveWebTabPillNode.tsx
@@ -3,7 +3,6 @@ import {
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
-  EditorConfig,
   LexicalEditor,
   LexicalNode,
   NodeKey,
@@ -45,12 +44,6 @@ export class ActiveWebTabPillNode extends BasePillNode {
     return "data-lexical-active-web-tab-pill";
   }
 
-  createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
-    span.className = "active-web-tab-pill-wrapper";
-    return span;
-  }
-
   static importDOM(): DOMConversionMap | null {
     return {
       span: (node: HTMLElement) => {
@@ -78,9 +71,10 @@ export class ActiveWebTabPillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
-    element.setAttribute("data-lexical-active-web-tab-pill", "true");
-    element.textContent = ACTIVE_WEB_TAB_MARKER;
+    const element = getEditorDocument(editor).win.createSpan({
+      text: ACTIVE_WEB_TAB_MARKER,
+      attr: { "data-lexical-active-web-tab-pill": "true" },
+    });
     return { element };
   }
 

--- a/src/components/chat-components/pills/BasePillNode.test.tsx
+++ b/src/components/chat-components/pills/BasePillNode.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { createEditor, type EditorConfig, type LexicalEditor } from "lexical";
+import { BasePillNode } from "./BasePillNode";
+
+class TestPillNode extends BasePillNode {
+  static getType(): string {
+    return "test-pill";
+  }
+
+  static clone(node: TestPillNode): TestPillNode {
+    return new TestPillNode(node.__value, node.__key);
+  }
+
+  getClassName(): string {
+    return "test-pill-wrapper";
+  }
+
+  getDataAttribute(): string {
+    return "data-lexical-test-pill";
+  }
+
+  decorate(): JSX.Element {
+    return <span />;
+  }
+}
+
+const TEST_EDITOR_CONFIG: EditorConfig = { namespace: "base-pill-test", theme: {} };
+
+/** Builds an editor whose root element lives in the jsdom document. */
+function makeEditor(): LexicalEditor {
+  const editor = createEditor({
+    namespace: "base-pill-test",
+    nodes: [TestPillNode],
+    onError: (e) => {
+      throw e;
+    },
+  });
+  editor.setRootElement(document.body.createDiv());
+  return editor;
+}
+
+describe("BasePillNode", () => {
+  describe("createDOM()", () => {
+    it("returns a detached span wearing the subclass's wrapper class", () => {
+      const editor = makeEditor();
+      editor.update(
+        () => {
+          const element = new TestPillNode("value").createDOM(TEST_EDITOR_CONFIG, editor);
+
+          expect(element.tagName).toBe("SPAN");
+          expect(element.className).toBe("test-pill-wrapper");
+          // Lexical owns placement; handing it an already-attached node would
+          // duplicate the pill in the composer.
+          expect(element.parentNode).toBeNull();
+        },
+        { discrete: true }
+      );
+    });
+
+    it("builds the span in the document that hosts the editor", () => {
+      const editor = makeEditor();
+      editor.update(
+        () => {
+          const element = new TestPillNode("value").createDOM(TEST_EDITOR_CONFIG, editor);
+
+          expect(element.ownerDocument).toBe(editor.getRootElement()?.ownerDocument);
+        },
+        { discrete: true }
+      );
+    });
+  });
+
+  describe("exportDOM()", () => {
+    it("marks the span with the pill attribute, its value, and the value as text", () => {
+      const editor = makeEditor();
+      editor.update(
+        () => {
+          const { element } = new TestPillNode("some value").exportDOM(editor);
+
+          expect((element as HTMLElement).getAttribute("data-lexical-test-pill")).toBe("");
+          expect((element as HTMLElement).getAttribute("data-pill-value")).toBe("some value");
+          expect(element?.textContent).toBe("some value");
+          expect(element?.parentNode).toBeNull();
+        },
+        { discrete: true }
+      );
+    });
+  });
+});

--- a/src/components/chat-components/pills/BasePillNode.tsx
+++ b/src/components/chat-components/pills/BasePillNode.tsx
@@ -118,19 +118,17 @@ export abstract class BasePillNode extends DecoratorNode<JSX.Element> implements
    * Default DOM creation - subclasses can override for custom elements.
    */
   createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
-    span.className = this.getClassName();
-    return span;
+    return getEditorDocument(editor).win.createSpan(this.getClassName());
   }
 
   /**
    * Default DOM export - subclasses can override for custom attributes.
    */
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
-    element.setAttribute(this.getDataAttribute(), "");
-    element.setAttribute("data-pill-value", this.__value);
-    element.textContent = this.__value;
+    const element = getEditorDocument(editor).win.createSpan({
+      text: this.__value,
+      attr: { [this.getDataAttribute()]: "", "data-pill-value": this.__value },
+    });
     return { element };
   }
 

--- a/src/components/chat-components/pills/FolderPillNode.tsx
+++ b/src/components/chat-components/pills/FolderPillNode.tsx
@@ -95,10 +95,10 @@ export class FolderPillNode extends BasePillNode {
    * Override to export DOM with curly braces
    */
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
-    element.setAttribute(this.getDataAttribute(), "");
-    element.setAttribute("data-pill-value", this.__value);
-    element.textContent = `{${this.getFolderPath()}}`;
+    const element = getEditorDocument(editor).win.createSpan({
+      text: `{${this.getFolderPath()}}`,
+      attr: { [this.getDataAttribute()]: "", "data-pill-value": this.__value },
+    });
     return { element };
   }
 

--- a/src/components/chat-components/pills/NotePillNode.tsx
+++ b/src/components/chat-components/pills/NotePillNode.tsx
@@ -4,7 +4,6 @@ import {
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
-  EditorConfig,
   LexicalEditor,
   LexicalNode,
   NodeKey,
@@ -44,12 +43,6 @@ export class NotePillNode extends BasePillNode {
     return "data-lexical-note-pill";
   }
 
-  createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
-    span.className = "note-pill-wrapper";
-    return span;
-  }
-
   static importDOM(): DOMConversionMap | null {
     return {
       span: (node: HTMLElement) => {
@@ -80,17 +73,20 @@ export class NotePillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
-    element.setAttribute("data-lexical-note-pill", "true");
-    element.setAttribute("data-note-title", this.__noteTitle);
-    element.setAttribute("data-note-path", this.__notePath);
     const lowerPath = this.__notePath.toLowerCase();
     const displayName = lowerPath.endsWith(".pdf")
       ? `${this.__noteTitle}.pdf`
       : lowerPath.endsWith(".canvas")
         ? `${this.__noteTitle}.canvas`
         : this.__noteTitle;
-    element.textContent = `[[${displayName}]]`;
+    const element = getEditorDocument(editor).win.createSpan({
+      text: `[[${displayName}]]`,
+      attr: {
+        "data-lexical-note-pill": "true",
+        "data-note-title": this.__noteTitle,
+        "data-note-path": this.__notePath,
+      },
+    });
     return { element };
   }
 

--- a/src/components/chat-components/pills/URLPillNode.tsx
+++ b/src/components/chat-components/pills/URLPillNode.tsx
@@ -4,7 +4,6 @@ import {
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
-  EditorConfig,
   LexicalEditor,
   LexicalNode,
   NodeKey,
@@ -50,12 +49,6 @@ export class URLPillNode extends BasePillNode {
     return "data-lexical-url-pill";
   }
 
-  createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
-    span.className = "url-pill-wrapper";
-    return span;
-  }
-
   static importDOM(): DOMConversionMap | null {
     return {
       span: (node: HTMLElement) => {
@@ -87,13 +80,13 @@ export class URLPillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
-    element.setAttribute("data-lexical-url-pill", "true");
-    element.setAttribute("data-url", this.__url);
+    const element = getEditorDocument(editor).win.createSpan({
+      text: this.__url,
+      attr: { "data-lexical-url-pill": "true", "data-url": this.__url },
+    });
     if (this.__title) {
       element.setAttribute("data-title", this.__title);
     }
-    element.textContent = this.__url;
     return { element };
   }
 

--- a/src/components/chat-components/pills/WebTabPillNode.tsx
+++ b/src/components/chat-components/pills/WebTabPillNode.tsx
@@ -4,7 +4,6 @@ import {
   DOMConversionMap,
   DOMConversionOutput,
   DOMExportOutput,
-  EditorConfig,
   LexicalEditor,
   LexicalNode,
   NodeKey,
@@ -64,12 +63,6 @@ export class WebTabPillNode extends BasePillNode {
     return "data-lexical-web-tab-pill";
   }
 
-  createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
-    const span = getEditorDocument(editor).createElement("span");
-    span.className = "web-tab-pill-wrapper";
-    return span;
-  }
-
   static importDOM(): DOMConversionMap | null {
     return {
       span: (node: HTMLElement) => {
@@ -101,16 +94,16 @@ export class WebTabPillNode extends BasePillNode {
   }
 
   exportDOM(editor: LexicalEditor): DOMExportOutput {
-    const element = getEditorDocument(editor).createElement("span");
-    element.setAttribute("data-lexical-web-tab-pill", "true");
-    element.setAttribute("data-url", this.__url);
+    const element = getEditorDocument(editor).win.createSpan({
+      text: formatWebTabPillTextContent(this.__url, this.__title),
+      attr: { "data-lexical-web-tab-pill": "true", "data-url": this.__url },
+    });
     if (this.__title) {
       element.setAttribute("data-title", this.__title);
     }
     if (this.__faviconUrl) {
       element.setAttribute("data-favicon-url", this.__faviconUrl);
     }
-    element.textContent = formatWebTabPillTextContent(this.__url, this.__title);
     return { element };
   }
 

--- a/src/components/command-ui/markdown-preview.tsx
+++ b/src/components/command-ui/markdown-preview.tsx
@@ -25,7 +25,7 @@ export function MarkdownPreview({ content, renderMarkdown, className }: Markdown
     // Reason: Render into a detached element so that if content changes
     // mid-render, the stale result never touches the live DOM.
     // Reason: Use the target's doc for popout-window safety in Obsidian
-    const scratchEl = targetEl.doc.createElement("div");
+    const scratchEl = targetEl.doc.win.createDiv();
 
     targetEl.replaceChildren();
     renderMarkdown(content, scratchEl)

--- a/src/components/quick-ask/QuickAskOverlay.tsx
+++ b/src/components/quick-ask/QuickAskOverlay.tsx
@@ -313,10 +313,7 @@ export class QuickAskOverlay {
 
     if (QuickAskOverlay.overlayRoot) return QuickAskOverlay.overlayRoot;
 
-    const doc = host.doc;
-    const root = doc.createElement("div");
-    root.className = "copilot-quick-ask-overlay-root";
-    host.appendChild(root);
+    const root = host.createDiv("copilot-quick-ask-overlay-root");
     host.classList.add("copilot-quick-ask-overlay-host");
     QuickAskOverlay.overlayRoot = root;
     return root;
@@ -334,9 +331,7 @@ export class QuickAskOverlay {
     this.ownerWindow = win;
 
     const overlayRoot = QuickAskOverlay.getOverlayRoot(overlayHost);
-    const overlayContainer = doc.createElement("div");
-    overlayContainer.className = "copilot-quick-ask-overlay";
-    overlayRoot.appendChild(overlayContainer);
+    const overlayContainer = overlayRoot.createDiv("copilot-quick-ask-overlay");
     this.overlayContainer = overlayContainer;
 
     this.root = createPluginRoot(overlayContainer, this.options.plugin.app);

--- a/src/symposium/symposiumDocument.ts
+++ b/src/symposium/symposiumDocument.ts
@@ -258,8 +258,10 @@ export async function buildSymposiumDocument(
   ownerDocument: Document
 ): Promise<SymposiumDocument> {
   const markdown = await app.vault.read(file);
-  const article = ownerDocument.createElement("article");
-  article.className = "markdown-preview-view markdown-rendered symposium-document";
+  const article = ownerDocument.win.createEl(
+    "article",
+    "markdown-preview-view markdown-rendered symposium-document"
+  );
 
   const render = (MarkdownRenderer as unknown as { render: ModernRender }).render;
   await render(app, markdown, article, file.path, component);
@@ -295,12 +297,12 @@ function normalizeMath(root: HTMLElement): void {
 
 function normalizeTaskCheckboxes(root: HTMLElement): void {
   root.querySelectorAll<HTMLInputElement>("input.task-list-item-checkbox").forEach((checkbox) => {
-    const marker = root.doc.createElement("span");
     const checked = checkbox.checked || checkbox.hasAttribute("checked");
-    marker.className = "symposium-task-marker";
-    marker.setAttribute("role", "img");
-    marker.setAttribute("aria-label", checked ? "Completed task" : "Open task");
-    marker.textContent = checked ? "☑" : "☐";
+    const marker = root.doc.win.createSpan({
+      cls: "symposium-task-marker",
+      text: checked ? "☑" : "☐",
+      attr: { role: "img", "aria-label": checked ? "Completed task" : "Open task" },
+    });
     checkbox.replaceWith(marker);
   });
 }
@@ -311,10 +313,9 @@ function removeUnsupportedContent(root: HTMLElement): void {
 
 function normalizeInternalLinks(root: HTMLElement): void {
   root.querySelectorAll<HTMLAnchorElement>("a.internal-link").forEach((link) => {
-    const replacement = root.doc.createElement("span");
-    replacement.className = [...link.classList]
-      .filter((name) => name !== "is-unresolved")
-      .join(" ");
+    const replacement = root.doc.win.createSpan(
+      [...link.classList].filter((name) => name !== "is-unresolved").join(" ")
+    );
     if (!replacement.classList.contains("internal-link")) {
       replacement.classList.add("internal-link");
     }
@@ -550,9 +551,10 @@ function asciiAt(bytes: Uint8Array, offset: number, expected: string): boolean {
 }
 
 function replaceMissingImage(image: HTMLImageElement, source: string): HTMLElement {
-  const replacement = image.doc.createElement("span");
-  replacement.className = "symposium-missing-asset";
-  replacement.textContent = `[Missing image: ${image.alt || source || "unknown"}]`;
+  const replacement = image.doc.win.createSpan({
+    cls: "symposium-missing-asset",
+    text: `[Missing image: ${image.alt || source || "unknown"}]`,
+  });
   image.replaceWith(replacement);
   return replacement;
 }
@@ -638,8 +640,7 @@ function decodeUrlComponent(value: string): string {
 }
 
 function serializeDocument(ownerDocument: Document, title: string, article: HTMLElement): string {
-  const titleElement = ownerDocument.createElement("title");
-  titleElement.textContent = title;
+  const titleElement = ownerDocument.win.createEl("title", { text: title });
   return [
     "<!doctype html>",
     '<html lang="en">',

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -5,8 +5,32 @@ declare global {
    * Obsidian provides `app` as an ambient global inside the plugin runtime.
    * Declared here so TypeScript stops flagging it across the codebase.
    */
-   
+
   var app: App;
+
+  /**
+   * Obsidian's DOM creation helpers, declared on `Window` so a specific
+   * window's copy can be called explicitly.
+   *
+   * Obsidian re-evaluates its `globalEnhance()` bootstrap inside every popout
+   * window, so each window owns helpers bound to that window's `document`.
+   * `obsidian.d.ts` declares them only as ambient globals, which always resolve
+   * to the main window; reaching them through a node's own `doc.win` is what
+   * keeps a detached element in the document that will host it.
+   */
+  interface Window {
+    createEl<K extends keyof HTMLElementTagNameMap>(
+      tag: K,
+      o?: DomElementInfo | string,
+      callback?: (el: HTMLElementTagNameMap[K]) => void
+    ): HTMLElementTagNameMap[K];
+    createDiv(o?: DomElementInfo | string, callback?: (el: HTMLDivElement) => void): HTMLDivElement;
+    createSpan(
+      o?: DomElementInfo | string,
+      callback?: (el: HTMLSpanElement) => void
+    ): HTMLSpanElement;
+    createFragment(callback?: (el: DocumentFragment) => void): DocumentFragment;
+  }
 }
 
 export {};


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#317

## Why

The community listing at [community.obsidian.md/plugins/copilot](https://community.obsidian.md/plugins/copilot) carries the line "Uses `document.createElement` instead of Obsidian's `createEl` helpers". Running the official rule behind that line — `npm run review:obsidian:source`, which is `eslint-plugin-obsidianmd` — reports 30 findings in first-party source today.

logancyang/obsidian-copilot-preview#293 records the plugin-realm migration as finished, but its success criterion is `grep -rn "document.createElement" src/`. That search only sees the literal global receiver. Every remaining site reaches its `Document` through a variable, so it passes the grep and still trips the rule: `doc.createDocumentFragment()` and `doc.createElement("span")` in `linkInlineCitations`, `getEditorDocument(editor).createElement("span")` in each Lexical pill's `createDOM`/`exportDOM`, `root.doc.createElement("span")` in the Symposium task-checkbox and internal-link normalizers, `host.doc.createElement("div")` in the Quick Ask overlay, and so on.

Those variable receivers are not incidental — each one is a deliberate popout fix, resolving the document that will host the element rather than trusting whichever window is focused. The obvious migration loses that: `obsidian.d.ts` declares the helpers as ambient globals and on `Node`, never on `Window`, so the rule's own suggestion `someDoc.win.createDiv()` does not typecheck, and the ambient global always builds in the main window's document. Obsidian does install a per-window copy — it re-evaluates its `globalEnhance()` bootstrap inside every popout — so only the declaration was missing.

## What

Every first-party construction site now goes through Obsidian's helpers, and the produced DOM is unchanged.

| Site shape | Before | After |
| --- | --- | --- |
| Element appended to a known parent | `doc.createElement("div")`, set `className`, `parent.appendChild(…)` | `parent.createDiv("…")` — one call, still in the parent's document |
| Element that must stay detached | `someDoc.createElement("span")` | `someDoc.win.createSpan("…")` — the copy Obsidian binds to that window |
| Fragment | `doc.createDocumentFragment()` | `doc.win.createFragment()` |

`typings/global.d.ts` declares the four helpers this codebase uses on `Window`, which is what makes the detached cases both type-safe and popout-correct. Five Lexical pills carried a `createDOM` override byte-identical to the base class's; they are deleted rather than migrated.

`obsidianmd/prefer-create-el` becomes an error for shipped source, so a native DOM call fails `npm run lint` instead of drifting back onto the listing. Tests keep the native API — jsdom has no Obsidian helpers — and `jest.setup.js` gains a polyfill mirroring `globalEnhance`, alongside the `Node.doc` / `Node.win` polyfills already there.

## Non goal

- The 40 `document.createElement` occurrences in the shipped `main.js` that come from bundled dependencies (React DOM, Radix, style-loader). They are upstream code.
- The guest-realm snippet in `getSelectedMarkdown()`, which runs inside the Web Viewer's page where Obsidian's helpers do not exist. logancyang/obsidian-copilot-preview#293 owns that one and it stays native.
- Widening #293's grep criterion to the lint rule. Recorded in #317 as follow-up.
- Migrating `createElement` calls inside test files.

## Screenshot

Not applicable — this PR changes how elements are constructed, not what is rendered. Every affected surface produces the same tag, classes, attributes, and text as before; the Verification path below is how a reviewer confirms that visually.

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Construction-only refactor; tests cover the chat citation link, the `markdown-rendered` text segment, the pill DOM contract, the image picker's `accept`/`multiple`, the Symposium document pipeline, and the gallery colour probe |
| A defect would fail CI or be obvious on first use | ✅ | A missing helper throws on the first call, so the surface fails to render rather than degrading quietly |
| A revert fully restores prior state, including persisted data | ✅ | No migration and no persisted write; the diff only changes how in-memory elements are built |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No such surface is touched |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Pill `exportDOM` output feeds Lexical's own clipboard round-trip and keeps identical `data-lexical-*` attributes and text |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Synchronous element construction only |
| No hot-path behavior lacks deterministic coverage | ✅ | Chat message rendering is the hot path and its changed sites are covered in `ChatSingleMessage.test.tsx` |
| No new dependency | ✅ | Dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ❌ | The Quick Ask overlay, the custom-command modal container, and the command-UI markdown preview have no automated coverage, and the change spans several feature areas rather than one |

Review: inspect `typings/global.d.ts` — the `Window` interface block — to confirm the declared signatures match `obsidian.d.ts`'s ambient `createEl` / `createDiv` / `createSpan` / `createFragment`, then inspect `src/components/quick-ask/QuickAskOverlay.tsx` (`getOverlayRoot`, `mountOverlay`), `src/commands/CustomCommandChatModal.tsx` (`open`), and `src/components/command-ui/markdown-preview.tsx` (`MarkdownPreview`) line by line, since those three carry no test. Then run Verification steps 4–6, which exercise exactly those surfaces, plus step 7 in a popout window.

## Verification

1. Build and load this branch in a test vault (`npm run test:vault`), then reload Obsidian.
2. Open Copilot chat and send a message that returns sources. Confirm the inline `[1]` marker renders as a clickable citation link and opens the cited note.
3. In the composer, add a note pill with `[[`, a folder pill with `{`, and a URL pill by pasting a link. Confirm each renders as a pill, then select the composer contents and copy — pasting back into the composer restores the same pills.
4. Click the composer's image attach button. Confirm the file dialog opens, then cancel it and confirm the composer still accepts clicks and typing.
5. Select text in a note and run a custom command from the Copilot menu. Confirm the modal opens over the note and its markdown preview renders.
6. Trigger Quick Ask in the editor. Confirm the overlay appears anchored to the cursor and closes cleanly.
7. Move the chat to a popout window (right-click the tab → Open in new window) and repeat steps 2 and 3 there, with the main window focused. Confirm citations and pills still render in the popout.
8. Publish a note to Symposium. Confirm the published page keeps task checkboxes, internal links, and embedded images.
