### PR TITLE
Restore the gallery build so component stories can be verified

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Obsidian community review gate
         run: npm run review:obsidian
       - run: npm run lint
+      # Type-checks the project and bundles the plugin. Otherwise both run only
+      # when a release PR merges, so a break would sit on master until someone
+      # cut a release.
+      - run: npm run build
+      # Builds the component gallery's whole story graph, so a story that cannot
+      # bundle fails the PR instead of reaching master unnoticed.
+      - run: npm run gallery:build
       - run: npm run test:mobile-load
       - run: npm test
       - name: Run Integration tests

--- a/dev/gallery/esbuild.config.mjs
+++ b/dev/gallery/esbuild.config.mjs
@@ -1,22 +1,27 @@
 import esbuild from "esbuild";
 import process from "process";
+import nodeModuleShim, { nodeBuiltinExternals } from "../../nodeModuleShim.mjs";
+import svgrPlugin from "../../svgrPlugin.mjs";
 
 const prod = process.argv[2] === "production";
 
 const context = await esbuild.context({
   entryPoints: ["dev/gallery/main.ts"],
   bundle: true,
-  // `node:*` matches the production bundle: the gallery plugin loads in the same
-  // Electron renderer, and a story for a component that transitively touches a
-  // Node builtin (e.g. BinaryPathSetting's binary detection) must not fail to
-  // bundle just because the module graph reaches one.
-  external: ["obsidian", "electron", "node:*"],
+  // Node builtins stay external as in the production bundle: the gallery plugin
+  // loads in the same Electron renderer, and a story for a component that
+  // transitively touches a Node builtin (e.g. BinaryPathSetting's binary
+  // detection) must not fail to bundle just because the module graph reaches one.
+  external: ["obsidian", "electron", ...nodeBuiltinExternals],
   format: "cjs",
   target: "es2020",
   logLevel: "info",
   sourcemap: prod ? false : "inline",
   treeShaking: true,
   outfile: "dev/gallery/main.js",
+  // `module` gets a shim rather than a slot in `external` because the renderer
+  // has no ESM `createRequire`; `svgrPlugin` loads the backend logo SVGs.
+  plugins: [nodeModuleShim, svgrPlugin],
   define: {
     global: "window",
     "process.env.NODE_ENV": prod ? '"production"' : '"development"',

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -1,29 +1,9 @@
 import esbuild from "esbuild";
-import { transform as svgrTransform } from "@svgr/core";
-import jsxPlugin from "@svgr/plugin-jsx";
-import { readFile } from "node:fs/promises";
 import process from "process";
 import { createRequire } from "module";
 import wasmPlugin from "./wasmPlugin.mjs";
-import nodeModuleShim from "./nodeModuleShim.mjs";
-
-// Inline SVGR plugin: each `import Foo from "./foo.svg"` resolves to a React
-// component (`React.FC<SVGProps<SVGSVGElement>>`) instead of a raw string.
-// Source SVGs use `fill="currentColor"`, so theme color follows automatically.
-const svgrPlugin = {
-  name: "svgr",
-  setup(build) {
-    build.onLoad({ filter: /\.svg$/ }, async (args) => {
-      const svg = await readFile(args.path, "utf8");
-      const contents = await svgrTransform(
-        svg,
-        { jsxRuntime: "classic", typescript: false, plugins: [jsxPlugin] },
-        { filePath: args.path, caller: { name: "esbuild-plugin-inline-svgr" } }
-      );
-      return { contents, loader: "jsx" };
-    });
-  },
-};
+import nodeModuleShim, { nodeBuiltinExternals } from "./nodeModuleShim.mjs";
+import svgrPlugin from "./svgrPlugin.mjs";
 
 // CommonJS plugin loaded via createRequire — pure JS, no ESM export needed.
 const patchRendererUnsafeUnref = createRequire(import.meta.url)(
@@ -87,38 +67,7 @@ const context = await esbuild.context({
     "@lezer/common",
     "@lezer/highlight",
     "@lezer/lr",
-    // Node.js built-in modules (available in Electron) - except `module` /
-    // `node:module` which we shim. Both prefixed (`node:foo`) and bare
-    // (`foo`) forms are listed because @anthropic-ai/claude-agent-sdk and
-    // its transitive deps mix the two styles.
-    "node:fs",
-    "node:fs/promises",
-    "node:path",
-    "node:os",
-    "node:url",
-    "node:buffer",
-    "node:stream",
-    "node:crypto",
-    "node:events",
-    "node:async_hooks",
-    "node:child_process",
-    "node:http",
-    "node:https",
-    "node:util",
-    "node:readline",
-    "node:process",
-    "async_hooks",
-    "child_process",
-    "crypto",
-    "events",
-    "fs",
-    "fs/promises",
-    "os",
-    "path",
-    "process",
-    "readline",
-    "url",
-    "util",
+    ...nodeBuiltinExternals,
   ],
   format: "cjs",
   target: "es2020",

--- a/nodeModuleShim.mjs
+++ b/nodeModuleShim.mjs
@@ -1,3 +1,33 @@
+// Node.js built-in modules to leave external: they exist in the Electron
+// renderer both bundles run in, so esbuild must not try to resolve them from
+// disk. `@anthropic-ai/claude-agent-sdk` and its transitive deps mix the
+// prefixed and bare spellings, so both have to be covered, but the two sides
+// cannot be covered the same way:
+//
+// - `node:` specifiers can only ever be builtins, so one wildcard covers every
+//   present and future one. `node:module` is the exception the wildcard cannot
+//   express — `nodeModuleShim` below claims it first, because the renderer has
+//   no ESM `createRequire`.
+// - Bare specifiers are ambiguous: `events`, `process`, `punycode`, and friends
+//   are also real npm packages, and externalizing one would shadow a dependency
+//   that legitimately resolves to `node_modules`. So bare spellings stay an
+//   explicit list of the ones the module graph actually reaches.
+export const nodeBuiltinExternals = [
+  "node:*",
+  "async_hooks",
+  "child_process",
+  "crypto",
+  "events",
+  "fs",
+  "fs/promises",
+  "os",
+  "path",
+  "process",
+  "readline",
+  "url",
+  "util",
+];
+
 // Plugin to provide a shim for node:module in browser/Electron renderer context
 const nodeModuleShim = {
   name: "node-module-shim",

--- a/svgrPlugin.mjs
+++ b/svgrPlugin.mjs
@@ -1,0 +1,23 @@
+import { transform as svgrTransform } from "@svgr/core";
+import jsxPlugin from "@svgr/plugin-jsx";
+import { readFile } from "node:fs/promises";
+
+// Inline SVGR plugin: each `import Foo from "./foo.svg"` resolves to a React
+// component (`React.FC<SVGProps<SVGSVGElement>>`) instead of a raw string.
+// Source SVGs use `fill="currentColor"`, so theme color follows automatically.
+const svgrPlugin = {
+  name: "svgr",
+  setup(build) {
+    build.onLoad({ filter: /\.svg$/ }, async (args) => {
+      const svg = await readFile(args.path, "utf8");
+      const contents = await svgrTransform(
+        svg,
+        { jsxRuntime: "classic", typescript: false, plugins: [jsxPlugin] },
+        { filePath: args.path, caller: { name: "esbuild-plugin-inline-svgr" } }
+      );
+      return { contents, loader: "jsx" };
+    });
+  },
+};
+
+export default svgrPlugin;


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#320

## Why

`npm run gallery:build` fails on master. It exits 1 with 16 esbuild errors — three "No loader is configured for `.svg` files" for the agent-mode backend logos, and thirteen "Could not resolve" for Node builtins reached through `@anthropic-ai/claude-agent-sdk`. Nothing renders, so no story can be looked at.

That blocks the component gallery workflow `CLAUDE.md` requires for user-visible React work: anyone adding or changing a story cannot see it, and visual states get reviewed from the diff or not at all. PR #2864 merged a story for `SemanticSearchSetting` whose three states were never rendered, for exactly this reason.

The cause is that `dev/gallery/esbuild.config.mjs` keeps its own copy of the production bundle's module-resolution policy, and the copy drifted. Its `external` used the pattern `"node:*"`, which matches only the `node:`-prefixed spelling; the SDK also imports the bare forms, and `esbuild.config.mjs` lists both spellings for that reason. The gallery config also set no `plugins` at all, so it had neither the SVG loader nor the `module` shim.

## What

> **Before:** a contributor adds a story, runs `npm run gallery:build`, and gets 16 esbuild errors and exit 1. No story renders, whether or not their own story is involved.
>
> **After:** the same command exits 0 and the gallery opens with every story, including ones whose components import an `.svg` or reach a Node builtin.

Both bundles now share one definition of the policy instead of holding a copy each, so they cannot drift apart again. The shipped plugin is untouched: `main.js` is byte-identical before and after.

The shared policy also closes the same gap on the production side, which listed sixteen `node:`-prefixed builtins by hand. A dependency that starts importing, say, `node:zlib` would have broken `npm run build`; it no longer does.

CI gains two build steps on pull requests. `npm run gallery:build` bundles the whole story graph, so a story that cannot build now fails its PR rather than reaching master unnoticed, which is how this breakage survived. `npm run build` type-checks the project and bundles the plugin; both previously ran only when a release PR merged, so a type error or a bundling break could sit on master until someone cut a release.

| Story's module graph reaches | Before | After |
| --- | --- | --- |
| A `node:`-prefixed builtin | Bundles | Bundles |
| The bare spelling of a builtin | Fails to resolve | Bundles |
| `module` | Fails to resolve | Bundles via the shim |
| An `.svg` import | No loader configured | Bundles, logo renders |

## Non goal

- No change to the shipped plugin bundle; `main.js` stays byte-identical.
- No redesign of the gallery, its story format, or `scripts/gen-gallery-stories.mjs`.
- No visual verification of stories already merged unrendered. _Suggested follow-up: verify the SemanticSearchSetting story's three states in the gallery._
- No fix for the `dev/gallery/Gallery.test.tsx` failure seen in a linked worktree; that is a jest `yaml` resolver issue unrelated to bundling.

## Screenshot

Not applicable — this PR changes build configuration only, and the shipped bundle is byte-identical, so no rendered surface changes. The restored gallery is exercised by CI and by Verification below.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Build config only; `main.js` is byte-identical, and both bundles are now built on every PR |
| A defect would fail CI or be obvious on first use | ✅ | `npm run gallery:build` now runs in CI and is the exact command that fails today |
| A revert fully restores prior state, including persisted data | ✅ | No data migration or persisted write; reverting restores the previous configs |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | No runtime code changed |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Build-time module resolution only |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No runtime code changed |
| No hot-path behavior lacks deterministic coverage | ✅ | The changed behavior is a build succeeding, covered by the two CI build steps |
| No new dependency | ✅ | `package.json` is unchanged; `@svgr/*` and `esbuild` were already devDependencies |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to developer tooling; a failure appears as a red CI step |

Review: confirm the shipped bundle is unaffected by running Verification step 1, then read `nodeModuleShim.mjs` — the `nodeBuiltinExternals` array and the comment above it — to check that the `"node:*"` wildcard does not strand `node:module`, which the shim below it claims first. Then read the `external` and `plugins` entries in `dev/gallery/esbuild.config.mjs`.

## Verification

1. On this branch, run `npm run build`, note the checksum of `main.js`, then repeat on `master`. The two checksums match, confirming the shipped plugin is unchanged.
2. Run `npm run gallery:build`. It exits 0. On `master` the same command exits 1.
3. Run `npm run gallery:vault`, open the vault, and run the Copilot gallery command. Stories render.
4. In the gallery, open a story whose component shows an agent-mode backend logo (Claude, Codex, or opencode). The logo renders, which exercises the `.svg` path that failed before.

## Note

`nodeBuiltinExternals` sits in `nodeModuleShim.mjs` rather than its own file so that the list and the `module` shim stay together. The list covers `node:module` only through its wildcard, and the shim claims that specifier first — an arrangement that only reads as intentional when the two are side by side.

The two spellings are covered differently on purpose. A `node:` specifier can only ever be a builtin, so one wildcard covers every present and future one. Bare specifiers are ambiguous — `events`, `process`, and `punycode` are also real npm packages — so wildcarding that side would shadow a dependency that legitimately resolves to `node_modules`.
