### PR TITLE
Seed Web Tab tracking from getMostRecentLeaf

### DIFF
--- a/src/services/webViewerService/webViewerServiceState.ts
+++ b/src/services/webViewerService/webViewerServiceState.ts
@@ -324,7 +324,7 @@ export class WebViewerStateManager {
     // Initialize snapshot eagerly
     this.recomputeActiveWebTabState({
       trigger: "active-leaf-change",
-      activeLeaf: this.app.workspace.activeLeaf ?? null,
+      activeLeaf: this.app.workspace.getMostRecentLeaf(),
     });
     // Initial subscription to webview events
     this.subscribeToWebviewLoadEvents();


### PR DESCRIPTION
Fixes logancyang/obsidian-copilot-preview#344
Relates to logancyang/obsidian-copilot-preview#291
Part of logancyang/obsidian-copilot-preview#345

## Why

The official Obsidian community plugin scorecard flags one deprecated Obsidian API in the plugin: "`activeLeaf` is deprecated. - The use of this field is discouraged." at `src/services/webViewerService/webViewerServiceState.ts:327`. Obsidian's own typings say the field may be removed and steer plugins to other accessors, so the read is a standing removal risk on a startup path.

The call site is the eager seed inside `startActiveWebTabTracking`, which runs once during plugin load on desktop. It initializes the Active Web Tab snapshot — the state behind the `{activeWebTab}` chat mention — before any workspace event has fired. The seeded leaf is the plugin's only remaining use of the deprecated field; the `active-leaf-change` handler in the same function already receives its leaf from the event itself.

## What

No behavior changes. The seed now reads the current leaf through `getMostRecentLeaf()`, the same accessor this service already uses in `getActiveLeaf()`, which `recomputeActiveWebTabState` consults for the active Web Viewer leaf anyway.

The two accessors do differ: `activeLeaf` is the focused leaf anywhere including the sidebars, while `getMostRecentLeaf()` reports the main editor area. That difference cannot reach a user here, because the seeded leaf feeds exactly one decision and both answers produce the same result at seed time:

| Seed-time condition | Seeded leaf is read? | Result before | Result after |
| --- | :---: | --- | --- |
| A Web Viewer tab is active | No — the active Web Viewer leaf wins outright | Snapshot tracks that tab | Snapshot tracks that tab |
| No Web Viewer tab active, focus in Copilot Chat | Yes — preserve check | Tracked tab preserved, and it is already empty | Tracked tab cleared, and it was already empty |
| No Web Viewer tab active, focus anywhere else | Yes — preserve check | Tracked tab cleared, already empty | Tracked tab cleared, already empty |

The tracked tab is always empty when the seed runs: the fields start `null`, and re-entering `startActiveWebTabTracking` calls `stopActiveWebTabTracking()` first, which resets them. Preserving nothing and clearing nothing are the same outcome.

## Non goal

- No change to the `active-leaf-change` or `layout-change` handlers, the sticky `preserveOnViewTypes` rule, or any other Active Web Tab behavior.
- No new tests: there is no behavior delta to assert, and a test that only checked which workspace accessor is called would pin implementation detail.
- No update to the scorecard snapshot in logancyang/obsidian-copilot-preview#291; per that issue's own workflow the body is replaced only after the next official authenticated review.
- No work on the other scorecard findings tracked separately — the `!important` declarations, the Node built-in imports, `getSettingDefinitions`, `atob`, or the LangChain deprecations.

## Screenshot

Not applicable — this PR changes which workspace accessor seeds an internal snapshot and renders nothing. The one surface downstream of that snapshot, the `{activeWebTab}` chat mention, is unchanged; Verification step 3 exercises it directly.

## Risk

**Low**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | No behavior change: the seeded leaf only feeds the preserve check, whose two outcomes are identical while tracked state is empty, which it always is at seed time |
| A defect would fail CI or be obvious on first use | ✅ | A wrong accessor name or return type fails the TypeScript build; a broken snapshot shows up as a missing `{activeWebTab}` mention on the first Web Viewer tab opened |
| A revert fully restores prior state, including persisted data | ✅ | One line, no persisted data or migration |
| No auth, permissions, secrets, or input-handling surface changes | ✅ | Reads a workspace leaf only |
| No public API, plugin API, message, or on-disk contract changes | ✅ | `startActiveWebTabTracking`'s signature and return shape are unchanged; the swap is internal to its body |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Synchronous read on the existing load path; event registration and ordering are untouched |
| No hot-path behavior lacks deterministic coverage | ✅ | Not a hot path — the seed runs once per plugin load; the existing suites over this service, `main.ts`, and `utils.ts` pass unchanged |
| No new dependency | ✅ | `getMostRecentLeaf` is in the pinned `obsidian` typings and already used elsewhere in this service |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | Confined to Active Web Tab tracking; a regression appears the first time a Web Viewer tab is mentioned in chat |

Review: skim `Why` and `What`, confirm the seed's only consumer is the `preserveOnViewTypes` branch in `recomputeActiveWebTabState` in `src/services/webViewerService/webViewerServiceState.ts`, run Verification step 3, confirm CI is green, and merge.

## Verification

1. Build this branch (`npm run build`) and load the plugin in a desktop test vault, with Obsidian's Web Viewer core plugin enabled.
2. Start Obsidian with the Copilot chat pane focused and no web tab open, then open the chat: no active web tab is offered, same as before.
3. Open a web page in a Web Viewer tab, then click into the Copilot chat: the `{activeWebTab}` mention resolves to that page's title and URL, and it stays offered while the chat pane holds focus.
4. Close the web tab and confirm the mention stops being offered.
