### PR TITLE
Scope type-aware ESLint rules by excluding TypeScript

### DIFF
--- a/designdocs/OBSIDIAN_COMMUNITY_REVIEW.md
+++ b/designdocs/OBSIDIAN_COMMUNITY_REVIEW.md
@@ -12,6 +12,7 @@ The safety rule is simple: review compliance must not change plugin behavior, pe
 - Forbidden source suppressions were replaced with types or narrower boundaries, not runtime rewrites.
 - The OpenCode Default effort row stays mounted. Unsupported models disable it with “Not supported” so the model list never shifts.
 - Safe element-owned DOM creation was migrated to Obsidian helpers. Provider networking, async handlers, document-owned DOM creation, settings search, and risky CSS warnings were deliberately not rewritten by this stack.
+- Type-aware ESLint rules are switched off for every file that is not `.ts`/`.tsx`, scoped by excluding TypeScript rather than by listing non-TypeScript extensions. `eslint-plugin-obsidianmd` decides which files its type-aware rules apply to and that selection differs between versions, so an extension list falls out of date silently. A type-aware rule reaching an untyped target such as `manifest.json` or `LICENSE` fails to load, and ESLint aborts the whole gate rather than reporting findings.
 
 ## Gate stages
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -688,13 +688,15 @@ export default [
     },
   },
 
-  // Non-TS files aren't in tsconfig.json — disable type-aware rules that
-  // obsidianmd's recommended config enables globally. Most typed obsidianmd
-  // rules are already gated to **/*.ts(x); only no-plugin-as-component leaks
-  // out via recommendedPluginRulesConfig, and @typescript-eslint/no-deprecated
-  // is enabled globally.
+  // Type-aware rules need the type information only the `**/*.ts(x)` block
+  // above requests via parserOptions.project. Scope them off by excluding
+  // TypeScript rather than by listing non-TS extensions: which files
+  // eslint-plugin-obsidianmd applies no-plugin-as-component to differs by
+  // version, and a type-aware rule reaching an untyped target such as
+  // manifest.json cannot load, which makes ESLint abort the whole run instead
+  // of reporting findings. scripts/review-obsidian-fixtures.mjs guards this.
   {
-    files: ["**/*.js", "**/*.mjs", "**/*.cjs", "**/*.jsx", "**/package.json"],
+    ignores: ["**/*.ts", "**/*.tsx"],
     rules: {
       "@typescript-eslint/no-deprecated": "off",
       "obsidianmd/no-plugin-as-component": "off",

--- a/scripts/review-obsidian-fixtures.mjs
+++ b/scripts/review-obsidian-fixtures.mjs
@@ -2,6 +2,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import { extname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { ESLint } from "eslint";
+import reviewConfig from "../eslint.review.config.mjs";
 import {
   collectPackageFindings,
   getManifestFilename,
@@ -49,6 +50,33 @@ const invalidLicenseFixture = "Copyright (C) 2020-2025 by Dynalist Inc.\n";
 
 function assert(condition, message) {
   if (!condition) throw new Error(message);
+}
+
+/**
+ * Prove the review config keeps an untyped target out of type-aware rule scope.
+ *
+ * ESLint aborts the entire run when a rule cannot load, so a type-aware rule
+ * that reaches a file carrying no type information silences the whole gate
+ * rather than failing it. Force such a rule on ahead of the repository's own
+ * config blocks and confirm those blocks still switch it off.
+ *
+ * @param {string} filePath - Repository-relative untyped review target.
+ */
+async function expectOutsideTypeAwareScope(filePath) {
+  const eslint = new ESLint({
+    cwd: repositoryRoot,
+    // The forced rule must sit ahead of the repository's blocks, which rules
+    // out overrideConfig (applied last) and the config file (loaded first).
+    overrideConfigFile: true,
+    baseConfig: [{ rules: { "obsidianmd/no-plugin-as-component": "error" } }, ...reviewConfig],
+  });
+  try {
+    await eslint.lintText("{}", { filePath: resolve(repositoryRoot, filePath) });
+  } catch (error) {
+    throw new Error(
+      `${filePath} is in type-aware ESLint scope, which aborts the whole review gate: ${error.message}`
+    );
+  }
 }
 
 function listTrackedReviewSources() {
@@ -126,6 +154,10 @@ async function main() {
     ignoredSources.length === 0,
     `Tracked files under Obsidian review source roots are hidden by the base ESLint config:\n${ignoredSources.join("\n")}\nMove non-source fixtures outside the review roots instead of ignoring them.`
   );
+
+  for (const target of ["manifest.json", "package.json", "LICENSE"]) {
+    await expectOutsideTypeAwareScope(target);
+  }
 
   const invalidSourceResult = await lintSourceFixture(invalidSourceFixture, "src/utils.ts");
   assert(invalidSourceResult.errorCount > 0, "ESLint accepted its invalid source fixture");


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#321

## Why

`npm run review:obsidian` is the gate that catches Obsidian community-review
blockers before submission. It chains five steps through `run-s`, so whichever
one fails first takes the other four with it.

`eslint.config.mjs` turned type-aware ESLint rules off by listing the file
types that are not TypeScript: `**/*.js`, `**/*.mjs`, `**/*.cjs`, `**/*.jsx`,
`**/package.json`. The gate also lints `manifest.json` and `LICENSE`, and those
two were never added to the list. `eslint.review.config.mjs` parses
`manifest.json` with `typescript-eslint/parser` and no `parserOptions.project`,
so a type-aware rule that reaches it has no type information to work with,
cannot load, and makes ESLint abort the entire run.

Whether a rule reaches it is the plugin's choice, and that choice has already
changed once. `eslint-plugin-obsidianmd` 0.3.x enabled
`obsidianmd/no-plugin-as-component` from a config block with no `files` filter,
so it applied to every lint target. The pinned 0.4.1 gates it to
`**/*.{ts,cts,mts,tsx}`. Against a 0.3.x install the gate dies on its first step
with `Error while loading rule 'obsidianmd/no-plugin-as-component'` and reports
nothing at all — the maintainer sees a configuration error about `manifest.json`
and learns nothing about whether the plugin passes review.

## What

The non-TypeScript override is now scoped by excluding TypeScript instead of by
listing extensions, so it covers every target that carries no type information,
including ones added later.

| Lint target | Before | After |
| --- | --- | --- |
| `src/**/*.ts(x)` | Type-aware rules enforced | Unchanged, still enforced |
| `**/*.js`, `.mjs`, `.cjs`, `.jsx`, `package.json` | Type-aware rules off | Unchanged, still off |
| `manifest.json`, `LICENSE` | In type-aware scope; abort the whole gate whenever a rule reaches them | Out of type-aware scope |

> **Before:** with `eslint-plugin-obsidianmd` 0.3.x installed, `npm run review:obsidian` stops in `review:obsidian:package` with a rule-loading error, and the source, styles, audit, and fixtures steps never run.
>
> **After:** all five steps run and report their own findings, whichever version's rule scoping is in effect.

`review:obsidian:fixtures` gains a check that forces a type-aware rule on ahead
of the repository's own config blocks and confirms `manifest.json`,
`package.json`, and `LICENSE` stay outside type-aware scope, so a future plugin
upgrade that widens rule applicability fails this check instead of silencing
the gate.

## Non goal

- Does not upgrade or re-pin `eslint-plugin-obsidianmd`; the pin stays at 0.4.1.
- Does not suppress, downgrade, or narrow any review rule. The source step reports the identical 60 findings before and after.
- Does not give `manifest.json` or `LICENSE` type information so type-aware rules could run on them.
- Does not detect stale `node_modules` that drift from the lockfile, which is how the abort surfaces in practice.

## Screenshot

Not applicable — this PR changes lint configuration and a review script. It has
no user-visible surface.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `review:obsidian:fixtures` asserts each untyped target stays out of type-aware scope, and fails when the override is reverted |
| A defect would fail CI or be obvious on first use | ✅ | The fixtures step runs in the same `review:obsidian` chain in PR CI and the release workflow |
| A revert fully restores prior state, including persisted data | ✅ | Lint configuration only; nothing is written or persisted |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No runtime code is touched |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No plugin source changes; `manifest.json` and `package.json` are unmodified |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Build-time linting only |
| No hot-path behavior lacks deterministic coverage | ✅ | The one changed behavior is the fixtures check itself |
| No new dependency | ✅ | `package.json` and `package-lock.json` are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to the review gate; a regression stops the gate on the next run |

Review: skim `## Why` and `## What`, then run Verification step 1 and confirm
all five steps report. If you want the one line that matters, it is the
`ignores` key in the non-TypeScript override block in `eslint.config.mjs`.

## Verification

1. From a clean checkout of this branch, run `npm run review:obsidian`. All five
   steps should run and the output should end with
   `Obsidian review fixtures passed.`
2. Confirm the fix is load-bearing: change that block's `ignores: ["**/*.ts",
   "**/*.tsx"]` back to `files: ["**/*.js", "**/*.mjs", "**/*.cjs", "**/*.jsx",
   "**/package.json"]`, then run `npm run review:obsidian:fixtures`. It should
   fail with `manifest.json is in type-aware ESLint scope, which aborts the
   whole review gate`. Undo the edit.
3. Confirm nothing was silently switched off: run `npm run lint` and check that
   `src/` reports the same findings as on `master`.

## Note

The abort reproduces on any checkout whose `node_modules` predates the 0.4.1
pin. On this machine `.claude/worktrees/tool-calls-tokens-ui-70f96d` still has
0.3.0 installed and produces the error verbatim; `npm ci` there clears it.
