### PR TITLE
Refresh the deployed gallery stylesheet during test:vault

### DIFF
--- a/designdocs/agents/TESTING_GUIDE.md
+++ b/designdocs/agents/TESTING_GUIDE.md
@@ -435,6 +435,14 @@ npm run gallery:build
 
 Deploy to the non-production test vault configured by `COPILOT_TEST_VAULT_PATH` with `npm run gallery:vault`. Before any CLI or UI mutation, verify that the resolved vault name and path match that configuration; never rely on the implicitly focused renderer.
 
+### The gallery shares a stylesheet with the plugin
+
+The gallery's stylesheet is built by concatenating `src/styles/tailwind.css` into its own source, so it carries a near-complete copy of the production stylesheet — and Obsidian injects every enabled plugin's `styles.css` document-wide. Both copies land in the same cascade at equal specificity, so a gallery copy built from an older `src/styles/tailwind.css` outranks the deployed production rules and the plugin's own views render pre-change behavior.
+
+`npm run test:vault` keeps the two in step: when the vault's gallery plugin resolves to the worktree being deployed, it rebuilds and reloads the gallery too. It cannot do that when the deployed gallery belongs to a different worktree — `gallery:vault` symlinks its whole source directory, so the live stylesheet is owned by whichever worktree deployed it last. In that case the deployment warns and names the owning path; run `npm run gallery:vault` from that worktree or disable the gallery plugin while testing.
+
+If a CSS change appears to have no effect, check for the same selector twice in the inspector before suspecting the change itself.
+
 The story tree keeps its top-level categories open. Select a category label to show its contact sheet. For nested categories, the label also folds or unfolds the subtree; use the adjacent chevron when you want to toggle it without changing the selected contact sheet. Selecting a different story or contact sheet does not close branches you already opened.
 
 ### Agent verification loop

--- a/scripts/test-vault.sh
+++ b/scripts/test-vault.sh
@@ -154,6 +154,53 @@ else
   fi
 fi
 
+# The component gallery plugin ships a near-complete copy of the production
+# stylesheet (scripts/prepare-gallery-css.mjs concatenates src/styles/tailwind.css
+# into its source), and Obsidian injects every enabled plugin's styles.css
+# document-wide. Both copies then compete at equal specificity in shared views, so
+# a gallery copy built from an older src/styles/tailwind.css silently outranks the
+# CSS deployed above and the plugin renders pre-change behavior.
+GALLERY_MANIFEST="$WORKTREE_ROOT/dev/gallery/manifest.json"
+GALLERY_ID=""
+if [[ -f "$GALLERY_MANIFEST" ]]; then
+  if ! GALLERY_ID="$(node -e '
+    const id = require("./dev/gallery/manifest.json").id;
+    if (typeof id !== "string" || id.length === 0) process.exit(1);
+    process.stdout.write(id);
+  ')" || [[ ! "$GALLERY_ID" =~ ^[a-z0-9-]+$ ]]; then
+    echo "warning: no valid plugin id in $GALLERY_MANIFEST; skipping the gallery refresh." >&2
+    GALLERY_ID=""
+  fi
+fi
+
+if [[ -n "$GALLERY_ID" ]]; then
+  GALLERY_PLUGIN_DIR="$VAULT_PATH/.obsidian/plugins/$GALLERY_ID"
+  if [[ -e "$GALLERY_PLUGIN_DIR" || -L "$GALLERY_PLUGIN_DIR" ]]; then
+    # gallery-vault.sh symlinks its whole source directory into the vault, so the
+    # live stylesheet belongs to whichever worktree deployed it last. Only that
+    # worktree can refresh it.
+    GALLERY_SOURCE_REAL="$(cd "$WORKTREE_ROOT/dev/gallery" && pwd -P)"
+    GALLERY_DEPLOYED_REAL="$(cd "$GALLERY_PLUGIN_DIR" 2>/dev/null && pwd -P || true)"
+    if [[ "$GALLERY_DEPLOYED_REAL" == "$GALLERY_SOURCE_REAL" ]]; then
+      # Obsidian injects styles.css when a plugin is enabled, so rewriting the
+      # symlinked file in place does not re-inject it. gallery:vault rebuilds and
+      # reloads, which is what makes the new stylesheet take effect.
+      echo "==> Redeploying the gallery plugin so both stylesheets match"
+      npm run gallery:vault
+    else
+      cat >&2 <<EOF
+warning: the vault's gallery plugin comes from somewhere else, so nothing built
+here can refresh it. Its stale copy of the production stylesheet can outrank the
+CSS just deployed, making these changes look like they had no effect.
+  deployed: ${GALLERY_DEPLOYED_REAL:-unresolved ($GALLERY_PLUGIN_DIR)}
+  here:     $GALLERY_SOURCE_REAL
+Run \`npm run gallery:vault\` from that worktree, or disable the $GALLERY_ID
+plugin while testing this one.
+EOF
+    fi
+  fi
+fi
+
 echo
 echo "Done."
 echo "  worktree: $WORKTREE_ROOT"

--- a/scripts/test-vault.test.sh
+++ b/scripts/test-vault.test.sh
@@ -24,11 +24,16 @@ printf 'clean styles\n' >"$FIXTURE_ROOT/styles.css"
 printf 'tracked\n' >"$FIXTURE_ROOT/source.txt"
 printf 'main.js\nstyles.css\n' >"$FIXTURE_ROOT/.gitignore"
 
+NPM_CALL_LOG="$TEST_ROOT/npm-calls.log"
 cat >"$FAKE_BIN/npm" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >>"$NPM_CALL_LOG"
+exit 0
+EOF
+cat >"$FAKE_BIN/obsidian" <<'EOF'
 #!/usr/bin/env bash
 exit 0
 EOF
-cp "$FAKE_BIN/npm" "$FAKE_BIN/obsidian"
 chmod +x "$FAKE_BIN/npm" "$FAKE_BIN/obsidian"
 
 git -C "$FIXTURE_ROOT" init -q
@@ -38,11 +43,14 @@ git -C "$FIXTURE_ROOT" config commit.gpgsign false
 git -C "$FIXTURE_ROOT" add .gitignore manifest.json scripts/test-vault.sh source.txt
 git -C "$FIXTURE_ROOT" commit -qm "fixture"
 
+DEPLOY_STDERR="$TEST_ROOT/deploy-stderr.log"
 run_deploy() {
+  : >"$NPM_CALL_LOG"
   PATH="$FAKE_BIN:$PATH" \
     COPILOT_TEST_VAULT_PATH="$VAULT_ROOT" \
     OBSIDIAN_BIN="$FAKE_BIN/obsidian" \
-    bash "$FIXTURE_ROOT/scripts/test-vault.sh" >/dev/null
+    NPM_CALL_LOG="$NPM_CALL_LOG" \
+    bash "$FIXTURE_ROOT/scripts/test-vault.sh" >/dev/null 2>"$DEPLOY_STDERR"
 }
 
 assert_manifest() {
@@ -110,5 +118,47 @@ printf 'dirty\n' >>"$FIXTURE_ROOT/source.txt"
 printf 'dirty bundle\n' >"$FIXTURE_ROOT/main.js"
 run_deploy
 assert_manifest dirty
+
+GALLERY_ID="copilot-component-gallery"
+GALLERY_PLUGIN_DIR="$VAULT_ROOT/.obsidian/plugins/$GALLERY_ID"
+mkdir -p "$FIXTURE_ROOT/dev/gallery"
+cat >"$FIXTURE_ROOT/dev/gallery/manifest.json" <<EOF
+{
+  "id": "$GALLERY_ID",
+  "name": "Gallery",
+  "version": "0.0.1"
+}
+EOF
+
+run_deploy
+if grep -q "gallery:vault" "$NPM_CALL_LOG"; then
+  echo "rebuilt the gallery when the vault has no gallery plugin installed" >&2
+  exit 1
+fi
+if grep -qi "gallery" "$DEPLOY_STDERR"; then
+  echo "warned about the gallery when the vault has no gallery plugin installed" >&2
+  exit 1
+fi
+
+ln -s "$FIXTURE_ROOT/dev/gallery" "$GALLERY_PLUGIN_DIR"
+run_deploy
+if ! grep -q "run gallery:vault" "$NPM_CALL_LOG"; then
+  echo "did not rebuild the gallery deployed from this worktree" >&2
+  exit 1
+fi
+
+FOREIGN_GALLERY="$TEST_ROOT/other-worktree/dev/gallery"
+mkdir -p "$FOREIGN_GALLERY"
+rm "$GALLERY_PLUGIN_DIR"
+ln -s "$FOREIGN_GALLERY" "$GALLERY_PLUGIN_DIR"
+run_deploy
+if grep -q "gallery:vault" "$NPM_CALL_LOG"; then
+  echo "rebuilt the gallery for a deployment owned by another worktree" >&2
+  exit 1
+fi
+if ! grep -q "comes from somewhere else" "$DEPLOY_STDERR"; then
+  echo "did not warn that the deployed gallery belongs to another worktree" >&2
+  exit 1
+fi
 
 echo "test-vault deployment tests passed"


### PR DESCRIPTION
## Why

The component gallery is a second Obsidian plugin (`copilot-component-gallery`) that developers enable alongside `copilot` in the same test vault. Its stylesheet is built by concatenating `src/styles/tailwind.css` into its own source, so it carries a near-complete copy of the production stylesheet: of its 101,725 bytes, 100,467 are byte-identical to the plugin's own `styles.css`, and only 61 lines are gallery-specific. Obsidian injects every enabled plugin's `styles.css` document-wide, so both copies land in the same cascade at equal specificity and load order decides the winner.

`npm run test:vault` rebuilds and deploys the plugin but never touches the gallery, so the gallery's copy is only as fresh as the last `npm run gallery:vault`. When it is older, it wins.

This was hit while verifying #2821, which removed `!important` from the stylesheet. The gallery's stale copy still carried `line-height: 1.5 !important` on `.message-content pre code` and outranked the freshly deployed rule, so the chat view kept rendering pre-change behavior. The inspector showed the same selector twice, once with `!important` and once without. Disabling the gallery plugin resolved it.

Two consequences: a CSS change can look like it had no effect after `test:vault`, and the gallery that `CLAUDE.md` directs agents to verify UI work in may itself be rendering against a stale stylesheet.

## What

`npm run test:vault` now keeps the two plugins' stylesheets in step.

| Vault state | Before | After |
| --- | --- | --- |
| No gallery plugin installed | Nothing | Nothing |
| Gallery resolves to the deployed worktree | Gallery keeps its old stylesheet and can outrank the new one | Runs `gallery:vault`, so both plugins ship the same generation of `src/styles/tailwind.css` |
| Gallery belongs to a different worktree | Silent | Warns, naming the owning path and the remedy |

The third row matters because `gallery-vault.sh` symlinks its whole source directory into the vault, so the live stylesheet is owned by whichever worktree deployed it last. Nothing built here can refresh another worktree's copy, so the deployment says so instead of appearing to have handled it.

`TESTING_GUIDE.md` documents the coupling for the agent verification loop.

## Non goal

- Does not reduce the duplication itself. The gallery still emits a full copy of the production stylesheet; this only stops it going stale. Removing the duplication means changing what `prepare-gallery-css.mjs` emits, which is a separate change.
- Does not scope the gallery's emitted CSS. Stories use the `modal` and `popover` hosts, which portal to `document.body`, so scoping under a gallery root would break the hosts that exist to reproduce real component boundaries.
- Does not refresh a gallery deployed from another worktree. That worktree owns the symlink.
- Does not change `gallery:vault`, `gallery:build`, or the gallery bundle.

## Screenshot

Not applicable. This changes a deployment script and its documentation; there is no user-visible surface. The stylesheet conflict it prevents was diagnosed in the Obsidian inspector, not in a rendered state this PR alters.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | `scripts/test-vault.test.sh` covers all three vault states against a fixture repo and vault |
| A defect would fail CI or be obvious on first use | ✅ | `npm run test:vault:script` exercises the branches; a wrong branch surfaces on the next deployment |
| A revert fully restores prior state | ✅ | Script-only change, no persisted state written |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Reads a plugin id from a tracked manifest and validates it against `^[a-z0-9-]+$` before using it in a path |
| No public API, plugin API, message, or on-disk contract changes | ✅ | No plugin or bundle output changes |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Sequential shell after the existing deployment |
| No hot-path behavior lacks deterministic coverage | ✅ | Each branch has a case; each was mutation-checked by breaking the branch and confirming the case fails |
| No new dependency | ✅ | Dependency manifests unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to `test:vault`, a developer-only script |

Review: read the gallery block at the end of `scripts/test-vault.sh`, from the `GALLERY_MANIFEST` assignment to the closing of the `GALLERY_ID` conditional, checking the same-worktree comparison against `pwd -P`. Then run Verification steps 2 and 3.

## Verification

1. Deploy both plugins into your `COPILOT_TEST_VAULT_PATH` vault from this branch: `npm run test:vault` then `npm run gallery:vault`. Confirm both are enabled in the vault.
2. Edit any rule in `src/styles/tailwind.css` that a chat view uses, then run `npm run test:vault` alone. Confirm the output shows `==> Redeploying the gallery plugin so both stylesheets match`, and that the inspector shows the edited rule once, not competing with a gallery copy.
3. Point the vault's gallery at a different worktree: `rm` the `copilot-component-gallery` symlink under `.obsidian/plugins/` and re-link it to another checkout's `dev/gallery`. Run `npm run test:vault` and confirm it warns, naming that worktree's path, and does not claim to have refreshed it.
4. Remove the `copilot-component-gallery` directory from the vault entirely and run `npm run test:vault`. Confirm it neither rebuilds the gallery nor warns.
