### PR TITLE
Support manual and keyless OpenAI-compatible models

### DIFF
--- a/docs/llm-providers.md
+++ b/docs/llm-providers.md
@@ -79,8 +79,10 @@ usual local URL:
 - LM Studio: `http://localhost:1234/v1`
 
 Start the local server before testing the provider. For another compatible
-service or proxy, choose **Add a custom provider** and supply its API key, base
-URL, and model ID.
+service or proxy, choose **Add a custom provider** and enter its base URL and
+model ID. The API key is optional; add one when the endpoint requires
+authentication. Model discovery uses the endpoint's `/v1/models` response, but
+you can always enter an exact model ID before searching the discovered list.
 
 If **Test** succeeds but Quick Chat cannot send a message, edit the provider
 and turn on **Enable CORS**. Responses then appear after completion instead of

--- a/src/LLMProviders/chatModelManager.bridge.test.ts
+++ b/src/LLMProviders/chatModelManager.bridge.test.ts
@@ -100,6 +100,27 @@ describe("chatModelManager", () => {
         expect(clientConfig.defaultHeaders?.["dangerously-allow-browser"]).toBeUndefined();
       });
 
+      it("omits Authorization for a keyless bridged OpenAI-compatible model (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
+        const model = await ChatModelManager.getInstance().createModelInstanceFromBridged(
+          bridgedModel({
+            provider: ChatModelProviders.OPENAI_FORMAT,
+            baseUrl: "http://127.0.0.1:8000/v1",
+            requiresApiKey: false,
+          })
+        );
+        const clientConfig = (
+          model as unknown as {
+            clientConfig: {
+              apiKey?: string;
+              defaultHeaders?: Record<string, string | null>;
+            };
+          }
+        ).clientConfig;
+
+        expect(clientConfig.apiKey).toBeUndefined();
+        expect(clientConfig.defaultHeaders?.Authorization).toBeNull();
+      });
+
       it("strips a versioned Google base URL because the client appends /v1beta itself", async () => {
         const GoogleMock = jest.requireMock("@langchain/google-genai").ChatGoogleGenerativeAI as {
           configs: Array<{ baseUrl?: string }>;

--- a/src/LLMProviders/chatModelManager.ts
+++ b/src/LLMProviders/chatModelManager.ts
@@ -196,6 +196,7 @@ export default class ChatModelManager {
     const { isThinkingEnabled, usesAdaptiveThinking } = modelInfo;
     const resolvedTemperature = this.getTemperatureForModel(modelInfo, customModel, settings);
     const maxTokens = customModel.maxTokens ?? settings.maxTokens;
+    const openAIFormatIsKeyless = customModel.requiresApiKey === false;
 
     // Base config - temperature will be handled by provider-specific methods
     const baseConfig: Omit<ModelConfig, "maxTokens" | "maxCompletionTokens"> = {
@@ -406,15 +407,21 @@ export default class ChatModelManager {
       },
       [ChatModelProviders.OPENAI_FORMAT]: {
         modelName: modelName,
-        apiKey: await this.resolveApiKey(
-          customModel.apiKey,
-          settings.openAIApiKey,
-          allowLegacyCredentialFallback
-        ),
+        apiKey: openAIFormatIsKeyless
+          ? undefined
+          : await this.resolveApiKey(
+              customModel.apiKey,
+              settings.openAIApiKey,
+              allowLegacyCredentialFallback
+            ),
         streamUsage: customModel.streamUsage ?? false,
         configuration: {
           baseURL: customModel.baseUrl,
           fetch: customModel.enableCors ? safeFetch : undefined,
+          // The OpenAI SDK accepts an explicit null to omit its default auth
+          // header while still constructing a client for a keyless endpoint.
+          // https://github.com/logancyang/obsidian-copilot/issues/2895
+          defaultHeaders: openAIFormatIsKeyless ? { Authorization: null } : undefined,
         },
         ...this.getOpenAISpecialConfig(
           modelName,
@@ -737,6 +744,13 @@ export default class ChatModelManager {
     model: CustomModel,
     allowLegacyCredentialFallback: boolean = true
   ): boolean {
+    if (
+      model.requiresApiKey === false &&
+      (model.provider as ChatModelProviders) === ChatModelProviders.OPENAI_FORMAT
+    ) {
+      return true;
+    }
+
     if ((model.provider as ChatModelProviders) === ChatModelProviders.AMAZON_BEDROCK) {
       const settings = getSettings();
       const apiKey =

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -478,6 +478,26 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     });
   });
 
+  it("skips an optional-auth provider when its stored key can no longer be resolved (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
+    const provider = {
+      ...makeOpenAICompatibleProvider(
+        "p-missing-stored-key",
+        "https://trusted-gateway.example.com/v1",
+        "Trusted gateway",
+        false
+      ),
+      apiKeyKeychainId: "keychain-p-missing-stored-key",
+    };
+    const deps = makeDeps({
+      resolved: [okEntry(provider, makeModel("p-missing-stored-key", "qwen3.8-27b"))],
+      keys: { "p-missing-stored-key": null },
+    });
+
+    const cfg = await buildOpencodeConfig(getSettings(), deps);
+
+    expect(cfg.provider).toEqual({});
+  });
+
   it("keeps a key-less self-hosted provider even when it carries a catalog id", async () => {
     // Guards the catalog-growth scenario: if a local runner like Ollama ever
     // gains a models.dev entry, its localhost baseUrl still tolerates a missing

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -625,6 +625,28 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     });
     expect(cp.models).toEqual({ "copilot-plus-flash": {} });
   });
+
+  it("skips Copilot Plus when its provisioned relay token is unavailable (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
+    const provider = makeProvider(
+      "p-plus",
+      { kind: "copilot-plus" },
+      {
+        providerType: "openai-compatible",
+        baseUrl: "https://models.brevilabs.com/v1",
+        requiresApiKey: false,
+      }
+    );
+    const deps = makeDeps({
+      resolved: [okEntry(provider, makeModel("p-plus", "copilot-plus-flash"))],
+      keys: { "p-plus": null },
+    });
+
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, unknown>;
+    };
+
+    expect(cfg.provider).toEqual({});
+  });
 });
 
 describe("buildOpencodeConfig — agent/prompt/mode/skills blocks (preserved)", () => {

--- a/src/agentMode/backends/opencode/OpencodeBackend.test.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.test.ts
@@ -95,7 +95,9 @@ function seedSkills(skills: Skill[]): void {
 function makeProvider(
   providerId: string,
   origin: ProviderOrigin,
-  overrides: Partial<Pick<Provider, "providerType" | "baseUrl" | "displayName" | "enableCors">> = {}
+  overrides: Partial<
+    Pick<Provider, "providerType" | "baseUrl" | "displayName" | "enableCors" | "requiresApiKey">
+  > = {}
 ): Provider {
   return {
     providerId,
@@ -103,6 +105,7 @@ function makeProvider(
     displayName: overrides.displayName ?? providerId,
     baseUrl: overrides.baseUrl,
     enableCors: overrides.enableCors,
+    requiresApiKey: overrides.requiresApiKey ?? true,
     origin,
     addedAt: 0,
   };
@@ -112,12 +115,13 @@ function makeProvider(
 function makeOpenAICompatibleProvider(
   providerId: string,
   baseUrl: string | undefined,
-  displayName = providerId
+  displayName = providerId,
+  requiresApiKey = true
 ): Provider {
   return makeProvider(
     providerId,
     { kind: "byok" },
-    { providerType: "openai-compatible" as ProviderType, baseUrl, displayName }
+    { providerType: "openai-compatible" as ProviderType, baseUrl, displayName, requiresApiKey }
   );
 }
 
@@ -369,7 +373,8 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     const provider = makeOpenAICompatibleProvider(
       "p-ollama",
       "http://localhost:11434/v1",
-      "Ollama"
+      "Ollama",
+      false
     );
     const deps = makeDeps({
       resolved: [okEntry(provider, makeModel("p-ollama", "llama3.2"))],
@@ -441,9 +446,7 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     expect(cfg.provider).toEqual({});
   });
 
-  it("drops a key-less OpenAI-compatible BYOK provider on a public host", async () => {
-    // Key tolerance keys off the baseUrl host, not catalog membership: a public
-    // endpoint with no key is dropped (its template requires one).
+  it("drops a key-less OpenAI-compatible BYOK provider when its persisted contract requires a key", async () => {
     const provider = makeOpenAICompatibleProvider("p-public", "https://my-proxy.example.com/v1");
     const deps = makeDeps({
       resolved: [okEntry(provider, makeModel("p-public", "gpt-5.5"))],
@@ -455,6 +458,26 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     expect(cfg.provider).toEqual({});
   });
 
+  it("keeps a keyless custom provider on a public host when its persisted contract allows it (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
+    const provider = makeOpenAICompatibleProvider(
+      "p-public-keyless",
+      "https://trusted-gateway.example.com/v1",
+      "Trusted gateway",
+      false
+    );
+    const deps = makeDeps({
+      resolved: [okEntry(provider, makeModel("p-public-keyless", "qwen3.8-27b"))],
+      keys: { "p-public-keyless": null },
+    });
+    const cfg = (await buildOpencodeConfig(getSettings(), deps)) as {
+      provider: Record<string, { options?: { baseURL?: string; apiKey?: string } }>;
+    };
+
+    expect(cfg.provider["p-public-keyless"].options).toEqual({
+      baseURL: "https://trusted-gateway.example.com/v1",
+    });
+  });
+
   it("keeps a key-less self-hosted provider even when it carries a catalog id", async () => {
     // Guards the catalog-growth scenario: if a local runner like Ollama ever
     // gains a models.dev entry, its localhost baseUrl still tolerates a missing
@@ -462,7 +485,11 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     const provider = makeProvider(
       "p-ollama-catalog",
       { kind: "byok", catalogProviderId: "ollama" },
-      { providerType: "openai-compatible", baseUrl: "http://localhost:11434/v1" }
+      {
+        providerType: "openai-compatible",
+        baseUrl: "http://localhost:11434/v1",
+        requiresApiKey: false,
+      }
     );
     const deps = makeDeps({
       resolved: [okEntry(provider, makeModel("p-ollama-catalog", "llama3.2"))],
@@ -480,7 +507,11 @@ describe("buildOpencodeConfig — provider/model injection", () => {
     const provider = makeProvider(
       "p-ollama-catalog",
       { kind: "byok", catalogProviderId: "ollama" },
-      { providerType: "openai-compatible", baseUrl: "http://localhost:11434/v1" }
+      {
+        providerType: "openai-compatible",
+        baseUrl: "http://localhost:11434/v1",
+        requiresApiKey: false,
+      }
     );
     const deps = makeDeps({
       resolved: [okEntry(provider, makeModel("p-ollama-catalog", "llama3.2"))],

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -2,7 +2,7 @@ import { ChatModelProviders } from "@/constants";
 import { logInfo, logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
 import type { CopilotSettings } from "@/settings/model";
-import { isSelfHostedProvider } from "@/modelManagement";
+import { providerRequiresApiKey } from "@/modelManagement";
 import { isCatalogProviderDefaultEndpoint } from "@/utils/providerBaseUrl";
 import type { BackendConfigRegistry, ProviderRegistry } from "@/modelManagement";
 import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
@@ -223,17 +223,14 @@ export async function buildOpencodeConfig(
     const origin = entry.provider.origin;
     const catalogProviderId = origin.kind === "byok" ? origin.catalogProviderId : undefined;
     const hasCatalogIdentity = !!catalogProviderId;
-    // Whether a missing key should drop the provider is a separate question:
-    // self-hosted endpoints commonly run key-less. Detect that from the baseUrl
-    // host so it stays correct even if a local runner gains a catalog id.
-    const isSelfHosted = isSelfHostedProvider(entry.provider);
 
     let providerConfig = provider[mapping.id];
     if (!providerConfig) {
       const apiKey = await providerRegistry.getApiKey(entry.provider.providerId);
-      // Catalog BYOK / Plus providers are useless without a key; self-hosted
-      // endpoints commonly run key-less, so don't drop them for a missing key.
-      if (!apiKey && !isSelfHosted) {
+      // Authentication is an explicit provider contract. Hostname shape cannot
+      // tell whether a local proxy requires auth or a remote gateway is keyless.
+      // https://github.com/logancyang/obsidian-copilot/issues/2895
+      if (!apiKey && providerRequiresApiKey(entry.provider)) {
         logInfo(
           `[AgentMode] skipping ${mapping.id}/${entry.configuredModel.info.id}: no API key in keychain`
         );

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -227,10 +227,11 @@ export async function buildOpencodeConfig(
     let providerConfig = provider[mapping.id];
     if (!providerConfig) {
       const apiKey = await providerRegistry.getApiKey(entry.provider.providerId);
-      // Authentication is an explicit provider contract. Hostname shape cannot
-      // tell whether a local proxy requires auth or a remote gateway is keyless.
+      // Copilot Plus provisions its relay token instead of asking for a BYOK key,
+      // but every relay request still requires that token. For BYOK providers,
+      // authentication is the explicit persisted contract, not hostname shape.
       // https://github.com/logancyang/obsidian-copilot/issues/2895
-      if (!apiKey && providerRequiresApiKey(entry.provider)) {
+      if (!apiKey && (origin.kind === "copilot-plus" || providerRequiresApiKey(entry.provider))) {
         logInfo(
           `[AgentMode] skipping ${mapping.id}/${entry.configuredModel.info.id}: no API key in keychain`
         );

--- a/src/agentMode/backends/opencode/OpencodeBackend.ts
+++ b/src/agentMode/backends/opencode/OpencodeBackend.ts
@@ -2,7 +2,7 @@ import { ChatModelProviders } from "@/constants";
 import { logInfo, logWarn } from "@/logger";
 import { getSettings } from "@/settings/model";
 import type { CopilotSettings } from "@/settings/model";
-import { providerRequiresApiKey } from "@/modelManagement";
+import { providerNeedsResolvedApiKey } from "@/modelManagement";
 import { isCatalogProviderDefaultEndpoint } from "@/utils/providerBaseUrl";
 import type { BackendConfigRegistry, ProviderRegistry } from "@/modelManagement";
 import { AcpBackend, AcpSpawnDescriptor } from "@/agentMode/acp/types";
@@ -227,11 +227,10 @@ export async function buildOpencodeConfig(
     let providerConfig = provider[mapping.id];
     if (!providerConfig) {
       const apiKey = await providerRegistry.getApiKey(entry.provider.providerId);
-      // Copilot Plus provisions its relay token instead of asking for a BYOK key,
-      // but every relay request still requires that token. For BYOK providers,
-      // authentication is the explicit persisted contract, not hostname shape.
+      // Runtime auth follows the persisted provider contract and keychain state,
+      // not hostname shape. A dangling keychain pointer must fail closed.
       // https://github.com/logancyang/obsidian-copilot/issues/2895
-      if (!apiKey && (origin.kind === "copilot-plus" || providerRequiresApiKey(entry.provider))) {
+      if (!apiKey && providerNeedsResolvedApiKey(entry.provider)) {
         logInfo(
           `[AgentMode] skipping ${mapping.id}/${entry.configuredModel.info.id}: no API key in keychain`
         );

--- a/src/aiParams.ts
+++ b/src/aiParams.ts
@@ -197,6 +197,8 @@ export interface CustomModel {
   provider: string;
   baseUrl?: string;
   apiKey?: string;
+  /** Runtime auth contract for bridged models; undefined preserves legacy behavior. */
+  requiresApiKey?: boolean;
   enabled: boolean;
   isEmbeddingModel?: boolean;
   isBuiltIn?: boolean;

--- a/src/modelManagement/catalog/builtinDefinitions.ts
+++ b/src/modelManagement/catalog/builtinDefinitions.ts
@@ -40,7 +40,9 @@ export const CUSTOM_OPENAI_DEFINITION: ProviderDefinition = {
   id: "custom-openai-compatible",
   displayName: "Custom OpenAI-compatible",
   providerType: "openai-compatible",
-  requiresApiKey: true,
+  // Custom endpoints may intentionally run without authentication.
+  // https://github.com/logancyang/obsidian-copilot/issues/2895
+  requiresApiKey: false,
   modelInputHint: "e.g. gpt-5.5",
 };
 

--- a/src/modelManagement/chatModel/configuredModelToCustomModel.test.ts
+++ b/src/modelManagement/chatModel/configuredModelToCustomModel.test.ts
@@ -145,13 +145,14 @@ describe("configuredModelToCustomModel", () => {
     expect(streaming.enableCors).toBe(false);
   });
 
-  it("substitutes a placeholder key only for keyless providers", () => {
+  it("carries the runtime auth contract without synthesizing a key (https://github.com/logancyang/obsidian-copilot/issues/2895)", () => {
     const keyless = configuredModelToCustomModel({
       provider: provider({ requiresApiKey: false, baseUrl: "http://localhost:11434/v1" }),
       configuredModel: configuredModel(),
       apiKey: null,
     });
-    expect(keyless.apiKey).toBe("default-key");
+    expect(keyless.apiKey).toBeUndefined();
+    expect(keyless.requiresApiKey).toBe(false);
 
     const requiresKey = configuredModelToCustomModel({
       provider: provider({ requiresApiKey: true }),
@@ -159,6 +160,14 @@ describe("configuredModelToCustomModel", () => {
       apiKey: null,
     });
     expect(requiresKey.apiKey).toBeUndefined();
+    expect(requiresKey.requiresApiKey).toBe(true);
+
+    const missingStoredKey = configuredModelToCustomModel({
+      provider: provider({ requiresApiKey: false, apiKeyKeychainId: "keychain-p1" }),
+      configuredModel: configuredModel(),
+      apiKey: null,
+    });
+    expect(missingStoredKey.requiresApiKey).toBe(true);
   });
 
   it("does not substitute a placeholder key for Copilot Plus", () => {
@@ -168,6 +177,7 @@ describe("configuredModelToCustomModel", () => {
       apiKey: null,
     });
     expect(custom.apiKey).toBeUndefined();
+    expect(custom.requiresApiKey).toBe(true);
   });
 
   it("derives capabilities from the model snapshot", () => {

--- a/src/modelManagement/chatModel/configuredModelToCustomModel.ts
+++ b/src/modelManagement/chatModel/configuredModelToCustomModel.ts
@@ -15,7 +15,7 @@
 import { CustomModel } from "@/aiParams";
 import { ChatModelProviders, ModelCapability, ProviderInfo } from "@/constants";
 import { logWarn } from "@/logger";
-import { providerRequiresApiKey } from "@/modelManagement/providers/providerRequiresApiKey";
+import { providerNeedsResolvedApiKey } from "@/modelManagement/providers/providerRequiresApiKey";
 import type { ConfiguredModel, Provider } from "@/modelManagement/types/persisted";
 
 /**
@@ -122,15 +122,7 @@ export function configuredModelToCustomModel(params: {
   const extras = provider.extras ?? {};
 
   const trimmedKey = apiKey && apiKey.length > 0 ? apiKey : undefined;
-  // Keyless providers (Ollama, LM Studio, unauthenticated proxies) still need a
-  // non-empty placeholder so the OpenAI-format client constructs — the legacy
-  // path used the same "default-key" sentinel. When a key IS required but
-  // missing, leave it undefined so credential validation fails loudly.
-  const resolvedApiKey =
-    trimmedKey ??
-    (provider.origin.kind === "copilot-plus" || providerRequiresApiKey(provider)
-      ? undefined
-      : "default-key");
+  const requiresApiKey = providerNeedsResolvedApiKey(provider) || !!trimmedKey;
 
   const capabilities: ModelCapability[] = [];
   if (info.reasoning) capabilities.push(ModelCapability.REASONING);
@@ -143,7 +135,8 @@ export function configuredModelToCustomModel(params: {
     displayName: info.displayName,
     enabled: true,
     baseUrl: provider.baseUrl,
-    apiKey: resolvedApiKey,
+    apiKey: trimmedKey,
+    requiresApiKey,
     // https://github.com/logancyang/obsidian-copilot-preview/issues/313:
     // verification can pass through requestUrl while Quick Chat fails through
     // native fetch. Preserve the user's explicit compatibility-versus-streaming

--- a/src/modelManagement/index.ts
+++ b/src/modelManagement/index.ts
@@ -35,7 +35,10 @@ export { ProviderRegistry } from "./providers/ProviderRegistry";
 export { isSelfHostedProvider, isSelfHostedUrl } from "./providers/isSelfHostedProvider";
 export { providerNeedsSelfHostWarning } from "./providers/selfHostPolicy";
 export type { SelfHostPolicyInput } from "./providers/selfHostPolicy";
-export { providerRequiresApiKey } from "./providers/providerRequiresApiKey";
+export {
+  providerNeedsResolvedApiKey,
+  providerRequiresApiKey,
+} from "./providers/providerRequiresApiKey";
 export { ConfiguredModelRegistry } from "./models/ConfiguredModelRegistry";
 export { BackendConfigRegistry } from "./backends/BackendConfigRegistry";
 export { ChatModelFactory } from "./chatModel/ChatModelFactory";

--- a/src/modelManagement/providers/providerRequiresApiKey.test.ts
+++ b/src/modelManagement/providers/providerRequiresApiKey.test.ts
@@ -1,5 +1,5 @@
 import type { Provider } from "@/modelManagement/types/persisted";
-import { providerRequiresApiKey } from "./providerRequiresApiKey";
+import { providerNeedsResolvedApiKey, providerRequiresApiKey } from "./providerRequiresApiKey";
 
 function provider(overrides: Partial<Provider> = {}): Provider {
   return {
@@ -14,22 +14,46 @@ function provider(overrides: Partial<Provider> = {}): Provider {
 }
 
 describe("providerRequiresApiKey", () => {
-  it("returns the explicit flag — the only runtime criteria", () => {
-    // The flag wins regardless of identity: a hosted catalog provider marked
-    // keyless reads keyless; a self-hosted row marked key-requiring reads so.
-    expect(
-      providerRequiresApiKey(
-        provider({ requiresApiKey: false, origin: { kind: "byok", catalogProviderId: "openai" } })
-      )
-    ).toBe(false);
-    expect(
-      providerRequiresApiKey(provider({ requiresApiKey: true, baseUrl: "http://localhost:11434" }))
-    ).toBe(true);
+  describe("providerRequiresApiKey()", () => {
+    it("returns the explicit flag — the only runtime criteria", () => {
+      // The flag wins regardless of identity: a hosted catalog provider marked
+      // keyless reads keyless; a self-hosted row marked key-requiring reads so.
+      expect(
+        providerRequiresApiKey(
+          provider({
+            requiresApiKey: false,
+            origin: { kind: "byok", catalogProviderId: "openai" },
+          })
+        )
+      ).toBe(false);
+      expect(
+        providerRequiresApiKey(
+          provider({ requiresApiKey: true, baseUrl: "http://localhost:11434" })
+        )
+      ).toBe(true);
+    });
+
+    it("defaults a flagless row to key-requiring (defensive backstop)", () => {
+      // Post-migration every persisted row carries the flag; a stray undefined
+      // must never read as keyless or its models would be silently dropped.
+      expect(providerRequiresApiKey(provider({ requiresApiKey: undefined }))).toBe(true);
+    });
   });
 
-  it("defaults a flagless row to key-requiring (defensive backstop)", () => {
-    // Post-migration every persisted row carries the flag; a stray undefined
-    // must never read as keyless or its models would be silently dropped.
-    expect(providerRequiresApiKey(provider({ requiresApiKey: undefined }))).toBe(true);
+  describe("providerNeedsResolvedApiKey()", () => {
+    it("requires a runtime key for required providers, Copilot Plus, and optional providers with a stored pointer (https://github.com/logancyang/obsidian-copilot/issues/2895)", () => {
+      expect(providerNeedsResolvedApiKey(provider({ requiresApiKey: true }))).toBe(true);
+      expect(
+        providerNeedsResolvedApiKey(
+          provider({ origin: { kind: "copilot-plus" }, requiresApiKey: false })
+        )
+      ).toBe(true);
+      expect(
+        providerNeedsResolvedApiKey(
+          provider({ requiresApiKey: false, apiKeyKeychainId: "keychain-p1" })
+        )
+      ).toBe(true);
+      expect(providerNeedsResolvedApiKey(provider({ requiresApiKey: false }))).toBe(false);
+    });
   });
 });

--- a/src/modelManagement/providers/providerRequiresApiKey.ts
+++ b/src/modelManagement/providers/providerRequiresApiKey.ts
@@ -16,3 +16,21 @@ import type { Provider } from "@/modelManagement/types/persisted";
 export function providerRequiresApiKey(provider: Provider): boolean {
   return provider.requiresApiKey ?? true;
 }
+
+/**
+ * Returns whether a runtime must resolve a credential before using this provider.
+ * Optional-auth providers become authenticated once they own a keychain pointer;
+ * a dangling pointer must fail closed instead of silently changing request semantics.
+ *
+ * @param provider - Persisted provider whose runtime credential contract is being evaluated.
+ */
+export function providerNeedsResolvedApiKey(provider: Provider): boolean {
+  // Copilot Plus provisions a relay token instead of a user-entered BYOK key,
+  // but every relay request still requires it.
+  // https://github.com/logancyang/obsidian-copilot/issues/2895
+  return (
+    provider.origin.kind === "copilot-plus" ||
+    providerRequiresApiKey(provider) ||
+    !!provider.apiKeyKeychainId
+  );
+}

--- a/src/modelManagement/ui/components/ModelChecklist.stories.tsx
+++ b/src/modelManagement/ui/components/ModelChecklist.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@/lib/story";
+import { ModelChecklist, type ModelChecklistProps } from "./ModelChecklist";
+
+const meta = {
+  title: "Settings/Model Checklist",
+  component: ModelChecklist,
+  args: {
+    availableModels: [],
+    selected: new Set<string>(),
+    onToggle: () => {},
+    onAddId: () => {},
+    query: "",
+    onQueryChange: () => {},
+  },
+  parameters: { gallery: { host: "modal", layout: "padded" } },
+} satisfies Meta<ModelChecklistProps>;
+export default meta;
+
+export const ManualEntry: StoryObj<ModelChecklistProps> = {
+  args: {
+    modelInputHint: "e.g. qwen/qwen3.8-27b",
+    fetchError: "Endpoint did not return a model list.",
+  },
+};
+
+export const DiscoveredModels: StoryObj<ModelChecklistProps> = {
+  args: {
+    availableModels: [
+      { id: "qwen/qwen3.8-27b", displayName: "Qwen 3.8 27B" },
+      { id: "text-embedding-3-small", displayName: "Text Embedding 3 Small", isEmbedding: true },
+    ],
+  },
+};

--- a/src/modelManagement/ui/components/ModelChecklist.stories.tsx
+++ b/src/modelManagement/ui/components/ModelChecklist.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
     query: "",
     onQueryChange: () => {},
   },
-  parameters: { gallery: { host: "modal", layout: "padded" } },
+  parameters: { gallery: { host: "leaf", layout: "padded" } },
 } satisfies Meta<ModelChecklistProps>;
 export default meta;
 

--- a/src/modelManagement/ui/components/ModelChecklist.test.tsx
+++ b/src/modelManagement/ui/components/ModelChecklist.test.tsx
@@ -9,6 +9,8 @@ function renderList(overrides: Partial<React.ComponentProps<typeof ModelChecklis
     selected: new Set<string>(),
     onToggle: jest.fn(),
     onAddId: jest.fn(),
+    query: "",
+    onQueryChange: jest.fn(),
     ...overrides,
   };
   render(<ModelChecklist {...props} />);
@@ -65,6 +67,8 @@ describe("ModelChecklist", () => {
         selected={new Set<string>()}
         onToggle={jest.fn()}
         onAddId={jest.fn()}
+        query=""
+        onQueryChange={jest.fn()}
       />
     );
     // Vision is the norm (not badged) and reasoning is hidden — a vision-capable
@@ -84,6 +88,13 @@ describe("ModelChecklist", () => {
     renderList({ availableModels: [PLAIN], onToggle });
     fireEvent.click(screen.getByRole("checkbox"));
     expect(onToggle).toHaveBeenCalledWith("gpt-5", true);
+  });
+
+  it("keeps manual entry above model search when discovery is unavailable (https://github.com/logancyang/obsidian-copilot/issues/2894)", () => {
+    renderList({ fetchError: "Endpoint did not return a model list." });
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs[0]).toBe(screen.getByTestId("model-checklist-manual-input"));
+    expect(inputs[1].getAttribute("placeholder")).toBe("Search available models…");
   });
 
   it("emits onAddId on Enter and clears the input", () => {
@@ -160,6 +171,15 @@ describe("ModelChecklist", () => {
     expect(screen.queryByTestId("model-row-gemini-2.0-flash")).toBeTruthy();
     expect(screen.queryByTestId(`model-row-${RICH.id}`)).toBeNull();
     expect(screen.queryByTestId("model-row-gpt-5")).toBeNull();
+  });
+
+  it("emits search query changes", () => {
+    const onQueryChange = jest.fn();
+    renderList({ onQueryChange });
+    fireEvent.change(screen.getByPlaceholderText("Search available models…"), {
+      target: { value: "qwen" },
+    });
+    expect(onQueryChange).toHaveBeenCalledWith("qwen");
   });
 
   it("sorts checked models to the top", () => {

--- a/src/modelManagement/ui/components/ModelChecklist.tsx
+++ b/src/modelManagement/ui/components/ModelChecklist.tsx
@@ -14,8 +14,10 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { ModelCapabilityIcons, hasCapabilityIcons } from "@/components/ui/model-display";
+import { SearchBar } from "@/components/ui/SearchBar";
 import { cn } from "@/lib/utils";
 import { capabilitiesFromConfiguredInfo } from "@/modelManagement/chatModel/modelCapabilityFlags";
 import type { ModelInfo } from "@/modelManagement/types/catalog";
@@ -34,7 +36,7 @@ export interface ModelChecklistProps {
   /** Wire ids currently checked. */
   selected: ReadonlySet<string>;
   onToggle: (id: string, next: boolean) => void;
-  /** Manual-add input — always visible. */
+  /** Manual-add input — always visible above endpoint discovery. */
   onAddId: (id: string) => void;
   /** Remove an id from the candidate pool. The X button only renders
    *  for ids the parent marked as custom-added (see `customIds`);
@@ -42,7 +44,8 @@ export interface ModelChecklistProps {
    *  so are non-removable. */
   onRemoveId?: (id: string) => void;
   /** Case-insensitive substring filter over name + id. */
-  query?: string;
+  query: string;
+  onQueryChange: (query: string) => void;
   /** Placeholder for the manual-add input. */
   modelInputHint?: string;
   /** Spinner shown above the list while the dialog auto-fetches. */
@@ -62,6 +65,7 @@ export const ModelChecklist: React.FC<ModelChecklistProps> = ({
   onAddId,
   onRemoveId,
   query,
+  onQueryChange,
   modelInputHint,
   fetching,
   fetchError,
@@ -90,6 +94,31 @@ export const ModelChecklist: React.FC<ModelChecklistProps> = ({
 
   return (
     <div className="tw-flex tw-flex-col tw-gap-2">
+      {/* Manual entry must remain reachable when an endpoint cannot provide /v1/models.
+          https://github.com/logancyang/obsidian-copilot/issues/2894 */}
+      <FormField label="Model ID">
+        <div className="tw-flex tw-gap-2">
+          <Input
+            className="tw-flex-1"
+            value={manualId}
+            onChange={(e) => setManualId(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleManualAdd();
+              }
+            }}
+            placeholder={modelInputHint ?? "Enter a model ID"}
+            data-testid="model-checklist-manual-input"
+          />
+          <Button variant="secondary" onClick={handleManualAdd} disabled={!manualId.trim()}>
+            Add
+          </Button>
+        </div>
+      </FormField>
+
+      <SearchBar value={query} onChange={onQueryChange} placeholder="Search available models…" />
+
       {fetching && (
         <div className="tw-flex tw-items-center tw-gap-2 tw-text-xs tw-text-muted">
           <Loader2 className="tw-size-3.5 tw-shrink-0 tw-animate-spin" />
@@ -186,30 +215,11 @@ export const ModelChecklist: React.FC<ModelChecklistProps> = ({
         >
           {fetching
             ? "Loading models…"
-            : query?.trim()
+            : query.trim()
               ? "No models match the current filters."
-              : "No models yet — type an id below or test your credentials to fetch the list."}
+              : "No models discovered — enter a model ID above or test your credentials."}
         </div>
       )}
-
-      <div className="tw-flex tw-gap-2">
-        <Input
-          className="tw-flex-1"
-          value={manualId}
-          onChange={(e) => setManualId(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              handleManualAdd();
-            }
-          }}
-          placeholder={modelInputHint ?? "Add a model id"}
-          data-testid="model-checklist-manual-input"
-        />
-        <Button variant="secondary" onClick={handleManualAdd} disabled={!manualId.trim()}>
-          Add
-        </Button>
-      </div>
     </div>
   );
 };

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
@@ -207,6 +207,30 @@ describe("ConfigureProviderForm (new mode)", () => {
     expect(rowCheckbox("llama3.2").getAttribute("aria-checked")).toBe("false");
   });
 
+  it("waits for Test before discovering models from a typed custom URL (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
+    mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
+    render(
+      <ConfigureProviderForm
+        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+        onClose={jest.fn()}
+      />
+    );
+    const baseUrlInput = screen.getByText("Base URL").parentElement?.querySelector("input");
+    expect(baseUrlInput).not.toBeNull();
+
+    fireEvent.change(baseUrlInput!, { target: { value: "h" } });
+    fireEvent.change(baseUrlInput!, { target: { value: "https://work.example.com/v1" } });
+    expect(mockListProviderModels).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Test" }));
+    await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledTimes(1));
+    expect(mockListProviderModels).toHaveBeenCalledWith(
+      "openai-compatible",
+      "https://work.example.com/v1",
+      expect.objectContaining({ apiKey: null })
+    );
+  });
+
   it("uses the source default URL as the input placeholder", () => {
     render(
       <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
@@ -103,6 +103,7 @@ jest.mock("@/modelManagement/providers/adapters/listProviderModels", () => ({
 }));
 
 import type { ProviderDefinition } from "@/modelManagement/types/runtime";
+import { CUSTOM_OPENAI_DEFINITION } from "@/modelManagement/catalog/builtinDefinitions";
 import { ConfigureProviderForm } from "./ConfigureProviderDialog";
 
 beforeEach(() => {
@@ -137,14 +138,6 @@ const ollamaSource: ProviderDefinition = {
   defaultBaseUrl: "http://localhost:11434/v1",
   requiresApiKey: false,
   modelInputHint: "e.g. llama3.2",
-};
-
-const customSource: ProviderDefinition = {
-  id: "custom-openai-compatible",
-  displayName: "Custom OpenAI-compatible",
-  providerType: "openai-compatible",
-  requiresApiKey: true,
-  modelInputHint: "e.g. gpt-5.5",
 };
 
 const anthropicCatalogMetadata = {
@@ -282,7 +275,10 @@ describe("ConfigureProviderForm (new mode)", () => {
   it("saves an explicit Quick Chat CORS choice for a new provider (https://github.com/logancyang/obsidian-copilot-preview/issues/313)", async () => {
     mockVerifyCredentials.mockResolvedValue({ ok: true, checkedAt: 1 });
     render(
-      <ConfigureProviderForm state={{ mode: "new", source: customSource }} onClose={jest.fn()} />
+      <ConfigureProviderForm
+        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+        onClose={jest.fn()}
+      />
     );
 
     fireEvent.change(screen.getByTestId("api-key"), { target: { value: "work-key" } });
@@ -346,6 +342,34 @@ describe("ConfigureProviderForm (new mode)", () => {
     await waitFor(() => expect(mockListProviderModels).toHaveBeenCalled());
     // No error chrome rendered.
     expect(screen.queryByText(/Listing not supported/i)).toBeNull();
+  });
+
+  it("saves a keyless custom endpoint (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
+    const onClose = jest.fn();
+    render(
+      <ConfigureProviderForm
+        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+        onClose={onClose}
+      />
+    );
+    const baseUrlInput = screen.getByText("Base URL").parentElement?.querySelector("input");
+    expect(baseUrlInput).not.toBeNull();
+    fireEvent.change(baseUrlInput!, {
+      target: { value: "http://127.0.0.1:8000/v1" },
+    });
+    manualAddId("qwen3.8-27b");
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mockSetupProvider).toHaveBeenCalledTimes(1));
+    expect(mockSetupProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: undefined,
+        requiresApiKey: false,
+        models: [expect.objectContaining({ id: "qwen3.8-27b" })],
+      })
+    );
+    expect(mockVerifyCredentials).not.toHaveBeenCalled();
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 });
 
@@ -583,12 +607,13 @@ describe("ConfigureProviderForm (hydration gate)", () => {
   });
 });
 
-// Use the customSource definition somewhere so it isn't flagged as unused;
-// covers the dialog's behavior for a catalog-less custom source.
 describe("ConfigureProviderForm (custom-openai source)", () => {
   it("shows the default 'Add a model id' / source-supplied hint in the manual input", () => {
     render(
-      <ConfigureProviderForm state={{ mode: "new", source: customSource }} onClose={jest.fn()} />
+      <ConfigureProviderForm
+        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+        onClose={jest.fn()}
+      />
     );
     expect(screen.getByPlaceholderText("e.g. gpt-5.5")).toBeTruthy();
   });

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
@@ -168,6 +168,22 @@ function rowCheckbox(id: string): HTMLElement {
 }
 
 describe("ConfigureProviderForm (new mode)", () => {
+  it.each([
+    ["Anthropic", anthropicSource],
+    ["OpenAI", openaiSource],
+    ["Ollama", ollamaSource],
+    ["custom OpenAI-compatible", CUSTOM_OPENAI_DEFINITION],
+  ] as const)(
+    "renders manual Model ID and discovery search together for %s (https://github.com/logancyang/obsidian-copilot/issues/2894)",
+    (_provider, source) => {
+      render(<ConfigureProviderForm state={{ mode: "new", source }} onClose={jest.fn()} />);
+      const modelsSection = screen.getByText("Models").parentElement;
+      expect(modelsSection).not.toBeNull();
+      expect(within(modelsSection!).getByTestId("model-checklist-manual-input")).toBeTruthy();
+      expect(within(modelsSection!).getByPlaceholderText("Search available models…")).toBeTruthy();
+    }
+  );
+
   it("skips the mount fetch when the source requires an API key and the field is empty", () => {
     render(
       <ConfigureProviderForm state={{ mode: "new", source: anthropicSource }} onClose={jest.fn()} />

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.test.tsx
@@ -298,6 +298,9 @@ describe("ConfigureProviderForm (new mode)", () => {
     );
 
     fireEvent.change(screen.getByTestId("api-key"), { target: { value: "work-key" } });
+    const baseUrlInput = screen.getByText("Base URL").parentElement?.querySelector("input");
+    expect(baseUrlInput).not.toBeNull();
+    fireEvent.change(baseUrlInput!, { target: { value: "https://work.example.com/v1" } });
     manualAddId("work-model");
     fireEvent.click(screen.getByRole("switch", { name: "Enable CORS" }));
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
@@ -386,6 +389,19 @@ describe("ConfigureProviderForm (new mode)", () => {
     );
     expect(mockVerifyCredentials).not.toHaveBeenCalled();
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it("requires a Base URL before saving a custom endpoint (https://github.com/logancyang/obsidian-copilot/issues/2895)", () => {
+    render(
+      <ConfigureProviderForm
+        state={{ mode: "new", source: CUSTOM_OPENAI_DEFINITION }}
+        onClose={jest.fn()}
+      />
+    );
+    manualAddId("qwen3.8-27b");
+
+    expect(screen.getByRole("button", { name: "Save" }).hasAttribute("disabled")).toBe(true);
+    expect(mockSetupProvider).not.toHaveBeenCalled();
   });
 });
 

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -684,7 +684,7 @@ export class ConfigureProviderModal extends ReactModal {
   }
 
   onOpen(): void {
-    this.modalEl.addClasses(["tw-flex", "tw-h-[70vh]", "tw-flex-col"]);
+    this.modalEl.addClasses(["tw-flex", "tw-h-[85vh]", "tw-flex-col"]);
     this.contentEl.addClasses([
       "tw-flex",
       "tw-min-h-0",

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -27,7 +27,6 @@ import { Button } from "@/components/ui/button";
 import { FormField } from "@/components/ui/form-field";
 import { Input } from "@/components/ui/input";
 import { PasswordInput } from "@/components/ui/password-input";
-import { SearchBar } from "@/components/ui/SearchBar";
 import { useApp } from "@/context";
 import { logError } from "@/logger";
 import type { ModelManagementApi } from "@/modelManagement/createModelManagement";
@@ -531,7 +530,6 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
 
         <div className="tw-flex tw-flex-col tw-gap-2">
           <div className="tw-text-sm tw-font-medium tw-text-normal">Models</div>
-          <SearchBar value={modelQuery} onChange={setModelQuery} placeholder="Search models..." />
           <ModelChecklist
             availableModels={pool.availableModels}
             selected={pool.selectedWireIds}
@@ -540,6 +538,7 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
             onRemoveId={pool.removeId}
             customIds={pool.customIds}
             query={modelQuery}
+            onQueryChange={setModelQuery}
             modelInputHint={modelInputHint}
             fetching={pool.fetching}
             fetchError={pool.fetchError}

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -440,11 +440,21 @@ const ConfigureProviderBody: React.FC<ConfigureProviderBodyProps> = ({
   // untested key falls through to the save-time auto-verify in the handlers.
   const verificationBlocksSave = isConclusiveVerificationFailure(verification?.code);
 
+  // A non-catalog OpenAI-compatible provider has no native routing default, so
+  // persisting it without a Base URL creates a model that no backend can call.
+  // https://github.com/logancyang/obsidian-copilot/issues/2895
+  const missingCustomBaseUrl =
+    providerType === "openai-compatible" && !catalogProviderId && !effectiveBaseUrl;
+
   // The candidate pool only fills with models the endpoint listed (which
   // requires working credentials) or ones the user explicitly typed, so a
   // non-empty selection already implies a usable setup. On top of that, gate
-  // on a present + non-conclusively-invalid key.
-  const canSave = pool.selectedWireIds.size > 0 && !missingRequiredKey && !verificationBlocksSave;
+  // on a routable endpoint and a present + non-conclusively-invalid key.
+  const canSave =
+    pool.selectedWireIds.size > 0 &&
+    !missingCustomBaseUrl &&
+    !missingRequiredKey &&
+    !verificationBlocksSave;
 
   const testFailed = verification?.ok === false;
 

--- a/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
+++ b/src/modelManagement/ui/dialogs/ConfigureProviderDialog.tsx
@@ -684,7 +684,7 @@ export class ConfigureProviderModal extends ReactModal {
   }
 
   onOpen(): void {
-    this.modalEl.addClasses(["tw-flex", "tw-h-[85vh]", "tw-flex-col"]);
+    this.modalEl.addClasses(["tw-flex", "tw-max-h-[85vh]", "tw-flex-col"]);
     this.contentEl.addClasses([
       "tw-flex",
       "tw-min-h-0",

--- a/src/modelManagement/ui/dialogs/useModelCandidatePool.ts
+++ b/src/modelManagement/ui/dialogs/useModelCandidatePool.ts
@@ -177,6 +177,12 @@ export function useModelCandidatePool({
     }
   }, [providerType, effectiveBaseUrl, apiKey, extras, mode, providerId, api]);
 
+  // New custom providers start without a routing target. Do not consume the
+  // one-shot fetch while the user is still typing that free-form URL; Test
+  // performs discovery once the endpoint is complete.
+  // https://github.com/logancyang/obsidian-copilot/issues/2895
+  const initialBaseUrlRef = useRef(effectiveBaseUrl);
+
   // Auto-fetch once on mount. In edit mode wait for the provider row to
   // hydrate so the saved-key probe uses the correct providerId. Skip in new
   // mode when the provider requires a key and the field is still empty — the
@@ -186,6 +192,7 @@ export function useModelCandidatePool({
   useEffect(() => {
     if (mountFetchedRef.current) return;
     if (!providerType || !effectiveBaseUrl) return;
+    if (mode === "new" && !initialBaseUrlRef.current) return;
     if (mode === "edit" && !providerHydrated) return;
     if (mode === "new" && requiresApiKey && !apiKey) return;
     mountFetchedRef.current = true;

--- a/src/settings/migrations/index.ts
+++ b/src/settings/migrations/index.ts
@@ -18,6 +18,7 @@ import { getSettings, normalizeRootFolders, setSettings } from "@/settings/model
 
 import { executeByokMigration } from "./byokMigration";
 import { executeGitHubCopilotRemoval } from "./githubCopilotRemovalMigration";
+import { planOptionalCustomProviderAuthMigration } from "./optionalCustomProviderAuthMigration";
 import { planRequiresApiKeyBackfill } from "./requiresApiKeyMigration";
 import { CURRENT_SETTINGS_VERSION } from "./version";
 
@@ -97,6 +98,14 @@ export async function runSettingsMigrations(api: ModelManagementApi): Promise<vo
   // the earlier migrations in this run left behind.
   if (fromVersion < 9) {
     executeGitHubCopilotRemoval(getSettings());
+  }
+
+  // v10: the custom OpenAI-compatible template now accepts keyless endpoints.
+  // Existing rows persisted the old required-key default, so update those rows
+  // while preserving any keychain pointer that records authenticated intent.
+  if (fromVersion < 10) {
+    const migrated = planOptionalCustomProviderAuthMigration(getSettings().providers);
+    if (migrated) setSettings({ providers: migrated });
   }
 
   // Bump unconditionally after the migrations so a per-provider failure can't

--- a/src/settings/migrations/optionalCustomProviderAuthMigration.test.ts
+++ b/src/settings/migrations/optionalCustomProviderAuthMigration.test.ts
@@ -1,0 +1,53 @@
+import type { Provider } from "@/modelManagement";
+import { planOptionalCustomProviderAuthMigration } from "./optionalCustomProviderAuthMigration";
+
+function provider(overrides: Partial<Provider> = {}): Provider {
+  return {
+    providerId: "p1",
+    providerType: "openai-compatible",
+    displayName: "Custom",
+    origin: { kind: "byok" },
+    requiresApiKey: true,
+    apiKeyKeychainId: null,
+    addedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("optionalCustomProviderAuthMigration", () => {
+  describe("planOptionalCustomProviderAuthMigration()", () => {
+    it("makes existing custom OpenAI-compatible BYOK rows optional without dropping their key pointer (https://github.com/logancyang/obsidian-copilot/issues/2895)", () => {
+      const next = planOptionalCustomProviderAuthMigration({
+        p1: provider({ apiKeyKeychainId: "keychain-p1" }),
+      });
+
+      expect(next?.p1.requiresApiKey).toBe(false);
+      expect(next?.p1.apiKeyKeychainId).toBe("keychain-p1");
+    });
+
+    it("leaves catalog providers, non-BYOK providers, and other provider types unchanged", () => {
+      const catalog = provider({
+        providerId: "catalog",
+        origin: { kind: "byok", catalogProviderId: "openai" },
+      });
+      const agent = provider({
+        providerId: "agent",
+        origin: { kind: "agent", agentType: "opencode" },
+      });
+      const anthropic = provider({ providerId: "anthropic", providerType: "anthropic" });
+
+      const next = planOptionalCustomProviderAuthMigration({ catalog, agent, anthropic });
+
+      expect(next).toBeNull();
+    });
+
+    it("returns null when every matching row is already optional", () => {
+      expect(
+        planOptionalCustomProviderAuthMigration({
+          p1: provider({ requiresApiKey: false }),
+        })
+      ).toBeNull();
+      expect(planOptionalCustomProviderAuthMigration({})).toBeNull();
+    });
+  });
+});

--- a/src/settings/migrations/optionalCustomProviderAuthMigration.ts
+++ b/src/settings/migrations/optionalCustomProviderAuthMigration.ts
@@ -1,0 +1,33 @@
+import type { Provider } from "@/modelManagement";
+
+/**
+ * Makes authentication optional for existing custom OpenAI-compatible BYOK providers.
+ * Stored keychain pointers remain intact, so authenticated providers keep failing
+ * closed if their configured secret cannot be resolved.
+ *
+ * @param providers - Persisted provider map from the pre-v10 settings snapshot.
+ */
+export function planOptionalCustomProviderAuthMigration(
+  providers: Record<string, Provider>
+): Record<string, Provider> | null {
+  let changed = false;
+  const next: Record<string, Provider> = {};
+
+  for (const [id, provider] of Object.entries(providers)) {
+    const isCustomOpenAICompatible =
+      provider.origin.kind === "byok" &&
+      !provider.origin.catalogProviderId &&
+      provider.providerType === "openai-compatible";
+
+    // Existing rows persisted the old template default, not a user choice.
+    // https://github.com/logancyang/obsidian-copilot/issues/2895
+    if (isCustomOpenAICompatible && provider.requiresApiKey !== false) {
+      next[id] = { ...provider, requiresApiKey: false };
+      changed = true;
+    } else {
+      next[id] = provider;
+    }
+  }
+
+  return changed ? next : null;
+}

--- a/src/settings/migrations/runSettingsMigrations.test.ts
+++ b/src/settings/migrations/runSettingsMigrations.test.ts
@@ -144,6 +144,36 @@ it("skips a future version", async () => {
   expect(mockSetSettings).not.toHaveBeenCalled();
 });
 
+it("v10: makes auth optional for an existing custom OpenAI-compatible provider (https://github.com/logancyang/obsidian-copilot/issues/2895)", async () => {
+  mockGetSettings.mockReturnValue(
+    settings({
+      settingsVersion: 9,
+      providers: {
+        custom: {
+          providerId: "custom",
+          providerType: "openai-compatible",
+          displayName: "Custom OpenAI-compatible",
+          origin: { kind: "byok" },
+          requiresApiKey: true,
+          apiKeyKeychainId: "keychain-custom",
+          addedAt: 0,
+        },
+      },
+    })
+  );
+  const { api } = makeApi();
+
+  await runSettingsMigrations(api);
+
+  const providerWrite = mockSetSettings.mock.calls.find((call) => "providers" in call[0])?.[0] as
+    | { providers: Record<string, { requiresApiKey?: boolean; apiKeyKeychainId?: string | null }> }
+    | undefined;
+  expect(providerWrite?.providers.custom).toEqual(
+    expect.objectContaining({ requiresApiKey: false, apiKeyKeychainId: "keychain-custom" })
+  );
+  expect(mockSetSettings).toHaveBeenCalledWith({ settingsVersion: CURRENT_SETTINGS_VERSION });
+});
+
 it("v6: seeds plus for a v5 vault with neither Miyo nor self-host", async () => {
   mockGetSettings.mockReturnValue(settings({ settingsVersion: 5 }));
   const { api, setupProvider } = makeApi();

--- a/src/settings/migrations/version.ts
+++ b/src/settings/migrations/version.ts
@@ -18,5 +18,6 @@
  *   8   → seed `copilotFolder` root so derived sub-folder accessors resolve.
  *   9   → drop models, selections, and tokens of the retired GitHub Copilot
  *         chat provider.
+ *   10  → make auth optional on existing custom OpenAI-compatible BYOK rows.
  */
-export const CURRENT_SETTINGS_VERSION = 9;
+export const CURRENT_SETTINGS_VERSION = 10;


### PR DESCRIPTION
Fixes #2894
Fixes #2895

## Why

Custom OpenAI-compatible BYOK setup currently assumes two optional server capabilities are mandatory:

- Model selection starts with discovery through `GET /v1/models`. Although a manual input exists, it sits below the discovery results and can be pushed out of view when discovery fails or returns a long list. Servers without usable model discovery therefore appear to offer only search and cannot be configured reliably.
- The custom provider definition marks API keys as required, so Copilot blocks saving a local or trusted endpoint that intentionally runs without authentication.

This blocks oMLX and other OpenAI-compatible servers whose model ID is known but whose discovery or authentication behavior differs from hosted OpenAI.

## What

| Condition | Before | After |
| --- | --- | --- |
| `/v1/models` unavailable or incomplete | Manual model entry is below discovery and easy to miss or lose off-screen | A labeled **Model ID** field is always first; the exact ID can be added independently of discovery |
| `/v1/models` returns models | Search filters the discovered list | Same behavior, immediately below manual entry |
| A new custom Base URL is still being typed | Discovery may consume its one-time request against a partial URL | Discovery waits for **Test**, then uses the completed URL |
| Provider form exceeds the original dialog height | Lower model controls appear cut off and require premature scrolling | Dialog grows with its content up to 85% of the viewport, then uses bounded internal scrolling |
| Custom endpoint has no API key | Save is blocked | API key is optional |
| Existing custom endpoint was saved before this change | Its persisted required-key default still blocks keyless use | Settings v10 migrates the provider to optional auth while preserving any configured keychain pointer |
| Custom endpoint has no Base URL | An incomplete provider can be persisted once the other fields pass validation | Save remains disabled until a routing target is present |
| Custom endpoint requires authentication | API key is entered, verified, and sent | Unchanged when a key is supplied |
| Keyless custom endpoint uses a public hostname in Agent mode | OpenCode drops it based on hostname inference | OpenCode follows the provider's persisted authentication contract |
| A configured custom key disappears from the keychain | Agent mode can silently register the provider without authentication | Runtime fails closed while the stored key pointer remains |
| A genuinely keyless endpoint is used in Quick Chat | The OpenAI-compatible bridge sends a synthetic bearer token | The client explicitly omits the Authorization header |

The shared Models section uses this layout for every provider type, not only custom OpenAI-compatible providers. The patch also adds adjacent component-gallery stories for unavailable and successful discovery states, focused regression coverage for both issues, and updated provider documentation.

## Non goal

- No automatic model-ID inference when `/v1/models` is unavailable.
- No authentication changes for built-in hosted providers.
- No endpoint probing to decide whether a custom server ought to require a key; the user supplies one when needed.

## Screenshot

Verified in the configured non-production Obsidian test vault through the component gallery. The ManualEntry story renders Model ID, discovery search, the endpoint error, and the model-list state together in one inline Models panel. A focused form test also verifies that Model ID and search share the same Models section for Anthropic, OpenAI, Ollama, and custom OpenAI-compatible providers.

## Risk

**High**

| Criterion | Status | Reason |
| --- | :---: | --- |
| No behavior change, or a cosmetic/copy/docs/config change visible where it renders, or deterministic tests cover the changed behavior | ✅ | Focused tests cover manual-entry ordering, search callbacks, and saving a keyless custom provider |
| A defect would fail CI or be obvious on first use | ✅ | A broken path is visible while adding the first provider or model |
| A revert fully restores prior state, including persisted data | ❌ | Settings v10 changes the persisted required-key default for existing custom providers; it intentionally preserves any configured keychain pointer |
| No auth, permissions, secrets, or input-handling surface changes | ❌ | Custom-provider authentication becomes optional and the model-ID input is promoted to a primary path |
| No public API, plugin API, message, or on-disk contract changes | ✅ | Stored provider and model shapes are unchanged |
| No core-path concurrency, async-lifecycle, or state-machine changes | ✅ | Discovery and save lifecycles are unchanged |
| No hot-path behavior lacks deterministic coverage | ✅ | This is a settings-only path with focused component and form tests |
| No new dependency | ✅ | Package manifests and lockfiles are unchanged |
| Human-only behavior stays in one feature area and surfaces quickly | ✅ | The change is confined to provider model configuration and is visible before Save |

Review `CUSTOM_OPENAI_DEFINITION` in `src/modelManagement/catalog/builtinDefinitions.ts`, then the model section in `ConfigureProviderDialog.tsx` and `ModelChecklist.tsx`, the v10 migration in `optionalCustomProviderAuthMigration.ts`, and the runtime auth paths in `providerRequiresApiKey.ts`, `OpencodeBackend.ts`, and `chatModelManager.ts`. Pay particular attention to the distinction between optional authentication and optional credential verification: supplied keys still use the existing verification and secret-storage path, the migration preserves configured keychain pointers, a custom Base URL remains mandatory, runtimes fail closed when a configured secret disappears, keyless Quick Chat omits Authorization, and Copilot Plus continues to require its provisioned relay token. Exercise both keyless and authenticated endpoints in the steps below.

## Verification

1. Start an OpenAI-compatible server without authentication and make `GET /v1/models` unavailable or return an empty list.
2. In Settings → Models → BYOK, add a custom OpenAI-compatible provider. Leave API Key empty, enter the Base URL, enter the exact ID in **Model ID**, choose **Add**, and save. Confirm the provider and model remain configured.
3. Select that model in chat and send a message. Confirm the request reaches the configured endpoint and returns a response.
4. Repeat with an endpoint that requires authentication. Enter its key, test the provider, add a model, and save. Confirm the key-backed flow still succeeds; a wrong key should still fail the existing credential test.
5. Repeat with an endpoint that returns `GET /v1/models`. Confirm search filters the discovered list and manual entry remains available above it.

Automated verification:

- `npm run test -- --runInBand`: 447 suites, 6,137 tests passed.
- `npm run build`: passed.
- `npm run test:mobile-load`: passed.
- `npm run gallery:build`: passed.
- Test-vault component-gallery deployment and runtime error check: passed.
- Focused provider-dialog and OpenCode backend tests after review fixes: 2 suites, 90 tests passed.
- Focused auth-propagation tests across provider policy, Quick Chat, and OpenCode: 4 suites, 75 tests passed.
- Focused settings-migration tests: 2 suites, 26 tests passed.
- `npm run lint`: passed with one unchanged warning in `SettingsPage.tsx`.
- `npm run review:obsidian`: passed; expected fixture findings remained confined to the review fixtures and no changed-source warning was introduced.
