### PR TITLE
Restore an off switch for the legacy vault index

### DIFF
--- a/docs/vault-search-and-indexing.md
+++ b/docs/vault-search-and-indexing.md
@@ -44,6 +44,20 @@ The **Search scope** control affects Copilot's integrated Miyo retrieval:
 
 The **Search chat** row is separate from vault search. **Ready · chats indexed** and **Syncing chats…** refer to ChatGPT and Claude chat history configured in Miyo, not to your notes.
 
+## Turn off the legacy vault index
+
+Vaults upgraded from an earlier version may still run Copilot's own embedding index, the one that predates Miyo. It builds when you switch chat modes and updates as you edit notes, which is noticeable on a large vault.
+
+**Settings → Copilot → Advanced → Legacy vault index** turns it off. Confirm the prompt, and:
+
+- No new indexing starts. A run already under way stops at its next batch, and the progress card in chat reports it as cancelled. To stop one the moment you see it, use the stop button on that card.
+- Search falls back to keyword matching.
+- The index already on disk is kept, but no longer read or updated. Run **Clear local Copilot index** from the command palette to remove it. A **Force reindex** that was already running is the exception: it clears the index as it starts, so stopping one part-way leaves only what it had rebuilt.
+
+Turning the switch back on does not build an index by itself. Run **Index (refresh) vault** from the command palette when you want one.
+
+If you have connected Miyo, this switch is greyed out. Miyo owns semantic search for the vault, and connecting or disconnecting it on the **Miyo** tab is what sets this.
+
 ## Privacy and device boundaries
 
 - File search and the Obsidian CLI run on your computer. Any excerpts Agent uses are then sent to the selected model as chat context. With a cloud model, that means its provider receives those excerpts; with a local model, they stay local.

--- a/src/components/modals/SemanticSearchToggleModal.tsx
+++ b/src/components/modals/SemanticSearchToggleModal.tsx
@@ -4,7 +4,7 @@ import { ConfirmModal } from "./ConfirmModal";
 export class SemanticSearchToggleModal extends ConfirmModal {
   constructor(app: App, onConfirm: () => void | Promise<void>, enabling: boolean) {
     const content = enabling
-      ? "Semantic search requires building an embedding index for your vault.\n\nUse 'Refresh Vault Index' or 'Force Reindex Vault' commands to build the index after enabling. Pick your embedding model below."
+      ? "Semantic search requires building an embedding index for your vault.\n\nUse 'Refresh Vault Index' or 'Force Reindex Vault' commands to build the index after enabling."
       : "Disabling semantic search will fall back to index-free lexical search (less resource-intensive, could be less accurate).\n\nYour existing index will be preserved but not used.";
 
     const title = enabling ? "Enable Semantic Search" : "Disable Semantic Search";

--- a/src/search/indexOperations.test.ts
+++ b/src/search/indexOperations.test.ts
@@ -1,0 +1,167 @@
+import type EmbeddingsManager from "@/LLMProviders/embeddingManager";
+import { IndexOperations } from "@/search/indexOperations";
+import type { SemanticIndexBackend } from "@/search/indexBackend/SemanticIndexBackend";
+import { App, TFile } from "obsidian";
+
+const settings = {
+  enableSemanticSearchV3: true,
+  embeddingRequestsPerMin: 60,
+  embeddingBatchSize: 1,
+};
+jest.mock("@/settings/model", () => ({
+  getSettings: () => settings,
+  subscribeToSettingsChange: () => () => {},
+}));
+
+const progress = {
+  isActive: false,
+  isPaused: false,
+  isCancelled: false,
+  completionStatus: "none" as string,
+};
+jest.mock("@/aiParams", () => ({
+  getIndexingProgressState: () => progress,
+  setIndexingProgressState: (next: Record<string, unknown>) => Object.assign(progress, next),
+  updateIndexingProgressState: (next: Record<string, unknown>) => Object.assign(progress, next),
+  resetIndexingProgressState: () =>
+    Object.assign(progress, { isActive: false, isCancelled: false, completionStatus: "none" }),
+  throttledUpdateIndexingCount: () => {},
+  flushIndexingCount: () => {},
+}));
+
+jest.mock("@/LLMProviders/embeddingManager", () => ({
+  __esModule: true,
+  default: { getModelName: () => "test-embedding-model" },
+}));
+
+const rateLimiterWait = jest.fn<Promise<void>, []>().mockResolvedValue(undefined);
+jest.mock("@/rateLimiter", () => ({
+  RateLimiter: class {
+    wait(): Promise<void> {
+      return rateLimiterWait();
+    }
+  },
+}));
+
+const getChunks = jest.fn();
+jest.mock("@/search/v3/chunks", () => ({ getSharedChunkManager: () => ({ getChunks }) }));
+
+jest.mock("@/search/searchUtils", () => ({
+  getMatchingPatterns: () => ({ inclusions: null, exclusions: null }),
+  shouldIndexFile: () => true,
+}));
+
+jest.mock("@/logger", () => ({ logInfo: () => {}, logWarn: () => {}, logError: () => {} }));
+
+const TFileConstructor = TFile as unknown as new (path: string) => TFile;
+const files = [new TFileConstructor("one.md"), new TFileConstructor("two.md")];
+
+function buildApp(): App {
+  for (const file of files) {
+    file.stat = { ctime: 0, mtime: 0, size: 0 };
+  }
+  return {
+    vault: {
+      getMarkdownFiles: () => files,
+      getAbstractFileByPath: (path: string) => files.find((file) => file.path === path),
+    },
+    metadataCache: { getFileCache: () => ({}) },
+  } as unknown as App;
+}
+
+/** An index backend that records nothing but the calls the indexing run makes on it. */
+function buildIndexBackend(): jest.Mocked<SemanticIndexBackend> {
+  return {
+    requiresEmbeddings: () => true,
+    checkAndHandleEmbeddingModelChange: jest.fn().mockResolvedValue(false),
+    clearIndex: jest.fn().mockResolvedValue(undefined),
+    clearFilesMissingEmbeddings: jest.fn(),
+    getFilesMissingEmbeddings: () => [],
+    markFileMissingEmbeddings: jest.fn(),
+    garbageCollect: jest.fn().mockResolvedValue(undefined),
+    getIndexedFiles: jest.fn().mockResolvedValue([]),
+    getLatestFileMtime: jest.fn().mockResolvedValue(0),
+    upsert: jest.fn().mockResolvedValue(undefined),
+    upsertBatch: jest.fn().mockResolvedValue(undefined),
+    markUnsavedChanges: jest.fn(),
+    save: jest.fn().mockResolvedValue(undefined),
+    checkIndexIntegrity: jest.fn().mockResolvedValue(undefined),
+    removeByPath: jest.fn().mockResolvedValue(undefined),
+  } as unknown as jest.Mocked<SemanticIndexBackend>;
+}
+
+describe("indexOperations", () => {
+  describe("IndexOperations", () => {
+    let indexBackend: jest.Mocked<SemanticIndexBackend>;
+    let embedDocuments: jest.Mock;
+    let indexOps: IndexOperations;
+
+    beforeEach(() => {
+      rateLimiterWait.mockResolvedValue(undefined);
+      settings.enableSemanticSearchV3 = true;
+      Object.assign(progress, {
+        isActive: false,
+        isPaused: false,
+        isCancelled: false,
+        completionStatus: "none",
+      });
+      embedDocuments = jest.fn().mockImplementation((texts: string[]) => texts.map(() => [0.1]));
+      getChunks.mockImplementation(async (paths: string[]) =>
+        paths.map((path, index) => ({
+          id: `${path}#0`,
+          notePath: path,
+          title: path,
+          heading: "",
+          mtime: index,
+          content: `NOTE BLOCK CONTENT:\n\ncontent of ${path}`,
+        }))
+      );
+      indexBackend = buildIndexBackend();
+      indexOps = new IndexOperations(buildApp(), indexBackend, {
+        getEmbeddingsAPI: async () => ({ embedDocuments }),
+      } as unknown as EmbeddingsManager);
+    });
+
+    describe("indexVaultToVectorStore()", () => {
+      it("indexes every file while the vault index stays enabled", async () => {
+        const indexed = await indexOps.indexVaultToVectorStore(true);
+
+        expect(indexed).toBe(2);
+        expect(embedDocuments).toHaveBeenCalledTimes(2);
+        expect(progress.completionStatus).toBe("success");
+      });
+
+      // The run latched the setting at entry, so a vault that was already being indexed kept
+      // being embedded after the user turned the switch off
+      // (https://github.com/logancyang/obsidian-copilot-preview/issues/319).
+      it("stops before the next batch and reports cancelled when the vault index is turned off mid-run (https://github.com/logancyang/obsidian-copilot-preview/issues/319)", async () => {
+        embedDocuments.mockImplementationOnce((texts: string[]) => {
+          settings.enableSemanticSearchV3 = false;
+          return texts.map(() => [0.1]);
+        });
+
+        await indexOps.indexVaultToVectorStore(true);
+
+        expect(embedDocuments).toHaveBeenCalledTimes(1);
+        expect(progress.completionStatus).toBe("cancelled");
+      });
+
+      // A paused run waits for a resume. Turning the vault index off is the user saying that
+      // resume is never coming, so the pause loop has to end on it too or the run waits forever
+      // (https://github.com/logancyang/obsidian-copilot-preview/issues/319).
+      it("ends a paused run when the vault index is turned off, rather than waiting for a resume that is not coming (https://github.com/logancyang/obsidian-copilot-preview/issues/319)", async () => {
+        embedDocuments.mockImplementationOnce((texts: string[]) => {
+          progress.isPaused = true;
+          window.setTimeout(() => {
+            settings.enableSemanticSearchV3 = false;
+          }, 10);
+          return texts.map(() => [0.1]);
+        });
+
+        await indexOps.indexVaultToVectorStore(true);
+
+        expect(progress.completionStatus).toBe("cancelled");
+      });
+    });
+  });
+});

--- a/src/search/indexOperations.ts
+++ b/src/search/indexOperations.ts
@@ -146,8 +146,8 @@ export class IndexOperations {
         return 0;
       }
 
-      // Check if user cancelled during chunk preparation
-      if (this.state.isIndexingCancelled || getIndexingProgressState().isCancelled) {
+      // Check if the user stopped indexing during chunk preparation
+      if (this.shouldStopIndexing()) {
         updateIndexingProgressState({ isActive: false, completionStatus: "cancelled" });
         return 0;
       }
@@ -161,7 +161,7 @@ export class IndexOperations {
       // Process chunks in dynamic batches so runtime config updates (pause/resume) apply immediately.
       let i = 0;
       while (i < allChunks.length) {
-        if (this.state.isIndexingCancelled || getIndexingProgressState().isCancelled) break;
+        if (this.shouldStopIndexing()) break;
         await this.handlePause();
 
         const batch = allChunks.slice(i, i + this.embeddingBatchSize);
@@ -457,6 +457,21 @@ export class IndexOperations {
     });
   }
 
+  /**
+   * Whether a run in flight must stop: the user cancelled it, or turned the vault index off from
+   * Advanced settings while it was running. The setting is re-read on each check rather than
+   * latched at entry, so a run started before the switch was flipped ends at the next batch
+   * instead of embedding the rest of the vault
+   * (https://github.com/logancyang/obsidian-copilot-preview/issues/319).
+   */
+  private shouldStopIndexing(): boolean {
+    return (
+      this.state.isIndexingCancelled ||
+      getIndexingProgressState().isCancelled ||
+      !getSettings().enableSemanticSearchV3
+    );
+  }
+
   private async handlePause(): Promise<void> {
     // Sync pause state from atom (UI may have toggled it)
     const atomState = getIndexingProgressState();
@@ -464,7 +479,7 @@ export class IndexOperations {
     this.state.isIndexingCancelled = atomState.isCancelled;
 
     if (this.state.isIndexingPaused) {
-      while (this.state.isIndexingPaused && !this.state.isIndexingCancelled) {
+      while (this.state.isIndexingPaused && !this.shouldStopIndexing()) {
         await new Promise((resolve) => window.setTimeout(resolve, 100));
         // Re-read atom state each iteration
         const current = getIndexingProgressState();
@@ -473,7 +488,7 @@ export class IndexOperations {
       }
 
       // After we exit the pause loop (meaning we've resumed), re-evaluate files
-      if (!this.state.isIndexingCancelled) {
+      if (!this.shouldStopIndexing()) {
         this.refreshRuntimeIndexingConfig();
         const files = await this.getFilesToIndex();
         if (files.length === 0) {
@@ -565,7 +580,7 @@ export class IndexOperations {
     // Flush any pending throttled count so the final value is displayed
     flushIndexingCount();
 
-    if (this.state.isIndexingCancelled || getIndexingProgressState().isCancelled) {
+    if (this.shouldStopIndexing()) {
       updateIndexingProgressState({
         isActive: false,
         completionStatus: "cancelled",

--- a/src/settings/v2/SettingsMainV2.tsx
+++ b/src/settings/v2/SettingsMainV2.tsx
@@ -22,8 +22,11 @@ import { SelfHostSettings } from "./components/SelfHostSettings";
 // (see designdocs/SETTINGS_REDESIGN_V4.md and SETTINGS_V4_PR_PLAN.md); the
 // underlying fields are NOT dropped and stay runtime-honored for existing
 // vaults:
-//   - enableSemanticSearchV3 — now driven implicitly by the Miyo connect flow
-//     (MiyoSettings), not a manual toggle.
+//   - enableSemanticSearchV3 — the Miyo connect flow (MiyoSettings) drives it
+//     implicitly. The Advanced tab surfaces it as "Legacy vault index"
+//     (LegacyVaultIndexSetting), the off switch a vault not using Miyo needs to
+//     stop indexing; it reads as the legacy index because that is all the flag
+//     still controls once Miyo owns semantic search.
 //   - qaInclusions/qaExclusions — still consumed (Miyo registration snapshot);
 //     their edit UI is deferred per issue #195 ("defer include/exclude").
 //   - embeddingModelKey / maxSourceChunks / enableInlineCitations / indexing

--- a/src/settings/v2/components/AdvancedSettings.tsx
+++ b/src/settings/v2/components/AdvancedSettings.tsx
@@ -3,6 +3,10 @@ import { Button } from "@/components/ui/button";
 import { SettingItem } from "@/components/ui/setting-item";
 import { SettingSection } from "@/components/ui/setting-section";
 import { LegacyChatPromptsNotice } from "@/settings/v2/components/LegacyChatPromptsNotice";
+import {
+  confirmLegacyVaultIndexToggle,
+  LegacyVaultIndexSetting,
+} from "@/settings/v2/components/LegacyVaultIndexSetting";
 import { useApp } from "@/context";
 import { logFileManager } from "@/logFileManager";
 import { flushRecordedPromptPayloadToLog } from "@/LLMProviders/chainRunner/utils/promptPayloadRecorder";
@@ -215,6 +219,20 @@ export const AdvancedSettings: React.FC = () => {
             </Button>
           </div>
         </SettingItem>
+
+        {/* The switch this restores (https://github.com/logancyang/obsidian-copilot-preview/issues/319)
+            is refused while Miyo owns the setting, because clearing it under a connected Miyo leaves
+            retrieval pointed at an index backend that can no longer refresh.
+
+            That refusal keys off the persisted `enableMiyo` intent rather than `shouldUseMiyo`,
+            which folds in `Platform.isMobile`. Miyo needs an explicit server URL on mobile, so a
+            phone syncing a desktop-configured vault would read "not Miyo", offer the switch, and
+            Sync the cleared flag back to that desktop. */}
+        <LegacyVaultIndexSetting
+          enabled={settings.enableSemanticSearchV3}
+          miyoManaged={settings.enableMiyo}
+          onToggle={(next) => confirmLegacyVaultIndexToggle(app, next)}
+        />
 
         <SettingItem
           type="switch"

--- a/src/settings/v2/components/LegacyVaultIndexSetting.stories.tsx
+++ b/src/settings/v2/components/LegacyVaultIndexSetting.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import {
+  LegacyVaultIndexSetting,
+  type LegacyVaultIndexSettingProps,
+} from "./LegacyVaultIndexSetting";
+
+const meta = {
+  title: "Settings/Legacy Vault Index Setting",
+  component: LegacyVaultIndexSetting,
+  args: {
+    enabled: true,
+    miyoManaged: false,
+    onToggle: () => {},
+  },
+  parameters: { gallery: { host: "settings-tab", layout: "padded" } },
+} satisfies Meta<LegacyVaultIndexSettingProps>;
+export default meta;
+
+/** The state a v3 upgrader lands in: the index is on, and now switchable off. */
+export const Enabled: StoryObj<LegacyVaultIndexSettingProps> = {};
+
+export const Disabled: StoryObj<LegacyVaultIndexSettingProps> = {
+  args: { enabled: false },
+};
+
+/** Miyo has taken over semantic search, so the index is idle and the switch is not settable here. */
+export const MiyoManaged: StoryObj<LegacyVaultIndexSettingProps> = {
+  args: { miyoManaged: true },
+};

--- a/src/settings/v2/components/LegacyVaultIndexSetting.test.tsx
+++ b/src/settings/v2/components/LegacyVaultIndexSetting.test.tsx
@@ -1,0 +1,92 @@
+import {
+  confirmLegacyVaultIndexToggle,
+  LegacyVaultIndexSetting,
+} from "@/settings/v2/components/LegacyVaultIndexSetting";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { App } from "obsidian";
+import React from "react";
+
+const updateSetting = jest.fn<void, unknown[]>();
+jest.mock("@/settings/model", () => ({
+  updateSetting: (...args: unknown[]) => updateSetting(...args),
+}));
+
+// Captures the modal's constructor arguments so the tests can assert what was
+// requested and then run the confirmation the user would have clicked.
+const modalCalls: { onConfirm: () => void | Promise<void>; enabling: boolean }[] = [];
+const open = jest.fn();
+jest.mock("@/components/modals/SemanticSearchToggleModal", () => ({
+  SemanticSearchToggleModal: class {
+    constructor(_app: App, onConfirm: () => void | Promise<void>, enabling: boolean) {
+      modalCalls.push({ onConfirm, enabling });
+    }
+    open = open;
+  },
+}));
+
+const app = {} as App;
+
+/** Run the confirmation callback of the most recently opened modal. */
+async function confirmLastModal(): Promise<void> {
+  await modalCalls[modalCalls.length - 1].onConfirm();
+}
+
+describe("LegacyVaultIndexSetting", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    modalCalls.length = 0;
+  });
+
+  describe("LegacyVaultIndexSetting()", () => {
+    it("reports the current state through the switch", () => {
+      render(<LegacyVaultIndexSetting enabled miyoManaged={false} onToggle={jest.fn()} />);
+
+      expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe("true");
+    });
+
+    it("asks for the opposite of the current state when toggled", () => {
+      const onToggle = jest.fn();
+      render(<LegacyVaultIndexSetting enabled miyoManaged={false} onToggle={onToggle} />);
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      expect(onToggle).toHaveBeenCalledWith(false);
+    });
+
+    it("refuses changes and points at the Miyo tab while Miyo owns the setting, so the restored switch cannot strand Miyo retrieval on an index backend that can no longer refresh (https://github.com/logancyang/obsidian-copilot-preview/issues/319)", () => {
+      const onToggle = jest.fn();
+      render(<LegacyVaultIndexSetting enabled miyoManaged onToggle={onToggle} />);
+
+      fireEvent.click(screen.getByRole("switch"));
+
+      expect(onToggle).not.toHaveBeenCalled();
+      expect(screen.getByRole("switch").getAttribute("aria-disabled")).toBe("true");
+      expect(screen.getByText(/Disconnect from the Miyo tab/)).toBeTruthy();
+    });
+  });
+
+  describe("confirmLegacyVaultIndexToggle()", () => {
+    it("leaves the setting untouched until the user confirms", () => {
+      confirmLegacyVaultIndexToggle(app, false);
+
+      expect(open).toHaveBeenCalled();
+      expect(updateSetting).not.toHaveBeenCalled();
+    });
+
+    it("writes the requested state on confirmation", async () => {
+      confirmLegacyVaultIndexToggle(app, true);
+      await confirmLastModal();
+
+      expect(modalCalls[0].enabling).toBe(true);
+      expect(updateSetting).toHaveBeenCalledWith("enableSemanticSearchV3", true);
+    });
+
+    it("clears the setting on confirmation when disabling", async () => {
+      confirmLegacyVaultIndexToggle(app, false);
+      await confirmLastModal();
+
+      expect(modalCalls[0].enabling).toBe(false);
+      expect(updateSetting).toHaveBeenCalledWith("enableSemanticSearchV3", false);
+    });
+  });
+});

--- a/src/settings/v2/components/LegacyVaultIndexSetting.tsx
+++ b/src/settings/v2/components/LegacyVaultIndexSetting.tsx
@@ -1,0 +1,58 @@
+import { SemanticSearchToggleModal } from "@/components/modals/SemanticSearchToggleModal";
+import { SettingItem } from "@/components/ui/setting-item";
+import { updateSetting } from "@/settings/model";
+import { App } from "obsidian";
+import React from "react";
+
+const DESCRIPTION =
+  "The built-in embedding index that powers semantic search when you are not using Miyo. " +
+  "Turning it off stops all indexing and falls back to keyword search; the index already on " +
+  "disk is kept, but no longer read or updated.";
+
+const MIYO_MANAGED_DESCRIPTION =
+  "Miyo is handling semantic search, so the built-in index is not in use and has nothing to " +
+  "index. Disconnect from the Miyo tab to return to keyword search.";
+
+export interface LegacyVaultIndexSettingProps {
+  /** Whether the built-in index is on, which is what makes vault indexing run. */
+  enabled: boolean;
+  /** Whether Miyo has taken over semantic search, leaving this index idle and not the user's to set. */
+  miyoManaged: boolean;
+  onToggle: (next: boolean) => void;
+}
+
+/**
+ * Exposes the on/off control for the built-in vault index, the single gate every legacy
+ * indexing path checks. Presentational only — confirming and applying the change belongs
+ * to its host.
+ */
+export const LegacyVaultIndexSetting: React.FC<LegacyVaultIndexSettingProps> = ({
+  enabled,
+  miyoManaged,
+  onToggle,
+}) => (
+  <SettingItem
+    type="switch"
+    title="Legacy vault index"
+    description={miyoManaged ? MIYO_MANAGED_DESCRIPTION : DESCRIPTION}
+    checked={enabled}
+    disabled={miyoManaged}
+    onCheckedChange={onToggle}
+  />
+);
+
+/**
+ * Confirm a change to the built-in vault index with the user, then apply it.
+ *
+ * @param app - Obsidian app the confirmation modal is opened against.
+ * @param next - The state the user asked for: true to enable, false to disable.
+ */
+export function confirmLegacyVaultIndexToggle(app: App, next: boolean): void {
+  // Writing the setting is the whole action: a run already in flight re-reads it between batches
+  // and stops itself, reporting cancelled on the progress card.
+  new SemanticSearchToggleModal(
+    app,
+    () => updateSetting("enableSemanticSearchV3", next),
+    next
+  ).open();
+}


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#319

## Why

A member asked in `#copilot-plus-members`, after being told the legacy embedding still works but is no longer configurable:

> Thank you for a fast answer. But how can I stop indexing from running if it's already enabled?

There is no answer to give them. The v4 settings redesign deleted `QASettings.tsx`, which held the **Enable Semantic Search** toggle. The setting behind it was deliberately kept runtime-honored for existing vaults, and nothing in the upgrade clears it.

So a vault upgrading from v3 with `enableSemanticSearchV3` on still indexes, on two triggers, with nothing in the UI to stop it:

- Switching chat mode into Vault QA or Copilot Plus kicks off a full vault index. "Vault QA (free)" is still unconditionally selectable in the mode dropdown, so this is one click away.
- Editing any note while in Copilot Plus mode reindexes that file.

The only remaining writers of the setting are the Miyo connect and disconnect flow, and the Relevant Notes empty state, which only turns it **on**. A user not on Miyo has to quit Obsidian and hand-edit `.obsidian/plugins/copilot/data.json`.

## What

A **Legacy vault index** switch in Settings → Advanced → Others, above Debug Mode. Flipping it opens the existing confirmation modal, whose disable-path copy was already written and, until now, unreachable.

It is named for the legacy index rather than for semantic search because that is all `enableSemanticSearchV3` still controls in practice: once Miyo is connected, Miyo owns semantic search and the built-in index has nothing to do. A row labelled "Semantic Search" reads as a global feature switch and invites exactly the wrong mental model.

| Condition | Before | After |
| --- | --- | --- |
| Vault not on Miyo, index on | No control anywhere; indexing keeps triggering on mode switch and note edit | Switch reads on; turning it off stops all further indexing |
| Turning it off while an index is running | Not reachable | The run ends at its next batch, and the in-chat progress card reports cancelled |
| Turning it off while an index is paused | Not reachable | The run ends, instead of waiting on a resume that is never coming |
| Turning it back on | Only reachable from the Relevant Notes empty state | Switch can be re-enabled; the modal points at the refresh command rather than indexing immediately |
| Vault connected to Miyo | Setting is Miyo's, changed only by connect and disconnect | Switch is shown greyed out and unclickable, pointing at the Miyo tab |

Writing the setting is nearly the whole action. The gap is that a run in flight latched the setting at entry, so `IndexOperations` now reads it through one `shouldStopIndexing()` predicate, which replaces the cancel check at the five places the run already tested for one. Nothing new is checked anywhere else, so a cleared setting stops a run exactly where a cancel does.

The pause loop is the one place that changes more than its exit reason. It waited on `isIndexingPaused && !isIndexingCancelled`, and clearing the setting unpauses nothing — so a paused run whose index had been switched off waited forever. It now ends.

The Miyo case is disabled rather than hidden because retrieval routes to Miyo on the `enableMiyo` flag alone, while the Miyo index backend only initializes when `enableSemanticSearchV3` is on. Letting the switch clear it underneath a connected Miyo would leave retrieval pointed at a backend that can no longer refresh.

`docs/vault-search-and-indexing.md` gains a section for the switch: where it lives, that the on-disk index is kept, and that turning it back on does not build an index by itself.

## Non goal

- **No hardening of the sub-second windows between a confirmed off and an in-flight embedding request.** A batch already held by the rate limiter, or a note whose chunks are already prepared, still completes. Losing that race costs one batch of embeddings from a provider the user already configured; the next batch stops. The in-chat progress card has offered pause and stop for a run in flight since #2173, so a user who wants a run to end *now* already has a control that ends it now.
- **No migration that auto-disables the setting.** It would be a one-way door: with the flag cleared and no other way to set it, users relying on semantic retrieval for Relevant Notes and Vault QA would lose it with no recourse. It also contradicts what users were told, that the previous embedding keeps working. The gap is a missing control, not a wrong default.
- **No normalization of the `enableMiyo` / `enableSemanticSearchV3` pair.** A vault migrated from the legacy `enableMiyoSearch` flag can hold Miyo on with the index flag off. The switch reports that truthfully — the legacy index really is off — and rewriting persisted flags to tidy the display is the same one-way door as above.
- **`ON_MODE_SWITCH` auto-indexing is unchanged.** A full vault index on every mode switch is arguably too aggressive even for users who want semantic search, but changing it silently alters behavior for people who rely on it.
- **Two pre-existing indexing defects are left to their own issues.** `initializeIndexingState` clears both cancellation flags, so a cancel raised during a run's opening phases is erased — that affects today's stop button, not just this switch. And re-enabling the flag does not reinitialize the backend, so semantic retrieval before any index command throws "Database is not loaded"; the Relevant Notes empty state can already reach that state today, and running **Index (refresh) vault** recovers it.
- **No embedding-model, chunk-limit, or include and exclude UI.** Still deferred per logancyang/obsidian-copilot-preview#195.
- **The local Orama index is not retired here.** Part 2.2 of logancyang/obsidian-copilot-preview#288 does that, and deletes this switch along with the setting it controls. This ships first because that retirement is large and users are blocked on shipped v4.0 now.

## Screenshot

There is no before image to pair these with: the row does not exist anywhere in the Copilot settings pane on `origin/master`, which is the defect.

<img width="732" height="381" alt="Legacy vault index row in Settings → Advanced" src="https://github.com/user-attachments/assets/e06a3176-9372-460e-9bc5-838454e67d1f" />

<img width="646" height="228" alt="The switch greyed out while Miyo is connected" src="https://github.com/user-attachments/assets/9a3bba03-fad7-4fbd-b2b7-d28e4c2d6f6f" />

## Risk

**Medium**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Six tests in `LegacyVaultIndexSetting.test.tsx` cover both toggle directions, the confirm and cancel paths, and the Miyo-managed refusal; three in `indexOperations.test.ts` cover the undisturbed run, the mid-run stop, and the paused-run stop. Both stop tests were confirmed to fail without the fix — the paused one by hanging to the timeout |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in CI, and a wrong result is visible the moment the switch is operated |
| A revert fully restores prior state, including persisted data | ✅ | Writes only `enableSemanticSearchV3`, a field that already existed and is already read everywhere; no migration and no new persisted shape |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No credential, permission, or input-parsing code touched |
| No public API, plugin API, message, or on-disk contract changes | ✅ | One new internal component and one new private method; no exported contract changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ❌ | `shouldStopIndexing()` widens the indexing run's existing stop condition, so it now also ends on a cleared setting, and the pause loop gains a second exit. `getBackendKey` ignores the flag, so `refreshBackend` does not swap `indexOps` and the running instance is the one that observes it |
| No hot-path behavior lacks deterministic coverage | ✅ | Every stop point the change touches is exercised: mid-run, mid-pause, and the untouched success path |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the Advanced settings tab and the indexing run it controls; a wrong result is visible the moment the switch is operated |

Review: read `shouldStopIndexing()` in `src/search/indexOperations.ts` and its five call sites — the post-chunking check in `indexVaultToVectorStore()`, the batch-loop head, both checks in `handlePause()`, and `finalizeIndexing()` — confirming each one replaces a cancel check that was already there rather than adding a new checkpoint. Then read `LegacyVaultIndexSetting` and `confirmLegacyVaultIndexToggle` in `src/settings/v2/components/LegacyVaultIndexSetting.tsx`, and the `miyoManaged` argument at its call site in `src/settings/v2/components/AdvancedSettings.tsx`, which keys off the persisted `enableMiyo` rather than `shouldUseMiyo` because the latter folds in `Platform.isMobile` and a phone would offer the switch for a vault whose desktop routes retrieval to Miyo. Then run Verification steps 2, 3, and 6.

## Verification

1. In a vault with semantic search already on and Miyo not connected, open **Settings → Advanced**. The **Legacy vault index** switch reads on.
2. Run the **Index (refresh) vault** command, and while it is indexing flip the switch off and confirm. Indexing stops and the in-chat progress card reports cancelled.
3. Run **Index (refresh) vault** again, pause it from the progress card, then flip the switch off and confirm. The run ends rather than sitting paused.
4. Switch the chat mode to Vault QA. No index starts and no progress card appears.
5. Edit a note while in Copilot Plus mode. No reindex is triggered.
6. Flip the switch back on and confirm. No progress card appears; the modal points at the refresh command instead of indexing immediately. Run **Index (refresh) vault** and it builds.
7. Connect Miyo from the Miyo tab, then return to Advanced. The switch is greyed out, does not respond to clicks, and its description points back at the Miyo tab.
8. Open the same vault on a phone with Miyo connected on desktop and no Miyo server URL set. The switch is still greyed out there.
