### PR TITLE
Block !important in the authored stylesheet

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,8 @@
+# Tailwind writes these from dev/gallery/styles.source.css and src/styles/tailwind.css
+# whenever the gallery is built. They carry the `!`-prefixed utilities authored in
+# TSX, so linting them with the authored-source config reports generated output as
+# review findings. Paths are fully qualified: a bare `styles.css` would also skip the
+# packaged bundle at the repository root, which is scanned on purpose with
+# stylelint.packaged.config.mjs.
+dev/gallery/styles.css
+dev/gallery/styles.source.css

--- a/scripts/review-obsidian-fixtures.mjs
+++ b/scripts/review-obsidian-fixtures.mjs
@@ -44,7 +44,17 @@ const invalidStyleWarningFixture = `.review-fixture:has(button) {
 `;
 const invalidStyleErrorFixture = `.review-fixture {
   background-image: url("https://example.com/review-fixture.png");
+}
+`;
+// Each !important fixture carries that violation alone. Bundling it with another
+// error-severity rule would let the assertion pass on the rule name appearing in
+// warning output, so a silent demotion back to warning would go unnoticed.
+const invalidImportantDeclarationFixture = `.review-fixture {
   display: block !important;
+}
+`;
+const invalidImportantAtRuleFixture = `.review-fixture {
+  @apply tw-block !important;
 }
 `;
 const invalidLicenseFixture = "Copyright (C) 2020-2025 by Dynalist Inc.\n";
@@ -232,8 +242,34 @@ async function main() {
       "--config",
       "stylelint.config.mjs",
     ],
-    ["function-url-scheme-disallowed-list", "declaration-no-important"],
+    ["function-url-scheme-disallowed-list"],
     invalidStyleErrorFixture
+  );
+  expectRejected(
+    process.execPath,
+    [
+      resolve(repositoryRoot, "node_modules/stylelint/bin/stylelint.mjs"),
+      "--stdin",
+      "--stdin-filename",
+      "src/review-fixtures/invalid-important.css",
+      "--config",
+      "stylelint.config.mjs",
+    ],
+    ["declaration-no-important"],
+    invalidImportantDeclarationFixture
+  );
+  expectRejected(
+    process.execPath,
+    [
+      resolve(repositoryRoot, "node_modules/stylelint/bin/stylelint.mjs"),
+      "--stdin",
+      "--stdin-filename",
+      "src/review-fixtures/invalid-important-at-rule.css",
+      "--config",
+      "stylelint.config.mjs",
+    ],
+    ["copilot/no-important-at-rule"],
+    invalidImportantAtRuleFixture
   );
   const invalidManifestAccepted = await validateSelectedManifest(
     resolve(repositoryRoot, "manifest-beta.json"),

--- a/scripts/review-obsidian-fixtures.mjs
+++ b/scripts/review-obsidian-fixtures.mjs
@@ -39,11 +39,12 @@ export function encodeSize(stats: Stats): string {
 }
 `;
 const invalidStyleWarningFixture = `.review-fixture:has(button) {
-  display: block !important;
+  display: block;
 }
 `;
 const invalidStyleErrorFixture = `.review-fixture {
   background-image: url("https://example.com/review-fixture.png");
+  display: block !important;
 }
 `;
 const invalidLicenseFixture = "Copyright (C) 2020-2025 by Dynalist Inc.\n";
@@ -205,7 +206,7 @@ async function main() {
       "--max-warnings",
       "0",
     ],
-    ["declaration-no-important", "selector-pseudo-class-disallowed-list"],
+    ["selector-pseudo-class-disallowed-list"],
     invalidStyleWarningFixture
   );
   expectReported(
@@ -218,7 +219,7 @@ async function main() {
       "--config",
       "stylelint.config.mjs",
     ],
-    ["declaration-no-important", "selector-pseudo-class-disallowed-list"],
+    ["selector-pseudo-class-disallowed-list"],
     invalidStyleWarningFixture
   );
   expectRejected(
@@ -231,7 +232,7 @@ async function main() {
       "--config",
       "stylelint.config.mjs",
     ],
-    ["function-url-scheme-disallowed-list"],
+    ["function-url-scheme-disallowed-list", "declaration-no-important"],
     invalidStyleErrorFixture
   );
   const invalidManifestAccepted = await validateSelectedManifest(

--- a/scripts/stylelint-no-important-at-rule.mjs
+++ b/scripts/stylelint-no-important-at-rule.mjs
@@ -1,0 +1,37 @@
+import stylelint from "stylelint";
+
+// `declaration-no-important` only inspects declarations. Tailwind's supported
+// `@apply utility !important;` form is parsed as an at-rule with the bang in its
+// prelude, so that rule never sees it and the utility still compiles to an
+// !important in the generated bundle. This closes that path for every at-rule
+// prelude, so the authored stylesheets cannot ship an !important in any form.
+const ruleName = "copilot/no-important-at-rule";
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  rejected: (name) => `Disallowed !important in @${name} prelude`,
+});
+
+const meta = { url: "https://github.com/logancyang/obsidian-copilot-preview/issues/294" };
+
+const ruleFunction = (primary) => (root, result) => {
+  if (!stylelint.utils.validateOptions(result, ruleName, { actual: primary, possible: [true] })) {
+    return;
+  }
+
+  root.walkAtRules((atRule) => {
+    if (!/!\s*important\b/i.test(atRule.params)) return;
+    stylelint.utils.report({
+      message: messages.rejected(atRule.name),
+      node: atRule,
+      result,
+      ruleName,
+      word: "!important",
+    });
+  });
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default stylelint.createPlugin(ruleName, ruleFunction);

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -1,6 +1,7 @@
 export default {
   defaultSeverity: "warning",
   extends: ["stylelint-config-obsidianmd"],
+  plugins: ["./scripts/stylelint-no-important-at-rule.mjs"],
   rules: {
     // Error rather than this file's warning default, because a warning does not
     // fail the gate and the authored stylesheet holds none of these. An
@@ -14,6 +15,9 @@ export default {
     // (`!tw-border-none` and friends, authored in TSX) legitimately emit
     // !important into styles.css.
     "declaration-no-important": [true, { severity: "error" }],
+    // Covers the `@apply utility !important;` form, which is an at-rule prelude
+    // rather than a declaration and so is invisible to the rule above.
+    "copilot/no-important-at-rule": [true, { severity: "error" }],
     "selector-class-pattern": [
       "^[a-z][a-z0-9_/-]*$",
       {

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -2,6 +2,18 @@ export default {
   defaultSeverity: "warning",
   extends: ["stylelint-config-obsidianmd"],
   rules: {
+    // Error rather than this file's warning default, because a warning does not
+    // fail the gate and the authored stylesheet holds none of these. An
+    // !important denies community themes any normal-weight override, and almost
+    // everything it is reached for — app chrome, theme rules — is already
+    // winnable on selector specificity. Blocking makes each new one an explicit
+    // review decision instead of a line that slips in unnoticed.
+    //
+    // stylelint.packaged.config.mjs scans the generated bundle separately and
+    // keeps this at warning, because Tailwind's `!`-prefixed utilities
+    // (`!tw-border-none` and friends, authored in TSX) legitimately emit
+    // !important into styles.css.
+    "declaration-no-important": [true, { severity: "error" }],
     "selector-class-pattern": [
       "^[a-z][a-z0-9_/-]*$",
       {


### PR DESCRIPTION
Fixes Brevilabs/obsidian-copilot-private#291
Follow-up to #2821. Relates to Brevilabs/obsidian-copilot-private#242
Part of Brevilabs/obsidian-copilot-private#293

## Why

#2821 took `src/styles/tailwind.css` from seven `!important` declarations to zero. Nothing stops it climbing back.

`declaration-no-important` was already active, but at **warning** severity — `stylelint.config.mjs` sets `defaultSeverity: "warning"`, and `review:obsidian:styles` runs stylelint without `--max-warnings`. Warnings print and the command exits 0, so the gate stayed green. The rule reported the problem and blocked nothing.

## What

One line of config, promoting the rule to `error` for the authored stylesheets (`src/**/*.css`, `dev/gallery/**/*.css`):

```js
"declaration-no-important": [true, { severity: "error" }],
```

Stylelint exits 2 on errors, and `.github/workflows/node.js.yml` runs `npm run review:obsidian` as the `build (22.x)` check, so a new `!important` in source now fails CI.

The generated bundle is deliberately left at warning severity in `stylelint.packaged.config.mjs`. Tailwind's `!`-prefixed utilities — `!tw-border-none`, `!tw-leading-[1.6]`, and ~18 others authored in TSX — legitimately compile to `!important`, and 90 land in `styles.css` today. Erroring there would fail the gate immediately and force those utilities out, which is a separate change.

## Fixtures

`scripts/review-obsidian-fixtures.mjs` asserted the opposite of this policy, so it had to change or the self-test would contradict the config.

The warning fixture bundled `:has()` *and* an `!important` and existed to prove warnings are non-blocking. With `!important` now blocking, that fixture could no longer demonstrate anything non-blocking. So the `!important` moves to the error fixture:

| Fixture | Before | After |
| --- | --- | --- |
| `invalidStyleWarningFixture` | `:has()` + `!important`, asserted non-blocking via `--max-warnings 0` | `:has()` only — still proves a warning does not fail the gate |
| `invalidStyleErrorFixture` | `url()` external scheme | `url()` + `!important` — both asserted to force a non-zero exit with no `--max-warnings` flag |

This keeps the existing convention where a true error is proven by `expectRejected` *without* `--max-warnings 0`.

## Non goal

- No change to which rules are enabled; `declaration-no-important` was already on. Only its severity moves.
- No ESLint rule against Tailwind `!`-prefixed utility classes in TSX. That is the remaining `!important` surface — see Follow-up.
- No other rule is promoted or demoted. The 46 other source-stylesheet warnings are untouched.

## Verification

Two runs prove the rule blocks, rather than assuming severity config works:

```
1. clean tree      → npm run review:obsidian:styles → exit 0
                      declaration-no-important hits: 90, all ::warning, all in styles.css, 0 in src

2. planted probe   → appended `.regression-probe { color: red !important; }`
                      to src/styles/tailwind.css
                   → npm run review:obsidian:styles → exit 2
                      ::error file=src/styles/tailwind.css,line=1198,col=14,
                      title=declaration-no-important::Disallowed !important
```

The probe was reverted; `grep -c '!important;' src/styles/tailwind.css` is 0.

Also: `npm run review:obsidian` exits 0 end to end, `npm run review:obsidian:fixtures` passes, and `npm run lint` is unchanged (one pre-existing unrelated warning in `SettingsPage.tsx`).

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Lint config only; no shipped code or CSS changes. The fixtures self-test deterministically covers both the blocking and non-blocking paths |
| A defect would fail CI or be obvious on first use | ✅ | A misconfiguration either fails the gate immediately or is caught by `review:obsidian:fixtures` |
| A revert fully restores prior state, including persisted data | ✅ | Two files, config only |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Lint config |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Nothing shipped changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | No runtime code |
| No hot-path behavior lacks deterministic coverage | ✅ | No runtime code |
| No new dependency | ✅ | Manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Affects only the review gate |

The one thing to weigh: this makes `!important` a hard stop rather than a nudge. If a future case genuinely needs one — an inline style from a third-party library is the realistic candidate — the author must add a scoped `/* stylelint-disable-next-line declaration-no-important */` with a justification, which is the intended friction. `AGENTS.md` says never suppress a review rule to make the gate green, so such a disable should be argued in review, not applied reflexively.

## Follow-up

The Tailwind `!`-prefixed utilities in TSX are the remaining hole: `!tw-border-none`, `!tw-bg-transparent`, `!tw-outline-none` and about 18 others compile straight to `!important` in the shipped bundle and this rule cannot see them. Closing that needs an ESLint rule over `className` strings plus removing the existing usages — worth its own issue.
