### PR TITLE
Guide V3 Chat users to opencode

### DIFF
--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -4,6 +4,8 @@ Quick Chat is Copilot V4's lightweight conversation view. Use it for a short que
 
 For multi-step work, native agent tools, reusable skills, permissioned file changes, or Agent project context, use **Agent** instead. On desktop, click **Open Copilot Agent Chat** in the ribbon or run **Open Copilot Agent Chat Window** from the command palette. See [Agents in Copilot V4](agent-mode-and-tools.md).
 
+Quick Chat's V3 chat window will be deprecated soon. On desktop, use **Agent with opencode** for bring-your-own-key models. The small, always-visible link above the message box opens Agent for you.
+
 ## Open Quick Chat
 
 Run **Open Copilot Chat Window** from the command palette. On mobile, the Copilot ribbon button opens Quick Chat because Agent requires desktop Obsidian.

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -4,7 +4,7 @@ Quick Chat is Copilot V4's lightweight conversation view. Use it for a short que
 
 For multi-step work, native agent tools, reusable skills, permissioned file changes, or Agent project context, use **Agent** instead. On desktop, click **Open Copilot Agent Chat** in the ribbon or run **Open Copilot Agent Chat Window** from the command palette. See [Agents in Copilot V4](agent-mode-and-tools.md).
 
-Quick Chat's V3 chat window will be deprecated soon. On desktop, use **Agent with opencode** for bring-your-own-key models. The small, always-visible link inside the message box, directly above its controls, opens Agent for you.
+Quick Chat's V3 chat window will be deprecated soon. On desktop, use **Agent with opencode** for bring-your-own-key and Copilot-hosted models. The small, always-visible link inside the message box, directly above its controls, opens Agent for you.
 
 ## Open Quick Chat
 

--- a/docs/chat-interface.md
+++ b/docs/chat-interface.md
@@ -4,7 +4,7 @@ Quick Chat is Copilot V4's lightweight conversation view. Use it for a short que
 
 For multi-step work, native agent tools, reusable skills, permissioned file changes, or Agent project context, use **Agent** instead. On desktop, click **Open Copilot Agent Chat** in the ribbon or run **Open Copilot Agent Chat Window** from the command palette. See [Agents in Copilot V4](agent-mode-and-tools.md).
 
-Quick Chat's V3 chat window will be deprecated soon. On desktop, use **Agent with opencode** for bring-your-own-key models. The small, always-visible link above the message box opens Agent for you.
+Quick Chat's V3 chat window will be deprecated soon. On desktop, use **Agent with opencode** for bring-your-own-key models. The small, always-visible link inside the message box, directly above its controls, opens Agent for you.
 
 ## Open Quick Chat
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -832,7 +832,9 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
             />
             <ChatInput
               footerContent={
-                <LegacyChatDeprecationHint onOpenAgent={() => void plugin.activateAgentView()} />
+                <LegacyChatDeprecationHint
+                  onOpenAgent={safeAsyncHandler(() => plugin.activateAgentView())}
+                />
               }
               inputMessage={inputMessage}
               setInputMessage={setInputMessage}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -15,6 +15,7 @@ import type { WebTabContext } from "@/types/message";
 import { ChatControls } from "@/components/chat-components/ChatControls";
 import ChatInput from "@/components/chat-components/ChatModeInput";
 import ChatMessages from "@/components/chat-components/ChatMessages";
+import { LegacyChatDeprecationHint } from "@/components/chat-components/ui/LegacyChatDeprecationHint";
 import { useChatModelPicker } from "@/components/chat-components/useChatModelPicker";
 import { NewVersionBanner } from "@/components/chat-components/NewVersionBanner";
 import IndexingProgressCard from "@/components/IndexingProgressCard";
@@ -829,6 +830,7 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
               onOpenSourceFile={handleOpenSourceFile}
               latestTokenCount={latestTokenCount}
             />
+            <LegacyChatDeprecationHint onOpenAgent={() => void plugin.activateAgentView()} />
             <ChatInput
               inputMessage={inputMessage}
               setInputMessage={setInputMessage}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -830,8 +830,10 @@ const ChatInternal: React.FC<ChatProps & { chatInput: ReturnType<typeof useChatI
               onOpenSourceFile={handleOpenSourceFile}
               latestTokenCount={latestTokenCount}
             />
-            <LegacyChatDeprecationHint onOpenAgent={() => void plugin.activateAgentView()} />
             <ChatInput
+              footerContent={
+                <LegacyChatDeprecationHint onOpenAgent={() => void plugin.activateAgentView()} />
+              }
               inputMessage={inputMessage}
               setInputMessage={setInputMessage}
               handleSendMessage={safeAsyncHandler(handleSendMessage)}

--- a/src/components/chat-components/ChatInput.tsx
+++ b/src/components/chat-components/ChatInput.tsx
@@ -60,6 +60,8 @@ export interface ChatInputProps {
    * consolidate into a config object, not more props.
    */
   topRightAccessory?: React.ReactNode;
+  /** Optional row rendered inside the composer immediately above its controls. */
+  footerContent?: React.ReactNode;
   /** Overrides the default composer placeholder copy. */
   placeholder?: string;
   /** Forwarded to the editor's placeholder slot — see {@link LexicalEditor}. */
@@ -219,6 +221,7 @@ export interface ChatInputHandle {
 const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput(
   {
     topRightAccessory,
+    footerContent,
     placeholder = DEFAULT_PLACEHOLDER,
     placeholderPrompts,
     inputMessage,
@@ -867,6 +870,8 @@ const ChatInput = React.forwardRef<ChatInputHandle, ChatInputProps>(function Cha
           <div className="-tw-ml-4 tw-w-6 tw-shrink-0 tw-self-start">{topRightAccessory}</div>
         )}
       </div>
+
+      {footerContent}
 
       <div className="tw-flex tw-h-7 tw-justify-between tw-gap-1 tw-px-1">
         <div className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1">

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.stories.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.stories.tsx
@@ -1,0 +1,15 @@
+import {
+  LegacyChatDeprecationHint,
+  type LegacyChatDeprecationHintProps,
+} from "@/components/chat-components/ui/LegacyChatDeprecationHint";
+import type { Meta, StoryObj } from "@/lib/story";
+
+const meta = {
+  title: "Chat/Legacy Chat Deprecation Hint",
+  component: LegacyChatDeprecationHint,
+  args: { onOpenAgent: () => {} },
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
+} satisfies Meta<LegacyChatDeprecationHintProps>;
+export default meta;
+
+export const Default: StoryObj<LegacyChatDeprecationHintProps> = {};

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
@@ -1,0 +1,22 @@
+import {
+  LegacyChatDeprecationHint,
+  type LegacyChatDeprecationHintProps,
+} from "@/components/chat-components/ui/LegacyChatDeprecationHint";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+
+const COPY = "V3 Chat will be deprecated soon. Use opencode for BYOK.";
+
+describe("LegacyChatDeprecationHint", () => {
+  describe("LegacyChatDeprecationHint()", () => {
+    it("explains the supported BYOK path and opens Agent when selected", () => {
+      const onOpenAgent = jest.fn();
+      const props: LegacyChatDeprecationHintProps = { onOpenAgent };
+
+      render(<LegacyChatDeprecationHint {...props} />);
+      fireEvent.click(screen.getByRole("button", { name: COPY }));
+
+      expect(onOpenAgent).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
@@ -9,11 +9,13 @@ const COPY = "V3 Chat will be deprecated soon. Use opencode for BYOK.";
 
 describe("LegacyChatDeprecationHint", () => {
   describe("LegacyChatDeprecationHint()", () => {
-    it("explains the supported BYOK path and opens Agent when selected", () => {
+    it("shows deprecation guidance with an alert icon and opens Agent when selected", () => {
       const onOpenAgent = jest.fn();
       const props: LegacyChatDeprecationHintProps = { onOpenAgent };
 
-      render(<LegacyChatDeprecationHint {...props} />);
+      const { container } = render(<LegacyChatDeprecationHint {...props} />);
+
+      expect(container.querySelector(".lucide-circle-alert")).not.toBeNull();
       fireEvent.click(screen.getByRole("button", { name: COPY }));
 
       expect(onOpenAgent).toHaveBeenCalledTimes(1);

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
@@ -5,7 +5,8 @@ import {
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
-const COPY = "V3 Chat will be deprecated soon. Use opencode for BYOK.";
+const COPY =
+  "V3 Chat will be deprecated soon. Use Agent with opencode for BYOK and Copilot-hosted models.";
 
 describe("LegacyChatDeprecationHint", () => {
   describe("LegacyChatDeprecationHint()", () => {

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
@@ -5,8 +5,7 @@ import {
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
-const COPY =
-  "V3 Chat will be deprecated soon. Use Agent with opencode for BYOK and Copilot-hosted models.";
+const COPY = "V3 Chat will be deprecated soon. Use opencode for BYOK and Copilot-hosted models.";
 
 describe("LegacyChatDeprecationHint", () => {
   describe("LegacyChatDeprecationHint()", () => {

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
@@ -5,10 +5,20 @@ import {
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
+let mockDesktopRuntime = true;
+
+jest.mock("@/utils/desktopRuntime", () => ({
+  isDesktopRuntime: () => mockDesktopRuntime,
+}));
+
 const COPY = "V3 Chat is retiring soon. Use opencode for BYOK and Copilot-hosted models.";
 
 describe("LegacyChatDeprecationHint", () => {
   describe("LegacyChatDeprecationHint()", () => {
+    beforeEach(() => {
+      mockDesktopRuntime = true;
+    });
+
     it("shows deprecation guidance with an alert icon and opens Agent when selected", () => {
       const onOpenAgent = jest.fn();
       const props: LegacyChatDeprecationHintProps = { onOpenAgent };
@@ -19,6 +29,14 @@ describe("LegacyChatDeprecationHint", () => {
       fireEvent.click(screen.getByRole("button", { name: COPY }));
 
       expect(onOpenAgent).toHaveBeenCalledTimes(1);
+    });
+
+    it("hides the Agent migration hint on mobile because Agent is unavailable (https://github.com/logancyang/obsidian-copilot-preview/issues/323)", () => {
+      mockDesktopRuntime = false;
+
+      render(<LegacyChatDeprecationHint onOpenAgent={jest.fn()} />);
+
+      expect(screen.queryByRole("button", { name: COPY })).toBeNull();
     });
   });
 });

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.test.tsx
@@ -5,7 +5,7 @@ import {
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
-const COPY = "V3 Chat will be deprecated soon. Use opencode for BYOK and Copilot-hosted models.";
+const COPY = "V3 Chat is retiring soon. Use opencode for BYOK and Copilot-hosted models.";
 
 describe("LegacyChatDeprecationHint", () => {
   describe("LegacyChatDeprecationHint()", () => {

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
@@ -7,7 +7,7 @@ export interface LegacyChatDeprecationHintProps {
   onOpenAgent: () => void;
 }
 
-/** Directs legacy V3 Chat users to the supported BYOK path in Agent. */
+/** Directs legacy V3 Chat users to supported models in Agent. */
 export function LegacyChatDeprecationHint({ onOpenAgent }: LegacyChatDeprecationHintProps) {
   return (
     <div className="tw-flex tw-min-w-0 tw-px-1">
@@ -22,7 +22,10 @@ export function LegacyChatDeprecationHint({ onOpenAgent }: LegacyChatDeprecation
         onClick={onOpenAgent}
       >
         <CircleAlert className="tw-size-3 tw-shrink-0" aria-hidden="true" />
-        <span className="tw-truncate">V3 Chat will be deprecated soon. Use opencode for BYOK.</span>
+        <span className="tw-truncate">
+          V3 Chat will be deprecated soon. Use Agent with opencode for BYOK and Copilot-hosted
+          models.
+        </span>
       </Button>
     </div>
   );

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
@@ -23,8 +23,7 @@ export function LegacyChatDeprecationHint({ onOpenAgent }: LegacyChatDeprecation
       >
         <CircleAlert className="tw-size-3 tw-shrink-0" aria-hidden="true" />
         <span className="tw-truncate">
-          V3 Chat will be deprecated soon. Use Agent with opencode for BYOK and Copilot-hosted
-          models.
+          V3 Chat will be deprecated soon. Use opencode for BYOK and Copilot-hosted models.
         </span>
       </Button>
     </div>

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
@@ -23,7 +23,7 @@ export function LegacyChatDeprecationHint({ onOpenAgent }: LegacyChatDeprecation
       >
         <CircleAlert className="tw-size-3 tw-shrink-0" aria-hidden="true" />
         <span className="tw-truncate">
-          V3 Chat will be deprecated soon. Use opencode for BYOK and Copilot-hosted models.
+          V3 Chat is retiring soon. Use opencode for BYOK and Copilot-hosted models.
         </span>
       </Button>
     </div>

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { isDesktopRuntime } from "@/utils/desktopRuntime";
 import { CircleAlert } from "lucide-react";
 import React from "react";
 
@@ -7,8 +8,12 @@ export interface LegacyChatDeprecationHintProps {
   onOpenAgent: () => void;
 }
 
-/** Directs legacy V3 Chat users to supported models in Agent. */
+/** Directs desktop V3 Chat users to supported models in Agent. */
 export function LegacyChatDeprecationHint({ onOpenAgent }: LegacyChatDeprecationHintProps) {
+  // Agent is unavailable on real and emulated mobile, so migration guidance must stay desktop-only.
+  // https://github.com/logancyang/obsidian-copilot-preview/issues/323
+  if (!isDesktopRuntime()) return null;
+
   return (
     <div className="tw-flex tw-min-w-0 tw-px-1">
       <Button

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
@@ -1,0 +1,29 @@
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Sparkles } from "lucide-react";
+import React from "react";
+
+export interface LegacyChatDeprecationHintProps {
+  onOpenAgent: () => void;
+}
+
+/** Directs legacy V3 Chat users to the supported BYOK path in Agent. */
+export function LegacyChatDeprecationHint({ onOpenAgent }: LegacyChatDeprecationHintProps) {
+  return (
+    <div className="tw-flex tw-min-w-0 tw-px-2 tw-pb-1">
+      <Button
+        variant="ghost2"
+        size="fit"
+        className={cn(
+          "tw-flex tw-min-w-0 tw-items-center tw-gap-1 tw-text-ui-smaller tw-text-muted",
+          "hover:tw-text-normal"
+        )}
+        title="Open Agent"
+        onClick={onOpenAgent}
+      >
+        <Sparkles className="tw-size-3 tw-shrink-0" aria-hidden="true" />
+        <span className="tw-truncate">V3 Chat will be deprecated soon. Use opencode for BYOK.</span>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
+++ b/src/components/chat-components/ui/LegacyChatDeprecationHint.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Sparkles } from "lucide-react";
+import { CircleAlert } from "lucide-react";
 import React from "react";
 
 export interface LegacyChatDeprecationHintProps {
@@ -10,7 +10,7 @@ export interface LegacyChatDeprecationHintProps {
 /** Directs legacy V3 Chat users to the supported BYOK path in Agent. */
 export function LegacyChatDeprecationHint({ onOpenAgent }: LegacyChatDeprecationHintProps) {
   return (
-    <div className="tw-flex tw-min-w-0 tw-px-2 tw-pb-1">
+    <div className="tw-flex tw-min-w-0 tw-px-1">
       <Button
         variant="ghost2"
         size="fit"
@@ -21,7 +21,7 @@ export function LegacyChatDeprecationHint({ onOpenAgent }: LegacyChatDeprecation
         title="Open Agent"
         onClick={onOpenAgent}
       >
-        <Sparkles className="tw-size-3 tw-shrink-0" aria-hidden="true" />
+        <CircleAlert className="tw-size-3 tw-shrink-0" aria-hidden="true" />
         <span className="tw-truncate">V3 Chat will be deprecated soon. Use opencode for BYOK.</span>
       </Button>
     </div>


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#323

## Why

The legacy desktop V3 Chat message box gives users no persistent guidance as that interface approaches deprecation. People can keep using the old path without realizing that both BYOK and Copilot-hosted models are moving to opencode-backed Agent chat. Agent is unavailable on mobile, where V3 Chat remains the usable chat surface.

## What

Desktop V3 Chat now always shows one small, muted line inside the message box, as its own row immediately above the mode picker and action buttons: “V3 Chat is retiring soon. Use opencode for BYOK and Copilot-hosted models.” It follows the existing multi-agent upsell's understated text treatment while using a distinct alert icon, does not pop up or require dismissal, and opens Agent when selected. Agent activation failures use the existing safe async handler so they are logged instead of becoming unhandled promise rejections. The line does not render on real or emulated mobile.

## Non goal

- Removing or disabling V3 Chat.
- Migrating saved chats, provider settings, or API keys.
- Changing opencode model registration or provider behavior.

## Screenshot

Not attached — Obsidian's CLI captures the main vault renderer, while the V3 Chat command opens the changed surface in a separate floating window. The live floating-window DOM confirms the notice is inside the desktop composer immediately before its control row, uses the alert icon, and shows the full sentence without truncation at the tested window width. Mobile emulation returned zero matching hints; restoring desktop mode returned one. The component gallery confirms the small, muted treatment without a banner or callout.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | The focused component tests cover the alert icon, copy, Agent action, and mobile exclusion; the gallery covers the rendered desktop state. |
| A defect would fail CI or be obvious on first use | ✅ | Missing copy, banner styling, or a broken action is visible immediately in V3 Chat. |
| A revert fully restores prior state, including persisted data | ✅ | The change writes no user data or settings. |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | The hint only opens the existing Agent view through the standard safe async handler. |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No external contract changes. |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | The hint is stateless. |
| No hot-path behavior lacks deterministic coverage | ✅ | The click behavior is covered by a deterministic component test. |
| No new dependency | ✅ | Existing UI and icon components are reused. |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Appearance is isolated to the legacy V3 composer and is visible on open. |

Review: run Verification steps 1–4 and confirm the hint remains understated on desktop and absent on mobile.

## Verification

1. Load this branch in a desktop Obsidian test vault and run **Open Copilot Chat Window**.
2. Confirm a small, muted line with an alert icon sits inside the message box as its own row immediately above the mode picker and action buttons. It should read “V3 Chat is retiring soon. Use opencode for BYOK and Copilot-hosted models.” There should be no popup, banner box, warning background, or dismiss control.
3. Select the line and confirm Agent opens.
4. Enable Obsidian's mobile emulation, reopen V3 Chat, and confirm the line is absent.
