### PR TITLE
Decode entitlement tokens through the buffer polyfill instead of atob

### DIFF
--- a/src/entitlement/verify.test.ts
+++ b/src/entitlement/verify.test.ts
@@ -133,4 +133,40 @@ describe("verifyEntitlement", () => {
     expect(await verify("not-a-jwt", { publicKeys })).toBeNull();
     expect(await verify("only.two", { publicKeys })).toBeNull();
   });
+
+  it("rejects segments containing characters outside the base64url alphabet", async () => {
+    const token = await signToken(keyPair.privateKey, plusClaims());
+    const [header, payload, signature] = token.split(".");
+    // The decoder skips these characters instead of throwing, so each segment
+    // must still be rejected downstream by JSON parsing or ES256 verification.
+    expect(await verify(`!!!!.${payload}.${signature}`, { publicKeys })).toBeNull();
+    expect(await verify(`${header}.!!!!.${signature}`, { publicKeys })).toBeNull();
+    expect(await verify(`${header}.${payload}.!!!!`, { publicKeys })).toBeNull();
+  });
+
+  it("verifies a token whose segments use the base64url-only '-' and '_' characters", async () => {
+    // U+07FF encodes to base64 indices 62 and 63, which base64url spells "-" and
+    // "_". A decoder handling only the standard alphabet drops both, corrupting
+    // the bytes and silently rejecting a valid license.
+    const userId = `${USER_ID}\u07ff\u07ff`;
+    const token = await signToken(keyPair.privateKey, plusClaims({ user_id: userId }));
+    const payloadSegment = token.split(".")[1];
+    expect(payloadSegment).toContain("-");
+    expect(payloadSegment).toContain("_");
+    expect((await verify(token, { publicKeys }))?.user_id).toBe(userId);
+  });
+
+  it("verifies tokens whose unpadded segments cover every base64 remainder length", async () => {
+    // base64url segments carry no padding, so each byte length mod 3 produces a
+    // different implied-padding case; a decoder mishandling one would reject
+    // otherwise-valid licenses.
+    const remainders = new Set<number>();
+    for (const filler of ["", "x", "xx"]) {
+      const token = await signToken(keyPair.privateKey, plusClaims({ user_id: USER_ID + filler }));
+      expect(await verify(token, { publicKeys })).not.toBeNull();
+      remainders.add(token.split(".")[1].length % 4);
+    }
+    // Guard the premise: the three fillers must land on distinct remainders.
+    expect(remainders.size).toBe(3);
+  });
 });

--- a/src/entitlement/verify.ts
+++ b/src/entitlement/verify.ts
@@ -1,3 +1,7 @@
+// Reason: `buffer` is the npm polyfill (browser-compatible), bundled by esbuild
+// so the same Buffer code path works on desktop (Electron) and mobile (WebView).
+import { Buffer } from "buffer/";
+
 import { ENTITLEMENT_PUBLIC_KEYS } from "./publicKeys";
 import type { EntitlementClaims } from "./types";
 
@@ -21,16 +25,20 @@ interface JwsHeader {
   kid?: string;
 }
 
-/** Decode a base64url segment to bytes. */
+/**
+ * Decode a base64url segment to bytes.
+ *
+ * Uses the `buffer` polyfill rather than `atob`, whose Node typing the Obsidian
+ * community review flags as deprecated. Its "base64" decoder accepts the
+ * base64url alphabet and omitted padding, so JWS segments need no rewriting.
+ * Characters outside the alphabet yield partial bytes rather than throwing;
+ * such a segment still fails JSON parsing or ES256 verification, so a malformed
+ * token is rejected either way.
+ *
+ * https://github.com/logancyang/obsidian-copilot-preview/issues/304
+ */
 function base64UrlToBytes(segment: string): Uint8Array {
-  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
-  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
-  const binary = atob(padded);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
+  return new Uint8Array(Buffer.from(segment, "base64"));
 }
 
 function parseJsonSegment<T>(segment: string): T | null {


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#304

## Why

The Obsidian community plugin review scorecard for the published release reports
"`atob` is deprecated. Use `Buffer.from(data, 'base64')` instead — 1 occurrence"
against `src/entitlement/verify.ts:28`. That call decodes the three base64url
segments of the offline ES256 entitlement token — header, claims, signature —
which the plugin reads on every check of whether a user is on Plus or Lite. The
finding has to clear for the plugin's review to pass.

The deprecation is a typings artifact rather than a platform problem. `atob` is
standard WHATWG API in both the Electron renderer and the mobile WebView;
`@types/node` marks only its own Node global deprecated, and TypeScript resolves
to that declaration.

A previous attempt, #2819, read the scorecard's suggested `Buffer.from` as a
desktop-only Node built-in unavailable on mobile, and hand-rolled a WHATWG
forgiving-base64 decoder to work around it. That premise does not hold in this
repo: `buffer` is a runtime dependency bundled by esbuild, and `src/utils.ts` and
`src/LLMProviders/BedrockChatModel.ts` already decode base64 to bytes through it
on mobile today.

## What

Entitlement tokens decode through the bundled `buffer` polyfill. Every
well-formed segment produces the same bytes as before on desktop and mobile, so
license recognition is unchanged. Malformed segments are still rejected, but by
a different mechanism.

| Segment | Before | After |
| --- | --- | --- |
| Well-formed | decodes to bytes | decodes to the same bytes |
| Malformed | decoder throws, caller catches, token rejected | decoder returns partial bytes, token rejected by JSON parsing or the ES256 check |

No production code calls `atob`, and the decoder's base64url alphabet handling
and padding step are gone, since the polyfill accepts both natively.

## Non goal

- The `atob` occurrences inside `src/agentMode/skills/builtin/builtinSkills.ts`
  shell-script string templates. Different execution context, not flagged, and
  skill content must not change.
- `atob` calls inside bundled third-party dependencies.
- Other scorecard warnings, tracked separately.
- Any change to token semantics: signature verification, expiry, or user
  binding.
- Preserving the exact throw behavior of `atob` on malformed segments. Rejection
  is preserved; the mechanism that produces it is not.

## Screenshot

Not applicable. This changes headless license-verification internals with no
visual surface.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Three tests in `verify.test.ts` cover base64url-alphabet segments, unpadded segments at every remainder length, and out-of-alphabet rejection |
| A defect would fail CI or be obvious on first use | ✅ | Those tests run in the unit suite in CI, and a decode defect rejects every license on the next plan check |
| A revert fully restores prior state, including persisted data | ✅ | No persisted data or format change; the token wire format is untouched |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | This changes how untrusted license-token input is decoded inside the entitlement verifier |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Module-internal helper; `verifyEntitlement`'s signature and the token format are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The decoder is pure and synchronous |
| No hot-path behavior lacks deterministic coverage | ✅ | Valid decode, malformed rejection, alphabet, and padding cases are all deterministic tests |
| No new dependency | ✅ | `buffer` is already a runtime dependency; dependency manifests are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | A wrong decode surfaces immediately as a license no longer being recognized |

Review: inspect `src/entitlement/verify.ts` — `base64UrlToBytes` — against the
malformed-segment row of the What table, confirming both callers still reject
what it returns; then `src/entitlement/verify.test.ts` — the three tests named
in the first Risk row — to confirm they pin decode output rather than the
decoder's identity. Then run Verification steps 2 and 3, including the
tampered-token variant.

## Verification

1. Build the branch and load it in a test vault signed in to a licensed Copilot
   account. Reload the plugin and confirm the plan still shows as Plus or Lite
   in settings.
2. Change one character of the cached license token in the plugin's `data.json`,
   reload, and confirm the license is no longer recognized and the plan falls
   back.
3. Restore the original token, reload, and confirm the plan is recognized again.
4. Repeat step 1 on a real mobile device, where the `buffer` polyfill rather than
   any Node built-in supplies the decoder, and confirm the plan is recognized
   there too.

## Note

The issue's success criteria ask for decode output that is byte-identical to the
`atob` path *and* identical throw behavior. This PR delivers the first and
deliberately not the second, as recorded under Non goal. Malformed segments are
still rejected, by JSON parsing or the ES256 check rather than by a throw, so the
security property holds; the throw-parity criterion should be reconciled on the
issue rather than read as unmet work.
